### PR TITLE
Persist in-tab project edits through a per-file overlay

### DIFF
--- a/ee/pocketpaw_ee/cloud/codeproject/dto.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/dto.py
@@ -18,6 +18,13 @@
 # ``initialPrompt`` + ``initialPromptConsumed`` so the frontend can auto-run one
 # build turn on first open and know when it's already been kicked off. Added
 # ``ConsumePromptRequest`` for the mark-consumed / re-arm PATCH route.
+#
+# Modified 2026-07-25 (B1, feat/code-project-file-sync): added the browser-runtime
+# file-sync trio — ``PutProjectFileRequest`` (one client-written file),
+# ``ProjectFileWriteResponse`` (the acknowledged path + durable blob pointer) and
+# ``ProjectFilesResponse`` (the whole overlay as the restore payload). ``content``
+# is a string because the in-tab filesystem carries source text over JSON; the
+# byte ceiling lives in ``websandbox/durability.py`` next to the storage, not here.
 from __future__ import annotations
 
 from pydantic import BaseModel, Field
@@ -61,6 +68,45 @@ class ConsumePromptRequest(BaseModel):
     consumed: bool = True
 
 
+class PutProjectFileRequest(BaseModel):
+    """One file the in-browser runtime just wrote — its path and its text.
+
+    ``path`` is project-relative; the service normalizes it and rejects anything
+    that escapes the project (absolute paths, ``..`` traversal). ``content`` is
+    the whole file, last-write-wins per path — this is a write-through of an
+    editor save, not a patch. An empty string is a legitimate empty file.
+    """
+
+    path: str = Field(..., min_length=1, max_length=1024)
+    content: str = ""
+
+
+class ProjectFileWriteResponse(BaseModel):
+    """Acknowledgement of one persisted file.
+
+    ``path`` echoes back the NORMALIZED key the overlay actually stored (which
+    can differ from what the client sent — a leading slash is stripped), so the
+    client can key its own dirty-tracking on the same string the later delete
+    and read-back use.
+    """
+
+    ok: bool = True
+    path: str
+    fileId: str
+
+
+class ProjectFilesResponse(BaseModel):
+    """The project's whole persisted overlay: ``{relative path: file content}``.
+
+    The restore payload for the in-tab runtime. It carries the DELTA only — the
+    starter scaffold baseline is re-materialized client-side from the starter id,
+    so a project that has never been edited returns an empty map rather than the
+    scaffold.
+    """
+
+    files: dict[str, str]
+
+
 class CodeProjectResponse(BaseModel):
     id: str
     workspaceId: str
@@ -86,5 +132,8 @@ __all__ = [
     "CodeProjectResponse",
     "ConsumePromptRequest",
     "CreateProjectRequest",
+    "ProjectFileWriteResponse",
+    "ProjectFilesResponse",
+    "PutProjectFileRequest",
     "RenameProjectRequest",
 ]

--- a/ee/pocketpaw_ee/cloud/codeproject/router.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/router.py
@@ -16,15 +16,29 @@
 #   PATCH  /codeproject/{id}/consume-prompt — mark the initial build prompt consumed
 #                                   on build-turn start, or re-arm it on a retry.
 #   DELETE /codeproject/{id}      — delete a project + tear down its bound VM.
+#   PUT    /codeproject/{id}/file  — persist ONE file written by the in-browser
+#                                   runtime (write-through to blob storage).
+#   DELETE /codeproject/{id}/file  — drop one file so it isn't restored again.
+#   GET    /codeproject/{id}/files — the project's persisted overlay, the restore
+#                                   payload the in-tab runtime replays.
 # Like the WebSandbox router, endpoints are license-gated + context-authenticated;
 # the tenancy/owner filtering in the service is the security boundary.
 #
 # Modified 2026-07-24 (feat/code-initial-prompt): added the consume-prompt PATCH
 # route so the frontend can flip ``initial_prompt_consumed`` when it kicks off the
 # auto-run build turn (and re-arm it on a retry-build).
+#
+# Modified 2026-07-25 (B1, feat/code-project-file-sync): added the three file-sync
+# routes above. They exist because the in-tab (WebContainer) runtime writes to a
+# filesystem inside the browser that no backend hook can see — the Daytona path
+# mirrors edits from the ``file.write`` WebSocket verb, but in a tab there is no
+# VM to mirror out of, so the client itself has to push each write through and
+# pull the whole set back on a reopen. Storage lives in ``websandbox/durability.py``
+# (the layer allowed to touch EEUploadService); like the websandbox snapshot /
+# restore routes, this router calls it directly and stays a thin adapter.
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, Response
+from fastapi import APIRouter, Depends, Query, Response
 
 from pocketpaw_ee.cloud._core.context import RequestContext, request_context
 from pocketpaw_ee.cloud._core.errors import Forbidden
@@ -35,9 +49,13 @@ from pocketpaw_ee.cloud.codeproject.dto import (
     CodeProjectResponse,
     ConsumePromptRequest,
     CreateProjectRequest,
+    ProjectFilesResponse,
+    ProjectFileWriteResponse,
+    PutProjectFileRequest,
     RenameProjectRequest,
 )
 from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.websandbox import durability as websandbox_durability
 from pocketpaw_ee.cloud.websandbox import service as websandbox_service
 from pocketpaw_ee.cloud.websandbox.dto import WebSandboxResponse
 
