### PR TITLE
The concierge remembers what the visitor already told it

### DIFF
--- a/docs/concepts/concierge-knowledge.mdx
+++ b/docs/concepts/concierge-knowledge.mdx
@@ -95,7 +95,7 @@ an email address, or an order number. Each site therefore has its own switch:
   `GET`/`PATCH /paw-bar/admin/site/{site_id}/settings`.
 - With it **off**, the concierge keeps working and keeps storing its own replies.
   Only the visitor's words are dropped, and transcripts for that site show the
-  assistant side alone.
+  assistant side alone. It also stops remembering across turns — see below.
 - The agent always receives the full message either way. The switch governs storage,
   never the answer.
 - It is read on every message, so turning it off stops collection from the next
@@ -107,3 +107,30 @@ off does not silence the bar, and disabling the concierge does not reset retenti
 
 Stored visitor messages are length-capped, so a pasted wall of text cannot grow the
 run collection without bound.
+
+## What a concierge remembers
+
+Those stored turns are also the concierge's memory. A visitor can say their name in
+one message and be recognised in the next, because each turn replays that visitor's
+earlier turns back to the agent. Without it the concierge answers every message cold:
+it has no thread and no message records of its own to fall back on, unlike a
+signed-in chat.
+
+What comes back is scoped to one visitor on one site in one workspace. Another
+visitor of the same bar, the same visitor on a different site, and any other tenant
+are all separate conversations, and none of them can appear in a run that is not
+theirs.
+
+The replay is bounded three ways: a limited number of recent exchanges, a cap on any
+single line, and a total character budget. When the budget runs out the oldest
+exchanges drop first, so what the agent sees is the most recent stretch of the
+conversation rather than a patchy sample of it. This keeps the cost of a turn flat
+however long a visitor keeps talking.
+
+Memory follows retention. With `concierge_store_transcripts` **off** nothing the
+visitor says is written down, so there is nothing to remember and the concierge
+answers each message fresh. That is the switch working as intended: it is one
+decision about whether the site keeps a record of its visitors, not two.
+
+If the record cannot be read for any reason, the concierge answers without memory
+rather than failing the visitor's chat.

--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -1,4 +1,25 @@
 # ee/paw_bar/router.py — HTTP surface for the Paw Bar widget layer.
+# Updated: 2026-07-29 (concierge conversation memory) — a concierge turn is no
+#   longer answered cold. ``concierge_chat`` built its ``RunSpec`` with
+#   ``history=[]``, so the agent forgot the visitor's name between one message and
+#   the next: the visitor is anonymous and has no ``Message`` rows, so the authed
+#   surfaces' ``load_history_for_scope`` had nothing to read. The stored run docs
+#   (``user_text`` + ``partial_text``, from the transcript work below) are now ALSO
+#   the memory. (1) ``_concierge_runs_for_visitor`` extracts the (workspace,
+#   context_type, scope_id, user_id) query that ``_load_transcript`` already used,
+#   so the owner's transcript read and the agent's rehydration share ONE definition
+#   of "this visitor's turns" — per-visitor, per-site, per-tenant isolation lives in
+#   exactly one place. (2) ``_load_concierge_history`` shapes those rows into
+#   ``[{"role","content"}]`` oldest-first (the shape ``load_history_for_scope``
+#   returns), bounded by ``_HISTORY_TURN_CAP`` exchanges / ``_HISTORY_MESSAGE_CHARS``
+#   per line / ``_HISTORY_TOTAL_CHARS`` overall — fitted newest-first so the budget
+#   drops the OLDEST turns and the replay stays contiguous. Failure-soft: a read
+#   error answers without memory instead of 500-ing the visitor. (3) The read
+#   happens BEFORE ``create_run`` writes this turn's doc, so the current message
+#   rides in ``content`` exactly once. (4) Gated on the SAME
+#   ``concierge_store_transcripts`` toggle as the write — retention off means no
+#   memory, which is the owner's privacy choice working rather than a gap to route
+#   around.
 # Updated: 2026-07-26 (site knowledge sync) — two owner endpoints over the site's
 #   own knowledge: GET /paw-bar/admin/site/{id}/knowledge reports how many articles
 #   the concierge can quote and how the last sync went, and POST
