### PR TITLE
Make the per-file store authoritative

### DIFF
--- a/ee/pocketpaw_ee/cloud/codeproject/domain.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/domain.py
@@ -17,6 +17,13 @@
 # is NOT surfaced on the wire ``CodeProjectResponse``; it is internal durability
 # bookkeeping, not a client-facing field.
 #
+# Modified 2026-07-25 (feat/code-s3-authoritative): added ``overlay_complete`` —
+# view-only like ``overlay`` (durability bookkeeping, never on the wire). It says
+# whether ``overlay`` is a COMPLETE image of the workspace or just the delta of
+# files that passed a write hook, which is the difference between "this path is
+# absent because the user deleted it" and "this path is absent because nothing ever
+# mirrored it". Restore reads it before doing anything destructive.
+#
 # Modified 2026-07-24 (feat/code-initial-prompt): added ``initial_prompt`` and
 # ``initial_prompt_consumed`` to CodeProjectView. Unlike ``overlay`` these DO flow
 # to the wire (``initialPrompt`` / ``initialPromptConsumed``) — the frontend reads
@@ -79,9 +86,11 @@ class CodeProjectView:
     updated_at: datetime
     # Durable blob-storage snapshot pointer — the project's files between VMs.
     snapshot_file_id: str | None = None
-    # The write-through per-file durability overlay (``relpath -> FileRecord id``),
-    # keyed on the project. View-only, mirroring WebSandboxView — not on the wire.
+    # The AUTHORITATIVE per-file store (``relpath -> FileRecord id``), keyed on the
+    # project. View-only, mirroring WebSandboxView — not on the wire.
     overlay: dict[str, str] = field(default_factory=dict)
+    # Whether ``overlay`` is a complete image of the workspace (see the model).
+    overlay_complete: bool = False
     # The natural-language build prompt captured at create-from-description time
     # (WHAT to build), and whether the auto-run build turn has been kicked off for
     # it. Both flow to the wire, unlike ``overlay``.

--- a/ee/pocketpaw_ee/cloud/codeproject/dto.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/dto.py
@@ -95,13 +95,35 @@ class ProjectFileWriteResponse(BaseModel):
     fileId: str
 
 
+class PutProjectFilesRequest(BaseModel):
+    """The in-tab runtime's whole project: ``{relative path: file content}``.
+
+    A REPLACEMENT, not a patch — a path absent from this map is absent from the
+    project, which is what lets a delete stick. The browser is the only thing
+    that can enumerate a filesystem living in a browser tab, so it walks its own
+    FS and posts the result. Excluded trees (``node_modules``, ``.git``, build
+    output) are filtered client-side before they get here, the same way the VM
+    sync filters them.
+    """
+
+    files: dict[str, str] = Field(default_factory=dict)
+
+
+class PutProjectFilesResponse(BaseModel):
+    """How many files the store now holds, after a whole-project replacement."""
+
+    ok: bool = True
+    stored: int
+
+
 class ProjectFilesResponse(BaseModel):
     """The project's whole persisted overlay: ``{relative path: file content}``.
 
-    The restore payload for the in-tab runtime. It carries the DELTA only — the
-    starter scaffold baseline is re-materialized client-side from the starter id,
-    so a project that has never been edited returns an empty map rather than the
-    scaffold.
+    The restore payload for the in-tab runtime. Once the store is COMPLETE (see
+    ``overlayComplete``) this is the whole project rather than a delta over a
+    baseline — which is what lets the client replay it and then delete anything
+    the map does not mention. An empty map means a project nothing has stored
+    yet, not a project with no files.
     """
 
     files: dict[str, str]

--- a/ee/pocketpaw_ee/cloud/codeproject/dto.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/dto.py
@@ -116,6 +116,11 @@ class CodeProjectResponse(BaseModel):
     repo: str
     initialPrompt: str | None = None
     initialPromptConsumed: bool = False
+    # Whether the per-file store holds the WHOLE project rather than a delta over
+    # a baseline. On the wire because the in-tab runtime needs it to decide
+    # whether it may prune: replaying a COMPLETE store means a file the store
+    # doesn't list was deleted, while replaying a partial one means no such thing.
+    overlayComplete: bool = False
     snapshotFileId: str | None = None
     currentSandboxId: str | None = None
     lastOpenedAt: str | None = None  # ISO-8601 UTC, or null

--- a/ee/pocketpaw_ee/cloud/codeproject/lifecycle.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/lifecycle.py
@@ -72,6 +72,17 @@
 # is therefore empty by construction. The reuse branch returns before it, so a live
 # VM (or a reopen that reuses one) is never re-materialized over. See
 # ``_scaffold_baseline`` for why this is the guard rather than a VM probe.
+#
+# 2026-07-25 (S1, feat/code-s3-authoritative): the cold-provision branch gained a
+# third step — ``_seed_project_files``, after the restore. WHY: the per-file store in
+# blob storage is now the project's whole truth (the tarball tier is retired because
+# a tarball cannot express a DELETE, so replaying it resurrected removed files), and
+# the write-through hooks only ever see files that pass through the editor. A clone's
+# tree and a materialized scaffold pass through nothing, so without an explicit sync
+# the store would be missing most of the project until its first clean disconnect —
+# and a session that crashes or idles out never has one. Ordering is load-bearing
+# again: scaffold, then restore, THEN sync, so what gets photographed is the user's
+# real workspace rather than the bare baseline.
 from __future__ import annotations
 
 import contextlib
