### PR TITLE
Discovery: hunts that go looking, and an email rule that never guesses

### DIFF
--- a/ee/pocketpaw_ee/cloud/growth/discovery.py
+++ b/ee/pocketpaw_ee/cloud/growth/discovery.py
@@ -48,12 +48,64 @@
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass
-from typing import Protocol
+from datetime import UTC, datetime
+from typing import Any, Protocol
 
-from pocketpaw_ee.cloud.growth.domain import EmailEvidence, recordable_emails
+from pocketpaw_ee.cloud._core.errors import CloudError, RateLimited
+from pocketpaw_ee.cloud.growth.domain import (
+    GROWTH_DISCOVERY_SWEEP_JOB_NAME,
+    SCHEDULED_CADENCES,
+    WEEKLY_DISCOVERY_WEEKDAY,
+    EmailEvidence,
+    recordable_emails,
+)
 
 logger = logging.getLogger(__name__)
+
+# How many prospects ONE workspace may have discovered in a calendar month,
+# across every ICP it owns. Read from the environment at CALL time (not
+# import) so a redeploy-free change and the tests' monkeypatching both work —
+# same convention as the follow-up sweep's knobs.
+#
+# The default is deliberately a number a human could actually work through.
+# The failure mode this bounds is not cost, it is a pipeline nobody reviews:
+# an ICP left running against loose criteria fills the list with companies
+# nobody chose, and a list nobody trusts stops getting opened at all.
+DEFAULT_DISCOVERY_MONTHLY_MAX = 200
+
+# How many due ICPs one sweep tick will work through.
+DUE_ICP_SCAN_LIMIT = 500
+
+
+def discovery_monthly_max() -> int:
+    """The per-workspace monthly discovery ceiling. Fail-soft on a bad value."""
+    raw = os.environ.get("GROWTH_DISCOVERY_MONTHLY_MAX", "").strip()
+    if not raw:
+        return DEFAULT_DISCOVERY_MONTHLY_MAX
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            "growth discovery: GROWTH_DISCOVERY_MONTHLY_MAX=%r is not an integer — using %d",
+            raw,
+            DEFAULT_DISCOVERY_MONTHLY_MAX,
+        )
+        return DEFAULT_DISCOVERY_MONTHLY_MAX
+    # 0 disables discovery entirely, which is a legitimate thing to want on a
+    # deployment that hasn't reviewed the feature yet. Negative is a typo.
+    return max(value, 0)
+
+
+def _period_start(now: datetime) -> datetime:
+    """The start of the calendar month ``now`` falls in, in UTC.
+
+    A calendar month rather than a rolling 30-day window: an operator asked
+    "how many did we find this month" answers from a calendar, and a ceiling
+    they cannot compute in their head is a ceiling they will be surprised by.
+    """
+    return now.astimezone(UTC).replace(day=1, hour=0, minute=0, second=0, microsecond=0)
 
 
 # ---------------------------------------------------------------------------
@@ -313,27 +365,44 @@ async def run_discovery(
     workspace_id: str,
     icp_id: str,
     research_fn: ResearchFn,
+    *,
+    now: datetime | None = None,
 ) -> DiscoveryOutcome:
-    """Run one ICP and file what it found. NEVER raises except NotFound.
+    """Run one ICP and file what it found.
 
-    The sequence is deliberately boring: read the ICP, research once, truncate
-    to ``max_per_run``, drop the rows that cannot be filed, upsert the rest at
-    ``status="new"``. Nothing here drafts, sends, or touches the Instinct gate
-    — a discovered prospect arrives in exactly the state a pasted domain does,
-    and every outbound step downstream still needs the human it always needed.
+    The sequence is deliberately boring: read the ICP, check the workspace's
+    monthly room, research once, truncate to what may still be filed, drop the
+    rows that cannot be filed, upsert the rest at ``status="new"``. Nothing
+    here drafts, sends, or touches the Instinct gate — a discovered prospect
+    arrives in exactly the state a pasted domain does, and every outbound step
+    downstream still needs the human it always needed.
 
-    ``max_per_run`` truncates the RESULT, so a research loop that returns 200
-    companies against a limit of 10 files at most 10. Rows skipped because the
-    workspace already has them do not free budget for extra ones: the number a
-    human agreed to review is the number that can appear.
+    TWO bounds, and they do different jobs. ``max_per_run`` is per ICP and
+    caps one batch at a size a human will actually read. The monthly ceiling is
+    per WORKSPACE and caps automated volume however many ICPs it is spread
+    across — five profiles must not buy five allowances. When the month has
+    less room left than this run wants, the run is TRUNCATED to the room
+    available; only a workspace with zero room left is refused outright, with a
+    429 ``icp.monthly_ceiling`` (a volume limit, not a wallet problem — see
+    ``RateLimited``).
 
