### PR TITLE
Give the growth agent tools — read, draft, propose, never send

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -110,6 +110,15 @@ Security review follow-up: documented per-route growth RBAC
 and the fact that a _growth_send blob can only be minted by this route —
 the generic POST /instinct/actions refuses reserved gated parameter keys.
 
+Updated: 2026-07-28 (feat/growth-mcp) — added the Growth — the agent surface
+section: the nine pocketpaw_growth in-process MCP tools the chat agent on the
+/growth rail drives, the table of how that surface is narrower than the HTTP
+one, and why the agent's reach ends at proposed (no send tool, no status
+argument, no route to gate_transition). Also added PATCH /growth/drafts/{id}
+— edit a draft's copy while it is still `draft`; anything past that is
+403 draft.not_editable, because from proposed on the stored body is what the
+Tray shows and what the worker sends.
+
 Updated: 2026-07-28 (feat/growth-api-scale) — the prospect list grew a scale
 surface. BREAKING: GET /growth/prospects now returns
 {items, next_cursor, total} instead of a bare array. Added q search across
@@ -1782,6 +1791,21 @@ List the workspace's drafts, newest first. Optional query filters:
 `prospect_id`, `channel`, `status` (enum-validated — an unknown value is a
 422) and `limit` (default 100, max 500).
 
