### PR TITLE
growth: WhatsApp sends behind a hard opt-in guard

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -82,6 +82,15 @@ GET /growth/drafts with prospect|channel|status filters, POST
 draft→proposed→approved→sent, sent→replied, non-terminal→rejected; illegal
 moves 422 draft.illegal_transition.
 
+Updated: 2026-07-27 (feat/growth-g6) — documented the Growth — WhatsApp
+dispatch section: the growth.dispatch job's channel="whatsapp" branch sends via
+MSG91 behind a HARD prospect.opted_in guard (not opted in ⇒ no provider call at
+all, typed error, blocked send-log row, draft left approved), the guard order,
+the per-attempt WhatsAppSendLog compliance record, connector-state credential
+resolution (no env fallback for the authkey), the fail-closed inbound webhook
+POST /growth/webhooks/msg91, and the GROWTH_WHATSAPP_MAX_PER_HOUR /
+GROWTH_MSG91_WEBHOOK_SECRET environment variables.
+
 Updated: 2026-07-27 (feat/growth-g4) — documented the Instinct send gate:
 POST /growth/drafts/{id}/propose files a gated _growth_send proposal and
 flips the draft to proposed; the status route now refuses the gate-owned
@@ -1719,6 +1728,117 @@ enqueues the `growth.dispatch` job `{draft_id, channel}` on the dedicated
 `growth` arq queue — with an execute-time re-check that the proposer STILL
 holds `growth.manage` (a since-demoted proposer's approved send fails
 closed), and `mark_failed` on the Action if the enqueue fails. On
-**reject** the draft flips to `rejected` and nothing is enqueued. The
-dispatch job body is a logging stub in this slice — G-5/G-6 implement the
-actual per-channel delivery and the `sent` flip.
+**reject** the draft flips to `rejected` and nothing is enqueued. For
+`channel="whatsapp"` the dispatch job is live — see *Growth — WhatsApp
+dispatch* below. Other channels keep the logging stub until their slice lands.
+
+---
+
+## Growth — WhatsApp dispatch (MSG91)
+
+Sixth slice of the `/growth` outbound engine (G-6): the `channel="whatsapp"`
+branch of the `growth.dispatch` arq job actually sends, through MSG91 (an
+official Meta WhatsApp Business Solution Provider).
+
+**The opt-in guard is a service-level invariant, not a UI convention.** Meta
+bans WhatsApp Business Accounts that send business-initiated template messages
+to numbers that never consented — the quality rating collapses, then the number
+gets restricted, then banned, for the whole tenant. So dispatch refuses any
+draft whose prospect has `opted_in = false`: it makes **no provider call at
+all**, raises `growth.whatsapp_opt_in_required`, records a `blocked` row, and
+leaves the draft in `approved` so the refusal is visible instead of silent.
+
+Because business-initiated messages must be pre-approved templates, the draft
+`body` is sent as the template's first body variable, never as free-form text.
+
+**Guard order** (each refusal writes its own send-log row and raises):
+
+| # | Guard | Error code | Blocked reason |
+|---|---|---|---|
+| 1 | Draft still `approved` (the G-4 gate owns that status) | `growth.draft_not_approved` | `draft_not_approved` |
+| 2 | Prospect still exists in the draft's workspace | `growth.prospect_unavailable` | `prospect_missing` |
+| 3 | **`prospect.opted_in`** | `growth.whatsapp_opt_in_required` | `not_opted_in` |
+| 4 | Prospect has a WhatsApp number | `growth.prospect_unavailable` | `no_number` |
+| 5 | Hourly rate cap | `growth.whatsapp_rate_capped` | `rate_capped` |
+| 6 | Resolvable MSG91 credentials | `growth.whatsapp_not_configured` | `not_configured` |
+
+On success the job writes a `sending` row, calls MSG91, finalises the row to
+`sent` (or `failed`), and flips the draft `approved → sent` through the gate's
+own `service.gate_transition` seam. The growth worker runs with `max_tries = 1`,
+so a refusal lands as a failed arq job for operator review — an outbound message
+is never retried automatically.
+
+Every attempt — including refused ones — writes a row to
+`growth_whatsapp_send_logs` (`WhatsAppSendLog`): workspace, draft, prospect,
+recipient number, status, blocked reason, provider message id, and
+`opted_in_at_attempt` (the consent fact *as of* the send, which a later prospect
+edit cannot rewrite).
+
+### Credentials
+
+The MSG91 authkey is resolved per workspace through the **connector state
+pattern** — the workspace's `msg91` `WorkspaceConnector` row, read via
+`CloudConnectorStateStore` with the `ws:<workspace_id>` scope key. There is
+deliberately **no env-var fallback for the authkey**: a deployment-global
+provider key would let one tenant's outbound traffic burn another tenant's WABA
+quality rating. No row, no send.
+
+Config keys on that row:
+
+| Key | Required | Notes |
+|---|---|---|
+| `authkey_enc` | yes* | The authkey as a `_core.crypto` Fernet ciphertext (needs `CLOUD_ENCRYPTION_KEY`). Preferred — keeps the plaintext out of Mongo and out of the connectors entity's own `config` echo. |
+| `authkey` | yes* | Plaintext fallback for installs with no encryption key. Warns on every resolve. |
+| `integrated_number` | yes | The WABA business number messages are sent from. |
+| `template_name` | yes | The pre-approved Meta template. |
+| `language_code` | no | Defaults to `en`. |
+| `namespace` | no | WABA template namespace, when the account requires one. |
+| `base_url` | no | Defaults to `https://api.msg91.com`. Per-workspace override for regional mirrors. |
+
+\* one of `authkey_enc` / `authkey`.
+
+The authkey is never logged, never returned by any DTO, and never persisted into
+the send log. `Msg91Credentials.__repr__` redacts it, so a traceback or a `%r`
+format cannot spill it either.
+
+### `POST /api/v1/growth/webhooks/msg91`
+
+Inbound MSG91 WhatsApp events. **Unauthenticated by nature** (MSG91 is the
+caller) — mounted separately from the licensed `/growth` router, with no license
+gate, no RBAC and no `RequestContext`.
+
+**Fails closed.** Trust rests entirely on the signature: HMAC-SHA256 over the
+raw request body, keyed by `GROWTH_MSG91_WEBHOOK_SECRET`, hex-encoded, in
+`X-Msg91-Signature` (an optional `sha256=` prefix is tolerated). A bad
+signature, a missing header, **and an unset secret** all return
+`403 growth.webhook_signature_invalid` / `growth.webhook_unsigned` /
+`growth.webhook_unverifiable`. Unlike the Recall webhook there is no
+accept-while-you-wire-it-up mode — a forged inbound reply would flip
+`opted_in` and thereby unlock business-initiated sends to a number that never
+consented.
+
+On a verified inbound reply the handler sets `prospect.opted_in = true`, moves
+the prospect to `replied`, and walks any `sent` WhatsApp draft for that prospect
+to `replied` (through the gate seam). Under Meta's rules a user-initiated
+message both opens the 24-hour service window and *is* the opt-in signal for
+that number.
+
+Delivery-status callbacks (`status` / `delivered` / `read` / …) are accepted and
+ignored — a receipt is not consent. A number no workspace holds is a 200 no-op.
+
+The response body is a constant `{"ok": true}` for every accepted request —
+processed, ignored, or unknown number — so the endpoint cannot be used as a
+membership oracle over phone numbers.
+
+Tenancy: the payload carries no workspace, so the lookup starts from the number
+and is immediately re-narrowed — when any workspace has actually WhatsApp'd that
+number, only those workspaces' rows are touched, so a tenant that merely holds
+the same prospect never learns someone else's outreach got a reply.
+
+### Environment
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `GROWTH_WHATSAPP_MAX_PER_HOUR` | `20` | Per-workspace outbound WhatsApp ceiling per rolling hour. WhatsApp quality rating is computed over a rolling window of recent business-initiated messages, and a burst (bulk approval, retry storm, mis-scoped follow-up cron) is exactly the shape that trips it — with the damage landing on the WABA, not the individual send. The cap bounds the blast radius of a bug. Attempts that reached the provider (`sending` / `sent` / `failed`) consume the window; refused attempts do not. There is no "disabled" value — `0` refuses every send rather than meaning unlimited, and a non-numeric or negative value falls back to the default, so a fat-fingered setting fails closed. |
+| `GROWTH_MSG91_WEBHOOK_SECRET` | *(unset)* | Shared secret for the inbound webhook HMAC. **Required** — while unset, `POST /growth/webhooks/msg91` rejects every request with 403. |
+| `CLOUD_ENCRYPTION_KEY` | *(unset)* | Existing deployment-wide Fernet key. Needed to store the MSG91 authkey as `authkey_enc` rather than plaintext. |

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -405,6 +405,7 @@ def mount_cloud(app: FastAPI) -> None:
     from pocketpaw_ee.cloud.decisions.router import router as decisions_router
     from pocketpaw_ee.cloud.fabric_ingest.router import router as fabric_ingest_router
     from pocketpaw_ee.cloud.growth.router import router as growth_router
+    from pocketpaw_ee.cloud.growth.webhooks import router as growth_webhooks_router
     from pocketpaw_ee.cloud.instinct_approvals.router import router as instinct_approvals_router
     from pocketpaw_ee.cloud.kb.router import router as kb_router
     from pocketpaw_ee.cloud.leads.router import router as leads_router
@@ -476,6 +477,14 @@ def mount_cloud(app: FastAPI) -> None:
     # Instinct-gated sends (the dedicated ``growth`` arq queue seam lives in
     # ``growth/worker.py``).
     app.include_router(growth_router, prefix="/api/v1")
+    # Growth inbound webhooks (G-6) — POST /growth/webhooks/msg91. Mounted
+    # SEPARATELY from growth_router because MSG91 is the caller: no license
+    # gate, no RBAC, no RequestContext. Trust is the shared-secret HMAC in
+    # ``growth/webhooks.py``, which FAILS CLOSED (bad, missing, or
+    # unconfigured signature ⇒ 403) — a forged inbound reply would flip
+    # ``prospect.opted_in`` and unlock business-initiated sends to a number
+    # that never consented.
+    app.include_router(growth_webhooks_router, prefix="/api/v1")
     # Sites control plane — RFC 12 Task 3.5. POST /sites/publish (compile +
     # smoke-gate + WfP deploy), GET /sites, and the custom-domain pair
     # (Cloudflare for SaaS) the Domains panel drives.

