### PR TITLE
Paw Bar: email the decision to visitors who leave the page

### DIFF
--- a/docs/concepts/concierge-knowledge.mdx
+++ b/docs/concepts/concierge-knowledge.mdx
@@ -134,3 +134,26 @@ decision about whether the site keeps a record of its visitors, not two.
 
 If the record cannot be read for any reason, the concierge answers without memory
 rather than failing the visitor's chat.
+
+## When the visitor leaves the page
+
+Some requests need a human decision, and humans take longer than a browser tab
+stays open. While a request is pending, the visitor can leave an email address
+(`POST /paw-bar/decision-contact`, guarded by the same key, origin and rate
+gates as the chat itself). When the owner approves or declines, the visitor is
+sent one email carrying exactly the reply the on-page poll would have shown —
+no more, no less — with a subject that names the site.
+
+The address is handled as narrowly as possible:
+
+- It is stored **only** on the pending decision rows it was left for. It never
+  enters the agent's context, the knowledge base, transcripts, or the proposal
+  the owner reviews, and no public endpoint ever returns it — the decision poll
+  response does not carry it.
+- One decision, one email. An approval that is re-delivered later (a retry, a
+  sweep) does not send again.
+- Email is best-effort on top of the poll, never instead of it. If no SMTP
+  transport is configured (`POCKETPAW_SMTP_HOST`, `POCKETPAW_SMTP_PORT`,
+  `POCKETPAW_SMTP_USER`, `POCKETPAW_SMTP_PASSWORD`, `POCKETPAW_SMTP_FROM`,
+  with STARTTLS on by default) or a send fails, the decision still lands on the
+  poll endpoint and the approve/reject flow is unaffected.

--- a/ee/pocketpaw_ee/paw_bar/decision_loop.py
+++ b/ee/pocketpaw_ee/paw_bar/decision_loop.py
@@ -1,4 +1,14 @@
 # ee/paw_bar/decision_loop.py — Close the customer decision loop via Instinct.
+# Updated: 2026-07-30 (async decision delivery) — deliver_customer_decision now
+#   closes the loop for a visitor who LEFT the page: if the flipped row carries
+#   a ``contact_email`` (attached via POST /paw-bar/decision-contact while the
+#   row was pending), it sends ONE email with the SAME customer-facing reply
+#   the poll returns. Sent only on the PENDING → decided transition (the prior
+#   row state is read before the flip), so an approve replay / re-delivery
+#   never re-sends. Fail-soft via paw_bar.mailer — a mail failure (or no SMTP
+#   transport at all) logs and moves on; the poll delivery is untouched. The
+#   email address never leaves the DecisionStatus row (PII invariant — see
+#   models.DecisionStatus.contact_email).
 # Updated: 2026-07-30 (visitor-reply leak) — both proposal paths pre-filled
 #   ``recommendation`` with the OWNER-facing framing ("A visitor (ref …) asked …
 #   untrusted input … Suggested reply: …"), and deliver_customer_decision sends
@@ -538,6 +548,10 @@ async def deliver_customer_decision(action: Any, *, declined: bool = False) -> N
         blob_workspace = str(blob.get("workspace_id") or "") or None
 
         store = get_paw_bar_store()
+        # Read the PRIOR state before flipping: the async email below fires only
+        # on the PENDING → decided transition, so a re-delivery / approve replay
+        # (prior state already delivered/declined) never re-sends.
+        prior = await store.get_decision_by_action(action_id, workspace_id=blob_workspace)
         updated = await store.set_decision(
             action_id,
             state=state,
@@ -559,6 +573,31 @@ async def deliver_customer_decision(action: Any, *, declined: bool = False) -> N
             updated.widget_id,
             updated.customer_ref,
         )
