### PR TITLE
Let either runtime restore the same durable state

### DIFF
--- a/ee/pocketpaw_ee/cloud/codeproject/router.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/router.py
@@ -19,7 +19,7 @@
 #   PUT    /codeproject/{id}/file  — persist ONE file written by the in-browser
 #                                   runtime (write-through to blob storage).
 #   DELETE /codeproject/{id}/file  — drop one file so it isn't restored again.
-#   GET    /codeproject/{id}/files — the project's persisted overlay, the restore
+#   GET    /codeproject/{id}/files — the project's whole persisted state, the restore
 #                                   payload the in-tab runtime replays.
 # Like the WebSandbox router, endpoints are license-gated + context-authenticated;
 # the tenancy/owner filtering in the service is the security boundary.
@@ -36,6 +36,12 @@
 # pull the whole set back on a reopen. Storage lives in ``websandbox/durability.py``
 # (the layer allowed to touch EEUploadService); like the websandbox snapshot /
 # restore routes, this router calls it directly and stays a thin adapter.
+#
+# Modified 2026-07-25 (B4, feat/code-cross-runtime-restore): docs only. The GET
+# /files payload is no longer "the overlay" — ``read_project_overlay`` now composes
+# the snapshot tar AND the overlay, so a project last saved in the Daytona runtime
+# is retrievable in-tab instead of coming back empty. No route, DTO, or wire shape
+# changed; the docstring here would otherwise describe the pre-fix behaviour.
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, Query, Response
@@ -196,8 +202,10 @@ async def read_project_files(
 ) -> ProjectFilesResponse:
     """Read every persisted file back (owner-scoped) — the restore payload.
 
-    The delta only: the client re-materializes the starter scaffold from the
-    starter id, then replays this map over it.
+    Both durability tiers, merged: the snapshot tar a Daytona session wrote (minus
+    the regenerable trees) as the baseline, with the per-file overlay on top. The
+    client re-materializes the starter scaffold from the starter id, then replays
+    this map over it — so a project saved in EITHER runtime reopens intact here.
     """
     workspace_id = _require_workspace(ctx)
     files = await websandbox_durability.read_project_overlay(workspace_id, ctx.user_id, project_id)

--- a/ee/pocketpaw_ee/cloud/websandbox/durability.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/durability.py
@@ -79,11 +79,30 @@
 # read path ``restore_project`` uses, same ``_require_s3_for_project_store``
 # fail-closed guard on the write, same ``uploads=`` DI seam. ADDITIVE: nothing
 # above is touched.
+#
+# Changed 2026-07-25 (B4, feat/code-cross-runtime-restore): ``read_project_overlay``
+# is now TWO-TIER, closing a cross-runtime data-visibility bug. WHY: a project can
+# open in either runtime, but the two tiers were read asymmetrically — work done in
+# a Daytona VM ends up in ``snapshot_file_id`` (and ``set_project_snapshot`` CLEARS
+# the overlay, correctly, because the tar supersedes it), while the in-tab read-back
+# looked ONLY at ``overlay``. So Daytona → disconnect → reopen IN-TAB returned ``{}``
+# and the browser re-materialized the bare starter scaffold: the user's work looked
+# deleted while it sat safe in S3 inside a tarball no browser can read. The read-back
+# now composes the SAME two tiers ``restore_project`` replays into a VM — snapshot
+# tar expanded in memory as the baseline, overlay applied on top (freshest wins) —
+# so whatever either runtime saved is retrievable from either runtime. It is a READ
+# -side fix only: no write path and no snapshot semantics changed. Two concerns the
+# VM path doesn't have are handled here because the payload crosses a JSON wire into
+# a browser: regenerable trees (``node_modules``/``.git``/build output, which the tar
+# carries with no excludes) are filtered out, and tar members are treated as
+# UNTRUSTED — absolute/traversing names and non-regular entries (symlinks, hardlinks,
+# devices) are skipped rather than materialized.
 from __future__ import annotations
 
 import io
 import logging
 import os
+import tarfile
 from pathlib import Path
 from typing import Any
 
@@ -908,25 +927,170 @@ def _overlay_max_files() -> int:
     return count
 
 
-def _require_safe_rel_path(rel_path: str) -> str:
-    """Normalize a client-supplied overlay path; reject anything that escapes.
+def _normalize_rel_path(rel_path: str) -> str | None:
+    """Normalize a path to the overlay's relpath shape; ``None`` if it escapes.
 
