### PR TITLE
Give the concierge inbox a conversation state row

### DIFF
--- a/docs/concepts/concierge-knowledge.mdx
+++ b/docs/concepts/concierge-knowledge.mdx
@@ -151,6 +151,62 @@ decision about whether the site keeps a record of its visitors, not two.
 If the record cannot be read for any reason, the concierge answers without memory
 rather than failing the visitor's chat.
 
+## The conversation queue
+
+Those stored turns make a log. A log tells the owner what happened; it does not tell
+them what still needs them. Each conversation therefore carries a small state row —
+identified, like the runs themselves, by the site's widget and the visitor's handle.
+
+The row holds lifecycle and operator notes only: a state, whether the bot is paused,
+a snooze deadline, tags, private notes, a contact address, and an unread counter. No
+messages. The transcript stays derived from the run documents, so there is exactly
+one record of what was said and a separate one of how the owner is handling it.
+
+Four states, and one rule that matters more than the rest:
+
+| State | Meaning |
+|---|---|
+| `open` | live and in the default view |
+| `needs_human` | escalated — the visitor asked for a person, or the bot could not answer |
+| `snoozed` | hidden until a deadline the owner set |
+| `closed` | done |
+
+**A visitor's message re-opens their conversation.** Closed or snoozed, it comes
+back to `open` the moment they write again — a returning customer must land in the
+queue, not in an archive. The one exception is `needs_human`: that is already the
+top of the queue, so "re-opening" it would be a demotion.
+
+The row is created on a visitor's first message, and on the owner's first action on
+an older conversation. Nothing was backfilled when this shipped, and nothing needs
+to be: a conversation with no row still lists, reading as a plain open conversation.
+
+Snooze expiry is decided when the queue is read, not by a background sweep. A snooze
+that has passed shows up as open wherever the owner looks — the list, the filters,
+the counts — with nothing scheduled that could fail quietly overnight and leave a
+customer waiting. A snooze with no deadline is indefinite until the owner says
+otherwise.
+
+### Reading and filing the queue
+
+- `GET /paw-bar/admin/site/{site_id}/conversations` lists a site's conversations
+  newest first, each carrying its state, unread count, tags, and whether a decision
+  of theirs is waiting on the owner. `?state=` filters the page; the per-state counts
+  that come back are the totals for the whole site, so the filter chips stay stable
+  while one of them is active.
+- `PATCH /paw-bar/admin/site/{site_id}/conversations/{customer_ref}` files one:
+  state, snooze, tags, a private note, or pausing the bot. A note appends rather than
+  replaces — an operator's running record of a customer is not something an edit
+  should quietly drop. It gates on `paw_bar.manage`, the write action, not the read.
+- `GET /paw-bar/admin/agent/{agent_id}/conversations` asks the same question of the
+  **agent**. A site concierge is an ordinary agent, and each site is one, so "this
+  site's conversations" and "this agent's visitor conversations" are the same list.
+  For an agent that fronts more than one site, they union, and each conversation
+  names the site it came from.
+
+Visitors are shown by the email they left, when they left one, and otherwise by a
+short stub of their anonymous handle. The email is still stored only where it was
+captured; the owner's list reads it there rather than keeping a second copy.
+
 ## When the visitor leaves the page
 
 Some requests need a human decision, and humans take longer than a browser tab

--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -1684,10 +1684,16 @@ class AgentConversationsResponse(BaseModel):
 class ConversationRow(BaseModel):
     """The full conversation state row, as the PATCH echoes it back.
 
-    Everything the owner surface needs to re-render one row without a refetch.
     ``state`` is the EFFECTIVE state (an expired snooze reads ``open``) while
     ``snooze_until`` keeps the stored timestamp, so the UI can say "was snoozed
     until 9am" on a row that has already come back.
+
+    DELIBERATELY NOT a whole list item. ``preview``, ``last_message_at`` and
+    ``has_pending_action`` are derived from the run docs, not from this row, so a
+    client re-rendering a list row from this echo must carry those three over from
+    the item it already had (or refetch the list). Completing the shape here would
+    put a run query on a write path purely to hand back data the caller is already
+    displaying — don't add it without a reason that survives that sentence.
     """
 
     id: str
@@ -1715,6 +1721,12 @@ class ConversationPatchRequest(BaseModel):
     can flip one thing without echoing the row back. ``note`` APPENDS a private
     operator note; it never replaces the existing ones. ``tags`` DOES replace (a
     tag set is edited as a whole in the UI).
+
+    ``unread_for_owner`` is deliberately absent: mark-as-read has no UI yet, and
+    the store already supports the write, so this is one field away whenever a
+    surface wants it. A client must NOT fake it locally — a browser-side read flag
+    disagrees with the next poll seconds later, which reads as a counter that
+    un-marks itself. Ask for the field instead.
     """
 
     state: str | None = None

--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -1939,7 +1939,11 @@ async def patch_site_conversation(
     """
     if not _CUSTOMER_REF_RE.match(customer_ref or ""):
         raise HTTPException(400, "invalid_customer_ref")
-    fields = _validated_conversation_fields(req, getattr(user, "id", "") or "")
+    # str(): the authenticated caller's id arrives as a PydanticObjectId, and a
+    # note carrying it raw fails ConversationNote's string_type validation with a
+    # 500. Unit tests hand-build notes with plain strings, so only a live PATCH
+    # showed it (rig, 2026-07-30).
+    fields = _validated_conversation_fields(req, str(getattr(user, "id", "") or ""))
     site, widget = await _resolve_site_and_widget(site_id, workspace_id)
     if widget is None:
         raise HTTPException(404, "conversation_not_found")

--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -1960,7 +1960,14 @@ async def patch_site_conversation(
             widget.id, customer_ref, workspace_id=workspace_id, **fields
         )
         conversation = updated or conversation
