### PR TITLE
Make CodeProject the real durable, project-keyed store

### DIFF
--- a/ee/pocketpaw_ee/cloud/codeproject/domain.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/domain.py
@@ -9,9 +9,16 @@
 # and ``is_scaffold_provider`` — the named test for "this project's ``repo`` field
 # holds a TEMPLATE id, not a repo IDENTITY". ``create_project``'s idempotency
 # reads it to decide whether a second create is the same project or a new one.
+#
+# Modified 2026-07-24 (feat/code-durable-project-store): added ``overlay`` to
+# CodeProjectView so the project-keyed durability path can read the snapshot +
+# overlay tiers off a single ``get_project`` (mirrors how WebSandboxView carries
+# ``overlay`` for websandbox restore). Like WebSandbox, overlay is view-only — it
+# is NOT surfaced on the wire ``CodeProjectResponse``; it is internal durability
+# bookkeeping, not a client-facing field.
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import NewType
 
@@ -66,6 +73,9 @@ class CodeProjectView:
     updated_at: datetime
     # Durable blob-storage snapshot pointer — the project's files between VMs.
     snapshot_file_id: str | None = None
+    # The write-through per-file durability overlay (``relpath -> FileRecord id``),
+    # keyed on the project. View-only, mirroring WebSandboxView — not on the wire.
+    overlay: dict[str, str] = field(default_factory=dict)
     # The current ephemeral sandbox (a WebSandbox row id), null when none is live.
     current_sandbox_id: str | None = None
     last_opened_at: datetime | None = None

--- a/ee/pocketpaw_ee/cloud/codeproject/service.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/service.py
@@ -22,6 +22,19 @@
 # older project, and the projects tab still showed one row. Scaffold providers
 # now always insert; identity providers keep the existing behaviour exactly, so a
 # returning user still lands back on the same ``/code/<id>`` for a repo.
+#
+# Modified 2026-07-24 (feat/code-durable-project-store): added the project-keyed
+# durability pointer ops — ``set_project_snapshot`` (records the S3 snapshot
+# pointer and CLEARS the overlay, since a full snapshot supersedes it),
+# ``set_project_overlay_entry`` / ``drop_project_overlay_entry`` /
+# ``move_project_overlay_entry`` (the incremental per-file tier). These mirror the
+# WebSandbox service ops one-for-one but anchor the pointer on the durable PROJECT
+# row instead of the ephemeral sandbox row, so a project's files round-trip
+# through blob storage independent of any runtime. All are owner-scoped (Rule 7),
+# and all are ``# no-event:`` durability bookkeeping (same reasoning as
+# ``set_snapshot`` on WebSandbox — no lifecycle transition to announce). This
+# module stays the sole writer of the CodeProject doc (Rule 2). The orchestration
+# that drives them (tar/untar + S3 upload) lives in ``websandbox/durability.py``.
 from __future__ import annotations
 
 import logging
@@ -91,6 +104,7 @@ def _doc_to_view(doc: _CodeProjectDoc) -> CodeProjectView:
         created_at=doc.created_at,
         updated_at=doc.updated_at,
         snapshot_file_id=doc.snapshot_file_id,
+        overlay=dict(doc.overlay or {}),
         current_sandbox_id=doc.current_sandbox_id,
         last_opened_at=doc.last_opened_at,
     )
