### PR TITLE
Give /code a dedicated agent that can't create pockets

### DIFF
--- a/ee/pocketpaw_ee/cloud/agents/domain.py
+++ b/ee/pocketpaw_ee/cloud/agents/domain.py
@@ -9,6 +9,11 @@ Beanie sub-model would require touching every caller of
 Updated: 2026-06-28 (feat/aiam-agent-revoke, AW-4) — added ``Agent.disabled``
 mirroring the new top-level flag on the Beanie doc, so callers (and the wire
 dict) can read whether an agent has been soft-disabled / revoked.
+Updated: 2026-07-24 (CX-2, feat/code-agent-exclusive-tools) — added
+``AgentConfigSpec.tool_mode`` (``"additive"`` | ``"exclusive"``) mirroring the
+Beanie ``AgentConfig.tool_mode``. An ``"exclusive"`` agent's ``tools`` become the
+run's MCP allow-list and suppress the universal pocket/widget/atlas grant
+(CX-1); ``"additive"`` (the default) is the unchanged legacy grant-union.
 """
 
 from __future__ import annotations
@@ -25,6 +30,11 @@ class AgentConfigSpec:
     model: str = ""
     system_prompt: str = ""
     tools: tuple[str, ...] = ()
+    # Tool-surface policy. "additive" (default) UNIONs the agent's tools with the
+    # universal MCP grant (legacy). "exclusive" caps the run's MCP surface to
+    # exactly ``tools`` (CX-1/CX-2) — a non-empty ``tools`` list alone does NOT
+    # imply exclusive; only this flag does.
+    tool_mode: str = "additive"
     trust_level: int = 3
     temperature: float = 0.7
     max_tokens: int = 4096

--- a/ee/pocketpaw_ee/cloud/agents/service.py
+++ b/ee/pocketpaw_ee/cloud/agents/service.py
@@ -25,6 +25,11 @@ Updated 2026-07-02 (feat/aiam-agent-revoke, AW-4 follow-up): ``get_persona``
 now returns ``None`` for a soft-disabled agent (reusing the doc it already
 loads — no extra read), so ``agent_bridge``'s smart-relevance LLM probe never
 fires for an agent ``pool.get`` would refuse to run.
+Updated 2026-07-24 (CX-2, feat/code-agent-exclusive-tools): ``tool_mode`` is
+threaded through the doc↔spec mappers (``_config_to_domain`` / ``_config_to_doc``)
+and the config-dict update path (``_apply_update``) so an "exclusive" policy
+round-trips and survives an update. Defaults to "additive", so every existing
+agent maps byte-for-byte as before.
 """
 
 from __future__ import annotations
@@ -71,6 +76,7 @@ def _config_to_domain(c: _AgentConfigDoc) -> AgentConfigSpec:
         model=c.model,
         system_prompt=c.system_prompt,
         tools=tuple(c.tools),
+        tool_mode=c.tool_mode,
         trust_level=c.trust_level,
         temperature=c.temperature,
         max_tokens=c.max_tokens,
@@ -91,6 +97,7 @@ def _config_to_doc(c: AgentConfigSpec) -> _AgentConfigDoc:
         model=c.model,
         system_prompt=c.system_prompt,
         tools=list(c.tools),
+        tool_mode=c.tool_mode,
         trust_level=c.trust_level,
         temperature=c.temperature,
         max_tokens=c.max_tokens,
@@ -179,6 +186,7 @@ def _apply_update(current: AgentConfigSpec, body: UpdateAgentRequest) -> AgentCo
             model=c.get("model", current.model),
             system_prompt=c.get("system_prompt", current.system_prompt),
             tools=tuple(c.get("tools", list(current.tools))),
+            tool_mode=c.get("tool_mode", current.tool_mode),
             trust_level=c.get("trust_level", current.trust_level),
             temperature=c.get("temperature", current.temperature),
             max_tokens=c.get("max_tokens", current.max_tokens),

