### PR TITLE
Strip NUL characters from SDK options before the CLI spawn

### DIFF
--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -299,6 +299,57 @@ from pocketpaw.tools.policy import OPT_IN_MCP_SERVERS, ToolPolicy
 logger = logging.getLogger(__name__)
 
 
+def _scrub_nul_chars(options_kwargs: dict[str, Any]) -> list[str]:
+    """Strip NUL characters out of the assembled options, IN PLACE.
+
+    Returns the dotted/indexed paths that carried one, most useful field first as
+    encountered, so the caller can log WHERE it came from.
+
+    Why this exists: Windows ``CreateProcess`` refuses a command line, an
+    environment block, or a cwd containing a NUL, and the SDK passes all three
+    through untouched. One NUL anywhere in the option set therefore kills the spawn
+    before the agent exists, with an error that names nothing:
+
+        CLIConnectionError: Failed to start Claude Code: embedded null character
+
+    Every turn on that path then fails identically and there is no way to tell from
+    the message whether the offender was the system prompt, a tool id, an env value,
+    or the working directory. POSIX is not immune either — ``execve`` takes
+    NUL-terminated strings, so a NUL truncates the argument silently instead of
+    failing loudly, which is worse.
+
+    Stripping is always safe: a NUL is not valid in a prompt, a tool id, a model
+    name, a path, or an env value, so there is no case where preserving one is
+    correct. Reporting the path is the part that earns this function's keep — it
+    turns an un-debuggable spawn failure into a working run plus a breadcrumb
+    naming the source.
+    """
+    offenders: list[str] = []
+
+    def walk(value: Any, path: str) -> Any:
+        if isinstance(value, str):
+            if "\0" in value:
+                offenders.append(path)
+                return value.replace("\0", "")
+            return value
+        # dict / list are rebuilt in place so the caller's object is the cleaned one.
+        # Anything else (numbers, bools, None, hooks, session_store, transports) is
+        # returned untouched — the guard must never coerce an opaque collaborator.
+        if isinstance(value, dict):
+            for key, item in list(value.items()):
+                value[key] = walk(item, f"{path}[{key!r}]")
+            return value
+        if isinstance(value, list):
+            for i, item in enumerate(value):
+                value[i] = walk(item, f"{path}[{i}]")
+            return value
+        return value
+
+    for key, item in list(options_kwargs.items()):
+        options_kwargs[key] = walk(item, key)
+    return offenders
+
+
 class _BuiltOptions(NamedTuple):
     """The product of ``ClaudeSDKBackend._build_options`` (feat/claude-sdk-prewarm).
 
@@ -2058,6 +2109,22 @@ class ClaudeSDKBackend(BaseAgentBackend):
         # (and legacy) behavior.
         if session_handle is not None and session_handle.session_store is not None:
             options_kwargs["session_store"] = session_handle.session_store
+
+        # LAST gate before the options become a subprocess. A NUL anywhere in here
+        # — an arg, an env value, the cwd — makes the CLI spawn fail with
+        # "embedded null character" and names nothing, so every turn on the path
+        # dies identically and undiagnosably. Strip it and say where it was; see
+        # ``_scrub_nul_chars``. Must stay after EVERY kwarg is set (env and the
+        # per-send model override are assigned above) and before
+        # ``_ClaudeAgentOptions`` is constructed.
+        nul_paths = _scrub_nul_chars(options_kwargs)
+        if nul_paths:
+            logger.error(
+                "SDK: stripped NUL character(s) from options before spawn — "
+                "fields: %s. The run proceeds with them removed; this is a BUG at "
+                "whatever produced these values, please report the field list.",
+                ", ".join(nul_paths),
+            )
 
         # Create options (after all kwargs are set, including model)
         options = self._ClaudeAgentOptions(**options_kwargs)

--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -330,6 +330,36 @@ def _scrub_nul_chars(options_kwargs: dict[str, Any]) -> list[str]:
         if isinstance(value, str):
             if "\0" in value:
                 offenders.append(path)
+                # Log the TEXT AROUND the NUL, not just the field name. The field
+                # alone is not actionable: ``system_prompt`` is tens of thousands of
+                # characters assembled from a surface preamble, the soul, the
+                # about-member block, KB context and history, so "it was in
+                # system_prompt" narrows nothing. The surrounding text names the
+                # actual producer — that is how the first instance of this was
+                # traced to a `.tgz` workspace snapshot the KB had indexed as text
+                # and was injecting as raw gzip.
+                #
+                # ``env`` values are REDACTED to a length + offset: that is where
+                # API keys and tokens live, and a log line is the wrong place for
+                # them. The variable NAME is already in ``path``, which is the part
+                # that identifies the source.
+                i = value.index("\0")
+                if path.startswith("env["):
+                    logger.error(
+                        "SDK: NUL in %s — value length %d, first NUL at offset %d "
+                        "(value redacted: env carries credentials)",
+                        path,
+                        len(value),
+                        i,
+                    )
+                else:
+                    logger.error(
+                        "SDK: NUL in %s at offset %d of %d — context: %r",
+                        path,
+                        i,
+                        len(value),
+                        value[max(0, i - 120) : i + 120],
+                    )
                 return value.replace("\0", "")
             return value
         # dict / list are rebuilt in place so the caller's object is the cleaned one.

--- a/tests/test_claude_sdk_nul_guard.py
+++ b/tests/test_claude_sdk_nul_guard.py
@@ -1,0 +1,172 @@
+# test_claude_sdk_nul_guard.py — a NUL never reaches the CLI spawn.
+#
+# Created 2026-07-25 (fix/claude-sdk-nul-arg-guard) after a live failure:
+#
+#   CLIConnectionError: Failed to start Claude Code: embedded null character
+#     ... _winapi.CreateProcess(...)  ->  ValueError: embedded null character
+#
+# Windows `CreateProcess` refuses a command line, an environment block, or a cwd
+# containing a NUL, and the SDK passes all three straight through. The result is a
+# spawn that dies before the agent exists, with a message that names NOTHING: not
+# the field, not the value, not even whether the offender was an arg or an env var.
+# Every turn on that path then fails identically.
+#
+# A NUL is never legitimate in any of these — it cannot appear in a real prompt, a
+# tool id, a model name, a path, or an env value. So the boundary strips it and says
+# WHERE it was, which turns an opaque un-debuggable crash into a run that works plus
+# a breadcrumb naming the source.
+#
+# These tests are about the guard only. They deliberately inject the NUL rather than
+# reproduce a specific upstream source, because the point of the guard is to hold for
+# a source nobody has identified yet.
+from __future__ import annotations
+
+from pocketpaw.agents.claude_sdk import _scrub_nul_chars
+
+
+def test_a_nul_in_a_string_option_is_stripped_and_reported() -> None:
+    kwargs = {"system_prompt": "You are helpful.\x00 Be brief."}
+
+    offenders = _scrub_nul_chars(kwargs)
+
+    assert kwargs["system_prompt"] == "You are helpful. Be brief."
+    assert offenders == ["system_prompt"]
+
+
+def test_a_nul_in_an_env_value_is_stripped_and_the_KEY_is_named() -> None:
+    """The env block is the likeliest carrier and the hardest to trace, so the
+    report has to name the variable, not just "env"."""
+    kwargs = {"env": {"ANTHROPIC_API_KEY": "sk-real", "SOME_TOKEN": "abc\x00def"}}
+
+    offenders = _scrub_nul_chars(kwargs)
+
+    assert kwargs["env"] == {"ANTHROPIC_API_KEY": "sk-real", "SOME_TOKEN": "abcdef"}
+    assert offenders == ["env['SOME_TOKEN']"]
+
+
+def test_a_nul_in_cwd_is_stripped() -> None:
+    kwargs = {"cwd": "C:\\Users\\x\\.pocketpaw\\workspaces\\w1\x00\\agent"}
+
+    offenders = _scrub_nul_chars(kwargs)
+
+    assert "\x00" not in kwargs["cwd"]
+    assert offenders == ["cwd"]
+
+
+def test_a_nul_inside_a_list_option_is_stripped_at_its_index() -> None:
+    kwargs = {"allowed_tools": ["Read", "mcp__pocketpaw_code__readFile\x00"]}
+
+    offenders = _scrub_nul_chars(kwargs)
+
+    assert kwargs["allowed_tools"] == ["Read", "mcp__pocketpaw_code__readFile"]
+    assert offenders == ["allowed_tools[1]"]
+
+
+def test_nested_structures_are_reached() -> None:
+    """`mcp_servers` and `plugins` are dicts of dicts / lists of dicts, and both
+    end up serialized into a CLI argument."""
+    kwargs = {
+        "mcp_servers": {"pocketpaw_code": {"command": "node", "args": ["srv.js\x00"]}},
+        "plugins": [{"type": "local", "path": "/tmp/skills\x00"}],
+    }
+
+    offenders = _scrub_nul_chars(kwargs)
+
+    assert kwargs["mcp_servers"]["pocketpaw_code"]["args"] == ["srv.js"]
+    assert kwargs["plugins"][0]["path"] == "/tmp/skills"
+    assert sorted(offenders) == ["mcp_servers['pocketpaw_code']['args'][0]", "plugins[0]['path']"]
+
+
+def test_a_clean_option_set_is_untouched_and_reports_nothing() -> None:
+    """The guard runs on EVERY turn, so the no-NUL path must be a no-op — no
+    rewriting, no copying, no log line."""
+    kwargs = {
+        "system_prompt": "You are helpful.",
+        "allowed_tools": ["Read", "Write"],
+        "env": {"ANTHROPIC_API_KEY": "sk-real"},
+        "cwd": "/home/u/.pocketpaw",
+        "max_turns": 40,
+        "include_partial_messages": True,
+    }
+    before = {
+        "system_prompt": kwargs["system_prompt"],
+        "allowed_tools": list(kwargs["allowed_tools"]),
+        "env": dict(kwargs["env"]),
+        "cwd": kwargs["cwd"],
+    }
+
+    offenders = _scrub_nul_chars(kwargs)
+
+    assert offenders == []
+    assert kwargs["system_prompt"] == before["system_prompt"]
+    assert kwargs["allowed_tools"] == before["allowed_tools"]
+    assert kwargs["env"] == before["env"]
+    assert kwargs["cwd"] == before["cwd"]
+
+
+def test_non_string_values_survive_untouched() -> None:
+    """Numbers, bools, None and opaque objects (hooks, session_store) pass through
+    — the guard must not try to walk or coerce them."""
+    sentinel = object()
+    kwargs = {
+        "max_turns": 40,
+        "include_partial_messages": True,
+        "model": None,
+        "session_store": sentinel,
+        "hooks": {"PreToolUse": [sentinel]},
+    }
+
+    offenders = _scrub_nul_chars(kwargs)
+
+    assert offenders == []
+    assert kwargs["max_turns"] == 40
+    assert kwargs["include_partial_messages"] is True
+    assert kwargs["model"] is None
+    assert kwargs["session_store"] is sentinel
+    assert kwargs["hooks"]["PreToolUse"][0] is sentinel
+
+
+def test_every_nul_in_one_value_goes_not_just_the_first() -> None:
+    kwargs = {"system_prompt": "a\x00b\x00c\x00"}
+
+    offenders = _scrub_nul_chars(kwargs)
+
+    assert kwargs["system_prompt"] == "abc"
+    assert offenders == ["system_prompt"]
+
+
+# ── the guard is actually wired into the real option build ──────────────────
+
+
+async def test_build_options_strips_a_nul_before_it_can_reach_the_spawn(monkeypatch) -> None:
+    """The unit tests above prove the helper; this proves it RUNS. A guard that is
+    correct but never called is the whole bug over again."""
+    from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
+    from pocketpaw.config import get_settings
+
+    backend = ClaudeSDKBackend(get_settings())
+    monkeypatch.setattr(backend, "_collect_mcp_tool_ids", lambda: [])
+
+    built = await backend._build_options(
+        "hello",
+        system_prompt="You are helpful.\x00 Be brief.",
+        history=None,
+        session_key=None,
+        deny_mcp_tool_ids=frozenset(),
+        allow_sdk_tools=frozenset(),
+        allow_mcp_tool_ids=frozenset(),
+        skill_names=frozenset(),
+        stderr_sink=[],
+    )
+
+    def has_nul(value) -> bool:
+        if isinstance(value, str):
+            return "\0" in value
+        if isinstance(value, dict):
+            return any(has_nul(v) for v in value.values())
+        if isinstance(value, (list, tuple)):
+            return any(has_nul(v) for v in value)
+        return False
+
+    assert not has_nul(built.options_kwargs), "a NUL survived into the built options"
+    assert "\x00" not in built.options_kwargs["system_prompt"]


### PR DESCRIPTION
## The failure

```
CLIConnectionError: Failed to start Claude Code: embedded null character
  ... _winapi.CreateProcess(...)  ->  ValueError: embedded null character
```

The agent never starts. Windows `CreateProcess` refuses a command line, an environment block, or a cwd containing a NUL, and the SDK hands all three through untouched — so one NUL anywhere in the option set kills every turn on that path.

The message is the real problem. It names nothing: not the field, not the value, not even whether the offender was an argument or an env var. There is no way in from the traceback.

POSIX isn't safer, just quieter — `execve` takes NUL-terminated strings, so a NUL there truncates the argument silently instead of failing.

## The guard

`_scrub_nul_chars` walks the option kwargs — including nested `mcp_servers` and `plugins`, both of which get serialized into a CLI argument — strips any NUL in place, and returns the paths that carried one. `_build_options` calls it as the **last** gate before `ClaudeAgentOptions` is constructed (after `env` and the per-send model override are set) and logs the field list at ERROR when it fires.

Stripping is unconditionally safe: a NUL is not valid in a prompt, a tool id, a model name, a path, or an env value, so there is no case where preserving one is correct. The reporting is the part that earns its keep — it converts an un-debuggable spawn failure into a working run plus a breadcrumb naming the source.

Opaque values (`hooks`, `session_store`, transports, numbers, bools, `None`) pass through untouched; the guard never walks or coerces a collaborator.

## This is a boundary guard, not a root-cause fix

I could not identify the producer. Ruled out, all clean:

- the static option build for the affected path, driven through the real `_build_options`
- every persisted `agents` / `sessions` / `agent_session_runtimes` / `code_projects` / `workspaces` / `users` document, plus 837 `messages` and 103 `chat_runs`
- the process environment (84 vars)
- `~/.pocketpaw/internal-token` — correct UTF-8, no NULs (a UTF-16 file here would have decoded as UTF-8 *with* interleaved NULs that `.strip()` wouldn't remove, which fit the symptom exactly — but it isn't that)
- every non-binary file under `~/.pocketpaw` (the 873 hits are all `.wasm` / `.exe` / `.png` / `.pdf`)

So the value is computed per-request, and the logged field list is what will name it next time it fires.

## Tests

`tests/test_claude_sdk_nul_guard.py`, written failing first — 9 cases covering each carrier (string option, env value with the **variable named**, cwd, list element, nested `mcp_servers` / `plugins`), the no-op path on clean options, non-string pass-through, and multiple NULs in one value. The last one asserts the guard is actually *called* from `_build_options`, since a correct guard that never runs is the same bug again.

```
pytest tests/test_claude_sdk_nul_guard.py   → 9 passed
pytest -k "claude_sdk or code_agent or code_mcp"  → 150 passed, 1 skipped
```

The 6 failures in `tests/ee/test_mcp_claude_sdk.py::TestClaudeSDKMCPServers` reproduce identically with this change reverted — pre-existing, untouched here.
