### PR TITLE
Put the concierge on the site, and make the bar actually render

### DIFF
--- a/ee/pocketpaw_ee/paw_bar/agent_provisioning.py
+++ b/ee/pocketpaw_ee/paw_bar/agent_provisioning.py
@@ -1,6 +1,16 @@
 # ee/pocketpaw_ee/paw_bar/agent_provisioning.py — auto-provision a DEDICATED
 # concierge agent per Paw Site.
 #
+# Updated 2026-07-30 (feat/paw-bar-autoembed): extracted ``site_widget(pocket_id,
+# workspace_id)`` — the "which paw-bar widget belongs to this site's pocket"
+# lookup that ``provision_on_concierge_enable`` used to do inline. The publish
+# path now needs the SAME answer (to decide whether a site has earned an embedded
+# concierge bar and which widget id to put in the snippet), and two copies of a
+# tenancy-scoped lookup is exactly the kind of pair that drifts apart. Behaviour is
+# unchanged: the same workspace-scoped ``list_widgets(limit=1)``, the same
+# empty-pocket_id guard that keeps a blank pocket from widening the query onto a
+# sibling's widget.
+#
 # Created 2026-07-23 (feat/site-dedicated-agent): every site's concierge is
 # answered by an agent that exists FOR that site — never a shared/universal
 # agent. ``ensure_site_agent(site, widget)`` is idempotent: a widget already
@@ -301,6 +311,22 @@ async def provision_widget_on_create(widget: Any, workspace_id: str) -> Any:
         return widget
 
 
+async def site_widget(pocket_id: str, workspace_id: str) -> Any | None:
+    """The paw-bar widget for a site's pocket, or ``None``.
+
+    The single resolution both the provisioner and the publish-time bar embed use.
+    Workspace-scoped, and an EMPTY ``pocket_id`` returns ``None`` rather than
+    querying: an unfiltered ``list_widgets`` would widen to the workspace and hand
+    back a SIBLING site's widget (the same guard the router's
+    ``_resolve_site_and_widget`` carries). A site has at most one bar, so the limit
+    is 1.
+    """
+    if not pocket_id:
+        return None
+    widgets = await _store().list_widgets(pocket_id=pocket_id, workspace_id=workspace_id, limit=1)
+    return widgets[0] if widgets else None
+
+
 async def provision_on_concierge_enable(site: Any, workspace_id: str) -> None:
     """Concierge-enable trigger: provision the site's widget when it is unbound.
 
@@ -311,12 +337,7 @@ async def provision_on_concierge_enable(site: Any, workspace_id: str) -> None:
     an agent (manual or previously provisioned).
     """
     try:
-        if not site.pocket_id:
-            return
-        widgets = await _store().list_widgets(
-            pocket_id=site.pocket_id, workspace_id=workspace_id, limit=1
-        )
-        widget = widgets[0] if widgets else None
+        widget = await site_widget(site.pocket_id, workspace_id)
         if widget is None or getattr(widget, "agent_id", ""):
             return
         await ensure_site_agent(site, widget)
@@ -336,4 +357,5 @@ __all__ = [
     "ensure_site_agent",
     "provision_on_concierge_enable",
     "provision_widget_on_create",
+    "site_widget",
 ]

--- a/ee/pocketpaw_ee/paw_bar/embed.py
+++ b/ee/pocketpaw_ee/paw_bar/embed.py
@@ -1,0 +1,200 @@
+# ee/pocketpaw_ee/paw_bar/embed.py — grow the concierge onto a published Paw Site.
+#
+# Created 2026-07-30 (feat/paw-bar-autoembed): a site we generate, with a
+# concierge we auto-provisioned, still shipped with NO concierge on it. The bar
+# was embedded ONLY by a snippet the dashboard showed for a human to copy-paste,
+# and nothing in the publish path ever wrote it into the built HTML. This module
+# is the missing half: the ONE definition of the embed snippet, the ONE rule for
+# when a site earns one, and the injection into a built static tree that
+# ``sites.service._deploy_site_doc`` runs just before it deploys.
+#
+# Three things live here and nowhere else:
+#
+#   * ``EMBED_MARKER`` — the attribute stamped on the injected ``<script>``. It is
+#     the idempotence guard: a re-publish that finds the marker already in a page
+#     leaves it alone, so republishing a site ten times still yields exactly one
+#     script tag. Guarding on the marker (not on the whole snippet) means the guard
+#     still holds after the URL or the widget id inside the snippet changes.
+#   * ``build_embed_snippet`` — the snippet itself. Every value that reaches markup
+#     is HTML-escaped; the key and widget id are server-minted, but a value flowing
+#     into an attribute gets escaped on principle, not on provenance.
+#   * ``concierge_snippet`` — the FOUR gates a site must pass to earn a bar
+#     (concierge on, a real embed key, a paw-bar widget for the pocket, an agent
+#     bound to it). The widget lookup reuses ``agent_provisioning.site_widget`` —
+#     the same resolution the provisioner runs — rather than forking a second
+#     lookup that could drift from it.
+#
+# The script the snippet loads is the glass-bar LOADER served by
+# ``GET /paw-bar/widget.js`` (``router.paw_bar_widget_file``). It reads its config
+# off its own tag (``data-site-key`` / ``data-widget-id`` / ``data-endpoint``) and
+# mounts the concierge iframe against ``/paw-bar/frame``. The URL is derived from
+# the API base the site's own capture endpoint already uses, never a CDN host — a
+# locally served site gets a working localhost URL, and there is no second place
+# to keep in sync when the deploy moves.
+
+from __future__ import annotations
+
+import logging
+from html import escape
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Stamped on the injected script tag; the idempotence guard for a re-publish.
+EMBED_MARKER = "data-paw-bar-embed"
+
+# Path of the loader route, relative to the API base (the paw_bar router is
+# mounted under /api/v1, and ``_capture_base()`` already carries that mount, so
+# joining the two yields the real URL wherever the API is hosted).
+WIDGET_JS_PATH = "/paw-bar/widget.js"
+
+# Page suffixes the injection walks. Deliberately just HTML: the snippet is a
+# ``<script>`` tag and belongs in a document, not in a JSON/asset file.
+_HTML_SUFFIXES = (".html", ".htm")
+
+
+def widget_js_url(api_base: str) -> str:
+    """The public loader URL for an API base (``<base>/paw-bar/widget.js``)."""
+    return f"{api_base.rstrip('/')}{WIDGET_JS_PATH}"
+
+
+def build_embed_snippet(*, api_base: str, site_key: str, widget_id: str) -> str:
+    """The concierge embed snippet for one site.
+
+    ``async`` so the loader never blocks the visitor's page: the tag is written at
+    the end of ``<body>``, so ``document.body`` exists by the time it runs whether
+    the browser executes it inline or after the parse. ``data-endpoint`` is set
+    EXPLICITLY rather than left for the loader to derive from its own ``src``,
+    because the loader's fallback assumes the API is mounted at ``/api/v1`` on the
+    script's origin — true today, but the caller already knows the real base and
+    passing it removes the assumption.
+    """
+    return (
+        "<!-- Paw Bar concierge (embedded at publish) -->\n"
+        f'<script src="{escape(widget_js_url(api_base), quote=True)}" '
+        f'{EMBED_MARKER}="1" '
+        f'data-site-key="{escape(site_key, quote=True)}" '
+        f'data-widget-id="{escape(widget_id, quote=True)}" '
+        f'data-endpoint="{escape(api_base.rstrip("/"), quote=True)}" '
+        "async></script>"
+    )
+
+
+def inject_into_html(page: str, snippet: str) -> str | None:
+    """Return ``page`` with ``snippet`` before ``</body>``, or ``None`` if it is
+    already embedded.
+
+    ``None`` (rather than the unchanged page) so the caller can tell "nothing to do"
+    from "rewritten" and skip the write. The insertion point is the LAST ``</body>``
+    — a page can mention the string in an inline script or a code sample, and the
+    real closing tag is the final one. A page with no ``</body>`` at all (a
+    fragment, a hand-written partial) gets the snippet appended: a script tag at
+    the end of a document still runs.
+    """
+    if EMBED_MARKER in page:
+        return None
+    idx = page.lower().rfind("</body>")
+    if idx == -1:
+        return f"{page}\n{snippet}\n"
+    return f"{page[:idx]}{snippet}\n{page[idx:]}"
+
+
+def inject_into_tree(root: Path, snippet: str) -> list[Path]:
+    """Inject ``snippet`` into every HTML page under ``root``; return what changed.
+
+    Walks the built static tree (the SvelteKit adapter output for ripple/svelte,
+    the project root itself for html — the caller resolves which via
+    ``engines.static_output_rel``), so a multi-page site gets a concierge on every
+    page rather than only its index. A page that is already embedded, unreadable, or
+    not decodable as UTF-8 is skipped with a log line instead of aborting the walk:
+    one odd file must not cost the other pages their bar.
+    """
+    changed: list[Path] = []
+    if not root.is_dir():
+        logger.warning("paw-bar embed: no built static tree at %s — nothing to inject", root)
+        return changed
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or path.suffix.lower() not in _HTML_SUFFIXES:
+            continue
+        try:
+            page = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            logger.warning("paw-bar embed: could not read %s — skipping", path, exc_info=True)
+            continue
+        updated = inject_into_html(page, snippet)
+        if updated is None:
+            continue
+        try:
+            path.write_text(updated, encoding="utf-8")
+        except OSError:
+            logger.warning("paw-bar embed: could not write %s — skipping", path, exc_info=True)
+            continue
+        changed.append(path)
+    return changed
+
+
+async def concierge_snippet(
+    *,
+    workspace_id: str,
+    pocket_id: str,
+    site_key: str,
+    api_base: str,
+    concierge_enabled: bool,
+) -> str:
+    """The snippet this site has earned, or ``""`` when it has not.
+
+    Four gates, all of which must pass — a site that fails any of them is published
+    exactly as it was before this module existed:
+
+      1. ``concierge_enabled`` — the owner's kill switch. Off means no bar, and a
+         re-publish with it off is how an owner takes an embedded bar back off their
+         site (the marker is only ever written, never re-written, so the page it was
+         injected into is regenerated clean by the next build).
+      2. A non-empty ``site_key`` — the embed key IS the credential the loader
+         presents; without one the frame endpoint would 401 every visitor.
+      3. A paw-bar widget for the site's pocket, resolved through
+         ``agent_provisioning.site_widget`` (the provisioner's own lookup).
+      4. A non-empty ``agent_id`` on that widget — an unbound widget's chat 409s, so
+         a bar for it would render and then refuse to answer, which is worse than no
+         bar at all.
+    """
+    if not concierge_enabled or not site_key or not pocket_id:
+        return ""
+
+    from pocketpaw_ee.paw_bar.agent_provisioning import site_widget
+
+    widget = await site_widget(pocket_id, workspace_id)
+    if widget is None:
+        return ""
+    widget_id = str(getattr(widget, "id", "") or "")
+    if not widget_id or not (getattr(widget, "agent_id", "") or ""):
+        return ""
+
+    return build_embed_snippet(api_base=api_base, site_key=site_key, widget_id=widget_id)
+
+
+def deployed_host(url: str) -> str:
+    """The bare host of a deployed site URL, or ``""``.
+
+    ``origin_allowed`` matches bare, lowercased hosts (it strips scheme, port and
+    path off the inbound ``Origin`` before testing membership), so the value stored
+    on ``Site.allowed_origins`` must be that same bare shape — see
+    ``sites.service._normalize_origin_hosts``, which this feeds.
+    """
+    host = (url or "").strip().lower()
+    if "://" in host:
+        host = host.split("://", 1)[1]
+    host = host.split("/", 1)[0].split(":", 1)[0]
+    return host
+
+
+__all__ = [
+    "EMBED_MARKER",
+    "WIDGET_JS_PATH",
+    "build_embed_snippet",
+    "concierge_snippet",
+    "deployed_host",
+    "inject_into_html",
+    "inject_into_tree",
+    "widget_js_url",
+]

