### PR TITLE
feat(cockpit): herdr pane telemetry SSE + preview (ADMIN, flagged)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,19 @@ jobs:
           POCKETPAW_LLM_PROVIDER: "ollama"
           POCKETPAW_OLLAMA_HOST: "http://localhost:11434"
 
+      - name: Run herdr cockpit tests
+        # tests/cloud is excluded by the addopts in pyproject.toml, so the step
+        # above never reaches this file — which would leave the cockpit's ADMIN
+        # gate (test_endpoints_require_admin) and its fail-open contract with NO
+        # automated coverage on any PR. `-o addopts=""` clears that ignore for
+        # this one file. The wider "no lane runs tests/cloud" gap is pre-existing
+        # and tracked separately; this keeps the new RBAC surface out of the
+        # blind spot rather than quietly widening it.
+        run: uv run pytest tests/cloud/test_herdr_cockpit.py -o addopts="" -q --tb=short
+        env:
+          POCKETPAW_LLM_PROVIDER: "ollama"
+          POCKETPAW_OLLAMA_HOST: "http://localhost:11434"
+
   import-linter:
     name: OSS-EE boundary
     runs-on: ubuntu-latest

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -251,6 +251,7 @@ def mount_cloud(app: FastAPI) -> None:
     from pocketpaw_ee.cloud.discovery.router import router as discovery_router
     from pocketpaw_ee.cloud.entitlements.router import router as entitlements_router
     from pocketpaw_ee.cloud.foresight.router import router as foresight_router
