### PR TITLE
Give the concierge something to know, and both sides of the conversation

### DIFF
--- a/docs/concepts/concierge-knowledge.mdx
+++ b/docs/concepts/concierge-knowledge.mdx
@@ -1,0 +1,109 @@
+---
+title: "Concierge Knowledge and Transcripts"
+description: "What a site's concierge knows, where that knowledge comes from, and what it records about the visitors it talks to."
+section: Core Concepts
+ogType: article
+keywords: ["concierge", "paw bar", "site knowledge", "kb sync", "visitor transcripts", "retention"]
+tags: ["paw-bar", "sites", "knowledge", "privacy"]
+---
+
+# Concierge Knowledge and Transcripts
+
+A Paw Bar concierge is an agent attached to a published site. It answers visitors'
+questions about that specific business, so two things decide whether it is any good:
+what it is allowed to know, and what it writes down about the people it talks to.
+
+## What a concierge is allowed to know
+
+A concierge run is locked to **one** knowledge scope: `pocket:<pocket_id>`, the
+pocket its site was published from. It cannot read the `agent:` scope or the
+workspace-wide scope. That is deliberate. The concierge answers anonymous callers
+from the public internet, and a public caller must never be able to reach the rest
+of the tenant's knowledge base by asking the right question.
+
+The upshot is that a concierge's usefulness is decided entirely by what is in that
+one scope.
+
+## Where the knowledge comes from
+
+The site's own pages are synced into that scope automatically.
+
+The content is read from the **pocket**, not from the built artifact and not by
+fetching the live site. The pocket is durable, so a sync works long after a publish
+has finished; and reading it needs no network, so there is no server-side fetch of a
+customer-controlled hostname to harden against.
+
+Each authoring engine is read the way it stores content:
+
+| Engine | Source | What is extracted |
+|---|---|---|
+| `html` | the source map | page title, body copy, image alt text; scripts and styles dropped |
+| `svelte` | the source map | prose from the markup; script and style blocks and template expressions dropped |
+| `ripple` | the rippleSpec | copy from the spec, skipping structural keys; price-like numbers are rendered with their key so they stay searchable |
+
+Pages that extract to almost nothing (an empty layout, a redirect stub) are skipped
+rather than indexed, and a very large site is truncated rather than allowed to turn
+one publish into an unbounded run of article compilations.
+
+### When it runs
+
+- **On publish.** The site's content just changed, so what the concierge can quote
+  is stale. Runs in the background: the site goes live immediately and the
+  concierge catches up.
+- **On dedicated-agent provisioning.** This is the catch-up path for a site that was
+  published before it had a concierge.
+- **On demand**, via `POST /paw-bar/admin/site/{site_id}/knowledge/sync`. This one is
+  awaited and returns its counts, because an owner pressed a button and wants the
+  result. It gates on `paw_bar.manage` rather than the read action, since it is a
+  mutation that spends compute.
+
+A **preview** publish deliberately does not sync. A draft the owner has not approved
+must not become something the concierge quotes to visitors.
+
+`GET /paw-bar/admin/site/{site_id}/knowledge` reports how many articles the concierge
+can currently quote, when the last sync ran, and a status: empty for a clean sync,
+otherwise `never_synced`, `no_content`, `pocket_unavailable` or `sync_failed`.
+
+### Re-syncing is safe
+
+Article sources are deterministic, so re-ingesting a page updates that article rather
+than adding a second copy of it. The site records which articles it produced, and a
+later sync removes the ones it has stopped producing, which is how a renamed or
+deleted page stops being quotable.
+
+A sync never clears the scope. Owner-uploaded files live in the same pocket scope and
+must survive; only articles the sync is certain it wrote are ever removed.
+
+### What is not covered
+
+A concierge embedded on a site PocketPaw does not host has no content in its pocket,
+so it syncs zero documents and reports `no_content`. Grounding one of those means
+crawling the customer's own origin through the SSRF-hardened import crawler, and is
+not part of this path.
+
+## What a concierge records
+
+The agent's replies have always been durable. The visitor's own messages are stored
+too, on the run document, which is what makes an owner's transcript a conversation
+rather than a monologue. A concierge visitor is anonymous and has no thread, so
+there is no message record for them anywhere else.
+
+This is personal data. A visitor types free text, so a stored line can carry a name,
+an email address, or an order number. Each site therefore has its own switch:
+
+- `concierge_store_transcripts` (default **on**) is readable and writable through
+  `GET`/`PATCH /paw-bar/admin/site/{site_id}/settings`.
+- With it **off**, the concierge keeps working and keeps storing its own replies.
+  Only the visitor's words are dropped, and transcripts for that site show the
+  assistant side alone.
+- The agent always receives the full message either way. The switch governs storage,
+  never the answer.
+- It is read on every message, so turning it off stops collection from the next
+  message onward. It does **not** retroactively purge lines already stored — that is
+  a delete operation, not a settings change.
+
+It is independent of the concierge kill switch in both directions: turning retention
+off does not silence the bar, and disabling the concierge does not reset retention.
+
+Stored visitor messages are length-capped, so a pasted wall of text cannot grow the
+run collection without bound.