-    The VM paths came out of the ``file.write`` jail; these come straight off the
-    wire, so the jail check moves to the write boundary. Leading slashes and
-    ``./`` segments are stripped (a client-side FS spells the same file both
-    ways, and the overlay key must be stable or a later delete won't match the
-    earlier write), while an empty path or any ``..`` traversal is a clean 422 —
-    the overlay key becomes a real path again on both restore paths
-    (``_overlay_abs_path`` in a VM, the client's FS in a tab).
+    ONE jail, two callers with different failure modes — the write boundary turns
+    ``None`` into a 422 (``_require_safe_rel_path``), the snapshot expander skips
+    the entry — so there is a single definition of "a safe project-relative path".
+    Leading slashes and ``./`` segments are stripped (a client-side FS spells the
+    same file both ways, and the overlay key must be stable or a later delete
+    won't match the earlier write); an empty path or any ``..`` traversal escapes.
     """
     candidate = (rel_path or "").strip().lstrip("/")
     segments = [s for s in candidate.split("/") if s not in ("", ".")]
     if not segments or any(s == ".." for s in segments):
+        return None
+    return "/".join(segments)
+
+
+def _require_safe_rel_path(rel_path: str) -> str:
+    """Normalize a client-supplied overlay path; reject anything that escapes.
+
+    The VM paths came out of the ``file.write`` jail; these come straight off the
+    wire, so the jail check moves to the write boundary. An empty path or any
+    ``..`` traversal is a clean 422 — the overlay key becomes a real path again on
+    both restore paths (``_overlay_abs_path`` in a VM, the client's FS in a tab).
+    """
+    safe = _normalize_rel_path(rel_path)
+    if safe is None:
         raise ValidationError(
             "codeproject.invalid_file_path",
             f"{rel_path!r} is not a valid project-relative file path",
         )
-    return "/".join(segments)
+    return safe
+
+
+# Path segments dropped when a snapshot tar is expanded for the BROWSER read-back.
+# ``snapshot_project`` tars the whole workspace with no excludes (right for a VM
+# restore, which wants a byte-identical tree), but every tree here is regenerable
+# or meaningless in a tab: ``npm install`` restores ``node_modules``, a build
+# restores ``dist``/``build``/``.next``/``.svelte-kit``, ``.turbo``/``.cache``/
+# ``coverage`` are derived artifacts, and ``.git`` is a binary object store the
+# in-tab runtime has no client for. They are also the bulk of the bytes — shipping
+# them through a JSON string map would be hundreds of MB the browser throws away.
+# Not applied to the VM restore path, which legitimately wants the whole tree.
+_SNAPSHOT_EXCLUDED_SEGMENTS = frozenset(
+    {
+        "node_modules",
+        ".git",
+        "dist",
+        "build",
+        ".next",
+        ".svelte-kit",
+        ".turbo",
+        ".cache",
+        "coverage",
+    }
+)
+
+
+def _is_excluded_snapshot_path(rel_path: str) -> bool:
+    """True when any segment of ``rel_path`` names a regenerable/irrelevant tree."""
+    return any(seg in _SNAPSHOT_EXCLUDED_SEGMENTS for seg in rel_path.split("/"))
+
+
+def _tar_member_rel_path(name: str) -> str | None:
+    """Jail a TAR member name into the overlay's relpath shape; ``None`` to skip.
+
+    A tar is untrusted input: it is expanded into the user's in-tab filesystem, so
+    a member that names an absolute path or climbs out of the workspace must never
+    become a write. Snapshot tars are built with ``-C <workdir> .``, so ordinary
+    members arrive as ``./src/app.ts`` and normalize to the same ``src/app.ts`` key
+    the overlay uses — which is what lets the two tiers merge by path at all.
+    Backslashes are rejected outright rather than normalized: they are not a path
+    separator here, so a ``..\\..\\x`` member would slip past the segment check.
+    """
+    raw = (name or "").strip()
+    if raw.startswith("/") or "\\" in raw:
+        return None
+    return _normalize_rel_path(raw)
+
+
+def _expand_snapshot_tar(data: bytes, *, project_id: str, cap: int) -> tuple[dict[str, str], int]:
+    """Expand a snapshot tarball in memory into ``({relpath: text}, total bytes)``.
+
+    The BASELINE tier of the browser read-back — the in-memory counterpart of
+    ``restore_project``'s ``tar -xzf`` into a VM. Written by ``tar -czf`` so the
+    blob is gzipped; ``r:*`` auto-detects anyway.
+
+    Three classes of member never make it into the payload:
+      * non-regular entries (directories, symlinks, hardlinks, devices) — a
+        directory carries no content and a link is a tar-smuggling vector with no
+        meaning in a browser FS;
+      * unsafe names (absolute or ``..``-traversing) and regenerable trees
+        (``_SNAPSHOT_EXCLUDED_SEGMENTS``);
+      * non-UTF-8 blobs — the transport is a JSON string map, so a binary file
+        can't be carried. Skipped with a warning rather than failing the whole
+        restore, mirroring how the overlay read-back tolerates one bad entry.
+
+    The byte cap is enforced from the member HEADER before anything is read, so a
+    huge (or zip-bomb) snapshot bounds memory instead of consuming it. Exceeding it
+    raises LOUD (413) — see ``read_project_overlay`` for why a truncated payload is
+    the one outcome to avoid.
+    """
+    files: dict[str, str] = {}
+    total = 0
+    skipped_unsafe = skipped_excluded = skipped_binary = 0
+    # A corrupt or truncated archive raises on open OR mid-iteration; both are the
+    # same failure — the baseline is unreadable — and both must be LOUD. Returning
+    # the overlay alone would look like a project that lost most of its files.
+    # ``EOFError``/``OSError`` join ``TarError`` because the decompressor, not
+    # tarfile, is what fails on a truncated gzip stream (``gzip.BadGzipFile`` is an
+    # OSError, a half-written blob raises EOFError).
+    try:
+        archive = tarfile.open(fileobj=io.BytesIO(data), mode="r:*")
+        with archive:
+            for member in archive:
+                if not member.isfile():
+                    continue
+                rel_path = _tar_member_rel_path(member.name)
+                if rel_path is None:
+                    skipped_unsafe += 1
+                    logger.warning(
+                        "codeproject.read_overlay: skipping unsafe snapshot entry for "
+                        "project=%s name=%r",
+                        project_id,
+                        member.name,
+                    )
+                    continue
+                if _is_excluded_snapshot_path(rel_path):
+                    skipped_excluded += 1
+                    continue
+                if total + member.size > cap:
+                    raise CloudError(
+                        413,
+                        "codeproject.overlay_too_large",
+                        f"Project files total over the {cap / 1024 / 1024:.0f} MB limit",
+                    )
+                handle = archive.extractfile(member)
+                blob = handle.read() if handle is not None else b""
+                try:
+                    files[rel_path] = blob.decode("utf-8")
+                except UnicodeDecodeError:
+                    skipped_binary += 1
+                    continue
+                total += len(blob)
+    except (tarfile.TarError, EOFError, OSError) as exc:
+        raise with_cause(
+            CloudError(
+                502,
+                "codeproject.snapshot_unreadable",
+                "The project's stored snapshot could not be read",
+            ),
+            exc,
+        ) from exc
+    logger.debug(
+        "codeproject.read_overlay: snapshot expanded for project=%s -> %d file(s), %d bytes "
+        "(skipped %d excluded, %d binary, %d unsafe)",
+        project_id,
+        len(files),
+        total,
+        skipped_excluded,
+        skipped_binary,
+        skipped_unsafe,
+    )
+    return files, total
 
 
 async def put_project_file(
@@ -997,27 +1161,44 @@ async def read_project_overlay(
     *,
     uploads: Any = None,
 ) -> dict[str, str]:
-    """Read a project's whole overlay back as ``{relpath: content}``.
+    """Read a project's whole durable state back as ``{relpath: content}``.
 
-    The restore payload for the in-tab runtime, and the counterpart of
-    ``restore_project``'s tier-2 replay: instead of writing each blob into a VM,
-    it returns them to the client, which re-materializes the scaffold baseline
-    and replays this map over it. Owner-scoped through ``get_project`` (a project
-    the caller doesn't own reads as ``NotFound`` before any blob is touched), and
-    each blob comes back through the same owner-scoped ``stream(...)`` path
-    ``_download_snapshot`` wraps — a foreign or vanished blob can't be read out
-    of this endpoint.
+    The restore payload for the in-tab runtime, and the read-side counterpart of
+    ``restore_project`` — which is exactly why it composes the SAME two tiers, in
+    the same order, instead of writing them into a VM:
+      1. ``snapshot_file_id`` — the full-workspace tarball a Daytona session wrote
+         on disconnect. Fetched from blob storage and expanded IN MEMORY as the
+         baseline, minus the trees a browser can't use (see
+         ``_expand_snapshot_tar``).
+      2. ``overlay`` — the per-file write-through tier, applied ON TOP so the
+         freshest bytes win, exactly as the VM replay orders them.
 
-    Both caps fail LOUD rather than truncating: a silently partial restore looks
-    like the user's files were deleted, which is worse than a 413 that says the
-    project outgrew the in-browser runtime. Individually unreadable entries (a
-    reaped blob, a non-UTF-8 file the JSON transport can't carry) are skipped
-    with a warning instead — one bad file must not sink the rest, the same rule
-    ``restore_project`` replays under.
+    Both tiers are read because a project is not bound to one runtime (B4). Reading
+    only the overlay meant a project last touched in DAYTONA came back empty here —
+    ``set_project_snapshot`` clears the overlay once its contents are inside the tar
+    — so reopening it in a tab re-materialized the bare scaffold and the user's work
+    looked deleted while it sat safe in S3. A project that never saw a VM has no
+    snapshot and this collapses to the overlay-only behaviour it always had.
+
+    Owner-scoped through ``get_project`` (a project the caller doesn't own reads as
+    ``NotFound`` before any blob is touched), and every blob — tar and overlay entry
+    alike — comes back through the same owner-scoped ``stream(...)`` path
+    ``_download_snapshot`` wraps, so a foreign or vanished blob can't be read out of
+    this endpoint.
+
+    Caps stay LOUD (413) rather than truncating, INCLUDING for the snapshot-derived
+    baseline: filtering already removed everything that isn't user work, so what is
+    left over the cap IS the user's project, and a silently partial restore looks
+    like their files were deleted. A 413 that says the project outgrew the in-browser
+    runtime is recoverable — it still opens in the VM runtime, whose restore has no
+    such cap. What IS dropped silently is only the non-user-work classes: excluded
+    trees, and individually unreadable/undecodable entries (a reaped blob, a binary
+    file the JSON transport can't carry), which are skipped with a warning so one bad
+    file doesn't sink the rest — the same rule ``restore_project`` replays under.
     """
     project = await codeproject_service.get_project(workspace_id, user_id, project_id)
     overlay = project.overlay or {}
-    if not overlay:
+    if not project.snapshot_file_id and not overlay:
         return {}
 
     max_files = _overlay_max_files()
@@ -1030,8 +1211,18 @@ async def read_project_overlay(
 
     up = uploads if uploads is not None else build_uploads()
     cap = _overlay_max_bytes()
-    total = 0
     files: dict[str, str] = {}
+    total = 0
+
+    # Tier 1 — the snapshot tar (baseline). A download or expansion failure raises:
+    # the baseline going missing is not "one bad file", it is most of the project.
+    if project.snapshot_file_id:
+        snapshot_bytes = await _download_snapshot(
+            up, project.snapshot_file_id, workspace_id=workspace_id, user_id=user_id
+        )
+        files, total = _expand_snapshot_tar(snapshot_bytes, project_id=project_id, cap=cap)
+
+    # Tier 2 — the overlay, applied on top (freshest wins).
     for rel_path in sorted(overlay):
         file_id = overlay[rel_path]
         try:
@@ -1044,26 +1235,39 @@ async def read_project_overlay(
                 file_id,
             )
             continue
-        total += len(data)
-        if total > cap:
-            raise CloudError(
-                413,
-                "codeproject.overlay_too_large",
-                f"Project files total over the {cap / 1024 / 1024:.0f} MB limit",
-            )
         try:
-            files[rel_path] = data.decode("utf-8")
+            text = data.decode("utf-8")
         except UnicodeDecodeError:
             logger.warning(
                 "codeproject.read_overlay: skipping non-UTF-8 entry for project=%s path=%r",
                 project_id,
                 rel_path,
             )
+            continue
+        # The baseline copy is superseded, so its bytes leave the budget with it —
+        # a file present in both tiers must not be counted twice against the cap.
+        superseded = len(files[rel_path].encode("utf-8")) if rel_path in files else 0
+        total += len(data) - superseded
+        if total > cap:
+            raise CloudError(
+                413,
+                "codeproject.overlay_too_large",
+                f"Project files total over the {cap / 1024 / 1024:.0f} MB limit",
+            )
+        files[rel_path] = text
+
+    if len(files) > max_files:
+        raise CloudError(
+            413,
+            "codeproject.overlay_too_many_files",
+            f"Project holds {len(files)} persisted files, over the {max_files} file limit",
+        )
     logger.debug(
-        "codeproject.read_overlay: project=%s -> %d file(s), %d bytes",
+        "codeproject.read_overlay: project=%s -> %d file(s), %d bytes (snapshot=%s)",
         project_id,
         len(files),
         total,
+        project.snapshot_file_id,
     )
     return files
 

--- a/ee/pocketpaw_ee/cloud/websandbox/ws.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/ws.py
@@ -74,6 +74,15 @@
 # user's edits is a far worse failure than writing them to the older anchor. The
 # anchor choice is made once, in ``build_durability_hooks``, so it is a single
 # testable decision rather than three copies of the same branch.
+#
+# 2026-07-25 (B4, feat/code-cross-runtime-restore): a FAILED durable write is no
+# longer invisible. The hooks are wrapped in ``_visible_durability`` and the
+# disconnect snapshot logs at WARNING instead of debug. WHY: the project store fails
+# CLOSED on a cloud whose ``POCKETPAW_UPLOAD_ADAPTER`` isn't ``s3``, and both the
+# per-file hooks (via ``FileRpc``) and the disconnect snapshot swallow that — so a
+# misconfigured deploy persisted NOTHING while every save reported ok, with the only
+# trace at debug. Still swallowed (a durability hiccup must not break a file write
+# that already landed); just diagnosable now, with the anchor and path in the line.
 from __future__ import annotations
 
 import asyncio
@@ -190,6 +199,35 @@ async def resolve_owning_project(workspace_id: str, user_id: str, row_id: str) -
     return project.id if project is not None else None
 
 
+def _visible_durability(op: str, anchor: str, hook: Any) -> Any:
+    """Wrap a durability hook so a failure is swallowed but never INVISIBLE (B4).
+
+    ``FileRpc`` already swallows a hook failure at DEBUG, which is right about the
+    swallowing (a durability hiccup must not turn a landed file write into a client
+    error) and wrong about the level. The project store fails CLOSED on a
+    misconfigured cloud (``POCKETPAW_UPLOAD_ADAPTER != s3`` → a 503 from
+    ``_require_s3_for_project_store``), so EVERY save on such a deploy raises here:
+    the user's edits are not persisted anywhere and the only trace is a debug line
+    nobody has enabled. Logging at WARNING with the anchor (durable project, or the
+    sandbox row when degraded) and the path makes that diagnosable from ordinary
+    production logs. Swallowing is unchanged.
+    """
+
+    async def _wrapped(*args: Any) -> None:
+        try:
+            await hook(*args)
+        except Exception:  # noqa: BLE001 — durability is best-effort; the file op landed
+            logger.warning(
+                "websandbox.durability: %s failed for %s path=%r — the edit is NOT persisted",
+                op,
+                anchor,
+                args[0] if args else "?",
+                exc_info=True,
+            )
+
+    return _wrapped
+
+
 def build_durability_hooks(
     workspace_id: str,
     user_id: str,
@@ -209,9 +247,12 @@ def build_durability_hooks(
     ``None`` (a sandbox opened outside the project flow) the hooks keep the
     original sandbox-keyed behaviour: degrade, never drop the write.
 
-    All three are best-effort at the call site — ``FileRpc`` swallows a hook
-    failure so durability never fails the file op itself.
+    All three are best-effort — a durability failure must never fail the file op
+    itself — but they are wrapped in ``_visible_durability`` so the failure is
+    LOGGED AT WARNING with its anchor and path instead of vanishing into debug.
     """
+    anchor = f"project={project_id}" if project_id else f"sandbox_row={row_id}"
+
     if project_id:
 
         async def _mirror(rel_path: str, data: bytes) -> None:
@@ -229,7 +270,11 @@ def build_durability_hooks(
                 workspace_id, user_id, project_id, src_rel, dst_rel
             )
 
-        return _mirror, _drop, _move
+        return (
+            _visible_durability("write-through mirror", anchor, _mirror),
+            _visible_durability("overlay drop", anchor, _drop),
+            _visible_durability("overlay re-key", anchor, _move),
+        )
 
     async def _mirror_row(rel_path: str, data: bytes) -> None:
         await websandbox_durability.mirror_file(
@@ -246,7 +291,11 @@ def build_durability_hooks(
         # restore replays the file where it now lives (WC-4c).
         await websandbox_durability.move_overlay(workspace_id, user_id, row_id, src_rel, dst_rel)
 
-    return _mirror_row, _drop_row, _move_row
+    return (
+        _visible_durability("write-through mirror", anchor, _mirror_row),
+        _visible_durability("overlay drop", anchor, _drop_row),
+        _visible_durability("overlay re-key", anchor, _move_row),
+    )
 
 
 async def snapshot_on_disconnect(
@@ -274,8 +323,10 @@ async def snapshot_on_disconnect(
     back to the sandbox-keyed snapshot rather than skipping the capture.
 
     Best-effort by design: a snapshot failure (VM already gone, S3 down, an
-    unprovisioned row) must NEVER surface on socket teardown — it is logged at
-    debug and swallowed.
+    unprovisioned row) must NEVER surface on socket teardown — it is swallowed. It
+    is logged at WARNING though (B4): this is the capture that makes a whole
+    session's work durable, so losing it silently is indistinguishable from data
+    loss on the next open.
     """
     try:
         if project_id and daytona_id:
@@ -287,10 +338,12 @@ async def snapshot_on_disconnect(
                 workspace_id, user_id, row_id, client=client
             )
     except Exception:  # noqa: BLE001 — teardown must never raise on a snapshot miss
-        logger.debug(
-            "websandbox.snapshot on disconnect failed for row=%s project=%s",
+        logger.warning(
+            "websandbox.snapshot on disconnect failed for row=%s project=%s daytona=%s — "
+            "this session's workspace was NOT captured",
             row_id,
             project_id,
+            daytona_id,
             exc_info=True,
         )
 

--- a/tests/cloud/test_codeproject_cross_runtime.py
+++ b/tests/cloud/test_codeproject_cross_runtime.py
@@ -1,0 +1,515 @@
+# test_codeproject_cross_runtime.py — the CROSS-RUNTIME restore matrix (B4,
+# feat/code-cross-runtime-restore): whatever a project saved in one runtime must be
+# retrievable from the other.
+#
+# Created 2026-07-25 (feat/code-cross-runtime-restore).
+#
+# The bug these guard: a project worked on in DAYTONA lands its state in the
+# snapshot tar, and ``set_project_snapshot`` clears the overlay (correctly — the tar
+# supersedes it). The in-tab read-back looked only at the overlay, so reopening that
+# same project in a browser tab returned ``{}`` and the client re-materialized the
+# bare starter scaffold. The user's work looked deleted while it sat safe in S3
+# inside a tarball no browser can read.
+#
+# Fakes only: blob storage through the ``uploads=`` DI seam, Daytona through
+# ``client=`` — no test touches real S3 or a real VM. The CodeProject registry runs
+# on real Beanie over mongomock-motor (the ``mongo_db`` fixture) so the owner-scoped
+# snapshot/overlay writes are exercised for real. Snapshot blobs are REAL gzipped
+# tars built in memory with ``tarfile``, so the expander is tested against the exact
+# archive shape ``tar -czf ... -C <workdir> .`` produces (members named ``./x``).
+#
+# Covers:
+#   * Daytona -> in-tab: a snapshot with an EMPTY overlay reads back the tar's files.
+#   * merge order: a path in BOTH tiers reads back the OVERLAY's content.
+#   * in-tab -> Daytona: an overlay-only project (snapshot_file_id is None) restores
+#     into a fresh VM without needing a snapshot.
+#   * filtering: node_modules / .git / build output and binary entries are excluded;
+#     ordinary nested source (incl. non-ASCII text) survives byte-identical.
+#   * tar safety: absolute, ``..``-traversing, and symlink members are skipped.
+#   * caps: a filtered snapshot still over the cap fails LOUD, never partial.
+from __future__ import annotations
+
+import io
+import logging
+import tarfile
+from datetime import UTC, datetime
+
+import pytest
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud._core.errors import CloudError
+from pocketpaw_ee.cloud.codeproject import router as codeproject_router
+from pocketpaw_ee.cloud.codeproject import service as codeproject_service
+from pocketpaw_ee.cloud.websandbox import durability
+from pocketpaw_ee.cloud.websandbox import ws as terminal_ws
+from pocketpaw_ee.cloud.websandbox.constants import WEBSANDBOX_WORKDIR
+
+from pocketpaw.uploads.errors import NotFound as UploadNotFound
+from pocketpaw.uploads.file_store import FileRecord
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+_WS = "w1"
+_USER = "u1"
+_SANDBOX = "dtn-1"
+
+
+# ---------------------------------------------------------------------------
+# Fakes + tar builder.
+# ---------------------------------------------------------------------------
+
+
+class _FakeDaytonaClient:
+    """Records VM ops and serves a canned tarball on download (the snapshot)."""
+
+    def __init__(self, tar_bytes: bytes = b"") -> None:
+        self.tar_bytes = tar_bytes
+        self.exec_calls: list[str] = []
+        self.upload_calls: list[dict] = []
+
+    async def execute_command(self, sandbox_id, command, **kwargs):  # noqa: ANN001
+        self.exec_calls.append(command)
+        return None
+
+    async def download_file(self, sandbox_id, remote_path):  # noqa: ANN001
+        return self.tar_bytes
+
+    async def upload_bytes(self, sandbox_id, data, remote_path):  # noqa: ANN001
+        self.upload_calls.append({"data": data, "remote_path": remote_path})
+
+
+class _FakeUploads:
+    """In-memory EEUploadService stand-in: one instance carries the blobs."""
+
+    def __init__(self) -> None:
+        self.upload_calls: list[dict] = []
+        self._blobs: dict[str, bytes] = {}
+        self._counter = 0
+
+    async def upload(self, file, owner_id, chat_id, workspace, folder_path="/", pocket_id=None):  # noqa: ANN001
+        data = await file.read()
+        self._counter += 1
+        file_id = f"file-{self._counter}"
+        self.upload_calls.append({"folder_path": folder_path, "data": data})
+        self._blobs[file_id] = data
+        return FileRecord(
+            id=file_id,
+            storage_key=f"key/{file_id}",
+            filename=file.filename,
+            mime="application/octet-stream",
+            size=len(data),
+            owner_id=owner_id,
+            chat_id=None,
+            created=datetime.now(UTC),
+        )
+
+    async def stream(self, file_id, requester_id, workspace):  # noqa: ANN001
+        if file_id not in self._blobs:
+            raise UploadNotFound()
+        data = self._blobs[file_id]
+        rec = FileRecord(
+            id=file_id,
+            storage_key=f"key/{file_id}",
+            filename="blob",
+            mime="application/octet-stream",
+            size=len(data),
+            owner_id=requester_id,
+            chat_id=None,
+            created=datetime.now(UTC),
+        )
+
+        async def _iter():
+            yield data
+
+        return rec, _iter()
+
+
+def _tar(files: dict[str, bytes], *, symlinks: dict[str, str] | None = None) -> bytes:
+    """A REAL gzipped tar shaped like ``tar -czf ... -C <workdir> .`` output.
+
+    Arcnames are passed through verbatim so a test can spell a member exactly as the
+    expander will see it (``./src/app.ts``, ``/etc/passwd``, ``../escape.ts``).
+    Directory entries are emitted for realism — they carry no content and must not
+    show up in the payload.
+    """
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as archive:
+        dirs: set[str] = set()
+        for name in files:
+            parent = name.rsplit("/", 1)[0]
+            if parent and parent not in dirs:
+                dirs.add(parent)
+                info = tarfile.TarInfo(parent)
+                info.type = tarfile.DIRTYPE
+                archive.addfile(info)
+        for name, blob in files.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(blob)
+            archive.addfile(info, io.BytesIO(blob))
+        for name, target in (symlinks or {}).items():
+            info = tarfile.TarInfo(name)
+            info.type = tarfile.SYMTYPE
+            info.linkname = target
+            archive.addfile(info)
+    return buf.getvalue()
+
+
+async def _project(workspace=_WS, user=_USER):  # noqa: ANN001
+    return await codeproject_service.create_project(
+        workspace, user, {"repo": "react", "provider": "starter"}
+    )
+
+
+async def _daytona_session(project_id: str, uploads: _FakeUploads, tar_bytes: bytes) -> None:
+    """Simulate a Daytona session ending: snapshot the VM, which clears the overlay."""
+    await durability.snapshot_project(
+        _WS,
+        _USER,
+        project_id,
+        _SANDBOX,
+        client=_FakeDaytonaClient(tar_bytes=tar_bytes),
+        uploads=uploads,
+    )
+
+
+def _ctx(workspace=_WS, user=_USER):  # noqa: ANN001
+    return RequestContext(
+        user_id=user,
+        workspace_id=workspace,
+        request_id="req-1",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Daytona -> in-tab. THE regression: snapshot set, overlay cleared, read back.
+# ---------------------------------------------------------------------------
+
+
+async def test_snapshot_only_project_reads_back_the_tars_files() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+
+    # Work done in the VM, then a disconnect snapshot — which CLEARS the overlay.
+    await durability.mirror_file_to_project(
+        _WS, _USER, project.id, "src/app.ts", b"pre-snapshot", uploads=uploads
+    )
+    await _daytona_session(
+        project.id,
+        uploads,
+        _tar({"./src/app.ts": b"console.log('work')", "./README.md": b"# hi"}),
+    )
+    fetched = await codeproject_service.get_project(_WS, _USER, project.id)
+    assert fetched.snapshot_file_id is not None
+    assert fetched.overlay == {}  # the state this read-back used to return as {}
+
+    files = await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads)
+
+    # The user's work comes back in the browser instead of a bare scaffold.
+    assert files == {"src/app.ts": "console.log('work')", "README.md": "# hi"}
+
+
+async def test_route_serves_the_snapshot_to_the_in_tab_runtime(monkeypatch) -> None:  # noqa: ANN001
+    # Same regression one layer up: the wire payload the tab actually replays.
+    project = await _project()
+    uploads = _FakeUploads()
+    monkeypatch.setattr(durability, "build_uploads", lambda: uploads)
+    await _daytona_session(project.id, uploads, _tar({"./index.html": b"<h1>hi</h1>"}))
+
+    listing = await codeproject_router.read_project_files(project.id, ctx=_ctx())
+
+    assert listing.files == {"index.html": "<h1>hi</h1>"}
+
+
+# ---------------------------------------------------------------------------
+# 2. Merge order — the overlay is the freshest tier and wins.
+# ---------------------------------------------------------------------------
+
+
+async def test_overlay_wins_over_the_snapshot_for_the_same_path() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+    await _daytona_session(
+        project.id,
+        uploads,
+        _tar({"./src/app.ts": b"OLD-FROM-TAR", "./only-in-tar.ts": b"BASE"}),
+    )
+    # An edit made AFTER the snapshot (either runtime writes this tier).
+    await durability.put_project_file(
+        _WS, _USER, project.id, "src/app.ts", "NEW-FROM-OVERLAY", uploads=uploads
+    )
+
+    files = await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads)
+
+    assert files == {"src/app.ts": "NEW-FROM-OVERLAY", "only-in-tar.ts": "BASE"}
+
+
+async def test_tiers_are_composed_in_the_same_order_the_vm_restore_replays() -> None:
+    # The VM restore untars the snapshot then writes the overlay over it. The
+    # read-back must agree, or the two runtimes disagree about the same project.
+    project = await _project()
+    uploads = _FakeUploads()
+    await _daytona_session(project.id, uploads, _tar({"./a.ts": b"TAR-A"}))
+    await durability.put_project_file(_WS, _USER, project.id, "a.ts", "OVERLAY-A", uploads=uploads)
+
+    vm = _FakeDaytonaClient()
+    await durability.restore_project(
+        _WS, _USER, project.id, "dtn-fresh", client=vm, uploads=uploads
+    )
+    read_back = await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads)
+
+    # The VM's LAST write to a.ts is the overlay copy...
+    vm_writes = [u for u in vm.upload_calls if u["remote_path"] == f"{WEBSANDBOX_WORKDIR}/a.ts"]
+    assert vm_writes[-1]["data"] == b"OVERLAY-A"
+    # ...and the browser payload agrees.
+    assert read_back["a.ts"] == "OVERLAY-A"
+
+
+# ---------------------------------------------------------------------------
+# 3. In-tab -> Daytona. The reverse direction, proven rather than assumed.
+# ---------------------------------------------------------------------------
+
+
+async def test_overlay_only_project_restores_into_a_fresh_vm() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+    # Written from the browser: the in-tab runtime never writes a snapshot.
+    await durability.put_project_file(
+        _WS, _USER, project.id, "src/app.ts", "from the tab", uploads=uploads
+    )
+    await durability.put_project_file(_WS, _USER, project.id, "top.ts", "T", uploads=uploads)
+    assert (await codeproject_service.get_project(_WS, _USER, project.id)).snapshot_file_id is None
+
+    vm = _FakeDaytonaClient()
+    await durability.restore_project(
+        _WS, _USER, project.id, "dtn-fresh", client=vm, uploads=uploads
+    )
+
+    # No snapshot needed — the overlay replays on its own, byte-for-byte.
+    assert not any("tar -xzf" in c for c in vm.exec_calls)
+    written = {u["remote_path"]: u["data"] for u in vm.upload_calls}
+    assert written[f"{WEBSANDBOX_WORKDIR}/src/app.ts"] == b"from the tab"
+    assert written[f"{WEBSANDBOX_WORKDIR}/top.ts"] == b"T"
+    assert any(f"mkdir -p {WEBSANDBOX_WORKDIR}/src" in c for c in vm.exec_calls)
+
+
+async def test_a_tab_written_file_survives_a_round_trip_through_the_vm() -> None:
+    # The full loop: tab writes -> VM restores + snapshots -> tab reads it back.
+    project = await _project()
+    uploads = _FakeUploads()
+    await durability.put_project_file(_WS, _USER, project.id, "note.md", "# mine", uploads=uploads)
+
+    vm = _FakeDaytonaClient()
+    await durability.restore_project(
+        _WS, _USER, project.id, "dtn-fresh", client=vm, uploads=uploads
+    )
+    # The VM session ends and tars what it restored.
+    await _daytona_session(project.id, uploads, _tar({"./note.md": b"# mine"}))
+
+    files = await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads)
+    assert files == {"note.md": "# mine"}
+
+
+# ---------------------------------------------------------------------------
+# 4. Filtering — regenerable trees and binary blobs never reach the browser.
+# ---------------------------------------------------------------------------
+
+
+async def test_regenerable_trees_and_binaries_are_excluded_but_source_survives() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+    source = "export const x = 1;\n// naïve — üñí\n"
+    await _daytona_session(
+        project.id,
+        uploads,
+        _tar(
+            {
+                "./node_modules/left-pad/index.js": b"module.exports = 1",
+                "./src/node_modules/nested/pkg.js": b"deep dep",
+                "./.git/objects/ab/cdef": b"\x00binary-git-object",
+                "./dist/bundle.js": b"built",
+                "./build/out.js": b"built",
+                "./.next/server/page.js": b"built",
+                "./.svelte-kit/generated/root.js": b"built",
+                "./.turbo/log.txt": b"cached",
+                "./.cache/x": b"cached",
+                "./coverage/lcov.info": b"report",
+                "./assets/logo.png": b"\x89PNG\r\n\x1a\n\xff\xfe",  # not UTF-8
+                "./src/deep/nested/mod.ts": source.encode("utf-8"),
+                "./package.json": b'{"name":"app"}',
+            }
+        ),
+    )
+
+    files = await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads)
+
+    assert set(files) == {"src/deep/nested/mod.ts", "package.json"}
+    # Byte-identical, non-ASCII included.
+    assert files["src/deep/nested/mod.ts"] == source
+    assert files["src/deep/nested/mod.ts"].encode("utf-8") == source.encode("utf-8")
+
+
+async def test_a_file_named_like_an_excluded_tree_is_kept() -> None:
+    # The filter matches whole path SEGMENTS — ``build.ts`` is source, ``build/`` is
+    # output. Dropping a user's file because of a prefix would be data loss.
+    project = await _project()
+    uploads = _FakeUploads()
+    await _daytona_session(
+        project.id,
+        uploads,
+        _tar({"./build.ts": b"SRC", "./src/dist-utils.ts": b"SRC2", "./build/x.js": b"OUT"}),
+    )
+
+    files = await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads)
+
+    assert files == {"build.ts": "SRC", "src/dist-utils.ts": "SRC2"}
+
+
+# ---------------------------------------------------------------------------
+# 5. Tar safety — the archive is untrusted input.
+# ---------------------------------------------------------------------------
+
+
+async def test_unsafe_tar_members_are_skipped_not_written() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+    await _daytona_session(
+        project.id,
+        uploads,
+        _tar(
+            {
+                "/etc/passwd": b"root:x:0:0",  # absolute
+                "../../escape.ts": b"ESCAPED",  # traversal
+                "./src/../../also-escape.ts": b"ESCAPED",  # traversal mid-path
+                "./ok.ts": b"OK",
+            },
+            symlinks={"./link-out.ts": "/etc/passwd", "./inner-link.ts": "ok.ts"},
+        ),
+    )
+
+    files = await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads)
+
+    # Only the one legitimate member survives — no absolute path, no traversal, and
+    # no link entry (a symlink is a smuggling vector with no meaning in a tab FS).
+    assert files == {"ok.ts": "OK"}
+    assert not any(p.startswith("/") or ".." in p for p in files)
+
+
+async def test_directory_members_do_not_become_files() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+    await _daytona_session(project.id, uploads, _tar({"./src/a.ts": b"A"}))
+
+    files = await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads)
+
+    assert files == {"src/a.ts": "A"}
+    assert "src" not in files
+
+
+# ---------------------------------------------------------------------------
+# Caps + failure modes — loud, never silently partial.
+# ---------------------------------------------------------------------------
+
+
+async def test_a_filtered_snapshot_over_the_byte_cap_fails_loud(monkeypatch) -> None:  # noqa: ANN001
+    # Policy: what survives filtering IS user work, so a truncated payload would
+    # look like deleted files. 413 instead — the project still opens in the VM
+    # runtime, whose restore has no such cap.
+    project = await _project()
+    uploads = _FakeUploads()
+    await _daytona_session(project.id, uploads, _tar({"./big.ts": b"x" * 4096}))
+    monkeypatch.setenv("POCKETPAW_CODEPROJECT_OVERLAY_MAX_MB", "0.001")  # ~1 KB
+
+    with pytest.raises(CloudError) as exc:
+        await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads)
+    assert exc.value.code == "codeproject.overlay_too_large"
+    assert exc.value.status_code == 413
+
+
+async def test_excluded_bytes_do_not_count_against_the_cap(monkeypatch) -> None:  # noqa: ANN001
+    # The complement: a huge node_modules must NOT push a small source tree over
+    # the cap, or every real project would 413.
+    project = await _project()
+    uploads = _FakeUploads()
+    await _daytona_session(
+        project.id,
+        uploads,
+        _tar({"./node_modules/huge/blob.js": b"y" * 200_000, "./src/a.ts": b"A"}),
+    )
+    monkeypatch.setenv("POCKETPAW_CODEPROJECT_OVERLAY_MAX_MB", "0.001")  # ~1 KB
+
+    assert await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads) == {
+        "src/a.ts": "A"
+    }
+
+
+async def test_a_corrupt_snapshot_raises_instead_of_returning_a_partial_tree() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+    await _daytona_session(project.id, uploads, b"NOT-A-TARBALL")
+    await durability.put_project_file(_WS, _USER, project.id, "a.ts", "A", uploads=uploads)
+
+    with pytest.raises(CloudError) as exc:
+        await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads)
+    # Returning just the overlay here would silently drop the whole baseline.
+    assert exc.value.code == "codeproject.snapshot_unreadable"
+    assert exc.value.status_code == 502
+
+
+async def test_a_truncated_snapshot_raises_too() -> None:
+    # Truncation fails in the DECOMPRESSOR mid-iteration, not at open — a different
+    # exception family, same "the baseline is gone" outcome, same loud answer.
+    project = await _project()
+    uploads = _FakeUploads()
+    whole = _tar({f"./f{i}.ts": b"x" * 500 for i in range(50)})
+    await _daytona_session(project.id, uploads, whole[: len(whole) // 2])
+
+    with pytest.raises(CloudError) as exc:
+        await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads)
+    assert exc.value.code == "codeproject.snapshot_unreadable"
+
+
+async def test_a_project_with_neither_tier_still_reads_back_empty() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+
+    assert await durability.read_project_overlay(_WS, _USER, project.id, uploads=uploads) == {}
+
+
+async def test_a_swallowed_durability_failure_is_logged_at_warning(monkeypatch, caplog) -> None:  # noqa: ANN001
+    """A misconfigured cloud persists nothing — that must be visible, not debug-only.
+
+    The exact production shape: ``POCKETPAW_UPLOAD_ADAPTER != s3`` in cloud makes the
+    project store fail closed on EVERY save. FileRpc swallows the hook failure (right
+    — the VM write already landed), so before this fix the only trace was a debug line.
+    """
+    project = await _project()
+    uploads = _FakeUploads()
+    monkeypatch.setattr(durability, "is_multi_tenant_cloud", lambda: True)
+    monkeypatch.setenv("POCKETPAW_UPLOAD_ADAPTER", "local")
+
+    on_write, _on_delete, _on_move = terminal_ws.build_durability_hooks(
+        _WS, _USER, "row-1", project.id, uploads
+    )
+    with caplog.at_level(logging.WARNING, logger="pocketpaw_ee.cloud.websandbox.ws"):
+        await on_write("src/app.ts", b"A")  # must NOT raise into the file op
+
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings, "a failed durable write was invisible"
+    message = warnings[-1].getMessage()
+    assert project.id in message and "src/app.ts" in message
+    # Still swallowed, and still genuinely unpersisted (the guard did its job).
+    assert (await codeproject_service.get_project(_WS, _USER, project.id)).overlay == {}
+
+
+async def test_the_snapshot_tier_is_owner_scoped_too() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+    await _daytona_session(project.id, uploads, _tar({"./secret.ts": b"S"}))
+
+    from pocketpaw_ee.cloud._core.errors import NotFound
+
+    with pytest.raises(NotFound):
+        await durability.read_project_overlay("w2", _USER, project.id, uploads=uploads)
+    with pytest.raises(NotFound):
+        await durability.read_project_overlay(_WS, "u2", project.id, uploads=uploads)


### PR DESCRIPTION
## The bug

A project can open in either runtime, and both now store their durable state on the same `CodeProject` in the same tenant S3. But the two tiers weren't read symmetrically.

`set_project_snapshot` writes the tarball pointer **and clears the overlay** — correct, a full snapshot supersedes the incremental tier. The in-tab restore payload, though, read *only* the overlay and never looked at `snapshot_file_id`.

So: work in Daytona → disconnect (snapshot written, overlay cleared) → open the same project in the browser → the read-back returns `{}` and you get a bare starter scaffold. The work is safe in S3 the whole time, sitting in a tarball the browser had no way to read.

## The fix

The in-tab read-back now composes **both tiers, in the same order the VM restore replays them**: expand the snapshot tarball in memory as the baseline, then apply the overlay on top so the freshest write wins. Read-side only — nothing about what Daytona writes changed.

**A tar is untrusted input**, and this one gets expanded into the user's filesystem, so members are jailed before they can become a write: absolute names and backslash-containing names are rejected outright (a backslash isn't a separator here, so `..\..\x` would otherwise slip past a segment check), `..` traversal is rejected, and non-regular members — directories, symlinks, hardlinks, devices — are skipped. The write-boundary jail was extended rather than duplicated: one non-raising normalizer underneath, so the PUT path still returns 422 and the tar expander skips.

