### PR TITLE
chore(loadtest): add a capacity rig for the cloud chat agent path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ output.txt
 !/deploy/paw-sites/.gitkeep
 /deploy/ripple/*
 !/deploy/ripple/.gitkeep
+
+# Load-test artifacts (scripts/loadtest)
+out/

--- a/scripts/loadtest/briefs/site-briefs.txt
+++ b/scripts/loadtest/briefs/site-briefs.txt
@@ -1,0 +1,38 @@
+# Site briefs for the /sites capacity baseline. Created 2026-07-29.
+#
+# One brief per line, cycled by chat_loadtest.py --prompt-file. Lines starting
+# with '#' and blank lines are ignored.
+#
+# PROVENANCE, because it changes how much the numbers are worth: these are
+# hand-authored to span the shapes a /sites request takes, NOT sampled from
+# production traffic. They vary along the three axes that move cost — how much
+# the brief specifies (a one-liner makes the agent invent more), whether it
+# names sections or content, and whether it asks for interaction beyond static
+# copy. If real briefs become available, replace this file; the agent's token
+# spend and turn length depend on brief shape, so a fixture that misses the
+# real distribution will bias every latency number measured with it.
+#
+# Keep the count near 20. Fewer and prompt-cache behaviour looks better than it
+# is, because the same few prefixes repeat.
+
+Build a landing page for a dentist in Austin
+Make me a site for my bakery
+I need a one-page site for a freelance photographer, with a gallery and a contact form
+Portfolio site for a UX designer. Work samples, an about section, and a way to reach me.
+Landing page for a B2B SaaS that does invoice reconciliation. Hero, three feature blocks, pricing, FAQ.
+Create a site for a yoga studio in Lisbon with a class schedule and instructor bios
+Simple coming-soon page with an email signup for a hardware startup
+A restaurant site: menu, hours, location map, and a reservations link
+Build a personal blog homepage with a list of recent posts and an about page
+Marketing site for a mobile app. App store badges, screenshots, and a short feature tour.
+Make a site for my dog grooming business, friendly and warm, with a price list
+Conference landing page with a speaker grid, agenda, and a register button
+Nonprofit site for an animal shelter — mission, how to donate, and adoptable pets
+Documentation-style site for an open source CLI tool with install steps and examples
+Build a real estate agent's site with property listings and a lead capture form
+Law firm site: practice areas, attorney profiles, and a consultation request form
+A wedding photographer's site with a portfolio, packages, and testimonials
+Landing page for an online course about data engineering, with a syllabus and pricing tiers
+Local plumber site that ranks for emergency callouts, with service areas and a phone CTA
+Product page for a physical product — a mechanical keyboard — with specs, photos, and a buy button
+Build a site for a small accounting practice offering bookkeeping and tax prep to freelancers

--- a/scripts/loadtest/chat_loadtest.py
+++ b/scripts/loadtest/chat_loadtest.py
@@ -1,0 +1,755 @@
+"""Stress-test the cloud chat agent path (/sites, /code, or any surface) and
+record end-to-end latency + host saturation metrics side by side.
+
+Created 2026-07-29 — capacity harness for the Claude-Agent-SDK-backed chat
+path. What it does:
+
+  * Drives ``POST /api/v1/cloud/chat/{scope}/{scope_id}/agent`` — the real
+    surface the client uses — in either OPEN loop (fixed arrival rate, the right
+    shape for finding a capacity ceiling) or CLOSED loop (fixed concurrent
+    virtual users, the right shape for measuring steady-state latency).
+  * Consumes each run's SSE stream and times the frames that matter:
+    accept (POST headers), ``message.persisted``, first ``text`` token,
+    first ``tool_start``, and the terminal frame
+    (``stream_end`` / ``error`` / ``interrupted``).
+  * Samples the HOST in parallel on a fixed interval — Claude Code CLI
+    subprocess count and RSS, web-process RSS/CPU, node/bun build processes
+    (site publish), system CPU/mem, agent-jail disk, arq queue depth (Redis),
+    and ChatRunDoc status counts (Mongo) — so a latency cliff can be attributed
+    to a specific resource rather than guessed at.
+  * Writes ``requests.jsonl`` + ``samples.csv`` and prints a percentile summary
+    with an error breakdown and a saturation verdict.
+
+Run it against a deploy you are allowed to saturate. It costs real tokens.
+
+Usage:
+    uv run python scripts/loadtest/chat_loadtest.py \
+        --base-url https://api.example.com \
+        --token "$PAW_TOKEN" --workspace "$PAW_WORKSPACE" \
+        --scope pocket --scope-id 68f... --surface sites \
+        --prompt "Build a landing page for a dentist in Austin" \
+        --mode open --rate 0.5 --duration 300 \
+        --out out/sites-open-0.5rps
+
+Optional host sampling (run ON the app box, or point at its Redis/Mongo):
+    --redis-url redis://localhost:6379/0 --mongo-url mongodb://localhost:27017 \
+    --mongo-db pocketpaw --jail-root ~/.pocketpaw/workspaces
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import contextlib
+import csv
+import json
+import os
+import random
+import shutil
+import statistics
+import sys
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+try:  # host sampling is optional — the driver still works without it
+    import psutil
+except ImportError:  # pragma: no cover - optional dep
+    psutil = None  # type: ignore[assignment]
+
+
+# --------------------------------------------------------------------------
+# per-request record
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class RequestRecord:
+    """One agent run, from POST to terminal frame. All times in ms."""
+
+    seq: int
+    started_at: float
+    accept_ms: float | None = None
+    persisted_ms: float | None = None
+    ttft_ms: float | None = None
+    first_tool_ms: float | None = None
+    total_ms: float | None = None
+    http_status: int | None = None
+    run_id: str | None = None
+    outcome: str = "pending"
+    error_code: str | None = None
+    error_message: str | None = None
+    frames: dict[str, int] = field(default_factory=dict)
+    text_chars: int = 0
+    usage: dict[str, Any] = field(default_factory=dict)
+
+
+# --------------------------------------------------------------------------
+# SSE parsing
+# --------------------------------------------------------------------------
+
+
+async def _iter_sse(response: httpx.Response):
+    """Yield ``(event, data)`` pairs from a text/event-stream response."""
+    event: str | None = None
+    async for raw in response.aiter_lines():
+        line = raw.rstrip("\r")
+        if not line:
+            event = None
+            continue
+        if line.startswith(":"):  # heartbeat
+            continue
+        if line.startswith("event:"):
+            event = line[6:].strip()
+        elif line.startswith("data:"):
+            payload = line[5:].strip()
+            if event is None:
+                continue
+            try:
+                data = json.loads(payload) if payload else {}
+            except json.JSONDecodeError:
+                data = {"_raw": payload}
+            yield event, data
+
+
+TERMINAL = {"stream_end", "error", "interrupted"}
+
+
+async def drive_one(
+    client: httpx.AsyncClient,
+    *,
+    seq: int,
+    url: str,
+    body: dict[str, Any],
+    timeout: float,
+    inflight: dict[str, int],
+) -> RequestRecord:
+    """Fire one agent run and time every frame that matters.
+
+    ``timeout`` is a WALL-CLOCK deadline, enforced with ``asyncio.timeout``.
+    It cannot be an httpx timeout: the SSE stream sends ``: ping`` heartbeats,
+    and an httpx read timeout resets on every byte — so a run that hangs
+    forever would keep the connection alive and never trip it.
+    """
+    rec = RequestRecord(seq=seq, started_at=time.time())
+    t0 = time.perf_counter()
+    inflight["n"] += 1
+    try:
+        async with asyncio.timeout(timeout), client.stream("POST", url, json=body) as resp:
+            rec.accept_ms = (time.perf_counter() - t0) * 1000
+            rec.http_status = resp.status_code
+            if resp.status_code != 200:
+                await resp.aread()
+                rec.outcome = f"http_{resp.status_code}"
+                rec.error_message = resp.text[:500]
+                rec.total_ms = (time.perf_counter() - t0) * 1000
+                return rec
+
+            async for event, data in _iter_sse(resp):
+                rec.frames[event] = rec.frames.get(event, 0) + 1
+                now = (time.perf_counter() - t0) * 1000
+
+                if event == "message.persisted":
+                    rec.persisted_ms = now
+                    rec.run_id = data.get("run_id")
+                elif event in ("chunk", "text"):
+                    # The cloud run emits assistant text as ``chunk``; ``text``
+                    # is accepted too so this keeps working if that is renamed.
+                    if rec.ttft_ms is None:
+                        rec.ttft_ms = now
+                    rec.text_chars += len(str(data.get("content") or data.get("text") or ""))
+                elif event == "tool_start" and rec.first_tool_ms is None:
+                    rec.first_tool_ms = now
+
+                if event in TERMINAL:
+                    rec.total_ms = now
+                    if event == "stream_end":
+                        rec.outcome = "completed"
+                        rec.usage = data.get("usage") or {}
+                    elif event == "interrupted":
+                        rec.outcome = "interrupted"
+                        rec.error_code = data.get("reason")
+                    else:
+                        rec.outcome = "error"
+                        rec.error_code = data.get("code") or data.get("error")
+                        rec.error_message = str(data.get("message") or "")[:500]
+                    return rec
+
+            # stream closed with no terminal frame
+            rec.total_ms = (time.perf_counter() - t0) * 1000
+            rec.outcome = "truncated"
+            return rec
+    except (TimeoutError, httpx.TimeoutException):
+        rec.total_ms = (time.perf_counter() - t0) * 1000
+        rec.outcome = "timeout"
+        return rec
+    except Exception as exc:  # noqa: BLE001 - a load driver must never die
+        rec.total_ms = (time.perf_counter() - t0) * 1000
+        rec.outcome = "conn_error"
+        rec.error_message = f"{type(exc).__name__}: {exc}"[:500]
+        return rec
+    finally:
+        inflight["n"] -= 1
+
+
+# --------------------------------------------------------------------------
+# host sampler
+# --------------------------------------------------------------------------
+
+_CLI_HINTS = ("claude", "claude-code")
+_BUILD_HINTS = ("vite", "svelte-kit", "rollup", "esbuild", "wrangler")
+
+
+class HostSampler:
+    """Samples process / system / queue metrics on a fixed interval."""
+
+    def __init__(
+        self,
+        *,
+        interval: float,
+        jail_root: str | None,
+        redis_url: str | None,
+        mongo_url: str | None,
+        mongo_db: str,
+        inflight: dict[str, int],
+    ) -> None:
+        self.interval = interval
+        self.jail_root = os.path.expanduser(jail_root) if jail_root else None
+        self.redis_url = redis_url
+        self.mongo_url = mongo_url
+        self.mongo_db = mongo_db
+        self.inflight = inflight
+        self.rows: list[dict[str, Any]] = []
+        self._redis = None
+        self._mongo = None
+
+    async def _connect(self) -> None:
+        if self.redis_url:
+            try:
+                import redis.asyncio as aioredis
+
+                self._redis = aioredis.from_url(self.redis_url, decode_responses=True)
+                await self._redis.ping()
+            except Exception as exc:  # noqa: BLE001
+                print(f"[sampler] redis disabled: {exc}", file=sys.stderr)
+                self._redis = None
+        if self.mongo_url:
+            try:
+                from motor.motor_asyncio import AsyncIOMotorClient
+
+                self._mongo = AsyncIOMotorClient(self.mongo_url)[self.mongo_db]
+                await self._mongo.command("ping")
+            except Exception as exc:  # noqa: BLE001
+                print(f"[sampler] mongo disabled: {exc}", file=sys.stderr)
+                self._mongo = None
+
+    def _process_metrics(self) -> dict[str, Any]:
+        """Count Claude CLI subprocesses, python web procs, and node build procs."""
+        out = {
+            "cli_procs": 0,
+            "cli_rss_mb": 0.0,
+            "web_procs": 0,
+            "web_rss_mb": 0.0,
+            "build_procs": 0,
+            "total_procs": 0,
+        }
+        if psutil is None:
+            return out
+        for proc in psutil.process_iter(["name", "cmdline", "memory_info"]):
+            try:
+                info = proc.info
+                name = (info.get("name") or "").lower()
+                cmdline = " ".join(info.get("cmdline") or []).lower()
+                mem = info.get("memory_info")
+                rss_mb = (mem.rss / 1_048_576) if mem else 0.0
+                out["total_procs"] += 1
+
+                # Claude Code CLI: a node process whose argv names the CLI.
+                if any(h in cmdline for h in _CLI_HINTS) and ("node" in name or "claude" in name):
+                    out["cli_procs"] += 1
+                    out["cli_rss_mb"] += rss_mb
+                # Site build subprocesses (svelte publish path).
+                elif any(h in cmdline for h in _BUILD_HINTS):
+                    out["build_procs"] += 1
+                # Backend web/worker processes.
+                elif "python" in name and (
+                    "pocketpaw" in cmdline or "uvicorn" in cmdline or "arq" in cmdline
+                ):
+                    out["web_procs"] += 1
+                    out["web_rss_mb"] += rss_mb
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                continue
+        out["cli_rss_mb"] = round(out["cli_rss_mb"], 1)
+        out["web_rss_mb"] = round(out["web_rss_mb"], 1)
+        return out
+
+    async def _queue_metrics(self) -> dict[str, Any]:
+        out: dict[str, Any] = {"arq_queued": None, "runs_queued": None, "runs_running": None}
+        if self._redis is not None:
+            try:
+                out["arq_queued"] = await self._redis.zcard("arq:queue")
+            except Exception:  # noqa: BLE001
+                out["arq_queued"] = None
+        if self._mongo is not None:
+            try:
+                col = self._mongo["chat_runs"]
+                out["runs_queued"] = await col.count_documents({"status": "queued"})
+                out["runs_running"] = await col.count_documents({"status": "running"})
+            except Exception:  # noqa: BLE001
+                pass
+        return out
+
+    async def run(self, stop: asyncio.Event) -> None:
+        await self._connect()
+        if psutil is not None:
+            psutil.cpu_percent(interval=None)  # prime the counter
+        while not stop.is_set():
+            row: dict[str, Any] = {
+                "ts": round(time.time(), 3),
+                "inflight": self.inflight["n"],
+            }
+            if psutil is not None:
+                row["sys_cpu_pct"] = psutil.cpu_percent(interval=None)
+                row["sys_mem_pct"] = psutil.virtual_memory().percent
+            row.update(self._process_metrics())
+            if self.jail_root and os.path.isdir(self.jail_root):
+                try:
+                    usage = shutil.disk_usage(self.jail_root)
+                    row["jail_disk_free_gb"] = round(usage.free / 1_073_741_824, 2)
+                    row["jail_disk_used_pct"] = round(100 * usage.used / usage.total, 1)
+                except OSError:
+                    pass
+            row.update(await self._queue_metrics())
+            self.rows.append(row)
+            with contextlib.suppress(TimeoutError):
+                await asyncio.wait_for(stop.wait(), timeout=self.interval)
+
+    def write_csv(self, path: Path) -> None:
+        if not self.rows:
+            return
+        cols: list[str] = []
+        for row in self.rows:
+            for key in row:
+                if key not in cols:
+                    cols.append(key)
+        with path.open("w", newline="", encoding="utf-8") as handle:
+            writer = csv.DictWriter(handle, fieldnames=cols)
+            writer.writeheader()
+            writer.writerows(self.rows)
+
+
+# --------------------------------------------------------------------------
+# load shapes
+# --------------------------------------------------------------------------
+
+
+async def run_open_loop(
+    client: httpx.AsyncClient,
+    *,
+    urls: list[str],
+    make_body,
+    rate: float,
+    duration: float,
+    timeout: float,
+    inflight: dict[str, int],
+    jitter: bool,
+) -> list[RequestRecord]:
+    """Fire requests at a fixed arrival rate regardless of completion.
+
+    This is the shape that finds a ceiling: if the system can't keep up,
+    in-flight count and latency climb without bound instead of the driver
+    silently throttling itself.
+    """
+    tasks: list[asyncio.Task] = []
+    seq = 0
+    deadline = time.perf_counter() + duration
+    while time.perf_counter() < deadline:
+        seq += 1
+        tasks.append(
+            asyncio.create_task(
+                drive_one(
+                    client,
+                    seq=seq,
+                    url=urls[(seq - 1) % len(urls)],
+                    body=make_body(seq),
+                    timeout=timeout,
+                    inflight=inflight,
+                )
+            )
+        )
+        gap = 1.0 / rate
+        if jitter:  # Poisson arrivals — bursty like real traffic
+            gap = random.expovariate(rate)
+        await asyncio.sleep(gap)
+    print(f"[driver] arrivals done ({seq} sent), draining {len(tasks)} in-flight…")
+    return list(await asyncio.gather(*tasks))
+
+
+async def run_closed_loop(
+    client: httpx.AsyncClient,
+    *,
+    urls: list[str],
+    make_body,
+    vus: int,
+    iterations: int,
+    timeout: float,
+    inflight: dict[str, int],
+) -> list[RequestRecord]:
+    """N virtual users, each looping sequentially. Measures steady-state
+    latency at a known concurrency."""
+    records: list[RequestRecord] = []
+    counter = {"n": 0}
+    lock = asyncio.Lock()
+
+    async def worker(vu: int) -> None:
+        # One scope per VU — a second run in the same scope supersedes the first.
+        vu_url = urls[vu % len(urls)]
+        for _ in range(iterations):
+            async with lock:
+                counter["n"] += 1
+                seq = counter["n"]
+            rec = await drive_one(
+                client, seq=seq, url=vu_url, body=make_body(seq), timeout=timeout, inflight=inflight
+            )
+            records.append(rec)
+
+    await asyncio.gather(*[worker(i) for i in range(vus)])
+    return records
+
+
+# --------------------------------------------------------------------------
+# reporting
+# --------------------------------------------------------------------------
+
+
+def _pct(values: list[float], p: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    idx = min(len(ordered) - 1, int(round((p / 100) * (len(ordered) - 1))))
+    return round(ordered[idx], 1)
+
+
+def _latency_row(label: str, values: list[float]) -> str:
+    if not values:
+        return f"  {label:<16} —"
+    return (
+        f"  {label:<16} n={len(values):<5} "
+        f"p50={_pct(values, 50):<9} p90={_pct(values, 90):<9} "
+        f"p95={_pct(values, 95):<9} p99={_pct(values, 99):<9} "
+        f"max={round(max(values), 1)}"
+    )
+
+
+def summarize(records: list[RequestRecord], sampler: HostSampler, wall_s: float) -> str:
+    lines: list[str] = []
+    total = len(records)
+    completed = [r for r in records if r.outcome == "completed"]
+    lines.append("")
+    lines.append("=" * 78)
+    lines.append("RESULTS")
+    lines.append("=" * 78)
+    lines.append(f"  requests sent      {total}")
+    pct_ok = 100 * len(completed) / max(total, 1)
+    lines.append(f"  completed          {len(completed)} ({pct_ok:.1f}%)")
+    lines.append(f"  wall clock         {wall_s:.1f}s")
+    if completed:
+        lines.append(f"  throughput         {60 * len(completed) / wall_s:.2f} completed runs/min")
+
+    lines.append("")
+    lines.append("LATENCY (ms)")
+    lines.append(_latency_row("accept", [r.accept_ms for r in records if r.accept_ms is not None]))
+    lines.append(
+        _latency_row("persisted", [r.persisted_ms for r in records if r.persisted_ms is not None])
+    )
+    lines.append(_latency_row("first token", [r.ttft_ms for r in records if r.ttft_ms is not None]))
+    lines.append(
+        _latency_row(
+            "first tool", [r.first_tool_ms for r in records if r.first_tool_ms is not None]
+        )
+    )
+    lines.append(_latency_row("total (ok)", [r.total_ms for r in completed if r.total_ms]))
+
+    outcomes: dict[str, int] = {}
+    for rec in records:
+        key = rec.outcome
+        if rec.error_code:
+            key = f"{rec.outcome}:{rec.error_code}"
+        outcomes[key] = outcomes.get(key, 0) + 1
+    lines.append("")
+    lines.append("OUTCOMES")
+    for key, count in sorted(outcomes.items(), key=lambda kv: -kv[1]):
+        lines.append(f"  {key:<40} {count}")
+
+    msgs = [r.error_message for r in records if r.error_message]
+    if msgs:
+        lines.append("")
+        lines.append("SAMPLE ERRORS (first 3 distinct)")
+        for msg in list(dict.fromkeys(msgs))[:3]:
+            lines.append(f"  {msg}")
+
+    tokens_in = sum(int(r.usage.get("input_tokens") or 0) for r in completed)
+    tokens_out = sum(int(r.usage.get("output_tokens") or 0) for r in completed)
+    if tokens_in or tokens_out:
+        lines.append("")
+        lines.append("TOKENS")
+        lines.append(f"  input   {tokens_in:,}   ({tokens_in * 60 / max(wall_s, 1):,.0f}/min)")
+        lines.append(f"  output  {tokens_out:,}   ({tokens_out * 60 / max(wall_s, 1):,.0f}/min)")
+        lines.append("  ^ compare against your org's ITPM / OTPM limit for the model in use")
+
+    if sampler.rows:
+        lines.append("")
+        lines.append("HOST PEAKS")
+
+        def peak(col: str) -> Any:
+            vals = [r[col] for r in sampler.rows if r.get(col) is not None]
+            return max(vals) if vals else None
+
+        def mean(col: str) -> Any:
+            vals = [r[col] for r in sampler.rows if r.get(col) is not None]
+            return round(statistics.fmean(vals), 1) if vals else None
+
+        for col, label in (
+            ("inflight", "in-flight runs"),
+            ("cli_procs", "claude CLI procs"),
+            ("cli_rss_mb", "claude CLI RSS (MB)"),
+            ("build_procs", "site-build procs"),
+            ("web_rss_mb", "web/worker RSS (MB)"),
+            ("sys_cpu_pct", "system CPU %"),
+            ("sys_mem_pct", "system mem %"),
+            ("arq_queued", "arq queue depth"),
+            ("runs_queued", "mongo runs queued"),
+            ("runs_running", "mongo runs running"),
+            ("jail_disk_free_gb", "jail disk free (GB)"),
+        ):
+            pk = peak(col)
+            if pk is None:
+                continue
+            lines.append(f"  {label:<24} peak={pk:<10} mean={mean(col)}")
+        lines.append(
+            "  (process counts are for THIS host — run the driver on the app box, or "
+            "sample it separately, or these numbers describe your laptop)"
+        )
+
+    lines.append("")
+    lines.append("SATURATION VERDICT")
+    for line in _verdict(records, sampler):
+        lines.append(f"  {line}")
+    lines.append("=" * 78)
+    return "\n".join(lines)
+
+
+def _verdict(records: list[RequestRecord], sampler: HostSampler) -> list[str]:
+    """Point at the resource that gave out first, instead of leaving it to guesswork."""
+    out: list[str] = []
+    rows = sampler.rows
+
+    def peak(col: str) -> float:
+        vals = [r[col] for r in rows if isinstance(r.get(col), int | float)]
+        return max(vals) if vals else 0.0
+
+    if any(r.outcome.startswith("http_429") for r in records):
+        out.append("HTTP 429 seen — an ingress/app rate limit fired before capacity did.")
+    if any(r.outcome == "http_402" for r in records):
+        out.append("HTTP 402 — credits/quota gate rejected runs; top up before re-testing.")
+    if any(r.error_code == "agent.jail_over_quota" for r in records):
+        out.append(
+            "agent.jail_over_quota — per-workspace jail hit POCKETPAW_AGENT_JAIL_QUOTA_MB "
+            "(default 2048MB). Raise it or shorten the scenario."
+        )
+    if any(r.error_code == "agent.backend_error" for r in records):
+        out.append(
+            "agent.backend_error — check the backend log for Anthropic 429/529: that is the "
+            "API-side rate limit, not your box."
+        )
+    if any(r.outcome == "timeout" for r in records):
+        out.append("Client timeouts — raise --timeout or the run genuinely stalled.")
+
+    if peak("arq_queued") > 0:
+        out.append(
+            f"arq queue depth peaked at {peak('arq_queued'):.0f} — the worker is the bottleneck. "
+            "WorkerSettings sets no max_jobs, so arq's default of 10 concurrent runs/worker "
+            "applies. Scale workers or set max_jobs."
+        )
+    if peak("sys_cpu_pct") > 85:
+        out.append(f"System CPU peaked at {peak('sys_cpu_pct'):.0f}% — CPU-bound.")
+    if peak("sys_mem_pct") > 85:
+        out.append(
+            f"System memory peaked at {peak('sys_mem_pct'):.0f}% — each concurrent run holds a "
+            "Claude Code CLI (Node) subprocess; memory is usually the first wall."
+        )
+    cli_peak = peak("cli_procs")
+    if cli_peak:
+        out.append(f"Peak concurrent Claude CLI subprocesses: {cli_peak:.0f}.")
+    if not out:
+        out.append("No saturation signal — the system absorbed this load. Raise --rate and re-run.")
+    return out
+
+
+# --------------------------------------------------------------------------
+# entry point
+# --------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument("--base-url", required=True, help="e.g. http://localhost:8000")
+    p.add_argument("--token", default=os.environ.get("PAW_TOKEN", ""), help="Bearer token")
+    p.add_argument("--workspace", default=os.environ.get("PAW_WORKSPACE", ""), help="workspace id")
+    p.add_argument("--scope", default="pocket", choices=["pocket", "group", "dm"])
+    p.add_argument("--scope-id", required=True)
+    p.add_argument("--surface", default=None, help="sites | code | home | pockets | …")
+    p.add_argument("--surface-meta", default=None, help='JSON dict, e.g. \'{"pocket_id":"…"}\'')
+    p.add_argument("--agent-id", default=None)
+    p.add_argument("--prompt", default=None, help="prompt text (use {n} for the request number)")
+    p.add_argument("--prompt-file", default=None, help="file with one prompt per line, cycled")
+    p.add_argument("--api-prefix", default="/api/v1")
+
+    p.add_argument("--mode", default="open", choices=["open", "closed"])
+    p.add_argument("--rate", type=float, default=0.5, help="open mode: arrivals/sec")
+    p.add_argument("--duration", type=float, default=120, help="open mode: seconds of arrivals")
+    p.add_argument("--jitter", action="store_true", help="open mode: Poisson arrivals")
+    p.add_argument("--vus", type=int, default=5, help="closed mode: concurrent virtual users")
+    p.add_argument("--iterations", type=int, default=3, help="closed mode: runs per VU")
+    p.add_argument("--timeout", type=float, default=900, help="per-request timeout (s)")
+
+    p.add_argument("--sample-interval", type=float, default=2.0)
+    p.add_argument("--jail-root", default=None, help="e.g. ~/.pocketpaw/workspaces")
+    p.add_argument("--redis-url", default=os.environ.get("POCKETPAW_REDIS_URL"))
+    p.add_argument("--mongo-url", default=None)
+    p.add_argument("--mongo-db", default="pocketpaw")
+    p.add_argument("--out", default=None, help="output dir (default: out/<timestamp>)")
+    return p
+
+
+async def main_async(args: argparse.Namespace) -> int:
+    prompts: list[str]
+    if args.prompt_file:
+        raw = Path(args.prompt_file).read_text("utf-8").splitlines()
+        prompts = [ln.strip() for ln in raw if ln.strip()]
+    elif args.prompt:
+        prompts = [args.prompt]
+    else:
+        print("error: pass --prompt or --prompt-file", file=sys.stderr)
+        return 2
+
+    surface_meta = json.loads(args.surface_meta) if args.surface_meta else None
+    root = f"{args.base_url.rstrip('/')}{args.api_prefix}"
+    # --scope-id accepts a comma-separated list. A new run supersedes the
+    # previous run in the SAME scope, so driving every request at one scope
+    # measures one user typing fast, not N users. Round-robin across scopes.
+    scope_ids = [s.strip() for s in args.scope_id.split(",") if s.strip()]
+    urls = [f"{root}/cloud/chat/{args.scope}/{sid}/agent" for sid in scope_ids]
+    url = urls[0]
+    if len(urls) > 1:
+        print(f"[driver] round-robin across {len(urls)} scopes")
+
+    def make_body(seq: int) -> dict[str, Any]:
+        text = prompts[(seq - 1) % len(prompts)].replace("{n}", str(seq))
+        body: dict[str, Any] = {
+            "content": text,
+            # unique per send so create_run's idempotency key never collapses
+            # two load-test runs into one
+            "client_message_id": f"loadtest-{int(time.time())}-{seq}",
+        }
+        if args.surface:
+            body["surface"] = args.surface
+        if surface_meta:
+            body["surface_meta"] = surface_meta
+        if args.agent_id:
+            body["agent_id"] = args.agent_id
+        return body
+
+    headers = {"Accept": "text/event-stream"}
+    if args.token:
+        headers["Authorization"] = f"Bearer {args.token}"
+    if args.workspace:
+        headers["X-Workspace-Id"] = args.workspace
+
+    out_dir = Path(args.out or f"out/{datetime.now(UTC).strftime('%Y%m%d-%H%M%S')}")
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    inflight = {"n": 0}
+    sampler = HostSampler(
+        interval=args.sample_interval,
+        jail_root=args.jail_root,
+        redis_url=args.redis_url,
+        mongo_url=args.mongo_url,
+        mongo_db=args.mongo_db,
+        inflight=inflight,
+    )
+    stop = asyncio.Event()
+    sampler_task = asyncio.create_task(sampler.run(stop))
+
+    shape = (
+        f"open loop @ {args.rate}/s for {args.duration}s"
+        if args.mode == "open"
+        else f"closed loop, {args.vus} VUs x {args.iterations}"
+    )
+    print(f"[driver] {shape}")
+    print(f"[driver] POST {url}")
+    print(f"[driver] surface={args.surface or '(none)'}  out={out_dir}")
+    if psutil is None:
+        print("[driver] psutil not installed — host process metrics disabled", file=sys.stderr)
+
+    limits = httpx.Limits(max_connections=1000, max_keepalive_connections=200)
+    started = time.perf_counter()
+    async with httpx.AsyncClient(headers=headers, limits=limits, timeout=None) as client:
+        if args.mode == "open":
+            records = await run_open_loop(
+                client,
+                urls=urls,
+                make_body=make_body,
+                rate=args.rate,
+                duration=args.duration,
+                timeout=args.timeout,
+                inflight=inflight,
+                jitter=args.jitter,
+            )
+        else:
+            records = await run_closed_loop(
+                client,
+                urls=urls,
+                make_body=make_body,
+                vus=args.vus,
+                iterations=args.iterations,
+                timeout=args.timeout,
+                inflight=inflight,
+            )
+    wall = time.perf_counter() - started
+
+    stop.set()
+    with contextlib.suppress(asyncio.CancelledError):
+        await sampler_task
+
+    with (out_dir / "requests.jsonl").open("w", encoding="utf-8") as handle:
+        for rec in sorted(records, key=lambda r: r.seq):
+            handle.write(json.dumps(asdict(rec)) + "\n")
+    sampler.write_csv(out_dir / "samples.csv")
+
+    report = summarize(records, sampler, wall)
+    print(report)
+    (out_dir / "summary.txt").write_text(report, encoding="utf-8")
+    print(f"\n[driver] wrote {out_dir}/requests.jsonl, samples.csv, summary.txt")
+
+    failed = sum(1 for r in records if r.outcome != "completed")
+    return 1 if failed and failed == len(records) else 0
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    try:
+        return asyncio.run(main_async(args))
+    except KeyboardInterrupt:
+        print("\n[driver] interrupted", file=sys.stderr)
+        return 130
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/loadtest/chat_loadtest.py
+++ b/scripts/loadtest/chat_loadtest.py
@@ -20,6 +20,13 @@ path. What it does:
   * Writes ``requests.jsonl`` + ``samples.csv`` and prints a percentile summary
     with an error breakdown and a saturation verdict.
 
+Updated 2026-07-29 (same day) for the in-process-backend baseline: polls the
+server's ``/__loadtest/metrics`` probe for event-loop lag and server RSS when
+one is exposed (``serve_sim.py`` installs it), counts completions that carried
+no assistant text, and reports prompt-cache read share. Those are the metrics
+that decide whether an in-process agent backend can replace a subprocess one,
+and none of them are visible from response timings alone.
+
 Run it against a deploy you are allowed to saturate. It costs real tokens.
 
 Usage:
@@ -55,6 +62,12 @@ from pathlib import Path
 from typing import Any
 
 import httpx
+
+# A Windows console defaults to a codepage that mangles the summary's em dashes
+# and arrows. The report is the product here, so make it render.
+for _stream in (sys.stdout, sys.stderr):
+    with contextlib.suppress(AttributeError, ValueError):
+        _stream.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr]
 
 try:  # host sampling is optional — the driver still works without it
     import psutil
@@ -216,6 +229,7 @@ class HostSampler:
         mongo_url: str | None,
         mongo_db: str,
         inflight: dict[str, int],
+        server_metrics_url: str | None = None,
     ) -> None:
         self.interval = interval
         self.jail_root = os.path.expanduser(jail_root) if jail_root else None
@@ -223,9 +237,11 @@ class HostSampler:
         self.mongo_url = mongo_url
         self.mongo_db = mongo_db
         self.inflight = inflight
+        self.server_metrics_url = server_metrics_url
         self.rows: list[dict[str, Any]] = []
         self._redis = None
         self._mongo = None
+        self._probe: httpx.AsyncClient | None = None
 
     async def _connect(self) -> None:
         if self.redis_url:
@@ -246,6 +262,36 @@ class HostSampler:
             except Exception as exc:  # noqa: BLE001
                 print(f"[sampler] mongo disabled: {exc}", file=sys.stderr)
                 self._mongo = None
+        if self.server_metrics_url:
+            self._probe = httpx.AsyncClient(timeout=2.0)
+            try:
+                r = await self._probe.get(self.server_metrics_url)
+                r.raise_for_status()
+            except Exception:  # noqa: BLE001
+                # Not every target exposes the probe — a plain deploy has no
+                # such route. Say so once, then stop asking.
+                print(
+                    f"[sampler] no server probe at {self.server_metrics_url} — "
+                    "event-loop lag will be blank (serve_sim.py installs one)",
+                    file=sys.stderr,
+                )
+                await self._probe.aclose()
+                self._probe = None
+
+    async def _server_metrics(self) -> dict[str, Any]:
+        """Pull loop lag + RSS measured inside the server process.
+
+        Reading drains the server's sample buffer, so each row covers the
+        window since the previous sample rather than the whole run.
+        """
+        if self._probe is None or not self.server_metrics_url:
+            return {}
+        try:
+            r = await self._probe.get(self.server_metrics_url)
+            payload = r.json()
+        except Exception:  # noqa: BLE001
+            return {}
+        return {k: v for k, v in payload.items() if v is not None}
 
     def _process_metrics(self) -> dict[str, Any]:
         """Count Claude CLI subprocesses, python web procs, and node build procs."""
@@ -324,9 +370,12 @@ class HostSampler:
                 except OSError:
                     pass
             row.update(await self._queue_metrics())
+            row.update(await self._server_metrics())
             self.rows.append(row)
             with contextlib.suppress(TimeoutError):
                 await asyncio.wait_for(stop.wait(), timeout=self.interval)
+        if self._probe is not None:
+            await self._probe.aclose()
 
     def write_csv(self, path: Path) -> None:
         if not self.rows:
@@ -456,6 +505,14 @@ def summarize(records: list[RequestRecord], sampler: HostSampler, wall_s: float)
     lines.append(f"  requests sent      {total}")
     pct_ok = 100 * len(completed) / max(total, 1)
     lines.append(f"  completed          {len(completed)} ({pct_ok:.1f}%)")
+    # A run can terminate cleanly and still have said nothing. That is what
+    # concurrent truncation looks like from the outside, so it is counted
+    # separately rather than folded into the success rate.
+    empty = [r for r in completed if r.text_chars == 0]
+    lines.append(
+        f"  empty completions  {len(empty)}"
+        + ("   <-- clean stream_end carrying no assistant text" if empty else "")
+    )
     lines.append(f"  wall clock         {wall_s:.1f}s")
     if completed:
         lines.append(f"  throughput         {60 * len(completed) / wall_s:.2f} completed runs/min")
@@ -494,11 +551,24 @@ def summarize(records: list[RequestRecord], sampler: HostSampler, wall_s: float)
 
     tokens_in = sum(int(r.usage.get("input_tokens") or 0) for r in completed)
     tokens_out = sum(int(r.usage.get("output_tokens") or 0) for r in completed)
+    cache_read = sum(int(r.usage.get("cache_read_input_tokens") or 0) for r in completed)
+    cache_write = sum(int(r.usage.get("cache_creation_input_tokens") or 0) for r in completed)
     if tokens_in or tokens_out:
         lines.append("")
         lines.append("TOKENS")
         lines.append(f"  input   {tokens_in:,}   ({tokens_in * 60 / max(wall_s, 1):,.0f}/min)")
         lines.append(f"  output  {tokens_out:,}   ({tokens_out * 60 / max(wall_s, 1):,.0f}/min)")
+        if cache_read or cache_write:
+            billable = tokens_in + cache_read + cache_write
+            share = 100 * cache_read / max(billable, 1)
+            lines.append(f"  cache read   {cache_read:,}")
+            lines.append(f"  cache write  {cache_write:,}")
+            lines.append(f"  cache read share  {share:.1f}% of input-side tokens")
+        else:
+            lines.append(
+                "  cache read/write  not reported — either the backend does not "
+                "surface it in stream_end usage, or caching is not engaging"
+            )
         lines.append("  ^ compare against your org's ITPM / OTPM limit for the model in use")
 
     if sampler.rows:
@@ -525,6 +595,9 @@ def summarize(records: list[RequestRecord], sampler: HostSampler, wall_s: float)
             ("runs_queued", "mongo runs queued"),
             ("runs_running", "mongo runs running"),
             ("jail_disk_free_gb", "jail disk free (GB)"),
+            ("srv_rss_mb", "server RSS (MB)"),
+            ("loop_lag_p95_ms", "event-loop lag p95 (ms)"),
+            ("loop_lag_max_ms", "event-loop lag max (ms)"),
         ):
             pk = peak(col)
             if pk is None:
@@ -534,6 +607,24 @@ def summarize(records: list[RequestRecord], sampler: HostSampler, wall_s: float)
             "  (process counts are for THIS host — run the driver on the app box, or "
             "sample it separately, or these numbers describe your laptop)"
         )
+
+        # Per-run memory cost, which is the number that decides how many boxes
+        # the agent tier needs. Derived, not measured directly: the server's
+        # RSS growth over its idle baseline, divided by peak concurrency. It
+        # assumes the growth is the runs, so treat it as an estimate and read
+        # it next to the raw RSS peak above.
+        rss_rows = [r["srv_rss_mb"] for r in sampler.rows if r.get("srv_rss_mb") is not None]
+        peak_inflight = peak("inflight") or 0
+        if len(rss_rows) >= 2 and peak_inflight:
+            growth = max(rss_rows) - min(rss_rows)
+            lines.append("")
+            lines.append("AGENT TIER")
+            lines.append(f"  peak concurrent runs      {peak_inflight:.0f}")
+            lines.append(f"  server RSS baseline/peak  {min(rss_rows)} / {max(rss_rows)} MB")
+            lines.append(
+                f"  approx RSS per run        {growth / peak_inflight:.2f} MB "
+                f"({growth:.1f} MB growth ÷ {peak_inflight:.0f} peak runs)"
+            )
 
     lines.append("")
     lines.append("SATURATION VERDICT")
@@ -582,6 +673,24 @@ def _verdict(records: list[RequestRecord], sampler: HostSampler) -> list[str]:
             f"System memory peaked at {peak('sys_mem_pct'):.0f}% — each concurrent run holds a "
             "Claude Code CLI (Node) subprocess; memory is usually the first wall."
         )
+    empty = sum(1 for r in records if r.outcome == "completed" and r.text_chars == 0)
+    if empty:
+        out.append(
+            f"{empty} run(s) ended with a clean stream_end and no assistant text. That is "
+            "not a capacity signal — it is concurrent truncation. Check that the backend "
+            "keeps cancellation state per run (AgentPool shares ONE instance per agent), "
+            "and that there are at least as many pockets as concurrent VUs."
+        )
+
+    lag95 = peak("loop_lag_p95_ms")
+    if lag95 > 250:
+        out.append(
+            f"Event-loop lag p95 peaked at {lag95:.0f}ms inside the server process. The loop "
+            "is the constraint, not the box — add web processes rather than RAM."
+        )
+    elif lag95:
+        out.append(f"Event-loop lag p95 peaked at {lag95:.0f}ms — the loop kept up.")
+
     cli_peak = peak("cli_procs")
     if cli_peak:
         out.append(f"Peak concurrent Claude CLI subprocesses: {cli_peak:.0f}.")
@@ -620,6 +729,11 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--timeout", type=float, default=900, help="per-request timeout (s)")
 
     p.add_argument("--sample-interval", type=float, default=2.0)
+    p.add_argument(
+        "--no-server-probe",
+        action="store_true",
+        help="skip GET {base-url}/__loadtest/metrics (event-loop lag + server RSS)",
+    )
     p.add_argument("--jail-root", default=None, help="e.g. ~/.pocketpaw/workspaces")
     p.add_argument("--redis-url", default=os.environ.get("POCKETPAW_REDIS_URL"))
     p.add_argument("--mongo-url", default=None)
@@ -632,7 +746,11 @@ async def main_async(args: argparse.Namespace) -> int:
     prompts: list[str]
     if args.prompt_file:
         raw = Path(args.prompt_file).read_text("utf-8").splitlines()
-        prompts = [ln.strip() for ln in raw if ln.strip()]
+        # Blank lines and '#' comments are dropped so a fixture can carry its
+        # own provenance note at the top instead of needing a sidecar file.
+        prompts = [ln.strip() for ln in raw if ln.strip() and not ln.lstrip().startswith("#")]
+        if not prompts:
+            raise SystemExit(f"[driver] no prompts in {args.prompt_file}")
     elif args.prompt:
         prompts = [args.prompt]
     else:
@@ -676,6 +794,9 @@ async def main_async(args: argparse.Namespace) -> int:
     out_dir.mkdir(parents=True, exist_ok=True)
 
     inflight = {"n": 0}
+    probe_url = None
+    if not args.no_server_probe:
+        probe_url = f"{args.base_url.rstrip('/')}/__loadtest/metrics"
     sampler = HostSampler(
         interval=args.sample_interval,
         jail_root=args.jail_root,
@@ -683,6 +804,7 @@ async def main_async(args: argparse.Namespace) -> int:
         mongo_url=args.mongo_url,
         mongo_db=args.mongo_db,
         inflight=inflight,
+        server_metrics_url=probe_url,
     )
     stop = asyncio.Event()
     sampler_task = asyncio.create_task(sampler.run(stop))

--- a/scripts/loadtest/serve_sim.py
+++ b/scripts/loadtest/serve_sim.py
@@ -1,0 +1,283 @@
+"""Boot the cloud stack with the simulated agent backend and seed a workspace,
+so ``chat_loadtest.py`` has something to hammer at zero token cost.
+
+Created 2026-07-29 — the load-test rig's server half. It:
+
+  1. Mints a local license + auth secret and points Beanie at a SCRATCH Mongo
+     database (dropped on exit unless ``--keep-db``).
+  2. Registers ``sim_backend.SimBackend`` under the backend name ``sim`` and
+     selects it, so no Anthropic key is needed and no tokens are spent.
+  3. Mounts the real cloud FastAPI app — real router, real run executor, real
+     Redis stream transport, real Mongo writes, real SSE.
+  4. Seeds user → workspace → agent → pocket over the real HTTP API.
+  5. Serves it with uvicorn and prints the exact ``chat_loadtest.py`` command,
+     with token / workspace / scope id already filled in.
+
+What this measures: YOUR stack's concurrency ceiling. What it does NOT measure:
+Anthropic rate limits, or the memory cost of a real Claude Code CLI subprocess
+per run (set ``PAW_SIM_SUBPROC=1`` / ``PAW_SIM_RSS_MB`` to approximate that).
+
+Usage:
+    uv run python scripts/loadtest/serve_sim.py --port 8099
+    # then, in another shell, paste the command it prints.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import contextlib
+import hashlib
+import json
+import os
+import sys
+import uuid
+from datetime import datetime, timedelta
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+
+def _license_key(secret: str) -> str:
+    payload = {
+        "org": "loadtest",
+        "plan": "enterprise",
+        "seats": 1000,
+        "exp": (datetime.now() + timedelta(days=365)).strftime("%Y-%m-%d"),  # noqa: DTZ005
+    }
+    body = json.dumps(payload)
+    sig = hashlib.sha256(f"{secret}:{body}".encode()).hexdigest()
+    return base64.b64encode(f"{body}.{sig}".encode()).decode()
+
+
+def _configure_env(args: argparse.Namespace, db_name: str) -> str:
+    secret = "loadtest-license-secret"
+    uri = f"{args.mongo_url.rstrip('/')}/{db_name}"
+    os.environ.update(
+        {
+            "POCKETPAW_LICENSE_KEY": _license_key(secret),
+            "POCKETPAW_LICENSE_SECRET": secret,
+            "AUTH_SECRET": "loadtest-auth-secret",
+            "POCKETPAW_CLOUD_MONGO_URI": uri,
+            "CLOUD_MONGODB_URI": uri,
+            "POCKETPAW_AGENT_BACKEND": "sim",
+            # Billing off: a load test should hit capacity limits, not the
+            # 402 credit gate at run start.
+            "POCKETPAW_BILLING_ENFORCED": "0",
+            "POCKETPAW_CLOUD_RUN_EXECUTOR": args.executor,
+        }
+    )
+    os.environ.pop("POCKETPAW_MEMORY_BACKEND", None)
+    if args.redis_url:
+        os.environ["POCKETPAW_REDIS_URL"] = args.redis_url
+    return uri
+
+
+async def _seed(app, base_url: str, n_pockets: int) -> dict[str, str]:
+    """Create user → workspace → agent → pocket over the real API."""
+    from httpx import ASGITransport, AsyncClient
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=base_url) as http:
+        email = f"loadtest-{uuid.uuid4().hex[:8]}@test.example"
+        # Random: the register endpoint rejects known-breached passwords.
+        password = f"Lt-{uuid.uuid4().hex}-9Z!"
+
+        r = await http.post(
+            "/api/v1/auth/register",
+            json={"email": email, "password": password, "full_name": "Load Test"},
+        )
+        if r.status_code != 201:
+            raise RuntimeError(f"register failed {r.status_code}: {r.text[:400]}")
+
+        r = await http.post(
+            "/api/v1/auth/bearer/login", data={"username": email, "password": password}
+        )
+        if r.status_code != 200:
+            raise RuntimeError(f"login failed {r.status_code}: {r.text[:400]}")
+        token = r.json()["access_token"]
+        headers = {"Authorization": f"Bearer {token}"}
+
+        slug = f"loadtest-{uuid.uuid4().hex[:6]}"
+        r = await http.post(
+            "/api/v1/workspaces", json={"name": "Load Test WS", "slug": slug}, headers=headers
+        )
+        if r.status_code not in (200, 201):
+            raise RuntimeError(f"workspace failed {r.status_code}: {r.text[:400]}")
+        workspace_id = r.json()["_id"]
+        await http.post(
+            "/api/v1/auth/set-active-workspace",
+            json={"workspace_id": workspace_id},
+            headers=headers,
+        )
+
+        r = await http.post(
+            "/api/v1/agents",
+            json={
+                "name": "Sim Agent",
+                "slug": f"sim-agent-{uuid.uuid4().hex[:6]}",
+                "backend": "sim",
+                "system_prompt": "You are a test agent.",
+            },
+            headers=headers,
+        )
+        agent_id = ""
+        if r.status_code in (200, 201):
+            payload = r.json()
+            agent_id = str(payload.get("_id") or payload.get("id") or "")
+        else:
+            print(f"[seed] WARN agent create {r.status_code}: {r.text[:200]}", file=sys.stderr)
+
+        # Seed MANY pockets, not one. A chat run supersedes the previous run in
+        # the same scope, so N sends into one pocket is one user typing N times
+        # — every earlier run gets cut short and the throughput number is
+        # meaningless. One pocket per concurrent virtual user is what actually
+        # models N users.
+        pocket_ids: list[str] = []
+        for i in range(max(1, n_pockets)):
+            r = await http.post(
+                "/api/v1/pockets", json={"name": f"Load Test Pocket {i + 1}"}, headers=headers
+            )
+            if r.status_code not in (200, 201):
+                raise RuntimeError(f"pocket {i} failed {r.status_code}: {r.text[:400]}")
+            payload = r.json()
+            pocket_id = str(payload.get("_id") or payload.get("id"))
+            pocket_ids.append(pocket_id)
+
+            # Attach the sim agent, or a chat addressed to it comes back 400
+            # agent.not_in_scope — and an unaddressed one resolves to the
+            # pocket's default agent, which is NOT the sim backend.
+            if agent_id:
+                r = await http.post(
+                    f"/api/v1/pockets/{pocket_id}/agents",
+                    json={"agentId": agent_id},
+                    headers=headers,
+                )
+                if r.status_code not in (200, 201, 204):
+                    print(
+                        f"[seed] WARN attach agent->pocket {r.status_code}: {r.text[:200]}",
+                        file=sys.stderr,
+                    )
+
+        return {
+            "token": token,
+            "workspace_id": workspace_id,
+            "agent_id": agent_id,
+            "pocket_id": pocket_ids[0],
+            "pocket_ids": ",".join(pocket_ids),
+            "email": email,
+        }
+
+
+async def main_async(args: argparse.Namespace) -> int:
+    db_name = args.db or f"loadtest_{uuid.uuid4().hex[:8]}"
+    uri = _configure_env(args, db_name)
+
+    import pocketpaw_ee.cloud.license as lic_mod
+    from beanie import init_beanie
+    from fastapi import FastAPI
+    from motor.motor_asyncio import AsyncIOMotorClient
+    from pocketpaw_ee.cloud import mount_cloud
+    from pocketpaw_ee.cloud.memory.bootstrap import register_default_backend
+    from pocketpaw_ee.cloud.memory.documents import MemoryFactDoc
+    from pocketpaw_ee.cloud.models import ALL_DOCUMENTS
+
+    from pocketpaw.agents.registry import register_backend
+
+    register_backend("sim", "sim_backend", "SimBackend")
+    lic_mod._cached_license = None
+    lic_mod._license_error = None
+
+    print(f"[serve] mongo   {uri}")
+    print(f"[serve] executor {args.executor}   redis {os.environ.get('POCKETPAW_REDIS_URL')}")
+    await init_beanie(connection_string=uri, document_models=[*ALL_DOCUMENTS, MemoryFactDoc])
+    register_default_backend()
+
+    app = FastAPI(title="pocketpaw loadtest rig")
+    mount_cloud(app)
+
+    print("[serve] seeding workspace…", flush=True)
+    seed = await _seed(app, f"http://127.0.0.1:{args.port}", args.pockets)
+    seed["mongo_db"] = db_name
+    seed["port"] = str(args.port)
+    n_pk = len(seed["pocket_ids"].split(","))
+    print(f"[serve] workspace={seed['workspace_id']} pockets={n_pk}", flush=True)
+    if seed["agent_id"]:
+        print(f"[serve] agent={seed['agent_id']}", flush=True)
+
+    # Also drop the credentials on disk — stdout is buffered when the rig runs
+    # detached, and the driver needs these to be scriptable.
+    seed_path = Path(args.seed_out)
+    seed_path.parent.mkdir(parents=True, exist_ok=True)
+    seed_path.write_text(json.dumps(seed, indent=2), encoding="utf-8")
+    print(f"[serve] seed written to {seed_path}", flush=True)
+
+    agent_flag = f" \\\n    --agent-id {seed['agent_id']}" if seed["agent_id"] else ""
+    print(
+        "\n"
+        + "=" * 78
+        + "\nREADY — run this in another shell:\n\n"
+        + f"""uv run python scripts/loadtest/chat_loadtest.py \\
+    --base-url http://127.0.0.1:{args.port} \\
+    --token {seed["token"]} \\
+    --workspace {seed["workspace_id"]} \\
+    --scope pocket --scope-id {seed["pocket_ids"]}{agent_flag} \\
+    --surface sites --prompt "Build a landing page for a dentist {{n}}" \\
+    --mode open --rate 1 --duration 60 --jitter \\
+    --redis-url {os.environ.get("POCKETPAW_REDIS_URL", "redis://localhost:6379")} \\
+    --mongo-url {args.mongo_url} --mongo-db {db_name} \\
+    --out out/sim-1rps"""
+        + "\n\n"
+        + "=" * 78
+        + "\n"
+    )
+
+    import uvicorn
+
+    config = uvicorn.Config(
+        app, host="127.0.0.1", port=args.port, log_level=args.log_level, access_log=False
+    )
+    server = uvicorn.Server(config)
+    try:
+        await server.serve()
+    finally:
+        if not args.keep_db:
+            print(f"\n[serve] dropping scratch db {db_name}")
+            client = AsyncIOMotorClient(args.mongo_url)
+            with contextlib.suppress(Exception):
+                await client.drop_database(db_name)
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument("--port", type=int, default=8099)
+    p.add_argument("--mongo-url", default="mongodb://localhost:27017")
+    p.add_argument(
+        "--redis-url", default=os.environ.get("POCKETPAW_REDIS_URL", "redis://localhost:6379")
+    )
+    p.add_argument("--executor", default="inprocess", choices=["inprocess", "arq"])
+    p.add_argument("--db", default=None, help="scratch db name (default: random)")
+    p.add_argument("--keep-db", action="store_true")
+    p.add_argument("--seed-out", default="out/loadtest_seed.json")
+    p.add_argument(
+        "--pockets",
+        type=int,
+        default=32,
+        help="distinct pockets to seed — one per concurrent virtual user",
+    )
+    p.add_argument("--log-level", default="warning")
+    args = p.parse_args()
+    try:
+        return asyncio.run(main_async(args))
+    except KeyboardInterrupt:
+        print("\n[serve] stopped")
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/loadtest/serve_sim.py
+++ b/scripts/loadtest/serve_sim.py
@@ -1,24 +1,38 @@
-"""Boot the cloud stack with the simulated agent backend and seed a workspace,
-so ``chat_loadtest.py`` has something to hammer at zero token cost.
+"""Boot the cloud stack against a chosen agent backend and seed a workspace, so
+``chat_loadtest.py`` has something to hammer.
 
 Created 2026-07-29 — the load-test rig's server half. It:
 
   1. Mints a local license + auth secret and points Beanie at a SCRATCH Mongo
-     database (dropped on exit unless ``--keep-db``).
-  2. Registers ``sim_backend.SimBackend`` under the backend name ``sim`` and
-     selects it, so no Anthropic key is needed and no tokens are spent.
+     database (dropped on exit unless ``--keep-db``). The drop runs in a
+     ``finally``, so a hard kill leaves the database behind — clean up with
+     ``db.getMongo().getDBNames().filter(n => n.startsWith('loadtest_'))``.
+  2. Selects the backend under test. Default ``--backend sim`` registers
+     ``sim_backend.SimBackend``, so no provider key is needed and no tokens are
+     spent. Any other value selects a backend already in the registry
+     (``deep_agents``, ``claude_agent_sdk``, …) and then the run is real: it
+     needs a working provider key in the environment and it spends money.
   3. Mounts the real cloud FastAPI app — real router, real run executor, real
      Redis stream transport, real Mongo writes, real SSE.
   4. Seeds user → workspace → agent → pocket over the real HTTP API.
   5. Serves it with uvicorn and prints the exact ``chat_loadtest.py`` command,
      with token / workspace / scope id already filled in.
 
-What this measures: YOUR stack's concurrency ceiling. What it does NOT measure:
-Anthropic rate limits, or the memory cost of a real Claude Code CLI subprocess
-per run (set ``PAW_SIM_SUBPROC=1`` / ``PAW_SIM_RSS_MB`` to approximate that).
+Updated 2026-07-29 (same day) for the baseline measurement: added ``--backend``
+and ``--model`` so a registered backend can be measured instead of the
+simulator, and added the ``/__loadtest/metrics`` probe. The probe reports event
+loop lag sampled from INSIDE this process, which is the number that decides the
+in-process ceiling — a client-side measurement sees the network and the
+driver's own loop instead, and would flatter the server.
+
+What this measures: YOUR stack's concurrency ceiling. With ``--backend sim`` it
+does NOT measure provider rate limits or the memory cost of a real Claude Code
+CLI subprocess per run (set ``PAW_SIM_SUBPROC=1`` / ``PAW_SIM_RSS_MB`` to
+approximate the latter).
 
 Usage:
     uv run python scripts/loadtest/serve_sim.py --port 8099
+    uv run python scripts/loadtest/serve_sim.py --backend deep_agents --pockets 250
     # then, in another shell, paste the command it prints.
 """
 
@@ -33,12 +47,30 @@ import json
 import os
 import sys
 import uuid
+from collections import deque
 from datetime import datetime, timedelta
 from pathlib import Path
+
+try:
+    import psutil
+except ImportError:  # pragma: no cover - optional dep
+    psutil = None  # type: ignore[assignment]
 
 _HERE = Path(__file__).resolve().parent
 if str(_HERE) not in sys.path:
     sys.path.insert(0, str(_HERE))
+
+# A Windows console defaults to cp1252, which has no U+2192. Without this,
+# --help dies in the encoder before printing a single option, because the
+# module docstring below contains arrows.
+for _stream in (sys.stdout, sys.stderr):
+    with contextlib.suppress(AttributeError, ValueError):
+        _stream.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr]
+
+# Bounded so a long run cannot grow this without limit. At the 50ms probe
+# interval below, 20k samples is ~17 minutes of history, and the driver drains
+# it on every poll anyway.
+_LAG_SAMPLES: deque[float] = deque(maxlen=20_000)
 
 
 def _license_key(secret: str) -> str:
@@ -63,7 +95,7 @@ def _configure_env(args: argparse.Namespace, db_name: str) -> str:
             "AUTH_SECRET": "loadtest-auth-secret",
             "POCKETPAW_CLOUD_MONGO_URI": uri,
             "CLOUD_MONGODB_URI": uri,
-            "POCKETPAW_AGENT_BACKEND": "sim",
+            "POCKETPAW_AGENT_BACKEND": args.backend,
             # Billing off: a load test should hit capacity limits, not the
             # 402 credit gate at run start.
             "POCKETPAW_BILLING_ENFORCED": "0",
@@ -73,10 +105,63 @@ def _configure_env(args: argparse.Namespace, db_name: str) -> str:
     os.environ.pop("POCKETPAW_MEMORY_BACKEND", None)
     if args.redis_url:
         os.environ["POCKETPAW_REDIS_URL"] = args.redis_url
+    if args.model:
+        # Per-backend model attribute, not a single global. Omitting a backend
+        # from _BACKEND_MODEL_ATTR silently drops the per-agent model, so set
+        # the generic key too and let the backend read whichever it honours.
+        os.environ["POCKETPAW_AGENT_MODEL"] = args.model
+        os.environ[f"POCKETPAW_{args.backend.upper()}_MODEL"] = args.model
     return uri
 
 
-async def _seed(app, base_url: str, n_pockets: int) -> dict[str, str]:
+async def _loop_lag_probe(interval: float = 0.05) -> None:
+    """Record event-loop scheduling delay, sampled inside the server process.
+
+    Sleep for a known interval and measure the overshoot. On an idle loop that
+    is near zero; under load it is how long a ready callback waited behind
+    other work, which is the thing that actually gives out first when the agent
+    tier runs in-process rather than in a subprocess.
+    """
+    loop = asyncio.get_running_loop()
+    while True:
+        t0 = loop.time()
+        await asyncio.sleep(interval)
+        _LAG_SAMPLES.append(max(0.0, (loop.time() - t0 - interval) * 1000))
+
+
+def _install_probe(app) -> None:
+    """Expose the loop-lag samples and this process's RSS to the driver.
+
+    Registered BEFORE ``mount_cloud`` so a catch-all route cannot shadow it.
+    Reading drains the buffer, so each poll describes the window since the
+    previous poll rather than the whole run to date.
+    """
+
+    @app.get("/__loadtest/metrics")
+    async def _loadtest_metrics() -> dict:  # pyright: ignore[reportUnusedFunction]
+        samples = sorted(_LAG_SAMPLES)
+        _LAG_SAMPLES.clear()
+
+        def pct(p: float) -> float | None:
+            if not samples:
+                return None
+            idx = min(len(samples) - 1, int(round((p / 100) * (len(samples) - 1))))
+            return round(samples[idx], 2)
+
+        rss_mb = None
+        if psutil is not None:
+            with contextlib.suppress(Exception):
+                rss_mb = round(psutil.Process().memory_info().rss / 1_048_576, 1)
+        return {
+            "loop_lag_p50_ms": pct(50),
+            "loop_lag_p95_ms": pct(95),
+            "loop_lag_max_ms": round(samples[-1], 2) if samples else None,
+            "loop_lag_n": len(samples),
+            "srv_rss_mb": rss_mb,
+        }
+
+
+async def _seed(app, base_url: str, n_pockets: int, backend: str) -> dict[str, str]:
     """Create user → workspace → agent → pocket over the real API."""
     from httpx import ASGITransport, AsyncClient
 
@@ -116,9 +201,9 @@ async def _seed(app, base_url: str, n_pockets: int) -> dict[str, str]:
         r = await http.post(
             "/api/v1/agents",
             json={
-                "name": "Sim Agent",
-                "slug": f"sim-agent-{uuid.uuid4().hex[:6]}",
-                "backend": "sim",
+                "name": f"Loadtest Agent ({backend})",
+                "slug": f"loadtest-agent-{uuid.uuid4().hex[:6]}",
+                "backend": backend,
                 "system_prompt": "You are a test agent.",
             },
             headers=headers,
@@ -146,9 +231,9 @@ async def _seed(app, base_url: str, n_pockets: int) -> dict[str, str]:
             pocket_id = str(payload.get("_id") or payload.get("id"))
             pocket_ids.append(pocket_id)
 
-            # Attach the sim agent, or a chat addressed to it comes back 400
-            # agent.not_in_scope — and an unaddressed one resolves to the
-            # pocket's default agent, which is NOT the sim backend.
+            # Attach the loadtest agent, or a chat addressed to it comes back
+            # 400 agent.not_in_scope — and an unaddressed one resolves to the
+            # pocket's default agent, which is NOT the backend under test.
             if agent_id:
                 r = await http.post(
                     f"/api/v1/pockets/{pocket_id}/agents",
@@ -184,24 +269,37 @@ async def main_async(args: argparse.Namespace) -> int:
     from pocketpaw_ee.cloud.memory.documents import MemoryFactDoc
     from pocketpaw_ee.cloud.models import ALL_DOCUMENTS
 
-    from pocketpaw.agents.registry import register_backend
+    from pocketpaw.agents.registry import _BACKEND_REGISTRY, register_backend
 
-    register_backend("sim", "sim_backend", "SimBackend")
+    if args.backend == "sim":
+        register_backend("sim", "sim_backend", "SimBackend")
+    elif args.backend not in _BACKEND_REGISTRY:
+        known = ", ".join(sorted(_BACKEND_REGISTRY))
+        raise SystemExit(f"[serve] unknown backend {args.backend!r}. Registered: {known}")
+    else:
+        print(
+            f"[serve] REAL BACKEND {args.backend} — this spends provider tokens and "
+            "needs a working key in the environment.",
+            flush=True,
+        )
     lic_mod._cached_license = None
     lic_mod._license_error = None
 
     print(f"[serve] mongo   {uri}")
+    print(f"[serve] backend {args.backend}   model {args.model or '(backend default)'}")
     print(f"[serve] executor {args.executor}   redis {os.environ.get('POCKETPAW_REDIS_URL')}")
     await init_beanie(connection_string=uri, document_models=[*ALL_DOCUMENTS, MemoryFactDoc])
     register_default_backend()
 
     app = FastAPI(title="pocketpaw loadtest rig")
+    _install_probe(app)
     mount_cloud(app)
 
     print("[serve] seeding workspace…", flush=True)
-    seed = await _seed(app, f"http://127.0.0.1:{args.port}", args.pockets)
+    seed = await _seed(app, f"http://127.0.0.1:{args.port}", args.pockets, args.backend)
     seed["mongo_db"] = db_name
     seed["port"] = str(args.port)
+    seed["backend"] = args.backend
     n_pk = len(seed["pocket_ids"].split(","))
     print(f"[serve] workspace={seed['workspace_id']} pockets={n_pk}", flush=True)
     if seed["agent_id"]:
@@ -215,6 +313,8 @@ async def main_async(args: argparse.Namespace) -> int:
     print(f"[serve] seed written to {seed_path}", flush=True)
 
     agent_flag = f" \\\n    --agent-id {seed['agent_id']}" if seed["agent_id"] else ""
+    briefs = _HERE / "briefs" / "site-briefs.txt"
+    briefs_rel = briefs.relative_to(Path.cwd()) if briefs.is_relative_to(Path.cwd()) else briefs
     print(
         "\n"
         + "=" * 78
@@ -224,11 +324,11 @@ async def main_async(args: argparse.Namespace) -> int:
     --token {seed["token"]} \\
     --workspace {seed["workspace_id"]} \\
     --scope pocket --scope-id {seed["pocket_ids"]}{agent_flag} \\
-    --surface sites --prompt "Build a landing page for a dentist {{n}}" \\
+    --surface sites --prompt-file {briefs_rel.as_posix()} \\
     --mode open --rate 1 --duration 60 --jitter \\
     --redis-url {os.environ.get("POCKETPAW_REDIS_URL", "redis://localhost:6379")} \\
     --mongo-url {args.mongo_url} --mongo-db {db_name} \\
-    --out out/sim-1rps"""
+    --out out/{args.backend}-1rps"""
         + "\n\n"
         + "=" * 78
         + "\n"
@@ -240,9 +340,13 @@ async def main_async(args: argparse.Namespace) -> int:
         app, host="127.0.0.1", port=args.port, log_level=args.log_level, access_log=False
     )
     server = uvicorn.Server(config)
+    probe = asyncio.create_task(_loop_lag_probe())
     try:
         await server.serve()
     finally:
+        probe.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await probe
         if not args.keep_db:
             print(f"\n[serve] dropping scratch db {db_name}")
             client = AsyncIOMotorClient(args.mongo_url)
@@ -256,6 +360,18 @@ def main() -> int:
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
     p.add_argument("--port", type=int, default=8099)
+    p.add_argument(
+        "--backend",
+        default="sim",
+        help=(
+            "agent backend under test. 'sim' (default) is the free simulator; "
+            "anything else must already be in the registry (deep_agents, "
+            "claude_agent_sdk, …) and needs a real provider key"
+        ),
+    )
+    p.add_argument(
+        "--model", default=None, help="model id for a real backend (default: the backend's own)"
+    )
     p.add_argument("--mongo-url", default="mongodb://localhost:27017")
     p.add_argument(
         "--redis-url", default=os.environ.get("POCKETPAW_REDIS_URL", "redis://localhost:6379")

--- a/scripts/loadtest/sim_backend.py
+++ b/scripts/loadtest/sim_backend.py
@@ -1,0 +1,192 @@
+"""A fake AgentBackend that simulates a realistic agent turn without calling
+any model — so the chat stack can be load-tested at zero token cost.
+
+Created 2026-07-29 — companion to ``chat_loadtest.py``. It exists to separate
+the two independent ceilings that "how many users can we handle" collapses:
+
+  1. YOUR stack — web process, run executor, Redis stream transport, Mongo,
+     SSE fan-out. Measurable with this backend. Costs nothing.
+  2. The provider — Anthropic ITPM/OTPM and the per-run Claude Code CLI
+     subprocess footprint. Needs a real API key and real spend.
+
+This module answers (1) only. Numbers produced with it are an UPPER bound on
+what the real path can do: a real run also holds a Node subprocess and waits on
+the model. Set ``PAW_SIM_SUBPROC=1`` to reproduce the process/RSS dimension.
+
+Timing knobs (env, all optional) — defaults model a site-creation turn:
+    PAW_SIM_TTFT_MS          1200   delay before the first token
+    PAW_SIM_DURATION_MS      25000  total turn length
+    PAW_SIM_TOKEN_INTERVAL_MS  40   gap between text chunks
+    PAW_SIM_TOOLS               6   tool_use/tool_result pairs per turn
+    PAW_SIM_JITTER_PCT         25   +/- randomisation on every delay
+    PAW_SIM_SUBPROC             0   1 = spawn a real sleeping subprocess per run
+    PAW_SIM_RSS_MB              0   MB to allocate per run (emulates CLI memory)
+    PAW_SIM_FAIL_PCT            0   % of runs that end in an error event
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import random
+import sys
+import time
+from collections.abc import AsyncIterator
+from typing import Any
+
+from pocketpaw.agents.backend import BackendInfo, Capability
+from pocketpaw.agents.protocol import AgentEvent
+from pocketpaw.tools.policy import ToolPolicy
+
+_LOREM = (
+    "Setting up the project structure and installing dependencies. "
+    "Drafting the hero section with a headline and call to action. "
+    "Wiring the pricing table and the contact form. "
+    "Running the build and checking the output. "
+)
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, default))
+    except (TypeError, ValueError):
+        return default
+
+
+def _jitter(value: float, pct: int) -> float:
+    if pct <= 0:
+        return value
+    span = value * (pct / 100.0)
+    return max(0.0, value + random.uniform(-span, span))
+
+
+class SimBackend:
+    """Emits the same AgentEvent stream shape a real turn does, on a timer."""
+
+    def __init__(self, settings: Any = None) -> None:
+        self._settings = settings
+        self._policy = ToolPolicy()
+        # NOTE: ``AgentPool`` caches ONE backend instance per agent, so every
+        # concurrent run shares this object. Cancellation state must therefore
+        # be per-run — an instance-level ``_stopped`` flag makes run N's stop()
+        # silently truncate every other in-flight run, which shows up as a
+        # clean ``stream_end`` carrying no content at all. Real cancellation
+        # still works: the executor cancels the asyncio task.
+        self._stops = 0
+
+    @staticmethod
+    def info() -> BackendInfo:
+        return BackendInfo(
+            name="sim",
+            display_name="Load-test simulator",
+            capabilities=(
+                Capability.STREAMING
+                | Capability.TOOLS
+                | Capability.MULTI_TURN
+                | Capability.CUSTOM_SYSTEM_PROMPT
+            ),
+            builtin_tools=["Bash", "Read", "Write"],
+            required_keys=[],
+            supported_providers=["sim"],
+            beta=True,
+        )
+
+    async def run(
+        self,
+        message: str,
+        *,
+        system_prompt: str | None = None,
+        history: list[dict] | None = None,
+        session_key: str | None = None,
+        **_kwargs: Any,
+    ) -> AsyncIterator[AgentEvent]:
+        ttft = _env_int("PAW_SIM_TTFT_MS", 1200) / 1000
+        duration = _env_int("PAW_SIM_DURATION_MS", 25_000) / 1000
+        interval = _env_int("PAW_SIM_TOKEN_INTERVAL_MS", 40) / 1000
+        n_tools = _env_int("PAW_SIM_TOOLS", 6)
+        jitter_pct = _env_int("PAW_SIM_JITTER_PCT", 25)
+        fail_pct = _env_int("PAW_SIM_FAIL_PCT", 0)
+        rss_mb = _env_int("PAW_SIM_RSS_MB", 0)
+        want_proc = _env_int("PAW_SIM_SUBPROC", 0) == 1
+
+        ballast: bytearray | None = None
+        proc: asyncio.subprocess.Process | None = None
+        started = time.perf_counter()
+        try:
+            # Hold the resources a real run would, so the sampler sees them.
+            if rss_mb > 0:
+                ballast = bytearray(rss_mb * 1_048_576)
+            if want_proc:
+                proc = await asyncio.create_subprocess_exec(
+                    sys.executable,
+                    "-c",
+                    f"import time; time.sleep({duration + 5})",
+                    stdout=asyncio.subprocess.DEVNULL,
+                    stderr=asyncio.subprocess.DEVNULL,
+                )
+
+            await asyncio.sleep(_jitter(ttft, jitter_pct))
+
+            # Interleave text and tool calls across the remaining budget.
+            body = duration - ttft
+            tool_at = {
+                int((i + 1) * (body / interval) / max(n_tools + 1, 1)) for i in range(n_tools)
+            }
+            chunks = max(1, int(body / interval))
+            words = _LOREM.split()
+            emitted = 0
+            for i in range(chunks):
+                if i in tool_at:
+                    name = random.choice(["Write", "Bash", "Read", "Edit"])
+                    yield AgentEvent(
+                        type="tool_use", content=name, metadata={"tool": name, "input": {}}
+                    )
+                    await asyncio.sleep(_jitter(0.35, jitter_pct))
+                    yield AgentEvent(type="tool_result", content="ok", metadata={"tool": name})
+                    emitted += 40
+                    continue
+                word = words[i % len(words)]
+                yield AgentEvent(type="message", content=word + " ")
+                emitted += 1
+                await asyncio.sleep(_jitter(interval, jitter_pct))
+
+            if fail_pct and random.randint(1, 100) <= fail_pct:
+                yield AgentEvent(type="error", content="simulated backend failure")
+                return
+
+            elapsed = time.perf_counter() - started
+            yield AgentEvent(
+                type="token_usage",
+                content="",
+                metadata={
+                    "input_tokens": 8_000 + len(message),
+                    "output_tokens": emitted * 4,
+                    "cache_read_input_tokens": 40_000,
+                    "sim_elapsed_s": round(elapsed, 2),
+                },
+            )
+            yield AgentEvent(type="done", content="")
+        finally:
+            if proc is not None and proc.returncode is None:
+                proc.kill()
+                await asyncio.gather(proc.wait(), return_exceptions=True)
+            del ballast
+
+    async def stop(self) -> None:
+        # Per-run cancellation only; see __init__. Counted for observability.
+        self._stops += 1
+
+    async def get_status(self) -> dict[str, Any]:
+        return {"backend": "sim", "healthy": True}
+
+    def get_tool_policy(self) -> ToolPolicy:
+        return self._policy
+
+    def set_tool_policy(self, policy: ToolPolicy) -> None:
+        self._policy = policy
+
+    def attach_specialist_tools(self, tools: list[Any]) -> None:
+        return None
+
+    def attach_subprocess_env(self, env: dict[str, str]) -> None:
+        return None


### PR DESCRIPTION
## What this is

A rig that answers "how many concurrent chat runs does the stack survive" by measuring instead of guessing, and that can point at either a free simulator or a real registered backend. Nothing in production code is touched.

`sim_backend.py` is an `AgentBackend` that fakes a turn. TTFT, duration, token cadence, tool calls, jitter and failure rate are all env knobs. Set `PAW_SIM_SUBPROC=1` and it holds a real subprocess at a chosen RSS, for when you want the process dimension back.

`serve_sim.py` boots the real cloud app against a scratch Mongo database with the backend under test selected. It seeds a user, workspace, agent and N pockets over the real HTTP API, then prints the exact driver command with token and scope ids already filled in. `--backend` defaults to `sim`; any other value has to be in the registry already (`deep_agents`, `claude_agent_sdk`, and the six others) and gets a loud warning at boot, because from there the run costs real money and needs a real key. An unknown name fails at boot with the registered list rather than failing per-request later.

`chat_loadtest.py` drives `POST /cloud/chat/{scope}/{scope_id}/agent`, either open loop (fixed arrival rate, which is what finds a ceiling) or closed loop (fixed VUs, which is what measures steady-state latency). It consumes each SSE stream and times accept, `message.persisted`, first `chunk`, first `tool_start`, and the terminal frame. A sampler runs alongside recording CLI process count and RSS, web RSS, system CPU and memory, arq queue depth, and Mongo's queued and running run counts.

`briefs/site-briefs.txt` holds 21 `/sites` briefs spanning the shapes a request takes, from a bare one-liner to a fully specified section list. Brief shape drives token spend and turn length, so this is the fixture that makes two runs comparable.

## Measuring the server's own event loop

`serve_sim.py` installs a `/__loadtest/metrics` probe reporting event-loop lag sampled from **inside** the server process, plus that process's RSS. Lag has to be measured there: from the client you see the network and the driver's own loop, which flatters the server exactly when it is struggling. The probe sleeps a known interval and reports the overshoot; reading drains the buffer, so each poll describes the window since the last one.

The driver polls it automatically off `--base-url` and goes quiet if there is no probe, so this is inert against an ordinary deploy. `--no-server-probe` turns it off.

## Three numbers the report adds

**Empty completions.** A run can end with a clean `stream_end` and no assistant text at all. It counts as success everywhere else, and it is what concurrent truncation looks like from outside. It now has its own line and its own verdict entry naming both causes.

**Event-loop lag and per-run RSS.** Lag peak and mean join the host table. An `AGENT TIER` block divides the server's RSS growth over its idle baseline by peak concurrency to get a per-run figure. That one is derived rather than measured, and the report says so.

**Prompt-cache read share**, from `cache_read_input_tokens` in the `stream_end` usage. When a backend reports nothing, the report says which of the two possible reasons applies instead of printing a silent zero.

## Running it

```bash
uv run python scripts/loadtest/serve_sim.py --pockets 32
# then paste the command it prints, roughly:
uv run python scripts/loadtest/chat_loadtest.py --rate 2 --duration 120 ...

# against a real backend — costs money, needs a key:
uv run python scripts/loadtest/serve_sim.py --backend deep_agents --pockets 250
```

## What it does not measure

Only our own stack: web process, run executor, Redis stream transport, Mongo, SSE fan-out. With `--backend sim` it does not touch a provider at all, and those numbers are an upper bound, because a real run also holds a subprocess and spends most of its life waiting on a model.

## Three traps, for whoever extends this

Each of these produces a wrong answer rather than an error, which is why they cost time to find.

1. One scope is not many users. A new run supersedes the previous run in the same scope, so N sends into one pocket cut each other short instead of running concurrently. Seed one pocket per VU (`--pockets N`) and pass the comma-separated list to `--scope-id`. Under-provisioning shows up as `interrupted:user_cancelled`, or as empty completions.
2. SSE heartbeats defeat read timeouts. `: ping` frames reset an httpx read timeout, so a hung run never trips one. The driver uses a wall-clock `asyncio.timeout` instead.
3. `AgentPool` caches one backend instance per agent. Cancellation state kept on the instance leaks across concurrent runs and truncates them: we watched 33 of 49 runs return a clean `stream_end` carrying no content at all. `sim_backend` keeps that state per run, and a real backend has to as well.

## First numbers

Laptop, 15 second simulated runs, `inprocess` executor:

| Arrival rate | Accept p50 | Peak concurrency |
|---|---|---|
| 1/sec | 30 ms | 27 |
| 2/sec | 73 ms | 64 |
| 4/sec | 1018 ms | 86 |

CPU peaked at 41% and memory at 50%, so the box was not the constraint. The asyncio event loop was. The knee sits somewhere between 2 and 4 arrivals per second on this hardware.

## Testing

Verified end to end against the sim backend, including that the new counters detect rather than always fire. Under-provisioned on purpose (15 requests across 4 pockets) the report showed 11 empty completions and the verdict named supersession; at 4 VUs across 4 pockets it showed 0. Loop lag read 371 ms p95 at 4 concurrent and 1247 ms at 9.

`ruff check` and `ruff format --check` clean. No existing code paths modified. The only non-additive change is one `.gitignore` entry for the rig's `out/`.

One pre-existing bug fixed on the way past: `--help` crashed on Windows because the docstring's arrows are not in cp1252 and the encoder died before printing a single option. Both scripts now force UTF-8 on stdout and stderr.

## Where this is going

The 300-400 concurrent user target puts roughly 250 concurrent runs on the agent tier, and with `claude_sdk` that is a Node subprocess each. With `--backend` and the probe in place, measuring `deep_agents` against that number is a single command on a Linux box with a provider key, which is the thing that decides whether we need a different backend at all.