@@ -1272,6 +1293,35 @@ _TRANSCRIPT_CAP = 200
 # question is never clipped.
 _STORED_USER_TEXT_CHARS = 4000
 
+# ---------------------------------------------------------------------------
+# Concierge conversation memory — the bounds on rehydrated history
+#
+# Every concierge turn replays the visitor's PRIOR turns into the run so the
+# agent remembers what was already said. Unbounded that would be both a cost
+# problem (the whole conversation is re-sent, and re-billed, on every turn) and
+# an abuse vector (a visitor could grow the prompt indefinitely by pasting).
+# Three bounds, each closing a different hole:
+# ---------------------------------------------------------------------------
+
+# How many prior EXCHANGES (a run = the visitor's line + the agent's reply) are
+# replayed. The most recent N, presented oldest-first. A site conversation is
+# short by nature — a dozen exchanges covers a full support or sales back-and-
+# forth, and it keeps the per-turn prompt cost flat instead of growing linearly.
+_HISTORY_TURN_CAP = 12
+
+# Max characters of any SINGLE replayed line. A long agent reply would otherwise
+# eat the whole budget below and evict every other turn; clipping it means the
+# newest exchange ALWAYS fits (2 x this < the total below), so memory can never
+# degrade to nothing because of one verbose turn. The clip affects the replayed
+# copy only — the stored transcript the owner reads is untouched.
+_HISTORY_MESSAGE_CHARS = 2000
+
+# Total characters across all replayed lines (~3k tokens). This is the real
+# ceiling on what a visitor can force us to re-send every turn. Turns are fitted
+# newest-first and the budget cuts off the OLDEST ones, so what survives is
+# always a contiguous run of the most recent conversation, never a gappy one.
+_HISTORY_TOTAL_CHARS = 12000
+
 
 class AdminWidgetView(BaseModel):
     """The site's paw-bar widget as the owner dashboard needs it (D2 overview)."""