@@ -324,6 +338,151 @@ async def bind_current_sandbox(
     return _doc_to_view(doc)
 
 
+# ---------------------------------------------------------------------------
+# Project-keyed durability pointers (feat/code-durable-project-store).
+#
+# The durable half of Code Mode's build-and-persist loop: a project's file
+# snapshot + per-file overlay live in the tenant's blob storage, and these ops
+# record/mutate the POINTERS on the durable project row. They mirror the
+# WebSandbox service ops (``set_snapshot`` / ``set_overlay_entry`` /
+# ``drop_overlay_entry`` / ``move_overlay_entry``) one-for-one, so the project
+# store behaves identically to the sandbox store — only the anchor differs. The
+# tar/untar + S3 upload orchestration that calls these lives in
+# ``websandbox/durability.py`` (the layer allowed to import EEUploadService);
+# this module stays the sole writer of the CodeProject doc (Rule 2). All are
+# owner-scoped (Rule 7 via ``_read_owned``) and ``# no-event:`` (durability
+# bookkeeping, not a lifecycle transition — same reasoning as WebSandbox's
+# ``set_snapshot``).
+# ---------------------------------------------------------------------------
+
+
+async def set_project_snapshot(
+    workspace_id: str,
+    user_id: str,
+    project_id: str,
+    file_id: str,
+) -> CodeProjectView:
+    """Record the durable project-snapshot pointer; clear the overlay.
+
+    Tenant- and owner-scoped (Rule 7 via ``_read_owned``): only the owning caller
+    can bind a snapshot to their own project. ``file_id`` is the blob-storage
+    ``FileRecord`` id produced by ``EEUploadService.upload`` in the durability
+    module — a durable pointer to the tarball of the project's files. A full
+    snapshot supersedes the incremental overlay, so the overlay is CLEARED here
+    (mirroring ``WebSandbox.set_snapshot``): everything the overlay held is now
+    inside the snapshot tar, and clearing it is what keeps restore from replaying
+    a stale write over a since-deleted file. Raises ``NotFound`` when no owned row
+    matches.
+    """
+    doc = await _read_owned(workspace_id, user_id, project_id)
+    if doc is None:
+        raise NotFound("code_project", project_id)
+    doc.snapshot_file_id = file_id
+    doc.overlay = {}
+    doc.updated_at = datetime.now(UTC)
+    await doc.save()
+    # no-event: the snapshot pointer is durability bookkeeping, not a lifecycle
+    # transition — no downstream handler reacts to it, and emitting a project
+    # event would falsely signal a state change to a projects-grid fan-out.
+    return _doc_to_view(doc)
+
+
+async def set_project_overlay_entry(
+    workspace_id: str,
+    user_id: str,
+    project_id: str,
+    rel_path: str,
+    file_id: str,
+) -> CodeProjectView:
+    """Record one write-through overlay entry (``rel_path -> FileRecord id``).
+
+    Tenant- and owner-scoped (Rule 7 via ``_read_owned``): only the owning caller
+    can mirror a file onto their own project. Called best-effort from the file
+    write path after the byte-for-byte VM write, so every editor save is durable
+    in blob storage the moment it lands — a crash / idle-out before the next full
+    snapshot no longer loses the edit. Last-write-wins per path. Raises
+    ``NotFound`` when no owned row matches.
+    """
+    doc = await _read_owned(workspace_id, user_id, project_id)
+    if doc is None:
+        raise NotFound("code_project", project_id)
+    # Reassign (not in-place mutate) so Beanie always sees the field as dirty.
+    overlay = dict(doc.overlay or {})
+    overlay[rel_path] = file_id
+    doc.overlay = overlay
+    doc.updated_at = datetime.now(UTC)
+    await doc.save()
+    # no-event: incremental durability bookkeeping, same reasoning as set_project_snapshot.
+    return _doc_to_view(doc)
+
+
+async def drop_project_overlay_entry(
+    workspace_id: str,
+    user_id: str,
+    project_id: str,
+    rel_path: str,
+) -> CodeProjectView:
+    """Drop overlay entries for ``rel_path`` (and anything under it) from a project.
+
+    Tenant- and owner-scoped (Rule 7 via ``_read_owned``). Called best-effort from
+    the file delete path after the VM delete: DROPPING an overlay entry is always
+    safe — it just falls back to the snapshot tier on restore, and it stops a
+    since-deleted file being resurrected from the overlay. A directory delete
+    drops every child under ``rel_path + '/'`` too. Raises ``NotFound`` when no
+    owned row matches.
+    """
+    doc = await _read_owned(workspace_id, user_id, project_id)
+    if doc is None:
+        raise NotFound("code_project", project_id)
+    prefix = rel_path.rstrip("/") + "/"
+    # Reassign (not in-place mutate) so Beanie always sees the field as dirty.
+    overlay = {
+        k: v for k, v in (doc.overlay or {}).items() if k != rel_path and not k.startswith(prefix)
+    }
+    doc.overlay = overlay
+    doc.updated_at = datetime.now(UTC)
+    await doc.save()
+    # no-event: incremental durability bookkeeping, same reasoning as set_project_snapshot.
+    return _doc_to_view(doc)
+
+
+async def move_project_overlay_entry(
+    workspace_id: str,
+    user_id: str,
+    project_id: str,
+    src: str,
+    dst: str,
+) -> CodeProjectView:
+    """Re-key overlay entries from ``src`` to ``dst`` (rename == move).
+
+    Tenant- and owner-scoped (Rule 7 via ``_read_owned``). Called best-effort from
+    the file move path after the VM move. The re-key is safe: the FileRecord id
+    (the actual blob) is unchanged — only its overlay KEY moves — so restore
+    replays the same content at the file's new path. A directory move re-keys
+    every child under ``src + '/'`` to the matching ``dst + '/'`` path; a path
+    with no overlay entry is a clean no-op. Raises ``NotFound`` when no owned row
+    matches.
+    """
+    doc = await _read_owned(workspace_id, user_id, project_id)
+    if doc is None:
+        raise NotFound("code_project", project_id)
+    src_prefix = src.rstrip("/") + "/"
+    dst_prefix = dst.rstrip("/") + "/"
+    overlay: dict[str, str] = {}
+    for k, v in (doc.overlay or {}).items():
+        if k == src:
+            overlay[dst] = v
+        elif k.startswith(src_prefix):
+            overlay[dst_prefix + k[len(src_prefix) :]] = v
+        else:
+            overlay[k] = v
+    doc.overlay = overlay
+    doc.updated_at = datetime.now(UTC)
+    await doc.save()
+    # no-event: incremental durability bookkeeping, same reasoning as set_project_snapshot.
+    return _doc_to_view(doc)
+
+
 async def _read_owned(
     workspace_id: str,
     user_id: str,
@@ -349,8 +508,12 @@ __all__ = [
     "bind_current_sandbox",
     "create_project",
     "delete_project",
+    "drop_project_overlay_entry",
     "get_project",
     "list_projects",
+    "move_project_overlay_entry",
     "rename_project",
+    "set_project_overlay_entry",
+    "set_project_snapshot",
     "view_to_wire",
 ]

--- a/ee/pocketpaw_ee/cloud/models/code_project.py
+++ b/ee/pocketpaw_ee/cloud/models/code_project.py
@@ -30,6 +30,17 @@ needed).
 Relation to WebSandbox: WebSandbox stays the EPHEMERAL runtime row (Daytona VM +
 lifecycle); CodeProject is the durable owner and points at the current one via
 ``current_sandbox_id`` (the WebSandbox row id), null when none is live.
+
+Modified 2026-07-24 (feat/code-durable-project-store): added ``overlay`` — the
+incremental per-file durability tier, keyed on the PROJECT rather than the
+ephemeral WebSandbox row. Mirrors ``WebSandbox.overlay`` (``relpath ->
+FileRecord id``): each mirrored editor save records an entry here, ``restore``
+replays them onto a fresh clone, and ``set_project_snapshot`` CLEARS it (a full
+snapshot supersedes the overlay, and clearing on snapshot is what avoids
+replaying a stale write over a since-deleted file). This makes a project-keyed
+durable store — snapshot pointer + overlay — that round-trips through S3
+independent of any runtime. Additive: the sandbox-keyed WebSandbox durability
+path is unchanged. No new index — read only via the owner-scoped project row.
 """
 
 from __future__ import annotations
@@ -72,6 +83,13 @@ class CodeProject(Document):
     # The project's files live HERE between sandboxes — this is why the project
     # survives VM reaping. Null until the first backup.
     snapshot_file_id: str | None = None
+    # The write-through per-file durability overlay, keyed on the PROJECT (mirrors
+    # ``WebSandbox.overlay``): ``relpath -> FileRecord id`` for each editor-saved
+    # file mirrored to blob storage since the last full project snapshot. Replayed
+    # onto a fresh clone on restore; cleared by ``set_project_snapshot`` (a full
+    # snapshot supersedes it). Null until the first mirror. No new index — read
+    # only via the owner-scoped project row.
+    overlay: dict[str, str] = Field(default_factory=dict)
     # The CURRENT ephemeral sandbox (a WebSandbox row id), or null when none is
     # live (never opened, or the VM was reaped). ``open_project`` resolves this.
     current_sandbox_id: str | None = None

--- a/ee/pocketpaw_ee/cloud/websandbox/durability.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/durability.py
@@ -49,6 +49,21 @@
 # Both take DI seams (``client=None`` → get_daytona_client, ``uploads=None`` →
 # a per-call EEUploadService) so tests inject fakes and never hit real Daytona
 # or S3.
+#
+# Changed 2026-07-24 (F, feat/code-durable-project-store): added the PROJECT-KEYED
+# sibling path — ``snapshot_project`` / ``restore_project`` / ``mirror_file_to_project``
+# / ``drop_project_overlay`` / ``move_project_overlay``. Same S3 vehicle, same VM
+# tar/untar mechanics, same DI seams; only the POINTER anchor differs — these
+# read/write the snapshot + overlay via ``codeproject/service`` (on the durable
+# CodeProject row) instead of ``websandbox/service`` (on the ephemeral WebSandbox
+# row), so a project's files round-trip through blob storage independent of any
+# runtime and independent of the WebSandbox row. The VM to snapshot/restore is
+# passed as an explicit Daytona ``sandbox_id`` (not resolved from a WebSandbox
+# row), the runtime-agnostic seam B2 will wire up. ADDITIVE: the sandbox-keyed
+# functions above are untouched. The project-keyed durable WRITE path
+# (``snapshot_project`` / ``mirror_file_to_project``) hard-requires S3 in cloud
+# via ``_require_s3_for_project_store`` — silent non-persistence to local disk is
+# worse than a loud 503.
 from __future__ import annotations
 
 import io
@@ -58,11 +73,21 @@ from pathlib import Path
 from typing import Any
 
 from pocketpaw_ee.cloud._core.errors import CloudError, ConflictError, with_cause
+from pocketpaw_ee.cloud.codeproject import service as codeproject_service
 from pocketpaw_ee.cloud.daytona.client import DaytonaClient, get_daytona_client
+from pocketpaw_ee.cloud.shared.db import is_multi_tenant_cloud
 from pocketpaw_ee.cloud.websandbox import service as websandbox_service
 from pocketpaw_ee.cloud.websandbox.constants import WEBSANDBOX_WORKDIR
 
 logger = logging.getLogger(__name__)
+
+# Blob-storage folders for the project-keyed durable store — grouped separately
+# from the sandbox-keyed ``/websandbox-*`` folders so a tenant's project
+# snapshots/overlay are distinguishable in their Files.
+_PROJECT_SNAPSHOT_FOLDER = "/code-project-snapshots"
+_PROJECT_OVERLAY_FOLDER = "/code-project-overlay"
+
+_TRUTHY = {"1", "true", "yes", "on"}
 
 # The in-VM staging path for the tarball (outside the workspace dir so it never
 # tars itself and a stale copy never re-enters a future snapshot).
@@ -476,11 +501,342 @@ async def move_overlay(
     await websandbox_service.move_overlay_entry(workspace_id, user_id, row_id, src_rel, dst_rel)
 
 
+# ===========================================================================
+# Project-keyed durable store (F, feat/code-durable-project-store).
+#
+# The durable half of the /code build-and-persist loop. Same S3 vehicle and VM
+# tar/untar as the sandbox-keyed path above; the ONLY difference is the pointer
+# anchor — snapshot + overlay live on the durable ``CodeProject`` row (via
+# ``codeproject/service``), so a project's files survive VM reaping and any
+# WebSandbox row. The VM is passed as an explicit Daytona ``sandbox_id`` rather
+# than resolved from a WebSandbox row, keeping this independent of the ephemeral
+# runtime row (B2 will wire the resolution). Tenancy is enforced by the
+# owner-scoped ``get_project`` (a project the caller doesn't own reads as
+# NotFound).
+# ===========================================================================
+
+
+def _require_s3_for_project_store() -> None:
+    """Hard-require S3-backed blob storage for the durable project store in cloud.
+
+    The ART-4 boot guard (``uploads/bootstrap.verify_cloud_storage_backend``) only
+    WARNs on a non-s3 adapter unless ``POCKETPAW_REQUIRE_S3_IN_CLOUD`` is set. For
+    the durable PROJECT store a warn is not enough: a project-keyed write that
+    lands on the box's local disk instead of the tenant's object store looks like
+    it persisted but is gone with the container — silent non-persistence, worse
+    than a loud failure. So the project-keyed durable WRITE path fails CLOSED —
+    a clean 503 ``CloudError`` (not a crash) — when running in cloud
+    (``is_multi_tenant_cloud()``, the same signal the jail and ART-4 guard read)
+    and ``POCKETPAW_UPLOAD_ADAPTER`` is not ``s3``.
+
+    No-op OFF multi-tenant cloud (OSS / dedicated installs never initialized the
+    cloud DB): there is no tenant object store to require, so local-disk uploads
+    are correct there and this must not raise.
+    """
+    if not is_multi_tenant_cloud():
+        return
+    adapter = os.environ.get("POCKETPAW_UPLOAD_ADAPTER", "local").strip().lower()
+    if adapter == "s3":
+        return
+    raise CloudError(
+        503,
+        "codeproject.durable_store_requires_s3",
+        "The durable project store requires S3-backed blob storage in cloud "
+        f"(POCKETPAW_UPLOAD_ADAPTER={adapter!r}, expected 's3'); a local adapter "
+        "writes project snapshots to the box's disk, which vanishes with the "
+        "container. Set POCKETPAW_UPLOAD_ADAPTER=s3 and the S3_* settings.",
+    )
+
+
+async def _upload_project_blob(
+    uploads: Any,
+    data: bytes,
+    *,
+    workspace_id: str,
+    user_id: str,
+    filename: str,
+    folder: str,
+    content_type: str,
+) -> str:
+    """Land bytes in the tenant's blob storage; return the FileRecord id.
+
+    The project-keyed analog of ``_upload_snapshot`` / ``mirror_file``'s inline
+    upload — a single wrapper both project write paths share, so the sandbox-keyed
+    helpers stay untouched. Wraps the bytes in a Starlette ``UploadFile`` (a dict
+    ``headers`` carrying the declared content-type is all ``UploadFile.content_type``
+    reads) and calls the workspace + owner-scoped ``upload`` (the ART-4 S3 path).
+    """
+    from fastapi import UploadFile
+
+    upload = UploadFile(
+        file=io.BytesIO(data),
+        filename=filename,
+        headers={"content-type": content_type},  # type: ignore[arg-type]
+    )
+    rec = await uploads.upload(
+        upload,
+        owner_id=user_id,
+        chat_id=None,
+        workspace=workspace_id,
+        folder_path=folder,
+    )
+    return rec.id
+
+
+async def snapshot_project(
+    workspace_id: str,
+    user_id: str,
+    project_id: str,
+    sandbox_id: str,
+    *,
+    client: DaytonaClient | None = None,
+    uploads: Any = None,
+) -> str:
+    """Snapshot a project's live VM workspace to blob storage; return the pointer.
+
+    Mirrors ``snapshot_workspace`` but anchors the pointer on the durable
+    ``CodeProject`` row. Resolves the project owner-scoped (``get_project`` raises
+    ``NotFound`` for a project the caller doesn't own), then ``tar -czf`` the
+    workspace dir in ``sandbox_id`` → ``download_file`` the tarball → size-cap →
+    upload to S3 (folder ``/code-project-snapshots``) → ``set_project_snapshot``
+    the returned FileRecord id (which also clears the overlay). Returns that id.
+
+    The ``sandbox_id`` is the live Daytona VM to snapshot, passed explicitly (not
+    resolved from a WebSandbox row) so this stays independent of the ephemeral
+    runtime row. Fails CLOSED on a non-s3 upload adapter in cloud before any VM
+    op. A tarball over the size cap raises a clean CloudError before any upload.
+    """
+    _require_s3_for_project_store()
+    daytona = _require_client(client)
+
+    # Owner-scoped tenancy gate: NotFound for a project the caller doesn't own.
+    await codeproject_service.get_project(workspace_id, user_id, project_id)
+
+    try:
+        await daytona.execute_command(
+            sandbox_id,
+            f"tar -czf {_SNAPSHOT_TMP} -C {WEBSANDBOX_WORKDIR} .",
+        )
+        data = await daytona.download_file(sandbox_id, _SNAPSHOT_TMP)
+    except Exception as exc:  # noqa: BLE001 — any VM-side failure is uniform
+        logger.warning(
+            "codeproject.snapshot: tar/download failed for project=%s", project_id, exc_info=True
+        )
+        raise with_cause(
+            CloudError(502, "codeproject.snapshot_failed", "Failed to snapshot the project"),
+            exc,
+        ) from exc
+
+    cap = _snapshot_max_bytes()
+    if len(data) > cap:
+        raise CloudError(
+            413,
+            "codeproject.snapshot_too_large",
+            f"Project snapshot is {len(data) / 1024 / 1024:.1f} MB, over the "
+            f"{cap / 1024 / 1024:.0f} MB limit",
+        )
+
+    up = uploads if uploads is not None else build_uploads()
+    file_id = await _upload_project_blob(
+        up,
+        data,
+        workspace_id=workspace_id,
+        user_id=user_id,
+        filename=f"code-project-snapshot-{project_id}.tgz",
+        folder=_PROJECT_SNAPSHOT_FOLDER,
+        content_type=_SNAPSHOT_MIME,
+    )
+    await codeproject_service.set_project_snapshot(workspace_id, user_id, project_id, file_id)
+    logger.info(
+        "codeproject.snapshot: project=%s daytona=%s -> file=%s (%d bytes)",
+        project_id,
+        sandbox_id,
+        file_id,
+        len(data),
+    )
+    return file_id
+
+
+async def restore_project(
+    workspace_id: str,
+    user_id: str,
+    project_id: str,
+    sandbox_id: str,
+    *,
+    client: DaytonaClient | None = None,
+    uploads: Any = None,
+) -> None:
+    """Restore a project's durable state into a (fresh) VM: snapshot then overlay.
+
+    Mirrors ``restore_workspace`` but reads the pointer off the durable
+    ``CodeProject`` row (via the owner-scoped ``get_project`` view — so it also
+    enforces tenancy). Applies the two tiers in order into ``sandbox_id``:
+      1. ``snapshot_file_id`` — the full-workspace tarball (baseline): fetched
+         from S3, ``upload_bytes`` into the VM, ``tar -xzf`` over the dir.
+      2. ``overlay`` — the write-through per-file tier (edits since the last
+         snapshot): each ``relpath -> FileRecord id`` is fetched and written over
+         the tree. Cleared whenever a snapshot is taken, so replay is always the
+         freshest source state, never a stale resurrection.
+
+    A project with NEITHER a snapshot nor an overlay is a clean 409 (nothing to
+    restore). No S3 guard here — restore is a READ path; the guard protects the
+    WRITE path so a project never silently persists to disk in the first place.
+    """
+    daytona = _require_client(client)
+
+    project = await codeproject_service.get_project(workspace_id, user_id, project_id)
+    overlay = project.overlay or {}
+    if not project.snapshot_file_id and not overlay:
+        raise ConflictError(
+            "codeproject.no_snapshot", "This project has no durable state to restore"
+        )
+
+    up = uploads if uploads is not None else build_uploads()
+
+    # Tier 1 — the full-workspace snapshot (baseline).
+    if project.snapshot_file_id:
+        data = await _download_snapshot(
+            up, project.snapshot_file_id, workspace_id=workspace_id, user_id=user_id
+        )
+        untar = f"mkdir -p {WEBSANDBOX_WORKDIR} && tar -xzf {_SNAPSHOT_TMP} -C {WEBSANDBOX_WORKDIR}"
+        try:
+            await daytona.upload_bytes(sandbox_id, data, _SNAPSHOT_TMP)
+            await daytona.execute_command(sandbox_id, untar)
+        except Exception as exc:  # noqa: BLE001 — any VM-side failure is uniform
+            logger.warning(
+                "codeproject.restore: snapshot untar failed for project=%s",
+                project_id,
+                exc_info=True,
+            )
+            raise with_cause(
+                CloudError(502, "codeproject.restore_failed", "Failed to restore the project"),
+                exc,
+            ) from exc
+        logger.info(
+            "codeproject.restore: project=%s daytona=%s <- snapshot=%s (%d bytes)",
+            project_id,
+            sandbox_id,
+            project.snapshot_file_id,
+            len(data),
+        )
+
+    # Tier 2 — replay the write-through overlay (freshest edits) over the tree.
+    replayed = 0
+    for rel_path, file_id in overlay.items():
+        abs_path = _overlay_abs_path(rel_path)
+        if abs_path is None:
+            logger.warning("codeproject.restore: skipping unsafe overlay path %r", rel_path)
+            continue
+        try:
+            file_bytes = await _download_snapshot(
+                up, file_id, workspace_id=workspace_id, user_id=user_id
+            )
+            parent = abs_path.rsplit("/", 1)[0]
+            await daytona.execute_command(sandbox_id, f"mkdir -p {parent}")
+            await daytona.upload_bytes(sandbox_id, file_bytes, abs_path)
+            replayed += 1
+        except Exception:  # noqa: BLE001 — one bad overlay file must not sink the rest
+            logger.warning(
+                "codeproject.restore: overlay replay failed for project=%s path=%r",
+                project_id,
+                rel_path,
+                exc_info=True,
+            )
+    if replayed:
+        logger.info(
+            "codeproject.restore: project=%s daytona=%s replayed %d overlay file(s)",
+            project_id,
+            sandbox_id,
+            replayed,
+        )
+
+
+async def mirror_file_to_project(
+    workspace_id: str,
+    user_id: str,
+    project_id: str,
+    rel_path: str,
+    data: bytes,
+    *,
+    uploads: Any = None,
+) -> str:
+    """Write-through one editor-saved file to blob storage; record the project overlay.
+
+    The project-keyed analog of ``mirror_file``: uploads the bytes to the tenant's
+    blob storage (folder ``/code-project-overlay``) and records ``rel_path ->
+    FileRecord id`` on the durable project via ``set_project_overlay_entry``.
+    Returns the FileRecord id. Fails CLOSED on a non-s3 upload adapter in cloud.
+    """
+    _require_s3_for_project_store()
+    up = uploads if uploads is not None else build_uploads()
+    basename = (rel_path or "file").rsplit("/", 1)[-1] or "file"
+    file_id = await _upload_project_blob(
+        up,
+        data,
+        workspace_id=workspace_id,
+        user_id=user_id,
+        filename=f"overlay-{project_id}-{basename}",
+        folder=_PROJECT_OVERLAY_FOLDER,
+        content_type="application/octet-stream",
+    )
+    await codeproject_service.set_project_overlay_entry(
+        workspace_id, user_id, project_id, rel_path, file_id
+    )
+    logger.debug(
+        "codeproject.mirror: project=%s path=%r -> file=%s (%d bytes)",
+        project_id,
+        rel_path,
+        file_id,
+        len(data),
+    )
+    return file_id
+
+
+async def drop_project_overlay(
+    workspace_id: str,
+    user_id: str,
+    project_id: str,
+    rel_path: str,
+) -> None:
+    """Drop the project overlay entry for a deleted file (delete-side sibling).
+
+    Delegates the doc write to the service (Rule 2). Dropping is always safe: the
+    file falls back to the snapshot tier on restore instead of being resurrected
+    from the overlay. A directory delete drops every child entry too.
+    """
+    await codeproject_service.drop_project_overlay_entry(
+        workspace_id, user_id, project_id, rel_path
+    )
+
+
+async def move_project_overlay(
+    workspace_id: str,
+    user_id: str,
+    project_id: str,
+    src_rel: str,
+    dst_rel: str,
+) -> None:
+    """Re-key the project overlay entry for a renamed file (move-side sibling).
+
+    Delegates the doc write to the service (Rule 2). The FileRecord id is
+    unchanged — only the overlay key moves — so restore replays the same durable
+    blob at the new path. A directory move re-keys every child entry too.
+    """
+    await codeproject_service.move_project_overlay_entry(
+        workspace_id, user_id, project_id, src_rel, dst_rel
+    )
+
+
 __all__ = [
     "build_uploads",
     "drop_overlay",
+    "drop_project_overlay",
     "mirror_file",
+    "mirror_file_to_project",
     "move_overlay",
+    "move_project_overlay",
+    "restore_project",
     "restore_workspace",
+    "snapshot_project",
     "snapshot_workspace",
 ]

--- a/tests/cloud/test_codeproject_durability.py
+++ b/tests/cloud/test_codeproject_durability.py
@@ -1,0 +1,410 @@
+# test_codeproject_durability.py — unit tests for the PROJECT-KEYED durable store
+# (F, feat/code-durable-project-store): S3 snapshot + per-file overlay anchored on
+# the durable CodeProject row, round-tripped through EEUploadService independent of
+# any runtime and independent of the ephemeral WebSandbox row.
+#
+# Created 2026-07-24 (feat/code-durable-project-store).
+#
+# All Daytona AND blob-storage interaction goes through FAKES injected via the DI
+# seams (``client=`` + ``uploads=``) — no test touches real Daytona or S3. The
+# CodeProject registry runs on real Beanie over mongomock-motor (the ``mongo_db``
+# fixture) so ``set_project_snapshot``'s owner-scoped write and ``get_project``'s
+# tenant filter are exercised for real. The VM to snapshot/restore is passed as an
+# explicit Daytona ``sandbox_id`` string (never resolved from a WebSandbox row) —
+# which is exactly how these tests prove "no WebSandbox row involved".
+#
+# Covers:
+#   * round-trip: snapshot + overlay write to a project by id, then restore the
+#     bytes byte-for-byte — with NO WebSandbox row created anywhere.
+#   * independence: two projects sharing the SAME starter ``repo`` in one
+#     workspace hold independent snapshot + overlay pointers (no collision).
+#   * snapshot clears the overlay (a full snapshot supersedes it).
+#   * overlay drop / move re-key the durable project pointer.
+#   * S3 guard: the project-keyed durable WRITE path RAISES a clean CloudError in
+#     cloud when the upload adapter isn't s3; does NOT raise on a non-cloud/OSS
+#     install.
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import CloudError
+from pocketpaw_ee.cloud.codeproject import service as codeproject_service
+from pocketpaw_ee.cloud.models.web_sandbox import WebSandbox as _WebSandboxDoc
+from pocketpaw_ee.cloud.websandbox import durability
+from pocketpaw_ee.cloud.websandbox.constants import WEBSANDBOX_WORKDIR
+
+from pocketpaw.uploads.errors import NotFound as UploadNotFound
+from pocketpaw.uploads.file_store import FileRecord
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+_WS = "w1"
+_USER = "u1"
+_SANDBOX = "dtn-1"  # a Daytona id passed straight in — no WebSandbox row behind it
+
+
+# ---------------------------------------------------------------------------
+# Fakes (same shape as the websandbox durability suite).
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeDaytonaClient:
+    tar_bytes: bytes = b"CANNED-TAR-BYTES"
+    exec_calls: list[str] = field(default_factory=list)
+    download_calls: list[str] = field(default_factory=list)
+    upload_calls: list[dict] = field(default_factory=list)
+
+    async def execute_command(self, sandbox_id, command, **kwargs):  # noqa: ANN001
+        self.exec_calls.append(command)
+        return None
+
+    async def download_file(self, sandbox_id, remote_path):  # noqa: ANN001
+        self.download_calls.append(remote_path)
+        return self.tar_bytes
+
+    async def upload_bytes(self, sandbox_id, data, remote_path):  # noqa: ANN001
+        self.upload_calls.append(
+            {"sandbox_id": sandbox_id, "data": data, "remote_path": remote_path}
+        )
+
+
+class _FakeUploads:
+    """In-memory stand-in for EEUploadService: records ``upload`` and serves the
+    bytes back on ``stream``. A single instance carries the blob so a snapshot
+    written here is readable by a later restore in the same test."""
+
+    def __init__(self) -> None:
+        self.upload_calls: list[dict] = []
+        self._blobs: dict[str, bytes] = {}
+        self._counter = 0
+
+    async def upload(self, file, owner_id, chat_id, workspace, folder_path="/", pocket_id=None):  # noqa: ANN001
+        data = await file.read()
+        self._counter += 1
+        file_id = f"file-{self._counter}"
+        self.upload_calls.append(
+            {
+                "owner_id": owner_id,
+                "workspace": workspace,
+                "folder_path": folder_path,
+                "filename": file.filename,
+                "content_type": file.content_type,
+                "data": data,
+            }
+        )
+        self._blobs[file_id] = data
+        return FileRecord(
+            id=file_id,
+            storage_key=f"key/{file_id}",
+            filename=file.filename,
+            mime="application/gzip",
+            size=len(data),
+            owner_id=owner_id,
+            chat_id=None,
+            created=datetime.now(UTC),
+        )
+
+    async def stream(self, file_id, requester_id, workspace):  # noqa: ANN001
+        if file_id not in self._blobs:
+            raise UploadNotFound()
+        data = self._blobs[file_id]
+        rec = FileRecord(
+            id=file_id,
+            storage_key=f"key/{file_id}",
+            filename="code-project-snapshot.tgz",
+            mime="application/gzip",
+            size=len(data),
+            owner_id=requester_id,
+            chat_id=None,
+            created=datetime.now(UTC),
+        )
+
+        async def _iter():
+            yield data
+
+        return rec, _iter()
+
+
+async def _project(workspace=_WS, user=_USER, repo="react", provider="starter", name=None):  # noqa: ANN001
+    """Create a durable project row (starter by default, so two share one repo)."""
+    body = {"repo": repo, "provider": provider}
+    if name is not None:
+        body["name"] = name
+    return await codeproject_service.create_project(workspace, user, body)
+
+
+# ---------------------------------------------------------------------------
+# Round-trip — snapshot + overlay written to a project, restored byte-for-byte,
+# with NO WebSandbox row involved.
+# ---------------------------------------------------------------------------
+
+
+async def test_snapshot_uploads_and_records_pointer_on_project() -> None:
+    project = await _project()
+    fake = _FakeDaytonaClient(tar_bytes=b"HELLO-SNAPSHOT")
+    uploads = _FakeUploads()
+
+    file_id = await durability.snapshot_project(
+        _WS, _USER, project.id, _SANDBOX, client=fake, uploads=uploads
+    )
+
+    # Tarred the workspace dir in the VM, then downloaded the tarball.
+    assert any("tar -czf" in c and WEBSANDBOX_WORKDIR in c for c in fake.exec_calls)
+    assert fake.download_calls == ["/tmp/ws-snapshot.tgz"]
+
+    # Uploaded the exact bytes, workspace + owner scoped, in the PROJECT snapshots
+    # folder — grouped separately from the sandbox-keyed folder.
+    assert len(uploads.upload_calls) == 1
+    up = uploads.upload_calls[0]
+    assert up["workspace"] == _WS
+    assert up["owner_id"] == _USER
+    assert up["folder_path"] == "/code-project-snapshots"
+    assert up["data"] == b"HELLO-SNAPSHOT"
+    assert up["content_type"] == "application/gzip"
+
+    # The durable pointer is returned AND persisted on the PROJECT row.
+    assert file_id == "file-1"
+    fetched = await codeproject_service.get_project(_WS, _USER, project.id)
+    assert fetched.snapshot_file_id == "file-1"
+
+    # No WebSandbox row was ever created — the store is project-keyed.
+    assert await _WebSandboxDoc.find_all().to_list() == []
+
+
+async def test_round_trip_snapshot_and_overlay_restores_bytes_no_websandbox() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+
+    # A disconnect snapshot (clears overlay), then a fresh session's edits mirror in.
+    await durability.snapshot_project(
+        _WS,
+        _USER,
+        project.id,
+        _SANDBOX,
+        client=_FakeDaytonaClient(tar_bytes=b"SNAP-DATA"),
+        uploads=uploads,
+    )
+    await durability.mirror_file_to_project(_WS, _USER, project.id, "a.ts", b"AAA", uploads=uploads)
+    await durability.mirror_file_to_project(
+        _WS, _USER, project.id, "dir/b.ts", b"BBB", uploads=uploads
+    )
+
+    # Restore into a FRESH VM (new fake client, brand-new Daytona id).
+    fresh = _FakeDaytonaClient()
+    await durability.restore_project(
+        _WS, _USER, project.id, "dtn-fresh", client=fresh, uploads=uploads
+    )
+
+    # Snapshot untarred first...
+    assert fresh.upload_calls[0]["remote_path"] == "/tmp/ws-snapshot.tgz"
+    assert fresh.upload_calls[0]["data"] == b"SNAP-DATA"
+    assert any("tar -xzf" in c and WEBSANDBOX_WORKDIR in c for c in fresh.exec_calls)
+
+    # ...then each overlay file written byte-for-byte into the jail at WORKDIR/relpath.
+    written = {u["remote_path"]: u["data"] for u in fresh.upload_calls}
+    assert written[f"{WEBSANDBOX_WORKDIR}/a.ts"] == b"AAA"
+    assert written[f"{WEBSANDBOX_WORKDIR}/dir/b.ts"] == b"BBB"
+    assert any(f"mkdir -p {WEBSANDBOX_WORKDIR}/dir" in c for c in fresh.exec_calls)
+
+    # The whole round-trip never touched a WebSandbox row.
+    assert await _WebSandboxDoc.find_all().to_list() == []
+
+
+async def test_mirror_records_overlay_and_snapshot_clears_it() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+
+    file_id = await durability.mirror_file_to_project(
+        _WS, _USER, project.id, "src/app.ts", b"console.log(1)", uploads=uploads
+    )
+    up = uploads.upload_calls[0]
+    assert up["folder_path"] == "/code-project-overlay"
+    assert up["data"] == b"console.log(1)"
+    assert file_id == "file-1"
+    assert (await codeproject_service.get_project(_WS, _USER, project.id)).overlay == {
+        "src/app.ts": "file-1"
+    }
+
+    # A full snapshot supersedes the incremental overlay → overlay is wiped.
+    await durability.snapshot_project(
+        _WS, _USER, project.id, _SANDBOX, client=_FakeDaytonaClient(), uploads=uploads
+    )
+    assert (await codeproject_service.get_project(_WS, _USER, project.id)).overlay == {}
+
+
+async def test_restore_overlay_only_no_snapshot() -> None:
+    project = await _project()
+    fake = _FakeDaytonaClient()
+    uploads = _FakeUploads()
+
+    await durability.mirror_file_to_project(
+        _WS, _USER, project.id, "only.ts", b"ONLY", uploads=uploads
+    )
+    await durability.restore_project(_WS, _USER, project.id, _SANDBOX, client=fake, uploads=uploads)
+
+    assert not any("tar -xzf" in c for c in fake.exec_calls)
+    written = {u["remote_path"]: u["data"] for u in fake.upload_calls}
+    assert written[f"{WEBSANDBOX_WORKDIR}/only.ts"] == b"ONLY"
+
+
+async def test_restore_with_neither_snapshot_nor_overlay_is_conflict() -> None:
+    project = await _project()
+    fake = _FakeDaytonaClient()
+    uploads = _FakeUploads()
+
+    with pytest.raises(CloudError) as exc:
+        await durability.restore_project(
+            _WS, _USER, project.id, _SANDBOX, client=fake, uploads=uploads
+        )
+    assert exc.value.code == "codeproject.no_snapshot"
+
+
+async def test_drop_project_overlay_removes_entry() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+    await durability.mirror_file_to_project(
+        _WS, _USER, project.id, "dir/a.ts", b"A", uploads=uploads
+    )
+    await durability.mirror_file_to_project(
+        _WS, _USER, project.id, "keep.ts", b"K", uploads=uploads
+    )
+
+    await durability.drop_project_overlay(_WS, _USER, project.id, "dir")
+
+    assert (await codeproject_service.get_project(_WS, _USER, project.id)).overlay == {
+        "keep.ts": "file-2"
+    }
+
+
+async def test_move_project_overlay_rekeys() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+    await durability.mirror_file_to_project(_WS, _USER, project.id, "a.ts", b"A", uploads=uploads)
+
+    await durability.move_project_overlay(_WS, _USER, project.id, "a.ts", "b.ts")
+
+    assert (await codeproject_service.get_project(_WS, _USER, project.id)).overlay == {
+        "b.ts": "file-1"
+    }
+
+
+# ---------------------------------------------------------------------------
+# Independence — two projects, one starter repo, one workspace: no collision.
+# ---------------------------------------------------------------------------
+
+
+async def test_two_projects_same_starter_hold_independent_state() -> None:
+    # Same workspace, same user, same starter template — two distinct projects
+    # (scaffold rows carry a per-row registry token, so they never dedupe).
+    todo = await _project(repo="react", provider="starter", name="todo")
+    blog = await _project(repo="react", provider="starter", name="blog")
+    assert todo.id != blog.id
+
+    uploads = _FakeUploads()
+    await durability.snapshot_project(
+        _WS, _USER, todo.id, _SANDBOX, client=_FakeDaytonaClient(tar_bytes=b"TODO"), uploads=uploads
+    )
+    await durability.mirror_file_to_project(_WS, _USER, todo.id, "todo.ts", b"T", uploads=uploads)
+    await durability.mirror_file_to_project(_WS, _USER, blog.id, "blog.ts", b"B", uploads=uploads)
+
+    todo_view = await codeproject_service.get_project(_WS, _USER, todo.id)
+    blog_view = await codeproject_service.get_project(_WS, _USER, blog.id)
+
+    # Snapshot landed only on todo; each overlay is the project's own.
+    assert todo_view.snapshot_file_id is not None
+    assert blog_view.snapshot_file_id is None
+    assert todo_view.overlay == {"todo.ts": "file-2"}
+    assert blog_view.overlay == {"blog.ts": "file-3"}
+
+
+# ---------------------------------------------------------------------------
+# Tenancy — a cross-tenant caller is denied before any VM/S3 op.
+# ---------------------------------------------------------------------------
+
+
+async def test_snapshot_denies_cross_tenant_caller() -> None:
+    project = await _project(workspace=_WS, user=_USER)
+    fake = _FakeDaytonaClient()
+    uploads = _FakeUploads()
+
+    from pocketpaw_ee.cloud._core.errors import NotFound
+
+    with pytest.raises(NotFound):
+        await durability.snapshot_project(
+            "w2", _USER, project.id, _SANDBOX, client=fake, uploads=uploads
+        )
+    assert fake.exec_calls == []
+    assert uploads.upload_calls == []
+
+
+# ---------------------------------------------------------------------------
+# S3 guard — the durable WRITE path fails closed in cloud without an s3 adapter,
+# but never raises off cloud (OSS / dedicated).
+# ---------------------------------------------------------------------------
+
+
+async def test_snapshot_write_raises_in_cloud_without_s3(monkeypatch) -> None:
+    project = await _project()
+    fake = _FakeDaytonaClient()
+    uploads = _FakeUploads()
+
+    # Force the multi-tenant-cloud signal on, and leave the adapter non-s3.
+    monkeypatch.setattr(durability, "is_multi_tenant_cloud", lambda: True)
+    monkeypatch.setenv("POCKETPAW_UPLOAD_ADAPTER", "local")
+
+    with pytest.raises(CloudError) as exc:
+        await durability.snapshot_project(
+            _WS, _USER, project.id, _SANDBOX, client=fake, uploads=uploads
+        )
+    assert exc.value.code == "codeproject.durable_store_requires_s3"
+    assert exc.value.status_code == 503
+    # Fails CLOSED before any VM or S3 op.
+    assert fake.exec_calls == []
+    assert uploads.upload_calls == []
+
+
+async def test_mirror_write_raises_in_cloud_without_s3(monkeypatch) -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+
+    monkeypatch.setattr(durability, "is_multi_tenant_cloud", lambda: True)
+    monkeypatch.setenv("POCKETPAW_UPLOAD_ADAPTER", "local")
+
+    with pytest.raises(CloudError) as exc:
+        await durability.mirror_file_to_project(
+            _WS, _USER, project.id, "a.ts", b"A", uploads=uploads
+        )
+    assert exc.value.code == "codeproject.durable_store_requires_s3"
+    assert uploads.upload_calls == []
+
+
+async def test_snapshot_write_ok_in_cloud_with_s3(monkeypatch) -> None:
+    project = await _project()
+    fake = _FakeDaytonaClient(tar_bytes=b"OK")
+    uploads = _FakeUploads()
+
+    monkeypatch.setattr(durability, "is_multi_tenant_cloud", lambda: True)
+    monkeypatch.setenv("POCKETPAW_UPLOAD_ADAPTER", "s3")
+
+    file_id = await durability.snapshot_project(
+        _WS, _USER, project.id, _SANDBOX, client=fake, uploads=uploads
+    )
+    assert file_id == "file-1"
+
+
+async def test_write_does_not_raise_off_cloud(monkeypatch) -> None:
+    # OSS / dedicated install: the cloud DB was never initialized, so the guard is
+    # a no-op even with a local adapter — local-disk uploads are correct there.
+    project = await _project()
+    uploads = _FakeUploads()
+
+    monkeypatch.setattr(durability, "is_multi_tenant_cloud", lambda: False)
+    monkeypatch.setenv("POCKETPAW_UPLOAD_ADAPTER", "local")
+
+    file_id = await durability.mirror_file_to_project(
+        _WS, _USER, project.id, "a.ts", b"A", uploads=uploads
+    )
+    assert file_id == "file-1"


### PR DESCRIPTION
## Why

First slice of the `/code` build-and-persist loop. Today `CodeProject` is *declared* durable — it has a `snapshot_file_id` field — but that pointer is never written; durability was attached to the ephemeral, repo-keyed `WebSandbox` row instead. This makes `CodeProject` the real durable store, anchored on the project id, so a project's files survive independent of any runtime.

This is the foundation the rest of the loop rides on (the build prompt and the file snapshots both persist here).

## What changed

Purely **additive** — the existing sandbox-keyed durability path is untouched (958 insertions, 1 deletion). The runtime cutover and data migration are a separate later task.

- **`CodeProject.overlay`** — a per-file overlay map mirroring `WebSandbox.overlay`, threaded onto the view (not the wire response, matching the WebSandbox precedent).
- **Project-keyed pointer ops** in `codeproject/service.py` — `set_project_snapshot` (sets `snapshot_file_id`, clears overlay), `set_project_overlay_entry`, `drop_project_overlay_entry`, `move_project_overlay_entry`. Owner-scoped, service stays the sole doc writer (ee/cloud rules).
- **Sibling durability functions** in `websandbox/durability.py` — `snapshot_project` / `restore_project` / `mirror_file_to_project` / `drop_project_overlay` / `move_project_overlay`. Same S3 vehicle (`EEUploadService`), same tar/untar and size cap, same DI seams (`uploads=None` for tests). Only the pointer anchor differs; the VM id is passed explicitly rather than resolved from a sandbox row (the runtime-agnostic seam the Daytona re-anchor will wire).
- **S3 hard-require guard** — the durable write path raises a clean 503 `CloudError` (`codeproject.durable_store_requires_s3`) when running in multi-tenant cloud with a non-S3 upload adapter. Silent non-persistence to local disk is worse than a loud failure. Reuses the existing `is_multi_tenant_cloud()` signal.

## Tests

`tests/cloud/test_codeproject_durability.py` (new, 15 tests) + existing durability/codeproject suites → **51 passed** locally. Covers: snapshot+overlay round-trips byte-for-byte with no `WebSandbox` row involved; two projects with the same starter `repo` hold independent state (no collision); the S3 guard fail-closes in cloud before any VM/S3 op and no-ops off cloud. Existing sandbox-keyed durability tests stay green.

## Not in this PR

- Repointing the Daytona `open_project`/`ws.py` hooks to the project store (the runtime cutover) — follow-up.
- Migrating existing `WebSandbox` overlays onto their projects — follow-up.
- Any frontend / build-turn / WebContainer work.

## Base

Stacked on `feat/code-mode-file-tools`.
