### PR TITLE
Anchor Daytona durability on the durable project

### DIFF
--- a/ee/pocketpaw_ee/cloud/codeproject/lifecycle.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/lifecycle.py
@@ -29,6 +29,29 @@
 # then bound the editor to a dead VM (no connection, empty tree). ``_reuse_if_live``
 # now confirms the bound VM actually exists and is ``started`` in Daytona; anything
 # else falls through to reprovision + snapshot restore.
+#
+# 2026-07-25 (B2, feat/code-daytona-project-anchor): restore now reads the durable
+# state off the PROJECT, not off the sandbox row. The old anchor was a bug waiting
+# to fire: a WebSandbox row is unique per (workspace, user, repo), and a scaffold
+# project puts a TEMPLATE id in ``repo``, so every project built from the same
+# starter shared ONE row and would have stomped each other's snapshot + overlay.
+# Anchoring on the project id removes that by construction and makes the stated
+# "CodeProject = durable / WebSandbox = ephemeral" split true rather than
+# aspirational. ``open_project`` therefore restores via ``restore_project`` into the
+# freshly-provisioned VM's Daytona id.
+#
+# The same change adds the one-way rollout backfill: ``_backfill_legacy_durability``
+# lifts a repo project's legacy sandbox-keyed pointers onto the project before
+# anything reads them. It runs LAZILY here rather than as a boot-time sweep because
+# (a) this is the only moment the legacy state matters — it has to be on the project
+# before the first project-keyed restore or mirror, and an open is exactly when that
+# happens; (b) it already has the tenancy context (workspace + user + owned project)
+# a global sweep would have to invent; and (c) it is idempotent by construction, so
+# every later open re-checks for free instead of needing a one-shot migration to be
+# scheduled, monitored, and re-run. It sits at the TOP of ``open_project`` so the
+# reuse branch is covered too, and it never fires for scaffold projects — copying
+# one shared row's state into N sibling starter projects is the very stomping this
+# task removes.
 from __future__ import annotations
 
 import contextlib
@@ -36,7 +59,7 @@ import logging
 
 from pocketpaw_ee.cloud._core.errors import NotFound
 from pocketpaw_ee.cloud.codeproject import service as codeproject_service
-from pocketpaw_ee.cloud.codeproject.domain import CodeProjectView
+from pocketpaw_ee.cloud.codeproject.domain import CodeProjectView, is_scaffold_provider
 from pocketpaw_ee.cloud.daytona.client import DaytonaClient, get_daytona_client
 from pocketpaw_ee.cloud.websandbox import durability as websandbox_durability
 from pocketpaw_ee.cloud.websandbox import provision as websandbox_provision