--- a/ee/pocketpaw_ee/cloud/agents/service.py
+++ b/ee/pocketpaw_ee/cloud/agents/service.py
@@ -30,6 +30,13 @@ threaded through the doc↔spec mappers (``_config_to_domain`` / ``_config_to_do
 and the config-dict update path (``_apply_update``) so an "exclusive" policy
 round-trips and survives an update. Defaults to "additive", so every existing
 agent maps byte-for-byte as before.
+Updated 2026-07-24 (CX-3, feat/code-agent-exclusive-tools): added
+``seed_code_agent`` / ``ensure_code_agent_all_workspaces`` — the dedicated
+``code`` slug agent for the ``/code`` surface. Its config is
+``tool_mode="exclusive"`` + ``tools=_CODE_FILE_TOOL_IDS`` (the four file tools)
+and its persona reuses ``CODE_SYSTEM_PROMPT``, so every run it does is capped to
+exactly those ids — no pocket/planner/widget grant. Idempotent, mirrors the
+default-agent seed + boot back-fill.
 """
 
 from __future__ import annotations
@@ -649,10 +656,102 @@ async def ensure_default_agent_all_workspaces() -> int:
     return seeded
 
 
+async def seed_code_agent(
+    workspace_id: str, owner_id: str
+) -> tuple[_AgentDoc, bool] | tuple[None, bool]:
+    """Create the dedicated ``code`` Agent for a workspace if missing (CX-3).
+
+    This is the backend-authoritative target for the ``/code`` surface. Unlike
+    the default ``pocketpaw`` agent, its config carries ``tool_mode="exclusive"``
+    and ``tools=<the four file tools>``, so the CX-1/CX-2 policy caps every run
+    it does to EXACTLY those ids — no pocket / planner / widget grant. That is
+    what makes "build an employee management app…" produce file-tool calls
+    against the user's project instead of a pocket.
+
+    The persona reuses ``CODE_SYSTEM_PROMPT`` (the CODE surface's own override)
+    verbatim so the agent identity and the surface prompt cannot drift, and the
+    tool ids come from ``_CODE_FILE_TOOL_IDS`` (the same constant the CODE
+    ``SurfaceProfile`` allows). It carries NO create-pocket skill: the CODE
+    surface deliberately ships none (see the long comment at
+    surface_registry.py:614), so ``skill_refs`` is empty.
+
+    Idempotent (find-by-slug short-circuit). Returns ``(agent, created)`` —
+    ``created`` is ``True`` only when this call inserted a new row. Returns
+    ``(None, False)`` if the insert raises (callers wrap in try/except).
+    """
+    # Local imports keep the surface package off this module's import graph and
+    # avoid any cycle; the constants are cheap module-level frozensets/strings.
+    from pocketpaw_ee.cloud.surface.surface_registry import _CODE_FILE_TOOL_IDS
+    from pocketpaw_ee.cloud.surface.system_prompts import CODE_SYSTEM_PROMPT
+
+    existing = await _AgentDoc.find_one(
+        _AgentDoc.workspace == workspace_id, _AgentDoc.slug == "code"
+    )
+    if existing is not None:
+        return existing, False
+
+    agent = _AgentDoc(
+        workspace=workspace_id,
+        name="Code",
+        slug="code",
+        avatar="",
+        owner=owner_id,
+        visibility="workspace",
+        config=_AgentConfigDoc(
+            system_prompt=CODE_SYSTEM_PROMPT,
+            tool_mode="exclusive",
+            tools=list(_CODE_FILE_TOOL_IDS),
+            # No create-pocket / widget skill — the CODE surface ships none.
+            skill_refs=[],
+            soul_persona="Code",
+        ),
+    )
+    await agent.insert()
+    logger.info(
+        "Dedicated 'code' agent seeded in workspace %s (id: %s)",
+        workspace_id,
+        agent.id,
+    )
+    await emit(
+        AgentCreated(
+            data={
+                "agent_id": str(agent.id),
+                "workspace_id": workspace_id,
+                "owner_id": owner_id,
+                "name": agent.name,
+                "slug": agent.slug,
+                "visibility": agent.visibility,
+            }
+        )
+    )
+    return agent, True
+
+
+async def ensure_code_agent_all_workspaces() -> int:
+    """Back-fill the dedicated ``code`` agent for every existing workspace.
+
+    Called on every boot beside ``ensure_default_agent_all_workspaces`` so the
+    ``/code`` target exists regardless of install age. Returns the number of
+    agents actually created this run.
+    """
+    from pocketpaw_ee.cloud.models.workspace import Workspace as _WorkspaceDoc
+
+    seeded = 0
+    async for ws in _WorkspaceDoc.find_all():
+        try:
+            _, created = await seed_code_agent(str(ws.id), str(ws.owner))
+            if created:
+                seeded += 1
+        except Exception as exc:
+            logger.warning("Failed to back-fill code agent for ws=%s: %s", ws.id, exc)
+    return seeded
+
+
 __all__ = [
     "create",
     "delete",
     "discover",
+    "ensure_code_agent_all_workspaces",
     "ensure_default_agent_all_workspaces",
     "get",
     "get_by_slug",
@@ -662,6 +761,7 @@ __all__ = [
     "is_owner_or_workspace_admin",
     "legacy_ctx",
     "list_agents",
+    "seed_code_agent",
     "seed_default_agent",
     "set_scopes",
     "suggest_for_mentions",

--- a/ee/pocketpaw_ee/cloud/chat/agent_router.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_router.py
@@ -169,6 +169,9 @@ async def post_agent_chat(
             user_id=user_id,
             agent_id_hint=body.agent_id,
             expected_workspace_id=workspace_id,
+            # CX-3: on /code the resolver routes an unhinted turn to the code
+            # agent (exclusive file-tool policy). No-op on every other surface.
+            surface=body.surface,
         )
         ctx.intent = body.intent
     except InvalidScope:

--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -181,6 +181,16 @@ the same ContextVar, added for Code Mode's browser-delegate channel: that caller
 pushes a frame and then PARKS waiting for the browser's reply, so a push into no
 stream has to be a fast, distinct failure rather than a silent no-op followed by
 a full-length timeout. No behaviour change to any existing push path.
+
+Changes: 2026-07-24 (CX-3, feat/code-agent-exclusive-tools) —
+``resolve_scope_context`` (and ``_resolve_session`` / ``_resolve_pocket``)
+gained a ``surface`` param, and ``_get_code_agent_id`` was added. On the CODE
+surface, an unhinted turn resolves to the dedicated ``code`` agent (slug
+``code``), lazy-seeded via ``agents.service.seed_code_agent`` on miss, instead
+of the default ``pocketpaw`` agent — so the exclusive file-tool policy is
+applied backend-authoritatively (the frontend need not pass the id). Guarded
+narrowly on CODE + no explicit ``agent_id_hint``; every other surface's
+resolution is byte-identical.
 """
 
 from __future__ import annotations
@@ -211,7 +221,7 @@ from pocketpaw.ripple import (
 from pocketpaw.ripple._pockets import _MCP_POCKET_BACKENDS
 from pocketpaw.stores import current_workspace as _oss_current_workspace
 from pocketpaw_ee.cloud.shared.errors import CloudError, Forbidden, NotFound
-from pocketpaw_ee.cloud.surface import SurfaceContext, SurfaceProfile
+from pocketpaw_ee.cloud.surface import SurfaceContext, SurfaceKind, SurfaceProfile
 
 logger = logging.getLogger(__name__)
 
@@ -947,6 +957,52 @@ async def _get_default_workspace_agent_id(workspace_id: str) -> str | None:
         return None
 
 
+async def _get_code_agent_id(workspace_id: str) -> str | None:
+    """Resolve the workspace's dedicated ``code`` agent id, LAZY-SEEDING on miss.
+
+    The ``/code`` surface is backend-authoritative (CX-3): a CODE-surface turn
+    must resolve to this agent, whose stored config carries the exclusive
+    file-tool policy (``tool_mode="exclusive"`` + ``tools=_CODE_FILE_TOOL_IDS``),
+    so the run is capped to exactly the four file tools — no pocket/planner/
+    widget grant. A workspace that predates the code-agent seed (or one whose
+    boot back-fill hasn't run) still works on its FIRST /code turn because this
+    helper seeds when the agent is absent. Returns ``None`` only when both the
+    lookup and the seed fail — the caller then falls back to the default agent
+    rather than erroring.
+    """
+    if not workspace_id:
+        return None
+    try:
+        from pocketpaw_ee.cloud.models.agent import Agent
+
+        agent = await Agent.find_one(Agent.workspace == workspace_id, Agent.slug == "code")
+        if agent is not None:
+            return str(agent.id)
+
+        # Lazy-seed. Resolve the workspace owner (mirrors the boot back-fill's
+        # ``ws.owner``) and delegate the write to the agents service — the sole
+        # owner of Agent writes. A bad/missing workspace doc degrades to an empty
+        # owner rather than blocking the seed.
+        owner_id = ""
+        try:
+            from beanie import PydanticObjectId
+
+            from pocketpaw_ee.cloud.models.workspace import Workspace
+
+            ws = await Workspace.get(PydanticObjectId(workspace_id))
+            owner_id = str(getattr(ws, "owner", "") or "") if ws is not None else ""
+        except Exception:
+            logger.debug("code-agent seed: workspace owner lookup failed for ws=%s", workspace_id)
+
+        from pocketpaw_ee.cloud.agents import service as agents_service
+
+        doc, _created = await agents_service.seed_code_agent(workspace_id, owner_id)
+        return str(doc.id) if doc is not None else None
+    except Exception:
+        logger.exception("code agent lookup/seed failed for ws=%s", workspace_id)
+        return None
+
+
 # ---------------------------------------------------------------------------
 # Scope resolution
 # ---------------------------------------------------------------------------
@@ -999,6 +1055,7 @@ async def resolve_scope_context(
     user_id: str,
     agent_id_hint: str | None,
     expected_workspace_id: str | None = None,
+    surface: str | None = None,
 ) -> ScopeContext:
     """Resolve a ``ScopeContext`` for a cloud agent chat request.
 
@@ -1008,6 +1065,13 @@ async def resolve_scope_context(
     field is empty/missing and (b) REJECT a caller whose workspace DISAGREES
     with a non-empty doc workspace (cross-tenant guard). Defaults to ``None`` —
     legacy / non-worker callers keep today's doc-only behavior.
+
+    ``surface`` is the client's raw surface hint (``body.surface`` /
+    ``spec.surface``). On the CODE surface, and only when the caller passed no
+    explicit ``agent_id_hint``, target resolution routes to the dedicated
+    ``code`` agent (lazy-seeded) instead of the default ``pocketpaw`` agent so
+    the exclusive file-tool policy applies backend-authoritatively (CX-3). Every
+    other surface leaves resolution byte-identical. Defaults to ``None``.
 
     Raises:
         InvalidScope: ``scope`` is not one of dm/group/pocket/session.
@@ -1022,9 +1086,13 @@ async def resolve_scope_context(
         raise InvalidScope(scope) from e
 
     if kind is ScopeKind.POCKET:
-        return await _resolve_pocket(scope_id, user_id, agent_id_hint, expected_workspace_id)
+        return await _resolve_pocket(
+            scope_id, user_id, agent_id_hint, expected_workspace_id, surface
+        )
     if kind is ScopeKind.SESSION:
-        return await _resolve_session(scope_id, user_id, agent_id_hint, expected_workspace_id)
+        return await _resolve_session(
+            scope_id, user_id, agent_id_hint, expected_workspace_id, surface
+        )
     return await _resolve_group_like(kind, scope_id, user_id, agent_id_hint, expected_workspace_id)
 
 
@@ -1033,6 +1101,7 @@ async def _resolve_session(
     user_id: str,
     agent_id_hint: str | None,
     expected_workspace_id: str | None = None,
+    surface: str | None = None,
 ) -> ScopeContext:
     session = await _get_session(scope_id)
     if session is None or getattr(session, "deleted_at", None) is not None:
@@ -1078,6 +1147,17 @@ async def _resolve_session(
             pocket_summary = _pocket_summary_data(pocket)
 
     target = agent_id_hint or getattr(session, "agent", None)
+    # /code is backend-authoritative (CX-3). When the surface is CODE and the
+    # caller passed no explicit ``agent_id_hint``, resolve to the dedicated
+    # ``code`` agent (lazy-seeded) — its exclusive file-tool config is what makes
+    # "build an employee management app…" write code instead of a pocket. This
+    # takes precedence over the session's stored agent and the default fallback
+    # so the exclusivity holds even when the frontend omits the id. Guarded
+    # narrowly on CODE — every other surface keeps byte-identical resolution.
+    if agent_id_hint is None and surface == SurfaceKind.CODE.value:
+        code_id = await _get_code_agent_id(workspace_id)
+        if code_id:
+            target = code_id
     if not target:
         # Sessions created via ``createPocketSession`` don't yet pin an agent
         # — fall back to the workspace's default ``pocketpaw`` agent (same
@@ -1168,6 +1248,7 @@ async def _resolve_pocket(
     user_id: str,
     agent_id_hint: str | None,
     expected_workspace_id: str | None = None,
+    surface: str | None = None,
 ) -> ScopeContext:
     pocket = await _get_pocket(scope_id)
     if pocket is None:
@@ -1210,6 +1291,15 @@ async def _resolve_pocket(
         target = agent_id_hint
     else:
         target = agent_ids[0]
+        # /code is backend-authoritative (CX-3): a CODE-surface turn with no
+        # explicit hint routes to the dedicated ``code`` agent (lazy-seeded),
+        # overriding the pocket's default agent, so the exclusive file-tool
+        # policy applies. Guarded narrowly on CODE — non-CODE pocket chats keep
+        # byte-identical resolution.
+        if surface == SurfaceKind.CODE.value:
+            code_id = await _get_code_agent_id(workspace_id)
+            if code_id:
+                target = code_id
 
     # Build the participant list: owner first, then team, then shared-with,
     # deduped. Pocket.owner is a required field on the model, so the falsy

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -1630,6 +1630,9 @@ async def execute_run(spec: RunSpec) -> None:
         user_id=spec.user_id,
         agent_id_hint=spec.agent_id,
         expected_workspace_id=spec.workspace_id,
+        # CX-3: on /code the resolver routes an unhinted turn to the dedicated
+        # code agent (exclusive file-tool policy). No-op on every other surface.
+        surface=spec.surface,
     )
     # Even with the spec fallback, a doc + spec that BOTH lack a usable workspace
     # must fail cleanly here — never attach an empty identity downstream (the

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -211,7 +211,15 @@ Changes:
   withhold-when-empty forward — including on the legacy ``resolved_profile is
   None`` path — so agent skills materialize even on non-entity / non-profile
   runs. The union still crosses into ``AgentPool.run`` as a plain
-  ``frozenset[str]`` (no EE symbol crosses into OSS). Per-agent MCP is DEFERRED.
+  ``frozenset[str]`` (no EE symbol crosses into OSS).
+- 2026-07-24 (CX-2, feat/code-agent-exclusive-tools) — per-agent MCP tool policy
+  (the M2 slice previously marked DEFERRED) is now LANDED. When the resolved
+  agent's config declares ``tool_mode="exclusive"``, ``_agent_tool_policy(instance)``
+  returns its declared ``tools`` and ``_drive_agent_loop`` sets
+  ``exclusive_mcp_tools=True`` + ``allow_mcp_tool_ids=<those tools>`` — driving the
+  CX-1 suppressible-grant cap so an exclusive agent (e.g. /code) gets EXACTLY its
+  declared MCP ids, OVERRIDING any surface allow-list. "additive" (the default)
+  is unchanged. The flag/allow-list cross into ``AgentPool.run`` as plain data.
 """
 
 from __future__ import annotations
@@ -833,6 +841,35 @@ def _agent_skill_set(instance: Any) -> frozenset[str]:
     return direct | plugin_skills
 
 
+def _agent_tool_policy(instance: Any) -> tuple[bool, frozenset[str]]:
+    """Resolve the agent's EXCLUSIVE tool policy from its raw config (CX-2).
+
+    Returns ``(exclusive, tools)``:
+    - ``exclusive`` is ``True`` ONLY when the agent config's
+      ``tool_mode == "exclusive"``. An explicit signal — a non-empty ``tools``
+      list does NOT by itself make an agent exclusive.
+    - ``tools`` is the frozenset of the agent's declared MCP tool ids, returned
+      only on the exclusive path (empty otherwise). The caller uses it as the
+      run's ``allow_mcp_tool_ids`` — which, paired with the CX-1
+      ``exclusive_mcp_tools`` cap, suppresses the universal pocket/widget/atlas
+      grant and OVERRIDES any surface allow-list. Additive agents (the default)
+      return ``(False, frozenset())`` so the legacy grant-union path is untouched.
+
+    ``instance.config`` is the raw config dict on the pooled instance; guarded
+    for dict-or-object exactly like ``backend`` is read at the run seam.
+    """
+    config = getattr(instance, "config", None) or {}
+    if isinstance(config, dict):
+        mode = config.get("tool_mode", "additive")
+        tools = config.get("tools", []) or []
+    else:
+        mode = getattr(config, "tool_mode", "additive")
+        tools = getattr(config, "tools", []) or []
+    if mode != "exclusive":
+        return (False, frozenset())
+    return (True, frozenset(tools))
+
+
 async def _prewarm_session(ctx: ScopeContext) -> None:
     """Eagerly warm the agent's CLI subprocess for this run's session BEFORE the
     first model turn (feat/claude-sdk-prewarm).
@@ -894,6 +931,15 @@ async def _prewarm_session(ctx: ScopeContext) -> None:
             surface_sys_override = ctx.resolved_profile.system_message_override
             surface_skills = ctx.resolved_profile.skill_names or frozenset()
         surface_skills = surface_skills | _agent_skill_set(instance)
+        # CX-2 — mirror _drive_agent_loop's exclusive-tool resolution EXACTLY so
+        # the prewarmed client's options (and thus its cache key) MATCH turn 1's.
+        # An exclusive agent caps its MCP surface, which changes ``allowed_tools``
+        # (part of the client cache key); without mirroring it here the prewarm
+        # would warm an UNCAPPED client that turn 1 discards — a wasted warm.
+        # Additive agents (the default) leave both values unchanged.
+        prewarm_exclusive, prewarm_tools = _agent_tool_policy(instance)
+        if prewarm_exclusive:
+            surface_allow_mcp = prewarm_tools
 
         # Bind this run's tenancy for the warm-up so the prewarmed subprocess
         # connects with the SAME per-tenant cwd jail the first turn will resolve
@@ -921,6 +967,7 @@ async def _prewarm_session(ctx: ScopeContext) -> None:
                 allow_mcp_tool_ids=surface_allow_mcp,
                 system_message_override=surface_sys_override,
                 skill_names=surface_skills,
+                exclusive_mcp_tools=prewarm_exclusive,
             )
         finally:
             detach_agent_identity(identity_tokens)
@@ -1100,6 +1147,21 @@ async def _drive_agent_loop(
         )
         if surface_allow_mcp is not None:
             run_kwargs["allow_mcp_tool_ids"] = surface_allow_mcp
+        # CX-2 — per-agent EXCLUSIVE tool policy. When the RESOLVED agent declares
+        # ``tool_mode="exclusive"``, its OWN ``tools`` become the MCP allow-list and
+        # the CX-1 ``exclusive_mcp_tools`` cap fires: the universal grant
+        # (pocket/widget/atlas + the ALWAYS_ALLOWED escape) is suppressed and the
+        # agent's declared ids OVERRIDE any surface ``allow_mcp_tool_ids`` set just
+        # above — agent-exclusive wins over the surface. ``exclusive_mcp_tools``
+        # rides the SAME withhold-when-empty contract as ``model_override`` /
+        # ``skill_names``: the key is added ONLY on the exclusive branch, so the 7
+        # non-Claude backends never receive a kwarg their narrower signature
+        # rejects. Additive agents (the default) touch nothing → the run is
+        # byte-identical to today, grant path intact.
+        agent_exclusive, agent_tools = _agent_tool_policy(instance)
+        if agent_exclusive:
+            run_kwargs["exclusive_mcp_tools"] = True
+            run_kwargs["allow_mcp_tool_ids"] = agent_tools
         # Forward the override only when the entity actually set one — withholding
         # keeps the prompt assembly untouched on every other run.
         if surface_sys_override is not None:

--- a/ee/pocketpaw_ee/cloud/models/agent.py
+++ b/ee/pocketpaw_ee/cloud/models/agent.py
@@ -14,6 +14,12 @@
 # agent everywhere while letting in-flight runs finish. Top-level (not on
 # AgentConfig) so toggling it bumps the doc's ``updatedAt`` and the pool's
 # staleness check + explicit cache invalidation both see the change.
+# Updated 2026-07-24 (CX-2, feat/code-agent-exclusive-tools): added
+# ``AgentConfig.tool_mode: str = "additive"`` (mirrors the domain
+# ``AgentConfigSpec.tool_mode``). "exclusive" makes the agent's ``tools`` the
+# run's MCP allow-list and suppresses the universal grant (CX-1); "additive"
+# (default) is the unchanged legacy grant-union, so existing agents persist and
+# behave exactly as before.
 
 """Agent configuration document."""
 
@@ -30,6 +36,10 @@ class AgentConfig(BaseModel):
     model: str = ""  # empty = use backend default
     system_prompt: str = ""
     tools: list[str] = Field(default_factory=list)
+    # Tool-surface policy — mirrors the domain ``AgentConfigSpec.tool_mode``.
+    # "additive" (default) UNIONs ``tools`` with the universal MCP grant (legacy);
+    # "exclusive" caps the run's MCP surface to exactly ``tools`` (CX-1/CX-2).
+    tool_mode: str = "additive"
     trust_level: int = Field(default=3, ge=1, le=5)
     temperature: float = Field(default=0.7, ge=0, le=2)
     max_tokens: int = Field(default=4096, ge=1)

--- a/ee/pocketpaw_ee/extensions.py
+++ b/ee/pocketpaw_ee/extensions.py
@@ -100,6 +100,12 @@ read-only: the ``pocketpaw_fabric`` server grew three ontology modification
 tools (``fabric_link_create`` / ``fabric_link_delete`` at MEMBER tier,
 ``fabric_type_update`` RBAC-gated on ``fabric.admin``), mirroring the REST
 routes. ``tool_ids()`` picks them up automatically via ``FABRIC_TOOL_IDS``.
+
+Updated: 2026-07-24 (CX-3, feat/code-agent-exclusive-tools) —
+``CloudLifecycleHook.on_startup`` now also back-fills the dedicated ``code``
+agent (``ensure_code_agent_all_workspaces``) beside the default ``pocketpaw``
+one, so existing workspaces resolve ``/code`` turns to the exclusive-file-tool
+agent without waiting for the first-turn lazy seed.
 """
 
 from __future__ import annotations
@@ -309,6 +315,11 @@ class CloudLifecycleHook:
         await seed_workspace(admin)
         # Back-fill the pocketpaw agent for workspaces that predate agent seeding.
         await ensure_default_agent_all_workspaces()
+        # Back-fill the dedicated /code agent (exclusive file-tool set) beside it
+        # so an existing workspace resolves /code turns without a first-turn seed.
+        from pocketpaw_ee.cloud.agents.service import ensure_code_agent_all_workspaces
+
+        await ensure_code_agent_all_workspaces()
 
         # Persist Haiku-generated chat titles into MongoDB.
         try:

--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -1,5 +1,14 @@
 """
 Claude Agent SDK backend for PocketPaw.
+Updated: 2026-07-24 (CX-1, feat/code-agent-cx1) — ``_build_options`` / ``run`` /
+  ``prewarm`` grow an ``exclusive_mcp_tools: bool = False`` keyword. When True, the
+  MCP scoping block CAPS the tool surface to ``allow_mcp_tool_ids`` alone — no
+  POCKET_CREATION_GRANT, no widget/atlas ids, and NOT the
+  ALWAYS_ALLOWED_MCP_SERVERS escape hatch — so a dedicated agent (e.g. /code) gets
+  EXACTLY the declared ids. ``exclusive_mcp_tools=True`` with
+  ``allow_mcp_tool_ids=None`` strips ALL ``mcp__`` ids (empty permitted set), so an
+  exclusive agent wins over even a broad surface. ``False`` (the default) keeps the
+  legacy grant-union scoping byte-for-byte. Built-in SDK tools are never touched.
 Updated: 2026-07-08 (CS-13, feat/per-send-model-override) — ``run`` /
   ``_build_options`` grow an optional ``model_override: str | None = None``
   keyword. When set, it is applied as the LAST word in the model-selection block,
@@ -1535,6 +1544,7 @@ class ClaudeSDKBackend(BaseAgentBackend):
         stderr_sink: list[str],
         session_handle: SessionHandle | None = None,
         model_override: str | None = None,
+        exclusive_mcp_tools: bool = False,
     ) -> _BuiltOptions:
         """Assemble the ``ClaudeAgentOptions`` a turn (or a prewarm) will run on.
 
@@ -1766,7 +1776,29 @@ class ClaudeSDKBackend(BaseAgentBackend):
         # Built-in SDK tools (Read/Write/Bash/...) are NEVER filtered here —
         # only ``mcp__*`` ids — so scoping a mode can't strip core tools.
         # Applied AFTER deny so a denied id can't sneak back via the grant.
-        if allow_mcp_tool_ids is not None:
+        #
+        # ``exclusive_mcp_tools`` (CX-1) is the exact-toolset signal: an
+        # EXCLUSIVE turn CAPS the MCP surface to ``allow_mcp_tool_ids`` alone —
+        # no POCKET_CREATION_GRANT, no widget/atlas ids, and NOT the
+        # ALWAYS_ALLOWED_MCP_SERVERS escape hatch — so a dedicated agent (e.g.
+        # /code) gets EXACTLY the ids it declared and nothing the universal
+        # grant would otherwise union back in. Precedence rule: an exclusive
+        # turn with ``allow_mcp_tool_ids=None`` strips ALL ``mcp__`` ids (an
+        # empty permitted set), which is how an exclusive agent wins even over a
+        # broad surface. The default (signal off) path below is byte-for-byte
+        # the legacy grant-union scoping.
+        if exclusive_mcp_tools:
+            permitted = allow_mcp_tool_ids or frozenset()
+            before_count = len(allowed_tools)
+            allowed_tools = [
+                t for t in allowed_tools if not t.startswith("mcp__") or t in permitted
+            ]
+            if len(allowed_tools) < before_count:
+                logger.info(
+                    "Exclusive MCP-allow: capped to exactly %s (no general grant)",
+                    sorted(permitted),
+                )
+        elif allow_mcp_tool_ids is not None:
             from pocketpaw.agents.sdk_mcp_atlas import ATLAS_TOOL_IDS
             from pocketpaw.agents.sdk_mcp_widgets import WIDGET_TOOL_IDS
 
@@ -2081,6 +2113,7 @@ class ClaudeSDKBackend(BaseAgentBackend):
         allow_sdk_tools: frozenset[str] = frozenset(),
         allow_mcp_tool_ids: frozenset[str] | None = None,
         skill_names: frozenset[str] = frozenset(),
+        exclusive_mcp_tools: bool = False,
     ) -> None:
         """Eagerly ``connect()`` the warm CLI subprocess for a session before its
         first turn, so the first real ``run`` reuses it instead of paying the
@@ -2130,6 +2163,7 @@ class ClaudeSDKBackend(BaseAgentBackend):
                 allow_sdk_tools=allow_sdk_tools,
                 allow_mcp_tool_ids=allow_mcp_tool_ids,
                 skill_names=skill_names,
+                exclusive_mcp_tools=exclusive_mcp_tools,
                 stderr_sink=[],
             )
             # Remember the digest we may have adopted a dir under, so a failed
@@ -2319,6 +2353,7 @@ class ClaudeSDKBackend(BaseAgentBackend):
         warm_client: LeasedClient | None = None,
         on_client_built: Callable[[Any, str, Callable], None] | None = None,
         model_override: str | None = None,
+        exclusive_mcp_tools: bool = False,
     ) -> AsyncIterator[AgentEvent]:
         """Process a message through Claude Agent SDK with streaming.
 
@@ -2485,6 +2520,7 @@ class ClaudeSDKBackend(BaseAgentBackend):
                 skill_names=skill_names,
                 session_handle=session_handle,
                 model_override=model_override,
+                exclusive_mcp_tools=exclusive_mcp_tools,
                 stderr_sink=_stderr_lines,
             )
             options = _built.options

--- a/src/pocketpaw/agents/pool.py
+++ b/src/pocketpaw/agents/pool.py
@@ -3,6 +3,14 @@
 Each cloud Agent gets its own AgentBackend + SoulManager + memory namespace.
 Instances are cached and evicted when idle (default 5 minutes).
 
+Updated: 2026-07-24 (CX-2, feat/code-agent-exclusive-tools) — ``run`` and
+  ``prewarm`` accept ``exclusive_mcp_tools: bool = False`` and forward it to the
+  backend ONLY when True (same withhold-when-empty idiom as ``model_override`` /
+  ``skill_names``). Only the Claude SDK backend consumes it — there it CAPS the
+  MCP surface to ``allow_mcp_tool_ids`` alone (no universal grant), so a
+  ``tool_mode="exclusive"`` agent (e.g. /code) gets EXACTLY its declared ids.
+  ``False`` = the unchanged grant-union path for every existing run.
+
 Updated: 2026-07-08 (CS-13, feat/per-send-model-override) — ``run`` accepts an
   optional ``model_override: str | None`` (the client's per-send model choice) and
   forwards it to the backend's ``run`` ONLY when non-None (the same
@@ -371,6 +379,7 @@ class AgentPool:
         allow_mcp_tool_ids: frozenset[str] | None = None,
         system_message_override: str | None = None,
         skill_names: frozenset[str] = frozenset(),
+        exclusive_mcp_tools: bool = False,
     ) -> None:
         """Eagerly warm the agent's CLI subprocess for ``session_key`` before its
         first turn, so the first ``run`` reuses it instead of paying the cold
@@ -441,6 +450,11 @@ class AgentPool:
             prewarm_kwargs["allow_mcp_tool_ids"] = allow_mcp_tool_ids
         if effective_skills:
             prewarm_kwargs["skill_names"] = effective_skills
+        # Per-agent exclusive-tool cap (CX-2). Mirror ``run`` so the prewarmed
+        # client's options (and cache key) match turn 1's — forwarded only when
+        # True; the caller passes the agent's declared ids as ``allow_mcp_tool_ids``.
+        if exclusive_mcp_tools:
+            prewarm_kwargs["exclusive_mcp_tools"] = exclusive_mcp_tools
         await backend_prewarm(**prewarm_kwargs)
 
     async def run(
@@ -460,6 +474,7 @@ class AgentPool:
         warm_client: LeasedClient | None = None,
         on_client_built: Callable[[Any, str, Callable], None] | None = None,
         model_override: str | None = None,
+        exclusive_mcp_tools: bool = False,
     ) -> AsyncIterator[Any]:
         """Run an agent on a message. Yields AgentEvent stream.
 
@@ -517,6 +532,13 @@ class AgentPool:
         backend's ``run`` ONLY when set, so the 6 non-Claude backends keep their
         narrower signature and only the Claude SDK backend acts on it (where it wins
         over smart-routing / ``claude_sdk_model``). ``None`` = the unchanged path.
+
+        ``exclusive_mcp_tools`` (CX-2) is the per-agent exclusive-tool signal. It
+        rides the SAME withhold-when-empty contract: forwarded to the backend's
+        ``run`` ONLY when ``True``, so the 6 non-Claude backends keep their narrower
+        signature and only the Claude SDK backend acts on it (there it CAPS the MCP
+        surface to ``allow_mcp_tool_ids`` alone — no universal grant). ``False``
+        (the default) = the unchanged grant-union path.
         """
         instance = await self.get(agent_id)
         instance.last_active = datetime.now(UTC)
@@ -615,6 +637,13 @@ class AgentPool:
             # this turn. None = legacy path, unchanged for every existing run.
             if model_override is not None:
                 run_kwargs["model_override"] = model_override
+            # Per-agent exclusive-tool cap (CX-2). Same withhold-when-empty rule:
+            # only the Claude SDK backend accepts ``exclusive_mcp_tools`` (it caps
+            # the MCP surface to ``allow_mcp_tool_ids`` alone); the other backends
+            # keep the narrower signature, so it is forwarded ONLY when True.
+            # False = legacy grant-union path, unchanged for every existing run.
+            if exclusive_mcp_tools:
+                run_kwargs["exclusive_mcp_tools"] = exclusive_mcp_tools
             async for event in instance.backend.run(message, **run_kwargs):
                 instance.last_active = datetime.now(UTC)
                 yield event

--- a/tests/cloud/agents/test_agent_tool_mode.py
+++ b/tests/cloud/agents/test_agent_tool_mode.py
@@ -1,0 +1,98 @@
+# tests/cloud/agents/test_agent_tool_mode.py
+# Created 2026-07-24 (CX-2, feat/code-agent-exclusive-tools) — pins the
+# ``tool_mode`` field round-tripping through the agents service:
+#   * mapper round-trip spec -> doc -> spec keeps "exclusive" (and the default
+#     "additive").
+#   * update() via the body.config-dict branch sets tool_mode -> "exclusive" and
+#     it persists to Mongo (re-read through the service), and is preserved when
+#     the dict omits it.
+"""``AgentConfig.tool_mode`` round-trips through the agents service."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud.agents import service as agents_service
+from pocketpaw_ee.cloud.agents.domain import AgentConfigSpec
+from pocketpaw_ee.cloud.agents.dto import CreateAgentRequest, UpdateAgentRequest
+
+# ---------------------------------------------------------------------------
+# Mapper round-trip (no Mongo)
+# ---------------------------------------------------------------------------
+
+
+def test_mapper_round_trip_preserves_exclusive():
+    spec = AgentConfigSpec(tool_mode="exclusive", tools=("mcp__code__read",))
+    doc = agents_service._config_to_doc(spec)
+    assert doc.tool_mode == "exclusive"
+    back = agents_service._config_to_domain(doc)
+    assert back.tool_mode == "exclusive"
+    assert back.tools == ("mcp__code__read",)
+
+
+def test_mapper_default_is_additive():
+    spec = AgentConfigSpec()
+    assert spec.tool_mode == "additive"
+    doc = agents_service._config_to_doc(spec)
+    assert doc.tool_mode == "additive"
+    assert agents_service._config_to_domain(doc).tool_mode == "additive"
+
+
+# ---------------------------------------------------------------------------
+# Service round-trip through Mongo (via the config-dict update branch)
+# ---------------------------------------------------------------------------
+
+
+def _ctx(user_id: str = "u1", workspace_id: str | None = "w1") -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="r",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+def _create_body(**kw) -> CreateAgentRequest:
+    base = dict(name="Coder", slug="coder", soul_enabled=False)
+    base.update(kw)
+    return CreateAgentRequest(**base)
+
+
+@pytest.mark.usefixtures("mongo_db")
+async def test_create_defaults_additive(recording_bus) -> None:
+    agent = await agents_service.create(_ctx(), "w1", _create_body())
+    assert agent.config.tool_mode == "additive"
+    reloaded = await agents_service.get(agent.id)
+    assert reloaded.config.tool_mode == "additive"
+
+
+@pytest.mark.usefixtures("mongo_db")
+async def test_update_config_dict_sets_and_persists_exclusive(recording_bus) -> None:
+    agent = await agents_service.create(_ctx(), "w1", _create_body())
+    updated = await agents_service.update(
+        _ctx(),
+        agent.id,
+        UpdateAgentRequest(config={"tool_mode": "exclusive", "tools": ["mcp__code__read"]}),
+    )
+    assert updated.config.tool_mode == "exclusive"
+    # Re-read through the service to prove it persisted to Mongo.
+    reloaded = await agents_service.get(agent.id)
+    assert reloaded.config.tool_mode == "exclusive"
+    assert reloaded.config.tools == ("mcp__code__read",)
+
+
+@pytest.mark.usefixtures("mongo_db")
+async def test_update_config_dict_preserves_when_omitted(recording_bus) -> None:
+    """The config-dict branch keeps the current tool_mode when the dict omits it."""
+    agent = await agents_service.create(_ctx(), "w1", _create_body())
+    # First flip to exclusive, then update an unrelated field.
+    await agents_service.update(
+        _ctx(), agent.id, UpdateAgentRequest(config={"tool_mode": "exclusive"})
+    )
+    updated = await agents_service.update(
+        _ctx(), agent.id, UpdateAgentRequest(config={"temperature": 0.4})
+    )
+    assert updated.config.tool_mode == "exclusive"

--- a/tests/cloud/agents/test_code_agent_seed.py
+++ b/tests/cloud/agents/test_code_agent_seed.py
@@ -1,0 +1,178 @@
+# tests/cloud/agents/test_code_agent_seed.py
+# Created 2026-07-24 (CX-3, feat/code-agent-exclusive-tools) — pins the dedicated
+# ``/code`` agent seed and the backend-authoritative routing that makes the
+# classic pocket repro die.
+#
+# Three properties carry the weight here:
+#   1. ``seed_code_agent`` inserts a slug-"code" agent whose config is
+#      ``tool_mode="exclusive"`` + ``tools=_CODE_FILE_TOOL_IDS`` and carries NO
+#      create-pocket / widget skill; it is idempotent.
+#   2. THE HEADLINE — the seeded agent's OWN config, sourced via the CX-2
+#      ``_agent_tool_policy`` and driven through the REAL ``_build_options``
+#      allowlist computation, yields an effective MCP surface of EXACTLY the four
+#      file ids and ZERO pocket / widget / atlas / planner ids. This is the
+#      "build an employee management app…" repro dying at the allowlist level.
+#   3. ``_get_code_agent_id`` lazy-seeds on miss, and a CODE-surface session
+#      resolution routes to slug "code" (lazy-seeding), not the default
+#      "pocketpaw" agent.
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pocketpaw_ee.cloud._core.realtime.events import AgentCreated
+from pocketpaw_ee.cloud.agents import service as agents_service
+from pocketpaw_ee.cloud.chat import agent_service
+from pocketpaw_ee.cloud.chat.runs import run_core
+from pocketpaw_ee.cloud.surface.surface_registry import _CODE_FILE_TOOL_IDS
+from pocketpaw_ee.cloud.surface.system_prompts import CODE_SYSTEM_PROMPT
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+# ── 1. the seed ─────────────────────────────────────────────────────────────
+
+
+async def test_seed_code_agent_inserts_exclusive_file_tool_agent(recording_bus) -> None:
+    doc, created = await agents_service.seed_code_agent("w1", "u1")
+
+    assert created is True
+    assert doc is not None
+    assert doc.slug == "code"
+    assert doc.visibility == "workspace"
+    # exclusive file-tool policy — this is what CX-1/CX-2 read at run time.
+    assert doc.config.tool_mode == "exclusive"
+    assert set(doc.config.tools) == set(_CODE_FILE_TOOL_IDS)
+    # persona reuses the CODE surface prompt verbatim (no drift).
+    assert doc.config.system_prompt == CODE_SYSTEM_PROMPT
+    # NO create-pocket / pocket / widget skill — the CODE surface ships none.
+    assert doc.config.skill_refs == []
+    assert not any(
+        "pocket" in s.lower() or "widget" in s.lower() for s in doc.config.skill_refs
+    )
+
+    created_events = [e for e in recording_bus.events if isinstance(e, AgentCreated)]
+    assert len(created_events) == 1
+    assert created_events[0].data["slug"] == "code"
+
+    # idempotent — a second call inserts nothing and returns the existing row.
+    recording_bus.events.clear()
+    again, created_again = await agents_service.seed_code_agent("w1", "u1")
+    assert created_again is False
+    assert str(again.id) == str(doc.id)
+    assert not any(isinstance(e, AgentCreated) for e in recording_bus.events)
+
+
+# ── 2. THE HEADLINE — the pocket repro dies at the allowlist level ───────────
+
+
+async def test_seeded_code_agent_config_drives_exclusive_allowlist(monkeypatch) -> None:
+    """The seeded agent's OWN config, resolved through CX-2 ``_agent_tool_policy``
+    and driven through the REAL ``_build_options`` computation with a candidate
+    pool that INCLUDES the universal grant ids, yields exactly the four file ids
+    and nothing that could author a pocket. Presence + absence together are the
+    point — this is the assertion that "build me an employee management app,
+    with components and a nice design" can no longer reach a pocket tool."""
+    from pocketpaw.agents.claude_sdk import POCKET_CREATION_GRANT, ClaudeSDKBackend
+    from pocketpaw.agents.sdk_mcp_atlas import ATLAS_TOOL_IDS
+    from pocketpaw.agents.sdk_mcp_widgets import WIDGET_TOOL_IDS
+    from pocketpaw.config import get_settings
+
+    doc, _ = await agents_service.seed_code_agent("w1", "u1")
+
+    # Source the exclusive policy FROM the seeded agent's config (the CX-2 seam).
+    exclusive, tools = run_core._agent_tool_policy(doc)
+    assert exclusive is True
+    assert tools == frozenset(_CODE_FILE_TOOL_IDS)
+
+    widget_id = next(iter(WIDGET_TOOL_IDS))
+    atlas_id = next(iter(ATLAS_TOOL_IDS))
+    planner_id = "mcp__pocketpaw_pocket_planner__plan_pocket"
+    assert planner_id in POCKET_CREATION_GRANT
+
+    backend = ClaudeSDKBackend(get_settings())
+    # A candidate pool that WOULD grant pocket/widget/atlas on a default turn, so
+    # the suppression is provable rather than vacuous.
+    pool = [*sorted(_CODE_FILE_TOOL_IDS), widget_id, atlas_id, planner_id]
+    monkeypatch.setattr(backend, "_collect_mcp_tool_ids", lambda: list(pool))
+
+    built = await backend._build_options(
+        "build me an employee management app, with components and a nice design",
+        system_prompt=doc.config.system_prompt,
+        history=None,
+        session_key=None,
+        deny_mcp_tool_ids=frozenset(),
+        allow_sdk_tools=frozenset(),
+        allow_mcp_tool_ids=tools,
+        skill_names=frozenset(),
+        stderr_sink=[],
+        exclusive_mcp_tools=exclusive,
+    )
+    effective = {t for t in built.options_kwargs["allowed_tools"] if t.startswith("mcp__")}
+
+    assert effective == set(_CODE_FILE_TOOL_IDS)
+    # the pocket repro dies: zero pocket / widget / atlas / planner ids survive.
+    assert not [t for t in effective if t.startswith("mcp__pocketpaw_pocket")]
+    assert widget_id not in effective
+    assert atlas_id not in effective
+    assert planner_id not in effective
+
+
+# ── 3. lazy-seed + CODE-surface routing ─────────────────────────────────────
+
+
+async def test_get_code_agent_id_lazy_seeds_when_absent() -> None:
+    """A workspace with no code agent still works on its FIRST /code turn: the
+    helper seeds one and returns its id, and a second call returns the SAME id
+    (no duplicate seed)."""
+    # No code agent yet.
+    from pocketpaw_ee.cloud.models.agent import Agent
+
+    assert await Agent.find_one(Agent.workspace == "w1", Agent.slug == "code") is None
+
+    first = await agent_service._get_code_agent_id("w1")
+    assert first is not None
+
+    seeded = await Agent.find_one(Agent.workspace == "w1", Agent.slug == "code")
+    assert seeded is not None
+    assert str(seeded.id) == first
+
+    second = await agent_service._get_code_agent_id("w1")
+    assert second == first  # idempotent — same id, no second row
+
+
+async def test_code_surface_session_resolves_to_code_agent_not_default() -> None:
+    """End to end: a session-scope /code turn with NO explicit agent hint and no
+    pre-existing code agent LAZY-SEEDS one and resolves ``target`` to slug
+    "code" — never the default "pocketpaw" agent."""
+    from pocketpaw_ee.cloud.models.agent import Agent
+    from pocketpaw_ee.cloud.models.session import Session
+
+    # A default pocketpaw agent exists — the CODE override must still win.
+    default_doc, _ = await agents_service.seed_default_agent("w1", "u1")
+
+    fake_session = Session.model_construct(
+        id="s1",
+        sessionId="ws",
+        workspace="w1",
+        owner="u1",
+        agent=None,
+        pocket=None,
+        deleted_at=None,
+    )
+    with patch(
+        "pocketpaw_ee.cloud.chat.agent_service._get_session",
+        AsyncMock(return_value=fake_session),
+    ):
+        ctx = await agent_service.resolve_scope_context(
+            scope="session",
+            scope_id="s1",
+            user_id="u1",
+            agent_id_hint=None,
+            surface="code",
+        )
+
+    resolved = await Agent.get(ctx.target_agent_id)
+    assert resolved is not None
+    assert resolved.slug == "code"
+    assert ctx.target_agent_id != str(default_doc.id)

--- a/tests/cloud/runs/test_run_core_agent_tool_policy.py
+++ b/tests/cloud/runs/test_run_core_agent_tool_policy.py
@@ -1,0 +1,191 @@
+# tests/cloud/runs/test_run_core_agent_tool_policy.py
+# Created 2026-07-24 (CX-2, feat/code-agent-exclusive-tools) — pins the
+# per-agent EXCLUSIVE tool policy resolution + its run_kwargs wiring in run_core:
+#   * _agent_tool_policy: (True, frozenset(tools)) only for tool_mode="exclusive";
+#     (False, frozenset()) for "additive" and for a config with no tool_mode;
+#     tolerant of a dict OR an object config.
+#   * _drive_agent_loop: an exclusive agent sets run_kwargs["exclusive_mcp_tools"]
+#     = True and OVERRIDES allow_mcp_tool_ids with the agent's own tools, even
+#     when the surface set a different allow_mcp. An additive agent touches
+#     neither key and leaves any surface allow_mcp intact (grant path unchanged).
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from pocketpaw_ee.cloud.chat.agent_service import ScopeContext, ScopeKind
+from pocketpaw_ee.cloud.chat.runs import run_core
+
+# ---------------------------------------------------------------------------
+# _agent_tool_policy (pure unit)
+# ---------------------------------------------------------------------------
+
+
+def _instance(config: Any) -> Any:
+    return SimpleNamespace(config=config)
+
+
+def test_tool_policy_exclusive_returns_tools():
+    inst = _instance({"tool_mode": "exclusive", "tools": ["mcp__code__read", "mcp__code__write"]})
+    assert run_core._agent_tool_policy(inst) == (
+        True,
+        frozenset({"mcp__code__read", "mcp__code__write"}),
+    )
+
+
+def test_tool_policy_additive_returns_false_empty():
+    inst = _instance({"tool_mode": "additive", "tools": ["mcp__code__read"]})
+    assert run_core._agent_tool_policy(inst) == (False, frozenset())
+
+
+def test_tool_policy_no_tool_mode_defaults_additive():
+    # A non-empty tools list alone does NOT make an agent exclusive.
+    inst = _instance({"tools": ["mcp__code__read"]})
+    assert run_core._agent_tool_policy(inst) == (False, frozenset())
+
+
+def test_tool_policy_empty_config():
+    assert run_core._agent_tool_policy(_instance({})) == (False, frozenset())
+
+
+def test_tool_policy_object_config():
+    """The resolver tolerates an object config (getattr path) too."""
+    cfg = SimpleNamespace(tool_mode="exclusive", tools=["mcp__code__ls"])
+    assert run_core._agent_tool_policy(_instance(cfg)) == (True, frozenset({"mcp__code__ls"}))
+
+
+# ---------------------------------------------------------------------------
+# _drive_agent_loop → run_kwargs wiring
+# ---------------------------------------------------------------------------
+
+
+def _scope_ctx(*, resolved_profile=None) -> ScopeContext:
+    ctx = ScopeContext(
+        kind=ScopeKind.SESSION,
+        scope_id="s1",
+        workspace_id="w1",
+        user_id="u1",
+        members=["u1"],
+        target_agent_id="a1",
+    )
+    ctx.resolved_profile = resolved_profile
+    return ctx
+
+
+async def _drain_run_kwargs(monkeypatch, ctx, agent_config: dict[str, Any]) -> dict[str, Any]:
+    """Drive _drive_agent_loop just far enough to capture the run_kwargs the
+    pool.run seam receives, then stop. Mocks every collaborator the loop touches
+    before pool.run."""
+    captured: dict[str, Any] = {}
+
+    class _FakePool:
+        async def get(self, _agent_id):
+            return SimpleNamespace(config=agent_config, agent_name="A")
+
+        def run(self, agent_id, content, session_key, **run_kwargs):
+            captured["run_kwargs"] = run_kwargs
+
+            async def _gen():
+                return
+                yield  # pragma: no cover
+
+            return _gen()
+
+    monkeypatch.setattr(run_core, "get_agent_pool", lambda: _FakePool())
+
+    async def _fake_knowledge(*a, **k):
+        return ""
+
+    monkeypatch.setattr(run_core, "build_knowledge_context", _fake_knowledge)
+    monkeypatch.setattr(run_core, "build_behavior_instructions", lambda ctx, backend_name=None: "")
+    monkeypatch.setattr(run_core, "attach_sse_event_sink", lambda q: None)
+    monkeypatch.setattr(run_core, "attach_agent_identity", lambda **k: None)
+    monkeypatch.setattr(run_core, "detach_sse_event_sink", lambda t: None)
+    monkeypatch.setattr(run_core, "detach_agent_identity", lambda t: None)
+
+    async def _never_cancelled():
+        return False
+
+    gen = run_core._drive_agent_loop(
+        ctx,
+        user_content="hi",
+        attachments_in=None,
+        mentions_in=None,
+        history=None,
+        is_cancelled=_never_cancelled,
+        emit_stream_start=False,
+    )
+    async for _ in gen:
+        pass
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_exclusive_agent_sets_flag_and_allow(monkeypatch):
+    """An exclusive agent (resolved_profile None) sets exclusive_mcp_tools=True
+    and allow_mcp_tool_ids = its own declared tools."""
+    ctx = _scope_ctx(resolved_profile=None)
+    captured = await _drain_run_kwargs(
+        monkeypatch,
+        ctx,
+        {"tool_mode": "exclusive", "tools": ["mcp__code__read", "mcp__code__write"]},
+    )
+    rk = captured["run_kwargs"]
+    assert rk["exclusive_mcp_tools"] is True
+    assert rk["allow_mcp_tool_ids"] == frozenset({"mcp__code__read", "mcp__code__write"})
+
+
+@pytest.mark.asyncio
+async def test_exclusive_agent_overrides_surface_allow(monkeypatch):
+    """When the surface already set allow_mcp_tool_ids, an exclusive agent WINS —
+    its own tools replace the surface allow-list."""
+    profile = SimpleNamespace(
+        deny_mcp_tool_ids=frozenset(),
+        allowed_sdk_tools=frozenset(),
+        allow_mcp_tool_ids=frozenset({"mcp__surface__tool"}),
+        system_message_override=None,
+        skill_names=frozenset(),
+    )
+    ctx = _scope_ctx(resolved_profile=profile)
+    captured = await _drain_run_kwargs(
+        monkeypatch,
+        ctx,
+        {"tool_mode": "exclusive", "tools": ["mcp__code__read"]},
+    )
+    rk = captured["run_kwargs"]
+    assert rk["exclusive_mcp_tools"] is True
+    assert rk["allow_mcp_tool_ids"] == frozenset({"mcp__code__read"})
+
+
+@pytest.mark.asyncio
+async def test_additive_agent_touches_nothing(monkeypatch):
+    """An additive agent adds no exclusive key and leaves a surface allow_mcp
+    intact — the grant path is byte-identical to today."""
+    profile = SimpleNamespace(
+        deny_mcp_tool_ids=frozenset(),
+        allowed_sdk_tools=frozenset(),
+        allow_mcp_tool_ids=frozenset({"mcp__surface__tool"}),
+        system_message_override=None,
+        skill_names=frozenset(),
+    )
+    ctx = _scope_ctx(resolved_profile=profile)
+    captured = await _drain_run_kwargs(
+        monkeypatch,
+        ctx,
+        {"tool_mode": "additive", "tools": ["mcp__code__read"]},
+    )
+    rk = captured["run_kwargs"]
+    assert "exclusive_mcp_tools" not in rk
+    assert rk["allow_mcp_tool_ids"] == frozenset({"mcp__surface__tool"})
+
+
+@pytest.mark.asyncio
+async def test_no_tool_mode_is_additive(monkeypatch):
+    """A legacy config with no tool_mode and no surface allow_mcp: neither key
+    is set (broad surfaces keep every tool)."""
+    ctx = _scope_ctx(resolved_profile=None)
+    captured = await _drain_run_kwargs(monkeypatch, ctx, {"tools": ["mcp__code__read"]})
+    rk = captured["run_kwargs"]
+    assert "exclusive_mcp_tools" not in rk
+    assert "allow_mcp_tool_ids" not in rk

--- a/tests/cloud/test_agent_service_scope.py
+++ b/tests/cloud/test_agent_service_scope.py
@@ -18,6 +18,12 @@ pocket's orientation data (name, description, type, template/pattern, ripple
 summary) for ALL pocket types using the already-fetched Pocket doc — no
 extra DB round-trips. Home keeps its backend_summary alongside the new
 field; non-pocket scopes carry ``pocket_summary=None``.
