### PR TITLE
Concierge form cards: structured collection of gated-action details

### DIFF
--- a/ee/pocketpaw_ee/cloud/surface/handlers/concierge.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/concierge.py
@@ -1,5 +1,14 @@
 # concierge.py — /paw-bar surface preamble (the public concierge widget).
 #
+# Updated: 2026-07-30 (form cards) — when the widget declares GATED actions
+# that take args, the actions paragraph now teaches a second ```pawbar-card
+# kind: "form". Instead of asking the visitor for name/phone/etc. in prose,
+# the agent emits a structured form card (verb + fields drawn from the
+# action's declared args, with a name-based type mapping spelled out in the
+# prompt), waits for the widget to submit it, and only falls back to calling
+# the tool directly when the visitor's message already carries every detail.
+# Widgets with no gated-with-args actions render no form instructions.
+#
 # Updated: 2026-07-16 (C1 hardening) — the conditional actions paragraph now also
 # renders a COMPACT catalog block (real product ids + names + formatted prices from
 # meta.pawbar_catalog) so the agent can name what it sells and emit pawbar-card
@@ -75,6 +84,58 @@ def _catalog_block(catalog: list[dict] | None) -> str:
     )
 
 
+def _form_block(declared: list[dict]) -> str:
+    """Build the form-card instructions for gated actions that take args.
+
+    Lists each gated action's declared args (name + type) and teaches the
+    ```pawbar-card kind "form" fence, including the name-based field-type
+    mapping the agent applies itself — this slice puts the mapping in the
+    prompt text, with no server-side enforcement. Empty string when no gated
+    action declares any args (nothing to build a form for)."""
+    gated: list[tuple[str, dict]] = []
+    for a in declared:
+        if str(a.get("policy") or "gated") == "auto":
+            continue
+        args = a.get("args")
+        if isinstance(args, dict) and args:
+            gated.append((str(a["verb"]), args))
+    if not gated:
+        return ""
+    arg_lines = []
+    for verb, args in gated:
+        listed = ", ".join(f"{name} ({typ})" for name, typ in args.items())
+        arg_lines.append(f"     - {verb}: {listed}")
+    args_list = "\n".join(arg_lines)
+    return (
+        "   FORMS for gated actions: when the visitor wants one of the gated "
+        "actions above and you do not yet have all the details it needs, do "
+        "NOT ask for them in prose — emit ONE fenced ```pawbar-card block of "
+        'kind "form" so the widget renders a real form. Use this EXACT '
+        "format:\n"
+        "   ```pawbar-card\n"
+        '   {"kind": "form", "verb": "<gated verb>", "title": "<short '
+        'title>", "submit_label": "<button text>", "fields": [{"name": '
+        '"<arg name>", "label": "<Human label>", "type": "text"}]}\n'
+        "   ```\n"
+        "   Form rules:\n"
+        '   - "verb" must be a gated verb listed above, and every field '
+        '"name" must be one of that verb\'s declared args:\n'
+        f"{args_list}\n"
+        '   - Each field\'s "type" must be one of text | tel | email | '
+        "number | textarea. Derive it from the arg: int and float args -> "
+        '"number"; str args -> "tel" if the arg name contains "phone", '
+        '"email" if it contains "email", "textarea" if it contains '
+        '"message", "notes", or "issue", otherwise "text". Never put a bool '
+        "arg in a form — leave bool args out.\n"
+        "   - Emit the form ONCE, then STOP and wait. The widget submits it "
+        "and runs the action itself; you will see the outcome in the "
+        "conversation on your next turn — do not call the action tool for a "
+        "form you emitted.\n"
+        "   - If the visitor's message ALREADY contains every detail the "
+        "action needs, skip the form and call the action tool directly.\n"
+    )
+
+
 def _actions_paragraph(actions: list[dict] | None, catalog: list[dict] | None) -> str:
     """Build procedure step 4 — the actions half.
 
@@ -122,6 +183,7 @@ def _actions_paragraph(actions: list[dict] | None, catalog: list[dict] | None) -
         "   Use only product ids/fields listed above or in the site knowledge; "
         "never invent a product or a price. Do NOT run code, browse the web, or "
         "take any action beyond the tools listed above.\n"
+        f"{_form_block(declared)}"
     )
 
 

--- a/ee/pocketpaw_ee/paw_bar/decision_loop.py
+++ b/ee/pocketpaw_ee/paw_bar/decision_loop.py
@@ -438,7 +438,14 @@ async def propose_customer_action(
             "default_reply": default_reply,
             "payload_summary": summary,
         }
-        store = get_instinct_store()
+        # ISO-2 store routing — the SAME per-workspace factory the event path
+        # uses (H1). The bare factory only resolved the right store when an
+        # AGENT run's ContextVars carried the workspace; the PUBLIC
+        # POST /paw-bar/action endpoint has no run context, so a form-card
+        # submit landed its proposal in the BARE instinct.db — invisible to the
+        # owner's workspace-scoped Tray/dashboard (found live 2026-07-30, first
+        # exercise of the endpoint path off an agent run).
+        store = get_instinct_store(workspace_id=ws or None)
         action = await store.propose(
             pocket_id=pocket_id or widget_id,
             title=title,

--- a/tests/cloud/test_paw_bar_actions.py
+++ b/tests/cloud/test_paw_bar_actions.py
@@ -1,4 +1,8 @@
 # tests/cloud/test_paw_bar_actions.py — Paw Bar action registry (C1), end to end.
+# Updated 2026-07-30: TestFormCardPreamble pins the form-card instruction block —
+# rendered only for gated actions WITH args (contract fence, per-verb arg list,
+# name-based type mapping, emit-once + skip-when-details-present), absent for
+# no-actions / auto-only / gated-argless widgets.
 # Created 2026-07-16: covers the visitor commerce loop + the concierge tool
 # injection. Layers:
 #   * Spec validation — bad action/catalog/checkout declarations are rejected.
@@ -754,3 +758,89 @@ class TestCatalogPreamble:
         pre = await build_preamble("ws", "u", SurfaceMeta(route_path="/paw-bar"))
         assert "Products you can sell" not in pre
         assert "don't act" in pre
+
+
+class TestFormCardPreamble:
+    """The form-card instruction block: rendered only for gated actions with args."""
+
+    @staticmethod
+    async def _preamble(actions: list[dict]) -> str:
+        from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
+        from pocketpaw_ee.cloud.surface.handlers.concierge import build_preamble
+
+        return await build_preamble(
+            "ws", "u", SurfaceMeta(route_path="/paw-bar", pawbar_actions=actions)
+        )
+
+    async def test_gated_action_with_args_renders_form_instructions(self) -> None:
+        """A gated action with typed args teaches the "form" pawbar-card: the
+        contract fence, the verb's arg list, and the name-based type mapping."""
+        pre = await self._preamble(
+            [
+                {
+                    "verb": "book_visit",
+                    "policy": "gated",
+                    "args": {"name": "str", "phone": "str", "issue": "str"},
+                    "label": "Book a visit",
+                }
+            ]
+        )
+        assert '"kind": "form"' in pre
+        assert "FORMS for gated actions" in pre
+        # The verb's declared args are listed so field names stay in-contract.
+        assert "book_visit: name (str), phone (str), issue (str)" in pre
+        # The type mapping travels in the prompt (no server-side enforcement).
+        assert "text | tel | email | number | textarea" in pre
+        assert '"tel" if the arg name contains "phone"' in pre
+        # Emit-once + skip-when-details-present behavior is instructed.
+        assert "Emit the form ONCE" in pre
+        assert "skip the form and call the action tool directly" in pre
+
+    async def test_no_actions_has_no_form_instructions(self) -> None:
+        from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
+        from pocketpaw_ee.cloud.surface.handlers.concierge import build_preamble
+
+        pre = await build_preamble("ws", "u", SurfaceMeta(route_path="/paw-bar"))
+        assert "FORMS for gated actions" not in pre
+        assert '"kind": "form"' not in pre
+
+    async def test_auto_only_actions_have_no_form_instructions(self) -> None:
+        """Auto actions run immediately — no gate, no form."""
+        pre = await self._preamble(
+            [
+                {
+                    "verb": "add_to_cart",
+                    "policy": "auto",
+                    "args": {"product_id": "str"},
+                    "label": "Add",
+                }
+            ]
+        )
+        assert "FORMS for gated actions" not in pre
+
+    async def test_gated_action_without_args_has_no_form_instructions(self) -> None:
+        """A gated verb with no declared args has nothing to build a form for."""
+        pre = await self._preamble(
+            [{"verb": "request_callback", "policy": "gated", "args": {}, "label": "Call me"}]
+        )
+        assert "FORMS for gated actions" not in pre
+
+    async def test_mixed_actions_list_only_gated_args(self) -> None:
+        pre = await self._preamble(
+            [
+                {
+                    "verb": "add_to_cart",
+                    "policy": "auto",
+                    "args": {"product_id": "str"},
+                    "label": "Add",
+                },
+                {
+                    "verb": "book_table",
+                    "policy": "gated",
+                    "args": {"name": "str", "party_size": "int"},
+                    "label": "Book a table",
+                },
+            ]
+        )
+        assert "book_table: name (str), party_size (int)" in pre
+        assert "add_to_cart: product_id" not in pre

