### PR TITLE
One pipeline per client, and a prospect that can be just a domain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,7 +236,11 @@ The web dashboard (`frontend/`) is vanilla JS/CSS/HTML served via FastAPI+Jinja2
   invoices and receipts with it. The provider credential itself is **not** an env
   var: it is per-workspace connector state on the workspace's `mailtrap` connector
   row (`MAILTRAP_API_TOKEN`, plus optional `MAILTRAP_FROM_EMAIL` /
-  `MAILTRAP_FROM_NAME`), so disabling the connector revokes sending immediately.
+  `MAILTRAP_FROM_NAME`, `MAILTRAP_REPLY_TO`, and `MAILTRAP_PROJECT_SENDERS` — a
+  `{project_id: {from_email, from_name, reply_to}}` map so an agency sends as the
+  client whose project owns the prospect, resolved per field with the workspace
+  values as the fallback), so disabling the connector revokes sending immediately
+  for every project at once.
   See `ee/pocketpaw_ee/cloud/growth/connector.py` and `docs/api-reference.md`.
 - **Session supervisor config**: `POCKETPAW_SESSION_SUPERVISOR` (default OFF). When
   truthy (`1`/`true`/`yes`/`on`), the cloud chat executor drives every agent turn

--- a/connectors/mailtrap.yaml
+++ b/connectors/mailtrap.yaml
@@ -37,6 +37,21 @@ auth:
     - name: MAILTRAP_FROM_NAME
       description: Display name on the From header (optional).
       required: false
+    - name: MAILTRAP_REPLY_TO
+      description: >-
+        Reply-To header for cold outreach (optional). Unlike the from-address
+        this is NOT constrained to the sending domain — it only tells the
+        recipient where to write back, so it can point at a real inbox.
+      required: false
+    - name: MAILTRAP_PROJECT_SENDERS
+      description: >-
+        Per-project sender overrides, as {project_id: {from_email, from_name,
+        reply_to}}. An agency sending for a client sends as that client.
+        Resolved per field, so a project that sets only from_name keeps the
+        workspace's reply_to. from_email is still pinned to
+        GROWTH_SENDING_DOMAIN — a client's own domain needs their DNS, which is
+        an onboarding flow, not a config key.
+      required: false
 
 # No actions: sending is gated behind the Instinct approval + the growth
 # dispatch worker, never a generic connector verb.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -129,6 +129,19 @@ each block excluding its own filter), and POST /growth/drafts/propose-batch
 (<=100 ids, each proposed through the existing Instinct gate, per-draft
 error entries, growth.manage).
 
+Updated: 2026-07-28 (feat/growth-projects) — a prospect can now be just a
+domain: name and company are optional on create and on a bulk row, defaulting
+to "" (not yet known), and nothing renders an empty value as "unknown".
+domain stays required and still normalises. Added project_id — the client
+container from cloud/projects — on create, on PATCH (three-valued: omit to
+leave alone, an id to reassign, "" to clear) and as an optional filter on the
+list, the facets and the search; a foreign project is 404 project.not_found.
+The email dispatcher resolves a per-project sender identity (from-name /
+from-address / reply-to, per-field fallback to the workspace default) via the
+MAILTRAP_PROJECT_SENDERS and MAILTRAP_REPLY_TO connector keys, and the daily
+follow-up sweep works one client's threads at a time so their nudges go out
+under that identity.
+
 Updated: 2026-07-27 (feat/growth-g8) — added the Growth — LinkedIn Queue
 section: GET /growth/linkedin/queue (proposed/approved linkedin drafts joined
 with prospect context, ?format=md for a paste-ready markdown export) and
@@ -1591,7 +1604,19 @@ Create a prospect. Body:
 }
 ```
 
-`name`, `company`, `domain`, and `source` are required. Enums: `source` is
+Only `domain` and `source` are required. `name` and `company` default to
+`""` — **not yet known**, which is the honest shape an import arrives in: a
+pasted list of bare domains, enriched by research later on the same
+`(workspace, domain)` identity. Nothing renders an empty value as the word
+"unknown". The agent surface is stricter: `growth_upsert_prospect` refuses to
+CREATE a row without a name and a company.
+
+`project_id` (optional) assigns the prospect to a client project
+(`cloud/projects`). It is validated against the caller's workspace — another
+tenant's project is `404 project.not_found`. Nullable throughout: a workspace
+not using projects is unaffected.
+
+Enums: `source` is
 `clay | directory | manual`; `tier` is `a | b | c | unqualified` (default
 `unqualified`); `status` is
 `new | qualified | drafted | in_sequence | replied | dead` (default `new`).
@@ -1670,6 +1695,7 @@ Query parameters:
 | Param | Default | Notes |
 |---|---|---|
 | `tier`, `status`, `source` | — | Validated against the enums above; an unknown value is a 422, not an empty list. |
+| `project_id` | — | Scope to one client's pipeline. Omitted means every project (the whole view for a workspace not using them); an empty string means the rows with no client assigned. |
 | `q` | — | Case-insensitive substring search across `name`, `company`, `domain` and `research_brief`. Regex metacharacters are escaped, so `.*` matches nothing rather than everything. Max 200 chars. |
 | `sort` | `newest` | `newest` \| `oldest` \| `company` \| `tier`. |
 | `cursor` | — | The previous page's `next_cursor`, passed back unchanged. |
@@ -1699,7 +1725,7 @@ be designed against those rather than bolted on.
 ### `GET /api/v1/growth/prospects/facets`
 
 Counts behind the filter chips. Takes the same `tier` / `status` / `source` /
-`q` filters as the list route and returns:
+`project_id` / `q` filters as the list route and returns:
 
 ```json
 {
@@ -1713,7 +1739,10 @@ Each block respects every active filter **except its own**. With
 `status=new` on, the tier counts describe the new rows rather than
 collapsing to whichever tier is selected — otherwise the selected chip reads
 `n` and every sibling reads `0`, which tells the user nothing about where to
-go next. `q` constrains all three blocks (it is not a facet of its own).
+go next. `q` constrains all three blocks (it is not a facet of its own), and so does
+`project_id` — it is not a chip the user toggles inside the list, it is
+*which client's list* they are looking at, so the other three counts have to
+be scoped to it.
 
 Every legal value appears, zeros included, so the chip row keeps a stable
 shape as the user filters. Served by one workspace-scoped `$facet`
@@ -1731,6 +1760,13 @@ identity) and `source` (capture-time provenance) are immutable; the other
 fields (`name`, `company`, `tier`, `research_brief`, `emails`,
 `linkedin_url`, `whatsapp_number`, `opted_in`, `status`) patch in place.
 Returns the updated envelope.
+
+`project_id` is three-valued here: omitting it leaves the assignment alone,
+an id reassigns the prospect to that client (validated against the workspace
+— a foreign project is `404 project.not_found`), and `""` clears it.
+Un-assigning is deliberately explicit: a bulk upsert only ever *sets* the
+project, so an enrichment pass that carries no project can never orphan a
+client's prospect.
 
 ## Growth — Drafts
 

--- a/ee/pocketpaw_ee/agent/mcp_servers/growth.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/growth.py
@@ -47,6 +47,14 @@
 # and the LinkedIn queue.
 #
 # Created 2026-07-28 (feat/growth-mcp): new module.
+# Updated 2026-07-28 (feat/growth-projects): a prospect may now be JUST A DOMAIN
+# — ``CreateProspectRequest`` accepts an empty name / company. The CREATE
+# refusal in ``_upsert_prospect_handler`` is UNCHANGED and is now the only thing
+# holding that line for the agent: a human pasting a domain list is entitled to
+# a nameless row, an agent that researched a company and still can't name it is
+# not. What did change is the placeholder: the ``or "unknown"`` fallbacks are
+# gone, because with an empty name legal in the store they would have stamped
+# the literal word "unknown" over a real (blank) value on any enrichment call.
 
 from __future__ import annotations
 
@@ -467,8 +475,6 @@ async def _upsert_prospect_handler(args: dict) -> dict:
         # Build once to canonicalise the domain (the DTO validator strips the
         # scheme / www / path), then look the row up on that canonical form.
         probe = CreateProspectRequest(
-            name=name or "unknown",
-            company=company or "unknown",
             domain=domain,
             source=_opt_str(args, "source") or "manual",
         )
