### PR TITLE
A lost provision job no longer bricks the pocket forever

### DIFF
--- a/ee/pocketpaw_ee/cloud/models/site.py
+++ b/ee/pocketpaw_ee/cloud/models/site.py
@@ -203,6 +203,15 @@ class Site(TimestampedDocument):
     # one; status becomes ``provisioned`` only after migrate + deploy succeed, and
     # ``failed`` on error. Defaults "none" for static sites and pre-DP0 rows.
     provision_status: str = "none"
+    # When the CURRENT provisioning attempt started (UTC). Exists so the
+    # single-flight guard can be bounded: a job that is never consumed or dies
+    # without writing a terminal status would otherwise leave the doc
+    # ``provisioning`` forever and make every later publish of the pocket a
+    # silent no-op — an unpublishable pocket with no error to see. None on
+    # static sites and pre-existing rows; a row with no stamp is treated as
+    # stale, which is the safe direction (a redundant enqueue costs one
+    # idempotent job, a stuck guard costs every future publish).
+    provision_started_at: datetime | None = None
     # BC-9: per-site annual plan (the Webflow model — each published site has its
     # OWN recurring annual plan on a tier, distinct from the workspace plan).
     # ``plan_tier`` is the site-plan catalog key (basic | pro | business — see

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -2343,6 +2343,33 @@ def _schedule_site_knowledge_sync(site: _SiteDoc) -> None:
         )
 
 
