### PR TITLE
fix(meetings): invite links for scheduled PawOS Call meetings

### DIFF
--- a/ee/pocketpaw_ee/cloud/livekit/invites.py
+++ b/ee/pocketpaw_ee/cloud/livekit/invites.py
@@ -123,7 +123,9 @@ async def validate_meeting_invite(token: str) -> dict[str, Any]:
             "This invite link has reached its maximum number of uses.",
         )
 
-    # Fetch the room info to confirm the call is still active.
+    # Fetch the room info to check if the call is currently active.
+    # For scheduled meetings the room may not exist yet — that's fine,
+    # the invite is still valid and the room will be created on join.
     from pocketpaw_ee.cloud.livekit.service import get_room_info
 
     room_info = await get_room_info(doc.group_id)
@@ -179,11 +181,17 @@ async def accept_meeting_invite(
             "This invite link has reached its maximum number of uses.",
         )
 
-    # Verify the call is still active.
-    from pocketpaw_ee.cloud.livekit.service import LIVEKIT_URL, get_room_info
+    # Ensure the LiveKit room exists — create it if this is a scheduled
+    # meeting where the room hasn't been started yet. If the room already
+    # exists and is inactive (call ended), reject.
+    from pocketpaw_ee.cloud.livekit.service import LIVEKIT_URL, create_room, get_room_info
 
     room_info = await get_room_info(doc.group_id)
-    if room_info is None or not room_info.get("active", False):
+    if room_info is None:
+        # Room doesn't exist yet — create it (scheduled meeting, guest is first to join)
+        logger.info("Creating LiveKit room for group %s (guest join via invite)", doc.group_id)
+        await create_room(doc.group_id)
+    elif not room_info.get("active", False):
         raise Forbidden(
             "meeting_invite.call_ended",
             "The call has ended. This invite is no longer valid.",

--- a/ee/pocketpaw_ee/cloud/meetings/providers/livekit/provider.py
+++ b/ee/pocketpaw_ee/cloud/meetings/providers/livekit/provider.py
@@ -31,6 +31,9 @@ class LiveKitProvider:
 
         Do NOT create the LiveKit room yet. Rooms are created lazily on
         start() so they don't accumulate for meetings that never happen.
+
+        join_url is left empty — the frontend generates a proper shareable
+        invite link via the /livekit/rooms/{group_id}/invite endpoint.
         """
         group_id = body.group_id
         if group_id:
@@ -40,11 +43,9 @@ class LiveKitProvider:
             room_name = f"meeting-{id(ctx)}"
             provider_payload = {"room_name": room_name}
 
-        join_url = f"pocketpaw://meetings/{body.title or 'call'}?join"
-
         return ProviderCreateResult(
             provider_payload=provider_payload,
-            join_url=join_url,
+            join_url="",
         )
 
     async def start(self, ctx: RequestContext, meeting) -> ProviderStartResult:


### PR DESCRIPTION
## What's in this PR

Follow-up fix to #1712 — makes invite links work for **scheduled** PawOS Call meetings (not just live ones).

### Problem
- The provider returned a hardcoded `pocketpaw://` `join_url`, so scheduled meetings had no real shareable link
- `accept_meeting_invite` required the LiveKit room to already exist and be active, so a guest joining a scheduled meeting (room not yet created) got rejected

### Changes
- **`livekit/provider.py`** — remove the hardcoded `pocketpaw://` join URL and return an empty string; the frontend generates a proper shareable invite via the `/livekit/rooms/{group_id}/invite` endpoint
- **`livekit/invites.py`**
  - `validate_meeting_invite`: a missing/inactive room is fine for scheduled meetings (invite stays valid; room is created on join)
  - `accept_meeting_invite`: auto-create the LiveKit room when it doesn't exist yet (scheduled meeting, first guest joins); only reject when the room **exists but is inactive** (call genuinely ended)

## Files changed
- `ee/pocketpaw_ee/cloud/livekit/invites.py`
- `ee/pocketpaw_ee/cloud/meetings/providers/livekit/provider.py`