@@ -497,8 +503,12 @@ async def _upsert_prospect_handler(args: dict) -> dict:
 
     try:
         body = CreateProspectRequest(
-            name=_pick(name, "name", None) or "unknown",
-            company=_pick(company, "company", None) or "unknown",
+            # No "unknown" placeholder: on a CREATE the refusal above already
+            # demanded both, and on an ENRICH the stored value carries forward
+            # — including a stored "" from a bare-domain import, which must
+            # survive an unrelated enrichment rather than be stamped over.
+            name=_pick(name, "name", "") or "",
+            company=_pick(company, "company", "") or "",
             domain=probe.domain,
             source=_pick(_opt_str(args, "source"), "source", "manual"),
             tier=_pick(_opt_str(args, "tier"), "tier", "unqualified"),

--- a/ee/pocketpaw_ee/cloud/growth/connector.py
+++ b/ee/pocketpaw_ee/cloud/growth/connector.py
@@ -2,6 +2,17 @@
 # client for the /growth outbound engine (G-5).
 #
 # Created 2026-07-27 (feat/growth-g5): new module.
+# Updated 2026-07-28 (feat/growth-projects): PER-PROJECT SENDER IDENTITY. An
+# agency sending for a client has to send AS the client, so the sender is
+# resolved per project (``resolve_sender_identity``) with a per-FIELD fallback
+# to the workspace default, and a workspace-level ``MAILTRAP_REPLY_TO`` joins
+# the blob. This sits in FRONT of credential resolution, not instead of it: the
+# token is still the workspace's, read from the same connector row, so
+# disabling the connector still revokes every project's sending at once.
+# ``from_email`` stays pinned to GROWTH_SENDING_DOMAIN even when a project
+# overrides it — the client's identity rides ``from_name`` and ``reply_to``,
+# which is how agencies send without holding the client's DNS. See
+# ``resolve_sender_identity`` for the full argument.
 #
 # WHY A MODULE AND NOT A YAML ACTION. ``connectors/mailtrap.yaml`` declares the
 # credential but ZERO actions, exactly like ``ship.yaml``. A generic
@@ -55,6 +66,17 @@ MAILTRAP_SEND_URL = "https://send.api.mailtrap.io/api/send"
 TOKEN_KEY = "MAILTRAP_API_TOKEN"
 FROM_EMAIL_KEY = "MAILTRAP_FROM_EMAIL"
 FROM_NAME_KEY = "MAILTRAP_FROM_NAME"
+REPLY_TO_KEY = "MAILTRAP_REPLY_TO"
+
+# Per-project sender overrides: ``{project_id: {from_email, from_name,
+# reply_to}}``. Lives in the SAME connector blob as the workspace defaults
+# above, because that blob is already the answer to "how does this workspace
+# send email" and disabling the connector must revoke every identity in it at
+# once, not all-but-one.
+PROJECT_SENDERS_KEY = "MAILTRAP_PROJECT_SENDERS"
+_PROJECT_FROM_EMAIL = "from_email"
+_PROJECT_FROM_NAME = "from_name"
+_PROJECT_REPLY_TO = "reply_to"
 
 # Deployment-level config: the secondary sending domain (see the module header).
 SENDING_DOMAIN_ENV = "GROWTH_SENDING_DOMAIN"
@@ -74,6 +96,20 @@ class EmailSendError(Exception):
     Every message is scrubbed of the workspace's token before it is raised, so
     the string is safe to persist on a ``MessageLog.error`` and to log.
     """
+
+
+@dataclass(frozen=True)
+class SenderIdentity:
+    """Who an outreach message goes out as: the resolved sender for one send.
+
+    Resolved per PROJECT with a per-field fallback to the workspace default —
+    see ``resolve_sender_identity`` for what a project may override and why
+    ``from_address`` is not free.
+    """
+
+    from_address: str
+    from_name: str = ""
+    reply_to: str = ""
 
 
 @dataclass(frozen=True)
@@ -171,17 +207,87 @@ def _resolve_from_address(config: dict[str, Any], sending_domain: str) -> str:
     return from_address
 
 
+def _project_overrides(config: dict[str, Any], project_id: str | None) -> dict[str, str]:
+    """The sender overrides stored for one project. Empty when there are none.
+
+    Fail-soft on shape: a hand-edited blob that isn't the expected nested map
+    yields no overrides, which sends as the workspace default. Refusing the
+    send instead would take a client's whole pipeline down over a typo in an
+    unrelated project's entry.
+    """
+    if not project_id:
+        return {}
+    raw = config.get(PROJECT_SENDERS_KEY)
+    if not isinstance(raw, dict):
+        return {}
+    entry = raw.get(project_id)
+    if not isinstance(entry, dict):
+        return {}
+    return {k: str(v).strip() for k, v in entry.items() if isinstance(v, str) and v.strip()}
+
+
+def resolve_sender_identity(
+    config: dict[str, Any], sending_domain: str, project_id: str | None = None
+) -> SenderIdentity:
+    """Who this message is FROM — the project's identity, else the workspace's.
+
+    An agency running outbound for a client has to send AS the client, so the
+    project is the unit of identity, not the workspace. Resolution is per
+    FIELD, not per record: a project that overrides only the display name keeps
+    the workspace's reply-to rather than losing it, which is the common case
+    (one agency inbox, many client names).
+
+    WHAT A PROJECT MAY AND MAY NOT OVERRIDE, and why it matters:
+
+    * ``from_name`` — free. It is a display string.
+    * ``reply_to`` — free, and NOT constrained to the sending domain. It is
+      just a header telling the recipient where to write back, and pointing it
+      at the client's own inbox is the entire point: the reply lands with the
+      client, not the agency.
+    * ``from_email`` — still validated against ``GROWTH_SENDING_DOMAIN``, same
+      as the workspace default. This is the constraint people try to argue
+      with, so: you cannot send as ``hello@theirdomain.com`` without their DNS.
+      Mail claiming a domain you don't hold fails DMARC, lands in spam, and
+      burns the reputation of the domain you DO hold. The honest shape is
+      ``clientname@<sending-domain>`` in the from-address, the client's name in
+      ``from_name``, and the client's inbox in ``reply_to`` — which is how
+      agencies actually send, and which reads correctly to the recipient.
+      Sending from a client's own domain needs their DNS delegated, and that is
+      an onboarding flow, not a config key.
+    """
+    overrides = _project_overrides(config, project_id)
+
+    from_address = overrides.get(_PROJECT_FROM_EMAIL) or ""
+    if from_address:
+        # Validated through the SAME check the workspace default gets — the
+        # override is a different value, not a different rule.
+        from_address = _resolve_from_address({FROM_EMAIL_KEY: from_address}, sending_domain)
+    else:
+        from_address = _resolve_from_address(config, sending_domain)
+
+    from_name = overrides.get(_PROJECT_FROM_NAME) or str(config.get(FROM_NAME_KEY) or "").strip()
+    reply_to = overrides.get(_PROJECT_REPLY_TO) or str(config.get(REPLY_TO_KEY) or "").strip()
+    return SenderIdentity(from_address=from_address, from_name=from_name, reply_to=reply_to)
+
+
 async def send_email(
     *,
     workspace_id: str,
     to_address: str,
     subject: str,
     body: str,
+    project_id: str | None = None,
 ) -> SentEmail:
     """Send one outreach email through Mailtrap. Raises ``EmailSendError``.
 
     The caller (``email_dispatch``) turns any raise into a ``failed``
     MessageLog row and leaves the draft ``approved`` so the send is retryable.
+
+    ``project_id`` selects the SENDER identity — an agency sending for a client
+    sends as that client. It does not select the credential: the token is still
+    the workspace's, read from the same connector row, and identity resolution
+    happens in FRONT of that rather than instead of it. A project with no
+    override, or no project at all, sends as the workspace default.
     """
     to_address = (to_address or "").strip()
     if "@" not in to_address:
@@ -199,18 +305,23 @@ async def send_email(
             "the mailtrap connector is not configured for this workspace — "
             "enable it and supply the sending token"
         )
-    from_address = _resolve_from_address(config, sending_domain)
-    from_name = str(config.get(FROM_NAME_KEY) or "").strip()
+    identity = resolve_sender_identity(config, sending_domain, project_id)
 
-    sender: dict[str, str] = {"email": from_address}
-    if from_name:
-        sender["name"] = from_name
-    payload = {
+    sender: dict[str, str] = {"email": identity.from_address}
+    if identity.from_name:
+        sender["name"] = identity.from_name
+    payload: dict[str, Any] = {
         "from": sender,
         "to": [{"email": to_address}],
         "subject": subject,
         "text": body,
     }
+    if identity.reply_to:
+        # Carried as the RFC 5322 header rather than a provider-specific field:
+        # ``headers`` is the documented passthrough, and a header is what the
+        # recipient's client actually reads. This is the field that makes a
+        # client's replies land with the client instead of the agency.
+        payload["headers"] = {"Reply-To": identity.reply_to}
 
     client = _http_client()
     try:
@@ -246,7 +357,7 @@ async def send_email(
         provider=MAILTRAP_CONNECTOR_NAME,
         provider_message_id=provider_message_id,
         to_address=to_address,
-        from_address=from_address,
+        from_address=identity.from_address,
     )
 
 
@@ -255,12 +366,16 @@ __all__ = [
     "FROM_NAME_KEY",
     "MAILTRAP_CONNECTOR_NAME",
     "MAILTRAP_SEND_URL",
+    "PROJECT_SENDERS_KEY",
     "PUBLIC_BASE_URL_ENV",
+    "REPLY_TO_KEY",
     "SENDING_DOMAIN_ENV",
     "TOKEN_KEY",
     "EmailSendError",
+    "SenderIdentity",
     "SentEmail",
     "load_workspace_config",
+    "resolve_sender_identity",
     "resolve_sending_domain",
     "send_email",
 ]

--- a/ee/pocketpaw_ee/cloud/growth/domain.py
+++ b/ee/pocketpaw_ee/cloud/growth/domain.py
@@ -29,6 +29,12 @@
 # orders derived from the Literals. The rank is data here rather than a
 # lexicographic accident in the query layer, so renaming a tier can't silently
 # reorder the list.
+# Updated 2026-07-28 (feat/growth-projects): ``Prospect.project_id`` — the
+# client a prospect belongs to, following the ``tasks`` / ``cycles`` consumer
+# pattern exactly (nullable, validated against the workspace at entry, an
+# optional filter on the reads). An agency runs one outbound pipeline per
+# client; the project primitive already models that container, so growth
+# consumes it rather than inventing a second scoping concept.
 # Updated 2026-07-27 (feat/growth-g4): the Instinct send gate —
 # ``GATE_OWNED_TARGETS`` marks the statuses only the gate machinery may set
 # (``approved`` via an approved ``_growth_send`` proposal, ``sent`` via the
@@ -91,6 +97,11 @@ class Prospect:
     company: str
     domain: str
     source: str  # ProspectSource — validated at the DTO boundary
+    # The client this prospect belongs to, when the workspace uses projects.
+    # Nullable throughout: a solo operator never sees a project and nothing
+    # about their pipeline changes. Validated against the workspace at entry —
+    # a project from another tenant is a hard error, not a silent null.
+    project_id: str | None = None
     tier: str = "unqualified"  # ProspectTier
     research_brief: str = ""
     emails: tuple[str, ...] = ()

--- a/ee/pocketpaw_ee/cloud/growth/dto.py
+++ b/ee/pocketpaw_ee/cloud/growth/dto.py
@@ -34,6 +34,14 @@
 # the manual LinkedIn send queue: the draft envelope joined with the prospect
 # context the captain needs to send by hand (name, company, profile URL,
 # research brief, tier). Response-only; the queue has no request DTO.
+# Updated 2026-07-28 (feat/growth-projects): a prospect may be JUST A DOMAIN.
+# ``name`` and ``company`` on CreateProspectRequest lost their ``min_length=1``
+# and now default to ``""`` — "not yet known", the shape a pasted domain list
+# actually arrives in (bulk rows validate through this same model, so they
+# relax with it). ``domain`` stays required and still normalises: it is the
+# dedupe identity, and a row without one is not a prospect. The LinkedIn queue
+# row gained ``prospect_domain`` so an export can still title a section for a
+# prospect whose name nobody has filled in yet.
 
 from __future__ import annotations
 
@@ -70,8 +78,23 @@ def _normalise_domain(v: str) -> str:
 
 
 class CreateProspectRequest(BaseModel):
-    name: str = Field(min_length=1, max_length=200)
-    company: str = Field(min_length=1, max_length=200)
+    """A prospect at capture time. Only ``domain`` is required.
+
+    ``name`` and ``company`` default to ``""`` meaning NOT YET KNOWN, because
+    that is the honest shape an import arrives in: a list of bare domains
+    pasted out of a directory, with the rest filled in later by research. An
+    empty string here is a fact ("we haven't looked yet"), never a placeholder
+    — nothing downstream may render it as the literal word "unknown".
+
+    The AGENT surface is stricter on purpose: ``growth_upsert_prospect``
+    refuses to CREATE a row without a name and a company, because an agent
+    that researched a company and still can't name it has failed at the job.
+    A human pasting a domain list is a different caller with a different
+    truth, and that guard lives in the MCP handler rather than here.
+    """
+
+    name: str = Field(default="", max_length=200)
+    company: str = Field(default="", max_length=200)
     domain: str = Field(min_length=1, max_length=253)
     source: ProspectSource
     tier: ProspectTier = "unqualified"
@@ -318,6 +341,9 @@ class LinkedInQueueItemResponse(BaseModel):
     draft: DraftResponse
     prospect_name: str
     prospect_company: str
+    # Always present, unlike name / company — the export titles a section with
+    # it when nobody has filled the rest in yet.
+    prospect_domain: str = ""
     linkedin_url: str | None
     research_brief: str
     tier: str

--- a/ee/pocketpaw_ee/cloud/growth/dto.py
+++ b/ee/pocketpaw_ee/cloud/growth/dto.py
@@ -42,6 +42,11 @@
 # dedupe identity, and a row without one is not a prospect. The LinkedIn queue
 # row gained ``prospect_domain`` so an export can still title a section for a
 # prospect whose name nobody has filled in yet.
+# Updated 2026-07-28 (feat/growth-projects): ``project_id`` on the create,
+# update and response shapes — the client a prospect belongs to. On the UPDATE
+# it is three-valued the way ``tasks`` does it (None = leave alone, an id =
+# reassign, "" = clear); on the CREATE it is a plain optional. Neither can
+# validate the id itself: only the service knows the caller's workspace.
 
 from __future__ import annotations
 
@@ -97,6 +102,10 @@ class CreateProspectRequest(BaseModel):
     company: str = Field(default="", max_length=200)
     domain: str = Field(min_length=1, max_length=253)
     source: ProspectSource
+    # The client this prospect belongs to. The SERVICE validates it against
+    # the caller's workspace (a project from another tenant is a 404) — the
+    # DTO can only check the shape, since it has no tenancy context.
+    project_id: str | None = None
     tier: ProspectTier = "unqualified"
     research_brief: str = ""
     emails: list[str] = Field(default_factory=list)
@@ -124,6 +133,11 @@ class UpdateProspectRequest(BaseModel):
 
     name: str | None = Field(default=None, min_length=1, max_length=200)
     company: str | None = Field(default=None, min_length=1, max_length=200)
+    # Three-valued, mirroring ``tasks``: ``None`` leaves the assignment alone,
+    # an id reassigns (validated against the workspace), and ``""`` clears it.
+    # Without the empty-string case there would be no way to un-assign a
+    # prospect from a client once assigned.
+    project_id: str | None = None
     tier: ProspectTier | None = None
     research_brief: str | None = None
     emails: list[str] | None = None
@@ -166,6 +180,7 @@ class ProspectResponse(BaseModel):
     company: str
     domain: str
     source: str
+    project_id: str | None = None
     tier: str
     research_brief: str
     emails: list[str]

--- a/ee/pocketpaw_ee/cloud/growth/email_dispatch.py
+++ b/ee/pocketpaw_ee/cloud/growth/email_dispatch.py
@@ -5,6 +5,12 @@
 # Created 2026-07-27 (feat/growth-g5): new module. Lives beside ``worker.py``
 # rather than inside it so each channel's delivery owns its own file — the
 # worker keeps a one-line branch per channel.
+# Updated 2026-07-28 (feat/growth-projects): the send carries the prospect's
+# ``project_id``, so the connector resolves that client's sender identity
+# (from-name / from-address / reply-to) instead of the workspace's. The
+# prospect is already loaded here for its email address, so this costs nothing
+# — and it deliberately reads the identity off the PROSPECT rather than the
+# draft, because the client owns the relationship, not the copy.
 #
 # ORDER OF OPERATIONS, and why:
 #
@@ -85,6 +91,10 @@ async def dispatch_email(draft_id: str) -> None:
             to_address=to_address,
             subject=draft.subject or "",
             body=draft.body,
+            # The sender identity follows the PROSPECT's client, so an agency's
+            # message goes out as that client. A prospect with no project (or a
+            # project with no override) sends as the workspace default.
+            project_id=prospect.project_id if prospect else None,
         )
     except Exception as exc:  # noqa: BLE001 — a failed send is recorded, never raised
         reason = (

--- a/ee/pocketpaw_ee/cloud/growth/followups.py
+++ b/ee/pocketpaw_ee/cloud/growth/followups.py
@@ -38,6 +38,14 @@
 # ``render_followup`` no longer assumes a company. The body already degraded
 # (``there`` / ``your team``); the generated subject now drops the dash instead
 # of sending "Following up —", which reads as a template that failed to render.
+# Also: the sweep now GROUPS BY CLIENT. Threads are partitioned by (workspace,
+# project) before they are worked, so one client's follow-ups run together and
+# go out under that client's sender identity, and the pass logs a per-client
+# created count instead of one undifferentiated number. The partition is over
+# the same collapsed thread map the flat loop walked — one thread, one
+# prospect, one project — so every thread is still visited exactly once and the
+# open-follow-up idempotency guard is untouched. Grouping changes the order the
+# work happens in, not how much of it happens.
 
 """Daily follow-up sweep for the /growth outbound engine."""
 
@@ -45,6 +53,7 @@ from __future__ import annotations
 
 import logging
 import os
+from collections import defaultdict
 from datetime import UTC, datetime, timedelta
 from typing import Any
 from uuid import uuid4
@@ -275,6 +284,67 @@ def _latest_sent_per_thread(rows: list[dict[str, Any]]) -> dict[tuple[str, str, 
     return threads
 
 
+# One thread, resolved far enough to know which client it belongs to:
+# ``((prospect_id, channel), latest_sent_row, prospect)``.
+_DueThread = tuple[tuple[str, str], dict[str, Any], Any]
+
+
+async def _group_due_threads(
+    growth_service: Any,
+    threads: dict[tuple[str, str, str], dict[str, Any]],
+    *,
+    cutoff: datetime,
+    counters: dict[str, int],
+) -> dict[tuple[str, str | None], list[_DueThread]]:
+    """Partition the due threads by ``(workspace, project)``.
+
+    WHY GROUP AT ALL. A follow-up goes out under the sender identity of the
+    client whose project owns the prospect (``growth/connector.py``). Working a
+    client's threads together is what makes that legible in the logs and gives
+    the pass a per-client "n proposed" line an operator can read — the sweep
+    stops being one undifferentiated queue for an agency running eight clients.
+
+    WHY THIS IS NOT N SWEEPS. The partition is over the SAME collapsed thread
+    map the single loop used to walk. A thread has one prospect, a prospect has
+    at most one project, so every thread lands in exactly one group and is
+    visited exactly once. The open-follow-up idempotency guard is untouched and
+    stays where it was, inside the per-thread body: grouping changes the ORDER
+    the threads are worked, never how many times.
+
+    The cheap checks stay in front of the expensive one, exactly as before: a
+    thread that isn't due yet is skipped WITHOUT a prospect read, so a backlog
+    of not-yet-due threads costs no more than it did.
+    """
+    groups: dict[tuple[str, str | None], list[_DueThread]] = {}
+    for (workspace_id, prospect_id, channel), latest in threads.items():
+        counters["threads"] += 1
+        try:
+            sent_at = _as_utc(latest.get("sent_at"))
+            if sent_at is None or sent_at > cutoff:
+                counters["skipped"] += 1
+                continue
+
+            prospect = await growth_service.get_prospect_system(workspace_id, prospect_id)
+            if prospect.status in _TERMINAL_PROSPECT_STATUSES:
+                counters["skipped"] += 1
+                continue
+        except Exception:  # noqa: BLE001 — one unreadable thread, not a dead pass
+            counters["skipped"] += 1
+            logger.exception(
+                "growth: follow-up sweep could not resolve prospect %s on '%s' (workspace=%s)",
+                prospect_id,
+                channel,
+                workspace_id,
+            )
+            continue
+
+        project_id = getattr(prospect, "project_id", None)
+        groups.setdefault((workspace_id, project_id), []).append(
+            ((prospect_id, channel), latest, prospect)
+        )
+    return groups
+
+
 async def _retract(growth_service: Any, workspace_id: str, draft_id: str) -> None:
     """Reject a follow-up draft whose proposal never made it to the tray.
 
@@ -305,6 +375,12 @@ async def followup_sweep(ctx: dict[str, Any], *, now: datetime | None = None) ->
     and how many threads were skipped (not due, replied, already open, or no
     resolvable proposer). NEVER raises — one bad thread must not take the
     whole daily pass down.
+
+    Work is GROUPED BY CLIENT (``_group_due_threads``) — one project's threads
+    together, so a follow-up goes out under that client's sender identity and
+    the pass logs a per-client line. The grouping is a partition of the same
+    thread map the flat loop walked, so every thread is still visited exactly
+    once and the open-follow-up idempotency guard is unaffected.
     """
     from pocketpaw_ee.cloud.growth import service as growth_service
     from pocketpaw_ee.cloud.growth.dto import CreateDraftRequest
@@ -316,6 +392,10 @@ async def followup_sweep(ctx: dict[str, Any], *, now: datetime | None = None) ->
 
     counters = {"threads": 0, "created": 0, "retired": 0, "skipped": 0}
     proposer_cache: dict[str, dict[str, str]] = {}
+    # How many follow-ups each client got this pass — the log line an agency
+    # operator actually reads. Not part of the returned counters, which the
+    # worker's contract fixes at four keys.
+    per_project: defaultdict[tuple[str, str | None], int] = defaultdict(int)
 
     try:
         sent_rows = await growth_service.list_sent_drafts_for_followup(limit=SENT_SCAN_LIMIT)
@@ -323,121 +403,139 @@ async def followup_sweep(ctx: dict[str, Any], *, now: datetime | None = None) ->
         logger.exception("growth: follow-up sweep could not read sent drafts")
         return counters
 
-    for (workspace_id, prospect_id, channel), latest in _latest_sent_per_thread(sent_rows).items():
-        counters["threads"] += 1
-        try:
-            sent_at = _as_utc(latest.get("sent_at"))
-            if sent_at is None or sent_at > cutoff:
-                counters["skipped"] += 1
-                continue
+    groups = await _group_due_threads(
+        growth_service, _latest_sent_per_thread(sent_rows), cutoff=cutoff, counters=counters
+    )
 
-            prospect = await growth_service.get_prospect_system(workspace_id, prospect_id)
-            if prospect.status in _TERMINAL_PROSPECT_STATUSES:
-                counters["skipped"] += 1
-                continue
+    for (workspace_id, project_id), members in groups.items():
+        for (prospect_id, channel), latest, prospect in members:
+            try:
+                thread = await growth_service.list_channel_drafts(
+                    workspace_id, prospect_id, channel
+                )
+                if any(d["status"] == "replied" for d in thread):
+                    # The draft-level reply signal, for a prospect row that
+                    # hasn't caught up yet. Same verdict: they answered, stop
+                    # nudging.
+                    counters["skipped"] += 1
+                    continue
 
-            thread = await growth_service.list_channel_drafts(workspace_id, prospect_id, channel)
-            if any(d["status"] == "replied" for d in thread):
-                # The draft-level reply signal, for a prospect row that hasn't
-                # caught up yet. Same verdict: they answered, stop nudging.
-                counters["skipped"] += 1
-                continue
+                followups = [d for d in thread if d["variant"] == "follow_up"]
+                if any(d["status"] in _OPEN_STATUSES for d in followups):
+                    # One is already waiting on a human — including the one this
+                    # sweep filed on its last pass. THIS IS THE IDEMPOTENCY
+                    # GUARD, and grouping does not touch it: a thread has one
+                    # prospect, so it lands in exactly one group and is visited
+                    # exactly once per pass. Grouping changes the ORDER threads
+                    # are worked, never how many times.
+                    counters["skipped"] += 1
+                    continue
 
-            followups = [d for d in thread if d["variant"] == "follow_up"]
-            if any(d["status"] in _OPEN_STATUSES for d in followups):
-                # One is already waiting on a human — including the one this
-                # sweep filed on its last pass. This is the idempotency guard.
-                counters["skipped"] += 1
-                continue
+                counted = [d for d in followups if d["status"] not in _UNCOUNTED_STATUSES]
+                if len(counted) >= max_followups:
+                    await growth_service.mark_prospect_dead(workspace_id, prospect_id)
+                    counters["retired"] += 1
+                    logger.info(
+                        "growth: prospect %s retired to dead after %d follow-ups on '%s' "
+                        "with no reply (workspace=%s project=%s)",
+                        prospect_id,
+                        len(counted),
+                        channel,
+                        workspace_id,
+                        project_id or "-",
+                    )
+                    continue
 
-            counted = [d for d in followups if d["status"] not in _UNCOUNTED_STATUSES]
-            if len(counted) >= max_followups:
-                await growth_service.mark_prospect_dead(workspace_id, prospect_id)
-                counters["retired"] += 1
-                logger.info(
-                    "growth: prospect %s retired to dead after %d follow-ups on '%s' "
-                    "with no reply (workspace=%s)",
+                if workspace_id not in proposer_cache:
+                    proposer_cache[workspace_id] = await _proposer_index(workspace_id)
+                fallback = thread[0] if thread else latest
+                first_touch = next((d for d in thread if d["variant"] == "first_touch"), fallback)
+                index = proposer_cache[workspace_id]
+                proposer = index.get(str(latest["id"])) or index.get(str(first_touch["id"]))
+                if not proposer:
+                    logger.warning(
+                        "growth: no proposer resolvable for draft %s — skipping its follow-up "
+                        "(an unapprovable proposal is worse than none)",
+                        latest["id"],
+                    )
+                    counters["skipped"] += 1
+                    continue
+
+                subject, body = render_followup(
+                    channel=channel,
+                    prospect_name=prospect.name,
+                    prospect_company=prospect.company,
+                    first_touch=first_touch,
+                )
+                draft = await growth_service.create_followup_draft(
+                    workspace_id,
                     prospect_id,
-                    len(counted),
+                    CreateDraftRequest(
+                        channel=channel,  # type: ignore[arg-type]
+                        subject=subject,
+                        body=body,
+                        variant="follow_up",
+                        demo_url=first_touch.get("demo_url"),
+                    ),
+                )
+                # The EXISTING gate path: files the ``_growth_send`` Action and
+                # flips the draft draft→proposed. It stops there — approval and
+                # dispatch stay the human's, exactly as for a first touch.
+                try:
+                    await growth_service.propose_send(
+                        _system_context(workspace_id, proposer, now), draft.id
+                    )
+                except Exception:
+                    # Retract the draft we just created. Left in ``draft`` status
+                    # it would count as an OPEN follow-up and block this thread on
+                    # every future pass — a silent, permanent stall. ``rejected``
+                    # is terminal, doesn't burn a cap slot, and lets the next pass
+                    # try again cleanly.
+                    await _retract(growth_service, workspace_id, draft.id)
+                    raise
+                counters["created"] += 1
+                per_project[(workspace_id, project_id)] += 1
+                logger.info(
+                    "growth: follow-up %d/%d proposed for prospect %s on '%s' "
+                    "(workspace=%s project=%s)",
+                    len(counted) + 1,
+                    max_followups,
+                    prospect_id,
                     channel,
                     workspace_id,
+                    project_id or "-",
                 )
-                continue
-
-            if workspace_id not in proposer_cache:
-                proposer_cache[workspace_id] = await _proposer_index(workspace_id)
-            fallback = thread[0] if thread else latest
-            first_touch = next((d for d in thread if d["variant"] == "first_touch"), fallback)
-            index = proposer_cache[workspace_id]
-            proposer = index.get(str(latest["id"])) or index.get(str(first_touch["id"]))
-            if not proposer:
-                logger.warning(
-                    "growth: no proposer resolvable for draft %s — skipping its follow-up "
-                    "(an unapprovable proposal is worse than none)",
-                    latest["id"],
-                )
+            except Exception:  # noqa: BLE001 — one bad thread must not stop the pass
                 counters["skipped"] += 1
-                continue
-
-            subject, body = render_followup(
-                channel=channel,
-                prospect_name=prospect.name,
-                prospect_company=prospect.company,
-                first_touch=first_touch,
-            )
-            draft = await growth_service.create_followup_draft(
-                workspace_id,
-                prospect_id,
-                CreateDraftRequest(
-                    channel=channel,  # type: ignore[arg-type]
-                    subject=subject,
-                    body=body,
-                    variant="follow_up",
-                    demo_url=first_touch.get("demo_url"),
-                ),
-            )
-            # The EXISTING gate path: files the ``_growth_send`` Action and
-            # flips the draft draft→proposed. It stops there — approval and
-            # dispatch stay the human's, exactly as for a first touch.
-            try:
-                await growth_service.propose_send(
-                    _system_context(workspace_id, proposer, now), draft.id
+                logger.exception(
+                    "growth: follow-up sweep failed for prospect %s on '%s' "
+                    "(workspace=%s project=%s)",
+                    prospect_id,
+                    channel,
+                    workspace_id,
+                    project_id or "-",
                 )
-            except Exception:
-                # Retract the draft we just created. Left in ``draft`` status
-                # it would count as an OPEN follow-up and block this thread on
-                # every future pass — a silent, permanent stall. ``rejected``
-                # is terminal, doesn't burn a cap slot, and lets the next pass
-                # try again cleanly.
-                await _retract(growth_service, workspace_id, draft.id)
-                raise
-            counters["created"] += 1
-            logger.info(
-                "growth: follow-up %d/%d proposed for prospect %s on '%s' (workspace=%s)",
-                len(counted) + 1,
-                max_followups,
-                prospect_id,
-                channel,
-                workspace_id,
-            )
-        except Exception:  # noqa: BLE001 — one bad thread must not stop the pass
-            counters["skipped"] += 1
-            logger.exception(
-                "growth: follow-up sweep failed for prospect %s on '%s' (workspace=%s)",
-                prospect_id,
-                channel,
-                workspace_id,
-            )
 
     logger.info(
-        "growth.followup_sweep threads=%d created=%d retired=%d skipped=%d (delay=%dd max=%d)",
+        "growth.followup_sweep threads=%d created=%d retired=%d skipped=%d "
+        "projects=%d (delay=%dd max=%d)",
         counters["threads"],
         counters["created"],
         counters["retired"],
         counters["skipped"],
+        len(groups),
         delay_days,
         max_followups,
     )
+    for (workspace_id, project_id), created in sorted(
+        per_project.items(), key=lambda item: (item[0][0], item[0][1] or "")
+    ):
+        logger.info(
+            "growth.followup_sweep workspace=%s project=%s created=%d",
+            workspace_id,
+            project_id or "-",
+            created,
+        )
     return counters
 
 

--- a/ee/pocketpaw_ee/cloud/growth/followups.py
+++ b/ee/pocketpaw_ee/cloud/growth/followups.py
@@ -34,6 +34,10 @@
 # so the tests freeze it instead of sleeping.
 #
 # Created 2026-07-27 (feat/growth-g7): new module.
+# Updated 2026-07-28 (feat/growth-projects): a prospect may be just a domain, so
+# ``render_followup`` no longer assumes a company. The body already degraded
+# (``there`` / ``your team``); the generated subject now drops the dash instead
+# of sending "Following up —", which reads as a template that failed to render.
 
 """Daily follow-up sweep for the /growth outbound engine."""
 
@@ -168,7 +172,11 @@ def render_followup(
                 else f"Re: {original_subject}"
             )
         else:
-            subject = f"Following up — {prospect_company}".strip()
+            # A prospect can be just a domain, so the company may be empty.
+            # Drop the dash rather than sending "Following up —", which reads
+            # like a template that failed to render.
+            company = prospect_company.strip()
+            subject = f"Following up — {company}" if company else "Following up"
         subject = subject[:200]
     return subject, body
 

--- a/ee/pocketpaw_ee/cloud/growth/router.py
+++ b/ee/pocketpaw_ee/cloud/growth/router.py
@@ -48,6 +48,11 @@
 # context; ``?format=md`` returns a paste-ready text/markdown export) and
 # POST /linkedin/{draft_id}/mark-sent (records a manual send via the G-3
 # transition machine). Deliberately manual — no LinkedIn API.
+# Updated 2026-07-28 (feat/growth-projects): GET /prospects and GET
+# /prospects/facets take an optional ``project_id`` — one client's pipeline.
+# Query params only; NO new route, so the guard-coverage test in
+# ``tests/cloud/growth/test_gate.py`` keeps its existing surface. Omitting it
+# means every project, so a workspace not using them sees no change.
 # Updated 2026-07-27 (integration/growth-v1): the G-8 LinkedIn routes carry the
 # G-4 per-route RBAC guards their branch predated — ``growth.read`` on the
 # queue, ``growth.manage`` on mark-sent (it is an OUTBOUND verb, same tier as
@@ -129,6 +134,7 @@ async def list_prospects(
     tier: ProspectTier | None = Query(default=None),
     status: ProspectStatus | None = Query(default=None),
     source: ProspectSource | None = Query(default=None),
+    project_id: str | None = Query(default=None, max_length=64),
     q: str | None = Query(default=None, max_length=200),
     sort: ProspectSort = Query(default="newest"),
     cursor: str | None = Query(default=None, max_length=200),
@@ -143,12 +149,17 @@ async def list_prospects(
     is the declared rank a→b→c→unqualified, not a lexicographic accident.
     ``cursor`` is the previous page's ``next_cursor``, passed back unchanged;
     ``null`` there means the last page. ``total`` counts every row matching the
-    filters, so the UI can say "n of m"."""
+    filters, so the UI can say "n of m".
+
+    ``project_id`` scopes to one client's pipeline. Omitted means every
+    project, which is the whole view for a workspace not using them; an empty
+    string means the rows with no client assigned."""
     return await growth_service.list_prospects(
         ctx,
         tier=tier,
         status=status,
         source=source,
+        project_id=project_id,
         q=q,
         sort=sort,
         cursor=cursor,
@@ -168,6 +179,7 @@ async def prospect_facets(
     tier: ProspectTier | None = Query(default=None),
     status: ProspectStatus | None = Query(default=None),
     source: ProspectSource | None = Query(default=None),
+    project_id: str | None = Query(default=None, max_length=64),
     q: str | None = Query(default=None, max_length=200),
     ctx: RequestContext = Depends(request_context),
 ) -> ProspectFacetsResponse:
@@ -177,7 +189,9 @@ async def prospect_facets(
     filter and respects the others — so with ``status=replied`` on, the tier
     counts describe the replied rows rather than collapsing to the selected
     tier. Every legal value is present, zeros included."""
-    return await growth_service.prospect_facets(ctx, tier=tier, status=status, source=source, q=q)
+    return await growth_service.prospect_facets(
+        ctx, tier=tier, status=status, source=source, project_id=project_id, q=q
+    )
 
 
 @router.get(

--- a/ee/pocketpaw_ee/cloud/growth/service.py
+++ b/ee/pocketpaw_ee/cloud/growth/service.py
@@ -75,6 +75,13 @@
 # export titles its sections through ``_queue_heading`` — whichever of
 # name/company is known, else the domain, never a placeholder word — and the
 # queue row carries ``prospect_domain`` to make that fallback possible.
+# Also ``project_id`` on the prospect — the client container, consumed exactly
+# the way ``tasks`` consumes it: validated at entry by ``_ensure_project_in_
+# workspace`` (growth's own copy of the check, calling the same public
+# ``projects.service.exists_in_workspace`` seam — see that helper on why it is
+# not imported from ``tasks``), an optional three-valued filter on list /
+# facets / search, and nullable everywhere so a workspace without projects is
+# untouched. ``upsert_by_domain`` only ever SETS the project, never clears it.
 # ``record_whatsapp_attempt`` / ``finish_whatsapp_attempt`` /
 # ``count_whatsapp_attempts_since`` own the WhatsApp compliance record and its
 # rate-cap window, and ``record_whatsapp_inbound_reply`` applies the opt-in +
@@ -156,6 +163,7 @@ def _to_domain(doc: _ProspectDoc) -> Prospect:
         company=doc.company,
         domain=doc.domain,
         source=doc.source,
+        project_id=getattr(doc, "project_id", None),
         tier=doc.tier,
         research_brief=doc.research_brief,
         emails=tuple(doc.emails),
@@ -208,6 +216,7 @@ def _to_response(p: Prospect) -> ProspectResponse:
         company=p.company,
         domain=p.domain,
         source=p.source,
+        project_id=p.project_id,
         tier=p.tier,
         research_brief=p.research_brief,
         emails=list(p.emails),
@@ -231,6 +240,31 @@ def _require_workspace(ctx: RequestContext) -> str:
     if not ctx.workspace_id:
         raise Forbidden("prospect.no_workspace", "Active workspace required for growth operations")
     return ctx.workspace_id
+
+
+async def _ensure_project_in_workspace(workspace_id: str, project_id: str) -> None:
+    """Validate that ``project_id`` names a real project in this workspace.
+
+    Growth's OWN copy of the check ``tasks`` and ``cycles`` each carry, rather
+    than an import of ``tasks.service._ensure_project_in_workspace``: that one
+    is private, and reaching across an entity boundary for a sibling's private
+    helper is the drift the 4-file rule exists to prevent. Both copies call the
+    same PUBLIC seam — ``projects.service.exists_in_workspace`` — so there is
+    one source of truth for the answer, three callers for the question.
+
+    The import is lazy for the same two reasons ``tasks`` gives: it avoids a
+    module-load cycle, and it degrades silently on a build that predates the
+    Projects entity (there, a supplied project id simply cannot be validated,
+    and growth is not the module that should fail the deploy over it).
+    """
+    try:
+        from pocketpaw_ee.cloud.projects import service as projects_service
+    except Exception:  # noqa: BLE001 — no Projects entity on this build
+        return
+    if not await projects_service.exists_in_workspace(workspace_id, project_id):
+        # Same 404 a foreign prospect id gets: another tenant's project must
+        # not be distinguishable from one that never existed.
+        raise NotFound("project", project_id)
 
 
 async def _fetch_in_workspace(workspace_id: str, prospect_id: str) -> _ProspectDoc:
@@ -275,6 +309,8 @@ async def create(ctx: RequestContext, body: CreateProspectRequest) -> ProspectRe
     that want create-or-update semantics use ``upsert_by_domain`` instead."""
     body = CreateProspectRequest.model_validate(body)
     workspace_id = _require_workspace(ctx)
+    if body.project_id:
+        await _ensure_project_in_workspace(workspace_id, body.project_id)
 
     existing = await _ProspectDoc.find_one({"workspace": workspace_id, "domain": body.domain})
     if existing is not None:
@@ -322,9 +358,16 @@ def _prospect_filters(
     tier: str | None = None,
     status: str | None = None,
     source: str | None = None,
+    project_id: str | None = None,
     q: str | None = None,
 ) -> dict[str, Any]:
     """Build the tenant-scoped Mongo filter shared by list / facets / count.
+
+    ``project_id`` scopes to one client's pipeline. It is three-valued like
+    ``tasks``: ``None`` is "every project" (the default — a workspace not using
+    projects is unaffected), an id scopes to that client, and an empty string
+    scopes to the UNASSIGNED rows, which is how the UI offers a "no client"
+    bucket without a magic id.
 
     SCALE CEILING — ``q`` is an unanchored, case-insensitive regex ``$or``
     across four fields. Mongo cannot use an index for that, so it is a
@@ -344,6 +387,8 @@ def _prospect_filters(
         filters["status"] = status
     if source is not None:
         filters["source"] = source
+    if project_id is not None:
+        filters["project_id"] = project_id or None
     if q is not None and q.strip():
         pattern = _escape_regex(q)
         filters["$or"] = [
@@ -495,6 +540,7 @@ async def list_prospects(
     tier: str | None = None,
     status: str | None = None,
     source: str | None = None,
+    project_id: str | None = None,
     q: str | None = None,
     sort: str = "newest",
     cursor: str | None = None,
@@ -515,7 +561,9 @@ async def list_prospects(
     workspace_id = _require_workspace(ctx)
     if sort != "tier" and sort not in _PROSPECT_SORT_SPECS:
         raise ValidationError("prospect.bad_sort", f"Unknown sort mode '{sort}'")
-    filters = _prospect_filters(workspace_id, tier=tier, status=status, source=source, q=q)
+    filters = _prospect_filters(
+        workspace_id, tier=tier, status=status, source=source, project_id=project_id, q=q
+    )
 
     # Over-fetch by one: the extra row is the "is there a next page" probe and
     # is never returned.
@@ -571,6 +619,7 @@ async def prospect_facets(
     tier: str | None = None,
     status: str | None = None,
     source: str | None = None,
+    project_id: str | None = None,
     q: str | None = None,
 ) -> ProspectFacetsResponse:
     """Counts per tier / status / source for the filter chips.
@@ -589,8 +638,12 @@ async def prospect_facets(
     workspace_id = _require_workspace(ctx)
     active = {"tier": tier, "status": status, "source": source}
 
-    # Shared prefix — tenancy + the search term, which constrains every block.
-    outer = _prospect_filters(workspace_id, q=q)
+    # Shared prefix — tenancy, the search term, and the project scope. The
+    # project goes in the OUTER match rather than getting a facet block of its
+    # own: it is not a chip the user toggles inside the list, it is which
+    # client's list they are looking at. Counts for the other three must be
+    # scoped to that client or the chips describe a pipeline nobody is viewing.
+    outer = _prospect_filters(workspace_id, project_id=project_id, q=q)
 
     branches: dict[str, list[dict[str, Any]]] = {}
     for block, (field, _order) in _PROSPECT_FACETS.items():
@@ -628,6 +681,14 @@ async def update(
     body = UpdateProspectRequest.model_validate(body)
     workspace_id = _require_workspace(ctx)
     doc = await _fetch_in_workspace(workspace_id, prospect_id)
+    if body.project_id is not None:
+        # Three-valued, like ``tasks``: an id reassigns (validated first), an
+        # empty string clears. ``None`` never reaches here.
+        if body.project_id:
+            await _ensure_project_in_workspace(workspace_id, body.project_id)
+            doc.project_id = body.project_id
+        else:
+            doc.project_id = None
     _apply_update(doc, body)
     await doc.save()  # bumps updatedAt
     # no-event: growth has no realtime subscriber in v1; the prospects view polls.
@@ -645,8 +706,14 @@ async def upsert_by_domain(
     worker/system identity, mirroring how the arq worker trusts the doc's
     workspace. Every mutable field EXCEPT ``source`` is overwritten on update —
     source records provenance at first capture and is kept.
+
+    ``project_id`` is one of the overwritten fields, and it is validated
+    against ``workspace_id`` BEFORE anything is written: an ingestion path is
+    exactly where a bad id would otherwise get in unchecked.
     """
     body = CreateProspectRequest.model_validate(prospect_data)
+    if body.project_id:
+        await _ensure_project_in_workspace(workspace_id, body.project_id)
 
     doc = await _ProspectDoc.find_one({"workspace": workspace_id, "domain": body.domain})
     if doc is None:
@@ -667,6 +734,14 @@ async def upsert_by_domain(
         "status",
     ):
         setattr(doc, field, getattr(body, field))
+    # ``project_id`` is the ONE field an upsert only ever SETS, never clears. A
+    # re-import that names a project reassigns the row; one that says nothing
+    # leaves the assignment alone. The alternative — treating the DTO's default
+    # ``None`` as "unassign" — would make every agent enrichment call
+    # (``growth_upsert_prospect``, which carries no project) silently orphan a
+    # client's prospect. Un-assigning is an explicit act: PATCH with ``""``.
+    if body.project_id:
+        doc.project_id = body.project_id
     await doc.save()  # bumps updatedAt
     # no-event: growth has no realtime subscriber in v1.
     return _to_response(_to_domain(doc))
@@ -703,7 +778,15 @@ async def bulk_ingest(ctx: RequestContext, body: BulkIngestRequest) -> BulkInges
             )
             continue
         existing = await _ProspectDoc.find_one({"workspace": workspace_id, "domain": row.domain})
-        await upsert_by_domain(workspace_id, row)
+        try:
+            await upsert_by_domain(workspace_id, row)
+        except CloudError as exc:
+            # A row can be well-FORMED and still be refused — naming a project
+            # that isn't in this workspace is the case that brought this here.
+            # It is one bad row, not a bad payload, so it joins the error list
+            # like a malformed one instead of aborting the other 499.
+            errors.append(BulkRowError(index=index, code=exc.code, message=exc.message))
+            continue
         if existing is None:
             created += 1
         else:

--- a/ee/pocketpaw_ee/cloud/growth/service.py
+++ b/ee/pocketpaw_ee/cloud/growth/service.py
@@ -70,6 +70,11 @@
 # MSG91 inbound webhook) never touch a doc class. It reuses G-5's
 # ``get_draft_for_dispatch`` / ``get_prospect_for_dispatch`` readers (G-6 had
 # built an identical pair under different names, collapsed at integration),
+# Updated 2026-07-28 (feat/growth-projects): a prospect may be JUST A DOMAIN.
+# ``name`` / ``company`` can now be empty (see ``dto.py``), so the LinkedIn
+# export titles its sections through ``_queue_heading`` — whichever of
+# name/company is known, else the domain, never a placeholder word — and the
+# queue row carries ``prospect_domain`` to make that fallback possible.
 # ``record_whatsapp_attempt`` / ``finish_whatsapp_attempt`` /
 # ``count_whatsapp_attempts_since`` own the WhatsApp compliance record and its
 # rate-cap window, and ``record_whatsapp_inbound_reply`` applies the opt-in +
@@ -1052,6 +1057,7 @@ async def linkedin_queue(
                 draft=_draft_to_response(draft),
                 prospect_name=prospect.name,
                 prospect_company=prospect.company,
+                prospect_domain=prospect.domain,
                 linkedin_url=prospect.linkedin_url,
                 research_brief=prospect.research_brief,
                 tier=prospect.tier,
@@ -1065,6 +1071,20 @@ def _one_line(text: str, max_len: int = 160) -> str:
     stripped = text.strip()
     line = stripped.splitlines()[0].strip() if stripped else ""
     return line if len(line) <= max_len else line[: max_len - 1] + "…"
+
+
+def _queue_heading(item: LinkedInQueueItemResponse) -> str:
+    """Title one queue section, honestly, whatever is known about the prospect.
+
+    A prospect can be just a domain: an import of bare domains files rows with
+    an empty name and company, and research fills them in later. So the heading
+    joins whichever of (name, company) exist and falls back to the DOMAIN,
+    which is always known — never to a placeholder word. ``Unknown — Unknown``
+    reads like a corrupted row; ``northwinddental.com`` reads like a company
+    nobody has researched yet, which is the truth.
+    """
+    known = [part for part in (item.prospect_name, item.prospect_company) if part.strip()]
+    return " — ".join(known) or item.prospect_domain or "(no domain)"
 
 
 def _render_queue_markdown(items: list[LinkedInQueueItemResponse]) -> str:
@@ -1087,7 +1107,7 @@ def _render_queue_markdown(items: list[LinkedInQueueItemResponse]) -> str:
 
     for group in grouped.values():
         head = group[0]
-        lines.append(f"## {head.prospect_name} — {head.prospect_company}")
+        lines.append(f"## {_queue_heading(head)}")
         lines.append("")
         if head.linkedin_url:
             lines.append(f"[LinkedIn profile]({head.linkedin_url})")

--- a/ee/pocketpaw_ee/cloud/models/prospect.py
+++ b/ee/pocketpaw_ee/cloud/models/prospect.py
@@ -11,7 +11,10 @@
 # Updated 2026-07-28 (feat/growth-projects): ``name`` and ``company`` default to
 # ``""`` — a prospect may be JUST A DOMAIN until research fills the rest in, so
 # the stored fields have to be able to say "not yet known". Existing rows all
-# carry values, so this is a widening with no migration.
+# carry values, so this is a widening with no migration. Also ``project_id`` —
+# the client container (``cloud/projects``) a prospect belongs to — plus a
+# (workspace, project_id, createdAt) index, because an agency's default view is
+# one client's pipeline rather than the whole workspace's.
 
 from __future__ import annotations
 
@@ -34,6 +37,10 @@ class Prospect(TimestampedDocument):
     # Company website domain, lowercased at the service boundary — the dedupe key.
     domain: str
     source: str  # clay | directory | manual (validated at the DTO boundary)
+    # The client this prospect belongs to (``cloud/projects``), or None on a
+    # workspace that doesn't use projects. Validated against the workspace by
+    # the service before it is written.
+    project_id: str | None = None
     tier: str = "unqualified"  # a | b | c | unqualified
     research_brief: str = ""
     emails: list[str] = Field(default_factory=list)
@@ -55,4 +62,8 @@ class Prospect(TimestampedDocument):
             ),
             # List cursor: the prospects view pages newest-first per workspace.
             [("workspace", 1), ("createdAt", -1)],
+            # Project-scoped list cursor: an agency's default view is ONE
+            # client's pipeline, so the project filter belongs in the index
+            # rather than as a post-filter over the whole workspace.
+            [("workspace", 1), ("project_id", 1), ("createdAt", -1)],
         ]

--- a/ee/pocketpaw_ee/cloud/models/prospect.py
+++ b/ee/pocketpaw_ee/cloud/models/prospect.py
@@ -8,6 +8,10 @@
 #
 # Created 2026-07-27 (feat/growth-g1): first slice of /growth — the prospect
 # store. Later slices (ingestion, drafts, gated sends) build on this doc.
+# Updated 2026-07-28 (feat/growth-projects): ``name`` and ``company`` default to
+# ``""`` — a prospect may be JUST A DOMAIN until research fills the rest in, so
+# the stored fields have to be able to say "not yet known". Existing rows all
+# carry values, so this is a widening with no migration.
 
 from __future__ import annotations
 
@@ -23,8 +27,10 @@ class Prospect(TimestampedDocument):
 
     # Tenancy boundary — every read filters on this.
     workspace: Indexed(str)  # type: ignore[valid-type]
-    name: str
-    company: str
+    # Both default to "" — NOT YET KNOWN. A pasted list of bare domains is a
+    # legitimate import; research fills these in later.
+    name: str = ""
+    company: str = ""
     # Company website domain, lowercased at the service boundary — the dedupe key.
     domain: str
     source: str  # clay | directory | manual (validated at the DTO boundary)

--- a/tests/cloud/growth/test_email_dispatch.py
+++ b/tests/cloud/growth/test_email_dispatch.py
@@ -499,3 +499,192 @@ def test_sending_domain_is_normalised(monkeypatch):
     monkeypatch.setenv(growth_connector.SENDING_DOMAIN_ENV, "  WWW.Outbound-Paw.dev. ")
 
     assert growth_connector.resolve_sending_domain() == "outbound-paw.dev"
+
+
+# ---------------------------------------------------------------------------
+# Per-project sender identity (feat/growth-projects)
+#
+# An agency sending for a client sends AS the client. Identity resolves per
+# project with a per-FIELD fallback to the workspace default; the credential
+# is untouched by any of it.
+# ---------------------------------------------------------------------------
+
+
+async def _seed_draft_for_project(project_id: str | None, domain: str) -> str:
+    prospect = _ProspectDoc(
+        workspace=WORKSPACE,
+        name="Sam Founder",
+        company="Acme Dental",
+        domain=domain,
+        source="manual",
+        project_id=project_id,
+        emails=[f"sam@{domain}"],
+    )
+    await prospect.insert()
+    draft = _DraftDoc(
+        workspace=WORKSPACE,
+        prospect_id=str(prospect.id),
+        channel="email",
+        subject="Quick question",
+        body="Hi Sam — worth a look?",
+        status="approved",
+    )
+    await draft.insert()
+    return str(draft.id)
+
+
+def _sent_payload(recorder: _Recorder, index: int = 0) -> dict[str, Any]:
+    import json
+
+    return json.loads(recorder.requests[index].content)
+
+
+@pytest.mark.asyncio
+async def test_project_sender_identity_overrides_the_workspace_default(
+    mongo_db, sending_env, monkeypatch
+):
+    recorder = _Recorder(_ok_response)
+    _install_transport(monkeypatch, recorder)
+    await _seed_connector(
+        {
+            growth_connector.TOKEN_KEY: TOKEN,
+            growth_connector.FROM_EMAIL_KEY: f"agency@{SENDING_DOMAIN}",
+            growth_connector.FROM_NAME_KEY: "The Agency",
+            growth_connector.REPLY_TO_KEY: "hello@agency.test",
+            growth_connector.PROJECT_SENDERS_KEY: {
+                "p-northwind": {
+                    "from_email": f"northwind@{SENDING_DOMAIN}",
+                    "from_name": "Northwind Dental",
+                    "reply_to": "front-desk@northwinddental.test",
+                }
+            },
+        }
+    )
+
+    await email_dispatch.dispatch_email(await _seed_draft_for_project("p-northwind", "nw.test"))
+
+    payload = _sent_payload(recorder)
+    assert payload["from"] == {
+        "email": f"northwind@{SENDING_DOMAIN}",
+        "name": "Northwind Dental",
+    }
+    # The reply lands with the CLIENT, not the agency. That is the feature.
+    assert payload["headers"]["Reply-To"] == "front-desk@northwinddental.test"
+
+
+@pytest.mark.asyncio
+async def test_sender_falls_back_per_field_not_per_record(mongo_db, sending_env, monkeypatch):
+    """A project that only renames itself keeps the workspace's reply-to —
+    one agency inbox, many client names, which is the common shape."""
+    recorder = _Recorder(_ok_response)
+    _install_transport(monkeypatch, recorder)
+    await _seed_connector(
+        {
+            growth_connector.TOKEN_KEY: TOKEN,
+            growth_connector.FROM_EMAIL_KEY: f"agency@{SENDING_DOMAIN}",
+            growth_connector.FROM_NAME_KEY: "The Agency",
+            growth_connector.REPLY_TO_KEY: "hello@agency.test",
+            growth_connector.PROJECT_SENDERS_KEY: {
+                "p-northwind": {"from_name": "Northwind Dental"}
+            },
+        }
+    )
+
+    await email_dispatch.dispatch_email(await _seed_draft_for_project("p-northwind", "nw.test"))
+
+    payload = _sent_payload(recorder)
+    assert payload["from"] == {"email": f"agency@{SENDING_DOMAIN}", "name": "Northwind Dental"}
+    assert payload["headers"]["Reply-To"] == "hello@agency.test"
+
+
+@pytest.mark.asyncio
+async def test_prospect_without_a_project_sends_as_the_workspace(
+    mongo_db, sending_env, monkeypatch
+):
+    """The no-projects workspace must be byte-for-byte what it was before."""
+    recorder = _Recorder(_ok_response)
+    _install_transport(monkeypatch, recorder)
+    await _seed_connector(
+        {
+            growth_connector.TOKEN_KEY: TOKEN,
+            growth_connector.FROM_EMAIL_KEY: f"agency@{SENDING_DOMAIN}",
+            growth_connector.FROM_NAME_KEY: "The Agency",
+            growth_connector.PROJECT_SENDERS_KEY: {
+                "p-northwind": {"from_name": "Northwind Dental"}
+            },
+        }
+    )
+
+    await email_dispatch.dispatch_email(await _seed_draft_for_project(None, "loose.test"))
+
+    payload = _sent_payload(recorder)
+    assert payload["from"] == {"email": f"agency@{SENDING_DOMAIN}", "name": "The Agency"}
+    assert "headers" not in payload
+
+
+@pytest.mark.asyncio
+async def test_project_from_address_still_has_to_be_on_the_sending_domain(
+    mongo_db, sending_env, monkeypatch
+):
+    """A project cannot send as a domain the deployment doesn't hold — that
+    mail fails DMARC and burns the domain it CAN send from. The override is a
+    different value, not a different rule."""
+    recorder = _Recorder(_ok_response)
+    _install_transport(monkeypatch, recorder)
+    await _seed_connector(
+        {
+            growth_connector.TOKEN_KEY: TOKEN,
+            growth_connector.PROJECT_SENDERS_KEY: {
+                "p-northwind": {"from_email": "hello@northwinddental.test"}
+            },
+        }
+    )
+
+    await email_dispatch.dispatch_email(await _seed_draft_for_project("p-northwind", "nw.test"))
+
+    assert recorder.requests == []
+    logs = await _logs()
+    assert [log.outcome for log in logs] == ["failed"]
+    assert "sending domain" in (logs[0].error or "")
+
+
+@pytest.mark.asyncio
+async def test_a_malformed_project_senders_blob_falls_back_instead_of_failing(
+    mongo_db, sending_env, monkeypatch
+):
+    """A typo in one project's entry must not take an unrelated client's
+    pipeline down — it sends as the workspace default."""
+    recorder = _Recorder(_ok_response)
+    _install_transport(monkeypatch, recorder)
+    await _seed_connector(
+        {
+            growth_connector.TOKEN_KEY: TOKEN,
+            growth_connector.FROM_EMAIL_KEY: f"agency@{SENDING_DOMAIN}",
+            growth_connector.PROJECT_SENDERS_KEY: "not-a-map",
+        }
+    )
+
+    await email_dispatch.dispatch_email(await _seed_draft_for_project("p-northwind", "nw.test"))
+
+    assert _sent_payload(recorder)["from"] == {"email": f"agency@{SENDING_DOMAIN}"}
+
+
+@pytest.mark.asyncio
+async def test_project_identity_never_changes_the_credential(mongo_db, sending_env, monkeypatch):
+    """Identity resolution sits in FRONT of credential resolution, not
+    instead of it: the token is still the workspace's, so disabling the
+    connector still revokes every project at once."""
+    recorder = _Recorder(_ok_response)
+    _install_transport(monkeypatch, recorder)
+    await _seed_connector(
+        {
+            growth_connector.TOKEN_KEY: TOKEN,
+            growth_connector.PROJECT_SENDERS_KEY: {
+                "p-northwind": {"from_name": "Northwind Dental"}
+            },
+        }
+    )
+
+    await email_dispatch.dispatch_email(await _seed_draft_for_project("p-northwind", "nw.test"))
+
+    assert recorder.requests[0].headers["Api-Token"] == TOKEN

--- a/tests/cloud/growth/test_followups.py
+++ b/tests/cloud/growth/test_followups.py
@@ -621,3 +621,91 @@ async def test_a_draft_with_no_send_record_still_falls_back_to_the_flip(db):
 
     assert row["sent_at"] is not None
     assert (datetime.now(UTC) - row["sent_at"]).days == 0
+
+
+# ---------------------------------------------------------------------------
+# Grouping by client (feat/growth-projects)
+#
+# The sweep works one client's threads together so their follow-ups go out
+# under that client's sender identity. The thing that must NOT change: it is
+# still ONE pass over each thread, and the open-follow-up guard still holds.
+# ---------------------------------------------------------------------------
+
+
+async def _project(workspace_id: str, name: str) -> str:
+    from pocketpaw_ee.cloud.models.project import Project as _ProjectDoc
+
+    doc = _ProjectDoc(
+        workspace=workspace_id,
+        name=name,
+        description="",
+        color="",
+        lead_id=None,
+        status="active",
+        created_by="u1",
+    )
+    await doc.insert()
+    return str(doc.id)
+
+
+@pytest.mark.asyncio
+async def test_sweep_covers_every_project_exactly_once(db, tray):
+    """Three clients plus an unassigned prospect: each gets one follow-up, and
+    nobody gets two. Grouping must not turn one sweep into N sweeps."""
+    a = await _project("w1", "Client A")
+    b = await _project("w1", "Client B")
+    for index, project_id in enumerate((a, a, b, None)):
+        await _sent_thread("w1", domain=f"client-{index}.com", project_id=project_id)
+
+    counters = await followup_sweep({}, now=_in_days(5))
+
+    assert counters["created"] == 4
+    followups = await _followups("w1")
+    assert len(followups) == 4
+    # One per thread — no thread was worked twice.
+    assert len({f.prospect_id for f in followups}) == 4
+    assert all(f.status == "proposed" for f in followups)
+
+
+@pytest.mark.asyncio
+async def test_grouping_does_not_break_the_open_followup_guard(db, tray):
+    """The idempotency guard is per-thread and survives the partition: a second
+    pass over the same grouped data proposes nothing new."""
+    a = await _project("w1", "Client A")
+    b = await _project("w1", "Client B")
+    for index, project_id in enumerate((a, b)):
+        await _sent_thread("w1", domain=f"client-{index}.com", project_id=project_id)
+
+    first = await followup_sweep({}, now=_in_days(5))
+    assert first["created"] == 2
+
+    second = await followup_sweep({}, now=_in_days(6))
+    assert second["created"] == 0
+    assert second["skipped"] == 2
+    assert len(await _followups("w1")) == 2
+
+
+@pytest.mark.asyncio
+async def test_a_client_whose_prospect_is_unreadable_does_not_stop_the_others(
+    db, tray, monkeypatch
+):
+    """One client's bad row must not cost another client their whole pass."""
+    a = await _project("w1", "Client A")
+    bad, _ = await _sent_thread("w1", domain="bad.com", project_id=a)
+    await _sent_thread("w1", domain="good.com")
+
+    real = growth_service.get_prospect_system
+
+    async def _flaky(workspace_id: str, prospect_id: str):
+        if prospect_id == bad.id:
+            raise RuntimeError("prospect row is unreadable")
+        return await real(workspace_id, prospect_id)
+
+    monkeypatch.setattr(growth_service, "get_prospect_system", _flaky)
+
+    counters = await followup_sweep({}, now=_in_days(5))
+
+    assert counters["created"] == 1
+    assert counters["skipped"] == 1
+    assert counters["threads"] == 2
+    assert [f.prospect_id for f in await _followups("w1")] != [bad.id]

--- a/tests/cloud/growth/test_followups.py
+++ b/tests/cloud/growth/test_followups.py
@@ -245,6 +245,22 @@ def test_render_followup_does_not_double_prefix_a_reply_subject():
     assert subject == "Re: already a reply"
 
 
+def test_render_followup_degrades_for_a_prospect_that_is_just_a_domain():
+    """Name and company can both be empty — the copy must still read like a
+    person wrote it, and must never surface a placeholder word."""
+    subject, body = render_followup(
+        channel="email",
+        prospect_name="",
+        prospect_company="",
+        first_touch={"subject": "", "body": "hi"},
+    )
+    assert subject == "Following up"  # no orphaned dash
+    assert "Hi there," in body
+    assert "your team" in body
+    assert "unknown" not in body.lower()
+    assert "unknown" not in (subject or "").lower()
+
+
 def test_render_followup_omits_subject_off_email():
     """The draft DTO refuses a subject on non-email channels — the renderer
     must not hand one over."""

--- a/tests/cloud/growth/test_linkedin_queue.py
+++ b/tests/cloud/growth/test_linkedin_queue.py
@@ -342,3 +342,29 @@ async def test_md_export_empty_queue(w1_client):
 async def test_queue_rejects_unknown_format(w1_client):
     resp = await w1_client.get("/api/v1/growth/linkedin/queue", params={"format": "html"})
     assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_md_export_titles_a_nameless_prospect_with_its_domain(w1_client):
+    """A prospect can be just a domain. The export must degrade to something
+    TRUE — the domain — never to a placeholder like "Unknown — Unknown"."""
+    prospect = await _create_prospect(w1_client, name="", company="")
+    draft = await _create_draft(w1_client, prospect["id"])
+    await _walk(w1_client, draft["id"], "proposed")
+
+    md = (await w1_client.get("/api/v1/growth/linkedin/queue", params={"format": "md"})).text
+    assert "## acme-dental.com" in md
+    assert "unknown" not in md.lower()
+    assert "—" not in md.splitlines()[2]  # no orphaned dash on the heading line
+
+
+@pytest.mark.asyncio
+async def test_md_export_titles_a_half_known_prospect_with_what_it_has(w1_client):
+    """Company known, contact not: the heading is the company alone."""
+    prospect = await _create_prospect(w1_client, name="")
+    draft = await _create_draft(w1_client, prospect["id"])
+    await _walk(w1_client, draft["id"], "proposed")
+
+    md = (await w1_client.get("/api/v1/growth/linkedin/queue", params={"format": "md"})).text
+    assert "## Acme Dental" in md
+    assert "## Acme Dental —" not in md

--- a/tests/cloud/growth/test_router.py
+++ b/tests/cloud/growth/test_router.py
@@ -438,3 +438,218 @@ async def test_research_fills_in_a_bare_domain_later(w1_client):
     assert patched.json()["company"] == "Northwind Dental"
     assert patched.json()["domain"] == "northwinddental.com"
     assert patched.json()["id"] == created["id"]
+
+
+# ---------------------------------------------------------------------------
+# Project scoping (feat/growth-projects)
+#
+# An agency runs one outbound pipeline per client, and ``cloud/projects`` is
+# already that container. Growth consumes it the way tasks and cycles do:
+# nullable, validated at entry, an optional filter on the reads.
+# ---------------------------------------------------------------------------
+
+
+async def _make_project(workspace_id: str, name: str = "Client A") -> str:
+    from pocketpaw_ee.cloud.models.project import Project as _ProjectDoc
+
+    doc = _ProjectDoc(
+        workspace=workspace_id,
+        name=name,
+        description="",
+        color="",
+        lead_id=None,
+        status="active",
+        created_by="u1",
+    )
+    await doc.insert()
+    return str(doc.id)
+
+
+@pytest.mark.asyncio
+async def test_create_assigns_a_project(w1_client, mongo_db):
+    project_id = await _make_project("w1")
+    resp = await w1_client.post("/api/v1/growth/prospects", json=_payload(project_id=project_id))
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["project_id"] == project_id
+
+
+@pytest.mark.asyncio
+async def test_create_without_a_project_is_unchanged(w1_client):
+    """A workspace that doesn't use projects sees exactly what it saw before."""
+    resp = await w1_client.post("/api/v1/growth/prospects", json=_payload())
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["project_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_a_foreign_or_missing_project(w1_client, mongo_db):
+    """Another tenant's project is a hard error, and indistinguishable from a
+    project that never existed — existence must not leak either way."""
+    foreign = await _make_project("w2")
+    resp = await w1_client.post("/api/v1/growth/prospects", json=_payload(project_id=foreign))
+    assert resp.status_code == 404
+    assert resp.json()["error"]["code"] == "project.not_found"
+
+    ghost = await w1_client.post(
+        "/api/v1/growth/prospects",
+        json=_payload(domain="other.com", project_id="507f1f77bcf86cd799439011"),
+    )
+    assert ghost.status_code == 404
+    assert ghost.json()["error"]["code"] == "project.not_found"
+
+    # Nothing was written on either refusal.
+    assert (await w1_client.get("/api/v1/growth/prospects")).json()["total"] == 0
+
+
+@pytest.mark.asyncio
+async def test_list_and_facets_scope_to_one_project(w1_client, mongo_db):
+    a = await _make_project("w1", "Client A")
+    b = await _make_project("w1", "Client B")
+    await w1_client.post(
+        "/api/v1/growth/prospects", json=_payload(domain="a1.com", project_id=a, tier="a")
+    )
+    await w1_client.post(
+        "/api/v1/growth/prospects", json=_payload(domain="a2.com", project_id=a, tier="b")
+    )
+    await w1_client.post(
+        "/api/v1/growth/prospects", json=_payload(domain="b1.com", project_id=b, tier="a")
+    )
+    await w1_client.post("/api/v1/growth/prospects", json=_payload(domain="loose.com"))
+
+    everything = (await w1_client.get("/api/v1/growth/prospects")).json()
+    assert everything["total"] == 4
+
+    scoped = (await w1_client.get("/api/v1/growth/prospects", params={"project_id": a})).json()
+    assert scoped["total"] == 2
+    assert {i["domain"] for i in scoped["items"]} == {"a1.com", "a2.com"}
+
+    # Empty string is the "no client assigned" bucket, not "every project".
+    unassigned = (await w1_client.get("/api/v1/growth/prospects", params={"project_id": ""})).json()
+    assert unassigned["total"] == 1
+    assert unassigned["items"][0]["domain"] == "loose.com"
+
+    # The chips describe the client being viewed, not the whole workspace.
+    facets = (
+        await w1_client.get("/api/v1/growth/prospects/facets", params={"project_id": a})
+    ).json()
+    assert facets["tier"]["a"] == 1
+    assert facets["tier"]["b"] == 1
+    assert facets["status"]["new"] == 2
+
+
+@pytest.mark.asyncio
+async def test_search_respects_the_project_scope(w1_client, mongo_db):
+    a = await _make_project("w1", "Client A")
+    await w1_client.post(
+        "/api/v1/growth/prospects",
+        json=_payload(domain="a1.com", company="Northwind Dental", project_id=a),
+    )
+    await w1_client.post(
+        "/api/v1/growth/prospects",
+        json=_payload(domain="b1.com", company="Northwind Dental"),
+    )
+
+    both = (await w1_client.get("/api/v1/growth/prospects", params={"q": "northwind"})).json()
+    assert both["total"] == 2
+    scoped = (
+        await w1_client.get("/api/v1/growth/prospects", params={"q": "northwind", "project_id": a})
+    ).json()
+    assert scoped["total"] == 1
+    assert scoped["items"][0]["domain"] == "a1.com"
+
+
+@pytest.mark.asyncio
+async def test_patch_reassigns_and_clears_the_project(w1_client, mongo_db):
+    a = await _make_project("w1", "Client A")
+    b = await _make_project("w1", "Client B")
+    created = (await w1_client.post("/api/v1/growth/prospects", json=_payload(project_id=a))).json()
+
+    moved = await w1_client.patch(
+        f"/api/v1/growth/prospects/{created['id']}", json={"project_id": b}
+    )
+    assert moved.status_code == 200, moved.text
+    assert moved.json()["project_id"] == b
+
+    # Omitting the field leaves the assignment alone.
+    untouched = await w1_client.patch(
+        f"/api/v1/growth/prospects/{created['id']}", json={"tier": "a"}
+    )
+    assert untouched.json()["project_id"] == b
+
+    # An empty string is the explicit un-assign.
+    cleared = await w1_client.patch(
+        f"/api/v1/growth/prospects/{created['id']}", json={"project_id": ""}
+    )
+    assert cleared.json()["project_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_patch_rejects_a_foreign_project(w1_client, mongo_db):
+    foreign = await _make_project("w2")
+    created = (await w1_client.post("/api/v1/growth/prospects", json=_payload())).json()
+    resp = await w1_client.patch(
+        f"/api/v1/growth/prospects/{created['id']}", json={"project_id": foreign}
+    )
+    assert resp.status_code == 404
+    assert resp.json()["error"]["code"] == "project.not_found"
+    same = (await w1_client.get(f"/api/v1/growth/prospects/{created['id']}")).json()
+    assert same["project_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_bulk_import_assigns_a_project_and_a_re_import_never_orphans(w1_client, mongo_db):
+    """An import lands in the selected client's pipeline. A later re-import
+    that says nothing about projects — an enrichment pass, say — must not
+    silently un-assign the rows."""
+    a = await _make_project("w1", "Client A")
+    rows = [{"domain": d, "source": "directory", "project_id": a} for d in ("x.com", "y.com")]
+    first = await w1_client.post("/api/v1/growth/prospects/bulk", json={"rows": rows})
+    assert first.status_code == 200, first.text
+    assert first.json()["created"] == 2
+
+    again = await w1_client.post(
+        "/api/v1/growth/prospects/bulk",
+        json={"rows": [{"domain": "x.com", "source": "directory", "name": "Ada"}]},
+    )
+    assert again.json()["updated"] == 1
+    scoped = (await w1_client.get("/api/v1/growth/prospects", params={"project_id": a})).json()
+    assert scoped["total"] == 2
+    enriched = next(i for i in scoped["items"] if i["domain"] == "x.com")
+    assert enriched["name"] == "Ada"
+    assert enriched["project_id"] == a
+
+
+@pytest.mark.asyncio
+async def test_bulk_import_rejects_a_foreign_project_row(w1_client, mongo_db):
+    foreign = await _make_project("w2")
+    resp = await w1_client.post(
+        "/api/v1/growth/prospects/bulk",
+        json={"rows": [{"domain": "x.com", "source": "directory", "project_id": foreign}]},
+    )
+    # One bad row, not a bad payload: it becomes an indexed error entry and
+    # the good rows in the same batch still land.
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["created"] == 0
+    assert [e["code"] for e in body["errors"]] == ["project.not_found"]
+    assert body["errors"][0]["index"] == 0
+    assert (await w1_client.get("/api/v1/growth/prospects")).json()["total"] == 0
+
+
+@pytest.mark.asyncio
+async def test_bulk_import_bad_project_row_does_not_abort_the_batch(w1_client, mongo_db):
+    foreign = await _make_project("w2")
+    resp = await w1_client.post(
+        "/api/v1/growth/prospects/bulk",
+        json={
+            "rows": [
+                {"domain": "bad.com", "source": "directory", "project_id": foreign},
+                {"domain": "good.com", "source": "directory"},
+            ]
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["created"] == 1
+    assert len(resp.json()["errors"]) == 1
+    listed = (await w1_client.get("/api/v1/growth/prospects")).json()
+    assert [i["domain"] for i in listed["items"]] == ["good.com"]

--- a/tests/cloud/growth/test_router.py
+++ b/tests/cloud/growth/test_router.py
@@ -368,3 +368,73 @@ async def test_cross_tenant_access_is_isolated(w1_client, w2_client, op):
         assert resp.status_code == 200
         assert resp.json()["items"] == []
         assert resp.json()["total"] == 0
+
+
+# ---------------------------------------------------------------------------
+# A prospect can be just a domain (feat/growth-projects)
+#
+# A pasted import arrives as bare domains. ``name`` / ``company`` mean "not yet
+# known" when empty; ``domain`` stays required because it IS the identity.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_accepts_a_bare_domain(w1_client):
+    resp = await w1_client.post(
+        "/api/v1/growth/prospects",
+        json={"domain": "northwinddental.com", "source": "directory"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["domain"] == "northwinddental.com"
+    # Empty means "not yet known" — never a placeholder word.
+    assert body["name"] == ""
+    assert body["company"] == ""
+    assert "unknown" not in resp.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_create_still_requires_a_domain(w1_client):
+    resp = await w1_client.post("/api/v1/growth/prospects", json={"source": "manual"})
+    assert resp.status_code == 422
+    blank = await w1_client.post(
+        "/api/v1/growth/prospects", json={"domain": "  ", "source": "manual"}
+    )
+    assert blank.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_bulk_ingest_accepts_bare_domain_rows(w1_client):
+    """The honest shape of an import: a list of domains, one per line."""
+    rows = [{"domain": d, "source": "directory"} for d in ("a-co.com", "b-co.com", "c-co.com")]
+    resp = await w1_client.post("/api/v1/growth/prospects/bulk", json={"rows": rows})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["created"] == 3
+    assert body["errors"] == []
+
+    listed = (await w1_client.get("/api/v1/growth/prospects")).json()
+    assert listed["total"] == 3
+    assert {item["domain"] for item in listed["items"]} == {"a-co.com", "b-co.com", "c-co.com"}
+    assert all(item["name"] == "" and item["company"] == "" for item in listed["items"])
+
+
+@pytest.mark.asyncio
+async def test_research_fills_in_a_bare_domain_later(w1_client):
+    """The whole point of allowing the empty row: it gets enriched in place,
+    on the same (workspace, domain) identity — no duplicate."""
+    created = (
+        await w1_client.post(
+            "/api/v1/growth/prospects",
+            json={"domain": "northwinddental.com", "source": "directory"},
+        )
+    ).json()
+    patched = await w1_client.patch(
+        f"/api/v1/growth/prospects/{created['id']}",
+        json={"name": "Dr Nguyen", "company": "Northwind Dental", "tier": "b"},
+    )
+    assert patched.status_code == 200, patched.text
+    assert patched.json()["name"] == "Dr Nguyen"
+    assert patched.json()["company"] == "Northwind Dental"
+    assert patched.json()["domain"] == "northwinddental.com"
+    assert patched.json()["id"] == created["id"]


### PR DESCRIPTION
An agency isn't one outbound pipeline — it's one per client. `/growth` v1
scoped everything to a workspace, so an agency running outbound for eight
clients got eight pipelines in one undifferentiated list, all sending from the
same identity. This scopes growth by the project primitive that `tasks` and
`cycles` already use, and fixes the import path that made the whole surface
unusable from zero.

Spec: `docs/design/drafts/2026-07-28-growth-discovery-and-projects.md` §3, §5.

## A prospect can be just a domain

`name` and `company` lose `min_length=1` and default to `""`, meaning *not yet
known*. That's the honest shape an import arrives in — someone hands you forty
agency websites and nothing else; research fills the rest in later. `domain`
stays required and still normalises.

The sweep for what breaks on an empty name found three real ones, all fixed:
the LinkedIn markdown export would have written `## — `, the follow-up subject
would have read `Following up —`, and the MCP upsert's `or "unknown"` fallbacks
would have **stamped the literal string "unknown" over a stored blank** on any
enrichment call.

The MCP handler's own refusal to create a nameless prospect is untouched. That
guard is about a different caller: when the agent researches a company and
files it, it should know the name, and an "unknown / unknown" row is worse than
a refusal it can act on. A human pasting a domain list carries no such
obligation. Same field, two callers, two truths.

## `project_id` on Prospect

Mirrors `tasks` exactly — nullable on the domain object, the doc and the DTOs,
validated at entry against the workspace, an optional filter on list, facets
and search, plus a `(workspace, project_id, createdAt)` index. A workspace not
using projects sees no change.

Growth got its own `_ensure_project_in_workspace` rather than importing
`tasks`'. Not a contract problem — both linter configs pass either way — but
that helper is private, and reaching across an entity boundary for a sibling's
private function is the drift the 4-file rule exists to prevent. Both copies
call the same public `projects.service.exists_in_workspace`.

Two edges worth knowing: an upsert only ever *sets* `project_id` and never
clears it, because otherwise every agent enrichment call would silently orphan
a client's prospect — un-assigning is an explicit `PATCH` with `""`. And a row
naming a foreign project is now one indexed error inside a bulk ingest rather
than a 404 that kills the whole batch.

## Sending as the client — and the part that can't work

Per-**field** fallback to the workspace default, resolved in front of the
existing credential read. A project that overrides only the display name keeps
the workspace reply-to instead of losing it, which is the common case: one
agency inbox, many client names.

**`from_email` stays pinned to `GROWTH_SENDING_DOMAIN`, and the spec was wrong
to imply otherwise.** You cannot send as `hello@theirdomain.com` without their
DNS — mail claiming a domain you don't hold fails DMARC, lands in spam, and
burns the reputation of the domain you *do* hold. The honest shape is
`clientname@<sending-domain>` in the from-address, the client's name in
`from_name`, and the client's own inbox in `reply_to`, which is how agencies
actually send and reads correctly to the recipient. Sending from a client's own
domain needs their DNS delegated — an onboarding flow, not a config key.

The token stays the workspace's, so disabling the connector still revokes every
project at once. Email only; WhatsApp is untouched and needs Meta Tech Provider
onboarding separately.

## The follow-up sweep works one client at a time

Threads partition by `(workspace, project)` before being worked, over the same
collapsed thread map the flat loop already walked — one thread, one prospect,
one project — so every thread is still visited exactly once. The open-follow-up
idempotency guard is untouched in place, and a test pins that a second pass over
grouped data proposes nothing. Cheap checks stay in front of the prospect read,
so a not-yet-due backlog costs no more than before.

## Tests

294 pass in `tests/cloud/growth/`, up from 274 on the base — 20 new. Both
import-linter configs clean (1 and 35 contracts). mypy reports the same 10
errors on the same lines as the base commit; none added.

`tests/cloud/tasks/` has 14 failures, confirmed pre-existing by running them on
the base commit — identical 14.

No new routes, so the guard-coverage surface in `test_gate.py` is unchanged by
design: `project_id` rides as a query param on the existing list and facets
routes.
