### PR TITLE
Fix the four pre-existing lint failures blocking dev

### DIFF
--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -6,6 +6,12 @@
 # depends on the OSS core package `pocketpaw`.
 #
 # Changes:
+#   - 2026-07-27 (fix/dev-ci): the "CodeAgent — runtime-agnostic" contract now
+#     sources the codeagent PACKAGE instead of a hand-kept list of its modules.
+#     The list had gone stale twice over — `delegates.py` was never added, and
+#     `transport.py` / `domain.py` were deleted with the turn-agent — and a
+#     contract that names a module which no longer exists fails the whole
+#     `lint-imports` run, not just that contract. See the contract below.
 #   - 2026-07-01 (ee-cython gate): the cython build hook is now GATED OFF by
 #     default (`enable-by-default = false`) so dev / CI / editable installs stay
 #     fast and readable — the ~25-min compile only fires when
@@ -666,13 +672,14 @@ allow_indirect_imports = "true"
 #
 # A human reviewer will not catch that on a diff that otherwise looks like a
 # helpful refactor. The linter will.
-source_modules = [
-    "pocketpaw_ee.cloud.codeagent.router",
-    "pocketpaw_ee.cloud.codeagent.service",
-    "pocketpaw_ee.cloud.codeagent.transport",
-    "pocketpaw_ee.cloud.codeagent.dto",
-    "pocketpaw_ee.cloud.codeagent.domain",
-]
+#
+# Sourced from the PACKAGE, not a file list. The original list named the five
+# modules codeagent had on 2026-07-21; `delegates.py` (added 2026-07-22) never
+# got added to it, and `transport.py` / `domain.py` were deleted 2026-07-23 with
+# the turn-agent, which broke the run outright. `as_packages` defaults to true,
+# so naming the package covers every submodule — including the ones added after
+# this contract was written.
+source_modules = ["pocketpaw_ee.cloud.codeagent"]
 forbidden_modules = [
     "pocketpaw_ee.cloud.daytona",
     "pocketpaw_ee.cloud.websandbox",

--- a/src/pocketpaw/atlas/data/atlas.json
+++ b/src/pocketpaw/atlas/data/atlas.json
@@ -1670,6 +1670,62 @@
     },
     {
       "gist": "",
+      "how": "a user invokes it as /code-next in chat; the agent loads it via the Skill tool (bundled Claude Code plugin). Workspace-installed skills are discovered via the system-prompt skills block, not atlas.",
+      "id": "skill:code-next",
+      "keywords": [
+        "code-next"
+      ],
+      "kind": "skill",
+      "name": "code-next",
+      "narrative": "Next.js 15 App Router projects with TypeScript and Tailwind CSS v4. Invoke when the work is Next: \"add a page\", \"why is this a client component\", \"params is a Promise now\", \"fetch data in a Server Component\", \"write a server action\", \"add an API route\", \"my data is stale\", \"set the page title\", \"protect a route\". Covers the Server/Client Component boundary, async request APIs, the app/ file conventions, route handlers, server actions and revalidation, metadata, next/image and next/font, middleware, and Tailwind v4's CSS-first configuration. This is the Next 15 line specifically — Cache Components, \"use cache\", proxy.ts, updateTag, and Turbopack-by-default are Next 16 and are NOT available. This is not a dashboard, not a pocket, and it produces no ui-spec.",
+      "requires": [],
+      "summary": "Next.js 15 App Router projects with TypeScript and Tailwind CSS v4.",
+      "surface": ""
+    },
+    {
+      "gist": "",
+      "how": "a user invokes it as /code-react in chat; the agent loads it via the Skill tool (bundled Claude Code plugin). Workspace-installed skills are discovered via the system-prompt skills block, not atlas.",
+      "id": "skill:code-react",
+      "keywords": [
+        "code-react"
+      ],
+      "kind": "skill",
+      "name": "code-react",
+      "narrative": "React 19 + Vite + TypeScript projects — the client-rendered SPA scaffold, not Next.js. Invoke when the work is React inside a Vite project: \"build a React component\", \"why is this effect firing twice\", \"add a form\", \"this state isn't updating\", \"share state between components\", \"add a route\", \"typing this prop is fighting me\", \"fetch data on mount\". Covers hooks and when not to reach for them, React 19 client APIs (Actions, useActionState, useOptimistic, use(), ref as a prop, Context as provider), Vite conventions (import.meta.env, assets, aliases), and the strict TypeScript settings this template turns on. There is NO server in this project: no App Router, no Server Components, no \"use server\". Those belong to the Next.js skill. This is not a dashboard, not a pocket, and it produces no ui-spec.",
+      "requires": [],
+      "summary": "React 19 + Vite + TypeScript projects — the client-rendered SPA scaffold, not Next.js.",
+      "surface": ""
+    },
+    {
+      "gist": "",
+      "how": "a user invokes it as /code-svelte in chat; the agent loads it via the Skill tool (bundled Claude Code plugin). Workspace-installed skills are discovered via the system-prompt skills block, not atlas.",
+      "id": "skill:code-svelte",
+      "keywords": [
+        "code-svelte"
+      ],
+      "kind": "skill",
+      "name": "code-svelte",
+      "narrative": "Plain Svelte 5 + Vite + TypeScript projects — components mounted into one page, NOT SvelteKit. Invoke when the work is Svelte: \"build a Svelte component\", \"why isn't my $state updating\", \"$derived vs $effect\", \"pass a snippet to a child\", \"bind a value both ways\", \"share state between components\", \"this prop isn't reactive\", \"add a transition\". Covers runes ($state, $derived, $effect, $props, $bindable), snippets and {@render}, event props, .svelte.ts state modules, context, attachments, and scoped styling. There is NO SvelteKit in this project: no file-based routing, no load functions, no form actions, no +page/+layout files, no adapters, no $app imports, no server rendering. This is not a dashboard, not a pocket, and it produces no ui-spec.",
+      "requires": [],
+      "summary": "Plain Svelte 5 + Vite + TypeScript projects — components mounted into one page, NOT SvelteKit.",
+      "surface": ""
+    },
+    {
+      "gist": "",
+      "how": "a user invokes it as /code-vue in chat; the agent loads it via the Skill tool (bundled Claude Code plugin). Workspace-installed skills are discovered via the system-prompt skills block, not atlas.",
+      "id": "skill:code-vue",
+      "keywords": [
+        "code-vue"
+      ],
+      "kind": "skill",
+      "name": "code-vue",
+      "narrative": "Vue 3 + Vite + TypeScript projects — the flat single-file-component scaffold, with no router and no store bundled. Invoke when the work is Vue: \"build a Vue component\", \"why isn't this ref updating\", \"v-model on a custom component\", \"extract a composable\", \"add a page\", \"props are losing reactivity\", \"watch is firing too often\", \"scoped styles aren't applying\". Covers <script setup>, refs vs reactive, computed and watchers, reactive props destructure, defineModel, useTemplateRef, composables, slots, provide/inject, scoped styling, and the strict TypeScript settings this template turns on. Vue Router and Pinia are NOT installed here; this skill frames them as things to add, not things present. This is not a dashboard, not a pocket, and it produces no ui-spec.",
+      "requires": [],
+      "summary": "Vue 3 + Vite + TypeScript projects — the flat single-file-component scaffold, with no router and no store bundled.",
+      "surface": ""
+    },
+    {
+      "gist": "",
       "how": "a user invokes it as /foresight-create-sim in chat; the agent loads it via the Skill tool (bundled Claude Code plugin). Workspace-installed skills are discovered via the system-prompt skills block, not atlas.",
       "id": "skill:foresight-create-sim",
       "keywords": [

--- a/tests/cloud/agents/test_code_agent_seed.py
+++ b/tests/cloud/agents/test_code_agent_seed.py
@@ -47,9 +47,7 @@ async def test_seed_code_agent_inserts_exclusive_file_tool_agent(recording_bus) 
     assert doc.config.system_prompt == CODE_SYSTEM_PROMPT
     # NO create-pocket / pocket / widget skill — the CODE surface ships none.
     assert doc.config.skill_refs == []
-    assert not any(
-        "pocket" in s.lower() or "widget" in s.lower() for s in doc.config.skill_refs
-    )
+    assert not any("pocket" in s.lower() or "widget" in s.lower() for s in doc.config.skill_refs)
 
     created_events = [e for e in recording_bus.events if isinstance(e, AgentCreated)]
     assert len(created_events) == 1

--- a/tests/ee/agent/test_code_mcp_server.py
+++ b/tests/ee/agent/test_code_mcp_server.py
@@ -193,11 +193,12 @@ async def _build_with(backend, *, allow, exclusive):
 def backend_with_grant_pool(monkeypatch):
     """A backend whose ``_collect_mcp_tool_ids`` yields a deterministic pool:
     the four code file ids + a widget id + an atlas id + a planner grant id."""
+    from pocketpaw_ee.cloud.surface.surface_registry import _CODE_FILE_TOOL_IDS
+
     from pocketpaw.agents.claude_sdk import POCKET_CREATION_GRANT, ClaudeSDKBackend
     from pocketpaw.agents.sdk_mcp_atlas import ATLAS_TOOL_IDS
     from pocketpaw.agents.sdk_mcp_widgets import WIDGET_TOOL_IDS
     from pocketpaw.config import get_settings
-    from pocketpaw_ee.cloud.surface.surface_registry import _CODE_FILE_TOOL_IDS
 
     widget_id = next(iter(WIDGET_TOOL_IDS))
     atlas_id = next(iter(ATLAS_TOOL_IDS))
@@ -322,9 +323,7 @@ async def test_write_file_relays_the_staged_sentence_as_success(in_workspace, mo
             },
         )
 
-    monkeypatch.setattr(
-        "pocketpaw_ee.cloud.codeagent.delegates.delegate_call_to_browser", _staged
-    )
+    monkeypatch.setattr("pocketpaw_ee.cloud.codeagent.delegates.delegate_call_to_browser", _staged)
 
     response = await _write_file_handler({"path": "src/button.tsx", "content": "x"})
     assert not response.get("is_error")
@@ -406,9 +405,7 @@ async def test_a_failed_delegate_relays_the_channels_own_message(in_workspace, m
             message="The browser did not finish the delegated task in 180s.",
         )
 
-    monkeypatch.setattr(
-        "pocketpaw_ee.cloud.codeagent.delegates.delegate_call_to_browser", _timeout
-    )
+    monkeypatch.setattr("pocketpaw_ee.cloud.codeagent.delegates.delegate_call_to_browser", _timeout)
 
     response = await _read_file_handler({"path": "a.ts"})
 
@@ -425,13 +422,9 @@ async def test_a_browser_side_error_result_becomes_an_error_response(in_workspac
     string."""
 
     async def _iserror(workspace_id, tool, tool_input):
-        return DelegateOutcome(
-            ok=True, result={"output": "no such file: a.ts", "isError": True}
-        )
+        return DelegateOutcome(ok=True, result={"output": "no such file: a.ts", "isError": True})
 
-    monkeypatch.setattr(
-        "pocketpaw_ee.cloud.codeagent.delegates.delegate_call_to_browser", _iserror
-    )
+    monkeypatch.setattr("pocketpaw_ee.cloud.codeagent.delegates.delegate_call_to_browser", _iserror)
 
     response = await _read_file_handler({"path": "a.ts"})
     assert response["is_error"] is True
@@ -446,9 +439,7 @@ async def test_an_empty_success_output_is_still_a_success(in_workspace, monkeypa
     async def _empty(workspace_id, tool, tool_input):
         return DelegateOutcome(ok=True, result={"output": "", "isError": False})
 
-    monkeypatch.setattr(
-        "pocketpaw_ee.cloud.codeagent.delegates.delegate_call_to_browser", _empty
-    )
+    monkeypatch.setattr("pocketpaw_ee.cloud.codeagent.delegates.delegate_call_to_browser", _empty)
 
     response = await _read_file_handler({"path": "empty.ts"})
     assert not response.get("is_error")

--- a/tests/ee/test_mcp_claude_sdk.py
+++ b/tests/ee/test_mcp_claude_sdk.py
@@ -1,5 +1,13 @@
 """Tests for MCP + Claude Agent SDK integration — Sprint 17.
 
+Updated: 2026-07-27 (fix/dev-ci) — ``_strip_builtin_servers`` now also drops
+  ``pocketpaw_code`` (the Code Mode delegate server: readFile / search /
+  listDir / writeFile), registered always-on via the ``code`` mcp_servers entry
+  point (``CloudCodeMcpProvider``) since #1763. That PR shipped the server and
+  its own test file but never taught this helper, so six assertions here counted
+  it as an external config and dev went red. Same regime as
+  ``pocketpaw_daytona``: ambient registration, scoped by the /code
+  SurfaceProfile allowlist rather than by being withheld.
 Updated: 2026-07-06 (feat/paw-sites-stock-imagery) — ``_strip_builtin_servers``
   now also drops ``pocketpaw_stock`` (search_stock_images: free Pexels +
   Unsplash photo search for site imagery, registered always-on via the
@@ -73,6 +81,7 @@ from unittest.mock import patch
 
 from pocketpaw_ee.agent.mcp_servers.ask import SERVER_NAME as _ASK_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.belt import SERVER_NAME as _BELT_MCP_SERVER_NAME
+from pocketpaw_ee.agent.mcp_servers.code import SERVER_NAME as _CODE_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.connectors import SERVER_NAME as _CONNECTORS_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.daytona import SERVER_NAME as _DAYTONA_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.decisions import SERVER_NAME as _DECISIONS_MCP_SERVER_NAME
@@ -175,6 +184,13 @@ def _strip_builtin_servers(result: dict) -> dict:
     # ``pocketpaw_daytona`` is always-on too — the /code surface scopes access
     # via its profile allowlist, same regime as fabric / instinct / media.
     out.pop(_DAYTONA_MCP_SERVER_NAME, None)
+    # ``pocketpaw_code`` is always-on too — the four /code file tools
+    # (readFile / search / listDir / writeFile) are ambient, NOT in
+    # ``OPT_IN_MCP_SERVERS``. The /code SurfaceProfile scopes them via
+    # ``tool_mode="exclusive"`` + ``_CODE_FILE_TOOL_IDS``, so the allowlist is
+    # the boundary, not registration — the same regime as its sibling
+    # ``pocketpaw_daytona`` directly above.
+    out.pop(_CODE_MCP_SERVER_NAME, None)
     # ``pocketpaw_atlas`` is always-on too — the capability atlas
     # (atlas_search / atlas_describe) is registered unconditionally in core
     # ``claude_sdk._get_mcp_servers`` so every agent can ground PocketPaw


### PR DESCRIPTION
Nothing here comes from feature work. `dev` has been red since roughly 25 Jul and it is blocking merges; run 30153951660 on `dev` itself fails the same way. Five separate things broke, none of them related to each other.

## Stale atlas artifact

Three tests were failing:

```
tests/atlas/test_compile.py::TestDeterminism::test_checked_in_artifact_is_fresh
tests/atlas/test_compile.py::TestConnectorsDirAnchoring::test_check_artifact_fresh_from_other_cwd
tests/atlas/test_widgets_skills.py::TestSkillExtraction::test_every_bundled_skill_has_a_valid_entry
```

Four bundled skills landed under `src/pocketpaw/bundled_skills/_bundled/skills/` (`code-next`, `code-react`, `code-svelte`, `code-vue`) without anyone re-running the compiler, so the checked-in `atlas.json` lagged the source. Ran `pocketpaw atlas build` and committed the result.

I diffed the regenerated artifact structurally rather than trusting the byte diff: 4 entries added, 0 removed, 0 changed, and `generated` / `schema` identical, which is also a decent proof the compiler is deterministic. The new entries carry `gist: ""`, matching all 15 pre-existing skill entries. 257 to 261 entries.

## Dead module in an import contract

```
uv run lint-imports --config ee/pyproject.toml
  → Module 'pocketpaw_ee.cloud.codeagent.domain' does not exist.
```

The "CodeAgent — runtime-agnostic: never reaches a sandbox" contract listed codeagent's modules one by one. That list was written on 21 Jul when the package had five files. Since then `transport.py` and `domain.py` were both deleted (2f81b7b5, which removed the separate turn-agent), and naming a module that no longer exists fails the whole `lint-imports` invocation rather than just that contract, so all 33 contracts stopped being checked.

Rather than delete the two dead entries I pointed the contract at the package. `as_packages` defaults to true, so one line covers every submodule now and in future. Worth flagging that this is slightly wider than what was there before: `delegates.py` was added on 22 Jul and never made it into the list, so it had never actually been covered. It is also the module most able to break this rule today, since it is the rendezvous that keeps file reads in the browser. The contract still reports KEPT with it in scope, so nothing was papered over to get here.

The sibling contracts enumerate modules because they need to exclude `service.py` from the Beanie rule. This one has no such carve-out, and its own comment says so, so there is nothing to preserve by keeping the list.

## Unsorted imports

One fixture in `tests/ee/agent/test_code_mcp_server.py` had `pocketpaw_ee` grouped in with the first-party `pocketpaw` imports. `ruff check --fix` split them.

## Unformatted test files

Not in the original report, but the same lint job also runs `ruff format --check .`, and that was failing on two files:

```
tests/cloud/agents/test_code_agent_seed.py
tests/ee/agent/test_code_mcp_server.py
```

I checked both against unmodified `origin/dev` before touching them, and they fail there too, so this is not fallout from the import fix above. Both were written against an 88 column assumption while the repo sets `line-length = 100`, so the formatter joins some wrapped calls back onto one line. Cosmetic only.

Left the narrative headers on those two test files alone. Both changes are formatter output with no behaviour in them, and a line about reflowed calls would not earn its place next to the architecture notes already in those headers. Happy to add them if you would rather the convention be absolute.

## A builtin MCP server the test helper had never been told about

Six tests in `tests/ee/test_mcp_claude_sdk.py` were failing, including:

```
TestClaudeSDKMCPServers::test_no_mcp_configs
  → assert {'pocketpaw_code': {'type': 'sdk'}} == {}
TestClaudeSDKMCPServers::test_enabled_stdio_server_passes
  → assert 2 == 1
```

`_strip_builtin_servers` is a helper in that file which drops always-on in-process servers so the assertions can focus on externally configured ones. It had no entry for `pocketpaw_code`, so six assertions counted the Code Mode delegate server as an external config.

I checked whether the server had any business being registered before touching the test, since if it were registering somewhere it should not, the test would have been right and the production code wrong. It is a legitimate ambient builtin. `OPT_IN_MCP_SERVERS` contains only `pocketpaw_planner`, so every other in-process server is always-on by design. `pocketpaw_code` registers through the standard `code` entry point (`CloudCodeMcpProvider`), and the `/code` SurfaceProfile scopes it with `tool_mode="exclusive"` plus `_CODE_FILE_TOOL_IDS`, so the allowlist is the boundary rather than registration. That is the same arrangement as the sibling `pocketpaw_daytona`, which this helper already strips for exactly that stated reason.

The gap traces to #1763, which shipped the server and 307 lines of its own tests but never updated this helper. The header of this file already records ten prior instances of the same miss, one per builtin.

No assertion was changed. The diff is one import, one `pop`, and a header entry.

## Verification

```
uv run ruff check .                                  All checks passed
uv run ruff format --check .                         2505 files already formatted
uv run lint-imports                                  1 kept, 0 broken
uv run --group ee lint-imports --config ee/pyproject.toml   33 kept, 0 broken
uv run pocketpaw atlas build --check                 artifact is up to date
uv run pytest tests/atlas -q                         178 passed
uv run --group ee pytest tests/ee/test_mcp_claude_sdk.py -q   32 passed
```

The three originally failing atlas tests pass by name. The two reformatted test files also pass, 35 between them.
