### PR TITLE
growth: follow-up sweep that proposes, never sends

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -93,6 +93,14 @@ Security review follow-up: documented per-route growth RBAC
 and the fact that a _growth_send blob can only be minted by this route —
 the generic POST /instinct/actions refuses reserved gated parameter keys.
 
+Updated: 2026-07-27 (feat/growth-g7) — added the Growth — Follow-ups section:
+the daily `growth.followup_sweep` arq cron on the `growth` queue turns a send
+that went quiet into a `variant: "follow_up"` draft filed back through the
+same `_growth_send` gate (proposed, never approved or sent), capped at
+GROWTH_FOLLOWUP_MAX per prospect+channel after which the prospect is retired
+to `dead`. Documented both env knobs (GROWTH_FOLLOWUP_DELAY_DAYS,
+GROWTH_FOLLOWUP_MAX).
+
 Updated: 2026-07-11 (feat/real-pipeline-s1) — documented the Fabric — Transform
 Mappings section: GET/POST/DELETE /fabric/ingest/mappings (author the
 workspace's source→Fabric mappings, now with a "connector" source_kind that
@@ -1722,3 +1730,70 @@ closed), and `mark_failed` on the Action if the enqueue fails. On
 **reject** the draft flips to `rejected` and nothing is enqueued. The
 dispatch job body is a logging stub in this slice — G-5/G-6 implement the
 actual per-channel delivery and the `sent` flip.
