### PR TITLE
Paw Bar: reply sources + public articles listing

### DIFF
--- a/docs/concepts/concierge-knowledge.mdx
+++ b/docs/concepts/concierge-knowledge.mdx
@@ -81,6 +81,22 @@ so it syncs zero documents and reports `no_content`. Grounding one of those mean
 crawling the customer's own origin through the SSRF-hardened import crawler, and is
 not part of this path.
 
+## What the visitor sees as sources
+
+A reply can end with a short "Sources" list — up to three of the site's own pages,
+each a title and a public link. It is sent as a single `sources` event on the chat
+stream, just before the stream ends, and the same pages are browsable through a
+public articles listing (`GET /paw-bar/articles`, behind the same key, origin and
+rate gates as the chat; capped at twenty entries with a short snippet each).
+
+Attribution is approximate by design. The server re-runs a quick knowledge search
+of the visitor's question against the same pocket scope the run reads, and shows
+the synced pages that match — "what the knowledge base would ground this question
+on", not a verified trace of what the model actually quoted. Only pages the site
+sync itself produced can appear; owner-uploaded files sharing the scope are never
+listed or linked. When nothing matches, or the search fails, no sources are shown
+and the reply is unaffected.
+
 ## What a concierge records
 
 The agent's replies have always been durable. The visitor's own messages are stored

--- a/ee/pocketpaw_ee/cloud/agents/knowledge.py
+++ b/ee/pocketpaw_ee/cloud/agents/knowledge.py
@@ -1,4 +1,9 @@
 # knowledge.py — Agent knowledge service via the kb-go binary.
+# Updated: 2026-07-30 — Paw Bar reply sources. Added the scope-form read pair
+#   search_articles_for_scope / list_articles_for_scope (raw {id, title, summary}
+#   hit dicts, mirroring ingest_text_to_scope's "caller owns the scope shape"
+#   contract) so the public concierge router can attribute a reply to the synced
+#   site pages and list them, without importing this module's private ``_kb``.
 # Updated: 2026-07-03 — FL-11b "hide-from-AI purge". Added
 #   KnowledgeService.remove_article(scope, article_id) → `kb delete
 #   <article_id> --scope <scope>`, mirroring get_article. Resilient: logs and
@@ -205,6 +210,32 @@ class KnowledgeService:
         if isinstance(results, list):
             return [r.get("summary", r.get("title", "")) for r in results]
         return []
+
+    @staticmethod
+    async def search_articles_for_scope(scope: str, query: str, limit: int = 5) -> list[dict]:
+        """Raw search hits (``{id, title, summary, concepts}`` dicts) for any scope.
+
+        The scope-form sibling of :meth:`search` — callers that need the article
+        id and title (not a formatted context block) use this. Like the other
+        scope-form entry points, the scope string is the caller's to shape
+        (``pocket:{pid}``, ``workspace:{wid}``); kb-go validates it itself.
+        Raises on subprocess failure — callers that must be fail-soft (the public
+        concierge sources path) wrap it.
+        """
+        results = await asyncio.to_thread(
+            _kb, "search", query, "--scope", scope, "--limit", str(limit)
+        )
+        return results if isinstance(results, list) else []
+
+    @staticmethod
+    async def list_articles_for_scope(scope: str) -> list[dict]:
+        """List a scope's articles as raw ``{id, title, summary, ...}`` dicts.
+
+        Scope-form sibling of :meth:`list_articles`, same contract notes as
+        :meth:`search_articles_for_scope`.
+        """
+        result = await asyncio.to_thread(_kb, "list", "--scope", scope)
+        return result if isinstance(result, list) else []
 
     @staticmethod
     async def search_context(agent_id: str, query: str, limit: int = 3) -> str:

--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -560,6 +560,29 @@ def _configured_frame_origin(request: Request) -> str:
     return f"{request.url.scheme}://{request.url.netloc}"
 
 
+def _request_origin(request: Request) -> str | None:
+    """The effective Origin for the public GET gates — same-origin case resolved.
+
+    Browsers OMIT the ``Origin`` header on same-origin GETs, so a fetch from OUR
+    OWN frame (the glass app polling its decision, loading articles) arrives
+    origin-less and the fail-closed gates 403'd it — found live on the
+    2026-07-30 rig: the frame's decision poll and articles fetch were dead while
+    every curl with an explicit Origin passed. When the browser-set
+    ``Sec-Fetch-Site: same-origin`` header is present, the caller can only be a
+    page on our own origin — i.e. the frame — so resolve it AS the frame origin
+    and let the dual-mode gate's frame branch do its normal work. Non-browser
+    callers can forge any Origin header anyway; the origin gates are
+    browser-defense, so this widens nothing. A request with neither header stays
+    origin-less and the gates stay fail-closed.
+    """
+    origin = request.headers.get("origin")
+    if origin:
+        return origin
+    if request.headers.get("sec-fetch-site", "").strip().lower() == "same-origin":
+        return _configured_frame_origin(request)
+    return None
+
+
 def _safe_parent_origin(po: str, allowed_origins: list[str]) -> str:
     """Validate the loader-supplied parent origin against the Site's allowlist.
 
@@ -2312,8 +2335,13 @@ async def get_decision(
     if widget is None:
         raise HTTPException(404, "Widget not found")
 
-    origin = request.headers.get("origin")
-    if not _origin_allowed(widget, origin):
+    # Same-origin GETs carry no Origin header — resolve the frame case first
+    # (see _request_origin), then apply the widget allowlist for real embedders.
+    # A request FROM our frame equals the frame origin and is allowed: the
+    # embedder was already gated by the frame CSP at render time (the same
+    # dual-mode reasoning as resolve_site_key).
+    origin = _request_origin(request)
+    if origin != _configured_frame_origin(request) and not _origin_allowed(widget, origin):
         raise HTTPException(403, "Origin not allowed for this widget")
 
     decision = await store.get_latest_decision(widget_id, customer_ref)
@@ -2966,8 +2994,12 @@ async def list_public_articles(
     disallowed origin / widget∩key binding mismatch → 403. An empty KB (or a
     site whose pages never synced) is a real state, not an error → 200 with
     ``{"articles": []}``. The kb read itself is fail-soft the same way.
+
+    ``_request_origin`` (not the raw header): a same-origin GET from our own
+    frame carries no Origin header, and the raw read made the frame's articles
+    fetch 403 on the live rig.
     """
