### PR TITLE
Never store a regenerable tree in the project store

### DIFF
--- a/ee/pocketpaw_ee/cloud/websandbox/durability.py
+++ b/ee/pocketpaw_ee/cloud/websandbox/durability.py
@@ -15,6 +15,18 @@
 # replays at its new path). ws.py binds them as the FileRpc on_delete / on_move
 # hooks, the delete/rename counterparts of the on_write mirror.
 #
+# Changed 2026-07-25 (fix/codeproject-never-store-generated-trees): the exclusion
+# of the regenerable trees is now enforced on the WRITE side, not just assumed of
+# the callers. It previously lived only in the walks that CHOOSE what to send — the
+# tar ``--exclude`` here and ``listProjectFiles`` in the client — so nothing stopped
+# a caller from naming ``node_modules/...`` directly and putting a regenerable file
+# in the tenant's S3. Both upload entry points now answer to
+# ``_SNAPSHOT_EXCLUDED_SEGMENTS``: ``mirror_file_to_project`` REFUSES (400
+# ``codeproject.path_not_durable``) before spending storage, and
+# ``put_project_files`` SKIPS, because a whole-filesystem write should be normalized
+# rather than rejected. Deletes stay unguarded on purpose — dropping an entry that
+# should never have existed is how an already-polluted store gets cleaned.
+#
 # The Daytona VM is pure scratch and gets reaped (WC-2). Code durability is git
 # (push); this module makes a user's UNCOMMITTED work + workspace state durable
 # by snapshotting the in-VM workspace dir to the tenant's blob storage (S3,
