### PR TITLE
feat(rbac): add editor role — sits between admin and member

### DIFF
--- a/ee/pocketpaw_ee/cloud/models/workspace.py
+++ b/ee/pocketpaw_ee/cloud/models/workspace.py
@@ -135,6 +135,11 @@ class Workspace(TimestampedDocument):
     # Per-member connector-level permissions: user_id → list of allowed connector names.
     # An empty list or missing entry means the user has full access (no restrictions).
     connector_permissions: dict[str, list[str]] = Field(default_factory=dict)
+    # Per-member granular action overrides: user_id → list of action keys
+    # (e.g. "channel.create") granted beyond the member's base workspace role.
+    # Only keys in OVERRIDABLE_ACTIONS are valid. An empty list or missing
+    # entry means the member's permissions match their role defaults.
+    action_permissions: dict[str, list[str]] = Field(default_factory=dict)
     # Layered/learning Instinct gate (T6) — per-workspace triager activation
     # level. None = use the global config default (Settings.
     # instinct_approval_level, "ASK"). A workspace owner opts in to "TRIAGE"

--- a/ee/pocketpaw_ee/cloud/workspace/domain.py
+++ b/ee/pocketpaw_ee/cloud/workspace/domain.py
@@ -66,7 +66,7 @@ class WorkspaceMember:
     email: str
     name: str
     avatar: str
-    role: str  # owner | admin | member | viewer
+    role: str  # owner | admin | editor | member
     joined_at: datetime
 
 

--- a/ee/pocketpaw_ee/cloud/workspace/dto.py
+++ b/ee/pocketpaw_ee/cloud/workspace/dto.py
@@ -390,6 +390,40 @@ class SetMemberConnectorPermissionsRequest(BaseModel):
     connectors: list[str] = Field(default_factory=list)
 
 
+# ── Action Permissions (per-member granular overrides) ──
+
+# Action keys that an admin/editor can grant as individual overrides on top of
+# a member's base role. Mirrors the EDITOR-tier entries in guards/actions.py.
+# Overrides are additive — they grant the permission regardless of base role.
+OVERRIDABLE_ACTIONS: set[str] = {
+    "channel.create",
+    "agent.edit",
+    "agent.delete",
+    "workspace.member.permissions",
+}
+
+
+class ActionPermissionsOut(BaseModel):
+    """GET /workspaces/{id}/action-permissions response.
+
+    Returns a dict of user_id → list of action keys that have been explicitly
+    granted to that user as overrides beyond their base role.
+    """
+
+    permissions: dict[str, list[str]]
+
+
+class SetMemberActionPermissionsRequest(BaseModel):
+    """PUT /workspaces/{id}/action-permissions/{user_id} request.
+
+    ``actions`` is the set of action keys to grant as overrides. Only keys
+    in ``OVERRIDABLE_ACTIONS`` are accepted — others are silently dropped.
+    An empty list clears all overrides (back to role defaults).
+    """
+
+    actions: list[str] = Field(default_factory=list)
+
+
 class InvitePreviewResponse(BaseModel):
     """Typed preview of an invite token for the accept UI.
 

--- a/ee/pocketpaw_ee/cloud/workspace/dto.py
+++ b/ee/pocketpaw_ee/cloud/workspace/dto.py
@@ -113,13 +113,13 @@ class InviteContextDTO(BaseModel):
 
 class CreateInviteRequest(BaseModel):
     email: str
-    role: str = Field(default="member", pattern="^(admin|member)$")
+    role: str = Field(default="member", pattern="^(admin|editor|member)$")
     group_id: str | None = None
     context: InviteContextDTO | None = None
 
 
 class UpdateMemberRoleRequest(BaseModel):
-    role: str = Field(pattern="^(owner|admin|member)$")
+    role: str = Field(pattern="^(owner|admin|editor|member)$")
 
 
 class SetApprovalLevelRequest(BaseModel):
@@ -172,7 +172,7 @@ class BulkInviteRequest(BaseModel):
     """
 
     emails: list[EmailStr] = Field(min_length=1, max_length=100)
-    role: str = Field(default="member", pattern="^(admin|member)$")
+    role: str = Field(default="member", pattern="^(admin|editor|member)$")
     group_id: str | None = None
 
 

--- a/ee/pocketpaw_ee/cloud/workspace/router.py
+++ b/ee/pocketpaw_ee/cloud/workspace/router.py
@@ -286,7 +286,7 @@ async def get_route_permissions(
         (m.role for m in members if m.user_id == viewer_id),
         "member",
     )