--- a/ee/pocketpaw_ee/cloud/growth/msg91.py
+++ b/ee/pocketpaw_ee/cloud/growth/msg91.py
@@ -1,0 +1,300 @@
+# ee/pocketpaw_ee/cloud/growth/msg91.py — the MSG91 WhatsApp provider seam for
+# the /growth outbound engine (G-6).
+#
+# MSG91 is an official Meta WhatsApp Business Solution Provider, so a
+# business-initiated message goes out as a PRE-APPROVED TEMPLATE — free-form
+# text is only legal inside a 24-hour service window opened by the recipient.
+# That is why this module only knows how to send a template: the draft body
+# rides in as a template variable, never as raw content.
+#
+# CREDENTIALS — the authkey is resolved through the repo's connector state
+# pattern (``CloudConnectorStateStore``, the same seam
+# ``registry.ensure_connected`` uses to rehydrate a connector on a cold
+# process), keyed ``ws:<workspace_id>`` against the workspace's ``msg91``
+# ``WorkspaceConnector`` row. Three consequences worth stating plainly:
+#
+#   * NEVER env-inline. There is no ``MSG91_AUTHKEY`` fallback. A cloud install
+#     is multi-tenant; a deployment-global provider key would let one tenant's
+#     outbound traffic burn another tenant's WABA quality rating. No row, no
+#     send.
+#   * NEVER logged. ``Msg91Credentials.__repr__`` redacts the authkey, so an
+#     exception traceback, a ``logger.info("...%r", creds)``, or a debugger
+#     frame dump cannot spill it. The only place the raw value is read is the
+#     outbound request header.
+#   * NEVER DTO'd. Nothing in this module returns credentials to a caller that
+#     serialises; the growth DTOs have no credential field at all.
+#
+# The preferred storage shape is ``authkey_enc`` — a ``_core.crypto`` Fernet
+# ciphertext, so the plaintext key is not sitting in Mongo and is not exposed by
+# the connectors entity's own ``ConnectorResponse.config`` echo. A plaintext
+# ``authkey`` key is accepted for installs with no ``CLOUD_ENCRYPTION_KEY``, and
+# logs a warning on every resolve so the gap is visible.
+#
+# Created 2026-07-27 (feat/growth-g6): new module — MSG91 WhatsApp dispatch with
+# hard opt-in enforcement.
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# The registry/connector-row name the workspace's MSG91 credentials live under.
+MSG91_CONNECTOR_NAME = "msg91"
+
+# MSG91's v5 WhatsApp outbound endpoint. Overridable per workspace via the
+# connector row's ``base_url`` (regional mirrors / a recorded test double),
+# never via a process-wide env var.
+DEFAULT_MSG91_BASE_URL = "https://api.msg91.com"
+_OUTBOUND_PATH = "/api/v5/whatsapp/whatsapp-outbound-message/bulk/"
+
+# A template send is a single small POST; a slow provider must not pin an arq
+# worker slot open indefinitely.
+_REQUEST_TIMEOUT_SECONDS = 30
+
+
+class Msg91Error(Exception):
+    """The provider refused or failed the send.
+
+    ``code`` is machine-readable so the send log can record WHY without
+    re-parsing prose. The message is truncated by the caller before it reaches
+    the log — a provider error body must never carry the request headers back
+    into storage.
+    """
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+class Msg91NotConfigured(Exception):
+    """No usable MSG91 credentials for this workspace.
+
+    Deliberately distinct from ``Msg91Error``: nothing was attempted, so the
+    send log records a ``blocked`` row rather than a ``failed`` one.
+    """
+
+
+@dataclass(frozen=True, repr=False)
+class Msg91Credentials:
+    """One workspace's resolved MSG91 WhatsApp configuration.
+
+    ``__repr__`` is hand-written to redact ``authkey``. The dataclass default
+    would interpolate it into every traceback and every ``%r`` format — the
+    single most common way a provider key ends up in a log aggregator.
+    """
+
+    authkey: str
+    integrated_number: str
+    template_name: str
+    language_code: str = "en"
+    namespace: str | None = None
+    base_url: str = DEFAULT_MSG91_BASE_URL
+
+    def __repr__(self) -> str:
+        return (
+            "Msg91Credentials(authkey='***redacted***', "
+            f"integrated_number={self.integrated_number!r}, "
+            f"template_name={self.template_name!r}, "
+            f"language_code={self.language_code!r}, "
+            f"namespace={self.namespace!r}, base_url={self.base_url!r})"
+        )
+
+    __str__ = __repr__
+
+
+def _read_authkey(config: dict[str, Any]) -> str:
+    """Pull the authkey out of a connector config blob.
+
+    ``authkey_enc`` (Fernet ciphertext) wins; a plaintext ``authkey`` is the
+    documented fallback for installs without ``CLOUD_ENCRYPTION_KEY`` and warns
+    every time so the weaker posture is visible in the logs. A ciphertext that
+    fails to decrypt returns "" — the caller treats that as "not configured"
+    rather than falling through to a half-resolved credential.
+    """
+    enc = str(config.get("authkey_enc") or "").strip()
+    if enc:
+        try:
+            from pocketpaw_ee.cloud._core import crypto
+
+            return str(crypto.decrypt(enc)).strip()
+        except Exception:  # noqa: BLE001 — an undecryptable key is "not configured"
+            logger.warning(
+                "growth/msg91: the stored authkey_enc could not be decrypted — is "
+                "CLOUD_ENCRYPTION_KEY the key it was written with? Refusing to send."
+            )
+            return ""
+    plain = str(config.get("authkey") or "").strip()
+    if plain:
+        logger.warning(
+            "growth/msg91: the MSG91 authkey is stored in PLAINTEXT on the connector "
+            "row. Set CLOUD_ENCRYPTION_KEY and re-save it as authkey_enc."
+        )
+    return plain
+
+
+async def resolve_credentials(workspace_id: str) -> Msg91Credentials:
+    """Resolve one workspace's MSG91 credentials, or raise ``Msg91NotConfigured``.
+
+    Reads the workspace's ``msg91`` connector row through the connector state
+    store — the same seam the OSS connector registry uses to rehydrate a
+    connector's config on a cold process. There is deliberately NO env-var
+    fallback for the authkey (see the module header).
+    """
+    if not workspace_id:
+        raise Msg91NotConfigured("no workspace — cannot resolve MSG91 credentials")
+
+    from pocketpaw_ee.cloud.connectors.state_provider import CloudConnectorStateStore
+
+    raw = CloudConnectorStateStore().get(MSG91_CONNECTOR_NAME, f"ws:{workspace_id}")
+    # The store returns a coroutine for namespaced (``ws:``) keys and a plain
+    # value for the file-delegate path; await only what needs awaiting.
+    config = await raw if hasattr(raw, "__await__") else raw
+    if not isinstance(config, dict):
+        raise Msg91NotConfigured(
+            f"workspace {workspace_id} has no enabled '{MSG91_CONNECTOR_NAME}' connector"
+        )
+
+    authkey = _read_authkey(config)
+    integrated_number = str(config.get("integrated_number") or "").strip()
+    template_name = str(config.get("template_name") or "").strip()
+    missing = [
+        name
+        for name, value in (
+            ("authkey", authkey),
+            ("integrated_number", integrated_number),
+            ("template_name", template_name),
+        )
+        if not value
+    ]
+    if missing:
+        # The NAMES of the missing fields are safe to log; the values are not,
+        # and no value is interpolated here.
+        raise Msg91NotConfigured(
+            f"the '{MSG91_CONNECTOR_NAME}' connector for workspace {workspace_id} is "
+            f"missing: {', '.join(missing)}"
+        )
+
+    return Msg91Credentials(
+        authkey=authkey,
+        integrated_number=integrated_number,
+        template_name=template_name,
+        language_code=str(config.get("language_code") or "en").strip() or "en",
+        namespace=(str(config.get("namespace")).strip() or None)
+        if config.get("namespace")
+        else None,
+        base_url=str(config.get("base_url") or DEFAULT_MSG91_BASE_URL).rstrip("/"),
+    )
+
+
+class Msg91WhatsAppClient:
+    """Minimal MSG91 WhatsApp template-send client.
+
+    One method, one endpoint. ``httpx`` is already a core dependency, so this
+    adds no new package (and therefore no 7-day release-age exposure). Tests
+    inject a fake with the same ``send_template`` signature — nothing in the
+    test suite ever constructs this class, so the suite is network-free by
+    construction rather than by mock-patching ``httpx``.
+    """
+
+    def __init__(self, credentials: Msg91Credentials) -> None:
+        self._creds = credentials
+
+    def __repr__(self) -> str:
+        # Never let the wrapped credentials leak through the client's repr.
+        return f"Msg91WhatsAppClient(base_url={self._creds.base_url!r})"
+
+    async def send_template(self, *, to_number: str, body_text: str) -> str:
+        """Send the pre-approved template to one number; return the provider id.
+
+        ``body_text`` fills the template's first body variable — the draft copy
+        a human approved in the Tray. Raises ``Msg91Error`` on a non-2xx or an
+        error-shaped 2xx body.
+        """
+        import httpx
+
+        creds = self._creds
+        template: dict[str, Any] = {
+            "name": creds.template_name,
+            "language": {"code": creds.language_code, "policy": "deterministic"},
+            "to_and_components": [
+                {
+                    "to": [to_number],
+                    "components": {"body_1": {"type": "text", "value": body_text}},
+                }
+            ],
+        }
+        if creds.namespace:
+            template["namespace"] = creds.namespace
+
+        payload = {
+            "integrated_number": creds.integrated_number,
+            "content_type": "template",
+            "payload": {
+                "messaging_product": "whatsapp",
+                "type": "template",
+                "template": template,
+            },
+        }
+
+        url = f"{creds.base_url}{_OUTBOUND_PATH}"
+        try:
+            async with httpx.AsyncClient(timeout=_REQUEST_TIMEOUT_SECONDS) as client:
+                resp = await client.post(
+                    url,
+                    json=payload,
+                    # The ONLY place the raw authkey is read. Not logged, not
+                    # returned, not stored.
+                    headers={"authkey": creds.authkey, "Content-Type": "application/json"},
+                )
+        except httpx.HTTPError as exc:
+            raise Msg91Error("msg91.transport_error", f"MSG91 request failed: {exc}") from exc
+
+        if resp.status_code >= 400:
+            raise Msg91Error(
+                "msg91.http_error",
+                f"MSG91 returned {resp.status_code}: {resp.text[:300]}",
+            )
+        return _extract_message_id(resp)
+
+
+def _extract_message_id(resp: Any) -> str:
+    """Best-effort provider message id out of an MSG91 2xx response.
+
+    MSG91 has shipped several 2xx envelopes over the v5 lifetime; the id is not
+    load-bearing for us (the send log's own id is), so an unrecognised shape
+    returns "" instead of failing a send that actually went out. An explicit
+    error-shaped 2xx DOES raise — those are real failures wearing a 200.
+    """
+    try:
+        data = resp.json()
+    except Exception:  # noqa: BLE001 — a non-JSON 2xx still means it went out
+        return ""
+    if not isinstance(data, dict):
+        return ""
+    status = str(data.get("status") or data.get("type") or "").lower()
+    if status in ("error", "fail", "failure"):
+        raise Msg91Error("msg91.rejected", f"MSG91 rejected the send: {str(data)[:300]}")
+    inner = data.get("data")
+    if isinstance(inner, dict):
+        for key in ("message_id", "messageId", "request_id", "requestId", "id"):
+            if inner.get(key):
+                return str(inner[key])
+    for key in ("message_id", "messageId", "request_id", "requestId"):
+        if data.get(key):
+            return str(data[key])
+    return ""
+
+
+__all__ = [
+    "DEFAULT_MSG91_BASE_URL",
+    "MSG91_CONNECTOR_NAME",
+    "Msg91Credentials",
+    "Msg91Error",
+    "Msg91NotConfigured",
+    "Msg91WhatsAppClient",
+    "resolve_credentials",
+]

--- a/ee/pocketpaw_ee/cloud/growth/service.py
+++ b/ee/pocketpaw_ee/cloud/growth/service.py
@@ -24,10 +24,20 @@
 # draft→proposed via ``transition``), and ``gate_transition`` is the internal
 # seam the growth executor / dispatch worker use to walk gate-owned edges
 # (same legality table, explicit workspace_id, no RequestContext).
+# Updated 2026-07-27 (feat/growth-g6): the WhatsApp dispatch + inbound seams.
+# This module stays the sole owner of the Beanie writes the G-6 slice needs, so
+# ``growth/whatsapp.py`` (the dispatch branch) and ``growth/webhooks.py`` (the
+# MSG91 inbound webhook) never touch a doc class: ``load_draft_for_dispatch`` /
+# ``load_prospect`` are the worker's system-identity readers,
+# ``record_whatsapp_attempt`` / ``finish_whatsapp_attempt`` /
+# ``count_whatsapp_attempts_since`` own the ``WhatsAppSendLog`` compliance
+# record and its rate-cap window, and ``record_whatsapp_inbound_reply`` applies
+# the opt-in + status flips an inbound reply implies.
 
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 from typing import Any
 
 from beanie import PydanticObjectId
@@ -56,6 +66,7 @@ from pocketpaw_ee.cloud.growth.dto import (
 )
 from pocketpaw_ee.cloud.models.draft import Draft as _DraftDoc
 from pocketpaw_ee.cloud.models.prospect import Prospect as _ProspectDoc
+from pocketpaw_ee.cloud.models.whatsapp_send_log import WhatsAppSendLog as _WhatsAppSendLogDoc
 
 logger = logging.getLogger(__name__)
 
@@ -512,15 +523,245 @@ async def propose_send(ctx: RequestContext, draft_id: str) -> ProposeSendRespons
     return ProposeSendResponse(proposal_id=proposal_id, draft=draft)
 
 
