### PR TITLE
Main agent drives /code with per-call file tools

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/code.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/code.py
@@ -1,57 +1,64 @@
-# code.py — in-process MCP server exposing the ONE tool the main chat agent
-# uses to reach the user's code: ``code_mode``. Created: 2026-07-22
-# (feat/code-mode-tool, CD-2).
+# code.py — in-process MCP server exposing the file tools the main chat agent
+# uses to reach the user's code. Created: 2026-07-22 (feat/code-mode-tool, CD-2).
+# Reshaped 2026-07-24 (feat/code-mode-file-tools).
 #
-# What this is for. The /code surface is being inverted so the MAIN PocketPaw
-# agent drives the conversation and Code Mode becomes a sub-agent it delegates
-# to. This file is the seam. The main agent gets exactly one coarse tool rather
-# than four proxied file verbs, so the sub-agent keeps its own read/write loop
-# and the main agent never learns the shape of a file session.
+# What changed and why. CD-2 gave the main agent ONE coarse tool, ``code_mode``,
+# that handed a whole task to a browser SUB-AGENT which ran its own read/write
+# loop. That sub-agent was removed (2026-07-23): the /code surface runs on the
+# MAIN PocketPaw agent, and a second, weaker in-browser agent was redundant.
+# With it gone, the reasoning that decomposed a task into individual file reads
+# and writes no longer existed anywhere — so it moves INTO the main agent, and
+# this server changes shape to match. Instead of one ``code_mode(task)`` tool,
+# it now exposes the four file verbs the agent reasons WITH:
 #
-# Why the tool does not touch a file. ``codeagent/transport.py`` recorded the
-# constraint that shaped this whole design: an MCP server runs in the BACKEND,
-# where the user's files are not. That is fatal to a tool that OPENS a file. It
-# is not fatal to this one, because ``code_mode`` never opens anything — it asks
-# the BROWSER to. The handler is an ``async def``, so it can await a future:
-# ``delegate_to_browser`` (CD-1) registers a correlation id, pushes one
-# ``code_delegate`` frame down the live SSE stream, and parks until the tab
-# POSTs the answer back. The same inversion MCP standardizes as elicitation.
+#   readFile(path)          — read a file
+#   search(query)           — search the project
+#   listDir(path)           — list a directory
+#   writeFile(path, content)— PROPOSE a full-file rewrite (staged, not written)
 #
-# Why this lives in ee/ and not src/pocketpaw/agents/. The build plan said
-# ``src/pocketpaw/agents/sdk_mcp_code.py``, next to ``sdk_mcp_widgets.py``. That
-# is the wrong side of the OSS/EE line twice over: the channel this wraps
-# (``ee.cloud.codeagent.delegates``) is EE cloud code, and the workspace
-# identity it needs comes from the per-stream ContextVars in
-# ``ee.cloud.chat.agent_service``. An OSS module importing either would invert
-# the dependency. So this clones ``belt.py`` instead — the closest sibling in
-# kind as well as in shape, since that one is also a single-tool gate that hands
-# work to something else rather than doing it. Registration is the standard
-# ``pocketpaw.mcp_servers`` entry point (``CloudCodeMcpProvider``), NOT
+# The main agent runs its own tool loop over these, exactly as a coding agent
+# does over local file tools. The difference this whole module exists for: the
+# files are not here.
+#
+# Why the tools do not touch a file. An MCP server runs in the BACKEND, where
+# the user's project is not — a WebContainer project lives in the user's tab and
+# has no server-side row a backend could open. That is fatal to a tool that
+# OPENS a file. It is not fatal to these, because they never open anything — they
+# ask the BROWSER to. Each handler is an ``async def``, so it can await a future:
+# ``delegate_call_to_browser`` (CD-1) registers a correlation id, pushes one
+# ``code_delegate`` frame carrying ``{tool, input}`` down the live SSE stream,
+# and parks until the tab POSTs the result back. The same inversion MCP
+# standardizes as elicitation.
+#
+# The write gate stays in the tab. ``writeFile`` NEVER writes. It delegates the
+# proposed content to the browser, which STAGES it for the user's per-hunk
+# review; the user accepting a hunk is the only thing that writes, and it happens
+# long after this tool has returned. So the honest result of a ``writeFile`` call
+# is "a change was proposed for review", never "the file was changed" — the
+# description and the system prompt both say so, because the model must not tell
+# the user a file was written when nothing has been.
+#
+# Why this lives in ee/ and not src/pocketpaw/agents/. The channel this wraps
+# (``ee.cloud.codeagent.delegates``) is EE cloud code, and the workspace identity
+# it needs comes from the per-stream ContextVars in ``ee.cloud.chat.agent_service``.
+# An OSS module importing either would invert the dependency. Registration is the
+# standard ``pocketpaw.mcp_servers`` entry point (``CloudCodeMcpProvider``), NOT
 # ``claude_sdk._get_mcp_servers``, which only builds the OSS-side servers.
 #
-# On metering, which the PRD left open: a ``code_mode`` call spends nothing
-# here. This handler calls no model — it parks on a future. The model spend
-# happens on the BROWSER side, where the tab actually runs the task and buys the
-# tokens; that path meters itself. One delegated task therefore bills exactly
-# once, on the side that does the work. There is no second meter here to
-# reconcile and nothing to double-count.
+# On metering: these handlers spend nothing. They call no model — they park on a
+# future. The model spend happens on the main agent's own chat turn, which meters
+# itself; the browser side runs no model at all (it just executes a file verb).
+# There is no second meter here to reconcile.
 #
-# NOTE (2026-07-23): the browser used to do that work by calling the
-# ``/codeagent/turn`` sub-agent, which is now removed. The metering principle is
-# unchanged — the backend park is free, the browser-side model call is not — but
-# which endpoint the tab now hits for the work is the frontend replacement's
-# concern, not this tool's.
-#
-# The tool id namespaces as ``mcp__pocketpaw_code__code_mode``. The /code
-# SurfaceProfile hardcodes that exact string as a literal (CD-3 shipped before
-# this file existed and could not import the constant). Do NOT drift the server
-# name or the tool name without changing ``surface_registry._CODE_MODE_TOOL_IDS``
-# in the same PR — they are matched by string, so a rename fails silently by
-# scoping the surface to a tool id nothing provides.
+# The tool ids namespace as ``mcp__pocketpaw_code__<verb>``. The /code
+# SurfaceProfile hardcodes these exact strings as literals (it shipped before this
+# file could export a constant). Do NOT drift the server name or any tool name
+# without changing ``surface_registry._CODE_FILE_TOOL_IDS`` in the same PR — they
+# are matched by string, so a rename fails silently by scoping the surface to an
+# id nothing provides. ``test_code_mcp_server`` pins both ends against each other.
 
 from __future__ import annotations
 
-import json
 import logging
 from typing import Any
 
@@ -60,25 +67,27 @@ logger = logging.getLogger(__name__)
 SERVER_NAME = "pocketpaw_code"
 
 # Claude Code namespaces in-process MCP tools as ``mcp__<server>__<tool>``.
-CODE_MODE_TOOL_ID = f"mcp__{SERVER_NAME}__code_mode"
+READ_FILE_TOOL_ID = f"mcp__{SERVER_NAME}__readFile"
+WRITE_FILE_TOOL_ID = f"mcp__{SERVER_NAME}__writeFile"
+SEARCH_TOOL_ID = f"mcp__{SERVER_NAME}__search"
+LIST_DIR_TOOL_ID = f"mcp__{SERVER_NAME}__listDir"
 
-# Exported as a tuple for the provider's ``tool_ids()``, mirroring
-# ``BELT_TOOL_IDS``. One entry today; the shape is what the loader expects.
-CODE_TOOL_IDS = (CODE_MODE_TOOL_ID,)
+# Exported as a tuple for the provider's ``tool_ids()``. Order is read-first so a
+# log or an allow-list dump reads in the order the agent typically calls them.
+CODE_TOOL_IDS = (
+    READ_FILE_TOOL_ID,
+    SEARCH_TOOL_ID,
+    LIST_DIR_TOOL_ID,
+    WRITE_FILE_TOOL_ID,
+)
 
-# The two permission sets the sub-agent understands. ``ask`` gets the read-only
-# verbs; ``edit`` may propose a change.
-_MODES = ("ask", "edit")
-
-# The safe default. It is deliberately the READ-ONLY mode, so that every way of
-# not-specifying a mode — omitted, null, empty, misspelled, wrong type — lands
-# on "cannot edit" rather than "can edit unexpectedly". ``dto.py`` makes the
-# same choice on the wire for the same reason.
-_DEFAULT_MODE = "ask"
-
-# A task that is empty or absent is a bug in the caller, not a request. Bounded
-# because it crosses the wire into the browser and ends up in a prompt.
-_MAX_TASK_CHARS = 8000
+# Bounds on what crosses the wire into the browser. Paths and queries are small
+# by nature; a rewrite can be a whole file. ``content`` is capped well under the
+# channel's ``MAX_DELEGATE_RESULT_CHARS`` return ceiling so a proposal and its
+# staged-summary answer both fit comfortably.
+_MAX_PATH_CHARS = 1024
+_MAX_QUERY_CHARS = 2048
+_MAX_CONTENT_CHARS = 180_000
 
 
 def _error_response(message: str) -> dict[str, Any]:
@@ -90,16 +99,18 @@ def _error_response(message: str) -> dict[str, Any]:
     }
 
 
-def _success_response(body: dict[str, Any]) -> dict[str, Any]:
-    """Build an MCP success response carrying ``body`` as JSON."""
-    return {
-        "content": [
-            {
-                "type": "text",
-                "text": json.dumps(body, separators=(",", ":"), default=str),
-            }
-        ]
-    }
+def _text_response(text: str, *, is_error: bool = False) -> dict[str, Any]:
+    """Build an MCP response carrying ``text`` verbatim.
+
+    The browser's executor already returns human/model-readable output (file
+    contents, a search listing, a staged-change sentence), so this relays it
+    rather than re-wrapping it in JSON. ``is_error`` rides the SDK's own flag so
+    the model treats a failed lookup differently from an empty one.
+    """
+    response: dict[str, Any] = {"content": [{"type": "text", "text": text}]}
+    if is_error:
+        response["is_error"] = True
+    return response
 
 
 def _workspace_id() -> str | None:
@@ -108,8 +119,8 @@ def _workspace_id() -> str | None:
 
     Only the workspace is read. The delegate is addressed to a workspace's live
     stream, and ``delegates.resolve_pending`` scopes the return leg the same
-    way; the user id is not an authorization input there, so asking for one
-    here would imply a check that is not made.
+    way; the user id is not an authorization input there, so asking for one here
+    would imply a check that is not made.
     """
     try:
         from pocketpaw_ee.cloud.chat.agent_service import current_workspace_id
@@ -119,52 +130,31 @@ def _workspace_id() -> str | None:
         return None
 
 
-def _normalize_mode(raw: Any) -> str:
-    """Coerce whatever the model sent into one of ``_MODES``.
+def _require_str(args: dict, key: str, *, max_chars: int, allow_empty: bool = False) -> str | None:
+    """Pull a bounded string argument, or return ``None`` if it is unusable.
 
-    Anything unrecognized becomes ``ask``. This is the one place the fail-safe
-    direction matters: a model that hallucinates ``mode="write"`` or sends an
-    integer must lose the ability to edit, not gain it. Logged rather than
-    rejected, because turning a garbled enum into a hard tool error would cost
-    the user a turn for something that has a correct, safe reading.
+    ``None`` means "reject" — the caller turns that into an MCP error. A separate
+    sentinel rather than an exception because a raise inside an in-process tool
+    handler reaches the model as a BROKEN tool, whereas an error response gives it
+    a sentence it can act on.
     """
-    if isinstance(raw, str):
-        mode = raw.strip().lower()
-        if mode in _MODES:
-            return mode
-        if mode:
-            logger.warning(
-                "code_mode: unrecognized mode %r, falling back to %s", raw, _DEFAULT_MODE
-            )
-    elif raw is not None:
-        logger.warning(
-            "code_mode: non-string mode %r, falling back to %s", type(raw), _DEFAULT_MODE
-        )
-    return _DEFAULT_MODE
+    value = args.get(key)
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if not text and not allow_empty:
+        return None
+    if len(value) > max_chars:
+        return None
+    return text if not allow_empty else value
 
 
-async def _code_mode_handler(args: dict) -> dict[str, Any]:
-    """Hand one coding task to the browser's Code Mode sub-agent and wait.
+async def _delegate(tool: str, tool_input: dict[str, Any]) -> dict[str, Any]:
+    """Resolve the workspace, delegate ONE call to the browser, relay the result.
 
-    Returns the sub-agent's payload on success. On EVERY failure path it returns
-    an MCP error rather than raising: a raise inside an in-process tool handler
-    surfaces to the model as a broken tool, whereas an error response gives it a
-    true sentence to say to the user. That distinction is the whole reason
-    ``delegate_to_browser`` returns an outcome on timeout instead of raising.
+    Every failure path returns an MCP response rather than raising, for the same
+    reason the handlers do: the caller is an agent tool.
     """
-    task = args.get("task")
-    if not isinstance(task, str) or not task.strip():
-        return _error_response("`task` is required — describe the coding task in words.")
-    task = task.strip()
-    if len(task) > _MAX_TASK_CHARS:
-        return _error_response(
-            f"`task` is too long ({len(task)} chars, limit {_MAX_TASK_CHARS}). "
-            "Describe the change rather than pasting the code — the sub-agent "
-            "reads the files itself."
-        )
-
-    mode = _normalize_mode(args.get("mode"))
-
     workspace_id = _workspace_id()
     if not workspace_id:
         # No cloud stream in scope: a CLI run, a background job, a test. The
@@ -174,23 +164,84 @@ async def _code_mode_handler(args: dict) -> dict[str, Any]:
             "the user's project from here."
         )
 
-    from pocketpaw_ee.cloud.codeagent.delegates import delegate_to_browser
+    from pocketpaw_ee.cloud.codeagent.delegates import delegate_call_to_browser
 
-    outcome = await delegate_to_browser(workspace_id, task, mode)
+    outcome = await delegate_call_to_browser(workspace_id, tool, tool_input)
 
     if not outcome.ok:
-        logger.info("code_mode delegate failed ws=%s error=%s", workspace_id, outcome.error)
+        logger.info("code.%s delegate failed ws=%s error=%s", tool, workspace_id, outcome.error)
         # Relay the channel's own message. It already distinguishes "no browser
         # attached" from "the browser was slow", and the model needs that
         # difference to say something true about what happened.
-        return _error_response(outcome.message or "The coding task could not be completed.")
+        return _error_response(outcome.message or "The file operation could not be completed.")
 
-    return _success_response(outcome.result or {})
+    result = outcome.result or {}
+    output = result.get("output")
+    if not isinstance(output, str):
+        output = ""
+    is_error = bool(result.get("isError"))
+    if is_error and not output:
+        output = "The file operation failed in the browser."
+    return _text_response(output, is_error=is_error)
+
+
+async def _read_file_handler(args: dict) -> dict[str, Any]:
+    path = _require_str(args, "path", max_chars=_MAX_PATH_CHARS)
+    if path is None:
+        return _error_response(
+            "`path` is required — the file to read, relative to the project root."
+        )
+    return await _delegate("readFile", {"path": path})
+
+
+async def _search_handler(args: dict) -> dict[str, Any]:
+    query = _require_str(args, "query", max_chars=_MAX_QUERY_CHARS)
+    if query is None:
+        return _error_response(
+            "`query` is required — the text or symbol to search the project for."
+        )
+    return await _delegate("search", {"query": query})
+
+
+async def _list_dir_handler(args: dict) -> dict[str, Any]:
+    # An empty path is legitimate here — it lists the project root — so this one
+    # verb allows the empty string rather than rejecting it.
+    path = _require_str(args, "path", max_chars=_MAX_PATH_CHARS, allow_empty=True)
+    if path is None:
+        return _error_response("`path` must be a string — the directory to list ('' for the root).")
+    return await _delegate("listDir", {"path": path})
+
+
+async def _write_file_handler(args: dict) -> dict[str, Any]:
+    """Propose a full-file rewrite. This does NOT write the file.
+
+    The proposed ``content`` is delegated to the browser, which stages it for the
+    user's per-hunk review. Nothing is written until the user accepts a hunk,
+    which happens after this returns — so a success here means "a change was
+    proposed for review", not "the file was changed".
+    """
+    path = _require_str(args, "path", max_chars=_MAX_PATH_CHARS)
+    if path is None:
+        return _error_response(
+            "`path` is required — the file to change, relative to the project root."
+        )
+    # ``content`` may legitimately be the empty string (blanking a file), so it is
+    # required-present but allowed-empty; only a non-string or an over-long body
+    # is rejected.
+    content = args.get("content")
+    if not isinstance(content, str):
+        return _error_response("`content` is required — the full new contents of the file.")
+    if len(content) > _MAX_CONTENT_CHARS:
+        return _error_response(
+            f"`content` is too long ({len(content)} chars, limit {_MAX_CONTENT_CHARS}). "
+            "Propose a change to a smaller file, or split the work across files."
+        )
+    return await _delegate("writeFile", {"path": path, "content": content})
 
 
 def build_code_server() -> tuple[str, Any] | None:
-    """Build the in-process SDK MCP server for ``code_mode``, or return ``None``
-    if the Claude Agent SDK isn't installed.
+    """Build the in-process SDK MCP server for the /code file tools, or return
+    ``None`` if the Claude Agent SDK isn't installed.
 
     Matches the ``(name, server) | None`` shape of ``build_belt_server`` so the
     backend's MCP registration loop treats it identically.
@@ -202,60 +253,119 @@ def build_code_server() -> tuple[str, Any] | None:
         return None
 
     @tool(
-        "code_mode",
+        "readFile",
         (
-            "Read, search, or change the code in the user's project. This is the "
-            "ONLY way to reach their code — the project does not live on your "
-            "machine, so the built-in file and shell tools do not address it. "
-            "Describe the task in words, the way the user gave it to you; this "
-            "tool locates the relevant code itself, so do NOT try to find files "
-            "first. Args: `task` (what to do, in plain language — required), "
-            "`mode` ('ask' to read, search, and answer questions about the code; "
-            "'edit' to change it — defaults to 'ask'). Use `mode='edit'` only "
-            "when the user actually wants the code changed. Returns the "
-            "sub-agent's result. On an error, relay the reason to the user — do "
-            "NOT claim the code was read or changed when this returned an error."
+            "Read a file from the user's project and return its contents. This is "
+            "how you look at their code — the project runs in the user's browser, "
+            "not on your machine, so the built-in file tools do not address it. "
+            "Args: `path` (the file, relative to the project root)."
         ),
         {
             "type": "object",
             "properties": {
-                "task": {
+                "path": {
                     "type": "string",
                     "minLength": 1,
-                    "description": (
-                        "The coding task in plain language, e.g. 'add a loading "
-                        "state to the submit button' or 'where is the retry "
-                        "logic'. Describe the change, don't paste the code."
-                    ),
-                },
-                "mode": {
-                    "type": "string",
-                    "enum": list(_MODES),
-                    "default": _DEFAULT_MODE,
-                    "description": (
-                        "'ask' reads and answers (read-only); 'edit' proposes a "
-                        "change. Defaults to 'ask'."
-                    ),
+                    "description": "File path relative to the project root, e.g. 'src/App.tsx'.",
                 },
             },
-            "required": ["task"],
+            "required": ["path"],
             "additionalProperties": False,
         },
     )
-    async def code_mode(args):  # type: ignore[no-untyped-def]
-        return await _code_mode_handler(args)
+    async def read_file(args):  # type: ignore[no-untyped-def]
+        return await _read_file_handler(args)
+
+    @tool(
+        "search",
+        (
+            "Search the user's project for a string or symbol and return the "
+            "matching lines with their file and line number. Use this to locate "
+            "code before reading or changing it. Args: `query` (the text to find)."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Text or symbol to search for, e.g. 'useState' or 'Sidebar'.",
+                },
+            },
+            "required": ["query"],
+            "additionalProperties": False,
+        },
+    )
+    async def search(args):  # type: ignore[no-untyped-def]
+        return await _search_handler(args)
+
+    @tool(
+        "listDir",
+        (
+            "List the entries of a directory in the user's project, to see how it "
+            "is laid out. Args: `path` (the directory relative to the project "
+            "root; use '' or '.' for the root)."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Directory relative to the project root; '' for the root.",
+                },
+            },
+            "required": ["path"],
+            "additionalProperties": False,
+        },
+    )
+    async def list_dir(args):  # type: ignore[no-untyped-def]
+        return await _list_dir_handler(args)
+
+    @tool(
+        "writeFile",
+        (
+            "Propose the full new contents of a file in the user's project. This "
+            "does NOT save the file — it stages the change for the user to review "
+            "and accept hunk by hunk. So report it as a change PROPOSED for "
+            "review, never as a file that was written or a feature that is done; "
+            "the user has to accept it first. Pass the ENTIRE new file in "
+            "`content`, not a diff or a snippet. Args: `path` (the file), "
+            "`content` (its full new contents)."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "File path relative to the project root.",
+                },
+                "content": {
+                    "type": "string",
+                    "description": "The COMPLETE new contents of the file, not a diff.",
+                },
+            },
+            "required": ["path", "content"],
+            "additionalProperties": False,
+        },
+    )
+    async def write_file(args):  # type: ignore[no-untyped-def]
+        return await _write_file_handler(args)
 
     server = create_sdk_mcp_server(
         name=SERVER_NAME,
         version="1.0.0",
-        tools=[code_mode],
+        tools=[read_file, search, list_dir, write_file],
     )
     return SERVER_NAME, server
 
 
 __all__ = [
-    "CODE_MODE_TOOL_ID",
     "CODE_TOOL_IDS",
+    "LIST_DIR_TOOL_ID",
+    "READ_FILE_TOOL_ID",
+    "SEARCH_TOOL_ID",
     "SERVER_NAME",
+    "WRITE_FILE_TOOL_ID",
     "build_code_server",
 ]

--- a/ee/pocketpaw_ee/cloud/agents/domain.py
+++ b/ee/pocketpaw_ee/cloud/agents/domain.py
@@ -9,6 +9,11 @@ Beanie sub-model would require touching every caller of
 Updated: 2026-06-28 (feat/aiam-agent-revoke, AW-4) — added ``Agent.disabled``
 mirroring the new top-level flag on the Beanie doc, so callers (and the wire
 dict) can read whether an agent has been soft-disabled / revoked.
+Updated: 2026-07-24 (CX-2, feat/code-agent-exclusive-tools) — added
+``AgentConfigSpec.tool_mode`` (``"additive"`` | ``"exclusive"``) mirroring the
+Beanie ``AgentConfig.tool_mode``. An ``"exclusive"`` agent's ``tools`` become the
+run's MCP allow-list and suppress the universal pocket/widget/atlas grant
+(CX-1); ``"additive"`` (the default) is the unchanged legacy grant-union.
 """
 
 from __future__ import annotations
@@ -25,6 +30,11 @@ class AgentConfigSpec:
     model: str = ""
     system_prompt: str = ""
     tools: tuple[str, ...] = ()
+    # Tool-surface policy. "additive" (default) UNIONs the agent's tools with the
+    # universal MCP grant (legacy). "exclusive" caps the run's MCP surface to
+    # exactly ``tools`` (CX-1/CX-2) — a non-empty ``tools`` list alone does NOT
+    # imply exclusive; only this flag does.
+    tool_mode: str = "additive"
     trust_level: int = 3
     temperature: float = 0.7
     max_tokens: int = 4096

--- a/ee/pocketpaw_ee/cloud/agents/service.py
+++ b/ee/pocketpaw_ee/cloud/agents/service.py
@@ -25,6 +25,11 @@ Updated 2026-07-02 (feat/aiam-agent-revoke, AW-4 follow-up): ``get_persona``
 now returns ``None`` for a soft-disabled agent (reusing the doc it already
 loads — no extra read), so ``agent_bridge``'s smart-relevance LLM probe never
 fires for an agent ``pool.get`` would refuse to run.
+Updated 2026-07-24 (CX-2, feat/code-agent-exclusive-tools): ``tool_mode`` is
+threaded through the doc↔spec mappers (``_config_to_domain`` / ``_config_to_doc``)
+and the config-dict update path (``_apply_update``) so an "exclusive" policy
+round-trips and survives an update. Defaults to "additive", so every existing
+agent maps byte-for-byte as before.
 """
 
 from __future__ import annotations
@@ -71,6 +76,7 @@ def _config_to_domain(c: _AgentConfigDoc) -> AgentConfigSpec:
         model=c.model,
         system_prompt=c.system_prompt,
         tools=tuple(c.tools),
+        tool_mode=c.tool_mode,
         trust_level=c.trust_level,
         temperature=c.temperature,
         max_tokens=c.max_tokens,
@@ -91,6 +97,7 @@ def _config_to_doc(c: AgentConfigSpec) -> _AgentConfigDoc:
         model=c.model,
         system_prompt=c.system_prompt,
         tools=list(c.tools),
+        tool_mode=c.tool_mode,
         trust_level=c.trust_level,
         temperature=c.temperature,
         max_tokens=c.max_tokens,
@@ -179,6 +186,7 @@ def _apply_update(current: AgentConfigSpec, body: UpdateAgentRequest) -> AgentCo
             model=c.get("model", current.model),
             system_prompt=c.get("system_prompt", current.system_prompt),
             tools=tuple(c.get("tools", list(current.tools))),
+            tool_mode=c.get("tool_mode", current.tool_mode),
             trust_level=c.get("trust_level", current.trust_level),
             temperature=c.get("temperature", current.temperature),
             max_tokens=c.get("max_tokens", current.max_tokens),

--- a/ee/pocketpaw_ee/cloud/agents/service.py
+++ b/ee/pocketpaw_ee/cloud/agents/service.py
@@ -30,6 +30,13 @@ threaded through the doc↔spec mappers (``_config_to_domain`` / ``_config_to_do
 and the config-dict update path (``_apply_update``) so an "exclusive" policy
 round-trips and survives an update. Defaults to "additive", so every existing
 agent maps byte-for-byte as before.
+Updated 2026-07-24 (CX-3, feat/code-agent-exclusive-tools): added
+``seed_code_agent`` / ``ensure_code_agent_all_workspaces`` — the dedicated
+``code`` slug agent for the ``/code`` surface. Its config is
+``tool_mode="exclusive"`` + ``tools=_CODE_FILE_TOOL_IDS`` (the four file tools)
+and its persona reuses ``CODE_SYSTEM_PROMPT``, so every run it does is capped to
+exactly those ids — no pocket/planner/widget grant. Idempotent, mirrors the
+default-agent seed + boot back-fill.
 """
 
 from __future__ import annotations
@@ -649,10 +656,102 @@ async def ensure_default_agent_all_workspaces() -> int:
     return seeded
 
 
+async def seed_code_agent(
+    workspace_id: str, owner_id: str
+) -> tuple[_AgentDoc, bool] | tuple[None, bool]:
+    """Create the dedicated ``code`` Agent for a workspace if missing (CX-3).
+
+    This is the backend-authoritative target for the ``/code`` surface. Unlike
+    the default ``pocketpaw`` agent, its config carries ``tool_mode="exclusive"``
+    and ``tools=<the four file tools>``, so the CX-1/CX-2 policy caps every run
+    it does to EXACTLY those ids — no pocket / planner / widget grant. That is
+    what makes "build an employee management app…" produce file-tool calls
+    against the user's project instead of a pocket.
+
+    The persona reuses ``CODE_SYSTEM_PROMPT`` (the CODE surface's own override)
+    verbatim so the agent identity and the surface prompt cannot drift, and the
+    tool ids come from ``_CODE_FILE_TOOL_IDS`` (the same constant the CODE
+    ``SurfaceProfile`` allows). It carries NO create-pocket skill: the CODE
+    surface deliberately ships none (see the long comment at
+    surface_registry.py:614), so ``skill_refs`` is empty.
+
+    Idempotent (find-by-slug short-circuit). Returns ``(agent, created)`` —
+    ``created`` is ``True`` only when this call inserted a new row. Returns
+    ``(None, False)`` if the insert raises (callers wrap in try/except).
+    """
+    # Local imports keep the surface package off this module's import graph and
+    # avoid any cycle; the constants are cheap module-level frozensets/strings.
+    from pocketpaw_ee.cloud.surface.surface_registry import _CODE_FILE_TOOL_IDS
+    from pocketpaw_ee.cloud.surface.system_prompts import CODE_SYSTEM_PROMPT
+
+    existing = await _AgentDoc.find_one(
+        _AgentDoc.workspace == workspace_id, _AgentDoc.slug == "code"
+    )
+    if existing is not None:
+        return existing, False
+
+    agent = _AgentDoc(
+        workspace=workspace_id,
+        name="Code",
+        slug="code",
+        avatar="",
+        owner=owner_id,
+        visibility="workspace",
+        config=_AgentConfigDoc(
+            system_prompt=CODE_SYSTEM_PROMPT,
+            tool_mode="exclusive",
+            tools=list(_CODE_FILE_TOOL_IDS),
+            # No create-pocket / widget skill — the CODE surface ships none.
+            skill_refs=[],
+            soul_persona="Code",
+        ),
+    )
+    await agent.insert()
+    logger.info(
+        "Dedicated 'code' agent seeded in workspace %s (id: %s)",
+        workspace_id,
+        agent.id,
+    )
+    await emit(
+        AgentCreated(
+            data={
+                "agent_id": str(agent.id),
+                "workspace_id": workspace_id,
+                "owner_id": owner_id,
+                "name": agent.name,
+                "slug": agent.slug,
+                "visibility": agent.visibility,
+            }
+        )
+    )
+    return agent, True
+
+
+async def ensure_code_agent_all_workspaces() -> int:
+    """Back-fill the dedicated ``code`` agent for every existing workspace.
+
+    Called on every boot beside ``ensure_default_agent_all_workspaces`` so the
+    ``/code`` target exists regardless of install age. Returns the number of
+    agents actually created this run.
+    """
+    from pocketpaw_ee.cloud.models.workspace import Workspace as _WorkspaceDoc
+
+    seeded = 0
+    async for ws in _WorkspaceDoc.find_all():
+        try:
+            _, created = await seed_code_agent(str(ws.id), str(ws.owner))
+            if created:
+                seeded += 1
+        except Exception as exc:
+            logger.warning("Failed to back-fill code agent for ws=%s: %s", ws.id, exc)
+    return seeded
+
+
 __all__ = [
     "create",
     "delete",
     "discover",
+    "ensure_code_agent_all_workspaces",
     "ensure_default_agent_all_workspaces",
     "get",
     "get_by_slug",
@@ -662,6 +761,7 @@ __all__ = [
     "is_owner_or_workspace_admin",
     "legacy_ctx",
     "list_agents",
+    "seed_code_agent",
     "seed_default_agent",
     "set_scopes",
     "suggest_for_mentions",

--- a/ee/pocketpaw_ee/cloud/chat/agent_router.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_router.py
@@ -169,6 +169,9 @@ async def post_agent_chat(
             user_id=user_id,
             agent_id_hint=body.agent_id,
             expected_workspace_id=workspace_id,
+            # CX-3: on /code the resolver routes an unhinted turn to the code
+            # agent (exclusive file-tool policy). No-op on every other surface.
+            surface=body.surface,
         )
         ctx.intent = body.intent
     except InvalidScope:

--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -181,6 +181,16 @@ the same ContextVar, added for Code Mode's browser-delegate channel: that caller
 pushes a frame and then PARKS waiting for the browser's reply, so a push into no
 stream has to be a fast, distinct failure rather than a silent no-op followed by
 a full-length timeout. No behaviour change to any existing push path.
+
+Changes: 2026-07-24 (CX-3, feat/code-agent-exclusive-tools) —
+``resolve_scope_context`` (and ``_resolve_session`` / ``_resolve_pocket``)
+gained a ``surface`` param, and ``_get_code_agent_id`` was added. On the CODE
+surface, an unhinted turn resolves to the dedicated ``code`` agent (slug
+``code``), lazy-seeded via ``agents.service.seed_code_agent`` on miss, instead
+of the default ``pocketpaw`` agent — so the exclusive file-tool policy is
+applied backend-authoritatively (the frontend need not pass the id). Guarded
+narrowly on CODE + no explicit ``agent_id_hint``; every other surface's
+resolution is byte-identical.
 """
 
 from __future__ import annotations
@@ -211,7 +221,7 @@ from pocketpaw.ripple import (
 from pocketpaw.ripple._pockets import _MCP_POCKET_BACKENDS
 from pocketpaw.stores import current_workspace as _oss_current_workspace
 from pocketpaw_ee.cloud.shared.errors import CloudError, Forbidden, NotFound
-from pocketpaw_ee.cloud.surface import SurfaceContext, SurfaceProfile
+from pocketpaw_ee.cloud.surface import SurfaceContext, SurfaceKind, SurfaceProfile
 
 logger = logging.getLogger(__name__)
 
@@ -947,6 +957,52 @@ async def _get_default_workspace_agent_id(workspace_id: str) -> str | None:
         return None
 
 
+async def _get_code_agent_id(workspace_id: str) -> str | None:
+    """Resolve the workspace's dedicated ``code`` agent id, LAZY-SEEDING on miss.
+
+    The ``/code`` surface is backend-authoritative (CX-3): a CODE-surface turn
+    must resolve to this agent, whose stored config carries the exclusive
+    file-tool policy (``tool_mode="exclusive"`` + ``tools=_CODE_FILE_TOOL_IDS``),
+    so the run is capped to exactly the four file tools — no pocket/planner/
+    widget grant. A workspace that predates the code-agent seed (or one whose
+    boot back-fill hasn't run) still works on its FIRST /code turn because this
+    helper seeds when the agent is absent. Returns ``None`` only when both the
+    lookup and the seed fail — the caller then falls back to the default agent
+    rather than erroring.
+    """
+    if not workspace_id:
+        return None
+    try:
+        from pocketpaw_ee.cloud.models.agent import Agent
+
+        agent = await Agent.find_one(Agent.workspace == workspace_id, Agent.slug == "code")
+        if agent is not None:
+            return str(agent.id)
+
+        # Lazy-seed. Resolve the workspace owner (mirrors the boot back-fill's
+        # ``ws.owner``) and delegate the write to the agents service — the sole
+        # owner of Agent writes. A bad/missing workspace doc degrades to an empty
+        # owner rather than blocking the seed.
+        owner_id = ""
+        try:
+            from beanie import PydanticObjectId
+
+            from pocketpaw_ee.cloud.models.workspace import Workspace
+
+            ws = await Workspace.get(PydanticObjectId(workspace_id))
+            owner_id = str(getattr(ws, "owner", "") or "") if ws is not None else ""
+        except Exception:
+            logger.debug("code-agent seed: workspace owner lookup failed for ws=%s", workspace_id)
+
+        from pocketpaw_ee.cloud.agents import service as agents_service
+
+        doc, _created = await agents_service.seed_code_agent(workspace_id, owner_id)
+        return str(doc.id) if doc is not None else None
+    except Exception:
+        logger.exception("code agent lookup/seed failed for ws=%s", workspace_id)
+        return None
+
+
 # ---------------------------------------------------------------------------
 # Scope resolution
 # ---------------------------------------------------------------------------
@@ -999,6 +1055,7 @@ async def resolve_scope_context(
     user_id: str,
     agent_id_hint: str | None,
     expected_workspace_id: str | None = None,
+    surface: str | None = None,
 ) -> ScopeContext:
     """Resolve a ``ScopeContext`` for a cloud agent chat request.
 
@@ -1008,6 +1065,13 @@ async def resolve_scope_context(
     field is empty/missing and (b) REJECT a caller whose workspace DISAGREES
     with a non-empty doc workspace (cross-tenant guard). Defaults to ``None`` —
     legacy / non-worker callers keep today's doc-only behavior.
+
+    ``surface`` is the client's raw surface hint (``body.surface`` /
+    ``spec.surface``). On the CODE surface, and only when the caller passed no
+    explicit ``agent_id_hint``, target resolution routes to the dedicated
+    ``code`` agent (lazy-seeded) instead of the default ``pocketpaw`` agent so
+    the exclusive file-tool policy applies backend-authoritatively (CX-3). Every
+    other surface leaves resolution byte-identical. Defaults to ``None``.
 
     Raises:
         InvalidScope: ``scope`` is not one of dm/group/pocket/session.
@@ -1022,9 +1086,13 @@ async def resolve_scope_context(
         raise InvalidScope(scope) from e
 
     if kind is ScopeKind.POCKET:
-        return await _resolve_pocket(scope_id, user_id, agent_id_hint, expected_workspace_id)
+        return await _resolve_pocket(
+            scope_id, user_id, agent_id_hint, expected_workspace_id, surface
+        )
     if kind is ScopeKind.SESSION:
-        return await _resolve_session(scope_id, user_id, agent_id_hint, expected_workspace_id)
+        return await _resolve_session(
+            scope_id, user_id, agent_id_hint, expected_workspace_id, surface
+        )
     return await _resolve_group_like(kind, scope_id, user_id, agent_id_hint, expected_workspace_id)
 
 
@@ -1033,6 +1101,7 @@ async def _resolve_session(
     user_id: str,
     agent_id_hint: str | None,
     expected_workspace_id: str | None = None,
+    surface: str | None = None,
 ) -> ScopeContext:
     session = await _get_session(scope_id)
     if session is None or getattr(session, "deleted_at", None) is not None:
@@ -1078,6 +1147,17 @@ async def _resolve_session(
             pocket_summary = _pocket_summary_data(pocket)
 
     target = agent_id_hint or getattr(session, "agent", None)
+    # /code is backend-authoritative (CX-3). When the surface is CODE and the
+    # caller passed no explicit ``agent_id_hint``, resolve to the dedicated
+    # ``code`` agent (lazy-seeded) — its exclusive file-tool config is what makes
+    # "build an employee management app…" write code instead of a pocket. This
+    # takes precedence over the session's stored agent and the default fallback
+    # so the exclusivity holds even when the frontend omits the id. Guarded
+    # narrowly on CODE — every other surface keeps byte-identical resolution.
+    if agent_id_hint is None and surface == SurfaceKind.CODE.value:
+        code_id = await _get_code_agent_id(workspace_id)
+        if code_id:
+            target = code_id
     if not target:
         # Sessions created via ``createPocketSession`` don't yet pin an agent
         # — fall back to the workspace's default ``pocketpaw`` agent (same
@@ -1168,6 +1248,7 @@ async def _resolve_pocket(
     user_id: str,
     agent_id_hint: str | None,
     expected_workspace_id: str | None = None,
+    surface: str | None = None,
 ) -> ScopeContext:
     pocket = await _get_pocket(scope_id)
     if pocket is None:
@@ -1210,6 +1291,15 @@ async def _resolve_pocket(
         target = agent_id_hint
     else:
         target = agent_ids[0]
+        # /code is backend-authoritative (CX-3): a CODE-surface turn with no
+        # explicit hint routes to the dedicated ``code`` agent (lazy-seeded),
+        # overriding the pocket's default agent, so the exclusive file-tool
+        # policy applies. Guarded narrowly on CODE — non-CODE pocket chats keep
+        # byte-identical resolution.
+        if surface == SurfaceKind.CODE.value:
+            code_id = await _get_code_agent_id(workspace_id)
+            if code_id:
+                target = code_id
 
     # Build the participant list: owner first, then team, then shared-with,
     # deduped. Pocket.owner is a required field on the model, so the falsy

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -1630,6 +1630,9 @@ async def execute_run(spec: RunSpec) -> None:
         user_id=spec.user_id,
         agent_id_hint=spec.agent_id,
         expected_workspace_id=spec.workspace_id,
+        # CX-3: on /code the resolver routes an unhinted turn to the dedicated
+        # code agent (exclusive file-tool policy). No-op on every other surface.
+        surface=spec.surface,
     )
     # Even with the spec fallback, a doc + spec that BOTH lack a usable workspace
     # must fail cleanly here — never attach an empty identity downstream (the

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -211,7 +211,15 @@ Changes:
   withhold-when-empty forward — including on the legacy ``resolved_profile is
   None`` path — so agent skills materialize even on non-entity / non-profile
   runs. The union still crosses into ``AgentPool.run`` as a plain
-  ``frozenset[str]`` (no EE symbol crosses into OSS). Per-agent MCP is DEFERRED.
+  ``frozenset[str]`` (no EE symbol crosses into OSS).
+- 2026-07-24 (CX-2, feat/code-agent-exclusive-tools) — per-agent MCP tool policy
+  (the M2 slice previously marked DEFERRED) is now LANDED. When the resolved
+  agent's config declares ``tool_mode="exclusive"``, ``_agent_tool_policy(instance)``
+  returns its declared ``tools`` and ``_drive_agent_loop`` sets
+  ``exclusive_mcp_tools=True`` + ``allow_mcp_tool_ids=<those tools>`` — driving the
+  CX-1 suppressible-grant cap so an exclusive agent (e.g. /code) gets EXACTLY its
+  declared MCP ids, OVERRIDING any surface allow-list. "additive" (the default)
+  is unchanged. The flag/allow-list cross into ``AgentPool.run`` as plain data.
 """
 
 from __future__ import annotations
@@ -833,6 +841,35 @@ def _agent_skill_set(instance: Any) -> frozenset[str]:
     return direct | plugin_skills
 
 
+def _agent_tool_policy(instance: Any) -> tuple[bool, frozenset[str]]:
+    """Resolve the agent's EXCLUSIVE tool policy from its raw config (CX-2).
+
+    Returns ``(exclusive, tools)``:
+    - ``exclusive`` is ``True`` ONLY when the agent config's
+      ``tool_mode == "exclusive"``. An explicit signal — a non-empty ``tools``
+      list does NOT by itself make an agent exclusive.
+    - ``tools`` is the frozenset of the agent's declared MCP tool ids, returned
+      only on the exclusive path (empty otherwise). The caller uses it as the
+      run's ``allow_mcp_tool_ids`` — which, paired with the CX-1
+      ``exclusive_mcp_tools`` cap, suppresses the universal pocket/widget/atlas
+      grant and OVERRIDES any surface allow-list. Additive agents (the default)
+      return ``(False, frozenset())`` so the legacy grant-union path is untouched.
+
+    ``instance.config`` is the raw config dict on the pooled instance; guarded
+    for dict-or-object exactly like ``backend`` is read at the run seam.
+    """
+    config = getattr(instance, "config", None) or {}
+    if isinstance(config, dict):
+        mode = config.get("tool_mode", "additive")
+        tools = config.get("tools", []) or []
+    else:
+        mode = getattr(config, "tool_mode", "additive")
+        tools = getattr(config, "tools", []) or []
+    if mode != "exclusive":
+        return (False, frozenset())
+    return (True, frozenset(tools))
+
+
 async def _prewarm_session(ctx: ScopeContext) -> None:
     """Eagerly warm the agent's CLI subprocess for this run's session BEFORE the
     first model turn (feat/claude-sdk-prewarm).
@@ -894,6 +931,15 @@ async def _prewarm_session(ctx: ScopeContext) -> None:
             surface_sys_override = ctx.resolved_profile.system_message_override
             surface_skills = ctx.resolved_profile.skill_names or frozenset()
         surface_skills = surface_skills | _agent_skill_set(instance)
+        # CX-2 — mirror _drive_agent_loop's exclusive-tool resolution EXACTLY so
+        # the prewarmed client's options (and thus its cache key) MATCH turn 1's.
+        # An exclusive agent caps its MCP surface, which changes ``allowed_tools``
+        # (part of the client cache key); without mirroring it here the prewarm
+        # would warm an UNCAPPED client that turn 1 discards — a wasted warm.
+        # Additive agents (the default) leave both values unchanged.
+        prewarm_exclusive, prewarm_tools = _agent_tool_policy(instance)
+        if prewarm_exclusive:
+            surface_allow_mcp = prewarm_tools
 
         # Bind this run's tenancy for the warm-up so the prewarmed subprocess
         # connects with the SAME per-tenant cwd jail the first turn will resolve
@@ -921,6 +967,7 @@ async def _prewarm_session(ctx: ScopeContext) -> None:
                 allow_mcp_tool_ids=surface_allow_mcp,
                 system_message_override=surface_sys_override,
                 skill_names=surface_skills,
+                exclusive_mcp_tools=prewarm_exclusive,
             )
         finally:
             detach_agent_identity(identity_tokens)
@@ -1100,6 +1147,21 @@ async def _drive_agent_loop(
         )
         if surface_allow_mcp is not None:
             run_kwargs["allow_mcp_tool_ids"] = surface_allow_mcp
+        # CX-2 — per-agent EXCLUSIVE tool policy. When the RESOLVED agent declares
+        # ``tool_mode="exclusive"``, its OWN ``tools`` become the MCP allow-list and
+        # the CX-1 ``exclusive_mcp_tools`` cap fires: the universal grant
+        # (pocket/widget/atlas + the ALWAYS_ALLOWED escape) is suppressed and the
+        # agent's declared ids OVERRIDE any surface ``allow_mcp_tool_ids`` set just
+        # above — agent-exclusive wins over the surface. ``exclusive_mcp_tools``
+        # rides the SAME withhold-when-empty contract as ``model_override`` /
+        # ``skill_names``: the key is added ONLY on the exclusive branch, so the 7
+        # non-Claude backends never receive a kwarg their narrower signature
+        # rejects. Additive agents (the default) touch nothing → the run is
+        # byte-identical to today, grant path intact.
+        agent_exclusive, agent_tools = _agent_tool_policy(instance)
+        if agent_exclusive:
+            run_kwargs["exclusive_mcp_tools"] = True
+            run_kwargs["allow_mcp_tool_ids"] = agent_tools
         # Forward the override only when the entity actually set one — withholding
         # keeps the prompt assembly untouched on every other run.
         if surface_sys_override is not None:

--- a/ee/pocketpaw_ee/cloud/codeagent/__init__.py
+++ b/ee/pocketpaw_ee/cloud/codeagent/__init__.py
@@ -9,9 +9,10 @@
 # prompts) was redundant and weaker.
 #
 # What remains is the browser-delegate channel (CD-1, ``delegates.py`` + the
-# ``/codeagent/resolve`` route). The main agent's ``code_mode`` tool parks on a
-# future and the browser wakes it by POSTing its answer back — the same "the work
-# happens in the browser" constraint that once made the turn stateless is what
-# makes a backend tool have to park and wait for the tab. ``service.py`` is now a
+# ``/codeagent/resolve`` route). The main agent's file tools (readFile / search /
+# listDir / writeFile) each park on a future and the browser wakes them by POSTing
+# the result back — the same "the work happens in the browser" constraint that
+# once made the turn stateless is what makes a backend tool have to park and wait
+# for the tab. ``service.py`` is now a
 # thin router→service pass-through for the resolve route; the rendezvous logic
 # lives in ``delegates.py``.

--- a/ee/pocketpaw_ee/cloud/codeagent/delegates.py
+++ b/ee/pocketpaw_ee/cloud/codeagent/delegates.py
@@ -1,18 +1,21 @@
 # delegates.py — The browser-delegate channel for Code Mode (CD-1).
 #
-# Created 2026-07-22 (feat/code-delegate-channel). The main chat agent is about
-# to gain ONE tool, ``code_mode``, that hands a coding task to the Code Mode
-# sub-agent. That tool runs in the BACKEND, but the work has to happen in the
-# USER'S BROWSER — a WebContainer project runs in the tab and has no server-side
-# row for a backend to reach, which is the same constraint that shaped the rest
-# of this module (see ``service.py``: the server never opens a file).
+# Created 2026-07-22 (feat/code-delegate-channel). Reshaped 2026-07-24
+# (feat/code-mode-file-tools): the main chat agent no longer hands a whole
+# ``task`` to a browser sub-agent — that sub-agent is gone. It now drives the
+# /code work in its OWN tool loop and delegates ONE file tool call at a time
+# (``readFile`` / ``writeFile`` / ``search`` / ``listDir``). Each of those tools
+# runs in the BACKEND, but the work has to happen in the USER'S BROWSER — a
+# WebContainer project runs in the tab and has no server-side row for a backend
+# to reach, which is the same constraint that shaped the rest of this module
+# (see ``service.py``: the server never opens a file).
 #
-# So the call is inverted. The backend does not execute the task; it PARKS on a
+# So the call is inverted. The backend does not execute the tool; it PARKS on a
 # future, pushes a ``code_delegate`` frame down the live SSE stream, and waits
 # for the browser to post the answer back to ``POST /codeagent/resolve``. This
 # module is both ends of that rendezvous and nothing else — it knows what a
 # correlation id is and how to wake a parked caller, and it knows nothing about
-# what the task said or what the browser did with it.
+# what the call did or what the browser returned for it.
 #
 # Modelled on ``pocketpaw.agents.plan_mode.PlanApprovalManager``, the shipped
 # precedent for parking a backend caller with a timeout. Two deliberate
@@ -309,20 +312,21 @@ def get_pending_delegates() -> PendingDelegates:
     return _registry
 
 
-async def delegate_to_browser(
+async def delegate_call_to_browser(
     workspace_id: str,
-    task: str,
-    mode: str = "ask",
+    tool: str,
+    tool_input: dict[str, Any],
     *,
     timeout: float = CODE_DELEGATE_TIMEOUT_SECONDS,
     registry: PendingDelegates | None = None,
     push: Callable[[str, dict[str, Any]], None] | None = None,
 ) -> DelegateOutcome:
-    """Hand ``task`` to the browser's Code Mode sub-agent and wait for its answer.
+    """Hand one file tool call to the browser and wait for its result.
 
-    This is the whole outbound half of the channel and the only entry point
-    CD-2's ``code_mode`` tool needs: register a slot, push one ``code_delegate``
-    frame, park.
+    This is the whole outbound half of the channel and the only entry point the
+    ``code.py`` file tools need: register a slot, push one ``code_delegate``
+    frame carrying ``{tool, input}``, park. The browser runs the matching
+    ``CodeFileSession`` verb and resolves with ``{output, isError}``.
 
     It FAILS FAST when there is no SSE stream in scope. ``push_sse_event`` is a
     documented no-op outside a stream, so without that check a tool invoked from
@@ -350,14 +354,14 @@ async def delegate_to_browser(
                 error=ERROR_NO_CLIENT,
                 message=(
                     "No browser session is attached to this conversation, so the "
-                    "coding task cannot be run."
+                    "code cannot be reached."
                 ),
             )
         push = push_sse_event
 
     corr_id = reg.open(workspace_id)
     try:
-        push(DELEGATE_EVENT, {"corrId": corr_id, "task": task, "mode": mode})
+        push(DELEGATE_EVENT, {"corrId": corr_id, "tool": tool, "input": tool_input})
     except Exception:  # noqa: BLE001 — a failed push must not kill the turn
         logger.warning("codeagent.delegate push failed corr=%s", corr_id, exc_info=True)
         # Nobody is parked on this future yet, so drop the slot rather than
@@ -366,14 +370,14 @@ async def delegate_to_browser(
         return DelegateOutcome(
             ok=False,
             error=ERROR_NO_CLIENT,
-            message="The coding task could not be sent to the browser.",
+            message="The file operation could not be sent to the browser.",
         )
 
     logger.debug(
-        "codeagent.delegate parked corr=%s ws=%s mode=%s timeout=%.0f",
+        "codeagent.delegate parked corr=%s ws=%s tool=%s timeout=%.0f",
         corr_id,
         workspace_id,
-        mode,
+        tool,
         timeout,
     )
     return await reg.wait(corr_id, timeout=timeout)
@@ -431,7 +435,7 @@ __all__ = [
     "MAX_DELEGATE_RESULT_CHARS",
     "DelegateOutcome",
     "PendingDelegates",
-    "delegate_to_browser",
+    "delegate_call_to_browser",
     "get_pending_delegates",
     "resolve_pending",
 ]

--- a/ee/pocketpaw_ee/cloud/codeagent/router.py
+++ b/ee/pocketpaw_ee/cloud/codeagent/router.py
@@ -8,10 +8,10 @@
 #
 #   POST /codeagent/resolve — hand a delegated task's result back to the backend.
 #
-# It is the return leg of a call the BACKEND started: the main agent's
-# ``code_mode`` tool pushes a ``code_delegate`` SSE frame and parks, the browser
-# does the work (it is the only side that can — a WebContainer project lives in
-# the tab), and this route wakes the parked turn. It spends no money and calls no
+# It is the return leg of a call the BACKEND started: one of the main agent's
+# file tools pushes a ``code_delegate`` SSE frame and parks, the browser runs the
+# file-session verb (it is the only side that can — a WebContainer project lives
+# in the tab), and this route wakes the parked tool. It spends no money and calls no
 # model; the workspace check here is genuine tenancy, since the correlation id it
 # carries names another user's parked turn if it names anything at all.
 #

--- a/ee/pocketpaw_ee/cloud/codeagent/service.py
+++ b/ee/pocketpaw_ee/cloud/codeagent/service.py
@@ -10,8 +10,8 @@
 # the weaker one, so it went.
 #
 # What remains is the INBOUND half of the browser-delegate rendezvous. The main
-# agent's ``code_mode`` tool parks on a future (``delegates.delegate_to_browser``)
-# and the browser wakes it by POSTing here. This service function is a thin
+# agent's file tools each park on a future (``delegates.delegate_call_to_browser``)
+# and the browser wakes them by POSTing here. This service function is a thin
 # pass-through to ``delegates.resolve_pending``; it exists only so the router
 # keeps ONE shape (router → service) for the ``/codeagent/resolve`` route. The
 # rendezvous logic itself lives in ``delegates.py``.

--- a/ee/pocketpaw_ee/cloud/codeproject/domain.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/domain.py
@@ -9,9 +9,16 @@
 # and ``is_scaffold_provider`` — the named test for "this project's ``repo`` field
 # holds a TEMPLATE id, not a repo IDENTITY". ``create_project``'s idempotency
 # reads it to decide whether a second create is the same project or a new one.
+#
+# Modified 2026-07-24 (feat/code-durable-project-store): added ``overlay`` to
+# CodeProjectView so the project-keyed durability path can read the snapshot +
+# overlay tiers off a single ``get_project`` (mirrors how WebSandboxView carries
+# ``overlay`` for websandbox restore). Like WebSandbox, overlay is view-only — it
+# is NOT surfaced on the wire ``CodeProjectResponse``; it is internal durability
+# bookkeeping, not a client-facing field.
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import NewType
 
@@ -66,6 +73,9 @@ class CodeProjectView:
     updated_at: datetime
     # Durable blob-storage snapshot pointer — the project's files between VMs.
     snapshot_file_id: str | None = None
+    # The write-through per-file durability overlay (``relpath -> FileRecord id``),
+    # keyed on the project. View-only, mirroring WebSandboxView — not on the wire.
+    overlay: dict[str, str] = field(default_factory=dict)
     # The current ephemeral sandbox (a WebSandbox row id), null when none is live.
     current_sandbox_id: str | None = None
     last_opened_at: datetime | None = None

--- a/ee/pocketpaw_ee/cloud/codeproject/domain.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/domain.py
@@ -17,6 +17,13 @@
 # is NOT surfaced on the wire ``CodeProjectResponse``; it is internal durability
 # bookkeeping, not a client-facing field.
 #
+# Modified 2026-07-25 (feat/code-s3-authoritative): added ``overlay_complete`` —
+# view-only like ``overlay`` (durability bookkeeping, never on the wire). It says
+# whether ``overlay`` is a COMPLETE image of the workspace or just the delta of
+# files that passed a write hook, which is the difference between "this path is
+# absent because the user deleted it" and "this path is absent because nothing ever
+# mirrored it". Restore reads it before doing anything destructive.
+#
 # Modified 2026-07-24 (feat/code-initial-prompt): added ``initial_prompt`` and
 # ``initial_prompt_consumed`` to CodeProjectView. Unlike ``overlay`` these DO flow
 # to the wire (``initialPrompt`` / ``initialPromptConsumed``) — the frontend reads
@@ -79,9 +86,11 @@ class CodeProjectView:
     updated_at: datetime
     # Durable blob-storage snapshot pointer — the project's files between VMs.
     snapshot_file_id: str | None = None
-    # The write-through per-file durability overlay (``relpath -> FileRecord id``),
-    # keyed on the project. View-only, mirroring WebSandboxView — not on the wire.
+    # The AUTHORITATIVE per-file store (``relpath -> FileRecord id``), keyed on the
+    # project. View-only, mirroring WebSandboxView — not on the wire.
     overlay: dict[str, str] = field(default_factory=dict)
+    # Whether ``overlay`` is a complete image of the workspace (see the model).
+    overlay_complete: bool = False
     # The natural-language build prompt captured at create-from-description time
     # (WHAT to build), and whether the auto-run build turn has been kicked off for
     # it. Both flow to the wire, unlike ``overlay``.

--- a/ee/pocketpaw_ee/cloud/codeproject/domain.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/domain.py
@@ -16,6 +16,12 @@
 # ``overlay`` for websandbox restore). Like WebSandbox, overlay is view-only — it
 # is NOT surfaced on the wire ``CodeProjectResponse``; it is internal durability
 # bookkeeping, not a client-facing field.
+#
+# Modified 2026-07-24 (feat/code-initial-prompt): added ``initial_prompt`` and
+# ``initial_prompt_consumed`` to CodeProjectView. Unlike ``overlay`` these DO flow
+# to the wire (``initialPrompt`` / ``initialPromptConsumed``) — the frontend reads
+# the prompt on first open to auto-run one build turn and the consumed flag to
+# avoid re-running it.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -76,6 +82,11 @@ class CodeProjectView:
     # The write-through per-file durability overlay (``relpath -> FileRecord id``),
     # keyed on the project. View-only, mirroring WebSandboxView — not on the wire.
     overlay: dict[str, str] = field(default_factory=dict)
+    # The natural-language build prompt captured at create-from-description time
+    # (WHAT to build), and whether the auto-run build turn has been kicked off for
+    # it. Both flow to the wire, unlike ``overlay``.
+    initial_prompt: str | None = None
+    initial_prompt_consumed: bool = False
     # The current ephemeral sandbox (a WebSandbox row id), null when none is live.
     current_sandbox_id: str | None = None
     last_opened_at: datetime | None = None

--- a/ee/pocketpaw_ee/cloud/codeproject/dto.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/dto.py
@@ -95,13 +95,35 @@ class ProjectFileWriteResponse(BaseModel):
     fileId: str
 
 
+class PutProjectFilesRequest(BaseModel):
+    """The in-tab runtime's whole project: ``{relative path: file content}``.
+
+    A REPLACEMENT, not a patch — a path absent from this map is absent from the
+    project, which is what lets a delete stick. The browser is the only thing
+    that can enumerate a filesystem living in a browser tab, so it walks its own
+    FS and posts the result. Excluded trees (``node_modules``, ``.git``, build
+    output) are filtered client-side before they get here, the same way the VM
+    sync filters them.
+    """
+
+    files: dict[str, str] = Field(default_factory=dict)
+
+
+class PutProjectFilesResponse(BaseModel):
+    """How many files the store now holds, after a whole-project replacement."""
+
+    ok: bool = True
+    stored: int
+
+
 class ProjectFilesResponse(BaseModel):
     """The project's whole persisted overlay: ``{relative path: file content}``.
 
-    The restore payload for the in-tab runtime. It carries the DELTA only — the
-    starter scaffold baseline is re-materialized client-side from the starter id,
-    so a project that has never been edited returns an empty map rather than the
-    scaffold.
+    The restore payload for the in-tab runtime. Once the store is COMPLETE (see
+    ``overlayComplete``) this is the whole project rather than a delta over a
+    baseline — which is what lets the client replay it and then delete anything
+    the map does not mention. An empty map means a project nothing has stored
+    yet, not a project with no files.
     """
 
     files: dict[str, str]

--- a/ee/pocketpaw_ee/cloud/codeproject/dto.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/dto.py
@@ -11,6 +11,13 @@
 # runtime sandbox to connect to), reusing the websandbox contract. ``rename`` takes
 # a ``RenameProjectRequest`` and returns the updated ``CodeProjectResponse``;
 # ``delete`` takes only the path id and returns 204.
+#
+# Modified 2026-07-24 (feat/code-initial-prompt): ``CreateProjectRequest`` now
+# accepts an optional ``initial_prompt`` (the natural-language description of WHAT
+# to build a from-scratch ``/code`` project), and ``CodeProjectResponse`` exposes
+# ``initialPrompt`` + ``initialPromptConsumed`` so the frontend can auto-run one
+# build turn on first open and know when it's already been kicked off. Added
+# ``ConsumePromptRequest`` for the mark-consumed / re-arm PATCH route.
 from __future__ import annotations
 
 from pydantic import BaseModel, Field
@@ -27,6 +34,10 @@ class CreateProjectRequest(BaseModel):
     repo: str = Field(..., min_length=1, max_length=1024)
     name: str | None = Field(default=None, max_length=200)
     provider: str = Field(default="github", max_length=32)
+    # The natural-language description of WHAT to build, when this project is
+    # created from a prompt rather than an existing repo. Persisted verbatim; the
+    # frontend reads it back on first open to auto-run one build turn.
+    initial_prompt: str | None = Field(default=None, max_length=8000)
 
 
 class RenameProjectRequest(BaseModel):
@@ -39,6 +50,17 @@ class RenameProjectRequest(BaseModel):
     name: str = Field(..., min_length=1, max_length=200)
 
 
+class ConsumePromptRequest(BaseModel):
+    """Mark the project's initial build prompt consumed — or re-arm it.
+
+    Sent when a build turn STARTS (``consumed=True``, the default) so a reopen
+    doesn't re-run the same build; a retry-build path re-arms the prompt
+    (``consumed=False``). Setting the state it's already in is a clean no-op.
+    """
+
+    consumed: bool = True
+
+
 class CodeProjectResponse(BaseModel):
     id: str
     workspaceId: str
@@ -46,6 +68,8 @@ class CodeProjectResponse(BaseModel):
     name: str
     provider: str
     repo: str
+    initialPrompt: str | None = None
+    initialPromptConsumed: bool = False
     snapshotFileId: str | None = None
     currentSandboxId: str | None = None
     lastOpenedAt: str | None = None  # ISO-8601 UTC, or null
@@ -60,6 +84,7 @@ class CodeProjectListResponse(BaseModel):
 __all__ = [
     "CodeProjectListResponse",
     "CodeProjectResponse",
+    "ConsumePromptRequest",
     "CreateProjectRequest",
     "RenameProjectRequest",
 ]

--- a/ee/pocketpaw_ee/cloud/codeproject/dto.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/dto.py
@@ -18,6 +18,13 @@
 # ``initialPrompt`` + ``initialPromptConsumed`` so the frontend can auto-run one
 # build turn on first open and know when it's already been kicked off. Added
 # ``ConsumePromptRequest`` for the mark-consumed / re-arm PATCH route.
+#
+# Modified 2026-07-25 (B1, feat/code-project-file-sync): added the browser-runtime
+# file-sync trio — ``PutProjectFileRequest`` (one client-written file),
+# ``ProjectFileWriteResponse`` (the acknowledged path + durable blob pointer) and
+# ``ProjectFilesResponse`` (the whole overlay as the restore payload). ``content``
+# is a string because the in-tab filesystem carries source text over JSON; the
+# byte ceiling lives in ``websandbox/durability.py`` next to the storage, not here.
 from __future__ import annotations
 
 from pydantic import BaseModel, Field
@@ -61,6 +68,45 @@ class ConsumePromptRequest(BaseModel):
     consumed: bool = True
 
 
+class PutProjectFileRequest(BaseModel):
+    """One file the in-browser runtime just wrote — its path and its text.
+
+    ``path`` is project-relative; the service normalizes it and rejects anything
+    that escapes the project (absolute paths, ``..`` traversal). ``content`` is
+    the whole file, last-write-wins per path — this is a write-through of an
+    editor save, not a patch. An empty string is a legitimate empty file.
+    """
+
+    path: str = Field(..., min_length=1, max_length=1024)
+    content: str = ""
+
+
+class ProjectFileWriteResponse(BaseModel):
+    """Acknowledgement of one persisted file.
+
+    ``path`` echoes back the NORMALIZED key the overlay actually stored (which
+    can differ from what the client sent — a leading slash is stripped), so the
+    client can key its own dirty-tracking on the same string the later delete
+    and read-back use.
+    """
+
+    ok: bool = True
+    path: str
+    fileId: str
+
+
+class ProjectFilesResponse(BaseModel):
+    """The project's whole persisted overlay: ``{relative path: file content}``.
+
+    The restore payload for the in-tab runtime. It carries the DELTA only — the
+    starter scaffold baseline is re-materialized client-side from the starter id,
+    so a project that has never been edited returns an empty map rather than the
+    scaffold.
+    """
+
+    files: dict[str, str]
+
+
 class CodeProjectResponse(BaseModel):
     id: str
     workspaceId: str
@@ -86,5 +132,8 @@ __all__ = [
     "CodeProjectResponse",
     "ConsumePromptRequest",
     "CreateProjectRequest",
+    "ProjectFileWriteResponse",
+    "ProjectFilesResponse",
+    "PutProjectFileRequest",
     "RenameProjectRequest",
 ]

--- a/ee/pocketpaw_ee/cloud/codeproject/dto.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/dto.py
@@ -116,6 +116,11 @@ class CodeProjectResponse(BaseModel):
     repo: str
     initialPrompt: str | None = None
     initialPromptConsumed: bool = False
+    # Whether the per-file store holds the WHOLE project rather than a delta over
+    # a baseline. On the wire because the in-tab runtime needs it to decide
+    # whether it may prune: replaying a COMPLETE store means a file the store
+    # doesn't list was deleted, while replaying a partial one means no such thing.
+    overlayComplete: bool = False
     snapshotFileId: str | None = None
     currentSandboxId: str | None = None
     lastOpenedAt: str | None = None  # ISO-8601 UTC, or null

--- a/ee/pocketpaw_ee/cloud/codeproject/lifecycle.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/lifecycle.py
@@ -52,10 +52,31 @@
 # reuse branch is covered too, and it never fires for scaffold projects — copying
 # one shared row's state into N sibling starter projects is the very stomping this
 # task removes.
+#
+# 2026-07-25 (B3, feat/code-scaffold-on-vm): a SCAFFOLD project can now open on the
+# Daytona runtime. It could not before — its ``repo`` is a starter template id, and
+# ``open_sandbox`` fail-closes on anything that isn't a clean http(s) URL, so the
+# open was rejected before a VM existed and scaffold projects were in-tab only.
+# The fix is a different door, not a weaker lock: ``open_bare_sandbox`` provisions
+# an EMPTY VM (no clone, no remote, no branch) and ``scaffold_into_sandbox``
+# materializes the starter into it. ``_validate_repo_url`` is untouched and still
+# guards every clone.
+#
+# Sequencing is load-bearing: scaffold FIRST, restore SECOND. The template is the
+# baseline; the durable snapshot + overlay are the user's work, so they land ON TOP
+# of it and win every conflict. Reversing it would have the template overwrite the
+# user's edits.
+#
+# The re-scaffold guard is structural: the scaffold call sits ONLY in the
+# cold-provision branch, so it runs against a VM this call just created and which
+# is therefore empty by construction. The reuse branch returns before it, so a live
+# VM (or a reopen that reuses one) is never re-materialized over. See
+# ``_scaffold_baseline`` for why this is the guard rather than a VM probe.
 from __future__ import annotations
 
 import contextlib
 import logging
+from typing import Any
 
 from pocketpaw_ee.cloud._core.errors import NotFound
 from pocketpaw_ee.cloud.codeproject import service as codeproject_service
@@ -63,6 +84,7 @@ from pocketpaw_ee.cloud.codeproject.domain import CodeProjectView, is_scaffold_p
 from pocketpaw_ee.cloud.daytona.client import DaytonaClient, get_daytona_client
 from pocketpaw_ee.cloud.websandbox import durability as websandbox_durability
 from pocketpaw_ee.cloud.websandbox import provision as websandbox_provision
+from pocketpaw_ee.cloud.websandbox import scaffold_service as websandbox_scaffold
 from pocketpaw_ee.cloud.websandbox import service as websandbox_service
 from pocketpaw_ee.cloud.websandbox.domain import WebSandboxView
 
@@ -85,21 +107,30 @@ async def open_project(
     user_id: str,
     project_id: str,
     client: DaytonaClient | None = None,
+    *,
+    bring_up: Any = None,
 ) -> WebSandboxView:
     """Open a durable project, returning a ready sandbox to connect to.
 
     Flow:
       1. Load the project (tenant + owner scoped; ``NotFound`` if not owned).
       2. If it's bound to a sandbox that is still live (``ready`` + Daytona id),
-         reuse it and re-stamp ``last_opened_at``.
-      3. Otherwise cold-provision a fresh sandbox for the project's repo (via
-         ``websandbox.provision.open_sandbox`` — idempotent on the repo, so this
-         reuses the project's stable WebSandbox row and boots a new VM into it),
-         then restore the PROJECT's durable state into it and bind it.
+         reuse it and re-stamp ``last_opened_at``. Nothing is re-materialized on
+         this branch — the VM already holds the user's work.
+      3. Otherwise cold-provision a FRESH sandbox for the project:
+         * a repo project clones (``open_sandbox``, which validates the URL);
+         * a scaffold project provisions an EMPTY VM (``open_bare_sandbox``) and
+           materializes its starter into it — its ``repo`` is a template id, so
+           there is nothing to clone and the clone validator must not see it.
+         Then restore the PROJECT's durable state ON TOP and bind it.
 
     Returns the ready ``WebSandboxView``. The bound-but-invalid case (the VM was
     reaped, or the id no longer resolves) falls through to reprovision — "if the
     id is invalid or unavailable, make a new sandbox."
+
+    ``bring_up`` is the same kind of DI seam as ``client``: it is threaded to
+    ``scaffold_into_sandbox`` so a test can drive the whole scaffold open without a
+    real VM. ``None`` means "use the real one"; no production caller passes it.
     """
     project = await codeproject_service.get_project(workspace_id, user_id, project_id)
     # B2 rollout: lift any legacy sandbox-keyed durable state onto the project
@@ -114,22 +145,110 @@ async def open_project(
         await codeproject_service.bind_current_sandbox(workspace_id, user_id, project_id, reused.id)
         return reused
 
-    # Provision a fresh sandbox for the repo (idempotent on the repo → reuses the
+    # Provision a fresh sandbox (idempotent on the registry key → reuses the
     # project's stable WebSandbox row, boots a new VM into it) and bind it.
-    sandbox = await websandbox_provision.open_sandbox(
-        workspace_id, user_id, {"repo": project.repo}, client=client
-    )
+    if is_scaffold_provider(project.provider):
+        sandbox = await websandbox_provision.open_bare_sandbox(
+            workspace_id, user_id, _scaffold_registry_key(project), client=client
+        )
+        # The BASELINE, written before any durable state: this VM was created
+        # moments ago and is empty, so materializing the template into it cannot
+        # overwrite anything.
+        await _scaffold_baseline(workspace_id, user_id, project, sandbox, client, bring_up)
+    else:
+        sandbox = await websandbox_provision.open_sandbox(
+            workspace_id, user_id, {"repo": project.repo}, client=client
+        )
     # CM-2a′ / B2: overlay the PROJECT's durable snapshot (uncommitted work +
     # branch from a prior session) onto the freshly-cloned VM, if one exists.
+    # B3: for a scaffold project this lands ON TOP of the starter above — the
+    # template is the baseline, the durable state is the user's work.
     await _restore_if_snapshotted(workspace_id, user_id, project, sandbox, client)
     await codeproject_service.bind_current_sandbox(workspace_id, user_id, project_id, sandbox.id)
     logger.info(
-        "codeproject.open: project=%s bound fresh sandbox=%s (repo=%s)",
+        "codeproject.open: project=%s bound fresh sandbox=%s (provider=%s repo=%s)",
         project_id,
         sandbox.id,
+        project.provider,
         project.repo,
     )
     return sandbox
+
+
+def _scaffold_registry_key(project: CodeProjectView) -> str:
+    """The WebSandbox registry key for a scaffold project — one row per PROJECT.
+
+    A sandbox row is unique per (workspace, user, key). Passing the raw template id
+    as that key would give every project built from ``react`` ONE row, and the row
+    is what binds a project to a VM: opening project B would rebind (and tear down)
+    project A's VM, and ``_reuse_if_live`` would then hand project A the sandbox
+    holding project B's files. That is the same shared-row collision B2 removed from
+    the durability pointers, so the key is namespaced by the project id and the
+    collision cannot occur.
+
+    The template id stays in the key because a key is also a debugging aid — a row
+    reading ``starter:react:<id>`` says what it is without a second lookup. It is
+    stable across opens (both parts are immutable), so idempotent reuse still holds.
+    """
+    return f"starter:{project.repo}:{project.id}"
+
+
+async def _scaffold_baseline(
+    workspace_id: str,
+    user_id: str,
+    project: CodeProjectView,
+    sandbox: WebSandboxView,
+    client: DaytonaClient | None,
+    bring_up: Any,
+) -> None:
+    """Materialize the project's starter into a freshly-provisioned, EMPTY VM.
+
+    The re-scaffold guard is the CALL SITE, not a flag: this only ever runs in
+    ``open_project``'s cold-provision branch, immediately after
+    ``open_bare_sandbox`` returned a VM it created in this same call. Such a VM is
+    empty by construction, so writing the template into it cannot destroy work. A
+    reopen that finds a live VM returns from the reuse branch above and never
+    reaches here; a reopen that finds a dead VM gets a new empty one, where the
+    template is again the correct baseline and the restore that follows puts the
+    user's own files back over it.
+
+    Deliberately NOT guarded by probing the VM for emptiness instead: the workdir
+    is a home directory that already contains shell dotfiles, so "is it empty" has
+    no honest answer, and a guard that reads ambiguous evidence is worse than one
+    that relies on an invariant the code itself maintains.
+
+    Best-effort, like the restore that follows it. A codescaffold outage (an
+    unreachable registry, a starter pulled from the catalog) must not strand a
+    returning user whose real work is in the durable state — an empty VM plus a
+    successful restore is recoverable, a failed open is not. A failed bring-up STEP
+    (a broken ``npm install``) does not raise at all; it is reported and logged, and
+    the files are still on disk.
+    """
+    body = {"starter": project.repo, "projectName": project.name}
+    extra = {} if bring_up is None else {"bring_up": bring_up}
+    try:
+        result = await websandbox_scaffold.scaffold_into_sandbox(
+            workspace_id, user_id, sandbox.id, body, client=client, **extra
+        )
+    except Exception:  # noqa: BLE001 — never block the open on the baseline
+        logger.warning(
+            "codeproject.open: scaffold failed for project=%s (starter=%s); "
+            "continuing with an empty VM",
+            project.id,
+            project.repo,
+            exc_info=True,
+        )
+        return
+    logger.info(
+        "codeproject.open: scaffolded project=%s starter=%s into daytona=%s "
+        "(files=%d, running=%s, failedStep=%s)",
+        project.id,
+        result.starter,
+        sandbox.sandbox_id,
+        result.fileCount,
+        result.running,
+        result.failedStep,
+    )
 
 
 async def delete_project(

--- a/ee/pocketpaw_ee/cloud/codeproject/lifecycle.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/lifecycle.py
@@ -29,6 +29,29 @@
 # then bound the editor to a dead VM (no connection, empty tree). ``_reuse_if_live``
 # now confirms the bound VM actually exists and is ``started`` in Daytona; anything
 # else falls through to reprovision + snapshot restore.
+#
+# 2026-07-25 (B2, feat/code-daytona-project-anchor): restore now reads the durable
+# state off the PROJECT, not off the sandbox row. The old anchor was a bug waiting
+# to fire: a WebSandbox row is unique per (workspace, user, repo), and a scaffold
+# project puts a TEMPLATE id in ``repo``, so every project built from the same
+# starter shared ONE row and would have stomped each other's snapshot + overlay.
+# Anchoring on the project id removes that by construction and makes the stated
+# "CodeProject = durable / WebSandbox = ephemeral" split true rather than
+# aspirational. ``open_project`` therefore restores via ``restore_project`` into the
+# freshly-provisioned VM's Daytona id.
+#
+# The same change adds the one-way rollout backfill: ``_backfill_legacy_durability``
+# lifts a repo project's legacy sandbox-keyed pointers onto the project before
+# anything reads them. It runs LAZILY here rather than as a boot-time sweep because
+# (a) this is the only moment the legacy state matters — it has to be on the project
+# before the first project-keyed restore or mirror, and an open is exactly when that
+# happens; (b) it already has the tenancy context (workspace + user + owned project)
+# a global sweep would have to invent; and (c) it is idempotent by construction, so
+# every later open re-checks for free instead of needing a one-shot migration to be
+# scheduled, monitored, and re-run. It sits at the TOP of ``open_project`` so the
+# reuse branch is covered too, and it never fires for scaffold projects — copying
+# one shared row's state into N sibling starter projects is the very stomping this
+# task removes.
 from __future__ import annotations
 
 import contextlib
@@ -36,7 +59,7 @@ import logging
 
 from pocketpaw_ee.cloud._core.errors import NotFound
 from pocketpaw_ee.cloud.codeproject import service as codeproject_service
-from pocketpaw_ee.cloud.codeproject.domain import CodeProjectView
+from pocketpaw_ee.cloud.codeproject.domain import CodeProjectView, is_scaffold_provider
 from pocketpaw_ee.cloud.daytona.client import DaytonaClient, get_daytona_client
 from pocketpaw_ee.cloud.websandbox import durability as websandbox_durability
 from pocketpaw_ee.cloud.websandbox import provision as websandbox_provision
@@ -72,13 +95,17 @@ async def open_project(
       3. Otherwise cold-provision a fresh sandbox for the project's repo (via
          ``websandbox.provision.open_sandbox`` — idempotent on the repo, so this
          reuses the project's stable WebSandbox row and boots a new VM into it),
-         then bind it onto the project.
+         then restore the PROJECT's durable state into it and bind it.
 
     Returns the ready ``WebSandboxView``. The bound-but-invalid case (the VM was
     reaped, or the id no longer resolves) falls through to reprovision — "if the
     id is invalid or unavailable, make a new sandbox."
     """
     project = await codeproject_service.get_project(workspace_id, user_id, project_id)
+    # B2 rollout: lift any legacy sandbox-keyed durable state onto the project
+    # BEFORE anything reads it. Idempotent, so this is a cheap no-op on every
+    # subsequent open.
+    project = await _backfill_legacy_durability(workspace_id, user_id, project)
 
     reused = await _reuse_if_live(workspace_id, user_id, project, client)
     if reused is not None:
@@ -92,9 +119,9 @@ async def open_project(
     sandbox = await websandbox_provision.open_sandbox(
         workspace_id, user_id, {"repo": project.repo}, client=client
     )
-    # CM-2a′: overlay the row's durable snapshot (uncommitted work + branch from a
-    # prior session) onto the freshly-cloned VM, if one exists.
-    await _restore_if_snapshotted(workspace_id, user_id, sandbox, client)
+    # CM-2a′ / B2: overlay the PROJECT's durable snapshot (uncommitted work +
+    # branch from a prior session) onto the freshly-cloned VM, if one exists.
+    await _restore_if_snapshotted(workspace_id, user_id, project, sandbox, client)
     await codeproject_service.bind_current_sandbox(workspace_id, user_id, project_id, sandbox.id)
     logger.info(
         "codeproject.open: project=%s bound fresh sandbox=%s (repo=%s)",
@@ -162,43 +189,130 @@ async def _teardown_bound_sandbox(
 async def _restore_if_snapshotted(
     workspace_id: str,
     user_id: str,
+    project: CodeProjectView,
     sandbox: WebSandboxView,
     client: DaytonaClient | None,
 ) -> None:
-    """Restore the sandbox row's durable state into its fresh VM, if any.
+    """Restore the PROJECT's durable state into the freshly-provisioned VM, if any.
 
-    The WebSandbox row is stable across reprovisions, so both durability tiers
-    survive on the row when we reprovision: the ``snapshot_file_id`` (captured on
-    a prior clean disconnect) AND the write-through ``overlay`` (per-file edits
-    mirrored since the last snapshot — the tier that covers a crash / idle-out
-    before any disconnect snapshot). Restore fires when EITHER exists; a row with
-    neither (first open, or nothing edited) is a clean no-op.
+    Both durability tiers live on the durable project row (B2): the
+    ``snapshot_file_id`` (captured on a prior clean disconnect) AND the
+    write-through ``overlay`` (per-file edits mirrored since the last snapshot —
+    the tier that covers a crash / idle-out before any disconnect snapshot).
+    Restore fires when EITHER exists; a project with neither (first open, or
+    nothing edited) is a clean no-op.
+
+    The anchor moved off the WebSandbox row deliberately. That row is unique per
+    (workspace, user, repo), so N projects sharing a starter template shared one
+    row and one set of pointers; reading the project instead makes each project's
+    durable state its own. The row is still what tells us WHICH VM to untar into —
+    ``sandbox.sandbox_id``, the live Daytona id.
 
     Best-effort by design: a restore failure (VM gone, S3 down, corrupt tarball)
     is logged and swallowed — the fresh clone from ``open_sandbox`` is still a
     usable workspace, so a durability miss must never fail the open.
     """
-    if not sandbox.snapshot_file_id and not sandbox.overlay:
+    if not project.snapshot_file_id and not project.overlay:
+        return
+    if not sandbox.sandbox_id:
+        # No bound VM to untar into (provision handed back an unready row). The
+        # durable state stays on the project untouched for the next open.
+        logger.warning(
+            "codeproject.open: project=%s has durable state but sandbox=%s has no VM; "
+            "skipping restore",
+            project.id,
+            sandbox.id,
+        )
         return
     try:
-        await websandbox_durability.restore_workspace(
-            workspace_id, user_id, sandbox.id, client=client
+        await websandbox_durability.restore_project(
+            workspace_id, user_id, project.id, sandbox.sandbox_id, client=client
         )
         logger.info(
-            "codeproject.open: restored durable state into sandbox=%s "
+            "codeproject.open: restored durable state for project=%s into daytona=%s "
             "(snapshot=%s, overlay=%d file(s))",
-            sandbox.id,
-            sandbox.snapshot_file_id,
-            len(sandbox.overlay or {}),
+            project.id,
+            sandbox.sandbox_id,
+            project.snapshot_file_id,
+            len(project.overlay or {}),
         )
     except Exception:  # noqa: BLE001 — a fresh clone is still usable; never block open
         logger.warning(
-            "codeproject.open: snapshot restore failed for sandbox=%s (snapshot=%s); "
+            "codeproject.open: snapshot restore failed for project=%s (snapshot=%s); "
             "continuing with the fresh clone",
-            sandbox.id,
-            sandbox.snapshot_file_id,
+            project.id,
+            project.snapshot_file_id,
             exc_info=True,
         )
+
+
+async def _backfill_legacy_durability(
+    workspace_id: str,
+    user_id: str,
+    project: CodeProjectView,
+) -> CodeProjectView:
+    """Lift legacy sandbox-keyed durable state onto the project. Returns the view.
+
+    The one-way rollout migration for B2. Before the cutover, a project's
+    uncommitted work was recorded on the WebSandbox row it was bound to; after it,
+    restore reads the project. Without this copy, a returning user with real work
+    on the old anchor reopens to a bare re-clone — silent data loss at exactly the
+    moment durability is supposed to pay off.
+
+    Conditions, all of which make it safe to run on every open:
+      * the project must hold NO durable state of its own (the service enforces
+        this too, so a race can't clobber fresher work);
+      * the project must be bound to a resolvable, owned sandbox row carrying
+        something to adopt;
+      * the project must NOT be a scaffold project. Its ``repo`` is a template id,
+        so its sandbox row is shared with every sibling built from the same
+        starter — adopting that row's state would copy one project's files into N
+        others, which is the exact stomping this cutover removes. Scaffold projects
+        never persisted through this path anyway (the Daytona adapter refuses a
+        non-repo source), so there is nothing to lose by skipping them.
+
+    Best-effort: any failure returns the project unchanged rather than blocking the
+    open. The legacy fields are left in place, so a missed backfill is retried on
+    the next open instead of being lost.
+    """
+    if project.snapshot_file_id or project.overlay:
+        return project
+    if not project.current_sandbox_id or is_scaffold_provider(project.provider):
+        return project
+    try:
+        sandbox = await websandbox_service.get_sandbox(
+            workspace_id, user_id, project.current_sandbox_id
+        )
+    except NotFound:
+        return project
+    if not sandbox.snapshot_file_id and not sandbox.overlay:
+        return project
+    try:
+        adopted = await codeproject_service.adopt_legacy_durability(
+            workspace_id,
+            user_id,
+            project.id,
+            sandbox.snapshot_file_id,
+            dict(sandbox.overlay or {}),
+        )
+    except Exception:  # noqa: BLE001 — a backfill miss must never block the open
+        logger.warning(
+            "codeproject.open: legacy durability backfill failed for project=%s "
+            "(sandbox=%s); continuing without it",
+            project.id,
+            project.current_sandbox_id,
+            exc_info=True,
+        )
+        return project
+    logger.info(
+        "codeproject.open: adopted legacy durable state for project=%s from sandbox=%s "
+        "(snapshot=%s, overlay=%d file(s))",
+        project.id,
+        project.current_sandbox_id,
+        adopted.snapshot_file_id,
+        len(adopted.overlay or {}),
+    )
+    return adopted
 
 
 async def _reuse_if_live(

--- a/ee/pocketpaw_ee/cloud/codeproject/lifecycle.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/lifecycle.py
@@ -72,6 +72,17 @@
 # is therefore empty by construction. The reuse branch returns before it, so a live
 # VM (or a reopen that reuses one) is never re-materialized over. See
 # ``_scaffold_baseline`` for why this is the guard rather than a VM probe.
+#
+# 2026-07-25 (S1, feat/code-s3-authoritative): the cold-provision branch gained a
+# third step — ``_seed_project_files``, after the restore. WHY: the per-file store in
+# blob storage is now the project's whole truth (the tarball tier is retired because
+# a tarball cannot express a DELETE, so replaying it resurrected removed files), and
+# the write-through hooks only ever see files that pass through the editor. A clone's
+# tree and a materialized scaffold pass through nothing, so without an explicit sync
+# the store would be missing most of the project until its first clean disconnect —
+# and a session that crashes or idles out never has one. Ordering is load-bearing
+# again: scaffold, then restore, THEN sync, so what gets photographed is the user's
+# real workspace rather than the bare baseline.
 from __future__ import annotations
 
 import contextlib
@@ -164,6 +175,11 @@ async def open_project(
     # B3: for a scaffold project this lands ON TOP of the starter above — the
     # template is the baseline, the durable state is the user's work.
     await _restore_if_snapshotted(workspace_id, user_id, project, sandbox, client)
+    # S1: the content that just landed (a clone's tree, a materialized scaffold)
+    # never passed a write hook, so nothing in blob storage knows about it until
+    # something enumerates the workspace. Seed the store NOW rather than at the
+    # first disconnect.
+    await _seed_project_files(workspace_id, user_id, project, sandbox, client)
     await codeproject_service.bind_current_sandbox(workspace_id, user_id, project_id, sandbox.id)
     logger.info(
         "codeproject.open: project=%s bound fresh sandbox=%s (provider=%s repo=%s)",
@@ -314,12 +330,11 @@ async def _restore_if_snapshotted(
 ) -> None:
     """Restore the PROJECT's durable state into the freshly-provisioned VM, if any.
 
-    Both durability tiers live on the durable project row (B2): the
-    ``snapshot_file_id`` (captured on a prior clean disconnect) AND the
-    write-through ``overlay`` (per-file edits mirrored since the last snapshot —
-    the tier that covers a crash / idle-out before any disconnect snapshot).
-    Restore fires when EITHER exists; a project with neither (first open, or
-    nothing edited) is a clean no-op.
+    The durable state lives on the project row (B2): the authoritative per-file
+    ``overlay``, plus — for a project whose state predates S1 — a legacy
+    ``snapshot_file_id`` that ``restore_project`` migrates into per-file entries on
+    its way past. Restore fires when EITHER exists; a project with neither (first
+    open, or nothing edited) is a clean no-op.
 
     The anchor moved off the WebSandbox row deliberately. That row is unique per
     (workspace, user, repo), so N projects sharing a starter template shared one
@@ -363,6 +378,57 @@ async def _restore_if_snapshotted(
             project.snapshot_file_id,
             exc_info=True,
         )
+
+
+async def _seed_project_files(
+    workspace_id: str,
+    user_id: str,
+    project: CodeProjectView,
+    sandbox: WebSandboxView,
+    client: DaytonaClient | None,
+) -> None:
+    """Re-image the project's per-file store from the freshly-materialized VM (S1).
+
+    The per-file store is the project's whole truth now, and the write-through hooks
+    only ever see what passes through the editor. Everything that lands another way
+    — a ``git clone``'s tree, a scaffold materialized by ``_scaffold_baseline``,
+    anything a bring-up step generates — is invisible to them. The retired tarball
+    used to cover that gap on disconnect; syncing here covers it from the START, so
+    a project is complete in blob storage the moment it opens rather than only after
+    its first clean disconnect (a session that crashes or idles out never had one).
+
+    Runs only on the COLD-PROVISION branch, which is the only branch where new
+    unseen content lands: the reuse branch returns before it, against a VM whose
+    files are already synced. It runs AFTER the restore so the sync photographs the
+    user's real workspace — running it before would capture the bare clone/scaffold
+    and re-add every file the user had deleted, which is the exact bug this whole
+    change removes.
+
+    Best-effort, like the scaffold and restore around it: a sync failure leaves the
+    project on whatever the store already held and is retried on the next disconnect
+    or open. Blocking an open on a durability capture would be the worse trade.
+    """
+    if not sandbox.sandbox_id:
+        return
+    try:
+        overlay = await websandbox_durability.sync_project_files(
+            workspace_id, user_id, project.id, sandbox.sandbox_id, client=client
+        )
+    except Exception:  # noqa: BLE001 — never block the open on a durability capture
+        logger.warning(
+            "codeproject.open: file sync failed for project=%s (daytona=%s); the store "
+            "still holds the previous state",
+            project.id,
+            sandbox.sandbox_id,
+            exc_info=True,
+        )
+        return
+    logger.info(
+        "codeproject.open: synced project=%s from daytona=%s (%d file(s) in the store)",
+        project.id,
+        sandbox.sandbox_id,
+        len(overlay),
+    )
 
 
 async def _backfill_legacy_durability(

--- a/ee/pocketpaw_ee/cloud/codeproject/router.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/router.py
@@ -13,9 +13,15 @@
 #   POST   /codeproject/{id}/open — resolve the project to a READY sandbox to connect
 #                                   to (reuse the bound one or provision a fresh one).
 #   PATCH  /codeproject/{id}      — rename a project's display name (owner-scoped).
+#   PATCH  /codeproject/{id}/consume-prompt — mark the initial build prompt consumed
+#                                   on build-turn start, or re-arm it on a retry.
 #   DELETE /codeproject/{id}      — delete a project + tear down its bound VM.
 # Like the WebSandbox router, endpoints are license-gated + context-authenticated;
 # the tenancy/owner filtering in the service is the security boundary.
+#
+# Modified 2026-07-24 (feat/code-initial-prompt): added the consume-prompt PATCH
+# route so the frontend can flip ``initial_prompt_consumed`` when it kicks off the
+# auto-run build turn (and re-arm it on a retry-build).
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, Response
@@ -27,6 +33,7 @@ from pocketpaw_ee.cloud.codeproject import service as codeproject_service
 from pocketpaw_ee.cloud.codeproject.dto import (
     CodeProjectListResponse,
     CodeProjectResponse,
+    ConsumePromptRequest,
     CreateProjectRequest,
     RenameProjectRequest,
 )
@@ -107,6 +114,24 @@ async def rename_project(
     """Rename a project's display name (owner-scoped)."""
     workspace_id = _require_workspace(ctx)
     view = await codeproject_service.rename_project(workspace_id, ctx.user_id, project_id, body)
+    return codeproject_service.view_to_wire(view)
+
+
+@router.patch("/{project_id}/consume-prompt", response_model=CodeProjectResponse)
+async def consume_prompt(
+    project_id: str,
+    body: ConsumePromptRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> CodeProjectResponse:
+    """Mark the initial build prompt consumed on build-turn start (owner-scoped).
+
+    ``consumed=True`` (the default) latches the prompt so a reopen doesn't re-run
+    the auto-build; ``consumed=False`` re-arms it for a retry-build. Idempotent.
+    """
+    workspace_id = _require_workspace(ctx)
+    view = await codeproject_service.mark_initial_prompt_consumed(
+        workspace_id, ctx.user_id, project_id, body
+    )
     return codeproject_service.view_to_wire(view)
 
 

--- a/ee/pocketpaw_ee/cloud/codeproject/router.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/router.py
@@ -19,7 +19,7 @@
 #   PUT    /codeproject/{id}/file  — persist ONE file written by the in-browser
 #                                   runtime (write-through to blob storage).
 #   DELETE /codeproject/{id}/file  — drop one file so it isn't restored again.
-#   GET    /codeproject/{id}/files — the project's persisted overlay, the restore
+#   GET    /codeproject/{id}/files — the project's whole persisted state, the restore
 #                                   payload the in-tab runtime replays.
 # Like the WebSandbox router, endpoints are license-gated + context-authenticated;
 # the tenancy/owner filtering in the service is the security boundary.
@@ -36,6 +36,12 @@
 # pull the whole set back on a reopen. Storage lives in ``websandbox/durability.py``
 # (the layer allowed to touch EEUploadService); like the websandbox snapshot /
 # restore routes, this router calls it directly and stays a thin adapter.
+#
+# Modified 2026-07-25 (B4, feat/code-cross-runtime-restore): docs only. The GET
+# /files payload is no longer "the overlay" — ``read_project_overlay`` now composes
+# the snapshot tar AND the overlay, so a project last saved in the Daytona runtime
+# is retrievable in-tab instead of coming back empty. No route, DTO, or wire shape
+# changed; the docstring here would otherwise describe the pre-fix behaviour.
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, Query, Response
@@ -196,8 +202,10 @@ async def read_project_files(
 ) -> ProjectFilesResponse:
     """Read every persisted file back (owner-scoped) — the restore payload.
 
-    The delta only: the client re-materializes the starter scaffold from the
-    starter id, then replays this map over it.
+    Both durability tiers, merged: the snapshot tar a Daytona session wrote (minus
+    the regenerable trees) as the baseline, with the per-file overlay on top. The
+    client re-materializes the starter scaffold from the starter id, then replays
+    this map over it — so a project saved in EITHER runtime reopens intact here.
     """
     workspace_id = _require_workspace(ctx)
     files = await websandbox_durability.read_project_overlay(workspace_id, ctx.user_id, project_id)

--- a/ee/pocketpaw_ee/cloud/codeproject/router.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/router.py
@@ -58,6 +58,8 @@ from pocketpaw_ee.cloud.codeproject.dto import (
     ProjectFilesResponse,
     ProjectFileWriteResponse,
     PutProjectFileRequest,
+    PutProjectFilesRequest,
+    PutProjectFilesResponse,
     RenameProjectRequest,
 )
 from pocketpaw_ee.cloud.license import require_license
@@ -181,6 +183,30 @@ async def put_project_file(
         workspace_id, ctx.user_id, project_id, body.path, body.content
     )
     return ProjectFileWriteResponse(ok=True, path=path, fileId=file_id)
+
+
+@router.put("/{project_id}/files", response_model=PutProjectFilesResponse)
+async def put_project_files(
+    project_id: str,
+    body: PutProjectFilesRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> PutProjectFilesResponse:
+    """Replace the in-tab project's whole store, marking it COMPLETE (owner-scoped).
+
+    The client walks the filesystem it hosts and posts everything at once. That
+    is the only way the store can become complete for a tab-hosted project — a
+    per-file PUT can never know whether it was the last one — and completeness is
+    what licenses the restore-time prune to treat an unlisted file as deleted.
+
+    All-or-nothing: every byte is uploaded before the map is swapped, so a failure
+    leaves the project exactly as it was rather than marking a partial store
+    complete.
+    """
+    workspace_id = _require_workspace(ctx)
+    stored = await websandbox_durability.put_project_files(
+        workspace_id, ctx.user_id, project_id, body.files
+    )
+    return PutProjectFilesResponse(ok=True, stored=stored)
 
 
 @router.delete("/{project_id}/file", status_code=204)

--- a/ee/pocketpaw_ee/cloud/codeproject/router.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/router.py
@@ -16,15 +16,29 @@
 #   PATCH  /codeproject/{id}/consume-prompt — mark the initial build prompt consumed
 #                                   on build-turn start, or re-arm it on a retry.
 #   DELETE /codeproject/{id}      — delete a project + tear down its bound VM.
+#   PUT    /codeproject/{id}/file  — persist ONE file written by the in-browser
+#                                   runtime (write-through to blob storage).
+#   DELETE /codeproject/{id}/file  — drop one file so it isn't restored again.
+#   GET    /codeproject/{id}/files — the project's persisted overlay, the restore
+#                                   payload the in-tab runtime replays.
 # Like the WebSandbox router, endpoints are license-gated + context-authenticated;
 # the tenancy/owner filtering in the service is the security boundary.
 #
 # Modified 2026-07-24 (feat/code-initial-prompt): added the consume-prompt PATCH
 # route so the frontend can flip ``initial_prompt_consumed`` when it kicks off the
 # auto-run build turn (and re-arm it on a retry-build).
+#
+# Modified 2026-07-25 (B1, feat/code-project-file-sync): added the three file-sync
+# routes above. They exist because the in-tab (WebContainer) runtime writes to a
+# filesystem inside the browser that no backend hook can see — the Daytona path
+# mirrors edits from the ``file.write`` WebSocket verb, but in a tab there is no
+# VM to mirror out of, so the client itself has to push each write through and
+# pull the whole set back on a reopen. Storage lives in ``websandbox/durability.py``
+# (the layer allowed to touch EEUploadService); like the websandbox snapshot /
+# restore routes, this router calls it directly and stays a thin adapter.
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, Response
+from fastapi import APIRouter, Depends, Query, Response
 
 from pocketpaw_ee.cloud._core.context import RequestContext, request_context
 from pocketpaw_ee.cloud._core.errors import Forbidden
@@ -35,9 +49,13 @@ from pocketpaw_ee.cloud.codeproject.dto import (
     CodeProjectResponse,
     ConsumePromptRequest,
     CreateProjectRequest,
+    ProjectFilesResponse,
+    ProjectFileWriteResponse,
+    PutProjectFileRequest,
     RenameProjectRequest,
 )
 from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.websandbox import durability as websandbox_durability
 from pocketpaw_ee.cloud.websandbox import service as websandbox_service
 from pocketpaw_ee.cloud.websandbox.dto import WebSandboxResponse
 
@@ -133,6 +151,57 @@ async def consume_prompt(
         workspace_id, ctx.user_id, project_id, body
     )
     return codeproject_service.view_to_wire(view)
+
+
+# ---------------------------------------------------------------------------
+# B1 — project file sync for the in-browser runtime.
+# ---------------------------------------------------------------------------
+
+
+@router.put("/{project_id}/file", response_model=ProjectFileWriteResponse)
+async def put_project_file(
+    project_id: str,
+    body: PutProjectFileRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> ProjectFileWriteResponse:
+    """Persist one file the in-browser runtime wrote (owner-scoped).
+
+    Called on every editor / agent save in a tab-hosted project. Last-write-wins
+    per path: a second write to the same path replaces the overlay entry rather
+    than adding one.
+    """
+    workspace_id = _require_workspace(ctx)
+    path, file_id = await websandbox_durability.put_project_file(
+        workspace_id, ctx.user_id, project_id, body.path, body.content
+    )
+    return ProjectFileWriteResponse(ok=True, path=path, fileId=file_id)
+
+
+@router.delete("/{project_id}/file", status_code=204)
+async def delete_project_file(
+    project_id: str,
+    path: str = Query(..., min_length=1, max_length=1024),
+    ctx: RequestContext = Depends(request_context),
+) -> Response:
+    """Drop one persisted file so a reopen doesn't resurrect it (owner-scoped)."""
+    workspace_id = _require_workspace(ctx)
+    await websandbox_durability.drop_project_file(workspace_id, ctx.user_id, project_id, path)
+    return Response(status_code=204)
+
+
+@router.get("/{project_id}/files", response_model=ProjectFilesResponse)
+async def read_project_files(
+    project_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> ProjectFilesResponse:
+    """Read every persisted file back (owner-scoped) — the restore payload.
+
+    The delta only: the client re-materializes the starter scaffold from the
+    starter id, then replays this map over it.
+    """
+    workspace_id = _require_workspace(ctx)
+    files = await websandbox_durability.read_project_overlay(workspace_id, ctx.user_id, project_id)
+    return ProjectFilesResponse(files=files)
 
 
 @router.delete("/{project_id}", status_code=204)

--- a/ee/pocketpaw_ee/cloud/codeproject/service.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/service.py
@@ -35,6 +35,16 @@
 # ``set_snapshot`` on WebSandbox — no lifecycle transition to announce). This
 # module stays the sole writer of the CodeProject doc (Rule 2). The orchestration
 # that drives them (tar/untar + S3 upload) lives in ``websandbox/durability.py``.
+#
+# Modified 2026-07-24 (feat/code-initial-prompt): ``create_project`` now persists
+# the optional ``initial_prompt`` (the WHAT-to-build description) on an actual
+# INSERT only — a github idempotent hit returns the existing row untouched, so a
+# repeat create never overwrites a project's prompt. The prompt + its
+# ``initial_prompt_consumed`` flag flow doc -> view -> wire (mirroring
+# ``snapshot_file_id``). Added ``mark_initial_prompt_consumed`` — an owner-scoped
+# (Rule 7) op that sets the consumed flag on build-turn START and re-arms it to
+# False on a retry-build; idempotent (already-in-state is a clean no-op) and
+# ``# no-event:`` (a build-turn bookkeeping flag, not a lifecycle transition).
 from __future__ import annotations
 
 import logging
@@ -56,6 +66,7 @@ from pocketpaw_ee.cloud.codeproject.domain import (
 )
 from pocketpaw_ee.cloud.codeproject.dto import (
     CodeProjectResponse,
+    ConsumePromptRequest,
     CreateProjectRequest,
     RenameProjectRequest,
 )
@@ -105,6 +116,8 @@ def _doc_to_view(doc: _CodeProjectDoc) -> CodeProjectView:
         updated_at=doc.updated_at,
         snapshot_file_id=doc.snapshot_file_id,
         overlay=dict(doc.overlay or {}),
+        initial_prompt=doc.initial_prompt,
+        initial_prompt_consumed=doc.initial_prompt_consumed,
         current_sandbox_id=doc.current_sandbox_id,
         last_opened_at=doc.last_opened_at,
     )
@@ -119,6 +132,8 @@ def view_to_wire(view: CodeProjectView) -> CodeProjectResponse:
         name=view.name,
         provider=view.provider,
         repo=view.repo,
+        initialPrompt=view.initial_prompt,
+        initialPromptConsumed=view.initial_prompt_consumed,
         snapshotFileId=view.snapshot_file_id,
         currentSandboxId=view.current_sandbox_id,
         lastOpenedAt=view.last_opened_at.isoformat() if view.last_opened_at else None,
@@ -175,6 +190,11 @@ async def create_project(
         provider=body.provider,
         repo=body.repo,
         registry_key=_registry_key(body.provider),
+        # The WHAT-to-build description, recorded ONLY on this actual insert — an
+        # idempotent hit returned above unchanged, so a repeat create never
+        # overwrites an existing project's prompt.
+        initial_prompt=body.initial_prompt,
+        initial_prompt_consumed=False,
     )
     await doc.insert()
 
@@ -263,6 +283,41 @@ async def rename_project(
             }
         )
     )
+    return _doc_to_view(doc)
+
+
+async def mark_initial_prompt_consumed(
+    workspace_id: str,
+    user_id: str,
+    project_id: str,
+    body: ConsumePromptRequest | dict,
+) -> CodeProjectView:
+    """Set (or re-arm) the project's ``initial_prompt_consumed`` flag.
+
+    Tenant- and owner-scoped (Rule 7 via ``_read_owned``): a caller can only touch
+    a project they own; a foreign / missing id raises ``NotFound``. The frontend
+    calls this with ``consumed=True`` when a build turn STARTS so a reopen doesn't
+    re-run the same auto-build, and with ``consumed=False`` on a retry-build to
+    re-arm the prompt. Validated at entry (Rule 6). Idempotent: setting the flag to
+    the value it already holds writes nothing and returns the current view.
+    """
+    body = ConsumePromptRequest.model_validate(body)
+
+    doc = await _read_owned(workspace_id, user_id, project_id)
+    if doc is None:
+        raise NotFound("code_project", project_id)
+
+    if doc.initial_prompt_consumed == body.consumed:
+        # no-event: already in the requested state — nothing was written.
+        return _doc_to_view(doc)
+
+    doc.initial_prompt_consumed = body.consumed
+    doc.updated_at = datetime.now(UTC)
+    await doc.save()
+    # no-event: the consumed flag is build-turn bookkeeping the frontend owns end
+    # to end (it sets it on turn start, re-arms it on retry) — no downstream
+    # handler reacts to it, and a projects-grid fan-out must not read it as a
+    # lifecycle transition. Same reasoning as the durability pointer writes above.
     return _doc_to_view(doc)
 
 
@@ -511,6 +566,7 @@ __all__ = [
     "drop_project_overlay_entry",
     "get_project",
     "list_projects",
+    "mark_initial_prompt_consumed",
     "move_project_overlay_entry",
     "rename_project",
     "set_project_overlay_entry",

--- a/ee/pocketpaw_ee/cloud/codeproject/service.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/service.py
@@ -54,6 +54,23 @@
 #     clobber state the project has since accumulated. The WebSandbox fields are
 #     left readable — this PR moves WHO the Daytona path writes, not what exists.
 #
+# Modified 2026-07-25 (feat/code-s3-authoritative): the per-file ``overlay`` is now
+# the AUTHORITATIVE store, which REVERSES this module's 2026-07-24 decision that
+# "a full snapshot supersedes it". WHY the reversal: a tarball is an unmodifiable
+# blob, so a DELETE has no representation inside it — replaying the baseline
+# resurrected every removed file — and clearing the overlay on snapshot destroyed
+# the one tier that could record the absence. Making the per-file map complete and
+# authoritative turns a delete into the removal of an entry, with nothing left to
+# resurrect it. Two ops change here:
+#   * ``set_project_snapshot`` NO LONGER CLEARS THE OVERLAY. It only records the
+#     legacy tarball pointer. Clearing would now discard the authoritative state.
+#   * ``replace_project_overlay`` — new: swap the whole map in ONE write, mark it
+#     complete, and clear the legacy tarball pointer. It is what
+#     ``durability.sync_project_files`` (workspace enumeration) and the legacy-tar
+#     migration write through, so a full re-image costs one doc save rather than
+#     one per file, and the drop-plus-add is atomic (a half-applied overlay would
+#     read as data loss).
+#
 # Modified 2026-07-24 (feat/code-initial-prompt): ``create_project`` now persists
 # the optional ``initial_prompt`` (the WHAT-to-build description) on an actual
 # INSERT only — a github idempotent hit returns the existing row untouched, so a
@@ -134,6 +151,7 @@ def _doc_to_view(doc: _CodeProjectDoc) -> CodeProjectView:
         updated_at=doc.updated_at,
         snapshot_file_id=doc.snapshot_file_id,
         overlay=dict(doc.overlay or {}),
+        overlay_complete=bool(doc.overlay_complete),
         initial_prompt=doc.initial_prompt,
         initial_prompt_consumed=doc.initial_prompt_consumed,
         current_sandbox_id=doc.current_sandbox_id,
@@ -480,28 +498,76 @@ async def set_project_snapshot(
     project_id: str,
     file_id: str,
 ) -> CodeProjectView:
-    """Record the durable project-snapshot pointer; clear the overlay.
+    """Record the LEGACY tarball pointer. Does NOT touch the overlay.
 
     Tenant- and owner-scoped (Rule 7 via ``_read_owned``): only the owning caller
     can bind a snapshot to their own project. ``file_id`` is the blob-storage
-    ``FileRecord`` id produced by ``EEUploadService.upload`` in the durability
-    module — a durable pointer to the tarball of the project's files. A full
-    snapshot supersedes the incremental overlay, so the overlay is CLEARED here
-    (mirroring ``WebSandbox.set_snapshot``): everything the overlay held is now
-    inside the snapshot tar, and clearing it is what keeps restore from replaying
-    a stale write over a since-deleted file. Raises ``NotFound`` when no owned row
-    matches.
+    ``FileRecord`` id of a whole-workspace tarball.
+
+    This used to CLEAR the overlay, on the reasoning that a full snapshot
+    supersedes an incremental delta. That reasoning is now inverted: the overlay
+    is the authoritative store, so clearing it would discard the project's real
+    state and hand the resurrection problem back to a tarball that cannot express
+    a deletion. Nothing in production writes a new tarball any more; this op
+    survives for the legacy pointer (the rollout backfill, and tests that stage
+    pre-migration state) and the pointer is cleared for good by the migration in
+    ``durability.restore_project``. Raises ``NotFound`` when no owned row matches.
     """
     doc = await _read_owned(workspace_id, user_id, project_id)
     if doc is None:
         raise NotFound("code_project", project_id)
     doc.snapshot_file_id = file_id
-    doc.overlay = {}
     doc.updated_at = datetime.now(UTC)
     await doc.save()
     # no-event: the snapshot pointer is durability bookkeeping, not a lifecycle
     # transition — no downstream handler reacts to it, and emitting a project
     # event would falsely signal a state change to a projects-grid fan-out.
+    return _doc_to_view(doc)
+
+
+async def replace_project_overlay(
+    workspace_id: str,
+    user_id: str,
+    project_id: str,
+    overlay: dict[str, str],
+    *,
+    complete: bool = True,
+    clear_snapshot: bool = True,
+) -> CodeProjectView:
+    """Swap the project's whole per-file store in ONE write. The authoritative op.
+
+    Tenant- and owner-scoped (Rule 7 via ``_read_owned``). The entry-point op for
+    a full re-image of a project: ``durability.sync_project_files`` enumerates the
+    VM workspace and hands the resulting map here, and the legacy-tarball migration
+    hands over the tar's members merged under the (fresher) existing entries.
+
+    Three properties matter, and all three are why this is ONE op rather than a
+    loop over ``set_project_overlay_entry`` / ``drop_project_overlay_entry``:
+      * ATOMIC — the adds and the drops land in a single doc save. A half-applied
+        re-image reads to the user as deleted files.
+      * DROPS ARE THE POINT — a path absent from ``overlay`` is a path the user
+        deleted. Passing the map wholesale is what lets a deletion be expressed by
+        omission, which is the whole reason the tarball tier was retired.
+      * ``complete`` records that the map was verified against a real workspace,
+        which is what makes restore's destructive prune safe to run.
+
+    ``clear_snapshot`` (default True) drops the legacy tarball pointer, because
+    after a verified re-image the tar is superseded and re-expanding it would
+    resurrect exactly the files this write just dropped. The migration passes
+    False when it could not carry every member across, so the tar stays readable
+    and the migration retries on the next open rather than losing data.
+    """
+    doc = await _read_owned(workspace_id, user_id, project_id)
+    if doc is None:
+        raise NotFound("code_project", project_id)
+    # Reassign (not in-place mutate) so Beanie always sees the field as dirty.
+    doc.overlay = dict(overlay)
+    doc.overlay_complete = complete
+    if clear_snapshot:
+        doc.snapshot_file_id = None
+    doc.updated_at = datetime.now(UTC)
+    await doc.save()
+    # no-event: durability bookkeeping, same reasoning as set_project_snapshot.
     return _doc_to_view(doc)
 
 
@@ -687,6 +753,7 @@ __all__ = [
     "mark_initial_prompt_consumed",
     "move_project_overlay_entry",
     "rename_project",
+    "replace_project_overlay",
     "set_project_overlay_entry",
     "set_project_snapshot",
     "view_to_wire",

--- a/ee/pocketpaw_ee/cloud/codeproject/service.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/service.py
@@ -22,6 +22,19 @@
 # older project, and the projects tab still showed one row. Scaffold providers
 # now always insert; identity providers keep the existing behaviour exactly, so a
 # returning user still lands back on the same ``/code/<id>`` for a repo.
+#
+# Modified 2026-07-24 (feat/code-durable-project-store): added the project-keyed
+# durability pointer ops — ``set_project_snapshot`` (records the S3 snapshot
+# pointer and CLEARS the overlay, since a full snapshot supersedes it),
+# ``set_project_overlay_entry`` / ``drop_project_overlay_entry`` /
+# ``move_project_overlay_entry`` (the incremental per-file tier). These mirror the
+# WebSandbox service ops one-for-one but anchor the pointer on the durable PROJECT
+# row instead of the ephemeral sandbox row, so a project's files round-trip
+# through blob storage independent of any runtime. All are owner-scoped (Rule 7),
+# and all are ``# no-event:`` durability bookkeeping (same reasoning as
+# ``set_snapshot`` on WebSandbox — no lifecycle transition to announce). This
+# module stays the sole writer of the CodeProject doc (Rule 2). The orchestration
+# that drives them (tar/untar + S3 upload) lives in ``websandbox/durability.py``.
 from __future__ import annotations
 
 import logging
@@ -91,6 +104,7 @@ def _doc_to_view(doc: _CodeProjectDoc) -> CodeProjectView:
         created_at=doc.created_at,
         updated_at=doc.updated_at,
         snapshot_file_id=doc.snapshot_file_id,
+        overlay=dict(doc.overlay or {}),
         current_sandbox_id=doc.current_sandbox_id,
         last_opened_at=doc.last_opened_at,
     )
@@ -324,6 +338,151 @@ async def bind_current_sandbox(
     return _doc_to_view(doc)
 
 
+# ---------------------------------------------------------------------------
+# Project-keyed durability pointers (feat/code-durable-project-store).
+#
+# The durable half of Code Mode's build-and-persist loop: a project's file
+# snapshot + per-file overlay live in the tenant's blob storage, and these ops
+# record/mutate the POINTERS on the durable project row. They mirror the
+# WebSandbox service ops (``set_snapshot`` / ``set_overlay_entry`` /
+# ``drop_overlay_entry`` / ``move_overlay_entry``) one-for-one, so the project
+# store behaves identically to the sandbox store — only the anchor differs. The
+# tar/untar + S3 upload orchestration that calls these lives in
+# ``websandbox/durability.py`` (the layer allowed to import EEUploadService);
+# this module stays the sole writer of the CodeProject doc (Rule 2). All are
+# owner-scoped (Rule 7 via ``_read_owned``) and ``# no-event:`` (durability
+# bookkeeping, not a lifecycle transition — same reasoning as WebSandbox's
+# ``set_snapshot``).
+# ---------------------------------------------------------------------------
+
+
+async def set_project_snapshot(
+    workspace_id: str,
+    user_id: str,
+    project_id: str,
+    file_id: str,
+) -> CodeProjectView:
+    """Record the durable project-snapshot pointer; clear the overlay.
+
+    Tenant- and owner-scoped (Rule 7 via ``_read_owned``): only the owning caller
+    can bind a snapshot to their own project. ``file_id`` is the blob-storage
+    ``FileRecord`` id produced by ``EEUploadService.upload`` in the durability
+    module — a durable pointer to the tarball of the project's files. A full
+    snapshot supersedes the incremental overlay, so the overlay is CLEARED here
+    (mirroring ``WebSandbox.set_snapshot``): everything the overlay held is now
+    inside the snapshot tar, and clearing it is what keeps restore from replaying
+    a stale write over a since-deleted file. Raises ``NotFound`` when no owned row
+    matches.
+    """
+    doc = await _read_owned(workspace_id, user_id, project_id)
+    if doc is None:
+        raise NotFound("code_project", project_id)
+    doc.snapshot_file_id = file_id
+    doc.overlay = {}
+    doc.updated_at = datetime.now(UTC)
+    await doc.save()
+    # no-event: the snapshot pointer is durability bookkeeping, not a lifecycle
+    # transition — no downstream handler reacts to it, and emitting a project
+    # event would falsely signal a state change to a projects-grid fan-out.
+    return _doc_to_view(doc)
+
+
+async def set_project_overlay_entry(
+    workspace_id: str,
+    user_id: str,
+    project_id: str,
+    rel_path: str,
+    file_id: str,
+) -> CodeProjectView:
+    """Record one write-through overlay entry (``rel_path -> FileRecord id``).
+
+    Tenant- and owner-scoped (Rule 7 via ``_read_owned``): only the owning caller
+    can mirror a file onto their own project. Called best-effort from the file
+    write path after the byte-for-byte VM write, so every editor save is durable
+    in blob storage the moment it lands — a crash / idle-out before the next full
+    snapshot no longer loses the edit. Last-write-wins per path. Raises
+    ``NotFound`` when no owned row matches.
+    """
+    doc = await _read_owned(workspace_id, user_id, project_id)
+    if doc is None:
+        raise NotFound("code_project", project_id)
+    # Reassign (not in-place mutate) so Beanie always sees the field as dirty.
+    overlay = dict(doc.overlay or {})
+    overlay[rel_path] = file_id
+    doc.overlay = overlay
+    doc.updated_at = datetime.now(UTC)
+    await doc.save()
+    # no-event: incremental durability bookkeeping, same reasoning as set_project_snapshot.
+    return _doc_to_view(doc)
+
+
+async def drop_project_overlay_entry(
+    workspace_id: str,
+    user_id: str,
+    project_id: str,
+    rel_path: str,
+) -> CodeProjectView:
+    """Drop overlay entries for ``rel_path`` (and anything under it) from a project.
+
+    Tenant- and owner-scoped (Rule 7 via ``_read_owned``). Called best-effort from
+    the file delete path after the VM delete: DROPPING an overlay entry is always
+    safe — it just falls back to the snapshot tier on restore, and it stops a
+    since-deleted file being resurrected from the overlay. A directory delete
+    drops every child under ``rel_path + '/'`` too. Raises ``NotFound`` when no
+    owned row matches.
+    """
+    doc = await _read_owned(workspace_id, user_id, project_id)
+    if doc is None:
+        raise NotFound("code_project", project_id)
+    prefix = rel_path.rstrip("/") + "/"
+    # Reassign (not in-place mutate) so Beanie always sees the field as dirty.
+    overlay = {
+        k: v for k, v in (doc.overlay or {}).items() if k != rel_path and not k.startswith(prefix)
+    }
+    doc.overlay = overlay
+    doc.updated_at = datetime.now(UTC)
+    await doc.save()
+    # no-event: incremental durability bookkeeping, same reasoning as set_project_snapshot.
+    return _doc_to_view(doc)
+
+
+async def move_project_overlay_entry(
+    workspace_id: str,
+    user_id: str,
+    project_id: str,
+    src: str,
+    dst: str,
+) -> CodeProjectView:
+    """Re-key overlay entries from ``src`` to ``dst`` (rename == move).
+
+    Tenant- and owner-scoped (Rule 7 via ``_read_owned``). Called best-effort from
+    the file move path after the VM move. The re-key is safe: the FileRecord id
+    (the actual blob) is unchanged — only its overlay KEY moves — so restore
+    replays the same content at the file's new path. A directory move re-keys
+    every child under ``src + '/'`` to the matching ``dst + '/'`` path; a path
+    with no overlay entry is a clean no-op. Raises ``NotFound`` when no owned row
+    matches.
+    """
+    doc = await _read_owned(workspace_id, user_id, project_id)
+    if doc is None:
+        raise NotFound("code_project", project_id)
+    src_prefix = src.rstrip("/") + "/"
+    dst_prefix = dst.rstrip("/") + "/"
+    overlay: dict[str, str] = {}
+    for k, v in (doc.overlay or {}).items():
+        if k == src:
+            overlay[dst] = v
+        elif k.startswith(src_prefix):
+            overlay[dst_prefix + k[len(src_prefix) :]] = v
+        else:
+            overlay[k] = v
+    doc.overlay = overlay
+    doc.updated_at = datetime.now(UTC)
+    await doc.save()
+    # no-event: incremental durability bookkeeping, same reasoning as set_project_snapshot.
+    return _doc_to_view(doc)
+
+
 async def _read_owned(
     workspace_id: str,
     user_id: str,
@@ -349,8 +508,12 @@ __all__ = [
     "bind_current_sandbox",
     "create_project",
     "delete_project",
+    "drop_project_overlay_entry",
     "get_project",
     "list_projects",
+    "move_project_overlay_entry",
     "rename_project",
+    "set_project_overlay_entry",
+    "set_project_snapshot",
     "view_to_wire",
 ]

--- a/ee/pocketpaw_ee/cloud/codeproject/service.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/service.py
@@ -36,6 +36,24 @@
 # module stays the sole writer of the CodeProject doc (Rule 2). The orchestration
 # that drives them (tar/untar + S3 upload) lives in ``websandbox/durability.py``.
 #
+# Modified 2026-07-25 (B2, feat/code-daytona-project-anchor): added the two ops the
+# Daytona cutover needs, because the runtime knows only its EPHEMERAL sandbox row
+# and the durable state now lives on the PROJECT.
+#   * ``find_project_for_sandbox`` — the reverse of ``bind_current_sandbox``: given
+#     a WebSandbox row id, which owned project is currently bound to it? The
+#     terminal socket has a row id and needs a project id to mirror/snapshot
+#     against. Ordered by ``last_opened_at`` desc because the bind is not unique:
+#     a WebSandbox row is keyed (workspace, user, repo), so two projects built from
+#     the same starter template can point at ONE row — the most recently opened is
+#     the one the user is actually looking at.
+#   * ``adopt_legacy_durability`` — the rollout backfill. Copies a legacy
+#     sandbox-keyed ``snapshot_file_id`` / ``overlay`` onto the project so an
+#     existing repo project's uncommitted work survives the cutover. Idempotent and
+#     NON-destructive by construction: it writes only when the project holds no
+#     durable state of its own, so a second call (or a later open) can never
+#     clobber state the project has since accumulated. The WebSandbox fields are
+#     left readable — this PR moves WHO the Daytona path writes, not what exists.
+#
 # Modified 2026-07-24 (feat/code-initial-prompt): ``create_project`` now persists
 # the optional ``initial_prompt`` (the WHAT-to-build description) on an actual
 # INSERT only — a github idempotent hit returns the existing row untouched, so a
@@ -393,6 +411,51 @@ async def bind_current_sandbox(
     return _doc_to_view(doc)
 
 
+async def find_project_for_sandbox(
+    workspace_id: str,
+    user_id: str,
+    sandbox_row_id: str,
+) -> CodeProjectView | None:
+    """Which owned project is currently bound to this ephemeral sandbox row?
+
+    The reverse of ``bind_current_sandbox``, and the seam the Daytona runtime
+    needs: a terminal socket is opened against a WebSandbox ROW id, but durable
+    state is anchored on the PROJECT, so the socket has to resolve its owner
+    before it can mirror or snapshot.
+
+    Returns ``None`` rather than raising when nothing is bound — a sandbox opened
+    outside the project flow (the plain ``/websandbox`` REST surface) has no owning
+    project, and that is a normal state the caller degrades on, not an error.
+
+    The bind is deliberately NOT treated as unique. A WebSandbox row is keyed
+    (workspace, user, repo) while a project is not, so two scaffold projects
+    started from the same template id can legitimately point at one row. Ordering
+    by ``last_opened_at`` desc picks the project the user most recently opened —
+    which is the one whose editor this socket belongs to, since ``open_project``
+    re-stamps that field on every open right before the socket connects. ``_id``
+    desc breaks a tie: BSON datetimes are millisecond-precision, so two binds
+    inside one millisecond would otherwise order arbitrarily, and an arbitrary
+    durable anchor is not something to leave to chance.
+
+    Tenant- AND owner-filtered (Rule 7): another tenant's project bound to the same
+    row id is invisible here.
+    """
+    docs = (
+        await _CodeProjectDoc.find(
+            {  # Rule 7 tenant + owner filter
+                "workspace_id": workspace_id,
+                "user_id": user_id,
+                "current_sandbox_id": sandbox_row_id,
+            }
+        )
+        .sort([("last_opened_at", -1), ("_id", -1)])
+        .to_list()
+    )
+    if not docs:
+        return None
+    return _doc_to_view(docs[0])
+
+
 # ---------------------------------------------------------------------------
 # Project-keyed durability pointers (feat/code-durable-project-store).
 #
@@ -538,6 +601,59 @@ async def move_project_overlay_entry(
     return _doc_to_view(doc)
 
 
+async def adopt_legacy_durability(
+    workspace_id: str,
+    user_id: str,
+    project_id: str,
+    snapshot_file_id: str | None,
+    overlay: dict[str, str] | None,
+) -> CodeProjectView:
+    """Adopt legacy sandbox-keyed durable state onto the project (B2 backfill).
+
+    Durability used to be anchored on the EPHEMERAL WebSandbox row. B2 moved the
+    Daytona path onto the durable project, so an existing project whose only
+    durable state sits on its old sandbox row would otherwise reopen empty. This
+    lifts that state across, once.
+
+    Two guarantees make it safe to call on every open (Rule: non-destructive):
+      * It writes ONLY when the project holds no durable state of its own — no
+        snapshot pointer and an empty overlay. A project that has since snapshotted
+        or mirrored anything is returned untouched, so a stale legacy pointer can
+        never overwrite fresher work.
+      * Nothing is deleted. The WebSandbox fields stay readable for the whole
+        rollout window; this copies, it does not move.
+
+    Tenant- and owner-scoped (Rule 7 via ``_read_owned``); raises ``NotFound`` when
+    no owned row matches. Passing nothing to adopt is a clean no-op.
+    """
+    doc = await _read_owned(workspace_id, user_id, project_id)
+    if doc is None:
+        raise NotFound("code_project", project_id)
+
+    if doc.snapshot_file_id or doc.overlay:
+        # no-event: the project already owns durable state — adopting would be a
+        # regression, so this is deliberately a read.
+        return _doc_to_view(doc)
+    legacy_overlay = dict(overlay or {})
+    if not snapshot_file_id and not legacy_overlay:
+        # no-event: nothing to adopt.
+        return _doc_to_view(doc)
+
+    doc.snapshot_file_id = snapshot_file_id
+    doc.overlay = legacy_overlay
+    doc.updated_at = datetime.now(UTC)
+    await doc.save()
+    logger.info(
+        "codeproject.adopt_legacy_durability: project=%s <- snapshot=%s, overlay=%d file(s)",
+        project_id,
+        snapshot_file_id,
+        len(legacy_overlay),
+    )
+    # no-event: durability bookkeeping, same reasoning as set_project_snapshot — a
+    # migration copy is not a lifecycle transition a projects-grid should react to.
+    return _doc_to_view(doc)
+
+
 async def _read_owned(
     workspace_id: str,
     user_id: str,
@@ -560,10 +676,12 @@ async def _read_owned(
 
 
 __all__ = [
+    "adopt_legacy_durability",
     "bind_current_sandbox",
     "create_project",
     "delete_project",
     "drop_project_overlay_entry",
+    "find_project_for_sandbox",
     "get_project",
     "list_projects",
     "mark_initial_prompt_consumed",

--- a/ee/pocketpaw_ee/cloud/codeproject/service.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/service.py
@@ -170,6 +170,7 @@ def view_to_wire(view: CodeProjectView) -> CodeProjectResponse:
         repo=view.repo,
         initialPrompt=view.initial_prompt,
         initialPromptConsumed=view.initial_prompt_consumed,
+        overlayComplete=view.overlay_complete,
         snapshotFileId=view.snapshot_file_id,
         currentSandboxId=view.current_sandbox_id,
         lastOpenedAt=view.last_opened_at.isoformat() if view.last_opened_at else None,

--- a/ee/pocketpaw_ee/cloud/models/agent.py
+++ b/ee/pocketpaw_ee/cloud/models/agent.py
@@ -14,6 +14,12 @@
 # agent everywhere while letting in-flight runs finish. Top-level (not on
 # AgentConfig) so toggling it bumps the doc's ``updatedAt`` and the pool's
 # staleness check + explicit cache invalidation both see the change.
+# Updated 2026-07-24 (CX-2, feat/code-agent-exclusive-tools): added
+# ``AgentConfig.tool_mode: str = "additive"`` (mirrors the domain
+# ``AgentConfigSpec.tool_mode``). "exclusive" makes the agent's ``tools`` the
+# run's MCP allow-list and suppresses the universal grant (CX-1); "additive"
+# (default) is the unchanged legacy grant-union, so existing agents persist and
+# behave exactly as before.
 
 """Agent configuration document."""
 
@@ -30,6 +36,10 @@ class AgentConfig(BaseModel):
     model: str = ""  # empty = use backend default
     system_prompt: str = ""
     tools: list[str] = Field(default_factory=list)
+    # Tool-surface policy — mirrors the domain ``AgentConfigSpec.tool_mode``.
+    # "additive" (default) UNIONs ``tools`` with the universal MCP grant (legacy);
+    # "exclusive" caps the run's MCP surface to exactly ``tools`` (CX-1/CX-2).
+    tool_mode: str = "additive"
     trust_level: int = Field(default=3, ge=1, le=5)
     temperature: float = Field(default=0.7, ge=0, le=2)
     max_tokens: int = Field(default=4096, ge=1)

--- a/ee/pocketpaw_ee/cloud/models/code_project.py
+++ b/ee/pocketpaw_ee/cloud/models/code_project.py
@@ -41,6 +41,14 @@ replaying a stale write over a since-deleted file). This makes a project-keyed
 durable store — snapshot pointer + overlay — that round-trips through S3
 independent of any runtime. Additive: the sandbox-keyed WebSandbox durability
 path is unchanged. No new index — read only via the owner-scoped project row.
+
+Modified 2026-07-24 (feat/code-initial-prompt): added ``initial_prompt`` (the
+natural-language description of WHAT to build, captured when a ``/code`` project
+is created from a prompt) and ``initial_prompt_consumed`` (whether the auto-run
+build turn has already been kicked off for it). The frontend reads the prompt on
+first open to auto-run one build turn and flips ``consumed`` on turn START; a
+retry-build re-arms it. Both are nullable/defaulted so every existing row stays
+valid. No new index — read only via the owner-scoped project row.
 """
 
 from __future__ import annotations
@@ -90,6 +98,15 @@ class CodeProject(Document):
     # snapshot supersedes it). Null until the first mirror. No new index — read
     # only via the owner-scoped project row.
     overlay: dict[str, str] = Field(default_factory=dict)
+    # The natural-language build prompt captured when a ``/code`` project is
+    # created from a description — WHAT to build. Null for projects opened from an
+    # existing repo with nothing to auto-build. The frontend reads it on first open
+    # to auto-run one build turn.
+    initial_prompt: str | None = None
+    # Whether the auto-run build turn has been kicked off for ``initial_prompt``.
+    # Set True on build-turn START (so a reopen doesn't re-run it); a retry-build
+    # re-arms it to False. Independent of whether the build succeeded.
+    initial_prompt_consumed: bool = False
     # The CURRENT ephemeral sandbox (a WebSandbox row id), or null when none is
     # live (never opened, or the VM was reaped). ``open_project`` resolves this.
     current_sandbox_id: str | None = None

--- a/ee/pocketpaw_ee/cloud/models/code_project.py
+++ b/ee/pocketpaw_ee/cloud/models/code_project.py
@@ -42,6 +42,22 @@ durable store — snapshot pointer + overlay — that round-trips through S3
 independent of any runtime. Additive: the sandbox-keyed WebSandbox durability
 path is unchanged. No new index — read only via the owner-scoped project row.
 
+Modified 2026-07-25 (feat/code-s3-authoritative): the per-file ``overlay`` is now
+the AUTHORITATIVE store and the tarball tier is retired as a source of truth. This
+REVERSES the 2026-07-24 note above ("``set_project_snapshot`` CLEARS it"), for a
+structural reason: a tarball is an unmodifiable blob, so a DELETE could not be
+represented in it — replaying the baseline resurrected every file the user had
+removed, on both runtimes, and clearing the overlay on snapshot threw away the only
+tier that COULD represent the absence. Under the new model the overlay is a complete
+image of the workspace (seeded by ``durability.sync_project_files``, which enumerates
+the VM and drops entries for paths that no longer exist), so a delete is simply the
+removal of an entry and there is nothing left to resurrect it. Two consequences here:
+``snapshot_file_id`` is now a LEGACY pointer, read once by the migration in
+``durability.restore_project`` (expand the tar into per-file entries) and then
+cleared forever; and ``overlay_complete`` records whether the overlay has been
+verified against a real workspace, which is what makes the destructive operations
+(pruning stale files out of a restored VM) safe to run at all.
+
 Modified 2026-07-24 (feat/code-initial-prompt): added ``initial_prompt`` (the
 natural-language description of WHAT to build, captured when a ``/code`` project
 is created from a prompt) and ``initial_prompt_consumed`` (whether the auto-run
@@ -87,17 +103,31 @@ class CodeProject(Document):
     # rename collide two rows into a DuplicateKeyError, and would make a
     # re-create under a since-renamed name mint a surprise duplicate.
     registry_key: str = ""
-    # Durable blob-storage snapshot pointer (an EEUploadService FileRecord id).
-    # The project's files live HERE between sandboxes — this is why the project
-    # survives VM reaping. Null until the first backup.
+    # LEGACY blob-storage tarball pointer (an EEUploadService FileRecord id).
+    # Written by the retired ``snapshot_project`` path; no longer produced. It is
+    # read exactly ONCE more, by the migration in ``durability.restore_project``,
+    # which expands the tar into per-file ``overlay`` entries and clears this back
+    # to None so the baseline can never resurrect a deleted file again.
     snapshot_file_id: str | None = None
-    # The write-through per-file durability overlay, keyed on the PROJECT (mirrors
-    # ``WebSandbox.overlay``): ``relpath -> FileRecord id`` for each editor-saved
-    # file mirrored to blob storage since the last full project snapshot. Replayed
-    # onto a fresh clone on restore; cleared by ``set_project_snapshot`` (a full
-    # snapshot supersedes it). Null until the first mirror. No new index — read
-    # only via the owner-scoped project row.
+    # The AUTHORITATIVE per-file store, keyed on the PROJECT: ``relpath ->
+    # FileRecord id``, one blob-storage object per file. Written by the editor
+    # write-through hooks, by the browser file-sync route, and — for everything
+    # that never passes a write hook (a clone, a scaffold, generated output) — by
+    # ``durability.sync_project_files``, which enumerates the VM workspace and
+    # DROPS entries whose paths no longer exist. Restore reconstructs the workspace
+    # from this map alone. No new index — read only via the owner-scoped row.
     overlay: dict[str, str] = Field(default_factory=dict)
+    # Whether ``overlay`` has been verified to be a COMPLETE image of the project's
+    # workspace (every non-regenerable file), rather than a partial delta of the
+    # files that happened to pass through a write hook. Set by
+    # ``sync_project_files`` and by the legacy-tarball migration; False for a
+    # project whose only writes came from the in-tab runtime, whose baseline (the
+    # starter scaffold) is re-materialized client-side and never stored.
+    #
+    # It exists to gate DESTRUCTIVE reconciliation: restore prunes workspace files
+    # missing from the overlay only when this is True, because "absent from the
+    # overlay" means "deleted by the user" only once the overlay is known complete.
+    overlay_complete: bool = False
     # The natural-language build prompt captured when a ``/code`` project is
     # created from a description — WHAT to build. Null for projects opened from an
     # existing repo with nothing to auto-build. The frontend reads it on first open

--- a/ee/pocketpaw_ee/cloud/models/code_project.py
+++ b/ee/pocketpaw_ee/cloud/models/code_project.py
@@ -30,6 +30,17 @@ needed).
 Relation to WebSandbox: WebSandbox stays the EPHEMERAL runtime row (Daytona VM +
 lifecycle); CodeProject is the durable owner and points at the current one via
 ``current_sandbox_id`` (the WebSandbox row id), null when none is live.
+
+Modified 2026-07-24 (feat/code-durable-project-store): added ``overlay`` — the
+incremental per-file durability tier, keyed on the PROJECT rather than the
+ephemeral WebSandbox row. Mirrors ``WebSandbox.overlay`` (``relpath ->
+FileRecord id``): each mirrored editor save records an entry here, ``restore``
+replays them onto a fresh clone, and ``set_project_snapshot`` CLEARS it (a full
+snapshot supersedes the overlay, and clearing on snapshot is what avoids
+replaying a stale write over a since-deleted file). This makes a project-keyed
+durable store — snapshot pointer + overlay — that round-trips through S3
+independent of any runtime. Additive: the sandbox-keyed WebSandbox durability
+path is unchanged. No new index — read only via the owner-scoped project row.
 """
 
 from __future__ import annotations
@@ -72,6 +83,13 @@ class CodeProject(Document):
     # The project's files live HERE between sandboxes — this is why the project
     # survives VM reaping. Null until the first backup.
     snapshot_file_id: str | None = None
+    # The write-through per-file durability overlay, keyed on the PROJECT (mirrors
+    # ``WebSandbox.overlay``): ``relpath -> FileRecord id`` for each editor-saved
+    # file mirrored to blob storage since the last full project snapshot. Replayed
+    # onto a fresh clone on restore; cleared by ``set_project_snapshot`` (a full
+    # snapshot supersedes it). Null until the first mirror. No new index — read
+    # only via the owner-scoped project row.
+    overlay: dict[str, str] = Field(default_factory=dict)
     # The CURRENT ephemeral sandbox (a WebSandbox row id), or null when none is
     # live (never opened, or the VM was reaped). ``open_project`` resolves this.
     current_sandbox_id: str | None = None

--- a/ee/pocketpaw_ee/cloud/surface/handlers/code.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/code.py
@@ -24,13 +24,17 @@
 # model that knows nothing of the current ``codeproject`` + ``CodeFileSession``
 # runtime (nothing under ``cloud/daytona/`` so much as mentions either).
 #
-# The preamble now states the single truth of this surface: the user's code is
-# reachable ONLY through the ``code_mode`` tool, and the agent has no filesystem
-# of its own here. It also tells the agent to call ``code_mode`` IMMEDIATELY when
-# the user's edit is scoped to a selection they already made — no exploratory
-# retrieval first. That is a latency mitigation, not a style note: the /code path
-# is two model calls deep (chat agent → code agent), so a redundant retrieval
-# round is paid twice, and the selection plus its file are already in context.
+# The preamble states the single truth of this surface: the user's code is
+# reachable ONLY through the file tools (``readFile`` / ``search`` / ``listDir`` /
+# ``writeFile``), and the agent has no filesystem of its own here. Updated
+# 2026-07-24 (feat/code-mode-file-tools): the surface used to expose ONE coarse
+# ``code_mode`` tool that handed a task to a browser sub-agent; that sub-agent is
+# gone and the MAIN agent now drives the work itself over these four per-call file
+# tools. ``writeFile`` STAGES a proposal for the user's per-hunk review — it does
+# not save — so the preamble is explicit that a write is a change proposed, not
+# made. It also tells the agent to act IMMEDIATELY when the user's edit is scoped
+# to a selection they already made — no re-reading the project first, since the
+# selection plus its file are already in context.
 #
 # Changed: 2026-07-22 (fix/code-surface-denies-pocket-authoring) — the procedure
 # block gained a paragraph on what "build an app" MEANS here. Reported from a
@@ -54,11 +58,11 @@
 # ``SurfaceProfile`` (see ``surface_registry.py``) sets ``ripple_mode="off"`` so
 # the agent doesn't inherit the ~20k-char "default to ui-spec" ripple LAW, DENIES
 # the file/shell built-ins AND ``Agent`` outright, and scopes the MCP surface to
-# ``code_mode``. This text is the explanation the agent gets for a restriction
-# already applied; the two must agree, so if the profile changes, change this
-# too. The profile also carries NO skill: the `code` skill teaches only the
-# denied built-ins and is retargeted onto ``code_mode`` in CD-2, so until then
-# this preamble is the whole of the agent's guidance on this surface.
+# the file tools (``_CODE_FILE_TOOL_IDS``). This text is the explanation the agent
+# gets for a restriction already applied; the two must agree, so if the profile
+# changes, change this too. The profile also carries NO skill: the `code` skill
+# taught only the denied built-ins, and its edit→run→verify discipline now lives
+# in this preamble and ``CODE_SYSTEM_PROMPT``, retargeted onto the file tools.
 
 from __future__ import annotations
 
@@ -66,14 +70,14 @@ from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
 
 
 async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> str:
-    """Render the /code surface preamble — code reached only via ``code_mode``.
+    """Render the /code surface preamble — code reached only via the file tools.
 
     Static: the preamble does not vary with storage flavour, working
     directory, or sandbox state, because none of those are the agent's
-    concern on this surface. The ``code_mode`` tool owns the project — it
-    resolves the sandbox and the file session itself. The only thing read
-    from ``meta`` is ``project_name``, and purely so the agent can name the
-    project the user is looking at.
+    concern on this surface. The file tools (readFile / search / listDir /
+    writeFile) reach the project; the browser that runs them owns the sandbox
+    and the file session. The only thing read from ``meta`` is ``project_name``,
+    and purely so the agent can name the project the user is looking at.
     """
     route = meta.route_path or "/code"
     return (
@@ -82,8 +86,8 @@ async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> 
 
 
 def _orientation(project_name: str | None) -> str:
-    """Render the ``<code-orientation>`` block — what surface this is, and the
-    one door to the user's code."""
+    """Render the ``<code-orientation>`` block — what surface this is, and how
+    the user's code is reached."""
     lines = [
         "<code-orientation>",
         "The user is on the CODE surface, a coding workspace. You write and "
@@ -93,10 +97,10 @@ def _orientation(project_name: str | None) -> str:
         "about the work as 'code', 'files', 'the project', 'tests' — never as a "
         "'pocket' or 'dashboard'.",
         "The user's project does NOT live on your machine. It lives in the "
-        "user's own project workspace, and the `code_mode` tool is the ONLY way "
-        "to reach it — that tool resolves the project, reads it, and makes the "
-        "change. You have no filesystem of your own on this surface: there is no "
-        "working directory to sit in, nothing to `cd` into, and no path you can "
+        "user's own project workspace, and you reach it ONLY through your file "
+        "tools — `readFile`, `search`, `listDir`, and `writeFile`. You have no "
+        "filesystem of your own on this surface: there is no working directory "
+        "to sit in, nothing to `cd` into, no shell, and no path on disk you can "
         "usefully name.",
     ]
 
@@ -113,22 +117,24 @@ def _procedure() -> str:
     """Render the ``<code-procedure>`` block — how to do the work."""
     lines = [
         "<code-procedure>",
-        "Treat the user's message on this surface as a coding task, and do the "
-        "work by calling `code_mode`. Describe the change you want in the terms "
-        "the user gave you; the tool handles locating the code and applying the "
-        "edit.",
+        "Work the way a coding agent works. To understand the project, `search` "
+        "for the relevant code and `readFile` the files that matter; `listDir` to "
+        "see how a folder is laid out. To change the code, call `writeFile` with "
+        "the file's COMPLETE new contents. `writeFile` does not save the file: it "
+        "STAGES your change for the user to review and accept hunk by hunk, so a "
+        "`writeFile` call is a change PROPOSED, not a change made.",
         "If the user's request is scoped to a selection they have ALREADY made, "
-        "call `code_mode` IMMEDIATELY, with no exploratory retrieval first. The "
+        "act on it IMMEDIATELY, without re-reading the whole project first. The "
         "selected code and the file it came from are already in your context — "
         "going looking for them again is a wasted round-trip the user waits "
-        "through, on a path that is already two model calls deep.",
+        "through.",
         "Do NOT attempt `Bash`, `Read`, `Write`, `Edit`, `Glob`, or `Grep` on "
         "this surface. They do not reach the user's project — they address the "
         "machine you are running on, which is a different computer with none of "
         "the user's code on it. Using them would edit the wrong files and look "
         "like it worked. They are withheld from you here for exactly that "
-        "reason; if you find yourself reaching for one, the answer is "
-        "`code_mode`.",
+        "reason; if you find yourself reaching for one, the answer is your file "
+        "tools above.",
         "Read a request to BUILD something as a request to build it in CODE. "
         '"Build me an employee management app, with components and a nice '
         "design\" means React/Vue/Svelte components and CSS in the user's "
@@ -137,10 +143,12 @@ def _procedure() -> str:
         '"dashboard" and "app" all keep their ordinary front-end meaning on '
         "this surface. The pocket, planner, and widget tools are withheld from "
         "you here for that reason; do not reach for a skill that calls them.",
-        "Report only what actually happened. If `code_mode` returns an error or "
-        "is unavailable, say so plainly — never describe a change as made when "
-        "the tool did not confirm it. When it succeeds, briefly summarize what "
-        "changed and where.",
+        "Report only what actually happened, and mind the difference between "
+        "reading and writing. A `writeFile` result means your change was STAGED "
+        "for review, not saved — say 'I've proposed…', never 'I created' or 'I "
+        "updated' as if it were done. If a tool returns an error or is "
+        "unavailable, say so plainly; never describe a change as made when the "
+        "tool did not confirm it.",
         "</code-procedure>",
     ]
     return "\n".join(lines) + "\n"

--- a/ee/pocketpaw_ee/cloud/surface/surface_registry.py
+++ b/ee/pocketpaw_ee/cloud/surface/surface_registry.py
@@ -80,6 +80,17 @@
 # deliverable instead. Both halves were needed; neither alone held.
 #
 # The CODE row stays STATIC — the prompt is a module constant like the tool ids.
+#
+# Changes: 2026-07-24 (feat/code-surface-cleanup, CX-4) — removed the
+# ``_CODE_POCKET_DENY`` MCP deny-list from the CODE profile. Since CX-3, /code
+# routes to a dedicated ``code`` agent whose ``tool_mode="exclusive"`` policy caps
+# the run's ``mcp__*`` tools to exactly the four file ids at run time; every id
+# ``_CODE_POCKET_DENY`` named was an ``mcp__*`` id that cap already strips, so the
+# surface deny-list was dead weight. The division of labor is now explicit: the
+# code AGENT enforces MCP tool restriction (structurally, via exclusivity), and the
+# SURFACE profile denies only the BUILT-IN tools the MCP cap cannot reach —
+# ``_CODE_BUILTIN_DENY`` (backend-disk tools + ``Agent``) and ``_CODE_SKILL_DENY``
+# (``Skill``), both KEPT unchanged.
 
 from __future__ import annotations
 
@@ -274,63 +285,28 @@ _CODE_BUILTIN_DENY: frozenset[str] = frozenset(
     {"Bash", "Read", "Write", "Edit", "Glob", "Grep", "Agent"}
 )
 
-# The pocket-AUTHORING tools the /code agent must not hold either.
+# The pocket-AUTHORING tools the /code agent must not hold used to live here as
+# ``_CODE_POCKET_DENY`` — an MCP deny-list spelling out the pocket / planner /
+# widget ids so they could not survive back into the allow-list via
+# ``POCKET_CREATION_GRANT`` / ``ALWAYS_ALLOWED_MCP_SERVERS`` / ``WIDGET_TOOL_IDS``.
+# It was REMOVED 2026-07-24 (CX-4). MCP tool restriction for /code is now enforced
+# STRUCTURALLY, one layer up: /code routes to a dedicated ``code`` agent whose
+# config is ``tool_mode="exclusive"`` + ``tools=_CODE_FILE_TOOL_IDS``, and at run
+# time that exclusive policy CAPS the run's ``mcp__*`` surface to exactly those
+# four file tools — no pocket / widget / atlas / planner id can reach the allow-list
+# regardless of any grant (proven by
+# ``tests/cloud/agents/test_code_agent_seed.py::
+# test_seeded_code_agent_config_drives_exclusive_allowlist``). With the cap moved to
+# the agent, an MCP deny-list on the surface is dead weight — every id it named is an
+# ``mcp__*`` id the exclusivity already strips.
 #
-# Reported from a live session: with a React project open on /code, "Let's build
-# an employee management app, with components, nice design etc" made the agent
-# create a pocket and author a ripple ui-spec instead of writing React. The user
-# asked for an app and got a dashboard.
-#
-# ``allow_mcp_tool_ids`` does NOT prevent this, which is the whole reason this
-# set exists. CD-3 scoped /code to ``code_mode``, but ``claude_sdk`` deliberately
-# lets three families survive ANY restrictive allow-list: ``POCKET_CREATION_GRANT``
-# (specialist create + planner), ``ALWAYS_ALLOWED_MCP_SERVERS`` (every tool on the
-# ``pocketpaw_pocket`` / ``_specialist`` / ``_planner`` servers), and
-# ``WIDGET_TOOL_IDS``. Those bypasses are RIGHT for a general chat surface — "create
-# a pocket" is the product's core capability and must work from anywhere — and
-# wrong for this one, where the deliverable is the user's code. Deny is applied
-# BEFORE the grant is unioned in, so it is the only lever that reaches them.
-#
-# Prose could not do this job. The preamble already says "do not build widgets,
-# charts, or a ui-spec, and do not create a pocket" and the agent did it anyway —
-# the same result /sites got before it denied these ids outright rather than
-# asking (see ``_SITES_SVELTE_CREATE_DENY``: "prose-only routing was proven to
-# fail"). Two surfaces have now independently confirmed it.
-#
-# READ-ONLY pocket access (``get_pocket`` / ``list_pockets``) is deliberately NOT
-# denied: reading a pocket cannot produce one, and a user on /code may reasonably
-# ask what a pocket contains. The line is drawn at AUTHORING.
-#
-# The widget ids are spelled out rather than imported so the CODE row stays a
-# STATIC profile (no lazy load, no resolver). ``test_code_deny_covers_every_widget
-# _tool`` pins this literal against the real ``WIDGET_TOOL_IDS``, so a widget tool
-# added later fails the suite instead of silently reopening the hole.
-_CODE_POCKET_DENY: frozenset[str] = frozenset(
-    {
-        # POCKET_CREATION_GRANT — survives the allow-list by design.
-        "mcp__pocketpaw_pocket_specialist__create",
-        "mcp__pocketpaw_pocket_planner__plan_pocket",
-        # ALWAYS_ALLOWED_MCP_SERVERS — the authoring verbs on the pocket servers.
-        "mcp__pocketpaw_pocket_specialist__edit",
-        "mcp__pocketpaw_pocket__add_widget",
-        "mcp__pocketpaw_pocket__update_widget",
-        # WIDGET_TOOL_IDS — the ripple catalog that turns "with components, nice
-        # design" into a ui-spec instead of React components.
-        "mcp__pocketpaw_widgets__get_widget_spec",
-        "mcp__pocketpaw_widgets__get_inline_widget_help",
-        "mcp__pocketpaw_widgets__start_flow",
-        # The READ verbs go too. An earlier pass kept them on the reasoning that
-        # reading a pocket cannot produce one — true in isolation, and beside the
-        # point: a pocket the agent can inspect is a pocket it can propose, and
-        # "let me look at how your other dashboard does this" is the first step
-        # back onto the path this profile exists to close. Nothing on /code needs
-        # them; the deliverable is the user's code.
-        "mcp__pocketpaw_pocket__get_pocket",
-        "mcp__pocketpaw_pocket__list_pockets",
-    }
-)
+# The exclusivity cap covers ONLY ``mcp__*`` ids, though. It does NOT and
+# structurally CANNOT touch the SDK's built-in tools, so the surface's remaining
+# denies below stay: ``_CODE_BUILTIN_DENY`` (Bash/Read/Write/… + Agent — the
+# backend-disk tools) and ``_CODE_SKILL_DENY`` (``Skill``) both deny BUILT-INS that
+# no MCP allow-list — exclusive or not — can reach.
 
-# ``Skill`` goes too, and it is the last door.
+# ``Skill`` is denied, and it is the last door.
 #
 # The bundled skills ship as a Claude Code LOCAL PLUGIN, which is loaded from the
 # SDK ``plugins=`` option independently of ``skill_names`` — so a surface CANNOT
@@ -340,13 +316,15 @@ _CODE_POCKET_DENY: frozenset[str] = frozenset(
 # request like "build an employee management app with components and nice design"
 # almost word for word, which is how the reported bug started.
 #
-# With every pocket tool denied above, invoking that skill can no longer BUILD
-# anything — but it would still cost the user a turn: the agent loads a long
-# instruction telling it to call ``get_widget_spec`` and ``pocket_specialist__
-# create``, attempts them, takes hard errors, and only then finds its file tools.
-# CD-3 made exactly this argument when it dropped the `code` skill from the
-# profile ("absence is recoverable; contradiction is not"); the same reasoning
-# applies to a skill that teaches the wrong deliverable.
+# With the code agent's exclusivity capping the pocket MCP tools out of reach,
+# invoking that skill can no longer BUILD anything — but it would still cost the
+# user a turn: the agent loads a long instruction telling it to call
+# ``get_widget_spec`` and ``pocket_specialist__create``, attempts them, takes hard
+# errors, and only then finds its file tools. ``Skill`` is a BUILT-IN, so the MCP
+# cap does not reach it — this surface deny is what keeps the skill from firing on
+# the exact repro prompt at all. CD-3 made the same argument when it dropped the
+# `code` skill from the profile ("absence is recoverable; contradiction is not");
+# it applies equally to a skill that teaches the wrong deliverable.
 #
 # /code needs no skill: ``CODE_SYSTEM_PROMPT`` is now the agent's whole guidance
 # here, and it is not a document the agent has to go and fetch. If a
@@ -611,6 +589,16 @@ SURFACES: list[SurfaceSpec] = [
         # Both sets are module-level literals, so this stays a STATIC profile (no
         # lazily-loaded ids, not meta-aware, no resolver needed).
         #
+        # The deny set covers only BUILT-IN tools now. Restricting the MCP surface
+        # for /code is no longer this profile's job: /code routes to the dedicated
+        # ``code`` agent, whose ``tool_mode="exclusive"`` policy caps the run's
+        # ``mcp__*`` tools to exactly the four file ids at run time — so the old
+        # ``_CODE_POCKET_DENY`` MCP deny-list became dead weight and was removed
+        # (CX-4). What the exclusivity cap CANNOT reach are the built-ins, which is
+        # exactly what ``_CODE_BUILTIN_DENY`` (backend-disk tools + ``Agent``) and
+        # ``_CODE_SKILL_DENY`` (``Skill`` — the create-pocket plugin's invoker)
+        # still deny here.
+        #
         # ``skill_names`` is deliberately EMPTY, where it used to carry the
         # `code` skill. That skill is not incidentally about the built-ins — it
         # is entirely about them ("you use the built-in Bash / Read / Write /
@@ -624,7 +612,7 @@ SURFACES: list[SurfaceSpec] = [
         profile=SurfaceProfile(
             ripple_mode="off",
             allow_mcp_tool_ids=_CODE_FILE_TOOL_IDS,
-            deny_mcp_tool_ids=_CODE_BUILTIN_DENY | _CODE_POCKET_DENY | _CODE_SKILL_DENY,
+            deny_mcp_tool_ids=_CODE_BUILTIN_DENY | _CODE_SKILL_DENY,
             # The surface's own system prompt, replacing the pocket-shaped
             # behavioral stack the shared builder would otherwise assemble. See
             # ``system_prompts.py`` for why a prohibition alone did not hold.

--- a/ee/pocketpaw_ee/cloud/surface/surface_registry.py
+++ b/ee/pocketpaw_ee/cloud/surface/surface_registry.py
@@ -42,8 +42,10 @@
 # in a sandbox behind the ``code_mode`` tool, so every one of those built-ins
 # would have read and written the server's own disk and reported success. The row
 # now DENIES them (``_CODE_BUILTIN_DENY`` — deny is the only lever that removes a
-# built-in) and scopes the MCP surface to the one tool that reaches the project
-# (``_CODE_MODE_TOOL_IDS``). ``Agent`` joins the deny set too: a spawned subagent
+# built-in) and scopes the MCP surface to the tools that reach the project
+# (``_CODE_FILE_TOOL_IDS`` — originally the single ``code_mode`` tool, now the
+# four per-call file verbs the main agent drives). ``Agent`` joins the deny set
+# too: a spawned subagent
 # is a second, unsupervised path to tools. ``skill_names`` drops to empty — the
 # `code` skill teaches nothing BUT those built-ins, so keeping it would inject an
 # instruction to call what the agent no longer has. Still a static ``profile``:
@@ -220,15 +222,24 @@ _SITES_BUILTIN_DENY: frozenset[str] = frozenset(
 # None-degrade path as the loom/media imports below). Do NOT drift the id.
 _BELT_GATE_TOOL_IDS: frozenset[str] = frozenset({"mcp__pocketpaw_belt__belt_propose_change"})
 
-# The single tool the /code agent reaches the user's project through. Everything
-# the surface can do to code happens behind it: the tool owns the sandbox, the
-# file session, and the edit. Spelled as a LITERAL for the same reason
-# ``_BELT_GATE_TOOL_IDS`` above is — its canonical constant lives in a SIBLING
-# branch's in-process MCP server (server ``pocketpaw_code``, tool ``code_mode``),
-# not importable on this base. When both PRs land, swap this literal for the
-# imported constant. The id format is the SDK's ``mcp__<server>__<tool>``
-# namespacing (see ``pocketpaw.agents.sdk_mcp_widgets``). Do NOT drift the id.
-_CODE_MODE_TOOL_IDS: frozenset[str] = frozenset({"mcp__pocketpaw_code__code_mode"})
+# The file tools the /code agent reaches the user's project through. The main
+# agent drives the /code work in its own tool loop and reaches the project ONLY
+# through these four verbs — each one delegates a single call to the browser,
+# which owns the file session (the project runs in the tab, not on the backend).
+# ``writeFile`` does not write: it stages a proposal for the user's per-hunk
+# review. Spelled as LITERALS for the same reason ``_BELT_GATE_TOOL_IDS`` above
+# is — their canonical constants live in the in-process MCP server (server
+# ``pocketpaw_code``), which the profile layer must not import. The id format is
+# the SDK's ``mcp__<server>__<tool>`` namespacing. Do NOT drift these ids;
+# ``test_code_mcp_server`` pins them against the server's own constants.
+_CODE_FILE_TOOL_IDS: frozenset[str] = frozenset(
+    {
+        "mcp__pocketpaw_code__readFile",
+        "mcp__pocketpaw_code__search",
+        "mcp__pocketpaw_code__listDir",
+        "mcp__pocketpaw_code__writeFile",
+    }
+)
 
 # Built-in SDK tools the /code agent must NOT have. Same mechanism and same
 # reasoning as ``_SITES_BUILTIN_DENY`` above: these bare tool NAMES ride in
@@ -238,9 +249,10 @@ _CODE_MODE_TOOL_IDS: frozenset[str] = frozenset({"mcp__pocketpaw_code__code_mode
 #
 # This is load-bearing, not tidiness. The /code agent runs on the BACKEND SERVER,
 # not in the user's project: its cwd is the per-tenant scratch jail, and the
-# user's code is only ever reachable through ``code_mode``. Left in place, the
-# built-ins let the agent read and write the SERVER's filesystem and then report
-# success — a silent wrong-machine failure with no error to notice.
+# user's code is only ever reachable through the file tools (which delegate to the
+# browser). Left in place, the built-ins let the agent read and write the SERVER's
+# filesystem and then report success — a silent wrong-machine failure with no
+# error to notice.
 #
 # ``allowed_sdk_tools`` cannot do this job: it is ADDITIVE (unioned INTO the
 # allow-list, ``effective = (agent_tools ∪ allow) − deny``), and the file/shell
@@ -250,7 +262,7 @@ _CODE_MODE_TOOL_IDS: frozenset[str] = frozenset({"mcp__pocketpaw_code__code_mode
 # lever.
 #
 # ``Agent`` is denied for a reason beyond parity with SITES. Under this design
-# ``code_mode`` is the ONLY path to the user's files; a spawned subagent is a
+# the file tools are the ONLY path to the user's files; a spawned subagent is a
 # SECOND path, with its own tool resolution and no supervision from this profile.
 # Denying the six file/shell tools while leaving the tool that spawns a fresh
 # tool-user would just move the hole one level down.
@@ -331,7 +343,7 @@ _CODE_POCKET_DENY: frozenset[str] = frozenset(
 # With every pocket tool denied above, invoking that skill can no longer BUILD
 # anything — but it would still cost the user a turn: the agent loads a long
 # instruction telling it to call ``get_widget_spec`` and ``pocket_specialist__
-# create``, attempts them, takes hard errors, and only then finds ``code_mode``.
+# create``, attempts them, takes hard errors, and only then finds its file tools.
 # CD-3 made exactly this argument when it dropped the `code` skill from the
 # profile ("absence is recoverable; contradiction is not"); the same reasoning
 # applies to a skill that teaches the wrong deliverable.
@@ -591,10 +603,12 @@ SURFACES: list[SurfaceSpec] = [
         code.build_preamble,
         # Code: edit + run code, but NOT on this machine. Ripple OFF so the
         # agent edits code instead of building a dashboard. The user's project
-        # is reachable ONLY through ``code_mode`` (allow), and the file/shell
-        # built-ins are stripped (deny) because they address the backend
-        # server's own disk, not the project — see ``_CODE_BUILTIN_DENY``. Both
-        # sets are module-level literals, so this stays a STATIC profile (no
+        # is reachable ONLY through the file tools ``_CODE_FILE_TOOL_IDS``
+        # (allow) — readFile / search / listDir / writeFile, each delegated one
+        # call at a time to the browser that holds the file session — and the
+        # file/shell built-ins are stripped (deny) because they address the
+        # backend server's own disk, not the project — see ``_CODE_BUILTIN_DENY``.
+        # Both sets are module-level literals, so this stays a STATIC profile (no
         # lazily-loaded ids, not meta-aware, no resolver needed).
         #
         # ``skill_names`` is deliberately EMPTY, where it used to carry the
@@ -604,13 +618,12 @@ SURFACES: list[SurfaceSpec] = [
         # under the deny above it would be an injected instruction to call tools
         # the agent no longer has: the agent attempts them, takes hard errors,
         # and burns turns before finding the path the preamble already gave it.
-        # Absence is recoverable; contradiction is not. The skill's edit→run→
-        # verify DISCIPLINE is worth keeping and gets retargeted onto
-        # ``code_mode`` in CD-2 — rewriting SKILL.md here would teach a tool that
-        # does not exist yet, which is the same failure pointed the other way.
+        # Absence is recoverable; contradiction is not. The edit→run→verify
+        # DISCIPLINE that skill carried now lives in ``CODE_SYSTEM_PROMPT``,
+        # retargeted onto the file tools above.
         profile=SurfaceProfile(
             ripple_mode="off",
-            allow_mcp_tool_ids=_CODE_MODE_TOOL_IDS,
+            allow_mcp_tool_ids=_CODE_FILE_TOOL_IDS,
             deny_mcp_tool_ids=_CODE_BUILTIN_DENY | _CODE_POCKET_DENY | _CODE_SKILL_DENY,
             # The surface's own system prompt, replacing the pocket-shaped
             # behavioral stack the shared builder would otherwise assemble. See

--- a/ee/pocketpaw_ee/cloud/surface/system_prompts.py
+++ b/ee/pocketpaw_ee/cloud/surface/system_prompts.py
@@ -42,11 +42,18 @@ from __future__ import annotations
 #
 # Paired with the CODE ``SurfaceProfile`` in ``surface_registry.py``: that row
 # denies the file/shell built-ins, ``Agent``, ``Skill``, and every pocket /
-# planner / widget tool, and scopes the MCP surface to ``code_mode``. Every
+# planner / widget tool, and scopes the MCP surface to the four file tools
+# (``_CODE_FILE_TOOL_IDS`` — readFile / search / listDir / writeFile). Every
 # capability claimed below is one the profile actually grants, and every tool the
 # profile withholds is either unmentioned or explained as absent. If the profile
 # changes, change this text in the same commit — a system prompt that promises a
 # denied tool is the failure this whole file exists to remove.
+#
+# The writeFile paragraph is load-bearing, not manners. ``writeFile`` STAGES a
+# proposal for the user's per-hunk review; nothing is written until the user
+# accepts. A model that reports "I created the file" after one writeFile call has
+# told the user something false, and the user will act on it — so the prompt is
+# explicit that a proposal is not a saved file.
 CODE_SYSTEM_PROMPT = """\
 <code-surface-role>
 You are PocketPaw's coding agent. The user is in a code editor looking at a real
@@ -54,9 +61,10 @@ software project, and your deliverable is WORKING CODE in that project — files
 created and changed, tests passing. Nothing else counts as done.
 
 The project does NOT live on your machine. It lives in the user's own workspace,
-and the `code_mode` tool is the ONLY way to reach it. That tool resolves the
-project, reads it, and applies the change. You have no filesystem of your own
-here: no working directory, nothing to `cd` into, no path worth naming.
+and you reach it ONLY through your file tools: `readFile`, `search`, `listDir`,
+and `writeFile`. You have no filesystem of your own here: no working directory,
+nothing to `cd` into, no shell, no path on disk worth naming. These four tools
+are the whole of your access to the code.
 </code-surface-role>
 
 <code-surface-deliverable>
@@ -75,38 +83,41 @@ however closely the words match one. On this surface:
 You cannot create a pocket here, and you should not offer to. The pocket,
 planner, and widget tools are withheld on this surface, as are the file and
 shell built-ins — not as a limitation to work around, but because none of them
-touch the user's project. `code_mode` is the path. If you catch yourself
-reaching for anything else, that is the signal you have drifted off this
-surface's job.
+touch the user's project. Your four file tools are the path. If you catch
+yourself reaching for anything else, that is the signal you have drifted off
+this surface's job.
 </code-surface-deliverable>
 
 <code-surface-procedure>
-Treat the user's message as a coding task and do it by calling `code_mode`.
-Describe the change in the user's own terms; the tool locates the code itself,
-so do NOT go hunting for files first.
+Work the way a coding agent works. To understand the project, `search` for the
+relevant code and `readFile` the files that matter; `listDir` when you need to
+see how a folder is laid out. Do not ask the user where something is if you can
+find it yourself.
 
-Use `mode='ask'` to read, search, and answer questions about the code. Use
-`mode='edit'` only when the user actually wants the code changed.
+To change the code, call `writeFile` with the file's COMPLETE new contents — not
+a diff, not a snippet. `writeFile` does not save the file: it stages your
+proposed contents for the user to review and accept hunk by hunk. So a
+`writeFile` call is a change PROPOSED, never a change made.
 
-If the request is scoped to a selection the user has ALREADY made, call
-`code_mode` IMMEDIATELY with no exploratory retrieval. The selected code and its
-file are already in your context, and this path is two model calls deep — a
-redundant lookup is a round-trip the user waits through twice.
-
-For a task large enough to need several edits, sequence them: make the change,
-see what came back, then decide the next one. Do not narrate a plan you have not
-started.
+If the request is scoped to a selection the user has already put in front of you,
+act on it directly rather than re-reading the whole project first. For a task
+large enough to need several edits, sequence them: make one change, see what came
+back, then decide the next. Do not narrate a plan you have not started.
 </code-surface-procedure>
 
 <code-surface-honesty>
-Report only what actually happened. `code_mode` tells you whether the change
-landed — say what it says.
+Report only what actually happened, and mind the difference between reading and
+writing.
 
-If it returns an error, or reports no browser session attached, say so plainly
-and stop. Never describe a file as written, a test as passing, or a feature as
-built when the tool did not confirm it. A wrong claim here is worse than a
-failure, because the user will act on it. When it succeeds, briefly summarize
-what changed and where.
+A `readFile`, `search`, or `listDir` result is the code as it is — quote it, work
+from it. A `writeFile` result means your change was STAGED for review, and the
+user still has to accept it; say "I've proposed…" or "I've drafted a change
+to…", never "I created" or "I updated" as if it were done. Never describe a file
+as written, a test as passing, or a feature as built when nothing confirmed it.
+
+If a tool returns an error, or reports no browser session attached, say so
+plainly and stop — do not claim work you could not do. A wrong claim here is
+worse than a failure, because the user will act on it.
 </code-surface-honesty>"""
 
 

--- a/ee/pocketpaw_ee/cloud/websandbox/durability.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/durability.py
@@ -97,11 +97,41 @@
 # carries with no excludes) are filtered out, and tar members are treated as
 # UNTRUSTED — absolute/traversing names and non-regular entries (symlinks, hardlinks,
 # devices) are skipped rather than materialized.
+#
+# Changed 2026-07-25 (S1, feat/code-s3-authoritative): the PER-FILE overlay is now the
+# project's whole truth and the tarball tier is RETIRED as a source of truth. This
+# reverses the CM-2a′ two-tier design documented above, and the reason is that a
+# tarball is an unmodifiable blob: a DELETE has no representation inside it. Replaying
+# the baseline resurrected every file the user removed — on both runtimes — and
+# ``set_project_snapshot`` clearing the overlay destroyed the one tier that could have
+# recorded the absence. A tombstone list would have patched the symptom; making the
+# per-file store COMPLETE makes a delete the removal of an entry, with nothing left to
+# resurrect it. Bytes still flow through ``EEUploadService`` (not presigned/direct-to-S3)
+# so the pluggable adapter and local/OSS installs keep working. Concretely:
+#   * ``snapshot_project`` is GONE. Nothing writes a whole-workspace tarball any more.
+#   * ``sync_project_files`` replaces it: tar the workspace as a TRANSPORT (one round
+#     trip instead of one per file), expand it in memory, write every member through
+#     to its own blob, and swap the whole map in with ONE service write. Files that
+#     never pass a write hook — a ``git clone``'s tree, a materialized scaffold,
+#     generated output — are how the store becomes complete; a path that no longer
+#     exists is DROPPED, which is how a delete survives.
+#   * ``restore_project`` reconstructs the VM from the overlay ALONE, then PRUNES
+#     workspace files the overlay doesn't list (a fresh clone/scaffold re-materializes
+#     files the user deleted, so replay-only would hand the resurrection bug straight
+#     back). The prune is gated on ``overlay_complete`` — "absent from the overlay"
+#     only means "deleted" once the overlay has been verified against a real workspace.
+#   * a project whose state PREDATES this change still carries ``snapshot_file_id``
+#     and a partial overlay. ``_migrate_legacy_snapshot`` expands that tar ONCE into
+#     per-file entries (existing entries win — they are fresher), then clears the
+#     pointer so it never runs again. It is idempotent and non-destructive: if any
+#     member fails to carry across, the pointer is KEPT and the untar fallback still
+#     materializes the session, so a partial migration retries instead of losing data.
 from __future__ import annotations
 
 import io
 import logging
 import os
+import shlex
 import tarfile
 from pathlib import Path
 from typing import Any
@@ -113,6 +143,7 @@ from pocketpaw_ee.cloud._core.errors import (
     with_cause,
 )
 from pocketpaw_ee.cloud.codeproject import service as codeproject_service
+from pocketpaw_ee.cloud.codeproject.domain import CodeProjectView
 from pocketpaw_ee.cloud.daytona.client import DaytonaClient, get_daytona_client
 from pocketpaw_ee.cloud.shared.db import is_multi_tenant_cloud
 from pocketpaw_ee.cloud.websandbox import service as websandbox_service
@@ -120,11 +151,27 @@ from pocketpaw_ee.cloud.websandbox.constants import WEBSANDBOX_WORKDIR
 
 logger = logging.getLogger(__name__)
 
-# Blob-storage folders for the project-keyed durable store — grouped separately
-# from the sandbox-keyed ``/websandbox-*`` folders so a tenant's project
-# snapshots/overlay are distinguishable in their Files.
-_PROJECT_SNAPSHOT_FOLDER = "/code-project-snapshots"
+# Blob-storage folder for the project-keyed per-file store — grouped separately
+# from the sandbox-keyed ``/websandbox-*`` folders so a tenant's project files are
+# distinguishable in their Files. There is no snapshot folder constant any more:
+# S1 retired the tarball tier, so nothing writes ``/code-project-snapshots``. The
+# tars already there are still readable, by FileRecord id, for the one-time
+# migration in ``_migrate_legacy_snapshot``.
 _PROJECT_OVERLAY_FOLDER = "/code-project-overlay"
+
+# The in-VM staging path for the file-sync transport tarball. Distinct from
+# ``_SNAPSHOT_TMP`` so a sync can never collide with (or be mistaken for) the
+# retired snapshot blob, and outside the workspace dir so it never tars itself.
+_PROJECT_SYNC_TMP = "/tmp/code-project-sync.tgz"  # noqa: S108 — a sandbox VM path, not host
+
+# Seconds allowed for the in-VM tar / find commands the sync + prune run. The
+# Daytona client's default (30s) is tuned for interactive one-liners; walking a
+# real source tree is slower, and a timeout here costs the whole capture.
+_SYNC_EXEC_TIMEOUT_SECONDS = 120
+
+# Paths deleted per ``rm`` invocation when restore prunes a stale file. Bounded so a
+# big prune can't exceed the shell's argument limit.
+_PRUNE_CHUNK = 100
 
 _TRUTHY = {"1", "true", "yes", "on"}
 
@@ -622,80 +669,6 @@ async def _upload_project_blob(
     return rec.id
 
 
-async def snapshot_project(
-    workspace_id: str,
-    user_id: str,
-    project_id: str,
-    sandbox_id: str,
-    *,
-    client: DaytonaClient | None = None,
-    uploads: Any = None,
-) -> str:
-    """Snapshot a project's live VM workspace to blob storage; return the pointer.
-
-    Mirrors ``snapshot_workspace`` but anchors the pointer on the durable
-    ``CodeProject`` row. Resolves the project owner-scoped (``get_project`` raises
-    ``NotFound`` for a project the caller doesn't own), then ``tar -czf`` the
-    workspace dir in ``sandbox_id`` → ``download_file`` the tarball → size-cap →
-    upload to S3 (folder ``/code-project-snapshots``) → ``set_project_snapshot``
-    the returned FileRecord id (which also clears the overlay). Returns that id.
-
-    The ``sandbox_id`` is the live Daytona VM to snapshot, passed explicitly (not
-    resolved from a WebSandbox row) so this stays independent of the ephemeral
-    runtime row. Fails CLOSED on a non-s3 upload adapter in cloud before any VM
-    op. A tarball over the size cap raises a clean CloudError before any upload.
-    """
-    _require_s3_for_project_store()
-    daytona = _require_client(client)
-
-    # Owner-scoped tenancy gate: NotFound for a project the caller doesn't own.
-    await codeproject_service.get_project(workspace_id, user_id, project_id)
-
-    try:
-        await daytona.execute_command(
-            sandbox_id,
-            f"tar -czf {_SNAPSHOT_TMP} -C {WEBSANDBOX_WORKDIR} .",
-        )
-        data = await daytona.download_file(sandbox_id, _SNAPSHOT_TMP)
-    except Exception as exc:  # noqa: BLE001 — any VM-side failure is uniform
-        logger.warning(
-            "codeproject.snapshot: tar/download failed for project=%s", project_id, exc_info=True
-        )
-        raise with_cause(
-            CloudError(502, "codeproject.snapshot_failed", "Failed to snapshot the project"),
-            exc,
-        ) from exc
-
-    cap = _snapshot_max_bytes()
-    if len(data) > cap:
-        raise CloudError(
-            413,
-            "codeproject.snapshot_too_large",
-            f"Project snapshot is {len(data) / 1024 / 1024:.1f} MB, over the "
-            f"{cap / 1024 / 1024:.0f} MB limit",
-        )
-
-    up = uploads if uploads is not None else build_uploads()
-    file_id = await _upload_project_blob(
-        up,
-        data,
-        workspace_id=workspace_id,
-        user_id=user_id,
-        filename=f"code-project-snapshot-{project_id}.tgz",
-        folder=_PROJECT_SNAPSHOT_FOLDER,
-        content_type=_SNAPSHOT_MIME,
-    )
-    await codeproject_service.set_project_snapshot(workspace_id, user_id, project_id, file_id)
-    logger.info(
-        "codeproject.snapshot: project=%s daytona=%s -> file=%s (%d bytes)",
-        project_id,
-        sandbox_id,
-        file_id,
-        len(data),
-    )
-    return file_id
-
-
 async def restore_project(
     workspace_id: str,
     user_id: str,
@@ -705,34 +678,51 @@ async def restore_project(
     client: DaytonaClient | None = None,
     uploads: Any = None,
 ) -> None:
-    """Restore a project's durable state into a (fresh) VM: snapshot then overlay.
+    """Reconstruct a project's workspace in ``sandbox_id`` from the per-file store.
 
-    Mirrors ``restore_workspace`` but reads the pointer off the durable
-    ``CodeProject`` row (via the owner-scoped ``get_project`` view — so it also
-    enforces tenancy). Applies the two tiers in order into ``sandbox_id``:
-      1. ``snapshot_file_id`` — the full-workspace tarball (baseline): fetched
-         from S3, ``upload_bytes`` into the VM, ``tar -xzf`` over the dir.
-      2. ``overlay`` — the write-through per-file tier (edits since the last
-         snapshot): each ``relpath -> FileRecord id`` is fetched and written over
-         the tree. Cleared whenever a snapshot is taken, so replay is always the
-         freshest source state, never a stale resurrection.
+    Reads the pointers off the durable ``CodeProject`` row (via the owner-scoped
+    ``get_project`` view — so it also enforces tenancy) and applies, in order:
 
-    A project with NEITHER a snapshot nor an overlay is a clean 409 (nothing to
-    restore). No S3 guard here — restore is a READ path; the guard protects the
-    WRITE path so a project never silently persists to disk in the first place.
+      0. MIGRATION (once per project, only for state that predates S1) — a legacy
+         ``snapshot_file_id`` is expanded into per-file overlay entries and the
+         pointer is cleared. If it could not be carried across in full, the pointer
+         is kept and the tar is untarred as a baseline for THIS session so nothing
+         is missing, and the migration retries on the next open.
+      1. OVERLAY — the authoritative store. Every ``relpath -> FileRecord id`` is
+         fetched and written into the workspace.
+      2. PRUNE — workspace files the overlay does NOT list are deleted, iff the
+         overlay is known complete. This is what makes a delete stick: the VM this
+         restores into was just cloned or scaffolded, so it holds baseline files
+         the user may have removed, and replay-only would resurrect every one of
+         them. Gated on ``overlay_complete`` because "absent from the overlay"
+         means "deleted" only once the overlay has been verified against a real
+         workspace — for an in-tab project (partial overlay, scaffold baseline
+         re-materialized client-side) it does not, and pruning would be data loss.
+
+    A project with NEITHER a legacy snapshot nor an overlay is a clean 409 (nothing
+    to restore). The prune assumes a FRESHLY provisioned VM — the only caller is
+    ``codeproject.lifecycle.open_project``'s cold-provision branch, so there is
+    never unsaved in-VM work for it to remove.
     """
     daytona = _require_client(client)
 
     project = await codeproject_service.get_project(workspace_id, user_id, project_id)
-    overlay = project.overlay or {}
-    if not project.snapshot_file_id and not overlay:
+    if not project.snapshot_file_id and not project.overlay:
         raise ConflictError(
             "codeproject.no_snapshot", "This project has no durable state to restore"
         )
 
     up = uploads if uploads is not None else build_uploads()
 
-    # Tier 1 — the full-workspace snapshot (baseline).
+    # Tier 0 — one-time migration off the retired tarball tier.
+    if project.snapshot_file_id:
+        project = await _migrate_legacy_snapshot(workspace_id, user_id, project, up)
+    overlay = project.overlay or {}
+
+    # Legacy FALLBACK — only reachable when the migration above could not carry the
+    # tar across in full (it leaves the pointer set for a retry). Untarring the
+    # baseline keeps this session complete rather than opening a project with holes
+    # in it; the per-file store still wins, because the overlay replays on top.
     if project.snapshot_file_id:
         data = await _download_snapshot(
             up, project.snapshot_file_id, workspace_id=workspace_id, user_id=user_id
@@ -759,7 +749,7 @@ async def restore_project(
             len(data),
         )
 
-    # Tier 2 — replay the write-through overlay (freshest edits) over the tree.
+    # Tier 1 — write the authoritative per-file store into the workspace.
     replayed = 0
     for rel_path, file_id in overlay.items():
         abs_path = _overlay_abs_path(rel_path)
@@ -783,10 +773,16 @@ async def restore_project(
             )
     if replayed:
         logger.info(
-            "codeproject.restore: project=%s daytona=%s replayed %d overlay file(s)",
+            "codeproject.restore: project=%s daytona=%s replayed %d file(s)",
             project_id,
             sandbox_id,
             replayed,
+        )
+
+    # Tier 2 — reconcile the deletions. See the docstring for why this is gated.
+    if project.overlay_complete:
+        await _prune_stale_workspace_files(
+            daytona, sandbox_id, overlay, project_id=project_id, replayed=replayed
         )
 
 
@@ -883,21 +879,32 @@ async def move_project_overlay(
 # state this path persists.
 # ===========================================================================
 
-# Read-back caps for the browser restore payload. The whole overlay is
-# materialized in memory as one JSON response, so both a per-file byte ceiling
-# and a file-count ceiling are enforced — a source tree is small, and an
-# unbounded read is a memory + latency hazard for the tab as much as the box.
-# Env-tunable in the same shape as ``POCKETPAW_WEBSANDBOX_SNAPSHOT_MAX_MB``.
-_DEFAULT_OVERLAY_MAX_MB = 10.0
-_DEFAULT_OVERLAY_MAX_FILES = 2000
+# Caps on the per-file store. Re-tuned by S1: the overlay used to be a DELTA (the
+# handful of files edited since the last tarball), and 10 MB / 2000 files was
+# generous for that. It now holds the project's WHOLE source tree, and those
+# numbers would reject an ordinary repo — a mid-size monorepo clears 2000 source
+# files on its own — turning "your project is too big" into the normal case.
+# node_modules, .git and build output are excluded (``_SNAPSHOT_EXCLUDED_SEGMENTS``),
+# so these bound SOURCE only, which is what makes 100 MB roomy rather than reckless.
+# Both stay LOUD (413) rather than truncating: a silently partial project reads to
+# the user as deleted files. Env-tunable in the same shape as
+# ``POCKETPAW_WEBSANDBOX_SNAPSHOT_MAX_MB``.
+_DEFAULT_OVERLAY_MAX_MB = 100.0
+_DEFAULT_OVERLAY_MAX_FILES = 10000
+
+# The PER-FILE ceiling, deliberately split from the aggregate above. It used to be
+# the same knob, which was fine while both meant "10 MB"; raising the aggregate to
+# 100 MB would otherwise have quietly let a single 100 MB file through the browser
+# write route. One runaway file and a whole runaway project are different failures
+# and now have different limits.
+_DEFAULT_FILE_MAX_MB = 10.0
 
 
 def _overlay_max_bytes() -> int:
-    """Overlay byte cap (``POCKETPAW_CODEPROJECT_OVERLAY_MAX_MB``).
+    """Aggregate byte cap for a project's files (``POCKETPAW_CODEPROJECT_OVERLAY_MAX_MB``).
 
-    Applied twice: as the per-file ceiling on a write (so one runaway file can
-    never land) and as the cumulative ceiling on the read-back (so the restore
-    payload stays bounded no matter how the overlay grew).
+    Bounds every whole-project materialization: the browser read-back payload, the
+    in-memory expansion of a sync transport tarball, and the legacy-tar migration.
     """
     raw = os.environ.get("POCKETPAW_CODEPROJECT_OVERLAY_MAX_MB", "").strip()
     mb = _DEFAULT_OVERLAY_MAX_MB
@@ -907,6 +914,20 @@ def _overlay_max_bytes() -> int:
         except ValueError:
             logger.warning(
                 "ignoring non-numeric POCKETPAW_CODEPROJECT_OVERLAY_MAX_MB=%r; using %s", raw, mb
+            )
+    return int(mb * 1024 * 1024)
+
+
+def _file_max_bytes() -> int:
+    """Per-file byte cap (``POCKETPAW_CODEPROJECT_FILE_MAX_MB``)."""
+    raw = os.environ.get("POCKETPAW_CODEPROJECT_FILE_MAX_MB", "").strip()
+    mb = _DEFAULT_FILE_MAX_MB
+    if raw:
+        try:
+            mb = float(raw)
+        except ValueError:
+            logger.warning(
+                "ignoring non-numeric POCKETPAW_CODEPROJECT_FILE_MAX_MB=%r; using %s", raw, mb
             )
     return int(mb * 1024 * 1024)
 
@@ -961,15 +982,21 @@ def _require_safe_rel_path(rel_path: str) -> str:
     return safe
 
 
-# Path segments dropped when a snapshot tar is expanded for the BROWSER read-back.
-# ``snapshot_project`` tars the whole workspace with no excludes (right for a VM
-# restore, which wants a byte-identical tree), but every tree here is regenerable
-# or meaningless in a tab: ``npm install`` restores ``node_modules``, a build
-# restores ``dist``/``build``/``.next``/``.svelte-kit``, ``.turbo``/``.cache``/
-# ``coverage`` are derived artifacts, and ``.git`` is a binary object store the
-# in-tab runtime has no client for. They are also the bulk of the bytes — shipping
-# them through a JSON string map would be hundreds of MB the browser throws away.
-# Not applied to the VM restore path, which legitimately wants the whole tree.
+# Path segments that never enter the per-file store. ONE list, four readers (S1):
+# ``_sync_tar_command`` excludes them at the source, ``_expand_tar_to_blobs``
+# re-checks after expansion, ``_list_workspace_files`` prunes them from the
+# enumeration, and the restore prune therefore cannot touch them.
+#
+# Every tree here is regenerable or meaningless to persist: ``npm install`` restores
+# ``node_modules``, a build restores ``dist``/``build``/``.next``/``.svelte-kit``,
+# ``.turbo``/``.cache``/``coverage`` are derived artifacts, and ``.git`` is a binary
+# object store whose durability is the remote. They are also the bulk of the bytes —
+# storing them one blob per file, or shipping them to a tab through a JSON string
+# map, would be hundreds of MB nothing reads.
+#
+# The exclusion is why the prune is safe: a path the enumeration cannot see is never
+# a candidate for deletion, so restoring into a fresh clone leaves ``.git`` and an
+# installed ``node_modules`` exactly where they are.
 _SNAPSHOT_EXCLUDED_SEGMENTS = frozenset(
     {
         "node_modules",
@@ -1007,31 +1034,29 @@ def _tar_member_rel_path(name: str) -> str | None:
     return _normalize_rel_path(raw)
 
 
-def _expand_snapshot_tar(data: bytes, *, project_id: str, cap: int) -> tuple[dict[str, str], int]:
-    """Expand a snapshot tarball in memory into ``({relpath: text}, total bytes)``.
+def _expand_tar_to_blobs(data: bytes, *, project_id: str, cap: int) -> tuple[dict[str, bytes], int]:
+    """Expand a tarball in memory into ``({relpath: raw bytes}, total bytes)``.
 
-    The BASELINE tier of the browser read-back — the in-memory counterpart of
-    ``restore_project``'s ``tar -xzf`` into a VM. Written by ``tar -czf`` so the
-    blob is gzipped; ``r:*`` auto-detects anyway.
+    ONE expander behind every place a tar is read: the browser read-back's baseline
+    (via ``_expand_snapshot_tar``, which decodes on top), the sync transport tarball,
+    and the legacy-tar migration. Written by ``tar -czf`` so the blob is gzipped;
+    ``r:*`` auto-detects anyway.
 
-    Three classes of member never make it into the payload:
+    Two classes of member never make it out:
       * non-regular entries (directories, symlinks, hardlinks, devices) — a
         directory carries no content and a link is a tar-smuggling vector with no
-        meaning in a browser FS;
+        meaning in a browser FS or a re-materialized workspace;
       * unsafe names (absolute or ``..``-traversing) and regenerable trees
-        (``_SNAPSHOT_EXCLUDED_SEGMENTS``);
-      * non-UTF-8 blobs — the transport is a JSON string map, so a binary file
-        can't be carried. Skipped with a warning rather than failing the whole
-        restore, mirroring how the overlay read-back tolerates one bad entry.
+        (``_SNAPSHOT_EXCLUDED_SEGMENTS``).
 
     The byte cap is enforced from the member HEADER before anything is read, so a
-    huge (or zip-bomb) snapshot bounds memory instead of consuming it. Exceeding it
+    huge (or zip-bomb) archive bounds memory instead of consuming it. Exceeding it
     raises LOUD (413) — see ``read_project_overlay`` for why a truncated payload is
     the one outcome to avoid.
     """
-    files: dict[str, str] = {}
+    blobs: dict[str, bytes] = {}
     total = 0
-    skipped_unsafe = skipped_excluded = skipped_binary = 0
+    skipped_unsafe = skipped_excluded = 0
     # A corrupt or truncated archive raises on open OR mid-iteration; both are the
     # same failure — the baseline is unreadable — and both must be LOUD. Returning
     # the overlay alone would look like a project that lost most of its files.
@@ -1065,11 +1090,7 @@ def _expand_snapshot_tar(data: bytes, *, project_id: str, cap: int) -> tuple[dic
                     )
                 handle = archive.extractfile(member)
                 blob = handle.read() if handle is not None else b""
-                try:
-                    files[rel_path] = blob.decode("utf-8")
-                except UnicodeDecodeError:
-                    skipped_binary += 1
-                    continue
+                blobs[rel_path] = blob
                 total += len(blob)
     except (tarfile.TarError, EOFError, OSError) as exc:
         raise with_cause(
@@ -1081,15 +1102,44 @@ def _expand_snapshot_tar(data: bytes, *, project_id: str, cap: int) -> tuple[dic
             exc,
         ) from exc
     logger.debug(
-        "codeproject.read_overlay: snapshot expanded for project=%s -> %d file(s), %d bytes "
-        "(skipped %d excluded, %d binary, %d unsafe)",
+        "codeproject.expand_tar: project=%s -> %d file(s), %d bytes "
+        "(skipped %d excluded, %d unsafe)",
         project_id,
-        len(files),
+        len(blobs),
         total,
         skipped_excluded,
-        skipped_binary,
         skipped_unsafe,
     )
+    return blobs, total
+
+
+def _expand_snapshot_tar(data: bytes, *, project_id: str, cap: int) -> tuple[dict[str, str], int]:
+    """Expand a tarball into ``({relpath: text}, total bytes)`` for the browser.
+
+    ``_expand_tar_to_blobs`` plus the one concern only the JSON wire has: a binary
+    file cannot be carried in a string map, so a non-UTF-8 member is skipped with a
+    warning rather than failing the whole restore — the same "one bad entry must not
+    sink the rest" rule the overlay read-back replays under. Its bytes still counted
+    against the cap during expansion (they were buffered), but they are not counted
+    in the returned total, which is the budget the overlay tier then adds to.
+    """
+    blobs, _raw_total = _expand_tar_to_blobs(data, project_id=project_id, cap=cap)
+    files: dict[str, str] = {}
+    total = 0
+    skipped_binary = 0
+    for rel_path, blob in blobs.items():
+        try:
+            files[rel_path] = blob.decode("utf-8")
+        except UnicodeDecodeError:
+            skipped_binary += 1
+            continue
+        total += len(blob)
+    if skipped_binary:
+        logger.debug(
+            "codeproject.read_overlay: skipped %d non-UTF-8 entry(ies) for project=%s",
+            skipped_binary,
+            project_id,
+        )
     return files, total
 
 
@@ -1120,7 +1170,7 @@ async def put_project_file(
     safe_path = _require_safe_rel_path(rel_path)
     data = content.encode("utf-8")
 
-    cap = _overlay_max_bytes()
+    cap = _file_max_bytes()
     if len(data) > cap:
         raise CloudError(
             413,
@@ -1272,6 +1322,369 @@ async def read_project_overlay(
     return files
 
 
+# ===========================================================================
+# Workspace file sync — what makes the per-file store COMPLETE (S1).
+#
+# The write-through hooks only ever see files that pass through the editor: a
+# ``git clone``'s tree, a materialized scaffold, and anything a process writes
+# (build output, generated files) are invisible to them. The tarball tier used to
+# cover that gap, and covering it is the price of retiring the tarball — so the
+# workspace is enumerated explicitly and every file written through to its own
+# blob.
+#
+# The tar is a TRANSPORT here, not a tier: one round trip to read the whole tree
+# instead of one ``download_file`` per file, expanded in memory and immediately
+# fanned out into per-file objects. Nothing durable is a tarball afterwards.
+# ===========================================================================
+
+
+def _sync_tar_command() -> str:
+    """The in-VM command that packs the workspace for a sync read.
+
+    Excludes are built from ``_SNAPSHOT_EXCLUDED_SEGMENTS`` so there is exactly ONE
+    definition of "a regenerable tree" — the same frozenset the expander re-checks
+    and the prune skips. Excluding at the tar level is what keeps a 500 MB
+    ``node_modules`` off the wire in the first place; re-checking after expansion is
+    defence in depth for a tar built elsewhere (a legacy snapshot, say).
+    """
+    excludes = " ".join(
+        f"--exclude={shlex.quote(seg)}" for seg in sorted(_SNAPSHOT_EXCLUDED_SEGMENTS)
+    )
+    return (
+        f"tar -czf {_PROJECT_SYNC_TMP} {excludes} "
+        f"-C {shlex.quote(WEBSANDBOX_WORKDIR)} . 2>/dev/null || true"
+    )
+
+
+async def sync_project_files(
+    workspace_id: str,
+    user_id: str,
+    project_id: str,
+    sandbox_id: str,
+    *,
+    client: DaytonaClient | None = None,
+    uploads: Any = None,
+) -> dict[str, str]:
+    """Re-image a project's per-file store from its live VM workspace.
+
+    The replacement for the retired ``snapshot_project``, and the operation that
+    makes "the overlay is the whole truth" true. Enumerate the workspace, write
+    every file through to its own blob, and swap the whole map in with ONE service
+    write. Returns the new overlay.
+
+    DELETIONS ARE THE POINT. Syncing enumerates what EXISTS, so a file the user
+    deleted simply isn't uploaded — and because the map is REPLACED rather than
+    merged, its old entry goes with it. Nothing is left to resurrect it: there is
+    no baseline blob to replay, and the next restore reconstructs the workspace
+    from this map alone.
+
+    Two things are deliberately NOT dropped, because "the sync didn't see it" is
+    not the same claim as "the user deleted it":
+      * paths inside an excluded tree (``dist/``, ``.next/`` …). The enumeration
+        never looks there, so an entry a write hook once recorded for such a path
+        is kept rather than silently discarded.
+      * paths whose upload FAILED this round. A stale pointer beats no pointer.
+    And an enumeration that comes back EMPTY is treated as a failed read, not as an
+    emptied workspace: it returns the existing overlay untouched. A transient VM
+    error must never be the thing that wipes a project.
+
+    Fails CLOSED on a non-s3 upload adapter in cloud (silent non-persistence is
+    worse than a loud 503), and LOUD on the aggregate caps rather than persisting a
+    truncated project. Both callers (``ws.snapshot_on_disconnect`` and
+    ``lifecycle.open_project``) are best-effort and log at WARNING, so a raise here
+    costs the capture, never the session.
+    """
+    _require_s3_for_project_store()
+    daytona = _require_client(client)
+
+    # Owner-scoped tenancy gate: NotFound for a project the caller doesn't own.
+    project = await codeproject_service.get_project(workspace_id, user_id, project_id)
+    previous = dict(project.overlay or {})
+
+    try:
+        await daytona.execute_command(
+            sandbox_id, _sync_tar_command(), timeout=_SYNC_EXEC_TIMEOUT_SECONDS
+        )
+        data = await daytona.download_file(sandbox_id, _PROJECT_SYNC_TMP)
+    except Exception as exc:  # noqa: BLE001 — any VM-side failure is uniform
+        logger.warning(
+            "codeproject.sync: tar/download failed for project=%s", project_id, exc_info=True
+        )
+        raise with_cause(
+            CloudError(502, "codeproject.sync_failed", "Failed to read the project workspace"),
+            exc,
+        ) from exc
+
+    cap = _overlay_max_bytes()
+    blobs, total = _expand_tar_to_blobs(data, project_id=project_id, cap=cap)
+
+    max_files = _overlay_max_files()
+    if len(blobs) > max_files:
+        raise CloudError(
+            413,
+            "codeproject.overlay_too_many_files",
+            f"Project holds {len(blobs)} files, over the {max_files} file limit",
+        )
+    if not blobs:
+        # An empty read is ambiguous (a genuinely empty workspace, or a tar that
+        # never ran) and the destructive reading of it is unrecoverable. Keep what
+        # we have; a real empty project loses nothing by staying as it was.
+        logger.warning(
+            "codeproject.sync: workspace enumeration for project=%s daytona=%s came back "
+            "EMPTY — keeping the existing %d file(s) rather than dropping them",
+            project_id,
+            sandbox_id,
+            len(previous),
+        )
+        return previous
+
+    up = uploads if uploads is not None else build_uploads()
+    overlay: dict[str, str] = {}
+    failed = 0
+    for rel_path in sorted(blobs):
+        try:
+            overlay[rel_path] = await _upload_project_blob(
+                up,
+                blobs[rel_path],
+                workspace_id=workspace_id,
+                user_id=user_id,
+                filename=f"overlay-{project_id}-{rel_path.rsplit('/', 1)[-1] or 'file'}",
+                folder=_PROJECT_OVERLAY_FOLDER,
+                content_type="application/octet-stream",
+            )
+        except Exception:  # noqa: BLE001 — one bad blob must not sink the whole sync
+            failed += 1
+            if rel_path in previous:
+                overlay[rel_path] = previous[rel_path]
+            logger.warning(
+                "codeproject.sync: upload failed for project=%s path=%r", project_id, rel_path
+            )
+
+    # Carry across the entries the enumeration could not have seen (see docstring).
+    kept_excluded = 0
+    for rel_path, file_id in previous.items():
+        if rel_path not in overlay and _is_excluded_snapshot_path(rel_path):
+            overlay[rel_path] = file_id
+            kept_excluded += 1
+
+    dropped = sorted(set(previous) - set(overlay))
+    view = await codeproject_service.replace_project_overlay(
+        workspace_id,
+        user_id,
+        project_id,
+        overlay,
+        # Verified against a real workspace — this is what licenses restore's prune.
+        complete=True,
+    )
+    logger.info(
+        "codeproject.sync: project=%s daytona=%s -> %d file(s), %d bytes "
+        "(dropped %d deleted, kept %d excluded, %d upload failure(s))",
+        project_id,
+        sandbox_id,
+        len(view.overlay),
+        total,
+        len(dropped),
+        kept_excluded,
+        failed,
+    )
+    return dict(view.overlay)
+
+
+async def _migrate_legacy_snapshot(
+    workspace_id: str,
+    user_id: str,
+    project: CodeProjectView,
+    uploads: Any,
+) -> CodeProjectView:
+    """Expand a project's legacy tarball into per-file entries, ONCE. Returns the view.
+
+    The one-way migration for state written before the tarball tier was retired.
+    Such a project carries a ``snapshot_file_id`` plus a partial overlay of the
+    edits made after the tar was taken, and reading the overlay alone would lose
+    everything that only ever lived inside the tar. So the tar is expanded and each
+    member written through to its own blob.
+
+    Three properties, all of which make it safe to run on every restore:
+      * NON-DESTRUCTIVE — an existing overlay entry always WINS. It is newer than
+        the tar by construction (it was written after the snapshot), so the tar's
+        copy is never allowed to overwrite it.
+      * IDEMPOTENT — success clears ``snapshot_file_id``, so there is no tar left
+        to expand a second time. A partial run keeps the pointer AND keeps every
+        entry it did carry across, so the retry only does the remainder.
+      * FAIL-SAFE — if the blob is unreadable, the upload adapter is misconfigured,
+        or any member fails to land, the pointer is KEPT. The caller then falls back
+        to untarring the baseline into the VM, so the session is complete either
+        way and the data is still in blob storage for the next attempt.
+
+    Clearing the pointer is not bookkeeping — it is the whole point. While it is
+    set, a restore replays a baseline that cannot express a deletion, which is the
+    bug this migration exists to end.
+    """
+    project_id = project.id
+    try:
+        _require_s3_for_project_store()
+        data = await _download_snapshot(
+            uploads, project.snapshot_file_id or "", workspace_id=workspace_id, user_id=user_id
+        )
+        blobs, _total = _expand_tar_to_blobs(data, project_id=project_id, cap=_overlay_max_bytes())
+    except Exception:  # noqa: BLE001 — any read failure keeps the pointer for a retry
+        logger.warning(
+            "codeproject.migrate: could not read legacy snapshot=%s for project=%s; "
+            "keeping the pointer and falling back to the tar baseline",
+            project.snapshot_file_id,
+            project_id,
+            exc_info=True,
+        )
+        return project
+
+    overlay = dict(project.overlay or {})
+    migrated = failed = 0
+    for rel_path in sorted(blobs):
+        if rel_path in overlay:
+            # The overlay entry post-dates the tar — never overwrite it.
+            continue
+        try:
+            overlay[rel_path] = await _upload_project_blob(
+                uploads,
+                blobs[rel_path],
+                workspace_id=workspace_id,
+                user_id=user_id,
+                filename=f"overlay-{project_id}-{rel_path.rsplit('/', 1)[-1] or 'file'}",
+                folder=_PROJECT_OVERLAY_FOLDER,
+                content_type="application/octet-stream",
+            )
+            migrated += 1
+        except Exception:  # noqa: BLE001 — a partial migration retries, never loses
+            failed += 1
+            logger.warning(
+                "codeproject.migrate: upload failed for project=%s path=%r",
+                project_id,
+                rel_path,
+            )
+
+    view = await codeproject_service.replace_project_overlay(
+        workspace_id,
+        user_id,
+        project_id,
+        overlay,
+        # A legacy tar was a whole-workspace image, so the merged map is complete —
+        # unless something failed to land, in which case it demonstrably isn't.
+        complete=failed == 0,
+        clear_snapshot=failed == 0,
+    )
+    logger.info(
+        "codeproject.migrate: project=%s legacy snapshot=%s -> %d new per-file entry(ies), "
+        "%d total (%d failure(s); pointer %s)",
+        project_id,
+        project.snapshot_file_id,
+        migrated,
+        len(view.overlay),
+        failed,
+        "kept for retry" if failed else "cleared",
+    )
+    return view
+
+
+async def _list_workspace_files(daytona: Any, sandbox_id: str) -> list[str]:
+    """Enumerate the VM workspace as project-relative paths (excluded trees pruned).
+
+    ``find`` rather than the sync's tar because the caller only needs NAMES — the
+    prune decides what to delete, and shipping the bytes to decide that would be
+    absurd. The excluded segments are pruned in the command AND re-checked in
+    Python, so the two enumerations agree on what is even visible.
+
+    Every path is re-jailed through ``_normalize_rel_path`` after the workspace
+    prefix is stripped: this list feeds an ``rm``, so a line that doesn't sit under
+    the workspace dir is dropped rather than trusted.
+    """
+    root = shlex.quote(WEBSANDBOX_WORKDIR)
+    names = " -o ".join(f"-name {shlex.quote(seg)}" for seg in sorted(_SNAPSHOT_EXCLUDED_SEGMENTS))
+    command = f"find {root} -type d \\( {names} \\) -prune -o -type f -print"
+    resp = await daytona.execute_command(sandbox_id, command, timeout=_SYNC_EXEC_TIMEOUT_SECONDS)
+    stdout = getattr(resp, "result", "") or ""
+    prefix = WEBSANDBOX_WORKDIR.rstrip("/") + "/"
+    found: list[str] = []
+    for line in stdout.splitlines():
+        raw = line.strip()
+        if not raw.startswith(prefix):
+            continue
+        rel_path = _normalize_rel_path(raw[len(prefix) :])
+        if rel_path is None or _is_excluded_snapshot_path(rel_path):
+            continue
+        found.append(rel_path)
+    return found
+
+
+async def _prune_stale_workspace_files(
+    daytona: Any,
+    sandbox_id: str,
+    overlay: dict[str, str],
+    *,
+    project_id: str,
+    replayed: int,
+) -> int:
+    """Delete workspace files the (complete) per-file store does not list. Returns the count.
+
+    The deletion half of "restore reconstructs the workspace from the overlay". A
+    restore always runs into a VM that was just cloned or scaffolded, so it holds
+    baseline files — including the ones the user DELETED. Writing the overlay over
+    that tree leaves those files behind, which is precisely the resurrection the
+    tarball tier used to cause. Removing them is what makes a delete durable.
+
+    Only ever called when ``overlay_complete`` is set, i.e. after a sync verified
+    the map against a real workspace. Two more guards on top of that:
+      * an EMPTY enumeration is treated as a failed read, never as "delete
+        everything" — the same reading ``sync_project_files`` takes;
+      * nothing is pruned when the overlay replay wrote NOTHING, because a restore
+        that failed to materialize the store must not then delete the baseline it
+        was supposed to replace.
+    Excluded trees are invisible to the enumeration, so ``.git``, ``node_modules``
+    and build output are never touched. Best-effort: a prune failure leaves a
+    resurrected file, which is recoverable; raising would fail the whole open.
+    """
+    if not overlay or not replayed:
+        return 0
+    try:
+        present = await _list_workspace_files(daytona, sandbox_id)
+    except Exception:  # noqa: BLE001 — a failed enumeration prunes nothing
+        logger.warning(
+            "codeproject.restore: could not enumerate the workspace for project=%s; "
+            "skipping the stale-file prune",
+            project_id,
+            exc_info=True,
+        )
+        return 0
+    if not present:
+        return 0
+
+    stale = [p for p in sorted(set(present)) if p not in overlay]
+    targets = [abs_path for abs_path in map(_overlay_abs_path, stale) if abs_path is not None]
+    if not targets:
+        return 0
+
+    removed = 0
+    for start in range(0, len(targets), _PRUNE_CHUNK):
+        chunk = targets[start : start + _PRUNE_CHUNK]
+        command = "rm -f " + " ".join(shlex.quote(p) for p in chunk)
+        try:
+            await daytona.execute_command(sandbox_id, command, timeout=_SYNC_EXEC_TIMEOUT_SECONDS)
+            removed += len(chunk)
+        except Exception:  # noqa: BLE001 — one failed chunk must not sink the restore
+            logger.warning(
+                "codeproject.restore: stale-file prune failed for project=%s (%d path(s))",
+                project_id,
+                len(chunk),
+                exc_info=True,
+            )
+    logger.info(
+        "codeproject.restore: project=%s daytona=%s pruned %d file(s) absent from the store",
+        project_id,
+        sandbox_id,
+        removed,
+    )
+    return removed
+
+
 __all__ = [
     "build_uploads",
     "drop_overlay",
@@ -1285,6 +1698,6 @@ __all__ = [
     "read_project_overlay",
     "restore_project",
     "restore_workspace",
-    "snapshot_project",
     "snapshot_workspace",
+    "sync_project_files",
 ]

--- a/ee/pocketpaw_ee/cloud/websandbox/durability.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/durability.py
@@ -827,6 +827,100 @@ async def mirror_file_to_project(
     return file_id
 
 
+async def put_project_files(
+    workspace_id: str,
+    user_id: str,
+    project_id: str,
+    files: dict[str, str],
+    *,
+    uploads: Any = None,
+) -> int:
+    """Replace the project's whole per-file store from a client-supplied map.
+
+    The in-tab analog of ``sync_project_files``: the browser holds the project's
+    filesystem, so IT is the only thing that can enumerate one. It walks its own
+    FS once (after materializing a starter, say) and hands the result here.
+
+    Why this exists as a BULK op rather than N calls to ``put_project_file``:
+    completeness has to be a property of a write that either wholly happened or
+    did not. ``overlay_complete`` is what licenses the restore-time prune to
+    delete a file the store does not list, so a store marked complete after a
+    partial upload would license deleting exactly the files that failed to
+    upload. Uploading everything FIRST and swapping the map in one write makes
+    that unrepresentable: a failure raises before the swap, and the project keeps
+    its previous state and its previous completeness.
+
+    Caps are the same ones the VM sync answers to, and they fail LOUD — a store
+    silently missing files is the input to a destructive prune.
+    """
+    _require_s3_for_project_store()
+    # Authorize BEFORE uploading. The swap at the end is owner-scoped and would
+    # reject a foreign caller anyway, but only after their bytes were already in
+    # the tenant's storage — an unauthorized request should not be able to spend
+    # storage on its way to a 404.
+    await codeproject_service.get_project(workspace_id, user_id, project_id)
+
+    max_files = _overlay_max_files()
+    if len(files) > max_files:
+        raise CloudError(
+            413,
+            "codeproject.overlay_too_many_files",
+            f"Project holds {len(files)} files, over the {max_files} file limit",
+        )
+
+    file_cap = _file_max_bytes()
+    total_cap = _overlay_max_bytes()
+    encoded: dict[str, bytes] = {}
+    total = 0
+    for raw_path, content in files.items():
+        safe_path = _require_safe_rel_path(raw_path)
+        data = (content or "").encode("utf-8")
+        if len(data) > file_cap:
+            raise CloudError(
+                413,
+                "codeproject.file_too_large",
+                f"{safe_path!r} is {len(data)} bytes, over the per-file limit",
+            )
+        total += len(data)
+        if total > total_cap:
+            raise CloudError(
+                413,
+                "codeproject.overlay_too_large",
+                f"Project exceeds the {total_cap}-byte store limit",
+            )
+        encoded[safe_path] = data
+
+    up = uploads if uploads is not None else build_uploads()
+    overlay: dict[str, str] = {}
+    for safe_path, data in encoded.items():
+        basename = safe_path.rsplit("/", 1)[-1] or "file"
+        overlay[safe_path] = await _upload_project_blob(
+            up,
+            data,
+            workspace_id=workspace_id,
+            user_id=user_id,
+            filename=f"overlay-{project_id}-{basename}",
+            folder=_PROJECT_OVERLAY_FOLDER,
+            content_type="application/octet-stream",
+        )
+
+    # Every byte is durable before the map moves — so this swap is the moment the
+    # store becomes both authoritative and complete, and never a moment earlier.
+    await codeproject_service.replace_project_overlay(
+        workspace_id,
+        user_id,
+        project_id,
+        overlay,
+        complete=True,
+    )
+    logger.info(
+        "codeproject.sync(in-tab): project=%s stored %d files",
+        project_id,
+        len(overlay),
+    )
+    return len(overlay)
+
+
 async def drop_project_overlay(
     workspace_id: str,
     user_id: str,

--- a/ee/pocketpaw_ee/cloud/websandbox/durability.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/durability.py
@@ -64,6 +64,21 @@
 # (``snapshot_project`` / ``mirror_file_to_project``) hard-requires S3 in cloud
 # via ``_require_s3_for_project_store`` — silent non-persistence to local disk is
 # worse than a loud 503.
+#
+# Changed 2026-07-25 (B1, feat/code-project-file-sync): added the BROWSER-runtime
+# siblings — ``put_project_file`` / ``drop_project_file`` / ``read_project_overlay``.
+# Every project-keyed function above tars or untars a Daytona VM, i.e. the bytes
+# live in a VM the backend can reach. On the in-tab (WebContainer) runtime there is
+# no VM: the filesystem is in the user's browser, so the bytes arrive FROM the
+# client on a write and must be handed BACK to it on a reopen. These three close
+# that loop over the same two-tier model, minus the snapshot tier — the baseline is
+# the starter scaffold, deterministically re-materializable client-side from the
+# starter id and therefore never uploaded, so the overlay alone is the whole
+# durable delta. Restore = re-materialize the scaffold, then replay the overlay.
+# Same S3 vehicle, same ``_upload_project_blob``, same owner-scoped ``stream(...)``
+# read path ``restore_project`` uses, same ``_require_s3_for_project_store``
+# fail-closed guard on the write, same ``uploads=`` DI seam. ADDITIVE: nothing
+# above is touched.
 from __future__ import annotations
 
 import io
@@ -72,7 +87,12 @@ import os
 from pathlib import Path
 from typing import Any
 
-from pocketpaw_ee.cloud._core.errors import CloudError, ConflictError, with_cause
+from pocketpaw_ee.cloud._core.errors import (
+    CloudError,
+    ConflictError,
+    ValidationError,
+    with_cause,
+)
 from pocketpaw_ee.cloud.codeproject import service as codeproject_service
 from pocketpaw_ee.cloud.daytona.client import DaytonaClient, get_daytona_client
 from pocketpaw_ee.cloud.shared.db import is_multi_tenant_cloud
@@ -827,14 +847,238 @@ async def move_project_overlay(
     )
 
 
+# ===========================================================================
+# Browser-runtime project file sync (B1, feat/code-project-file-sync).
+#
+# The in-tab (WebContainer) runtime has no VM, so the three functions here are
+# the client-side counterparts of ``mirror_file_to_project`` /
+# ``drop_project_overlay`` / ``restore_project``: the bytes arrive from the
+# browser on a write and are streamed back to it on a reopen, instead of being
+# tarred out of and untarred into a Daytona VM.
+#
+# Only the OVERLAY tier is involved. The baseline is the starter scaffold, which
+# the client re-materializes deterministically from the starter id
+# (``codescaffold.compose``), so a fresh project stores nothing and the overlay
+# IS the durable delta. That also means these never write ``snapshot_file_id``:
+# ``set_project_snapshot`` clears the overlay, which would discard exactly the
+# state this path persists.
+# ===========================================================================
+
+# Read-back caps for the browser restore payload. The whole overlay is
+# materialized in memory as one JSON response, so both a per-file byte ceiling
+# and a file-count ceiling are enforced — a source tree is small, and an
+# unbounded read is a memory + latency hazard for the tab as much as the box.
+# Env-tunable in the same shape as ``POCKETPAW_WEBSANDBOX_SNAPSHOT_MAX_MB``.
+_DEFAULT_OVERLAY_MAX_MB = 10.0
+_DEFAULT_OVERLAY_MAX_FILES = 2000
+
+
+def _overlay_max_bytes() -> int:
+    """Overlay byte cap (``POCKETPAW_CODEPROJECT_OVERLAY_MAX_MB``).
+
+    Applied twice: as the per-file ceiling on a write (so one runaway file can
+    never land) and as the cumulative ceiling on the read-back (so the restore
+    payload stays bounded no matter how the overlay grew).
+    """
+    raw = os.environ.get("POCKETPAW_CODEPROJECT_OVERLAY_MAX_MB", "").strip()
+    mb = _DEFAULT_OVERLAY_MAX_MB
+    if raw:
+        try:
+            mb = float(raw)
+        except ValueError:
+            logger.warning(
+                "ignoring non-numeric POCKETPAW_CODEPROJECT_OVERLAY_MAX_MB=%r; using %s", raw, mb
+            )
+    return int(mb * 1024 * 1024)
+
+
+def _overlay_max_files() -> int:
+    """Overlay file-count cap (``POCKETPAW_CODEPROJECT_OVERLAY_MAX_FILES``)."""
+    raw = os.environ.get("POCKETPAW_CODEPROJECT_OVERLAY_MAX_FILES", "").strip()
+    count = _DEFAULT_OVERLAY_MAX_FILES
+    if raw:
+        try:
+            count = int(raw)
+        except ValueError:
+            logger.warning(
+                "ignoring non-numeric POCKETPAW_CODEPROJECT_OVERLAY_MAX_FILES=%r; using %s",
+                raw,
+                count,
+            )
+    return count
+
+
+def _require_safe_rel_path(rel_path: str) -> str:
+    """Normalize a client-supplied overlay path; reject anything that escapes.
+
+    The VM paths came out of the ``file.write`` jail; these come straight off the
+    wire, so the jail check moves to the write boundary. Leading slashes and
+    ``./`` segments are stripped (a client-side FS spells the same file both
+    ways, and the overlay key must be stable or a later delete won't match the
+    earlier write), while an empty path or any ``..`` traversal is a clean 422 —
+    the overlay key becomes a real path again on both restore paths
+    (``_overlay_abs_path`` in a VM, the client's FS in a tab).
+    """
+    candidate = (rel_path or "").strip().lstrip("/")
+    segments = [s for s in candidate.split("/") if s not in ("", ".")]
+    if not segments or any(s == ".." for s in segments):
+        raise ValidationError(
+            "codeproject.invalid_file_path",
+            f"{rel_path!r} is not a valid project-relative file path",
+        )
+    return "/".join(segments)
+
+
+async def put_project_file(
+    workspace_id: str,
+    user_id: str,
+    project_id: str,
+    rel_path: str,
+    content: str,
+    *,
+    uploads: Any = None,
+) -> tuple[str, str]:
+    """Persist one browser-written file; return ``(normalized path, FileRecord id)``.
+
+    The write half of the in-tab loop, and the counterpart of
+    ``mirror_file_to_project`` for a runtime whose filesystem the backend can't
+    read: the client hands us the text it just wrote to its in-tab FS and we
+    write it through to the tenant's blob storage + the project's overlay, so the
+    edit outlives the tab. Delegates to ``mirror_file_to_project`` so both
+    runtimes share ONE upload + pointer path (and therefore one S3 fail-closed
+    guard, one blob folder, one last-write-wins rule per path) — the only things
+    added here are the wire-facing concerns: path jailing and a size ceiling.
+
+    Text only, because the transport is a JSON string (the in-tab FS deals in
+    source files). Encoded UTF-8 so the read-back is byte-identical.
+    """
+    _require_s3_for_project_store()  # fail closed before validating or uploading
+    safe_path = _require_safe_rel_path(rel_path)
+    data = content.encode("utf-8")
+
+    cap = _overlay_max_bytes()
+    if len(data) > cap:
+        raise CloudError(
+            413,
+            "codeproject.file_too_large",
+            f"{safe_path!r} is {len(data) / 1024 / 1024:.1f} MB, over the "
+            f"{cap / 1024 / 1024:.0f} MB per-file limit",
+        )
+
+    file_id = await mirror_file_to_project(
+        workspace_id, user_id, project_id, safe_path, data, uploads=uploads
+    )
+    return safe_path, file_id
+
+
+async def drop_project_file(
+    workspace_id: str,
+    user_id: str,
+    project_id: str,
+    rel_path: str,
+) -> str:
+    """Drop a browser-deleted file from the project overlay; return the dropped path.
+
+    Normalizes through the SAME ``_require_safe_rel_path`` as the write so the
+    key actually matches what the write stored — a delete that missed would leave
+    the file to reappear on the next restore, which is the exact bug this tier
+    exists to prevent. Delegates the pointer write to ``drop_project_overlay``
+    (and through it to the service, Rule 2). A directory path drops every child.
+    """
+    safe_path = _require_safe_rel_path(rel_path)
+    await drop_project_overlay(workspace_id, user_id, project_id, safe_path)
+    return safe_path
+
+
+async def read_project_overlay(
+    workspace_id: str,
+    user_id: str,
+    project_id: str,
+    *,
+    uploads: Any = None,
+) -> dict[str, str]:
+    """Read a project's whole overlay back as ``{relpath: content}``.
+
+    The restore payload for the in-tab runtime, and the counterpart of
+    ``restore_project``'s tier-2 replay: instead of writing each blob into a VM,
+    it returns them to the client, which re-materializes the scaffold baseline
+    and replays this map over it. Owner-scoped through ``get_project`` (a project
+    the caller doesn't own reads as ``NotFound`` before any blob is touched), and
+    each blob comes back through the same owner-scoped ``stream(...)`` path
+    ``_download_snapshot`` wraps — a foreign or vanished blob can't be read out
+    of this endpoint.
+
+    Both caps fail LOUD rather than truncating: a silently partial restore looks
+    like the user's files were deleted, which is worse than a 413 that says the
+    project outgrew the in-browser runtime. Individually unreadable entries (a
+    reaped blob, a non-UTF-8 file the JSON transport can't carry) are skipped
+    with a warning instead — one bad file must not sink the rest, the same rule
+    ``restore_project`` replays under.
+    """
+    project = await codeproject_service.get_project(workspace_id, user_id, project_id)
+    overlay = project.overlay or {}
+    if not overlay:
+        return {}
+
+    max_files = _overlay_max_files()
+    if len(overlay) > max_files:
+        raise CloudError(
+            413,
+            "codeproject.overlay_too_many_files",
+            f"Project holds {len(overlay)} persisted files, over the {max_files} file limit",
+        )
+
+    up = uploads if uploads is not None else build_uploads()
+    cap = _overlay_max_bytes()
+    total = 0
+    files: dict[str, str] = {}
+    for rel_path in sorted(overlay):
+        file_id = overlay[rel_path]
+        try:
+            data = await _download_snapshot(up, file_id, workspace_id=workspace_id, user_id=user_id)
+        except CloudError:
+            logger.warning(
+                "codeproject.read_overlay: unreadable blob for project=%s path=%r file=%s",
+                project_id,
+                rel_path,
+                file_id,
+            )
+            continue
+        total += len(data)
+        if total > cap:
+            raise CloudError(
+                413,
+                "codeproject.overlay_too_large",
+                f"Project files total over the {cap / 1024 / 1024:.0f} MB limit",
+            )
+        try:
+            files[rel_path] = data.decode("utf-8")
+        except UnicodeDecodeError:
+            logger.warning(
+                "codeproject.read_overlay: skipping non-UTF-8 entry for project=%s path=%r",
+                project_id,
+                rel_path,
+            )
+    logger.debug(
+        "codeproject.read_overlay: project=%s -> %d file(s), %d bytes",
+        project_id,
+        len(files),
+        total,
+    )
+    return files
+
+
 __all__ = [
     "build_uploads",
     "drop_overlay",
+    "drop_project_file",
     "drop_project_overlay",
     "mirror_file",
     "mirror_file_to_project",
     "move_overlay",
     "move_project_overlay",
+    "put_project_file",
+    "read_project_overlay",
     "restore_project",
     "restore_workspace",
     "snapshot_project",

--- a/ee/pocketpaw_ee/cloud/websandbox/durability.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/durability.py
@@ -79,11 +79,30 @@
 # read path ``restore_project`` uses, same ``_require_s3_for_project_store``
 # fail-closed guard on the write, same ``uploads=`` DI seam. ADDITIVE: nothing
 # above is touched.
+#
+# Changed 2026-07-25 (B4, feat/code-cross-runtime-restore): ``read_project_overlay``
+# is now TWO-TIER, closing a cross-runtime data-visibility bug. WHY: a project can
+# open in either runtime, but the two tiers were read asymmetrically — work done in
+# a Daytona VM ends up in ``snapshot_file_id`` (and ``set_project_snapshot`` CLEARS
+# the overlay, correctly, because the tar supersedes it), while the in-tab read-back
+# looked ONLY at ``overlay``. So Daytona → disconnect → reopen IN-TAB returned ``{}``
+# and the browser re-materialized the bare starter scaffold: the user's work looked
+# deleted while it sat safe in S3 inside a tarball no browser can read. The read-back
+# now composes the SAME two tiers ``restore_project`` replays into a VM — snapshot
+# tar expanded in memory as the baseline, overlay applied on top (freshest wins) —
+# so whatever either runtime saved is retrievable from either runtime. It is a READ
+# -side fix only: no write path and no snapshot semantics changed. Two concerns the
+# VM path doesn't have are handled here because the payload crosses a JSON wire into
+# a browser: regenerable trees (``node_modules``/``.git``/build output, which the tar
+# carries with no excludes) are filtered out, and tar members are treated as
+# UNTRUSTED — absolute/traversing names and non-regular entries (symlinks, hardlinks,
+# devices) are skipped rather than materialized.
 from __future__ import annotations
 
 import io
 import logging
 import os
+import tarfile
 from pathlib import Path
 from typing import Any
 
@@ -908,25 +927,170 @@ def _overlay_max_files() -> int:
     return count
 
 
-def _require_safe_rel_path(rel_path: str) -> str:
-    """Normalize a client-supplied overlay path; reject anything that escapes.
+def _normalize_rel_path(rel_path: str) -> str | None:
+    """Normalize a path to the overlay's relpath shape; ``None`` if it escapes.
 
-    The VM paths came out of the ``file.write`` jail; these come straight off the
-    wire, so the jail check moves to the write boundary. Leading slashes and
-    ``./`` segments are stripped (a client-side FS spells the same file both
-    ways, and the overlay key must be stable or a later delete won't match the
-    earlier write), while an empty path or any ``..`` traversal is a clean 422 —
-    the overlay key becomes a real path again on both restore paths
-    (``_overlay_abs_path`` in a VM, the client's FS in a tab).
+    ONE jail, two callers with different failure modes — the write boundary turns
+    ``None`` into a 422 (``_require_safe_rel_path``), the snapshot expander skips
+    the entry — so there is a single definition of "a safe project-relative path".
+    Leading slashes and ``./`` segments are stripped (a client-side FS spells the
+    same file both ways, and the overlay key must be stable or a later delete
+    won't match the earlier write); an empty path or any ``..`` traversal escapes.
     """
     candidate = (rel_path or "").strip().lstrip("/")
     segments = [s for s in candidate.split("/") if s not in ("", ".")]
     if not segments or any(s == ".." for s in segments):
+        return None
+    return "/".join(segments)
+
+
+def _require_safe_rel_path(rel_path: str) -> str:
+    """Normalize a client-supplied overlay path; reject anything that escapes.
+
+    The VM paths came out of the ``file.write`` jail; these come straight off the
+    wire, so the jail check moves to the write boundary. An empty path or any
+    ``..`` traversal is a clean 422 — the overlay key becomes a real path again on
+    both restore paths (``_overlay_abs_path`` in a VM, the client's FS in a tab).
+    """
+    safe = _normalize_rel_path(rel_path)
+    if safe is None:
         raise ValidationError(
             "codeproject.invalid_file_path",
             f"{rel_path!r} is not a valid project-relative file path",
         )
-    return "/".join(segments)
+    return safe
+
+
+# Path segments dropped when a snapshot tar is expanded for the BROWSER read-back.
+# ``snapshot_project`` tars the whole workspace with no excludes (right for a VM
+# restore, which wants a byte-identical tree), but every tree here is regenerable
+# or meaningless in a tab: ``npm install`` restores ``node_modules``, a build
+# restores ``dist``/``build``/``.next``/``.svelte-kit``, ``.turbo``/``.cache``/
+# ``coverage`` are derived artifacts, and ``.git`` is a binary object store the
+# in-tab runtime has no client for. They are also the bulk of the bytes — shipping
+# them through a JSON string map would be hundreds of MB the browser throws away.
+# Not applied to the VM restore path, which legitimately wants the whole tree.
+_SNAPSHOT_EXCLUDED_SEGMENTS = frozenset(
+    {
+        "node_modules",
+        ".git",
+        "dist",
+        "build",
+        ".next",
+        ".svelte-kit",
+        ".turbo",
+        ".cache",
+        "coverage",
+    }
+)
+
+
+def _is_excluded_snapshot_path(rel_path: str) -> bool:
+    """True when any segment of ``rel_path`` names a regenerable/irrelevant tree."""
+    return any(seg in _SNAPSHOT_EXCLUDED_SEGMENTS for seg in rel_path.split("/"))
+
+
+def _tar_member_rel_path(name: str) -> str | None:
+    """Jail a TAR member name into the overlay's relpath shape; ``None`` to skip.
+
+    A tar is untrusted input: it is expanded into the user's in-tab filesystem, so
+    a member that names an absolute path or climbs out of the workspace must never
+    become a write. Snapshot tars are built with ``-C <workdir> .``, so ordinary
+    members arrive as ``./src/app.ts`` and normalize to the same ``src/app.ts`` key
+    the overlay uses — which is what lets the two tiers merge by path at all.
+    Backslashes are rejected outright rather than normalized: they are not a path
+    separator here, so a ``..\\..\\x`` member would slip past the segment check.
+    """
+    raw = (name or "").strip()
+    if raw.startswith("/") or "\\" in raw:
+        return None
+    return _normalize_rel_path(raw)
+
+
+def _expand_snapshot_tar(data: bytes, *, project_id: str, cap: int) -> tuple[dict[str, str], int]:
+    """Expand a snapshot tarball in memory into ``({relpath: text}, total bytes)``.
+
+    The BASELINE tier of the browser read-back — the in-memory counterpart of
+    ``restore_project``'s ``tar -xzf`` into a VM. Written by ``tar -czf`` so the
+    blob is gzipped; ``r:*`` auto-detects anyway.
+
+    Three classes of member never make it into the payload:
+      * non-regular entries (directories, symlinks, hardlinks, devices) — a
+        directory carries no content and a link is a tar-smuggling vector with no
+        meaning in a browser FS;
+      * unsafe names (absolute or ``..``-traversing) and regenerable trees
+        (``_SNAPSHOT_EXCLUDED_SEGMENTS``);
+      * non-UTF-8 blobs — the transport is a JSON string map, so a binary file
+        can't be carried. Skipped with a warning rather than failing the whole
+        restore, mirroring how the overlay read-back tolerates one bad entry.
+
+    The byte cap is enforced from the member HEADER before anything is read, so a
+    huge (or zip-bomb) snapshot bounds memory instead of consuming it. Exceeding it
+    raises LOUD (413) — see ``read_project_overlay`` for why a truncated payload is
+    the one outcome to avoid.
+    """
+    files: dict[str, str] = {}
+    total = 0
+    skipped_unsafe = skipped_excluded = skipped_binary = 0
+    # A corrupt or truncated archive raises on open OR mid-iteration; both are the
+    # same failure — the baseline is unreadable — and both must be LOUD. Returning
+    # the overlay alone would look like a project that lost most of its files.
+    # ``EOFError``/``OSError`` join ``TarError`` because the decompressor, not
+    # tarfile, is what fails on a truncated gzip stream (``gzip.BadGzipFile`` is an
+    # OSError, a half-written blob raises EOFError).
+    try:
+        archive = tarfile.open(fileobj=io.BytesIO(data), mode="r:*")
+        with archive:
+            for member in archive:
+                if not member.isfile():
+                    continue
+                rel_path = _tar_member_rel_path(member.name)
+                if rel_path is None:
+                    skipped_unsafe += 1
+                    logger.warning(
+                        "codeproject.read_overlay: skipping unsafe snapshot entry for "
+                        "project=%s name=%r",
+                        project_id,
+                        member.name,
+                    )
+                    continue
+                if _is_excluded_snapshot_path(rel_path):
+                    skipped_excluded += 1
+                    continue
+                if total + member.size > cap:
+                    raise CloudError(
+                        413,
+                        "codeproject.overlay_too_large",
+                        f"Project files total over the {cap / 1024 / 1024:.0f} MB limit",
+                    )
+                handle = archive.extractfile(member)
+                blob = handle.read() if handle is not None else b""
+                try:
+                    files[rel_path] = blob.decode("utf-8")
+                except UnicodeDecodeError:
+                    skipped_binary += 1
+                    continue
+                total += len(blob)
+    except (tarfile.TarError, EOFError, OSError) as exc:
+        raise with_cause(
+            CloudError(
+                502,
+                "codeproject.snapshot_unreadable",
+                "The project's stored snapshot could not be read",
+            ),
+            exc,
+        ) from exc
+    logger.debug(
+        "codeproject.read_overlay: snapshot expanded for project=%s -> %d file(s), %d bytes "
+        "(skipped %d excluded, %d binary, %d unsafe)",
+        project_id,
+        len(files),
+        total,
+        skipped_excluded,
+        skipped_binary,
+        skipped_unsafe,
+    )
+    return files, total
 
 
 async def put_project_file(
@@ -997,27 +1161,44 @@ async def read_project_overlay(
     *,
     uploads: Any = None,
 ) -> dict[str, str]:
-    """Read a project's whole overlay back as ``{relpath: content}``.
+    """Read a project's whole durable state back as ``{relpath: content}``.
 
-    The restore payload for the in-tab runtime, and the counterpart of
-    ``restore_project``'s tier-2 replay: instead of writing each blob into a VM,
-    it returns them to the client, which re-materializes the scaffold baseline
-    and replays this map over it. Owner-scoped through ``get_project`` (a project
-    the caller doesn't own reads as ``NotFound`` before any blob is touched), and
-    each blob comes back through the same owner-scoped ``stream(...)`` path
-    ``_download_snapshot`` wraps — a foreign or vanished blob can't be read out
-    of this endpoint.
+    The restore payload for the in-tab runtime, and the read-side counterpart of
+    ``restore_project`` — which is exactly why it composes the SAME two tiers, in
+    the same order, instead of writing them into a VM:
+      1. ``snapshot_file_id`` — the full-workspace tarball a Daytona session wrote
+         on disconnect. Fetched from blob storage and expanded IN MEMORY as the
+         baseline, minus the trees a browser can't use (see
+         ``_expand_snapshot_tar``).
+      2. ``overlay`` — the per-file write-through tier, applied ON TOP so the
+         freshest bytes win, exactly as the VM replay orders them.
 
-    Both caps fail LOUD rather than truncating: a silently partial restore looks
-    like the user's files were deleted, which is worse than a 413 that says the
-    project outgrew the in-browser runtime. Individually unreadable entries (a
-    reaped blob, a non-UTF-8 file the JSON transport can't carry) are skipped
-    with a warning instead — one bad file must not sink the rest, the same rule
-    ``restore_project`` replays under.
+    Both tiers are read because a project is not bound to one runtime (B4). Reading
+    only the overlay meant a project last touched in DAYTONA came back empty here —
+    ``set_project_snapshot`` clears the overlay once its contents are inside the tar
+    — so reopening it in a tab re-materialized the bare scaffold and the user's work
+    looked deleted while it sat safe in S3. A project that never saw a VM has no
+    snapshot and this collapses to the overlay-only behaviour it always had.
+
+    Owner-scoped through ``get_project`` (a project the caller doesn't own reads as
+    ``NotFound`` before any blob is touched), and every blob — tar and overlay entry
+    alike — comes back through the same owner-scoped ``stream(...)`` path
+    ``_download_snapshot`` wraps, so a foreign or vanished blob can't be read out of
+    this endpoint.
+
+    Caps stay LOUD (413) rather than truncating, INCLUDING for the snapshot-derived
+    baseline: filtering already removed everything that isn't user work, so what is
+    left over the cap IS the user's project, and a silently partial restore looks
+    like their files were deleted. A 413 that says the project outgrew the in-browser
+    runtime is recoverable — it still opens in the VM runtime, whose restore has no
+    such cap. What IS dropped silently is only the non-user-work classes: excluded
+    trees, and individually unreadable/undecodable entries (a reaped blob, a binary
+    file the JSON transport can't carry), which are skipped with a warning so one bad
+    file doesn't sink the rest — the same rule ``restore_project`` replays under.
     """
     project = await codeproject_service.get_project(workspace_id, user_id, project_id)
     overlay = project.overlay or {}
-    if not overlay:
+    if not project.snapshot_file_id and not overlay:
         return {}
 
     max_files = _overlay_max_files()
@@ -1030,8 +1211,18 @@ async def read_project_overlay(
 
     up = uploads if uploads is not None else build_uploads()
     cap = _overlay_max_bytes()
-    total = 0
     files: dict[str, str] = {}
+    total = 0
+
+    # Tier 1 — the snapshot tar (baseline). A download or expansion failure raises:
+    # the baseline going missing is not "one bad file", it is most of the project.
+    if project.snapshot_file_id:
+        snapshot_bytes = await _download_snapshot(
+            up, project.snapshot_file_id, workspace_id=workspace_id, user_id=user_id
+        )
+        files, total = _expand_snapshot_tar(snapshot_bytes, project_id=project_id, cap=cap)
+
+    # Tier 2 — the overlay, applied on top (freshest wins).
     for rel_path in sorted(overlay):
         file_id = overlay[rel_path]
         try:
@@ -1044,26 +1235,39 @@ async def read_project_overlay(
                 file_id,
             )
             continue
-        total += len(data)
-        if total > cap:
-            raise CloudError(
-                413,
-                "codeproject.overlay_too_large",
-                f"Project files total over the {cap / 1024 / 1024:.0f} MB limit",
-            )
         try:
-            files[rel_path] = data.decode("utf-8")
+            text = data.decode("utf-8")
         except UnicodeDecodeError:
             logger.warning(
                 "codeproject.read_overlay: skipping non-UTF-8 entry for project=%s path=%r",
                 project_id,
                 rel_path,
             )
+            continue
+        # The baseline copy is superseded, so its bytes leave the budget with it —
+        # a file present in both tiers must not be counted twice against the cap.
+        superseded = len(files[rel_path].encode("utf-8")) if rel_path in files else 0
+        total += len(data) - superseded
+        if total > cap:
+            raise CloudError(
+                413,
+                "codeproject.overlay_too_large",
+                f"Project files total over the {cap / 1024 / 1024:.0f} MB limit",
+            )
+        files[rel_path] = text
+
+    if len(files) > max_files:
+        raise CloudError(
+            413,
+            "codeproject.overlay_too_many_files",
+            f"Project holds {len(files)} persisted files, over the {max_files} file limit",
+        )
     logger.debug(
-        "codeproject.read_overlay: project=%s -> %d file(s), %d bytes",
+        "codeproject.read_overlay: project=%s -> %d file(s), %d bytes (snapshot=%s)",
         project_id,
         len(files),
         total,
+        project.snapshot_file_id,
     )
     return files
 

--- a/ee/pocketpaw_ee/cloud/websandbox/durability.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/durability.py
@@ -49,6 +49,21 @@
 # Both take DI seams (``client=None`` → get_daytona_client, ``uploads=None`` →
 # a per-call EEUploadService) so tests inject fakes and never hit real Daytona
 # or S3.
+#
+# Changed 2026-07-24 (F, feat/code-durable-project-store): added the PROJECT-KEYED
+# sibling path — ``snapshot_project`` / ``restore_project`` / ``mirror_file_to_project``
+# / ``drop_project_overlay`` / ``move_project_overlay``. Same S3 vehicle, same VM
+# tar/untar mechanics, same DI seams; only the POINTER anchor differs — these
+# read/write the snapshot + overlay via ``codeproject/service`` (on the durable
+# CodeProject row) instead of ``websandbox/service`` (on the ephemeral WebSandbox
+# row), so a project's files round-trip through blob storage independent of any
+# runtime and independent of the WebSandbox row. The VM to snapshot/restore is
+# passed as an explicit Daytona ``sandbox_id`` (not resolved from a WebSandbox
+# row), the runtime-agnostic seam B2 will wire up. ADDITIVE: the sandbox-keyed
+# functions above are untouched. The project-keyed durable WRITE path
+# (``snapshot_project`` / ``mirror_file_to_project``) hard-requires S3 in cloud
+# via ``_require_s3_for_project_store`` — silent non-persistence to local disk is
+# worse than a loud 503.
 from __future__ import annotations
 
 import io
@@ -58,11 +73,21 @@ from pathlib import Path
 from typing import Any
 
 from pocketpaw_ee.cloud._core.errors import CloudError, ConflictError, with_cause
+from pocketpaw_ee.cloud.codeproject import service as codeproject_service
 from pocketpaw_ee.cloud.daytona.client import DaytonaClient, get_daytona_client
+from pocketpaw_ee.cloud.shared.db import is_multi_tenant_cloud
 from pocketpaw_ee.cloud.websandbox import service as websandbox_service
 from pocketpaw_ee.cloud.websandbox.constants import WEBSANDBOX_WORKDIR
 
 logger = logging.getLogger(__name__)
+
+# Blob-storage folders for the project-keyed durable store — grouped separately
+# from the sandbox-keyed ``/websandbox-*`` folders so a tenant's project
+# snapshots/overlay are distinguishable in their Files.
+_PROJECT_SNAPSHOT_FOLDER = "/code-project-snapshots"
+_PROJECT_OVERLAY_FOLDER = "/code-project-overlay"
+
+_TRUTHY = {"1", "true", "yes", "on"}
 
 # The in-VM staging path for the tarball (outside the workspace dir so it never
 # tars itself and a stale copy never re-enters a future snapshot).
@@ -476,11 +501,342 @@ async def move_overlay(
     await websandbox_service.move_overlay_entry(workspace_id, user_id, row_id, src_rel, dst_rel)
 
 
+# ===========================================================================
+# Project-keyed durable store (F, feat/code-durable-project-store).
+#
+# The durable half of the /code build-and-persist loop. Same S3 vehicle and VM
+# tar/untar as the sandbox-keyed path above; the ONLY difference is the pointer
+# anchor — snapshot + overlay live on the durable ``CodeProject`` row (via
+# ``codeproject/service``), so a project's files survive VM reaping and any
+# WebSandbox row. The VM is passed as an explicit Daytona ``sandbox_id`` rather
+# than resolved from a WebSandbox row, keeping this independent of the ephemeral
+# runtime row (B2 will wire the resolution). Tenancy is enforced by the
+# owner-scoped ``get_project`` (a project the caller doesn't own reads as
+# NotFound).
+# ===========================================================================
+
+
+def _require_s3_for_project_store() -> None:
+    """Hard-require S3-backed blob storage for the durable project store in cloud.
+
+    The ART-4 boot guard (``uploads/bootstrap.verify_cloud_storage_backend``) only
+    WARNs on a non-s3 adapter unless ``POCKETPAW_REQUIRE_S3_IN_CLOUD`` is set. For
+    the durable PROJECT store a warn is not enough: a project-keyed write that
+    lands on the box's local disk instead of the tenant's object store looks like
+    it persisted but is gone with the container — silent non-persistence, worse
+    than a loud failure. So the project-keyed durable WRITE path fails CLOSED —
+    a clean 503 ``CloudError`` (not a crash) — when running in cloud
+    (``is_multi_tenant_cloud()``, the same signal the jail and ART-4 guard read)
+    and ``POCKETPAW_UPLOAD_ADAPTER`` is not ``s3``.
+
+    No-op OFF multi-tenant cloud (OSS / dedicated installs never initialized the
+    cloud DB): there is no tenant object store to require, so local-disk uploads
+    are correct there and this must not raise.
+    """
+    if not is_multi_tenant_cloud():
+        return
+    adapter = os.environ.get("POCKETPAW_UPLOAD_ADAPTER", "local").strip().lower()
+    if adapter == "s3":
+        return
+    raise CloudError(
+        503,
+        "codeproject.durable_store_requires_s3",
+        "The durable project store requires S3-backed blob storage in cloud "
+        f"(POCKETPAW_UPLOAD_ADAPTER={adapter!r}, expected 's3'); a local adapter "
+        "writes project snapshots to the box's disk, which vanishes with the "
+        "container. Set POCKETPAW_UPLOAD_ADAPTER=s3 and the S3_* settings.",
+    )
+
+
+async def _upload_project_blob(
+    uploads: Any,
+    data: bytes,
+    *,
+    workspace_id: str,
+    user_id: str,
+    filename: str,
+    folder: str,
+    content_type: str,
+) -> str:
+    """Land bytes in the tenant's blob storage; return the FileRecord id.
+
+    The project-keyed analog of ``_upload_snapshot`` / ``mirror_file``'s inline
+    upload — a single wrapper both project write paths share, so the sandbox-keyed
+    helpers stay untouched. Wraps the bytes in a Starlette ``UploadFile`` (a dict
+    ``headers`` carrying the declared content-type is all ``UploadFile.content_type``
+    reads) and calls the workspace + owner-scoped ``upload`` (the ART-4 S3 path).
+    """
+    from fastapi import UploadFile
+
+    upload = UploadFile(
+        file=io.BytesIO(data),
+        filename=filename,
+        headers={"content-type": content_type},  # type: ignore[arg-type]
+    )
+    rec = await uploads.upload(
+        upload,
+        owner_id=user_id,
+        chat_id=None,
+        workspace=workspace_id,
+        folder_path=folder,
+    )
+    return rec.id
+
+
+async def snapshot_project(
+    workspace_id: str,
+    user_id: str,
+    project_id: str,
+    sandbox_id: str,
+    *,
+    client: DaytonaClient | None = None,
+    uploads: Any = None,
+) -> str:
+    """Snapshot a project's live VM workspace to blob storage; return the pointer.
+
+    Mirrors ``snapshot_workspace`` but anchors the pointer on the durable
+    ``CodeProject`` row. Resolves the project owner-scoped (``get_project`` raises
+    ``NotFound`` for a project the caller doesn't own), then ``tar -czf`` the
+    workspace dir in ``sandbox_id`` → ``download_file`` the tarball → size-cap →
+    upload to S3 (folder ``/code-project-snapshots``) → ``set_project_snapshot``
+    the returned FileRecord id (which also clears the overlay). Returns that id.
+
+    The ``sandbox_id`` is the live Daytona VM to snapshot, passed explicitly (not
+    resolved from a WebSandbox row) so this stays independent of the ephemeral
+    runtime row. Fails CLOSED on a non-s3 upload adapter in cloud before any VM
+    op. A tarball over the size cap raises a clean CloudError before any upload.
+    """
+    _require_s3_for_project_store()
+    daytona = _require_client(client)
+
+    # Owner-scoped tenancy gate: NotFound for a project the caller doesn't own.
+    await codeproject_service.get_project(workspace_id, user_id, project_id)
+
+    try:
+        await daytona.execute_command(
+            sandbox_id,
+            f"tar -czf {_SNAPSHOT_TMP} -C {WEBSANDBOX_WORKDIR} .",
+        )
+        data = await daytona.download_file(sandbox_id, _SNAPSHOT_TMP)
+    except Exception as exc:  # noqa: BLE001 — any VM-side failure is uniform
+        logger.warning(
+            "codeproject.snapshot: tar/download failed for project=%s", project_id, exc_info=True
+        )
+        raise with_cause(
+            CloudError(502, "codeproject.snapshot_failed", "Failed to snapshot the project"),
+            exc,
+        ) from exc
+
+    cap = _snapshot_max_bytes()
+    if len(data) > cap:
+        raise CloudError(
+            413,
+            "codeproject.snapshot_too_large",
+            f"Project snapshot is {len(data) / 1024 / 1024:.1f} MB, over the "
+            f"{cap / 1024 / 1024:.0f} MB limit",
+        )
+
+    up = uploads if uploads is not None else build_uploads()
+    file_id = await _upload_project_blob(
+        up,
+        data,
+        workspace_id=workspace_id,
+        user_id=user_id,
+        filename=f"code-project-snapshot-{project_id}.tgz",
+        folder=_PROJECT_SNAPSHOT_FOLDER,
+        content_type=_SNAPSHOT_MIME,
+    )
+    await codeproject_service.set_project_snapshot(workspace_id, user_id, project_id, file_id)
+    logger.info(
+        "codeproject.snapshot: project=%s daytona=%s -> file=%s (%d bytes)",
+        project_id,
+        sandbox_id,
+        file_id,
+        len(data),
+    )
+    return file_id
+
+
+async def restore_project(
+    workspace_id: str,
+    user_id: str,
+    project_id: str,
+    sandbox_id: str,
+    *,
+    client: DaytonaClient | None = None,
+    uploads: Any = None,
+) -> None:
+    """Restore a project's durable state into a (fresh) VM: snapshot then overlay.
+
+    Mirrors ``restore_workspace`` but reads the pointer off the durable
+    ``CodeProject`` row (via the owner-scoped ``get_project`` view — so it also
+    enforces tenancy). Applies the two tiers in order into ``sandbox_id``:
+      1. ``snapshot_file_id`` — the full-workspace tarball (baseline): fetched
+         from S3, ``upload_bytes`` into the VM, ``tar -xzf`` over the dir.
+      2. ``overlay`` — the write-through per-file tier (edits since the last
+         snapshot): each ``relpath -> FileRecord id`` is fetched and written over
+         the tree. Cleared whenever a snapshot is taken, so replay is always the
+         freshest source state, never a stale resurrection.
+
+    A project with NEITHER a snapshot nor an overlay is a clean 409 (nothing to
+    restore). No S3 guard here — restore is a READ path; the guard protects the
+    WRITE path so a project never silently persists to disk in the first place.
+    """
+    daytona = _require_client(client)
+
+    project = await codeproject_service.get_project(workspace_id, user_id, project_id)
+    overlay = project.overlay or {}
+    if not project.snapshot_file_id and not overlay:
+        raise ConflictError(
+            "codeproject.no_snapshot", "This project has no durable state to restore"
+        )
+
+    up = uploads if uploads is not None else build_uploads()
+
+    # Tier 1 — the full-workspace snapshot (baseline).
+    if project.snapshot_file_id:
+        data = await _download_snapshot(
+            up, project.snapshot_file_id, workspace_id=workspace_id, user_id=user_id
+        )
+        untar = f"mkdir -p {WEBSANDBOX_WORKDIR} && tar -xzf {_SNAPSHOT_TMP} -C {WEBSANDBOX_WORKDIR}"
+        try:
+            await daytona.upload_bytes(sandbox_id, data, _SNAPSHOT_TMP)
+            await daytona.execute_command(sandbox_id, untar)
+        except Exception as exc:  # noqa: BLE001 — any VM-side failure is uniform
+            logger.warning(
+                "codeproject.restore: snapshot untar failed for project=%s",
+                project_id,
+                exc_info=True,
+            )
+            raise with_cause(
+                CloudError(502, "codeproject.restore_failed", "Failed to restore the project"),
+                exc,
+            ) from exc
+        logger.info(
+            "codeproject.restore: project=%s daytona=%s <- snapshot=%s (%d bytes)",
+            project_id,
+            sandbox_id,
+            project.snapshot_file_id,
+            len(data),
+        )
+
+    # Tier 2 — replay the write-through overlay (freshest edits) over the tree.
+    replayed = 0
+    for rel_path, file_id in overlay.items():
+        abs_path = _overlay_abs_path(rel_path)
+        if abs_path is None:
+            logger.warning("codeproject.restore: skipping unsafe overlay path %r", rel_path)
+            continue
+        try:
+            file_bytes = await _download_snapshot(
+                up, file_id, workspace_id=workspace_id, user_id=user_id
+            )
+            parent = abs_path.rsplit("/", 1)[0]
+            await daytona.execute_command(sandbox_id, f"mkdir -p {parent}")
+            await daytona.upload_bytes(sandbox_id, file_bytes, abs_path)
+            replayed += 1
+        except Exception:  # noqa: BLE001 — one bad overlay file must not sink the rest
+            logger.warning(
+                "codeproject.restore: overlay replay failed for project=%s path=%r",
+                project_id,
+                rel_path,
+                exc_info=True,
+            )
+    if replayed:
+        logger.info(
+            "codeproject.restore: project=%s daytona=%s replayed %d overlay file(s)",
+            project_id,
+            sandbox_id,
+            replayed,
+        )
+
+
+async def mirror_file_to_project(
+    workspace_id: str,
+    user_id: str,
+    project_id: str,
+    rel_path: str,
+    data: bytes,
+    *,
+    uploads: Any = None,
+) -> str:
+    """Write-through one editor-saved file to blob storage; record the project overlay.
+
+    The project-keyed analog of ``mirror_file``: uploads the bytes to the tenant's
+    blob storage (folder ``/code-project-overlay``) and records ``rel_path ->
+    FileRecord id`` on the durable project via ``set_project_overlay_entry``.
+    Returns the FileRecord id. Fails CLOSED on a non-s3 upload adapter in cloud.
+    """
+    _require_s3_for_project_store()
+    up = uploads if uploads is not None else build_uploads()
+    basename = (rel_path or "file").rsplit("/", 1)[-1] or "file"
+    file_id = await _upload_project_blob(
+        up,
+        data,
+        workspace_id=workspace_id,
+        user_id=user_id,
+        filename=f"overlay-{project_id}-{basename}",
+        folder=_PROJECT_OVERLAY_FOLDER,
+        content_type="application/octet-stream",
+    )
+    await codeproject_service.set_project_overlay_entry(
+        workspace_id, user_id, project_id, rel_path, file_id
+    )
+    logger.debug(
+        "codeproject.mirror: project=%s path=%r -> file=%s (%d bytes)",
+        project_id,
+        rel_path,
+        file_id,
+        len(data),
+    )
+    return file_id
+
+
+async def drop_project_overlay(
+    workspace_id: str,
+    user_id: str,
+    project_id: str,
+    rel_path: str,
+) -> None:
+    """Drop the project overlay entry for a deleted file (delete-side sibling).
+
+    Delegates the doc write to the service (Rule 2). Dropping is always safe: the
+    file falls back to the snapshot tier on restore instead of being resurrected
+    from the overlay. A directory delete drops every child entry too.
+    """
+    await codeproject_service.drop_project_overlay_entry(
+        workspace_id, user_id, project_id, rel_path
+    )
+
+
+async def move_project_overlay(
+    workspace_id: str,
+    user_id: str,
+    project_id: str,
+    src_rel: str,
+    dst_rel: str,
+) -> None:
+    """Re-key the project overlay entry for a renamed file (move-side sibling).
+
+    Delegates the doc write to the service (Rule 2). The FileRecord id is
+    unchanged — only the overlay key moves — so restore replays the same durable
+    blob at the new path. A directory move re-keys every child entry too.
+    """
+    await codeproject_service.move_project_overlay_entry(
+        workspace_id, user_id, project_id, src_rel, dst_rel
+    )
+
+
 __all__ = [
     "build_uploads",
     "drop_overlay",
+    "drop_project_overlay",
     "mirror_file",
+    "mirror_file_to_project",
     "move_overlay",
+    "move_project_overlay",
+    "restore_project",
     "restore_workspace",
+    "snapshot_project",
     "snapshot_workspace",
 ]

--- a/ee/pocketpaw_ee/cloud/websandbox/provision.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/provision.py
@@ -35,12 +35,28 @@
 # Every provisioning fn takes ``client: DaytonaClient | None = None`` (default
 # ``get_daytona_client()``) — the mandatory DI seam so tests inject a FAKE client
 # and no test ever hits real Daytona.
+#
+# 2026-07-25 (B3, feat/code-scaffold-on-vm): the open flow split in two. The
+# shared half — quota, the idempotent registry row, cold-provision, boot wait,
+# the ready/rebind write, old-VM teardown — moved into ``_provision_into_row``;
+# what differs is only what gets put INTO the booted VM. ``open_sandbox`` keeps
+# the git clone (and keeps ``_validate_repo_url`` on it, unconditionally);
+# ``open_bare_sandbox`` adds an EMPTY VM with no clone, no git remote, and no
+# edit branch, for a scaffold project whose "repo" is a starter TEMPLATE id.
+#
+# The split exists so ``_validate_repo_url`` never has to be loosened. A template
+# id ("react") is not a URL and never will be; the fix is to keep it off the
+# clone path entirely rather than to teach the validator a second, weaker shape.
+# That validator is a security control — it is what stops a local-path remote or
+# a client-supplied credential reaching the VM's git config (and its snapshots) —
+# so anything that would relax it for a non-git caller is the wrong direction.
 from __future__ import annotations
 
 import asyncio
 import contextlib
 import logging
 import os
+from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime, timedelta
 from urllib.parse import urlparse
 from uuid import uuid4
@@ -196,6 +212,33 @@ def _validate_repo_url(repo: str) -> str:
     return candidate
 
 
+# The registry key's own bound. It is stored in ``WebSandbox.repo``, whose write
+# command (``CreateSandboxRequest.repo``) caps at 1024 — checking it here turns a
+# too-long key into a clean 400 instead of a pydantic error from two layers down.
+_MAX_REGISTRY_KEY = 1024
+
+
+def _validate_registry_key(key: str) -> str:
+    """Validate a NON-git registry key (the row's ``repo`` slot), returning it.
+
+    Deliberately NOT ``_validate_repo_url``. A bare VM clones nothing, so this
+    string is only ever a registry key — the (workspace, user, key) tuple that
+    makes ``create_sandbox`` idempotent. There is no URL to parse, no remote to
+    write, and no credential that could ride along, so the URL rules would be
+    both wrong and unenforceable here.
+
+    That is also why this is not a public write surface: no router binds it. The
+    only caller is the scaffold open path, which builds the key server-side from a
+    project it has already tenant-checked.
+    """
+    candidate = (key or "").strip()
+    if not candidate:
+        raise BadRequest("websandbox.invalid_key", "A workspace key is required")
+    if len(candidate) > _MAX_REGISTRY_KEY:
+        raise BadRequest("websandbox.invalid_key", "Workspace key is too long")
+    return candidate
+
+
 def _require_client(client: DaytonaClient | None) -> DaytonaClient:
     """Resolve the Daytona client, raising a clean CloudError when unconfigured.
 
@@ -217,6 +260,11 @@ def _require_client(client: DaytonaClient | None) -> DaytonaClient:
 # open flow.
 # ---------------------------------------------------------------------------
 
+#: What puts CONTENT into a freshly-booted, empty VM, called once with
+#: ``(daytona, daytona_id, project_dir)`` after the boot wait and the workdir
+#: mkdir. ``open_sandbox`` passes the git clone; a bare open passes nothing.
+_FillStage = Callable[[DaytonaClient, str, str], Awaitable[None]]
+
 
 async def open_sandbox(
     workspace_id: str,
@@ -236,9 +284,129 @@ async def open_sandbox(
     On any failure after the row exists, the row is advanced to ``stopped`` and a
     ``CloudError`` is raised (never left stuck in ``opening``); a VM created before
     the failure is best-effort stopped+deleted so a crash can't leak a live VM.
+
+    ``_validate_repo_url`` runs here, on EVERY clone, before anything is
+    provisioned. The bare path (``open_bare_sandbox``) exists precisely so that
+    stays true — a caller with no repo takes a different door instead of asking
+    this one to accept a weaker string.
     """
     body = OpenSandboxRequest.model_validate(body)
     repo_url = _validate_repo_url(body.repo)
+    # WC-5a: the repo is checked out onto a fresh branch in the VM so AI edits
+    # never touch the default branch. Minted before the fill stage so the same
+    # name reaches both the checkout and the row's ``branch`` binding.
+    branch = _new_edit_branch()
+
+    async def _clone_into(daytona: DaytonaClient, daytona_id: str, project_dir: str) -> None:
+        """Clone the repo, branch it, and (when brokered) wire the push remote."""
+        # CM-3c: if the caller has a GitHub connection whose installation can reach
+        # this repo, clone it via the BROKER — the token is minted + used entirely
+        # server-side and NEVER enters the VM (the VM receives files + a token-free
+        # git remote). Otherwise, clone the PUBLIC repo in-VM with NO credentials.
+        scoped = await websandbox_broker.resolve_repo_token(workspace_id, user_id, repo_url)
+        if scoped is not None:
+            await websandbox_broker.clone_into_vm(
+                daytona,
+                daytona_id,
+                scoped,
+                project_dir,
+                clean_url=repo_url,
+                branch=body.branch,
+            )
+        else:
+            await daytona.git_clone(daytona_id, repo_url, project_dir, branch=body.branch)
+
+        # Check out a fresh ``paw/edit-<hex>`` branch IN the VM (WC-5a) so every AI
+        # edit lands on an isolated branch, never the checked-out default. cwd is
+        # the pinned workspace dir where the repo was cloned.
+        await daytona.execute_command(
+            daytona_id,
+            f"git checkout -b {branch}",
+            cwd=project_dir,
+            timeout=_BRANCH_CHECKOUT_TIMEOUT_SECONDS,
+        )
+
+        # CM-3d: for a broker-cloned (connected) repo, repoint ``origin`` at the
+        # git proxy so an in-VM ``git push``/``fetch`` works with the token still
+        # minted server-side (never in the VM). Best-effort — a wiring miss leaves
+        # the clone fully usable, it just can't push yet; it must never fail the
+        # open. Skipped for public clones (no connection to push through) and when
+        # no public backend URL is reachable from the VM.
+        if scoped is not None:
+            with contextlib.suppress(Exception):
+                await codegit_wire.wire_push_remote(
+                    daytona,
+                    daytona_id,
+                    workspace_id,
+                    user_id,
+                    websandbox_broker.repo_full_name(repo_url) or repo_url,
+                    project_dir,
+                )
+
+    return await _provision_into_row(
+        workspace_id,
+        user_id,
+        repo_url,
+        branch=branch,
+        fill=_clone_into,
+        client=client,
+    )
+
+
+async def open_bare_sandbox(
+    workspace_id: str,
+    user_id: str,
+    key: str,
+    client: DaytonaClient | None = None,
+) -> WebSandboxView:
+    """Cold-provision an EMPTY Daytona VM — no clone, no git remote, no branch.
+
+    The scaffold half of the open flow (B3). A scaffold project's ``repo`` field
+    holds a starter TEMPLATE id, not a URL, so there is nothing to clone and no
+    remote to authenticate: the VM boots empty and the caller materializes the
+    starter into it (``websandbox.scaffold_service.scaffold_into_sandbox``).
+
+    Everything else is identical to ``open_sandbox`` — the same per-user quota,
+    the same idempotent (workspace, user, key) row, the same failure handling, the
+    same old-VM teardown on a re-open. ``key`` is the row's registry key only; it
+    is server-built by the caller and never reaches git, a URL builder, or a
+    shell (see ``_validate_registry_key``).
+
+    Returns the ready view with a bound Daytona id and NO ``branch`` — a VM with
+    no repository has no branch to report, and inventing one would make the git
+    surface look available on a project that has no git.
+    """
+    return await _provision_into_row(
+        workspace_id,
+        user_id,
+        _validate_registry_key(key),
+        branch=None,
+        fill=None,
+        client=client,
+    )
+
+
+async def _provision_into_row(
+    workspace_id: str,
+    user_id: str,
+    registry_key: str,
+    *,
+    branch: str | None,
+    fill: _FillStage | None,
+    client: DaytonaClient | None,
+) -> WebSandboxView:
+    """Cold-provision a VM into the (workspace, user, ``registry_key``) row.
+
+    The half both open paths share: quota + re-open bookkeeping, the idempotent
+    registry row, the cold-provision with the aggressive Daytona lifecycle, the
+    boot wait, the ``ready`` rebind, and the old-VM teardown. ``fill`` is the only
+    difference between them — what (if anything) gets put into the booted VM.
+
+    ``registry_key`` is ALREADY validated by the caller: ``open_sandbox`` runs the
+    fail-closed ``_validate_repo_url`` on it, the bare path runs
+    ``_validate_registry_key``. This function never relaxes either — it does not
+    inspect the key at all, it only stores it.
+    """
     daytona = _require_client(client)
 
     # Quota + re-open bookkeeping — read the caller's OWN rows once (tenant- and
@@ -246,7 +414,7 @@ async def open_sandbox(
     # row (not a new slot); opening a NEW repo past the per-user live cap is
     # rejected cleanly rather than cold-booting an unbounded number of VMs.
     owned = await websandbox_service.list_sandboxes(workspace_id, user_id)
-    existing = next((r for r in owned if r.repo == repo_url), None)
+    existing = next((r for r in owned if r.repo == registry_key), None)
     old_sandbox_id = existing.sandbox_id if existing is not None else None
     cap = _max_per_user()
     if cap and existing is None:
@@ -260,12 +428,11 @@ async def open_sandbox(
     # 1. Upsert the registry row (idempotent on workspace+user+repo) and move it
     #    to ``opening`` so a concurrent reader sees the in-flight state.
     row = await websandbox_service.create_sandbox(
-        workspace_id, user_id, {"repo": repo_url, "status": "pending"}
+        workspace_id, user_id, {"repo": registry_key, "status": "pending"}
     )
     await websandbox_service.update_status(workspace_id, user_id, row.id, {"status": "opening"})
 
     daytona_id: str | None = None
-    branch = _new_edit_branch()
     try:
         # 2. Cold-provision with the aggressive Daytona lifecycle (all MINUTES):
         #    stop after 5 idle, archive 5 after stop, delete immediately on stop.
@@ -288,62 +455,22 @@ async def open_sandbox(
         )
         daytona_id = info.id
 
-        # 3. Block until the VM is booted before cloning.
+        # 3. Block until the VM is booted before filling it.
         await daytona.wait_for_sandbox(
             daytona_id, target_state="started", timeout=_BOOT_TIMEOUT_SECONDS
         )
 
-        # 4. Clone the repo into the sandbox's project dir.
-        # Clone INTO the pinned workspace dir (WEBSANDBOX_WORKDIR = /home/daytona)
-        # so the file tree, the terminal cwd, and the clone all agree on one
-        # directory. get_project_dir() returns /root on this image, which the
+        # 4. Fill the sandbox's project dir (a clone, or nothing for a bare VM).
+        # The dir is the pinned workspace dir (WEBSANDBOX_WORKDIR = /home/daytona)
+        # so the file tree, the terminal cwd, and whatever lands here all agree on
+        # one directory. get_project_dir() returns /root on this image, which the
         # terminal never opens in — that mismatch is why the tree looked empty.
-        #
-        # CM-3c: if the caller has a GitHub connection whose installation can reach
-        # this repo, clone it via the BROKER — the token is minted + used entirely
-        # server-side and NEVER enters the VM (the VM receives files + a token-free
-        # git remote). Otherwise, clone the PUBLIC repo in-VM with NO credentials.
+        # It is created even on the bare path: the scaffold materializes into it,
+        # and the file tree lists it.
         project_dir = WEBSANDBOX_WORKDIR
         await daytona.execute_command(daytona_id, f"mkdir -p {project_dir}")
-        scoped = await websandbox_broker.resolve_repo_token(workspace_id, user_id, repo_url)
-        if scoped is not None:
-            await websandbox_broker.clone_into_vm(
-                daytona,
-                daytona_id,
-                scoped,
-                project_dir,
-                clean_url=repo_url,
-                branch=body.branch,
-            )
-        else:
-            await daytona.git_clone(daytona_id, repo_url, project_dir, branch=body.branch)
-
-        # 4b. Check out a fresh ``paw/edit-<hex>`` branch IN the VM (WC-5a) so
-        #     every AI edit lands on an isolated branch, never the checked-out
-        #     default. cwd is the pinned workspace dir where the repo was cloned.
-        await daytona.execute_command(
-            daytona_id,
-            f"git checkout -b {branch}",
-            cwd=project_dir,
-            timeout=_BRANCH_CHECKOUT_TIMEOUT_SECONDS,
-        )
-
-        # 4c. CM-3d: for a broker-cloned (connected) repo, repoint ``origin`` at
-        #     the git proxy so an in-VM ``git push``/``fetch`` works with the token
-        #     still minted server-side (never in the VM). Best-effort — a wiring
-        #     miss leaves the clone fully usable, it just can't push yet; it must
-        #     never fail the open. Skipped for public clones (no connection to push
-        #     through) and when no public backend URL is reachable from the VM.
-        if scoped is not None:
-            with contextlib.suppress(Exception):
-                await codegit_wire.wire_push_remote(
-                    daytona,
-                    daytona_id,
-                    workspace_id,
-                    user_id,
-                    websandbox_broker.repo_full_name(repo_url) or repo_url,
-                    project_dir,
-                )
+        if fill is not None:
+            await fill(daytona, daytona_id, project_dir)
     except Exception as exc:  # noqa: BLE001 — any provisioning failure is handled uniformly
         # Best-effort teardown of a half-created VM so a failure can't leak it.
         if daytona_id is not None:
@@ -354,13 +481,17 @@ async def open_sandbox(
             await websandbox_service.update_status(
                 workspace_id, user_id, row.id, {"status": "stopped"}
             )
-        logger.warning("websandbox.open failed for repo=%s row=%s", repo_url, row.id, exc_info=True)
+        logger.warning(
+            "websandbox.open failed for key=%s row=%s", registry_key, row.id, exc_info=True
+        )
         raise with_cause(
             CloudError(502, "websandbox.provision_failed", "Failed to provision the sandbox"),
             exc,
         ) from exc
 
     # 5. Bind the Daytona id + the auto-created feature branch, and mark ready.
+    #    ``branch`` is None on the bare path and ``update_status`` skips a None,
+    #    so a bare VM's row simply carries no branch.
     ready = await websandbox_service.update_status(
         workspace_id,
         user_id,
@@ -377,11 +508,12 @@ async def open_sandbox(
         with contextlib.suppress(Exception):
             await daytona.delete_sandbox(old_sandbox_id)
     logger.info(
-        "websandbox.open ready: row=%s daytona=%s branch=%s repo=%s",
+        "websandbox.open ready: row=%s daytona=%s branch=%s key=%s filled=%s",
         row.id,
         daytona_id,
         branch,
-        repo_url,
+        registry_key,
+        fill is not None,
     )
     return ready
 
@@ -533,6 +665,7 @@ async def stop_websandbox_reaper(app: FastAPI) -> None:
 
 __all__ = [
     "get_tree",
+    "open_bare_sandbox",
     "open_sandbox",
     "reap_idle_sandboxes",
     "start_websandbox_reaper",

--- a/ee/pocketpaw_ee/cloud/websandbox/ws.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/ws.py
@@ -74,6 +74,15 @@
 # user's edits is a far worse failure than writing them to the older anchor. The
 # anchor choice is made once, in ``build_durability_hooks``, so it is a single
 # testable decision rather than three copies of the same branch.
+#
+# 2026-07-25 (B4, feat/code-cross-runtime-restore): a FAILED durable write is no
+# longer invisible. The hooks are wrapped in ``_visible_durability`` and the
+# disconnect snapshot logs at WARNING instead of debug. WHY: the project store fails
+# CLOSED on a cloud whose ``POCKETPAW_UPLOAD_ADAPTER`` isn't ``s3``, and both the
+# per-file hooks (via ``FileRpc``) and the disconnect snapshot swallow that — so a
+# misconfigured deploy persisted NOTHING while every save reported ok, with the only
+# trace at debug. Still swallowed (a durability hiccup must not break a file write
+# that already landed); just diagnosable now, with the anchor and path in the line.
 from __future__ import annotations
 
 import asyncio
@@ -190,6 +199,35 @@ async def resolve_owning_project(workspace_id: str, user_id: str, row_id: str) -
     return project.id if project is not None else None
 
 
+def _visible_durability(op: str, anchor: str, hook: Any) -> Any:
+    """Wrap a durability hook so a failure is swallowed but never INVISIBLE (B4).
+
+    ``FileRpc`` already swallows a hook failure at DEBUG, which is right about the
+    swallowing (a durability hiccup must not turn a landed file write into a client
+    error) and wrong about the level. The project store fails CLOSED on a
+    misconfigured cloud (``POCKETPAW_UPLOAD_ADAPTER != s3`` → a 503 from
+    ``_require_s3_for_project_store``), so EVERY save on such a deploy raises here:
+    the user's edits are not persisted anywhere and the only trace is a debug line
+    nobody has enabled. Logging at WARNING with the anchor (durable project, or the
+    sandbox row when degraded) and the path makes that diagnosable from ordinary
+    production logs. Swallowing is unchanged.
+    """
+
+    async def _wrapped(*args: Any) -> None:
+        try:
+            await hook(*args)
+        except Exception:  # noqa: BLE001 — durability is best-effort; the file op landed
+            logger.warning(
+                "websandbox.durability: %s failed for %s path=%r — the edit is NOT persisted",
+                op,
+                anchor,
+                args[0] if args else "?",
+                exc_info=True,
+            )
+
+    return _wrapped
+
+
 def build_durability_hooks(
     workspace_id: str,
     user_id: str,
@@ -209,9 +247,12 @@ def build_durability_hooks(
     ``None`` (a sandbox opened outside the project flow) the hooks keep the
     original sandbox-keyed behaviour: degrade, never drop the write.
 
-    All three are best-effort at the call site — ``FileRpc`` swallows a hook
-    failure so durability never fails the file op itself.
+    All three are best-effort — a durability failure must never fail the file op
+    itself — but they are wrapped in ``_visible_durability`` so the failure is
+    LOGGED AT WARNING with its anchor and path instead of vanishing into debug.
     """
+    anchor = f"project={project_id}" if project_id else f"sandbox_row={row_id}"
+
     if project_id:
 
         async def _mirror(rel_path: str, data: bytes) -> None:
@@ -229,7 +270,11 @@ def build_durability_hooks(
                 workspace_id, user_id, project_id, src_rel, dst_rel
             )
 
-        return _mirror, _drop, _move
+        return (
+            _visible_durability("write-through mirror", anchor, _mirror),
+            _visible_durability("overlay drop", anchor, _drop),
+            _visible_durability("overlay re-key", anchor, _move),
+        )
 
     async def _mirror_row(rel_path: str, data: bytes) -> None:
         await websandbox_durability.mirror_file(
@@ -246,7 +291,11 @@ def build_durability_hooks(
         # restore replays the file where it now lives (WC-4c).
         await websandbox_durability.move_overlay(workspace_id, user_id, row_id, src_rel, dst_rel)
 
-    return _mirror_row, _drop_row, _move_row
+    return (
+        _visible_durability("write-through mirror", anchor, _mirror_row),
+        _visible_durability("overlay drop", anchor, _drop_row),
+        _visible_durability("overlay re-key", anchor, _move_row),
+    )
 
 
 async def snapshot_on_disconnect(
@@ -274,8 +323,10 @@ async def snapshot_on_disconnect(
     back to the sandbox-keyed snapshot rather than skipping the capture.
 
     Best-effort by design: a snapshot failure (VM already gone, S3 down, an
-    unprovisioned row) must NEVER surface on socket teardown — it is logged at
-    debug and swallowed.
+    unprovisioned row) must NEVER surface on socket teardown — it is swallowed. It
+    is logged at WARNING though (B4): this is the capture that makes a whole
+    session's work durable, so losing it silently is indistinguishable from data
+    loss on the next open.
     """
     try:
         if project_id and daytona_id:
@@ -287,10 +338,12 @@ async def snapshot_on_disconnect(
                 workspace_id, user_id, row_id, client=client
             )
     except Exception:  # noqa: BLE001 — teardown must never raise on a snapshot miss
-        logger.debug(
-            "websandbox.snapshot on disconnect failed for row=%s project=%s",
+        logger.warning(
+            "websandbox.snapshot on disconnect failed for row=%s project=%s daytona=%s — "
+            "this session's workspace was NOT captured",
             row_id,
             project_id,
+            daytona_id,
             exc_info=True,
         )
 

--- a/ee/pocketpaw_ee/cloud/websandbox/ws.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/ws.py
@@ -58,6 +58,22 @@
 # ``_drop`` (on_delete → overlay drop), ``_move`` (on_move → overlay re-key) — so
 # a create/save is mirrored, a delete isn't resurrected, and a rename replays at
 # its new path on restore.
+#
+# 2026-07-25 (B2, feat/code-daytona-project-anchor): those durability hooks — and
+# the disconnect snapshot — now target the DURABLE PROJECT instead of the ephemeral
+# sandbox row. The row is unique per (workspace, user, repo), and a scaffold project
+# puts a TEMPLATE id in ``repo``, so N projects from one starter shared a single row
+# and would have overwritten each other's snapshot + overlay. The socket only knows
+# its row, so it resolves the owning project once at connect time
+# (``codeproject_service.find_project_for_sandbox``) and routes every durability
+# write through the project id from then on.
+#
+# The socket DEGRADES rather than dropping writes: a sandbox opened outside the
+# project flow (the plain ``/websandbox`` REST surface) has no owning project, so
+# the hooks fall back to the sandbox-keyed functions exactly as before. Losing a
+# user's edits is a far worse failure than writing them to the older anchor. The
+# anchor choice is made once, in ``build_durability_hooks``, so it is a single
+# testable decision rather than three copies of the same branch.
 from __future__ import annotations
 
 import asyncio
@@ -65,12 +81,15 @@ import json
 import logging
 import time
 import uuid
+from collections.abc import Awaitable, Callable
+from typing import Any
 
 from fastapi import Query, WebSocket, WebSocketDisconnect
 
 from pocketpaw_ee.cloud._core.errors import CloudError
 from pocketpaw_ee.cloud.auth import service as auth_service
 from pocketpaw_ee.cloud.auth.ws_tickets import consume_ws_ticket
+from pocketpaw_ee.cloud.codeproject import service as codeproject_service
 from pocketpaw_ee.cloud.daytona.client import DaytonaClient, get_daytona_client
 from pocketpaw_ee.cloud.license import get_license
 from pocketpaw_ee.cloud.websandbox import durability as websandbox_durability
@@ -146,13 +165,100 @@ class TerminalConnectionManager:
 manager = TerminalConnectionManager()
 
 
+async def resolve_owning_project(workspace_id: str, user_id: str, row_id: str) -> str | None:
+    """The durable project this sandbox row belongs to, or ``None`` (B2).
+
+    The socket is opened against a WebSandbox ROW, but durable state is anchored on
+    the PROJECT, so the anchor has to be resolved once at connect time. ``None``
+    means "no owning project" — a sandbox opened straight off the ``/websandbox``
+    REST surface — and the caller degrades to the sandbox-keyed path.
+
+    A lookup FAILURE also resolves to ``None`` on purpose: degrading to the older
+    anchor still persists the user's edits somewhere, whereas propagating the error
+    would refuse the socket over a durability detail.
+    """
+    try:
+        project = await codeproject_service.find_project_for_sandbox(workspace_id, user_id, row_id)
+    except Exception:  # noqa: BLE001 — a resolution miss degrades, never denies
+        logger.warning(
+            "websandbox.ws: owning-project lookup failed for row=%s; "
+            "falling back to sandbox-keyed durability",
+            row_id,
+            exc_info=True,
+        )
+        return None
+    return project.id if project is not None else None
+
+
+def build_durability_hooks(
+    workspace_id: str,
+    user_id: str,
+    row_id: str,
+    project_id: str | None,
+    uploads: Any,
+) -> tuple[
+    Callable[[str, bytes], Awaitable[None]],
+    Callable[[str], Awaitable[None]],
+    Callable[[str, str], Awaitable[None]],
+]:
+    """Build the (on_write, on_delete, on_move) FileRpc durability hooks (B2).
+
+    ONE place decides the anchor. With a ``project_id`` every editor save, delete,
+    and rename is written through against the durable project — the fix for N
+    projects on one starter template sharing a single repo-keyed sandbox row. With
+    ``None`` (a sandbox opened outside the project flow) the hooks keep the
+    original sandbox-keyed behaviour: degrade, never drop the write.
+
+    All three are best-effort at the call site — ``FileRpc`` swallows a hook
+    failure so durability never fails the file op itself.
+    """
+    if project_id:
+
+        async def _mirror(rel_path: str, data: bytes) -> None:
+            await websandbox_durability.mirror_file_to_project(
+                workspace_id, user_id, project_id, rel_path, data, uploads=uploads
+            )
+
+        async def _drop(rel_path: str) -> None:
+            await websandbox_durability.drop_project_overlay(
+                workspace_id, user_id, project_id, rel_path
+            )
+
+        async def _move(src_rel: str, dst_rel: str) -> None:
+            await websandbox_durability.move_project_overlay(
+                workspace_id, user_id, project_id, src_rel, dst_rel
+            )
+
+        return _mirror, _drop, _move
+
+    async def _mirror_row(rel_path: str, data: bytes) -> None:
+        await websandbox_durability.mirror_file(
+            workspace_id, user_id, row_id, rel_path, data, uploads=uploads
+        )
+
+    async def _drop_row(rel_path: str) -> None:
+        # Delete-side durability: drop the overlay entry so a deleted file is not
+        # resurrected on restore (WC-4c).
+        await websandbox_durability.drop_overlay(workspace_id, user_id, row_id, rel_path)
+
+    async def _move_row(src_rel: str, dst_rel: str) -> None:
+        # Rename-side durability: re-key the overlay entry to the new path so
+        # restore replays the file where it now lives (WC-4c).
+        await websandbox_durability.move_overlay(workspace_id, user_id, row_id, src_rel, dst_rel)
+
+    return _mirror_row, _drop_row, _move_row
+
+
 async def snapshot_on_disconnect(
     workspace_id: str,
     user_id: str,
     row_id: str,
     client: DaytonaClient | None,
+    *,
+    project_id: str | None = None,
+    daytona_id: str | None = None,
 ) -> None:
-    """Best-effort workspace snapshot when a terminal socket closes (CM-2a′).
+    """Best-effort workspace snapshot when a terminal socket closes (CM-2a′, B2).
 
     The durable half of Code Mode is the S3 snapshot; the Daytona VM is pure
     scratch. With the aggressive Daytona lifecycle (stop 5 / delete-on-stop), a
@@ -161,15 +267,32 @@ async def snapshot_on_disconnect(
     still alive. ``codeproject.lifecycle.open_project`` restores the latest
     snapshot on the next open.
 
+    The pointer lands on the durable PROJECT when the socket resolved one, keyed by
+    ``project_id`` and taken from the live VM ``daytona_id`` (the project-keyed
+    snapshot addresses the VM directly rather than through the row). Without both —
+    a sandbox opened outside the project flow, or a row with no bound VM — it falls
+    back to the sandbox-keyed snapshot rather than skipping the capture.
+
     Best-effort by design: a snapshot failure (VM already gone, S3 down, an
     unprovisioned row) must NEVER surface on socket teardown — it is logged at
-    debug and swallowed. The snapshot pointer lands on the stable WebSandbox row,
-    which survives the VM's reaping.
+    debug and swallowed.
     """
     try:
-        await websandbox_durability.snapshot_workspace(workspace_id, user_id, row_id, client=client)
+        if project_id and daytona_id:
+            await websandbox_durability.snapshot_project(
+                workspace_id, user_id, project_id, daytona_id, client=client
+            )
+        else:
+            await websandbox_durability.snapshot_workspace(
+                workspace_id, user_id, row_id, client=client
+            )
     except Exception:  # noqa: BLE001 — teardown must never raise on a snapshot miss
-        logger.debug("websandbox.snapshot on disconnect failed for row=%s", row_id, exc_info=True)
+        logger.debug(
+            "websandbox.snapshot on disconnect failed for row=%s project=%s",
+            row_id,
+            project_id,
+            exc_info=True,
+        )
 
 
 async def terminal_websocket_endpoint(
@@ -261,6 +384,11 @@ async def terminal_websocket_endpoint(
         await websocket.close(code=_CLOSE_LICENSE, reason="Sandbox runtime unavailable")
         return
 
+    # B2: resolve the DURABLE anchor once, now that the row is owner-authorized.
+    # Every durability write below (mirror / drop / move / disconnect snapshot)
+    # targets this project id; ``None`` degrades to the sandbox-keyed path.
+    project_id = await resolve_owning_project(workspace_id, user_id, row_id)
+
     # Every gate passed — accept the socket (unless Path 3 already did) and open
     # the PTY. ``accepted`` keeps accept() exactly-once across both paths.
     if not accepted:
@@ -288,26 +416,15 @@ async def terminal_websocket_endpoint(
     # dir (resolved lazily on first use); it reuses the already-owner-authorized
     # client + sandbox_id and never re-authorizes per frame.
     #
-    # Write-through durability (CM-2a′): build ONE overlay uploads service for the
-    # session and pass FileRpc a mirror closure bound to this tenant + row. Each
-    # editor save then also lands in blob storage; a mirror failure is swallowed
-    # inside FileRpc so it never fails the save.
+    # Write-through durability (CM-2a′, re-anchored in B2): build ONE overlay
+    # uploads service for the session and pass FileRpc hooks bound to this tenant
+    # and to the DURABLE PROJECT that owns this row (resolved once, above). Each
+    # editor save then also lands in blob storage against the project; a mirror
+    # failure is swallowed inside FileRpc so it never fails the save.
     overlay_uploads = websandbox_durability.build_uploads()
-
-    async def _mirror(rel_path: str, data: bytes) -> None:
-        await websandbox_durability.mirror_file(
-            workspace_id, user_id, row_id, rel_path, data, uploads=overlay_uploads
-        )
-
-    async def _drop(rel_path: str) -> None:
-        # Delete-side durability: drop the overlay entry so a deleted file is not
-        # resurrected on restore (WC-4c). Best-effort — swallowed inside FileRpc.
-        await websandbox_durability.drop_overlay(workspace_id, user_id, row_id, rel_path)
-
-    async def _move(src_rel: str, dst_rel: str) -> None:
-        # Rename-side durability: re-key the overlay entry to the new path so
-        # restore replays the file where it now lives (WC-4c). Best-effort.
-        await websandbox_durability.move_overlay(workspace_id, user_id, row_id, src_rel, dst_rel)
+    _mirror, _drop, _move = build_durability_hooks(
+        workspace_id, user_id, row_id, project_id, overlay_uploads
+    )
 
     file_rpc = FileRpc(client, row.sandbox_id, on_write=_mirror, on_delete=_drop, on_move=_move)
 
@@ -367,15 +484,25 @@ async def terminal_websocket_endpoint(
     finally:
         # Teardown: kill the pty session so the shell doesn't leak in the VM.
         await manager.unregister(websocket)
-        # CM-2a′ durability: capture the workspace to S3 on this clean disconnect
-        # so a returning user restores their uncommitted work. Best-effort — a
-        # snapshot miss never turns a normal close into an error.
-        await snapshot_on_disconnect(workspace_id, user_id, row_id, client)
+        # CM-2a′ durability, project-anchored (B2): capture the workspace to S3 on
+        # this clean disconnect so a returning user restores their uncommitted
+        # work. Best-effort — a snapshot miss never turns a normal close into an
+        # error.
+        await snapshot_on_disconnect(
+            workspace_id,
+            user_id,
+            row_id,
+            client,
+            project_id=project_id,
+            daytona_id=row.sandbox_id,
+        )
 
 
 __all__ = [
     "TerminalConnectionManager",
+    "build_durability_hooks",
     "manager",
+    "resolve_owning_project",
     "snapshot_on_disconnect",
     "terminal_websocket_endpoint",
 ]

--- a/ee/pocketpaw_ee/cloud/websandbox/ws.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/ws.py
@@ -83,6 +83,16 @@
 # misconfigured deploy persisted NOTHING while every save reported ok, with the only
 # trace at debug. Still swallowed (a durability hiccup must not break a file write
 # that already landed); just diagnosable now, with the anchor and path in the line.
+#
+# 2026-07-25 (S1, feat/code-s3-authoritative): the disconnect capture for a
+# PROJECT-anchored socket is now ``sync_project_files`` (a per-file re-image of the
+# workspace) instead of ``snapshot_project`` (one whole-workspace tarball). WHY: the
+# tarball could not express a DELETE — replaying it resurrected every file the user
+# removed, and taking it CLEARED the per-file overlay that could have recorded the
+# absence. The per-file store is now the whole truth, and a sync is what keeps it
+# complete for everything that never passes a write hook (a clone, a scaffold,
+# generated output). The degrade path is untouched: a sandbox with no owning project
+# still writes the sandbox-keyed tarball, which remains its only durability.
 from __future__ import annotations
 
 import asyncio
@@ -307,39 +317,44 @@ async def snapshot_on_disconnect(
     project_id: str | None = None,
     daytona_id: str | None = None,
 ) -> None:
-    """Best-effort workspace snapshot when a terminal socket closes (CM-2a′, B2).
+    """Best-effort workspace capture when a terminal socket closes (CM-2a′, B2, S1).
 
-    The durable half of Code Mode is the S3 snapshot; the Daytona VM is pure
-    scratch. With the aggressive Daytona lifecycle (stop 5 / delete-on-stop), a
-    disconnected VM is reclaimed within minutes — so a CLEAN disconnect (tab
-    close, navigate away) is the moment to capture the workspace while the VM is
-    still alive. ``codeproject.lifecycle.open_project`` restores the latest
-    snapshot on the next open.
+    The durable half of Code Mode is blob storage; the Daytona VM is pure scratch.
+    With the aggressive Daytona lifecycle (stop 5 / delete-on-stop), a disconnected
+    VM is reclaimed within minutes — so a CLEAN disconnect (tab close, navigate
+    away) is the moment to capture the workspace while the VM is still alive.
+    ``codeproject.lifecycle.open_project`` reconstructs it on the next open.
 
-    The pointer lands on the durable PROJECT when the socket resolved one, keyed by
-    ``project_id`` and taken from the live VM ``daytona_id`` (the project-keyed
-    snapshot addresses the VM directly rather than through the row). Without both —
-    a sandbox opened outside the project flow, or a row with no bound VM — it falls
-    back to the sandbox-keyed snapshot rather than skipping the capture.
+    A PROJECT-anchored socket now runs ``sync_project_files`` — a per-file re-image
+    of the workspace — where it used to write one whole-workspace TARBALL (S1). The
+    tar could not represent a DELETE: replaying it resurrected every file the user
+    removed during the session, and the write-through overlay that could have
+    recorded the absence was cleared by the snapshot. Syncing enumerates what
+    exists, so a deleted file is simply absent from the store afterwards. The
+    capture still needs both a ``project_id`` and a live ``daytona_id``; without
+    them (a sandbox opened outside the project flow, or a row with no bound VM) it
+    falls back to the sandbox-keyed tarball snapshot rather than skipping the
+    capture — that legacy path is unchanged and still the only durability such a
+    sandbox has.
 
-    Best-effort by design: a snapshot failure (VM already gone, S3 down, an
+    Best-effort by design: a capture failure (VM already gone, S3 down, an
     unprovisioned row) must NEVER surface on socket teardown — it is swallowed. It
-    is logged at WARNING though (B4): this is the capture that makes a whole
-    session's work durable, so losing it silently is indistinguishable from data
-    loss on the next open.
+    is logged at WARNING though (B4): this is what makes a whole session's work
+    durable, so losing it silently is indistinguishable from data loss on the next
+    open.
     """
     try:
         if project_id and daytona_id:
-            await websandbox_durability.snapshot_project(
+            await websandbox_durability.sync_project_files(
                 workspace_id, user_id, project_id, daytona_id, client=client
             )
         else:
             await websandbox_durability.snapshot_workspace(
                 workspace_id, user_id, row_id, client=client
             )
-    except Exception:  # noqa: BLE001 — teardown must never raise on a snapshot miss
+    except Exception:  # noqa: BLE001 — teardown must never raise on a capture miss
         logger.warning(
-            "websandbox.snapshot on disconnect failed for row=%s project=%s daytona=%s — "
+            "websandbox.capture on disconnect failed for row=%s project=%s daytona=%s — "
             "this session's workspace was NOT captured",
             row_id,
             project_id,

--- a/ee/pocketpaw_ee/extensions.py
+++ b/ee/pocketpaw_ee/extensions.py
@@ -1026,17 +1026,18 @@ class CloudBeltMcpProvider:
 
 class CloudCodeMcpProvider:
     """`pocketpaw.mcp_servers` — the Code Mode delegate in-process server
-    (``pocketpaw_code``). Hosts ``code_mode`` only.
+    (``pocketpaw_code``). Hosts the four /code file tools: ``readFile`` /
+    ``search`` / ``listDir`` / ``writeFile``.
 
     The main chat agent drives the /code surface and reaches the user's project
-    through this one coarse tool. The handler does not open a file: it parks on
-    a future while the BROWSER does the work and posts the answer back to
-    ``POST /codeagent/resolve``, because a WebContainer project lives in the tab
-    and has no server-side row a backend could reach.
+    through these tools, one call at a time. No handler opens a file: each parks
+    on a future while the BROWSER runs the matching file-session verb and posts
+    the result back to ``POST /codeagent/resolve``, because a WebContainer
+    project lives in the tab and has no server-side row a backend could reach.
 
     Ambient (NOT in ``OPT_IN_MCP_SERVERS``), the same regime as the sibling belt
     / loom / media servers: the /code surface scopes access via its profile,
-    which allows this tool id and DENIES the file/shell built-ins outright.
+    which allows these tool ids and DENIES the file/shell built-ins outright.
     ``build_code_server`` returns None — and the loop skips it — when the
     claude_agent_sdk isn't installed, so chat never breaks.
     """

--- a/ee/pocketpaw_ee/extensions.py
+++ b/ee/pocketpaw_ee/extensions.py
@@ -100,6 +100,12 @@ read-only: the ``pocketpaw_fabric`` server grew three ontology modification
 tools (``fabric_link_create`` / ``fabric_link_delete`` at MEMBER tier,
 ``fabric_type_update`` RBAC-gated on ``fabric.admin``), mirroring the REST
 routes. ``tool_ids()`` picks them up automatically via ``FABRIC_TOOL_IDS``.
+
+Updated: 2026-07-24 (CX-3, feat/code-agent-exclusive-tools) —
+``CloudLifecycleHook.on_startup`` now also back-fills the dedicated ``code``
+agent (``ensure_code_agent_all_workspaces``) beside the default ``pocketpaw``
+one, so existing workspaces resolve ``/code`` turns to the exclusive-file-tool
+agent without waiting for the first-turn lazy seed.
 """
 
 from __future__ import annotations
@@ -309,6 +315,11 @@ class CloudLifecycleHook:
         await seed_workspace(admin)
         # Back-fill the pocketpaw agent for workspaces that predate agent seeding.
         await ensure_default_agent_all_workspaces()
+        # Back-fill the dedicated /code agent (exclusive file-tool set) beside it
+        # so an existing workspace resolves /code turns without a first-turn seed.
+        from pocketpaw_ee.cloud.agents.service import ensure_code_agent_all_workspaces
+
+        await ensure_code_agent_all_workspaces()
 
         # Persist Haiku-generated chat titles into MongoDB.
         try:

--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -1,5 +1,14 @@
 """
 Claude Agent SDK backend for PocketPaw.
+Updated: 2026-07-24 (CX-1, feat/code-agent-cx1) — ``_build_options`` / ``run`` /
+  ``prewarm`` grow an ``exclusive_mcp_tools: bool = False`` keyword. When True, the
+  MCP scoping block CAPS the tool surface to ``allow_mcp_tool_ids`` alone — no
+  POCKET_CREATION_GRANT, no widget/atlas ids, and NOT the
+  ALWAYS_ALLOWED_MCP_SERVERS escape hatch — so a dedicated agent (e.g. /code) gets
+  EXACTLY the declared ids. ``exclusive_mcp_tools=True`` with
+  ``allow_mcp_tool_ids=None`` strips ALL ``mcp__`` ids (empty permitted set), so an
+  exclusive agent wins over even a broad surface. ``False`` (the default) keeps the
+  legacy grant-union scoping byte-for-byte. Built-in SDK tools are never touched.
 Updated: 2026-07-08 (CS-13, feat/per-send-model-override) — ``run`` /
   ``_build_options`` grow an optional ``model_override: str | None = None``
   keyword. When set, it is applied as the LAST word in the model-selection block,
@@ -1535,6 +1544,7 @@ class ClaudeSDKBackend(BaseAgentBackend):
         stderr_sink: list[str],
         session_handle: SessionHandle | None = None,
         model_override: str | None = None,
+        exclusive_mcp_tools: bool = False,
     ) -> _BuiltOptions:
         """Assemble the ``ClaudeAgentOptions`` a turn (or a prewarm) will run on.
 
@@ -1766,7 +1776,29 @@ class ClaudeSDKBackend(BaseAgentBackend):
         # Built-in SDK tools (Read/Write/Bash/...) are NEVER filtered here —
         # only ``mcp__*`` ids — so scoping a mode can't strip core tools.
         # Applied AFTER deny so a denied id can't sneak back via the grant.
-        if allow_mcp_tool_ids is not None:
+        #
+        # ``exclusive_mcp_tools`` (CX-1) is the exact-toolset signal: an
+        # EXCLUSIVE turn CAPS the MCP surface to ``allow_mcp_tool_ids`` alone —
+        # no POCKET_CREATION_GRANT, no widget/atlas ids, and NOT the
+        # ALWAYS_ALLOWED_MCP_SERVERS escape hatch — so a dedicated agent (e.g.
+        # /code) gets EXACTLY the ids it declared and nothing the universal
+        # grant would otherwise union back in. Precedence rule: an exclusive
+        # turn with ``allow_mcp_tool_ids=None`` strips ALL ``mcp__`` ids (an
+        # empty permitted set), which is how an exclusive agent wins even over a
+        # broad surface. The default (signal off) path below is byte-for-byte
+        # the legacy grant-union scoping.
+        if exclusive_mcp_tools:
+            permitted = allow_mcp_tool_ids or frozenset()
+            before_count = len(allowed_tools)
+            allowed_tools = [
+                t for t in allowed_tools if not t.startswith("mcp__") or t in permitted
+            ]
+            if len(allowed_tools) < before_count:
+                logger.info(
+                    "Exclusive MCP-allow: capped to exactly %s (no general grant)",
+                    sorted(permitted),
+                )
+        elif allow_mcp_tool_ids is not None:
             from pocketpaw.agents.sdk_mcp_atlas import ATLAS_TOOL_IDS
             from pocketpaw.agents.sdk_mcp_widgets import WIDGET_TOOL_IDS
 
@@ -2081,6 +2113,7 @@ class ClaudeSDKBackend(BaseAgentBackend):
         allow_sdk_tools: frozenset[str] = frozenset(),
         allow_mcp_tool_ids: frozenset[str] | None = None,
         skill_names: frozenset[str] = frozenset(),
+        exclusive_mcp_tools: bool = False,
     ) -> None:
         """Eagerly ``connect()`` the warm CLI subprocess for a session before its
         first turn, so the first real ``run`` reuses it instead of paying the
@@ -2130,6 +2163,7 @@ class ClaudeSDKBackend(BaseAgentBackend):
                 allow_sdk_tools=allow_sdk_tools,
                 allow_mcp_tool_ids=allow_mcp_tool_ids,
                 skill_names=skill_names,
+                exclusive_mcp_tools=exclusive_mcp_tools,
                 stderr_sink=[],
             )
             # Remember the digest we may have adopted a dir under, so a failed
@@ -2319,6 +2353,7 @@ class ClaudeSDKBackend(BaseAgentBackend):
         warm_client: LeasedClient | None = None,
         on_client_built: Callable[[Any, str, Callable], None] | None = None,
         model_override: str | None = None,
+        exclusive_mcp_tools: bool = False,
     ) -> AsyncIterator[AgentEvent]:
         """Process a message through Claude Agent SDK with streaming.
 
@@ -2485,6 +2520,7 @@ class ClaudeSDKBackend(BaseAgentBackend):
                 skill_names=skill_names,
                 session_handle=session_handle,
                 model_override=model_override,
+                exclusive_mcp_tools=exclusive_mcp_tools,
                 stderr_sink=_stderr_lines,
             )
             options = _built.options

--- a/src/pocketpaw/agents/pool.py
+++ b/src/pocketpaw/agents/pool.py
@@ -3,6 +3,14 @@
 Each cloud Agent gets its own AgentBackend + SoulManager + memory namespace.
 Instances are cached and evicted when idle (default 5 minutes).
 
+Updated: 2026-07-24 (CX-2, feat/code-agent-exclusive-tools) — ``run`` and
+  ``prewarm`` accept ``exclusive_mcp_tools: bool = False`` and forward it to the
+  backend ONLY when True (same withhold-when-empty idiom as ``model_override`` /
+  ``skill_names``). Only the Claude SDK backend consumes it — there it CAPS the
+  MCP surface to ``allow_mcp_tool_ids`` alone (no universal grant), so a
+  ``tool_mode="exclusive"`` agent (e.g. /code) gets EXACTLY its declared ids.
+  ``False`` = the unchanged grant-union path for every existing run.
+
 Updated: 2026-07-08 (CS-13, feat/per-send-model-override) — ``run`` accepts an
   optional ``model_override: str | None`` (the client's per-send model choice) and
   forwards it to the backend's ``run`` ONLY when non-None (the same
@@ -371,6 +379,7 @@ class AgentPool:
         allow_mcp_tool_ids: frozenset[str] | None = None,
         system_message_override: str | None = None,
         skill_names: frozenset[str] = frozenset(),
+        exclusive_mcp_tools: bool = False,
     ) -> None:
         """Eagerly warm the agent's CLI subprocess for ``session_key`` before its
         first turn, so the first ``run`` reuses it instead of paying the cold
@@ -441,6 +450,11 @@ class AgentPool:
             prewarm_kwargs["allow_mcp_tool_ids"] = allow_mcp_tool_ids
         if effective_skills:
             prewarm_kwargs["skill_names"] = effective_skills
+        # Per-agent exclusive-tool cap (CX-2). Mirror ``run`` so the prewarmed
+        # client's options (and cache key) match turn 1's — forwarded only when
+        # True; the caller passes the agent's declared ids as ``allow_mcp_tool_ids``.
+        if exclusive_mcp_tools:
+            prewarm_kwargs["exclusive_mcp_tools"] = exclusive_mcp_tools
         await backend_prewarm(**prewarm_kwargs)
 
     async def run(
@@ -460,6 +474,7 @@ class AgentPool:
         warm_client: LeasedClient | None = None,
         on_client_built: Callable[[Any, str, Callable], None] | None = None,
         model_override: str | None = None,
+        exclusive_mcp_tools: bool = False,
     ) -> AsyncIterator[Any]:
         """Run an agent on a message. Yields AgentEvent stream.
 
@@ -517,6 +532,13 @@ class AgentPool:
         backend's ``run`` ONLY when set, so the 6 non-Claude backends keep their
         narrower signature and only the Claude SDK backend acts on it (where it wins
         over smart-routing / ``claude_sdk_model``). ``None`` = the unchanged path.
+
+        ``exclusive_mcp_tools`` (CX-2) is the per-agent exclusive-tool signal. It
+        rides the SAME withhold-when-empty contract: forwarded to the backend's
+        ``run`` ONLY when ``True``, so the 6 non-Claude backends keep their narrower
+        signature and only the Claude SDK backend acts on it (there it CAPS the MCP
+        surface to ``allow_mcp_tool_ids`` alone — no universal grant). ``False``
+        (the default) = the unchanged grant-union path.
         """
         instance = await self.get(agent_id)
         instance.last_active = datetime.now(UTC)
@@ -615,6 +637,13 @@ class AgentPool:
             # this turn. None = legacy path, unchanged for every existing run.
             if model_override is not None:
                 run_kwargs["model_override"] = model_override
+            # Per-agent exclusive-tool cap (CX-2). Same withhold-when-empty rule:
+            # only the Claude SDK backend accepts ``exclusive_mcp_tools`` (it caps
+            # the MCP surface to ``allow_mcp_tool_ids`` alone); the other backends
+            # keep the narrower signature, so it is forwarded ONLY when True.
+            # False = legacy grant-union path, unchanged for every existing run.
+            if exclusive_mcp_tools:
+                run_kwargs["exclusive_mcp_tools"] = exclusive_mcp_tools
             async for event in instance.backend.run(message, **run_kwargs):
                 instance.last_active = datetime.now(UTC)
                 yield event

--- a/tests/cloud/agents/test_agent_tool_mode.py
+++ b/tests/cloud/agents/test_agent_tool_mode.py
@@ -1,0 +1,98 @@
+# tests/cloud/agents/test_agent_tool_mode.py
+# Created 2026-07-24 (CX-2, feat/code-agent-exclusive-tools) — pins the
+# ``tool_mode`` field round-tripping through the agents service:
+#   * mapper round-trip spec -> doc -> spec keeps "exclusive" (and the default
+#     "additive").
+#   * update() via the body.config-dict branch sets tool_mode -> "exclusive" and
+#     it persists to Mongo (re-read through the service), and is preserved when
+#     the dict omits it.
+"""``AgentConfig.tool_mode`` round-trips through the agents service."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud.agents import service as agents_service
+from pocketpaw_ee.cloud.agents.domain import AgentConfigSpec
+from pocketpaw_ee.cloud.agents.dto import CreateAgentRequest, UpdateAgentRequest
+
+# ---------------------------------------------------------------------------
+# Mapper round-trip (no Mongo)
+# ---------------------------------------------------------------------------
+
+
+def test_mapper_round_trip_preserves_exclusive():
+    spec = AgentConfigSpec(tool_mode="exclusive", tools=("mcp__code__read",))
+    doc = agents_service._config_to_doc(spec)
+    assert doc.tool_mode == "exclusive"
+    back = agents_service._config_to_domain(doc)
+    assert back.tool_mode == "exclusive"
+    assert back.tools == ("mcp__code__read",)
+
+
+def test_mapper_default_is_additive():
+    spec = AgentConfigSpec()
+    assert spec.tool_mode == "additive"
+    doc = agents_service._config_to_doc(spec)
+    assert doc.tool_mode == "additive"
+    assert agents_service._config_to_domain(doc).tool_mode == "additive"
+
+
+# ---------------------------------------------------------------------------
+# Service round-trip through Mongo (via the config-dict update branch)
+# ---------------------------------------------------------------------------
+
+
+def _ctx(user_id: str = "u1", workspace_id: str | None = "w1") -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="r",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+def _create_body(**kw) -> CreateAgentRequest:
+    base = dict(name="Coder", slug="coder", soul_enabled=False)
+    base.update(kw)
+    return CreateAgentRequest(**base)
+
+
+@pytest.mark.usefixtures("mongo_db")
+async def test_create_defaults_additive(recording_bus) -> None:
+    agent = await agents_service.create(_ctx(), "w1", _create_body())
+    assert agent.config.tool_mode == "additive"
+    reloaded = await agents_service.get(agent.id)
+    assert reloaded.config.tool_mode == "additive"
+
+
+@pytest.mark.usefixtures("mongo_db")
+async def test_update_config_dict_sets_and_persists_exclusive(recording_bus) -> None:
+    agent = await agents_service.create(_ctx(), "w1", _create_body())
+    updated = await agents_service.update(
+        _ctx(),
+        agent.id,
+        UpdateAgentRequest(config={"tool_mode": "exclusive", "tools": ["mcp__code__read"]}),
+    )
+    assert updated.config.tool_mode == "exclusive"
+    # Re-read through the service to prove it persisted to Mongo.
+    reloaded = await agents_service.get(agent.id)
+    assert reloaded.config.tool_mode == "exclusive"
+    assert reloaded.config.tools == ("mcp__code__read",)
+
+
+@pytest.mark.usefixtures("mongo_db")
+async def test_update_config_dict_preserves_when_omitted(recording_bus) -> None:
+    """The config-dict branch keeps the current tool_mode when the dict omits it."""
+    agent = await agents_service.create(_ctx(), "w1", _create_body())
+    # First flip to exclusive, then update an unrelated field.
+    await agents_service.update(
+        _ctx(), agent.id, UpdateAgentRequest(config={"tool_mode": "exclusive"})
+    )
+    updated = await agents_service.update(
+        _ctx(), agent.id, UpdateAgentRequest(config={"temperature": 0.4})
+    )
+    assert updated.config.tool_mode == "exclusive"

--- a/tests/cloud/agents/test_code_agent_seed.py
+++ b/tests/cloud/agents/test_code_agent_seed.py
@@ -1,0 +1,178 @@
+# tests/cloud/agents/test_code_agent_seed.py
+# Created 2026-07-24 (CX-3, feat/code-agent-exclusive-tools) — pins the dedicated
+# ``/code`` agent seed and the backend-authoritative routing that makes the
+# classic pocket repro die.
+#
+# Three properties carry the weight here:
+#   1. ``seed_code_agent`` inserts a slug-"code" agent whose config is
+#      ``tool_mode="exclusive"`` + ``tools=_CODE_FILE_TOOL_IDS`` and carries NO
+#      create-pocket / widget skill; it is idempotent.
+#   2. THE HEADLINE — the seeded agent's OWN config, sourced via the CX-2
+#      ``_agent_tool_policy`` and driven through the REAL ``_build_options``
+#      allowlist computation, yields an effective MCP surface of EXACTLY the four
+#      file ids and ZERO pocket / widget / atlas / planner ids. This is the
+#      "build an employee management app…" repro dying at the allowlist level.
+#   3. ``_get_code_agent_id`` lazy-seeds on miss, and a CODE-surface session
+#      resolution routes to slug "code" (lazy-seeding), not the default
+#      "pocketpaw" agent.
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pocketpaw_ee.cloud._core.realtime.events import AgentCreated
+from pocketpaw_ee.cloud.agents import service as agents_service
+from pocketpaw_ee.cloud.chat import agent_service
+from pocketpaw_ee.cloud.chat.runs import run_core
+from pocketpaw_ee.cloud.surface.surface_registry import _CODE_FILE_TOOL_IDS
+from pocketpaw_ee.cloud.surface.system_prompts import CODE_SYSTEM_PROMPT
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+# ── 1. the seed ─────────────────────────────────────────────────────────────
+
+
+async def test_seed_code_agent_inserts_exclusive_file_tool_agent(recording_bus) -> None:
+    doc, created = await agents_service.seed_code_agent("w1", "u1")
+
+    assert created is True
+    assert doc is not None
+    assert doc.slug == "code"
+    assert doc.visibility == "workspace"
+    # exclusive file-tool policy — this is what CX-1/CX-2 read at run time.
+    assert doc.config.tool_mode == "exclusive"
+    assert set(doc.config.tools) == set(_CODE_FILE_TOOL_IDS)
+    # persona reuses the CODE surface prompt verbatim (no drift).
+    assert doc.config.system_prompt == CODE_SYSTEM_PROMPT
+    # NO create-pocket / pocket / widget skill — the CODE surface ships none.
+    assert doc.config.skill_refs == []
+    assert not any(
+        "pocket" in s.lower() or "widget" in s.lower() for s in doc.config.skill_refs
+    )
+
+    created_events = [e for e in recording_bus.events if isinstance(e, AgentCreated)]
+    assert len(created_events) == 1
+    assert created_events[0].data["slug"] == "code"
+
+    # idempotent — a second call inserts nothing and returns the existing row.
+    recording_bus.events.clear()
+    again, created_again = await agents_service.seed_code_agent("w1", "u1")
+    assert created_again is False
+    assert str(again.id) == str(doc.id)
+    assert not any(isinstance(e, AgentCreated) for e in recording_bus.events)
+
+
+# ── 2. THE HEADLINE — the pocket repro dies at the allowlist level ───────────
+
+
+async def test_seeded_code_agent_config_drives_exclusive_allowlist(monkeypatch) -> None:
+    """The seeded agent's OWN config, resolved through CX-2 ``_agent_tool_policy``
+    and driven through the REAL ``_build_options`` computation with a candidate
+    pool that INCLUDES the universal grant ids, yields exactly the four file ids
+    and nothing that could author a pocket. Presence + absence together are the
+    point — this is the assertion that "build me an employee management app,
+    with components and a nice design" can no longer reach a pocket tool."""
+    from pocketpaw.agents.claude_sdk import POCKET_CREATION_GRANT, ClaudeSDKBackend
+    from pocketpaw.agents.sdk_mcp_atlas import ATLAS_TOOL_IDS
+    from pocketpaw.agents.sdk_mcp_widgets import WIDGET_TOOL_IDS
+    from pocketpaw.config import get_settings
+
+    doc, _ = await agents_service.seed_code_agent("w1", "u1")
+
+    # Source the exclusive policy FROM the seeded agent's config (the CX-2 seam).
+    exclusive, tools = run_core._agent_tool_policy(doc)
+    assert exclusive is True
+    assert tools == frozenset(_CODE_FILE_TOOL_IDS)
+
+    widget_id = next(iter(WIDGET_TOOL_IDS))
+    atlas_id = next(iter(ATLAS_TOOL_IDS))
+    planner_id = "mcp__pocketpaw_pocket_planner__plan_pocket"
+    assert planner_id in POCKET_CREATION_GRANT
+
+    backend = ClaudeSDKBackend(get_settings())
+    # A candidate pool that WOULD grant pocket/widget/atlas on a default turn, so
+    # the suppression is provable rather than vacuous.
+    pool = [*sorted(_CODE_FILE_TOOL_IDS), widget_id, atlas_id, planner_id]
+    monkeypatch.setattr(backend, "_collect_mcp_tool_ids", lambda: list(pool))
+
+    built = await backend._build_options(
+        "build me an employee management app, with components and a nice design",
+        system_prompt=doc.config.system_prompt,
+        history=None,
+        session_key=None,
+        deny_mcp_tool_ids=frozenset(),
+        allow_sdk_tools=frozenset(),
+        allow_mcp_tool_ids=tools,
+        skill_names=frozenset(),
+        stderr_sink=[],
+        exclusive_mcp_tools=exclusive,
+    )
+    effective = {t for t in built.options_kwargs["allowed_tools"] if t.startswith("mcp__")}
+
+    assert effective == set(_CODE_FILE_TOOL_IDS)
+    # the pocket repro dies: zero pocket / widget / atlas / planner ids survive.
+    assert not [t for t in effective if t.startswith("mcp__pocketpaw_pocket")]
+    assert widget_id not in effective
+    assert atlas_id not in effective
+    assert planner_id not in effective
+
+
+# ── 3. lazy-seed + CODE-surface routing ─────────────────────────────────────
+
+
+async def test_get_code_agent_id_lazy_seeds_when_absent() -> None:
+    """A workspace with no code agent still works on its FIRST /code turn: the
+    helper seeds one and returns its id, and a second call returns the SAME id
+    (no duplicate seed)."""
+    # No code agent yet.
+    from pocketpaw_ee.cloud.models.agent import Agent
+
+    assert await Agent.find_one(Agent.workspace == "w1", Agent.slug == "code") is None
+
+    first = await agent_service._get_code_agent_id("w1")
+    assert first is not None
+
+    seeded = await Agent.find_one(Agent.workspace == "w1", Agent.slug == "code")
+    assert seeded is not None
+    assert str(seeded.id) == first
+
+    second = await agent_service._get_code_agent_id("w1")
+    assert second == first  # idempotent — same id, no second row
+
+
+async def test_code_surface_session_resolves_to_code_agent_not_default() -> None:
+    """End to end: a session-scope /code turn with NO explicit agent hint and no
+    pre-existing code agent LAZY-SEEDS one and resolves ``target`` to slug
+    "code" — never the default "pocketpaw" agent."""
+    from pocketpaw_ee.cloud.models.agent import Agent
+    from pocketpaw_ee.cloud.models.session import Session
+
+    # A default pocketpaw agent exists — the CODE override must still win.
+    default_doc, _ = await agents_service.seed_default_agent("w1", "u1")
+
+    fake_session = Session.model_construct(
+        id="s1",
+        sessionId="ws",
+        workspace="w1",
+        owner="u1",
+        agent=None,
+        pocket=None,
+        deleted_at=None,
+    )
+    with patch(
+        "pocketpaw_ee.cloud.chat.agent_service._get_session",
+        AsyncMock(return_value=fake_session),
+    ):
+        ctx = await agent_service.resolve_scope_context(
+            scope="session",
+            scope_id="s1",
+            user_id="u1",
+            agent_id_hint=None,
+            surface="code",
+        )
+
+    resolved = await Agent.get(ctx.target_agent_id)
+    assert resolved is not None
+    assert resolved.slug == "code"
+    assert ctx.target_agent_id != str(default_doc.id)

--- a/tests/cloud/runs/test_run_core_agent_tool_policy.py
+++ b/tests/cloud/runs/test_run_core_agent_tool_policy.py
@@ -1,0 +1,191 @@
+# tests/cloud/runs/test_run_core_agent_tool_policy.py
+# Created 2026-07-24 (CX-2, feat/code-agent-exclusive-tools) — pins the
+# per-agent EXCLUSIVE tool policy resolution + its run_kwargs wiring in run_core:
+#   * _agent_tool_policy: (True, frozenset(tools)) only for tool_mode="exclusive";
+#     (False, frozenset()) for "additive" and for a config with no tool_mode;
+#     tolerant of a dict OR an object config.
+#   * _drive_agent_loop: an exclusive agent sets run_kwargs["exclusive_mcp_tools"]
+#     = True and OVERRIDES allow_mcp_tool_ids with the agent's own tools, even
+#     when the surface set a different allow_mcp. An additive agent touches
+#     neither key and leaves any surface allow_mcp intact (grant path unchanged).
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from pocketpaw_ee.cloud.chat.agent_service import ScopeContext, ScopeKind
+from pocketpaw_ee.cloud.chat.runs import run_core
+
+# ---------------------------------------------------------------------------
+# _agent_tool_policy (pure unit)
+# ---------------------------------------------------------------------------
+
+
+def _instance(config: Any) -> Any:
+    return SimpleNamespace(config=config)
+
+
+def test_tool_policy_exclusive_returns_tools():
+    inst = _instance({"tool_mode": "exclusive", "tools": ["mcp__code__read", "mcp__code__write"]})
+    assert run_core._agent_tool_policy(inst) == (
+        True,
+        frozenset({"mcp__code__read", "mcp__code__write"}),
+    )
+
+
+def test_tool_policy_additive_returns_false_empty():
+    inst = _instance({"tool_mode": "additive", "tools": ["mcp__code__read"]})
+    assert run_core._agent_tool_policy(inst) == (False, frozenset())
+
+
+def test_tool_policy_no_tool_mode_defaults_additive():
+    # A non-empty tools list alone does NOT make an agent exclusive.
+    inst = _instance({"tools": ["mcp__code__read"]})
+    assert run_core._agent_tool_policy(inst) == (False, frozenset())
+
+
+def test_tool_policy_empty_config():
+    assert run_core._agent_tool_policy(_instance({})) == (False, frozenset())
+
+
+def test_tool_policy_object_config():
+    """The resolver tolerates an object config (getattr path) too."""
+    cfg = SimpleNamespace(tool_mode="exclusive", tools=["mcp__code__ls"])
+    assert run_core._agent_tool_policy(_instance(cfg)) == (True, frozenset({"mcp__code__ls"}))
+
+
+# ---------------------------------------------------------------------------
+# _drive_agent_loop → run_kwargs wiring
+# ---------------------------------------------------------------------------
+
+
+def _scope_ctx(*, resolved_profile=None) -> ScopeContext:
+    ctx = ScopeContext(
+        kind=ScopeKind.SESSION,
+        scope_id="s1",
+        workspace_id="w1",
+        user_id="u1",
+        members=["u1"],
+        target_agent_id="a1",
+    )
+    ctx.resolved_profile = resolved_profile
+    return ctx
+
+
+async def _drain_run_kwargs(monkeypatch, ctx, agent_config: dict[str, Any]) -> dict[str, Any]:
+    """Drive _drive_agent_loop just far enough to capture the run_kwargs the
+    pool.run seam receives, then stop. Mocks every collaborator the loop touches
+    before pool.run."""
+    captured: dict[str, Any] = {}
+
+    class _FakePool:
+        async def get(self, _agent_id):
+            return SimpleNamespace(config=agent_config, agent_name="A")
+
+        def run(self, agent_id, content, session_key, **run_kwargs):
+            captured["run_kwargs"] = run_kwargs
+
+            async def _gen():
+                return
+                yield  # pragma: no cover
+
+            return _gen()
+
+    monkeypatch.setattr(run_core, "get_agent_pool", lambda: _FakePool())
+
+    async def _fake_knowledge(*a, **k):
+        return ""
+
+    monkeypatch.setattr(run_core, "build_knowledge_context", _fake_knowledge)
+    monkeypatch.setattr(run_core, "build_behavior_instructions", lambda ctx, backend_name=None: "")
+    monkeypatch.setattr(run_core, "attach_sse_event_sink", lambda q: None)
+    monkeypatch.setattr(run_core, "attach_agent_identity", lambda **k: None)
+    monkeypatch.setattr(run_core, "detach_sse_event_sink", lambda t: None)
+    monkeypatch.setattr(run_core, "detach_agent_identity", lambda t: None)
+
+    async def _never_cancelled():
+        return False
+
+    gen = run_core._drive_agent_loop(
+        ctx,
+        user_content="hi",
+        attachments_in=None,
+        mentions_in=None,
+        history=None,
+        is_cancelled=_never_cancelled,
+        emit_stream_start=False,
+    )
+    async for _ in gen:
+        pass
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_exclusive_agent_sets_flag_and_allow(monkeypatch):
+    """An exclusive agent (resolved_profile None) sets exclusive_mcp_tools=True
+    and allow_mcp_tool_ids = its own declared tools."""
+    ctx = _scope_ctx(resolved_profile=None)
+    captured = await _drain_run_kwargs(
+        monkeypatch,
+        ctx,
+        {"tool_mode": "exclusive", "tools": ["mcp__code__read", "mcp__code__write"]},
+    )
+    rk = captured["run_kwargs"]
+    assert rk["exclusive_mcp_tools"] is True
+    assert rk["allow_mcp_tool_ids"] == frozenset({"mcp__code__read", "mcp__code__write"})
+
+
+@pytest.mark.asyncio
+async def test_exclusive_agent_overrides_surface_allow(monkeypatch):
+    """When the surface already set allow_mcp_tool_ids, an exclusive agent WINS —
+    its own tools replace the surface allow-list."""
+    profile = SimpleNamespace(
+        deny_mcp_tool_ids=frozenset(),
+        allowed_sdk_tools=frozenset(),
+        allow_mcp_tool_ids=frozenset({"mcp__surface__tool"}),
+        system_message_override=None,
+        skill_names=frozenset(),
+    )
+    ctx = _scope_ctx(resolved_profile=profile)
+    captured = await _drain_run_kwargs(
+        monkeypatch,
+        ctx,
+        {"tool_mode": "exclusive", "tools": ["mcp__code__read"]},
+    )
+    rk = captured["run_kwargs"]
+    assert rk["exclusive_mcp_tools"] is True
+    assert rk["allow_mcp_tool_ids"] == frozenset({"mcp__code__read"})
+
+
+@pytest.mark.asyncio
+async def test_additive_agent_touches_nothing(monkeypatch):
+    """An additive agent adds no exclusive key and leaves a surface allow_mcp
+    intact — the grant path is byte-identical to today."""
+    profile = SimpleNamespace(
+        deny_mcp_tool_ids=frozenset(),
+        allowed_sdk_tools=frozenset(),
+        allow_mcp_tool_ids=frozenset({"mcp__surface__tool"}),
+        system_message_override=None,
+        skill_names=frozenset(),
+    )
+    ctx = _scope_ctx(resolved_profile=profile)
+    captured = await _drain_run_kwargs(
+        monkeypatch,
+        ctx,
+        {"tool_mode": "additive", "tools": ["mcp__code__read"]},
+    )
+    rk = captured["run_kwargs"]
+    assert "exclusive_mcp_tools" not in rk
+    assert rk["allow_mcp_tool_ids"] == frozenset({"mcp__surface__tool"})
+
+
+@pytest.mark.asyncio
+async def test_no_tool_mode_is_additive(monkeypatch):
+    """A legacy config with no tool_mode and no surface allow_mcp: neither key
+    is set (broad surfaces keep every tool)."""
+    ctx = _scope_ctx(resolved_profile=None)
+    captured = await _drain_run_kwargs(monkeypatch, ctx, {"tools": ["mcp__code__read"]})
+    rk = captured["run_kwargs"]
+    assert "exclusive_mcp_tools" not in rk
+    assert "allow_mcp_tool_ids" not in rk

--- a/tests/cloud/surface/test_studio_code_handlers.py
+++ b/tests/cloud/surface/test_studio_code_handlers.py
@@ -19,9 +19,11 @@
 # Grep and that the profile carry them in ``allowed_sdk_tools``; both encoded the
 # stale belief that the /code agent works on a filesystem it can see. It does
 # not — it runs on the backend server, and the user's project is reachable only
-# through the ``code_mode`` tool. The replacements assert the inverse: the
-# resolved profile DENIES every file/shell built-in (plus ``Agent``), allows
-# exactly ``code_mode``, and surfaces NO skill; and the rendered preamble leaks
+# through the file tools (readFile / search / listDir / writeFile — originally a
+# single ``code_mode`` tool, replaced 2026-07-24). The replacements assert the
+# inverse: the resolved profile DENIES every file/shell built-in (plus
+# ``Agent``), allows exactly those file tools, and surfaces NO skill; the preamble
+# leaks
 # no path and names no Daytona MCP tool — including when a legacy client still
 # stamps the old ``current_dir`` / ``storage_root`` / ``workspace_vm`` /
 # ``is_cloud_storage`` hints. The registry-import assertion is exercised too,
@@ -173,11 +175,12 @@ async def test_code_handler_carries_coding_orientation() -> None:
     assert "build a pocket" not in lower
 
 
-async def test_code_handler_routes_all_work_through_code_mode() -> None:
-    """`code_mode` is named as the ONLY route to the user's project."""
+async def test_code_handler_routes_all_work_through_the_file_tools() -> None:
+    """The file tools are named as the ONLY route to the user's project."""
     preamble = await code_handler.build_preamble(WORKSPACE, USER, SurfaceMeta(route_path="/code"))
 
-    assert "code_mode" in preamble
+    for tool in ("readFile", "search", "listDir", "writeFile"):
+        assert tool in preamble, f"the preamble must name the {tool} tool"
     lower = preamble.lower()
     assert "only" in lower
 
@@ -194,16 +197,16 @@ async def test_code_handler_forbids_the_filesystem_builtins() -> None:
     assert "no filesystem" in lower
 
 
-async def test_code_handler_calls_code_mode_immediately_on_a_selection() -> None:
-    """An edit scoped to a selection the user already made goes straight to
-    `code_mode` — no exploratory retrieval first (the path is two model calls
-    deep, so a redundant round-trip is expensive)."""
+async def test_code_handler_acts_immediately_on_a_selection() -> None:
+    """An edit scoped to a selection the user already made is acted on at once —
+    no re-reading the project first (the selection and its file are already in
+    context, so a redundant round-trip is a wasted wait)."""
     preamble = await code_handler.build_preamble(WORKSPACE, USER, SurfaceMeta(route_path="/code"))
     lower = preamble.lower()
 
     assert "selection" in lower
     assert "immediately" in lower
-    assert "retrieval" in lower
+    assert "re-read" in lower
 
 
 async def test_code_handler_names_no_daytona_tool() -> None:
@@ -285,13 +288,21 @@ def test_studio_profile_ripple_off_media_tools_and_skill() -> None:
     assert VIDEO_GENERATE_TOOL_ID in profile.allow_mcp_tool_ids
 
 
-def test_code_profile_ripple_off_and_scoped_to_code_mode() -> None:
+def test_code_profile_ripple_off_and_scoped_to_the_file_tools() -> None:
     """The /code profile turns ripple OFF (so the agent edits code, not a
-    dashboard) and scopes the MCP surface to exactly the ``code_mode`` tool."""
+    dashboard) and scopes the MCP surface to exactly the four file tools the main
+    agent drives."""
     profile = resolve_profile(SurfaceKind.CODE, SurfaceMeta())
 
     assert profile.ripple_mode == "off"
-    assert profile.allow_mcp_tool_ids == frozenset({"mcp__pocketpaw_code__code_mode"})
+    assert profile.allow_mcp_tool_ids == frozenset(
+        {
+            "mcp__pocketpaw_code__readFile",
+            "mcp__pocketpaw_code__search",
+            "mcp__pocketpaw_code__listDir",
+            "mcp__pocketpaw_code__writeFile",
+        }
+    )
 
 
 def test_code_profile_denies_the_skill_tool() -> None:
@@ -322,8 +333,10 @@ def test_code_profile_carries_its_own_system_prompt() -> None:
     profile = resolve_profile(SurfaceKind.CODE, SurfaceMeta())
 
     assert profile.system_message_override == CODE_SYSTEM_PROMPT
-    # It has to say what the surface DOES build, not only what it must not.
-    assert "code_mode" in CODE_SYSTEM_PROMPT
+    # It has to say what the surface DOES build, not only what it must not — and
+    # name the tools it actually grants.
+    for tool in ("readFile", "search", "listDir", "writeFile"):
+        assert tool in CODE_SYSTEM_PROMPT
     assert "WORKING CODE" in CODE_SYSTEM_PROMPT
     # And it must not promise a tool the profile denies.
     for denied in ("deliver_artifact", "get_widget_spec", "pocket_specialist"):
@@ -400,10 +413,10 @@ async def test_code_profile_grants_no_filesystem_tool_in_the_effective_allowlist
     the eight tool names known today, so a daytona tool added later is caught
     without anyone remembering to update this test.
 
-    Note we assert only ABSENCE. ``code_mode`` itself will not appear here until
-    CD-2 lands its MCP server: ``allow_mcp_tool_ids`` is a FILTER over the tools
-    that exist, not a grant that conjures one. Its presence is pinned at the
-    profile level in ``test_code_profile_ripple_off_and_scoped_to_code_mode``."""
+    Note this test asserts only ABSENCE — the file tools' PRESENCE is pinned in
+    ``test_file_tools_reach_the_effective_allowlist`` (in test_code_mcp_server)
+    and at the profile level in
+    ``test_code_profile_ripple_off_and_scoped_to_the_file_tools``."""
     from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
     from pocketpaw.config import get_settings
 
@@ -449,8 +462,8 @@ async def test_code_profile_grants_no_filesystem_tool_in_the_effective_allowlist
     assert "WebSearch" in effective
     # And at least one MCP id must survive, or a future change that nulls out MCP
     # resolution entirely would make every `not in` above trivially true while the
-    # surface silently loses code_mode too. Not pinned to a specific server — any
-    # surviving mcp__ id proves the MCP filter ran on a populated list.
+    # surface silently loses its file tools too. Not pinned to a specific server —
+    # any surviving mcp__ id proves the MCP filter ran on a populated list.
     assert any(t.startswith("mcp__") for t in effective), (
         "no mcp__ tool survived the allow-list filter — MCP resolution produced "
         "nothing, so the absence assertions above prove nothing"
@@ -532,9 +545,9 @@ async def test_code_profile_builds_no_pocket_in_the_effective_allowlist() -> Non
 
     # Positive controls, so the assertions above cannot pass vacuously.
     assert "WebSearch" in effective
-    assert "mcp__pocketpaw_code__code_mode" in effective, (
-        "code_mode itself was filtered out — the surface has lost its only door "
-        "to the user's project, so the absence assertions above prove nothing"
+    assert "mcp__pocketpaw_code__readFile" in effective, (
+        "the file tools were filtered out — the surface has lost its door to the "
+        "user's project, so the absence assertions above prove nothing"
     )
 
 

--- a/tests/cloud/surface/test_studio_code_handlers.py
+++ b/tests/cloud/surface/test_studio_code_handlers.py
@@ -50,6 +50,20 @@
 # have gone green against the OLD profile too — that one named all six built-ins
 # in the additive ``allowed_sdk_tools`` and shipped them anyway — so the negative
 # has to be asserted against the COMPUTED result, not the declaration.
+#
+# Changes: 2026-07-24 (feat/code-surface-cleanup, CX-4) — dropped the two
+# pocket-authoring guards (``test_code_profile_builds_no_pocket_in_the_effective_
+# allowlist`` and ``test_code_deny_covers_every_widget_tool_and_the_pocket_
+# creation_grant``) and the ``_POCKET_AUTHORING_TOOLS`` literal they read. The
+# surface profile's ``_CODE_POCKET_DENY`` MCP deny-list they pinned was removed:
+# MCP tool restriction for /code is now enforced structurally by the dedicated
+# ``code`` agent's ``tool_mode="exclusive"`` policy, and the pocket repro dying at
+# the allowlist level is proven in ``tests/cloud/agents/test_code_agent_seed.py``.
+# The BUILT-IN denies this surface still owns (file/shell + ``Agent``, and
+# ``Skill``) — which the MCP cap cannot reach — stay guarded here by
+# ``test_code_profile_denies_the_filesystem_builtins_and_subagents``,
+# ``test_code_profile_grants_no_filesystem_tool_in_the_effective_allowlist``, and
+# ``test_code_profile_denies_the_skill_tool``.
 
 from __future__ import annotations
 
@@ -118,20 +132,6 @@ async def test_studio_handler_relays_provider_errors() -> None:
 # The file/shell built-ins the /code agent must not hold. They address the
 # backend server, which is not the machine the user's project is on.
 _FILESYSTEM_BUILTINS = frozenset({"Bash", "Read", "Write", "Edit", "Glob", "Grep"})
-
-# The pocket-AUTHORING tools the /code agent must not hold. Each one is a way to
-# answer "build me an app" with a dashboard instead of code. Read-only pocket
-# access (``get_pocket`` / ``list_pockets``) is deliberately absent from this set
-# — reading a pocket cannot produce one.
-_POCKET_AUTHORING_TOOLS = frozenset(
-    {
-        "mcp__pocketpaw_pocket_specialist__create",
-        "mcp__pocketpaw_pocket_specialist__edit",
-        "mcp__pocketpaw_pocket_planner__plan_pocket",
-        "mcp__pocketpaw_pocket__add_widget",
-        "mcp__pocketpaw_pocket__update_widget",
-    }
-)
 
 # The Daytona MCP tool names the old preamble advertised. They address an older
 # cloud-projects model that knows nothing of the current codeproject +
@@ -470,114 +470,20 @@ async def test_code_profile_grants_no_filesystem_tool_in_the_effective_allowlist
     )
 
 
-async def test_code_profile_builds_no_pocket_in_the_effective_allowlist() -> None:
-    """The /code agent must not be able to BUILD A POCKET.
-
-    Reported from a live session: with a React project open on /code, "Let's
-    build an employee management app, with components, nice design etc" made the
-    agent create a pocket and start authoring a ripple ui-spec instead of writing
-    React. The user asked for an app; the agent shipped a dashboard.
-
-    The preamble already forbids this in prose ("do not build widgets, charts, or
-    a ui-spec, and do not create a pocket"), and the prose lost — exactly as the
-    /sites svelte-create comment predicted when it denied the same two tools
-    rather than asking nicely.
-
-    The reason the deny was needed is that ``allow_mcp_tool_ids`` CANNOT express
-    it. CD-3 scoped /code to ``code_mode``, but ``claude_sdk`` deliberately lets
-    two families survive any restrictive allow-list: ``POCKET_CREATION_GRANT``
-    (create + plan) and ``ALWAYS_ALLOWED_MCP_SERVERS`` (the whole
-    ``pocketpaw_pocket*`` family), plus ``WIDGET_TOOL_IDS`` unioned into the
-    grant. Those bypasses are correct for a general chat surface — "create a
-    pocket" is the core capability — and wrong for this one, where the
-    deliverable is code. Deny runs BEFORE the grant is applied and is the only
-    lever that reaches them.
-
-    Asserted against the COMPUTED allowlist, not the declaration, for the same
-    reason the filesystem test above is: the bypasses live in the computation."""
-    from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
-    from pocketpaw.config import get_settings
-
-    profile = resolve_profile(SurfaceKind.CODE, SurfaceMeta())
-    backend = ClaudeSDKBackend(get_settings())
-
-    built = await backend._build_options(
-        "Let's build an employee management app, with components, nice design etc",
-        system_prompt="you are on the code surface",
-        history=None,
-        session_key=None,
-        deny_mcp_tool_ids=profile.deny_mcp_tool_ids,
-        allow_sdk_tools=profile.allowed_sdk_tools or frozenset(),
-        allow_mcp_tool_ids=profile.allow_mcp_tool_ids,
-        skill_names=profile.skill_names,
-        stderr_sink=[],
-    )
-    effective = set(built.options_kwargs["allowed_tools"])
-
-    for tool in sorted(_POCKET_AUTHORING_TOOLS):
-        assert tool not in effective, (
-            f"{tool} reached the SDK's effective allowlist on /code — the agent "
-            f"can build a pocket instead of writing the user's code. Effective "
-            f"allowlist: {sorted(effective)}"
-        )
-
-    # The ripple widget catalog, by prefix so a widget tool added later is caught
-    # without anyone remembering to update this test. These are the tools that
-    # turn "with components, nice design" into a ui-spec.
-    leaked_widgets = sorted(t for t in effective if t.startswith("mcp__pocketpaw_widgets__"))
-    assert not leaked_widgets, (
-        f"ripple widget tools reached the effective allowlist on /code: "
-        f"{leaked_widgets}. 'Components' on this surface means React/Vue "
-        f"components in the user's project, not ripple widgets in a ui-spec."
-    )
-
-    # No pocket tool of ANY kind survives — read verbs included. An earlier pass
-    # kept ``get_pocket`` / ``list_pockets`` on the reasoning that reading a
-    # pocket cannot produce one; that is true and beside the point, since a
-    # pocket the agent can inspect is a pocket it can propose. Prefix scan, so a
-    # tool added to the server later is caught without updating this test.
-    leaked_pocket = sorted(t for t in effective if t.startswith("mcp__pocketpaw_pocket"))
-    assert not leaked_pocket, (
-        f"pocket tools reached the effective allowlist on /code: {leaked_pocket}. "
-        f"The deliverable on this surface is the user's code; nothing here needs "
-        f"a pocket, in read or write."
-    )
-
-    # Positive controls, so the assertions above cannot pass vacuously.
-    assert "WebSearch" in effective
-    assert "mcp__pocketpaw_code__readFile" in effective, (
-        "the file tools were filtered out — the surface has lost its door to the "
-        "user's project, so the absence assertions above prove nothing"
-    )
-
-
-def test_code_deny_covers_every_widget_tool_and_the_pocket_creation_grant() -> None:
-    """The /code deny set is spelled as literals; pin it against the real sources.
-
-    ``_CODE_POCKET_DENY`` enumerates ids rather than importing them, so the CODE
-    row can stay a STATIC profile with no lazy load. The cost of a literal is
-    drift: a tool added to ``WIDGET_TOOL_IDS`` or ``POCKET_CREATION_GRANT`` later
-    would bypass the allow-list exactly as before and nobody would notice, because
-    both are grant families that survive any restrictive allow-list. This test is
-    what makes the literal safe — it fails the moment a new one appears."""
-    from pocketpaw.agents.claude_sdk import POCKET_CREATION_GRANT
-    from pocketpaw.agents.sdk_mcp_widgets import WIDGET_TOOL_IDS
-
-    profile = resolve_profile(SurfaceKind.CODE, SurfaceMeta())
-
-    missing_widgets = frozenset(WIDGET_TOOL_IDS) - profile.deny_mcp_tool_ids
-    assert not missing_widgets, (
-        f"ripple widget tools not denied on /code: {sorted(missing_widgets)}. "
-        f"WIDGET_TOOL_IDS is unioned into the MCP grant in claude_sdk, so it "
-        f"survives allow_mcp_tool_ids — add these to _CODE_POCKET_DENY."
-    )
-
-    missing_grant = POCKET_CREATION_GRANT - profile.deny_mcp_tool_ids
-    assert not missing_grant, (
-        f"pocket-creation grant tools not denied on /code: {sorted(missing_grant)}. "
-        f"POCKET_CREATION_GRANT bypasses every restrictive allow-list by design — "
-        f"add these to _CODE_POCKET_DENY."
-    )
+# NOTE (2026-07-24, CX-4): the "/code must not BUILD A POCKET" guarantee no longer
+# lives at the SURFACE level and so is no longer asserted here. It used to be
+# enforced by the surface profile's ``_CODE_POCKET_DENY`` MCP deny-list, which this
+# file pinned via ``test_code_profile_builds_no_pocket_in_the_effective_allowlist``
+# and ``test_code_deny_covers_every_widget_tool_and_the_pocket_creation_grant``.
+# Both were REMOVED with the deny-list: MCP tool restriction for /code is now
+# enforced structurally by the dedicated ``code`` agent's exclusive tool policy
+# (``tool_mode="exclusive"`` caps the run's ``mcp__*`` surface to exactly the four
+# file ids). The pocket repro dying at the allowlist level is now proven end to end
+# in ``tests/cloud/agents/test_code_agent_seed.py::
+# test_seeded_code_agent_config_drives_exclusive_allowlist``. What THIS surface
+# profile still owns — and still tests below — is the BUILT-IN tools the MCP cap
+# cannot reach: the file/shell built-ins + ``Agent`` (``_CODE_BUILTIN_DENY``) and
+# ``Skill`` (``_CODE_SKILL_DENY``).
 
 
 def test_code_profile_is_static_and_meta_independent() -> None:

--- a/tests/cloud/test_agent_service_scope.py
+++ b/tests/cloud/test_agent_service_scope.py
@@ -18,6 +18,12 @@ pocket's orientation data (name, description, type, template/pattern, ripple
 summary) for ALL pocket types using the already-fetched Pocket doc — no
 extra DB round-trips. Home keeps its backend_summary alongside the new
 field; non-pocket scopes carry ``pocket_summary=None``.
+
+Updated: 2026-07-24 (CX-3, feat/code-agent-exclusive-tools) — added the CODE
+surface routing tests: an unhinted CODE-surface session/pocket resolution
+routes ``target`` to the dedicated ``code`` agent (``_get_code_agent_id``,
+patched here), an explicit ``agent_id_hint`` is still honored, and non-CODE
+surfaces are byte-identical.
 """
 
 from __future__ import annotations
@@ -745,3 +751,127 @@ async def test_resolve_group_scope_has_no_pocket_summary():
             scope="group", scope_id="g1", user_id="u_caller", agent_id_hint=None
         )
     assert ctx.pocket_summary is None
+
+
+# ===========================================================================
+# CX-3 — the /code surface routes to the dedicated ``code`` agent.
+#
+# On the CODE surface, an unhinted turn resolves ``target`` to the code agent
+# (via ``_get_code_agent_id``, which lazy-seeds) instead of the session's stored
+# agent / the default ``pocketpaw`` agent. An explicit ``agent_id_hint`` is still
+# honored, and every non-CODE surface is byte-identical. These are unit-scoped
+# (the code-agent id is patched); the lazy-seed + end-to-end routing against real
+# Mongo lives in tests/cloud/agents/test_code_agent_seed.py.
+# ===========================================================================
+
+
+def _fake_session(agent):
+    from pocketpaw_ee.cloud.models.session import Session
+
+    return Session.model_construct(
+        id="s1",
+        sessionId="ws",
+        workspace="w1",
+        owner="u1",
+        agent=agent,
+        pocket=None,
+        deleted_at=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_code_surface_routes_session_to_code_agent():
+    """CODE surface + no hint ⇒ ``target`` is the code agent, overriding the
+    session's stored agent."""
+    code_mock = AsyncMock(return_value="code-agent-id")
+    with (
+        patch(
+            "pocketpaw_ee.cloud.chat.agent_service._get_session",
+            AsyncMock(return_value=_fake_session(agent="a1")),
+        ),
+        patch("pocketpaw_ee.cloud.chat.agent_service._get_code_agent_id", code_mock),
+    ):
+        ctx = await resolve_scope_context(
+            scope="session",
+            scope_id="s1",
+            user_id="u1",
+            agent_id_hint=None,
+            surface="code",
+        )
+    assert ctx.target_agent_id == "code-agent-id"
+    code_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_code_surface_respects_explicit_agent_hint():
+    """An explicit ``agent_id_hint`` is honored even on CODE — the override only
+    replaces the DEFAULT resolution, never a caller's pinned agent."""
+    code_mock = AsyncMock(return_value="code-agent-id")
+    with (
+        patch(
+            "pocketpaw_ee.cloud.chat.agent_service._get_session",
+            AsyncMock(return_value=_fake_session(agent="a1")),
+        ),
+        patch("pocketpaw_ee.cloud.chat.agent_service._get_code_agent_id", code_mock),
+    ):
+        ctx = await resolve_scope_context(
+            scope="session",
+            scope_id="s1",
+            user_id="u1",
+            agent_id_hint="a2",
+            surface="code",
+        )
+    assert ctx.target_agent_id == "a2"
+    code_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_non_code_surface_does_not_route_to_code_agent():
+    """A non-CODE surface (or no surface hint) leaves session resolution
+    byte-identical — the code-agent seam is never touched."""
+    code_mock = AsyncMock(return_value="code-agent-id")
+    with (
+        patch(
+            "pocketpaw_ee.cloud.chat.agent_service._get_session",
+            AsyncMock(return_value=_fake_session(agent="a1")),
+        ),
+        patch("pocketpaw_ee.cloud.chat.agent_service._get_code_agent_id", code_mock),
+    ):
+        ctx = await resolve_scope_context(
+            scope="session",
+            scope_id="s1",
+            user_id="u1",
+            agent_id_hint=None,
+            surface="generic",
+        )
+    assert ctx.target_agent_id == "a1"
+    code_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_code_surface_routes_pocket_to_code_agent():
+    """CODE surface + no hint also overrides the pocket's default agent."""
+    pocket = SimpleNamespace(
+        id="p1",
+        workspace="w1",
+        owner="u_caller",
+        team=["u_caller"],
+        agents=["agent_primary"],
+        tool_specs=[],
+        visibility="workspace",
+        shared_with=[],
+    )
+    code_mock = AsyncMock(return_value="code-agent-id")
+    with (
+        patch("pocketpaw_ee.cloud.chat.agent_service._get_pocket", AsyncMock(return_value=pocket)),
+        patch("pocketpaw_ee.cloud.chat.agent_service._get_code_agent_id", code_mock),
+    ):
+        ctx = await resolve_scope_context(
+            scope="pocket",
+            scope_id="p1",
+            user_id="u_caller",
+            agent_id_hint=None,
+            surface="code",
+        )
+    assert ctx.target_agent_id == "code-agent-id"
+    code_mock.assert_awaited_once()

--- a/tests/cloud/test_codeagent_delegates.py
+++ b/tests/cloud/test_codeagent_delegates.py
@@ -29,7 +29,7 @@ from pocketpaw_ee.cloud.codeagent.delegates import (
     MAX_DELEGATE_RESULT_CHARS,
     DelegateOutcome,
     PendingDelegates,
-    delegate_to_browser,
+    delegate_call_to_browser,
     get_pending_delegates,
     resolve_pending,
 )
@@ -68,8 +68,8 @@ async def _park(
     push: object,
     *,
     workspace_id: str = WS,
-    task: str = "add a test",
-    mode: str = "ask",
+    tool: str = "readFile",
+    tool_input: dict | None = None,
     timeout: float = SLOW,
 ) -> asyncio.Task[DelegateOutcome]:
     """Start a delegation and wait until it is actually parked.
@@ -81,10 +81,10 @@ async def _park(
     """
     before = len(reg)
     task_handle = asyncio.create_task(
-        delegate_to_browser(
+        delegate_call_to_browser(
             workspace_id,
-            task,
-            mode,
+            tool,
+            tool_input if tool_input is not None else {"path": "a.py"},
             timeout=timeout,
             registry=reg,
             push=push,  # type: ignore[arg-type]
@@ -123,13 +123,15 @@ async def test_park_then_resolve_returns_the_payload(reg, push):
     assert len(reg) == 0
 
 
-async def test_push_carries_corr_id_task_and_mode(reg, push):
-    handle = await _park(reg, push, task="rename the handler", mode="edit")
+async def test_push_carries_corr_id_tool_and_input(reg, push):
+    handle = await _park(
+        reg, push, tool="writeFile", tool_input={"path": "handler.py", "content": "x"}
+    )
 
     name, data = push.frames[0]
     assert name == DELEGATE_EVENT
-    assert data["task"] == "rename the handler"
-    assert data["mode"] == "edit"
+    assert data["tool"] == "writeFile"
+    assert data["input"] == {"path": "handler.py", "content": "x"}
     assert data["corrId"]
 
     resolve_pending(WS, data["corrId"], {}, registry=reg)
@@ -301,7 +303,9 @@ async def test_a_failed_push_gives_up_immediately(reg):
         raise RuntimeError("sink is gone")
 
     outcome = await asyncio.wait_for(
-        delegate_to_browser(WS, "task", registry=reg, push=_explode, timeout=SLOW),
+        delegate_call_to_browser(
+            WS, "readFile", {"path": "a.py"}, registry=reg, push=_explode, timeout=SLOW
+        ),
         timeout=SLOW,
     )
 
@@ -319,7 +323,7 @@ async def test_no_sse_stream_fails_fast_rather_than_parking(reg):
     is a documented no-op, so parking would burn the full budget on a failure
     that was knowable at the push."""
     outcome = await asyncio.wait_for(
-        delegate_to_browser(WS, "task", registry=reg, timeout=SLOW),
+        delegate_call_to_browser(WS, "readFile", {"path": "a.py"}, registry=reg, timeout=SLOW),
         timeout=SLOW,
     )
 
@@ -340,15 +344,20 @@ async def test_frame_reaches_a_real_attached_sse_sink(reg):
     token = attach_sse_event_sink(queue)
     try:
         handle = asyncio.create_task(
-            delegate_to_browser(WS, "refactor it", "edit", timeout=SLOW, registry=reg)
+            delegate_call_to_browser(
+                WS, "writeFile", {"path": "a.ts", "content": "x"}, timeout=SLOW, registry=reg
+            )
         )
         name, data = await asyncio.wait_for(queue.get(), timeout=SLOW)
         assert name == DELEGATE_EVENT
-        assert data["task"] == "refactor it"
-        assert data["mode"] == "edit"
+        assert data["tool"] == "writeFile"
+        assert data["input"] == {"path": "a.ts", "content": "x"}
 
-        resolve_pending(WS, data["corrId"], {"answer": "ok"}, registry=reg)
-        assert (await asyncio.wait_for(handle, timeout=SLOW)).result == {"answer": "ok"}
+        resolve_pending(WS, data["corrId"], {"output": "ok", "isError": False}, registry=reg)
+        assert (await asyncio.wait_for(handle, timeout=SLOW)).result == {
+            "output": "ok",
+            "isError": False,
+        }
     finally:
         detach_sse_event_sink(token)
 

--- a/tests/cloud/test_codeproject.py
+++ b/tests/cloud/test_codeproject.py
@@ -17,9 +17,10 @@
 #     provisioning a second one.
 #   * open_project REPROVISIONS when the bound sandbox is invalid/unavailable
 #     (reaped) — "if the id is invalid or unavailable, make a new sandbox."
-#   * (CM-2a′) open_project RESTORES the row's durable snapshot into the fresh VM
-#     on reprovision when one exists, and skips restore when there's no snapshot;
-#     a restore failure is swallowed (the fresh clone is still returned ready).
+#   * (CM-2a′, re-anchored in B2) open_project RESTORES the PROJECT's durable
+#     snapshot into the fresh VM on reprovision when one exists, and skips restore
+#     when there's no snapshot; a restore failure is swallowed (the fresh clone is
+#     still returned ready).
 from __future__ import annotations
 
 import pytest
@@ -214,8 +215,16 @@ async def test_open_project_reprovisions_when_vm_deleted_out_of_band() -> None:
 
 
 # ---------------------------------------------------------------------------
-# open_project — CM-2a′ snapshot restore on reprovision.
+# open_project — CM-2a′ snapshot restore on reprovision, PROJECT-anchored (B2).
 # ---------------------------------------------------------------------------
+#
+# Adapted 2026-07-25 (B2, feat/code-daytona-project-anchor). These three tests
+# asserted the same behaviour against the OLD anchor: durable state was staged on
+# the WebSandbox row (``sandbox_service.set_snapshot`` / ``set_overlay_entry``) and
+# restore went through ``restore_workspace(row_id)``. The behaviour under test is
+# unchanged — restore fires on reprovision when either tier exists, and a failure
+# is swallowed — only the anchor moved, so the staging now goes through the project
+# service and the spy asserts the project id + the fresh VM's Daytona id.
 
 
 async def test_open_project_restores_snapshot_on_reprovision(monkeypatch) -> None:
@@ -224,46 +233,55 @@ async def test_open_project_restores_snapshot_on_reprovision(monkeypatch) -> Non
 
     restored: list[dict] = []
 
-    async def _spy_restore(workspace_id, user_id, row_id, *, client=None):  # noqa: ANN001
-        restored.append({"workspace_id": workspace_id, "user_id": user_id, "row_id": row_id})
+    async def _spy_restore(workspace_id, user_id, project_id, sandbox_id, *, client=None):  # noqa: ANN001
+        restored.append(
+            {
+                "workspace_id": workspace_id,
+                "user_id": user_id,
+                "project_id": project_id,
+                "sandbox_id": sandbox_id,
+            }
+        )
 
-    monkeypatch.setattr(lifecycle.websandbox_durability, "restore_workspace", _spy_restore)
+    monkeypatch.setattr(lifecycle.websandbox_durability, "restore_project", _spy_restore)
 
-    # First open: a fresh row with no snapshot → nothing to restore.
+    # First open: a fresh project with no snapshot → nothing to restore.
     first = await lifecycle.open_project(_WS, _USER, project.id, client=fake)
     assert restored == []
 
-    # A clean disconnect captured a snapshot onto the stable row; then the VM was
-    # reaped out from under the project.
-    await sandbox_service.set_snapshot(_WS, _USER, first.id, "file-123")
+    # A clean disconnect captured a snapshot onto the durable PROJECT; then the VM
+    # was reaped out from under it.
+    await service.set_project_snapshot(_WS, _USER, project.id, "file-123")
     await sandbox_service.mark_reaped(first.id)
 
-    # Reopening reprovisions a fresh VM AND restores the row's snapshot into it.
+    # Reopening reprovisions a fresh VM AND restores the project's snapshot into it.
     second = await lifecycle.open_project(_WS, _USER, project.id, client=fake)
     assert second.id == first.id
     assert len(restored) == 1
-    assert restored[0]["row_id"] == second.id
+    assert restored[0]["project_id"] == project.id
+    # Restored into the FRESH VM, addressed by its Daytona id (not the row id).
+    assert restored[0]["sandbox_id"] == second.sandbox_id
 
 
 async def test_open_project_restores_overlay_only_on_reprovision(monkeypatch) -> None:
-    # The crash-before-any-snapshot case: the row carries a write-through overlay
-    # but no snapshot. Restore must still fire.
+    # The crash-before-any-snapshot case: the project carries a write-through
+    # overlay but no snapshot. Restore must still fire.
     project = await service.create_project(_WS, _USER, {"repo": _REPO})
     fake = _FakeDaytonaClient()
 
     restored: list[str] = []
 
-    async def _spy_restore(workspace_id, user_id, row_id, *, client=None):  # noqa: ANN001
-        restored.append(row_id)
+    async def _spy_restore(workspace_id, user_id, project_id, sandbox_id, *, client=None):  # noqa: ANN001
+        restored.append(project_id)
 
-    monkeypatch.setattr(lifecycle.websandbox_durability, "restore_workspace", _spy_restore)
+    monkeypatch.setattr(lifecycle.websandbox_durability, "restore_project", _spy_restore)
 
     first = await lifecycle.open_project(_WS, _USER, project.id, client=fake)
-    await sandbox_service.set_overlay_entry(_WS, _USER, first.id, "a.ts", "file-1")
+    await service.set_project_overlay_entry(_WS, _USER, project.id, "a.ts", "file-1")
     await sandbox_service.mark_reaped(first.id)
 
-    second = await lifecycle.open_project(_WS, _USER, project.id, client=fake)
-    assert restored == [second.id]
+    await lifecycle.open_project(_WS, _USER, project.id, client=fake)
+    assert restored == [project.id]
 
 
 async def test_open_project_swallows_restore_failure(monkeypatch) -> None:
@@ -271,13 +289,13 @@ async def test_open_project_swallows_restore_failure(monkeypatch) -> None:
     fake = _FakeDaytonaClient()
 
     first = await lifecycle.open_project(_WS, _USER, project.id, client=fake)
-    await sandbox_service.set_snapshot(_WS, _USER, first.id, "file-123")
+    await service.set_project_snapshot(_WS, _USER, project.id, "file-123")
     await sandbox_service.mark_reaped(first.id)
 
-    async def _boom_restore(workspace_id, user_id, row_id, *, client=None):  # noqa: ANN001
+    async def _boom_restore(workspace_id, user_id, project_id, sandbox_id, *, client=None):  # noqa: ANN001
         raise RuntimeError("boom: restore failed")
 
-    monkeypatch.setattr(lifecycle.websandbox_durability, "restore_workspace", _boom_restore)
+    monkeypatch.setattr(lifecycle.websandbox_durability, "restore_project", _boom_restore)
 
     # A restore failure is best-effort: the open still returns a ready sandbox
     # (the fresh clone), not an error.

--- a/tests/cloud/test_codeproject.py
+++ b/tests/cloud/test_codeproject.py
@@ -342,3 +342,105 @@ async def test_a_git_repo_stays_idempotent() -> None:
 
     assert second.id == first.id
     assert len(await service.list_projects(_WS, _USER)) == 1
+
+
+# ---------------------------------------------------------------------------
+# initial build prompt — persist on create, expose on the wire, mark consumed.
+# ---------------------------------------------------------------------------
+#
+# A1 (feat/code-initial-prompt): creating a /code project from a description
+# records WHAT to build on the durable row, exposes it on the wire so the frontend
+# can auto-run one build turn on first open, and offers an owner-scoped op to latch
+# it consumed on turn start (re-armable on a retry-build).
+
+
+async def test_create_persists_initial_prompt_unconsumed_and_exposes_it() -> None:
+    view = await service.create_project(
+        _WS,
+        _USER,
+        {
+            "repo": _STARTER,
+            "provider": "starter",
+            "name": "todo app",
+            "initial_prompt": "build a todo app",
+        },
+    )
+    assert view.initial_prompt == "build a todo app"
+    assert view.initial_prompt_consumed is False
+
+    # It survives a reload and reaches the camelCase wire response.
+    reloaded = await service.get_project(_WS, _USER, view.id)
+    assert reloaded.initial_prompt == "build a todo app"
+    wire = service.view_to_wire(reloaded)
+    assert wire.initialPrompt == "build a todo app"
+    assert wire.initialPromptConsumed is False
+
+
+async def test_create_without_initial_prompt_leaves_it_null() -> None:
+    view = await service.create_project(_WS, _USER, {"repo": _REPO})
+    assert view.initial_prompt is None
+    assert view.initial_prompt_consumed is False
+    assert service.view_to_wire(view).initialPrompt is None
+
+
+async def test_github_idempotent_recreate_does_not_overwrite_prompt() -> None:
+    first = await service.create_project(
+        _WS, _USER, {"repo": _REPO, "initial_prompt": "the original prompt"}
+    )
+    # A second create for the same git repo is an idempotent hit — the existing
+    # row is returned UNCHANGED, so a stray prompt on the re-create can't clobber it.
+    second = await service.create_project(
+        _WS, _USER, {"repo": _REPO, "initial_prompt": "a different prompt"}
+    )
+    assert second.id == first.id
+    assert second.initial_prompt == "the original prompt"
+
+
+async def test_mark_initial_prompt_consumed_sets_true() -> None:
+    project = await service.create_project(
+        _WS, _USER, {"repo": _STARTER, "provider": "starter", "initial_prompt": "build it"}
+    )
+    assert project.initial_prompt_consumed is False
+
+    updated = await service.mark_initial_prompt_consumed(_WS, _USER, project.id, {})
+    assert updated.initial_prompt_consumed is True
+    # The prompt itself is untouched — only the flag flips.
+    assert updated.initial_prompt == "build it"
+    assert (await service.get_project(_WS, _USER, project.id)).initial_prompt_consumed is True
+
+
+async def test_mark_initial_prompt_consumed_can_reset() -> None:
+    project = await service.create_project(
+        _WS, _USER, {"repo": _STARTER, "provider": "starter", "initial_prompt": "build it"}
+    )
+    await service.mark_initial_prompt_consumed(_WS, _USER, project.id, {"consumed": True})
+    # A retry-build re-arms the prompt.
+    rearmed = await service.mark_initial_prompt_consumed(
+        _WS, _USER, project.id, {"consumed": False}
+    )
+    assert rearmed.initial_prompt_consumed is False
+
+
+async def test_mark_initial_prompt_consumed_already_consumed_is_noop() -> None:
+    project = await service.create_project(
+        _WS, _USER, {"repo": _STARTER, "provider": "starter", "initial_prompt": "build it"}
+    )
+    once = await service.mark_initial_prompt_consumed(_WS, _USER, project.id, {"consumed": True})
+    # Marking it consumed again is a clean no-op, not an error.
+    twice = await service.mark_initial_prompt_consumed(_WS, _USER, project.id, {"consumed": True})
+    assert once.initial_prompt_consumed is True
+    assert twice.initial_prompt_consumed is True
+
+
+async def test_mark_initial_prompt_consumed_is_owner_scoped() -> None:
+    mine = await service.create_project(
+        _WS, _USER, {"repo": _STARTER, "provider": "starter", "initial_prompt": "build it"}
+    )
+    # Another user in the same workspace can't consume my project's prompt.
+    with pytest.raises(NotFound):
+        await service.mark_initial_prompt_consumed(_WS, "user-2", mine.id, {"consumed": True})
+    # A different workspace can't either.
+    with pytest.raises(NotFound):
+        await service.mark_initial_prompt_consumed("ws-2", _USER, mine.id, {"consumed": True})
+    # Still un-consumed for the real owner — no cross-tenant write leaked through.
+    assert (await service.get_project(_WS, _USER, mine.id)).initial_prompt_consumed is False

--- a/tests/cloud/test_codeproject_bulk_files.py
+++ b/tests/cloud/test_codeproject_bulk_files.py
@@ -1,0 +1,140 @@
+# test_codeproject_bulk_files.py — the in-tab whole-project write.
+#
+# Created 2026-07-25 (S1 follow-up). `put_project_files` is the in-tab analog of
+# the VM's `sync_project_files`: the browser hosts the filesystem, so it is the
+# only thing that can enumerate one, and it posts the whole map at once.
+#
+# What these lock is the property that makes the restore-time PRUNE safe to run:
+# `overlay_complete` may only ever be set by a write that WHOLLY succeeded. A
+# store marked complete after a partial upload would license deleting exactly the
+# files that failed to upload — so the all-or-nothing test below is the important
+# one, not the happy path.
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import CloudError, NotFound, ValidationError
+from pocketpaw_ee.cloud.codeproject import service as codeproject_service
+from pocketpaw_ee.cloud.websandbox import durability
+
+from tests.cloud.test_codeproject_file_sync import _FakeUploads, _project
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+_WS = "w1"
+_USER = "u1"
+
+
+async def test_a_whole_project_write_marks_the_store_complete() -> None:
+    """The happy path, and the flag that licenses the prune."""
+    project = await _project()
+    uploads = _FakeUploads()
+
+    stored = await durability.put_project_files(
+        _WS,
+        _USER,
+        project.id,
+        {"src/App.tsx": "export default App;", "README.md": "# hi"},
+        uploads=uploads,
+    )
+
+    assert stored == 2
+    view = await codeproject_service.get_project(_WS, _USER, project.id)
+    assert set(view.overlay) == {"src/App.tsx", "README.md"}
+    assert view.overlay_complete is True
+
+
+async def test_a_replacement_drops_a_path_the_client_no_longer_has() -> None:
+    """The delete that used to come back. The map is the project, so a path the
+    client didn't send is a path the project doesn't have."""
+    project = await _project()
+    uploads = _FakeUploads()
+
+    await durability.put_project_files(
+        _WS, _USER, project.id, {"keep.ts": "a", "delete-me.ts": "b"}, uploads=uploads
+    )
+    await durability.put_project_files(_WS, _USER, project.id, {"keep.ts": "a"}, uploads=uploads)
+
+    view = await codeproject_service.get_project(_WS, _USER, project.id)
+    assert set(view.overlay) == {"keep.ts"}
+
+
+async def test_a_failed_upload_leaves_the_store_untouched_and_incomplete() -> None:
+    """THE load-bearing test. A partial upload must not become a complete store,
+    because `overlay_complete` is what lets the restore prune delete files."""
+    project = await _project()
+    uploads = _FakeUploads()
+
+    # Seed a known-good prior state so we can prove it survives the failure.
+    await durability.put_project_files(_WS, _USER, project.id, {"before.ts": "x"}, uploads=uploads)
+    await codeproject_service.replace_project_overlay(
+        _WS, _USER, project.id, {"before.ts": "file-1"}, complete=False
+    )
+
+    calls = {"n": 0}
+    original = uploads.upload
+
+    async def _fail_on_second(*args, **kwargs):  # noqa: ANN002, ANN003
+        calls["n"] += 1
+        if calls["n"] >= 2:
+            raise RuntimeError("storage went away mid-write")
+        return await original(*args, **kwargs)
+
+    uploads.upload = _fail_on_second  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError):
+        await durability.put_project_files(
+            _WS, _USER, project.id, {"a.ts": "1", "b.ts": "2", "c.ts": "3"}, uploads=uploads
+        )
+
+    view = await codeproject_service.get_project(_WS, _USER, project.id)
+    assert set(view.overlay) == {"before.ts"}, "a failed write must not swap the map"
+    assert view.overlay_complete is False, "a partial upload must never read as complete"
+
+
+async def test_an_escaping_path_is_rejected_before_anything_uploads() -> None:
+    """Jailed at the boundary, and jailed BEFORE the first upload — a rejected
+    batch should not leave orphan blobs behind."""
+    project = await _project()
+    uploads = _FakeUploads()
+
+    with pytest.raises(ValidationError):
+        await durability.put_project_files(
+            _WS, _USER, project.id, {"ok.ts": "a", "../escape.ts": "b"}, uploads=uploads
+        )
+
+    assert uploads.upload_calls == []
+    view = await codeproject_service.get_project(_WS, _USER, project.id)
+    assert view.overlay == {}
+
+
+async def test_over_the_file_count_cap_fails_loud(monkeypatch) -> None:  # noqa: ANN001
+    """Loud, not truncated — a silently short store is the input to a prune."""
+    project = await _project()
+    uploads = _FakeUploads()
+    monkeypatch.setattr(durability, "_overlay_max_files", lambda: 2)
+
+    with pytest.raises(CloudError) as err:
+        await durability.put_project_files(
+            _WS, _USER, project.id, {"a": "1", "b": "2", "c": "3"}, uploads=uploads
+        )
+
+    assert err.value.code == "codeproject.overlay_too_many_files"
+    assert uploads.upload_calls == []
+
+
+async def test_a_foreign_caller_cannot_replace_the_store() -> None:
+    """Rejected, and rejected BEFORE spending storage — an unauthorized request
+    should not be able to upload its way to a 404."""
+    project = await _project()
+    uploads = _FakeUploads()
+
+    with pytest.raises(NotFound):
+        await durability.put_project_files(
+            "other-ws", _USER, project.id, {"a.ts": "1"}, uploads=uploads
+        )
+    with pytest.raises(NotFound):
+        await durability.put_project_files(
+            _WS, "other-user", project.id, {"a.ts": "1"}, uploads=uploads
+        )
+
+    assert uploads.upload_calls == [], "a foreign caller must not reach the upload path"

--- a/tests/cloud/test_codeproject_cross_runtime.py
+++ b/tests/cloud/test_codeproject_cross_runtime.py
@@ -1,0 +1,515 @@
+# test_codeproject_cross_runtime.py — the CROSS-RUNTIME restore matrix (B4,
+# feat/code-cross-runtime-restore): whatever a project saved in one runtime must be
+# retrievable from the other.
+#
+# Created 2026-07-25 (feat/code-cross-runtime-restore).
+#
+# The bug these guard: a project worked on in DAYTONA lands its state in the
+# snapshot tar, and ``set_project_snapshot`` clears the overlay (correctly — the tar
+# supersedes it). The in-tab read-back looked only at the overlay, so reopening that
+# same project in a browser tab returned ``{}`` and the client re-materialized the
+# bare starter scaffold. The user's work looked deleted while it sat safe in S3
+# inside a tarball no browser can read.
+#
+# Fakes only: blob storage through the ``uploads=`` DI seam, Daytona through
+# ``client=`` — no test touches real S3 or a real VM. The CodeProject registry runs
+# on real Beanie over mongomock-motor (the ``mongo_db`` fixture) so the owner-scoped
+# snapshot/overlay writes are exercised for real. Snapshot blobs are REAL gzipped
+# tars built in memory with ``tarfile``, so the expander is tested against the exact
+# archive shape ``tar -czf ... -C <workdir> .`` produces (members named ``./x``).
+#
+# Covers:
+#   * Daytona -> in-tab: a snapshot with an EMPTY overlay reads back the tar's files.
+#   * merge order: a path in BOTH tiers reads back the OVERLAY's content.
+#   * in-tab -> Daytona: an overlay-only project (snapshot_file_id is None) restores
+#     into a fresh VM without needing a snapshot.
+#   * filtering: node_modules / .git / build output and binary entries are excluded;
+#     ordinary nested source (incl. non-ASCII text) survives byte-identical.
+#   * tar safety: absolute, ``..``-traversing, and symlink members are skipped.
+#   * caps: a filtered snapshot still over the cap fails LOUD, never partial.
+from __future__ import annotations
+
+import io
+import logging
+import tarfile
+from datetime import UTC, datetime
+
+import pytest
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud._core.errors import CloudError
+from pocketpaw_ee.cloud.codeproject import router as codeproject_router
+from pocketpaw_ee.cloud.codeproject import service as codeproject_service
+from pocketpaw_ee.cloud.websandbox import durability
+from pocketpaw_ee.cloud.websandbox import ws as terminal_ws
+from pocketpaw_ee.cloud.websandbox.constants import WEBSANDBOX_WORKDIR
+
+from pocketpaw.uploads.errors import NotFound as UploadNotFound
+from pocketpaw.uploads.file_store import FileRecord
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+_WS = "w1"
+_USER = "u1"
+_SANDBOX = "dtn-1"
+
+
+# ---------------------------------------------------------------------------
+# Fakes + tar builder.
+# ---------------------------------------------------------------------------
+
+
+class _FakeDaytonaClient:
+    """Records VM ops and serves a canned tarball on download (the snapshot)."""
+
+    def __init__(self, tar_bytes: bytes = b"") -> None:
+        self.tar_bytes = tar_bytes
+        self.exec_calls: list[str] = []
+        self.upload_calls: list[dict] = []
+
+    async def execute_command(self, sandbox_id, command, **kwargs):  # noqa: ANN001
+        self.exec_calls.append(command)
+        return None
+
+    async def download_file(self, sandbox_id, remote_path):  # noqa: ANN001
+        return self.tar_bytes
+
+    async def upload_bytes(self, sandbox_id, data, remote_path):  # noqa: ANN001
+        self.upload_calls.append({"data": data, "remote_path": remote_path})
+
+
+class _FakeUploads:
+    """In-memory EEUploadService stand-in: one instance carries the blobs."""
+
+    def __init__(self) -> None:
+        self.upload_calls: list[dict] = []
+        self._blobs: dict[str, bytes] = {}
+        self._counter = 0
+
+    async def upload(self, file, owner_id, chat_id, workspace, folder_path="/", pocket_id=None):  # noqa: ANN001
+        data = await file.read()
+        self._counter += 1
+        file_id = f"file-{self._counter}"
+        self.upload_calls.append({"folder_path": folder_path, "data": data})
+        self._blobs[file_id] = data
+        return FileRecord(
+            id=file_id,
+            storage_key=f"key/{file_id}",
+            filename=file.filename,
+            mime="application/octet-stream",
+            size=len(data),
+            owner_id=owner_id,
+            chat_id=None,
+            created=datetime.now(UTC),
+        )
+
+    async def stream(self, file_id, requester_id, workspace):  # noqa: ANN001
+        if file_id not in self._blobs:
+            raise UploadNotFound()
+        data = self._blobs[file_id]
+        rec = FileRecord(
+            id=file_id,
+            storage_key=f"key/{file_id}",
+            filename="blob",
+            mime="application/octet-stream",
+            size=len(data),
+            owner_id=requester_id,
+            chat_id=None,
+            created=datetime.now(UTC),
+        )
+
+        async def _iter():
+            yield data
+
+        return rec, _iter()
+
+
+def _tar(files: dict[str, bytes], *, symlinks: dict[str, str] | None = None) -> bytes:
+    """A REAL gzipped tar shaped like ``tar -czf ... -C <workdir> .`` output.
+
+    Arcnames are passed through verbatim so a test can spell a member exactly as the
+    expander will see it (``./src/app.ts``, ``/etc/passwd``, ``../escape.ts``).
+    Directory entries are emitted for realism — they carry no content and must not
+    show up in the payload.
+    """
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as archive:
+        dirs: set[str] = set()
+        for name in files:
+            parent = name.rsplit("/", 1)[0]
+            if parent and parent not in dirs:
+                dirs.add(parent)
+                info = tarfile.TarInfo(parent)
+                info.type = tarfile.DIRTYPE
+                archive.addfile(info)
+        for name, blob in files.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(blob)
+            archive.addfile(info, io.BytesIO(blob))
+        for name, target in (symlinks or {}).items():
+            info = tarfile.TarInfo(name)
+            info.type = tarfile.SYMTYPE
+            info.linkname = target
+            archive.addfile(info)
+    return buf.getvalue()
+
+
+async def _project(workspace=_WS, user=_USER):  # noqa: ANN001
+    return await codeproject_service.create_project(
+        workspace, user, {"repo": "react", "provider": "starter"}
+    )
+
+
+async def _daytona_session(project_id: str, uploads: _FakeUploads, tar_bytes: bytes) -> None:
+    """Simulate a Daytona session ending: snapshot the VM, which clears the overlay."""
+    await durability.snapshot_project(
+        _WS,
+        _USER,
+        project_id,
+        _SANDBOX,
+        client=_FakeDaytonaClient(tar_bytes=tar_bytes),
+        uploads=uploads,
+    )
+
+
+def _ctx(workspace=_WS, user=_USER):  # noqa: ANN001
+    return RequestContext(
+        user_id=user,
+        workspace_id=workspace,
+        request_id="req-1",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Daytona -> in-tab. THE regression: snapshot set, overlay cleared, read back.
+# ---------------------------------------------------------------------------
+
+
+async def test_snapshot_only_project_reads_back_the_tars_files() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+
+    # Work done in the VM, then a disconnect snapshot — which CLEARS the overlay.
+    await durability.mirror_file_to_project(
+        _WS, _USER, project.id, "src/app.ts", b"pre-snapshot", uploads=uploads
+    )
+    await _daytona_session(
+        project.id,
+        uploads,
+        _tar({"./src/app.ts": b"console.log('work')", "./README.md": b"# hi"}),
+    )
+    fetched = await codeproject_service.get_project(_WS, _USER, project.id)
+    assert fetched.snapshot_file_id is not None
+    assert fetched.overlay == {}  # the state this read-back used to return as {}
+
+    files = await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads)
+
+    # The user's work comes back in the browser instead of a bare scaffold.
+    assert files == {"src/app.ts": "console.log('work')", "README.md": "# hi"}
+
+
+async def test_route_serves_the_snapshot_to_the_in_tab_runtime(monkeypatch) -> None:  # noqa: ANN001
+    # Same regression one layer up: the wire payload the tab actually replays.
+    project = await _project()
+    uploads = _FakeUploads()
+    monkeypatch.setattr(durability, "build_uploads", lambda: uploads)
+    await _daytona_session(project.id, uploads, _tar({"./index.html": b"<h1>hi</h1>"}))
+
+    listing = await codeproject_router.read_project_files(project.id, ctx=_ctx())
+
+    assert listing.files == {"index.html": "<h1>hi</h1>"}
+
+
+# ---------------------------------------------------------------------------
+# 2. Merge order — the overlay is the freshest tier and wins.
+# ---------------------------------------------------------------------------
+
+
+async def test_overlay_wins_over_the_snapshot_for_the_same_path() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+    await _daytona_session(
+        project.id,
+        uploads,
+        _tar({"./src/app.ts": b"OLD-FROM-TAR", "./only-in-tar.ts": b"BASE"}),
+    )
+    # An edit made AFTER the snapshot (either runtime writes this tier).
+    await durability.put_project_file(
+        _WS, _USER, project.id, "src/app.ts", "NEW-FROM-OVERLAY", uploads=uploads
+    )
+
+    files = await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads)
+
+    assert files == {"src/app.ts": "NEW-FROM-OVERLAY", "only-in-tar.ts": "BASE"}
+
+
+async def test_tiers_are_composed_in_the_same_order_the_vm_restore_replays() -> None:
+    # The VM restore untars the snapshot then writes the overlay over it. The
+    # read-back must agree, or the two runtimes disagree about the same project.
+    project = await _project()
+    uploads = _FakeUploads()
+    await _daytona_session(project.id, uploads, _tar({"./a.ts": b"TAR-A"}))
+    await durability.put_project_file(_WS, _USER, project.id, "a.ts", "OVERLAY-A", uploads=uploads)
+
+    vm = _FakeDaytonaClient()
+    await durability.restore_project(
+        _WS, _USER, project.id, "dtn-fresh", client=vm, uploads=uploads
+    )
+    read_back = await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads)
+
+    # The VM's LAST write to a.ts is the overlay copy...
+    vm_writes = [u for u in vm.upload_calls if u["remote_path"] == f"{WEBSANDBOX_WORKDIR}/a.ts"]
+    assert vm_writes[-1]["data"] == b"OVERLAY-A"
+    # ...and the browser payload agrees.
+    assert read_back["a.ts"] == "OVERLAY-A"
+
+
+# ---------------------------------------------------------------------------
+# 3. In-tab -> Daytona. The reverse direction, proven rather than assumed.
+# ---------------------------------------------------------------------------
+
+
+async def test_overlay_only_project_restores_into_a_fresh_vm() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+    # Written from the browser: the in-tab runtime never writes a snapshot.
+    await durability.put_project_file(
+        _WS, _USER, project.id, "src/app.ts", "from the tab", uploads=uploads
+    )
+    await durability.put_project_file(_WS, _USER, project.id, "top.ts", "T", uploads=uploads)
+    assert (await codeproject_service.get_project(_WS, _USER, project.id)).snapshot_file_id is None
+
+    vm = _FakeDaytonaClient()
+    await durability.restore_project(
+        _WS, _USER, project.id, "dtn-fresh", client=vm, uploads=uploads
+    )
+
+    # No snapshot needed — the overlay replays on its own, byte-for-byte.
+    assert not any("tar -xzf" in c for c in vm.exec_calls)
+    written = {u["remote_path"]: u["data"] for u in vm.upload_calls}
+    assert written[f"{WEBSANDBOX_WORKDIR}/src/app.ts"] == b"from the tab"
+    assert written[f"{WEBSANDBOX_WORKDIR}/top.ts"] == b"T"
+    assert any(f"mkdir -p {WEBSANDBOX_WORKDIR}/src" in c for c in vm.exec_calls)
+
+
+async def test_a_tab_written_file_survives_a_round_trip_through_the_vm() -> None:
+    # The full loop: tab writes -> VM restores + snapshots -> tab reads it back.
+    project = await _project()
+    uploads = _FakeUploads()
+    await durability.put_project_file(_WS, _USER, project.id, "note.md", "# mine", uploads=uploads)
+
+    vm = _FakeDaytonaClient()
+    await durability.restore_project(
+        _WS, _USER, project.id, "dtn-fresh", client=vm, uploads=uploads
+    )
+    # The VM session ends and tars what it restored.
+    await _daytona_session(project.id, uploads, _tar({"./note.md": b"# mine"}))
+
+    files = await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads)
+    assert files == {"note.md": "# mine"}
+
+
+# ---------------------------------------------------------------------------
+# 4. Filtering — regenerable trees and binary blobs never reach the browser.
+# ---------------------------------------------------------------------------
+
+
+async def test_regenerable_trees_and_binaries_are_excluded_but_source_survives() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+    source = "export const x = 1;\n// naïve — üñí\n"
+    await _daytona_session(
+        project.id,
+        uploads,
+        _tar(
+            {
+                "./node_modules/left-pad/index.js": b"module.exports = 1",
+                "./src/node_modules/nested/pkg.js": b"deep dep",
+                "./.git/objects/ab/cdef": b"\x00binary-git-object",
+                "./dist/bundle.js": b"built",
+                "./build/out.js": b"built",
+                "./.next/server/page.js": b"built",
+                "./.svelte-kit/generated/root.js": b"built",
+                "./.turbo/log.txt": b"cached",
+                "./.cache/x": b"cached",
+                "./coverage/lcov.info": b"report",
+                "./assets/logo.png": b"\x89PNG\r\n\x1a\n\xff\xfe",  # not UTF-8
+                "./src/deep/nested/mod.ts": source.encode("utf-8"),
+                "./package.json": b'{"name":"app"}',
+            }
+        ),
+    )
+
+    files = await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads)
+
+    assert set(files) == {"src/deep/nested/mod.ts", "package.json"}
+    # Byte-identical, non-ASCII included.
+    assert files["src/deep/nested/mod.ts"] == source
+    assert files["src/deep/nested/mod.ts"].encode("utf-8") == source.encode("utf-8")
+
+
+async def test_a_file_named_like_an_excluded_tree_is_kept() -> None:
+    # The filter matches whole path SEGMENTS — ``build.ts`` is source, ``build/`` is
+    # output. Dropping a user's file because of a prefix would be data loss.
+    project = await _project()
+    uploads = _FakeUploads()
+    await _daytona_session(
+        project.id,
+        uploads,
+        _tar({"./build.ts": b"SRC", "./src/dist-utils.ts": b"SRC2", "./build/x.js": b"OUT"}),
+    )
+
+    files = await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads)
+
+    assert files == {"build.ts": "SRC", "src/dist-utils.ts": "SRC2"}
+
+
+# ---------------------------------------------------------------------------
+# 5. Tar safety — the archive is untrusted input.
+# ---------------------------------------------------------------------------
+
+
+async def test_unsafe_tar_members_are_skipped_not_written() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+    await _daytona_session(
+        project.id,
+        uploads,
+        _tar(
+            {
+                "/etc/passwd": b"root:x:0:0",  # absolute
+                "../../escape.ts": b"ESCAPED",  # traversal
+                "./src/../../also-escape.ts": b"ESCAPED",  # traversal mid-path
+                "./ok.ts": b"OK",
+            },
+            symlinks={"./link-out.ts": "/etc/passwd", "./inner-link.ts": "ok.ts"},
+        ),
+    )
+
+    files = await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads)
+
+    # Only the one legitimate member survives — no absolute path, no traversal, and
+    # no link entry (a symlink is a smuggling vector with no meaning in a tab FS).
+    assert files == {"ok.ts": "OK"}
+    assert not any(p.startswith("/") or ".." in p for p in files)
+
+
+async def test_directory_members_do_not_become_files() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+    await _daytona_session(project.id, uploads, _tar({"./src/a.ts": b"A"}))
+
+    files = await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads)
+
+    assert files == {"src/a.ts": "A"}
+    assert "src" not in files
+
+
+# ---------------------------------------------------------------------------
+# Caps + failure modes — loud, never silently partial.
+# ---------------------------------------------------------------------------
+
+
+async def test_a_filtered_snapshot_over_the_byte_cap_fails_loud(monkeypatch) -> None:  # noqa: ANN001
+    # Policy: what survives filtering IS user work, so a truncated payload would
+    # look like deleted files. 413 instead — the project still opens in the VM
+    # runtime, whose restore has no such cap.
+    project = await _project()
+    uploads = _FakeUploads()
+    await _daytona_session(project.id, uploads, _tar({"./big.ts": b"x" * 4096}))
+    monkeypatch.setenv("POCKETPAW_CODEPROJECT_OVERLAY_MAX_MB", "0.001")  # ~1 KB
+
+    with pytest.raises(CloudError) as exc:
+        await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads)
+    assert exc.value.code == "codeproject.overlay_too_large"
+    assert exc.value.status_code == 413
+
+
+async def test_excluded_bytes_do_not_count_against_the_cap(monkeypatch) -> None:  # noqa: ANN001
+    # The complement: a huge node_modules must NOT push a small source tree over
+    # the cap, or every real project would 413.
+    project = await _project()
+    uploads = _FakeUploads()
+    await _daytona_session(
+        project.id,
+        uploads,
+        _tar({"./node_modules/huge/blob.js": b"y" * 200_000, "./src/a.ts": b"A"}),
+    )
+    monkeypatch.setenv("POCKETPAW_CODEPROJECT_OVERLAY_MAX_MB", "0.001")  # ~1 KB
+
+    assert await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads) == {
+        "src/a.ts": "A"
+    }
+
+
+async def test_a_corrupt_snapshot_raises_instead_of_returning_a_partial_tree() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+    await _daytona_session(project.id, uploads, b"NOT-A-TARBALL")
+    await durability.put_project_file(_WS, _USER, project.id, "a.ts", "A", uploads=uploads)
+
+    with pytest.raises(CloudError) as exc:
+        await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads)
+    # Returning just the overlay here would silently drop the whole baseline.
+    assert exc.value.code == "codeproject.snapshot_unreadable"
+    assert exc.value.status_code == 502
+
+
+async def test_a_truncated_snapshot_raises_too() -> None:
+    # Truncation fails in the DECOMPRESSOR mid-iteration, not at open — a different
+    # exception family, same "the baseline is gone" outcome, same loud answer.
+    project = await _project()
+    uploads = _FakeUploads()
+    whole = _tar({f"./f{i}.ts": b"x" * 500 for i in range(50)})
+    await _daytona_session(project.id, uploads, whole[: len(whole) // 2])
+
+    with pytest.raises(CloudError) as exc:
+        await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads)
+    assert exc.value.code == "codeproject.snapshot_unreadable"
+
+
+async def test_a_project_with_neither_tier_still_reads_back_empty() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+
+    assert await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads) == {}
+
+
+async def test_a_swallowed_durability_failure_is_logged_at_warning(monkeypatch, caplog) -> None:  # noqa: ANN001
+    """A misconfigured cloud persists nothing — that must be visible, not debug-only.
+
+    The exact production shape: ``POCKETPAW_UPLOAD_ADAPTER != s3`` in cloud makes the
+    project store fail closed on EVERY save. FileRpc swallows the hook failure (right
+    — the VM write already landed), so before this fix the only trace was a debug line.
+    """
+    project = await _project()
+    uploads = _FakeUploads()
+    monkeypatch.setattr(durability, "is_multi_tenant_cloud", lambda: True)
+    monkeypatch.setenv("POCKETPAW_UPLOAD_ADAPTER", "local")
+
+    on_write, _on_delete, _on_move = terminal_ws.build_durability_hooks(
+        _WS, _USER, "row-1", project.id, uploads
+    )
+    with caplog.at_level(logging.WARNING, logger="pocketpaw_ee.cloud.websandbox.ws"):
+        await on_write("src/app.ts", b"A")  # must NOT raise into the file op
+
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings, "a failed durable write was invisible"
+    message = warnings[-1].getMessage()
+    assert project.id in message and "src/app.ts" in message
+    # Still swallowed, and still genuinely unpersisted (the guard did its job).
+    assert (await codeproject_service.get_project(_WS, _USER, project.id)).overlay == {}
+
+
+async def test_the_snapshot_tier_is_owner_scoped_too() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+    await _daytona_session(project.id, uploads, _tar({"./secret.ts": b"S"}))
+
+    from pocketpaw_ee.cloud._core.errors import NotFound
+
+    with pytest.raises(NotFound):
+        await durability.read_project_overlay("w2", _USER, project.id, uploads=uploads)
+    with pytest.raises(NotFound):
+        await durability.read_project_overlay(_WS, "u2", project.id, uploads=uploads)

--- a/tests/cloud/test_codeproject_cross_runtime.py
+++ b/tests/cloud/test_codeproject_cross_runtime.py
@@ -27,6 +27,13 @@
 #     ordinary nested source (incl. non-ASCII text) survives byte-identical.
 #   * tar safety: absolute, ``..``-traversing, and symlink members are skipped.
 #   * caps: a filtered snapshot still over the cap fails LOUD, never partial.
+#
+# Updated 2026-07-25 (S1, feat/code-s3-authoritative): ``snapshot_project`` is gone —
+# the tarball tier was retired because a tar cannot express a DELETE — so the
+# "a Daytona session ended" setup now stages the LEGACY row shape directly (tar in
+# blob storage + ``snapshot_file_id`` pointing at it). That is deliberately still the
+# scenario under test: the browser read-back must keep serving such a project until a
+# VM open migrates it to per-file entries. The read path itself is unchanged.
 from __future__ import annotations
 
 import io
@@ -160,15 +167,24 @@ async def _project(workspace=_WS, user=_USER):  # noqa: ANN001
 
 
 async def _daytona_session(project_id: str, uploads: _FakeUploads, tar_bytes: bytes) -> None:
-    """Simulate a Daytona session ending: snapshot the VM, which clears the overlay."""
-    await durability.snapshot_project(
-        _WS,
-        _USER,
-        project_id,
-        _SANDBOX,
-        client=_FakeDaytonaClient(tar_bytes=tar_bytes),
-        uploads=uploads,
+    """Stage a LEGACY tarball snapshot on a project (pre-S1 durable state).
+
+    S1 retired the tarball tier and deleted ``snapshot_project``, so this stages the
+    state directly: land the tar in blob storage and point the project at it. That
+    is exactly the row shape a project written by the old Daytona path still has in
+    Mongo today, which is what these cross-runtime read-back tests are about — the
+    browser must keep serving a legacy project's files until a VM open migrates it.
+    """
+    file_id = await durability._upload_project_blob(
+        uploads,
+        tar_bytes,
+        workspace_id=_WS,
+        user_id=_USER,
+        filename="legacy-snapshot.tgz",
+        folder="/code-project-snapshots",
+        content_type="application/gzip",
     )
+    await codeproject_service.set_project_snapshot(_WS, _USER, project_id, file_id)
 
 
 def _ctx(workspace=_WS, user=_USER):  # noqa: ANN001
@@ -190,10 +206,9 @@ async def test_snapshot_only_project_reads_back_the_tars_files() -> None:
     project = await _project()
     uploads = _FakeUploads()
 
-    # Work done in the VM, then a disconnect snapshot — which CLEARS the overlay.
-    await durability.mirror_file_to_project(
-        _WS, _USER, project.id, "src/app.ts", b"pre-snapshot", uploads=uploads
-    )
+    # A pre-S1 Daytona session: everything the user did is inside the tarball and
+    # the overlay is empty (the old ``set_project_snapshot`` cleared it, which is
+    # exactly the state that made this read-back return ``{}``).
     await _daytona_session(
         project.id,
         uploads,

--- a/tests/cloud/test_codeproject_daytona_anchor.py
+++ b/tests/cloud/test_codeproject_daytona_anchor.py
@@ -1,0 +1,434 @@
+# test_codeproject_daytona_anchor.py — the B2 cutover: the DAYTONA runtime's
+# durability is anchored on the durable CodeProject, not on the ephemeral
+# WebSandbox row.
+#
+# Created 2026-07-25 (B2, feat/code-daytona-project-anchor).
+#
+# The bug this removes: a WebSandbox row is unique per (workspace, user, repo),
+# and a SCAFFOLD project puts a TEMPLATE id in ``repo``. Every project built from
+# the same starter therefore shared ONE row — and, before this change, one
+# ``snapshot_file_id`` + one ``overlay``. Two projects would have overwritten each
+# other's durable state. Anchoring on the project id removes that by construction.
+#
+# What is proved here, end to end, on real Beanie over mongomock-motor (the
+# ``mongo_db`` fixture) with FAKE Daytona + FAKE blob storage injected through the
+# existing DI seams:
+#   * the full chain stays intact and moves whole: provision -> mirror a write ->
+#     snapshot on disconnect -> reprovision -> restore, with every pointer read
+#     from the CodeProject and the WebSandbox row's durable fields never written.
+#   * the collision is gone: two projects sharing one starter ``repo`` (and even
+#     one sandbox ROW) hold independent durable state.
+#   * the degrade path: a sandbox with NO owning project still mirrors and
+#     snapshots against the row exactly as before — no write is dropped.
+#   * the rollout backfill: a repo project with legacy state on its sandbox row
+#     adopts it on open, is idempotent on a second open, is non-destructive to the
+#     row, never overwrites state the project already holds, and never fires for a
+#     scaffold project (whose row is shared).
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from pocketpaw_ee.cloud.codeproject import lifecycle
+from pocketpaw_ee.cloud.codeproject import service as codeproject_service
+from pocketpaw_ee.cloud.websandbox import durability
+from pocketpaw_ee.cloud.websandbox import provision as websandbox_provision
+from pocketpaw_ee.cloud.websandbox import service as sandbox_service
+from pocketpaw_ee.cloud.websandbox import ws as terminal_ws
+
+from tests.cloud.test_codeproject_durability import _FakeDaytonaClient as _FakeVmClient
+from tests.cloud.test_codeproject_durability import _FakeUploads
+from tests.cloud.test_websandbox_provision import _FakeDaytonaClient as _FakeProvisionClient
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+_WS = "ws-1"
+_USER = "user-1"
+_REPO = "https://github.com/acme/widgets.git"
+_STARTER = "react"
+_SNAPSHOT_TMP = "/tmp/ws-snapshot.tgz"  # noqa: S108 — a sandbox VM path, not host
+
+
+@pytest.fixture()
+def uploads(monkeypatch) -> _FakeUploads:  # noqa: ANN001
+    """A fake blob store wired in as the module default.
+
+    ``snapshot_on_disconnect`` and ``restore_project`` (via ``open_project``) build
+    their own uploads service, so the DI seam has to be closed at the module level
+    for a whole-chain test. One instance carries the blobs, so bytes written by a
+    mirror or a snapshot are readable by the later restore.
+    """
+    fake = _FakeUploads()
+    monkeypatch.setattr(durability, "build_uploads", lambda: fake)
+    return fake
+
+
+async def _starter_row():
+    """Register the runtime row a starter project would get.
+
+    Registered directly rather than through ``provision.open_sandbox`` because the
+    provisioner only accepts an http(s) git URL — scaffold-on-Daytona is a separate
+    task. What matters here is the ROW's key: it is (workspace, user, repo), and
+    ``repo`` is the template id, so every project on that starter resolves to this
+    one row.
+    """
+    return await sandbox_service.create_sandbox(
+        _WS, _USER, {"repo": _STARTER, "sandbox_id": "dtn-shared", "status": "ready"}
+    )
+
+
+# ---------------------------------------------------------------------------
+# Proof 1 — the whole chain, project-anchored.
+# ---------------------------------------------------------------------------
+
+
+async def test_full_chain_mirrors_snapshots_and_restores_against_the_project(uploads) -> None:  # noqa: ANN001
+    """provision -> mirror -> snapshot on disconnect -> reprovision -> restore.
+
+    Every durable pointer is read off the CodeProject; the WebSandbox row's
+    ``snapshot_file_id`` / ``overlay`` are never written, so nothing in the chain
+    depends on the ephemeral row surviving.
+    """
+    project = await codeproject_service.create_project(_WS, _USER, {"repo": _REPO})
+    prov = _FakeProvisionClient()
+
+    # 1. Open the project — cold-provisions a VM and binds the row.
+    sandbox = await lifecycle.open_project(_WS, _USER, project.id, client=prov)
+    assert sandbox.sandbox_id is not None
+
+    # The terminal socket knows only its ROW; it resolves the durable anchor.
+    project_id = await terminal_ws.resolve_owning_project(_WS, _USER, sandbox.id)
+    assert project_id == project.id
+
+    # 2. An editor save flows through the socket's write-through hook.
+    on_write, _on_delete, _on_move = terminal_ws.build_durability_hooks(
+        _WS, _USER, sandbox.id, project_id, uploads
+    )
+    await on_write("src/app.ts", b"EDITED-IN-THE-VM")
+
+    stored = await codeproject_service.get_project(_WS, _USER, project.id)
+    assert list(stored.overlay) == ["src/app.ts"]
+    row = await sandbox_service.get_sandbox(_WS, _USER, sandbox.id)
+    assert row.overlay == {}, "the mirror still wrote to the EPHEMERAL row"
+
+    # 3. A clean disconnect snapshots the live VM onto the project.
+    vm = _FakeVmClient(tar_bytes=b"SNAPSHOT-TAR")
+    await terminal_ws.snapshot_on_disconnect(
+        _WS,
+        _USER,
+        sandbox.id,
+        vm,
+        project_id=project_id,
+        daytona_id=sandbox.sandbox_id,
+    )
+    snapshotted = await codeproject_service.get_project(_WS, _USER, project.id)
+    assert snapshotted.snapshot_file_id is not None
+    assert snapshotted.overlay == {}, "a full snapshot supersedes the overlay"
+    row = await sandbox_service.get_sandbox(_WS, _USER, sandbox.id)
+    assert row.snapshot_file_id is None, "the snapshot pointer landed on the EPHEMERAL row"
+
+    # 4. The VM is reaped; reopening reprovisions and restores from the PROJECT.
+    await sandbox_service.mark_reaped(sandbox.id)
+    second = await lifecycle.open_project(_WS, _USER, project.id, client=prov)
+    assert second.sandbox_id != sandbox.sandbox_id  # genuinely fresh VM
+
+    untarred = [c for c in prov.upload_calls if c["path"] == _SNAPSHOT_TMP]
+    assert untarred, "the project's snapshot was never pushed into the fresh VM"
+    assert untarred[-1]["data"] == b"SNAPSHOT-TAR"
+    assert untarred[-1]["id"] == second.sandbox_id
+
+
+async def test_delete_and_move_hooks_also_target_the_project(uploads) -> None:  # noqa: ANN001
+    """The delete / rename sides of the overlay move with the write side."""
+    project = await codeproject_service.create_project(_WS, _USER, {"repo": _REPO})
+    prov = _FakeProvisionClient()
+    sandbox = await lifecycle.open_project(_WS, _USER, project.id, client=prov)
+
+    on_write, on_delete, on_move = terminal_ws.build_durability_hooks(
+        _WS, _USER, sandbox.id, project.id, uploads
+    )
+    await on_write("a.ts", b"A")
+    await on_write("dir/b.ts", b"B")
+
+    await on_move("a.ts", "renamed.ts")
+    await on_delete("dir")
+
+    stored = await codeproject_service.get_project(_WS, _USER, project.id)
+    assert list(stored.overlay) == ["renamed.ts"]
+    row = await sandbox_service.get_sandbox(_WS, _USER, sandbox.id)
+    assert row.overlay == {}
+
+
+# ---------------------------------------------------------------------------
+# Proof 2 — the collision is gone.
+# ---------------------------------------------------------------------------
+
+
+async def test_two_projects_on_one_starter_row_hold_independent_state(uploads) -> None:  # noqa: ANN001
+    """The bug, stated as the behaviour we want.
+
+    Two projects built from the same starter share ONE WebSandbox row (it is keyed
+    (workspace, user, repo) and ``repo`` is a template id). Their durable state must
+    still be their own.
+    """
+    todo = await codeproject_service.create_project(
+        _WS, _USER, {"repo": _STARTER, "provider": "starter", "name": "todo"}
+    )
+    blog = await codeproject_service.create_project(
+        _WS, _USER, {"repo": _STARTER, "provider": "starter", "name": "blog"}
+    )
+    assert todo.id != blog.id
+
+    # One shared runtime row, both projects bound to it — the collision, exactly.
+    # ``create_sandbox`` is idempotent on (workspace, user, repo), so registering
+    # each project's runtime hands back the SAME row: that is the collision, not a
+    # contrivance of the test.
+    shared = await _starter_row()
+    assert (await _starter_row()).id == shared.id
+
+    await codeproject_service.bind_current_sandbox(_WS, _USER, todo.id, shared.id)
+    await codeproject_service.bind_current_sandbox(_WS, _USER, blog.id, shared.id)
+
+    todo_write, _d, _m = terminal_ws.build_durability_hooks(_WS, _USER, shared.id, todo.id, uploads)
+    blog_write, _d2, _m2 = terminal_ws.build_durability_hooks(
+        _WS, _USER, shared.id, blog.id, uploads
+    )
+    await todo_write("todo.ts", b"T")
+    await blog_write("blog.ts", b"B")
+
+    todo_state = await codeproject_service.get_project(_WS, _USER, todo.id)
+    blog_state = await codeproject_service.get_project(_WS, _USER, blog.id)
+    assert list(todo_state.overlay) == ["todo.ts"]
+    assert list(blog_state.overlay) == ["blog.ts"], (
+        "one project's files landed on the other — the durable state is still shared"
+    )
+
+    # And the shared ephemeral row — the thing they used to collide on — holds none.
+    row = await sandbox_service.get_sandbox(_WS, _USER, shared.id)
+    assert row.overlay == {}
+    assert row.snapshot_file_id is None
+
+
+async def test_shared_row_resolves_to_the_most_recently_opened_project() -> None:
+    """When a row is shared, the socket belongs to the project just opened.
+
+    ``open_project`` re-stamps ``last_opened_at`` immediately before the browser
+    connects, so "most recently opened" is what identifies the editor on the other
+    end of this socket.
+    """
+    todo = await codeproject_service.create_project(
+        _WS, _USER, {"repo": _STARTER, "provider": "starter", "name": "todo"}
+    )
+    blog = await codeproject_service.create_project(
+        _WS, _USER, {"repo": _STARTER, "provider": "starter", "name": "blog"}
+    )
+    shared = await _starter_row()
+
+    await codeproject_service.bind_current_sandbox(_WS, _USER, todo.id, shared.id)
+    # BSON datetimes are millisecond-precision, and a real user's two opens are
+    # seconds apart — step past the tick so the test asserts ordering, not a tie.
+    await asyncio.sleep(0.005)
+    await codeproject_service.bind_current_sandbox(_WS, _USER, blog.id, shared.id)
+    assert await terminal_ws.resolve_owning_project(_WS, _USER, shared.id) == blog.id
+
+    # Reopening the first project moves the anchor back to it.
+    await asyncio.sleep(0.005)
+    await codeproject_service.bind_current_sandbox(_WS, _USER, todo.id, shared.id)
+    assert await terminal_ws.resolve_owning_project(_WS, _USER, shared.id) == todo.id
+
+
+async def test_resolve_owning_project_is_tenant_and_owner_scoped() -> None:
+    project = await codeproject_service.create_project(_WS, _USER, {"repo": _REPO})
+    sandbox = await websandbox_provision.open_sandbox(
+        _WS, _USER, {"repo": _REPO}, client=_FakeProvisionClient()
+    )
+    await codeproject_service.bind_current_sandbox(_WS, _USER, project.id, sandbox.id)
+
+    assert await terminal_ws.resolve_owning_project(_WS, _USER, sandbox.id) == project.id
+    # Another user / another workspace can't resolve someone else's project.
+    assert await terminal_ws.resolve_owning_project(_WS, "user-2", sandbox.id) is None
+    assert await terminal_ws.resolve_owning_project("ws-2", _USER, sandbox.id) is None
+
+
+# ---------------------------------------------------------------------------
+# Proof 3 — degrade, never drop: a sandbox with no owning project.
+# ---------------------------------------------------------------------------
+
+
+async def test_sandbox_without_a_project_keeps_the_sandbox_keyed_behaviour(uploads) -> None:  # noqa: ANN001
+    """A sandbox opened outside the project flow still mirrors and snapshots.
+
+    Falling back to the older anchor persists the user's edits; skipping the write
+    would lose them. That trade is the whole reason the degrade path exists.
+    """
+    prov = _FakeProvisionClient()
+    sandbox = await websandbox_provision.open_sandbox(_WS, _USER, {"repo": _REPO}, client=prov)
+    assert sandbox.sandbox_id is not None
+
+    project_id = await terminal_ws.resolve_owning_project(_WS, _USER, sandbox.id)
+    assert project_id is None  # nothing owns this row
+
+    on_write, on_delete, on_move = terminal_ws.build_durability_hooks(
+        _WS, _USER, sandbox.id, project_id, uploads
+    )
+    await on_write("a.ts", b"A")
+    await on_write("gone.ts", b"G")
+    await on_move("a.ts", "b.ts")
+    await on_delete("gone.ts")
+
+    row = await sandbox_service.get_sandbox(_WS, _USER, sandbox.id)
+    assert list(row.overlay) == ["b.ts"], "the write was dropped instead of degrading"
+
+    # The disconnect snapshot degrades the same way — onto the row.
+    vm = _FakeVmClient(tar_bytes=b"ROW-TAR")
+    await terminal_ws.snapshot_on_disconnect(_WS, _USER, sandbox.id, vm, project_id=None)
+    row = await sandbox_service.get_sandbox(_WS, _USER, sandbox.id)
+    assert row.snapshot_file_id is not None
+    assert row.overlay == {}
+
+
+async def test_snapshot_degrades_when_the_row_has_no_bound_vm(uploads) -> None:  # noqa: ANN001
+    """A project id with no Daytona id can't address a VM — fall back, don't skip."""
+    project = await codeproject_service.create_project(_WS, _USER, {"repo": _REPO})
+    sandbox = await websandbox_provision.open_sandbox(
+        _WS, _USER, {"repo": _REPO}, client=_FakeProvisionClient()
+    )
+    await codeproject_service.bind_current_sandbox(_WS, _USER, project.id, sandbox.id)
+
+    vm = _FakeVmClient(tar_bytes=b"ROW-TAR")
+    await terminal_ws.snapshot_on_disconnect(
+        _WS, _USER, sandbox.id, vm, project_id=project.id, daytona_id=None
+    )
+    # Landed on the row (the sandbox-keyed path), not silently nowhere.
+    row = await sandbox_service.get_sandbox(_WS, _USER, sandbox.id)
+    assert row.snapshot_file_id is not None
+    assert (await codeproject_service.get_project(_WS, _USER, project.id)).snapshot_file_id is None
+
+
+# ---------------------------------------------------------------------------
+# Proof 4 — the rollout backfill.
+# ---------------------------------------------------------------------------
+
+
+async def _bind_legacy_state(
+    project_id: str,
+    prov: _FakeProvisionClient,
+    *,
+    snapshot: str = "legacy-snap",
+    overlay: tuple[str, str] = ("legacy.ts", "legacy-file"),
+) -> str:
+    """Open a project, then stage pre-cutover durable state on its sandbox ROW."""
+    sandbox = await lifecycle.open_project(_WS, _USER, project_id, client=prov)
+    # set_snapshot clears the overlay, so the snapshot goes first (the same order
+    # the legacy runtime produced: snapshot on disconnect, then edits after it).
+    await sandbox_service.set_snapshot(_WS, _USER, sandbox.id, snapshot)
+    await sandbox_service.set_overlay_entry(_WS, _USER, sandbox.id, overlay[0], overlay[1])
+    await sandbox_service.mark_reaped(sandbox.id)
+    return sandbox.id
+
+
+async def test_backfill_adopts_legacy_sandbox_state_on_open(monkeypatch) -> None:  # noqa: ANN001
+    project = await codeproject_service.create_project(_WS, _USER, {"repo": _REPO})
+    prov = _FakeProvisionClient()
+    row_id = await _bind_legacy_state(project.id, prov)
+
+    restored: list[str] = []
+
+    async def _spy_restore(workspace_id, user_id, project_id, sandbox_id, *, client=None):  # noqa: ANN001
+        restored.append(project_id)
+
+    monkeypatch.setattr(lifecycle.websandbox_durability, "restore_project", _spy_restore)
+
+    await lifecycle.open_project(_WS, _USER, project.id, client=prov)
+
+    adopted = await codeproject_service.get_project(_WS, _USER, project.id)
+    assert adopted.snapshot_file_id == "legacy-snap"
+    assert adopted.overlay == {"legacy.ts": "legacy-file"}
+    # …and the adopted state is what the reprovision restored from.
+    assert restored == [project.id]
+
+    # Non-destructive: the legacy fields stay readable for the rollout window.
+    row = await sandbox_service.get_sandbox(_WS, _USER, row_id)
+    assert row.snapshot_file_id == "legacy-snap"
+    assert row.overlay == {"legacy.ts": "legacy-file"}
+
+
+async def test_backfill_is_idempotent_across_opens(monkeypatch) -> None:  # noqa: ANN001
+    project = await codeproject_service.create_project(_WS, _USER, {"repo": _REPO})
+    prov = _FakeProvisionClient()
+    await _bind_legacy_state(project.id, prov)
+
+    async def _noop_restore(workspace_id, user_id, project_id, sandbox_id, *, client=None):  # noqa: ANN001
+        return None
+
+    monkeypatch.setattr(lifecycle.websandbox_durability, "restore_project", _noop_restore)
+
+    await lifecycle.open_project(_WS, _USER, project.id, client=prov)
+    first = await codeproject_service.get_project(_WS, _USER, project.id)
+
+    # A second open re-runs the backfill check and must change nothing.
+    await lifecycle.open_project(_WS, _USER, project.id, client=prov)
+    second = await codeproject_service.get_project(_WS, _USER, project.id)
+
+    assert second.snapshot_file_id == first.snapshot_file_id == "legacy-snap"
+    assert second.overlay == first.overlay == {"legacy.ts": "legacy-file"}
+
+
+async def test_backfill_never_overwrites_state_the_project_already_holds(monkeypatch) -> None:  # noqa: ANN001
+    project = await codeproject_service.create_project(_WS, _USER, {"repo": _REPO})
+    prov = _FakeProvisionClient()
+    await _bind_legacy_state(project.id, prov)
+
+    # The project has already snapshotted since the cutover — fresher than the row.
+    await codeproject_service.set_project_snapshot(_WS, _USER, project.id, "fresh-snap")
+    await codeproject_service.set_project_overlay_entry(
+        _WS, _USER, project.id, "new.ts", "new-file"
+    )
+
+    async def _noop_restore(workspace_id, user_id, project_id, sandbox_id, *, client=None):  # noqa: ANN001
+        return None
+
+    monkeypatch.setattr(lifecycle.websandbox_durability, "restore_project", _noop_restore)
+
+    await lifecycle.open_project(_WS, _USER, project.id, client=prov)
+
+    kept = await codeproject_service.get_project(_WS, _USER, project.id)
+    assert kept.snapshot_file_id == "fresh-snap", "a stale legacy pointer overwrote live work"
+    assert kept.overlay == {"new.ts": "new-file"}
+
+
+async def test_backfill_skips_scaffold_projects(monkeypatch) -> None:  # noqa: ANN001
+    """A scaffold project's row is SHARED with every sibling on the same starter.
+
+    Adopting it would copy one project's files into N others — the exact stomping
+    this cutover removes. Scaffold projects never persisted through the Daytona
+    path anyway, so there is nothing to carry across.
+    """
+    project = await codeproject_service.create_project(
+        _WS, _USER, {"repo": _STARTER, "provider": "starter", "name": "todo"}
+    )
+    sandbox = await _starter_row()
+    await codeproject_service.bind_current_sandbox(_WS, _USER, project.id, sandbox.id)
+    await sandbox_service.set_snapshot(_WS, _USER, sandbox.id, "legacy-snap")
+
+    async def _noop_restore(workspace_id, user_id, project_id, sandbox_id, *, client=None):  # noqa: ANN001
+        return None
+
+    monkeypatch.setattr(lifecycle.websandbox_durability, "restore_project", _noop_restore)
+
+    await lifecycle.open_project(_WS, _USER, project.id, client=_FakeProvisionClient())
+
+    fresh = await codeproject_service.get_project(_WS, _USER, project.id)
+    assert fresh.snapshot_file_id is None
+    assert fresh.overlay == {}
+
+
+async def test_adopt_legacy_durability_is_owner_scoped() -> None:
+    from pocketpaw_ee.cloud._core.errors import NotFound
+
+    mine = await codeproject_service.create_project(_WS, _USER, {"repo": _REPO})
+    with pytest.raises(NotFound):
+        await codeproject_service.adopt_legacy_durability(
+            _WS, "user-2", mine.id, "hijacked-snap", {"x.ts": "hijacked"}
+        )
+    assert (await codeproject_service.get_project(_WS, _USER, mine.id)).snapshot_file_id is None

--- a/tests/cloud/test_codeproject_daytona_anchor.py
+++ b/tests/cloud/test_codeproject_daytona_anchor.py
@@ -35,9 +35,10 @@ from pocketpaw_ee.cloud.websandbox import durability
 from pocketpaw_ee.cloud.websandbox import provision as websandbox_provision
 from pocketpaw_ee.cloud.websandbox import service as sandbox_service
 from pocketpaw_ee.cloud.websandbox import ws as terminal_ws
+from pocketpaw_ee.cloud.websandbox.constants import WEBSANDBOX_WORKDIR
 
 from tests.cloud.test_codeproject_durability import _FakeDaytonaClient as _FakeVmClient
-from tests.cloud.test_codeproject_durability import _FakeUploads
+from tests.cloud.test_codeproject_durability import _FakeUploads, _tar
 from tests.cloud.test_websandbox_provision import _FakeDaytonaClient as _FakeProvisionClient
 
 pytestmark = pytest.mark.usefixtures("mongo_db")
@@ -82,12 +83,15 @@ async def _starter_row():
 # ---------------------------------------------------------------------------
 
 
-async def test_full_chain_mirrors_snapshots_and_restores_against_the_project(uploads) -> None:  # noqa: ANN001
-    """provision -> mirror -> snapshot on disconnect -> reprovision -> restore.
+async def test_full_chain_mirrors_captures_and_restores_against_the_project(uploads) -> None:  # noqa: ANN001
+    """provision -> mirror -> capture on disconnect -> reprovision -> restore.
 
     Every durable pointer is read off the CodeProject; the WebSandbox row's
     ``snapshot_file_id`` / ``overlay`` are never written, so nothing in the chain
     depends on the ephemeral row surviving.
+
+    The disconnect capture is a per-file SYNC since S1, not a tarball snapshot, so
+    what the chain carries across is the store itself.
     """
     project = await codeproject_service.create_project(_WS, _USER, {"repo": _REPO})
     prov = _FakeProvisionClient()
@@ -111,8 +115,12 @@ async def test_full_chain_mirrors_snapshots_and_restores_against_the_project(upl
     row = await sandbox_service.get_sandbox(_WS, _USER, sandbox.id)
     assert row.overlay == {}, "the mirror still wrote to the EPHEMERAL row"
 
-    # 3. A clean disconnect snapshots the live VM onto the project.
-    vm = _FakeVmClient(tar_bytes=b"SNAPSHOT-TAR")
+    # 3. A clean disconnect re-images the live VM's workspace onto the project. The
+    #    tree carries a file the write hook never saw (a clone's own file) — the
+    #    whole reason the capture enumerates the VM instead of trusting the hooks.
+    vm = _FakeVmClient(
+        tar_bytes=_tar({"./src/app.ts": b"EDITED-IN-THE-VM", "./README.md": b"# hi"})
+    )
     await terminal_ws.snapshot_on_disconnect(
         _WS,
         _USER,
@@ -121,21 +129,24 @@ async def test_full_chain_mirrors_snapshots_and_restores_against_the_project(upl
         project_id=project_id,
         daytona_id=sandbox.sandbox_id,
     )
-    snapshotted = await codeproject_service.get_project(_WS, _USER, project.id)
-    assert snapshotted.snapshot_file_id is not None
-    assert snapshotted.overlay == {}, "a full snapshot supersedes the overlay"
+    captured = await codeproject_service.get_project(_WS, _USER, project.id)
+    assert set(captured.overlay) == {"src/app.ts", "README.md"}
+    assert captured.overlay_complete is True
+    assert captured.snapshot_file_id is None, "the retired tarball tier was written to"
     row = await sandbox_service.get_sandbox(_WS, _USER, sandbox.id)
-    assert row.snapshot_file_id is None, "the snapshot pointer landed on the EPHEMERAL row"
+    assert row.snapshot_file_id is None, "the capture landed on the EPHEMERAL row"
+    assert row.overlay == {}
 
     # 4. The VM is reaped; reopening reprovisions and restores from the PROJECT.
     await sandbox_service.mark_reaped(sandbox.id)
     second = await lifecycle.open_project(_WS, _USER, project.id, client=prov)
     assert second.sandbox_id != sandbox.sandbox_id  # genuinely fresh VM
 
-    untarred = [c for c in prov.upload_calls if c["path"] == _SNAPSHOT_TMP]
-    assert untarred, "the project's snapshot was never pushed into the fresh VM"
-    assert untarred[-1]["data"] == b"SNAPSHOT-TAR"
-    assert untarred[-1]["id"] == second.sandbox_id
+    # Every stored file was pushed into the fresh VM, and no tarball was untarred.
+    pushed = {c["path"]: c["data"] for c in prov.upload_calls if c["id"] == second.sandbox_id}
+    assert pushed[f"{WEBSANDBOX_WORKDIR}/src/app.ts"] == b"EDITED-IN-THE-VM"
+    assert pushed[f"{WEBSANDBOX_WORKDIR}/README.md"] == b"# hi"
+    assert _SNAPSHOT_TMP not in pushed
 
 
 async def test_delete_and_move_hooks_also_target_the_project(uploads) -> None:  # noqa: ANN001

--- a/tests/cloud/test_codeproject_durability.py
+++ b/tests/cloud/test_codeproject_durability.py
@@ -1,0 +1,410 @@
+# test_codeproject_durability.py — unit tests for the PROJECT-KEYED durable store
+# (F, feat/code-durable-project-store): S3 snapshot + per-file overlay anchored on
+# the durable CodeProject row, round-tripped through EEUploadService independent of
+# any runtime and independent of the ephemeral WebSandbox row.
+#
+# Created 2026-07-24 (feat/code-durable-project-store).
+#
+# All Daytona AND blob-storage interaction goes through FAKES injected via the DI
+# seams (``client=`` + ``uploads=``) — no test touches real Daytona or S3. The
+# CodeProject registry runs on real Beanie over mongomock-motor (the ``mongo_db``
+# fixture) so ``set_project_snapshot``'s owner-scoped write and ``get_project``'s
+# tenant filter are exercised for real. The VM to snapshot/restore is passed as an
+# explicit Daytona ``sandbox_id`` string (never resolved from a WebSandbox row) —
+# which is exactly how these tests prove "no WebSandbox row involved".
+#
+# Covers:
+#   * round-trip: snapshot + overlay write to a project by id, then restore the
+#     bytes byte-for-byte — with NO WebSandbox row created anywhere.
+#   * independence: two projects sharing the SAME starter ``repo`` in one
+#     workspace hold independent snapshot + overlay pointers (no collision).
+#   * snapshot clears the overlay (a full snapshot supersedes it).
+#   * overlay drop / move re-key the durable project pointer.
+#   * S3 guard: the project-keyed durable WRITE path RAISES a clean CloudError in
+#     cloud when the upload adapter isn't s3; does NOT raise on a non-cloud/OSS
+#     install.
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import CloudError
+from pocketpaw_ee.cloud.codeproject import service as codeproject_service
+from pocketpaw_ee.cloud.models.web_sandbox import WebSandbox as _WebSandboxDoc
+from pocketpaw_ee.cloud.websandbox import durability
+from pocketpaw_ee.cloud.websandbox.constants import WEBSANDBOX_WORKDIR
+
+from pocketpaw.uploads.errors import NotFound as UploadNotFound
+from pocketpaw.uploads.file_store import FileRecord
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+_WS = "w1"
+_USER = "u1"
+_SANDBOX = "dtn-1"  # a Daytona id passed straight in — no WebSandbox row behind it
+
+
+# ---------------------------------------------------------------------------
+# Fakes (same shape as the websandbox durability suite).
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeDaytonaClient:
+    tar_bytes: bytes = b"CANNED-TAR-BYTES"
+    exec_calls: list[str] = field(default_factory=list)
+    download_calls: list[str] = field(default_factory=list)
+    upload_calls: list[dict] = field(default_factory=list)
+
+    async def execute_command(self, sandbox_id, command, **kwargs):  # noqa: ANN001
+        self.exec_calls.append(command)
+        return None
+
+    async def download_file(self, sandbox_id, remote_path):  # noqa: ANN001
+        self.download_calls.append(remote_path)
+        return self.tar_bytes
+
+    async def upload_bytes(self, sandbox_id, data, remote_path):  # noqa: ANN001
+        self.upload_calls.append(
+            {"sandbox_id": sandbox_id, "data": data, "remote_path": remote_path}
+        )
+
+
+class _FakeUploads:
+    """In-memory stand-in for EEUploadService: records ``upload`` and serves the
+    bytes back on ``stream``. A single instance carries the blob so a snapshot
+    written here is readable by a later restore in the same test."""
+
+    def __init__(self) -> None:
+        self.upload_calls: list[dict] = []
+        self._blobs: dict[str, bytes] = {}
+        self._counter = 0
+
+    async def upload(self, file, owner_id, chat_id, workspace, folder_path="/", pocket_id=None):  # noqa: ANN001
+        data = await file.read()
+        self._counter += 1
+        file_id = f"file-{self._counter}"
+        self.upload_calls.append(
+            {
+                "owner_id": owner_id,
+                "workspace": workspace,
+                "folder_path": folder_path,
+                "filename": file.filename,
+                "content_type": file.content_type,
+                "data": data,
+            }
+        )
+        self._blobs[file_id] = data
+        return FileRecord(
+            id=file_id,
+            storage_key=f"key/{file_id}",
+            filename=file.filename,
+            mime="application/gzip",
+            size=len(data),
+            owner_id=owner_id,
+            chat_id=None,
+            created=datetime.now(UTC),
+        )
+
+    async def stream(self, file_id, requester_id, workspace):  # noqa: ANN001
+        if file_id not in self._blobs:
+            raise UploadNotFound()
+        data = self._blobs[file_id]
+        rec = FileRecord(
+            id=file_id,
+            storage_key=f"key/{file_id}",
+            filename="code-project-snapshot.tgz",
+            mime="application/gzip",
+            size=len(data),
+            owner_id=requester_id,
+            chat_id=None,
+            created=datetime.now(UTC),
+        )
+
+        async def _iter():
+            yield data
+
+        return rec, _iter()
+
+
+async def _project(workspace=_WS, user=_USER, repo="react", provider="starter", name=None):  # noqa: ANN001
+    """Create a durable project row (starter by default, so two share one repo)."""
+    body = {"repo": repo, "provider": provider}
+    if name is not None:
+        body["name"] = name
+    return await codeproject_service.create_project(workspace, user, body)
+
+
+# ---------------------------------------------------------------------------
+# Round-trip — snapshot + overlay written to a project, restored byte-for-byte,
+# with NO WebSandbox row involved.
+# ---------------------------------------------------------------------------
+
+
+async def test_snapshot_uploads_and_records_pointer_on_project() -> None:
+    project = await _project()
+    fake = _FakeDaytonaClient(tar_bytes=b"HELLO-SNAPSHOT")
+    uploads = _FakeUploads()
+
+    file_id = await durability.snapshot_project(
+        _WS, _USER, project.id, _SANDBOX, client=fake, uploads=uploads
+    )
+
+    # Tarred the workspace dir in the VM, then downloaded the tarball.
+    assert any("tar -czf" in c and WEBSANDBOX_WORKDIR in c for c in fake.exec_calls)
+    assert fake.download_calls == ["/tmp/ws-snapshot.tgz"]
+
+    # Uploaded the exact bytes, workspace + owner scoped, in the PROJECT snapshots
+    # folder — grouped separately from the sandbox-keyed folder.
+    assert len(uploads.upload_calls) == 1
+    up = uploads.upload_calls[0]
+    assert up["workspace"] == _WS
+    assert up["owner_id"] == _USER
+    assert up["folder_path"] == "/code-project-snapshots"
+    assert up["data"] == b"HELLO-SNAPSHOT"
+    assert up["content_type"] == "application/gzip"
+
+    # The durable pointer is returned AND persisted on the PROJECT row.
+    assert file_id == "file-1"
+    fetched = await codeproject_service.get_project(_WS, _USER, project.id)
+    assert fetched.snapshot_file_id == "file-1"
+
+    # No WebSandbox row was ever created — the store is project-keyed.
+    assert await _WebSandboxDoc.find_all().to_list() == []
+
+
+async def test_round_trip_snapshot_and_overlay_restores_bytes_no_websandbox() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+
+    # A disconnect snapshot (clears overlay), then a fresh session's edits mirror in.
+    await durability.snapshot_project(
+        _WS,
+        _USER,
+        project.id,
+        _SANDBOX,
+        client=_FakeDaytonaClient(tar_bytes=b"SNAP-DATA"),
+        uploads=uploads,
+    )
+    await durability.mirror_file_to_project(_WS, _USER, project.id, "a.ts", b"AAA", uploads=uploads)
+    await durability.mirror_file_to_project(
+        _WS, _USER, project.id, "dir/b.ts", b"BBB", uploads=uploads
+    )
+
+    # Restore into a FRESH VM (new fake client, brand-new Daytona id).
+    fresh = _FakeDaytonaClient()
+    await durability.restore_project(
+        _WS, _USER, project.id, "dtn-fresh", client=fresh, uploads=uploads
+    )
+
+    # Snapshot untarred first...
+    assert fresh.upload_calls[0]["remote_path"] == "/tmp/ws-snapshot.tgz"
+    assert fresh.upload_calls[0]["data"] == b"SNAP-DATA"
+    assert any("tar -xzf" in c and WEBSANDBOX_WORKDIR in c for c in fresh.exec_calls)
+
+    # ...then each overlay file written byte-for-byte into the jail at WORKDIR/relpath.
+    written = {u["remote_path"]: u["data"] for u in fresh.upload_calls}
+    assert written[f"{WEBSANDBOX_WORKDIR}/a.ts"] == b"AAA"
+    assert written[f"{WEBSANDBOX_WORKDIR}/dir/b.ts"] == b"BBB"
+    assert any(f"mkdir -p {WEBSANDBOX_WORKDIR}/dir" in c for c in fresh.exec_calls)
+
+    # The whole round-trip never touched a WebSandbox row.
+    assert await _WebSandboxDoc.find_all().to_list() == []
+
+
+async def test_mirror_records_overlay_and_snapshot_clears_it() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+
+    file_id = await durability.mirror_file_to_project(
+        _WS, _USER, project.id, "src/app.ts", b"console.log(1)", uploads=uploads
+    )
+    up = uploads.upload_calls[0]
+    assert up["folder_path"] == "/code-project-overlay"
+    assert up["data"] == b"console.log(1)"
+    assert file_id == "file-1"
+    assert (await codeproject_service.get_project(_WS, _USER, project.id)).overlay == {
+        "src/app.ts": "file-1"
+    }
+
+    # A full snapshot supersedes the incremental overlay → overlay is wiped.
+    await durability.snapshot_project(
+        _WS, _USER, project.id, _SANDBOX, client=_FakeDaytonaClient(), uploads=uploads
+    )
+    assert (await codeproject_service.get_project(_WS, _USER, project.id)).overlay == {}
+
+
+async def test_restore_overlay_only_no_snapshot() -> None:
+    project = await _project()
+    fake = _FakeDaytonaClient()
+    uploads = _FakeUploads()
+
+    await durability.mirror_file_to_project(
+        _WS, _USER, project.id, "only.ts", b"ONLY", uploads=uploads
+    )
+    await durability.restore_project(_WS, _USER, project.id, _SANDBOX, client=fake, uploads=uploads)
+
+    assert not any("tar -xzf" in c for c in fake.exec_calls)
+    written = {u["remote_path"]: u["data"] for u in fake.upload_calls}
+    assert written[f"{WEBSANDBOX_WORKDIR}/only.ts"] == b"ONLY"
+
+
+async def test_restore_with_neither_snapshot_nor_overlay_is_conflict() -> None:
+    project = await _project()
+    fake = _FakeDaytonaClient()
+    uploads = _FakeUploads()
+
+    with pytest.raises(CloudError) as exc:
+        await durability.restore_project(
+            _WS, _USER, project.id, _SANDBOX, client=fake, uploads=uploads
+        )
+    assert exc.value.code == "codeproject.no_snapshot"
+
+
+async def test_drop_project_overlay_removes_entry() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+    await durability.mirror_file_to_project(
+        _WS, _USER, project.id, "dir/a.ts", b"A", uploads=uploads
+    )
+    await durability.mirror_file_to_project(
+        _WS, _USER, project.id, "keep.ts", b"K", uploads=uploads
+    )
+
+    await durability.drop_project_overlay(_WS, _USER, project.id, "dir")
+
+    assert (await codeproject_service.get_project(_WS, _USER, project.id)).overlay == {
+        "keep.ts": "file-2"
+    }
+
+
+async def test_move_project_overlay_rekeys() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+    await durability.mirror_file_to_project(_WS, _USER, project.id, "a.ts", b"A", uploads=uploads)
+
+    await durability.move_project_overlay(_WS, _USER, project.id, "a.ts", "b.ts")
+
+    assert (await codeproject_service.get_project(_WS, _USER, project.id)).overlay == {
+        "b.ts": "file-1"
+    }
+
+
+# ---------------------------------------------------------------------------
+# Independence — two projects, one starter repo, one workspace: no collision.
+# ---------------------------------------------------------------------------
+
+
+async def test_two_projects_same_starter_hold_independent_state() -> None:
+    # Same workspace, same user, same starter template — two distinct projects
+    # (scaffold rows carry a per-row registry token, so they never dedupe).
+    todo = await _project(repo="react", provider="starter", name="todo")
+    blog = await _project(repo="react", provider="starter", name="blog")
+    assert todo.id != blog.id
+
+    uploads = _FakeUploads()
+    await durability.snapshot_project(
+        _WS, _USER, todo.id, _SANDBOX, client=_FakeDaytonaClient(tar_bytes=b"TODO"), uploads=uploads
+    )
+    await durability.mirror_file_to_project(_WS, _USER, todo.id, "todo.ts", b"T", uploads=uploads)
+    await durability.mirror_file_to_project(_WS, _USER, blog.id, "blog.ts", b"B", uploads=uploads)
+
+    todo_view = await codeproject_service.get_project(_WS, _USER, todo.id)
+    blog_view = await codeproject_service.get_project(_WS, _USER, blog.id)
+
+    # Snapshot landed only on todo; each overlay is the project's own.
+    assert todo_view.snapshot_file_id is not None
+    assert blog_view.snapshot_file_id is None
+    assert todo_view.overlay == {"todo.ts": "file-2"}
+    assert blog_view.overlay == {"blog.ts": "file-3"}
+
+
+# ---------------------------------------------------------------------------
+# Tenancy — a cross-tenant caller is denied before any VM/S3 op.
+# ---------------------------------------------------------------------------
+
+
+async def test_snapshot_denies_cross_tenant_caller() -> None:
+    project = await _project(workspace=_WS, user=_USER)
+    fake = _FakeDaytonaClient()
+    uploads = _FakeUploads()
+
+    from pocketpaw_ee.cloud._core.errors import NotFound
+
+    with pytest.raises(NotFound):
+        await durability.snapshot_project(
+            "w2", _USER, project.id, _SANDBOX, client=fake, uploads=uploads
+        )
+    assert fake.exec_calls == []
+    assert uploads.upload_calls == []
+
+
+# ---------------------------------------------------------------------------
+# S3 guard — the durable WRITE path fails closed in cloud without an s3 adapter,
+# but never raises off cloud (OSS / dedicated).
+# ---------------------------------------------------------------------------
+
+
+async def test_snapshot_write_raises_in_cloud_without_s3(monkeypatch) -> None:
+    project = await _project()
+    fake = _FakeDaytonaClient()
+    uploads = _FakeUploads()
+
+    # Force the multi-tenant-cloud signal on, and leave the adapter non-s3.
+    monkeypatch.setattr(durability, "is_multi_tenant_cloud", lambda: True)
+    monkeypatch.setenv("POCKETPAW_UPLOAD_ADAPTER", "local")
+
+    with pytest.raises(CloudError) as exc:
+        await durability.snapshot_project(
+            _WS, _USER, project.id, _SANDBOX, client=fake, uploads=uploads
+        )
+    assert exc.value.code == "codeproject.durable_store_requires_s3"
+    assert exc.value.status_code == 503
+    # Fails CLOSED before any VM or S3 op.
+    assert fake.exec_calls == []
+    assert uploads.upload_calls == []
+
+
+async def test_mirror_write_raises_in_cloud_without_s3(monkeypatch) -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+
+    monkeypatch.setattr(durability, "is_multi_tenant_cloud", lambda: True)
+    monkeypatch.setenv("POCKETPAW_UPLOAD_ADAPTER", "local")
+
+    with pytest.raises(CloudError) as exc:
+        await durability.mirror_file_to_project(
+            _WS, _USER, project.id, "a.ts", b"A", uploads=uploads
+        )
+    assert exc.value.code == "codeproject.durable_store_requires_s3"
+    assert uploads.upload_calls == []
+
+
+async def test_snapshot_write_ok_in_cloud_with_s3(monkeypatch) -> None:
+    project = await _project()
+    fake = _FakeDaytonaClient(tar_bytes=b"OK")
+    uploads = _FakeUploads()
+
+    monkeypatch.setattr(durability, "is_multi_tenant_cloud", lambda: True)
+    monkeypatch.setenv("POCKETPAW_UPLOAD_ADAPTER", "s3")
+
+    file_id = await durability.snapshot_project(
+        _WS, _USER, project.id, _SANDBOX, client=fake, uploads=uploads
+    )
+    assert file_id == "file-1"
+
+
+async def test_write_does_not_raise_off_cloud(monkeypatch) -> None:
+    # OSS / dedicated install: the cloud DB was never initialized, so the guard is
+    # a no-op even with a local adapter — local-disk uploads are correct there.
+    project = await _project()
+    uploads = _FakeUploads()
+
+    monkeypatch.setattr(durability, "is_multi_tenant_cloud", lambda: False)
+    monkeypatch.setenv("POCKETPAW_UPLOAD_ADAPTER", "local")
+
+    file_id = await durability.mirror_file_to_project(
+        _WS, _USER, project.id, "a.ts", b"A", uploads=uploads
+    )
+    assert file_id == "file-1"

--- a/tests/cloud/test_codeproject_durability.py
+++ b/tests/cloud/test_codeproject_durability.py
@@ -14,17 +14,26 @@
 # which is exactly how these tests prove "no WebSandbox row involved".
 #
 # Covers:
-#   * round-trip: snapshot + overlay write to a project by id, then restore the
-#     bytes byte-for-byte — with NO WebSandbox row created anywhere.
+#   * round-trip: the per-file store is written by id, then restored byte-for-byte
+#     — with NO WebSandbox row created anywhere.
 #   * independence: two projects sharing the SAME starter ``repo`` in one
-#     workspace hold independent snapshot + overlay pointers (no collision).
-#   * snapshot clears the overlay (a full snapshot supersedes it).
+#     workspace hold independent stores (no collision).
 #   * overlay drop / move re-key the durable project pointer.
 #   * S3 guard: the project-keyed durable WRITE path RAISES a clean CloudError in
 #     cloud when the upload adapter isn't s3; does NOT raise on a non-cloud/OSS
 #     install.
+#
+# Updated 2026-07-25 (S1, feat/code-s3-authoritative): every ``snapshot_project``
+# case became a ``sync_project_files`` case. The tarball tier is retired (a tar
+# cannot express a DELETE, so replaying it resurrected removed files) and the
+# per-file store is the whole truth, so what these prove now is that a workspace
+# re-image lands one blob per file and that a full snapshot no longer wipes the
+# store. The delete/completeness behaviour has its own suite:
+# ``test_codeproject_s3_authoritative.py``.
 from __future__ import annotations
 
+import io
+import tarfile
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 
@@ -128,6 +137,22 @@ class _FakeUploads:
         return rec, _iter()
 
 
+def _tar(files: dict[str, bytes]) -> bytes:
+    """A REAL gzipped tar shaped like ``tar -czf ... -C <workdir> .`` output.
+
+    The sync path reads the workspace THROUGH a tarball (one round trip instead of
+    one download per file), so the fake VM has to hand back a real archive rather
+    than a canned string. Members are named ``./x`` exactly as tar writes them.
+    """
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as archive:
+        for name, blob in files.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(blob)
+            archive.addfile(info, io.BytesIO(blob))
+    return buf.getvalue()
+
+
 async def _project(workspace=_WS, user=_USER, repo="react", provider="starter", name=None):  # noqa: ANN001
     """Create a durable project row (starter by default, so two share one repo)."""
     body = {"repo": repo, "provider": provider}
@@ -142,49 +167,49 @@ async def _project(workspace=_WS, user=_USER, repo="react", provider="starter", 
 # ---------------------------------------------------------------------------
 
 
-async def test_snapshot_uploads_and_records_pointer_on_project() -> None:
+async def test_sync_uploads_every_workspace_file_and_records_the_store() -> None:
     project = await _project()
-    fake = _FakeDaytonaClient(tar_bytes=b"HELLO-SNAPSHOT")
+    fake = _FakeDaytonaClient(tar_bytes=_tar({"./a.ts": b"AAA", "./dir/b.ts": b"BBB"}))
     uploads = _FakeUploads()
 
-    file_id = await durability.snapshot_project(
+    overlay = await durability.sync_project_files(
         _WS, _USER, project.id, _SANDBOX, client=fake, uploads=uploads
     )
 
-    # Tarred the workspace dir in the VM, then downloaded the tarball.
+    # Tarred the workspace dir in the VM as a TRANSPORT, then downloaded it once.
     assert any("tar -czf" in c and WEBSANDBOX_WORKDIR in c for c in fake.exec_calls)
-    assert fake.download_calls == ["/tmp/ws-snapshot.tgz"]
+    assert fake.download_calls == ["/tmp/code-project-sync.tgz"]
 
-    # Uploaded the exact bytes, workspace + owner scoped, in the PROJECT snapshots
-    # folder — grouped separately from the sandbox-keyed folder.
-    assert len(uploads.upload_calls) == 1
-    up = uploads.upload_calls[0]
-    assert up["workspace"] == _WS
-    assert up["owner_id"] == _USER
-    assert up["folder_path"] == "/code-project-snapshots"
-    assert up["data"] == b"HELLO-SNAPSHOT"
-    assert up["content_type"] == "application/gzip"
+    # One blob PER FILE — workspace + owner scoped, in the overlay folder. Nothing
+    # lands in the retired snapshots folder.
+    assert len(uploads.upload_calls) == 2
+    assert {u["folder_path"] for u in uploads.upload_calls} == {"/code-project-overlay"}
+    assert {u["workspace"] for u in uploads.upload_calls} == {_WS}
+    assert {u["owner_id"] for u in uploads.upload_calls} == {_USER}
+    assert {u["data"] for u in uploads.upload_calls} == {b"AAA", b"BBB"}
 
-    # The durable pointer is returned AND persisted on the PROJECT row.
-    assert file_id == "file-1"
+    # The store is the whole map, persisted on the PROJECT row and marked verified.
+    assert set(overlay) == {"a.ts", "dir/b.ts"}
     fetched = await codeproject_service.get_project(_WS, _USER, project.id)
-    assert fetched.snapshot_file_id == "file-1"
+    assert fetched.overlay == overlay
+    assert fetched.overlay_complete is True
+    assert fetched.snapshot_file_id is None
 
     # No WebSandbox row was ever created — the store is project-keyed.
     assert await _WebSandboxDoc.find_all().to_list() == []
 
 
-async def test_round_trip_snapshot_and_overlay_restores_bytes_no_websandbox() -> None:
+async def test_round_trip_sync_and_overlay_restores_bytes_no_websandbox() -> None:
     project = await _project()
     uploads = _FakeUploads()
 
-    # A disconnect snapshot (clears overlay), then a fresh session's edits mirror in.
-    await durability.snapshot_project(
+    # A disconnect sync, then a fresh session's edits mirror in on top.
+    await durability.sync_project_files(
         _WS,
         _USER,
         project.id,
         _SANDBOX,
-        client=_FakeDaytonaClient(tar_bytes=b"SNAP-DATA"),
+        client=_FakeDaytonaClient(tar_bytes=_tar({"./from-the-vm.ts": b"VM"})),
         uploads=uploads,
     )
     await durability.mirror_file_to_project(_WS, _USER, project.id, "a.ts", b"AAA", uploads=uploads)
@@ -198,13 +223,12 @@ async def test_round_trip_snapshot_and_overlay_restores_bytes_no_websandbox() ->
         _WS, _USER, project.id, "dtn-fresh", client=fresh, uploads=uploads
     )
 
-    # Snapshot untarred first...
-    assert fresh.upload_calls[0]["remote_path"] == "/tmp/ws-snapshot.tgz"
-    assert fresh.upload_calls[0]["data"] == b"SNAP-DATA"
-    assert any("tar -xzf" in c and WEBSANDBOX_WORKDIR in c for c in fresh.exec_calls)
+    # No tarball is fetched or untarred — the per-file store is the whole truth.
+    assert not any("tar -xzf" in c for c in fresh.exec_calls)
 
-    # ...then each overlay file written byte-for-byte into the jail at WORKDIR/relpath.
+    # Every file is written byte-for-byte into the jail at WORKDIR/relpath.
     written = {u["remote_path"]: u["data"] for u in fresh.upload_calls}
+    assert written[f"{WEBSANDBOX_WORKDIR}/from-the-vm.ts"] == b"VM"
     assert written[f"{WEBSANDBOX_WORKDIR}/a.ts"] == b"AAA"
     assert written[f"{WEBSANDBOX_WORKDIR}/dir/b.ts"] == b"BBB"
     assert any(f"mkdir -p {WEBSANDBOX_WORKDIR}/dir" in c for c in fresh.exec_calls)
@@ -213,7 +237,7 @@ async def test_round_trip_snapshot_and_overlay_restores_bytes_no_websandbox() ->
     assert await _WebSandboxDoc.find_all().to_list() == []
 
 
-async def test_mirror_records_overlay_and_snapshot_clears_it() -> None:
+async def test_mirror_records_the_store_and_a_legacy_snapshot_no_longer_wipes_it() -> None:
     project = await _project()
     uploads = _FakeUploads()
 
@@ -228,11 +252,13 @@ async def test_mirror_records_overlay_and_snapshot_clears_it() -> None:
         "src/app.ts": "file-1"
     }
 
-    # A full snapshot supersedes the incremental overlay → overlay is wiped.
-    await durability.snapshot_project(
-        _WS, _USER, project.id, _SANDBOX, client=_FakeDaytonaClient(), uploads=uploads
-    )
-    assert (await codeproject_service.get_project(_WS, _USER, project.id)).overlay == {}
+    # Recording a legacy tarball pointer must NOT clear the store. It used to (a
+    # "full snapshot supersedes the delta"), and that is precisely what threw away
+    # the only tier able to record a deletion.
+    await codeproject_service.set_project_snapshot(_WS, _USER, project.id, "legacy-tar")
+    kept = await codeproject_service.get_project(_WS, _USER, project.id)
+    assert kept.overlay == {"src/app.ts": "file-1"}
+    assert kept.snapshot_file_id == "legacy-tar"
 
 
 async def test_restore_overlay_only_no_snapshot() -> None:
@@ -304,8 +330,13 @@ async def test_two_projects_same_starter_hold_independent_state() -> None:
     assert todo.id != blog.id
 
     uploads = _FakeUploads()
-    await durability.snapshot_project(
-        _WS, _USER, todo.id, _SANDBOX, client=_FakeDaytonaClient(tar_bytes=b"TODO"), uploads=uploads
+    await durability.sync_project_files(
+        _WS,
+        _USER,
+        todo.id,
+        _SANDBOX,
+        client=_FakeDaytonaClient(tar_bytes=_tar({"./synced.ts": b"S"})),
+        uploads=uploads,
     )
     await durability.mirror_file_to_project(_WS, _USER, todo.id, "todo.ts", b"T", uploads=uploads)
     await durability.mirror_file_to_project(_WS, _USER, blog.id, "blog.ts", b"B", uploads=uploads)
@@ -313,10 +344,10 @@ async def test_two_projects_same_starter_hold_independent_state() -> None:
     todo_view = await codeproject_service.get_project(_WS, _USER, todo.id)
     blog_view = await codeproject_service.get_project(_WS, _USER, blog.id)
 
-    # Snapshot landed only on todo; each overlay is the project's own.
-    assert todo_view.snapshot_file_id is not None
-    assert blog_view.snapshot_file_id is None
-    assert todo_view.overlay == {"todo.ts": "file-2"}
+    # The sync landed only on todo; each store is the project's own.
+    assert todo_view.overlay_complete is True
+    assert blog_view.overlay_complete is False
+    assert todo_view.overlay == {"synced.ts": "file-1", "todo.ts": "file-2"}
     assert blog_view.overlay == {"blog.ts": "file-3"}
 
 
@@ -325,7 +356,7 @@ async def test_two_projects_same_starter_hold_independent_state() -> None:
 # ---------------------------------------------------------------------------
 
 
-async def test_snapshot_denies_cross_tenant_caller() -> None:
+async def test_sync_denies_cross_tenant_caller() -> None:
     project = await _project(workspace=_WS, user=_USER)
     fake = _FakeDaytonaClient()
     uploads = _FakeUploads()
@@ -333,7 +364,7 @@ async def test_snapshot_denies_cross_tenant_caller() -> None:
     from pocketpaw_ee.cloud._core.errors import NotFound
 
     with pytest.raises(NotFound):
-        await durability.snapshot_project(
+        await durability.sync_project_files(
             "w2", _USER, project.id, _SANDBOX, client=fake, uploads=uploads
         )
     assert fake.exec_calls == []
@@ -346,7 +377,7 @@ async def test_snapshot_denies_cross_tenant_caller() -> None:
 # ---------------------------------------------------------------------------
 
 
-async def test_snapshot_write_raises_in_cloud_without_s3(monkeypatch) -> None:
+async def test_sync_write_raises_in_cloud_without_s3(monkeypatch) -> None:
     project = await _project()
     fake = _FakeDaytonaClient()
     uploads = _FakeUploads()
@@ -356,7 +387,7 @@ async def test_snapshot_write_raises_in_cloud_without_s3(monkeypatch) -> None:
     monkeypatch.setenv("POCKETPAW_UPLOAD_ADAPTER", "local")
 
     with pytest.raises(CloudError) as exc:
-        await durability.snapshot_project(
+        await durability.sync_project_files(
             _WS, _USER, project.id, _SANDBOX, client=fake, uploads=uploads
         )
     assert exc.value.code == "codeproject.durable_store_requires_s3"
@@ -381,18 +412,18 @@ async def test_mirror_write_raises_in_cloud_without_s3(monkeypatch) -> None:
     assert uploads.upload_calls == []
 
 
-async def test_snapshot_write_ok_in_cloud_with_s3(monkeypatch) -> None:
+async def test_sync_write_ok_in_cloud_with_s3(monkeypatch) -> None:
     project = await _project()
-    fake = _FakeDaytonaClient(tar_bytes=b"OK")
+    fake = _FakeDaytonaClient(tar_bytes=_tar({"./ok.ts": b"OK"}))
     uploads = _FakeUploads()
 
     monkeypatch.setattr(durability, "is_multi_tenant_cloud", lambda: True)
     monkeypatch.setenv("POCKETPAW_UPLOAD_ADAPTER", "s3")
 
-    file_id = await durability.snapshot_project(
+    overlay = await durability.sync_project_files(
         _WS, _USER, project.id, _SANDBOX, client=fake, uploads=uploads
     )
-    assert file_id == "file-1"
+    assert overlay == {"ok.ts": "file-1"}
 
 
 async def test_write_does_not_raise_off_cloud(monkeypatch) -> None:

--- a/tests/cloud/test_codeproject_file_sync.py
+++ b/tests/cloud/test_codeproject_file_sync.py
@@ -392,7 +392,9 @@ async def test_put_ok_in_cloud_with_s3(monkeypatch) -> None:  # noqa: ANN001
 async def test_write_over_the_per_file_cap_is_rejected(monkeypatch) -> None:  # noqa: ANN001
     project = await _project()
     uploads = _FakeUploads()
-    monkeypatch.setenv("POCKETPAW_CODEPROJECT_OVERLAY_MAX_MB", "0.000001")  # ~1 byte
+    # The PER-FILE knob, split from the aggregate one in S1: the aggregate had to
+    # grow to hold a whole source tree, and one runaway file must stay bounded.
+    monkeypatch.setenv("POCKETPAW_CODEPROJECT_FILE_MAX_MB", "0.000001")  # ~1 byte
 
     with pytest.raises(CloudError) as exc:
         await durability.put_project_file(

--- a/tests/cloud/test_codeproject_file_sync.py
+++ b/tests/cloud/test_codeproject_file_sync.py
@@ -1,0 +1,476 @@
+# test_codeproject_file_sync.py — unit tests for BROWSER-runtime project file sync
+# (B1, feat/code-project-file-sync): the in-tab (WebContainer) runtime pushes each
+# write through to the project's durable overlay and pulls the whole set back on a
+# reopen, because the filesystem lives in the user's browser and no backend hook
+# can read it.
+#
+# Created 2026-07-25 (feat/code-project-file-sync).
+#
+# The bug these guard: an edit in a tab-hosted project was written to an in-tab
+# filesystem only, so reopening the project re-materialized the bare starter
+# scaffold and every change was gone.
+#
+# Blob storage is a FAKE injected through the ``uploads=`` DI seam — no test
+# touches real S3. The CodeProject registry runs on real Beanie over
+# mongomock-motor (the ``mongo_db`` fixture) so the owner-scoped overlay writes and
+# the tenant filter are exercised for real. No Daytona client appears anywhere:
+# that's the point — this path never has a VM.
+#
+# Covers:
+#   * write-through: PUT records ``path -> file_id``; a second write to the same
+#     path REPLACES the entry rather than duplicating it.
+#   * round-trip: two files (one nested) come back with byte-identical content.
+#   * delete: a dropped file no longer appears in the read-back.
+#   * tenancy: another workspace / another user gets NotFound on every verb.
+#   * the S3 fail-closed guard still raises on the write path in cloud.
+#   * path jailing, the read-back caps, and the router wiring for all three routes.
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud._core.errors import CloudError, NotFound, ValidationError
+from pocketpaw_ee.cloud.codeproject import router as codeproject_router
+from pocketpaw_ee.cloud.codeproject import service as codeproject_service
+from pocketpaw_ee.cloud.models.web_sandbox import WebSandbox as _WebSandboxDoc
+from pocketpaw_ee.cloud.websandbox import durability
+
+from pocketpaw.uploads.errors import NotFound as UploadNotFound
+from pocketpaw.uploads.file_store import FileRecord
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+_WS = "w1"
+_USER = "u1"
+
+
+class _FakeUploads:
+    """In-memory stand-in for EEUploadService — records uploads, serves them back.
+
+    One instance carries the blobs, so a file written through here is readable by
+    a later read-back in the same test (exactly the reopen the feature exists for).
+    """
+
+    def __init__(self) -> None:
+        self.upload_calls: list[dict] = []
+        self.stream_calls: list[dict] = []
+        self._blobs: dict[str, bytes] = {}
+        self._counter = 0
+
+    async def upload(self, file, owner_id, chat_id, workspace, folder_path="/", pocket_id=None):  # noqa: ANN001
+        data = await file.read()
+        self._counter += 1
+        file_id = f"file-{self._counter}"
+        self.upload_calls.append(
+            {
+                "owner_id": owner_id,
+                "workspace": workspace,
+                "folder_path": folder_path,
+                "filename": file.filename,
+                "content_type": file.content_type,
+                "data": data,
+            }
+        )
+        self._blobs[file_id] = data
+        return FileRecord(
+            id=file_id,
+            storage_key=f"key/{file_id}",
+            filename=file.filename,
+            mime="application/octet-stream",
+            size=len(data),
+            owner_id=owner_id,
+            chat_id=None,
+            created=datetime.now(UTC),
+        )
+
+    async def stream(self, file_id, requester_id, workspace):  # noqa: ANN001
+        self.stream_calls.append({"file_id": file_id, "requester": requester_id, "ws": workspace})
+        if file_id not in self._blobs:
+            raise UploadNotFound()
+        data = self._blobs[file_id]
+        rec = FileRecord(
+            id=file_id,
+            storage_key=f"key/{file_id}",
+            filename="overlay",
+            mime="application/octet-stream",
+            size=len(data),
+            owner_id=requester_id,
+            chat_id=None,
+            created=datetime.now(UTC),
+        )
+
+        async def _iter():
+            yield data
+
+        return rec, _iter()
+
+
+async def _project(workspace=_WS, user=_USER, name=None):  # noqa: ANN001
+    """A durable starter project — the in-tab runtime's case (no repo to clone)."""
+    body = {"repo": "react", "provider": "starter"}
+    if name is not None:
+        body["name"] = name
+    return await codeproject_service.create_project(workspace, user, body)
+
+
+def _ctx(workspace=_WS, user=_USER):  # noqa: ANN001
+    return RequestContext(
+        user_id=user,
+        workspace_id=workspace,
+        request_id="req-1",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Write-through — the overlay records the pointer, and a rewrite replaces it.
+# ---------------------------------------------------------------------------
+
+
+async def test_put_records_overlay_pointer() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+
+    path, file_id = await durability.put_project_file(
+        _WS, _USER, project.id, "src/app.ts", "console.log(1)", uploads=uploads
+    )
+
+    assert (path, file_id) == ("src/app.ts", "file-1")
+    # The bytes landed in the tenant's blob storage, workspace + owner scoped.
+    assert len(uploads.upload_calls) == 1
+    up = uploads.upload_calls[0]
+    assert up["workspace"] == _WS
+    assert up["owner_id"] == _USER
+    assert up["folder_path"] == "/code-project-overlay"
+    assert up["data"] == b"console.log(1)"
+    # …and the durable pointer is on the PROJECT row.
+    assert (await codeproject_service.get_project(_WS, _USER, project.id)).overlay == {
+        "src/app.ts": "file-1"
+    }
+    # No VM, no WebSandbox row — this runtime lives in the browser.
+    assert await _WebSandboxDoc.find_all().to_list() == []
+
+
+async def test_second_write_to_same_path_replaces_the_entry() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+
+    await durability.put_project_file(_WS, _USER, project.id, "a.ts", "v1", uploads=uploads)
+    _path, second_id = await durability.put_project_file(
+        _WS, _USER, project.id, "a.ts", "v2", uploads=uploads
+    )
+
+    overlay = (await codeproject_service.get_project(_WS, _USER, project.id)).overlay
+    # ONE entry, pointing at the newest blob — not two rows for one file.
+    assert overlay == {"a.ts": second_id}
+    assert len(overlay) == 1
+
+    files = await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads)
+    assert files == {"a.ts": "v2"}
+
+
+async def test_put_normalizes_a_leading_slash_so_the_key_is_stable() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+
+    path, _ = await durability.put_project_file(
+        _WS, _USER, project.id, "/src/x.ts", "X", uploads=uploads
+    )
+
+    assert path == "src/x.ts"
+    assert (await codeproject_service.get_project(_WS, _USER, project.id)).overlay == {
+        "src/x.ts": "file-1"
+    }
+
+
+@pytest.mark.parametrize("bad", ["", "   ", "/", "../etc/passwd", "src/../../escape.ts"])
+async def test_put_rejects_paths_that_escape_the_project(bad) -> None:  # noqa: ANN001
+    project = await _project()
+    uploads = _FakeUploads()
+
+    with pytest.raises(ValidationError):
+        await durability.put_project_file(_WS, _USER, project.id, bad, "x", uploads=uploads)
+    assert uploads.upload_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Round-trip — write, then read the whole overlay back byte-identical.
+# ---------------------------------------------------------------------------
+
+
+async def test_round_trip_returns_exactly_the_written_files() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+
+    await durability.put_project_file(
+        _WS, _USER, project.id, "index.html", "<h1>hi</h1>", uploads=uploads
+    )
+    await durability.put_project_file(
+        _WS,
+        _USER,
+        project.id,
+        "src/lib/x.ts",
+        "export const x = 1;\n// naïve — üñí\n",
+        uploads=uploads,
+    )
+
+    files = await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads)
+
+    assert files == {
+        "index.html": "<h1>hi</h1>",
+        "src/lib/x.ts": "export const x = 1;\n// naïve — üñí\n",
+    }
+    # Byte-identical, not merely equal-looking: what went in came back out.
+    assert files["src/lib/x.ts"].encode("utf-8") == uploads.upload_calls[1]["data"]
+
+
+async def test_read_back_is_empty_for_an_untouched_project() -> None:
+    # A fresh project stores NOTHING — the scaffold baseline is re-materialized
+    # client-side from the starter id, so the overlay is the delta only.
+    project = await _project()
+    uploads = _FakeUploads()
+
+    assert await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads) == {}
+    assert uploads.stream_calls == []
+
+
+async def test_read_back_skips_an_unreadable_blob_instead_of_failing() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+    await durability.put_project_file(_WS, _USER, project.id, "keep.ts", "K", uploads=uploads)
+    # A pointer whose blob was reaped from storage: one bad entry must not sink
+    # the whole restore.
+    await codeproject_service.set_project_overlay_entry(
+        _WS, _USER, project.id, "gone.ts", "file-missing"
+    )
+
+    files = await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads)
+    assert files == {"keep.ts": "K"}
+
+
+# ---------------------------------------------------------------------------
+# Delete — a dropped file does not come back on the next restore.
+# ---------------------------------------------------------------------------
+
+
+async def test_delete_drops_the_file_from_the_read_back() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+    await durability.put_project_file(_WS, _USER, project.id, "a.ts", "A", uploads=uploads)
+    await durability.put_project_file(_WS, _USER, project.id, "dir/b.ts", "B", uploads=uploads)
+
+    dropped = await durability.drop_project_file(_WS, _USER, project.id, "a.ts")
+
+    assert dropped == "a.ts"
+    files = await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads)
+    assert files == {"dir/b.ts": "B"}
+
+
+async def test_delete_normalizes_the_same_way_the_write_did() -> None:
+    # The write stored ``src/a.ts``; a delete spelled ``/src/a.ts`` must still
+    # match, or the file silently reappears on the next reopen.
+    project = await _project()
+    uploads = _FakeUploads()
+    await durability.put_project_file(_WS, _USER, project.id, "src/a.ts", "A", uploads=uploads)
+
+    await durability.drop_project_file(_WS, _USER, project.id, "/src/a.ts")
+
+    assert await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads) == {}
+
+
+async def test_delete_of_a_directory_drops_every_child() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+    await durability.put_project_file(_WS, _USER, project.id, "src/a.ts", "A", uploads=uploads)
+    await durability.put_project_file(_WS, _USER, project.id, "src/deep/b.ts", "B", uploads=uploads)
+    await durability.put_project_file(_WS, _USER, project.id, "keep.ts", "K", uploads=uploads)
+
+    await durability.drop_project_file(_WS, _USER, project.id, "src")
+
+    assert await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads) == {
+        "keep.ts": "K"
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tenancy — every verb is owner-scoped; a foreign caller sees NotFound.
+# ---------------------------------------------------------------------------
+
+
+async def test_put_denies_a_foreign_workspace() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+
+    with pytest.raises(NotFound):
+        await durability.put_project_file(
+            "w2", _USER, project.id, "a.ts", "MINE NOW", uploads=uploads
+        )
+    # Nothing leaked into the owner's project.
+    assert (await codeproject_service.get_project(_WS, _USER, project.id)).overlay == {}
+
+
+async def test_put_denies_another_user_in_the_same_workspace() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+
+    with pytest.raises(NotFound):
+        await durability.put_project_file(
+            _WS, "u2", project.id, "a.ts", "MINE NOW", uploads=uploads
+        )
+    assert (await codeproject_service.get_project(_WS, _USER, project.id)).overlay == {}
+
+
+async def test_read_back_denies_a_foreign_caller() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+    await durability.put_project_file(_WS, _USER, project.id, "secret.ts", "S", uploads=uploads)
+
+    with pytest.raises(NotFound):
+        await durability.read_project_overlay("w2", _USER, project.id, uploads=uploads)
+    with pytest.raises(NotFound):
+        await durability.read_project_overlay(_WS, "u2", project.id, uploads=uploads)
+    # No blob was even reached — the tenancy gate is BEFORE storage.
+    assert uploads.stream_calls == []
+
+
+async def test_delete_denies_a_foreign_caller() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+    await durability.put_project_file(_WS, _USER, project.id, "a.ts", "A", uploads=uploads)
+
+    with pytest.raises(NotFound):
+        await durability.drop_project_file("w2", _USER, project.id, "a.ts")
+    with pytest.raises(NotFound):
+        await durability.drop_project_file(_WS, "u2", project.id, "a.ts")
+    # Still there for the real owner.
+    assert await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads) == {
+        "a.ts": "A"
+    }
+
+
+# ---------------------------------------------------------------------------
+# S3 guard — the durable WRITE path still fails closed in cloud without s3.
+# ---------------------------------------------------------------------------
+
+
+async def test_put_raises_in_cloud_without_s3(monkeypatch) -> None:  # noqa: ANN001
+    project = await _project()
+    uploads = _FakeUploads()
+
+    monkeypatch.setattr(durability, "is_multi_tenant_cloud", lambda: True)
+    monkeypatch.setenv("POCKETPAW_UPLOAD_ADAPTER", "local")
+
+    with pytest.raises(CloudError) as exc:
+        await durability.put_project_file(_WS, _USER, project.id, "a.ts", "A", uploads=uploads)
+    assert exc.value.code == "codeproject.durable_store_requires_s3"
+    assert exc.value.status_code == 503
+    # Fails CLOSED — nothing was uploaded and no pointer was recorded.
+    assert uploads.upload_calls == []
+    assert (await codeproject_service.get_project(_WS, _USER, project.id)).overlay == {}
+
+
+async def test_put_ok_in_cloud_with_s3(monkeypatch) -> None:  # noqa: ANN001
+    project = await _project()
+    uploads = _FakeUploads()
+
+    monkeypatch.setattr(durability, "is_multi_tenant_cloud", lambda: True)
+    monkeypatch.setenv("POCKETPAW_UPLOAD_ADAPTER", "s3")
+
+    path, file_id = await durability.put_project_file(
+        _WS, _USER, project.id, "a.ts", "A", uploads=uploads
+    )
+    assert (path, file_id) == ("a.ts", "file-1")
+
+
+# ---------------------------------------------------------------------------
+# Caps — bounded, and LOUD rather than silently partial.
+# ---------------------------------------------------------------------------
+
+
+async def test_write_over_the_per_file_cap_is_rejected(monkeypatch) -> None:  # noqa: ANN001
+    project = await _project()
+    uploads = _FakeUploads()
+    monkeypatch.setenv("POCKETPAW_CODEPROJECT_OVERLAY_MAX_MB", "0.000001")  # ~1 byte
+
+    with pytest.raises(CloudError) as exc:
+        await durability.put_project_file(
+            _WS, _USER, project.id, "big.ts", "far too many bytes", uploads=uploads
+        )
+    assert exc.value.code == "codeproject.file_too_large"
+    assert exc.value.status_code == 413
+    assert uploads.upload_calls == []
+
+
+async def test_read_back_over_the_file_count_cap_raises(monkeypatch) -> None:  # noqa: ANN001
+    project = await _project()
+    uploads = _FakeUploads()
+    await durability.put_project_file(_WS, _USER, project.id, "a.ts", "A", uploads=uploads)
+    await durability.put_project_file(_WS, _USER, project.id, "b.ts", "B", uploads=uploads)
+
+    monkeypatch.setenv("POCKETPAW_CODEPROJECT_OVERLAY_MAX_FILES", "1")
+
+    with pytest.raises(CloudError) as exc:
+        await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads)
+    # Loud, not truncated: a half-restored project looks like data loss.
+    assert exc.value.code == "codeproject.overlay_too_many_files"
+    assert exc.value.status_code == 413
+
+
+async def test_read_back_over_the_byte_cap_raises(monkeypatch) -> None:  # noqa: ANN001
+    project = await _project()
+    uploads = _FakeUploads()
+    await durability.put_project_file(_WS, _USER, project.id, "a.ts", "AAAA", uploads=uploads)
+
+    monkeypatch.setenv("POCKETPAW_CODEPROJECT_OVERLAY_MAX_MB", "0.000001")  # ~1 byte
+
+    with pytest.raises(CloudError) as exc:
+        await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads)
+    assert exc.value.code == "codeproject.overlay_too_large"
+    assert exc.value.status_code == 413
+
+
+# ---------------------------------------------------------------------------
+# Router wiring — the three routes reach the storage layer and shape the wire.
+# ---------------------------------------------------------------------------
+
+
+async def test_routes_round_trip_a_file(monkeypatch) -> None:  # noqa: ANN001
+    project = await _project()
+    uploads = _FakeUploads()
+    # The routes build their own uploads service; pin it to the fake so no test
+    # touches real storage.
+    monkeypatch.setattr(durability, "build_uploads", lambda: uploads)
+
+    written = await codeproject_router.put_project_file(
+        project.id,
+        codeproject_router.PutProjectFileRequest(path="/src/app.ts", content="hello"),
+        ctx=_ctx(),
+    )
+    assert written.ok is True
+    assert written.path == "src/app.ts"  # the normalized key the overlay stored
+    assert written.fileId == "file-1"
+
+    listing = await codeproject_router.read_project_files(project.id, ctx=_ctx())
+    assert listing.files == {"src/app.ts": "hello"}
+
+    resp = await codeproject_router.delete_project_file(project.id, path="src/app.ts", ctx=_ctx())
+    assert resp.status_code == 204
+    assert (await codeproject_router.read_project_files(project.id, ctx=_ctx())).files == {}
+
+
+async def test_routes_are_owner_scoped(monkeypatch) -> None:  # noqa: ANN001
+    project = await _project()
+    uploads = _FakeUploads()
+    monkeypatch.setattr(durability, "build_uploads", lambda: uploads)
+
+    foreign = _ctx(workspace="w2", user="u2")
+    with pytest.raises(NotFound):
+        await codeproject_router.read_project_files(project.id, ctx=foreign)
+    with pytest.raises(NotFound):
+        await codeproject_router.put_project_file(
+            project.id,
+            codeproject_router.PutProjectFileRequest(path="a.ts", content="x"),
+            ctx=foreign,
+        )

--- a/tests/cloud/test_codeproject_s3_authoritative.py
+++ b/tests/cloud/test_codeproject_s3_authoritative.py
@@ -1,0 +1,597 @@
+# test_codeproject_s3_authoritative.py — the S1 cutover: the per-file store IS the
+# project, and the tarball tier is retired as a source of truth.
+#
+# Created 2026-07-25 (S1, feat/code-s3-authoritative).
+#
+# The bug this removes: a project's baseline was one gzipped tarball, and a tarball
+# is an unmodifiable blob — a DELETE has no representation inside it. Replaying the
+# baseline on restore resurrected every file the user had removed, and taking a
+# snapshot CLEARED the per-file overlay, which was the only tier that could have
+# recorded the absence. A tombstone list would have patched the symptom; making the
+# per-file store COMPLETE removes the vector: a delete is the removal of an entry,
+# and there is no baseline left to resurrect it.
+#
+# What is proved here, on real Beanie over mongomock-motor (the ``mongo_db``
+# fixture) with a FAKE Daytona VM and FAKE blob storage injected through the
+# existing DI seams — no real VM, no real S3:
+#   1. THE BUG IS DEAD — a file deleted in the VM is gone after sync + restore, both
+#      for a file that passed a write hook and for one that never did (a clone's or
+#      a scaffold's file), including when the fresh VM re-materializes it.
+#   2. COMPLETENESS — a file that arrived without passing a write hook is in the
+#      store after a sync and restores from it.
+#   3. LEGACY MIGRATION — a pre-S1 project (tarball pointer + partial overlay)
+#      migrates to per-file entries once, loses nothing, clears the pointer, and is
+#      idempotent on a second run.
+#   4. RESTORE IS STORE-ONLY — a migrated/new project never fetches or untars a
+#      tarball again.
+#   5. THE DESTRUCTIVE PARTS ARE GATED — an empty enumeration never wipes a store,
+#      an entry inside an excluded tree is never dropped by a sync that cannot see
+#      it, and the prune never fires for a project whose store isn't verified
+#      complete (the in-tab case, whose baseline lives in the browser).
+#
+# The fake VM models a real filesystem rather than canned bytes, because "the file
+# is gone" is a claim about a filesystem: it serves ``find`` from its own tree,
+# applies ``rm -f``, absorbs ``upload_bytes`` writes, and packs the tree into a REAL
+# gzipped tar on ``download_file``. A canned-blob fake could not tell the difference
+# between a deletion that worked and one that silently didn't.
+from __future__ import annotations
+
+import shlex
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import CloudError
+from pocketpaw_ee.cloud.codeproject import service as codeproject_service
+from pocketpaw_ee.cloud.websandbox import durability
+from pocketpaw_ee.cloud.websandbox.constants import WEBSANDBOX_WORKDIR
+
+from tests.cloud.test_codeproject_durability import _FakeUploads, _tar
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+_WS = "w1"
+_USER = "u1"
+_VM = "dtn-1"
+_FRESH_VM = "dtn-fresh"
+
+
+# ---------------------------------------------------------------------------
+# A fake VM with an actual filesystem.
+# ---------------------------------------------------------------------------
+
+
+class _Resp:
+    """The shape ``DaytonaClient.execute_command`` returns (``result`` + ``exit_code``)."""
+
+    def __init__(self, result: str = "", exit_code: int = 0) -> None:
+        self.result = result
+        self.exit_code = exit_code
+
+
+class _FakeVm:
+    """A Daytona stand-in that keeps a real in-memory workspace tree.
+
+    Implements exactly the four verbs the durability paths use, faithfully enough
+    that a deletion is observable end to end:
+      * ``tar -czf`` is a no-op; ``download_file`` packs the CURRENT tree (minus the
+        regenerable trees the real command excludes) into a real gzipped tar, which
+        is the transport the sync reads;
+      * ``find`` lists the tree, excluded segments pruned, workspace-prefixed;
+      * ``rm -f`` actually removes paths — this is what the prune is judged on;
+      * ``upload_bytes`` writes a file, so a restore genuinely materializes.
+    """
+
+    def __init__(self, files: dict[str, bytes] | None = None) -> None:
+        self.files: dict[str, bytes] = dict(files or {})
+        self.exec_calls: list[str] = []
+        self.download_calls: list[str] = []
+        self.upload_paths: list[str] = []
+
+    def _visible(self) -> dict[str, bytes]:
+        return {
+            path: blob
+            for path, blob in self.files.items()
+            if not durability._is_excluded_snapshot_path(path)
+        }
+
+    async def execute_command(self, sandbox_id, command, **kwargs):  # noqa: ANN001
+        self.exec_calls.append(command)
+        if command.startswith("find "):
+            listing = "\n".join(f"{WEBSANDBOX_WORKDIR}/{p}" for p in sorted(self._visible()))
+            return _Resp(result=listing)
+        if command.startswith("rm -f "):
+            prefix = WEBSANDBOX_WORKDIR.rstrip("/") + "/"
+            for token in shlex.split(command)[2:]:
+                if token.startswith(prefix):
+                    self.files.pop(token[len(prefix) :], None)
+        return _Resp()
+
+    async def download_file(self, sandbox_id, remote_path):  # noqa: ANN001
+        self.download_calls.append(remote_path)
+        return _tar({f"./{p}": blob for p, blob in self._visible().items()})
+
+    async def upload_bytes(self, sandbox_id, data, remote_path):  # noqa: ANN001
+        self.upload_paths.append(remote_path)
+        prefix = WEBSANDBOX_WORKDIR.rstrip("/") + "/"
+        if remote_path.startswith(prefix):
+            self.files[remote_path[len(prefix) :]] = data
+
+
+class _TrackingUploads(_FakeUploads):
+    """``_FakeUploads`` plus a record of which blobs were READ back."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.stream_calls: list[str] = []
+
+    async def stream(self, file_id, requester_id, workspace):  # noqa: ANN001
+        self.stream_calls.append(file_id)
+        return await super().stream(file_id, requester_id, workspace)
+
+
+async def _project(repo="react", provider="starter"):  # noqa: ANN001
+    return await codeproject_service.create_project(
+        _WS, _USER, {"repo": repo, "provider": provider}
+    )
+
+
+async def _stage_legacy_snapshot(project_id: str, uploads: _FakeUploads, tar_bytes: bytes) -> str:
+    """Put a project into the PRE-S1 row shape: a tarball in blob storage + a pointer.
+
+    Exactly what ``snapshot_project`` used to leave behind, staged directly because
+    the writer is gone. This is the state every existing project is in right now.
+    """
+    file_id = await durability._upload_project_blob(
+        uploads,
+        tar_bytes,
+        workspace_id=_WS,
+        user_id=_USER,
+        filename="legacy-snapshot.tgz",
+        folder="/code-project-snapshots",
+        content_type="application/gzip",
+    )
+    await codeproject_service.set_project_snapshot(_WS, _USER, project_id, file_id)
+    return file_id
+
+
+# ---------------------------------------------------------------------------
+# 1. THE BUG IS DEAD — a deleted file does not come back.
+# ---------------------------------------------------------------------------
+
+
+async def test_a_file_deleted_in_the_vm_is_gone_after_sync_and_restore() -> None:
+    """The headline case, end to end: create -> sync -> delete -> sync -> restore."""
+    project = await _project()
+    uploads = _FakeUploads()
+    vm = _FakeVm({"src/app.ts": b"APP", "src/doomed.ts": b"DOOMED"})
+
+    await durability.sync_project_files(_WS, _USER, project.id, _VM, client=vm, uploads=uploads)
+    assert set((await codeproject_service.get_project(_WS, _USER, project.id)).overlay) == {
+        "src/app.ts",
+        "src/doomed.ts",
+    }
+
+    # The user deletes it in the VM (a terminal ``rm``, a delete that never reached
+    # a hook — the store must reconcile from the workspace, not from an event).
+    vm.files.pop("src/doomed.ts")
+    await durability.sync_project_files(_WS, _USER, project.id, _VM, client=vm, uploads=uploads)
+
+    stored = await codeproject_service.get_project(_WS, _USER, project.id)
+    assert set(stored.overlay) == {"src/app.ts"}, "the deleted file is still in the store"
+
+    # Restore into a genuinely fresh VM: the deletion has to survive the round trip.
+    fresh = _FakeVm()
+    await durability.restore_project(
+        _WS, _USER, project.id, _FRESH_VM, client=fresh, uploads=uploads
+    )
+    assert fresh.files == {"src/app.ts": b"APP"}
+
+
+async def test_a_deleted_clone_file_is_gone_even_though_it_never_passed_a_write_hook() -> None:
+    """The case a tombstone-free design has to handle.
+
+    ``src/from-the-clone.ts`` arrived with the ``git clone`` — no write hook ever saw
+    it, so under the old design only the tarball knew about it, and only the tarball
+    could bring it back. Here the sync captures it and the next sync drops it.
+    """
+    project = await _project(repo="https://github.com/acme/widgets.git", provider="github")
+    uploads = _FakeUploads()
+    vm = _FakeVm({"src/from-the-clone.ts": b"CLONED", "package.json": b"{}"})
+
+    await durability.sync_project_files(_WS, _USER, project.id, _VM, client=vm, uploads=uploads)
+    vm.files.pop("src/from-the-clone.ts")
+    await durability.sync_project_files(_WS, _USER, project.id, _VM, client=vm, uploads=uploads)
+
+    fresh = _FakeVm()
+    await durability.restore_project(
+        _WS, _USER, project.id, _FRESH_VM, client=fresh, uploads=uploads
+    )
+    assert fresh.files == {"package.json": b"{}"}
+
+
+async def test_the_prune_removes_a_deleted_file_the_fresh_vm_re_materialized() -> None:
+    """The production shape of the same case: the fresh VM is NOT empty.
+
+    A reopened project cold-provisions, and the VM it gets has just been cloned (or
+    scaffolded) — so it holds the baseline copy of the file the user deleted.
+    Replaying the store over that tree would leave the file behind, which is the
+    resurrection this whole change removes. Restore prunes it.
+    """
+    project = await _project(repo="https://github.com/acme/widgets.git", provider="github")
+    uploads = _FakeUploads()
+    vm = _FakeVm({"keep.ts": b"KEEP", "deleted-by-the-user.ts": b"OLD"})
+    await durability.sync_project_files(_WS, _USER, project.id, _VM, client=vm, uploads=uploads)
+    vm.files.pop("deleted-by-the-user.ts")
+    await durability.sync_project_files(_WS, _USER, project.id, _VM, client=vm, uploads=uploads)
+
+    # The fresh VM is a fresh CLONE: both files are back on disk.
+    fresh = _FakeVm({"keep.ts": b"KEEP", "deleted-by-the-user.ts": b"OLD"})
+    await durability.restore_project(
+        _WS, _USER, project.id, _FRESH_VM, client=fresh, uploads=uploads
+    )
+
+    assert fresh.files == {"keep.ts": b"KEEP"}
+    assert any(c.startswith("rm -f ") for c in fresh.exec_calls)
+
+
+async def test_the_prune_never_touches_regenerable_trees() -> None:
+    """``.git`` and ``node_modules`` are absent from the store BY DESIGN.
+
+    They are excluded from every enumeration, so "not in the store" says nothing
+    about them — deleting them would destroy the clone's history and force a
+    reinstall on every reopen.
+    """
+    project = await _project(repo="https://github.com/acme/widgets.git", provider="github")
+    uploads = _FakeUploads()
+    vm = _FakeVm({"a.ts": b"A"})
+    await durability.sync_project_files(_WS, _USER, project.id, _VM, client=vm, uploads=uploads)
+
+    fresh = _FakeVm(
+        {
+            "a.ts": b"A",
+            ".git/HEAD": b"ref: refs/heads/main",
+            "node_modules/left-pad/index.js": b"dep",
+            "dist/bundle.js": b"built",
+        }
+    )
+    await durability.restore_project(
+        _WS, _USER, project.id, _FRESH_VM, client=fresh, uploads=uploads
+    )
+
+    assert ".git/HEAD" in fresh.files
+    assert "node_modules/left-pad/index.js" in fresh.files
+    assert "dist/bundle.js" in fresh.files
+
+
+# ---------------------------------------------------------------------------
+# 2. COMPLETENESS — files that never passed a write hook are in the store.
+# ---------------------------------------------------------------------------
+
+
+async def test_scaffold_output_that_never_passed_a_hook_is_captured_and_restores() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+    # A materialized starter: none of this went through ``file.write``.
+    vm = _FakeVm(
+        {
+            "package.json": b'{"name":"app"}',
+            "src/main.tsx": b"render()",
+            "public/favicon.ico": b"\x00\x01binary",  # binary survives: bytes, not text
+        }
+    )
+
+    overlay = await durability.sync_project_files(
+        _WS, _USER, project.id, _VM, client=vm, uploads=uploads
+    )
+    assert set(overlay) == {"package.json", "src/main.tsx", "public/favicon.ico"}
+
+    fresh = _FakeVm()
+    await durability.restore_project(
+        _WS, _USER, project.id, _FRESH_VM, client=fresh, uploads=uploads
+    )
+    assert fresh.files == vm.files
+
+
+async def test_regenerable_trees_never_enter_the_store() -> None:
+    """The complement of completeness: ``node_modules`` is not user work.
+
+    It is excluded at the tar level AND re-checked after expansion, so it never
+    costs a blob, never counts against the caps, and never has to be restored.
+    """
+    project = await _project()
+    uploads = _FakeUploads()
+    vm = _FakeVm(
+        {
+            "src/a.ts": b"A",
+            "node_modules/left-pad/index.js": b"dep",
+            ".git/objects/ab/cdef": b"\x00obj",
+            "dist/bundle.js": b"built",
+            "build.ts": b"NOT-A-BUILD-DIR",  # segment match, not prefix match
+        }
+    )
+
+    overlay = await durability.sync_project_files(
+        _WS, _USER, project.id, _VM, client=vm, uploads=uploads
+    )
+    assert set(overlay) == {"src/a.ts", "build.ts"}
+
+
+# ---------------------------------------------------------------------------
+# 3. LEGACY MIGRATION — once, lossless, pointer cleared, idempotent.
+# ---------------------------------------------------------------------------
+
+
+async def test_a_legacy_tarball_migrates_to_per_file_entries_and_loses_nothing() -> None:
+    project = await _project()
+    uploads = _TrackingUploads()
+
+    # A pre-S1 project: most of the work inside the tar, plus the handful of edits a
+    # write hook mirrored after the snapshot was taken.
+    await _stage_legacy_snapshot(
+        project.id,
+        uploads,
+        _tar(
+            {
+                "./src/app.ts": b"OLD-FROM-TAR",
+                "./only-in-tar.ts": b"TAR-ONLY",
+                "./node_modules/dep/index.js": b"dep",  # filtered, not migrated
+            }
+        ),
+    )
+    await durability.mirror_file_to_project(
+        _WS, _USER, project.id, "src/app.ts", b"NEW-FROM-OVERLAY", uploads=uploads
+    )
+    await durability.mirror_file_to_project(
+        _WS, _USER, project.id, "only-in-overlay.ts", b"OVERLAY-ONLY", uploads=uploads
+    )
+
+    fresh = _FakeVm()
+    await durability.restore_project(
+        _WS, _USER, project.id, _FRESH_VM, client=fresh, uploads=uploads
+    )
+
+    # Nothing is lost, and the fresher tier wins where the two overlap.
+    assert fresh.files == {
+        "src/app.ts": b"NEW-FROM-OVERLAY",
+        "only-in-tar.ts": b"TAR-ONLY",
+        "only-in-overlay.ts": b"OVERLAY-ONLY",
+    }
+
+    migrated = await codeproject_service.get_project(_WS, _USER, project.id)
+    assert set(migrated.overlay) == {"src/app.ts", "only-in-tar.ts", "only-in-overlay.ts"}
+    assert migrated.snapshot_file_id is None, "the legacy pointer would migrate again"
+    assert migrated.overlay_complete is True
+
+
+async def test_the_migration_is_idempotent_on_a_second_restore() -> None:
+    project = await _project()
+    uploads = _TrackingUploads()
+    legacy_id = await _stage_legacy_snapshot(project.id, uploads, _tar({"./a.ts": b"A"}))
+
+    await durability.restore_project(
+        _WS, _USER, project.id, _FRESH_VM, client=_FakeVm(), uploads=uploads
+    )
+    first = await codeproject_service.get_project(_WS, _USER, project.id)
+    uploads_after_first = len(uploads.upload_calls)
+
+    await durability.restore_project(
+        _WS, _USER, project.id, "dtn-third", client=_FakeVm(), uploads=uploads
+    )
+    second = await codeproject_service.get_project(_WS, _USER, project.id)
+
+    assert second.overlay == first.overlay
+    assert second.snapshot_file_id is None
+    # No second expansion: the tar was neither re-read nor re-uploaded.
+    assert len(uploads.upload_calls) == uploads_after_first
+    assert uploads.stream_calls.count(legacy_id) == 1
+
+
+async def test_a_failed_migration_keeps_the_pointer_and_falls_back_to_the_tar() -> None:
+    """Non-destructive by construction: a migration that can't finish must not clear.
+
+    Clearing the pointer on a partial run would strand whatever hadn't been carried
+    across. Keeping it means the next open retries, and the untar fallback still
+    materializes the session so the user never sees a project with holes in it.
+    """
+    project = await _project()
+    uploads = _FakeUploads()
+    await _stage_legacy_snapshot(project.id, uploads, _tar({"./a.ts": b"A"}))
+
+    async def _explode(*args, **kwargs):  # noqa: ANN002, ANN003
+        raise RuntimeError("blob storage is down")
+
+    original = durability._upload_project_blob
+    durability._upload_project_blob = _explode
+    try:
+        vm = _FakeVm()
+        await durability.restore_project(
+            _WS, _USER, project.id, _FRESH_VM, client=vm, uploads=uploads
+        )
+    finally:
+        durability._upload_project_blob = original
+
+    kept = await codeproject_service.get_project(_WS, _USER, project.id)
+    assert kept.snapshot_file_id is not None, "a partial migration threw the tar away"
+    assert kept.overlay_complete is False, "an incomplete store must not license a prune"
+    # The session was still materialized — via the legacy untar fallback.
+    assert any("tar -xzf" in c for c in vm.exec_calls)
+
+
+# ---------------------------------------------------------------------------
+# 4. RESTORE IS STORE-ONLY for a migrated / new project.
+# ---------------------------------------------------------------------------
+
+
+async def test_restore_never_fetches_a_tarball_for_a_synced_project() -> None:
+    project = await _project()
+    uploads = _TrackingUploads()
+    vm = _FakeVm({"a.ts": b"A", "dir/b.ts": b"B"})
+    await durability.sync_project_files(_WS, _USER, project.id, _VM, client=vm, uploads=uploads)
+
+    fresh = _FakeVm()
+    await durability.restore_project(
+        _WS, _USER, project.id, _FRESH_VM, client=fresh, uploads=uploads
+    )
+
+    assert not any("tar -xzf" in c for c in fresh.exec_calls)
+    assert "/tmp/ws-snapshot.tgz" not in fresh.upload_paths, "a tarball was staged in the VM"
+    assert fresh.files == {"a.ts": b"A", "dir/b.ts": b"B"}
+    # Every blob read was an overlay entry — the store, nothing else.
+    stored = await codeproject_service.get_project(_WS, _USER, project.id)
+    assert set(uploads.stream_calls) == set(stored.overlay.values())
+
+
+async def test_restore_after_migration_reads_only_the_store() -> None:
+    project = await _project()
+    uploads = _TrackingUploads()
+    legacy_id = await _stage_legacy_snapshot(project.id, uploads, _tar({"./a.ts": b"A"}))
+    await durability.restore_project(
+        _WS, _USER, project.id, _FRESH_VM, client=_FakeVm(), uploads=uploads
+    )
+
+    uploads.stream_calls.clear()
+    fresh = _FakeVm()
+    await durability.restore_project(
+        _WS, _USER, project.id, "dtn-third", client=fresh, uploads=uploads
+    )
+
+    assert legacy_id not in uploads.stream_calls
+    assert not any("tar -xzf" in c for c in fresh.exec_calls)
+    assert fresh.files == {"a.ts": b"A"}
+
+
+# ---------------------------------------------------------------------------
+# 5. THE DESTRUCTIVE PARTS ARE GATED.
+# ---------------------------------------------------------------------------
+
+
+async def test_an_empty_enumeration_never_wipes_the_store() -> None:
+    """A transient VM failure must not read as "the user deleted everything"."""
+    project = await _project()
+    uploads = _FakeUploads()
+    vm = _FakeVm({"a.ts": b"A"})
+    await durability.sync_project_files(_WS, _USER, project.id, _VM, client=vm, uploads=uploads)
+    before = (await codeproject_service.get_project(_WS, _USER, project.id)).overlay
+
+    kept = await durability.sync_project_files(
+        _WS, _USER, project.id, _VM, client=_FakeVm(), uploads=uploads
+    )
+
+    assert kept == before
+    assert (await codeproject_service.get_project(_WS, _USER, project.id)).overlay == before
+
+
+async def test_sync_keeps_entries_it_could_not_have_seen() -> None:
+    """An overlay entry inside an excluded tree is invisible to the enumeration.
+
+    "The sync didn't see it" is not the same claim as "the user deleted it", so such
+    an entry is carried across rather than silently dropped.
+    """
+    project = await _project()
+    uploads = _FakeUploads()
+    await durability.mirror_file_to_project(
+        _WS, _USER, project.id, "dist/hand-edited.js", b"EDITED", uploads=uploads
+    )
+
+    overlay = await durability.sync_project_files(
+        _WS, _USER, project.id, _VM, client=_FakeVm({"a.ts": b"A"}), uploads=uploads
+    )
+
+    assert overlay == {"a.ts": "file-2", "dist/hand-edited.js": "file-1"}
+
+
+async def test_an_in_tab_project_is_never_pruned() -> None:
+    """The in-tab runtime's baseline lives in the BROWSER, so its store is partial.
+
+    It holds only the files the tab wrote; the starter scaffold is re-materialized
+    client-side and never stored. Pruning "everything not in the store" there would
+    delete the entire scaffold, so the prune is gated on a store that a sync has
+    actually verified against a workspace.
+    """
+    project = await _project()
+    uploads = _FakeUploads()
+    await durability.put_project_file(
+        _WS, _USER, project.id, "src/App.tsx", "MINE", uploads=uploads
+    )
+    assert (await codeproject_service.get_project(_WS, _USER, project.id)).overlay_complete is False
+
+    # Opening it on the VM runtime: the scaffold is materialized, then restored over.
+    fresh = _FakeVm({"src/App.tsx": b"TEMPLATE", "vite.config.ts": b"TEMPLATE-CONFIG"})
+    await durability.restore_project(
+        _WS, _USER, project.id, _FRESH_VM, client=fresh, uploads=uploads
+    )
+
+    assert fresh.files["src/App.tsx"] == b"MINE"  # the tab's copy wins
+    assert fresh.files["vite.config.ts"] == b"TEMPLATE-CONFIG"  # and nothing was pruned
+    assert not any(c.startswith("rm -f ") for c in fresh.exec_calls)
+
+
+async def test_a_restore_that_materialized_nothing_prunes_nothing() -> None:
+    """A store whose blobs are all unreadable must not delete the baseline.
+
+    The replay tolerates one bad entry, so a total failure looks like "0 replayed" —
+    and pruning on top of that would remove the clone the user could still work from.
+    """
+    project = await _project()
+    uploads = _FakeUploads()
+    vm = _FakeVm({"a.ts": b"A"})
+    await durability.sync_project_files(_WS, _USER, project.id, _VM, client=vm, uploads=uploads)
+
+    # Every blob vanishes from storage (a reap, a bucket misconfiguration).
+    uploads._blobs.clear()
+
+    fresh = _FakeVm({"a.ts": b"A", "b.ts": b"B"})
+    await durability.restore_project(
+        _WS, _USER, project.id, _FRESH_VM, client=fresh, uploads=uploads
+    )
+
+    assert fresh.files == {"a.ts": b"A", "b.ts": b"B"}
+    assert not any(c.startswith("rm -f ") for c in fresh.exec_calls)
+
+
+# ---------------------------------------------------------------------------
+# Caps — sized for a whole source tree now, and still LOUD rather than partial.
+# ---------------------------------------------------------------------------
+
+
+async def test_the_caps_hold_an_ordinary_source_project() -> None:
+    """The re-tune, stated as the behaviour: the defaults must not reject real work.
+
+    The old 10 MB / 2000-file limits were sized for a DELTA. The store now holds the
+    whole tree, and a 3000-file project is ordinary — under the old numbers it would
+    have 413'd on every capture.
+    """
+    project = await _project()
+    uploads = _FakeUploads()
+    vm = _FakeVm({f"src/mod{i}.ts": b"x" * 2048 for i in range(3000)})
+
+    overlay = await durability.sync_project_files(
+        _WS, _USER, project.id, _VM, client=vm, uploads=uploads
+    )
+    assert len(overlay) == 3000
+
+
+async def test_a_project_over_the_file_cap_fails_loud(monkeypatch) -> None:  # noqa: ANN001
+    project = await _project()
+    uploads = _FakeUploads()
+    vm = _FakeVm({"a.ts": b"A", "b.ts": b"B"})
+    monkeypatch.setenv("POCKETPAW_CODEPROJECT_OVERLAY_MAX_FILES", "1")
+
+    with pytest.raises(CloudError) as exc:
+        await durability.sync_project_files(_WS, _USER, project.id, _VM, client=vm, uploads=uploads)
+    assert exc.value.code == "codeproject.overlay_too_many_files"
+    assert exc.value.status_code == 413
+    # Loud, and nothing was written — never a truncated store.
+    assert uploads.upload_calls == []
+    assert (await codeproject_service.get_project(_WS, _USER, project.id)).overlay == {}
+
+
+async def test_a_project_over_the_byte_cap_fails_loud(monkeypatch) -> None:  # noqa: ANN001
+    project = await _project()
+    uploads = _FakeUploads()
+    vm = _FakeVm({"big.ts": b"x" * 4096})
+    monkeypatch.setenv("POCKETPAW_CODEPROJECT_OVERLAY_MAX_MB", "0.001")  # ~1 KB
+
+    with pytest.raises(CloudError) as exc:
+        await durability.sync_project_files(_WS, _USER, project.id, _VM, client=vm, uploads=uploads)
+    assert exc.value.code == "codeproject.overlay_too_large"
+    assert uploads.upload_calls == []

--- a/tests/cloud/test_codeproject_scaffold_open.py
+++ b/tests/cloud/test_codeproject_scaffold_open.py
@@ -1,0 +1,370 @@
+# test_codeproject_scaffold_open.py — B3: a SCAFFOLD project opens on the Daytona
+# VM runtime.
+#
+# Created 2026-07-25 (B3, feat/code-scaffold-on-vm).
+#
+# What was broken: ``open_project`` provisioned every project through
+# ``open_sandbox``, which runs ``_validate_repo_url`` and fail-closes on anything
+# that isn't a clean http(s) URL. A scaffold project's ``repo`` is a starter
+# TEMPLATE id ("react"), so the open was rejected before a VM existed — scaffold
+# projects were in-tab only.
+#
+# The fix is a second door, not a weaker lock: ``open_bare_sandbox`` provisions an
+# EMPTY VM (no clone, no remote, no branch) and ``scaffold_into_sandbox``
+# materializes the starter into it. These tests hold that line explicitly — the
+# clone validator's rules are asserted here, unchanged, so a future refactor that
+# quietly loosens them fails a test instead of shipping.
+#
+# What is proved, on real Beanie over mongomock-motor (the ``mongo_db`` fixture)
+# with a FAKE Daytona client, a FAKE ``bring_up``, and a FAKE blob store injected
+# through the existing DI seams — no VM, no npm, no network:
+#   1. a scaffold open provisions a VM and materializes the starter, and the git
+#      clone path is NOT taken;
+#   2. a repo open is byte-for-byte the old behaviour (regression);
+#   3. the durable state restores ON TOP of the scaffold, in that order;
+#   4. a reopen does not re-scaffold over the user's work — neither when the VM is
+#      still live, nor when it died and a fresh one is provisioned;
+#   5. ``_validate_repo_url`` still rejects file:// / git@ / ssh:// / bare paths /
+#      credential-embedding URLs.
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import BadRequest
+from pocketpaw_ee.cloud.codeproject import lifecycle
+from pocketpaw_ee.cloud.codeproject import service as codeproject_service
+from pocketpaw_ee.cloud.codescaffold import registry as codescaffold_registry
+from pocketpaw_ee.cloud.codescaffold.registry import Template
+from pocketpaw_ee.cloud.websandbox import durability, provision, scaffold
+from pocketpaw_ee.cloud.websandbox import service as sandbox_service
+
+from tests.cloud.test_codeproject_durability import _FakeUploads
+from tests.cloud.test_websandbox_provision import _FakeDaytonaClient as _FakeProvisionClient
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+_WS = "ws-1"
+_USER = "user-1"
+_REPO = "https://github.com/acme/widgets.git"
+_STARTER = "react"
+_WORKDIR = "/home/daytona"
+
+#: What the fake npm registry hands back for the starter.
+_TEMPLATE_FILES = {
+    "package.json": '{"name":"template-default"}',
+    "src/app.tsx": "TEMPLATE-BASELINE",
+}
+
+
+# ---------------------------------------------------------------------------
+# Fakes — every one of them closes a DI seam that already existed.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _TracingClient(_FakeProvisionClient):
+    """The provisioning fake, plus an ORDER trace.
+
+    ``upload_bytes`` is how a restore lands bytes in the VM, and the fake
+    ``bring_up`` never calls it, so appending here gives an unambiguous signal for
+    "the restore ran" that can be compared against "the scaffold ran".
+    """
+
+    trace: list[str] = field(default_factory=list)
+
+    async def upload_bytes(self, sandbox_id, data, remote_path):  # noqa: ANN001
+        self.trace.append("restore")
+        await super().upload_bytes(sandbox_id, data, remote_path)
+
+
+class _RecordingBringUp:
+    """Stands in for ``scaffold.bring_up`` — records, touches nothing.
+
+    Returns a clean ``BringUp`` so ``scaffold_into_sandbox`` maps a real response;
+    what a real bring-up does to a VM (tar upload, npm install, dev server) is
+    ``test_websandbox_scaffold``'s job, not this file's.
+    """
+
+    def __init__(self, trace: list[str] | None = None) -> None:
+        self.calls: list[dict] = []
+        self._trace = trace if trace is not None else []
+
+    async def __call__(  # noqa: ANN204
+        self,
+        daytona,  # noqa: ANN001
+        sandbox_id,  # noqa: ANN001
+        files,  # noqa: ANN001
+        project_dir,  # noqa: ANN001
+        *,
+        port=None,  # noqa: ANN001
+        assets=None,  # noqa: ANN001
+        run_migrations=True,  # noqa: ANN001
+    ):
+        self._trace.append("scaffold")
+        self.calls.append(
+            {
+                "sandbox_id": sandbox_id,
+                "files": dict(files),
+                "project_dir": project_dir,
+                "port": port,
+            }
+        )
+        return scaffold.BringUp(
+            steps=[scaffold.Step(name="materialize", ok=True, exitCode=0)],
+            running=True,
+            port=port or 5173,
+        )
+
+
+@pytest.fixture()
+def uploads(monkeypatch) -> _FakeUploads:  # noqa: ANN001
+    """A fake blob store wired in as the module default.
+
+    ``put_project_file`` and ``restore_project`` each build their own uploads
+    service, so the seam is closed at module level and ONE instance carries the
+    blob — bytes written by a seed are readable by the later restore.
+    """
+    fake = _FakeUploads()
+    monkeypatch.setattr(durability, "build_uploads", lambda: fake)
+    return fake
+
+
+@pytest.fixture(autouse=True)
+def offline_starter(monkeypatch) -> None:  # noqa: ANN001
+    """No npm registry in a unit test.
+
+    Faked at ``fetch_template`` rather than at ``compose`` deliberately: compose
+    still runs for real, so the catalog check and the project-name stamp into
+    package.json are exercised — those are the parts the open path depends on.
+    """
+
+    async def _fetch(starter):  # noqa: ANN001, ANN202
+        return Template(files=dict(_TEMPLATE_FILES), assets={})
+
+    monkeypatch.setattr(codescaffold_registry, "fetch_template", _fetch)
+
+
+async def _scaffold_project(name: str = "booking"):  # noqa: ANN202
+    return await codeproject_service.create_project(
+        _WS, _USER, {"repo": _STARTER, "provider": "starter", "name": name}
+    )
+
+
+# ---------------------------------------------------------------------------
+# Proof 1 — a scaffold project opens on a VM, and never touches the clone path.
+# ---------------------------------------------------------------------------
+
+
+async def test_scaffold_open_provisions_a_bare_vm_and_materializes_the_starter() -> None:
+    project = await _scaffold_project()
+    client = _TracingClient()
+    bring_up = _RecordingBringUp()
+
+    sandbox = await lifecycle.open_project(_WS, _USER, project.id, client=client, bring_up=bring_up)
+
+    # A real VM was provisioned and the row is ready with its Daytona id bound.
+    assert len(client.create_calls) == 1
+    assert sandbox.status == "ready"
+    assert sandbox.sandbox_id == "dtn-1"
+
+    # The starter was materialized INTO that VM, at the pinned workspace dir.
+    assert len(bring_up.calls) == 1
+    assert bring_up.calls[0]["sandbox_id"] == "dtn-1"
+    assert bring_up.calls[0]["project_dir"] == _WORKDIR
+    assert bring_up.calls[0]["files"]["src/app.tsx"] == "TEMPLATE-BASELINE"
+    # compose ran for real, so the project's own name is in its package.json.
+    assert '"name": "booking"' in bring_up.calls[0]["files"]["package.json"]
+
+    # And the git clone path was NOT taken: no clone, no broker upload, no
+    # ``git checkout -b``, and no branch on the row (there is no repository).
+    assert client.clone_calls == []
+    assert not any("git checkout" in c for c in client.exec_calls)
+    assert sandbox.branch is None
+
+    # The project is bound to the row it just opened.
+    stored = await codeproject_service.get_project(_WS, _USER, project.id)
+    assert stored.current_sandbox_id == sandbox.id
+
+
+async def test_a_template_id_is_never_validated_as_a_repo_url() -> None:
+    """The clone validator would reject "react" — and never sees it.
+
+    This is the whole shape of the fix in one test: the rule that made a scaffold
+    open impossible is still in force for clones, and the scaffold open succeeds
+    anyway because it does not go through the clone.
+    """
+    with pytest.raises(BadRequest):
+        provision._validate_repo_url(_STARTER)
+
+    project = await _scaffold_project()
+    sandbox = await lifecycle.open_project(
+        _WS, _USER, project.id, client=_TracingClient(), bring_up=_RecordingBringUp()
+    )
+
+    assert sandbox.status == "ready"
+
+
+async def test_the_sandbox_row_key_is_scoped_to_the_project() -> None:
+    """Two projects on one starter get two rows, not one shared one.
+
+    A row is unique per (workspace, user, key) and it is what binds a project to a
+    VM. Keying on the bare template id would make opening the second project
+    rebind — and tear down — the first one's VM, and then hand the first project
+    the second's files on its next open.
+    """
+    first = await _scaffold_project("alpha")
+    second = await _scaffold_project("beta")
+    client = _TracingClient()
+
+    a = await lifecycle.open_project(
+        _WS, _USER, first.id, client=client, bring_up=_RecordingBringUp()
+    )
+    b = await lifecycle.open_project(
+        _WS, _USER, second.id, client=client, bring_up=_RecordingBringUp()
+    )
+
+    assert a.id != b.id
+    assert a.sandbox_id != b.sandbox_id
+    row_a = await sandbox_service.get_sandbox(_WS, _USER, a.id)
+    row_b = await sandbox_service.get_sandbox(_WS, _USER, b.id)
+    assert row_a.repo == f"starter:{_STARTER}:{first.id}"
+    assert row_b.repo == f"starter:{_STARTER}:{second.id}"
+    # Opening the second project did not tear the first one's VM down.
+    assert client.delete_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Proof 2 — a repo project is completely unchanged.
+# ---------------------------------------------------------------------------
+
+
+async def test_a_repo_project_open_is_unchanged() -> None:
+    project = await codeproject_service.create_project(_WS, _USER, {"repo": _REPO})
+    client = _TracingClient()
+    bring_up = _RecordingBringUp()
+
+    sandbox = await lifecycle.open_project(_WS, _USER, project.id, client=client, bring_up=bring_up)
+
+    # Cloned, branched, and keyed on the repo URL exactly as before.
+    assert len(client.clone_calls) == 1
+    assert client.clone_calls[0]["repo_url"] == _REPO
+    assert client.clone_calls[0]["path"] == _WORKDIR
+    assert sandbox.branch is not None and sandbox.branch.startswith("paw/edit-")
+    assert any(f"git checkout -b {sandbox.branch}" == c for c in client.exec_calls)
+    row = await sandbox_service.get_sandbox(_WS, _USER, sandbox.id)
+    assert row.repo == _REPO
+
+    # And nothing was scaffolded into it.
+    assert bring_up.calls == []
+
+
+# ---------------------------------------------------------------------------
+# Proof 3 — the durable state restores ON TOP of the scaffold, in that order.
+# ---------------------------------------------------------------------------
+
+
+async def test_durable_state_restores_on_top_of_the_scaffold(uploads) -> None:  # noqa: ANN001
+    """The template is the baseline; the user's work wins.
+
+    Order is the assertion. Restoring first would let the template overwrite the
+    edits it is supposed to sit under.
+    """
+    project = await _scaffold_project()
+    # A file the user saved in a previous session, on the SAME path the starter
+    # ships — the collision that makes ordering observable.
+    await durability.put_project_file(_WS, _USER, project.id, "src/app.tsx", "USER-EDIT")
+
+    trace: list[str] = []
+    client = _TracingClient(trace=trace)
+    bring_up = _RecordingBringUp(trace)
+
+    await lifecycle.open_project(_WS, _USER, project.id, client=client, bring_up=bring_up)
+
+    assert trace == ["scaffold", "restore"], "the restore must land AFTER the scaffold"
+    # The bytes that landed last are the user's, at the same path the starter used.
+    assert client.upload_calls[-1]["data"] == b"USER-EDIT"
+    assert client.upload_calls[-1]["path"] == f"{_WORKDIR}/src/app.tsx"
+    assert bring_up.calls[0]["files"]["src/app.tsx"] == "TEMPLATE-BASELINE"
+
+
+# ---------------------------------------------------------------------------
+# Proof 4 — reopen safety. The dangerous edge: re-materializing a template over
+# work the user has already done.
+# ---------------------------------------------------------------------------
+
+
+async def test_reopening_a_live_scaffold_project_does_not_re_scaffold() -> None:
+    project = await _scaffold_project()
+    client = _TracingClient()
+    bring_up = _RecordingBringUp()
+
+    first = await lifecycle.open_project(_WS, _USER, project.id, client=client, bring_up=bring_up)
+    second = await lifecycle.open_project(_WS, _USER, project.id, client=client, bring_up=bring_up)
+
+    # Same live VM reused — no new VM, and crucially NO second scaffold over the
+    # files the user has been editing in it.
+    assert second.sandbox_id == first.sandbox_id
+    assert len(client.create_calls) == 1
+    assert len(bring_up.calls) == 1
+
+
+async def test_reopening_after_the_vm_died_rescaffolds_only_the_empty_baseline(uploads) -> None:  # noqa: ANN001
+    """A fresh VM is empty, so the template is again the correct baseline.
+
+    Daytona's own lifecycle deletes an idle Code Mode VM in minutes, so this is the
+    ordinary returning-user path, not an edge. What must hold is that the user's
+    work still lands last.
+    """
+    project = await _scaffold_project()
+    trace: list[str] = []
+    client = _TracingClient(trace=trace)
+    bring_up = _RecordingBringUp(trace)
+
+    first = await lifecycle.open_project(_WS, _USER, project.id, client=client, bring_up=bring_up)
+    # The user edits a file; it is mirrored to the durable project store.
+    await durability.put_project_file(_WS, _USER, project.id, "src/app.tsx", "USER-EDIT")
+    # Daytona reclaims the idle VM out of band; the Mongo row still says ready.
+    client.deleted_out_of_band.add(first.sandbox_id)
+    trace.clear()
+
+    second = await lifecycle.open_project(_WS, _USER, project.id, client=client, bring_up=bring_up)
+
+    assert second.sandbox_id != first.sandbox_id
+    assert len(bring_up.calls) == 2, "a brand-new empty VM does need the baseline"
+    assert trace == ["scaffold", "restore"], "and the user's work still lands last"
+    assert client.upload_calls[-1]["data"] == b"USER-EDIT"
+
+
+# ---------------------------------------------------------------------------
+# Proof 5 — the clone validator is unchanged. Asserted explicitly so a later
+# refactor cannot quietly loosen it to "make scaffolds work".
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "repo",
+    [
+        "file:///etc/passwd",
+        "file://../../secrets",
+        "git@github.com:acme/widgets.git",
+        "ssh://git@github.com/acme/widgets.git",
+        "/var/lib/secrets",
+        "../../etc",
+        "acme/widgets",
+        _STARTER,
+        "https://user:token@github.com/acme/widgets.git",
+        "https://x-access-token:ghp_deadbeef@github.com/acme/widgets.git",
+        "",
+        "   ",
+    ],
+)
+def test_validate_repo_url_still_fails_closed(repo: str) -> None:
+    with pytest.raises(BadRequest) as exc:
+        provision._validate_repo_url(repo)
+
+    assert exc.value.status_code == 400
+
+
+def test_validate_repo_url_still_accepts_a_clean_https_url() -> None:
+    assert provision._validate_repo_url(f"  {_REPO}  ") == _REPO

--- a/tests/ee/agent/test_code_mcp_server.py
+++ b/tests/ee/agent/test_code_mcp_server.py
@@ -1,36 +1,45 @@
-# test_code_mcp_server.py — the ``code_mode`` in-process MCP tool (CD-2).
+# test_code_mcp_server.py — the /code file tools (feat/code-mode-file-tools).
 #
-# Created 2026-07-22 (feat/code-mode-tool). Covers the single tool the main chat
-# agent uses to reach the user's project: it resolves the workspace from the
-# per-stream ContextVars, hands the task to CD-1's delegate channel, and turns
-# whatever comes back into an MCP response.
+# Created 2026-07-22 (feat/code-mode-tool) for the single ``code_mode`` tool.
+# Rewritten 2026-07-24 when that coarse tool was replaced by the four file verbs
+# the MAIN agent drives — ``readFile`` / ``search`` / ``listDir`` / ``writeFile``.
+# Each resolves the workspace from the per-stream ContextVars, delegates ONE call
+# to CD-1's browser channel, and turns whatever comes back into an MCP response.
 #
-# Two properties carry most of the weight here.
+# Three properties carry most of the weight here.
 #
-# FIRST, the mode default fails SAFE. Every way of not-saying-a-mode — omitted,
-# null, empty, misspelled, wrong type — has to land on read-only ``ask``. The
-# failure mode of a forgotten field must be "cannot edit", never "can edit
-# unexpectedly", so these are enumerated rather than sampled.
+# FIRST, a malformed call never reaches the browser. A missing path, a non-string
+# query, an over-long rewrite — each is rejected as an MCP error before a delegate
+# is parked, because parking on a bad call would burn the channel budget on
+# something knowable at once.
 #
 # SECOND, no failure path raises. A raise inside an in-process tool handler
 # reaches the model as a broken tool; an error RESPONSE gives it a true sentence
-# to say. So a timeout, a dead stream, and a missing workspace all have to come
-# back as ``is_error`` payloads carrying the channel's own message.
+# to say. So a timeout, a dead stream, and a missing workspace all come back as
+# ``is_error`` payloads carrying the channel's own message.
+#
+# THIRD, ``writeFile`` is honest about staging. It delegates the proposed content
+# and relays the browser's staged-change sentence; the response is what the model
+# reads, and it must not read as "the file was written".
 #
 # The delegate channel itself is not re-tested here (see
-# tests/cloud/test_codeagent_delegates.py) — these drive the handler against a
-# stub and assert on what the handler does with the outcome.
+# tests/cloud/test_codeagent_delegates.py) — these drive the handlers against a
+# stub and assert on what each does with the outcome.
 from __future__ import annotations
-
-import json
 
 import pytest
 from pocketpaw_ee.agent.mcp_servers import code as code_mcp
 from pocketpaw_ee.agent.mcp_servers.code import (
-    CODE_MODE_TOOL_ID,
     CODE_TOOL_IDS,
+    LIST_DIR_TOOL_ID,
+    READ_FILE_TOOL_ID,
+    SEARCH_TOOL_ID,
     SERVER_NAME,
-    _code_mode_handler,
+    WRITE_FILE_TOOL_ID,
+    _list_dir_handler,
+    _read_file_handler,
+    _search_handler,
+    _write_file_handler,
     build_code_server,
 )
 from pocketpaw_ee.cloud.codeagent.delegates import DelegateOutcome
@@ -51,65 +60,70 @@ def captured_delegate(monkeypatch):
     handler imports it inside the function body to avoid an import cycle."""
     calls: list[dict] = []
 
-    async def _stub(workspace_id, task, mode):
-        calls.append({"workspace_id": workspace_id, "task": task, "mode": mode})
-        return DelegateOutcome(ok=True, result={"summary": "done", "filesRead": ["a.ts"]})
+    async def _stub(workspace_id, tool, tool_input):
+        calls.append({"workspace_id": workspace_id, "tool": tool, "input": tool_input})
+        return DelegateOutcome(ok=True, result={"output": "the file contents", "isError": False})
 
     monkeypatch.setattr(
-        "pocketpaw_ee.cloud.codeagent.delegates.delegate_to_browser",
+        "pocketpaw_ee.cloud.codeagent.delegates.delegate_call_to_browser",
         _stub,
     )
     return calls
 
 
-def _payload(response: dict) -> dict:
-    """Pull the JSON body back out of an MCP success response."""
-    return json.loads(response["content"][0]["text"])
+def _text(response: dict) -> str:
+    """Pull the relayed text back out of an MCP response."""
+    return response["content"][0]["text"]
 
 
 # ── the id contract with the /code SurfaceProfile ───────────────────────────
 
 
-def test_tool_id_matches_the_literal_the_surface_profile_hardcodes():
-    """CD-3 shipped first and could not import this constant, so it spelled the
-    id as a literal. They are matched by STRING: a rename here scopes the /code
-    surface to a tool nothing provides, and it fails silently — the agent simply
-    has no way to reach the code. Pin both halves."""
+def test_tool_ids_match_the_literals_the_surface_profile_hardcodes():
+    """The profile shipped before this module exported constants, so it spells
+    the ids as literals. They are matched by STRING: a rename here scopes the
+    /code surface to a tool nothing provides, and it fails silently — the agent
+    simply has no way to reach the code. Pin both halves."""
     assert SERVER_NAME == "pocketpaw_code"
-    assert CODE_MODE_TOOL_ID == "mcp__pocketpaw_code__code_mode"
-    assert CODE_TOOL_IDS == (CODE_MODE_TOOL_ID,)
+    assert READ_FILE_TOOL_ID == "mcp__pocketpaw_code__readFile"
+    assert SEARCH_TOOL_ID == "mcp__pocketpaw_code__search"
+    assert LIST_DIR_TOOL_ID == "mcp__pocketpaw_code__listDir"
+    assert WRITE_FILE_TOOL_ID == "mcp__pocketpaw_code__writeFile"
+    assert set(CODE_TOOL_IDS) == {
+        READ_FILE_TOOL_ID,
+        SEARCH_TOOL_ID,
+        LIST_DIR_TOOL_ID,
+        WRITE_FILE_TOOL_ID,
+    }
 
 
-def test_the_surface_profile_actually_carries_this_id():
+def test_the_surface_profile_actually_carries_every_id():
     """The other end of the same contract, read from the real profile rather
     than restated. If either side drifts, this fails instead of the surface
-    quietly losing its only tool."""
+    quietly losing a tool."""
     from pocketpaw_ee.cloud.surface.domain import SurfaceKind, SurfaceMeta
     from pocketpaw_ee.cloud.surface.service import resolve_profile
 
     profile = resolve_profile(SurfaceKind.CODE, SurfaceMeta())
     assert profile.allow_mcp_tool_ids is not None
-    assert CODE_MODE_TOOL_ID in profile.allow_mcp_tool_ids
+    for tool_id in CODE_TOOL_IDS:
+        assert tool_id in profile.allow_mcp_tool_ids
 
 
 @pytest.mark.asyncio
-async def test_code_mode_reaches_the_effective_allowlist_and_the_builtins_do_not():
+async def test_file_tools_reach_the_effective_allowlist_and_the_builtins_do_not():
     """The whole seam, end to end, through the REAL allowlist computation.
-
-    Its sibling in ``tests/cloud/surface/test_studio_code_handlers.py`` could
-    only assert ABSENCE — when CD-3 shipped, ``allow_mcp_tool_ids`` was a filter
-    over tools that existed, and no server provided ``code_mode`` yet, so the id
-    could not appear no matter how correct the profile was. This file is the
-    change that makes it appear, so this is where presence gets pinned.
 
     Asserting both directions at once is the point. Presence alone would pass on
     a surface that also still had ``Bash``; absence alone was already green on a
     surface with no way to reach the code at all. Only together do they say the
-    agent has exactly one door and it is the right one."""
-    from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
-    from pocketpaw.config import get_settings
+    agent has exactly the file tools and nothing that addresses the wrong
+    machine."""
     from pocketpaw_ee.cloud.surface.domain import SurfaceKind, SurfaceMeta
     from pocketpaw_ee.cloud.surface.service import resolve_profile
+
+    from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
+    from pocketpaw.config import get_settings
 
     profile = resolve_profile(SurfaceKind.CODE, SurfaceMeta())
     built = await ClaudeSDKBackend(get_settings())._build_options(
@@ -125,102 +139,140 @@ async def test_code_mode_reaches_the_effective_allowlist_and_the_builtins_do_not
     )
     effective = set(built.options_kwargs["allowed_tools"])
 
-    assert CODE_MODE_TOOL_ID in effective, (
-        "the /code agent has no way to reach the user's code. Either this "
-        "server is not registered via the pocketpaw.mcp_servers entry point "
-        "(a fresh checkout needs `uv sync --dev --group ee` to pick up a NEW "
-        "entry point), or the id drifted from the literal the profile allows. "
-        f"Effective MCP ids: {sorted(t for t in effective if t.startswith('mcp__'))}"
-    )
+    for tool_id in CODE_TOOL_IDS:
+        assert tool_id in effective, (
+            "the /code agent is missing a file tool. Either this server is not "
+            "registered via the pocketpaw.mcp_servers entry point (a fresh "
+            "checkout needs `uv sync --dev --group ee` to pick up the entry "
+            "point), or an id drifted from the literal the profile allows. "
+            f"Missing: {tool_id}. Effective MCP ids: "
+            f"{sorted(t for t in effective if t.startswith('mcp__'))}"
+        )
     for tool in ("Bash", "Read", "Write", "Edit", "Glob", "Grep", "Agent"):
         assert tool not in effective, f"{tool} addresses the backend's disk, not the user's project"
     assert not [t for t in effective if t.startswith("mcp__pocketpaw_daytona__")]
 
 
-# ── the round trip ──────────────────────────────────────────────────────────
+# ── each verb round-trips to the delegate with the right shape ──────────────
 
 
 @pytest.mark.asyncio
-async def test_task_round_trips_to_the_delegate_and_back(in_workspace, captured_delegate):
-    response = await _code_mode_handler({"task": "add a loading state", "mode": "edit"})
+async def test_read_file_delegates_and_relays(in_workspace, captured_delegate):
+    response = await _read_file_handler({"path": "  src/App.tsx  "})
 
     assert captured_delegate == [
-        {"workspace_id": WS, "task": "add a loading state", "mode": "edit"}
+        {"workspace_id": WS, "tool": "readFile", "input": {"path": "src/App.tsx"}}
     ]
     assert not response.get("is_error")
-    assert _payload(response) == {"summary": "done", "filesRead": ["a.ts"]}
+    assert _text(response) == "the file contents"
 
 
 @pytest.mark.asyncio
-async def test_task_is_stripped_before_it_crosses_the_wire(in_workspace, captured_delegate):
-    await _code_mode_handler({"task": "  fix the retry logic \n"})
-    assert captured_delegate[0]["task"] == "fix the retry logic"
+async def test_search_delegates_the_query(in_workspace, captured_delegate):
+    await _search_handler({"query": "Sidebar"})
+    assert captured_delegate == [
+        {"workspace_id": WS, "tool": "search", "input": {"query": "Sidebar"}}
+    ]
 
 
-# ── the mode default fails safe ─────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_list_dir_delegates_the_path(in_workspace, captured_delegate):
+    await _list_dir_handler({"path": "src/components"})
+    assert captured_delegate[0]["tool"] == "listDir"
+    assert captured_delegate[0]["input"] == {"path": "src/components"}
+
+
+@pytest.mark.asyncio
+async def test_list_dir_allows_the_empty_root_path(in_workspace, captured_delegate):
+    """Listing the project root is a normal request — the one verb where the
+    empty string is a value, not a malformed argument."""
+    await _list_dir_handler({"path": ""})
+    assert captured_delegate == [{"workspace_id": WS, "tool": "listDir", "input": {"path": ""}}]
+
+
+@pytest.mark.asyncio
+async def test_write_file_delegates_the_full_content(in_workspace, captured_delegate):
+    await _write_file_handler({"path": "src/button.tsx", "content": "export const B = 1;\n"})
+    assert captured_delegate == [
+        {
+            "workspace_id": WS,
+            "tool": "writeFile",
+            "input": {"path": "src/button.tsx", "content": "export const B = 1;\n"},
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_write_file_relays_the_staged_sentence_as_success(in_workspace, monkeypatch):
+    """writeFile stages a proposal; the browser answers with a sentence
+    describing it. The handler relays that verbatim as a NON-error, so the model
+    can repeat it — 'I've proposed…', not 'I wrote…'."""
+
+    async def _staged(workspace_id, tool, tool_input):
+        return DelegateOutcome(
+            ok=True,
+            result={
+                "output": "Proposed 2 changes to `src/button.tsx` for review.",
+                "isError": False,
+            },
+        )
+
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.codeagent.delegates.delegate_call_to_browser", _staged
+    )
+
+    response = await _write_file_handler({"path": "src/button.tsx", "content": "x"})
+    assert not response.get("is_error")
+    assert "Proposed 2 changes" in _text(response)
+
+
+@pytest.mark.asyncio
+async def test_write_file_allows_blanking_a_file(in_workspace, captured_delegate):
+    """Empty ``content`` is a legitimate rewrite (clearing a file), so it is
+    required-present but allowed-empty — only a non-string is rejected."""
+    await _write_file_handler({"path": "a.ts", "content": ""})
+    assert captured_delegate[0]["input"] == {"path": "a.ts", "content": ""}
+
+
+# ── malformed calls are rejected before they reach the browser ──────────────
 
 
 @pytest.mark.parametrize(
-    "args",
+    "handler,args",
     [
-        pytest.param({"task": "t"}, id="omitted"),
-        pytest.param({"task": "t", "mode": None}, id="null"),
-        pytest.param({"task": "t", "mode": ""}, id="empty"),
-        pytest.param({"task": "t", "mode": "   "}, id="whitespace"),
-        pytest.param({"task": "t", "mode": "write"}, id="hallucinated"),
-        pytest.param({"task": "t", "mode": "EDIT_ALL"}, id="unrecognized"),
-        pytest.param({"task": "t", "mode": 1}, id="int"),
-        pytest.param({"task": "t", "mode": True}, id="bool"),
-        pytest.param({"task": "t", "mode": ["edit"]}, id="list"),
+        pytest.param(_read_file_handler, {}, id="read-missing-path"),
+        pytest.param(_read_file_handler, {"path": ""}, id="read-empty-path"),
+        pytest.param(_read_file_handler, {"path": "   "}, id="read-whitespace-path"),
+        pytest.param(_read_file_handler, {"path": 42}, id="read-non-string-path"),
+        pytest.param(_search_handler, {}, id="search-missing-query"),
+        pytest.param(_search_handler, {"query": ""}, id="search-empty-query"),
+        pytest.param(_search_handler, {"query": None}, id="search-null-query"),
+        pytest.param(_list_dir_handler, {"path": 3}, id="listdir-non-string-path"),
+        pytest.param(_write_file_handler, {"content": "x"}, id="write-missing-path"),
+        pytest.param(_write_file_handler, {"path": "a.ts"}, id="write-missing-content"),
+        pytest.param(
+            _write_file_handler, {"path": "a.ts", "content": 5}, id="write-non-string-content"
+        ),
     ],
 )
 @pytest.mark.asyncio
-async def test_every_way_of_not_saying_edit_resolves_to_ask(
-    args, in_workspace, captured_delegate
+async def test_a_malformed_call_is_rejected_without_reaching_the_browser(
+    handler, args, in_workspace, captured_delegate
 ):
-    """The one direction that matters. A model that garbles this field must lose
-    the ability to edit, not gain it."""
-    await _code_mode_handler(args)
-    assert captured_delegate[0]["mode"] == "ask"
-
-
-@pytest.mark.parametrize("raw", ["edit", "EDIT", " Edit "])
-@pytest.mark.asyncio
-async def test_edit_is_honoured_when_actually_asked_for(raw, in_workspace, captured_delegate):
-    """The safe default must not be so eager that it swallows a real request —
-    otherwise /code could never edit anything."""
-    await _code_mode_handler({"task": "t", "mode": raw})
-    assert captured_delegate[0]["mode"] == "edit"
-
-
-# ── every failure is a response, never a raise ──────────────────────────────
-
-
-@pytest.mark.parametrize(
-    "args",
-    [
-        pytest.param({}, id="missing"),
-        pytest.param({"task": None}, id="null"),
-        pytest.param({"task": ""}, id="empty"),
-        pytest.param({"task": "   "}, id="whitespace"),
-        pytest.param({"task": 42}, id="int"),
-    ],
-)
-@pytest.mark.asyncio
-async def test_a_bad_task_is_rejected_without_reaching_the_browser(
-    args, in_workspace, captured_delegate
-):
-    response = await _code_mode_handler(args)
+    response = await handler(args)
     assert response["is_error"] is True
     assert captured_delegate == [], "a malformed call must not park a delegate"
 
 
 @pytest.mark.asyncio
-async def test_an_oversized_task_is_rejected_with_advice(in_workspace, captured_delegate):
-    response = await _code_mode_handler({"task": "x" * 9000})
+async def test_an_oversized_write_is_rejected_with_advice(in_workspace, captured_delegate):
+    response = await _write_file_handler({"path": "a.ts", "content": "x" * 200_000})
     assert response["is_error"] is True
-    assert "too long" in response["content"][0]["text"]
+    assert "too long" in _text(response)
     assert captured_delegate == []
+
+
+# ── every failure is a response, never a raise ──────────────────────────────
 
 
 @pytest.mark.asyncio
@@ -229,10 +281,10 @@ async def test_no_workspace_in_scope_is_an_error_not_a_crash(monkeypatch, captur
     to scope the return leg to, so the tool must decline rather than park."""
     monkeypatch.setattr(code_mcp, "_workspace_id", lambda: None)
 
-    response = await _code_mode_handler({"task": "t"})
+    response = await _read_file_handler({"path": "a.ts"})
 
     assert response["is_error"] is True
-    assert "no active workspace" in response["content"][0]["text"].lower()
+    assert "no active workspace" in _text(response).lower()
     assert captured_delegate == []
 
 
@@ -240,9 +292,9 @@ async def test_no_workspace_in_scope_is_an_error_not_a_crash(monkeypatch, captur
 async def test_a_failed_delegate_relays_the_channels_own_message(in_workspace, monkeypatch):
     """The channel distinguishes "no browser attached" from "the browser was
     slow". The model needs that difference to say something true, so the handler
-    must pass the message through rather than substituting a generic one."""
+    passes the message through rather than substituting a generic one."""
 
-    async def _timeout(workspace_id, task, mode):
+    async def _timeout(workspace_id, tool, tool_input):
         return DelegateOutcome(
             ok=False,
             error="timeout",
@@ -250,47 +302,58 @@ async def test_a_failed_delegate_relays_the_channels_own_message(in_workspace, m
         )
 
     monkeypatch.setattr(
-        "pocketpaw_ee.cloud.codeagent.delegates.delegate_to_browser", _timeout
+        "pocketpaw_ee.cloud.codeagent.delegates.delegate_call_to_browser", _timeout
     )
 
-    response = await _code_mode_handler({"task": "t"})
+    response = await _read_file_handler({"path": "a.ts"})
 
     assert response["is_error"] is True
-    assert "did not finish" in response["content"][0]["text"]
-    assert "180s" in response["content"][0]["text"]
+    assert "did not finish" in _text(response)
+    assert "180s" in _text(response)
 
 
 @pytest.mark.asyncio
-async def test_a_failed_delegate_with_no_message_still_says_something(in_workspace, monkeypatch):
-    async def _bare(workspace_id, task, mode):
-        return DelegateOutcome(ok=False, error="aborted", message="")
+async def test_a_browser_side_error_result_becomes_an_error_response(in_workspace, monkeypatch):
+    """``ok`` says the round trip completed; ``isError`` in the payload says the
+    verb itself failed (a missing file, an unreadable path). That must surface to
+    the model as an error it can act on, not as a successful read of an error
+    string."""
 
-    monkeypatch.setattr("pocketpaw_ee.cloud.codeagent.delegates.delegate_to_browser", _bare)
+    async def _iserror(workspace_id, tool, tool_input):
+        return DelegateOutcome(
+            ok=True, result={"output": "no such file: a.ts", "isError": True}
+        )
 
-    response = await _code_mode_handler({"task": "t"})
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.codeagent.delegates.delegate_call_to_browser", _iserror
+    )
+
+    response = await _read_file_handler({"path": "a.ts"})
     assert response["is_error"] is True
-    assert response["content"][0]["text"].strip() != "Error:"
+    assert "no such file" in _text(response)
 
 
 @pytest.mark.asyncio
-async def test_an_empty_success_result_is_still_a_success(in_workspace, monkeypatch):
-    """``ok`` is the signal, not truthiness of the payload. A sub-agent that
-    answered with nothing did not fail."""
+async def test_an_empty_success_output_is_still_a_success(in_workspace, monkeypatch):
+    """An empty file, or a listing of an empty directory, is a real answer — not
+    a failure. ``ok`` is the signal, not truthiness of the output."""
 
-    async def _empty(workspace_id, task, mode):
-        return DelegateOutcome(ok=True, result={})
+    async def _empty(workspace_id, tool, tool_input):
+        return DelegateOutcome(ok=True, result={"output": "", "isError": False})
 
-    monkeypatch.setattr("pocketpaw_ee.cloud.codeagent.delegates.delegate_to_browser", _empty)
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.codeagent.delegates.delegate_call_to_browser", _empty
+    )
 
-    response = await _code_mode_handler({"task": "t"})
+    response = await _read_file_handler({"path": "empty.ts"})
     assert not response.get("is_error")
-    assert _payload(response) == {}
+    assert _text(response) == ""
 
 
 # ── the server assembles ────────────────────────────────────────────────────
 
 
-def test_server_builds_with_exactly_one_tool():
+def test_server_builds_with_the_four_file_tools():
     built = build_code_server()
     if built is None:
         pytest.skip("claude_agent_sdk not installed")
@@ -299,9 +362,9 @@ def test_server_builds_with_exactly_one_tool():
     assert server is not None
 
 
-def test_provider_reports_the_tool_id():
-    """The entry-point provider is how the id reaches the SDK allowlist. A
-    provider that builds but reports no ids leaves the tool uncallable."""
+def test_provider_reports_every_tool_id():
+    """The entry-point provider is how the ids reach the SDK allowlist. A
+    provider that builds but reports the wrong ids leaves tools uncallable."""
     from pocketpaw_ee.extensions import CloudCodeMcpProvider
 
-    assert CloudCodeMcpProvider().tool_ids() == [CODE_MODE_TOOL_ID]
+    assert set(CloudCodeMcpProvider().tool_ids()) == set(CODE_TOOL_IDS)

--- a/tests/ee/agent/test_code_mcp_server.py
+++ b/tests/ee/agent/test_code_mcp_server.py
@@ -25,6 +25,12 @@
 # The delegate channel itself is not re-tested here (see
 # tests/cloud/test_codeagent_delegates.py) — these drive the handlers against a
 # stub and assert on what each does with the outcome.
+#
+# Extended 2026-07-24 (CX-1) with three ``_build_options`` cases proving the
+# ``exclusive_mcp_tools`` cap: (a) exclusive + a declared allow-list yields
+# EXACTLY those ids (grant suppressed), (b) exclusive + None strips ALL mcp ids,
+# (c) the default path still applies the pocket/widget/atlas grant. A
+# deterministic candidate pool is injected so the suppression is provable.
 from __future__ import annotations
 
 import pytest
@@ -151,6 +157,105 @@ async def test_file_tools_reach_the_effective_allowlist_and_the_builtins_do_not(
     for tool in ("Bash", "Read", "Write", "Edit", "Glob", "Grep", "Agent"):
         assert tool not in effective, f"{tool} addresses the backend's disk, not the user's project"
     assert not [t for t in effective if t.startswith("mcp__pocketpaw_daytona__")]
+
+
+# ── exclusive_mcp_tools caps the surface to exactly the declared ids (CX-1) ──
+
+
+def _mcp_ids(built) -> set[str]:
+    """The ``mcp__*`` ids that survived ``_build_options`` scoping."""
+    return {t for t in built.options_kwargs["allowed_tools"] if t.startswith("mcp__")}
+
+
+async def _build_with(backend, *, allow, exclusive):
+    """Run ``_build_options`` with a deterministic candidate MCP pool.
+
+    The pool is monkeypatched (via the fixture) to contain the four code file
+    ids PLUS one widget id, one atlas id, and one planner (grant) id — so the
+    suppression is provable: an exclusive turn must strip the grant ids that a
+    default turn keeps. A test where the grant id was never a candidate would
+    prove nothing."""
+    return await backend._build_options(
+        "refactor this",
+        system_prompt="you are on the code surface",
+        history=None,
+        session_key=None,
+        deny_mcp_tool_ids=frozenset(),
+        allow_sdk_tools=frozenset(),
+        allow_mcp_tool_ids=allow,
+        skill_names=frozenset(),
+        stderr_sink=[],
+        exclusive_mcp_tools=exclusive,
+    )
+
+
+@pytest.fixture
+def backend_with_grant_pool(monkeypatch):
+    """A backend whose ``_collect_mcp_tool_ids`` yields a deterministic pool:
+    the four code file ids + a widget id + an atlas id + a planner grant id."""
+    from pocketpaw.agents.claude_sdk import POCKET_CREATION_GRANT, ClaudeSDKBackend
+    from pocketpaw.agents.sdk_mcp_atlas import ATLAS_TOOL_IDS
+    from pocketpaw.agents.sdk_mcp_widgets import WIDGET_TOOL_IDS
+    from pocketpaw.config import get_settings
+    from pocketpaw_ee.cloud.surface.surface_registry import _CODE_FILE_TOOL_IDS
+
+    widget_id = next(iter(WIDGET_TOOL_IDS))
+    atlas_id = next(iter(ATLAS_TOOL_IDS))
+    planner_id = "mcp__pocketpaw_pocket_planner__plan_pocket"
+    assert planner_id in POCKET_CREATION_GRANT
+
+    pool = [*sorted(_CODE_FILE_TOOL_IDS), widget_id, atlas_id, planner_id]
+    backend = ClaudeSDKBackend(get_settings())
+    monkeypatch.setattr(backend, "_collect_mcp_tool_ids", lambda: list(pool))
+    return backend, widget_id, atlas_id, planner_id
+
+
+@pytest.mark.asyncio
+async def test_exclusive_caps_to_exactly_the_declared_ids(backend_with_grant_pool):
+    """(a) exclusive + a declared allow-list ⇒ the effective MCP surface is
+    EXACTLY those ids; the universal pocket/widget/atlas grant is NOT unioned
+    back in."""
+    from pocketpaw_ee.cloud.surface.surface_registry import _CODE_FILE_TOOL_IDS
+
+    backend, widget_id, atlas_id, planner_id = backend_with_grant_pool
+    built = await _build_with(backend, allow=_CODE_FILE_TOOL_IDS, exclusive=True)
+
+    assert _mcp_ids(built) == set(_CODE_FILE_TOOL_IDS)
+    # the grant ids that were candidates are gone
+    assert widget_id not in _mcp_ids(built)
+    assert atlas_id not in _mcp_ids(built)
+    assert planner_id not in _mcp_ids(built)
+    assert not [t for t in _mcp_ids(built) if t.startswith("mcp__pocketpaw_pocket")]
+
+
+@pytest.mark.asyncio
+async def test_exclusive_with_no_allowlist_strips_all_mcp(backend_with_grant_pool):
+    """(b) exclusive + ``allow_mcp_tool_ids=None`` ⇒ the empty permitted set
+    strips EVERY ``mcp__`` id. This is the precedence rule that lets an
+    exclusive agent win over even a broad surface."""
+    backend, *_ = backend_with_grant_pool
+    built = await _build_with(backend, allow=None, exclusive=True)
+
+    assert _mcp_ids(built) == set()
+
+
+@pytest.mark.asyncio
+async def test_default_path_still_applies_the_grant(backend_with_grant_pool):
+    """(c) the DEFAULT path (signal off) is unchanged: the grant still applies,
+    so a widget id and an atlas id present in the candidate pool SURVIVE the
+    same allow-list that case (a) capped away."""
+    from pocketpaw_ee.cloud.surface.surface_registry import _CODE_FILE_TOOL_IDS
+
+    backend, widget_id, atlas_id, planner_id = backend_with_grant_pool
+    built = await _build_with(backend, allow=_CODE_FILE_TOOL_IDS, exclusive=False)
+
+    effective = _mcp_ids(built)
+    # the declared ids are still there
+    assert set(_CODE_FILE_TOOL_IDS) <= effective
+    # and the grant ids that (a) stripped now survive — proving suppression
+    assert widget_id in effective
+    assert atlas_id in effective
+    assert planner_id in effective
 
 
 # ── each verb round-trips to the delegate with the right shape ──────────────


### PR DESCRIPTION
## What this does

The /code surface used to give the main chat agent one coarse tool, `code_mode(task)`, that handed a whole coding task to a browser sub-agent. That sub-agent was removed — so the tool now delegates to nothing, and Code Mode is down.

This replaces `code_mode` with the four file tools the main agent reasons *with*, driving its own tool loop the way a coding agent does:

- `readFile(path)` — read a file
- `search(query)` — search the project
- `listDir(path)` — list a directory
- `writeFile(path, content)` — **propose** a full-file rewrite

The files still live in the user's browser, not on the backend, so each tool parks on the existing browser-delegate channel and pushes one `code_delegate` frame carrying `{corrId, tool, input}`. The browser runs the matching file-session verb and resolves `{output, isError}`. Reasoning moved to the main agent; execution stays in the tab.

## The write gate

`writeFile` never writes. It delegates the proposed contents to the browser, which stages them for the user's per-hunk review — the user accepting a hunk is the only thing that writes, and it happens long after the tool returns. So the tool, the system prompt, and the /code preamble all report a `writeFile` as a change **proposed for review**, never as a file that was written. The honesty rule is load-bearing: a model that says "I created the file" after one `writeFile` has told the user something false.

## Changes

- `delegates.py`: `delegate_to_browser(task, mode)` → `delegate_call_to_browser(tool, input)`; the frame carries a tool call instead of a task
- `code.py`: one `code_mode` tool → four file tools with a uniform outcome relay
- `surface_registry.py`: the /code allow-list scopes to the four tool ids
- `system_prompts.py` + `handlers/code.py`: rewritten for the file-tool vocabulary and the staging-honesty rule
- tests updated across the delegate channel, the MCP server, and the surface profile

## Testing

`pytest` green on the delegate channel, the code MCP server, the surface handlers, and the system-prompt tests (79 tests). `ruff` clean.

## Coordination

This is one half of a lockstep pair — it changes the `code_delegate` wire shape, and the browser executor changes with it. Ships with the paw-enterprise change (linked below). Base is `feat/code-mode`; Code Mode is non-functional end to end until both land.