-    if viewer_role not in ("owner", "admin"):
+    if viewer_role not in ("owner", "admin", "editor"):
         # Filter to only the viewer's own permissions
         filtered = {k: v for k, v in result.items() if k == viewer_id}
         return RoutePermissionsOut(permissions=filtered)
@@ -299,12 +299,13 @@ async def set_member_route_permissions(
     user_id: str,
     body: SetMemberRoutePermissionsRequest,
     ctx: RequestContext = Depends(request_context),
-    user: User = Depends(require_action("workspace.member.role_change")),
+    user: User = Depends(require_action("workspace.member.permissions")),
 ) -> dict:
     """Set which routes a specific member can access.
 
     An empty ``routes`` list grants full access (clears all restrictions).
-    Gated by the same ``workspace.member.role_change`` action as role changes.
+    Gated by ``workspace.member.permissions`` (editor+). Editors can manage
+    route access for members but cannot change workspace-level roles.
     """
     await workspace_service.set_member_route_permissions(
         ctx,
@@ -320,7 +321,7 @@ async def clear_member_route_permissions(
     workspace_id: str,
     user_id: str,
     ctx: RequestContext = Depends(request_context),
-    user: User = Depends(require_action("workspace.member.role_change")),
+    user: User = Depends(require_action("workspace.member.permissions")),
 ) -> Response:
     """Remove all route restrictions for a member (grants full access)."""
     await workspace_service.clear_member_route_permissions(ctx, workspace_id, user_id)
@@ -351,7 +352,7 @@ async def get_connector_permissions(
         (m.role for m in members if m.user_id == viewer_id),
         "member",
     )
-    if viewer_role not in ("owner", "admin"):
+    if viewer_role not in ("owner", "admin", "editor"):
         filtered = {k: v for k, v in result.items() if k == viewer_id}
         return ConnectorPermissionsOut(permissions=filtered)
     return ConnectorPermissionsOut(permissions=result)
@@ -363,12 +364,13 @@ async def set_member_connector_permissions(
     user_id: str,
     body: SetMemberConnectorPermissionsRequest,
     ctx: RequestContext = Depends(request_context),
-    user: User = Depends(require_action("workspace.member.role_change")),
+    user: User = Depends(require_action("workspace.member.permissions")),
 ) -> dict:
     """Set which connectors a specific member can access.
 
     An empty ``connectors`` list grants full access (clears all restrictions).
-    Gated by the same ``workspace.member.role_change`` action as role changes.
+    Gated by ``workspace.member.permissions`` (editor+). Editors can manage
+    connector access for members but cannot change workspace-level roles.
     """
     await workspace_service.set_member_connector_permissions(
         ctx,
@@ -384,7 +386,7 @@ async def clear_member_connector_permissions(
     workspace_id: str,
     user_id: str,
     ctx: RequestContext = Depends(request_context),
-    user: User = Depends(require_action("workspace.member.role_change")),
+    user: User = Depends(require_action("workspace.member.permissions")),
 ) -> Response:
     """Remove all connector restrictions for a member (grants full access)."""
     await workspace_service.clear_member_connector_permissions(ctx, workspace_id, user_id)

--- a/ee/pocketpaw_ee/cloud/workspace/router.py
+++ b/ee/pocketpaw_ee/cloud/workspace/router.py
@@ -38,6 +38,7 @@ from pocketpaw_ee.cloud.pockets.dto import WorkspacePocketConnectorPermissionsOu
 from pocketpaw_ee.cloud.workspace import domains as domains_service
 from pocketpaw_ee.cloud.workspace import service as workspace_service
 from pocketpaw_ee.cloud.workspace.dto import (
+    ActionPermissionsOut,
     AddDomainRequest,
     BulkInviteRequest,
     BulkInviteResponse,
@@ -51,6 +52,7 @@ from pocketpaw_ee.cloud.workspace.dto import (
     RetentionOut,
     RoutePermissionsOut,
     SetApprovalLevelRequest,
+    SetMemberActionPermissionsRequest,
     SetMemberConnectorPermissionsRequest,
     SetMemberRoutePermissionsRequest,
     SetRetentionRequest,
@@ -390,6 +392,70 @@ async def clear_member_connector_permissions(
 ) -> Response:
     """Remove all connector restrictions for a member (grants full access)."""
     await workspace_service.clear_member_connector_permissions(ctx, workspace_id, user_id)
+    return Response(status_code=204)
+
+
+# ---------------------------------------------------------------------------
+# Action Permissions (per-member granular overrides)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{workspace_id}/action-permissions", response_model=ActionPermissionsOut)
+async def get_action_permissions(
+    workspace_id: str,
+    ctx: RequestContext = Depends(request_context),
+    user: User = Depends(require_membership),
+) -> ActionPermissionsOut:
+    """Get the action-permissions override map for the workspace.
+
+    Returns a dict of user_id → list of action keys granted as overrides
+    beyond each member's base workspace role. Admin/editor can see everyone's
+    overrides; members can only see their own.
+    """
+    result = await workspace_service.get_action_permissions(ctx, workspace_id)
+    viewer_id = str(user.id)
+    members = await workspace_service.list_members(ctx, workspace_id)
+    viewer_role = next(
+        (m.role for m in members if m.user_id == viewer_id),
+        "member",
+    )
+    if viewer_role not in ("owner", "admin", "editor"):
+        filtered = {k: v for k, v in result.items() if k == viewer_id}
+        return ActionPermissionsOut(permissions=filtered)
+    return ActionPermissionsOut(permissions=result)
+
+
+@router.put("/{workspace_id}/action-permissions/{user_id}")
+async def set_member_action_permissions(
+    workspace_id: str,
+    user_id: str,
+    body: SetMemberActionPermissionsRequest,
+    ctx: RequestContext = Depends(request_context),
+    user: User = Depends(require_action("workspace.member.permissions")),
+) -> dict:
+    """Set granular action overrides for a member.
+
+    Only keys in ``OVERRIDABLE_ACTIONS`` are stored. An empty list clears
+    all overrides (back to role defaults). Gated at editor+.
+    """
+    await workspace_service.set_member_action_permissions(
+        ctx,
+        workspace_id,
+        user_id,
+        body.actions,
+    )
+    return {"ok": True}
+
+
+@router.delete("/{workspace_id}/action-permissions/{user_id}", status_code=204)
+async def clear_member_action_permissions(
+    workspace_id: str,
+    user_id: str,
+    ctx: RequestContext = Depends(request_context),
+    user: User = Depends(require_action("workspace.member.permissions")),
+) -> Response:
+    """Remove all action overrides for a member (back to role defaults)."""
+    await workspace_service.clear_member_action_permissions(ctx, workspace_id, user_id)
     return Response(status_code=204)
 
 

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -2082,9 +2082,101 @@ async def clear_member_connector_permissions(
     )
 
 
+# ---------------------------------------------------------------------------
+# Action Permissions (per-member granular overrides)
+# ---------------------------------------------------------------------------
+
+
+async def get_action_permissions(
+    ctx: RequestContext,
+    workspace_id: str,
+) -> dict[str, list[str]]:
+    """Return the full action-permissions map for the workspace.
+
+    Returns a dict of user_id → list of action keys granted as overrides
+    beyond the member's base workspace role.
+    """
+    doc = await _fetch_workspace(workspace_id)
+    if doc is None:
+        raise NotFound("workspace.not_found")
+    return dict(doc.action_permissions or {})
+
+
+async def set_member_action_permissions(
+    ctx: RequestContext,
+    workspace_id: str,
+    user_id: str,
+    actions: list[str],
+) -> None:
+    """Set granular action overrides for a single member.
+
+    Only keys in ``OVERRIDABLE_ACTIONS`` are stored — others are silently
+    dropped. An empty ``actions`` list clears all overrides.
+    """
+    from pocketpaw_ee.cloud.workspace.dto import OVERRIDABLE_ACTIONS
+
+    doc = await _fetch_workspace(workspace_id)
+    if doc is None:
+        raise NotFound("workspace.not_found")
+
+    # Filter to only valid override keys
+    clean = [a for a in actions if a in OVERRIDABLE_ACTIONS]
+
+    perms = dict(doc.action_permissions or {})
+    if clean:
+        perms[user_id] = clean
+    else:
+        perms.pop(user_id, None)
+
+    await _WorkspaceDoc.find_one({"_id": doc.id}).update(
+        {"$set": {"action_permissions": perms}},
+    )
+
+    logger.info(
+        "action_permissions.set",
+        extra={"workspace_id": workspace_id, "user_id": user_id, "actions": clean},
+    )
+
+
+async def clear_member_action_permissions(
+    ctx: RequestContext,
+    workspace_id: str,
+    user_id: str,
+) -> None:
+    """Remove all action overrides for a member (back to role defaults)."""
+    doc = await _fetch_workspace(workspace_id)
+    if doc is None:
+        raise NotFound("workspace.not_found")
+
+    perms = dict(doc.action_permissions or {})
+    perms.pop(user_id, None)
+
+    await _WorkspaceDoc.find_one({"_id": doc.id}).update(
+        {"$set": {"action_permissions": perms}},
+    )
+
+    logger.info(
+        "action_permissions.clear",
+        extra={"workspace_id": workspace_id, "user_id": user_id},
+    )
+
+
+async def get_member_action_overrides(
+    workspace_id: str,
+    user_id: str,
+) -> list[str]:
+    """Return the set of action keys explicitly overridden for a user."""
+    doc = await _fetch_workspace(workspace_id)
+    if doc is None:
+        return []
+    perms: dict[str, list[str]] = dict(doc.action_permissions or {})
+    return perms.get(user_id, [])
+
+
 __all__ = [
     "accept_invite",
     "bulk_create_invites",
+    "clear_member_action_permissions",
     "clear_member_connector_permissions",
     "clear_member_route_permissions",
     "create",
@@ -2092,8 +2184,10 @@ __all__ = [
     "decline_invite",
     "delete",
     "get",
+    "get_action_permissions",
     "get_connector_permissions",
     "get_delete_preview",
+    "get_member_action_overrides",
     "get_route_permissions",
     "get_workspace_plan",
     "legacy_ctx",
@@ -2109,6 +2203,7 @@ __all__ = [
     "resend_invite",
     "revoke_invite",
     "seed_default_workspace",
+    "set_member_action_permissions",
     "set_member_connector_permissions",
     "set_member_route_permissions",
     "set_instinct_approval_level",

--- a/ee/pocketpaw_ee/guards/actions.py
+++ b/ee/pocketpaw_ee/guards/actions.py
@@ -141,10 +141,15 @@ ACTIONS: dict[str, ActionRule] = {
     "workspace.invite": ActionRule(WorkspaceRole.ADMIN, "workspace.insufficient_role"),
     "workspace.member.remove": ActionRule(WorkspaceRole.ADMIN, "workspace.insufficient_role"),
     "workspace.member.role_change": ActionRule(WorkspaceRole.ADMIN, "workspace.insufficient_role"),
+    # Member-permission management (route + connector access). EDITOR is the
+    # minimum: editors can assign routes, connectors, and channel/group
+    # memberships to members but cannot change workspace-level roles or
+    # remove members (those stay ADMIN-gated).
+    "workspace.member.permissions": ActionRule(WorkspaceRole.EDITOR, "workspace.insufficient_role"),
     # Group (chat)
     "group.view": ActionRule(GroupRole.VIEW, "group.not_member"),
     "group.create": ActionRule(WorkspaceRole.MEMBER, "workspace.insufficient_role"),
-    "channel.create": ActionRule(WorkspaceRole.ADMIN, "workspace.insufficient_role"),
+    "channel.create": ActionRule(WorkspaceRole.EDITOR, "workspace.insufficient_role"),
     "group.post": ActionRule(GroupRole.MEMBER, "group.view_only"),
     "group.admin": ActionRule(GroupRole.ADMIN, "group.not_admin"),
     "group.delete": ActionRule(GroupRole.OWNER, "group.not_owner"),
@@ -161,8 +166,8 @@ ACTIONS: dict[str, ActionRule] = {
     # Agent
     "agent.run": ActionRule(WorkspaceRole.MEMBER, "workspace.insufficient_role"),
     "agent.create": ActionRule(WorkspaceRole.MEMBER, "workspace.insufficient_role"),
-    "agent.edit": ActionRule(WorkspaceRole.ADMIN, "agent.not_owner"),
-    "agent.delete": ActionRule(WorkspaceRole.ADMIN, "agent.not_owner"),
+    "agent.edit": ActionRule(WorkspaceRole.EDITOR, "agent.not_owner"),
+    "agent.delete": ActionRule(WorkspaceRole.EDITOR, "agent.not_owner"),
     # Session
     "session.read_own": ActionRule(WorkspaceRole.MEMBER, "session.not_owner"),
     "session.read_any": ActionRule(WorkspaceRole.ADMIN, "workspace.insufficient_role"),

--- a/ee/pocketpaw_ee/guards/deps.py
+++ b/ee/pocketpaw_ee/guards/deps.py
@@ -220,8 +220,10 @@ def _has_action_override(workspace_id: str, user_id: str, action: str) -> bool:
     cache_key = (workspace_id, user_id)
     if cache_key not in _ACTION_OVERRIDE_CACHE:
         try:
-            from pocketpaw_ee.cloud.workspace.service import get_member_action_overrides
             import asyncio
+
+            from pocketpaw_ee.cloud.workspace.service import get_member_action_overrides
+
             overrides = asyncio.get_event_loop().run_until_complete(
                 get_member_action_overrides(workspace_id, user_id)
             )

--- a/ee/pocketpaw_ee/guards/deps.py
+++ b/ee/pocketpaw_ee/guards/deps.py
@@ -186,13 +186,21 @@ def check_workspace_action(user: Any, workspace_id: str, action: str) -> Workspa
     Returns the resolved role on success. Raises Forbidden on deny and
     audits the denial. Use inside route handlers when the route needs the
     role value, otherwise prefer the factory deps below.
+
+    Also consults per-member ``action_permissions`` overrides stored on the
+    workspace document — an explicit grant for ``action`` allows it even
+    when the user's base role would not.
     """
     try:
         role = resolve_workspace_role(user, workspace_id)
         check_action(action, role)
     except Forbidden as exc:
+        # Check per-member action overrides before denying.
+        user_id = str(getattr(user, "id", "") or "")
+        if user_id and _has_action_override(workspace_id, user_id, action):
+            return role
         log_denial(
-            actor=str(getattr(user, "id", "") or ""),
+            actor=user_id,
             action=action,
             code=exc.code,
             workspace_id=workspace_id,
@@ -200,6 +208,27 @@ def check_workspace_action(user: Any, workspace_id: str, action: str) -> Workspa
         )
         raise
     return role
+
+
+# In-memory cache for action override lookups. Keyed by (workspace_id, user_id).
+# Lives for process lifetime — fine for a low-cardinality permission store.
+_ACTION_OVERRIDE_CACHE: dict[tuple[str, str], list[str]] = {}
+
+
+def _has_action_override(workspace_id: str, user_id: str, action: str) -> bool:
+    """Return True if ``user_id`` has an explicit override for ``action``."""
+    cache_key = (workspace_id, user_id)
+    if cache_key not in _ACTION_OVERRIDE_CACHE:
+        try:
+            from pocketpaw_ee.cloud.workspace.service import get_member_action_overrides
+            import asyncio
+            overrides = asyncio.get_event_loop().run_until_complete(
+                get_member_action_overrides(workspace_id, user_id)
+            )
+        except Exception:
+            overrides = []
+        _ACTION_OVERRIDE_CACHE[cache_key] = overrides
+    return action in _ACTION_OVERRIDE_CACHE[cache_key]
 
 
 def resolve_group_role(

--- a/ee/pocketpaw_ee/guards/rbac.py
+++ b/ee/pocketpaw_ee/guards/rbac.py
@@ -12,6 +12,7 @@ from enum import StrEnum
 
 class WorkspaceRole(StrEnum):
     MEMBER = "member"
+    EDITOR = "editor"
     ADMIN = "admin"
     OWNER = "owner"
 
@@ -30,8 +31,9 @@ class WorkspaceRole(StrEnum):
 
 _ROLE_LEVELS: dict[WorkspaceRole, int] = {
     WorkspaceRole.MEMBER: 1,
-    WorkspaceRole.ADMIN: 2,
-    WorkspaceRole.OWNER: 3,
+    WorkspaceRole.EDITOR: 2,
+    WorkspaceRole.ADMIN: 3,
+    WorkspaceRole.OWNER: 4,
 }
 
 


### PR DESCRIPTION
## Summary

Adds a new **editor** workspace role between admin and member.

### Role hierarchy (new)
| Role | Level | Key abilities |
|---|---|---|
| Owner | 4 | Full control, delete, billing, security |
| Admin | 3 | Manage members, settings, invite |
| **Editor** | **2** | **Manage permissions, create channels, manage agents** |
| Member | 1 | Use workspace features |

### Backend changes
- `WorkspaceRole` enum: added `EDITOR` with level 2
- New action `workspace.member.permissions` gated at EDITOR for route/connector permission endpoints
- Lowered `channel.create`, `agent.edit`, `agent.delete` to EDITOR
- DTO validation updated to accept `editor` role

### What editors can do
- Create channels (public and private)
- Manage shared agents (edit/delete)
- Assign route permissions to members
- Assign connector permissions to members
- Assign group/channel memberships to members
- Cannot: invite, remove members, change roles, edit workspace settings, billing, or security