+
+Updated: 2026-07-24 (CX-3, feat/code-agent-exclusive-tools) — added the CODE
+surface routing tests: an unhinted CODE-surface session/pocket resolution
+routes ``target`` to the dedicated ``code`` agent (``_get_code_agent_id``,
+patched here), an explicit ``agent_id_hint`` is still honored, and non-CODE
+surfaces are byte-identical.
 """
 
 from __future__ import annotations
@@ -745,3 +751,127 @@ async def test_resolve_group_scope_has_no_pocket_summary():
             scope="group", scope_id="g1", user_id="u_caller", agent_id_hint=None
         )
     assert ctx.pocket_summary is None
+
+
+# ===========================================================================
+# CX-3 — the /code surface routes to the dedicated ``code`` agent.
+#
+# On the CODE surface, an unhinted turn resolves ``target`` to the code agent
+# (via ``_get_code_agent_id``, which lazy-seeds) instead of the session's stored
+# agent / the default ``pocketpaw`` agent. An explicit ``agent_id_hint`` is still
+# honored, and every non-CODE surface is byte-identical. These are unit-scoped
+# (the code-agent id is patched); the lazy-seed + end-to-end routing against real
+# Mongo lives in tests/cloud/agents/test_code_agent_seed.py.
+# ===========================================================================
+
+
+def _fake_session(agent):
+    from pocketpaw_ee.cloud.models.session import Session
+
+    return Session.model_construct(
+        id="s1",
+        sessionId="ws",
+        workspace="w1",
+        owner="u1",
+        agent=agent,
+        pocket=None,
+        deleted_at=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_code_surface_routes_session_to_code_agent():
+    """CODE surface + no hint ⇒ ``target`` is the code agent, overriding the
+    session's stored agent."""
+    code_mock = AsyncMock(return_value="code-agent-id")
+    with (
+        patch(
+            "pocketpaw_ee.cloud.chat.agent_service._get_session",
+            AsyncMock(return_value=_fake_session(agent="a1")),
+        ),
+        patch("pocketpaw_ee.cloud.chat.agent_service._get_code_agent_id", code_mock),
+    ):
+        ctx = await resolve_scope_context(
+            scope="session",
+            scope_id="s1",
+            user_id="u1",
+            agent_id_hint=None,
+            surface="code",
+        )
+    assert ctx.target_agent_id == "code-agent-id"
+    code_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_code_surface_respects_explicit_agent_hint():
+    """An explicit ``agent_id_hint`` is honored even on CODE — the override only
+    replaces the DEFAULT resolution, never a caller's pinned agent."""
+    code_mock = AsyncMock(return_value="code-agent-id")
+    with (
+        patch(
+            "pocketpaw_ee.cloud.chat.agent_service._get_session",
+            AsyncMock(return_value=_fake_session(agent="a1")),
+        ),
+        patch("pocketpaw_ee.cloud.chat.agent_service._get_code_agent_id", code_mock),
+    ):
+        ctx = await resolve_scope_context(
+            scope="session",
+            scope_id="s1",
+            user_id="u1",
+            agent_id_hint="a2",
+            surface="code",
+        )
+    assert ctx.target_agent_id == "a2"
+    code_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_non_code_surface_does_not_route_to_code_agent():
+    """A non-CODE surface (or no surface hint) leaves session resolution
+    byte-identical — the code-agent seam is never touched."""
+    code_mock = AsyncMock(return_value="code-agent-id")
+    with (
+        patch(
+            "pocketpaw_ee.cloud.chat.agent_service._get_session",
+            AsyncMock(return_value=_fake_session(agent="a1")),
+        ),
+        patch("pocketpaw_ee.cloud.chat.agent_service._get_code_agent_id", code_mock),
+    ):
+        ctx = await resolve_scope_context(
+            scope="session",
+            scope_id="s1",
+            user_id="u1",
+            agent_id_hint=None,
+            surface="generic",
+        )
+    assert ctx.target_agent_id == "a1"
+    code_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_code_surface_routes_pocket_to_code_agent():
+    """CODE surface + no hint also overrides the pocket's default agent."""
+    pocket = SimpleNamespace(
+        id="p1",
+        workspace="w1",
+        owner="u_caller",
+        team=["u_caller"],
+        agents=["agent_primary"],
+        tool_specs=[],
+        visibility="workspace",
+        shared_with=[],
+    )
+    code_mock = AsyncMock(return_value="code-agent-id")
+    with (
+        patch("pocketpaw_ee.cloud.chat.agent_service._get_pocket", AsyncMock(return_value=pocket)),
+        patch("pocketpaw_ee.cloud.chat.agent_service._get_code_agent_id", code_mock),
+    ):
+        ctx = await resolve_scope_context(
+            scope="pocket",
+            scope_id="p1",
+            user_id="u_caller",
+            agent_id_hint=None,
+            surface="code",
+        )
+    assert ctx.target_agent_id == "code-agent-id"
+    code_mock.assert_awaited_once()