+
+## Growth — Follow-ups
+
+Final slice of the `/growth` v1 outbound engine (G-7): the loop that closes
+the cycle. A draft that went out and got no reply produces a **second draft**
+— a short nudge — which is filed straight back into the Instinct Tray through
+the same `_growth_send` gate. There is **no new API surface** here and no new
+authority: the sweep's terminal state is a `proposed` draft plus a pending
+Action a human decides on, exactly like a first touch typed by hand. Nothing
+auto-approves and nothing auto-sends.
+
+**Where it runs.** `growth.followup_sweep`, a daily arq **cron** at 13:00 UTC
+on the dedicated `growth` queue
+(`pocketpaw_ee.cloud.growth.worker.WorkerSettings.cron_jobs`, `unique=True`
+so a horizontally-scaled worker fleet runs one tick, not N). Deploy it with
+the same process that already serves `growth.dispatch`:
+
+```bash
+arq pocketpaw_ee.cloud.growth.worker.WorkerSettings
+```
+
+**What it does**, per (workspace, prospect, channel) thread:
+
+1. Finds the thread's most recent `sent` draft and checks it is older than
+   `GROWTH_FOLLOWUP_DELAY_DAYS`. The clock starts at the LAST touch, not the
+   first — a thread that already had a nudge waits the full delay again.
+2. Skips the thread when the prospect is `replied` (they answered) or `dead`
+   (already retired), or when any draft in the thread is `replied`.
+3. Skips the thread when a follow-up is already **open** in it (`draft`,
+   `proposed` or `approved`) — that one is the human's move. This is also
+   what makes the sweep idempotent: the follow-up it filed on the last pass
+   blocks the next one, so re-running a pass creates nothing.
+4. Counts the thread's non-rejected follow-ups. At `GROWTH_FOLLOWUP_MAX` the
+   prospect is retired to `status: "dead"` and nothing further is created —
+   the sweep never touches them again. (A follow-up a human **rejected**
+   doesn't burn a cap slot.)
+5. Otherwise: creates a `variant: "follow_up"` draft (copy templated in code
+   from the thread's first touch — a placeholder the `/growth` crew skill
+   replaces; on email the subject is the original's, `Re:`-prefixed, so the
+   nudge threads under it) and immediately runs it through the existing
+   propose path — filing the `_growth_send` Action and flipping the draft to
+   `proposed`.
+
+**Who proposes.** A cron has no user, but the gate re-checks the proposer's
+*current* `growth.manage` role at execute time, so a "system"-proposed
+follow-up would be approvable and then fail closed at dispatch. The sweep
+therefore **inherits the human** who proposed the thread's last send, read off
+that draft's own `_growth_send` Action — they become the follow-up's trigger
+source, its Tray assignee, and the identity the execute-time re-check runs
+against. When no proposer can be resolved (a draft that reached `sent` with no
+Tray record) the thread is skipped: a proposal nobody can execute is worse
+than none.
+
+**Config.** Both read from the environment at sweep time, so a change takes
+effect on the next tick without a redeploy. An unparseable or out-of-range
+value logs a warning and falls back to the default — a typo must not take the
+outbound loop down.
+
+| Env var | Default | Meaning |
+|---|---|---|
+| `GROWTH_FOLLOWUP_DELAY_DAYS` | `4` | Days of silence after a send before its follow-up comes due. Minimum `1`. |
+| `GROWTH_FOLLOWUP_MAX` | `2` | Follow-ups allowed per (prospect, channel). On the pass where a capped thread comes due again, the prospect is set to `dead` instead. |
+
+**Send timestamp.** The age check reads the draft's `sent_at` when the
+dispatch worker's send record supplies one, and otherwise falls back to
+`updated_at` — which, for a draft sitting in `sent`, is the moment of the
+`sent` transition, since the status flip is the last write to that row.

--- a/ee/pocketpaw_ee/cloud/growth/followups.py
+++ b/ee/pocketpaw_ee/cloud/growth/followups.py
@@ -1,0 +1,442 @@
+# ee/pocketpaw_ee/cloud/growth/followups.py — the daily follow-up sweep that
+# closes the /growth outbound cycle (G-7).
+#
+# A draft that went out N days ago and got no reply produces a SECOND draft —
+# a short nudge — which is filed straight back into the Instinct tray through
+# the EXISTING ``_growth_send`` propose path. Nothing here approves anything
+# and nothing here sends: the sweep's terminal state is a ``proposed`` draft
+# plus a pending Action a human decides on, exactly like a first touch typed
+# by hand. That is the whole point of the slice — the loop closes without the
+# gate opening.
+#
+# Sweep rules, per (workspace, prospect, channel) thread:
+#   * the thread's most recent SENT draft must be older than
+#     ``GROWTH_FOLLOWUP_DELAY_DAYS`` (default 4),
+#   * the prospect must not be ``replied`` (they answered — stop) or ``dead``
+#     (already retired), and no draft in the thread may be ``replied``,
+#   * no follow-up may already be OPEN in the thread (draft / proposed /
+#     approved) — that one is the human's move, not ours. This is also what
+#     makes the sweep idempotent: the follow-up it just filed blocks the next
+#     pass,
+#   * at most ``GROWTH_FOLLOWUP_MAX`` (default 2) follow-ups per thread. On
+#     the pass where a capped thread comes due again, the prospect is retired
+#     to ``dead`` instead — we stop touching them.
+#
+# WHO PROPOSES: a cron has no user, but the gate's execute-time RBAC re-check
+# (``executor._proposer_still_authorized``) resolves a REAL user, so a
+# "system"-proposed follow-up would be approvable and then fail closed at
+# dispatch. The sweep therefore inherits the human who proposed the thread's
+# last send — read off that draft's own ``_growth_send`` Action. Unresolvable
+# proposer → the thread is SKIPPED, because a follow-up nobody can execute is
+# worse than none.
+#
+# Time is INJECTED (``now=``) rather than read from the clock inside the loop,
+# so the tests freeze it instead of sleeping.
+#
+# Created 2026-07-27 (feat/growth-g7): new module.
+
+"""Daily follow-up sweep for the /growth outbound engine."""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from uuid import uuid4
+
+logger = logging.getLogger(__name__)
+
+# The arq job name the cron entry registers under on the ``growth`` queue.
+# Explicit + dotted (like ``GROWTH_DISPATCH_JOB_NAME``) so the wire name
+# survives a rename of the Python function.
+GROWTH_FOLLOWUP_SWEEP_JOB_NAME = "growth.followup_sweep"
+
+# Config defaults. Both are read from the environment at CALL time (not
+# import) so a redeploy-free change and the tests' monkeypatching both work.
+DEFAULT_FOLLOWUP_DELAY_DAYS = 4
+DEFAULT_FOLLOWUP_MAX = 2
+
+# How many sent drafts one pass looks at. The scan is oldest-first, so a
+# backlog over this cap sheds the NEWEST sends (the ones furthest from being
+# due) and the next daily pass picks them up.
+SENT_SCAN_LIMIT = 500
+# How far back the proposer lookup reads a workspace's Instinct actions.
+ACTION_SCAN_LIMIT = 500
+
+# A follow-up in one of these statuses is still the human's move — the sweep
+# must not stack a second one on top of it.
+_OPEN_STATUSES = frozenset({"draft", "proposed", "approved"})
+# A rejected follow-up was refused by a human; it doesn't burn a cap slot.
+_UNCOUNTED_STATUSES = frozenset({"rejected"})
+# Prospect statuses the sweep never touches.
+_TERMINAL_PROSPECT_STATUSES = frozenset({"replied", "dead"})
+
+
+def _int_env(name: str, default: int, *, minimum: int) -> int:
+    """Read a small positive integer from the environment, fail-soft.
+
+    A missing, blank, non-numeric or out-of-range value logs and falls back to
+    the default — a typo'd env var must not take the outbound loop down.
+    """
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning("growth: %s=%r is not an integer — using %d", name, raw, default)
+        return default
+    if value < minimum:
+        logger.warning(
+            "growth: %s=%d is below the %d minimum — using %d", name, value, minimum, default
+        )
+        return default
+    return value
+
+
+def followup_delay_days() -> int:
+    """Days of silence after a send before its follow-up comes due."""
+    return _int_env("GROWTH_FOLLOWUP_DELAY_DAYS", DEFAULT_FOLLOWUP_DELAY_DAYS, minimum=1)
+
+
+def followup_max() -> int:
+    """Maximum follow-ups per (prospect, channel) before the prospect is retired."""
+    return _int_env("GROWTH_FOLLOWUP_MAX", DEFAULT_FOLLOWUP_MAX, minimum=0)
+
+
+# ---------------------------------------------------------------------------
+# Copy
+# ---------------------------------------------------------------------------
+
+# PLACEHOLDER COPY — deliberately dumb, deliberately in code. One short,
+# non-pushy nudge per channel that references the original touch so the
+# recipient has context without a re-pitch. The /growth crew skill replaces
+# this with real per-prospect copy; until then a human still reads every word
+# in The Tray before it can go anywhere, so a bland nudge is safe and an
+# unreviewed clever one would not be.
+_FOLLOWUP_TEMPLATES: dict[str, str] = {
+    "email": (
+        "Hi {name},\n\n"
+        "Following up on my note about {company} — no worries if the timing is off.\n\n"
+        "If it's useful I can send over the short version, otherwise I'll leave you to it.\n\n"
+        "Original message:\n{quoted}"
+    ),
+    "linkedin": (
+        "Hi {name} — circling back on my earlier note about {company}. "
+        "Happy to drop the short version if it's useful, otherwise no worries at all."
+    ),
+    "whatsapp": (
+        "Hi {name}, following up on my earlier message about {company}. "
+        "No rush — happy to send the short version if it's useful."
+    ),
+}
+# Any channel we have no template for falls back to this.
+_FOLLOWUP_FALLBACK = (
+    "Hi {name} — following up on my earlier message about {company}. "
+    "No worries if the timing is off."
+)
+# How much of the original touch gets quoted back in the email nudge.
+_QUOTE_LIMIT = 500
+
+
+def render_followup(
+    *, channel: str, prospect_name: str, prospect_company: str, first_touch: dict[str, Any]
+) -> tuple[str | None, str]:
+    """Render the follow-up's ``(subject, body)`` from the original touch.
+
+    ``subject`` is email-only (the DTO refuses one on the other channels) and
+    is the original's, ``Re:``-prefixed — so the nudge threads under the first
+    touch in the recipient's client instead of arriving as a new conversation.
+    """
+    template = _FOLLOWUP_TEMPLATES.get(channel, _FOLLOWUP_FALLBACK)
+    original_body = str(first_touch.get("body") or "")
+    quoted = original_body[:_QUOTE_LIMIT].strip()
+    body = template.format(
+        name=prospect_name or "there",
+        company=prospect_company or "your team",
+        quoted=quoted,
+    )
+
+    subject: str | None = None
+    if channel == "email":
+        original_subject = str(first_touch.get("subject") or "").strip()
+        if original_subject:
+            subject = (
+                original_subject
+                if original_subject.lower().startswith("re:")
+                else f"Re: {original_subject}"
+            )
+        else:
+            subject = f"Following up — {prospect_company}".strip()
+        subject = subject[:200]
+    return subject, body
+
+
+# ---------------------------------------------------------------------------
+# Proposer resolution
+# ---------------------------------------------------------------------------
+
+
+async def _proposer_index(workspace_id: str) -> dict[str, str]:
+    """Map ``draft_id -> proposer user id`` for one workspace's gated sends.
+
+    Read off each ``_growth_send`` Action's own blob. Newest-first, so a draft
+    that somehow carries two proposals resolves to the most recent one. Read
+    ONLY — the sweep never writes to Instinct outside the propose path. Any
+    failure yields an empty map, which makes every thread in that workspace
+    skip rather than file an unexecutable follow-up.
+    """
+    try:
+        from pocketpaw.stores import get_instinct_store
+        from pocketpaw_ee.cloud.growth.propose import GROWTH_SEND_PARAM_KEY
+
+        store = get_instinct_store(workspace_id=workspace_id or None)
+        actions = await store.list_actions(
+            pocket_id=workspace_id, workspace_id=workspace_id, limit=ACTION_SCAN_LIMIT
+        )
+    except Exception:  # noqa: BLE001 — an unreadable tray must not crash the sweep
+        logger.warning(
+            "growth: could not read the Instinct tray for workspace %s — skipping its "
+            "follow-ups this pass",
+            workspace_id,
+            exc_info=True,
+        )
+        return {}
+
+    index: dict[str, str] = {}
+    for action in actions:
+        blob = (getattr(action, "parameters", None) or {}).get(GROWTH_SEND_PARAM_KEY)
+        if not isinstance(blob, dict):
+            continue
+        draft_id = str(blob.get("draft_id") or "")
+        requested_by = str(blob.get("requested_by") or "")
+        if draft_id and requested_by and draft_id not in index:
+            index[draft_id] = requested_by
+    return index
+
+
+def _system_context(workspace_id: str, user_id: str, now: datetime) -> Any:
+    """A RequestContext standing in for the human whose thread this continues.
+
+    The propose path is written against a request envelope; the sweep has no
+    request, so it mints one carrying the inherited proposer. Everything
+    downstream (the Action's trigger, its assignee, the execute-time RBAC
+    re-check) then resolves to a real user — which is exactly what makes the
+    follow-up approvable in The Tray.
+    """
+    from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id=f"growth-followup-{uuid4().hex[:12]}",
+        scope=ScopeKind.WORKSPACE,
+        started_at=now,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The sweep
+# ---------------------------------------------------------------------------
+
+
+def _as_utc(value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    return value.replace(tzinfo=UTC) if value.tzinfo is None else value
+
+
+def _latest_sent_per_thread(rows: list[dict[str, Any]]) -> dict[tuple[str, str, str], dict]:
+    """Collapse the sent-draft scan to the newest send per thread.
+
+    The delay is measured from the LAST touch, not the first — otherwise a
+    thread that already had a follow-up would come due again immediately.
+    """
+    threads: dict[tuple[str, str, str], dict[str, Any]] = {}
+    for row in rows:
+        key = (str(row["workspace_id"]), str(row["prospect_id"]), str(row["channel"]))
+        current = threads.get(key)
+        row_sent = _as_utc(row.get("sent_at"))
+        if current is None:
+            threads[key] = row
+            continue
+        current_sent = _as_utc(current.get("sent_at"))
+        if row_sent is not None and (current_sent is None or row_sent > current_sent):
+            threads[key] = row
+    return threads
+
+
+async def _retract(growth_service: Any, workspace_id: str, draft_id: str) -> None:
+    """Reject a follow-up draft whose proposal never made it to the tray.
+
+    Best-effort — the caller is already unwinding, so a failure here just gets
+    logged. ``draft → rejected`` is a legal edge and terminal, so the retracted
+    row neither blocks the thread nor burns a cap slot.
+    """
+    try:
+        await growth_service.gate_transition(workspace_id, draft_id, "rejected")
+    except Exception:  # noqa: BLE001 — cleanup on an error path
+        logger.warning(
+            "growth: could not retract un-proposed follow-up draft %s — it will "
+            "block this thread until a human clears it",
+            draft_id,
+            exc_info=True,
+        )
+
+
+async def followup_sweep(ctx: dict[str, Any], *, now: datetime | None = None) -> dict[str, int]:
+    """Propose a follow-up for every outbound thread that went quiet (G-7).
+
+    Registered as a daily arq cron on the ``growth`` queue. ``ctx`` is arq's
+    job context (unused — the sweep resolves everything it needs itself);
+    ``now`` is the injectable clock the tests freeze.
+
+    Returns a counter dict for the worker log: how many threads were looked
+    at, how many follow-ups were proposed, how many prospects were retired,
+    and how many threads were skipped (not due, replied, already open, or no
+    resolvable proposer). NEVER raises — one bad thread must not take the
+    whole daily pass down.
+    """
+    from pocketpaw_ee.cloud.growth import service as growth_service
+    from pocketpaw_ee.cloud.growth.dto import CreateDraftRequest
+
+    now = _as_utc(now) or datetime.now(UTC)
+    delay_days = followup_delay_days()
+    max_followups = followup_max()
+    cutoff = now - timedelta(days=delay_days)
+
+    counters = {"threads": 0, "created": 0, "retired": 0, "skipped": 0}
+    proposer_cache: dict[str, dict[str, str]] = {}
+
+    try:
+        sent_rows = await growth_service.list_sent_drafts_for_followup(limit=SENT_SCAN_LIMIT)
+    except Exception:  # noqa: BLE001 — a failed scan is a no-op pass, not a crash
+        logger.exception("growth: follow-up sweep could not read sent drafts")
+        return counters
+
+    for (workspace_id, prospect_id, channel), latest in _latest_sent_per_thread(sent_rows).items():
+        counters["threads"] += 1
+        try:
+            sent_at = _as_utc(latest.get("sent_at"))
+            if sent_at is None or sent_at > cutoff:
+                counters["skipped"] += 1
+                continue
+
+            prospect = await growth_service.get_prospect_system(workspace_id, prospect_id)
+            if prospect.status in _TERMINAL_PROSPECT_STATUSES:
+                counters["skipped"] += 1
+                continue
+
+            thread = await growth_service.list_channel_drafts(workspace_id, prospect_id, channel)
+            if any(d["status"] == "replied" for d in thread):
+                # The draft-level reply signal, for a prospect row that hasn't
+                # caught up yet. Same verdict: they answered, stop nudging.
+                counters["skipped"] += 1
+                continue
+
+            followups = [d for d in thread if d["variant"] == "follow_up"]
+            if any(d["status"] in _OPEN_STATUSES for d in followups):
+                # One is already waiting on a human — including the one this
+                # sweep filed on its last pass. This is the idempotency guard.
+                counters["skipped"] += 1
+                continue
+
+            counted = [d for d in followups if d["status"] not in _UNCOUNTED_STATUSES]
+            if len(counted) >= max_followups:
+                await growth_service.mark_prospect_dead(workspace_id, prospect_id)
+                counters["retired"] += 1
+                logger.info(
+                    "growth: prospect %s retired to dead after %d follow-ups on '%s' "
+                    "with no reply (workspace=%s)",
+                    prospect_id,
+                    len(counted),
+                    channel,
+                    workspace_id,
+                )
+                continue
+
+            if workspace_id not in proposer_cache:
+                proposer_cache[workspace_id] = await _proposer_index(workspace_id)
+            fallback = thread[0] if thread else latest
+            first_touch = next((d for d in thread if d["variant"] == "first_touch"), fallback)
+            index = proposer_cache[workspace_id]
+            proposer = index.get(str(latest["id"])) or index.get(str(first_touch["id"]))
+            if not proposer:
+                logger.warning(
+                    "growth: no proposer resolvable for draft %s — skipping its follow-up "
+                    "(an unapprovable proposal is worse than none)",
+                    latest["id"],
+                )
+                counters["skipped"] += 1
+                continue
+
+            subject, body = render_followup(
+                channel=channel,
+                prospect_name=prospect.name,
+                prospect_company=prospect.company,
+                first_touch=first_touch,
+            )
+            draft = await growth_service.create_followup_draft(
+                workspace_id,
+                prospect_id,
+                CreateDraftRequest(
+                    channel=channel,  # type: ignore[arg-type]
+                    subject=subject,
+                    body=body,
+                    variant="follow_up",
+                    demo_url=first_touch.get("demo_url"),
+                ),
+            )
+            # The EXISTING gate path: files the ``_growth_send`` Action and
+            # flips the draft draft→proposed. It stops there — approval and
+            # dispatch stay the human's, exactly as for a first touch.
+            try:
+                await growth_service.propose_send(
+                    _system_context(workspace_id, proposer, now), draft.id
+                )
+            except Exception:
+                # Retract the draft we just created. Left in ``draft`` status
+                # it would count as an OPEN follow-up and block this thread on
+                # every future pass — a silent, permanent stall. ``rejected``
+                # is terminal, doesn't burn a cap slot, and lets the next pass
+                # try again cleanly.
+                await _retract(growth_service, workspace_id, draft.id)
+                raise
+            counters["created"] += 1
+            logger.info(
+                "growth: follow-up %d/%d proposed for prospect %s on '%s' (workspace=%s)",
+                len(counted) + 1,
+                max_followups,
+                prospect_id,
+                channel,
+                workspace_id,
+            )
+        except Exception:  # noqa: BLE001 — one bad thread must not stop the pass
+            counters["skipped"] += 1
+            logger.exception(
+                "growth: follow-up sweep failed for prospect %s on '%s' (workspace=%s)",
+                prospect_id,
+                channel,
+                workspace_id,
+            )
+
+    logger.info(
+        "growth.followup_sweep threads=%d created=%d retired=%d skipped=%d (delay=%dd max=%d)",
+        counters["threads"],
+        counters["created"],
+        counters["retired"],
+        counters["skipped"],
+        delay_days,
+        max_followups,
+    )
+    return counters
+
+
+__all__ = [
+    "GROWTH_FOLLOWUP_SWEEP_JOB_NAME",
+    "followup_delay_days",
+    "followup_max",
+    "followup_sweep",
+    "render_followup",
+]

--- a/ee/pocketpaw_ee/cloud/growth/service.py
+++ b/ee/pocketpaw_ee/cloud/growth/service.py
@@ -24,10 +24,19 @@
 # draft→proposed via ``transition``), and ``gate_transition`` is the internal
 # seam the growth executor / dispatch worker use to walk gate-owned edges
 # (same legality table, explicit workspace_id, no RequestContext).
+# Updated 2026-07-27 (feat/growth-g7): the follow-up sweep's data seams — the
+# only Beanie access the cron sweep (``growth/followups.py``) gets, since the
+# import-linter "Growth" contract keeps the doc classes inside this module.
+# ``list_sent_drafts_for_followup`` (cross-tenant scan, the one deliberate
+# global read), ``list_channel_drafts`` / ``get_prospect_system`` /
+# ``mark_prospect_dead`` / ``create_followup_draft`` — all keyed on an explicit
+# ``workspace_id`` because the sweep runs under the worker's system identity,
+# mirroring ``upsert_by_domain`` and ``gate_transition``.
 
 from __future__ import annotations
 
 import logging
+from datetime import UTC, datetime
 from typing import Any
 
 from beanie import PydanticObjectId
@@ -363,8 +372,21 @@ async def create_draft(
     flips to ``drafted`` on its first draft; later statuses (``in_sequence``,
     ``replied``, ``dead``) are never regressed.
     """
-    body = CreateDraftRequest.model_validate(body)
     workspace_id = _require_workspace(ctx)
+    return await _insert_draft(workspace_id, prospect_id, body)
+
+
+async def _insert_draft(
+    workspace_id: str, prospect_id: str, body: CreateDraftRequest
+) -> DraftResponse:
+    """Insert one draft against a prospect in ``workspace_id``.
+
+    The shared core of the HTTP ``create_draft`` and the system-identity
+    ``create_followup_draft`` (G-7) — same validation, same prospect check,
+    same first-draft status nudge, so a follow-up born in the cron sweep is
+    indistinguishable from one an operator typed.
+    """
+    body = CreateDraftRequest.model_validate(body)
     prospect = await _fetch_in_workspace(workspace_id, prospect_id)
 
     doc = _DraftDoc(
@@ -512,14 +534,156 @@ async def propose_send(ctx: RequestContext, draft_id: str) -> ProposeSendRespons
     return ProposeSendResponse(proposal_id=proposal_id, draft=draft)
 
 
+# ---------------------------------------------------------------------------
+# Follow-up sweep seams (G-7)
+#
+# The daily cron sweep (``growth/followups.py``) runs under the worker's system
+# identity across every tenant, so these take an explicit ``workspace_id``
+# instead of a RequestContext — same discipline as ``upsert_by_domain`` and
+# ``gate_transition``. They live here (not in ``followups.py``) because the
+# import-linter "Growth" contract keeps ``models.draft`` / ``models.prospect``
+# behind this module.
+# ---------------------------------------------------------------------------
+
+
+def _resolved_sent_at(doc: _DraftDoc) -> datetime | None:
+    """When this draft actually went out.
+
+    Prefers an explicit ``sent_at`` written by the dispatch worker's send
+    record (G-5/G-6) when the field exists, and otherwise falls back to
+    ``updatedAt`` — which, for a draft sitting in ``sent``, IS the moment of
+    the ``sent`` transition (the status flip is the last write). The fallback
+    goes stale only if something else edits a sent draft, which no current
+    code path does. Mongo returns naive datetimes, so anchor them to UTC.
+    """
+    raw = getattr(doc, "sent_at", None) or getattr(doc, "updatedAt", None)
+    if raw is None:
+        return None
+    return raw.replace(tzinfo=UTC) if raw.tzinfo is None else raw
+
+
+async def list_sent_drafts_for_followup(*, limit: int = 500) -> list[dict[str, Any]]:
+    """Every draft currently sitting in ``sent``, oldest-touched first.
+
+    global-read: the follow-up cron sweeps ALL tenants under the worker's
+    system identity — there is no request workspace to filter on. Each row
+    carries its own ``workspace_id`` and the caller re-enters per-workspace
+    reads through the scoped helpers below, so nothing crosses tenants
+    downstream.
+
+    Returns lightweight wire dicts (not domain objects) so the sweep never
+    needs the doc class. ``sent_at`` is resolved per ``_resolved_sent_at``;
+    the caller applies the age threshold, keeping the delay policy in one
+    place. The oldest-first sort means the ``limit`` cap sheds the NEWEST
+    sends — the ones furthest from being due — when a backlog exceeds it.
+    """
+    cursor = (
+        _DraftDoc.find({"status": "sent"})
+        .sort(+_DraftDoc.updatedAt)  # type: ignore[operator]
+        .limit(limit)
+    )
+    return [
+        {
+            "id": str(doc.id),
+            "workspace_id": doc.workspace,
+            "prospect_id": doc.prospect_id,
+            "channel": doc.channel,
+            "variant": doc.variant,
+            "subject": doc.subject,
+            "body": doc.body,
+            "demo_url": doc.demo_url,
+            "sent_at": _resolved_sent_at(doc),
+        }
+        async for doc in cursor
+    ]
+
+
+async def list_channel_drafts(
+    workspace_id: str, prospect_id: str, channel: str
+) -> list[dict[str, Any]]:
+    """Every draft for one (prospect, channel) pair, oldest first.
+
+    The sweep reads this to decide three things at once: is a follow-up
+    already open (dedupe), how many follow-ups has this pair already had
+    (the cap), and which draft was the first touch (the template source).
+    """
+    cursor = (
+        _DraftDoc.find(
+            {"workspace": workspace_id, "prospect_id": prospect_id, "channel": channel}
+        ).sort(+_DraftDoc.createdAt)  # type: ignore[operator]
+    )
+    return [
+        {
+            "id": str(doc.id),
+            "workspace_id": doc.workspace,
+            "prospect_id": doc.prospect_id,
+            "channel": doc.channel,
+            "variant": doc.variant,
+            "status": doc.status,
+            "subject": doc.subject,
+            "body": doc.body,
+            "demo_url": doc.demo_url,
+        }
+        async for doc in cursor
+    ]
+
+
+async def get_prospect_system(workspace_id: str, prospect_id: str) -> ProspectResponse:
+    """Read a prospect under the worker's system identity (still tenant-scoped:
+    a cross-workspace id raises NotFound exactly as the HTTP ``get`` does)."""
+    doc = await _fetch_in_workspace(workspace_id, prospect_id)
+    return _to_response(_to_domain(doc))
+
+
+async def mark_prospect_dead(workspace_id: str, prospect_id: str) -> ProspectResponse:
+    """Retire a prospect the sequence is done with (G-7 cap reached).
+
+    ``dead`` is the terminal outbound status — the sweep skips those rows on
+    every later pass, so nothing touches this prospect again. Idempotent: a
+    prospect already ``dead`` is returned unchanged without a write.
+    """
+    doc = await _fetch_in_workspace(workspace_id, prospect_id)
+    if doc.status == "dead":
+        return _to_response(_to_domain(doc))
+    doc.status = "dead"
+    await doc.save()  # bumps updatedAt
+    # no-event: growth has no realtime subscriber in v1; the prospects view polls.
+    return _to_response(_to_domain(doc))
+
+
+async def create_followup_draft(
+    workspace_id: str, prospect_id: str, body: CreateDraftRequest
+) -> DraftResponse:
+    """Create a follow-up draft under the worker's system identity (G-7).
+
+    Same insert as the HTTP ``create_draft`` (shared ``_insert_draft`` core),
+    keyed on an explicit workspace instead of a RequestContext. The draft is
+    born in ``draft`` status like any other — the sweep then walks it onto the
+    EXISTING gate propose path, so it reaches a human in The Tray and NOTHING
+    is approved or sent without them.
+    """
+    body = CreateDraftRequest.model_validate(body)
+    if body.variant != "follow_up":
+        raise ValidationError(
+            "draft.not_a_followup",
+            "create_followup_draft only creates variant='follow_up' drafts",
+        )
+    return await _insert_draft(workspace_id, prospect_id, body)
+
+
 __all__ = [
     "bulk_ingest",
     "create",
     "create_draft",
+    "create_followup_draft",
     "gate_transition",
     "get",
+    "get_prospect_system",
+    "list_channel_drafts",
     "list_drafts",
     "list_prospects",
+    "list_sent_drafts_for_followup",
+    "mark_prospect_dead",
     "propose_send",
     "transition",
     "update",

--- a/ee/pocketpaw_ee/cloud/growth/worker.py
+++ b/ee/pocketpaw_ee/cloud/growth/worker.py
@@ -12,6 +12,10 @@
 # actual delivery and the draft's ``sent`` flip (via the service's
 # ``gate_transition`` seam). The job only ever EXISTS for a draft whose
 # ``_growth_send`` proposal a human approved — that is the whole gate.
+# Updated 2026-07-27 (feat/growth-g7): the daily follow-up sweep joins the
+# queue as arq's first CRON job (``cron_jobs``, ``unique=True`` so only one
+# worker in a horizontally-scaled deploy runs a given tick). It PROPOSES
+# follow-ups into the Instinct tray and never sends — same gate, same human.
 #
 # Unlike workspace jobs (which ride arq's DEFAULT queue on the shared chat-runs
 # worker — see ``jobs/domain.py``), growth gets its OWN queue + worker process
@@ -39,12 +43,17 @@ import logging
 import os
 from typing import Any
 
+from arq import cron
 from arq.connections import RedisSettings
 from arq.worker import func
 
 from pocketpaw_ee.cloud import init_realtime
 from pocketpaw_ee.cloud._core.realtime import xproc
 from pocketpaw_ee.cloud.growth.domain import GROWTH_DISPATCH_JOB_NAME, GROWTH_QUEUE_NAME
+from pocketpaw_ee.cloud.growth.followups import (
+    GROWTH_FOLLOWUP_SWEEP_JOB_NAME,
+    followup_sweep,
+)
 from pocketpaw_ee.cloud.shared.db import close_cloud_db, init_cloud_db
 
 logger = logging.getLogger(__name__)
@@ -111,6 +120,23 @@ class WorkerSettings:
     # constant so the executor's ``enqueue_job(GROWTH_DISPATCH_JOB_NAME, ...)``
     # always matches, independent of the Python function's name.
     functions = [func(dispatch, name=GROWTH_DISPATCH_JOB_NAME)]
+    # G-7 — one daily tick at 13:00 UTC (business hours across US/EU, and well
+    # clear of the midnight batch traffic every other scheduler piles onto).
+    # ``unique=True`` (arq's default, explicit here because it is the property
+    # that matters) means a horizontally-scaled growth worker fleet still runs
+    # the sweep exactly once per tick. The sweep only ever PROPOSES — it
+    # cannot send, so a duplicate tick would at worst be a no-op anyway (the
+    # open-follow-up guard makes it idempotent).
+    cron_jobs = [
+        cron(
+            followup_sweep,
+            name=GROWTH_FOLLOWUP_SWEEP_JOB_NAME,
+            hour=13,
+            minute=0,
+            unique=True,
+            run_at_startup=False,
+        )
+    ]
     on_startup = _startup
     on_shutdown = _shutdown
     # Crash policy mirrors the chat-runs worker: no auto-retry. Outbound work
@@ -120,4 +146,11 @@ class WorkerSettings:
     redis_settings = _redis_settings()
 
 
-__all__ = ["GROWTH_DISPATCH_JOB_NAME", "GROWTH_QUEUE_NAME", "WorkerSettings", "dispatch"]
+__all__ = [
+    "GROWTH_DISPATCH_JOB_NAME",
+    "GROWTH_FOLLOWUP_SWEEP_JOB_NAME",
+    "GROWTH_QUEUE_NAME",
+    "WorkerSettings",
+    "dispatch",
+    "followup_sweep",
+]

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -814,6 +814,10 @@ name = "Growth — Beanie writes only from service.py"
 # feat/growth-g4 — the gate modules join the boundary: ``propose`` files the
 # Instinct Action and ``executor`` flips drafts ONLY through the service's
 # ``gate_transition`` seam, never the doc class directly.
+# feat/growth-g7 — ``followups`` (the daily cron sweep) joins too: it reads and
+# writes drafts/prospects ONLY through the service's system-identity seams
+# (``list_sent_drafts_for_followup`` / ``list_channel_drafts`` /
+# ``create_followup_draft`` / ``mark_prospect_dead``).
 type = "forbidden"
 allow_indirect_imports = "true"
 source_modules = [
@@ -823,6 +827,7 @@ source_modules = [
     "pocketpaw_ee.cloud.growth.worker",
     "pocketpaw_ee.cloud.growth.propose",
     "pocketpaw_ee.cloud.growth.executor",
+    "pocketpaw_ee.cloud.growth.followups",
 ]
 forbidden_modules = [
     "pocketpaw_ee.cloud.models.prospect",

--- a/tests/cloud/growth/test_followups.py
+++ b/tests/cloud/growth/test_followups.py
@@ -1,0 +1,515 @@
+# tests/cloud/growth/test_followups.py — the daily follow-up sweep (G-7), the
+# slice that closes the /growth outbound cycle.
+#
+# What it proves:
+#   1. A send that went quiet past the delay produces a ``follow_up`` draft AND
+#      a real proposal in the Instinct tray — and the draft stops at
+#      ``proposed``. Nothing is approved, nothing is sent.
+#   2. The stop conditions: a replied prospect, a send below the delay
+#      threshold, a follow-up already open, and a prospect already ``dead``.
+#   3. Idempotency — a second pass over the same data creates nothing.
+#   4. The cap: after ``GROWTH_FOLLOWUP_MAX`` unanswered follow-ups the
+#      prospect is retired to ``dead`` and nothing further is created.
+#   5. Both env knobs (``GROWTH_FOLLOWUP_DELAY_DAYS`` /
+#      ``GROWTH_FOLLOWUP_MAX``) actually move the behaviour.
+#   6. The cron is registered on the ``growth`` queue.
+#
+# Time is FROZEN by injection — every test passes an explicit ``now`` into the
+# sweep instead of backdating docs or sleeping. Setup writes rows at the real
+# clock and the sweep is then run from a point N days in the future, which is
+# the same relative geometry with none of the wall-clock cost.
+#
+# Harness mirrors test_gate.py: mongomock Beanie via ``mongo_db`` plus ONE tmp
+# InstinctStore monkeypatched behind ``pocketpaw.stores.get_instinct_store``,
+# so the propose path, the tray assertions and the sweep's proposer lookup all
+# hit the same store.
+#
+# Created 2026-07-27 (feat/growth-g7): new module.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud.growth import service as growth_service
+from pocketpaw_ee.cloud.growth.followups import (
+    GROWTH_FOLLOWUP_SWEEP_JOB_NAME,
+    followup_sweep,
+    render_followup,
+)
+from pocketpaw_ee.cloud.growth.propose import GROWTH_SEND_PARAM_KEY
+
+from pocketpaw.instinct.store import InstinctStore
+
+# ---------------------------------------------------------------------------
+# Harness
+# ---------------------------------------------------------------------------
+
+
+def _ctx(workspace_id: str, user_id: str = "u1") -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="test",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+@pytest.fixture
+def tray(tmp_path: Path, monkeypatch) -> InstinctStore:
+    """One shared InstinctStore behind every seam that resolves a store."""
+    store = InstinctStore(tmp_path / "growth_followups.db")
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: store)
+    return store
+
+
+@pytest_asyncio.fixture
+async def db(mongo_db: Any) -> Any:
+    """Alias so tests read as ``(db, tray)`` rather than the raw fixture name."""
+    return mongo_db
+
+
+# ---------------------------------------------------------------------------
+# Data helpers
+# ---------------------------------------------------------------------------
+
+
+async def _prospect(workspace_id: str, **overrides: Any) -> Any:
+    from pocketpaw_ee.cloud.growth.dto import CreateProspectRequest
+
+    payload: dict[str, Any] = {
+        "name": "Sam Founder",
+        "company": "Acme Dental",
+        "domain": "acme-dental.com",
+        "source": "manual",
+    }
+    payload.update(overrides)
+    return await growth_service.create(
+        _ctx(workspace_id), CreateProspectRequest.model_validate(payload)
+    )
+
+
+async def _draft(
+    workspace_id: str,
+    prospect_id: str,
+    *,
+    user_id: str = "u1",
+    channel: str = "email",
+    subject: str | None = "Quick idea for Acme Dental",
+    body: str = "Saw your booking flow — here's a live demo.",
+    variant: str = "first_touch",
+) -> Any:
+    from pocketpaw_ee.cloud.growth.dto import CreateDraftRequest
+
+    return await growth_service.create_draft(
+        _ctx(workspace_id, user_id),
+        prospect_id,
+        CreateDraftRequest(
+            channel=channel,  # type: ignore[arg-type]
+            subject=subject if channel == "email" else None,
+            body=body,
+            variant=variant,  # type: ignore[arg-type]
+        ),
+    )
+
+
+async def _send(
+    workspace_id: str, draft_id: str, *, user_id: str = "u1", gated: bool = True
+) -> None:
+    """Walk a draft all the way to ``sent`` the way production does.
+
+    ``gated=True`` files the real ``_growth_send`` proposal first, which is
+    what leaves the proposer record the sweep later inherits. ``gated=False``
+    skips it, simulating a draft that reached ``sent`` without a tray record.
+    """
+    if gated:
+        await growth_service.propose_send(_ctx(workspace_id, user_id), draft_id)
+    else:
+        await growth_service.gate_transition(workspace_id, draft_id, "proposed")
+    await growth_service.gate_transition(workspace_id, draft_id, "approved")
+    await growth_service.gate_transition(workspace_id, draft_id, "sent")
+
+
+async def _sent_thread(
+    workspace_id: str = "w1", *, user_id: str = "u1", channel: str = "email", **prospect_kw: Any
+) -> tuple[Any, Any]:
+    """A prospect with one first-touch draft already sent through the gate."""
+    prospect = await _prospect(workspace_id, **prospect_kw)
+    draft = await _draft(workspace_id, prospect.id, user_id=user_id, channel=channel)
+    await _send(workspace_id, draft.id, user_id=user_id)
+    return prospect, draft
+
+
+async def _drafts(workspace_id: str) -> list[Any]:
+    return await growth_service.list_drafts(_ctx(workspace_id))
+
+
+async def _followups(workspace_id: str) -> list[Any]:
+    return [d for d in await _drafts(workspace_id) if d.variant == "follow_up"]
+
+
+async def _tray_action_for(store: InstinctStore, workspace_id: str, draft_id: str) -> Any:
+    """The pending ``_growth_send`` Action filed for a specific draft, if any."""
+    for action in await store.list_actions(
+        pocket_id=workspace_id, workspace_id=workspace_id, limit=100
+    ):
+        blob = (getattr(action, "parameters", None) or {}).get(GROWTH_SEND_PARAM_KEY)
+        if isinstance(blob, dict) and str(blob.get("draft_id")) == str(draft_id):
+            return action
+    return None
+
+
+def _in_days(days: float) -> datetime:
+    return datetime.now(UTC) + timedelta(days=days)
+
+
+# ---------------------------------------------------------------------------
+# The happy path — a quiet send becomes a proposed follow-up
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_quiet_send_proposes_a_followup_into_the_tray(db, tray):
+    prospect, first = await _sent_thread()
+
+    counters = await followup_sweep({}, now=_in_days(5))
+
+    assert counters["created"] == 1
+    followups = await _followups("w1")
+    assert len(followups) == 1
+    followup = followups[0]
+
+    # The draft stops at the gate — proposed, never approved, never sent.
+    assert followup.status == "proposed"
+    assert followup.channel == "email"
+    assert followup.prospect_id == prospect.id
+
+    # …and a REAL proposal is waiting in the tray for it.
+    action = await _tray_action_for(tray, "w1", followup.id)
+    assert action is not None
+    assert str(getattr(action.status, "value", action.status)) == "pending"
+    blob = action.parameters[GROWTH_SEND_PARAM_KEY]
+    assert blob["workspace_id"] == "w1"
+    assert blob["draft_id"] == followup.id
+    assert blob["channel"] == "email"
+    assert blob["preview"]["body"] == followup.body
+
+    # The original send is untouched.
+    original = next(d for d in await _drafts("w1") if d.id == first.id)
+    assert original.status == "sent"
+
+
+@pytest.mark.asyncio
+async def test_followup_inherits_the_original_proposer(db, tray):
+    """A cron has no user, so the follow-up rides the human who sent the first
+    touch — otherwise the gate's execute-time RBAC re-check has nobody to
+    check and the approved send would fail closed."""
+    await _sent_thread(user_id="carol")
+
+    await followup_sweep({}, now=_in_days(5))
+
+    followup = (await _followups("w1"))[0]
+    action = await _tray_action_for(tray, "w1", followup.id)
+    blob = action.parameters[GROWTH_SEND_PARAM_KEY]
+    assert blob["requested_by"] == "carol"
+    # The executor resolves the proposer off the trigger, not the blob — they
+    # must agree or it refuses to dispatch.
+    assert action.trigger.source == "carol"
+    assert action.assignee == "carol"
+
+
+@pytest.mark.asyncio
+async def test_followup_copy_threads_under_the_original(db, tray):
+    await _sent_thread()
+
+    await followup_sweep({}, now=_in_days(5))
+
+    followup = (await _followups("w1"))[0]
+    assert followup.subject == "Re: Quick idea for Acme Dental"
+    assert "Sam Founder" in followup.body
+    assert "Saw your booking flow" in followup.body  # quotes the first touch
+
+
+def test_render_followup_does_not_double_prefix_a_reply_subject():
+    subject, _ = render_followup(
+        channel="email",
+        prospect_name="Sam",
+        prospect_company="Acme",
+        first_touch={"subject": "Re: already a reply", "body": "hi"},
+    )
+    assert subject == "Re: already a reply"
+
+
+def test_render_followup_omits_subject_off_email():
+    """The draft DTO refuses a subject on non-email channels — the renderer
+    must not hand one over."""
+    for channel in ("linkedin", "whatsapp"):
+        subject, body = render_followup(
+            channel=channel,
+            prospect_name="Sam",
+            prospect_company="Acme",
+            first_touch={"subject": None, "body": "hi"},
+        )
+        assert subject is None
+        assert "Acme" in body
+
+
+# ---------------------------------------------------------------------------
+# The stop conditions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_replied_prospect_gets_nothing(db, tray):
+    from pocketpaw_ee.cloud.growth.dto import UpdateProspectRequest
+
+    prospect, _ = await _sent_thread()
+    await growth_service.update(_ctx("w1"), prospect.id, UpdateProspectRequest(status="replied"))
+
+    counters = await followup_sweep({}, now=_in_days(5))
+
+    assert counters["created"] == 0
+    assert await _followups("w1") == []
+
+
+@pytest.mark.asyncio
+async def test_send_below_the_delay_threshold_gets_nothing(db, tray):
+    await _sent_thread()
+
+    counters = await followup_sweep({}, now=_in_days(2))
+
+    assert counters["created"] == 0
+    assert await _followups("w1") == []
+
+
+@pytest.mark.asyncio
+async def test_existing_open_followup_is_not_duplicated(db, tray):
+    from pocketpaw_ee.cloud.growth.dto import CreateDraftRequest
+
+    prospect, _ = await _sent_thread()
+    await growth_service.create_followup_draft(
+        "w1",
+        prospect.id,
+        CreateDraftRequest(channel="email", subject="Re: x", body="nudge", variant="follow_up"),
+    )
+
+    counters = await followup_sweep({}, now=_in_days(5))
+
+    assert counters["created"] == 0
+    assert len(await _followups("w1")) == 1
+
+
+@pytest.mark.asyncio
+async def test_sweep_is_idempotent(db, tray):
+    await _sent_thread()
+
+    first = await followup_sweep({}, now=_in_days(5))
+    second = await followup_sweep({}, now=_in_days(5))
+
+    assert first["created"] == 1
+    assert second["created"] == 0
+    assert len(await _followups("w1")) == 1
+
+
+@pytest.mark.asyncio
+async def test_send_with_no_tray_record_is_skipped(db, tray):
+    """No resolvable proposer → no follow-up. A proposal nobody can execute
+    (the gate re-checks the proposer's role at approve time) is worse than
+    none, so the sweep declines rather than filing a dud."""
+    prospect = await _prospect("w1")
+    draft = await _draft("w1", prospect.id)
+    await _send("w1", draft.id, gated=False)
+
+    counters = await followup_sweep({}, now=_in_days(5))
+
+    assert counters["created"] == 0
+    assert counters["skipped"] == 1
+    assert await _followups("w1") == []
+
+
+@pytest.mark.asyncio
+async def test_a_failed_propose_retracts_its_draft(db, tray, monkeypatch):
+    """A draft created but never proposed would sit in ``draft`` forever,
+    counting as an open follow-up and stalling the thread on every future
+    pass. It gets retracted instead, and the next pass tries again."""
+    await _sent_thread()
+
+    real_propose = growth_service.propose_send
+    calls = {"n": 0}
+
+    async def _flaky(ctx, draft_id):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("tray unavailable")
+        return await real_propose(ctx, draft_id)
+
+    monkeypatch.setattr(growth_service, "propose_send", _flaky)
+
+    failed = await followup_sweep({}, now=_in_days(5))
+    assert failed["created"] == 0
+    assert [f.status for f in await _followups("w1")] == ["rejected"]
+
+    # Nothing is stuck: the next pass files a real one.
+    recovered = await followup_sweep({}, now=_in_days(5))
+    assert recovered["created"] == 1
+    assert sorted(f.status for f in await _followups("w1")) == ["proposed", "rejected"]
+
+
+# ---------------------------------------------------------------------------
+# The cap
+# ---------------------------------------------------------------------------
+
+
+async def _thread_with_sent_followups(count: int, *, workspace_id: str = "w1") -> Any:
+    """A first touch plus ``count`` follow-ups, all already sent + unanswered."""
+    prospect, _ = await _sent_thread(workspace_id)
+    for _ in range(count):
+        followup = await _draft(
+            workspace_id, prospect.id, subject="Re: Quick idea", variant="follow_up"
+        )
+        await _send(workspace_id, followup.id)
+    return prospect
+
+
+@pytest.mark.asyncio
+async def test_third_pass_after_two_followups_retires_the_prospect(db, tray):
+    prospect = await _thread_with_sent_followups(2)
+
+    counters = await followup_sweep({}, now=_in_days(5))
+
+    assert counters["created"] == 0
+    assert counters["retired"] == 1
+    refreshed = await growth_service.get_prospect_system("w1", prospect.id)
+    assert refreshed.status == "dead"
+    # Still exactly the two follow-ups that were already there.
+    assert len(await _followups("w1")) == 2
+
+
+@pytest.mark.asyncio
+async def test_the_whole_cycle_over_three_sweeps(db, tray):
+    """The slice end to end, on the real sequence rather than a pre-baked
+    state: sweep 1 proposes nudge #1, sweep 2 (after it went out and stayed
+    quiet) proposes nudge #2, sweep 3 finds the cap reached and retires the
+    prospect. Every draft passes through the human gate on the way."""
+    prospect, _ = await _sent_thread()
+
+    assert (await followup_sweep({}, now=_in_days(5)))["created"] == 1
+    nudge_1 = (await _followups("w1"))[0]
+    assert nudge_1.status == "proposed"
+    # The human approves it in the tray and it goes out.
+    await growth_service.gate_transition("w1", nudge_1.id, "approved")
+    await growth_service.gate_transition("w1", nudge_1.id, "sent")
+
+    assert (await followup_sweep({}, now=_in_days(10)))["created"] == 1
+    nudge_2 = next(f for f in await _followups("w1") if f.id != nudge_1.id)
+    assert nudge_2.status == "proposed"
+    await growth_service.gate_transition("w1", nudge_2.id, "approved")
+    await growth_service.gate_transition("w1", nudge_2.id, "sent")
+
+    third = await followup_sweep({}, now=_in_days(15))
+    assert third["created"] == 0
+    assert third["retired"] == 1
+    assert (await growth_service.get_prospect_system("w1", prospect.id)).status == "dead"
+    assert len(await _followups("w1")) == 2
+
+
+@pytest.mark.asyncio
+async def test_a_dead_prospect_is_never_touched_again(db, tray):
+    await _thread_with_sent_followups(2)
+
+    await followup_sweep({}, now=_in_days(5))
+    counters = await followup_sweep({}, now=_in_days(10))
+
+    assert counters["created"] == 0
+    assert counters["retired"] == 0  # already dead — not re-retired
+    assert len(await _followups("w1")) == 2
+
+
+@pytest.mark.asyncio
+async def test_one_sent_followup_still_earns_a_second(db, tray):
+    """The cap is 2, so a thread with one unanswered follow-up gets one more —
+    the dedupe guard is about OPEN follow-ups, not any follow-up ever."""
+    await _thread_with_sent_followups(1)
+
+    counters = await followup_sweep({}, now=_in_days(5))
+
+    assert counters["created"] == 1
+    followups = await _followups("w1")
+    assert len(followups) == 2
+    assert sum(1 for f in followups if f.status == "proposed") == 1
+
+
+# ---------------------------------------------------------------------------
+# Config knobs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delay_days_env_moves_the_threshold(db, tray, monkeypatch):
+    await _sent_thread()
+    monkeypatch.setenv("GROWTH_FOLLOWUP_DELAY_DAYS", "10")
+
+    assert (await followup_sweep({}, now=_in_days(5)))["created"] == 0
+    assert (await followup_sweep({}, now=_in_days(11)))["created"] == 1
+
+
+@pytest.mark.asyncio
+async def test_followup_max_env_moves_the_cap(db, tray, monkeypatch):
+    prospect = await _thread_with_sent_followups(1)
+    monkeypatch.setenv("GROWTH_FOLLOWUP_MAX", "1")
+
+    counters = await followup_sweep({}, now=_in_days(5))
+
+    assert counters["created"] == 0
+    assert counters["retired"] == 1
+    assert (await growth_service.get_prospect_system("w1", prospect.id)).status == "dead"
+
+
+@pytest.mark.asyncio
+async def test_a_junk_env_value_falls_back_to_the_default(db, tray, monkeypatch):
+    await _sent_thread()
+    monkeypatch.setenv("GROWTH_FOLLOWUP_DELAY_DAYS", "not-a-number")
+
+    assert (await followup_sweep({}, now=_in_days(5)))["created"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Tenancy + registration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sweep_crosses_tenants_without_mixing_them(db, tray):
+    """The cron has no request workspace, so it scans globally — every row it
+    writes must still land in the workspace it came from."""
+    await _sent_thread("w1", user_id="alice")
+    await _sent_thread("w2", user_id="bob", domain="other-co.com")
+
+    counters = await followup_sweep({}, now=_in_days(5))
+
+    assert counters["created"] == 2
+    w1_followup = (await _followups("w1"))[0]
+    w2_followup = (await _followups("w2"))[0]
+    assert w1_followup.workspace_id == "w1"
+    assert w2_followup.workspace_id == "w2"
+    w1_blob = (await _tray_action_for(tray, "w1", w1_followup.id)).parameters[GROWTH_SEND_PARAM_KEY]
+    w2_blob = (await _tray_action_for(tray, "w2", w2_followup.id)).parameters[GROWTH_SEND_PARAM_KEY]
+    assert w1_blob["requested_by"] == "alice"
+    assert w2_blob["requested_by"] == "bob"
+
+
+def test_cron_is_registered_on_the_growth_queue():
+    from pocketpaw_ee.cloud.growth.worker import WorkerSettings
+
+    assert WorkerSettings.queue_name == "growth"
+    jobs = {job.name: job for job in WorkerSettings.cron_jobs}
+    sweep = jobs[GROWTH_FOLLOWUP_SWEEP_JOB_NAME]
+    # Daily, and unique so a scaled-out worker fleet runs one tick, not N.
+    assert sweep.hour == 13
+    assert sweep.minute == 0
+    assert sweep.unique is True


### PR DESCRIPTION
Stacked on #1803 (sibling of #1804 — both branch off the gate slice).

A daily cron on the growth queue finds sends that went quiet past `GROWTH_FOLLOWUP_DELAY_DAYS` (default 4) and files a follow-up draft back through the **existing** propose path. It stops at `proposed` — the nudge lands in the Instinct tray and waits for a human like any other send. Max 2 follow-ups per thread (`GROWTH_FOLLOWUP_MAX`), then the prospect goes `dead` and we stop touching them.

## Decisions worth a look
- **The sweep inherits a human proposer.** A cron has no user, but the executor re-checks the proposer's *current* `growth.manage` role at dispatch. A "system" proposer would produce follow-ups that look approvable in the tray and then fail closed at send — a silent dead end. So the sweep reads the proposer off the thread's last send and reuses it; a thread with no resolvable proposer is skipped, because a proposal nobody can execute is worse than no proposal.
- **"No existing follow-up" means no *open* one.** Read literally as "none ever", the cap of 2 would be unreachable — the first nudge would block every later one. Open-status scoping is also what makes the sweep idempotent, and a human-rejected follow-up doesn't burn a cap slot.
- **The delay measures from the last touch**, not the first, or an already-nudged thread comes due again immediately.
- If proposing fails after the draft exists, the draft is retracted to `rejected` — otherwise it sits in `draft` and stalls that thread on every future pass.

## Verification
213 passed across growth, ship and instinct (20 new). Covers the five acceptance cases, cron registration on the growth queue, and a three-sweep cycle ending in `dead`. Time is frozen by injection, no sleeps. Mutation-checked: deleting the delay check or the open-follow-up guard turns 4 tests red, so they aren't passing vacuously. Both import-linter configs green; ruff clean, no new mypy errors.

**One coordination note for review:** the send timestamp currently resolves from the draft's own `sent_at`/`updatedAt`. #1804 lands a separate MessageLog collection — after both merge, `_resolved_sent_at` (one clearly-marked function) should point at it.