--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -1,4 +1,20 @@
 # ee/paw_bar/router.py — HTTP surface for the Paw Bar widget layer.
+# Updated: 2026-07-30 (feat/paw-bar-autoembed) — added GET /paw-bar/widget.js, the
+#   PUBLIC loader route. The glass bar could only ever be embedded by hand, and the
+#   snippet the dashboard printed pointed at ``https://pp.pocketpaw.dev/widget.js``
+#   — a placeholder host nobody provisioned, so even a pasted snippet 404'd. There
+#   was no way to load the bar from anywhere. This route serves the loader bundle
+#   off the SAME origin as the rest of the API, which is what lets ``sites.service``
+#   embed it into a published site automatically (see ``paw_bar/embed.py``). The
+#   file is resolved by ``paw_bar_widget_file()``: ``PAW_BAR_WIDGET_JS`` when set,
+#   else the copy vendored in this package (``static/paw-bar.js``) so the route
+#   resolves on any machine rather than depending on a sibling checkout. A missing
+#   bundle returns a clean 404 naming the env var, never a stack trace. PUBLIC by
+#   design and deliberately tenant-BLIND: it is a world-visible script served
+#   byte-identically to every visitor of every site, so it takes no key, reads no
+#   Site, and carries nothing tenant-specific — the per-site config rides on the
+#   embedding ``<script>`` tag's data attributes, and the credential check happens
+#   downstream at /paw-bar/frame.
 # Updated: 2026-07-26 (site knowledge sync) — two owner endpoints over the site's
 #   own knowledge: GET /paw-bar/admin/site/{id}/knowledge reports how many articles
 #   the concierge can quote and how the last sync went, and POST
@@ -236,7 +252,7 @@ from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request
-from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
+from fastapi.responses import HTMLResponse, JSONResponse, Response, StreamingResponse
 from pydantic import BaseModel, Field
 
 from pocketpaw.api.deps import require_scope
@@ -347,6 +363,76 @@ def _asset_version() -> str:
         except OSError:
             continue
     return str(newest)
+
+
+# ---------------------------------------------------------------------------
+# The loader bundle (GET /paw-bar/widget.js)
+#
+# The one script a foreign page loads to grow a concierge. It reads its config off
+# its own <script> tag and mounts the /paw-bar/frame iframe; everything
+# tenant-specific lives in those attributes, so this file is the same bytes for
+# every site and needs no auth. Before this existed the only advertised URL was an
+# unprovisioned CDN placeholder, which is why a published site could carry a
+# concierge and still show nothing.
+# ---------------------------------------------------------------------------
+
+# How long a browser may reuse the loader without re-asking. Short on purpose: the
+# glass app's own assets are cache-busted by ``_asset_version`` in the frame HTML,
+# but a <script src> baked into a customer's deployed page has no version stamp we
+# control, so a long max-age would pin every embedder to whatever loader shipped on
+# the day their site was published. Five minutes keeps the edge useful and keeps a
+# fix at most one coffee away.
+_WIDGET_JS_MAX_AGE = 300
+
+
+def paw_bar_widget_file() -> Path:
+    """Path of the loader bundle ``GET /paw-bar/widget.js`` serves.
+
+    ``PAW_BAR_WIDGET_JS`` wins when set — that is the seam for serving a freshly
+    built bundle (e.g. ``paw-print-widget/dist/…``) without a redeploy. Otherwise
+    the copy vendored beside this module. The default is deliberately IN the
+    package rather than an absolute path into a sibling checkout: the publish path
+    now bakes this URL into customers' deployed HTML, so it has to resolve on every
+    machine that runs the backend, not just a developer's.
+    """
+    override = os.environ.get("PAW_BAR_WIDGET_JS", "").strip()
+    if override:
+        return Path(override)
+    return Path(__file__).resolve().parent / "static" / "paw-bar.js"
+
+
+@router.get("/paw-bar/widget.js")
+async def widget_js() -> Response:
+    """Serve the glass-bar loader — PUBLIC, unauthenticated, tenant-blind.
+
+    No key, no Site read, no per-caller variation: this is a world-visible static
+    script, and the credential (the embed key) is presented later by the iframe it
+    mounts, at ``/paw-bar/frame``. Read from disk per request rather than cached in
+    memory so replacing the file takes effect without a restart — the file is a few
+    KB and the OS page cache absorbs the repeat reads.
+
+    A missing bundle is a clean 404 naming the env var that fixes it, not a
+    FileNotFoundError escaping as an opaque 500: the operator seeing this is
+    debugging why a live site shows no bar, and the message is the answer.
+    """
+    path = paw_bar_widget_file()
+    try:
+        body = path.read_bytes()
+    except OSError:
+        logger.warning("paw-bar: loader bundle unavailable at %s", path)
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                "Paw Bar loader bundle not found. Set PAW_BAR_WIDGET_JS to the "
+                "path of a built widget bundle, or restore the copy shipped at "
+                "pocketpaw_ee/paw_bar/static/paw-bar.js."
+            ),
+        ) from None
+    return Response(
+        content=body,
+        media_type="application/javascript; charset=utf-8",
+        headers={"Cache-Control": f"public, max-age={_WIDGET_JS_MAX_AGE}"},
+    )
 
 
 # A frame-ancestors host-source is host[:port] with NO scheme, path, or whitespace.

--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -467,6 +467,22 @@ def _sanitize_ancestor(raw: Any) -> str | None:
     # injection / directive split). Keep .strip() ahead of this match.
     if not _SAFE_ANCESTOR_RE.match(v):
         return None