--- a/tests/ee/agent/test_code_mcp_server.py
+++ b/tests/ee/agent/test_code_mcp_server.py
@@ -25,6 +25,12 @@
 # The delegate channel itself is not re-tested here (see
 # tests/cloud/test_codeagent_delegates.py) — these drive the handlers against a
 # stub and assert on what each does with the outcome.
+#
+# Extended 2026-07-24 (CX-1) with three ``_build_options`` cases proving the
+# ``exclusive_mcp_tools`` cap: (a) exclusive + a declared allow-list yields
+# EXACTLY those ids (grant suppressed), (b) exclusive + None strips ALL mcp ids,
+# (c) the default path still applies the pocket/widget/atlas grant. A
+# deterministic candidate pool is injected so the suppression is provable.
 from __future__ import annotations
 
 import pytest
@@ -151,6 +157,105 @@ async def test_file_tools_reach_the_effective_allowlist_and_the_builtins_do_not(
     for tool in ("Bash", "Read", "Write", "Edit", "Glob", "Grep", "Agent"):
         assert tool not in effective, f"{tool} addresses the backend's disk, not the user's project"
     assert not [t for t in effective if t.startswith("mcp__pocketpaw_daytona__")]
+
+
+# ── exclusive_mcp_tools caps the surface to exactly the declared ids (CX-1) ──
+
+
+def _mcp_ids(built) -> set[str]:
+    """The ``mcp__*`` ids that survived ``_build_options`` scoping."""
+    return {t for t in built.options_kwargs["allowed_tools"] if t.startswith("mcp__")}
+
+
+async def _build_with(backend, *, allow, exclusive):
+    """Run ``_build_options`` with a deterministic candidate MCP pool.
+
+    The pool is monkeypatched (via the fixture) to contain the four code file
+    ids PLUS one widget id, one atlas id, and one planner (grant) id — so the
+    suppression is provable: an exclusive turn must strip the grant ids that a
+    default turn keeps. A test where the grant id was never a candidate would
+    prove nothing."""
+    return await backend._build_options(
+        "refactor this",
+        system_prompt="you are on the code surface",
+        history=None,
+        session_key=None,
+        deny_mcp_tool_ids=frozenset(),
+        allow_sdk_tools=frozenset(),
+        allow_mcp_tool_ids=allow,
+        skill_names=frozenset(),
+        stderr_sink=[],
+        exclusive_mcp_tools=exclusive,
+    )
+
+
+@pytest.fixture
+def backend_with_grant_pool(monkeypatch):
+    """A backend whose ``_collect_mcp_tool_ids`` yields a deterministic pool:
+    the four code file ids + a widget id + an atlas id + a planner grant id."""
+    from pocketpaw.agents.claude_sdk import POCKET_CREATION_GRANT, ClaudeSDKBackend
+    from pocketpaw.agents.sdk_mcp_atlas import ATLAS_TOOL_IDS
+    from pocketpaw.agents.sdk_mcp_widgets import WIDGET_TOOL_IDS
+    from pocketpaw.config import get_settings
+    from pocketpaw_ee.cloud.surface.surface_registry import _CODE_FILE_TOOL_IDS
+
+    widget_id = next(iter(WIDGET_TOOL_IDS))
+    atlas_id = next(iter(ATLAS_TOOL_IDS))
+    planner_id = "mcp__pocketpaw_pocket_planner__plan_pocket"
+    assert planner_id in POCKET_CREATION_GRANT
+
+    pool = [*sorted(_CODE_FILE_TOOL_IDS), widget_id, atlas_id, planner_id]
+    backend = ClaudeSDKBackend(get_settings())
+    monkeypatch.setattr(backend, "_collect_mcp_tool_ids", lambda: list(pool))
+    return backend, widget_id, atlas_id, planner_id
+
+
+@pytest.mark.asyncio
+async def test_exclusive_caps_to_exactly_the_declared_ids(backend_with_grant_pool):
+    """(a) exclusive + a declared allow-list ⇒ the effective MCP surface is
+    EXACTLY those ids; the universal pocket/widget/atlas grant is NOT unioned
+    back in."""
+    from pocketpaw_ee.cloud.surface.surface_registry import _CODE_FILE_TOOL_IDS
+
+    backend, widget_id, atlas_id, planner_id = backend_with_grant_pool
+    built = await _build_with(backend, allow=_CODE_FILE_TOOL_IDS, exclusive=True)
+
+    assert _mcp_ids(built) == set(_CODE_FILE_TOOL_IDS)
+    # the grant ids that were candidates are gone
+    assert widget_id not in _mcp_ids(built)
+    assert atlas_id not in _mcp_ids(built)
+    assert planner_id not in _mcp_ids(built)
+    assert not [t for t in _mcp_ids(built) if t.startswith("mcp__pocketpaw_pocket")]
+
+
+@pytest.mark.asyncio
+async def test_exclusive_with_no_allowlist_strips_all_mcp(backend_with_grant_pool):
+    """(b) exclusive + ``allow_mcp_tool_ids=None`` ⇒ the empty permitted set
+    strips EVERY ``mcp__`` id. This is the precedence rule that lets an
+    exclusive agent win over even a broad surface."""
+    backend, *_ = backend_with_grant_pool
+    built = await _build_with(backend, allow=None, exclusive=True)
+
+    assert _mcp_ids(built) == set()
+
+
+@pytest.mark.asyncio
+async def test_default_path_still_applies_the_grant(backend_with_grant_pool):
+    """(c) the DEFAULT path (signal off) is unchanged: the grant still applies,
+    so a widget id and an atlas id present in the candidate pool SURVIVE the
+    same allow-list that case (a) capped away."""
+    from pocketpaw_ee.cloud.surface.surface_registry import _CODE_FILE_TOOL_IDS
+
+    backend, widget_id, atlas_id, planner_id = backend_with_grant_pool
+    built = await _build_with(backend, allow=_CODE_FILE_TOOL_IDS, exclusive=False)
+
+    effective = _mcp_ids(built)
+    # the declared ids are still there
+    assert set(_CODE_FILE_TOOL_IDS) <= effective
+    # and the grant ids that (a) stripped now survive — proving suppression
+    assert widget_id in effective
+    assert atlas_id in effective
+    assert planner_id in effective
 
 
 # ── each verb round-trips to the delegate with the right shape ──────────────


### PR DESCRIPTION
## Why

`/code` still creates pockets in production. "Build an employee management app with components and a nice design" yields a pocket and a ripple ui-spec instead of code. The prior fix deny-listed pocket tools on the CODE surface, but that fights a hardcoded grant union in `_build_options` that re-adds pocket/widget/atlas tools on every turn (`claude_sdk.py:1769-1786`). Every new pocket or widget tool re-opens the hole.

This replaces the deny-list with a structural guarantee: a dedicated `code` agent whose MCP toolset is honored literally, so it *cannot* reach a pocket tool by construction. It also lands RFC #14's deferred M2 (per-agent tool scoping).

## What changed

Three stacked slices, one coherent change:

**Suppressible grant (`claude_sdk.py`, `pool.py`)** — `_build_options`/`run`/`prewarm` grow an `exclusive_mcp_tools` flag, threaded through `AgentPool`. When set, a turn's MCP surface is capped to `allow_mcp_tool_ids` alone: no pocket-creation grant, no widget or atlas ids, no always-allowed escape hatch. `allow=None` under exclusivity strips every `mcp__` id, so an exclusive agent wins even over a broad surface. The default path (flag off) is byte-for-byte the old grant-union behavior.

**Agent tool policy (`agents/domain.py`, `models/agent.py`, `agents/service.py`, `run_core.py`)** — agent config carries an explicit `tool_mode` (`additive` | `exclusive`), mirrored on the domain spec and the Beanie model. `run_core` reads the resolved agent's policy via a new `_agent_tool_policy` helper; an exclusive agent's own `tools` become the run's allow-list and drive the flag above, overriding any surface allow-list. An explicit signal, not "non-empty tools implies exclusive" — an agent can list tools and still want the additive grant.

**Seed and route the `code` agent (`agents/service.py`, `extensions.py`, `chat/agent_service.py`)** — `seed_code_agent` mirrors the default-agent seed but with `tool_mode="exclusive"`, `tools=_CODE_FILE_TOOL_IDS`, the CODE surface's own system prompt as persona (imported, so the two can't drift), and no create-pocket skill. Boot back-fill covers existing workspaces; a missing agent lazy-seeds on the first `/code` turn. Routing is backend-authoritative: a CODE-surface turn with no explicit agent hint resolves to the `code` agent instead of the default. The frontend already sends `surface="code"` and no agent id, so no client change is needed.