@@ -801,8 +813,26 @@ async def mirror_file_to_project(
     blob storage (folder ``/code-project-overlay``) and records ``rel_path ->
     FileRecord id`` on the durable project via ``set_project_overlay_entry``.
     Returns the FileRecord id. Fails CLOSED on a non-s3 upload adapter in cloud.
+
+    REFUSES a regenerable tree (``node_modules``, ``.git``, build output, caches).
+    This is the ONE upload path both runtimes share, so the guard belongs here: it
+    covers the in-tab write, the VM mirror, and anything added later, in one place.
+    Until this existed the exclusion lived only in the walks that CHOOSE what to
+    send (the client's ``listProjectFiles``, the VM's tar ``--exclude``) — so a
+    caller that named such a path directly, like an editor save on a file the user
+    opened inside ``node_modules``, put a regenerable file in the tenant's S3 and
+    on the project overlay. Loud rather than silent: nothing legitimate asks to
+    durably store a file that ``npm install`` regenerates, so a caller that does
+    has a bug worth surfacing.
     """
     _require_s3_for_project_store()
+    if _is_excluded_snapshot_path(rel_path):
+        raise CloudError(
+            400,
+            "codeproject.path_not_durable",
+            f"{rel_path!r} is inside a regenerable tree "
+            f"({', '.join(sorted(_SNAPSHOT_EXCLUDED_SEGMENTS))}) and is never stored",
+        )
     up = uploads if uploads is not None else build_uploads()
     basename = (rel_path or "file").rsplit("/", 1)[-1] or "file"
     file_id = await _upload_project_blob(
@@ -871,9 +901,25 @@ async def put_project_files(
     file_cap = _file_max_bytes()
     total_cap = _overlay_max_bytes()
     encoded: dict[str, bytes] = {}
+    skipped: list[str] = []
     total = 0
     for raw_path, content in files.items():
         safe_path = _require_safe_rel_path(raw_path)
+        # DROP the regenerable trees instead of refusing the request. Unlike a
+        # single-file write (which names one path and is a bug if that path is
+        # node_modules), this call's contract is "here is my whole filesystem" —
+        # normalizing what the client over-reported is the right server behavior,
+        # and failing the whole write would break saving for a client whose only
+        # sin is a stale filter. Dropped BEFORE the size caps too, so an
+        # over-reported node_modules can't push a legitimate project over a limit.
+        #
+        # Safe for the prune despite `overlay_complete`: the restore-time prune is
+        # built from this same exclusion set, so it never considers these paths and
+        # a store that omits them cannot license deleting an installed
+        # node_modules. See the set's own header.
+        if _is_excluded_snapshot_path(safe_path):
+            skipped.append(safe_path)
+            continue
         data = (content or "").encode("utf-8")
         if len(data) > file_cap:
             raise CloudError(
@@ -889,6 +935,16 @@ async def put_project_files(
                 f"Project exceeds the {total_cap}-byte store limit",
             )
         encoded[safe_path] = data
+
+    if skipped:
+        # Never silent: a client that keeps sending these is a client whose walk is
+        # not filtering, and the count is how anyone finds out.
+        logger.info(
+            "codeproject.put_files: skipped %d regenerable path(s) for project=%s (e.g. %s)",
+            len(skipped),
+            project_id,
+            ", ".join(skipped[:3]),
+        )
 
     up = uploads if uploads is not None else build_uploads()
     overlay: dict[str, str] = {}

--- a/tests/cloud/test_codeproject_excluded_paths.py
+++ b/tests/cloud/test_codeproject_excluded_paths.py
@@ -1,0 +1,160 @@
+# test_codeproject_excluded_paths.py — node_modules never reaches blob storage.
+#
+# Created 2026-07-25 (fix/codeproject-never-store-generated-trees). Before this,
+# the exclusion of the regenerable trees lived ONLY in the enumerating walks: the
+# client's `listProjectFiles` and the VM's tar `--exclude`. Both are the paths that
+# CHOOSE what to send. Nothing on the receiving side enforced it, so any caller
+# that named a `node_modules` path — an editor save on a file the user opened in
+# there, a client that forgot to filter, an older build — got it uploaded to the
+# tenant's S3 and recorded on the project overlay.
+#
+# The rule these lock: the durable project store NEVER holds a regenerable tree,
+# and the guarantee is the SERVER's, not the client's. Two entry points reach blob
+# storage and both are covered:
+#
+#   • `mirror_file_to_project` (every single-file write, both runtimes) REJECTS
+#     before spending a byte of storage. Loud, because a caller naming such a path
+#     is a caller with a bug.
+#   • `put_project_files` (the in-tab bulk write) SKIPS them. Not loud: its
+#     contract is "here is my whole filesystem", so normalizing what the client
+#     over-reported is the correct server behavior, not an error. Safe for the
+#     prune too — the restore-time prune is already blind to excluded paths, so a
+#     store that omits them never licenses deleting an installed node_modules.
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import CloudError
+from pocketpaw_ee.cloud.codeproject import service as codeproject_service
+from pocketpaw_ee.cloud.websandbox import durability
+
+from tests.cloud.test_codeproject_file_sync import _FakeUploads, _project
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+_WS = "w1"
+_USER = "u1"
+
+# One representative per reason the tree is excluded: installed dependencies,
+# version-control internals, build output, framework and tool caches.
+_EXCLUDED_WRITES = [
+    "node_modules/left-pad/index.js",
+    "node_modules/.package-lock.json",
+    "packages/app/node_modules/dep/index.js",
+    ".git/HEAD",
+    "dist/bundle.js",
+    "build/main.css",
+    ".next/server/app.js",
+    ".svelte-kit/generated/root.js",
+    ".turbo/cache/x",
+    ".cache/deps/y",
+    "coverage/lcov.info",
+]
+
+
+# ── single-file writes reject, and spend nothing ─────────────────────────────
+
+
+@pytest.mark.parametrize("rel_path", _EXCLUDED_WRITES)
+async def test_a_single_file_write_to_a_generated_tree_is_refused(rel_path: str) -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+
+    with pytest.raises(CloudError) as excinfo:
+        await durability.put_project_file(
+            _WS, _USER, project.id, rel_path, "regenerable", uploads=uploads
+        )
+
+    assert excinfo.value.code == "codeproject.path_not_durable"
+    # THE POINT: refused BEFORE the upload, so no byte of the tenant's storage was
+    # spent and no overlay pointer was recorded.
+    assert uploads.upload_calls == []
+    view = await codeproject_service.get_project(_WS, _USER, project.id)
+    assert view.overlay == {}
+
+
+async def test_the_deep_mirror_chokepoint_refuses_too() -> None:
+    """`mirror_file_to_project` is the ONE upload path both runtimes share, so the
+    guard belongs there and not only at the wire boundary above it."""
+    project = await _project()
+    uploads = _FakeUploads()
+
+    with pytest.raises(CloudError) as excinfo:
+        await durability.mirror_file_to_project(
+            _WS, _USER, project.id, "node_modules/dep/index.js", b"bytes", uploads=uploads
+        )
+
+    assert excinfo.value.code == "codeproject.path_not_durable"
+    assert uploads.upload_calls == []
+
+
+async def test_a_source_file_whose_NAME_collides_is_still_stored() -> None:
+    """SEGMENT, not substring. `build/` is regenerable output; `build.ts` is source
+    and must still persist, or this guard eats real work."""
+    project = await _project()
+    uploads = _FakeUploads()
+
+    for rel_path in ("build.ts", "src/dist.ts", "coverage.md", "src/node_modules.md"):
+        await durability.put_project_file(
+            _WS, _USER, project.id, rel_path, "real source", uploads=uploads
+        )
+
+    view = await codeproject_service.get_project(_WS, _USER, project.id)
+    assert set(view.overlay) == {"build.ts", "src/dist.ts", "coverage.md", "src/node_modules.md"}
+
+
+# ── the bulk write normalizes instead of failing ─────────────────────────────
+
+
+async def test_a_bulk_write_skips_generated_trees_and_keeps_the_rest() -> None:
+    project = await _project()
+    uploads = _FakeUploads()
+
+    stored = await durability.put_project_files(
+        _WS,
+        _USER,
+        project.id,
+        {
+            "src/App.tsx": "export default App;",
+            "package.json": "{}",
+            "node_modules/left-pad/index.js": "module.exports = pad;",
+            "dist/bundle.js": "minified",
+            ".git/HEAD": "ref: refs/heads/main",
+        },
+        uploads=uploads,
+    )
+
+    assert stored == 2
+    view = await codeproject_service.get_project(_WS, _USER, project.id)
+    assert set(view.overlay) == {"src/App.tsx", "package.json"}
+    # Still a COMPLETE store: the prune is blind to excluded paths, so omitting
+    # them cannot license deleting an installed node_modules.
+    assert view.overlay_complete is True
+    assert len(uploads.upload_calls) == 2
+
+
+async def test_a_bulk_write_of_nothing_but_generated_trees_stores_nothing() -> None:
+    """The degenerate case: a client that sent only noise leaves an empty store
+    rather than an error, and still spends no storage."""
+    project = await _project()
+    uploads = _FakeUploads()
+
+    stored = await durability.put_project_files(
+        _WS,
+        _USER,
+        project.id,
+        {"node_modules/a/index.js": "x", "dist/b.js": "y"},
+        uploads=uploads,
+    )
+
+    assert stored == 0
+    assert uploads.upload_calls == []
+    view = await codeproject_service.get_project(_WS, _USER, project.id)
+    assert view.overlay == {}
+
+
+async def test_the_excluded_set_is_the_snapshot_set() -> None:
+    """One definition of "regenerable", not two. The guard reuses the set the
+    snapshot/prune already answers to, so the two cannot drift apart."""
+    assert durability._is_excluded_snapshot_path("node_modules/x")
+    assert not durability._is_excluded_snapshot_path("src/build.ts")
+    assert "node_modules" in durability._SNAPSHOT_EXCLUDED_SEGMENTS

--- a/tests/cloud/test_codeproject_s3_authoritative.py
+++ b/tests/cloud/test_codeproject_s3_authoritative.py
@@ -488,15 +488,20 @@ async def test_sync_keeps_entries_it_could_not_have_seen() -> None:
     """
     project = await _project()
     uploads = _FakeUploads()
-    await durability.mirror_file_to_project(
-        _WS, _USER, project.id, "dist/hand-edited.js", b"EDITED", uploads=uploads
+    # Planted through the overlay BOOKKEEPING call rather than through a write:
+    # since fix/codeproject-never-store-generated-trees the write path refuses an
+    # excluded path outright, so a write can no longer create one of these. An entry
+    # like this can still be PRESENT — a store written before that guard has them —
+    # and surviving the prune is exactly what this test is about.
+    await codeproject_service.set_project_overlay_entry(
+        _WS, _USER, project.id, "dist/hand-edited.js", "file-legacy"
     )
 
     overlay = await durability.sync_project_files(
         _WS, _USER, project.id, _VM, client=_FakeVm({"a.ts": b"A"}), uploads=uploads
     )
 
-    assert overlay == {"a.ts": "file-2", "dist/hand-edited.js": "file-1"}
+    assert overlay == {"a.ts": "file-1", "dist/hand-edited.js": "file-legacy"}
 
 
 async def test_an_in_tab_project_is_never_pruned() -> None:


### PR DESCRIPTION
Ports the one commit from `feat/code-s3-authoritative` that `dev` is actually missing. **Do not merge that branch** — see below.

## What

`websandbox/durability.py` stops persisting regenerable directories into the project store, plus the tests that pin it.

```
ee/pocketpaw_ee/cloud/websandbox/durability.py    +56
tests/cloud/test_codeproject_excluded_paths.py   +160  (new)
tests/cloud/test_codeproject_s3_authoritative.py  +11 -3
```

## Why a port instead of merging the branch

`feat/code-s3-authoritative` is stale. Its 15 commits look unmerged by commit list, but the work already reached `dev` through #1778's squash — `test_codeproject_s3_authoritative.py`, `test_codeproject_cross_runtime.py`, `test_codeproject_durability.py`, `test_codeproject_daytona_anchor.py`, `test_codeproject_file_sync.py`, `test_codeproject_bulk_files.py` and `test_codeproject_scaffold_open.py` are all present there.

A tree comparison against `dev` (rather than a 3-dot diff, which lies on a branch this old) shows merging it would **revert** work that landed after it forked:

| would be lost | |
|---|---|
| `sites/import_service.py` | −742 |
| `sites/url_crawler.py` | −769 |
| `claude_sdk.py` | −131 (NUL guard #1790 + skill_names gate #1791) |
| `skills/code-{next,react,svelte,vue}/SKILL.md` | −236 each (#1793) |
| `skills/materialize.py` | −63 |
| `tests/test_claude_sdk_nul_guard.py` | −172 |
| `tests/ee/sites/test_import*.py` | −1,037 |

Net: 232 insertions against 4,507 deletions. The only content genuinely absent from `dev` is the commit ported here.

## Testing

`tests/cloud/test_codeproject_excluded_paths.py tests/cloud/test_codeproject_s3_authoritative.py` — 34 passed.

## Follow-up

`feat/code-s3-authoritative` can be deleted once this lands. It carries nothing else `dev` needs.