--- a/tests/cloud/test_paw_bar_decision_loop_tenancy.py
+++ b/tests/cloud/test_paw_bar_decision_loop_tenancy.py
@@ -107,3 +107,38 @@ async def test_cloud_proposal_lands_in_the_tenants_pending_feed(tmp_path: Path) 
     assert blob["workspace_id"] == WS_REAL, (
         f"proposal scoped to {blob['workspace_id']!r}, expected the real workspace"
     )
+
+
+async def test_gated_action_proposal_lands_in_the_tenants_pending_feed(
+    tmp_path: Path,
+) -> None:
+    """The ACTION path (public POST /paw-bar/action → propose_customer_action)
+    must route through the per-workspace store exactly like the event path.
+
+    Pre-fix (found live 2026-07-30, the first exercise of this path OFF an
+    agent run): the bare ``get_instinct_store()`` only resolved the workspace
+    when an agent run's ContextVars carried it — the public endpoint has no run
+    context, so a form-card submit landed its proposal in the BARE instinct.db,
+    invisible to the owner's workspace-scoped Tray and dashboard.
+    """
+    from pocketpaw_ee.paw_bar.decision_loop import propose_customer_action
+
+    pp_store = PawBarStore(tmp_path / "paw_bar.db")
+    action_id = await propose_customer_action(
+        widget=_widget(),
+        workspace_id=WS_REAL,
+        customer_ref="cust-1",
+        verb="book_visit",
+        args={"name": "Asha", "phone": "512-555-3344"},
+        summary="name=Asha, phone=512-555-3344",
+        paw_bar_store=pp_store,
+    )
+
+    assert action_id is not None, "the gated proposal was dropped"
+
+    dashboard_store = stores.get_instinct_store(workspace_id=WS_REAL)
+    pending = await dashboard_store.pending(workspace_id=WS_REAL)
+    assert action_id in {a.id for a in pending}, (
+        "the gated-action proposal is not in the tenant's per-workspace feed — "
+        "it landed in the bare store the dashboard never reads"
+    )


