### PR TITLE
Drop the redundant MCP pocket deny-list from the CODE surface

### DIFF
--- a/ee/pocketpaw_ee/cloud/surface/surface_registry.py
+++ b/ee/pocketpaw_ee/cloud/surface/surface_registry.py
@@ -80,6 +80,17 @@
 # deliverable instead. Both halves were needed; neither alone held.
 #
 # The CODE row stays STATIC — the prompt is a module constant like the tool ids.
+#
+# Changes: 2026-07-24 (feat/code-surface-cleanup, CX-4) — removed the
+# ``_CODE_POCKET_DENY`` MCP deny-list from the CODE profile. Since CX-3, /code
+# routes to a dedicated ``code`` agent whose ``tool_mode="exclusive"`` policy caps
+# the run's ``mcp__*`` tools to exactly the four file ids at run time; every id
+# ``_CODE_POCKET_DENY`` named was an ``mcp__*`` id that cap already strips, so the
+# surface deny-list was dead weight. The division of labor is now explicit: the
+# code AGENT enforces MCP tool restriction (structurally, via exclusivity), and the
+# SURFACE profile denies only the BUILT-IN tools the MCP cap cannot reach —
+# ``_CODE_BUILTIN_DENY`` (backend-disk tools + ``Agent``) and ``_CODE_SKILL_DENY``
+# (``Skill``), both KEPT unchanged.
 
 from __future__ import annotations
 
@@ -274,63 +285,28 @@ _CODE_BUILTIN_DENY: frozenset[str] = frozenset(
     {"Bash", "Read", "Write", "Edit", "Glob", "Grep", "Agent"}
 )
 
-# The pocket-AUTHORING tools the /code agent must not hold either.
+# The pocket-AUTHORING tools the /code agent must not hold used to live here as
+# ``_CODE_POCKET_DENY`` — an MCP deny-list spelling out the pocket / planner /
+# widget ids so they could not survive back into the allow-list via
+# ``POCKET_CREATION_GRANT`` / ``ALWAYS_ALLOWED_MCP_SERVERS`` / ``WIDGET_TOOL_IDS``.
+# It was REMOVED 2026-07-24 (CX-4). MCP tool restriction for /code is now enforced
+# STRUCTURALLY, one layer up: /code routes to a dedicated ``code`` agent whose
+# config is ``tool_mode="exclusive"`` + ``tools=_CODE_FILE_TOOL_IDS``, and at run
+# time that exclusive policy CAPS the run's ``mcp__*`` surface to exactly those
+# four file tools — no pocket / widget / atlas / planner id can reach the allow-list
+# regardless of any grant (proven by
+# ``tests/cloud/agents/test_code_agent_seed.py::
+# test_seeded_code_agent_config_drives_exclusive_allowlist``). With the cap moved to
+# the agent, an MCP deny-list on the surface is dead weight — every id it named is an
+# ``mcp__*`` id the exclusivity already strips.
 #
