### PR TITLE
Persist the build prompt on the code project

### DIFF
--- a/ee/pocketpaw_ee/cloud/codeproject/domain.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/domain.py
@@ -16,6 +16,12 @@
 # ``overlay`` for websandbox restore). Like WebSandbox, overlay is view-only — it
 # is NOT surfaced on the wire ``CodeProjectResponse``; it is internal durability
 # bookkeeping, not a client-facing field.
+#
+# Modified 2026-07-24 (feat/code-initial-prompt): added ``initial_prompt`` and
+# ``initial_prompt_consumed`` to CodeProjectView. Unlike ``overlay`` these DO flow
+# to the wire (``initialPrompt`` / ``initialPromptConsumed``) — the frontend reads
+# the prompt on first open to auto-run one build turn and the consumed flag to
+# avoid re-running it.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -76,6 +82,11 @@ class CodeProjectView:
     # The write-through per-file durability overlay (``relpath -> FileRecord id``),
     # keyed on the project. View-only, mirroring WebSandboxView — not on the wire.
     overlay: dict[str, str] = field(default_factory=dict)
+    # The natural-language build prompt captured at create-from-description time
+    # (WHAT to build), and whether the auto-run build turn has been kicked off for
+    # it. Both flow to the wire, unlike ``overlay``.
+    initial_prompt: str | None = None
+    initial_prompt_consumed: bool = False
     # The current ephemeral sandbox (a WebSandbox row id), null when none is live.
     current_sandbox_id: str | None = None
     last_opened_at: datetime | None = None

--- a/ee/pocketpaw_ee/cloud/codeproject/dto.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/dto.py
@@ -11,6 +11,13 @@
 # runtime sandbox to connect to), reusing the websandbox contract. ``rename`` takes
 # a ``RenameProjectRequest`` and returns the updated ``CodeProjectResponse``;
 # ``delete`` takes only the path id and returns 204.
+#
+# Modified 2026-07-24 (feat/code-initial-prompt): ``CreateProjectRequest`` now
+# accepts an optional ``initial_prompt`` (the natural-language description of WHAT
+# to build a from-scratch ``/code`` project), and ``CodeProjectResponse`` exposes
+# ``initialPrompt`` + ``initialPromptConsumed`` so the frontend can auto-run one
+# build turn on first open and know when it's already been kicked off. Added
+# ``ConsumePromptRequest`` for the mark-consumed / re-arm PATCH route.
 from __future__ import annotations
 
 from pydantic import BaseModel, Field
@@ -27,6 +34,10 @@ class CreateProjectRequest(BaseModel):
     repo: str = Field(..., min_length=1, max_length=1024)
     name: str | None = Field(default=None, max_length=200)
     provider: str = Field(default="github", max_length=32)
+    # The natural-language description of WHAT to build, when this project is
+    # created from a prompt rather than an existing repo. Persisted verbatim; the
+    # frontend reads it back on first open to auto-run one build turn.
+    initial_prompt: str | None = Field(default=None, max_length=8000)
 
 
 class RenameProjectRequest(BaseModel):
@@ -39,6 +50,17 @@ class RenameProjectRequest(BaseModel):
     name: str = Field(..., min_length=1, max_length=200)
 
 
+class ConsumePromptRequest(BaseModel):
+    """Mark the project's initial build prompt consumed — or re-arm it.
+
+    Sent when a build turn STARTS (``consumed=True``, the default) so a reopen
+    doesn't re-run the same build; a retry-build path re-arms the prompt
+    (``consumed=False``). Setting the state it's already in is a clean no-op.
+    """
+
+    consumed: bool = True
+
+
 class CodeProjectResponse(BaseModel):
     id: str
     workspaceId: str
@@ -46,6 +68,8 @@ class CodeProjectResponse(BaseModel):
     name: str
     provider: str
     repo: str
+    initialPrompt: str | None = None
+    initialPromptConsumed: bool = False
     snapshotFileId: str | None = None
     currentSandboxId: str | None = None
     lastOpenedAt: str | None = None  # ISO-8601 UTC, or null
