### PR TITLE
One code specialist per starter template

### DIFF
--- a/src/pocketpaw/bundled_skills/_bundled/skills/code-next/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/skills/code-next/SKILL.md
@@ -27,33 +27,28 @@ Scaffolded from `create-next-app@15.5.20`, template `app-tw/ts`:
 app/layout.tsx        root layout, Geist + Geist_Mono via next/font/google
 app/page.tsx          the / route
 app/globals.css       @import "tailwindcss" plus an @theme inline block
-next.config.ts
 postcss.config.mjs    { plugins: ["@tailwindcss/postcss"] }
 tsconfig.json         paths: { "@/*": ["./*"] }, moduleResolution "bundler"
-eslint.config.mjs · biome.json · next-env.d.ts · app/favicon.ico · public/*.svg
+next.config.ts · eslint.config.mjs · biome.json · next-env.d.ts · public/*.svg
 ```
 
 Dependency ranges: `next` ^15.5, `react` / `react-dom` ^19, `tailwindcss` ^4
 with `@tailwindcss/postcss` ^4, `typescript` ^5.
 
 Two structural facts that trip people up: there is **no `src/` directory** —
-`app/` sits at the repository root, and `@/*` resolves to `./*`, not `./src/*`.
-And there is **no `tailwind.config.js`** — Tailwind v4 is configured in CSS.
+`app/` sits at the root and `@/*` resolves to `./*`, not `./src/*` — and there
+is **no `tailwind.config.js`**, because Tailwind v4 is configured in CSS.
 
 ## The Server / Client boundary
 
-Every component under `app/` is a Server Component unless the file (or a file
-above it in the import chain) starts with `"use client"`. Server Components can
-be `async` and reach a database directly, and they send zero JavaScript. They
-cannot use hooks, event handlers, or browser APIs.
-
-Push the boundary down. A page needing one interactive control stays a Server
-Component and imports a small client child:
+Every component under `app/` is a Server Component unless the file (or one above
+it in the import chain) starts with `"use client"`. Server Components can be
+`async` and reach a database directly and send zero JavaScript; they cannot use
+hooks, event handlers, or browser APIs. Push the boundary down — a page needing
+one interactive control stays a Server Component and imports a client child:
 
 ```tsx
-// app/products/page.tsx — server
-import { AddToCart } from './add-to-cart'   // 'use client' at its top
-
+// app/products/page.tsx — server. AddToCart carries 'use client' itself.
 export default async function Page() {
   const products = await db.product.findMany()
   return products.map((p) => <AddToCart key={p.id} id={p.id} name={p.name} />)
@@ -61,8 +56,7 @@ export default async function Page() {
 ```
 
 A Server Component may be passed to a client component as `children` and still
-render on the server. Props crossing the boundary must be serializable — no
-functions, no class instances.
+render on the server. Props crossing the boundary must be serializable.
 
 ## Request APIs are async in Next 15
 
@@ -70,21 +64,20 @@ The most common source of type errors on this version. `params`,
 `searchParams`, `cookies()`, `headers()`, and `draftMode()` return Promises:
 
 ```tsx
-export default async function Page({
-  params,
-  searchParams,
-}: {
+type Props = {
   params: Promise<{ slug: string }>
-  searchParams: Promise<{ [k: string]: string | string[] | undefined }>
-}) {
+  searchParams: Promise<Record<string, string | string[] | undefined>>
+}
+
+export default async function Page({ params }: Props) {
   const { slug } = await params
   const session = (await cookies()).get('session')
 }
 ```
 
 Next 15.5 also generates global `PageProps<'/blog/[slug]'>`, `LayoutProps<'/'>`,
-and `RouteContext<'/api/items/[id]'>` types — no import needed, and they cover
-parallel route slots. In a client component, `use(params)` unwraps the promise.
+and `RouteContext<'/api/items/[id]'>` types — no import needed, covering parallel
+slots. In a client component, `use(params)` unwraps the same promise.
 
 ## File conventions in `app/`
 
@@ -92,15 +85,15 @@ parallel route slots. In a client component, `use(params)` unwraps the promise.
 |---|---|
 | `page.tsx` | makes a segment routable |
 | `layout.tsx` | wraps its segment; persists across navigation, never remounts |
-| `template.tsx` | like a layout but remounts on every navigation |
+| `template.tsx` | like a layout, but remounts on every navigation |
 | `loading.tsx` | Suspense fallback for the segment |
 | `error.tsx` | error boundary; must be `"use client"` and takes `reset` |
 | `not-found.tsx` | rendered by `notFound()` |
 | `route.ts` | an HTTP endpoint; cannot coexist with `page.tsx` in one segment |
 
 Folder names drive the URL: `[slug]` dynamic, `[...slug]` catch-all,
-`(marketing)` a route group adding no URL segment, `_lib` a private folder
-excluded from routing, `@modal` a parallel route slot.
+`(marketing)` a route group adding no segment, `_lib` a private folder excluded
+from routing, `@modal` a parallel route slot.
 
 ```ts
 // app/api/items/[id]/route.ts
@@ -111,9 +104,9 @@ export async function GET(_req: Request, ctx: RouteContext<'/api/items/[id]'>) {
 
 ## Caching and revalidation
 
-Next 15 flipped the defaults to uncached: `fetch` is not cached, GET route
-handlers are not cached, and page segments in the client router cache are stale
-immediately. Caching is now something you ask for:
+Next 15 flipped the defaults to uncached: `fetch` and GET route handlers are not
+cached, and page segments in the client router cache are stale immediately.
+Caching is now something you ask for:
 
 ```ts
 await fetch(url, { cache: 'force-cache' })            // persist it
@@ -121,24 +114,19 @@ await fetch(url, { next: { revalidate: 3600 } })      // time-based
 await fetch(url, { next: { tags: ['products'] } })    // tag it for later
 ```
 
-For non-`fetch` work (an ORM call, a filesystem read) wrap it in
-`unstable_cache`. Per-segment behaviour comes from route segment config:
-`export const dynamic = 'force-static' | 'force-dynamic'` and
-`export const revalidate = 60`.
-
-Invalidate from a server action or route handler with `revalidatePath('/blog')`
-or `revalidateTag('products')`. On this version `revalidateTag` takes the tag
-alone — the second `cacheLife` argument is Next 16. React's `cache()`
-deduplicates a function within one request, so a layout and a page can both
-call `getUser()` without two round trips.
+Wrap non-`fetch` work (an ORM call, a filesystem read) in `unstable_cache`.
+Per-segment behaviour comes from route segment config — `export const dynamic =
+'force-static' | 'force-dynamic'`, `export const revalidate = 60`. Invalidate
+from a server action or route handler with `revalidatePath('/blog')` or
+`revalidateTag('products')`; here `revalidateTag` takes the tag alone, since the
+second `cacheLife` argument is Next 16. React's `cache()` deduplicates a
+function within one request, so a layout and a page can both call `getUser()`.
 
 ## Server Actions
 
 ```tsx
 // app/actions.ts
 'use server'
-import { revalidatePath } from 'next/cache'
-
 export async function createPost(_prev: unknown, formData: FormData) {
   const title = String(formData.get('title') ?? '')
   if (!title) return { error: 'Title is required' }
@@ -149,7 +137,7 @@ export async function createPost(_prev: unknown, formData: FormData) {
 ```
 
 ```tsx
-'use client'
+'use client' // the caller
 const [state, action, pending] = useActionState(createPost, { error: null })
 return (
   <form action={action}>
@@ -160,22 +148,20 @@ return (
 )
 ```
 
-An action is a public HTTP endpoint the moment it is exported. Authorize and
-validate inside the action body — a check in the calling component protects
-nothing. `useFormStatus` reads the enclosing form's pending state from a child.
+An action is a public HTTP endpoint the moment it is exported: authorize and
+validate inside the action body, because a check in the calling component
+protects nothing. `useFormStatus` reads the form's pending state from a child.
 
 ## Metadata, images, fonts, links
 
 - `export const metadata: Metadata` for static, `generateMetadata({ params })`
-  when it depends on data.
-- `next/image` needs `width` and `height` (or `fill` with a positioned parent);
-  remote hosts must be listed in `images.remotePatterns`.
-- `next/font/google` self-hosts and exposes CSS variables — the template already
-  wires Geist and Geist Mono onto `<html>`.
-- `next/link` prefetches automatically. `legacyBehavior` with a nested `<a>` is
-  deprecated on 15.5 and removed in 16; write `<Link href="/x">Text</Link>`.
-- `typedRoutes: true` in `next.config.ts` is stable on 15.5 and turns a wrong
-  `href` into a compile error.
+  when it depends on data. `next/image` needs `width` and `height` (or `fill`
+  with a positioned parent); remote hosts go in `images.remotePatterns`.
+- `next/font/google` self-hosts and exposes CSS variables — already wired for
+  Geist and Geist Mono onto `<html>`.
+- `next/link` prefetches automatically; `legacyBehavior` with a nested `<a>` is
+  deprecated on 15.5. `typedRoutes: true` in `next.config.ts` is stable on 15.5
+  and turns a wrong `href` into a compile error.
 
 ## Middleware
 
@@ -186,32 +172,22 @@ function named `middleware`. Node.js runtime support went stable in 15.5:
 export const config = { matcher: ['/account/:path*'], runtime: 'nodejs' }
 
 export function middleware(request: NextRequest) {
-  if (!request.cookies.get('session')) {
-    return NextResponse.redirect(new URL('/login', request.url))
-  }
-  return NextResponse.next()
+  return request.cookies.get('session')
+    ? NextResponse.next()
+    : NextResponse.redirect(new URL('/login', request.url))
 }
 ```
 
-Keep it thin — it sits in front of every matched request, and real authorization
-belongs in the data layer as well.
+Keep it thin — it sits in front of every matched request, and real
+authorization belongs in the data layer too.
 
 ## Tailwind v4
 
-Configuration is CSS-first. `app/globals.css` opens with `@import "tailwindcss"`
-and declares tokens in an `@theme` block; each token becomes a utility.
-
-```css
-@import "tailwindcss";
-
-@theme inline {
-  --color-brand: oklch(0.62 0.19 264);
-  --font-sans: var(--font-geist-sans);
-}
-```
-
-`--color-brand` yields `bg-brand`, `text-brand`, `border-brand`. No config file,
-no `content` array. `@apply` exists but is rarely the right answer.
+Configuration is CSS-first: `app/globals.css` opens with `@import "tailwindcss"`
+and declares tokens in an `@theme` block, where each token becomes a utility.
+`--color-brand: oklch(0.62 0.19 264)` yields `bg-brand`, `text-brand`,
+`border-brand`. There is no config file and no `content` array. `@apply` exists
+but is rarely the right answer.
 
 ## Not available on Next 15
 
@@ -222,9 +198,9 @@ These belong to Next 16 and will fail here:
 - `proxy.ts` as a replacement for `middleware.ts`.
 - `updateTag()` and `refresh()` from `next/cache`, and the two-argument
   `revalidateTag(tag, profile)`.
-- `reactCompiler` as a stable top-level config option.
+- `reactCompiler` as a stable top-level config option, and Turbopack as the
+  default bundler with top-level `turbopack` config.
 - React 19.2-only APIs: `<Activity>`, `useEffectEvent`, View Transitions.
-- Turbopack as the default bundler and top-level `turbopack` config.
 
 ## Common mistakes
 
@@ -233,30 +209,28 @@ These belong to Next 16 and will fail here:
 - **Reading `params` or `cookies()` synchronously.** They are Promises on 15.
 - **An event handler passed from a Server Component to a client one.** Functions
   do not serialize across the boundary.
-- **A secret read in a file that ends up client-side.** Anything not prefixed
+- **A secret read in a file that ends up client-side.** Anything unprefixed by
   `NEXT_PUBLIC_` is server-only and unreadable from a `"use client"` file.
 - **Expecting Next 14 caching.** Stale data usually means a missing
-  `revalidatePath`/`revalidateTag`; unexpectedly fresh data means a missing
+  `revalidatePath`/`revalidateTag`; fresh-when-you-wanted-cached means a missing
   `force-cache`.
 - **A server action with no authorization check.** It is a public endpoint.
 - **`useState` or `useEffect` in a Server Component.** They do not exist there.
-- **`@/src/...` import paths.** The alias is `@/*` → `./*`, and there is no
-  `src/` directory in this template.
-- **Reaching for `tailwind.config.js`.** v4 has no such file.
+- **`@/src/...` paths or `tailwind.config.js`.** Neither exists here.
 - **`route.ts` beside `page.tsx` in one folder**, or `error.tsx` without
   `"use client"`. Both are hard failures.
 
 ## Review checklist
 
 - `"use client"` appears only on leaves that need interactivity.
-- Every `params`, `searchParams`, `cookies()`, `headers()` access is awaited.
-- Props crossing the server/client boundary are serializable.
-- Data-fetching calls state their caching intent explicitly.
-- Every mutation is followed by `revalidatePath` or `revalidateTag`.
-- Every server action validates input and checks authorization itself.
-- Secrets are unprefixed and read only in server code.
-- Dynamic pages export `metadata` or `generateMetadata`.
-- `next/image` has dimensions; remote hosts are in `images.remotePatterns`.
+- Every `params`, `searchParams`, `cookies()`, `headers()` access is awaited,
+  and props crossing the server/client boundary are serializable.
+- Data-fetching calls state their caching intent explicitly, and every mutation
+  is followed by `revalidatePath` or `revalidateTag`.
+- Every server action validates input and checks authorization itself, and
+  secrets are unprefixed and read only in server code.
+- Dynamic pages export `metadata` or `generateMetadata`; `next/image` has
+  dimensions and remote hosts are in `images.remotePatterns`.
 - Segments that can fail have `error.tsx`; slow segments have `loading.tsx`.
 - No Next 16 API (`"use cache"`, `proxy.ts`, `updateTag`, two-argument
   `revalidateTag`) appears anywhere.

--- a/src/pocketpaw/bundled_skills/_bundled/skills/code-next/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/skills/code-next/SKILL.md
@@ -1,0 +1,262 @@
+---
+name: code-next
+description: |
+  Next.js 15 App Router projects with TypeScript and Tailwind CSS v4.
+  Invoke when the work is Next: "add a page", "why is this a client
+  component", "params is a Promise now", "fetch data in a Server
+  Component", "write a server action", "add an API route", "my data is
+  stale", "set the page title", "protect a route". Covers the Server/Client
+  Component boundary, async request APIs, the app/ file conventions, route
+  handlers, server actions and revalidation, metadata, next/image and
+  next/font, middleware, and Tailwind v4's CSS-first configuration. This is
+  the Next 15 line specifically — Cache Components, "use cache", proxy.ts,
+  updateTag, and Turbopack-by-default are Next 16 and are NOT available.
+  This is not a dashboard, not a pocket, and it produces no ui-spec.
+---
+
+# Next.js 15 App Router + TypeScript + Tailwind v4
+
+A full-stack React framework. Most components render on the server; only what
+needs interactivity ships to the browser.
+
+## What is actually in the project
+
+Scaffolded from `create-next-app@15.5.20`, template `app-tw/ts`:
+
+```
+app/layout.tsx        root layout, Geist + Geist_Mono via next/font/google
+app/page.tsx          the / route
+app/globals.css       @import "tailwindcss" plus an @theme inline block
+next.config.ts
+postcss.config.mjs    { plugins: ["@tailwindcss/postcss"] }
+tsconfig.json         paths: { "@/*": ["./*"] }, moduleResolution "bundler"
+eslint.config.mjs · biome.json · next-env.d.ts · app/favicon.ico · public/*.svg
+```
+
+Dependency ranges: `next` ^15.5, `react` / `react-dom` ^19, `tailwindcss` ^4
+with `@tailwindcss/postcss` ^4, `typescript` ^5.
+
+Two structural facts that trip people up: there is **no `src/` directory** —
+`app/` sits at the repository root, and `@/*` resolves to `./*`, not `./src/*`.
+And there is **no `tailwind.config.js`** — Tailwind v4 is configured in CSS.
+
+## The Server / Client boundary
+
+Every component under `app/` is a Server Component unless the file (or a file
+above it in the import chain) starts with `"use client"`. Server Components can
+be `async` and reach a database directly, and they send zero JavaScript. They
+cannot use hooks, event handlers, or browser APIs.
+
+Push the boundary down. A page needing one interactive control stays a Server
+Component and imports a small client child:
+
+```tsx
+// app/products/page.tsx — server
+import { AddToCart } from './add-to-cart'   // 'use client' at its top
+
+export default async function Page() {
+  const products = await db.product.findMany()
+  return products.map((p) => <AddToCart key={p.id} id={p.id} name={p.name} />)
+}
+```
+
+A Server Component may be passed to a client component as `children` and still
+render on the server. Props crossing the boundary must be serializable — no
+functions, no class instances.
+
+## Request APIs are async in Next 15
+
+The most common source of type errors on this version. `params`,
+`searchParams`, `cookies()`, `headers()`, and `draftMode()` return Promises:
+
+```tsx
+export default async function Page({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ slug: string }>
+  searchParams: Promise<{ [k: string]: string | string[] | undefined }>
+}) {
+  const { slug } = await params
+  const session = (await cookies()).get('session')
+}
+```
+
+Next 15.5 also generates global `PageProps<'/blog/[slug]'>`, `LayoutProps<'/'>`,
+and `RouteContext<'/api/items/[id]'>` types — no import needed, and they cover
+parallel route slots. In a client component, `use(params)` unwraps the promise.
+
+## File conventions in `app/`
+
+| File | Role |
+|---|---|
+| `page.tsx` | makes a segment routable |
+| `layout.tsx` | wraps its segment; persists across navigation, never remounts |
+| `template.tsx` | like a layout but remounts on every navigation |
+| `loading.tsx` | Suspense fallback for the segment |
+| `error.tsx` | error boundary; must be `"use client"` and takes `reset` |
+| `not-found.tsx` | rendered by `notFound()` |
+| `route.ts` | an HTTP endpoint; cannot coexist with `page.tsx` in one segment |
+
+Folder names drive the URL: `[slug]` dynamic, `[...slug]` catch-all,
+`(marketing)` a route group adding no URL segment, `_lib` a private folder
+excluded from routing, `@modal` a parallel route slot.
+
+```ts
+// app/api/items/[id]/route.ts
+export async function GET(_req: Request, ctx: RouteContext<'/api/items/[id]'>) {
+  return Response.json(await getItem((await ctx.params).id))
+}
+```
+
+## Caching and revalidation
+
+Next 15 flipped the defaults to uncached: `fetch` is not cached, GET route
+handlers are not cached, and page segments in the client router cache are stale
+immediately. Caching is now something you ask for:
+
+```ts
+await fetch(url, { cache: 'force-cache' })            // persist it
+await fetch(url, { next: { revalidate: 3600 } })      // time-based
+await fetch(url, { next: { tags: ['products'] } })    // tag it for later
+```
+
+For non-`fetch` work (an ORM call, a filesystem read) wrap it in
+`unstable_cache`. Per-segment behaviour comes from route segment config:
+`export const dynamic = 'force-static' | 'force-dynamic'` and
+`export const revalidate = 60`.
+
+Invalidate from a server action or route handler with `revalidatePath('/blog')`
+or `revalidateTag('products')`. On this version `revalidateTag` takes the tag
+alone — the second `cacheLife` argument is Next 16. React's `cache()`
+deduplicates a function within one request, so a layout and a page can both
+call `getUser()` without two round trips.
+
+## Server Actions
+
+```tsx
+// app/actions.ts
+'use server'
+import { revalidatePath } from 'next/cache'
+
+export async function createPost(_prev: unknown, formData: FormData) {
+  const title = String(formData.get('title') ?? '')
+  if (!title) return { error: 'Title is required' }
+  await db.post.create({ data: { title } })
+  revalidatePath('/posts')
+  return { error: null }
+}
+```
+
+```tsx
+'use client'
+const [state, action, pending] = useActionState(createPost, { error: null })
+return (
+  <form action={action}>
+    <input name="title" />
+    <button disabled={pending}>Create</button>
+    {state.error && <p role="alert">{state.error}</p>}
+  </form>
+)
+```
+
+An action is a public HTTP endpoint the moment it is exported. Authorize and
+validate inside the action body — a check in the calling component protects
+nothing. `useFormStatus` reads the enclosing form's pending state from a child.
+
+## Metadata, images, fonts, links
+
+- `export const metadata: Metadata` for static, `generateMetadata({ params })`
+  when it depends on data.
+- `next/image` needs `width` and `height` (or `fill` with a positioned parent);
+  remote hosts must be listed in `images.remotePatterns`.
+- `next/font/google` self-hosts and exposes CSS variables — the template already
+  wires Geist and Geist Mono onto `<html>`.
+- `next/link` prefetches automatically. `legacyBehavior` with a nested `<a>` is
+  deprecated on 15.5 and removed in 16; write `<Link href="/x">Text</Link>`.
+- `typedRoutes: true` in `next.config.ts` is stable on 15.5 and turns a wrong
+  `href` into a compile error.
+
+## Middleware
+
+The file is `middleware.ts` at the project root on this version, exporting a
+function named `middleware`. Node.js runtime support went stable in 15.5:
+
+```ts
+export const config = { matcher: ['/account/:path*'], runtime: 'nodejs' }
+
+export function middleware(request: NextRequest) {
+  if (!request.cookies.get('session')) {
+    return NextResponse.redirect(new URL('/login', request.url))
+  }
+  return NextResponse.next()
+}
+```
+
+Keep it thin — it sits in front of every matched request, and real authorization
+belongs in the data layer as well.
+
+## Tailwind v4
+
+Configuration is CSS-first. `app/globals.css` opens with `@import "tailwindcss"`
+and declares tokens in an `@theme` block; each token becomes a utility.
+
+```css
+@import "tailwindcss";
+
+@theme inline {
+  --color-brand: oklch(0.62 0.19 264);
+  --font-sans: var(--font-geist-sans);
+}
+```
+
+`--color-brand` yields `bg-brand`, `text-brand`, `border-brand`. No config file,
+no `content` array. `@apply` exists but is rarely the right answer.
+
+## Not available on Next 15
+
+These belong to Next 16 and will fail here:
+
+- Cache Components and `"use cache"` as stable, plus the `cacheComponents` flag.
+  (`experimental.dynamicIO` exists on 15 but is experimental — do not build on it.)
+- `proxy.ts` as a replacement for `middleware.ts`.
+- `updateTag()` and `refresh()` from `next/cache`, and the two-argument
+  `revalidateTag(tag, profile)`.
+- `reactCompiler` as a stable top-level config option.
+- React 19.2-only APIs: `<Activity>`, `useEffectEvent`, View Transitions.
+- Turbopack as the default bundler and top-level `turbopack` config.
+
+## Common mistakes
+
+- **`"use client"` on a page** because one child needed a hook. It opts the whole
+  subtree into the client bundle. Move the boundary down.
+- **Reading `params` or `cookies()` synchronously.** They are Promises on 15.
+- **An event handler passed from a Server Component to a client one.** Functions
+  do not serialize across the boundary.
+- **A secret read in a file that ends up client-side.** Anything not prefixed
+  `NEXT_PUBLIC_` is server-only and unreadable from a `"use client"` file.
+- **Expecting Next 14 caching.** Stale data usually means a missing
+  `revalidatePath`/`revalidateTag`; unexpectedly fresh data means a missing
+  `force-cache`.
+- **A server action with no authorization check.** It is a public endpoint.
+- **`useState` or `useEffect` in a Server Component.** They do not exist there.
+- **`@/src/...` import paths.** The alias is `@/*` → `./*`, and there is no
+  `src/` directory in this template.
+- **Reaching for `tailwind.config.js`.** v4 has no such file.
+- **`route.ts` beside `page.tsx` in one folder**, or `error.tsx` without
+  `"use client"`. Both are hard failures.
+
+## Review checklist
+
+- `"use client"` appears only on leaves that need interactivity.
+- Every `params`, `searchParams`, `cookies()`, `headers()` access is awaited.
+- Props crossing the server/client boundary are serializable.
+- Data-fetching calls state their caching intent explicitly.
+- Every mutation is followed by `revalidatePath` or `revalidateTag`.
+- Every server action validates input and checks authorization itself.
+- Secrets are unprefixed and read only in server code.
+- Dynamic pages export `metadata` or `generateMetadata`.
+- `next/image` has dimensions; remote hosts are in `images.remotePatterns`.
+- Segments that can fail have `error.tsx`; slow segments have `loading.tsx`.
+- No Next 16 API (`"use cache"`, `proxy.ts`, `updateTag`, two-argument
+  `revalidateTag`) appears anywhere.

--- a/src/pocketpaw/bundled_skills/_bundled/skills/code-react/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/skills/code-react/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: code-react
+description: |
+  React 19 + Vite + TypeScript projects — the client-rendered SPA scaffold,
+  not Next.js. Invoke when the work is React inside a Vite project: "build a
+  React component", "why is this effect firing twice", "add a form",
+  "this state isn't updating", "share state between components", "add a
+  route", "typing this prop is fighting me", "fetch data on mount". Covers
+  hooks and when not to reach for them, React 19 client APIs (Actions,
+  useActionState, useOptimistic, use(), ref as a prop, Context as provider),
+  Vite conventions (import.meta.env, assets, aliases), and the strict
+  TypeScript settings this template turns on. There is NO server in this
+  project: no App Router, no Server Components, no "use server". Those
+  belong to the Next.js skill. This is not a dashboard, not a pocket, and
+  it produces no ui-spec.
+---
+
+# React 19 + Vite + TypeScript
+
+The project is a **client-rendered single-page app**. Everything ships to the
+browser; there is no server, no server rendering, and no request lifecycle.
+If a piece of advice starts with "on the server", it does not apply here.
+
+## What is actually in the project
+
+Scaffolded from `create-vite@8.3.0`, template `template-react-ts`:
+
+```
+index.html            <div id="root"> plus the module script tag
+src/main.tsx          createRoot(...).render(<StrictMode><App /></StrictMode>)
+src/App.tsx           the one component that exists
+src/App.css           component styles
+src/index.css         global styles, imported by main.tsx
+src/assets/react.svg
+public/vite.svg       served at /vite.svg, never processed
+vite.config.ts        defineConfig({ plugins: [react()] })
+tsconfig.json         a solution file; the real options are in the two below
+tsconfig.app.json     src/**, browser libs
+tsconfig.node.json    vite.config.ts only
+eslint.config.js      flat config
+```
+
+Verified versions: react `^19.2.0`, react-dom `^19.2.0`, vite `^7.3.1`,
+`@vitejs/plugin-react` `^5.1.1`, typescript `~5.9.3`.
+
+There is **no router, no state library, no data-fetching library, no CSS
+framework**. Anything beyond the list above has to be added as a dependency
+and wired up by hand. Say so plainly rather than writing imports that will not
+resolve.
+
+## Components
+
+Function components only. Three React 19 changes matter day to day:
+
+```tsx
+// 1. ref is an ordinary prop — forwardRef is gone
+function Field({ label, ref }: { label: string; ref?: React.Ref<HTMLInputElement> }) {
+  return <label>{label}<input ref={ref} /></label>
+}
+
+// 2. context objects render directly; .Provider is no longer required
+<ThemeContext value="dark">{children}</ThemeContext>
+
+// 3. ref callbacks may return a cleanup function
+<div ref={(node) => {
+  const ro = new ResizeObserver(onResize)
+  ro.observe(node)
+  return () => ro.disconnect()
+}} />
+```
+
+## State
+
+Derive, do not synchronize. If a value can be computed from props or other
+state, compute it during render:
+
+```tsx
+// wrong: a second source of truth that drifts
+const [total, setTotal] = useState(0)
+useEffect(() => setTotal(items.length), [items])
+
+// right
+const total = items.length
+```
+
+To reset state when an identity changes, change the `key` instead of writing an
+effect:
+
+```tsx
+<ProfileForm key={userId} userId={userId} />
+```
+
+Reach for `useReducer` when several fields change together under one event.
+Reach for context when a value is genuinely ambient (theme, current user);
+passing two props down two levels is not a reason to.
+
+## Effects
+
+An effect is for synchronizing with something outside React: a subscription, a
+timer, an imperative DOM API, a network request tied to the lifetime of a view.
+It is not for transforming data and not for responding to a click — put that in
+the event handler.
+
+`<StrictMode>` is on in this template, so in development every effect mounts,
+unmounts, and mounts again. An effect that leaks (a subscription with no
+teardown, a fetch with no abort) shows up as a double request or a doubled
+listener. That is the check working, not a bug to suppress.
+
+```tsx
+useEffect(() => {
+  const controller = new AbortController()
+  fetch(`/api/users/${id}`, { signal: controller.signal })
+    .then((r) => r.json())
+    .then(setUser)
+    .catch((e) => { if (e.name !== 'AbortError') setError(e) })
+  return () => controller.abort()
+}, [id])
+```
+
+## Forms and async work
+
+React 19's Actions work in a client app. `useActionState` owns the pending flag
+and the returned error, so no separate `isSubmitting` state is needed:
+
+```tsx
+const [error, submit, isPending] = useActionState(
+  async (_prev: string | null, formData: FormData) => {
+    const res = await saveName(formData.get('name') as string)
+    return res.ok ? null : res.message
+  },
+  null,
+)
+
+return (
+  <form action={submit}>
+    <input name="name" />
+    <button disabled={isPending}>Save</button>
+    {error && <p role="alert">{error}</p>}
+  </form>
+)
+```
+
+`useFormStatus` reads the enclosing form's pending state from a child component
+without prop drilling. `useOptimistic` shows the expected result while the
+request is in flight and rolls back on failure.
+
+`use()` unwraps a promise during render, but only if the promise was created
+outside render — a promise built inline is a new promise every pass and will
+suspend forever:
+
+```tsx
+const cache = new Map<string, Promise<User>>()
+const loadUser = (id: string) =>
+  cache.get(id) ??
+  cache.set(id, fetch(`/api/users/${id}`).then(r => r.json())).get(id)!
+
+// wrap the caller in <Suspense>
+const user = use(loadUser(id))
+```
+
+`use()` also reads context conditionally, which hooks cannot do.
+
+## Document metadata
+
+`<title>`, `<meta>`, and `<link>` rendered anywhere in the tree hoist into
+`<head>` in React 19. For a single-page app this covers per-view titles without
+a helper library.
+
+## Vite conventions
+
+- Environment values come from `import.meta.env`. Only keys prefixed `VITE_`
+  are exposed to client code, and everything exposed is public — no secrets.
+  `import.meta.env.DEV` and `.PROD` are booleans.
+- Imported assets (`import url from './assets/logo.svg'`) are hashed and
+  rewritten. Files in `public/` are copied verbatim and referenced by absolute
+  path.
+- A path alias needs both halves: `resolve.alias` in `vite.config.ts` (e.g.
+  `{ '@': fileURLToPath(new URL('./src', import.meta.url)) }`) *and*
+  `"paths": { "@/*": ["src/*"] }` in `tsconfig.app.json`. One without the other
+  fails in exactly one place — types or resolution, never both.
+- `*.module.css` gives scoped class names with no extra configuration.
+
+## TypeScript settings this template turns on
+
+`tsconfig.app.json` sets `verbatimModuleSyntax`, `erasableSyntaxOnly`,
+`noUnusedLocals`, `noUnusedParameters`, and `noUncheckedSideEffectImports`.
+Consequences worth knowing before the first type error:
+
+- Type-only imports must say so: `import type { ReactNode } from 'react'`.
+  A mixed import that only carries types will fail.
+- `erasableSyntaxOnly` bans `enum`, constructor parameter properties, and
+  namespaces. Use a union of string literals or `as const` object instead.
+- An unused parameter is an error; prefix it with `_` to keep the signature.
+
+## Routing
+
+Not included. If the app needs more than one view, add a router as a real
+dependency and mount it in `main.tsx` — do not hand-roll `window.location`
+branching and call it routing. Until a router exists, conditional rendering on
+a piece of state is the honest option; name it as temporary.
+
+## Common mistakes
+
+- **Writing Next.js.** No `app/` directory, no `"use client"`, no
+  `"use server"`, no Server Components, no `next/link` or `next/image`. Every
+  component here is a client component and those imports do not resolve.
+- **Effects that mirror props into state.** Produces one render of stale data
+  and a whole class of "why is it one behind" bugs. Derive instead.
+- **Blaming StrictMode for a double request.** The second mount is exposing a
+  missing cleanup. Add the abort, keep the check.
+- **Missing or lying dependency arrays.** An empty array on an effect that
+  closes over `id` captures the first `id` forever.
+- **Index as `key` in a reordering list.** State attaches to the wrong row after
+  an insert or a sort. Key on a stable id.
+- **Mutating state in place.** `items.push(x)` then `setItems(items)` is the
+  same reference, so nothing re-renders. Build a new array.
+- **A promise created inside render and handed to `use()`.** Suspends forever.
+- **Reading a ref during render.** `ref.current` is not reactive and is null on
+  the first pass; read it in an effect or a handler.
+- **`VITE_`-prefixed secrets.** They are in the bundle. Anything private needs a
+  backend this project does not have.
+
+## Review checklist
+
+- Every stateful value has exactly one owner; nothing is derived into state.
+- Every effect synchronizes with something external and returns a cleanup when
+  it subscribes, observes, times, or fetches.
+- Dependency arrays list every reactive value the effect reads.
+- Lists key on stable ids, not indices.
+- Async UI has a pending path and an error path, not just the happy one.
+- Type-only imports use `import type`; no `enum`, no parameter properties.
+- No unused locals or parameters left behind.
+- No `next/*` import, no `"use client"`, no `"use server"` anywhere.
+- New dependencies are actually added to `package.json`, not just imported.
+- Nothing secret sits behind a `VITE_` variable.

--- a/src/pocketpaw/bundled_skills/_bundled/skills/code-svelte/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/skills/code-svelte/SKILL.md
@@ -29,29 +29,20 @@ src/main.ts              mount(App, { target: document.getElementById('app')! })
 src/App.svelte           root component
 src/lib/Counter.svelte   the one child component
 src/app.css              global styles, imported by main.ts
-src/assets/svelte.svg
 public/vite.svg          served at /vite.svg, never processed
 svelte.config.js         { preprocess: vitePreprocess() }
 vite.config.ts           defineConfig({ plugins: [svelte()] })
 tsconfig.app.json        extends @tsconfig/svelte, checkJs on
-tsconfig.node.json
+src/assets/svelte.svg · tsconfig.json · tsconfig.node.json
 ```
 
 Verified versions: svelte `^5.45.2`, vite `^7.3.1`,
 `@sveltejs/vite-plugin-svelte` `^6.2.1`, `svelte-check` `^4.3.4`,
 typescript `~5.9.3`.
 
-The app is mounted imperatively:
-
-```ts
-import { mount } from 'svelte'
-import App from './App.svelte'
-
-const app = mount(App, { target: document.getElementById('app')! })
-```
-
-`mount()` — not `new App({ target })`. The class-component constructor is the
-Svelte 4 API and throws in Svelte 5 unless legacy compatibility is on.
+The app is mounted imperatively with `mount(App, { target })` from `svelte` —
+not `new App({ target })`. The class-component constructor is the Svelte 4 API
+and throws under Svelte 5 unless legacy compatibility is on.
 
 ## Runes
 
@@ -64,28 +55,22 @@ Reactivity is explicit. A plain `let` is a plain variable; declaring it with
   let user = $state({ name: 'Ada', tags: ['admin'] })
 
   const doubled = $derived(count * 2)
-  const summary = $derived.by(() => {
-    const t = user.tags.join(', ')
-    return `${user.name} (${t})`
-  })
+  const summary = $derived.by(() => `${user.name} (${user.tags.join(', ')})`)
 </script>
 ```
 
 - **`$state`** — deep by default. Objects and arrays are proxied, so
-  `user.tags.push('owner')` is reactive. `$state.raw` opts out of that for a
-  value you always replace wholesale; `$state.snapshot(x)` produces a plain
-  object to hand to code that dislikes proxies (structured clone, JSON, a
-  third-party library).
-- **`$derived`** — a cached expression. `$derived.by(() => { ... })` when the
-  computation needs statements. It re-evaluates lazily and must stay pure.
+  `user.tags.push('owner')` is reactive. `$state.raw` opts out for a value you
+  always replace wholesale; `$state.snapshot(x)` produces a plain object for
+  code that dislikes proxies (structured clone, JSON, a third-party library).
+- **`$derived`** — a cached, lazily re-evaluated expression that must stay pure.
+  `$derived.by(() => { ... })` when the computation needs statements.
 - **`$effect`** — for synchronizing with things outside Svelte: an observer, a
-  timer, a canvas, a subscription. Dependencies are tracked dynamically — it
-  depends on exactly what it read. Return a teardown function.
-  `$effect.pre` fires before the DOM updates.
-- **`$props`** — the component's inputs.
-- **`$bindable`** — marks a prop the parent may bind to.
-- **`$inspect`** — a development-only logger that re-fires when its argument
-  changes deeply.
+  timer, a canvas, a subscription. Dependencies are tracked dynamically, so it
+  depends on exactly what it read. Return a teardown. `$effect.pre` fires before
+  the DOM updates.
+- **`$props`**, **`$bindable`** — component inputs, and the opt-in that lets a
+  parent bind to one. **`$inspect`** — a development-only deep logger.
 
 The rule that prevents most bad Svelte 5: **if you are assigning to state
 inside `$effect`, it should almost certainly have been `$derived`.** Effects
@@ -111,21 +96,10 @@ that write state create ordering puzzles and re-entrancy loops.
 </button>
 ```
 
-Props are read-only unless declared `$bindable`:
-
-```svelte
-<!-- child -->
-<script lang="ts">
-  let { value = $bindable('') }: { value?: string } = $props()
-</script>
-<input bind:value />
-
-<!-- parent -->
-<TextField bind:value={name} />
-```
-
-Prefer callback props over binding. Binding is for genuine two-way form
-controls, not as a general upward channel.
+Props are read-only unless declared `$bindable`. In the child,
+`let { value = $bindable('') } = $props()` plus `<input bind:value />`; the
+parent then writes `<TextField bind:value={name} />`. Prefer callback props —
+binding is for genuine two-way form controls, not a general upward channel.
 
 ## Events are properties
 
@@ -133,32 +107,24 @@ controls, not as a general upward channel.
 no `on:click` directive in Svelte 5, and `createEventDispatcher` is gone. A
 child notifies its parent by calling a function prop.
 
-Modifiers are gone too; write them out:
-
-```svelte
-<form onsubmit={(e) => { e.preventDefault(); save() }}>
-```
+Modifiers are gone too; write them out —
+`<form onsubmit={(e) => { e.preventDefault(); save() }}>`.
 
 ## Snippets replace slots
 
 ```svelte
 <!-- List.svelte -->
 <script lang="ts">
-  import type { Snippet } from 'svelte'
   let { items, row }: { items: Item[]; row: Snippet<[Item]> } = $props()
 </script>
 
-<ul>
-  {#each items as item (item.id)}
-    <li>{@render row(item)}</li>
-  {/each}
-</ul>
+{#each items as item (item.id)}
+  <li>{@render row(item)}</li>
+{/each}
 
 <!-- caller -->
 <List {items}>
-  {#snippet row(item)}
-    <strong>{item.name}</strong>
-  {/snippet}
+  {#snippet row(item)}<strong>{item.name}</strong>{/snippet}
 </List>
 ```
 
@@ -173,10 +139,7 @@ how state is shared without a store library:
 ```ts
 // src/lib/session.svelte.ts
 export const session = $state({ user: null as User | null, loading: false })
-
-export function signOut() {
-  session.user = null
-}
+export const signOut = () => { session.user = null }
 ```
 
 Import `session` anywhere and mutate its properties. Do not export a
@@ -184,43 +147,40 @@ destructured primitive — the binding is copied and the reader never updates.
 Export the object, or export a getter.
 
 The Svelte 4 store contract still works (`writable`, `$store` auto-subscribe)
-and is worth knowing when reading older code, but new code should use runes.
-
-For values scoped to a component subtree, `setContext`/`getContext` from
-`svelte`, called during component initialization only.
+and is worth recognizing in older code, but new code uses runes. For values
+scoped to a subtree, `setContext`/`getContext` from `svelte`, called during
+component initialization only.
 
 ## Template features worth using
 
 - `{#each items as item (item.id)}` — the keyed form. Unkeyed `each` reuses DOM
   nodes positionally and will smear state across rows after an insert.
-- `{#key expr} ... {/key}` — tears down and rebuilds a subtree when `expr`
-  changes. This is the clean way to reset a component.
+- `{#key expr} ... {/key}` — rebuilds a subtree when `expr` changes; the clean
+  way to reset a component.
 - `{#await promise}` / `:then` / `:catch` — inline async without an effect.
-- `class:active={isActive}` and `style:color={c}` directives; `class` also
-  accepts an object or array of conditions.
+- `class:active={isActive}` and `style:color={c}`; `class` also accepts an
+  object or array of conditions.
 - `{@attach fn}` (Svelte 5.29+) — attaches behaviour to an element, replacing
-  `use:action`. The function receives the node, may read reactive state, and may
-  return a teardown.
+  `use:action`. It receives the node, may read reactive state, may return a
+  teardown.
 - `transition:`, `in:`, `out:`, `animate:` from `svelte/transition` and
   `svelte/animate`.
 
 ## Styling
 
-A `<style>` block in a component is scoped to that component's markup. It does
-not reach child components or dynamically inserted HTML; `:global(.selector)`
-opts a rule out. Unused selectors are stripped at compile time and reported —
-that warning usually means the selector only matches markup a child owns.
-
-Global styles belong in `src/app.css`, imported once from `main.ts`.
+A `<style>` block is scoped to that component's markup and does not reach child
+components or dynamically inserted HTML; `:global(.selector)` opts a rule out.
+Unused selectors are stripped at compile time and reported — that warning
+usually means the selector only matches markup a child owns. Global styles
+belong in `src/app.css`, imported once from `main.ts`.
 
 ## Types and Vite conventions
 
 - Type checking for `.svelte` files comes from `svelte-check`, a devDependency
   in this template; the plain TypeScript compiler does not understand `.svelte`.
-- Type props with an `interface Props`; type snippets with `Snippet<[Args]>`;
-  type a component value with `Component` from `svelte`.
-- `tsconfig.app.json` sets `checkJs: true`, so JavaScript in `.svelte` files is
-  type-checked too.
+- Type props with an `interface Props`, snippets with `Snippet<[Args]>`, a
+  component value with `Component` from `svelte`. `tsconfig.app.json` sets
+  `checkJs: true`, so JavaScript in `.svelte` files is checked too.
 - `import.meta.env.VITE_*` for public configuration — it lands in the bundle, so
   no secrets. `public/` is copied verbatim; imported assets are hashed.
 - A path alias needs `resolve.alias` in `vite.config.ts` *and* `paths` in
@@ -229,10 +189,9 @@ Global styles belong in `src/app.css`, imported once from `main.ts`.
 ## Routing
 
 There is none. If the app needs multiple views, either branch on a piece of
-`$state` or add a small client-side router as a dependency and mount views from
-it. (If the project later moves to SvelteKit, routing, data loading, and server
-rendering come from the framework instead — none of that applies to this
-project as it stands.)
+`$state` or add a small client-side router as a dependency. (If the project ever
+moves to SvelteKit, routing, data loading, and server rendering come from the
+framework instead — none of that applies to this project as it stands.)
 
 ## Common mistakes
 
@@ -243,8 +202,7 @@ project as it stands.)
 - **Svelte 4 syntax.** `export let` for props, `$:` reactive statements,
   `on:click`, `createEventDispatcher`, `<slot />`, `new App({ target })`. All
   superseded; several are hard errors under runes.
-- **A plain `let` expected to be reactive.** Without `$state` it never triggers
-  an update.
+- **A plain `let` expected to be reactive.** Without `$state` nothing updates.
 - **`$effect` used to derive a value.** Use `$derived`.
 - **Destructuring reactive state at module scope.** `const { user } = session`
   copies the value once. Keep the object.
@@ -254,8 +212,7 @@ project as it stands.)
   index, not the item.
 - **A scoped selector targeting a child's markup.** It is stripped as unused;
   use `:global()` or let the child own the style.
-- **Effects with no teardown.** Observers, intervals, and listeners leak on
-  unmount.
+- **Effects with no teardown.** Observers, intervals, and listeners leak.
 - **Binding as a general upward data path.** Use a callback prop unless it is a
   real two-way control.
 
@@ -267,10 +224,10 @@ project as it stands.)
 - Every `$effect` that subscribes, observes, or schedules returns a teardown.
 - Props come from `$props()` with a typed `Props` interface; only genuine
   two-way controls use `$bindable`.
-- Child-to-parent communication is callback props, not dispatched events.
-- Composition uses snippets and `{@render}`, not `<slot>`.
+- Child-to-parent communication is callback props, not dispatched events, and
+  composition uses snippets with `{@render}`, not `<slot>`.
 - `{#each}` over anything reorderable is keyed on a stable id.
-- Shared state lives in a `.svelte.ts` module and is exported as an object or
-  getter, never as a destructured primitive.
+- Shared state lives in a `.svelte.ts` module, exported as an object or getter,
+  never as a destructured primitive.
 - No SvelteKit file names, imports, or page options anywhere.
 - Nothing secret sits behind a `VITE_` variable.

--- a/src/pocketpaw/bundled_skills/_bundled/skills/code-svelte/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/skills/code-svelte/SKILL.md
@@ -1,0 +1,276 @@
+---
+name: code-svelte
+description: |
+  Plain Svelte 5 + Vite + TypeScript projects — components mounted into one
+  page, NOT SvelteKit. Invoke when the work is Svelte: "build a Svelte
+  component", "why isn't my $state updating", "$derived vs $effect", "pass a
+  snippet to a child", "bind a value both ways", "share state between
+  components", "this prop isn't reactive", "add a transition". Covers runes
+  ($state, $derived, $effect, $props, $bindable), snippets and {@render},
+  event props, .svelte.ts state modules, context, attachments, and scoped
+  styling. There is NO SvelteKit in this project: no file-based routing, no
+  load functions, no form actions, no +page/+layout files, no adapters, no
+  $app imports, no server rendering. This is not a dashboard, not a pocket,
+  and it produces no ui-spec.
+---
+
+# Svelte 5 + Vite + TypeScript
+
+A plain Svelte app: one HTML page, one mount call, components all the way down.
+SvelteKit is not installed and none of its conventions exist here.
+
+## What is actually in the project
+
+Scaffolded from `create-vite@8.3.0`, template `template-svelte-ts`:
+
+```
+index.html               <div id="app">
+src/main.ts              mount(App, { target: document.getElementById('app')! })
+src/App.svelte           root component
+src/lib/Counter.svelte   the one child component
+src/app.css              global styles, imported by main.ts
+src/assets/svelte.svg
+public/vite.svg          served at /vite.svg, never processed
+svelte.config.js         { preprocess: vitePreprocess() }
+vite.config.ts           defineConfig({ plugins: [svelte()] })
+tsconfig.app.json        extends @tsconfig/svelte, checkJs on
+tsconfig.node.json
+```
+
+Verified versions: svelte `^5.45.2`, vite `^7.3.1`,
+`@sveltejs/vite-plugin-svelte` `^6.2.1`, `svelte-check` `^4.3.4`,
+typescript `~5.9.3`.
+
+The app is mounted imperatively:
+
+```ts
+import { mount } from 'svelte'
+import App from './App.svelte'
+
+const app = mount(App, { target: document.getElementById('app')! })
+```
+
+`mount()` — not `new App({ target })`. The class-component constructor is the
+Svelte 4 API and throws in Svelte 5 unless legacy compatibility is on.
+
+## Runes
+
+Reactivity is explicit. A plain `let` is a plain variable; declaring it with
+`$state` is what makes assignments reactive.
+
+```svelte
+<script lang="ts">
+  let count = $state(0)
+  let user = $state({ name: 'Ada', tags: ['admin'] })
+
+  const doubled = $derived(count * 2)
+  const summary = $derived.by(() => {
+    const t = user.tags.join(', ')
+    return `${user.name} (${t})`
+  })
+</script>
+```
+
+- **`$state`** — deep by default. Objects and arrays are proxied, so
+  `user.tags.push('owner')` is reactive. `$state.raw` opts out of that for a
+  value you always replace wholesale; `$state.snapshot(x)` produces a plain
+  object to hand to code that dislikes proxies (structured clone, JSON, a
+  third-party library).
+- **`$derived`** — a cached expression. `$derived.by(() => { ... })` when the
+  computation needs statements. It re-evaluates lazily and must stay pure.
+- **`$effect`** — for synchronizing with things outside Svelte: an observer, a
+  timer, a canvas, a subscription. Dependencies are tracked dynamically — it
+  depends on exactly what it read. Return a teardown function.
+  `$effect.pre` fires before the DOM updates.
+- **`$props`** — the component's inputs.
+- **`$bindable`** — marks a prop the parent may bind to.
+- **`$inspect`** — a development-only logger that re-fires when its argument
+  changes deeply.
+
+The rule that prevents most bad Svelte 5: **if you are assigning to state
+inside `$effect`, it should almost certainly have been `$derived`.** Effects
+that write state create ordering puzzles and re-entrancy loops.
+
+## Props
+
+```svelte
+<script lang="ts">
+  interface Props {
+    label: string
+    count?: number
+    onselect?: (id: string) => void
+    children?: import('svelte').Snippet
+  }
+
+  let { label, count = 0, onselect, children, ...rest }: Props = $props()
+</script>
+
+<button {...rest} onclick={() => onselect?.(label)}>
+  {label} — {count}
+  {@render children?.()}
+</button>
+```
+
+Props are read-only unless declared `$bindable`:
+
+```svelte
+<!-- child -->
+<script lang="ts">
+  let { value = $bindable('') }: { value?: string } = $props()
+</script>
+<input bind:value />
+
+<!-- parent -->
+<TextField bind:value={name} />
+```
+
+Prefer callback props over binding. Binding is for genuine two-way form
+controls, not as a general upward channel.
+
+## Events are properties
+
+`onclick`, `oninput`, `onsubmit` — plain attributes taking a function. There is
+no `on:click` directive in Svelte 5, and `createEventDispatcher` is gone. A
+child notifies its parent by calling a function prop.
+
+Modifiers are gone too; write them out:
+
+```svelte
+<form onsubmit={(e) => { e.preventDefault(); save() }}>
+```
+
+## Snippets replace slots
+
+```svelte
+<!-- List.svelte -->
+<script lang="ts">
+  import type { Snippet } from 'svelte'
+  let { items, row }: { items: Item[]; row: Snippet<[Item]> } = $props()
+</script>
+
+<ul>
+  {#each items as item (item.id)}
+    <li>{@render row(item)}</li>
+  {/each}
+</ul>
+
+<!-- caller -->
+<List {items}>
+  {#snippet row(item)}
+    <strong>{item.name}</strong>
+  {/snippet}
+</List>
+```
+
+Content placed directly between a component's tags arrives as the `children`
+snippet. `{@render children?.()}` renders it.
+
+## Shared state lives in `.svelte.ts` modules
+
+Runes work in any file with a `.svelte.ts` (or `.svelte.js`) extension. That is
+how state is shared without a store library:
+
+```ts
+// src/lib/session.svelte.ts
+export const session = $state({ user: null as User | null, loading: false })
+
+export function signOut() {
+  session.user = null
+}
+```
+
+Import `session` anywhere and mutate its properties. Do not export a
+destructured primitive — the binding is copied and the reader never updates.
+Export the object, or export a getter.
+
+The Svelte 4 store contract still works (`writable`, `$store` auto-subscribe)
+and is worth knowing when reading older code, but new code should use runes.
+
+For values scoped to a component subtree, `setContext`/`getContext` from
+`svelte`, called during component initialization only.
+
+## Template features worth using
+
+- `{#each items as item (item.id)}` — the keyed form. Unkeyed `each` reuses DOM
+  nodes positionally and will smear state across rows after an insert.
+- `{#key expr} ... {/key}` — tears down and rebuilds a subtree when `expr`
+  changes. This is the clean way to reset a component.
+- `{#await promise}` / `:then` / `:catch` — inline async without an effect.
+- `class:active={isActive}` and `style:color={c}` directives; `class` also
+  accepts an object or array of conditions.
+- `{@attach fn}` (Svelte 5.29+) — attaches behaviour to an element, replacing
+  `use:action`. The function receives the node, may read reactive state, and may
+  return a teardown.
+- `transition:`, `in:`, `out:`, `animate:` from `svelte/transition` and
+  `svelte/animate`.
+
+## Styling
+
+A `<style>` block in a component is scoped to that component's markup. It does
+not reach child components or dynamically inserted HTML; `:global(.selector)`
+opts a rule out. Unused selectors are stripped at compile time and reported —
+that warning usually means the selector only matches markup a child owns.
+
+Global styles belong in `src/app.css`, imported once from `main.ts`.
+
+## Types and Vite conventions
+
+- Type checking for `.svelte` files comes from `svelte-check`, a devDependency
+  in this template; the plain TypeScript compiler does not understand `.svelte`.
+- Type props with an `interface Props`; type snippets with `Snippet<[Args]>`;
+  type a component value with `Component` from `svelte`.
+- `tsconfig.app.json` sets `checkJs: true`, so JavaScript in `.svelte` files is
+  type-checked too.
+- `import.meta.env.VITE_*` for public configuration — it lands in the bundle, so
+  no secrets. `public/` is copied verbatim; imported assets are hashed.
+- A path alias needs `resolve.alias` in `vite.config.ts` *and* `paths` in
+  `tsconfig.app.json`.
+
+## Routing
+
+There is none. If the app needs multiple views, either branch on a piece of
+`$state` or add a small client-side router as a dependency and mount views from
+it. (If the project later moves to SvelteKit, routing, data loading, and server
+rendering come from the framework instead — none of that applies to this
+project as it stands.)
+
+## Common mistakes
+
+- **Writing SvelteKit.** No `+page.svelte`, no `+layout.svelte`, no `load`
+  function, no form actions, no `$app/navigation`, `$app/stores`, or
+  `$app/environment`, no adapters, no `export const prerender`/`ssr`. Those
+  imports do not resolve and those file names mean nothing here.
+- **Svelte 4 syntax.** `export let` for props, `$:` reactive statements,
+  `on:click`, `createEventDispatcher`, `<slot />`, `new App({ target })`. All
+  superseded; several are hard errors under runes.
+- **A plain `let` expected to be reactive.** Without `$state` it never triggers
+  an update.
+- **`$effect` used to derive a value.** Use `$derived`.
+- **Destructuring reactive state at module scope.** `const { user } = session`
+  copies the value once. Keep the object.
+- **Passing `$state` to an external library and hitting proxy complaints.** Send
+  `$state.snapshot(value)`.
+- **Unkeyed `{#each}` over a list that reorders.** Component state follows the
+  index, not the item.
+- **A scoped selector targeting a child's markup.** It is stripped as unused;
+  use `:global()` or let the child own the style.
+- **Effects with no teardown.** Observers, intervals, and listeners leak on
+  unmount.
+- **Binding as a general upward data path.** Use a callback prop unless it is a
+  real two-way control.
+
+## Review checklist
+
+- Every reactive value is declared with `$state`; every derived value with
+  `$derived` or `$derived.by`.
+- No `$effect` assigns to state that could be derived.
+- Every `$effect` that subscribes, observes, or schedules returns a teardown.
+- Props come from `$props()` with a typed `Props` interface; only genuine
+  two-way controls use `$bindable`.
+- Child-to-parent communication is callback props, not dispatched events.
+- Composition uses snippets and `{@render}`, not `<slot>`.
+- `{#each}` over anything reorderable is keyed on a stable id.
+- Shared state lives in a `.svelte.ts` module and is exported as an object or
+  getter, never as a destructured primitive.
+- No SvelteKit file names, imports, or page options anywhere.
+- Nothing secret sits behind a `VITE_` variable.

--- a/src/pocketpaw/bundled_skills/_bundled/skills/code-vue/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/skills/code-vue/SKILL.md
@@ -153,17 +153,16 @@ export function useOnline() {
 }
 ```
 
-Call composables synchronously at the top of `<script setup>`. Calling one
-inside a callback, a conditional, or after an `await` detaches it from the
-component instance, and its lifecycle hooks silently never fire.
+Call composables synchronously at the top of `<script setup>`. Calling one in a
+callback, a conditional, or after an `await` detaches it from the component
+instance and its lifecycle hooks silently never fire.
 
 ## Slots, provide/inject, ids
 
-- Slots for layout composition: `<slot name="footer" :item="item" />`, consumed
-  as `<template #footer="{ item }">`.
-- `provide`/`inject` for ambient values across depth. Type the key with
-  `InjectionKey<T>` so the injected value is not `unknown`.
-- `useId()` for stable `id`/`aria-describedby` pairs instead of a counter.
+- Slots for composition: `<slot name="footer" :item="item" />`, consumed as
+  `<template #footer="{ item }">`.
+- `provide`/`inject` for ambient values across depth; type the key with
+  `InjectionKey<T>`. `useId()` gives stable `id`/`aria-describedby` pairs.
 
 ## Styling
 
@@ -229,9 +228,9 @@ registered on the app instance before any import of them resolves.
 - Every watcher that starts async work cleans it up with `onWatcherCleanup`.
 - Props are read-only; two-way binding goes through `defineModel` or an emit.
 - Composables are called synchronously at setup top level.
-- `v-for` keys on a stable id, never an index.
-- No `v-if` sharing an element with `v-for`.
+- `v-for` keys on a stable id, never an index, and never shares an element
+  with `v-if`.
 - Injected values are typed with an `InjectionKey`.
 - Type-only imports use `import type`; no `enum`, no parameter properties.
-- No import of a package that is not in `package.json`.
-- Nothing secret sits behind a `VITE_` variable.
+- No import of a package absent from `package.json`, and nothing secret sits
+  behind a `VITE_` variable.

--- a/src/pocketpaw/bundled_skills/_bundled/skills/code-vue/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/skills/code-vue/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: code-vue
+description: |
+  Vue 3 + Vite + TypeScript projects — the flat single-file-component
+  scaffold, with no router and no store bundled. Invoke when the work is
+  Vue: "build a Vue component", "why isn't this ref updating", "v-model on
+  a custom component", "extract a composable", "add a page", "props are
+  losing reactivity", "watch is firing too often", "scoped styles aren't
+  applying". Covers <script setup>, refs vs reactive, computed and watchers,
+  reactive props destructure, defineModel, useTemplateRef, composables,
+  slots, provide/inject, scoped styling, and the strict TypeScript settings
+  this template turns on. Vue Router and Pinia are NOT installed here; this
+  skill frames them as things to add, not things present. This is not a
+  dashboard, not a pocket, and it produces no ui-spec.
+---
+
+# Vue 3 + Vite + TypeScript
+
+Single-file components compiled by Vite, mounted into one page. There is no
+router, no store, no server rendering, and no data layer until one is added.
+
+## What is actually in the project
+
+Scaffolded from `create-vite@8.3.0`, template `template-vue-ts`. This is
+deliberately the flat Vite template, not `create-vue` — which is why nothing
+optional is preinstalled:
+
+```
+index.html               <div id="app">
+src/main.ts              createApp(App).mount('#app')
+src/App.vue              root component
+src/components/HelloWorld.vue
+src/style.css            global styles, imported by main.ts
+public/vite.svg          served at /vite.svg, never processed
+vite.config.ts           defineConfig({ plugins: [vue()] })
+tsconfig.app.json        extends @vue/tsconfig/tsconfig.dom.json
+src/assets/vue.svg · tsconfig.json · tsconfig.node.json
+```
+
+Verified versions: vue `^3.5.25`, vite `^7.3.1`, `@vitejs/plugin-vue` `^6.0.2`,
+`vue-tsc` `^3.1.5`, typescript `~5.9.3`, `@vue/tsconfig` `^0.8.1`.
+
+Vue 3.5 matters for specifics below — reactive props destructure, `useId`,
+`useTemplateRef`, and `onWatcherCleanup` all landed there and are stable.
+
+## Component shape
+
+`<script setup lang="ts">` for everything. Top-level bindings are exposed to
+the template automatically; there is no `return` and no `components:` block —
+an imported component is usable by name.
+
+```vue
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import ItemRow from './ItemRow.vue'
+
+const { items, emptyLabel = 'Nothing yet' } = defineProps<{
+  items: Item[]
+  emptyLabel?: string
+}>()
+
+const query = ref('')
+const visible = computed(() => items.filter((i) => i.name.includes(query.value)))
+</script>
+
+<template>
+  <input v-model="query" />
+  <p v-if="!visible.length">{{ emptyLabel }}</p>
+  <ItemRow v-for="item in visible" :key="item.id" :item="item" />
+</template>
+```
+
+Destructuring `defineProps` keeps reactivity as of 3.5 and a default is plain
+JavaScript syntax — `withDefaults` is gone. The catch: a destructured prop is
+reactive only where the compiler sees it, so handing one to a composable or a
+`watch` source needs a getter (`() => items`).
+
+## Reactivity
+
+- `ref()` for everything by default. `.value` in script, unwrapped in template.
+- `reactive()` only for an object you never reassign. It cannot hold a
+  primitive, and destructuring it severs reactivity permanently.
+- `shallowRef()` for large payloads you always replace wholesale — no deep proxy.
+- `computed()` for derived values: cached, and must stay pure.
+
+```ts
+const state = reactive({ count: 0 })
+const { count } = state       // dead number, never updates
+const count = toRef(state, 'count')  // live
+```
+
+## Watchers
+
+`watch` for a named source, `watchEffect` when the dependencies are obvious
+from the body. Both need `{ flush: 'post' }` to observe the updated DOM.
+Register teardown with `onWatcherCleanup` so a stale request cannot land after
+a newer one:
+
+```ts
+watch(id, async (newId) => {
+  const controller = new AbortController()
+  onWatcherCleanup(() => controller.abort())
+  results.value = await load(newId, controller.signal)
+})
+```
+
+A watcher that only computes a value should have been a `computed`. Watchers
+are for side effects.
+
+## Two-way binding
+
+`defineModel()` replaces the `modelValue` prop plus `update:modelValue` emit:
+
+```vue
+<script setup lang="ts">
+const model = defineModel<string>({ required: true })
+const size = defineModel<'sm' | 'lg'>('size', { default: 'sm' })
+</script>
+
+<template><input v-model="model" /></template>
+```
+
+The parent writes `<TextField v-model="name" v-model:size="size" />`. For
+anything else, `defineEmits<{ submit: [value: string] }>()` and call the emitter.
+
+## Template refs
+
+`useTemplateRef('name')` binds by the string in the template, so it works for
+dynamic and conditional elements:
+
+```vue
+<script setup lang="ts">
+const input = useTemplateRef<HTMLInputElement>('field')
+onMounted(() => input.value?.focus())
+</script>
+
+<template><input ref="field" /></template>
+```
+
+## Composables
+
+A composable is a `useX` function that calls reactive APIs and returns refs —
+the unit of reuse. Extract one when the same state and its watchers appear twice.
+
+```ts
+// src/composables/useOnline.ts
+export function useOnline() {
+  const online = ref(navigator.onLine)
+  const sync = () => (online.value = navigator.onLine)
+  onMounted(() => addEventListener('online', sync))
+  onUnmounted(() => removeEventListener('online', sync))
+  return { online }
+}
+```
+
+Call composables synchronously at the top of `<script setup>`. Calling one
+inside a callback, a conditional, or after an `await` detaches it from the
+component instance, and its lifecycle hooks silently never fire.
+
+## Slots, provide/inject, ids
+
+- Slots for layout composition: `<slot name="footer" :item="item" />`, consumed
+  as `<template #footer="{ item }">`.
+- `provide`/`inject` for ambient values across depth. Type the key with
+  `InjectionKey<T>` so the injected value is not `unknown`.
+- `useId()` for stable `id`/`aria-describedby` pairs instead of a counter.
+
+## Styling
+
+`<style scoped>` rewrites selectors with a data attribute and does not reach
+into a child component — use `:deep(.child-class)` for that, `:global()` to opt
+out entirely, `<style module>` for a `$style` object. `v-bind()` inside a style
+block wires reactive state to a CSS custom property.
+
+## TypeScript settings this template turns on
+
+`tsconfig.app.json` extends `@vue/tsconfig/tsconfig.dom.json` and adds
+`strict`, `noUnusedLocals`, `noUnusedParameters`, `erasableSyntaxOnly`,
+`noFallthroughCasesInSwitch`, `noUncheckedSideEffectImports`.
+
+- `erasableSyntaxOnly` bans `enum`, constructor parameter properties, and
+  namespaces. Use a string-literal union or an `as const` object.
+- Type-only imports need `import type`.
+- Types inside `defineProps<T>()` and `defineEmits<T>()` are compiled, so they
+  can only reference types resolvable in that file.
+- Type checking for `.vue` files comes from `vue-tsc`, a devDependency in this
+  template; the plain TypeScript compiler does not understand SFCs.
+
+## Vite conventions
+
+`import.meta.env.VITE_*` for public configuration — everything exposed is in the
+bundle, so no secrets. Imported assets get hashed; `public/` is copied verbatim.
+A path alias needs both `resolve.alias` in `vite.config.ts` and `paths` in
+`tsconfig.app.json`; one without the other fails in exactly one place.
+
+## What you would add
+
+Neither exists in the project. Both must be added as real dependencies and
+registered on the app instance before any import of them resolves.
+
+- **Routing** — Vue Router. Until it is added there is no `<RouterView>`,
+  `<RouterLink>`, `useRoute`, or `useRouter`; a `v-if` on state is the honest
+  stand-in, and should be named as temporary.
+- **Shared state** — Pinia. For a small app a module exporting a `reactive()`
+  object is often enough and needs nothing added.
+
+## Common mistakes
+
+- **Assuming a router or store is present.** Importing `vue-router` or `pinia`
+  in this project fails to resolve. Say what needs adding first.
+- **Destructuring `reactive()`.** Yields plain values. Use `toRefs`, or keep the
+  object whole.
+- **Forgetting `.value` in script, or writing it in a template.** The template
+  unwraps refs; the script does not.
+- **Mutating a prop.** Props are readonly. Emit, or use `defineModel`.
+- **Passing a destructured prop straight to `watch`.** Pass `() => prop`.
+- **A `watch` that only derives a value.** That is a `computed`.
+- **`v-if` and `v-for` on the same element.** `v-if` wins on precedence and is
+  evaluated before the loop variable exists. Wrap in `<template v-for>`.
+- **Index as `:key`.** Component state binds to the wrong row after a reorder.
+- **Calling a composable after `await`.** It loses the active instance and its
+  lifecycle hooks never fire.
+- **Reading the DOM inside `watch` without `flush: 'post'`.** The DOM is still
+  the previous render.
+
+## Review checklist
+
+- Derived values are `computed`, not watchers writing into refs.
+- Every watcher that starts async work cleans it up with `onWatcherCleanup`.
+- Props are read-only; two-way binding goes through `defineModel` or an emit.
+- Composables are called synchronously at setup top level.
+- `v-for` keys on a stable id, never an index.
+- No `v-if` sharing an element with `v-for`.
+- Injected values are typed with an `InjectionKey`.
+- Type-only imports use `import type`; no `enum`, no parameter properties.
+- No import of a package that is not in `package.json`.
+- Nothing secret sits behind a `VITE_` variable.


### PR DESCRIPTION
Stacked on #1791.

## What

Four bundled skills, one per entry in the `codescaffold` `STARTERS` catalog.

| skill | template |
|---|---|
| `code-react` | React 19 + Vite + TS (`create-vite@8.3.0`, `template-react-ts`) |
| `code-vue` | Vue 3 + Vite + TS (`template-vue-ts`) |
| `code-svelte` | Svelte 5 + Vite + TS (`template-svelte-ts`) |
| `code-next` | Next 15 App Router + TS + Tailwind (`create-next-app@15.5.20`) |

## Why scoped this way

Each skill describes the project the user actually has open, not the framework's wider ecosystem. That distinction is where a generic version of this goes wrong:

- The **svelte** starter is plain Svelte 5, not SvelteKit — `domain.py` explains that `sv` ships a generator manifest rather than a flat template. So `code-svelte` carries no `load` functions, form actions, adapters or `+page` contract, and lists reaching for them as a failure mode. An agent that assumed SvelteKit would go looking for files that aren't there.
- The **react** starter is a Vite SPA, so no Server Components and no App Router. Those live in `code-next` only.
- The **vue** starter comes from the flat `template-vue-ts`, deliberately not `create-vue`, so it has no router and no Pinia. The skill frames both as "what you'd add".
- **`code-next` pins 15.** It also enumerates the Next 16 APIs (`"use cache"`, `proxy.ts`, two-argument `cacheLife`) that will fail on this template.

## No tool vocabulary

The bodies name no tools or commands. The `/code` surface's available tools differ across the in-flight code-mode stack (#1730 → #1778 → …): on `dev` it has the built-ins, and after that stack it has four file tools and denies `Skill` outright. A skill that names tools becomes an instruction to call tools the agent may not have — which is why the previous `code` skill was dropped from the surface profile. Config file *contents* are shown; invocations are not.

## Inert until wired

Nothing references these yet. They ship in the wheel and load only once a surface names them in `skill_names`, which #1791 makes binding. The follow-up that points `/code` at them needs a decision on base branch, since the `/code` profile differs between `dev` and the code-mode stack.

## Checks

Frontmatter parses with exactly `name` + `description`; `name` matches directory; descriptions 753–807 chars against a 1,536 limit. Body sweeps: zero tool/command vocabulary; the scope-check hits are all negations in `Common mistakes` and `Review checklist`. No existing file touched, so no test impact.