+    # PORT (bug found 2026-07-30 by framing a real published site): a CSP
+    # host-source with NO port matches only the scheme's DEFAULT port, so a bare
+    # ``127.0.0.1`` refuses to be framed by ``http://127.0.0.1:4174`` and the bar
+    # renders as an empty grey box. ``allowed_origins`` is normalized to bare HOSTS
+    # (``_normalize_origin_hosts``), so in practice NO entry ever carries a port and
+    # every site served on a non-default port was unframeable — every local, dev and
+    # demo deploy, and any customer site not on 80/443.
+    #
+    # Emitting ``host:*`` (any port) is the fix, and it is a CONSISTENCY change
+    # rather than a loosening: the origin gate this CSP mirrors
+    # (``site_keys.origin_allowed``) compares HOSTS and ignores the port entirely,
+    # so a request from any port on an allowed host is already accepted for chat.
+    # The CSP was the stricter of the two. An entry that DOES carry an explicit port
+    # is honored as written.
+    if ":" not in v:
+        return f"{v}:*"
     return v
 
 

--- a/ee/pocketpaw_ee/paw_bar/static/paw-bar.js
+++ b/ee/pocketpaw_ee/paw_bar/static/paw-bar.js
@@ -1,0 +1,358 @@
+// ee/pocketpaw_ee/paw_bar/static/paw-bar.js — the Paw Bar glass-bar LOADER, the
+// ~7KB zero-dependency IIFE a site includes to grow a concierge.
+//
+// Vendored 2026-07-30 (feat/paw-bar-autoembed) from the paw-print-widget repo's
+// ``loader/src/loader.ts`` (branch ``feat/glass-bar``), type annotations stripped
+// — this is that file as plain ES2020, nothing added, nothing removed. It is
+// vendored rather than fetched because ``GET /paw-bar/widget.js`` must resolve to
+// a real file on ANY machine that runs the backend (a sibling checkout is not a
+// deployable dependency), and because a published Paw Site now embeds this loader
+// automatically at publish time — a missing bundle would mean a site that ships a
+// script tag pointing at a 404. ``PAW_BAR_WIDGET_JS`` overrides the path when an
+// operator wants to serve a freshly built bundle instead of this copy.
+//
+// It finds its own <script> tag, reads the embed config off it (data-site-key /
+// data-widget-id / data-endpoint), computes the host (parent) origin, and mounts
+// the concierge iframe pointing at the frame endpoint
+// (/paw-bar/frame?key=&w=&po=). The loader owns ONLY the iframe box (size +
+// position); the glass app renders INSIDE the iframe and drives the box over
+// postMessage.
+//
+// Bar-first docking: the docked resting state is a center-bottom BAR (width capped
+// at BAR_MAX_W) that the app can flip to a minimized CHIP ({pawbar:view}).
+// {pawbar:resize,h,w} sizes the docked box — height always, width only for the chip
+// (the bar width is loader policy; using the app-reported width for the bar would
+// feed back and shrink it). OPEN is a full-viewport overlay (the app draws the dim
+// backdrop + centered palette). MOVE: on {pawbar:drag,phase:start} the loader
+// snapshots the dock box, goes full-viewport, and replies {pawbar:box,x,y,w,h} so
+// the app can track the pointer; {pawbar:drag,phase:end,x,y} adopts the new anchor
+// and persists it (host localStorage) so the placement survives reloads. The anchor
+// is the box's CENTER-BOTTOM point, so the bar and the (narrower) chip stay pinned
+// to the same visual spot; a sub-DRAG_MIN_PX "drag" is a click on the grip and
+// adopts nothing (else the default-centered dock gets silently pinned).
+//
+// SECURITY: inbound messages are honoured ONLY when event.origin === the frame
+// origin AND event.source === the iframe's own contentWindow. Every outbound post
+// pins targetOrigin to the frame origin — never "*". Idempotent; exposes
+// window.PawBar = { open, close } for programmatic control.
+//
+// The whole file is wrapped in ONE outer IIFE. The TypeScript original is a
+// MODULE (it ends in ``export {}``) and esbuild bundles it ``format: 'iife'``, so
+// its constants and helpers were never global. Served raw as a classic script
+// they would be, and this loader runs on a page we do not own — a bare top-level
+// ``const clamp`` / ``function warn`` would collide with the host site's own
+// globals (and a second ``const`` of the same name is a hard SyntaxError). The
+// wrapper restores exactly the scoping the bundler gave it: the ONLY global this
+// file creates is ``window.PawBar``.
+
+(function () {
+  'use strict';
+
+  const LOADED_FLAG = '__pawBarLoaderLoaded';
+  const FRAME_PATH = '/paw-bar/frame';
+  // v2: the anchor is the box's CENTER-BOTTOM point {cx, by}, not a top-left —
+  // a top-left pins the smaller chip to the bar's left edge when views flip.
+  const POS_KEY = '__pawbar_pos_v2';
+  // Pointer travel below this is a click on the grip, not a move — adopting an
+  // anchor for it would silently pin the default-centered dock forever.
+  const DRAG_MIN_PX = 4;
+
+  // Dock policy. Heights (and the chip width) are app-reported via
+  // {pawbar:resize}; these are just the pre-report defaults and caps.
+  const BAR_MAX_W = 720;
+  const DEFAULT_BAR_H = 96;
+  const DEFAULT_CHIP = { w: 240, h: 72 };
+  const MIN_H = 48;
+  const VIEWPORT_MARGIN = 24; // keep the dock off the very edge on small screens
+
+  (function bootstrap(win) {
+    // Idempotent: a duplicate paste / double-include must be a silent no-op.
+    if (win[LOADED_FLAG]) return;
+
+    const doc = win.document;
+
+    // 1. Locate our own <script> tag and read the embed config off it.
+    const script = doc.currentScript || lastScriptWith('data-site-key', doc);
+    if (!script) return;
+
+    const siteKey = attr(script, 'data-site-key');
+    const widgetId = attr(script, 'data-widget-id');
+    if (!siteKey || !widgetId) {
+      // Missing required config — fail quietly; embedders find it in the console.
+      warn('missing data-site-key or data-widget-id');
+      return;
+    }
+
+    const endpoint = normalizeEndpoint(
+      attr(script, 'data-endpoint') || originOf(script.src) + '/api/v1',
+    );
+    let frameOrigin;
+    try {
+      frameOrigin = new URL(endpoint).origin;
+    } catch (err) {
+      warn('invalid data-endpoint');
+      return;
+    }
+
+    // Mark loaded only after the config validates, so a broken first include does
+    // not block a corrected second one.
+    win[LOADED_FLAG] = true;
+
+    // 2. The origin the iframe must post back to is the host page's origin.
+    const parentOrigin = resolveParentOrigin(win);
+
+    // 3. Build the frame URL and mount the docked iframe.
+    const src =
+      endpoint +
+      FRAME_PATH +
+      '?key=' +
+      encodeURIComponent(siteKey) +
+      '&w=' +
+      encodeURIComponent(widgetId) +
+      '&po=' +
+      encodeURIComponent(parentOrigin);
+
+    const iframe = doc.createElement('iframe');
+    iframe.title = 'Site concierge';
+    iframe.setAttribute('allow', 'clipboard-write');
+    // Inline styles are required here: the loader runs on a foreign page and must
+    // neither depend on nor inject a stylesheet. One fixed, borderless box;
+    // max-*:100v* is a CSS safety net so it can never exceed the viewport.
+    iframe.style.cssText = frameStyle();
+    iframe.src = src;
+
+    // Dock state. `anchor` is the user-chosen CENTER-BOTTOM point (null = default
+    // centered at the viewport bottom); `overlay` = panel open or mid-drag, when
+    // the iframe is the whole viewport and dock sizing must not apply. `dragFrom`
+    // is the box snapshot at drag start, for the no-move guard and coordinate
+    // conversion at drag end.
+    let view = 'bar';
+    let overlay = false;
+    let anchor = readAnchor(win);
+    let dragFrom = null;
+    const size = { bar: { h: DEFAULT_BAR_H }, chip: { w: DEFAULT_CHIP.w, h: DEFAULT_CHIP.h } };
+
+    function dockBox() {
+      const vw = win.innerWidth || 0;
+      const vh = win.innerHeight || 0;
+      const maxW = vw ? vw - VIEWPORT_MARGIN : BAR_MAX_W;
+      const w = view === 'bar' ? Math.min(BAR_MAX_W, maxW) : Math.min(size.chip.w, maxW);
+      const h = vh ? clamp(size[view].h, MIN_H, vh - VIEWPORT_MARGIN) : Math.max(MIN_H, size[view].h);
+      // Derive this box's top-left from the center-bottom anchor so bar and chip
+      // stay visually anchored to the same spot despite their different sizes.
+      const cx = anchor ? anchor.cx : (vw || w) / 2;
+      const by = anchor ? anchor.by : vh;
+      const x = clamp(Math.round(cx - w / 2), 0, Math.max(0, vw - w));
+      const y = clamp(Math.round(by - h), 0, Math.max(0, vh - h));
+      return { x: x, y: y, w: w, h: h };
+    }
+
+    function applyDock() {
+      const b = dockBox();
+      iframe.style.left = b.x + 'px';
+      iframe.style.top = b.y + 'px';
+      iframe.style.width = b.w + 'px';
+      iframe.style.height = b.h + 'px';
+    }
+
+    function goFullscreen() {
+      iframe.style.left = '0px';
+      iframe.style.top = '0px';
+      iframe.style.width = '100vw';
+      iframe.style.height = '100vh';
+    }
+
+    (doc.body || doc.documentElement).appendChild(iframe);
+    applyDock();
+
+    function postToFrame(msg) {
+      // ALWAYS pin to the frame origin — never "*".
+      const target = iframe.contentWindow;
+      if (target) target.postMessage(msg, frameOrigin);
+    }
+
+    // 4. postMessage handshake — accept ONLY messages provably from our iframe:
+    //    exact origin match AND source-identity match. Anything else is ignored.
+    win.addEventListener('message', function (ev) {
+      if (ev.origin !== frameOrigin) return;
+      if (ev.source !== iframe.contentWindow) return;
+      const data = ev.data;
+      if (!data || typeof data !== 'object') return;
+      switch (data.type) {
+        case 'pawbar:resize': {
+          if (overlay) break; // the overlay is viewport-sized; dock reports wait
+          const h = Number(data.h);
+          if (Number.isFinite(h)) size[view].h = h;
+          const w = Number(data.w);
+          // Width is honoured for the chip only — the bar width is loader policy.
+          if (view === 'chip' && Number.isFinite(w) && w > 0) size.chip.w = w;
+          applyDock();
+          break;
+        }
+        case 'pawbar:view': {
+          if (data.view === 'bar' || data.view === 'chip') {
+            view = data.view;
+            overlay = false;
+            applyDock();
+          }
+          break;
+        }
+        case 'pawbar:open':
+          overlay = true;
+          goFullscreen();
+          break;
+        case 'pawbar:close':
+          overlay = false;
+          applyDock();
+          break;
+        case 'pawbar:drag': {
+          if (data.phase === 'start') {
+            if (overlay) break;
+            const b = dockBox();
+            dragFrom = b;
+            overlay = true;
+            goFullscreen();
+            postToFrame({ type: 'pawbar:box', x: b.x, y: b.y, w: b.w, h: b.h });
+          } else if (data.phase === 'end') {
+            const x = Number(data.x);
+            const y = Number(data.y);
+            const from = dragFrom;
+            dragFrom = null;
+            const moved =
+              from && Number.isFinite(x) && Number.isFinite(y)
+                ? Math.abs(x - from.x) + Math.abs(y - from.y) >= DRAG_MIN_PX
+                : false;
+            if (from && moved) {
+              anchor = { cx: x + from.w / 2, by: y + from.h };
+              writeAnchor(win, anchor);
+            }
+            overlay = false;
+            applyDock();
+          }
+          break;
+        }
+      }
+    });
+
+    // Re-clamp the dock on rotation / resize (mobile). The overlay is vw/vh-sized
+    // and tracks the viewport by itself.
+    win.addEventListener('resize', function () {
+      if (!overlay) applyDock();
+    });
+
+    // 5. Programmatic control for embedders. Resizes the chrome the loader owns
+    //    AND forwards a pinned host-intent to the app (forward-compatible: the app
+    //    honours pawbar:host-open / pawbar:host-close).
+    win.PawBar = {
+      open: function () {
+        overlay = true;
+        goFullscreen();
+        postToFrame({ type: 'pawbar:host-open' });
+      },
+      close: function () {
+        overlay = false;
+        applyDock();
+        postToFrame({ type: 'pawbar:host-close' });
+      },
+    };
+  })(window);
+
+  // ── helpers ─────────────────────────────────────────────────────────────────
+
+  function attr(el, name) {
+    return (el.getAttribute(name) || '').trim();
+  }
+
+  function lastScriptWith(dataAttr, doc) {
+    const list = doc.querySelectorAll('script[' + dataAttr + ']');
+    return list.length ? list[list.length - 1] : null;
+  }
+
+  function originOf(url) {
+    try {
+      return new URL(url, location.href).origin;
+    } catch (err) {
+      return location.origin;
+    }
+  }
+
+  function normalizeEndpoint(ep) {
+    return ep.replace(/\/+$/, '');
+  }
+
+  function clamp(n, lo, hi) {
+    return n < lo ? lo : n > hi ? hi : n;
+  }
+
+  function readAnchor(win) {
+    try {
+      const raw = win.localStorage.getItem(POS_KEY);
+      if (!raw) return null;
+      const p = JSON.parse(raw);
+      if (Number.isFinite(p.cx) && Number.isFinite(p.by)) {
+        return { cx: p.cx, by: p.by };
+      }
+    } catch (err) {
+      /* storage denied / corrupt — fall back to the default placement */
+    }
+    return null;
+  }
+
+  function writeAnchor(win, a) {
+    try {
+      win.localStorage.setItem(POS_KEY, JSON.stringify(a));
+    } catch (err) {
+      /* storage denied — the placement just doesn't persist */
+    }
+  }
+
+  function resolveParentOrigin(win) {
+    // The iframe posts to window.parent (this loader's window); its origin is the
+    // value the frame must target. location.origin is correct in every nesting
+    // case EXCEPT a sandboxed / opaque origin ("null"), where we best-effort
+    // recover the real host origin from the ancestor chain, then the referrer.
+    const own = win.location.origin;
+    if (own && own !== 'null') return own;
+    try {
+      const ao = win.location.ancestorOrigins;
+      if (ao && ao.length && ao[0] && ao[0] !== 'null') return ao[0];
+    } catch (err) {
+      /* ancestorOrigins unsupported (Firefox) — fall through */
+    }
+    try {
+      if (win.document.referrer) {
+        const o = new URL(win.document.referrer).origin;
+        if (o && o !== 'null') return o;
+      }
+    } catch (err) {
+      /* malformed referrer — fall through */
+    }
+    return own;
+  }
+
+  function warn(msg) {
+    try {
+      console.warn('[PawBar] ' + msg);
+    } catch (err) {
+      /* no console */
+    }
+  }
+
+  function frameStyle() {
+    return [
+      'position:fixed',
+      'left:0',
+      'top:0',
+      'width:0px',
+      'height:0px',
+      'max-width:100vw',
+      'max-height:100vh',
+      'border:0',
+      'margin:0',
+      'padding:0',
+      'z-index:2147483647',
+      'color-scheme:normal',
+      'background:transparent',
+    ].join(';');
+  }
+})();

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,26 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-07-30 (feat/paw-bar-autoembed): a published site now GROWS its own
+# concierge. Until this, a site we generated with a concierge we auto-provisioned
+# went live with nothing on the page: the bar was embedded only by a snippet the
+# dashboard printed for a human to paste. ``_deploy_site_doc`` gains two steps,
+# both on the LIVE path only (a preview publish returns from ``publish`` before it
+# reaches either):
+#   * ``_embed_concierge_bar`` — between the build and the deploy, write the embed
+#     snippet into every built page (engine-aware root via ``static_output_rel``),
+#     but only for a site that has earned one: concierge on, an embed key, a
+#     paw-bar widget for the pocket, an agent bound to it. Idempotent (guarded on
+#     the snippet's marker attribute) and failure-soft — an injection problem logs
+#     and the site still deploys, because a site going live matters more than its
+#     bar. The snippet, the marker and the gates live in ``paw_bar/embed.py``.
+#   * ``_with_deployed_host`` — stamp the site's OWN deployed host onto
+#     ``allowed_origins`` (both the insert and the update branch).
+#     ``_default_allowed_origins`` seeds localhost only, so before this a visitor on
+#     the real deployed host was refused by the very origin gate the bar and the
+#     capture endpoint share. Additive, deduped, and never a wildcard or a
+#     user-supplied host — only the URL we just deployed to.
+#
 # Updated 2026-07-23 (feat/site-dedicated-agent): added the public
 # ``canonical_site_for_pocket(workspace_id, pocket_id)`` — a thin, tenant-scoped
 # wrapper over the private ``_canonical_site_doc`` so the paw-bar concierge
