### PR TITLE
Type to take over: the owner replies and the bot stops talking

### DIFF
--- a/docs/concepts/concierge-knowledge.mdx
+++ b/docs/concepts/concierge-knowledge.mdx
@@ -207,6 +207,74 @@ Visitors are shown by the email they left, when they left one, and otherwise by 
 short stub of their anonymous handle. The email is still stored only where it was
 captured; the owner's list reads it there rather than keeping a second copy.
 
+## When a human takes over
+
+Typing is taking over. There is no separate button to press first, because the
+failure this is built to prevent is a bot and a person answering the same customer
+at the same time — and a button is a thing you can forget.
+
+`POST /paw-bar/admin/site/{site_id}/conversations/{customer_ref}/reply` sends the
+owner's line, and does everything else that has to happen with it: the reply is
+stored, the bot is muted, the conversation's unread counter clears, and a closed or
+snoozed thread comes back to `open`. An owner answering a customer is engagement;
+leaving that thread filed while a human types into it is how a conversation
+disappears mid-sentence. Like the PATCH, it gates on `paw_bar.manage`.
+
+An owner's reply does **not** go through the approval loop. Instinct gates actions
+the agent proposes, because a machine wants a side effect and a human should decide.
+A human typing a sentence already is the decision.
+
+### The bot stops talking
+
+While a conversation is paused, a visitor's message does not reach the agent at all.
+The check happens before any run is created, so there is no agent turn, nothing
+metered, and no tools in reach. What the visitor gets back is a distinct
+`human_replying` event on the chat stream saying a person is replying, followed by
+the normal end-of-stream event. It is never silence: an empty stream reads as a
+failure, and a muted bot must not look like a broken one.
+
+The visitor's message is still kept, and their conversation moves to `needs_human`.
+Someone typing to a paused bot is by definition waiting on a person, and the owner
+has to be able to read what they said while they were typing. Retention applies here
+exactly as it does elsewhere: with `concierge_store_transcripts` off, that line is
+not stored either. Muting is not a way around the site's own privacy switch.
+
+Because these lines have no run behind them — the owner's replies, the system's own
+notices, and any visitor message that arrived while the bot was muted — they are
+stored separately from the run documents and merged back into the transcript by
+timestamp. The transcript's roles are therefore `user`, `assistant`, `owner` and
+`system`, interleaved in the order they were said, so the owner can see when the
+human stepped in and what the bot had been saying until then.
+
+Keeping owner replies out of the run collection is deliberate. Runs are billed
+compute; a reply shaped as one would charge the owner credits for typing their own
+sentence and count as agent work that never happened.
+
+### The bot comes back
+
+A mute with no owner activity for four hours ends by itself, and the thread says so
+with a system line explaining that the assistant is answering again. The window is
+fixed for now, and the guard matters more than making it configurable: the common
+way this feature fails in practice is an owner who steps in, gets pulled away, and
+leaves the bar silent for every visitor after that.
+
+Like the snooze, the hand-back is decided when the row is read rather than by a
+background sweep, so the chat endpoint and the visitor's own poll always agree about
+whether a human is holding the conversation. Replying again restarts the clock.
+
+### How the reply reaches the visitor
+
+`GET /paw-bar/messages/{widget_id}/{customer_ref}` is the visitor side, polled by
+the bar on the page. It is public, behind the same key, origin and rate gates as the
+chat, and it is the narrowest read on this surface: what was said (`owner` or
+`system`, with a timestamp) and whether the bot is currently paused. Nothing else
+crosses. The private notes, the tags, the assignee, the captured email and the queue
+state are all owner-only, and the visitor's own stored lines are not echoed back
+either.
+
+`after` takes the timestamp of the last message the page rendered and returns only
+what came after it, so a poll never shows the same reply twice.
+
 ## When the visitor leaves the page
 
 Some requests need a human decision, and humans take longer than a browser tab

--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -1,4 +1,35 @@
 # ee/paw_bar/router.py — HTTP surface for the Paw Bar widget layer.
+# Updated: 2026-07-30 (owner inbox, slice 2) — TYPE-TO-TAKEOVER. The owner types,
+#   the bot shuts up, and the visitor sees a human:
+#     + POST .../site/{id}/conversations/{customer_ref}/reply — {text} →
+#       {ok, message, conversation}. One call does all of it: persists an ``owner``
+#       line, mutes the bot (``bot_paused``, stamped so the idle clock starts),
+#       stamps ``last_owner_at``, clears the unread counter, and REOPENS a
+#       closed/snoozed thread. ``message`` is a TranscriptMessage (the shape the
+#       thread already renders); ``conversation`` is the same ConversationRow the
+#       PATCH echoes. Gated on ``paw_bar.manage``, workspace-scoped like its
+#       siblings. NOT a run: an owner reply never becomes a ChatRunDoc, so the
+#       metering sweeper can't bill the owner for typing.
+#     ~ POST /paw-bar/chat — the MUTE, checked BEFORE the run is created: when the
+#       conversation is paused, the visitor's line is kept (under the same
+#       retention toggle), the thread flips to ``needs_human``, and the response is
+#       exactly two SSE frames — ``human_replying`` {"message": …} then
+#       ``stream_end`` — with NO run dispatched, no metering, no tool surface.
+#       Never an empty stream: the glass app reads clean-but-empty as "No reply."
+#     + GET /paw-bar/messages/{widget_id}/{customer_ref}?signed_key=&after= — the
+#       visitor-side poll, PUBLIC, same ``_front_gate_for_key`` chain as articles
+#       (404 → 429 → 401 → 403) and the same ``_request_origin`` same-origin fix.
+#       Returns {messages:[{role,content,at}], bot_paused} and NOTHING else — no
+#       notes, tags, assignee, contact_email, or queue state ever cross to a
+#       visitor, and a visitor's own stored lines are not echoed back.
+#     ~ GET .../conversations/{customer_ref} — the transcript now MERGES two
+#       sources by timestamp: ChatRunDoc (user/assistant) and the new
+#       paw_bar_owner_messages rows (owner/system, plus muted-turn visitor lines
+#       presented as "user"). ``TranscriptMessage.role`` widens from
+#       user|assistant to user|assistant|owner|system — ADDITIVE.
+#   IDLE AUTO-RESUME (§10 Q2 — 4h, hard-coded): a mute with no owner activity for
+#   4h ends itself. Computed on READ in the store, so chat and the poll agree, and
+#   materialized by both with one system message explaining the hand-back.
 # Updated: 2026-07-30 (owner inbox, slice 1) — the concierge LOG becomes a QUEUE.
 #   A lifecycle row (``paw_bar_conversations``) is now upserted on every visitor
 #   turn from ``concierge_chat`` (failure-soft — inbox bookkeeping never costs a