--- a/docs/docs-config.json
+++ b/docs/docs-config.json
@@ -295,6 +295,11 @@
             "icon": "lucide:eye"
           },
           {
+            "label": "Concierge Knowledge",
+            "href": "/concepts/concierge-knowledge",
+            "icon": "lucide:book-open"
+          },
+          {
             "label": "Pocket Sources",
             "href": "/concepts/pocket-sources",
             "icon": "lucide:database"

--- a/ee/pocketpaw_ee/cloud/auth/site_keys.py
+++ b/ee/pocketpaw_ee/cloud/auth/site_keys.py
@@ -59,6 +59,15 @@
 # ``concierge_enabled=False`` refuses the resolved concierge (403 ``concierge_disabled``).
 # The FRAME endpoint enforces the same switch inline (it calls ``lookup_site_by_key``
 # directly, not this resolver).
+#
+# Updated 2026-07-26 (concierge transcripts): the resolver body moved into
+# ``resolve_site_key_with_site``, which returns ``(RequestContext, Site)``;
+# ``resolve_site_key`` is now a thin wrapper that drops the Site. Same gates, same
+# order, same statuses — the Site is returned only AFTER every gate passes. The
+# concierge chat path needs an owner-set Site field the context does not carry
+# (``concierge_store_transcripts``, the visitor-message retention toggle), and the
+# gate had already loaded the doc, so this hands it over instead of paying for a
+# second ``find_one`` per message.
 
 from __future__ import annotations
 
@@ -234,6 +243,31 @@ async def resolve_site_key(
             key" beyond the status — both are 401 so an attacker can't enumerate
             which embed keys are live.
     """
+    ctx, _site = await resolve_site_key_with_site(
+        key, origin, customer_ref, frame_origin=frame_origin
+    )
+    return ctx
+
+
+async def resolve_site_key_with_site(
+    key: str,
+    origin: str | None,
+    customer_ref: str,
+    *,
+    frame_origin: str | None = None,
+) -> tuple[RequestContext, _SiteDoc]:
+    """``resolve_site_key`` plus the resolved Site doc — the SAME gate chain.
+
+    This holds the actual implementation; ``resolve_site_key`` is a thin wrapper
+    that drops the Site. Callers that need an owner-set Site field the context
+    does not carry (the transcript-retention toggle
+    ``concierge_store_transcripts`` is the first) use this instead of re-querying
+    the Site — the gate already loaded it, so the field is free.
+
+    The Site is returned ONLY after every gate has passed, so a caller can never
+    read a field off a Site whose key was rejected. See ``resolve_site_key`` for
+    the full gate order and the raised statuses; behavior here is identical.
+    """
     site = await lookup_site_by_key(key)
 
     # Kill switch (D1 / SS-6): the owner's on/off toggle for the concierge, checked
@@ -253,7 +287,7 @@ async def resolve_site_key(
     elif not origin_allowed(site.allowed_origins, origin):
         raise HTTPException(status_code=403, detail="origin_not_allowed")
 
-    return _context_from_site(site, customer_ref)
+    return _context_from_site(site, customer_ref), site
 
 
-__all__ = ["lookup_site_by_key", "resolve_site_key"]
+__all__ = ["lookup_site_by_key", "resolve_site_key", "resolve_site_key_with_site"]

--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -356,9 +356,7 @@ def current_pocket_id() -> str | None:
 # which widget to run ``execute_action`` against. ``None`` (every non-concierge or
 # no-actions run) means the server builds NO tools — deny-all, exactly as before.
 # Shape: ``{"widget_id": str, "actions": [{"verb","policy","args","label"}, ...]}``.
-_active_pawbar_run: ContextVar[dict[str, Any] | None] = ContextVar(
-    "agent_pawbar_run", default=None
-)
+_active_pawbar_run: ContextVar[dict[str, Any] | None] = ContextVar("agent_pawbar_run", default=None)
 
 
 def bind_pawbar_run(run: dict[str, Any] | None) -> Token:
@@ -1102,7 +1100,9 @@ async def _resolve_concierge(
     # Reconcile the pocket's workspace against the key's — a non-empty doc
     # workspace that disagrees raises Forbidden (cross-tenant guard); an empty
     # doc workspace falls back to the trusted key workspace.
-    workspace_id = _reconcile_workspace_id(str(getattr(pocket, "workspace", "")), expected_workspace_id)
+    workspace_id = _reconcile_workspace_id(
+        str(getattr(pocket, "workspace", "")), expected_workspace_id
+    )
     if not workspace_id:
         raise CloudError(400, "concierge.no_workspace", "Concierge run has no workspace")
 

--- a/ee/pocketpaw_ee/cloud/chat/runs/domain.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/domain.py
@@ -17,7 +17,16 @@ Same boundary reason as ``surface`` — the HTTP handler has the value but submi
 ``RunSpec`` to the executor, so without carrying it the executor's rebuilt ctx would
 never see the client's model choice. ``None`` (the default / older clients) leaves the
 backend's own model selection untouched, byte-identical to today. It's a bare ``str``,
-so it survives the pickle round-trip like every other field."""
+so it survives the pickle round-trip like every other field.
+
+Changes: 2026-07-26 (concierge transcripts) — ``RunSpec`` grows
+``persist_user_text``: the user's message text to WRITE DOWN on the run doc, as
+opposed to ``content``, which is what the agent is asked. Every authed surface
+leaves it "" because it already persisted the user turn as its own Message row;
+the CONCIERGE surface sets it (when the site's retention toggle allows) because
+its anonymous visitor has no Message row, so the run doc is the only place the
+visitor half of a transcript can live. A bare ``str``, so it pickles like the
+rest."""
 
 from __future__ import annotations
 
@@ -40,6 +49,11 @@ class RunSpec(BaseModel):
     client_message_id: str
     user_message_id: str
     content: str
+    # The user's message text to PERSIST on the run doc (``ChatRunDoc.user_text``).
+    # Distinct from ``content``: content is what the agent is asked, this is what we
+    # choose to write down. "" on every authed surface (they persist a Message row
+    # instead); set by the concierge surface when the site allows it.
+    persist_user_text: str = ""
     history: list[dict[str, str]]
     intent: str | None
     attachments: list[dict[str, Any]] = []

--- a/ee/pocketpaw_ee/cloud/chat/runs/service.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/service.py
@@ -16,6 +16,10 @@ Changes:
   boundary (EE Rule 2 — only this module touches ``ChatRunDoc``). ``bill_run`` now
   calls ``mark_billed`` instead. Reading ``run_doc.usage`` in metering stays fine;
   only the WRITE moves here, the owner of the document.
+- 2026-07-26 (concierge transcripts) — ``create_run`` copies
+  ``RunSpec.persist_user_text`` onto ``ChatRunDoc.user_text``. Only the concierge
+  surface ever sets it (its anonymous visitor has no Message row to point
+  ``user_message_id`` at), so every other caller writes "" and is unchanged.
 """
 
 from __future__ import annotations
@@ -55,6 +59,7 @@ async def create_run(spec: RunSpec) -> ChatRunDoc:
         agent_id=spec.agent_id,
         client_message_id=spec.client_message_id,
         user_message_id=spec.user_message_id,
+        user_text=spec.persist_user_text,
     )
     try:
         await doc.insert()

--- a/ee/pocketpaw_ee/cloud/models/chat_run.py
+++ b/ee/pocketpaw_ee/cloud/models/chat_run.py
@@ -16,6 +16,14 @@ Changes:
   until its cost is metered (the durable backlog the sweeper drains). The
   exactly-once guarantee is doubly held — the ledger's ``run:{run_id}``
   idempotency key is the real guard, this flag is the cheap "already done" filter.
+- 2026-07-26 (concierge transcripts) — added ``user_text``. Every authed surface
+  persists the user's turn as its own Message document and points
+  ``user_message_id`` at it; the CONCIERGE surface has an anonymous visitor with
+  no thread and no Message row, so the visitor half of the conversation was never
+  written down and the owner's "transcript" read as the agent talking to itself.
+  This field is that missing half, written only for concierge runs whose site has
+  ``concierge_store_transcripts`` on. It is PERSONAL DATA — a visitor types free
+  text — so it is opt-outable per site and length-capped by the writer.
 """
 
 from __future__ import annotations
@@ -62,6 +70,14 @@ class ChatRunDoc(Document):
     # exactly-once guard; this flag is the cheap "skip already-billed" filter that
     # keeps each sweep bounded.
     billed: bool = False
+    # The user's OWN message text, stored on the run itself. Empty on every surface
+    # that persists the user turn as a real Message document (``user_message_id``
+    # points at it there) — this exists for the CONCIERGE surface, whose visitor is
+    # anonymous and therefore has no thread and no Message row. Written only when
+    # the site's ``concierge_store_transcripts`` toggle is on, and length-capped by
+    # the writer. Treat it as PERSONAL DATA: a visitor types free text, so it can
+    # carry a name, an email, or an order number.
+    user_text: str = ""
     createdAt: datetime = Field(default_factory=_utcnow)
     started_at: datetime | None = None
     ended_at: datetime | None = None

--- a/ee/pocketpaw_ee/cloud/models/site.py
+++ b/ee/pocketpaw_ee/cloud/models/site.py
@@ -136,6 +136,14 @@
 # ``window.__PAWBAR__`` config payload. Both default backward-compatibly
 # (``concierge_enabled=True`` + ``concierge_greeting=""``), so every existing Site
 # reads as enabled with no greeting — no migration.
+#
+# Updated 2026-07-26 (concierge transcripts): added ``concierge_store_transcripts``
+# — the owner's retention switch for the VISITOR half of a conversation. It is
+# deliberately its own toggle rather than a fold into ``concierge_enabled``,
+# because it is the one concierge setting that governs whether NEW personal data
+# is collected (visitor free text can carry a name, an email, an order number).
+# Defaults True so the owner-facing transcript is a real two-sided conversation;
+# an owner on a privacy-sensitive site turns it off and keeps the concierge.
 
 from __future__ import annotations
 
@@ -264,6 +272,20 @@ class Site(TimestampedDocument):
     # reads it in a parallel slice and falls back to its own default when "".
     # Defaults "" (no custom greeting), so no migration.
     concierge_greeting: str = ""
+    # Paw Bar concierge (transcripts): the OWNER's retention switch for the
+    # VISITOR half of a conversation. The agent's replies were always durable
+    # (``ChatRunDoc.partial_text``); when this is True the visitor's own message is
+    # persisted too (``ChatRunDoc.user_text``), which is what makes an owner-facing
+    # transcript a real two-sided conversation instead of a monologue. It is a
+    # separate switch because it is the only concierge setting that decides whether
+    # NEW personal data is stored: a visitor types free text, so the stored line can
+    # carry a name, an email, an order number. An owner running a
+    # privacy-sensitive site turns it off and keeps the concierge — replies still
+    # persist, only the visitor's words are dropped. Read per message (never
+    # cached), so flipping it off stops collection on the very next turn; it does
+    # NOT retroactively purge lines already stored. Defaults True (the transcript
+    # the dashboard promises), so no migration.
+    concierge_store_transcripts: bool = True
 
     def rotate_signed_key(self) -> str:
         """Regenerate the public embed key and return the new value (T1).

--- a/ee/pocketpaw_ee/cloud/models/site.py
+++ b/ee/pocketpaw_ee/cloud/models/site.py
@@ -144,6 +144,14 @@
 # is collected (visitor free text can carry a name, an email, an order number).
 # Defaults True so the owner-facing transcript is a real two-sided conversation;
 # an owner on a privacy-sensitive site turns it off and keeps the concierge.
+#
+# Updated 2026-07-26 (site knowledge sync): added ``kb_article_ids`` /
+# ``kb_synced_at`` / ``kb_sync_error`` — the bookkeeping behind "this site's own
+# pages are in the pocket KB its concierge reads". Without it a dedicated concierge
+# was provisioned knowledge-empty and could not answer a question about the business
+# it fronts. The ids exist so a re-sync can prune what a renamed page left behind
+# without clearing a scope that also holds owner-uploaded files. All default
+# empty/None, so no migration.
 
 from __future__ import annotations
 
@@ -286,6 +294,17 @@ class Site(TimestampedDocument):
     # NOT retroactively purge lines already stored. Defaults True (the transcript
     # the dashboard promises), so no migration.
     concierge_store_transcripts: bool = True
+    # Site knowledge sync (``sites.kb_ingest``): the kb-go article ids this site's
+    # own content currently occupies in ``pocket:<pocket_id>`` — the scope its
+    # concierge reads. Kept so a later sync can delete the articles a renamed or
+    # deleted page left behind WITHOUT touching the rest of the scope, which also
+    # holds owner-uploaded files. Empty until the first sync, so no migration.
+    kb_article_ids: list[str] = Field(default_factory=list)
+    # When the last sync ran (success or not) and why it produced nothing, so the
+    # dashboard can tell "this concierge has no knowledge yet" apart from "syncing
+    # is broken". "" means the last sync was clean.
+    kb_synced_at: datetime | None = None
+    kb_sync_error: str = ""
 
     def rotate_signed_key(self) -> str:
         """Regenerate the public embed key and return the new value (T1).

--- a/ee/pocketpaw_ee/cloud/surface/surface_registry.py
+++ b/ee/pocketpaw_ee/cloud/surface/surface_registry.py
@@ -417,9 +417,7 @@ def _concierge_profile(meta: SurfaceMeta) -> SurfaceProfile:
         from pocketpaw_ee.agent.mcp_servers.pawbar import pawbar_tool_id
 
         verb_ids = frozenset(
-            pawbar_tool_id(a["verb"])
-            for a in actions
-            if isinstance(a, dict) and a.get("verb")
+            pawbar_tool_id(a["verb"]) for a in actions if isinstance(a, dict) and a.get("verb")
         )
         allow = allow | verb_ids
     return SurfaceProfile(

--- a/ee/pocketpaw_ee/guards/actions.py
+++ b/ee/pocketpaw_ee/guards/actions.py
@@ -3,6 +3,11 @@
 # machine-readable `code` emitted on denial. Tests iterate ACTIONS to
 # guarantee every guarded operation is covered.
 #
+# Updated: 2026-07-26 (site knowledge sync) — added ``paw_bar.manage`` (ADMIN) for
+# the owner-triggered site→pocket-KB sync. Same role as ``paw_bar.read`` but its
+# own action: the sync is a mutation that spends compute (ingest compiles
+# articles), and a write should not ride a read gate that could later be widened.
+#
 # Updated: 2026-07-16 (D2 concierge dashboard reads) — added ``paw_bar.read``
 # (ADMIN) so the per-site Concierge dashboard reads (ee.pocketpaw_ee.paw_bar
 # .router: overview / conversations / decisions / handoffs) gate on the caller's
@@ -270,6 +275,11 @@ ACTIONS: dict[str, ActionRule] = {
     # carry visitor PII and owner decision context, so the surface is owner/admin
     # only and must not be visible to every workspace member.
     "paw_bar.read": ActionRule(WorkspaceRole.ADMIN, "workspace.insufficient_role"),
+    # Paw Bar concierge dashboard — the owner WRITE surface (today: the
+    # site→pocket-KB knowledge sync). ADMIN like the read, but its own action
+    # because it is a mutation that also spends compute (ingest compiles articles),
+    # so it must not inherit a read gate. Mirrors belt.read / belt.manage.
+    "paw_bar.manage": ActionRule(WorkspaceRole.ADMIN, "workspace.insufficient_role"),
     # Belt console — the develop-station read + repo-admin surface
     # (ee.cloud.belt.router, feat/belt-console-backend SC-1). read is MEMBER so
     # any team member can list discoverable repos + their own station runs.

--- a/ee/pocketpaw_ee/paw_bar/agent_provisioning.py
+++ b/ee/pocketpaw_ee/paw_bar/agent_provisioning.py
@@ -226,7 +226,30 @@ async def ensure_site_agent(site: Any, widget: Any) -> str | None:
             widget.id,
         )
         return None
+
+    # (4) Give the new agent something to know. A concierge reads ONE KB scope —
+    # its site's pocket — and until the site's own pages are in that scope the agent
+    # is provisioned knowledge-empty and answers "I don't know" about the business
+    # it fronts. Sites published before this existed have never synced, so a bind is
+    # the natural catch-up point. Background + failure-soft: never a gate on a bind.
+    _schedule_knowledge_sync(site)
     return agent.id
+
+
+def _schedule_knowledge_sync(site: Any) -> None:
+    """Fire the background site→pocket-KB sync, swallowing everything. Imported
+    lazily so provisioning keeps working even if the sites KB module cannot be
+    loaded in a given deployment."""
+    try:
+        from pocketpaw_ee.sites.kb_ingest import schedule_site_knowledge_sync
+
+        schedule_site_knowledge_sync(site)
+    except Exception:  # noqa: BLE001 — knowledge sync is never a gate on a bind
+        logger.warning(
+            "paw-bar concierge: could not schedule knowledge sync for site %s",
+            getattr(site, "id", "?"),
+            exc_info=True,
+        )
 
 
 async def _canonical_site_for_pocket(workspace_id: str, pocket_id: str) -> Any | None:

--- a/ee/pocketpaw_ee/paw_bar/agent_provisioning.py
+++ b/ee/pocketpaw_ee/paw_bar/agent_provisioning.py
@@ -84,7 +84,7 @@ def derive_conversation_starters(widget: Any) -> list[str]:
     starters: list[str] = []
     if spec is not None and getattr(spec, "catalog", None):
         starters.append("What do you sell?")
-    for action in (getattr(spec, "actions", None) or []):
+    for action in getattr(spec, "actions", None) or []:
         if len(starters) >= _MAX_STARTERS:
             break
         label = (getattr(action, "label", "") or "").strip()

--- a/ee/pocketpaw_ee/paw_bar/decision_loop.py
+++ b/ee/pocketpaw_ee/paw_bar/decision_loop.py
@@ -98,6 +98,7 @@ def _sanitize_for_human(text: Any, *, cap: int) -> str:
     s = re.sub(r"\s+", " ", s).strip()
     return s[:cap]
 
+
 # Schema version stamped onto the ``_customer_reply`` blob. Bump when the blob
 # shape changes so a stale pending Action approved after a deploy is handled
 # loudly rather than misinterpreted. (Mirrors instinct_bridge._POCKET_WRITE_SCHEMA.)
@@ -127,9 +128,7 @@ def resolve_workspace_id(widget: Any) -> str:
     instinct.db) is done separately in ``propose_customer_decision`` from the
     real ``workspace_id`` only — an owner label is never a store-path token.
     """
-    return str(getattr(widget, "workspace_id", "") or "") or str(
-        getattr(widget, "owner", "") or ""
-    )
+    return str(getattr(widget, "workspace_id", "") or "") or str(getattr(widget, "owner", "") or "")
 
 
 def _summarize_payload(payload: dict[str, Any]) -> str:
@@ -385,8 +384,7 @@ async def propose_customer_action(
         safe_summary = _sanitize_for_human(summary, cap=_MAX_SUMMARY_CHARS)
         safe_widget_name = _sanitize_for_human(widget_name, cap=80) or widget_id
         default_reply = (
-            f"Thanks, we've passed your '{verb}' request to the team and will "
-            "follow up shortly."
+            f"Thanks, we've passed your '{verb}' request to the team and will follow up shortly."
         )
         title = f"Visitor action on {safe_widget_name}: {verb}".strip()
         recommendation = (

--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -1,4 +1,14 @@
 # ee/paw_bar/router.py — HTTP surface for the Paw Bar widget layer.
+# Updated: 2026-07-26 (site knowledge sync) — two owner endpoints over the site's
+#   own knowledge: GET /paw-bar/admin/site/{id}/knowledge reports how many articles
+#   the concierge can quote and how the last sync went, and POST
+#   .../knowledge/sync re-reads the site's pages into pocket:<pocket_id> (the ONE
+#   scope a concierge reads) without needing a re-publish. The sync also runs
+#   automatically on publish and on agent provisioning; this is the manual handle.
+#   The read gates on paw_bar.read, the sync on the new paw_bar.manage — both ADMIN,
+#   but a mutation that spends compute does not ride a read gate. The sync is
+#   awaited here (the owner clicked a button and wants the result) while the
+#   automatic triggers are backgrounded.
 # Updated: 2026-07-26 (concierge transcripts) — the visitor half of a conversation
 #   is now written down, so an owner's transcript is a dialogue instead of the
 #   agent talking to itself. (1) concierge_chat resolves the embed key through
@@ -1093,6 +1103,95 @@ async def update_site_concierge_settings(
         concierge_greeting=site.concierge_greeting,
         concierge_store_transcripts=site.concierge_store_transcripts,
     )
+
+
+# ---------------------------------------------------------------------------
+# Admin: per-Site concierge KNOWLEDGE (site content → the pocket KB it reads)
+#
+# A concierge answers from ONE scope, ``pocket:<pocket_id>``, so if nothing put the
+# site's own pages there the agent is live but knows nothing about the business it
+# fronts. The sync runs automatically on publish and on agent provisioning; these
+# two endpoints are the owner's window into it — what the concierge currently
+# knows, and a way to re-run the sync without re-publishing.
+#
+# Gates: the read uses ``paw_bar.read`` and the sync ``paw_bar.manage`` (both
+# ADMIN). The sync is a mutation that spends compute, so it does not ride the read.
+# ---------------------------------------------------------------------------
+
+_require_paw_bar_manage = require_action("paw_bar.manage", workspace_dep=current_workspace_id)
+
+
+class ConciergeKnowledgeResponse(BaseModel):
+    """What a site's concierge currently knows, and how the last sync went.
+
+    ``status`` is "" for a clean sync; otherwise a stable machine code the dashboard
+    can turn into a sentence: ``never_synced`` (nothing has run yet), ``no_content``
+    (the pocket holds no ingestable pages — the case for a foreign site we do not
+    host), ``pocket_unavailable`` or ``sync_failed``.
+    """
+
+    site_id: str
+    article_count: int
+    synced_at: str
+    status: str
+    ingested: int = 0
+    removed: int = 0
+    skipped: int = 0
+
+
+def _knowledge_response(site: Any, report: Any = None) -> ConciergeKnowledgeResponse:
+    synced_at = getattr(site, "kb_synced_at", None)
+    status = getattr(site, "kb_sync_error", "") or ""
+    if not synced_at and not status:
+        status = "never_synced"
+    return ConciergeKnowledgeResponse(
+        site_id=str(site.id),
+        article_count=len(getattr(site, "kb_article_ids", None) or []),
+        synced_at=synced_at.isoformat() if synced_at else "",
+        status=status,
+        ingested=getattr(report, "ingested", 0) or 0,
+        removed=getattr(report, "removed", 0) or 0,
+        skipped=getattr(report, "skipped", 0) or 0,
+    )
+
+
+@router.get(
+    "/paw-bar/admin/site/{site_id}/knowledge",
+    response_model=ConciergeKnowledgeResponse,
+    dependencies=[Depends(_require_paw_bar_read)],
+)
+async def get_site_knowledge(
+    site_id: str,
+    workspace_id: str = Depends(current_workspace_id),
+) -> ConciergeKnowledgeResponse:
+    """How much of this site the concierge can actually quote. Workspace-scoped."""
+    site = await _load_site_scoped(site_id, workspace_id)
+    return _knowledge_response(site)
+
+
+@router.post(
+    "/paw-bar/admin/site/{site_id}/knowledge/sync",
+    response_model=ConciergeKnowledgeResponse,
+    dependencies=[Depends(_require_paw_bar_manage)],
+)
+async def sync_site_knowledge_now(
+    site_id: str,
+    workspace_id: str = Depends(current_workspace_id),
+) -> ConciergeKnowledgeResponse:
+    """Re-read the site's pages into the KB its concierge answers from.
+
+    Awaited rather than backgrounded, unlike the publish and provisioning triggers:
+    the owner clicked a button and needs the result, not a promise. It is idempotent
+    (re-ingesting a page versions its article rather than duplicating it) and prunes
+    the articles pages that no longer exist left behind, so pressing it twice is
+    harmless. Never raises on a sync failure — the failure is reported in ``status``
+    so the dashboard can show it instead of a stack trace.
+    """
+    from pocketpaw_ee.sites.kb_ingest import safe_sync_site_knowledge
+
+    site = await _load_site_scoped(site_id, workspace_id)
+    report = await safe_sync_site_knowledge(site)
+    return _knowledge_response(site, report)
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -1,4 +1,19 @@
 # ee/paw_bar/router.py — HTTP surface for the Paw Bar widget layer.
+# Updated: 2026-07-26 (concierge transcripts) — the visitor half of a conversation
+#   is now written down, so an owner's transcript is a dialogue instead of the
+#   agent talking to itself. (1) concierge_chat resolves the embed key through
+#   ``resolve_site_key_with_site`` (same gates, hands back the Site the gate
+#   already loaded) and sets ``RunSpec.persist_user_text`` — the visitor's message,
+#   capped at ``_STORED_USER_TEXT_CHARS``, and ONLY when the site's
+#   ``concierge_store_transcripts`` is on. The agent always receives the full
+#   message; the toggle governs storage, not the answer. (2) ``_load_transcript``
+#   emits the user turn (``ChatRunDoc.user_text``, stamped at run creation) before
+#   the assistant turn (``partial_text``, stamped at completion); either may be
+#   absent and the other still renders, so a retention-off site reads exactly as it
+#   did before. (3) the conversations list falls back to the visitor's question
+#   when a run produced no reply, instead of rendering a blank row. (4) the
+#   settings GET/PATCH carry ``concierge_store_transcripts``. Turning the toggle
+#   off stops collection on the next message; it does NOT purge stored lines.
 # Updated: 2026-07-23 (feat/site-dedicated-agent) — auto-provision a DEDICATED
 #   concierge agent per site. (1) create_widget: when the request carries NO
 #   agent_id and the pocket resolves to a published Site, provision + bind one
@@ -40,9 +55,9 @@
 #   site→widget→pocket resolution as the other reads; the transcript is the
 #   concierge ``ChatRunDoc`` runs for (pocket, customer_ref), most-recent 200,
 #   oldest-first; 400 on a bad customer_ref, 404 when the ref has no conversation
-#   here. v1 caveat: the concierge MVP does not persist the visitor's message, so
-#   every turn is role "assistant" (the agent reply on ``partial_text``) until
-#   visitor-text capture is approved (a PII-posture decision).
+#   here. (The v1 caveat that every turn was role "assistant" no longer holds —
+#   see the 2026-07-26 entry above; visitor lines are stored when the site's
+#   retention toggle allows.)
 # Updated: 2026-07-16 (D2 security review — role gate + empty-pocket guard) —
 #   the four D2 reads now gate on ``require_action("paw_bar.read")`` (ADMIN — the
 #   caller's WORKSPACE ROLE), NOT the coarse ``require_scope("admin")`` that
@@ -323,6 +338,7 @@ def _asset_version() -> str:
             continue
     return str(newest)
 
+
 # A frame-ancestors host-source is host[:port] with NO scheme, path, or whitespace.
 # ``allowed_origins`` is owner-controlled data flowing into a response HEADER, so
 # each entry is reduced to this safe shape (or dropped) — a stray space / ``;`` /
@@ -440,7 +456,7 @@ def _pawbar_bootstrap_html(config: dict[str, Any], asset_mount: str, page_bg: st
     config_json = json.dumps(config).replace("<", "\\u003c")
     v = _asset_version()
     preview_style = (
-        f'<style>html,body{{background:{page_bg};color-scheme:dark}}</style>\n' if page_bg else ""
+        f"<style>html,body{{background:{page_bg};color-scheme:dark}}</style>\n" if page_bg else ""
     )
     return (
         "<!doctype html>\n"
@@ -952,8 +968,9 @@ async def list_events(
 # admin CRUD above: ``require_scope("admin")`` (a signed-in dashboard session) +
 # the caller's ACTIVE workspace via ``current_workspace_id``. The lookup is
 # workspace-scoped, so another tenant's site id resolves to 404 and never leaks or
-# mutates. Reads/writes touch ONLY the two concierge fields — the site's publish /
-# billing / capture config is out of scope here. Co-located with the paw-bar
+# mutates. Reads/writes touch ONLY the concierge fields (the kill switch, the
+# greeting, and the transcript-retention toggle) — the site's publish / billing /
+# capture config is out of scope here. Co-located with the paw-bar
 # enforcement (the frame/chat/action gates) rather than the heavier sites control
 # plane so the owner surface and the switch it drives sit in one place.
 # ---------------------------------------------------------------------------
@@ -969,6 +986,11 @@ class ConciergeSettingsUpdate(BaseModel):
 
     concierge_enabled: bool | None = None
     concierge_greeting: str | None = None
+    # Retention switch for the VISITOR half of a transcript. Off means the
+    # concierge keeps working and keeps storing its own replies, but the visitor's
+    # words are never written down. Turning it off does NOT purge what is already
+    # stored — that is a delete operation, not a settings change.
+    concierge_store_transcripts: bool | None = None
 
 
 class ConciergeSettingsResponse(BaseModel):
@@ -977,6 +999,7 @@ class ConciergeSettingsResponse(BaseModel):
     site_id: str
     concierge_enabled: bool
     concierge_greeting: str
+    concierge_store_transcripts: bool
 
 
 async def _load_site_scoped(site_id: str, workspace_id: str) -> Any:
@@ -1019,6 +1042,7 @@ async def get_site_concierge_settings(
         site_id=str(site.id),
         concierge_enabled=site.concierge_enabled,
         concierge_greeting=site.concierge_greeting,
+        concierge_store_transcripts=site.concierge_store_transcripts,
     )
 
 
@@ -1067,6 +1091,7 @@ async def update_site_concierge_settings(
         site_id=str(site.id),
         concierge_enabled=site.concierge_enabled,
         concierge_greeting=site.concierge_greeting,
+        concierge_store_transcripts=site.concierge_store_transcripts,
     )
 
 
@@ -1141,6 +1166,13 @@ _CONVERSATION_SCAN_CAP = 200
 # never ships the whole history in one response.
 _TRANSCRIPT_CAP = 200
 
+# Max characters of a visitor's own message persisted on the run doc for the
+# transcript. The agent still receives the FULL message — this caps only what we
+# write down, so a pasted wall of text (or a deliberate storage-stuffing attempt)
+# can't grow the run collection without bound. Generous enough that a real
+# question is never clipped.
+_STORED_USER_TEXT_CHARS = 4000
+
 
 class AdminWidgetView(BaseModel):
     """The site's paw-bar widget as the owner dashboard needs it (D2 overview)."""
@@ -1202,12 +1234,11 @@ class ConversationsResponse(BaseModel):
 class TranscriptMessage(BaseModel):
     """One message in a conversation transcript (D2 drill-in).
 
-    ``role`` is "user" or "assistant" per the frozen contract. NOTE (v1): the
-    concierge run path is a stateless MVP that does NOT persist the visitor's
-    (user) message — only the agent reply survives, on ``ChatRunDoc.partial_text``
-    — so today every message is role "assistant". Persisting visitor text is a
-    privacy posture decision (it stores visitor PII) tracked as a follow-up; when
-    it lands, user turns fill in here with no shape change.
+    ``role`` is "user" or "assistant" per the frozen contract. Both roles are now
+    real: the agent reply comes from ``ChatRunDoc.partial_text`` and the visitor's
+    own line from ``ChatRunDoc.user_text``. A site whose owner turned
+    ``concierge_store_transcripts`` off stores no visitor lines, so its transcripts
+    are assistant-only — the same shape this DTO always had, just missing one role.
     """
 
     role: str
@@ -1386,12 +1417,12 @@ async def get_site_conversation_transcript(
     customer_ref). Capped at the most recent ``_TRANSCRIPT_CAP`` (200) turns,
     presented oldest-first. 404 when the ref has no concierge conversation here.
 
-    ROLE COVERAGE (v1): the concierge run path is a stateless MVP that does not
-    persist the visitor's message (see ``concierge_chat`` — user_message_id="",
-    "no persisted user message"), so the only per-visitor content that survives is
-    the agent reply on ``ChatRunDoc.partial_text``. Every message is therefore role
-    "assistant" today. Persisting visitor text (to fill in the "user" turns) stores
-    visitor PII and is a privacy-posture decision for a follow-up, NOT done here.
+    ROLE COVERAGE: both halves of the conversation are here — the visitor's line
+    from ``ChatRunDoc.user_text`` and the agent's from ``partial_text``. The
+    visitor half is stored only while the site's ``concierge_store_transcripts``
+    toggle is on (it is personal data, so the owner controls it); an owner who
+    turns it off keeps getting assistant-only transcripts from that point on, and
+    lines already stored are NOT retroactively purged.
     """
     if not _CUSTOMER_REF_RE.match(customer_ref or ""):
         raise HTTPException(400, "invalid_customer_ref")
@@ -1596,11 +1627,16 @@ async def _list_conversations(
             continue
         seen.add(run.user_id)
         when = run.ended_at or run.createdAt
+        # Prefer the agent's reply as the row preview (unchanged). Fall back to the
+        # visitor's own question when there is no reply — a run that failed or was
+        # cut off used to render a blank row, which told the owner nothing; the
+        # question at least says what the visitor wanted.
+        preview = (run.partial_text or "") or (getattr(run, "user_text", "") or "")
         items.append(
             ConversationItem(
                 customer_ref=run.user_id,
                 last_message_at=when.isoformat() if when else "",
-                preview=(run.partial_text or "")[:_CONVERSATION_PREVIEW_CHARS],
+                preview=preview[:_CONVERSATION_PREVIEW_CHARS],
             )
         )
         if len(items) >= limit:
@@ -1609,9 +1645,7 @@ async def _list_conversations(
     # A cursor is offered only when the scan hit its cap (older runs may remain);
     # it is the oldest run we looked at, so the next page continues strictly older.
     next_cursor = (
-        runs[-1].createdAt.isoformat()
-        if len(runs) >= _CONVERSATION_SCAN_CAP and runs
-        else None
+        runs[-1].createdAt.isoformat() if len(runs) >= _CONVERSATION_SCAN_CAP and runs else None
     )
     return ConversationsResponse(items=items, cursor=next_cursor, unsupported=False)
 
@@ -1623,11 +1657,15 @@ async def _load_transcript(
 
     Fetches this (pocket, customer_ref)'s concierge ``ChatRunDoc`` runs (index-
     backed, most-recent ``_TRANSCRIPT_CAP``), then presents them oldest-first. Each
-    completed run contributes the agent reply (``partial_text``) as an "assistant"
-    message; the visitor's own message is not persisted by the stateless concierge
-    MVP, so it does not appear (see the endpoint docstring). Returns ``None`` when
-    the ref has NO concierge run here (the caller 404s) — distinct from an empty
-    list, which means runs exist but none carried reply text yet.
+    run contributes up to TWO messages, in conversation order: the visitor's own
+    line (``user_text``) as "user", then the agent reply (``partial_text``) as
+    "assistant". Either can be missing and the other still renders — a site with
+    ``concierge_store_transcripts`` off has no user lines (assistant-only, exactly
+    the old shape), and a run that failed before producing text has no assistant
+    line. Both empty and the run contributes nothing.
+
+    Returns ``None`` when the ref has NO concierge run here (the caller 404s) —
+    distinct from an empty list, which means runs exist but none carried any text.
     """
     from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
 
@@ -1647,17 +1685,29 @@ async def _load_transcript(
 
     messages: list[TranscriptMessage] = []
     for run in reversed(runs):  # oldest-first
-        text = run.partial_text or ""
-        if not text:
-            continue
-        when = run.ended_at or run.createdAt
-        messages.append(
-            TranscriptMessage(
-                role="assistant",
-                content=text,
-                created_at=when.isoformat() if when else "",
+        # The visitor's line is stamped at the moment the run was created; the
+        # reply is stamped when it finished. Using each one's own timestamp keeps
+        # the pair honest about how long the answer took.
+        asked = run.createdAt
+        answered = run.ended_at or run.createdAt
+        user_text = getattr(run, "user_text", "") or ""
+        if user_text:
+            messages.append(
+                TranscriptMessage(
+                    role="user",
+                    content=user_text,
+                    created_at=asked.isoformat() if asked else "",
+                )
             )
-        )
+        reply = run.partial_text or ""
+        if reply:
+            messages.append(
+                TranscriptMessage(
+                    role="assistant",
+                    content=reply,
+                    created_at=answered.isoformat() if answered else "",
+                )
+            )
     return messages
 
 
@@ -2003,9 +2053,11 @@ async def concierge_chat(body: ConciergeChatRequest, request: Request) -> Stream
     # credential; there is no user. ``frame_origin`` makes the origin gate accept an
     # iframe-mode request (Origin == our frame, already gated by the frame CSP) while
     # still requiring an inline-mode request's Origin to be on ``Site.allowed_origins``.
-    from pocketpaw_ee.cloud.auth.site_keys import resolve_site_key
+    # ``_with_site`` hands back the Site the gate already loaded, so step (8) can
+    # read the owner's transcript-retention toggle without a second query.
+    from pocketpaw_ee.cloud.auth.site_keys import resolve_site_key_with_site
 
-    ctx = await resolve_site_key(
+    ctx, site = await resolve_site_key_with_site(
         body.signed_key, origin, body.customer_ref, frame_origin=frame_origin
     )
 
@@ -2099,8 +2151,19 @@ async def concierge_chat(body: ConciergeChatRequest, request: Request) -> Stream
     # anonymous customer handle (session / rate-limit key, never a principal).
     # ``surface="concierge"`` makes execute_run resolve the CONCIERGE
     # SurfaceProfile (tool lockdown); ``context_type="concierge"`` makes it
-    # resolve the CONCIERGE scope (KB locked to pocket:<id>). Stateless MVP:
-    # ``history=[]`` (no cross-visitor bleed) and no persisted user message.
+    # resolve the CONCIERGE scope (KB locked to pocket:<id>). ``history=[]`` stays
+    # (each turn is answered fresh — no cross-visitor bleed).
+    #
+    # ``persist_user_text`` is the visitor's own line, written onto the run doc so
+    # the owner's transcript is a conversation rather than a monologue. The visitor
+    # is anonymous and has no Message row, so ``user_message_id`` stays "" and this
+    # is the only place that text can live. Gated on the site owner's
+    # ``concierge_store_transcripts`` (re-read every turn, so turning it off stops
+    # collection on the next message) and length-capped — the agent still gets the
+    # full message either way, this governs only what is stored.
+    stored_user_text = (
+        body.message[:_STORED_USER_TEXT_CHARS] if site.concierge_store_transcripts else ""
+    )
     spec = RunSpec(
         run_id=run_id,
         workspace_id=ctx.workspace_id,
@@ -2112,6 +2175,7 @@ async def concierge_chat(body: ConciergeChatRequest, request: Request) -> Stream
         agent_id=widget.agent_id,
         client_message_id=client_message_id,
         user_message_id="",
+        persist_user_text=stored_user_text,
         content=body.message,
         history=[],
         intent=None,

--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -1306,6 +1306,11 @@ class SiteOverviewResponse(BaseModel):
     widget: AdminWidgetView | None = None
     enabled: bool
     greeting: str
+    # The third owner setting, alongside ``enabled`` and ``greeting``: whether the
+    # visitor's own messages are stored. Carried here so the dashboard renders all
+    # three from the one call it already makes rather than a second round trip for
+    # a single boolean.
+    store_transcripts: bool = True
     counts: OverviewCounts
 
 
@@ -1468,6 +1473,7 @@ async def get_site_overview(
         widget=widget_view,
         enabled=site.concierge_enabled,
         greeting=site.concierge_greeting,
+        store_transcripts=site.concierge_store_transcripts,
         counts=counts,
     )
 

--- a/ee/pocketpaw_ee/sites/kb_ingest.py
+++ b/ee/pocketpaw_ee/sites/kb_ingest.py
@@ -1,0 +1,564 @@
+# ee/pocketpaw_ee/sites/kb_ingest.py — put a site's own content into the pocket KB
+# its concierge reads from.
+#
+# Created 2026-07-26. A dedicated concierge agent used to start KNOWLEDGE-EMPTY: it
+# was provisioned with a soul and a persona and a KB scope, and nothing was ever put
+# in that scope. Demos only looked grounded because the widget spec happened to
+# carry a catalog. Ask a concierge "what are your opening hours" and the answer was
+# an honest "I don't know" about a business whose own homepage says 8am.
+#
+# The concierge's grounding scope is fixed: ``agent_service._kb_scopes_for_context``
+# locks a CONCIERGE run to ``pocket:<pocket_id>`` and nothing else (no agent:, no
+# workspace:, no user: — a public caller must never read the whole tenant's KB). So
+# "the concierge knows the business" reduces to one job: get the site's pages into
+# ``pocket:<pocket_id>``. That is all this module does.
+#
+# SOURCE OF TRUTH — the POCKET, not the built artifact and not the live URL:
+#   * the pocket is durable, so this works at publish time, at agent-provision time
+#     for a site published months ago, and on an owner's manual re-sync — a build
+#     directory only exists during a publish;
+#   * it needs no network, so there is no SSRF surface. Fetching a site's own
+#     ``url`` would mean fetching a customer-controlled hostname server-side, which
+#     is exactly the class of request ``url_crawler`` had to be hardened against;
+#   * it is what a re-publish would deploy, so the KB never describes a page the
+#     site no longer serves.
+#
+# LANES. Three engines, three shapes, one extractor each (see ``extract_site_documents``):
+#   * html   — the ``source`` map is the site's real HTML (this is also what the
+#              URL-import crawler writes, so an agency's imported client site is
+#              covered by this path);
+#   * svelte — the ``source`` map is hand-written components; script/style blocks and
+#              template expressions are dropped, the prose survives;
+#   * ripple — there is no HTML yet, the copy lives in the rippleSpec, so the spec is
+#              walked for its text-bearing values.
+#
+# NOT COVERED (deliberate, named so it is not mistaken for done): a site minted by
+# ``mint_foreign_site`` — a concierge embedded on a site we do not host — has no
+# content in its pocket, so it syncs zero documents. Grounding those means crawling
+# the customer's own origin, which is the ``url_crawler`` SSRF-hardened path, and is
+# its own slice. ``sync_site_knowledge`` reports it as skipped rather than pretending.
+#
+# IDEMPOTENCE. kb-go derives an article id from ``--source`` and re-ingesting the
+# same source bumps that article's version instead of duplicating it, so the page
+# sources here are deterministic (``site-<path-slug>``). The Site then remembers the
+# ids it produced, and a later sync deletes the ones that stopped being produced —
+# that is how a deleted or renamed page leaves the KB. The pocket scope is SHARED
+# with owner-uploaded files, so this NEVER clears the scope; it only removes ids it
+# is certain it wrote.
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from html.parser import HTMLParser
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Max pages ingested in one sync. A large site is truncated rather than allowed to
+# turn a publish into an unbounded fan-out of LLM compilations.
+_MAX_DOCUMENTS = 60
+
+# Max characters kept per page. Long enough for a real content page; past this the
+# tail is dropped rather than stored.
+_MAX_DOCUMENT_CHARS = 40_000
+
+# Pages shorter than this carry no answerable content (an empty layout, a redirect
+# stub) and are skipped so they don't dilute BM25 scoring.
+_MIN_DOCUMENT_CHARS = 40
+
+# Tags whose CONTENT is never page copy.
+_NON_CONTENT_TAGS = {"script", "style", "noscript", "template", "svg", "head"}
+
+# rippleSpec keys that carry structure rather than copy. Everything else is treated
+# as potential copy: over-collecting costs a few noise tokens in a BM25 index,
+# under-collecting loses the price or the product name, which is the whole point.
+_SPEC_STRUCTURAL_KEYS = {
+    "align",
+    "as",
+    "bg",
+    "class",
+    "className",
+    "color",
+    "component",
+    "direction",
+    "engine",
+    "font",
+    "gap",
+    "height",
+    "href",
+    "icon",
+    "id",
+    "justify",
+    "key",
+    "kind",
+    "layout",
+    "pattern",
+    "pocket_id",
+    "position",
+    "rel",
+    "size",
+    "src",
+    "style",
+    "target",
+    "theme",
+    "type",
+    "url",
+    "variant",
+    "widget_id",
+    "width",
+}
+
+# Numeric keys worth rendering into the text — a bare number is noise, but a price
+# is the single most asked-about fact on a commerce page.
+_SPEC_NUMERIC_KEYS = {"amount", "cost", "price", "price_cents", "qty", "quantity"}
+
+_HEX_COLOR_RE = re.compile(r"^#[0-9a-fA-F]{3,8}$")
+_URL_RE = re.compile(r"^(?:https?:)?//|^(?:data|mailto|tel|blob):", re.I)
+_HAS_LETTER_RE = re.compile(r"[^\W\d_]", re.UNICODE)
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+_WS_RE = re.compile(r"[ \t\r\f\v]+")
+_BLANKS_RE = re.compile(r"\n{3,}")
+_SVELTE_BLOCK_RE = re.compile(r"<(script|style)\b[^>]*>.*?</\1>", re.I | re.S)
+_SVELTE_EXPR_RE = re.compile(r"\{[^{}]*\}")
+
+
+@dataclass(frozen=True)
+class SiteDocument:
+    """One ingestable unit of a site: a page, or the whole spec for a ripple site."""
+
+    path: str
+    source: str
+    text: str
+
+
+@dataclass
+class SiteKnowledgeReport:
+    """What one sync did. Returned to the owner-facing endpoint and logged."""
+
+    ingested: int = 0
+    removed: int = 0
+    skipped: int = 0
+    article_ids: list[str] = field(default_factory=list)
+    error: str = ""
+
+
+# --------------------------------------------------------------------------- #
+# Text extraction
+# --------------------------------------------------------------------------- #
+
+
+class _TextHarvester(HTMLParser):
+    """Collect visible text from HTML, dropping non-content tags.
+
+    Block-level tags emit a newline so headings and list items don't run into the
+    following sentence — BM25 does not care, but a human reading the article (and an
+    agent quoting it back to a visitor) does. ``convert_charrefs`` is on, so
+    ``&amp;`` arrives already decoded.
+    """
+
+    _BLOCK_TAGS = {
+        "address", "article", "aside", "blockquote", "br", "div", "footer", "h1",
+        "h2", "h3", "h4", "h5", "h6", "header", "hr", "li", "main", "nav", "ol",
+        "p", "section", "table", "td", "th", "tr", "ul",
+    }  # fmt: skip
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self._chunks: list[str] = []
+        self._suppress_depth = 0
+        self._in_title = False
+
+    def handle_starttag(self, tag: str, attrs: Any) -> None:
+        # The document title is the page's own summary of itself ("Brew & Co |
+        # Opening Hours") and is worth more per token than most of the body, so it
+        # is read even though it lives inside the otherwise-suppressed <head>.
+        if tag == "title":
+            self._in_title = True
+            return
+        if tag in _NON_CONTENT_TAGS:
+            self._suppress_depth += 1
+            return
+        if tag in self._BLOCK_TAGS:
+            self._chunks.append("\n")
+        # An image's alt text is real content on a visual page.
+        if tag == "img":
+            for name, value in attrs or []:
+                if name == "alt" and value:
+                    self._chunks.append(f"{value}\n")
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "title":
+            self._in_title = False
+            self._chunks.append("\n")
+            return
+        if tag in _NON_CONTENT_TAGS:
+            self._suppress_depth = max(0, self._suppress_depth - 1)
+            return
+        if tag in self._BLOCK_TAGS:
+            self._chunks.append("\n")
+
+    def handle_data(self, data: str) -> None:
+        if self._in_title or self._suppress_depth == 0:
+            self._chunks.append(data)
+
+    def text(self) -> str:
+        return _tidy("".join(self._chunks))
+
+
+def _tidy(raw: str) -> str:
+    """Collapse runs of spaces and blank lines, strip per-line padding."""
+    collapsed = _WS_RE.sub(" ", raw)
+    lines = [line.strip() for line in collapsed.split("\n")]
+    return _BLANKS_RE.sub("\n\n", "\n".join(lines)).strip()
+
+
+def html_to_text(html: str) -> str:
+    """Visible text of an HTML document. Malformed markup degrades to whatever the
+    parser managed rather than raising — this runs over customer-authored and
+    crawler-harvested pages, so it must never be the thing that fails a publish."""
+    harvester = _TextHarvester()
+    try:
+        harvester.feed(html)
+        harvester.close()
+    except Exception:  # noqa: BLE001 — partial text beats no text
+        logger.debug("sites.kb: HTML parse ended early; keeping partial text", exc_info=True)
+    return harvester.text()
+
+
+def svelte_to_text(source: str) -> str:
+    """Prose from a Svelte component: script and style blocks removed first (their
+    contents are code, not copy), then template expressions like ``{item.name}``,
+    then the remaining markup is read as HTML."""
+    without_blocks = _SVELTE_BLOCK_RE.sub(" ", source)
+    without_exprs = _SVELTE_EXPR_RE.sub(" ", without_blocks)
+    return html_to_text(without_exprs)
+
+
+def _is_copy(value: str) -> bool:
+    """True when a spec string looks like something a visitor would read."""
+    text = value.strip()
+    if not text or len(text) > _MAX_DOCUMENT_CHARS:
+        return False
+    if _HEX_COLOR_RE.match(text) or _URL_RE.match(text):
+        return False
+    # Anything with no letter at all is an id, a measurement, or a colour token.
+    return bool(_HAS_LETTER_RE.search(text))
+
+
+def spec_to_text(spec: Any) -> str:
+    """Walk a rippleSpec and return its copy, in document order.
+
+    A ripple site has no HTML until it is built, so the spec IS the page. Keys that
+    carry structure are skipped (see ``_SPEC_STRUCTURAL_KEYS``); price-ish numbers
+    are rendered with their key so "1200" reaches the index as "price 1200" and can
+    actually be retrieved.
+    """
+    out: list[str] = []
+    seen: set[int] = set()
+
+    def walk(node: Any, key: str | None) -> None:
+        # Specs are trees, but a caller could hand us a self-referencing dict; the
+        # id guard makes that terminate instead of recursing forever.
+        if isinstance(node, (dict, list)):
+            if id(node) in seen:
+                return
+            seen.add(id(node))
+        if isinstance(node, dict):
+            for child_key, child in node.items():
+                if child_key in _SPEC_STRUCTURAL_KEYS:
+                    continue
+                walk(child, child_key)
+        elif isinstance(node, list):
+            for child in node:
+                walk(child, key)
+        elif isinstance(node, str):
+            if _is_copy(node):
+                out.append(node.strip())
+        elif isinstance(node, bool):
+            return  # a flag is never copy (and bool is an int, so check it first)
+        elif isinstance(node, (int, float)) and key in _SPEC_NUMERIC_KEYS:
+            out.append(f"{key} {node}")
+
+    walk(spec, None)
+    return _tidy("\n".join(out))
+
+
+# --------------------------------------------------------------------------- #
+# Document assembly
+# --------------------------------------------------------------------------- #
+
+
+def _path_slug(path: str) -> str:
+    """A kb-safe, deterministic article source for a page path.
+
+    kb-go derives an article id from the source string, so this must be stable
+    across syncs (that is what makes a re-sync update rather than duplicate) and
+    must not collide with an owner-uploaded file in the same pocket scope — hence
+    the ``site-`` prefix. kb-go also splits on "/", so slashes become dashes here
+    rather than being handed over intact.
+    """
+    # Drop the file extension first so an html lane's "/about.html" and a svelte
+    # lane's "/about" describe the same page under the same name.
+    stripped = re.sub(r"\.(html?|svelte|md|svx)$", "", path.strip().lower())
+    # SvelteKit route scaffolding is not part of the page's identity, so
+    # "src/routes/menu/+page" reads as "menu" like the html lane's "menu.html".
+    stripped = re.sub(r"^/?src/routes/", "", stripped)
+    stripped = re.sub(r"/?\+(page|layout)$", "", stripped)
+    cleaned = _SLUG_RE.sub("-", stripped).strip("-")
+    # Index pages of any lane land on one name, so "/", "/index.html" and a
+    # SvelteKit root route are one article rather than three copies of the homepage.
+    if cleaned in ("", "index", "src-routes-page"):
+        cleaned = "home"
+    return f"site-{cleaned}"[:120]
+
+
+def _page_text(path: str, body: str, engine: str) -> str:
+    if engine == "html":
+        return html_to_text(body)
+    if engine == "svelte":
+        return svelte_to_text(body)
+    return _tidy(body)
+
+
+def _is_page(path: str, engine: str) -> bool:
+    lowered = path.lower()
+    if engine == "html":
+        return lowered.endswith((".html", ".htm"))
+    if engine == "svelte":
+        # Route files are pages; components they import are pulled in as text too,
+        # since a component often holds the pricing table or the hours block.
+        return lowered.endswith((".svelte", ".md", ".svx"))
+    return False
+
+
+def extract_site_documents(
+    *,
+    engine: str,
+    ripple_spec: Any = None,
+    source: dict[str, Any] | None = None,
+) -> list[SiteDocument]:
+    """Turn a pocket's stored content into ingestable documents, one per page.
+
+    Pure — no I/O, no Beanie, no kb subprocess — so the lane rules are unit-testable
+    on their own. Returns [] when there is nothing to ingest (a foreign site with an
+    empty pocket, a spec with no copy), which the caller reports rather than treats
+    as a failure.
+    """
+    docs: list[SiteDocument] = []
+
+    if engine in ("html", "svelte") and isinstance(source, dict):
+        # Sorted so a sync is deterministic and the homepage tends to lead.
+        for path in sorted(source):
+            if len(docs) >= _MAX_DOCUMENTS:
+                break
+            body = source.get(path)
+            if not isinstance(body, str) or not _is_page(path, engine):
+                continue
+            text = _page_text(path, body, engine)[:_MAX_DOCUMENT_CHARS]
+            if len(text) < _MIN_DOCUMENT_CHARS:
+                continue
+            docs.append(SiteDocument(path=path, source=_path_slug(path), text=text))
+        return docs
+
+    # ripple (and anything unrecognised that still carries a spec): the spec is the
+    # whole site, so it becomes one document.
+    text = spec_to_text(ripple_spec or {})[:_MAX_DOCUMENT_CHARS]
+    if len(text) >= _MIN_DOCUMENT_CHARS:
+        docs.append(SiteDocument(path="/", source=_path_slug("/"), text=text))
+    return docs
+
+
+# --------------------------------------------------------------------------- #
+# Sync
+# --------------------------------------------------------------------------- #
+
+
+def kb_scope_for_pocket(pocket_id: str) -> str:
+    """The scope a CONCIERGE run reads. Mirrors ``_kb_scopes_for_context``'s
+    concierge branch — if that ever changes, this is the other end of the pair."""
+    return f"pocket:{pocket_id}"
+
+
+async def _load_pocket_content(site: Any) -> dict[str, Any] | None:
+    """The site's pocket as a wire dict, or None when it can't be read.
+
+    Reads AS THE SITE OWNER (``site.owner``) — the same identity ``publish_pocket``
+    uses — so the access check is the real one and this can never read a pocket the
+    site's owner could not.
+    """
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    if not site.pocket_id:
+        return None
+    try:
+        return await pockets_service.get(site.pocket_id, site.owner)
+    except Exception:  # noqa: BLE001 — a missing/denied pocket is "nothing to sync"
+        logger.warning(
+            "sites.kb: could not read pocket %s for site %s",
+            site.pocket_id,
+            getattr(site, "id", "?"),
+            exc_info=True,
+        )
+        return None
+
+
+async def sync_site_knowledge(site: Any) -> SiteKnowledgeReport:
+    """Ingest a site's own content into its pocket KB and prune what it replaced.
+
+    Idempotent: the same content re-syncs to the same article ids (kb-go versions
+    them), and ids this site produced previously but no longer produces are deleted,
+    so a removed page stops being quotable. Only ids recorded on THIS Site are ever
+    deleted — the pocket scope also holds owner-uploaded files and must survive.
+
+    Records ``kb_article_ids`` / ``kb_synced_at`` / ``kb_sync_error`` on the Site so
+    the dashboard can show whether the concierge actually has anything to work with.
+    """
+    from pocketpaw_ee.cloud.agents.knowledge import KnowledgeService
+
+    report = SiteKnowledgeReport()
+    scope = kb_scope_for_pocket(site.pocket_id or "")
+    previous = list(getattr(site, "kb_article_ids", None) or [])
+
+    pocket = await _load_pocket_content(site)
+    if pocket is None:
+        report.error = "pocket_unavailable"
+        await _record_sync(site, report, previous=previous)
+        return report
+
+    docs = extract_site_documents(
+        engine=pocket.get("engine") or "ripple",
+        ripple_spec=pocket.get("rippleSpec") or {},
+        source=pocket.get("source") if isinstance(pocket.get("source"), dict) else None,
+    )
+    if not docs:
+        # Nothing to ingest is a real state, not an error: a foreign site's pocket
+        # holds no pages. Previously-ingested articles are left alone rather than
+        # purged on what may be a transient empty read.
+        report.error = "no_content"
+        await _record_sync(site, report, previous=previous)
+        return report
+
+    for doc in docs:
+        try:
+            result = await KnowledgeService.ingest_text_to_scope(scope, doc.text, doc.source)
+        except Exception:  # noqa: BLE001 — one bad page must not lose the rest
+            report.skipped += 1
+            logger.warning(
+                "sites.kb: ingest failed for %s on site %s",
+                doc.path,
+                getattr(site, "id", "?"),
+                exc_info=True,
+            )
+            continue
+        article_id = str((result or {}).get("article") or "").strip()
+        if not article_id:
+            report.skipped += 1
+            continue
+        report.ingested += 1
+        report.article_ids.append(article_id)
+
+    # Prune what this site used to publish and no longer does. Anything not in the
+    # fresh set is a page that was renamed or deleted.
+    stale = [a for a in previous if a not in set(report.article_ids)]
+    for article_id in stale:
+        if await KnowledgeService.remove_article(scope, article_id):
+            report.removed += 1
+
+    await _record_sync(site, report, previous=previous)
+    logger.info(
+        "sites.kb: synced site %s into %s (ingested=%d removed=%d skipped=%d)",
+        getattr(site, "id", "?"),
+        scope,
+        report.ingested,
+        report.removed,
+        report.skipped,
+    )
+    return report
+
+
+async def _record_sync(site: Any, report: SiteKnowledgeReport, *, previous: list[str]) -> None:
+    """Persist the sync bookkeeping on the Site.
+
+    Writes ONLY the three kb_* fields, via ``$set`` rather than a whole-document
+    save. This runs in the background, minutes after the publish that scheduled it,
+    holding a Site instance snapshotted at that moment — so a full save would
+    silently roll back anything written to the same Site in between (a domain
+    connected, a subscription stamped). A targeted set touches nothing it does not
+    own.
+
+    A failed or empty sync keeps the PREVIOUS article ids: they are still in the KB,
+    so forgetting them would strand them beyond the reach of any future prune. The
+    reason is recorded so the dashboard can tell "no knowledge yet" from "syncing is
+    broken".
+    """
+    updates = {
+        "kb_article_ids": report.article_ids if report.ingested else previous,
+        "kb_synced_at": datetime.now(UTC),
+        "kb_sync_error": report.error,
+    }
+    try:
+        await site.set(updates)
+    except Exception:  # noqa: BLE001 — bookkeeping must not fail the caller
+        logger.warning(
+            "sites.kb: could not record sync state on site %s",
+            getattr(site, "id", "?"),
+            exc_info=True,
+        )
+
+
+async def safe_sync_site_knowledge(site: Any) -> SiteKnowledgeReport:
+    """``sync_site_knowledge`` that never raises — the form background callers use."""
+    try:
+        return await sync_site_knowledge(site)
+    except Exception:  # noqa: BLE001 — a KB sync is never a gate on publish or chat
+        logger.warning("sites.kb: sync failed for site %s", getattr(site, "id", "?"), exc_info=True)
+        return SiteKnowledgeReport(error="sync_failed")
+
+
+# Background-task keepalive: asyncio holds only a WEAK ref to a bare create_task, so
+# a fire-and-forget sync can be collected mid-run. Mirrors the pre-warm scheduler in
+# ``sites.service``.
+_SYNC_TASKS: set[asyncio.Task[Any]] = set()
+
+
+def _default_sync_scheduler(coro: Any) -> None:
+    """Detach the sync onto the running loop and return immediately. With no running
+    loop (a sync call site) the coroutine is closed and skipped. Tests patch this
+    module attribute to run the coroutine inline instead."""
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        coro.close()
+        return
+    task = loop.create_task(coro)
+    _SYNC_TASKS.add(task)
+    task.add_done_callback(_SYNC_TASKS.discard)
+
+
+def schedule_site_knowledge_sync(site: Any) -> None:
+    """Fire a background KB sync for a site. Never blocks, never raises.
+
+    Ingest compiles articles, which can be slow, so no caller waits on it: a publish
+    returns as soon as the site is live and the concierge gains its knowledge a
+    moment later. Callers that need the result (the owner's "sync now") await
+    ``sync_site_knowledge`` directly.
+    """
+    _default_sync_scheduler(safe_sync_site_knowledge(site))
+
+
+__all__ = [
+    "SiteDocument",
+    "SiteKnowledgeReport",
+    "extract_site_documents",
+    "html_to_text",
+    "kb_scope_for_pocket",
+    "safe_sync_site_knowledge",
+    "schedule_site_knowledge_sync",
+    "spec_to_text",
+    "svelte_to_text",
+    "sync_site_knowledge",
+]

--- a/ee/pocketpaw_ee/sites/kb_ingest.py
+++ b/ee/pocketpaw_ee/sites/kb_ingest.py
@@ -461,8 +461,27 @@ async def sync_site_knowledge(site: Any) -> SiteKnowledgeReport:
         report.ingested += 1
         report.article_ids.append(article_id)
 
+    if not report.ingested:
+        # The site HAS pages and not one of them made it in — the ingest engine is
+        # unreachable or broken. That is a failure, not a clean sync of nothing, and
+        # saying so is the difference between a dashboard that reads "nothing
+        # learned yet" and one that tells the owner something is wrong.
+        report.error = "ingest_failed"
+        await _record_sync(site, report, previous=previous)
+        logger.warning(
+            "sites.kb: every page failed to ingest for site %s (%d skipped)",
+            getattr(site, "id", "?"),
+            report.skipped,
+        )
+        return report
+
     # Prune what this site used to publish and no longer does. Anything not in the
     # fresh set is a page that was renamed or deleted.
+    #
+    # Reachable ONLY after a successful ingest, deliberately: the fresh set is the
+    # thing "no longer produced" is measured against, so an empty one from a failed
+    # run would mark EVERY existing article stale and delete the site's whole
+    # knowledge base over a transient outage.
     stale = [a for a in previous if a not in set(report.article_ids)]
     for article_id in stale:
         if await KnowledgeService.remove_article(scope, article_id):

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -2137,7 +2137,36 @@ async def _deploy_site_doc(
         if is_dynamic:
             doc.d1_database_id = d1_database_id
         await doc.save()
+
+    # The site's content just changed, so the knowledge its concierge answers from
+    # is now stale. Re-sync in the background: ingest compiles articles and can be
+    # slow, and a publish must not wait on it — the site goes live immediately and
+    # the concierge catches up a moment later. A preview publish never reaches here
+    # (it returns earlier), so a draft never rewrites the live KB.
+    _schedule_site_knowledge_sync(doc)
     return doc
+
+
+def _schedule_site_knowledge_sync(site: _SiteDoc) -> None:
+    """Fire the background site→pocket-KB sync. Non-async, never blocks, never
+    raises. Looked up through the module so tests can patch it, mirroring
+    ``_schedule_native_prewarm``.
+
+    The try/except is the point: this is called from the tail of a LIVE deploy, so
+    anything that escapes here would fail a publish of a site that is already
+    deployed and serving. A concierge with stale knowledge is a much smaller problem
+    than a publish that reports failure after succeeding.
+    """
+    try:
+        from pocketpaw_ee.sites.kb_ingest import schedule_site_knowledge_sync
+
+        schedule_site_knowledge_sync(site)
+    except Exception:  # noqa: BLE001 — never fail a live publish over a KB sync
+        logger.warning(
+            "sites.kb: could not schedule knowledge sync for site %s",
+            getattr(site, "id", "?"),
+            exc_info=True,
+        )
 
 
 async def _provision_dynamic_site(
@@ -2445,6 +2474,10 @@ async def finalize_provisioned_site(site: _SiteDoc, *, url: str) -> None:
     site.deployed_at = datetime.now(UTC)
     site.url = url
     await site.save()
+    # A dynamic site stands up through this job rather than through
+    # ``_deploy_site_doc``, so it needs its own knowledge sync or its concierge
+    # would be the only one left knowing nothing about the business.
+    _schedule_site_knowledge_sync(site)
 
 
 async def mark_provision_failed(site: _SiteDoc) -> None:

--- a/tests/cloud/test_paw_bar_admin_aggregation.py
+++ b/tests/cloud/test_paw_bar_admin_aggregation.py
@@ -995,3 +995,15 @@ async def test_knowledge_member_role_is_forbidden(mongo_db, store, fabric, monke
     async with AsyncClient(transport=transport, base_url="http://t") as c:
         assert (await c.get(f"/paw-bar/admin/site/{site.id}/knowledge")).status_code == 403
         assert (await c.post(f"/paw-bar/admin/site/{site.id}/knowledge/sync")).status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_overview_carries_the_transcript_retention_setting(client):
+    """The dashboard renders all three owner settings from the one call it already
+    makes, rather than a second round trip for a single boolean."""
+    c, store, _fabric = client
+    site = await _site(concierge_store_transcripts=False)
+    await store.create_widget(_widget())
+
+    body = (await c.get(f"/paw-bar/admin/site/{site.id}/overview")).json()
+    assert body["store_transcripts"] is False

--- a/tests/cloud/test_paw_bar_admin_aggregation.py
+++ b/tests/cloud/test_paw_bar_admin_aggregation.py
@@ -24,6 +24,10 @@
 #   agent's, a run with no reply still shows what was asked, the question is
 #   stamped earlier than the answer, and the conversations preview falls back to
 #   the visitor's question only when there is no reply to show.
+# Updated 2026-07-26 (site knowledge sync): an eleventh layer covers the two
+#   knowledge endpoints — the read distinguishes "never synced" from a failure, the
+#   sync is awaited and returns its own counts, a failed sync surfaces as a status
+#   rather than a 500, and both are cross-tenant-404 and member-403.
 
 from __future__ import annotations
 
@@ -894,3 +898,100 @@ async def test_conversations_preview_still_prefers_the_reply(client):
 
     body = (await c.get(f"/paw-bar/admin/site/{site.id}/conversations")).json()
     assert [i["preview"] for i in body["items"]] == ["Yes, within 5km."]
+
+
+# --------------------------------------------------------------------------- #
+# Layer 11 — concierge knowledge (site content in the pocket KB it reads)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_knowledge_reports_never_synced_before_the_first_sync(client):
+    """A site that has never synced is distinguishable from one whose sync failed,
+    so the dashboard can say "no knowledge yet" instead of "something is broken"."""
+    c, store, _fabric = client
+    site = await _site()
+    await store.create_widget(_widget())
+
+    body = (await c.get(f"/paw-bar/admin/site/{site.id}/knowledge")).json()
+    assert body["article_count"] == 0
+    assert body["status"] == "never_synced"
+    assert body["synced_at"] == ""
+
+
+@pytest.mark.asyncio
+async def test_knowledge_reports_what_the_concierge_can_quote(client):
+    c, store, _fabric = client
+    site = await _site()
+    site.kb_article_ids = ["site-home", "site-about"]
+    site.kb_synced_at = datetime.now(UTC)
+    await site.save()
+
+    body = (await c.get(f"/paw-bar/admin/site/{site.id}/knowledge")).json()
+    assert body["article_count"] == 2
+    assert body["status"] == ""
+    assert body["synced_at"]
+
+
+@pytest.mark.asyncio
+async def test_knowledge_sync_runs_and_reports(client, monkeypatch):
+    """The owner clicked a button, so the sync is awaited and its result returned
+    rather than promised."""
+    c, store, _fabric = client
+    site = await _site()
+
+    async def _fake_sync(target):
+        from pocketpaw_ee.sites.kb_ingest import SiteKnowledgeReport
+
+        target.kb_article_ids = ["site-home"]
+        target.kb_synced_at = datetime.now(UTC)
+        target.kb_sync_error = ""
+        return SiteKnowledgeReport(ingested=1, removed=2, article_ids=["site-home"])
+
+    monkeypatch.setattr("pocketpaw_ee.sites.kb_ingest.safe_sync_site_knowledge", _fake_sync)
+
+    res = await c.post(f"/paw-bar/admin/site/{site.id}/knowledge/sync")
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["ingested"] == 1
+    assert body["removed"] == 2
+    assert body["article_count"] == 1
+    assert body["status"] == ""
+
+
+@pytest.mark.asyncio
+async def test_knowledge_sync_surfaces_a_failure_instead_of_500ing(client, monkeypatch):
+    c, store, _fabric = client
+    site = await _site()
+
+    async def _failing_sync(target):
+        from pocketpaw_ee.sites.kb_ingest import SiteKnowledgeReport
+
+        target.kb_sync_error = "sync_failed"
+        return SiteKnowledgeReport(error="sync_failed")
+
+    monkeypatch.setattr("pocketpaw_ee.sites.kb_ingest.safe_sync_site_knowledge", _failing_sync)
+
+    res = await c.post(f"/paw-bar/admin/site/{site.id}/knowledge/sync")
+    assert res.status_code == 200
+    assert res.json()["status"] == "sync_failed"
+
+
+@pytest.mark.asyncio
+async def test_knowledge_cross_tenant_is_404(client):
+    c, _store, _fabric = client
+    site = await _site(workspace="ws-other")
+    assert (await c.get(f"/paw-bar/admin/site/{site.id}/knowledge")).status_code == 404
+    assert (await c.post(f"/paw-bar/admin/site/{site.id}/knowledge/sync")).status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_knowledge_member_role_is_forbidden(mongo_db, store, fabric, monkeypatch):
+    """A site's knowledge state and its sync are owner/admin surfaces: the read
+    exposes how the concierge is configured, and the sync spends compute."""
+    app = _build_app(store, fabric, monkeypatch, role="member")
+    site = await _site()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as c:
+        assert (await c.get(f"/paw-bar/admin/site/{site.id}/knowledge")).status_code == 403
+        assert (await c.post(f"/paw-bar/admin/site/{site.id}/knowledge/sync")).status_code == 403

--- a/tests/cloud/test_paw_bar_admin_aggregation.py
+++ b/tests/cloud/test_paw_bar_admin_aggregation.py
@@ -19,6 +19,11 @@
 #     status, created_at}.
 #   * Handoffs empty-but-well-shaped in v1 (no producer), and isolated by widget.
 #   * Conversations list (LISTABLE — grouped by customer_ref, unsupported=False).
+# Updated 2026-07-26 (concierge transcripts): a tenth layer covers two-sided
+#   transcripts — a run carrying ``user_text`` renders the visitor turn before the
+#   agent's, a run with no reply still shows what was asked, the question is
+#   stamped earlier than the answer, and the conversations preview falls back to
+#   the visitor's question only when there is no reply to show.
 
 from __future__ import annotations
 
@@ -616,8 +621,9 @@ _CUST = "cust-0001"  # valid customer_ref (>= 8 chars, allowed charset)
 @pytest.mark.asyncio
 async def test_transcript_happy_path_ordered_and_shaped(client):
     """The transcript is this visitor's concierge turns, oldest-first, shaped
-    {customer_ref, messages:[{role,content,created_at}], count}. v1: assistant-only
-    (the concierge MVP doesn't persist the visitor's message)."""
+    {customer_ref, messages:[{role,content,created_at}], count}. These runs carry
+    no stored visitor text, so the result is assistant-only — which is exactly the
+    shape a site with transcript retention turned off keeps producing."""
     c, store, _fabric = client
     site = await _site()
     await store.create_widget(_widget())
@@ -787,3 +793,104 @@ async def test_preview_frame_served_when_concierge_disabled(client):
     res = await c.get(f"/paw-bar/admin/site/{site.id}/preview-frame")
     assert res.status_code == 200
     assert "window.__PAWBAR__" in res.text
+
+
+# --------------------------------------------------------------------------- #
+# Layer 10 — two-sided transcripts (visitor lines stored on the run doc)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_transcript_interleaves_visitor_and_agent_turns(client):
+    """A run that stored the visitor's line renders BOTH turns, question first,
+    so the owner reads a conversation instead of a monologue."""
+    c, store, _fabric = client
+    site = await _site()
+    await store.create_widget(_widget())
+    now = datetime.now(UTC)
+    await _mk_run(
+        user_id=_CUST,
+        user_text="What time do you open?",
+        partial_text="We open at 8am.",
+        createdAt=now - timedelta(minutes=5),
+        ended_at=now - timedelta(minutes=4),
+    )
+    await _mk_run(
+        user_id=_CUST,
+        user_text="Do you do gluten free?",
+        partial_text="Yes, every day.",
+        createdAt=now,
+        ended_at=now,
+    )
+
+    res = await c.get(f"/paw-bar/admin/site/{site.id}/conversations/{_CUST}")
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["count"] == 4
+    assert [(m["role"], m["content"]) for m in body["messages"]] == [
+        ("user", "What time do you open?"),
+        ("assistant", "We open at 8am."),
+        ("user", "Do you do gluten free?"),
+        ("assistant", "Yes, every day."),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_transcript_keeps_visitor_turn_when_reply_missing(client):
+    """A run that failed before answering still shows what was asked — otherwise
+    the owner sees an empty conversation and has no idea what went wrong."""
+    c, store, _fabric = client
+    site = await _site()
+    await store.create_widget(_widget())
+    await _mk_run(user_id=_CUST, user_text="Are you open on Sunday?", partial_text="")
+
+    res = await c.get(f"/paw-bar/admin/site/{site.id}/conversations/{_CUST}")
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert [(m["role"], m["content"]) for m in body["messages"]] == [
+        ("user", "Are you open on Sunday?")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_transcript_user_turn_is_stamped_at_ask_time(client):
+    """The question carries the run's creation time and the answer its end time,
+    so a slow reply is visible in the transcript rather than collapsed."""
+    c, store, _fabric = client
+    site = await _site()
+    await store.create_widget(_widget())
+    asked = datetime.now(UTC) - timedelta(minutes=2)
+    answered = datetime.now(UTC)
+    await _mk_run(
+        user_id=_CUST, user_text="hello?", partial_text="hi!", createdAt=asked, ended_at=answered
+    )
+
+    body = (await c.get(f"/paw-bar/admin/site/{site.id}/conversations/{_CUST}")).json()
+    # Mongo stores millisecond precision, so compare the ORDER rather than exact
+    # microseconds: the question must be stamped strictly before the answer.
+    assert body["messages"][0]["created_at"] < body["messages"][1]["created_at"]
+
+
+@pytest.mark.asyncio
+async def test_conversations_preview_falls_back_to_visitor_question(client):
+    """A conversation whose run produced no reply used to render a blank row; it
+    now previews what the visitor asked."""
+    c, store, _fabric = client
+    site = await _site()
+    await store.create_widget(_widget())
+    await _mk_run(user_id=_CUST, user_text="Do you deliver?", partial_text="")
+
+    body = (await c.get(f"/paw-bar/admin/site/{site.id}/conversations")).json()
+    assert [i["preview"] for i in body["items"]] == ["Do you deliver?"]
+
+
+@pytest.mark.asyncio
+async def test_conversations_preview_still_prefers_the_reply(client):
+    """The existing preview behaviour is unchanged when there IS a reply."""
+    c, store, _fabric = client
+    site = await _site()
+    await store.create_widget(_widget())
+    await _mk_run(user_id=_CUST, user_text="Do you deliver?", partial_text="Yes, within 5km.")
+
+    body = (await c.get(f"/paw-bar/admin/site/{site.id}/conversations")).json()
+    assert [i["preview"] for i in body["items"]] == ["Yes, within 5km."]

--- a/tests/cloud/test_paw_bar_concierge_chat.py
+++ b/tests/cloud/test_paw_bar_concierge_chat.py
@@ -14,6 +14,11 @@
 #     SIBLING pocket/workspace than the key → 403, and a happy path that streams
 #     SSE frames while dispatching a correctly-shaped CONCIERGE RunSpec (executor
 #     stubbed — the live agent run is T5).
+# Updated 2026-07-26 (concierge transcripts): a fourth layer covers visitor-message
+#   retention — the dispatched spec carries the visitor's line by default, carries
+#   nothing when the site's concierge_store_transcripts is off (while the AGENT
+#   still receives the full message either way), the stored copy is length-capped,
+#   and create_run actually lands the field on the run document.
 
 from __future__ import annotations
 
@@ -483,3 +488,134 @@ async def test_chat_rate_limit_is_429(concierge_client):
         )
     res = await client.post("/paw-bar/chat", json=_payload(widget.id), headers={"Origin": _ORIGIN})
     assert res.status_code == 429
+
+
+# --------------------------------------------------------------------------- #
+# Layer 4 — visitor-message retention (concierge transcripts)
+#
+# The concierge visitor is anonymous and has no Message row, so the run doc is the
+# only place the visitor half of a transcript can live. These prove the toggle
+# actually governs storage, that the AGENT is unaffected by it, and that the
+# stored copy is bounded.
+# --------------------------------------------------------------------------- #
+
+
+async def _dispatch(client, store, monkeypatch, *, site_kw=None, **payload_ov):
+    """Run one chat request through the endpoint and return the dispatched RunSpec."""
+    from pocketpaw_ee.cloud.chat.runs.memory_stream import InMemoryStreamTransport
+
+    await _site(**(site_kw or {}))
+    widget = await store.create_widget(_widget(agent_id="agent-xyz"))
+
+    transport = InMemoryStreamTransport()
+    fake_exec = _FakeExecutor(transport)
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.chat.runs.transport.get_stream_transport", lambda: transport
+    )
+    monkeypatch.setattr("pocketpaw_ee.cloud.chat.runs.executor.get_executor", lambda: fake_exec)
+
+    async def _fake_create_run(spec):
+        return SimpleNamespace(run_id=spec.run_id)
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.chat.runs.service.create_run", _fake_create_run)
+
+    res = await client.post(
+        "/paw-bar/chat", json=_payload(widget.id, **payload_ov), headers={"Origin": _ORIGIN}
+    )
+    assert res.status_code == 200, res.text
+    assert len(fake_exec.submitted) == 1
+    return fake_exec.submitted[0]
+
+
+@pytest.mark.asyncio
+async def test_chat_persists_visitor_message_by_default(concierge_client, monkeypatch):
+    """A site with the default settings stores the visitor's line, so the owner's
+    transcript is a conversation and not the agent talking to itself."""
+    client, store = concierge_client
+    spec = await _dispatch(client, store, monkeypatch, message="Do you do gluten free?")
+    assert spec.persist_user_text == "Do you do gluten free?"
+    # The visitor is still anonymous: no Message row is claimed for that text.
+    assert spec.user_message_id == ""
+
+
+@pytest.mark.asyncio
+async def test_chat_does_not_persist_visitor_message_when_retention_off(
+    concierge_client, monkeypatch
+):
+    """concierge_store_transcripts=False keeps the concierge fully working while
+    the visitor's words are never written down."""
+    client, store = concierge_client
+    spec = await _dispatch(
+        client,
+        store,
+        monkeypatch,
+        site_kw={"concierge_store_transcripts": False},
+        message="My order number is 12345",
+    )
+    assert spec.persist_user_text == ""
+    # The AGENT still gets the whole message — the toggle governs storage only.
+    assert spec.content == "My order number is 12345"
+
+
+@pytest.mark.asyncio
+async def test_chat_stored_visitor_message_is_length_capped(concierge_client, monkeypatch):
+    """A pasted wall of text can't grow the run collection without bound, and the
+    agent still receives every character of it."""
+    from pocketpaw_ee.paw_bar.router import _STORED_USER_TEXT_CHARS
+
+    client, store = concierge_client
+    long_message = "a" * (_STORED_USER_TEXT_CHARS + 500)
+    spec = await _dispatch(client, store, monkeypatch, message=long_message)
+    assert len(spec.persist_user_text) == _STORED_USER_TEXT_CHARS
+    assert spec.content == long_message
+
+
+@pytest.mark.asyncio
+async def test_create_run_writes_visitor_text_onto_the_run_doc(mongo_db):
+    """The spec field actually lands on the document the transcript reads back."""
+    from pocketpaw_ee.cloud.chat.runs.domain import RunSpec
+    from pocketpaw_ee.cloud.chat.runs.service import create_run
+
+    spec = RunSpec(
+        run_id="run-transcript-1",
+        workspace_id="ws-1",
+        context_type="concierge",
+        scope_id="pocket-1",
+        session_key="cloud:concierge:pocket-1:cust-1:agent-xyz",
+        group=None,
+        user_id="cust-1",
+        agent_id="agent-xyz",
+        client_message_id="cmid-transcript-1",
+        user_message_id="",
+        persist_user_text="What time do you open?",
+        content="What time do you open?",
+        history=[],
+        intent=None,
+    )
+    doc = await create_run(spec)
+    assert doc.user_text == "What time do you open?"
+
+
+@pytest.mark.asyncio
+async def test_create_run_defaults_visitor_text_to_empty(mongo_db):
+    """Every authed surface leaves the field unset and is unchanged by this."""
+    from pocketpaw_ee.cloud.chat.runs.domain import RunSpec
+    from pocketpaw_ee.cloud.chat.runs.service import create_run
+
+    spec = RunSpec(
+        run_id="run-transcript-2",
+        workspace_id="ws-1",
+        context_type="pocket",
+        scope_id="pocket-1",
+        session_key="cloud:pocket:pocket-1",
+        group=None,
+        user_id="user:maya",
+        agent_id="agent-xyz",
+        client_message_id="cmid-transcript-2",
+        user_message_id="msg-1",
+        content="hello",
+        history=[],
+        intent=None,
+    )
+    doc = await create_run(spec)
+    assert doc.user_text == ""

--- a/tests/cloud/test_paw_bar_concierge_settings.py
+++ b/tests/cloud/test_paw_bar_concierge_settings.py
@@ -10,6 +10,9 @@
 #   * The admin settings surface: GET + PATCH /paw-bar/admin/site/{id}/settings
 #     round-trips the two fields, rejects a cross-tenant id (404), and a PATCH that
 #     flips the switch off silences the frame on the NEXT request (immediate effect).
+# Updated 2026-07-26 (concierge transcripts): a fifth layer covers the
+#   transcript-retention toggle — exposed on GET, writable via PATCH, defaults on,
+#   and fully independent of the kill switch in both directions.
 
 from __future__ import annotations
 
@@ -310,3 +313,56 @@ async def test_toggle_off_silences_frame_immediately(client):
     after = await c.get("/paw-bar/frame", params={"key": _VALID_KEY})
     assert after.status_code == 403
     assert "concierge_disabled" in after.text
+
+
+# --------------------------------------------------------------------------- #
+# Layer 5 — the transcript-retention toggle
+#
+# Retention is its own switch because it is the only concierge setting that
+# governs whether NEW personal data is collected. These prove it is exposed,
+# writable, independent of the kill switch, and defaults to on.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_settings_get_exposes_transcript_retention_default_on(client):
+    c, _store = client
+    site = await _site()
+    body = (await c.get(f"/paw-bar/admin/site/{site.id}/settings")).json()
+    assert body["concierge_store_transcripts"] is True
+
+
+@pytest.mark.asyncio
+async def test_settings_patch_can_turn_transcript_retention_off(client):
+    c, _store = client
+    site = await _site()
+    res = await c.patch(
+        f"/paw-bar/admin/site/{site.id}/settings",
+        json={"concierge_store_transcripts": False},
+    )
+    assert res.status_code == 200, res.text
+    assert res.json()["concierge_store_transcripts"] is False
+    got = await c.get(f"/paw-bar/admin/site/{site.id}/settings")
+    assert got.json()["concierge_store_transcripts"] is False
+
+
+@pytest.mark.asyncio
+async def test_transcript_retention_is_independent_of_the_kill_switch(client):
+    """Turning retention off must not silence the concierge, and turning the
+    concierge off must not silently flip retention."""
+    c, _store = client
+    site = await _site(concierge_greeting="Hi there")
+    res = await c.patch(
+        f"/paw-bar/admin/site/{site.id}/settings",
+        json={"concierge_store_transcripts": False},
+    )
+    body = res.json()
+    assert body["concierge_store_transcripts"] is False
+    assert body["concierge_enabled"] is True  # concierge still live
+    assert body["concierge_greeting"] == "Hi there"  # untouched
+
+    res2 = await c.patch(
+        f"/paw-bar/admin/site/{site.id}/settings",
+        json={"concierge_enabled": False},
+    )
+    assert res2.json()["concierge_store_transcripts"] is False  # still off, not reset

--- a/tests/cloud/test_site_kb_ingest.py
+++ b/tests/cloud/test_site_kb_ingest.py
@@ -385,3 +385,61 @@ async def test_sync_only_writes_its_own_fields(monkeypatch):
 
     assert len(site.set_calls) == 1
     assert set(site.set_calls[0]) == {"kb_article_ids", "kb_synced_at", "kb_sync_error"}
+
+
+@pytest.mark.asyncio
+async def test_total_ingest_failure_is_reported_not_called_clean(monkeypatch):
+    """A site that HAS pages where not one of them made it in means the ingest
+    engine is unreachable. Reporting that as a clean sync of nothing leaves the
+    dashboard saying "nothing learned yet" while the real problem is invisible."""
+
+    async def _broken(scope, text, source):
+        raise RuntimeError("kb binary not found")
+
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.agents.knowledge.KnowledgeService.ingest_text_to_scope", _broken
+    )
+    _patch_pocket(
+        monkeypatch,
+        {"engine": "html", "source": {"index.html": f"<p>{_long('We open at 8am.')}</p>"}},
+    )
+    site = _FakeSite()
+
+    report = await kb_ingest.sync_site_knowledge(site)
+
+    assert report.ingested == 0
+    assert report.skipped == 1
+    assert report.error == "ingest_failed"
+    assert site.kb_sync_error == "ingest_failed"
+
+
+@pytest.mark.asyncio
+async def test_a_failed_ingest_never_purges_the_existing_knowledge(monkeypatch):
+    """The fresh set is what "no longer produced" is measured against, so an empty
+    one from a failed run would mark every existing article stale. A transient
+    outage must not wipe the site's whole knowledge base."""
+    removed: list[str] = []
+
+    async def _broken(scope, text, source):
+        raise RuntimeError("kb down")
+
+    async def _remove(scope, article_id):
+        removed.append(article_id)
+        return True
+
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.agents.knowledge.KnowledgeService.ingest_text_to_scope", _broken
+    )
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.agents.knowledge.KnowledgeService.remove_article", _remove
+    )
+    _patch_pocket(
+        monkeypatch,
+        {"engine": "html", "source": {"index.html": f"<p>{_long('We open at 8am.')}</p>"}},
+    )
+    site = _FakeSite(kb_article_ids=["site-home", "site-about", "site-pricing"])
+
+    await kb_ingest.sync_site_knowledge(site)
+
+    assert removed == []  # nothing deleted
+    assert site.kb_article_ids == ["site-home", "site-about", "site-pricing"]  # all kept

--- a/tests/cloud/test_site_kb_ingest.py
+++ b/tests/cloud/test_site_kb_ingest.py
@@ -1,0 +1,387 @@
+# tests/cloud/test_site_kb_ingest.py — site content → the pocket KB its concierge
+# reads (ee.pocketpaw_ee.sites.kb_ingest).
+# Created 2026-07-26. A dedicated concierge reads exactly ONE scope,
+# pocket:<pocket_id>, and nothing used to put the site's own pages there, so the
+# agent was live and knowledge-empty. Layers:
+#   * Extraction (pure, no I/O): HTML strips script/style but keeps the title and
+#     image alt text; Svelte drops script/style blocks and template expressions;
+#     ripple walks the spec for copy while skipping structural keys, and renders
+#     price-ish numbers with their key so they are retrievable.
+#   * Article sources: deterministic and kb-safe, so a re-sync UPDATES rather than
+#     duplicating, and "/", "index.html" and a SvelteKit root route are one article.
+#   * Sync: ingests into pocket:<id>, records the ids on the Site, prunes only the
+#     ids it previously wrote (the scope is shared with owner-uploaded files, which
+#     must survive), and reports rather than raises on an empty or broken read.
+#   * Triggers: a live publish and an agent provision each schedule a sync; a
+#     PREVIEW publish does not.
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pocketpaw_ee.sites import kb_ingest
+
+# --------------------------------------------------------------------------- #
+# Extraction
+# --------------------------------------------------------------------------- #
+
+
+def test_html_keeps_copy_and_drops_code():
+    html = (
+        "<html><head><title>Brew &amp; Co | Hours</title>"
+        "<style>body{color:red}</style></head>"
+        "<body><h1>Brew &amp; Co</h1><p>We open at 8am.</p>"
+        "<script>var tracker = 1;</script>"
+        '<img src="latte.jpg" alt="Latte art"></body></html>'
+    )
+    text = kb_ingest.html_to_text(html)
+    assert "Brew & Co | Hours" in text  # the title is the page's own summary
+    assert "We open at 8am." in text
+    assert "Latte art" in text  # alt text is real content on a visual page
+    assert "color:red" not in text
+    assert "tracker" not in text
+
+
+def test_html_survives_malformed_markup():
+    """Customer-authored and crawler-harvested pages are not always well formed;
+    partial text beats failing the publish that scheduled the sync."""
+    text = kb_ingest.html_to_text("<p>Open daily<p>Closed Sunday</div></span>")
+    assert "Open daily" in text
+    assert "Closed Sunday" in text
+
+
+def test_svelte_drops_code_blocks_and_expressions():
+    source = (
+        "<script>let price = 320; import X from './X.svelte';</script>"
+        "<h1>Menu</h1><p>Flat white {price} rupees</p>"
+        "<style>h1{font-size:2rem}</style>"
+    )
+    text = kb_ingest.svelte_to_text(source)
+    assert "Menu" in text
+    assert "Flat white" in text and "rupees" in text
+    assert "import" not in text
+    assert "font-size" not in text
+
+
+def test_spec_collects_copy_and_skips_structure():
+    spec = {
+        "type": "page",
+        "id": "p1",
+        "blocks": [
+            {
+                "type": "hero",
+                "heading": "Acme Bakery",
+                "sub": "Fresh sourdough daily",
+                "class": "text-lg",
+                "href": "https://acme.test/order",
+                "color": "#ff0055",
+            },
+            {"type": "catalog", "items": [{"name": "Sourdough", "price_cents": 500}]},
+        ],
+    }
+    text = kb_ingest.spec_to_text(spec)
+    assert "Acme Bakery" in text
+    assert "Fresh sourdough daily" in text
+    assert "Sourdough" in text
+    assert "price_cents 500" in text  # a bare 500 would be unretrievable
+    assert "text-lg" not in text
+    assert "acme.test" not in text
+    assert "#ff0055" not in text
+
+
+def test_spec_walk_terminates_on_a_self_referencing_dict():
+    spec: dict[str, Any] = {"heading": "Acme Bakery"}
+    spec["self"] = spec
+    assert "Acme Bakery" in kb_ingest.spec_to_text(spec)
+
+
+def test_spec_ignores_booleans():
+    """A flag is never copy, and bool is an int, so it must be checked first."""
+    assert kb_ingest.spec_to_text({"visible": True, "heading": "Acme"}).strip() == "Acme"
+
+
+# --------------------------------------------------------------------------- #
+# Article sources (idempotence depends on these being stable)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("/", "site-home"),
+        ("index.html", "site-home"),
+        ("src/routes/+page.svelte", "site-home"),
+        ("/about.html", "site-about"),
+        ("/about", "site-about"),
+        ("src/routes/menu/+page.svelte", "site-menu"),
+        ("/products/coffee.html", "site-products-coffee"),
+    ],
+)
+def test_article_source_is_stable_and_kb_safe(path, expected):
+    """kb-go derives an article id from the source and splits it on "/", so a source
+    must carry no slashes, must be prefixed so it cannot collide with an
+    owner-uploaded file in the same pocket scope, and must be identical across syncs
+    (that is what makes a re-sync version the article instead of duplicating it)."""
+    source = kb_ingest._path_slug(path)
+    assert source == expected
+    assert "/" not in source
+    assert source.startswith("site-")
+
+
+# --------------------------------------------------------------------------- #
+# Document assembly
+# --------------------------------------------------------------------------- #
+
+
+def _long(text: str) -> str:
+    return (text + " ") * 8
+
+
+def test_html_lane_makes_one_document_per_page_and_skips_assets():
+    docs = kb_ingest.extract_site_documents(
+        engine="html",
+        source={
+            "index.html": f"<h1>Home</h1><p>{_long('Open 8am to 6pm daily.')}</p>",
+            "about.html": f"<p>{_long('Baking here since 1998.')}</p>",
+            "styles.css": "body{margin:0}",
+            "app.js": "console.log(1)",
+        },
+    )
+    assert [d.source for d in docs] == ["site-about", "site-home"]
+    assert all("margin:0" not in d.text for d in docs)
+
+
+def test_ripple_lane_makes_one_document_for_the_whole_spec():
+    docs = kb_ingest.extract_site_documents(
+        engine="ripple",
+        ripple_spec={"blocks": [{"heading": _long("Acme Bakery opens at 8am.")}]},
+    )
+    assert len(docs) == 1
+    assert docs[0].source == "site-home"
+
+
+def test_near_empty_pages_are_skipped():
+    """An empty layout or a redirect stub has nothing answerable in it and would
+    only dilute BM25 scoring."""
+    docs = kb_ingest.extract_site_documents(
+        engine="html", source={"index.html": "<html><body><div></div></body></html>"}
+    )
+    assert docs == []
+
+
+def test_foreign_site_with_an_empty_pocket_yields_nothing():
+    """A concierge embedded on a site we do not host has no content in its pocket.
+    That is a real state, not a crash — grounding it means crawling the customer's
+    own origin, which is a separate, SSRF-hardened path."""
+    assert kb_ingest.extract_site_documents(engine="html", source=None) == []
+
+
+def test_page_count_is_capped():
+    source = {f"p{i}.html": f"<p>{_long('Page about our services.')}</p>" for i in range(200)}
+    docs = kb_ingest.extract_site_documents(engine="html", source=source)
+    assert len(docs) == kb_ingest._MAX_DOCUMENTS
+
+
+# --------------------------------------------------------------------------- #
+# Sync
+# --------------------------------------------------------------------------- #
+
+
+class _FakeSite:
+    """Stands in for the Beanie Site doc — only the fields the sync touches."""
+
+    def __init__(self, **ov: Any) -> None:
+        self.id = "site-1"
+        self.pocket_id = "pocket-1"
+        self.owner = "user:maya"
+        self.workspace = "ws-1"
+        self.kb_article_ids: list[str] = []
+        self.kb_synced_at = None
+        self.kb_sync_error = ""
+        self.set_calls: list[dict] = []
+        self.__dict__.update(ov)
+
+    async def set(self, updates: dict) -> None:
+        """Mirrors Beanie's ``$set``: applies only the named fields. The sync must
+        never write anything outside these, so the fake records what it was asked
+        for and the tests assert on it."""
+        self.set_calls.append(dict(updates))
+        for key, value in updates.items():
+            setattr(self, key, value)
+
+
+def _patch_kb(monkeypatch, *, ingested: list[str], removed: list[str]):
+    """Capture what the sync asks kb-go to do, without a subprocess."""
+    calls: dict[str, list] = {"ingest": [], "remove": []}
+
+    async def _ingest(scope, text, source):
+        calls["ingest"].append((scope, source, text))
+        return {"article": ingested.pop(0) if ingested else source}
+
+    async def _remove(scope, article_id):
+        calls["remove"].append((scope, article_id))
+        removed.append(article_id)
+        return True
+
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.agents.knowledge.KnowledgeService.ingest_text_to_scope", _ingest
+    )
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.agents.knowledge.KnowledgeService.remove_article", _remove
+    )
+    return calls
+
+
+def _patch_pocket(monkeypatch, pocket: dict | None):
+    async def _get(pocket_id, user_id):
+        if pocket is None:
+            raise RuntimeError("pocket gone")
+        return pocket
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.pockets.service.get", _get)
+
+
+@pytest.mark.asyncio
+async def test_sync_ingests_pages_into_the_pocket_scope(monkeypatch):
+    """The scope must be the one a CONCIERGE run reads — pocket:<id> and nothing
+    else. Any other scope means the ingest is invisible to the agent."""
+    calls = _patch_kb(monkeypatch, ingested=[], removed=[])
+    _patch_pocket(
+        monkeypatch,
+        {"engine": "html", "source": {"index.html": f"<p>{_long('We open at 8am.')}</p>"}},
+    )
+    site = _FakeSite()
+
+    report = await kb_ingest.sync_site_knowledge(site)
+
+    assert report.ingested == 1
+    assert report.error == ""
+    assert calls["ingest"][0][0] == "pocket:pocket-1"
+    assert site.kb_article_ids == ["site-home"]
+    assert site.kb_synced_at is not None
+
+
+@pytest.mark.asyncio
+async def test_resync_prunes_only_pages_that_disappeared(monkeypatch):
+    """A renamed or deleted page must stop being quotable, but the pocket scope is
+    SHARED with owner-uploaded files, so the sync may only delete ids it wrote."""
+    removed: list[str] = []
+    _patch_kb(monkeypatch, ingested=[], removed=removed)
+    _patch_pocket(
+        monkeypatch,
+        {"engine": "html", "source": {"index.html": f"<p>{_long('We open at 8am.')}</p>"}},
+    )
+    site = _FakeSite(kb_article_ids=["site-home", "site-old-page", "an-uploaded-file"])
+
+    await kb_ingest.sync_site_knowledge(site)
+
+    assert removed == ["site-old-page", "an-uploaded-file"]  # both were OURS to prune
+    assert site.kb_article_ids == ["site-home"]
+
+
+@pytest.mark.asyncio
+async def test_sync_never_prunes_an_id_it_did_not_record(monkeypatch):
+    """The uploads a pocket holds are not in kb_article_ids, so they are untouched."""
+    removed: list[str] = []
+    _patch_kb(monkeypatch, ingested=[], removed=removed)
+    _patch_pocket(
+        monkeypatch,
+        {"engine": "html", "source": {"index.html": f"<p>{_long('We open at 8am.')}</p>"}},
+    )
+    site = _FakeSite(kb_article_ids=[])
+
+    await kb_ingest.sync_site_knowledge(site)
+
+    assert removed == []
+
+
+@pytest.mark.asyncio
+async def test_sync_keeps_previous_ids_when_there_is_nothing_to_ingest(monkeypatch):
+    """An empty read may be transient. Forgetting the ids would strand those
+    articles beyond the reach of any future prune, so they are kept and the reason
+    is recorded."""
+    _patch_kb(monkeypatch, ingested=[], removed=[])
+    _patch_pocket(monkeypatch, {"engine": "html", "source": {}})
+    site = _FakeSite(kb_article_ids=["site-home"])
+
+    report = await kb_ingest.sync_site_knowledge(site)
+
+    assert report.error == "no_content"
+    assert report.ingested == 0
+    assert site.kb_article_ids == ["site-home"]  # not stranded
+    assert site.kb_sync_error == "no_content"
+
+
+@pytest.mark.asyncio
+async def test_sync_reports_an_unreadable_pocket_instead_of_raising(monkeypatch):
+    _patch_kb(monkeypatch, ingested=[], removed=[])
+    _patch_pocket(monkeypatch, None)
+    site = _FakeSite()
+
+    report = await kb_ingest.sync_site_knowledge(site)
+
+    assert report.error == "pocket_unavailable"
+    assert site.kb_sync_error == "pocket_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_one_failed_page_does_not_lose_the_others(monkeypatch):
+    async def _ingest(scope, text, source):
+        if source == "site-about":
+            raise RuntimeError("kb exploded")
+        return {"article": source}
+
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.agents.knowledge.KnowledgeService.ingest_text_to_scope", _ingest
+    )
+    _patch_pocket(
+        monkeypatch,
+        {
+            "engine": "html",
+            "source": {
+                "index.html": f"<p>{_long('We open at 8am.')}</p>",
+                "about.html": f"<p>{_long('Baking since 1998.')}</p>",
+            },
+        },
+    )
+    site = _FakeSite()
+
+    report = await kb_ingest.sync_site_knowledge(site)
+
+    assert report.ingested == 1
+    assert report.skipped == 1
+    assert site.kb_article_ids == ["site-home"]
+
+
+@pytest.mark.asyncio
+async def test_safe_sync_swallows_everything(monkeypatch):
+    """The background form is used from publish and from an agent bind, neither of
+    which may fail because a KB sync did."""
+
+    async def _boom(site):
+        raise RuntimeError("nope")
+
+    monkeypatch.setattr(kb_ingest, "sync_site_knowledge", _boom)
+    report = await kb_ingest.safe_sync_site_knowledge(_FakeSite())
+    assert report.error == "sync_failed"
+
+
+@pytest.mark.asyncio
+async def test_sync_only_writes_its_own_fields(monkeypatch):
+    """The sync runs in the background, minutes after the publish that scheduled it,
+    holding a Site instance snapshotted at that moment. A whole-document save would
+    silently roll back anything written to the same Site in between — a connected
+    domain, a stamped subscription. It must touch only the three kb_* fields.
+    """
+    _patch_kb(monkeypatch, ingested=[], removed=[])
+    _patch_pocket(
+        monkeypatch,
+        {"engine": "html", "source": {"index.html": f"<p>{_long('We open at 8am.')}</p>"}},
+    )
+    site = _FakeSite()
+
+    await kb_ingest.sync_site_knowledge(site)
+
+    assert len(site.set_calls) == 1
+    assert set(site.set_calls[0]) == {"kb_article_ids", "kb_synced_at", "kb_sync_error"}

--- a/tests/cloud/test_site_keys.py
+++ b/tests/cloud/test_site_keys.py
@@ -14,6 +14,11 @@
 # gate) and ``resolve_site_key``'s new ``frame_origin`` dual-mode gate (an Origin
 # equal to our frame origin is accepted without an allowlist check; a mismatched
 # Origin still falls back to the fail-closed ``allowed_origins`` gate).
+# Updated 2026-07-26 (concierge transcripts): + coverage for
+# ``resolve_site_key_with_site``, which now holds the implementation and returns
+# ``(ctx, Site)`` so the chat path can read an owner-set field without a second
+# query. The added cases prove the Site is handed over ONLY after every gate
+# passes — a bad key still 401s and a bad origin still 403s with nothing returned.
 
 from __future__ import annotations
 
@@ -341,4 +346,48 @@ async def test_frame_origin_none_is_pure_inline_behavior(mongo_db):
     assert ctx.scope is ScopeKind.CONCIERGE
     with pytest.raises(HTTPException) as exc:
         await resolve_site_key(_VALID_KEY, "https://evil.example", "cust-1")
+    assert exc.value.status_code == 403
+
+
+# --------------------------------------------------------------------------- #
+# resolve_site_key_with_site — the same gates, plus the resolved Site
+#
+# The chat path needs an owner-set Site field the context does not carry
+# (concierge_store_transcripts), and the gate already loaded the doc. These prove
+# handing it over does not weaken any gate: the Site comes back ONLY on success.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_resolve_with_site_returns_the_resolved_site(mongo_db):
+    from pocketpaw_ee.cloud.auth.site_keys import resolve_site_key_with_site
+
+    site = await _site()
+    ctx, resolved = await resolve_site_key_with_site(_VALID_KEY, _ALLOWED_ORIGIN, "cust-0001")
+    assert resolved.id == site.id
+    assert resolved.concierge_store_transcripts is True
+    # The context is byte-identical in the fields callers depend on.
+    assert ctx.workspace_id == site.workspace
+    assert ctx.pocket_id == site.pocket_id
+
+
+@pytest.mark.asyncio
+async def test_resolve_with_site_withholds_the_site_on_a_bad_key(mongo_db):
+    from fastapi import HTTPException
+    from pocketpaw_ee.cloud.auth.site_keys import resolve_site_key_with_site
+
+    await _site()
+    with pytest.raises(HTTPException) as exc:
+        await resolve_site_key_with_site("site_key_" + "z" * 24, _ALLOWED_ORIGIN, "cust-0001")
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_resolve_with_site_withholds_the_site_on_a_bad_origin(mongo_db):
+    from fastapi import HTTPException
+    from pocketpaw_ee.cloud.auth.site_keys import resolve_site_key_with_site
+
+    await _site()
+    with pytest.raises(HTTPException) as exc:
+        await resolve_site_key_with_site(_VALID_KEY, "https://evil.example", "cust-0001")
     assert exc.value.status_code == 403

--- a/tests/ee/sites/test_kb_sync_triggers.py
+++ b/tests/ee/sites/test_kb_sync_triggers.py
@@ -1,0 +1,149 @@
+# tests/ee/sites/test_kb_sync_triggers.py — the two automatic triggers that keep a
+# concierge's knowledge current.
+# Created 2026-07-26. The sync itself is covered in tests/cloud/test_site_kb_ingest.py;
+# this file only proves it is FIRED at the right moments and not at the wrong ones:
+#   * a live publish schedules one (the site's content just changed, so what the
+#     concierge can quote is now stale);
+#   * a PREVIEW publish does not (a draft must never rewrite the live KB);
+#   * provisioning a dedicated agent schedules one, which is how a site published
+#     before this existed stops being knowledge-empty;
+#   * neither trigger can fail its caller — publishing and binding an agent both
+#     survive a broken sync.
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.sites import service as sites_service
+
+
+class _FakeGenerator:
+    async def build(self, **kw):
+        from pocketpaw_ee.sites.generator_client import BuildResult
+
+        return BuildResult(project_dir="/tmp/site", ripple_version="0.2.0")
+
+
+class _FakeCF:
+    async def put_worker(self, *, script_name, bundle, bindings=None):
+        return True
+
+
+@pytest.fixture
+def captured_syncs(monkeypatch):
+    """Record the sites the service schedules a knowledge sync for, without running
+    one (a real sync would shell out to kb-go)."""
+    seen: list = []
+    monkeypatch.setattr(sites_service, "_schedule_site_knowledge_sync", seen.append)
+    return seen
+
+
+async def _publish(*, preview: bool = False):
+    return await sites_service.publish(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id="pocket-1",
+        ripple_spec={"type": "container"},
+        theme={},
+        name="Brew and Co",
+        preview=preview,
+        _generator=_FakeGenerator(),
+        _cloudflare=None if preview else _FakeCF(),
+        _bundle_reader=lambda d: b"x",
+        _local_deploy=(lambda site_id, project_dir: f"http://localhost/{site_id}"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_live_publish_schedules_a_knowledge_sync(beanie_test_db, captured_syncs):
+    """A publish changes what the site says, so the concierge's knowledge is stale
+    the moment it lands."""
+    await _publish()
+    assert len(captured_syncs) == 1
+    assert captured_syncs[0].pocket_id == "pocket-1"
+
+
+@pytest.mark.asyncio
+async def test_preview_publish_does_not_touch_the_live_knowledge(
+    monkeypatch, beanie_test_db, captured_syncs
+):
+    """A preview is a draft the owner has not approved. Ingesting it would let the
+    concierge quote a page no visitor can see."""
+    monkeypatch.setenv("PAW_SITES_LOCAL", "1")
+    await _publish(preview=True)
+    assert captured_syncs == []
+
+
+@pytest.mark.asyncio
+async def test_publish_survives_a_broken_sync_scheduler(beanie_test_db, monkeypatch):
+    """The sync fires from the tail of a LIVE deploy, so anything escaping it would
+    fail a publish of a site that is already deployed and serving. A concierge with
+    stale knowledge is a far smaller problem than that."""
+    from pocketpaw_ee.sites import kb_ingest
+
+    def _boom(coro):
+        coro.close()
+        raise RuntimeError("scheduler down")
+
+    monkeypatch.setattr(kb_ingest, "_default_sync_scheduler", _boom)
+
+    site = await _publish()
+
+    assert site.deployed is True
+
+
+@pytest.mark.asyncio
+async def test_agent_provisioning_schedules_a_knowledge_sync(monkeypatch):
+    """A dedicated agent is provisioned with a soul and an empty KB. Sites published
+    before this existed have never synced, so a bind is the catch-up point."""
+    from pocketpaw_ee.paw_bar import agent_provisioning
+
+    seen: list = []
+    monkeypatch.setattr(agent_provisioning, "_schedule_knowledge_sync", seen.append)
+
+    site = type(
+        "S",
+        (),
+        {
+            "id": "site-1",
+            "pocket_id": "pocket-1",
+            "workspace": "ws1",
+            "owner": "u1",
+            "name": "Brew and Co",
+            "concierge_greeting": "",
+        },
+    )()
+    widget = type("W", (), {"id": "w1", "agent_id": "", "spec": None})()
+    agent = type("A", (), {"id": "agent-1"})()
+
+    async def _get_by_slug(workspace_id, slug):
+        return agent
+
+    class _Store:
+        async def update_fields(self, widget_id, fields, *, workspace_id):
+            return widget
+
+    monkeypatch.setattr(agent_provisioning, "_store", lambda: _Store())
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.agents.service.get_by_slug", _get_by_slug, raising=False
+    )
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.agents.service.legacy_ctx", lambda *a, **k: object(), raising=False
+    )
+
+    bound = await agent_provisioning.ensure_site_agent(site, widget)
+
+    assert bound == "agent-1"
+    assert seen == [site]
+
+
+@pytest.mark.asyncio
+async def test_provisioning_sync_helper_never_raises(monkeypatch):
+    """``_schedule_knowledge_sync`` is the failure-soft boundary: a bind must
+    complete even if the sites KB module cannot be reached at all."""
+    from pocketpaw_ee.paw_bar import agent_provisioning
+    from pocketpaw_ee.sites import kb_ingest
+
+    def _boom(site):
+        raise RuntimeError("kb module down")
+
+    monkeypatch.setattr(kb_ingest, "schedule_site_knowledge_sync", _boom)
+    agent_provisioning._schedule_knowledge_sync(object())  # must not raise


### PR DESCRIPTION
Closes the two open decisions the per-site concierge arc was parked on.
Stacked on `feat/site-dedicated-agent` (#1776), so review this diff alone.

## 1. The concierge starts knowing the business

A dedicated concierge was provisioned with a soul, a persona and a KB
scope, and nothing ever put anything in that scope. Ask one about
opening hours and it correctly answered "I don't know" about a business
whose own homepage says 8am. Demos only looked grounded because the
widget spec happened to carry a catalog.

A concierge run reads exactly one scope, `pocket:<pocket_id>`, and never
`agent:` or `workspace:` (a public caller must not reach the tenant's
whole KB). So the fix is to get the site's own pages into that scope,
which is what the new `sites/kb_ingest.py` does.

Content is read from the **pocket**, not the built artifact and not the
live URL. The pocket is durable, so this works at publish time, at
provisioning time for a site published months ago, and on a manual
re-sync. It also needs no network, so there is no SSRF surface: fetching
a site's own `url` would mean fetching a customer-controlled hostname
server side, the exact class of request the import crawler had to be
hardened against.

Three lanes, one extractor each. HTML keeps title, body copy and image
alt text and drops script and style. Svelte drops code blocks and
template expressions. Ripple has no HTML yet, so the spec is walked for
copy, skipping structural keys and rendering price-like numbers with
their key so a price stays searchable.

Triggers: a live publish and a dedicated-agent bind, both backgrounded
because ingest compiles articles and neither caller can wait. A preview
publish deliberately does not fire, so a draft never rewrites the live
KB. Owners get `GET .../knowledge` and `POST .../knowledge/sync`, the
latter awaited because someone clicked a button. The sync gates on a new
`paw_bar.manage` action rather than the existing read, since it is a
mutation that spends compute.

Re-syncs are idempotent: kb-go derives an article id from the source
string, so deterministic sources mean a re-sync versions an article
instead of duplicating it. The site records the ids it produced and a
later sync prunes the ones it stopped producing, which is how a renamed
page leaves the KB. It never clears the scope, because owner-uploaded
files live there too.

**Not covered, named rather than implied:** a site minted for a foreign
origin has no content in its pocket, so it syncs zero documents and
reports `no_content`. Grounding those means crawling the customer's own
origin through the hardened crawler, which is its own slice.

## 2. Transcripts have both sides

An owner opening a transcript saw only the agent's replies. The cause
was structural: every authed surface persists the user turn as a Message
document, but a concierge visitor is anonymous and has no thread, so
there was nowhere for that text to live. `ChatRunDoc.user_text` is that
missing half.

Because a visitor types free text, a stored line can carry a name, an
email or an order number. That is new personal data, so the owner gets a
switch: `concierge_store_transcripts`, defaulting on, independent of the
kill switch in both directions. With it off the concierge keeps working
and keeps storing its replies; only the visitor's words are dropped. The
agent receives the full message either way, so the switch governs
storage and never the answer. Stored copies are capped at 4000
characters. Turning it off stops collection from the next message on and
does not purge what is already stored.

Transcripts now render the question stamped at ask time before the
answer stamped at reply time. Either half can be missing and the other
still shows, so a retention-off site produces exactly the assistant-only
shape it produced before. A run that failed before answering keeps its
question, and the conversations list previews that question rather than
a blank row.

## Worth a look during review

- **A lost-update bug I introduced and fixed.** The sync's bookkeeping
  first used a whole-document save. It runs minutes after the publish
  that scheduled it, holding a Site snapshotted at that moment, so it
  silently rolled back a domain connected in between. Caught by an
  existing sites test; now a targeted `$set` of three fields, with a
  regression test pinning it.
- **The stack was already failing CI lint.** `dev` is clean, but both
  `integration/paw-bar-ship` and `feat/site-dedicated-agent` fail `ruff
  check` and `ruff format --check`, so #1775 and #1776 are red on their
  own. First commit here fixes it; those two still need it (or this
  branch) before they go green.
- The resolver refactor: `resolve_site_key_with_site` now holds the
  implementation and `resolve_site_key` wraps it. Same gates, same
  order, same statuses, and the Site is returned only after all of them
  pass. Tests cover the withholding on a bad key and a bad origin.

## Tests

993 passing across the paw-bar, sites, runs, kb and RBAC suites. `ruff
check`, `ruff format --check`, both import-linter configs and `atlas
build --check` are all green.

One pre-existing failure is untouched and unrelated:
`tests/cloud/runs/test_run_core.py::test_execute_run_threads_surface_meta_into_ctx`,
confirmed red on `feat/site-dedicated-agent` before this branch existed.

Docs: new `docs/concepts/concierge-knowledge.mdx`, registered in the
sidebar.