### PR TITLE
Make SurfaceProfile.skill_names a binding allowlist

### DIFF
--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -173,6 +173,17 @@ Updated: 2026-06-07 (feat/entity-pocket-profile-field, entity-rooms A2) — ``ru
   connect), so the run goes through a fresh stateless query whose options carry
   the plugin; the temp dir is removed in the outer ``finally``. Empty
   ``skill_names`` is a no-op. Crosses the EE→OSS boundary as a plain frozenset.
+Updated: 2026-07-25 (feat/bundled-skills-per-surface) — a non-empty
+  ``skill_names`` now SUPPRESSES the wholesale bundled-skills plugin
+  (``_should_load_bundled_plugin``). Before this, the two plugin entries were
+  independent: the bundled plugin loaded from ``plugins=`` regardless of
+  ``skill_names``, so a surface could not withhold a bundled skill by naming a
+  narrower set — ``SurfaceProfile.skill_names`` was additive-only, and /code had
+  to deny the ``Skill`` BUILT-IN outright to keep ``pocketpaw-create-pocket``
+  from firing on "build an app with components and nice design". With the gate,
+  naming skills yields exactly those (``materialize_run_skills`` resolves
+  bundled names too, via its new packaged fallback) and naming none keeps the
+  full bundled set, so general chat is byte-for-byte unchanged.
 Updated: 2026-06-06 (feat/entity-pocket-profile-field, entity-rooms chunk ①) —
   ``run`` also accepts ``allow_sdk_tools: frozenset[str]``, the per-entity
   ADDITIVE SDK-tool allowlist (resolved upstream from the entity pocket's
@@ -1279,6 +1290,25 @@ class ClaudeSDKBackend(BaseAgentBackend):
         return system_prompt[:cut]
 
     @staticmethod
+    def _should_load_bundled_plugin(*, enabled: bool, skill_names: frozenset[str]) -> bool:
+        """Whether to load the WHOLE bundled-skills plugin this connect.
+
+        The bundled skills ship as a local plugin passed via SDK ``plugins=``,
+        which loads independently of ``skill_names``. That made a surface's
+        skill allowlist advisory rather than binding: naming a narrow set could
+        not withhold ``pocketpaw-create-pocket``, whose description matches
+        "build an app with components and nice design" almost word for word.
+        /code had to deny the ``Skill`` built-in outright to stop it.
+
+        Gating the wholesale load on an EMPTY ``skill_names`` makes the
+        allowlist binding — name skills and the run gets exactly those (each
+        materialized by ``materialize_run_skills``, bundled ones included);
+        name none and the full bundled set loads as before, so general chat is
+        unchanged. ``sdk_load_bundled_skills=False`` still disables it outright.
+        """
+        return enabled and not skill_names
+
+    @staticmethod
     def _plugin_digest(skill_names: frozenset[str], *, bundled: bool) -> str:
         """Stable digest of the agent's plugin IDENTITY for the cache key.
 
@@ -1852,7 +1882,9 @@ class ClaudeSDKBackend(BaseAgentBackend):
         # ``skills=`` option is also gated by setting_sources, but
         # ``plugins=`` is not. Toggle via ``sdk_load_bundled_skills``.
         bundled_loaded = False
-        if self.settings.sdk_load_bundled_skills:
+        if self._should_load_bundled_plugin(
+            enabled=self.settings.sdk_load_bundled_skills, skill_names=skill_names
+        ):
             from pocketpaw.bundled_skills import bundled_skills_plugin_dir
 
             plugin_dir = bundled_skills_plugin_dir()

--- a/src/pocketpaw/skills/materialize.py
+++ b/src/pocketpaw/skills/materialize.py
@@ -11,6 +11,19 @@
 # ``skills/<slug>/SKILL.md``) is the ONLY channel that survives that isolation,
 # exactly as the bundled-skills plugin does. We build a FRESH plugin per run so
 # only the entity's named skills are surfaced — never the full installed set.
+#
+# Modified: 2026-07-25 (feat/bundled-skills-per-surface) — named-skill
+# resolution gained a BUNDLED fallback. ``SkillLoader.SKILL_PATHS`` scans
+# ``~/.agents``, ``~/.claude`` and ``~/.pocketpaw`` but NOT the packaged
+# ``_bundled/skills/``, so a surface could only name a bundled skill when the
+# boot-time ~/.claude/skills mirror happened to be on
+# (``POCKETPAW_AUTO_INSTALL_BUNDLED_SKILLS`` turns it off). ``_bundled_skill_dirs``
+# reads the package directly as a source of LAST resort — an installed skill of
+# the same name still shadows it, so a user override keeps winning. This is
+# what lets the SDK backend stop loading the bundled plugin wholesale whenever
+# a surface names skills (see ``ClaudeSDKBackend._should_load_bundled_plugin``),
+# which is what finally makes ``SurfaceProfile.skill_names`` a real allowlist
+# instead of an advisory one.
 
 from __future__ import annotations
 
@@ -58,6 +71,40 @@ def _safe_slug(name: str) -> str | None:
     return name
 
 
+def _bundled_plugin_root() -> Path | None:
+    """Return the PACKAGED bundled-skills plugin root, or ``None``.
+
+    A seam, not just a wrapper: tests swap this for a throwaway bundle, and the
+    import is local so ``pocketpaw.skills`` never hard-depends on the shipping
+    side. Any failure degrades to "no bundle" — resolution then behaves exactly
+    as it did before the bundled fallback existed.
+    """
+    try:
+        from pocketpaw.bundled_skills import bundled_skills_plugin_dir
+
+        return bundled_skills_plugin_dir()
+    except Exception:  # noqa: BLE001 — a missing bundle must never fail a run
+        return None
+
+
+def _bundled_skill_dirs() -> dict[str, Path]:
+    """Map bundled skill name → its directory, for name-based resolution.
+
+    ``SkillLoader.SKILL_PATHS`` covers ``~/.agents``, ``~/.claude`` and
+    ``~/.pocketpaw`` — NOT the packaged ``_bundled/skills/``. Bundled skills
+    reached the loader only through the boot-time ~/.claude/skills mirror, which
+    ``POCKETPAW_AUTO_INSTALL_BUNDLED_SKILLS=false`` disables. This reads the
+    package directly so a surface can name a bundled skill unconditionally.
+    """
+    root = _bundled_plugin_root()
+    if root is None:
+        return {}
+    try:
+        return {p.name: p for p in (root / "skills").iterdir() if (p / "SKILL.md").is_file()}
+    except OSError:  # bundle absent or unreadable — degrade to no bundle
+        return {}
+
+
 def materialize_run_skills(
     skill_names: Iterable[str],
     run_id: str | None = None,
@@ -89,19 +136,25 @@ def materialize_run_skills(
         return None
 
     available = get_skill_loader().get_all()
+    bundled = _bundled_skill_dirs()
     matched: list[tuple[str, Path]] = []
     unknown: list[str] = []
     for name in sorted(requested):
-        skill = available.get(name)
-        if skill is None:
-            unknown.append(name)
-            continue
         slug = _safe_slug(name)
         if slug is None:
             logger.warning("materialize_run_skills: skipping unsafe skill slug %r", name)
             continue
+        # Resolution order: an INSTALLED skill (SKILL_PATHS) shadows a packaged
+        # bundled one of the same name, so a user override still wins. The
+        # bundled fallback exists because SKILL_PATHS does not cover the
+        # packaged ``_bundled/skills/`` dir — without it, naming a bundled
+        # skill only worked when the boot-time ~/.claude/skills mirror was on.
         # ``Skill.path`` points at SKILL.md; its parent is the skill directory.
-        skill_dir = skill.path.parent
+        skill = available.get(name)
+        skill_dir = skill.path.parent if skill is not None else bundled.get(name)
+        if skill_dir is None:
+            unknown.append(name)
+            continue
         if not (skill_dir / "SKILL.md").is_file():
             logger.warning(
                 "materialize_run_skills: skill %r has no SKILL.md at %s — skipping",

--- a/tests/test_claude_sdk_skill_names.py
+++ b/tests/test_claude_sdk_skill_names.py
@@ -59,3 +59,32 @@ def test_cache_key_folds_in_plugin_digest_so_warm_client_can_be_reused() -> None
     assert key_a == key_a2, "same skill set → same key, so the warm client is reused"
     assert key_a != key_b, "different skill set → different key, so the client rebuilds"
     assert key_a != key_none, "a skill run must not collide with a non-skill run"
+
+
+# --- P1: the surface allowlist is authoritative over the bundled plugin ---
+# Added 2026-07-25 (feat/bundled-skills-per-surface). The bundled skills ship
+# as a local plugin loaded via SDK ``plugins=``, which is INDEPENDENT of
+# ``skill_names`` — so a surface could not withhold ``pocketpaw-create-pocket``
+# by naming a narrower set (see surface_registry.py's _CODE_SKILL_DENY note).
+# Gating the wholesale load on an EMPTY skill_names makes the per-surface
+# allowlist real: name skills and you get exactly those, name none and you get
+# the full bundled set (unchanged for general chat).
+
+
+def test_bundled_plugin_withheld_when_surface_names_skills() -> None:
+    """A surface that names skills does NOT also get the whole bundled set."""
+    assert not ClaudeSDKBackend._should_load_bundled_plugin(
+        enabled=True, skill_names=frozenset({"code-react"})
+    ), "naming a skill subset must suppress the wholesale bundled plugin"
+
+
+def test_bundled_plugin_loads_when_no_skill_names() -> None:
+    """Back-compat: no named skills → the full bundled set still loads."""
+    assert ClaudeSDKBackend._should_load_bundled_plugin(enabled=True, skill_names=frozenset()), (
+        "general chat must keep the full bundled set"
+    )
+
+
+def test_bundled_plugin_respects_the_settings_toggle() -> None:
+    """``sdk_load_bundled_skills=False`` still wins over everything."""
+    assert not ClaudeSDKBackend._should_load_bundled_plugin(enabled=False, skill_names=frozenset())

--- a/tests/test_skills_materialize.py
+++ b/tests/test_skills_materialize.py
@@ -137,3 +137,58 @@ def test_cleanup_removes_dir(installed_skills):
     assert not root.exists()
     cleanup_run_skills(None)  # no raise
     cleanup_run_skills(root)  # idempotent
+
+
+# --- P1: bundled skills are resolvable by name ---------------------------
+# Added 2026-07-25 (feat/bundled-skills-per-surface): a surface that names
+# skills must be able to name a BUNDLED one. The SkillLoader only scans
+# SKILL_PATHS (~/.agents, ~/.claude, ~/.pocketpaw), so a bundled skill was
+# reachable by name only via the boot-time ~/.claude/skills mirror — which
+# POCKETPAW_AUTO_INSTALL_BUNDLED_SKILLS=false turns off. These pin the
+# packaged _bundled/skills/ dir as a resolution source of LAST resort.
+
+
+@pytest.fixture
+def fake_bundled(tmp_path, monkeypatch):
+    """Point ``bundled_skills_plugin_dir()`` at a throwaway packaged bundle."""
+    from pocketpaw.skills import materialize as materialize_mod
+
+    bundle_root = tmp_path / "_bundled"
+    (bundle_root / "skills").mkdir(parents=True)
+    _make_skill_dir(bundle_root / "skills", "code-react")
+    _make_skill_dir(bundle_root / "skills", "github")  # name clash on purpose
+    monkeypatch.setattr(materialize_mod, "_bundled_plugin_root", lambda: bundle_root, raising=False)
+    return bundle_root
+
+
+def test_resolves_bundled_skill_absent_from_loader(installed_skills, fake_bundled):
+    """A bundled skill the SkillLoader never saw still materializes by name."""
+    root = materialize_run_skills(["code-react"])
+    try:
+        assert root is not None, "bundled skill must resolve without the ~/.claude mirror"
+        assert (root / "skills" / "code-react" / "SKILL.md").is_file()
+    finally:
+        cleanup_run_skills(root)
+
+
+def test_installed_skill_wins_over_bundled_on_name_clash(installed_skills, fake_bundled):
+    """An installed skill overrides a bundled one of the same name."""
+    root = materialize_run_skills(["github"])
+    try:
+        assert root is not None
+        body = (root / "skills" / "github" / "SKILL.md").read_text(encoding="utf-8")
+        assert "Body for github." in body
+        # The installed fixture carries ref.md; the bundled one does not.
+        assert (root / "skills" / "github" / "ref.md").is_file(), (
+            "installed skill dir must win, assets and all"
+        )
+    finally:
+        cleanup_run_skills(root)
+
+
+def test_bundled_fallback_is_inert_when_no_bundle_present(installed_skills, monkeypatch):
+    """No packaged bundle → unchanged behavior, no crash."""
+    from pocketpaw.skills import materialize as materialize_mod
+
+    monkeypatch.setattr(materialize_mod, "_bundled_plugin_root", lambda: None, raising=False)
+    assert materialize_run_skills(["code-react"]) is None


### PR DESCRIPTION
## What

A surface can now name the skills its agent gets, and that naming actually holds.

## Why

`SurfaceProfile.skill_names` reads like an allowlist but wasn't one. Bundled skills ship as a Claude Code local plugin handed to the SDK through `plugins=`, and that path ignores `skill_names` entirely. So a surface could add skills but never withhold one.

That's the reason `/code` denies the `Skill` built-in outright. `pocketpaw-create-pocket` describes itself as "create / build a pocket, dashboard, tracker, tool, viewer ... with enterprise-quality design", which matches a request like "build an employee management app with components and nice design" almost word for word — and an empty `skill_names` did nothing to stop it. Denying the built-in was the only lever left, and it costs us every future code-targeted skill along with the bad one. The comment on `_CODE_SKILL_DENY` says as much: removing `Skill` from that set is the one-line change that admits a code skill, once it's safe to do.

This makes it safe to do.

## How

**`materialize_run_skills` can resolve a bundled skill by name.** `SkillLoader.SKILL_PATHS` scans `~/.agents`, `~/.claude` and `~/.pocketpaw` — not the packaged `_bundled/skills/`. Bundled skills only reached the loader through the boot-time `~/.claude/skills` mirror, which `POCKETPAW_AUTO_INSTALL_BUNDLED_SKILLS=false` disables. The packaged directory is now a fallback of last resort, so naming a bundled skill works regardless of the mirror. An installed skill of the same name still shadows it, so user overrides keep winning.

**A non-empty `skill_names` suppresses the wholesale bundled plugin** (`_should_load_bundled_plugin`). Name skills and the run gets exactly those. Name none and the full bundled set loads exactly as before.

## Compatibility

General chat sets no `skill_names`, so it keeps the full bundled set and is unchanged. `sdk_load_bundled_skills=False` still disables everything. Surfaces that already name skills (`/studio`, `/belt`, sites) stop also receiving the other 15 bundled skills — that's the fix, but it's the one behavior change worth a second look in review.

## Testing

Six new tests: bundled resolution with the loader empty, installed-shadows-bundled on a name clash, inert with no bundle present, and the three gate cases.

`tests/test_skills_materialize.py tests/test_claude_sdk_skill_names.py tests/test_claude_sdk_skill_warm_reuse.py tests/test_bundled_skills_installer.py tests/test_skills.py` — 52 passed.

Full suite: 8378 passed, 43 failed. Those 43 reproduce identically on `origin/dev` with this branch stashed (`test_codex_cli_backend`, `test_context_budget`, `test_multitenant_session_isolation`, `test_oss_artifact_delivery`) — pre-existing, untouched here.

## Follow-ups

Two stacked PRs build on this: dropping `Skill` from `_CODE_SKILL_DENY` and pointing `/code` at a named roster, then the specialist skills themselves.