### PR TITLE
Let a site concierge read its own agent's knowledge

### DIFF
--- a/docs/concepts/concierge-knowledge.mdx
+++ b/docs/concepts/concierge-knowledge.mdx
@@ -15,18 +15,49 @@ what it is allowed to know, and what it writes down about the people it talks to
 
 ## What a concierge is allowed to know
 
-A concierge run is locked to **one** knowledge scope: `pocket:<pocket_id>`, the
-pocket its site was published from. It cannot read the `agent:` scope or the
-workspace-wide scope. That is deliberate. The concierge answers anonymous callers
-from the public internet, and a public caller must never be able to reach the rest
-of the tenant's knowledge base by asking the right question.
+A concierge run reads exactly **two** knowledge scopes:
 
-The upshot is that a concierge's usefulness is decided entirely by what is in that
-one scope.
+- `pocket:<pocket_id>` — the pocket its site was published from, where the page
+  sync writes.
+- `agent:<agent_id>` — whatever the owner attached to this site's concierge agent
+  directly, in the agent's own Knowledge tab.
+
+It reads neither the workspace-wide scope nor any member's private scope, and that
+line is where the security argument lives. Every site concierge is a **dedicated**
+agent, one per site, created for that site and never shared — so its `agent:` scope
+is one site's own material, put there by the owner for these visitors. The
+workspace scope is the opposite: every pocket, every other agent, every owner
+upload in the tenant. A concierge answers anonymous callers from the public
+internet, so handing it the tenant-wide scope would mean a stranger could reach the
+rest of the business by asking the right question. That scope stays out.
+
+The agent it runs is not the caller's choice either. It comes from the site's own
+widget binding, and the run is refused outright if that agent does not belong to
+the site's workspace, so no visitor can steer a concierge onto a sibling agent's
+knowledge.
+
+<Callout type="warning">
+**Anything you attach to a site concierge is publishable by definition.** The
+agent's Knowledge tab is a public surface once that agent fronts a site: a
+visitor can get any of it quoted back at them by asking a question it answers.
+Put the price list you would print on the site there. Do not put the internal one.
+
+Knowledge that must stay private belongs on a different agent — an internal agent
+with no site binding reads nothing to visitors, because no visitor ever runs it.
+</Callout>
+
+`GET /api/v1/agents/{agent_id}/knowledge` reports this per agent: it returns
+`visible_to_site_visitors` beside the article list, `true` when a Paw Bar widget
+binds that agent to a published site. It reads the real binding, so an agent bound
+by hand in the dashboard counts the same as an auto-provisioned one. The flag is a
+label, not a gate — it changes nothing about who may call the endpoint (still the
+agent's owner or a workspace admin) and nothing about what a visitor can reach. It
+exists so the owner is told before they attach something, rather than after a
+visitor quotes it.
 
 ## Where the knowledge comes from
 
-The site's own pages are synced into that scope automatically.
+The site's own pages are synced into the pocket scope automatically.
 
 The content is read from the **pocket**, not from the built artifact and not by
 fetching the live site. The pocket is durable, so a sync works long after a publish
@@ -90,12 +121,14 @@ public articles listing (`GET /paw-bar/articles`, behind the same key, origin an
 rate gates as the chat; capped at twenty entries with a short snippet each).
 
 Attribution is approximate by design. The server re-runs a quick knowledge search
-of the visitor's question against the same pocket scope the run reads, and shows
-the synced pages that match — "what the knowledge base would ground this question
-on", not a verified trace of what the model actually quoted. Only pages the site
-sync itself produced can appear; owner-uploaded files sharing the scope are never
-listed or linked. When nothing matches, or the search fails, no sources are shown
-and the reply is unaffected.
+of the visitor's question against the site's pocket scope and shows the synced pages
+that match — "what the knowledge base would ground this question on", not a verified
+trace of what the model actually quoted. Only pages the site sync itself produced
+can appear. Owner-uploaded files sharing the pocket scope, and anything attached to
+the agent's own scope, are never listed or linked: they have no public URL to point
+at, so a reply can be grounded in them without them showing up as a citation. When
+nothing matches, or the search fails, no sources are shown and the reply is
+unaffected.
 
 ## What a concierge records
 

--- a/ee/pocketpaw_ee/cloud/agents/router.py
+++ b/ee/pocketpaw_ee/cloud/agents/router.py
@@ -12,6 +12,14 @@ require ``require_agent_owner_or_admin`` — same guard as PATCH/DELETE agent
 CRUD. Previously they had no RBAC guard beyond ``require_license``, so any
 workspace member could inject content into any agent's knowledge base.
 
+Updated 2026-07-30 (Paw Bar inbox D5): ``GET /agents/{id}/knowledge`` now returns
+``visible_to_site_visitors`` beside ``items``. A concierge run reads its own
+``agent:<id>`` KB scope, so knowledge attached to a site-bound agent is reachable
+by anonymous site visitors; the flag lets the Knowledge tab badge that instead of
+leaving it silent. Derived from the real widget→agent binding
+(``agents_service.is_visible_to_site_visitors``), and failure-soft — a badge must
+never break the list.
+
 Updated 2026-06-28 (feat/aiam-agent-revoke, AW-4): added
 ``PATCH /agents/{id}/disable`` and ``PATCH /agents/{id}/enable`` for the agent
 soft-disable / revoke-everywhere flow. Both carry the SAME owner/admin guard
@@ -240,14 +248,24 @@ async def search_knowledge(agent_id: str, q: str = Query(..., min_length=1), lim
 
 @router.get("/{agent_id}/knowledge")
 async def list_knowledge(agent_id: str):
-    """List all knowledge articles for an agent."""
+    """List all knowledge articles for an agent.
+
+    ``visible_to_site_visitors`` (Paw Bar inbox D5) is ``True`` when a paw-bar
+    widget binds this agent to a published Paw Site. A concierge run reads its own
+    ``agent:<id>`` scope, so on such an agent EVERYTHING listed here is readable by
+    anonymous visitors — the flag exists so the Knowledge surface can say that
+    before an owner attaches something private. It is a label, not a gate: it
+    never changes what this endpoint returns to its (already owner/admin-scoped)
+    caller.
+    """
     from pocketpaw_ee.cloud.agents.knowledge import KnowledgeService
 
     try:
         articles = await KnowledgeService.list_articles(agent_id)
     except RuntimeError as exc:
         raise HTTPException(status_code=500, detail=f"Failed to list knowledge: {exc}")
-    return {"items": articles}
+    visible = await agents_service.is_visible_to_site_visitors(agent_id)
+    return {"items": articles, "visible_to_site_visitors": visible}
 
 
 @router.get("/{agent_id}/knowledge/{article_id}")

--- a/ee/pocketpaw_ee/cloud/agents/service.py
+++ b/ee/pocketpaw_ee/cloud/agents/service.py
@@ -19,7 +19,14 @@ Public API:
 - ``get_scopes(agent_id)``
 - ``set_scopes(agent_id, scopes)``
 - ``discover(ctx, workspace_id, body)``
+- ``is_visible_to_site_visitors(agent_id)`` — does a Paw Bar widget bind this
+  agent to a published site, i.e. do anonymous visitors reach it?
 - ``legacy_ctx(user_id, workspace_id)`` — helper for the router
+
+Updated 2026-07-30 (Paw Bar inbox D5): added ``is_visible_to_site_visitors``.
+A concierge run now reads its own ``agent:<id>`` knowledge scope, so knowledge
+attached to a site concierge is publishable by definition; the agent knowledge
+read carries this flag so the owner is told that before they attach.
 
 Updated 2026-07-02 (feat/aiam-agent-revoke, AW-4 follow-up): ``get_persona``
 now returns ``None`` for a soft-disabled agent (reusing the doc it already
@@ -541,6 +548,43 @@ async def get_workspace(agent_id: str) -> str | None:
         return None
     doc = await _AgentDoc.get(agent_oid)
     return doc.workspace if doc else None
+
+
+async def is_visible_to_site_visitors(agent_id: str) -> bool:
+    """True when this agent answers ANONYMOUS visitors on a published Paw Site.
+
+    An agent is visitor-facing when a paw-bar widget is bound to it — the same
+    binding ``paw_bar.agent_provisioning.ensure_site_agent`` writes, and the same
+    one ``concierge_chat`` resolves before it runs the agent for a stranger. The
+    check reads the binding, NOT the deterministic ``concierge-<site_id>`` slug,
+    so a hand-bound agent is recognised too.
+
+    Why this exists (Paw Bar inbox D5): a concierge run now reads its own
+    ``agent:<id>`` KB scope alongside the site pocket
+    (``chat.agent_service._kb_scopes_for_context``). That is what makes the
+    Knowledge tab useful for a site owner — and it also means **anything attached
+    to this agent is publishable by definition**. The knowledge read surfaces this
+    flag so the UI can say so BEFORE an owner drops a private price list onto a
+    public concierge.
+
+    Failure-soft and NOT an authorization gate — it labels a surface, it does not
+    guard one. A store that cannot be read yields ``False``, which is coherent:
+    if the paw-bar store is unreachable, no bar is serving visitors either.
+    """
+    if not agent_id:
+        return False
+    try:
+        workspace_id = await get_workspace(agent_id)
+        if not workspace_id:
+            return False
+        from pocketpaw_ee.paw_bar.agent_provisioning import widget_for_agent
+
+        return await widget_for_agent(agent_id, workspace_id) is not None
+    except Exception:  # noqa: BLE001 — a badge must never 500 the knowledge read
+        logger.warning(
+            "could not resolve site-visitor visibility for agent %s", agent_id, exc_info=True
+        )
+        return False
 
 
 async def get_persona(agent_id: str) -> str | None:

--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -187,6 +187,16 @@ cloud Mongo client is connected — so it hard-failed EVERY workspace-less run
 ``run_core.execute_run`` now wraps the run lifecycle in ``mark_cloud_chat_run``
 and the jail fails closed only when this marker is set; otherwise it falls back
 to ``settings.file_jail_path`` (pre-ART-2 behavior).
+
+Changes: 2026-07-30 (Paw Bar inbox D5) — ``_kb_scopes_for_context`` now grants a
+CONCIERGE run ``agent:<target_agent_id>`` ALONGSIDE ``pocket:<pocket_id>``.
+Before this, an owner who opened their site's concierge in ``/agents`` and
+attached knowledge to the AGENT got nothing on the site — only the site→pocket
+page sync reached the visitor, and the failure was silent. Each site concierge is
+a dedicated, bijective agent (``paw_bar.agent_provisioning.ensure_site_agent``),
+so its ``agent:`` scope is that one site's knowledge, not a cross-tenant pool.
+``workspace:`` and ``user:`` stay DROPPED — those are the tenant-wide and
+member-private tiers a public, anonymous visitor must never reach.
 """
 
 from __future__ import annotations
@@ -1974,17 +1984,44 @@ def _kb_scopes_for_context(ctx: ScopeContext) -> list[str]:
     is the cloud-side decision (the OSS resolver only honors the field it is
     handed).
 
-    CONCIERGE (T2, finding #2): a PUBLIC, anonymous concierge run is locked to
-    the Site's pocket ALONE — ``[pocket:<pocket_id>]`` and nothing else. The
-    ``agent:`` and ``workspace:`` scopes are deliberately DROPPED: a public
-    caller must never read the whole tenant's KB (``workspace:``) nor an agent's
-    cross-pocket KB (``agent:``), only the one pocket the Site is published from.
-    This is the KB half of "a concierge must not reach a sibling pocket in the
-    same workspace"; the pocket binding itself is set by ``_resolve_concierge``.
+    CONCIERGE (T2 finding #2, widened by Paw Bar inbox D5): a PUBLIC, anonymous
+    concierge run reads exactly TWO scopes — ``pocket:<pocket_id>`` (the Site's
+    own pocket, where the page sync writes) and ``agent:<target_agent_id>`` (the
+    knowledge the owner attached to this site's concierge agent directly). Site
+    pocket first: it is the more specific answer to "what is this site about".
+
+    ``agent:`` is safe here and ``workspace:`` is not, and the difference is not
+    cosmetic:
+
+    * Each site concierge is a DEDICATED agent, bijective with its site
+      (``paw_bar.agent_provisioning.ensure_site_agent``; deterministic slug
+      ``concierge-<site_id>``, never a shared/universal agent). Its ``agent:``
+      scope therefore holds one site's knowledge — the owner put it there for
+      these visitors — and ``_resolve_concierge`` has already proven that agent
+      belongs to this Site's workspace (``_agent_in_workspace``) and that the
+      run's pocket reconciles to the same tenant. A sibling agent's scope is
+      unreachable: the id comes from the widget binding, never from the caller.
+    * ``workspace:`` is the TENANT-WIDE tier — every pocket, every agent, every
+      owner upload in the workspace. Handing that to an anonymous caller is the
+      "ask the right question, read the whole company" hole, so it stays dropped.
+    * ``user:`` is the member-private tier and can never fire here anyway
+      (``members`` is empty for a concierge), but it is dropped explicitly.
+
+    The consequence is a product rule, not just a code rule: anything attached to
+    a site concierge agent is PUBLISHABLE BY DEFINITION. The agent knowledge read
+    advertises that with ``visible_to_site_visitors`` (see
+    ``agents.service.is_visible_to_site_visitors``) so the owner is told before
+    they attach, not after a visitor quotes it back at them.
     """
     if ctx.kind is ScopeKind.CONCIERGE:
-        # Public, site-scoped grounding ONLY. Never agent:/workspace:/user:.
-        return [f"pocket:{ctx.pocket_id}"] if ctx.pocket_id else []
+        # Public, site-scoped grounding: the Site's pocket + this site's own
+        # dedicated concierge agent. NEVER workspace:/user:.
+        concierge_scopes: list[str] = []
+        if ctx.pocket_id:
+            concierge_scopes.append(f"pocket:{ctx.pocket_id}")
+        if ctx.target_agent_id:
+            concierge_scopes.append(f"agent:{ctx.target_agent_id}")
+        return concierge_scopes
     scopes: list[str] = []
     seen: set[str] = set()
     for candidate in (

--- a/ee/pocketpaw_ee/cloud/surface/surface_registry.py
+++ b/ee/pocketpaw_ee/cloud/surface/surface_registry.py
@@ -401,8 +401,9 @@ def _concierge_profile(meta: SurfaceMeta) -> SurfaceProfile:
     """/paw-bar — the PUBLIC concierge widget. Ripple OFF (it answers questions,
     never builds a dashboard) + the public-safe tool lockdown (``_CONCIERGE_DENY``
     hard-strips web/code/write/subagent/pocket-write tools) + the site-scoped MCP
-    allow-list. KB grounding is locked to ``pocket:<id>`` by
-    ``ScopeKind.CONCIERGE`` in ``agent_service._kb_scopes_for_context`` — the
+    allow-list. KB grounding is locked to ``pocket:<id>`` + ``agent:<id>`` (the
+    site's own pocket and its own dedicated concierge agent, never ``workspace:``)
+    by ``ScopeKind.CONCIERGE`` in ``agent_service._kb_scopes_for_context`` — the
     profile governs tools, the scope governs KB.
 
     C1 — action registry: when the widget declares actions (carried on

--- a/ee/pocketpaw_ee/paw_bar/agent_provisioning.py
+++ b/ee/pocketpaw_ee/paw_bar/agent_provisioning.py
@@ -1,6 +1,15 @@
 # ee/pocketpaw_ee/paw_bar/agent_provisioning.py — auto-provision a DEDICATED
 # concierge agent per Paw Site.
 #
+# Updated 2026-07-30 (Paw Bar inbox D5): added ``widget_for_agent(agent_id,
+# workspace_id)`` — the REVERSE of the bind ``ensure_site_agent`` writes. D5 lets a
+# concierge run read its own ``agent:<id>`` knowledge scope, which makes "is this
+# agent answering public site visitors?" a question the agent Knowledge surface has
+# to answer out loud (``agents.service.is_visible_to_site_visitors`` is its one
+# caller). It reads the real binding — ``widget.agent_id`` — rather than sniffing
+# the deterministic ``concierge-<site_id>`` slug, so a MANUALLY bound agent (which
+# the provisioner never renames) is recognised too.
+#
 # Updated 2026-07-30 (publish-time provisioning): added ``ensure_site_widget`` —
 # the missing THIRD trigger. A site created AND published by the agent in one
 # conversation never passes through widget-create (a dashboard flow) or a
@@ -55,6 +64,10 @@ _MAX_STARTERS = 4
 
 # Max length of the generated agent display name (Agent.name is capped at 100).
 _MAX_AGENT_NAME = 100
+
+# How many of a workspace's paw-bar widgets ``widget_for_agent`` will scan for a
+# bind. One bar per site, so this is far above any real tenant.
+_AGENT_BIND_SCAN_LIMIT = 500
 
 
 def _store():
@@ -337,6 +350,34 @@ async def site_widget(pocket_id: str, workspace_id: str) -> Any | None:
     return widgets[0] if widgets else None
 
 
+async def widget_for_agent(agent_id: str, workspace_id: str) -> Any | None:
+    """The paw-bar widget bound to ``agent_id`` in ``workspace_id``, or ``None``.
+
+    The reverse of the bind ``ensure_site_agent`` writes, and the only honest way
+    to answer "does this agent front a public site bar?" — it reads the binding
+    itself (``widget.agent_id``), not the deterministic ``concierge-<site_id>``
+    slug, so an agent a human bound by hand in the dashboard counts exactly the
+    same as a provisioned one.
+
+    Workspace-scoped, and an empty ``agent_id`` / ``workspace_id`` returns
+    ``None`` rather than querying — an unscoped scan would hand back a sibling
+    tenant's widget (the same guard ``site_widget`` carries).
+
+    The store has no ``agent_id`` predicate, so this lists the workspace's bars
+    and scans. Bounded by ``_AGENT_BIND_SCAN_LIMIT``: a workspace holds one bar
+    per site, so the cap is far above any real tenant, and being over it degrades
+    to "not visible" rather than to a slow query.
+    """
+    if not agent_id or not workspace_id:
+        return None
+    widgets = await _store().list_widgets(workspace_id=workspace_id, limit=_AGENT_BIND_SCAN_LIMIT)
+    target = str(agent_id)
+    for widget in widgets:
+        if str(getattr(widget, "agent_id", "") or "") == target:
+            return widget
+    return None
+
+
 async def ensure_site_widget(site: Any, workspace_id: str) -> Any | None:
     """Publish-time trigger: a concierge-enabled site must HAVE a paw-bar widget.
 
@@ -422,4 +463,5 @@ __all__ = [
     "provision_on_concierge_enable",
     "provision_widget_on_create",
     "site_widget",
+    "widget_for_agent",
 ]

--- a/ee/pocketpaw_ee/sites/kb_ingest.py
+++ b/ee/pocketpaw_ee/sites/kb_ingest.py
@@ -7,11 +7,15 @@
 # carry a catalog. Ask a concierge "what are your opening hours" and the answer was
 # an honest "I don't know" about a business whose own homepage says 8am.
 #
-# The concierge's grounding scope is fixed: ``agent_service._kb_scopes_for_context``
-# locks a CONCIERGE run to ``pocket:<pocket_id>`` and nothing else (no agent:, no
-# workspace:, no user: — a public caller must never read the whole tenant's KB). So
-# "the concierge knows the business" reduces to one job: get the site's pages into
-# ``pocket:<pocket_id>``. That is all this module does.
+# The concierge's grounding scopes are fixed by
+# ``agent_service._kb_scopes_for_context``: a CONCIERGE run reads
+# ``pocket:<pocket_id>`` and ``agent:<its own agent id>``, and nothing else (no
+# workspace:, no user: — a public caller must never read the whole tenant's KB).
+# The second scope is the owner's own attachments on the site's agent; this module
+# owns the FIRST one, so "the concierge knows the business without anyone uploading
+# anything" reduces to one job: get the site's pages into ``pocket:<pocket_id>``.
+# That is all this module does, and it is why a re-publish can never clobber what an
+# owner attached to the agent — the two scopes have separate writers.
 #
 # SOURCE OF TRUTH — the POCKET, not the built artifact and not the live URL:
 #   * the pocket is durable, so this works at publish time, at agent-provision time
@@ -378,8 +382,11 @@ def extract_site_documents(
 
 
 def kb_scope_for_pocket(pocket_id: str) -> str:
-    """The scope a CONCIERGE run reads. Mirrors ``_kb_scopes_for_context``'s
-    concierge branch — if that ever changes, this is the other end of the pair."""
+    """The scope the page sync writes, and the first of the two a CONCIERGE run
+    reads. Mirrors the POCKET half of ``_kb_scopes_for_context``'s concierge branch
+    — if that ever changes, this is the other end of the pair. The other half,
+    ``agent:<agent_id>``, has a different writer (the owner, through the agent's
+    Knowledge tab), which is why a re-sync can never clobber it."""
     return f"pocket:{pocket_id}"
 
 

--- a/tests/cloud/test_paw_bar_agent_provisioning.py
+++ b/tests/cloud/test_paw_bar_agent_provisioning.py
@@ -472,3 +472,137 @@ class TestIdentityAndFrameStarters:
         res = await c.get("/paw-bar/frame", params={"key": _VALID_KEY})
         assert res.status_code == 200
         assert "starters" in res.text
+
+
+# --------------------------------------------------------------------------- #
+# Paw Bar inbox D5 — the "visible to site visitors" signal
+# --------------------------------------------------------------------------- #
+
+
+@pytest_asyncio.fixture
+async def bar_store(tmp_path, mongo_db):
+    """A tmp paw-bar store patched in at the source (no HTTP app), plus Beanie for
+    the Agent docs ``is_visible_to_site_visitors`` resolves the workspace from."""
+    from unittest.mock import patch
+
+    store = PawBarStore(tmp_path / "visibility.db")
+    with patch("pocketpaw_ee.api.get_paw_bar_store", return_value=store):
+        yield store
+
+
+async def _agent_doc(**ov: Any):
+    from pocketpaw_ee.cloud.models.agent import Agent
+
+    d: dict[str, Any] = dict(
+        workspace=_WS, name="Brew & Co Concierge", slug="concierge-site-1", owner=_OWNER
+    )
+    d.update(ov)
+    agent = Agent(**d)
+    await agent.insert()
+    return agent
+
+
+class TestSiteVisitorVisibility:
+    """D5 consequence 1: a concierge run reads its own ``agent:<id>`` scope, so the
+    agent's Knowledge surface must SAY that anything on it is publishable. The
+    machine-readable half of that badge is ``visible_to_site_visitors`` on
+    ``GET /agents/{id}/knowledge``, derived from the real widget→agent binding."""
+
+    @pytest.mark.asyncio
+    async def test_widget_for_agent_finds_the_bound_widget(self, bar_store) -> None:
+        from pocketpaw_ee.paw_bar import agent_provisioning as ap
+
+        widget = await bar_store.create_widget(_widget(agent_id="agent-bound"))
+        assert (await ap.widget_for_agent("agent-bound", _WS)).id == widget.id
+
+    @pytest.mark.asyncio
+    async def test_widget_for_agent_ignores_an_unbound_or_sibling_widget(self, bar_store) -> None:
+        from pocketpaw_ee.paw_bar import agent_provisioning as ap
+
+        await bar_store.create_widget(_widget(agent_id=""))
+        await bar_store.create_widget(_widget(pocket_id="pocket-2", agent_id="agent-other"))
+        assert await ap.widget_for_agent("agent-bound", _WS) is None
+
+    @pytest.mark.asyncio
+    async def test_widget_for_agent_is_workspace_scoped(self, bar_store) -> None:
+        """Another tenant's bar never answers for this workspace's agent."""
+        from pocketpaw_ee.paw_bar import agent_provisioning as ap
+
+        await bar_store.create_widget(_widget(agent_id="agent-bound", workspace_id="ws-other"))
+        assert await ap.widget_for_agent("agent-bound", _WS) is None
+        assert await ap.widget_for_agent("agent-bound", "ws-other") is not None
+
+    @pytest.mark.asyncio
+    async def test_widget_for_agent_refuses_an_unscoped_lookup(self, bar_store) -> None:
+        """An empty agent id or workspace returns None instead of scanning — an
+        unscoped list would hand back a sibling tenant's bar."""
+        from pocketpaw_ee.paw_bar import agent_provisioning as ap
+
+        await bar_store.create_widget(_widget(agent_id="agent-bound"))
+        assert await ap.widget_for_agent("", _WS) is None
+        assert await ap.widget_for_agent("agent-bound", "") is None
+
+    @pytest.mark.asyncio
+    async def test_site_bound_agent_is_flagged_visible(self, bar_store) -> None:
+        from pocketpaw_ee.cloud.agents import service as agents_service
+
+        agent = await _agent_doc()
+        await bar_store.create_widget(_widget(agent_id=str(agent.id)))
+        assert await agents_service.is_visible_to_site_visitors(str(agent.id)) is True
+
+    @pytest.mark.asyncio
+    async def test_internal_agent_is_not_flagged_visible(self, bar_store) -> None:
+        """An ordinary workspace agent fronts no bar — no badge, no false alarm."""
+        from pocketpaw_ee.cloud.agents import service as agents_service
+
+        internal = await _agent_doc(slug="hr-assistant", name="HR Assistant")
+        await bar_store.create_widget(_widget(agent_id="someone-else"))
+        assert await agents_service.is_visible_to_site_visitors(str(internal.id)) is False
+
+    @pytest.mark.asyncio
+    async def test_visibility_of_an_unknown_agent_is_false(self, bar_store) -> None:
+        """A missing / malformed agent id resolves no workspace, so there is
+        nothing to scan and nothing to claim."""
+        from pocketpaw_ee.cloud.agents import service as agents_service
+
+        assert await agents_service.is_visible_to_site_visitors("") is False
+        assert await agents_service.is_visible_to_site_visitors("not-an-object-id") is False
+
+    @pytest.mark.asyncio
+    async def test_visibility_is_failure_soft(self, bar_store) -> None:
+        """The flag labels a surface, it does not guard one — an unreadable store
+        yields False rather than 500-ing the owner's Knowledge tab."""
+        from unittest.mock import patch
+
+        from pocketpaw_ee.cloud.agents import service as agents_service
+
+        agent = await _agent_doc()
+        await bar_store.create_widget(_widget(agent_id=str(agent.id)))
+        with patch(
+            "pocketpaw_ee.paw_bar.agent_provisioning.widget_for_agent",
+            side_effect=RuntimeError("store is gone"),
+        ):
+            assert await agents_service.is_visible_to_site_visitors(str(agent.id)) is False
+
+    @pytest.mark.asyncio
+    async def test_knowledge_read_carries_the_flag(self, bar_store) -> None:
+        """The wire shape the frontend badge reads: ``GET /agents/{id}/knowledge``
+        returns ``visible_to_site_visitors`` beside ``items``."""
+        from unittest.mock import AsyncMock, patch
+
+        from pocketpaw_ee.cloud.agents.router import list_knowledge
+
+        agent = await _agent_doc()
+        await bar_store.create_widget(_widget(agent_id=str(agent.id)))
+        internal = await _agent_doc(slug="hr-assistant", name="HR Assistant")
+
+        with patch(
+            "pocketpaw_ee.cloud.agents.knowledge.KnowledgeService.list_articles",
+            new=AsyncMock(return_value=[{"id": "a1", "title": "Hours"}]),
+        ):
+            public = await list_knowledge(str(agent.id))
+            private = await list_knowledge(str(internal.id))
+
+        assert public["visible_to_site_visitors"] is True
+        assert public["items"] == [{"id": "a1", "title": "Hours"}]
+        assert private["visible_to_site_visitors"] is False

--- a/tests/cloud/test_paw_bar_concierge_chat.py
+++ b/tests/cloud/test_paw_bar_concierge_chat.py
@@ -19,6 +19,14 @@
 #   nothing when the site's concierge_store_transcripts is off (while the AGENT
 #   still receives the full message either way), the stored copy is length-capped,
 #   and create_run actually lands the field on the run document.
+# Updated 2026-07-30 (Paw Bar inbox D5): the layer-1 grounding guard was WIDENED
+#   deliberately — a concierge run now reads ``agent:<its own id>`` alongside
+#   ``pocket:<its site>``, because a site concierge is a dedicated agent bijective
+#   with its site and an owner attaching knowledge to it was silently getting
+#   nothing on the site. ``workspace:`` and ``user:`` stay dropped. The isolation
+#   matrix that guards the widened blast radius lives beside it: a sibling agent's
+#   scope is never granted (unit + end-to-end through the resolver), the
+#   tenant-wide scope is never granted, and two tenants' scope sets are disjoint.
 # Updated 2026-07-29 (concierge conversation memory): a fifth layer covers the
 #   rehydrated RunSpec.history — prior turns of the SAME visitor come back
 #   oldest-first in the {"role","content"} shape the agent consumes; a sibling
@@ -93,15 +101,81 @@ def _concierge_ctx(pocket_id="pk-1", workspace_id="ws-1", customer="cust-42", ag
     )
 
 
-def test_concierge_kb_scope_is_pocket_only():
-    """Finding #2 (KB half): a concierge run grounds on its Site pocket ALONE —
-    never the agent's cross-pocket KB nor the whole tenant's workspace KB."""
+def test_concierge_kb_scope_is_site_pocket_plus_own_agent():
+    """A concierge run grounds on its Site pocket AND its own agent's scope.
+
+    DELIBERATE CHANGE (Paw Bar inbox D5, 2026-07-30). This test previously asserted
+    ``scopes == ["pocket:pk-1"]`` and that no ``agent:`` scope was present. That
+    was too tight and failed SILENTLY in the owner's face: a site concierge is a
+    DEDICATED agent bijective with its site, so an owner who opened it in /agents
+    and attached knowledge to the agent got nothing on the site — only the
+    site→pocket page sync ever reached a visitor, with no error and no warning.
+
+    ``agent:`` is now granted; ``workspace:`` is NOT, and that asymmetry is the
+    whole security argument: ``agent:`` is one site's own knowledge (the id comes
+    from the widget binding, and ``_resolve_concierge`` already proved the agent
+    belongs to this Site's workspace), while ``workspace:`` is the tenant-wide
+    tier an anonymous visitor must never reach. See the sibling-agent, workspace
+    and cross-tenant isolation tests immediately below.
+    """
     scopes = _kb_scopes_for_context(_concierge_ctx(pocket_id="pk-1", workspace_id="ws-1"))
-    assert scopes == ["pocket:pk-1"]
-    # The leaky scopes a member run would carry are absent.
+    assert scopes == ["pocket:pk-1", "agent:agent-1"]
+    # The scopes that stay leaky for a public caller are still absent.
     assert not any(s.startswith("workspace:") for s in scopes)
-    assert not any(s.startswith("agent:") for s in scopes)
     assert not any(s.startswith("user:") for s in scopes)
+
+
+def test_concierge_kb_scope_excludes_a_sibling_agent():
+    """Blast-radius guard: the ``agent:`` scope granted is the RUN'S OWN agent and
+    nothing else. A sibling agent in the same workspace stays unreachable — the id
+    comes from the widget binding the resolver validated, never from the caller."""
+    scopes = _kb_scopes_for_context(_concierge_ctx(agent="agent-mine"))
+    assert "agent:agent-mine" in scopes
+    assert "agent:agent-sibling" not in scopes
+    # Exactly one agent scope, ever.
+    assert [s for s in scopes if s.startswith("agent:")] == ["agent:agent-mine"]
+
+
+def test_concierge_kb_scope_never_carries_workspace_or_user():
+    """The two tiers D5 keeps DROPPED: ``workspace:`` (every pocket, agent and
+    upload in the tenant) and ``user:`` (a member's private mail/calendar KB).
+    Widening the concierge to ``agent:`` must not have widened it to either."""
+    scopes = _kb_scopes_for_context(
+        _concierge_ctx(pocket_id="pk-1", workspace_id="ws-1", customer="cust-42")
+    )
+    assert "workspace:ws-1" not in scopes
+    assert not any(s.startswith("workspace:") for s in scopes)
+    # ``user:`` can't fire anyway (members is empty for a concierge) — asserted
+    # explicitly so a future change to the member-private gate can't leak here.
+    assert "user:cust-42" not in scopes
+    assert not any(s.startswith("user:") for s in scopes)
+
+
+def test_concierge_kb_scopes_share_nothing_across_tenants():
+    """Two concierge runs in different tenants have DISJOINT scope sets — neither
+    site's pocket nor either agent appears in the other's grounding."""
+    mine = _kb_scopes_for_context(
+        _concierge_ctx(pocket_id="pk-mine", workspace_id="ws-mine", agent="agent-mine")
+    )
+    theirs = _kb_scopes_for_context(
+        _concierge_ctx(pocket_id="pk-theirs", workspace_id="ws-theirs", agent="agent-theirs")
+    )
+    assert set(mine).isdisjoint(theirs)
+    assert "pocket:pk-theirs" not in mine
+    assert "agent:agent-theirs" not in mine
+
+
+def test_concierge_kb_scope_degrades_when_a_binding_is_missing():
+    """Defensive shape: each scope is emitted only when its id is present, so a
+    half-resolved context can never produce a malformed ``agent:``/``pocket:``
+    scope string (which kb-go would sanitize into some OTHER scope's directory)."""
+    no_agent = _kb_scopes_for_context(_concierge_ctx(pocket_id="pk-1", agent=""))
+    assert no_agent == ["pocket:pk-1"]
+
+    no_pocket = _kb_scopes_for_context(_concierge_ctx(pocket_id="", agent="agent-1"))
+    assert no_pocket == ["agent:agent-1"]
+
+    assert _kb_scopes_for_context(_concierge_ctx(pocket_id="", agent="")) == []
 
 
 def test_member_pocket_scope_still_carries_full_set():
@@ -177,8 +251,11 @@ async def test_resolve_concierge_binds_pocket_and_agent(mongo_db):
     assert ctx.user_id == "cust-1"
     # No workspace participant is exposed to a public concierge.
     assert ctx.members == []
-    # And its KB is locked to the pocket (end-to-end through the resolved ctx).
-    assert _kb_scopes_for_context(ctx) == [f"pocket:{pocket.id}"]
+    # And its KB is the site pocket + THIS agent, end-to-end through the resolved
+    # ctx — the agent id the scope grants is the one the resolver just proved
+    # belongs to this workspace, never a value the caller supplied unchecked.
+    assert _kb_scopes_for_context(ctx) == [f"pocket:{pocket.id}", f"agent:{agent.id}"]
+    assert f"workspace:{ctx.workspace_id}" not in _kb_scopes_for_context(ctx)
 
 
 @pytest.mark.asyncio
@@ -215,6 +292,30 @@ async def test_resolve_concierge_rejects_agent_from_another_workspace(mongo_db):
             expected_workspace_id="ws-1",
         )
     assert exc.value.code == "concierge.agent_forbidden"
+
+
+@pytest.mark.asyncio
+async def test_concierge_scope_never_names_a_sibling_agent_end_to_end(mongo_db):
+    """D5 blast radius, end-to-end: two agents live in the SAME workspace and the
+    widget binds ONE. The resolved run grounds on that agent's scope alone — the
+    sibling's knowledge is unreachable even though it is only one tenant away, and
+    the tenant-wide ``workspace:`` scope is absent entirely."""
+    pocket = await _pocket(workspace="ws-1")
+    bound = await _agent(workspace="ws-1", slug="concierge-bound")
+    sibling = await _agent(workspace="ws-1", slug="hr-assistant")
+
+    ctx = await resolve_scope_context(
+        scope="concierge",
+        scope_id=str(pocket.id),
+        user_id="cust-1",
+        agent_id_hint=str(bound.id),
+        expected_workspace_id="ws-1",
+    )
+
+    scopes = _kb_scopes_for_context(ctx)
+    assert scopes == [f"pocket:{pocket.id}", f"agent:{bound.id}"]
+    assert f"agent:{sibling.id}" not in scopes
+    assert "workspace:ws-1" not in scopes
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Paw Bar inbox **D5**. Scope is D5 only — no thumbs/revise-into-knowledge loop, no conversations state.

## The bug

`_kb_scopes_for_context` locked a `CONCIERGE` run to `['pocket:<site pocket>']` and deliberately dropped `agent:`. So an owner who opened their site's concierge in `/agents` and attached knowledge **to the agent** got nothing on the site — only the site→pocket page sync ever reached a visitor. No error, no warning; the concierge just kept saying it didn't know.

## What changed

**1. The scope.** A concierge run now reads `pocket:<site pocket>` **and** `agent:<its own agent id>`. `workspace:` and `user:` stay dropped.

The asymmetry is the whole security argument. Every site concierge is a dedicated agent, one per site (`ensure_site_agent`), so its `agent:` scope holds one site's material that the owner put there for these visitors. `workspace:` is the tenant-wide tier — every pocket, every other agent, every owner upload — and an anonymous caller must never reach it.

The agent id is not the caller's: it rides `RunSpec.agent_id` from `widget.agent_id`, and `_resolve_concierge` already proved that agent belongs to the site's workspace (`_agent_in_workspace`) before the run starts. No wiring was needed — `ctx.target_agent_id` is always populated for a concierge run, or resolution raises `concierge.no_agent`.

**2. The badge.** `GET /agents/{id}/knowledge` now returns `visible_to_site_visitors: bool` beside `items`. True when a paw-bar widget binds that agent to a published site — read from the real binding, not the `concierge-<site_id>` slug, so a hand-bound agent counts too. It labels a surface, it does not guard one: same owner/admin guard, same articles, and an unreadable store yields `false` rather than breaking the tab. Rendering the badge is the frontend's job.

`widget_for_agent(agent_id, workspace_id)` is the new reverse lookup in `agent_provisioning`; workspace-scoped, refuses an unscoped query, bounded scan.

**3. The docs.** `docs/concepts/concierge-knowledge.mdx` said the concierge reads one scope and cannot read `agent:`. It now names both scopes, explains why `agent:` is safe where `workspace:` is not, and carries the blunt rule as a warning: **anything attached to a site concierge is publishable by definition** — private material belongs on an agent no site binds.

## What a visitor can and cannot reach

| | after this change |
|---|---|
| `pocket:<the site's own pocket>` | **yes** (unchanged) |
| `agent:<the site's own concierge agent>` | **yes** (new) |
| `agent:<any other agent>` | no |
| `workspace:<the tenant>` | no |
| `user:<any member>` | no |
| anything in another tenant | no |

## Tests

The two existing assertions that pinned the old behaviour were **updated, not deleted**, and each carries the reasoning in its docstring. New isolation coverage guards the widened blast radius: a sibling agent's scope is never granted (unit and end-to-end through the resolver, with two agents in one workspace), the tenant-wide and member-private tiers are never granted, two tenants' scope sets are disjoint, and a half-resolved context degrades instead of emitting a malformed scope string. Nine more cover the visibility signal, including the wire shape and the failure-soft path.

917 passed, 2 skipped across the concierge, agent-service, chat, sites-KB and paw-bar suites. `ruff check` + `ruff format --check` clean; both import-linter configs pass.

## Note for the sibling branches

Two comments in files I stayed out of are now stale and want a one-line fix from their owner:
- `ee/pocketpaw_ee/paw_bar/router.py:2704` — "(KB locked to pocket:<id>)"
- `ee/pocketpaw_ee/paw_bar/router.py:2486` — "the one scope `_kb_scopes_for_context` grants a CONCIERGE run" (`_concierge_sources` itself is correct: it still searches the pocket scope alone, which is what should be citable)