+# ---------------------------------------------------------------------------
+# WhatsApp dispatch + inbound (G-6)
+# ---------------------------------------------------------------------------
+
+
+async def load_draft_for_dispatch(draft_id: str) -> Draft | None:
+    """Load a draft by id for the dispatch worker, or ``None``.
+
+    # global-read: the ``growth.dispatch`` arq job carries only (draft_id,
+    # channel) — the job exists ONLY because ``growth.executor`` enqueued it
+    # after a human approved that draft's ``_growth_send`` proposal, so the
+    # doc's own ``workspace`` is the authoritative tenancy for the send. Same
+    # trust model as ``upsert_by_domain`` (worker/system identity, explicit
+    # workspace threaded onward from what we read here). Returns ``None``
+    # rather than raising: a draft deleted between approval and dispatch is a
+    # recordable non-event, not a worker crash.
+    """
+    try:
+        oid = PydanticObjectId(draft_id)
+    except Exception:  # noqa: BLE001 — malformed id == nothing to dispatch
+        return None
+    doc = await _DraftDoc.find_one({"_id": oid})
+    return _draft_to_domain(doc) if doc is not None else None
+
+
+async def load_prospect(workspace_id: str, prospect_id: str) -> Prospect | None:
+    """Load a prospect inside a workspace for a system-identity caller.
+
+    The workspace filter is explicit and mandatory — the dispatch worker passes
+    the workspace it read off the draft, so a draft can never reach across
+    tenants to a prospect. ``None`` when absent (a deleted prospect is a
+    recordable non-event, not a crash).
+    """
+    if not workspace_id:
+        return None
+    try:
+        oid = PydanticObjectId(prospect_id)
+    except Exception:  # noqa: BLE001 — malformed id == nothing to send to
+        return None
+    doc = await _ProspectDoc.find_one({"_id": oid, "workspace": workspace_id})
+    return _to_domain(doc) if doc is not None else None
+
+
+async def record_whatsapp_attempt(
+    workspace_id: str,
+    *,
+    draft_id: str,
+    prospect_id: str,
+    to_number: str,
+    status: str,
+    blocked_reason: str = "",
+    opted_in_at_attempt: bool = False,
+) -> str:
+    """Write the compliance row for one WhatsApp send attempt; return its id.
+
+    Written BEFORE the provider is called (``status="sending"``) so an attempt
+    that crashes mid-flight still leaves a trace, and so the rate-cap window
+    counts in-flight attempts rather than only completed ones. Guard refusals
+    write ``status="blocked"`` with the machine-readable ``blocked_reason`` and
+    are never followed by a provider call.
+    """
+    doc = _WhatsAppSendLogDoc(
+        workspace=workspace_id,
+        draft_id=draft_id,
+        prospect_id=prospect_id,
+        to_number=to_number,
+        status=status,
+        blocked_reason=blocked_reason,
+        opted_in_at_attempt=opted_in_at_attempt,
+    )
+    await doc.insert()
+    # no-event: growth has no realtime subscriber in v1; the sends view polls.
+    return str(doc.id)
+
+
+async def finish_whatsapp_attempt(
+    log_id: str,
+    *,
+    status: str,
+    provider_message_id: str = "",
+    error_code: str = "",
+    error: str = "",
+) -> None:
+    """Finalise a ``sending`` row to ``sent`` / ``failed``.
+
+    ``error`` is truncated here rather than at the call site so no caller can
+    accidentally persist a full provider response (which may echo request
+    headers) into the log.
+    """
+    try:
+        oid = PydanticObjectId(log_id)
+    except Exception:  # noqa: BLE001 — nothing to finalise
+        return
+    doc = await _WhatsAppSendLogDoc.find_one({"_id": oid})
+    if doc is None:
+        return
+    doc.status = status
+    doc.provider_message_id = provider_message_id
+    doc.error_code = error_code
+    doc.error = error[:500]
+    await doc.save()  # bumps updatedAt
+    # no-event: growth has no realtime subscriber in v1; the sends view polls.
+
+
+async def count_whatsapp_attempts_since(workspace_id: str, since: datetime) -> int:
+    """Count attempts that REACHED the provider in the window.
+
+    ``blocked`` rows are excluded on purpose: a refused attempt never touched
+    Meta, so it must not consume the quality-rating budget the cap protects.
+    ``sending`` rows ARE counted — an in-flight send is already committed.
+    """
+    return await _WhatsAppSendLogDoc.find(
+        {
+            "workspace": workspace_id,
+            "status": {"$in": ["sending", "sent", "failed"]},
+            "createdAt": {"$gte": since},
+        }
+    ).count()
+
+
+def _number_variants(number: str) -> list[str]:
+    """The exact stored spellings an inbound number most often matches.
+
+    MSG91 reports the sender in E.164 digits with no ``+``; a prospect row may
+    have been imported with a ``+``. Those three spellings cover the common
+    case with a plain indexed equality match — anything more decorated falls
+    through to ``_loose_number_regex``.
+    """
+    digits = "".join(ch for ch in number if ch.isdigit())
+    if not digits:
+        return []
+    variants = {number.strip(), digits, f"+{digits}"}
+    return [v for v in variants if v]
+
+
+def _loose_number_regex(number: str) -> str:
+    """A separator-tolerant pattern for the same digits.
+
+    Prospects imported from a CSV or a directory carry human formatting —
+    ``+91 98765 43210``, ``+91-98765-43210``, ``(91) 98765 43210``. Normalising
+    the column would mean a migration plus a write-path change shared with
+    every other /growth slice, so the read path absorbs the variance instead:
+    the digits in order, with any non-digits allowed between them. Only used
+    when the exact-match query misses, so the common inbound event still costs
+    one indexed lookup.
+    """
+    digits = "".join(ch for ch in number if ch.isdigit())
+    if not digits:
+        return ""
+    return r"^\D*" + r"\D*".join(digits) + r"\D*$"
+
+
+async def _has_sent_whatsapp_draft(workspace_id: str, prospect_id: str) -> bool:
+    count = await _DraftDoc.find(
+        {
+            "workspace": workspace_id,
+            "prospect_id": prospect_id,
+            "channel": "whatsapp",
+            "status": "sent",
+        }
+    ).count()
+    return count > 0
+
+
+async def record_whatsapp_inbound_reply(number: str) -> int:
+    """Apply an inbound WhatsApp reply: opt the prospect in, mark them replied.
+
+    Returns how many prospect rows were updated — 0 for a number we don't hold,
+    which the webhook turns into a plain 200 so the endpoint never reveals
+    whether a number exists in the system.
+
+    # global-read: the MSG91 inbound webhook is unauthenticated by nature (the
+    # provider is the caller) and its payload carries no workspace, so the
+    # lookup starts from the number alone. Tenancy is re-narrowed immediately:
+    # when any workspace has actually WhatsApp'd this number, only those
+    # workspaces' rows are touched — a tenant that merely holds the same
+    # prospect never learns that someone else's outreach got a reply. Scoping
+    # the resolve by the receiving ``integrated_number`` instead (exact, per
+    # WABA) is the follow-up once the connector row is queryable by config.
+    """
+    variants = _number_variants(number)
+    if not variants:
+        return 0
+
+    docs = await _ProspectDoc.find({"whatsapp_number": {"$in": variants}}).to_list()
+    if not docs:
+        # Second pass for human-formatted stored numbers. See _loose_number_regex.
+        pattern = _loose_number_regex(number)
+        if pattern:
+            docs = await _ProspectDoc.find({"whatsapp_number": {"$regex": pattern}}).to_list()
+    if not docs:
+        return 0
+
+    messaged = [d for d in docs if await _has_sent_whatsapp_draft(d.workspace, str(d.id))]
+    targets = messaged or docs
+
+    for doc in targets:
+        doc.opted_in = True
+        doc.status = "replied"
+        await doc.save()  # bumps updatedAt
+        # no-event: growth has no realtime subscriber in v1.
+
+        sent_drafts = await _DraftDoc.find(
+            {
+                "workspace": doc.workspace,
+                "prospect_id": str(doc.id),
+                "channel": "whatsapp",
+                "status": "sent",
+            }
+        ).to_list()
+        for draft in sent_drafts:
+            # sent→replied is legal per DRAFT_TRANSITIONS and is not a
+            # gate-owned target; the gate seam is used because this caller runs
+            # under a system identity with no RequestContext.
+            await gate_transition(doc.workspace, str(draft.id), "replied")
+
+    logger.info(
+        "growth.whatsapp_inbound: reply matched %d prospect row(s) across %d candidate(s)",
+        len(targets),
+        len(docs),
+    )
+    return len(targets)
+
+
 __all__ = [
     "bulk_ingest",
+    "count_whatsapp_attempts_since",
     "create",
     "create_draft",
+    "finish_whatsapp_attempt",
     "gate_transition",
     "get",
     "list_drafts",
     "list_prospects",
+    "load_draft_for_dispatch",
+    "load_prospect",
     "propose_send",
+    "record_whatsapp_attempt",
+    "record_whatsapp_inbound_reply",
     "transition",
     "update",
     "upsert_by_domain",

--- a/ee/pocketpaw_ee/cloud/growth/webhooks.py
+++ b/ee/pocketpaw_ee/cloud/growth/webhooks.py
@@ -1,0 +1,214 @@
+# ee/pocketpaw_ee/cloud/growth/webhooks.py — the inbound MSG91 WhatsApp webhook
+# for the /growth outbound engine (G-6).
+#
+# ``POST /api/v1/growth/webhooks/msg91``. Like the Recall webhook, this router
+# carries NO auth dependency — the provider is the caller — so trust rests
+# entirely on the signature. Unlike the Recall webhook it FAILS CLOSED: a
+# missing header, a malformed header, a bad digest, AND an unconfigured secret
+# all return 403. An inbound reply is the event that flips ``opted_in`` to True,
+# i.e. the event that unlocks future business-initiated sends to that number, so
+# an unauthenticated caller must never be able to forge one. There is no
+# "accept it while you finish wiring up the secret" mode.
+#
+# Signature scheme: HMAC-SHA256 over the RAW request body, keyed by
+# ``GROWTH_MSG91_WEBHOOK_SECRET``, hex-encoded, in ``X-Msg91-Signature``. An
+# optional ``sha256=`` prefix is tolerated because several providers emit it.
+# MSG91 does not publish a fixed signing scheme for WhatsApp inbound events
+# (you configure the callback URL and any custom headers on the account), so
+# this is the repo-standard shared-secret HMAC — the same primitive the Svix
+# verification in ``meetings/providers/recall/webhooks.py`` uses, minus the
+# Svix-specific id/timestamp envelope.
+#
+# WHAT AN INBOUND REPLY MEANS: under Meta's rules a user-initiated message both
+# opens a 24-hour service window and is the opt-in signal for that number. So
+# the handler sets ``prospect.opted_in = True``, moves the prospect to
+# ``replied``, and walks any ``sent`` WhatsApp draft for that prospect to
+# ``replied`` through the service's gate seam.
+#
+# The response body is a CONSTANT ``{"ok": true}`` for every accepted request —
+# processed, ignored, or unknown number. A caller with a valid signature still
+# must not be able to use this endpoint as a membership oracle over phone
+# numbers.
+#
+# Created 2026-07-27 (feat/growth-g6): new module.
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import os
+from typing import Any
+
+from fastapi import APIRouter, Request
+from starlette.datastructures import Headers
+
+from pocketpaw_ee.cloud._core.errors import Forbidden
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/growth/webhooks", tags=["Growth"])
+
+_SECRET_ENV = "GROWTH_MSG91_WEBHOOK_SECRET"
+_SIGNATURE_HEADERS = ("x-msg91-signature", "x-webhook-signature")
+
+# Event/type discriminators that mean "this is a delivery receipt, not a human
+# replying". Status callbacks must never be read as an opt-in.
+_STATUS_TYPES = frozenset(
+    {"status", "statuses", "delivery", "delivered", "read", "sent", "failed", "deleted"}
+)
+
+# Keys the sender's number has appeared under across MSG91's inbound shapes.
+_NUMBER_KEYS = (
+    "customer_number",
+    "from",
+    "sender",
+    "mobile",
+    "recipient_number",
+    "number",
+)
+
+
+@router.post("/msg91")
+async def msg91_webhook(request: Request) -> dict:
+    """Ingest an MSG91 WhatsApp inbound event.
+
+    A verified inbound reply opts the prospect in, marks them ``replied``, and
+    walks their sent WhatsApp drafts to ``replied``. Delivery-status callbacks
+    and numbers we don't hold are accepted and ignored. A bad or missing
+    signature is a 403 — nothing is read from an unverified body.
+    """
+    raw = await request.body()
+    _verify_signature(request.headers, raw)
+
+    try:
+        event = json.loads(raw or b"{}")
+    except ValueError:
+        logger.warning("growth/msg91 webhook: body was not valid JSON")
+        return {"ok": True}
+    if not isinstance(event, dict):
+        return {"ok": True}
+
+    if _is_status_callback(event):
+        return {"ok": True}
+
+    number = _extract_number(event)
+    if not number:
+        logger.info("growth/msg91 webhook: inbound event carried no sender number — ignored")
+        return {"ok": True}
+
+    from pocketpaw_ee.cloud.growth import service as growth_service
+
+    matched = await growth_service.record_whatsapp_inbound_reply(number)
+    # Logged (operators need it), never returned — the response shape is
+    # identical for a known and an unknown number.
+    logger.info("growth/msg91 webhook: inbound reply applied to %d prospect row(s)", matched)
+    return {"ok": True}
+
+
+# ---------------------------------------------------------------------------
+# Signature verification — fail closed
+# ---------------------------------------------------------------------------
+
+
+def _verify_signature(headers: Headers, body: bytes) -> None:
+    """Verify the shared-secret HMAC. Raises ``Forbidden`` on ANY doubt.
+
+    Deliberately stricter than the Recall webhook's verifier: an unset secret
+    rejects rather than warning-and-accepting, because accepting an unsigned
+    body here would let anyone flip ``opted_in`` on a prospect and thereby
+    unlock business-initiated sends to a number that never consented.
+    """
+    secret = os.environ.get(_SECRET_ENV, "").strip()
+    if not secret:
+        logger.error(
+            "%s is not set — rejecting the MSG91 webhook. This endpoint fails closed; "
+            "set the secret to enable inbound replies.",
+            _SECRET_ENV,
+        )
+        raise Forbidden(
+            "growth.webhook_unverifiable",
+            "The MSG91 webhook secret is not configured on this deployment.",
+        )
+
+    provided = ""
+    for name in _SIGNATURE_HEADERS:
+        value = headers.get(name)
+        if value:
+            provided = value.strip()
+            break
+    if not provided:
+        raise Forbidden(
+            "growth.webhook_unsigned", "The MSG91 webhook is missing its signature header."
+        )
+    # Tolerate the common ``sha256=<hex>`` prefix form.
+    if "=" in provided:
+        prefix, _, rest = provided.partition("=")
+        if prefix.strip().lower() in ("sha256", "v1"):
+            provided = rest.strip()
+
+    expected = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(provided.lower(), expected):
+        raise Forbidden(
+            "growth.webhook_signature_invalid", "The MSG91 webhook signature did not verify."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Payload shape helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_status_callback(event: dict[str, Any]) -> bool:
+    """True when the payload is a delivery receipt rather than a human reply."""
+    for key in ("type", "event", "event_type"):
+        value = event.get(key)
+        if isinstance(value, str) and value.strip().lower() in _STATUS_TYPES:
+            return True
+    # Meta's envelope nests receipts under ``statuses`` with no inbound message.
+    for container in (event, event.get("data"), event.get("payload")):
+        if (
+            isinstance(container, dict)
+            and container.get("statuses")
+            and not container.get("messages")
+        ):
+            return True
+    return False
+
+
+def _extract_number(event: dict[str, Any]) -> str:
+    """Pull the sender's number out of an inbound payload, or "".
+
+    MSG91 has used several envelopes (flat, ``data``-wrapped, and a Meta-style
+    ``messages[]`` passthrough), so this checks the shapes we've seen rather
+    than assuming one. Returns the raw string; normalisation into the spellings
+    a prospect row might carry happens in the service.
+    """
+    containers: list[dict[str, Any]] = [event]
+    for key in ("data", "payload", "content", "message"):
+        nested = event.get(key)
+        if isinstance(nested, dict):
+            containers.append(nested)
+
+    for container in containers:
+        for key in _NUMBER_KEYS:
+            value = container.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+            # Meta nests ``from`` inside a contact/profile object in some shapes.
+            if isinstance(value, dict):
+                inner = value.get("number") or value.get("wa_id") or value.get("id")
+                if isinstance(inner, str) and inner.strip():
+                    return inner.strip()
+        messages = container.get("messages")
+        if isinstance(messages, list) and messages:
+            first = messages[0]
+            if isinstance(first, dict):
+                sender = first.get("from") or first.get("customer_number")
+                if isinstance(sender, str) and sender.strip():
+                    return sender.strip()
+    return ""
+
+
+__all__ = ["router"]

--- a/ee/pocketpaw_ee/cloud/growth/whatsapp.py
+++ b/ee/pocketpaw_ee/cloud/growth/whatsapp.py
@@ -1,0 +1,295 @@
+# ee/pocketpaw_ee/cloud/growth/whatsapp.py — the ``channel="whatsapp"`` branch of
+# the ``growth.dispatch`` job (G-6).
+#
+# THE OPT-IN GUARD IS THE POINT OF THIS MODULE. Meta's policy on
+# business-initiated template messages is not a style preference: sending a
+# template to a number that never opted in tanks the WhatsApp Business Account's
+# quality rating, and a repeat offender's number gets restricted and then banned
+# — for the whole tenant, not the one draft. So ``prospect.opted_in`` is enforced
+# HERE, at the service layer, one call above the provider, rather than as a UI
+# convention or a router check. A not-opted-in prospect makes NO provider call at
+# all: the guard writes a ``blocked`` compliance row, raises ``OptInRequired``,
+# and leaves the draft sitting in ``approved`` so a human can see it never went.
+#
+# Guard sequence (order matters — the cheap, irreversible-consequence checks
+# come first, and every refusal writes its own ``blocked`` row):
+#   1. Draft exists and is still ``approved``. The gate (G-4) owns that status;
+#      a draft that moved between enqueue and dispatch must not send.
+#   2. The prospect still exists in the DRAFT's workspace (tenancy is threaded
+#      from the doc, never from the job payload).
+#   3. ``prospect.opted_in`` — the hard guard. No opt-in, no provider call.
+#   4. A reachable number.
+#   5. The per-hour rate cap (``GROWTH_WHATSAPP_MAX_PER_HOUR``).
+#   6. Resolvable MSG91 credentials for that workspace.
+# Only then: write the ``sending`` row, call the provider, finalise the row, and
+# flip approved→sent through the EXISTING ``service.gate_transition`` seam — the
+# gate owns that edge, this module does not reimplement it.
+#
+# WHY A RATE CAP AT ALL: WhatsApp quality rating is computed over a rolling
+# window of recent business-initiated messages. A burst — a bulk approval, a
+# retry storm, a mis-scoped follow-up cron — is exactly the shape that trips it,
+# and the damage (messaging-limit downgrade, then restriction) lands on the
+# WABA, not on the individual send. Capping outbound per hour keeps a bug
+# expensive-but-survivable instead of account-fatal. Refused sends do NOT
+# consume the window (they never reached Meta) and are never silently dropped:
+# each writes a ``rate_capped`` row and fails the job loudly.
+#
+# Created 2026-07-27 (feat/growth-g6): new module.
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from pocketpaw_ee.cloud.growth.msg91 import (
+    Msg91Credentials,
+    Msg91Error,
+    Msg91NotConfigured,
+    Msg91WhatsAppClient,
+)
+
+logger = logging.getLogger(__name__)
+
+# Per-workspace outbound ceiling per rolling hour. 20 is deliberately low: the
+# /growth engine is a considered-outbound tool, not a blaster, and a human
+# approves every single send through the Instinct gate anyway — so the cap is a
+# blast-radius bound on bugs, not a throughput knob.
+_MAX_PER_HOUR_ENV = "GROWTH_WHATSAPP_MAX_PER_HOUR"
+_DEFAULT_MAX_PER_HOUR = 20
+_RATE_WINDOW = timedelta(hours=1)
+
+
+class WhatsAppDispatchError(Exception):
+    """A WhatsApp send was refused or failed. ``code`` is machine-readable."""
+
+    code = "growth.whatsapp_dispatch_failed"
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+
+class DraftNotApproved(WhatsAppDispatchError):
+    """The draft is not in ``approved`` — the gate did not clear this send."""
+
+    code = "growth.draft_not_approved"
+
+
+class ProspectUnavailable(WhatsAppDispatchError):
+    """The draft's prospect is gone, or has no reachable WhatsApp number."""
+
+    code = "growth.prospect_unavailable"
+
+
+class OptInRequired(WhatsAppDispatchError):
+    """The prospect has not opted in — the hard compliance stop.
+
+    Raised BEFORE any provider client is constructed or called. If you are
+    reading this because a send failed: the fix is an opt-in, never a bypass.
+    """
+
+    code = "growth.whatsapp_opt_in_required"
+
+
+class RateCapExceeded(WhatsAppDispatchError):
+    """The workspace already sent its hourly allowance."""
+
+    code = "growth.whatsapp_rate_capped"
+
+
+class WhatsAppNotConfigured(WhatsAppDispatchError):
+    """No usable MSG91 credentials for the draft's workspace."""
+
+    code = "growth.whatsapp_not_configured"
+
+
+def max_per_hour() -> int:
+    """The configured hourly cap. Read per call so ops can retune without a
+    redeploy and so tests can drive the boundary with ``monkeypatch.setenv``.
+    A non-numeric or negative value falls back to the default rather than
+    accidentally disabling the protection."""
+    raw = os.environ.get(_MAX_PER_HOUR_ENV, "").strip()
+    if not raw:
+        return _DEFAULT_MAX_PER_HOUR
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            "%s=%r is not an integer — falling back to %d",
+            _MAX_PER_HOUR_ENV,
+            raw,
+            _DEFAULT_MAX_PER_HOUR,
+        )
+        return _DEFAULT_MAX_PER_HOUR
+    return value if value >= 0 else _DEFAULT_MAX_PER_HOUR
+
+
+def _build_client(credentials: Msg91Credentials) -> Any:
+    """Construct the provider client.
+
+    Module-level indirection so tests inject a fake by monkeypatching THIS
+    function — the same seam shape as ``executor._get_pool``. Because the fake
+    is the only client the suite ever builds, "the provider was never called"
+    is assertable directly on the fake instead of by mocking ``httpx``.
+    """
+    return Msg91WhatsAppClient(credentials)
+
+
+async def dispatch_whatsapp(draft_id: str) -> None:
+    """Send one approved WhatsApp draft via MSG91. See the module header.
+
+    Raises a ``WhatsAppDispatchError`` subclass on every refusal. The growth
+    worker runs with ``max_tries = 1``, so a raise records a failed job for
+    operator review rather than retrying an outbound message.
+    """
+    from pocketpaw_ee.cloud.growth import service as growth_service
+
+    draft = await growth_service.load_draft_for_dispatch(draft_id)
+    if draft is None:
+        # Nothing to block, nothing to send, nothing to attribute to a
+        # workspace — a deleted draft is a non-event, not a failure.
+        logger.warning("growth/whatsapp: draft %s no longer exists — nothing dispatched", draft_id)
+        return
+
+    workspace_id = draft.workspace_id
+
+    async def _blocked(reason: str, *, to_number: str = "", opted_in: bool = False) -> None:
+        """Record a refusal. No provider call has happened or will happen."""
+        await growth_service.record_whatsapp_attempt(
+            workspace_id,
+            draft_id=draft_id,
+            prospect_id=draft.prospect_id,
+            to_number=to_number,
+            status="blocked",
+            blocked_reason=reason,
+            opted_in_at_attempt=opted_in,
+        )
+
+    # (1) The gate (G-4) owns ``approved``. A draft that moved between enqueue
+    # and dispatch — rejected by hand, already sent — must not go out.
+    if draft.status != "approved":
+        await _blocked("draft_not_approved")
+        raise DraftNotApproved(
+            f"draft {draft_id} is '{draft.status}', not 'approved' — refusing to send"
+        )
+
+    # (2) Tenancy comes off the draft doc, never off the job payload.
+    prospect = await growth_service.load_prospect(workspace_id, draft.prospect_id)
+    if prospect is None:
+        await _blocked("prospect_missing")
+        raise ProspectUnavailable(
+            f"draft {draft_id} points at a prospect that no longer exists in its workspace"
+        )
+
+    # (3) THE HARD GUARD. Not a warning, not a UI convention: no opt-in, no
+    # provider call, draft left approved, refusal recorded.
+    if not prospect.opted_in:
+        await _blocked("not_opted_in", to_number=prospect.whatsapp_number or "")
+        logger.warning(
+            "growth/whatsapp: REFUSED draft %s — prospect %s has not opted in "
+            "(no provider call made)",
+            draft_id,
+            draft.prospect_id,
+        )
+        raise OptInRequired(
+            "WhatsApp template sends require a recorded opt-in from the prospect; "
+            f"prospect {draft.prospect_id} has none"
+        )
+
+    to_number = (prospect.whatsapp_number or "").strip()
+    # (4) An opted-in prospect with no number is a data problem, not a policy one.
+    if not to_number:
+        await _blocked("no_number", opted_in=True)
+        raise ProspectUnavailable(
+            f"prospect {draft.prospect_id} has opted in but carries no WhatsApp number"
+        )
+
+    # (5) Quality-rating protection. Counted over the trailing hour of attempts
+    # that actually reached the provider; refusals don't consume the budget.
+    # There is deliberately no "disabled" value: a cap of 0 refuses everything
+    # rather than meaning "unlimited", so a fat-fingered env var fails closed.
+    cap = max_per_hour()
+    since = datetime.now(UTC) - _RATE_WINDOW
+    recent = await growth_service.count_whatsapp_attempts_since(workspace_id, since)
+    if recent >= cap:
+        await _blocked("rate_capped", to_number=to_number, opted_in=True)
+        logger.warning(
+            "growth/whatsapp: REFUSED draft %s — workspace %s already made %d/%d "
+            "attempts this hour (no provider call made)",
+            draft_id,
+            workspace_id,
+            recent,
+            cap,
+        )
+        raise RateCapExceeded(
+            f"workspace {workspace_id} has already sent {recent} WhatsApp messages in "
+            f"the last hour (cap {cap}, {_MAX_PER_HOUR_ENV})"
+        )
+
+    # (6) Credentials last — an unconfigured workspace is a blocked attempt, not
+    # a failed one, because nothing was tried.
+    try:
+        credentials = await resolve_credentials(workspace_id)
+    except Msg91NotConfigured as exc:
+        await _blocked("not_configured", to_number=to_number, opted_in=True)
+        raise WhatsAppNotConfigured(str(exc)) from exc
+
+    log_id = await growth_service.record_whatsapp_attempt(
+        workspace_id,
+        draft_id=draft_id,
+        prospect_id=draft.prospect_id,
+        to_number=to_number,
+        status="sending",
+        opted_in_at_attempt=True,
+    )
+
+    client = _build_client(credentials)
+    try:
+        provider_message_id = await client.send_template(to_number=to_number, body_text=draft.body)
+    except Msg91Error as exc:
+        await growth_service.finish_whatsapp_attempt(
+            log_id, status="failed", error_code=exc.code, error=exc.message
+        )
+        # The draft stays ``approved`` — the approval stands, the delivery
+        # didn't. An operator can re-dispatch without a second human approval.
+        raise WhatsAppDispatchError(f"MSG91 send failed: {exc.message}") from exc
+
+    await growth_service.finish_whatsapp_attempt(
+        log_id, status="sent", provider_message_id=provider_message_id
+    )
+    # The gate owns approved→sent; this module walks it through the existing
+    # seam rather than writing the status itself.
+    await growth_service.gate_transition(workspace_id, draft_id, "sent")
+    logger.info(
+        "growth/whatsapp: sent draft %s (workspace=%s, provider_message_id=%r)",
+        draft_id,
+        workspace_id,
+        provider_message_id,
+    )
+
+
+async def resolve_credentials(workspace_id: str) -> Msg91Credentials:
+    """Thin re-export of the msg91 resolver.
+
+    Kept as a module-level function here so a test can stub credential
+    resolution at the dispatch seam without reaching into the connector state
+    store — and so the credential object never has to be threaded through the
+    job payload.
+    """
+    from pocketpaw_ee.cloud.growth.msg91 import resolve_credentials as _resolve
+
+    return await _resolve(workspace_id)
+
+
+__all__ = [
+    "DraftNotApproved",
+    "OptInRequired",
+    "ProspectUnavailable",
+    "RateCapExceeded",
+    "WhatsAppDispatchError",
+    "WhatsAppNotConfigured",
+    "dispatch_whatsapp",
+    "max_per_hour",
+]

--- a/ee/pocketpaw_ee/cloud/growth/worker.py
+++ b/ee/pocketpaw_ee/cloud/growth/worker.py
@@ -12,6 +12,12 @@
 # actual delivery and the draft's ``sent`` flip (via the service's
 # ``gate_transition`` seam). The job only ever EXISTS for a draft whose
 # ``_growth_send`` proposal a human approved — that is the whole gate.
+# Updated 2026-07-27 (feat/growth-g6): the ``channel="whatsapp"`` branch is
+# live — it delegates to ``growth.whatsapp.dispatch_whatsapp``, which enforces
+# the hard ``prospect.opted_in`` guard (no opt-in ⇒ NO provider call at all),
+# the hourly ``GROWTH_WHATSAPP_MAX_PER_HOUR`` cap, the MSG91 send, and the
+# approved→sent flip through ``service.gate_transition``. Other channels keep
+# the stub.
 #
 # Unlike workspace jobs (which ride arq's DEFAULT queue on the shared chat-runs
 # worker — see ``jobs/domain.py``), growth gets its OWN queue + worker process
@@ -51,19 +57,33 @@ logger = logging.getLogger(__name__)
 
 
 async def dispatch(ctx: dict[str, Any], draft_id: str, channel: str) -> None:
-    """Dispatch an APPROVED outbound draft — STUB (G-4).
+    """Dispatch an APPROVED outbound draft.
 
     This job is enqueued ONLY by ``executor.execute_approved_growth_send``
     after a human approved the draft's ``_growth_send`` Instinct proposal —
     there is no other producer, so a job here IS the approval record's
-    downstream. In this slice it logs and returns: no provider call, no
-    draft mutation, nothing is marked sent. G-5/G-6 replace the body with the
-    real per-channel delivery + the draft's ``sent`` flip (via
-    ``service.gate_transition``) + follow-up scheduling.
+    downstream.
+
+    ``whatsapp`` is live (G-6): it enforces the hard opt-in guard, the hourly
+    rate cap, sends via MSG91, and flips the draft approved→sent through the
+    gate seam. Every refusal RAISES (``max_tries = 1``, so the job lands as a
+    failed job an operator can see) and writes its own compliance row — a
+    refused send is never a silent success.
+
+    The other channels remain the G-4 logging stub until their slices land
+    (G-5 email); they mark nothing sent.
     """
+    if channel == "whatsapp":
+        # Imported lazily so the worker module stays importable (and arq's
+        # settings class evaluable) without the provider stack.
+        from pocketpaw_ee.cloud.growth.whatsapp import dispatch_whatsapp
+
+        await dispatch_whatsapp(draft_id)
+        return
+
     logger.info(
         "growth worker: dispatch STUB — draft=%s channel=%s (approved send queued; "
-        "no delivery in G-4, nothing marked sent)",
+        "no delivery for this channel yet, nothing marked sent)",
         draft_id,
         channel,
     )

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -1,5 +1,12 @@
 """Cloud document models — re-exports for Beanie init.
 