+### `PATCH /api/v1/growth/drafts/{draft_id}`
+
+Edit a draft's copy. Body: any subset of `subject`, `body`, `demo_url`
+(an empty body object is a 422 — there is nothing to change). No `status`
+field exists on this request: a lifecycle move dressed as an edit would be a
+second, unreviewed road to `approved`.
+
+**Only while the draft is still `draft`.** From `proposed` on, the stored body
+is what a human is reading in the Tray and what the dispatch worker puts on
+the wire, so an edit there would send copy nobody approved — refused with
+`403 draft.not_editable`. Revise by rejecting the draft and writing a new one.
+`subject` stays email-only (`422 draft.subject_not_allowed` on a linkedin /
+whatsapp draft). Cross-tenant or unknown ids: `404 draft.not_found`. Requires
+`growth.write` (MEMBER) — editing copy is authoring, not an outbound verb.
+
 ### `POST /api/v1/growth/drafts/{draft_id}/status`
 
 Move a draft along the lifecycle. Body: `{"status": "proposed"}` (any
@@ -2145,3 +2169,51 @@ the same prospect never learns someone else's outreach got a reply.
 | `GROWTH_WHATSAPP_MAX_PER_HOUR` | `20` | Per-workspace outbound WhatsApp ceiling per rolling hour. WhatsApp quality rating is computed over a rolling window of recent business-initiated messages, and a burst (bulk approval, retry storm, mis-scoped follow-up cron) is exactly the shape that trips it — with the damage landing on the WABA, not the individual send. The cap bounds the blast radius of a bug. Attempts that reached the provider (`sending` / `sent` / `failed`) consume the window; refused attempts do not. There is no "disabled" value — `0` refuses every send rather than meaning unlimited, and a non-numeric or negative value falls back to the default, so a fat-fingered setting fails closed. |
 | `GROWTH_MSG91_WEBHOOK_SECRET` | *(unset)* | Shared secret for the inbound webhook HMAC. **Required** — while unset, `POST /growth/webhooks/msg91` rejects every request with 403. |
 | `CLOUD_ENCRYPTION_KEY` | *(unset)* | Existing deployment-wide Fernet key. Needed to store the MSG91 authkey as `authkey_enc` rather than plaintext. |
+
+## Growth — the agent surface (`pocketpaw_growth` MCP)
+
+The chat agent on the `/growth` rail reaches the same service layer through
+nine in-process MCP tools. It is the operator's assistant on that page: it can
+research and file a prospect, write and revise the copy, and put a send in
+front of a human. It cannot send.
+
+| Tool | RBAC | What it does |
+|---|---|---|
+| `growth_list_prospects` | `growth.read` | Compact rows + the filter-scoped `total`; `tier` / `status` / `source` / `q` / `sort` / `cursor` / `limit` |
+| `growth_get_prospect` | `growth.read` | One prospect in full, with every draft written for it |
+| `growth_list_drafts` | `growth.read` | Drafts with truncated body previews; filters by prospect / channel / status |
+| `growth_linkedin_queue` | `growth.read` | The manual LinkedIn queue with its prospect context |
+| `growth_upsert_prospect` | `growth.write` | Create-or-enrich keyed on `domain`; omitted fields keep their stored values |
+| `growth_create_draft` | `growth.write` | Write one channel's copy — born `draft` |
+| `growth_update_draft` | `growth.write` | Revise copy, only while the draft is still `draft` |
+| `growth_propose_send` | `growth.manage` | Files one `_growth_send` Instinct proposal; returns `{status: "proposed", proposal_id}` |
+| `growth_propose_send_batch` | `growth.manage` | The same, over up to 100 draft ids — one proposal each |
+
+The agent's surface is deliberately **narrower than the HTTP one**:
+
+| Verb | Operator over HTTP | Agent over MCP |
+|------|--------------------|----------------|
+| reads, upsert a prospect, write a draft | runs | runs |
+| edit a draft's copy (while `draft`) | runs | runs |
+| propose a send | runs | runs |
+| move a draft to `approved` or `sent` | **refused** (gate-owned) | **no tool exists** |
+| mark a LinkedIn draft sent | runs | **no tool exists** |
+
+**The agent's reach ends at `proposed`.** No tool sends; no tool takes a
+`status` argument (the legal move is exposed as the named verb
+`growth_propose_send`, so there is no shape of argument that could ask for
+`approved`); and `service.gate_transition` — the seam the executor and the
+dispatch worker walk — is not reachable from the MCP module at all. The two
+`status` fields that do appear are read filters on the list tools.
+`growth_update_draft` stops at `draft` for the same reason: from `proposed`
+on, the stored body is what the Tray shows and what goes on the wire, so an
+edit past that point would be a send bypass wearing an edit's clothes. Tests
+assert all of this against the tool list and schemas, so a tool added later
+trips them before it ships.
+
+Tenancy comes from the chat stream's identity — no tool accepts a
+`workspace_id`, and every schema sets `additionalProperties: false`. The RBAC
+tiers mirror the HTTP routes, and the ADMIN tier on the propose verbs is
+load-bearing: `growth.executor` re-checks `growth.manage` against the
+proposer's **current** role at approve time, so a proposal filed below that
+tier could only ever clog the Tray.

--- a/ee/pocketpaw_ee/agent/mcp_servers/__init__.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/__init__.py
@@ -1,5 +1,8 @@
 """In-process MCP servers exposed to agent backends for cloud features.
 
+Updated: 2026-07-28 (feat/growth-mcp) — added ``growth.py`` (``pocketpaw_growth``)
+to the listing below: the agent-facing /growth surface, read-and-propose only.
+
 Updated: 2026-06-11 (feat/fabric-instinct-mcp-providers) — added the server
 surface listing below, plus the two new read-only servers (``fabric.py`` /
 ``instinct.py``). On the claude_agent_sdk backend, registry tools (BaseTool)
@@ -29,6 +32,14 @@ Server surfaces (module → server name → tools):
 * ``fabric.py`` → ``pocketpaw_fabric`` → ``fabric_query`` / ``fabric_stats``
   (READ-ONLY ontology access, workspace-scoped)
 * ``foresight.py`` → ``pocketpaw_foresight`` → scenario save/run
+* ``growth.py`` → ``pocketpaw_growth`` → the /growth outbound surface:
+  ``growth_list_prospects`` / ``growth_get_prospect`` / ``growth_list_drafts``
+  / ``growth_linkedin_queue`` (reads), ``growth_upsert_prospect`` /
+  ``growth_create_draft`` / ``growth_update_draft`` (authoring writes), and
+  ``growth_propose_send`` / ``growth_propose_send_batch`` (gated). NOTHING here
+  sends and nothing reaches the gate-owned draft statuses ``approved`` /
+  ``sent`` — the agent's reach ends at ``proposed``, a human approves in the
+  Tray, and the dispatch worker sends
 * ``icons.py`` → ``pocketpaw_icons`` → ``search_icons`` (free open-source
   icon/SVG search via Iconify for site iconography; pure read, no identity)
 * ``instinct.py`` → ``pocketpaw_instinct`` → ``instinct_pending`` /

--- a/ee/pocketpaw_ee/agent/mcp_servers/growth.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/growth.py
@@ -1,0 +1,970 @@
+# ee/pocketpaw_ee/agent/mcp_servers/growth.py — the agent-facing /growth surface.
+#
+# In-process MCP server (``pocketpaw_growth``) letting the chat agent on the
+# /growth rail work a prospect end to end: read the list, read one prospect with
+# its drafts, add a prospect it just researched, write and revise the copy, and
+# FILE the send for human approval. It stops there.
+#
+# THE LINE THAT MATTERS — the agent's reach ends at ``proposed``:
+#   * NO tool sends. Not one. The dispatch worker sends, and only after a human
+#     approves an Instinct proposal in the Tray.
+#   * NO tool can reach a status in ``GATE_OWNED_TARGETS`` (``approved`` /
+#     ``sent``). No tool takes a ``status`` argument at all — the legal moves are
+#     exposed as named verbs (``growth_propose_send``) instead, so there is no
+#     shape of argument that could ask for ``approved``.
+#   * ``service.gate_transition`` (the seam the executor and the dispatch worker
+#     walk) is deliberately NOT imported here, and a test asserts it stays that
+#     way. Same reason ``connectors/mailtrap.yaml`` ships ``actions: []``: every
+#     bypass around the gate has to stay closed, including a friendly-looking
+#     one.
+#   * ``growth_update_draft`` edits only a draft still in ``draft``; the service
+#     refuses the rest (403 ``draft.not_editable``). Editing a proposed draft
+#     would put copy on the wire that nobody approved — that is a send bypass
+#     wearing an edit's clothes.
+#
+# Every tool calls the SERVICE layer (``ee.cloud.growth.service``), never a
+# Beanie document: the service owns tenancy filtering, validation and the
+# proposal filing, and the import-linter "Growth" contract lists this module so
+# a doc import here fails CI.
+#
+# Tenancy: the workspace is resolved from the chat stream's identity ContextVars
+# (``ee.cloud.chat.agent_service``), exactly as belt.py / ship.py do. No tool
+# accepts a ``workspace_id`` argument — the model cannot name a tenant.
+#
+# RBAC: the same per-action tiers the HTTP routes carry — ``growth.read`` on the
+# reads, ``growth.write`` on the authoring writes, ``growth.manage`` (ADMIN) on
+# the propose verbs. The propose tier is not decoration: ``growth.executor``
+# re-checks ``growth.manage`` against the proposer's CURRENT role at approve
+# time, so a proposal filed under a lower tier could never be approved — it
+# would just clog the Tray. A denial comes back as a structured envelope
+# (``ok:false, denied:true``), never a raised exception (mirrors
+# workspace_admin.py).
+#
+# Output shaping: the list tools return COMPACT rows (id / name / company /
+# domain / tier / status) plus the filter-scoped ``total``, never every field of
+# every row — a 100-row context dump buys nothing and costs the turn. Full
+# bodies appear only where the agent needs them to act: one prospect's drafts,
+# and the LinkedIn queue.
+#
+# Created 2026-07-28 (feat/growth-mcp): new module.
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from ._audit import record_tool_call
+
+logger = logging.getLogger(__name__)
+
+SERVER_NAME = "pocketpaw_growth"
+
+# Stable tool ids — Claude Code namespaces in-process MCP tools as
+# ``mcp__<server>__<tool>``; a surface profile allowlist would reference these.
+GROWTH_TOOL_NAMES: tuple[str, ...] = (
+    "growth_list_prospects",
+    "growth_get_prospect",
+    "growth_list_drafts",
+    "growth_upsert_prospect",
+    "growth_create_draft",
+    "growth_update_draft",
+    "growth_propose_send",
+    "growth_propose_send_batch",
+    "growth_linkedin_queue",
+)
+
+GROWTH_TOOL_IDS: tuple[str, ...] = tuple(f"mcp__{SERVER_NAME}__{n}" for n in GROWTH_TOOL_NAMES)
+
+# RBAC actions, mirroring the HTTP router's per-route guards.
+READ_ACTION = "growth.read"
+WRITE_ACTION = "growth.write"
+MANAGE_ACTION = "growth.manage"
+
+# Page sizes. The agent reads to DECIDE, not to recite: a big page is context
+# spent on rows it will not act on. ``_MAX_LIST_LIMIT`` caps what the model can
+# ask for; ``total`` tells it how much it did not see.
+_DEFAULT_LIST_LIMIT = 25
+_MAX_LIST_LIMIT = 100
+
+# How wide the upsert's existing-row lookup searches before giving up on
+# preserving the row's lifecycle status. See ``_find_by_domain``.
+_UPSERT_LOOKUP_LIMIT = 100
+
+
+# ---------------------------------------------------------------------------
+# Envelopes + identity
+# ---------------------------------------------------------------------------
+
+
+def _error_response(message: str) -> dict[str, Any]:
+    return {"content": [{"type": "text", "text": f"Error: {message}"}], "is_error": True}
+
+
+def _success_response(body: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "content": [{"type": "text", "text": json.dumps(body, separators=(",", ":"), default=str)}]
+    }
+
+
+def _identity() -> tuple[str | None, str | None]:
+    """Resolve (workspace_id, user_id) from the cloud chat session context."""
+    try:
+        from pocketpaw_ee.cloud.chat.agent_service import current_user_id, current_workspace_id
+
+        return current_workspace_id(), current_user_id()
+    except Exception:  # noqa: BLE001 — no cloud session context
+        return None, None
+
+
+def _build_ctx(workspace_id: str, user_id: str) -> Any:
+    """Synthesise the ``RequestContext`` the growth service takes. The chat
+    stream has no FastAPI request scope, so we build one from the resolved
+    identity — the same thing tasks.py / workspace_admin.py do."""
+    from datetime import UTC, datetime
+
+    from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="mcp-growth",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+
+async def _load_user(user_id: str) -> Any | None:
+    """Load the User doc so the RBAC check has the ``.workspaces`` membership
+    list it reads. ``None`` on a bad id / missing user — the caller maps that to
+    an error envelope (fails closed)."""
+    from beanie import PydanticObjectId
+
+    from pocketpaw_ee.cloud.models.user import User as _UserDoc
+
+    try:
+        return await _UserDoc.get(PydanticObjectId(user_id))
+    except Exception:  # noqa: BLE001 — malformed id / DB error → treat as no user
+        return None
+
+
+async def _gate(tool: str, action: str) -> tuple[str, str, Any] | dict[str, Any]:
+    """Resolve identity + apply the workspace RBAC gate for ``tool``.
+
+    Returns ``(workspace_id, user_id, ctx)`` when the gate PASSES, or a
+    ready-to-return response dict when it fails. A denial comes back as a
+    structured envelope rather than a raised exception (the gate already audits
+    it), so the agent can explain the refusal instead of the turn erroring out.
+    """
+    workspace_id, user_id = _identity()
+    if not workspace_id or not user_id:
+        return _error_response(
+            f"{tool} requires workspace and user context (call it from a cloud chat session)."
+        )
+
+    from pocketpaw_ee.guards.deps import check_workspace_action
+    from pocketpaw_ee.guards.rbac import Forbidden
+
+    user = await _load_user(user_id)
+    if user is None:
+        return _error_response("could not resolve the calling user for the permission check.")
+
+    try:
+        check_workspace_action(user, workspace_id, action)
+    except Forbidden as exc:
+        logger.info(
+            "%s denied: user=%s workspace=%s code=%s", tool, user_id, workspace_id, exc.code
+        )
+        return _success_response(
+            {
+                "ok": False,
+                "denied": True,
+                "code": exc.code,
+                "message": f"You do not have permission to run {tool} ({action}).",
+            }
+        )
+
+    record_tool_call(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        tool_server=SERVER_NAME,
+        tool_name=tool,
+        status="ok",
+        ok=True,
+    )
+    return workspace_id, user_id, _build_ctx(workspace_id, user_id)
+
+
+def _service_error(exc: Exception, what: str) -> dict[str, Any]:
+    """Relay a service failure plainly. A CloudError stringifies as
+    ``code: message`` — both halves are safe to show and the code is what the
+    agent should quote back."""
+    logger.info("growth mcp: %s failed: %s", what, exc, exc_info=True)
+    return _error_response(f"could not {what}: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Wire shaping — compact by default
+# ---------------------------------------------------------------------------
+
+
+def _prospect_row(p: Any) -> dict[str, Any]:
+    """One list row: enough to pick a prospect, not enough to bloat the turn.
+    The research brief and contact details live on ``growth_get_prospect``."""
+    return {
+        "id": p.id,
+        "name": p.name,
+        "company": p.company,
+        "domain": p.domain,
+        "tier": p.tier,
+        "status": p.status,
+        "source": p.source,
+    }
+
+
+def _prospect_full(p: Any) -> dict[str, Any]:
+    return {
+        **_prospect_row(p),
+        "research_brief": p.research_brief,
+        "emails": list(p.emails),
+        "linkedin_url": p.linkedin_url,
+        "whatsapp_number": p.whatsapp_number,
+        "opted_in": p.opted_in,
+        "created_at": p.created_at,
+        "updated_at": p.updated_at,
+    }
+
+
+def _draft_row(d: Any, *, body: bool = True) -> dict[str, Any]:
+    row: dict[str, Any] = {
+        "id": d.id,
+        "prospect_id": d.prospect_id,
+        "channel": d.channel,
+        "variant": d.variant,
+        "status": d.status,
+        "subject": d.subject,
+    }
+    if body:
+        row["body"] = d.body
+        row["demo_url"] = d.demo_url
+    else:
+        row["body_preview"] = _preview(d.body)
+    return row
+
+
+def _preview(text: str, max_len: int = 120) -> str:
+    flat = " ".join((text or "").split())
+    return flat if len(flat) <= max_len else flat[: max_len - 1] + "…"
+
+
+def _clamp_limit(raw: Any, default: int = _DEFAULT_LIST_LIMIT) -> int:
+    try:
+        return max(1, min(int(raw), _MAX_LIST_LIMIT))
+    except (TypeError, ValueError):
+        return default
+
+
+def _opt_str(args: dict, key: str) -> str | None:
+    """Read an optional string arg. Blank means "not supplied" — a model that
+    fills every key with ``""`` must not be read as "clear this filter"."""
+    value = args.get(key)
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value or None
+
+
+# ---------------------------------------------------------------------------
+# Handlers — reads
+# ---------------------------------------------------------------------------
+
+
+async def _list_prospects_handler(args: dict) -> dict:
+    gate = await _gate("growth_list_prospects", READ_ACTION)
+    if isinstance(gate, dict):
+        return gate
+    _ws, _user, ctx = gate
+
+    from pocketpaw_ee.cloud.growth import service
+
+    limit = _clamp_limit(args.get("limit"))
+    try:
+        page = await service.list_prospects(
+            ctx,
+            tier=_opt_str(args, "tier"),
+            status=_opt_str(args, "status"),
+            source=_opt_str(args, "source"),
+            q=_opt_str(args, "q"),
+            sort=_opt_str(args, "sort") or "newest",
+            cursor=_opt_str(args, "cursor"),
+            limit=limit,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return _service_error(exc, "list prospects")
+
+    return _success_response(
+        {
+            "prospects": [_prospect_row(p) for p in page.items],
+            "showing": len(page.items),
+            "total": page.total,
+            "next_cursor": page.next_cursor,
+            "note": (
+                "Compact rows. Call growth_get_prospect for the research brief, "
+                "contact details and drafts. `total` is the filter-scoped count, "
+                "not the page; pass `next_cursor` back to read the next page."
+            ),
+        }
+    )
+
+
+async def _get_prospect_handler(args: dict) -> dict:
+    gate = await _gate("growth_get_prospect", READ_ACTION)
+    if isinstance(gate, dict):
+        return gate
+    _ws, _user, ctx = gate
+
+    prospect_id = _opt_str(args, "prospect_id")
+    if not prospect_id:
+        return _error_response("growth_get_prospect requires a `prospect_id`.")
+
+    from pocketpaw_ee.cloud.growth import service
+
+    try:
+        prospect = await service.get(ctx, prospect_id)
+        drafts = await service.list_drafts(ctx, prospect_id=prospect_id, limit=_MAX_LIST_LIMIT)
+    except Exception as exc:  # noqa: BLE001
+        return _service_error(exc, "read the prospect")
+
+    return _success_response(
+        {
+            "prospect": _prospect_full(prospect),
+            "drafts": [_draft_row(d) for d in drafts],
+        }
+    )
+
+
+async def _list_drafts_handler(args: dict) -> dict:
+    gate = await _gate("growth_list_drafts", READ_ACTION)
+    if isinstance(gate, dict):
+        return gate
+    _ws, _user, ctx = gate
+
+    from pocketpaw_ee.cloud.growth import service
+
+    try:
+        drafts = await service.list_drafts(
+            ctx,
+            prospect_id=_opt_str(args, "prospect_id"),
+            channel=_opt_str(args, "channel"),
+            status=_opt_str(args, "status"),
+            limit=_clamp_limit(args.get("limit")),
+        )
+    except Exception as exc:  # noqa: BLE001
+        return _service_error(exc, "list drafts")
+
+    return _success_response(
+        {
+            "drafts": [_draft_row(d, body=False) for d in drafts],
+            "showing": len(drafts),
+            "note": (
+                "Bodies are truncated previews. Read the full copy with "
+                "growth_get_prospect. `status` here is a READ filter — a draft's "
+                "status is moved by proposing it and by a human approving it, "
+                "never by an argument."
+            ),
+        }
+    )
+
+
+async def _linkedin_queue_handler(args: dict) -> dict:
+    gate = await _gate("growth_linkedin_queue", READ_ACTION)
+    if isinstance(gate, dict):
+        return gate
+    _ws, _user, ctx = gate
+
+    from pocketpaw_ee.cloud.growth import service
+
+    try:
+        items = await service.linkedin_queue(ctx, limit=_clamp_limit(args.get("limit")))
+    except Exception as exc:  # noqa: BLE001
+        return _service_error(exc, "read the LinkedIn queue")
+
+    return _success_response(
+        {
+            "queue": [
+                {
+                    "draft": _draft_row(item.draft),
+                    "prospect_name": item.prospect_name,
+                    "prospect_company": item.prospect_company,
+                    "linkedin_url": item.linkedin_url,
+                    "tier": item.tier,
+                    "research_brief": item.research_brief,
+                }
+                for item in items
+            ],
+            "count": len(items),
+            "note": (
+                "LinkedIn sending is MANUAL by design — there is no API "
+                "integration and no tool that sends. A human copies these and "
+                "sends them, then marks them sent."
+            ),
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Handlers — authoring writes
+# ---------------------------------------------------------------------------
+
+
+async def _find_by_domain(ctx: Any, domain: str) -> Any | None:
+    """Find an existing prospect by its exact (normalised) domain.
+
+    Used to make ``growth_upsert_prospect`` a MERGE rather than a replace.
+    ``upsert_by_domain`` overwrites every mutable field from the request, so a
+    re-upsert of a prospect already in ``in_sequence`` would silently reset it
+    to ``new`` and blank the fields the agent did not repeat. Reading the row
+    first lets the handler carry those forward.
+
+    The lookup rides the service's ``q`` search (which covers the domain field)
+    and exact-matches the result, so it needs no new service seam. On a miss the
+    caller proceeds with defaults — a create, which is the correct behaviour for
+    a domain that genuinely is not there.
+    """
+    from pocketpaw_ee.cloud.growth import service
+
+    page = await service.list_prospects(ctx, q=domain, limit=_UPSERT_LOOKUP_LIMIT)
+    for item in page.items:
+        if item.domain == domain:
+            return item
+    return None
+
+
+async def _upsert_prospect_handler(args: dict) -> dict:
+    gate = await _gate("growth_upsert_prospect", WRITE_ACTION)
+    if isinstance(gate, dict):
+        return gate
+    workspace_id, _user, ctx = gate
+
+    from pocketpaw_ee.cloud.growth import service
+    from pocketpaw_ee.cloud.growth.dto import CreateProspectRequest
+
+    name = _opt_str(args, "name")
+    company = _opt_str(args, "company")
+    domain = _opt_str(args, "domain")
+    if not domain:
+        return _error_response("growth_upsert_prospect requires a company `domain`.")
+
+    emails = args.get("emails")
+    emails = (
+        [e for e in emails if isinstance(e, str) and e.strip()]
+        if isinstance(emails, list)
+        else None
+    )
+    opted_in = args.get("opted_in") if isinstance(args.get("opted_in"), bool) else None
+
+    try:
+        # Build once to canonicalise the domain (the DTO validator strips the
+        # scheme / www / path), then look the row up on that canonical form.
+        probe = CreateProspectRequest(
+            name=name or "unknown",
+            company=company or "unknown",
+            domain=domain,
+            source=_opt_str(args, "source") or "manual",
+        )
+    except Exception as exc:  # noqa: BLE001 — malformed domain
+        return _service_error(exc, "read the domain")
+
+    try:
+        existing = await _find_by_domain(ctx, probe.domain)
+    except Exception as exc:  # noqa: BLE001
+        return _service_error(exc, "look up the prospect")
+
+    def _pick(supplied: Any, field: str, fallback: Any) -> Any:
+        """Supplied wins; otherwise carry the stored value forward."""
+        if supplied is not None:
+            return supplied
+        return getattr(existing, field) if existing is not None else fallback
+
+    try:
+        body = CreateProspectRequest(
+            name=_pick(name, "name", None) or "unknown",
+            company=_pick(company, "company", None) or "unknown",
+            domain=probe.domain,
+            source=_pick(_opt_str(args, "source"), "source", "manual"),
+            tier=_pick(_opt_str(args, "tier"), "tier", "unqualified"),
+            research_brief=_pick(_opt_str(args, "research_brief"), "research_brief", ""),
+            emails=_pick(emails, "emails", []),
+            linkedin_url=_pick(_opt_str(args, "linkedin_url"), "linkedin_url", None),
+            whatsapp_number=_pick(_opt_str(args, "whatsapp_number"), "whatsapp_number", None),
+            opted_in=_pick(opted_in, "opted_in", False),
+            # NOT settable by the agent. The outbound lifecycle is driven by
+            # what happens to the prospect (a draft written, a reply received,
+            # the sweep giving up), never by an argument in a research call.
+            status=existing.status if existing is not None else "new",
+        )
+    except Exception as exc:  # noqa: BLE001 — DTO rejection
+        return _service_error(exc, "validate the prospect")
+
+    try:
+        result = await service.upsert_by_domain(workspace_id, body)
+    except Exception as exc:  # noqa: BLE001
+        return _service_error(exc, "save the prospect")
+
+    return _success_response(
+        {
+            "ok": True,
+            "created": existing is None,
+            "prospect": _prospect_full(result),
+        }
+    )
+
+
+async def _create_draft_handler(args: dict) -> dict:
+    gate = await _gate("growth_create_draft", WRITE_ACTION)
+    if isinstance(gate, dict):
+        return gate
+    _ws, _user, ctx = gate
+
+    prospect_id = _opt_str(args, "prospect_id")
+    if not prospect_id:
+        return _error_response("growth_create_draft requires a `prospect_id`.")
+
+    from pocketpaw_ee.cloud.growth import service
+    from pocketpaw_ee.cloud.growth.dto import CreateDraftRequest
+
+    try:
+        body = CreateDraftRequest(
+            channel=_opt_str(args, "channel") or "email",
+            subject=_opt_str(args, "subject"),
+            body=args.get("body") if isinstance(args.get("body"), str) else "",
+            variant=_opt_str(args, "variant") or "first_touch",
+            demo_url=_opt_str(args, "demo_url"),
+        )
+    except Exception as exc:  # noqa: BLE001 — DTO rejection
+        return _service_error(exc, "validate the draft")
+
+    try:
+        draft = await service.create_draft(ctx, prospect_id, body)
+    except Exception as exc:  # noqa: BLE001
+        return _service_error(exc, "create the draft")
+
+    return _success_response(
+        {
+            "ok": True,
+            "draft": _draft_row(draft),
+            "note": (
+                "The draft is saved as `draft`. Nothing is queued and nothing "
+                "will send until you propose it and a human approves it in the Tray."
+            ),
+        }
+    )
+
+
+async def _update_draft_handler(args: dict) -> dict:
+    gate = await _gate("growth_update_draft", WRITE_ACTION)
+    if isinstance(gate, dict):
+        return gate
+    _ws, _user, ctx = gate
+
+    draft_id = _opt_str(args, "draft_id")
+    if not draft_id:
+        return _error_response("growth_update_draft requires a `draft_id`.")
+
+    from pocketpaw_ee.cloud.growth import service
+    from pocketpaw_ee.cloud.growth.dto import UpdateDraftRequest
+
+    try:
+        body = UpdateDraftRequest(
+            subject=_opt_str(args, "subject"),
+            body=args.get("body") if isinstance(args.get("body"), str) else None,
+            demo_url=_opt_str(args, "demo_url"),
+        )
+    except Exception as exc:  # noqa: BLE001 — DTO rejection (nothing to change, blank body)
+        return _service_error(exc, "validate the edit")
+
+    try:
+        draft = await service.update_draft(ctx, draft_id, body)
+    except Exception as exc:  # noqa: BLE001
+        return _service_error(exc, "edit the draft")
+
+    return _success_response({"ok": True, "draft": _draft_row(draft)})
+
+
+# ---------------------------------------------------------------------------
+# Handlers — propose (the end of the agent's reach)
+# ---------------------------------------------------------------------------
+
+_PROPOSE_NOTE = (
+    "NOTHING has been sent. The draft is now `proposed` and waiting in the "
+    "Instinct Tray for a human to approve or reject. Only after approval does "
+    "the dispatch worker send it. Never tell the user their message went out."
+)
+
+
+async def _propose_send_handler(args: dict) -> dict:
+    gate = await _gate("growth_propose_send", MANAGE_ACTION)
+    if isinstance(gate, dict):
+        return gate
+    _ws, _user, ctx = gate
+
+    draft_id = _opt_str(args, "draft_id")
+    if not draft_id:
+        return _error_response("growth_propose_send requires a `draft_id`.")
+
+    from pocketpaw_ee.cloud.growth import service
+
+    try:
+        result = await service.propose_send(ctx, draft_id)
+    except Exception as exc:  # noqa: BLE001
+        return _service_error(exc, "propose the send")
+
+    return _success_response(
+        {
+            "ok": True,
+            "status": "proposed",
+            "proposal_id": result.proposal_id,
+            "draft": _draft_row(result.draft, body=False),
+            "note": _PROPOSE_NOTE,
+        }
+    )
+
+
+async def _propose_send_batch_handler(args: dict) -> dict:
+    gate = await _gate("growth_propose_send_batch", MANAGE_ACTION)
+    if isinstance(gate, dict):
+        return gate
+    _ws, _user, ctx = gate
+
+    raw = args.get("draft_ids")
+    draft_ids = (
+        [d.strip() for d in raw if isinstance(d, str) and d.strip()]
+        if isinstance(raw, list)
+        else []
+    )
+    if not draft_ids:
+        return _error_response("growth_propose_send_batch requires a non-empty `draft_ids` list.")
+
+    from pocketpaw_ee.cloud.growth import service
+    from pocketpaw_ee.cloud.growth.dto import ProposeBatchRequest
+
+    try:
+        result = await service.propose_send_batch(ctx, ProposeBatchRequest(draft_ids=draft_ids))
+    except Exception as exc:  # noqa: BLE001
+        return _service_error(exc, "propose the batch")
+
+    return _success_response(
+        {
+            "ok": True,
+            "status": "proposed",
+            "proposed": result.proposed,
+            "failed": [f.model_dump() for f in result.failed],
+            "note": (
+                f"{_PROPOSE_NOTE} Each draft is its own proposal — a human "
+                "approves them one by one; there is no batch approval."
+            ),
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Server construction
+# ---------------------------------------------------------------------------
+
+
+def _build_tools() -> list[Any] | None:
+    """Build the SDK tool objects, or ``None`` when the Claude Agent SDK isn't
+    installed. Split out from ``build_growth_server`` so the gate test can walk
+    every exposed tool's name and input schema without standing up a server."""
+    try:
+        from claude_agent_sdk import tool
+    except ImportError:
+        logger.debug("claude_agent_sdk not installed; %s MCP disabled", SERVER_NAME)
+        return None
+
+    @tool(
+        "growth_list_prospects",
+        (
+            "List the workspace's outbound prospects as COMPACT rows (id, name, "
+            "company, domain, tier, status, source) plus `total`, the count of "
+            "every row matching the filters. Filter by `tier` (a/b/c/"
+            "unqualified), `status`, `source`, and `q` (a search across name / "
+            "company / domain / research brief). `sort` is newest (default) / "
+            "oldest / company / tier. Pass the returned `next_cursor` back to "
+            "read the next page. Use growth_get_prospect for the full record."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "tier": {"type": "string", "enum": ["a", "b", "c", "unqualified"]},
+                "status": {
+                    "type": "string",
+                    "enum": ["new", "qualified", "drafted", "in_sequence", "replied", "dead"],
+                    "description": "Filter by prospect lifecycle status (a READ filter).",
+                },
+                "source": {"type": "string", "enum": ["clay", "directory", "manual"]},
+                "q": {"type": "string", "description": "Search name/company/domain/brief."},
+                "sort": {"type": "string", "enum": ["newest", "oldest", "company", "tier"]},
+                "cursor": {"type": "string", "description": "The previous page's next_cursor."},
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": _MAX_LIST_LIMIT,
+                    "description": f"Rows per page (default {_DEFAULT_LIST_LIMIT}).",
+                },
+            },
+            "additionalProperties": False,
+        },
+    )
+    async def growth_list_prospects(args):  # type: ignore[no-untyped-def]
+        return await _list_prospects_handler(args)
+
+    @tool(
+        "growth_get_prospect",
+        (
+            "Read ONE prospect in full — research brief, emails, LinkedIn URL, "
+            "WhatsApp number, opt-in and lifecycle status — together with every "
+            "draft written for it (full copy). Call this before writing or "
+            "revising copy so the message reflects what is already known and "
+            "already said."
+        ),
+        {
+            "type": "object",
+            "properties": {"prospect_id": {"type": "string", "minLength": 1}},
+            "required": ["prospect_id"],
+            "additionalProperties": False,
+        },
+    )
+    async def growth_get_prospect(args):  # type: ignore[no-untyped-def]
+        return await _get_prospect_handler(args)
+
+    @tool(
+        "growth_list_drafts",
+        (
+            "List the workspace's drafts (newest first) with TRUNCATED body "
+            "previews, optionally filtered by prospect, channel or status. Use "
+            "it to collect draft ids — e.g. every draft still in `draft` — "
+            "before proposing them. `status` is a read filter only; a draft "
+            "moves status by being proposed and then approved by a human."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "prospect_id": {"type": "string"},
+                "channel": {"type": "string", "enum": ["email", "linkedin", "whatsapp"]},
+                "status": {
+                    "type": "string",
+                    "enum": ["draft", "proposed", "approved", "sent", "replied", "rejected"],
+                    "description": "Filter by draft status (a READ filter — it moves nothing).",
+                },
+                "limit": {"type": "integer", "minimum": 1, "maximum": _MAX_LIST_LIMIT},
+            },
+            "additionalProperties": False,
+        },
+    )
+    async def growth_list_drafts(args):  # type: ignore[no-untyped-def]
+        return await _list_drafts_handler(args)
+
+    @tool(
+        "growth_upsert_prospect",
+        (
+            "Add a prospect you just researched, or enrich one that already "
+            "exists. Keyed on the company `domain` — a domain already in the "
+            "workspace is UPDATED, never duplicated. Fields you leave out keep "
+            "their stored values, so you can add just an email or just a "
+            "research brief. `emails` REPLACES the stored list when you pass "
+            "it, so include the ones you want to keep. The prospect's lifecycle "
+            "status is managed by the system and cannot be set here."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "domain": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Company website domain — the dedupe key.",
+                },
+                "name": {"type": "string", "description": "Contact name."},
+                "company": {"type": "string"},
+                "source": {
+                    "type": "string",
+                    "enum": ["clay", "directory", "manual"],
+                    "description": "Where the prospect came from (default manual).",
+                },
+                "tier": {
+                    "type": "string",
+                    "enum": ["a", "b", "c", "unqualified"],
+                    "description": "Qualification tier — a is the best fit.",
+                },
+                "research_brief": {
+                    "type": "string",
+                    "description": "What you found: the fit, the hook, the specific observation.",
+                },
+                "emails": {"type": "array", "items": {"type": "string"}},
+                "linkedin_url": {"type": "string"},
+                "whatsapp_number": {"type": "string"},
+                "opted_in": {
+                    "type": "boolean",
+                    "description": "Whether the prospect opted in to WhatsApp contact.",
+                },
+            },
+            "required": ["domain"],
+            "additionalProperties": False,
+        },
+    )
+    async def growth_upsert_prospect(args):  # type: ignore[no-untyped-def]
+        return await _upsert_prospect_handler(args)
+
+    @tool(
+        "growth_create_draft",
+        (
+            "Write one channel's outreach copy for a prospect. The draft is "
+            "saved as `draft` — nothing is queued and nothing sends. `subject` "
+            "is email-only. `variant` is first_touch (default) or follow_up. "
+            "When the copy is ready, call growth_propose_send to put it in "
+            "front of a human."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "prospect_id": {"type": "string", "minLength": 1},
+                "channel": {"type": "string", "enum": ["email", "linkedin", "whatsapp"]},
+                "body": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "The message copy.",
+                },
+                "subject": {"type": "string", "description": "Email subject line (email only)."},
+                "variant": {"type": "string", "enum": ["first_touch", "follow_up"]},
+                "demo_url": {"type": "string", "description": "Optional demo link to include."},
+            },
+            "required": ["prospect_id", "channel", "body"],
+            "additionalProperties": False,
+        },
+    )
+    async def growth_create_draft(args):  # type: ignore[no-untyped-def]
+        return await _create_draft_handler(args)
+
+    @tool(
+        "growth_update_draft",
+        (
+            "Revise a draft's copy — subject, body, demo_url, any subset. Only "
+            "works while the draft is still `draft`: once it has been proposed, "
+            "the stored copy is what a human is reviewing and what would be "
+            "sent, so editing it is refused (draft.not_editable). To change "
+            "proposed copy, have the human reject it and write a new draft."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "draft_id": {"type": "string", "minLength": 1},
+                "subject": {"type": "string"},
+                "body": {"type": "string", "minLength": 1},
+                "demo_url": {"type": "string"},
+            },
+            "required": ["draft_id"],
+            "additionalProperties": False,
+        },
+    )
+    async def growth_update_draft(args):  # type: ignore[no-untyped-def]
+        return await _update_draft_handler(args)
+
+    @tool(
+        "growth_propose_send",
+        (
+            "PROPOSE sending a draft, for HUMAN APPROVAL. This does NOT send "
+            "anything: it files the draft in the Instinct Tray and moves it to "
+            "`proposed`. A human approves or rejects it there, and only an "
+            "approved draft is picked up by the dispatch worker. Returns "
+            "{status:'proposed', proposal_id}. NEVER tell the user a message "
+            "was sent, delivered or is on its way — it is only PROPOSED."
+        ),
+        {
+            "type": "object",
+            "properties": {"draft_id": {"type": "string", "minLength": 1}},
+            "required": ["draft_id"],
+            "additionalProperties": False,
+        },
+    )
+    async def growth_propose_send(args):  # type: ignore[no-untyped-def]
+        return await _propose_send_handler(args)
+
+    @tool(
+        "growth_propose_send_batch",
+        (
+            "PROPOSE sending several drafts at once, for HUMAN APPROVAL — up to "
+            "100 ids. Files ONE proposal per draft; a human still approves each "
+            "in the Tray, and nothing is sent by this tool. A draft that cannot "
+            "be proposed (already proposed, rejected, missing) comes back in "
+            "`failed` and the rest still go. NEVER report these as sent."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "draft_ids": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "minItems": 1,
+                    "maxItems": 100,
+                }
+            },
+            "required": ["draft_ids"],
+            "additionalProperties": False,
+        },
+    )
+    async def growth_propose_send_batch(args):  # type: ignore[no-untyped-def]
+        return await _propose_send_batch_handler(args)
+
+    @tool(
+        "growth_linkedin_queue",
+        (
+            "Read the manual LinkedIn send queue: linkedin drafts in "
+            "proposed/approved with the prospect context a human needs to send "
+            "them by hand (name, company, profile URL, research brief, tier). "
+            "LinkedIn sending is manual by design — there is no integration and "
+            "no tool that sends."
+        ),
+        {
+            "type": "object",
+            "properties": {"limit": {"type": "integer", "minimum": 1, "maximum": _MAX_LIST_LIMIT}},
+            "additionalProperties": False,
+        },
+    )
+    async def growth_linkedin_queue(args):  # type: ignore[no-untyped-def]
+        return await _linkedin_queue_handler(args)
+
+    return [
+        growth_list_prospects,
+        growth_get_prospect,
+        growth_list_drafts,
+        growth_upsert_prospect,
+        growth_create_draft,
+        growth_update_draft,
+        growth_propose_send,
+        growth_propose_send_batch,
+        growth_linkedin_queue,
+    ]
+
+
+def build_growth_server() -> tuple[str, Any] | None:
+    """Build the in-process SDK MCP server for /growth, or ``None`` when the
+    Claude Agent SDK isn't installed (chat must never break because of us)."""
+    tools = _build_tools()
+    if tools is None:
+        return None
+
+    from claude_agent_sdk import create_sdk_mcp_server
+
+    server = create_sdk_mcp_server(name=SERVER_NAME, version="1.0.0", tools=tools)
+    return SERVER_NAME, server
+
+
+__all__ = [
+    "GROWTH_TOOL_IDS",
+    "GROWTH_TOOL_NAMES",
+    "MANAGE_ACTION",
+    "READ_ACTION",
+    "SERVER_NAME",
+    "WRITE_ACTION",
+    "build_growth_server",
+]