@@ -133,6 +151,57 @@ async def consume_prompt(
         workspace_id, ctx.user_id, project_id, body
     )
     return codeproject_service.view_to_wire(view)
+
+
+# ---------------------------------------------------------------------------
+# B1 — project file sync for the in-browser runtime.
+# ---------------------------------------------------------------------------
+
+
+@router.put("/{project_id}/file", response_model=ProjectFileWriteResponse)
+async def put_project_file(
+    project_id: str,
+    body: PutProjectFileRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> ProjectFileWriteResponse:
+    """Persist one file the in-browser runtime wrote (owner-scoped).
+
+    Called on every editor / agent save in a tab-hosted project. Last-write-wins
+    per path: a second write to the same path replaces the overlay entry rather
+    than adding one.
+    """
+    workspace_id = _require_workspace(ctx)
+    path, file_id = await websandbox_durability.put_project_file(
+        workspace_id, ctx.user_id, project_id, body.path, body.content
+    )
+    return ProjectFileWriteResponse(ok=True, path=path, fileId=file_id)
+
+
+@router.delete("/{project_id}/file", status_code=204)
+async def delete_project_file(
+    project_id: str,
+    path: str = Query(..., min_length=1, max_length=1024),
+    ctx: RequestContext = Depends(request_context),
+) -> Response:
+    """Drop one persisted file so a reopen doesn't resurrect it (owner-scoped)."""
+    workspace_id = _require_workspace(ctx)
+    await websandbox_durability.drop_project_file(workspace_id, ctx.user_id, project_id, path)
+    return Response(status_code=204)
+
+
+@router.get("/{project_id}/files", response_model=ProjectFilesResponse)
+async def read_project_files(
+    project_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> ProjectFilesResponse:
+    """Read every persisted file back (owner-scoped) — the restore payload.
+
+    The delta only: the client re-materializes the starter scaffold from the
+    starter id, then replays this map over it.
+    """
+    workspace_id = _require_workspace(ctx)
+    files = await websandbox_durability.read_project_overlay(workspace_id, ctx.user_id, project_id)
+    return ProjectFilesResponse(files=files)
 
 
 @router.delete("/{project_id}", status_code=204)

--- a/ee/pocketpaw_ee/cloud/websandbox/durability.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/durability.py
@@ -64,6 +64,21 @@
 # (``snapshot_project`` / ``mirror_file_to_project``) hard-requires S3 in cloud
 # via ``_require_s3_for_project_store`` — silent non-persistence to local disk is
 # worse than a loud 503.
+#
+# Changed 2026-07-25 (B1, feat/code-project-file-sync): added the BROWSER-runtime
+# siblings — ``put_project_file`` / ``drop_project_file`` / ``read_project_overlay``.
+# Every project-keyed function above tars or untars a Daytona VM, i.e. the bytes
+# live in a VM the backend can reach. On the in-tab (WebContainer) runtime there is
+# no VM: the filesystem is in the user's browser, so the bytes arrive FROM the
+# client on a write and must be handed BACK to it on a reopen. These three close
+# that loop over the same two-tier model, minus the snapshot tier — the baseline is
+# the starter scaffold, deterministically re-materializable client-side from the
+# starter id and therefore never uploaded, so the overlay alone is the whole
+# durable delta. Restore = re-materialize the scaffold, then replay the overlay.
+# Same S3 vehicle, same ``_upload_project_blob``, same owner-scoped ``stream(...)``
+# read path ``restore_project`` uses, same ``_require_s3_for_project_store``
+# fail-closed guard on the write, same ``uploads=`` DI seam. ADDITIVE: nothing
+# above is touched.
 from __future__ import annotations
 
 import io
@@ -72,7 +87,12 @@ import os
 from pathlib import Path
 from typing import Any
 
-from pocketpaw_ee.cloud._core.errors import CloudError, ConflictError, with_cause
+from pocketpaw_ee.cloud._core.errors import (
+    CloudError,
+    ConflictError,
+    ValidationError,
+    with_cause,
+)
 from pocketpaw_ee.cloud.codeproject import service as codeproject_service
 from pocketpaw_ee.cloud.daytona.client import DaytonaClient, get_daytona_client
 from pocketpaw_ee.cloud.shared.db import is_multi_tenant_cloud
@@ -827,14 +847,238 @@ async def move_project_overlay(
     )
 
 
+# ===========================================================================
+# Browser-runtime project file sync (B1, feat/code-project-file-sync).
+#
+# The in-tab (WebContainer) runtime has no VM, so the three functions here are
+# the client-side counterparts of ``mirror_file_to_project`` /
+# ``drop_project_overlay`` / ``restore_project``: the bytes arrive from the
+# browser on a write and are streamed back to it on a reopen, instead of being
+# tarred out of and untarred into a Daytona VM.
+#
+# Only the OVERLAY tier is involved. The baseline is the starter scaffold, which
+# the client re-materializes deterministically from the starter id
+# (``codescaffold.compose``), so a fresh project stores nothing and the overlay
+# IS the durable delta. That also means these never write ``snapshot_file_id``:
+# ``set_project_snapshot`` clears the overlay, which would discard exactly the
+# state this path persists.
+# ===========================================================================
+
+# Read-back caps for the browser restore payload. The whole overlay is
+# materialized in memory as one JSON response, so both a per-file byte ceiling
+# and a file-count ceiling are enforced — a source tree is small, and an
+# unbounded read is a memory + latency hazard for the tab as much as the box.
+# Env-tunable in the same shape as ``POCKETPAW_WEBSANDBOX_SNAPSHOT_MAX_MB``.
+_DEFAULT_OVERLAY_MAX_MB = 10.0
+_DEFAULT_OVERLAY_MAX_FILES = 2000
+
+
+def _overlay_max_bytes() -> int:
+    """Overlay byte cap (``POCKETPAW_CODEPROJECT_OVERLAY_MAX_MB``).
+
+    Applied twice: as the per-file ceiling on a write (so one runaway file can
+    never land) and as the cumulative ceiling on the read-back (so the restore
+    payload stays bounded no matter how the overlay grew).
+    """
+    raw = os.environ.get("POCKETPAW_CODEPROJECT_OVERLAY_MAX_MB", "").strip()
+    mb = _DEFAULT_OVERLAY_MAX_MB
+    if raw:
+        try:
+            mb = float(raw)
+        except ValueError:
+            logger.warning(
+                "ignoring non-numeric POCKETPAW_CODEPROJECT_OVERLAY_MAX_MB=%r; using %s", raw, mb
+            )
+    return int(mb * 1024 * 1024)
+
+
+def _overlay_max_files() -> int:
+    """Overlay file-count cap (``POCKETPAW_CODEPROJECT_OVERLAY_MAX_FILES``)."""
+    raw = os.environ.get("POCKETPAW_CODEPROJECT_OVERLAY_MAX_FILES", "").strip()
+    count = _DEFAULT_OVERLAY_MAX_FILES
+    if raw:
+        try:
+            count = int(raw)
+        except ValueError:
+            logger.warning(
+                "ignoring non-numeric POCKETPAW_CODEPROJECT_OVERLAY_MAX_FILES=%r; using %s",
+                raw,
+                count,
+            )
+    return count
+
+
+def _require_safe_rel_path(rel_path: str) -> str:
+    """Normalize a client-supplied overlay path; reject anything that escapes.
+
+    The VM paths came out of the ``file.write`` jail; these come straight off the
+    wire, so the jail check moves to the write boundary. Leading slashes and
+    ``./`` segments are stripped (a client-side FS spells the same file both
+    ways, and the overlay key must be stable or a later delete won't match the
+    earlier write), while an empty path or any ``..`` traversal is a clean 422 —
+    the overlay key becomes a real path again on both restore paths
+    (``_overlay_abs_path`` in a VM, the client's FS in a tab).
+    """
+    candidate = (rel_path or "").strip().lstrip("/")
+    segments = [s for s in candidate.split("/") if s not in ("", ".")]
+    if not segments or any(s == ".." for s in segments):
+        raise ValidationError(
+            "codeproject.invalid_file_path",
+            f"{rel_path!r} is not a valid project-relative file path",
+        )
+    return "/".join(segments)
+
+
+async def put_project_file(
+    workspace_id: str,
+    user_id: str,
+    project_id: str,
+    rel_path: str,
+    content: str,
+    *,
+    uploads: Any = None,
+) -> tuple[str, str]:
+    """Persist one browser-written file; return ``(normalized path, FileRecord id)``.
+
+    The write half of the in-tab loop, and the counterpart of
+    ``mirror_file_to_project`` for a runtime whose filesystem the backend can't
+    read: the client hands us the text it just wrote to its in-tab FS and we
+    write it through to the tenant's blob storage + the project's overlay, so the
+    edit outlives the tab. Delegates to ``mirror_file_to_project`` so both
+    runtimes share ONE upload + pointer path (and therefore one S3 fail-closed
+    guard, one blob folder, one last-write-wins rule per path) — the only things
+    added here are the wire-facing concerns: path jailing and a size ceiling.
+
+    Text only, because the transport is a JSON string (the in-tab FS deals in
+    source files). Encoded UTF-8 so the read-back is byte-identical.
+    """
+    _require_s3_for_project_store()  # fail closed before validating or uploading
+    safe_path = _require_safe_rel_path(rel_path)
+    data = content.encode("utf-8")
+
+    cap = _overlay_max_bytes()
+    if len(data) > cap:
+        raise CloudError(
+            413,
+            "codeproject.file_too_large",
+            f"{safe_path!r} is {len(data) / 1024 / 1024:.1f} MB, over the "
+            f"{cap / 1024 / 1024:.0f} MB per-file limit",
+        )
+
+    file_id = await mirror_file_to_project(
+        workspace_id, user_id, project_id, safe_path, data, uploads=uploads
+    )
+    return safe_path, file_id
+
+
+async def drop_project_file(
+    workspace_id: str,
+    user_id: str,
+    project_id: str,
+    rel_path: str,
+) -> str:
+    """Drop a browser-deleted file from the project overlay; return the dropped path.
+
+    Normalizes through the SAME ``_require_safe_rel_path`` as the write so the
+    key actually matches what the write stored — a delete that missed would leave
+    the file to reappear on the next restore, which is the exact bug this tier
+    exists to prevent. Delegates the pointer write to ``drop_project_overlay``
+    (and through it to the service, Rule 2). A directory path drops every child.
+    """
+    safe_path = _require_safe_rel_path(rel_path)
+    await drop_project_overlay(workspace_id, user_id, project_id, safe_path)
+    return safe_path
+
+
+async def read_project_overlay(
+    workspace_id: str,
+    user_id: str,
+    project_id: str,
+    *,
+    uploads: Any = None,
+) -> dict[str, str]:
+    """Read a project's whole overlay back as ``{relpath: content}``.
+
+    The restore payload for the in-tab runtime, and the counterpart of
+    ``restore_project``'s tier-2 replay: instead of writing each blob into a VM,
+    it returns them to the client, which re-materializes the scaffold baseline
+    and replays this map over it. Owner-scoped through ``get_project`` (a project
+    the caller doesn't own reads as ``NotFound`` before any blob is touched), and
+    each blob comes back through the same owner-scoped ``stream(...)`` path
+    ``_download_snapshot`` wraps — a foreign or vanished blob can't be read out
+    of this endpoint.
+
+    Both caps fail LOUD rather than truncating: a silently partial restore looks
+    like the user's files were deleted, which is worse than a 413 that says the
+    project outgrew the in-browser runtime. Individually unreadable entries (a
+    reaped blob, a non-UTF-8 file the JSON transport can't carry) are skipped
+    with a warning instead — one bad file must not sink the rest, the same rule
+    ``restore_project`` replays under.
+    """
+    project = await codeproject_service.get_project(workspace_id, user_id, project_id)
+    overlay = project.overlay or {}
+    if not overlay:
+        return {}
+
+    max_files = _overlay_max_files()
+    if len(overlay) > max_files:
+        raise CloudError(
+            413,
+            "codeproject.overlay_too_many_files",
+            f"Project holds {len(overlay)} persisted files, over the {max_files} file limit",
+        )
+
+    up = uploads if uploads is not None else build_uploads()
+    cap = _overlay_max_bytes()
+    total = 0
+    files: dict[str, str] = {}
+    for rel_path in sorted(overlay):
+        file_id = overlay[rel_path]
+        try:
+            data = await _download_snapshot(up, file_id, workspace_id=workspace_id, user_id=user_id)
+        except CloudError:
+            logger.warning(
+                "codeproject.read_overlay: unreadable blob for project=%s path=%r file=%s",
+                project_id,
+                rel_path,
+                file_id,
+            )
+            continue
+        total += len(data)
+        if total > cap:
+            raise CloudError(
+                413,
+                "codeproject.overlay_too_large",
+                f"Project files total over the {cap / 1024 / 1024:.0f} MB limit",
+            )
+        try:
+            files[rel_path] = data.decode("utf-8")
+        except UnicodeDecodeError:
+            logger.warning(
+                "codeproject.read_overlay: skipping non-UTF-8 entry for project=%s path=%r",
+                project_id,
+                rel_path,
+            )
+    logger.debug(
+        "codeproject.read_overlay: project=%s -> %d file(s), %d bytes",
+        project_id,
+        len(files),
+        total,
+    )
+    return files
+
+
 __all__ = [
     "build_uploads",
     "drop_overlay",
+    "drop_project_file",
     "drop_project_overlay",
     "mirror_file",
     "mirror_file_to_project",
     "move_overlay",
     "move_project_overlay",
+    "put_project_file",
+    "read_project_overlay",
     "restore_project",
     "restore_workspace",
     "snapshot_project",

--- a/tests/cloud/test_codeproject_file_sync.py
+++ b/tests/cloud/test_codeproject_file_sync.py
@@ -1,0 +1,476 @@
+# test_codeproject_file_sync.py — unit tests for BROWSER-runtime project file sync
+# (B1, feat/code-project-file-sync): the in-tab (WebContainer) runtime pushes each
+# write through to the project's durable overlay and pulls the whole set back on a
+# reopen, because the filesystem lives in the user's browser and no backend hook
+# can read it.
+#
+# Created 2026-07-25 (feat/code-project-file-sync).
+#
+# The bug these guard: an edit in a tab-hosted project was written to an in-tab
+# filesystem only, so reopening the project re-materialized the bare starter
+# scaffold and every change was gone.
+#
+# Blob storage is a FAKE injected through the ``uploads=`` DI seam — no test
+# touches real S3. The CodeProject registry runs on real Beanie over
+# mongomock-motor (the ``mongo_db`` fixture) so the owner-scoped overlay writes and
+# the tenant filter are exercised for real. No Daytona client appears anywhere:
+# that's the point — this path never has a VM.
+#
+# Covers:
+#   * write-through: PUT records ``path -> file_id``; a second write to the same
+#     path REPLACES the entry rather than duplicating it.
+#   * round-trip: two files (one nested) come back with byte-identical content.
+#   * delete: a dropped file no longer appears in the read-back.
+#   * tenancy: another workspace / another user gets NotFound on every verb.
+#   * the S3 fail-closed guard still raises on the write path in cloud.
+#   * path jailing, the read-back caps, and the router wiring for all three routes.
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud._core.errors import CloudError, NotFound, ValidationError
+from pocketpaw_ee.cloud.codeproject import router as codeproject_router
+from pocketpaw_ee.cloud.codeproject import service as codeproject_service
+from pocketpaw_ee.cloud.models.web_sandbox import WebSandbox as _WebSandboxDoc
+from pocketpaw_ee.cloud.websandbox import durability
+
+from pocketpaw.uploads.errors import NotFound as UploadNotFound
+from pocketpaw.uploads.file_store import FileRecord
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+_WS = "w1"
+_USER = "u1"
+
+
+class _FakeUploads:
+    """In-memory stand-in for EEUploadService — records uploads, serves them back.
+
+    One instance carries the blobs, so a file written through here is readable by
+    a later read-back in the same test (exactly the reopen the feature exists for).
+    """
+
+    def __init__(self) -> None:
+        self.upload_calls: list[dict] = []
+        self.stream_calls: list[dict] = []
+        self._blobs: dict[str, bytes] = {}
+        self._counter = 0
+
+    async def upload(self, file, owner_id, chat_id, workspace, folder_path="/", pocket_id=None):  # noqa: ANN001
+        data = await file.read()
+        self._counter += 1
+        file_id = f"file-{self._counter}"
+        self.upload_calls.append(
+            {
+                "owner_id": owner_id,
+                "workspace": workspace,
+                "folder_path": folder_path,
+                "filename": file.filename,
+                "content_type": file.content_type,
+                "data": data,
+            }
+        )
+        self._blobs[file_id] = data
+        return FileRecord(
+            id=file_id,
+            storage_key=f"key/{file_id}",
+            filename=file.filename,
+            mime="application/octet-stream",
+            size=len(data),
+            owner_id=owner_id,
+            chat_id=None,
+            created=datetime.now(UTC),
+        )
+
+    async def stream(self, file_id, requester_id, workspace):  # noqa: ANN001
+        self.stream_calls.append({"file_id": file_id, "requester": requester_id, "ws": workspace})
+        if file_id not in self._blobs:
+            raise UploadNotFound()
+        data = self._blobs[file_id]
+        rec = FileRecord(
+            id=file_id,
+            storage_key=f"key/{file_id}",
+            filename="overlay",
+            mime="application/octet-stream",
+            size=len(data),
+            owner_id=requester_id,
+            chat_id=None,
+            created=datetime.now(UTC),
+        )
+
+        async def _iter():
+            yield data
+
+        return rec, _iter()
+
+
+async def _project(workspace=_WS, user=_USER, name=None):  # noqa: ANN001
+    """A durable starter project — the in-tab runtime's case (no repo to clone)."""
+    body = {"repo": "react", "provider": "starter"}
+    if name is not None:
+        body["name"] = name
+    return await codeproject_service.create_project(workspace, user, body)
+
+
+def _ctx(workspace=_WS, user=_USER):  # noqa: ANN001
+    return RequestContext(
+        user_id=user,
+        workspace_id=workspace,
+        request_id="req-1",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Write-through — the overlay records the pointer, and a rewrite replaces it.
+# ---------------------------------------------------------------------------
+
+
+async def test_put_records_overlay_pointer() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+
+    path, file_id = await durability.put_project_file(
+        _WS, _USER, project.id, "src/app.ts", "console.log(1)", uploads=uploads
+    )
+
+    assert (path, file_id) == ("src/app.ts", "file-1")
+    # The bytes landed in the tenant's blob storage, workspace + owner scoped.
+    assert len(uploads.upload_calls) == 1
+    up = uploads.upload_calls[0]
+    assert up["workspace"] == _WS
+    assert up["owner_id"] == _USER
+    assert up["folder_path"] == "/code-project-overlay"
+    assert up["data"] == b"console.log(1)"
+    # …and the durable pointer is on the PROJECT row.
+    assert (await codeproject_service.get_project(_WS, _USER, project.id)).overlay == {
+        "src/app.ts": "file-1"
+    }
+    # No VM, no WebSandbox row — this runtime lives in the browser.
+    assert await _WebSandboxDoc.find_all().to_list() == []
+
+
+async def test_second_write_to_same_path_replaces_the_entry() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+
+    await durability.put_project_file(_WS, _USER, project.id, "a.ts", "v1", uploads=uploads)
+    _path, second_id = await durability.put_project_file(
+        _WS, _USER, project.id, "a.ts", "v2", uploads=uploads
+    )
+
+    overlay = (await codeproject_service.get_project(_WS, _USER, project.id)).overlay
+    # ONE entry, pointing at the newest blob — not two rows for one file.
+    assert overlay == {"a.ts": second_id}
+    assert len(overlay) == 1
+
+    files = await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads)
+    assert files == {"a.ts": "v2"}
+
+
+async def test_put_normalizes_a_leading_slash_so_the_key_is_stable() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+
+    path, _ = await durability.put_project_file(
+        _WS, _USER, project.id, "/src/x.ts", "X", uploads=uploads
+    )
+
+    assert path == "src/x.ts"
+    assert (await codeproject_service.get_project(_WS, _USER, project.id)).overlay == {
+        "src/x.ts": "file-1"
+    }
+
+
+@pytest.mark.parametrize("bad", ["", "   ", "/", "../etc/passwd", "src/../../escape.ts"])
+async def test_put_rejects_paths_that_escape_the_project(bad) -> None:  # noqa: ANN001
+    project = await _project()
+    uploads = _FakeUploads()
+
+    with pytest.raises(ValidationError):
+        await durability.put_project_file(_WS, _USER, project.id, bad, "x", uploads=uploads)
+    assert uploads.upload_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Round-trip — write, then read the whole overlay back byte-identical.
+# ---------------------------------------------------------------------------
+
+
+async def test_round_trip_returns_exactly_the_written_files() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+
+    await durability.put_project_file(
+        _WS, _USER, project.id, "index.html", "<h1>hi</h1>", uploads=uploads
+    )
+    await durability.put_project_file(
+        _WS,
+        _USER,
+        project.id,
+        "src/lib/x.ts",
+        "export const x = 1;\n// naïve — üñí\n",
+        uploads=uploads,
+    )
+
+    files = await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads)
+
+    assert files == {
+        "index.html": "<h1>hi</h1>",
+        "src/lib/x.ts": "export const x = 1;\n// naïve — üñí\n",
+    }
+    # Byte-identical, not merely equal-looking: what went in came back out.
+    assert files["src/lib/x.ts"].encode("utf-8") == uploads.upload_calls[1]["data"]
+
+
+async def test_read_back_is_empty_for_an_untouched_project() -> None:
+    # A fresh project stores NOTHING — the scaffold baseline is re-materialized
+    # client-side from the starter id, so the overlay is the delta only.
+    project = await _project()
+    uploads = _FakeUploads()
+
+    assert await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads) == {}
+    assert uploads.stream_calls == []
+
+
+async def test_read_back_skips_an_unreadable_blob_instead_of_failing() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+    await durability.put_project_file(_WS, _USER, project.id, "keep.ts", "K", uploads=uploads)
+    # A pointer whose blob was reaped from storage: one bad entry must not sink
+    # the whole restore.
+    await codeproject_service.set_project_overlay_entry(
+        _WS, _USER, project.id, "gone.ts", "file-missing"
+    )
+
+    files = await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads)
+    assert files == {"keep.ts": "K"}
+
+
+# ---------------------------------------------------------------------------
+# Delete — a dropped file does not come back on the next restore.
+# ---------------------------------------------------------------------------
+
+
+async def test_delete_drops_the_file_from_the_read_back() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+    await durability.put_project_file(_WS, _USER, project.id, "a.ts", "A", uploads=uploads)
+    await durability.put_project_file(_WS, _USER, project.id, "dir/b.ts", "B", uploads=uploads)
+
+    dropped = await durability.drop_project_file(_WS, _USER, project.id, "a.ts")
+
+    assert dropped == "a.ts"
+    files = await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads)
+    assert files == {"dir/b.ts": "B"}
+
+
+async def test_delete_normalizes_the_same_way_the_write_did() -> None:
+    # The write stored ``src/a.ts``; a delete spelled ``/src/a.ts`` must still
+    # match, or the file silently reappears on the next reopen.
+    project = await _project()
+    uploads = _FakeUploads()
+    await durability.put_project_file(_WS, _USER, project.id, "src/a.ts", "A", uploads=uploads)
+
+    await durability.drop_project_file(_WS, _USER, project.id, "/src/a.ts")
+
+    assert await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads) == {}
+
+
+async def test_delete_of_a_directory_drops_every_child() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+    await durability.put_project_file(_WS, _USER, project.id, "src/a.ts", "A", uploads=uploads)
+    await durability.put_project_file(_WS, _USER, project.id, "src/deep/b.ts", "B", uploads=uploads)
+    await durability.put_project_file(_WS, _USER, project.id, "keep.ts", "K", uploads=uploads)
+
+    await durability.drop_project_file(_WS, _USER, project.id, "src")
+
+    assert await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads) == {
+        "keep.ts": "K"
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tenancy — every verb is owner-scoped; a foreign caller sees NotFound.
+# ---------------------------------------------------------------------------
+
+
+async def test_put_denies_a_foreign_workspace() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+
+    with pytest.raises(NotFound):
+        await durability.put_project_file(
+            "w2", _USER, project.id, "a.ts", "MINE NOW", uploads=uploads
+        )
+    # Nothing leaked into the owner's project.
+    assert (await codeproject_service.get_project(_WS, _USER, project.id)).overlay == {}
+
+
+async def test_put_denies_another_user_in_the_same_workspace() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+
+    with pytest.raises(NotFound):
+        await durability.put_project_file(
+            _WS, "u2", project.id, "a.ts", "MINE NOW", uploads=uploads
+        )
+    assert (await codeproject_service.get_project(_WS, _USER, project.id)).overlay == {}
+
+
+async def test_read_back_denies_a_foreign_caller() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+    await durability.put_project_file(_WS, _USER, project.id, "secret.ts", "S", uploads=uploads)
+
+    with pytest.raises(NotFound):
+        await durability.read_project_overlay("w2", _USER, project.id, uploads=uploads)
+    with pytest.raises(NotFound):
+        await durability.read_project_overlay(_WS, "u2", project.id, uploads=uploads)
+    # No blob was even reached — the tenancy gate is BEFORE storage.
+    assert uploads.stream_calls == []
+
+
+async def test_delete_denies_a_foreign_caller() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+    await durability.put_project_file(_WS, _USER, project.id, "a.ts", "A", uploads=uploads)
+
+    with pytest.raises(NotFound):
+        await durability.drop_project_file("w2", _USER, project.id, "a.ts")
+    with pytest.raises(NotFound):
+        await durability.drop_project_file(_WS, "u2", project.id, "a.ts")
+    # Still there for the real owner.
+    assert await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads) == {
+        "a.ts": "A"
+    }
+
+
+# ---------------------------------------------------------------------------
+# S3 guard — the durable WRITE path still fails closed in cloud without s3.
+# ---------------------------------------------------------------------------
+
+
+async def test_put_raises_in_cloud_without_s3(monkeypatch) -> None:  # noqa: ANN001
+    project = await _project()
+    uploads = _FakeUploads()
+
+    monkeypatch.setattr(durability, "is_multi_tenant_cloud", lambda: True)
+    monkeypatch.setenv("POCKETPAW_UPLOAD_ADAPTER", "local")
+
+    with pytest.raises(CloudError) as exc:
+        await durability.put_project_file(_WS, _USER, project.id, "a.ts", "A", uploads=uploads)
+    assert exc.value.code == "codeproject.durable_store_requires_s3"
+    assert exc.value.status_code == 503
+    # Fails CLOSED — nothing was uploaded and no pointer was recorded.
+    assert uploads.upload_calls == []
+    assert (await codeproject_service.get_project(_WS, _USER, project.id)).overlay == {}
+
+
+async def test_put_ok_in_cloud_with_s3(monkeypatch) -> None:  # noqa: ANN001
+    project = await _project()
+    uploads = _FakeUploads()
+
+    monkeypatch.setattr(durability, "is_multi_tenant_cloud", lambda: True)
+    monkeypatch.setenv("POCKETPAW_UPLOAD_ADAPTER", "s3")
+
+    path, file_id = await durability.put_project_file(
+        _WS, _USER, project.id, "a.ts", "A", uploads=uploads
+    )
+    assert (path, file_id) == ("a.ts", "file-1")
+
+
+# ---------------------------------------------------------------------------
+# Caps — bounded, and LOUD rather than silently partial.
+# ---------------------------------------------------------------------------
+
+
+async def test_write_over_the_per_file_cap_is_rejected(monkeypatch) -> None:  # noqa: ANN001
+    project = await _project()
+    uploads = _FakeUploads()
+    monkeypatch.setenv("POCKETPAW_CODEPROJECT_OVERLAY_MAX_MB", "0.000001")  # ~1 byte
+
+    with pytest.raises(CloudError) as exc:
+        await durability.put_project_file(
+            _WS, _USER, project.id, "big.ts", "far too many bytes", uploads=uploads
+        )
+    assert exc.value.code == "codeproject.file_too_large"
+    assert exc.value.status_code == 413
+    assert uploads.upload_calls == []
+
+
+async def test_read_back_over_the_file_count_cap_raises(monkeypatch) -> None:  # noqa: ANN001
+    project = await _project()
+    uploads = _FakeUploads()
+    await durability.put_project_file(_WS, _USER, project.id, "a.ts", "A", uploads=uploads)
+    await durability.put_project_file(_WS, _USER, project.id, "b.ts", "B", uploads=uploads)
+
+    monkeypatch.setenv("POCKETPAW_CODEPROJECT_OVERLAY_MAX_FILES", "1")
+
+    with pytest.raises(CloudError) as exc:
+        await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads)
+    # Loud, not truncated: a half-restored project looks like data loss.
+    assert exc.value.code == "codeproject.overlay_too_many_files"
+    assert exc.value.status_code == 413
+
+
+async def test_read_back_over_the_byte_cap_raises(monkeypatch) -> None:  # noqa: ANN001
+    project = await _project()
+    uploads = _FakeUploads()
+    await durability.put_project_file(_WS, _USER, project.id, "a.ts", "AAAA", uploads=uploads)
+
+    monkeypatch.setenv("POCKETPAW_CODEPROJECT_OVERLAY_MAX_MB", "0.000001")  # ~1 byte
+
+    with pytest.raises(CloudError) as exc:
+        await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads)
+    assert exc.value.code == "codeproject.overlay_too_large"
+    assert exc.value.status_code == 413
+
+
+# ---------------------------------------------------------------------------
+# Router wiring — the three routes reach the storage layer and shape the wire.
+# ---------------------------------------------------------------------------
+
+
+async def test_routes_round_trip_a_file(monkeypatch) -> None:  # noqa: ANN001
+    project = await _project()
+    uploads = _FakeUploads()
+    # The routes build their own uploads service; pin it to the fake so no test
+    # touches real storage.
+    monkeypatch.setattr(durability, "build_uploads", lambda: uploads)
+
+    written = await codeproject_router.put_project_file(
+        project.id,
+        codeproject_router.PutProjectFileRequest(path="/src/app.ts", content="hello"),
+        ctx=_ctx(),
+    )
+    assert written.ok is True
+    assert written.path == "src/app.ts"  # the normalized key the overlay stored
+    assert written.fileId == "file-1"
+
+    listing = await codeproject_router.read_project_files(project.id, ctx=_ctx())
+    assert listing.files == {"src/app.ts": "hello"}
+
+    resp = await codeproject_router.delete_project_file(project.id, path="src/app.ts", ctx=_ctx())
+    assert resp.status_code == 204
+    assert (await codeproject_router.read_project_files(project.id, ctx=_ctx())).files == {}
+
+
+async def test_routes_are_owner_scoped(monkeypatch) -> None:  # noqa: ANN001
+    project = await _project()
+    uploads = _FakeUploads()
+    monkeypatch.setattr(durability, "build_uploads", lambda: uploads)
+
+    foreign = _ctx(workspace="w2", user="u2")
+    with pytest.raises(NotFound):
+        await codeproject_router.read_project_files(project.id, ctx=foreign)
+    with pytest.raises(NotFound):
+        await codeproject_router.put_project_file(
+            project.id,
+            codeproject_router.PutProjectFileRequest(path="a.ts", content="x"),
+            ctx=foreign,
+        )