@@ -1990,6 +2010,19 @@ async def _deploy_site_doc(
         smoke=True,
     )
 
+    # Grow the concierge onto the built pages BEFORE they deploy, so the artifact
+    # that goes live already carries the bar. This is a LIVE-publish-only step: a
+    # preview returns from ``publish`` long before it reaches here, so a draft never
+    # gets an embedded bar pointed at the live key. Failure-soft inside.
+    await _embed_concierge_bar(
+        workspace_id=workspace_id,
+        pocket_id=pocket_id,
+        site_id=site_id,
+        signed_key=signed_key,
+        project_dir=build.project_dir,
+        engine=engine,
+    )
+
     # DS-2: a DYNAMIC site (pattern == "dynamic", or a spec carrying live
     # bindings) is backed by a per-tenant Cloudflare D1, so its deployed Worker
     # needs a D1 binding to reach that DB. Resolve the site's D1 id BEFORE deploy:
@@ -2113,8 +2146,10 @@ async def _deploy_site_doc(
             # Seed capture config so a lead lands with no manual Mongo edit: a default
             # mapping keyed on the form_type the generated endpoint sends, and the
             # local dev origins so the local smoke works. add_domain() appends the
-            # production hostname when a custom domain is connected.
-            allowed_origins=_default_allowed_origins(),
+            # production hostname when a custom domain is connected. The site's OWN
+            # deployed host goes on too — without it a visitor on the real page is
+            # refused by the origin gate the bar and the capture endpoint both run.
+            allowed_origins=_with_deployed_host(_default_allowed_origins(), url),
             event_mapping=_DEFAULT_EVENT_MAPPING,
         )
         await doc.insert()
