### PR TITLE
growth: outreach drafts with an enforced lifecycle

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -75,6 +75,13 @@ Updated: 2026-07-27 (feat/growth-g2) — added POST /growth/prospects/bulk to
 the Growth — Prospects section: batch ingestion (max 500 rows) via the
 upsert-by-domain seam, per-row errors, idempotent re-runs.
 
+Updated: 2026-07-27 (feat/growth-g3) — added the Growth — Drafts section:
+per-channel outreach drafts on a prospect (POST /growth/prospects/{id}/drafts,
+GET /growth/drafts with prospect|channel|status filters, POST
+/growth/drafts/{id}/status) with the enforced lifecycle
+draft→proposed→approved→sent, sent→replied, non-terminal→rejected; illegal
+moves 422 draft.illegal_transition.
+
 Updated: 2026-07-11 (feat/real-pipeline-s1) — documented the Fabric — Transform
 Mappings section: GET/POST/DELETE /fabric/ingest/mappings (author the
 workspace's source→Fabric mappings, now with a "connector" source_kind that
@@ -1405,3 +1412,61 @@ identity) and `source` (capture-time provenance) are immutable; the other
 fields (`name`, `company`, `tier`, `research_brief`, `emails`,
 `linkedin_url`, `whatsapp_number`, `opted_in`, `status`) patch in place.
 Returns the updated envelope.