--- a/ee/pocketpaw_ee/agent/mcp_servers/growth.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/growth.py
@@ -480,6 +480,15 @@ async def _upsert_prospect_handler(args: dict) -> dict:
     except Exception as exc:  # noqa: BLE001
         return _service_error(exc, "look up the prospect")
 
+    if existing is None and (not name or not company):
+        # Only an ENRICHMENT call may omit these — there is nothing stored to
+        # carry forward, and a row named "unknown / unknown" is worse than a
+        # refusal the agent can act on.
+        return _error_response(
+            f"'{probe.domain}' is not in this workspace yet, so "
+            "growth_upsert_prospect needs `name` and `company` to add it."
+        )
+
     def _pick(supplied: Any, field: str, fallback: Any) -> Any:
         """Supplied wins; otherwise carry the stored value forward."""
         if supplied is not None:

--- a/ee/pocketpaw_ee/cloud/growth/dto.py
+++ b/ee/pocketpaw_ee/cloud/growth/dto.py
@@ -26,6 +26,10 @@
 # ProposeBatchRequest / ProposeBatchError / ProposeBatchResponse — proposing a
 # selection of drafts in one call, with per-draft error entries in the
 # bulk-ingest style (100-id cap enforced at the boundary).
+# Updated 2026-07-28 (feat/growth-mcp): UpdateDraftRequest — a partial edit of a
+# draft's COPY (subject / body / demo_url), the shape the agent surface needs to
+# revise a draft it wrote. No ``status`` field, deliberately: the lifecycle moves
+# through the transition route and the Instinct gate, never through an edit.
 # Updated 2026-07-27 (feat/growth-g8): LinkedInQueueItemResponse — one row of
 # the manual LinkedIn send queue: the draft envelope joined with the prospect
 # context the captain needs to send by hand (name, company, profile URL,