@@ -60,6 +84,7 @@ class CodeProjectListResponse(BaseModel):
 __all__ = [
     "CodeProjectListResponse",
     "CodeProjectResponse",
+    "ConsumePromptRequest",
     "CreateProjectRequest",
     "RenameProjectRequest",
 ]

--- a/ee/pocketpaw_ee/cloud/codeproject/router.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/router.py
@@ -13,9 +13,15 @@
 #   POST   /codeproject/{id}/open — resolve the project to a READY sandbox to connect
 #                                   to (reuse the bound one or provision a fresh one).
 #   PATCH  /codeproject/{id}      — rename a project's display name (owner-scoped).
+#   PATCH  /codeproject/{id}/consume-prompt — mark the initial build prompt consumed
+#                                   on build-turn start, or re-arm it on a retry.
 #   DELETE /codeproject/{id}      — delete a project + tear down its bound VM.
 # Like the WebSandbox router, endpoints are license-gated + context-authenticated;
 # the tenancy/owner filtering in the service is the security boundary.
+#
+# Modified 2026-07-24 (feat/code-initial-prompt): added the consume-prompt PATCH
+# route so the frontend can flip ``initial_prompt_consumed`` when it kicks off the
+# auto-run build turn (and re-arm it on a retry-build).
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, Response
@@ -27,6 +33,7 @@ from pocketpaw_ee.cloud.codeproject import service as codeproject_service
 from pocketpaw_ee.cloud.codeproject.dto import (
     CodeProjectListResponse,
     CodeProjectResponse,
+    ConsumePromptRequest,
     CreateProjectRequest,
     RenameProjectRequest,
 )
@@ -107,6 +114,24 @@ async def rename_project(
     """Rename a project's display name (owner-scoped)."""
     workspace_id = _require_workspace(ctx)
     view = await codeproject_service.rename_project(workspace_id, ctx.user_id, project_id, body)
+    return codeproject_service.view_to_wire(view)
+
+
+@router.patch("/{project_id}/consume-prompt", response_model=CodeProjectResponse)
+async def consume_prompt(
+    project_id: str,
+    body: ConsumePromptRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> CodeProjectResponse:
+    """Mark the initial build prompt consumed on build-turn start (owner-scoped).
+
+    ``consumed=True`` (the default) latches the prompt so a reopen doesn't re-run
+    the auto-build; ``consumed=False`` re-arms it for a retry-build. Idempotent.
+    """
+    workspace_id = _require_workspace(ctx)
+    view = await codeproject_service.mark_initial_prompt_consumed(
+        workspace_id, ctx.user_id, project_id, body
+    )
     return codeproject_service.view_to_wire(view)
 
 

--- a/ee/pocketpaw_ee/cloud/codeproject/service.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/service.py
@@ -35,6 +35,16 @@
 # ``set_snapshot`` on WebSandbox — no lifecycle transition to announce). This
 # module stays the sole writer of the CodeProject doc (Rule 2). The orchestration
 # that drives them (tar/untar + S3 upload) lives in ``websandbox/durability.py``.
+#
+# Modified 2026-07-24 (feat/code-initial-prompt): ``create_project`` now persists
+# the optional ``initial_prompt`` (the WHAT-to-build description) on an actual
+# INSERT only — a github idempotent hit returns the existing row untouched, so a
+# repeat create never overwrites a project's prompt. The prompt + its
+# ``initial_prompt_consumed`` flag flow doc -> view -> wire (mirroring
+# ``snapshot_file_id``). Added ``mark_initial_prompt_consumed`` — an owner-scoped
+# (Rule 7) op that sets the consumed flag on build-turn START and re-arms it to
+# False on a retry-build; idempotent (already-in-state is a clean no-op) and
+# ``# no-event:`` (a build-turn bookkeeping flag, not a lifecycle transition).
 from __future__ import annotations
 
 import logging
@@ -56,6 +66,7 @@ from pocketpaw_ee.cloud.codeproject.domain import (
 )
 from pocketpaw_ee.cloud.codeproject.dto import (
     CodeProjectResponse,
+    ConsumePromptRequest,
     CreateProjectRequest,
     RenameProjectRequest,
 )
@@ -105,6 +116,8 @@ def _doc_to_view(doc: _CodeProjectDoc) -> CodeProjectView:
         updated_at=doc.updated_at,
         snapshot_file_id=doc.snapshot_file_id,
         overlay=dict(doc.overlay or {}),
+        initial_prompt=doc.initial_prompt,
+        initial_prompt_consumed=doc.initial_prompt_consumed,
         current_sandbox_id=doc.current_sandbox_id,
         last_opened_at=doc.last_opened_at,
     )
@@ -119,6 +132,8 @@ def view_to_wire(view: CodeProjectView) -> CodeProjectResponse:
         name=view.name,
         provider=view.provider,
         repo=view.repo,
+        initialPrompt=view.initial_prompt,
+        initialPromptConsumed=view.initial_prompt_consumed,
         snapshotFileId=view.snapshot_file_id,
         currentSandboxId=view.current_sandbox_id,
         lastOpenedAt=view.last_opened_at.isoformat() if view.last_opened_at else None,
@@ -175,6 +190,11 @@ async def create_project(
         provider=body.provider,
         repo=body.repo,
         registry_key=_registry_key(body.provider),
+        # The WHAT-to-build description, recorded ONLY on this actual insert — an
+        # idempotent hit returned above unchanged, so a repeat create never
+        # overwrites an existing project's prompt.
+        initial_prompt=body.initial_prompt,
+        initial_prompt_consumed=False,
     )
     await doc.insert()
 
@@ -263,6 +283,41 @@ async def rename_project(
             }
         )
     )