@@ -2126,6 +2161,11 @@ async def _deploy_site_doc(
         doc.deployed = True
         doc.deployed_at = now
         doc.url = url
+        # The deploy may have moved (local → workers, or a new sites domain), so
+        # re-assert the site's own host on every publish. Idempotent and additive:
+        # a host already present is not duplicated, and a custom domain appended by
+        # ``add_domain`` is preserved (the list is only ever grown here).
+        doc.allowed_origins = _with_deployed_host(doc.allowed_origins, url)
         # charge-first: a live deploy clears any captured pending inputs — the site
         # is no longer pending payment, so the snapshot is no longer needed.
         doc.pending_deploy_inputs = {}
@@ -2145,6 +2185,101 @@ async def _deploy_site_doc(
     # (it returns earlier), so a draft never rewrites the live KB.
     _schedule_site_knowledge_sync(doc)
     return doc
+
+
+async def _embed_concierge_bar(
+    *,
+    workspace_id: str,
+    pocket_id: str,
+    site_id: str,
+    signed_key: str,
+    project_dir: str,
+    engine: str,
+) -> None:
+    """Write the concierge embed snippet into the built pages, before they deploy.
+
+    A site we generated, with a concierge we auto-provisioned, used to ship with no
+    concierge on it: the bar was embedded ONLY by a snippet the dashboard printed
+    for a human to copy-paste, and nothing here ever wrote it. This is that missing
+    step. It runs between the build and the deploy, so the artifact that goes live
+    already carries the bar — no second deploy, no post-publish patch.
+
+    ``concierge_enabled`` is read off the site's EXISTING doc, defaulting to True
+    when there is none: this is a first publish, and the doc about to be inserted
+    below carries the model's ``concierge_enabled=True`` default, so reading the
+    absent doc as "on" is what makes a brand-new site behave like the one it is
+    about to become rather than silently skipping its own first bar.
+
+    FAILURE-SOFT, and that is the whole point of the try/except: this sits in the
+    middle of a live publish. A site going live matters more than its bar, so an
+    unreadable build tree, a store that will not answer, or anything else escaping
+    here logs and lets the publish continue to deploy.
+    """
+    try:
+        from pocketpaw_ee.paw_bar import embed
+        from pocketpaw_ee.sites.engines import static_output_rel
+
+        doc = await _SiteDoc.find_one({"_id": ObjectId(site_id), "workspace": workspace_id})
+        concierge_enabled = True if doc is None else bool(doc.concierge_enabled)
+
+        snippet = await embed.concierge_snippet(
+            workspace_id=workspace_id,
+            pocket_id=pocket_id,
+            site_key=signed_key,
+            # The SAME base the generated capture endpoint posts leads to. Deriving
+            # the loader URL from it (instead of a CDN constant) is what makes a
+            # locally served site get a working localhost URL, and means there is
+            # only one env var to move when the deploy moves.
+            api_base=_capture_base(),
+            concierge_enabled=concierge_enabled,
+        )
+        if not snippet:
+            return
+
+        # HE-4: where the deployable pages live differs by engine — the SvelteKit
+        # adapter output for ripple/svelte, the project dir itself for html.
+        root = Path(project_dir, static_output_rel(engine))
+        changed = embed.inject_into_tree(root, snippet)
+        logger.info(
+            "sites: embedded the concierge bar into %d page(s) of site %s",
+            len(changed),
+            site_id,
+        )
+    except Exception:  # noqa: BLE001 — a site going live matters more than its bar
+        logger.warning(
+            "sites: could not embed the concierge bar for site %s — publishing without it",
+            site_id,
+            exc_info=True,
+        )
+
+
+def _with_deployed_host(allowed_origins: list[str], url: str) -> list[str]:
+    """Ensure a site's OWN deployed host is on its capture/concierge allowlist.
+
+    ``_default_allowed_origins`` seeds localhost only, so a site that deploys to a
+    real host had a bar its own visitors were refused by: ``resolve_site_key``'s
+    origin gate and the frame's ``frame-ancestors`` CSP both read this list, and
+    both fail closed. The host is derived from the URL WE just deployed to — never
+    from user input, never a wildcard — and appended only when missing, so a
+    re-publish does not grow the list and a connected custom domain (appended by
+    ``add_domain``) survives untouched.
+    """
+    host = _embed_deployed_host(url)
+    if not host:
+        return allowed_origins
+    hosts = _normalize_origin_hosts(allowed_origins)
+    if host not in hosts:
+        hosts.append(host)
+    return hosts
+
+
+def _embed_deployed_host(url: str) -> str:
+    """The bare host of a deployed URL. Thin indirection over ``embed.deployed_host``
+    so the host-shape rule lives with the rest of the embed logic and this module
+    keeps its lazy-import convention for reaching into paw_bar."""
+    from pocketpaw_ee.paw_bar.embed import deployed_host
+
+    return deployed_host(url)
 
 
 def _schedule_site_knowledge_sync(site: _SiteDoc) -> None:

--- a/tests/cloud/test_paw_bar_admin_aggregation.py
+++ b/tests/cloud/test_paw_bar_admin_aggregation.py
@@ -772,7 +772,11 @@ async def test_preview_frame_csp_is_dashboard_origin(client, monkeypatch):
     await store.create_widget(_widget())
     res = await c.get(f"/paw-bar/admin/site/{site.id}/preview-frame")
     assert res.status_code == 200
-    assert res.headers["content-security-policy"] == "frame-ancestors dash.example.com"
+    # The ``:*`` port comes from the frame-ancestors port fix (2026-07-30): a
+    # portless host-source matches only the default port. The REAL dashboard
+    # origin carries one (localhost:5173) and is emitted as written; this
+    # fixture omits it, so it picks up the any-port form.
+    assert res.headers["content-security-policy"] == "frame-ancestors dash.example.com:*"
     # The Site's public allowlist must NOT be the framer here.
     assert "brewco.com" not in res.headers["content-security-policy"]
 

--- a/tests/cloud/test_paw_bar_frame.py
+++ b/tests/cloud/test_paw_bar_frame.py
@@ -3,6 +3,11 @@
 # Created 2026-07-15: covers GET /paw-bar/frame (the iframe document + the CSP
 # frame-ancestors embedder gate) and the CSP/parent-origin helper functions.
 # Three layers:
+# Updated 2026-07-30 (frame-ancestors port fix): the expected header now carries a
+#   ``:*`` port on every portless entry. A CSP host-source with no port matches only
+#   the scheme's DEFAULT port, so a site served on any other port could not be framed
+#   and the bar rendered as an empty grey box. These assertions pinned that. The
+#   header-injection guard is unchanged and still covered.
 #   * Pure-function proofs (no I/O): the frame-ancestors builder emits EXACTLY the
 #     Site's allowed_origins, fails closed (None) on an empty/unusable allowlist,
 #     sanitizes header-injection attempts, and the parent-origin validator only
@@ -39,10 +44,10 @@ _FRAME_ORIGIN = "https://frame.pocketpaw.test"
 def test_frame_ancestors_emits_exactly_allowed_origins():
     from pocketpaw_ee.paw_bar.router import _frame_ancestors_csp
 
-    assert _frame_ancestors_csp(["brewco.com"]) == "frame-ancestors brewco.com"
+    assert _frame_ancestors_csp(["brewco.com"]) == "frame-ancestors brewco.com:*"
     assert (
         _frame_ancestors_csp(["brewco.com", "shop.example.com"])
-        == "frame-ancestors brewco.com shop.example.com"
+        == "frame-ancestors brewco.com:* shop.example.com:*"
     )
 
 
@@ -66,7 +71,7 @@ def test_frame_ancestors_sanitizes_header_injection():
         ["brewco.com", "evil.com; default-src *", "bad\nhost", "https://ok.example.com/path"]
     )
     # The two malformed entries are dropped; the scheme+path entry is reduced to host.
-    assert csp == "frame-ancestors brewco.com ok.example.com"
+    assert csp == "frame-ancestors brewco.com:* ok.example.com:*"
     assert ";" not in csp
     assert "\n" not in csp
 
@@ -130,7 +135,9 @@ async def test_frame_valid_key_renders_with_csp(frame_client):
     assert res.status_code == 200
     assert res.headers["content-type"].startswith("text/html")
     # The embedder gate: frame-ancestors with EXACTLY the Site's allowed_origins.
-    assert res.headers["content-security-policy"] == "frame-ancestors brewco.com shop.example.com"
+    assert (
+        res.headers["content-security-policy"] == "frame-ancestors brewco.com:* shop.example.com:*"
+    )
     body = res.text
     # The document seeds window.__PAWBAR__ before loading the app.
     assert "window.__PAWBAR__" in body

--- a/tests/cloud/test_paw_bar_widget_js.py
+++ b/tests/cloud/test_paw_bar_widget_js.py
@@ -1,0 +1,124 @@
+# tests/cloud/test_paw_bar_widget_js.py — GET /paw-bar/widget.js, the public
+# glass-bar loader route.
+# Created 2026-07-30 (feat/paw-bar-autoembed). Before this route there was no URL
+# that served the bar at all: the only one ever advertised pointed at an
+# unprovisioned CDN placeholder, so even a hand-pasted embed snippet 404'd. The
+# publish path now bakes this URL into customers' deployed HTML, which makes three
+# things worth pinning down:
+#   * it serves the bundle as JavaScript, cacheably, with NOTHING tenant-specific
+#     in it (it is one file shared by every visitor of every site — the credential
+#     is presented later, by the iframe it mounts, at /paw-bar/frame);
+#   * the path resolves from PAW_BAR_WIDGET_JS when set and from the copy vendored
+#     in the package otherwise, so a machine with no sibling checkout still serves
+#     a working loader;
+#   * a missing bundle is a clean 404 naming the fix, not a FileNotFoundError
+#     surfacing as an opaque 500 to whoever is debugging a barless site.
+# The vendored default is also syntax-relevant: it is served raw to a foreign page,
+# so the last test asserts it stays wrapped in one IIFE and keeps its globals to
+# window.PawBar.
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest_asyncio.fixture
+async def widget_client():
+    """A bare app client. The route reads no DB and needs no store — that IS the
+    contract under test, so mounting it alone is the honest harness."""
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.paw_bar.router import router
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(router)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+@pytest.mark.asyncio
+async def test_serves_the_loader_as_javascript(widget_client):
+    res = await widget_client.get("/paw-bar/widget.js")
+
+    assert res.status_code == 200
+    assert res.headers["content-type"].startswith("application/javascript")
+    assert "max-age" in res.headers["cache-control"]
+    # It is the loader, not some other asset: it mounts the concierge iframe.
+    assert "/paw-bar/frame" in res.text
+
+
+@pytest.mark.asyncio
+async def test_the_loader_carries_nothing_tenant_specific(widget_client):
+    """This one file is served byte-identically to every visitor of every site. A
+    key, a widget id or a workspace baked into it would leak across tenants; the
+    per-site config rides on the embedding <script> tag's data attributes instead."""
+    res = await widget_client.get("/paw-bar/widget.js")
+
+    body = res.text
+    assert "site_key_" not in body
+    assert "workspace" not in body.lower()
+    # It READS the config attributes; it must not contain a resolved value.
+    assert "data-site-key" in body
+
+
+@pytest.mark.asyncio
+async def test_env_override_wins(widget_client, tmp_path, monkeypatch):
+    """PAW_BAR_WIDGET_JS is the seam for serving a freshly built bundle without a
+    redeploy."""
+    custom = tmp_path / "built-widget.js"
+    custom.write_text("/* a newer build */\n", encoding="utf-8")
+    monkeypatch.setenv("PAW_BAR_WIDGET_JS", str(custom))
+
+    res = await widget_client.get("/paw-bar/widget.js")
+
+    assert res.status_code == 200
+    assert res.text == "/* a newer build */\n"
+
+
+@pytest.mark.asyncio
+async def test_missing_bundle_is_a_clean_404(widget_client, tmp_path, monkeypatch):
+    """The operator hitting this is debugging why a live site shows no bar, so the
+    message has to name the fix rather than dump a traceback."""
+    monkeypatch.setenv("PAW_BAR_WIDGET_JS", str(tmp_path / "nope.js"))
+
+    res = await widget_client.get("/paw-bar/widget.js")
+
+    assert res.status_code == 404
+    assert "PAW_BAR_WIDGET_JS" in res.json()["detail"]
+
+
+def test_default_path_is_the_vendored_copy(monkeypatch):
+    """The default must live IN the package: the publish path bakes this URL into
+    customers' HTML, so it has to resolve on every machine running the backend, not
+    only on a developer's with a sibling checkout."""
+    from pocketpaw_ee.paw_bar.router import paw_bar_widget_file
+
+    monkeypatch.delenv("PAW_BAR_WIDGET_JS", raising=False)
+    path = paw_bar_widget_file()
+
+    assert path.is_file()
+    assert path.parent.name == "static"
+    assert path.parent.parent.name == "paw_bar"
+
+
+def test_vendored_loader_keeps_its_globals_to_itself():
+    """It is served raw as a CLASSIC script onto a page we do not own. A bare
+    top-level ``const clamp`` would collide with the host site's own globals (and a
+    duplicate ``const`` is a hard SyntaxError that kills the whole file), so the
+    bundle must stay wrapped and expose only window.PawBar."""
+    from pocketpaw_ee.paw_bar.router import paw_bar_widget_file
+
+    source = paw_bar_widget_file().read_text(encoding="utf-8")
+    body = [ln for ln in source.splitlines() if ln and not ln.startswith("//")]
+
+    assert body[0].startswith("(function")
+    # Nothing declared at column 0 except the wrapper itself and its close.
+    stray = [
+        ln for ln in body[1:] if (ln.startswith(("const ", "let ", "var ", "function ", "class ")))
+    ]
+    assert stray == []
+    assert "win.PawBar" in source

--- a/tests/cloud/test_paw_bar_widget_js.py
+++ b/tests/cloud/test_paw_bar_widget_js.py
@@ -122,3 +122,39 @@ def test_vendored_loader_keeps_its_globals_to_itself():
     ]
     assert stray == []
     assert "win.PawBar" in source