@@ -207,6 +211,39 @@ class CreateDraftRequest(BaseModel):
         return self
 
 
+class UpdateDraftRequest(BaseModel):
+    """Partial edit of a draft's COPY — every field optional, ``None`` means
+    "leave as-is".
+
+    There is no ``status`` field and there never will be: a status move is a
+    lifecycle event that goes through the transition route (and, for the
+    gate-owned targets, through an approved Instinct proposal). Letting an edit
+    carry a status would be a second, unreviewed road to ``approved``.
+
+    ``channel`` and ``prospect_id`` are likewise not editable — a draft for a
+    different channel or a different prospect is a different draft.
+    ``subject`` stays email-only, but that check needs the stored draft's
+    channel, so it lives in the service rather than here.
+    """
+
+    subject: str | None = Field(default=None, max_length=200)
+    body: str | None = Field(default=None, min_length=1, max_length=10_000)
+    demo_url: str | None = Field(default=None, max_length=2048)
+
+    @field_validator("body")
+    @classmethod
+    def _non_blank_body(cls, v: str | None) -> str | None:
+        if v is not None and not v.strip():
+            raise ValueError("body must not be blank")
+        return v
+
+    @model_validator(mode="after")
+    def _at_least_one_field(self) -> UpdateDraftRequest:
+        if self.subject is None and self.body is None and self.demo_url is None:
+            raise ValueError("provide at least one of subject / body / demo_url")
+        return self
+
+
 class TransitionDraftRequest(BaseModel):
     """Target status for a lifecycle move. Whether the move is LEGAL from the
     draft's current status is the service's call (``draft.illegal_transition``,
@@ -302,5 +339,6 @@ __all__ = [
     "ProspectPageResponse",
     "ProspectResponse",
     "TransitionDraftRequest",
+    "UpdateDraftRequest",
     "UpdateProspectRequest",
 ]

--- a/ee/pocketpaw_ee/cloud/growth/router.py
+++ b/ee/pocketpaw_ee/cloud/growth/router.py
@@ -28,6 +28,11 @@
 # /drafts/{id}/propose — takes ``growth.manage`` (ADMIN): the propose route
 # has to sit at the same tier ``growth.executor`` re-checks at dispatch, or a
 # member-filed proposal would always fail closed at approve time.
+# Updated 2026-07-28 (feat/growth-mcp): PATCH /drafts/{id} — edit a draft's copy
+# (subject / body / demo_url) while it is still ``draft``. Anything past that is
+# 403 ``draft.not_editable``: from ``proposed`` on, the stored body is what the
+# Tray shows and what the worker sends. Declared ABOVE the /drafts/{id}/status
+# POST for readability only — different methods, no path-match ambiguity.
 # Updated 2026-07-28 (feat/growth-api-scale): GET /prospects grew the scale
 # query — ``q`` (search), ``sort`` (newest|oldest|company|tier), ``cursor`` —
 # and now returns ``ProspectPageResponse`` ({items, next_cursor, total})
@@ -80,6 +85,7 @@ from pocketpaw_ee.cloud.growth.dto import (
     ProspectPageResponse,
     ProspectResponse,
     TransitionDraftRequest,
+    UpdateDraftRequest,
     UpdateProspectRequest,
 )
 from pocketpaw_ee.cloud.license import require_license
@@ -235,6 +241,26 @@ async def list_drafts(
     return await growth_service.list_drafts(
         ctx, prospect_id=prospect_id, channel=channel, status=status, limit=limit
     )
+
+
+@router.patch(
+    "/drafts/{draft_id}",
+    response_model=DraftResponse,
+    dependencies=[Depends(require_action_any_workspace("growth.write"))],
+)
+async def update_draft(
+    draft_id: str,
+    body: UpdateDraftRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> DraftResponse:
+    """Edit a draft's copy — subject / body / demo_url, any subset.
+
+    Only while the draft is still ``draft``: from ``proposed`` on, the stored
+    body is what the human reviews in the Tray and what the worker sends, so an
+    edit is refused with 403 ``draft.not_editable``. There is no ``status``
+    field on the body — lifecycle moves go through the status route and the
+    gate."""
+    return await growth_service.update_draft(ctx, draft_id, body)
 
 
 @router.post(

--- a/ee/pocketpaw_ee/cloud/growth/service.py
+++ b/ee/pocketpaw_ee/cloud/growth/service.py
@@ -24,6 +24,12 @@
 # draft→proposed via ``transition``), and ``gate_transition`` is the internal
 # seam the growth executor / dispatch worker use to walk gate-owned edges
 # (same legality table, explicit workspace_id, no RequestContext).
+# Updated 2026-07-28 (feat/growth-mcp): ``update_draft`` — a partial edit of a
+# draft's COPY, refused with 403 ``draft.not_editable`` for anything past
+# ``draft``. The guard is structural: from ``proposed`` on, the stored body IS
+# what the human reviews in the Tray and what the dispatch worker puts on the
+# wire, so an edit there would send copy nobody approved. The agent surface
+# (``agent/mcp_servers/growth.py``) is the caller that needed it.
 # Updated 2026-07-28 (feat/growth-api-scale): the list query grew a scale
 # surface — ``q`` (escaped case-insensitive regex across four fields, ceiling
 # documented on ``_prospect_filters``), four ``sort`` modes with the tier rank
@@ -122,6 +128,7 @@ from pocketpaw_ee.cloud.growth.dto import (
     ProspectPageResponse,
     ProspectResponse,
     TransitionDraftRequest,
+    UpdateDraftRequest,
     UpdateProspectRequest,
 )
 from pocketpaw_ee.cloud.models.draft import Draft as _DraftDoc
@@ -792,6 +799,48 @@ async def list_drafts(
         .limit(limit)
     )
     return [_draft_to_response(_draft_to_domain(doc)) async for doc in cursor]
+
+
+async def update_draft(
+    ctx: RequestContext, draft_id: str, body: UpdateDraftRequest
+) -> DraftResponse:
+    """Edit a draft's copy (subject / body / demo_url) — ONLY while it is
+    still ``draft``.
+
+    The status guard is load-bearing, not tidiness. Once a draft is
+    ``proposed``, a human is reading THAT copy in the Tray, and the dispatch
+    worker sends the stored body — so an edit after proposal would put text on
+    the wire that nobody approved. Same reasoning at ``approved`` / ``sent``.
+    Anything past ``draft`` is refused with 403 ``draft.not_editable``; revise
+    by rejecting the draft and writing a new one.
+
+    The lifecycle is untouched here: this function never reads or writes
+    ``status``.
+    """
+    body = UpdateDraftRequest.model_validate(body)
+    workspace_id = _require_workspace(ctx)
+    doc = await _fetch_draft_in_workspace(workspace_id, draft_id)
+
+    if doc.status != "draft":
+        raise Forbidden(
+            "draft.not_editable",
+            f"A draft in '{doc.status}' can no longer be edited — its copy is "
+            "what the gate reviews and what the worker sends. Reject it and "
+            "write a new draft instead",
+        )
+    if body.subject is not None and doc.channel != "email":
+        raise ValidationError(
+            "draft.subject_not_allowed",
+            f"subject is only valid on the email channel (this draft is '{doc.channel}')",
+        )
+
+    for field in ("subject", "body", "demo_url"):
+        value = getattr(body, field)
+        if value is not None:
+            setattr(doc, field, value)
+    await doc.save()  # bumps updatedAt
+    # no-event: growth has no realtime subscriber in v1; the drafts view polls.
+    return _draft_to_response(_draft_to_domain(doc))
 
 
 async def transition(

--- a/ee/pocketpaw_ee/extensions.py
+++ b/ee/pocketpaw_ee/extensions.py
@@ -1135,6 +1135,44 @@ class CloudShipMcpProvider:
         return list(EXTERNAL_ACTIONS_TOOL_IDS)
 
 
+class CloudGrowthMcpProvider:
+    """`pocketpaw.mcp_servers` — the /growth outbound in-process server
+    (``pocketpaw_growth``). Hosts the prospect + draft verbs the chat agent on
+    the /growth rail may drive.
+
+    Reads (prospect list / one prospect with its drafts / draft list / LinkedIn
+    queue) and AUTHORING writes (upsert a researched prospect, write a draft,
+    revise a draft still in ``draft``) execute through
+    ``ee.cloud.growth.service``. The OUTBOUND verbs do not, and there is no tool
+    that sends: ``growth_propose_send`` / ``growth_propose_send_batch`` file
+    Instinct proposals and return ``status="proposed"``. Nothing reaches
+    ``approved`` or ``sent`` from here — those are ``GATE_OWNED_TARGETS``,
+    walked only by ``ee.cloud.growth.executor`` after a human approval and by
+    the dispatch worker. The tools carry the same per-action RBAC tiers as the
+    HTTP routes (read / write / manage), so a proposal the executor could never
+    approve is never filed.
+
+    Ambient (NOT in ``OPT_IN_MCP_SERVERS``) — surfaces scope access via their
+    profile allowlist, the same regime the sibling belt / ship / external-action
+    servers use. ``build_growth_server`` returns None — and the loop skips it —
+    when the claude_agent_sdk isn't installed, so chat never breaks.
+    """
+
+    def build_server(self) -> tuple[str, Any] | None:
+        try:
+            from pocketpaw_ee.agent.mcp_servers.growth import build_growth_server
+
+            return build_growth_server()
+        except ImportError:
+            # claude_agent_sdk not installed — same posture as the siblings.
+            return None
+
+    def tool_ids(self) -> list[str]:
+        from pocketpaw_ee.agent.mcp_servers.growth import GROWTH_TOOL_IDS
+
+        return list(GROWTH_TOOL_IDS)
+
+
 class CloudWorkspaceAdminMcpProvider:
     """`pocketpaw.mcp_servers` — the workspace-administration in-process server
     (``pocketpaw_workspace_admin``, feat/workspace-admin-tools WA-1).

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -264,6 +264,7 @@ belt = "pocketpaw_ee.extensions:CloudBeltMcpProvider"
 code = "pocketpaw_ee.extensions:CloudCodeMcpProvider"
 external_actions = "pocketpaw_ee.extensions:CloudExternalActionsMcpProvider"
 ship = "pocketpaw_ee.extensions:CloudShipMcpProvider"
