### PR TITLE
Point a concierge notification at the inbox, not a dead chat room

### DIFF
--- a/ee/pocketpaw_ee/cloud/models/notification.py
+++ b/ee/pocketpaw_ee/cloud/models/notification.py
@@ -15,6 +15,10 @@ class NotificationSource(BaseModel):
     id: str
     pocket_id: str | None = None
     room_id: str | None = None
+    # The agent this source belongs to, when it belongs to one. The concierge
+    # kinds set it: their inbox lives on an AGENT, so without it a client has
+    # no id to build a link from and falls back to the chat surface.
+    agent_id: str | None = None
 
 
 class Notification(TimestampedDocument):

--- a/ee/pocketpaw_ee/cloud/notifications/domain.py
+++ b/ee/pocketpaw_ee/cloud/notifications/domain.py
@@ -32,6 +32,7 @@ class NotificationSource:
     id: str
     pocket_id: str | None = None
     room_id: str | None = None
+    agent_id: str | None = None
 
 
 @dataclass(frozen=True)

--- a/ee/pocketpaw_ee/cloud/notifications/dto.py
+++ b/ee/pocketpaw_ee/cloud/notifications/dto.py
@@ -27,6 +27,7 @@ class NotificationOut(BaseModel):
     source_type: str | None = None
     source_pocket_id: str | None = None
     source_room_id: str | None = None
+    source_agent_id: str | None = None
     read: bool
     created_at: str | None
     actor_id: str | None = None
@@ -45,6 +46,7 @@ def notification_to_dto(n: Notification) -> NotificationOut:
         source_type=n.source.type if n.source else None,
         source_pocket_id=n.source.pocket_id if n.source else None,
         source_room_id=n.source.room_id if n.source else None,
+        source_agent_id=n.source.agent_id if n.source else None,
         read=n.read,
         created_at=iso_utc(n.created_at),
         actor_id=n.actor_id,