@@ -318,7 +349,7 @@ import os
 import re
 import uuid
 from collections.abc import AsyncIterator
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -331,6 +362,7 @@ from pocketpaw.paw_bar.models import (
     MAX_PAYLOAD_BYTES,
     ConversationState,
     DecisionState,
+    OwnerMessageRole,
     PawBarEvent,
     PawBarEventMapping,
     PawBarSpec,
@@ -1507,6 +1539,30 @@ _MAX_CONVERSATION_TAGS = 20
 _MAX_TAG_CHARS = 40
 _MAX_NOTE_CHARS = 2000
 
+# Owner reply bounds (slice 2). The cap matches ``_STORED_USER_TEXT_CHARS`` on the
+# visitor's side of the same thread — both halves of a conversation get the same
+# room — and an over-long reply is REFUSED rather than silently truncated: the
+# owner is talking to a customer, and a sentence that ends mid-word without anyone
+# saying so is worse than an error they can act on.
+_MAX_OWNER_REPLY_CHARS = 4000
+
+# How many out-of-band lines one visitor poll returns (the most recent N,
+# presented oldest-first). A widget polls every few seconds, so it is never behind
+# by more than a handful; the cap exists so a thread that sat unpolled for a day
+# can't return an unbounded page.
+_OWNER_POLL_CAP = 50
+
+# The only roles a PUBLIC read may serve. The visitor's own muted line is stored
+# in the same table (it has no run doc) and is deliberately NOT in here: echoing a
+# visitor's words back to them is pointless, and a public read that serves stored
+# visitor content is one bug away from serving someone else's.
+_PUBLIC_MESSAGE_ROLES = ["owner", "system"]
+
+# What the widget is told when it sends into a muted bot. It is NOT an answer and
+# must never be rendered as one — the frame's own event name says so. Kept short
+# and specific: the visitor needs to know a person has this, not to read a policy.
+_HUMAN_REPLYING_MESSAGE = "Someone from the team is replying — hang tight."
+
 # How many of a visitor's ref characters survive into the fallback display name.
 # Enough to tell two visitors apart at a glance, short enough to read as a label.
 _DISPLAY_REF_CHARS = 6
@@ -1703,6 +1759,10 @@ class ConversationRow(BaseModel):
     display_name: str
     last_visitor_at: str
     last_owner_at: str
+    # When the human stepped in (slice 2). ``bot_paused`` is EFFECTIVE, so it goes
+    # false on its own once this ages past the idle window; this field is what lets
+    # the UI say "hands back at 14:20" instead of just "paused".
+    bot_paused_at: str = ""
     unread_for_owner: int
     created_at: str
     updated_at: str
@@ -1732,16 +1792,82 @@ class ConversationPatchResponse(BaseModel):
 class TranscriptMessage(BaseModel):
     """One message in a conversation transcript (D2 drill-in).
 
-    ``role`` is "user" or "assistant" per the frozen contract. Both roles are now
-    real: the agent reply comes from ``ChatRunDoc.partial_text`` and the visitor's
-    own line from ``ChatRunDoc.user_text``. A site whose owner turned
-    ``concierge_store_transcripts`` off stores no visitor lines, so its transcripts
-    are assistant-only — the same shape this DTO always had, just missing one role.
+    ``role`` is "user", "assistant", "owner" or "system". The first two come from
+    the run stream — the agent reply from ``ChatRunDoc.partial_text``, the
+    visitor's own line from ``ChatRunDoc.user_text``. The last two come from the
+    ``paw_bar_owner_messages`` table: a human on the team typing, and the product
+    explaining itself. A visitor line that arrived while the bot was muted has no
+    run doc, so it comes from that table too and is presented as "user" — the
+    thread cares who spoke, not which storage answered.
+
+    Widening from user|assistant is ADDITIVE: an existing consumer that only knows
+    the first two roles still renders every message it used to, in the same shape.
+
+    A site whose owner turned ``concierge_store_transcripts`` off stores no visitor
+    lines, so its transcripts are assistant-only (plus whatever the owner typed) —
+    the same shape this DTO always had, just missing a role.
+
+    There is deliberately NO message id: run-derived messages have none (they are
+    projections of a run doc, two per run), so an id here would exist for half the
+    thread. Anything that needs to address a message keys off the RUN.
     """
 
     role: str
     content: str
     created_at: str
+
+
+class ConversationReplyRequest(BaseModel):
+    """Body of POST .../conversations/{customer_ref}/reply — the owner's own turn."""
+
+    text: str
+
+
+class ConversationReplyResponse(BaseModel):
+    """What the composer gets back: the line it just sent + the row it changed.
+
+    ``message`` is a :class:`TranscriptMessage` on purpose — the exact shape the
+    thread is already rendering — so the composer appends the echo to the list it
+    has instead of refetching the transcript to see its own sentence.
+    ``conversation`` is the full row in the SAME shape the PATCH echoes, because
+    sending a reply moves state (the bot mutes, a closed thread reopens, the unread
+    badge clears) and the list row has to re-render.
+    """
+
+    ok: bool = True
+    message: TranscriptMessage
+    conversation: ConversationRow
+
+
+class VisitorMessage(BaseModel):
+    """One owner/system line as the VISITOR's widget sees it.
+
+    A deliberately narrow projection, and the narrowness is the point: this is the
+    only public read of a conversation. It carries what was said, who said it
+    (owner or system — never an operator's identity), and when. Everything the
+    owner side keeps on the same conversation — private notes, tags, assignee,
+    captured email, the queue state — is owner-only data that must never cross to
+    the visitor. ``at`` is an ISO-8601 UTC timestamp; a poller passes the last one
+    it saw back as ``after``.
+    """
+
+    role: str
+    content: str
+    at: str
+
+
+class VisitorMessagesResponse(BaseModel):
+    """GET /paw-bar/messages/{widget_id}/{customer_ref} payload.
+
+    ``bot_paused`` is the EFFECTIVE mute: true only while a human is actually
+    holding the conversation, and false again the moment the idle window lapses.
+    It is the one piece of conversation STATE a visitor is allowed to know, and
+    only because it is about them — it tells the widget whether to say "someone is
+    replying" or hand the composer back to the assistant.
+    """
+
+    messages: list[VisitorMessage] = Field(default_factory=list)
+    bot_paused: bool = False
 
 
 class ConversationTranscriptResponse(BaseModel):
@@ -1970,6 +2096,104 @@ async def patch_site_conversation(
     )
 
 
+@router.post(
+    "/paw-bar/admin/site/{site_id}/conversations/{customer_ref}/reply",
+    response_model=ConversationReplyResponse,
+)
+async def post_site_conversation_reply(
+    site_id: str,
+    customer_ref: str,
+    req: ConversationReplyRequest,
+    # Same gate-as-author-lookup as the PATCH: ``require_action`` hands back the
+    # caller once the role check passes, so the reply is attributed for free.
+    user: Any = Depends(_require_paw_bar_manage),
+    workspace_id: str = Depends(current_workspace_id),
+) -> ConversationReplyResponse:
+    """The owner types, and the bot stops talking. THE takeover.
+
+    Typing IS taking over — there is no separate "take over" button to forget to
+    press, because the failure this design refuses is a human and a bot answering
+    the same customer at the same time. So one call does all of it, in one place,
+    and no caller can do half:
+
+      * the reply is persisted as an ``owner`` line on the thread;
+      * ``bot_paused`` goes on (and the store stamps WHEN, which starts the
+        4h idle clock that eventually hands the conversation back);
+      * ``last_owner_at`` is now and ``unread_for_owner`` clears — the owner is
+        demonstrably reading this conversation, so it is no longer unread;
+      * a ``closed`` or ``snoozed`` thread REOPENS. An owner replying is
+        engagement; leaving it filed while a human answers it is how a
+        conversation disappears from the queue mid-sentence.
+
+    Auth and tenancy are the PATCH's, exactly: ``paw_bar.manage``, the Site loaded
+    workspace-scoped (cross-tenant → 404), then its widget — so the row written
+    always belongs to this tenant. A ``customer_ref`` with no concierge runs on
+    this site 404s, same rule and for the same reason: that is not a conversation,
+    it's a guess.
+
+    D4: an owner's chat reply does NOT go through Instinct. Instinct gates
+    agent-proposed ACTIONS, because a machine wants a side effect. A human typing
+    a sentence is already the human decision.
+
+    The reply is NOT dispatched as a run. It never touches ``ChatRunDoc``, so it
+    is never swept into billing (``metering.sweeper`` bills every unbilled terminal
+    run) and never counted as agent compute — the owner is not charged credits for
+    typing their own sentence.
+    """
+    if not _CUSTOMER_REF_RE.match(customer_ref or ""):
+        raise HTTPException(400, "invalid_customer_ref")
+    text = (req.text or "").strip()
+    if not text:
+        raise HTTPException(422, "empty_reply")
+    if len(text) > _MAX_OWNER_REPLY_CHARS:
+        raise HTTPException(422, "reply_too_long")
+
+    site, widget = await _resolve_site_and_widget(site_id, workspace_id)
+    if widget is None:
+        raise HTTPException(404, "conversation_not_found")
+
+    store = _store()
+    conversation = await store.get_conversation(widget.id, customer_ref, workspace_id=workspace_id)
+    if conversation is None:
+        runs = await _concierge_runs_for_visitor(
+            site.pocket_id, customer_ref, workspace_id, limit=1
+        )
+        if not runs:
+            raise HTTPException(404, "conversation_not_found")
+        conversation = await store.ensure_conversation(widget.id, customer_ref, workspace_id)
+
+    message = await store.add_owner_message(
+        widget.id,
+        customer_ref,
+        text,
+        role=OwnerMessageRole.OWNER,
+        author=getattr(user, "id", "") or "",
+        workspace_id=workspace_id,
+    )
+
+    fields: dict[str, Any] = {
+        "bot_paused": True,
+        "last_owner_at": datetime.now().isoformat(),
+        "unread_for_owner": 0,
+    }
+    if conversation.state in (ConversationState.CLOSED, ConversationState.SNOOZED):
+        fields["state"] = ConversationState.OPEN.value
+        # A reopened thread forgets its snooze deadline, the same way a visitor's
+        # return does — it is live again, not merely due back later.
+        fields["snooze_until"] = ""
+    updated = await store.update_conversation(
+        widget.id, customer_ref, workspace_id=workspace_id, **fields
+    )
+    conversation = updated or conversation
+
+    _pending, emails = await _decision_side_data(widget, [customer_ref])
+    return ConversationReplyResponse(
+        ok=True,
+        message=_owner_transcript_message(message),
+        conversation=_conversation_row(conversation, emails.get(customer_ref, "")),
+    )
+
+
 @router.get(
     "/paw-bar/admin/agent/{agent_id}/conversations",
     response_model=AgentConversationsResponse,
@@ -2082,8 +2306,9 @@ async def get_site_conversation_transcript(
     customer_ref). Capped at the most recent ``_TRANSCRIPT_CAP`` (200) turns,
     presented oldest-first. 404 when the ref has no concierge conversation here.
 
-    ROLE COVERAGE: both halves of the conversation are here — the visitor's line
-    from ``ChatRunDoc.user_text`` and the agent's from ``partial_text``. The
+    ROLE COVERAGE: all four roles are here — "user" and "assistant" from the run
+    stream, "owner" and "system" from the out-of-band table (slice 2), interleaved
+    strictly by timestamp so the thread shows exactly when a human stepped in. The
     visitor half is stored only while the site's ``concierge_store_transcripts``
     toggle is on (it is personal data, so the owner controls it); an owner who
     turns it off keeps getting assistant-only transcripts from that point on, and
@@ -2095,7 +2320,7 @@ async def get_site_conversation_transcript(
     # No concierge widget on this site → no conversation exists to read.
     if widget is None:
         raise HTTPException(404, "conversation_not_found")
-    messages = await _load_transcript(site.pocket_id, customer_ref, workspace_id)
+    messages = await _load_transcript(site.pocket_id, customer_ref, workspace_id, widget=widget)
     if messages is None:
         # No concierge run for this (pocket, customer_ref) — the ref has no
         # conversation on this site's widget.
@@ -2322,9 +2547,36 @@ def _conversation_row(conversation: Any, captured_email: str = "") -> Conversati
         display_name=_display_name(contact_email, conversation.customer_ref),
         last_visitor_at=conversation.last_visitor_at,
         last_owner_at=conversation.last_owner_at,
+        bot_paused_at=getattr(conversation, "bot_paused_at", "") or "",
         unread_for_owner=conversation.unread_for_owner,
         created_at=conversation.created_at.isoformat(),
         updated_at=conversation.updated_at.isoformat(),
+    )
+
+
+# How a stored out-of-band role reads in a TRANSCRIPT. Owner and system keep their
+# own names — the thread's whole point is that you can see when a human took over.
+# A visitor's muted line is presented as "user": it is the same person saying the
+# same kind of thing as every other visitor line, and only happens to live in a
+# different table because no run was dispatched for it.
+_TRANSCRIPT_ROLE_BY_STORED = {
+    OwnerMessageRole.OWNER.value: "owner",
+    OwnerMessageRole.SYSTEM.value: "system",
+    OwnerMessageRole.VISITOR.value: "user",
+}
+
+
+def _owner_transcript_message(message: Any) -> TranscriptMessage:
+    """Project one ``paw_bar_owner_messages`` row into the transcript's shape.
+
+    Shared by the reply echo and the transcript merge so the composer's optimistic
+    append and the refetched thread can't render the same sentence two ways.
+    """
+    stored = getattr(message.role, "value", str(message.role))
+    return TranscriptMessage(
+        role=_TRANSCRIPT_ROLE_BY_STORED.get(stored, "system"),
+        content=message.content,
+        created_at=message.created_at,
     )
 
 
@@ -2644,28 +2896,63 @@ async def _load_concierge_history(
         return []
 
 
+def _transcript_sort_key(created_at: str) -> datetime:
+    """One comparable instant for a transcript line, whatever wrote it.
+
+    The two sources keep time differently and the difference is load-bearing:
+    ``ChatRunDoc.createdAt`` is timezone-aware UTC, while an out-of-band line is an
+    ISO string this router's store wrote. Sorting the raw strings would interleave
+    the thread wrongly by the host's UTC offset on any machine not set to UTC — a
+    human's reply landing hours before the question it answers.
+
+    So every stamp is parsed, and a naive one is read as UTC (both writers mean
+    UTC; the store writes aware UTC deliberately). An unparseable or empty stamp
+    sorts FIRST, which is where a line nobody dated belongs: visible at the top of
+    the thread rather than silently dropped.
+    """
+    if created_at:
+        try:
+            moment = datetime.fromisoformat(created_at)
+        except ValueError:
+            return datetime.min.replace(tzinfo=UTC)
+        return moment if moment.tzinfo else moment.replace(tzinfo=UTC)
+    return datetime.min.replace(tzinfo=UTC)
+
+
 async def _load_transcript(
-    pocket_id: str, customer_ref: str, workspace_id: str
+    pocket_id: str,
+    customer_ref: str,
+    workspace_id: str,
+    widget: PawBarWidget | None = None,
 ) -> list[TranscriptMessage] | None:
-    """Build one visitor's concierge transcript, oldest-first (D2 drill-in).
+    """Build one visitor's full conversation, oldest-first (D2 drill-in + slice 2).
 
-    Fetches this (pocket, customer_ref)'s concierge ``ChatRunDoc`` runs (index-
-    backed, most-recent ``_TRANSCRIPT_CAP``), then presents them oldest-first. Each
-    run contributes up to TWO messages, in conversation order: the visitor's own
-    line (``user_text``) as "user", then the agent reply (``partial_text``) as
-    "assistant". Either can be missing and the other still renders — a site with
-    ``concierge_store_transcripts`` off has no user lines (assistant-only, exactly
-    the old shape), and a run that failed before producing text has no assistant
-    line. Both empty and the run contributes nothing.
+    TWO sources, merged into ONE timeline:
 
-    Returns ``None`` when the ref has NO concierge run here (the caller 404s) —
-    distinct from an empty list, which means runs exist but none carried any text.
+      * the concierge ``ChatRunDoc`` runs (index-backed, most-recent
+        ``_TRANSCRIPT_CAP``). Each run contributes up to two messages in
+        conversation order: the visitor's line (``user_text``) as "user", then the
+        agent reply (``partial_text``) as "assistant". Either can be missing and
+        the other still renders — a site with ``concierge_store_transcripts`` off
+        has no user lines (assistant-only, exactly the shape this endpoint has
+        always returned), and a run that failed before producing text has no
+        assistant line.
+      * the ``paw_bar_owner_messages`` rows — the lines with no run behind them:
+        the owner's own replies, the system's hand-back notices, and any visitor
+        message that arrived while the bot was muted.
+
+    Merged strictly by timestamp (see ``_transcript_sort_key``), because the whole
+    value of this view is seeing WHEN the human stepped in relative to what the
+    bot had been saying. The merge is best-effort on the out-of-band side: if that
+    store hiccups the run-derived transcript still renders, which is what it did
+    before this slice.
+
+    Returns ``None`` only when the ref has NOTHING here (the caller 404s) —
+    distinct from an empty list, which means rows exist but none carried text.
     """
     runs = await _concierge_runs_for_visitor(
         pocket_id, customer_ref, workspace_id, limit=_TRANSCRIPT_CAP
     )
-    if not runs:
-        return None
 
     messages: list[TranscriptMessage] = []
     for run in reversed(runs):  # oldest-first
@@ -2692,7 +2979,29 @@ async def _load_transcript(
                     created_at=answered.isoformat() if answered else "",
                 )
             )
-    return messages
+
+    out_of_band: list[Any] = []
+    if widget is not None:
+        try:
+            out_of_band = await _store().list_owner_messages(
+                widget.id,
+                customer_ref,
+                workspace_id=workspace_id,
+                limit=_TRANSCRIPT_CAP,
+            )
+        except Exception:  # noqa: BLE001 — the run-derived half must still render
+            logger.warning("owner message read failed for widget %s", widget.id, exc_info=True)
+    if not runs and not out_of_band:
+        return None
+    messages.extend(_owner_transcript_message(m) for m in out_of_band if m.content)
+
+    # Stable sort on the parsed instant: two lines stamped identically keep the
+    # order they were added, so a run's question still precedes its own answer.
+    messages.sort(key=lambda m: _transcript_sort_key(m.created_at))
+    # Keep the most recent window. The bound is what the run-derived read could
+    # already return on its own (two messages per capped run), so adding a second
+    # source widened the transcript's content, never its size.
+    return messages[-(_TRANSCRIPT_CAP * 2) :]
 
 
 async def _count_conversations(pocket_id: str, workspace_id: str) -> int:
@@ -3029,8 +3338,12 @@ def _article_page_url(article_id: str, base_url: str) -> str:
 async def _concierge_sources(pocket_id: str, message: str, site: Any) -> list[dict[str, str]]:
     """Sources for one concierge reply: synced site pages that match the message.
 
-    Searches the SAME ``pocket:<pocket_id>`` scope the concierge run reads (the
-    one scope ``_kb_scopes_for_context`` grants a CONCIERGE run), then keeps only
+    Searches the site's ``pocket:<pocket_id>`` scope — one of the two
+    ``_kb_scopes_for_context`` grants a CONCIERGE run (the other is
+    ``agent:<its own id>``; never ``workspace:`` or ``user:``). Only the pocket
+    scope is searched here, and deliberately: a "source" has to be a link the
+    visitor can open, and only the page sync's articles have a public URL. Then
+    keeps only
     hits whose article id is in ``Site.kb_article_ids`` — the articles the page
     sync wrote — so an owner-uploaded private file can never surface as a public
     "source". Entries need BOTH a non-empty title and url; deduped by url; capped
@@ -3086,6 +3399,70 @@ def _sse(event: str, data: dict[str, Any], *, entry_id: str | None = None) -> by
     private helper of the authed chat module."""
     head = f"id: {entry_id}\n" if entry_id else ""
     return f"{head}event: {event}\ndata: {json.dumps(data)}\n\n".encode()
+
+
+async def _human_replying_response(
+    store: Any,
+    *,
+    widget_id: str,
+    customer_ref: str,
+    workspace_id: str,
+    text: str,
+) -> StreamingResponse:
+    """The muted-bot answer: keep the visitor's line, escalate, say a human is on it.
+
+    Emits exactly TWO frames — ``human_replying`` carrying a short human-facing
+    line, then the terminal ``stream_end`` — over the same SSE media type as a real
+    turn, so the widget's existing stream reader needs no special casing beyond
+    knowing that this event is a non-answer rather than an answer. There is
+    deliberately no ``message.persisted`` head: that frame announces a run, and the
+    entire point of this path is that no run exists to announce.
+
+    Two writes happen BEFORE the response is returned — not inside the generator —
+    because a visitor who closes the tab mid-request would otherwise take their own
+    message with them: the body might never be consumed, and the owner would be
+    left answering a question nobody can see. Both are failure-soft (a visitor's
+    experience must not depend on the owner's bookkeeping succeeding):
+
+      * the visitor's line is stored as a ``visitor`` row — it has no run doc to
+        live on, and without it the owner's transcript would stop dead at the
+        moment they took over, which is precisely when they need to read it. Empty
+        when the site's transcript retention is off; the toggle governs this path
+        exactly as it governs the run path.
+      * the conversation flips to ``needs_human``. A visitor talking into a muted
+        bot is, by definition, waiting on a person.
+    """
+    try:
+        if text:
+            await store.add_owner_message(
+                widget_id,
+                customer_ref,
+                text,
+                role=OwnerMessageRole.VISITOR,
+                workspace_id=workspace_id,
+            )
+        await store.update_conversation(
+            widget_id,
+            customer_ref,
+            workspace_id=workspace_id,
+            state=ConversationState.NEEDS_HUMAN.value,
+        )
+    except Exception:  # noqa: BLE001 — the visitor still gets told a human is on it
+        logger.warning("paused-bot turn bookkeeping failed (non-fatal)", exc_info=True)
+
+    async def gen() -> AsyncIterator[bytes]:
+        yield _sse("human_replying", {"message": _HUMAN_REPLYING_MESSAGE})
+        yield _sse("stream_end", {"assistant_message_id": None, "cancelled": False})
+
+    return StreamingResponse(
+        gen(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
 
 
 @router.post("/paw-bar/chat")
@@ -3218,12 +3595,41 @@ async def concierge_chat(body: ConciergeChatRequest, request: Request) -> Stream
     # FAILURE-SOFT, deliberately and non-negotiably: inbox bookkeeping is the
     # owner's convenience, and a hiccup writing it must never cost a visitor their
     # answer. Worst case the owner's queue is one message stale until the next turn.
+    #
+    # The idle auto-resume runs FIRST so a mute that has aged out is already gone
+    # before this turn is classified — one cheap conditional UPDATE that no-ops for
+    # every conversation nobody has taken over (the overwhelming majority).
+    conversation = None
     try:
-        await store.upsert_conversation_on_visitor_turn(
+        await store.auto_resume_bot_if_idle(body.widget_id, body.customer_ref, ctx.workspace_id)
+        conversation = await store.upsert_conversation_on_visitor_turn(
             body.widget_id, body.customer_ref, ctx.workspace_id
         )
     except Exception:
         logger.warning("conversation state upsert failed (non-fatal)", exc_info=True)
+
+    # (7c) THE MUTE. A human is holding this conversation, so the bot does not
+    # answer over them — double-answering is the single loudest complaint about
+    # every product that shipped this feature, and the reason takeover is worth
+    # building at all.
+    #
+    # This sits BEFORE the run is created, deliberately: no ChatRunDoc, so no
+    # metering, no run analytics, no tool surface, and nothing for the executor to
+    # dispatch. The visitor's line is still kept (under the SAME retention toggle
+    # the run path honours — this is not a back door around the owner's privacy
+    # choice), the conversation is escalated to ``needs_human`` because someone is
+    # now waiting on a person, and the widget is told what happened.
+    #
+    # It is told with a FRAME, never with silence: a clean-but-empty stream reads
+    # as "No reply." in the glass app, so a muted bot would look like a broken one.
+    if conversation is not None and conversation.bot_paused:
+        return await _human_replying_response(
+            store,
+            widget_id=body.widget_id,
+            customer_ref=body.customer_ref,
+            workspace_id=ctx.workspace_id,
+            text=body.message[:_STORED_USER_TEXT_CHARS] if site.concierge_store_transcripts else "",
+        )
 
     # (8) Dispatch a CONCIERGE run over the SAME machinery the authed chat uses.
     from pocketpaw_ee.cloud.chat.runs import service as run_service
@@ -3264,7 +3670,8 @@ async def concierge_chat(body: ConciergeChatRequest, request: Request) -> Stream
     # anonymous customer handle (session / rate-limit key, never a principal).
     # ``surface="concierge"`` makes execute_run resolve the CONCIERGE
     # SurfaceProfile (tool lockdown); ``context_type="concierge"`` makes it
-    # resolve the CONCIERGE scope (KB locked to pocket:<id>).
+    # resolve the CONCIERGE scope (KB locked to pocket:<id> + agent:<its own id>,
+    # never workspace: or user: — D5, #1821).
     #
     # ``persist_user_text`` is the visitor's own line, written onto the run doc so
     # the owner's transcript is a conversation rather than a monologue. The visitor
@@ -3656,6 +4063,115 @@ async def list_public_articles(
         if len(articles) >= _ARTICLES_MAX:
             break
     return ArticlesResponse(articles=articles)
+
+
+# ---------------------------------------------------------------------------
+# Visitor-side message poll (2026-07-30, owner inbox slice 2) — the other half
+# of takeover. The owner's reply is written on the dashboard; this is how it
+# reaches the person waiting on the page. Sibling of the decision poll, same
+# armor class as chat via the shared ``_front_gate_for_key``, and deliberately
+# the NARROWEST read on this router: a conversation carries private notes, tags,
+# an assignee, a captured email and a queue state, and none of them belong to
+# the visitor. What crosses is what was said to them, and whether a human is
+# holding the thread.
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/paw-bar/messages/{widget_id}/{customer_ref}",
+    response_model=VisitorMessagesResponse,
+)
+async def get_visitor_messages(
+    widget_id: str,
+    customer_ref: str,
+    request: Request,
+    signed_key: str = Query("", description="The public Site.signed_key"),
+    after: str = Query("", description="Only messages stamped strictly later"),
+) -> VisitorMessagesResponse:
+    """Poll for owner/system messages on this visitor's thread.
+
+    Gates are the SAME front-gate chain as chat, via ``_front_gate_for_key``:
+    malformed handle → 400, unknown widget → 404, rate limit → 429,
+    bad/unknown/revoked key → 401, disallowed origin or a widget∩key binding
+    mismatch → 403. ``_request_origin`` rather than the raw header, because a
+    same-origin GET from our own frame carries no Origin and the raw read made
+    exactly this kind of poll 403 on the live rig.
+
+    WHAT CROSSES, exhaustively: ``role`` (owner | system), ``content``, ``at``,
+    plus the thread's ``bot_paused``. Nothing else — not the private notes, not
+    the tags, not the assignee, not the captured email, not the queue state, not
+    even the visitor's own stored lines. This is the only public read of a
+    conversation, so its shape is the boundary.
+
+    ``after`` is a strict cursor (the last ``at`` the widget rendered), the page is
+    capped at ``_OWNER_POLL_CAP`` and comes back oldest-first. A malformed
+    ``after`` is IGNORED rather than refused, the same way the conversation list
+    treats a malformed cursor: a poll that hard-failed on a bad cursor would leave
+    the visitor staring at a thread that silently stopped updating.
+
+    The idle auto-resume is applied here too, so the poll and the chat endpoint can
+    never disagree about whether the bot is muted — the visitor learns the
+    assistant is back on the same tick the assistant starts answering again.
+    """
+    origin = _request_origin(request)
+    widget, ctx, _site = await _front_gate_for_key(
+        widget_id=widget_id,
+        signed_key=signed_key,
+        customer_ref=customer_ref,
+        origin=origin,
+        request=request,
+    )
+
+    store = _store()
+    try:
+        await store.auto_resume_bot_if_idle(widget.id, customer_ref, ctx.workspace_id)
+        conversation = await store.get_conversation(
+            widget.id, customer_ref, workspace_id=ctx.workspace_id
+        )
+        messages = await store.list_owner_messages(
+            widget.id,
+            customer_ref,
+            workspace_id=ctx.workspace_id,
+            after=_normalized_after(after),
+            roles=_PUBLIC_MESSAGE_ROLES,
+            limit=_OWNER_POLL_CAP,
+        )
+    except Exception:  # noqa: BLE001 — a poll that 500s stalls the visitor's thread
+        logger.warning("visitor message poll failed for widget %s", widget.id, exc_info=True)
+        return VisitorMessagesResponse(messages=[], bot_paused=False)
+
+    return VisitorMessagesResponse(
+        messages=[
+            VisitorMessage(role=m.role.value, content=m.content, at=m.created_at)
+            for m in messages
+            if m.content
+        ],
+        bot_paused=bool(conversation.bot_paused) if conversation is not None else False,
+    )
+
+
+def _normalized_after(after: str) -> str:
+    """Re-render a client ``after`` cursor in the format the rows are stored in.
+
+    The cursor is compared as a string in SQL, which only works while every value
+    shares one format. Rows are written by ``_utc_stamp`` (aware UTC), but a
+    browser round-tripping the value through ``Date.toISOString()`` hands back a
+    ``…Z`` spelling of the same instant — and ``'Z'`` sorts AFTER the ``'.'`` of a
+    fractional second, so the same moment would compare as later and the poll
+    would skip messages it should have delivered. Parse, convert to UTC, re-render.
+    An unparseable cursor yields "" (no filter) rather than an error: a bad cursor
+    should cost a duplicate render, never a stalled thread.
+    """
+    stamp = (after or "").strip()
+    if not stamp:
+        return ""
+    try:
+        moment = datetime.fromisoformat(stamp)
+    except ValueError:
+        return ""
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=UTC)
+    return moment.astimezone(UTC).isoformat()
 
 
 # ---------------------------------------------------------------------------

--- a/src/pocketpaw/paw_bar/models.py
+++ b/src/pocketpaw/paw_bar/models.py
@@ -1,4 +1,15 @@
 # ee/paw_bar/models.py — Pydantic models for the Paw Bar widget layer.
+# Updated: 2026-07-30 (owner inbox, slice 2 — type-to-takeover) — the OUT-OF-BAND
+#   thread vocabulary: ``OwnerMessageRole`` (owner | system | visitor) and
+#   ``OwnerMessage``, the rows of ``paw_bar_owner_messages``. These are the thread
+#   lines that have no ChatRunDoc: the owner's own replies, the system's
+#   explanations (the bot handing itself back), and a visitor line that arrived
+#   while the bot was muted and therefore never dispatched a run. They are NOT run
+#   docs on purpose — ``metering.sweeper.sweep_unbilled_runs`` bills every unbilled
+#   terminal run, so an owner reply shaped as one would charge the owner credits
+#   for typing their own sentence and count as agent compute that never happened.
+#   ``created_at`` is an ISO string in UTC (aware), matching ChatRunDoc.createdAt,
+#   so the transcript reader can merge both sources on one comparable clock.
 # Updated: 2026-07-30 (owner inbox, slice 1) — the conversation STATE vocabulary:
 #   ``ConversationState`` (open | needs_human | snoozed | closed),
 #   ``ConversationNote`` (an owner's private {author, text, at}) and
@@ -562,9 +573,70 @@ class Conversation(BaseModel):
     contact_email: str = ""
     last_visitor_at: str = ""
     last_owner_at: str = ""
+    # When the bot was muted (slice 2). Set whenever ``bot_paused`` flips on,
+    # cleared when it flips off. The idle auto-resume reads it, and the owner UI
+    # uses it to say when the bot hands itself back.
+    bot_paused_at: str = ""
     unread_for_owner: int = 0
     created_at: datetime = Field(default_factory=datetime.now)
     updated_at: datetime = Field(default_factory=datetime.now)
+
+
+def _gen_owner_message_id() -> str:
+    """Fresh owner-message row id (``ppm_…``) — same reason as the conversation id."""
+    return _gen_id("ppm")
+
+
+class OwnerMessageRole(StrEnum):
+    """Who spoke a line that has no run doc behind it.
+
+    ``OWNER``   — a human on the site's team typed it. The line the visitor is
+                  waiting for; the whole point of the takeover.
+    ``SYSTEM``  — the product explaining itself in the thread ("the assistant is
+                  answering again"). Visitor-facing, but authored by nobody.
+    ``VISITOR`` — a visitor message that arrived while the bot was MUTED. It never
+                  became a ``ChatRunDoc`` because no run was dispatched (that is
+                  the entire point of muting), so without this row the owner's
+                  transcript would simply stop mid-conversation at the moment a
+                  human took over. Never returned by the public poll: the visitor
+                  already has their own words on screen, and echoing them back is
+                  how a public read starts leaking a thread.
+    """
+
+    OWNER = "owner"
+    SYSTEM = "system"
+    VISITOR = "visitor"
+
+
+class OwnerMessage(BaseModel):
+    """One thread line stored outside the run stream (owner inbox, slice 2).
+
+    The transcript is normally derived from ``ChatRunDoc`` — one run per visitor
+    turn, carrying both halves. These are the lines with no run: see
+    :class:`OwnerMessageRole`. Keyed by ``(widget_id, customer_ref)``, the same
+    identity as :class:`Conversation`, so the reader merges the two sources on one
+    key and one clock.
+
+    ``created_at`` is an ISO-8601 string in UTC (timezone-aware), deliberately NOT
+    a naive local stamp like the conversation row's: this value is sorted against
+    ``ChatRunDoc.createdAt`` (aware UTC) to interleave the thread, and it is
+    handed to clients. A naive local stamp would interleave wrongly by the host's
+    UTC offset on every machine that isn't set to UTC.
+
+    PII posture: ``content`` is free text an owner or a visitor typed, so treat it
+    as personal data — same class as ``ChatRunDoc.user_text``. ``author`` is the
+    owner's user id, and is owner-facing only: the public poll projects role +
+    content + timestamp and nothing else.
+    """
+
+    id: str = Field(default_factory=_gen_owner_message_id)
+    widget_id: str
+    customer_ref: str
+    workspace_id: str = ""
+    role: OwnerMessageRole = OwnerMessageRole.OWNER
+    content: str = ""
+    author: str = ""
+    created_at: str = ""
 
 
 # ---------------------------------------------------------------------------

--- a/src/pocketpaw/paw_bar/store.py
+++ b/src/pocketpaw/paw_bar/store.py
@@ -1,4 +1,20 @@
 # ee/paw_bar/store.py — Async SQLite store for Paw Bar widgets and events.
+# Updated: 2026-07-30 (owner inbox, slice 2 — type-to-takeover) — the lines that
+#   have no run doc get a home, and a muted bot gets a deadline:
+#   * new paw_bar_owner_messages table (sibling of paw_bar_conversations, same
+#     additive-migration + workspace-scoped conventions): owner replies, system
+#     explanations, and visitor lines that arrived while the bot was muted.
+#     add_owner_message writes one, list_owner_messages reads a thread oldest-first
+#     with a strict ``after`` cursor and a cap. Timestamps are ISO UTC (aware) so
+#     they sort against ChatRunDoc.createdAt on one clock.
+#   * paw_bar_conversations gains ``bot_paused_at`` (additive ALTER): when the mute
+#     started. update_conversation stamps it whenever bot_paused flips on and
+#     clears it when it flips off, so every writer gets the bookkeeping for free.
+#   * IDLE AUTO-RESUME, computed on READ like the snooze expiry: a mute whose last
+#     owner activity is older than BOT_PAUSE_IDLE_HOURS reads as un-paused
+#     everywhere (``_EFFECTIVE_BOT_PAUSED_SQL``), and auto_resume_bot_if_idle
+#     materializes it — one atomic UPDATE, then a single system message so the
+#     thread explains itself. No sweeper, so a forgotten mute always ends.
 # Updated: 2026-07-30 (owner inbox, slice 1) — new paw_bar_conversations table:
 #   the thin lifecycle row that turns the concierge log into a queue, keyed
 #   UNIQUE(widget_id, customer_ref). Mirrors the paw_bar_decisions conventions
@@ -95,7 +111,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -108,12 +124,15 @@ from pocketpaw.paw_bar.models import (
     ConversationState,
     DecisionState,
     DecisionStatus,
+    OwnerMessage,
+    OwnerMessageRole,
     PawBarCart,
     PawBarCartItem,
     PawBarEvent,
     PawBarSpec,
     PawBarWidget,
     _gen_conversation_id,
+    _gen_owner_message_id,
     _gen_token,
 )
 
@@ -226,10 +245,30 @@ CREATE TABLE IF NOT EXISTS paw_bar_conversations (
     contact_email TEXT DEFAULT '',
     last_visitor_at TEXT DEFAULT '',
     last_owner_at TEXT DEFAULT '',
+    bot_paused_at TEXT DEFAULT '',
     unread_for_owner INTEGER DEFAULT 0,
     created_at TEXT DEFAULT (datetime('now')),
     updated_at TEXT DEFAULT (datetime('now')),
     UNIQUE (widget_id, customer_ref)
+);
+
+-- Owner inbox (slice 2): the thread lines that have NO run doc. A concierge turn
+-- is a ChatRunDoc and stays one; these are the three kinds of line a run can't
+-- express — the owner's own reply, a system explanation, and a visitor message
+-- that arrived while the bot was muted (no run was dispatched, by design). Kept
+-- out of the run collection deliberately: the metering sweeper bills every
+-- unbilled terminal run, so an owner reply shaped as one would charge the owner
+-- for typing. Same (widget_id, customer_ref) identity as the conversation row,
+-- so the transcript reader merges the two sources on one key.
+CREATE TABLE IF NOT EXISTS paw_bar_owner_messages (
+    id TEXT PRIMARY KEY,
+    widget_id TEXT NOT NULL,
+    customer_ref TEXT NOT NULL,
+    workspace_id TEXT DEFAULT '',
+    role TEXT DEFAULT 'owner',
+    content TEXT DEFAULT '',
+    author TEXT DEFAULT '',
+    created_at TEXT DEFAULT ''
 );
 
 CREATE INDEX IF NOT EXISTS idx_pp_widgets_pocket ON paw_bar_widgets(pocket_id);
@@ -247,6 +286,8 @@ CREATE INDEX IF NOT EXISTS idx_pp_spec_revisions_widget
     ON paw_bar_spec_revisions(widget_id, revision DESC);
 CREATE INDEX IF NOT EXISTS idx_pp_conversations_state
     ON paw_bar_conversations(widget_id, state, updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_pp_owner_messages_thread
+    ON paw_bar_owner_messages(widget_id, customer_ref, created_at);
 """
 
 # The paw_bar_conversations columns, with the exact declaration each ALTER must
@@ -264,10 +305,50 @@ _CONVERSATION_COLUMNS: dict[str, str] = {
     "contact_email": "TEXT DEFAULT ''",
     "last_visitor_at": "TEXT DEFAULT ''",
     "last_owner_at": "TEXT DEFAULT ''",
+    "bot_paused_at": "TEXT DEFAULT ''",
     "unread_for_owner": "INTEGER DEFAULT 0",
     "created_at": "TEXT",
     "updated_at": "TEXT",
 }
+
+# The paw_bar_owner_messages columns, same contract as the conversation map above:
+# keep in lockstep with the CREATE TABLE, primary key excluded.
+_OWNER_MESSAGE_COLUMNS: dict[str, str] = {
+    "workspace_id": "TEXT DEFAULT ''",
+    "role": "TEXT DEFAULT 'owner'",
+    "content": "TEXT DEFAULT ''",
+    "author": "TEXT DEFAULT ''",
+    "created_at": "TEXT DEFAULT ''",
+}
+
+# How long a muted bot stays muted with no owner activity before it hands itself
+# back (§10 Q2 — 4h, hard-coded in v1). The guard is what matters, not the knob:
+# the failure mode it closes is an owner who takes over, gets pulled away, and
+# leaves the bot silently muted for every visitor after that — the single loudest
+# complaint about this feature in the products that shipped it first. Applied on
+# READ, so it holds even if nothing is running to notice.
+BOT_PAUSE_IDLE_HOURS = 4
+
+# What the thread says when the mute lapses. Written as a SYSTEM message so the
+# visitor (and the owner, later) can see why the voice changed back, instead of
+# the bot just resuming mid-conversation as if nothing happened.
+BOT_RESUME_SYSTEM_MESSAGE = "The team stepped away — the assistant is answering again."
+
+# Idle auto-resume, decided in SQL at READ time — the same discipline as the
+# snooze expiry above and for the same reason: no sweeper, nothing to fail
+# silently at 3am. A row reads as un-paused once the LATER of "when the mute
+# started" and "when the owner last did something" has aged past the window.
+# Both timestamps are naive local ISO (the whole conversation row is), so they
+# compare as strings against a locally-computed cutoff. A mute carrying NEITHER
+# timestamp never expires: that can only be a row paused by a writer that
+# predates this column, and inventing a deadline for it would hand a live
+# conversation back to the bot on the strength of a guess.
+_EFFECTIVE_BOT_PAUSED_SQL = (
+    "CASE WHEN bot_paused = 1"
+    " AND MAX(bot_paused_at, last_owner_at) != ''"
+    " AND MAX(bot_paused_at, last_owner_at) <= ?"
+    " THEN 0 ELSE bot_paused END"
+)
 
 # Snooze expiry, decided in SQL at READ time. A row is only really snoozed while
 # its ``snooze_until`` is still in the future; once that instant passes it reads
@@ -280,6 +361,35 @@ _EFFECTIVE_STATE_SQL = (
     "CASE WHEN state = 'snoozed' AND snooze_until != '' AND snooze_until <= ?"
     " THEN 'open' ELSE state END"
 )
+
+
+def _bot_pause_cutoff(now: str) -> str:
+    """The instant a mute must predate to have gone idle, as a comparable string.
+
+    Takes the same ``now`` stamp the effective-state CASE binds, so one read can
+    never evaluate the two rules against two different clocks. A malformed stamp
+    (which can only mean a caller passed something that wasn't
+    ``datetime.now().isoformat()``) yields an empty cutoff — and an empty cutoff
+    matches nothing, so the mute simply stays on. Failing towards "the human is
+    still here" is the only safe direction: the cost of a late hand-back is a
+    quiet bot, and the cost of an early one is the bot talking over a person.
+    """
+    try:
+        moment = datetime.fromisoformat(now)
+    except ValueError:
+        return ""
+    return (moment - timedelta(hours=BOT_PAUSE_IDLE_HOURS)).isoformat()
+
+
+def _utc_stamp() -> str:
+    """Now, as the aware-UTC ISO string the owner-message rows are written with.
+
+    Deliberately not the naive ``datetime.now()`` the conversation row uses: these
+    stamps are sorted against ``ChatRunDoc.createdAt`` (aware UTC) to interleave a
+    transcript, and they go out on the wire. A naive local stamp would interleave
+    wrongly by the host's UTC offset everywhere but a UTC-set machine.
+    """
+    return datetime.now(UTC).isoformat()
 
 
 def _decision_workspace_scope(workspace_id: str | None) -> tuple[str | None, list[Any]]:
@@ -395,6 +505,14 @@ class PawBarStore:
             for name, decl in _CONVERSATION_COLUMNS.items():
                 if name not in cols:
                     await db.execute(f"ALTER TABLE paw_bar_conversations ADD COLUMN {name} {decl}")
+        # paw_bar_owner_messages (owner inbox, slice 2) — same reasoning as the
+        # conversations block above: new table today, ALTER path ready for the
+        # first column that post-dates a deployed one.
+        if "paw_bar_owner_messages" in existing:
+            cols = await _columns("paw_bar_owner_messages")
+            for name, decl in _OWNER_MESSAGE_COLUMNS.items():
+                if name not in cols:
+                    await db.execute(f"ALTER TABLE paw_bar_owner_messages ADD COLUMN {name} {decl}")
 
     def _conn(self) -> aiosqlite.Connection:
         return aiosqlite.connect(self._db_path)
@@ -945,23 +1063,28 @@ class PawBarStore:
     def _conversation_select(
         where: str, params: list[Any], *, order: str = "", now: str | None = None
     ) -> tuple[str, list[Any]]:
-        """Build a conversation SELECT that carries the EFFECTIVE state.
+        """Build a conversation SELECT that carries the EFFECTIVE state + mute.
 
-        Every read goes through here so snooze expiry is applied in exactly one
-        place: the extra ``effective_state`` column is the ``_EFFECTIVE_STATE_SQL``
-        CASE, and ``_row_to_conversation`` presents it as the row's state. The CASE
-        parameter binds BEFORE the WHERE parameters because it sits in the select
-        list — hence the explicit assembly rather than string concatenation at the
-        call sites.
+        Every read goes through here so the two time-based rules are applied in
+        exactly one place each: ``effective_state`` is the ``_EFFECTIVE_STATE_SQL``
+        CASE (snooze expiry) and ``effective_bot_paused`` is the
+        ``_EFFECTIVE_BOT_PAUSED_SQL`` CASE (idle auto-resume).
+        ``_row_to_conversation`` presents both as the row's own values, so no
+        caller has to remember to re-apply either — and the owner's list, the
+        visitor's poll, and the chat endpoint can never disagree about whether the
+        bot is muted. The CASE parameters bind BEFORE the WHERE parameters because
+        they sit in the select list — hence the explicit assembly rather than
+        string concatenation at the call sites.
         """
         stamp = now or datetime.now().isoformat()
         sql = (
-            f"SELECT *, {_EFFECTIVE_STATE_SQL} AS effective_state"
+            f"SELECT *, {_EFFECTIVE_STATE_SQL} AS effective_state,"
+            f" {_EFFECTIVE_BOT_PAUSED_SQL} AS effective_bot_paused"
             f" FROM paw_bar_conversations WHERE {where}"
         )
         if order:
             sql += f" {order}"
-        return sql, [stamp, *params]
+        return sql, [stamp, _bot_pause_cutoff(stamp), *params]
 
     async def upsert_conversation_on_visitor_turn(
         self, widget_id: str, customer_ref: str, workspace_id: str = ""
@@ -1145,6 +1268,7 @@ class PawBarStore:
             "notes",
             "contact_email",
             "last_owner_at",
+            "bot_paused_at",
             "unread_for_owner",
         }
         assignments: list[str] = []
@@ -1153,6 +1277,15 @@ class PawBarStore:
         if note is not None:
             appended = [*existing.notes, _as_note(note)]
             fields["notes"] = [n.model_dump() for n in appended]
+        # The mute clock is bookkeeping, not a field a caller should have to
+        # remember: any writer that pauses the bot stamps WHEN, and any writer that
+        # un-pauses it clears the stamp. Done here rather than at the call sites
+        # because the idle auto-resume reads that timestamp, and a writer that
+        # forgot it would create a mute with no deadline — exactly the forgotten
+        # -muted-bot failure the window exists to prevent. An explicit
+        # ``bot_paused_at`` in the same call still wins (the restore path needs it).
+        if "bot_paused" in fields and "bot_paused_at" not in fields:
+            fields["bot_paused_at"] = datetime.now().isoformat() if fields["bot_paused"] else ""
         for key, val in fields.items():
             if key not in allowed:
                 continue
@@ -1216,6 +1349,162 @@ class PawBarStore:
                     if row[0] in counts:
                         counts[row[0]] = row[1]
         return counts
+
+    async def auto_resume_bot_if_idle(
+        self, widget_id: str, customer_ref: str, workspace_id: str | None = None
+    ) -> OwnerMessage | None:
+        """Hand a forgotten mute back to the bot. Returns the system message, once.
+
+        The WRITE half of the idle auto-resume whose read half lives in
+        ``_EFFECTIVE_BOT_PAUSED_SQL``. Reads already report an aged-out mute as
+        un-paused, so nothing depends on this running — it exists to make the
+        stored row agree with what every reader already sees, and to leave a line
+        in the thread saying why the voice changed back.
+
+        The flip is a SINGLE conditional UPDATE and the system message is written
+        only if that UPDATE actually changed a row, so two visitors polling at the
+        same instant produce exactly one hand-back message rather than two. Returns
+        ``None`` when there was nothing to resume — the overwhelmingly common case,
+        and the reason this is cheap enough to call on every visitor turn.
+        """
+        await self._ensure_schema()
+        now = datetime.now().isoformat()
+        cutoff = _bot_pause_cutoff(now)
+        if not cutoff:
+            return None
+        conditions = "widget_id = ? AND customer_ref = ? AND bot_paused = 1"
+        params: list[Any] = [now, widget_id, customer_ref]
+        ws_cond, ws_params = _conversation_workspace_scope(workspace_id)
+        if ws_cond:
+            conditions += f" AND {ws_cond}"
+            params.extend(ws_params)
+        params.append(cutoff)
+        async with self._conn() as db:
+            cursor = await db.execute(
+                "UPDATE paw_bar_conversations"
+                " SET bot_paused = 0, bot_paused_at = '', updated_at = ?"
+                f" WHERE {conditions}"
+                " AND MAX(bot_paused_at, last_owner_at) != ''"
+                " AND MAX(bot_paused_at, last_owner_at) <= ?",
+                params,
+            )
+            changed = cursor.rowcount
+            await db.commit()
+        if not changed:
+            return None
+        return await self.add_owner_message(
+            widget_id,
+            customer_ref,
+            BOT_RESUME_SYSTEM_MESSAGE,
+            role=OwnerMessageRole.SYSTEM,
+            workspace_id=workspace_id or "",
+        )
+
+    # ---------------- Owner / system messages (owner inbox, slice 2) ----------------
+    #
+    # The thread lines with no run doc behind them. Same (widget_id, customer_ref)
+    # identity as the conversation row, and the same tenancy posture: the caller
+    # has already resolved the widget workspace-scoped, and ``workspace_id`` is the
+    # second, independent guard.
+    # -------------------------------------------------------------------------
+
+    async def add_owner_message(
+        self,
+        widget_id: str,
+        customer_ref: str,
+        content: str,
+        *,
+        role: OwnerMessageRole | str = OwnerMessageRole.OWNER,
+        author: str = "",
+        workspace_id: str = "",
+    ) -> OwnerMessage:
+        """Append one line to a conversation's out-of-band thread.
+
+        Append-only by construction — there is no update or delete. A support
+        thread is a record of what was actually said, and the visitor has already
+        read it; a line that could be edited afterwards is not a transcript.
+        ``role`` is normalized through :class:`OwnerMessageRole`, so an unknown
+        value raises here rather than becoming a row no reader can classify.
+        """
+        await self._ensure_schema()
+        message = OwnerMessage(
+            id=_gen_owner_message_id(),
+            widget_id=widget_id,
+            customer_ref=customer_ref,
+            workspace_id=workspace_id,
+            role=OwnerMessageRole(role),
+            content=content,
+            author=author,
+            created_at=_utc_stamp(),
+        )
+        async with self._conn() as db:
+            await db.execute(
+                "INSERT INTO paw_bar_owner_messages"
+                " (id, widget_id, customer_ref, workspace_id, role, content, author, created_at)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    message.id,
+                    message.widget_id,
+                    message.customer_ref,
+                    message.workspace_id,
+                    message.role.value,
+                    message.content,
+                    message.author,
+                    message.created_at,
+                ),
+            )
+            await db.commit()
+        return message
+
+    async def list_owner_messages(
+        self,
+        widget_id: str,
+        customer_ref: str,
+        workspace_id: str | None = None,
+        after: str = "",
+        roles: list[str] | None = None,
+        limit: int = 50,
+    ) -> list[OwnerMessage]:
+        """One thread's out-of-band lines, OLDEST-first.
+
+        ``after`` is a strict cursor: only lines stamped strictly LATER come back,
+        so a visitor's poll can pass the last ``at`` it rendered and never see a
+        message twice. It is compared as a string, which is exactly right because
+        every row is written with :func:`_utc_stamp` — one format, one timezone, so
+        lexical order IS chronological. ``roles`` restricts the read (the public
+        poll asks for owner + system only; a visitor's own muted line is never
+        served back to them).
+
+        The cap keeps the LATEST ``limit`` lines: a long-running thread's newest
+        messages are the ones a poll is missing. They are then reversed so the
+        result reads oldest-first like every other transcript in this codebase.
+        """
+        conditions = "widget_id = ? AND customer_ref = ?"
+        params: list[Any] = [widget_id, customer_ref]
+        ws_cond, ws_params = _conversation_workspace_scope(workspace_id)
+        if ws_cond:
+            conditions += f" AND {ws_cond}"
+            params.extend(ws_params)
+        if after:
+            conditions += " AND created_at > ?"
+            params.append(after)
+        if roles is not None:
+            if not roles:
+                return []
+            placeholders = ", ".join("?" for _ in roles)
+            conditions += f" AND role IN ({placeholders})"
+            params.extend(roles)
+        params.append(limit)
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                "SELECT * FROM paw_bar_owner_messages"
+                f" WHERE {conditions} ORDER BY created_at DESC, id DESC LIMIT ?",
+                params,
+            ) as cur:
+                rows = [self._row_to_owner_message(row) async for row in cur]
+        return list(reversed(rows))
 
     # ---------------- Carts (C1 — visitor-scoped commerce state) ----------------
 
@@ -1347,18 +1636,24 @@ class PawBarStore:
         select computes), so callers never have to remember to re-apply snooze
         expiry. ``snooze_until`` is left as stored: an expired snooze reads as
         ``open`` but keeps the timestamp that says when it lapsed.
+        ``bot_paused`` gets the same treatment from ``effective_bot_paused`` — an
+        aged-out mute reads as un-paused while ``bot_paused_at`` keeps saying when
+        the human stepped in.
         """
         raw_tags = json.loads(row["tags"]) if row["tags"] else []
         raw_notes = json.loads(row["notes"]) if row["notes"] else []
         keys = row.keys()
         state = row["effective_state"] if "effective_state" in keys else row["state"]
+        paused = (
+            row["effective_bot_paused"] if "effective_bot_paused" in keys else row["bot_paused"]
+        )
         return Conversation(
             id=row["id"],
             widget_id=row["widget_id"],
             customer_ref=row["customer_ref"],
             workspace_id=row["workspace_id"] or "",
             state=ConversationState(state or ConversationState.OPEN.value),
-            bot_paused=bool(row["bot_paused"]),
+            bot_paused=bool(paused),
             snooze_until=row["snooze_until"] or "",
             assignee=row["assignee"] or "",
             tags=[str(t) for t in raw_tags],
@@ -1366,9 +1661,32 @@ class PawBarStore:
             contact_email=row["contact_email"] or "",
             last_visitor_at=row["last_visitor_at"] or "",
             last_owner_at=row["last_owner_at"] or "",
+            bot_paused_at=(row["bot_paused_at"] or "") if "bot_paused_at" in keys else "",
             unread_for_owner=row["unread_for_owner"] or 0,
             created_at=datetime.fromisoformat(row["created_at"]),
             updated_at=datetime.fromisoformat(row["updated_at"]),
+        )
+
+    def _row_to_owner_message(self, row: Any) -> OwnerMessage:
+        """Rebuild an :class:`OwnerMessage` from a ``paw_bar_owner_messages`` row.
+
+        An unrecognized stored role degrades to SYSTEM rather than raising: a row
+        this reader can't classify is still a line somebody saw, and dropping the
+        whole thread over one is worse than showing it as an unattributed note.
+        """
+        try:
+            role = OwnerMessageRole(row["role"] or OwnerMessageRole.OWNER.value)
+        except ValueError:
+            role = OwnerMessageRole.SYSTEM
+        return OwnerMessage(
+            id=row["id"],
+            widget_id=row["widget_id"],
+            customer_ref=row["customer_ref"],
+            workspace_id=row["workspace_id"] or "",
+            role=role,
+            content=row["content"] or "",
+            author=row["author"] or "",
+            created_at=row["created_at"] or "",
         )
 
     def _row_to_decision(self, row: Any) -> DecisionStatus:

--- a/tests/cloud/test_paw_bar_takeover.py
+++ b/tests/cloud/test_paw_bar_takeover.py
@@ -1,0 +1,1145 @@
+# tests/cloud/test_paw_bar_takeover.py — type-to-takeover (owner inbox, slice 2).
+# Created 2026-07-30: the owner types, the bot shuts up, the visitor sees a human.
+# Layers, in the order the feature fails if any one of them is wrong:
+#   * Owner reply: persists an owner line, mutes the bot (stamped), clears the
+#     unread counter, reopens a closed/snoozed thread, refuses empty / oversized
+#     text, refuses a ref with no conversation, and refuses a cross-workspace
+#     caller.
+#   * THE MUTE (centrepiece): a visitor turn into a paused conversation emits
+#     ``human_replying``, emits NO chunk frames, dispatches NO run, and — the
+#     billing-safety proof — creates NO ChatRunDoc. It still keeps the visitor's
+#     line (under the site's retention toggle) and escalates to needs_human.
+#   * Visitor poll: owner/system lines oldest-first, strict ``after`` filtering,
+#     the EXACT public key allowlist (no notes / tags / assignee / email / state),
+#     a visitor's own stored line never echoed back, and every refusal code on the
+#     front-gate chain (400 → 404 → 429 → 401 → 403 origin, 403 binding).
+#   * Idle auto-resume: a mute with no owner activity for 4h reads as un-paused,
+#     materializes once with a system message, and a FRESH pause does not resume.
+#   * Transcript merge: all four roles interleaved strictly by timestamp, an
+#     assistant-only thread still renders, and a muted-turn visitor line appears as
+#     "user" even though it never had a run.
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from pocketpaw.paw_bar.models import (
+    ConversationState,
+    OwnerMessageRole,
+    PawBarBlock,
+    PawBarEvent,
+    PawBarSpec,
+    PawBarWidget,
+)
+from pocketpaw.paw_bar.store import (
+    BOT_PAUSE_IDLE_HOURS,
+    BOT_RESUME_SYSTEM_MESSAGE,
+    PawBarStore,
+)
+
+_KEY = "site_key_" + "a" * 24
+_ORIGIN = "https://brewco.com"
+_REF = "cust-0001"
+
+
+# --------------------------------------------------------------------------- #
+# Builders
+# --------------------------------------------------------------------------- #
+
+
+async def _site(**ov: Any):
+    from pocketpaw_ee.cloud.models.site import Site
+
+    d = dict(
+        workspace="ws-1",
+        pocket_id="pocket-1",
+        owner="user:maya",
+        name="Brew & Co",
+        script_name="",
+        signed_key=_KEY,
+        allowed_origins=["brewco.com"],
+    )
+    d.update(ov)
+    s = Site(**d)
+    await s.insert()
+    return s
+
+
+def _widget(**ov: Any) -> PawBarWidget:
+    d = dict(
+        pocket_id="pocket-1",
+        owner="user:maya",
+        name="Brew & Co",
+        spec=PawBarSpec(
+            widget_id="pp_seed",
+            pocket_id=str(ov.get("pocket_id", "pocket-1")),
+            blocks=[PawBarBlock(type="text", content="Hi")],
+        ),
+        allowed_domains=["brewco.com"],
+        agent_id="agent-xyz",
+        workspace_id="ws-1",
+    )
+    d.update(ov)
+    return PawBarWidget(**d)
+
+
+async def _mk_run(**ov: Any):
+    from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
+
+    d = dict(
+        run_id=uuid.uuid4().hex,
+        workspace="ws-1",
+        context_type="concierge",
+        scope_id="pocket-1",
+        session_key="cloud:concierge:pocket-1:cust-0001:agent-xyz",
+        user_id=_REF,
+        agent_id="agent-xyz",
+        client_message_id=uuid.uuid4().hex,
+        user_message_id="",
+        status="completed",
+        partial_text="We open at 8.",
+    )
+    d.update(ov)
+    doc = ChatRunDoc(**d)
+    await doc.insert()
+    return doc
+
+
+async def _run_count() -> int:
+    from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
+
+    return len(await ChatRunDoc.find_all().to_list())
+
+
+def _fake_user(role: str, workspace_id: str = "ws-1", user_id: str = "u1") -> SimpleNamespace:
+    return SimpleNamespace(
+        id=user_id,
+        active_workspace=workspace_id,
+        workspaces=[SimpleNamespace(workspace=workspace_id, role=role)],
+    )
+
+
+def _build_app(store, monkeypatch, *, role: str = "admin", workspace_id: str = "ws-1"):
+    from pocketpaw_ee.cloud._core.deps import current_workspace_id
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.cloud.auth import current_active_user
+    from pocketpaw_ee.paw_bar.router import router
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(router)
+    app.dependency_overrides[current_active_user] = lambda: _fake_user(role, workspace_id)
+    app.dependency_overrides[current_workspace_id] = lambda: workspace_id
+    monkeypatch.setattr("pocketpaw_ee.paw_bar.router._store", lambda: store)
+    return app
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+
+
+@pytest_asyncio.fixture
+async def store(tmp_path):
+    return PawBarStore(tmp_path / "takeover.db")
+
+
+@pytest_asyncio.fixture
+async def client(mongo_db, store, monkeypatch):
+    """ADMIN client in ws-1 (the owner side), backed by the tmp store + Beanie."""
+    app = _build_app(store, monkeypatch, role="admin")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        yield c, store
+
+
+@pytest_asyncio.fixture
+async def public(mongo_db, store, monkeypatch):
+    """PUBLIC client (no auth overrides) for the visitor-facing endpoints."""
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.paw_bar.router import router
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(router)
+    monkeypatch.setattr("pocketpaw_ee.paw_bar.router._store", lambda: store)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        yield c, store
+
+
+class _FakeExecutor:
+    """Captures submitted specs; writes a canned reply so a real turn terminates."""
+
+    def __init__(self, transport) -> None:
+        self.transport = transport
+        self.submitted: list = []
+
+    async def submit(self, spec) -> None:
+        self.submitted.append(spec)
+        await self.transport.append_event(
+            spec.run_id, "chunk", {"content": "We open at 8am!", "type": "text"}
+        )
+        await self.transport.append_event(
+            spec.run_id, "stream_end", {"assistant_message_id": "m1", "cancelled": False}
+        )
+
+
+def _stub_run_dispatch(monkeypatch, *, real_create_run: bool = False) -> _FakeExecutor:
+    """Wire the in-memory transport + a capturing executor, and stub create_run.
+
+    Returns the executor so a test can assert what was dispatched — or, for the
+    mute, that NOTHING was. ``real_create_run=True`` lets the REAL ``create_run``
+    write this turn's ChatRunDoc: that is what makes "a paused turn creates no run
+    doc" a proof rather than a tautology, because the same call with the bot
+    un-paused demonstrably DOES write one.
+    """
+    from pocketpaw_ee.cloud.chat.runs.memory_stream import InMemoryStreamTransport
+
+    transport = InMemoryStreamTransport()
+    fake_exec = _FakeExecutor(transport)
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.chat.runs.transport.get_stream_transport", lambda: transport
+    )
+    monkeypatch.setattr("pocketpaw_ee.cloud.chat.runs.executor.get_executor", lambda: fake_exec)
+
+    if not real_create_run:
+
+        async def _fake_create_run(spec):
+            return SimpleNamespace(run_id=spec.run_id)
+
+        monkeypatch.setattr("pocketpaw_ee.cloud.chat.runs.service.create_run", _fake_create_run)
+    return fake_exec
+
+
+def _chat_payload(widget_id: str, **ov) -> dict:
+    p = dict(
+        widget_id=widget_id,
+        signed_key=_KEY,
+        customer_ref=_REF,
+        message="Are you there?",
+    )
+    p.update(ov)
+    return p
+
+
+def _poll_params(**ov) -> dict:
+    p = dict(signed_key=_KEY)
+    p.update(ov)
+    return p
+
+
+async def _paused_conversation(store, widget_id: str, workspace_id: str = "ws-1"):
+    """A conversation an owner has taken over, the state the mute reads."""
+    await store.upsert_conversation_on_visitor_turn(widget_id, _REF, workspace_id)
+    return await store.update_conversation(
+        widget_id,
+        _REF,
+        workspace_id=workspace_id,
+        bot_paused=True,
+        last_owner_at=datetime.now().isoformat(),
+    )
+
+
+def _age_the_pause(store, widget_id: str, hours: int, workspace_id: str = "ws-1"):
+    """Backdate a mute so the idle window has (or hasn't) elapsed."""
+    stamp = (datetime.now() - timedelta(hours=hours)).isoformat()
+    return store.update_conversation(
+        widget_id,
+        _REF,
+        workspace_id=workspace_id,
+        bot_paused_at=stamp,
+        last_owner_at=stamp,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Layer 1 — the owner's reply
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_reply_persists_pauses_and_clears_unread(client):
+    """One call does all of it: the line lands, the bot mutes, the badge clears."""
+    c, store = client
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    await _mk_run()
+    await store.upsert_conversation_on_visitor_turn(widget.id, _REF, "ws-1")
+
+    res = await c.post(
+        f"/paw-bar/admin/site/{site.id}/conversations/{_REF}/reply",
+        json={"text": "  Hi! I'm Maya, I can help.  "},
+    )
+
+    assert res.status_code == 200
+    body = res.json()
+    assert body["ok"] is True
+    # The echo is a transcript message — the shape the thread already renders.
+    assert body["message"] == {
+        "role": "owner",
+        "content": "Hi! I'm Maya, I can help.",
+        "created_at": body["message"]["created_at"],
+    }
+    assert body["message"]["created_at"]
+    row = body["conversation"]
+    assert row["bot_paused"] is True
+    assert row["bot_paused_at"], "the mute is stamped, or the idle clock never starts"
+    assert row["last_owner_at"]
+    assert row["unread_for_owner"] == 0
+
+    stored = await store.list_owner_messages(widget.id, _REF, workspace_id="ws-1")
+    assert [(m.role.value, m.content, m.author) for m in stored] == [
+        ("owner", "Hi! I'm Maya, I can help.", "u1")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_reply_never_creates_a_run_doc(client):
+    """An owner reply is not agent compute: no ChatRunDoc, so the metering sweeper
+    can never bill the owner for typing their own sentence."""
+    c, store = client
+    site = await _site()
+    await store.create_widget(_widget())
+    await _mk_run()
+    before = await _run_count()
+
+    res = await c.post(
+        f"/paw-bar/admin/site/{site.id}/conversations/{_REF}/reply", json={"text": "On it."}
+    )
+
+    assert res.status_code == 200
+    assert await _run_count() == before
+
+
+@pytest.mark.parametrize("filed", ["closed", "snoozed"])
+@pytest.mark.asyncio
+async def test_reply_reopens_a_filed_conversation(client, filed):
+    """An owner replying is engagement — a filed thread comes back to the queue."""
+    c, store = client
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    await _mk_run()
+    await store.upsert_conversation_on_visitor_turn(widget.id, _REF, "ws-1")
+    await store.update_conversation(
+        widget.id,
+        _REF,
+        workspace_id="ws-1",
+        state=filed,
+        snooze_until=(datetime.now() + timedelta(hours=2)).isoformat(),
+    )
+
+    res = await c.post(
+        f"/paw-bar/admin/site/{site.id}/conversations/{_REF}/reply", json={"text": "Sorry — here!"}
+    )
+
+    assert res.status_code == 200
+    assert res.json()["conversation"]["state"] == "open"
+    assert res.json()["conversation"]["snooze_until"] == ""
+
+
+@pytest.mark.asyncio
+async def test_reply_on_a_needs_human_thread_keeps_that_state(client):
+    """needs_human is the top of the queue; replying doesn't demote it."""
+    c, store = client
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    await _mk_run()
+    await store.upsert_conversation_on_visitor_turn(widget.id, _REF, "ws-1")
+    await store.update_conversation(widget.id, _REF, workspace_id="ws-1", state="needs_human")
+
+    res = await c.post(
+        f"/paw-bar/admin/site/{site.id}/conversations/{_REF}/reply", json={"text": "Looking now."}
+    )
+
+    assert res.json()["conversation"]["state"] == "needs_human"
+
+
+@pytest.mark.asyncio
+async def test_reply_mints_a_row_for_a_legacy_conversation(client):
+    """A conversation that predates the state table is replyable — the row is minted
+    on the first owner action rather than 404ing."""
+    c, store = client
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    await _mk_run()  # runs exist, no state row
+
+    res = await c.post(
+        f"/paw-bar/admin/site/{site.id}/conversations/{_REF}/reply", json={"text": "Hello!"}
+    )
+
+    assert res.status_code == 200
+    assert (await store.get_conversation(widget.id, _REF, "ws-1")).bot_paused is True
+
+
+@pytest.mark.parametrize("text", ["", "   ", "\n\t "])
+@pytest.mark.asyncio
+async def test_reply_refuses_empty_text(client, text):
+    c, store = client
+    site = await _site()
+    await store.create_widget(_widget())
+    await _mk_run()
+    res = await c.post(
+        f"/paw-bar/admin/site/{site.id}/conversations/{_REF}/reply", json={"text": text}
+    )
+    assert res.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_reply_refuses_an_oversized_message(client):
+    """Refused, never silently truncated — a customer-facing sentence that ends
+    mid-word without anyone saying so is worse than an error the owner can act on."""
+    c, store = client
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    await _mk_run()
+    res = await c.post(
+        f"/paw-bar/admin/site/{site.id}/conversations/{_REF}/reply", json={"text": "x" * 4001}
+    )
+    assert res.status_code == 422
+    assert await store.list_owner_messages(widget.id, _REF) == []
+
+
+@pytest.mark.asyncio
+async def test_reply_to_an_unknown_ref_is_404(client):
+    """A ref with no concierge runs here isn't a conversation, it's a guess."""
+    c, store = client
+    site = await _site()
+    await store.create_widget(_widget())
+    res = await c.post(
+        f"/paw-bar/admin/site/{site.id}/conversations/cust-9999/reply", json={"text": "hi"}
+    )
+    assert res.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_reply_refuses_a_malformed_ref(client):
+    c, store = client
+    site = await _site()
+    await store.create_widget(_widget())
+    res = await c.post(f"/paw-bar/admin/site/{site.id}/conversations/no/reply", json={"text": "hi"})
+    assert res.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_reply_requires_an_admin_role(mongo_db, store, monkeypatch):
+    site = await _site()
+    await store.create_widget(_widget())
+    await _mk_run()
+    app = _build_app(store, monkeypatch, role="member")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        res = await c.post(
+            f"/paw-bar/admin/site/{site.id}/conversations/{_REF}/reply", json={"text": "hi"}
+        )
+    assert res.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_reply_is_cross_workspace_refused(mongo_db, store, monkeypatch):
+    """A ws-2 admin cannot answer a ws-1 visitor — the site 404s first."""
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    await _mk_run()
+    await store.upsert_conversation_on_visitor_turn(widget.id, _REF, "ws-1")
+
+    app = _build_app(store, monkeypatch, role="admin", workspace_id="ws-2")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        res = await c.post(
+            f"/paw-bar/admin/site/{site.id}/conversations/{_REF}/reply", json={"text": "hi"}
+        )
+
+    assert res.status_code == 404
+    assert await store.list_owner_messages(widget.id, _REF) == []
+    assert (await store.get_conversation(widget.id, _REF, "ws-1")).bot_paused is False
+
+
+# --------------------------------------------------------------------------- #
+# Layer 2 — THE MUTE. The bot does not talk over a human.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_paused_visitor_turn_emits_human_replying_and_dispatches_nothing(public, monkeypatch):
+    """THE centrepiece. A visitor typing into a taken-over conversation gets a
+    distinct non-answer frame — never a bot reply, never an empty stream — and the
+    turn dispatches no run at all."""
+    c, store = public
+    await _site()
+    widget = await store.create_widget(_widget())
+    # The REAL create_run — an un-paused turn through this exact path writes a run
+    # doc (the control test below proves it), so "none was written" means the mute
+    # stopped it, not that the test stubbed it away.
+    fake_exec = _stub_run_dispatch(monkeypatch, real_create_run=True)
+    await _paused_conversation(store, widget.id)
+    before = await _run_count()
+
+    res = await c.post("/paw-bar/chat", json=_chat_payload(widget.id), headers={"Origin": _ORIGIN})
+
+    assert res.status_code == 200
+    body = res.text
+    assert "event: human_replying" in body
+    assert '"message": "Someone from the team is replying' in body
+    assert "event: stream_end" in body
+    # No bot voice, in any form.
+    assert "event: chunk" not in body
+    assert "event: message.persisted" not in body
+    # THE BILLING-SAFETY PROOF: no run doc was created, so the metering sweeper
+    # (which bills every unbilled terminal run) has nothing to charge for a turn
+    # the agent never took.
+    assert await _run_count() == before
+    assert fake_exec.submitted == [], "no run was dispatched to the executor"
+
+
+@pytest.mark.asyncio
+async def test_an_unpaused_turn_does_create_a_run_doc(public, monkeypatch):
+    """The control for the proof above: the same call, the same real create_run,
+    with the bot un-paused — one run doc. Without this, 'no run doc' proves nothing."""
+    c, store = public
+    await _site()
+    widget = await store.create_widget(_widget())
+    _stub_run_dispatch(monkeypatch, real_create_run=True)
+    before = await _run_count()
+
+    await c.post("/paw-bar/chat", json=_chat_payload(widget.id), headers={"Origin": _ORIGIN})
+
+    assert await _run_count() == before + 1
+
+
+@pytest.mark.asyncio
+async def test_paused_turn_keeps_the_visitor_line_and_escalates(public, monkeypatch):
+    """The owner must be able to READ what the visitor said while they were typing,
+    and the thread must show that someone is waiting on a person."""
+    c, store = public
+    await _site()
+    widget = await store.create_widget(_widget())
+    _stub_run_dispatch(monkeypatch)
+    await _paused_conversation(store, widget.id)
+
+    await c.post(
+        "/paw-bar/chat",
+        json=_chat_payload(widget.id, message="Is anyone there?"),
+        headers={"Origin": _ORIGIN},
+    )
+
+    stored = await store.list_owner_messages(widget.id, _REF, workspace_id="ws-1")
+    assert [(m.role.value, m.content) for m in stored] == [("visitor", "Is anyone there?")]
+    conversation = await store.get_conversation(widget.id, _REF, "ws-1")
+    assert conversation.state is ConversationState.NEEDS_HUMAN
+    assert conversation.unread_for_owner == 2, "the visitor's new message is unread"
+
+
+@pytest.mark.asyncio
+async def test_paused_turn_honours_the_retention_toggle(public, monkeypatch):
+    """Muting is not a back door around the owner's privacy choice: with transcript
+    storage off, the visitor's line is not kept here either."""
+    c, store = public
+    await _site(concierge_store_transcripts=False)
+    widget = await store.create_widget(_widget())
+    _stub_run_dispatch(monkeypatch)
+    await _paused_conversation(store, widget.id)
+
+    res = await c.post("/paw-bar/chat", json=_chat_payload(widget.id), headers={"Origin": _ORIGIN})
+
+    assert "event: human_replying" in res.text
+    assert await store.list_owner_messages(widget.id, _REF, workspace_id="ws-1") == []
+    # The escalation still happens — that is metadata, not content.
+    assert (
+        await store.get_conversation(widget.id, _REF, "ws-1")
+    ).state is ConversationState.NEEDS_HUMAN
+
+
+@pytest.mark.asyncio
+async def test_unpaused_visitor_turn_still_gets_the_bot(public, monkeypatch):
+    """The mute is the exception, not the rule: a normal conversation is untouched."""
+    c, store = public
+    await _site()
+    widget = await store.create_widget(_widget())
+    fake_exec = _stub_run_dispatch(monkeypatch)
+
+    res = await c.post("/paw-bar/chat", json=_chat_payload(widget.id), headers={"Origin": _ORIGIN})
+
+    assert "event: chunk" in res.text
+    assert "event: human_replying" not in res.text
+    assert len(fake_exec.submitted) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_mute_on_another_widget_does_not_mute_this_one(public, monkeypatch):
+    """The mute is keyed by (widget, visitor). A sibling site taking over its own
+    visitor of the same handle must not silence this site's bot."""
+    c, store = public
+    await _site()
+    widget = await store.create_widget(_widget())
+    fake_exec = _stub_run_dispatch(monkeypatch)
+    await store.upsert_conversation_on_visitor_turn("other-widget", _REF, "ws-2")
+    await store.update_conversation(
+        "other-widget",
+        _REF,
+        workspace_id="ws-2",
+        bot_paused=True,
+        last_owner_at=datetime.now().isoformat(),
+    )
+
+    res = await c.post("/paw-bar/chat", json=_chat_payload(widget.id), headers={"Origin": _ORIGIN})
+
+    assert "event: chunk" in res.text
+    assert len(fake_exec.submitted) == 1
+
+
+# --------------------------------------------------------------------------- #
+# Layer 3 — the visitor's poll
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_poll_returns_owner_and_system_lines_oldest_first(public):
+    c, store = public
+    await _site()
+    widget = await store.create_widget(_widget())
+    await store.add_owner_message(widget.id, _REF, "First", workspace_id="ws-1")
+    await store.add_owner_message(
+        widget.id, _REF, "Second", role=OwnerMessageRole.SYSTEM, workspace_id="ws-1"
+    )
+
+    res = await c.get(
+        f"/paw-bar/messages/{widget.id}/{_REF}",
+        params=_poll_params(),
+        headers={"Origin": _ORIGIN},
+    )
+
+    assert res.status_code == 200
+    body = res.json()
+    assert [(m["role"], m["content"]) for m in body["messages"]] == [
+        ("owner", "First"),
+        ("system", "Second"),
+    ]
+    assert body["bot_paused"] is False
+
+
+@pytest.mark.asyncio
+async def test_poll_response_keys_are_exactly_the_allowlist(public):
+    """The ONLY public read of a conversation. Its shape is the boundary: no notes,
+    no tags, no assignee, no contact_email, no queue state, no author."""
+    c, store = public
+    await _site()
+    widget = await store.create_widget(_widget())
+    await store.upsert_conversation_on_visitor_turn(widget.id, _REF, "ws-1")
+    await store.update_conversation(
+        widget.id,
+        _REF,
+        workspace_id="ws-1",
+        state="needs_human",
+        tags=["vip", "refund"],
+        note={"author": "u1", "text": "known chargeback risk", "at": ""},
+        contact_email="visitor@example.com",
+        assignee="u1",
+        bot_paused=True,
+        last_owner_at=datetime.now().isoformat(),
+    )
+    await store.add_owner_message(widget.id, _REF, "On it", author="u1", workspace_id="ws-1")
+
+    res = await c.get(
+        f"/paw-bar/messages/{widget.id}/{_REF}",
+        params=_poll_params(),
+        headers={"Origin": _ORIGIN},
+    )
+
+    body = res.json()
+    assert set(body) == {"messages", "bot_paused"}
+    assert set(body["messages"][0]) == {"role", "content", "at"}
+    # None of the owner-only data appears anywhere in the serialized response.
+    raw = res.text
+    for leak in ("vip", "refund", "chargeback", "visitor@example.com", "needs_human", "u1"):
+        assert leak not in raw, f"{leak!r} leaked to a public read"
+
+
+@pytest.mark.asyncio
+async def test_poll_never_echoes_the_visitors_own_line(public):
+    """A muted-turn visitor line lives in the same table; the visitor already has
+    their own words, and a public read that serves stored visitor content is one
+    bug away from serving someone else's."""
+    c, store = public
+    await _site()
+    widget = await store.create_widget(_widget())
+    await store.add_owner_message(
+        widget.id, _REF, "my own question", role=OwnerMessageRole.VISITOR, workspace_id="ws-1"
+    )
+    await store.add_owner_message(widget.id, _REF, "the answer", workspace_id="ws-1")
+
+    res = await c.get(
+        f"/paw-bar/messages/{widget.id}/{_REF}",
+        params=_poll_params(),
+        headers={"Origin": _ORIGIN},
+    )
+
+    assert [m["content"] for m in res.json()["messages"]] == ["the answer"]
+
+
+@pytest.mark.asyncio
+async def test_poll_after_is_strictly_greater_than(public):
+    c, store = public
+    await _site()
+    widget = await store.create_widget(_widget())
+    first = await store.add_owner_message(widget.id, _REF, "one", workspace_id="ws-1")
+    await store.add_owner_message(widget.id, _REF, "two", workspace_id="ws-1")
+
+    res = await c.get(
+        f"/paw-bar/messages/{widget.id}/{_REF}",
+        params=_poll_params(after=first.created_at),
+        headers={"Origin": _ORIGIN},
+    )
+
+    assert [m["content"] for m in res.json()["messages"]] == ["two"]
+
+
+@pytest.mark.asyncio
+async def test_poll_accepts_a_javascript_style_cursor(public):
+    """A browser round-trips the timestamp through Date.toISOString() and hands
+    back a '…Z' spelling. Compared raw, 'Z' sorts after a fractional second and the
+    poll would skip the very message it just delivered."""
+    c, store = public
+    await _site()
+    widget = await store.create_widget(_widget())
+    first = await store.add_owner_message(widget.id, _REF, "one", workspace_id="ws-1")
+    await store.add_owner_message(widget.id, _REF, "two", workspace_id="ws-1")
+    js_cursor = (
+        datetime.fromisoformat(first.created_at).astimezone(UTC).isoformat().replace("+00:00", "Z")
+    )
+
+    res = await c.get(
+        f"/paw-bar/messages/{widget.id}/{_REF}",
+        params=_poll_params(after=js_cursor),
+        headers={"Origin": _ORIGIN},
+    )
+
+    assert [m["content"] for m in res.json()["messages"]] == ["two"]
+
+
+@pytest.mark.asyncio
+async def test_poll_ignores_a_malformed_cursor(public):
+    """A bad cursor costs a duplicate render, never a stalled thread."""
+    c, store = public
+    await _site()
+    widget = await store.create_widget(_widget())
+    await store.add_owner_message(widget.id, _REF, "one", workspace_id="ws-1")
+
+    res = await c.get(
+        f"/paw-bar/messages/{widget.id}/{_REF}",
+        params=_poll_params(after="not-a-timestamp"),
+        headers={"Origin": _ORIGIN},
+    )
+
+    assert res.status_code == 200
+    assert [m["content"] for m in res.json()["messages"]] == ["one"]
+
+
+@pytest.mark.asyncio
+async def test_poll_caps_the_page(public):
+    c, store = public
+    await _site()
+    widget = await store.create_widget(_widget())
+    for i in range(55):
+        await store.add_owner_message(widget.id, _REF, f"line {i}", workspace_id="ws-1")
+
+    res = await c.get(
+        f"/paw-bar/messages/{widget.id}/{_REF}",
+        params=_poll_params(),
+        headers={"Origin": _ORIGIN},
+    )
+
+    messages = res.json()["messages"]
+    assert len(messages) == 50
+    # The newest window, still oldest-first inside it.
+    assert messages[0]["content"] == "line 5"
+    assert messages[-1]["content"] == "line 54"
+
+
+@pytest.mark.asyncio
+async def test_poll_reports_the_mute(public):
+    c, store = public
+    await _site()
+    widget = await store.create_widget(_widget())
+    await _paused_conversation(store, widget.id)
+
+    res = await c.get(
+        f"/paw-bar/messages/{widget.id}/{_REF}",
+        params=_poll_params(),
+        headers={"Origin": _ORIGIN},
+    )
+
+    assert res.json()["bot_paused"] is True
+
+
+@pytest.mark.asyncio
+async def test_poll_does_not_cross_to_a_sibling_visitor(public):
+    """Another visitor's thread on the same widget never appears in this one."""
+    c, store = public
+    await _site()
+    widget = await store.create_widget(_widget())
+    await store.add_owner_message(widget.id, "cust-0002", "not yours", workspace_id="ws-1")
+    await store.add_owner_message(widget.id, _REF, "yours", workspace_id="ws-1")
+
+    res = await c.get(
+        f"/paw-bar/messages/{widget.id}/{_REF}",
+        params=_poll_params(),
+        headers={"Origin": _ORIGIN},
+    )
+
+    assert [m["content"] for m in res.json()["messages"]] == ["yours"]
+
+
+@pytest.mark.asyncio
+async def test_poll_malformed_ref_is_400(public):
+    c, store = public
+    await _site()
+    widget = await store.create_widget(_widget())
+    res = await c.get(
+        f"/paw-bar/messages/{widget.id}/no",
+        params=_poll_params(),
+        headers={"Origin": _ORIGIN},
+    )
+    assert res.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_poll_unknown_widget_is_404(public):
+    c, _store = public
+    await _site()
+    res = await c.get(
+        f"/paw-bar/messages/nope/{_REF}", params=_poll_params(), headers={"Origin": _ORIGIN}
+    )
+    assert res.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_poll_rate_limit_is_429(public):
+    c, store = public
+    await _site()
+    widget = await store.create_widget(_widget(rate_limit_per_min=2))
+    for _ in range(2):
+        await store.record_event(
+            PawBarEvent(widget_id=widget.id, type="concierge_message", customer_ref=_REF)
+        )
+    res = await c.get(
+        f"/paw-bar/messages/{widget.id}/{_REF}",
+        params=_poll_params(),
+        headers={"Origin": _ORIGIN},
+    )
+    assert res.status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_poll_bad_key_is_401(public):
+    c, store = public
+    await _site()
+    widget = await store.create_widget(_widget())
+    res = await c.get(
+        f"/paw-bar/messages/{widget.id}/{_REF}",
+        params=_poll_params(signed_key="short"),
+        headers={"Origin": _ORIGIN},
+    )
+    assert res.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_poll_wrong_origin_is_403(public):
+    c, store = public
+    await _site()
+    widget = await store.create_widget(_widget())
+    res = await c.get(
+        f"/paw-bar/messages/{widget.id}/{_REF}",
+        params=_poll_params(),
+        headers={"Origin": "https://evil.example"},
+    )
+    assert res.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_poll_widget_bound_to_a_sibling_pocket_is_403(public):
+    """A key for pocket A must not drive a widget for pocket B."""
+    c, store = public
+    await _site()
+    widget = await store.create_widget(_widget(pocket_id="pocket-2"))
+    res = await c.get(
+        f"/paw-bar/messages/{widget.id}/{_REF}",
+        params=_poll_params(),
+        headers={"Origin": _ORIGIN},
+    )
+    assert res.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_poll_from_our_own_frame_without_an_origin_header(public):
+    """Same-origin GETs carry no Origin header — the frame's own poll must work, or
+    the visitor never sees the owner's reply (found live on the 2026-07-30 rig)."""
+    c, store = public
+    await _site()
+    widget = await store.create_widget(_widget())
+    await store.add_owner_message(widget.id, _REF, "hello", workspace_id="ws-1")
+
+    res = await c.get(
+        f"/paw-bar/messages/{widget.id}/{_REF}",
+        params=_poll_params(),
+        headers={"Sec-Fetch-Site": "same-origin"},
+    )
+
+    assert res.status_code == 200
+    assert [m["content"] for m in res.json()["messages"]] == ["hello"]
+
+
+@pytest.mark.asyncio
+async def test_poll_is_cross_workspace_scoped(public, monkeypatch):
+    """A row stamped with a foreign tenant never surfaces on this key's poll."""
+    c, store = public
+    await _site()
+    widget = await store.create_widget(_widget())
+    await store.add_owner_message(widget.id, _REF, "foreign", workspace_id="ws-2")
+    await store.add_owner_message(widget.id, _REF, "ours", workspace_id="ws-1")
+
+    res = await c.get(
+        f"/paw-bar/messages/{widget.id}/{_REF}",
+        params=_poll_params(),
+        headers={"Origin": _ORIGIN},
+    )
+
+    assert [m["content"] for m in res.json()["messages"]] == ["ours"]
+
+
+# --------------------------------------------------------------------------- #
+# Layer 4 — idle auto-resume (4h, computed on read)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_an_idle_mute_reads_as_unpaused(store):
+    """No sweeper: the row itself reports the hand-back the moment it is due."""
+    await _paused_conversation(store, "w1")
+    assert (await store.get_conversation("w1", _REF, "ws-1")).bot_paused is True
+
+    await _age_the_pause(store, "w1", BOT_PAUSE_IDLE_HOURS + 1)
+
+    assert (await store.get_conversation("w1", _REF, "ws-1")).bot_paused is False
+
+
+@pytest.mark.asyncio
+async def test_a_fresh_mute_does_not_resume(store):
+    """The guard must not fire while the owner is mid-conversation."""
+    await _paused_conversation(store, "w1")
+    await _age_the_pause(store, "w1", BOT_PAUSE_IDLE_HOURS - 1)
+
+    assert (await store.get_conversation("w1", _REF, "ws-1")).bot_paused is True
+    assert await store.auto_resume_bot_if_idle("w1", _REF, "ws-1") is None
+
+
+@pytest.mark.asyncio
+async def test_auto_resume_writes_one_system_message(store):
+    """The thread explains itself — and says it once, however many readers race."""
+    await _paused_conversation(store, "w1")
+    await _age_the_pause(store, "w1", BOT_PAUSE_IDLE_HOURS + 1)
+
+    first = await store.auto_resume_bot_if_idle("w1", _REF, "ws-1")
+    second = await store.auto_resume_bot_if_idle("w1", _REF, "ws-1")
+
+    assert first is not None
+    assert first.role is OwnerMessageRole.SYSTEM
+    assert first.content == BOT_RESUME_SYSTEM_MESSAGE
+    assert second is None
+    lines = await store.list_owner_messages("w1", _REF, workspace_id="ws-1")
+    assert [m.content for m in lines] == [BOT_RESUME_SYSTEM_MESSAGE]
+    stored = await store.get_conversation("w1", _REF, "ws-1")
+    assert stored.bot_paused is False
+    assert stored.bot_paused_at == ""
+
+
+@pytest.mark.asyncio
+async def test_owner_activity_restarts_the_idle_clock(client):
+    """Replying again is owner activity — the window measures from the last one."""
+    c, store = client
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    await _mk_run()
+    await _paused_conversation(store, widget.id)
+    await _age_the_pause(store, widget.id, BOT_PAUSE_IDLE_HOURS + 1)
+
+    await c.post(
+        f"/paw-bar/admin/site/{site.id}/conversations/{_REF}/reply",
+        json={"text": "Still here."},
+    )
+
+    assert (await store.get_conversation(widget.id, _REF, "ws-1")).bot_paused is True
+
+
+@pytest.mark.asyncio
+async def test_the_bot_answers_again_after_the_idle_window(public, monkeypatch):
+    """End to end: the visitor who comes back after 4h of silence gets the bot, and
+    the thread carries the line explaining why."""
+    c, store = public
+    await _site()
+    widget = await store.create_widget(_widget())
+    fake_exec = _stub_run_dispatch(monkeypatch)
+    await _paused_conversation(store, widget.id)
+    await _age_the_pause(store, widget.id, BOT_PAUSE_IDLE_HOURS + 1)
+
+    res = await c.post("/paw-bar/chat", json=_chat_payload(widget.id), headers={"Origin": _ORIGIN})
+
+    assert "event: chunk" in res.text
+    assert "event: human_replying" not in res.text
+    assert len(fake_exec.submitted) == 1
+    system = [
+        m
+        for m in await store.list_owner_messages(widget.id, _REF, workspace_id="ws-1")
+        if m.role is OwnerMessageRole.SYSTEM
+    ]
+    assert [m.content for m in system] == [BOT_RESUME_SYSTEM_MESSAGE]
+
+
+@pytest.mark.asyncio
+async def test_the_poll_agrees_with_chat_about_an_expired_mute(public):
+    """Both surfaces apply the same rule, so the visitor is never told a human is
+    replying by one endpoint and served a bot by the other."""
+    c, store = public
+    await _site()
+    widget = await store.create_widget(_widget())
+    await _paused_conversation(store, widget.id)
+    await _age_the_pause(store, widget.id, BOT_PAUSE_IDLE_HOURS + 1)
+
+    res = await c.get(
+        f"/paw-bar/messages/{widget.id}/{_REF}",
+        params=_poll_params(),
+        headers={"Origin": _ORIGIN},
+    )
+
+    body = res.json()
+    assert body["bot_paused"] is False
+    assert [m["content"] for m in body["messages"]] == [BOT_RESUME_SYSTEM_MESSAGE]
+
+
+# --------------------------------------------------------------------------- #
+# Layer 5 — the merged transcript
+# --------------------------------------------------------------------------- #
+
+
+async def _transcript(c, site_id: str) -> list[tuple[str, str]]:
+    res = await c.get(f"/paw-bar/admin/site/{site_id}/conversations/{_REF}")
+    assert res.status_code == 200
+    return [(m["role"], m["content"]) for m in res.json()["messages"]]
+
+
+@pytest.mark.asyncio
+async def test_transcript_interleaves_all_four_roles_by_timestamp(client):
+    """The whole value of this view is seeing WHEN the human stepped in relative to
+    what the bot had been saying."""
+    c, store = client
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    base = datetime.now(UTC) - timedelta(hours=1)
+    await _mk_run(
+        createdAt=base,
+        ended_at=base + timedelta(seconds=5),
+        user_text="Do you deliver?",
+        partial_text="We do!",
+    )
+
+    async def _line(offset_s: int, content: str, role):
+        message = await store.add_owner_message(
+            widget.id, _REF, content, role=role, workspace_id="ws-1"
+        )
+        # Rewrite the stamp so the ordering under test is deterministic rather
+        # than a race against wall-clock microseconds.
+        import aiosqlite
+
+        async with aiosqlite.connect(store._db_path) as db:
+            await db.execute(
+                "UPDATE paw_bar_owner_messages SET created_at = ? WHERE id = ?",
+                ((base + timedelta(seconds=offset_s)).isoformat(), message.id),
+            )
+            await db.commit()
+
+    await _line(10, "When?", OwnerMessageRole.VISITOR)
+    await _line(20, "Tomorrow — I'll sort it.", OwnerMessageRole.OWNER)
+    await _line(30, BOT_RESUME_SYSTEM_MESSAGE, OwnerMessageRole.SYSTEM)
+
+    assert await _transcript(c, str(site.id)) == [
+        ("user", "Do you deliver?"),
+        ("assistant", "We do!"),
+        ("user", "When?"),
+        ("owner", "Tomorrow — I'll sort it."),
+        ("system", BOT_RESUME_SYSTEM_MESSAGE),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_transcript_still_renders_an_assistant_only_thread(client):
+    """Landmine 3: a site with transcript storage off is a NORMAL state, and the
+    merge must not have made it a broken one."""
+    c, store = client
+    site = await _site(concierge_store_transcripts=False)
+    await store.create_widget(_widget())
+    await _mk_run(user_text="", partial_text="We open at 8.")
+
+    assert await _transcript(c, str(site.id)) == [("assistant", "We open at 8.")]
+
+
+@pytest.mark.asyncio
+async def test_transcript_messages_carry_no_ids(client):
+    """Landmine 4: run-derived messages have no id, so the DTO must not grow one —
+    half the thread could never satisfy it."""
+    c, store = client
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    await _mk_run()
+    await store.add_owner_message(widget.id, _REF, "hi", workspace_id="ws-1")
+
+    res = await c.get(f"/paw-bar/admin/site/{site.id}/conversations/{_REF}")
+
+    for message in res.json()["messages"]:
+        assert set(message) == {"role", "content", "created_at"}
+
+
+@pytest.mark.asyncio
+async def test_transcript_does_not_show_another_visitors_owner_lines(client):
+    c, store = client
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    await _mk_run()
+    await store.add_owner_message(widget.id, "cust-0002", "for someone else", workspace_id="ws-1")
+    await store.add_owner_message(widget.id, _REF, "for you", workspace_id="ws-1")
+
+    assert ("owner", "for someone else") not in await _transcript(c, str(site.id))
+    assert ("owner", "for you") in await _transcript(c, str(site.id))
+
+
+@pytest.mark.asyncio
+async def test_transcript_is_cross_workspace_refused(mongo_db, store, monkeypatch):
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    await _mk_run()
+    await store.add_owner_message(widget.id, _REF, "private", workspace_id="ws-1")
+
+    app = _build_app(store, monkeypatch, role="admin", workspace_id="ws-2")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        res = await c.get(f"/paw-bar/admin/site/{site.id}/conversations/{_REF}")
+
+    assert res.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_transcript_survives_an_owner_message_store_failure(client, monkeypatch):
+    """Best-effort on the new half: the run-derived transcript still renders."""
+    c, store = client
+    site = await _site()
+    await store.create_widget(_widget())
+    await _mk_run()
+
+    async def _boom(*_a, **_kw):
+        raise RuntimeError("sqlite is having a moment")
+
+    monkeypatch.setattr(store, "list_owner_messages", _boom)
+
+    assert await _transcript(c, str(site.id)) == [("assistant", "We open at 8.")]


### PR DESCRIPTION
Slice 2 of the Paw Bar owner inbox, stacked on #1822 (`feat/paw-bar-conversations`).

Slice 1 made the concierge log a queue. This makes it a place the owner can answer from, and makes the bot get out of the way when they do. A bot that keeps answering over a human is the loudest complaint in every review of every product in this class, so the muting is the part to read closely.

## What lands

**`POST /paw-bar/admin/site/{site_id}/conversations/{customer_ref}/reply`** — `{text}` → `{ok, message, conversation}`. One call stores the owner's line, mutes the bot, stamps `last_owner_at`, clears the unread counter, and reopens a closed or snoozed thread. Gated on `paw_bar.manage`, workspace-scoped at the same two seams as the PATCH. `message` is a `TranscriptMessage` (the shape the thread already renders); `conversation` is the same `ConversationRow` the PATCH echoes.

**The mute in `concierge_chat`** — checked before the run is created. A paused conversation gets no agent turn, nothing metered, no tool surface. The visitor's line is still kept (under the same retention toggle the run path honours), the thread moves to `needs_human`, and the response is exactly two SSE frames:

```
event: human_replying
data: {"message": "Someone from the team is replying — hang tight."}

event: stream_end
data: {"assistant_message_id": null, "cancelled": false}
```

Never an empty stream: the glass app reads clean-but-empty as "No reply.", so a muted bot would look like a broken one.

**`GET /paw-bar/messages/{widget_id}/{customer_ref}?signed_key=&after=`** — the visitor side, behind the same front gate as the articles listing (404 → 429 → 401 → 403) and the same `_request_origin` handling for same-origin GETs. Returns `{"messages": [{role, content, at}], "bot_paused": bool}` and nothing else. Notes, tags, assignee, captured email and queue state stay owner-only, and a visitor's own stored lines are not echoed back. A `…Z` cursor from `Date.toISOString()` is normalized before it is compared, or the poll would skip the message it just delivered.

**Idle auto-resume** — four hours, hard-coded. A mute with no owner activity for that long reads as un-paused everywhere, decided on read like the snooze expiry, so the chat endpoint and the poll can never disagree. Materialized with one conditional UPDATE plus a single system line explaining the hand-back.

**Transcript merge** — `GET .../conversations/{customer_ref}` interleaves both sources by timestamp. `TranscriptMessage.role` widens from `user|assistant` to `user|assistant|owner|system`, additively.

## Why owner turns are not run docs

`metering/sweeper.py::sweep_unbilled_runs` bills every unbilled terminal chat run. An owner reply shaped as one would charge the owner credits for typing their own sentence and appear in run analytics as agent compute that never happened. So they live in a new `paw_bar_owner_messages` table beside `paw_bar_conversations`, same additive-migration and workspace-scoping conventions. Timestamps there are aware UTC so they sort against `ChatRunDoc.createdAt` on one clock rather than drifting by the host's offset.

## Tests

`tests/cloud/test_paw_bar_takeover.py`, 49 tests. The centrepiece asserts a paused visitor turn emits `human_replying`, emits no chunk frames, dispatches nothing to the executor, and creates no `ChatRunDoc` — with the **real** `create_run` wired, and a paired control test proving the same call does create one when the bot is not paused. Otherwise "no run doc" would only be proving the test stubbed it away.

Also covered: the poll's exact key allowlist and every refusal code, `after` filtering including the JS-style cursor, the four-hour resume and its single system message, a fresh pause not resuming, all four roles interleaved by timestamp, an assistant-only thread still rendering, and cross-workspace refusal on every new surface.

Full paw-bar set: 411 passing (362 on the base). `ruff check`, `ruff format --check`, and both import-linter configs clean.

## Also in here

Two comments in `router.py` went stale when D5 shipped (#1821): a concierge run now reads `pocket:<site>` and `agent:<its own id>`, never `workspace:` or `user:`. Wording corrected. `_concierge_sources` still searches only the pocket scope, and that is right — a source has to be a link the visitor can open, which only the page sync's articles have.

The concierge concepts doc gains a "When a human takes over" section.

## Not in here

Handoffs, notifications, in-thread approval cards, and the frontend. `GET /paw-bar/admin/site/{id}/decisions` still returns no `customer_ref`, so a thread cannot yet attribute a pending action to the visitor it belongs to — that is slice 4's to add.
