### PR TITLE
Open a scaffolded project on the VM runtime

### DIFF
--- a/ee/pocketpaw_ee/cloud/codeproject/lifecycle.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/lifecycle.py
@@ -52,10 +52,31 @@
 # reuse branch is covered too, and it never fires for scaffold projects — copying
 # one shared row's state into N sibling starter projects is the very stomping this
 # task removes.
+#
+# 2026-07-25 (B3, feat/code-scaffold-on-vm): a SCAFFOLD project can now open on the
+# Daytona runtime. It could not before — its ``repo`` is a starter template id, and
+# ``open_sandbox`` fail-closes on anything that isn't a clean http(s) URL, so the
+# open was rejected before a VM existed and scaffold projects were in-tab only.
+# The fix is a different door, not a weaker lock: ``open_bare_sandbox`` provisions
+# an EMPTY VM (no clone, no remote, no branch) and ``scaffold_into_sandbox``
+# materializes the starter into it. ``_validate_repo_url`` is untouched and still
+# guards every clone.
+#
+# Sequencing is load-bearing: scaffold FIRST, restore SECOND. The template is the
+# baseline; the durable snapshot + overlay are the user's work, so they land ON TOP
+# of it and win every conflict. Reversing it would have the template overwrite the
+# user's edits.
+#
+# The re-scaffold guard is structural: the scaffold call sits ONLY in the
+# cold-provision branch, so it runs against a VM this call just created and which
+# is therefore empty by construction. The reuse branch returns before it, so a live
+# VM (or a reopen that reuses one) is never re-materialized over. See
+# ``_scaffold_baseline`` for why this is the guard rather than a VM probe.
 from __future__ import annotations
 
 import contextlib
 import logging
+from typing import Any
 
 from pocketpaw_ee.cloud._core.errors import NotFound
 from pocketpaw_ee.cloud.codeproject import service as codeproject_service
@@ -63,6 +84,7 @@ from pocketpaw_ee.cloud.codeproject.domain import CodeProjectView, is_scaffold_p
 from pocketpaw_ee.cloud.daytona.client import DaytonaClient, get_daytona_client
 from pocketpaw_ee.cloud.websandbox import durability as websandbox_durability
 from pocketpaw_ee.cloud.websandbox import provision as websandbox_provision
+from pocketpaw_ee.cloud.websandbox import scaffold_service as websandbox_scaffold
 from pocketpaw_ee.cloud.websandbox import service as websandbox_service
 from pocketpaw_ee.cloud.websandbox.domain import WebSandboxView
 
@@ -85,21 +107,30 @@ async def open_project(
     user_id: str,
     project_id: str,
     client: DaytonaClient | None = None,
+    *,
+    bring_up: Any = None,
 ) -> WebSandboxView:
     """Open a durable project, returning a ready sandbox to connect to.
 
     Flow:
       1. Load the project (tenant + owner scoped; ``NotFound`` if not owned).
       2. If it's bound to a sandbox that is still live (``ready`` + Daytona id),
-         reuse it and re-stamp ``last_opened_at``.
-      3. Otherwise cold-provision a fresh sandbox for the project's repo (via
-         ``websandbox.provision.open_sandbox`` — idempotent on the repo, so this
-         reuses the project's stable WebSandbox row and boots a new VM into it),
-         then restore the PROJECT's durable state into it and bind it.
+         reuse it and re-stamp ``last_opened_at``. Nothing is re-materialized on
+         this branch — the VM already holds the user's work.
+      3. Otherwise cold-provision a FRESH sandbox for the project:
+         * a repo project clones (``open_sandbox``, which validates the URL);
+         * a scaffold project provisions an EMPTY VM (``open_bare_sandbox``) and
+           materializes its starter into it — its ``repo`` is a template id, so
+           there is nothing to clone and the clone validator must not see it.
+         Then restore the PROJECT's durable state ON TOP and bind it.
 
     Returns the ready ``WebSandboxView``. The bound-but-invalid case (the VM was
     reaped, or the id no longer resolves) falls through to reprovision — "if the
     id is invalid or unavailable, make a new sandbox."
+
+    ``bring_up`` is the same kind of DI seam as ``client``: it is threaded to
+    ``scaffold_into_sandbox`` so a test can drive the whole scaffold open without a
+    real VM. ``None`` means "use the real one"; no production caller passes it.
     """
     project = await codeproject_service.get_project(workspace_id, user_id, project_id)
     # B2 rollout: lift any legacy sandbox-keyed durable state onto the project