+growth = "pocketpaw_ee.extensions:CloudGrowthMcpProvider"
 fabric = "pocketpaw_ee.extensions:CloudFabricMcpProvider"
 instinct = "pocketpaw_ee.extensions:CloudInstinctMcpProvider"
 daytona = "pocketpaw_ee.extensions:CloudDaytonaMcpProvider"
@@ -830,7 +831,12 @@ name = "Growth — Beanie writes only from service.py"
 # stays on the forbidden list.
 type = "forbidden"
 allow_indirect_imports = "true"
+# feat/growth-mcp — the agent surface joins the boundary:
+# ``agent.mcp_servers.growth`` reaches prospects and drafts ONLY through
+# ``growth.service``, never a doc class. It is also the module where a stray
+# Beanie import would be least visible, so the contract is the check.
 source_modules = [
+    "pocketpaw_ee.agent.mcp_servers.growth",
     "pocketpaw_ee.cloud.growth.router",
     "pocketpaw_ee.cloud.growth.dto",
     "pocketpaw_ee.cloud.growth.domain",

--- a/tests/cloud/growth/test_drafts.py
+++ b/tests/cloud/growth/test_drafts.py
@@ -10,6 +10,13 @@
 # prospect → 404 on create, foreign draft ids 404, lists never leak).
 #
 # Created 2026-07-27 (feat/growth-g3): third slice of /growth — drafts.
+# Updated 2026-07-28 (feat/growth-mcp): PATCH /growth/drafts/{id} — editing a
+# draft's copy. The load-bearing case is the REFUSAL: parametrized over
+# proposed / approved / sent / rejected, each 403 ``draft.not_editable`` with
+# the stored body unchanged, because from ``proposed`` on the stored copy is
+# what the Tray shows and what the worker sends. Plus the email-only subject
+# check (needs the STORED channel, hence service-side), empty/blank payloads,
+# a ``status`` key that the edit DTO has no field for, and tenancy.
 # Updated 2026-07-27 (feat/growth-g4): the Instinct send gate owns the
 # ``approved`` / ``sent`` edges now — the public status route refuses them
 # with 403 ``draft.gate_required`` (new tests below). Lifecycle walks that
@@ -463,3 +470,111 @@ async def test_drafts_are_tenant_scoped(w1_client, w2_client):
     # The cross-tenant attempt must not have moved the draft.
     listed = (await w1_client.get("/api/v1/growth/drafts")).json()
     assert listed[0]["status"] == "draft"
+
+
+# ---------------------------------------------------------------------------
+# Edit the copy (feat/growth-mcp) — PATCH /drafts/{id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_draft_edits_the_copy_while_still_draft(w1_client):
+    """Subject / body / demo_url are editable, any subset, while the draft
+    has not left ``draft``. The status is untouched by an edit."""
+    prospect = await _create_prospect(w1_client)
+    draft = await _create_draft(w1_client, prospect["id"])
+
+    resp = await w1_client.patch(
+        f"/api/v1/growth/drafts/{draft['id']}",
+        json={"body": "Rewrote the opener so it leads with the booking drop-off."},
+    )
+    assert resp.status_code == 200, resp.text
+    edited = resp.json()
+    assert edited["body"].startswith("Rewrote the opener")
+    assert edited["subject"] == draft["subject"]  # untouched
+    assert edited["status"] == "draft"
+
+    resp = await w1_client.patch(
+        f"/api/v1/growth/drafts/{draft['id']}",
+        json={"subject": "A faster path from search to booked", "demo_url": "https://d.example"},
+    )
+    assert resp.status_code == 200, resp.text
+    edited = resp.json()
+    assert edited["subject"] == "A faster path from search to booked"
+    assert edited["demo_url"] == "https://d.example"
+    assert edited["body"].startswith("Rewrote the opener")
+
+
+@pytest.mark.parametrize("status", ["proposed", "approved", "sent", "rejected"])
+@pytest.mark.asyncio
+async def test_update_draft_refused_once_the_draft_has_moved(w1_client, status):
+    """The load-bearing guard: from ``proposed`` on, the stored body IS what
+    the human reviews in the Tray and what the dispatch worker sends, so an
+    edit would put unapproved copy on the wire. 403 ``draft.not_editable``,
+    and the stored copy is unchanged."""
+    prospect = await _create_prospect(w1_client)
+    draft = await _create_draft(w1_client, prospect["id"])
+    walk = {
+        "proposed": ("proposed",),
+        "approved": ("proposed", "approved"),
+        "sent": ("proposed", "approved", "sent"),
+        "rejected": ("rejected",),
+    }[status]
+    await _walk(w1_client, draft["id"], *walk)
+
+    resp = await w1_client.patch(
+        f"/api/v1/growth/drafts/{draft['id']}", json={"body": "swapped copy"}
+    )
+    assert resp.status_code == 403, resp.text
+    assert resp.json()["error"]["code"] == "draft.not_editable"
+
+    listed = (await w1_client.get("/api/v1/growth/drafts")).json()
+    assert listed[0]["body"] == draft["body"]
+
+
+@pytest.mark.asyncio
+async def test_update_draft_rejects_a_subject_on_a_non_email_channel(w1_client):
+    """``subject`` stays email-only — the check needs the STORED channel, so
+    it lives in the service rather than the DTO."""
+    prospect = await _create_prospect(w1_client)
+    draft = await _create_draft(
+        w1_client, prospect["id"], channel="linkedin", subject=None, body="Connect note."
+    )
+    resp = await w1_client.patch(f"/api/v1/growth/drafts/{draft['id']}", json={"subject": "nope"})
+    assert resp.status_code == 422
+    assert resp.json()["error"]["code"] == "draft.subject_not_allowed"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},  # nothing to change
+        {"body": "   "},  # blank body
+        {"status": "approved"},  # no status field exists on the edit DTO
+    ],
+)
+@pytest.mark.asyncio
+async def test_update_draft_rejects_bad_payloads(w1_client, payload):
+    """An empty patch and a blank body 422 at the boundary. So does a
+    ``status`` key: the edit DTO has no status field, and a lifecycle move
+    dressed as an edit would be a second road to ``approved``."""
+    prospect = await _create_prospect(w1_client)
+    draft = await _create_draft(w1_client, prospect["id"])
+    resp = await w1_client.patch(f"/api/v1/growth/drafts/{draft['id']}", json=payload)
+    assert resp.status_code == 422, resp.text
+    listed = (await w1_client.get("/api/v1/growth/drafts")).json()
+    assert listed[0]["status"] == "draft"
+
+
+@pytest.mark.asyncio
+async def test_update_draft_is_tenant_scoped(w1_client, w2_client):
+    """w2 cannot edit w1's draft — identical 404, and nothing is written."""
+    prospect = await _create_prospect(w1_client)
+    draft = await _create_draft(w1_client, prospect["id"])
+    resp = await w2_client.patch(
+        f"/api/v1/growth/drafts/{draft['id']}", json={"body": "tenant leak"}
+    )
+    assert resp.status_code == 404
+    assert resp.json()["error"]["code"] == "draft.not_found"
+    listed = (await w1_client.get("/api/v1/growth/drafts")).json()
+    assert listed[0]["body"] == draft["body"]

