### PR TITLE
growth: bulk prospect ingestion

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -71,6 +71,10 @@ section: workspace-scoped prospect store under /growth/prospects (create /
 get / list with tier|status|source filters / update), domain-deduped per
 workspace, cross-tenant ids 404. First slice of the /growth outbound engine.
 
+Updated: 2026-07-27 (feat/growth-g2) — added POST /growth/prospects/bulk to
+the Growth — Prospects section: batch ingestion (max 500 rows) via the
+upsert-by-domain seam, per-row errors, idempotent re-runs.
+
 Updated: 2026-07-11 (feat/real-pipeline-s1) — documented the Fabric — Transform
 Mappings section: GET/POST/DELETE /fabric/ingest/mappings (author the
 workspace's source→Fabric mappings, now with a "connector" source_kind that
@@ -1302,8 +1306,9 @@ prospect store. All routes are license-gated and carry the canonical
 prospect id from another workspace returns an identical 404 (existence never
 leaks). The company website `domain` is the dedupe key — normalised to a bare
 lowercase hostname (scheme, `www.`, path, and port stripped) — unique per
-workspace. Later slices add ingestion, drafts, and Instinct-gated sends on the
-dedicated `growth` arq queue (`pocketpaw_ee.cloud.growth.worker.WorkerSettings`).
+workspace. G-2 adds the bulk-ingestion route below; later slices add drafts
+and Instinct-gated sends on the dedicated `growth` arq queue
+(`pocketpaw_ee.cloud.growth.worker.WorkerSettings`).
 
 ### `POST /api/v1/growth/prospects`
 
@@ -1334,6 +1339,54 @@ create-or-update callers use the service's `upsert_by_domain` seam instead.
 
 Returns the prospect envelope: all fields above plus `id`, `workspace_id`,
 and ISO `created_at` / `updated_at`.
+
+### `POST /api/v1/growth/prospects/bulk`
+
+Batch create-or-update — the ingestion endpoint for Clay exports and
+partner-directory scrapes (G-2). Body:
+
+```json
+{
+  "rows": [
+    {
+      "name": "Sam Founder",
+      "company": "Acme Dental",
+      "domain": "acme-dental.com",
+      "source": "clay",
+      "emails": ["sam@acme-dental.com"]
+    }
+  ]
+}
+```
+
+Each row is `CreateProspectRequest`-shaped (same fields, defaults, and enums
+as the single-create route above). Max **500 rows** — an oversized payload is
+a 422 before any row is processed. Rows are processed individually through
+the upsert-by-domain seam:
+
+- a **new** `(workspace, domain)` inserts → counted in `created`;
+- an **existing** one updates in place (all fields overwritten except
+  `source`, which keeps first-capture provenance) → counted in `updated`;
+- an **invalid** row (bad enum, missing field, empty domain) is skipped and
+  recorded — the rest of the batch proceeds. No all-or-nothing abort;
+  upserts are idempotent, so re-posting the same payload is safe and reports
+  every row as updated.
+
+Response:
+
+```json
+{
+  "created": 18,
+  "updated": 1,
+  "errors": [
+    {"index": 4, "code": "prospect.invalid_row", "message": "source: Input should be 'clay', 'directory' or 'manual'"}
+  ]
+}
+```
+
+`index` is the row's position in the submitted `rows` array. Rows land only
+in the caller's workspace — the same domains ingested by another workspace
+create independent rows.
 
 ### `GET /api/v1/growth/prospects`
 

--- a/ee/pocketpaw_ee/cloud/growth/dto.py
+++ b/ee/pocketpaw_ee/cloud/growth/dto.py
@@ -6,8 +6,15 @@
 #
 # Created 2026-07-27 (feat/growth-g1): first slice of /growth — the prospect
 # store. Domain → DTO mapping lives in ``service.py`` as private helpers.
+# Updated 2026-07-27 (feat/growth-g2): bulk-ingestion DTOs — BulkIngestRequest
+# (raw rows, 500-row cap enforced at the DTO boundary so an oversized payload
+# 422s before any row is touched), BulkRowError, BulkIngestResponse. Rows are
+# deliberately ``dict`` (not CreateProspectRequest) so one invalid row becomes
+# a per-row error entry in the response instead of failing the whole payload.
 
 from __future__ import annotations
+
+from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -73,6 +80,32 @@ class UpdateProspectRequest(BaseModel):
     status: ProspectStatus | None = None
 
 
+class BulkIngestRequest(BaseModel):
+    """Bulk-ingestion payload: up to 500 CreateProspectRequest-shaped rows.
+
+    Rows stay ``dict`` on purpose — the service validates each row
+    individually so a bad row records an error entry while the rest proceed
+    (no all-or-nothing abort). The 500-row cap IS enforced here: an oversized
+    payload is a 422 before any row is processed.
+    """
+
+    rows: list[dict[str, Any]] = Field(max_length=500)
+
+
+class BulkRowError(BaseModel):
+    """One failed row in a bulk ingest: its position and why it was skipped."""
+
+    index: int
+    code: str
+    message: str
+
+
+class BulkIngestResponse(BaseModel):
+    created: int
+    updated: int
+    errors: list[BulkRowError]
+
+
 class ProspectResponse(BaseModel):
     id: str
     workspace_id: str
@@ -92,6 +125,9 @@ class ProspectResponse(BaseModel):
 
 
 __all__ = [
+    "BulkIngestRequest",
+    "BulkIngestResponse",
+    "BulkRowError",
     "CreateProspectRequest",
     "ProspectResponse",
     "UpdateProspectRequest",

--- a/ee/pocketpaw_ee/cloud/growth/router.py
+++ b/ee/pocketpaw_ee/cloud/growth/router.py
@@ -8,6 +8,9 @@
 # Created 2026-07-27 (feat/growth-g1): first slice of /growth — create / get /
 # list (tier/status/source filters) / update. Later slices add ingestion,
 # drafts, and Instinct-gated sends.
+# Updated 2026-07-27 (feat/growth-g2): POST /bulk — batch ingestion (Clay /
+# directory imports) via the service's ``bulk_ingest``; 500-row cap on the DTO,
+# per-row errors in the response.
 
 from __future__ import annotations
 
@@ -17,6 +20,8 @@ from pocketpaw_ee.cloud._core.context import RequestContext, request_context
 from pocketpaw_ee.cloud.growth import service as growth_service
 from pocketpaw_ee.cloud.growth.domain import ProspectSource, ProspectStatus, ProspectTier
 from pocketpaw_ee.cloud.growth.dto import (
+    BulkIngestRequest,
+    BulkIngestResponse,
     CreateProspectRequest,
     ProspectResponse,
     UpdateProspectRequest,
@@ -34,6 +39,17 @@ async def create_prospect(
     ctx: RequestContext = Depends(request_context),
 ) -> ProspectResponse:
     return await growth_service.create(ctx, body)
+
+
+@router.post("/bulk", response_model=BulkIngestResponse)
+async def bulk_ingest_prospects(
+    body: BulkIngestRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> BulkIngestResponse:
+    """Batch create-or-update (max 500 rows). Bad rows come back as indexed
+    error entries; the rest land. Idempotent — re-posting the same payload
+    updates the existing rows instead of duplicating them."""
+    return await growth_service.bulk_ingest(ctx, body)
 
 
 @router.get("", response_model=list[ProspectResponse])

--- a/ee/pocketpaw_ee/cloud/growth/service.py
+++ b/ee/pocketpaw_ee/cloud/growth/service.py
@@ -8,6 +8,9 @@
 # Created 2026-07-27 (feat/growth-g1): first slice of /growth — the prospect
 # store. No events yet: growth has no realtime subscriber in v1, so writes
 # carry ``# no-event:`` markers per the ee/cloud emit rule.
+# Updated 2026-07-27 (feat/growth-g2): ``bulk_ingest`` — per-row validation +
+# ``upsert_by_domain`` over a capped batch; a bad row records an indexed error
+# entry and the rest proceed (idempotent upserts, so no rollback is needed).
 
 from __future__ import annotations
 
@@ -15,12 +18,16 @@ import logging
 from typing import Any
 
 from beanie import PydanticObjectId
+from pydantic import ValidationError as PydanticValidationError
 
 from pocketpaw_ee.cloud._core.context import RequestContext
 from pocketpaw_ee.cloud._core.errors import ConflictError, Forbidden, NotFound
 from pocketpaw_ee.cloud._core.time import iso_utc
 from pocketpaw_ee.cloud.growth.domain import Prospect
 from pocketpaw_ee.cloud.growth.dto import (
+    BulkIngestRequest,
+    BulkIngestResponse,
+    BulkRowError,
     CreateProspectRequest,
     ProspectResponse,
     UpdateProspectRequest,
@@ -225,7 +232,56 @@ async def upsert_by_domain(
     return _to_response(_to_domain(doc))
 
 
+async def bulk_ingest(ctx: RequestContext, body: BulkIngestRequest) -> BulkIngestResponse:
+    """Ingest a batch of prospect rows via ``upsert_by_domain``.
+
+    Each row is validated individually: an invalid row records a
+    ``BulkRowError`` (with its payload index) and the remaining rows proceed —
+    no all-or-nothing abort. Upserts are idempotent, so a partial failure
+    needs no rollback and a re-run of the same payload is safe (second run
+    reports every row as updated). The 500-row cap lives on the DTO, so an
+    oversized payload 422s at the boundary before this function runs.
+    """
+    body = BulkIngestRequest.model_validate(body)
+    workspace_id = _require_workspace(ctx)
+
+    created = 0
+    updated = 0
+    errors: list[BulkRowError] = []
+    for index, raw in enumerate(body.rows):
+        try:
+            row = CreateProspectRequest.model_validate(raw)
+        except PydanticValidationError as exc:
+            first = exc.errors()[0]
+            loc = ".".join(str(part) for part in first["loc"]) or "row"
+            errors.append(
+                BulkRowError(
+                    index=index,
+                    code="prospect.invalid_row",
+                    message=f"{loc}: {first['msg']}",
+                )
+            )
+            continue
+        existing = await _ProspectDoc.find_one({"workspace": workspace_id, "domain": row.domain})
+        await upsert_by_domain(workspace_id, row)
+        if existing is None:
+            created += 1
+        else:
+            updated += 1
+
+    logger.info(
+        "growth.bulk_ingest workspace=%s rows=%d created=%d updated=%d errors=%d",
+        workspace_id,
+        len(body.rows),
+        created,
+        updated,
+        len(errors),
+    )
+    return BulkIngestResponse(created=created, updated=updated, errors=errors)
+
+
 __all__ = [
+    "bulk_ingest",
     "create",
     "get",
     "list_prospects",

--- a/tests/cloud/growth/test_router.py
+++ b/tests/cloud/growth/test_router.py
@@ -7,6 +7,10 @@
 # cross-tenant isolation (foreign ids 404, foreign rows never listed).
 #
 # Created 2026-07-27 (feat/growth-g1): first slice of /growth.
+# Updated 2026-07-27 (feat/growth-g2): bulk-ingestion coverage — POST /bulk
+# idempotency (20 rows twice → second run all-updated), mixed-validity payloads
+# (bad rows become indexed error entries, good rows land), the 501-row 422 cap,
+# and cross-tenant scoping (bulk rows land only in the caller's workspace).
 
 from __future__ import annotations
 
@@ -198,6 +202,111 @@ async def test_list_filters_by_tier_status_source(w1_client):
 async def test_list_rejects_unknown_filter_value(w1_client):
     resp = await w1_client.get("/api/v1/growth/prospects", params={"tier": "platinum"})
     assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Bulk ingestion — POST /bulk
+# ---------------------------------------------------------------------------
+
+
+def _bulk_rows(n: int, source: str = "clay") -> list[dict[str, Any]]:
+    return [
+        {
+            "name": f"Contact {i}",
+            "company": f"Company {i}",
+            "domain": f"company-{i}.com",
+            "source": source,
+        }
+        for i in range(n)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_bulk_ingest_is_idempotent(w1_client):
+    """POSTing the same 20 rows twice: first run creates all, second run
+    updates all — never duplicates (upsert keyed on workspace+domain)."""
+    rows = _bulk_rows(20)
+
+    first = await w1_client.post("/api/v1/growth/prospects/bulk", json={"rows": rows})
+    assert first.status_code == 200, first.text
+    assert first.json() == {"created": 20, "updated": 0, "errors": []}
+
+    second = await w1_client.post("/api/v1/growth/prospects/bulk", json={"rows": rows})
+    assert second.status_code == 200, second.text
+    assert second.json() == {"created": 0, "updated": 20, "errors": []}
+
+    listed = await w1_client.get("/api/v1/growth/prospects", params={"limit": 500})
+    assert len(listed.json()) == 20
+
+
+@pytest.mark.asyncio
+async def test_bulk_ingest_mixed_validity_records_errors_and_lands_good_rows(w1_client):
+    """A bad row becomes an indexed error entry; the rows around it land."""
+    rows = [
+        _payload(domain="alpha.io", company="Alpha"),
+        _payload(domain="bad.io", source="scraped"),  # invalid enum → error at index 1
+        {"name": "No Domain", "company": "Ghost", "source": "manual"},  # missing domain → index 2
+        _payload(domain="omega.io", company="Omega"),
+    ]
+
+    resp = await w1_client.post("/api/v1/growth/prospects/bulk", json={"rows": rows})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["created"] == 2
+    assert body["updated"] == 0
+    assert [e["index"] for e in body["errors"]] == [1, 2]
+    for err in body["errors"]:
+        assert err["code"] == "prospect.invalid_row"
+        assert err["message"]
+
+    listed = await w1_client.get("/api/v1/growth/prospects")
+    assert {p["domain"] for p in listed.json()} == {"alpha.io", "omega.io"}
+
+
+@pytest.mark.asyncio
+async def test_bulk_ingest_updates_existing_and_creates_new_in_one_call(w1_client):
+    """A payload mixing known and new domains splits into updated + created."""
+    await w1_client.post("/api/v1/growth/prospects", json=_payload(domain="alpha.io"))
+
+    rows = [
+        _payload(domain="alpha.io", name="Refreshed Contact", tier="a"),
+        _payload(domain="brand-new.io", company="Brand New"),
+    ]
+    resp = await w1_client.post("/api/v1/growth/prospects/bulk", json={"rows": rows})
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"created": 1, "updated": 1, "errors": []}
+
+    listed = (await w1_client.get("/api/v1/growth/prospects")).json()
+    by_domain = {p["domain"]: p for p in listed}
+    assert by_domain["alpha.io"]["name"] == "Refreshed Contact"
+    assert by_domain["alpha.io"]["tier"] == "a"
+
+
+@pytest.mark.asyncio
+async def test_bulk_ingest_rejects_more_than_500_rows(w1_client):
+    resp = await w1_client.post("/api/v1/growth/prospects/bulk", json={"rows": _bulk_rows(501)})
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_bulk_ingest_is_workspace_scoped(w1_client, w2_client):
+    """Bulk rows land only in the caller's workspace: w2 sees none of w1's
+    ingested rows, and the same domains ingested by w2 create fresh rows."""
+    rows = _bulk_rows(3)
+    resp = await w1_client.post("/api/v1/growth/prospects/bulk", json={"rows": rows})
+    assert resp.json() == {"created": 3, "updated": 0, "errors": []}
+
+    # w2 sees nothing from w1's ingest.
+    assert (await w2_client.get("/api/v1/growth/prospects")).json() == []
+
+    # The same domains in w2 are creates (fresh rows), not cross-tenant updates.
+    resp = await w2_client.post("/api/v1/growth/prospects/bulk", json={"rows": rows})
+    assert resp.json() == {"created": 3, "updated": 0, "errors": []}
+
+    w1_listed = (await w1_client.get("/api/v1/growth/prospects")).json()
+    w2_listed = (await w2_client.get("/api/v1/growth/prospects")).json()
+    assert len(w1_listed) == 3 and len(w2_listed) == 3
+    assert {p["id"] for p in w1_listed}.isdisjoint({p["id"] for p in w2_listed})
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Second slice of the growth module, stacked on #1798.

Adds `POST /api/v1/growth/prospects/bulk` — batch prospect ingestion through the existing `upsert_by_domain` seam. Rows validate individually: a bad row records an indexed error entry and the rest proceed, so a Clay export with one malformed record doesn't lose the other 499. Re-posting the same payload is safe (upserts are idempotent — second run reports everything as updated). 500-row cap at the DTO boundary.

Also ships the `growth-ingest` crew skill in the workspace repo documenting the two ingest paths (Clay search + partner-directory scrape) and the payload contract.

## Verification
`pytest tests/cloud/growth/` → 21 passed (5 new: double-post idempotency, mixed-validity indexed errors, create/update split, 501-row 422, cross-tenant isolation). Both import-linter configs green (1 kept / 34 kept, 0 broken). ruff check + format clean.