+Updated: 2026-07-27 (feat/growth-g6) — added ``WhatsAppSendLog`` (the /growth
+per-attempt outbound WhatsApp compliance record: one row per attempt, including
+the attempts the opt-in guard REFUSED) to the imports and
+``get_all_documents()`` so the ``growth_whatsapp_send_logs`` collection is wired
+into ``init_beanie``. Kept out of ``__all__`` like ``Prospect`` / ``Draft`` —
+only ``ee.cloud.growth.service`` imports the doc class directly (import-linter
+"Growth" contract).
 Updated: 2026-07-27 (feat/growth-g4 merge) — merged integration/ship-v1 into the
 growth stack so the ``_growth_send`` gate slice can wire the sixth gated kind on
 top of ship's instinct-router changes; both changelog blocks below retained.
@@ -219,6 +226,7 @@ from pocketpaw_ee.cloud.models.temporal_sweep_state import TemporalSweepStateDoc
 from pocketpaw_ee.cloud.models.user import OAuthAccount, User, WorkspaceMembership
 from pocketpaw_ee.cloud.models.vapid_keypair import VapidKeypair
 from pocketpaw_ee.cloud.models.web_sandbox import WebSandbox
+from pocketpaw_ee.cloud.models.whatsapp_send_log import WhatsAppSendLog
 from pocketpaw_ee.cloud.models.workspace import Workspace, WorkspaceSettings
 from pocketpaw_ee.cloud.models.workspace_automation_config import WorkspaceAutomationConfig
 from pocketpaw_ee.cloud.models.workspace_job import WorkspaceJobDoc