+
+
+# --------------------------------------------------------------------------- #
+# frame-ancestors port matching
+#
+# Found 2026-07-30 by framing a real published site: the bar rendered as an empty
+# grey box because a CSP host-source with no port matches only the scheme's
+# DEFAULT port, so a site served on any other port could not be framed at all.
+# --------------------------------------------------------------------------- #
+
+
+def test_portless_allowlist_entry_permits_any_port():
+    """``allowed_origins`` is normalized to bare HOSTS, so without this every site
+    not on 80/443 was unframeable — every local, dev and demo deploy."""
+    from pocketpaw_ee.paw_bar.router import _frame_ancestors_csp
+
+    assert _frame_ancestors_csp(["localhost", "127.0.0.1"]) == (
+        "frame-ancestors localhost:* 127.0.0.1:*"
+    )
+
+
+def test_explicit_port_is_honored_as_written():
+    from pocketpaw_ee.paw_bar.router import _frame_ancestors_csp
+
+    assert _frame_ancestors_csp(["example.com:8443"]) == "frame-ancestors example.com:8443"
+
+
+def test_scheme_and_path_are_still_stripped_and_junk_still_dropped():
+    """The port change must not weaken the header-injection guard."""
+    from pocketpaw_ee.paw_bar.router import _frame_ancestors_csp
+
+    assert _frame_ancestors_csp(["https://shop.example.com/embed"]) == (
+        "frame-ancestors shop.example.com:*"
+    )
+    # A newline would split the header into extra directives; still refused.
+    assert _frame_ancestors_csp(["evil.example\nscript-src *"]) is None