**Filtering, because the snapshot tars everything.** `tar -czf ... -C <workdir> .` has no excludes, so a snapshot can carry `node_modules`, `.git`, and build output — hundreds of MB, and useless as a JSON payload. One named constant excludes those trees by path *segment* (so a file named `build.ts` survives), with the reasoning recorded next to it: they're reinstallable or rebuildable, and `npm install` restores `node_modules`. Non-UTF-8 entries are skipped with a warning, matching how the read-back already tolerates one unreadable file. The byte cap is checked from each member's header *before* any read, so a tar bomb can't blow up memory.

**Cap policy: loud, not partial.** A filtered snapshot still over the cap raises 413 rather than truncating. Filtering has already removed everything that isn't user work, so what remains over the cap *is* the project — truncating it would look exactly like deleted files. A corrupt or truncated snapshot raises 502 rather than quietly falling back to the overlay alone.

## Also: a failed durable write is no longer invisible

FileRpc swallowed durability hook failures at **debug**. Combined with the project store's fail-closed S3 guard, a cloud with `POCKETPAW_UPLOAD_ADAPTER != s3` meant edits silently didn't persist with no visible trace. Failures are still swallowed — a durability hiccup must not break the user's file write — but now log at **warning** with the anchor and path.

## Tests

`tests/cloud/test_codeproject_cross_runtime.py` (new, 17 tests) → **460 passed** across every suite that touches the changed modules. Real gzipped tars built with `tarfile`, fakes on both DI seams, no S3 and no VM.

- **Daytona → in-tab**, the regression itself, at both the function and route layer.
- **Merge order** — a path in both tiers reads back the overlay's content, and the browser payload agrees with the VM's last write.
- **In-tab → Daytona proven, not assumed** — an overlay-only project (`snapshot_file_id is None`) restores into a fresh VM with no `tar -xzf` and byte-identical uploads, plus a full tab → VM → tab loop.
- **Filtering** — all nine excluded trees including a nested `src/node_modules`, a PNG, and a file *named* like an excluded tree that must survive; non-ASCII source round-trips byte-identical.
- **Tar safety** — absolute path, `..` traversal, mid-path traversal, and two symlinks all skipped; only the legitimate member survives.

The regression was proven rather than asserted: with the durability module reverted, the three Daytona → in-tab tests fail; restored, they pass.

## Known trade

The excluded-tree list is a fixed constant, so a project keeping user-authored files under, say, `build/` won't see them in the tab (they still restore fully in the VM). That trade is documented at the constant.

## Base

Stacked on `feat/code-daytona-project-anchor` (#1785).
