### PR TITLE
A brand-new site shipped without its concierge

### DIFF
--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -2021,6 +2021,10 @@ async def _deploy_site_doc(
         signed_key=signed_key,
         project_dir=build.project_dir,
         engine=engine,
+        # A FIRST publish has no Site doc yet — it is inserted further down — so
+        # pass the two fields provisioning needs to stand one up in memory.
+        user_id=user_id,
+        site_name=site_name,
     )
 
     # DS-2: a DYNAMIC site (pattern == "dynamic", or a spec carrying live
@@ -2195,6 +2199,8 @@ async def _embed_concierge_bar(
     signed_key: str,
     project_dir: str,
     engine: str,
+    user_id: str = "",
+    site_name: str = "",
 ) -> None:
     """Write the concierge embed snippet into the built pages, before they deploy.
 
@@ -2229,10 +2235,31 @@ async def _embed_concierge_bar(
         # snippet check below would silently skip the bar. Mint the widget +
         # agent here so the first publish ships with its concierge. Idempotent
         # and failure-soft inside; requires the site doc (draft flows have one).
-        if concierge_enabled and doc is not None:
+        if concierge_enabled:
             from pocketpaw_ee.paw_bar.agent_provisioning import ensure_site_widget
 
-            await ensure_site_widget(doc, workspace_id)
+            # A FIRST publish reaches here BEFORE the Site doc is inserted, so
+            # ``doc`` is None and the old ``doc is not None`` guard skipped
+            # provisioning entirely: no widget, no dedicated agent, the
+            # four-gate snippet check returned "" and the page shipped bar-less
+            # — with no log line, because the empty snippet returns early. Only
+            # a SECOND publish (doc now present) grew a bar, which is exactly
+            # why this looked fixed. Stand up a transient doc for that first
+            # pass: ``ensure_site_widget``/``ensure_site_agent`` only read
+            # ``.workspace``/``.owner``/``.id``/``.name``/``.pocket_id`` off the
+            # object, never re-reading the DB, and the real insert below carries
+            # the same values.
+            provisioning_doc = doc
+            if provisioning_doc is None:
+                provisioning_doc = _SiteDoc(
+                    id=ObjectId(site_id),
+                    workspace=workspace_id,
+                    pocket_id=pocket_id,
+                    owner=user_id,
+                    name=site_name,
+                    signed_key=signed_key,
+                )
+            await ensure_site_widget(provisioning_doc, workspace_id)
 
         snippet = await embed.concierge_snippet(
             workspace_id=workspace_id,

--- a/tests/cloud/test_paw_bar_agent_provisioning.py
+++ b/tests/cloud/test_paw_bar_agent_provisioning.py
@@ -472,3 +472,74 @@ class TestIdentityAndFrameStarters:
         res = await c.get("/paw-bar/frame", params={"key": _VALID_KEY})
         assert res.status_code == 200
         assert "starters" in res.text
+
+
+class TestFirstPublishProvisioning:
+    """The FIRST publish must provision too (audit finding, 2026-07-30).
+
+    ``_embed_concierge_bar`` guarded provisioning on ``doc is not None``, but on
+    a first publish the Site doc is inserted AFTER the embed step — so ``doc``
+    was None, provisioning was skipped, the four-gate snippet check returned ""
+    and the page shipped bar-less with no log line at all. A re-publish (doc now
+    present) grew a bar, which is precisely why this read as working. These
+    tests pin the transient-doc path used when no Site doc exists yet.
+    """
+
+    @pytest.mark.asyncio
+    async def test_transient_doc_provisions_widget_and_agent(self, client) -> None:
+        from bson import ObjectId
+        from pocketpaw_ee.cloud.models.site import Site
+        from pocketpaw_ee.paw_bar import agent_provisioning as ap
+
+        _c, store = client
+        # No Site doc in the DB at all — the first-publish state.
+        site_id = ObjectId()
+        transient = Site(
+            id=site_id,
+            workspace=_WS,
+            pocket_id=_POCKET,
+            owner=_OWNER,
+            name="Northwind Plumbing",
+            signed_key=_VALID_KEY,
+        )
+
+        widget = await ap.ensure_site_widget(transient, _WS)
+
+        assert widget is not None, "a first publish must still mint the widget"
+        assert widget.agent_id, "and bind it to a dedicated agent"
+        assert widget.pocket_id == _POCKET
+        # The agent is named off the transient doc, not a DB re-read.
+        from pocketpaw_ee.cloud.agents import service as agents_service
+
+        agent = await agents_service.get(widget.agent_id)
+        assert agent.name == "Northwind Plumbing Concierge"
+        assert agent.slug == f"concierge-{site_id}"
+
+    @pytest.mark.asyncio
+    async def test_second_publish_adopts_the_first_publish_widget(self, client) -> None:
+        """Idempotent across the first→second publish boundary: the real doc
+        must adopt what the transient pass created, never mint a sibling."""
+        from bson import ObjectId
+        from pocketpaw_ee.cloud.models.site import Site
+        from pocketpaw_ee.paw_bar import agent_provisioning as ap
+
+        _c, store = client
+        site_id = ObjectId()
+        transient = Site(
+            id=site_id,
+            workspace=_WS,
+            pocket_id=_POCKET,
+            owner=_OWNER,
+            name="Northwind Plumbing",
+            signed_key=_VALID_KEY,
+        )
+        first = await ap.ensure_site_widget(transient, _WS)
+
+        # Now the doc really exists (the publish inserted it) and we publish again.
+        await transient.insert()
+        second = await ap.ensure_site_widget(transient, _WS)
+
+        assert second is not None and first is not None
+        assert second.id == first.id
+        widgets = await store.list_widgets(pocket_id=_POCKET, workspace_id=_WS, limit=10)
+        assert len(widgets) == 1, "a second publish must not mint a sibling widget"


### PR DESCRIPTION
A first publish went live with no concierge bar on it, silently.

`_embed_concierge_bar` only provisioned when a Site doc already existed, but
on a first publish that doc is inserted *after* the embed step. So the widget
and dedicated agent were never created, the snippet check returned empty, and
the page shipped bar-less — with no log line, because an empty snippet returns
early. A re-publish grew a bar normally, which is why the earlier publish-time
provisioning fix looked correct: it was verified by republishing an existing
site.

Now the first pass builds a transient Site to provision against. Provisioning
only reads `workspace` / `owner` / `id` / `name` / `pocket_id` off the object
and never re-reads the database, and the insert further down carries the same
values.

Tests cover the first-publish path and that a second publish adopts the same
widget instead of minting a sibling. 525 sites tests pass.

Found by the dynamic-sites audit: it published a fresh site and found zero
paw-bar markers in the artifact.