+    return _doc_to_view(doc)
+
+
+async def mark_initial_prompt_consumed(
+    workspace_id: str,
+    user_id: str,
+    project_id: str,
+    body: ConsumePromptRequest | dict,
+) -> CodeProjectView:
+    """Set (or re-arm) the project's ``initial_prompt_consumed`` flag.
+
+    Tenant- and owner-scoped (Rule 7 via ``_read_owned``): a caller can only touch
+    a project they own; a foreign / missing id raises ``NotFound``. The frontend
+    calls this with ``consumed=True`` when a build turn STARTS so a reopen doesn't
+    re-run the same auto-build, and with ``consumed=False`` on a retry-build to
+    re-arm the prompt. Validated at entry (Rule 6). Idempotent: setting the flag to
+    the value it already holds writes nothing and returns the current view.
+    """
+    body = ConsumePromptRequest.model_validate(body)
+
+    doc = await _read_owned(workspace_id, user_id, project_id)
+    if doc is None:
+        raise NotFound("code_project", project_id)
+
+    if doc.initial_prompt_consumed == body.consumed:
+        # no-event: already in the requested state — nothing was written.
+        return _doc_to_view(doc)
+
+    doc.initial_prompt_consumed = body.consumed
+    doc.updated_at = datetime.now(UTC)
+    await doc.save()
+    # no-event: the consumed flag is build-turn bookkeeping the frontend owns end
+    # to end (it sets it on turn start, re-arms it on retry) — no downstream
+    # handler reacts to it, and a projects-grid fan-out must not read it as a
+    # lifecycle transition. Same reasoning as the durability pointer writes above.
     return _doc_to_view(doc)
 
 
@@ -511,6 +566,7 @@ __all__ = [
     "drop_project_overlay_entry",
     "get_project",
     "list_projects",
+    "mark_initial_prompt_consumed",
     "move_project_overlay_entry",
     "rename_project",
     "set_project_overlay_entry",

--- a/ee/pocketpaw_ee/cloud/models/code_project.py
+++ b/ee/pocketpaw_ee/cloud/models/code_project.py
@@ -41,6 +41,14 @@ replaying a stale write over a since-deleted file). This makes a project-keyed
 durable store — snapshot pointer + overlay — that round-trips through S3
 independent of any runtime. Additive: the sandbox-keyed WebSandbox durability
 path is unchanged. No new index — read only via the owner-scoped project row.