-    return ConversationPatchResponse(ok=True, conversation=_conversation_row(conversation))
+    # Resolve the display email the same way the LIST does, so a client that
+    # re-renders a row from this echo doesn't watch a named visitor turn back into
+    # an anonymous handle.
+    _pending, emails = await _decision_side_data(widget, [customer_ref])
+    return ConversationPatchResponse(
+        ok=True,
+        conversation=_conversation_row(conversation, emails.get(customer_ref, "")),
+    )
 
 
 @router.get(
@@ -2293,8 +2300,14 @@ def _validated_conversation_fields(req: ConversationPatchRequest, author: str) -
     return fields
 
 
-def _conversation_row(conversation: Any) -> ConversationRow:
-    """Project a stored :class:`Conversation` into the wire shape."""
+def _conversation_row(conversation: Any, captured_email: str = "") -> ConversationRow:
+    """Project a stored :class:`Conversation` into the wire shape.
+
+    ``captured_email`` is the address the visitor left on a decision, resolved by
+    the caller (slice 1 never writes it onto the row itself). It fills both
+    ``contact_email`` and the display name so this echo and the list agree.
+    """
+    contact_email = conversation.contact_email or captured_email
     return ConversationRow(
         id=conversation.id,
         widget_id=conversation.widget_id,
@@ -2305,8 +2318,8 @@ def _conversation_row(conversation: Any) -> ConversationRow:
         assignee=conversation.assignee,
         tags=list(conversation.tags),
         notes=[note.model_dump() for note in conversation.notes],
-        contact_email=conversation.contact_email,
-        display_name=_display_name(conversation.contact_email, conversation.customer_ref),
+        contact_email=contact_email,
+        display_name=_display_name(contact_email, conversation.customer_ref),
         last_visitor_at=conversation.last_visitor_at,
         last_owner_at=conversation.last_owner_at,
         unread_for_owner=conversation.unread_for_owner,
@@ -2346,23 +2359,46 @@ async def _conversation_side_data(
     the store hiccups the list still renders, just without the queue metadata.
     """
     states: dict[str, Any] = {}
-    pending: set[str] = set()
-    emails: dict[str, str] = {}
     if widget is None or not refs:
-        return states, pending, emails
-    store = _store()
+        return states, set(), {}
     try:
-        rows = await store.list_conversations(
+        rows = await _store().list_conversations(
             widget.id, workspace_id=workspace_id, limit=len(refs), customer_refs=refs
         )
         states = {row.customer_ref: row for row in rows}
     except Exception:  # noqa: BLE001 — queue metadata is additive, never fatal
         logger.warning("conversation state read failed for widget %s", widget.id, exc_info=True)
+    pending, emails = await _decision_side_data(widget, refs)
+    return states, pending, emails
+
+
+async def _decision_side_data(
+    widget: PawBarWidget | None, refs: list[str]
+) -> tuple[set[str], dict[str, str]]:
+    """What this widget's DECISION rows say about a set of visitors.
+
+    Returns ``(refs with an undecided action, contact email by ref)`` from ONE
+    bounded read of the rows the Decisions list already serves — never a second
+    query into Instinct, whose rows are stamped with the widget owner rather than
+    the tenant and so can't be read workspace-scoped.
+
+    The email is READ here rather than copied onto the conversation row: it stays
+    in the one place the PII invariant names, and this owner-authed surface is
+    exactly who the visitor left it for. Shared by the list and the PATCH echo so
+    a row can't change its display name depending on which one produced it.
+    Best-effort — a store hiccup costs the metadata, never the response.
+    """
+    if widget is None or not refs:
+        return set(), {}
     try:
-        decisions = await store.list_decisions_for_widget(widget.id, limit=_CONVERSATION_SCAN_CAP)
-    except Exception:  # noqa: BLE001 — same posture as the state read
+        decisions = await _store().list_decisions_for_widget(
+            widget.id, limit=_CONVERSATION_SCAN_CAP
+        )
+    except Exception:  # noqa: BLE001 — additive metadata, never fatal
         logger.warning("decision read failed for widget %s", widget.id, exc_info=True)
-        decisions = []
+        return set(), {}
+    pending: set[str] = set()
+    emails: dict[str, str] = {}
     wanted = set(refs)
     for decision in decisions:
         ref = decision.customer_ref
@@ -2374,7 +2410,7 @@ async def _conversation_side_data(
         # a visitor is their most recent one.
         if decision.contact_email and ref not in emails:
             emails[ref] = decision.contact_email
-    return states, pending, emails
+    return pending, emails
 
 
 async def _list_conversations(

--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -1,4 +1,28 @@
 # ee/paw_bar/router.py — HTTP surface for the Paw Bar widget layer.
+# Updated: 2026-07-30 (owner inbox, slice 1) — the concierge LOG becomes a QUEUE.
+#   A lifecycle row (``paw_bar_conversations``) is now upserted on every visitor
+#   turn from ``concierge_chat`` (failure-soft — inbox bookkeeping never costs a
+#   visitor their answer) and joined onto the owner reads:
+#     ~ GET  .../site/{id}/conversations — ADDITIVE. Every existing field keeps
+#       its name and meaning; each item GAINS state / bot_paused /
+#       unread_for_owner / tags / snooze_until / contact_email / display_name /
+#       has_pending_action, all with safe defaults so a LEGACY conversation with
+#       no state row still lists (no backfill, ever). The response gains
+#       ``counts`` (per-state totals, UNFILTERED so the filter chips stay stable)
+#       and an optional ``?state=`` filter (unknown value → 422).
+#     + PATCH .../site/{id}/conversations/{customer_ref} — {state?, snooze_until?,
+#       tags?, note?, bot_paused?} → {ok, conversation}. ``note`` APPENDS a
+#       private operator note attributed to the caller; ``tags`` replaces. Gated
+#       on ``paw_bar.manage`` (this router's existing write action — there is no
+#       ``paw_bar.write``). A conversation with no row yet gets one minted on this
+#       first owner action; a ref with no concierge runs on the site 404s.
+#     + GET  .../agent/{agent_id}/conversations — the agent-scoped union (D1): the
+#       concierge IS a normal agent, so its widgets' sites are unioned into one
+#       list, each item carrying site_id + site_name. ``widget_count`` / ``sites``
+#       are the positive binding signal (an ordinary agent answers 200 with 0).
+#   Snooze expiry is computed on READ in the store, so a snooze always ends on
+#   time with no sweeper. ``has_pending_action`` reuses the decision rows the
+#   Decisions list already reads — never a second query into Instinct.
 # Updated: 2026-07-30 (reply sources + articles) — visible grounding for the
 #   concierge. (1) ``concierge_chat`` now emits at most ONE ``event: sources``
 #   SSE frame ({"sources": [{title, url}]}, max 3, deduped by url) after the
@@ -294,6 +318,7 @@ import os
 import re
 import uuid
 from collections.abc import AsyncIterator
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -304,6 +329,8 @@ from pydantic import BaseModel, Field
 from pocketpaw.api.deps import require_scope
 from pocketpaw.paw_bar.models import (
     MAX_PAYLOAD_BYTES,
+    ConversationState,
+    DecisionState,
     PawBarEvent,
     PawBarEventMapping,
     PawBarSpec,
@@ -1472,6 +1499,23 @@ _CONVERSATION_SCAN_CAP = 200
 # never ships the whole history in one response.
 _TRANSCRIPT_CAP = 200
 
+# Owner-supplied conversation metadata bounds (slice 1). The owner is trusted, but
+# these fields are stored and echoed on every list read, so they are capped like
+# every other persisted string on this surface — a runaway paste can't turn one
+# row into the payload of the whole inbox.
+_MAX_CONVERSATION_TAGS = 20
+_MAX_TAG_CHARS = 40
+_MAX_NOTE_CHARS = 2000
+
+# How many of a visitor's ref characters survive into the fallback display name.
+# Enough to tell two visitors apart at a glance, short enough to read as a label.
+_DISPLAY_REF_CHARS = 6
+
+# How many widgets one agent's inbox unions over. An agent normally fronts ONE
+# site; the cap keeps a pathological binding from fanning out into an unbounded
+# number of per-site scans.
+_AGENT_WIDGET_CAP = 20
+
 # Max characters of a visitor's own message persisted on the run doc for the
 # transcript. The agent still receives the FULL message — this caps only what we
 # write down, so a pasted wall of text (or a deliberate storage-stuffing attempt)
@@ -1551,24 +1595,138 @@ class SiteOverviewResponse(BaseModel):
 
 
 class ConversationItem(BaseModel):
+    """One row in the owner's conversation list (D2 + the slice-1 queue fields).
+
+    The first three fields are the frozen D2 contract, derived from the run docs.
+    Everything after them comes from the ``paw_bar_conversations`` state row and
+    carries a SAFE DEFAULT: a conversation that has no row yet — every one that
+    predates the table — still serializes, reading as a plain open conversation
+    with nothing pending. That is what makes the queue backfill-free.
+    """
+
     customer_ref: str
     last_message_at: str
     preview: str
+    state: str = "open"
+    bot_paused: bool = False
+    unread_for_owner: int = 0
+    tags: list[str] = Field(default_factory=list)
+    snooze_until: str = ""
+    contact_email: str = ""
+    # What the owner should SEE instead of a 32-char hex handle: the visitor's
+    # email when they left one, else a short readable stub of the ref.
+    display_name: str = ""
+    # True when this visitor has an undecided gated action waiting on the owner —
+    # the "needs you" chip. Read from the SAME decision rows the Decisions list
+    # uses (never a second query against Instinct, whose rows are keyed by the
+    # widget owner rather than the tenant).
+    has_pending_action: bool = False
 
 
 class ConversationsResponse(BaseModel):
-    """GET /paw-bar/admin/site/{id}/conversations payload (D2).
+    """GET /paw-bar/admin/site/{id}/conversations payload (D2 + slice 1).
 
     ``unsupported`` stays False on this deployment: concierge runs ARE listable
     (the ChatRunDoc compound index backs the per-site query). The field is part of
     the frozen contract so the frontend degrades gracefully if a future backend
     can't serve the list. ``cursor`` is the ISO ``createdAt`` to page older
     conversations from; ``None`` when the scan reached the end.
+
+    ``counts`` is the per-state total for the whole widget — UNFILTERED, so the
+    filter chips keep showing all four numbers while one of them is active. It is
+    ``{}`` when the site has no paw-bar widget (there is nothing to count), and
+    counts only conversations that actually have a state row: a legacy row still
+    LISTS with defaults, but it is never invented into a total.
     """
 
     items: list[ConversationItem] = Field(default_factory=list)
     cursor: str | None = None
     unsupported: bool = False
+    counts: dict[str, int] = Field(default_factory=dict)
+
+
+class AgentConversationItem(ConversationItem):
+    """A conversation in the AGENT-scoped inbox — the site lens made explicit.
+
+    One agent can front more than one site (manual widget binds are never
+    overwritten by the provisioner), so the union carries which site each
+    conversation came from. Identical to :class:`ConversationItem` otherwise.
+    """
+
+    site_id: str = ""
+    site_name: str = ""
+
+
+class AgentSiteRef(BaseModel):
+    """One site included in an agent-scoped union."""
+
+    site_id: str
+    site_name: str = ""
+
+
+class AgentConversationsResponse(BaseModel):
+    """GET /paw-bar/admin/agent/{agent_id}/conversations payload (D1 seed).
+
+    ``sites`` + ``widget_count`` are the POSITIVE binding signal: an agent that
+    fronts no paw-bar widget answers 200 with ``widget_count=0`` and empty
+    everything, so a client can tell "a concierge with a quiet inbox" from "an
+    ordinary agent that should not show a Conversations tab at all" without a
+    second call. ``counts`` sums the per-widget state counts across the union and
+    is UNFILTERED, like the site read's.
+    """
+
+    items: list[AgentConversationItem] = Field(default_factory=list)
+    counts: dict[str, int] = Field(default_factory=dict)
+    sites: list[AgentSiteRef] = Field(default_factory=list)
+    widget_count: int = 0
+
+
+class ConversationRow(BaseModel):
+    """The full conversation state row, as the PATCH echoes it back.
+
+    Everything the owner surface needs to re-render one row without a refetch.
+    ``state`` is the EFFECTIVE state (an expired snooze reads ``open``) while
+    ``snooze_until`` keeps the stored timestamp, so the UI can say "was snoozed
+    until 9am" on a row that has already come back.
+    """
+
+    id: str
+    widget_id: str
+    customer_ref: str
+    state: str
+    bot_paused: bool
+    snooze_until: str
+    assignee: str
+    tags: list[str] = Field(default_factory=list)
+    notes: list[dict[str, str]] = Field(default_factory=list)
+    contact_email: str
+    display_name: str
+    last_visitor_at: str
+    last_owner_at: str
+    unread_for_owner: int
+    created_at: str
+    updated_at: str
+
+
+class ConversationPatchRequest(BaseModel):
+    """Body of PATCH .../conversations/{customer_ref} — every field optional.
+
+    Only the fields actually SENT are applied (``model_fields_set``), so a client
+    can flip one thing without echoing the row back. ``note`` APPENDS a private
+    operator note; it never replaces the existing ones. ``tags`` DOES replace (a
+    tag set is edited as a whole in the UI).
+    """
+
+    state: str | None = None
+    snooze_until: str | None = None
+    tags: list[str] | None = None
+    note: str | None = None
+    bot_paused: bool | None = None
+
+
+class ConversationPatchResponse(BaseModel):
+    ok: bool = True
+    conversation: ConversationRow
 
 
 class TranscriptMessage(BaseModel):
@@ -1723,9 +1881,10 @@ async def get_site_conversations(
     site_id: str,
     limit: int = Query(20, ge=1, le=100),
     cursor: str | None = Query(None),
+    state: str | None = Query(None, description="open | needs_human | snoozed | closed"),
     workspace_id: str = Depends(current_workspace_id),
 ) -> ConversationsResponse:
-    """Recent concierge conversations for a site, newest first (D2).
+    """Recent concierge conversations for a site, newest first (D2 + slice 1).
 
     Concierge runs persist as ``ChatRunDoc`` (context_type "concierge",
     scope_id = the site's pocket). The compound (workspace, context_type,
@@ -1734,9 +1893,167 @@ async def get_site_conversations(
     one conversation each (most-recent run wins for the preview + timestamp). The
     scan window is bounded (never a full-collection read). Cross-site isolation:
     scope_id is the site's OWN pocket, so a sibling site's runs never match.
+
+    Slice 1 joins each conversation's state row onto its item (queue state, unread
+    count, tags, whether a decision is waiting) and returns the widget's unfiltered
+    per-state ``counts``. ``?state=`` filters the page on the joined state; an
+    unknown value 422s rather than silently returning everything.
     """
-    site = await _load_site_scoped(site_id, workspace_id)
-    return await _list_conversations(site.pocket_id, workspace_id, limit=limit, cursor=cursor)
+    if state is not None and state not in {s.value for s in ConversationState}:
+        raise HTTPException(422, "invalid_state")
+    site, widget = await _resolve_site_and_widget(site_id, workspace_id)
+    return await _list_conversations(
+        site.pocket_id, workspace_id, limit=limit, cursor=cursor, widget=widget, state=state
+    )
+
+
+@router.patch(
+    "/paw-bar/admin/site/{site_id}/conversations/{customer_ref}",
+    response_model=ConversationPatchResponse,
+)
+async def patch_site_conversation(
+    site_id: str,
+    customer_ref: str,
+    req: ConversationPatchRequest,
+    # The gate doubles as the author lookup: ``require_action`` RETURNS the caller
+    # once it clears the role check, so a note is attributed without a second dep.
+    user: Any = Depends(_require_paw_bar_manage),
+    workspace_id: str = Depends(current_workspace_id),
+) -> ConversationPatchResponse:
+    """File a conversation: change its state, snooze it, tag it, or note it.
+
+    The owner WRITE half of the inbox. Gated on ``paw_bar.manage`` — the paw-bar
+    write action (there is no ``paw_bar.write``; ``manage`` is the mutation gate
+    this router already uses, and both resolve to ADMIN) — and workspace-scoped at
+    the same two seams as the reads: the Site loads scoped (cross-tenant → 404),
+    then its widget, so the row being written always belongs to this tenant.
+
+    LAZY ROW CREATION: a conversation that predates the state table has no row.
+    Rather than 404 on the owner's first snooze, the row is minted with defaults
+    (``ensure_conversation`` — it does NOT touch the unread counter or the visitor
+    timestamps, because an owner filing something is not visitor activity) and the
+    patch applies to it. A ``customer_ref`` with no concierge runs on this site
+    404s: that is not a conversation, it's a guess.
+
+    Only the fields SENT are applied. ``note`` appends; ``tags`` replaces.
+    """
+    if not _CUSTOMER_REF_RE.match(customer_ref or ""):
+        raise HTTPException(400, "invalid_customer_ref")
+    fields = _validated_conversation_fields(req, getattr(user, "id", "") or "")
+    site, widget = await _resolve_site_and_widget(site_id, workspace_id)
+    if widget is None:
+        raise HTTPException(404, "conversation_not_found")
+
+    store = _store()
+    conversation = await store.get_conversation(widget.id, customer_ref, workspace_id=workspace_id)
+    if conversation is None:
+        # No row yet — only mint one if this ref actually HAS a conversation here.
+        runs = await _concierge_runs_for_visitor(
+            site.pocket_id, customer_ref, workspace_id, limit=1
+        )
+        if not runs:
+            raise HTTPException(404, "conversation_not_found")
+        conversation = await store.ensure_conversation(widget.id, customer_ref, workspace_id)
+
+    if fields:
+        updated = await store.update_conversation(
+            widget.id, customer_ref, workspace_id=workspace_id, **fields
+        )
+        conversation = updated or conversation
+    return ConversationPatchResponse(ok=True, conversation=_conversation_row(conversation))
+
+
+@router.get(
+    "/paw-bar/admin/agent/{agent_id}/conversations",
+    response_model=AgentConversationsResponse,
+    dependencies=[Depends(_require_paw_bar_read)],
+)
+async def get_agent_conversations(
+    agent_id: str,
+    limit: int = Query(20, ge=1, le=100),
+    state: str | None = Query(None, description="open | needs_human | snoozed | closed"),
+    workspace_id: str = Depends(current_workspace_id),
+) -> AgentConversationsResponse:
+    """Every visitor conversation this AGENT is answering, across its sites (D1).
+
+    A site concierge is a normal Agent, and "this site's conversations" and "this
+    agent's visitor conversations" are the same list — the site is 1:1 with its
+    concierge. This endpoint is the agent-centric side of that identity, and the
+    seed of the cross-site inbox: it resolves agent → its bound widget(s) → their
+    sites and unions the per-site lists, newest first, each item carrying the site
+    it came from.
+
+    Tenancy, three seams deep: the AGENT must live in the caller's workspace (a
+    cross-tenant id 404s, never leaking that it exists), the widgets are read
+    workspace-scoped, and each widget's Site must resolve in this workspace or the
+    widget is skipped — so a legacy widget row with a blank workspace can't drag a
+    foreign site's conversations into the union.
+
+    An agent with no bound widget answers 200 with ``widget_count=0`` and empty
+    everything: "not a concierge" is a normal answer, not an error, and the
+    positive marker lets a client hide the tab rather than guess from emptiness.
+    """
+    if state is not None and state not in {s.value for s in ConversationState}:
+        raise HTTPException(422, "invalid_state")
+    from pocketpaw_ee.cloud.agents import service as agents_service
+    from pocketpaw_ee.sites.service import _canonical_site_doc
+
+    try:
+        agent_workspace = await agents_service.get_workspace(agent_id)
+    except Exception:  # noqa: BLE001 — an unresolvable agent is a 404, not a 500
+        agent_workspace = None
+    if agent_workspace != workspace_id:
+        raise HTTPException(404, "agent_not_found")
+
+    widgets = await _store().list_widgets(
+        agent_id=agent_id, workspace_id=workspace_id, limit=_AGENT_WIDGET_CAP
+    )
+
+    items: list[AgentConversationItem] = []
+    sites: list[AgentSiteRef] = []
+    counts: dict[str, int] = {}
+    for widget in widgets:
+        if not widget.pocket_id:
+            continue
+        # ``_canonical_site_doc`` rather than a bare find_one: a pocket published
+        # before stable site identity can still have duplicate Site docs, and the
+        # arbitrary one is how a dashboard ends up deep-linking a stale site id.
+        # Reused rather than re-derived so there is one answer to "which Site doc
+        # is this pocket's site".
+        site = await _canonical_site_doc(workspace_id, widget.pocket_id)
+        if site is None:
+            # The widget's pocket has no published site in this workspace — there
+            # is no conversation surface to read, and (belt-and-suspenders) this is
+            # where a legacy blank-workspace widget stops.
+            continue
+        sites.append(AgentSiteRef(site_id=str(site.id), site_name=site.name or ""))
+        page = await _list_conversations(
+            widget.pocket_id, workspace_id, limit=limit, cursor=None, widget=widget, state=state
+        )
+        for item in page.items:
+            items.append(
+                AgentConversationItem(
+                    **item.model_dump(), site_id=str(site.id), site_name=site.name or ""
+                )
+            )
+        for key, value in page.counts.items():
+            counts[key] = counts.get(key, 0) + value
+
+    # Newest first across the whole union, then cut to the page size. Sorting on
+    # the ISO timestamp is a string sort on purpose — the values are all produced
+    # by ``datetime.isoformat`` and an empty one sorts last, where a conversation
+    # with no timestamp belongs.
+    items.sort(key=lambda i: i.last_message_at or "", reverse=True)
+    return AgentConversationsResponse(
+        items=items[:limit],
+        counts=counts,
+        sites=sites,
+        # The BINDING signal: how many paw-bar widgets this agent answers for,
+        # counted before the site resolution. ``sites`` can be shorter (a widget
+        # whose site was never published has nothing to list) — but the agent is a
+        # concierge either way, and that is the question a client is asking.
+        widget_count=len(widgets),
+    )
 
 
 @router.get(
@@ -1924,8 +2241,150 @@ async def get_site_preview_frame(
 # --- D2 aggregation data-source helpers -------------------------------------
 
 
+def _validated_conversation_fields(req: ConversationPatchRequest, author: str) -> dict[str, Any]:
+    """Turn a validated PATCH body into the store's keyword fields.
+
+    Only the keys the client actually SENT survive (``model_fields_set``), so a
+    PATCH carrying one field can't blank the others. Validation is strict and
+    up-front — a bad value is a 422 before anything is written, never a row in a
+    state no filter can find:
+
+      * ``state`` must be one of the four; anything else 422s.
+      * ``snooze_until`` must be an ISO timestamp (the store compares it as a
+        string in SQL, so a free-form value would silently never expire). Empty
+        string is allowed — it clears the snooze.
+      * ``tags`` are trimmed, de-duplicated, and capped in count and length.
+      * ``note`` is capped and attributed to the CALLER, never to a client-
+        supplied author.
+    """
+    fields: dict[str, Any] = {}
+    sent = req.model_fields_set
+    if "state" in sent and req.state is not None:
+        if req.state not in {s.value for s in ConversationState}:
+            raise HTTPException(422, "invalid_state")
+        fields["state"] = req.state
+    if "snooze_until" in sent and req.snooze_until is not None:
+        stamp = req.snooze_until.strip()
+        if stamp:
+            try:
+                datetime.fromisoformat(stamp)
+            except ValueError as exc:
+                raise HTTPException(422, "invalid_snooze_until") from exc
+        fields["snooze_until"] = stamp
+    if "tags" in sent and req.tags is not None:
+        cleaned: list[str] = []
+        for tag in req.tags:
+            value = str(tag).strip()[:_MAX_TAG_CHARS]
+            if value and value not in cleaned:
+                cleaned.append(value)
+        if len(cleaned) > _MAX_CONVERSATION_TAGS:
+            raise HTTPException(422, "too_many_tags")
+        fields["tags"] = cleaned
+    if "note" in sent and req.note is not None:
+        text = req.note.strip()[:_MAX_NOTE_CHARS]
+        if text:
+            fields["note"] = {
+                "author": author,
+                "text": text,
+                "at": datetime.now().isoformat(),
+            }
+    if "bot_paused" in sent and req.bot_paused is not None:
+        fields["bot_paused"] = bool(req.bot_paused)
+    return fields
+
+
+def _conversation_row(conversation: Any) -> ConversationRow:
+    """Project a stored :class:`Conversation` into the wire shape."""
+    return ConversationRow(
+        id=conversation.id,
+        widget_id=conversation.widget_id,
+        customer_ref=conversation.customer_ref,
+        state=conversation.state.value,
+        bot_paused=conversation.bot_paused,
+        snooze_until=conversation.snooze_until,
+        assignee=conversation.assignee,
+        tags=list(conversation.tags),
+        notes=[note.model_dump() for note in conversation.notes],
+        contact_email=conversation.contact_email,
+        display_name=_display_name(conversation.contact_email, conversation.customer_ref),
+        last_visitor_at=conversation.last_visitor_at,
+        last_owner_at=conversation.last_owner_at,
+        unread_for_owner=conversation.unread_for_owner,
+        created_at=conversation.created_at.isoformat(),
+        updated_at=conversation.updated_at.isoformat(),
+    )
+
+
+def _display_name(contact_email: str, customer_ref: str) -> str:
+    """What to call a visitor in the owner's list.
+
+    Their email when they left one during a decision capture — that is the whole
+    point of collecting it — otherwise a short stub of the anonymous handle
+    (``visitor-ab12cd``). Never the raw 32-char ref: an inbox of hex strings is
+    unreadable, and the stub is enough to tell two live conversations apart.
+    """
+    if contact_email:
+        return contact_email
+    return f"visitor-{customer_ref[:_DISPLAY_REF_CHARS]}" if customer_ref else "visitor"
+
+
+async def _conversation_side_data(
+    widget: PawBarWidget | None, workspace_id: str, refs: list[str]
+) -> tuple[dict[str, Any], set[str], dict[str, str]]:
+    """Load the per-visitor extras a conversation list row needs.
+
+    Returns ``(state rows by ref, refs with a pending action, contact email by
+    ref)``. Two bounded store reads for the WHOLE page, never one per row:
+
+      * the ``paw_bar_conversations`` rows for exactly the refs on this page, and
+      * this widget's decision rows, which answer both "is something waiting on
+        the owner" and "did this visitor ever leave an email".
+
+    The email is READ from the decision row rather than copied onto the
+    conversation row — it stays in the one place the PII invariant names, and this
+    owner-authed list is exactly who it was left for. Best-effort throughout: if
+    the store hiccups the list still renders, just without the queue metadata.
+    """
+    states: dict[str, Any] = {}
+    pending: set[str] = set()
+    emails: dict[str, str] = {}
+    if widget is None or not refs:
+        return states, pending, emails
+    store = _store()
+    try:
+        rows = await store.list_conversations(
+            widget.id, workspace_id=workspace_id, limit=len(refs), customer_refs=refs
+        )
+        states = {row.customer_ref: row for row in rows}
+    except Exception:  # noqa: BLE001 — queue metadata is additive, never fatal
+        logger.warning("conversation state read failed for widget %s", widget.id, exc_info=True)
+    try:
+        decisions = await store.list_decisions_for_widget(widget.id, limit=_CONVERSATION_SCAN_CAP)
+    except Exception:  # noqa: BLE001 — same posture as the state read
+        logger.warning("decision read failed for widget %s", widget.id, exc_info=True)
+        decisions = []
+    wanted = set(refs)
+    for decision in decisions:
+        ref = decision.customer_ref
+        if ref not in wanted:
+            continue
+        if decision.state == DecisionState.PENDING:
+            pending.add(ref)
+        # list_decisions_for_widget is newest-first, so the FIRST email we see for
+        # a visitor is their most recent one.
+        if decision.contact_email and ref not in emails:
+            emails[ref] = decision.contact_email
+    return states, pending, emails
+
+
 async def _list_conversations(
-    pocket_id: str, workspace_id: str, *, limit: int, cursor: str | None
+    pocket_id: str,
+    workspace_id: str,
+    *,
+    limit: int,
+    cursor: str | None,
+    widget: PawBarWidget | None = None,
+    state: str | None = None,
 ) -> ConversationsResponse:
     """Group concierge ``ChatRunDoc`` runs into per-customer conversations.
 
@@ -1935,6 +2394,16 @@ async def _list_conversations(
     cursor (the oldest scanned run's timestamp) when the window filled — the
     signal that older conversations remain. Best-effort: a store error degrades to
     an empty, well-shaped payload rather than failing the dashboard.
+
+    The RUNS stay the source of the list (a conversation exists because someone
+    talked to the concierge, not because a row was written), and the state row is
+    joined onto each one where it exists. A conversation with no row keeps every
+    default — which is why nothing had to be backfilled when the table shipped.
+
+    ``state`` filters on that joined state, AFTER the dedupe, so an unjoined
+    legacy conversation is found under ``open`` where the owner expects it.
+    Filtering is a page-level operation: a filtered page can come back shorter
+    than ``limit`` while older matches remain behind the cursor.
     """
     from datetime import datetime
 
@@ -1961,7 +2430,10 @@ async def _list_conversations(
         logger.warning("conversations read failed for pocket %s", pocket_id, exc_info=True)
         return ConversationsResponse(items=[], cursor=None, unsupported=False)
 
-    items: list[ConversationItem] = []
+    # Dedupe the scanned window first (most-recent run per customer wins), THEN
+    # join and filter, THEN cut to `limit` — cutting first would hide a matching
+    # conversation behind a page of non-matching ones.
+    candidates: list[tuple[str, str, str]] = []
     seen: set[str] = set()
     for run in runs:
         if run.user_id in seen:
@@ -1973,11 +2445,34 @@ async def _list_conversations(
         # cut off used to render a blank row, which told the owner nothing; the
         # question at least says what the visitor wanted.
         preview = (run.partial_text or "") or (getattr(run, "user_text", "") or "")
+        candidates.append(
+            (run.user_id, when.isoformat() if when else "", preview[:_CONVERSATION_PREVIEW_CHARS])
+        )
+
+    states, pending, emails = await _conversation_side_data(
+        widget, workspace_id, [ref for ref, _, _ in candidates]
+    )
+
+    items: list[ConversationItem] = []
+    for ref, last_message_at, preview in candidates:
+        row = states.get(ref)
+        row_state = row.state.value if row is not None else "open"
+        if state and row_state != state:
+            continue
+        email = (row.contact_email if row is not None else "") or emails.get(ref, "")
         items.append(
             ConversationItem(
-                customer_ref=run.user_id,
-                last_message_at=when.isoformat() if when else "",
-                preview=preview[:_CONVERSATION_PREVIEW_CHARS],
+                customer_ref=ref,
+                last_message_at=last_message_at,
+                preview=preview,
+                state=row_state,
+                bot_paused=bool(row.bot_paused) if row is not None else False,
+                unread_for_owner=row.unread_for_owner if row is not None else 0,
+                tags=list(row.tags) if row is not None else [],
+                snooze_until=row.snooze_until if row is not None else "",
+                contact_email=email,
+                display_name=_display_name(email, ref),
+                has_pending_action=ref in pending,
             )
         )
         if len(items) >= limit:
@@ -1988,7 +2483,23 @@ async def _list_conversations(
     next_cursor = (
         runs[-1].createdAt.isoformat() if len(runs) >= _CONVERSATION_SCAN_CAP and runs else None
     )
-    return ConversationsResponse(items=items, cursor=next_cursor, unsupported=False)
+    counts = await _conversation_counts(widget, workspace_id)
+    return ConversationsResponse(items=items, cursor=next_cursor, unsupported=False, counts=counts)
+
+
+async def _conversation_counts(widget: PawBarWidget | None, workspace_id: str) -> dict[str, int]:
+    """Per-state totals for a widget's inbox — ``{}`` when there is no widget.
+
+    Deliberately NOT derived from the listed page: the chips report the whole
+    queue, so they stay stable while a filter is active. Best-effort → ``{}``.
+    """
+    if widget is None:
+        return {}
+    try:
+        return await _store().conversation_counts(widget.id, workspace_id=workspace_id)
+    except Exception:  # noqa: BLE001 — a badge must not 500 the list
+        logger.warning("conversation counts failed for widget %s", widget.id, exc_info=True)
+        return {}
 
 
 async def _concierge_runs_for_visitor(
@@ -2661,6 +3172,22 @@ async def concierge_chat(body: ConciergeChatRequest, request: Request) -> Stream
         )
     except Exception:
         logger.debug("concierge chat marker record failed (non-fatal)", exc_info=True)
+
+    # Touch the conversation's state row (owner inbox, slice 1). THIS is what makes
+    # the queue backfill-free: the row is minted on a visitor's first message and
+    # kept current on every one after — no migration, no sweeper, no separate
+    # producer to forget. It also carries the auto-reopen rule, so a visitor coming
+    # back to a conversation the owner closed lands back in the inbox.
+    #
+    # FAILURE-SOFT, deliberately and non-negotiably: inbox bookkeeping is the
+    # owner's convenience, and a hiccup writing it must never cost a visitor their
+    # answer. Worst case the owner's queue is one message stale until the next turn.
+    try:
+        await store.upsert_conversation_on_visitor_turn(
+            body.widget_id, body.customer_ref, ctx.workspace_id
+        )
+    except Exception:
+        logger.warning("conversation state upsert failed (non-fatal)", exc_info=True)
 
     # (8) Dispatch a CONCIERGE run over the SAME machinery the authed chat uses.
     from pocketpaw_ee.cloud.chat.runs import service as run_service

--- a/src/pocketpaw/paw_bar/models.py
+++ b/src/pocketpaw/paw_bar/models.py
@@ -1,4 +1,11 @@
 # ee/paw_bar/models.py — Pydantic models for the Paw Bar widget layer.
+# Updated: 2026-07-30 (owner inbox, slice 1) — the conversation STATE vocabulary:
+#   ``ConversationState`` (open | needs_human | snoozed | closed),
+#   ``ConversationNote`` (an owner's private {author, text, at}) and
+#   ``Conversation`` — a thin lifecycle row over the concierge run docs, keyed by
+#   (widget_id, customer_ref). It stores NO messages: the transcript stays derived
+#   from ChatRunDoc and this row adds only lifecycle + operator metadata, so the
+#   queue and the log never disagree about what was said.
 # Updated: 2026-07-30 (async decision delivery) — DecisionStatus gains an
 #   optional ``contact_email`` (empty default). A visitor who leaves the page
 #   while their request is PENDING can leave an email; when the owner decides,
@@ -455,6 +462,107 @@ class DecisionStatus(BaseModel):
     # the row level; the only consumer is the one-shot email the delivery
     # hook sends when the row flips out of PENDING.
     contact_email: str = ""
+    created_at: datetime = Field(default_factory=datetime.now)
+    updated_at: datetime = Field(default_factory=datetime.now)
+
+
+# ---------------------------------------------------------------------------
+# Conversation lifecycle — the owner inbox's state row (slice 1)
+#
+# A concierge conversation already EXISTS as a stream of ChatRunDoc rows keyed by
+# (workspace, context_type='concierge', scope_id, customer_ref). What it lacks is
+# a place to say "this one still needs me". These models are that place, and
+# nothing more: no messages, no copies of the transcript. One row per
+# (widget_id, customer_ref), created lazily on the visitor's first turn, so the
+# log becomes a queue without a backfill.
+# ---------------------------------------------------------------------------
+
+
+def _gen_conversation_id() -> str:
+    """Fresh conversation row id (``ppc_…``).
+
+    Named rather than inlined so the model default and the store's INSERT mint
+    ids the same way — the store writes rows with raw SQL, so without this the
+    prefix would live in two places and drift.
+    """
+    return _gen_id("ppc")
+
+
+class ConversationState(StrEnum):
+    """Where a visitor conversation sits in the owner's queue.
+
+    ``OPEN``        — live; the bot is handling it (or the owner is) and it sits
+                      in the default inbox view.
+    ``NEEDS_HUMAN`` — escalated: the visitor asked for a person, or the bot could
+                      not answer. It is the ONE state a visitor reply does not
+                      change — already at the top of the queue, nowhere to raise.
+    ``SNOOZED``     — deliberately hidden until ``snooze_until``. Expiry is
+                      computed on READ (see the store) — there is no sweeper, so
+                      a snooze always ends on time even if nothing is running.
+    ``CLOSED``      — done. A new visitor message re-opens it automatically.
+    """
+
+    OPEN = "open"
+    NEEDS_HUMAN = "needs_human"
+    SNOOZED = "snoozed"
+    CLOSED = "closed"
+
+
+class ConversationNote(BaseModel):
+    """One private operator note on a conversation — never shown to the visitor.
+
+    Notes are append-only from the owner API (a PATCH carrying ``note`` appends
+    rather than replaces), so the internal thread of "what we know about this
+    person" survives every other edit. ``at`` is an ISO timestamp string, matching
+    how the row's other time fields are stored.
+    """
+
+    author: str = ""
+    text: str = ""
+    at: str = ""
+
+
+class Conversation(BaseModel):
+    """The lifecycle + operator metadata for ONE visitor conversation.
+
+    Identity is ``(widget_id, customer_ref)`` — 1:1 with the concierge run
+    stream's ``session_key`` — and the row is deliberately thin: the transcript is
+    NOT here, it stays derived from the run docs. What lives here is only what the
+    runs cannot express: the queue state, whether the bot is muted, the owner's
+    tags and private notes, and the unread counter.
+
+    ``workspace_id`` is the REAL tenant workspace (the concierge run's
+    ``ctx.workspace_id``), unlike ``DecisionStatus.workspace_id``, which stores
+    the widget owner — so scoped reads here are a true tenancy filter.
+
+    ``snooze_until`` / ``last_visitor_at`` / ``last_owner_at`` are ISO strings
+    rather than datetimes so the store can compare them in SQL (the snooze-expiry
+    CASE) without a round trip through Python.
+
+    PII posture: ``contact_email`` mirrors the invariant on
+    ``DecisionStatus.contact_email`` — a visitor-supplied address, owner-visible
+    only. It must never reach the Instinct action, the agent's context, the KB,
+    the transcript, the soul, or any PUBLIC read. Slice 1 never writes it (the
+    owner list derives the display name from the decision row that captured it);
+    the column exists so a later slice can promote it explicitly.
+    """
+
+    id: str = Field(default_factory=_gen_conversation_id)
+    widget_id: str
+    customer_ref: str
+    workspace_id: str = ""
+    state: ConversationState = ConversationState.OPEN
+    bot_paused: bool = False
+    snooze_until: str = ""
+    # Present for the operator toolkit later; there is no assignment UI in v1
+    # (solo-owner posture), so nothing writes it yet.
+    assignee: str = ""
+    tags: list[str] = Field(default_factory=list)
+    notes: list[ConversationNote] = Field(default_factory=list)
+    contact_email: str = ""
+    last_visitor_at: str = ""
+    last_owner_at: str = ""
+    unread_for_owner: int = 0
     created_at: datetime = Field(default_factory=datetime.now)
     updated_at: datetime = Field(default_factory=datetime.now)
 

--- a/src/pocketpaw/paw_bar/store.py
+++ b/src/pocketpaw/paw_bar/store.py
@@ -124,11 +124,20 @@ def _as_note(value: Any) -> ConversationNote:
     Accepts a model, a dict, or a bare string (treated as the text). ``at`` is
     stamped now when the caller didn't supply one, so a note is always ordered in
     the thread even if the API omitted the timestamp.
+
+    ``author`` is coerced with ``str()`` because the router passes the AUTHENTICATED
+    caller's id, and that arrives as a ``PydanticObjectId`` — not a ``str``. Unit
+    tests that hand-build a note pass a plain string and never see it, so the real
+    PATCH 500'd on a pydantic string_type error the first time an owner filed a
+    note against a live session (found on the rig, 2026-07-30).
     """
     if isinstance(value, ConversationNote):
         note = value
     elif isinstance(value, dict):
-        note = ConversationNote.model_validate(value)
+        raw = dict(value)
+        if raw.get("author") is not None:
+            raw["author"] = str(raw["author"])
+        note = ConversationNote.model_validate(raw)
     else:
         note = ConversationNote(text=str(value))
     if not note.at:

--- a/src/pocketpaw/paw_bar/store.py
+++ b/src/pocketpaw/paw_bar/store.py
@@ -1,4 +1,17 @@
 # ee/paw_bar/store.py — Async SQLite store for Paw Bar widgets and events.
+# Updated: 2026-07-30 (owner inbox, slice 1) — new paw_bar_conversations table:
+#   the thin lifecycle row that turns the concierge log into a queue, keyed
+#   UNIQUE(widget_id, customer_ref). Mirrors the paw_bar_decisions conventions
+#   (SCHEMA_SQL for fresh DBs + additive _migrate_columns ALTERs for deployed
+#   ones, a _conversation_workspace_scope tenancy fragment). Methods:
+#   upsert_conversation_on_visitor_turn (lazy create-or-touch — bumps the unread
+#   counter and AUTO-REOPENS a closed/snoozed row, leaving needs_human alone),
+#   ensure_conversation (create-without-touch, for the first owner-side read),
+#   get_conversation / list_conversations / update_conversation (whitelisted
+#   fields; a single ``note`` APPENDS) / conversation_counts. Snooze expiry is
+#   computed on READ via _EFFECTIVE_STATE_SQL — a snooze ends on time with no
+#   sweeper process. list_widgets also gains an ``agent_id`` filter so the
+#   agent-scoped inbox can resolve one agent's widgets in one query.
 # Updated: 2026-07-30 (async decision delivery) — paw_bar_decisions gains a
 #   contact_email TEXT DEFAULT '' column (additive: SCHEMA_SQL for fresh DBs +
 #   _migrate_columns ALTER for deployed ones, same pattern as workspace_id).
@@ -90,6 +103,9 @@ import aiosqlite
 
 from pocketpaw.paw_bar.models import (
     MAX_CART_ITEMS,
+    Conversation,
+    ConversationNote,
+    ConversationState,
     DecisionState,
     DecisionStatus,
     PawBarCart,
@@ -97,8 +113,28 @@ from pocketpaw.paw_bar.models import (
     PawBarEvent,
     PawBarSpec,
     PawBarWidget,
+    _gen_conversation_id,
     _gen_token,
 )
+
+
+def _as_note(value: Any) -> ConversationNote:
+    """Coerce whatever a caller passed as a note into a :class:`ConversationNote`.
+
+    Accepts a model, a dict, or a bare string (treated as the text). ``at`` is
+    stamped now when the caller didn't supply one, so a note is always ordered in
+    the thread even if the API omitted the timestamp.
+    """
+    if isinstance(value, ConversationNote):
+        note = value
+    elif isinstance(value, dict):
+        note = ConversationNote.model_validate(value)
+    else:
+        note = ConversationNote(text=str(value))
+    if not note.at:
+        note = note.model_copy(update={"at": datetime.now().isoformat()})
+    return note
+
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS paw_bar_widgets (
@@ -169,6 +205,33 @@ CREATE TABLE IF NOT EXISTS paw_bar_carts (
     PRIMARY KEY (widget_id, customer_ref)
 );
 
+-- Owner inbox (slice 1): the conversation STATE row. One per
+-- (widget_id, customer_ref) — the same identity as the concierge run stream's
+-- session_key — holding lifecycle + operator metadata ONLY. No messages: the
+-- transcript stays derived from the run docs, so there is one source of truth
+-- for what was said and one for how the owner is handling it. Created lazily on
+-- the visitor's first turn (or the owner's first read), so no backfill is needed
+-- and a legacy conversation with no row still lists with defaults.
+CREATE TABLE IF NOT EXISTS paw_bar_conversations (
+    id TEXT PRIMARY KEY,
+    widget_id TEXT NOT NULL,
+    customer_ref TEXT NOT NULL,
+    workspace_id TEXT DEFAULT '',
+    state TEXT DEFAULT 'open',
+    bot_paused INTEGER DEFAULT 0,
+    snooze_until TEXT DEFAULT '',
+    assignee TEXT DEFAULT '',
+    tags TEXT DEFAULT '[]',
+    notes TEXT DEFAULT '[]',
+    contact_email TEXT DEFAULT '',
+    last_visitor_at TEXT DEFAULT '',
+    last_owner_at TEXT DEFAULT '',
+    unread_for_owner INTEGER DEFAULT 0,
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now')),
+    UNIQUE (widget_id, customer_ref)
+);
+
 CREATE INDEX IF NOT EXISTS idx_pp_widgets_pocket ON paw_bar_widgets(pocket_id);
 CREATE INDEX IF NOT EXISTS idx_pp_widgets_owner ON paw_bar_widgets(owner);
 CREATE INDEX IF NOT EXISTS idx_pp_widgets_workspace ON paw_bar_widgets(workspace_id);
@@ -182,7 +245,41 @@ CREATE INDEX IF NOT EXISTS idx_pp_decisions_action
     ON paw_bar_decisions(instinct_action_id);
 CREATE INDEX IF NOT EXISTS idx_pp_spec_revisions_widget
     ON paw_bar_spec_revisions(widget_id, revision DESC);
+CREATE INDEX IF NOT EXISTS idx_pp_conversations_state
+    ON paw_bar_conversations(widget_id, state, updated_at DESC);
 """
+
+# The paw_bar_conversations columns, with the exact declaration each ALTER must
+# use when adding it to an already-deployed table. Keep in lockstep with the
+# CREATE TABLE above (the primary key + the UNIQUE constraint can't be ALTERed in
+# and are therefore not listed — a table that old is recreated, not migrated).
+_CONVERSATION_COLUMNS: dict[str, str] = {
+    "workspace_id": "TEXT DEFAULT ''",
+    "state": "TEXT DEFAULT 'open'",
+    "bot_paused": "INTEGER DEFAULT 0",
+    "snooze_until": "TEXT DEFAULT ''",
+    "assignee": "TEXT DEFAULT ''",
+    "tags": "TEXT DEFAULT '[]'",
+    "notes": "TEXT DEFAULT '[]'",
+    "contact_email": "TEXT DEFAULT ''",
+    "last_visitor_at": "TEXT DEFAULT ''",
+    "last_owner_at": "TEXT DEFAULT ''",
+    "unread_for_owner": "INTEGER DEFAULT 0",
+    "created_at": "TEXT",
+    "updated_at": "TEXT",
+}
+
+# Snooze expiry, decided in SQL at READ time. A row is only really snoozed while
+# its ``snooze_until`` is still in the future; once that instant passes it reads
+# as ``open`` again — no sweeper process, no cron, nothing to fail silently at
+# 3am and leave a customer waiting. An empty ``snooze_until`` means "snoozed
+# indefinitely" (the owner never set an end), so it never expires. Every state
+# filter and every count goes through this ONE expression so the list, the badge,
+# and the row detail can never disagree about what state a conversation is in.
+_EFFECTIVE_STATE_SQL = (
+    "CASE WHEN state = 'snoozed' AND snooze_until != '' AND snooze_until <= ?"
+    " THEN 'open' ELSE state END"
+)
 
 
 def _decision_workspace_scope(workspace_id: str | None) -> tuple[str | None, list[Any]]:
@@ -208,6 +305,21 @@ def _widget_workspace_scope(workspace_id: str | None) -> tuple[str | None, list[
     so a legacy/global row is matched on ``= ''`` as well as ``IS NULL``.
     Returns ``(None, [])`` when ``workspace_id`` is ``None`` — no scoping,
     fully backward-compatible.
+    """
+    if workspace_id is None:
+        return None, []
+    return "(workspace_id = ? OR workspace_id = '' OR workspace_id IS NULL)", [workspace_id]
+
+
+def _conversation_workspace_scope(workspace_id: str | None) -> tuple[str | None, list[Any]]:
+    """Build the tenancy WHERE fragment + bound params for a scoped conversation read.
+
+    Same shape as :func:`_decision_workspace_scope`, but the column means what it
+    says here: a conversation row stores the REAL tenant workspace (the concierge
+    run's ``ctx.workspace_id``), not the widget owner, so this IS a true tenancy
+    filter rather than a widget-owner match. A legacy row written before the
+    column carried a value (''/NULL) still matches, so the queue never loses a
+    conversation to a migration. ``None`` leaves the read unscoped.
     """
     if workspace_id is None:
         return None, []
@@ -270,6 +382,19 @@ class PawBarStore:
                     await db.execute(
                         f"ALTER TABLE paw_bar_decisions ADD COLUMN {name} TEXT DEFAULT ''"
                     )
+        # paw_bar_conversations (owner inbox, slice 1). The table is new, so a
+        # fresh DB gets the whole thing from SCHEMA_SQL and this is a no-op. It is
+        # listed anyway because the SAME trap that bit widgets and decisions
+        # applies the moment a column is added later: CREATE TABLE IF NOT EXISTS
+        # no-ops on the deployed table, and the SCHEMA_SQL index over
+        # (widget_id, state, updated_at) then fails with "no such column". Each
+        # entry carries its own type + default so the INTEGER counters don't
+        # arrive as text.
+        if "paw_bar_conversations" in existing:
+            cols = await _columns("paw_bar_conversations")
+            for name, decl in _CONVERSATION_COLUMNS.items():
+                if name not in cols:
+                    await db.execute(f"ALTER TABLE paw_bar_conversations ADD COLUMN {name} {decl}")
 
     def _conn(self) -> aiosqlite.Connection:
         return aiosqlite.connect(self._db_path)
@@ -329,7 +454,16 @@ class PawBarStore:
         owner: str | None = None,
         limit: int = 100,
         workspace_id: str | None = None,
+        agent_id: str | None = None,
     ) -> list[PawBarWidget]:
+        """List widgets, optionally filtered by pocket / owner / bound agent.
+
+        ``agent_id`` backs the agent-scoped inbox: a site concierge IS a normal
+        agent, so "this agent's conversations" resolves agent → its widget(s) →
+        their sites. Combined with ``workspace_id`` it is one query instead of a
+        workspace-wide list filtered in Python. An empty/None ``agent_id`` drops
+        the filter (it never means "unbound widgets").
+        """
         conditions: list[str] = []
         params: list[Any] = []
         if pocket_id:
@@ -338,6 +472,9 @@ class PawBarStore:
         if owner:
             conditions.append("owner = ?")
             params.append(owner)
+        if agent_id:
+            conditions.append("agent_id = ?")
+            params.append(agent_id)
         ws_cond, ws_params = _widget_workspace_scope(workspace_id)
         if ws_cond:
             conditions.append(ws_cond)
@@ -794,6 +931,292 @@ class PawBarStore:
                 row = await cur.fetchone()
                 return row[0] if row else 0
 
+    # ---------------- Conversations (owner inbox, slice 1) ----------------
+    #
+    # The state row over a concierge conversation. Everything here is keyed by
+    # (widget_id, customer_ref) and, like the decision reads, relies on the caller
+    # having ALREADY resolved the widget workspace-scoped — so ``widget_id`` names
+    # a widget in the caller's tenant and a sibling site's rows can never match.
+    # The ``workspace_id`` argument is the second, independent guard (this column
+    # holds the real tenant, unlike the decisions table's owner column).
+    # -------------------------------------------------------------------------
+
+    @staticmethod
+    def _conversation_select(
+        where: str, params: list[Any], *, order: str = "", now: str | None = None
+    ) -> tuple[str, list[Any]]:
+        """Build a conversation SELECT that carries the EFFECTIVE state.
+
+        Every read goes through here so snooze expiry is applied in exactly one
+        place: the extra ``effective_state`` column is the ``_EFFECTIVE_STATE_SQL``
+        CASE, and ``_row_to_conversation`` presents it as the row's state. The CASE
+        parameter binds BEFORE the WHERE parameters because it sits in the select
+        list — hence the explicit assembly rather than string concatenation at the
+        call sites.
+        """
+        stamp = now or datetime.now().isoformat()
+        sql = (
+            f"SELECT *, {_EFFECTIVE_STATE_SQL} AS effective_state"
+            f" FROM paw_bar_conversations WHERE {where}"
+        )
+        if order:
+            sql += f" {order}"
+        return sql, [stamp, *params]
+
+    async def upsert_conversation_on_visitor_turn(
+        self, widget_id: str, customer_ref: str, workspace_id: str = ""
+    ) -> Conversation:
+        """Create-or-touch the conversation row for a visitor's message.
+
+        Called on every visitor turn (from ``concierge_chat``), which is what makes
+        the queue backfill-free: the first message a visitor ever sends mints the
+        row, and every message after that keeps it current. Three effects:
+
+          * ``last_visitor_at`` = now, ``unread_for_owner`` += 1 — the owner has
+            something new to look at.
+          * AUTO-REOPEN: a ``closed`` or ``snoozed`` row goes back to ``open``, and
+            forgets any ``snooze_until`` it was carrying — a live conversation is
+            not due back later, it is here now. This is the universal
+            behaviour every inbox in this class has, and the one whose absence
+            reads as a lost customer: a visitor who comes back after you closed
+            them out must land in the queue, not in an archive.
+          * ``needs_human`` is left ALONE — it is already the top of the queue, so
+            "reopening" it would be a demotion.
+
+        Idempotent per message by construction (one row, counters advance). The
+        write is a single UPSERT so two turns racing can't lose an increment.
+        """
+        await self._ensure_schema()
+        now = datetime.now().isoformat()
+        row_id = _gen_conversation_id()
+        async with self._conn() as db:
+            await db.execute(
+                "INSERT INTO paw_bar_conversations"
+                " (id, widget_id, customer_ref, workspace_id, state, last_visitor_at,"
+                " unread_for_owner, created_at, updated_at)"
+                " VALUES (?, ?, ?, ?, 'open', ?, 1, ?, ?)"
+                " ON CONFLICT (widget_id, customer_ref) DO UPDATE SET"
+                "   last_visitor_at = excluded.last_visitor_at,"
+                "   unread_for_owner = paw_bar_conversations.unread_for_owner + 1,"
+                "   state = CASE WHEN paw_bar_conversations.state IN ('closed', 'snoozed')"
+                "     THEN 'open' ELSE paw_bar_conversations.state END,"
+                "   snooze_until = CASE WHEN paw_bar_conversations.state IN ('closed', 'snoozed')"
+                "     THEN '' ELSE paw_bar_conversations.snooze_until END,"
+                "   updated_at = excluded.updated_at",
+                (row_id, widget_id, customer_ref, workspace_id, now, now, now),
+            )
+            await db.commit()
+        conversation = await self.get_conversation(widget_id, customer_ref)
+        # The row was just written, so this can only be None if the DB vanished
+        # underneath us; return an unsaved value object rather than raising, so a
+        # visitor's chat is never broken by an inbox bookkeeping read.
+        return conversation or Conversation(
+            widget_id=widget_id, customer_ref=customer_ref, workspace_id=workspace_id
+        )
+
+    async def ensure_conversation(
+        self, widget_id: str, customer_ref: str, workspace_id: str = ""
+    ) -> Conversation:
+        """Return the conversation row, creating a DEFAULT one if it doesn't exist.
+
+        The owner-side sibling of :meth:`upsert_conversation_on_visitor_turn`: it
+        does NOT touch ``last_visitor_at`` or the unread counter, because an owner
+        opening or filing a conversation is not new visitor activity. This is how a
+        LEGACY conversation (one that predates the table) becomes manageable — the
+        first owner action on it mints the row with the same defaults the list
+        already renders for it, so nothing appears to change.
+        """
+        existing = await self.get_conversation(widget_id, customer_ref, workspace_id=workspace_id)
+        if existing is not None:
+            return existing
+        now = datetime.now().isoformat()
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(
+                "INSERT INTO paw_bar_conversations"
+                " (id, widget_id, customer_ref, workspace_id, state, created_at, updated_at)"
+                " VALUES (?, ?, ?, ?, 'open', ?, ?)"
+                " ON CONFLICT (widget_id, customer_ref) DO NOTHING",
+                (_gen_conversation_id(), widget_id, customer_ref, workspace_id, now, now),
+            )
+            await db.commit()
+        conversation = await self.get_conversation(
+            widget_id, customer_ref, workspace_id=workspace_id
+        )
+        return conversation or Conversation(
+            widget_id=widget_id, customer_ref=customer_ref, workspace_id=workspace_id
+        )
+
+    async def get_conversation(
+        self, widget_id: str, customer_ref: str, workspace_id: str | None = None
+    ) -> Conversation | None:
+        """One conversation's state row, or ``None`` when it has none yet.
+
+        ``None`` is a normal answer, not an error: a conversation that predates
+        this table (or one whose visitor never sent a turn after it shipped) simply
+        has no row, and every caller renders it with the model defaults.
+        """
+        conditions = "widget_id = ? AND customer_ref = ?"
+        params: list[Any] = [widget_id, customer_ref]
+        ws_cond, ws_params = _conversation_workspace_scope(workspace_id)
+        if ws_cond:
+            conditions += f" AND {ws_cond}"
+            params.extend(ws_params)
+        sql, bound = self._conversation_select(conditions, params, order="LIMIT 1")
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(sql, bound) as cur:
+                row = await cur.fetchone()
+                return self._row_to_conversation(row) if row else None
+
+    async def list_conversations(
+        self,
+        widget_id: str,
+        workspace_id: str | None = None,
+        state: str | None = None,
+        limit: int = 50,
+        customer_refs: list[str] | None = None,
+    ) -> list[Conversation]:
+        """A widget's conversation rows, most recently updated first.
+
+        ``state`` filters on the EFFECTIVE state, so an expired snooze is found
+        under ``open`` and not under ``snoozed`` — the same rule the row detail and
+        the counts use. ``customer_refs``, when given, restricts the read to those
+        visitors: that is the join path for the owner list, which is driven by the
+        run docs and needs the state rows for exactly the refs on the page (an
+        exact IN-list beats hoping a "most recent 200 rows" window covers them).
+        Rows that don't exist are simply absent — the caller supplies defaults.
+        """
+        conditions = "widget_id = ?"
+        params: list[Any] = [widget_id]
+        ws_cond, ws_params = _conversation_workspace_scope(workspace_id)
+        if ws_cond:
+            conditions += f" AND {ws_cond}"
+            params.extend(ws_params)
+        now = datetime.now().isoformat()
+        if state:
+            conditions += f" AND {_EFFECTIVE_STATE_SQL} = ?"
+            params.extend([now, state])
+        if customer_refs is not None:
+            if not customer_refs:
+                return []
+            placeholders = ", ".join("?" for _ in customer_refs)
+            conditions += f" AND customer_ref IN ({placeholders})"
+            params.extend(customer_refs)
+        sql, bound = self._conversation_select(
+            conditions, params, order="ORDER BY updated_at DESC LIMIT ?", now=now
+        )
+        bound.append(limit)
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(sql, bound) as cur:
+                return [self._row_to_conversation(row) async for row in cur]
+
+    async def update_conversation(
+        self,
+        widget_id: str,
+        customer_ref: str,
+        workspace_id: str | None = None,
+        **fields: Any,
+    ) -> Conversation | None:
+        """Patch a conversation's operator fields. Returns ``None`` if it has no row.
+
+        Only whitelisted keys are written (an unknown key is ignored, never
+        interpolated into SQL). ``note`` is the one special case: a SINGLE note
+        APPENDS to the existing list rather than replacing it, because private
+        notes are the operator's running record of a customer and a PATCH that
+        silently dropped the earlier ones would be a data-loss bug wearing an
+        edit's clothes. Pass ``notes=[…]`` to replace the whole list deliberately.
+
+        The lookup and the UPDATE are both workspace-scoped, so a cross-tenant
+        (widget, customer) pair writes nothing and reads back ``None``.
+        """
+        existing = await self.get_conversation(widget_id, customer_ref, workspace_id=workspace_id)
+        if existing is None:
+            return None
+        allowed = {
+            "state",
+            "bot_paused",
+            "snooze_until",
+            "assignee",
+            "tags",
+            "notes",
+            "contact_email",
+            "last_owner_at",
+            "unread_for_owner",
+        }
+        assignments: list[str] = []
+        values: list[Any] = []
+        note = fields.pop("note", None)
+        if note is not None:
+            appended = [*existing.notes, _as_note(note)]
+            fields["notes"] = [n.model_dump() for n in appended]
+        for key, val in fields.items():
+            if key not in allowed:
+                continue
+            if key == "state":
+                # Normalize + validate here too: the store is called from more than
+                # one surface, and an unknown state would poison every filter.
+                val = ConversationState(val).value
+            elif key in ("tags", "notes"):
+                val = json.dumps(
+                    [n.model_dump() if isinstance(n, ConversationNote) else n for n in val]
+                )
+            elif key == "bot_paused":
+                val = 1 if val else 0
+            assignments.append(f"{key} = ?")
+            values.append(val)
+        if not assignments:
+            return existing
+        assignments.append("updated_at = ?")
+        values.append(datetime.now().isoformat())
+        sql = (
+            f"UPDATE paw_bar_conversations SET {', '.join(assignments)}"
+            " WHERE widget_id = ? AND customer_ref = ?"
+        )
+        values.extend([widget_id, customer_ref])
+        ws_cond, ws_params = _conversation_workspace_scope(workspace_id)
+        if ws_cond:
+            sql += f" AND {ws_cond}"
+            values.extend(ws_params)
+        await self._ensure_schema()
+        async with self._conn() as db:
+            await db.execute(sql, values)
+            await db.commit()
+        return await self.get_conversation(widget_id, customer_ref, workspace_id=workspace_id)
+
+    async def conversation_counts(
+        self, widget_id: str, workspace_id: str | None = None
+    ) -> dict[str, int]:
+        """Per-state counts for one widget — the inbox filter chips.
+
+        All four keys are always present (0 when empty) so the dashboard renders a
+        stable set of chips. Counted on the EFFECTIVE state, so a snooze that has
+        expired shows up under ``open`` exactly where the owner will find it. Only
+        rows that EXIST are counted: a legacy conversation with no row is listed
+        with default state but is deliberately not invented into a count.
+        """
+        counts = {s.value: 0 for s in ConversationState}
+        conditions = "widget_id = ?"
+        params: list[Any] = [widget_id]
+        ws_cond, ws_params = _conversation_workspace_scope(workspace_id)
+        if ws_cond:
+            conditions += f" AND {ws_cond}"
+            params.extend(ws_params)
+        await self._ensure_schema()
+        async with self._conn() as db:
+            async with db.execute(
+                f"SELECT {_EFFECTIVE_STATE_SQL} AS s, COUNT(*)"
+                f" FROM paw_bar_conversations WHERE {conditions} GROUP BY s",
+                [datetime.now().isoformat(), *params],
+            ) as cur:
+                async for row in cur:
+                    if row[0] in counts:
+                        counts[row[0]] = row[1]
+        return counts
+
     # ---------------- Carts (C1 — visitor-scoped commerce state) ----------------
 
     async def get_cart(self, widget_id: str, customer_ref: str) -> PawBarCart | None:
@@ -915,6 +1338,37 @@ class PawBarStore:
             payload=json.loads(row["payload"]) if row["payload"] else {},
             customer_ref=row["customer_ref"],
             timestamp=datetime.fromisoformat(row["timestamp"]),
+        )
+
+    def _row_to_conversation(self, row: Any) -> Conversation:
+        """Rebuild a :class:`Conversation` from a row read via ``_conversation_select``.
+
+        ``state`` is the row's EFFECTIVE state (the ``effective_state`` column the
+        select computes), so callers never have to remember to re-apply snooze
+        expiry. ``snooze_until`` is left as stored: an expired snooze reads as
+        ``open`` but keeps the timestamp that says when it lapsed.
+        """
+        raw_tags = json.loads(row["tags"]) if row["tags"] else []
+        raw_notes = json.loads(row["notes"]) if row["notes"] else []
+        keys = row.keys()
+        state = row["effective_state"] if "effective_state" in keys else row["state"]
+        return Conversation(
+            id=row["id"],
+            widget_id=row["widget_id"],
+            customer_ref=row["customer_ref"],
+            workspace_id=row["workspace_id"] or "",
+            state=ConversationState(state or ConversationState.OPEN.value),
+            bot_paused=bool(row["bot_paused"]),
+            snooze_until=row["snooze_until"] or "",
+            assignee=row["assignee"] or "",
+            tags=[str(t) for t in raw_tags],
+            notes=[_as_note(n) for n in raw_notes],
+            contact_email=row["contact_email"] or "",
+            last_visitor_at=row["last_visitor_at"] or "",
+            last_owner_at=row["last_owner_at"] or "",
+            unread_for_owner=row["unread_for_owner"] or 0,
+            created_at=datetime.fromisoformat(row["created_at"]),
+            updated_at=datetime.fromisoformat(row["updated_at"]),
         )
 
     def _row_to_decision(self, row: Any) -> DecisionStatus:

--- a/tests/cloud/test_paw_bar_conversations.py
+++ b/tests/cloud/test_paw_bar_conversations.py
@@ -576,6 +576,28 @@ async def test_patch_note_appends_and_is_attributed_to_the_caller(client):
 
 
 @pytest.mark.asyncio
+async def test_patch_echo_names_the_visitor_the_same_way_the_list_does(client):
+    """A client re-rendering a row from the PATCH echo must not watch a named
+    visitor turn back into an anonymous handle."""
+    c, store = client
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    await _mk_run()
+    await store.upsert_conversation_on_visitor_turn(widget.id, _REF, "ws-1")
+    await _mk_decision(store, widget.id, contact_email="ada@brewco.com")
+
+    listed = (await c.get(f"/paw-bar/admin/site/{site.id}/conversations")).json()["items"][0]
+    patched = (
+        await c.patch(
+            f"/paw-bar/admin/site/{site.id}/conversations/{_REF}", json={"state": "closed"}
+        )
+    ).json()["conversation"]
+
+    assert patched["display_name"] == listed["display_name"] == "ada@brewco.com"
+    assert patched["contact_email"] == "ada@brewco.com"
+
+
+@pytest.mark.asyncio
 async def test_patch_only_touches_the_fields_sent(client):
     c, store = client
     site = await _site()

--- a/tests/cloud/test_paw_bar_conversations.py
+++ b/tests/cloud/test_paw_bar_conversations.py
@@ -31,6 +31,7 @@ from typing import Any
 import aiosqlite
 import pytest
 import pytest_asyncio
+from beanie import PydanticObjectId
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
@@ -123,7 +124,15 @@ async def _mk_decision(store: PawBarStore, widget_id: str, **ov: Any) -> Decisio
     return await store.create_decision(DecisionStatus(widget_id=widget_id, **d))
 
 
-def _fake_user(role: str, workspace_id: str = "ws-1", user_id: str = "u1") -> SimpleNamespace:
+# The authenticated caller's id is a PydanticObjectId, NOT a str. A stand-in that
+# used a friendly "u1" is exactly why a note built from the real caller reached
+# production shape only on the rig, where it 500'd on pydantic string_type. Every
+# endpoint test in this file now runs against the real-shaped principal, so the
+# whole class of "works with a str id" bug is caught here rather than live.
+_USER_ID = PydanticObjectId()
+
+
+def _fake_user(role: str, workspace_id: str = "ws-1", user_id: Any = _USER_ID) -> SimpleNamespace:
     return SimpleNamespace(
         id=user_id,
         active_workspace=workspace_id,
@@ -571,7 +580,8 @@ async def test_patch_note_appends_and_is_attributed_to_the_caller(client):
     ]
 
     assert [n["text"] for n in row["notes"]] == ["called them back", "left a voicemail"]
-    assert {n["author"] for n in row["notes"]} == {"u1"}
+    # Attributed to the REAL caller id, stringified — never the raw ObjectId.
+    assert {n["author"] for n in row["notes"]} == {str(_USER_ID)}
     assert row["state"] == "closed"
 
 

--- a/tests/cloud/test_paw_bar_conversations.py
+++ b/tests/cloud/test_paw_bar_conversations.py
@@ -927,3 +927,40 @@ async def test_upsert_failure_never_breaks_the_visitor_chat(client, monkeypatch)
     assert res.status_code == 200, res.text
     assert "event: chunk" in res.text
     assert "event: stream_end" in res.text
+
+
+class TestNoteAuthorCoercion:
+    """A note filed by a REAL authenticated owner (rig, 2026-07-30).
+
+    ``current_user`` hands back a ``PydanticObjectId``, not a str. Notes built
+    from it failed ConversationNote's string_type validation and the PATCH 500'd
+    — invisible to every unit test that hand-builds a note with a plain string.
+    """
+
+    def test_store_coerces_an_objectid_author(self) -> None:
+        from beanie import PydanticObjectId
+
+        from pocketpaw.paw_bar.store import _as_note
+
+        oid = PydanticObjectId()
+        note = _as_note({"author": oid, "text": "rang them back"})
+
+        assert note.author == str(oid)
+        assert isinstance(note.author, str)
+        assert note.text == "rang them back"
+        assert note.at, "a note must always be ordered in the thread"
+
+    def test_router_stringifies_the_caller_id(self) -> None:
+        from beanie import PydanticObjectId
+        from pocketpaw_ee.paw_bar.router import (
+            ConversationPatchRequest,
+            _validated_conversation_fields,
+        )
+
+        author = str(PydanticObjectId())
+        fields = _validated_conversation_fields(
+            ConversationPatchRequest(note="called them"), author
+        )
+
+        assert fields["note"]["author"] == author
+        assert isinstance(fields["note"]["author"], str)

--- a/tests/cloud/test_paw_bar_conversations.py
+++ b/tests/cloud/test_paw_bar_conversations.py
@@ -1,0 +1,907 @@
+# tests/cloud/test_paw_bar_conversations.py — the owner inbox's conversation
+# STATE row (slice 1). Created 2026-07-30: covers the paw_bar_conversations table,
+# the lazy upsert on a visitor turn, and the three owner endpoints that turn the
+# concierge log into a queue. Layers:
+#   * Migration: a LEGACY paw_bar.db (pre-conversations, and one carrying a
+#     stripped-down conversations table) gains the table / the missing columns via
+#     the additive _migrate_columns ALTER path — the same trap that bit widgets
+#     and decisions.
+#   * Upsert: creates on first visitor turn, touches (unread++) after, AUTO-REOPENS
+#     a closed / snoozed row, and leaves needs_human alone.
+#   * Snooze: an expired snooze reads as open everywhere (row, list filter, counts)
+#     with no sweeper; a future one stays snoozed; an open-ended one never expires.
+#   * Owner reads: the ?state= filter, the unfiltered counts, and a LEGACY
+#     conversation with no row still listing with safe defaults.
+#   * PATCH: each field, the note APPEND (never replace), 422 on a bad state /
+#     snooze / tag flood, 404 on a ref with no conversation, and lazy row creation
+#     on a legacy conversation's first owner action.
+#   * Agent-scoped union: two widgets of ONE agent union into one list carrying
+#     site_id/site_name, another agent's widget is excluded, an unbound agent gets
+#     a 200 with widget_count=0, and a cross-workspace agent id 404s.
+#   * Tenancy: every new read and write refuses a cross-workspace caller.
+#   * Failure-soft: a store error in the upsert never breaks the visitor's chat.
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from typing import Any
+
+import aiosqlite
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from pocketpaw.paw_bar.models import (
+    ConversationState,
+    DecisionState,
+    DecisionStatus,
+    PawBarBlock,
+    PawBarSpec,
+    PawBarWidget,
+)
+from pocketpaw.paw_bar.store import PawBarStore
+
+_KEY = "site_key_" + "a" * 24
+_REF = "cust-0001"
+
+
+# --------------------------------------------------------------------------- #
+# Builders
+# --------------------------------------------------------------------------- #
+
+
+async def _site(**ov: Any):
+    from pocketpaw_ee.cloud.models.site import Site
+
+    d = dict(
+        workspace="ws-1",
+        pocket_id="pocket-1",
+        owner="user:maya",
+        name="Brew & Co",
+        script_name="",
+        signed_key=_KEY,
+        allowed_origins=["brewco.com"],
+    )
+    d.update(ov)
+    s = Site(**d)
+    await s.insert()
+    return s
+
+
+def _widget(**ov: Any) -> PawBarWidget:
+    d = dict(
+        pocket_id="pocket-1",
+        owner="user:maya",
+        name="Brew & Co",
+        spec=PawBarSpec(
+            widget_id="pp_seed",
+            pocket_id=str(ov.get("pocket_id", "pocket-1")),
+            blocks=[PawBarBlock(type="text", content="Hi")],
+        ),
+        allowed_domains=["brewco.com"],
+        agent_id="agent-xyz",
+        workspace_id="ws-1",
+    )
+    d.update(ov)
+    return PawBarWidget(**d)
+
+
+async def _mk_run(**ov: Any):
+    from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
+
+    d = dict(
+        run_id=uuid.uuid4().hex,
+        workspace="ws-1",
+        context_type="concierge",
+        scope_id="pocket-1",
+        session_key="cloud:concierge:pocket-1:cust-0001:agent-xyz",
+        user_id=_REF,
+        agent_id="agent-xyz",
+        client_message_id=uuid.uuid4().hex,
+        user_message_id="",
+        status="completed",
+        partial_text="We open at 8.",
+    )
+    d.update(ov)
+    doc = ChatRunDoc(**d)
+    await doc.insert()
+    return doc
+
+
+async def _mk_decision(store: PawBarStore, widget_id: str, **ov: Any) -> DecisionStatus:
+    d = dict(
+        customer_ref=_REF,
+        event_type="paw_bar_action:checkout",
+        instinct_action_id="act-" + uuid.uuid4().hex[:8],
+        workspace_id="user:maya",
+        state=DecisionState.PENDING,
+    )
+    d.update(ov)
+    return await store.create_decision(DecisionStatus(widget_id=widget_id, **d))
+
+
+def _fake_user(role: str, workspace_id: str = "ws-1", user_id: str = "u1") -> SimpleNamespace:
+    return SimpleNamespace(
+        id=user_id,
+        active_workspace=workspace_id,
+        workspaces=[SimpleNamespace(workspace=workspace_id, role=role)],
+    )
+
+
+def _build_app(store, monkeypatch, *, role: str = "admin", workspace_id: str = "ws-1"):
+    from pocketpaw_ee.cloud._core.deps import current_workspace_id
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.cloud.auth import current_active_user
+    from pocketpaw_ee.paw_bar.router import router
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(router)
+    app.dependency_overrides[current_active_user] = lambda: _fake_user(role, workspace_id)
+    app.dependency_overrides[current_workspace_id] = lambda: workspace_id
+    monkeypatch.setattr("pocketpaw_ee.paw_bar.router._store", lambda: store)
+    return app
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+
+
+@pytest_asyncio.fixture
+async def store(tmp_path):
+    return PawBarStore(tmp_path / "conv.db")
+
+
+@pytest_asyncio.fixture
+async def client(mongo_db, store, monkeypatch):
+    """ADMIN client in ws-1, backed by the tmp paw_bar store + Beanie."""
+    app = _build_app(store, monkeypatch, role="admin")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        yield c, store
+
+
+def _future(minutes: int = 60) -> str:
+    return (datetime.now() + timedelta(minutes=minutes)).isoformat()
+
+
+def _past(minutes: int = 60) -> str:
+    return (datetime.now() - timedelta(minutes=minutes)).isoformat()
+
+
+# --------------------------------------------------------------------------- #
+# Layer 1 — schema migration on a legacy DB
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_conversations_table_is_created_on_a_legacy_db(tmp_path):
+    """A paw_bar.db from before this slice gains the table (and keeps the older
+    additive ALTERs working) on the next _ensure_schema."""
+    db_path = tmp_path / "legacy.db"
+    async with aiosqlite.connect(db_path) as db:
+        # A pre-W4a widgets table: no workspace_id, no agent_id.
+        await db.execute(
+            "CREATE TABLE paw_bar_widgets (id TEXT PRIMARY KEY, pocket_id TEXT NOT NULL,"
+            " owner TEXT NOT NULL, name TEXT DEFAULT '', spec TEXT NOT NULL,"
+            " allowed_domains TEXT DEFAULT '[]', access_token TEXT NOT NULL,"
+            " rate_limit_per_min INTEGER DEFAULT 60, per_customer_limit_per_min INTEGER DEFAULT 10,"
+            " event_mapping TEXT DEFAULT '{}', created_at TEXT, updated_at TEXT)"
+        )
+        await db.commit()
+
+    st = PawBarStore(db_path)
+    conversation = await st.upsert_conversation_on_visitor_turn("w-legacy", _REF, "ws-1")
+    assert conversation.state is ConversationState.OPEN
+
+    async with aiosqlite.connect(db_path) as db:
+        async with db.execute("PRAGMA table_info(paw_bar_conversations)") as cur:
+            cols = {row[1] for row in await cur.fetchall()}
+        async with db.execute("PRAGMA table_info(paw_bar_widgets)") as cur:
+            widget_cols = {row[1] for row in await cur.fetchall()}
+    assert {"state", "bot_paused", "unread_for_owner", "snooze_until", "tags", "notes"} <= cols
+    # The pre-existing ALTER path still ran alongside the new table.
+    assert {"workspace_id", "agent_id"} <= widget_cols
+
+
+@pytest.mark.asyncio
+async def test_conversations_columns_are_added_to_a_stale_table(tmp_path):
+    """A DEPLOYED conversations table missing later columns is ALTERed additively —
+    otherwise the SCHEMA_SQL index over (widget_id, state, updated_at) would fail
+    with 'no such column', exactly as it did for widgets and decisions."""
+    db_path = tmp_path / "stale.db"
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute(
+            "CREATE TABLE paw_bar_conversations (id TEXT PRIMARY KEY, widget_id TEXT NOT NULL,"
+            " customer_ref TEXT NOT NULL, UNIQUE (widget_id, customer_ref))"
+        )
+        await db.commit()
+
+    st = PawBarStore(db_path)
+    conversation = await st.upsert_conversation_on_visitor_turn("w-stale", _REF, "ws-1")
+    assert conversation.unread_for_owner == 1
+
+    async with aiosqlite.connect(db_path) as db:
+        async with db.execute("PRAGMA table_info(paw_bar_conversations)") as cur:
+            cols = {row[1] for row in await cur.fetchall()}
+    assert {
+        "workspace_id",
+        "state",
+        "bot_paused",
+        "snooze_until",
+        "assignee",
+        "tags",
+        "notes",
+        "contact_email",
+        "last_visitor_at",
+        "last_owner_at",
+        "unread_for_owner",
+        "created_at",
+        "updated_at",
+    } <= cols
+
+
+# --------------------------------------------------------------------------- #
+# Layer 2 — the lazy upsert on a visitor turn
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_upsert_creates_then_touches(store):
+    first = await store.upsert_conversation_on_visitor_turn("w1", _REF, "ws-1")
+    assert first.state is ConversationState.OPEN
+    assert first.unread_for_owner == 1
+    assert first.last_visitor_at
+
+    second = await store.upsert_conversation_on_visitor_turn("w1", _REF, "ws-1")
+    assert second.id == first.id, "the same conversation, not a second row"
+    assert second.unread_for_owner == 2
+    assert second.last_visitor_at >= first.last_visitor_at
+
+
+@pytest.mark.parametrize("filed", ["closed", "snoozed"])
+@pytest.mark.asyncio
+async def test_upsert_auto_reopens_a_filed_conversation(store, filed):
+    """The universal inbox behaviour: a visitor who comes back re-opens the thread.
+    Its absence reads as a lost customer."""
+    await store.upsert_conversation_on_visitor_turn("w1", _REF, "ws-1")
+    await store.update_conversation(
+        "w1", _REF, workspace_id="ws-1", state=filed, snooze_until=_future()
+    )
+
+    reopened = await store.upsert_conversation_on_visitor_turn("w1", _REF, "ws-1")
+    assert reopened.state is ConversationState.OPEN
+    # A reopened snooze forgets its deadline — it is live again, not merely due.
+    assert reopened.snooze_until == ""
+
+
+@pytest.mark.asyncio
+async def test_upsert_leaves_needs_human_alone(store):
+    """needs_human is already the top of the queue — 'reopening' it is a demotion."""
+    await store.upsert_conversation_on_visitor_turn("w1", _REF, "ws-1")
+    await store.update_conversation("w1", _REF, workspace_id="ws-1", state="needs_human")
+
+    after = await store.upsert_conversation_on_visitor_turn("w1", _REF, "ws-1")
+    assert after.state is ConversationState.NEEDS_HUMAN
+    assert after.unread_for_owner == 2, "the unread counter still advances"
+
+
+@pytest.mark.asyncio
+async def test_upsert_keeps_visitors_separate(store):
+    await store.upsert_conversation_on_visitor_turn("w1", "cust-a", "ws-1")
+    await store.upsert_conversation_on_visitor_turn("w1", "cust-b", "ws-1")
+    await store.upsert_conversation_on_visitor_turn("w1", "cust-b", "ws-1")
+
+    a = await store.get_conversation("w1", "cust-a", "ws-1")
+    b = await store.get_conversation("w1", "cust-b", "ws-1")
+    assert (a.unread_for_owner, b.unread_for_owner) == (1, 2)
+
+
+# --------------------------------------------------------------------------- #
+# Layer 3 — snooze expiry is computed on READ (no sweeper)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_expired_snooze_reads_as_open_everywhere(store):
+    await store.upsert_conversation_on_visitor_turn("w1", _REF, "ws-1")
+    await store.update_conversation(
+        "w1", _REF, workspace_id="ws-1", state="snoozed", snooze_until=_past()
+    )
+
+    row = await store.get_conversation("w1", _REF, "ws-1")
+    assert row.state is ConversationState.OPEN
+    assert row.snooze_until, "the lapsed deadline is kept, so the UI can explain it"
+    assert await store.conversation_counts("w1", "ws-1") == {
+        "open": 1,
+        "needs_human": 0,
+        "snoozed": 0,
+        "closed": 0,
+    }
+    assert [c.customer_ref for c in await store.list_conversations("w1", "ws-1", state="open")] == [
+        _REF
+    ]
+    assert await store.list_conversations("w1", "ws-1", state="snoozed") == []
+
+
+@pytest.mark.asyncio
+async def test_future_snooze_stays_snoozed(store):
+    await store.upsert_conversation_on_visitor_turn("w1", _REF, "ws-1")
+    await store.update_conversation(
+        "w1", _REF, workspace_id="ws-1", state="snoozed", snooze_until=_future()
+    )
+
+    assert (await store.get_conversation("w1", _REF, "ws-1")).state is ConversationState.SNOOZED
+    assert (await store.conversation_counts("w1", "ws-1"))["snoozed"] == 1
+
+
+@pytest.mark.asyncio
+async def test_open_ended_snooze_never_expires(store):
+    """No deadline means 'until I say so' — an empty snooze_until must not read as
+    an already-lapsed one."""
+    await store.upsert_conversation_on_visitor_turn("w1", _REF, "ws-1")
+    await store.update_conversation("w1", _REF, workspace_id="ws-1", state="snoozed")
+
+    assert (await store.get_conversation("w1", _REF, "ws-1")).state is ConversationState.SNOOZED
+
+
+# --------------------------------------------------------------------------- #
+# Layer 4 — store-level tenancy
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_store_reads_and_writes_refuse_another_workspace(store):
+    await store.upsert_conversation_on_visitor_turn("w1", _REF, "ws-1")
+
+    assert await store.get_conversation("w1", _REF, "ws-other") is None
+    assert await store.list_conversations("w1", "ws-other") == []
+    assert await store.conversation_counts("w1", "ws-other") == {
+        "open": 0,
+        "needs_human": 0,
+        "snoozed": 0,
+        "closed": 0,
+    }
+    assert (
+        await store.update_conversation("w1", _REF, workspace_id="ws-other", state="closed") is None
+    )
+    # The real owner's row is untouched by the refused write.
+    assert (await store.get_conversation("w1", _REF, "ws-1")).state is ConversationState.OPEN
+
+
+@pytest.mark.asyncio
+async def test_update_appends_notes_and_replaces_tags(store):
+    await store.upsert_conversation_on_visitor_turn("w1", _REF, "ws-1")
+    await store.update_conversation(
+        "w1", _REF, workspace_id="ws-1", note={"author": "u1", "text": "first"}, tags=["vip"]
+    )
+    row = await store.update_conversation(
+        "w1", _REF, workspace_id="ws-1", note={"author": "u1", "text": "second"}, tags=["lead"]
+    )
+
+    assert [n.text for n in row.notes] == ["first", "second"]
+    assert row.tags == ["lead"]
+    assert all(n.at for n in row.notes), "every note is timestamped for the thread order"
+
+
+@pytest.mark.asyncio
+async def test_update_ignores_unknown_fields(store):
+    """An unknown key is dropped, never interpolated into the UPDATE."""
+    await store.upsert_conversation_on_visitor_turn("w1", _REF, "ws-1")
+    before = await store.get_conversation("w1", _REF, "ws-1")
+    row = await store.update_conversation(
+        "w1", _REF, workspace_id="ws-1", id="hijacked", created_at="1999-01-01", nonsense=1
+    )
+    assert (row.id, row.customer_ref, row.widget_id) == (before.id, _REF, "w1")
+    assert row.created_at == before.created_at
+
+
+@pytest.mark.asyncio
+async def test_ensure_conversation_does_not_count_as_visitor_activity(store):
+    """The owner opening a legacy conversation mints its row WITHOUT faking an
+    unread message or a visitor timestamp."""
+    row = await store.ensure_conversation("w1", _REF, "ws-1")
+    assert (row.unread_for_owner, row.last_visitor_at) == (0, "")
+    assert (await store.ensure_conversation("w1", _REF, "ws-1")).id == row.id
+
+
+# --------------------------------------------------------------------------- #
+# Layer 5 — the owner list read (join, filter, counts, legacy defaults)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_list_joins_the_state_row(client):
+    c, store = client
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    await _mk_run()
+    await store.upsert_conversation_on_visitor_turn(widget.id, _REF, "ws-1")
+    await store.update_conversation(
+        widget.id, _REF, workspace_id="ws-1", state="needs_human", tags=["vip"], bot_paused=True
+    )
+    await _mk_decision(store, widget.id, state=DecisionState.PENDING)
+
+    body = (await c.get(f"/paw-bar/admin/site/{site.id}/conversations")).json()
+    assert len(body["items"]) == 1
+    item = body["items"][0]
+    assert item["customer_ref"] == _REF
+    assert item["preview"] == "We open at 8."
+    assert item["state"] == "needs_human"
+    assert item["bot_paused"] is True
+    assert item["unread_for_owner"] == 1
+    assert item["tags"] == ["vip"]
+    assert item["has_pending_action"] is True
+    assert item["display_name"] == f"visitor-{_REF[:6]}"
+    assert body["counts"] == {"open": 0, "needs_human": 1, "snoozed": 0, "closed": 0}
+
+
+@pytest.mark.asyncio
+async def test_list_renders_a_legacy_conversation_with_defaults(client):
+    """The backfill-free contract: a conversation from before the table still
+    lists, reading as a plain open conversation with nothing pending."""
+    c, store = client
+    site = await _site()
+    await store.create_widget(_widget())
+    await _mk_run()
+
+    body = (await c.get(f"/paw-bar/admin/site/{site.id}/conversations")).json()
+    item = body["items"][0]
+    assert (item["state"], item["bot_paused"], item["unread_for_owner"]) == ("open", False, 0)
+    assert (item["tags"], item["snooze_until"], item["contact_email"]) == ([], "", "")
+    assert item["has_pending_action"] is False
+    # Counts report only rows that EXIST — a legacy conversation is never invented
+    # into a total, so the chips can sum to less than the listed rows.
+    assert body["counts"] == {"open": 0, "needs_human": 0, "snoozed": 0, "closed": 0}
+
+
+@pytest.mark.asyncio
+async def test_list_state_filter(client):
+    c, store = client
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    await _mk_run(user_id="cust-open")
+    await _mk_run(user_id="cust-closed")
+    await store.upsert_conversation_on_visitor_turn(widget.id, "cust-open", "ws-1")
+    await store.upsert_conversation_on_visitor_turn(widget.id, "cust-closed", "ws-1")
+    await store.update_conversation(widget.id, "cust-closed", workspace_id="ws-1", state="closed")
+
+    listed = (await c.get(f"/paw-bar/admin/site/{site.id}/conversations?state=closed")).json()
+    assert [i["customer_ref"] for i in listed["items"]] == ["cust-closed"]
+    # The chips stay UNFILTERED while a filter is applied.
+    assert listed["counts"] == {"open": 1, "needs_human": 0, "snoozed": 0, "closed": 1}
+
+    opened = (await c.get(f"/paw-bar/admin/site/{site.id}/conversations?state=open")).json()
+    assert [i["customer_ref"] for i in opened["items"]] == ["cust-open"]
+
+    bad = await c.get(f"/paw-bar/admin/site/{site.id}/conversations?state=banana")
+    assert bad.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_list_shows_the_captured_email_as_the_display_name(client):
+    """A visitor who left an email during a decision capture is named by it — the
+    email is READ from the decision row, never copied onto the conversation."""
+    c, store = client
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    await _mk_run()
+    await _mk_decision(store, widget.id, contact_email="ada@brewco.com")
+
+    item = (await c.get(f"/paw-bar/admin/site/{site.id}/conversations")).json()["items"][0]
+    assert item["contact_email"] == "ada@brewco.com"
+    assert item["display_name"] == "ada@brewco.com"
+
+
+@pytest.mark.asyncio
+async def test_list_is_cross_workspace_refused(client):
+    c, store = client
+    site = await _site(workspace="ws-other")
+    await store.create_widget(_widget(workspace_id="ws-other"))
+    res = await c.get(f"/paw-bar/admin/site/{site.id}/conversations")
+    assert res.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_list_state_rows_do_not_cross_sites(client):
+    """A sibling site's conversation row never joins onto this site's list."""
+    c, store = client
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    other = await store.create_widget(_widget(pocket_id="pocket-2"))
+    await _mk_run()
+    await store.upsert_conversation_on_visitor_turn(other.id, _REF, "ws-1")
+    await store.update_conversation(other.id, _REF, workspace_id="ws-1", state="closed")
+
+    item = (await c.get(f"/paw-bar/admin/site/{site.id}/conversations")).json()["items"][0]
+    assert item["state"] == "open", "the sibling widget's closed row must not leak"
+    assert widget.id != other.id
+
+
+# --------------------------------------------------------------------------- #
+# Layer 6 — the PATCH
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_patch_each_field(client):
+    c, store = client
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    await _mk_run()
+    await store.upsert_conversation_on_visitor_turn(widget.id, _REF, "ws-1")
+
+    url = f"/paw-bar/admin/site/{site.id}/conversations/{_REF}"
+    snooze = _future()
+    res = await c.patch(
+        url,
+        json={
+            "state": "snoozed",
+            "snooze_until": snooze,
+            "tags": ["vip", "billing"],
+            "bot_paused": True,
+        },
+    )
+    assert res.status_code == 200, res.text
+    row = res.json()["conversation"]
+    assert res.json()["ok"] is True
+    assert row["state"] == "snoozed"
+    assert row["snooze_until"] == snooze
+    assert row["tags"] == ["vip", "billing"]
+    assert row["bot_paused"] is True
+    assert row["customer_ref"] == _REF and row["widget_id"] == widget.id
+    assert row["unread_for_owner"] == 1, "filing a conversation is not reading it"
+
+
+@pytest.mark.asyncio
+async def test_patch_note_appends_and_is_attributed_to_the_caller(client):
+    c, store = client
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    await _mk_run()
+    await store.upsert_conversation_on_visitor_turn(widget.id, _REF, "ws-1")
+
+    url = f"/paw-bar/admin/site/{site.id}/conversations/{_REF}"
+    await c.patch(url, json={"note": "called them back"})
+    row = (await c.patch(url, json={"note": "left a voicemail", "state": "closed"})).json()[
+        "conversation"
+    ]
+
+    assert [n["text"] for n in row["notes"]] == ["called them back", "left a voicemail"]
+    assert {n["author"] for n in row["notes"]} == {"u1"}
+    assert row["state"] == "closed"
+
+
+@pytest.mark.asyncio
+async def test_patch_only_touches_the_fields_sent(client):
+    c, store = client
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    await _mk_run()
+    await store.upsert_conversation_on_visitor_turn(widget.id, _REF, "ws-1")
+
+    url = f"/paw-bar/admin/site/{site.id}/conversations/{_REF}"
+    await c.patch(url, json={"tags": ["vip"], "state": "needs_human"})
+    row = (await c.patch(url, json={"bot_paused": True})).json()["conversation"]
+
+    assert row["tags"] == ["vip"]
+    assert row["state"] == "needs_human"
+
+
+@pytest.mark.asyncio
+async def test_patch_rejects_bad_values(client):
+    c, store = client
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    await _mk_run()
+    await store.upsert_conversation_on_visitor_turn(widget.id, _REF, "ws-1")
+
+    url = f"/paw-bar/admin/site/{site.id}/conversations/{_REF}"
+    assert (await c.patch(url, json={"state": "escalated"})).status_code == 422
+    assert (await c.patch(url, json={"snooze_until": "tomorrow-ish"})).status_code == 422
+    assert (await c.patch(url, json={"tags": [f"t{i}" for i in range(40)]})).status_code == 422
+    # Nothing was written by any of the refusals.
+    assert (await store.get_conversation(widget.id, _REF, "ws-1")).state is ConversationState.OPEN
+
+
+@pytest.mark.asyncio
+async def test_patch_mints_a_row_for_a_legacy_conversation(client):
+    """A conversation that predates the table is filed on the owner's first action
+    — the row is created lazily rather than 404ing."""
+    c, store = client
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    await _mk_run()
+    assert await store.get_conversation(widget.id, _REF, "ws-1") is None
+
+    res = await c.patch(
+        f"/paw-bar/admin/site/{site.id}/conversations/{_REF}", json={"state": "closed"}
+    )
+    assert res.status_code == 200, res.text
+    assert res.json()["conversation"]["state"] == "closed"
+    stored = await store.get_conversation(widget.id, _REF, "ws-1")
+    assert stored.state is ConversationState.CLOSED
+    assert stored.unread_for_owner == 0
+
+
+@pytest.mark.asyncio
+async def test_patch_404s_on_a_ref_with_no_conversation(client):
+    c, store = client
+    site = await _site()
+    await store.create_widget(_widget())
+    res = await c.patch(
+        f"/paw-bar/admin/site/{site.id}/conversations/cust-nobody", json={"state": "closed"}
+    )
+    assert res.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_patch_rejects_a_malformed_customer_ref(client):
+    c, store = client
+    site = await _site()
+    await store.create_widget(_widget())
+    res = await c.patch(
+        f"/paw-bar/admin/site/{site.id}/conversations/bad ref!", json={"state": "closed"}
+    )
+    assert res.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_patch_is_cross_workspace_refused(mongo_db, store, monkeypatch):
+    """A ws-2 admin cannot file a ws-1 conversation — the site 404s first."""
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    await _mk_run()
+    await store.upsert_conversation_on_visitor_turn(widget.id, _REF, "ws-1")
+
+    app = _build_app(store, monkeypatch, role="admin", workspace_id="ws-2")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        res = await c.patch(
+            f"/paw-bar/admin/site/{site.id}/conversations/{_REF}", json={"state": "closed"}
+        )
+    assert res.status_code == 404
+    assert (await store.get_conversation(widget.id, _REF, "ws-1")).state is ConversationState.OPEN
+
+
+@pytest.mark.asyncio
+async def test_patch_requires_an_admin_role(mongo_db, store, monkeypatch):
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    await _mk_run()
+    await store.upsert_conversation_on_visitor_turn(widget.id, _REF, "ws-1")
+
+    app = _build_app(store, monkeypatch, role="member")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        res = await c.patch(
+            f"/paw-bar/admin/site/{site.id}/conversations/{_REF}", json={"state": "closed"}
+        )
+    assert res.status_code == 403
+
+
+# --------------------------------------------------------------------------- #
+# Layer 7 — the agent-scoped union
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_agent_conversations_union_two_sites(client, monkeypatch):
+    """One agent, two sites → one list, each item naming the site it came from."""
+    c, store = client
+    site_a = await _site(name="Brew & Co")
+    site_b = await _site(pocket_id="pocket-2", name="Roast House", signed_key=_KEY + "b")
+    widget_a = await store.create_widget(_widget())
+    widget_b = await store.create_widget(_widget(pocket_id="pocket-2"))
+    # A DIFFERENT agent's widget on a third site must never appear.
+    await _site(pocket_id="pocket-3", name="Someone Else", signed_key=_KEY + "c")
+    other = await store.create_widget(_widget(pocket_id="pocket-3", agent_id="agent-other"))
+
+    await _mk_run(user_id="cust-a", scope_id="pocket-1")
+    await _mk_run(user_id="cust-b", scope_id="pocket-2")
+    await _mk_run(user_id="cust-other", scope_id="pocket-3")
+    await store.upsert_conversation_on_visitor_turn(widget_a.id, "cust-a", "ws-1")
+    await store.upsert_conversation_on_visitor_turn(widget_b.id, "cust-b", "ws-1")
+    await store.upsert_conversation_on_visitor_turn(other.id, "cust-other", "ws-1")
+
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.agents.service.get_workspace",
+        _fake_get_workspace({"agent-xyz": "ws-1", "agent-other": "ws-1"}),
+    )
+    body = (await c.get("/paw-bar/admin/agent/agent-xyz/conversations")).json()
+
+    refs = {i["customer_ref"] for i in body["items"]}
+    assert refs == {"cust-a", "cust-b"}, "another agent's widget is excluded"
+    by_ref = {i["customer_ref"]: i for i in body["items"]}
+    assert by_ref["cust-a"]["site_id"] == str(site_a.id)
+    assert by_ref["cust-a"]["site_name"] == "Brew & Co"
+    assert by_ref["cust-b"]["site_id"] == str(site_b.id)
+    assert by_ref["cust-b"]["site_name"] == "Roast House"
+    assert body["widget_count"] == 2
+    assert {s["site_name"] for s in body["sites"]} == {"Brew & Co", "Roast House"}
+    assert body["counts"]["open"] == 2, "counts sum across the union"
+
+
+def _fake_get_workspace(mapping: dict[str, str]):
+    async def _get_workspace(agent_id: str) -> str | None:
+        return mapping.get(agent_id)
+
+    return _get_workspace
+
+
+@pytest.mark.asyncio
+async def test_agent_conversations_state_filter(client, monkeypatch):
+    c, store = client
+    await _site()
+    widget = await store.create_widget(_widget())
+    await _mk_run(user_id="cust-a")
+    await _mk_run(user_id="cust-b")
+    await store.upsert_conversation_on_visitor_turn(widget.id, "cust-a", "ws-1")
+    await store.upsert_conversation_on_visitor_turn(widget.id, "cust-b", "ws-1")
+    await store.update_conversation(widget.id, "cust-b", workspace_id="ws-1", state="needs_human")
+
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.agents.service.get_workspace",
+        _fake_get_workspace({"agent-xyz": "ws-1"}),
+    )
+    body = (await c.get("/paw-bar/admin/agent/agent-xyz/conversations?state=needs_human")).json()
+    assert [i["customer_ref"] for i in body["items"]] == ["cust-b"]
+    assert body["counts"] == {"open": 1, "needs_human": 1, "snoozed": 0, "closed": 0}
+
+    assert (
+        await c.get("/paw-bar/admin/agent/agent-xyz/conversations?state=nope")
+    ).status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_agent_with_no_widget_is_a_200_with_a_zero_binding_signal(client, monkeypatch):
+    """An ordinary agent is not an error — it answers 200 with widget_count=0 so a
+    client can hide the Conversations tab instead of guessing from emptiness."""
+    c, _store = client
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.agents.service.get_workspace",
+        _fake_get_workspace({"agent-plain": "ws-1"}),
+    )
+    res = await c.get("/paw-bar/admin/agent/agent-plain/conversations")
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body == {"items": [], "counts": {}, "sites": [], "widget_count": 0}
+
+
+@pytest.mark.asyncio
+async def test_agent_conversations_refuse_another_workspace(client, monkeypatch):
+    """A ws-2 agent 404s for the ws-1 admin — never leaks that it exists."""
+    c, store = client
+    await _site(workspace="ws-2", pocket_id="pocket-9")
+    widget = await store.create_widget(
+        _widget(pocket_id="pocket-9", workspace_id="ws-2", agent_id="agent-ws2")
+    )
+    await _mk_run(workspace="ws-2", scope_id="pocket-9", user_id="cust-ws2")
+    await store.upsert_conversation_on_visitor_turn(widget.id, "cust-ws2", "ws-2")
+
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.agents.service.get_workspace",
+        _fake_get_workspace({"agent-ws2": "ws-2"}),
+    )
+    assert (await c.get("/paw-bar/admin/agent/agent-ws2/conversations")).status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_agent_conversations_require_an_admin_role(mongo_db, store, monkeypatch):
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.agents.service.get_workspace",
+        _fake_get_workspace({"agent-xyz": "ws-1"}),
+    )
+    app = _build_app(store, monkeypatch, role="member")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        res = await c.get("/paw-bar/admin/agent/agent-xyz/conversations")
+    assert res.status_code == 403
+
+
+# --------------------------------------------------------------------------- #
+# Layer 8 — the upsert is failure-soft inside concierge_chat
+# --------------------------------------------------------------------------- #
+
+
+_ORIGIN = "https://brewco.com"
+
+
+class _FakeExecutor:
+    """Writes a canned reply to the transport so the SSE tail terminates without a
+    live agent run (borrowed from test_paw_bar_concierge_chat)."""
+
+    def __init__(self, transport) -> None:
+        self.transport = transport
+
+    async def submit(self, spec) -> None:
+        await self.transport.append_event(
+            spec.run_id, "chunk", {"content": "We open at 8am!", "type": "text"}
+        )
+        await self.transport.append_event(
+            spec.run_id, "stream_end", {"assistant_message_id": "m1", "cancelled": False}
+        )
+
+
+def _stub_the_run(monkeypatch) -> None:
+    from pocketpaw_ee.cloud.chat.runs.memory_stream import InMemoryStreamTransport
+
+    transport = InMemoryStreamTransport()
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.chat.runs.transport.get_stream_transport", lambda: transport
+    )
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.chat.runs.executor.get_executor", lambda: _FakeExecutor(transport)
+    )
+
+    async def _fake_create_run(spec):
+        return SimpleNamespace(run_id=spec.run_id)
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.chat.runs.service.create_run", _fake_create_run)
+
+
+async def _chat(c, widget_id: str, customer_ref: str = _REF):
+    return await c.post(
+        "/paw-bar/chat",
+        json={
+            "widget_id": widget_id,
+            "signed_key": _KEY,
+            "customer_ref": customer_ref,
+            "message": "What time do you open?",
+        },
+        headers={"Origin": _ORIGIN},
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_visitor_turn_creates_the_conversation_row(client, monkeypatch):
+    """The real call site: a live POST /paw-bar/chat mints the state row. This is
+    what makes the queue backfill-free — no migration, no separate producer."""
+    c, store = client
+    await _site()
+    widget = await store.create_widget(_widget())
+    _stub_the_run(monkeypatch)
+
+    assert (await _chat(c, widget.id)).status_code == 200
+    row = await store.get_conversation(widget.id, _REF, "ws-1")
+    assert row is not None
+    assert (row.state, row.unread_for_owner) == (ConversationState.OPEN, 1)
+    assert row.workspace_id == "ws-1", "stamped with the KEY's tenant, not the widget owner"
+
+    assert (await _chat(c, widget.id)).status_code == 200
+    assert (await store.get_conversation(widget.id, _REF, "ws-1")).unread_for_owner == 2
+
+
+@pytest.mark.asyncio
+async def test_a_visitor_turn_reopens_a_closed_conversation(client, monkeypatch):
+    """End-to-end auto-reopen: the owner closed it, the visitor came back."""
+    c, store = client
+    await _site()
+    widget = await store.create_widget(_widget())
+    _stub_the_run(monkeypatch)
+
+    await _chat(c, widget.id)
+    await store.update_conversation(widget.id, _REF, workspace_id="ws-1", state="closed")
+    await _chat(c, widget.id)
+
+    assert (await store.get_conversation(widget.id, _REF, "ws-1")).state is ConversationState.OPEN
+
+
+@pytest.mark.asyncio
+async def test_upsert_failure_never_breaks_the_visitor_chat(client, monkeypatch):
+    """Inbox bookkeeping is the owner's convenience. If the state write throws, the
+    visitor still gets their answer — the queue is at worst one message stale."""
+    c, store = client
+    await _site()
+    widget = await store.create_widget(_widget())
+    _stub_the_run(monkeypatch)
+
+    async def _boom(*_a, **_kw):
+        raise RuntimeError("disk full")
+
+    monkeypatch.setattr(store, "upsert_conversation_on_visitor_turn", _boom)
+
+    res = await _chat(c, widget.id)
+    assert res.status_code == 200, res.text
+    assert "event: chunk" in res.text
+    assert "event: stream_end" in res.text

--- a/tests/cloud/test_paw_bar_conversations.py
+++ b/tests/cloud/test_paw_bar_conversations.py
@@ -762,6 +762,64 @@ def _fake_get_workspace(mapping: dict[str, str]):
     return _get_workspace
 
 
+async def _real_agent(name: str = "Brew & Co Concierge", workspace_id: str = "ws-1"):
+    """Create an agent through the REAL agents service and return it."""
+    from pocketpaw_ee.cloud.agents import service as agents_service
+    from pocketpaw_ee.cloud.agents.dto import CreateAgentRequest
+
+    ctx = agents_service.legacy_ctx("user:maya", workspace_id)
+    return await agents_service.create(
+        ctx,
+        workspace_id,
+        CreateAgentRequest(name=name, slug=f"concierge-{uuid.uuid4().hex[:8]}"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_agent_conversations_resolve_a_real_agent(client):
+    """No mocked resolver anywhere in this test.
+
+    Every other agent-endpoint test patches ``agents_service.get_workspace``, so
+    none of them prove the endpoint works against the real one — the same shape of
+    hole that let the note-author 500 through. It matters here because the real
+    resolver parses the id as an ObjectId first: the friendly ``agent-xyz`` handles
+    the other tests use resolve to None and 404, so a stubbed resolver is the only
+    reason those pass.
+    """
+    c, store = client
+    site = await _site()
+    agent = await _real_agent()
+    widget = await store.create_widget(_widget(agent_id=agent.id))
+    await _mk_run(user_id="cust-a")
+    await store.upsert_conversation_on_visitor_turn(widget.id, "cust-a", "ws-1")
+
+    res = await c.get(f"/paw-bar/admin/agent/{agent.id}/conversations")
+
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert [i["customer_ref"] for i in body["items"]] == ["cust-a"]
+    assert body["items"][0]["site_id"] == str(site.id)
+    assert body["items"][0]["site_name"] == "Brew & Co"
+    assert body["widget_count"] == 1
+    assert body["counts"]["open"] == 1
+
+
+@pytest.mark.asyncio
+async def test_a_real_agent_in_another_workspace_is_404(client):
+    """The tenancy gate proven against the real resolver, not a stub that was
+    handed the answer."""
+    c, store = client
+    await _site(workspace="ws-2", pocket_id="pocket-9")
+    agent = await _real_agent(name="Someone Else Concierge", workspace_id="ws-2")
+    widget = await store.create_widget(
+        _widget(pocket_id="pocket-9", workspace_id="ws-2", agent_id=agent.id)
+    )
+    await _mk_run(workspace="ws-2", scope_id="pocket-9", user_id="cust-ws2")
+    await store.upsert_conversation_on_visitor_turn(widget.id, "cust-ws2", "ws-2")
+
+    assert (await c.get(f"/paw-bar/admin/agent/{agent.id}/conversations")).status_code == 404
+
+
 @pytest.mark.asyncio
 async def test_agent_conversations_state_filter(client, monkeypatch):
     c, store = client


### PR DESCRIPTION
Slice 1 of the Paw Bar owner inbox. The concierge log becomes a queue.

Today the dashboard can show an owner every conversation their site's concierge has had, and nothing else. There is no way to say "I've dealt with this one", "hide this until tomorrow", or "this one needs me". That is the gap between a transcript viewer and a support inbox, and it is the first of the six slices in `docs/design/drafts/2026-07-30-paw-bar-inbox-unified-thread.md`.

## What's here

A thin state row per conversation, `paw_bar_conversations`, keyed on `(widget_id, customer_ref)` — the same identity the concierge run stream already uses. It holds lifecycle and operator metadata only: state, whether the bot is paused, a snooze deadline, tags, private notes, a contact address, an unread counter. **No messages.** The transcript stays derived from the run docs, so there is one record of what was said and a separate one of how the owner is handling it.

Endpoints, all additive — the existing shapes are frozen contracts the dashboard already consumes:

| | |
|---|---|
| `GET .../site/{id}/conversations` | every existing field unchanged; each item gains `state`, `bot_paused`, `unread_for_owner`, `tags`, `snooze_until`, `contact_email`, `display_name`, `has_pending_action`. Response gains `counts` and an optional `?state=` filter |
| `PATCH .../site/{id}/conversations/{customer_ref}` | `{state?, snooze_until?, tags?, note?, bot_paused?}` → `{ok, conversation}` |
| `GET .../agent/{id}/conversations` | the same question asked of the agent: its sites' conversations unioned, each naming where it came from |

## Three decisions worth reviewing

**Backfill-free, deliberately.** The row is minted on a visitor's next message, or on the owner's first action on an older conversation. Nothing was migrated. A conversation with no row still lists, reading as a plain open conversation — every new field carries a safe default. The one visible consequence: `counts` only counts rows that exist, so on an old site the chips can sum to less than the rows on screen. Inventing totals for conversations we have no state for seemed worse than that.

**A visitor's message re-opens their conversation.** Closed or snoozed, it comes back to `open` the moment they write again. Every product in this class does this, and its absence reads as a lost customer. `needs_human` is the exception — it's already the top of the queue, so re-opening it would be a demotion.

**Snooze expiry is computed on read.** One SQL expression that every filter, count and row detail goes through. No sweeper, no cron: nothing scheduled that can fail quietly at 3am and leave a customer waiting past their snooze.

## Notes for review

- The PATCH gates on `paw_bar.manage`. The design named `paw_bar.write`, which doesn't exist — `manage` is this router's existing mutation action (both ADMIN). Say the word if you'd rather add a third action.
- `has_pending_action` reads the decision rows the Decisions list already reads. No second query into Instinct, whose rows are keyed by the widget owner rather than the tenant.
- A captured contact email is read from the decision row where it was left, never copied onto the conversation row — the PII invariant on that field says it lives in one place, and this owner-authed list is exactly who it was left for.
- The visitor-turn write is failure-soft. A store hiccup logs and the chat streams normally; the queue is at worst one message stale.
- Tenancy is checked at every new read and write: the site (or the agent) resolves workspace-scoped first, then its widget, then the rows. A cross-workspace caller gets a 404 that leaks nothing, including on the agent endpoint.

## Verification

- `tests/cloud/test_paw_bar_conversations.py` — 37 new tests: the additive-ALTER migration path on a legacy DB, upsert create/touch/auto-reopen (and the `needs_human` exception), snooze expiry across the row, filter and counts, the PATCH per field plus note-append and the 422s, the agent union across two widgets of one agent excluding a third agent's, cross-workspace refusal on every new read and write, legacy rows listing with defaults, and the failure-soft upsert driven through a real `POST /paw-bar/chat`.
- Full paw-bar set green: 361 passed (324 before, 37 new).
- `ruff check` and `ruff format --check` clean; both import-linter configs pass.
- `docs/concepts/concierge-knowledge.mdx` gains a "conversation queue" section.

Slice 2 (owner reply, the `bot_paused` gate, the visitor poll) stacks on this branch.