@@ -72,13 +95,17 @@ async def open_project(
       3. Otherwise cold-provision a fresh sandbox for the project's repo (via
          ``websandbox.provision.open_sandbox`` — idempotent on the repo, so this
          reuses the project's stable WebSandbox row and boots a new VM into it),
-         then bind it onto the project.
+         then restore the PROJECT's durable state into it and bind it.
 
     Returns the ready ``WebSandboxView``. The bound-but-invalid case (the VM was
     reaped, or the id no longer resolves) falls through to reprovision — "if the
     id is invalid or unavailable, make a new sandbox."
     """
     project = await codeproject_service.get_project(workspace_id, user_id, project_id)
+    # B2 rollout: lift any legacy sandbox-keyed durable state onto the project
+    # BEFORE anything reads it. Idempotent, so this is a cheap no-op on every
+    # subsequent open.
+    project = await _backfill_legacy_durability(workspace_id, user_id, project)
 
     reused = await _reuse_if_live(workspace_id, user_id, project, client)
     if reused is not None:
@@ -92,9 +119,9 @@ async def open_project(
     sandbox = await websandbox_provision.open_sandbox(
         workspace_id, user_id, {"repo": project.repo}, client=client
     )
-    # CM-2a′: overlay the row's durable snapshot (uncommitted work + branch from a
-    # prior session) onto the freshly-cloned VM, if one exists.
-    await _restore_if_snapshotted(workspace_id, user_id, sandbox, client)
+    # CM-2a′ / B2: overlay the PROJECT's durable snapshot (uncommitted work +
+    # branch from a prior session) onto the freshly-cloned VM, if one exists.
+    await _restore_if_snapshotted(workspace_id, user_id, project, sandbox, client)
     await codeproject_service.bind_current_sandbox(workspace_id, user_id, project_id, sandbox.id)
     logger.info(
         "codeproject.open: project=%s bound fresh sandbox=%s (repo=%s)",
@@ -162,43 +189,130 @@ async def _teardown_bound_sandbox(
 async def _restore_if_snapshotted(
     workspace_id: str,
     user_id: str,
+    project: CodeProjectView,
     sandbox: WebSandboxView,
     client: DaytonaClient | None,
 ) -> None:
-    """Restore the sandbox row's durable state into its fresh VM, if any.
+    """Restore the PROJECT's durable state into the freshly-provisioned VM, if any.
 
-    The WebSandbox row is stable across reprovisions, so both durability tiers
-    survive on the row when we reprovision: the ``snapshot_file_id`` (captured on
-    a prior clean disconnect) AND the write-through ``overlay`` (per-file edits
-    mirrored since the last snapshot — the tier that covers a crash / idle-out
-    before any disconnect snapshot). Restore fires when EITHER exists; a row with
-    neither (first open, or nothing edited) is a clean no-op.
+    Both durability tiers live on the durable project row (B2): the
+    ``snapshot_file_id`` (captured on a prior clean disconnect) AND the
+    write-through ``overlay`` (per-file edits mirrored since the last snapshot —
+    the tier that covers a crash / idle-out before any disconnect snapshot).
+    Restore fires when EITHER exists; a project with neither (first open, or
+    nothing edited) is a clean no-op.
+
+    The anchor moved off the WebSandbox row deliberately. That row is unique per
+    (workspace, user, repo), so N projects sharing a starter template shared one
+    row and one set of pointers; reading the project instead makes each project's
+    durable state its own. The row is still what tells us WHICH VM to untar into —
+    ``sandbox.sandbox_id``, the live Daytona id.
 
     Best-effort by design: a restore failure (VM gone, S3 down, corrupt tarball)
     is logged and swallowed — the fresh clone from ``open_sandbox`` is still a
     usable workspace, so a durability miss must never fail the open.
     """
-    if not sandbox.snapshot_file_id and not sandbox.overlay:
+    if not project.snapshot_file_id and not project.overlay:
+        return
+    if not sandbox.sandbox_id:
+        # No bound VM to untar into (provision handed back an unready row). The
+        # durable state stays on the project untouched for the next open.
+        logger.warning(
+            "codeproject.open: project=%s has durable state but sandbox=%s has no VM; "
+            "skipping restore",
+            project.id,
+            sandbox.id,
+        )
         return
     try:
-        await websandbox_durability.restore_workspace(
-            workspace_id, user_id, sandbox.id, client=client
+        await websandbox_durability.restore_project(
+            workspace_id, user_id, project.id, sandbox.sandbox_id, client=client
         )
         logger.info(
-            "codeproject.open: restored durable state into sandbox=%s "
+            "codeproject.open: restored durable state for project=%s into daytona=%s "
             "(snapshot=%s, overlay=%d file(s))",
-            sandbox.id,
-            sandbox.snapshot_file_id,
-            len(sandbox.overlay or {}),
+            project.id,
+            sandbox.sandbox_id,
+            project.snapshot_file_id,
+            len(project.overlay or {}),
         )
     except Exception:  # noqa: BLE001 — a fresh clone is still usable; never block open
         logger.warning(
-            "codeproject.open: snapshot restore failed for sandbox=%s (snapshot=%s); "
+            "codeproject.open: snapshot restore failed for project=%s (snapshot=%s); "
             "continuing with the fresh clone",
-            sandbox.id,
-            sandbox.snapshot_file_id,
+            project.id,
+            project.snapshot_file_id,
             exc_info=True,
         )
+
+
+async def _backfill_legacy_durability(
+    workspace_id: str,
+    user_id: str,
+    project: CodeProjectView,
+) -> CodeProjectView:
+    """Lift legacy sandbox-keyed durable state onto the project. Returns the view.
+
+    The one-way rollout migration for B2. Before the cutover, a project's
+    uncommitted work was recorded on the WebSandbox row it was bound to; after it,
+    restore reads the project. Without this copy, a returning user with real work
+    on the old anchor reopens to a bare re-clone — silent data loss at exactly the
+    moment durability is supposed to pay off.
+
+    Conditions, all of which make it safe to run on every open:
+      * the project must hold NO durable state of its own (the service enforces
+        this too, so a race can't clobber fresher work);
+      * the project must be bound to a resolvable, owned sandbox row carrying
+        something to adopt;
+      * the project must NOT be a scaffold project. Its ``repo`` is a template id,
+        so its sandbox row is shared with every sibling built from the same
+        starter — adopting that row's state would copy one project's files into N
+        others, which is the exact stomping this cutover removes. Scaffold projects
+        never persisted through this path anyway (the Daytona adapter refuses a
+        non-repo source), so there is nothing to lose by skipping them.
+
+    Best-effort: any failure returns the project unchanged rather than blocking the
+    open. The legacy fields are left in place, so a missed backfill is retried on
+    the next open instead of being lost.
+    """
+    if project.snapshot_file_id or project.overlay:
+        return project
+    if not project.current_sandbox_id or is_scaffold_provider(project.provider):
+        return project
+    try:
+        sandbox = await websandbox_service.get_sandbox(
+            workspace_id, user_id, project.current_sandbox_id
+        )
+    except NotFound:
+        return project
+    if not sandbox.snapshot_file_id and not sandbox.overlay:
+        return project
+    try:
+        adopted = await codeproject_service.adopt_legacy_durability(
+            workspace_id,
+            user_id,
+            project.id,
+            sandbox.snapshot_file_id,
+            dict(sandbox.overlay or {}),
+        )
+    except Exception:  # noqa: BLE001 — a backfill miss must never block the open
+        logger.warning(
+            "codeproject.open: legacy durability backfill failed for project=%s "
+            "(sandbox=%s); continuing without it",
+            project.id,
+            project.current_sandbox_id,
+            exc_info=True,
+        )
+        return project
+    logger.info(
+        "codeproject.open: adopted legacy durable state for project=%s from sandbox=%s "
+        "(snapshot=%s, overlay=%d file(s))",
+        project.id,
+        project.current_sandbox_id,
+        adopted.snapshot_file_id,
+        len(adopted.overlay or {}),
+    )
+    return adopted
 
 
 async def _reuse_if_live(

--- a/ee/pocketpaw_ee/cloud/codeproject/service.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/service.py
@@ -36,6 +36,24 @@
 # module stays the sole writer of the CodeProject doc (Rule 2). The orchestration
 # that drives them (tar/untar + S3 upload) lives in ``websandbox/durability.py``.
 #
+# Modified 2026-07-25 (B2, feat/code-daytona-project-anchor): added the two ops the
+# Daytona cutover needs, because the runtime knows only its EPHEMERAL sandbox row
+# and the durable state now lives on the PROJECT.
+#   * ``find_project_for_sandbox`` — the reverse of ``bind_current_sandbox``: given
+#     a WebSandbox row id, which owned project is currently bound to it? The
+#     terminal socket has a row id and needs a project id to mirror/snapshot
+#     against. Ordered by ``last_opened_at`` desc because the bind is not unique:
+#     a WebSandbox row is keyed (workspace, user, repo), so two projects built from
+#     the same starter template can point at ONE row — the most recently opened is
+#     the one the user is actually looking at.
+#   * ``adopt_legacy_durability`` — the rollout backfill. Copies a legacy
+#     sandbox-keyed ``snapshot_file_id`` / ``overlay`` onto the project so an
+#     existing repo project's uncommitted work survives the cutover. Idempotent and
+#     NON-destructive by construction: it writes only when the project holds no
+#     durable state of its own, so a second call (or a later open) can never
+#     clobber state the project has since accumulated. The WebSandbox fields are
+#     left readable — this PR moves WHO the Daytona path writes, not what exists.
+#
 # Modified 2026-07-24 (feat/code-initial-prompt): ``create_project`` now persists
 # the optional ``initial_prompt`` (the WHAT-to-build description) on an actual
 # INSERT only — a github idempotent hit returns the existing row untouched, so a
@@ -393,6 +411,51 @@ async def bind_current_sandbox(
     return _doc_to_view(doc)
 
 
+async def find_project_for_sandbox(
+    workspace_id: str,
+    user_id: str,
+    sandbox_row_id: str,
+) -> CodeProjectView | None:
+    """Which owned project is currently bound to this ephemeral sandbox row?
+
+    The reverse of ``bind_current_sandbox``, and the seam the Daytona runtime
+    needs: a terminal socket is opened against a WebSandbox ROW id, but durable
+    state is anchored on the PROJECT, so the socket has to resolve its owner
+    before it can mirror or snapshot.
+
+    Returns ``None`` rather than raising when nothing is bound — a sandbox opened
+    outside the project flow (the plain ``/websandbox`` REST surface) has no owning
+    project, and that is a normal state the caller degrades on, not an error.
+
+    The bind is deliberately NOT treated as unique. A WebSandbox row is keyed
+    (workspace, user, repo) while a project is not, so two scaffold projects
+    started from the same template id can legitimately point at one row. Ordering
+    by ``last_opened_at`` desc picks the project the user most recently opened —
+    which is the one whose editor this socket belongs to, since ``open_project``
+    re-stamps that field on every open right before the socket connects. ``_id``
+    desc breaks a tie: BSON datetimes are millisecond-precision, so two binds
+    inside one millisecond would otherwise order arbitrarily, and an arbitrary
+    durable anchor is not something to leave to chance.
+
+    Tenant- AND owner-filtered (Rule 7): another tenant's project bound to the same
+    row id is invisible here.
+    """
+    docs = (
+        await _CodeProjectDoc.find(
+            {  # Rule 7 tenant + owner filter
+                "workspace_id": workspace_id,
+                "user_id": user_id,
+                "current_sandbox_id": sandbox_row_id,
+            }
+        )
+        .sort([("last_opened_at", -1), ("_id", -1)])
+        .to_list()
+    )
+    if not docs:
+        return None
+    return _doc_to_view(docs[0])
+
+
 # ---------------------------------------------------------------------------
 # Project-keyed durability pointers (feat/code-durable-project-store).
 #
@@ -538,6 +601,59 @@ async def move_project_overlay_entry(
     return _doc_to_view(doc)
 
 
+async def adopt_legacy_durability(
+    workspace_id: str,
+    user_id: str,
+    project_id: str,
+    snapshot_file_id: str | None,
+    overlay: dict[str, str] | None,
+) -> CodeProjectView:
+    """Adopt legacy sandbox-keyed durable state onto the project (B2 backfill).
+
+    Durability used to be anchored on the EPHEMERAL WebSandbox row. B2 moved the
+    Daytona path onto the durable project, so an existing project whose only
+    durable state sits on its old sandbox row would otherwise reopen empty. This
+    lifts that state across, once.
+
+    Two guarantees make it safe to call on every open (Rule: non-destructive):
+      * It writes ONLY when the project holds no durable state of its own — no
+        snapshot pointer and an empty overlay. A project that has since snapshotted
+        or mirrored anything is returned untouched, so a stale legacy pointer can
+        never overwrite fresher work.
+      * Nothing is deleted. The WebSandbox fields stay readable for the whole
+        rollout window; this copies, it does not move.
+
+    Tenant- and owner-scoped (Rule 7 via ``_read_owned``); raises ``NotFound`` when
+    no owned row matches. Passing nothing to adopt is a clean no-op.
+    """
+    doc = await _read_owned(workspace_id, user_id, project_id)
+    if doc is None:
+        raise NotFound("code_project", project_id)
+
+    if doc.snapshot_file_id or doc.overlay:
+        # no-event: the project already owns durable state — adopting would be a
+        # regression, so this is deliberately a read.
+        return _doc_to_view(doc)
+    legacy_overlay = dict(overlay or {})
+    if not snapshot_file_id and not legacy_overlay:
+        # no-event: nothing to adopt.
+        return _doc_to_view(doc)
+
+    doc.snapshot_file_id = snapshot_file_id
+    doc.overlay = legacy_overlay
+    doc.updated_at = datetime.now(UTC)
+    await doc.save()
+    logger.info(
+        "codeproject.adopt_legacy_durability: project=%s <- snapshot=%s, overlay=%d file(s)",
+        project_id,
+        snapshot_file_id,
+        len(legacy_overlay),
+    )
+    # no-event: durability bookkeeping, same reasoning as set_project_snapshot — a
+    # migration copy is not a lifecycle transition a projects-grid should react to.
+    return _doc_to_view(doc)
+
+
 async def _read_owned(
     workspace_id: str,
     user_id: str,
@@ -560,10 +676,12 @@ async def _read_owned(
 
 
 __all__ = [
+    "adopt_legacy_durability",
     "bind_current_sandbox",
     "create_project",
     "delete_project",
     "drop_project_overlay_entry",
+    "find_project_for_sandbox",
     "get_project",
     "list_projects",
     "mark_initial_prompt_consumed",

--- a/ee/pocketpaw_ee/cloud/websandbox/ws.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/ws.py
@@ -58,6 +58,22 @@
 # ``_drop`` (on_delete → overlay drop), ``_move`` (on_move → overlay re-key) — so
 # a create/save is mirrored, a delete isn't resurrected, and a rename replays at
 # its new path on restore.
+#
+# 2026-07-25 (B2, feat/code-daytona-project-anchor): those durability hooks — and
+# the disconnect snapshot — now target the DURABLE PROJECT instead of the ephemeral
+# sandbox row. The row is unique per (workspace, user, repo), and a scaffold project
+# puts a TEMPLATE id in ``repo``, so N projects from one starter shared a single row
+# and would have overwritten each other's snapshot + overlay. The socket only knows
+# its row, so it resolves the owning project once at connect time
+# (``codeproject_service.find_project_for_sandbox``) and routes every durability
+# write through the project id from then on.
+#
+# The socket DEGRADES rather than dropping writes: a sandbox opened outside the
+# project flow (the plain ``/websandbox`` REST surface) has no owning project, so
+# the hooks fall back to the sandbox-keyed functions exactly as before. Losing a
+# user's edits is a far worse failure than writing them to the older anchor. The
+# anchor choice is made once, in ``build_durability_hooks``, so it is a single
+# testable decision rather than three copies of the same branch.
 from __future__ import annotations
 
 import asyncio
@@ -65,12 +81,15 @@ import json
 import logging
 import time
 import uuid
+from collections.abc import Awaitable, Callable
+from typing import Any
 
 from fastapi import Query, WebSocket, WebSocketDisconnect
 
 from pocketpaw_ee.cloud._core.errors import CloudError
 from pocketpaw_ee.cloud.auth import service as auth_service
 from pocketpaw_ee.cloud.auth.ws_tickets import consume_ws_ticket
+from pocketpaw_ee.cloud.codeproject import service as codeproject_service
 from pocketpaw_ee.cloud.daytona.client import DaytonaClient, get_daytona_client
 from pocketpaw_ee.cloud.license import get_license
 from pocketpaw_ee.cloud.websandbox import durability as websandbox_durability
@@ -146,13 +165,100 @@ class TerminalConnectionManager:
 manager = TerminalConnectionManager()
 
 
+async def resolve_owning_project(workspace_id: str, user_id: str, row_id: str) -> str | None:
+    """The durable project this sandbox row belongs to, or ``None`` (B2).
+
+    The socket is opened against a WebSandbox ROW, but durable state is anchored on
+    the PROJECT, so the anchor has to be resolved once at connect time. ``None``
+    means "no owning project" — a sandbox opened straight off the ``/websandbox``
+    REST surface — and the caller degrades to the sandbox-keyed path.
+
+    A lookup FAILURE also resolves to ``None`` on purpose: degrading to the older
+    anchor still persists the user's edits somewhere, whereas propagating the error
+    would refuse the socket over a durability detail.
+    """
+    try:
+        project = await codeproject_service.find_project_for_sandbox(workspace_id, user_id, row_id)
+    except Exception:  # noqa: BLE001 — a resolution miss degrades, never denies
+        logger.warning(
+            "websandbox.ws: owning-project lookup failed for row=%s; "
+            "falling back to sandbox-keyed durability",
+            row_id,
+            exc_info=True,
+        )
+        return None
+    return project.id if project is not None else None
+
+
+def build_durability_hooks(
+    workspace_id: str,
+    user_id: str,
+    row_id: str,
+    project_id: str | None,
+    uploads: Any,
+) -> tuple[
+    Callable[[str, bytes], Awaitable[None]],
+    Callable[[str], Awaitable[None]],
+    Callable[[str, str], Awaitable[None]],
+]:
+    """Build the (on_write, on_delete, on_move) FileRpc durability hooks (B2).
+
+    ONE place decides the anchor. With a ``project_id`` every editor save, delete,
+    and rename is written through against the durable project — the fix for N
+    projects on one starter template sharing a single repo-keyed sandbox row. With
+    ``None`` (a sandbox opened outside the project flow) the hooks keep the
+    original sandbox-keyed behaviour: degrade, never drop the write.
+
+    All three are best-effort at the call site — ``FileRpc`` swallows a hook
+    failure so durability never fails the file op itself.
+    """
+    if project_id:
+
+        async def _mirror(rel_path: str, data: bytes) -> None:
+            await websandbox_durability.mirror_file_to_project(
+                workspace_id, user_id, project_id, rel_path, data, uploads=uploads
+            )
+
+        async def _drop(rel_path: str) -> None:
+            await websandbox_durability.drop_project_overlay(
+                workspace_id, user_id, project_id, rel_path
+            )
+
+        async def _move(src_rel: str, dst_rel: str) -> None:
+            await websandbox_durability.move_project_overlay(
+                workspace_id, user_id, project_id, src_rel, dst_rel
+            )
+
+        return _mirror, _drop, _move
+
+    async def _mirror_row(rel_path: str, data: bytes) -> None:
+        await websandbox_durability.mirror_file(
+            workspace_id, user_id, row_id, rel_path, data, uploads=uploads
+        )
+
+    async def _drop_row(rel_path: str) -> None:
+        # Delete-side durability: drop the overlay entry so a deleted file is not
+        # resurrected on restore (WC-4c).
+        await websandbox_durability.drop_overlay(workspace_id, user_id, row_id, rel_path)
+
+    async def _move_row(src_rel: str, dst_rel: str) -> None:
+        # Rename-side durability: re-key the overlay entry to the new path so
+        # restore replays the file where it now lives (WC-4c).
+        await websandbox_durability.move_overlay(workspace_id, user_id, row_id, src_rel, dst_rel)
+
+    return _mirror_row, _drop_row, _move_row
+
+
 async def snapshot_on_disconnect(
     workspace_id: str,
     user_id: str,
     row_id: str,
     client: DaytonaClient | None,
+    *,
+    project_id: str | None = None,
+    daytona_id: str | None = None,
 ) -> None:
-    """Best-effort workspace snapshot when a terminal socket closes (CM-2a′).
+    """Best-effort workspace snapshot when a terminal socket closes (CM-2a′, B2).
 
     The durable half of Code Mode is the S3 snapshot; the Daytona VM is pure
     scratch. With the aggressive Daytona lifecycle (stop 5 / delete-on-stop), a
@@ -161,15 +267,32 @@ async def snapshot_on_disconnect(
     still alive. ``codeproject.lifecycle.open_project`` restores the latest
     snapshot on the next open.
 
+    The pointer lands on the durable PROJECT when the socket resolved one, keyed by
+    ``project_id`` and taken from the live VM ``daytona_id`` (the project-keyed
+    snapshot addresses the VM directly rather than through the row). Without both —
+    a sandbox opened outside the project flow, or a row with no bound VM — it falls
+    back to the sandbox-keyed snapshot rather than skipping the capture.
+
     Best-effort by design: a snapshot failure (VM already gone, S3 down, an
     unprovisioned row) must NEVER surface on socket teardown — it is logged at
-    debug and swallowed. The snapshot pointer lands on the stable WebSandbox row,
-    which survives the VM's reaping.
+    debug and swallowed.
     """
     try:
-        await websandbox_durability.snapshot_workspace(workspace_id, user_id, row_id, client=client)
+        if project_id and daytona_id:
+            await websandbox_durability.snapshot_project(
+                workspace_id, user_id, project_id, daytona_id, client=client
+            )
+        else:
+            await websandbox_durability.snapshot_workspace(
+                workspace_id, user_id, row_id, client=client
+            )
     except Exception:  # noqa: BLE001 — teardown must never raise on a snapshot miss
-        logger.debug("websandbox.snapshot on disconnect failed for row=%s", row_id, exc_info=True)
+        logger.debug(
+            "websandbox.snapshot on disconnect failed for row=%s project=%s",
+            row_id,
+            project_id,
+            exc_info=True,
+        )
 
 
 async def terminal_websocket_endpoint(
@@ -261,6 +384,11 @@ async def terminal_websocket_endpoint(
         await websocket.close(code=_CLOSE_LICENSE, reason="Sandbox runtime unavailable")
         return
 
+    # B2: resolve the DURABLE anchor once, now that the row is owner-authorized.
+    # Every durability write below (mirror / drop / move / disconnect snapshot)
+    # targets this project id; ``None`` degrades to the sandbox-keyed path.
+    project_id = await resolve_owning_project(workspace_id, user_id, row_id)
+
     # Every gate passed — accept the socket (unless Path 3 already did) and open
     # the PTY. ``accepted`` keeps accept() exactly-once across both paths.
     if not accepted:
@@ -288,26 +416,15 @@ async def terminal_websocket_endpoint(
     # dir (resolved lazily on first use); it reuses the already-owner-authorized
     # client + sandbox_id and never re-authorizes per frame.
     #
-    # Write-through durability (CM-2a′): build ONE overlay uploads service for the
-    # session and pass FileRpc a mirror closure bound to this tenant + row. Each
-    # editor save then also lands in blob storage; a mirror failure is swallowed
-    # inside FileRpc so it never fails the save.
+    # Write-through durability (CM-2a′, re-anchored in B2): build ONE overlay
+    # uploads service for the session and pass FileRpc hooks bound to this tenant
+    # and to the DURABLE PROJECT that owns this row (resolved once, above). Each
+    # editor save then also lands in blob storage against the project; a mirror
+    # failure is swallowed inside FileRpc so it never fails the save.
     overlay_uploads = websandbox_durability.build_uploads()
-
-    async def _mirror(rel_path: str, data: bytes) -> None:
-        await websandbox_durability.mirror_file(
-            workspace_id, user_id, row_id, rel_path, data, uploads=overlay_uploads
-        )
-
-    async def _drop(rel_path: str) -> None:
-        # Delete-side durability: drop the overlay entry so a deleted file is not
-        # resurrected on restore (WC-4c). Best-effort — swallowed inside FileRpc.
-        await websandbox_durability.drop_overlay(workspace_id, user_id, row_id, rel_path)
-
-    async def _move(src_rel: str, dst_rel: str) -> None:
-        # Rename-side durability: re-key the overlay entry to the new path so
-        # restore replays the file where it now lives (WC-4c). Best-effort.
-        await websandbox_durability.move_overlay(workspace_id, user_id, row_id, src_rel, dst_rel)
+    _mirror, _drop, _move = build_durability_hooks(
+        workspace_id, user_id, row_id, project_id, overlay_uploads
+    )
 
     file_rpc = FileRpc(client, row.sandbox_id, on_write=_mirror, on_delete=_drop, on_move=_move)
 
@@ -367,15 +484,25 @@ async def terminal_websocket_endpoint(
     finally:
         # Teardown: kill the pty session so the shell doesn't leak in the VM.
         await manager.unregister(websocket)
-        # CM-2a′ durability: capture the workspace to S3 on this clean disconnect
-        # so a returning user restores their uncommitted work. Best-effort — a
-        # snapshot miss never turns a normal close into an error.
-        await snapshot_on_disconnect(workspace_id, user_id, row_id, client)
+        # CM-2a′ durability, project-anchored (B2): capture the workspace to S3 on
+        # this clean disconnect so a returning user restores their uncommitted
+        # work. Best-effort — a snapshot miss never turns a normal close into an
+        # error.
+        await snapshot_on_disconnect(
+            workspace_id,
+            user_id,
+            row_id,
+            client,
+            project_id=project_id,
+            daytona_id=row.sandbox_id,
+        )
 
 
 __all__ = [
     "TerminalConnectionManager",
+    "build_durability_hooks",
     "manager",
+    "resolve_owning_project",
     "snapshot_on_disconnect",
     "terminal_websocket_endpoint",
 ]

--- a/tests/cloud/test_codeproject.py
+++ b/tests/cloud/test_codeproject.py
@@ -17,9 +17,10 @@
 #     provisioning a second one.
 #   * open_project REPROVISIONS when the bound sandbox is invalid/unavailable
 #     (reaped) — "if the id is invalid or unavailable, make a new sandbox."
-#   * (CM-2a′) open_project RESTORES the row's durable snapshot into the fresh VM
-#     on reprovision when one exists, and skips restore when there's no snapshot;
-#     a restore failure is swallowed (the fresh clone is still returned ready).
+#   * (CM-2a′, re-anchored in B2) open_project RESTORES the PROJECT's durable
+#     snapshot into the fresh VM on reprovision when one exists, and skips restore
+#     when there's no snapshot; a restore failure is swallowed (the fresh clone is
+#     still returned ready).
 from __future__ import annotations
 
 import pytest
@@ -214,8 +215,16 @@ async def test_open_project_reprovisions_when_vm_deleted_out_of_band() -> None:
 
 
 # ---------------------------------------------------------------------------
-# open_project — CM-2a′ snapshot restore on reprovision.
+# open_project — CM-2a′ snapshot restore on reprovision, PROJECT-anchored (B2).
 # ---------------------------------------------------------------------------
+#
+# Adapted 2026-07-25 (B2, feat/code-daytona-project-anchor). These three tests
+# asserted the same behaviour against the OLD anchor: durable state was staged on
+# the WebSandbox row (``sandbox_service.set_snapshot`` / ``set_overlay_entry``) and
+# restore went through ``restore_workspace(row_id)``. The behaviour under test is
+# unchanged — restore fires on reprovision when either tier exists, and a failure
+# is swallowed — only the anchor moved, so the staging now goes through the project
+# service and the spy asserts the project id + the fresh VM's Daytona id.
 
 
 async def test_open_project_restores_snapshot_on_reprovision(monkeypatch) -> None:
@@ -224,46 +233,55 @@ async def test_open_project_restores_snapshot_on_reprovision(monkeypatch) -> Non
 
     restored: list[dict] = []
 
-    async def _spy_restore(workspace_id, user_id, row_id, *, client=None):  # noqa: ANN001
-        restored.append({"workspace_id": workspace_id, "user_id": user_id, "row_id": row_id})
+    async def _spy_restore(workspace_id, user_id, project_id, sandbox_id, *, client=None):  # noqa: ANN001
+        restored.append(
+            {
+                "workspace_id": workspace_id,
+                "user_id": user_id,
+                "project_id": project_id,
+                "sandbox_id": sandbox_id,
+            }
+        )
 
-    monkeypatch.setattr(lifecycle.websandbox_durability, "restore_workspace", _spy_restore)
+    monkeypatch.setattr(lifecycle.websandbox_durability, "restore_project", _spy_restore)
 
-    # First open: a fresh row with no snapshot → nothing to restore.
+    # First open: a fresh project with no snapshot → nothing to restore.
     first = await lifecycle.open_project(_WS, _USER, project.id, client=fake)
     assert restored == []
 
-    # A clean disconnect captured a snapshot onto the stable row; then the VM was
-    # reaped out from under the project.
-    await sandbox_service.set_snapshot(_WS, _USER, first.id, "file-123")
+    # A clean disconnect captured a snapshot onto the durable PROJECT; then the VM
+    # was reaped out from under it.
+    await service.set_project_snapshot(_WS, _USER, project.id, "file-123")
     await sandbox_service.mark_reaped(first.id)
 
-    # Reopening reprovisions a fresh VM AND restores the row's snapshot into it.
+    # Reopening reprovisions a fresh VM AND restores the project's snapshot into it.
     second = await lifecycle.open_project(_WS, _USER, project.id, client=fake)
     assert second.id == first.id
     assert len(restored) == 1
-    assert restored[0]["row_id"] == second.id
+    assert restored[0]["project_id"] == project.id
+    # Restored into the FRESH VM, addressed by its Daytona id (not the row id).
+    assert restored[0]["sandbox_id"] == second.sandbox_id
 
 
 async def test_open_project_restores_overlay_only_on_reprovision(monkeypatch) -> None:
-    # The crash-before-any-snapshot case: the row carries a write-through overlay
-    # but no snapshot. Restore must still fire.
+    # The crash-before-any-snapshot case: the project carries a write-through
+    # overlay but no snapshot. Restore must still fire.
     project = await service.create_project(_WS, _USER, {"repo": _REPO})
     fake = _FakeDaytonaClient()
 
     restored: list[str] = []
 
-    async def _spy_restore(workspace_id, user_id, row_id, *, client=None):  # noqa: ANN001
-        restored.append(row_id)
+    async def _spy_restore(workspace_id, user_id, project_id, sandbox_id, *, client=None):  # noqa: ANN001
+        restored.append(project_id)
 
-    monkeypatch.setattr(lifecycle.websandbox_durability, "restore_workspace", _spy_restore)
+    monkeypatch.setattr(lifecycle.websandbox_durability, "restore_project", _spy_restore)
 
     first = await lifecycle.open_project(_WS, _USER, project.id, client=fake)
-    await sandbox_service.set_overlay_entry(_WS, _USER, first.id, "a.ts", "file-1")
+    await service.set_project_overlay_entry(_WS, _USER, project.id, "a.ts", "file-1")
     await sandbox_service.mark_reaped(first.id)
 
-    second = await lifecycle.open_project(_WS, _USER, project.id, client=fake)
-    assert restored == [second.id]
+    await lifecycle.open_project(_WS, _USER, project.id, client=fake)
+    assert restored == [project.id]
 
 
 async def test_open_project_swallows_restore_failure(monkeypatch) -> None:
@@ -271,13 +289,13 @@ async def test_open_project_swallows_restore_failure(monkeypatch) -> None:
     fake = _FakeDaytonaClient()
 
     first = await lifecycle.open_project(_WS, _USER, project.id, client=fake)
-    await sandbox_service.set_snapshot(_WS, _USER, first.id, "file-123")
+    await service.set_project_snapshot(_WS, _USER, project.id, "file-123")
     await sandbox_service.mark_reaped(first.id)
 
-    async def _boom_restore(workspace_id, user_id, row_id, *, client=None):  # noqa: ANN001
+    async def _boom_restore(workspace_id, user_id, project_id, sandbox_id, *, client=None):  # noqa: ANN001
         raise RuntimeError("boom: restore failed")
 
-    monkeypatch.setattr(lifecycle.websandbox_durability, "restore_workspace", _boom_restore)
+    monkeypatch.setattr(lifecycle.websandbox_durability, "restore_project", _boom_restore)
 
     # A restore failure is best-effort: the open still returns a ready sandbox
     # (the fresh clone), not an error.

--- a/tests/cloud/test_codeproject_daytona_anchor.py
+++ b/tests/cloud/test_codeproject_daytona_anchor.py
@@ -1,0 +1,434 @@
+# test_codeproject_daytona_anchor.py — the B2 cutover: the DAYTONA runtime's
+# durability is anchored on the durable CodeProject, not on the ephemeral
+# WebSandbox row.
+#
+# Created 2026-07-25 (B2, feat/code-daytona-project-anchor).
+#
+# The bug this removes: a WebSandbox row is unique per (workspace, user, repo),
+# and a SCAFFOLD project puts a TEMPLATE id in ``repo``. Every project built from
+# the same starter therefore shared ONE row — and, before this change, one
+# ``snapshot_file_id`` + one ``overlay``. Two projects would have overwritten each
+# other's durable state. Anchoring on the project id removes that by construction.
+#
+# What is proved here, end to end, on real Beanie over mongomock-motor (the
+# ``mongo_db`` fixture) with FAKE Daytona + FAKE blob storage injected through the
+# existing DI seams:
+#   * the full chain stays intact and moves whole: provision -> mirror a write ->
+#     snapshot on disconnect -> reprovision -> restore, with every pointer read
+#     from the CodeProject and the WebSandbox row's durable fields never written.
+#   * the collision is gone: two projects sharing one starter ``repo`` (and even
+#     one sandbox ROW) hold independent durable state.
+#   * the degrade path: a sandbox with NO owning project still mirrors and
+#     snapshots against the row exactly as before — no write is dropped.
+#   * the rollout backfill: a repo project with legacy state on its sandbox row
+#     adopts it on open, is idempotent on a second open, is non-destructive to the
+#     row, never overwrites state the project already holds, and never fires for a
+#     scaffold project (whose row is shared).
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from pocketpaw_ee.cloud.codeproject import lifecycle
+from pocketpaw_ee.cloud.codeproject import service as codeproject_service
+from pocketpaw_ee.cloud.websandbox import durability
+from pocketpaw_ee.cloud.websandbox import provision as websandbox_provision
+from pocketpaw_ee.cloud.websandbox import service as sandbox_service
+from pocketpaw_ee.cloud.websandbox import ws as terminal_ws
+
+from tests.cloud.test_codeproject_durability import _FakeDaytonaClient as _FakeVmClient
+from tests.cloud.test_codeproject_durability import _FakeUploads
+from tests.cloud.test_websandbox_provision import _FakeDaytonaClient as _FakeProvisionClient
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+_WS = "ws-1"
+_USER = "user-1"
+_REPO = "https://github.com/acme/widgets.git"
+_STARTER = "react"
+_SNAPSHOT_TMP = "/tmp/ws-snapshot.tgz"  # noqa: S108 — a sandbox VM path, not host
+
+
+@pytest.fixture()
+def uploads(monkeypatch) -> _FakeUploads:  # noqa: ANN001
+    """A fake blob store wired in as the module default.
+
+    ``snapshot_on_disconnect`` and ``restore_project`` (via ``open_project``) build
+    their own uploads service, so the DI seam has to be closed at the module level
+    for a whole-chain test. One instance carries the blobs, so bytes written by a
+    mirror or a snapshot are readable by the later restore.
+    """
+    fake = _FakeUploads()
+    monkeypatch.setattr(durability, "build_uploads", lambda: fake)
+    return fake
+
+
+async def _starter_row():
+    """Register the runtime row a starter project would get.
+
+    Registered directly rather than through ``provision.open_sandbox`` because the
+    provisioner only accepts an http(s) git URL — scaffold-on-Daytona is a separate
+    task. What matters here is the ROW's key: it is (workspace, user, repo), and
+    ``repo`` is the template id, so every project on that starter resolves to this
+    one row.
+    """
+    return await sandbox_service.create_sandbox(
+        _WS, _USER, {"repo": _STARTER, "sandbox_id": "dtn-shared", "status": "ready"}
+    )
+
+
+# ---------------------------------------------------------------------------
+# Proof 1 — the whole chain, project-anchored.
+# ---------------------------------------------------------------------------
+
+
+async def test_full_chain_mirrors_snapshots_and_restores_against_the_project(uploads) -> None:  # noqa: ANN001
+    """provision -> mirror -> snapshot on disconnect -> reprovision -> restore.
+
+    Every durable pointer is read off the CodeProject; the WebSandbox row's
+    ``snapshot_file_id`` / ``overlay`` are never written, so nothing in the chain
+    depends on the ephemeral row surviving.
+    """
+    project = await codeproject_service.create_project(_WS, _USER, {"repo": _REPO})
+    prov = _FakeProvisionClient()
+
+    # 1. Open the project — cold-provisions a VM and binds the row.
+    sandbox = await lifecycle.open_project(_WS, _USER, project.id, client=prov)
+    assert sandbox.sandbox_id is not None
+
+    # The terminal socket knows only its ROW; it resolves the durable anchor.
+    project_id = await terminal_ws.resolve_owning_project(_WS, _USER, sandbox.id)
+    assert project_id == project.id
+
+    # 2. An editor save flows through the socket's write-through hook.
+    on_write, _on_delete, _on_move = terminal_ws.build_durability_hooks(
+        _WS, _USER, sandbox.id, project_id, uploads
+    )
+    await on_write("src/app.ts", b"EDITED-IN-THE-VM")
+
+    stored = await codeproject_service.get_project(_WS, _USER, project.id)
+    assert list(stored.overlay) == ["src/app.ts"]
+    row = await sandbox_service.get_sandbox(_WS, _USER, sandbox.id)
+    assert row.overlay == {}, "the mirror still wrote to the EPHEMERAL row"
+
+    # 3. A clean disconnect snapshots the live VM onto the project.
+    vm = _FakeVmClient(tar_bytes=b"SNAPSHOT-TAR")
+    await terminal_ws.snapshot_on_disconnect(
+        _WS,
+        _USER,
+        sandbox.id,
+        vm,
+        project_id=project_id,
+        daytona_id=sandbox.sandbox_id,
+    )
+    snapshotted = await codeproject_service.get_project(_WS, _USER, project.id)
+    assert snapshotted.snapshot_file_id is not None
+    assert snapshotted.overlay == {}, "a full snapshot supersedes the overlay"
+    row = await sandbox_service.get_sandbox(_WS, _USER, sandbox.id)
+    assert row.snapshot_file_id is None, "the snapshot pointer landed on the EPHEMERAL row"
+
+    # 4. The VM is reaped; reopening reprovisions and restores from the PROJECT.
+    await sandbox_service.mark_reaped(sandbox.id)
+    second = await lifecycle.open_project(_WS, _USER, project.id, client=prov)
+    assert second.sandbox_id != sandbox.sandbox_id  # genuinely fresh VM
+
+    untarred = [c for c in prov.upload_calls if c["path"] == _SNAPSHOT_TMP]
+    assert untarred, "the project's snapshot was never pushed into the fresh VM"
+    assert untarred[-1]["data"] == b"SNAPSHOT-TAR"
+    assert untarred[-1]["id"] == second.sandbox_id
+
+
+async def test_delete_and_move_hooks_also_target_the_project(uploads) -> None:  # noqa: ANN001
+    """The delete / rename sides of the overlay move with the write side."""
+    project = await codeproject_service.create_project(_WS, _USER, {"repo": _REPO})
+    prov = _FakeProvisionClient()
+    sandbox = await lifecycle.open_project(_WS, _USER, project.id, client=prov)
+
+    on_write, on_delete, on_move = terminal_ws.build_durability_hooks(
+        _WS, _USER, sandbox.id, project.id, uploads
+    )
+    await on_write("a.ts", b"A")
+    await on_write("dir/b.ts", b"B")
+
+    await on_move("a.ts", "renamed.ts")
+    await on_delete("dir")
+
+    stored = await codeproject_service.get_project(_WS, _USER, project.id)
+    assert list(stored.overlay) == ["renamed.ts"]
+    row = await sandbox_service.get_sandbox(_WS, _USER, sandbox.id)
+    assert row.overlay == {}
+
+
+# ---------------------------------------------------------------------------
+# Proof 2 — the collision is gone.
+# ---------------------------------------------------------------------------
+
+
+async def test_two_projects_on_one_starter_row_hold_independent_state(uploads) -> None:  # noqa: ANN001
+    """The bug, stated as the behaviour we want.
+
+    Two projects built from the same starter share ONE WebSandbox row (it is keyed
+    (workspace, user, repo) and ``repo`` is a template id). Their durable state must
+    still be their own.
+    """
+    todo = await codeproject_service.create_project(
+        _WS, _USER, {"repo": _STARTER, "provider": "starter", "name": "todo"}
+    )
+    blog = await codeproject_service.create_project(
+        _WS, _USER, {"repo": _STARTER, "provider": "starter", "name": "blog"}
+    )
+    assert todo.id != blog.id
+
+    # One shared runtime row, both projects bound to it — the collision, exactly.
+    # ``create_sandbox`` is idempotent on (workspace, user, repo), so registering
+    # each project's runtime hands back the SAME row: that is the collision, not a
+    # contrivance of the test.
+    shared = await _starter_row()
+    assert (await _starter_row()).id == shared.id
+
+    await codeproject_service.bind_current_sandbox(_WS, _USER, todo.id, shared.id)
+    await codeproject_service.bind_current_sandbox(_WS, _USER, blog.id, shared.id)
+
+    todo_write, _d, _m = terminal_ws.build_durability_hooks(_WS, _USER, shared.id, todo.id, uploads)
+    blog_write, _d2, _m2 = terminal_ws.build_durability_hooks(
+        _WS, _USER, shared.id, blog.id, uploads
+    )
+    await todo_write("todo.ts", b"T")
+    await blog_write("blog.ts", b"B")
+
+    todo_state = await codeproject_service.get_project(_WS, _USER, todo.id)
+    blog_state = await codeproject_service.get_project(_WS, _USER, blog.id)
+    assert list(todo_state.overlay) == ["todo.ts"]
+    assert list(blog_state.overlay) == ["blog.ts"], (
+        "one project's files landed on the other — the durable state is still shared"
+    )
+
+    # And the shared ephemeral row — the thing they used to collide on — holds none.
+    row = await sandbox_service.get_sandbox(_WS, _USER, shared.id)
+    assert row.overlay == {}
+    assert row.snapshot_file_id is None
+
+
+async def test_shared_row_resolves_to_the_most_recently_opened_project() -> None:
+    """When a row is shared, the socket belongs to the project just opened.
+
+    ``open_project`` re-stamps ``last_opened_at`` immediately before the browser
+    connects, so "most recently opened" is what identifies the editor on the other
+    end of this socket.
+    """
+    todo = await codeproject_service.create_project(
+        _WS, _USER, {"repo": _STARTER, "provider": "starter", "name": "todo"}
+    )
+    blog = await codeproject_service.create_project(
+        _WS, _USER, {"repo": _STARTER, "provider": "starter", "name": "blog"}
+    )
+    shared = await _starter_row()
+
+    await codeproject_service.bind_current_sandbox(_WS, _USER, todo.id, shared.id)
+    # BSON datetimes are millisecond-precision, and a real user's two opens are
+    # seconds apart — step past the tick so the test asserts ordering, not a tie.
+    await asyncio.sleep(0.005)
+    await codeproject_service.bind_current_sandbox(_WS, _USER, blog.id, shared.id)
+    assert await terminal_ws.resolve_owning_project(_WS, _USER, shared.id) == blog.id
+
+    # Reopening the first project moves the anchor back to it.
+    await asyncio.sleep(0.005)
+    await codeproject_service.bind_current_sandbox(_WS, _USER, todo.id, shared.id)
+    assert await terminal_ws.resolve_owning_project(_WS, _USER, shared.id) == todo.id
+
+
+async def test_resolve_owning_project_is_tenant_and_owner_scoped() -> None:
+    project = await codeproject_service.create_project(_WS, _USER, {"repo": _REPO})
+    sandbox = await websandbox_provision.open_sandbox(
+        _WS, _USER, {"repo": _REPO}, client=_FakeProvisionClient()
+    )
+    await codeproject_service.bind_current_sandbox(_WS, _USER, project.id, sandbox.id)
+
+    assert await terminal_ws.resolve_owning_project(_WS, _USER, sandbox.id) == project.id
+    # Another user / another workspace can't resolve someone else's project.
+    assert await terminal_ws.resolve_owning_project(_WS, "user-2", sandbox.id) is None
+    assert await terminal_ws.resolve_owning_project("ws-2", _USER, sandbox.id) is None
+
+
+# ---------------------------------------------------------------------------
+# Proof 3 — degrade, never drop: a sandbox with no owning project.
+# ---------------------------------------------------------------------------
+
+
+async def test_sandbox_without_a_project_keeps_the_sandbox_keyed_behaviour(uploads) -> None:  # noqa: ANN001
+    """A sandbox opened outside the project flow still mirrors and snapshots.
+
+    Falling back to the older anchor persists the user's edits; skipping the write
+    would lose them. That trade is the whole reason the degrade path exists.
+    """
+    prov = _FakeProvisionClient()
+    sandbox = await websandbox_provision.open_sandbox(_WS, _USER, {"repo": _REPO}, client=prov)
+    assert sandbox.sandbox_id is not None
+
+    project_id = await terminal_ws.resolve_owning_project(_WS, _USER, sandbox.id)
+    assert project_id is None  # nothing owns this row
+
+    on_write, on_delete, on_move = terminal_ws.build_durability_hooks(
+        _WS, _USER, sandbox.id, project_id, uploads
+    )
+    await on_write("a.ts", b"A")
+    await on_write("gone.ts", b"G")
+    await on_move("a.ts", "b.ts")
+    await on_delete("gone.ts")
+
+    row = await sandbox_service.get_sandbox(_WS, _USER, sandbox.id)
+    assert list(row.overlay) == ["b.ts"], "the write was dropped instead of degrading"
+
+    # The disconnect snapshot degrades the same way — onto the row.
+    vm = _FakeVmClient(tar_bytes=b"ROW-TAR")
+    await terminal_ws.snapshot_on_disconnect(_WS, _USER, sandbox.id, vm, project_id=None)
+    row = await sandbox_service.get_sandbox(_WS, _USER, sandbox.id)
+    assert row.snapshot_file_id is not None
+    assert row.overlay == {}
+
+
+async def test_snapshot_degrades_when_the_row_has_no_bound_vm(uploads) -> None:  # noqa: ANN001
+    """A project id with no Daytona id can't address a VM — fall back, don't skip."""
+    project = await codeproject_service.create_project(_WS, _USER, {"repo": _REPO})
+    sandbox = await websandbox_provision.open_sandbox(
+        _WS, _USER, {"repo": _REPO}, client=_FakeProvisionClient()
+    )
+    await codeproject_service.bind_current_sandbox(_WS, _USER, project.id, sandbox.id)
+
+    vm = _FakeVmClient(tar_bytes=b"ROW-TAR")
+    await terminal_ws.snapshot_on_disconnect(
+        _WS, _USER, sandbox.id, vm, project_id=project.id, daytona_id=None
+    )
+    # Landed on the row (the sandbox-keyed path), not silently nowhere.
+    row = await sandbox_service.get_sandbox(_WS, _USER, sandbox.id)
+    assert row.snapshot_file_id is not None
+    assert (await codeproject_service.get_project(_WS, _USER, project.id)).snapshot_file_id is None
+
+
+# ---------------------------------------------------------------------------
+# Proof 4 — the rollout backfill.
+# ---------------------------------------------------------------------------
+
+
+async def _bind_legacy_state(
+    project_id: str,
+    prov: _FakeProvisionClient,
+    *,
+    snapshot: str = "legacy-snap",
+    overlay: tuple[str, str] = ("legacy.ts", "legacy-file"),
+) -> str:
+    """Open a project, then stage pre-cutover durable state on its sandbox ROW."""
+    sandbox = await lifecycle.open_project(_WS, _USER, project_id, client=prov)
+    # set_snapshot clears the overlay, so the snapshot goes first (the same order
+    # the legacy runtime produced: snapshot on disconnect, then edits after it).
+    await sandbox_service.set_snapshot(_WS, _USER, sandbox.id, snapshot)
+    await sandbox_service.set_overlay_entry(_WS, _USER, sandbox.id, overlay[0], overlay[1])
+    await sandbox_service.mark_reaped(sandbox.id)
+    return sandbox.id
+
+
+async def test_backfill_adopts_legacy_sandbox_state_on_open(monkeypatch) -> None:  # noqa: ANN001
+    project = await codeproject_service.create_project(_WS, _USER, {"repo": _REPO})
+    prov = _FakeProvisionClient()
+    row_id = await _bind_legacy_state(project.id, prov)
+
+    restored: list[str] = []
+
+    async def _spy_restore(workspace_id, user_id, project_id, sandbox_id, *, client=None):  # noqa: ANN001
+        restored.append(project_id)
+
+    monkeypatch.setattr(lifecycle.websandbox_durability, "restore_project", _spy_restore)
+
+    await lifecycle.open_project(_WS, _USER, project.id, client=prov)
+
+    adopted = await codeproject_service.get_project(_WS, _USER, project.id)
+    assert adopted.snapshot_file_id == "legacy-snap"
+    assert adopted.overlay == {"legacy.ts": "legacy-file"}
+    # …and the adopted state is what the reprovision restored from.
+    assert restored == [project.id]
+
+    # Non-destructive: the legacy fields stay readable for the rollout window.
+    row = await sandbox_service.get_sandbox(_WS, _USER, row_id)
+    assert row.snapshot_file_id == "legacy-snap"
+    assert row.overlay == {"legacy.ts": "legacy-file"}
+
+
+async def test_backfill_is_idempotent_across_opens(monkeypatch) -> None:  # noqa: ANN001
+    project = await codeproject_service.create_project(_WS, _USER, {"repo": _REPO})
+    prov = _FakeProvisionClient()
+    await _bind_legacy_state(project.id, prov)
+
+    async def _noop_restore(workspace_id, user_id, project_id, sandbox_id, *, client=None):  # noqa: ANN001
+        return None
+
+    monkeypatch.setattr(lifecycle.websandbox_durability, "restore_project", _noop_restore)
+
+    await lifecycle.open_project(_WS, _USER, project.id, client=prov)
+    first = await codeproject_service.get_project(_WS, _USER, project.id)
+
+    # A second open re-runs the backfill check and must change nothing.
+    await lifecycle.open_project(_WS, _USER, project.id, client=prov)
+    second = await codeproject_service.get_project(_WS, _USER, project.id)
+
+    assert second.snapshot_file_id == first.snapshot_file_id == "legacy-snap"
+    assert second.overlay == first.overlay == {"legacy.ts": "legacy-file"}
+
+
+async def test_backfill_never_overwrites_state_the_project_already_holds(monkeypatch) -> None:  # noqa: ANN001
+    project = await codeproject_service.create_project(_WS, _USER, {"repo": _REPO})
+    prov = _FakeProvisionClient()
+    await _bind_legacy_state(project.id, prov)
+
+    # The project has already snapshotted since the cutover — fresher than the row.
+    await codeproject_service.set_project_snapshot(_WS, _USER, project.id, "fresh-snap")
+    await codeproject_service.set_project_overlay_entry(
+        _WS, _USER, project.id, "new.ts", "new-file"
+    )
+
+    async def _noop_restore(workspace_id, user_id, project_id, sandbox_id, *, client=None):  # noqa: ANN001
+        return None
+
+    monkeypatch.setattr(lifecycle.websandbox_durability, "restore_project", _noop_restore)
+
+    await lifecycle.open_project(_WS, _USER, project.id, client=prov)
+
+    kept = await codeproject_service.get_project(_WS, _USER, project.id)
+    assert kept.snapshot_file_id == "fresh-snap", "a stale legacy pointer overwrote live work"
+    assert kept.overlay == {"new.ts": "new-file"}
+
+
+async def test_backfill_skips_scaffold_projects(monkeypatch) -> None:  # noqa: ANN001
+    """A scaffold project's row is SHARED with every sibling on the same starter.
+
+    Adopting it would copy one project's files into N others — the exact stomping
+    this cutover removes. Scaffold projects never persisted through the Daytona
+    path anyway, so there is nothing to carry across.
+    """
+    project = await codeproject_service.create_project(
+        _WS, _USER, {"repo": _STARTER, "provider": "starter", "name": "todo"}
+    )
+    sandbox = await _starter_row()
+    await codeproject_service.bind_current_sandbox(_WS, _USER, project.id, sandbox.id)
+    await sandbox_service.set_snapshot(_WS, _USER, sandbox.id, "legacy-snap")
+
+    async def _noop_restore(workspace_id, user_id, project_id, sandbox_id, *, client=None):  # noqa: ANN001
+        return None
+
+    monkeypatch.setattr(lifecycle.websandbox_durability, "restore_project", _noop_restore)
+
+    await lifecycle.open_project(_WS, _USER, project.id, client=_FakeProvisionClient())
+
+    fresh = await codeproject_service.get_project(_WS, _USER, project.id)
+    assert fresh.snapshot_file_id is None
+    assert fresh.overlay == {}
+
+
+async def test_adopt_legacy_durability_is_owner_scoped() -> None:
+    from pocketpaw_ee.cloud._core.errors import NotFound
+
+    mine = await codeproject_service.create_project(_WS, _USER, {"repo": _REPO})
+    with pytest.raises(NotFound):
+        await codeproject_service.adopt_legacy_durability(
+            _WS, "user-2", mine.id, "hijacked-snap", {"x.ts": "hijacked"}
+        )
+    assert (await codeproject_service.get_project(_WS, _USER, mine.id)).snapshot_file_id is None


### PR DESCRIPTION
## Why

Durability was attached to the wrong entity. `WebSandbox` is the ephemeral Daytona row, keyed `(workspace, user, repo)` and reprovisioned freely; `CodeProject` is the durable, deep-linkable thing behind `/code/<id>`. The snapshot pointer and overlay lived on the ephemeral one.

For a starter project `repo` is a *template* id, so several projects created from the same starter share one sandbox row — and would stomp each other's durable state. Anchoring on the project id removes that by construction, and makes the stated "project is durable, sandbox is ephemeral" model actually true.

## What changed

The mirror-on-write → snapshot-on-disconnect → restore-on-open chain keeps its exact shape. Only the anchor moved.

- **Restore** — `_restore_if_snapshotted` takes the project, gates on the project's own snapshot/overlay, and restores into the fresh VM's Daytona id.
- **Reverse lookup** — `find_project_for_sandbox` resolves the owning project for a socket, tenant- and owner-scoped, ordered by `last_opened_at` then `_id`. The bind isn't treated as unique because a repo-keyed row can be shared, and `open_project` re-stamps `last_opened_at` immediately before the browser connects. The `_id` tiebreak is there because BSON datetimes are millisecond-precision — without it, two binds inside one millisecond ordered arbitrarily, which actually flaked once during a full-suite run.
- **Socket** — the owning project is resolved once after row authz, and the anchor choice is made in one place for the write, delete, and move hooks.
- **Degrade, don't lose data** — a sandbox with no owning project (or a lookup error, or a row with no bound VM) falls back to the sandbox-keyed path exactly as before.
- **Migration** — a lazy, idempotent backfill at the top of `open_project` copies legacy row state onto the project when the project has none. It sits there rather than in a boot sweep because that's the only moment the legacy state matters (it must land before the first project-keyed restore or mirror, which is what an open does), it already has the tenancy context a global sweep would have to invent, and every later open re-checks for free instead of needing a one-shot migration scheduled and monitored. Nothing is deleted; the old fields stay readable. It never fires for scaffold projects, whose shared row is the very thing being fixed.

`durability.py` is untouched — the sandbox-keyed functions and the REST restore route that still uses them are intact.

## Tests

`uv run pytest tests/cloud/ -k "websandbox or codeproject or durability"` → **443 passed**. New file: 12 tests over real Beanie on mongomock with fake Daytona and fake blob storage through the existing DI seams.

- **Full chain** — open → mirror → snapshot on disconnect → reap → reopen, asserting at each step that the row's overlay stays empty and its snapshot pointer stays null, so nothing depends on the row.
- **Collision gone** — two starter projects, with `create_sandbox` idempotency asserted to hand both the *same* row (so the collision is real, not staged), yet each project's state is its own.
- **Degrade** — a sandbox with no owning project still mirrors and snapshots onto the row.
- **Backfill** — adopts on open, is idempotent, never overwrites existing project state, leaves the row readable, and skips scaffolds.

Three restore tests were adapted, not weakened: their intent ("restore fires when either tier exists; a failure is swallowed") is unchanged, and one gained a *stronger* assertion — that the restore addresses the fresh VM's id. The disconnect-snapshot tests in `test_websandbox_terminal.py` were left untouched and still pass; they now exercise the degrade path, which is its own non-regression proof.

## Before this ships

**Verify `POCKETPAW_UPLOAD_ADAPTER=s3` on the deploy.** The project-keyed write path carries a fail-closed S3 guard that the sandbox-keyed one doesn't. On a misconfigured cloud, mirrors now raise 503 where they previously wrote to the box's local disk — both are data loss, but this one is quieter, because `FileRpc` swallows hook failures at debug level. Raising that to a warning is a small follow-up worth doing.

A project-keyed mirror that *fails* is deliberately not retried against the sandbox row: writing to an anchor nothing restores from would manufacture false durability. The degrade path is only for the deterministic "no owning project" case.

## Base

Stacked on `feat/code-project-file-sync` (#1784).