-# Reported from a live session: with a React project open on /code, "Let's build
-# an employee management app, with components, nice design etc" made the agent
-# create a pocket and author a ripple ui-spec instead of writing React. The user
-# asked for an app and got a dashboard.
-#
-# ``allow_mcp_tool_ids`` does NOT prevent this, which is the whole reason this
-# set exists. CD-3 scoped /code to ``code_mode``, but ``claude_sdk`` deliberately
-# lets three families survive ANY restrictive allow-list: ``POCKET_CREATION_GRANT``
-# (specialist create + planner), ``ALWAYS_ALLOWED_MCP_SERVERS`` (every tool on the
-# ``pocketpaw_pocket`` / ``_specialist`` / ``_planner`` servers), and
-# ``WIDGET_TOOL_IDS``. Those bypasses are RIGHT for a general chat surface — "create
-# a pocket" is the product's core capability and must work from anywhere — and
-# wrong for this one, where the deliverable is the user's code. Deny is applied
-# BEFORE the grant is unioned in, so it is the only lever that reaches them.
-#
-# Prose could not do this job. The preamble already says "do not build widgets,
-# charts, or a ui-spec, and do not create a pocket" and the agent did it anyway —
-# the same result /sites got before it denied these ids outright rather than
-# asking (see ``_SITES_SVELTE_CREATE_DENY``: "prose-only routing was proven to
-# fail"). Two surfaces have now independently confirmed it.
-#
-# READ-ONLY pocket access (``get_pocket`` / ``list_pockets``) is deliberately NOT
-# denied: reading a pocket cannot produce one, and a user on /code may reasonably
-# ask what a pocket contains. The line is drawn at AUTHORING.
-#
-# The widget ids are spelled out rather than imported so the CODE row stays a
-# STATIC profile (no lazy load, no resolver). ``test_code_deny_covers_every_widget
-# _tool`` pins this literal against the real ``WIDGET_TOOL_IDS``, so a widget tool
-# added later fails the suite instead of silently reopening the hole.
-_CODE_POCKET_DENY: frozenset[str] = frozenset(
-    {
-        # POCKET_CREATION_GRANT — survives the allow-list by design.
-        "mcp__pocketpaw_pocket_specialist__create",
-        "mcp__pocketpaw_pocket_planner__plan_pocket",
-        # ALWAYS_ALLOWED_MCP_SERVERS — the authoring verbs on the pocket servers.
-        "mcp__pocketpaw_pocket_specialist__edit",
-        "mcp__pocketpaw_pocket__add_widget",
-        "mcp__pocketpaw_pocket__update_widget",
-        # WIDGET_TOOL_IDS — the ripple catalog that turns "with components, nice
-        # design" into a ui-spec instead of React components.
-        "mcp__pocketpaw_widgets__get_widget_spec",
-        "mcp__pocketpaw_widgets__get_inline_widget_help",
-        "mcp__pocketpaw_widgets__start_flow",
-        # The READ verbs go too. An earlier pass kept them on the reasoning that
-        # reading a pocket cannot produce one — true in isolation, and beside the
-        # point: a pocket the agent can inspect is a pocket it can propose, and
-        # "let me look at how your other dashboard does this" is the first step
-        # back onto the path this profile exists to close. Nothing on /code needs
-        # them; the deliverable is the user's code.
-        "mcp__pocketpaw_pocket__get_pocket",
-        "mcp__pocketpaw_pocket__list_pockets",
-    }
-)
+# The exclusivity cap covers ONLY ``mcp__*`` ids, though. It does NOT and
+# structurally CANNOT touch the SDK's built-in tools, so the surface's remaining
+# denies below stay: ``_CODE_BUILTIN_DENY`` (Bash/Read/Write/… + Agent — the
+# backend-disk tools) and ``_CODE_SKILL_DENY`` (``Skill``) both deny BUILT-INS that
+# no MCP allow-list — exclusive or not — can reach.
 
-# ``Skill`` goes too, and it is the last door.
+# ``Skill`` is denied, and it is the last door.
 #
 # The bundled skills ship as a Claude Code LOCAL PLUGIN, which is loaded from the
 # SDK ``plugins=`` option independently of ``skill_names`` — so a surface CANNOT