+
+        # Async half of the loop: the visitor left the page and parked an email
+        # on the pending row (POST /paw-bar/decision-contact). Send them the
+        # SAME customer-facing reply the poll returns — approved or declined —
+        # exactly once (guarded on the state transition above). Best-effort:
+        # the mailer is fail-soft and this whole block must never break the
+        # approve/reject response.
+        if prior is not None and prior.state == DecisionState.PENDING and updated.contact_email:
+            try:
+                from pocketpaw_ee.paw_bar import mailer
+
+                widget = await store.get_widget(updated.widget_id)
+                site_name = str(getattr(widget, "name", "") or "") or "the site"
+                await mailer.send_decision_email(
+                    updated.contact_email,
+                    f"Update from {site_name}",
+                    updated.reply,
+                )
+            except Exception:  # noqa: BLE001 — mail is best-effort over delivery
+                logger.warning(
+                    "async decision email failed for action %s — the decision "
+                    "is still readable on the poll endpoint",
+                    action_id,
+                    exc_info=True,
+                )
     except Exception:  # noqa: BLE001 — delivery is best-effort over approve/reject
         logger.warning(
             "failed to deliver customer decision for action %s — the parked row "

--- a/ee/pocketpaw_ee/paw_bar/mailer.py
+++ b/ee/pocketpaw_ee/paw_bar/mailer.py
@@ -1,0 +1,87 @@
+# ee/paw_bar/mailer.py — Minimal, fail-soft SMTP sender for the Paw Bar
+# async decision delivery (2026-07-30).
+# Created: 2026-07-30 — pocketpaw has no system-owned outbound email transport
+#   (the Gmail client is a user-scoped OAuth tool, not ours to send from), so
+#   this module is a deliberately tiny SMTP sender used ONLY by the decision
+#   delivery hook. Env-driven, no config-module coupling:
+#     POCKETPAW_SMTP_HOST      — SMTP server hostname (unset → transport off)
+#     POCKETPAW_SMTP_PORT      — port (default 587)
+#     POCKETPAW_SMTP_USER      — auth username (optional; no user → no login)
+#     POCKETPAW_SMTP_PASSWORD  — auth password (optional)
+#     POCKETPAW_SMTP_FROM      — the From address (unset → transport off)
+#     POCKETPAW_SMTP_STARTTLS  — "1" (default) upgrades via STARTTLS; "0" off
+#   FAIL-SOFT is the contract: no transport configured → one warning log and
+#   False; a send error → warning and False. Nothing here ever raises into the
+#   caller — a mail failure must never break an approve/reject, and the on-page
+#   decision poll keeps working regardless.
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import smtplib
+from email.message import EmailMessage
+
+logger = logging.getLogger(__name__)
+
+
+def smtp_configured() -> bool:
+    """True when the minimum viable transport (host + from) is present."""
+    return bool(os.environ.get("POCKETPAW_SMTP_HOST")) and bool(
+        os.environ.get("POCKETPAW_SMTP_FROM")
+    )
+
+
+def _send_sync(to_addr: str, subject: str, body: str) -> None:
+    """Blocking SMTP send — run via ``asyncio.to_thread`` from the async path."""
+    host = os.environ["POCKETPAW_SMTP_HOST"]
+    port = int(os.environ.get("POCKETPAW_SMTP_PORT", "587") or "587")
+    user = os.environ.get("POCKETPAW_SMTP_USER", "")
+    password = os.environ.get("POCKETPAW_SMTP_PASSWORD", "")
+    sender = os.environ["POCKETPAW_SMTP_FROM"]
+    starttls = os.environ.get("POCKETPAW_SMTP_STARTTLS", "1") != "0"
+
+    msg = EmailMessage()
+    msg["From"] = sender
+    msg["To"] = to_addr
+    msg["Subject"] = subject
+    msg.set_content(body)
+
+    with smtplib.SMTP(host, port, timeout=15) as smtp:
+        if starttls:
+            smtp.starttls()
+        if user:
+            smtp.login(user, password)
+        smtp.send_message(msg)
+
+
+async def send_decision_email(to_addr: str, subject: str, body: str) -> bool:
+    """Send one plain-text email; return True on success, False otherwise.
+
+    Fail-soft by contract: an unconfigured transport logs a warning and returns
+    False; so does any transport error. Never raises. The recipient address is
+    visitor PII — it is logged only in redacted form (local-part hidden).
+    """
+    if not smtp_configured():
+        logger.warning(
+            "paw-bar decision email skipped — no SMTP transport configured "
+            "(set POCKETPAW_SMTP_HOST + POCKETPAW_SMTP_FROM to enable async "
+            "delivery; the on-page decision poll still works)"
+        )
+        return False
+    try:
+        await asyncio.to_thread(_send_sync, to_addr, subject, body)
+        return True
+    except Exception:  # noqa: BLE001 — fail-soft: mail must never break the approve
+        domain = to_addr.rsplit("@", 1)[-1] if "@" in to_addr else "<invalid>"
+        logger.warning(
+            "paw-bar decision email send failed (recipient domain %s) — the "
+            "decision was still delivered on the poll endpoint",
+            domain,
+            exc_info=True,
+        )
+        return False
+
+
+__all__ = ["send_decision_email", "smtp_configured"]

--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -1,4 +1,11 @@
 # ee/paw_bar/router.py — HTTP surface for the Paw Bar widget layer.
+# Updated: 2026-07-30 (async decision delivery) — added POST
+#   /paw-bar/decision-contact: a visitor whose request is still PENDING leaves
+#   an optional email before closing the tab; the delivery hook later emails
+#   them the same customer-facing reply the poll returns. Same fail-closed
+#   armor as chat/action via the shared ``_front_gate_for_key``; email is
+#   validated (RFC-ish regex + 254 cap → 422), stamped onto PENDING rows only,
+#   and NEVER echoed back on any public read (the poll response omits it).
 # Updated: 2026-07-30 (feat/paw-bar-autoembed) — added GET /paw-bar/widget.js, the
 #   PUBLIC loader route. The glass bar could only ever be embedded by hand, and the
 #   snippet the dashboard printed pointed at ``https://pp.pocketpaw.dev/widget.js``
@@ -2745,6 +2752,88 @@ async def get_cart(
         logger.debug("cart-read marker record failed (non-fatal)", exc_info=True)
     cart = await store.get_cart(w, customer_ref)
     return JSONResponse(cart_wire(widget, customer_ref, cart))
+
+
+# ---------------------------------------------------------------------------
+# Async decision delivery (2026-07-30) — the visitor who leaves the page
+#
+# The decision loop's on-page half is the poll endpoint above; this is the
+# async half. A visitor whose request is still PENDING can leave an email
+# before closing the tab; when the owner decides, the delivery hook emails
+# them the SAME customer-facing reply the poll would have shown. Same armor
+# class as /paw-bar/chat via the shared ``_front_gate_for_key``. The email is
+# row-only PII (see models.DecisionStatus.contact_email) and is NEVER echoed
+# back by any public read — the decision poll response omits it by shape.
+# ---------------------------------------------------------------------------
+
+# Simple RFC-ish shape check — one local part, one @, a dotted domain. The
+# 254-char cap is the SMTP path limit; anything longer is refused outright.
+_CONTACT_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+_MAX_CONTACT_EMAIL_CHARS = 254
+
+
+class DecisionContactRequest(BaseModel):
+    widget_id: str
+    # The public, origin-bound embed key (Site.signed_key) — same credential
+    # model as ConciergeChatRequest; there is no signed-in user.
+    signed_key: str
+    customer_ref: str
+    email: str
+
+
+@router.post("/paw-bar/decision-contact")
+async def post_decision_contact(body: DecisionContactRequest, request: Request) -> JSONResponse:
+    """Attach a contact email to this visitor's PENDING decision rows.
+
+    Gates mirror ``concierge_chat`` via the shared ``_front_gate_for_key``
+    (fail-closed, cheap gates first): widget exists (404) → rate limit (429) →
+    embed-key auth + dual-mode origin gate (401/403) → widget∩key binding
+    (403). Then the email is validated (422) and stamped onto the visitor's
+    pending rows only — a decided row was already answered on-page. Returns
+    ``{ok: true, attached: N}``; the address itself is never echoed back here
+    or on any other public read.
+    """
+    origin = request.headers.get("origin")
+    widget, _ctx = await _front_gate_for_key(
+        widget_id=body.widget_id,
+        signed_key=body.signed_key,
+        customer_ref=body.customer_ref,
+        origin=origin,
+        request=request,
+    )
+
+    email = body.email.strip()
+    if len(email) > _MAX_CONTACT_EMAIL_CHARS or not _CONTACT_EMAIL_RE.match(email):
+        raise HTTPException(422, "invalid_email")
+
+    store = _store()
+    # Record a marker so contact posts count toward the shared rate limiter
+    # (the front gate only CHECKS the limit). Payload stays EMPTY — the email
+    # must never land in the event log (PII invariant). Best-effort.
+    try:
+        await store.record_event(
+            PawBarEvent(
+                widget_id=widget.id,
+                type="pawbar_decision_contact",
+                payload={},
+                customer_ref=body.customer_ref,
+            )
+        )
+    except Exception:
+        logger.debug("decision-contact marker record failed (non-fatal)", exc_info=True)
+
+    # Scope the write with the same workspace value the decision rows were
+    # stamped with at propose time (decision_loop.resolve_workspace_id — the
+    # widget's real workspace, or the owner label for a legacy row).
+    from pocketpaw_ee.paw_bar.decision_loop import resolve_workspace_id
+
+    attached = await store.attach_contact_email(
+        widget.id,
+        body.customer_ref,
+        email,
+        workspace_id=resolve_workspace_id(widget) or None,
+    )
+    return JSONResponse({"ok": True, "attached": attached})
 
 
 # ---------------------------------------------------------------------------

--- a/src/pocketpaw/paw_bar/models.py
+++ b/src/pocketpaw/paw_bar/models.py
@@ -1,4 +1,9 @@
 # ee/paw_bar/models.py — Pydantic models for the Paw Bar widget layer.
+# Updated: 2026-07-30 (async decision delivery) — DecisionStatus gains an
+#   optional ``contact_email`` (empty default). A visitor who leaves the page
+#   while their request is PENDING can leave an email; when the owner decides,
+#   the delivery hook sends the same customer-facing reply there. PII posture:
+#   the email lives ONLY on this row — see the field comment.
 # Updated: 2026-07-16 (Paw Bar action registry, C1) — the visitor-commerce
 #   vocabulary. PawBarSpec gains three optional fields: ``actions`` (declared
 #   verbs: {verb, policy in {auto,gated}, args flat-type-map, label}), ``catalog``
@@ -442,6 +447,14 @@ class DecisionStatus(BaseModel):
     state: DecisionState = DecisionState.PENDING
     reply: str = ""
     decided_by: str = ""
+    # PII INVARIANT (binding): the visitor's optional contact email lives ONLY
+    # on this DecisionStatus row. It must never be copied into the Instinct
+    # Action / its ``_customer_reply`` blob, the agent's context, the KB,
+    # transcripts, or the soul — and it is never echoed back by any public
+    # read (the decision poll response omits it). Storage is capped here at
+    # the row level; the only consumer is the one-shot email the delivery
+    # hook sends when the row flips out of PENDING.
+    contact_email: str = ""
     created_at: datetime = Field(default_factory=datetime.now)
     updated_at: datetime = Field(default_factory=datetime.now)
 

--- a/src/pocketpaw/paw_bar/store.py
+++ b/src/pocketpaw/paw_bar/store.py
@@ -1,4 +1,12 @@
 # ee/paw_bar/store.py — Async SQLite store for Paw Bar widgets and events.
+# Updated: 2026-07-30 (async decision delivery) — paw_bar_decisions gains a
+#   contact_email TEXT DEFAULT '' column (additive: SCHEMA_SQL for fresh DBs +
+#   _migrate_columns ALTER for deployed ones, same pattern as workspace_id).
+#   New attach_contact_email(widget_id, customer_ref, email, workspace_id):
+#   stamps the email onto that visitor's PENDING rows only (a decided row is
+#   already answered on-page) and returns the count. set_decision deliberately
+#   does NOT touch the column, so the delivery hook can read it off the flipped
+#   row. The email is row-only PII — see the DecisionStatus field comment.
 # Updated: 2026-07-16 (D2 owner aggregation reads) — added two widget-keyed
 #   decision reads for the per-site Concierge dashboard: list_decisions_for_widget
 #   (recent decisions for ONE widget, newest first) and count_pending_decisions
@@ -132,6 +140,7 @@ CREATE TABLE IF NOT EXISTS paw_bar_decisions (
     state TEXT DEFAULT 'pending',
     reply TEXT DEFAULT '',
     decided_by TEXT DEFAULT '',
+    contact_email TEXT DEFAULT '',
     created_at TEXT DEFAULT (datetime('now')),
     updated_at TEXT DEFAULT (datetime('now'))
 );
@@ -252,13 +261,15 @@ class PawBarStore:
                     await db.execute(
                         f"ALTER TABLE paw_bar_widgets ADD COLUMN {name} TEXT DEFAULT ''"
                     )
-        # paw_bar_decisions: workspace_id (W4a) — the decision-scope reads need it.
-        if "paw_bar_decisions" in existing and "workspace_id" not in await _columns(
-            "paw_bar_decisions"
-        ):
-            await db.execute(
-                "ALTER TABLE paw_bar_decisions ADD COLUMN workspace_id TEXT DEFAULT ''"
-            )
+        # paw_bar_decisions: workspace_id (W4a) — the decision-scope reads need
+        # it — and contact_email (2026-07-30 async delivery).
+        if "paw_bar_decisions" in existing:
+            cols = await _columns("paw_bar_decisions")
+            for name in ("workspace_id", "contact_email"):
+                if name not in cols:
+                    await db.execute(
+                        f"ALTER TABLE paw_bar_decisions ADD COLUMN {name} TEXT DEFAULT ''"
+                    )
 
     def _conn(self) -> aiosqlite.Connection:
         return aiosqlite.connect(self._db_path)
@@ -583,8 +594,9 @@ class PawBarStore:
             await db.execute(
                 "INSERT INTO paw_bar_decisions"
                 " (id, widget_id, customer_ref, event_type, instinct_action_id,"
-                " workspace_id, state, reply, decided_by, created_at, updated_at)"
-                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                " workspace_id, state, reply, decided_by, contact_email,"
+                " created_at, updated_at)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     decision.id,
                     decision.widget_id,
@@ -595,6 +607,7 @@ class PawBarStore:
                     decision.state.value,
                     decision.reply,
                     decision.decided_by,
+                    decision.contact_email,
                     decision.created_at.isoformat(),
                     decision.updated_at.isoformat(),
                 ),
@@ -677,6 +690,42 @@ class PawBarStore:
             await db.execute(sql, params)
             await db.commit()
         return await self.get_decision_by_action(instinct_action_id, workspace_id=workspace_id)
+
+    async def attach_contact_email(
+        self,
+        widget_id: str,
+        customer_ref: str,
+        email: str,
+        workspace_id: str | None = None,
+    ) -> int:
+        """Stamp a contact email onto this visitor's PENDING decision rows.
+
+        The async half of the decision loop: a visitor who is about to leave the
+        page leaves an email; when the owner later decides, the delivery hook
+        reads it off the flipped row and sends the same customer-facing reply
+        there. Only ``state = 'pending'`` rows are touched — a decided row was
+        already answered on-page and re-stamping it would re-arm nothing.
+
+        ``workspace_id``, when supplied, scopes the UPDATE with the same tenancy
+        fragment as every other decision write (legacy ''/NULL rows still
+        match), so a cross-tenant (widget, customer) pair flips nothing.
+        Returns the number of rows stamped. PII posture: the email lives ONLY
+        on these rows — see the ``DecisionStatus.contact_email`` comment.
+        """
+        ws_cond, ws_params = _decision_workspace_scope(workspace_id)
+        sql = (
+            "UPDATE paw_bar_decisions SET contact_email = ?, updated_at = ?"
+            " WHERE widget_id = ? AND customer_ref = ? AND state = 'pending'"
+        )
+        params: list[Any] = [email, datetime.now().isoformat(), widget_id, customer_ref]
+        if ws_cond:
+            sql += f" AND {ws_cond}"
+            params.extend(ws_params)
+        await self._ensure_schema()
+        async with self._conn() as db:
+            cur = await db.execute(sql, params)
+            await db.commit()
+            return cur.rowcount or 0
 
     async def get_latest_decision(self, widget_id: str, customer_ref: str) -> DecisionStatus | None:
         """Return the most-recent decision for a (widget, customer) pair.
@@ -879,6 +928,7 @@ class PawBarStore:
             state=DecisionState(row["state"]),
             reply=row["reply"] or "",
             decided_by=row["decided_by"] or "",
+            contact_email=row["contact_email"] or "",
             created_at=datetime.fromisoformat(row["created_at"]),
             updated_at=datetime.fromisoformat(row["updated_at"]),
         )

--- a/tests/cloud/test_paw_bar_decision_contact.py
+++ b/tests/cloud/test_paw_bar_decision_contact.py
@@ -1,0 +1,532 @@
+# tests/cloud/test_paw_bar_decision_contact.py — the async half of the Paw Bar
+# decision loop (2026-07-30).
+# Created: 2026-07-30 — a visitor who leaves the page while their request is
+# PENDING can leave an email (POST /paw-bar/decision-contact); when the owner
+# decides, deliver_customer_decision emails them the SAME customer-facing reply
+# the on-page poll returns. Layers:
+#   * The public endpoint (httpx + mongomock Site) — shares the concierge armor
+#     via _front_gate_for_key: bad key 401, wrong origin 403, sibling pocket
+#     403, over-limit 429, unknown widget 404, malformed/oversized email 422;
+#     a good post stamps PENDING rows only and returns {ok, attached: N}.
+#   * PII posture — the decision poll response NEVER carries the email, and the
+#     attach response never echoes it back.
+#   * Delivery — a stubbed sender proves exactly ONE email per decision on the
+#     PENDING → decided transition (approve AND reject), no re-send on an
+#     approve replay, no send without an attached email.
+#   * Fail-soft — with no SMTP transport configured the real mailer returns
+#     False, nothing raises, and the row still flips (the poll keeps working).
+#
+# asyncio_mode = "auto" (see pyproject) → async tests need no per-test marker.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from pocketpaw_ee.paw_bar.decision_loop import (
+    deliver_customer_decision,
+    propose_customer_decision,
+)
+
+from pocketpaw.instinct.store import InstinctStore
+from pocketpaw.paw_bar.models import (
+    DecisionState,
+    DecisionStatus,
+    PawBarBlock,
+    PawBarEvent,
+    PawBarSpec,
+    PawBarWidget,
+)
+from pocketpaw.paw_bar.store import PawBarStore
+
+_VALID_KEY = "site_key_" + "a" * 24
+_ORIGIN = "https://brewco.com"
+_CUST = "cust-0001"
+_EMAIL = "visitor@example.com"
+
+
+def _spec(pocket_id: str = "pocket-1") -> PawBarSpec:
+    return PawBarSpec(
+        widget_id="pp_seed",
+        pocket_id=pocket_id,
+        blocks=[PawBarBlock(type="text", content="Brew & Co")],
+    )
+
+
+def _widget(**ov: Any) -> PawBarWidget:
+    d: dict[str, Any] = dict(
+        pocket_id="pocket-1",
+        owner="user:maya",
+        name="Brew & Co",
+        spec=_spec(),
+        allowed_domains=["brewco.com"],
+        agent_id="agent-xyz",
+        workspace_id="ws-1",
+    )
+    d.update(ov)
+    return PawBarWidget(**d)
+
+
+async def _site(**ov: Any):
+    from pocketpaw_ee.cloud.models.site import Site
+
+    d = dict(
+        workspace="ws-1",
+        pocket_id="pocket-1",
+        owner="user:maya",
+        script_name="",
+        signed_key=_VALID_KEY,
+        allowed_origins=["brewco.com"],
+    )
+    d.update(ov)
+    s = Site(**d)
+    await s.insert()
+    return s
+
+
+def _pending_row(widget_id: str, customer_ref: str = _CUST, **ov: Any) -> DecisionStatus:
+    d: dict[str, Any] = dict(
+        widget_id=widget_id,
+        customer_ref=customer_ref,
+        event_type="appointment_request",
+        instinct_action_id="",
+        workspace_id="ws-1",
+        state=DecisionState.PENDING,
+    )
+    d.update(ov)
+    return DecisionStatus(**d)
+
+
+def _contact_body(widget_id: str, **ov: Any) -> dict[str, Any]:
+    b = dict(widget_id=widget_id, signed_key=_VALID_KEY, customer_ref=_CUST, email=_EMAIL)
+    b.update(ov)
+    return b
+
+
+@pytest_asyncio.fixture
+async def contact_client(tmp_path, mongo_db):
+    """Public app client for POST /paw-bar/decision-contact, backed by a tmp
+    store (widget + decisions) + Beanie (Site). Yields (client, store).
+    Mirrors test_paw_bar_actions.action_client."""
+    from unittest.mock import patch
+
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.paw_bar.router import router
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(router)
+    store = PawBarStore(tmp_path / "contact.db")
+    with patch("pocketpaw_ee.paw_bar.router._store", return_value=store):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            yield client, store
+
+
+# --------------------------------------------------------------------------- #
+# Layer 1 — the public endpoint's fail-closed gates + the attach itself
+# --------------------------------------------------------------------------- #
+
+
+class TestContactEndpoint:
+    async def test_attach_stamps_pending_rows_only(self, contact_client) -> None:
+        client, store = contact_client
+        await _site()
+        widget = await store.create_widget(_widget())
+        # Two pending rows for this visitor + one already-decided one.
+        await store.create_decision(_pending_row(widget.id))
+        await store.create_decision(_pending_row(widget.id, event_type="paw_bar_action:book"))
+        await store.create_decision(
+            _pending_row(widget.id, state=DecisionState.DELIVERED, reply="done")
+        )
+
+        res = await client.post(
+            "/paw-bar/decision-contact",
+            json=_contact_body(widget.id),
+            headers={"Origin": _ORIGIN},
+        )
+        assert res.status_code == 200, res.text
+        assert res.json() == {"ok": True, "attached": 2}
+
+        rows = await store.list_decisions_for_widget(widget.id)
+        pending = [r for r in rows if r.state == DecisionState.PENDING]
+        decided = [r for r in rows if r.state == DecisionState.DELIVERED]
+        assert all(r.contact_email == _EMAIL for r in pending)
+        # The already-decided row was answered on-page — never re-armed.
+        assert all(r.contact_email == "" for r in decided)
+
+    async def test_attach_response_never_echoes_the_email(self, contact_client) -> None:
+        client, store = contact_client
+        await _site()
+        widget = await store.create_widget(_widget())
+        await store.create_decision(_pending_row(widget.id))
+        res = await client.post(
+            "/paw-bar/decision-contact",
+            json=_contact_body(widget.id),
+            headers={"Origin": _ORIGIN},
+        )
+        assert res.status_code == 200
+        assert _EMAIL not in res.text
+
+    async def test_attach_other_visitor_rows_untouched(self, contact_client) -> None:
+        client, store = contact_client
+        await _site()
+        widget = await store.create_widget(_widget())
+        await store.create_decision(_pending_row(widget.id, customer_ref="sibling-visitor"))
+        res = await client.post(
+            "/paw-bar/decision-contact",
+            json=_contact_body(widget.id),
+            headers={"Origin": _ORIGIN},
+        )
+        assert res.status_code == 200
+        assert res.json()["attached"] == 0
+        (row,) = await store.list_decisions_for_widget(widget.id)
+        assert row.contact_email == ""
+
+    async def test_unknown_widget_is_404(self, contact_client) -> None:
+        client, _store_ = contact_client
+        await _site()
+        res = await client.post(
+            "/paw-bar/decision-contact",
+            json=_contact_body("pp_ghost"),
+            headers={"Origin": _ORIGIN},
+        )
+        assert res.status_code == 404
+
+    async def test_bad_key_is_401(self, contact_client) -> None:
+        client, store = contact_client
+        await _site()
+        widget = await store.create_widget(_widget())
+        res = await client.post(
+            "/paw-bar/decision-contact",
+            json=_contact_body(widget.id, signed_key="short"),
+            headers={"Origin": _ORIGIN},
+        )
+        assert res.status_code == 401
+
+    async def test_wrong_origin_is_403(self, contact_client) -> None:
+        client, store = contact_client
+        await _site()
+        widget = await store.create_widget(_widget())
+        res = await client.post(
+            "/paw-bar/decision-contact",
+            json=_contact_body(widget.id),
+            headers={"Origin": "https://evil.example"},
+        )
+        assert res.status_code == 403
+
+    async def test_widget_bound_to_sibling_pocket_is_403(self, contact_client) -> None:
+        client, store = contact_client
+        await _site(pocket_id="pocket-A")
+        widget = await store.create_widget(
+            _widget(pocket_id="pocket-B", spec=_spec(pocket_id="pocket-B"))
+        )
+        res = await client.post(
+            "/paw-bar/decision-contact",
+            json=_contact_body(widget.id),
+            headers={"Origin": _ORIGIN},
+        )
+        assert res.status_code == 403
+
+    async def test_rate_limit_is_429(self, contact_client) -> None:
+        client, store = contact_client
+        await _site()
+        widget = await store.create_widget(_widget(per_customer_limit_per_min=2))
+        for _ in range(2):
+            await store.record_event(
+                PawBarEvent(widget_id=widget.id, type="concierge_message", customer_ref=_CUST)
+            )
+        res = await client.post(
+            "/paw-bar/decision-contact",
+            json=_contact_body(widget.id),
+            headers={"Origin": _ORIGIN},
+        )
+        assert res.status_code == 429
+
+    @pytest.mark.parametrize(
+        "bad_email",
+        [
+            "not-an-email",
+            "missing@tld",
+            "two@@example.com",
+            "spaces in@example.com",
+            "a" * 250 + "@example.com",  # over the 254-char cap
+            "",
+        ],
+    )
+    async def test_malformed_email_is_422(self, contact_client, bad_email: str) -> None:
+        client, store = contact_client
+        await _site()
+        widget = await store.create_widget(_widget())
+        await store.create_decision(_pending_row(widget.id))
+        res = await client.post(
+            "/paw-bar/decision-contact",
+            json=_contact_body(widget.id, email=bad_email),
+            headers={"Origin": _ORIGIN},
+        )
+        assert res.status_code == 422, bad_email
+        # Nothing was stamped.
+        (row,) = await store.list_decisions_for_widget(widget.id)
+        assert row.contact_email == ""
+
+
+# --------------------------------------------------------------------------- #
+# Layer 2 — PII posture: the public decision poll never carries the email
+# --------------------------------------------------------------------------- #
+
+
+class TestPollNeverLeaksEmail:
+    async def test_poll_response_omits_contact_email(self, contact_client) -> None:
+        client, store = contact_client
+        await _site()
+        widget = await store.create_widget(_widget())
+        await store.create_decision(_pending_row(widget.id, contact_email=_EMAIL))
+
+        res = await client.get(
+            f"/paw-bar/events/{widget.id}/decision/{_CUST}",
+            headers={"Origin": _ORIGIN},
+        )
+        assert res.status_code == 200
+        body = res.json()
+        assert body["found"] is True
+        assert "contact_email" not in body
+        assert _EMAIL not in res.text
+
+    async def test_poll_after_delivery_still_omits_email(self, contact_client) -> None:
+        client, store = contact_client
+        await _site()
+        widget = await store.create_widget(_widget())
+        await store.create_decision(
+            _pending_row(
+                widget.id,
+                state=DecisionState.DELIVERED,
+                reply="Confirmed!",
+                contact_email=_EMAIL,
+            )
+        )
+        res = await client.get(
+            f"/paw-bar/events/{widget.id}/decision/{_CUST}",
+            headers={"Origin": _ORIGIN},
+        )
+        assert res.status_code == 200
+        assert res.json()["reply"] == "Confirmed!"
+        assert _EMAIL not in res.text
+
+
+# --------------------------------------------------------------------------- #
+# Layer 3 — delivery sends exactly one email on the PENDING → decided flip
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def stores(tmp_path: Path, monkeypatch):
+    """Isolated Instinct + PawBar stores patched onto the lazy-imported
+    singletons (mirrors test_paw_bar_decision_loop.stores)."""
+    pp_store = PawBarStore(tmp_path / "pb_contact_loop.db")
+    instinct_store = InstinctStore(tmp_path / "instinct_contact_loop.db")
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: instinct_store)
+    monkeypatch.setattr("pocketpaw.stores.get_paw_bar_store", lambda: pp_store)
+    return pp_store, instinct_store
+
+
+@pytest.fixture
+def sent(monkeypatch):
+    """Stub the mailer's send with a recorder; returns the list of sends."""
+    calls: list[dict[str, str]] = []
+
+    async def _record(to_addr: str, subject: str, body: str) -> bool:
+        calls.append({"to": to_addr, "subject": subject, "body": body})
+        return True
+
+    monkeypatch.setattr("pocketpaw_ee.paw_bar.mailer.send_decision_email", _record)
+    return calls
+
+
+async def _open_loop_with_email(pp_store: PawBarStore) -> tuple[PawBarWidget, str]:
+    """Create a widget + event, open the loop, attach the visitor's email.
+    Returns (widget, instinct_action_id)."""
+    widget = await pp_store.create_widget(_widget(workspace_id="", owner="ws:brew"))
+    event = PawBarEvent(
+        widget_id=widget.id,
+        type="appointment_request",
+        payload={"when": "Tuesday 3pm"},
+        customer_ref=_CUST,
+    )
+    action_id = await propose_customer_decision(widget=widget, event=event, paw_bar_store=pp_store)
+    assert action_id is not None
+    attached = await pp_store.attach_contact_email(widget.id, _CUST, _EMAIL, workspace_id="ws:brew")
+    assert attached == 1
+    return widget, action_id
+
+
+class TestDeliveryEmail:
+    async def test_approve_sends_exactly_one_email(self, stores, sent) -> None:
+        pp_store, instinct_store = stores
+        widget, action_id = await _open_loop_with_email(pp_store)
+
+        approved = await instinct_store.approve(action_id, approver="user:owner")
+        await deliver_customer_decision(approved, declined=False)
+
+        assert len(sent) == 1
+        assert sent[0]["to"] == _EMAIL
+        # Subject names the site; body is the SAME reply the poll returns.
+        assert sent[0]["subject"] == f"Update from {widget.name}"
+        row = await pp_store.get_latest_decision(widget.id, _CUST)
+        assert row is not None and row.state == DecisionState.DELIVERED
+        assert sent[0]["body"] == row.reply
+        assert row.reply  # non-empty customer-facing reply
+
+    async def test_replayed_delivery_does_not_resend(self, stores, sent) -> None:
+        pp_store, instinct_store = stores
+        _widget_, action_id = await _open_loop_with_email(pp_store)
+
+        approved = await instinct_store.approve(action_id, approver="user:owner")
+        await deliver_customer_decision(approved, declined=False)
+        # A replayed approve delivery (retry / sweep) must NOT email again —
+        # the guard is the row's PENDING → decided transition, already spent.
+        await deliver_customer_decision(approved, declined=False)
+        assert len(sent) == 1
+
+    async def test_reject_sends_the_decline_reply(self, stores, sent) -> None:
+        pp_store, instinct_store = stores
+        widget, action_id = await _open_loop_with_email(pp_store)
+
+        rejected = await instinct_store.reject(
+            action_id, reason="No slots Tuesday — pick another day", rejector="user:owner"
+        )
+        await deliver_customer_decision(rejected, declined=True)
+
+        assert len(sent) == 1
+        assert sent[0]["to"] == _EMAIL
+        assert "No slots Tuesday" in sent[0]["body"]
+        row = await pp_store.get_latest_decision(widget.id, _CUST)
+        assert row is not None and row.state == DecisionState.DECLINED
+        assert sent[0]["body"] == row.reply
+
+    async def test_no_attached_email_sends_nothing(self, stores, sent) -> None:
+        pp_store, instinct_store = stores
+        widget = await pp_store.create_widget(_widget(workspace_id="", owner="ws:brew"))
+        event = PawBarEvent(
+            widget_id=widget.id,
+            type="appointment_request",
+            payload={},
+            customer_ref=_CUST,
+        )
+        action_id = await propose_customer_decision(
+            widget=widget, event=event, paw_bar_store=pp_store
+        )
+        approved = await instinct_store.approve(action_id, approver="user:owner")
+        await deliver_customer_decision(approved, declined=False)
+        assert sent == []
+        row = await pp_store.get_latest_decision(widget.id, _CUST)
+        assert row is not None and row.state == DecisionState.DELIVERED
+
+
+# --------------------------------------------------------------------------- #
+# Layer 4 — fail-soft: no SMTP transport leaves the whole flow green
+# --------------------------------------------------------------------------- #
+
+
+_SMTP_ENV = (
+    "POCKETPAW_SMTP_HOST",
+    "POCKETPAW_SMTP_PORT",
+    "POCKETPAW_SMTP_USER",
+    "POCKETPAW_SMTP_PASSWORD",
+    "POCKETPAW_SMTP_FROM",
+    "POCKETPAW_SMTP_STARTTLS",
+)
+
+
+class TestFailSoft:
+    async def test_no_transport_still_delivers_on_poll(self, stores, monkeypatch) -> None:
+        """With NO SMTP env at all the REAL mailer runs, returns False, and the
+        approve flow stays green — the row flips and the poll works."""
+        for var in _SMTP_ENV:
+            monkeypatch.delenv(var, raising=False)
+        pp_store, instinct_store = stores
+        widget, action_id = await _open_loop_with_email(pp_store)
+
+        approved = await instinct_store.approve(action_id, approver="user:owner")
+        await deliver_customer_decision(approved, declined=False)  # must not raise
+
+        row = await pp_store.get_latest_decision(widget.id, _CUST)
+        assert row is not None
+        assert row.state == DecisionState.DELIVERED
+        assert row.reply
+
+    async def test_mailer_unconfigured_returns_false(self, monkeypatch) -> None:
+        from pocketpaw_ee.paw_bar import mailer
+
+        for var in _SMTP_ENV:
+            monkeypatch.delenv(var, raising=False)
+        assert mailer.smtp_configured() is False
+        assert await mailer.send_decision_email(_EMAIL, "s", "b") is False
+
+    async def test_mailer_send_error_returns_false(self, monkeypatch) -> None:
+        """A configured transport whose send blows up is swallowed to False."""
+        from pocketpaw_ee.paw_bar import mailer
+
+        monkeypatch.setenv("POCKETPAW_SMTP_HOST", "smtp.example.test")
+        monkeypatch.setenv("POCKETPAW_SMTP_FROM", "noreply@example.test")
+
+        def _boom(*_a: Any, **_k: Any) -> None:
+            raise ConnectionRefusedError("no smtp here")
+
+        monkeypatch.setattr(mailer, "_send_sync", _boom)
+        assert await mailer.send_decision_email(_EMAIL, "s", "b") is False
+
+
+# --------------------------------------------------------------------------- #
+# Layer 5 — store: additive migration + workspace scoping of the attach
+# --------------------------------------------------------------------------- #
+
+
+class TestStore:
+    async def test_attach_is_workspace_scoped(self, tmp_path: Path) -> None:
+        store = PawBarStore(tmp_path / "scoped.db")
+        await store.create_decision(
+            _pending_row("pp_a", workspace_id="ws-a", instinct_action_id="act-1")
+        )
+        # A cross-tenant attach stamps nothing.
+        assert await store.attach_contact_email("pp_a", _CUST, _EMAIL, workspace_id="ws-b") == 0
+        # The owning tenant stamps it.
+        assert await store.attach_contact_email("pp_a", _CUST, _EMAIL, workspace_id="ws-a") == 1
+        row = await store.get_decision_by_action("act-1")
+        assert row is not None and row.contact_email == _EMAIL
+
+    async def test_pre_existing_db_gains_contact_email_column(self, tmp_path: Path) -> None:
+        """A paw_bar.db created before this slice ALTER-gains the column on the
+        next _ensure_schema (same additive pattern as workspace_id)."""
+        import aiosqlite
+
+        db_path = tmp_path / "legacy.db"
+        async with aiosqlite.connect(db_path) as db:
+            await db.execute(
+                "CREATE TABLE paw_bar_decisions ("
+                " id TEXT PRIMARY KEY, widget_id TEXT NOT NULL,"
+                " customer_ref TEXT NOT NULL, event_type TEXT DEFAULT '',"
+                " instinct_action_id TEXT DEFAULT '', workspace_id TEXT DEFAULT '',"
+                " state TEXT DEFAULT 'pending', reply TEXT DEFAULT '',"
+                " decided_by TEXT DEFAULT '',"
+                " created_at TEXT DEFAULT (datetime('now')),"
+                " updated_at TEXT DEFAULT (datetime('now')))"
+            )
+            await db.execute(
+                "INSERT INTO paw_bar_decisions (id, widget_id, customer_ref)"
+                " VALUES ('d1', 'pp_a', ?)",
+                (_CUST,),
+            )
+            await db.commit()
+
+        store = PawBarStore(db_path)
+        # The legacy row reads back with an empty contact_email…
+        row = await store.get_latest_decision("pp_a", _CUST)
+        assert row is not None and row.contact_email == ""
+        # …and the new column is writable.
+        assert await store.attach_contact_email("pp_a", _CUST, _EMAIL) == 1
+        row = await store.get_latest_decision("pp_a", _CUST)
+        assert row is not None and row.contact_email == _EMAIL


### PR DESCRIPTION
## What this closes

The decision loop had an on-page half only. A visitor asks something that needs the owner's call, the widget polls for the answer - and the moment they close the tab, the owner's decision goes nowhere. This adds the async half: the visitor can leave an email while the request is pending, and when the owner approves or declines, they get one email with the same reply the poll would have shown.

## Endpoint contract (for the widget team)

`POST /paw-bar/decision-contact`

Body:
```json
{
  "widget_id": "pp_...",
  "signed_key": "<Site.signed_key>",
  "customer_ref": "<anonymous visitor handle>",
  "email": "visitor@example.com"
}
```

Responses:
- `200` -> `{"ok": true, "attached": N}` (N = pending decision rows stamped; 0 is still ok)
- `404` unknown widget
- `429` rate limit (same limiter as chat; contact posts also count toward it)
- `401` bad/unknown/revoked embed key
- `403` disallowed origin, or widget not bound to the key's workspace/pocket
- `400` malformed `customer_ref`
- `422` `invalid_email` (RFC-ish syntax check, 254-char cap)

Gate order mirrors `/paw-bar/chat` via the shared `_front_gate_for_key`. The email is validated after authentication so refusal shapes stay fail-closed-first.

## How delivery works

`deliver_customer_decision` reads the row's prior state before flipping it. If the flip is a real PENDING -> decided transition and the row carries a `contact_email`, it sends exactly one email: subject `Update from <site name>`, body = the customer-facing reply (the operator's edited wording on approve, the decline reason on reject). A re-delivered approval (retry, sweep) finds the transition already spent and does not send again.

## Email transport

Nothing system-owned existed (the Gmail client is user-scoped OAuth), so this adds a deliberately small SMTP sender used only by this path: `POCKETPAW_SMTP_HOST` / `PORT` / `USER` / `PASSWORD` / `FROM`, STARTTLS on by default. Fail-soft by contract - no transport or a send failure logs a warning and returns; the approve/reject response and the on-page poll are never affected.

## PII posture

The address lives only on the `DecisionStatus` row (additive SQLite migration, same pattern as `workspace_id`). It never enters the Instinct proposal, the agent's context, the KB, transcripts, or the event log, and no public read returns it - the decision poll omits it by shape. The invariant is documented at the field definition.

## Tests

25 new in `tests/cloud/test_paw_bar_decision_contact.py`: every gate's refusal shape, attach stamps pending rows only (scoped per workspace and per visitor), the poll never carries the address, a stubbed sender proves one email on approve and on reject with no resend on replay, the real mailer's no-transport and send-error paths, and the legacy-DB column migration. Full paw-bar set: 293 green. Both import-linter configs kept.

Docs: `docs/concepts/concierge-knowledge.mdx` gains a "When the visitor leaves the page" section.