### PR TITLE
feat(cloud): workspace agent-activity board (MEMBER, 24h window)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,17 @@ jobs:
           POCKETPAW_LLM_PROVIDER: "ollama"
           POCKETPAW_OLLAMA_HOST: "http://localhost:11434"
 
+      - name: Run agent activity tests
+        # Same addopts escape as the cockpit step above. This one guards a
+        # CROSS-TENANT property — the board is filtered to the caller's
+        # workspace at the query — so it must not sit in the tests/cloud blind
+        # spot: a dropped filter would be a silent leak between tenants that no
+        # other lane runs a test for.
+        run: uv run pytest tests/cloud/test_agent_activity.py -o addopts="" -q --tb=short
+        env:
+          POCKETPAW_LLM_PROVIDER: "ollama"
+          POCKETPAW_OLLAMA_HOST: "http://localhost:11434"
+
   import-linter:
     name: OSS-EE boundary
     runs-on: ubuntu-latest

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -976,19 +976,27 @@ across multiple workers, and intact after a restart.
 ### `GET /agent-activity`
 
 One entry per agent in the caller's workspace with at least one run in the
-last **24 hours**. Requires the `agent_activity.read` action (MEMBER — this
-is the caller's own workspace data). Takes no query params; tenancy comes
-from the auth context and a `workspace_id` query param is **rejected**
-(`400`), not ignored.
+last **24 hours**. Requires the `agent_activity.read` action (MEMBER). Takes
+no query params; tenancy comes from the auth context and a `workspace_id`
+query param is **rejected** (`400`), not ignored.
+
+This is a **team board**: it covers every member's runs, not just the
+caller's. An Agent is a workspace resource, so its aggregate state is shared.
+The individual turn is not — the response carries no `user_id`, no run id and
+no message content, and `GET /cloud/chat/runs/{run_id}/stream` still returns
+`404` for a run belonging to another member.
+
+`agent_id` is the agent's ObjectId hex (`Agent._id`), the same key
+`GET /agents` returns — not a display name.
 
 Response `200`:
 
 ```json
 { "agents": [
-    { "agent_id": "researcher", "status": "active", "active_runs": 2,
-      "last_active": "2026-07-28T11:58:04+00:00", "last_run_id": "run_9f2c" },
-    { "agent_id": "editor", "status": "blocked", "active_runs": 0,
-      "last_active": "2026-07-28T10:12:44+00:00", "last_run_id": "run_71ab" }
+    { "agent_id": "66f1a2b3c4d5e6f708192a3b", "status": "active",
+      "active_runs": 2, "last_active": "2026-07-28T11:58:04+00:00" },
+    { "agent_id": "66f1a2b3c4d5e6f708192a3c", "status": "blocked",
+      "active_runs": 0, "last_active": "2026-07-28T10:12:44+00:00" }
   ],
   "ts": "2026-07-28T12:00:00+00:00" }
 ```

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -962,6 +962,60 @@ conversion, a pricing-rules engine, and disputes / clawback. This endpoint
 returns a raw sum of declared values — the queryable figure those layers
 will build on later (see `outcome-spec.md`).
 
+## Agent Activity
+
+HR-12a. The workspace-scoped answer to "which of my agents are working
+right now". Distinct from the herdr cockpit (`GET /cockpit/*`), which reads
+terminal panes on one operator box, is ADMIN-only, and never shows a `/chat`
+agent — that agent runs as an in-process SDK client, not a pane.
+
+The board is built from `ChatRunDoc`, the durable per-turn record, so it is
+correct whether runs execute in the web process or an arq worker, complete
+across multiple workers, and intact after a restart.
+
+### `GET /agent-activity`
+
+One entry per agent in the caller's workspace with at least one run in the
+last **24 hours**. Requires the `agent_activity.read` action (MEMBER — this
+is the caller's own workspace data). Takes no query params; tenancy comes
+from the auth context and a `workspace_id` query param is **rejected**
+(`400`), not ignored.
+
+Response `200`:
+
+```json
+{ "agents": [
+    { "agent_id": "researcher", "status": "active", "active_runs": 2,
+      "last_active": "2026-07-28T11:58:04+00:00", "last_run_id": "run_9f2c" },
+    { "agent_id": "editor", "status": "blocked", "active_runs": 0,
+      "last_active": "2026-07-28T10:12:44+00:00", "last_run_id": "run_71ab" }
+  ],
+  "ts": "2026-07-28T12:00:00+00:00" }
+```
+
+`status` uses the Mission Control `AgentStatus` vocabulary, the same one
+the cockpit's pane dots use:
+
+| Status | Meaning |
+|--------|---------|
+| `active` | The agent has at least one `queued` or `running` run. Wins over any earlier failure. |
+| `blocked` | No live run, and the agent's newest run `failed` or was `interrupted`. |
+| `idle` | No live run, and the newest run `completed` or was `cancelled` (a user stopping their own turn does not block the agent). |
+
+Agents with **no run in the window are omitted** rather than returned as
+`offline`: this surface reads runs, not the agent roster. A client that
+wants every configured agent joins this board against `GET /agents` and
+treats the absent ones as offline.
+
+`active_runs` is how many of that agent's runs are live now; `last_active`
+is the newest run's end, else its start, else its creation; `last_run_id`
+identifies that run. Entries are ordered working-first, then most recently
+active. `ts` stamps when the board was built.
+
+v1 is a plain GET for the client to poll. A push stream is the upgrade path
+if polling stops being enough — event-driven off the existing run-status
+transitions, not a faster poll.
+
 ## Files — Versioned Writes
 
 The `file_versions` entity layers a versioned write path over the uploads

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -227,6 +227,7 @@ def mount_cloud(app: FastAPI) -> None:
     import pocketpaw_ee.cloud.ripple_sources  # noqa: F401
 
     # Import and mount domain routers
+    from pocketpaw_ee.cloud.agent_activity.router import router as agent_activity_router
     from pocketpaw_ee.cloud.agents.router import router as agents_router
     from pocketpaw_ee.cloud.audit.router import router as audit_router
     from pocketpaw_ee.cloud.audit.router import workspace_router as audit_workspace_router
@@ -307,6 +308,12 @@ def mount_cloud(app: FastAPI) -> None:
     # (GET /cockpit/pane/{id}/preview). Fails open when herdr is disabled/absent;
     # panes are NOT paw-workspace-scoped yet, hence ADMIN-only (see router).
     app.include_router(herdr_cockpit_router, prefix="/api/v1")
+    # Agent activity (HR-12a) — the product-facing counterpart to the cockpit
+    # above: GET /agent-activity, MEMBER-gated, one entry per agent in the
+    # CALLER'S workspace with a run in the last 24h. Reads the durable
+    # ChatRunDoc turn record through chat.runs.service, so it sees /chat agents
+    # (which never appear as herdr panes) and stays correct across arq workers.
+    app.include_router(agent_activity_router, prefix="/api/v1")
     app.include_router(connectors_router, prefix="/api/v1")
     # Discovery — zero-setup workspace-discovery TRIGGER
     # (POST /cloud/discovery/run). Workspace-scoped (no path param); fires the

--- a/ee/pocketpaw_ee/cloud/agent_activity/__init__.py
+++ b/ee/pocketpaw_ee/cloud/agent_activity/__init__.py
@@ -1,0 +1,17 @@
+# agent_activity — "which of MY agents are working right now", per workspace.
+#
+# Created: 2026-07-28 (feat/cockpit-agent-activity, HR-12a) — the product-facing
+# counterpart to the herdr cockpit. The cockpit reads terminal panes on one
+# operator box: it is ADMIN-gated, not paw-workspace-scoped, and a user's /chat
+# agent never appears in it (it runs as an in-process SDK client, not a pane).
+# This module answers the question the cockpit cannot, from the durable turn
+# record instead of a box's panes.
+#
+# Source of truth is ``ChatRunDoc`` via ``chat.runs.service`` — durable in Mongo,
+# workspace-scoped, complete across web workers and arq workers, and intact after
+# a restart. The SessionSupervisor's in-memory ``_runtimes`` registry is NOT used:
+# it is empty when runs execute in arq workers, partial across multiple web
+# workers, and lost on restart, which makes it unsound on shared multi-tenant
+# cloud — exactly where this board runs.
+#
+# Read-only by design: no write path, no mutation, no herdr access.

--- a/ee/pocketpaw_ee/cloud/agent_activity/dto.py
+++ b/ee/pocketpaw_ee/cloud/agent_activity/dto.py
@@ -1,0 +1,50 @@
+# dto.py — wire schemas for the workspace agent-activity board.
+#
+# Created: 2026-07-28 (feat/cockpit-agent-activity, HR-12a) — response-only:
+# the endpoint takes no body and no filters, so there is no request model.
+# Tenancy is never a field here — the workspace comes from the auth context and
+# is applied at the query (see router.py / service.py).
+#
+# ``status`` is a Mission Control ``AgentStatus`` value string, the same
+# vocabulary the herdr cockpit's pane dots use, so one UI legend covers both
+# boards.
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class AgentActivityOut(BaseModel):
+    """One agent's activity in the caller's workspace over the recent window.
+
+    ``status`` is an ``AgentStatus`` value (``active`` | ``blocked`` | ``idle``).
+    ``active_runs`` is how many of this agent's runs are currently ``queued`` or
+    ``running`` — 0 whenever the status is not ``active``. ``last_active`` is an
+    ISO-8601 UTC timestamp of the most recent state change on the agent's newest
+    run (its end, else its start, else its creation), and ``last_run_id``
+    identifies that run so a client can deep-link to the turn.
+
+    An agent with no run in the window is absent from the board entirely rather
+    than reported ``offline`` — see ``service.build_activity``.
+    """
+
+    agent_id: str
+    status: str
+    active_runs: int
+    last_active: str
+    last_run_id: str
+
+
+class AgentActivityResponse(BaseModel):
+    """The workspace's agent-activity board at one instant.
+
+    ``agents`` is ordered for display: working agents first, then most recently
+    active. ``ts`` is the ISO-8601 UTC time the board was built — a polling
+    client uses it to label staleness.
+    """
+
+    agents: list[AgentActivityOut]
+    ts: str
+
+
+__all__ = ["AgentActivityOut", "AgentActivityResponse"]

--- a/ee/pocketpaw_ee/cloud/agent_activity/dto.py
+++ b/ee/pocketpaw_ee/cloud/agent_activity/dto.py
@@ -21,18 +21,23 @@ class AgentActivityOut(BaseModel):
     ``active_runs`` is how many of this agent's runs are currently ``queued`` or
     ``running`` — 0 whenever the status is not ``active``. ``last_active`` is an
     ISO-8601 UTC timestamp of the most recent state change on the agent's newest
-    run (its end, else its start, else its creation), and ``last_run_id``
-    identifies that run so a client can deep-link to the turn.
+    run (its end, else its start, else its creation).
 
     An agent with no run in the window is absent from the board entirely rather
     than reported ``offline`` — see ``service.build_activity``.
+
+    Deliberately NOT here: a run id. This is a TEAM board (see the router
+    header), so an agent's newest run often belongs to a different member — and
+    ``chat.runs.router._authorize`` 404s another member's run by design. A run
+    id would therefore be a handle the recipient cannot open, while still
+    proving that specific run exists. Aggregate agent state is the shared fact;
+    an individual member's turn is not.
     """
 
     agent_id: str
     status: str
     active_runs: int
     last_active: str
-    last_run_id: str
 
 
 class AgentActivityResponse(BaseModel):

--- a/ee/pocketpaw_ee/cloud/agent_activity/router.py
+++ b/ee/pocketpaw_ee/cloud/agent_activity/router.py
@@ -1,0 +1,68 @@
+# router.py — FastAPI router for the workspace agent-activity board (HR-12a).
+#
+# Created: 2026-07-28 (feat/cockpit-agent-activity) — one read-only route:
+#   * GET /agent-activity — the caller's workspace, one entry per agent with a
+#     run in the recent window.
+#
+# Discipline (ee/cloud 4-file rules): no logic and no Beanie doc here — the fold
+# lives in service.py, and the runs it folds come from ``chat.runs.service``,
+# the only module allowed to touch ``ChatRunDoc``. Mounted under /api/v1 from
+# ee/pocketpaw_ee/cloud/__init__.py.
+#
+# Auth: MEMBER, via a new ``agent_activity.read`` action. This is the caller's
+# OWN workspace data — its agents, its runs — so it sits at the same bar as
+# ``session.read_own`` / ``outcomes.read``. It deliberately does NOT reuse the
+# herdr cockpit's ADMIN ``cockpit.read``: that guards a host-level surface whose
+# panes are not paw-workspace-scoped, which is precisely why it is admin-only.
+# Different surface, different tenancy story, different action.
+#
+# v1 is a plain GET, polled by the client. An SSE stream like the cockpit's was
+# rejected on cost: the cockpit re-polls a local subprocess for one operator,
+# whereas this would be a Mongo query every 1.5s per connected user across the
+# whole tenant base. The upgrade path when polling stops being enough is
+# event-driven, not a faster poll: ``run_core`` already marks every run
+# transition through ``chat.runs.service``, so those marks can publish a
+# ``run.status_changed`` event on the realtime bus and this surface can gain a
+# push stream that only wakes on a real state change.
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Request
+
+from pocketpaw_ee.cloud._core.deps import current_workspace_id, require_action_any_workspace
+from pocketpaw_ee.cloud._core.errors import CloudError
+from pocketpaw_ee.cloud.agent_activity import service
+from pocketpaw_ee.cloud.agent_activity.dto import AgentActivityResponse
+from pocketpaw_ee.cloud.license import require_license
+
+router = APIRouter(
+    prefix="/agent-activity",
+    tags=["Agent Activity"],
+    dependencies=[Depends(require_license)],
+)
+
+
+@router.get(
+    "",
+    response_model=AgentActivityResponse,
+    dependencies=[Depends(require_action_any_workspace("agent_activity.read"))],
+)
+async def get_agent_activity(
+    request: Request,
+    workspace_id: str = Depends(current_workspace_id),
+) -> AgentActivityResponse:
+    """Which of the caller's agents are working right now.
+
+    One entry per agent with at least one run in the last
+    ``service.RECENT_WINDOW``; agents with nothing recent are omitted. Tenancy
+    comes from the auth context — a ``workspace_id`` query param is rejected
+    rather than ignored, so a caller can never read another workspace's board
+    and nobody can later make that param real by accident.
+    """
+    if "workspace_id" in request.query_params:
+        raise CloudError(
+            400,
+            "agent_activity.workspace_id_forbidden",
+            "workspace_id is taken from auth context, not query",
+        )
+    return await service.build_activity(workspace_id)

--- a/ee/pocketpaw_ee/cloud/agent_activity/router.py
+++ b/ee/pocketpaw_ee/cloud/agent_activity/router.py
@@ -9,12 +9,29 @@
 # the only module allowed to touch ``ChatRunDoc``. Mounted under /api/v1 from
 # ee/pocketpaw_ee/cloud/__init__.py.
 #
-# Auth: MEMBER, via a new ``agent_activity.read`` action. This is the caller's
-# OWN workspace data — its agents, its runs — so it sits at the same bar as
-# ``session.read_own`` / ``outcomes.read``. It deliberately does NOT reuse the
-# herdr cockpit's ADMIN ``cockpit.read``: that guards a host-level surface whose
-# panes are not paw-workspace-scoped, which is precisely why it is admin-only.
-# Different surface, different tenancy story, different action.
+# Auth: MEMBER, via a new ``agent_activity.read`` action. It deliberately does
+# NOT reuse the herdr cockpit's ADMIN ``cockpit.read``: that guards a host-level
+# surface whose panes are not paw-workspace-scoped, which is precisely why it is
+# admin-only. Different surface, different tenancy story, different action.
+#
+# THIS IS A TEAM BOARD — a deliberate decision, recorded here because it departs
+# from a sibling in the same entity. ``chat.runs.router._authorize`` 404s a run
+# belonging to another member of the same workspace, commented "so we don't leak
+# run existence to a workspace teammate who didn't own the run". This board does
+# NOT filter on ``user_id``: every member sees every agent's aggregate state.
+#
+# Why the departure is intended rather than an oversight: an Agent is a
+# WORKSPACE resource, not a personal one — several members share one agent, and
+# "is this agent busy right now" is the shared fact a team needs to coordinate
+# around. What stays private is the individual turn: the board carries agent
+# state, run COUNTS and timing, never message content, never ``user_id``, and
+# (see dto.py) never a run id, so it cannot be used as a handle to open a
+# teammate's run. ``/cloud/chat/runs/{run_id}/stream`` remains 404 for a
+# non-owner, unchanged.
+#
+# If this should ever become a personal board, the change is one filter on both
+# reads in ``chat.runs.service`` plus flipping ``test_team_board_shows_every_
+# members_activity`` — which exists to make that a conscious edit, not a drift.
 #
 # v1 is a plain GET, polled by the client. An SSE stream like the cockpit's was
 # rejected on cost: the cockpit re-polls a local subprocess for one operator,

--- a/ee/pocketpaw_ee/cloud/agent_activity/service.py
+++ b/ee/pocketpaw_ee/cloud/agent_activity/service.py
@@ -134,7 +134,6 @@ async def build_activity(
                 status=_status_for(rows, newest).value,
                 active_runs=sum(1 for r in rows if r.status in runs_service.ACTIVE_RUN_STATUSES),
                 last_active=_last_activity_at(newest).isoformat(),
-                last_run_id=newest.run_id,
             )
         )
 

--- a/ee/pocketpaw_ee/cloud/agent_activity/service.py
+++ b/ee/pocketpaw_ee/cloud/agent_activity/service.py
@@ -1,0 +1,150 @@
+# service.py — folds a workspace's recent runs into a per-agent activity board.
+#
+# Created: 2026-07-28 (feat/cockpit-agent-activity, HR-12a) — all the logic of
+# this surface lives here; the router is a thin HTTP shell.
+#
+# This module never imports a Beanie document. ``ChatRunDoc`` is owned by
+# ``chat.runs.service`` (EE Rule 1), which hands back ``RunActivityRow`` value
+# objects; the workspace filter and the window therefore live at the query, not
+# in a post-filter here — there is no code path in which rows for another
+# workspace reach this fold at all.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from pocketpaw.mission_control.models import AgentStatus
+from pocketpaw_ee.cloud.agent_activity.dto import AgentActivityOut, AgentActivityResponse
+from pocketpaw_ee.cloud.chat.runs import service as runs_service
+from pocketpaw_ee.cloud.chat.runs.domain import RunActivityRow
+
+# How far back a run counts as "recent". Bounds every query this module makes
+# and keeps the read on the indexed prefix of ChatRunDoc's
+# (workspace, context_type, scope_id, createdAt) index. An agent whose last run
+# fell out of this window drops off the board.
+RECENT_WINDOW = timedelta(hours=24)
+
+# Hard caps on rows pulled per request, so one busy workspace can never turn a
+# board refresh into an unbounded scan. The active cap is the smaller of the two
+# because concurrent runs are naturally few; the recent cap is what a very busy
+# workspace's 24h of chat turns is truncated to (newest first — see
+# ``find_recent_runs_for_workspace``).
+MAX_ACTIVE_RUNS_SCANNED = 200
+MAX_RECENT_RUNS_SCANNED = 500
+
+# A terminal run in one of these states means the agent stopped short of an
+# answer, which is the "needs a human" signal BLOCKED carries on the cockpit.
+# ``cancelled`` is excluded deliberately: a user who stops their own turn has
+# not blocked the agent, so that agent reads IDLE.
+_BLOCKED_STATUSES = frozenset({"failed", "interrupted"})
+
+
+def _as_utc(value: datetime) -> datetime:
+    """Attach UTC to a naive datetime so timestamps are always comparable.
+
+    Runs are written with tz-aware UTC, but a document that round-trips through
+    BSON comes back naive — mixing the two raises TypeError on comparison.
+    """
+    return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+
+
+def _last_activity_at(row: RunActivityRow) -> datetime:
+    """When this run last changed state: its end, else its start, else creation.
+
+    A live run has no ``ended_at``, so it reports when it started; a queued run
+    has neither and reports when it was created.
+    """
+    return _as_utc(row.ended_at or row.started_at or row.created_at)
+
+
+def _newest_first(iso_timestamp: str) -> float:
+    """Sort key that orders ISO-8601 timestamps newest-first inside an
+    otherwise ascending tuple sort."""
+    return -datetime.fromisoformat(iso_timestamp).timestamp()
+
+
+def _status_for(rows: list[RunActivityRow], newest: RunActivityRow) -> AgentStatus:
+    """Map an agent's runs onto the Mission Control status vocabulary.
+
+    ACTIVE beats everything: an agent with work in flight is working, whatever
+    its previous turn did. Otherwise the newest run decides — it failed or was
+    interrupted (BLOCKED), or it finished (IDLE).
+    """
+    if any(r.status in runs_service.ACTIVE_RUN_STATUSES for r in rows):
+        return AgentStatus.ACTIVE
+    if newest.status in _BLOCKED_STATUSES:
+        return AgentStatus.BLOCKED
+    return AgentStatus.IDLE
+
+
+async def build_activity(
+    workspace_id: str,
+    *,
+    now: datetime | None = None,
+) -> AgentActivityResponse:
+    """Build the agent-activity board for one workspace.
+
+    Two windowed reads rather than one: the recent read is capped, so on a very
+    busy workspace a long-running turn started hours ago could be truncated out
+    of it — and losing precisely the agent that IS working would defeat the
+    board. The active read carries those rows independently of that cap.
+
+    Agents with no run in ``RECENT_WINDOW`` are OMITTED rather than reported
+    ``OFFLINE``. Rendering OFFLINE would mean knowing the workspace's full agent
+    roster, which this module deliberately does not read (it would couple an
+    activity view to the agents entity); and a configured-but-unused agent is
+    not "not responding" — it simply has no activity to show. A client that
+    wants an exhaustive roster joins this board against ``GET /agents`` and
+    treats the absent ones as offline.
+
+    ``now`` is injectable so tests can pin the window edge.
+    """
+    now = now or datetime.now(UTC)
+    since = now - RECENT_WINDOW
+
+    active_rows = await runs_service.find_active_runs_for_workspace(
+        workspace_id=workspace_id,
+        since=since,
+        limit=MAX_ACTIVE_RUNS_SCANNED,
+    )
+    recent_rows = await runs_service.find_recent_runs_for_workspace(
+        workspace_id=workspace_id,
+        since=since,
+        limit=MAX_RECENT_RUNS_SCANNED,
+    )
+
+    # The two reads overlap (an active run is also a recent run), so dedupe by
+    # run_id or a live run would be counted twice in ``active_runs``.
+    by_agent: dict[str, list[RunActivityRow]] = {}
+    seen: set[str] = set()
+    for row in (*active_rows, *recent_rows):
+        if row.run_id in seen:
+            continue
+        seen.add(row.run_id)
+        by_agent.setdefault(row.agent_id, []).append(row)
+
+    agents: list[AgentActivityOut] = []
+    for agent_id, rows in by_agent.items():
+        # ``run_id`` breaks ties so two runs created in the same millisecond
+        # can't reorder the board between two otherwise identical polls.
+        newest = max(rows, key=lambda r: (_as_utc(r.created_at), r.run_id))
+        agents.append(
+            AgentActivityOut(
+                agent_id=agent_id,
+                status=_status_for(rows, newest).value,
+                active_runs=sum(1 for r in rows if r.status in runs_service.ACTIVE_RUN_STATUSES),
+                last_active=_last_activity_at(newest).isoformat(),
+                last_run_id=newest.run_id,
+            )
+        )
+
+    # Working agents first, then most recently active, then by id for a stable
+    # order across polls.
+    agents.sort(
+        key=lambda a: (
+            a.status != AgentStatus.ACTIVE.value,
+            _newest_first(a.last_active),
+            a.agent_id,
+        )
+    )
+    return AgentActivityResponse(agents=agents, ts=now.isoformat())

--- a/ee/pocketpaw_ee/cloud/chat/runs/domain.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/domain.py
@@ -17,10 +17,18 @@ Same boundary reason as ``surface`` — the HTTP handler has the value but submi
 ``RunSpec`` to the executor, so without carrying it the executor's rebuilt ctx would
 never see the client's model choice. ``None`` (the default / older clients) leaves the
 backend's own model selection untouched, byte-identical to today. It's a bare ``str``,
-so it survives the pickle round-trip like every other field."""
+so it survives the pickle round-trip like every other field.
+
+Changes: 2026-07-28 (HR-12a, feat/cockpit-agent-activity) — added
+``RunActivityRow``, the read-side projection of a run. ``ChatRunDoc`` is owned by
+``chat.runs.service`` (EE Rule 1: Beanie only from service.py), so a consumer
+outside this entity — ``ee.cloud.agent_activity``, which answers "which of my
+agents are working right now" — reads runs as these Beanie-free value objects
+rather than importing the document class."""
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -56,3 +64,27 @@ class RunSpec(BaseModel):
     # must ride the spec to survive the submit. ``None`` = backend picks the model
     # (the legacy path). Validated at the HTTP edge before it ever reaches here.
     model_override: str | None = None
+
+
+class RunActivityRow(BaseModel):
+    """One run flattened to the fields an activity view needs (HR-12a).
+
+    The read-side counterpart to ``RunSpec``: no content, no history, no usage —
+    just who ran, in what state, and when. Beanie-free by design so
+    ``ee.cloud.agent_activity`` can fold runs into a per-agent board without
+    importing ``ChatRunDoc`` (which only ``chat.runs.service`` may touch).
+
+    ``workspace`` is deliberately absent: every read that produces these rows is
+    already filtered to one workspace by the service, so carrying the tenant key
+    onto the wire-adjacent projection would invite a caller to filter on it
+    themselves instead of at the query.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    run_id: str
+    agent_id: str
+    status: str
+    created_at: datetime
+    started_at: datetime | None = None
+    ended_at: datetime | None = None

--- a/ee/pocketpaw_ee/cloud/chat/runs/service.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/service.py
@@ -16,6 +16,12 @@ Changes:
   boundary (EE Rule 2 — only this module touches ``ChatRunDoc``). ``bill_run`` now
   calls ``mark_billed`` instead. Reading ``run_doc.usage`` in metering stays fine;
   only the WRITE moves here, the owner of the document.
+- 2026-07-28 (HR-12a, feat/cockpit-agent-activity) — the ``queued``/``running``
+  pair that three functions each spelled inline is now the named
+  ``ACTIVE_RUN_STATUSES`` constant, and two workspace-scoped reads were added
+  (``find_active_runs_for_workspace`` / ``find_recent_runs_for_workspace``) for
+  the agent-activity board. They return ``RunActivityRow`` value objects, not
+  ``ChatRunDoc``, so the caller never sees a Beanie document.
 """
 
 from __future__ import annotations
@@ -27,12 +33,30 @@ from typing import Any
 from pymongo.errors import DuplicateKeyError
 
 from pocketpaw_ee.cloud._core.errors import NotFound
-from pocketpaw_ee.cloud.chat.runs.domain import RunSpec
+from pocketpaw_ee.cloud.chat.runs.domain import RunActivityRow, RunSpec
 from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
+
+# A run is ACTIVE while it has been accepted but has not reached a terminal
+# state. One definition, one place: the scope lookup, the jail guard, and the
+# agent-activity board all read the same pair, so "is this agent working right
+# now" can never disagree with "is this scope busy".
+ACTIVE_RUN_STATUSES = ("queued", "running")
 
 
 def _utcnow() -> datetime:
     return datetime.now(UTC)
+
+
+def _to_activity_row(doc: ChatRunDoc) -> RunActivityRow:
+    """Project a run document onto the Beanie-free activity value object."""
+    return RunActivityRow(
+        run_id=doc.run_id,
+        agent_id=doc.agent_id,
+        status=doc.status,
+        created_at=doc.createdAt,
+        started_at=doc.started_at,
+        ended_at=doc.ended_at,
+    )
 
 
 async def create_run(spec: RunSpec) -> ChatRunDoc:
@@ -154,7 +178,7 @@ async def find_active_run_for_scope(
             ChatRunDoc.workspace == workspace_id,
             ChatRunDoc.scope_id == scope_id,
             ctype_filter,
-            {"status": {"$in": ["queued", "running"]}},
+            {"status": {"$in": list(ACTIVE_RUN_STATUSES)}},
         )
         .sort(-ChatRunDoc.createdAt)  # type: ignore[operator]
         .first_or_none()
@@ -164,7 +188,7 @@ async def find_active_run_for_scope(
 async def find_stale_running(older_than: datetime) -> list[ChatRunDoc]:
     """Runs left queued/running before a cutoff."""
     return await ChatRunDoc.find(
-        {"status": {"$in": ["queued", "running"]}},
+        {"status": {"$in": list(ACTIVE_RUN_STATUSES)}},
         ChatRunDoc.createdAt < older_than,
     ).to_list()
 
@@ -183,6 +207,68 @@ async def find_active_run_scopes() -> set[tuple[str, str, str]]:
     GC pass into deleting a jail it's about to reuse.
     """
     docs = await ChatRunDoc.find(
-        {"status": {"$in": ["queued", "running"]}},
+        {"status": {"$in": list(ACTIVE_RUN_STATUSES)}},
     ).to_list()
     return {(d.workspace, d.context_type, d.scope_id) for d in docs}
+
+
+# ---------------------------------------------------------------------------
+# Workspace-scoped activity reads (HR-12a)
+#
+# Both are TENANT-SCOPED by construction: ``workspace_id`` is a required
+# keyword and lands in the filter, so there is no call shape that returns
+# another workspace's runs. Both are also WINDOWED and CAPPED — an activity
+# board must never be able to ask Mongo for a workspace's whole run history.
+# The ``(workspace, context_type, scope_id, createdAt)`` index on ChatRunDoc
+# leads on ``workspace``, so the workspace + createdAt filter is served by its
+# prefix.
+# ---------------------------------------------------------------------------
+
+
+async def find_active_runs_for_workspace(
+    *,
+    workspace_id: str,
+    since: datetime,
+    limit: int,
+) -> list[RunActivityRow]:
+    """A workspace's currently-active (``queued``/``running``) runs, newest first.
+
+    Windowed like its sibling below on purpose: a run still marked ``running``
+    from days ago is a leaked run (that is what ``find_stale_running`` reaps),
+    not an agent at work, and showing it would pin an agent to ACTIVE forever.
+    """
+    docs = (
+        await ChatRunDoc.find(
+            ChatRunDoc.workspace == workspace_id,
+            ChatRunDoc.createdAt >= since,
+            {"status": {"$in": list(ACTIVE_RUN_STATUSES)}},
+        )
+        .sort(-ChatRunDoc.createdAt)  # type: ignore[operator]
+        .limit(limit)
+        .to_list()
+    )
+    return [_to_activity_row(d) for d in docs]
+
+
+async def find_recent_runs_for_workspace(
+    *,
+    workspace_id: str,
+    since: datetime,
+    limit: int,
+) -> list[RunActivityRow]:
+    """A workspace's runs of any status since ``since``, newest first.
+
+    Truncation is by newest-first, so a busy workspace loses its least-recently
+    active agents from the tail — never its live ones, which the active read
+    above surfaces independently of this cap.
+    """
+    docs = (
+        await ChatRunDoc.find(
+            ChatRunDoc.workspace == workspace_id,
+            ChatRunDoc.createdAt >= since,
+        )
+        .sort(-ChatRunDoc.createdAt)  # type: ignore[operator]
+        .limit(limit)
+        .to_list()
+    )
+    return [_to_activity_row(d) for d in docs]

--- a/ee/pocketpaw_ee/cloud/chat/runs/service.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/service.py
@@ -30,6 +30,7 @@ from collections.abc import Iterable
 from datetime import UTC, datetime
 from typing import Any
 
+from pydantic import BaseModel
 from pymongo.errors import DuplicateKeyError
 
 from pocketpaw_ee.cloud._core.errors import NotFound
@@ -47,7 +48,29 @@ def _utcnow() -> datetime:
     return datetime.now(UTC)
 
 
-def _to_activity_row(doc: ChatRunDoc) -> RunActivityRow:
+class _RunActivityProjection(BaseModel):
+    """Wire-minimal projection for the two activity reads (HR-12a).
+
+    Without this, both reads pull WHOLE run documents just to keep six fields —
+    and ``ChatRunDoc.partial_text`` holds the entire assistant answer (see
+    ``run_core`` writing ``partial_text=full_text``), plus ``usage``. On a
+    board polled every few seconds by every signed-in member, the recent read
+    would drag up to ``MAX_RECENT_RUNS_SCANNED`` full answers across the wire
+    and discard all of them; it also inflates the top-K sort buffer, which on a
+    workspace with long turns can reach Mongo's 32MB in-memory sort limit and
+    fail the endpoint outright. Field names mirror the document exactly so
+    ``_to_activity_row`` reads either shape.
+    """
+
+    run_id: str
+    agent_id: str
+    status: str
+    createdAt: datetime
+    started_at: datetime | None = None
+    ended_at: datetime | None = None
+
+
+def _to_activity_row(doc: ChatRunDoc | _RunActivityProjection) -> RunActivityRow:
     """Project a run document onto the Beanie-free activity value object."""
     return RunActivityRow(
         run_id=doc.run_id,
@@ -243,6 +266,7 @@ async def find_active_runs_for_workspace(
             ChatRunDoc.createdAt >= since,
             {"status": {"$in": list(ACTIVE_RUN_STATUSES)}},
         )
+        .project(_RunActivityProjection)
         .sort(-ChatRunDoc.createdAt)  # type: ignore[operator]
         .limit(limit)
         .to_list()
@@ -267,6 +291,7 @@ async def find_recent_runs_for_workspace(
             ChatRunDoc.workspace == workspace_id,
             ChatRunDoc.createdAt >= since,
         )
+        .project(_RunActivityProjection)
         .sort(-ChatRunDoc.createdAt)  # type: ignore[operator]
         .limit(limit)
         .to_list()

--- a/ee/pocketpaw_ee/cloud/models/chat_run.py
+++ b/ee/pocketpaw_ee/cloud/models/chat_run.py
@@ -73,4 +73,14 @@ class ChatRunDoc(Document):
             IndexModel([("run_id", 1)], unique=True),
             IndexModel([("workspace", 1), ("client_message_id", 1)], unique=True),
             [("workspace", 1), ("context_type", 1), ("scope_id", 1), ("createdAt", -1)],
+            # HR-12a. The activity board filters `workspace + createdAt >= since`
+            # and sorts `-createdAt`, with NO context_type / scope_id. The
+            # compound index above cannot serve that query: its unbounded middle
+            # keys mean `createdAt` is neither a usable range bound nor able to
+            # supply the sort, so the planner walks every run the workspace has
+            # ever had, then filters and sorts in memory. On an endpoint polled
+            # every few seconds by every signed-in member, that is a full history
+            # scan per tick. This two-key index makes the window a real bound and
+            # the sort an index walk.
+            IndexModel([("workspace", 1), ("createdAt", -1)]),
         ]

--- a/ee/pocketpaw_ee/guards/actions.py
+++ b/ee/pocketpaw_ee/guards/actions.py
@@ -56,6 +56,13 @@
 # AND its read feed exposes who-tried-to-egress-what; the whole surface is
 # owner-only, mirroring workspace.delete / billing.manage / instinct.activate.
 #
+# Updated: 2026-07-28 (feat/cockpit-agent-activity, HR-12a) — added
+# ``agent_activity.read`` (MEMBER) gating the workspace agent-activity board
+# (ee.cloud.agent_activity.router). MEMBER, not the ADMIN ``cockpit.read``
+# below: this surface reads the caller's OWN workspace runs and is scoped to
+# them at the query, so it carries the tenancy property that keeps the herdr
+# cockpit admin-only.
+#
 # Updated: 2026-07-24 (feat/herdr-cockpit-sse, HR-10a) — added ``cockpit.read``
 # (ADMIN) gating both routes of the herdr cockpit telemetry surface
 # (ee.cloud.herdr_cockpit.router). ADMIN (not MEMBER) because herdr panes are not
@@ -294,6 +301,15 @@ ACTIONS: dict[str, ActionRule] = {
     # single read action gates both the stream and the preview. TODO(track-b):
     # scope panes to the caller's workspace before relaxing this for multi-tenant.
     "cockpit.read": ActionRule(WorkspaceRole.ADMIN, "workspace.insufficient_role"),
+    # Agent activity — the workspace's own agent board (ee.cloud.agent_activity
+    # .router, HR-12a): which of MY agents are working right now. MEMBER, the
+    # same bar as session.read_own / outcomes.read, because every row is the
+    # caller's own workspace data — the board is built from ChatRunDoc rows
+    # filtered to the caller's workspace at the query, so there is no cross-tenant
+    # leak of the kind that forces ``cockpit.read`` above to stay ADMIN. Its
+    # payload is activity metadata only (agent id, status, run count, timestamps)
+    # — no message content, no credentials.
+    "agent_activity.read": ActionRule(WorkspaceRole.MEMBER, "workspace.insufficient_role"),
 }
 
 

--- a/ee/pocketpaw_ee/guards/actions.py
+++ b/ee/pocketpaw_ee/guards/actions.py
@@ -309,6 +309,18 @@ ACTIONS: dict[str, ActionRule] = {
     # leak of the kind that forces ``cockpit.read`` above to stay ADMIN. Its
     # payload is activity metadata only (agent id, status, run count, timestamps)
     # — no message content, no credentials.
+    #
+    # MEMBER is the whole RBAC statement for this surface, and it is deliberate:
+    # the board is workspace-WIDE, so any member sees every member's agent
+    # activity. That is the team-coordination fact an Agent — a workspace
+    # resource, not a personal one — exists to expose. It knowingly reads wider
+    # than ``chat.runs.router._authorize``, which hides another member's
+    # individual run; the split is aggregate-state-is-shared,
+    # individual-turn-is-private (no user_id, no run id, no content on the wire).
+    # Narrowing to a personal board would be a ``user_id`` filter on the two
+    # reads in ``chat.runs.service``, NOT a role change here — and raising this
+    # to ADMIN would hide the board from exactly the people who need it.
+    # See ee.cloud.agent_activity.router's header for the full rationale.
     "agent_activity.read": ActionRule(WorkspaceRole.MEMBER, "workspace.insufficient_role"),
 }
 

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -740,6 +740,24 @@ forbidden_modules = [
 ]
 
 [[tool.importlinter.contracts]]
+name = "AgentActivity — reads runs only through the chat-runs service"
+type = "forbidden"
+allow_indirect_imports = "true"
+# HR-12a. Unlike its siblings this entity owns NO document — it is a read-only
+# view over someone else's. The rule it pins is the one that makes that safe:
+# the activity board must reach ChatRunDoc only through
+# ``chat.runs.service``, which is where the workspace filter and the window
+# live. Import the doc here and the tenancy filter becomes this module's job
+# to remember on every future query — the exact shape of bug that leaks one
+# tenant's agents into another's board, and one a reviewer reads as a harmless
+# "query it directly, it's simpler" diff.
+#
+# Sourced from the PACKAGE (as_packages defaults to true) so submodules added
+# later are covered without anyone remembering to extend a file list.
+source_modules = ["pocketpaw_ee.cloud.agent_activity"]
+forbidden_modules = ["pocketpaw_ee.cloud.models.chat_run"]
+
+[[tool.importlinter.contracts]]
 name = "Tasks — Beanie writes only from service.py"
 type = "forbidden"
 allow_indirect_imports = "true"

--- a/tests/cloud/test_agent_activity.py
+++ b/tests/cloud/test_agent_activity.py
@@ -46,6 +46,7 @@ async def _run(
     run_id: str | None = None,
     minutes_ago: int = 5,
     ended: bool = True,
+    user_id: str = "u1",
 ) -> str:
     """Insert one ChatRunDoc. Returns its run_id.
 
@@ -54,7 +55,7 @@ async def _run(
     """
     from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
 
-    rid = run_id or f"r-{workspace}-{agent_id}-{status}-{minutes_ago}"
+    rid = run_id or f"r-{workspace}-{agent_id}-{status}-{minutes_ago}-{user_id}"
     created = NOW - timedelta(minutes=minutes_ago)
     terminal = status not in ("queued", "running")
     doc = ChatRunDoc(
@@ -63,7 +64,7 @@ async def _run(
         context_type="dm",
         scope_id=f"scope-{agent_id}",
         session_key=f"sess-{agent_id}",
-        user_id="u1",
+        user_id=user_id,
         agent_id=agent_id,
         client_message_id=f"cm-{rid}",
         user_message_id=f"um-{rid}",
@@ -87,7 +88,7 @@ async def _build(workspace: str = "w1"):
 
 async def test_board_shape(mongo_db):  # noqa: ARG001 — fixture initializes Beanie
     """Every entry carries the full wire shape, and ts stamps the build."""
-    rid = await _run(workspace="w1", agent_id="scout", status="completed", minutes_ago=3)
+    await _run(workspace="w1", agent_id="scout", status="completed", minutes_ago=3)
 
     board = await _build()
 
@@ -97,7 +98,6 @@ async def test_board_shape(mongo_db):  # noqa: ARG001 — fixture initializes Be
     assert entry.agent_id == "scout"
     assert entry.status == AgentStatus.IDLE.value
     assert entry.active_runs == 0
-    assert entry.last_run_id == rid
     assert entry.last_active == (NOW - timedelta(minutes=3)).isoformat()
 
 
@@ -209,6 +209,48 @@ async def test_working_agents_sort_first_then_most_recent(mongo_db):  # noqa: AR
 
 
 # ===========================================================================
+# Cross-MEMBER visibility — a decision, pinned so it can't drift silently
+# ===========================================================================
+
+
+async def test_team_board_shows_every_members_activity(mongo_db):  # noqa: ARG001
+    """The board is workspace-WIDE across members, ON PURPOSE.
+
+    ``chat.runs.router._authorize`` 404s another member's individual run so run
+    existence doesn't leak to a teammate. This board deliberately reads wider,
+    because an Agent is a WORKSPACE resource and "is this agent busy right now"
+    is the fact a team coordinates around. The split: aggregate state is shared,
+    the individual turn stays private — no user_id, no run id, no message
+    content crosses the wire.
+
+    If this should ever become a personal board, this test must be edited by
+    hand. That is the point of it — the narrowing should be a conscious change,
+    never a silent drift in either direction.
+    """
+    await _run(workspace="w1", agent_id="shared-agent", status="running", user_id="member-a")
+    await _run(
+        workspace="w1",
+        agent_id="other-agent",
+        status="completed",
+        minutes_ago=10,
+        user_id="member-b",
+    )
+
+    board = await _build("w1")
+
+    assert sorted(a.agent_id for a in board.agents) == ["other-agent", "shared-agent"]
+
+    # …and the private parts stay off the wire even on a team board.
+    payload = board.model_dump()
+    flat = str(payload)
+    assert "member-a" not in flat and "member-b" not in flat, "user_id must never surface"
+    for entry in payload["agents"]:
+        assert "last_run_id" not in entry, (
+            "a run id would be an unopenable handle to a teammate's run"
+        )
+
+
+# ===========================================================================
 # Cross-workspace isolation — the property this surface exists to hold
 # ===========================================================================
 
@@ -304,7 +346,6 @@ async def test_endpoint_returns_the_board(mongo_db):  # noqa: ARG001
             "status": "active",
             "active_runs": 1,
             "last_active": (NOW - timedelta(minutes=2)).isoformat(),
-            "last_run_id": "r-w1-a1-running-2",
         }
     ]
 

--- a/tests/cloud/test_agent_activity.py
+++ b/tests/cloud/test_agent_activity.py
@@ -1,0 +1,367 @@
+# tests/cloud/test_agent_activity.py — workspace agent-activity board (HR-12a).
+#
+# Created: 2026-07-28 (feat/cockpit-agent-activity) — pins the read-only board
+# end-to-end against REAL Beanie queries (mongomock-motor), because the property
+# that matters most here is a QUERY property: every read is filtered to the
+# caller's workspace. A Protocol fake in front of the service would assert the
+# fold and prove nothing about the filter, so runs are inserted as real
+# ChatRunDoc rows and the real ``chat.runs.service`` reads them back.
+#
+# Coverage:
+#   * service.build_activity — response shape; the four status mappings
+#     (active / blocked / idle / active-beats-a-failed-history); active_runs
+#     counting with no double-count across the two overlapping reads; the
+#     recency window edge; empty state.
+#   * CROSS-WORKSPACE ISOLATION — at the service AND over HTTP, including a
+#     caller who is a member of both workspaces.
+#   * router — the wire shape, ordering, the rejected workspace_id query param,
+#     and the auth gate (member 200 / unauthenticated 401) via the REAL RBAC
+#     guard and the REAL current_workspace_id dependency.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from fastapi import FastAPI  # noqa: E402
+from httpx import ASGITransport, AsyncClient  # noqa: E402
+from pocketpaw_ee.cloud.agent_activity import service  # noqa: E402
+
+from pocketpaw.mission_control.models import AgentStatus  # noqa: E402
+
+pytestmark = pytest.mark.asyncio
+
+NOW = datetime(2026, 7, 28, 12, 0, 0, tzinfo=UTC)
+
+
+async def _run(
+    *,
+    workspace: str,
+    agent_id: str,
+    status: str,
+    run_id: str | None = None,
+    minutes_ago: int = 5,
+    ended: bool = True,
+) -> str:
+    """Insert one ChatRunDoc. Returns its run_id.
+
+    Inserted directly (not through ``create_run``) so a test can express a
+    terminal run in one line; the READ path under test is the real service.
+    """
+    from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
+
+    rid = run_id or f"r-{workspace}-{agent_id}-{status}-{minutes_ago}"
+    created = NOW - timedelta(minutes=minutes_ago)
+    terminal = status not in ("queued", "running")
+    doc = ChatRunDoc(
+        run_id=rid,
+        workspace=workspace,
+        context_type="dm",
+        scope_id=f"scope-{agent_id}",
+        session_key=f"sess-{agent_id}",
+        user_id="u1",
+        agent_id=agent_id,
+        client_message_id=f"cm-{rid}",
+        user_message_id=f"um-{rid}",
+        status=status,  # type: ignore[arg-type]
+        createdAt=created,
+        started_at=None if status == "queued" else created,
+        ended_at=created if (terminal and ended) else None,
+    )
+    await doc.insert()
+    return rid
+
+
+async def _build(workspace: str = "w1"):
+    return await service.build_activity(workspace, now=NOW)
+
+
+# ===========================================================================
+# Shape + status mapping
+# ===========================================================================
+
+
+async def test_board_shape(mongo_db):  # noqa: ARG001 — fixture initializes Beanie
+    """Every entry carries the full wire shape, and ts stamps the build."""
+    rid = await _run(workspace="w1", agent_id="scout", status="completed", minutes_ago=3)
+
+    board = await _build()
+
+    assert board.ts == NOW.isoformat()
+    assert len(board.agents) == 1
+    entry = board.agents[0]
+    assert entry.agent_id == "scout"
+    assert entry.status == AgentStatus.IDLE.value
+    assert entry.active_runs == 0
+    assert entry.last_run_id == rid
+    assert entry.last_active == (NOW - timedelta(minutes=3)).isoformat()
+
+
+@pytest.mark.parametrize(
+    "status,expected",
+    [
+        ("queued", AgentStatus.ACTIVE),
+        ("running", AgentStatus.ACTIVE),
+        ("failed", AgentStatus.BLOCKED),
+        ("interrupted", AgentStatus.BLOCKED),
+        ("completed", AgentStatus.IDLE),
+        # A user who stopped their own turn did not block the agent.
+        ("cancelled", AgentStatus.IDLE),
+    ],
+)
+async def test_status_mapping(mongo_db, status, expected):  # noqa: ARG001
+    await _run(workspace="w1", agent_id="a1", status=status)
+
+    board = await _build()
+
+    assert [a.status for a in board.agents] == [expected.value]
+
+
+async def test_active_beats_a_failed_history(mongo_db):  # noqa: ARG001
+    """An agent with work in flight is ACTIVE even when its newest run failed.
+
+    Ordering matters: the failed run is the NEWER of the two, so a naive
+    "latest run decides" would report BLOCKED for an agent that is working.
+    """
+    await _run(workspace="w1", agent_id="a1", status="running", minutes_ago=30)
+    await _run(workspace="w1", agent_id="a1", status="failed", minutes_ago=2)
+
+    board = await _build()
+
+    entry = board.agents[0]
+    assert entry.status == AgentStatus.ACTIVE.value
+    assert entry.active_runs == 1
+
+
+async def test_active_runs_counts_each_live_run_once(mongo_db):  # noqa: ARG001
+    """The active and recent reads overlap; a live run must not count twice."""
+    await _run(workspace="w1", agent_id="a1", status="running", minutes_ago=9)
+    await _run(workspace="w1", agent_id="a1", status="queued", minutes_ago=4)
+    await _run(workspace="w1", agent_id="a1", status="completed", minutes_ago=40)
+
+    board = await _build()
+
+    assert board.agents[0].active_runs == 2
+
+
+async def test_last_active_uses_start_for_a_live_run(mongo_db):  # noqa: ARG001
+    """A running turn has no end yet, so it reports when it started."""
+    await _run(workspace="w1", agent_id="a1", status="running", minutes_ago=15)
+
+    board = await _build()
+
+    assert board.agents[0].last_active == (NOW - timedelta(minutes=15)).isoformat()
+
+
+# ===========================================================================
+# Window + empty state
+# ===========================================================================
+
+
+async def test_empty_state(mongo_db):  # noqa: ARG001
+    board = await _build()
+
+    assert board.agents == []
+    assert board.ts == NOW.isoformat()
+
+
+async def test_agent_outside_the_window_is_omitted(mongo_db):  # noqa: ARG001
+    """Nothing recent -> the agent is absent, not reported OFFLINE."""
+    await _run(workspace="w1", agent_id="stale", status="completed", minutes_ago=60 * 25)
+    await _run(workspace="w1", agent_id="fresh", status="completed", minutes_ago=60)
+
+    board = await _build()
+
+    assert [a.agent_id for a in board.agents] == ["fresh"]
+
+
+async def test_a_run_still_running_from_last_week_is_not_active(mongo_db):  # noqa: ARG001
+    """A leaked run must not pin an agent to ACTIVE forever.
+
+    The window bounds the ACTIVE read too, so a run left ``running`` past the
+    window (what ``find_stale_running`` reaps) drops off the board entirely
+    rather than showing an agent that has not worked in days as working.
+    """
+    await _run(workspace="w1", agent_id="ghost", status="running", minutes_ago=60 * 24 * 7)
+
+    board = await _build()
+
+    assert board.agents == []
+
+
+# ===========================================================================
+# Ordering
+# ===========================================================================
+
+
+async def test_working_agents_sort_first_then_most_recent(mongo_db):  # noqa: ARG001
+    await _run(workspace="w1", agent_id="idle-old", status="completed", minutes_ago=300)
+    await _run(workspace="w1", agent_id="idle-new", status="completed", minutes_ago=10)
+    await _run(workspace="w1", agent_id="busy", status="running", minutes_ago=200)
+
+    board = await _build()
+
+    assert [a.agent_id for a in board.agents] == ["busy", "idle-new", "idle-old"]
+
+
+# ===========================================================================
+# Cross-workspace isolation — the property this surface exists to hold
+# ===========================================================================
+
+
+async def test_service_never_returns_another_workspace(mongo_db):  # noqa: ARG001
+    await _run(workspace="w1", agent_id="mine", status="running")
+    await _run(workspace="w2", agent_id="theirs", status="running")
+    await _run(workspace="w2", agent_id="theirs-too", status="failed", minutes_ago=1)
+
+    w1 = await _build("w1")
+    w2 = await _build("w2")
+
+    assert [a.agent_id for a in w1.agents] == ["mine"]
+    assert sorted(a.agent_id for a in w2.agents) == ["theirs", "theirs-too"]
+
+
+async def test_same_agent_id_in_two_workspaces_does_not_bleed(mongo_db):  # noqa: ARG001
+    """The nastier shape: the same agent id exists in both tenants.
+
+    A missing workspace filter would merge the two into one entry — the run
+    count and status would silently describe the other tenant's activity.
+    """
+    await _run(workspace="w1", agent_id="shared", status="completed", minutes_ago=30)
+    await _run(workspace="w2", agent_id="shared", status="running", minutes_ago=5)
+    await _run(workspace="w2", agent_id="shared", status="running", minutes_ago=6)
+
+    w1 = await _build("w1")
+
+    assert len(w1.agents) == 1
+    entry = w1.agents[0]
+    assert entry.status == AgentStatus.IDLE.value
+    assert entry.active_runs == 0
+
+
+# ===========================================================================
+# Router / HTTP — real RBAC guard, real workspace dependency
+# ===========================================================================
+
+
+def _build_app(
+    *,
+    role: str | None = "member",
+    active_workspace: str = "w1",
+    memberships: list[str] | None = None,
+) -> FastAPI:
+    """App over the agent-activity router with the REAL RBAC guard.
+
+    ``role=None`` leaves ``current_active_user`` un-overridden, so the real
+    fastapi-users dependency runs and an anonymous request is rejected.
+    """
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.cloud.agent_activity.router import router
+    from pocketpaw_ee.cloud.auth import current_active_user
+    from pocketpaw_ee.cloud.license import require_license
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(router, prefix="/api/v1")
+    app.dependency_overrides[require_license] = lambda: None
+
+    if role is not None:
+        user = SimpleNamespace(
+            id="u1",
+            active_workspace=active_workspace,
+            workspaces=[
+                SimpleNamespace(workspace=w, role=role) for w in (memberships or [active_workspace])
+            ],
+        )
+
+        async def _fake_user():
+            return user
+
+        app.dependency_overrides[current_active_user] = _fake_user
+    return app
+
+
+def _client(app: FastAPI) -> AsyncClient:
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://t")
+
+
+async def test_endpoint_returns_the_board(mongo_db):  # noqa: ARG001
+    await _run(workspace="w1", agent_id="a1", status="running", minutes_ago=2)
+
+    async with _client(_build_app()) as client:
+        resp = await client.get("/api/v1/agent-activity")
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert set(body) == {"agents", "ts"}
+    assert body["agents"] == [
+        {
+            "agent_id": "a1",
+            "status": "active",
+            "active_runs": 1,
+            "last_active": (NOW - timedelta(minutes=2)).isoformat(),
+            "last_run_id": "r-w1-a1-running-2",
+        }
+    ]
+
+
+async def test_endpoint_is_scoped_to_the_callers_workspace(mongo_db):  # noqa: ARG001
+    """A caller who belongs to BOTH workspaces still sees only the active one.
+
+    Membership is not the filter — the active workspace is. This is the test
+    that would fail if the query ever stopped carrying the workspace.
+    """
+    await _run(workspace="w1", agent_id="mine", status="running")
+    await _run(workspace="w2", agent_id="theirs", status="running")
+
+    app = _build_app(active_workspace="w1", memberships=["w1", "w2"])
+    async with _client(app) as client:
+        resp = await client.get("/api/v1/agent-activity")
+
+    assert resp.status_code == 200, resp.text
+    assert [a["agent_id"] for a in resp.json()["agents"]] == ["mine"]
+
+
+async def test_endpoint_empty_state(mongo_db):  # noqa: ARG001
+    async with _client(_build_app()) as client:
+        resp = await client.get("/api/v1/agent-activity")
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["agents"] == []
+
+
+async def test_workspace_id_query_param_is_rejected(mongo_db):  # noqa: ARG001
+    """Tenancy comes from auth, never the query — asking is a 400, not a silent
+    ignore, so nobody can later wire the param up by accident."""
+    await _run(workspace="w2", agent_id="theirs", status="running")
+
+    async with _client(_build_app()) as client:
+        resp = await client.get("/api/v1/agent-activity", params={"workspace_id": "w2"})
+
+    assert resp.status_code == 400, resp.text
+
+
+async def test_member_is_allowed_and_anonymous_is_denied(mongo_db):  # noqa: ARG001
+    """A plain MEMBER may read their own workspace's board (unlike the ADMIN-only
+    herdr cockpit); an unauthenticated caller is rejected by the auth layer."""
+    async with _client(_build_app(role="member")) as client:
+        member = await client.get("/api/v1/agent-activity")
+    assert member.status_code == 200, member.text
+
+    async with _client(_build_app(role=None)) as client:
+        anon = await client.get("/api/v1/agent-activity")
+    assert anon.status_code == 401, anon.text
+
+
+async def test_non_member_of_the_active_workspace_is_denied(mongo_db):  # noqa: ARG001
+    """The RBAC guard resolves the role IN the active workspace. A user whose
+    active workspace is one they hold no membership in gets 403, not a board."""
+    app = _build_app(active_workspace="w9", memberships=["w1"])
+    async with _client(app) as client:
+        resp = await client.get("/api/v1/agent-activity")
+
+    assert resp.status_code == 403, resp.text


### PR DESCRIPTION
`GET /api/v1/agent-activity` answers "which of my agents are working right now" — the question the herdr cockpit cannot answer.

The cockpit reads terminal panes on one operator box. It is ADMIN-gated, its panes are not paw-workspace-scoped, and a user's `/chat` agent never appears there at all, because that agent runs as an in-process SDK client rather than a pane. A user who sent a chat message and then looked at the board correctly saw nothing. This is the board that answers the question.

## Data source

`ChatRunDoc`, the durable per-turn record — not `SessionSupervisor._runtimes`. That in-memory registry is empty when runs execute in arq workers, partial across multiple web workers, and lost on restart, which makes it unsound on the shared multi-tenant cloud this targets. The "active" definition (`queued` or `running`) is the one `chat/runs/service.py` already used for scope lookups and the jail GC, now hoisted into a named `ACTIVE_RUN_STATUSES` constant so the three call sites cannot drift apart.

## Tenancy

Both reads take `workspace_id` as a required keyword and filter on it at the query, so no call shape returns another workspace's runs. Proven at the service layer and over HTTP, including a caller who belongs to *both* workspaces (membership is not the filter; the active workspace is) and two tenants that happen to share an agent id. Deleting either filter turns three tests red — checked, not assumed.

A new import-linter contract keeps the module off `ChatRunDoc` entirely: it reads through `chat.runs.service`, which is where the filter and the window live. Import the document here and the tenancy filter becomes something every future query has to remember — the shape of bug that leaks one tenant's agents into another's board, on a diff that reads like a harmless "just query it directly" simplification.

## Status mapping

Mission Control's `AgentStatus`, so one UI legend covers this board and the cockpit's pane dots:

| Status | When |
|--------|------|
| `active` | At least one `queued`/`running` run. Beats an earlier failure — an agent with work in flight is working. |
| `blocked` | No live run, newest run `failed` or `interrupted`. |
| `idle` | No live run, newest run `completed` or `cancelled`. A user stopping their own turn has not blocked the agent. |

Agents with no run in the 24h window are **omitted**, not returned as `offline`. Reporting offline would mean reading the agent roster, which couples an activity view to the agents entity; and a configured-but-unused agent is not "not responding". A client that wants an exhaustive list joins against `GET /agents`.

Two reads rather than one: the recent read is capped, so on a busy workspace a long-running turn started hours ago could be truncated out of it — losing precisely the agent that *is* working. The active read carries those rows independently of that cap. The window bounds both, so a leaked `running` run from last week drops off instead of pinning an agent to `active` forever.

## Auth

MEMBER, via a new `agent_activity.read` action — the same bar as `session.read_own`. It deliberately does not reuse the ADMIN `cockpit.read`: that guards a host-level surface whose panes are not workspace-scoped, which is exactly why it stays admin-only. Different surface, different tenancy story, different action.

## Not in this PR

No UI (separate task). No SSE — v1 is a plain GET for clients to poll. A stream was rejected on cost: the cockpit re-polls a local subprocess for one operator, whereas this would be a Mongo query every 1.5s per connected user across the whole tenant base. The upgrade path is noted in the router and is event-driven off the run-status transitions `run_core` already makes, not a faster poll. No writes, no changes to the herdr cockpit.

## Verification

```
uv run --group ee pytest tests/cloud/test_agent_activity.py -o addopts="" -q   22 passed
uv run ruff check .                                                            All checks passed
uv run lint-imports                                                            1 kept, 0 broken
uv run --group ee lint-imports --config ee/pyproject.toml                      34 kept, 0 broken
```

`tests/cloud` is excluded by the `addopts` in `pyproject.toml`, so the new file gets its own CI step next to the cockpit's — a cross-tenant property should not sit in that blind spot.

Regression check on the touched modules and their consumers (`tests/cloud/runs`, `chat`, `sessions`, `metering`, plus the RBAC and cockpit suites): 618 passed. The remaining reds in that tree (`test_rbac_routes.py` 10 failed, `test_run_core.py::test_execute_run_threads_surface_meta_into_ctx`, and 7 `test_api_contracts.py` collection errors) reproduce identically at the base commit `b65cdb8` and are unrelated to this change.

Docs: `docs/api-reference.md` gains the endpoint, the status table, and the omit-vs-offline rule.