@@ -164,6 +175,11 @@ async def open_project(
     # B3: for a scaffold project this lands ON TOP of the starter above — the
     # template is the baseline, the durable state is the user's work.
     await _restore_if_snapshotted(workspace_id, user_id, project, sandbox, client)
+    # S1: the content that just landed (a clone's tree, a materialized scaffold)
+    # never passed a write hook, so nothing in blob storage knows about it until
+    # something enumerates the workspace. Seed the store NOW rather than at the
+    # first disconnect.
+    await _seed_project_files(workspace_id, user_id, project, sandbox, client)
     await codeproject_service.bind_current_sandbox(workspace_id, user_id, project_id, sandbox.id)
     logger.info(
         "codeproject.open: project=%s bound fresh sandbox=%s (provider=%s repo=%s)",
@@ -314,12 +330,11 @@ async def _restore_if_snapshotted(
 ) -> None:
     """Restore the PROJECT's durable state into the freshly-provisioned VM, if any.
 
-    Both durability tiers live on the durable project row (B2): the
-    ``snapshot_file_id`` (captured on a prior clean disconnect) AND the
-    write-through ``overlay`` (per-file edits mirrored since the last snapshot —
-    the tier that covers a crash / idle-out before any disconnect snapshot).
-    Restore fires when EITHER exists; a project with neither (first open, or
-    nothing edited) is a clean no-op.
+    The durable state lives on the project row (B2): the authoritative per-file
+    ``overlay``, plus — for a project whose state predates S1 — a legacy
+    ``snapshot_file_id`` that ``restore_project`` migrates into per-file entries on
+    its way past. Restore fires when EITHER exists; a project with neither (first
+    open, or nothing edited) is a clean no-op.
 
     The anchor moved off the WebSandbox row deliberately. That row is unique per
     (workspace, user, repo), so N projects sharing a starter template shared one
@@ -363,6 +378,57 @@ async def _restore_if_snapshotted(
             project.snapshot_file_id,
             exc_info=True,
         )
+
+
+async def _seed_project_files(
+    workspace_id: str,
+    user_id: str,
+    project: CodeProjectView,
+    sandbox: WebSandboxView,
+    client: DaytonaClient | None,
+) -> None:
+    """Re-image the project's per-file store from the freshly-materialized VM (S1).
+
+    The per-file store is the project's whole truth now, and the write-through hooks
+    only ever see what passes through the editor. Everything that lands another way
+    — a ``git clone``'s tree, a scaffold materialized by ``_scaffold_baseline``,
+    anything a bring-up step generates — is invisible to them. The retired tarball
+    used to cover that gap on disconnect; syncing here covers it from the START, so
+    a project is complete in blob storage the moment it opens rather than only after
+    its first clean disconnect (a session that crashes or idles out never had one).
+
+    Runs only on the COLD-PROVISION branch, which is the only branch where new
+    unseen content lands: the reuse branch returns before it, against a VM whose
+    files are already synced. It runs AFTER the restore so the sync photographs the
+    user's real workspace — running it before would capture the bare clone/scaffold
+    and re-add every file the user had deleted, which is the exact bug this whole
+    change removes.
+
+    Best-effort, like the scaffold and restore around it: a sync failure leaves the
+    project on whatever the store already held and is retried on the next disconnect
+    or open. Blocking an open on a durability capture would be the worse trade.
+    """
+    if not sandbox.sandbox_id:
+        return
+    try:
+        overlay = await websandbox_durability.sync_project_files(
+            workspace_id, user_id, project.id, sandbox.sandbox_id, client=client
+        )
+    except Exception:  # noqa: BLE001 — never block the open on a durability capture
+        logger.warning(
+            "codeproject.open: file sync failed for project=%s (daytona=%s); the store "
+            "still holds the previous state",
+            project.id,
+            sandbox.sandbox_id,
+            exc_info=True,
+        )
+        return
+    logger.info(
+        "codeproject.open: synced project=%s from daytona=%s (%d file(s) in the store)",
+        project.id,
+        sandbox.sandbox_id,
+        len(overlay),
+    )
 
 
 async def _backfill_legacy_durability(

--- a/ee/pocketpaw_ee/cloud/codeproject/router.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/router.py
@@ -58,6 +58,8 @@ from pocketpaw_ee.cloud.codeproject.dto import (
     ProjectFilesResponse,
     ProjectFileWriteResponse,
     PutProjectFileRequest,
+    PutProjectFilesRequest,
+    PutProjectFilesResponse,
     RenameProjectRequest,
 )
 from pocketpaw_ee.cloud.license import require_license
@@ -181,6 +183,30 @@ async def put_project_file(
         workspace_id, ctx.user_id, project_id, body.path, body.content
     )
     return ProjectFileWriteResponse(ok=True, path=path, fileId=file_id)
+
+
+@router.put("/{project_id}/files", response_model=PutProjectFilesResponse)
+async def put_project_files(
+    project_id: str,
+    body: PutProjectFilesRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> PutProjectFilesResponse:
+    """Replace the in-tab project's whole store, marking it COMPLETE (owner-scoped).
+
+    The client walks the filesystem it hosts and posts everything at once. That
+    is the only way the store can become complete for a tab-hosted project — a
+    per-file PUT can never know whether it was the last one — and completeness is
+    what licenses the restore-time prune to treat an unlisted file as deleted.
+
+    All-or-nothing: every byte is uploaded before the map is swapped, so a failure
+    leaves the project exactly as it was rather than marking a partial store
+    complete.
+    """
+    workspace_id = _require_workspace(ctx)
+    stored = await websandbox_durability.put_project_files(
+        workspace_id, ctx.user_id, project_id, body.files
+    )
+    return PutProjectFilesResponse(ok=True, stored=stored)
 
 
 @router.delete("/{project_id}/file", status_code=204)

--- a/ee/pocketpaw_ee/cloud/codeproject/service.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/service.py
@@ -54,6 +54,23 @@
 #     clobber state the project has since accumulated. The WebSandbox fields are
 #     left readable — this PR moves WHO the Daytona path writes, not what exists.
 #
+# Modified 2026-07-25 (feat/code-s3-authoritative): the per-file ``overlay`` is now
+# the AUTHORITATIVE store, which REVERSES this module's 2026-07-24 decision that
+# "a full snapshot supersedes it". WHY the reversal: a tarball is an unmodifiable
+# blob, so a DELETE has no representation inside it — replaying the baseline
+# resurrected every removed file — and clearing the overlay on snapshot destroyed
+# the one tier that could record the absence. Making the per-file map complete and
+# authoritative turns a delete into the removal of an entry, with nothing left to
+# resurrect it. Two ops change here:
+#   * ``set_project_snapshot`` NO LONGER CLEARS THE OVERLAY. It only records the
+#     legacy tarball pointer. Clearing would now discard the authoritative state.
+#   * ``replace_project_overlay`` — new: swap the whole map in ONE write, mark it
+#     complete, and clear the legacy tarball pointer. It is what
+#     ``durability.sync_project_files`` (workspace enumeration) and the legacy-tar
+#     migration write through, so a full re-image costs one doc save rather than
+#     one per file, and the drop-plus-add is atomic (a half-applied overlay would
+#     read as data loss).
+#
 # Modified 2026-07-24 (feat/code-initial-prompt): ``create_project`` now persists
 # the optional ``initial_prompt`` (the WHAT-to-build description) on an actual
 # INSERT only — a github idempotent hit returns the existing row untouched, so a
@@ -134,6 +151,7 @@ def _doc_to_view(doc: _CodeProjectDoc) -> CodeProjectView:
         updated_at=doc.updated_at,
         snapshot_file_id=doc.snapshot_file_id,
         overlay=dict(doc.overlay or {}),
+        overlay_complete=bool(doc.overlay_complete),
         initial_prompt=doc.initial_prompt,
         initial_prompt_consumed=doc.initial_prompt_consumed,
         current_sandbox_id=doc.current_sandbox_id,
@@ -480,28 +498,76 @@ async def set_project_snapshot(
     project_id: str,
     file_id: str,
 ) -> CodeProjectView:
-    """Record the durable project-snapshot pointer; clear the overlay.
+    """Record the LEGACY tarball pointer. Does NOT touch the overlay.
 
     Tenant- and owner-scoped (Rule 7 via ``_read_owned``): only the owning caller
     can bind a snapshot to their own project. ``file_id`` is the blob-storage
-    ``FileRecord`` id produced by ``EEUploadService.upload`` in the durability
-    module — a durable pointer to the tarball of the project's files. A full
-    snapshot supersedes the incremental overlay, so the overlay is CLEARED here
-    (mirroring ``WebSandbox.set_snapshot``): everything the overlay held is now
-    inside the snapshot tar, and clearing it is what keeps restore from replaying
-    a stale write over a since-deleted file. Raises ``NotFound`` when no owned row
-    matches.
+    ``FileRecord`` id of a whole-workspace tarball.
+
+    This used to CLEAR the overlay, on the reasoning that a full snapshot
+    supersedes an incremental delta. That reasoning is now inverted: the overlay
+    is the authoritative store, so clearing it would discard the project's real
+    state and hand the resurrection problem back to a tarball that cannot express
+    a deletion. Nothing in production writes a new tarball any more; this op
+    survives for the legacy pointer (the rollout backfill, and tests that stage
+    pre-migration state) and the pointer is cleared for good by the migration in
+    ``durability.restore_project``. Raises ``NotFound`` when no owned row matches.
     """
     doc = await _read_owned(workspace_id, user_id, project_id)
     if doc is None:
         raise NotFound("code_project", project_id)
     doc.snapshot_file_id = file_id
-    doc.overlay = {}
     doc.updated_at = datetime.now(UTC)
     await doc.save()
     # no-event: the snapshot pointer is durability bookkeeping, not a lifecycle
     # transition — no downstream handler reacts to it, and emitting a project
     # event would falsely signal a state change to a projects-grid fan-out.
+    return _doc_to_view(doc)
+
+
+async def replace_project_overlay(
+    workspace_id: str,
+    user_id: str,
+    project_id: str,
+    overlay: dict[str, str],
+    *,
+    complete: bool = True,
+    clear_snapshot: bool = True,
+) -> CodeProjectView:
+    """Swap the project's whole per-file store in ONE write. The authoritative op.
+
+    Tenant- and owner-scoped (Rule 7 via ``_read_owned``). The entry-point op for
+    a full re-image of a project: ``durability.sync_project_files`` enumerates the
+    VM workspace and hands the resulting map here, and the legacy-tarball migration
+    hands over the tar's members merged under the (fresher) existing entries.
+
+    Three properties matter, and all three are why this is ONE op rather than a
+    loop over ``set_project_overlay_entry`` / ``drop_project_overlay_entry``:
+      * ATOMIC — the adds and the drops land in a single doc save. A half-applied
+        re-image reads to the user as deleted files.
+      * DROPS ARE THE POINT — a path absent from ``overlay`` is a path the user
+        deleted. Passing the map wholesale is what lets a deletion be expressed by
+        omission, which is the whole reason the tarball tier was retired.
+      * ``complete`` records that the map was verified against a real workspace,
+        which is what makes restore's destructive prune safe to run.
+
+    ``clear_snapshot`` (default True) drops the legacy tarball pointer, because
+    after a verified re-image the tar is superseded and re-expanding it would
+    resurrect exactly the files this write just dropped. The migration passes
+    False when it could not carry every member across, so the tar stays readable
+    and the migration retries on the next open rather than losing data.
+    """
+    doc = await _read_owned(workspace_id, user_id, project_id)
+    if doc is None:
+        raise NotFound("code_project", project_id)
+    # Reassign (not in-place mutate) so Beanie always sees the field as dirty.
+    doc.overlay = dict(overlay)
+    doc.overlay_complete = complete
+    if clear_snapshot:
+        doc.snapshot_file_id = None
+    doc.updated_at = datetime.now(UTC)
+    await doc.save()
+    # no-event: durability bookkeeping, same reasoning as set_project_snapshot.
     return _doc_to_view(doc)
 
 
@@ -687,6 +753,7 @@ __all__ = [
     "mark_initial_prompt_consumed",
     "move_project_overlay_entry",
     "rename_project",
+    "replace_project_overlay",
     "set_project_overlay_entry",
     "set_project_snapshot",
     "view_to_wire",

--- a/ee/pocketpaw_ee/cloud/codeproject/service.py
+++ b/ee/pocketpaw_ee/cloud/codeproject/service.py
@@ -170,6 +170,7 @@ def view_to_wire(view: CodeProjectView) -> CodeProjectResponse:
         repo=view.repo,
         initialPrompt=view.initial_prompt,
         initialPromptConsumed=view.initial_prompt_consumed,
+        overlayComplete=view.overlay_complete,
         snapshotFileId=view.snapshot_file_id,
         currentSandboxId=view.current_sandbox_id,
         lastOpenedAt=view.last_opened_at.isoformat() if view.last_opened_at else None,

--- a/ee/pocketpaw_ee/cloud/models/code_project.py
+++ b/ee/pocketpaw_ee/cloud/models/code_project.py
@@ -42,6 +42,22 @@ durable store — snapshot pointer + overlay — that round-trips through S3
 independent of any runtime. Additive: the sandbox-keyed WebSandbox durability
 path is unchanged. No new index — read only via the owner-scoped project row.
 
+Modified 2026-07-25 (feat/code-s3-authoritative): the per-file ``overlay`` is now
+the AUTHORITATIVE store and the tarball tier is retired as a source of truth. This
+REVERSES the 2026-07-24 note above ("``set_project_snapshot`` CLEARS it"), for a
+structural reason: a tarball is an unmodifiable blob, so a DELETE could not be
+represented in it — replaying the baseline resurrected every file the user had
+removed, on both runtimes, and clearing the overlay on snapshot threw away the only
+tier that COULD represent the absence. Under the new model the overlay is a complete
+image of the workspace (seeded by ``durability.sync_project_files``, which enumerates
+the VM and drops entries for paths that no longer exist), so a delete is simply the
+removal of an entry and there is nothing left to resurrect it. Two consequences here:
+``snapshot_file_id`` is now a LEGACY pointer, read once by the migration in
+``durability.restore_project`` (expand the tar into per-file entries) and then
+cleared forever; and ``overlay_complete`` records whether the overlay has been
+verified against a real workspace, which is what makes the destructive operations
+(pruning stale files out of a restored VM) safe to run at all.
+
 Modified 2026-07-24 (feat/code-initial-prompt): added ``initial_prompt`` (the
 natural-language description of WHAT to build, captured when a ``/code`` project
 is created from a prompt) and ``initial_prompt_consumed`` (whether the auto-run
@@ -87,17 +103,31 @@ class CodeProject(Document):
     # rename collide two rows into a DuplicateKeyError, and would make a
     # re-create under a since-renamed name mint a surprise duplicate.
     registry_key: str = ""
-    # Durable blob-storage snapshot pointer (an EEUploadService FileRecord id).
-    # The project's files live HERE between sandboxes — this is why the project
-    # survives VM reaping. Null until the first backup.
+    # LEGACY blob-storage tarball pointer (an EEUploadService FileRecord id).
+    # Written by the retired ``snapshot_project`` path; no longer produced. It is
+    # read exactly ONCE more, by the migration in ``durability.restore_project``,
+    # which expands the tar into per-file ``overlay`` entries and clears this back
+    # to None so the baseline can never resurrect a deleted file again.
     snapshot_file_id: str | None = None
-    # The write-through per-file durability overlay, keyed on the PROJECT (mirrors
-    # ``WebSandbox.overlay``): ``relpath -> FileRecord id`` for each editor-saved
-    # file mirrored to blob storage since the last full project snapshot. Replayed
-    # onto a fresh clone on restore; cleared by ``set_project_snapshot`` (a full
-    # snapshot supersedes it). Null until the first mirror. No new index — read
-    # only via the owner-scoped project row.
+    # The AUTHORITATIVE per-file store, keyed on the PROJECT: ``relpath ->
+    # FileRecord id``, one blob-storage object per file. Written by the editor
+    # write-through hooks, by the browser file-sync route, and — for everything
+    # that never passes a write hook (a clone, a scaffold, generated output) — by
+    # ``durability.sync_project_files``, which enumerates the VM workspace and
+    # DROPS entries whose paths no longer exist. Restore reconstructs the workspace
+    # from this map alone. No new index — read only via the owner-scoped row.
     overlay: dict[str, str] = Field(default_factory=dict)
+    # Whether ``overlay`` has been verified to be a COMPLETE image of the project's
+    # workspace (every non-regenerable file), rather than a partial delta of the
+    # files that happened to pass through a write hook. Set by
+    # ``sync_project_files`` and by the legacy-tarball migration; False for a
+    # project whose only writes came from the in-tab runtime, whose baseline (the
+    # starter scaffold) is re-materialized client-side and never stored.
+    #
+    # It exists to gate DESTRUCTIVE reconciliation: restore prunes workspace files
+    # missing from the overlay only when this is True, because "absent from the
+    # overlay" means "deleted by the user" only once the overlay is known complete.
+    overlay_complete: bool = False
     # The natural-language build prompt captured when a ``/code`` project is
     # created from a description — WHAT to build. Null for projects opened from an
     # existing repo with nothing to auto-build. The frontend reads it on first open

--- a/ee/pocketpaw_ee/cloud/websandbox/durability.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/durability.py
@@ -97,11 +97,41 @@
 # carries with no excludes) are filtered out, and tar members are treated as
 # UNTRUSTED — absolute/traversing names and non-regular entries (symlinks, hardlinks,
 # devices) are skipped rather than materialized.
+#
+# Changed 2026-07-25 (S1, feat/code-s3-authoritative): the PER-FILE overlay is now the
+# project's whole truth and the tarball tier is RETIRED as a source of truth. This
+# reverses the CM-2a′ two-tier design documented above, and the reason is that a
+# tarball is an unmodifiable blob: a DELETE has no representation inside it. Replaying
+# the baseline resurrected every file the user removed — on both runtimes — and
+# ``set_project_snapshot`` clearing the overlay destroyed the one tier that could have
+# recorded the absence. A tombstone list would have patched the symptom; making the
+# per-file store COMPLETE makes a delete the removal of an entry, with nothing left to
+# resurrect it. Bytes still flow through ``EEUploadService`` (not presigned/direct-to-S3)
+# so the pluggable adapter and local/OSS installs keep working. Concretely:
+#   * ``snapshot_project`` is GONE. Nothing writes a whole-workspace tarball any more.
+#   * ``sync_project_files`` replaces it: tar the workspace as a TRANSPORT (one round
+#     trip instead of one per file), expand it in memory, write every member through
+#     to its own blob, and swap the whole map in with ONE service write. Files that
+#     never pass a write hook — a ``git clone``'s tree, a materialized scaffold,
+#     generated output — are how the store becomes complete; a path that no longer
+#     exists is DROPPED, which is how a delete survives.
+#   * ``restore_project`` reconstructs the VM from the overlay ALONE, then PRUNES
+#     workspace files the overlay doesn't list (a fresh clone/scaffold re-materializes
+#     files the user deleted, so replay-only would hand the resurrection bug straight
+#     back). The prune is gated on ``overlay_complete`` — "absent from the overlay"
+#     only means "deleted" once the overlay has been verified against a real workspace.
+#   * a project whose state PREDATES this change still carries ``snapshot_file_id``
+#     and a partial overlay. ``_migrate_legacy_snapshot`` expands that tar ONCE into
+#     per-file entries (existing entries win — they are fresher), then clears the
+#     pointer so it never runs again. It is idempotent and non-destructive: if any
+#     member fails to carry across, the pointer is KEPT and the untar fallback still
+#     materializes the session, so a partial migration retries instead of losing data.
 from __future__ import annotations
 
 import io
 import logging
 import os
+import shlex
 import tarfile
 from pathlib import Path
 from typing import Any
@@ -113,6 +143,7 @@ from pocketpaw_ee.cloud._core.errors import (
     with_cause,
 )
 from pocketpaw_ee.cloud.codeproject import service as codeproject_service
+from pocketpaw_ee.cloud.codeproject.domain import CodeProjectView
 from pocketpaw_ee.cloud.daytona.client import DaytonaClient, get_daytona_client
 from pocketpaw_ee.cloud.shared.db import is_multi_tenant_cloud
 from pocketpaw_ee.cloud.websandbox import service as websandbox_service
@@ -120,11 +151,27 @@ from pocketpaw_ee.cloud.websandbox.constants import WEBSANDBOX_WORKDIR
 
 logger = logging.getLogger(__name__)
 
-# Blob-storage folders for the project-keyed durable store — grouped separately
-# from the sandbox-keyed ``/websandbox-*`` folders so a tenant's project
-# snapshots/overlay are distinguishable in their Files.
-_PROJECT_SNAPSHOT_FOLDER = "/code-project-snapshots"
+# Blob-storage folder for the project-keyed per-file store — grouped separately
+# from the sandbox-keyed ``/websandbox-*`` folders so a tenant's project files are
+# distinguishable in their Files. There is no snapshot folder constant any more:
+# S1 retired the tarball tier, so nothing writes ``/code-project-snapshots``. The
+# tars already there are still readable, by FileRecord id, for the one-time
+# migration in ``_migrate_legacy_snapshot``.
 _PROJECT_OVERLAY_FOLDER = "/code-project-overlay"
+
+# The in-VM staging path for the file-sync transport tarball. Distinct from
+# ``_SNAPSHOT_TMP`` so a sync can never collide with (or be mistaken for) the
+# retired snapshot blob, and outside the workspace dir so it never tars itself.
+_PROJECT_SYNC_TMP = "/tmp/code-project-sync.tgz"  # noqa: S108 — a sandbox VM path, not host
+
+# Seconds allowed for the in-VM tar / find commands the sync + prune run. The
+# Daytona client's default (30s) is tuned for interactive one-liners; walking a
+# real source tree is slower, and a timeout here costs the whole capture.
+_SYNC_EXEC_TIMEOUT_SECONDS = 120
+
+# Paths deleted per ``rm`` invocation when restore prunes a stale file. Bounded so a
+# big prune can't exceed the shell's argument limit.
+_PRUNE_CHUNK = 100
 
 _TRUTHY = {"1", "true", "yes", "on"}
 
@@ -622,80 +669,6 @@ async def _upload_project_blob(
     return rec.id
 
 
-async def snapshot_project(
-    workspace_id: str,
-    user_id: str,
-    project_id: str,
-    sandbox_id: str,
-    *,
-    client: DaytonaClient | None = None,
-    uploads: Any = None,
-) -> str:
-    """Snapshot a project's live VM workspace to blob storage; return the pointer.
-
-    Mirrors ``snapshot_workspace`` but anchors the pointer on the durable
-    ``CodeProject`` row. Resolves the project owner-scoped (``get_project`` raises
-    ``NotFound`` for a project the caller doesn't own), then ``tar -czf`` the
-    workspace dir in ``sandbox_id`` → ``download_file`` the tarball → size-cap →
-    upload to S3 (folder ``/code-project-snapshots``) → ``set_project_snapshot``
-    the returned FileRecord id (which also clears the overlay). Returns that id.
-
-    The ``sandbox_id`` is the live Daytona VM to snapshot, passed explicitly (not
-    resolved from a WebSandbox row) so this stays independent of the ephemeral
-    runtime row. Fails CLOSED on a non-s3 upload adapter in cloud before any VM
-    op. A tarball over the size cap raises a clean CloudError before any upload.
-    """
-    _require_s3_for_project_store()
-    daytona = _require_client(client)
-
-    # Owner-scoped tenancy gate: NotFound for a project the caller doesn't own.
-    await codeproject_service.get_project(workspace_id, user_id, project_id)
-
-    try:
-        await daytona.execute_command(
-            sandbox_id,
-            f"tar -czf {_SNAPSHOT_TMP} -C {WEBSANDBOX_WORKDIR} .",
-        )
-        data = await daytona.download_file(sandbox_id, _SNAPSHOT_TMP)
-    except Exception as exc:  # noqa: BLE001 — any VM-side failure is uniform
-        logger.warning(
-            "codeproject.snapshot: tar/download failed for project=%s", project_id, exc_info=True
-        )
-        raise with_cause(
-            CloudError(502, "codeproject.snapshot_failed", "Failed to snapshot the project"),
-            exc,
-        ) from exc
-
-    cap = _snapshot_max_bytes()
-    if len(data) > cap:
-        raise CloudError(
-            413,
-            "codeproject.snapshot_too_large",
-            f"Project snapshot is {len(data) / 1024 / 1024:.1f} MB, over the "
-            f"{cap / 1024 / 1024:.0f} MB limit",
-        )
-
-    up = uploads if uploads is not None else build_uploads()
-    file_id = await _upload_project_blob(
-        up,
-        data,
-        workspace_id=workspace_id,
-        user_id=user_id,
-        filename=f"code-project-snapshot-{project_id}.tgz",
-        folder=_PROJECT_SNAPSHOT_FOLDER,
-        content_type=_SNAPSHOT_MIME,
-    )
-    await codeproject_service.set_project_snapshot(workspace_id, user_id, project_id, file_id)
-    logger.info(
-        "codeproject.snapshot: project=%s daytona=%s -> file=%s (%d bytes)",
-        project_id,
-        sandbox_id,
-        file_id,
-        len(data),
-    )
-    return file_id
-
-
 async def restore_project(
     workspace_id: str,
     user_id: str,
@@ -705,34 +678,51 @@ async def restore_project(
     client: DaytonaClient | None = None,
     uploads: Any = None,
 ) -> None:
-    """Restore a project's durable state into a (fresh) VM: snapshot then overlay.
+    """Reconstruct a project's workspace in ``sandbox_id`` from the per-file store.
 
-    Mirrors ``restore_workspace`` but reads the pointer off the durable
-    ``CodeProject`` row (via the owner-scoped ``get_project`` view — so it also
-    enforces tenancy). Applies the two tiers in order into ``sandbox_id``:
-      1. ``snapshot_file_id`` — the full-workspace tarball (baseline): fetched
-         from S3, ``upload_bytes`` into the VM, ``tar -xzf`` over the dir.
-      2. ``overlay`` — the write-through per-file tier (edits since the last
-         snapshot): each ``relpath -> FileRecord id`` is fetched and written over
-         the tree. Cleared whenever a snapshot is taken, so replay is always the
-         freshest source state, never a stale resurrection.
+    Reads the pointers off the durable ``CodeProject`` row (via the owner-scoped
+    ``get_project`` view — so it also enforces tenancy) and applies, in order:
 
-    A project with NEITHER a snapshot nor an overlay is a clean 409 (nothing to
-    restore). No S3 guard here — restore is a READ path; the guard protects the
-    WRITE path so a project never silently persists to disk in the first place.
+      0. MIGRATION (once per project, only for state that predates S1) — a legacy
+         ``snapshot_file_id`` is expanded into per-file overlay entries and the
+         pointer is cleared. If it could not be carried across in full, the pointer
+         is kept and the tar is untarred as a baseline for THIS session so nothing
+         is missing, and the migration retries on the next open.
+      1. OVERLAY — the authoritative store. Every ``relpath -> FileRecord id`` is
+         fetched and written into the workspace.
+      2. PRUNE — workspace files the overlay does NOT list are deleted, iff the
+         overlay is known complete. This is what makes a delete stick: the VM this
+         restores into was just cloned or scaffolded, so it holds baseline files
+         the user may have removed, and replay-only would resurrect every one of
+         them. Gated on ``overlay_complete`` because "absent from the overlay"
+         means "deleted" only once the overlay has been verified against a real
+         workspace — for an in-tab project (partial overlay, scaffold baseline
+         re-materialized client-side) it does not, and pruning would be data loss.
+
+    A project with NEITHER a legacy snapshot nor an overlay is a clean 409 (nothing
+    to restore). The prune assumes a FRESHLY provisioned VM — the only caller is
+    ``codeproject.lifecycle.open_project``'s cold-provision branch, so there is
+    never unsaved in-VM work for it to remove.
     """
     daytona = _require_client(client)
 
     project = await codeproject_service.get_project(workspace_id, user_id, project_id)
-    overlay = project.overlay or {}
-    if not project.snapshot_file_id and not overlay:
+    if not project.snapshot_file_id and not project.overlay:
         raise ConflictError(
             "codeproject.no_snapshot", "This project has no durable state to restore"
         )
 
     up = uploads if uploads is not None else build_uploads()
 
-    # Tier 1 — the full-workspace snapshot (baseline).
+    # Tier 0 — one-time migration off the retired tarball tier.
+    if project.snapshot_file_id:
+        project = await _migrate_legacy_snapshot(workspace_id, user_id, project, up)
+    overlay = project.overlay or {}
+
+    # Legacy FALLBACK — only reachable when the migration above could not carry the
+    # tar across in full (it leaves the pointer set for a retry). Untarring the
+    # baseline keeps this session complete rather than opening a project with holes
+    # in it; the per-file store still wins, because the overlay replays on top.
     if project.snapshot_file_id:
         data = await _download_snapshot(
             up, project.snapshot_file_id, workspace_id=workspace_id, user_id=user_id
@@ -759,7 +749,7 @@ async def restore_project(
             len(data),
         )
 
-    # Tier 2 — replay the write-through overlay (freshest edits) over the tree.
+    # Tier 1 — write the authoritative per-file store into the workspace.
     replayed = 0
     for rel_path, file_id in overlay.items():
         abs_path = _overlay_abs_path(rel_path)
@@ -783,10 +773,16 @@ async def restore_project(
             )
     if replayed:
         logger.info(
-            "codeproject.restore: project=%s daytona=%s replayed %d overlay file(s)",
+            "codeproject.restore: project=%s daytona=%s replayed %d file(s)",
             project_id,
             sandbox_id,
             replayed,
+        )
+
+    # Tier 2 — reconcile the deletions. See the docstring for why this is gated.
+    if project.overlay_complete:
+        await _prune_stale_workspace_files(
+            daytona, sandbox_id, overlay, project_id=project_id, replayed=replayed
         )
 
 
@@ -883,21 +879,32 @@ async def move_project_overlay(
 # state this path persists.
 # ===========================================================================
 
-# Read-back caps for the browser restore payload. The whole overlay is
-# materialized in memory as one JSON response, so both a per-file byte ceiling
-# and a file-count ceiling are enforced — a source tree is small, and an
-# unbounded read is a memory + latency hazard for the tab as much as the box.
-# Env-tunable in the same shape as ``POCKETPAW_WEBSANDBOX_SNAPSHOT_MAX_MB``.
-_DEFAULT_OVERLAY_MAX_MB = 10.0
-_DEFAULT_OVERLAY_MAX_FILES = 2000
+# Caps on the per-file store. Re-tuned by S1: the overlay used to be a DELTA (the
+# handful of files edited since the last tarball), and 10 MB / 2000 files was
+# generous for that. It now holds the project's WHOLE source tree, and those
+# numbers would reject an ordinary repo — a mid-size monorepo clears 2000 source
+# files on its own — turning "your project is too big" into the normal case.
+# node_modules, .git and build output are excluded (``_SNAPSHOT_EXCLUDED_SEGMENTS``),
+# so these bound SOURCE only, which is what makes 100 MB roomy rather than reckless.
+# Both stay LOUD (413) rather than truncating: a silently partial project reads to
+# the user as deleted files. Env-tunable in the same shape as
+# ``POCKETPAW_WEBSANDBOX_SNAPSHOT_MAX_MB``.
+_DEFAULT_OVERLAY_MAX_MB = 100.0
+_DEFAULT_OVERLAY_MAX_FILES = 10000
+
+# The PER-FILE ceiling, deliberately split from the aggregate above. It used to be
+# the same knob, which was fine while both meant "10 MB"; raising the aggregate to
+# 100 MB would otherwise have quietly let a single 100 MB file through the browser
+# write route. One runaway file and a whole runaway project are different failures
+# and now have different limits.
+_DEFAULT_FILE_MAX_MB = 10.0
 
 
 def _overlay_max_bytes() -> int:
-    """Overlay byte cap (``POCKETPAW_CODEPROJECT_OVERLAY_MAX_MB``).
+    """Aggregate byte cap for a project's files (``POCKETPAW_CODEPROJECT_OVERLAY_MAX_MB``).
 
-    Applied twice: as the per-file ceiling on a write (so one runaway file can
-    never land) and as the cumulative ceiling on the read-back (so the restore
-    payload stays bounded no matter how the overlay grew).
+    Bounds every whole-project materialization: the browser read-back payload, the
+    in-memory expansion of a sync transport tarball, and the legacy-tar migration.
     """
     raw = os.environ.get("POCKETPAW_CODEPROJECT_OVERLAY_MAX_MB", "").strip()
     mb = _DEFAULT_OVERLAY_MAX_MB
@@ -907,6 +914,20 @@ def _overlay_max_bytes() -> int:
         except ValueError:
             logger.warning(
                 "ignoring non-numeric POCKETPAW_CODEPROJECT_OVERLAY_MAX_MB=%r; using %s", raw, mb
+            )
+    return int(mb * 1024 * 1024)
+
+
+def _file_max_bytes() -> int:
+    """Per-file byte cap (``POCKETPAW_CODEPROJECT_FILE_MAX_MB``)."""
+    raw = os.environ.get("POCKETPAW_CODEPROJECT_FILE_MAX_MB", "").strip()
+    mb = _DEFAULT_FILE_MAX_MB
+    if raw:
+        try:
+            mb = float(raw)
+        except ValueError:
+            logger.warning(
+                "ignoring non-numeric POCKETPAW_CODEPROJECT_FILE_MAX_MB=%r; using %s", raw, mb
             )
     return int(mb * 1024 * 1024)
 
@@ -961,15 +982,21 @@ def _require_safe_rel_path(rel_path: str) -> str:
     return safe
 
 
-# Path segments dropped when a snapshot tar is expanded for the BROWSER read-back.
-# ``snapshot_project`` tars the whole workspace with no excludes (right for a VM
-# restore, which wants a byte-identical tree), but every tree here is regenerable
-# or meaningless in a tab: ``npm install`` restores ``node_modules``, a build
-# restores ``dist``/``build``/``.next``/``.svelte-kit``, ``.turbo``/``.cache``/
-# ``coverage`` are derived artifacts, and ``.git`` is a binary object store the
-# in-tab runtime has no client for. They are also the bulk of the bytes — shipping
-# them through a JSON string map would be hundreds of MB the browser throws away.
-# Not applied to the VM restore path, which legitimately wants the whole tree.
+# Path segments that never enter the per-file store. ONE list, four readers (S1):
+# ``_sync_tar_command`` excludes them at the source, ``_expand_tar_to_blobs``
+# re-checks after expansion, ``_list_workspace_files`` prunes them from the
+# enumeration, and the restore prune therefore cannot touch them.
+#
+# Every tree here is regenerable or meaningless to persist: ``npm install`` restores
+# ``node_modules``, a build restores ``dist``/``build``/``.next``/``.svelte-kit``,
+# ``.turbo``/``.cache``/``coverage`` are derived artifacts, and ``.git`` is a binary
+# object store whose durability is the remote. They are also the bulk of the bytes —
+# storing them one blob per file, or shipping them to a tab through a JSON string
+# map, would be hundreds of MB nothing reads.
+#
+# The exclusion is why the prune is safe: a path the enumeration cannot see is never
+# a candidate for deletion, so restoring into a fresh clone leaves ``.git`` and an
+# installed ``node_modules`` exactly where they are.
 _SNAPSHOT_EXCLUDED_SEGMENTS = frozenset(
     {
         "node_modules",
@@ -1007,31 +1034,29 @@ def _tar_member_rel_path(name: str) -> str | None:
     return _normalize_rel_path(raw)
 
 
-def _expand_snapshot_tar(data: bytes, *, project_id: str, cap: int) -> tuple[dict[str, str], int]:
-    """Expand a snapshot tarball in memory into ``({relpath: text}, total bytes)``.
+def _expand_tar_to_blobs(data: bytes, *, project_id: str, cap: int) -> tuple[dict[str, bytes], int]:
+    """Expand a tarball in memory into ``({relpath: raw bytes}, total bytes)``.
 
-    The BASELINE tier of the browser read-back — the in-memory counterpart of
-    ``restore_project``'s ``tar -xzf`` into a VM. Written by ``tar -czf`` so the
-    blob is gzipped; ``r:*`` auto-detects anyway.
+    ONE expander behind every place a tar is read: the browser read-back's baseline
+    (via ``_expand_snapshot_tar``, which decodes on top), the sync transport tarball,
+    and the legacy-tar migration. Written by ``tar -czf`` so the blob is gzipped;
+    ``r:*`` auto-detects anyway.
 
-    Three classes of member never make it into the payload:
+    Two classes of member never make it out:
       * non-regular entries (directories, symlinks, hardlinks, devices) — a
         directory carries no content and a link is a tar-smuggling vector with no
-        meaning in a browser FS;
+        meaning in a browser FS or a re-materialized workspace;
       * unsafe names (absolute or ``..``-traversing) and regenerable trees
-        (``_SNAPSHOT_EXCLUDED_SEGMENTS``);
-      * non-UTF-8 blobs — the transport is a JSON string map, so a binary file
-        can't be carried. Skipped with a warning rather than failing the whole
-        restore, mirroring how the overlay read-back tolerates one bad entry.
+        (``_SNAPSHOT_EXCLUDED_SEGMENTS``).
 
     The byte cap is enforced from the member HEADER before anything is read, so a
-    huge (or zip-bomb) snapshot bounds memory instead of consuming it. Exceeding it
+    huge (or zip-bomb) archive bounds memory instead of consuming it. Exceeding it
     raises LOUD (413) — see ``read_project_overlay`` for why a truncated payload is
     the one outcome to avoid.
     """
-    files: dict[str, str] = {}
+    blobs: dict[str, bytes] = {}
     total = 0
-    skipped_unsafe = skipped_excluded = skipped_binary = 0
+    skipped_unsafe = skipped_excluded = 0
     # A corrupt or truncated archive raises on open OR mid-iteration; both are the
     # same failure — the baseline is unreadable — and both must be LOUD. Returning
     # the overlay alone would look like a project that lost most of its files.
@@ -1065,11 +1090,7 @@ def _expand_snapshot_tar(data: bytes, *, project_id: str, cap: int) -> tuple[dic
                     )
                 handle = archive.extractfile(member)
                 blob = handle.read() if handle is not None else b""
-                try:
-                    files[rel_path] = blob.decode("utf-8")
-                except UnicodeDecodeError:
-                    skipped_binary += 1
-                    continue
+                blobs[rel_path] = blob
                 total += len(blob)
     except (tarfile.TarError, EOFError, OSError) as exc:
         raise with_cause(
@@ -1081,15 +1102,44 @@ def _expand_snapshot_tar(data: bytes, *, project_id: str, cap: int) -> tuple[dic
             exc,
         ) from exc
     logger.debug(
-        "codeproject.read_overlay: snapshot expanded for project=%s -> %d file(s), %d bytes "
-        "(skipped %d excluded, %d binary, %d unsafe)",
+        "codeproject.expand_tar: project=%s -> %d file(s), %d bytes "
+        "(skipped %d excluded, %d unsafe)",
         project_id,
-        len(files),
+        len(blobs),
         total,
         skipped_excluded,
-        skipped_binary,
         skipped_unsafe,
     )
+    return blobs, total
+
+
+def _expand_snapshot_tar(data: bytes, *, project_id: str, cap: int) -> tuple[dict[str, str], int]:
+    """Expand a tarball into ``({relpath: text}, total bytes)`` for the browser.
+
+    ``_expand_tar_to_blobs`` plus the one concern only the JSON wire has: a binary
+    file cannot be carried in a string map, so a non-UTF-8 member is skipped with a
+    warning rather than failing the whole restore — the same "one bad entry must not
+    sink the rest" rule the overlay read-back replays under. Its bytes still counted
+    against the cap during expansion (they were buffered), but they are not counted
+    in the returned total, which is the budget the overlay tier then adds to.
+    """
+    blobs, _raw_total = _expand_tar_to_blobs(data, project_id=project_id, cap=cap)
+    files: dict[str, str] = {}
+    total = 0
+    skipped_binary = 0
+    for rel_path, blob in blobs.items():
+        try:
+            files[rel_path] = blob.decode("utf-8")
+        except UnicodeDecodeError:
+            skipped_binary += 1
+            continue
+        total += len(blob)
+    if skipped_binary:
+        logger.debug(
+            "codeproject.read_overlay: skipped %d non-UTF-8 entry(ies) for project=%s",
+            skipped_binary,
+            project_id,
+        )
     return files, total
 
 
@@ -1120,7 +1170,7 @@ async def put_project_file(
     safe_path = _require_safe_rel_path(rel_path)
     data = content.encode("utf-8")
 
-    cap = _overlay_max_bytes()
+    cap = _file_max_bytes()
     if len(data) > cap:
         raise CloudError(
             413,
@@ -1272,6 +1322,369 @@ async def read_project_overlay(
     return files
 
 
+# ===========================================================================
+# Workspace file sync — what makes the per-file store COMPLETE (S1).
+#
+# The write-through hooks only ever see files that pass through the editor: a
+# ``git clone``'s tree, a materialized scaffold, and anything a process writes
+# (build output, generated files) are invisible to them. The tarball tier used to
+# cover that gap, and covering it is the price of retiring the tarball — so the
+# workspace is enumerated explicitly and every file written through to its own
+# blob.
+#
+# The tar is a TRANSPORT here, not a tier: one round trip to read the whole tree
+# instead of one ``download_file`` per file, expanded in memory and immediately
+# fanned out into per-file objects. Nothing durable is a tarball afterwards.
+# ===========================================================================
+
+
+def _sync_tar_command() -> str:
+    """The in-VM command that packs the workspace for a sync read.
+
+    Excludes are built from ``_SNAPSHOT_EXCLUDED_SEGMENTS`` so there is exactly ONE
+    definition of "a regenerable tree" — the same frozenset the expander re-checks
+    and the prune skips. Excluding at the tar level is what keeps a 500 MB
+    ``node_modules`` off the wire in the first place; re-checking after expansion is
+    defence in depth for a tar built elsewhere (a legacy snapshot, say).
+    """
+    excludes = " ".join(
+        f"--exclude={shlex.quote(seg)}" for seg in sorted(_SNAPSHOT_EXCLUDED_SEGMENTS)
+    )
+    return (
+        f"tar -czf {_PROJECT_SYNC_TMP} {excludes} "
+        f"-C {shlex.quote(WEBSANDBOX_WORKDIR)} . 2>/dev/null || true"
+    )
+
+
+async def sync_project_files(
+    workspace_id: str,
+    user_id: str,
+    project_id: str,
+    sandbox_id: str,
+    *,
+    client: DaytonaClient | None = None,
+    uploads: Any = None,
+) -> dict[str, str]:
+    """Re-image a project's per-file store from its live VM workspace.
+
+    The replacement for the retired ``snapshot_project``, and the operation that
+    makes "the overlay is the whole truth" true. Enumerate the workspace, write
+    every file through to its own blob, and swap the whole map in with ONE service
+    write. Returns the new overlay.
+
+    DELETIONS ARE THE POINT. Syncing enumerates what EXISTS, so a file the user
+    deleted simply isn't uploaded — and because the map is REPLACED rather than
+    merged, its old entry goes with it. Nothing is left to resurrect it: there is
+    no baseline blob to replay, and the next restore reconstructs the workspace
+    from this map alone.
+
+    Two things are deliberately NOT dropped, because "the sync didn't see it" is
+    not the same claim as "the user deleted it":
+      * paths inside an excluded tree (``dist/``, ``.next/`` …). The enumeration
+        never looks there, so an entry a write hook once recorded for such a path
+        is kept rather than silently discarded.
+      * paths whose upload FAILED this round. A stale pointer beats no pointer.
+    And an enumeration that comes back EMPTY is treated as a failed read, not as an
+    emptied workspace: it returns the existing overlay untouched. A transient VM
+    error must never be the thing that wipes a project.
+
+    Fails CLOSED on a non-s3 upload adapter in cloud (silent non-persistence is
+    worse than a loud 503), and LOUD on the aggregate caps rather than persisting a
+    truncated project. Both callers (``ws.snapshot_on_disconnect`` and
+    ``lifecycle.open_project``) are best-effort and log at WARNING, so a raise here
+    costs the capture, never the session.
+    """
+    _require_s3_for_project_store()
+    daytona = _require_client(client)
+
+    # Owner-scoped tenancy gate: NotFound for a project the caller doesn't own.
+    project = await codeproject_service.get_project(workspace_id, user_id, project_id)
+    previous = dict(project.overlay or {})
+
+    try:
+        await daytona.execute_command(
+            sandbox_id, _sync_tar_command(), timeout=_SYNC_EXEC_TIMEOUT_SECONDS
+        )
+        data = await daytona.download_file(sandbox_id, _PROJECT_SYNC_TMP)
+    except Exception as exc:  # noqa: BLE001 — any VM-side failure is uniform
+        logger.warning(
+            "codeproject.sync: tar/download failed for project=%s", project_id, exc_info=True
+        )
+        raise with_cause(
+            CloudError(502, "codeproject.sync_failed", "Failed to read the project workspace"),
+            exc,
+        ) from exc
+
+    cap = _overlay_max_bytes()
+    blobs, total = _expand_tar_to_blobs(data, project_id=project_id, cap=cap)
+
+    max_files = _overlay_max_files()
+    if len(blobs) > max_files:
+        raise CloudError(
+            413,
+            "codeproject.overlay_too_many_files",
+            f"Project holds {len(blobs)} files, over the {max_files} file limit",
+        )
+    if not blobs:
+        # An empty read is ambiguous (a genuinely empty workspace, or a tar that
+        # never ran) and the destructive reading of it is unrecoverable. Keep what
+        # we have; a real empty project loses nothing by staying as it was.
+        logger.warning(
+            "codeproject.sync: workspace enumeration for project=%s daytona=%s came back "
+            "EMPTY — keeping the existing %d file(s) rather than dropping them",
+            project_id,
+            sandbox_id,
+            len(previous),
+        )
+        return previous
+
+    up = uploads if uploads is not None else build_uploads()
+    overlay: dict[str, str] = {}
+    failed = 0
+    for rel_path in sorted(blobs):
+        try:
+            overlay[rel_path] = await _upload_project_blob(
+                up,
+                blobs[rel_path],
+                workspace_id=workspace_id,
+                user_id=user_id,
+                filename=f"overlay-{project_id}-{rel_path.rsplit('/', 1)[-1] or 'file'}",
+                folder=_PROJECT_OVERLAY_FOLDER,
+                content_type="application/octet-stream",
+            )
+        except Exception:  # noqa: BLE001 — one bad blob must not sink the whole sync
+            failed += 1
+            if rel_path in previous:
+                overlay[rel_path] = previous[rel_path]
+            logger.warning(
+                "codeproject.sync: upload failed for project=%s path=%r", project_id, rel_path
+            )
+
+    # Carry across the entries the enumeration could not have seen (see docstring).
+    kept_excluded = 0
+    for rel_path, file_id in previous.items():
+        if rel_path not in overlay and _is_excluded_snapshot_path(rel_path):
+            overlay[rel_path] = file_id
+            kept_excluded += 1
+
+    dropped = sorted(set(previous) - set(overlay))
+    view = await codeproject_service.replace_project_overlay(
+        workspace_id,
+        user_id,
+        project_id,
+        overlay,
+        # Verified against a real workspace — this is what licenses restore's prune.
+        complete=True,
+    )
+    logger.info(
+        "codeproject.sync: project=%s daytona=%s -> %d file(s), %d bytes "
+        "(dropped %d deleted, kept %d excluded, %d upload failure(s))",
+        project_id,
+        sandbox_id,
+        len(view.overlay),
+        total,
+        len(dropped),
+        kept_excluded,
+        failed,
+    )
+    return dict(view.overlay)
+
+
+async def _migrate_legacy_snapshot(
+    workspace_id: str,
+    user_id: str,
+    project: CodeProjectView,
+    uploads: Any,
+) -> CodeProjectView:
+    """Expand a project's legacy tarball into per-file entries, ONCE. Returns the view.
+
+    The one-way migration for state written before the tarball tier was retired.
+    Such a project carries a ``snapshot_file_id`` plus a partial overlay of the
+    edits made after the tar was taken, and reading the overlay alone would lose
+    everything that only ever lived inside the tar. So the tar is expanded and each
+    member written through to its own blob.
+
+    Three properties, all of which make it safe to run on every restore:
+      * NON-DESTRUCTIVE — an existing overlay entry always WINS. It is newer than
+        the tar by construction (it was written after the snapshot), so the tar's
+        copy is never allowed to overwrite it.
+      * IDEMPOTENT — success clears ``snapshot_file_id``, so there is no tar left
+        to expand a second time. A partial run keeps the pointer AND keeps every
+        entry it did carry across, so the retry only does the remainder.
+      * FAIL-SAFE — if the blob is unreadable, the upload adapter is misconfigured,
+        or any member fails to land, the pointer is KEPT. The caller then falls back
+        to untarring the baseline into the VM, so the session is complete either
+        way and the data is still in blob storage for the next attempt.
+
+    Clearing the pointer is not bookkeeping — it is the whole point. While it is
+    set, a restore replays a baseline that cannot express a deletion, which is the
+    bug this migration exists to end.
+    """
+    project_id = project.id
+    try:
+        _require_s3_for_project_store()
+        data = await _download_snapshot(
+            uploads, project.snapshot_file_id or "", workspace_id=workspace_id, user_id=user_id
+        )
+        blobs, _total = _expand_tar_to_blobs(data, project_id=project_id, cap=_overlay_max_bytes())
+    except Exception:  # noqa: BLE001 — any read failure keeps the pointer for a retry
+        logger.warning(
+            "codeproject.migrate: could not read legacy snapshot=%s for project=%s; "
+            "keeping the pointer and falling back to the tar baseline",
+            project.snapshot_file_id,
+            project_id,
+            exc_info=True,
+        )
+        return project
+
+    overlay = dict(project.overlay or {})
+    migrated = failed = 0
+    for rel_path in sorted(blobs):
+        if rel_path in overlay:
+            # The overlay entry post-dates the tar — never overwrite it.
+            continue
+        try:
+            overlay[rel_path] = await _upload_project_blob(
+                uploads,
+                blobs[rel_path],
+                workspace_id=workspace_id,
+                user_id=user_id,
+                filename=f"overlay-{project_id}-{rel_path.rsplit('/', 1)[-1] or 'file'}",
+                folder=_PROJECT_OVERLAY_FOLDER,
+                content_type="application/octet-stream",
+            )
+            migrated += 1
+        except Exception:  # noqa: BLE001 — a partial migration retries, never loses
+            failed += 1
+            logger.warning(
+                "codeproject.migrate: upload failed for project=%s path=%r",
+                project_id,
+                rel_path,
+            )
+
+    view = await codeproject_service.replace_project_overlay(
+        workspace_id,
+        user_id,
+        project_id,
+        overlay,
+        # A legacy tar was a whole-workspace image, so the merged map is complete —
+        # unless something failed to land, in which case it demonstrably isn't.
+        complete=failed == 0,
+        clear_snapshot=failed == 0,
+    )
+    logger.info(
+        "codeproject.migrate: project=%s legacy snapshot=%s -> %d new per-file entry(ies), "
+        "%d total (%d failure(s); pointer %s)",
+        project_id,
+        project.snapshot_file_id,
+        migrated,
+        len(view.overlay),
+        failed,
+        "kept for retry" if failed else "cleared",
+    )
+    return view
+
+
+async def _list_workspace_files(daytona: Any, sandbox_id: str) -> list[str]:
+    """Enumerate the VM workspace as project-relative paths (excluded trees pruned).
+
+    ``find`` rather than the sync's tar because the caller only needs NAMES — the
+    prune decides what to delete, and shipping the bytes to decide that would be
+    absurd. The excluded segments are pruned in the command AND re-checked in
+    Python, so the two enumerations agree on what is even visible.
+
+    Every path is re-jailed through ``_normalize_rel_path`` after the workspace
+    prefix is stripped: this list feeds an ``rm``, so a line that doesn't sit under
+    the workspace dir is dropped rather than trusted.
+    """
+    root = shlex.quote(WEBSANDBOX_WORKDIR)
+    names = " -o ".join(f"-name {shlex.quote(seg)}" for seg in sorted(_SNAPSHOT_EXCLUDED_SEGMENTS))
+    command = f"find {root} -type d \\( {names} \\) -prune -o -type f -print"
+    resp = await daytona.execute_command(sandbox_id, command, timeout=_SYNC_EXEC_TIMEOUT_SECONDS)
+    stdout = getattr(resp, "result", "") or ""
+    prefix = WEBSANDBOX_WORKDIR.rstrip("/") + "/"
+    found: list[str] = []
+    for line in stdout.splitlines():
+        raw = line.strip()
+        if not raw.startswith(prefix):
+            continue
+        rel_path = _normalize_rel_path(raw[len(prefix) :])
+        if rel_path is None or _is_excluded_snapshot_path(rel_path):
+            continue
+        found.append(rel_path)
+    return found
+
+
+async def _prune_stale_workspace_files(
+    daytona: Any,
+    sandbox_id: str,
+    overlay: dict[str, str],
+    *,
+    project_id: str,
+    replayed: int,
+) -> int:
+    """Delete workspace files the (complete) per-file store does not list. Returns the count.
+
+    The deletion half of "restore reconstructs the workspace from the overlay". A
+    restore always runs into a VM that was just cloned or scaffolded, so it holds
+    baseline files — including the ones the user DELETED. Writing the overlay over
+    that tree leaves those files behind, which is precisely the resurrection the
+    tarball tier used to cause. Removing them is what makes a delete durable.
+
+    Only ever called when ``overlay_complete`` is set, i.e. after a sync verified
+    the map against a real workspace. Two more guards on top of that:
+      * an EMPTY enumeration is treated as a failed read, never as "delete
+        everything" — the same reading ``sync_project_files`` takes;
+      * nothing is pruned when the overlay replay wrote NOTHING, because a restore
+        that failed to materialize the store must not then delete the baseline it
+        was supposed to replace.
+    Excluded trees are invisible to the enumeration, so ``.git``, ``node_modules``
+    and build output are never touched. Best-effort: a prune failure leaves a
+    resurrected file, which is recoverable; raising would fail the whole open.
+    """
+    if not overlay or not replayed:
+        return 0
+    try:
+        present = await _list_workspace_files(daytona, sandbox_id)
+    except Exception:  # noqa: BLE001 — a failed enumeration prunes nothing
+        logger.warning(
+            "codeproject.restore: could not enumerate the workspace for project=%s; "
+            "skipping the stale-file prune",
+            project_id,
+            exc_info=True,
+        )
+        return 0
+    if not present:
+        return 0
+
+    stale = [p for p in sorted(set(present)) if p not in overlay]
+    targets = [abs_path for abs_path in map(_overlay_abs_path, stale) if abs_path is not None]
+    if not targets:
+        return 0
+
+    removed = 0
+    for start in range(0, len(targets), _PRUNE_CHUNK):
+        chunk = targets[start : start + _PRUNE_CHUNK]
+        command = "rm -f " + " ".join(shlex.quote(p) for p in chunk)
+        try:
+            await daytona.execute_command(sandbox_id, command, timeout=_SYNC_EXEC_TIMEOUT_SECONDS)
+            removed += len(chunk)
+        except Exception:  # noqa: BLE001 — one failed chunk must not sink the restore
+            logger.warning(
+                "codeproject.restore: stale-file prune failed for project=%s (%d path(s))",
+                project_id,
+                len(chunk),
+                exc_info=True,
+            )
+    logger.info(
+        "codeproject.restore: project=%s daytona=%s pruned %d file(s) absent from the store",
+        project_id,
+        sandbox_id,
+        removed,
+    )
+    return removed
+
+
 __all__ = [
     "build_uploads",
     "drop_overlay",
@@ -1285,6 +1698,6 @@ __all__ = [
     "read_project_overlay",
     "restore_project",
     "restore_workspace",
-    "snapshot_project",
     "snapshot_workspace",
+    "sync_project_files",
 ]

--- a/ee/pocketpaw_ee/cloud/websandbox/durability.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/durability.py
@@ -827,6 +827,100 @@ async def mirror_file_to_project(
     return file_id
 
 
+async def put_project_files(
+    workspace_id: str,
+    user_id: str,
+    project_id: str,
+    files: dict[str, str],
+    *,
+    uploads: Any = None,
+) -> int:
+    """Replace the project's whole per-file store from a client-supplied map.
+
+    The in-tab analog of ``sync_project_files``: the browser holds the project's
+    filesystem, so IT is the only thing that can enumerate one. It walks its own
+    FS once (after materializing a starter, say) and hands the result here.
+
+    Why this exists as a BULK op rather than N calls to ``put_project_file``:
+    completeness has to be a property of a write that either wholly happened or
+    did not. ``overlay_complete`` is what licenses the restore-time prune to
+    delete a file the store does not list, so a store marked complete after a
+    partial upload would license deleting exactly the files that failed to
+    upload. Uploading everything FIRST and swapping the map in one write makes
+    that unrepresentable: a failure raises before the swap, and the project keeps
+    its previous state and its previous completeness.
+
+    Caps are the same ones the VM sync answers to, and they fail LOUD — a store
+    silently missing files is the input to a destructive prune.
+    """
+    _require_s3_for_project_store()
+    # Authorize BEFORE uploading. The swap at the end is owner-scoped and would
+    # reject a foreign caller anyway, but only after their bytes were already in
+    # the tenant's storage — an unauthorized request should not be able to spend
+    # storage on its way to a 404.
+    await codeproject_service.get_project(workspace_id, user_id, project_id)
+
+    max_files = _overlay_max_files()
+    if len(files) > max_files:
+        raise CloudError(
+            413,
+            "codeproject.overlay_too_many_files",
+            f"Project holds {len(files)} files, over the {max_files} file limit",
+        )
+
+    file_cap = _file_max_bytes()
+    total_cap = _overlay_max_bytes()
+    encoded: dict[str, bytes] = {}
+    total = 0
+    for raw_path, content in files.items():
+        safe_path = _require_safe_rel_path(raw_path)
+        data = (content or "").encode("utf-8")
+        if len(data) > file_cap:
+            raise CloudError(
+                413,
+                "codeproject.file_too_large",
+                f"{safe_path!r} is {len(data)} bytes, over the per-file limit",
+            )
+        total += len(data)
+        if total > total_cap:
+            raise CloudError(
+                413,
+                "codeproject.overlay_too_large",
+                f"Project exceeds the {total_cap}-byte store limit",
+            )
+        encoded[safe_path] = data
+
+    up = uploads if uploads is not None else build_uploads()
+    overlay: dict[str, str] = {}
+    for safe_path, data in encoded.items():
+        basename = safe_path.rsplit("/", 1)[-1] or "file"
+        overlay[safe_path] = await _upload_project_blob(
+            up,
+            data,
+            workspace_id=workspace_id,
+            user_id=user_id,
+            filename=f"overlay-{project_id}-{basename}",
+            folder=_PROJECT_OVERLAY_FOLDER,
+            content_type="application/octet-stream",
+        )
+
+    # Every byte is durable before the map moves — so this swap is the moment the
+    # store becomes both authoritative and complete, and never a moment earlier.
+    await codeproject_service.replace_project_overlay(
+        workspace_id,
+        user_id,
+        project_id,
+        overlay,
+        complete=True,
+    )
+    logger.info(
+        "codeproject.sync(in-tab): project=%s stored %d files",
+        project_id,
+        len(overlay),
+    )
+    return len(overlay)
+
+
 async def drop_project_overlay(
     workspace_id: str,
     user_id: str,

--- a/ee/pocketpaw_ee/cloud/websandbox/ws.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/ws.py
@@ -83,6 +83,16 @@
 # misconfigured deploy persisted NOTHING while every save reported ok, with the only
 # trace at debug. Still swallowed (a durability hiccup must not break a file write
 # that already landed); just diagnosable now, with the anchor and path in the line.
+#
+# 2026-07-25 (S1, feat/code-s3-authoritative): the disconnect capture for a
+# PROJECT-anchored socket is now ``sync_project_files`` (a per-file re-image of the
+# workspace) instead of ``snapshot_project`` (one whole-workspace tarball). WHY: the
+# tarball could not express a DELETE — replaying it resurrected every file the user
+# removed, and taking it CLEARED the per-file overlay that could have recorded the
+# absence. The per-file store is now the whole truth, and a sync is what keeps it
+# complete for everything that never passes a write hook (a clone, a scaffold,
+# generated output). The degrade path is untouched: a sandbox with no owning project
+# still writes the sandbox-keyed tarball, which remains its only durability.
 from __future__ import annotations
 
 import asyncio
@@ -307,39 +317,44 @@ async def snapshot_on_disconnect(
     project_id: str | None = None,
     daytona_id: str | None = None,
 ) -> None:
-    """Best-effort workspace snapshot when a terminal socket closes (CM-2a′, B2).
+    """Best-effort workspace capture when a terminal socket closes (CM-2a′, B2, S1).
 
-    The durable half of Code Mode is the S3 snapshot; the Daytona VM is pure
-    scratch. With the aggressive Daytona lifecycle (stop 5 / delete-on-stop), a
-    disconnected VM is reclaimed within minutes — so a CLEAN disconnect (tab
-    close, navigate away) is the moment to capture the workspace while the VM is
-    still alive. ``codeproject.lifecycle.open_project`` restores the latest
-    snapshot on the next open.
+    The durable half of Code Mode is blob storage; the Daytona VM is pure scratch.
+    With the aggressive Daytona lifecycle (stop 5 / delete-on-stop), a disconnected
+    VM is reclaimed within minutes — so a CLEAN disconnect (tab close, navigate
+    away) is the moment to capture the workspace while the VM is still alive.
+    ``codeproject.lifecycle.open_project`` reconstructs it on the next open.
 
-    The pointer lands on the durable PROJECT when the socket resolved one, keyed by
-    ``project_id`` and taken from the live VM ``daytona_id`` (the project-keyed
-    snapshot addresses the VM directly rather than through the row). Without both —
-    a sandbox opened outside the project flow, or a row with no bound VM — it falls
-    back to the sandbox-keyed snapshot rather than skipping the capture.
+    A PROJECT-anchored socket now runs ``sync_project_files`` — a per-file re-image
+    of the workspace — where it used to write one whole-workspace TARBALL (S1). The
+    tar could not represent a DELETE: replaying it resurrected every file the user
+    removed during the session, and the write-through overlay that could have
+    recorded the absence was cleared by the snapshot. Syncing enumerates what
+    exists, so a deleted file is simply absent from the store afterwards. The
+    capture still needs both a ``project_id`` and a live ``daytona_id``; without
+    them (a sandbox opened outside the project flow, or a row with no bound VM) it
+    falls back to the sandbox-keyed tarball snapshot rather than skipping the
+    capture — that legacy path is unchanged and still the only durability such a
+    sandbox has.
 
-    Best-effort by design: a snapshot failure (VM already gone, S3 down, an
+    Best-effort by design: a capture failure (VM already gone, S3 down, an
     unprovisioned row) must NEVER surface on socket teardown — it is swallowed. It
-    is logged at WARNING though (B4): this is the capture that makes a whole
-    session's work durable, so losing it silently is indistinguishable from data
-    loss on the next open.
+    is logged at WARNING though (B4): this is what makes a whole session's work
+    durable, so losing it silently is indistinguishable from data loss on the next
+    open.
     """
     try:
         if project_id and daytona_id:
-            await websandbox_durability.snapshot_project(
+            await websandbox_durability.sync_project_files(
                 workspace_id, user_id, project_id, daytona_id, client=client
             )
         else:
             await websandbox_durability.snapshot_workspace(
                 workspace_id, user_id, row_id, client=client
             )
-    except Exception:  # noqa: BLE001 — teardown must never raise on a snapshot miss
+    except Exception:  # noqa: BLE001 — teardown must never raise on a capture miss
         logger.warning(
-            "websandbox.snapshot on disconnect failed for row=%s project=%s daytona=%s — "
+            "websandbox.capture on disconnect failed for row=%s project=%s daytona=%s — "
             "this session's workspace was NOT captured",
             row_id,
             project_id,

--- a/tests/cloud/test_codeproject_bulk_files.py
+++ b/tests/cloud/test_codeproject_bulk_files.py
@@ -1,0 +1,140 @@
+# test_codeproject_bulk_files.py — the in-tab whole-project write.
+#
+# Created 2026-07-25 (S1 follow-up). `put_project_files` is the in-tab analog of
+# the VM's `sync_project_files`: the browser hosts the filesystem, so it is the
+# only thing that can enumerate one, and it posts the whole map at once.
+#
+# What these lock is the property that makes the restore-time PRUNE safe to run:
+# `overlay_complete` may only ever be set by a write that WHOLLY succeeded. A
+# store marked complete after a partial upload would license deleting exactly the
+# files that failed to upload — so the all-or-nothing test below is the important
+# one, not the happy path.
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import CloudError, NotFound, ValidationError
+from pocketpaw_ee.cloud.codeproject import service as codeproject_service
+from pocketpaw_ee.cloud.websandbox import durability
+
+from tests.cloud.test_codeproject_file_sync import _FakeUploads, _project
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+_WS = "w1"
+_USER = "u1"
+
+
+async def test_a_whole_project_write_marks_the_store_complete() -> None:
+    """The happy path, and the flag that licenses the prune."""
+    project = await _project()
+    uploads = _FakeUploads()
+
+    stored = await durability.put_project_files(
+        _WS,
+        _USER,
+        project.id,
+        {"src/App.tsx": "export default App;", "README.md": "# hi"},
+        uploads=uploads,
+    )
+
+    assert stored == 2
+    view = await codeproject_service.get_project(_WS, _USER, project.id)
+    assert set(view.overlay) == {"src/App.tsx", "README.md"}
+    assert view.overlay_complete is True
+
+
+async def test_a_replacement_drops_a_path_the_client_no_longer_has() -> None:
+    """The delete that used to come back. The map is the project, so a path the
+    client didn't send is a path the project doesn't have."""
+    project = await _project()
+    uploads = _FakeUploads()
+
+    await durability.put_project_files(
+        _WS, _USER, project.id, {"keep.ts": "a", "delete-me.ts": "b"}, uploads=uploads
+    )
+    await durability.put_project_files(_WS, _USER, project.id, {"keep.ts": "a"}, uploads=uploads)
+
+    view = await codeproject_service.get_project(_WS, _USER, project.id)
+    assert set(view.overlay) == {"keep.ts"}
+
+
+async def test_a_failed_upload_leaves_the_store_untouched_and_incomplete() -> None:
+    """THE load-bearing test. A partial upload must not become a complete store,
+    because `overlay_complete` is what lets the restore prune delete files."""
+    project = await _project()
+    uploads = _FakeUploads()
+
+    # Seed a known-good prior state so we can prove it survives the failure.
+    await durability.put_project_files(_WS, _USER, project.id, {"before.ts": "x"}, uploads=uploads)
+    await codeproject_service.replace_project_overlay(
+        _WS, _USER, project.id, {"before.ts": "file-1"}, complete=False
+    )
+
+    calls = {"n": 0}
+    original = uploads.upload
+
+    async def _fail_on_second(*args, **kwargs):  # noqa: ANN002, ANN003
+        calls["n"] += 1
+        if calls["n"] >= 2:
+            raise RuntimeError("storage went away mid-write")
+        return await original(*args, **kwargs)
+
+    uploads.upload = _fail_on_second  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError):
+        await durability.put_project_files(
+            _WS, _USER, project.id, {"a.ts": "1", "b.ts": "2", "c.ts": "3"}, uploads=uploads
+        )
+
+    view = await codeproject_service.get_project(_WS, _USER, project.id)
+    assert set(view.overlay) == {"before.ts"}, "a failed write must not swap the map"
+    assert view.overlay_complete is False, "a partial upload must never read as complete"
+
+
+async def test_an_escaping_path_is_rejected_before_anything_uploads() -> None:
+    """Jailed at the boundary, and jailed BEFORE the first upload — a rejected
+    batch should not leave orphan blobs behind."""
+    project = await _project()
+    uploads = _FakeUploads()
+
+    with pytest.raises(ValidationError):
+        await durability.put_project_files(
+            _WS, _USER, project.id, {"ok.ts": "a", "../escape.ts": "b"}, uploads=uploads
+        )
+
+    assert uploads.upload_calls == []
+    view = await codeproject_service.get_project(_WS, _USER, project.id)
+    assert view.overlay == {}
+
+
+async def test_over_the_file_count_cap_fails_loud(monkeypatch) -> None:  # noqa: ANN001
+    """Loud, not truncated — a silently short store is the input to a prune."""
+    project = await _project()
+    uploads = _FakeUploads()
+    monkeypatch.setattr(durability, "_overlay_max_files", lambda: 2)
+
+    with pytest.raises(CloudError) as err:
+        await durability.put_project_files(
+            _WS, _USER, project.id, {"a": "1", "b": "2", "c": "3"}, uploads=uploads
+        )
+
+    assert err.value.code == "codeproject.overlay_too_many_files"
+    assert uploads.upload_calls == []
+
+
+async def test_a_foreign_caller_cannot_replace_the_store() -> None:
+    """Rejected, and rejected BEFORE spending storage — an unauthorized request
+    should not be able to upload its way to a 404."""
+    project = await _project()
+    uploads = _FakeUploads()
+
+    with pytest.raises(NotFound):
+        await durability.put_project_files(
+            "other-ws", _USER, project.id, {"a.ts": "1"}, uploads=uploads
+        )
+    with pytest.raises(NotFound):
+        await durability.put_project_files(
+            _WS, "other-user", project.id, {"a.ts": "1"}, uploads=uploads
+        )
+
+    assert uploads.upload_calls == [], "a foreign caller must not reach the upload path"

--- a/tests/cloud/test_codeproject_cross_runtime.py
+++ b/tests/cloud/test_codeproject_cross_runtime.py
@@ -27,6 +27,13 @@
 #     ordinary nested source (incl. non-ASCII text) survives byte-identical.
 #   * tar safety: absolute, ``..``-traversing, and symlink members are skipped.
 #   * caps: a filtered snapshot still over the cap fails LOUD, never partial.
+#
+# Updated 2026-07-25 (S1, feat/code-s3-authoritative): ``snapshot_project`` is gone —
+# the tarball tier was retired because a tar cannot express a DELETE — so the
+# "a Daytona session ended" setup now stages the LEGACY row shape directly (tar in
+# blob storage + ``snapshot_file_id`` pointing at it). That is deliberately still the
+# scenario under test: the browser read-back must keep serving such a project until a
+# VM open migrates it to per-file entries. The read path itself is unchanged.
 from __future__ import annotations
 
 import io
@@ -160,15 +167,24 @@ async def _project(workspace=_WS, user=_USER):  # noqa: ANN001
 
 
 async def _daytona_session(project_id: str, uploads: _FakeUploads, tar_bytes: bytes) -> None:
-    """Simulate a Daytona session ending: snapshot the VM, which clears the overlay."""
-    await durability.snapshot_project(
-        _WS,
-        _USER,
-        project_id,
-        _SANDBOX,
-        client=_FakeDaytonaClient(tar_bytes=tar_bytes),
-        uploads=uploads,
+    """Stage a LEGACY tarball snapshot on a project (pre-S1 durable state).
+
+    S1 retired the tarball tier and deleted ``snapshot_project``, so this stages the
+    state directly: land the tar in blob storage and point the project at it. That
+    is exactly the row shape a project written by the old Daytona path still has in
+    Mongo today, which is what these cross-runtime read-back tests are about — the
+    browser must keep serving a legacy project's files until a VM open migrates it.
+    """
+    file_id = await durability._upload_project_blob(
+        uploads,
+        tar_bytes,
+        workspace_id=_WS,
+        user_id=_USER,
+        filename="legacy-snapshot.tgz",
+        folder="/code-project-snapshots",
+        content_type="application/gzip",
     )
+    await codeproject_service.set_project_snapshot(_WS, _USER, project_id, file_id)
 
 
 def _ctx(workspace=_WS, user=_USER):  # noqa: ANN001
@@ -190,10 +206,9 @@ async def test_snapshot_only_project_reads_back_the_tars_files() -> None:
     project = await _project()
     uploads = _FakeUploads()
 
-    # Work done in the VM, then a disconnect snapshot — which CLEARS the overlay.
-    await durability.mirror_file_to_project(
-        _WS, _USER, project.id, "src/app.ts", b"pre-snapshot", uploads=uploads
-    )
+    # A pre-S1 Daytona session: everything the user did is inside the tarball and
+    # the overlay is empty (the old ``set_project_snapshot`` cleared it, which is
+    # exactly the state that made this read-back return ``{}``).
     await _daytona_session(
         project.id,
         uploads,

--- a/tests/cloud/test_codeproject_daytona_anchor.py
+++ b/tests/cloud/test_codeproject_daytona_anchor.py
@@ -35,9 +35,10 @@ from pocketpaw_ee.cloud.websandbox import durability
 from pocketpaw_ee.cloud.websandbox import provision as websandbox_provision
 from pocketpaw_ee.cloud.websandbox import service as sandbox_service
 from pocketpaw_ee.cloud.websandbox import ws as terminal_ws
+from pocketpaw_ee.cloud.websandbox.constants import WEBSANDBOX_WORKDIR
 
 from tests.cloud.test_codeproject_durability import _FakeDaytonaClient as _FakeVmClient
-from tests.cloud.test_codeproject_durability import _FakeUploads
+from tests.cloud.test_codeproject_durability import _FakeUploads, _tar
 from tests.cloud.test_websandbox_provision import _FakeDaytonaClient as _FakeProvisionClient
 
 pytestmark = pytest.mark.usefixtures("mongo_db")
@@ -82,12 +83,15 @@ async def _starter_row():
 # ---------------------------------------------------------------------------
 
 
-async def test_full_chain_mirrors_snapshots_and_restores_against_the_project(uploads) -> None:  # noqa: ANN001
-    """provision -> mirror -> snapshot on disconnect -> reprovision -> restore.
+async def test_full_chain_mirrors_captures_and_restores_against_the_project(uploads) -> None:  # noqa: ANN001
+    """provision -> mirror -> capture on disconnect -> reprovision -> restore.
 
     Every durable pointer is read off the CodeProject; the WebSandbox row's
     ``snapshot_file_id`` / ``overlay`` are never written, so nothing in the chain
     depends on the ephemeral row surviving.
+
+    The disconnect capture is a per-file SYNC since S1, not a tarball snapshot, so
+    what the chain carries across is the store itself.
     """
     project = await codeproject_service.create_project(_WS, _USER, {"repo": _REPO})
     prov = _FakeProvisionClient()
@@ -111,8 +115,12 @@ async def test_full_chain_mirrors_snapshots_and_restores_against_the_project(upl
     row = await sandbox_service.get_sandbox(_WS, _USER, sandbox.id)
     assert row.overlay == {}, "the mirror still wrote to the EPHEMERAL row"
 
-    # 3. A clean disconnect snapshots the live VM onto the project.
-    vm = _FakeVmClient(tar_bytes=b"SNAPSHOT-TAR")
+    # 3. A clean disconnect re-images the live VM's workspace onto the project. The
+    #    tree carries a file the write hook never saw (a clone's own file) — the
+    #    whole reason the capture enumerates the VM instead of trusting the hooks.
+    vm = _FakeVmClient(
+        tar_bytes=_tar({"./src/app.ts": b"EDITED-IN-THE-VM", "./README.md": b"# hi"})
+    )
     await terminal_ws.snapshot_on_disconnect(
         _WS,
         _USER,
@@ -121,21 +129,24 @@ async def test_full_chain_mirrors_snapshots_and_restores_against_the_project(upl
         project_id=project_id,
         daytona_id=sandbox.sandbox_id,
     )
-    snapshotted = await codeproject_service.get_project(_WS, _USER, project.id)
-    assert snapshotted.snapshot_file_id is not None
-    assert snapshotted.overlay == {}, "a full snapshot supersedes the overlay"
+    captured = await codeproject_service.get_project(_WS, _USER, project.id)
+    assert set(captured.overlay) == {"src/app.ts", "README.md"}
+    assert captured.overlay_complete is True
+    assert captured.snapshot_file_id is None, "the retired tarball tier was written to"
     row = await sandbox_service.get_sandbox(_WS, _USER, sandbox.id)
-    assert row.snapshot_file_id is None, "the snapshot pointer landed on the EPHEMERAL row"
+    assert row.snapshot_file_id is None, "the capture landed on the EPHEMERAL row"
+    assert row.overlay == {}
 
     # 4. The VM is reaped; reopening reprovisions and restores from the PROJECT.
     await sandbox_service.mark_reaped(sandbox.id)
     second = await lifecycle.open_project(_WS, _USER, project.id, client=prov)
     assert second.sandbox_id != sandbox.sandbox_id  # genuinely fresh VM
 
-    untarred = [c for c in prov.upload_calls if c["path"] == _SNAPSHOT_TMP]
-    assert untarred, "the project's snapshot was never pushed into the fresh VM"
-    assert untarred[-1]["data"] == b"SNAPSHOT-TAR"
-    assert untarred[-1]["id"] == second.sandbox_id
+    # Every stored file was pushed into the fresh VM, and no tarball was untarred.
+    pushed = {c["path"]: c["data"] for c in prov.upload_calls if c["id"] == second.sandbox_id}
+    assert pushed[f"{WEBSANDBOX_WORKDIR}/src/app.ts"] == b"EDITED-IN-THE-VM"
+    assert pushed[f"{WEBSANDBOX_WORKDIR}/README.md"] == b"# hi"
+    assert _SNAPSHOT_TMP not in pushed
 
 
 async def test_delete_and_move_hooks_also_target_the_project(uploads) -> None:  # noqa: ANN001

--- a/tests/cloud/test_codeproject_durability.py
+++ b/tests/cloud/test_codeproject_durability.py
@@ -14,17 +14,26 @@
 # which is exactly how these tests prove "no WebSandbox row involved".
 #
 # Covers:
-#   * round-trip: snapshot + overlay write to a project by id, then restore the
-#     bytes byte-for-byte — with NO WebSandbox row created anywhere.
+#   * round-trip: the per-file store is written by id, then restored byte-for-byte
+#     — with NO WebSandbox row created anywhere.
 #   * independence: two projects sharing the SAME starter ``repo`` in one
-#     workspace hold independent snapshot + overlay pointers (no collision).
-#   * snapshot clears the overlay (a full snapshot supersedes it).
+#     workspace hold independent stores (no collision).
 #   * overlay drop / move re-key the durable project pointer.
 #   * S3 guard: the project-keyed durable WRITE path RAISES a clean CloudError in
 #     cloud when the upload adapter isn't s3; does NOT raise on a non-cloud/OSS
 #     install.
+#
+# Updated 2026-07-25 (S1, feat/code-s3-authoritative): every ``snapshot_project``
+# case became a ``sync_project_files`` case. The tarball tier is retired (a tar
+# cannot express a DELETE, so replaying it resurrected removed files) and the
+# per-file store is the whole truth, so what these prove now is that a workspace
+# re-image lands one blob per file and that a full snapshot no longer wipes the
+# store. The delete/completeness behaviour has its own suite:
+# ``test_codeproject_s3_authoritative.py``.
 from __future__ import annotations
 
+import io
+import tarfile
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 
@@ -128,6 +137,22 @@ class _FakeUploads:
         return rec, _iter()
 
 
+def _tar(files: dict[str, bytes]) -> bytes:
+    """A REAL gzipped tar shaped like ``tar -czf ... -C <workdir> .`` output.
+
+    The sync path reads the workspace THROUGH a tarball (one round trip instead of
+    one download per file), so the fake VM has to hand back a real archive rather
+    than a canned string. Members are named ``./x`` exactly as tar writes them.
+    """
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as archive:
+        for name, blob in files.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(blob)
+            archive.addfile(info, io.BytesIO(blob))
+    return buf.getvalue()
+
+
 async def _project(workspace=_WS, user=_USER, repo="react", provider="starter", name=None):  # noqa: ANN001
     """Create a durable project row (starter by default, so two share one repo)."""
     body = {"repo": repo, "provider": provider}
@@ -142,49 +167,49 @@ async def _project(workspace=_WS, user=_USER, repo="react", provider="starter", 
 # ---------------------------------------------------------------------------
 
 
-async def test_snapshot_uploads_and_records_pointer_on_project() -> None:
+async def test_sync_uploads_every_workspace_file_and_records_the_store() -> None:
     project = await _project()
-    fake = _FakeDaytonaClient(tar_bytes=b"HELLO-SNAPSHOT")
+    fake = _FakeDaytonaClient(tar_bytes=_tar({"./a.ts": b"AAA", "./dir/b.ts": b"BBB"}))
     uploads = _FakeUploads()
 
-    file_id = await durability.snapshot_project(
+    overlay = await durability.sync_project_files(
         _WS, _USER, project.id, _SANDBOX, client=fake, uploads=uploads
     )
 
-    # Tarred the workspace dir in the VM, then downloaded the tarball.
+    # Tarred the workspace dir in the VM as a TRANSPORT, then downloaded it once.
     assert any("tar -czf" in c and WEBSANDBOX_WORKDIR in c for c in fake.exec_calls)
-    assert fake.download_calls == ["/tmp/ws-snapshot.tgz"]
+    assert fake.download_calls == ["/tmp/code-project-sync.tgz"]
 
-    # Uploaded the exact bytes, workspace + owner scoped, in the PROJECT snapshots
-    # folder — grouped separately from the sandbox-keyed folder.
-    assert len(uploads.upload_calls) == 1
-    up = uploads.upload_calls[0]
-    assert up["workspace"] == _WS
-    assert up["owner_id"] == _USER
-    assert up["folder_path"] == "/code-project-snapshots"
-    assert up["data"] == b"HELLO-SNAPSHOT"
-    assert up["content_type"] == "application/gzip"
+    # One blob PER FILE — workspace + owner scoped, in the overlay folder. Nothing
+    # lands in the retired snapshots folder.
+    assert len(uploads.upload_calls) == 2
+    assert {u["folder_path"] for u in uploads.upload_calls} == {"/code-project-overlay"}
+    assert {u["workspace"] for u in uploads.upload_calls} == {_WS}
+    assert {u["owner_id"] for u in uploads.upload_calls} == {_USER}
+    assert {u["data"] for u in uploads.upload_calls} == {b"AAA", b"BBB"}
 
-    # The durable pointer is returned AND persisted on the PROJECT row.
-    assert file_id == "file-1"
+    # The store is the whole map, persisted on the PROJECT row and marked verified.
+    assert set(overlay) == {"a.ts", "dir/b.ts"}
     fetched = await codeproject_service.get_project(_WS, _USER, project.id)
-    assert fetched.snapshot_file_id == "file-1"
+    assert fetched.overlay == overlay
+    assert fetched.overlay_complete is True
+    assert fetched.snapshot_file_id is None
 
     # No WebSandbox row was ever created — the store is project-keyed.
     assert await _WebSandboxDoc.find_all().to_list() == []
 
 
-async def test_round_trip_snapshot_and_overlay_restores_bytes_no_websandbox() -> None:
+async def test_round_trip_sync_and_overlay_restores_bytes_no_websandbox() -> None:
     project = await _project()
     uploads = _FakeUploads()
 
-    # A disconnect snapshot (clears overlay), then a fresh session's edits mirror in.
-    await durability.snapshot_project(
+    # A disconnect sync, then a fresh session's edits mirror in on top.
+    await durability.sync_project_files(
         _WS,
         _USER,
         project.id,
         _SANDBOX,
-        client=_FakeDaytonaClient(tar_bytes=b"SNAP-DATA"),
+        client=_FakeDaytonaClient(tar_bytes=_tar({"./from-the-vm.ts": b"VM"})),
         uploads=uploads,
     )
     await durability.mirror_file_to_project(_WS, _USER, project.id, "a.ts", b"AAA", uploads=uploads)
@@ -198,13 +223,12 @@ async def test_round_trip_snapshot_and_overlay_restores_bytes_no_websandbox() ->
         _WS, _USER, project.id, "dtn-fresh", client=fresh, uploads=uploads
     )
 
-    # Snapshot untarred first...
-    assert fresh.upload_calls[0]["remote_path"] == "/tmp/ws-snapshot.tgz"
-    assert fresh.upload_calls[0]["data"] == b"SNAP-DATA"
-    assert any("tar -xzf" in c and WEBSANDBOX_WORKDIR in c for c in fresh.exec_calls)
+    # No tarball is fetched or untarred — the per-file store is the whole truth.
+    assert not any("tar -xzf" in c for c in fresh.exec_calls)
 
-    # ...then each overlay file written byte-for-byte into the jail at WORKDIR/relpath.
+    # Every file is written byte-for-byte into the jail at WORKDIR/relpath.
     written = {u["remote_path"]: u["data"] for u in fresh.upload_calls}
+    assert written[f"{WEBSANDBOX_WORKDIR}/from-the-vm.ts"] == b"VM"
     assert written[f"{WEBSANDBOX_WORKDIR}/a.ts"] == b"AAA"
     assert written[f"{WEBSANDBOX_WORKDIR}/dir/b.ts"] == b"BBB"
     assert any(f"mkdir -p {WEBSANDBOX_WORKDIR}/dir" in c for c in fresh.exec_calls)
@@ -213,7 +237,7 @@ async def test_round_trip_snapshot_and_overlay_restores_bytes_no_websandbox() ->
     assert await _WebSandboxDoc.find_all().to_list() == []
 
 
-async def test_mirror_records_overlay_and_snapshot_clears_it() -> None:
+async def test_mirror_records_the_store_and_a_legacy_snapshot_no_longer_wipes_it() -> None:
     project = await _project()
     uploads = _FakeUploads()
 
@@ -228,11 +252,13 @@ async def test_mirror_records_overlay_and_snapshot_clears_it() -> None:
         "src/app.ts": "file-1"
     }
 
-    # A full snapshot supersedes the incremental overlay → overlay is wiped.
-    await durability.snapshot_project(
-        _WS, _USER, project.id, _SANDBOX, client=_FakeDaytonaClient(), uploads=uploads
-    )
-    assert (await codeproject_service.get_project(_WS, _USER, project.id)).overlay == {}
+    # Recording a legacy tarball pointer must NOT clear the store. It used to (a
+    # "full snapshot supersedes the delta"), and that is precisely what threw away
+    # the only tier able to record a deletion.
+    await codeproject_service.set_project_snapshot(_WS, _USER, project.id, "legacy-tar")
+    kept = await codeproject_service.get_project(_WS, _USER, project.id)
+    assert kept.overlay == {"src/app.ts": "file-1"}
+    assert kept.snapshot_file_id == "legacy-tar"
 
 
 async def test_restore_overlay_only_no_snapshot() -> None:
@@ -304,8 +330,13 @@ async def test_two_projects_same_starter_hold_independent_state() -> None:
     assert todo.id != blog.id
 
     uploads = _FakeUploads()
-    await durability.snapshot_project(
-        _WS, _USER, todo.id, _SANDBOX, client=_FakeDaytonaClient(tar_bytes=b"TODO"), uploads=uploads
+    await durability.sync_project_files(
+        _WS,
+        _USER,
+        todo.id,
+        _SANDBOX,
+        client=_FakeDaytonaClient(tar_bytes=_tar({"./synced.ts": b"S"})),
+        uploads=uploads,
     )
     await durability.mirror_file_to_project(_WS, _USER, todo.id, "todo.ts", b"T", uploads=uploads)
     await durability.mirror_file_to_project(_WS, _USER, blog.id, "blog.ts", b"B", uploads=uploads)
@@ -313,10 +344,10 @@ async def test_two_projects_same_starter_hold_independent_state() -> None:
     todo_view = await codeproject_service.get_project(_WS, _USER, todo.id)
     blog_view = await codeproject_service.get_project(_WS, _USER, blog.id)
 
-    # Snapshot landed only on todo; each overlay is the project's own.
-    assert todo_view.snapshot_file_id is not None
-    assert blog_view.snapshot_file_id is None
-    assert todo_view.overlay == {"todo.ts": "file-2"}
+    # The sync landed only on todo; each store is the project's own.
+    assert todo_view.overlay_complete is True
+    assert blog_view.overlay_complete is False
+    assert todo_view.overlay == {"synced.ts": "file-1", "todo.ts": "file-2"}
     assert blog_view.overlay == {"blog.ts": "file-3"}
 
 
@@ -325,7 +356,7 @@ async def test_two_projects_same_starter_hold_independent_state() -> None:
 # ---------------------------------------------------------------------------
 
 
-async def test_snapshot_denies_cross_tenant_caller() -> None:
+async def test_sync_denies_cross_tenant_caller() -> None:
     project = await _project(workspace=_WS, user=_USER)
     fake = _FakeDaytonaClient()
     uploads = _FakeUploads()
@@ -333,7 +364,7 @@ async def test_snapshot_denies_cross_tenant_caller() -> None:
     from pocketpaw_ee.cloud._core.errors import NotFound
 
     with pytest.raises(NotFound):
-        await durability.snapshot_project(
+        await durability.sync_project_files(
             "w2", _USER, project.id, _SANDBOX, client=fake, uploads=uploads
         )
     assert fake.exec_calls == []
@@ -346,7 +377,7 @@ async def test_snapshot_denies_cross_tenant_caller() -> None:
 # ---------------------------------------------------------------------------
 
 
-async def test_snapshot_write_raises_in_cloud_without_s3(monkeypatch) -> None:
+async def test_sync_write_raises_in_cloud_without_s3(monkeypatch) -> None:
     project = await _project()
     fake = _FakeDaytonaClient()
     uploads = _FakeUploads()
@@ -356,7 +387,7 @@ async def test_snapshot_write_raises_in_cloud_without_s3(monkeypatch) -> None:
     monkeypatch.setenv("POCKETPAW_UPLOAD_ADAPTER", "local")
 
     with pytest.raises(CloudError) as exc:
-        await durability.snapshot_project(
+        await durability.sync_project_files(
             _WS, _USER, project.id, _SANDBOX, client=fake, uploads=uploads
         )
     assert exc.value.code == "codeproject.durable_store_requires_s3"
@@ -381,18 +412,18 @@ async def test_mirror_write_raises_in_cloud_without_s3(monkeypatch) -> None:
     assert uploads.upload_calls == []
 
 
-async def test_snapshot_write_ok_in_cloud_with_s3(monkeypatch) -> None:
+async def test_sync_write_ok_in_cloud_with_s3(monkeypatch) -> None:
     project = await _project()
-    fake = _FakeDaytonaClient(tar_bytes=b"OK")
+    fake = _FakeDaytonaClient(tar_bytes=_tar({"./ok.ts": b"OK"}))
     uploads = _FakeUploads()
 
     monkeypatch.setattr(durability, "is_multi_tenant_cloud", lambda: True)
     monkeypatch.setenv("POCKETPAW_UPLOAD_ADAPTER", "s3")
 
-    file_id = await durability.snapshot_project(
+    overlay = await durability.sync_project_files(
         _WS, _USER, project.id, _SANDBOX, client=fake, uploads=uploads
     )
-    assert file_id == "file-1"
+    assert overlay == {"ok.ts": "file-1"}
 
 
 async def test_write_does_not_raise_off_cloud(monkeypatch) -> None:

--- a/tests/cloud/test_codeproject_file_sync.py
+++ b/tests/cloud/test_codeproject_file_sync.py
@@ -392,7 +392,9 @@ async def test_put_ok_in_cloud_with_s3(monkeypatch) -> None:  # noqa: ANN001
 async def test_write_over_the_per_file_cap_is_rejected(monkeypatch) -> None:  # noqa: ANN001
     project = await _project()
     uploads = _FakeUploads()
-    monkeypatch.setenv("POCKETPAW_CODEPROJECT_OVERLAY_MAX_MB", "0.000001")  # ~1 byte
+    # The PER-FILE knob, split from the aggregate one in S1: the aggregate had to
+    # grow to hold a whole source tree, and one runaway file must stay bounded.
+    monkeypatch.setenv("POCKETPAW_CODEPROJECT_FILE_MAX_MB", "0.000001")  # ~1 byte
 
     with pytest.raises(CloudError) as exc:
         await durability.put_project_file(

--- a/tests/cloud/test_codeproject_s3_authoritative.py
+++ b/tests/cloud/test_codeproject_s3_authoritative.py
@@ -1,0 +1,597 @@
+# test_codeproject_s3_authoritative.py — the S1 cutover: the per-file store IS the
+# project, and the tarball tier is retired as a source of truth.
+#
+# Created 2026-07-25 (S1, feat/code-s3-authoritative).
+#
+# The bug this removes: a project's baseline was one gzipped tarball, and a tarball
+# is an unmodifiable blob — a DELETE has no representation inside it. Replaying the
+# baseline on restore resurrected every file the user had removed, and taking a
+# snapshot CLEARED the per-file overlay, which was the only tier that could have
+# recorded the absence. A tombstone list would have patched the symptom; making the
+# per-file store COMPLETE removes the vector: a delete is the removal of an entry,
+# and there is no baseline left to resurrect it.
+#
+# What is proved here, on real Beanie over mongomock-motor (the ``mongo_db``
+# fixture) with a FAKE Daytona VM and FAKE blob storage injected through the
+# existing DI seams — no real VM, no real S3:
+#   1. THE BUG IS DEAD — a file deleted in the VM is gone after sync + restore, both
+#      for a file that passed a write hook and for one that never did (a clone's or
+#      a scaffold's file), including when the fresh VM re-materializes it.
+#   2. COMPLETENESS — a file that arrived without passing a write hook is in the
+#      store after a sync and restores from it.
+#   3. LEGACY MIGRATION — a pre-S1 project (tarball pointer + partial overlay)
+#      migrates to per-file entries once, loses nothing, clears the pointer, and is
+#      idempotent on a second run.
+#   4. RESTORE IS STORE-ONLY — a migrated/new project never fetches or untars a
+#      tarball again.
+#   5. THE DESTRUCTIVE PARTS ARE GATED — an empty enumeration never wipes a store,
+#      an entry inside an excluded tree is never dropped by a sync that cannot see
+#      it, and the prune never fires for a project whose store isn't verified
+#      complete (the in-tab case, whose baseline lives in the browser).
+#
+# The fake VM models a real filesystem rather than canned bytes, because "the file
+# is gone" is a claim about a filesystem: it serves ``find`` from its own tree,
+# applies ``rm -f``, absorbs ``upload_bytes`` writes, and packs the tree into a REAL
+# gzipped tar on ``download_file``. A canned-blob fake could not tell the difference
+# between a deletion that worked and one that silently didn't.
+from __future__ import annotations
+
+import shlex
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import CloudError
+from pocketpaw_ee.cloud.codeproject import service as codeproject_service
+from pocketpaw_ee.cloud.websandbox import durability
+from pocketpaw_ee.cloud.websandbox.constants import WEBSANDBOX_WORKDIR
+
+from tests.cloud.test_codeproject_durability import _FakeUploads, _tar
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+_WS = "w1"
+_USER = "u1"
+_VM = "dtn-1"
+_FRESH_VM = "dtn-fresh"
+
+
+# ---------------------------------------------------------------------------
+# A fake VM with an actual filesystem.
+# ---------------------------------------------------------------------------
+
+
+class _Resp:
+    """The shape ``DaytonaClient.execute_command`` returns (``result`` + ``exit_code``)."""
+
+    def __init__(self, result: str = "", exit_code: int = 0) -> None:
+        self.result = result
+        self.exit_code = exit_code
+
+
+class _FakeVm:
+    """A Daytona stand-in that keeps a real in-memory workspace tree.
+
+    Implements exactly the four verbs the durability paths use, faithfully enough
+    that a deletion is observable end to end:
+      * ``tar -czf`` is a no-op; ``download_file`` packs the CURRENT tree (minus the
+        regenerable trees the real command excludes) into a real gzipped tar, which
+        is the transport the sync reads;
+      * ``find`` lists the tree, excluded segments pruned, workspace-prefixed;
+      * ``rm -f`` actually removes paths — this is what the prune is judged on;
+      * ``upload_bytes`` writes a file, so a restore genuinely materializes.
+    """
+
+    def __init__(self, files: dict[str, bytes] | None = None) -> None:
+        self.files: dict[str, bytes] = dict(files or {})
+        self.exec_calls: list[str] = []
+        self.download_calls: list[str] = []
+        self.upload_paths: list[str] = []
+
+    def _visible(self) -> dict[str, bytes]:
+        return {
+            path: blob
+            for path, blob in self.files.items()
+            if not durability._is_excluded_snapshot_path(path)
+        }
+
+    async def execute_command(self, sandbox_id, command, **kwargs):  # noqa: ANN001
+        self.exec_calls.append(command)
+        if command.startswith("find "):
+            listing = "\n".join(f"{WEBSANDBOX_WORKDIR}/{p}" for p in sorted(self._visible()))
+            return _Resp(result=listing)
+        if command.startswith("rm -f "):
+            prefix = WEBSANDBOX_WORKDIR.rstrip("/") + "/"
+            for token in shlex.split(command)[2:]:
+                if token.startswith(prefix):
+                    self.files.pop(token[len(prefix) :], None)
+        return _Resp()
+
+    async def download_file(self, sandbox_id, remote_path):  # noqa: ANN001
+        self.download_calls.append(remote_path)
+        return _tar({f"./{p}": blob for p, blob in self._visible().items()})
+
+    async def upload_bytes(self, sandbox_id, data, remote_path):  # noqa: ANN001
+        self.upload_paths.append(remote_path)
+        prefix = WEBSANDBOX_WORKDIR.rstrip("/") + "/"
+        if remote_path.startswith(prefix):
+            self.files[remote_path[len(prefix) :]] = data
+
+
+class _TrackingUploads(_FakeUploads):
+    """``_FakeUploads`` plus a record of which blobs were READ back."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.stream_calls: list[str] = []
+
+    async def stream(self, file_id, requester_id, workspace):  # noqa: ANN001
+        self.stream_calls.append(file_id)
+        return await super().stream(file_id, requester_id, workspace)
+
+
+async def _project(repo="react", provider="starter"):  # noqa: ANN001
+    return await codeproject_service.create_project(
+        _WS, _USER, {"repo": repo, "provider": provider}
+    )
+
+
+async def _stage_legacy_snapshot(project_id: str, uploads: _FakeUploads, tar_bytes: bytes) -> str:
+    """Put a project into the PRE-S1 row shape: a tarball in blob storage + a pointer.
+
+    Exactly what ``snapshot_project`` used to leave behind, staged directly because
+    the writer is gone. This is the state every existing project is in right now.
+    """
+    file_id = await durability._upload_project_blob(
+        uploads,
+        tar_bytes,
+        workspace_id=_WS,
+        user_id=_USER,
+        filename="legacy-snapshot.tgz",
+        folder="/code-project-snapshots",
+        content_type="application/gzip",
+    )
+    await codeproject_service.set_project_snapshot(_WS, _USER, project_id, file_id)
+    return file_id
+
+
+# ---------------------------------------------------------------------------
+# 1. THE BUG IS DEAD — a deleted file does not come back.
+# ---------------------------------------------------------------------------
+
+
+async def test_a_file_deleted_in_the_vm_is_gone_after_sync_and_restore() -> None:
+    """The headline case, end to end: create -> sync -> delete -> sync -> restore."""
+    project = await _project()
+    uploads = _FakeUploads()
+    vm = _FakeVm({"src/app.ts": b"APP", "src/doomed.ts": b"DOOMED"})
+
+    await durability.sync_project_files(_WS, _USER, project.id, _VM, client=vm, uploads=uploads)
+    assert set((await codeproject_service.get_project(_WS, _USER, project.id)).overlay) == {
+        "src/app.ts",
+        "src/doomed.ts",
+    }
+
+    # The user deletes it in the VM (a terminal ``rm``, a delete that never reached
+    # a hook — the store must reconcile from the workspace, not from an event).
+    vm.files.pop("src/doomed.ts")
+    await durability.sync_project_files(_WS, _USER, project.id, _VM, client=vm, uploads=uploads)
+
+    stored = await codeproject_service.get_project(_WS, _USER, project.id)
+    assert set(stored.overlay) == {"src/app.ts"}, "the deleted file is still in the store"
+
+    # Restore into a genuinely fresh VM: the deletion has to survive the round trip.
+    fresh = _FakeVm()
+    await durability.restore_project(
+        _WS, _USER, project.id, _FRESH_VM, client=fresh, uploads=uploads
+    )
+    assert fresh.files == {"src/app.ts": b"APP"}
+
+
+async def test_a_deleted_clone_file_is_gone_even_though_it_never_passed_a_write_hook() -> None:
+    """The case a tombstone-free design has to handle.
+
+    ``src/from-the-clone.ts`` arrived with the ``git clone`` — no write hook ever saw
+    it, so under the old design only the tarball knew about it, and only the tarball
+    could bring it back. Here the sync captures it and the next sync drops it.
+    """
+    project = await _project(repo="https://github.com/acme/widgets.git", provider="github")
+    uploads = _FakeUploads()
+    vm = _FakeVm({"src/from-the-clone.ts": b"CLONED", "package.json": b"{}"})
+
+    await durability.sync_project_files(_WS, _USER, project.id, _VM, client=vm, uploads=uploads)
+    vm.files.pop("src/from-the-clone.ts")
+    await durability.sync_project_files(_WS, _USER, project.id, _VM, client=vm, uploads=uploads)
+
+    fresh = _FakeVm()
+    await durability.restore_project(
+        _WS, _USER, project.id, _FRESH_VM, client=fresh, uploads=uploads
+    )
+    assert fresh.files == {"package.json": b"{}"}
+
+
+async def test_the_prune_removes_a_deleted_file_the_fresh_vm_re_materialized() -> None:
+    """The production shape of the same case: the fresh VM is NOT empty.
+
+    A reopened project cold-provisions, and the VM it gets has just been cloned (or
+    scaffolded) — so it holds the baseline copy of the file the user deleted.
+    Replaying the store over that tree would leave the file behind, which is the
+    resurrection this whole change removes. Restore prunes it.
+    """
+    project = await _project(repo="https://github.com/acme/widgets.git", provider="github")
+    uploads = _FakeUploads()
+    vm = _FakeVm({"keep.ts": b"KEEP", "deleted-by-the-user.ts": b"OLD"})
+    await durability.sync_project_files(_WS, _USER, project.id, _VM, client=vm, uploads=uploads)
+    vm.files.pop("deleted-by-the-user.ts")
+    await durability.sync_project_files(_WS, _USER, project.id, _VM, client=vm, uploads=uploads)
+
+    # The fresh VM is a fresh CLONE: both files are back on disk.
+    fresh = _FakeVm({"keep.ts": b"KEEP", "deleted-by-the-user.ts": b"OLD"})
+    await durability.restore_project(
+        _WS, _USER, project.id, _FRESH_VM, client=fresh, uploads=uploads
+    )
+
+    assert fresh.files == {"keep.ts": b"KEEP"}
+    assert any(c.startswith("rm -f ") for c in fresh.exec_calls)
+
+
+async def test_the_prune_never_touches_regenerable_trees() -> None:
+    """``.git`` and ``node_modules`` are absent from the store BY DESIGN.
+
+    They are excluded from every enumeration, so "not in the store" says nothing
+    about them — deleting them would destroy the clone's history and force a
+    reinstall on every reopen.
+    """
+    project = await _project(repo="https://github.com/acme/widgets.git", provider="github")
+    uploads = _FakeUploads()
+    vm = _FakeVm({"a.ts": b"A"})
+    await durability.sync_project_files(_WS, _USER, project.id, _VM, client=vm, uploads=uploads)
+
+    fresh = _FakeVm(
+        {
+            "a.ts": b"A",
+            ".git/HEAD": b"ref: refs/heads/main",
+            "node_modules/left-pad/index.js": b"dep",
+            "dist/bundle.js": b"built",
+        }
+    )
+    await durability.restore_project(
+        _WS, _USER, project.id, _FRESH_VM, client=fresh, uploads=uploads
+    )
+
+    assert ".git/HEAD" in fresh.files
+    assert "node_modules/left-pad/index.js" in fresh.files
+    assert "dist/bundle.js" in fresh.files
+
+
+# ---------------------------------------------------------------------------
+# 2. COMPLETENESS — files that never passed a write hook are in the store.
+# ---------------------------------------------------------------------------
+
+
+async def test_scaffold_output_that_never_passed_a_hook_is_captured_and_restores() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+    # A materialized starter: none of this went through ``file.write``.
+    vm = _FakeVm(
+        {
+            "package.json": b'{"name":"app"}',
+            "src/main.tsx": b"render()",
+            "public/favicon.ico": b"\x00\x01binary",  # binary survives: bytes, not text
+        }
+    )
+
+    overlay = await durability.sync_project_files(
+        _WS, _USER, project.id, _VM, client=vm, uploads=uploads
+    )
+    assert set(overlay) == {"package.json", "src/main.tsx", "public/favicon.ico"}
+
+    fresh = _FakeVm()
+    await durability.restore_project(
+        _WS, _USER, project.id, _FRESH_VM, client=fresh, uploads=uploads
+    )
+    assert fresh.files == vm.files
+
+
+async def test_regenerable_trees_never_enter_the_store() -> None:
+    """The complement of completeness: ``node_modules`` is not user work.
+
+    It is excluded at the tar level AND re-checked after expansion, so it never
+    costs a blob, never counts against the caps, and never has to be restored.
+    """
+    project = await _project()
+    uploads = _FakeUploads()
+    vm = _FakeVm(
+        {
+            "src/a.ts": b"A",
+            "node_modules/left-pad/index.js": b"dep",
+            ".git/objects/ab/cdef": b"\x00obj",
+            "dist/bundle.js": b"built",
+            "build.ts": b"NOT-A-BUILD-DIR",  # segment match, not prefix match
+        }
+    )
+
+    overlay = await durability.sync_project_files(
+        _WS, _USER, project.id, _VM, client=vm, uploads=uploads
+    )
+    assert set(overlay) == {"src/a.ts", "build.ts"}
+
+
+# ---------------------------------------------------------------------------
+# 3. LEGACY MIGRATION — once, lossless, pointer cleared, idempotent.
+# ---------------------------------------------------------------------------
+
+
+async def test_a_legacy_tarball_migrates_to_per_file_entries_and_loses_nothing() -> None:
+    project = await _project()
+    uploads = _TrackingUploads()
+
+    # A pre-S1 project: most of the work inside the tar, plus the handful of edits a
+    # write hook mirrored after the snapshot was taken.
+    await _stage_legacy_snapshot(
+        project.id,
+        uploads,
+        _tar(
+            {
+                "./src/app.ts": b"OLD-FROM-TAR",
+                "./only-in-tar.ts": b"TAR-ONLY",
+                "./node_modules/dep/index.js": b"dep",  # filtered, not migrated
+            }
+        ),
+    )
+    await durability.mirror_file_to_project(
+        _WS, _USER, project.id, "src/app.ts", b"NEW-FROM-OVERLAY", uploads=uploads
+    )
+    await durability.mirror_file_to_project(
+        _WS, _USER, project.id, "only-in-overlay.ts", b"OVERLAY-ONLY", uploads=uploads
+    )
+
+    fresh = _FakeVm()
+    await durability.restore_project(
+        _WS, _USER, project.id, _FRESH_VM, client=fresh, uploads=uploads
+    )
+
+    # Nothing is lost, and the fresher tier wins where the two overlap.
+    assert fresh.files == {
+        "src/app.ts": b"NEW-FROM-OVERLAY",
+        "only-in-tar.ts": b"TAR-ONLY",
+        "only-in-overlay.ts": b"OVERLAY-ONLY",
+    }
+
+    migrated = await codeproject_service.get_project(_WS, _USER, project.id)
+    assert set(migrated.overlay) == {"src/app.ts", "only-in-tar.ts", "only-in-overlay.ts"}
+    assert migrated.snapshot_file_id is None, "the legacy pointer would migrate again"
+    assert migrated.overlay_complete is True
+
+
+async def test_the_migration_is_idempotent_on_a_second_restore() -> None:
+    project = await _project()
+    uploads = _TrackingUploads()
+    legacy_id = await _stage_legacy_snapshot(project.id, uploads, _tar({"./a.ts": b"A"}))
+
+    await durability.restore_project(
+        _WS, _USER, project.id, _FRESH_VM, client=_FakeVm(), uploads=uploads
+    )
+    first = await codeproject_service.get_project(_WS, _USER, project.id)
+    uploads_after_first = len(uploads.upload_calls)
+
+    await durability.restore_project(
+        _WS, _USER, project.id, "dtn-third", client=_FakeVm(), uploads=uploads
+    )
+    second = await codeproject_service.get_project(_WS, _USER, project.id)
+
+    assert second.overlay == first.overlay
+    assert second.snapshot_file_id is None
+    # No second expansion: the tar was neither re-read nor re-uploaded.
+    assert len(uploads.upload_calls) == uploads_after_first
+    assert uploads.stream_calls.count(legacy_id) == 1
+
+
+async def test_a_failed_migration_keeps_the_pointer_and_falls_back_to_the_tar() -> None:
+    """Non-destructive by construction: a migration that can't finish must not clear.
+
+    Clearing the pointer on a partial run would strand whatever hadn't been carried
+    across. Keeping it means the next open retries, and the untar fallback still
+    materializes the session so the user never sees a project with holes in it.
+    """
+    project = await _project()
+    uploads = _FakeUploads()
+    await _stage_legacy_snapshot(project.id, uploads, _tar({"./a.ts": b"A"}))
+
+    async def _explode(*args, **kwargs):  # noqa: ANN002, ANN003
+        raise RuntimeError("blob storage is down")
+
+    original = durability._upload_project_blob
+    durability._upload_project_blob = _explode
+    try:
+        vm = _FakeVm()
+        await durability.restore_project(
+            _WS, _USER, project.id, _FRESH_VM, client=vm, uploads=uploads
+        )
+    finally:
+        durability._upload_project_blob = original
+
+    kept = await codeproject_service.get_project(_WS, _USER, project.id)
+    assert kept.snapshot_file_id is not None, "a partial migration threw the tar away"
+    assert kept.overlay_complete is False, "an incomplete store must not license a prune"
+    # The session was still materialized — via the legacy untar fallback.
+    assert any("tar -xzf" in c for c in vm.exec_calls)
+
+
+# ---------------------------------------------------------------------------
+# 4. RESTORE IS STORE-ONLY for a migrated / new project.
+# ---------------------------------------------------------------------------
+
+
+async def test_restore_never_fetches_a_tarball_for_a_synced_project() -> None:
+    project = await _project()
+    uploads = _TrackingUploads()
+    vm = _FakeVm({"a.ts": b"A", "dir/b.ts": b"B"})
+    await durability.sync_project_files(_WS, _USER, project.id, _VM, client=vm, uploads=uploads)
+
+    fresh = _FakeVm()
+    await durability.restore_project(
+        _WS, _USER, project.id, _FRESH_VM, client=fresh, uploads=uploads
+    )
+
+    assert not any("tar -xzf" in c for c in fresh.exec_calls)
+    assert "/tmp/ws-snapshot.tgz" not in fresh.upload_paths, "a tarball was staged in the VM"
+    assert fresh.files == {"a.ts": b"A", "dir/b.ts": b"B"}
+    # Every blob read was an overlay entry — the store, nothing else.
+    stored = await codeproject_service.get_project(_WS, _USER, project.id)
+    assert set(uploads.stream_calls) == set(stored.overlay.values())
+
+
+async def test_restore_after_migration_reads_only_the_store() -> None:
+    project = await _project()
+    uploads = _TrackingUploads()
+    legacy_id = await _stage_legacy_snapshot(project.id, uploads, _tar({"./a.ts": b"A"}))
+    await durability.restore_project(
+        _WS, _USER, project.id, _FRESH_VM, client=_FakeVm(), uploads=uploads
+    )
+
+    uploads.stream_calls.clear()
+    fresh = _FakeVm()
+    await durability.restore_project(
+        _WS, _USER, project.id, "dtn-third", client=fresh, uploads=uploads
+    )
+
+    assert legacy_id not in uploads.stream_calls
+    assert not any("tar -xzf" in c for c in fresh.exec_calls)
+    assert fresh.files == {"a.ts": b"A"}
+
+
+# ---------------------------------------------------------------------------
+# 5. THE DESTRUCTIVE PARTS ARE GATED.
+# ---------------------------------------------------------------------------
+
+
+async def test_an_empty_enumeration_never_wipes_the_store() -> None:
+    """A transient VM failure must not read as "the user deleted everything"."""
+    project = await _project()
+    uploads = _FakeUploads()
+    vm = _FakeVm({"a.ts": b"A"})
+    await durability.sync_project_files(_WS, _USER, project.id, _VM, client=vm, uploads=uploads)
+    before = (await codeproject_service.get_project(_WS, _USER, project.id)).overlay
+
+    kept = await durability.sync_project_files(
+        _WS, _USER, project.id, _VM, client=_FakeVm(), uploads=uploads
+    )
+
+    assert kept == before
+    assert (await codeproject_service.get_project(_WS, _USER, project.id)).overlay == before
+
+
+async def test_sync_keeps_entries_it_could_not_have_seen() -> None:
+    """An overlay entry inside an excluded tree is invisible to the enumeration.
+
+    "The sync didn't see it" is not the same claim as "the user deleted it", so such
+    an entry is carried across rather than silently dropped.
+    """
+    project = await _project()
+    uploads = _FakeUploads()
+    await durability.mirror_file_to_project(
+        _WS, _USER, project.id, "dist/hand-edited.js", b"EDITED", uploads=uploads
+    )
+
+    overlay = await durability.sync_project_files(
+        _WS, _USER, project.id, _VM, client=_FakeVm({"a.ts": b"A"}), uploads=uploads
+    )
+
+    assert overlay == {"a.ts": "file-2", "dist/hand-edited.js": "file-1"}
+
+
+async def test_an_in_tab_project_is_never_pruned() -> None:
+    """The in-tab runtime's baseline lives in the BROWSER, so its store is partial.
+
+    It holds only the files the tab wrote; the starter scaffold is re-materialized
+    client-side and never stored. Pruning "everything not in the store" there would
+    delete the entire scaffold, so the prune is gated on a store that a sync has
+    actually verified against a workspace.
+    """
+    project = await _project()
+    uploads = _FakeUploads()
+    await durability.put_project_file(
+        _WS, _USER, project.id, "src/App.tsx", "MINE", uploads=uploads
+    )
+    assert (await codeproject_service.get_project(_WS, _USER, project.id)).overlay_complete is False
+
+    # Opening it on the VM runtime: the scaffold is materialized, then restored over.
+    fresh = _FakeVm({"src/App.tsx": b"TEMPLATE", "vite.config.ts": b"TEMPLATE-CONFIG"})
+    await durability.restore_project(
+        _WS, _USER, project.id, _FRESH_VM, client=fresh, uploads=uploads
+    )
+
+    assert fresh.files["src/App.tsx"] == b"MINE"  # the tab's copy wins
+    assert fresh.files["vite.config.ts"] == b"TEMPLATE-CONFIG"  # and nothing was pruned
+    assert not any(c.startswith("rm -f ") for c in fresh.exec_calls)
+
+
+async def test_a_restore_that_materialized_nothing_prunes_nothing() -> None:
+    """A store whose blobs are all unreadable must not delete the baseline.
+
+    The replay tolerates one bad entry, so a total failure looks like "0 replayed" —
+    and pruning on top of that would remove the clone the user could still work from.
+    """
+    project = await _project()
+    uploads = _FakeUploads()
+    vm = _FakeVm({"a.ts": b"A"})
+    await durability.sync_project_files(_WS, _USER, project.id, _VM, client=vm, uploads=uploads)
+
+    # Every blob vanishes from storage (a reap, a bucket misconfiguration).
+    uploads._blobs.clear()
+
+    fresh = _FakeVm({"a.ts": b"A", "b.ts": b"B"})
+    await durability.restore_project(
+        _WS, _USER, project.id, _FRESH_VM, client=fresh, uploads=uploads
+    )
+
+    assert fresh.files == {"a.ts": b"A", "b.ts": b"B"}
+    assert not any(c.startswith("rm -f ") for c in fresh.exec_calls)
+
+
+# ---------------------------------------------------------------------------
+# Caps — sized for a whole source tree now, and still LOUD rather than partial.
+# ---------------------------------------------------------------------------
+
+
+async def test_the_caps_hold_an_ordinary_source_project() -> None:
+    """The re-tune, stated as the behaviour: the defaults must not reject real work.
+
+    The old 10 MB / 2000-file limits were sized for a DELTA. The store now holds the
+    whole tree, and a 3000-file project is ordinary — under the old numbers it would
+    have 413'd on every capture.
+    """
+    project = await _project()
+    uploads = _FakeUploads()
+    vm = _FakeVm({f"src/mod{i}.ts": b"x" * 2048 for i in range(3000)})
+
+    overlay = await durability.sync_project_files(
+        _WS, _USER, project.id, _VM, client=vm, uploads=uploads
+    )
+    assert len(overlay) == 3000
+
+
+async def test_a_project_over_the_file_cap_fails_loud(monkeypatch) -> None:  # noqa: ANN001
+    project = await _project()
+    uploads = _FakeUploads()
+    vm = _FakeVm({"a.ts": b"A", "b.ts": b"B"})
+    monkeypatch.setenv("POCKETPAW_CODEPROJECT_OVERLAY_MAX_FILES", "1")
+
+    with pytest.raises(CloudError) as exc:
+        await durability.sync_project_files(_WS, _USER, project.id, _VM, client=vm, uploads=uploads)
+    assert exc.value.code == "codeproject.overlay_too_many_files"
+    assert exc.value.status_code == 413
+    # Loud, and nothing was written — never a truncated store.
+    assert uploads.upload_calls == []
+    assert (await codeproject_service.get_project(_WS, _USER, project.id)).overlay == {}
+
+
+async def test_a_project_over_the_byte_cap_fails_loud(monkeypatch) -> None:  # noqa: ANN001
+    project = await _project()
+    uploads = _FakeUploads()
+    vm = _FakeVm({"big.ts": b"x" * 4096})
+    monkeypatch.setenv("POCKETPAW_CODEPROJECT_OVERLAY_MAX_MB", "0.001")  # ~1 KB
+
+    with pytest.raises(CloudError) as exc:
+        await durability.sync_project_files(_WS, _USER, project.id, _VM, client=vm, uploads=uploads)
+    assert exc.value.code == "codeproject.overlay_too_large"
+    assert uploads.upload_calls == []


### PR DESCRIPTION
## Why

A deleted file came back on restore, on both runtimes. The reason was structural: project state was `unmodifiable baseline + delta`, and an absence can't be expressed in that shape — replaying the baseline resurrects whatever the delta removed.

The obvious patch was a tombstone list. This does the other thing instead: **makes the per-file store complete and authoritative, and retires the tarball as a source of truth.** A delete is then just the removal of an entry, and there is nothing left to bring the file back.

Worth stating plainly: the overlay was *already* one S3 object per file. This isn't a move to S3 — it's dropping the second, coarser tier that sat above it. Bytes still flow through `EEUploadService`, so the pluggable adapter and local/OSS installs keep working.

## What changed

- **`snapshot_project` is deleted.** Nothing writes a whole-workspace tarball any more. `set_project_snapshot` no longer clears the overlay — clearing was the mechanism that destroyed the only tier able to record an absence, so leaving it in place as a footgun was worse than reversing it. It survives only as the legacy-pointer setter.
- **`sync_project_files`** enumerates the workspace, filters, and writes each file through to its own blob, swapping the whole map in atomically. It runs at disconnect (where the tarball snapshot used to) and once on cold provision, so a project is complete in storage from the start rather than after its first disconnect. It tars the workspace as a *transport* — one round trip rather than N downloads — then expands in memory.
- **Restore reads the store only**, and then **prunes**: workspace files the store doesn't list are deleted. See below.
- **Legacy migration** runs once inside restore: expand the old tarball into per-file entries, existing overlay entries win (they post-date the tar), clear the pointer. On failure the pointer is *kept* and the old untar runs for that session, so a partial migration retries rather than loses data.
- **Caps** re-tuned for holding a whole project rather than a delta: 10 MB → 100 MB aggregate, 2000 → 10000 files, with the per-file ceiling split onto its own knob so raising the aggregate didn't quietly admit a 100 MB single file. Both still fail loud.

## The prune — the one destructive addition

Restore always lands in a freshly cloned or scaffolded VM, which re-materializes exactly the files the user deleted. Without a prune, "the deleted file is gone" is only true for an empty VM, and the fix doesn't hold in production.

It is gated four ways: it runs only when a verified sync has marked the store complete, only when the replay actually wrote files, never when enumeration comes back empty or errors, and excluded trees (`.git`, `node_modules`, build output) are invisible to it by construction. Structurally it is also only reachable on the **cold-provision** path — a live VM returns from the reuse branch well before restore — so it can only ever remove baseline files the user had already deleted.

Worst case of a bug here is a broken VM workspace, not durable data loss: the bytes are in the store and the next open re-materializes them.

## Deletion semantics

The map is replaced, so an absent path is dropped. Two things are deliberately never dropped, because "the sync didn't see it" is not "the user deleted it": entries inside an excluded tree, and entries whose upload failed this round. An enumeration returning **zero** files is treated as a failed read and leaves the store untouched — a transient VM error must never be the thing that wipes a project.

## Tests

**545 passed, 4 skipped** across the affected suites; 18 new. The fake VM models a real filesystem — serves `find`, applies `rm -f`, absorbs uploads, packs a real gzipped tar — because a canned-blob fake can't tell a deletion that worked from one that silently didn't.

- The bug is dead: a file deleted in the VM is gone after sync and restore, **including a file that came from the clone and never passed a write hook**, and including one a fresh VM re-materialized.
- Completeness: scaffold/clone output that never passed a hook is captured and restores.
- Migration: a legacy tarball migrates once, loses nothing, clears the pointer, is idempotent, and a failed migration keeps the pointer and falls back.
- Restore fetches no tarball for a synced or migrated project.
- Safety: an empty enumeration never wipes the store; entries the sync couldn't have seen survive; an in-tab project is never pruned.

## Follow-up worth doing soon

**Storage growth.** Sync re-uploads every file on every capture and old blobs are never reaped, because the overlay is `relpath -> file_id` with no content hash to detect an unchanged file. A 1000-file project costs 1000 new objects per session. Pre-existing in kind — every editor save already leaks a blob — but the volume is materially higher now. A `relpath -> {id, sha}` shape fixes it; that's a schema change I kept out of this diff.

Also: the seed sync adds a tar plus N uploads to cold provision. It's best-effort and runs after the restore so it can't affect correctness, but a large project will make an open noticeably slower — worth real timings before this goes wide.

## Base

Stacked on `feat/code-scaffold-on-vm` (#1787). Supersedes the planned tombstone task.