+
+## Growth — Drafts
+
+Third slice of the `/growth` outbound engine (G-3): per-channel outreach
+drafts attached to a prospect, with an enforced status lifecycle. Same gates
+as prospects — license + `request_context`, every read workspace-scoped
+(cross-tenant ids 404). The lifecycle is the object the send-gate slice
+(G-4) proposes and dispatches on top of:
+
+```
+draft → proposed → approved → sent → replied
+  └────────┴──────────┴─────────┴──→ rejected   (any non-terminal)
+```
+
+`replied` and `rejected` are terminal. Any other move — skipping ahead,
+going backwards, leaving a terminal state — is a
+`422 draft.illegal_transition`. Transitions are mechanism-only: no side
+effects, no sending.
+
+### `POST /api/v1/growth/prospects/{prospect_id}/drafts`
+
+Attach one channel's copy to a prospect. Body:
+
+```json
+{
+  "channel": "email",
+  "subject": "Quick idea for Acme Dental's booking flow",
+  "body": "Saw your online booking stops at a contact form — here's a live demo.",
+  "variant": "first_touch",
+  "demo_url": null
+}
+```
+
+`channel` (`email | linkedin | whatsapp`) and `body` (non-empty, max 10 000
+chars) are required. `subject` is **email-only** — sending it on another
+channel is a 422. `variant` is `first_touch | follow_up` (default
+`first_touch`). Drafts are always born in `status: "draft"` — there is no
+status field here; lifecycle moves go through the transition route.
+
+The prospect must exist in the caller's workspace (`404 prospect.not_found`
+otherwise). A prospect still in `new` / `qualified` flips to `drafted` on
+its first draft; later prospect statuses are never regressed.
+
+Returns the draft envelope: the fields above plus `id`, `workspace_id`,
+`prospect_id`, `status`, and ISO `created_at` / `updated_at`.
+
+### `GET /api/v1/growth/drafts`
+
+List the workspace's drafts, newest first. Optional query filters:
+`prospect_id`, `channel`, `status` (enum-validated — an unknown value is a
+422) and `limit` (default 100, max 500).
+
+### `POST /api/v1/growth/drafts/{draft_id}/status`
+
+Move a draft along the lifecycle. Body: `{"status": "proposed"}` (any
+`DraftStatus`). Legal moves per the machine above; anything else is a
+`422 draft.illegal_transition` and the draft is unchanged. Cross-tenant or
+unknown ids: `404 draft.not_found`. Returns the updated envelope.

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -1,5 +1,9 @@
 """PocketPaw Enterprise Cloud — domain-driven architecture.
 
+Modified: 2026-07-27 (feat/growth-g3) — The growth router now also carries
+    drafts (``/growth/prospects/{id}/drafts``, ``/growth/drafts``,
+    ``/growth/drafts/{id}/status``); its prefix widened to ``/growth`` with
+    final prospect URLs unchanged.
 Modified: 2026-07-27 (feat/growth-g1) — Mounts the growth prospect-store
     router (``/growth/prospects`` create / get / list / update) under
     ``/api/v1``. License gate + ``request_context`` on every route;

--- a/ee/pocketpaw_ee/cloud/growth/domain.py
+++ b/ee/pocketpaw_ee/cloud/growth/domain.py
@@ -9,6 +9,11 @@
 #
 # Created 2026-07-27 (feat/growth-g1): first slice of /growth — the prospect
 # store. Later slices add ingestion, drafts, and Instinct-gated sends.
+# Updated 2026-07-27 (feat/growth-g3): ``Draft`` — per-channel outreach copy
+# attached to a prospect, with the enforced status machine
+# (``DRAFT_TRANSITIONS``): draft→proposed→approved→sent, sent→replied, any
+# non-terminal→rejected. The transition table lives here (pure data) so the
+# service stays a dumb enforcer and G-4 can wire Instinct proposals on top.
 
 from __future__ import annotations
 
@@ -59,8 +64,55 @@ class Prospect:
     updated_at: datetime | None = None
 
 
+# Outreach channel a draft targets. ``subject`` only applies to email.
+DraftChannel = Literal["email", "linkedin", "whatsapp"]
+
+# Which touch in the sequence the copy is written for.
+DraftVariant = Literal["first_touch", "follow_up"]
+
+# Draft lifecycle. ``replied`` and ``rejected`` are terminal.
+DraftStatus = Literal["draft", "proposed", "approved", "sent", "replied", "rejected"]
+
+# The enforced status machine: draft→proposed→approved→sent (the happy chain),
+# sent→replied (the prospect answered), and any NON-terminal status→rejected.
+# ``replied`` / ``rejected`` are terminal — absent keys, so nothing leaves them.
+# The service raises ``draft.illegal_transition`` (422) for any pair not here.
+DRAFT_TRANSITIONS: dict[str, frozenset[str]] = {
+    "draft": frozenset({"proposed", "rejected"}),
+    "proposed": frozenset({"approved", "rejected"}),
+    "approved": frozenset({"sent", "rejected"}),
+    "sent": frozenset({"replied", "rejected"}),
+}
+
+
+@dataclass(frozen=True)
+class Draft:
+    """Draft value object — one channel's outreach copy for a prospect.
+
+    ``subject`` is email-only (``None`` on linkedin / whatsapp — the DTO
+    boundary enforces it). ``body`` is the message copy and is never empty.
+    """
+
+    id: str
+    workspace_id: str
+    prospect_id: str
+    channel: str  # DraftChannel — validated at the DTO boundary
+    body: str
+    subject: str | None = None  # email only
+    variant: str = "first_touch"  # DraftVariant
+    status: str = "draft"  # DraftStatus
+    demo_url: str | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
 __all__ = [
+    "DRAFT_TRANSITIONS",
     "GROWTH_QUEUE_NAME",
+    "Draft",
+    "DraftChannel",
+    "DraftStatus",
+    "DraftVariant",
     "Prospect",
     "ProspectSource",
     "ProspectStatus",

--- a/ee/pocketpaw_ee/cloud/growth/dto.py
+++ b/ee/pocketpaw_ee/cloud/growth/dto.py
@@ -11,14 +11,25 @@
 # 422s before any row is touched), BulkRowError, BulkIngestResponse. Rows are
 # deliberately ``dict`` (not CreateProspectRequest) so one invalid row becomes
 # a per-row error entry in the response instead of failing the whole payload.
+# Updated 2026-07-27 (feat/growth-g3): draft DTOs — CreateDraftRequest (subject
+# is email-only, enforced here at the boundary; body non-empty),
+# TransitionDraftRequest (the target status; legality is the SERVICE's job —
+# the DTO only checks it's a known status), DraftResponse.
 
 from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
-from pocketpaw_ee.cloud.growth.domain import ProspectSource, ProspectStatus, ProspectTier
+from pocketpaw_ee.cloud.growth.domain import (
+    DraftChannel,
+    DraftStatus,
+    DraftVariant,
+    ProspectSource,
+    ProspectStatus,
+    ProspectTier,
+)
 
 
 def _normalise_domain(v: str) -> str:
@@ -124,11 +135,63 @@ class ProspectResponse(BaseModel):
     updated_at: str | None
 
 
+class CreateDraftRequest(BaseModel):
+    """One channel's outreach copy for a prospect.
+
+    A draft is always born in ``status="draft"`` — there is no status field
+    here; lifecycle moves happen only through the transition route.
+    """
+
+    channel: DraftChannel
+    subject: str | None = Field(default=None, max_length=200)
+    body: str = Field(min_length=1, max_length=10_000)
+    variant: DraftVariant = "first_touch"
+    demo_url: str | None = Field(default=None, max_length=2048)
+
+    @field_validator("body")
+    @classmethod
+    def _non_blank_body(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("body must not be blank")
+        return v
+
+    @model_validator(mode="after")
+    def _subject_is_email_only(self) -> CreateDraftRequest:
+        if self.channel != "email" and self.subject is not None:
+            raise ValueError("subject is only valid on the email channel")
+        return self
+
+
+class TransitionDraftRequest(BaseModel):
+    """Target status for a lifecycle move. Whether the move is LEGAL from the
+    draft's current status is the service's call (``draft.illegal_transition``,
+    422) — this DTO only rejects unknown status names."""
+
+    status: DraftStatus
+
+
+class DraftResponse(BaseModel):
+    id: str
+    workspace_id: str
+    prospect_id: str
+    channel: str
+    subject: str | None
+    body: str
+    variant: str
+    status: str
+    demo_url: str | None
+    created_at: str | None
+    updated_at: str | None
+
+
 __all__ = [
     "BulkIngestRequest",
     "BulkIngestResponse",
     "BulkRowError",
+    "CreateDraftRequest",
     "CreateProspectRequest",
+    "DraftResponse",
     "ProspectResponse",
+    "TransitionDraftRequest",
     "UpdateProspectRequest",
 ]

--- a/ee/pocketpaw_ee/cloud/growth/router.py
+++ b/ee/pocketpaw_ee/cloud/growth/router.py
@@ -11,6 +11,11 @@
 # Updated 2026-07-27 (feat/growth-g2): POST /bulk — batch ingestion (Clay /
 # directory imports) via the service's ``bulk_ingest``; 500-row cap on the DTO,
 # per-row errors in the response.
+# Updated 2026-07-27 (feat/growth-g3): drafts — POST /prospects/{id}/drafts,
+# GET /drafts (prospect/channel/status filters), POST /drafts/{id}/status
+# (illegal moves 422 ``draft.illegal_transition``). Router prefix widened from
+# ``/growth/prospects`` to ``/growth`` (routes now carry ``/prospects``
+# themselves) so drafts mount beside prospects — final URLs unchanged.
 
 from __future__ import annotations
 
@@ -18,22 +23,29 @@ from fastapi import APIRouter, Depends, Query
 
 from pocketpaw_ee.cloud._core.context import RequestContext, request_context
 from pocketpaw_ee.cloud.growth import service as growth_service
-from pocketpaw_ee.cloud.growth.domain import ProspectSource, ProspectStatus, ProspectTier
+from pocketpaw_ee.cloud.growth.domain import (
+    DraftChannel,
+    DraftStatus,
+    ProspectSource,
+    ProspectStatus,
+    ProspectTier,
+)
 from pocketpaw_ee.cloud.growth.dto import (
     BulkIngestRequest,
     BulkIngestResponse,
+    CreateDraftRequest,
     CreateProspectRequest,
+    DraftResponse,
     ProspectResponse,
+    TransitionDraftRequest,
     UpdateProspectRequest,
 )
 from pocketpaw_ee.cloud.license import require_license
 
-router = APIRouter(
-    prefix="/growth/prospects", tags=["Growth"], dependencies=[Depends(require_license)]
-)
+router = APIRouter(prefix="/growth", tags=["Growth"], dependencies=[Depends(require_license)])
 
 
-@router.post("", response_model=ProspectResponse)
+@router.post("/prospects", response_model=ProspectResponse)
 async def create_prospect(
     body: CreateProspectRequest,
     ctx: RequestContext = Depends(request_context),
@@ -41,7 +53,7 @@ async def create_prospect(
     return await growth_service.create(ctx, body)
 
 
-@router.post("/bulk", response_model=BulkIngestResponse)
+@router.post("/prospects/bulk", response_model=BulkIngestResponse)
 async def bulk_ingest_prospects(
     body: BulkIngestRequest,
     ctx: RequestContext = Depends(request_context),
@@ -52,7 +64,7 @@ async def bulk_ingest_prospects(
     return await growth_service.bulk_ingest(ctx, body)
 
 
-@router.get("", response_model=list[ProspectResponse])
+@router.get("/prospects", response_model=list[ProspectResponse])
 async def list_prospects(
     tier: ProspectTier | None = Query(default=None),
     status: ProspectStatus | None = Query(default=None),
@@ -65,7 +77,7 @@ async def list_prospects(
     )
 
 
-@router.get("/{prospect_id}", response_model=ProspectResponse)
+@router.get("/prospects/{prospect_id}", response_model=ProspectResponse)
 async def get_prospect(
     prospect_id: str,
     ctx: RequestContext = Depends(request_context),
@@ -73,10 +85,52 @@ async def get_prospect(
     return await growth_service.get(ctx, prospect_id)
 
 
-@router.patch("/{prospect_id}", response_model=ProspectResponse)
+@router.patch("/prospects/{prospect_id}", response_model=ProspectResponse)
 async def update_prospect(
     prospect_id: str,
     body: UpdateProspectRequest,
     ctx: RequestContext = Depends(request_context),
 ) -> ProspectResponse:
     return await growth_service.update(ctx, prospect_id, body)
+
+
+# ---------------------------------------------------------------------------
+# Drafts (G-3)
+# ---------------------------------------------------------------------------
+
+
+@router.post("/prospects/{prospect_id}/drafts", response_model=DraftResponse)
+async def create_draft(
+    prospect_id: str,
+    body: CreateDraftRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> DraftResponse:
+    """Attach one channel's outreach copy to a prospect. The prospect must
+    exist in the caller's workspace (404 otherwise); a new/qualified prospect
+    flips to ``drafted`` on its first draft."""
+    return await growth_service.create_draft(ctx, prospect_id, body)
+
+
+@router.get("/drafts", response_model=list[DraftResponse])
+async def list_drafts(
+    prospect_id: str | None = Query(default=None),
+    channel: DraftChannel | None = Query(default=None),
+    status: DraftStatus | None = Query(default=None),
+    limit: int = Query(default=100, ge=1, le=500),
+    ctx: RequestContext = Depends(request_context),
+) -> list[DraftResponse]:
+    return await growth_service.list_drafts(
+        ctx, prospect_id=prospect_id, channel=channel, status=status, limit=limit
+    )
+
+
+@router.post("/drafts/{draft_id}/status", response_model=DraftResponse)
+async def transition_draft(
+    draft_id: str,
+    body: TransitionDraftRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> DraftResponse:
+    """Move a draft along the lifecycle. Legal: draft→proposed→approved→sent,
+    sent→replied, any non-terminal→rejected. Anything else is a 422
+    ``draft.illegal_transition``."""
+    return await growth_service.transition(ctx, draft_id, body)

--- a/ee/pocketpaw_ee/cloud/growth/service.py
+++ b/ee/pocketpaw_ee/cloud/growth/service.py
@@ -11,6 +11,12 @@
 # Updated 2026-07-27 (feat/growth-g2): ``bulk_ingest`` — per-row validation +
 # ``upsert_by_domain`` over a capped batch; a bad row records an indexed error
 # entry and the rest proceed (idempotent upserts, so no rollback is needed).
+# Updated 2026-07-27 (feat/growth-g3): drafts — ``create_draft`` (prospect must
+# exist in the workspace; first draft flips a new/qualified prospect to
+# ``drafted``), ``list_drafts`` (prospect/channel/status filters), and
+# ``transition`` — a dumb enforcer of ``DRAFT_TRANSITIONS`` (illegal moves →
+# 422 ``draft.illegal_transition``), no side effects; G-4 wires proposals on
+# top. This module also owns the Draft doc writes (same "Growth" contract).
 
 from __future__ import annotations
 
@@ -21,17 +27,21 @@ from beanie import PydanticObjectId
 from pydantic import ValidationError as PydanticValidationError
 
 from pocketpaw_ee.cloud._core.context import RequestContext
-from pocketpaw_ee.cloud._core.errors import ConflictError, Forbidden, NotFound
+from pocketpaw_ee.cloud._core.errors import ConflictError, Forbidden, NotFound, ValidationError
 from pocketpaw_ee.cloud._core.time import iso_utc
-from pocketpaw_ee.cloud.growth.domain import Prospect
+from pocketpaw_ee.cloud.growth.domain import DRAFT_TRANSITIONS, Draft, Prospect
 from pocketpaw_ee.cloud.growth.dto import (
     BulkIngestRequest,
     BulkIngestResponse,
     BulkRowError,
+    CreateDraftRequest,
     CreateProspectRequest,
+    DraftResponse,
     ProspectResponse,
+    TransitionDraftRequest,
     UpdateProspectRequest,
 )
+from pocketpaw_ee.cloud.models.draft import Draft as _DraftDoc
 from pocketpaw_ee.cloud.models.prospect import Prospect as _ProspectDoc
 
 logger = logging.getLogger(__name__)
@@ -59,6 +69,38 @@ def _to_domain(doc: _ProspectDoc) -> Prospect:
         status=doc.status,
         created_at=getattr(doc, "createdAt", None),
         updated_at=getattr(doc, "updatedAt", None),
+    )
+
+
+def _draft_to_domain(doc: _DraftDoc) -> Draft:
+    return Draft(
+        id=str(doc.id),
+        workspace_id=doc.workspace,
+        prospect_id=doc.prospect_id,
+        channel=doc.channel,
+        subject=doc.subject,
+        body=doc.body,
+        variant=doc.variant,
+        status=doc.status,
+        demo_url=doc.demo_url,
+        created_at=getattr(doc, "createdAt", None),
+        updated_at=getattr(doc, "updatedAt", None),
+    )
+
+
+def _draft_to_response(d: Draft) -> DraftResponse:
+    return DraftResponse(
+        id=d.id,
+        workspace_id=d.workspace_id,
+        prospect_id=d.prospect_id,
+        channel=d.channel,
+        subject=d.subject,
+        body=d.body,
+        variant=d.variant,
+        status=d.status,
+        demo_url=d.demo_url,
+        created_at=iso_utc(d.created_at),
+        updated_at=iso_utc(d.updated_at),
     )
 
 
@@ -280,11 +322,111 @@ async def bulk_ingest(ctx: RequestContext, body: BulkIngestRequest) -> BulkInges
     return BulkIngestResponse(created=created, updated=updated, errors=errors)
 
 
+# ---------------------------------------------------------------------------
+# Drafts (G-3)
+# ---------------------------------------------------------------------------
+
+
+async def _fetch_draft_in_workspace(workspace_id: str, draft_id: str) -> _DraftDoc:
+    """Fetch a draft scoped to the caller's workspace — identical 404s for a
+    malformed id, a missing row, or another tenant's row."""
+    try:
+        oid = PydanticObjectId(draft_id)
+    except Exception as exc:  # noqa: BLE001 — malformed id == not found
+        raise NotFound("draft", draft_id) from exc
+    doc = await _DraftDoc.find_one({"_id": oid, "workspace": workspace_id})
+    if doc is None:
+        raise NotFound("draft", draft_id)
+    return doc
+
+
+async def create_draft(
+    ctx: RequestContext, prospect_id: str, body: CreateDraftRequest
+) -> DraftResponse:
+    """Attach one channel's outreach copy to a prospect.
+
+    The prospect must exist in the caller's workspace (cross-tenant ids 404,
+    existence never leaks). A prospect still sitting in ``new`` / ``qualified``
+    flips to ``drafted`` on its first draft; later statuses (``in_sequence``,
+    ``replied``, ``dead``) are never regressed.
+    """
+    body = CreateDraftRequest.model_validate(body)
+    workspace_id = _require_workspace(ctx)
+    prospect = await _fetch_in_workspace(workspace_id, prospect_id)
+
+    doc = _DraftDoc(
+        workspace=workspace_id,
+        prospect_id=str(prospect.id),
+        **body.model_dump(),
+    )
+    await doc.insert()
+    # no-event: growth has no realtime subscriber in v1; the drafts view polls.
+
+    if prospect.status in ("new", "qualified"):
+        prospect.status = "drafted"
+        await prospect.save()  # bumps updatedAt
+        # no-event: growth has no realtime subscriber in v1.
+
+    return _draft_to_response(_draft_to_domain(doc))
+
+
+async def list_drafts(
+    ctx: RequestContext,
+    *,
+    prospect_id: str | None = None,
+    channel: str | None = None,
+    status: str | None = None,
+    limit: int = 100,
+) -> list[DraftResponse]:
+    """List the workspace's drafts, newest first, optionally filtered."""
+    workspace_id = _require_workspace(ctx)
+    filters: dict[str, Any] = {"workspace": workspace_id}
+    if prospect_id is not None:
+        filters["prospect_id"] = prospect_id
+    if channel is not None:
+        filters["channel"] = channel
+    if status is not None:
+        filters["status"] = status
+    cursor = (
+        _DraftDoc.find(filters)
+        .sort(-_DraftDoc.createdAt)  # type: ignore[operator]
+        .limit(limit)
+    )
+    return [_draft_to_response(_draft_to_domain(doc)) async for doc in cursor]
+
+
+async def transition(
+    ctx: RequestContext, draft_id: str, body: TransitionDraftRequest
+) -> DraftResponse:
+    """Move a draft along the status machine — a dumb enforcer, no side
+    effects. Legal moves per ``DRAFT_TRANSITIONS``: draft→proposed→approved→
+    sent, sent→replied, any non-terminal→rejected. Anything else is a 422
+    ``draft.illegal_transition``. G-4 wires Instinct proposals ON TOP of this
+    seam; it stays mechanism-only."""
+    body = TransitionDraftRequest.model_validate(body)
+    workspace_id = _require_workspace(ctx)
+    doc = await _fetch_draft_in_workspace(workspace_id, draft_id)
+
+    if body.status not in DRAFT_TRANSITIONS.get(doc.status, frozenset()):
+        raise ValidationError(
+            "draft.illegal_transition",
+            f"Cannot move a draft from '{doc.status}' to '{body.status}'",
+        )
+
+    doc.status = body.status
+    await doc.save()  # bumps updatedAt
+    # no-event: growth has no realtime subscriber in v1; the drafts view polls.
+    return _draft_to_response(_draft_to_domain(doc))
+
+
 __all__ = [
     "bulk_ingest",
     "create",
+    "create_draft",
     "get",
+    "list_drafts",
     "list_prospects",
+    "transition",
     "update",
     "upsert_by_domain",
 ]

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -1,5 +1,11 @@
 """Cloud document models — re-exports for Beanie init.
 
+Updated: 2026-07-27 (feat/growth-g3) — added ``Draft`` (the /growth per-channel
+outreach draft: workspace-scoped, attached to a prospect, status lifecycle
+enforced in the service) to the imports and ``get_all_documents()`` so the
+``growth_drafts`` collection is wired into ``init_beanie``. Kept out of
+``__all__`` like ``Prospect`` — only ``ee.cloud.growth.service`` imports the
+doc class directly (import-linter "Growth" contract).
 Updated: 2026-07-27 (feat/growth-g1) — added ``Prospect`` (the /growth
 outbound-engine prospect store: workspace-scoped, unique (workspace, domain)
 dedupe key) to the imports and ``get_all_documents()`` so the
@@ -142,6 +148,7 @@ from pocketpaw_ee.cloud.models.connector import WorkspaceConnector
 from pocketpaw_ee.cloud.models.credit import CreditBalance, CreditLedgerEntry
 from pocketpaw_ee.cloud.models.cycle import Cycle, CycleDailyPoint
 from pocketpaw_ee.cloud.models.deep_work_log import DeepWorkLog
+from pocketpaw_ee.cloud.models.draft import Draft
 from pocketpaw_ee.cloud.models.fabric_ingest_state import (
     FabricIngestConfig,
     FabricIngestState,
@@ -480,6 +487,10 @@ def get_all_documents():
         # ``ee.cloud.growth.service`` imports this doc directly (import-linter
         # "Growth" contract).
         Prospect,
+        # Growth drafts (G-3) — per-channel outreach copy attached to a
+        # prospect, status lifecycle enforced in the service. Same import
+        # boundary as Prospect.
+        Draft,
         PushSubscription,
         VapidKeypair,
         WorkspaceSensePreference,

--- a/ee/pocketpaw_ee/cloud/models/draft.py
+++ b/ee/pocketpaw_ee/cloud/models/draft.py
@@ -1,0 +1,39 @@
+# ee/pocketpaw_ee/cloud/models/draft.py — per-channel outreach draft for the
+# /growth surface (G-3, feat/growth-g3). Workspace-scoped, attached to a
+# ``growth_prospects`` row by ``prospect_id``. Status lifecycle
+# (draft→proposed→approved→sent, sent→replied, non-terminal→rejected) is
+# enforced in ``ee.cloud.growth.service`` — the only module allowed to import
+# this doc class (import-linter "Growth" contract).
+#
+# Created 2026-07-27 (feat/growth-g3): third slice of /growth — drafts. G-4
+# wires Instinct-gated proposals and dispatch on top of this record.
+
+from __future__ import annotations
+
+from beanie import Indexed
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class Draft(TimestampedDocument):
+    """One channel's outreach draft for a prospect in a workspace."""
+
+    # Tenancy boundary — every read filters on this.
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    # The growth_prospects row this copy targets (stringified ObjectId).
+    prospect_id: str
+    channel: str  # email | linkedin | whatsapp (validated at the DTO boundary)
+    subject: str | None = None  # email only
+    body: str
+    variant: str = "first_touch"  # first_touch | follow_up
+    status: str = "draft"  # draft | proposed | approved | sent | replied | rejected
+    demo_url: str | None = None
+
+    class Settings:
+        name = "growth_drafts"
+        indexes = [
+            # A prospect's drafts — the per-prospect drafts view / dedupe scan.
+            [("workspace", 1), ("prospect_id", 1)],
+            # The send-gate queue view (G-4): drafts by status per channel.
+            [("workspace", 1), ("status", 1), ("channel", 1)],
+        ]

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -798,6 +798,8 @@ name = "Growth — Beanie writes only from service.py"
 # feat/growth-g1 — only ``growth.service`` owns the Prospect Beanie writes;
 # dto/domain/router/worker go through it. The worker is the dedicated
 # ``growth`` arq queue seam and must never touch the doc class directly.