--- a/tests/cloud/growth/test_gate.py
+++ b/tests/cloud/growth/test_gate.py
@@ -928,6 +928,10 @@ class TestGrowthRouteRbac:
             ("POST", "/growth/prospects/{prospect_id}/drafts"): "growth.write",
             ("PATCH", "/growth/prospects/{prospect_id}"): "growth.write",
             ("POST", "/growth/drafts/{draft_id}/status"): "growth.write",
+            # Editing a draft's COPY is authoring, not outbound — and the
+            # service refuses it past ``draft`` anyway, so it can never touch
+            # copy the gate has already been shown.
+            ("PATCH", "/growth/drafts/{draft_id}"): "growth.write",
             # The outbound verb sits at the ADMIN tier the executor re-checks.
             ("POST", "/growth/drafts/{draft_id}/propose"): "growth.manage",
             # G-10a's batch propose is the same outbound verb over N ids, so

--- a/tests/cloud/growth/test_mcp_server.py
+++ b/tests/cloud/growth/test_mcp_server.py
@@ -1,0 +1,663 @@
+# tests/cloud/growth/test_mcp_server.py — the agent-facing /growth MCP surface
+# (``ee/pocketpaw_ee/agent/mcp_servers/growth.py``).
+#
+# The security-critical assertion is ``TestTheGateHolds``: NO exposed tool can
+# reach a draft status in ``GATE_OWNED_TARGETS`` (``approved`` / ``sent``). It
+# is written against the TOOL LIST and the tool SCHEMAS rather than against the
+# nine tools that exist today, so adding a tenth tool that takes a ``status``
+# argument — or naming one ``growth_send_now`` — fails this file before it can
+# ship. The dynamic half drives every tool through the real handlers and asserts
+# no draft ever left ``draft``/``proposed``, and that ``service.gate_transition``
+# (the executor's seam) is never called from here.
+#
+# The rest pins the round trip: every tool goes through
+# ``ee.cloud.growth.service`` against real (mongomock) Beanie, tenancy comes
+# from the chat identity ContextVars and never from an argument, the RBAC tiers
+# match the HTTP routes, and a call outside a chat stream errors instead of
+# operating on a blank workspace.
+#
+# Harness: the ``mongo_db`` fixture from tests/cloud/conftest.py, real User docs
+# (the RBAC gate loads the doc and reads ``.workspaces``), identity bound via
+# ``attach_agent_identity``, and one tmp ``InstinctStore`` behind
+# ``pocketpaw.stores.get_instinct_store`` so the propose path files a real
+# Action — same seam test_gate.py patches.
+#
+# Created 2026-07-28 (feat/growth-mcp): new module.
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+import pytest_asyncio
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.agent.mcp_servers import growth as growth_mcp  # noqa: E402
+from pocketpaw_ee.cloud.chat.agent_service import (  # noqa: E402
+    attach_agent_identity,
+    detach_agent_identity,
+)
+from pocketpaw_ee.cloud.growth.domain import GATE_OWNED_TARGETS  # noqa: E402
+
+from pocketpaw.instinct.store import InstinctStore  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Harness
+# ---------------------------------------------------------------------------
+
+
+class _identity:
+    """Bind the workspace/user ContextVars the handlers read, then reset."""
+
+    def __init__(self, workspace: str, user: str) -> None:
+        self._ws, self._user = workspace, user
+        self._token: Any = None
+
+    def __enter__(self) -> _identity:
+        self._token = attach_agent_identity(workspace_id=self._ws, user_id=self._user)
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        detach_agent_identity(self._token)
+
+
+async def _seed_user(email: str, workspace: str, role: str = "admin") -> str:
+    """Insert a real User doc with a membership the RBAC gate can resolve."""
+    from pocketpaw_ee.cloud.models.user import User, WorkspaceMembership
+
+    doc = User(
+        email=email,
+        hashed_password="x",
+        is_active=True,
+        is_verified=True,
+        full_name="Growth Operator",
+        active_workspace=workspace,
+        workspaces=[WorkspaceMembership(workspace=workspace, role=role)],
+    )
+    await doc.insert()
+    return str(doc.id)
+
+
+@pytest.fixture
+def instinct_store(tmp_path: Path, monkeypatch) -> InstinctStore:
+    """One tmp store behind every seam that resolves an instinct store, so
+    ``growth_propose_send`` files a real Action instead of touching
+    ``~/.pocketpaw/instinct.db``."""
+    store = InstinctStore(tmp_path / "growth_mcp.db")
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: store)
+    return store
+
+
+@pytest_asyncio.fixture
+async def admin_w1(mongo_db: Any) -> str:
+    return await _seed_user("admin-w1@growth.test", "w1", role="admin")
+
+
+@pytest_asyncio.fixture
+async def admin_w2(mongo_db: Any) -> str:
+    return await _seed_user("admin-w2@growth.test", "w2", role="admin")
+
+
+@pytest_asyncio.fixture
+async def member_w1(mongo_db: Any) -> str:
+    return await _seed_user("member-w1@growth.test", "w1", role="member")
+
+
+def _payload(response: dict) -> dict:
+    """Decode a tool response's JSON body. Fails loudly on an error envelope so
+    a broken call can't be mistaken for an empty result."""
+    assert not response.get("is_error"), response["content"][0]["text"]
+    return json.loads(response["content"][0]["text"])
+
+
+def _error_text(response: dict) -> str:
+    assert response.get("is_error"), f"expected an error envelope, got {response}"
+    return response["content"][0]["text"]
+
+
+async def _seed_prospect(user_id: str, **over: Any) -> dict:
+    args = {
+        "domain": "acme-dental.com",
+        "name": "Sam Founder",
+        "company": "Acme Dental",
+        "research_brief": "Booking flow dead-ends at a contact form.",
+        "tier": "a",
+        **over,
+    }
+    with _identity("w1", user_id):
+        return _payload(await growth_mcp._upsert_prospect_handler(args))["prospect"]
+
+
+async def _seed_draft(user_id: str, prospect_id: str, **over: Any) -> dict:
+    args = {
+        "prospect_id": prospect_id,
+        "channel": "email",
+        "subject": "A faster path from search to booked",
+        "body": "Saw your online booking stops at a contact form — here is a live demo.",
+        **over,
+    }
+    with _identity("w1", user_id):
+        return _payload(await growth_mcp._create_draft_handler(args))["draft"]
+
+
+# ---------------------------------------------------------------------------
+# The gate — the assertion this whole module exists for
+# ---------------------------------------------------------------------------
+
+
+class TestTheGateHolds:
+    """The agent's reach ends at ``proposed``. Written against the tool list and
+    the schemas, so a FUTURE tool addition trips these before it ships."""
+
+    def test_the_exposed_tool_set_is_exactly_this(self):
+        """A new tool must be added here deliberately — which forces whoever
+        adds it to read the rest of this class."""
+        tools = growth_mcp._build_tools()
+        assert tools is not None, "the Claude Agent SDK must be installed for this suite"
+        assert {t.name for t in tools} == {
+            "growth_list_prospects",
+            "growth_get_prospect",
+            "growth_list_drafts",
+            "growth_upsert_prospect",
+            "growth_create_draft",
+            "growth_update_draft",
+            "growth_propose_send",
+            "growth_propose_send_batch",
+            "growth_linkedin_queue",
+        }
+        assert set(growth_mcp.GROWTH_TOOL_NAMES) == {t.name for t in tools}
+        assert set(growth_mcp.GROWTH_TOOL_IDS) == {
+            f"mcp__pocketpaw_growth__{t.name}" for t in tools
+        }
+
+    def test_no_tool_name_claims_to_send(self):
+        """A tool is named for what it does. Nothing here sends, dispatches or
+        approves — the only outbound verbs are PROPOSE verbs."""
+        for tool in growth_mcp._build_tools():
+            forbidden = ("send", "dispatch", "approve", "deliver", "transition")
+            offending = [word for word in forbidden if word in tool.name]
+            assert not offending or tool.name.startswith("growth_propose_send"), (
+                f"{tool.name} names a verb the agent does not have: {offending}"
+            )
+
+    def test_no_write_tool_takes_a_status_argument(self):
+        """The legal moves are exposed as named verbs. A ``status`` INPUT on a
+        write tool would be a shape of argument that could ask for
+        ``approved`` — so the write tools have none at all, and the two reads
+        that do have one use it as a filter."""
+        reads_that_filter_on_status = {"growth_list_prospects", "growth_list_drafts"}
+        for tool in growth_mcp._build_tools():
+            props = tool.input_schema.get("properties", {})
+            if tool.name in reads_that_filter_on_status:
+                continue
+            assert "status" not in props, f"{tool.name} accepts a status argument"
+
+    def test_no_tool_schema_offers_a_gate_owned_value(self):
+        """No enum on any tool offers ``approved`` or ``sent`` as something to
+        SET. The two read filters may name them (reading an approved draft is
+        fine — the LinkedIn queue is built on it), so this walks the write
+        tools only."""
+        writes = {
+            "growth_upsert_prospect",
+            "growth_create_draft",
+            "growth_update_draft",
+            "growth_propose_send",
+            "growth_propose_send_batch",
+        }
+        for tool in growth_mcp._build_tools():
+            if tool.name not in writes:
+                continue
+            for prop, spec in tool.input_schema.get("properties", {}).items():
+                values = set(spec.get("enum") or ())
+                assert not (values & GATE_OWNED_TARGETS), (
+                    f"{tool.name}.{prop} offers a gate-owned value: {values & GATE_OWNED_TARGETS}"
+                )
+
+    def test_the_module_never_reaches_the_gate_seam(self):
+        """``service.gate_transition`` is how the executor and the dispatch
+        worker walk the gate-owned edges. It must be unreachable from the agent
+        surface — including via ``mark_linkedin_sent``, which walks
+        approved→sent."""
+        source = Path(growth_mcp.__file__).read_text(encoding="utf-8")
+        code = "\n".join(line for line in source.splitlines() if not line.lstrip().startswith("#"))
+        for seam in ("gate_transition", "mark_linkedin_sent", "service.transition"):
+            assert seam not in code, f"the growth MCP module references {seam}"
+
+    def test_no_tool_accepts_a_workspace_id(self):
+        """Tenancy comes from the chat stream's identity. A model that could
+        name a tenant could read another one."""
+        for tool in growth_mcp._build_tools():
+            props = tool.input_schema.get("properties", {})
+            assert "workspace_id" not in props, f"{tool.name} accepts a workspace_id"
+            assert tool.input_schema.get("additionalProperties") is False, (
+                f"{tool.name} allows extra properties — a stray key could smuggle one in"
+            )
+
+    @pytest.mark.asyncio
+    async def test_driving_every_tool_never_reaches_approved_or_sent(
+        self, mongo_db, admin_w1, instinct_store, monkeypatch
+    ):
+        """The dynamic half: run the whole surface end to end and assert the
+        drafts stopped at ``proposed``, and that nothing called the gate seam."""
+        from pocketpaw_ee.cloud.growth import service as growth_service
+
+        calls: list[tuple] = []
+
+        async def _tripwire(*args: Any, **kwargs: Any):
+            calls.append((args, kwargs))
+            raise AssertionError("the agent surface reached the gate seam")
+
+        monkeypatch.setattr(growth_service, "gate_transition", _tripwire)
+        monkeypatch.setattr(growth_service, "mark_linkedin_sent", _tripwire)
+
+        prospect = await _seed_prospect(admin_w1)
+        draft = await _seed_draft(admin_w1, prospect["id"])
+        second = await _seed_draft(
+            admin_w1, prospect["id"], channel="linkedin", subject=None, body="Connect note."
+        )
+
+        with _identity("w1", admin_w1):
+            await growth_mcp._list_prospects_handler({})
+            await growth_mcp._get_prospect_handler({"prospect_id": prospect["id"]})
+            await growth_mcp._list_drafts_handler({})
+            await growth_mcp._update_draft_handler({"draft_id": draft["id"], "body": "revised"})
+            await growth_mcp._propose_send_handler({"draft_id": draft["id"]})
+            await growth_mcp._propose_send_batch_handler({"draft_ids": [second["id"]]})
+            await growth_mcp._linkedin_queue_handler({})
+            drafts = _payload(await growth_mcp._list_drafts_handler({}))["drafts"]
+
+        assert calls == []
+        assert {d["status"] for d in drafts} == {"proposed"}
+        assert not {d["status"] for d in drafts} & GATE_OWNED_TARGETS
+
+    @pytest.mark.asyncio
+    async def test_a_proposed_draft_can_no_longer_be_edited(
+        self, mongo_db, admin_w1, instinct_store
+    ):
+        """Editing a proposed draft would put copy on the wire that nobody
+        approved — the same bypass as sending, wearing an edit's clothes."""
+        prospect = await _seed_prospect(admin_w1)
+        draft = await _seed_draft(admin_w1, prospect["id"])
+        with _identity("w1", admin_w1):
+            await growth_mcp._propose_send_handler({"draft_id": draft["id"]})
+            response = await growth_mcp._update_draft_handler(
+                {"draft_id": draft["id"], "body": "swapped after approval was asked for"}
+            )
+            assert "draft.not_editable" in _error_text(response)
+            fetched = _payload(
+                await growth_mcp._get_prospect_handler({"prospect_id": prospect["id"]})
+            )
+        assert fetched["drafts"][0]["body"] == draft["body"]
+
+
+# ---------------------------------------------------------------------------
+# Registration contract
+# ---------------------------------------------------------------------------
+
+
+class TestRegistration:
+    def test_provider_exposes_the_server_and_its_tool_ids(self):
+        from pocketpaw_ee.extensions import CloudGrowthMcpProvider
+
+        provider = CloudGrowthMcpProvider()
+        built = provider.build_server()
+        assert built is not None
+        name, server = built
+        assert name == growth_mcp.SERVER_NAME == "pocketpaw_growth"
+        assert server is not None
+        assert set(provider.tool_ids()) == set(growth_mcp.GROWTH_TOOL_IDS)
+
+
+# ---------------------------------------------------------------------------
+# Round trips — every tool goes through the service
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTrips:
+    @pytest.mark.asyncio
+    async def test_upsert_then_list_then_get(self, mongo_db, admin_w1):
+        prospect = await _seed_prospect(admin_w1)
+        assert prospect["domain"] == "acme-dental.com"
+        assert prospect["tier"] == "a"
+
+        with _identity("w1", admin_w1):
+            listed = _payload(await growth_mcp._list_prospects_handler({"q": "Acme"}))
+            fetched = _payload(
+                await growth_mcp._get_prospect_handler({"prospect_id": prospect["id"]})
+            )
+
+        assert listed["total"] == 1
+        assert listed["showing"] == 1
+        row = listed["prospects"][0]
+        assert row["company"] == "Acme Dental"
+        # Compact by design — the brief and contact details are not in the list.
+        assert "research_brief" not in row
+        assert "emails" not in row
+
+        assert fetched["prospect"]["research_brief"].startswith("Booking flow")
+        assert fetched["drafts"] == []
+
+    @pytest.mark.asyncio
+    async def test_upsert_normalises_the_domain_and_dedupes(self, mongo_db, admin_w1):
+        """The domain is the dedupe key, canonicalised at the DTO boundary — a
+        pasted URL and a bare hostname are the same prospect."""
+        first = await _seed_prospect(admin_w1, domain="https://www.Acme-Dental.com/about")
+        assert first["domain"] == "acme-dental.com"
+        second = await _seed_prospect(admin_w1, domain="acme-dental.com", tier="b")
+        assert second["id"] == first["id"]
+
+        with _identity("w1", admin_w1):
+            listed = _payload(await growth_mcp._list_prospects_handler({}))
+        assert listed["total"] == 1
+        assert listed["prospects"][0]["tier"] == "b"
+
+    @pytest.mark.asyncio
+    async def test_upsert_merges_instead_of_blanking_what_it_was_not_told(self, mongo_db, admin_w1):
+        """A re-upsert enriches. Fields the agent leaves out keep their stored
+        values, and the lifecycle status — which the agent cannot set — is
+        carried forward rather than reset to ``new``."""
+        prospect = await _seed_prospect(admin_w1)
+        first_draft = await _seed_draft(admin_w1, prospect["id"])
+        assert first_draft["status"] == "draft"
+
+        with _identity("w1", admin_w1):
+            # Writing a draft moved the prospect to ``drafted``.
+            before = _payload(
+                await growth_mcp._get_prospect_handler({"prospect_id": prospect["id"]})
+            )["prospect"]
+            assert before["status"] == "drafted"
+
+            enriched = _payload(
+                await growth_mcp._upsert_prospect_handler(
+                    {"domain": "acme-dental.com", "emails": ["sam@acme-dental.com"]}
+                )
+            )["prospect"]
+
+        assert enriched["emails"] == ["sam@acme-dental.com"]
+        assert enriched["status"] == "drafted"  # not reset
+        assert enriched["name"] == "Sam Founder"  # not blanked
+        assert enriched["research_brief"].startswith("Booking flow")
+        assert enriched["tier"] == "a"
+
+    @pytest.mark.asyncio
+    async def test_create_then_update_then_propose(self, mongo_db, admin_w1, instinct_store):
+        prospect = await _seed_prospect(admin_w1)
+        draft = await _seed_draft(admin_w1, prospect["id"])
+        assert draft["status"] == "draft"
+
+        with _identity("w1", admin_w1):
+            edited = _payload(
+                await growth_mcp._update_draft_handler(
+                    {"draft_id": draft["id"], "body": "Rewrote the opener.", "subject": "New line"}
+                )
+            )["draft"]
+            assert edited["body"] == "Rewrote the opener."
+            assert edited["subject"] == "New line"
+            assert edited["status"] == "draft"
+
+            proposed = _payload(await growth_mcp._propose_send_handler({"draft_id": draft["id"]}))
+
+        assert proposed["status"] == "proposed"
+        assert proposed["proposal_id"]
+        assert proposed["draft"]["status"] == "proposed"
+        assert "NOTHING has been sent" in proposed["note"]
+        # The proposal is a real, durably stored Instinct Action.
+        assert await instinct_store.get_action(proposed["proposal_id"]) is not None
+
+    @pytest.mark.asyncio
+    async def test_propose_batch_files_one_proposal_per_draft(
+        self, mongo_db, admin_w1, instinct_store
+    ):
+        prospect = await _seed_prospect(admin_w1)
+        a = await _seed_draft(admin_w1, prospect["id"])
+        b = await _seed_draft(
+            admin_w1, prospect["id"], channel="whatsapp", subject=None, body="Hi Sam!"
+        )
+
+        with _identity("w1", admin_w1):
+            result = _payload(
+                await growth_mcp._propose_send_batch_handler({"draft_ids": [a["id"], b["id"]]})
+            )
+            # A second pass finds them already proposed — partial success, not a
+            # second road to approval.
+            again = _payload(await growth_mcp._propose_send_batch_handler({"draft_ids": [a["id"]]}))
+
+        assert result["proposed"] == 2
+        assert result["failed"] == []
+        assert again["proposed"] == 0
+        assert again["failed"][0]["code"] == "draft.illegal_transition"
+        pending = await instinct_store.pending()
+        assert len(pending) == 2
+
+    @pytest.mark.asyncio
+    async def test_list_drafts_previews_bodies_and_filters(self, mongo_db, admin_w1):
+        prospect = await _seed_prospect(admin_w1)
+        await _seed_draft(admin_w1, prospect["id"], body="x" * 400)
+        await _seed_draft(
+            admin_w1, prospect["id"], channel="linkedin", subject=None, body="Connect note."
+        )
+
+        with _identity("w1", admin_w1):
+            everything = _payload(await growth_mcp._list_drafts_handler({}))
+            linkedin = _payload(await growth_mcp._list_drafts_handler({"channel": "linkedin"}))
+
+        assert everything["showing"] == 2
+        long_row = next(r for r in everything["drafts"] if r["channel"] == "email")
+        assert "body" not in long_row
+        assert len(long_row["body_preview"]) <= 120
+        assert linkedin["showing"] == 1
+
+    @pytest.mark.asyncio
+    async def test_linkedin_queue_carries_the_prospect_context(
+        self, mongo_db, admin_w1, instinct_store
+    ):
+        prospect = await _seed_prospect(admin_w1, linkedin_url="https://linkedin.com/in/sam")
+        draft = await _seed_draft(
+            admin_w1, prospect["id"], channel="linkedin", subject=None, body="Connect note."
+        )
+        with _identity("w1", admin_w1):
+            await growth_mcp._propose_send_handler({"draft_id": draft["id"]})
+            queue = _payload(await growth_mcp._linkedin_queue_handler({}))
+
+        assert queue["count"] == 1
+        row = queue["queue"][0]
+        assert row["prospect_company"] == "Acme Dental"
+        assert row["linkedin_url"] == "https://linkedin.com/in/sam"
+        assert row["draft"]["body"] == "Connect note."
+        assert "MANUAL" in row.get("note", "") or "MANUAL" in queue["note"]
+
+    @pytest.mark.asyncio
+    async def test_list_reports_the_filter_scoped_total_not_the_page(self, mongo_db, admin_w1):
+        for i in range(7):
+            await _seed_prospect(admin_w1, domain=f"clinic-{i}.com", company=f"Clinic {i}")
+
+        with _identity("w1", admin_w1):
+            page = _payload(await growth_mcp._list_prospects_handler({"limit": 3}))
+            rest = _payload(
+                await growth_mcp._list_prospects_handler(
+                    {"limit": 3, "cursor": page["next_cursor"]}
+                )
+            )
+
+        assert page["showing"] == 3
+        assert page["total"] == 7
+        assert page["next_cursor"]
+        assert rest["showing"] == 3
+        assert {r["id"] for r in page["prospects"]} & {r["id"] for r in rest["prospects"]} == set()
+
+    @pytest.mark.asyncio
+    async def test_an_absurd_limit_is_clamped_not_honoured(self, mongo_db, admin_w1):
+        """The agent reads to decide, not to recite — a 5,000-row ask is capped
+        rather than dumped into the turn."""
+        for i in range(3):
+            await _seed_prospect(admin_w1, domain=f"clinic-{i}.com")
+        with _identity("w1", admin_w1):
+            page = _payload(await growth_mcp._list_prospects_handler({"limit": 5000}))
+        assert page["showing"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Tenancy + identity
+# ---------------------------------------------------------------------------
+
+
+class TestTenancy:
+    @pytest.mark.asyncio
+    async def test_another_workspace_sees_none_of_it(self, mongo_db, admin_w1, admin_w2):
+        prospect = await _seed_prospect(admin_w1)
+        await _seed_draft(admin_w1, prospect["id"])
+
+        with _identity("w2", admin_w2):
+            listed = _payload(await growth_mcp._list_prospects_handler({}))
+            drafts = _payload(await growth_mcp._list_drafts_handler({}))
+            fetched = await growth_mcp._get_prospect_handler({"prospect_id": prospect["id"]})
+
+        assert listed["total"] == 0
+        assert listed["prospects"] == []
+        assert drafts["drafts"] == []
+        # Identical 404 wording — existence never leaks across tenants.
+        assert "prospect.not_found" in _error_text(fetched)
+
+    @pytest.mark.asyncio
+    async def test_another_workspace_cannot_touch_the_draft(
+        self, mongo_db, admin_w1, admin_w2, instinct_store
+    ):
+        prospect = await _seed_prospect(admin_w1)
+        draft = await _seed_draft(admin_w1, prospect["id"])
+
+        with _identity("w2", admin_w2):
+            edit = await growth_mcp._update_draft_handler(
+                {"draft_id": draft["id"], "body": "tenant leak"}
+            )
+            propose = await growth_mcp._propose_send_handler({"draft_id": draft["id"]})
+            batch = _payload(
+                await growth_mcp._propose_send_batch_handler({"draft_ids": [draft["id"]]})
+            )
+
+        assert "draft.not_found" in _error_text(edit)
+        assert "draft.not_found" in _error_text(propose)
+        assert batch["proposed"] == 0
+        assert batch["failed"][0]["code"] == "draft.not_found"
+
+        with _identity("w1", admin_w1):
+            fetched = _payload(
+                await growth_mcp._get_prospect_handler({"prospect_id": prospect["id"]})
+            )
+        assert fetched["drafts"][0]["body"] == draft["body"]
+        assert fetched["drafts"][0]["status"] == "draft"
+
+    @pytest.mark.asyncio
+    async def test_a_workspace_id_argument_is_ignored(self, mongo_db, admin_w1, admin_w2):
+        """Belt and braces on top of the schema's ``additionalProperties:
+        false``: even if a stray ``workspace_id`` reached a handler, the
+        workspace still comes from the identity."""
+        await _seed_prospect(admin_w1)
+        with _identity("w2", admin_w2):
+            listed = _payload(await growth_mcp._list_prospects_handler({"workspace_id": "w1"}))
+        assert listed["total"] == 0
+
+    @pytest.mark.asyncio
+    async def test_outside_a_chat_stream_every_tool_errors(self, mongo_db):
+        """No identity ContextVars → an explicit error, never a blank-workspace
+        read."""
+        handlers = [
+            growth_mcp._list_prospects_handler,
+            growth_mcp._get_prospect_handler,
+            growth_mcp._list_drafts_handler,
+            growth_mcp._upsert_prospect_handler,
+            growth_mcp._create_draft_handler,
+            growth_mcp._update_draft_handler,
+            growth_mcp._propose_send_handler,
+            growth_mcp._propose_send_batch_handler,
+            growth_mcp._linkedin_queue_handler,
+        ]
+        for handler in handlers:
+            response = await handler({})
+            assert "requires workspace and user context" in _error_text(response)
+
+    @pytest.mark.asyncio
+    async def test_an_unresolvable_user_fails_closed(self, mongo_db):
+        with _identity("w1", "not-an-object-id"):
+            response = await growth_mcp._list_prospects_handler({})
+        assert "could not resolve the calling user" in _error_text(response)
+
+
+# ---------------------------------------------------------------------------
+# RBAC — the same tiers the HTTP routes carry
+# ---------------------------------------------------------------------------
+
+
+class TestRbac:
+    @pytest.mark.asyncio
+    async def test_a_member_reads_and_writes_but_cannot_propose(
+        self, mongo_db, member_w1, instinct_store
+    ):
+        """``growth.manage`` is ADMIN. It is not decoration: the executor
+        re-checks it against the proposer's CURRENT role at approve time, so a
+        member-filed proposal could only ever clog the Tray."""
+        prospect = await _seed_prospect(member_w1)
+        draft = await _seed_draft(member_w1, prospect["id"])
+
+        with _identity("w1", member_w1):
+            read = _payload(await growth_mcp._list_prospects_handler({}))
+            single = _payload(await growth_mcp._propose_send_handler({"draft_id": draft["id"]}))
+            batch = _payload(
+                await growth_mcp._propose_send_batch_handler({"draft_ids": [draft["id"]]})
+            )
+
+        assert read["total"] == 1
+        for denial in (single, batch):
+            assert denial["ok"] is False
+            assert denial["denied"] is True
+            assert denial["code"]
+
+        # And nothing was proposed.
+        assert await instinct_store.pending() == []
+        with _identity("w1", member_w1):
+            drafts = _payload(await growth_mcp._list_drafts_handler({}))
+        assert drafts["drafts"][0]["status"] == "draft"
+
+
+# ---------------------------------------------------------------------------
+# Input validation — a malformed call explains itself
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    @pytest.mark.asyncio
+    async def test_missing_required_ids_explain_themselves(self, mongo_db, admin_w1):
+        with _identity("w1", admin_w1):
+            assert "prospect_id" in _error_text(await growth_mcp._get_prospect_handler({}))
+            assert "prospect_id" in _error_text(await growth_mcp._create_draft_handler({}))
+            assert "draft_id" in _error_text(await growth_mcp._update_draft_handler({}))
+            assert "draft_id" in _error_text(await growth_mcp._propose_send_handler({}))
+            assert "draft_ids" in _error_text(
+                await growth_mcp._propose_send_batch_handler({"draft_ids": []})
+            )
+            assert "domain" in _error_text(await growth_mcp._upsert_prospect_handler({}))
+
+    @pytest.mark.asyncio
+    async def test_a_subject_on_a_non_email_channel_is_refused(self, mongo_db, admin_w1):
+        prospect = await _seed_prospect(admin_w1)
+        with _identity("w1", admin_w1):
+            response = await growth_mcp._create_draft_handler(
+                {
+                    "prospect_id": prospect["id"],
+                    "channel": "whatsapp",
+                    "subject": "not allowed here",
+                    "body": "Hi Sam!",
+                }
+            )
+        assert response.get("is_error")
+
+    @pytest.mark.asyncio
+    async def test_an_empty_body_is_refused(self, mongo_db, admin_w1):
+        prospect = await _seed_prospect(admin_w1)
+        with _identity("w1", admin_w1):
+            response = await growth_mcp._create_draft_handler(
+                {"prospect_id": prospect["id"], "channel": "email", "body": "   "}
+            )
+        assert response.get("is_error")

--- a/tests/cloud/growth/test_mcp_server.py
+++ b/tests/cloud/growth/test_mcp_server.py
@@ -628,6 +628,28 @@ class TestRbac:
 
 class TestValidation:
     @pytest.mark.asyncio
+    async def test_a_new_prospect_needs_a_name_and_a_company(self, mongo_db, admin_w1):
+        """Only an ENRICHMENT call may omit them — there is nothing stored to
+        carry forward on a create, and an "unknown / unknown" row is worse than
+        a refusal the agent can act on."""
+        with _identity("w1", admin_w1):
+            refused = await growth_mcp._upsert_prospect_handler({"domain": "nobody.com"})
+            assert "needs `name` and `company`" in _error_text(refused)
+            listed = _payload(await growth_mcp._list_prospects_handler({}))
+        assert listed["total"] == 0
+
+        # Once the row exists, a domain-only enrichment is fine.
+        prospect = await _seed_prospect(admin_w1)
+        with _identity("w1", admin_w1):
+            enriched = _payload(
+                await growth_mcp._upsert_prospect_handler(
+                    {"domain": prospect["domain"], "tier": "c"}
+                )
+            )["prospect"]
+        assert enriched["tier"] == "c"
+        assert enriched["name"] == "Sam Founder"
+
+    @pytest.mark.asyncio
     async def test_missing_required_ids_explain_themselves(self, mongo_db, admin_w1):
         with _identity("w1", admin_w1):
             assert "prospect_id" in _error_text(await growth_mcp._get_prospect_handler({}))

--- a/tests/ee/test_mcp_claude_sdk.py
+++ b/tests/ee/test_mcp_claude_sdk.py
@@ -73,6 +73,7 @@ from unittest.mock import patch
 
 from pocketpaw_ee.agent.mcp_servers.ask import SERVER_NAME as _ASK_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.belt import SERVER_NAME as _BELT_MCP_SERVER_NAME
+from pocketpaw_ee.agent.mcp_servers.code import SERVER_NAME as _CODE_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.connectors import SERVER_NAME as _CONNECTORS_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.daytona import SERVER_NAME as _DAYTONA_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.decisions import SERVER_NAME as _DECISIONS_MCP_SERVER_NAME
@@ -84,6 +85,7 @@ from pocketpaw_ee.agent.mcp_servers.external_actions import (
 )
 from pocketpaw_ee.agent.mcp_servers.fabric import SERVER_NAME as _FABRIC_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.foresight import SERVER_NAME as _FORESIGHT_MCP_SERVER_NAME
+from pocketpaw_ee.agent.mcp_servers.growth import SERVER_NAME as _GROWTH_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.icons import SERVER_NAME as _ICONS_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.instinct import SERVER_NAME as _INSTINCT_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.loom import SERVER_NAME as _LOOM_MCP_SERVER_NAME
@@ -95,6 +97,7 @@ from pocketpaw_ee.agent.mcp_servers.planner import (
 )
 from pocketpaw_ee.agent.mcp_servers.planner import SERVER_NAME as _PLANNER_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.pockets import SERVER_NAME as _POCKET_MCP_SERVER_NAME
+from pocketpaw_ee.agent.mcp_servers.ship import SERVER_NAME as _SHIP_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.sites import SERVER_NAME as _SITES_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.stock_images import SERVER_NAME as _STOCK_MCP_SERVER_NAME
 from pocketpaw_ee.agent.mcp_servers.tasks import SERVER_NAME as _TASKS_MCP_SERVER_NAME
@@ -185,6 +188,17 @@ def _strip_builtin_servers(result: dict) -> dict:
     # the RBAC gate on each tool is the security boundary, not registration
     # (WA-1, feat/workspace-admin-tools).
     out.pop(_WORKSPACE_ADMIN_MCP_SERVER_NAME, None)
+    # ``pocketpaw_growth`` is always-on too — the /growth rail's agent surface
+    # (prospect + draft reads, authoring writes, and the PROPOSE verbs). It
+    # sends nothing; the Instinct gate is the security boundary, not
+    # registration. Same regime as belt / ship / workspace_admin.
+    out.pop(_GROWTH_MCP_SERVER_NAME, None)
+    # ``pocketpaw_code`` (CD-3) and ``pocketpaw_ship`` (SHIP-4) are always-on as
+    # well and were never added here when they landed — every assertion in this
+    # class has been failing on their names since. Stripped now so the file
+    # measures what it claims to measure: EXTERNAL config.
+    out.pop(_CODE_MCP_SERVER_NAME, None)
+    out.pop(_SHIP_MCP_SERVER_NAME, None)
     return out
 
 


### PR DESCRIPTION
`/growth` now has a chat rail (paw-enterprise#707), and until this lands that
rail is an agent that can discuss your prospects but can't touch one. Every
other verb surface has an MCP server; this is growth's.

`pocketpaw_growth`, nine tools, all of them through `cloud.growth.service`:

| Tool | RBAC |
|---|---|
| `growth_list_prospects` — filters, `q`, `sort`, `cursor` | `growth.read` |
| `growth_get_prospect` — the record plus its drafts | `growth.read` |
| `growth_list_drafts` | `growth.read` |
| `growth_linkedin_queue` | `growth.read` |
| `growth_upsert_prospect` | `growth.write` |
| `growth_create_draft` / `growth_update_draft` | `growth.write` |
| `growth_propose_send` / `growth_propose_send_batch` | `growth.manage` |

Registered through a `pocketpaw.mcp_servers` entry point and added to the
import-linter Growth contract's source modules, so a Beanie import from the
agent surface breaks CI rather than review.

## The gate

The agent's reach stops at a **proposed** draft. No tool sends. No write tool
takes a `status` argument — the only `status` enum on the surface is a read
filter on `growth_list_drafts`, and it moves nothing. Neither
`gate_transition` nor `mark_linkedin_sent` is referenced in the module.

`TestTheGateHolds` asserts that against the tool list and the schemas rather
than against today's tools, so a future tool that opens the door fails the
suite. A dynamic pass drives every tool and asserts the drafts stopped at
`proposed`.

## Three things beyond the brief

**`service.update_draft` + `PATCH /growth/drafts/{id}`.** `growth_update_draft`
had no backing service function. The new one refuses anything past `draft` with
403 `draft.not_editable` — from `proposed` on, the stored body is what the Tray
shows a human and what the worker puts on the wire, so an edit there is a send
bypass wearing an edit's clothes. Exposed over HTTP too, since the UI wants the
same thing.

**`growth_list_drafts`.** `propose_send_batch` is unusable without a way to
collect draft ids across prospects; `get_prospect` reaches one at a time.

**`cursor` on `growth_list_prospects`.** The page already returns
`next_cursor`; without the argument the agent can't reach row 200.

`growth_upsert_prospect` merges rather than replaces. `upsert_by_domain`
overwrites every mutable field, so a naive re-upsert would reset a prospect in
`in_sequence` back to `new` and blank whatever the agent didn't repeat. The
handler reads the row first and carries the rest forward. Prospect status is
never settable by the agent.

## Tests

268 pass in `tests/cloud/growth/` (28 new MCP tests, 6 new draft-edit tests),
43 across the MCP registry and instinct, both import-linter configs clean.
`tests/ee/` minus sites: 1604 passed, 1 skipped.

`tests/ee/sites` is 61 failed / 3 errors and pre-existing — identical on the
base branch, nothing to do with growth.

One red this branch did cause and fixes: `test_mcp_claude_sdk.py`'s
`_strip_builtin_servers` needs every new ambient server listed. `pocketpaw_code`
and `pocketpaw_ship` were never added when they landed, so that file had 6
failing assertions on the base branch. Green now.

## Worth knowing before merge

- **There is no `GROWTH` SurfaceKind.** The tools reach the agent anyway —
  `surface='growth'` falls back to `GENERIC`, whose default profile applies no
  MCP restriction, and this server is ambient. But the rail gets no preamble
  handler and no profile-scoped allowlist. Natural next slice; `GROWTH_TOOL_IDS`
  is exported ready for it.
- The entry point registers on `uv sync --dev --group ee` (editable installs
  cache entry points in dist-info). Deploy needs the same.