-    A paused ICP returns a zero outcome rather than raising — the cron already
+    Rows skipped because the workspace already has them do not free budget for
+    extra ones: the number a human agreed to review is the number that can
+    appear.
+
+    Raises only ``NotFound`` (the ICP is gone) and the ceiling's
+    ``RateLimited``. Everything else — a research crash, an unfilable row — is
+    a counted non-event, because one bad ICP must not end a cron pass that has
+    other workspaces left to serve.
+
+    A paused ICP returns a zero outcome rather than raising: the cron already
     filters on status, and a manual caller asking for a paused profile wants
     "it didn't run", not a 4xx.
     """
     from pocketpaw_ee.cloud.growth import service as growth_service
     from pocketpaw_ee.cloud.growth.dto import CreateProspectRequest
 
+    now = now or datetime.now(UTC)
     icp = await growth_service.get_icp_system(workspace_id, icp_id)
     if icp.status != "active":
         logger.info("growth discovery: icp=%s is %s — not running", icp_id, icp.status)
@@ -341,11 +410,24 @@ async def run_discovery(
             icp_id=icp_id, workspace_id=workspace_id, error=f"icp is {icp.status}"
         )
 
+    # The ceiling is checked BEFORE the research pass, not after: a workspace
+    # that is out of room should not spend an agent run to discover that.
+    ceiling = discovery_monthly_max()
+    spent = await growth_service.count_discovered_since(workspace_id, _period_start(now))
+    room = max(ceiling - spent, 0)
+    if room <= 0:
+        raise RateLimited(
+            "icp.monthly_ceiling",
+            f"This workspace has discovered {spent} prospects this month, "
+            f"which is its ceiling of {ceiling}. Discovery resumes next month; "
+            f"pause an ICP or narrow its criteria if this is not what you wanted.",
+        )
+
     result, error = await _research(icp, research_fn, workspace_id=workspace_id)
     if result is None:
         return DiscoveryOutcome(icp_id=icp_id, workspace_id=workspace_id, error=error)
 
-    considered = result.companies[: max(icp.max_per_run, 0)]
+    considered = result.companies[: max(min(icp.max_per_run, room), 0)]
     filed = 0
     skipped_existing = 0
     skipped_invalid = 0
@@ -413,6 +495,119 @@ async def run_discovery(
 
 
 # ---------------------------------------------------------------------------
+# The cron sweep
+# ---------------------------------------------------------------------------
+
+
+def _is_due(cadence: str, now: datetime) -> bool:
+    """Is this cadence due on this tick?
+
+    ``daily`` on every tick; ``weekly`` only on ``WEEKLY_DISCOVERY_WEEKDAY``.
+    The weekday is fixed rather than per-ICP because "weekly" has to mean a
+    predictable day — otherwise an operator cannot tell a skipped run from a
+    run that was never due.
+
+    Note what is NOT here: no comparison against ``last_run_at``. A worker that
+    was down for three days resumes with ONE normal run rather than a backlog
+    that fires all at once, which is the behaviour you want from something that
+    spends agent time and fills a list a human has to read.
+    """
+    if cadence == "daily":
+        return True
+    if cadence == "weekly":
+        return now.astimezone(UTC).weekday() == WEEKLY_DISCOVERY_WEEKDAY
+    return False
+
+
+async def discovery_sweep(
+    ctx: dict[str, Any], *, now: datetime | None = None
+) -> dict[str, int]:
+    """Run every due ICP across every tenant. NEVER raises.
+
+    Registered as a daily arq cron on the ``growth`` queue. ``ctx`` is arq's
+    job context (unused — the sweep resolves everything itself); ``now`` is the
+    injectable clock the tests freeze instead of sleeping, exactly as the
+    follow-up sweep does it.
+
+    Returns a counter dict for the worker log: how many ICPs were due, how many
+    ran, how many prospects were filed, and how many ICPs were skipped (paused
+    between the scan and the run, out of monthly room, or their research
+    failed). One failing ICP is a skip, never the end of the pass — the next
+    workspace in the list has done nothing wrong.
+
+    With no production ``ResearchFn`` wired the sweep logs once and does
+    nothing. That is the correct degraded state: an ICP with a cadence on and
+    no research behind it should be visibly idle, never a source of
+    half-researched rows.
+    """
+    from pocketpaw_ee.cloud.growth import service as growth_service
+
+    now = (now or datetime.now(UTC)).astimezone(UTC)
+    counters = {"due": 0, "ran": 0, "filed": 0, "skipped": 0}
+
+    research_fn = resolve_research_fn()
+    if research_fn is None:
+        logger.info(
+            "growth discovery: no research loop is wired (see "
+            "discovery.set_production_research_fn) — sweep is a no-op"
+        )
+        return counters
+
+    try:
+        icps = await growth_service.list_due_icps(
+            sorted(SCHEDULED_CADENCES), limit=DUE_ICP_SCAN_LIMIT
+        )
+    except Exception:  # noqa: BLE001 — a failed scan is a no-op pass, not a crash
+        logger.exception("growth discovery: could not read the due ICPs")
+        return counters
+
+    for icp in icps:
+        if not _is_due(icp.cadence, now):
+            continue
+        counters["due"] += 1
+        try:
+            outcome = await run_discovery(icp.workspace_id, icp.id, research_fn, now=now)
+        except CloudError as exc:
+            # The monthly ceiling, or an ICP deleted between the scan and the
+            # run. Both are ordinary — log the code and move to the next one.
+            counters["skipped"] += 1
+            logger.info(
+                "growth discovery: skipped icp=%s workspace=%s — %s",
+                icp.id,
+                icp.workspace_id,
+                exc.code,
+            )
+            continue
+        except Exception:  # noqa: BLE001 — one bad ICP must not end the pass
+            counters["skipped"] += 1
+            logger.exception(
+                "growth discovery: icp=%s workspace=%s failed", icp.id, icp.workspace_id
+            )
+            continue
+
+        if outcome.error:
+            counters["skipped"] += 1
+            continue
+        counters["ran"] += 1
+        counters["filed"] += outcome.filed
+        try:
+            await growth_service.mark_icp_run(icp.workspace_id, icp.id, now)
+        except Exception:  # noqa: BLE001 — a missing timestamp is not a failed run
+            logger.warning(
+                "growth discovery: could not stamp last_run_at for icp=%s", icp.id, exc_info=True
+            )
+
+    logger.info(
+        "growth discovery sweep: due=%d ran=%d filed=%d skipped=%d",
+        counters["due"],
+        counters["ran"],
+        counters["filed"],
+        counters["skipped"],
+    )
+    return counters
+
+
+# ---------------------------------------------------------------------------
 # Production wiring seam — the research loop.
 # ---------------------------------------------------------------------------
 #
@@ -445,6 +640,8 @@ def resolve_research_fn() -> ResearchFn | None:
 
 
 __all__ = [
+    "DEFAULT_DISCOVERY_MONTHLY_MAX",
+    "GROWTH_DISCOVERY_SWEEP_JOB_NAME",
     "DiscoveredCompany",
     "DiscoveryOutcome",
     "DiscoveryPreview",
@@ -452,6 +649,8 @@ __all__ = [
     "ResearchFn",
     "ResearchRequest",
     "ResearchResult",
+    "discovery_monthly_max",
+    "discovery_sweep",
     "preview_discovery",
     "resolve_research_fn",
     "run_discovery",

--- a/ee/pocketpaw_ee/cloud/growth/discovery.py
+++ b/ee/pocketpaw_ee/cloud/growth/discovery.py
@@ -245,6 +245,66 @@ def _to_preview(company: DiscoveredCompany, *, already_known: bool) -> Previewed
 
 
 # ---------------------------------------------------------------------------
+# The preview — the same research, none of the writes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DiscoveryPreview:
+    """What a run WOULD file, and why it might file less than it found."""
+
+    icp_id: str
+    workspace_id: str
+    items: tuple[PreviewedProspect, ...] = ()
+    notes: str = ""
+    error: str = ""
+
+
+async def preview_discovery(
+    workspace_id: str,
+    icp_id: str,
+    research_fn: ResearchFn,
+) -> DiscoveryPreview:
+    """Run the research once and report what WOULD be filed. Writes nothing.
+
+    This is how someone comes to trust an ICP before switching a cadence on.
+    Criteria are prose, and prose that reads precisely to its author routinely
+    describes the wrong companies — the only way to find that out is to look at
+    the rows it produces. Doing that by turning a cadence on and reading the
+    pipeline afterwards means cleaning up a list you did not want.
+
+    The projection is the SAME ``_to_preview`` the run uses, so the preview
+    cannot drift from what a run actually stores — including the email rule.
+    Showing raw evidence here would advertise addresses the engine refuses to
+    keep, which is exactly the confusion the rule exists to prevent.
+
+    A paused ICP still previews: checking whether a profile is worth resuming
+    is the reason to look at one.
+    """
+    from pocketpaw_ee.cloud.growth import service as growth_service
+
+    icp = await growth_service.get_icp_system(workspace_id, icp_id)
+    result, error = await _research(icp, research_fn, workspace_id=workspace_id)
+    if result is None:
+        return DiscoveryPreview(icp_id=icp_id, workspace_id=workspace_id, error=error)
+
+    items: list[PreviewedProspect] = []
+    for company in result.companies[: max(icp.max_per_run, 0)]:
+        preview = _to_preview(company, already_known=False)
+        if not preview.domain:
+            continue
+        known = await growth_service.prospect_exists_by_domain(workspace_id, preview.domain)
+        items.append(_to_preview(company, already_known=known))
+
+    return DiscoveryPreview(
+        icp_id=icp_id,
+        workspace_id=workspace_id,
+        items=tuple(items),
+        notes=result.notes,
+    )
+
+
+# ---------------------------------------------------------------------------
 # The run
 # ---------------------------------------------------------------------------
 
@@ -387,10 +447,12 @@ def resolve_research_fn() -> ResearchFn | None:
 __all__ = [
     "DiscoveredCompany",
     "DiscoveryOutcome",
+    "DiscoveryPreview",
     "PreviewedProspect",
     "ResearchFn",
     "ResearchRequest",
     "ResearchResult",
+    "preview_discovery",
     "resolve_research_fn",
     "run_discovery",
     "set_production_research_fn",

--- a/ee/pocketpaw_ee/cloud/growth/discovery.py
+++ b/ee/pocketpaw_ee/cloud/growth/discovery.py
@@ -1,0 +1,397 @@
+# ee/pocketpaw_ee/cloud/growth/discovery.py — the ICP discovery engine: turn a
+# standing description of who a workspace wants into prospects in its pipeline.
+#
+# Created 2026-07-29 (feat/growth-discovery): the run, the preview, and the
+# injectable research seam. The cron and the workspace ceiling land alongside.
+#
+# THE SHAPE — copied deliberately from ``belt/headless.py``, which solved the
+# same problem (a job that needs an LLM, and a test suite that must never call
+# one):
+#   * ``ResearchFn`` — an injectable async callable ``(ResearchRequest) ->
+#     ResearchResult``. It is the genuine external boundary: the agent loop that
+#     reads the criteria, searches, opens pages, and reports what it found.
+#     Tests inject a deterministic fake that returns canned companies, so code
+#     under test NEVER calls a real LLM. Production wires the real loop through
+#     ``set_production_research_fn`` — an explicit follow-up, and until one is
+#     wired ``resolve_research_fn`` returns None and the cron is a logged no-op
+#     rather than a crash.
+#   * ``run_discovery`` — research once, drop what cannot be filed, upsert the
+#     rest. Never raises: a research failure is a zero-result run, not a dead
+#     cron tick.
+#   * ``preview_discovery`` — the same research, none of the writes.
+#
+# WHAT THIS MODULE MAY NOT DO, and why each is structural rather than a
+# convention:
+#   * It never INVENTS an email. Every address goes through
+#     ``domain.recordable_emails``, which drops anything not observed on a page
+#     we read. See that function for the reasoning; the short version is that a
+#     guessed address bounces, the bounce lands on the sending domain's
+#     reputation, and an LLM cannot run the verification waterfall that makes
+#     Clay's addresses real. An empty ``emails`` is the honest result and a
+#     perfectly good prospect.
+#   * It never DRAFTS, never SENDS, and never touches ``gate_transition``. A
+#     discovered prospect lands at ``status="new"`` with no draft attached — the
+#     same place a pasted domain lands. Everything downstream of that still runs
+#     through the human gate it always did. Discovery adds rows to a list; it
+#     does not start conversations.
+#   * It never writes through a second path. Every row is filed by
+#     ``service.upsert_by_domain``, the same seam bulk import and the agent
+#     surface use, so the (workspace, domain) dedupe key holds across all of
+#     them and there is one place where a prospect comes into existence.
+#   * It never re-files a domain the workspace already has (see
+#     ``service.prospect_exists_by_domain``): a daily cron that re-upserts a
+#     live prospect would reset its ``status`` and lose the follow-up thread.
+#     Discovery only ever inserts.
+
+"""ICP discovery for the /growth outbound engine."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Protocol
+
+from pocketpaw_ee.cloud.growth.domain import EmailEvidence, recordable_emails
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# The research boundary
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ResearchRequest:
+    """Everything the research loop needs for ONE run of one ICP.
+
+    Flattened out of the ICP rather than passing the ICP itself: the research
+    loop is the external boundary, and handing it a workspace-scoped domain
+    object would invite it to reach for fields (ids, cadence, timestamps) that
+    are none of its business. ``max_results`` is the ICP's ``max_per_run`` — a
+    request, not a guarantee; the caller truncates whatever comes back.
+    """
+
+    workspace_id: str
+    icp_id: str
+    criteria: str
+    icp_name: str = ""
+    geography: str = ""
+    exclusions: str = ""
+    max_results: int = 10
+    project_id: str | None = None
+
+
+@dataclass(frozen=True)
+class DiscoveredCompany:
+    """One company the research found.
+
+    ``domain`` is the only field that matters — it is the dedupe identity, and
+    a result without one is not a prospect (a company nobody can look up is not
+    a lead). Everything else may legitimately be empty: a bare domain plus the
+    pages it was found on is a perfectly good row for a human to qualify.
+
+    ``emails`` carries EVIDENCE, not addresses. The research reports what it
+    saw and where; ``recordable_emails`` decides what may be stored. That split
+    is the whole safety property — see the module header.
+    """
+
+    domain: str
+    name: str = ""
+    company: str = ""
+    research_brief: str = ""
+    source_urls: tuple[str, ...] = ()
+    emails: tuple[EmailEvidence, ...] = ()
+
+
+@dataclass(frozen=True)
+class ResearchResult:
+    """What one research pass returned. ``notes`` is free text for the run log
+    ("searched 4 directories, 2 were paywalled") — it is never stored on a
+    prospect, so it cannot become an unattributed claim about a company."""
+
+    companies: tuple[DiscoveredCompany, ...] = ()
+    notes: str = ""
+
+
+class ResearchFn(Protocol):
+    """Injectable research loop — the genuine external boundary (the agent run
+    that turns criteria into companies). Tests inject a deterministic fake;
+    production wires the real loop. Async so the real implementation can await
+    an agent."""
+
+    async def __call__(self, request: ResearchRequest) -> ResearchResult: ...
+
+
+# ---------------------------------------------------------------------------
+# Run outcomes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PreviewedProspect:
+    """One company as it WOULD be filed — the preview row.
+
+    ``emails`` here has already been through the observed-only filter, so what
+    the preview shows is exactly what a run would store. A preview that
+    displayed the raw evidence would be advertising addresses the engine
+    refuses to keep.
+    """
+
+    domain: str
+    name: str = ""
+    company: str = ""
+    research_brief: str = ""
+    source_urls: tuple[str, ...] = ()
+    emails: tuple[str, ...] = ()
+    # Already in the pipeline — a run would SKIP this one. Surfaced rather than
+    # hidden so a preview full of them says "your criteria describe people you
+    # already have", which is the useful thing to learn before switching a
+    # cadence on.
+    already_known: bool = False
+
+
+@dataclass(frozen=True)
+class DiscoveryOutcome:
+    """What one run did. Counts rather than rows: the caller that wants the
+    rows reads the prospect list, which is where they now are."""
+
+    icp_id: str
+    workspace_id: str
+    filed: int = 0
+    skipped_existing: int = 0
+    skipped_invalid: int = 0
+    considered: int = 0
+    notes: str = ""
+    # Why a run produced nothing, when it produced nothing for a reason worth
+    # reporting (research crashed, the ICP is paused, the workspace is at its
+    # monthly ceiling). Empty on a clean run — including a clean run that found
+    # no companies, which is an answer rather than a fault.
+    error: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Shared internals
+# ---------------------------------------------------------------------------
+
+
+async def _research(
+    icp: object,
+    research_fn: ResearchFn,
+    *,
+    workspace_id: str,
+) -> tuple[ResearchResult | None, str]:
+    """Run the research once. Returns ``(result, error)`` — never raises.
+
+    A research failure is a run that found nothing, not a dead cron tick: the
+    next tick tries again, and one bad ICP must not take the pass down for
+    every other workspace. Same discipline as ``belt/headless``'s develop loop.
+    """
+    request = ResearchRequest(
+        workspace_id=workspace_id,
+        icp_id=str(getattr(icp, "id", "")),
+        icp_name=str(getattr(icp, "name", "")),
+        criteria=str(getattr(icp, "criteria", "")),
+        geography=str(getattr(icp, "geography", "")),
+        exclusions=str(getattr(icp, "exclusions", "")),
+        max_results=int(getattr(icp, "max_per_run", 10)),
+        project_id=getattr(icp, "project_id", None),
+    )
+    try:
+        result = await research_fn(request)
+    except Exception as exc:  # noqa: BLE001 — research must not crash the run
+        logger.warning(
+            "growth discovery: research failed for icp=%s workspace=%s — filing nothing",
+            request.icp_id,
+            workspace_id,
+            exc_info=True,
+        )
+        return None, f"research failed: {exc}"
+    if result is None:
+        return ResearchResult(), ""
+    return result, ""
+
+
+def _clean_urls(urls: tuple[str, ...]) -> list[str]:
+    """Trim, drop blanks, collapse duplicates, and cap the trail.
+
+    The cap is not paranoia about storage: a source list long enough to need
+    scrolling is one nobody reads, and an audit trail nobody reads is not one.
+    """
+    seen: dict[str, None] = {}
+    for url in urls:
+        cleaned = url.strip()
+        if cleaned:
+            seen.setdefault(cleaned, None)
+    return list(seen)[:20]
+
+
+def _to_preview(company: DiscoveredCompany, *, already_known: bool) -> PreviewedProspect:
+    """Project one research result onto the row it would become.
+
+    THE single place evidence turns into addresses, for both the run and the
+    preview — so the preview cannot drift from what the run actually files, and
+    there is exactly one call to ``recordable_emails`` to audit.
+    """
+    return PreviewedProspect(
+        domain=company.domain.strip().lower(),
+        name=company.name.strip(),
+        company=company.company.strip(),
+        research_brief=company.research_brief.strip(),
+        source_urls=tuple(_clean_urls(company.source_urls)),
+        emails=recordable_emails(company.emails),
+        already_known=already_known,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The run
+# ---------------------------------------------------------------------------
+
+
+async def run_discovery(
+    workspace_id: str,
+    icp_id: str,
+    research_fn: ResearchFn,
+) -> DiscoveryOutcome:
+    """Run one ICP and file what it found. NEVER raises except NotFound.
+
+    The sequence is deliberately boring: read the ICP, research once, truncate
+    to ``max_per_run``, drop the rows that cannot be filed, upsert the rest at
+    ``status="new"``. Nothing here drafts, sends, or touches the Instinct gate
+    — a discovered prospect arrives in exactly the state a pasted domain does,
+    and every outbound step downstream still needs the human it always needed.
+
+    ``max_per_run`` truncates the RESULT, so a research loop that returns 200
+    companies against a limit of 10 files at most 10. Rows skipped because the
+    workspace already has them do not free budget for extra ones: the number a
+    human agreed to review is the number that can appear.
+
+    A paused ICP returns a zero outcome rather than raising — the cron already
+    filters on status, and a manual caller asking for a paused profile wants
+    "it didn't run", not a 4xx.
+    """
+    from pocketpaw_ee.cloud.growth import service as growth_service
+    from pocketpaw_ee.cloud.growth.dto import CreateProspectRequest
+
+    icp = await growth_service.get_icp_system(workspace_id, icp_id)
+    if icp.status != "active":
+        logger.info("growth discovery: icp=%s is %s — not running", icp_id, icp.status)
+        return DiscoveryOutcome(
+            icp_id=icp_id, workspace_id=workspace_id, error=f"icp is {icp.status}"
+        )
+
+    result, error = await _research(icp, research_fn, workspace_id=workspace_id)
+    if result is None:
+        return DiscoveryOutcome(icp_id=icp_id, workspace_id=workspace_id, error=error)
+
+    considered = result.companies[: max(icp.max_per_run, 0)]
+    filed = 0
+    skipped_existing = 0
+    skipped_invalid = 0
+
+    for company in considered:
+        preview = _to_preview(company, already_known=False)
+        if not preview.domain:
+            # A result with no domain is not a prospect — there is nothing to
+            # dedupe on and nothing for a human to open.
+            skipped_invalid += 1
+            continue
+        if await growth_service.prospect_exists_by_domain(workspace_id, preview.domain):
+            skipped_existing += 1
+            continue
+
+        try:
+            await growth_service.upsert_by_domain(
+                workspace_id,
+                CreateProspectRequest(
+                    name=preview.name,
+                    company=preview.company,
+                    domain=preview.domain,
+                    source="discovery",
+                    project_id=icp.project_id,
+                    research_brief=preview.research_brief,
+                    # ALREADY filtered to observed-on-a-page addresses. This is
+                    # the only place a discovered prospect's emails are set,
+                    # and the value came from ``recordable_emails``.
+                    emails=list(preview.emails),
+                    status="new",
+                    icp_id=icp_id,
+                    source_urls=list(preview.source_urls),
+                ),
+            )
+        except Exception:  # noqa: BLE001 — one bad row must not end the run
+            logger.warning(
+                "growth discovery: could not file %s for icp=%s — skipping",
+                preview.domain,
+                icp_id,
+                exc_info=True,
+            )
+            skipped_invalid += 1
+            continue
+        filed += 1
+
+    logger.info(
+        "growth discovery: icp=%s workspace=%s considered=%d filed=%d "
+        "skipped_existing=%d skipped_invalid=%d",
+        icp_id,
+        workspace_id,
+        len(considered),
+        filed,
+        skipped_existing,
+        skipped_invalid,
+    )
+    return DiscoveryOutcome(
+        icp_id=icp_id,
+        workspace_id=workspace_id,
+        filed=filed,
+        skipped_existing=skipped_existing,
+        skipped_invalid=skipped_invalid,
+        considered=len(considered),
+        notes=result.notes,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Production wiring seam — the research loop.
+# ---------------------------------------------------------------------------
+#
+# The real agent loop is a follow-up; this hook lets it be wired without
+# touching the cron again. Until one is wired, ``resolve_research_fn`` returns
+# None and the discovery sweep is a logged no-op — a deploy is never left with
+# a cron that crashes on every tick, and code under test NEVER reaches a real
+# LLM (tests pass a fake ``ResearchFn`` straight into ``run_discovery`` /
+# ``preview_discovery``, bypassing this seam entirely).
+
+_PRODUCTION_RESEARCH_FN: ResearchFn | None = None
+
+
+def set_production_research_fn(fn: ResearchFn | None) -> None:
+    """Wire (or clear) the production research loop the discovery cron uses.
+
+    Called once at app wiring time by a deploy that ships a real loop. Tests do
+    NOT use this — they inject a fake directly."""
+    global _PRODUCTION_RESEARCH_FN
+    _PRODUCTION_RESEARCH_FN = fn
+
+
+def resolve_research_fn() -> ResearchFn | None:
+    """The wired production research loop, or None.
+
+    None means the cron logs and does nothing. That is the correct degraded
+    state: an ICP with a cadence on and no research loop behind it should be
+    visibly idle, never a source of half-researched rows."""
+    return _PRODUCTION_RESEARCH_FN
+
+
+__all__ = [
+    "DiscoveredCompany",
+    "DiscoveryOutcome",
+    "PreviewedProspect",
+    "ResearchFn",
+    "ResearchRequest",
+    "ResearchResult",
+    "resolve_research_fn",
+    "run_discovery",
+    "set_production_research_fn",
+]

--- a/ee/pocketpaw_ee/cloud/growth/domain.py
+++ b/ee/pocketpaw_ee/cloud/growth/domain.py
@@ -35,6 +35,13 @@
 # optional filter on the reads). An agency runs one outbound pipeline per
 # client; the project primitive already models that container, so growth
 # consumes it rather than inventing a second scoping concept.
+# Updated 2026-07-29 (feat/growth-discovery): the ICP — a STANDING description
+# of who a workspace wants, plus a cadence. ``Icp`` (the value object),
+# ``IcpCadence`` / ``IcpStatus`` and their orders, and ``ProspectSource`` gains
+# ``discovery``. Plus the provenance vocabulary the discovery engine writes and
+# the UI reads: ``EmailEvidence`` (an address, how we know it, and WHERE it was
+# seen) and ``EMAIL_CONFIDENCE``. The email fields are the load-bearing part —
+# see ``EmailEvidence`` for why a guessed address is worse than an empty one.
 # Updated 2026-07-27 (feat/growth-g4): the Instinct send gate —
 # ``GATE_OWNED_TARGETS`` marks the statuses only the gate machinery may set
 # (``approved`` via an approved ``_growth_send`` proposal, ``sent`` via the
@@ -43,6 +50,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Literal, get_args
@@ -55,8 +63,12 @@ from typing import Literal, get_args
 # forwarded to the job function and crash it — see the jobs/domain.py history).
 GROWTH_QUEUE_NAME = "growth"
 
-# Where the prospect came from.
-ProspectSource = Literal["clay", "directory", "manual"]
+# Where the prospect came from. ``discovery`` is the ICP research engine — a
+# row nobody typed and nobody imported, found by a standing description of who
+# the workspace wants. It is its own source (not folded into ``directory``)
+# because provenance is the whole question a human asks about an auto-found
+# row: "who put this here, and can I see where it came from".
+ProspectSource = Literal["clay", "directory", "discovery", "manual"]
 
 # Qualification tier. ``unqualified`` until research triages it.
 ProspectTier = Literal["a", "b", "c", "unqualified"]
@@ -109,8 +121,180 @@ class Prospect:
     whatsapp_number: str | None = None
     opted_in: bool = False
     status: str = "new"  # ProspectStatus
+    # The standing ICP that found this row, when discovery did. Nullable
+    # everywhere: a typed or imported prospect has no ICP, and that is a fact
+    # rather than a gap.
+    icp_id: str | None = None
+    # WHERE the row came from — the pages the research actually read. This is
+    # the audit trail for an auto-found prospect: a human reviewing a row
+    # nobody typed needs to open the source and check the claim. Empty on a
+    # manually created prospect, which needs no such trail.
+    source_urls: tuple[str, ...] = ()
     created_at: datetime | None = None
     updated_at: datetime | None = None
+
+
+# ---------------------------------------------------------------------------
+# The ICP — a standing description of who a workspace wants (feat/growth-
+# discovery)
+# ---------------------------------------------------------------------------
+
+# How often the discovery cron runs an ICP. ``off`` is the DEFAULT and means
+# "this ICP only runs when a human asks" (the preview route, or a manual run).
+# A standing description of who you want is a useful artifact on its own; it
+# becomes a recurring spend the moment a cadence is switched on, so the switch
+# is an explicit act rather than the shape a new ICP arrives in.
+IcpCadence = Literal["off", "daily", "weekly"]
+
+# Whether the ICP is live. ``paused`` keeps the definition (and its history)
+# while stopping the cron — deleting is for an ICP that was a mistake, pausing
+# is for one that did its job.
+IcpStatus = Literal["active", "paused"]
+
+ICP_CADENCE_ORDER: tuple[str, ...] = get_args(IcpCadence)
+ICP_STATUS_ORDER: tuple[str, ...] = get_args(IcpStatus)
+
+# Cadences the cron actually schedules. ``off`` is absent by construction, so
+# the sweep's due-check can never accidentally include it.
+SCHEDULED_CADENCES: frozenset[str] = frozenset({"daily", "weekly"})
+
+# The weekday a ``weekly`` ICP runs on (Monday, ``date.weekday() == 0``).
+# FIXED rather than per-ICP: "weekly" has to mean a predictable day or an
+# operator cannot tell a skipped run from a run that was never due. Monday puts
+# the week's new prospects in the list before the week's outreach is decided.
+WEEKLY_DISCOVERY_WEEKDAY = 0
+
+# Default ceiling on how many prospects ONE run of an ICP may file. Small on
+# purpose: the first thing an operator does with a new ICP is read the rows and
+# decide whether the criteria describe who they actually want, and a run that
+# files 200 rows makes that impossible.
+DEFAULT_ICP_MAX_PER_RUN = 10
+
+# Hard upper bound on ``max_per_run``, enforced at the DTO boundary. A run is
+# an LLM research pass, not a database scan: past this the right tool is a
+# second ICP with narrower criteria, not a bigger batch.
+MAX_ICP_MAX_PER_RUN = 100
+
+# The arq job the discovery cron registers under on ``GROWTH_QUEUE_NAME``.
+# Explicit + dotted like the other two, so the wire name survives a rename of
+# the Python function.
+GROWTH_DISCOVERY_SWEEP_JOB_NAME = "growth.discovery_sweep"
+
+
+@dataclass(frozen=True)
+class Icp:
+    """An Ideal Customer Profile — a STANDING description of who a workspace
+    wants, plus how often to go looking.
+
+    ``criteria`` is deliberately free text, not a filter tree: it is what the
+    research READS, and the thing that makes a good ICP good ("dental practices
+    with 2-6 chairs that still book by phone") does not decompose into enum
+    columns without losing exactly the part that was useful. ``geography`` and
+    ``exclusions`` are separated out of it only because both are answers the
+    research must apply as HARD constraints rather than weigh — a company
+    outside the geography or on the exclusion list is not a weaker match, it is
+    not a match.
+    """
+
+    id: str
+    workspace_id: str
+    name: str
+    criteria: str
+    project_id: str | None = None
+    geography: str = ""
+    exclusions: str = ""
+    cadence: str = "off"  # IcpCadence
+    max_per_run: int = DEFAULT_ICP_MAX_PER_RUN
+    status: str = "active"  # IcpStatus
+    last_run_at: datetime | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+# ---------------------------------------------------------------------------
+# Email provenance — the one hard constraint of the discovery engine
+# ---------------------------------------------------------------------------
+
+# HOW we know an address. This is the load-bearing vocabulary of the whole
+# discovery slice, so it is worth being explicit about why it exists.
+#
+# Clay and Apollo return an email because they ran a VERIFICATION WATERFALL:
+# several independent providers, an SMTP or catch-all probe, a confidence
+# score. An LLM has none of that. What it CAN do — and will, fluently, unless
+# the type system stops it — is produce ``firstname@company.com`` because that
+# is what such an address looks like. That guess is not a cheaper email; it is
+# a different and much worse object. It bounces, the bounce lands on the
+# SENDING domain's reputation (see ``GROWTH_SENDING_DOMAIN`` in CLAUDE.md), and
+# it poisons the list with rows that look contactable and are not.
+#
+# So the engine records an address ONLY when it was actually observed as text
+# on a page it read, together with the URL where it was seen. Everything else
+# stays empty, and an empty ``emails`` is a perfectly good prospect — a domain
+# with a research brief is exactly what a human or a real verification provider
+# picks up from.
+#
+#   ``observed`` — the address appeared, as text, on the page at ``seen_at_url``.
+#   ``claimed``  — something asserted it (an aggregator, the model's own
+#                  memory) without us reading a page carrying it.
+#   ``guessed``  — constructed from a pattern. The default, because a piece of
+#                  evidence that does not say how it was obtained must be
+#                  treated as the least trustworthy kind, not the most.
+EmailConfidence = Literal["observed", "claimed", "guessed"]
+
+EMAIL_CONFIDENCE: tuple[str, ...] = get_args(EmailConfidence)
+
+# The ONLY confidence that may become a stored address. A frozenset rather than
+# a bare ``== "observed"`` comparison so the rule has a name and one place to
+# change if a real verification provider is ever wired in (that provider would
+# add its own value here — an LLM never will).
+RECORDABLE_EMAIL_CONFIDENCE: frozenset[str] = frozenset({"observed"})
+
+
+@dataclass(frozen=True)
+class EmailEvidence:
+    """One candidate address, how we know it, and WHERE it was seen.
+
+    The research layer returns these instead of bare strings, so "we found an
+    email" and "we can prove where it was" are the same statement. An evidence
+    object that cannot answer the second question cannot produce an address —
+    see ``recordable_emails``.
+    """
+
+    address: str
+    # Defaults to the LEAST trustworthy value on purpose: evidence that forgot
+    # to say how it was obtained is a guess until it proves otherwise. A
+    # research implementation that omits the field gets fail-closed behaviour
+    # rather than a silent promotion to "observed".
+    confidence: str = "guessed"  # EmailConfidence
+    # The page the address was read from. Required in practice — an
+    # ``observed`` claim with no URL is unfalsifiable, so it is not recordable.
+    seen_at_url: str = ""
+
+    @property
+    def is_recordable(self) -> bool:
+        """True only for an address we can point at on a page we read."""
+        return bool(
+            self.address.strip()
+            and self.confidence in RECORDABLE_EMAIL_CONFIDENCE
+            and self.seen_at_url.strip()
+        )
+
+
+def recordable_emails(evidence: Iterable[EmailEvidence]) -> tuple[str, ...]:
+    """The addresses from ``evidence`` that may actually be stored.
+
+    THE door — nothing else in the discovery path turns evidence into an
+    address, so "never invent an email" is enforced in one auditable function
+    rather than asked of a prompt. Anything guessed, claimed, or missing its
+    source URL is dropped silently: the caller gets a prospect with no email,
+    which is the honest result. Order is preserved and duplicates collapse (the
+    same address on two pages is one address).
+    """
+    seen: dict[str, None] = {}
+    for item in evidence:
+        if item.is_recordable:
+            seen.setdefault(item.address.strip().lower(), None)
+    return tuple(seen)
 
 
 # Outreach channel a draft targets. ``subject`` only applies to email.
@@ -221,19 +405,33 @@ class MessageLog:
 
 
 __all__ = [
+    "DEFAULT_ICP_MAX_PER_RUN",
     "DRAFT_TRANSITIONS",
+    "EMAIL_CONFIDENCE",
     "GATE_OWNED_TARGETS",
+    "GROWTH_DISCOVERY_SWEEP_JOB_NAME",
     "GROWTH_DISPATCH_JOB_NAME",
     "GROWTH_QUEUE_NAME",
+    "ICP_CADENCE_ORDER",
+    "ICP_STATUS_ORDER",
+    "MAX_ICP_MAX_PER_RUN",
     "MESSAGE_LOG_OUTCOMES",
     "PROSPECT_SOURCE_ORDER",
     "PROSPECT_STATUS_ORDER",
     "PROVIDER_REACHED_OUTCOMES",
+    "RECORDABLE_EMAIL_CONFIDENCE",
+    "SCHEDULED_CADENCES",
     "TIER_SORT_ORDER",
+    "WEEKLY_DISCOVERY_WEEKDAY",
     "Draft",
     "DraftChannel",
     "DraftStatus",
     "DraftVariant",
+    "EmailConfidence",
+    "EmailEvidence",
+    "Icp",
+    "IcpCadence",
+    "IcpStatus",
     "MessageLog",
     "MessageOutcome",
     "Prospect",
@@ -241,4 +439,5 @@ __all__ = [
     "ProspectSource",
     "ProspectStatus",
     "ProspectTier",
+    "recordable_emails",
 ]

--- a/ee/pocketpaw_ee/cloud/growth/dto.py
+++ b/ee/pocketpaw_ee/cloud/growth/dto.py
@@ -42,6 +42,15 @@
 # dedupe identity, and a row without one is not a prospect. The LinkedIn queue
 # row gained ``prospect_domain`` so an export can still title a section for a
 # prospect whose name nobody has filled in yet.
+# Updated 2026-07-29 (feat/growth-discovery): the ICP shapes — CreateIcpRequest
+# (name + criteria required, everything else optional; ``cadence`` defaults to
+# ``off`` and ``max_per_run`` is capped at the boundary), UpdateIcpRequest
+# (partial, ``project_id`` three-valued like the prospect update), IcpResponse.
+# Plus ``icp_id`` / ``source_urls`` on the prospect create + response: the
+# provenance of a row nobody typed. The DTO cannot enforce the observed-email
+# rule — by the time an address reaches ``emails`` it is a plain string — so
+# that filter lives one layer up, in ``domain.recordable_emails``, which the
+# discovery run is the only caller of.
 # Updated 2026-07-28 (feat/growth-projects): ``project_id`` on the create,
 # update and response shapes — the client a prospect belongs to. On the UPDATE
 # it is three-valued the way ``tasks`` does it (None = leave alone, an id =
@@ -55,9 +64,13 @@ from typing import Any
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from pocketpaw_ee.cloud.growth.domain import (
+    DEFAULT_ICP_MAX_PER_RUN,
+    MAX_ICP_MAX_PER_RUN,
     DraftChannel,
     DraftStatus,
     DraftVariant,
+    IcpCadence,
+    IcpStatus,
     ProspectSource,
     ProspectStatus,
     ProspectTier,
@@ -230,6 +243,85 @@ class ProspectFacetsResponse(BaseModel):
     source: dict[str, int]
 
 
+# ---------------------------------------------------------------------------
+# ICPs (feat/growth-discovery)
+# ---------------------------------------------------------------------------
+
+
+class CreateIcpRequest(BaseModel):
+    """A standing description of who the workspace wants.
+
+    ``name`` and ``criteria`` are the only required fields — an ICP with no
+    criteria describes nobody, and the research would have nothing to read.
+    ``cadence`` defaults to ``off``: writing down who you want is free, going
+    looking for them on a schedule is a recurring spend, so the schedule is an
+    explicit act rather than the shape a new ICP arrives in.
+    """
+
+    name: str = Field(min_length=1, max_length=200)
+    criteria: str = Field(min_length=1, max_length=4000)
+    # The client this ICP prospects for. The SERVICE validates it against the
+    # caller's workspace (a project from another tenant is a 404) — the DTO has
+    # no tenancy context, exactly like ``CreateProspectRequest``.
+    project_id: str | None = None
+    geography: str = Field(default="", max_length=500)
+    exclusions: str = Field(default="", max_length=2000)
+    cadence: IcpCadence = "off"
+    max_per_run: int = Field(default=DEFAULT_ICP_MAX_PER_RUN, ge=1, le=MAX_ICP_MAX_PER_RUN)
+    status: IcpStatus = "active"
+
+    @field_validator("name", "criteria")
+    @classmethod
+    def _non_blank(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("must not be blank")
+        return v
+
+
+class UpdateIcpRequest(BaseModel):
+    """Partial update — every field optional, ``None`` means "leave as-is".
+
+    Editing ``criteria`` deliberately does NOT re-run anything: the next
+    scheduled tick (or a preview) picks the new text up. An edit that
+    immediately spent an LLM budget would make tuning an ICP expensive, and
+    tuning is the main thing anyone does with one.
+    """
+
+    name: str | None = Field(default=None, min_length=1, max_length=200)
+    criteria: str | None = Field(default=None, min_length=1, max_length=4000)
+    # Three-valued like ``UpdateProspectRequest``: ``None`` leaves the
+    # assignment alone, an id reassigns, ``""`` clears it.
+    project_id: str | None = None
+    geography: str | None = Field(default=None, max_length=500)
+    exclusions: str | None = Field(default=None, max_length=2000)
+    cadence: IcpCadence | None = None
+    max_per_run: int | None = Field(default=None, ge=1, le=MAX_ICP_MAX_PER_RUN)
+    status: IcpStatus | None = None
+
+    @field_validator("name", "criteria")
+    @classmethod
+    def _non_blank(cls, v: str | None) -> str | None:
+        if v is not None and not v.strip():
+            raise ValueError("must not be blank")
+        return v
+
+
+class IcpResponse(BaseModel):
+    id: str
+    workspace_id: str
+    name: str
+    criteria: str
+    project_id: str | None
+    geography: str
+    exclusions: str
+    cadence: str
+    max_per_run: int
+    status: str
+    last_run_at: str | None
+    created_at: str | None
+    updated_at: str | None
+
+
 class CreateDraftRequest(BaseModel):
     """One channel's outreach copy for a prospect.
 
@@ -377,8 +469,10 @@ __all__ = [
     "BulkIngestResponse",
     "BulkRowError",
     "CreateDraftRequest",
+    "CreateIcpRequest",
     "CreateProspectRequest",
     "DraftResponse",
+    "IcpResponse",
     "LinkedInQueueItemResponse",
     "ProposeBatchError",
     "ProposeBatchRequest",
@@ -389,5 +483,6 @@ __all__ = [
     "ProspectResponse",
     "TransitionDraftRequest",
     "UpdateDraftRequest",
+    "UpdateIcpRequest",
     "UpdateProspectRequest",
 ]

--- a/ee/pocketpaw_ee/cloud/growth/dto.py
+++ b/ee/pocketpaw_ee/cloud/growth/dto.py
@@ -322,6 +322,40 @@ class IcpResponse(BaseModel):
     updated_at: str | None
 
 
+class PreviewedProspectResponse(BaseModel):
+    """One company as a run WOULD file it.
+
+    ``emails`` has already been through the observed-only filter, so this is
+    exactly what would be stored — never the raw evidence, which would
+    advertise addresses the engine refuses to keep.
+    """
+
+    domain: str
+    name: str
+    company: str
+    research_brief: str
+    source_urls: list[str]
+    emails: list[str]
+    # A run would SKIP this one — the workspace already has it. Shown rather
+    # than filtered out, because a preview full of these is the useful signal
+    # that the criteria describe people you already know.
+    already_known: bool
+
+
+class IcpPreviewResponse(BaseModel):
+    """The result of a dry run: what would land, and why it might be short.
+
+    ``error`` is populated when the research itself failed — a preview that
+    returned nothing because the search provider was down must not be
+    indistinguishable from an ICP that describes nobody.
+    """
+
+    icp_id: str
+    items: list[PreviewedProspectResponse]
+    notes: str = ""
+    error: str = ""
+
+
 class CreateDraftRequest(BaseModel):
     """One channel's outreach copy for a prospect.
 
@@ -472,8 +506,10 @@ __all__ = [
     "CreateIcpRequest",
     "CreateProspectRequest",
     "DraftResponse",
+    "IcpPreviewResponse",
     "IcpResponse",
     "LinkedInQueueItemResponse",
+    "PreviewedProspectResponse",
     "ProposeBatchError",
     "ProposeBatchRequest",
     "ProposeBatchResponse",

--- a/ee/pocketpaw_ee/cloud/growth/dto.py
+++ b/ee/pocketpaw_ee/cloud/growth/dto.py
@@ -113,6 +113,12 @@ class CreateProspectRequest(BaseModel):
     whatsapp_number: str | None = None
     opted_in: bool = False
     status: ProspectStatus = "new"
+    # Discovery provenance. Both are written by the discovery run and left at
+    # their defaults by every other caller. ``emails`` reaching this model has
+    # ALREADY passed the observed-only filter (``domain.recordable_emails``) —
+    # the DTO cannot re-check it, because by here an address is just a string.
+    icp_id: str | None = None
+    source_urls: list[str] = Field(default_factory=list, max_length=20)
 
     @field_validator("domain")
     @classmethod
@@ -188,6 +194,8 @@ class ProspectResponse(BaseModel):
     whatsapp_number: str | None
     opted_in: bool
     status: str
+    icp_id: str | None = None
+    source_urls: list[str] = Field(default_factory=list)
     created_at: str | None
     updated_at: str | None
 

--- a/ee/pocketpaw_ee/cloud/growth/router.py
+++ b/ee/pocketpaw_ee/cloud/growth/router.py
@@ -57,6 +57,13 @@
 # G-4 per-route RBAC guards their branch predated — ``growth.read`` on the
 # queue, ``growth.manage`` on mark-sent (it is an OUTBOUND verb, same tier as
 # propose).
+# Updated 2026-07-29 (feat/growth-discovery): the ICP surface — POST/GET
+# /icps, GET/PATCH/DELETE /icps/{id}. Reads at ``growth.read``, mutations at
+# ``growth.write``: an ICP is a description of who you want, which is authoring
+# work, not the outbound verb. Turning a cadence on is an ordinary PATCH for
+# the same reason — the BOUNDS (per run, and per workspace per month) are what
+# make a standing schedule safe, not a second approval on the switch. Every one
+# of these has an entry in the guard-coverage test in test_gate.py.
 
 from __future__ import annotations
 
@@ -71,6 +78,7 @@ from pocketpaw_ee.cloud.growth import service as growth_service
 from pocketpaw_ee.cloud.growth.domain import (
     DraftChannel,
     DraftStatus,
+    IcpStatus,
     ProspectSort,
     ProspectSource,
     ProspectStatus,
@@ -80,8 +88,10 @@ from pocketpaw_ee.cloud.growth.dto import (
     BulkIngestRequest,
     BulkIngestResponse,
     CreateDraftRequest,
+    CreateIcpRequest,
     CreateProspectRequest,
     DraftResponse,
+    IcpResponse,
     LinkedInQueueItemResponse,
     ProposeBatchRequest,
     ProposeBatchResponse,
@@ -91,6 +101,7 @@ from pocketpaw_ee.cloud.growth.dto import (
     ProspectResponse,
     TransitionDraftRequest,
     UpdateDraftRequest,
+    UpdateIcpRequest,
     UpdateProspectRequest,
 )
 from pocketpaw_ee.cloud.license import require_license
@@ -217,6 +228,87 @@ async def update_prospect(
     ctx: RequestContext = Depends(request_context),
 ) -> ProspectResponse:
     return await growth_service.update(ctx, prospect_id, body)
+
+
+# ---------------------------------------------------------------------------
+# ICPs (feat/growth-discovery)
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/icps",
+    response_model=IcpResponse,
+    dependencies=[Depends(require_action_any_workspace("growth.write"))],
+)
+async def create_icp(
+    body: CreateIcpRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> IcpResponse:
+    """Define who this workspace wants. ``cadence`` defaults to ``off`` — the
+    ICP exists and can be previewed, but nothing runs on a schedule until
+    someone switches it on."""
+    return await growth_service.create_icp(ctx, body)
+
+
+@router.get(
+    "/icps",
+    response_model=list[IcpResponse],
+    dependencies=[Depends(require_action_any_workspace("growth.read"))],
+)
+async def list_icps(
+    project_id: str | None = Query(default=None, max_length=64),
+    status: IcpStatus | None = Query(default=None),
+    limit: int = Query(default=100, ge=1, le=500),
+    ctx: RequestContext = Depends(request_context),
+) -> list[IcpResponse]:
+    """The workspace's ICPs, newest first. A bare list, not the prospect
+    list's page envelope — a workspace holds a handful of hand-written
+    profiles, not thousands of rows."""
+    return await growth_service.list_icps(ctx, project_id=project_id, status=status, limit=limit)
+
+
+@router.get(
+    "/icps/{icp_id}",
+    response_model=IcpResponse,
+    dependencies=[Depends(require_action_any_workspace("growth.read"))],
+)
+async def get_icp(
+    icp_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> IcpResponse:
+    return await growth_service.get_icp(ctx, icp_id)
+
+
+@router.patch(
+    "/icps/{icp_id}",
+    response_model=IcpResponse,
+    dependencies=[Depends(require_action_any_workspace("growth.write"))],
+)
+async def update_icp(
+    icp_id: str,
+    body: UpdateIcpRequest,
+    ctx: RequestContext = Depends(request_context),
+) -> IcpResponse:
+    """Edit an ICP. Changing ``criteria`` does not re-run anything — the next
+    tick (or a preview) picks the new text up, so tuning stays free."""
+    return await growth_service.update_icp(ctx, icp_id, body)
+
+
+@router.delete(
+    "/icps/{icp_id}",
+    status_code=204,
+    dependencies=[Depends(require_action_any_workspace("growth.write"))],
+)
+async def delete_icp(
+    icp_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> Response:
+    """Delete an ICP. Prospects it discovered keep their ``icp_id`` and source
+    URLs — provenance records what happened, and deleting the profile does not
+    un-find the companies. To stop the cron without losing the definition,
+    PATCH ``status`` to ``paused`` instead."""
+    await growth_service.delete_icp(ctx, icp_id)
+    return Response(status_code=204)
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/cloud/growth/router.py
+++ b/ee/pocketpaw_ee/cloud/growth/router.py
@@ -91,6 +91,7 @@ from pocketpaw_ee.cloud.growth.dto import (
     CreateIcpRequest,
     CreateProspectRequest,
     DraftResponse,
+    IcpPreviewResponse,
     IcpResponse,
     LinkedInQueueItemResponse,
     ProposeBatchRequest,
@@ -292,6 +293,31 @@ async def update_icp(
     """Edit an ICP. Changing ``criteria`` does not re-run anything — the next
     tick (or a preview) picks the new text up, so tuning stays free."""
     return await growth_service.update_icp(ctx, icp_id, body)
+
+
+@router.post(
+    "/icps/{icp_id}/preview",
+    response_model=IcpPreviewResponse,
+    dependencies=[Depends(require_action_any_workspace("growth.write"))],
+)
+async def preview_icp(
+    icp_id: str,
+    ctx: RequestContext = Depends(request_context),
+) -> IcpPreviewResponse:
+    """Dry-run this ICP: research once, return what it WOULD file, write
+    nothing.
+
+    This is how someone comes to trust an ICP before switching its cadence on
+    — criteria are prose, and prose that reads precisely to its author
+    routinely describes the wrong companies. Rows already in the pipeline come
+    back flagged ``already_known`` rather than hidden, because a preview full
+    of them is the useful signal.
+
+    A POST despite writing nothing: it spends a real research pass, so it is
+    not safe to retry blindly and does not belong on a GET. It sits at
+    ``growth.write`` for the same reason — it is not the outbound verb (it
+    cannot reach a prospect), but it is not free either."""
+    return await growth_service.preview_icp(ctx, icp_id)
 
 
 @router.delete(

--- a/ee/pocketpaw_ee/cloud/growth/service.py
+++ b/ee/pocketpaw_ee/cloud/growth/service.py
@@ -1762,6 +1762,60 @@ async def prospect_exists_by_domain(workspace_id: str, domain: str) -> bool:
     return doc is not None
 
 
+async def count_discovered_since(workspace_id: str, since: datetime) -> int:
+    """How many prospects DISCOVERY has filed for this workspace since ``since``.
+
+    The monthly ceiling reads this before every run. It counts by ``source``
+    rather than by ``icp_id`` on purpose: the bound is on how much automated
+    volume one workspace generates in a period, and splitting the work across
+    five ICPs must not multiply the allowance by five. Manually created and
+    imported rows are not counted — a human typing a domain is not the thing
+    the ceiling is protecting anyone from.
+    """
+    return await _ProspectDoc.find(
+        {"workspace": workspace_id, "source": "discovery", "createdAt": {"$gte": since}}
+    ).count()
+
+
+async def list_due_icps(cadences: list[str], *, limit: int = 500) -> list[IcpResponse]:
+    """Every ACTIVE ICP whose cadence is in ``cadences``, across all tenants.
+
+    # global-read: the discovery cron runs under the worker's system identity
+    # with no workspace context — it exists precisely to serve every tenant on
+    # one tick. Identical to ``list_sent_drafts_for_followup``: the read is
+    # global, and every row it returns carries its own ``workspace_id``, which
+    # the sweep threads back into the tenant-scoped run.
+
+    Oldest-first so a workspace that has been waiting longest is served first
+    if the batch is capped. Paused ICPs and ``cadence="off"`` never appear —
+    the cron cannot run something a human switched off.
+    """
+    docs = (
+        await _IcpDoc.find({"status": "active", "cadence": {"$in": cadences}})
+        .sort([("createdAt", 1), ("_id", 1)])
+        .limit(limit)
+        .to_list()
+    )
+    return [_icp_to_response(_icp_to_domain(doc)) for doc in docs]
+
+
+async def mark_icp_run(workspace_id: str, icp_id: str, when: datetime) -> None:
+    """Stamp ``last_run_at`` after a run. Best-effort and idempotent.
+
+    Deliberately NOT the due-check's input: the sweep decides what is due from
+    the cadence and the tick, so a worker that was down for three days resumes
+    with one normal run rather than a backlog that fires all at once. This
+    field answers an operator's "has this thing actually been running?", which
+    is a different question from "should it run now".
+    """
+    doc = await _IcpDoc.find_one({"_id": PydanticObjectId(icp_id), "workspace": workspace_id})
+    if doc is None:
+        return
+    doc.last_run_at = when
+    await doc.save()  # bumps updatedAt
+    # no-event: growth has no realtime subscriber in v1; the ICP view polls.
+
+
 async def mark_prospect_dead(workspace_id: str, prospect_id: str) -> ProspectResponse:
     """Retire a prospect the sequence is done with (G-7 cap reached).
 

--- a/ee/pocketpaw_ee/cloud/growth/service.py
+++ b/ee/pocketpaw_ee/cloud/growth/service.py
@@ -86,6 +86,15 @@
 # ``count_whatsapp_attempts_since`` own the WhatsApp compliance record and its
 # rate-cap window, and ``record_whatsapp_inbound_reply`` applies the opt-in +
 # status flips an inbound reply implies.
+# Updated 2026-07-29 (feat/growth-discovery): the ICP store — ``create_icp`` /
+# ``get_icp`` / ``list_icps`` / ``update_icp`` / ``delete_icp``, the same
+# workspace-scoped shape as the prospect CRUD (identical 404s for malformed,
+# missing and cross-tenant ids). No uniqueness constraint: two ICPs may share a
+# name, told apart by ``project_id``. Delete leaves discovered prospects'
+# ``icp_id`` intact — see ``delete_icp`` on why provenance is not a foreign key.
+# Also ``upsert_by_domain`` learned the two provenance fields, both SET-ONLY
+# like ``project_id``: an enrichment call carrying neither must not erase the
+# record of where a discovered row came from.
 # Updated 2026-07-27 (integration/growth-v1): G-5's ``MessageLog`` and G-6's
 # ``WhatsAppSendLog`` were the same record under two names (parallel branches,
 # neither could see the other). Unified onto ``MessageLog``: the WhatsApp
@@ -121,6 +130,7 @@ from pocketpaw_ee.cloud.growth.domain import (
     PROVIDER_REACHED_OUTCOMES,
     TIER_SORT_ORDER,
     Draft,
+    Icp,
     MessageLog,
     Prospect,
 )
@@ -129,8 +139,10 @@ from pocketpaw_ee.cloud.growth.dto import (
     BulkIngestResponse,
     BulkRowError,
     CreateDraftRequest,
+    CreateIcpRequest,
     CreateProspectRequest,
     DraftResponse,
+    IcpResponse,
     LinkedInQueueItemResponse,
     ProposeBatchError,
     ProposeBatchRequest,
@@ -141,9 +153,11 @@ from pocketpaw_ee.cloud.growth.dto import (
     ProspectResponse,
     TransitionDraftRequest,
     UpdateDraftRequest,
+    UpdateIcpRequest,
     UpdateProspectRequest,
 )
 from pocketpaw_ee.cloud.models.draft import Draft as _DraftDoc
+from pocketpaw_ee.cloud.models.icp import Icp as _IcpDoc
 from pocketpaw_ee.cloud.models.message_log import MessageLog as _MessageLogDoc
 from pocketpaw_ee.cloud.models.prospect import Prospect as _ProspectDoc
 
@@ -813,6 +827,160 @@ async def bulk_ingest(ctx: RequestContext, body: BulkIngestRequest) -> BulkInges
         len(errors),
     )
     return BulkIngestResponse(created=created, updated=updated, errors=errors)
+
+
+# ---------------------------------------------------------------------------
+# ICPs (feat/growth-discovery)
+# ---------------------------------------------------------------------------
+
+
+def _icp_to_domain(doc: _IcpDoc) -> Icp:
+    return Icp(
+        id=str(doc.id),
+        workspace_id=doc.workspace,
+        name=doc.name,
+        criteria=doc.criteria,
+        project_id=doc.project_id,
+        geography=doc.geography,
+        exclusions=doc.exclusions,
+        cadence=doc.cadence,
+        max_per_run=doc.max_per_run,
+        status=doc.status,
+        last_run_at=doc.last_run_at,
+        created_at=getattr(doc, "createdAt", None),
+        updated_at=getattr(doc, "updatedAt", None),
+    )
+
+
+def _icp_to_response(icp: Icp) -> IcpResponse:
+    return IcpResponse(
+        id=icp.id,
+        workspace_id=icp.workspace_id,
+        name=icp.name,
+        criteria=icp.criteria,
+        project_id=icp.project_id,
+        geography=icp.geography,
+        exclusions=icp.exclusions,
+        cadence=icp.cadence,
+        max_per_run=icp.max_per_run,
+        status=icp.status,
+        last_run_at=iso_utc(icp.last_run_at),
+        created_at=iso_utc(icp.created_at),
+        updated_at=iso_utc(icp.updated_at),
+    )
+
+
+async def _fetch_icp_in_workspace(workspace_id: str, icp_id: str) -> _IcpDoc:
+    """Fetch an ICP scoped to the caller's workspace — identical 404s for a
+    malformed id, a missing row, or another tenant's row, so existence never
+    leaks (same shape as ``_fetch_in_workspace``)."""
+    try:
+        oid = PydanticObjectId(icp_id)
+    except Exception as exc:  # noqa: BLE001 — malformed id == not found
+        raise NotFound("icp", icp_id) from exc
+    doc = await _IcpDoc.find_one({"_id": oid, "workspace": workspace_id})
+    if doc is None:
+        raise NotFound("icp", icp_id)
+    return doc
+
+
+async def create_icp(ctx: RequestContext, body: CreateIcpRequest) -> IcpResponse:
+    """Create an ICP. No uniqueness constraint: two ICPs may share a name (an
+    agency running "dental clinics" for two clients holds two of them, told
+    apart by ``project_id``), so there is no 409 here."""
+    body = CreateIcpRequest.model_validate(body)
+    workspace_id = _require_workspace(ctx)
+    if body.project_id:
+        await _ensure_project_in_workspace(workspace_id, body.project_id)
+
+    doc = _IcpDoc(workspace=workspace_id, **body.model_dump())
+    await doc.insert()
+    # no-event: growth has no realtime subscriber in v1; the ICP view polls.
+    return _icp_to_response(_icp_to_domain(doc))
+
+
+async def get_icp(ctx: RequestContext, icp_id: str) -> IcpResponse:
+    workspace_id = _require_workspace(ctx)
+    doc = await _fetch_icp_in_workspace(workspace_id, icp_id)
+    return _icp_to_response(_icp_to_domain(doc))
+
+
+async def list_icps(
+    ctx: RequestContext,
+    *,
+    project_id: str | None = None,
+    status: str | None = None,
+    limit: int = 100,
+) -> list[IcpResponse]:
+    """The workspace's ICPs, newest first.
+
+    A bare list rather than the prospect list's page envelope: an ICP is a
+    hand-written artifact and a workspace holds a handful, not thousands. If
+    that ever stops being true the answer is the same cursor machinery the
+    prospect list already carries, not a bigger limit.
+
+    ``project_id`` is three-valued like the prospect list — omitted means every
+    project, an id scopes to that client, ``""`` selects the unassigned ones.
+    """
+    workspace_id = _require_workspace(ctx)
+    filters: dict[str, Any] = {"workspace": workspace_id}
+    if project_id is not None:
+        filters["project_id"] = project_id or None
+    if status is not None:
+        filters["status"] = status
+    docs = await _IcpDoc.find(filters).sort([("createdAt", -1), ("_id", -1)]).limit(limit).to_list()
+    return [_icp_to_response(_icp_to_domain(doc)) for doc in docs]
+
+
+async def update_icp(ctx: RequestContext, icp_id: str, body: UpdateIcpRequest) -> IcpResponse:
+    """Partial update. Switching ``cadence`` on is how discovery starts running
+    on a schedule — the field is an ordinary edit here because the BOUNDS (per
+    run and per workspace per month) are what make an always-on cadence safe,
+    not a second approval on the switch."""
+    body = UpdateIcpRequest.model_validate(body)
+    workspace_id = _require_workspace(ctx)
+    doc = await _fetch_icp_in_workspace(workspace_id, icp_id)
+
+    if body.project_id is not None:
+        if body.project_id:
+            await _ensure_project_in_workspace(workspace_id, body.project_id)
+            doc.project_id = body.project_id
+        else:
+            doc.project_id = None
+    for field in (
+        "name",
+        "criteria",
+        "geography",
+        "exclusions",
+        "cadence",
+        "max_per_run",
+        "status",
+    ):
+        value = getattr(body, field)
+        if value is not None:
+            setattr(doc, field, value)
+    await doc.save()  # bumps updatedAt
+    # no-event: growth has no realtime subscriber in v1; the ICP view polls.
+    return _icp_to_response(_icp_to_domain(doc))
+
+
+async def delete_icp(ctx: RequestContext, icp_id: str) -> None:
+    """Delete an ICP.
+
+    Prospects it discovered are LEFT ALONE, ``icp_id`` and all. Provenance is a
+    record of what happened, not a foreign key: those rows really were found by
+    a profile that really existed, and deleting the definition does not un-find
+    them. The alternative — nulling the pointer across every discovered row —
+    is a mass write that erases the only answer to "where did this company come
+    from" for rows a human is about to review.
+
+    An operator who wants the ICP to stop running without losing the definition
+    pauses it instead (``status="paused"``).
+    """
+    workspace_id = _require_workspace(ctx)
+    doc = await _fetch_icp_in_workspace(workspace_id, icp_id)
+    await doc.delete()
+    # no-event: growth has no realtime subscriber in v1; the ICP view polls.
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/cloud/growth/service.py
+++ b/ee/pocketpaw_ee/cloud/growth/service.py
@@ -171,6 +171,8 @@ def _to_domain(doc: _ProspectDoc) -> Prospect:
         whatsapp_number=doc.whatsapp_number,
         opted_in=doc.opted_in,
         status=doc.status,
+        icp_id=getattr(doc, "icp_id", None),
+        source_urls=tuple(getattr(doc, "source_urls", None) or ()),
         created_at=getattr(doc, "createdAt", None),
         updated_at=getattr(doc, "updatedAt", None),
     )
@@ -224,6 +226,8 @@ def _to_response(p: Prospect) -> ProspectResponse:
         whatsapp_number=p.whatsapp_number,
         opted_in=p.opted_in,
         status=p.status,
+        icp_id=p.icp_id,
+        source_urls=list(p.source_urls),
         created_at=iso_utc(p.created_at),
         updated_at=iso_utc(p.updated_at),
     )
@@ -734,14 +738,22 @@ async def upsert_by_domain(
         "status",
     ):
         setattr(doc, field, getattr(body, field))
-    # ``project_id`` is the ONE field an upsert only ever SETS, never clears. A
-    # re-import that names a project reassigns the row; one that says nothing
-    # leaves the assignment alone. The alternative — treating the DTO's default
-    # ``None`` as "unassign" — would make every agent enrichment call
+    # ``project_id`` is one of the fields an upsert only ever SETS, never
+    # clears. A re-import that names a project reassigns the row; one that says
+    # nothing leaves the assignment alone. The alternative — treating the DTO's
+    # default ``None`` as "unassign" — would make every agent enrichment call
     # (``growth_upsert_prospect``, which carries no project) silently orphan a
     # client's prospect. Un-assigning is an explicit act: PATCH with ``""``.
     if body.project_id:
         doc.project_id = body.project_id
+    # Discovery provenance follows the same set-only rule, for the same reason
+    # doubled: an enrichment call that carries no ICP and no source URLs must
+    # not ERASE the record of where a discovered row came from. Provenance that
+    # a later write can silently delete is not provenance.
+    if body.icp_id:
+        doc.icp_id = body.icp_id
+    if body.source_urls:
+        doc.source_urls = list(body.source_urls)
     await doc.save()  # bumps updatedAt
     # no-event: growth has no realtime subscriber in v1.
     return _to_response(_to_domain(doc))

--- a/ee/pocketpaw_ee/cloud/growth/service.py
+++ b/ee/pocketpaw_ee/cloud/growth/service.py
@@ -142,8 +142,10 @@ from pocketpaw_ee.cloud.growth.dto import (
     CreateIcpRequest,
     CreateProspectRequest,
     DraftResponse,
+    IcpPreviewResponse,
     IcpResponse,
     LinkedInQueueItemResponse,
+    PreviewedProspectResponse,
     ProposeBatchError,
     ProposeBatchRequest,
     ProposeBatchResponse,
@@ -963,6 +965,52 @@ async def update_icp(ctx: RequestContext, icp_id: str, body: UpdateIcpRequest) -
     await doc.save()  # bumps updatedAt
     # no-event: growth has no realtime subscriber in v1; the ICP view polls.
     return _icp_to_response(_icp_to_domain(doc))
+
+
+async def preview_icp(ctx: RequestContext, icp_id: str) -> IcpPreviewResponse:
+    """Dry-run an ICP: research once, report what WOULD be filed, write nothing.
+
+    Lives here rather than in the router because tenancy does — the router
+    stays a thin shell and every workspace check in this entity is in one file.
+    The actual work is ``discovery.preview_discovery``; the import is lazy
+    because discovery imports this module back (it may only reach docs through
+    these seams), and a lazy import is how the followups cron already resolves
+    the same loop.
+
+    A deployment with no research backend wired returns 503 rather than an
+    empty preview. "Found nobody" and "nothing went looking" are different
+    answers, and an operator tuning criteria against a silently-disabled engine
+    would rewrite them forever.
+    """
+    from pocketpaw_ee.cloud.growth import discovery as growth_discovery
+
+    workspace_id = _require_workspace(ctx)
+    research_fn = growth_discovery.resolve_research_fn()
+    if research_fn is None:
+        raise CloudError(
+            503,
+            "icp.research_unavailable",
+            "Discovery research is not configured on this deployment",
+        )
+
+    preview = await growth_discovery.preview_discovery(workspace_id, icp_id, research_fn)
+    return IcpPreviewResponse(
+        icp_id=preview.icp_id,
+        items=[
+            PreviewedProspectResponse(
+                domain=item.domain,
+                name=item.name,
+                company=item.company,
+                research_brief=item.research_brief,
+                source_urls=list(item.source_urls),
+                emails=list(item.emails),
+                already_known=item.already_known,
+            )
+            for item in preview.items
+        ],
+        notes=preview.notes,
+        error=preview.error,
+    )
 
 
 async def delete_icp(ctx: RequestContext, icp_id: str) -> None:

--- a/ee/pocketpaw_ee/cloud/growth/service.py
+++ b/ee/pocketpaw_ee/cloud/growth/service.py
@@ -155,6 +155,7 @@ from pocketpaw_ee.cloud.growth.dto import (
     UpdateDraftRequest,
     UpdateIcpRequest,
     UpdateProspectRequest,
+    _normalise_domain,
 )
 from pocketpaw_ee.cloud.models.draft import Draft as _DraftDoc
 from pocketpaw_ee.cloud.models.icp import Icp as _IcpDoc
@@ -1668,6 +1669,49 @@ async def get_prospect_system(workspace_id: str, prospect_id: str) -> ProspectRe
     a cross-workspace id raises NotFound exactly as the HTTP ``get`` does)."""
     doc = await _fetch_in_workspace(workspace_id, prospect_id)
     return _to_response(_to_domain(doc))
+
+
+# ---------------------------------------------------------------------------
+# Discovery seams (feat/growth-discovery)
+#
+# The discovery run and its cron live in ``growth/discovery.py`` and cannot
+# touch a doc class (import-linter "Growth" contract), so every read and write
+# they need is a named function here — the same arrangement ``followups`` has.
+# All of them take an explicit ``workspace_id`` because discovery runs under a
+# worker/system identity, mirroring ``upsert_by_domain`` and ``gate_transition``.
+# ---------------------------------------------------------------------------
+
+
+async def get_icp_system(workspace_id: str, icp_id: str) -> IcpResponse:
+    """Read an ICP under the worker's system identity (still tenant-scoped: a
+    cross-workspace id raises NotFound exactly as the HTTP ``get_icp`` does)."""
+    doc = await _fetch_icp_in_workspace(workspace_id, icp_id)
+    return _icp_to_response(_icp_to_domain(doc))
+
+
+async def prospect_exists_by_domain(workspace_id: str, domain: str) -> bool:
+    """Is this company already in the workspace's pipeline?
+
+    Discovery asks BEFORE filing, and skips the ones that are. Two reasons,
+    and the second is the load-bearing one:
+
+    1. Finding a company you already have is not a discovery. Filing it again
+       would spend the run's ``max_per_run`` budget on nothing.
+    2. ``upsert_by_domain`` overwrites ``status`` on an existing row — correct
+       for a human re-importing a list, wrong for a DAILY CRON. A prospect
+       sitting at ``in_sequence`` with two sent drafts would be reset to
+       ``new`` by a re-find, and the follow-up sweep would lose the thread.
+       Skipping known domains means discovery only ever INSERTS, so no
+       automated pass can walk a live prospect backwards.
+
+    Normalises the domain the same way the DTO does, so a research result
+    naming ``https://www.Acme.com/about`` matches the stored ``acme.com``.
+    """
+    normalised = _normalise_domain(domain)
+    if not normalised:
+        return False
+    doc = await _ProspectDoc.find_one({"workspace": workspace_id, "domain": normalised})
+    return doc is not None
 
 
 async def mark_prospect_dead(workspace_id: str, prospect_id: str) -> ProspectResponse:

--- a/ee/pocketpaw_ee/cloud/growth/worker.py
+++ b/ee/pocketpaw_ee/cloud/growth/worker.py
@@ -59,7 +59,12 @@ from arq.worker import func
 
 from pocketpaw_ee.cloud import init_realtime
 from pocketpaw_ee.cloud._core.realtime import xproc
-from pocketpaw_ee.cloud.growth.domain import GROWTH_DISPATCH_JOB_NAME, GROWTH_QUEUE_NAME
+from pocketpaw_ee.cloud.growth.discovery import discovery_sweep
+from pocketpaw_ee.cloud.growth.domain import (
+    GROWTH_DISCOVERY_SWEEP_JOB_NAME,
+    GROWTH_DISPATCH_JOB_NAME,
+    GROWTH_QUEUE_NAME,
+)
 from pocketpaw_ee.cloud.growth.followups import (
     GROWTH_FOLLOWUP_SWEEP_JOB_NAME,
     followup_sweep,
@@ -168,7 +173,27 @@ class WorkerSettings:
             minute=0,
             unique=True,
             run_at_startup=False,
-        )
+        ),
+        # G-13 — discovery runs at 06:00 UTC, seven hours AHEAD of the
+        # follow-up sweep rather than near it. Two reasons, in order of
+        # importance. First, they must not contend: discovery is the expensive
+        # tick (an agent research run per due ICP) and the follow-up sweep is
+        # the time-sensitive one, so stacking them would let a slow hunt delay
+        # outreach that is already overdue. Second, discovery FEEDS the list a
+        # human then triages — landing it at the start of the working day in
+        # Europe and India means the morning's finds are waiting when someone
+        # sits down, instead of arriving mid-afternoon behind the day's other
+        # work. ``unique=True`` for the same reason as above: a scaled worker
+        # fleet must run one sweep per tick, and discovery WRITES prospects, so
+        # a duplicate tick would double-file rather than no-op.
+        cron(
+            discovery_sweep,
+            name=GROWTH_DISCOVERY_SWEEP_JOB_NAME,
+            hour=6,
+            minute=0,
+            unique=True,
+            run_at_startup=False,
+        ),
     ]
     on_startup = _startup
     on_shutdown = _shutdown

--- a/ee/pocketpaw_ee/cloud/models/__init__.py
+++ b/ee/pocketpaw_ee/cloud/models/__init__.py
@@ -13,6 +13,10 @@ the attempts the opt-in guard REFUSED) to the imports and
 into ``init_beanie``. Kept out of ``__all__`` like ``Prospect`` / ``Draft`` —
 only ``ee.cloud.growth.service`` imports the doc class directly (import-linter
 "Growth" contract).
+Updated: 2026-07-29 (feat/growth-discovery) — added ``Icp`` (the standing
+description of who a workspace wants, plus the discovery cadence) to the
+imports and ``get_all_documents()`` so the ``growth_icps`` collection is wired
+into ``init_beanie``. Kept out of ``__all__`` like the other growth docs.
 Updated: 2026-07-27 (feat/growth-g4 merge) — merged integration/ship-v1 into the
 growth stack so the ``_growth_send`` gate slice can wire the sixth gated kind on
 top of ship's instinct-router changes; both changelog blocks below retained.
@@ -198,6 +202,7 @@ from pocketpaw_ee.cloud.models.foresight_workspace_scenario import (
     ForesightWorkspaceScenario,
 )
 from pocketpaw_ee.cloud.models.group import Group, GroupAgent
+from pocketpaw_ee.cloud.models.icp import Icp
 from pocketpaw_ee.cloud.models.instinct_approval import InstinctApproval
 from pocketpaw_ee.cloud.models.instinct_rule import InstinctRuleDoc
 from pocketpaw_ee.cloud.models.instinct_workspace_config import InstinctWorkspaceConfig
@@ -533,6 +538,10 @@ def get_all_documents():
         # ATTEMPT (sent | failed) written by the dispatch worker through
         # ``growth.service.record_message_log``. Same import boundary.
         MessageLog,
+        # Growth ICP (feat/growth-discovery) — the standing description of who
+        # a workspace wants, and the cadence the discovery cron runs it on.
+        # Same import boundary as Prospect / Draft / MessageLog.
+        Icp,
         PushSubscription,
         VapidKeypair,
         WorkspaceSensePreference,

--- a/ee/pocketpaw_ee/cloud/models/icp.py
+++ b/ee/pocketpaw_ee/cloud/models/icp.py
@@ -1,0 +1,60 @@
+# ee/pocketpaw_ee/cloud/models/icp.py — the ICP record for the /growth
+# discovery engine: a STANDING description of who a workspace wants, plus the
+# cadence the discovery cron runs it on. Workspace-scoped. Only
+# ``ee.cloud.growth.service`` may import this doc class (import-linter "Growth"
+# contract).
+#
+# Created 2026-07-29 (feat/growth-discovery): first slice of the discovery
+# engine — the ICP store, its CRUD, and the research seam that reads it.
+#
+# NO unique index. Unlike ``Prospect`` (where ``domain`` is a real dedupe
+# identity), two ICPs in one workspace may legitimately share a name: an agency
+# running "dental clinics" for two different clients holds two of them, scoped
+# by ``project_id``. The (workspace, status, cadence) index is what the
+# discovery cron actually queries — the due-ICP scan — so that is the one that
+# earns its keep.
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from beanie import Indexed
+
+from pocketpaw_ee.cloud.models.base import TimestampedDocument
+
+
+class Icp(TimestampedDocument):
+    """One Ideal Customer Profile in a workspace."""
+
+    # Tenancy boundary — every read filters on this.
+    workspace: Indexed(str)  # type: ignore[valid-type]
+    name: str
+    # Free text on purpose — this is what the research READS. See the ``Icp``
+    # value object in ``growth/domain.py`` for why it is not a filter tree.
+    criteria: str
+    # The client this ICP prospects for (``cloud/projects``), or None on a
+    # workspace that doesn't use projects. Validated against the workspace by
+    # the service before it is written.
+    project_id: str | None = None
+    # Hard constraints the research applies rather than weighs.
+    geography: str = ""
+    exclusions: str = ""
+    cadence: str = "off"  # off | daily | weekly — off is the default
+    max_per_run: int = 10
+    status: str = "active"  # active | paused
+    # When the discovery cron last ran this ICP. Read by the operator surface
+    # ("has this thing actually been running?"); the sweep's due-check keys on
+    # the cadence + the tick, not on this, so a missed tick is a missed tick
+    # rather than a backlog that fires all at once on recovery.
+    last_run_at: datetime | None = None
+
+    class Settings:
+        name = "growth_icps"
+        indexes = [
+            # The list view: one workspace's ICPs, newest first.
+            [("workspace", 1), ("createdAt", -1)],
+            # The discovery cron's due scan — every ACTIVE ICP with a
+            # scheduled cadence, across tenants (the one deliberate global
+            # read, justified at the service seam).
+            [("status", 1), ("cadence", 1)],
+        ]

--- a/ee/pocketpaw_ee/cloud/models/prospect.py
+++ b/ee/pocketpaw_ee/cloud/models/prospect.py
@@ -15,6 +15,12 @@
 # the client container (``cloud/projects``) a prospect belongs to — plus a
 # (workspace, project_id, createdAt) index, because an agency's default view is
 # one client's pipeline rather than the whole workspace's.
+# Updated 2026-07-29 (feat/growth-discovery): provenance for a row nobody typed
+# — ``icp_id`` (the standing profile that found it) and ``source_urls`` (the
+# pages the research actually read). Both empty on a manually created or
+# imported prospect. Plus a (workspace, source, createdAt) index: the monthly
+# discovery ceiling counts this workspace's discovered rows in the current
+# period, and that count runs on every discovery run.
 
 from __future__ import annotations
 
@@ -36,7 +42,8 @@ class Prospect(TimestampedDocument):
     company: str = ""
     # Company website domain, lowercased at the service boundary — the dedupe key.
     domain: str
-    source: str  # clay | directory | manual (validated at the DTO boundary)
+    # clay | directory | discovery | manual (validated at the DTO boundary)
+    source: str
     # The client this prospect belongs to (``cloud/projects``), or None on a
     # workspace that doesn't use projects. Validated against the workspace by
     # the service before it is written.
@@ -48,6 +55,12 @@ class Prospect(TimestampedDocument):
     whatsapp_number: str | None = None
     opted_in: bool = False
     status: str = "new"  # new | qualified | drafted | in_sequence | replied | dead
+    # The standing ICP that discovered this row, when discovery did. None on a
+    # typed or imported prospect.
+    icp_id: str | None = None
+    # The pages the research read to produce this row — the audit trail for a
+    # prospect nobody typed. Empty on a manually created one.
+    source_urls: list[str] = Field(default_factory=list)
 
     class Settings:
         name = "growth_prospects"
@@ -66,4 +79,8 @@ class Prospect(TimestampedDocument):
             # client's pipeline, so the project filter belongs in the index
             # rather than as a post-filter over the whole workspace.
             [("workspace", 1), ("project_id", 1), ("createdAt", -1)],
+            # The discovery monthly ceiling: count this workspace's rows with
+            # ``source="discovery"`` created since the period start. Runs on
+            # every discovery run, before anything is filed.
+            [("workspace", 1), ("source", 1), ("createdAt", -1)],
         ]

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -829,6 +829,12 @@ name = "Growth — Beanie writes only from service.py"
 # integration/growth-v1 — G-6's ``WhatsAppSendLog`` was folded into G-5's
 # ``MessageLog`` (one send record, not two), so only ``models.message_log``
 # stays on the forbidden list.
+# feat/growth-discovery — the ``Icp`` doc joins the forbidden list and
+# ``growth.discovery`` joins the source list. The discovery run reaches ICPs
+# and prospects ONLY through the service's system-identity seams, exactly as
+# ``followups`` does: it is the second cron on this queue, and a module that
+# files rows on a schedule is precisely where a direct doc write would be
+# least visible.
 type = "forbidden"
 allow_indirect_imports = "true"
 # feat/growth-mcp — the agent surface joins the boundary:
@@ -854,6 +860,7 @@ forbidden_modules = [
     "pocketpaw_ee.cloud.models.prospect",
     "pocketpaw_ee.cloud.models.draft",
     "pocketpaw_ee.cloud.models.message_log",
+    "pocketpaw_ee.cloud.models.icp",
 ]
 
 [[tool.importlinter.contracts]]

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -850,6 +850,7 @@ source_modules = [
     "pocketpaw_ee.cloud.growth.propose",
     "pocketpaw_ee.cloud.growth.executor",
     "pocketpaw_ee.cloud.growth.connector",
+    "pocketpaw_ee.cloud.growth.discovery",
     "pocketpaw_ee.cloud.growth.email_dispatch",
     "pocketpaw_ee.cloud.growth.followups",
     "pocketpaw_ee.cloud.growth.whatsapp",

--- a/tests/cloud/growth/test_discovery.py
+++ b/tests/cloud/growth/test_discovery.py
@@ -535,3 +535,142 @@ class TestProductionResearchSeam:
         finally:
             set_production_research_fn(None)
         assert resolve_research_fn() is None
+
+
+# ---------------------------------------------------------------------------
+# Preview — the same research, none of the writes
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def wired():
+    """Wire a research loop for the duration of one test and clear it after.
+
+    The route resolves the production seam, so an HTTP-level preview test has
+    to install one. Cleared in a finally so a failure can't leak a fake into
+    the next test."""
+    installed: list[Any] = []
+
+    def _install(fn: Any) -> Any:
+        set_production_research_fn(fn)
+        installed.append(fn)
+        return fn
+
+    try:
+        yield _install
+    finally:
+        set_production_research_fn(None)
+
+
+class TestPreview:
+    """Trust before cadence. A preview shows exactly what a run would file —
+    same projection, same email rule — and leaves the pipeline untouched."""
+
+    @pytest.mark.asyncio
+    async def test_preview_writes_nothing(self, w1, wired):
+        icp = await _create_icp(w1)
+        wired(FakeResearch(_company("acme-dental.com"), _company("brightsmile.com")))
+
+        resp = await w1.post(f"{ICPS_URL}/{icp['id']}/preview")
+
+        assert resp.status_code == 200, resp.text
+        assert len(resp.json()["items"]) == 2
+        assert await _prospects(w1) == []
+        assert (await w1.get("/api/v1/growth/drafts")).json() == []
+
+    @pytest.mark.asyncio
+    async def test_preview_shows_only_recordable_emails(self, w1, wired):
+        """A preview that displayed the raw evidence would advertise addresses
+        the engine refuses to keep — the projection is shared with the run
+        precisely so the two cannot drift."""
+        icp = await _create_icp(w1)
+        wired(
+            FakeResearch(
+                _company(
+                    "acme-dental.com",
+                    emails=(
+                        EmailEvidence("guess@acme-dental.com", "guessed"),
+                        EmailEvidence(
+                            "hello@acme-dental.com",
+                            "observed",
+                            "https://acme-dental.com/contact",
+                        ),
+                    ),
+                )
+            )
+        )
+
+        (item,) = (await w1.post(f"{ICPS_URL}/{icp['id']}/preview")).json()["items"]
+
+        assert item["emails"] == ["hello@acme-dental.com"]
+
+    @pytest.mark.asyncio
+    async def test_a_known_company_is_flagged_not_hidden(self, w1, wired):
+        """A preview full of already_known rows is the useful signal that the
+        criteria describe people you already have."""
+        await w1.post(
+            "/api/v1/growth/prospects",
+            json={"domain": "acme-dental.com", "source": "manual"},
+        )
+        icp = await _create_icp(w1)
+        wired(FakeResearch(_company("acme-dental.com"), _company("brightsmile.com")))
+
+        items = (await w1.post(f"{ICPS_URL}/{icp['id']}/preview")).json()["items"]
+
+        assert {i["domain"]: i["already_known"] for i in items} == {
+            "acme-dental.com": True,
+            "brightsmile.com": False,
+        }
+
+    @pytest.mark.asyncio
+    async def test_a_paused_icp_still_previews(self, w1, wired):
+        """Checking whether a profile is worth resuming is the reason to look
+        at a paused one."""
+        icp = await _create_icp(w1, status="paused")
+        wired(FakeResearch(_company("acme-dental.com")))
+
+        resp = await w1.post(f"{ICPS_URL}/{icp['id']}/preview")
+
+        assert resp.status_code == 200, resp.text
+        assert len(resp.json()["items"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_a_research_failure_is_reported_not_swallowed(self, w1, wired):
+        """ "Found nobody" and "the search provider was down" must not look the
+        same to someone tuning criteria."""
+        icp = await _create_icp(w1)
+        wired(ExplodingResearch())
+
+        body = (await w1.post(f"{ICPS_URL}/{icp['id']}/preview")).json()
+
+        assert body["items"] == []
+        assert "research failed" in body["error"]
+
+    @pytest.mark.asyncio
+    async def test_preview_respects_max_per_run(self, w1, wired):
+        icp = await _create_icp(w1, max_per_run=2)
+        wired(FakeResearch(*[_company(f"co-{i:02d}.com") for i in range(6)]))
+
+        items = (await w1.post(f"{ICPS_URL}/{icp['id']}/preview")).json()["items"]
+
+        assert len(items) == 2
+
+    @pytest.mark.asyncio
+    async def test_no_research_backend_is_a_503_not_an_empty_preview(self, w1):
+        """An operator tuning criteria against a silently-disabled engine would
+        rewrite them forever."""
+        icp = await _create_icp(w1)
+
+        resp = await w1.post(f"{ICPS_URL}/{icp['id']}/preview")
+
+        assert resp.status_code == 503, resp.text
+        assert resp.json()["error"]["code"] == "icp.research_unavailable"
+
+    @pytest.mark.asyncio
+    async def test_another_tenants_icp_is_a_404(self, w1, w2, wired):
+        icp = await _create_icp(w1)
+        wired(FakeResearch(_company("acme-dental.com")))
+
+        resp = await w2.post(f"{ICPS_URL}/{icp['id']}/preview")
+
+        assert resp.status_code == 404, resp.text

--- a/tests/cloud/growth/test_discovery.py
+++ b/tests/cloud/growth/test_discovery.py
@@ -12,12 +12,50 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
 from pocketpaw_ee.cloud.growth.domain import (
     RECORDABLE_EMAIL_CONFIDENCE,
     EmailEvidence,
     recordable_emails,
 )
+
+from tests.cloud.growth.test_router import _build_app
+
+ICPS_URL = "/api/v1/growth/icps"
+
+
+@pytest_asyncio.fixture
+async def w1(mongo_db: Any) -> AsyncClient:
+    transport = ASGITransport(app=_build_app(workspace_id="w1"))
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+@pytest_asyncio.fixture
+async def w2(mongo_db: Any) -> AsyncClient:
+    transport = ASGITransport(app=_build_app(workspace_id="w2"))
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+def _icp_payload(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "name": "Small dental practices",
+        "criteria": "Dental practices with 2-6 chairs that still book by phone.",
+    }
+    base.update(overrides)
+    return base
+
+
+async def _create_icp(client: AsyncClient, **overrides: Any) -> dict[str, Any]:
+    resp = await client.post(ICPS_URL, json=_icp_payload(**overrides))
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
 
 # ---------------------------------------------------------------------------
 # The provenance rule at the domain level
@@ -95,3 +133,109 @@ class TestRecordableEmails:
             ]
         )
         assert found == ("hello@acme.com",)
+
+
+# ---------------------------------------------------------------------------
+# ICP CRUD
+# ---------------------------------------------------------------------------
+
+
+class TestIcpCrud:
+    """The ICP is a hand-written artifact: create it, read it, tune it, retire
+    it. The interesting assertions are the DEFAULTS (a new ICP does not run)
+    and the tenant boundary (identical 404s, never a cross-tenant read)."""
+
+    @pytest.mark.asyncio
+    async def test_a_new_icp_does_not_run(self, w1):
+        """The default that matters. Writing down who you want is free;
+        going looking for them on a schedule is a recurring spend, so the
+        cadence has to be switched on deliberately."""
+        icp = await _create_icp(w1)
+        assert icp["cadence"] == "off"
+        assert icp["status"] == "active"
+        assert icp["max_per_run"] == 10
+        assert icp["workspace_id"] == "w1"
+        assert icp["last_run_at"] is None
+
+    @pytest.mark.asyncio
+    async def test_criteria_is_required_and_cannot_be_blank(self, w1):
+        assert (await w1.post(ICPS_URL, json={"name": "n"})).status_code == 422
+        assert (await w1.post(ICPS_URL, json={"name": "n", "criteria": "  "})).status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_max_per_run_is_capped_at_the_boundary(self, w1):
+        """A run is an LLM research pass, not a database scan — past the cap
+        the right tool is a second ICP with narrower criteria."""
+        resp = await w1.post(ICPS_URL, json=_icp_payload(max_per_run=500))
+        assert resp.status_code == 422
+        assert (await w1.post(ICPS_URL, json=_icp_payload(max_per_run=0))).status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_get_and_list_return_the_created_icp(self, w1):
+        icp = await _create_icp(w1)
+        assert (await w1.get(f"{ICPS_URL}/{icp['id']}")).json()["name"] == icp["name"]
+        listed = (await w1.get(ICPS_URL)).json()
+        assert [row["id"] for row in listed] == [icp["id"]]
+
+    @pytest.mark.asyncio
+    async def test_two_icps_may_share_a_name(self, w1):
+        """No uniqueness constraint: an agency runs "dental clinics" for two
+        clients and holds two profiles, told apart by their project."""
+        first = await _create_icp(w1)
+        second = await _create_icp(w1)
+        assert first["id"] != second["id"]
+        assert len((await w1.get(ICPS_URL)).json()) == 2
+
+    @pytest.mark.asyncio
+    async def test_patch_switches_the_cadence_on(self, w1):
+        icp = await _create_icp(w1)
+        resp = await w1.patch(f"{ICPS_URL}/{icp['id']}", json={"cadence": "weekly"})
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["cadence"] == "weekly"
+        # Untouched fields survive a partial update.
+        assert resp.json()["criteria"] == icp["criteria"]
+
+    @pytest.mark.asyncio
+    async def test_patch_rejects_an_unknown_cadence(self, w1):
+        icp = await _create_icp(w1)
+        resp = await w1.patch(f"{ICPS_URL}/{icp['id']}", json={"cadence": "hourly"})
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_delete_removes_it_from_the_list(self, w1):
+        icp = await _create_icp(w1)
+        assert (await w1.delete(f"{ICPS_URL}/{icp['id']}")).status_code == 204
+        assert (await w1.get(f"{ICPS_URL}/{icp['id']}")).status_code == 404
+        assert (await w1.get(ICPS_URL)).json() == []
+
+    @pytest.mark.asyncio
+    async def test_list_filters_by_status(self, w1):
+        active = await _create_icp(w1)
+        paused = await _create_icp(w1, status="paused")
+        ids = [r["id"] for r in (await w1.get(ICPS_URL, params={"status": "paused"})).json()]
+        assert ids == [paused["id"]]
+        ids = [r["id"] for r in (await w1.get(ICPS_URL, params={"status": "active"})).json()]
+        assert ids == [active["id"]]
+
+    @pytest.mark.parametrize("method", ["get", "patch", "delete"])
+    @pytest.mark.asyncio
+    async def test_another_tenants_icp_is_a_404(self, w1, w2, method: str):
+        """Identical 404s for a foreign row and a row that never existed —
+        existence must not leak across tenants."""
+        icp = await _create_icp(w1)
+        url = f"{ICPS_URL}/{icp['id']}"
+        resp = (
+            await w2.patch(url, json={"name": "stolen"})
+            if method == "patch"
+            else await getattr(w2, method)(url)
+        )
+        assert resp.status_code == 404, resp.text
+
+    @pytest.mark.asyncio
+    async def test_a_foreign_icp_never_appears_in_the_list(self, w1, w2):
+        await _create_icp(w1)
+        assert (await w2.get(ICPS_URL)).json() == []
+
+    @pytest.mark.asyncio
+    async def test_a_malformed_id_is_a_404_not_a_500(self, w1):
+        assert (await w1.get(f"{ICPS_URL}/not-an-object-id")).status_code == 404

--- a/tests/cloud/growth/test_discovery.py
+++ b/tests/cloud/growth/test_discovery.py
@@ -1,0 +1,97 @@
+# tests/cloud/growth/test_discovery.py — tests for the /growth ICP discovery
+# engine: the email-provenance rule, the ICP CRUD service seams, the discovery
+# run against a FAKE ``ResearchFn`` (code under test never calls a real LLM —
+# the belt/headless pattern), the preview path, and the bounds.
+#
+# Created 2026-07-29 (feat/growth-discovery): the provenance rule first,
+# because it is the constraint the rest of the slice exists to protect. An LLM
+# cannot run Clay's verification waterfall, so a "found" address that nobody
+# read off a page is a guess — and a guessed address bounces, burns the sending
+# domain's reputation, and poisons the list. These tests pin that the rule is
+# STRUCTURAL (a filter the data must pass) rather than a request in a prompt.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.growth.domain import (
+    RECORDABLE_EMAIL_CONFIDENCE,
+    EmailEvidence,
+    recordable_emails,
+)
+
+# ---------------------------------------------------------------------------
+# The provenance rule at the domain level
+# ---------------------------------------------------------------------------
+
+
+class TestRecordableEmails:
+    """``recordable_emails`` is THE door between "the research mentioned an
+    address" and "we stored one". Nothing else in the discovery path may open
+    it, so every way of failing to prove where an address came from is pinned
+    here."""
+
+    def test_an_observed_address_with_its_page_is_recorded(self):
+        found = recordable_emails(
+            [
+                EmailEvidence(
+                    address="hello@acme-dental.com",
+                    confidence="observed",
+                    seen_at_url="https://acme-dental.com/contact",
+                )
+            ]
+        )
+        assert found == ("hello@acme-dental.com",)
+
+    @pytest.mark.parametrize("confidence", ["guessed", "claimed"])
+    def test_an_unobserved_address_produces_nothing(self, confidence: str):
+        """The core case. A pattern-built ``first@company.com`` and an address
+        an aggregator merely asserted are both refused, even when they carry a
+        URL — the URL is where the CLAIM was made, not where the address was
+        read."""
+        found = recordable_emails(
+            [
+                EmailEvidence(
+                    address="sam@acme-dental.com",
+                    confidence=confidence,
+                    seen_at_url="https://directory.example/acme",
+                )
+            ]
+        )
+        assert found == ()
+
+    def test_observed_without_a_url_produces_nothing(self):
+        """An ``observed`` claim with no page is unfalsifiable — which is
+        exactly the shape a model produces when it wants to say yes."""
+        assert recordable_emails([EmailEvidence("sam@acme.com", confidence="observed")]) == ()
+
+    def test_the_default_confidence_is_the_untrusted_one(self):
+        """Evidence that never says how it was obtained fails closed. A
+        research implementation that forgets the field gets no address, not a
+        free promotion to observed."""
+        assert EmailEvidence(address="sam@acme.com").confidence not in RECORDABLE_EMAIL_CONFIDENCE
+        assert recordable_emails([EmailEvidence(address="sam@acme.com")]) == ()
+
+    def test_a_blank_address_is_dropped_even_when_observed(self):
+        assert recordable_emails([EmailEvidence("   ", "observed", "https://acme.com")]) == ()
+
+    def test_the_same_address_on_two_pages_is_one_address(self):
+        found = recordable_emails(
+            [
+                EmailEvidence("Hello@Acme.com", "observed", "https://acme.com/contact"),
+                EmailEvidence("hello@acme.com", "observed", "https://acme.com/about"),
+                EmailEvidence("sales@acme.com", "observed", "https://acme.com/about"),
+            ]
+        )
+        assert found == ("hello@acme.com", "sales@acme.com")
+
+    def test_a_good_address_survives_a_batch_of_bad_ones(self):
+        """Mixed evidence keeps what it can prove instead of failing the whole
+        prospect — the row is still worth having without the guesses."""
+        found = recordable_emails(
+            [
+                EmailEvidence("guess@acme.com", "guessed"),
+                EmailEvidence("hello@acme.com", "observed", "https://acme.com/contact"),
+                EmailEvidence("claimed@acme.com", "claimed", "https://directory.example/acme"),
+            ]
+        )
+        assert found == ("hello@acme.com",)

--- a/tests/cloud/growth/test_discovery.py
+++ b/tests/cloud/growth/test_discovery.py
@@ -17,6 +17,15 @@ from typing import Any
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
+from pocketpaw_ee.cloud._core.errors import NotFound
+from pocketpaw_ee.cloud.growth.discovery import (
+    DiscoveredCompany,
+    ResearchRequest,
+    ResearchResult,
+    resolve_research_fn,
+    run_discovery,
+    set_production_research_fn,
+)
 from pocketpaw_ee.cloud.growth.domain import (
     RECORDABLE_EMAIL_CONFIDENCE,
     EmailEvidence,
@@ -239,3 +248,290 @@ class TestIcpCrud:
     @pytest.mark.asyncio
     async def test_a_malformed_id_is_a_404_not_a_500(self, w1):
         assert (await w1.get(f"{ICPS_URL}/not-an-object-id")).status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# The discovery run — against a FAKE ResearchFn
+# ---------------------------------------------------------------------------
+
+
+class FakeResearch:
+    """A deterministic stand-in for the agent research loop.
+
+    The whole point of the ``ResearchFn`` seam (copied from belt/headless):
+    code under test never calls a real LLM, and a test can hand the run
+    EXACTLY the shape a misbehaving model would produce — a company with a
+    guessed address, a result with no domain, two hundred rows against a limit
+    of ten — and assert what the engine does with it.
+    """
+
+    def __init__(self, *companies: DiscoveredCompany, notes: str = "") -> None:
+        self.result = ResearchResult(companies=tuple(companies), notes=notes)
+        self.calls: list[ResearchRequest] = []
+
+    async def __call__(self, request: ResearchRequest) -> ResearchResult:
+        self.calls.append(request)
+        return self.result
+
+
+class ExplodingResearch:
+    """A research loop that fails, which is what a real one does sometimes."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def __call__(self, request: ResearchRequest) -> ResearchResult:
+        self.calls += 1
+        raise RuntimeError("the search provider returned 503")
+
+
+def _company(domain: str, **overrides: Any) -> DiscoveredCompany:
+    base: dict[str, Any] = {
+        "name": "",
+        "company": f"Co {domain}",
+        "research_brief": "Three chairs, books by phone.",
+        "source_urls": (f"https://{domain}/about",),
+    }
+    base.update(overrides)
+    return DiscoveredCompany(domain=domain, **base)
+
+
+async def _prospects(client: AsyncClient) -> list[dict[str, Any]]:
+    resp = await client.get("/api/v1/growth/prospects")
+    assert resp.status_code == 200, resp.text
+    return resp.json()["items"]
+
+
+class TestDiscoveryRun:
+    """Files what it found, and nothing else. The assertions worth reading are
+    the negative ones: no drafts, no invented emails, no reset statuses."""
+
+    @pytest.mark.asyncio
+    async def test_a_found_company_lands_as_a_new_prospect(self, w1):
+        icp = await _create_icp(w1)
+        research = FakeResearch(_company("acme-dental.com"))
+
+        outcome = await run_discovery("w1", icp["id"], research)
+
+        assert outcome.filed == 1
+        (row,) = await _prospects(w1)
+        assert row["domain"] == "acme-dental.com"
+        assert row["source"] == "discovery"
+        assert row["status"] == "new"
+        assert row["tier"] == "unqualified"
+        assert row["icp_id"] == icp["id"]
+        assert row["source_urls"] == ["https://acme-dental.com/about"]
+
+    @pytest.mark.asyncio
+    async def test_the_icp_criteria_reach_the_research_loop(self, w1):
+        icp = await _create_icp(w1, geography="Bengaluru", exclusions="No chains.")
+        research = FakeResearch()
+
+        await run_discovery("w1", icp["id"], research)
+
+        (request,) = research.calls
+        assert request.criteria == icp["criteria"]
+        assert request.geography == "Bengaluru"
+        assert request.exclusions == "No chains."
+        assert request.max_results == icp["max_per_run"]
+        assert request.workspace_id == "w1"
+
+    @pytest.mark.asyncio
+    async def test_an_unobserved_email_never_reaches_the_prospect(self, w1):
+        """THE constraint, end to end. The research claims an address it built
+        from a pattern; the filed row carries no email at all. A prospect with
+        an empty ``emails`` is a good prospect — a human or a real verification
+        provider picks it up from there. A guessed one bounces and burns the
+        sending domain."""
+        icp = await _create_icp(w1)
+        research = FakeResearch(
+            _company(
+                "acme-dental.com",
+                emails=(
+                    EmailEvidence("sam@acme-dental.com", "guessed"),
+                    EmailEvidence(
+                        "info@acme-dental.com",
+                        "claimed",
+                        "https://some-directory.example/acme",
+                    ),
+                    # An ``observed`` claim with nowhere to check it.
+                    EmailEvidence("hello@acme-dental.com", "observed"),
+                ),
+            )
+        )
+
+        outcome = await run_discovery("w1", icp["id"], research)
+
+        assert outcome.filed == 1
+        (row,) = await _prospects(w1)
+        assert row["emails"] == []
+
+    @pytest.mark.asyncio
+    async def test_an_observed_email_does_reach_the_prospect(self, w1):
+        """The other half — the rule refuses guesses, it does not refuse
+        emails. An address read off the company's own contact page is exactly
+        what the engine is for."""
+        icp = await _create_icp(w1)
+        research = FakeResearch(
+            _company(
+                "acme-dental.com",
+                emails=(
+                    EmailEvidence("guess@acme-dental.com", "guessed"),
+                    EmailEvidence(
+                        "hello@acme-dental.com",
+                        "observed",
+                        "https://acme-dental.com/contact",
+                    ),
+                ),
+            )
+        )
+
+        await run_discovery("w1", icp["id"], research)
+
+        (row,) = await _prospects(w1)
+        assert row["emails"] == ["hello@acme-dental.com"]
+
+    @pytest.mark.asyncio
+    async def test_it_drafts_nothing_and_sends_nothing(self, w1):
+        """Discovery adds rows to a list; it does not start conversations.
+        Everything downstream still needs the human gate it always needed."""
+        icp = await _create_icp(w1)
+
+        await run_discovery("w1", icp["id"], FakeResearch(_company("acme-dental.com")))
+
+        assert (await w1.get("/api/v1/growth/drafts")).json() == []
+
+    @pytest.mark.asyncio
+    async def test_a_domain_the_workspace_already_has_is_skipped(self, w1):
+        """A daily cron that re-upserted a live prospect would reset its status
+        and lose the follow-up thread. Discovery only ever inserts."""
+        await w1.post(
+            "/api/v1/growth/prospects",
+            json={
+                "name": "Sam",
+                "company": "Acme Dental",
+                "domain": "acme-dental.com",
+                "source": "manual",
+                "status": "in_sequence",
+            },
+        )
+        icp = await _create_icp(w1)
+
+        outcome = await run_discovery("w1", icp["id"], FakeResearch(_company("acme-dental.com")))
+
+        assert (outcome.filed, outcome.skipped_existing) == (0, 1)
+        (row,) = await _prospects(w1)
+        assert row["status"] == "in_sequence"
+        assert row["source"] == "manual"
+        assert row["icp_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_a_known_domain_is_recognised_through_its_url_form(self, w1):
+        """The research reports what it read off the page; the existence check
+        normalises the same way the dedupe key does."""
+        await w1.post(
+            "/api/v1/growth/prospects",
+            json={"domain": "acme-dental.com", "source": "manual"},
+        )
+        icp = await _create_icp(w1)
+
+        outcome = await run_discovery(
+            "w1", icp["id"], FakeResearch(_company("https://www.Acme-Dental.com/pricing"))
+        )
+
+        assert outcome.skipped_existing == 1
+        assert len(await _prospects(w1)) == 1
+
+    @pytest.mark.asyncio
+    async def test_max_per_run_truncates_the_result(self, w1):
+        """A research loop that ignores the limit does not get to file 200
+        rows: the number a human agreed to review is the number that appears."""
+        icp = await _create_icp(w1, max_per_run=3)
+        research = FakeResearch(*[_company(f"co-{i:02d}.com") for i in range(20)])
+
+        outcome = await run_discovery("w1", icp["id"], research)
+
+        assert (outcome.filed, outcome.considered) == (3, 3)
+        assert len(await _prospects(w1)) == 3
+
+    @pytest.mark.asyncio
+    async def test_skipped_rows_do_not_free_budget_for_extra_ones(self, w1):
+        """The cap is on what the run CONSIDERS, so a result full of known
+        companies produces a short run rather than digging deeper."""
+        await w1.post(
+            "/api/v1/growth/prospects",
+            json={"domain": "co-00.com", "source": "manual"},
+        )
+        icp = await _create_icp(w1, max_per_run=2)
+        research = FakeResearch(*[_company(f"co-{i:02d}.com") for i in range(5)])
+
+        outcome = await run_discovery("w1", icp["id"], research)
+
+        assert (outcome.considered, outcome.filed, outcome.skipped_existing) == (2, 1, 1)
+
+    @pytest.mark.asyncio
+    async def test_a_result_without_a_domain_is_dropped(self, w1):
+        """A company nobody can look up is not a lead — there is nothing to
+        dedupe on and nothing for a human to open."""
+        icp = await _create_icp(w1)
+        research = FakeResearch(_company("   "), _company("acme-dental.com"))
+
+        outcome = await run_discovery("w1", icp["id"], research)
+
+        assert (outcome.filed, outcome.skipped_invalid) == (1, 1)
+
+    @pytest.mark.asyncio
+    async def test_a_research_crash_files_nothing_and_does_not_raise(self, w1):
+        """One bad ICP must not take down a cron pass that has other
+        workspaces left to serve."""
+        icp = await _create_icp(w1)
+        research = ExplodingResearch()
+
+        outcome = await run_discovery("w1", icp["id"], research)
+
+        assert outcome.filed == 0
+        assert "research failed" in outcome.error
+        assert await _prospects(w1) == []
+
+    @pytest.mark.asyncio
+    async def test_a_paused_icp_does_not_run(self, w1):
+        icp = await _create_icp(w1, status="paused")
+        research = FakeResearch(_company("acme-dental.com"))
+
+        outcome = await run_discovery("w1", icp["id"], research)
+
+        assert outcome.error == "icp is paused"
+        assert research.calls == []
+        assert await _prospects(w1) == []
+
+    @pytest.mark.asyncio
+    async def test_rows_land_in_the_icps_workspace_only(self, w1, w2):
+        icp = await _create_icp(w1)
+
+        await run_discovery("w1", icp["id"], FakeResearch(_company("acme-dental.com")))
+
+        assert len(await _prospects(w1)) == 1
+        assert await _prospects(w2) == []
+
+    @pytest.mark.asyncio
+    async def test_another_tenants_icp_id_is_a_404(self, w1, w2):
+        icp = await _create_icp(w1)
+        with pytest.raises(NotFound):
+            await run_discovery("w2", icp["id"], FakeResearch(_company("acme.com")))
+
+
+class TestProductionResearchSeam:
+    """Until a real loop is wired, the engine is visibly idle rather than a
+    source of half-researched rows."""
+
+    def test_no_loop_is_wired_by_default(self):
+        assert resolve_research_fn() is None
+
+    def test_wiring_and_clearing_round_trip(self):
+        fake = FakeResearch()
+        set_production_research_fn(fake)
+        try:
+            assert resolve_research_fn() is fake
+        finally:
+            set_production_research_fn(None)
+        assert resolve_research_fn() is None

--- a/tests/cloud/growth/test_gate.py
+++ b/tests/cloud/growth/test_gate.py
@@ -943,6 +943,15 @@ class TestGrowthRouteRbac:
             # ``sent`` is gate-owned.
             ("GET", "/growth/linkedin/queue"): "growth.read",
             ("POST", "/growth/linkedin/{draft_id}/mark-sent"): "growth.manage",
+            # The ICP surface (feat/growth-discovery). Describing who you want
+            # is authoring work, so it sits at the same MEMBER tier as writing
+            # a draft — an ICP cannot send anything, and the discovery run it
+            # schedules files prospects at ``status="new"`` with no draft.
+            ("GET", "/growth/icps"): "growth.read",
+            ("GET", "/growth/icps/{icp_id}"): "growth.read",
+            ("POST", "/growth/icps"): "growth.write",
+            ("PATCH", "/growth/icps/{icp_id}"): "growth.write",
+            ("DELETE", "/growth/icps/{icp_id}"): "growth.write",
         }
 
         seen: dict[tuple[str, str], str] = {}

--- a/tests/cloud/growth/test_gate.py
+++ b/tests/cloud/growth/test_gate.py
@@ -952,6 +952,9 @@ class TestGrowthRouteRbac:
             ("POST", "/growth/icps"): "growth.write",
             ("PATCH", "/growth/icps/{icp_id}"): "growth.write",
             ("DELETE", "/growth/icps/{icp_id}"): "growth.write",
+            # Preview writes nothing, but it spends a real research pass — not
+            # the outbound verb (it cannot reach a prospect), not free either.
+            ("POST", "/growth/icps/{icp_id}/preview"): "growth.write",
         }
 
         seen: dict[tuple[str, str], str] = {}

--- a/tests/cloud/growth/test_list_query.py
+++ b/tests/cloud/growth/test_list_query.py
@@ -8,6 +8,10 @@
 # Created 2026-07-28 (feat/growth-api-scale): G-10a — the list endpoint could
 # not reach row 3,000, find a company by name, or say "n of m". Split into its
 # own file rather than growing test_router.py past readability.
+# Updated 2026-07-29 (feat/growth-discovery): the source facet now asserts a
+# ``discovery: 0`` bucket. That is the derived ``PROSPECT_SOURCE_ORDER`` doing
+# its job — a new source can never go missing from the chip row — so adding a
+# source is SUPPOSED to land here rather than pass silently.
 
 from __future__ import annotations
 
@@ -375,7 +379,7 @@ async def test_facets_count_every_tier_status_and_source(w1_client):
         "replied": 2,
         "dead": 0,
     }
-    assert body["source"] == {"clay": 2, "directory": 1, "manual": 2}
+    assert body["source"] == {"clay": 2, "directory": 1, "discovery": 0, "manual": 2}
 
 
 @pytest.mark.asyncio
@@ -384,7 +388,7 @@ async def test_facets_include_zero_counts_for_a_stable_chip_row(w1_client):
     doesn't reshuffle as rows arrive."""
     body = (await w1_client.get(FACETS_URL)).json()
     assert set(body["tier"]) == {"a", "b", "c", "unqualified"}
-    assert set(body["source"]) == {"clay", "directory", "manual"}
+    assert set(body["source"]) == {"clay", "directory", "discovery", "manual"}
     assert sum(body["status"].values()) == 0
 
 
@@ -395,7 +399,7 @@ async def test_tier_counts_respect_an_active_status_filter(w1_client):
     await _seed(w1_client, FACET_ROWS)
     body = (await w1_client.get(FACETS_URL, params={"status": "new"})).json()
     assert body["tier"] == {"a": 1, "b": 1, "c": 1, "unqualified": 0}
-    assert body["source"] == {"clay": 1, "directory": 1, "manual": 1}
+    assert body["source"] == {"clay": 1, "directory": 1, "discovery": 0, "manual": 1}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Until now `/growth` could hold prospects, write to them, and chase them — but
something had to put them in the list first. This is the part that goes
looking.

An **ICP** is a standing description of who a workspace wants to reach, plus a
cadence. `criteria` is free text because the agent reads it, and a filter
builder would be a worse interface for the same job — dropdowns cannot hold
"shops still hand-rolling WordPress sites for local clients".

Discovery is **not a scraper and not a data-vendor integration**. The agent can
already research a company and file it; a hunt is that capability run on a
schedule. Results land through the existing `upsert_by_domain` merge path — no
second write path — stamped `source='discovery'` with the `icp_id` that found
them and the URLs the research actually read.

## The email rule

This is the load-bearing constraint, and it is what separates us from Clay and
Apollo rather than a weaker version of them. They run verification waterfalls
across many providers. An LLM cannot, and a guessed address bounces, burns the
sending domain's reputation, and poisons the list.

So `recordable_emails` is **the** door: one auditable function that turns
evidence into a storable address. Anything guessed, merely claimed, or missing
its source URL is dropped, and the caller gets a prospect with no email — the
honest result. It is enforced in code rather than asked of a prompt, and the
tests drive it with `guessed` and `claimed` evidence to prove nothing survives.

## The research seam

Following `belt/headless.py`: the LLM boundary is an injectable `ResearchFn`,
and the tests drive a deterministic fake, so nothing under test calls a real
model. **The production research loop is not wired in this PR.** With none
wired the sweep logs once and does nothing, which is the correct degraded
state — a hunt with a cadence on and no research behind it should be visibly
idle, never a source of half-researched rows.

## Preview

`POST /growth/icps/{id}/preview` runs the research once and returns what it
*would* file, writing nothing. A cadence is a standing spend commitment, so
nobody should switch one on without seeing real output from their wording
first. The response carries `error` separately from an empty result: a preview
that came back empty because the provider fell over must never look identical
to a hunt that describes nobody.

## Bounds

`max_per_run` per ICP, a per-workspace monthly ceiling, and `cadence: off` as
the default so a new hunt never spends until someone switches it on. The
ceiling counts by `source` rather than by `icp_id`, so splitting work across
five hunts cannot multiply one workspace's allowance by five.

## The clock

Discovery runs at 06:00 UTC, seven hours clear of the follow-up sweep's 13:00.
They must not contend — discovery is the expensive tick and the sweep is the
time-sensitive one, so stacking them would let a slow hunt delay outreach
that's already overdue. And discovery feeds a list a human triages, so landing
it at the start of the working day in Europe and India means the morning's
finds are waiting when someone sits down.

`unique=True` carries more weight here than on the follow-up sweep: that one
only proposes and its open-follow-up guard makes a duplicate tick a no-op,
while discovery **writes** prospects, so a second concurrent tick would
double-file.

Discovery does not draft and does not send. It files at `status='new'` and
nothing in it touches the send gate.

## Tests

340 pass in `tests/cloud/growth/`, up from 294 on the base. Both import-linter
configs clean (1 and 35 contracts). Both crons verified to register with the
expected hours.