-    origin = request.headers.get("origin")
+    origin = _request_origin(request)
     widget, ctx, site = await _front_gate_for_key(
         widget_id=widget_id,
         signed_key=signed_key,

--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -560,6 +560,35 @@ def _configured_frame_origin(request: Request) -> str:
     return f"{request.url.scheme}://{request.url.netloc}"
 
 
+def _dead_frame_response(po: str, allowed_origins: list[str]) -> HTMLResponse:
+    """The invisible shell a declined frame renders: nothing, then self-remove.
+
+    A refused GET /paw-bar/frame lands inside a VISIBLE iframe on the
+    customer's site, so the body must render blank — never an error payload.
+    The inline script posts ``{pawbar: 'dead'}`` to the (allowlist-validated)
+    parent so a loader that understands it removes the iframe entirely; an
+    older loader simply keeps an invisible 48px sliver. Status stays 403:
+    programmatic callers still see a refusal.
+    """
+    parent = _safe_parent_origin(po, allowed_origins)
+    script = (
+        "<script>try{parent.postMessage({type:'pawbar:dead'},"
+        + json.dumps(parent)
+        + ")}catch(e){}</script>"
+        if parent
+        else ""
+    )
+    return HTMLResponse(
+        content=(
+            "<!doctype html><html><head><meta charset='utf-8'>"
+            "<style>html,body{background:transparent;margin:0}</style>"
+            f"</head><body>{script}</body></html>"
+        ),
+        status_code=403,
+        headers={"Cache-Control": "no-store"},
+    )
+
+
 def _request_origin(request: Request) -> str | None:
     """The effective Origin for the public GET gates — same-origin case resolved.
 
@@ -788,18 +817,25 @@ async def frame(
     site = await lookup_site_by_key(key)
 
     # (1b) Kill switch (D1 / SS-6): the owner's ``concierge_enabled`` toggle. When
-    # off, refuse to render (403) — the same fail-closed shape as the empty-allowlist
-    # refusal below. Re-read on every request (``lookup_site_by_key`` does a fresh
-    # find_one, nothing is cached), so toggling off silences the frame immediately.
-    # Distinct from ``revoked`` (which cuts the KEY at 401 inside lookup_site_by_key).
+    # off, refuse to RENDER — but this response body lands inside a visible
+    # iframe on the customer's site, so a JSON error is a defect, not a refusal
+    # (the 2026-07-30 rig showed literal {"detail":"concierge_disabled"} on the
+    # page). Return the invisible shell: a blank document that tells the loader
+    # to remove the iframe (``pawbar:dead``). Still 403 — curl callers see the
+    # status; browsers see nothing. Re-read per request (``lookup_site_by_key``
+    # does a fresh find_one), so toggling off silences the frame immediately.
+    # Distinct from ``revoked`` (which cuts the KEY at 401 inside
+    # lookup_site_by_key — an api-shaped JSON 401 stays correct there: a revoked
+    # key means the embed script itself is stale/removed on next publish).
     if not site.concierge_enabled:
-        raise HTTPException(status_code=403, detail="concierge_disabled")
+        return _dead_frame_response(po, site.allowed_origins)
 
     # (2) The embedder gate: the CSP frame-ancestors header. Fail closed when no
-    # allowlisted origin survives sanitization — refuse to render.
+    # allowlisted origin survives sanitization — refuse to render (same
+    # invisible-shell shape: this body also lands in a visible iframe).
     csp = _frame_ancestors_csp(site.allowed_origins)
     if csp is None:
-        raise HTTPException(status_code=403, detail="frame_ancestors_unset")
+        return _dead_frame_response(po, site.allowed_origins)
 
     # (3) Bootstrap config. ``endpoint`` is the API base derived from the request
     # path (mount-agnostic: /api/v1 in prod, "" when the router is mounted bare in

--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -2377,6 +2377,23 @@ _SOURCES_SEARCH_LIMIT = 8
 _SOURCES_WAIT_S = 0.1
 
 
+def _humanize_article_title(title: str) -> str:
+    """Visitor-facing title for a synced page article — never the raw KB id.
+
+    Slug-sourced articles carry their ``site-<slug>`` id as the title
+    ("site-services"), which read as internals in the Sources chips and the
+    articles list during the 2026-07-30 rig smoke. Strip the prefix, break the
+    slug on dashes, and title-case ("site-home" → "Home"). A title that isn't
+    id-shaped (an LLM-compiled article's real title) passes through untouched.
+    """
+    t = title.strip()
+    if t.startswith("site-"):
+        slug = t[len("site-") :].strip("-")
+        words = [w for w in slug.split("-") if w]
+        return " ".join(w.capitalize() for w in words) if words else "Home"
+    return t
+
+
 def _article_page_url(article_id: str, base_url: str) -> str:
     """Best-effort public page URL for a synced KB article — "" when unmappable.
 
@@ -2432,7 +2449,7 @@ async def _concierge_sources(pocket_id: str, message: str, site: Any) -> list[di
             if not url or url in seen_urls:
                 continue
             seen_urls.add(url)
-            sources.append({"title": title, "url": url})
+            sources.append({"title": _humanize_article_title(title), "url": url})
             if len(sources) >= _SOURCES_MAX:
                 break
         return sources
@@ -3002,7 +3019,9 @@ async def list_public_articles(
         if not url:
             continue
         snippet = " ".join(str(entry.get("summary") or "").split())[:_ARTICLE_SNIPPET_CHARS]
-        articles.append(ConciergeArticle(title=title, url=url, snippet=snippet))
+        articles.append(
+            ConciergeArticle(title=_humanize_article_title(title), url=url, snippet=snippet)
+        )
         if len(articles) >= _ARTICLES_MAX:
             break
     return ArticlesResponse(articles=articles)

--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -1,4 +1,21 @@
 # ee/paw_bar/router.py — HTTP surface for the Paw Bar widget layer.
+# Updated: 2026-07-30 (reply sources + articles) — visible grounding for the
+#   concierge. (1) ``concierge_chat`` now emits at most ONE ``event: sources``
+#   SSE frame ({"sources": [{title, url}]}, max 3, deduped by url) after the
+#   model stream completes and immediately BEFORE the terminal ``stream_end``
+#   frame. Attribution is deliberately APPROXIMATE (Crisp-style): a server-side
+#   KB search of the visitor's message against the SAME ``pocket:<pocket_id>``
+#   scope the concierge run reads, filtered to the articles the site's page sync
+#   produced (``Site.kb_article_ids``) and mapped back to public page URLs via
+#   the ``site-<slug>`` article-id convention — NOT an exact tool trace. The
+#   search runs CONCURRENTLY with the model stream so it adds ~0ms; fail-soft
+#   (any error / timeout emits nothing). (2) GET /paw-bar/articles — a public
+#   listing of the site's synced KB pages ({title, url, snippet ≤160}), capped
+#   at 20, behind the SAME ``_front_gate_for_key`` chain as chat (404 → 429 →
+#   401 → 403); no injection screen because there is no free text. The shared
+#   front-gate now resolves via ``resolve_site_key_with_site`` and hands back
+#   the Site too, so articles (and any future public read) can use owner-set
+#   Site fields without a second query.
 # Updated: 2026-07-30 (async decision delivery) — added POST
 #   /paw-bar/decision-contact: a visitor whose request is still PENDING leaves
 #   an optional email before closing the tab; the delivery hook later emails
@@ -270,6 +287,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
@@ -2332,6 +2350,97 @@ async def get_decision(
 # ---------------------------------------------------------------------------
 
 
+# --- Reply sources (visible grounding) -------------------------------------
+#
+# APPROXIMATE ATTRIBUTION, ON PURPOSE (Crisp-style "Sources"): the concierge run
+# grounds itself with a KB search inside the agent loop, and that trace is not
+# surfaced by the transport. Rather than plumb a tool trace through the run
+# machinery, we re-run a cheap server-side KB search of the visitor's OWN message
+# against the SAME ``pocket:<pocket_id>`` scope the run reads, and show the synced
+# site pages that match. The pages shown are therefore "what the KB would ground
+# this question on", not "what the model verifiably quoted" — good enough to give
+# the visitor a place to read more, and honest about being a heuristic.
+#
+# Fail-soft and near-free: the search task starts before the stream is relayed and
+# runs CONCURRENTLY with the model turn (seconds), so by ``stream_end`` it is
+# almost always already done; a short grace wait bounds the added latency, and any
+# error or timeout emits nothing at all (never an empty ``sources`` event).
+
+# At most this many entries ride the ``sources`` event (CONTRACT: max 3).
+_SOURCES_MAX = 3
+# Search a few more than we show — hits are filtered to synced site pages and
+# deduped by url, so over-fetching keeps the event full when some hits drop.
+_SOURCES_SEARCH_LIMIT = 8
+# Grace wait at stream end for a search that somehow outlived the model turn.
+# The budget for ADDED latency is ~100ms; past it we drop sources, not delay the
+# terminal frame.
+_SOURCES_WAIT_S = 0.1
+
+
+def _article_page_url(article_id: str, base_url: str) -> str:
+    """Best-effort public page URL for a synced KB article — "" when unmappable.
+
+    The page sync ingests each page under a deterministic ``site-<slug>`` source
+    (``kb_ingest._path_slug``), and kb-go's compile fallback keeps that as the
+    article id. Reversing the slug is LOSSY (slashes and dashes both became "-"),
+    and an LLM-compiled article is titled — not sourced — so its id carries no
+    slug at all; both cases degrade to the site's base URL. That is the accepted
+    cost of approximate attribution: the link always lands on the right SITE,
+    usually on the right page.
+    """
+    base = (base_url or "").strip().rstrip("/")
+    if not base:
+        return ""
+    if article_id.startswith("site-"):
+        slug = article_id[len("site-") :]
+        if slug and slug != "home":
+            return f"{base}/{slug}"
+    return f"{base}/"
+
+
+async def _concierge_sources(pocket_id: str, message: str, site: Any) -> list[dict[str, str]]:
+    """Sources for one concierge reply: synced site pages that match the message.
+
+    Searches the SAME ``pocket:<pocket_id>`` scope the concierge run reads (the
+    one scope ``_kb_scopes_for_context`` grants a CONCIERGE run), then keeps only
+    hits whose article id is in ``Site.kb_article_ids`` — the articles the page
+    sync wrote — so an owner-uploaded private file can never surface as a public
+    "source". Entries need BOTH a non-empty title and url; deduped by url; capped
+    at ``_SOURCES_MAX``. Fail-soft: any error returns [] and the reply is
+    unaffected.
+    """
+    try:
+        base_url = str(getattr(site, "url", "") or "")
+        synced = set(getattr(site, "kb_article_ids", None) or [])
+        if not pocket_id or not message.strip() or not base_url.strip() or not synced:
+            return []
+        from pocketpaw_ee.cloud.agents.knowledge import KnowledgeService
+
+        hits = await KnowledgeService.search_articles_for_scope(
+            f"pocket:{pocket_id}", message, limit=_SOURCES_SEARCH_LIMIT
+        )
+        sources: list[dict[str, str]] = []
+        seen_urls: set[str] = set()
+        for hit in hits:
+            if not isinstance(hit, dict):
+                continue
+            article_id = str(hit.get("id") or "")
+            title = str(hit.get("title") or "").strip()
+            if article_id not in synced or not title:
+                continue
+            url = _article_page_url(article_id, base_url)
+            if not url or url in seen_urls:
+                continue
+            seen_urls.add(url)
+            sources.append({"title": title, "url": url})
+            if len(sources) >= _SOURCES_MAX:
+                break
+        return sources
+    except Exception:  # noqa: BLE001 — sources are best-effort, the reply is not
+        logger.debug("concierge sources lookup failed (non-fatal)", exc_info=True)
+        return []
+
+
 class ConciergeChatRequest(BaseModel):
     widget_id: str
     # The public, origin-bound embed key (Site.signed_key) baked into the widget.
@@ -2573,27 +2682,54 @@ async def concierge_chat(body: ConciergeChatRequest, request: Request) -> Stream
 
     transport = get_stream_transport()
 
+    # Reply sources (visible grounding): kick the approximate-attribution KB
+    # search off NOW so it runs concurrently with the model turn — by the time
+    # ``stream_end`` arrives it is effectively always finished, so surfacing it
+    # adds ~0ms. Fail-soft by construction (``_concierge_sources`` never raises).
+    sources_task = asyncio.create_task(_concierge_sources(ctx.pocket_id or "", body.message, site))
+
     async def gen() -> AsyncIterator[bytes]:
         # Mirror agent_router.post_agent_chat's tail: announce the run, then relay
         # the transport frames the executor writes, verbatim, until a terminal one.
-        yield _sse(
-            "message.persisted",
-            {"run_id": run_id, "client_message_id": client_message_id},
-        )
-        cursor = "0"
-        while True:
-            saw_terminal = False
-            async for ev in transport.read_events(run_id, after=cursor, block_ms=2000):
-                cursor = ev.entry_id
-                yield _sse(ev.event, ev.data, entry_id=ev.entry_id)
-                if ev.is_terminal:
-                    saw_terminal = True
-            if saw_terminal:
-                return
-            if await transport.is_cancelled(run_id):
-                yield _sse("interrupted", {"reason": "cancelled"})
-                return
-            yield b": ping\n\n"
+        # One insertion: immediately BEFORE relaying a terminal ``stream_end``
+        # frame, emit at most one ``sources`` event (CONTRACT: the widget renders
+        # it only between the model stream completing and stream_end; nothing is
+        # emitted when no source qualifies, and never after stream_end).
+        try:
+            yield _sse(
+                "message.persisted",
+                {"run_id": run_id, "client_message_id": client_message_id},
+            )
+            cursor = "0"
+            while True:
+                saw_terminal = False
+                async for ev in transport.read_events(run_id, after=cursor, block_ms=2000):
+                    cursor = ev.entry_id
+                    if ev.event == "stream_end":
+                        # The model stream is complete. Give the concurrent
+                        # search a short grace, then either surface it or drop
+                        # it — the terminal frame is never delayed past the
+                        # ~100ms budget and never blocked by a wedged search.
+                        try:
+                            sources = await asyncio.wait_for(
+                                asyncio.shield(sources_task), timeout=_SOURCES_WAIT_S
+                            )
+                        except Exception:  # noqa: BLE001 — timeout/err ⇒ no event
+                            sources = []
+                        if sources:
+                            yield _sse("sources", {"sources": sources})
+                    yield _sse(ev.event, ev.data, entry_id=ev.entry_id)
+                    if ev.is_terminal:
+                        saw_terminal = True
+                if saw_terminal:
+                    return
+                if await transport.is_cancelled(run_id):
+                    yield _sse("interrupted", {"reason": "cancelled"})
+                    return
+                yield b": ping\n\n"
+        finally:
+            # Client gone or stream over — never leave the search task dangling.
+            sources_task.cancel()
 
     return StreamingResponse(
         gen(),
@@ -2632,19 +2768,23 @@ async def _front_gate_for_key(
     customer_ref: str,
     origin: str | None,
     request: Request,
-) -> tuple[PawBarWidget, Any]:
+) -> tuple[PawBarWidget, Any, Any]:
     """The shared public front-gate: resolve the widget + authenticate the key.
 
     Mirrors ``concierge_chat`` steps 1-6 (fail-closed, cheap gates first):
       0. ``customer_ref`` matches the charset + length bound (400) — cheapest gate.
       1. Widget exists (404) — UNSCOPED (workspace unknown until the key resolves).
       2. Rate limit, overall + per-customer (429).
-      3. Authenticate the embed key + dual-mode origin gate (``resolve_site_key`` —
-         401 bad/unknown/revoked key, 403 disallowed/missing origin, fail-closed).
+      3. Authenticate the embed key + dual-mode origin gate
+         (``resolve_site_key_with_site`` — 401 bad/unknown/revoked key, 403
+         disallowed/missing origin, fail-closed).
       4. Bind the widget to the RESOLVED key: it must belong to the key's workspace
          AND pocket (403) — a key for pocket A must not drive a widget for pocket B.
-    Returns ``(widget, ctx)`` where ``ctx.workspace_id`` is the authenticated
-    tenant used to scope any gated Instinct proposal."""
+    Returns ``(widget, ctx, site)`` where ``ctx.workspace_id`` is the
+    authenticated tenant used to scope any gated Instinct proposal and ``site`` is
+    the Site the gate already loaded — handed back (same pattern as
+    ``resolve_site_key_with_site``) so a caller that needs an owner-set Site field
+    (the articles listing reads ``url`` + ``kb_article_ids``) never re-queries."""
     if not _CUSTOMER_REF_RE.match(customer_ref or ""):
         raise HTTPException(400, "invalid_customer_ref")
     store = _store()
@@ -2662,16 +2802,18 @@ async def _front_gate_for_key(
         raise HTTPException(429, "Rate limit exceeded")
 
     frame_origin = _configured_frame_origin(request)
-    from pocketpaw_ee.cloud.auth.site_keys import resolve_site_key
+    from pocketpaw_ee.cloud.auth.site_keys import resolve_site_key_with_site
 
-    ctx = await resolve_site_key(signed_key, origin, customer_ref, frame_origin=frame_origin)
+    ctx, site = await resolve_site_key_with_site(
+        signed_key, origin, customer_ref, frame_origin=frame_origin
+    )
 
     # Bind the widget to the resolved key (finding #2 — no sibling-pocket reach).
     if widget.workspace_id and widget.workspace_id != ctx.workspace_id:
         raise HTTPException(403, "widget_workspace_mismatch")
     if widget.pocket_id != ctx.pocket_id:
         raise HTTPException(403, "widget_pocket_mismatch")
-    return widget, ctx
+    return widget, ctx, site
 
 
 class PawBarActionRequest(BaseModel):
@@ -2695,7 +2837,7 @@ async def post_action(body: PawBarActionRequest, request: Request) -> JSONRespon
     decision endpoint. The executor's status hint becomes the HTTP status on
     failure (422 bad verb/args, 409 empty cart / unavailable)."""
     origin = request.headers.get("origin")
-    widget, ctx = await _front_gate_for_key(
+    widget, ctx, _site = await _front_gate_for_key(
         widget_id=body.w,
         signed_key=body.key,
         customer_ref=body.customer_ref,
@@ -2732,7 +2874,7 @@ async def get_cart(
     from pocketpaw_ee.paw_bar.actions import cart_wire
 
     origin = request.headers.get("origin")
-    widget, _ctx = await _front_gate_for_key(
+    widget, _ctx, _site = await _front_gate_for_key(
         widget_id=w,
         signed_key=key,
         customer_ref=customer_ref,
@@ -2752,6 +2894,118 @@ async def get_cart(
         logger.debug("cart-read marker record failed (non-fatal)", exc_info=True)
     cart = await store.get_cart(w, customer_ref)
     return JSONResponse(cart_wire(widget, customer_ref, cart))
+
+
+# ---------------------------------------------------------------------------
+# Public articles listing (2026-07-30) — the concierge's visible library
+#
+# The reply-side "sources" event shows WHICH pages grounded one answer; this is
+# the browsable other half: everything the concierge can quote, i.e. the site's
+# synced KB pages. Same armor class as chat via the shared ``_front_gate_for_key``
+# (404 unknown widget → 429 rate limit → 401 bad key → 403 origin/binding). No
+# injection screen — there is no free text on this endpoint. The listing is
+# filtered to ``Site.kb_article_ids`` (the page sync's own articles), so an
+# owner-uploaded private file in the same pocket scope is never listed publicly.
+# ---------------------------------------------------------------------------
+
+# Cap on listed articles (CONTRACT: 20) and on the plain-text snippet length
+# (CONTRACT: ≤160 chars).
+_ARTICLES_MAX = 20
+_ARTICLE_SNIPPET_CHARS = 160
+
+# The articles listing has no per-visitor handle in its contract (widget_id +
+# signed_key only), but the shared front-gate rate-limits per customer_ref — so
+# bare listing calls share ONE fixed, well-formed bucket per widget. A caller MAY
+# pass its real visitor handle to get the same per-visitor accounting as chat.
+_ARTICLES_DEFAULT_REF = "pawbar-articles"
+
+
+class ConciergeArticle(BaseModel):
+    """One publicly listable synced page: title + public url + short snippet."""
+
+    title: str
+    url: str
+    snippet: str = ""
+
+
+class ArticlesResponse(BaseModel):
+    articles: list[ConciergeArticle]
+
+
+@router.get("/paw-bar/articles", response_model=ArticlesResponse)
+async def list_public_articles(
+    request: Request,
+    widget_id: str = Query("", description="The Paw Bar widget id"),
+    signed_key: str = Query("", description="The public Site.signed_key"),
+    customer_ref: str = Query(
+        "",
+        description="Optional visitor handle for per-visitor rate accounting",
+    ),
+) -> ArticlesResponse:
+    """List the site's synced KB pages → {"articles": [{title, url, snippet}]}.
+
+    Gates are the SAME front-gate chain as chat, via ``_front_gate_for_key``:
+    unknown widget → 404, rate limit → 429, bad/unknown/revoked key → 401,
+    disallowed origin / widget∩key binding mismatch → 403. An empty KB (or a
+    site whose pages never synced) is a real state, not an error → 200 with
+    ``{"articles": []}``. The kb read itself is fail-soft the same way.
+    """
+    origin = request.headers.get("origin")
+    widget, ctx, site = await _front_gate_for_key(
+        widget_id=widget_id,
+        signed_key=signed_key,
+        customer_ref=customer_ref or _ARTICLES_DEFAULT_REF,
+        origin=origin,
+        request=request,
+    )
+
+    # Record a marker so listing reads count toward the shared rate limiter (the
+    # front gate only CHECKS the limit — same reasoning as the cart read).
+    # Best-effort; a store hiccup must not fail the read.
+    try:
+        await _store().record_event(
+            PawBarEvent(
+                widget_id=widget.id,
+                type="pawbar_articles_read",
+                payload={},
+                customer_ref=customer_ref or _ARTICLES_DEFAULT_REF,
+            )
+        )
+    except Exception:
+        logger.debug("articles-read marker record failed (non-fatal)", exc_info=True)
+
+    base_url = str(getattr(site, "url", "") or "")
+    synced = set(getattr(site, "kb_article_ids", None) or [])
+    pocket_id = ctx.pocket_id or ""
+    if not pocket_id or not base_url.strip() or not synced:
+        return ArticlesResponse(articles=[])
+
+    from pocketpaw_ee.cloud.agents.knowledge import KnowledgeService
+
+    try:
+        raw = await KnowledgeService.list_articles_for_scope(f"pocket:{pocket_id}")
+    except Exception:  # noqa: BLE001 — a kb hiccup lists nothing, never 500s
+        logger.warning("paw-bar articles: kb list failed for pocket %s", pocket_id, exc_info=True)
+        return ArticlesResponse(articles=[])
+
+    articles: list[ConciergeArticle] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        article_id = str(entry.get("id") or "")
+        title = str(entry.get("title") or "").strip()
+        # Only the page sync's own articles are listable — an owner-uploaded
+        # file sharing the pocket scope stays private.
+        if article_id not in synced or not title:
+            continue
+        url = _article_page_url(article_id, base_url)
+        if not url:
+            continue
+        snippet = " ".join(str(entry.get("summary") or "").split())[:_ARTICLE_SNIPPET_CHARS]
+        articles.append(ConciergeArticle(title=title, url=url, snippet=snippet))
+        if len(articles) >= _ARTICLES_MAX:
+            break
+    return ArticlesResponse(articles=articles)
 
 
 # ---------------------------------------------------------------------------
@@ -2794,7 +3048,7 @@ async def post_decision_contact(body: DecisionContactRequest, request: Request) 
     or on any other public read.
     """
     origin = request.headers.get("origin")
-    widget, _ctx = await _front_gate_for_key(
+    widget, _ctx, _site = await _front_gate_for_key(
         widget_id=body.widget_id,
         signed_key=body.signed_key,
         customer_ref=body.customer_ref,

--- a/ee/pocketpaw_ee/paw_bar/static/paw-bar.js
+++ b/ee/pocketpaw_ee/paw_bar/static/paw-bar.js
@@ -197,6 +197,11 @@
           }
           break;
         }
+        case 'pawbar:dead':
+          // The frame declined to render (concierge disabled / unusable
+          // allowlist): remove the iframe entirely so the site shows NOTHING.
+          iframe.remove();
+          break;
         case 'pawbar:open':
           overlay = true;
           goFullscreen();

--- a/tests/cloud/test_paw_bar_concierge_settings.py
+++ b/tests/cloud/test_paw_bar_concierge_settings.py
@@ -148,7 +148,10 @@ async def test_frame_disabled_concierge_is_403(client):
     await _site(concierge_enabled=False)
     res = await c.get("/paw-bar/frame", params={"key": _VALID_KEY})
     assert res.status_code == 403
-    assert "concierge_disabled" in res.text
+    # The refusal renders inside a VISIBLE iframe — it must be the blank
+    # self-removing shell, never an error payload (2026-07-30 rig report).
+    assert res.text.startswith("<!doctype html>")
+    assert "concierge_disabled" not in res.text
 
 
 @pytest.mark.asyncio
@@ -312,7 +315,9 @@ async def test_toggle_off_silences_frame_immediately(client):
 
     after = await c.get("/paw-bar/frame", params={"key": _VALID_KEY})
     assert after.status_code == 403
-    assert "concierge_disabled" in after.text
+    # Blank shell, not an error payload — the body renders on the site.
+    assert after.text.startswith("<!doctype html>")
+    assert "concierge_disabled" not in after.text
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/cloud/test_paw_bar_frame.py
+++ b/tests/cloud/test_paw_bar_frame.py
@@ -411,7 +411,7 @@ class TestDeadFrameShell:
         from pocketpaw_ee.paw_bar.router import _dead_frame_response
 
         allowed = _dead_frame_response("https://brewco.com", ["brewco.com"]).body.decode()
-        assert "pawbar:'dead'" in allowed and "https://brewco.com" in allowed
+        assert "type:'pawbar:dead'" in allowed and "https://brewco.com" in allowed
         # An unlisted parent gets NO script — nothing is posted anywhere.
         stranger = _dead_frame_response("https://evil.example", ["brewco.com"]).body.decode()
         assert "postMessage" not in stranger

--- a/tests/cloud/test_paw_bar_frame.py
+++ b/tests/cloud/test_paw_bar_frame.py
@@ -389,3 +389,29 @@ async def test_chat_frozen_inline_origin_still_works(chat_client, monkeypatch):
     )
     assert res.status_code == 200
     assert len(fake_exec.submitted) == 1
+
+
+class TestDeadFrameShell:
+    """A refused frame renders INSIDE a visible iframe on the customer's site —
+    the body must be a blank self-removing shell, never an error payload
+    (2026-07-30 captain report: literal JSON on the page while disabled)."""
+
+    def test_dead_frame_is_blank_html_403(self) -> None:
+        from pocketpaw_ee.paw_bar.router import _dead_frame_response
+
+        res = _dead_frame_response("", ["brewco.com"])
+        assert res.status_code == 403
+        body = res.body.decode()
+        assert body.startswith("<!doctype html>")
+        # Never an error payload — no JSON detail shape anywhere in the shell.
+        assert '"detail"' not in body and "concierge_disabled" not in body
+        assert res.headers["cache-control"] == "no-store"
+
+    def test_dead_frame_posts_dead_to_validated_parent_only(self) -> None:
+        from pocketpaw_ee.paw_bar.router import _dead_frame_response
+
+        allowed = _dead_frame_response("https://brewco.com", ["brewco.com"]).body.decode()
+        assert "pawbar:'dead'" in allowed and "https://brewco.com" in allowed
+        # An unlisted parent gets NO script — nothing is posted anywhere.
+        stranger = _dead_frame_response("https://evil.example", ["brewco.com"]).body.decode()
+        assert "postMessage" not in stranger

--- a/tests/cloud/test_paw_bar_reply_sources.py
+++ b/tests/cloud/test_paw_bar_reply_sources.py
@@ -1,0 +1,553 @@
+# tests/cloud/test_paw_bar_reply_sources.py — visible grounding for the concierge.
+# Created 2026-07-30: covers the two public grounding surfaces added on
+# feat/paw-bar-reply-sources, against the exact contracts the widget team builds on:
+#   * The ``sources`` SSE event on POST /paw-bar/chat — at most ONE event, shaped
+#     {"sources": [{"title", "url"}]}, max 3 entries, deduped by url, entries need
+#     BOTH a non-empty title and url, emitted after the model stream completes and
+#     BEFORE stream_end, and emitted not at all (no empty event) when the KB is
+#     empty, the search errors, or no hit maps to a synced public page. Hits are
+#     filtered to ``Site.kb_article_ids`` so an owner-uploaded private file never
+#     surfaces as a public source.
+#   * GET /paw-bar/articles — {"articles": [{title, url, snippet}]}, sourced from
+#     the site's synced KB pages, cap 20, snippet ≤160 plain chars, behind the SAME
+#     front-gate chain as chat (404 unknown widget → 429 rate limit → 401 bad key →
+#     403 origin/binding), empty KB → 200 with an empty list, kb errors fail-soft.
+# The kb-go subprocess boundary (KnowledgeService.search_articles_for_scope /
+# list_articles_for_scope) is patched — the mapping/filter/cap logic under test is
+# real; only the external binary is stubbed.
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from pocketpaw.paw_bar.models import PawBarBlock, PawBarEvent, PawBarSpec, PawBarWidget
+from pocketpaw.paw_bar.store import PawBarStore
+
+_VALID_KEY = "site_key_" + "a" * 24
+_ORIGIN = "https://brewco.com"
+_SITE_URL = "https://brewco.pawsites.dev"
+
+
+def _spec(pocket_id="pocket-1") -> PawBarSpec:
+    return PawBarSpec(
+        widget_id="pp_seed",
+        pocket_id=pocket_id,
+        blocks=[PawBarBlock(type="text", content="Hi from Brew & Co")],
+    )
+
+
+def _widget(**ov) -> PawBarWidget:
+    d = dict(
+        pocket_id="pocket-1",
+        owner="user:maya",
+        name="Brew & Co",
+        spec=_spec(),
+        allowed_domains=["brewco.com"],
+        agent_id="agent-xyz",
+        workspace_id="ws-1",
+        rate_limit_per_min=60,
+        per_customer_limit_per_min=10,
+    )
+    d.update(ov)
+    return PawBarWidget(**d)
+
+
+async def _site(**ov):
+    from pocketpaw_ee.cloud.models.site import Site
+
+    d = dict(
+        workspace="ws-1",
+        pocket_id="pocket-1",
+        owner="user:maya",
+        script_name="",
+        signed_key=_VALID_KEY,
+        allowed_origins=["brewco.com"],
+        url=_SITE_URL,
+        kb_article_ids=["site-home", "site-hours", "site-menu"],
+    )
+    d.update(ov)
+    s = Site(**d)
+    await s.insert()
+    return s
+
+
+class _FakeExecutor:
+    """Writes a canned reply + stream_end to the transport so the SSE tail
+    terminates without a live agent run."""
+
+    def __init__(self, transport) -> None:
+        self.transport = transport
+        self.submitted: list = []
+
+    async def submit(self, spec) -> None:
+        self.submitted.append(spec)
+        await self.transport.append_event(
+            spec.run_id, "chunk", {"content": "We open at 8am!", "type": "text"}
+        )
+        await self.transport.append_event(
+            spec.run_id, "stream_end", {"assistant_message_id": "m1", "cancelled": False}
+        )
+
+
+@pytest_asyncio.fixture
+async def concierge_client(tmp_path, mongo_db):
+    """A public app client backed by a tmp store + Beanie — yields (client, store)."""
+    from unittest.mock import patch
+
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.paw_bar.router import router
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(router)
+
+    store = PawBarStore(tmp_path / "sources.db")
+    with patch("pocketpaw_ee.paw_bar.router._store", return_value=store):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            yield client, store
+
+
+def _payload(widget_id: str, **ov) -> dict:
+    p = dict(
+        widget_id=widget_id,
+        signed_key=_VALID_KEY,
+        customer_ref="cust-1",
+        message="What time do you open?",
+    )
+    p.update(ov)
+    return p
+
+
+def _sse_events(body: str) -> list[tuple[str, dict | None]]:
+    """Parse an SSE body into ordered (event, data) tuples."""
+    events: list[tuple[str, dict | None]] = []
+    for block in body.split("\n\n"):
+        name, data = None, None
+        for line in block.splitlines():
+            if line.startswith("event: "):
+                name = line[len("event: ") :]
+            elif line.startswith("data: "):
+                data = json.loads(line[len("data: ") :])
+        if name:
+            events.append((name, data))
+    return events
+
+
+def _stub_run_machinery(monkeypatch):
+    """Force the in-memory transport + a canned executor; stub create_run."""
+    from pocketpaw_ee.cloud.chat.runs.memory_stream import InMemoryStreamTransport
+
+    transport = InMemoryStreamTransport()
+    fake_exec = _FakeExecutor(transport)
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.chat.runs.transport.get_stream_transport", lambda: transport
+    )
+    monkeypatch.setattr("pocketpaw_ee.cloud.chat.runs.executor.get_executor", lambda: fake_exec)
+
+    async def _fake_create_run(spec):
+        return SimpleNamespace(run_id=spec.run_id)
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.chat.runs.service.create_run", _fake_create_run)
+    return fake_exec
+
+
+def _stub_kb_search(monkeypatch, hits, *, calls: list | None = None, boom: bool = False):
+    """Patch the kb-go subprocess boundary for the sources search."""
+    from pocketpaw_ee.cloud.agents.knowledge import KnowledgeService
+
+    async def _search(scope, query, limit=5):
+        if calls is not None:
+            calls.append((scope, query, limit))
+        if boom:
+            raise RuntimeError("kb binary unavailable")
+        return hits
+
+    monkeypatch.setattr(KnowledgeService, "search_articles_for_scope", staticmethod(_search))
+
+
+async def _chat(client, widget_id: str, **payload_ov):
+    res = await client.post(
+        "/paw-bar/chat", json=_payload(widget_id, **payload_ov), headers={"Origin": _ORIGIN}
+    )
+    assert res.status_code == 200, res.text
+    return _sse_events(res.text)
+
+
+# --------------------------------------------------------------------------- #
+# The ``sources`` SSE event
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_sources_event_emitted_with_synced_kb(concierge_client, monkeypatch):
+    """Hits that map to synced pages ride ONE ``sources`` event, in the exact
+    contract shape, searched against the run's own pocket scope."""
+    client, store = concierge_client
+    await _site()
+    widget = await store.create_widget(_widget())
+    _stub_run_machinery(monkeypatch)
+    calls: list = []
+    _stub_kb_search(
+        monkeypatch,
+        [
+            {"id": "site-hours", "title": "Opening Hours", "summary": "8am daily"},
+            {"id": "site-menu", "title": "Our Menu", "summary": "Coffee and buns"},
+        ],
+        calls=calls,
+    )
+
+    events = await _chat(client, widget.id)
+
+    sources = [d for name, d in events if name == "sources"]
+    assert sources == [
+        {
+            "sources": [
+                {"title": "Opening Hours", "url": f"{_SITE_URL}/hours"},
+                {"title": "Our Menu", "url": f"{_SITE_URL}/menu"},
+            ]
+        }
+    ]
+    # The search ran against the SAME scope the concierge run reads, with the
+    # visitor's own message as the query.
+    assert calls and calls[0][0] == "pocket:pocket-1"
+    assert calls[0][1] == "What time do you open?"
+
+
+@pytest.mark.asyncio
+async def test_sources_event_precedes_stream_end(concierge_client, monkeypatch):
+    """CONTRACT: after the model stream, before stream_end — never after it."""
+    client, store = concierge_client
+    await _site()
+    widget = await store.create_widget(_widget())
+    _stub_run_machinery(monkeypatch)
+    _stub_kb_search(monkeypatch, [{"id": "site-hours", "title": "Opening Hours"}])
+
+    events = await _chat(client, widget.id)
+
+    names = [name for name, _ in events]
+    assert names.count("sources") == 1
+    assert names.index("chunk") < names.index("sources") < names.index("stream_end")
+    assert names[-1] == "stream_end"  # nothing, sources included, follows stream_end
+
+
+@pytest.mark.asyncio
+async def test_sources_capped_at_three_and_deduped_by_url(concierge_client, monkeypatch):
+    """Five mappable hits, the first two landing on the same page → the dupe is
+    dropped and the event carries exactly three entries."""
+    client, store = concierge_client
+    await _site(
+        kb_article_ids=["site-home", "site-hours", "site-menu", "site-about", "site-contact"]
+    )
+    widget = await store.create_widget(_widget())
+    _stub_run_machinery(monkeypatch)
+    _stub_kb_search(
+        monkeypatch,
+        [
+            {"id": "site-hours", "title": "Opening Hours"},
+            {"id": "site-hours", "title": "Opening Hours (dupe)"},  # same url → dropped
+            {"id": "site-menu", "title": "Our Menu"},
+            {"id": "site-about", "title": "About Us"},
+            {"id": "site-contact", "title": "Contact"},  # over the cap → dropped
+        ],
+    )
+
+    events = await _chat(client, widget.id)
+
+    (payload,) = [d for name, d in events if name == "sources"]
+    assert [s["url"] for s in payload["sources"]] == [
+        f"{_SITE_URL}/hours",
+        f"{_SITE_URL}/menu",
+        f"{_SITE_URL}/about",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_sources_drop_unsynced_and_untitled_hits(concierge_client, monkeypatch):
+    """A hit outside ``Site.kb_article_ids`` (an owner-uploaded file in the same
+    pocket scope) and a hit with no title never surface."""
+    client, store = concierge_client
+    await _site(kb_article_ids=["site-hours"])
+    widget = await store.create_widget(_widget())
+    _stub_run_machinery(monkeypatch)
+    _stub_kb_search(
+        monkeypatch,
+        [
+            {"id": "internal-price-sheet", "title": "Internal Price Sheet"},  # not synced
+            {"id": "site-hours", "title": ""},  # no title
+            {"id": "site-hours", "title": "Opening Hours"},
+        ],
+    )
+
+    events = await _chat(client, widget.id)
+
+    (payload,) = [d for name, d in events if name == "sources"]
+    assert payload == {"sources": [{"title": "Opening Hours", "url": f"{_SITE_URL}/hours"}]}
+
+
+@pytest.mark.asyncio
+async def test_no_sources_event_when_kb_is_empty(concierge_client, monkeypatch):
+    """No qualifying hit → NOTHING is emitted (no empty ``sources`` event)."""
+    client, store = concierge_client
+    await _site()
+    widget = await store.create_widget(_widget())
+    _stub_run_machinery(monkeypatch)
+    _stub_kb_search(monkeypatch, [])
+
+    events = await _chat(client, widget.id)
+
+    assert "sources" not in [name for name, _ in events]
+    assert [name for name, _ in events][-1] == "stream_end"  # the stream still ends cleanly
+
+
+@pytest.mark.asyncio
+async def test_no_sources_event_when_search_errors(concierge_client, monkeypatch):
+    """Fail-soft: a kb failure costs the sources, never the reply."""
+    client, store = concierge_client
+    await _site()
+    widget = await store.create_widget(_widget())
+    _stub_run_machinery(monkeypatch)
+    _stub_kb_search(monkeypatch, [], boom=True)
+
+    events = await _chat(client, widget.id)
+
+    names = [name for name, _ in events]
+    assert "sources" not in names
+    assert "chunk" in names and names[-1] == "stream_end"
+
+
+@pytest.mark.asyncio
+async def test_no_sources_event_when_site_has_no_synced_pages(concierge_client, monkeypatch):
+    """A site whose pages never synced (empty kb_article_ids) emits nothing —
+    and never even hits the kb binary."""
+    client, store = concierge_client
+    await _site(kb_article_ids=[])
+    widget = await store.create_widget(_widget())
+    _stub_run_machinery(monkeypatch)
+    calls: list = []
+    _stub_kb_search(monkeypatch, [{"id": "site-hours", "title": "Opening Hours"}], calls=calls)
+
+    events = await _chat(client, widget.id)
+
+    assert "sources" not in [name for name, _ in events]
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_home_article_maps_to_site_root(concierge_client, monkeypatch):
+    """The index page's ``site-home`` article links to the site root, not /home."""
+    client, store = concierge_client
+    await _site()
+    widget = await store.create_widget(_widget())
+    _stub_run_machinery(monkeypatch)
+    _stub_kb_search(monkeypatch, [{"id": "site-home", "title": "Brew & Co"}])
+
+    events = await _chat(client, widget.id)
+
+    (payload,) = [d for name, d in events if name == "sources"]
+    assert payload == {"sources": [{"title": "Brew & Co", "url": f"{_SITE_URL}/"}]}
+
+
+# --------------------------------------------------------------------------- #
+# GET /paw-bar/articles
+# --------------------------------------------------------------------------- #
+
+
+def _stub_kb_list(monkeypatch, articles, *, boom: bool = False):
+    from pocketpaw_ee.cloud.agents.knowledge import KnowledgeService
+
+    async def _list(scope):
+        if boom:
+            raise RuntimeError("kb binary unavailable")
+        return articles
+
+    monkeypatch.setattr(KnowledgeService, "list_articles_for_scope", staticmethod(_list))
+
+
+def _articles_params(widget_id: str, **ov) -> dict:
+    p = dict(widget_id=widget_id, signed_key=_VALID_KEY)
+    p.update(ov)
+    return p
+
+
+@pytest.mark.asyncio
+async def test_articles_happy_path(concierge_client, monkeypatch):
+    """Synced pages come back as {title, url, snippet}; an owner-uploaded article
+    sharing the pocket scope is never listed."""
+    client, store = concierge_client
+    await _site(kb_article_ids=["site-home", "site-hours"])
+    widget = await store.create_widget(_widget())
+    _stub_kb_list(
+        monkeypatch,
+        [
+            {"id": "site-home", "title": "Brew & Co", "summary": "A  neighbourhood\ncoffee shop"},
+            {"id": "site-hours", "title": "Opening Hours", "summary": "8am to 6pm, daily"},
+            {"id": "owner-upload", "title": "Supplier Contract", "summary": "private"},
+        ],
+    )
+
+    res = await client.get(
+        "/paw-bar/articles", params=_articles_params(widget.id), headers={"Origin": _ORIGIN}
+    )
+
+    assert res.status_code == 200
+    assert res.json() == {
+        "articles": [
+            {
+                "title": "Brew & Co",
+                "url": f"{_SITE_URL}/",
+                "snippet": "A neighbourhood coffee shop",
+            },
+            {
+                "title": "Opening Hours",
+                "url": f"{_SITE_URL}/hours",
+                "snippet": "8am to 6pm, daily",
+            },
+        ]
+    }
+
+
+@pytest.mark.asyncio
+async def test_articles_snippet_is_capped_at_160_plain_chars(concierge_client, monkeypatch):
+    client, store = concierge_client
+    await _site(kb_article_ids=["site-hours"])
+    widget = await store.create_widget(_widget())
+    _stub_kb_list(monkeypatch, [{"id": "site-hours", "title": "Hours", "summary": "x" * 400}])
+
+    res = await client.get(
+        "/paw-bar/articles", params=_articles_params(widget.id), headers={"Origin": _ORIGIN}
+    )
+
+    assert res.status_code == 200
+    (article,) = res.json()["articles"]
+    assert len(article["snippet"]) == 160
+
+
+@pytest.mark.asyncio
+async def test_articles_capped_at_twenty(concierge_client, monkeypatch):
+    client, store = concierge_client
+    ids = [f"site-page-{i}" for i in range(30)]
+    await _site(kb_article_ids=ids)
+    widget = await store.create_widget(_widget())
+    _stub_kb_list(
+        monkeypatch, [{"id": i, "title": f"Page {i}", "summary": "text here"} for i in ids]
+    )
+
+    res = await client.get(
+        "/paw-bar/articles", params=_articles_params(widget.id), headers={"Origin": _ORIGIN}
+    )
+
+    assert res.status_code == 200
+    assert len(res.json()["articles"]) == 20
+
+
+@pytest.mark.asyncio
+async def test_articles_empty_kb_is_200_with_empty_list(concierge_client, monkeypatch):
+    client, store = concierge_client
+    await _site(kb_article_ids=[])
+    widget = await store.create_widget(_widget())
+    _stub_kb_list(monkeypatch, [])
+
+    res = await client.get(
+        "/paw-bar/articles", params=_articles_params(widget.id), headers={"Origin": _ORIGIN}
+    )
+
+    assert res.status_code == 200
+    assert res.json() == {"articles": []}
+
+
+@pytest.mark.asyncio
+async def test_articles_kb_error_is_200_with_empty_list(concierge_client, monkeypatch):
+    """Fail-soft like the rest of the KB reads — a kb hiccup never 500s a visitor."""
+    client, store = concierge_client
+    await _site()
+    widget = await store.create_widget(_widget())
+    _stub_kb_list(monkeypatch, [], boom=True)
+
+    res = await client.get(
+        "/paw-bar/articles", params=_articles_params(widget.id), headers={"Origin": _ORIGIN}
+    )
+
+    assert res.status_code == 200
+    assert res.json() == {"articles": []}
+
+
+@pytest.mark.asyncio
+async def test_articles_unknown_widget_is_404(concierge_client):
+    client, _store = concierge_client
+    await _site()
+    res = await client.get(
+        "/paw-bar/articles", params=_articles_params("nope"), headers={"Origin": _ORIGIN}
+    )
+    assert res.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_articles_rate_limit_is_429(concierge_client):
+    client, store = concierge_client
+    await _site()
+    widget = await store.create_widget(_widget(rate_limit_per_min=2))
+    for _ in range(2):
+        await store.record_event(
+            PawBarEvent(widget_id=widget.id, type="pawbar_articles_read", customer_ref="cust-1")
+        )
+    res = await client.get(
+        "/paw-bar/articles", params=_articles_params(widget.id), headers={"Origin": _ORIGIN}
+    )
+    assert res.status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_articles_bad_key_is_401(concierge_client):
+    client, store = concierge_client
+    await _site()
+    widget = await store.create_widget(_widget())
+    res = await client.get(
+        "/paw-bar/articles",
+        params=_articles_params(widget.id, signed_key="short"),
+        headers={"Origin": _ORIGIN},
+    )
+    assert res.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_articles_wrong_origin_is_403(concierge_client):
+    client, store = concierge_client
+    await _site()
+    widget = await store.create_widget(_widget())
+    res = await client.get(
+        "/paw-bar/articles",
+        params=_articles_params(widget.id),
+        headers={"Origin": "https://evil.example"},
+    )
+    assert res.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_articles_widget_bound_to_sibling_pocket_is_403(concierge_client):
+    client, store = concierge_client
+    await _site(pocket_id="pocket-A")
+    widget = await store.create_widget(
+        _widget(pocket_id="pocket-B", spec=_spec(pocket_id="pocket-B"))
+    )
+    res = await client.get(
+        "/paw-bar/articles", params=_articles_params(widget.id), headers={"Origin": _ORIGIN}
+    )
+    assert res.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_articles_widget_from_other_workspace_is_403(concierge_client):
+    client, store = concierge_client
+    await _site()
+    widget = await store.create_widget(_widget(workspace_id="ws-other"))
+    res = await client.get(
+        "/paw-bar/articles", params=_articles_params(widget.id), headers={"Origin": _ORIGIN}
+    )
+    assert res.status_code == 403

--- a/tests/cloud/test_paw_bar_reply_sources.py
+++ b/tests/cloud/test_paw_bar_reply_sources.py
@@ -551,3 +551,18 @@ async def test_articles_widget_from_other_workspace_is_403(concierge_client):
         "/paw-bar/articles", params=_articles_params(widget.id), headers={"Origin": _ORIGIN}
     )
     assert res.status_code == 403
+
+
+class TestHumanizedTitles:
+    """Slug-shaped article ids never reach the visitor as titles (2026-07-30
+    rig smoke: chips read "site-services")."""
+
+    def test_slug_titles_humanize(self) -> None:
+        from pocketpaw_ee.paw_bar.router import _humanize_article_title
+
+        assert _humanize_article_title("site-home") == "Home"
+        assert _humanize_article_title("site-services") == "Services"
+        assert _humanize_article_title("site-contact-us") == "Contact Us"
+        assert _humanize_article_title("site-") == "Home"
+        # A real compiled title passes through untouched.
+        assert _humanize_article_title("Our Service Areas") == "Our Service Areas"

--- a/tests/cloud/test_paw_bar_reply_sources.py
+++ b/tests/cloud/test_paw_bar_reply_sources.py
@@ -566,3 +566,53 @@ class TestHumanizedTitles:
         assert _humanize_article_title("site-") == "Home"
         # A real compiled title passes through untouched.
         assert _humanize_article_title("Our Service Areas") == "Our Service Areas"
+
+
+class TestSameOriginFrameGets:
+    """Same-origin GETs from OUR frame carry no Origin header (browsers omit it)
+    — the gates must resolve Sec-Fetch-Site: same-origin as the frame origin
+    instead of 403ing (2026-07-30 rig find: the frame's articles fetch and
+    decision poll were dead)."""
+
+    async def test_articles_same_origin_no_origin_header_passes(
+        self, concierge_client, monkeypatch
+    ) -> None:
+        client, store = concierge_client
+        await _site(kb_article_ids=["site-home"])
+        widget = await store.create_widget(_widget())
+        _stub_kb_list(monkeypatch, [{"id": "site-home", "title": "Home", "summary": "hi"}])
+
+        res = await client.get(
+            "/paw-bar/articles",
+            params=_articles_params(widget.id),
+            headers={"Sec-Fetch-Site": "same-origin"},
+        )
+        assert res.status_code == 200
+
+    async def test_articles_originless_without_fetch_metadata_stays_403(
+        self, concierge_client, monkeypatch
+    ) -> None:
+        client, store = concierge_client
+        await _site(kb_article_ids=["site-home"])
+        widget = await store.create_widget(_widget())
+        _stub_kb_list(monkeypatch, [{"id": "site-home", "title": "Home", "summary": "hi"}])
+
+        res = await client.get("/paw-bar/articles", params=_articles_params(widget.id))
+        assert res.status_code == 403
+
+    async def test_articles_cross_site_fetch_metadata_stays_gated(
+        self, concierge_client, monkeypatch
+    ) -> None:
+        # A cross-site GET (Sec-Fetch-Site: cross-site, no Origin) must not
+        # inherit the frame's pass — it stays on the fail-closed allowlist gate.
+        client, store = concierge_client
+        await _site(kb_article_ids=["site-home"])
+        widget = await store.create_widget(_widget())
+        _stub_kb_list(monkeypatch, [{"id": "site-home", "title": "Home", "summary": "hi"}])
+
+        res = await client.get(
+            "/paw-bar/articles",
+            params=_articles_params(widget.id),
+            headers={"Sec-Fetch-Site": "cross-site"},
+        )
+        assert res.status_code == 403


### PR DESCRIPTION
Stacked on #1818 (`feat/paw-bar-async-email`).

A concierge reply used to arrive with no trail — the visitor couldn't tell which page an answer came from, and there was no way to browse what the bar can quote. This adds both halves of visible grounding, per-reply attribution and a browsable library.

## Sources on each reply

`concierge_chat` now emits at most one `sources` SSE event, after the model stream completes and immediately before `stream_end`:

```
event: sources
data: {"sources": [{"title": "Opening Hours", "url": "https://brewco.pawsites.dev/hours"}]}
```

Max 3 entries, deduped by url, and only entries with both a title and a url. Nothing is emitted when nothing qualifies — no empty event.

Attribution is approximate on purpose (the Crisp-style "Sources" pattern): the server re-runs a cheap KB search of the visitor's message against the same `pocket:<pocket_id>` scope the run reads, keeps hits whose article ids are in `Site.kb_article_ids` (the page sync's own output — owner-uploaded files never surface), and maps the `site-<slug>` ids back to public page URLs. It is not a tool trace. The search runs concurrently with the model turn, so it adds ~0ms to the stream; any error or timeout drops the sources, never the reply.

## Public articles listing

`GET /paw-bar/articles?widget_id=...&signed_key=...` returns `{"articles": [{title, url, snippet}]}` — the site's synced KB pages, cap 20, snippet ≤160 plain-text chars. Same front-gate chain as chat (404 unknown widget → 429 rate limit → 401 bad key → 403 origin/binding), no injection screen since there's no free text. Empty KB is a 200 with an empty list, and a kb hiccup fails soft the same way.

To support this, `_front_gate_for_key` now resolves through `resolve_site_key_with_site` and returns the Site it already loaded (same pattern as the chat path), and `KnowledgeService` grows scope-form read methods (`search_articles_for_scope` / `list_articles_for_scope`) so the router doesn't reach into the private `_kb` wrapper.

## Tests

19 new tests in `tests/cloud/test_paw_bar_reply_sources.py` (event shape, cap + dedupe, synced-only filter, ordering vs `stream_end`, fail-soft on empty/erroring KB, and every articles refusal code). Full paw-bar set: 312 passed. Ruff + both import-linter configs clean.

Docs: `docs/concepts/concierge-knowledge.mdx` gains a "What the visitor sees as sources" section.