### PR TITLE
growth: send approved emails through Mailtrap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,6 +225,19 @@ The web dashboard (`frontend/`) is vanilla JS/CSS/HTML served via FastAPI+Jinja2
   env-configurable), marking queued/running `ChatRunDoc`s older than 10 minutes as
   `interrupted` so runs abandoned by a backend restart surface a retry affordance
   instead of leaving clients subscribed forever.
+- **Growth outbound config (`GROWTH_SENDING_DOMAIN`)**: the secondary domain the
+  `/growth` engine sends cold outreach from — **required**, with no default. The
+  dispatch worker fails closed when it is unset (nothing goes out), validates the
+  from-address against it at send time, and refuses a value equal to the
+  deployment's own host (`POCKETPAW_PUBLIC_BASE_URL`). Never point it at the apex:
+  cold outreach draws spam complaints at rates transactional mail never sees, and
+  the complaints land on the *sending* domain's reputation — a burnt secondary
+  domain costs a DNS record and a warm-up, a burnt apex takes password resets,
+  invoices and receipts with it. The provider credential itself is **not** an env
+  var: it is per-workspace connector state on the workspace's `mailtrap` connector
+  row (`MAILTRAP_API_TOKEN`, plus optional `MAILTRAP_FROM_EMAIL` /
+  `MAILTRAP_FROM_NAME`), so disabling the connector revokes sending immediately.
+  See `ee/pocketpaw_ee/cloud/growth/connector.py` and `docs/api-reference.md`.
 - **Session supervisor config**: `POCKETPAW_SESSION_SUPERVISOR` (default OFF). When
   truthy (`1`/`true`/`yes`/`on`), the cloud chat executor drives every agent turn
   through the `SessionSupervisor` + the durable `(workspace, session, agent) ->

--- a/connectors/mailtrap.yaml
+++ b/connectors/mailtrap.yaml
@@ -1,0 +1,43 @@
+# Mailtrap connector — the outbound email provider for the /growth engine.
+# Created: 2026-07-27 (feat/growth-g5, G-5).
+#
+# Like ship.yaml, this connector declares NO actions: the send is not an
+# agent-callable REST verb. Outbound email leaves the building through exactly
+# one path — an Instinct-approved draft picked up by the ``growth.dispatch``
+# worker (``ee/pocketpaw_ee/cloud/growth/email_dispatch.py``), which calls the
+# typed client in ``ee/pocketpaw_ee/cloud/growth/connector.py``. Exposing a
+# generic "send an email" action here would route around the approval gate.
+#
+# This connector exists for the CREDENTIAL: per-workspace, BYO, stored in the
+# WorkspaceConnector row's config blob (the same connector-state pattern
+# stripe/gmail use) and read back through the cloud connector state store. The
+# central project never holds a shared sending key, and no send credential is
+# ever inlined from the process environment.
+
+name: mailtrap
+display_name: Mailtrap
+type: email
+icon: mail
+
+auth:
+  method: api_key
+  credentials:
+    - name: MAILTRAP_API_TOKEN
+      description: >-
+        Mailtrap Email Sending API token for this workspace's sending domain.
+        Per-workspace by design — the central project never holds a shared
+        sending credential.
+      required: true
+    - name: MAILTRAP_FROM_EMAIL
+      description: >-
+        From-address for cold outreach. MUST sit on the workspace's secondary
+        sending domain (GROWTH_SENDING_DOMAIN), never the apex — the dispatcher
+        refuses to send otherwise. Defaults to outreach@<GROWTH_SENDING_DOMAIN>.
+      required: false
+    - name: MAILTRAP_FROM_NAME
+      description: Display name on the From header (optional).
+      required: false
+
+# No actions: sending is gated behind the Instinct approval + the growth
+# dispatch worker, never a generic connector verb.
+actions: []

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -82,6 +82,13 @@ GET /growth/drafts with prospect|channel|status filters, POST
 draft→proposed→approved→sent, sent→replied, non-terminal→rejected; illegal
 moves 422 draft.illegal_transition.
 
+Updated: 2026-07-27 (feat/growth-g5) — documented email dispatch: the
+growth.dispatch job's email branch now sends through the per-workspace
+Mailtrap connector, re-checks that the draft is still approved before any
+provider call, writes a MessageLog audit row per attempt, and flips the draft
+to sent through the existing gate seam. Also documented the retryable failure
+path (failed row, draft stays approved, nothing raises) and the required
+GROWTH_SENDING_DOMAIN config plus why outreach never rides the apex.
 Updated: 2026-07-27 (feat/growth-g4) — documented the Instinct send gate:
 POST /growth/drafts/{id}/propose files a gated _growth_send proposal and
 flips the draft to proposed; the status route now refuses the gate-owned
@@ -1719,6 +1726,52 @@ enqueues the `growth.dispatch` job `{draft_id, channel}` on the dedicated
 `growth` arq queue — with an execute-time re-check that the proposer STILL
 holds `growth.manage` (a since-demoted proposer's approved send fails
 closed), and `mark_failed` on the Action if the enqueue fails. On
-**reject** the draft flips to `rejected` and nothing is enqueued. The
-dispatch job body is a logging stub in this slice — G-5/G-6 implement the
-actual per-channel delivery and the `sent` flip.
+**reject** the draft flips to `rejected` and nothing is enqueued.
+
+### Dispatch — how an approved email actually sends (G-5)
+
+The `growth.dispatch` job's `email` branch is live. It is not an HTTP route —
+there is no "send this now" endpoint, by design — but its behaviour is part of
+the contract the propose/approve routes above promise.
+
+1. **Load and re-check.** The job re-reads the draft and refuses anything that
+   is not `approved`. A job whose draft was rejected while queued, or a
+   redelivered job for a draft already `sent`, logs a warning and makes **no**
+   provider call. This is the dispatcher's half of the send gate.
+2. **Send.** Delivery goes through the workspace's **Mailtrap** connector
+   (`connectors/mailtrap.yaml`) over the Email Sending API. The token is a
+   per-workspace credential held in that workspace's connector row and read
+   through the connector state store — never an inlined process credential,
+   and never logged, returned, or put on a DTO. Disabling the connector
+   revokes sending immediately (the state store only resolves enabled rows).
+   The connector declares **no actions**, so no agent or connector-execute
+   call can reach a send: the approved-draft path is the only one.
+3. **Record, then flip.** A `MessageLog` row is written first (the audit row
+   proves a message physically left even if the following write fails), then
+   the draft moves `approved → sent` through the same gate seam the executor
+   uses. No second status path is introduced.
+
+**Failure is retryable, not fatal.** A provider rejection, a transport error,
+an unconfigured connector, a prospect with no email address, or a
+subject-less draft all produce `MessageLog(outcome="failed", error=...)` and
+leave the draft `approved` — the human approval still stands, only delivery
+failed, so a re-run needs no second approval. Nothing raises out of the job:
+the growth worker runs `max_tries=1` precisely so outbound work is never
+auto-retried into a double-send, and the `MessageLog` row is the durable
+failure record.
+
+**`MessageLog`** (collection `growth_message_logs`, one row per delivery
+**attempt**): `workspace`, `draft_id`, `prospect_id`, `channel`, `provider`
+(`"mailtrap"`), `provider_message_id`, `to_address`, `sent_at`, `outcome`
+(`sent | failed`), `error`. Written only by the growth service.
+
+**Config — `GROWTH_SENDING_DOMAIN` (required to send).** The secondary
+sending domain outreach rides. Unset means nothing goes out; the dispatcher
+fails closed rather than guessing. The from-address (default
+`outreach@<GROWTH_SENDING_DOMAIN>`, overridable per workspace via the
+connector's `MAILTRAP_FROM_EMAIL`) is validated against it at send time, and
+the value may not equal the deployment's own host (`POCKETPAW_PUBLIC_BASE_URL`).
+Cold outreach draws spam complaints at rates transactional mail never sees,
+and every complaint lands on the sending domain's reputation — a burnt
+secondary domain costs a DNS record and a warm-up, while a burnt apex takes
+password resets, invoices, and receipts down with it.

--- a/ee/pocketpaw_ee/cloud/growth/connector.py
+++ b/ee/pocketpaw_ee/cloud/growth/connector.py
@@ -1,0 +1,266 @@
+# ee/pocketpaw_ee/cloud/growth/connector.py — the Mailtrap email-sending
+# client for the /growth outbound engine (G-5).
+#
+# Created 2026-07-27 (feat/growth-g5): new module.
+#
+# WHY A MODULE AND NOT A YAML ACTION. ``connectors/mailtrap.yaml`` declares the
+# credential but ZERO actions, exactly like ``ship.yaml``. A generic
+# "send_email" REST action would be reachable from the agent/connector-execute
+# surface and would route around the Instinct send gate. Outbound email leaves
+# the building through one path only: an approved draft → ``growth.dispatch`` →
+# ``email_dispatch.dispatch_email`` → this module.
+#
+# CREDENTIALS — connector state, never env-inline. The Mailtrap token lives in
+# the workspace's ``WorkspaceConnector`` row config blob (keyed on the YAML's
+# declared credential name, the same shape stripe/gmail use) and is read back
+# through the cloud connector state store (``ws:<workspace_id>`` scope key).
+# The central deployment never holds a shared sending key. The token is never
+# logged, never put on a domain/DTO/response, and never streamed: it exists
+# only as a local in this module's request builder, and every error string this
+# module raises is passed through ``_scrub`` so a provider echo can't leak it.
+#
+# GROWTH_SENDING_DOMAIN — the SECONDARY sending domain, deliberately not the
+# apex. Cold outreach gets marked as spam at rates a transactional stream never
+# sees; every complaint lands on the sending domain's reputation. Burning a
+# secondary domain costs a DNS record and a warm-up. Burning the apex takes
+# password resets, invoices and receipts down with it, and reputation recovery
+# on a burnt apex is measured in months. So: outreach rides its own domain, and
+# this module REFUSES to send when the from-address isn't on it — including
+# refusing when the configured sending domain is the deployment's own public
+# host (``POCKETPAW_PUBLIC_BASE_URL``), which is the apex by definition.
+
+"""Mailtrap Email Sending API client for the /growth dispatch worker."""
+
+from __future__ import annotations
+
+import inspect
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+# The registry key for ``connectors/mailtrap.yaml`` and the ``provider`` value
+# stamped onto every MessageLog row this module produces.
+MAILTRAP_CONNECTOR_NAME = "mailtrap"
+
+# Mailtrap Email Sending API — transactional stream. HTTPS JSON, preferred over
+# SMTP: one request, a structured error body, and a provider message id we can
+# put on the audit row.
+MAILTRAP_SEND_URL = "https://send.api.mailtrap.io/api/send"
+
+# Config-blob keys, matching the credential names declared in the YAML.
+TOKEN_KEY = "MAILTRAP_API_TOKEN"
+FROM_EMAIL_KEY = "MAILTRAP_FROM_EMAIL"
+FROM_NAME_KEY = "MAILTRAP_FROM_NAME"
+
+# Deployment-level config: the secondary sending domain (see the module header).
+SENDING_DOMAIN_ENV = "GROWTH_SENDING_DOMAIN"
+
+# The deployment's own public host — the apex we refuse to send outreach from.
+PUBLIC_BASE_URL_ENV = "POCKETPAW_PUBLIC_BASE_URL"
+
+# Local part used when the workspace hasn't pinned an explicit from-address.
+_DEFAULT_LOCAL_PART = "outreach"
+
+_TIMEOUT_SECONDS = 20.0
+
+
+class EmailSendError(Exception):
+    """A send could not be made, or the provider refused it.
+
+    Every message is scrubbed of the workspace's token before it is raised, so
+    the string is safe to persist on a ``MessageLog.error`` and to log.
+    """
+
+
+@dataclass(frozen=True)
+class SentEmail:
+    """What a successful send yields for the audit row."""
+
+    provider: str
+    provider_message_id: str | None
+    to_address: str
+    from_address: str
+
+
+def _scrub(text: str, secret: str) -> str:
+    """Remove a credential from a string before it is logged or persisted.
+
+    The provider can echo request material in an error body; a token that took
+    a round trip through their error path is still a token. Belt and braces on
+    top of "never put it in the message in the first place".
+    """
+    if secret and secret in text:
+        text = text.replace(secret, "***")
+    return text
+
+
+def resolve_sending_domain() -> str:
+    """The configured secondary sending domain. Raises when unusable.
+
+    Fails CLOSED: an unset ``GROWTH_SENDING_DOMAIN`` means nothing goes out,
+    rather than falling back to whatever domain the token happens to allow.
+    Also refuses the deployment's own public host — see the module header on
+    why cold outreach never rides the apex.
+    """
+    domain = os.environ.get(SENDING_DOMAIN_ENV, "").strip().lower().rstrip(".")
+    if not domain:
+        raise EmailSendError(
+            f"{SENDING_DOMAIN_ENV} is not set — refusing to send outreach without an "
+            "explicit secondary sending domain"
+        )
+    if domain.startswith("www."):
+        domain = domain[len("www.") :]
+
+    public_host = urlparse(os.environ.get(PUBLIC_BASE_URL_ENV, "").strip()).hostname or ""
+    public_host = public_host.lower().rstrip(".")
+    if public_host.startswith("www."):
+        public_host = public_host[len("www.") :]
+    if public_host and domain == public_host:
+        raise EmailSendError(
+            f"{SENDING_DOMAIN_ENV} is the deployment's own apex domain — cold outreach "
+            "must ride a secondary domain so a spam-complaint burst can never take "
+            "transactional mail down with it"
+        )
+    return domain
+
+
+async def load_workspace_config(workspace_id: str) -> dict[str, Any]:
+    """Read the workspace's Mailtrap connector config from connector state.
+
+    Goes through the cloud ``ConnectorStateStore`` seam (``ws:<workspace_id>``
+    scope key), which resolves the ENABLED ``WorkspaceConnector`` row — so
+    disabling the connector immediately revokes sending, with no separate
+    kill switch to remember. ``get`` returns an awaitable for namespaced keys;
+    the file-backed fallback is sync, hence the ``inspect.isawaitable`` dance
+    the registry itself uses.
+    """
+    from pocketpaw_ee.cloud.connectors.state_provider import CloudConnectorStateStore
+
+    result: Any = CloudConnectorStateStore().get(MAILTRAP_CONNECTOR_NAME, f"ws:{workspace_id}")
+    if inspect.isawaitable(result):
+        result = await result
+    return dict(result or {})
+
+
+def _http_client() -> Any:
+    """Build the HTTPS client. A seam so tests inject a MockTransport.
+
+    ``httpx`` is already a core dependency — no Mailtrap SDK is pulled in for
+    one JSON POST (and no new package to age past the 7-day supply-chain bar).
+    """
+    import httpx
+
+    return httpx.AsyncClient(timeout=_TIMEOUT_SECONDS)
+
+
+def _resolve_from_address(config: dict[str, Any], sending_domain: str) -> str:
+    """Pick and VALIDATE the from-address against the sending domain."""
+    raw = str(config.get(FROM_EMAIL_KEY) or "").strip()
+    from_address = raw or f"{_DEFAULT_LOCAL_PART}@{sending_domain}"
+    _, _, host = from_address.partition("@")
+    host = host.strip().lower().rstrip(".")
+    if not host or host != sending_domain:
+        raise EmailSendError(
+            f"from-address is not on the configured sending domain "
+            f"('{sending_domain}') — refusing to send"
+        )
+    return from_address
+
+
+async def send_email(
+    *,
+    workspace_id: str,
+    to_address: str,
+    subject: str,
+    body: str,
+) -> SentEmail:
+    """Send one outreach email through Mailtrap. Raises ``EmailSendError``.
+
+    The caller (``email_dispatch``) turns any raise into a ``failed``
+    MessageLog row and leaves the draft ``approved`` so the send is retryable.
+    """
+    to_address = (to_address or "").strip()
+    if "@" not in to_address:
+        raise EmailSendError("prospect has no usable email address")
+    if not (subject or "").strip():
+        raise EmailSendError("draft has no subject — refusing to send a subject-less cold email")
+    if not (body or "").strip():
+        raise EmailSendError("draft has no body — refusing to send an empty email")
+
+    sending_domain = resolve_sending_domain()
+    config = await load_workspace_config(workspace_id)
+    token = str(config.get(TOKEN_KEY) or "").strip()
+    if not token:
+        raise EmailSendError(
+            "the mailtrap connector is not configured for this workspace — "
+            "enable it and supply the sending token"
+        )
+    from_address = _resolve_from_address(config, sending_domain)
+    from_name = str(config.get(FROM_NAME_KEY) or "").strip()
+
+    sender: dict[str, str] = {"email": from_address}
+    if from_name:
+        sender["name"] = from_name
+    payload = {
+        "from": sender,
+        "to": [{"email": to_address}],
+        "subject": subject,
+        "text": body,
+    }
+
+    client = _http_client()
+    try:
+        async with client:
+            response = await client.post(
+                MAILTRAP_SEND_URL,
+                json=payload,
+                headers={"Api-Token": token},
+            )
+    except Exception as exc:  # noqa: BLE001 — transport failures are retryable sends
+        # Type name only: an httpx exception's str() can carry request detail,
+        # and this string is persisted on the audit row.
+        raise EmailSendError(f"mailtrap request failed ({type(exc).__name__})") from exc
+
+    if response.status_code >= 400:
+        detail = _scrub((response.text or "")[:200], token)
+        raise EmailSendError(f"mailtrap rejected the send (HTTP {response.status_code}): {detail}")
+
+    try:
+        data = response.json()
+    except Exception:  # noqa: BLE001 — a 2xx with an unparseable body still sent
+        data = {}
+    if isinstance(data, dict) and data.get("success") is False:
+        errors = data.get("errors")
+        detail = _scrub(str(errors)[:200] if errors else "no detail", token)
+        raise EmailSendError(f"mailtrap reported failure: {detail}")
+
+    message_ids = data.get("message_ids") if isinstance(data, dict) else None
+    provider_message_id = (
+        str(message_ids[0]) if isinstance(message_ids, list) and message_ids else None
+    )
+    return SentEmail(
+        provider=MAILTRAP_CONNECTOR_NAME,
+        provider_message_id=provider_message_id,
+        to_address=to_address,
+        from_address=from_address,
+    )
+
+
+__all__ = [
+    "FROM_EMAIL_KEY",
+    "FROM_NAME_KEY",
+    "MAILTRAP_CONNECTOR_NAME",
+    "MAILTRAP_SEND_URL",
+    "PUBLIC_BASE_URL_ENV",
+    "SENDING_DOMAIN_ENV",
+    "TOKEN_KEY",
+    "EmailSendError",
+    "SentEmail",
+    "load_workspace_config",
+    "resolve_sending_domain",
+    "send_email",
+]

--- a/ee/pocketpaw_ee/cloud/growth/domain.py
+++ b/ee/pocketpaw_ee/cloud/growth/domain.py
@@ -14,6 +14,9 @@
 # (``DRAFT_TRANSITIONS``): draft→proposed→approved→sent, sent→replied, any
 # non-terminal→rejected. The transition table lives here (pure data) so the
 # service stays a dumb enforcer and G-4 can wire Instinct proposals on top.
+# Updated 2026-07-27 (feat/growth-g5): ``MessageLog`` — the audit value object
+# for ONE outbound delivery attempt (``MESSAGE_LOG_OUTCOMES``: sent | failed).
+# One row per attempt, not per draft, so a retried send keeps both records.
 # Updated 2026-07-27 (feat/growth-g4): the Instinct send gate —
 # ``GATE_OWNED_TARGETS`` marks the statuses only the gate machinery may set
 # (``approved`` via an approved ``_growth_send`` proposal, ``sent`` via the
@@ -126,15 +129,50 @@ class Draft:
     updated_at: datetime | None = None
 
 
+# G-5 — outcome of one outbound delivery ATTEMPT. ``sent`` means the provider
+# accepted the message; ``failed`` means it did not, and the draft deliberately
+# stays ``approved`` so the attempt is retryable without a second approval.
+MessageOutcome = Literal["sent", "failed"]
+
+MESSAGE_LOG_OUTCOMES: frozenset[str] = frozenset({"sent", "failed"})
+
+
+@dataclass(frozen=True)
+class MessageLog:
+    """One outbound delivery attempt for a draft — the audit record.
+
+    Tenancy is required at construction (``workspace_id``, no default), like
+    every other growth value object. Carries the PROVIDER's identity and
+    message id, never its credential; ``error`` is a sanitised, human-readable
+    reason produced by the channel connector.
+    """
+
+    id: str
+    workspace_id: str
+    draft_id: str
+    prospect_id: str
+    channel: str  # DraftChannel
+    provider: str  # e.g. "mailtrap"
+    to_address: str
+    outcome: str  # MessageOutcome
+    provider_message_id: str | None = None
+    sent_at: datetime | None = None
+    error: str | None = None
+    created_at: datetime | None = None
+
+
 __all__ = [
     "DRAFT_TRANSITIONS",
     "GATE_OWNED_TARGETS",
     "GROWTH_DISPATCH_JOB_NAME",
     "GROWTH_QUEUE_NAME",
+    "MESSAGE_LOG_OUTCOMES",
     "Draft",
     "DraftChannel",
     "DraftStatus",
     "DraftVariant",
+    "MessageLog",
+    "MessageOutcome",
     "Prospect",
     "ProspectSource",
     "ProspectStatus",

--- a/ee/pocketpaw_ee/cloud/growth/email_dispatch.py
+++ b/ee/pocketpaw_ee/cloud/growth/email_dispatch.py
@@ -1,0 +1,155 @@
+# ee/pocketpaw_ee/cloud/growth/email_dispatch.py — the email branch of the
+# ``growth.dispatch`` arq job (G-5): an APPROVED draft actually leaves the
+# building.
+#
+# Created 2026-07-27 (feat/growth-g5): new module. Lives beside ``worker.py``
+# rather than inside it so each channel's delivery owns its own file — the
+# worker keeps a one-line branch per channel.
+#
+# ORDER OF OPERATIONS, and why:
+#
+#   1. Load the draft (the queue hands the worker only an id) and REFUSE
+#      anything that is not ``approved``. draft / proposed / sent / replied /
+#      rejected are all no-ops with a warning and NO provider call. This is the
+#      last line of the send gate: the enqueue side already proves a human
+#      approved the ``_growth_send`` proposal, but a job that sat in the queue
+#      while the draft was rejected — or a redelivered job for a draft already
+#      ``sent`` — must never put a second message on the wire.
+#   2. Send through ``growth.connector`` (Mailtrap HTTPS API, per-workspace
+#      credential out of connector state).
+#   3. Write the ``MessageLog`` audit row BEFORE the status flip. If the flip
+#      then fails, the message physically left and the audit row proves it; the
+#      reverse order could lose the only record of a real send.
+#   4. Flip approved→sent through ``service.gate_transition`` — the EXISTING
+#      gate seam that owns that edge. No second path is added here.
+#
+# FAILURE PATH: a connector error writes ``MessageLog(outcome="failed",
+# error=...)`` and leaves the draft ``approved``, which is exactly the
+# retryable state (the human's approval still stands; only delivery failed).
+# Nothing raises out of this module — the growth worker runs ``max_tries=1``
+# specifically so outbound work can never be auto-retried into a double-send,
+# so an escaping exception would buy nothing and lose the audit row. The
+# durable failure record IS the MessageLog row, mirroring how the executor's
+# ``_fail`` chokepoint records an outcome instead of propagating.
+
+"""Email delivery for the ``growth.dispatch`` job."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+from pocketpaw_ee.cloud.growth import connector as growth_connector
+from pocketpaw_ee.cloud.growth import service as growth_service
+from pocketpaw_ee.cloud.growth.domain import Draft
+
+logger = logging.getLogger(__name__)
+
+# The only draft status a send may happen from.
+_SENDABLE_STATUS = "approved"
+
+EMAIL_CHANNEL = "email"
+
+
+async def dispatch_email(draft_id: str) -> None:
+    """Deliver one approved email draft. Never raises."""
+    draft = await growth_service.get_draft_for_dispatch(draft_id)
+    if draft is None:
+        logger.warning("growth email dispatch: draft %s no longer exists — nothing sent", draft_id)
+        return
+    if draft.channel != EMAIL_CHANNEL:
+        logger.warning(
+            "growth email dispatch: draft %s is channel=%r, not email — nothing sent",
+            draft_id,
+            draft.channel,
+        )
+        return
+    if draft.status != _SENDABLE_STATUS:
+        # The gate's last line. Not an error — a queued job whose draft moved
+        # on is expected; it just must not send.
+        logger.warning(
+            "growth email dispatch: draft %s is %r, not %r — refusing to send",
+            draft_id,
+            draft.status,
+            _SENDABLE_STATUS,
+        )
+        return
+
+    workspace_id = draft.workspace_id
+    prospect = await growth_service.get_prospect_for_dispatch(workspace_id, draft.prospect_id)
+    to_address = next((e for e in (prospect.emails if prospect else ()) if e and "@" in e), "")
+
+    try:
+        sent = await growth_connector.send_email(
+            workspace_id=workspace_id,
+            to_address=to_address,
+            subject=draft.subject or "",
+            body=draft.body,
+        )
+    except Exception as exc:  # noqa: BLE001 — a failed send is recorded, never raised
+        reason = (
+            str(exc)
+            if isinstance(exc, growth_connector.EmailSendError)
+            # An unexpected exception's str() is not known-sanitised; record the
+            # type only so no credential can reach the audit row.
+            else f"unexpected dispatch error ({type(exc).__name__})"
+        )
+        logger.error("growth email dispatch: draft %s failed — %s", draft_id, reason)
+        await _record(
+            draft=draft,
+            to_address=to_address,
+            outcome="failed",
+            error=reason,
+        )
+        return
+
+    await _record(
+        draft=draft,
+        to_address=sent.to_address,
+        outcome="sent",
+        provider_message_id=sent.provider_message_id,
+        sent_at=datetime.now(UTC),
+    )
+
+    try:
+        await growth_service.gate_transition(workspace_id, draft_id, "sent")
+    except Exception:  # noqa: BLE001 — the message is already out; don't re-send
+        logger.exception(
+            "growth email dispatch: draft %s was DELIVERED but the sent flip failed — "
+            "the MessageLog row is the record of truth",
+            draft_id,
+        )
+
+
+async def _record(
+    *,
+    draft: Draft,
+    to_address: str,
+    outcome: str,
+    provider_message_id: str | None = None,
+    sent_at: datetime | None = None,
+    error: str | None = None,
+) -> None:
+    """Write the audit row. Best-effort — a log failure must not re-raise."""
+    try:
+        await growth_service.record_message_log(
+            workspace_id=draft.workspace_id,
+            draft_id=draft.id,
+            prospect_id=draft.prospect_id,
+            channel=EMAIL_CHANNEL,
+            provider=growth_connector.MAILTRAP_CONNECTOR_NAME,
+            to_address=to_address,
+            outcome=outcome,
+            provider_message_id=provider_message_id,
+            sent_at=sent_at,
+            error=error,
+        )
+    except Exception:  # noqa: BLE001 — audit write failure must not break the job
+        logger.exception(
+            "growth email dispatch: could not write the %s message log for draft %s",
+            outcome,
+            draft.id,
+        )
+
+
+__all__ = ["EMAIL_CHANNEL", "dispatch_email"]

--- a/ee/pocketpaw_ee/cloud/growth/service.py
+++ b/ee/pocketpaw_ee/cloud/growth/service.py
@@ -24,10 +24,17 @@
 # draft→proposed via ``transition``), and ``gate_transition`` is the internal
 # seam the growth executor / dispatch worker use to walk gate-owned edges
 # (same legality table, explicit workspace_id, no RequestContext).
+# Updated 2026-07-27 (feat/growth-g5): the dispatch-worker seams —
+# ``get_draft_for_dispatch`` / ``get_prospect_for_dispatch`` (the worker is
+# handed only a draft id by the queue and derives tenancy FROM the row; see the
+# ``global-read`` justifications on those reads) and ``record_message_log``,
+# the sole writer of the ``MessageLog`` audit doc — one row per delivery
+# ATTEMPT, so a failure and its later retry both survive.
 
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 from typing import Any
 
 from beanie import PydanticObjectId
@@ -39,7 +46,9 @@ from pocketpaw_ee.cloud._core.time import iso_utc
 from pocketpaw_ee.cloud.growth.domain import (
     DRAFT_TRANSITIONS,
     GATE_OWNED_TARGETS,
+    MESSAGE_LOG_OUTCOMES,
     Draft,
+    MessageLog,
     Prospect,
 )
 from pocketpaw_ee.cloud.growth.dto import (
@@ -55,6 +64,7 @@ from pocketpaw_ee.cloud.growth.dto import (
     UpdateProspectRequest,
 )
 from pocketpaw_ee.cloud.models.draft import Draft as _DraftDoc
+from pocketpaw_ee.cloud.models.message_log import MessageLog as _MessageLogDoc
 from pocketpaw_ee.cloud.models.prospect import Prospect as _ProspectDoc
 
 logger = logging.getLogger(__name__)
@@ -512,15 +522,123 @@ async def propose_send(ctx: RequestContext, draft_id: str) -> ProposeSendRespons
     return ProposeSendResponse(proposal_id=proposal_id, draft=draft)
 
 
+# ---------------------------------------------------------------------------
+# Dispatch-worker seams (G-5)
+# ---------------------------------------------------------------------------
+
+
+async def get_draft_for_dispatch(draft_id: str) -> Draft | None:
+    """Load a draft by id ALONE — the dispatch worker's entry read.
+
+    The arq job carries only ``(draft_id, channel)``: the worker process has no
+    RequestContext and no workspace to filter on, so tenancy is DERIVED from
+    the row and every subsequent call (prospect read, status flip, audit write)
+    is scoped to ``draft.workspace_id``. Safe because the id itself is not
+    attacker-supplied — the only producer of this job is
+    ``executor.execute_approved_growth_send``, which already validated the
+    draft against the approved proposal's workspace. Returns ``None`` for a
+    malformed or vanished id so the job can no-op instead of raising.
+
+    # global-read: worker path — no request workspace exists to filter on; the
+    # draft id comes from the gate's own enqueue and the row supplies tenancy.
+    """
+    try:
+        oid = PydanticObjectId(draft_id)
+    except Exception:  # noqa: BLE001 — malformed id == nothing to dispatch
+        return None
+    doc = await _DraftDoc.find_one({"_id": oid})
+    return _draft_to_domain(doc) if doc is not None else None
+
+
+async def get_prospect_for_dispatch(workspace_id: str, prospect_id: str) -> Prospect | None:
+    """Load the draft's prospect for the dispatch worker, workspace-scoped.
+
+    Takes the explicit ``workspace_id`` the draft supplied, so the read is
+    tenant-filtered like every other prospect read. ``None`` (not NotFound) —
+    a missing prospect is a recorded delivery failure, not an exception in a
+    background job.
+    """
+    try:
+        oid = PydanticObjectId(prospect_id)
+    except Exception:  # noqa: BLE001 — malformed id == no prospect
+        return None
+    doc = await _ProspectDoc.find_one({"_id": oid, "workspace": workspace_id})
+    return _to_domain(doc) if doc is not None else None
+
+
+async def record_message_log(
+    *,
+    workspace_id: str,
+    draft_id: str,
+    prospect_id: str,
+    channel: str,
+    provider: str,
+    to_address: str,
+    outcome: str,
+    provider_message_id: str | None = None,
+    sent_at: datetime | None = None,
+    error: str | None = None,
+) -> MessageLog:
+    """Write the audit row for ONE outbound delivery attempt (G-5).
+
+    Sole writer of the ``MessageLog`` doc (the "Growth" import-linter contract
+    keeps the doc class out of the worker/connector modules). One row per
+    ATTEMPT: a ``failed`` row leaves the draft ``approved`` so the retry writes
+    a second row and the delivery history stays complete.
+
+    ``error`` is truncated — connectors already sanitise their messages, but a
+    provider error body should never be able to bloat the audit collection.
+    """
+    if outcome not in MESSAGE_LOG_OUTCOMES:
+        raise ValidationError(
+            "message_log.invalid_outcome",
+            f"'{outcome}' is not a delivery outcome ({sorted(MESSAGE_LOG_OUTCOMES)})",
+        )
+    if not workspace_id:
+        raise ValidationError("message_log.no_workspace", "A message log needs a workspace")
+
+    doc = _MessageLogDoc(
+        workspace=workspace_id,
+        draft_id=draft_id,
+        prospect_id=prospect_id,
+        channel=channel,
+        provider=provider,
+        provider_message_id=provider_message_id,
+        to_address=to_address,
+        sent_at=sent_at,
+        outcome=outcome,
+        error=error[:500] if error else None,
+    )
+    await doc.insert()
+    # no-event: growth has no realtime subscriber in v1; the sends view polls.
+    return MessageLog(
+        id=str(doc.id),
+        workspace_id=doc.workspace,
+        draft_id=doc.draft_id,
+        prospect_id=doc.prospect_id,
+        channel=doc.channel,
+        provider=doc.provider,
+        to_address=doc.to_address,
+        outcome=doc.outcome,
+        provider_message_id=doc.provider_message_id,
+        sent_at=doc.sent_at,
+        error=doc.error,
+        created_at=getattr(doc, "createdAt", None),
+    )
+
+
 __all__ = [
     "bulk_ingest",
     "create",
     "create_draft",
     "gate_transition",
     "get",
+    "get_draft_for_dispatch",
+    "get_prospect_for_dispatch",
     "list_drafts",
     "list_prospects",
     "propose_send",
+    "record_message_log",
     "transition",
     "update",
     "upsert_by_domain",

--- a/ee/pocketpaw_ee/cloud/growth/worker.py
+++ b/ee/pocketpaw_ee/cloud/growth/worker.py
@@ -12,6 +12,10 @@
 # actual delivery and the draft's ``sent`` flip (via the service's
 # ``gate_transition`` seam). The job only ever EXISTS for a draft whose
 # ``_growth_send`` proposal a human approved — that is the whole gate.
+# Updated 2026-07-27 (feat/growth-g5): the ``email`` branch is live — it hands
+# off to ``growth/email_dispatch.dispatch_email`` (per-channel module, so each
+# channel's delivery stays in its own file and the job body keeps one branch
+# per channel). Other channels still log the stub.
 #
 # Unlike workspace jobs (which ride arq's DEFAULT queue on the shared chat-runs
 # worker — see ``jobs/domain.py``), growth gets its OWN queue + worker process
@@ -51,19 +55,27 @@ logger = logging.getLogger(__name__)
 
 
 async def dispatch(ctx: dict[str, Any], draft_id: str, channel: str) -> None:
-    """Dispatch an APPROVED outbound draft — STUB (G-4).
+    """Dispatch an APPROVED outbound draft.
 
     This job is enqueued ONLY by ``executor.execute_approved_growth_send``
     after a human approved the draft's ``_growth_send`` Instinct proposal —
     there is no other producer, so a job here IS the approval record's
-    downstream. In this slice it logs and returns: no provider call, no
-    draft mutation, nothing is marked sent. G-5/G-6 replace the body with the
-    real per-channel delivery + the draft's ``sent`` flip (via
-    ``service.gate_transition``) + follow-up scheduling.
+    downstream. Each channel owns its own delivery module and re-checks that
+    the draft is still ``approved`` before anything reaches a provider.
+
+    ``email`` is live (G-5). The remaining channels still log and return.
     """
+    if channel == "email":
+        # Lazy import — keeps the arq worker's boot free of the HTTP client
+        # stack until an email job actually lands.
+        from pocketpaw_ee.cloud.growth.email_dispatch import dispatch_email
+
+        await dispatch_email(draft_id)
+        return
+
     logger.info(
         "growth worker: dispatch STUB — draft=%s channel=%s (approved send queued; "
-        "no delivery in G-4, nothing marked sent)",
+        "no delivery for this channel yet, nothing marked sent)",
         draft_id,
         channel,
     )

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -3,6 +3,12 @@
 Updated: 2026-07-27 (feat/growth-g4 merge) — merged integration/ship-v1 into the
 growth stack so the ``_growth_send`` gate slice can wire the sixth gated kind on
 top of ship's instinct-router changes; both changelog blocks below retained.
+Updated: 2026-07-27 (feat/growth-g5) — added ``MessageLog`` (the /growth
+outbound audit row: one record per delivery ATTEMPT, ``sent`` | ``failed``) to
+the imports and ``get_all_documents()`` so the ``growth_message_logs``
+collection is wired into ``init_beanie``. Kept out of ``__all__`` like
+``Prospect`` / ``Draft`` — only ``ee.cloud.growth.service`` imports the doc
+class directly (import-linter "Growth" contract).
 Updated: 2026-07-27 (feat/growth-g3) — added ``Draft`` (the /growth per-channel
 outreach draft: workspace-scoped, attached to a prospect, status lifecycle
 enforced in the service) to the imports and ``get_all_documents()`` so the
@@ -193,6 +199,7 @@ from pocketpaw_ee.cloud.models.meeting import (
 )
 from pocketpaw_ee.cloud.models.member_ingest_state import MemberIngestState
 from pocketpaw_ee.cloud.models.message import Attachment, Mention, Message, Reaction
+from pocketpaw_ee.cloud.models.message_log import MessageLog
 from pocketpaw_ee.cloud.models.notification import Notification, NotificationSource
 from pocketpaw_ee.cloud.models.notification_delivery import NotificationDeliveryConfig
 from pocketpaw_ee.cloud.models.payment import Payment
@@ -509,6 +516,10 @@ def get_all_documents():
         # prospect, status lifecycle enforced in the service. Same import
         # boundary as Prospect.
         Draft,
+        # Growth message log (G-5) — one audit row per outbound delivery
+        # ATTEMPT (sent | failed) written by the dispatch worker through
+        # ``growth.service.record_message_log``. Same import boundary.
+        MessageLog,
         PushSubscription,
         VapidKeypair,
         WorkspaceSensePreference,

--- a/ee/pocketpaw_ee/cloud/models/message_log.py
+++ b/ee/pocketpaw_ee/cloud/models/message_log.py
@@ -1,0 +1,52 @@
+# ee/pocketpaw_ee/cloud/models/message_log.py — the audit row for one outbound
+# /growth delivery attempt (G-5, feat/growth-g5). Workspace-scoped, one row per
+# ATTEMPT (not per draft): a send that fails writes ``outcome="failed"`` and the
+# retry writes a second row, so the collection is the full delivery history a
+# deliverability review or a retry sweep reads.
+#
+# Only ``ee.cloud.growth.service`` imports this doc class (import-linter
+# "Growth" contract) — the dispatch worker records through
+# ``service.record_message_log``.
+#
+# NEVER stores credentials or the provider's auth header — only the
+# provider NAME, the provider's own message id, and the recipient address.
+# ``error`` carries a connector-produced, credential-free string (see
+# ``growth/connector.py``, which raises only sanitised messages).
+#
+# Created 2026-07-27 (feat/growth-g5): fifth slice of /growth — email dispatch.
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from beanie import Indexed
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class MessageLog(TimestampedDocument):
+    """One outbound delivery attempt for a growth draft."""
+
+    # Tenancy boundary — every read filters on this.
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    # The growth_drafts row this attempt delivered (stringified ObjectId).
+    draft_id: str
+    # The growth_prospects row the draft targets (stringified ObjectId).
+    prospect_id: str
+    channel: str  # email | linkedin | whatsapp
+    provider: str  # "mailtrap" for the email channel
+    provider_message_id: str | None = None  # provider's own id, when it returns one
+    to_address: str
+    sent_at: datetime | None = None  # set on a successful send only
+    outcome: str  # sent | failed
+    error: str | None = None  # sanitised failure detail; never a credential
+
+    class Settings:
+        name = "growth_message_logs"
+        indexes = [
+            # A draft's delivery history — the retry sweep and the "did this
+            # actually go out?" lookup.
+            [("workspace", 1), ("draft_id", 1)],
+            # Failure triage / deliverability review per channel.
+            [("workspace", 1), ("outcome", 1), ("channel", 1)],
+        ]

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -814,6 +814,10 @@ name = "Growth — Beanie writes only from service.py"
 # feat/growth-g4 — the gate modules join the boundary: ``propose`` files the
 # Instinct Action and ``executor`` flips drafts ONLY through the service's
 # ``gate_transition`` seam, never the doc class directly.
+# feat/growth-g5 — the MessageLog audit doc joins the boundary (writes only
+# from ``growth.service.record_message_log``), and the dispatch modules join
+# the source list: ``email_dispatch`` records + flips through the service, and
+# ``connector`` only ever touches the provider's HTTP API.
 type = "forbidden"
 allow_indirect_imports = "true"
 source_modules = [
@@ -823,10 +827,13 @@ source_modules = [
     "pocketpaw_ee.cloud.growth.worker",
     "pocketpaw_ee.cloud.growth.propose",
     "pocketpaw_ee.cloud.growth.executor",
+    "pocketpaw_ee.cloud.growth.connector",
+    "pocketpaw_ee.cloud.growth.email_dispatch",
 ]
 forbidden_modules = [
     "pocketpaw_ee.cloud.models.prospect",
     "pocketpaw_ee.cloud.models.draft",
+    "pocketpaw_ee.cloud.models.message_log",
 ]
 
 [[tool.importlinter.contracts]]

--- a/tests/cloud/growth/test_email_dispatch.py
+++ b/tests/cloud/growth/test_email_dispatch.py
@@ -1,0 +1,501 @@
+# tests/cloud/growth/test_email_dispatch.py — the email branch of
+# ``growth.dispatch`` (G-5): an approved draft actually leaves the building.
+#
+# What this suite proves:
+#
+#   1. HAPPY PATH — an ``approved`` email draft calls the Mailtrap send API
+#      exactly ONCE with the right payload (from-address on the configured
+#      secondary sending domain, recipient, subject, body, ``Api-Token``
+#      header), flips the draft approved→sent through the EXISTING
+#      ``service.gate_transition`` seam, and writes a ``sent`` MessageLog row
+#      carrying the provider's message id.
+#   2. GATE — a draft in ANY other status (draft / proposed / sent / replied /
+#      rejected) makes NO send call and changes no state. Parametrized; this is
+#      the dispatcher's half of the send gate.
+#   3. FAILURE — a connector error writes ``MessageLog(outcome="failed")``,
+#      leaves the draft ``approved`` (retryable — the human approval stands),
+#      and lets NO exception escape the job.
+#   4. CREDENTIAL HYGIENE — the workspace's Mailtrap token never appears in
+#      logs, in the MessageLog row, or in any value the dispatch path returns,
+#      even when the provider echoes it back in an error body (grep-style
+#      assertion over every captured surface).
+#   5. SENDING DOMAIN — an unset ``GROWTH_SENDING_DOMAIN``, a from-address off
+#      that domain, and a sending domain that IS the deployment's apex all fail
+#      closed with no HTTP call.
+#
+# NETWORK-FREE: every send goes through ``httpx.MockTransport`` injected at the
+# ``connector._http_client`` seam. The credential itself is read the real way —
+# through the cloud connector state store, off a ``WorkspaceConnector`` row in
+# the mongomock DB — so the connector-state pattern is exercised, not faked.
+#
+# Created 2026-07-27 (feat/growth-g5): new module.
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+import pytest
+from pocketpaw_ee.cloud.growth import connector as growth_connector
+from pocketpaw_ee.cloud.growth import email_dispatch
+from pocketpaw_ee.cloud.growth import service as growth_service
+from pocketpaw_ee.cloud.growth import worker as growth_worker
+from pocketpaw_ee.cloud.models.connector import WorkspaceConnector
+from pocketpaw_ee.cloud.models.draft import Draft as _DraftDoc
+from pocketpaw_ee.cloud.models.message_log import MessageLog as _MessageLogDoc
+from pocketpaw_ee.cloud.models.prospect import Prospect as _ProspectDoc
+
+WORKSPACE = "w1"
+TOKEN = "mt-super-secret-token-9f3a"
+SENDING_DOMAIN = "outbound-paw.dev"
+
+# ---------------------------------------------------------------------------
+# Harness
+# ---------------------------------------------------------------------------
+
+
+class _Recorder:
+    """Captures the requests the connector puts on the wire."""
+
+    def __init__(self, response_factory) -> None:
+        self.requests: list[httpx.Request] = []
+        self._response_factory = response_factory
+
+    def handler(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        return self._response_factory(request)
+
+
+def _ok_response(_request: httpx.Request) -> httpx.Response:
+    return httpx.Response(
+        200, json={"success": True, "message_ids": ["0c7fd939-0000-4000-8000-000000000001"]}
+    )
+
+
+@pytest.fixture
+def sending_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(growth_connector.SENDING_DOMAIN_ENV, SENDING_DOMAIN)
+    monkeypatch.setenv(growth_connector.PUBLIC_BASE_URL_ENV, "https://app.pocketpaw.test")
+
+
+def _install_transport(monkeypatch: pytest.MonkeyPatch, recorder: _Recorder) -> None:
+    def _client() -> httpx.AsyncClient:
+        return httpx.AsyncClient(transport=httpx.MockTransport(recorder.handler), timeout=5.0)
+
+    monkeypatch.setattr(growth_connector, "_http_client", _client)
+
+
+async def _seed_connector(config: dict[str, Any] | None = None) -> None:
+    """Create the workspace's enabled Mailtrap connector row."""
+    await WorkspaceConnector(
+        workspace=WORKSPACE,
+        name=growth_connector.MAILTRAP_CONNECTOR_NAME,
+        enabled=True,
+        scope="workspace",
+        config=config if config is not None else {growth_connector.TOKEN_KEY: TOKEN},
+    ).insert()
+
+
+async def _seed_draft(status: str = "approved", *, channel: str = "email") -> tuple[str, str]:
+    """Insert a prospect + a draft in the given status. Returns (draft_id, prospect_id)."""
+    prospect = _ProspectDoc(
+        workspace=WORKSPACE,
+        name="Sam Founder",
+        company="Acme Dental",
+        domain="acme-dental.com",
+        source="manual",
+        emails=["sam@acme-dental.com"],
+    )
+    await prospect.insert()
+    draft = _DraftDoc(
+        workspace=WORKSPACE,
+        prospect_id=str(prospect.id),
+        channel=channel,
+        subject="Quick question about Acme Dental",
+        body="Hi Sam — noticed you run three clinics. Worth a look?",
+        status=status,
+    )
+    await draft.insert()
+    return str(draft.id), str(prospect.id)
+
+
+async def _logs() -> list[_MessageLogDoc]:
+    return await _MessageLogDoc.find({"workspace": WORKSPACE}).to_list()
+
+
+# ---------------------------------------------------------------------------
+# 1. Happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_approved_draft_sends_once_flips_to_sent_and_logs(mongo_db, sending_env, monkeypatch):
+    recorder = _Recorder(_ok_response)
+    _install_transport(monkeypatch, recorder)
+    await _seed_connector()
+    draft_id, prospect_id = await _seed_draft("approved")
+
+    await email_dispatch.dispatch_email(draft_id)
+
+    # Sent exactly once, to the right endpoint, with the right payload.
+    assert len(recorder.requests) == 1
+    request = recorder.requests[0]
+    assert str(request.url) == growth_connector.MAILTRAP_SEND_URL
+    assert request.method == "POST"
+    assert request.headers["Api-Token"] == TOKEN
+    import json
+
+    payload = json.loads(request.content)
+    assert payload["from"]["email"] == f"outreach@{SENDING_DOMAIN}"
+    assert payload["to"] == [{"email": "sam@acme-dental.com"}]
+    assert payload["subject"] == "Quick question about Acme Dental"
+    assert payload["text"].startswith("Hi Sam")
+
+    # The draft moved through the gate seam.
+    draft = await _DraftDoc.get(draft_id)
+    assert draft.status == "sent"
+
+    # One audit row, marked sent, carrying the provider's message id.
+    logs = await _logs()
+    assert len(logs) == 1
+    row = logs[0]
+    assert row.outcome == "sent"
+    assert row.provider == "mailtrap"
+    assert row.channel == "email"
+    assert row.draft_id == draft_id
+    assert row.prospect_id == prospect_id
+    assert row.to_address == "sam@acme-dental.com"
+    assert row.provider_message_id == "0c7fd939-0000-4000-8000-000000000001"
+    assert row.sent_at is not None
+    assert row.error is None
+
+
+@pytest.mark.asyncio
+async def test_worker_dispatch_job_routes_email_to_the_dispatcher(
+    mongo_db, sending_env, monkeypatch
+):
+    """The arq job's ``email`` branch reaches the real delivery path."""
+    recorder = _Recorder(_ok_response)
+    _install_transport(monkeypatch, recorder)
+    await _seed_connector()
+    draft_id, _ = await _seed_draft("approved")
+
+    await growth_worker.dispatch({}, draft_id, "email")
+
+    assert len(recorder.requests) == 1
+    assert (await _DraftDoc.get(draft_id)).status == "sent"
+
+
+@pytest.mark.asyncio
+async def test_from_name_is_included_when_configured(mongo_db, sending_env, monkeypatch):
+    recorder = _Recorder(_ok_response)
+    _install_transport(monkeypatch, recorder)
+    await _seed_connector(
+        {
+            growth_connector.TOKEN_KEY: TOKEN,
+            growth_connector.FROM_EMAIL_KEY: f"sam@{SENDING_DOMAIN}",
+            growth_connector.FROM_NAME_KEY: "Sam at Paw",
+        }
+    )
+    draft_id, _ = await _seed_draft("approved")
+
+    await email_dispatch.dispatch_email(draft_id)
+
+    import json
+
+    payload = json.loads(recorder.requests[0].content)
+    assert payload["from"] == {"email": f"sam@{SENDING_DOMAIN}", "name": "Sam at Paw"}
+
+
+# ---------------------------------------------------------------------------
+# 2. The gate — only ``approved`` sends
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", ["draft", "proposed", "sent", "replied", "rejected"])
+async def test_non_approved_draft_never_sends_and_changes_nothing(
+    mongo_db, sending_env, monkeypatch, status
+):
+    recorder = _Recorder(_ok_response)
+    _install_transport(monkeypatch, recorder)
+    await _seed_connector()
+    draft_id, _ = await _seed_draft(status)
+
+    await email_dispatch.dispatch_email(draft_id)
+
+    assert recorder.requests == []
+    assert (await _DraftDoc.get(draft_id)).status == status
+    assert await _logs() == []
+
+
+@pytest.mark.asyncio
+async def test_missing_draft_is_a_no_op(mongo_db, sending_env, monkeypatch):
+    recorder = _Recorder(_ok_response)
+    _install_transport(monkeypatch, recorder)
+    await _seed_connector()
+
+    await email_dispatch.dispatch_email("not-an-object-id")
+
+    assert recorder.requests == []
+    assert await _logs() == []
+
+
+@pytest.mark.asyncio
+async def test_non_email_channel_draft_is_refused(mongo_db, sending_env, monkeypatch):
+    """The email dispatcher never touches another channel's draft."""
+    recorder = _Recorder(_ok_response)
+    _install_transport(monkeypatch, recorder)
+    await _seed_connector()
+    draft_id, _ = await _seed_draft("approved", channel="linkedin")
+
+    await email_dispatch.dispatch_email(draft_id)
+
+    assert recorder.requests == []
+    assert (await _DraftDoc.get(draft_id)).status == "approved"
+
+
+# ---------------------------------------------------------------------------
+# 3. Failure path — retryable, recorded, silent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_provider_rejection_logs_failed_and_leaves_the_draft_approved(
+    mongo_db, sending_env, monkeypatch
+):
+    recorder = _Recorder(lambda _r: httpx.Response(422, json={"errors": ["sender not verified"]}))
+    _install_transport(monkeypatch, recorder)
+    await _seed_connector()
+    draft_id, _ = await _seed_draft("approved")
+
+    # No exception escapes the job.
+    await email_dispatch.dispatch_email(draft_id)
+
+    assert len(recorder.requests) == 1
+    assert (await _DraftDoc.get(draft_id)).status == "approved"  # retryable
+    logs = await _logs()
+    assert len(logs) == 1
+    assert logs[0].outcome == "failed"
+    assert logs[0].sent_at is None
+    assert logs[0].provider_message_id is None
+    assert "422" in (logs[0].error or "")
+
+
+@pytest.mark.asyncio
+async def test_transport_error_logs_failed_without_raising(mongo_db, sending_env, monkeypatch):
+    def _boom(_request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused")
+
+    recorder = _Recorder(_boom)
+    _install_transport(monkeypatch, recorder)
+    await _seed_connector()
+    draft_id, _ = await _seed_draft("approved")
+
+    await email_dispatch.dispatch_email(draft_id)
+
+    assert (await _DraftDoc.get(draft_id)).status == "approved"
+    logs = await _logs()
+    assert len(logs) == 1
+    assert logs[0].outcome == "failed"
+    assert "ConnectError" in (logs[0].error or "")
+
+
+@pytest.mark.asyncio
+async def test_unconfigured_connector_fails_closed_with_no_http_call(
+    mongo_db, sending_env, monkeypatch
+):
+    """No connector row at all — nothing goes on the wire."""
+    recorder = _Recorder(_ok_response)
+    _install_transport(monkeypatch, recorder)
+    draft_id, _ = await _seed_draft("approved")
+
+    await email_dispatch.dispatch_email(draft_id)
+
+    assert recorder.requests == []
+    assert (await _DraftDoc.get(draft_id)).status == "approved"
+    logs = await _logs()
+    assert len(logs) == 1
+    assert logs[0].outcome == "failed"
+    assert "not configured" in (logs[0].error or "")
+
+
+@pytest.mark.asyncio
+async def test_disabled_connector_revokes_sending(mongo_db, sending_env, monkeypatch):
+    """Disabling the connector row immediately stops sends — the state store
+    only resolves ENABLED rows, so there is no separate kill switch."""
+    recorder = _Recorder(_ok_response)
+    _install_transport(monkeypatch, recorder)
+    await WorkspaceConnector(
+        workspace=WORKSPACE,
+        name=growth_connector.MAILTRAP_CONNECTOR_NAME,
+        enabled=False,
+        scope="workspace",
+        config={growth_connector.TOKEN_KEY: TOKEN},
+    ).insert()
+    draft_id, _ = await _seed_draft("approved")
+
+    await email_dispatch.dispatch_email(draft_id)
+
+    assert recorder.requests == []
+    assert (await _DraftDoc.get(draft_id)).status == "approved"
+
+
+@pytest.mark.asyncio
+async def test_prospect_without_an_email_fails_closed(mongo_db, sending_env, monkeypatch):
+    recorder = _Recorder(_ok_response)
+    _install_transport(monkeypatch, recorder)
+    await _seed_connector()
+    prospect = _ProspectDoc(
+        workspace=WORKSPACE,
+        name="No Email",
+        company="Acme",
+        domain="acme.com",
+        source="manual",
+        emails=[],
+    )
+    await prospect.insert()
+    draft = _DraftDoc(
+        workspace=WORKSPACE,
+        prospect_id=str(prospect.id),
+        channel="email",
+        subject="Hello",
+        body="Body",
+        status="approved",
+    )
+    await draft.insert()
+
+    await email_dispatch.dispatch_email(str(draft.id))
+
+    assert recorder.requests == []
+    logs = await _logs()
+    assert len(logs) == 1 and logs[0].outcome == "failed"
+
+
+# ---------------------------------------------------------------------------
+# 4. Credential hygiene
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_token_never_reaches_logs_or_the_audit_row_even_when_echoed(
+    mongo_db, sending_env, monkeypatch, caplog
+):
+    """The provider echoes the token in its error body — nothing persists it.
+
+    Grep-style: after a full failing dispatch, the token must not appear in any
+    captured log record, in any MessageLog field, or in the draft row.
+    """
+
+    def _echoing_error(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, text=f"invalid api token: {TOKEN}")
+
+    recorder = _Recorder(_echoing_error)
+    _install_transport(monkeypatch, recorder)
+    await _seed_connector()
+    draft_id, _ = await _seed_draft("approved")
+
+    with caplog.at_level(logging.DEBUG):
+        await email_dispatch.dispatch_email(draft_id)
+
+    logged = "\n".join(
+        [r.getMessage() for r in caplog.records] + [str(r.args) for r in caplog.records]
+    )
+    assert TOKEN not in logged
+
+    logs = await _logs()
+    assert len(logs) == 1
+    assert TOKEN not in str(logs[0].model_dump())
+    assert logs[0].outcome == "failed"
+
+    draft = await _DraftDoc.get(draft_id)
+    assert TOKEN not in str(draft.model_dump())
+
+
+@pytest.mark.asyncio
+async def test_success_path_leaves_no_token_in_logs(mongo_db, sending_env, monkeypatch, caplog):
+    recorder = _Recorder(_ok_response)
+    _install_transport(monkeypatch, recorder)
+    await _seed_connector()
+    draft_id, _ = await _seed_draft("approved")
+
+    with caplog.at_level(logging.DEBUG):
+        await email_dispatch.dispatch_email(draft_id)
+
+    logged = "\n".join(
+        [r.getMessage() for r in caplog.records] + [str(r.args) for r in caplog.records]
+    )
+    assert TOKEN not in logged
+    assert TOKEN not in str((await _logs())[0].model_dump())
+
+
+@pytest.mark.asyncio
+async def test_draft_response_dto_carries_no_credential(mongo_db, sending_env, monkeypatch):
+    """The public draft envelope after a send is credential-free."""
+    recorder = _Recorder(_ok_response)
+    _install_transport(monkeypatch, recorder)
+    await _seed_connector()
+    draft_id, _ = await _seed_draft("approved")
+
+    await email_dispatch.dispatch_email(draft_id)
+
+    response = await growth_service.gate_transition(WORKSPACE, draft_id, "replied")
+    assert TOKEN not in response.model_dump_json()
+
+
+# ---------------------------------------------------------------------------
+# 5. Sending-domain guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unset_sending_domain_refuses_to_send(mongo_db, monkeypatch):
+    monkeypatch.delenv(growth_connector.SENDING_DOMAIN_ENV, raising=False)
+    recorder = _Recorder(_ok_response)
+    _install_transport(monkeypatch, recorder)
+    await _seed_connector()
+    draft_id, _ = await _seed_draft("approved")
+
+    await email_dispatch.dispatch_email(draft_id)
+
+    assert recorder.requests == []
+    assert (await _DraftDoc.get(draft_id)).status == "approved"
+    assert growth_connector.SENDING_DOMAIN_ENV in ((await _logs())[0].error or "")
+
+
+@pytest.mark.asyncio
+async def test_from_address_off_the_sending_domain_refuses_to_send(
+    mongo_db, sending_env, monkeypatch
+):
+    recorder = _Recorder(_ok_response)
+    _install_transport(monkeypatch, recorder)
+    await _seed_connector(
+        {
+            growth_connector.TOKEN_KEY: TOKEN,
+            growth_connector.FROM_EMAIL_KEY: "sam@pocketpaw.test",  # the apex, not the secondary
+        }
+    )
+    draft_id, _ = await _seed_draft("approved")
+
+    await email_dispatch.dispatch_email(draft_id)
+
+    assert recorder.requests == []
+    assert (await _DraftDoc.get(draft_id)).status == "approved"
+    assert "sending domain" in ((await _logs())[0].error or "")
+
+
+def test_sending_domain_may_not_be_the_deployment_apex(monkeypatch):
+    """Cold outreach on the apex gambles the transactional domain's reputation."""
+    monkeypatch.setenv(growth_connector.PUBLIC_BASE_URL_ENV, "https://app.pocketpaw.test")
+    monkeypatch.setenv(growth_connector.SENDING_DOMAIN_ENV, "app.pocketpaw.test")
+
+    with pytest.raises(growth_connector.EmailSendError, match="apex"):
+        growth_connector.resolve_sending_domain()
+
+
+def test_sending_domain_is_normalised(monkeypatch):
+    monkeypatch.setenv(growth_connector.PUBLIC_BASE_URL_ENV, "https://app.pocketpaw.test")
+    monkeypatch.setenv(growth_connector.SENDING_DOMAIN_ENV, "  WWW.Outbound-Paw.dev. ")
+
+    assert growth_connector.resolve_sending_domain() == "outbound-paw.dev"


### PR DESCRIPTION
Stacked on #1803. The first real dispatcher — approved email drafts now actually leave the building.

The job loads the draft, refuses anything that isn't `approved` without touching the provider, sends via a per-workspace Mailtrap connector, writes a MessageLog audit row, then flips the draft through the existing `gate_transition` seam. No second status path.

## Decisions worth a look
- **The connector declares zero actions.** Credentials live in connector state like ship's, but a generic REST send action would be reachable from the agent/connector-execute surface — and that's a road around the approval gate. The token is read at send time and only resolves for *enabled* rows, so disabling the connector revokes sending with no separate kill switch.
- **`GROWTH_SENDING_DOMAIN` fails closed** — unset means nothing sends. The from-address is checked against it, and a value matching the deployment's own host is refused: cold outreach on the apex gambles the domain that carries password resets and invoices.
- **Record, then flip.** The audit row is written before the status change, so a message that physically left always has a record even if the flip fails.
- **Failures stay retryable** — provider error writes a failed MessageLog row and leaves the draft `approved`; nothing raises. The worker runs `max_tries=1` on purpose so outbound work is never auto-retried into a double-send.
- Every error string passes through a scrubber that strips the token; the hygiene test goes red if it's removed.

## Verification
215 passed across growth, ship and instinct (22 new). Coverage includes: exact send payload and headers, parametrized non-approved statuses making no provider call, provider rejection and transport failure leaving the draft retryable, fail-closed on unconfigured/disabled connector, sending-domain guards, and a credential-leak sweep across logs, the audit row, the draft row and the response DTO — including a 401 body that echoes the token back. Network-free via MockTransport. Both import-linter configs green; ruff and mypy clean on the new modules.

Pre-existing connector-suite failures confirmed identical with this diff stashed.