@@ -114,22 +145,110 @@ async def open_project(
         await codeproject_service.bind_current_sandbox(workspace_id, user_id, project_id, reused.id)
         return reused
 
-    # Provision a fresh sandbox for the repo (idempotent on the repo → reuses the
+    # Provision a fresh sandbox (idempotent on the registry key → reuses the
     # project's stable WebSandbox row, boots a new VM into it) and bind it.
-    sandbox = await websandbox_provision.open_sandbox(
-        workspace_id, user_id, {"repo": project.repo}, client=client
-    )
+    if is_scaffold_provider(project.provider):
+        sandbox = await websandbox_provision.open_bare_sandbox(
+            workspace_id, user_id, _scaffold_registry_key(project), client=client
+        )
+        # The BASELINE, written before any durable state: this VM was created
+        # moments ago and is empty, so materializing the template into it cannot
+        # overwrite anything.
+        await _scaffold_baseline(workspace_id, user_id, project, sandbox, client, bring_up)
+    else:
+        sandbox = await websandbox_provision.open_sandbox(
+            workspace_id, user_id, {"repo": project.repo}, client=client
+        )
     # CM-2a′ / B2: overlay the PROJECT's durable snapshot (uncommitted work +
     # branch from a prior session) onto the freshly-cloned VM, if one exists.
+    # B3: for a scaffold project this lands ON TOP of the starter above — the
+    # template is the baseline, the durable state is the user's work.
     await _restore_if_snapshotted(workspace_id, user_id, project, sandbox, client)
     await codeproject_service.bind_current_sandbox(workspace_id, user_id, project_id, sandbox.id)
     logger.info(
-        "codeproject.open: project=%s bound fresh sandbox=%s (repo=%s)",
+        "codeproject.open: project=%s bound fresh sandbox=%s (provider=%s repo=%s)",
         project_id,
         sandbox.id,
+        project.provider,
         project.repo,
     )
     return sandbox
+
+
+def _scaffold_registry_key(project: CodeProjectView) -> str:
+    """The WebSandbox registry key for a scaffold project — one row per PROJECT.
+
+    A sandbox row is unique per (workspace, user, key). Passing the raw template id
+    as that key would give every project built from ``react`` ONE row, and the row
+    is what binds a project to a VM: opening project B would rebind (and tear down)
+    project A's VM, and ``_reuse_if_live`` would then hand project A the sandbox
+    holding project B's files. That is the same shared-row collision B2 removed from
+    the durability pointers, so the key is namespaced by the project id and the
+    collision cannot occur.
+
+    The template id stays in the key because a key is also a debugging aid — a row
+    reading ``starter:react:<id>`` says what it is without a second lookup. It is
+    stable across opens (both parts are immutable), so idempotent reuse still holds.
+    """
+    return f"starter:{project.repo}:{project.id}"
+
+
+async def _scaffold_baseline(
+    workspace_id: str,
+    user_id: str,
+    project: CodeProjectView,
+    sandbox: WebSandboxView,
+    client: DaytonaClient | None,
+    bring_up: Any,
+) -> None:
+    """Materialize the project's starter into a freshly-provisioned, EMPTY VM.
+
+    The re-scaffold guard is the CALL SITE, not a flag: this only ever runs in
+    ``open_project``'s cold-provision branch, immediately after
+    ``open_bare_sandbox`` returned a VM it created in this same call. Such a VM is
+    empty by construction, so writing the template into it cannot destroy work. A
+    reopen that finds a live VM returns from the reuse branch above and never
+    reaches here; a reopen that finds a dead VM gets a new empty one, where the
+    template is again the correct baseline and the restore that follows puts the
+    user's own files back over it.
+
+    Deliberately NOT guarded by probing the VM for emptiness instead: the workdir
+    is a home directory that already contains shell dotfiles, so "is it empty" has
+    no honest answer, and a guard that reads ambiguous evidence is worse than one
+    that relies on an invariant the code itself maintains.
+
+    Best-effort, like the restore that follows it. A codescaffold outage (an
+    unreachable registry, a starter pulled from the catalog) must not strand a
+    returning user whose real work is in the durable state — an empty VM plus a
+    successful restore is recoverable, a failed open is not. A failed bring-up STEP
+    (a broken ``npm install``) does not raise at all; it is reported and logged, and
+    the files are still on disk.
+    """
+    body = {"starter": project.repo, "projectName": project.name}
+    extra = {} if bring_up is None else {"bring_up": bring_up}
+    try:
+        result = await websandbox_scaffold.scaffold_into_sandbox(
+            workspace_id, user_id, sandbox.id, body, client=client, **extra
+        )
+    except Exception:  # noqa: BLE001 — never block the open on the baseline
+        logger.warning(
+            "codeproject.open: scaffold failed for project=%s (starter=%s); "
+            "continuing with an empty VM",
+            project.id,
+            project.repo,
+            exc_info=True,
+        )
+        return
+    logger.info(
+        "codeproject.open: scaffolded project=%s starter=%s into daytona=%s "
+        "(files=%d, running=%s, failedStep=%s)",
+        project.id,
+        result.starter,
+        sandbox.sandbox_id,
+        result.fileCount,
+        result.running,
+        result.failedStep,
+    )
 
 
 async def delete_project(

--- a/ee/pocketpaw_ee/cloud/websandbox/provision.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/provision.py
@@ -35,12 +35,28 @@
 # Every provisioning fn takes ``client: DaytonaClient | None = None`` (default
 # ``get_daytona_client()``) — the mandatory DI seam so tests inject a FAKE client
 # and no test ever hits real Daytona.
+#
+# 2026-07-25 (B3, feat/code-scaffold-on-vm): the open flow split in two. The
+# shared half — quota, the idempotent registry row, cold-provision, boot wait,
+# the ready/rebind write, old-VM teardown — moved into ``_provision_into_row``;
+# what differs is only what gets put INTO the booted VM. ``open_sandbox`` keeps
+# the git clone (and keeps ``_validate_repo_url`` on it, unconditionally);
+# ``open_bare_sandbox`` adds an EMPTY VM with no clone, no git remote, and no
+# edit branch, for a scaffold project whose "repo" is a starter TEMPLATE id.
+#
+# The split exists so ``_validate_repo_url`` never has to be loosened. A template
+# id ("react") is not a URL and never will be; the fix is to keep it off the
+# clone path entirely rather than to teach the validator a second, weaker shape.
+# That validator is a security control — it is what stops a local-path remote or
+# a client-supplied credential reaching the VM's git config (and its snapshots) —
+# so anything that would relax it for a non-git caller is the wrong direction.
 from __future__ import annotations
 
 import asyncio
 import contextlib
 import logging
 import os
+from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime, timedelta
 from urllib.parse import urlparse
 from uuid import uuid4
@@ -196,6 +212,33 @@ def _validate_repo_url(repo: str) -> str:
     return candidate
 
 
+# The registry key's own bound. It is stored in ``WebSandbox.repo``, whose write
+# command (``CreateSandboxRequest.repo``) caps at 1024 — checking it here turns a
+# too-long key into a clean 400 instead of a pydantic error from two layers down.
+_MAX_REGISTRY_KEY = 1024
+
+
+def _validate_registry_key(key: str) -> str:
+    """Validate a NON-git registry key (the row's ``repo`` slot), returning it.
+
+    Deliberately NOT ``_validate_repo_url``. A bare VM clones nothing, so this
+    string is only ever a registry key — the (workspace, user, key) tuple that
+    makes ``create_sandbox`` idempotent. There is no URL to parse, no remote to
+    write, and no credential that could ride along, so the URL rules would be
+    both wrong and unenforceable here.
+
+    That is also why this is not a public write surface: no router binds it. The
+    only caller is the scaffold open path, which builds the key server-side from a
+    project it has already tenant-checked.
+    """
+    candidate = (key or "").strip()
+    if not candidate:
+        raise BadRequest("websandbox.invalid_key", "A workspace key is required")
+    if len(candidate) > _MAX_REGISTRY_KEY:
+        raise BadRequest("websandbox.invalid_key", "Workspace key is too long")
+    return candidate
+
+
 def _require_client(client: DaytonaClient | None) -> DaytonaClient:
     """Resolve the Daytona client, raising a clean CloudError when unconfigured.
 
@@ -217,6 +260,11 @@ def _require_client(client: DaytonaClient | None) -> DaytonaClient:
 # open flow.
 # ---------------------------------------------------------------------------
 
+#: What puts CONTENT into a freshly-booted, empty VM, called once with
+#: ``(daytona, daytona_id, project_dir)`` after the boot wait and the workdir
+#: mkdir. ``open_sandbox`` passes the git clone; a bare open passes nothing.
+_FillStage = Callable[[DaytonaClient, str, str], Awaitable[None]]
+
 
 async def open_sandbox(
     workspace_id: str,
@@ -236,9 +284,129 @@ async def open_sandbox(
     On any failure after the row exists, the row is advanced to ``stopped`` and a
     ``CloudError`` is raised (never left stuck in ``opening``); a VM created before
     the failure is best-effort stopped+deleted so a crash can't leak a live VM.
+
+    ``_validate_repo_url`` runs here, on EVERY clone, before anything is
+    provisioned. The bare path (``open_bare_sandbox``) exists precisely so that
+    stays true — a caller with no repo takes a different door instead of asking
+    this one to accept a weaker string.
     """
     body = OpenSandboxRequest.model_validate(body)
     repo_url = _validate_repo_url(body.repo)
+    # WC-5a: the repo is checked out onto a fresh branch in the VM so AI edits
+    # never touch the default branch. Minted before the fill stage so the same
+    # name reaches both the checkout and the row's ``branch`` binding.
+    branch = _new_edit_branch()
+
+    async def _clone_into(daytona: DaytonaClient, daytona_id: str, project_dir: str) -> None:
+        """Clone the repo, branch it, and (when brokered) wire the push remote."""
+        # CM-3c: if the caller has a GitHub connection whose installation can reach
+        # this repo, clone it via the BROKER — the token is minted + used entirely
+        # server-side and NEVER enters the VM (the VM receives files + a token-free
+        # git remote). Otherwise, clone the PUBLIC repo in-VM with NO credentials.
+        scoped = await websandbox_broker.resolve_repo_token(workspace_id, user_id, repo_url)
+        if scoped is not None:
+            await websandbox_broker.clone_into_vm(
+                daytona,
+                daytona_id,
+                scoped,
+                project_dir,
+                clean_url=repo_url,
+                branch=body.branch,
+            )
+        else:
+            await daytona.git_clone(daytona_id, repo_url, project_dir, branch=body.branch)
+
+        # Check out a fresh ``paw/edit-<hex>`` branch IN the VM (WC-5a) so every AI
+        # edit lands on an isolated branch, never the checked-out default. cwd is
+        # the pinned workspace dir where the repo was cloned.
+        await daytona.execute_command(
+            daytona_id,
+            f"git checkout -b {branch}",
+            cwd=project_dir,
+            timeout=_BRANCH_CHECKOUT_TIMEOUT_SECONDS,
+        )
+
+        # CM-3d: for a broker-cloned (connected) repo, repoint ``origin`` at the
+        # git proxy so an in-VM ``git push``/``fetch`` works with the token still
+        # minted server-side (never in the VM). Best-effort — a wiring miss leaves
+        # the clone fully usable, it just can't push yet; it must never fail the
+        # open. Skipped for public clones (no connection to push through) and when
+        # no public backend URL is reachable from the VM.
+        if scoped is not None:
+            with contextlib.suppress(Exception):
+                await codegit_wire.wire_push_remote(
+                    daytona,
+                    daytona_id,
+                    workspace_id,
+                    user_id,
+                    websandbox_broker.repo_full_name(repo_url) or repo_url,
+                    project_dir,
+                )
+
+    return await _provision_into_row(
+        workspace_id,
+        user_id,
+        repo_url,
+        branch=branch,
+        fill=_clone_into,
+        client=client,
+    )
+
+
+async def open_bare_sandbox(
+    workspace_id: str,
+    user_id: str,
+    key: str,
+    client: DaytonaClient | None = None,
+) -> WebSandboxView:
+    """Cold-provision an EMPTY Daytona VM — no clone, no git remote, no branch.
+
+    The scaffold half of the open flow (B3). A scaffold project's ``repo`` field
+    holds a starter TEMPLATE id, not a URL, so there is nothing to clone and no
+    remote to authenticate: the VM boots empty and the caller materializes the
+    starter into it (``websandbox.scaffold_service.scaffold_into_sandbox``).
+
+    Everything else is identical to ``open_sandbox`` — the same per-user quota,
+    the same idempotent (workspace, user, key) row, the same failure handling, the
+    same old-VM teardown on a re-open. ``key`` is the row's registry key only; it
+    is server-built by the caller and never reaches git, a URL builder, or a
+    shell (see ``_validate_registry_key``).
+
+    Returns the ready view with a bound Daytona id and NO ``branch`` — a VM with
+    no repository has no branch to report, and inventing one would make the git
+    surface look available on a project that has no git.
+    """
+    return await _provision_into_row(
+        workspace_id,
+        user_id,
+        _validate_registry_key(key),
+        branch=None,
+        fill=None,
+        client=client,
+    )
+
+
+async def _provision_into_row(
+    workspace_id: str,
+    user_id: str,
+    registry_key: str,
+    *,
+    branch: str | None,
+    fill: _FillStage | None,
+    client: DaytonaClient | None,
+) -> WebSandboxView:
+    """Cold-provision a VM into the (workspace, user, ``registry_key``) row.
+
+    The half both open paths share: quota + re-open bookkeeping, the idempotent
+    registry row, the cold-provision with the aggressive Daytona lifecycle, the
+    boot wait, the ``ready`` rebind, and the old-VM teardown. ``fill`` is the only
+    difference between them — what (if anything) gets put into the booted VM.
+
+    ``registry_key`` is ALREADY validated by the caller: ``open_sandbox`` runs the
+    fail-closed ``_validate_repo_url`` on it, the bare path runs
+    ``_validate_registry_key``. This function never relaxes either — it does not
+    inspect the key at all, it only stores it.
+    """
     daytona = _require_client(client)
 
     # Quota + re-open bookkeeping — read the caller's OWN rows once (tenant- and
@@ -246,7 +414,7 @@ async def open_sandbox(
     # row (not a new slot); opening a NEW repo past the per-user live cap is
     # rejected cleanly rather than cold-booting an unbounded number of VMs.
     owned = await websandbox_service.list_sandboxes(workspace_id, user_id)
-    existing = next((r for r in owned if r.repo == repo_url), None)
+    existing = next((r for r in owned if r.repo == registry_key), None)
     old_sandbox_id = existing.sandbox_id if existing is not None else None
     cap = _max_per_user()
     if cap and existing is None:
@@ -260,12 +428,11 @@ async def open_sandbox(
     # 1. Upsert the registry row (idempotent on workspace+user+repo) and move it
     #    to ``opening`` so a concurrent reader sees the in-flight state.
     row = await websandbox_service.create_sandbox(
-        workspace_id, user_id, {"repo": repo_url, "status": "pending"}
+        workspace_id, user_id, {"repo": registry_key, "status": "pending"}
     )
     await websandbox_service.update_status(workspace_id, user_id, row.id, {"status": "opening"})
 
     daytona_id: str | None = None
-    branch = _new_edit_branch()
     try:
         # 2. Cold-provision with the aggressive Daytona lifecycle (all MINUTES):
         #    stop after 5 idle, archive 5 after stop, delete immediately on stop.
@@ -288,62 +455,22 @@ async def open_sandbox(
         )
         daytona_id = info.id
 
-        # 3. Block until the VM is booted before cloning.
+        # 3. Block until the VM is booted before filling it.
         await daytona.wait_for_sandbox(
             daytona_id, target_state="started", timeout=_BOOT_TIMEOUT_SECONDS
         )
 
-        # 4. Clone the repo into the sandbox's project dir.
-        # Clone INTO the pinned workspace dir (WEBSANDBOX_WORKDIR = /home/daytona)
-        # so the file tree, the terminal cwd, and the clone all agree on one
-        # directory. get_project_dir() returns /root on this image, which the
+        # 4. Fill the sandbox's project dir (a clone, or nothing for a bare VM).
+        # The dir is the pinned workspace dir (WEBSANDBOX_WORKDIR = /home/daytona)
+        # so the file tree, the terminal cwd, and whatever lands here all agree on
+        # one directory. get_project_dir() returns /root on this image, which the
         # terminal never opens in — that mismatch is why the tree looked empty.
-        #
-        # CM-3c: if the caller has a GitHub connection whose installation can reach
-        # this repo, clone it via the BROKER — the token is minted + used entirely
-        # server-side and NEVER enters the VM (the VM receives files + a token-free
-        # git remote). Otherwise, clone the PUBLIC repo in-VM with NO credentials.
+        # It is created even on the bare path: the scaffold materializes into it,
+        # and the file tree lists it.
         project_dir = WEBSANDBOX_WORKDIR
         await daytona.execute_command(daytona_id, f"mkdir -p {project_dir}")
-        scoped = await websandbox_broker.resolve_repo_token(workspace_id, user_id, repo_url)
-        if scoped is not None:
-            await websandbox_broker.clone_into_vm(
-                daytona,
-                daytona_id,
-                scoped,
-                project_dir,
-                clean_url=repo_url,
-                branch=body.branch,
-            )
-        else:
-            await daytona.git_clone(daytona_id, repo_url, project_dir, branch=body.branch)
-
-        # 4b. Check out a fresh ``paw/edit-<hex>`` branch IN the VM (WC-5a) so
-        #     every AI edit lands on an isolated branch, never the checked-out
-        #     default. cwd is the pinned workspace dir where the repo was cloned.
-        await daytona.execute_command(
-            daytona_id,
-            f"git checkout -b {branch}",
-            cwd=project_dir,
-            timeout=_BRANCH_CHECKOUT_TIMEOUT_SECONDS,
-        )
-
-        # 4c. CM-3d: for a broker-cloned (connected) repo, repoint ``origin`` at
-        #     the git proxy so an in-VM ``git push``/``fetch`` works with the token
-        #     still minted server-side (never in the VM). Best-effort — a wiring
-        #     miss leaves the clone fully usable, it just can't push yet; it must
-        #     never fail the open. Skipped for public clones (no connection to push
-        #     through) and when no public backend URL is reachable from the VM.
-        if scoped is not None:
-            with contextlib.suppress(Exception):
-                await codegit_wire.wire_push_remote(
-                    daytona,
-                    daytona_id,
-                    workspace_id,
-                    user_id,
-                    websandbox_broker.repo_full_name(repo_url) or repo_url,
-                    project_dir,
-                )
+        if fill is not None:
+            await fill(daytona, daytona_id, project_dir)
     except Exception as exc:  # noqa: BLE001 — any provisioning failure is handled uniformly
         # Best-effort teardown of a half-created VM so a failure can't leak it.
         if daytona_id is not None:
@@ -354,13 +481,17 @@ async def open_sandbox(
             await websandbox_service.update_status(
                 workspace_id, user_id, row.id, {"status": "stopped"}
             )
-        logger.warning("websandbox.open failed for repo=%s row=%s", repo_url, row.id, exc_info=True)
+        logger.warning(
+            "websandbox.open failed for key=%s row=%s", registry_key, row.id, exc_info=True
+        )
         raise with_cause(
             CloudError(502, "websandbox.provision_failed", "Failed to provision the sandbox"),
             exc,
         ) from exc
 
     # 5. Bind the Daytona id + the auto-created feature branch, and mark ready.
+    #    ``branch`` is None on the bare path and ``update_status`` skips a None,
+    #    so a bare VM's row simply carries no branch.
     ready = await websandbox_service.update_status(
         workspace_id,
         user_id,
@@ -377,11 +508,12 @@ async def open_sandbox(
         with contextlib.suppress(Exception):
             await daytona.delete_sandbox(old_sandbox_id)
     logger.info(
-        "websandbox.open ready: row=%s daytona=%s branch=%s repo=%s",
+        "websandbox.open ready: row=%s daytona=%s branch=%s key=%s filled=%s",
         row.id,
         daytona_id,
         branch,
-        repo_url,
+        registry_key,
+        fill is not None,
     )
     return ready
 
@@ -533,6 +665,7 @@ async def stop_websandbox_reaper(app: FastAPI) -> None:
 
 __all__ = [
     "get_tree",
+    "open_bare_sandbox",
     "open_sandbox",
     "reap_idle_sandboxes",
     "start_websandbox_reaper",

--- a/tests/cloud/test_codeproject_scaffold_open.py
+++ b/tests/cloud/test_codeproject_scaffold_open.py
@@ -1,0 +1,370 @@
+# test_codeproject_scaffold_open.py — B3: a SCAFFOLD project opens on the Daytona
+# VM runtime.
+#
+# Created 2026-07-25 (B3, feat/code-scaffold-on-vm).
+#
+# What was broken: ``open_project`` provisioned every project through
+# ``open_sandbox``, which runs ``_validate_repo_url`` and fail-closes on anything
+# that isn't a clean http(s) URL. A scaffold project's ``repo`` is a starter
+# TEMPLATE id ("react"), so the open was rejected before a VM existed — scaffold
+# projects were in-tab only.
+#
+# The fix is a second door, not a weaker lock: ``open_bare_sandbox`` provisions an
+# EMPTY VM (no clone, no remote, no branch) and ``scaffold_into_sandbox``
+# materializes the starter into it. These tests hold that line explicitly — the
+# clone validator's rules are asserted here, unchanged, so a future refactor that
+# quietly loosens them fails a test instead of shipping.
+#
+# What is proved, on real Beanie over mongomock-motor (the ``mongo_db`` fixture)
+# with a FAKE Daytona client, a FAKE ``bring_up``, and a FAKE blob store injected
+# through the existing DI seams — no VM, no npm, no network:
+#   1. a scaffold open provisions a VM and materializes the starter, and the git
+#      clone path is NOT taken;
+#   2. a repo open is byte-for-byte the old behaviour (regression);
+#   3. the durable state restores ON TOP of the scaffold, in that order;
+#   4. a reopen does not re-scaffold over the user's work — neither when the VM is
+#      still live, nor when it died and a fresh one is provisioned;
+#   5. ``_validate_repo_url`` still rejects file:// / git@ / ssh:// / bare paths /
+#      credential-embedding URLs.
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import BadRequest
+from pocketpaw_ee.cloud.codeproject import lifecycle
+from pocketpaw_ee.cloud.codeproject import service as codeproject_service
+from pocketpaw_ee.cloud.codescaffold import registry as codescaffold_registry
+from pocketpaw_ee.cloud.codescaffold.registry import Template
+from pocketpaw_ee.cloud.websandbox import durability, provision, scaffold
+from pocketpaw_ee.cloud.websandbox import service as sandbox_service
+
+from tests.cloud.test_codeproject_durability import _FakeUploads
+from tests.cloud.test_websandbox_provision import _FakeDaytonaClient as _FakeProvisionClient
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+_WS = "ws-1"
+_USER = "user-1"
+_REPO = "https://github.com/acme/widgets.git"
+_STARTER = "react"
+_WORKDIR = "/home/daytona"
+
+#: What the fake npm registry hands back for the starter.
+_TEMPLATE_FILES = {
+    "package.json": '{"name":"template-default"}',
+    "src/app.tsx": "TEMPLATE-BASELINE",
+}
+
+
+# ---------------------------------------------------------------------------
+# Fakes — every one of them closes a DI seam that already existed.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _TracingClient(_FakeProvisionClient):
+    """The provisioning fake, plus an ORDER trace.
+
+    ``upload_bytes`` is how a restore lands bytes in the VM, and the fake
+    ``bring_up`` never calls it, so appending here gives an unambiguous signal for
+    "the restore ran" that can be compared against "the scaffold ran".
+    """
+
+    trace: list[str] = field(default_factory=list)
+
+    async def upload_bytes(self, sandbox_id, data, remote_path):  # noqa: ANN001
+        self.trace.append("restore")
+        await super().upload_bytes(sandbox_id, data, remote_path)
+
+
+class _RecordingBringUp:
+    """Stands in for ``scaffold.bring_up`` — records, touches nothing.
+
+    Returns a clean ``BringUp`` so ``scaffold_into_sandbox`` maps a real response;
+    what a real bring-up does to a VM (tar upload, npm install, dev server) is
+    ``test_websandbox_scaffold``'s job, not this file's.
+    """
+
+    def __init__(self, trace: list[str] | None = None) -> None:
+        self.calls: list[dict] = []
+        self._trace = trace if trace is not None else []
+
+    async def __call__(  # noqa: ANN204
+        self,
+        daytona,  # noqa: ANN001
+        sandbox_id,  # noqa: ANN001
+        files,  # noqa: ANN001
+        project_dir,  # noqa: ANN001
+        *,
+        port=None,  # noqa: ANN001
+        assets=None,  # noqa: ANN001
+        run_migrations=True,  # noqa: ANN001
+    ):
+        self._trace.append("scaffold")
+        self.calls.append(
+            {
+                "sandbox_id": sandbox_id,
+                "files": dict(files),
+                "project_dir": project_dir,
+                "port": port,
+            }
+        )
+        return scaffold.BringUp(
+            steps=[scaffold.Step(name="materialize", ok=True, exitCode=0)],
+            running=True,
+            port=port or 5173,
+        )
+
+
+@pytest.fixture()
+def uploads(monkeypatch) -> _FakeUploads:  # noqa: ANN001
+    """A fake blob store wired in as the module default.
+
+    ``put_project_file`` and ``restore_project`` each build their own uploads
+    service, so the seam is closed at module level and ONE instance carries the
+    blob — bytes written by a seed are readable by the later restore.
+    """
+    fake = _FakeUploads()
+    monkeypatch.setattr(durability, "build_uploads", lambda: fake)
+    return fake
+
+
+@pytest.fixture(autouse=True)
+def offline_starter(monkeypatch) -> None:  # noqa: ANN001
+    """No npm registry in a unit test.
+
+    Faked at ``fetch_template`` rather than at ``compose`` deliberately: compose
+    still runs for real, so the catalog check and the project-name stamp into
+    package.json are exercised — those are the parts the open path depends on.
+    """
+
+    async def _fetch(starter):  # noqa: ANN001, ANN202
+        return Template(files=dict(_TEMPLATE_FILES), assets={})
+
+    monkeypatch.setattr(codescaffold_registry, "fetch_template", _fetch)
+
+
+async def _scaffold_project(name: str = "booking"):  # noqa: ANN202
+    return await codeproject_service.create_project(
+        _WS, _USER, {"repo": _STARTER, "provider": "starter", "name": name}
+    )
+
+
+# ---------------------------------------------------------------------------
+# Proof 1 — a scaffold project opens on a VM, and never touches the clone path.
+# ---------------------------------------------------------------------------
+
+
+async def test_scaffold_open_provisions_a_bare_vm_and_materializes_the_starter() -> None:
+    project = await _scaffold_project()
+    client = _TracingClient()
+    bring_up = _RecordingBringUp()
+
+    sandbox = await lifecycle.open_project(_WS, _USER, project.id, client=client, bring_up=bring_up)
+
+    # A real VM was provisioned and the row is ready with its Daytona id bound.
+    assert len(client.create_calls) == 1
+    assert sandbox.status == "ready"
+    assert sandbox.sandbox_id == "dtn-1"
+
+    # The starter was materialized INTO that VM, at the pinned workspace dir.
+    assert len(bring_up.calls) == 1
+    assert bring_up.calls[0]["sandbox_id"] == "dtn-1"
+    assert bring_up.calls[0]["project_dir"] == _WORKDIR
+    assert bring_up.calls[0]["files"]["src/app.tsx"] == "TEMPLATE-BASELINE"
+    # compose ran for real, so the project's own name is in its package.json.
+    assert '"name": "booking"' in bring_up.calls[0]["files"]["package.json"]
+
+    # And the git clone path was NOT taken: no clone, no broker upload, no
+    # ``git checkout -b``, and no branch on the row (there is no repository).
+    assert client.clone_calls == []
+    assert not any("git checkout" in c for c in client.exec_calls)
+    assert sandbox.branch is None
+
+    # The project is bound to the row it just opened.
+    stored = await codeproject_service.get_project(_WS, _USER, project.id)
+    assert stored.current_sandbox_id == sandbox.id
+
+
+async def test_a_template_id_is_never_validated_as_a_repo_url() -> None:
+    """The clone validator would reject "react" — and never sees it.
+
+    This is the whole shape of the fix in one test: the rule that made a scaffold
+    open impossible is still in force for clones, and the scaffold open succeeds
+    anyway because it does not go through the clone.
+    """
+    with pytest.raises(BadRequest):
+        provision._validate_repo_url(_STARTER)
+
+    project = await _scaffold_project()
+    sandbox = await lifecycle.open_project(
+        _WS, _USER, project.id, client=_TracingClient(), bring_up=_RecordingBringUp()
+    )
+
+    assert sandbox.status == "ready"
+
+
+async def test_the_sandbox_row_key_is_scoped_to_the_project() -> None:
+    """Two projects on one starter get two rows, not one shared one.
+
+    A row is unique per (workspace, user, key) and it is what binds a project to a
+    VM. Keying on the bare template id would make opening the second project
+    rebind — and tear down — the first one's VM, and then hand the first project
+    the second's files on its next open.
+    """
+    first = await _scaffold_project("alpha")
+    second = await _scaffold_project("beta")
+    client = _TracingClient()
+
+    a = await lifecycle.open_project(
+        _WS, _USER, first.id, client=client, bring_up=_RecordingBringUp()
+    )
+    b = await lifecycle.open_project(
+        _WS, _USER, second.id, client=client, bring_up=_RecordingBringUp()
+    )
+
+    assert a.id != b.id
+    assert a.sandbox_id != b.sandbox_id
+    row_a = await sandbox_service.get_sandbox(_WS, _USER, a.id)
+    row_b = await sandbox_service.get_sandbox(_WS, _USER, b.id)
+    assert row_a.repo == f"starter:{_STARTER}:{first.id}"
+    assert row_b.repo == f"starter:{_STARTER}:{second.id}"
+    # Opening the second project did not tear the first one's VM down.
+    assert client.delete_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Proof 2 — a repo project is completely unchanged.
+# ---------------------------------------------------------------------------
+
+
+async def test_a_repo_project_open_is_unchanged() -> None:
+    project = await codeproject_service.create_project(_WS, _USER, {"repo": _REPO})
+    client = _TracingClient()
+    bring_up = _RecordingBringUp()
+
+    sandbox = await lifecycle.open_project(_WS, _USER, project.id, client=client, bring_up=bring_up)
+
+    # Cloned, branched, and keyed on the repo URL exactly as before.
+    assert len(client.clone_calls) == 1
+    assert client.clone_calls[0]["repo_url"] == _REPO
+    assert client.clone_calls[0]["path"] == _WORKDIR
+    assert sandbox.branch is not None and sandbox.branch.startswith("paw/edit-")
+    assert any(f"git checkout -b {sandbox.branch}" == c for c in client.exec_calls)
+    row = await sandbox_service.get_sandbox(_WS, _USER, sandbox.id)
+    assert row.repo == _REPO
+
+    # And nothing was scaffolded into it.
+    assert bring_up.calls == []
+
+
+# ---------------------------------------------------------------------------
+# Proof 3 — the durable state restores ON TOP of the scaffold, in that order.
+# ---------------------------------------------------------------------------
+
+
+async def test_durable_state_restores_on_top_of_the_scaffold(uploads) -> None:  # noqa: ANN001
+    """The template is the baseline; the user's work wins.
+
+    Order is the assertion. Restoring first would let the template overwrite the
+    edits it is supposed to sit under.
+    """
+    project = await _scaffold_project()
+    # A file the user saved in a previous session, on the SAME path the starter
+    # ships — the collision that makes ordering observable.
+    await durability.put_project_file(_WS, _USER, project.id, "src/app.tsx", "USER-EDIT")
+
+    trace: list[str] = []
+    client = _TracingClient(trace=trace)
+    bring_up = _RecordingBringUp(trace)
+
+    await lifecycle.open_project(_WS, _USER, project.id, client=client, bring_up=bring_up)
+
+    assert trace == ["scaffold", "restore"], "the restore must land AFTER the scaffold"
+    # The bytes that landed last are the user's, at the same path the starter used.
+    assert client.upload_calls[-1]["data"] == b"USER-EDIT"
+    assert client.upload_calls[-1]["path"] == f"{_WORKDIR}/src/app.tsx"
+    assert bring_up.calls[0]["files"]["src/app.tsx"] == "TEMPLATE-BASELINE"
+
+
+# ---------------------------------------------------------------------------
+# Proof 4 — reopen safety. The dangerous edge: re-materializing a template over
+# work the user has already done.
+# ---------------------------------------------------------------------------
+
+
+async def test_reopening_a_live_scaffold_project_does_not_re_scaffold() -> None:
+    project = await _scaffold_project()
+    client = _TracingClient()
+    bring_up = _RecordingBringUp()
+
+    first = await lifecycle.open_project(_WS, _USER, project.id, client=client, bring_up=bring_up)
+    second = await lifecycle.open_project(_WS, _USER, project.id, client=client, bring_up=bring_up)
+
+    # Same live VM reused — no new VM, and crucially NO second scaffold over the
+    # files the user has been editing in it.
+    assert second.sandbox_id == first.sandbox_id
+    assert len(client.create_calls) == 1
+    assert len(bring_up.calls) == 1
+
+
+async def test_reopening_after_the_vm_died_rescaffolds_only_the_empty_baseline(uploads) -> None:  # noqa: ANN001
+    """A fresh VM is empty, so the template is again the correct baseline.
+
+    Daytona's own lifecycle deletes an idle Code Mode VM in minutes, so this is the
+    ordinary returning-user path, not an edge. What must hold is that the user's
+    work still lands last.
+    """
+    project = await _scaffold_project()
+    trace: list[str] = []
+    client = _TracingClient(trace=trace)
+    bring_up = _RecordingBringUp(trace)
+
+    first = await lifecycle.open_project(_WS, _USER, project.id, client=client, bring_up=bring_up)
+    # The user edits a file; it is mirrored to the durable project store.
+    await durability.put_project_file(_WS, _USER, project.id, "src/app.tsx", "USER-EDIT")
+    # Daytona reclaims the idle VM out of band; the Mongo row still says ready.
+    client.deleted_out_of_band.add(first.sandbox_id)
+    trace.clear()
+
+    second = await lifecycle.open_project(_WS, _USER, project.id, client=client, bring_up=bring_up)
+
+    assert second.sandbox_id != first.sandbox_id
+    assert len(bring_up.calls) == 2, "a brand-new empty VM does need the baseline"
+    assert trace == ["scaffold", "restore"], "and the user's work still lands last"
+    assert client.upload_calls[-1]["data"] == b"USER-EDIT"
+
+
+# ---------------------------------------------------------------------------
+# Proof 5 — the clone validator is unchanged. Asserted explicitly so a later
+# refactor cannot quietly loosen it to "make scaffolds work".
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "repo",
+    [
+        "file:///etc/passwd",
+        "file://../../secrets",
+        "git@github.com:acme/widgets.git",
+        "ssh://git@github.com/acme/widgets.git",
+        "/var/lib/secrets",
+        "../../etc",
+        "acme/widgets",
+        _STARTER,
+        "https://user:token@github.com/acme/widgets.git",
+        "https://x-access-token:ghp_deadbeef@github.com/acme/widgets.git",
+        "",
+        "   ",
+    ],
+)
+def test_validate_repo_url_still_fails_closed(repo: str) -> None:
+    with pytest.raises(BadRequest) as exc:
+        provision._validate_repo_url(repo)
+
+    assert exc.value.status_code == 400
+
+
+def test_validate_repo_url_still_accepts_a_clean_https_url() -> None:
+    assert provision._validate_repo_url(f"  {_REPO}  ") == _REPO


### PR DESCRIPTION
## Why

A project created from a description can't open on the VM runtime at all. `open_project` provisions through the clone path, which runs `_validate_repo_url`, and a scaffold project's `repo` is a template id (`react`) rather than a URL — so it's rejected before anything happens. Described projects have been in-tab only.

That's the last thing standing between the two runtimes being interchangeable.

## The clone validator is not relaxed

`_validate_repo_url` is a security control: it rejects `file://`, `git@`/`ssh://`, bare paths, and URLs with embedded credentials, so the provisioner never hands a sandbox a local-path remote and never writes a client-supplied credential into the VM's git remote, where it would persist into snapshots. Loosening it to accept template ids would have been the easy fix and the wrong one.

Instead the open flow is **split**, because a clone and a scaffold are genuinely different operations that happen to both end in "a VM exists". The shared half — quota, the idempotent registry row, cold provision, boot wait, workdir, the `ready` rebind, old-VM teardown, failure handling — moved into one private helper, and the only difference between the paths is what goes *into* the booted VM. `open_sandbox` keeps its clone and still runs `_validate_repo_url` unconditionally, first thing. A new `open_bare_sandbox` provisions an empty VM: no clone, no remote, no `paw/edit-*` branch. Its key is validated as a registry key (non-empty, bounded), because that string is only ever a key — never a URL, remote, or shell argument. No router binds it.

`open_project` then scaffolds the starter into that bare VM and lets the existing restore run, so the durable snapshot and overlay land **on top of** the template — scaffold is the baseline, the user's work wins.

## The dangerous edge: never re-scaffold over real work

The guard is **structural** rather than a check: the scaffold call sits only in the cold-provision branch, so it always runs against a VM that same call just created, empty by construction. A reopen with a live VM returns from the reuse branch and never reaches it. A reopen whose VM died gets a fresh empty VM, where the template is again the correct baseline and the restore immediately replays the user's files over it.

Probing the VM for emptiness was the alternative and it's worse: the workdir is a home directory carrying shell dotfiles, so "is it empty" has no honest answer, and a guard resting on ambiguous evidence is weaker than one resting on an invariant the code maintains.

## A collision this surfaced

Scaffold sandbox rows have to be keyed **per project** (`starter:<template>:<project id>`), not on the bare template id. Rows are unique per `(workspace, user, key)` and the row is what binds a project to a VM — so keying on the template alone would give every project from one starter a single shared row, and opening project B would tear down project A's VM, after which the reuse branch would hand A the sandbox holding B's files. Same shared-row collision the durability re-anchor removed, one layer down. Existing rows keyed on the bare id are left to the idle reaper.

## Tests

`tests/cloud/test_codeproject_scaffold_open.py` (new, 20 tests) → **527 passed, 4 skipped** across the affected suites. Real Beanie on mongomock with fake Daytona, fake bring-up, and fake blob storage; the template registry is faked so `compose` itself still runs for real — no VM, no npm, no network.

- A scaffold open provisions one bare VM and materializes the starter, with no clone call, no `git checkout`, and a null branch.
- A template id is never validated as a repo URL — asserted from both directions.
- Two projects on one starter get two rows and two VMs; opening the second deletes nothing.
- A repo open is unchanged: same clone URL, `paw/edit-*` branch bound, bring-up never called.
- Durable state restores on top — the order trace is exactly `["scaffold", "restore"]` and the last bytes into the VM are the user's edit at a path the template also shipped.
- Reopening a live project doesn't re-scaffold; reopening after the VM died re-scaffolds only the empty baseline, then restores.
- `_validate_repo_url` still fails closed across 12 parametrized cases, asserted explicitly so a later refactor can't quietly loosen it.

Scaffolding is best-effort and never blocks the open, for the same reason the restore is: a codescaffold outage shouldn't strand a returning user whose real work is in durable state.

## Known gap

On a fresh-VM reopen the template is re-laid before the restore, so a template file the user *deleted* comes back — the restore replays files that exist, it doesn't delete. This is already true of the snapshot tier (an untar doesn't delete) and is now also true of the starter baseline. The fix is a durable tombstone list, which is worth its own change and would also cover the in-tab deletion gap.

## Base

Stacked on `feat/code-cross-runtime-restore` (#1786).
