### PR TITLE
growth: workspace-scoped prospect store

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -66,6 +66,11 @@ rebuild — dynamic-source split + input-keyspace confinement) and GET
 /sites/by-pocket/{id}/native-artifact (serve the armed build's body_html + css
 for shadow render — per-GET arm-build cost, path-traversal-guarded CSS reader).
 
+Updated: 2026-07-27 (feat/growth-g1) — documented the Growth — Prospects
+section: workspace-scoped prospect store under /growth/prospects (create /
+get / list with tier|status|source filters / update), domain-deduped per
+workspace, cross-tenant ids 404. First slice of the /growth outbound engine.
+
 Updated: 2026-07-11 (feat/real-pipeline-s1) — documented the Fabric — Transform
 Mappings section: GET/POST/DELETE /fabric/ingest/mappings (author the
 workspace's source→Fabric mappings, now with a "connector" source_kind that
@@ -1288,3 +1293,62 @@ disabled, no ingestor registered under the connector id — reports
 `status: "error"` with the reason in `errors` (HTTP 200, matching the
 background sweep's never-raise, per-source isolation contract). Re-runs are
 idempotent: objects upsert by `(source_connector, source_id)`.
+
+## Growth — Prospects
+
+First slice of the `/growth` outbound engine (G-1): a workspace-scoped
+prospect store. All routes are license-gated and carry the canonical
+`request_context`; every read is workspace-scoped inside the service, so a
+prospect id from another workspace returns an identical 404 (existence never
+leaks). The company website `domain` is the dedupe key — normalised to a bare
+lowercase hostname (scheme, `www.`, path, and port stripped) — unique per
+workspace. Later slices add ingestion, drafts, and Instinct-gated sends on the
+dedicated `growth` arq queue (`pocketpaw_ee.cloud.growth.worker.WorkerSettings`).
+
+### `POST /api/v1/growth/prospects`
+
+Create a prospect. Body:
+
+```json
+{
+  "name": "Sam Founder",
+  "company": "Acme Dental",
+  "domain": "acme-dental.com",
+  "source": "manual",
+  "tier": "unqualified",
+  "research_brief": "",
+  "emails": [],
+  "linkedin_url": null,
+  "whatsapp_number": null,
+  "opted_in": false,
+  "status": "new"
+}
+```
+
+`name`, `company`, `domain`, and `source` are required. Enums: `source` is
+`clay | directory | manual`; `tier` is `a | b | c | unqualified` (default
+`unqualified`); `status` is
+`new | qualified | drafted | in_sequence | replied | dead` (default `new`).
+A duplicate `(workspace, domain)` returns `409 prospect.domain_taken` —
+create-or-update callers use the service's `upsert_by_domain` seam instead.
+
+Returns the prospect envelope: all fields above plus `id`, `workspace_id`,
+and ISO `created_at` / `updated_at`.
+
+### `GET /api/v1/growth/prospects`
+
+List the workspace's prospects, newest first. Optional query filters:
+`tier`, `status`, `source` (validated against the enums above — an unknown
+value is a 422, not an empty list) and `limit` (default 100, max 500).
+
+### `GET /api/v1/growth/prospects/{prospect_id}`
+
+Fetch one prospect. Cross-tenant or unknown ids: `404 prospect.not_found`.
+
+### `PATCH /api/v1/growth/prospects/{prospect_id}`
+
+Partial update — send only the fields to change. `domain` (the dedupe
+identity) and `source` (capture-time provenance) are immutable; the other
+fields (`name`, `company`, `tier`, `research_brief`, `emails`,
+`linkedin_url`, `whatsapp_number`, `opted_in`, `status`) patch in place.
+Returns the updated envelope.

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -1,5 +1,9 @@
 """PocketPaw Enterprise Cloud — domain-driven architecture.
 
+Modified: 2026-07-27 (feat/growth-g1) — Mounts the growth prospect-store
+    router (``/growth/prospects`` create / get / list / update) under
+    ``/api/v1``. License gate + ``request_context`` on every route;
+    workspace-scoped reads inside the service (cross-tenant ids 404).
 Modified: 2026-07-11 (feat/real-pipeline-s1) — Mounts the fabric_ingest
     transform-surface router (``/fabric/ingest/mappings`` CRUD +
     ``/fabric/ingest/run`` run-now) next to the fabric router under
@@ -396,6 +400,7 @@ def mount_cloud(app: FastAPI) -> None:
 
     from pocketpaw_ee.cloud.decisions.router import router as decisions_router
     from pocketpaw_ee.cloud.fabric_ingest.router import router as fabric_ingest_router
+    from pocketpaw_ee.cloud.growth.router import router as growth_router
     from pocketpaw_ee.cloud.instinct_approvals.router import router as instinct_approvals_router
     from pocketpaw_ee.cloud.kb.router import router as kb_router
     from pocketpaw_ee.cloud.leads.router import router as leads_router
@@ -461,6 +466,12 @@ def mount_cloud(app: FastAPI) -> None:
     # drains here) and authed GET /sites/{id}/leads (plan-gated + RBAC +
     # workspace-scoped) for the Leads view.
     app.include_router(leads_router, prefix="/api/v1")
+    # Growth — G-1 prospect store (/growth outbound engine, first slice).
+    # License-gated, workspace-scoped CRUD under /growth/prospects; cross-tenant
+    # ids 404 inside the service. Later slices add ingestion, drafts, and
+    # Instinct-gated sends (the dedicated ``growth`` arq queue seam lives in
+    # ``growth/worker.py``).
+    app.include_router(growth_router, prefix="/api/v1")
     # Sites control plane — RFC 12 Task 3.5. POST /sites/publish (compile +
     # smoke-gate + WfP deploy), GET /sites, and the custom-domain pair
     # (Cloudflare for SaaS) the Domains panel drives.

--- a/ee/pocketpaw_ee/cloud/growth/__init__.py
+++ b/ee/pocketpaw_ee/cloud/growth/__init__.py
@@ -1,0 +1,5 @@
+# ee/pocketpaw_ee/cloud/growth/__init__.py — Growth entity package marker.
+# Created 2026-07-27 (feat/growth-g1): the /growth outbound-engine surface,
+# first slice — the prospect store (domain/dto/service/router 4-file shape,
+# plus the ``growth`` arq queue seam in worker.py). Plain marker: importing
+# this package must not pull the router or the worker.

--- a/ee/pocketpaw_ee/cloud/growth/domain.py
+++ b/ee/pocketpaw_ee/cloud/growth/domain.py
@@ -1,0 +1,68 @@
+# ee/pocketpaw_ee/cloud/growth/domain.py — frozen value objects + pure
+# constants for the /growth outbound engine. Domain enforces tenancy at
+# construction (``workspace_id`` required, no default) per the cloud 4-file
+# rules. Pure Python — no Beanie / Pydantic / FastAPI imports — so the service
+# can be unit-tested without the ODM and the import-linter contract can depend
+# on it freely. Also home of ``GROWTH_QUEUE_NAME``, the dedicated arq queue the
+# growth worker seam listens on (later slices enqueue ingestion / draft / send
+# jobs there).
+#
+# Created 2026-07-27 (feat/growth-g1): first slice of /growth — the prospect
+# store. Later slices add ingestion, drafts, and Instinct-gated sends.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal
+
+# Dedicated arq queue for growth jobs. Unlike workspace jobs (which ride arq's
+# default queue on the shared chat-runs worker — see ``jobs/domain.py``), growth
+# gets its OWN queue + worker seam (``growth/worker.py``) so a burst of outbound
+# work can never starve interactive chat runs. arq's enqueue selector for this
+# is ``_queue_name`` (underscore-prefixed; a bare ``queue=`` kwarg would be
+# forwarded to the job function and crash it — see the jobs/domain.py history).
+GROWTH_QUEUE_NAME = "growth"
+
+# Where the prospect came from.
+ProspectSource = Literal["clay", "directory", "manual"]
+
+# Qualification tier. ``unqualified`` until research triages it.
+ProspectTier = Literal["a", "b", "c", "unqualified"]
+
+# Outbound lifecycle. Later slices move prospects along this chain.
+ProspectStatus = Literal["new", "qualified", "drafted", "in_sequence", "replied", "dead"]
+
+
+@dataclass(frozen=True)
+class Prospect:
+    """Prospect value object — one company/contact target in a workspace.
+
+    ``domain`` is the company website domain and the tenant-local dedupe key
+    (the service lowercases it at entry; ``upsert_by_domain`` keys on it).
+    """
+
+    id: str
+    workspace_id: str
+    name: str
+    company: str
+    domain: str
+    source: str  # ProspectSource — validated at the DTO boundary
+    tier: str = "unqualified"  # ProspectTier
+    research_brief: str = ""
+    emails: tuple[str, ...] = ()
+    linkedin_url: str | None = None
+    whatsapp_number: str | None = None
+    opted_in: bool = False
+    status: str = "new"  # ProspectStatus
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+__all__ = [
+    "GROWTH_QUEUE_NAME",
+    "Prospect",
+    "ProspectSource",
+    "ProspectStatus",
+    "ProspectTier",
+]

--- a/ee/pocketpaw_ee/cloud/growth/dto.py
+++ b/ee/pocketpaw_ee/cloud/growth/dto.py
@@ -1,0 +1,98 @@
+# ee/pocketpaw_ee/cloud/growth/dto.py — request/response DTOs for the prospect
+# entity. Distinct Request and Response shapes per the ee/cloud rule — never
+# reuse a model for input and output. ``domain`` (the dedupe key) is normalised
+# to a bare lowercase hostname at the DTO boundary so every caller — router,
+# upsert, later ingestion slices — dedupes on the same canonical form.
+#
+# Created 2026-07-27 (feat/growth-g1): first slice of /growth — the prospect
+# store. Domain → DTO mapping lives in ``service.py`` as private helpers.
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field, field_validator
+
+from pocketpaw_ee.cloud.growth.domain import ProspectSource, ProspectStatus, ProspectTier
+
+
+def _normalise_domain(v: str) -> str:
+    """Canonicalise a company-website domain for the dedupe key.
+
+    Lowercases, strips whitespace, drops an ``http(s)://`` scheme, a ``www.``
+    prefix, and any path/port suffix — so ``https://www.Acme.com/about`` and
+    ``acme.com`` dedupe to the same row.
+    """
+    v = v.strip().lower()
+    for scheme in ("https://", "http://"):
+        if v.startswith(scheme):
+            v = v[len(scheme) :]
+            break
+    v = v.split("/", 1)[0].split(":", 1)[0]
+    if v.startswith("www."):
+        v = v[len("www.") :]
+    return v
+
+
+class CreateProspectRequest(BaseModel):
+    name: str = Field(min_length=1, max_length=200)
+    company: str = Field(min_length=1, max_length=200)
+    domain: str = Field(min_length=1, max_length=253)
+    source: ProspectSource
+    tier: ProspectTier = "unqualified"
+    research_brief: str = ""
+    emails: list[str] = Field(default_factory=list)
+    linkedin_url: str | None = None
+    whatsapp_number: str | None = None
+    opted_in: bool = False
+    status: ProspectStatus = "new"
+
+    @field_validator("domain")
+    @classmethod
+    def _clean_domain(cls, v: str) -> str:
+        cleaned = _normalise_domain(v)
+        if not cleaned:
+            raise ValueError("domain must contain a hostname")
+        return cleaned
+
+
+class UpdateProspectRequest(BaseModel):
+    """Partial update — every field optional; ``None`` means "leave as-is".
+
+    ``domain`` and ``source`` are deliberately NOT updatable: the domain is
+    the dedupe identity (changing it is a delete+create, not an edit) and the
+    source records provenance at capture time.
+    """
+
+    name: str | None = Field(default=None, min_length=1, max_length=200)
+    company: str | None = Field(default=None, min_length=1, max_length=200)
+    tier: ProspectTier | None = None
+    research_brief: str | None = None
+    emails: list[str] | None = None
+    linkedin_url: str | None = None
+    whatsapp_number: str | None = None
+    opted_in: bool | None = None
+    status: ProspectStatus | None = None
+
+
+class ProspectResponse(BaseModel):
+    id: str
+    workspace_id: str
+    name: str
+    company: str
+    domain: str
+    source: str
+    tier: str
+    research_brief: str
+    emails: list[str]
+    linkedin_url: str | None
+    whatsapp_number: str | None
+    opted_in: bool
+    status: str
+    created_at: str | None
+    updated_at: str | None
+
+
+__all__ = [
+    "CreateProspectRequest",
+    "ProspectResponse",
+    "UpdateProspectRequest",
+]

--- a/ee/pocketpaw_ee/cloud/growth/router.py
+++ b/ee/pocketpaw_ee/cloud/growth/router.py
@@ -1,0 +1,66 @@
+# ee/pocketpaw_ee/cloud/growth/router.py — FastAPI router for the prospect
+# store. Thin shell over ``ee.cloud.growth.service``: parses requests,
+# delegates, returns DTOs. License gate + canonical ``request_context``
+# dependency on every route — services never see raw ``Request`` objects, and
+# every read/write is workspace-scoped inside the service (cross-tenant ids
+# 404). Mounted under ``/api/v1`` → final paths ``/api/v1/growth/prospects``.
+#
+# Created 2026-07-27 (feat/growth-g1): first slice of /growth — create / get /
+# list (tier/status/source filters) / update. Later slices add ingestion,
+# drafts, and Instinct-gated sends.
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+
+from pocketpaw_ee.cloud._core.context import RequestContext, request_context
+from pocketpaw_ee.cloud.growth import service as growth_service
+from pocketpaw_ee.cloud.growth.domain import ProspectSource, ProspectStatus, ProspectTier
+from pocketpaw_ee.cloud.growth.dto import (
+    CreateProspectRequest,
+    ProspectResponse,
+    UpdateProspectRequest,
+)
+from pocketpaw_ee.cloud.license import require_license
+
+router = APIRouter(
+    prefix="/growth/prospects", tags=["Growth"], dependencies=[Depends(require_license)]
+)
+
+
+@router.post("", response_model=ProspectResponse)
+async def create_prospect(
+    body: CreateProspectRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> ProspectResponse:
+    return await growth_service.create(ctx, body)
+
+
+@router.get("", response_model=list[ProspectResponse])
+async def list_prospects(
+    tier: ProspectTier | None = Query(default=None),
+    status: ProspectStatus | None = Query(default=None),
+    source: ProspectSource | None = Query(default=None),
+    limit: int = Query(default=100, ge=1, le=500),
+    ctx: RequestContext = Depends(request_context),
+) -> list[ProspectResponse]:
+    return await growth_service.list_prospects(
+        ctx, tier=tier, status=status, source=source, limit=limit
+    )
+
+
+@router.get("/{prospect_id}", response_model=ProspectResponse)
+async def get_prospect(
+    prospect_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> ProspectResponse:
+    return await growth_service.get(ctx, prospect_id)
+
+
+@router.patch("/{prospect_id}", response_model=ProspectResponse)
+async def update_prospect(
+    prospect_id: str,
+    body: UpdateProspectRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> ProspectResponse:
+    return await growth_service.update(ctx, prospect_id, body)

--- a/ee/pocketpaw_ee/cloud/growth/service.py
+++ b/ee/pocketpaw_ee/cloud/growth/service.py
@@ -1,0 +1,234 @@
+# ee/pocketpaw_ee/cloud/growth/service.py — sole owner of Prospect writes
+# (service-is-repo; only this module imports ``models.prospect``). Tenancy:
+# every read filters on ``workspace``; a cross-tenant id raises NotFound so
+# existence never leaks. ``upsert_by_domain`` is the create-or-update seam the
+# later ingestion slices (Clay / directory imports) call — keyed on
+# (workspace_id, normalised domain), matching the unique index on the doc.
+#
+# Created 2026-07-27 (feat/growth-g1): first slice of /growth — the prospect
+# store. No events yet: growth has no realtime subscriber in v1, so writes
+# carry ``# no-event:`` markers per the ee/cloud emit rule.
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from beanie import PydanticObjectId
+
+from pocketpaw_ee.cloud._core.context import RequestContext
+from pocketpaw_ee.cloud._core.errors import ConflictError, Forbidden, NotFound
+from pocketpaw_ee.cloud._core.time import iso_utc
+from pocketpaw_ee.cloud.growth.domain import Prospect
+from pocketpaw_ee.cloud.growth.dto import (
+    CreateProspectRequest,
+    ProspectResponse,
+    UpdateProspectRequest,
+)
+from pocketpaw_ee.cloud.models.prospect import Prospect as _ProspectDoc
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Private mapping helpers
+# ---------------------------------------------------------------------------
+
+
+def _to_domain(doc: _ProspectDoc) -> Prospect:
+    return Prospect(
+        id=str(doc.id),
+        workspace_id=doc.workspace,
+        name=doc.name,
+        company=doc.company,
+        domain=doc.domain,
+        source=doc.source,
+        tier=doc.tier,
+        research_brief=doc.research_brief,
+        emails=tuple(doc.emails),
+        linkedin_url=doc.linkedin_url,
+        whatsapp_number=doc.whatsapp_number,
+        opted_in=doc.opted_in,
+        status=doc.status,
+        created_at=getattr(doc, "createdAt", None),
+        updated_at=getattr(doc, "updatedAt", None),
+    )
+
+
+def _to_response(p: Prospect) -> ProspectResponse:
+    return ProspectResponse(
+        id=p.id,
+        workspace_id=p.workspace_id,
+        name=p.name,
+        company=p.company,
+        domain=p.domain,
+        source=p.source,
+        tier=p.tier,
+        research_brief=p.research_brief,
+        emails=list(p.emails),
+        linkedin_url=p.linkedin_url,
+        whatsapp_number=p.whatsapp_number,
+        opted_in=p.opted_in,
+        status=p.status,
+        created_at=iso_utc(p.created_at),
+        updated_at=iso_utc(p.updated_at),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tenancy helpers
+# ---------------------------------------------------------------------------
+
+
+def _require_workspace(ctx: RequestContext) -> str:
+    """Growth always operates in a workspace; a route reached without an
+    active workspace must fail closed, not fall through to a global read."""
+    if not ctx.workspace_id:
+        raise Forbidden("prospect.no_workspace", "Active workspace required for growth operations")
+    return ctx.workspace_id
+
+
+async def _fetch_in_workspace(workspace_id: str, prospect_id: str) -> _ProspectDoc:
+    """Fetch a prospect scoped to the caller's workspace. Raises NotFound for
+    a malformed id, a missing row, or a row in another workspace — identical
+    404s, so existence never leaks across tenants."""
+    try:
+        oid = PydanticObjectId(prospect_id)
+    except Exception as exc:  # noqa: BLE001 — malformed id == not found
+        raise NotFound("prospect", prospect_id) from exc
+    doc = await _ProspectDoc.find_one({"_id": oid, "workspace": workspace_id})
+    if doc is None:
+        raise NotFound("prospect", prospect_id)
+    return doc
+
+
+def _apply_update(doc: _ProspectDoc, body: UpdateProspectRequest) -> None:
+    """Copy the non-None fields of a partial update onto the doc in place."""
+    for field in (
+        "name",
+        "company",
+        "tier",
+        "research_brief",
+        "emails",
+        "linkedin_url",
+        "whatsapp_number",
+        "opted_in",
+        "status",
+    ):
+        value = getattr(body, field)
+        if value is not None:
+            setattr(doc, field, value)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def create(ctx: RequestContext, body: CreateProspectRequest) -> ProspectResponse:
+    """Create a prospect. A duplicate (workspace, domain) is a 409 — callers
+    that want create-or-update semantics use ``upsert_by_domain`` instead."""
+    body = CreateProspectRequest.model_validate(body)
+    workspace_id = _require_workspace(ctx)
+
+    existing = await _ProspectDoc.find_one({"workspace": workspace_id, "domain": body.domain})
+    if existing is not None:
+        raise ConflictError(
+            "prospect.domain_taken",
+            f"A prospect for domain '{body.domain}' already exists in this workspace",
+        )
+
+    doc = _ProspectDoc(workspace=workspace_id, **body.model_dump())
+    await doc.insert()
+    # no-event: growth has no realtime subscriber in v1; the prospects view polls.
+    return _to_response(_to_domain(doc))
+
+
+async def get(ctx: RequestContext, prospect_id: str) -> ProspectResponse:
+    workspace_id = _require_workspace(ctx)
+    doc = await _fetch_in_workspace(workspace_id, prospect_id)
+    return _to_response(_to_domain(doc))
+
+
+async def list_prospects(
+    ctx: RequestContext,
+    *,
+    tier: str | None = None,
+    status: str | None = None,
+    source: str | None = None,
+    limit: int = 100,
+) -> list[ProspectResponse]:
+    """List the workspace's prospects, newest first, optionally filtered."""
+    workspace_id = _require_workspace(ctx)
+    filters: dict[str, Any] = {"workspace": workspace_id}
+    if tier is not None:
+        filters["tier"] = tier
+    if status is not None:
+        filters["status"] = status
+    if source is not None:
+        filters["source"] = source
+    cursor = (
+        _ProspectDoc.find(filters)
+        .sort(-_ProspectDoc.createdAt)  # type: ignore[operator]
+        .limit(limit)
+    )
+    return [_to_response(_to_domain(doc)) async for doc in cursor]
+
+
+async def update(
+    ctx: RequestContext, prospect_id: str, body: UpdateProspectRequest
+) -> ProspectResponse:
+    body = UpdateProspectRequest.model_validate(body)
+    workspace_id = _require_workspace(ctx)
+    doc = await _fetch_in_workspace(workspace_id, prospect_id)
+    _apply_update(doc, body)
+    await doc.save()  # bumps updatedAt
+    # no-event: growth has no realtime subscriber in v1; the prospects view polls.
+    return _to_response(_to_domain(doc))
+
+
+async def upsert_by_domain(
+    workspace_id: str, prospect_data: CreateProspectRequest
+) -> ProspectResponse:
+    """Create-or-update keyed on (workspace_id, normalised domain).
+
+    The ingestion seam later slices call: a re-imported company updates the
+    existing row (never a duplicate); a new domain inserts. Takes an explicit
+    ``workspace_id`` (not a RequestContext) because ingestion runs under a
+    worker/system identity, mirroring how the arq worker trusts the doc's
+    workspace. Every mutable field EXCEPT ``source`` is overwritten on update —
+    source records provenance at first capture and is kept.
+    """
+    body = CreateProspectRequest.model_validate(prospect_data)
+
+    doc = await _ProspectDoc.find_one({"workspace": workspace_id, "domain": body.domain})
+    if doc is None:
+        doc = _ProspectDoc(workspace=workspace_id, **body.model_dump())
+        await doc.insert()
+        # no-event: growth has no realtime subscriber in v1.
+        return _to_response(_to_domain(doc))
+
+    for field in (
+        "name",
+        "company",
+        "tier",
+        "research_brief",
+        "emails",
+        "linkedin_url",
+        "whatsapp_number",
+        "opted_in",
+        "status",
+    ):
+        setattr(doc, field, getattr(body, field))
+    await doc.save()  # bumps updatedAt
+    # no-event: growth has no realtime subscriber in v1.
+    return _to_response(_to_domain(doc))
+
+
+__all__ = [
+    "create",
+    "get",
+    "list_prospects",
+    "update",
+    "upsert_by_domain",
+]

--- a/ee/pocketpaw_ee/cloud/growth/worker.py
+++ b/ee/pocketpaw_ee/cloud/growth/worker.py
@@ -1,0 +1,100 @@
+# ee/pocketpaw_ee/cloud/growth/worker.py — arq worker seam for the dedicated
+# ``growth`` queue (G-1, feat/growth-g1). Registration only: no real jobs yet.
+# Later slices (ingestion, drafts, gated-send dispatch) register their
+# entrypoints into ``WorkerSettings.functions`` here and enqueue with
+# ``_queue_name=GROWTH_QUEUE_NAME`` (arq's selector is the underscore-prefixed
+# kwarg; a bare ``queue=`` is forwarded to the job function and crashes it —
+# see the jobs/domain.py history).
+#
+# Unlike workspace jobs (which ride arq's DEFAULT queue on the shared chat-runs
+# worker — see ``jobs/domain.py``), growth gets its OWN queue + worker process
+# so a burst of outbound work can never starve interactive chat runs.
+#
+# Deploy as a separate process alongside the web service::
+#
+#     arq pocketpaw_ee.cloud.growth.worker.WorkerSettings
+#
+# The startup/shutdown pair mirrors ``chat/runs/worker.py``: pin the xproc role
+# BEFORE anything emits, init the cloud DB + realtime bus, close the DB on the
+# way out. ``redis_settings`` is evaluated eagerly at class-body time because
+# arq reads ``settings_cls.__dict__`` directly (bypassing descriptors) — the
+# same shape + rationale as the chat-runs worker; tests set a stub
+# ``POCKETPAW_REDIS_URL`` in ``tests/cloud/conftest.py`` before import.
+
+"""arq worker entry point for the dedicated ``growth`` queue (seam only)."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+from arq.connections import RedisSettings
+
+from pocketpaw_ee.cloud import init_realtime
+from pocketpaw_ee.cloud._core.realtime import xproc
+from pocketpaw_ee.cloud.growth.domain import GROWTH_QUEUE_NAME
+from pocketpaw_ee.cloud.shared.db import close_cloud_db, init_cloud_db
+
+logger = logging.getLogger(__name__)
+
+
+async def growth_heartbeat(ctx: dict[str, Any]) -> None:
+    """Placeholder entrypoint — the queue-registration seam.
+
+    arq refuses to boot a worker with zero functions ("at least one function
+    or cron_job must be registered"), so the seam ships this no-op. Later
+    slices replace/extend it with the real ingestion / draft / send jobs.
+    """
+    logger.info("growth worker: heartbeat (no growth jobs registered yet)")
+
+
+async def _startup(ctx: dict[str, Any]) -> None:
+    """Boot the worker: pin role, init the DB + realtime bus.
+
+    ``xproc.set_role("worker")`` must run before any code emits, so ``emit()``
+    routes over the cross-process bridge instead of into the worker's empty
+    local bus — same ordering as the chat-runs worker.
+    """
+    xproc.set_role("worker")
+    mongo_uri = os.environ.get("CLOUD_MONGODB_URI", "mongodb://localhost:27017/paw-enterprise")
+    await init_cloud_db(mongo_uri)
+    init_realtime()
+
+
+async def _shutdown(ctx: dict[str, Any]) -> None:
+    await close_cloud_db()
+
+
+def _redis_settings() -> RedisSettings:
+    """Resolve arq RedisSettings from ``POCKETPAW_REDIS_URL``.
+
+    Eager (called at class-body evaluation) because arq's ``get_kwargs`` reads
+    ``settings_cls.__dict__`` directly, bypassing the descriptor protocol —
+    same rationale as ``chat/runs/worker.py``. Fails loud when the env var is
+    missing rather than silently falling back to localhost.
+    """
+    url = os.environ.get("POCKETPAW_REDIS_URL", "").strip()
+    if not url:
+        raise RuntimeError("POCKETPAW_REDIS_URL must be set to run the growth arq worker")
+    return RedisSettings.from_dsn(url)
+
+
+class WorkerSettings:
+    """arq worker configuration for the ``growth`` queue.
+
+    Loaded by ``arq pocketpaw_ee.cloud.growth.worker.WorkerSettings``.
+    """
+
+    queue_name = GROWTH_QUEUE_NAME
+    functions = [growth_heartbeat]
+    on_startup = _startup
+    on_shutdown = _shutdown
+    # Crash policy mirrors the chat-runs worker: no auto-retry. Outbound work
+    # must never double-send on a retry; failed jobs surface for manual review.
+    max_tries = 1
+    # Eager: arq reads __dict__, which bypasses descriptors. See `_redis_settings`.
+    redis_settings = _redis_settings()
+
+
+__all__ = ["GROWTH_QUEUE_NAME", "WorkerSettings", "growth_heartbeat"]

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -1,5 +1,12 @@
 """Cloud document models — re-exports for Beanie init.
 
+Updated: 2026-07-27 (feat/growth-g1) — added ``Prospect`` (the /growth
+outbound-engine prospect store: workspace-scoped, unique (workspace, domain)
+dedupe key) to the imports and ``get_all_documents()`` so the
+``growth_prospects`` collection is wired into ``init_beanie``. Kept out of
+``__all__`` so it can't be star-imported into routers/DTOs/domains — only
+``ee.cloud.growth.service`` imports the doc class directly (import-linter
+"Growth" contract).
 Updated: 2026-07-15 (fix/workspace-vm-map-to-db) — added ``WorkspaceVm`` (the
 workspace→Daytona-VM mapping, moved out of the local
 ``~/.pocketpaw/daytona_workspace_vm_map.json`` file into the ``workspace_vms``
@@ -177,6 +184,7 @@ from pocketpaw_ee.cloud.models.planner import PlanSession, PlanSessionAgentGap
 from pocketpaw_ee.cloud.models.pocket import Pocket, Widget, WidgetPosition
 from pocketpaw_ee.cloud.models.pocket_backend import PocketBackendCredential
 from pocketpaw_ee.cloud.models.project import Project
+from pocketpaw_ee.cloud.models.prospect import Prospect
 from pocketpaw_ee.cloud.models.push_subscription import PushSubscription
 from pocketpaw_ee.cloud.models.read_state import ReadState
 from pocketpaw_ee.cloud.models.request_log import RequestLog
@@ -467,6 +475,11 @@ def get_all_documents():
         Lead,
         Site,
         SiteRateCounter,
+        # Growth prospect store (G-1) — the /growth outbound engine's
+        # workspace-scoped, domain-deduped prospect record. Only
+        # ``ee.cloud.growth.service`` imports this doc directly (import-linter
+        # "Growth" contract).
+        Prospect,
         PushSubscription,
         VapidKeypair,
         WorkspaceSensePreference,

--- a/ee/pocketpaw_ee/cloud/models/prospect.py
+++ b/ee/pocketpaw_ee/cloud/models/prospect.py
@@ -1,0 +1,52 @@
+# ee/pocketpaw_ee/cloud/models/prospect.py — outbound-engine prospect record
+# for the /growth surface (G-1, feat/growth-g1). Workspace-scoped; the company
+# website ``domain`` is the dedupe key, enforced by a UNIQUE
+# (workspace, domain) index so one tenant can never hold two rows for the same
+# company while two tenants can each hold their own. Only
+# ``ee.cloud.growth.service`` may import this doc class (import-linter
+# "Growth" contract).
+#
+# Created 2026-07-27 (feat/growth-g1): first slice of /growth — the prospect
+# store. Later slices (ingestion, drafts, gated sends) build on this doc.
+
+from __future__ import annotations
+
+from beanie import Indexed
+from pydantic import Field
+from pymongo import IndexModel
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class Prospect(TimestampedDocument):
+    """One outbound prospect (a company + who to reach there) in a workspace."""
+
+    # Tenancy boundary — every read filters on this.
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    name: str
+    company: str
+    # Company website domain, lowercased at the service boundary — the dedupe key.
+    domain: str
+    source: str  # clay | directory | manual (validated at the DTO boundary)
+    tier: str = "unqualified"  # a | b | c | unqualified
+    research_brief: str = ""
+    emails: list[str] = Field(default_factory=list)
+    linkedin_url: str | None = None
+    whatsapp_number: str | None = None
+    opted_in: bool = False
+    status: str = "new"  # new | qualified | drafted | in_sequence | replied | dead
+
+    class Settings:
+        name = "growth_prospects"
+        indexes = [
+            # Dedupe key: one row per company domain per workspace. The leading
+            # ``workspace`` keeps the constraint tenant-local — two workspaces
+            # can each prospect the same company.
+            IndexModel(
+                [("workspace", 1), ("domain", 1)],
+                unique=True,
+                name="uq_workspace_domain",
+            ),
+            # List cursor: the prospects view pages newest-first per workspace.
+            [("workspace", 1), ("createdAt", -1)],
+        ]

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -666,12 +666,17 @@ allow_indirect_imports = "true"
 #
 # A human reviewer will not catch that on a diff that otherwise looks like a
 # helpful refactor. The linter will.
+# 2026-07-27 (feat/growth-g1 touch-time fix): dropped the ``transport`` and
+# ``domain`` entries — both modules were removed by the 2026-07-23 turn-agent
+# refactor ("remove the separate turn-agent, keep the delegate channel"), and
+# import-linter hard-fails on a nonexistent module, breaking the whole ee
+# config. ``delegates.py`` (the surviving delegate channel) is added in their
+# place so the sandbox guard still covers every codeagent module.
 source_modules = [
     "pocketpaw_ee.cloud.codeagent.router",
     "pocketpaw_ee.cloud.codeagent.service",
-    "pocketpaw_ee.cloud.codeagent.transport",
+    "pocketpaw_ee.cloud.codeagent.delegates",
     "pocketpaw_ee.cloud.codeagent.dto",
-    "pocketpaw_ee.cloud.codeagent.domain",
 ]
 forbidden_modules = [
     "pocketpaw_ee.cloud.daytona",
@@ -787,6 +792,21 @@ source_modules = [
     "pocketpaw_ee.cloud.cycles.scheduler",
 ]
 forbidden_modules = ["pocketpaw_ee.cloud.models.cycle"]
+
+[[tool.importlinter.contracts]]
+name = "Growth — Beanie writes only from service.py"
+# feat/growth-g1 — only ``growth.service`` owns the Prospect Beanie writes;
+# dto/domain/router/worker go through it. The worker is the dedicated
+# ``growth`` arq queue seam and must never touch the doc class directly.
+type = "forbidden"
+allow_indirect_imports = "true"
+source_modules = [
+    "pocketpaw_ee.cloud.growth.router",
+    "pocketpaw_ee.cloud.growth.dto",
+    "pocketpaw_ee.cloud.growth.domain",
+    "pocketpaw_ee.cloud.growth.worker",
+]
+forbidden_modules = ["pocketpaw_ee.cloud.models.prospect"]
 
 [[tool.importlinter.contracts]]
 name = "LLM provisioning — Beanie writes only from service.py"

--- a/tests/cloud/growth/__init__.py
+++ b/tests/cloud/growth/__init__.py
@@ -1,0 +1,3 @@
+# tests/cloud/growth — tests for the /growth prospect store (G-1,
+# feat/growth-g1). Router wiring + tenancy in test_router.py; service-level
+# upsert/dedupe behaviour in test_service.py.

--- a/tests/cloud/growth/test_router.py
+++ b/tests/cloud/growth/test_router.py
@@ -1,0 +1,230 @@
+# tests/cloud/growth/test_router.py — HTTP-layer tests for
+# ``ee/cloud/growth/router.py``. Follows the cycles-router test pattern: build
+# a FastAPI app with the growth router + a fixed RequestContext override per
+# workspace (w1/w2 clients), mongomock-backed Beanie via the shared
+# ``mongo_db`` fixture. Covers create/get/list/update wiring, list filters,
+# the duplicate-domain 409, and — parametrized across get/update/list —
+# cross-tenant isolation (foreign ids 404, foreign rows never listed).
+#
+# Created 2026-07-27 (feat/growth-g1): first slice of /growth.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind, request_context
+from pocketpaw_ee.cloud._core.http import add_error_handler
+from pocketpaw_ee.cloud.growth.router import router as growth_router
+from pocketpaw_ee.cloud.license import require_license
+
+
+def _make_ctx(workspace_id: str | None, user_id: str = "u1") -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="test",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+def _build_app(workspace_id: str | None = "w1", user_id: str = "u1") -> FastAPI:
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(growth_router, prefix="/api/v1")
+
+    async def _ctx() -> RequestContext:
+        return _make_ctx(workspace_id, user_id)
+
+    app.dependency_overrides[request_context] = _ctx
+    app.dependency_overrides[require_license] = lambda: None
+    return app
+
+
+@pytest_asyncio.fixture
+async def w1_client(mongo_db: Any) -> AsyncClient:
+    app = _build_app(workspace_id="w1")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+@pytest_asyncio.fixture
+async def w2_client(mongo_db: Any) -> AsyncClient:
+    app = _build_app(workspace_id="w2")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+def _payload(**overrides: Any) -> dict[str, Any]:
+    base = {
+        "name": "Sam Founder",
+        "company": "Acme Dental",
+        "domain": "acme-dental.com",
+        "source": "manual",
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# CRUD wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_returns_prospect_with_defaults(w1_client):
+    resp = await w1_client.post("/api/v1/growth/prospects", json=_payload())
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["workspace_id"] == "w1"
+    assert body["name"] == "Sam Founder"
+    assert body["company"] == "Acme Dental"
+    assert body["domain"] == "acme-dental.com"
+    assert body["source"] == "manual"
+    # Spec defaults.
+    assert body["tier"] == "unqualified"
+    assert body["status"] == "new"
+    assert body["research_brief"] == ""
+    assert body["emails"] == []
+    assert body["linkedin_url"] is None
+    assert body["whatsapp_number"] is None
+    assert body["opted_in"] is False
+    assert body["id"]
+    assert body["created_at"]
+
+
+@pytest.mark.asyncio
+async def test_create_normalises_domain(w1_client):
+    resp = await w1_client.post(
+        "/api/v1/growth/prospects",
+        json=_payload(domain="https://www.Acme-Dental.com/about"),
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["domain"] == "acme-dental.com"
+
+
+@pytest.mark.asyncio
+async def test_create_duplicate_domain_is_409(w1_client):
+    assert (await w1_client.post("/api/v1/growth/prospects", json=_payload())).status_code == 200
+    resp = await w1_client.post("/api/v1/growth/prospects", json=_payload(name="Someone Else"))
+    assert resp.status_code == 409
+    assert resp.json()["error"]["code"] == "prospect.domain_taken"
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_bad_source(w1_client):
+    resp = await w1_client.post("/api/v1/growth/prospects", json=_payload(source="scraped"))
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_get_roundtrips(w1_client):
+    created = (await w1_client.post("/api/v1/growth/prospects", json=_payload())).json()
+    resp = await w1_client.get(f"/api/v1/growth/prospects/{created['id']}")
+    assert resp.status_code == 200
+    fetched = resp.json()
+    # Mongo truncates datetimes to milliseconds on persist, so the create
+    # response (pre-persist, microsecond precision) differs in the timestamp
+    # tail — compare everything else exactly.
+    drop = {"created_at", "updated_at"}
+    assert {k: v for k, v in fetched.items() if k not in drop} == {
+        k: v for k, v in created.items() if k not in drop
+    }
+
+
+@pytest.mark.asyncio
+async def test_update_patches_only_sent_fields(w1_client):
+    created = (await w1_client.post("/api/v1/growth/prospects", json=_payload())).json()
+    resp = await w1_client.patch(
+        f"/api/v1/growth/prospects/{created['id']}",
+        json={"tier": "a", "status": "qualified", "emails": ["sam@acme-dental.com"]},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["tier"] == "a"
+    assert body["status"] == "qualified"
+    assert body["emails"] == ["sam@acme-dental.com"]
+    # Untouched fields survive.
+    assert body["name"] == "Sam Founder"
+    assert body["domain"] == "acme-dental.com"
+
+
+@pytest.mark.asyncio
+async def test_update_rejects_bad_tier(w1_client):
+    created = (await w1_client.post("/api/v1/growth/prospects", json=_payload())).json()
+    resp = await w1_client.patch(f"/api/v1/growth/prospects/{created['id']}", json={"tier": "s"})
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_list_filters_by_tier_status_source(w1_client):
+    await w1_client.post("/api/v1/growth/prospects", json=_payload())
+    await w1_client.post(
+        "/api/v1/growth/prospects",
+        json=_payload(domain="beta.io", company="Beta", tier="a", source="clay"),
+    )
+    await w1_client.post(
+        "/api/v1/growth/prospects",
+        json=_payload(domain="gamma.io", company="Gamma", tier="a", source="directory"),
+    )
+
+    resp = await w1_client.get("/api/v1/growth/prospects")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 3
+
+    resp = await w1_client.get("/api/v1/growth/prospects", params={"tier": "a"})
+    assert {p["domain"] for p in resp.json()} == {"beta.io", "gamma.io"}
+
+    resp = await w1_client.get("/api/v1/growth/prospects", params={"source": "clay"})
+    assert [p["domain"] for p in resp.json()] == ["beta.io"]
+
+    resp = await w1_client.get("/api/v1/growth/prospects", params={"status": "new"})
+    assert len(resp.json()) == 3
+
+    resp = await w1_client.get(
+        "/api/v1/growth/prospects", params={"tier": "a", "source": "directory"}
+    )
+    assert [p["domain"] for p in resp.json()] == ["gamma.io"]
+
+
+@pytest.mark.asyncio
+async def test_list_rejects_unknown_filter_value(w1_client):
+    resp = await w1_client.get("/api/v1/growth/prospects", params={"tier": "platinum"})
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Tenancy — a foreign workspace's ids 404, its rows never list.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("op", ["get", "update", "list"])
+async def test_cross_tenant_access_is_isolated(w1_client, w2_client, op):
+    """A prospect created in w1 is invisible to w2: GET and PATCH by id 404
+    (existence never leaks), and w2's list never contains it."""
+    created = (await w1_client.post("/api/v1/growth/prospects", json=_payload())).json()
+
+    if op == "get":
+        resp = await w2_client.get(f"/api/v1/growth/prospects/{created['id']}")
+        assert resp.status_code == 404
+        assert resp.json()["error"]["code"] == "prospect.not_found"
+    elif op == "update":
+        resp = await w2_client.patch(
+            f"/api/v1/growth/prospects/{created['id']}", json={"tier": "a"}
+        )
+        assert resp.status_code == 404
+        # The cross-tenant PATCH must not have mutated the row.
+        same = (await w1_client.get(f"/api/v1/growth/prospects/{created['id']}")).json()
+        assert same["tier"] == "unqualified"
+    else:  # list
+        resp = await w2_client.get("/api/v1/growth/prospects")
+        assert resp.status_code == 200
+        assert resp.json() == []

--- a/tests/cloud/growth/test_service.py
+++ b/tests/cloud/growth/test_service.py
@@ -1,0 +1,79 @@
+# tests/cloud/growth/test_service.py — service-level tests for
+# ``ee/cloud/growth/service.py``, centred on ``upsert_by_domain`` (the seam
+# later ingestion slices call): same domain twice → update-not-duplicate,
+# domain normalisation converging on one row, source preserved on update, and
+# the tenant boundary (same domain in two workspaces → two independent rows).
+#
+# Created 2026-07-27 (feat/growth-g1): first slice of /growth.
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pocketpaw_ee.cloud.growth import service as growth_service
+from pocketpaw_ee.cloud.growth.dto import CreateProspectRequest
+from pocketpaw_ee.cloud.models.prospect import Prospect as _ProspectDoc
+
+
+def _req(**overrides: Any) -> CreateProspectRequest:
+    base: dict[str, Any] = {
+        "name": "Sam Founder",
+        "company": "Acme Dental",
+        "domain": "acme-dental.com",
+        "source": "manual",
+    }
+    base.update(overrides)
+    return CreateProspectRequest.model_validate(base)
+
+
+@pytest.mark.asyncio
+async def test_upsert_by_domain_creates_then_updates_not_duplicates(mongo_db):
+    first = await growth_service.upsert_by_domain("w1", _req())
+    assert first.tier == "unqualified"
+
+    second = await growth_service.upsert_by_domain(
+        "w1", _req(name="Sam F.", tier="a", emails=["sam@acme-dental.com"])
+    )
+
+    # Same row, updated — never a duplicate.
+    assert second.id == first.id
+    assert second.name == "Sam F."
+    assert second.tier == "a"
+    assert second.emails == ["sam@acme-dental.com"]
+    assert await _ProspectDoc.find({"workspace": "w1"}).count() == 1
+
+
+@pytest.mark.asyncio
+async def test_upsert_by_domain_normalises_before_keying(mongo_db):
+    """Scheme / www / case / path variants of one domain converge on one row."""
+    first = await growth_service.upsert_by_domain("w1", _req(domain="acme-dental.com"))
+    second = await growth_service.upsert_by_domain(
+        "w1", _req(domain="https://www.ACME-Dental.com/pricing", name="Updated")
+    )
+    assert second.id == first.id
+    assert second.domain == "acme-dental.com"
+    assert await _ProspectDoc.find({"workspace": "w1"}).count() == 1
+
+
+@pytest.mark.asyncio
+async def test_upsert_by_domain_preserves_source_on_update(mongo_db):
+    """``source`` records provenance at first capture; a re-import from a
+    different source updates the fields but keeps the original source."""
+    first = await growth_service.upsert_by_domain("w1", _req(source="manual"))
+    second = await growth_service.upsert_by_domain("w1", _req(source="clay", tier="b"))
+    assert second.id == first.id
+    assert second.source == "manual"
+    assert second.tier == "b"
+
+
+@pytest.mark.asyncio
+async def test_upsert_by_domain_is_workspace_scoped(mongo_db):
+    """The dedupe key is tenant-local: the same domain in two workspaces is
+    two independent rows."""
+    w1_row = await growth_service.upsert_by_domain("w1", _req())
+    w2_row = await growth_service.upsert_by_domain("w2", _req())
+    assert w1_row.id != w2_row.id
+    assert w1_row.workspace_id == "w1"
+    assert w2_row.workspace_id == "w2"
+    assert await _ProspectDoc.find({"domain": "acme-dental.com"}).count() == 2  # global-read: test


### PR DESCRIPTION
First slice of the growth module: a workspace-scoped prospect store in the standard 4-file shape, plus a dedicated `growth` arq queue seam for the outbound jobs that later slices will add.

## What's here
- `ee/pocketpaw_ee/cloud/growth/` — Prospect domain (frozen, tenancy required at construction), DTOs, service (sole Beanie writer, tenant filter on every read, fail-closed when no active workspace), CRUD routes under `/api/v1/growth/prospects` with tier/status/source filters
- `upsert_by_domain(workspace_id, data)` — create-or-update keyed on (workspace, normalised domain), backed by a unique index. This is the seam the ingestion slices call; `source` is preserved on update so capture provenance survives re-imports
- `growth/worker.py` — own arq queue so outbound bursts can't starve interactive chat runs (no-op heartbeat until the first real job lands; arq requires at least one function)
- 16 tests: CRUD, enum validation, duplicate-domain 409, parametrized cross-tenant 404s, upsert convergence
- api-reference: new Growth section

## Heads-up for review
- `ee/pyproject.toml` also drops two stale codeagent modules from the sandbox-guard import contract — they were deleted in the 2026-07-23 turn-agent refactor and import-linter hard-fails the whole ee config on nonexistent modules, so the ee lint gate could never pass without it. Happy to split it out if you'd rather.
- Stacked series: g2 (ingestion) will branch off this head.

## Verification
`pytest tests/cloud/growth/` → 16 passed. `lint-imports` core → 1 kept, 0 broken; ee config → 34 kept, 0 broken (includes the new Growth write-isolation contract). Pre-existing rbac/api-contract reds on dev confirmed identical with this diff reverted.