### PR DESCRIPTION
## Why

On the in-tab (WebContainer) runtime, an edit — the user's or the agent's — is written to a filesystem that lives in the browser tab and nowhere else. Close the project and reopen it and you're looking at the bare starter scaffold again, with every change gone.

The durable project store (#1782) gave `CodeProject` somewhere to keep files. This is the endpoint the browser writes them through.

## The model

Two tiers, reusing the shape the store already has:

- **Baseline** is the starter scaffold, and it is deliberately *not* uploaded — it's deterministically re-materializable from the starter id. A fresh project stores nothing.
- **Overlay** is every file written since: `relpath -> FileRecord id`, which is exactly the existing `CodeProject.overlay`.
- **Restore** re-materializes the scaffold, then replays the overlay over it.

So the browser only needs to write one file through, drop one, and read the overlay back.

## What changed

Three owner-scoped routes on the existing project router, backed by browser-side siblings in `durability.py`:

```
PUT    /codeproject/{id}/file    {path, content}
DELETE /codeproject/{id}/file?path=...
GET    /codeproject/{id}/files   -> {files: {path: content}}
```

`put_project_file` delegates to the existing `mirror_file_to_project` rather than re-implementing upload-plus-pointer, so both runtimes share one upload path, one blob folder, one S3 guard, and one last-write-wins rule. It adds only what a wire-facing caller needs: path jailing and a size ceiling. The read-back reuses the same owner-scoped `stream(...)` that restore already uses.

Nothing here writes `snapshot_file_id`. That would call `set_project_snapshot`, which clears the overlay — discarding exactly the state this path exists to keep.

**Paths are normalized and jailed at the write boundary.** VM paths arrive pre-jailed by `file.write`; these come straight off the wire. Leading slashes and `./` segments are stripped (a client FS spells the same file both ways, and the overlay key has to be stable or a later delete won't match the earlier write), while an empty path or any `..` traversal is a clean 422. Deletes normalize identically, otherwise a deleted file resurrects on restore. The existing restore-side jail still re-rejects independently.

**Caps fail loud rather than truncating** — `POCKETPAW_CODEPROJECT_OVERLAY_MAX_MB` (default 10, per-file on write and cumulative on read-back) and `POCKETPAW_CODEPROJECT_OVERLAY_MAX_FILES` (default 2000). A silently partial restore looks exactly like data loss. Individually unreadable entries (a reaped blob, a non-UTF-8 file the JSON transport can't carry) are skipped with a warning, matching how restore already handles one bad file.

## Tests

`tests/cloud/test_codeproject_file_sync.py` (new, 25 tests) → **65 passed** with the existing project suites. Covers write-through and replace-on-rewrite, a byte-identical round-trip including a nested path and non-ASCII content, delete (including a directory dropping every child, and delete normalizing the same way the write did), tenancy on all three routes, the S3 guard raising in cloud before anything uploads, all three caps, and five path-escape cases.

## Not in this PR

The frontend that calls these (debounced write-through on save, restore-on-open). The Daytona re-anchor and scaffold-on-VM work are separate too.

Binary assets are out of scope by shape — content is carried as a JSON string, which suits the source text an in-tab FS holds.

## Base

Stacked on `feat/code-initial-prompt` (#1783).