@@ -340,13 +316,15 @@ _CODE_POCKET_DENY: frozenset[str] = frozenset(
 # request like "build an employee management app with components and nice design"
 # almost word for word, which is how the reported bug started.
 #
-# With every pocket tool denied above, invoking that skill can no longer BUILD
-# anything — but it would still cost the user a turn: the agent loads a long
-# instruction telling it to call ``get_widget_spec`` and ``pocket_specialist__
-# create``, attempts them, takes hard errors, and only then finds its file tools.
-# CD-3 made exactly this argument when it dropped the `code` skill from the
-# profile ("absence is recoverable; contradiction is not"); the same reasoning
-# applies to a skill that teaches the wrong deliverable.
+# With the code agent's exclusivity capping the pocket MCP tools out of reach,
+# invoking that skill can no longer BUILD anything — but it would still cost the
+# user a turn: the agent loads a long instruction telling it to call
+# ``get_widget_spec`` and ``pocket_specialist__create``, attempts them, takes hard
+# errors, and only then finds its file tools. ``Skill`` is a BUILT-IN, so the MCP
+# cap does not reach it — this surface deny is what keeps the skill from firing on
+# the exact repro prompt at all. CD-3 made the same argument when it dropped the
+# `code` skill from the profile ("absence is recoverable; contradiction is not");
+# it applies equally to a skill that teaches the wrong deliverable.
 #
 # /code needs no skill: ``CODE_SYSTEM_PROMPT`` is now the agent's whole guidance
 # here, and it is not a document the agent has to go and fetch. If a
@@ -611,6 +589,16 @@ SURFACES: list[SurfaceSpec] = [
         # Both sets are module-level literals, so this stays a STATIC profile (no
         # lazily-loaded ids, not meta-aware, no resolver needed).
         #
+        # The deny set covers only BUILT-IN tools now. Restricting the MCP surface
+        # for /code is no longer this profile's job: /code routes to the dedicated
+        # ``code`` agent, whose ``tool_mode="exclusive"`` policy caps the run's
+        # ``mcp__*`` tools to exactly the four file ids at run time — so the old
+        # ``_CODE_POCKET_DENY`` MCP deny-list became dead weight and was removed
+        # (CX-4). What the exclusivity cap CANNOT reach are the built-ins, which is
+        # exactly what ``_CODE_BUILTIN_DENY`` (backend-disk tools + ``Agent``) and
+        # ``_CODE_SKILL_DENY`` (``Skill`` — the create-pocket plugin's invoker)
+        # still deny here.
+        #
         # ``skill_names`` is deliberately EMPTY, where it used to carry the
         # `code` skill. That skill is not incidentally about the built-ins — it
         # is entirely about them ("you use the built-in Bash / Read / Write /
@@ -624,7 +612,7 @@ SURFACES: list[SurfaceSpec] = [
         profile=SurfaceProfile(
             ripple_mode="off",
             allow_mcp_tool_ids=_CODE_FILE_TOOL_IDS,
-            deny_mcp_tool_ids=_CODE_BUILTIN_DENY | _CODE_POCKET_DENY | _CODE_SKILL_DENY,
+            deny_mcp_tool_ids=_CODE_BUILTIN_DENY | _CODE_SKILL_DENY,
             # The surface's own system prompt, replacing the pocket-shaped
             # behavioral stack the shared builder would otherwise assemble. See
             # ``system_prompts.py`` for why a prohibition alone did not hold.

--- a/tests/cloud/surface/test_studio_code_handlers.py
+++ b/tests/cloud/surface/test_studio_code_handlers.py
@@ -50,6 +50,20 @@
 # have gone green against the OLD profile too — that one named all six built-ins
 # in the additive ``allowed_sdk_tools`` and shipped them anyway — so the negative
 # has to be asserted against the COMPUTED result, not the declaration.
+#
+# Changes: 2026-07-24 (feat/code-surface-cleanup, CX-4) — dropped the two
+# pocket-authoring guards (``test_code_profile_builds_no_pocket_in_the_effective_
+# allowlist`` and ``test_code_deny_covers_every_widget_tool_and_the_pocket_
+# creation_grant``) and the ``_POCKET_AUTHORING_TOOLS`` literal they read. The
+# surface profile's ``_CODE_POCKET_DENY`` MCP deny-list they pinned was removed:
+# MCP tool restriction for /code is now enforced structurally by the dedicated
+# ``code`` agent's ``tool_mode="exclusive"`` policy, and the pocket repro dying at
+# the allowlist level is proven in ``tests/cloud/agents/test_code_agent_seed.py``.
+# The BUILT-IN denies this surface still owns (file/shell + ``Agent``, and
+# ``Skill``) — which the MCP cap cannot reach — stay guarded here by
+# ``test_code_profile_denies_the_filesystem_builtins_and_subagents``,
+# ``test_code_profile_grants_no_filesystem_tool_in_the_effective_allowlist``, and
+# ``test_code_profile_denies_the_skill_tool``.
 
 from __future__ import annotations
 
@@ -118,20 +132,6 @@ async def test_studio_handler_relays_provider_errors() -> None:
 # The file/shell built-ins the /code agent must not hold. They address the
 # backend server, which is not the machine the user's project is on.
 _FILESYSTEM_BUILTINS = frozenset({"Bash", "Read", "Write", "Edit", "Glob", "Grep"})
-
-# The pocket-AUTHORING tools the /code agent must not hold. Each one is a way to
-# answer "build me an app" with a dashboard instead of code. Read-only pocket
-# access (``get_pocket`` / ``list_pockets``) is deliberately absent from this set
-# — reading a pocket cannot produce one.
-_POCKET_AUTHORING_TOOLS = frozenset(
-    {
-        "mcp__pocketpaw_pocket_specialist__create",
-        "mcp__pocketpaw_pocket_specialist__edit",
-        "mcp__pocketpaw_pocket_planner__plan_pocket",
-        "mcp__pocketpaw_pocket__add_widget",
-        "mcp__pocketpaw_pocket__update_widget",
-    }
-)
 
 # The Daytona MCP tool names the old preamble advertised. They address an older
 # cloud-projects model that knows nothing of the current codeproject +
@@ -470,114 +470,20 @@ async def test_code_profile_grants_no_filesystem_tool_in_the_effective_allowlist
     )
 
 
-async def test_code_profile_builds_no_pocket_in_the_effective_allowlist() -> None:
-    """The /code agent must not be able to BUILD A POCKET.
-
-    Reported from a live session: with a React project open on /code, "Let's
-    build an employee management app, with components, nice design etc" made the
-    agent create a pocket and start authoring a ripple ui-spec instead of writing
-    React. The user asked for an app; the agent shipped a dashboard.
-
-    The preamble already forbids this in prose ("do not build widgets, charts, or
-    a ui-spec, and do not create a pocket"), and the prose lost — exactly as the
-    /sites svelte-create comment predicted when it denied the same two tools
-    rather than asking nicely.
-
-    The reason the deny was needed is that ``allow_mcp_tool_ids`` CANNOT express
-    it. CD-3 scoped /code to ``code_mode``, but ``claude_sdk`` deliberately lets
-    two families survive any restrictive allow-list: ``POCKET_CREATION_GRANT``
-    (create + plan) and ``ALWAYS_ALLOWED_MCP_SERVERS`` (the whole
-    ``pocketpaw_pocket*`` family), plus ``WIDGET_TOOL_IDS`` unioned into the
-    grant. Those bypasses are correct for a general chat surface — "create a
-    pocket" is the core capability — and wrong for this one, where the
-    deliverable is code. Deny runs BEFORE the grant is applied and is the only
-    lever that reaches them.
-
-    Asserted against the COMPUTED allowlist, not the declaration, for the same
-    reason the filesystem test above is: the bypasses live in the computation."""
-    from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
-    from pocketpaw.config import get_settings
-
-    profile = resolve_profile(SurfaceKind.CODE, SurfaceMeta())
-    backend = ClaudeSDKBackend(get_settings())
-
-    built = await backend._build_options(
-        "Let's build an employee management app, with components, nice design etc",
-        system_prompt="you are on the code surface",
-        history=None,
-        session_key=None,
-        deny_mcp_tool_ids=profile.deny_mcp_tool_ids,
-        allow_sdk_tools=profile.allowed_sdk_tools or frozenset(),
-        allow_mcp_tool_ids=profile.allow_mcp_tool_ids,
-        skill_names=profile.skill_names,
-        stderr_sink=[],
-    )
-    effective = set(built.options_kwargs["allowed_tools"])
-
-    for tool in sorted(_POCKET_AUTHORING_TOOLS):
-        assert tool not in effective, (
-            f"{tool} reached the SDK's effective allowlist on /code — the agent "
-            f"can build a pocket instead of writing the user's code. Effective "
-            f"allowlist: {sorted(effective)}"
-        )
-
-    # The ripple widget catalog, by prefix so a widget tool added later is caught
-    # without anyone remembering to update this test. These are the tools that
-    # turn "with components, nice design" into a ui-spec.
-    leaked_widgets = sorted(t for t in effective if t.startswith("mcp__pocketpaw_widgets__"))
-    assert not leaked_widgets, (
-        f"ripple widget tools reached the effective allowlist on /code: "
-        f"{leaked_widgets}. 'Components' on this surface means React/Vue "
-        f"components in the user's project, not ripple widgets in a ui-spec."
-    )
-
-    # No pocket tool of ANY kind survives — read verbs included. An earlier pass
-    # kept ``get_pocket`` / ``list_pockets`` on the reasoning that reading a
-    # pocket cannot produce one; that is true and beside the point, since a
-    # pocket the agent can inspect is a pocket it can propose. Prefix scan, so a
-    # tool added to the server later is caught without updating this test.
-    leaked_pocket = sorted(t for t in effective if t.startswith("mcp__pocketpaw_pocket"))
-    assert not leaked_pocket, (
-        f"pocket tools reached the effective allowlist on /code: {leaked_pocket}. "
-        f"The deliverable on this surface is the user's code; nothing here needs "
-        f"a pocket, in read or write."
-    )
-
-    # Positive controls, so the assertions above cannot pass vacuously.
-    assert "WebSearch" in effective
-    assert "mcp__pocketpaw_code__readFile" in effective, (
-        "the file tools were filtered out — the surface has lost its door to the "
-        "user's project, so the absence assertions above prove nothing"
-    )
-
-
-def test_code_deny_covers_every_widget_tool_and_the_pocket_creation_grant() -> None:
-    """The /code deny set is spelled as literals; pin it against the real sources.
-
-    ``_CODE_POCKET_DENY`` enumerates ids rather than importing them, so the CODE
-    row can stay a STATIC profile with no lazy load. The cost of a literal is
-    drift: a tool added to ``WIDGET_TOOL_IDS`` or ``POCKET_CREATION_GRANT`` later
-    would bypass the allow-list exactly as before and nobody would notice, because
-    both are grant families that survive any restrictive allow-list. This test is
-    what makes the literal safe — it fails the moment a new one appears."""
-    from pocketpaw.agents.claude_sdk import POCKET_CREATION_GRANT
-    from pocketpaw.agents.sdk_mcp_widgets import WIDGET_TOOL_IDS
-
-    profile = resolve_profile(SurfaceKind.CODE, SurfaceMeta())
-
-    missing_widgets = frozenset(WIDGET_TOOL_IDS) - profile.deny_mcp_tool_ids
-    assert not missing_widgets, (
-        f"ripple widget tools not denied on /code: {sorted(missing_widgets)}. "
-        f"WIDGET_TOOL_IDS is unioned into the MCP grant in claude_sdk, so it "
-        f"survives allow_mcp_tool_ids — add these to _CODE_POCKET_DENY."
-    )
-
-    missing_grant = POCKET_CREATION_GRANT - profile.deny_mcp_tool_ids
-    assert not missing_grant, (
-        f"pocket-creation grant tools not denied on /code: {sorted(missing_grant)}. "
-        f"POCKET_CREATION_GRANT bypasses every restrictive allow-list by design — "
-        f"add these to _CODE_POCKET_DENY."
-    )
+# NOTE (2026-07-24, CX-4): the "/code must not BUILD A POCKET" guarantee no longer
+# lives at the SURFACE level and so is no longer asserted here. It used to be
+# enforced by the surface profile's ``_CODE_POCKET_DENY`` MCP deny-list, which this
+# file pinned via ``test_code_profile_builds_no_pocket_in_the_effective_allowlist``
+# and ``test_code_deny_covers_every_widget_tool_and_the_pocket_creation_grant``.
+# Both were REMOVED with the deny-list: MCP tool restriction for /code is now
+# enforced structurally by the dedicated ``code`` agent's exclusive tool policy
+# (``tool_mode="exclusive"`` caps the run's ``mcp__*`` surface to exactly the four
+# file ids). The pocket repro dying at the allowlist level is now proven end to end
+# in ``tests/cloud/agents/test_code_agent_seed.py::
+# test_seeded_code_agent_config_drives_exclusive_allowlist``. What THIS surface
+# profile still owns — and still tests below — is the BUILT-IN tools the MCP cap
+# cannot reach: the file/shell built-ins + ``Agent`` (``_CODE_BUILTIN_DENY``) and
+# ``Skill`` (``_CODE_SKILL_DENY``).
 
 
 def test_code_profile_is_static_and_meta_independent() -> None:


### PR DESCRIPTION
## Why

Stacked on #1780. Now that the `/code` surface routes to a dedicated agent whose exclusive tool policy caps every run to the four file tools, the CODE surface's MCP pocket deny-list is doing work the agent already guarantees.

## What changed

Removed `_CODE_POCKET_DENY` (the `mcp__` pocket / planner / widget deny-list) from the CODE profile. Every id it named is an `mcp__` id, and the code agent's `tool_mode="exclusive"` policy strips all `mcp__` ids outside its declared set before the SDK launches. The deny-list can no longer change the outcome on a `/code` run.

## What deliberately stayed

`_CODE_BUILTIN_DENY` (Bash/Read/Write/Edit/Glob/Grep/Agent) and `_CODE_SKILL_DENY` (`Skill`) are unchanged. These deny **built-in** tools, and the exclusive-tool cap only filters `mcp__` ids — it does not touch built-ins. `Skill` in particular still matters: the bundled `pocketpaw-create-pocket` skill loads as an SDK plugin regardless of the agent's skill set, and its description matches "build an employee management app with components and a nice design" almost verbatim. With the pocket MCP tools capped it can no longer build anything, but leaving `Skill` open would let that skill fire on the repro prompt and waste a turn. So it stays.

The surface comments now spell out the division of labor: MCP restriction comes from the agent's exclusive policy; the surface only denies the built-ins the cap can't reach.

## Note on the original plan

The task list originally paired `_CODE_POCKET_DENY` and `_CODE_SKILL_DENY` for removal. That was based on the premise that suppressing the grant covers everything — true for MCP tools, not for the `Skill` built-in. Only the MCP deny is removed here.

## Tests

`tests/cloud/surface/ tests/ee/agent/test_code_mcp_server.py tests/cloud/agents/test_code_agent_seed.py` → 56 CODE-scoped tests pass. Verified: the effective `/code` allowlist is still exactly the four file tools (now agent-enforced), and `Skill` + the built-ins remain in the CODE deny set. Removed the two obsolete surface-level pocket-guard tests and left a note pointing to where the guarantee now lives.

## Base

Stacked on `feat/code-agent-exclusive-tools` (#1780).
