### PR TITLE
growth: LinkedIn manual send queue

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -82,6 +82,12 @@ GET /growth/drafts with prospect|channel|status filters, POST
 draft→proposed→approved→sent, sent→replied, non-terminal→rejected; illegal
 moves 422 draft.illegal_transition.
 
+Updated: 2026-07-27 (feat/growth-g8) — added the Growth — LinkedIn Queue
+section: GET /growth/linkedin/queue (proposed/approved linkedin drafts joined
+with prospect context, ?format=md for a paste-ready markdown export) and
+POST /growth/linkedin/{draft_id}/mark-sent (record a manual send via the G-3
+machine). Deliberately manual — no LinkedIn API.
+
 Updated: 2026-07-11 (feat/real-pipeline-s1) — documented the Fabric — Transform
 Mappings section: GET/POST/DELETE /fabric/ingest/mappings (author the
 workspace's source→Fabric mappings, now with a "connector" source_kind that
@@ -1470,3 +1476,47 @@ Move a draft along the lifecycle. Body: `{"status": "proposed"}` (any
 `DraftStatus`). Legal moves per the machine above; anything else is a
 `422 draft.illegal_transition` and the draft is unchanged. Cross-tenant or
 unknown ids: `404 draft.not_found`. Returns the updated envelope.
+
+## Growth — LinkedIn Queue
+
+The manual send surface for LinkedIn outreach (G-8). **Deliberately manual**:
+there is no LinkedIn API integration and no automation — the captain
+copy-pastes each note by hand (account-ban avoidance is the feature). Same
+gates as the rest of `/growth` — license + `request_context`, every read
+workspace-scoped.
+
+### `GET /api/v1/growth/linkedin/queue`
+
+The workspace's linkedin-channel drafts in `proposed` / `approved`, newest
+first, each joined with its prospect's targeting context. Query:
+`limit` (default 100, max 500) and `format` (`json` default, `md`).
+
+JSON items:
+
+```json
+{
+  "draft": { "id": "…", "body": "…", "variant": "first_touch", "status": "approved", "…": "…" },
+  "prospect_name": "Sam Founder",
+  "prospect_company": "Acme Dental",
+  "linkedin_url": "https://linkedin.com/in/sam-founder",
+  "research_brief": "Books via a contact form; no online scheduling.",
+  "tier": "a"
+}
+```
+
+`?format=md` returns `text/markdown` instead — a paste-ready export, one
+section per prospect (no tables, no HTML): name + company heading, the
+profile URL as a link, tier + the brief's first line, the connect note
+(`first_touch` body, with a char count against LinkedIn's 300-char connect
+limit), the after-accept message (`follow_up` body, when queued), and each
+draft's id for the mark-sent call.
+
+### `POST /api/v1/growth/linkedin/{draft_id}/mark-sent`
+
+Record that a queued LinkedIn draft was manually sent. The draft must be
+linkedin-channel (`422 draft.wrong_channel` otherwise) and `approved` — the
+move rides the G-3 machine, so anything but approved→sent is a
+`422 draft.illegal_transition`. Cross-tenant or unknown ids:
+`404 draft.not_found`. Returns the updated draft envelope (`status: "sent"`);
+the draft leaves the queue and continues the normal lifecycle
+(sent→replied / rejected).

--- a/ee/pocketpaw_ee/cloud/growth/dto.py
+++ b/ee/pocketpaw_ee/cloud/growth/dto.py
@@ -15,6 +15,10 @@
 # is email-only, enforced here at the boundary; body non-empty),
 # TransitionDraftRequest (the target status; legality is the SERVICE's job —
 # the DTO only checks it's a known status), DraftResponse.
+# Updated 2026-07-27 (feat/growth-g8): LinkedInQueueItemResponse — one row of
+# the manual LinkedIn send queue: the draft envelope joined with the prospect
+# context the captain needs to send by hand (name, company, profile URL,
+# research brief, tier). Response-only; the queue has no request DTO.
 
 from __future__ import annotations
 
@@ -184,6 +188,22 @@ class DraftResponse(BaseModel):
     updated_at: str | None
 
 
+class LinkedInQueueItemResponse(BaseModel):
+    """One row of the manual LinkedIn send queue.
+
+    The draft envelope plus the prospect context needed to send it by hand —
+    the queue exists so the captain can copy-paste; there is no LinkedIn API
+    integration by design (account-ban avoidance).
+    """
+
+    draft: DraftResponse
+    prospect_name: str
+    prospect_company: str
+    linkedin_url: str | None
+    research_brief: str
+    tier: str
+
+
 __all__ = [
     "BulkIngestRequest",
     "BulkIngestResponse",
@@ -191,6 +211,7 @@ __all__ = [
     "CreateDraftRequest",
     "CreateProspectRequest",
     "DraftResponse",
+    "LinkedInQueueItemResponse",
     "ProspectResponse",
     "TransitionDraftRequest",
     "UpdateProspectRequest",

--- a/ee/pocketpaw_ee/cloud/growth/router.py
+++ b/ee/pocketpaw_ee/cloud/growth/router.py
@@ -16,10 +16,18 @@
 # (illegal moves 422 ``draft.illegal_transition``). Router prefix widened from
 # ``/growth/prospects`` to ``/growth`` (routes now carry ``/prospects``
 # themselves) so drafts mount beside prospects — final URLs unchanged.
+# Updated 2026-07-27 (feat/growth-g8): LinkedIn manual queue — GET
+# /linkedin/queue (proposed/approved linkedin drafts joined with prospect
+# context; ``?format=md`` returns a paste-ready text/markdown export) and
+# POST /linkedin/{draft_id}/mark-sent (records a manual send via the G-3
+# transition machine). Deliberately manual — no LinkedIn API.
 
 from __future__ import annotations
 
+from typing import Literal
+
 from fastapi import APIRouter, Depends, Query
+from fastapi.responses import PlainTextResponse, Response
 
 from pocketpaw_ee.cloud._core.context import RequestContext, request_context
 from pocketpaw_ee.cloud.growth import service as growth_service
@@ -36,6 +44,7 @@ from pocketpaw_ee.cloud.growth.dto import (
     CreateDraftRequest,
     CreateProspectRequest,
     DraftResponse,
+    LinkedInQueueItemResponse,
     ProspectResponse,
     TransitionDraftRequest,
     UpdateProspectRequest,
@@ -134,3 +143,37 @@ async def transition_draft(
     sent→replied, any non-terminal→rejected. Anything else is a 422
     ``draft.illegal_transition``."""
     return await growth_service.transition(ctx, draft_id, body)
+
+
+# ---------------------------------------------------------------------------
+# LinkedIn manual queue (G-8)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/linkedin/queue", response_model=None)
+async def linkedin_queue(
+    format: Literal["json", "md"] = Query(default="json"),
+    limit: int = Query(default=100, ge=1, le=500),
+    ctx: RequestContext = Depends(request_context),
+) -> list[LinkedInQueueItemResponse] | Response:
+    """The manual send queue: the workspace's linkedin drafts in
+    proposed/approved, newest first, joined with prospect context.
+    ``?format=md`` returns a paste-ready ``text/markdown`` export instead —
+    one section per prospect with the connect note and after-accept message.
+    Manual send is the feature: there is no LinkedIn API integration."""
+    if format == "md":
+        markdown = await growth_service.linkedin_queue_markdown(ctx, limit=limit)
+        return PlainTextResponse(markdown, media_type="text/markdown; charset=utf-8")
+    return await growth_service.linkedin_queue(ctx, limit=limit)
+
+
+@router.post("/linkedin/{draft_id}/mark-sent", response_model=DraftResponse)
+async def mark_linkedin_sent(
+    draft_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> DraftResponse:
+    """Record a manual LinkedIn send. The draft must be linkedin-channel
+    (422 ``draft.wrong_channel``) and ``approved`` — the move rides the G-3
+    machine, so anything but approved→sent is a 422
+    ``draft.illegal_transition``."""
+    return await growth_service.mark_linkedin_sent(ctx, draft_id)

--- a/ee/pocketpaw_ee/cloud/growth/service.py
+++ b/ee/pocketpaw_ee/cloud/growth/service.py
@@ -17,6 +17,14 @@
 # ``transition`` — a dumb enforcer of ``DRAFT_TRANSITIONS`` (illegal moves →
 # 422 ``draft.illegal_transition``), no side effects; G-4 wires proposals on
 # top. This module also owns the Draft doc writes (same "Growth" contract).
+# Updated 2026-07-27 (feat/growth-g8): LinkedIn manual queue —
+# ``linkedin_queue`` (proposed/approved linkedin drafts joined with their
+# prospect via two queries, newest first), ``linkedin_queue_markdown``
+# (copy-paste export grouped per prospect: connect note + after-accept
+# message), and ``mark_linkedin_sent`` (channel guard + the EXISTING
+# ``transition`` function, so approved→sent stays the only legal move and
+# proposed→sent 422s as ``draft.illegal_transition``). Deliberately manual —
+# no LinkedIn API, no automation (account-ban avoidance is the feature).
 
 from __future__ import annotations
 
@@ -37,6 +45,7 @@ from pocketpaw_ee.cloud.growth.dto import (
     CreateDraftRequest,
     CreateProspectRequest,
     DraftResponse,
+    LinkedInQueueItemResponse,
     ProspectResponse,
     TransitionDraftRequest,
     UpdateProspectRequest,
@@ -419,13 +428,152 @@ async def transition(
     return _draft_to_response(_draft_to_domain(doc))
 
 
+# ---------------------------------------------------------------------------
+# LinkedIn manual queue (G-8)
+# ---------------------------------------------------------------------------
+
+
+async def linkedin_queue(
+    ctx: RequestContext, *, limit: int = 100
+) -> list[LinkedInQueueItemResponse]:
+    """The manual LinkedIn send queue: the workspace's linkedin-channel drafts
+    in ``proposed`` / ``approved``, newest first, each joined with its
+    prospect's targeting context (name, company, profile URL, brief, tier).
+
+    The join is two queries (drafts, then their prospects by id), not an
+    aggregation — the queue is small (manual sending is the bottleneck by
+    design). A draft whose prospect vanished is skipped rather than crashing
+    the queue.
+    """
+    workspace_id = _require_workspace(ctx)
+    cursor = (
+        _DraftDoc.find(
+            {
+                "workspace": workspace_id,
+                "channel": "linkedin",
+                "status": {"$in": ["proposed", "approved"]},
+            }
+        )
+        .sort(-_DraftDoc.createdAt)  # type: ignore[operator]
+        .limit(limit)
+    )
+    drafts = [_draft_to_domain(doc) async for doc in cursor]
+
+    prospect_oids = []
+    for draft in drafts:
+        try:
+            prospect_oids.append(PydanticObjectId(draft.prospect_id))
+        except Exception:  # noqa: BLE001 — malformed ref == orphan, skipped below
+            continue
+    prospects: dict[str, Prospect] = {}
+    if prospect_oids:
+        async for pdoc in _ProspectDoc.find(
+            {"workspace": workspace_id, "_id": {"$in": prospect_oids}}
+        ):
+            prospects[str(pdoc.id)] = _to_domain(pdoc)
+
+    items: list[LinkedInQueueItemResponse] = []
+    for draft in drafts:
+        prospect = prospects.get(draft.prospect_id)
+        if prospect is None:
+            continue
+        items.append(
+            LinkedInQueueItemResponse(
+                draft=_draft_to_response(draft),
+                prospect_name=prospect.name,
+                prospect_company=prospect.company,
+                linkedin_url=prospect.linkedin_url,
+                research_brief=prospect.research_brief,
+                tier=prospect.tier,
+            )
+        )
+    return items
+
+
+def _one_line(text: str, max_len: int = 160) -> str:
+    """First non-empty line of a blob, hard-capped for the one-line brief."""
+    stripped = text.strip()
+    line = stripped.splitlines()[0].strip() if stripped else ""
+    return line if len(line) <= max_len else line[: max_len - 1] + "…"
+
+
+def _render_queue_markdown(items: list[LinkedInQueueItemResponse]) -> str:
+    """Render the queue as paste-ready markdown — one section per prospect.
+
+    No tables, no HTML: heading = name + company, profile URL as a link, tier
+    + one-line brief, then the connect note (first_touch body, with a char
+    count against LinkedIn's 300-char connect limit) and the after-accept
+    message (follow_up body, when one is queued), each with its draft id so
+    mark-sent can be called after the manual send.
+    """
+    lines = ["# LinkedIn outreach queue", ""]
+    if not items:
+        lines.append("_Queue is empty — no proposed or approved LinkedIn drafts._")
+        return "\n".join(lines) + "\n"
+
+    grouped: dict[str, list[LinkedInQueueItemResponse]] = {}
+    for item in items:  # preserves newest-first order of first appearance
+        grouped.setdefault(item.draft.prospect_id, []).append(item)
+
+    for group in grouped.values():
+        head = group[0]
+        lines.append(f"## {head.prospect_name} — {head.prospect_company}")
+        lines.append("")
+        if head.linkedin_url:
+            lines.append(f"[LinkedIn profile]({head.linkedin_url})")
+            lines.append("")
+        brief = _one_line(head.research_brief)
+        lines.append(f"Tier {head.tier.upper()}" + (f" — {brief}" if brief else ""))
+        lines.append("")
+        first = next((i for i in group if i.draft.variant == "first_touch"), None)
+        follow = next((i for i in group if i.draft.variant == "follow_up"), None)
+        for label, entry in (("Connect note", first), ("After accept", follow)):
+            if entry is None:
+                continue
+            counter = f"{len(entry.draft.body)}/300 chars, " if label == "Connect note" else ""
+            lines.append(f"{label} ({counter}{entry.draft.status}):")
+            lines.append("")
+            lines.append(entry.draft.body)
+            lines.append("")
+            lines.append(f"Draft id: `{entry.draft.id}`")
+            lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+async def linkedin_queue_markdown(ctx: RequestContext, *, limit: int = 100) -> str:
+    """The queue as copy-paste markdown (``?format=md`` on the queue route)."""
+    return _render_queue_markdown(await linkedin_queue(ctx, limit=limit))
+
+
+async def mark_linkedin_sent(ctx: RequestContext, draft_id: str) -> DraftResponse:
+    """Record that the captain manually sent a queued LinkedIn draft.
+
+    Guard: the draft must be linkedin-channel (422 ``draft.wrong_channel``
+    otherwise). The status move itself is delegated to the EXISTING
+    ``transition`` function, so approved→sent remains the only legal path and
+    anything else (e.g. proposed→sent) 422s as ``draft.illegal_transition`` —
+    no second lifecycle enforcer.
+    """
+    workspace_id = _require_workspace(ctx)
+    doc = await _fetch_draft_in_workspace(workspace_id, draft_id)
+    if doc.channel != "linkedin":
+        raise ValidationError(
+            "draft.wrong_channel",
+            f"mark-sent is for linkedin drafts; this draft targets '{doc.channel}'",
+        )
+    return await transition(ctx, draft_id, TransitionDraftRequest(status="sent"))
+
+
 __all__ = [
     "bulk_ingest",
     "create",
     "create_draft",
     "get",
+    "linkedin_queue",
+    "linkedin_queue_markdown",
     "list_drafts",
     "list_prospects",
+    "mark_linkedin_sent",
     "transition",
     "update",
     "upsert_by_domain",

--- a/tests/cloud/growth/test_linkedin_queue.py
+++ b/tests/cloud/growth/test_linkedin_queue.py
@@ -1,0 +1,304 @@
+# tests/cloud/growth/test_linkedin_queue.py — HTTP-layer tests for the G-8
+# LinkedIn manual-queue slice (``ee/cloud/growth/{router,service}.py``). Same
+# harness as test_drafts.py: FastAPI app + fixed RequestContext override per
+# workspace (w1/w2 clients), mongomock-backed Beanie via the shared
+# ``mongo_db`` fixture. Covers: queue membership (linkedin-only,
+# proposed/approved-only, newest first, prospect join fields), tenancy (w2's
+# queue never sees w1's drafts), mark-sent (approved→sent green;
+# proposed→sent 422 ``draft.illegal_transition``; email-channel 422
+# ``draft.wrong_channel``; cross-tenant 404; sent drafts leave the queue and
+# stay on the normal lifecycle — sent→replied still legal), and the
+# ``?format=md`` export (heading, profile link, tier + brief, connect note,
+# after-accept message, draft ids, empty-queue shape).
+#
+# Created 2026-07-27 (feat/growth-g8): LinkedIn manual queue + md export.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind, request_context
+from pocketpaw_ee.cloud._core.http import add_error_handler
+from pocketpaw_ee.cloud.growth.router import router as growth_router
+from pocketpaw_ee.cloud.license import require_license
+
+
+def _make_ctx(workspace_id: str | None, user_id: str = "u1") -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="test",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+def _build_app(workspace_id: str | None = "w1", user_id: str = "u1") -> FastAPI:
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(growth_router, prefix="/api/v1")
+
+    async def _ctx() -> RequestContext:
+        return _make_ctx(workspace_id, user_id)
+
+    app.dependency_overrides[request_context] = _ctx
+    app.dependency_overrides[require_license] = lambda: None
+    return app
+
+
+@pytest_asyncio.fixture
+async def w1_client(mongo_db: Any) -> AsyncClient:
+    app = _build_app(workspace_id="w1")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+@pytest_asyncio.fixture
+async def w2_client(mongo_db: Any) -> AsyncClient:
+    app = _build_app(workspace_id="w2")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+def _prospect_payload(**overrides: Any) -> dict[str, Any]:
+    base = {
+        "name": "Sam Founder",
+        "company": "Acme Dental",
+        "domain": "acme-dental.com",
+        "source": "manual",
+        "tier": "a",
+        "research_brief": "Books via a contact form; no online scheduling.\nSecond line.",
+        "linkedin_url": "https://linkedin.com/in/sam-founder",
+    }
+    base.update(overrides)
+    return base
+
+
+async def _create_prospect(client: AsyncClient, **overrides: Any) -> dict[str, Any]:
+    resp = await client.post("/api/v1/growth/prospects", json=_prospect_payload(**overrides))
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+async def _create_draft(client: AsyncClient, prospect_id: str, **overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "channel": "linkedin",
+        "body": "Loved the smile-gallery on your site — building tools for clinics like yours.",
+    }
+    base.update(overrides)
+    resp = await client.post(f"/api/v1/growth/prospects/{prospect_id}/drafts", json=base)
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+async def _walk(client: AsyncClient, draft_id: str, *statuses: str) -> dict[str, Any]:
+    body: dict[str, Any] = {}
+    for status in statuses:
+        resp = await client.post(
+            f"/api/v1/growth/drafts/{draft_id}/status", json={"status": status}
+        )
+        assert resp.status_code == 200, f"{status}: {resp.text}"
+        body = resp.json()
+    return body
+
+
+async def _queued_ids(client: AsyncClient) -> list[str]:
+    resp = await client.get("/api/v1/growth/linkedin/queue")
+    assert resp.status_code == 200, resp.text
+    return [item["draft"]["id"] for item in resp.json()]
+
+
+# ---------------------------------------------------------------------------
+# Queue membership + join
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_queue_only_linkedin_proposed_or_approved(w1_client, w2_client):
+    """The queue holds ONLY the workspace's linkedin drafts in proposed or
+    approved — an email draft (even approved), a still-in-``draft`` linkedin
+    draft, and another tenant's proposed linkedin draft all stay out."""
+    prospect = await _create_prospect(w1_client)
+    proposed = await _create_draft(w1_client, prospect["id"])
+    await _walk(w1_client, proposed["id"], "proposed")
+    approved = await _create_draft(w1_client, prospect["id"], variant="follow_up")
+    await _walk(w1_client, approved["id"], "proposed", "approved")
+
+    # Excluded: linkedin still in `draft`.
+    await _create_draft(w1_client, prospect["id"])
+    # Excluded: email channel, even when approved.
+    email = await _create_draft(
+        w1_client, prospect["id"], channel="email", subject="Hi", body="Email body"
+    )
+    await _walk(w1_client, email["id"], "proposed", "approved")
+    # Excluded: another tenant's proposed linkedin draft.
+    foreign_prospect = await _create_prospect(w2_client, domain="other.io", company="Other")
+    foreign = await _create_draft(w2_client, foreign_prospect["id"])
+    await _walk(w2_client, foreign["id"], "proposed")
+
+    assert set(await _queued_ids(w1_client)) == {proposed["id"], approved["id"]}
+    assert await _queued_ids(w2_client) == [foreign["id"]]
+
+
+@pytest.mark.asyncio
+async def test_queue_joins_prospect_context_and_orders_newest_first(w1_client):
+    p1 = await _create_prospect(w1_client)
+    p2 = await _create_prospect(
+        w1_client,
+        name="Ada Ops",
+        company="Beta Clinic",
+        domain="beta-clinic.io",
+        tier="b",
+        linkedin_url=None,
+    )
+    d1 = await _create_draft(w1_client, p1["id"])
+    await _walk(w1_client, d1["id"], "proposed")
+    d2 = await _create_draft(w1_client, p2["id"], body="Second note")
+    await _walk(w1_client, d2["id"], "proposed", "approved")
+
+    resp = await w1_client.get("/api/v1/growth/linkedin/queue")
+    items = resp.json()
+    # Newest first: d2 was created after d1.
+    assert [i["draft"]["id"] for i in items] == [d2["id"], d1["id"]]
+
+    by_id = {i["draft"]["id"]: i for i in items}
+    first = by_id[d1["id"]]
+    assert first["prospect_name"] == "Sam Founder"
+    assert first["prospect_company"] == "Acme Dental"
+    assert first["linkedin_url"] == "https://linkedin.com/in/sam-founder"
+    assert first["tier"] == "a"
+    assert first["research_brief"].startswith("Books via a contact form")
+    assert first["draft"]["status"] == "proposed"
+    second = by_id[d2["id"]]
+    assert second["linkedin_url"] is None
+    assert second["draft"]["status"] == "approved"
+
+
+# ---------------------------------------------------------------------------
+# mark-sent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mark_sent_approved_goes_sent_and_leaves_queue(w1_client):
+    """approved→sent via mark-sent, and the sent draft (a) drops off the
+    queue and (b) stays on the normal lifecycle — sent→replied is legal."""
+    prospect = await _create_prospect(w1_client)
+    draft = await _create_draft(w1_client, prospect["id"])
+    await _walk(w1_client, draft["id"], "proposed", "approved")
+
+    resp = await w1_client.post(f"/api/v1/growth/linkedin/{draft['id']}/mark-sent")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "sent"
+    assert await _queued_ids(w1_client) == []
+
+    # Feeds the normal draft lifecycle: sent→replied still works.
+    final = await _walk(w1_client, draft["id"], "replied")
+    assert final["status"] == "replied"
+
+
+@pytest.mark.asyncio
+async def test_mark_sent_on_proposed_is_422_illegal_transition(w1_client):
+    prospect = await _create_prospect(w1_client)
+    draft = await _create_draft(w1_client, prospect["id"])
+    await _walk(w1_client, draft["id"], "proposed")
+
+    resp = await w1_client.post(f"/api/v1/growth/linkedin/{draft['id']}/mark-sent")
+    assert resp.status_code == 422, resp.text
+    assert resp.json()["error"]["code"] == "draft.illegal_transition"
+    # Unchanged — still queued as proposed.
+    assert await _queued_ids(w1_client) == [draft["id"]]
+
+
+@pytest.mark.asyncio
+async def test_mark_sent_on_email_draft_is_422_wrong_channel(w1_client):
+    """A non-linkedin draft is rejected on channel BEFORE any status move —
+    even an approved email draft cannot ride the linkedin mark-sent route."""
+    prospect = await _create_prospect(w1_client)
+    draft = await _create_draft(
+        w1_client, prospect["id"], channel="email", subject="Hi", body="Email body"
+    )
+    await _walk(w1_client, draft["id"], "proposed", "approved")
+
+    resp = await w1_client.post(f"/api/v1/growth/linkedin/{draft['id']}/mark-sent")
+    assert resp.status_code == 422, resp.text
+    assert resp.json()["error"]["code"] == "draft.wrong_channel"
+    listed = (await w1_client.get("/api/v1/growth/drafts", params={"channel": "email"})).json()
+    assert listed[0]["status"] == "approved"
+
+
+@pytest.mark.asyncio
+async def test_mark_sent_cross_tenant_is_404(w1_client, w2_client):
+    prospect = await _create_prospect(w1_client)
+    draft = await _create_draft(w1_client, prospect["id"])
+    await _walk(w1_client, draft["id"], "proposed", "approved")
+
+    resp = await w2_client.post(f"/api/v1/growth/linkedin/{draft['id']}/mark-sent")
+    assert resp.status_code == 404
+    assert resp.json()["error"]["code"] == "draft.not_found"
+    # Untouched for w1.
+    assert await _queued_ids(w1_client) == [draft["id"]]
+
+
+# ---------------------------------------------------------------------------
+# Markdown export
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_md_export_renders_paste_ready_sections(w1_client):
+    """?format=md renders one section per prospect: name+company heading,
+    profile link, tier + one-line brief, connect note (first_touch) and
+    after-accept message (follow_up), each with its draft id."""
+    prospect = await _create_prospect(w1_client)
+    connect = await _create_draft(w1_client, prospect["id"])
+    await _walk(w1_client, connect["id"], "proposed", "approved")
+    follow = await _create_draft(
+        w1_client,
+        prospect["id"],
+        variant="follow_up",
+        body="Thanks for connecting, Sam! Here's the 2-min demo I mentioned.",
+    )
+    await _walk(w1_client, follow["id"], "proposed")
+
+    resp = await w1_client.get("/api/v1/growth/linkedin/queue", params={"format": "md"})
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/markdown")
+    md = resp.text
+
+    assert "## Sam Founder — Acme Dental" in md
+    assert "[LinkedIn profile](https://linkedin.com/in/sam-founder)" in md
+    # Tier + one-line brief (first line only — the second line stays out).
+    assert "Tier A — Books via a contact form; no online scheduling." in md
+    assert "Second line." not in md
+    assert "Connect note (" in md
+    assert "Loved the smile-gallery on your site" in md
+    assert "After accept (" in md
+    assert "Thanks for connecting, Sam!" in md
+    assert f"Draft id: `{connect['id']}`" in md
+    assert f"Draft id: `{follow['id']}`" in md
+    # Paste-ready: no tables, no HTML.
+    assert "|" not in md
+    assert "<" not in md.replace("≤", "")
+
+
+@pytest.mark.asyncio
+async def test_md_export_empty_queue(w1_client):
+    resp = await w1_client.get("/api/v1/growth/linkedin/queue", params={"format": "md"})
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/markdown")
+    assert "# LinkedIn outreach queue" in resp.text
+    assert "Queue is empty" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_queue_rejects_unknown_format(w1_client):
+    resp = await w1_client.get("/api/v1/growth/linkedin/queue", params={"format": "html"})
+    assert resp.status_code == 422


### PR DESCRIPTION
Stacked on #1800. The deliberately-manual slice: LinkedIn sends stay human (automation there gets accounts restricted), so the platform's job is to make the manual part effortless.

- `GET /growth/linkedin/queue` — queued LinkedIn drafts joined with the prospect's profile link, tier, and research brief, newest first
- `?format=md` — paste-ready markdown: one section per prospect with the connect note (with a live character counter against LinkedIn's 300 limit), the after-accept message, and draft ids
- `POST /growth/linkedin/{id}/mark-sent` — channel-guarded (422 `draft.wrong_channel`), then delegates to the existing lifecycle `transition`, so there's exactly one status enforcer and approved→sent stays the only legal path

No LinkedIn API, no new documents — two workspace-scoped queries in the service.

## Verification
`pytest tests/cloud/growth/` → 60 passed (9 new: queue membership incl. cross-tenant both directions, join fields + ordering, mark-sent legal/illegal paths, md export assertions, empty queue, unknown format). Both import-linter configs green. ruff clean.