### PR TITLE
chore(ci): stop the stale bot closing PRs that are waiting on review

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,5 +1,15 @@
 # Stale — auto-close abandoned PRs and issues.
 # Created: 2026-02-26
+# Updated: 2026-07-28 — the PR window was eating live work. Three changes:
+#   1. `needs-work` added to exempt-pr-labels. It's this repo's review-queue
+#      label, so nearly every open PR carries it while it waits on captain
+#      review — the one state the bot must never treat as abandonment.
+#      It wasn't exempt, and the bot closed 25 unmerged PRs on that path.
+#   2. `security` added to exempt-pr-labels. Issues already had it; PRs
+#      didn't, so a security fix could age out silently.
+#   3. days-before-pr-stale 14 -> 45. Review here is batched and captain-gated,
+#      so a PR sitting three weeks is normal, not dead. 45 + 7 still reaps
+#      genuinely abandoned work within two months.
 name: Stale
 
 on:
@@ -18,11 +28,11 @@ jobs:
       - uses: actions/stale@v9
         with:
           # PRs
-          days-before-pr-stale: 14
+          days-before-pr-stale: 45
           days-before-pr-close: 7
           stale-pr-label: 'stale'
           stale-pr-message: >
-            This PR has been inactive for 14 days. It will be closed in 7 days
+            This PR has been inactive for 45 days. It will be closed in 7 days
             if there's no further activity. If you're still working on this,
             push an update or leave a comment.
           close-pr-message: >
@@ -41,5 +51,5 @@ jobs:
 
           # Don't stale these
           exempt-issue-labels: 'pinned,good first issue,roadmap,security'
-          exempt-pr-labels: 'pinned,work-in-progress'
+          exempt-pr-labels: 'pinned,work-in-progress,needs-work,security'
           exempt-all-assignees: true


### PR DESCRIPTION
## The problem

`stale.yml` exempts `pinned` and `work-in-progress`. This repo queues review with `needs-work`, which wasn't on that list. So the label that means "waiting on the captain" read to the bot as "abandoned", and PRs sitting in the normal review queue got closed on a 14-day timer.

25 unmerged PRs went that way. Among them: an SVG upload XSS fix, the Antigravity backend, the ripple widget-richness prompt fix, and the shield access log. Three more open PRs were mid-countdown when this got caught, including a fail-closed fix on the catalog gate.

## The change

- `needs-work` and `security` added to `exempt-pr-labels`. Issues already exempted `security`, PRs didn't.
- `days-before-pr-stale` 14 -> 45. Review here is batched and captain-gated, so three weeks of silence on a PR is routine. 45 + 7 still clears genuinely dead work inside two months.
- Warning message updated to quote the new window.

## Testing

Parsed the workflow with pyyaml and asserted the three values. There's no behavior to unit-test here, it's an action config.

## Follow-up

This wants to merge before the next scheduled run (Monday 09:00 UTC), otherwise the remaining queue gets staled again. I've already removed the `stale` label by hand from the three open PRs that were counting down, so nothing is at risk this week.