+# feat/growth-g3 — the Draft doc joins the same boundary: writes only from
+# ``growth.service``.
 type = "forbidden"
 allow_indirect_imports = "true"
 source_modules = [
@@ -806,7 +808,10 @@ source_modules = [
     "pocketpaw_ee.cloud.growth.domain",
     "pocketpaw_ee.cloud.growth.worker",
 ]
-forbidden_modules = ["pocketpaw_ee.cloud.models.prospect"]
+forbidden_modules = [
+    "pocketpaw_ee.cloud.models.prospect",
+    "pocketpaw_ee.cloud.models.draft",
+]
 
 [[tool.importlinter.contracts]]
 name = "LLM provisioning — Beanie writes only from service.py"

--- a/tests/cloud/growth/test_drafts.py
+++ b/tests/cloud/growth/test_drafts.py
@@ -1,0 +1,383 @@
+# tests/cloud/growth/test_drafts.py — HTTP-layer tests for the G-3 drafts
+# slice (``ee/cloud/growth/{router,service}.py``). Same harness as
+# test_router.py: FastAPI app + fixed RequestContext override per workspace
+# (w1/w2 clients), mongomock-backed Beanie via the shared ``mongo_db``
+# fixture. Covers: one prospect fully drafted across the three channels, the
+# prospect.status flip to ``drafted`` (and no regression from later
+# statuses), the legal lifecycle chain, parametrized illegal transitions
+# (422 ``draft.illegal_transition``), DTO-boundary validation (blank body,
+# subject on a non-email channel), list filters, and tenancy (foreign
+# prospect → 404 on create, foreign draft ids 404, lists never leak).
+#
+# Created 2026-07-27 (feat/growth-g3): third slice of /growth — drafts.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind, request_context
+from pocketpaw_ee.cloud._core.http import add_error_handler
+from pocketpaw_ee.cloud.growth.router import router as growth_router
+from pocketpaw_ee.cloud.license import require_license
+
+
+def _make_ctx(workspace_id: str | None, user_id: str = "u1") -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="test",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+def _build_app(workspace_id: str | None = "w1", user_id: str = "u1") -> FastAPI:
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(growth_router, prefix="/api/v1")
+
+    async def _ctx() -> RequestContext:
+        return _make_ctx(workspace_id, user_id)
+
+    app.dependency_overrides[request_context] = _ctx
+    app.dependency_overrides[require_license] = lambda: None
+    return app
+
+
+@pytest_asyncio.fixture
+async def w1_client(mongo_db: Any) -> AsyncClient:
+    app = _build_app(workspace_id="w1")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+@pytest_asyncio.fixture
+async def w2_client(mongo_db: Any) -> AsyncClient:
+    app = _build_app(workspace_id="w2")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+def _prospect_payload(**overrides: Any) -> dict[str, Any]:
+    base = {
+        "name": "Sam Founder",
+        "company": "Acme Dental",
+        "domain": "acme-dental.com",
+        "source": "manual",
+    }
+    base.update(overrides)
+    return base
+
+
+def _draft_payload(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "channel": "email",
+        "subject": "Quick idea for Acme Dental's booking flow",
+        "body": "Saw your online booking stops at a contact form — here's a live demo.",
+    }
+    base.update(overrides)
+    return base
+
+
+async def _create_prospect(client: AsyncClient, **overrides: Any) -> dict[str, Any]:
+    resp = await client.post("/api/v1/growth/prospects", json=_prospect_payload(**overrides))
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+async def _create_draft(client: AsyncClient, prospect_id: str, **overrides: Any) -> dict[str, Any]:
+    resp = await client.post(
+        f"/api/v1/growth/prospects/{prospect_id}/drafts", json=_draft_payload(**overrides)
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+async def _walk(client: AsyncClient, draft_id: str, *statuses: str) -> dict[str, Any]:
+    """Walk a draft through a sequence of transitions, asserting each is legal."""
+    body: dict[str, Any] = {}
+    for status in statuses:
+        resp = await client.post(
+            f"/api/v1/growth/drafts/{draft_id}/status", json={"status": status}
+        )
+        assert resp.status_code == 200, f"{status}: {resp.text}"
+        body = resp.json()
+        assert body["status"] == status
+    return body
+
+
+# ---------------------------------------------------------------------------
+# Create — three channels on one prospect, defaults, validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_one_prospect_fully_drafted_across_three_channels(w1_client):
+    """The G-3 acceptance slice: a qualified prospect carries an email, a
+    linkedin, and a whatsapp draft, all born in ``status=draft``."""
+    prospect = await _create_prospect(w1_client)
+    email = await _create_draft(w1_client, prospect["id"])
+    linkedin = await _create_draft(
+        w1_client,
+        prospect["id"],
+        channel="linkedin",
+        subject=None,
+        body="Loved the smile-gallery on your site — building tools for clinics like yours.",
+    )
+    whatsapp = await _create_draft(
+        w1_client,
+        prospect["id"],
+        channel="whatsapp",
+        subject=None,
+        body="Hi Sam! Following up on your reply — happy to walk you through the demo.",
+        variant="follow_up",
+    )
+
+    assert email["channel"] == "email"
+    assert email["subject"] is not None
+    assert linkedin["channel"] == "linkedin"
+    assert linkedin["subject"] is None
+    assert whatsapp["channel"] == "whatsapp"
+    assert whatsapp["variant"] == "follow_up"
+    for draft in (email, linkedin, whatsapp):
+        assert draft["status"] == "draft"
+        assert draft["workspace_id"] == "w1"
+        assert draft["prospect_id"] == prospect["id"]
+        assert draft["id"]
+        assert draft["created_at"]
+
+    listed = await w1_client.get("/api/v1/growth/drafts", params={"prospect_id": prospect["id"]})
+    assert listed.status_code == 200
+    assert {d["channel"] for d in listed.json()} == {"email", "linkedin", "whatsapp"}
+
+
+@pytest.mark.asyncio
+async def test_draft_defaults(w1_client):
+    prospect = await _create_prospect(w1_client)
+    draft = await _create_draft(w1_client, prospect["id"])
+    assert draft["variant"] == "first_touch"
+    assert draft["status"] == "draft"
+    assert draft["demo_url"] is None
+
+
+@pytest.mark.asyncio
+async def test_first_draft_flips_prospect_status_to_drafted(w1_client):
+    """A ``new`` prospect flips to ``drafted`` on its first draft; the same
+    holds for ``qualified``."""
+    for domain, patch in (("alpha.io", None), ("beta.io", {"status": "qualified"})):
+        prospect = await _create_prospect(w1_client, domain=domain, company=domain)
+        if patch:
+            resp = await w1_client.patch(f"/api/v1/growth/prospects/{prospect['id']}", json=patch)
+            assert resp.status_code == 200
+        await _create_draft(w1_client, prospect["id"])
+        fetched = (await w1_client.get(f"/api/v1/growth/prospects/{prospect['id']}")).json()
+        assert fetched["status"] == "drafted", domain
+
+
+@pytest.mark.asyncio
+async def test_draft_never_regresses_a_later_prospect_status(w1_client):
+    """A prospect already past ``drafted`` (e.g. ``replied``) keeps its
+    status when another draft (a follow_up) is added."""
+    prospect = await _create_prospect(w1_client)
+    resp = await w1_client.patch(
+        f"/api/v1/growth/prospects/{prospect['id']}", json={"status": "replied"}
+    )
+    assert resp.status_code == 200
+    await _create_draft(w1_client, prospect["id"], variant="follow_up")
+    fetched = (await w1_client.get(f"/api/v1/growth/prospects/{prospect['id']}")).json()
+    assert fetched["status"] == "replied"
+
+
+@pytest.mark.asyncio
+async def test_create_draft_rejects_blank_body(w1_client):
+    prospect = await _create_prospect(w1_client)
+    resp = await w1_client.post(
+        f"/api/v1/growth/prospects/{prospect['id']}/drafts",
+        json=_draft_payload(body="   "),
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("channel", ["linkedin", "whatsapp"])
+async def test_subject_is_email_only(w1_client, channel):
+    prospect = await _create_prospect(w1_client)
+    resp = await w1_client.post(
+        f"/api/v1/growth/prospects/{prospect['id']}/drafts",
+        json=_draft_payload(channel=channel, subject="Should not be here"),
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_create_draft_rejects_unknown_channel(w1_client):
+    prospect = await _create_prospect(w1_client)
+    resp = await w1_client.post(
+        f"/api/v1/growth/prospects/{prospect['id']}/drafts",
+        json=_draft_payload(channel="carrier_pigeon", subject=None),
+    )
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle — legal chain green, illegal moves 422
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_legal_chain_walks_green(w1_client):
+    """draft→proposed→approved→sent→replied, every hop a 200."""
+    prospect = await _create_prospect(w1_client)
+    draft = await _create_draft(w1_client, prospect["id"])
+    final = await _walk(w1_client, draft["id"], "proposed", "approved", "sent", "replied")
+    assert final["status"] == "replied"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("start", ["draft", "proposed", "approved", "sent"])
+async def test_any_nonterminal_can_be_rejected(w1_client, start):
+    prospect = await _create_prospect(w1_client)
+    draft = await _create_draft(w1_client, prospect["id"])
+    chain = {
+        "draft": (),
+        "proposed": ("proposed",),
+        "approved": ("proposed", "approved"),
+        "sent": ("proposed", "approved", "sent"),
+    }[start]
+    if chain:
+        await _walk(w1_client, draft["id"], *chain)
+    final = await _walk(w1_client, draft["id"], "rejected")
+    assert final["status"] == "rejected"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("chain", "attempt"),
+    [
+        # Skipping ahead.
+        ((), "approved"),
+        ((), "sent"),
+        ((), "replied"),
+        (("proposed",), "sent"),
+        # Going backwards.
+        (("proposed",), "draft"),
+        (("proposed", "approved"), "proposed"),
+        (("proposed", "approved", "sent"), "approved"),
+        # Self-transition.
+        ((), "draft"),
+        # Terminal states are terminal.
+        (("proposed", "approved", "sent", "replied"), "rejected"),
+        (("proposed", "approved", "sent", "replied"), "draft"),
+        (("proposed", "approved", "sent", "replied"), "sent"),
+        (("rejected",), "proposed"),
+        (("rejected",), "rejected"),
+    ],
+)
+async def test_illegal_transition_is_422(w1_client, chain, attempt):
+    """Any move outside the machine — skips, reversals, self-loops, exits from
+    a terminal state — is a 422 ``draft.illegal_transition`` and does not
+    mutate the draft."""
+    prospect = await _create_prospect(w1_client)
+    draft = await _create_draft(w1_client, prospect["id"])
+    if chain:
+        await _walk(w1_client, draft["id"], *chain)
+    before = chain[-1] if chain else "draft"
+
+    resp = await w1_client.post(
+        f"/api/v1/growth/drafts/{draft['id']}/status", json={"status": attempt}
+    )
+    assert resp.status_code == 422, resp.text
+    assert resp.json()["error"]["code"] == "draft.illegal_transition"
+
+    listed = (
+        await w1_client.get("/api/v1/growth/drafts", params={"prospect_id": prospect["id"]})
+    ).json()
+    assert listed[0]["status"] == before
+
+
+@pytest.mark.asyncio
+async def test_transition_rejects_unknown_status_name(w1_client):
+    prospect = await _create_prospect(w1_client)
+    draft = await _create_draft(w1_client, prospect["id"])
+    resp = await w1_client.post(
+        f"/api/v1/growth/drafts/{draft['id']}/status", json={"status": "shipped"}
+    )
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# List filters
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_drafts_filters_by_channel_and_status(w1_client):
+    p1 = await _create_prospect(w1_client, domain="alpha.io", company="Alpha")
+    p2 = await _create_prospect(w1_client, domain="beta.io", company="Beta")
+    email = await _create_draft(w1_client, p1["id"])
+    await _create_draft(w1_client, p1["id"], channel="linkedin", subject=None, body="Connect note")
+    await _create_draft(w1_client, p2["id"], channel="linkedin", subject=None, body="Other note")
+    await _walk(w1_client, email["id"], "proposed")
+
+    resp = await w1_client.get("/api/v1/growth/drafts")
+    assert len(resp.json()) == 3
+
+    resp = await w1_client.get("/api/v1/growth/drafts", params={"channel": "linkedin"})
+    assert {d["prospect_id"] for d in resp.json()} == {p1["id"], p2["id"]}
+
+    resp = await w1_client.get("/api/v1/growth/drafts", params={"status": "proposed"})
+    assert [d["id"] for d in resp.json()] == [email["id"]]
+
+    resp = await w1_client.get(
+        "/api/v1/growth/drafts", params={"prospect_id": p1["id"], "channel": "linkedin"}
+    )
+    assert len(resp.json()) == 1
+
+    resp = await w1_client.get("/api/v1/growth/drafts", params={"channel": "fax"})
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Tenancy — foreign prospects 404 on create, drafts never leak
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_draft_on_foreign_workspace_prospect_is_404(w1_client, w2_client):
+    """w2 cannot attach a draft to w1's prospect — identical 404, existence
+    never leaks, and nothing is written."""
+    prospect = await _create_prospect(w1_client)
+    resp = await w2_client.post(
+        f"/api/v1/growth/prospects/{prospect['id']}/drafts", json=_draft_payload()
+    )
+    assert resp.status_code == 404
+    assert resp.json()["error"]["code"] == "prospect.not_found"
+    assert (await w1_client.get("/api/v1/growth/drafts")).json() == []
+    assert (await w2_client.get("/api/v1/growth/drafts")).json() == []
+
+
+@pytest.mark.asyncio
+async def test_drafts_are_tenant_scoped(w1_client, w2_client):
+    """w1's drafts never appear in w2's list, and w2 cannot read or move
+    w1's draft by id."""
+    prospect = await _create_prospect(w1_client)
+    draft = await _create_draft(w1_client, prospect["id"])
+
+    assert (await w2_client.get("/api/v1/growth/drafts")).json() == []
+
+    resp = await w2_client.post(
+        f"/api/v1/growth/drafts/{draft['id']}/status", json={"status": "proposed"}
+    )
+    assert resp.status_code == 404
+    assert resp.json()["error"]["code"] == "draft.not_found"
+
+    # The cross-tenant attempt must not have moved the draft.
+    listed = (await w1_client.get("/api/v1/growth/drafts")).json()
+    assert listed[0]["status"] == "draft"


### PR DESCRIPTION
Third slice, stacked on #1799.

Drafts are the unit the send gate (next slice) will propose and dispatch: per-channel outreach copy attached to a prospect, with a status machine enforced in the service — draft→proposed→approved→sent→replied, any non-terminal→rejected, everything else 422s with `draft.illegal_transition` and mutates nothing. Transition is deliberately dumb (no side effects); the Instinct wiring lands in the next slice on top of it.

Creating a first draft flips the prospect to `drafted` (never regressing later statuses). Subject is email-only, bodies must be non-blank — both at the DTO boundary. Ships the growth-draft crew skill (qualify → tier → per-channel copy via copywriting/humanizer) in the workspace repo, and the api-reference Drafts section.

## Verification
`pytest tests/cloud/growth/` → 51 passed (22 new: 3-channel drafting, legal chain, 13 parametrized illegal transitions, tenancy 404s, status flip + no-regress). Both import-linter configs green (Draft doc added to the Growth write-isolation contract). Route-table smoke confirms existing URLs unchanged after the router-prefix widening.