## The repro is dead

The headline test sources the exclusive policy from the *seeded agent's own config*, injects widget/atlas/planner ids into the candidate pool, and drives the real allowlist computation with the literal "build me an employee management app, with components and a nice design" prompt. The effective MCP surface comes out as exactly the four file tools, with zero pocket, widget, atlas, or planner ids surviving.

## Tests

Targeted suites over the touched modules, run locally: **776 passed, 1 failed**. The one failure (`test_run_core.py::test_execute_run_threads_surface_meta_into_ctx`) is pre-existing on the base branch (`AttributeError: run_id`), confirmed by running it against the untouched base tree — not introduced here.

Coverage added: the three exclusivity cases against `_build_options`, the `_agent_tool_policy` resolution and `run_kwargs` wiring (including agent-over-surface precedence), `tool_mode` domain/Beanie round-trip, the seed (idempotent, correct config, no pocket skill), lazy-seed on miss, and the backend routing (CODE routes to the `code` agent, other surfaces unchanged).

## Not in this PR

- Deleting the now-redundant `_CODE_POCKET_DENY` / `_CODE_SKILL_DENY` deny-lists (follow-up; they stay as belt-and-suspenders for now).
- Project-keyed `/code` sessions (follow-up).
- Any change to the file-tool delegate itself (#1778).

## Base

Stacked on `feat/code-mode-file-tools` (#1778). Rebase onto `feat/code-mode` once that merges.