@@ -509,6 +517,10 @@ def get_all_documents():
         # prospect, status lifecycle enforced in the service. Same import
         # boundary as Prospect.
         Draft,
+        # Growth WhatsApp send log (G-6) — one row per outbound attempt,
+        # including the attempts the opt-in guard refused (``blocked``). Same
+        # import boundary as Prospect / Draft.
+        WhatsAppSendLog,
         PushSubscription,
         VapidKeypair,
         WorkspaceSensePreference,

--- a/ee/pocketpaw_ee/cloud/models/whatsapp_send_log.py
+++ b/ee/pocketpaw_ee/cloud/models/whatsapp_send_log.py
@@ -1,0 +1,66 @@
+# ee/pocketpaw_ee/cloud/models/whatsapp_send_log.py — the per-attempt outbound
+# WhatsApp send record for the /growth engine (G-6, feat/growth-g6).
+#
+# This is the COMPLIANCE record, not a convenience log. Meta's business-initiated
+# messaging policy makes "we only messaged opted-in people" a claim we have to be
+# able to prove after the fact, per recipient, so every attempt writes a row
+# BEFORE the provider is called and the row is finalised after — including the
+# attempts we refused. ``status="blocked"`` + ``blocked_reason="not_opted_in"``
+# is the row that proves the guard fired and no message left the building.
+#
+# Named ``WhatsAppSendLog`` deliberately: the sibling G-5 (email dispatch) slice
+# introduces its own ``MessageLog``-style record for the email channel. Rather
+# than guess at that shape from a concurrent branch, the WhatsApp channel carries
+# its own distinctly-named record; reconciling the two into one send log is a
+# follow-up once both have landed.
+#
+# Only ``ee.cloud.growth.service`` imports this doc class (import-linter "Growth"
+# contract) — the whatsapp/msg91/webhook modules go through the service.
+#
+# Created 2026-07-27 (feat/growth-g6): sixth slice of /growth — MSG91 WhatsApp
+# dispatch with hard opt-in enforcement.
+
+from __future__ import annotations
+
+from beanie import Indexed
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class WhatsAppSendLog(TimestampedDocument):
+    """One outbound WhatsApp send attempt (including refused attempts)."""
+
+    # Tenancy boundary — every read filters on this.
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    draft_id: str
+    prospect_id: str
+    # The recipient, as it was resolved at attempt time. Kept because the
+    # compliance question is always "who did you message, and were they opted
+    # in", and the prospect row can be edited afterwards.
+    to_number: str = ""
+    # ``sending`` is written BEFORE the provider call and finalised to ``sent``
+    # or ``failed`` after it. ``blocked`` means a guard refused the attempt and
+    # NO provider call was made at all.
+    status: str = "sending"  # sending | sent | failed | blocked
+    # Machine-readable reason a ``blocked`` row exists (``not_opted_in``,
+    # ``rate_capped``, ``draft_not_approved``, ``no_number``, ``not_configured``).
+    blocked_reason: str = ""
+    provider: str = "msg91"
+    provider_message_id: str = ""
+    error_code: str = ""
+    error: str = ""
+    # The opt-in fact AS OF the attempt — a later edit to the prospect can never
+    # rewrite what we knew when we pressed send.
+    opted_in_at_attempt: bool = False
+
+    class Settings:
+        name = "growth_whatsapp_send_logs"
+        indexes = [
+            # The rate-cap window scan: attempts that reached the provider in
+            # this workspace within the trailing hour.
+            [("workspace", 1), ("status", 1), ("createdAt", -1)],
+            # A draft's send history — the per-draft audit view.
+            [("workspace", 1), ("draft_id", 1)],
+            # The compliance query: everything we ever sent to one number.
+            [("workspace", 1), ("to_number", 1)],
+        ]

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -814,6 +814,10 @@ name = "Growth — Beanie writes only from service.py"
 # feat/growth-g4 — the gate modules join the boundary: ``propose`` files the
 # Instinct Action and ``executor`` flips drafts ONLY through the service's
 # ``gate_transition`` seam, never the doc class directly.