--- a/ee/pocketpaw_ee/cloud/notifications/service.py
+++ b/ee/pocketpaw_ee/cloud/notifications/service.py
@@ -63,7 +63,11 @@ def _source_to_domain(
     if src is None:
         return None
     return NotificationSource(
-        type=src.type, id=src.id, pocket_id=src.pocket_id, room_id=src.room_id
+        type=src.type,
+        id=src.id,
+        pocket_id=src.pocket_id,
+        room_id=src.room_id,
+        agent_id=getattr(src, "agent_id", None),
     )
 
 
@@ -76,7 +80,11 @@ def _source_to_doc(
     if isinstance(src, _NotificationSourceDoc):
         return src
     return _NotificationSourceDoc(
-        type=src.type, id=src.id, pocket_id=src.pocket_id, room_id=src.room_id
+        type=src.type,
+        id=src.id,
+        pocket_id=src.pocket_id,
+        room_id=src.room_id,
+        agent_id=getattr(src, "agent_id", None),
     )
 
 

--- a/ee/pocketpaw_ee/paw_bar/notify.py
+++ b/ee/pocketpaw_ee/paw_bar/notify.py
@@ -39,7 +39,9 @@ NOTIFY_VISITOR_REPLY = "paw_bar_visitor_reply"
 # The notification source ``type``, with ``id`` = "<widget_id>:<customer_ref>" —
 # the exact pair the owner inbox is keyed by, so a click can resolve the thread.
 # A compound id rather than borrowing ``pocket_id``/``room_id`` for something
-# they don't mean.
+# they don't mean. The source ALSO carries ``agent_id``: the compound id names
+# the conversation, but a client still needs somewhere to open it, and the
+# concierge inbox lives on an agent rather than in a chat room.
 NOTIFY_SOURCE_TYPE = "paw_bar_conversation"
 
 # How much of a visitor's line rides along as the notification body. Enough to
@@ -91,6 +93,32 @@ async def resolve_workspace_owner(workspace_id: str) -> str:
         return ""
 
 
+async def resolve_widget_agent(widget_id: str, workspace_id: str = "") -> str:
+    """The concierge agent bound to a widget, or "" when there isn't one.
+
+    Resolved HERE rather than at each call site on purpose. The three producers
+    differ in what they hold — the new-conversation path has the widget object,
+    the handoff path only has its id — and a notification that silently omits the
+    agent is not a visible failure: it degrades to a link the owner can't follow,
+    which is precisely the bug this field exists to fix. One resolver means a
+    fourth producer cannot forget. Workspace-scoped like every other widget read.
+
+    Returns "" for every failure mode (no widget, unbound widget, store error),
+    all of which mean "no agent to link to" — a normal answer on this path.
+    """
+    if not widget_id:
+        return ""
+    try:
+        from pocketpaw.stores import get_paw_bar_store
+
+        store = get_paw_bar_store(workspace_id=workspace_id or None)
+        widget = await store.get_widget(widget_id, workspace_id=workspace_id or None)
+        return str(getattr(widget, "agent_id", "") or "") if widget is not None else ""
+    except Exception:  # noqa: BLE001 — notification routing is never load-bearing
+        logger.debug("widget agent lookup failed for %s", widget_id, exc_info=True)
+        return ""
+
+
 async def notify_workspace_owner(
     *,
     workspace_id: str,
@@ -99,6 +127,7 @@ async def notify_workspace_owner(
     body: str = "",
     widget_id: str = "",
     customer_ref: str = "",
+    agent_id: str = "",
 ) -> bool:
     """Notify the workspace owner about one conversation. Never raises.
 
@@ -110,6 +139,10 @@ async def notify_workspace_owner(
         recipient = await resolve_workspace_owner(workspace_id)
         if not recipient:
             return False
+
+        # Caller-supplied wins (it already holds the widget — no second read);
+        # otherwise resolve it, so no producer can omit it by forgetting.
+        agent_id = agent_id or await resolve_widget_agent(widget_id, workspace_id)
 
         from pocketpaw_ee.cloud.notifications import service as notifications_service
         from pocketpaw_ee.cloud.notifications.domain import NotificationSource
@@ -123,6 +156,15 @@ async def notify_workspace_owner(
             source=NotificationSource(
                 type=NOTIFY_SOURCE_TYPE,
                 id=f"{widget_id}:{customer_ref}",
+                # The bound concierge agent. The compound id above says WHICH
+                # conversation; this says where that conversation can be opened.
+                # Without it a client has no id to build a link from and falls
+                # back to the chat surface — which is exactly what happened:
+                # the click landed on /chat/<widget_id>:<customer_ref>, a room
+                # that cannot exist, and the empty default agent rendered.
+                # "" (an unbound or legacy widget) stays None, and the client
+                # degrades to the agents list rather than a dead room.
+                agent_id=agent_id or None,
             ),
         )
         return True
@@ -142,6 +184,7 @@ __all__ = [
     "NOTIFY_SOURCE_TYPE",
     "NOTIFY_VISITOR_REPLY",
     "notify_workspace_owner",
+    "resolve_widget_agent",
     "resolve_workspace_owner",
     "safe_preview",
 ]

--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -3722,6 +3722,9 @@ async def concierge_chat(body: ConciergeChatRequest, request: Request) -> Stream
             body=body.message,
             widget_id=body.widget_id,
             customer_ref=body.customer_ref,
+            # Passed rather than left to the resolver: the widget is already in
+            # hand here, and this await sits inside the visitor's turn.
+            agent_id=str(getattr(widget, "agent_id", "") or ""),
         )
 
     # (7c) THE MUTE. A human is holding this conversation, so the bot does not

--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -1,4 +1,15 @@
 # ee/paw_bar/router.py — HTTP surface for the Paw Bar widget layer.
+# Updated: 2026-07-31 (in-thread approvals) — the admin transcript now carries
+#   ``pending_actions`` (this visitor's still-PENDING decisions, mapped to the
+#   same DecisionItem shape the decisions tab serves) and ``bot_paused``, and
+#   DecisionItem gains ``customer_ref``. The dashboard's ConversationThread has
+#   had the approval card since slices 2+4, with TWO wire sources — transcript
+#   ``pending_actions`` preferred, decisions-list-filtered-by-ref as fallback —
+#   and this deployment served NEITHER, so a real approval sat behind the
+#   "approve it from Decisions" notice (found live 2026-07-31). Both new reads
+#   are failure-soft: a broken decisions read costs the thread its cards, never
+#   the transcript. Settled decisions stay absent from pending_actions on
+#   purpose — the card list is a to-do, not a log.
 # Updated: 2026-07-31 (owner inbox, slice 3) — THE ESCAPE HATCH. A visitor can
 #   always reach a person, and the owner is told when it happens:
 #     + POST /paw-bar/request-human — {key, w, customer_ref, message?, contact?}
@@ -1911,6 +1922,17 @@ class ConversationTranscriptResponse(BaseModel):
     customer_ref: str
     messages: list[TranscriptMessage] = Field(default_factory=list)
     count: int
+    # The Instinct proposals parked in THIS conversation, still waiting on a
+    # human (slice 4 — the in-thread approval card). The dashboard's thread
+    # prefers this over the site-wide decisions fallback because it is already
+    # scoped to one visitor: with neither source, the UI can only show the
+    # "approve it from Decisions" notice a real approval sat behind (found live
+    # 2026-07-31). Settled decisions are deliberately absent — an approved
+    # booking is history, and the card list is a to-do, not a log.
+    pending_actions: list[DecisionItem] = Field(default_factory=list)
+    # The conversation row's mute flag, so the thread's takeover banner state
+    # arrives with the SAME read that renders the timeline.
+    bot_paused: bool | None = None
 
 
 class DecisionItem(BaseModel):
@@ -1919,6 +1941,12 @@ class DecisionItem(BaseModel):
     summary: str
     status: str
     created_at: str
+    # Which visitor raised it. The site-wide decisions list serves EVERY
+    # visitor, so without this the thread's fallback source cannot attribute a
+    # card to the open conversation and must refuse to guess (a stranger's
+    # booking approved into the wrong thread is the failure mode). "" on a
+    # legacy row.
+    customer_ref: str = ""
 
 
 class DecisionsResponse(BaseModel):
@@ -2366,8 +2394,48 @@ async def get_site_conversation_transcript(
         # No concierge run for this (pocket, customer_ref) — the ref has no
         # conversation on this site's widget.
         raise HTTPException(404, "conversation_not_found")
+
+    # Slice 4: the approvals parked in THIS conversation ride with the thread.
+    # Filtered in-handler off the same widget-scoped read the decisions tab
+    # uses (widget_id is the cross-site isolation seam), narrowed to this
+    # visitor + still-pending. Failure-soft: a broken decisions read costs the
+    # thread its cards, never the transcript.
+    pending: list[DecisionItem] = []
+    try:
+        from pocketpaw.paw_bar.models import DecisionState
+
+        decisions = await _store().list_decisions_for_widget(widget.id, limit=200)
+        pending = [
+            DecisionItem(
+                id=d.instinct_action_id or d.id,
+                verb_or_kind=_decision_verb_or_kind(d.event_type),
+                summary=_decision_summary(d),
+                status=d.state.value,
+                created_at=d.created_at.isoformat(),
+                customer_ref=d.customer_ref,
+            )
+            for d in decisions
+            if d.customer_ref == customer_ref and d.state == DecisionState.PENDING
+        ]
+    except Exception:  # noqa: BLE001 — cards degrade, the transcript never 500s
+        logger.warning("transcript pending_actions read failed (non-fatal)", exc_info=True)
+
+    bot_paused: bool | None = None
+    try:
+        conversation = await _store().get_conversation(
+            widget.id, customer_ref, workspace_id=workspace_id
+        )
+        if conversation is not None:
+            bot_paused = bool(conversation.bot_paused)
+    except Exception:  # noqa: BLE001 — same degrade rule
+        logger.warning("transcript conversation read failed (non-fatal)", exc_info=True)
+
     return ConversationTranscriptResponse(
-        customer_ref=customer_ref, messages=messages, count=len(messages)
+        customer_ref=customer_ref,
+        messages=messages,
+        count=len(messages),
+        pending_actions=pending,
+        bot_paused=bot_paused,
     )
 
 
@@ -2402,6 +2470,7 @@ async def get_site_decisions(
             summary=_decision_summary(d),
             status=d.state.value,
             created_at=d.created_at.isoformat(),
+            customer_ref=d.customer_ref,
         )
         for d in decisions
     ]

--- a/tests/cloud/notifications/test_dto.py
+++ b/tests/cloud/notifications/test_dto.py
@@ -26,8 +26,17 @@ def _domain(**overrides) -> Notification:
 
 
 def test_dto_contains_wire_keys() -> None:
-    """Asserts the keys the existing wire shape promises:
-    id, user_id, workspace_id, kind, title, body, source_id, read, created_at."""
+    """Pins the FULL wire shape — every key a client may read.
+
+    This assertion had drifted: it still listed only the nine original keys while
+    the DTO had since grown ``source_type`` / ``source_pocket_id`` /
+    ``source_room_id`` / ``actor_id``, so it was failing on dev before this
+    change (the notifications tests are in the ``tests/cloud`` blind spot, so
+    nothing surfaced it). Brought back in line and extended with
+    ``source_agent_id``. Keep it exhaustive rather than a subset: this DTO is
+    also what the ``notification.new`` bus frame dumps, so a key added here
+    changes the socket contract too, and that should be a deliberate edit.
+    """
     out = NotificationOut(
         id="n1",
         user_id="u1",
@@ -48,6 +57,11 @@ def test_dto_contains_wire_keys() -> None:
         "title",
         "body",
         "source_id",
+        "source_type",
+        "source_pocket_id",
+        "source_room_id",
+        "source_agent_id",
+        "actor_id",
         "read",
         "created_at",
     }
@@ -77,3 +91,36 @@ def test_notification_to_dto_serializes_naive_created_at_as_utc() -> None:
     naive = datetime(2026, 4, 27, 12, 0, 0)
     out = notification_to_dto(_domain(created_at=naive))
     assert out.created_at == "2026-04-27T12:00:00+00:00"
+
+
+def test_the_source_agent_id_reaches_the_wire():
+    """A concierge notification's agent id must survive the domain → DTO hop.
+
+    Regression (found live 2026-07-31): the concierge inbox lives on an AGENT,
+    not in a chat room, so a client with no agent id has nothing to build a link
+    from and falls back to the chat surface — the click landed on
+    /chat/<widget_id>:<customer_ref>, a room that cannot exist, and the default
+    agent rendered empty. The DTO is the only path to both the REST read and the
+    ``notification.new`` bus frame (which dumps this same DTO), so dropping the
+    field here breaks the link on every surface at once.
+    """
+    dto = notification_to_dto(
+        _domain(
+            kind="paw_bar_conversation_new",
+            source=NotificationSource(
+                type="paw_bar_conversation",
+                id="pp-w1:cust-abc",
+                agent_id="agt_ridgeline",
+            ),
+        )
+    )
+    assert dto.source_agent_id == "agt_ridgeline"
+    assert dto.source_id == "pp-w1:cust-abc"
+
+
+def test_a_source_without_an_agent_serializes_as_none():
+    """An ordinary (non-concierge) source has no agent — that is not an error."""
+    dto = notification_to_dto(
+        _domain(source=NotificationSource(type="message", id="m1", room_id="r1"))
+    )
+    assert dto.source_agent_id is None

--- a/tests/cloud/test_paw_bar_conversations.py
+++ b/tests/cloud/test_paw_bar_conversations.py
@@ -1032,3 +1032,97 @@ class TestNoteAuthorCoercion:
 
         assert fields["note"]["author"] == author
         assert isinstance(fields["note"]["author"], str)
+
+
+# ── In-thread approvals (2026-07-31) — pending_actions ride the transcript ────
+# The dashboard's thread has had the approval card since slices 2+4 with two
+# wire sources (transcript pending_actions preferred, decisions-filtered-by-ref
+# fallback) and the backend served NEITHER: a real approval sat behind the
+# "approve it from Decisions" notice. These pin both halves of the fix.
+
+
+@pytest.mark.asyncio
+async def test_transcript_carries_this_visitors_pending_decisions(client):
+    """A PENDING decision rides the transcript — scoped to THIS visitor only.
+
+    The wrong-scoping failure mode is concrete: a card from somebody else's
+    conversation gets an owner approving a stranger's booking into the wrong
+    thread. So the OTHER visitor's pending row must be absent, not just the
+    settled ones.
+    """
+    c, store = client
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    await _mk_run()
+
+    mine = await _mk_decision(store, widget.id, event_type="paw_bar_action:book_visit")
+    await _mk_decision(store, widget.id, customer_ref="cust-somebody-else")
+    await _mk_decision(store, widget.id, state=DecisionState.DELIVERED)
+
+    res = await c.get(f"/paw-bar/admin/site/{site.id}/conversations/{_REF}")
+    assert res.status_code == 200, res.text
+    body = res.json()
+
+    actions = body["pending_actions"]
+    assert [a["id"] for a in actions] == [mine.instinct_action_id], (
+        "pending_actions must be exactly this visitor's still-pending rows — "
+        "no other visitor, no settled decision"
+    )
+    assert actions[0]["customer_ref"] == _REF
+    assert actions[0]["status"] == "pending"
+    assert actions[0]["verb_or_kind"]
+
+
+@pytest.mark.asyncio
+async def test_transcript_carries_bot_paused(client):
+    """The mute flag arrives with the same read that renders the timeline."""
+    c, store = client
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    await _mk_run()
+    await store.upsert_conversation_on_visitor_turn(widget.id, _REF, "ws-1")
+    await store.update_conversation(
+        widget.id,
+        _REF,
+        workspace_id="ws-1",
+        bot_paused=True,
+        last_owner_at=datetime.now().isoformat(),
+    )
+
+    res = await c.get(f"/paw-bar/admin/site/{site.id}/conversations/{_REF}")
+    assert res.status_code == 200, res.text
+    assert res.json()["bot_paused"] is True
+
+
+@pytest.mark.asyncio
+async def test_transcript_survives_a_broken_decisions_read(client, monkeypatch):
+    """Cards degrade; the transcript never 500s over its garnish."""
+    c, store = client
+    site = await _site()
+    await store.create_widget(_widget())
+    await _mk_run()
+
+    async def _boom(*a: Any, **k: Any):
+        raise RuntimeError("decisions store down")
+
+    monkeypatch.setattr(store, "list_decisions_for_widget", _boom)
+
+    res = await c.get(f"/paw-bar/admin/site/{site.id}/conversations/{_REF}")
+    assert res.status_code == 200, res.text
+    assert res.json()["pending_actions"] == []
+    assert res.json()["messages"], "the transcript itself must still be served"
+
+
+@pytest.mark.asyncio
+async def test_decisions_list_carries_customer_ref(client):
+    """The fallback source: without customer_ref on each item the thread cannot
+    attribute a card to the open conversation and must refuse to guess."""
+    c, store = client
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    await _mk_decision(store, widget.id)
+
+    res = await c.get(f"/paw-bar/admin/site/{site.id}/decisions")
+    assert res.status_code == 200, res.text
+    items = res.json()["items"]
+    assert items and items[0]["customer_ref"] == _REF


### PR DESCRIPTION
Clicking "New concierge conversation" in the bell landed on `/chat/<widget_id>:<customer_ref>` and showed the default PocketPaw agent with an empty thread. Reported live on the dev rig.

Pairs with qbtrix/paw-enterprise#PENDING — this side carries the data, that side does the routing. Neither works alone.

## Why it happened

Neither half of that compound id is a room. The notification's source type had no case in the target resolver, so it fell through the default arm — which sends unknown types to `/chat`. The chat surface then did what it does for a room that doesn't exist and rendered the default agent.

## What changed here

A concierge conversation lives in an **agent's** inbox, so the link has to name an agent. The compound id says *which* conversation; nothing said *where* to open it.

`NotificationSource` gains `agent_id`, carried through the domain object, the Mongo doc, and the DTO — and therefore the `notification.new` bus frame, which dumps that same DTO, so the socket path and the REST path can't disagree.

It resolves inside `notify.py` rather than at each producer. The three producers differ in what they hold (the new-conversation path has the widget object, the handoff path only has its id), and an omitted agent isn't a visible failure — it's a link the owner can't follow. One resolver means a fourth producer can't forget. The new-conversation path passes the widget it already has, so the visitor's turn doesn't pay for a second read.

A notification written before this, or one from an unbound widget, has no agent id and resolves to `/agents` rather than a dead room.

## Verification

On the running rig, a fresh visitor turn writes `source.agent_id=6a6a0cf01012578f4e4c1e6f` — matching the agent id in that run's own `stream_start` frame. The three notifications from before the fix have no such field, which is the data signature of the bug.

`tests/cloud -k paw_bar` 481 passed. Both import-linter configs clean, ruff clean.

## One pre-existing failure fixed, six left alone

`test_dto_contains_wire_keys` was already red on dev: it still pinned the nine original wire keys while the DTO had grown `source_type`, `source_pocket_id`, `source_room_id` and `actor_id`. Fixed and extended, since I was adding a key to the same assertion. Kept exhaustive rather than a subset — this DTO is the socket contract too, so a new key should be a deliberate edit.

The rest of that suite is red on dev for six further reasons this change doesn't touch (dev 7 failures, this branch 6). Nothing surfaced any of it because the notifications tests sit in the `tests/cloud` blind spot — worth a follow-up.