### PR TITLE
Search, sort and paginate the growth prospect list

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -110,6 +110,16 @@ Security review follow-up: documented per-route growth RBAC
 and the fact that a _growth_send blob can only be minted by this route —
 the generic POST /instinct/actions refuses reserved gated parameter keys.
 
+Updated: 2026-07-28 (feat/growth-api-scale) — the prospect list grew a scale
+surface. BREAKING: GET /growth/prospects now returns
+{items, next_cursor, total} instead of a bare array. Added q search across
+name/company/domain/research_brief, four sort modes (tier ordering is the
+declared rank a-b-c-unqualified, not lexicographic), keyset cursor
+pagination, GET /growth/prospects/facets (per-tier/status/source counts,
+each block excluding its own filter), and POST /growth/drafts/propose-batch
+(<=100 ids, each proposed through the existing Instinct gate, per-draft
+error entries, growth.manage).
+
 Updated: 2026-07-27 (feat/growth-g8) — added the Growth — LinkedIn Queue
 section: GET /growth/linkedin/queue (proposed/approved linkedin drafts joined
 with prospect context, ?format=md for a paste-ready markdown export) and
@@ -1545,8 +1555,8 @@ and Instinct-gated sends on the dedicated `growth` arq queue
 the license gate. Reads (`GET /growth/prospects`, `GET /growth/drafts`, …)
 require `growth.read` (MEMBER); authoring writes — create/update a prospect,
 bulk ingest, create a draft, non-gated lifecycle moves — require `growth.write`
-(MEMBER); and the outbound verb `POST /growth/drafts/{id}/propose` requires
-`growth.manage` (ADMIN). The propose route sits at the ADMIN tier deliberately:
+(MEMBER); and the outbound verbs — `POST /growth/drafts/{id}/propose` and
+`POST /growth/drafts/propose-batch` — require `growth.manage` (ADMIN). The propose route sits at the ADMIN tier deliberately:
 `growth.executor` re-checks that same action against the proposer's *current*
 role at dispatch time, so a member-filed proposal would always fail closed at
 approve. A caller below the required tier gets
@@ -1632,9 +1642,74 @@ create independent rows.
 
 ### `GET /api/v1/growth/prospects`
 
-List the workspace's prospects, newest first. Optional query filters:
-`tier`, `status`, `source` (validated against the enums above — an unknown
-value is a 422, not an empty list) and `limit` (default 100, max 500).
+One page of the workspace's prospects. **The response is an envelope, not a
+bare array** — it changed shape in G-10a:
+
+```json
+{
+  "items": [ { ...prospect envelope }, ... ],
+  "next_cursor": "newest:2026-07-28T09:14:02+00:00|66a1...f3",
+  "total": 3182
+}
+```
+
+`total` counts every row matching the current filters (not the page), so the
+UI can say "showing 40 of 3,182". `next_cursor` is `null` on the last page.
+
+Query parameters:
+
+| Param | Default | Notes |
+|---|---|---|
+| `tier`, `status`, `source` | — | Validated against the enums above; an unknown value is a 422, not an empty list. |
+| `q` | — | Case-insensitive substring search across `name`, `company`, `domain` and `research_brief`. Regex metacharacters are escaped, so `.*` matches nothing rather than everything. Max 200 chars. |
+| `sort` | `newest` | `newest` \| `oldest` \| `company` \| `tier`. |
+| `cursor` | — | The previous page's `next_cursor`, passed back unchanged. |
+| `limit` | 100 | Max 500. |
+
+**Tier sort order is the declared rank `a → b → c → unqualified`**, not a
+lexicographic comparison. Today's tier names happen to sort the same way
+lexicographically; that is an accident, and renaming a tier would break it
+silently. The rank lives in `growth/domain.py` as `TIER_SORT_ORDER` and the
+query walks those buckets in order.
+
+**Pagination is keyset**, so a page never skips or repeats a row when the
+collection is written to mid-scroll. The cursor is opaque — do not parse or
+construct it — and carries the sort mode it was issued under: reusing a
+cursor after changing `sort` is a `422 prospect.bad_cursor` rather than a
+silently wrong page. Any malformed cursor is the same 422.
+
+**Search scale ceiling.** `q` is an unanchored regex `$or` across four
+fields, which Mongo cannot serve from an index — it is a collection scan
+bounded by the workspace filter. Fine at the scale this surface targets (tens
+of thousands of rows per workspace); past ~100k it needs a real text index or
+an external search index. No text index was added here: `models/prospect.py`
+carries a unique `(workspace, domain)` index plus a `(workspace, createdAt)`
+list cursor, and a Mongo text index is a per-collection singleton that has to
+be designed against those rather than bolted on.
+
+### `GET /api/v1/growth/prospects/facets`
+
+Counts behind the filter chips. Takes the same `tier` / `status` / `source` /
+`q` filters as the list route and returns:
+
+```json
+{
+  "tier":   { "a": 12, "b": 40, "c": 8, "unqualified": 300 },
+  "status": { "new": 210, "qualified": 90, "drafted": 40, "in_sequence": 12, "replied": 6, "dead": 2 },
+  "source": { "clay": 180, "directory": 140, "manual": 40 }
+}
+```
+
+Each block respects every active filter **except its own**. With
+`status=new` on, the tier counts describe the new rows rather than
+collapsing to whichever tier is selected — otherwise the selected chip reads
+`n` and every sibling reads `0`, which tells the user nothing about where to
+go next. `q` constrains all three blocks (it is not a facet of its own).
+
+Every legal value appears, zeros included, so the chip row keeps a stable
+shape as the user filters. Served by one workspace-scoped `$facet`
+aggregation — three separate queries would be three chances for the counts to
+disagree with each other.
 
 ### `GET /api/v1/growth/prospects/{prospect_id}`
 
@@ -1755,6 +1830,44 @@ closed), and `mark_failed` on the Action if the enqueue fails. On
 `email` branch is live (below) and the `whatsapp` branch is live (*Growth —
 WhatsApp dispatch*); `linkedin` keeps the logging stub on purpose — it is
 sent by hand from the LinkedIn queue.
+
+### `POST /api/v1/growth/drafts/propose-batch`
+
+Propose a selection of drafts in one call. Requires `growth.manage` (ADMIN)
+— the same tier as the single propose, so batching is not a cheaper route to
+the outbound verb.
+
+```json
+{ "draft_ids": ["66a1...f3", "66a1...f4", "66a1...f5"] }
+```
+
+Max 100 ids; an oversized payload is a `422` at the boundary, before a single
+proposal is filed. The cap is 100 rather than bulk ingest's 500 because each
+id costs a proposal a human then has to triage in the Tray.
+
+Each id goes through the **same** `propose_send` path as the single-draft
+route: one gated `_growth_send` Instinct proposal per draft, each approved or
+rejected individually. There is no batch proposal object, no batch approval,
+and no shortcut into the gate — a "batch" here is a UI convenience over N
+gated proposals. Nothing is sent by this route.
+
+Partial success, like bulk ingest — a draft that cannot be proposed (missing,
+cross-tenant, already proposed, terminal) records an indexed error entry and
+the remaining ids still go:
+
+```json
+{
+  "proposed": 2,
+  "failed": [
+    { "index": 1, "draft_id": "not-an-object-id", "code": "draft.not_found", "message": "..." },
+    { "index": 2, "draft_id": "66a1...f5", "code": "draft.illegal_transition", "message": "..." }
+  ]
+}
+```
+
+`index` is the id's position in the submitted `draft_ids` array. Nothing is
+rolled back on partial failure — the proposals already filed are legitimate
+and a human can reject them in the Tray.
 
 ### Dispatch — how an approved email actually sends (G-5)
 

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -1,5 +1,10 @@
 """PocketPaw Enterprise Cloud — domain-driven architecture.
 
+Modified: 2026-07-28 (feat/growth-api-scale) — The growth router's list route
+    changed shape: ``GET /growth/prospects`` returns
+    ``{items, next_cursor, total}`` instead of a bare array (BREAKING), and
+    gained ``q`` / ``sort`` / ``cursor``. Two new routes on the same mount:
+    ``GET /growth/prospects/facets`` and ``POST /growth/drafts/propose-batch``.
 Modified: 2026-07-27 (feat/growth-g3) — The growth router now also carries
     drafts (``/growth/prospects/{id}/drafts``, ``/growth/drafts``,
     ``/growth/drafts/{id}/status``); its prefix widened to ``/growth`` with

--- a/ee/pocketpaw_ee/cloud/growth/domain.py
+++ b/ee/pocketpaw_ee/cloud/growth/domain.py
@@ -23,10 +23,12 @@
 # ``MESSAGE_LOG_OUTCOMES``, and ``PROVIDER_REACHED_OUTCOMES`` names the subset
 # the WhatsApp rate cap counts.
 # Updated 2026-07-28 (feat/growth-api-scale): the prospect list's scale
-# vocabulary — ``ProspectSort`` (the four ordering modes the UI offers) and
-# ``TIER_SORT_ORDER``, the DECLARED qualification rank a→b→c→unqualified. The
-# rank is data here rather than a lexicographic accident in the query layer, so
-# renaming a tier can't silently reorder the list.
+# vocabulary — ``ProspectSort`` (the four ordering modes the UI offers),
+# ``TIER_SORT_ORDER``, the DECLARED qualification rank a→b→c→unqualified, and
+# ``PROSPECT_STATUS_ORDER`` / ``PROSPECT_SOURCE_ORDER``, the facet display
+# orders derived from the Literals. The rank is data here rather than a
+# lexicographic accident in the query layer, so renaming a tier can't silently
+# reorder the list.
 # Updated 2026-07-27 (feat/growth-g4): the Instinct send gate —
 # ``GATE_OWNED_TARGETS`` marks the statuses only the gate machinery may set
 # (``approved`` via an approved ``_growth_send`` proposal, ``sent`` via the
@@ -37,7 +39,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Literal
+from typing import Literal, get_args
 
 # Dedicated arq queue for growth jobs. Unlike workspace jobs (which ride arq's
 # default queue on the shared chat-runs worker — see ``jobs/domain.py``), growth
@@ -66,6 +68,13 @@ ProspectSort = Literal["newest", "oldest", "company", "tier"]
 # accident breaks silently. The list query walks these buckets in this order, so
 # the ordering survives any rename of the values above.
 TIER_SORT_ORDER: tuple[str, ...] = ("a", "b", "c", "unqualified")
+
+# Display order for the facet counts. Derived from the Literals above rather
+# than re-typed, so a new status or source can never go missing from the chip
+# row. ``TIER_SORT_ORDER`` stays hand-written because it is a RANK, which is a
+# different claim than "the set of legal values".
+PROSPECT_STATUS_ORDER: tuple[str, ...] = get_args(ProspectStatus)
+PROSPECT_SOURCE_ORDER: tuple[str, ...] = get_args(ProspectSource)
 
 
 @dataclass(frozen=True)
@@ -206,6 +215,8 @@ __all__ = [
     "GROWTH_DISPATCH_JOB_NAME",
     "GROWTH_QUEUE_NAME",
     "MESSAGE_LOG_OUTCOMES",
+    "PROSPECT_SOURCE_ORDER",
+    "PROSPECT_STATUS_ORDER",
     "PROVIDER_REACHED_OUTCOMES",
     "TIER_SORT_ORDER",
     "Draft",

--- a/ee/pocketpaw_ee/cloud/growth/domain.py
+++ b/ee/pocketpaw_ee/cloud/growth/domain.py
@@ -22,6 +22,11 @@
 # and ``blocked`` (a guard refused; no provider call happened) join
 # ``MESSAGE_LOG_OUTCOMES``, and ``PROVIDER_REACHED_OUTCOMES`` names the subset
 # the WhatsApp rate cap counts.
+# Updated 2026-07-28 (feat/growth-api-scale): the prospect list's scale
+# vocabulary — ``ProspectSort`` (the four ordering modes the UI offers) and
+# ``TIER_SORT_ORDER``, the DECLARED qualification rank a→b→c→unqualified. The
+# rank is data here rather than a lexicographic accident in the query layer, so
+# renaming a tier can't silently reorder the list.
 # Updated 2026-07-27 (feat/growth-g4): the Instinct send gate —
 # ``GATE_OWNED_TARGETS`` marks the statuses only the gate machinery may set
 # (``approved`` via an approved ``_growth_send`` proposal, ``sent`` via the
@@ -50,6 +55,17 @@ ProspectTier = Literal["a", "b", "c", "unqualified"]
 
 # Outbound lifecycle. Later slices move prospects along this chain.
 ProspectStatus = Literal["new", "qualified", "drafted", "in_sequence", "replied", "dead"]
+
+# G-10a — the prospect list's ordering modes. ``newest`` is the default and is
+# byte-for-byte the pre-G-10a behaviour.
+ProspectSort = Literal["newest", "oldest", "company", "tier"]
+
+# Qualification rank, best first. This is DECLARED, not derived: a lexicographic
+# sort over the current tier names happens to produce the same order, which is
+# luck — rename ``unqualified`` to ``untriaged`` or add a ``d`` tier and the
+# accident breaks silently. The list query walks these buckets in this order, so
+# the ordering survives any rename of the values above.
+TIER_SORT_ORDER: tuple[str, ...] = ("a", "b", "c", "unqualified")
 
 
 @dataclass(frozen=True)
@@ -191,6 +207,7 @@ __all__ = [
     "GROWTH_QUEUE_NAME",
     "MESSAGE_LOG_OUTCOMES",
     "PROVIDER_REACHED_OUTCOMES",
+    "TIER_SORT_ORDER",
     "Draft",
     "DraftChannel",
     "DraftStatus",
@@ -198,6 +215,7 @@ __all__ = [
     "MessageLog",
     "MessageOutcome",
     "Prospect",
+    "ProspectSort",
     "ProspectSource",
     "ProspectStatus",
     "ProspectTier",

--- a/ee/pocketpaw_ee/cloud/growth/dto.py
+++ b/ee/pocketpaw_ee/cloud/growth/dto.py
@@ -21,7 +21,8 @@
 # cursor-paginated envelope GET /growth/prospects now returns
 # ({items, next_cursor, total}) in place of the bare array. Breaking on
 # purpose: "n of m" needs a filter-scoped total and reaching row 3,000 needs a
-# resume key, and neither fits in a naked list.
+# resume key, and neither fits in a naked list. ProspectFacetsResponse — the
+# per-tier / per-status / per-source counts behind the filter chips.
 # Updated 2026-07-27 (feat/growth-g8): LinkedInQueueItemResponse — one row of
 # the manual LinkedIn send queue: the draft envelope joined with the prospect
 # context the captain needs to send by hand (name, company, profile URL,
@@ -161,6 +162,21 @@ class ProspectPageResponse(BaseModel):
     total: int
 
 
+class ProspectFacetsResponse(BaseModel):
+    """Counts per tier / status / source for the filter chips (G-10a).
+
+    Each block is ``{value: count}`` covering EVERY legal value, zeros
+    included — the chip row keeps a stable shape as the user filters instead
+    of chips appearing and vanishing. Each block respects the OTHER active
+    filters but not its own, so the tier counts stay meaningful while a status
+    filter is on (that is the whole point of a facet).
+    """
+
+    tier: dict[str, int]
+    status: dict[str, int]
+    source: dict[str, int]
+
+
 class CreateDraftRequest(BaseModel):
     """One channel's outreach copy for a prospect.
 