+# feat/growth-g6 — the WhatsApp dispatch modules join the boundary, and the
+# ``WhatsAppSendLog`` compliance doc joins the forbidden list: ``whatsapp``
+# (the dispatch branch), ``msg91`` (the provider seam) and ``webhooks`` (the
+# inbound MSG91 endpoint) all read and write through ``growth.service``.
 type = "forbidden"
 allow_indirect_imports = "true"
 source_modules = [
@@ -823,10 +827,14 @@ source_modules = [
     "pocketpaw_ee.cloud.growth.worker",
     "pocketpaw_ee.cloud.growth.propose",
     "pocketpaw_ee.cloud.growth.executor",
+    "pocketpaw_ee.cloud.growth.whatsapp",
+    "pocketpaw_ee.cloud.growth.msg91",
+    "pocketpaw_ee.cloud.growth.webhooks",
 ]
 forbidden_modules = [
     "pocketpaw_ee.cloud.models.prospect",
     "pocketpaw_ee.cloud.models.draft",
+    "pocketpaw_ee.cloud.models.whatsapp_send_log",
 ]
 
 [[tool.importlinter.contracts]]

--- a/tests/cloud/growth/test_whatsapp_dispatch.py
+++ b/tests/cloud/growth/test_whatsapp_dispatch.py
@@ -1,0 +1,527 @@
+# tests/cloud/growth/test_whatsapp_dispatch.py — the G-6 WhatsApp dispatch
+# slice (``ee/cloud/growth/{whatsapp,msg91,worker,service}.py``).
+#
+# This is the COMPLIANCE suite. The load-bearing assertion in the whole file is
+# ``fake_client.calls == []`` on the not-opted-in path: Meta bans WABA numbers
+# that send business-initiated templates to people who never consented, so
+# "the provider was never called" has to be provable, not inferred from a
+# status field. Everything else here exists to keep that guarantee honest.
+#
+# What it proves:
+#   1. An opted-in approved draft sends exactly once, flips approved→sent
+#      through the gate seam, and writes a ``sent`` compliance row.
+#   2. A NOT-opted-in prospect makes ZERO provider calls, raises the typed
+#      ``OptInRequired``, leaves the draft ``approved``, and writes a
+#      ``blocked``/``not_opted_in`` row. A companion test booby-traps credential
+#      resolution to prove the guard fires before credentials are even read.
+#   3. A draft that isn't ``approved`` (the gate didn't clear it) never sends.
+#   4. The hourly cap refuses the N+1th send with no provider call — and
+#      refused attempts do NOT consume the window.
+#   5. A provider failure is recorded as ``failed`` and leaves the draft
+#      ``approved`` (the approval stands, the delivery didn't).
+#   6. Credentials never reach a log record, a response, or the send log —
+#      including through ``repr()``, the usual leak path.
+#   7. The arq worker routes ``channel="whatsapp"`` into the real branch.
+#
+# Network-free by construction: the suite monkeypatches ``whatsapp._build_client``,
+# so ``Msg91WhatsAppClient`` (the only thing that imports httpx) is never
+# constructed. No ``httpx`` mocking, no recorded cassettes, no socket.
+#
+# Created 2026-07-27 (feat/growth-g6): new module.
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud.growth import service as growth_service
+from pocketpaw_ee.cloud.growth import whatsapp as growth_whatsapp
+from pocketpaw_ee.cloud.growth.dto import CreateDraftRequest, CreateProspectRequest
+from pocketpaw_ee.cloud.growth.msg91 import Msg91Credentials, Msg91Error, Msg91NotConfigured
+
+# A distinctive sentinel so a substring search over logs / serialised output is
+# a meaningful leak assertion rather than a coincidence.
+SECRET_AUTHKEY = "msg91-authkey-DO-NOT-LEAK-8f3a91"
+
+_CREDS = Msg91Credentials(
+    authkey=SECRET_AUTHKEY,
+    integrated_number="919000000000",
+    template_name="paw_first_touch",
+)
+
+
+class FakeMsg91Client:
+    """Records every send instead of making one. The assertion surface for
+    "no provider call happened" is simply ``calls == []``."""
+
+    def __init__(self, credentials: Msg91Credentials, *, raises: Exception | None = None) -> None:
+        self.credentials = credentials
+        self.calls: list[tuple[str, str]] = []
+        self._raises = raises
+
+    async def send_template(self, *, to_number: str, body_text: str) -> str:
+        self.calls.append((to_number, body_text))
+        if self._raises is not None:
+            raise self._raises
+        return f"msg91-{len(self.calls)}"
+
+
+class ExplodingCredentials:
+    """Sentinel: any credential resolution at all is a test failure.
+
+    Used to prove the opt-in guard short-circuits BEFORE the provider stack is
+    touched — not merely before the HTTP call.
+    """
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def __call__(self, workspace_id: str) -> Msg91Credentials:
+        self.calls += 1
+        raise AssertionError(
+            "credentials were resolved for a send that should have been refused earlier"
+        )
+
+
+@pytest.fixture
+def fake_client(monkeypatch: pytest.MonkeyPatch) -> FakeMsg91Client:
+    """Install a fake provider client + stub credentials at the dispatch seams."""
+    client = FakeMsg91Client(_CREDS)
+
+    async def _resolve(workspace_id: str) -> Msg91Credentials:
+        return _CREDS
+
+    monkeypatch.setattr(growth_whatsapp, "resolve_credentials", _resolve)
+    monkeypatch.setattr(growth_whatsapp, "_build_client", lambda creds: client)
+    return client
+
+
+def _ctx(workspace_id: str, user_id: str = "u1") -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="test",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+async def _seed_prospect(
+    workspace_id: str = "w1",
+    *,
+    domain: str = "acme-dental.com",
+    opted_in: bool = True,
+    number: str | None = "919876543210",
+) -> Any:
+    return await growth_service.create(
+        _ctx(workspace_id),
+        CreateProspectRequest(
+            name="Sam Founder",
+            company="Acme Dental",
+            domain=domain,
+            source="manual",
+            whatsapp_number=number,
+            opted_in=opted_in,
+        ),
+    )
+
+
+async def _seed_draft(
+    workspace_id: str,
+    prospect_id: str,
+    *,
+    body: str = "Saw your booking flow stops at a contact form — 2 min demo?",
+    approve: bool = True,
+) -> Any:
+    draft = await growth_service.create_draft(
+        _ctx(workspace_id),
+        prospect_id,
+        CreateDraftRequest(channel="whatsapp", body=body),
+    )
+    await growth_service.gate_transition(workspace_id, draft.id, "proposed")
+    if approve:
+        await growth_service.gate_transition(workspace_id, draft.id, "approved")
+    return draft
+
+
+@pytest_asyncio.fixture
+async def approved_draft(mongo_db: Any) -> Any:  # noqa: ARG001 — forces Beanie init
+    prospect = await _seed_prospect()
+    draft = await _seed_draft("w1", prospect.id)
+    return prospect, draft
+
+
+async def _logs(workspace_id: str = "w1") -> list[Any]:
+    from pocketpaw_ee.cloud.models.whatsapp_send_log import WhatsAppSendLog
+
+    return await WhatsAppSendLog.find({"workspace": workspace_id}).to_list()
+
+
+async def _draft_status(workspace_id: str, draft_id: str) -> str:
+    drafts = await growth_service.list_drafts(_ctx(workspace_id))
+    return next(d.status for d in drafts if d.id == draft_id)
+
+
+# ---------------------------------------------------------------------------
+# 1 — the happy path
+# ---------------------------------------------------------------------------
+
+
+class TestOptedInSend:
+    async def test_sends_once_flips_to_sent_and_records(
+        self, approved_draft: Any, fake_client: FakeMsg91Client
+    ) -> None:
+        _prospect, draft = approved_draft
+
+        await growth_whatsapp.dispatch_whatsapp(draft.id)
+
+        assert fake_client.calls == [("919876543210", draft.body)]
+        assert await _draft_status("w1", draft.id) == "sent"
+
+        logs = await _logs()
+        assert len(logs) == 1
+        assert logs[0].status == "sent"
+        assert logs[0].blocked_reason == ""
+        assert logs[0].provider_message_id == "msg91-1"
+        assert logs[0].opted_in_at_attempt is True
+        assert logs[0].draft_id == draft.id
+
+    async def test_worker_routes_whatsapp_into_the_real_branch(
+        self, approved_draft: Any, fake_client: FakeMsg91Client
+    ) -> None:
+        """The arq job entrypoint, not just the module function."""
+        from pocketpaw_ee.cloud.growth import worker
+
+        _prospect, draft = approved_draft
+        await worker.dispatch({}, draft.id, "whatsapp")
+
+        assert len(fake_client.calls) == 1
+        assert await _draft_status("w1", draft.id) == "sent"
+
+    async def test_worker_leaves_other_channels_on_the_stub(
+        self, mongo_db: Any, fake_client: FakeMsg91Client
+    ) -> None:
+        from pocketpaw_ee.cloud.growth import worker
+
+        prospect = await _seed_prospect(domain="other-co.com")
+        draft = await growth_service.create_draft(
+            _ctx("w1"), prospect.id, CreateDraftRequest(channel="linkedin", body="hi")
+        )
+        await growth_service.gate_transition("w1", draft.id, "proposed")
+        await growth_service.gate_transition("w1", draft.id, "approved")
+
+        await worker.dispatch({}, draft.id, "linkedin")
+
+        assert fake_client.calls == []
+        assert await _draft_status("w1", draft.id) == "approved"
+
+
+# ---------------------------------------------------------------------------
+# 2 — THE critical one: no opt-in, no provider call
+# ---------------------------------------------------------------------------
+
+
+class TestOptInGuard:
+    @pytest_asyncio.fixture
+    async def not_opted_in(self, mongo_db: Any) -> Any:  # noqa: ARG002
+        prospect = await _seed_prospect(opted_in=False)
+        draft = await _seed_draft("w1", prospect.id)
+        return prospect, draft
+
+    async def test_provider_is_never_called(
+        self, not_opted_in: Any, fake_client: FakeMsg91Client
+    ) -> None:
+        _prospect, draft = not_opted_in
+
+        with pytest.raises(growth_whatsapp.OptInRequired):
+            await growth_whatsapp.dispatch_whatsapp(draft.id)
+
+        # The whole slice in one line: nothing left the building.
+        assert fake_client.calls == []
+
+    async def test_draft_stays_approved(
+        self, not_opted_in: Any, fake_client: FakeMsg91Client
+    ) -> None:
+        _prospect, draft = not_opted_in
+
+        with pytest.raises(growth_whatsapp.OptInRequired):
+            await growth_whatsapp.dispatch_whatsapp(draft.id)
+
+        assert await _draft_status("w1", draft.id) == "approved"
+
+    async def test_writes_a_blocked_compliance_row(
+        self, not_opted_in: Any, fake_client: FakeMsg91Client
+    ) -> None:
+        _prospect, draft = not_opted_in
+
+        with pytest.raises(growth_whatsapp.OptInRequired):
+            await growth_whatsapp.dispatch_whatsapp(draft.id)
+
+        logs = await _logs()
+        assert len(logs) == 1
+        assert logs[0].status == "blocked"
+        assert logs[0].blocked_reason == "not_opted_in"
+        assert logs[0].opted_in_at_attempt is False
+        assert logs[0].provider_message_id == ""
+
+    async def test_error_carries_a_machine_readable_code(
+        self, not_opted_in: Any, fake_client: FakeMsg91Client
+    ) -> None:
+        _prospect, draft = not_opted_in
+
+        with pytest.raises(growth_whatsapp.OptInRequired) as exc_info:
+            await growth_whatsapp.dispatch_whatsapp(draft.id)
+
+        assert exc_info.value.code == "growth.whatsapp_opt_in_required"
+
+    async def test_guard_fires_before_credentials_are_resolved(
+        self, not_opted_in: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Not just "before the HTTP call" — before the provider stack at all.
+
+        A guard that ran after credential resolution would still be correct on
+        paper, but it would mean an unconfigured-vs-non-consenting prospect
+        produce different failures. This pins the order.
+        """
+        _prospect, draft = not_opted_in
+        exploding = ExplodingCredentials()
+        monkeypatch.setattr(growth_whatsapp, "resolve_credentials", exploding)
+        monkeypatch.setattr(
+            growth_whatsapp,
+            "_build_client",
+            lambda creds: pytest.fail("a provider client was constructed for a refused send"),
+        )
+
+        with pytest.raises(growth_whatsapp.OptInRequired):
+            await growth_whatsapp.dispatch_whatsapp(draft.id)
+
+        assert exploding.calls == 0
+
+    async def test_opted_in_but_no_number_is_a_data_error_not_a_send(
+        self, mongo_db: Any, fake_client: FakeMsg91Client
+    ) -> None:
+        prospect = await _seed_prospect(opted_in=True, number=None)
+        draft = await _seed_draft("w1", prospect.id)
+
+        with pytest.raises(growth_whatsapp.ProspectUnavailable):
+            await growth_whatsapp.dispatch_whatsapp(draft.id)
+
+        assert fake_client.calls == []
+        logs = await _logs()
+        assert [entry.blocked_reason for entry in logs] == ["no_number"]
+
+
+# ---------------------------------------------------------------------------
+# 3 — the gate still owns ``approved``
+# ---------------------------------------------------------------------------
+
+
+class TestGateStillOwnsApproved:
+    async def test_unapproved_draft_never_sends(
+        self, mongo_db: Any, fake_client: FakeMsg91Client
+    ) -> None:
+        prospect = await _seed_prospect()
+        draft = await _seed_draft("w1", prospect.id, approve=False)  # sits at ``proposed``
+
+        with pytest.raises(growth_whatsapp.DraftNotApproved):
+            await growth_whatsapp.dispatch_whatsapp(draft.id)
+
+        assert fake_client.calls == []
+        assert await _draft_status("w1", draft.id) == "proposed"
+        assert [entry.blocked_reason for entry in await _logs()] == ["draft_not_approved"]
+
+    async def test_missing_draft_is_a_non_event(
+        self, mongo_db: Any, fake_client: FakeMsg91Client
+    ) -> None:
+        await growth_whatsapp.dispatch_whatsapp("000000000000000000000000")
+        assert fake_client.calls == []
+        assert await _logs() == []
+
+
+# ---------------------------------------------------------------------------
+# 4 — the hourly rate cap
+# ---------------------------------------------------------------------------
+
+
+class TestRateCap:
+    async def test_default_is_twenty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("GROWTH_WHATSAPP_MAX_PER_HOUR", raising=False)
+        assert growth_whatsapp.max_per_hour() == 20
+
+    async def test_garbage_value_falls_back_to_the_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GROWTH_WHATSAPP_MAX_PER_HOUR", "not-a-number")
+        assert growth_whatsapp.max_per_hour() == 20
+
+    async def test_zero_refuses_everything_rather_than_meaning_unlimited(
+        self, mongo_db: Any, fake_client: FakeMsg91Client, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A fat-fingered cap must fail closed, not open the floodgates."""
+        monkeypatch.setenv("GROWTH_WHATSAPP_MAX_PER_HOUR", "0")
+        prospect = await _seed_prospect()
+        draft = await _seed_draft("w1", prospect.id)
+
+        with pytest.raises(growth_whatsapp.RateCapExceeded):
+            await growth_whatsapp.dispatch_whatsapp(draft.id)
+
+        assert fake_client.calls == []
+
+    async def test_n_plus_one_is_refused_without_a_provider_call(
+        self, mongo_db: Any, fake_client: FakeMsg91Client, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GROWTH_WHATSAPP_MAX_PER_HOUR", "1")
+        prospect = await _seed_prospect()
+        first = await _seed_draft("w1", prospect.id, body="first touch")
+        second = await _seed_draft("w1", prospect.id, body="second touch")
+
+        await growth_whatsapp.dispatch_whatsapp(first.id)
+        assert len(fake_client.calls) == 1
+
+        with pytest.raises(growth_whatsapp.RateCapExceeded):
+            await growth_whatsapp.dispatch_whatsapp(second.id)
+
+        # The N+1th send never reached the provider, and its draft is untouched.
+        assert len(fake_client.calls) == 1
+        assert await _draft_status("w1", second.id) == "approved"
+        assert [entry.blocked_reason for entry in await _logs()] == ["", "rate_capped"]
+
+    async def test_the_cap_is_per_workspace(
+        self, mongo_db: Any, fake_client: FakeMsg91Client, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """One tenant burning its allowance must not throttle another."""
+        monkeypatch.setenv("GROWTH_WHATSAPP_MAX_PER_HOUR", "1")
+        p1 = await _seed_prospect("w1")
+        d1 = await _seed_draft("w1", p1.id)
+        p2 = await _seed_prospect("w2")
+        d2 = await _seed_draft("w2", p2.id)
+
+        await growth_whatsapp.dispatch_whatsapp(d1.id)
+        await growth_whatsapp.dispatch_whatsapp(d2.id)
+
+        assert len(fake_client.calls) == 2
+        assert await _draft_status("w2", d2.id) == "sent"
+
+    async def test_refused_attempts_do_not_consume_the_window(
+        self, mongo_db: Any, fake_client: FakeMsg91Client, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A blocked attempt never reached Meta, so it must not spend budget."""
+        monkeypatch.setenv("GROWTH_WHATSAPP_MAX_PER_HOUR", "1")
+        blocked_prospect = await _seed_prospect(domain="no-consent.com", opted_in=False)
+        blocked_draft = await _seed_draft("w1", blocked_prospect.id)
+        with pytest.raises(growth_whatsapp.OptInRequired):
+            await growth_whatsapp.dispatch_whatsapp(blocked_draft.id)
+
+        good_prospect = await _seed_prospect(domain="consented.com")
+        good_draft = await _seed_draft("w1", good_prospect.id)
+        await growth_whatsapp.dispatch_whatsapp(good_draft.id)
+
+        assert len(fake_client.calls) == 1
+        assert await _draft_status("w1", good_draft.id) == "sent"
+
+
+# ---------------------------------------------------------------------------
+# 5 — provider + configuration failures
+# ---------------------------------------------------------------------------
+
+
+class TestFailurePaths:
+    async def test_provider_failure_is_recorded_and_leaves_the_draft_approved(
+        self, approved_draft: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _prospect, draft = approved_draft
+        client = FakeMsg91Client(
+            _CREDS, raises=Msg91Error("msg91.http_error", "MSG91 returned 502")
+        )
+
+        async def _resolve(workspace_id: str) -> Msg91Credentials:
+            return _CREDS
+
+        monkeypatch.setattr(growth_whatsapp, "resolve_credentials", _resolve)
+        monkeypatch.setattr(growth_whatsapp, "_build_client", lambda creds: client)
+
+        with pytest.raises(growth_whatsapp.WhatsAppDispatchError):
+            await growth_whatsapp.dispatch_whatsapp(draft.id)
+
+        # The approval stands; only the delivery failed.
+        assert await _draft_status("w1", draft.id) == "approved"
+        logs = await _logs()
+        assert len(logs) == 1
+        assert logs[0].status == "failed"
+        assert logs[0].error_code == "msg91.http_error"
+
+    async def test_unconfigured_workspace_blocks_without_a_client(
+        self, approved_draft: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _prospect, draft = approved_draft
+
+        async def _resolve(workspace_id: str) -> Msg91Credentials:
+            raise Msg91NotConfigured("no msg91 connector")
+
+        monkeypatch.setattr(growth_whatsapp, "resolve_credentials", _resolve)
+        monkeypatch.setattr(
+            growth_whatsapp,
+            "_build_client",
+            lambda creds: pytest.fail("a client was built without credentials"),
+        )
+
+        with pytest.raises(growth_whatsapp.WhatsAppNotConfigured):
+            await growth_whatsapp.dispatch_whatsapp(draft.id)
+
+        assert await _draft_status("w1", draft.id) == "approved"
+        assert [entry.blocked_reason for entry in await _logs()] == ["not_configured"]
+
+
+# ---------------------------------------------------------------------------
+# 6 — the credential must not leak
+# ---------------------------------------------------------------------------
+
+
+class TestCredentialsNeverLeak:
+    def test_repr_and_str_redact_the_authkey(self) -> None:
+        assert SECRET_AUTHKEY not in repr(_CREDS)
+        assert SECRET_AUTHKEY not in str(_CREDS)
+        assert SECRET_AUTHKEY not in f"{_CREDS}"
+        assert SECRET_AUTHKEY not in "{!r}".format(_CREDS)  # noqa: UP032 — exercising %r path
+        assert "***redacted***" in repr(_CREDS)
+
+    def test_client_repr_does_not_unwrap_its_credentials(self) -> None:
+        from pocketpaw_ee.cloud.growth.msg91 import Msg91WhatsAppClient
+
+        assert SECRET_AUTHKEY not in repr(Msg91WhatsAppClient(_CREDS))
+
+    async def test_a_full_send_writes_no_credential_anywhere(
+        self, approved_draft: Any, fake_client: FakeMsg91Client, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Grep-style: after a real send, the authkey is in no log line, no
+        persisted document, and no DTO the routes can return."""
+        _prospect, draft = approved_draft
+
+        with caplog.at_level(logging.DEBUG):
+            await growth_whatsapp.dispatch_whatsapp(draft.id)
+
+        assert SECRET_AUTHKEY not in caplog.text
+
+        logs = await _logs()
+        assert SECRET_AUTHKEY not in str([entry.model_dump() for entry in logs])
+
+        drafts = await growth_service.list_drafts(_ctx("w1"))
+        prospects = await growth_service.list_prospects(_ctx("w1"))
+        serialised = str([d.model_dump() for d in drafts] + [p.model_dump() for p in prospects])
+        assert SECRET_AUTHKEY not in serialised
+
+    async def test_a_refused_send_writes_no_credential_anywhere(
+        self, mongo_db: Any, fake_client: FakeMsg91Client, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        prospect = await _seed_prospect(opted_in=False)
+        draft = await _seed_draft("w1", prospect.id)
+
+        with caplog.at_level(logging.DEBUG), pytest.raises(growth_whatsapp.OptInRequired):
+            await growth_whatsapp.dispatch_whatsapp(draft.id)
+
+        assert SECRET_AUTHKEY not in caplog.text
+        assert SECRET_AUTHKEY not in str([entry.model_dump() for entry in await _logs()])

--- a/tests/cloud/growth/test_whatsapp_webhook.py
+++ b/tests/cloud/growth/test_whatsapp_webhook.py
@@ -1,0 +1,327 @@
+# tests/cloud/growth/test_whatsapp_webhook.py — the G-6 inbound MSG91 webhook
+# (``ee/cloud/growth/webhooks.py``).
+#
+# The endpoint is unauthenticated by nature (MSG91 is the caller) and it is the
+# ONLY thing that can set ``prospect.opted_in = True`` — i.e. the only thing
+# that can unlock business-initiated template sends to a number. So the suite
+# leads with the fail-closed cases: a forged, unsigned, or unverifiable request
+# must never reach the service.
+#
+# What it proves:
+#   1. FAIL CLOSED — bad signature, missing header, and an unset webhook secret
+#      are all 403, and nothing is mutated in any of those cases.
+#   2. A verified reply from a known number opts the prospect in, moves them to
+#      ``replied``, and walks their ``sent`` WhatsApp draft to ``replied``.
+#   3. An unknown number is a 200 no-op whose response body is byte-identical to
+#      the known-number response — the endpoint is not a membership oracle over
+#      phone numbers.
+#   4. Delivery-status callbacks are ignored (a receipt is not consent).
+#   5. Number spellings (+prefix, spaces, dashes) still match the stored row.
+#
+# Harness: the webhook router alone in a bare FastAPI app (no auth, no license,
+# no RequestContext — matching how it is mounted in ``ee/cloud/__init__.py``),
+# with mongomock-backed Beanie via the shared ``mongo_db`` fixture. Requests are
+# signed by the test itself over the exact bytes posted.
+#
+# Created 2026-07-27 (feat/growth-g6): new module.
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud._core.http import add_error_handler
+from pocketpaw_ee.cloud.growth import service as growth_service
+from pocketpaw_ee.cloud.growth.dto import CreateDraftRequest, CreateProspectRequest
+from pocketpaw_ee.cloud.growth.webhooks import router as growth_webhooks_router
+
+WEBHOOK_SECRET = "test-msg91-webhook-secret"
+NUMBER = "919876543210"
+
+
+@pytest.fixture(autouse=True)
+def _webhook_secret(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GROWTH_MSG91_WEBHOOK_SECRET", WEBHOOK_SECRET)
+
+
+@pytest_asyncio.fixture
+async def client(mongo_db: Any) -> AsyncClient:  # noqa: ARG001 — forces Beanie init
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(growth_webhooks_router, prefix="/api/v1")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as c:
+        yield c
+
+
+def _sign(body: bytes, secret: str = WEBHOOK_SECRET) -> str:
+    return hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+async def _post(
+    client: AsyncClient,
+    payload: dict[str, Any],
+    *,
+    signature: str | None = "__valid__",
+) -> Any:
+    body = json.dumps(payload).encode()
+    headers = {"content-type": "application/json"}
+    if signature == "__valid__":
+        headers["X-Msg91-Signature"] = _sign(body)
+    elif signature is not None:
+        headers["X-Msg91-Signature"] = signature
+    return await client.post("/api/v1/growth/webhooks/msg91", content=body, headers=headers)
+
+
+def _ctx(workspace_id: str = "w1") -> RequestContext:
+    return RequestContext(
+        user_id="u1",
+        workspace_id=workspace_id,
+        request_id="test",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+async def _seed_sent_outreach(
+    *,
+    workspace_id: str = "w1",
+    number: str | None = NUMBER,
+    domain: str = "acme-dental.com",
+    send_it: bool = True,
+) -> tuple[Any, Any]:
+    """A prospect we WhatsApp'd, with the draft parked in ``sent``."""
+    prospect = await growth_service.create(
+        _ctx(workspace_id),
+        CreateProspectRequest(
+            name="Sam Founder",
+            company="Acme Dental",
+            domain=domain,
+            source="manual",
+            whatsapp_number=number,
+            opted_in=False,
+        ),
+    )
+    draft = await growth_service.create_draft(
+        _ctx(workspace_id),
+        prospect.id,
+        CreateDraftRequest(channel="whatsapp", body="2 min demo?"),
+    )
+    await growth_service.gate_transition(workspace_id, draft.id, "proposed")
+    await growth_service.gate_transition(workspace_id, draft.id, "approved")
+    if send_it:
+        await growth_service.gate_transition(workspace_id, draft.id, "sent")
+    return prospect, draft
+
+
+async def _reload_prospect(prospect_id: str, workspace_id: str = "w1") -> Any:
+    return await growth_service.get(_ctx(workspace_id), prospect_id)
+
+
+async def _draft_status(draft_id: str, workspace_id: str = "w1") -> str:
+    drafts = await growth_service.list_drafts(_ctx(workspace_id))
+    return next(d.status for d in drafts if d.id == draft_id)
+
+
+def _inbound(number: str = NUMBER) -> dict[str, Any]:
+    return {"type": "message", "customer_number": number, "content": {"text": "yes, interested"}}
+
+
+# ---------------------------------------------------------------------------
+# 1 — fail closed
+# ---------------------------------------------------------------------------
+
+
+class TestFailsClosed:
+    async def test_bad_signature_is_rejected(self, client: AsyncClient) -> None:
+        prospect, draft = await _seed_sent_outreach()
+
+        resp = await _post(client, _inbound(), signature="deadbeef")
+
+        assert resp.status_code in (401, 403), resp.text
+        # Nothing was read from the unverified body.
+        assert (await _reload_prospect(prospect.id)).opted_in is False
+        assert await _draft_status(draft.id) == "sent"
+
+    async def test_missing_signature_header_is_rejected(self, client: AsyncClient) -> None:
+        prospect, _draft = await _seed_sent_outreach()
+
+        resp = await _post(client, _inbound(), signature=None)
+
+        assert resp.status_code in (401, 403), resp.text
+        assert (await _reload_prospect(prospect.id)).opted_in is False
+
+    async def test_unconfigured_secret_is_rejected_not_waved_through(
+        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The Recall webhook warns-and-accepts when its secret is unset. This
+        one must not: an unsigned body here forges consent."""
+        monkeypatch.delenv("GROWTH_MSG91_WEBHOOK_SECRET", raising=False)
+        prospect, _draft = await _seed_sent_outreach()
+
+        resp = await _post(client, _inbound())
+
+        assert resp.status_code in (401, 403), resp.text
+        assert (await _reload_prospect(prospect.id)).opted_in is False
+
+    async def test_a_signature_for_a_different_body_is_rejected(self, client: AsyncClient) -> None:
+        """Replaying a valid digest against tampered content must not pass."""
+        prospect, _draft = await _seed_sent_outreach()
+        other_signature = _sign(json.dumps({"type": "message"}).encode())
+
+        resp = await _post(client, _inbound(), signature=other_signature)
+
+        assert resp.status_code in (401, 403), resp.text
+        assert (await _reload_prospect(prospect.id)).opted_in is False
+
+    async def test_a_signature_from_the_wrong_secret_is_rejected(self, client: AsyncClient) -> None:
+        prospect, _draft = await _seed_sent_outreach()
+        body = json.dumps(_inbound()).encode()
+
+        resp = await _post(client, _inbound(), signature=_sign(body, secret="not-our-secret"))
+
+        assert resp.status_code in (401, 403), resp.text
+        assert (await _reload_prospect(prospect.id)).opted_in is False
+
+
+# ---------------------------------------------------------------------------
+# 2 — a verified reply
+# ---------------------------------------------------------------------------
+
+
+class TestVerifiedReply:
+    async def test_opts_in_and_flips_statuses(self, client: AsyncClient) -> None:
+        prospect, draft = await _seed_sent_outreach()
+
+        resp = await _post(client, _inbound())
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == {"ok": True}
+
+        refreshed = await _reload_prospect(prospect.id)
+        assert refreshed.opted_in is True
+        assert refreshed.status == "replied"
+        assert await _draft_status(draft.id) == "replied"
+
+    async def test_sha256_prefixed_signature_is_accepted(self, client: AsyncClient) -> None:
+        prospect, _draft = await _seed_sent_outreach()
+        body = json.dumps(_inbound()).encode()
+
+        resp = await _post(client, _inbound(), signature=f"sha256={_sign(body)}")
+
+        assert resp.status_code == 200, resp.text
+        assert (await _reload_prospect(prospect.id)).opted_in is True
+
+    @pytest.mark.parametrize(
+        "stored",
+        ["+919876543210", "+91 98765 43210", "919876543210", "+91-98765-43210"],
+    )
+    async def test_number_spellings_still_match(self, client: AsyncClient, stored: str) -> None:
+        prospect, _draft = await _seed_sent_outreach(number=stored)
+
+        resp = await _post(client, _inbound(NUMBER))
+
+        assert resp.status_code == 200, resp.text
+        assert (await _reload_prospect(prospect.id)).opted_in is True
+
+    async def test_meta_style_messages_envelope_is_understood(self, client: AsyncClient) -> None:
+        prospect, _draft = await _seed_sent_outreach()
+        payload = {"data": {"messages": [{"from": NUMBER, "text": {"body": "yes"}}]}}
+
+        resp = await _post(client, payload)
+
+        assert resp.status_code == 200, resp.text
+        assert (await _reload_prospect(prospect.id)).opted_in is True
+
+    async def test_reply_from_a_prospect_we_never_messaged_still_opts_them_in(
+        self, client: AsyncClient
+    ) -> None:
+        """An inbound message IS the opt-in signal under Meta's rules, whether
+        or not we happened to have a sent draft outstanding."""
+        prospect, draft = await _seed_sent_outreach(send_it=False)
+
+        resp = await _post(client, _inbound())
+
+        assert resp.status_code == 200, resp.text
+        refreshed = await _reload_prospect(prospect.id)
+        assert refreshed.opted_in is True
+        assert refreshed.status == "replied"
+        # The draft never sent, so it stays where the gate left it.
+        assert await _draft_status(draft.id) == "approved"
+
+
+# ---------------------------------------------------------------------------
+# 3 — no membership oracle, no consent from receipts
+# ---------------------------------------------------------------------------
+
+
+class TestNoLeakAndNoFalseConsent:
+    async def test_unknown_number_is_an_indistinguishable_200(self, client: AsyncClient) -> None:
+        prospect, draft = await _seed_sent_outreach()
+
+        known = await _post(client, _inbound(NUMBER))
+        unknown = await _post(client, _inbound("910000000000"))
+
+        assert unknown.status_code == known.status_code == 200
+        # Byte-identical: a caller cannot tell whether the number exists.
+        assert unknown.content == known.content
+
+        # ...and the unknown number changed nothing about the real prospect
+        # beyond what the known-number call already did.
+        assert (await _reload_prospect(prospect.id)).opted_in is True
+        assert await _draft_status(draft.id) == "replied"
+
+    async def test_unknown_number_mutates_nothing(self, client: AsyncClient) -> None:
+        prospect, draft = await _seed_sent_outreach()
+
+        resp = await _post(client, _inbound("910000000000"))
+
+        assert resp.status_code == 200
+        assert (await _reload_prospect(prospect.id)).opted_in is False
+        assert await _draft_status(draft.id) == "sent"
+
+    @pytest.mark.parametrize("status_type", ["status", "delivered", "read", "sent"])
+    async def test_delivery_receipts_are_not_consent(
+        self, client: AsyncClient, status_type: str
+    ) -> None:
+        prospect, draft = await _seed_sent_outreach()
+
+        resp = await _post(client, {"type": status_type, "customer_number": NUMBER})
+
+        assert resp.status_code == 200
+        assert (await _reload_prospect(prospect.id)).opted_in is False
+        assert await _draft_status(draft.id) == "sent"
+
+    async def test_a_payload_with_no_number_is_ignored(self, client: AsyncClient) -> None:
+        prospect, _draft = await _seed_sent_outreach()
+
+        resp = await _post(client, {"type": "message", "content": {"text": "hi"}})
+
+        assert resp.status_code == 200
+        assert (await _reload_prospect(prospect.id)).opted_in is False
+
+    async def test_a_reply_only_touches_the_tenant_that_messaged_the_number(
+        self, client: AsyncClient
+    ) -> None:
+        """Two tenants can hold the same prospect. Only the one that actually
+        sent to the number learns that a reply came back."""
+        messaged, messaged_draft = await _seed_sent_outreach(workspace_id="w1")
+        bystander, _ = await _seed_sent_outreach(workspace_id="w2", send_it=False)
+
+        resp = await _post(client, _inbound())
+
+        assert resp.status_code == 200
+        assert (await _reload_prospect(messaged.id, "w1")).opted_in is True
+        assert await _draft_status(messaged_draft.id, "w1") == "replied"
+
+        untouched = await _reload_prospect(bystander.id, "w2")
+        assert untouched.opted_in is False
+        assert untouched.status != "replied"


### PR DESCRIPTION
Stacked on #1803 (sibling of #1804 and #1805 — all three branch off the gate slice).

Approved WhatsApp drafts now send via MSG91, but only to a prospect with a recorded opt-in. Meta's policy isn't advisory here: business-initiated templates to non-opted-in numbers wreck the WABA quality rating and get numbers banned — for the whole tenant, not the one draft. So the guard is a service-layer invariant, not a UI convention.

**A prospect without opt-in produces zero provider interaction.** The check fires before credentials are even resolved (whatsapp.py step 3, ahead of the client build), writes a `blocked`/`not_opted_in` compliance row, raises a typed error, and leaves the draft `approved`. Success walks approved→sent through the existing `gate_transition` seam.

- Inbound webhook fails closed on bad, missing, replayed **and** unconfigured signatures — nothing is read from an unverified body — and always returns a constant `{"ok": true}` so it can't be used to probe whether a number is in our database.
- `GROWTH_WHATSAPP_MAX_PER_HOUR` (default 20) refuses the N+1th send with no provider call; refused attempts don't consume the window, and `0` refuses everything rather than quietly meaning unlimited.
- Authkey resolves per workspace through connector state with no env fallback; the credentials repr redacts it.

## Verification
237 passed across growth, ship and instinct. Network-free by construction — the fake is injected at the client-build seam, so the class that imports httpx is never constructed on any test path. The critical test asserts the fake was **never invoked** for a non-opted-in prospect. Both import-linter configs green; ruff clean.

## Known gaps for review
- **Not operator-usable as shipped:** there's no `connectors/msg91.yaml`, and the state store won't create rows, so the config has to be inserted by hand until a follow-up adds the connector definition. Dispatch degrades cleanly to `blocked`/`not_configured` meanwhile.
- **The MSG91 request envelope is unverified against a live account** — their public docs don't publish the JSON body shape. Worth one live smoke before production; the failure mode is a clean error row, not a silent send.
- The hourly cap counts log rows rather than using an atomic counter, so concurrent workers could overshoot slightly.
- Webhook tenancy is number-derived; resolving it from the receiving integrated number needs the connector row to be queryable by config value.
- `WhatsAppSendLog` needs reconciling with #1804's MessageLog once both land.