+
+Modified 2026-07-24 (feat/code-initial-prompt): added ``initial_prompt`` (the
+natural-language description of WHAT to build, captured when a ``/code`` project
+is created from a prompt) and ``initial_prompt_consumed`` (whether the auto-run
+build turn has already been kicked off for it). The frontend reads the prompt on
+first open to auto-run one build turn and flips ``consumed`` on turn START; a
+retry-build re-arms it. Both are nullable/defaulted so every existing row stays
+valid. No new index — read only via the owner-scoped project row.
 """
 
 from __future__ import annotations
@@ -90,6 +98,15 @@ class CodeProject(Document):
     # snapshot supersedes it). Null until the first mirror. No new index — read
     # only via the owner-scoped project row.
     overlay: dict[str, str] = Field(default_factory=dict)
+    # The natural-language build prompt captured when a ``/code`` project is
+    # created from a description — WHAT to build. Null for projects opened from an
+    # existing repo with nothing to auto-build. The frontend reads it on first open
+    # to auto-run one build turn.
+    initial_prompt: str | None = None
+    # Whether the auto-run build turn has been kicked off for ``initial_prompt``.
+    # Set True on build-turn START (so a reopen doesn't re-run it); a retry-build
+    # re-arms it to False. Independent of whether the build succeeded.
+    initial_prompt_consumed: bool = False
     # The CURRENT ephemeral sandbox (a WebSandbox row id), or null when none is
     # live (never opened, or the VM was reaped). ``open_project`` resolves this.
     current_sandbox_id: str | None = None

--- a/tests/cloud/test_codeproject.py
+++ b/tests/cloud/test_codeproject.py
@@ -342,3 +342,105 @@ async def test_a_git_repo_stays_idempotent() -> None:
 
     assert second.id == first.id
     assert len(await service.list_projects(_WS, _USER)) == 1
+
+
+# ---------------------------------------------------------------------------
+# initial build prompt — persist on create, expose on the wire, mark consumed.
+# ---------------------------------------------------------------------------
+#
+# A1 (feat/code-initial-prompt): creating a /code project from a description
+# records WHAT to build on the durable row, exposes it on the wire so the frontend
+# can auto-run one build turn on first open, and offers an owner-scoped op to latch
+# it consumed on turn start (re-armable on a retry-build).
+
+
+async def test_create_persists_initial_prompt_unconsumed_and_exposes_it() -> None:
+    view = await service.create_project(
+        _WS,
+        _USER,
+        {
+            "repo": _STARTER,
+            "provider": "starter",
+            "name": "todo app",
+            "initial_prompt": "build a todo app",
+        },
+    )
+    assert view.initial_prompt == "build a todo app"
+    assert view.initial_prompt_consumed is False
+
+    # It survives a reload and reaches the camelCase wire response.
+    reloaded = await service.get_project(_WS, _USER, view.id)
+    assert reloaded.initial_prompt == "build a todo app"
+    wire = service.view_to_wire(reloaded)
+    assert wire.initialPrompt == "build a todo app"
+    assert wire.initialPromptConsumed is False
+
+
+async def test_create_without_initial_prompt_leaves_it_null() -> None:
+    view = await service.create_project(_WS, _USER, {"repo": _REPO})
+    assert view.initial_prompt is None
+    assert view.initial_prompt_consumed is False
+    assert service.view_to_wire(view).initialPrompt is None
+
+
+async def test_github_idempotent_recreate_does_not_overwrite_prompt() -> None:
+    first = await service.create_project(
+        _WS, _USER, {"repo": _REPO, "initial_prompt": "the original prompt"}
+    )
+    # A second create for the same git repo is an idempotent hit — the existing
+    # row is returned UNCHANGED, so a stray prompt on the re-create can't clobber it.
+    second = await service.create_project(
+        _WS, _USER, {"repo": _REPO, "initial_prompt": "a different prompt"}
+    )
+    assert second.id == first.id
+    assert second.initial_prompt == "the original prompt"
+
+
+async def test_mark_initial_prompt_consumed_sets_true() -> None:
+    project = await service.create_project(
+        _WS, _USER, {"repo": _STARTER, "provider": "starter", "initial_prompt": "build it"}
+    )
+    assert project.initial_prompt_consumed is False
+
+    updated = await service.mark_initial_prompt_consumed(_WS, _USER, project.id, {})
+    assert updated.initial_prompt_consumed is True
+    # The prompt itself is untouched — only the flag flips.
+    assert updated.initial_prompt == "build it"
+    assert (await service.get_project(_WS, _USER, project.id)).initial_prompt_consumed is True
+
+
+async def test_mark_initial_prompt_consumed_can_reset() -> None:
+    project = await service.create_project(
+        _WS, _USER, {"repo": _STARTER, "provider": "starter", "initial_prompt": "build it"}
+    )
+    await service.mark_initial_prompt_consumed(_WS, _USER, project.id, {"consumed": True})
+    # A retry-build re-arms the prompt.
+    rearmed = await service.mark_initial_prompt_consumed(
+        _WS, _USER, project.id, {"consumed": False}
+    )
+    assert rearmed.initial_prompt_consumed is False
+
+
+async def test_mark_initial_prompt_consumed_already_consumed_is_noop() -> None:
+    project = await service.create_project(
+        _WS, _USER, {"repo": _STARTER, "provider": "starter", "initial_prompt": "build it"}
+    )
+    once = await service.mark_initial_prompt_consumed(_WS, _USER, project.id, {"consumed": True})
+    # Marking it consumed again is a clean no-op, not an error.
+    twice = await service.mark_initial_prompt_consumed(_WS, _USER, project.id, {"consumed": True})
+    assert once.initial_prompt_consumed is True
+    assert twice.initial_prompt_consumed is True
+
+
+async def test_mark_initial_prompt_consumed_is_owner_scoped() -> None:
+    mine = await service.create_project(
+        _WS, _USER, {"repo": _STARTER, "provider": "starter", "initial_prompt": "build it"}
+    )
+    # Another user in the same workspace can't consume my project's prompt.
+    with pytest.raises(NotFound):
+        await service.mark_initial_prompt_consumed(_WS, "user-2", mine.id, {"consumed": True})
+    # A different workspace can't either.
+    with pytest.raises(NotFound):
+        await service.mark_initial_prompt_consumed("ws-2", _USER, mine.id, {"consumed": True})
+    # Still un-consumed for the real owner — no cross-tenant write leaked through.
+    assert (await service.get_project(_WS, _USER, mine.id)).initial_prompt_consumed is False


### PR DESCRIPTION
## Why

Second slice of the `/code` build-and-persist loop. Today the create flow reads the user's description only to pick a framework and a name, then throws it away — so a project boots a bare scaffold with no memory of what it was supposed to be, and nothing can build it. This gives the durable row somewhere to keep that instruction.

Paired with paw-enterprise #TBD (the frontend that sends it).

## What changed

- **`CodeProject`** gains `initial_prompt` and `initial_prompt_consumed`.
- **`CreateProjectRequest`** accepts an optional `initial_prompt` (≤ 8000 chars). It is stored only on an actual insert, so a github idempotent re-create returns the existing row without clobbering its prompt.
- Both fields flow doc → view → camelCase wire (`initialPrompt` / `initialPromptConsumed`), mirroring how `snapshotFileId` already travels.
- **`PATCH /codeproject/{id}/consume-prompt`** with `{consumed: bool}` — owner-scoped. The frontend sets it true when a build turn starts, so a reopen doesn't rebuild, and false to re-arm on a retry. Already-in-state is a clean no-op.

Follows the ee/cloud rules: service is the sole `models.code_project` importer, validate at entry, tenant + owner filter on reads, `no-event` with a reason on the consume write (build-turn bookkeeping, not a lifecycle transition), `CloudError` rather than `HTTPException`.

## Tests

`tests/cloud/test_codeproject.py` → **27 passed** (8 new), plus the durability and registry-index suites green. Covers: create persists the prompt with `consumed=false` and exposes both on the wire; a create without one leaves it null; a github idempotent re-create does not overwrite an existing prompt; consume sets, re-arms, and no-ops idempotently; another workspace or user gets `NotFound`.

## Not in this PR

Auto-running the build turn on first open, and letting that build create files (both follow-ups). This PR only gives the prompt a durable home.

## Base

Stacked on `feat/code-durable-project-store` (#1782).