+    from pocketpaw_ee.cloud.herdr_cockpit.router import router as herdr_cockpit_router
     from pocketpaw_ee.cloud.jobs.router import router as jobs_router
     from pocketpaw_ee.cloud.license import get_license_info
     from pocketpaw_ee.cloud.meetings.providers.recall.webhooks import (
@@ -301,6 +302,11 @@ def mount_cloud(app: FastAPI) -> None:
     app.include_router(deep_work_log_router, prefix="/api/v1")
     app.include_router(chat_router, prefix="/api/v1")
     app.include_router(runs_router, prefix="/api/v1")
+    # Herdr cockpit telemetry (HR-10a) — ADMIN-gated, flag-gated read-only SSE
+    # stream of herdr pane "dots" (GET /cockpit/stream) + on-demand pane preview
+    # (GET /cockpit/pane/{id}/preview). Fails open when herdr is disabled/absent;
+    # panes are NOT paw-workspace-scoped yet, hence ADMIN-only (see router).
+    app.include_router(herdr_cockpit_router, prefix="/api/v1")
     app.include_router(connectors_router, prefix="/api/v1")
     # Discovery — zero-setup workspace-discovery TRIGGER
     # (POST /cloud/discovery/run). Workspace-scoped (no path param); fires the

--- a/ee/pocketpaw_ee/cloud/herdr_cockpit/__init__.py
+++ b/ee/pocketpaw_ee/cloud/herdr_cockpit/__init__.py
@@ -1,0 +1,7 @@
+# herdr_cockpit — read-only cockpit telemetry over the flagged HerdrRuntime.
+#
+# Created: 2026-07-24 (feat/herdr-cockpit-sse, HR-10a) — the contract-defining
+# backend half of HR-10: a live SSE stream of herdr pane status ("dots") plus an
+# on-demand pane-preview endpoint. Both routes are ADMIN-gated and fail open when
+# herdr is disabled or absent (see router.py for the tenancy rationale). No pane
+# mutation lives here — this module is read-only by design.

--- a/ee/pocketpaw_ee/cloud/herdr_cockpit/dto.py
+++ b/ee/pocketpaw_ee/cloud/herdr_cockpit/dto.py
@@ -1,0 +1,53 @@
+# dto.py — wire schemas for the herdr cockpit telemetry surface.
+#
+# Created: 2026-07-24 (feat/herdr-cockpit-sse, HR-10a) — plain snake_case
+# Pydantic response models the cockpit UI reads. There is no request body: the
+# stream takes no input and the preview takes only path/query params. Tenancy is
+# never a field here — the ADMIN gate + auth context govern access (see router).
+#
+# ``CockpitSnapshot`` is the JSON ``data`` of each ``cockpit.snapshot`` SSE frame.
+# ``PanePreviewOut`` is the JSON body of the on-demand preview endpoint.
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class CockpitPaneOut(BaseModel):
+    """One herdr pane's live "dot" in a snapshot frame.
+
+    ``status`` is a Mission Control ``AgentStatus`` *value* string
+    (``idle`` | ``active`` | ``blocked`` | ``offline``). All ids are opaque
+    strings minted by herdr; the only one guaranteed present is ``pane_id``.
+    """
+
+    pane_id: str
+    workspace_id: str | None = None
+    agent: str | None = None
+    status: str
+    tab_id: str | None = None
+    terminal_id: str | None = None
+
+
+class CockpitSnapshot(BaseModel):
+    """The ``data`` payload of one ``cockpit.snapshot`` SSE frame.
+
+    ``herdr_available`` is False (and ``panes`` empty) whenever herdr is
+    disabled, absent, or unreachable this tick — the stream never errors, it
+    degrades. ``ts`` is an ISO-8601 UTC timestamp for the snapshot.
+    """
+
+    ts: str
+    herdr_available: bool
+    panes: list[CockpitPaneOut]
+
+
+class PanePreviewOut(BaseModel):
+    """On-demand pane scrollback preview.
+
+    ``text`` is empty when herdr is unavailable or the pane cannot be read —
+    the endpoint fails open rather than 500-ing.
+    """
+
+    pane_id: str
+    text: str

--- a/ee/pocketpaw_ee/cloud/herdr_cockpit/router.py
+++ b/ee/pocketpaw_ee/cloud/herdr_cockpit/router.py
@@ -1,0 +1,121 @@
+# router.py — FastAPI router for the herdr cockpit telemetry surface (HR-10a).
+#
+# Created: 2026-07-24 (feat/herdr-cockpit-sse) — the thin HTTP shell over
+# ``herdr_cockpit.service``. Two read-only routes, both ADMIN-gated:
+#   * GET /cockpit/stream  — text/event-stream; emits one ``cockpit.snapshot``
+#     frame every POLL_INTERVAL_S with the live pane "dots".
+#   * GET /cockpit/pane/{pane_id}/preview — on-demand pane scrollback (JSON).
+#
+# Discipline (ee/cloud 4-file rules): no business logic and no Beanie doc live
+# here — the fail-open telemetry logic is in service.py. Mounted under /api/v1
+# from ee/pocketpaw_ee/cloud/__init__.py. Mirrors the SSE shape of
+# chat/runs/router.py and the ADMIN-gate shape of automations_status/router.py.
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections.abc import AsyncIterator
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import StreamingResponse
+
+from pocketpaw.agents.herdr_runtime import HerdrRuntime
+from pocketpaw_ee.cloud._core.deps import require_action_any_workspace
+from pocketpaw_ee.cloud.herdr_cockpit import service
+from pocketpaw_ee.cloud.herdr_cockpit.dto import PanePreviewOut
+from pocketpaw_ee.cloud.license import require_license
+
+logger = logging.getLogger(__name__)
+
+# How often the stream re-polls HerdrRuntime and emits a snapshot frame. Small
+# and named so the cadence is one edit away; the poll is a direct adapter read
+# (v1) — bus/Redis push is a later optimization, explicitly out of HR-10a scope.
+POLL_INTERVAL_S = 1.5
+
+# ---------------------------------------------------------------------------
+# Auth: ADMIN-only (v1 safety). RATIONALE — herdr panes on a box are NOT
+# paw-workspace-scoped: herdr mints its own opaque workspace ids (PaneRef.
+# workspace_id ≠ a paw workspace id), so a member-visible cockpit on a SHARED
+# box could leak other tenants' panes. Gating to a workspace ADMIN plus the
+# default-off ``herdr_runtime_enabled`` flag keeps v1 safe on the dedicated-box
+# (Track-A) deployment, where the workspace admin is the box operator.
+#
+# TODO(track-b): multi-tenant enablement MUST first scope panes to the caller's
+# workspace (map herdr's pane workspace_id → the paw workspace, filter the
+# snapshot, and authorize the preview per-pane) BEFORE this may be exposed to
+# non-admins or on a multi-tenant shared box. Do not relax the ADMIN gate until
+# that pane→tenant scoping exists.
+# ---------------------------------------------------------------------------
+_COCKPIT_ADMIN = Depends(require_action_any_workspace("cockpit.read"))
+
+router = APIRouter(
+    prefix="/cockpit",
+    tags=["Herdr Cockpit"],
+    dependencies=[Depends(require_license)],
+)
+
+
+def get_herdr_runtime() -> HerdrRuntime:
+    """Provide a HerdrRuntime built from live settings.
+
+    A FastAPI dependency so tests inject a fake via
+    ``app.dependency_overrides[get_herdr_runtime]``. Construction is cheap (reads
+    settings + resolves the binary; no subprocess), so a fresh instance per
+    request/connection is fine — the adapter is stateless per call.
+    """
+    from pocketpaw.config import get_settings
+
+    return HerdrRuntime(get_settings())
+
+
+def _sse(event: str, data: dict) -> bytes:
+    """Encode one named Server-Sent-Event frame."""
+    return f"event: {event}\ndata: {json.dumps(data)}\n\n".encode()
+
+
+@router.get("/stream", dependencies=[_COCKPIT_ADMIN])
+async def stream_cockpit(
+    runtime: HerdrRuntime = Depends(get_herdr_runtime),
+) -> StreamingResponse:
+    """Live SSE stream of herdr pane telemetry.
+
+    Emits one ``cockpit.snapshot`` frame every ``POLL_INTERVAL_S``. Each frame's
+    ``data`` is a ``CockpitSnapshot`` (``ts``, ``herdr_available``, ``panes``).
+    The generator never raises — ``build_snapshot`` absorbs ``HerdrUnavailable``
+    and emits a fail-open frame (``herdr_available=False``, empty panes), so the
+    stream stays alive whether or not herdr is running. The frame cadence itself
+    acts as the proxy keep-alive, so no separate heartbeat is needed.
+    """
+
+    async def gen() -> AsyncIterator[bytes]:
+        while True:
+            snapshot = await service.build_snapshot(runtime)
+            yield _sse("cockpit.snapshot", snapshot.model_dump())
+            await asyncio.sleep(POLL_INTERVAL_S)
+
+    return StreamingResponse(
+        gen(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+@router.get("/pane/{pane_id}/preview", response_model=PanePreviewOut, dependencies=[_COCKPIT_ADMIN])
+async def preview_pane(
+    pane_id: str,
+    lines: int = Query(default=service.PREVIEW_DEFAULT_LINES, ge=1),
+    runtime: HerdrRuntime = Depends(get_herdr_runtime),
+) -> PanePreviewOut:
+    """On-demand scrollback preview for one pane.
+
+    ``lines`` is clamped to a sane maximum in the service (a too-large value is
+    capped, not rejected). Fails open to ``text=""`` when herdr is unavailable or
+    the pane cannot be read — never a 500.
+    """
+    return await service.read_preview(runtime, pane_id, lines)

--- a/ee/pocketpaw_ee/cloud/herdr_cockpit/service.py
+++ b/ee/pocketpaw_ee/cloud/herdr_cockpit/service.py
@@ -1,0 +1,111 @@
+# service.py — fail-open telemetry logic over the HerdrRuntime adapter.
+#
+# Created: 2026-07-24 (feat/herdr-cockpit-sse, HR-10a) — builds a cockpit
+# snapshot (one "dot" per herdr pane) and reads an on-demand pane preview. All
+# herdr access goes through the injected ``HerdrRuntime`` and every call is
+# wrapped so ``HerdrUnavailable`` (flag off, binary missing, server down) never
+# propagates: the snapshot degrades to ``herdr_available=False`` + empty panes,
+# the preview degrades to empty text. This is the single place the fail-open
+# contract is enforced, so the router stays a thin HTTP shell.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from pocketpaw.agents.errors import HerdrUnavailable
+from pocketpaw.agents.herdr_runtime import HerdrRuntime
+from pocketpaw.mission_control.models import AgentStatus
+from pocketpaw_ee.cloud.herdr_cockpit.dto import (
+    CockpitPaneOut,
+    CockpitSnapshot,
+    PanePreviewOut,
+)
+
+# Upper bound on preview scrollback so a caller can't ask herdr for an unbounded
+# read. Clamped (not rejected) — a too-large request is silently capped here.
+PREVIEW_MAX_LINES = 500
+PREVIEW_DEFAULT_LINES = 25
+
+
+def _now_iso() -> str:
+    """Current UTC time as an ISO-8601 string (snapshot timestamp)."""
+    return datetime.now(UTC).isoformat()
+
+
+def clamp_lines(lines: int | None) -> int:
+    """Clamp a requested preview line count into ``[1, PREVIEW_MAX_LINES]``.
+
+    ``None`` (or anything below 1) falls back to a floor of 1; values above the
+    cap are silently reduced to it. This is a clamp, not a validation gate — the
+    caller never gets a 4xx for an out-of-range ``lines``.
+    """
+    if lines is None:
+        return PREVIEW_DEFAULT_LINES
+    return max(1, min(int(lines), PREVIEW_MAX_LINES))
+
+
+async def build_snapshot(runtime: HerdrRuntime) -> CockpitSnapshot:
+    """One telemetry tick: every herdr pane with its live ``AgentStatus``.
+
+    Fail-open contract:
+    - herdr disabled / binary absent (cheap ``available`` guard, no subprocess)
+      OR ``list_panes()`` raising ``HerdrUnavailable`` (server down mid-tick) →
+      ``herdr_available=False`` with an empty pane list.
+    - a single pane's ``status()`` failing (e.g. the pane closed between the list
+      and the status call) → that pane reports ``offline`` rather than sinking
+      the whole frame.
+
+    Never raises; the SSE loop can call this forever without a try/except.
+    """
+    ts = _now_iso()
+
+    # Cheap guard first — skip the subprocess entirely when herdr is off/absent.
+    if not runtime.available:
+        return CockpitSnapshot(ts=ts, herdr_available=False, panes=[])
+
+    try:
+        panes = await runtime.list_panes()
+    except HerdrUnavailable:
+        # Flag on but herdr unreachable this tick (server down, socket error).
+        return CockpitSnapshot(ts=ts, herdr_available=False, panes=[])
+
+    out: list[CockpitPaneOut] = []
+    for pane in panes:
+        try:
+            status = await runtime.status(pane)
+            status_value = status.value
+        except HerdrUnavailable:
+            # Pane vanished (or is not an agent pane) between list and status —
+            # fail that dot to offline, keep the rest of the frame intact.
+            status_value = AgentStatus.OFFLINE.value
+        out.append(
+            CockpitPaneOut(
+                pane_id=pane.pane_id,
+                workspace_id=pane.workspace_id,
+                agent=pane.agent,
+                status=status_value,
+                tab_id=pane.tab_id,
+                terminal_id=pane.terminal_id,
+            )
+        )
+
+    return CockpitSnapshot(ts=ts, herdr_available=True, panes=out)
+
+
+async def read_preview(
+    runtime: HerdrRuntime,
+    pane_id: str,
+    lines: int | None = None,
+) -> PanePreviewOut:
+    """On-demand scrollback preview for one pane, fail-open to empty text.
+
+    ``lines`` is clamped to ``[1, PREVIEW_MAX_LINES]``. When herdr is
+    unavailable or the pane cannot be read the preview comes back with
+    ``text=""`` instead of raising — the caller sees an empty pane, never a 500.
+    """
+    clamped = clamp_lines(lines)
+    try:
+        text = await runtime.read(pane_id, lines=clamped)
+    except HerdrUnavailable:
+        text = ""
+    return PanePreviewOut(pane_id=pane_id, text=text)

--- a/ee/pocketpaw_ee/cloud/herdr_cockpit/service.py
+++ b/ee/pocketpaw_ee/cloud/herdr_cockpit/service.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 
 from pocketpaw.agents.errors import HerdrUnavailable
-from pocketpaw.agents.herdr_runtime import HerdrRuntime
+from pocketpaw.agents.herdr_runtime import HerdrRuntime, map_agent_status
 from pocketpaw.mission_control.models import AgentStatus
 from pocketpaw_ee.cloud.herdr_cockpit.dto import (
     CockpitPaneOut,
@@ -64,20 +64,32 @@ async def build_snapshot(runtime: HerdrRuntime) -> CockpitSnapshot:
         return CockpitSnapshot(ts=ts, herdr_available=False, panes=[])
 
     try:
-        panes = await runtime.list_panes()
+        # ``list_agents`` (not ``list_panes``): this is an AGENT board, so a
+        # plain shell pane is not a subject — listing every pane rendered each
+        # bare shell as an "offline" agent, which reads as a fleet of dead
+        # agents at rest. It also halves the work: the list records already
+        # carry ``agent_status`` (verified against herdr v0.7.4), so a snapshot
+        # costs ONE subprocess instead of 1 + one ``agent get`` per pane. At 20
+        # panes on a 1.5s tick that was ~14 spawns/second, per connected admin.
+        panes = await runtime.list_agents()
     except HerdrUnavailable:
         # Flag on but herdr unreachable this tick (server down, socket error).
         return CockpitSnapshot(ts=ts, herdr_available=False, panes=[])
 
     out: list[CockpitPaneOut] = []
     for pane in panes:
-        try:
-            status = await runtime.status(pane)
-            status_value = status.value
-        except HerdrUnavailable:
-            # Pane vanished (or is not an agent pane) between list and status —
-            # fail that dot to offline, keep the rest of the frame intact.
-            status_value = AgentStatus.OFFLINE.value
+        raw_status = pane.raw.get("agent_status")
+        if raw_status is not None:
+            status_value = map_agent_status(raw_status).value
+        else:
+            # Older/leaner herdr payload without the inline status — fall back
+            # to the per-pane call rather than mislabelling the dot.
+            try:
+                status_value = (await runtime.status(pane)).value
+            except HerdrUnavailable:
+                # Pane vanished between the list and the status call — fail
+                # that one dot to offline, keep the rest of the frame intact.
+                status_value = AgentStatus.OFFLINE.value
         out.append(
             CockpitPaneOut(
                 pane_id=pane.pane_id,
@@ -107,5 +119,13 @@ async def read_preview(
     try:
         text = await runtime.read(pane_id, lines=clamped)
     except HerdrUnavailable:
+        text = ""
+    except ValueError:
+        # ``pane_id`` is a raw URL segment, and the adapter refuses a flag-like
+        # id (argument-injection guard) by raising ValueError — which is NOT a
+        # HerdrUnavailable and would otherwise escape as a 500, breaking the
+        # never-a-500 contract this module promises. Note it fires even with the
+        # flag OFF, because the adapter validates the target while building argv
+        # before it checks availability. A malformed id simply has no scrollback.
         text = ""
     return PanePreviewOut(pane_id=pane_id, text=text)

--- a/ee/pocketpaw_ee/guards/actions.py
+++ b/ee/pocketpaw_ee/guards/actions.py
@@ -55,6 +55,12 @@
 # ban-capable writes (resolve a decision, PATCH the egress deny/allow config)
 # AND its read feed exposes who-tried-to-egress-what; the whole surface is
 # owner-only, mirroring workspace.delete / billing.manage / instinct.activate.
+#
+# Updated: 2026-07-24 (feat/herdr-cockpit-sse, HR-10a) — added ``cockpit.read``
+# (ADMIN) gating both routes of the herdr cockpit telemetry surface
+# (ee.cloud.herdr_cockpit.router). ADMIN (not MEMBER) because herdr panes are not
+# paw-workspace-scoped, so a member-visible cockpit on a shared box could leak
+# other tenants' panes; see the entry's inline note and the router's TODO(track-b).
 
 from __future__ import annotations
 
@@ -280,6 +286,14 @@ ACTIONS: dict[str, ActionRule] = {
     # action guards every route (reads included) because the decision feed
     # itself carries who-tried-to-egress-what, which is sensitive.
     "security.manage": ActionRule(WorkspaceRole.OWNER, "workspace.insufficient_role"),
+    # Herdr cockpit — the read-only pane-telemetry surface (ee.cloud.herdr_cockpit
+    # .router, HR-10a). ADMIN because herdr panes are NOT paw-workspace-scoped
+    # (herdr mints its own workspace ids), so on a shared box a member-visible
+    # cockpit could leak other tenants' panes. ADMIN + the default-off
+    # ``herdr_runtime_enabled`` flag keeps v1 safe on the dedicated-box case; a
+    # single read action gates both the stream and the preview. TODO(track-b):
+    # scope panes to the caller's workspace before relaxing this for multi-tenant.
+    "cockpit.read": ActionRule(WorkspaceRole.ADMIN, "workspace.insufficient_role"),
 }
 
 

--- a/tests/cloud/test_herdr_cockpit.py
+++ b/tests/cloud/test_herdr_cockpit.py
@@ -67,6 +67,15 @@ class FakeHerdrRuntime:
             raise HerdrUnavailable("test: herdr unreachable")
         return list(self._panes)
 
+    async def list_agents(self) -> list[PaneRef]:
+        # build_snapshot uses list_agents (agent panes only). Honour the
+        # "list_panes" key too so the existing fail-open test keeps expressing
+        # "the listing call is down" without caring which listing it is.
+        if "list_agents" in self._raise_on or "list_panes" in self._raise_on:
+            raise HerdrUnavailable("test: herdr unreachable")
+        self.status_calls = getattr(self, "status_calls", [])
+        return list(self._panes)
+
     async def status(self, ref: PaneRef | str) -> AgentStatus:
         pane_id = ref.pane_id if isinstance(ref, PaneRef) else str(ref)
         if "status" in self._raise_on or pane_id in self._raise_on:
@@ -78,6 +87,10 @@ class FakeHerdrRuntime:
     ) -> str:
         pane_id = ref.pane_id if isinstance(ref, PaneRef) else str(ref)
         self.read_calls.append((pane_id, lines))
+        if pane_id.startswith("-"):
+            # Mirrors the real adapter's argument-injection guard, which raises
+            # ValueError (NOT HerdrUnavailable) for a flag-like id.
+            raise ValueError(f"invalid pane id: {pane_id!r} — must not start with '-'")
         if "read" in self._raise_on:
             raise HerdrUnavailable("test: read failed")
         return self._text
@@ -90,6 +103,9 @@ def _pane(pane_id: str, **kw) -> PaneRef:
         agent=kw.get("agent", "claude"),
         tab_id=kw.get("tab_id", "tab-1"),
         terminal_id=kw.get("terminal_id", "term-1"),
+        # ``raw`` carries herdr's full record; the snapshot reads agent_status
+        # from it, so tests can pin the status without a per-pane status() call.
+        raw=kw.get("raw", {}),
     )
 
 
@@ -311,6 +327,48 @@ async def test_preview_endpoint_fails_open_to_empty_text():
 
     assert resp.status_code == 200, resp.text
     assert resp.json() == {"pane_id": "p1", "text": ""}
+
+
+async def test_preview_endpoint_does_not_500_on_a_flaglike_pane_id():
+    """A flag-like pane id must fail open, not 500.
+
+    ``pane_id`` is a raw URL segment. The adapter's argument-injection guard
+    refuses a leading ``-`` by raising ValueError — which is not a
+    HerdrUnavailable, so it escaped the fail-open handler and surfaced as a 500.
+    The security control was fine (herdr never saw the value); the contract that
+    this route never 500s was not.
+    """
+    app = _build_app(role="admin", runtime=FakeHerdrRuntime())
+    async with _client(app) as client:
+        resp = await client.get("/api/v1/cockpit/pane/--help/preview")
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"pane_id": "--help", "text": ""}
+
+
+async def test_snapshot_uses_inline_agent_status_without_per_pane_calls():
+    """One subprocess per tick, not 1 + N.
+
+    herdr's agent-list records already carry ``agent_status`` (verified against
+    v0.7.4), so the snapshot reads it inline. A per-pane ``status()`` call here
+    would be a regression: at 20 panes on a 1.5s tick it was ~14 process spawns
+    a second, per connected admin.
+    """
+    panes = [
+        _pane("p1", raw={"agent_status": "working"}),
+        _pane("p2", raw={"agent_status": "blocked"}),
+    ]
+
+    class NoStatusCalls(FakeHerdrRuntime):
+        async def status(self, ref):  # noqa: ANN001 — test double
+            raise AssertionError("status() must not be called when the list carries it")
+
+    snap = await service.build_snapshot(NoStatusCalls(panes=panes))
+    assert snap.herdr_available is True
+    assert [p.status for p in snap.panes] == [
+        AgentStatus.ACTIVE.value,
+        AgentStatus.BLOCKED.value,
+    ]
 
 
 async def test_endpoints_require_admin():

--- a/tests/cloud/test_herdr_cockpit.py
+++ b/tests/cloud/test_herdr_cockpit.py
@@ -1,0 +1,332 @@
+# tests/cloud/test_herdr_cockpit.py — herdr cockpit telemetry backend (HR-10a).
+#
+# Created: 2026-07-24 (feat/herdr-cockpit-sse) — pins the read-only cockpit
+# surface end-to-end where cheap, injecting a FAKE HerdrRuntime (canned panes,
+# no real herdr server). Coverage:
+#   * service.build_snapshot — frame shape + AgentStatus value strings; the
+#     three fail-open branches (flag off, list_panes down, single-pane status
+#     failure isolated); read_preview text + line clamp + fail-open.
+#   * router — GET /cockpit/stream emits a named ``cockpit.snapshot`` frame;
+#     GET /cockpit/pane/{id}/preview returns {pane_id,text}; both fail open;
+#     both are ADMIN-gated (member -> 403, admin -> 200) via the REAL RBAC guard.
+#
+# Spy-don't-over-mock: the fake is only the herdr I/O boundary; the real PaneRef
+# / AgentStatus value objects and the real require_action_any_workspace guard run.
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from fastapi import FastAPI  # noqa: E402
+from httpx import ASGITransport, AsyncClient  # noqa: E402
+from pocketpaw_ee.cloud.herdr_cockpit import service  # noqa: E402
+
+from pocketpaw.agents.errors import HerdrUnavailable  # noqa: E402
+from pocketpaw.agents.herdr_runtime import PaneRef  # noqa: E402
+from pocketpaw.mission_control.models import AgentStatus  # noqa: E402
+
+pytestmark = pytest.mark.asyncio
+
+
+# ---------------------------------------------------------------------------
+# Fake HerdrRuntime — the herdr I/O boundary only. Records read() calls so tests
+# can assert the line clamp; raises HerdrUnavailable on demand for fail-open.
+# ---------------------------------------------------------------------------
+
+
+class FakeHerdrRuntime:
+    def __init__(
+        self,
+        *,
+        available: bool = True,
+        panes: list[PaneRef] | None = None,
+        statuses: dict[str, AgentStatus] | None = None,
+        text: str = "scrollback text",
+        raise_on: set[str] | None = None,
+    ) -> None:
+        self._available = available
+        self._panes = panes or []
+        self._statuses = statuses or {}
+        self._text = text
+        # membership: a bare method name ("list_panes"/"status"/"read") fails that
+        # call globally; a pane_id fails only that pane's status() call.
+        self._raise_on = raise_on or set()
+        self.read_calls: list[tuple[str, int | None]] = []
+
+    @property
+    def available(self) -> bool:
+        return self._available
+
+    async def list_panes(self) -> list[PaneRef]:
+        if "list_panes" in self._raise_on:
+            raise HerdrUnavailable("test: herdr unreachable")
+        return list(self._panes)
+
+    async def status(self, ref: PaneRef | str) -> AgentStatus:
+        pane_id = ref.pane_id if isinstance(ref, PaneRef) else str(ref)
+        if "status" in self._raise_on or pane_id in self._raise_on:
+            raise HerdrUnavailable("test: status failed")
+        return self._statuses.get(pane_id, AgentStatus.IDLE)
+
+    async def read(
+        self, ref: PaneRef | str, *, source: str = "visible", lines: int | None = None
+    ) -> str:
+        pane_id = ref.pane_id if isinstance(ref, PaneRef) else str(ref)
+        self.read_calls.append((pane_id, lines))
+        if "read" in self._raise_on:
+            raise HerdrUnavailable("test: read failed")
+        return self._text
+
+
+def _pane(pane_id: str, **kw) -> PaneRef:
+    return PaneRef(
+        pane_id=pane_id,
+        workspace_id=kw.get("workspace_id", "hw-1"),
+        agent=kw.get("agent", "claude"),
+        tab_id=kw.get("tab_id", "tab-1"),
+        terminal_id=kw.get("terminal_id", "term-1"),
+    )
+
+
+# ===========================================================================
+# Service layer — build_snapshot
+# ===========================================================================
+
+
+async def test_build_snapshot_shape_and_status_values():
+    """A healthy tick: herdr_available True, one dot per pane, each carrying the
+    full wire shape with the AgentStatus VALUE string."""
+    runtime = FakeHerdrRuntime(
+        panes=[_pane("p1", agent="claude"), _pane("p2", agent="codex")],
+        statuses={"p1": AgentStatus.ACTIVE, "p2": AgentStatus.BLOCKED},
+    )
+
+    snap = await service.build_snapshot(runtime)
+
+    assert snap.herdr_available is True
+    assert snap.ts  # ISO-8601 timestamp present
+    assert len(snap.panes) == 2
+    by_id = {p.pane_id: p for p in snap.panes}
+    assert by_id["p1"].status == "active"
+    assert by_id["p2"].status == "blocked"
+    # Full wire shape on every dot.
+    p1 = by_id["p1"]
+    assert (p1.workspace_id, p1.agent, p1.tab_id, p1.terminal_id) == (
+        "hw-1",
+        "claude",
+        "tab-1",
+        "term-1",
+    )
+    # status is always a valid AgentStatus value string.
+    assert {p.status for p in snap.panes} <= {s.value for s in AgentStatus}
+
+
+async def test_build_snapshot_flag_off_is_fail_open():
+    """herdr disabled/absent (available False) -> no subprocess, empty fail-open
+    frame, never an error."""
+    runtime = FakeHerdrRuntime(available=False, panes=[_pane("p1")])
+
+    snap = await service.build_snapshot(runtime)
+
+    assert snap.herdr_available is False
+    assert snap.panes == []
+
+
+async def test_build_snapshot_list_panes_unavailable_is_fail_open():
+    """Flag on but herdr unreachable this tick -> herdr_available False, empty."""
+    runtime = FakeHerdrRuntime(panes=[_pane("p1")], raise_on={"list_panes"})
+
+    snap = await service.build_snapshot(runtime)
+
+    assert snap.herdr_available is False
+    assert snap.panes == []
+
+
+async def test_build_snapshot_single_pane_status_failure_is_isolated():
+    """One pane's status() failing (pane closed mid-tick) -> that dot goes
+    offline; the rest of the frame survives and herdr stays available."""
+    runtime = FakeHerdrRuntime(
+        panes=[_pane("p1"), _pane("p2")],
+        statuses={"p2": AgentStatus.ACTIVE},
+        raise_on={"p1"},  # only p1's status() raises
+    )
+
+    snap = await service.build_snapshot(runtime)
+
+    assert snap.herdr_available is True
+    by_id = {p.pane_id: p for p in snap.panes}
+    assert by_id["p1"].status == "offline"  # failed pane fails safe
+    assert by_id["p2"].status == "active"  # healthy pane intact
+
+
+# ===========================================================================
+# Service layer — read_preview
+# ===========================================================================
+
+
+async def test_read_preview_returns_text():
+    runtime = FakeHerdrRuntime(text="hello from pane")
+    out = await service.read_preview(runtime, "p1", 25)
+    assert out.pane_id == "p1"
+    assert out.text == "hello from pane"
+
+
+async def test_read_preview_clamps_lines():
+    """A too-large request is capped to PREVIEW_MAX_LINES; sub-1 floors to 1."""
+    runtime = FakeHerdrRuntime()
+
+    await service.read_preview(runtime, "p1", 10_000)
+    await service.read_preview(runtime, "p1", 0)
+    await service.read_preview(runtime, "p1", None)
+
+    lines_seen = [lines for _pid, lines in runtime.read_calls]
+    assert lines_seen[0] == service.PREVIEW_MAX_LINES  # 10_000 -> 500
+    assert lines_seen[1] == 1  # 0 -> floor 1
+    assert lines_seen[2] == service.PREVIEW_DEFAULT_LINES  # None -> default
+
+
+async def test_read_preview_fail_open_to_empty_text():
+    runtime = FakeHerdrRuntime(raise_on={"read"})
+    out = await service.read_preview(runtime, "p1", 25)
+    assert out.pane_id == "p1"
+    assert out.text == ""
+
+
+# ===========================================================================
+# Router / HTTP — real RBAC guard, fake runtime injected
+# ===========================================================================
+
+
+def _build_app(*, role: str = "admin", runtime: FakeHerdrRuntime | None = None) -> FastAPI:
+    """App over the cockpit router with the REAL RBAC guard; the caller's
+    workspace role drives require_action_any_workspace. License bypassed; the
+    HerdrRuntime provider is overridden with the injected fake."""
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.cloud.auth import current_active_user
+    from pocketpaw_ee.cloud.herdr_cockpit.router import get_herdr_runtime, router
+    from pocketpaw_ee.cloud.license import require_license
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(router, prefix="/api/v1")
+    app.dependency_overrides[require_license] = lambda: None
+
+    user = SimpleNamespace(
+        id="u1",
+        active_workspace="w1",
+        workspaces=[SimpleNamespace(workspace="w1", role=role)],
+    )
+
+    async def _fake_user():
+        return user
+
+    app.dependency_overrides[current_active_user] = _fake_user
+    app.dependency_overrides[get_herdr_runtime] = lambda: runtime or FakeHerdrRuntime()
+    return app
+
+
+def _client(app: FastAPI) -> AsyncClient:
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://t")
+
+
+def _parse_one_frame(raw: bytes) -> tuple[str, dict]:
+    """Parse one encoded SSE frame's event name + JSON data payload."""
+    event = ""
+    data = ""
+    for line in raw.decode().splitlines():
+        if line.startswith("event:"):
+            event = line[len("event:") :].strip()
+        elif line.startswith("data:"):
+            data = line[len("data:") :].strip()
+    return event, json.loads(data)
+
+
+async def _first_stream_frame(runtime: FakeHerdrRuntime) -> tuple[str, dict]:
+    """Drive the stream handler directly and pull exactly the first frame.
+
+    httpx's ASGITransport buffers the whole response body, so it cannot read an
+    endless SSE stream incrementally (it hangs). Pulling the handler's
+    StreamingResponse body_iterator by hand is the reliable way to assert the
+    first frame; aclose() then stops the generator so its poll sleep never
+    leaks. The ADMIN gate is exercised over real HTTP in
+    test_endpoints_require_admin, so bypassing DI here is fine.
+    """
+    from pocketpaw_ee.cloud.herdr_cockpit.router import stream_cockpit
+
+    resp = await stream_cockpit(runtime=runtime)
+    assert resp.media_type == "text/event-stream"
+    agen = resp.body_iterator
+    try:
+        raw = await agen.__anext__()
+    finally:
+        await agen.aclose()
+    return _parse_one_frame(raw)
+
+
+async def test_stream_emits_named_cockpit_snapshot_frame():
+    runtime = FakeHerdrRuntime(
+        panes=[_pane("p1", agent="claude")],
+        statuses={"p1": AgentStatus.ACTIVE},
+    )
+    event, data = await _first_stream_frame(runtime)
+
+    assert event == "cockpit.snapshot"
+    assert data["herdr_available"] is True
+    assert data["ts"]
+    assert data["panes"][0]["pane_id"] == "p1"
+    assert data["panes"][0]["status"] == "active"
+
+
+async def test_stream_fails_open_when_herdr_off():
+    """Flag off -> the stream still emits frames, just herdr_available:false with
+    no panes (never a 500, never a crash)."""
+    event, data = await _first_stream_frame(FakeHerdrRuntime(available=False))
+
+    assert event == "cockpit.snapshot"
+    assert data["herdr_available"] is False
+    assert data["panes"] == []
+
+
+async def test_preview_endpoint_returns_text():
+    runtime = FakeHerdrRuntime(text="pane scrollback")
+    app = _build_app(role="admin", runtime=runtime)
+    async with _client(app) as client:
+        resp = await client.get("/api/v1/cockpit/pane/p1/preview", params={"lines": 25})
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body == {"pane_id": "p1", "text": "pane scrollback"}
+
+
+async def test_preview_endpoint_fails_open_to_empty_text():
+    runtime = FakeHerdrRuntime(raise_on={"read"})
+    app = _build_app(role="admin", runtime=runtime)
+    async with _client(app) as client:
+        resp = await client.get("/api/v1/cockpit/pane/p1/preview")
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"pane_id": "p1", "text": ""}
+
+
+async def test_endpoints_require_admin():
+    """A MEMBER is denied on BOTH routes (403); an ADMIN passes. Herdr panes are
+    not workspace-scoped, so the surface is admin-only in v1."""
+    member_app = _build_app(role="member", runtime=FakeHerdrRuntime())
+    async with _client(member_app) as client:
+        # A denied stream short-circuits at the guard (finite 403 body, no
+        # streaming), so a plain GET is safe and does not hang.
+        stream_resp = await client.get("/api/v1/cockpit/stream")
+        preview_resp = await client.get("/api/v1/cockpit/pane/p1/preview")
+
+    assert stream_resp.status_code == 403
+    assert preview_resp.status_code == 403
+
+    admin_app = _build_app(role="admin", runtime=FakeHerdrRuntime())
+    async with _client(admin_app) as client:
+        admin_preview = await client.get("/api/v1/cockpit/pane/p1/preview")
+    assert admin_preview.status_code == 200


### PR DESCRIPTION
## What ships
Read-only backend for an agent "cockpit": an ADMIN-gated SSE stream of live herdr pane status ("dots") plus an on-demand pane-preview endpoint. Both go through the HerdrRuntime adapter and both fail open when herdr is off or absent.

- `GET /api/v1/cockpit/stream` — text/event-stream, one `cockpit.snapshot` frame every ~1.5s: `{ts, herdr_available, panes:[{pane_id, workspace_id, agent, status, ...}]}`
- `GET /api/v1/cockpit/pane/{id}/preview?lines=25` — `{pane_id, text}`

## Stacked on #1747
This imports the HerdrRuntime adapter, which is still on `feat/herdr-runtime-adapter` (#1747), not dev — so this PR is based on that branch. Merge #1747 first (with `--rebase`, since it has this dependent), then this rebases onto dev. Its own diff is one commit, 7 files.

## Notes for review
- **ADMIN-only, deliberately.** herdr panes aren't paw-workspace-scoped (herdr mints its own workspace ids), so a member-visible cockpit on a shared box could leak other tenants' panes. ADMIN plus the default-off `herdr_runtime_enabled` flag keeps v1 safe on the dedicated-box case. A `TODO(track-b)` marks the pane→tenant scoping required before multi-tenant or member exposure.
- **Fail-open everywhere:** herdr off/absent → `herdr_available:false` + empty panes (stream keeps ticking, never a 500); a pane vanishing mid-tick degrades that one dot to `offline`, not the whole frame; preview → empty text.
- v1 polls the adapter directly every 1.5s (no bus/Redis push — a later optimization). No pane mutation; previews on-demand only.

## Tests
12 fake-adapter tests (snapshot shape + status values, three fail-open branches, preview + line clamp, ADMIN 200 / member 403). Also verified live against a real herdr on the dev box: `build_snapshot` returned real dots (idle/active/offline) and failed open to empty when disabled.