@@ -1755,6 +1805,112 @@ async def _list_conversations(
     return ConversationsResponse(items=items, cursor=next_cursor, unsupported=False)
 
 
+async def _concierge_runs_for_visitor(
+    pocket_id: str, customer_ref: str, workspace_id: str, *, limit: int
+) -> list[Any]:
+    """One visitor's concierge runs on one site, most-recent first.
+
+    THE per-visitor isolation seam, deliberately in ONE place: both the owner's
+    transcript read and the agent's conversation-memory rehydration go through
+    this query, so there is no second, drifting definition of "this visitor's
+    turns". All four predicates are load-bearing:
+
+      * ``workspace``     — tenant isolation; another tenant's runs never match.
+      * ``context_type``  — concierge runs only; an authed pocket/session run on
+                            the same pocket is a different conversation.
+      * ``scope_id``      — the site's OWN pocket; a sibling site never matches.
+      * ``user_id``       — the anonymous customer handle; a sibling VISITOR of
+                            the same widget never matches.
+
+    Callers pass ``workspace_id`` / ``pocket_id`` from the authenticated
+    authority (the resolved site key or the session's workspace), never from the
+    request body. Index-backed and always bounded by ``limit``.
+    """
+    from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
+
+    return (
+        await ChatRunDoc.find(
+            ChatRunDoc.workspace == workspace_id,
+            ChatRunDoc.context_type == _CONCIERGE_CONTEXT_TYPE,
+            ChatRunDoc.scope_id == pocket_id,
+            ChatRunDoc.user_id == customer_ref,
+        )
+        .sort(-ChatRunDoc.createdAt)  # type: ignore[operator]
+        .limit(limit)
+        .to_list()
+    )
+
+
+async def _load_concierge_history(
+    pocket_id: str, customer_ref: str, workspace_id: str
+) -> list[dict[str, str]]:
+    """Rehydrate one visitor's prior turns as ``RunSpec.history``.
+
+    The concierge visitor is anonymous and has no ``Message`` rows, so the authed
+    surfaces' ``load_history_for_scope`` has nothing to read and every turn was
+    answered cold: the agent could not recall a name, an order number, or its own
+    previous answer. The stored run docs ARE the transcript, so they are also the
+    memory — same rows, same query (``_concierge_runs_for_visitor``), just shaped
+    for the model instead of for the dashboard.
+
+    Shape matches ``load_history_for_scope``: ``[{"role", "content"}]``, roles
+    "user" / "assistant", oldest-first.
+
+    Bounded by ``_HISTORY_TURN_CAP`` exchanges, ``_HISTORY_MESSAGE_CHARS`` per
+    line, and ``_HISTORY_TOTAL_CHARS`` overall. Turns are fitted newest-first and
+    the budget cuts the oldest off, so the replay is always the most recent
+    CONTIGUOUS stretch of the conversation — an older turn never jumps a newer
+    one just because it happens to be shorter.
+
+    The CURRENT turn is not in here: the caller reads before ``create_run``
+    writes this turn's doc, so the visitor's message rides in ``RunSpec.content``
+    exactly once.
+
+    Failure-soft: any read error degrades to no memory and logs. A visitor's chat
+    must not 500 because the run collection hiccuped.
+    """
+    # An empty handle is not a visitor — every anonymous caller that omitted the
+    # ref would otherwise share one bucket and read each other's conversation.
+    if not customer_ref:
+        return []
+
+    try:
+        runs = await _concierge_runs_for_visitor(
+            pocket_id, customer_ref, workspace_id, limit=_HISTORY_TURN_CAP
+        )
+
+        history: list[dict[str, str]] = []
+        budget = _HISTORY_TOTAL_CHARS
+        for run in runs:  # newest-first — the newest turns win the char budget
+            turn: list[dict[str, str]] = []
+            for role, raw in (
+                ("user", getattr(run, "user_text", "") or ""),
+                ("assistant", getattr(run, "partial_text", "") or ""),
+            ):
+                line = raw[:_HISTORY_MESSAGE_CHARS]
+                if line:
+                    turn.append({"role": role, "content": line})
+            if not turn:
+                # A run that stored neither side (retention off and no reply yet)
+                # contributes nothing, and costs nothing.
+                continue
+            cost = sum(len(m["content"]) for m in turn)
+            if cost > budget:
+                # Out of budget. Everything left in ``runs`` is OLDER, so stop
+                # rather than skip — that is what keeps the replay contiguous.
+                break
+            budget -= cost
+            history = turn + history  # prepend: the result reads oldest-first
+        return history
+    except Exception:  # noqa: BLE001 — memory is best-effort, the reply is not
+        logger.warning(
+            "concierge history load failed for pocket %s; answering without memory",
+            pocket_id,
+            exc_info=True,
+        )
+        return []
+
+
 async def _load_transcript(
     pocket_id: str, customer_ref: str, workspace_id: str
 ) -> list[TranscriptMessage] | None:
@@ -1772,18 +1928,8 @@ async def _load_transcript(
     Returns ``None`` when the ref has NO concierge run here (the caller 404s) —
     distinct from an empty list, which means runs exist but none carried any text.
     """
-    from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
-
-    runs = (
-        await ChatRunDoc.find(
-            ChatRunDoc.workspace == workspace_id,
-            ChatRunDoc.context_type == _CONCIERGE_CONTEXT_TYPE,
-            ChatRunDoc.scope_id == pocket_id,
-            ChatRunDoc.user_id == customer_ref,
-        )
-        .sort(-ChatRunDoc.createdAt)  # type: ignore[operator]
-        .limit(_TRANSCRIPT_CAP)
-        .to_list()
+    runs = await _concierge_runs_for_visitor(
+        pocket_id, customer_ref, workspace_id, limit=_TRANSCRIPT_CAP
     )
     if not runs:
         return None
@@ -2256,8 +2402,7 @@ async def concierge_chat(body: ConciergeChatRequest, request: Request) -> Stream
     # anonymous customer handle (session / rate-limit key, never a principal).
     # ``surface="concierge"`` makes execute_run resolve the CONCIERGE
     # SurfaceProfile (tool lockdown); ``context_type="concierge"`` makes it
-    # resolve the CONCIERGE scope (KB locked to pocket:<id>). ``history=[]`` stays
-    # (each turn is answered fresh — no cross-visitor bleed).
+    # resolve the CONCIERGE scope (KB locked to pocket:<id>).
     #
     # ``persist_user_text`` is the visitor's own line, written onto the run doc so
     # the owner's transcript is a conversation rather than a monologue. The visitor
@@ -2268,6 +2413,22 @@ async def concierge_chat(body: ConciergeChatRequest, request: Request) -> Stream
     # full message either way, this governs only what is stored.
     stored_user_text = (
         body.message[:_STORED_USER_TEXT_CHARS] if site.concierge_store_transcripts else ""
+    )
+    # ``history`` is THIS visitor's prior turns on THIS site (see
+    # ``_load_concierge_history``). Read BEFORE ``create_run`` below writes this
+    # turn's doc, so the current message rides in ``content`` and appears exactly
+    # once. Scoped to (workspace, concierge, pocket, customer_ref) — a sibling
+    # visitor's, a sibling site's, and another tenant's turns can never appear.
+    #
+    # Gated on the SAME retention toggle as the write: an owner who turned
+    # transcript storage off gets no memory, because there is nothing stored to
+    # remember from and because replaying the agent's half alone would feed it a
+    # conversation with the questions missing. That degradation is the owner's
+    # privacy choice working, not a bug to route around.
+    prior_history = (
+        await _load_concierge_history(ctx.pocket_id or "", body.customer_ref, ctx.workspace_id)
+        if site.concierge_store_transcripts
+        else []
     )
     spec = RunSpec(
         run_id=run_id,
@@ -2282,7 +2443,7 @@ async def concierge_chat(body: ConciergeChatRequest, request: Request) -> Stream
         user_message_id="",
         persist_user_text=stored_user_text,
         content=body.message,
-        history=[],
+        history=prior_history,
         intent=None,
         attachments=[],
         mentions=[],

--- a/tests/cloud/test_paw_bar_concierge_chat.py
+++ b/tests/cloud/test_paw_bar_concierge_chat.py
@@ -19,9 +19,20 @@
 #   nothing when the site's concierge_store_transcripts is off (while the AGENT
 #   still receives the full message either way), the stored copy is length-capped,
 #   and create_run actually lands the field on the run document.
+# Updated 2026-07-29 (concierge conversation memory): a fifth layer covers the
+#   rehydrated RunSpec.history — prior turns of the SAME visitor come back
+#   oldest-first in the {"role","content"} shape the agent consumes; a sibling
+#   visitor's, a sibling site's, and another tenant's turns never do (the isolation
+#   property, one test each); the replay is bounded by turns, by per-line
+#   characters, and by a total character budget that drops the oldest turns first;
+#   a retention-off site yields no memory at all; a read error answers without
+#   memory instead of 500-ing; and the visitor's current message reaches the agent
+#   exactly once.
 
 from __future__ import annotations
 
+import uuid
+from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
 import pytest
@@ -359,7 +370,7 @@ async def test_chat_happy_path_streams_and_dispatches_concierge_run(concierge_cl
     assert spec.workspace_id == "ws-1"
     assert spec.agent_id == "agent-xyz"
     assert spec.user_id == "cust-1"  # anonymous handle, never a principal
-    assert spec.history == []  # stateless MVP — no cross-visitor bleed
+    assert spec.history == []  # first turn — this visitor has nothing to replay
     assert spec.surface_meta.get("pocket_id") == "pocket-1"
 
 
@@ -500,8 +511,16 @@ async def test_chat_rate_limit_is_429(concierge_client):
 # --------------------------------------------------------------------------- #
 
 
-async def _dispatch(client, store, monkeypatch, *, site_kw=None, **payload_ov):
-    """Run one chat request through the endpoint and return the dispatched RunSpec."""
+async def _dispatch(
+    client, store, monkeypatch, *, site_kw=None, real_create_run=False, **payload_ov
+):
+    """Run one chat request through the endpoint and return the dispatched RunSpec.
+
+    ``create_run`` is stubbed by default (nothing needs the document). Pass
+    ``real_create_run=True`` to let the REAL one write this turn's run doc — that is
+    what makes the "current message isn't replayed into history" test meaningful,
+    since the doc it writes is exactly the row a mis-ordered read would pick up.
+    """
     from pocketpaw_ee.cloud.chat.runs.memory_stream import InMemoryStreamTransport
 
     await _site(**(site_kw or {}))
@@ -517,7 +536,8 @@ async def _dispatch(client, store, monkeypatch, *, site_kw=None, **payload_ov):
     async def _fake_create_run(spec):
         return SimpleNamespace(run_id=spec.run_id)
 
-    monkeypatch.setattr("pocketpaw_ee.cloud.chat.runs.service.create_run", _fake_create_run)
+    if not real_create_run:
+        monkeypatch.setattr("pocketpaw_ee.cloud.chat.runs.service.create_run", _fake_create_run)
 
     res = await client.post(
         "/paw-bar/chat", json=_payload(widget.id, **payload_ov), headers={"Origin": _ORIGIN}
@@ -619,3 +639,275 @@ async def test_create_run_defaults_visitor_text_to_empty(mongo_db):
     )
     doc = await create_run(spec)
     assert doc.user_text == ""
+
+
+# --------------------------------------------------------------------------- #
+# Layer 5 — conversation memory (rehydrated RunSpec.history)
+#
+# The concierge used to answer every turn cold: tell it your name, ask for it
+# back, and it had never heard of you. The stored run docs are now replayed into
+# the run. The property that must not be got wrong is WHOSE turns come back —
+# one visitor, on one site, in one tenant — so that has a test each.
+# --------------------------------------------------------------------------- #
+
+# A fixed clock so seeded turns have an unambiguous order (equal timestamps would
+# leave the newest-first sort at the mercy of insertion order).
+_MEMORY_CLOCK = datetime(2026, 7, 29, 12, 0, tzinfo=UTC)
+
+
+async def _mk_run(*, minutes_ago: int = 0, **ov):
+    """Insert one stored concierge turn — the row conversation memory reads back.
+
+    Defaults describe cust-1's turn on pocket-1 in ws-1, which is exactly what
+    ``_dispatch``'s request resolves to; override a field to seed the turn of a
+    sibling visitor, a sibling site, or another tenant.
+    """
+    from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
+
+    d = dict(
+        run_id=uuid.uuid4().hex,
+        workspace="ws-1",
+        context_type="concierge",
+        scope_id="pocket-1",
+        session_key="cloud:concierge:pocket-1:cust-1:agent-xyz",
+        user_id="cust-1",
+        agent_id="agent-xyz",
+        client_message_id=uuid.uuid4().hex,
+        user_message_id="",
+        status="completed",
+        user_text="",
+        partial_text="",
+        createdAt=_MEMORY_CLOCK - timedelta(minutes=minutes_ago),
+    )
+    d.update(ov)
+    doc = ChatRunDoc(**d)
+    await doc.insert()
+    return doc
+
+
+@pytest.mark.asyncio
+async def test_chat_rehydrates_this_visitors_prior_turns(concierge_client, monkeypatch):
+    """The defect this closes: prior turns come back, oldest-first, in the
+    {"role","content"} shape ``load_history_for_scope`` returns for authed
+    surfaces — so the agent can answer "what is my name" from what it was told."""
+    client, store = concierge_client
+    await _mk_run(
+        minutes_ago=10,
+        user_text="My name is Priya.",
+        partial_text="Nice to meet you, Priya.",
+    )
+    await _mk_run(minutes_ago=5, user_text="I have 12 clients.", partial_text="Twelve, noted.")
+
+    spec = await _dispatch(client, store, monkeypatch, message="What is my name?")
+
+    assert spec.history == [
+        {"role": "user", "content": "My name is Priya."},
+        {"role": "assistant", "content": "Nice to meet you, Priya."},
+        {"role": "user", "content": "I have 12 clients."},
+        {"role": "assistant", "content": "Twelve, noted."},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_chat_history_never_carries_a_sibling_visitors_turns(concierge_client, monkeypatch):
+    """ISOLATION: two anonymous visitors share the widget, the pocket, and the
+    agent — only the customer handle separates them. One visitor's words must
+    never be replayed into another's run."""
+    client, store = concierge_client
+    await _mk_run(minutes_ago=5, user_text="I am cust-1.", partial_text="Hello, cust-1.")
+    await _mk_run(
+        minutes_ago=4,
+        user_id="cust-2",
+        session_key="cloud:concierge:pocket-1:cust-2:agent-xyz",
+        user_text="My order number is 99887 and my name is Bob.",
+        partial_text="Thanks Bob, order 99887 ships Tuesday.",
+    )
+
+    spec = await _dispatch(client, store, monkeypatch, message="Where is my order?")
+
+    assert spec.history == [
+        {"role": "user", "content": "I am cust-1."},
+        {"role": "assistant", "content": "Hello, cust-1."},
+    ]
+    assert "Bob" not in str(spec.history)
+    assert "99887" not in str(spec.history)
+
+
+@pytest.mark.asyncio
+async def test_chat_history_never_carries_a_sibling_sites_turns(concierge_client, monkeypatch):
+    """ISOLATION: the same visitor handle on a SIBLING site's pocket is a separate
+    conversation — the run's scope is the key's own pocket."""
+    client, store = concierge_client
+    await _mk_run(
+        minutes_ago=5,
+        scope_id="pocket-2",
+        session_key="cloud:concierge:pocket-2:cust-1:agent-xyz",
+        user_text="I asked this on the other site.",
+        partial_text="Answered on the other site.",
+    )
+
+    spec = await _dispatch(client, store, monkeypatch, message="What did I ask?")
+
+    assert spec.history == []
+
+
+@pytest.mark.asyncio
+async def test_chat_history_never_carries_another_tenants_turns(concierge_client, monkeypatch):
+    """ISOLATION: tenant boundary. A row matching on every other predicate but
+    belonging to a different workspace must not be readable."""
+    client, store = concierge_client
+    await _mk_run(
+        minutes_ago=5,
+        workspace="ws-other",
+        user_text="Another tenant's visitor.",
+        partial_text="Another tenant's reply.",
+    )
+
+    spec = await _dispatch(client, store, monkeypatch, message="What did I ask?")
+
+    assert spec.history == []
+
+
+@pytest.mark.asyncio
+async def test_chat_history_is_empty_when_retention_is_off(concierge_client, monkeypatch):
+    """The owner's privacy choice governs memory too. With
+    concierge_store_transcripts off there is nothing being written down to
+    remember from, and replaying the agent's half alone would hand it a
+    conversation with the questions missing. No memory is the correct outcome,
+    and the concierge still answers."""
+    client, store = concierge_client
+    await _mk_run(
+        minutes_ago=5,
+        user_text="My name is Priya.",
+        partial_text="Nice to meet you, Priya.",
+    )
+
+    spec = await _dispatch(
+        client,
+        store,
+        monkeypatch,
+        site_kw={"concierge_store_transcripts": False},
+        message="What is my name?",
+    )
+
+    assert spec.history == []
+    assert spec.content == "What is my name?"
+
+
+@pytest.mark.asyncio
+async def test_chat_history_is_bounded_by_the_turn_cap(concierge_client, monkeypatch):
+    """A long conversation replays its most recent exchanges, not all of them —
+    the per-turn prompt cost stays flat instead of growing with the visitor."""
+    from pocketpaw_ee.paw_bar.router import _HISTORY_TURN_CAP
+
+    client, store = concierge_client
+    seeded = _HISTORY_TURN_CAP + 3
+    for i in range(seeded):
+        await _mk_run(minutes_ago=seeded - i, user_text=f"q{i}", partial_text=f"a{i}")
+
+    spec = await _dispatch(client, store, monkeypatch, message="and now?")
+
+    assert len(spec.history) == _HISTORY_TURN_CAP * 2
+    # The OLDEST three were dropped; the surviving stretch ends at the newest.
+    assert spec.history[0] == {"role": "user", "content": "q3"}
+    assert spec.history[-1] == {"role": "assistant", "content": f"a{seeded - 1}"}
+
+
+@pytest.mark.asyncio
+async def test_chat_history_is_bounded_by_the_character_budget(concierge_client, monkeypatch):
+    """A visitor pasting walls of text cannot grow the prompt without limit. The
+    budget drops whole exchanges from the OLDEST end, so what survives is the most
+    recent contiguous stretch — never half a turn, never a gappy conversation."""
+    from pocketpaw_ee.paw_bar.router import _HISTORY_TOTAL_CHARS, _HISTORY_TURN_CAP
+
+    client, store = concierge_client
+    line = 1500
+    per_turn = line * 2
+    fits = _HISTORY_TOTAL_CHARS // per_turn  # whole exchanges the budget holds
+    seeded = fits * 2
+    # The premises this test reasons from — the char budget must be the binding
+    # bound here, not the turn cap.
+    assert 0 < fits < seeded <= _HISTORY_TURN_CAP
+
+    for i in range(seeded):
+        await _mk_run(
+            minutes_ago=seeded - i,
+            user_text=f"{i}" + "x" * (line - 1),
+            partial_text=f"{i}" + "y" * (line - 1),
+        )
+
+    spec = await _dispatch(client, store, monkeypatch, message="and now?")
+
+    assert sum(len(m["content"]) for m in spec.history) <= _HISTORY_TOTAL_CHARS
+    assert len(spec.history) == fits * 2  # whole exchanges only
+    assert spec.history[0]["content"].startswith(str(seeded - fits))
+    assert spec.history[-1]["content"].startswith(str(seeded - 1))
+    assert [m["role"] for m in spec.history] == ["user", "assistant"] * fits
+
+
+@pytest.mark.asyncio
+async def test_chat_history_clips_one_long_line_instead_of_evicting_the_turn(
+    concierge_client, monkeypatch
+):
+    """A verbose agent reply is clipped rather than allowed to eat the whole
+    budget, which is what guarantees the newest exchange always fits."""
+    from pocketpaw_ee.paw_bar.router import _HISTORY_MESSAGE_CHARS
+
+    client, store = concierge_client
+    await _mk_run(
+        minutes_ago=5,
+        user_text="Tell me everything.",
+        partial_text="z" * (_HISTORY_MESSAGE_CHARS + 500),
+    )
+
+    spec = await _dispatch(client, store, monkeypatch, message="and now?")
+
+    assert [m["role"] for m in spec.history] == ["user", "assistant"]
+    assert len(spec.history[1]["content"]) == _HISTORY_MESSAGE_CHARS
+
+
+@pytest.mark.asyncio
+async def test_chat_answers_without_memory_when_the_history_read_fails(
+    concierge_client, monkeypatch
+):
+    """Failure-soft: memory is best-effort, the reply is not. A run-collection
+    hiccup degrades to a cold answer, it never 500s the visitor's chat."""
+    client, store = concierge_client
+    await _mk_run(minutes_ago=5, user_text="My name is Priya.", partial_text="Hello, Priya.")
+
+    async def _boom(*_a, **_kw):
+        raise RuntimeError("run collection unavailable")
+
+    monkeypatch.setattr("pocketpaw_ee.paw_bar.router._concierge_runs_for_visitor", _boom)
+
+    # ``_dispatch`` asserts 200 — the chat survived.
+    spec = await _dispatch(client, store, monkeypatch, message="What is my name?")
+
+    assert spec.history == []
+
+
+@pytest.mark.asyncio
+async def test_chat_does_not_replay_the_current_message_into_history(concierge_client, monkeypatch):
+    """The current turn rides in ``content`` and appears EXACTLY once. The real
+    ``create_run`` writes this turn's doc here, so a history read ordered after it
+    would pick the visitor's own message straight back up — this is the test that
+    pins the ordering."""
+    client, store = concierge_client
+    await _mk_run(minutes_ago=5, user_text="My name is Priya.", partial_text="Hello, Priya.")
+
+    message = "What is my name?"
+    spec = await _dispatch(client, store, monkeypatch, real_create_run=True, message=message)
+
+    occurrences = [spec.content, *(m["content"] for m in spec.history)].count(message)
+    assert occurrences == 1
+    assert spec.history == [
+        {"role": "user", "content": "My name is Priya."},
+        {"role": "assistant", "content": "Hello, Priya."},
+    ]
+
+    # And the doc create_run wrote IS visible to the next turn's read — the
+    # exclusion above is ordering, not a blind spot.
+    from pocketpaw_ee.paw_bar.router import _load_concierge_history
+
+    next_turn = await _load_concierge_history("pocket-1", "cust-1", "ws-1")
+    assert {"role": "user", "content": message} in next_turn


### PR DESCRIPTION
Stacked on `feat/concierge-knowledge-and-transcripts` (#1797), so review this
diff alone.

## The defect, reproduced before and after

Before, on a live local backend against the Ridgeline HVAC demo site:

    visitor: My name is Priya and I have exactly 12 freelance clients.
    bot:     Nice to meet you, Priya.
    visitor: What is my name, and how many clients did I say I have?
    bot:     I don't have that information, you haven't shared your name...

After, same rig, same two turns:

    bot:     Your name is Priya, and you said you have 12 freelance clients.

This was not a missing feature so much as a structural hole. Every authed
surface persists the user turn as its own Message document, so history reads
back. A concierge visitor is anonymous, has no thread and no Message rows, so
there was nothing to read and every turn was answered cold.

The transcript work on the base branch is what makes the fix small: the stored
run docs already hold both halves of every exchange, so they are the memory
too. Same rows, same query, shaped for the model instead of for the dashboard.

## Isolation is the property that matters

`_concierge_runs_for_visitor` extracts the query the owner transcript already
used, so there is exactly ONE definition of "this visitor's turns" rather than
a second one that can drift. All four predicates carry weight: workspace,
context_type, the site's own pocket, and the anonymous customer handle. Tests
cover a sibling visitor, a sibling site, and another tenant, each proving their
turns never appear.

## Bounds

Three, each closing a different hole: twelve exchanges replayed, 2000
characters per line, 12000 overall. Turns are fitted newest-first so the budget
drops the oldest and the replay stays contiguous rather than gappy, and a
single long reply is clipped rather than allowed to evict every other turn.
Without these, a visitor could grow the prompt indefinitely by pasting, and
every turn would re-send and re-bill the whole conversation.

## Privacy

Gated on the same `concierge_store_transcripts` toggle as the write. Retention
off means no stored text, so no memory. That is the owner's privacy choice
working, not a gap to route around with a parallel store, and the docs now say
so plainly.

Reads happen before the current turn's run doc is written, so the visitor's
message rides in `content` exactly once. A failed history read answers without
memory rather than 500-ing the visitor.

## Tests

79 passing across the concierge chat and admin aggregation suites, including
the four isolation cases, both bounds, the clip-not-evict case, the
failure-soft path, and no-duplicate-current-message. `ruff check`, `ruff format
--check` and both import-linter configs are green.

Verified live end to end, not only in unit tests.