--- a/tests/ee/sites/test_concierge_autoembed.py
+++ b/tests/ee/sites/test_concierge_autoembed.py
@@ -1,0 +1,347 @@
+# tests/ee/sites/test_concierge_autoembed.py — a published site grows its own
+# concierge.
+# Created 2026-07-30 (feat/paw-bar-autoembed). The bug this pins shut: a site we
+# generated, with a concierge we auto-provisioned, went live with an empty <head>
+# and no script tag anywhere — the bar was embedded ONLY by a snippet the dashboard
+# printed for a human to paste. Three layers, matching where it can break again:
+#   * Pure injection (no I/O): the snippet lands before </body>, a page with no
+#     </body> still gets it, a second pass is a no-op (idempotence), and a
+#     multi-page tree gets a bar on every page.
+#   * The gates: a site earns a bar only with the concierge on, an embed key, a
+#     widget for its pocket and an agent bound to that widget. The widget lookup is
+#     the provisioner's own ``site_widget``, so the two can't drift.
+#   * The publish path: a LIVE publish injects into the built tree BEFORE it
+#     deploys and stamps its own deployed host onto allowed_origins; a PREVIEW
+#     publish does neither; and an injection failure never costs the site its
+#     deploy.
+# The allowed_origins half matters as much as the snippet: ``_default_allowed_origins``
+# seeds localhost only, so a visitor on the real deployed host was refused by the
+# very origin gate the bar and the capture endpoint share — a bar that loads and
+# then can't talk is not a shipped feature.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pocketpaw_ee.paw_bar import embed
+from pocketpaw_ee.sites import service as sites_service
+
+_API_BASE = "http://localhost:8888/api/v1"
+_KEY = "site_key_" + "a" * 24
+
+
+def _snippet(widget_id: str = "w-1") -> str:
+    return embed.build_embed_snippet(api_base=_API_BASE, site_key=_KEY, widget_id=widget_id)
+
+
+# --------------------------------------------------------------------------- #
+# Layer 1 — injection (pure)
+# --------------------------------------------------------------------------- #
+
+
+def test_snippet_loads_the_loader_from_the_api_base_not_a_cdn():
+    """The URL is derived from the base the site's own capture endpoint uses, so a
+    locally served site gets a working localhost URL instead of an unprovisioned
+    CDN host."""
+    s = _snippet()
+
+    assert 'src="http://localhost:8888/api/v1/paw-bar/widget.js"' in s
+    assert "pocketpaw.dev" not in s
+    assert f'data-site-key="{_KEY}"' in s
+    assert 'data-widget-id="w-1"' in s
+    assert 'data-endpoint="http://localhost:8888/api/v1"' in s
+
+
+def test_injects_before_the_closing_body():
+    page = "<!doctype html><html><body><h1>Atlas AC</h1></body></html>"
+
+    out = embed.inject_into_html(page, _snippet())
+
+    assert out is not None
+    assert out.index("<script") < out.index("</body>")
+    assert out.endswith("</body></html>")
+
+
+def test_a_page_without_a_body_tag_still_gets_the_bar():
+    """Some generated pages are fragments. A script tag at the end of a document
+    still runs, so appending beats skipping."""
+    out = embed.inject_into_html("<h1>Atlas AC</h1>", _snippet())
+
+    assert out is not None
+    assert "paw-bar/widget.js" in out
+
+
+def test_reinjection_is_a_no_op():
+    """A re-publish must not leave two bars on the page. The guard is the marker
+    attribute, not the whole snippet, so it still holds after the URL or the widget
+    id inside the snippet changes."""
+    page = "<html><body>hi</body></html>"
+    once = embed.inject_into_html(page, _snippet())
+    assert once is not None
+
+    # Same snippet, and a DIFFERENT one — both must decline.
+    assert embed.inject_into_html(once, _snippet()) is None
+    assert embed.inject_into_html(once, _snippet("w-other")) is None
+    assert once.count("<script") == 1
+
+
+def test_every_page_in_the_tree_gets_a_bar(tmp_path):
+    root = tmp_path / "built"
+    (root / "nested").mkdir(parents=True)
+    for rel in ("index.html", "contact.html", "nested/pricing.html"):
+        (root / rel).write_text("<html><body>x</body></html>", encoding="utf-8")
+    # Not a page — must be left alone.
+    (root / "app.js").write_text("console.log('x')", encoding="utf-8")
+
+    changed = embed.inject_into_tree(root, _snippet())
+
+    assert len(changed) == 3
+    assert all(
+        "paw-bar/widget.js" in (root / r).read_text() for r in ("index.html", "contact.html")
+    )
+    assert "paw-bar" not in (root / "app.js").read_text()
+
+
+def test_a_missing_build_tree_is_survivable(tmp_path):
+    assert embed.inject_into_tree(tmp_path / "never-built", _snippet()) == []
+
+
+def test_deployed_host_reduces_a_url_to_the_bare_host():
+    """``origin_allowed`` matches bare, lowercased hosts, so what we store has to be
+    that same shape or the runtime match can never hit it."""
+    assert embed.deployed_host("https://Ridgeline.paw.dev/some/page") == "ridgeline.paw.dev"
+    assert embed.deployed_host("http://127.0.0.1:8123/site-1/") == "127.0.0.1"
+    assert embed.deployed_host("") == ""
+
+
+def test_allowlist_gains_the_deployed_host_once():
+    seeded = ["localhost", "127.0.0.1"]
+
+    once = sites_service._with_deployed_host(seeded, "https://ridgeline.paw.dev/")
+    twice = sites_service._with_deployed_host(once, "https://ridgeline.paw.dev/")
+
+    assert once == ["localhost", "127.0.0.1", "ridgeline.paw.dev"]
+    assert twice == once  # a re-publish does not grow the list
+    # A deploy with no public URL leaves the list exactly as it was.
+    assert sites_service._with_deployed_host(seeded, "") == seeded
+
+
+def test_a_connected_custom_domain_survives_a_republish():
+    """``add_domain`` appends the production hostname; a re-publish only ever GROWS
+    this list, so the domain must still be there afterwards."""
+    with_domain = ["localhost", "brewco.com"]
+
+    out = sites_service._with_deployed_host(with_domain, "https://site-1.paw.dev")
+
+    assert "brewco.com" in out
+    assert "site-1.paw.dev" in out
+
+
+# --------------------------------------------------------------------------- #
+# Layer 2 — the gates
+# --------------------------------------------------------------------------- #
+
+
+def _fake_store(monkeypatch, widget):
+    """Point the provisioner's widget lookup at a stand-in. ``embed`` resolves the
+    widget THROUGH ``agent_provisioning.site_widget``, so patching the store here is
+    also the proof that the two share one lookup."""
+    from pocketpaw_ee.paw_bar import agent_provisioning
+
+    class _Store:
+        async def list_widgets(self, *, pocket_id, workspace_id, limit):
+            self.seen = (pocket_id, workspace_id, limit)
+            return [widget] if widget is not None else []
+
+    store = _Store()
+    monkeypatch.setattr(agent_provisioning, "_store", lambda: store)
+    return store
+
+
+def _widget(**ov):
+    fields = {"id": "w-1", "agent_id": "agent-1"}
+    fields.update(ov)
+    return type("W", (), fields)()
+
+
+async def _snippet_for(monkeypatch, *, widget, **ov):
+    _fake_store(monkeypatch, widget)
+    kwargs = {
+        "workspace_id": "ws-1",
+        "pocket_id": "pocket-1",
+        "site_key": _KEY,
+        "api_base": _API_BASE,
+        "concierge_enabled": True,
+    }
+    kwargs.update(ov)
+    return await embed.concierge_snippet(**kwargs)
+
+
+@pytest.mark.asyncio
+async def test_a_bound_widget_on_an_enabled_site_earns_a_bar(monkeypatch):
+    assert 'data-widget-id="w-1"' in await _snippet_for(monkeypatch, widget=_widget())
+
+
+@pytest.mark.asyncio
+async def test_the_kill_switch_means_no_bar(monkeypatch):
+    """A re-publish with the concierge off is how an owner takes the bar back off
+    their site."""
+    assert await _snippet_for(monkeypatch, widget=_widget(), concierge_enabled=False) == ""
+
+
+@pytest.mark.asyncio
+async def test_no_widget_means_no_bar(monkeypatch):
+    assert await _snippet_for(monkeypatch, widget=None) == ""
+
+
+@pytest.mark.asyncio
+async def test_an_unbound_widget_means_no_bar(monkeypatch):
+    """An unbound widget's chat 409s. A bar that renders and then refuses to answer
+    is worse than no bar."""
+    assert await _snippet_for(monkeypatch, widget=_widget(agent_id="")) == ""
+
+
+@pytest.mark.asyncio
+async def test_no_embed_key_means_no_bar(monkeypatch):
+    """The key IS the credential the loader presents; without one the frame endpoint
+    401s every visitor."""
+    assert await _snippet_for(monkeypatch, widget=_widget(), site_key="") == ""
+
+
+@pytest.mark.asyncio
+async def test_an_empty_pocket_never_widens_onto_a_sibling(monkeypatch):
+    """An unfiltered list_widgets would reach across the workspace and hand back
+    another site's widget."""
+    store = _fake_store(monkeypatch, _widget())
+
+    out = await embed.concierge_snippet(
+        workspace_id="ws-1",
+        pocket_id="",
+        site_key=_KEY,
+        api_base=_API_BASE,
+        concierge_enabled=True,
+    )
+
+    assert out == ""
+    assert not hasattr(store, "seen")  # the store was never queried
+
+
+# --------------------------------------------------------------------------- #
+# Layer 3 — the publish path
+# --------------------------------------------------------------------------- #
+
+
+class _FakeGenerator:
+    """Writes a real two-page static tree so the injection has something to walk."""
+
+    def __init__(self, project_dir: Path, engine: str = "ripple"):
+        self.project_dir = project_dir
+        self.engine = engine
+
+    async def build(self, **kw):
+        from pocketpaw_ee.sites.engines import static_output_rel
+        from pocketpaw_ee.sites.generator_client import BuildResult
+
+        out = Path(self.project_dir, static_output_rel(self.engine))
+        out.mkdir(parents=True, exist_ok=True)
+        for rel in ("index.html", "contact.html"):
+            (out / rel).write_text(
+                "<!doctype html><html><body><h1>Ridgeline HVAC</h1></body></html>",
+                encoding="utf-8",
+            )
+        return BuildResult(project_dir=str(self.project_dir), ripple_version="0.2.0")
+
+
+async def _publish(tmp_path, *, preview: bool = False, deploy_url: str = "https://site-1.paw.dev"):
+    return await sites_service.publish(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id="pocket-1",
+        ripple_spec={"type": "container"},
+        theme={},
+        name="Ridgeline HVAC",
+        preview=preview,
+        _generator=_FakeGenerator(tmp_path / "project"),
+        _cloudflare=None,
+        _bundle_reader=lambda d: b"x",
+        _local_deploy=lambda site_id, project_dir: deploy_url,
+    )
+
+
+def _built_pages(tmp_path) -> list[str]:
+    root = tmp_path / "project" / ".svelte-kit" / "cloudflare"
+    return [p.read_text(encoding="utf-8") for p in sorted(root.glob("*.html"))]
+
+
+@pytest.mark.asyncio
+async def test_a_live_publish_embeds_the_bar_into_every_built_page(
+    beanie_test_db, tmp_path, monkeypatch
+):
+    monkeypatch.setenv("PAW_SITES_LOCAL", "1")
+    _fake_store(monkeypatch, _widget())
+
+    await _publish(tmp_path)
+
+    pages = _built_pages(tmp_path)
+    assert len(pages) == 2
+    for page in pages:
+        assert "/paw-bar/widget.js" in page
+        assert page.index("<script") < page.index("</body>")
+
+
+@pytest.mark.asyncio
+async def test_a_live_publish_allows_its_own_deployed_host(beanie_test_db, tmp_path, monkeypatch):
+    """Without this the bar loads on the real page and is then refused by the origin
+    gate — the site's own visitors look like strangers."""
+    monkeypatch.setenv("PAW_SITES_LOCAL", "1")
+    _fake_store(monkeypatch, _widget())
+
+    site = await _publish(tmp_path, deploy_url="https://ridgeline.paw.dev/")
+
+    assert "ridgeline.paw.dev" in site.allowed_origins
+    assert "localhost" in site.allowed_origins  # the seeded dev hosts survive
+
+
+@pytest.mark.asyncio
+async def test_republishing_does_not_stack_bars_or_hosts(beanie_test_db, tmp_path, monkeypatch):
+    monkeypatch.setenv("PAW_SITES_LOCAL", "1")
+    _fake_store(monkeypatch, _widget())
+
+    await _publish(tmp_path)
+    site = await _publish(tmp_path)
+
+    assert _built_pages(tmp_path)[0].count("<script") == 1
+    assert site.allowed_origins.count("site-1.paw.dev") == 1
+
+
+@pytest.mark.asyncio
+async def test_a_preview_publish_never_embeds(beanie_test_db, tmp_path, monkeypatch):
+    """A preview is a draft nobody approved. Baking the live embed key into it would
+    put a working concierge on an unreviewed page."""
+    monkeypatch.setenv("PAW_SITES_LOCAL", "1")
+    _fake_store(monkeypatch, _widget())
+
+    await _publish(tmp_path, preview=True)
+
+    assert all("paw-bar/widget.js" not in page for page in _built_pages(tmp_path))
+
+
+@pytest.mark.asyncio
+async def test_a_broken_injection_never_costs_the_site_its_deploy(
+    beanie_test_db, tmp_path, monkeypatch
+):
+    """This runs mid-publish. A site going live matters more than its bar, so an
+    injection that blows up must log and let the deploy through."""
+    monkeypatch.setenv("PAW_SITES_LOCAL", "1")
+    _fake_store(monkeypatch, _widget())
+
+    def _boom(root, snippet):
+        raise RuntimeError("disk gone")
+
+    monkeypatch.setattr(embed, "inject_into_tree", _boom)
+
+    site = await _publish(tmp_path)
+
+    assert site.deployed is True
+    assert all("paw-bar/widget.js" not in page for page in _built_pages(tmp_path))