+# How long a Site may sit in ``provision_status="provisioning"`` before a new
+# publish stops treating it as in-flight. A real dynamic provision (D1 create,
+# migration, build, deploy) has been measured at ~5 minutes, so this is generous;
+# it exists purely so a job that was never consumed or died mid-flight cannot
+# brick the pocket permanently.
+_PROVISION_STALE_AFTER = timedelta(minutes=30)
+
+
+def _provisioning_is_stale(doc: Any) -> bool:
+    """True when a ``provisioning`` Site's last update is older than the window.
+
+    Missing/unreadable timestamps read as STALE: a doc we cannot date is far more
+    likely to be a leftover than a live job, and the failure modes are asymmetric
+    — a redundant enqueue costs one idempotent job, while a stuck guard costs the
+    pocket every future publish.
+    """
+    stamp = getattr(doc, "provision_started_at", None)
+    if stamp is None:
+        return True
+    try:
+        if stamp.tzinfo is None:
+            stamp = stamp.replace(tzinfo=UTC)
+        return datetime.now(UTC) - stamp > _PROVISION_STALE_AFTER
+    except (AttributeError, TypeError, ValueError):
+        return True
+
+
 async def _provision_dynamic_site(
     *,
     workspace_id: str,
@@ -2384,9 +2411,28 @@ async def _provision_dynamic_site(
     # SINGLE-FLIGHT: a publish while the site is already provisioning must not enqueue
     # a second job — return the in-progress provisioning response as a no-op. (We do
     # not resolve the in-flight job id here; the caller can poll the site's status.)
+    #
+    # BOUNDED, because an unbounded guard is a trap. If the job is never consumed
+    # (no worker running) or dies without writing a terminal status, the doc stays
+    # "provisioning" forever and EVERY later publish of that pocket is silently a
+    # no-op — the pocket becomes permanently unpublishable with no error anywhere
+    # to see. Two sites on the rig were bricked exactly this way (2026-07-31).
+    # After the stale window we treat the previous attempt as lost and fall through
+    # to enqueue a fresh one: a genuinely in-flight job is far shorter than this,
+    # and the job is idempotent (the D1 id is persisted before the build and reused
+    # on retry).
     if doc is not None and doc.provision_status == "provisioning":
-        doc._provision_job_id = None
-        return doc
+        if _provisioning_is_stale(doc):
+            logger.warning(
+                "sites: site %s has been provisioning since %s — treating that job "
+                "as lost and re-enqueueing, rather than no-op'ing every publish "
+                "of this pocket forever",
+                doc.id,
+                getattr(doc, "provision_started_at", None),
+            )
+        else:
+            doc._provision_job_id = None
+            return doc
 
     # Ensure the canonical doc exists in ``provisioning`` state. leave ``deployed`` /
     # ``url`` for the job to finalize; seed the same identity/capture fields the static
@@ -2403,6 +2449,7 @@ async def _provision_dynamic_site(
             url="",
             signed_key=signed_key,
             provision_status="provisioning",
+            provision_started_at=datetime.now(UTC),
             builder_origin=builder_origin or "",
             allowed_origins=_default_allowed_origins(),
             event_mapping=_DEFAULT_EVENT_MAPPING,
@@ -2422,6 +2469,7 @@ async def _provision_dynamic_site(
         doc.deployed = False
         doc.url = ""
         doc.provision_status = "provisioning"
+        doc.provision_started_at = datetime.now(UTC)
         doc.pending_deploy_inputs = {}
         await doc.save()
 

--- a/tests/ee/sites/test_site_provision_status.py
+++ b/tests/ee/sites/test_site_provision_status.py
@@ -8,6 +8,8 @@
 # pure pydantic construction here.
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 from pocketpaw_ee.cloud.models.site import Site
 
 
@@ -42,3 +44,47 @@ def test_provision_status_accepts_documented_states() -> None:
     """The documented value set is none | provisioning | provisioned | failed."""
     for state in ("none", "provisioning", "provisioned", "failed"):
         assert _site(provision_status=state).provision_status == state
+
+
+class TestProvisioningStaleGuard:
+    """A lost provision job must not brick the pocket forever (rig, 2026-07-31).
+
+    The single-flight guard had no staleness bound, so a job that was never
+    consumed (no worker running) or died without a terminal status left the doc
+    in "provisioning" and made EVERY later publish of that pocket a silent
+    no-op. Two demo sites were stuck exactly this way.
+    """
+
+    def test_a_fresh_provisioning_doc_is_not_stale(self) -> None:
+        from datetime import UTC, datetime
+
+        from pocketpaw_ee.sites.service import _provisioning_is_stale
+
+        doc = SimpleNamespace(provision_started_at=datetime.now(UTC))
+        assert _provisioning_is_stale(doc) is False
+
+    def test_an_old_provisioning_doc_is_stale(self) -> None:
+        from datetime import UTC, datetime, timedelta
+
+        from pocketpaw_ee.sites.service import _PROVISION_STALE_AFTER, _provisioning_is_stale
+
+        old = datetime.now(UTC) - _PROVISION_STALE_AFTER - timedelta(minutes=1)
+        assert _provisioning_is_stale(SimpleNamespace(provision_started_at=old)) is True
+
+    def test_a_naive_timestamp_is_handled_not_crashed(self) -> None:
+        from datetime import datetime, timedelta
+
+        from pocketpaw_ee.sites.service import _PROVISION_STALE_AFTER, _provisioning_is_stale
+
+        naive_old = datetime.utcnow() - _PROVISION_STALE_AFTER - timedelta(minutes=1)
+        assert (
+            _provisioning_is_stale(SimpleNamespace(updated_at=naive_old, created_at=None)) is True
+        )
+
+    def test_an_undateable_doc_reads_as_stale(self) -> None:
+        from pocketpaw_ee.sites.service import _provisioning_is_stale
+
+        # Asymmetric failure modes: a redundant enqueue costs one idempotent job,
+        # a stuck guard costs the pocket every future publish.
+        assert _provisioning_is_stale(SimpleNamespace(provision_started_at=None)) is True
+        assert _provisioning_is_stale(SimpleNamespace(provision_started_at="not-a-date")) is True


### PR DESCRIPTION
The dynamic single-flight guard was unbounded: a job that was never consumed (no worker running) or died without a terminal status left the Site in `provisioning`, and every later publish of that pocket became a silent no-op returning 200 while doing nothing. Two demo sites were stuck exactly that way — showing as Draft and never rendering, which is how it was found.

Sites now stamp `provision_started_at`, and a guard older than 30 minutes is treated as a lost attempt: log and re-enqueue. A real provision measures ~5 minutes, so the window is generous; an undateable row reads as stale because the failure modes are asymmetric — a redundant enqueue costs one idempotent job, a stuck guard costs every future publish.

557 sites tests pass (the one failure is the known pre-existing `test_site_billing` isolation flake, which passes alone); ruff and both import-linter configs clean.