### PR DESCRIPTION
## What

A booking request came in as a prose blob — the concierge asked the visitor to "send name, phone, address" and the CRM got unusable free text. The widget spec already declares each gated action's typed args, so the concierge preamble now teaches a second `pawbar-card` kind, `form`:

```
{"kind": "form", "verb": "book_visit", "title": "Book a repair visit", "submit_label": "Send request", "fields": [{"name": "name", "label": "Name", "type": "text"}, {"name": "phone", "label": "Phone", "type": "tel"}]}
```

- `verb` must be a declared gated verb; every field `name` must be one of that verb's declared args (the preamble lists them per verb).
- `type` ∈ text | tel | email | number | textarea, derived by the agent from the arg: int/float → number; str → tel/email/textarea by name (`phone`, `email`, `message`/`notes`/`issue`), otherwise text. Bool args stay out of forms. The mapping travels in the prompt text — no server-side enforcement in this slice.
- Emit once, then wait: the widget submits the form and runs the action itself; the agent sees the outcome next turn. A message that already carries every detail skips the form and calls the tool directly, same as today.

## Scope

The block renders only when the widget declares gated actions with args. No-actions, auto-only, and gated-argless widgets keep today's preamble byte-for-byte.

## Tests

`TestFormCardPreamble` pins the contract fence, the per-verb arg list, the type-mapping text, emit-once/skip behavior, and absence for the three no-form cases. Full paw-bar set: 323 passed (`tests/cloud/test_paw_bar_*.py` + `tests/ee/test_paw_bar_customer_reply_router.py`).

Stacked on #1819: base is `feat/paw-bar-reply-sources`.