@@ -243,6 +259,7 @@ __all__ = [
     "DraftResponse",
     "LinkedInQueueItemResponse",
     "ProposeSendResponse",
+    "ProspectFacetsResponse",
     "ProspectPageResponse",
     "ProspectResponse",
     "TransitionDraftRequest",

--- a/ee/pocketpaw_ee/cloud/growth/dto.py
+++ b/ee/pocketpaw_ee/cloud/growth/dto.py
@@ -23,6 +23,9 @@
 # purpose: "n of m" needs a filter-scoped total and reaching row 3,000 needs a
 # resume key, and neither fits in a naked list. ProspectFacetsResponse — the
 # per-tier / per-status / per-source counts behind the filter chips.
+# ProposeBatchRequest / ProposeBatchError / ProposeBatchResponse — proposing a
+# selection of drafts in one call, with per-draft error entries in the
+# bulk-ingest style (100-id cap enforced at the boundary).
 # Updated 2026-07-27 (feat/growth-g8): LinkedInQueueItemResponse — one row of
 # the manual LinkedIn send queue: the draft envelope joined with the prospect
 # context the captain needs to send by hand (name, company, profile URL,
@@ -234,6 +237,39 @@ class ProposeSendResponse(BaseModel):
     draft: DraftResponse
 
 
+class ProposeBatchRequest(BaseModel):
+    """Draft ids to propose in one call — up to 100 (G-10a).
+
+    The cap IS enforced here, so an oversized payload 422s before a single
+    proposal is filed. 100 rather than bulk-ingest's 500 because each id costs
+    an Instinct proposal a human then has to triage in the Tray: a batch that
+    outruns the reviewer defeats the gate.
+    """
+
+    draft_ids: list[str] = Field(max_length=100)
+
+
+class ProposeBatchError(BaseModel):
+    """One draft that could not be proposed: where it was and why.
+
+    Same shape as ``BulkRowError`` plus the id, because the caller holds ids
+    here rather than opaque rows and needs to know WHICH draft failed without
+    counting back into its own array.
+    """
+
+    index: int
+    draft_id: str
+    code: str
+    message: str
+
+
+class ProposeBatchResponse(BaseModel):
+    """How many drafts were proposed, and the per-draft failures."""
+
+    proposed: int
+    failed: list[ProposeBatchError]
+
+
 class LinkedInQueueItemResponse(BaseModel):
     """One row of the manual LinkedIn send queue.
 
@@ -258,6 +294,9 @@ __all__ = [
     "CreateProspectRequest",
     "DraftResponse",
     "LinkedInQueueItemResponse",
+    "ProposeBatchError",
+    "ProposeBatchRequest",
+    "ProposeBatchResponse",
     "ProposeSendResponse",
     "ProspectFacetsResponse",
     "ProspectPageResponse",

--- a/ee/pocketpaw_ee/cloud/growth/dto.py
+++ b/ee/pocketpaw_ee/cloud/growth/dto.py
@@ -17,6 +17,11 @@
 # the DTO only checks it's a known status), DraftResponse.
 # Updated 2026-07-27 (feat/growth-g4): ProposeSendResponse — the Instinct
 # proposal id + the flipped draft returned by POST /growth/drafts/{id}/propose.
+# Updated 2026-07-28 (feat/growth-api-scale): ProspectPageResponse — the
+# cursor-paginated envelope GET /growth/prospects now returns
+# ({items, next_cursor, total}) in place of the bare array. Breaking on
+# purpose: "n of m" needs a filter-scoped total and reaching row 3,000 needs a
+# resume key, and neither fits in a naked list.
 # Updated 2026-07-27 (feat/growth-g8): LinkedInQueueItemResponse — one row of
 # the manual LinkedIn send queue: the draft envelope joined with the prospect
 # context the captain needs to send by hand (name, company, profile URL,
@@ -141,6 +146,21 @@ class ProspectResponse(BaseModel):
     updated_at: str | None
 
 
+class ProspectPageResponse(BaseModel):
+    """One cursor-paginated page of prospects (G-10a).
+
+    Replaces the bare array the list route used to return — a BREAKING change,
+    made deliberately: without ``total`` the UI cannot say "n of m", and
+    without ``next_cursor`` it cannot reach row 3,000. ``total`` counts every
+    row matching the CURRENT filters (not the page), so it is stable while
+    paging and is what the count reads from.
+    """
+
+    items: list[ProspectResponse]
+    next_cursor: str | None = None
+    total: int
+
+
 class CreateDraftRequest(BaseModel):
     """One channel's outreach copy for a prospect.
 
@@ -223,6 +243,7 @@ __all__ = [
     "DraftResponse",
     "LinkedInQueueItemResponse",
     "ProposeSendResponse",
+    "ProspectPageResponse",
     "ProspectResponse",
     "TransitionDraftRequest",
     "UpdateProspectRequest",

--- a/ee/pocketpaw_ee/cloud/growth/router.py
+++ b/ee/pocketpaw_ee/cloud/growth/router.py
@@ -32,7 +32,9 @@
 # query — ``q`` (search), ``sort`` (newest|oldest|company|tier), ``cursor`` —
 # and now returns ``ProspectPageResponse`` ({items, next_cursor, total})
 # instead of a bare array. BREAKING for any existing consumer of the list
-# route; the frontend list view is the only one and lands with it.
+# route; the frontend list view is the only one and lands with it. Plus GET
+# /prospects/facets — tier/status/source counts for the filter chips, declared
+# ABOVE /prospects/{prospect_id} so the literal path wins the match.
 # Updated 2026-07-27 (feat/growth-g8): LinkedIn manual queue — GET
 # /linkedin/queue (proposed/approved linkedin drafts joined with prospect
 # context; ``?format=md`` returns a paste-ready text/markdown export) and
@@ -69,6 +71,7 @@ from pocketpaw_ee.cloud.growth.dto import (
     DraftResponse,
     LinkedInQueueItemResponse,
     ProposeSendResponse,
+    ProspectFacetsResponse,
     ProspectPageResponse,
     ProspectResponse,
     TransitionDraftRequest,
@@ -140,6 +143,30 @@ async def list_prospects(
         cursor=cursor,
         limit=limit,
     )
+
+
+# Registered BEFORE /prospects/{prospect_id}: FastAPI matches in declaration
+# order, so a literal path that could also read as an id has to come first or
+# "facets" arrives as a prospect_id and 404s.
+@router.get(
+    "/prospects/facets",
+    response_model=ProspectFacetsResponse,
+    dependencies=[Depends(require_action_any_workspace("growth.read"))],
+)
+async def prospect_facets(
+    tier: ProspectTier | None = Query(default=None),
+    status: ProspectStatus | None = Query(default=None),
+    source: ProspectSource | None = Query(default=None),
+    q: str | None = Query(default=None, max_length=200),
+    ctx: RequestContext = Depends(request_context),
+) -> ProspectFacetsResponse:
+    """Counts per tier / status / source for the filter chips.
+
+    Takes the same filters as the list route. Each block excludes its OWN
+    filter and respects the others — so with ``status=replied`` on, the tier
+    counts describe the replied rows rather than collapsing to the selected
+    tier. Every legal value is present, zeros included."""
+    return await growth_service.prospect_facets(ctx, tier=tier, status=status, source=source, q=q)
 
 
 @router.get(

--- a/ee/pocketpaw_ee/cloud/growth/router.py
+++ b/ee/pocketpaw_ee/cloud/growth/router.py
@@ -28,6 +28,11 @@
 # /drafts/{id}/propose — takes ``growth.manage`` (ADMIN): the propose route
 # has to sit at the same tier ``growth.executor`` re-checks at dispatch, or a
 # member-filed proposal would always fail closed at approve time.
+# Updated 2026-07-28 (feat/growth-api-scale): GET /prospects grew the scale
+# query — ``q`` (search), ``sort`` (newest|oldest|company|tier), ``cursor`` —
+# and now returns ``ProspectPageResponse`` ({items, next_cursor, total})
+# instead of a bare array. BREAKING for any existing consumer of the list
+# route; the frontend list view is the only one and lands with it.
 # Updated 2026-07-27 (feat/growth-g8): LinkedIn manual queue — GET
 # /linkedin/queue (proposed/approved linkedin drafts joined with prospect
 # context; ``?format=md`` returns a paste-ready text/markdown export) and
@@ -64,6 +69,7 @@ from pocketpaw_ee.cloud.growth.dto import (
     DraftResponse,
     LinkedInQueueItemResponse,
     ProposeSendResponse,
+    ProspectPageResponse,
     ProspectResponse,
     TransitionDraftRequest,
     UpdateProspectRequest,
@@ -102,7 +108,7 @@ async def bulk_ingest_prospects(
 
 @router.get(
     "/prospects",
-    response_model=list[ProspectResponse],
+    response_model=ProspectPageResponse,
     dependencies=[Depends(require_action_any_workspace("growth.read"))],
 )
 async def list_prospects(
@@ -111,15 +117,28 @@ async def list_prospects(
     source: ProspectSource | None = Query(default=None),
     q: str | None = Query(default=None, max_length=200),
     sort: ProspectSort = Query(default="newest"),
+    cursor: str | None = Query(default=None, max_length=200),
     limit: int = Query(default=100, ge=1, le=500),
     ctx: RequestContext = Depends(request_context),
-) -> list[ProspectResponse]:
-    """``q`` is a case-insensitive substring search across name / company /
+) -> ProspectPageResponse:
+    """One page of prospects: ``{items, next_cursor, total}``.
+
+    ``q`` is a case-insensitive substring search across name / company /
     domain / research_brief — the "find that one company" box. ``sort`` is
     ``newest`` (default) / ``oldest`` / ``company`` / ``tier``; the tier order
-    is the declared rank a→b→c→unqualified, not a lexicographic accident."""
+    is the declared rank a→b→c→unqualified, not a lexicographic accident.
+    ``cursor`` is the previous page's ``next_cursor``, passed back unchanged;
+    ``null`` there means the last page. ``total`` counts every row matching the
+    filters, so the UI can say "n of m"."""
     return await growth_service.list_prospects(
-        ctx, tier=tier, status=status, source=source, q=q, sort=sort, limit=limit
+        ctx,
+        tier=tier,
+        status=status,
+        source=source,
+        q=q,
+        sort=sort,
+        cursor=cursor,
+        limit=limit,
     )
 
 

--- a/ee/pocketpaw_ee/cloud/growth/router.py
+++ b/ee/pocketpaw_ee/cloud/growth/router.py
@@ -34,7 +34,10 @@
 # instead of a bare array. BREAKING for any existing consumer of the list
 # route; the frontend list view is the only one and lands with it. Plus GET
 # /prospects/facets — tier/status/source counts for the filter chips, declared
-# ABOVE /prospects/{prospect_id} so the literal path wins the match.
+# ABOVE /prospects/{prospect_id} so the literal path wins the match. Plus POST
+# /drafts/propose-batch — up to 100 draft ids, each proposed through the SAME
+# gated path as the single-draft route (growth.manage, one Instinct proposal
+# per draft, per-draft error entries).
 # Updated 2026-07-27 (feat/growth-g8): LinkedIn manual queue — GET
 # /linkedin/queue (proposed/approved linkedin drafts joined with prospect
 # context; ``?format=md`` returns a paste-ready text/markdown export) and
@@ -70,6 +73,8 @@ from pocketpaw_ee.cloud.growth.dto import (
     CreateProspectRequest,
     DraftResponse,
     LinkedInQueueItemResponse,
+    ProposeBatchRequest,
+    ProposeBatchResponse,
     ProposeSendResponse,
     ProspectFacetsResponse,
     ProspectPageResponse,
@@ -267,6 +272,27 @@ async def propose_draft_send(
     ``rejected``. A draft that cannot legally move to ``proposed`` is a 422
     ``draft.illegal_transition`` (so re-proposing is refused)."""
     return await growth_service.propose_send(ctx, draft_id)
+
+
+@router.post(
+    "/drafts/propose-batch",
+    response_model=ProposeBatchResponse,
+    dependencies=[Depends(require_action_any_workspace("growth.manage"))],
+)
+async def propose_draft_send_batch(
+    body: ProposeBatchRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> ProposeBatchResponse:
+    """Propose a selection of drafts — up to 100 ids, an oversized payload
+    422s at the boundary.
+
+    Each id rides the SAME gated path as the single-draft route: one
+    ``_growth_send`` Instinct proposal per draft, each approved or rejected by
+    a human in the Tray. Nothing is sent here and there is no batch approval.
+    Partial success — a draft that can't be proposed becomes an indexed
+    ``{index, draft_id, code, message}`` entry in ``failed`` and the rest
+    still go. Same ADMIN tier (``growth.manage``) as the single propose."""
+    return await growth_service.propose_send_batch(ctx, body)
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/cloud/growth/router.py
+++ b/ee/pocketpaw_ee/cloud/growth/router.py
@@ -108,11 +108,14 @@ async def list_prospects(
     tier: ProspectTier | None = Query(default=None),
     status: ProspectStatus | None = Query(default=None),
     source: ProspectSource | None = Query(default=None),
+    q: str | None = Query(default=None, max_length=200),
     limit: int = Query(default=100, ge=1, le=500),
     ctx: RequestContext = Depends(request_context),
 ) -> list[ProspectResponse]:
+    """``q`` is a case-insensitive substring search across name / company /
+    domain / research_brief — the "find that one company" box."""
     return await growth_service.list_prospects(
-        ctx, tier=tier, status=status, source=source, limit=limit
+        ctx, tier=tier, status=status, source=source, q=q, limit=limit
     )
 
 

--- a/ee/pocketpaw_ee/cloud/growth/router.py
+++ b/ee/pocketpaw_ee/cloud/growth/router.py
@@ -51,6 +51,7 @@ from pocketpaw_ee.cloud.growth import service as growth_service
 from pocketpaw_ee.cloud.growth.domain import (
     DraftChannel,
     DraftStatus,
+    ProspectSort,
     ProspectSource,
     ProspectStatus,
     ProspectTier,
@@ -109,13 +110,16 @@ async def list_prospects(
     status: ProspectStatus | None = Query(default=None),
     source: ProspectSource | None = Query(default=None),
     q: str | None = Query(default=None, max_length=200),
+    sort: ProspectSort = Query(default="newest"),
     limit: int = Query(default=100, ge=1, le=500),
     ctx: RequestContext = Depends(request_context),
 ) -> list[ProspectResponse]:
     """``q`` is a case-insensitive substring search across name / company /
-    domain / research_brief — the "find that one company" box."""
+    domain / research_brief — the "find that one company" box. ``sort`` is
+    ``newest`` (default) / ``oldest`` / ``company`` / ``tier``; the tier order
+    is the declared rank a→b→c→unqualified, not a lexicographic accident."""
     return await growth_service.list_prospects(
-        ctx, tier=tier, status=status, source=source, q=q, limit=limit
+        ctx, tier=tier, status=status, source=source, q=q, sort=sort, limit=limit
     )
 
 

--- a/ee/pocketpaw_ee/cloud/growth/service.py
+++ b/ee/pocketpaw_ee/cloud/growth/service.py
@@ -578,7 +578,12 @@ async def prospect_facets(
         branches[block] = stages
 
     pipeline: list[dict[str, Any]] = [{"$match": outer}, {"$facet": branches}]
-    rows = await _ProspectDoc.get_motor_collection().aggregate(pipeline).to_list(None)
+    # Straight to the driver collection rather than Beanie's
+    # ``Document.aggregate``: that wrapper returns a latent command cursor that
+    # cannot be awaited under mongomock-motor (the reference_mongomock_quirks
+    # caveat — aggregation CURSORS, not aggregation itself). The driver's own
+    # cursor round-trips $facet with nested $match/$group there and in Mongo.
+    rows = await _ProspectDoc.get_pymongo_collection().aggregate(pipeline).to_list(None)
     raw: dict[str, Any] = rows[0] if rows else {}
 
     counted: dict[str, dict[str, int]] = {}

--- a/ee/pocketpaw_ee/cloud/growth/service.py
+++ b/ee/pocketpaw_ee/cloud/growth/service.py
@@ -66,6 +66,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from datetime import UTC, datetime
 from typing import Any
 
@@ -256,16 +257,48 @@ async def get(ctx: RequestContext, prospect_id: str) -> ProspectResponse:
     return _to_response(_to_domain(doc))
 
 
-async def list_prospects(
-    ctx: RequestContext,
+# ---------------------------------------------------------------------------
+# Prospect list query (G-10a)
+# ---------------------------------------------------------------------------
+
+# Fields the ``q`` search scans. Deliberately the four a human types into a
+# "find that company" box — identity (name/company), the dedupe key (domain),
+# and the qualification notes (research_brief).
+PROSPECT_SEARCH_FIELDS: tuple[str, ...] = ("name", "company", "domain", "research_brief")
+
+
+def _escape_regex(term: str) -> str:
+    """Neutralise regex metacharacters so a search term is matched literally.
+
+    Without this a caller could submit ``.*`` (harmless but wrong results) or a
+    catastrophic-backtracking pattern (a real DoS vector, since the regex runs
+    server-side in Mongo). ``re.escape`` is the whole defence — the term is
+    never compiled in Python, only handed to Mongo as a literal-ised pattern.
+    """
+    return re.escape(term.strip())
+
+
+def _prospect_filters(
+    workspace_id: str,
     *,
     tier: str | None = None,
     status: str | None = None,
     source: str | None = None,
-    limit: int = 100,
-) -> list[ProspectResponse]:
-    """List the workspace's prospects, newest first, optionally filtered."""
-    workspace_id = _require_workspace(ctx)
+    q: str | None = None,
+) -> dict[str, Any]:
+    """Build the tenant-scoped Mongo filter shared by list / facets / count.
+
+    SCALE CEILING — ``q`` is an unanchored, case-insensitive regex ``$or``
+    across four fields. Mongo cannot use an index for that, so it is a
+    collection scan bounded by the ``workspace`` filter. That is fine at the
+    single-workspace scale this surface targets (tens of thousands of rows,
+    single-digit-millisecond scans); past ~100k prospects per workspace this
+    needs a real text index or an external search index. A text index is NOT
+    added here on purpose: ``models/prospect.py`` carries a unique
+    (workspace, domain) index plus a (workspace, createdAt) list cursor, and a
+    Mongo text index is a per-collection singleton that would have to be
+    designed against those rather than bolted on.
+    """
     filters: dict[str, Any] = {"workspace": workspace_id}
     if tier is not None:
         filters["tier"] = tier
@@ -273,6 +306,30 @@ async def list_prospects(
         filters["status"] = status
     if source is not None:
         filters["source"] = source
+    if q is not None and q.strip():
+        pattern = _escape_regex(q)
+        filters["$or"] = [
+            {field: {"$regex": pattern, "$options": "i"}} for field in PROSPECT_SEARCH_FIELDS
+        ]
+    return filters
+
+
+async def list_prospects(
+    ctx: RequestContext,
+    *,
+    tier: str | None = None,
+    status: str | None = None,
+    source: str | None = None,
+    q: str | None = None,
+    limit: int = 100,
+) -> list[ProspectResponse]:
+    """List the workspace's prospects, newest first, optionally filtered.
+
+    ``q`` is a case-insensitive substring match across name / company /
+    domain / research_brief (see ``_prospect_filters`` for the scale ceiling).
+    """
+    workspace_id = _require_workspace(ctx)
+    filters = _prospect_filters(workspace_id, tier=tier, status=status, source=source, q=q)
     cursor = (
         _ProspectDoc.find(filters)
         .sort(-_ProspectDoc.createdAt)  # type: ignore[operator]

--- a/ee/pocketpaw_ee/cloud/growth/service.py
+++ b/ee/pocketpaw_ee/cloud/growth/service.py
@@ -30,7 +30,9 @@
 # WALKED rather than compared, and keyset cursor pagination returning
 # ``ProspectPageResponse`` ({items, next_cursor, total}) in place of a bare
 # list. Cursors carry their sort mode so a mid-scroll sort change 422s instead
-# of resuming against a key that means something else.
+# of resuming against a key that means something else. ``prospect_facets``
+# counts tier/status/source in ONE workspace-scoped ``$facet`` aggregation,
+# each block excluding its own filter.
 # Updated 2026-07-27 (feat/growth-g8): LinkedIn manual queue —
 # ``linkedin_queue`` (proposed/approved linkedin drafts joined with their
 # prospect via two queries, newest first), ``linkedin_queue_markdown``
@@ -87,6 +89,8 @@ from pocketpaw_ee.cloud.growth.domain import (
     DRAFT_TRANSITIONS,
     GATE_OWNED_TARGETS,
     MESSAGE_LOG_OUTCOMES,
+    PROSPECT_SOURCE_ORDER,
+    PROSPECT_STATUS_ORDER,
     PROVIDER_REACHED_OUTCOMES,
     TIER_SORT_ORDER,
     Draft,
@@ -102,6 +106,7 @@ from pocketpaw_ee.cloud.growth.dto import (
     DraftResponse,
     LinkedInQueueItemResponse,
     ProposeSendResponse,
+    ProspectFacetsResponse,
     ProspectPageResponse,
     ProspectResponse,
     TransitionDraftRequest,
@@ -526,6 +531,66 @@ async def list_prospects(
         next_cursor=next_cursor,
         total=total,
     )
+
+
+# The facet blocks: response field → (document field, display order).
+_PROSPECT_FACETS: dict[str, tuple[str, tuple[str, ...]]] = {
+    "tier": ("tier", TIER_SORT_ORDER),
+    "status": ("status", PROSPECT_STATUS_ORDER),
+    "source": ("source", PROSPECT_SOURCE_ORDER),
+}
+
+
+async def prospect_facets(
+    ctx: RequestContext,
+    *,
+    tier: str | None = None,
+    status: str | None = None,
+    source: str | None = None,
+    q: str | None = None,
+) -> ProspectFacetsResponse:
+    """Counts per tier / status / source for the filter chips.
+
+    Each block respects every active filter EXCEPT its own: with a status
+    filter on, the tier counts still describe that status's rows rather than
+    collapsing to the one selected tier. That self-exclusion is what makes a
+    facet a facet — otherwise the selected chip reads ``n`` and every sibling
+    reads ``0``, which tells the user nothing about where to go next.
+
+    ONE aggregation, workspace-scoped: the ``$or`` search and the tenancy
+    filter (which every block shares) go in the outer ``$match``, and each
+    ``$facet`` branch adds only the sibling filters it needs. Three round
+    trips would be three chances for the counts to disagree with each other.
+    """
+    workspace_id = _require_workspace(ctx)
+    active = {"tier": tier, "status": status, "source": source}
+
+    # Shared prefix — tenancy + the search term, which constrains every block.
+    outer = _prospect_filters(workspace_id, q=q)
+
+    branches: dict[str, list[dict[str, Any]]] = {}
+    for block, (field, _order) in _PROSPECT_FACETS.items():
+        siblings = {f: v for f, v in active.items() if f != block and v is not None}
+        stages: list[dict[str, Any]] = []
+        if siblings:
+            stages.append({"$match": siblings})
+        stages.append({"$group": {"_id": f"${field}", "n": {"$sum": 1}}})
+        branches[block] = stages
+
+    pipeline: list[dict[str, Any]] = [{"$match": outer}, {"$facet": branches}]
+    rows = await _ProspectDoc.get_motor_collection().aggregate(pipeline).to_list(None)
+    raw: dict[str, Any] = rows[0] if rows else {}
+
+    counted: dict[str, dict[str, int]] = {}
+    for block, (_field, order) in _PROSPECT_FACETS.items():
+        seen = {b["_id"]: int(b["n"]) for b in raw.get(block, []) if b.get("_id") is not None}
+        # Every legal value is present, zeros included, so the chip row keeps a
+        # stable shape while the user filters. An unknown value (legacy row,
+        # hand-edited document) is appended rather than silently dropped.
+        counted[block] = {value: seen.pop(value, 0) for value in order} | {
+            value: count for value, count in seen.items()
+        }
+    return ProspectFacetsResponse(**counted)
 
 
 async def update(

--- a/ee/pocketpaw_ee/cloud/growth/service.py
+++ b/ee/pocketpaw_ee/cloud/growth/service.py
@@ -24,6 +24,13 @@
 # draft→proposed via ``transition``), and ``gate_transition`` is the internal
 # seam the growth executor / dispatch worker use to walk gate-owned edges
 # (same legality table, explicit workspace_id, no RequestContext).
+# Updated 2026-07-28 (feat/growth-api-scale): the list query grew a scale
+# surface — ``q`` (escaped case-insensitive regex across four fields, ceiling
+# documented on ``_prospect_filters``), four ``sort`` modes with the tier rank
+# WALKED rather than compared, and keyset cursor pagination returning
+# ``ProspectPageResponse`` ({items, next_cursor, total}) in place of a bare
+# list. Cursors carry their sort mode so a mid-scroll sort change 422s instead
+# of resuming against a key that means something else.
 # Updated 2026-07-27 (feat/growth-g8): LinkedIn manual queue —
 # ``linkedin_queue`` (proposed/approved linkedin drafts joined with their
 # prospect via two queries, newest first), ``linkedin_queue_markdown``
@@ -95,6 +102,7 @@ from pocketpaw_ee.cloud.growth.dto import (
     DraftResponse,
     LinkedInQueueItemResponse,
     ProposeSendResponse,
+    ProspectPageResponse,
     ProspectResponse,
     TransitionDraftRequest,
     UpdateProspectRequest,
@@ -378,6 +386,80 @@ async def _tier_ordered_page(
     return collected
 
 
+# ---------------------------------------------------------------------------
+# Keyset cursor (G-10a)
+#
+# Convention follows ``audit/service.py`` and ``sessions/service.py``: an
+# opaque composite ``{sort_value}|{oid}``, keyset (not offset) so a page never
+# skips or repeats a row when the collection is written to mid-scroll.
+#
+# ONE extension over those two: the sort mode is prefixed
+# (``{sort}:{value}|{oid}``). Audit and sessions have a single fixed ordering,
+# so their cursor can only ever be read back the way it was written. This list
+# has four, and a UI that changes the sort while holding a cursor would
+# otherwise resume against a key that means something different — silently
+# wrong rows rather than an error. The prefix turns that into a 422.
+#
+# The oid is split off with ``rsplit`` because the company sort's value is
+# user-supplied and may itself contain ``|``; an ObjectId hex never can.
+# ---------------------------------------------------------------------------
+
+
+def _encode_prospect_cursor(sort: str, value: str, oid: PydanticObjectId) -> str:
+    return f"{sort}:{value}|{oid!s}"
+
+
+def _decode_prospect_cursor(cursor: str, sort: str) -> tuple[str, PydanticObjectId]:
+    """Split an opaque cursor into ``(sort_value, oid)``, verifying the mode.
+
+    Any malformed cursor — bad shape, unparseable id, or a cursor minted under
+    a different sort — is a 422 ``prospect.bad_cursor`` rather than a wrong
+    page.
+    """
+    try:
+        head, oid_str = cursor.rsplit("|", 1)
+        mode, value = head.split(":", 1)
+        # Broad catch: a bad id raises bson's InvalidId, not ValueError — same
+        # reasoning as ``_fetch_in_workspace``, a malformed id is caller error.
+        oid = PydanticObjectId(oid_str)
+    except Exception as exc:  # noqa: BLE001 — any malformed cursor is a 422
+        raise ValidationError("prospect.bad_cursor", "Invalid pagination cursor") from exc
+    if mode != sort:
+        raise ValidationError(
+            "prospect.bad_cursor",
+            f"Cursor was issued for sort '{mode}' but the request asks for '{sort}'",
+        )
+    return value, oid
+
+
+def _keyset_clause(sort: str, value: str, oid: PydanticObjectId) -> dict[str, Any]:
+    """The "strictly after the cursor row" clause for a non-tier sort."""
+    if sort == "newest":
+        at = _parse_cursor_datetime(value)
+        return {"$or": [{"createdAt": {"$lt": at}}, {"createdAt": at, "_id": {"$lt": oid}}]}
+    if sort == "oldest":
+        at = _parse_cursor_datetime(value)
+        return {"$or": [{"createdAt": {"$gt": at}}, {"createdAt": at, "_id": {"$gt": oid}}]}
+    # company — ascending, ties broken by ascending _id
+    return {"$or": [{"company": {"$gt": value}}, {"company": value, "_id": {"$gt": oid}}]}
+
+
+def _parse_cursor_datetime(value: str) -> datetime:
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise ValidationError("prospect.bad_cursor", "Invalid pagination cursor") from exc
+
+
+def _cursor_value_for(doc: _ProspectDoc, sort: str) -> str:
+    if sort == "company":
+        return doc.company
+    if sort == "tier":
+        return doc.tier
+    created = getattr(doc, "createdAt", None)
+    return created.isoformat() if created is not None else ""
+
+
 async def list_prospects(
     ctx: RequestContext,
     *,
@@ -386,25 +468,64 @@ async def list_prospects(
     source: str | None = None,
     q: str | None = None,
     sort: str = "newest",
+    cursor: str | None = None,
     limit: int = 100,
-) -> list[ProspectResponse]:
-    """List the workspace's prospects, optionally filtered and ordered.
+) -> ProspectPageResponse:
+    """One page of the workspace's prospects, filtered and ordered.
 
     ``q`` is a case-insensitive substring match across name / company /
     domain / research_brief (see ``_prospect_filters`` for the scale ceiling).
-    ``sort`` is one of ``newest`` (default, the pre-G-10a behaviour) /
-    ``oldest`` / ``company`` / ``tier``.
+    ``sort`` is ``newest`` (default, the pre-G-10a ordering) / ``oldest`` /
+    ``company`` / ``tier``. ``cursor`` resumes after the last row of the
+    previous page — pass back the ``next_cursor`` the page returned, unchanged.
+
+    ``total`` counts every row matching the filters, NOT the page, and is
+    computed without the cursor clause so it stays put while the caller pages
+    through ("showing 40 of 3,182").
     """
     workspace_id = _require_workspace(ctx)
+    if sort != "tier" and sort not in _PROSPECT_SORT_SPECS:
+        raise ValidationError("prospect.bad_sort", f"Unknown sort mode '{sort}'")
     filters = _prospect_filters(workspace_id, tier=tier, status=status, source=source, q=q)
+
+    # Over-fetch by one: the extra row is the "is there a next page" probe and
+    # is never returned.
+    probe = limit + 1
     if sort == "tier":
-        docs = await _tier_ordered_page(filters, limit=limit)
+        start_tier: str | None = None
+        after_oid: PydanticObjectId | None = None
+        if cursor:
+            start_tier, after_oid = _decode_prospect_cursor(cursor, sort)
+            if start_tier not in TIER_SORT_ORDER:
+                raise ValidationError("prospect.bad_cursor", "Invalid pagination cursor")
+        docs = await _tier_ordered_page(
+            filters, limit=probe, start_tier=start_tier, after_oid=after_oid
+        )
     else:
-        spec = _PROSPECT_SORT_SPECS.get(sort)
-        if spec is None:
-            raise ValidationError("prospect.bad_sort", f"Unknown sort mode '{sort}'")
-        docs = await _ProspectDoc.find(filters).sort(spec).limit(limit).to_list()
-    return [_to_response(_to_domain(doc)) for doc in docs]
+        find_filter: dict[str, Any] = filters
+        if cursor:
+            value, oid = _decode_prospect_cursor(cursor, sort)
+            find_filter = {"$and": [filters, _keyset_clause(sort, value, oid)]}
+        docs = (
+            await _ProspectDoc.find(find_filter)
+            .sort(_PROSPECT_SORT_SPECS[sort])
+            .limit(probe)
+            .to_list()
+        )
+
+    has_more = len(docs) > limit
+    page = docs[:limit]
+    next_cursor = (
+        _encode_prospect_cursor(sort, _cursor_value_for(page[-1], sort), page[-1].id)
+        if has_more and page
+        else None
+    )
+    total = await _ProspectDoc.find(filters).count()
+    return ProspectPageResponse(
+        items=[_to_response(_to_domain(doc)) for doc in page],
+        next_cursor=next_cursor,
+        total=total,
+    )
 
 
 async def update(

--- a/ee/pocketpaw_ee/cloud/growth/service.py
+++ b/ee/pocketpaw_ee/cloud/growth/service.py
@@ -32,7 +32,10 @@
 # list. Cursors carry their sort mode so a mid-scroll sort change 422s instead
 # of resuming against a key that means something else. ``prospect_facets``
 # counts tier/status/source in ONE workspace-scoped ``$facet`` aggregation,
-# each block excluding its own filter.
+# each block excluding its own filter. ``propose_send_batch`` proposes a
+# selection of drafts by calling the EXISTING ``propose_send`` per id — one
+# gated Instinct proposal each, no batch proposal object and no second route
+# to ``approved``; partial success in the ``bulk_ingest`` style.
 # Updated 2026-07-27 (feat/growth-g8): LinkedIn manual queue —
 # ``linkedin_queue`` (proposed/approved linkedin drafts joined with their
 # prospect via two queries, newest first), ``linkedin_queue_markdown``
@@ -83,7 +86,13 @@ from beanie import PydanticObjectId
 from pydantic import ValidationError as PydanticValidationError
 
 from pocketpaw_ee.cloud._core.context import RequestContext
-from pocketpaw_ee.cloud._core.errors import ConflictError, Forbidden, NotFound, ValidationError
+from pocketpaw_ee.cloud._core.errors import (
+    CloudError,
+    ConflictError,
+    Forbidden,
+    NotFound,
+    ValidationError,
+)
 from pocketpaw_ee.cloud._core.time import iso_utc
 from pocketpaw_ee.cloud.growth.domain import (
     DRAFT_TRANSITIONS,
@@ -105,6 +114,9 @@ from pocketpaw_ee.cloud.growth.dto import (
     CreateProspectRequest,
     DraftResponse,
     LinkedInQueueItemResponse,
+    ProposeBatchError,
+    ProposeBatchRequest,
+    ProposeBatchResponse,
     ProposeSendResponse,
     ProspectFacetsResponse,
     ProspectPageResponse,
@@ -884,6 +896,57 @@ async def propose_send(ctx: RequestContext, draft_id: str) -> ProposeSendRespons
     # in which case the pending proposal stays for the human to reject.
     draft = await transition(ctx, draft_id, TransitionDraftRequest(status="proposed"))
     return ProposeSendResponse(proposal_id=proposal_id, draft=draft)
+
+
+async def propose_send_batch(
+    ctx: RequestContext, body: ProposeBatchRequest
+) -> ProposeBatchResponse:
+    """Propose a selection of drafts in one call (G-10a).
+
+    Each id goes through the EXISTING ``propose_send`` — one Instinct
+    proposal per draft, filed by the same code path the single-draft route
+    uses. There is deliberately no batch proposal object and no shortcut into
+    ``gate_transition``: a "batch" here is a UI convenience over N gated
+    proposals, and a human still approves each one in the Tray. A parallel
+    mechanism would be a second way to reach ``approved``, which is exactly
+    what ``GATE_OWNED_TARGETS`` exists to prevent.
+
+    Partial success, like ``bulk_ingest``: a draft that can't be proposed
+    (missing, cross-tenant, already proposed, terminal) records an indexed
+    error entry and the rest still go. Nothing is rolled back — the proposals
+    already filed are legitimate and a human can reject them.
+    """
+    body = ProposeBatchRequest.model_validate(body)
+    workspace_id = _require_workspace(ctx)
+
+    proposed = 0
+    failed: list[ProposeBatchError] = []
+    for index, draft_id in enumerate(body.draft_ids):
+        try:
+            await propose_send(ctx, draft_id)
+        except CloudError as exc:
+            # Only the domain's own failures become per-draft entries; an
+            # unexpected exception still aborts the batch loudly rather than
+            # being flattened into a row the caller might ignore.
+            failed.append(
+                ProposeBatchError(
+                    index=index,
+                    draft_id=draft_id,
+                    code=exc.code,
+                    message=exc.message,
+                )
+            )
+            continue
+        proposed += 1
+
+    logger.info(
+        "growth.propose_batch workspace=%s requested=%d proposed=%d failed=%d",
+        workspace_id,
+        len(body.draft_ids),
+        proposed,
+        len(failed),
+    )
+    return ProposeBatchResponse(proposed=proposed, failed=failed)
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/cloud/growth/service.py
+++ b/ee/pocketpaw_ee/cloud/growth/service.py
@@ -81,6 +81,7 @@ from pocketpaw_ee.cloud.growth.domain import (
     GATE_OWNED_TARGETS,
     MESSAGE_LOG_OUTCOMES,
     PROVIDER_REACHED_OUTCOMES,
+    TIER_SORT_ORDER,
     Draft,
     MessageLog,
     Prospect,
@@ -314,6 +315,69 @@ def _prospect_filters(
     return filters
 
 
+# Mongo sort keys per sort mode. Every spec ends in ``_id`` so ties break
+# deterministically — without it two rows sharing a createdAt / company can
+# swap places between two identical queries, which silently duplicates or drops
+# a row across a paginated boundary. ``tier`` is absent on purpose: its order is
+# a declared rank, not a field comparison — see ``_tier_ordered_page``.
+_PROSPECT_SORT_SPECS: dict[str, list[tuple[str, int]]] = {
+    "newest": [("createdAt", -1), ("_id", -1)],
+    "oldest": [("createdAt", 1), ("_id", 1)],
+    "company": [("company", 1), ("_id", 1)],
+}
+
+
+def _tier_buckets(filters: dict[str, Any]) -> tuple[str, ...]:
+    """The tier buckets to walk, best-qualified first.
+
+    An active ``tier`` filter collapses the walk to that one bucket — the
+    filter is enum-validated at the router, so it is always a known tier.
+    """
+    active = filters.get("tier")
+    if active is None:
+        return TIER_SORT_ORDER
+    return (active,) if active in TIER_SORT_ORDER else ()
+
+
+async def _tier_ordered_page(
+    filters: dict[str, Any],
+    *,
+    limit: int,
+    start_tier: str | None = None,
+    after_oid: PydanticObjectId | None = None,
+) -> list[_ProspectDoc]:
+    """Fetch up to ``limit`` docs ordered by the DECLARED tier rank.
+
+    Mongo cannot sort by a rank that isn't in the document, and adding a
+    computed rank via ``$addFields`` would drag the whole list query into an
+    aggregation. Instead the rank is walked: one bounded query per tier bucket,
+    in ``TIER_SORT_ORDER``, stopping as soon as the page is full — at most four
+    queries, each bounded by the remaining page size.
+
+    Within a bucket rows come back newest-first by ``_id`` (an ObjectId is
+    monotonic in creation time, so it doubles as the recency key AND the
+    tie-breaker, which keeps the resume key a single value).
+    """
+    collected: list[_ProspectDoc] = []
+    buckets = _tier_buckets(filters)
+    started = start_tier is None
+    for bucket_tier in buckets:
+        if not started:
+            if bucket_tier != start_tier:
+                continue
+            started = True
+        remaining = limit - len(collected)
+        if remaining <= 0:
+            break
+        bucket_filter: dict[str, Any] = {**filters, "tier": bucket_tier}
+        if bucket_tier == start_tier and after_oid is not None:
+            bucket_filter["_id"] = {"$lt": after_oid}
+        collected.extend(
+            await _ProspectDoc.find(bucket_filter).sort([("_id", -1)]).limit(remaining).to_list()
+        )
+    return collected
+
+
 async def list_prospects(
     ctx: RequestContext,
     *,
@@ -321,21 +385,26 @@ async def list_prospects(
     status: str | None = None,
     source: str | None = None,
     q: str | None = None,
+    sort: str = "newest",
     limit: int = 100,
 ) -> list[ProspectResponse]:
-    """List the workspace's prospects, newest first, optionally filtered.
+    """List the workspace's prospects, optionally filtered and ordered.
 
     ``q`` is a case-insensitive substring match across name / company /
     domain / research_brief (see ``_prospect_filters`` for the scale ceiling).
+    ``sort`` is one of ``newest`` (default, the pre-G-10a behaviour) /
+    ``oldest`` / ``company`` / ``tier``.
     """
     workspace_id = _require_workspace(ctx)
     filters = _prospect_filters(workspace_id, tier=tier, status=status, source=source, q=q)
-    cursor = (
-        _ProspectDoc.find(filters)
-        .sort(-_ProspectDoc.createdAt)  # type: ignore[operator]
-        .limit(limit)
-    )
-    return [_to_response(_to_domain(doc)) async for doc in cursor]
+    if sort == "tier":
+        docs = await _tier_ordered_page(filters, limit=limit)
+    else:
+        spec = _PROSPECT_SORT_SPECS.get(sort)
+        if spec is None:
+            raise ValidationError("prospect.bad_sort", f"Unknown sort mode '{sort}'")
+        docs = await _ProspectDoc.find(filters).sort(spec).limit(limit).to_list()
+    return [_to_response(_to_domain(doc)) for doc in docs]
 
 
 async def update(

--- a/tests/cloud/growth/test_gate.py
+++ b/tests/cloud/growth/test_gate.py
@@ -920,6 +920,7 @@ class TestGrowthRouteRbac:
 
         expected = {
             ("GET", "/growth/prospects"): "growth.read",
+            ("GET", "/growth/prospects/facets"): "growth.read",
             ("GET", "/growth/prospects/{prospect_id}"): "growth.read",
             ("GET", "/growth/drafts"): "growth.read",
             ("POST", "/growth/prospects"): "growth.write",

--- a/tests/cloud/growth/test_gate.py
+++ b/tests/cloud/growth/test_gate.py
@@ -930,6 +930,10 @@ class TestGrowthRouteRbac:
             ("POST", "/growth/drafts/{draft_id}/status"): "growth.write",
             # The outbound verb sits at the ADMIN tier the executor re-checks.
             ("POST", "/growth/drafts/{draft_id}/propose"): "growth.manage",
+            # G-10a's batch propose is the same outbound verb over N ids, so
+            # it sits at the same ADMIN tier — a lower tier here would be a
+            # way to file proposals the executor then refuses at approve time.
+            ("POST", "/growth/drafts/propose-batch"): "growth.manage",
             # G-8's manual LinkedIn surface. mark-sent is an OUTBOUND verb —
             # same ADMIN tier as propose — and it walks the gate seam, since
             # ``sent`` is gate-owned.
@@ -949,3 +953,142 @@ class TestGrowthRouteRbac:
                 seen[(method, route.path)] = guards[0].replace("require_action_growth_", "growth.")
 
         assert seen == expected
+
+
+# ---------------------------------------------------------------------------
+# Batch propose (G-10a) — N ids, N gated proposals, no shortcut
+# ---------------------------------------------------------------------------
+
+
+BATCH_URL = "/api/v1/growth/drafts/propose-batch"
+
+
+async def _n_drafts(client: AsyncClient, n: int, *, prefix: str = "batch") -> list[dict]:
+    """n prospects, one email draft each. Each gets its own domain — the
+    (workspace, domain) index is unique, so two calls in one test need
+    distinct prefixes or the second 409s."""
+    drafts = []
+    for i in range(n):
+        _, draft = await _drafted_prospect(
+            client, domain=f"{prefix}-{i:02d}.io", company=f"Co {prefix} {i:02d}"
+        )
+        drafts.append(draft)
+    return drafts
+
+
+class TestProposeBatch:
+    """A batch is a UI convenience over N gated proposals, never a way around
+    the gate: every id rides the same ``propose_send`` path, so each draft
+    still needs its own human approval in the Tray."""
+
+    @pytest.mark.asyncio
+    async def test_twelve_valid_ids_file_twelve_gated_proposals(self, w1, gate_store):
+        drafts = await _n_drafts(w1, 12)
+
+        resp = await w1.post(BATCH_URL, json={"draft_ids": [d["id"] for d in drafts]})
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == {"proposed": 12, "failed": []}
+
+        # One gated proposal per draft — filed through the gate, not around it.
+        actions = await gate_store.list_actions(limit=100)
+        assert len(actions) == 12
+        blobs = [a.parameters["_growth_send"] for a in actions]
+        assert all(b["kind"] == "growth_send" for b in blobs)
+        assert all(b["workspace_id"] == "w1" for b in blobs)
+        assert {b["draft_id"] for b in blobs} == {d["id"] for d in drafts}
+        # Every one is PENDING: nothing was approved, nothing was sent.
+        assert all(str(getattr(a.status, "value", a.status)) == "pending" for a in actions)
+        for draft in drafts:
+            assert await _draft_status(w1, draft["id"]) == "proposed"
+
+    @pytest.mark.asyncio
+    async def test_mixed_validity_proposes_the_good_and_reports_the_bad(self, w1, gate_store):
+        """A bad id becomes an indexed error entry; the ids around it still
+        get proposed — same partial-success contract as bulk ingest."""
+        good = await _n_drafts(w1, 2, prefix="good")
+        already = (await _n_drafts(w1, 1, prefix="already"))[0]
+        await _propose(w1, already["id"])  # now 'proposed' — can't move again
+
+        ids = [good[0]["id"], "not-an-object-id", already["id"], good[1]["id"]]
+        resp = await w1.post(BATCH_URL, json={"draft_ids": ids})
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["proposed"] == 2
+        assert [e["index"] for e in body["failed"]] == [1, 2]
+        assert body["failed"][0] == {
+            "index": 1,
+            "draft_id": "not-an-object-id",
+            "code": "draft.not_found",
+            "message": body["failed"][0]["message"],
+        }
+        assert body["failed"][1]["draft_id"] == already["id"]
+        assert body["failed"][1]["code"] == "draft.illegal_transition"
+
+        # The valid ones really landed.
+        assert await _draft_status(w1, good[0]["id"]) == "proposed"
+        assert await _draft_status(w1, good[1]["id"]) == "proposed"
+        # 1 from the setup propose + 2 from the batch. The already-proposed
+        # draft did NOT get a second proposal.
+        assert len(await gate_store.list_actions(limit=100)) == 3
+
+    @pytest.mark.asyncio
+    async def test_over_one_hundred_ids_is_422_before_anything_is_filed(self, w1, gate_store):
+        drafts = await _n_drafts(w1, 2)
+        oversized = [drafts[0]["id"]] * 101
+
+        resp = await w1.post(BATCH_URL, json={"draft_ids": oversized})
+
+        assert resp.status_code == 422, resp.text
+        # The cap is enforced at the DTO boundary — no proposal was filed.
+        assert await gate_store.list_actions(limit=100) == []
+        assert await _draft_status(w1, drafts[0]["id"]) == "draft"
+
+    @pytest.mark.asyncio
+    async def test_exactly_one_hundred_ids_is_accepted(self, w1):
+        """The cap is 100, not 99 — pins the boundary."""
+        draft = (await _n_drafts(w1, 1))[0]
+        # 1 real id + 99 unknown ones: proves the payload passed validation
+        # (a 422 would mean the cap fired) without creating 100 drafts.
+        ids = [draft["id"]] + [f"missing-{i}" for i in range(99)]
+        resp = await w1.post(BATCH_URL, json={"draft_ids": ids})
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["proposed"] == 1
+        assert len(resp.json()["failed"]) == 99
+
+    @pytest.mark.asyncio
+    async def test_a_member_cannot_batch_propose(self, w1, gate_store):
+        """Same ADMIN tier as the single propose — batching must not be a
+        cheaper route to the outbound verb."""
+        drafts = await _n_drafts(w1, 2)
+        transport = ASGITransport(app=_build_growth_app("w1", role="member"))
+        async with AsyncClient(transport=transport, base_url="http://t") as member:
+            resp = await member.post(BATCH_URL, json={"draft_ids": [d["id"] for d in drafts]})
+
+        assert resp.status_code == 403, resp.text
+        assert resp.json()["error"]["code"] == "workspace.insufficient_role"
+        assert await gate_store.list_actions(limit=100) == []
+        assert await _draft_status(w1, drafts[0]["id"]) == "draft"
+
+    @pytest.mark.asyncio
+    async def test_another_tenants_draft_ids_propose_nothing(self, w1, w2, gate_store):
+        """Cross-tenant ids 404 into the failed list — existence never leaks
+        and no proposal is filed against the other workspace's draft."""
+        foreign = await _n_drafts(w2, 2)
+
+        resp = await w1.post(BATCH_URL, json={"draft_ids": [d["id"] for d in foreign]})
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["proposed"] == 0
+        assert [e["code"] for e in body["failed"]] == ["draft.not_found", "draft.not_found"]
+        assert await gate_store.list_actions(limit=100) == []
+        assert await _draft_status(w2, foreign[0]["id"]) == "draft"
+
+    @pytest.mark.asyncio
+    async def test_an_empty_batch_is_a_no_op(self, w1, gate_store):
+        resp = await w1.post(BATCH_URL, json={"draft_ids": []})
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == {"proposed": 0, "failed": []}
+        assert await gate_store.list_actions(limit=100) == []

--- a/tests/cloud/growth/test_list_query.py
+++ b/tests/cloud/growth/test_list_query.py
@@ -1,0 +1,135 @@
+# tests/cloud/growth/test_list_query.py — HTTP-layer tests for the G-10a
+# prospect-list scale surface: ``q`` full-text-ish search, the four ``sort``
+# modes, cursor pagination + ``total``, and the facets endpoint. Reuses the
+# ``test_router.py`` app harness (fixed RequestContext per workspace,
+# mongomock-backed Beanie) so the RBAC guards and the license gate are wired
+# exactly as in production.
+#
+# Created 2026-07-28 (feat/growth-api-scale): G-10a — the list endpoint could
+# not reach row 3,000, find a company by name, or say "n of m". Split into its
+# own file rather than growing test_router.py past readability.
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from tests.cloud.growth.test_router import _build_app, _payload
+
+LIST_URL = "/api/v1/growth/prospects"
+FACETS_URL = "/api/v1/growth/prospects/facets"
+
+
+@pytest_asyncio.fixture
+async def w1_client(mongo_db: Any) -> AsyncClient:
+    app = _build_app(workspace_id="w1")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+@pytest_asyncio.fixture
+async def w2_client(mongo_db: Any) -> AsyncClient:
+    app = _build_app(workspace_id="w2")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+async def _seed(client: AsyncClient, rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Create rows one at a time (sequential inserts give a stable createdAt
+    order, which the newest/oldest sort assertions depend on)."""
+    created = []
+    for row in rows:
+        resp = await client.post(LIST_URL, json=_payload(**row))
+        assert resp.status_code == 200, resp.text
+        created.append(resp.json())
+    return created
+
+
+# ---------------------------------------------------------------------------
+# 1. ``q`` search
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("term", "expected_domain"),
+    [
+        ("norah", "alpha.io"),  # name
+        ("zenith", "beta.io"),  # company
+        ("gamma-corp", "gamma-corp.io"),  # domain
+        ("periodontics", "delta.io"),  # research_brief
+    ],
+)
+async def test_q_matches_across_all_four_fields(w1_client, term, expected_domain):
+    await _seed(
+        w1_client,
+        [
+            {"domain": "alpha.io", "name": "Norah Bright", "company": "Alpha Dental"},
+            {"domain": "beta.io", "name": "Sam Founder", "company": "Zenith Clinics"},
+            {"domain": "gamma-corp.io", "name": "Sam Founder", "company": "Gamma"},
+            {
+                "domain": "delta.io",
+                "name": "Sam Founder",
+                "company": "Delta",
+                "research_brief": "Runs a periodontics practice in Pune",
+            },
+        ],
+    )
+    resp = await w1_client.get(LIST_URL, params={"q": term})
+    assert resp.status_code == 200, resp.text
+    assert [p["domain"] for p in resp.json()] == [expected_domain]
+
+
+@pytest.mark.asyncio
+async def test_q_is_case_insensitive(w1_client):
+    await _seed(w1_client, [{"domain": "alpha.io", "company": "Alpha Dental"}])
+    for term in ("alpha dental", "ALPHA DENTAL", "AlPhA dEnTaL"):
+        resp = await w1_client.get(LIST_URL, params={"q": term})
+        assert [p["domain"] for p in resp.json()] == ["alpha.io"], term
+
+
+@pytest.mark.asyncio
+async def test_q_is_workspace_scoped(w1_client, w2_client):
+    """The other tenant's matching row is never returned — the search runs
+    inside the workspace filter, not beside it."""
+    await _seed(w1_client, [{"domain": "alpha.io", "company": "Sharedname Clinics"}])
+    await _seed(w2_client, [{"domain": "beta.io", "company": "Sharedname Clinics"}])
+
+    w1_hits = (await w1_client.get(LIST_URL, params={"q": "sharedname"})).json()
+    w2_hits = (await w2_client.get(LIST_URL, params={"q": "sharedname"})).json()
+    assert [p["domain"] for p in w1_hits] == ["alpha.io"]
+    assert [p["domain"] for p in w2_hits] == ["beta.io"]
+
+
+@pytest.mark.asyncio
+async def test_q_composes_with_the_existing_filters(w1_client):
+    await _seed(
+        w1_client,
+        [
+            {"domain": "alpha.io", "company": "Acme One", "tier": "a"},
+            {"domain": "beta.io", "company": "Acme Two", "tier": "b"},
+        ],
+    )
+    resp = await w1_client.get(LIST_URL, params={"q": "acme", "tier": "a"})
+    assert [p["domain"] for p in resp.json()] == ["alpha.io"]
+
+
+@pytest.mark.asyncio
+async def test_q_metacharacters_are_matched_literally(w1_client):
+    """A regex metacharacter is escaped, not compiled — ``.*`` matches nothing
+    rather than everything, and a catastrophic pattern can't be injected."""
+    await _seed(w1_client, [{"domain": "alpha.io", "company": "Acme"}])
+    resp = await w1_client.get(LIST_URL, params={"q": ".*"})
+    assert resp.json() == []
+
+
+@pytest.mark.asyncio
+async def test_blank_q_is_ignored(w1_client):
+    await _seed(w1_client, [{"domain": "alpha.io"}, {"domain": "beta.io"}])
+    resp = await w1_client.get(LIST_URL, params={"q": "   "})
+    assert len(resp.json()) == 2

--- a/tests/cloud/growth/test_list_query.py
+++ b/tests/cloud/growth/test_list_query.py
@@ -133,3 +133,90 @@ async def test_blank_q_is_ignored(w1_client):
     await _seed(w1_client, [{"domain": "alpha.io"}, {"domain": "beta.io"}])
     resp = await w1_client.get(LIST_URL, params={"q": "   "})
     assert len(resp.json()) == 2
+
+
+# ---------------------------------------------------------------------------
+# 2. ``sort``
+# ---------------------------------------------------------------------------
+
+
+SORT_ROWS = [
+    {"domain": "zulu.io", "company": "Zulu Clinics", "tier": "unqualified"},
+    {"domain": "alpha.io", "company": "Alpha Dental", "tier": "c"},
+    {"domain": "mike.io", "company": "Mike Ortho", "tier": "a"},
+    {"domain": "bravo.io", "company": "Bravo Health", "tier": "b"},
+]
+
+
+@pytest.mark.asyncio
+async def test_sort_newest_is_the_default_and_is_creation_order_reversed(w1_client):
+    await _seed(w1_client, SORT_ROWS)
+    default = (await w1_client.get(LIST_URL)).json()
+    explicit = (await w1_client.get(LIST_URL, params={"sort": "newest"})).json()
+    assert [p["domain"] for p in default] == ["bravo.io", "mike.io", "alpha.io", "zulu.io"]
+    assert default == explicit
+
+
+@pytest.mark.asyncio
+async def test_sort_oldest_is_creation_order(w1_client):
+    await _seed(w1_client, SORT_ROWS)
+    rows = (await w1_client.get(LIST_URL, params={"sort": "oldest"})).json()
+    assert [p["domain"] for p in rows] == ["zulu.io", "alpha.io", "mike.io", "bravo.io"]
+
+
+@pytest.mark.asyncio
+async def test_sort_company_is_alphabetical(w1_client):
+    await _seed(w1_client, SORT_ROWS)
+    rows = (await w1_client.get(LIST_URL, params={"sort": "company"})).json()
+    assert [p["company"] for p in rows] == [
+        "Alpha Dental",
+        "Bravo Health",
+        "Mike Ortho",
+        "Zulu Clinics",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_sort_tier_walks_the_declared_rank(w1_client):
+    """a → b → c → unqualified. Asserted on the tier sequence itself, not on
+    the row order, so the test states the rank rather than restating the
+    fixture."""
+    await _seed(w1_client, SORT_ROWS)
+    rows = (await w1_client.get(LIST_URL, params={"sort": "tier"})).json()
+    assert [p["tier"] for p in rows] == ["a", "b", "c", "unqualified"]
+    assert [p["domain"] for p in rows] == ["mike.io", "bravo.io", "alpha.io", "zulu.io"]
+
+
+@pytest.mark.asyncio
+async def test_sort_tier_orders_within_a_bucket_newest_first(w1_client):
+    await _seed(
+        w1_client,
+        [
+            {"domain": "a-old.io", "tier": "a"},
+            {"domain": "b-only.io", "tier": "b"},
+            {"domain": "a-new.io", "tier": "a"},
+        ],
+    )
+    rows = (await w1_client.get(LIST_URL, params={"sort": "tier"})).json()
+    assert [p["domain"] for p in rows] == ["a-new.io", "a-old.io", "b-only.io"]
+
+
+@pytest.mark.asyncio
+async def test_sort_tier_composes_with_a_tier_filter(w1_client):
+    await _seed(w1_client, SORT_ROWS)
+    rows = (await w1_client.get(LIST_URL, params={"sort": "tier", "tier": "b"})).json()
+    assert [p["domain"] for p in rows] == ["bravo.io"]
+
+
+@pytest.mark.asyncio
+async def test_sort_tier_is_workspace_scoped(w1_client, w2_client):
+    await _seed(w1_client, [{"domain": "alpha.io", "tier": "a"}])
+    await _seed(w2_client, [{"domain": "beta.io", "tier": "a"}])
+    rows = (await w1_client.get(LIST_URL, params={"sort": "tier"})).json()
+    assert [p["domain"] for p in rows] == ["alpha.io"]
+
+
+@pytest.mark.asyncio
+async def test_unknown_sort_mode_is_422(w1_client):
+    resp = await w1_client.get(LIST_URL, params={"sort": "cheapest"})
+    assert resp.status_code == 422

--- a/tests/cloud/growth/test_list_query.py
+++ b/tests/cloud/growth/test_list_query.py
@@ -50,6 +50,13 @@ async def _seed(client: AsyncClient, rows: list[dict[str, Any]]) -> list[dict[st
     return created
 
 
+def _items(resp: Any) -> list[dict[str, Any]]:
+    """The page envelope's rows. G-10a replaced the bare array with
+    ``{items, next_cursor, total}``."""
+    assert resp.status_code == 200, resp.text
+    return resp.json()["items"]
+
+
 # ---------------------------------------------------------------------------
 # 1. ``q`` search
 # ---------------------------------------------------------------------------
@@ -81,8 +88,7 @@ async def test_q_matches_across_all_four_fields(w1_client, term, expected_domain
         ],
     )
     resp = await w1_client.get(LIST_URL, params={"q": term})
-    assert resp.status_code == 200, resp.text
-    assert [p["domain"] for p in resp.json()] == [expected_domain]
+    assert [p["domain"] for p in _items(resp)] == [expected_domain]
 
 
 @pytest.mark.asyncio
@@ -90,7 +96,7 @@ async def test_q_is_case_insensitive(w1_client):
     await _seed(w1_client, [{"domain": "alpha.io", "company": "Alpha Dental"}])
     for term in ("alpha dental", "ALPHA DENTAL", "AlPhA dEnTaL"):
         resp = await w1_client.get(LIST_URL, params={"q": term})
-        assert [p["domain"] for p in resp.json()] == ["alpha.io"], term
+        assert [p["domain"] for p in _items(resp)] == ["alpha.io"], term
 
 
 @pytest.mark.asyncio
@@ -100,8 +106,8 @@ async def test_q_is_workspace_scoped(w1_client, w2_client):
     await _seed(w1_client, [{"domain": "alpha.io", "company": "Sharedname Clinics"}])
     await _seed(w2_client, [{"domain": "beta.io", "company": "Sharedname Clinics"}])
 
-    w1_hits = (await w1_client.get(LIST_URL, params={"q": "sharedname"})).json()
-    w2_hits = (await w2_client.get(LIST_URL, params={"q": "sharedname"})).json()
+    w1_hits = _items(await w1_client.get(LIST_URL, params={"q": "sharedname"}))
+    w2_hits = _items(await w2_client.get(LIST_URL, params={"q": "sharedname"}))
     assert [p["domain"] for p in w1_hits] == ["alpha.io"]
     assert [p["domain"] for p in w2_hits] == ["beta.io"]
 
@@ -116,7 +122,7 @@ async def test_q_composes_with_the_existing_filters(w1_client):
         ],
     )
     resp = await w1_client.get(LIST_URL, params={"q": "acme", "tier": "a"})
-    assert [p["domain"] for p in resp.json()] == ["alpha.io"]
+    assert [p["domain"] for p in _items(resp)] == ["alpha.io"]
 
 
 @pytest.mark.asyncio
@@ -125,14 +131,14 @@ async def test_q_metacharacters_are_matched_literally(w1_client):
     rather than everything, and a catastrophic pattern can't be injected."""
     await _seed(w1_client, [{"domain": "alpha.io", "company": "Acme"}])
     resp = await w1_client.get(LIST_URL, params={"q": ".*"})
-    assert resp.json() == []
+    assert _items(resp) == []
 
 
 @pytest.mark.asyncio
 async def test_blank_q_is_ignored(w1_client):
     await _seed(w1_client, [{"domain": "alpha.io"}, {"domain": "beta.io"}])
     resp = await w1_client.get(LIST_URL, params={"q": "   "})
-    assert len(resp.json()) == 2
+    assert len(_items(resp)) == 2
 
 
 # ---------------------------------------------------------------------------
@@ -151,8 +157,8 @@ SORT_ROWS = [
 @pytest.mark.asyncio
 async def test_sort_newest_is_the_default_and_is_creation_order_reversed(w1_client):
     await _seed(w1_client, SORT_ROWS)
-    default = (await w1_client.get(LIST_URL)).json()
-    explicit = (await w1_client.get(LIST_URL, params={"sort": "newest"})).json()
+    default = _items(await w1_client.get(LIST_URL))
+    explicit = _items(await w1_client.get(LIST_URL, params={"sort": "newest"}))
     assert [p["domain"] for p in default] == ["bravo.io", "mike.io", "alpha.io", "zulu.io"]
     assert default == explicit
 
@@ -160,14 +166,14 @@ async def test_sort_newest_is_the_default_and_is_creation_order_reversed(w1_clie
 @pytest.mark.asyncio
 async def test_sort_oldest_is_creation_order(w1_client):
     await _seed(w1_client, SORT_ROWS)
-    rows = (await w1_client.get(LIST_URL, params={"sort": "oldest"})).json()
+    rows = _items(await w1_client.get(LIST_URL, params={"sort": "oldest"}))
     assert [p["domain"] for p in rows] == ["zulu.io", "alpha.io", "mike.io", "bravo.io"]
 
 
 @pytest.mark.asyncio
 async def test_sort_company_is_alphabetical(w1_client):
     await _seed(w1_client, SORT_ROWS)
-    rows = (await w1_client.get(LIST_URL, params={"sort": "company"})).json()
+    rows = _items(await w1_client.get(LIST_URL, params={"sort": "company"}))
     assert [p["company"] for p in rows] == [
         "Alpha Dental",
         "Bravo Health",
@@ -182,7 +188,7 @@ async def test_sort_tier_walks_the_declared_rank(w1_client):
     the row order, so the test states the rank rather than restating the
     fixture."""
     await _seed(w1_client, SORT_ROWS)
-    rows = (await w1_client.get(LIST_URL, params={"sort": "tier"})).json()
+    rows = _items(await w1_client.get(LIST_URL, params={"sort": "tier"}))
     assert [p["tier"] for p in rows] == ["a", "b", "c", "unqualified"]
     assert [p["domain"] for p in rows] == ["mike.io", "bravo.io", "alpha.io", "zulu.io"]
 
@@ -197,14 +203,14 @@ async def test_sort_tier_orders_within_a_bucket_newest_first(w1_client):
             {"domain": "a-new.io", "tier": "a"},
         ],
     )
-    rows = (await w1_client.get(LIST_URL, params={"sort": "tier"})).json()
+    rows = _items(await w1_client.get(LIST_URL, params={"sort": "tier"}))
     assert [p["domain"] for p in rows] == ["a-new.io", "a-old.io", "b-only.io"]
 
 
 @pytest.mark.asyncio
 async def test_sort_tier_composes_with_a_tier_filter(w1_client):
     await _seed(w1_client, SORT_ROWS)
-    rows = (await w1_client.get(LIST_URL, params={"sort": "tier", "tier": "b"})).json()
+    rows = _items(await w1_client.get(LIST_URL, params={"sort": "tier", "tier": "b"}))
     assert [p["domain"] for p in rows] == ["bravo.io"]
 
 
@@ -212,7 +218,7 @@ async def test_sort_tier_composes_with_a_tier_filter(w1_client):
 async def test_sort_tier_is_workspace_scoped(w1_client, w2_client):
     await _seed(w1_client, [{"domain": "alpha.io", "tier": "a"}])
     await _seed(w2_client, [{"domain": "beta.io", "tier": "a"}])
-    rows = (await w1_client.get(LIST_URL, params={"sort": "tier"})).json()
+    rows = _items(await w1_client.get(LIST_URL, params={"sort": "tier"}))
     assert [p["domain"] for p in rows] == ["alpha.io"]
 
 
@@ -220,3 +226,121 @@ async def test_sort_tier_is_workspace_scoped(w1_client, w2_client):
 async def test_unknown_sort_mode_is_422(w1_client):
     resp = await w1_client.get(LIST_URL, params={"sort": "cheapest"})
     assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# 3. Cursor pagination + total
+# ---------------------------------------------------------------------------
+
+
+# 9 rows spread across all four tiers, so the tier sort's bucket walk has to
+# cross a bucket boundary mid-page (limit=2 over 3/2/2/2 buckets).
+_TIER_CYCLE = ("a", "b", "c", "unqualified")
+PAGE_ROWS = [
+    {"domain": f"co-{i:02d}.io", "company": f"Company {i:02d}", "tier": _TIER_CYCLE[i % 4]}
+    for i in range(9)
+]
+
+
+async def _drain(client: AsyncClient, params: dict[str, Any]) -> tuple[list[str], list[int]]:
+    """Page through the whole result set. Returns the ids in page order plus
+    the ``total`` seen on each page (so a test can assert it never moves)."""
+    ids: list[str] = []
+    totals: list[int] = []
+    cursor: str | None = None
+    for _ in range(20):  # loop guard — a non-terminating cursor is a bug
+        page_params = dict(params)
+        if cursor:
+            page_params["cursor"] = cursor
+        resp = await client.get(LIST_URL, params=page_params)
+        assert resp.status_code == 200, resp.text
+        page = resp.json()
+        ids.extend(row["id"] for row in page["items"])
+        totals.append(page["total"])
+        cursor = page["next_cursor"]
+        if cursor is None:
+            return ids, totals
+    raise AssertionError("cursor never terminated")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("sort", ["newest", "oldest", "company", "tier"])
+async def test_cursor_round_trips_with_no_overlap_and_no_gap(w1_client, sort):
+    """Page 1 → cursor → page 2 … covers every row exactly once, in the same
+    order a single unpaginated call would have produced."""
+    await _seed(w1_client, PAGE_ROWS)
+
+    one_shot = _items(await w1_client.get(LIST_URL, params={"sort": sort, "limit": 100}))
+    assert len(one_shot) == 9
+
+    paged_ids, totals = await _drain(w1_client, {"sort": sort, "limit": 2})
+    assert paged_ids == [row["id"] for row in one_shot]  # no overlap, no gap
+    assert len(set(paged_ids)) == 9
+    assert totals == [9] * len(totals)  # total is stable across pages
+
+
+@pytest.mark.asyncio
+async def test_next_cursor_is_null_on_the_last_page(w1_client):
+    await _seed(w1_client, PAGE_ROWS[:3])
+    page = (await w1_client.get(LIST_URL, params={"limit": 3})).json()
+    assert len(page["items"]) == 3
+    assert page["next_cursor"] is None
+
+
+@pytest.mark.asyncio
+async def test_total_counts_the_filtered_set_not_the_page(w1_client):
+    await _seed(w1_client, PAGE_ROWS)
+    page = (await w1_client.get(LIST_URL, params={"limit": 2, "tier": "a"})).json()
+    assert len(page["items"]) == 2
+    assert page["total"] == 3  # 3 tier-a rows out of 9
+    assert page["next_cursor"] is not None
+
+
+@pytest.mark.asyncio
+async def test_total_respects_the_q_filter(w1_client):
+    await _seed(w1_client, PAGE_ROWS)
+    page = (await w1_client.get(LIST_URL, params={"q": "Company 0"})).json()
+    assert page["total"] == len(page["items"]) == 9  # Company 00..08
+
+
+@pytest.mark.asyncio
+async def test_paging_is_workspace_scoped(w1_client, w2_client):
+    await _seed(w1_client, PAGE_ROWS[:4])
+    await _seed(w2_client, PAGE_ROWS[:4])
+    w1_ids, w1_totals = await _drain(w1_client, {"limit": 2})
+    w2_ids, w2_totals = await _drain(w2_client, {"limit": 2})
+    assert w1_totals[0] == w2_totals[0] == 4
+    assert set(w1_ids).isdisjoint(set(w2_ids))
+
+
+@pytest.mark.asyncio
+async def test_a_cursor_from_another_sort_is_rejected(w1_client):
+    """Changing the sort while holding a cursor would otherwise resume against
+    a key that means something else — silently wrong rows."""
+    await _seed(w1_client, PAGE_ROWS)
+    page = (await w1_client.get(LIST_URL, params={"limit": 2, "sort": "newest"})).json()
+    resp = await w1_client.get(
+        LIST_URL, params={"limit": 2, "sort": "company", "cursor": page["next_cursor"]}
+    )
+    assert resp.status_code == 422
+    assert resp.json()["error"]["code"] == "prospect.bad_cursor"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad", ["garbage", "newest:not-a-date|deadbeef", "newest:x|y"])
+async def test_a_malformed_cursor_is_422_not_a_wrong_page(w1_client, bad):
+    await _seed(w1_client, PAGE_ROWS[:2])
+    resp = await w1_client.get(LIST_URL, params={"cursor": bad})
+    assert resp.status_code == 422
+    assert resp.json()["error"]["code"] == "prospect.bad_cursor"
+
+
+@pytest.mark.asyncio
+async def test_a_cursor_from_another_workspace_leaks_nothing(w1_client, w2_client):
+    """A stolen cursor is just a sort key — it cannot pull the other tenant's
+    rows, because the workspace filter is applied independently."""
+    await _seed(w1_client, PAGE_ROWS[:4])
+    page = (await w1_client.get(LIST_URL, params={"limit": 2})).json()
+    resp = await w2_client.get(LIST_URL, params={"limit": 2, "cursor": page["next_cursor"]})
+    assert resp.status_code == 200
+    assert resp.json() == {"items": [], "next_cursor": None, "total": 0}

--- a/tests/cloud/growth/test_list_query.py
+++ b/tests/cloud/growth/test_list_query.py
@@ -344,3 +344,100 @@ async def test_a_cursor_from_another_workspace_leaks_nothing(w1_client, w2_clien
     resp = await w2_client.get(LIST_URL, params={"limit": 2, "cursor": page["next_cursor"]})
     assert resp.status_code == 200
     assert resp.json() == {"items": [], "next_cursor": None, "total": 0}
+
+
+# ---------------------------------------------------------------------------
+# 4. Facets
+# ---------------------------------------------------------------------------
+
+
+FACET_ROWS = [
+    {"domain": "a1.io", "tier": "a", "status": "new", "source": "clay"},
+    {"domain": "a2.io", "tier": "a", "status": "replied", "source": "clay"},
+    {"domain": "b1.io", "tier": "b", "status": "new", "source": "directory"},
+    {"domain": "b2.io", "tier": "b", "status": "replied", "source": "manual"},
+    {"domain": "c1.io", "tier": "c", "status": "new", "source": "manual"},
+]
+
+
+@pytest.mark.asyncio
+async def test_facets_count_every_tier_status_and_source(w1_client):
+    await _seed(w1_client, FACET_ROWS)
+    resp = await w1_client.get(FACETS_URL)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["tier"] == {"a": 2, "b": 2, "c": 1, "unqualified": 0}
+    assert body["status"] == {
+        "new": 3,
+        "qualified": 0,
+        "drafted": 0,
+        "in_sequence": 0,
+        "replied": 2,
+        "dead": 0,
+    }
+    assert body["source"] == {"clay": 2, "directory": 1, "manual": 2}
+
+
+@pytest.mark.asyncio
+async def test_facets_include_zero_counts_for_a_stable_chip_row(w1_client):
+    """An empty workspace still reports every legal value, so the chip row
+    doesn't reshuffle as rows arrive."""
+    body = (await w1_client.get(FACETS_URL)).json()
+    assert set(body["tier"]) == {"a", "b", "c", "unqualified"}
+    assert set(body["source"]) == {"clay", "directory", "manual"}
+    assert sum(body["status"].values()) == 0
+
+
+@pytest.mark.asyncio
+async def test_tier_counts_respect_an_active_status_filter(w1_client):
+    """The acceptance case: with status=new on, the tier counts describe the
+    NEW rows only — a1/b1/c1 — not the whole workspace."""
+    await _seed(w1_client, FACET_ROWS)
+    body = (await w1_client.get(FACETS_URL, params={"status": "new"})).json()
+    assert body["tier"] == {"a": 1, "b": 1, "c": 1, "unqualified": 0}
+    assert body["source"] == {"clay": 1, "directory": 1, "manual": 1}
+
+
+@pytest.mark.asyncio
+async def test_a_block_does_not_apply_its_own_filter(w1_client):
+    """status=new must NOT collapse the status block to {new: 3, rest: 0} —
+    that would tell the user nothing about where to go next."""
+    await _seed(w1_client, FACET_ROWS)
+    unfiltered = (await w1_client.get(FACETS_URL)).json()
+    filtered = (await w1_client.get(FACETS_URL, params={"status": "new"})).json()
+    assert filtered["status"] == unfiltered["status"]
+    assert filtered["status"]["replied"] == 2
+
+
+@pytest.mark.asyncio
+async def test_facets_compose_two_sibling_filters(w1_client):
+    await _seed(w1_client, FACET_ROWS)
+    body = (await w1_client.get(FACETS_URL, params={"status": "new", "source": "manual"})).json()
+    # Only c1.io is both new and manual.
+    assert body["tier"] == {"a": 0, "b": 0, "c": 1, "unqualified": 0}
+
+
+@pytest.mark.asyncio
+async def test_facets_respect_the_q_filter_in_every_block(w1_client):
+    """``q`` constrains all three blocks — it isn't a facet of its own, so
+    there is nothing for a block to exclude."""
+    await _seed(w1_client, FACET_ROWS)
+    body = (await w1_client.get(FACETS_URL, params={"q": "a1.io"})).json()
+    assert body["tier"] == {"a": 1, "b": 0, "c": 0, "unqualified": 0}
+    assert body["source"]["clay"] == 1
+
+
+@pytest.mark.asyncio
+async def test_facets_are_workspace_scoped(w1_client, w2_client):
+    await _seed(w1_client, FACET_ROWS)
+    await _seed(w2_client, [{"domain": "a1.io", "tier": "a"}])
+    assert (await w1_client.get(FACETS_URL)).json()["tier"]["a"] == 2
+    assert (await w2_client.get(FACETS_URL)).json()["tier"]["a"] == 1
+
+
+@pytest.mark.asyncio
+async def test_facets_path_is_not_swallowed_by_the_prospect_id_route(w1_client):
+    """``/prospects/facets`` must not be matched as ``/prospects/{id}``."""
+    resp = await w1_client.get(FACETS_URL)
+    assert resp.status_code == 200
+    assert set(resp.json()) == {"tier", "status", "source"}

--- a/tests/cloud/growth/test_router.py
+++ b/tests/cloud/growth/test_router.py
@@ -7,6 +7,10 @@
 # cross-tenant isolation (foreign ids 404, foreign rows never listed).
 #
 # Created 2026-07-27 (feat/growth-g1): first slice of /growth.
+# Updated 2026-07-28 (feat/growth-api-scale): the list route returns the
+# {items, next_cursor, total} page envelope, so every list assertion here reads
+# ``.json()["items"]``. The scale surface itself (q / sort / cursor / facets)
+# is covered in test_list_query.py.
 # Updated 2026-07-27 (feat/growth-g2): bulk-ingestion coverage — POST /bulk
 # idempotency (20 rows twice → second run all-updated), mixed-validity payloads
 # (bad rows become indexed error entries, good rows land), the 501-row 422 cap,
@@ -206,21 +210,21 @@ async def test_list_filters_by_tier_status_source(w1_client):
 
     resp = await w1_client.get("/api/v1/growth/prospects")
     assert resp.status_code == 200
-    assert len(resp.json()) == 3
+    assert len(resp.json()["items"]) == 3
 
     resp = await w1_client.get("/api/v1/growth/prospects", params={"tier": "a"})
-    assert {p["domain"] for p in resp.json()} == {"beta.io", "gamma.io"}
+    assert {p["domain"] for p in resp.json()["items"]} == {"beta.io", "gamma.io"}
 
     resp = await w1_client.get("/api/v1/growth/prospects", params={"source": "clay"})
-    assert [p["domain"] for p in resp.json()] == ["beta.io"]
+    assert [p["domain"] for p in resp.json()["items"]] == ["beta.io"]
 
     resp = await w1_client.get("/api/v1/growth/prospects", params={"status": "new"})
-    assert len(resp.json()) == 3
+    assert len(resp.json()["items"]) == 3
 
     resp = await w1_client.get(
         "/api/v1/growth/prospects", params={"tier": "a", "source": "directory"}
     )
-    assert [p["domain"] for p in resp.json()] == ["gamma.io"]
+    assert [p["domain"] for p in resp.json()["items"]] == ["gamma.io"]
 
 
 @pytest.mark.asyncio
@@ -261,7 +265,8 @@ async def test_bulk_ingest_is_idempotent(w1_client):
     assert second.json() == {"created": 0, "updated": 20, "errors": []}
 
     listed = await w1_client.get("/api/v1/growth/prospects", params={"limit": 500})
-    assert len(listed.json()) == 20
+    assert len(listed.json()["items"]) == 20
+    assert listed.json()["total"] == 20
 
 
 @pytest.mark.asyncio
@@ -285,7 +290,7 @@ async def test_bulk_ingest_mixed_validity_records_errors_and_lands_good_rows(w1_
         assert err["message"]
 
     listed = await w1_client.get("/api/v1/growth/prospects")
-    assert {p["domain"] for p in listed.json()} == {"alpha.io", "omega.io"}
+    assert {p["domain"] for p in listed.json()["items"]} == {"alpha.io", "omega.io"}
 
 
 @pytest.mark.asyncio
@@ -301,7 +306,7 @@ async def test_bulk_ingest_updates_existing_and_creates_new_in_one_call(w1_clien
     assert resp.status_code == 200, resp.text
     assert resp.json() == {"created": 1, "updated": 1, "errors": []}
 
-    listed = (await w1_client.get("/api/v1/growth/prospects")).json()
+    listed = (await w1_client.get("/api/v1/growth/prospects")).json()["items"]
     by_domain = {p["domain"]: p for p in listed}
     assert by_domain["alpha.io"]["name"] == "Refreshed Contact"
     assert by_domain["alpha.io"]["tier"] == "a"
@@ -322,14 +327,14 @@ async def test_bulk_ingest_is_workspace_scoped(w1_client, w2_client):
     assert resp.json() == {"created": 3, "updated": 0, "errors": []}
 
     # w2 sees nothing from w1's ingest.
-    assert (await w2_client.get("/api/v1/growth/prospects")).json() == []
+    assert (await w2_client.get("/api/v1/growth/prospects")).json()["items"] == []
 
     # The same domains in w2 are creates (fresh rows), not cross-tenant updates.
     resp = await w2_client.post("/api/v1/growth/prospects/bulk", json={"rows": rows})
     assert resp.json() == {"created": 3, "updated": 0, "errors": []}
 
-    w1_listed = (await w1_client.get("/api/v1/growth/prospects")).json()
-    w2_listed = (await w2_client.get("/api/v1/growth/prospects")).json()
+    w1_listed = (await w1_client.get("/api/v1/growth/prospects")).json()["items"]
+    w2_listed = (await w2_client.get("/api/v1/growth/prospects")).json()["items"]
     assert len(w1_listed) == 3 and len(w2_listed) == 3
     assert {p["id"] for p in w1_listed}.isdisjoint({p["id"] for p in w2_listed})
 
@@ -361,4 +366,5 @@ async def test_cross_tenant_access_is_isolated(w1_client, w2_client, op):
     else:  # list
         resp = await w2_client.get("/api/v1/growth/prospects")
         assert resp.status_code == 200
-        assert resp.json() == []
+        assert resp.json()["items"] == []
+        assert resp.json()["total"] == 0

--- a/tests/cloud/growth/test_whatsapp_dispatch.py
+++ b/tests/cloud/growth/test_whatsapp_dispatch.py
@@ -523,7 +523,7 @@ class TestCredentialsNeverLeak:
         assert SECRET_AUTHKEY not in str([entry.model_dump() for entry in logs])
 
         drafts = await growth_service.list_drafts(_ctx("w1"))
-        prospects = await growth_service.list_prospects(_ctx("w1"))
+        prospects = (await growth_service.list_prospects(_ctx("w1"))).items
         serialised = str([d.model_dump() for d in drafts] + [p.model_dump() for p in prospects])
         assert SECRET_AUTHKEY not in serialised
 


### PR DESCRIPTION
The prospect list was a bare array capped at 500 rows, newest-first, with three
enum filters and no search. That works for a demo workspace and falls apart the
first time an agency has a few thousand prospects in it. This adds the query
surface the list view needs to stay usable at that size.

**`q`** — case-insensitive substring across name, company, domain and
research_brief. Terms are `re.escape`d, so `.*` matches nothing and no
backtracking pattern reaches Mongo.

**`sort`** — `newest` (default, byte-for-byte the old ordering), `oldest`,
`company`, `tier`. Tier order is the declared rank a→b→c→unqualified, walked
bucket by bucket rather than handed to Mongo as a field sort — at most four
bounded queries, one when a tier filter is active.

**Cursor pagination** — keyset, following the convention in `audit/service.py`
and `sessions/service.py`. One extension over those two: the cursor carries its
sort mode, because they each have a single fixed ordering and this list has
four. Changing sort mid-scroll now returns `422 prospect.bad_cursor` instead of
silently wrong rows.

**`GET /growth/prospects/facets`** — tier/status/source counts for the filter
chips, one `$facet` aggregation. Each block excludes its own filter and
respects the others, so with a status filter on the tier counts still describe
that status's rows. Every legal value comes back, zeros included.

**`POST /growth/drafts/propose-batch`** — up to 100 draft ids, each one routed
through the existing `propose_send`. No batch proposal object and no path into
`gate_transition`: every id files its own `_growth_send` proposal that a human
approves in the tray. Partial success in the bulk-ingest style.

## Breaking

`GET /growth/prospects` returns `{items, next_cursor, total}` instead of a bare
array. The list view is the only consumer and its half lands alongside this.

## Notes

- No text index. `models/prospect.py` already carries a unique
  `(workspace, domain)` index and a `(workspace, createdAt)` list cursor, and a
  Mongo text index is a per-collection singleton that needs designing against
  those rather than bolting on. The scan ceiling (~100k rows per workspace) is
  documented on `_prospect_filters`.
- `total` costs a second query per page. Fine at this scale; worth caching
  client-side per filter-set if the list ends up polling hard.
- `fa9a66be` is a WIP commit left by a connection drop mid-run. Its code is
  complete and superseded by the commit after it — squash on merge.

## Tests

337 pass across `tests/cloud/growth/`, `tests/cloud/ship/` and
`tests/instinct/`. Both import-linter configs clean (1 contract root, 35 ee).
Cursor round-trips are parametrized across all four sort modes: paged ids match
the one-shot ordering exactly, no overlap and no gap, with `total` identical on
every page.

`test_gate.py`'s existing route-guard test caught both new routes before they
were pinned — any further `/growth` route needs an entry there too.