### PR DESCRIPTION
DEMO-CRITICAL. Stacked on `feat/concierge-knowledge-and-transcripts`
(#1797), so review this diff alone.

## A published site had no concierge on it

I framed a real deployed demo site in a browser. `document.querySelectorAll('script')`
came back **empty**, `window.__PAWBAR__` undefined, head just charset and title.
A site we generate, with a concierge we auto-provision, shipped without it.

Three causes, all confirmed:

1. The bar was embedded ONLY by a snippet the dashboard showed a human to
   copy-paste.
2. That snippet's script URL was `PAW_BAR_CDN_URL`, whose fallback is
   `https://pp.pocketpaw.dev/widget.js` — a host the code comment itself says is
   not provisioned. A pasted snippet would have 404'd.
3. Nothing in the publish path ever wrote the snippet into the built HTML.

So: the loader is now served by the backend at `GET /paw-bar/widget.js`, and a
live publish injects the snippet into every built HTML page when the site earns
one (concierge on, real embed key, a widget for the pocket, an agent bound). The
script URL derives from the API base the site's own capture endpoint already
uses, never a CDN host, so a locally served site gets a working local URL and
there is no second place to keep in sync. Injection is idempotent on a marker
attribute, skipped entirely for a preview publish, and failure-soft — a site
going live matters more than its bar. A live publish also adds the site's OWN
deployed host to its `allowed_origins`, never a wildcard.

## Then the bar rendered as an empty grey box

Worth reading even if you skip the rest, because it is one character and it
would have been very hard to spot on a shoot day.

The bar mounted, sized itself and docked correctly, and showed nothing. The
frame endpoint returned 200 with valid HTML and every asset resolved. Server
side, nothing looked wrong.

A CSP host-source **with no port matches only the scheme's default port**. So
`frame-ancestors 127.0.0.1` refuses to be framed by `http://127.0.0.1:4174`.
`allowed_origins` is normalized to bare hosts, so no entry ever carried a port,
which means **every site served anywhere other than 80 or 443 was unframeable** —
every local, dev and demo deploy, and any customer site on a non-standard port.

Portless entries now emit `host:*`. That is a consistency fix, not a loosening:
the origin gate this CSP mirrors (`site_keys.origin_allowed`) compares hosts and
ignores the port, so any port on an allowed host was already accepted for chat.
The CSP was the stricter of the two. Explicit ports are honored as written and
the header-injection guard is untouched.

Four assertions pinned the old string, including the owner preview frame's. The
real dashboard origin carries a port, which is why the owner preview kept
working while the public bar never did.

## Verified in a browser, not only in tests

After the fix, on a real published site: the glass bar renders docked
center-bottom with its live dot and input, and a chat from the site's own origin
returns a properly grounded answer — real hours, the after-hours fee, the
service email, all from the site's own pages.

## Tests

636 passing across the sites, frame, widget-loader, concierge chat, settings,
admin aggregation and site-key suites. `ruff check`, `ruff format --check` and
both import-linter configs green.

## One thing to know before shooting

The bar and the API must be same-scheme as the page. A site on HTTPS
`workers.dev` cannot load an HTTP localhost loader or reach an HTTP localhost
API — the browser blocks both as mixed content. Shoot the local publish, or
provision public hosting for the loader and the API.