### PR TITLE
The agent ledger: an agent-keyed record of what actually happened

### DIFF
--- a/ee/pocketpaw_ee/cloud/agents/router.py
+++ b/ee/pocketpaw_ee/cloud/agents/router.py
@@ -27,6 +27,24 @@ soft-disable / revoke-everywhere flow. Both carry the SAME owner/admin guard
 tenant-scope protection, so a cross-workspace / non-owner caller cannot revoke
 or restore an agent it doesn't own.
 
+Updated 2026-07-31 (AL-1, agent ledger spine): added
+``GET /agents/{id}/ledger?window=30d`` — the agent's own track record: counts by
+kind, the outcome ratio, attributed value, and the recent rows. It reads the
+per-workspace ``agent_ledger`` store and NOTHING else. That single-source rule is
+the whole point: the previous way to answer "what did this agent do for me" was
+to assemble numbers from paw_bar_events, the run docs, and Instinct by hand,
+which is exactly how a dashboard ends up disagreeing with the ledger it claims
+to summarize.
+
+Ops metrics (tokens, cost, latency, model mix) are deliberately NOT in this
+response. They live in the run docs / usage tracker, are read federated where
+they already are, and copying them into an analytics payload is the two-meters
+bug we have paid for once already.
+
+Carries the same visibility gate as the knowledge reads
+(``agents_service.ensure_can_read``): a track record is at least as revealing as
+the config that produced it, so another member cannot read a private agent's.
+
 Updated 2026-07-15 (fix/agent-visibility-enforcement, ASG-7): the READ endpoints
 now enforce agent visibility. ``GET /agents/{id}`` routes through
 ``agents_service.get_for_viewer`` (404 for another user's private agent);
@@ -464,3 +482,81 @@ async def set_agent_scope(
     """
     updated = await agents_service.set_scopes(agent_id, body.scopes)
     return ScopeAssignmentResponse(agent_id=agent_id, scopes=updated)
+
+
+# ---------------------------------------------------------------------------
+# Agent ledger — the track record (AL-1)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{agent_id}/ledger")
+async def get_agent_ledger(
+    agent_id: str,
+    window: str = Query(default="30d"),
+    limit: int = Query(default=50, ge=1, le=200),
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> dict:
+    """What this agent actually achieved, over ``window``.
+
+    ``window`` accepts ``24h`` / ``7d`` / ``30d`` / ``2w`` / ``all``. A window
+    that cannot be parsed is a 422 rather than a silent fallback to the default:
+    an analytics surface that quietly answers a different question than the one
+    asked is worse than one that refuses.
+
+    The response is assembled from ONE source (this workspace's agent ledger),
+    with each aggregate computed in SQL over the same filter, so the counts, the
+    outcome ratio, and the value total can never disagree with each other or
+    with the rows listed beneath them.
+    """
+    from pocketpaw.agent_ledger.models import WindowParseError, window_start
+    from pocketpaw.stores import get_agent_ledger_store
+
+    # Visibility gate: same guard as the knowledge reads — a private agent's
+    # record is not another member's to read.
+    await agents_service.ensure_can_read(agent_id, workspace_id, user_id)
+
+    try:
+        since = window_start(window)
+    except WindowParseError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    store = get_agent_ledger_store(workspace_id=workspace_id or None)
+    scope = {"agent_id": agent_id, "workspace_id": workspace_id or "", "since": since}
+    counts = await store.counts_by_kind(**scope)
+    outcomes = await store.counts_by_outcome(**scope)
+    value_by_currency = await store.value_by_currency(**scope)
+    recent = await store.query(**scope, limit=limit)
+
+    # Ratios are reported over the rows that actually carry a verdict, and the
+    # denominator ships with them. "60% solved" out of five is a different claim
+    # from "60% solved" out of five hundred, and a board that hides which one it
+    # means teaches its reader to over-trust it.
+    decided = sum(outcomes.values())
+    outcome_ratio = (
+        {status: round(count / decided, 4) for status, count in outcomes.items()} if decided else {}
+    )
+
+    # One currency → a headline total. More than one → no headline, because
+    # adding cents to pence produces a number that is wrong invisibly. The
+    # per-currency breakdown is always the authoritative field.
+    single_currency = next(iter(value_by_currency)) if len(value_by_currency) == 1 else ""
+
+    return {
+        "agent_id": agent_id,
+        "window": window,
+        "since": since,
+        "counts_by_kind": counts,
+        "total_events": sum(counts.values()),
+        "outcome": {
+            "counts": outcomes,
+            "decided": decided,
+            "ratio": outcome_ratio,
+        },
+        "value": {
+            "by_currency": value_by_currency,
+            "currency": single_currency,
+            "total_cents": value_by_currency.get(single_currency, 0) if single_currency else 0,
+        },
+        "recent": [row.model_dump() for row in recent],
+    }

--- a/ee/pocketpaw_ee/paw_bar/decision_loop.py
+++ b/ee/pocketpaw_ee/paw_bar/decision_loop.py
@@ -1,4 +1,16 @@
 # ee/paw_bar/decision_loop.py — Close the customer decision loop via Instinct.
+# Updated: 2026-07-31 (AL-1, agent ledger spine) — both propose paths now stamp
+#   ``actor_agent_id`` on the Action from the widget's bound agent, via the new
+#   ``resolve_widget_agent`` helper. Until now the only trace of WHICH agent
+#   raised a paw-bar proposal was the ``paw_bar:<widget_id>`` trigger string:
+#   readable by a person, not joinable by a query. The ledger emitter keys every
+#   approval on the Action's ``actor_agent_id``, so an unstamped proposal would
+#   land in the unattributed bucket and the concierge's own value board would
+#   show nothing. The binding already existed on the widget (``widget.agent_id``,
+#   set by agent_provisioning) — all that was missing was carrying it across.
+#   The helper is fail-soft in the ``notify.py`` shape: a widget with no agent,
+#   or a duck-typed object without the attribute, yields "" and the proposal is
+#   raised exactly as before.
 # Updated: 2026-07-30 (async decision delivery) — deliver_customer_decision now
 #   closes the loop for a visitor who LEFT the page: if the flipped row carries
 #   a ``contact_email`` (attached via POST /paw-bar/decision-contact while the
@@ -147,6 +159,24 @@ def resolve_workspace_id(widget: Any) -> str:
     real ``workspace_id`` only — an owner label is never a store-path token.
     """
     return str(getattr(widget, "workspace_id", "") or "") or str(getattr(widget, "owner", "") or "")
+
+
+def resolve_widget_agent(widget: Any) -> str:
+    """The agent id bound to a Paw Bar widget, or "" when there isn't one (AL-1).
+
+    A site concierge IS a normal agent: ``agent_provisioning`` binds one and
+    stamps ``widget.agent_id``, which is the same key the agent-scoped inbox and
+    the notification deep-link already resolve by. This reads that binding so a
+    proposal can carry its proposer into the ledger.
+
+    Fail-soft by construction — ``getattr`` with a default, coerced through
+    ``str``. An unbound widget, a legacy widget written before the column, or a
+    duck-typed stand-in in a test all return "", and "" is a legal
+    ``actor_agent_id``: the proposal still gets raised, the approval still gets
+    recorded, and the row simply counts as unattributed. Attribution is worth
+    having, never worth failing a customer's request over.
+    """
+    return str(getattr(widget, "agent_id", "") or "")
 
 
 def _summarize_payload(payload: dict[str, Any]) -> str:
@@ -309,6 +339,12 @@ async def propose_customer_decision(
             # customer relationship), NOT the workspace — The Tray filters by
             # assignee to show an operator only the items they own.
             assignee=owner or None,
+            # AL-1 — the AGENT that raised this, so the approval lands on that
+            # concierge's ledger. Distinct from ``assignee`` (the human who
+            # decides) and from ``workspace_id`` (the tenant): three identities,
+            # three jobs, and conflating any two of them is what made the
+            # concierge funnel un-queryable in the first place.
+            actor_agent_id=resolve_widget_agent(widget),
         )
 
         # Park the PENDING decision row so the customer surface has something to
@@ -463,6 +499,11 @@ async def propose_customer_action(
             # owner; the two must agree, or the same visitor raises two
             # differently-routed proposals depending on which path caught them.
             assignee=str(getattr(widget, "owner", "") or "") or None,
+            # AL-1 — same attribution as the event path above. The two paths must
+            # agree here for the same reason they must agree on the assignee: one
+            # visitor should not produce two differently-attributed proposals
+            # depending on which entry point caught them.
+            actor_agent_id=resolve_widget_agent(widget),
         )
         decision = DecisionStatus(
             widget_id=widget_id,
@@ -627,5 +668,6 @@ __all__ = [
     "deliver_customer_decision",
     "propose_customer_action",
     "propose_customer_decision",
+    "resolve_widget_agent",
     "resolve_workspace_id",
 ]

--- a/src/pocketpaw/agent_ledger/__init__.py
+++ b/src/pocketpaw/agent_ledger/__init__.py
@@ -1,0 +1,102 @@
+# Agent ledger — the agent-keyed record of what an agent actually achieved.
+# Created: 2026-07-31 (AL-1, ledger spine) — the public surface of the module.
+#   Re-exports the row model, the closed `paw.*` kind vocabulary, the window
+#   helpers, and the store, so every consumer (the Instinct emitter, the paw-bar
+#   emitters in AL-2, the metering sweeper in AL-3, the read endpoints) imports
+#   from ONE place and the internal file split stays free to move.
+#
+# The store handle itself is NOT constructed here — use
+# ``pocketpaw.stores.get_agent_ledger_store(workspace_id=...)`` so the
+# per-workspace file routing, the fail-closed cloud guard, and the bounded
+# handle cache all apply. Constructing AgentLedgerStore directly is for tests.
+
+from __future__ import annotations
+
+from pocketpaw.agent_ledger.models import (
+    ATTR_ACTION_CATEGORY,
+    ATTR_ACTION_ID,
+    ATTR_AGENT_ID,
+    ATTR_AGENT_NAME,
+    ATTR_APPROVAL_AUTO,
+    ATTR_CONVERSATION_ID,
+    ATTR_DECISION_ACTOR,
+    ATTR_INSTINCT_EVENT,
+    ATTR_OPERATION_NAME,
+    ATTR_POCKET_ID,
+    ATTR_SCOPE_TYPE,
+    CORE_KINDS,
+    KIND_ACTION_APPROVED,
+    KIND_ACTION_DELIVERED,
+    KIND_ACTION_OUTCOME,
+    KIND_ACTION_PROPOSED,
+    KIND_ACTION_REJECTED,
+    KIND_CONVERSATION_STARTED,
+    KIND_CONVERSATION_TAKEOVER,
+    KIND_HANDOFF_RAISED,
+    KIND_HANDOFF_RESOLVED,
+    KIND_RUN_COMPLETED,
+    KIND_VISITOR_ACTION,
+    LEDGER_VOCAB_VERSION,
+    SURFACE_BELT,
+    SURFACE_CHAT,
+    SURFACE_DEEP_WORK,
+    SURFACE_GROWTH,
+    SURFACE_INSTINCT,
+    SURFACE_PAW_BAR,
+    CoreKind,
+    LedgerActor,
+    LedgerKindValidationError,
+    LedgerRow,
+    WindowParseError,
+    is_core_kind,
+    parse_window,
+    surface_from_trigger,
+    validate_ledger_kind,
+    window_start,
+)
+from pocketpaw.agent_ledger.store import MAX_QUERY_LIMIT, AgentLedgerStore
+
+__all__ = [
+    "ATTR_ACTION_CATEGORY",
+    "ATTR_ACTION_ID",
+    "ATTR_AGENT_ID",
+    "ATTR_AGENT_NAME",
+    "ATTR_APPROVAL_AUTO",
+    "ATTR_CONVERSATION_ID",
+    "ATTR_DECISION_ACTOR",
+    "ATTR_INSTINCT_EVENT",
+    "ATTR_OPERATION_NAME",
+    "ATTR_POCKET_ID",
+    "ATTR_SCOPE_TYPE",
+    "CORE_KINDS",
+    "KIND_ACTION_APPROVED",
+    "KIND_ACTION_DELIVERED",
+    "KIND_ACTION_OUTCOME",
+    "KIND_ACTION_PROPOSED",
+    "KIND_ACTION_REJECTED",
+    "KIND_CONVERSATION_STARTED",
+    "KIND_CONVERSATION_TAKEOVER",
+    "KIND_HANDOFF_RAISED",
+    "KIND_HANDOFF_RESOLVED",
+    "KIND_RUN_COMPLETED",
+    "KIND_VISITOR_ACTION",
+    "LEDGER_VOCAB_VERSION",
+    "MAX_QUERY_LIMIT",
+    "SURFACE_BELT",
+    "SURFACE_CHAT",
+    "SURFACE_DEEP_WORK",
+    "SURFACE_GROWTH",
+    "SURFACE_INSTINCT",
+    "SURFACE_PAW_BAR",
+    "AgentLedgerStore",
+    "CoreKind",
+    "LedgerActor",
+    "LedgerKindValidationError",
+    "LedgerRow",
+    "WindowParseError",
+    "is_core_kind",
+    "parse_window",
+    "surface_from_trigger",
+    "validate_ledger_kind",
+    "window_start",
+]

--- a/src/pocketpaw/agent_ledger/models.py
+++ b/src/pocketpaw/agent_ledger/models.py
@@ -341,6 +341,11 @@ _WINDOW_PATTERN = re.compile(r"^(\d+)([dhw])$")
 
 _WINDOW_UNITS: dict[str, str] = {"h": "hours", "d": "days", "w": "weeks"}
 
+# How many of each unit fit in a day — used to bound the raw AMOUNT before any
+# timedelta is constructed. Kept beside _WINDOW_UNITS so a new unit can't be
+# added to one table and forgotten in the other.
+_WINDOW_UNIT_PER_DAY: dict[str, float] = {"h": 24, "d": 1, "w": 1 / 7}
+
 # Refuse an absurd window rather than letting it become an unbounded scan under
 # a friendly-looking query string. A year of an append-only ledger is already
 # past the point where the rollup (deferred, additive) is the right answer.
@@ -378,6 +383,15 @@ def parse_window(window: str) -> timedelta | None:
     amount = int(match.group(1))
     if amount <= 0:
         raise WindowParseError(f"window must be positive, got {window!r}")
+    # Bound the AMOUNT before building the timedelta, not after. ``timedelta``
+    # raises OverflowError — not ValueError — once the value exceeds C-int range
+    # or its own 999999999-day cap, and OverflowError is not a WindowParseError,
+    # so it escaped the router's 422 handler and surfaced as a 500. A caller
+    # typing '99999999999d' got a server error where the contract promises a
+    # rejected input. Comparing in the unit's own terms keeps the check ahead of
+    # every construction path.
+    if amount > _MAX_WINDOW_DAYS * _WINDOW_UNIT_PER_DAY[match.group(2)]:
+        raise WindowParseError(f"window {window!r} exceeds the {_MAX_WINDOW_DAYS}-day maximum")
     delta = timedelta(**{_WINDOW_UNITS[match.group(2)]: amount})
     if delta > timedelta(days=_MAX_WINDOW_DAYS):
         raise WindowParseError(f"window {window!r} exceeds the {_MAX_WINDOW_DAYS}-day maximum")

--- a/src/pocketpaw/agent_ledger/models.py
+++ b/src/pocketpaw/agent_ledger/models.py
@@ -1,0 +1,397 @@
+# Agent ledger models — the row shape + the closed `paw.*` kind vocabulary.
+# Created: 2026-07-31 (AL-1, ledger spine) — "what did my agents do for me?" was
+#   un-askable because every surface recorded its own fragment in its own store
+#   with its own key, and half of them carried no agent_id at all. This module
+#   defines the ONE agent-keyed row every surface writes, and the vocabulary of
+#   things worth recording.
+#
+# Two decisions worth the reader's time:
+#
+#   * GOVERNANCE MIRRORS SENSES (src/pocketpaw/senses/vocabulary.py). The
+#     ``paw.*`` core is CLOSED — an unknown ``paw.*`` kind raises rather than
+#     silently landing — because an analytics vocabulary that anyone can extend
+#     in the core namespace stops being comparable across surfaces within a
+#     release. The ``vendor.*`` extension space is OPEN and validated only for
+#     shape, so a third-party surface can record its own beats without a PR
+#     against core.
+#
+#   * ``attrs`` USES OTEL GenAI SEMANTIC-CONVENTION NAMES where one exists
+#     (``gen_ai.agent.id``, not ``agent_id``). The ops half of agent
+#     observability standardized on OTel during 2025-26; the VALUE half — what
+#     an agent achieved for its owner — did not, which is why this store exists
+#     at all. Borrowing their attribute names now means a later OTel exporter is
+#     an adapter, not a rewrite. Paw concepts with no OTel equivalent take a
+#     ``paw.*`` attribute name, deliberately distinguishable from the borrowed
+#     ones.
+#
+# What must NEVER appear on a row: tokens, cost, latency, model mix, traces.
+# Those stay federated in usage_tracker / ChatRunDoc / the inference gateway and
+# are read where they already live. Copying them here re-creates the
+# chart-vs-wallet two-meters bug (a usage chart read one meter while the wallet
+# held the spend, and they disagreed) — the row model has no field for them on
+# purpose, so the mistake cannot be made quietly.
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator
+
+# Bump when the core vocabulary changes. Unlike sense ids, ledger kinds are NOT
+# individually versioned: a kind names a beat in the agent's life ("an action was
+# approved"), and versioning that per-kind would fragment the very comparability
+# the closed core exists to protect. The catalog as a whole carries the version.
+LEDGER_VOCAB_VERSION = "1"
+
+# Core kind ids follow paw.<domain>.<verb>. Extension (vendor) kinds follow
+# <vendor>.<domain>.<verb> and are accepted freely — the core is closed, the
+# extension space is open. Same split as senses/vocabulary.py.
+_CORE_KIND_PATTERN = re.compile(r"^paw\.[a-z0-9_]+\.[a-z0-9_]+$")
+_EXTENSION_KIND_PATTERN = re.compile(r"^[a-z0-9_]+\.[a-z0-9_]+\.[a-z0-9_]+$")
+
+
+class LedgerKindValidationError(ValueError):
+    """Raised when a ledger kind is malformed or an unknown ``paw.*`` core id."""
+
+
+@dataclass(frozen=True)
+class CoreKind:
+    """A single curated core kind in the versioned vocabulary."""
+
+    id: str
+    display_name: str
+    description: str
+
+
+# ---------------------------------------------------------------------------
+# The v1 kind vocabulary
+# ---------------------------------------------------------------------------
+#
+# Every kind here has a producer in the codebase today — this is not a wish list.
+# AL-1 emits the three action-lifecycle kinds; the rest are defined now so the
+# vocabulary is settled before five emitters race to invent names for the same
+# beat, which is exactly how a "closed core" stops being one.
+
+KIND_ACTION_PROPOSED = "paw.action.proposed"
+KIND_ACTION_APPROVED = "paw.action.approved"
+KIND_ACTION_REJECTED = "paw.action.rejected"
+KIND_ACTION_DELIVERED = "paw.action.delivered"
+KIND_ACTION_OUTCOME = "paw.action.outcome"
+KIND_HANDOFF_RAISED = "paw.handoff.raised"
+KIND_HANDOFF_RESOLVED = "paw.handoff.resolved"
+KIND_VISITOR_ACTION = "paw.visitor.action"
+KIND_CONVERSATION_STARTED = "paw.conversation.started"
+KIND_CONVERSATION_TAKEOVER = "paw.conversation.takeover"
+KIND_RUN_COMPLETED = "paw.run.completed"
+
+CORE_KINDS: tuple[CoreKind, ...] = (
+    CoreKind(
+        id=KIND_ACTION_PROPOSED,
+        display_name="Action proposed",
+        description="The agent asked a human to decide something.",
+    ),
+    CoreKind(
+        id=KIND_ACTION_APPROVED,
+        display_name="Action approved",
+        description="A human (or the triager) let the agent's proposal through.",
+    ),
+    CoreKind(
+        id=KIND_ACTION_REJECTED,
+        display_name="Action rejected",
+        description="A human declined the agent's proposal.",
+    ),
+    CoreKind(
+        id=KIND_ACTION_DELIVERED,
+        display_name="Action delivered",
+        description="The approved answer actually reached the person waiting for it.",
+    ),
+    CoreKind(
+        id=KIND_ACTION_OUTCOME,
+        display_name="Action outcome",
+        description=(
+            "The verdict on an executed action — whether it solved the problem, "
+            "not merely whether it ran."
+        ),
+    ),
+    CoreKind(
+        id=KIND_HANDOFF_RAISED,
+        display_name="Handoff raised",
+        description="The agent decided a human needed to take this one.",
+    ),
+    CoreKind(
+        id=KIND_HANDOFF_RESOLVED,
+        display_name="Handoff resolved",
+        description="The human finished what the agent handed over.",
+    ),
+    CoreKind(
+        id=KIND_VISITOR_ACTION,
+        display_name="Visitor action",
+        description=(
+            "A visitor-owned action the agent executed directly (add to cart, "
+            "checkout) — the one kind that routinely carries attributed value."
+        ),
+    ),
+    CoreKind(
+        id=KIND_CONVERSATION_STARTED,
+        display_name="Conversation started",
+        description="A new person started talking to this agent.",
+    ),
+    CoreKind(
+        id=KIND_CONVERSATION_TAKEOVER,
+        display_name="Conversation takeover",
+        description="The owner took the conversation off the agent.",
+    ),
+    CoreKind(
+        id=KIND_RUN_COMPLETED,
+        display_name="Run completed",
+        description=(
+            "One terminal agent run, counted. COUNT ONLY — tokens and cost stay "
+            "in the run doc where billing reads them."
+        ),
+    ),
+)
+
+_CORE_KIND_IDS: frozenset[str] = frozenset(k.id for k in CORE_KINDS)
+
+
+def is_core_kind(kind: str) -> bool:
+    """True if ``kind`` is one of the curated core kinds."""
+    return kind in _CORE_KIND_IDS
+
+
+def validate_ledger_kind(kind: str) -> str:
+    """Validate a ledger kind, returning it unchanged if valid.
+
+    Rules (identical in shape to :func:`pocketpaw.senses.vocabulary.
+    validate_sense_id`):
+
+      - A ``paw.*`` kind is accepted ONLY if it is in the curated core set. An
+        unknown ``paw.*`` kind raises — the core namespace is closed so a new
+        emitter can't silently fragment it (two surfaces inventing
+        ``paw.action.done`` and ``paw.action.complete`` for the same beat is how
+        an analytics vocabulary dies).
+      - A non-``paw.*`` kind (vendor extension, ``vendor.domain.verb``) is
+        accepted freely — the extension space is open.
+      - Anything that is neither a well-formed core kind nor a well-formed
+        extension kind raises.
+    """
+    if not isinstance(kind, str) or not kind:
+        raise LedgerKindValidationError(f"ledger kind must be a non-empty string, got {kind!r}")
+
+    if kind.startswith("paw."):
+        if not _CORE_KIND_PATTERN.match(kind):
+            raise LedgerKindValidationError(
+                f"malformed core ledger kind {kind!r} (expected paw.<domain>.<verb>)"
+            )
+        if kind not in _CORE_KIND_IDS:
+            raise LedgerKindValidationError(
+                f"unknown core ledger kind {kind!r}; the paw.* namespace is "
+                f"closed. Known core kinds: {sorted(_CORE_KIND_IDS)}. "
+                f"Use a vendor.domain.verb kind for custom beats."
+            )
+        return kind
+
+    # Extension (vendor) kind — open namespace, just enforce the shape.
+    if not _EXTENSION_KIND_PATTERN.match(kind):
+        raise LedgerKindValidationError(
+            f"malformed extension ledger kind {kind!r} (expected vendor.domain.verb)"
+        )
+    return kind
+
+
+# ---------------------------------------------------------------------------
+# Actor + surface
+# ---------------------------------------------------------------------------
+
+
+class LedgerActor(StrEnum):
+    """WHO caused this row — not who it is about (that is always ``agent_id``).
+
+    The split matters for the value board: "12 approvals" reads very differently
+    depending on whether a human clicked twelve times or the triager did.
+    """
+
+    VISITOR = "visitor"  # an anonymous person on a site
+    OWNER = "owner"  # the workspace's human operator
+    AGENT = "agent"  # the agent acted on its own authority
+    SYSTEM = "system"  # a sweeper, an executor, the auto-triager
+
+
+# The surfaces that produce rows. Deliberately plain strings on an open set
+# rather than a closed enum: a new surface should be able to record its work
+# before it has earned a constant here, and an unknown surface is a legible
+# label in a dashboard, not a crash. The KIND vocabulary is what stays closed.
+SURFACE_PAW_BAR = "paw_bar"
+SURFACE_CHAT = "chat"
+SURFACE_BELT = "belt"
+SURFACE_DEEP_WORK = "deep_work"
+SURFACE_GROWTH = "growth"
+SURFACE_INSTINCT = "instinct"  # the fallback: gated, but by an unidentified surface
+
+# Instinct ``ActionTrigger.source`` prefixes → surface. Sources are colon-
+# qualified by convention ("paw_bar:<widget_id>", "belt:develop"), so a prefix
+# match is the honest read. Anything unmatched falls back to SURFACE_INSTINCT
+# rather than guessing — an "instinct" bucket the owner can see is better than a
+# confident mislabel they cannot.
+_SOURCE_PREFIX_SURFACES: tuple[tuple[str, str], ...] = (
+    ("paw_bar:", SURFACE_PAW_BAR),
+    ("belt:", SURFACE_BELT),
+    ("deep_work:", SURFACE_DEEP_WORK),
+    ("growth:", SURFACE_GROWTH),
+)
+
+
+def surface_from_trigger(trigger_type: str, trigger_source: str) -> str:
+    """Best-effort map from an Instinct trigger to a ledger surface.
+
+    Used by the Instinct emitter, which sees every agent kind but is told only
+    what the proposer put in the trigger. Prefix-matches the known
+    colon-qualified sources first, then treats a bare ``agent`` trigger as chat
+    (that is what an agent run proposes as), and otherwise returns
+    ``SURFACE_INSTINCT``. Never raises — a bad trigger yields the fallback.
+    """
+    source = str(trigger_source or "").strip().lower()
+    for prefix, surface in _SOURCE_PREFIX_SURFACES:
+        if source.startswith(prefix):
+            return surface
+    if str(trigger_type or "").strip().lower() == "agent":
+        return SURFACE_CHAT
+    return SURFACE_INSTINCT
+
+
+# ---------------------------------------------------------------------------
+# OTel GenAI semantic-convention attribute names
+# ---------------------------------------------------------------------------
+#
+# Borrowed verbatim from the OTel GenAI semantic conventions so a later exporter
+# maps 1:1. Only the names are borrowed — no OTel infra, no spans, no collector.
+
+ATTR_AGENT_ID = "gen_ai.agent.id"
+ATTR_AGENT_NAME = "gen_ai.agent.name"
+ATTR_CONVERSATION_ID = "gen_ai.conversation.id"
+ATTR_OPERATION_NAME = "gen_ai.operation.name"
+
+# Paw concepts with no OTel equivalent. Namespaced under ``paw.`` precisely so a
+# reader can tell at a glance which attributes are portable and which are ours.
+ATTR_ACTION_ID = "paw.action.id"
+ATTR_ACTION_CATEGORY = "paw.action.category"
+ATTR_INSTINCT_EVENT = "paw.instinct.event"
+ATTR_APPROVAL_AUTO = "paw.approval.auto"
+ATTR_DECISION_ACTOR = "paw.decision.actor"
+ATTR_POCKET_ID = "paw.pocket.id"
+ATTR_SCOPE_TYPE = "paw.scope.type"
+
+
+# ---------------------------------------------------------------------------
+# The row
+# ---------------------------------------------------------------------------
+
+
+class LedgerRow(BaseModel):
+    """One thing an agent did, keyed by the agent that did it.
+
+    ``agent_id`` is THE key of the whole design: the named worker with identity
+    and memory owns its outcomes, not the pocket and not the surface. An empty
+    ``agent_id`` is legal and means "we could not attribute this one" — the row
+    still lands surface-keyed and the board shows an honest unattributed bucket,
+    which beats dropping the row and quietly under-counting.
+    """
+
+    # Assigned by SQLite on insert; None on a row that has not been appended.
+    id: int | None = None
+    agent_id: str = ""
+    workspace_id: str = ""
+    surface: str = SURFACE_INSTINCT
+    kind: str
+    # The OutcomeStatus value ("solved" / "partial" / "not_solved" / "unknown")
+    # when this row carries a verdict. None on every kind that isn't a verdict.
+    outcome: str | None = None
+    # Attributed value in minor units, when it is genuinely known (a cart total,
+    # a checkout). Deliberately RAW — whether the owner's "value" is order value,
+    # fee, or margin is an outcome-metering question, and baking one answer in
+    # here would make the other two unrecoverable.
+    value_cents: int | None = None
+    currency: str | None = None
+    # The producing record's id (action_id / run_id / "widget:customer"). Half of
+    # the UNIQUE(kind, ref) dedupe guard, so it must be STABLE across replays.
+    ref: str
+    actor: str = LedgerActor.SYSTEM.value
+    attrs: dict[str, Any] = Field(default_factory=dict)
+    # ISO-8601 UTC (aware). Aware, not naive, because these rows are compared
+    # against ChatRunDoc.createdAt and rendered in windows — a naive local stamp
+    # would skew every window by the host's UTC offset.
+    ts: str = Field(default_factory=lambda: datetime.now(UTC).isoformat())
+
+    @field_validator("kind")
+    @classmethod
+    def _check_kind(cls, value: str) -> str:
+        """Enforce the vocabulary at the model boundary, not at each call site."""
+        return validate_ledger_kind(value)
+
+
+# ---------------------------------------------------------------------------
+# Window parsing (shared by every read surface)
+# ---------------------------------------------------------------------------
+
+_WINDOW_PATTERN = re.compile(r"^(\d+)([dhw])$")
+
+_WINDOW_UNITS: dict[str, str] = {"h": "hours", "d": "days", "w": "weeks"}
+
+# Refuse an absurd window rather than letting it become an unbounded scan under
+# a friendly-looking query string. A year of an append-only ledger is already
+# past the point where the rollup (deferred, additive) is the right answer.
+_MAX_WINDOW_DAYS = 366
+
+
+class WindowParseError(ValueError):
+    """Raised when a caller-supplied analytics window can't be understood."""
+
+
+def parse_window(window: str) -> timedelta | None:
+    """Parse ``30d`` / ``7d`` / ``24h`` / ``2w`` / ``all`` into a lookback.
+
+    Returns ``None`` for ``all`` — and ONLY for ``all``. An empty or blank
+    window raises rather than falling back to unbounded: "" is what an
+    accidentally-empty query parameter looks like, and answering it with the
+    whole history is the largest possible reinterpretation of a question nobody
+    asked. Unbounded has an explicit spelling; use it.
+
+    Raises :class:`WindowParseError` on anything malformed or beyond
+    ``_MAX_WINDOW_DAYS`` so a router can turn it into a 422 instead of serving a
+    silently-wrong number — an analytics surface that quietly reinterprets your
+    question is worse than one that refuses it.
+    """
+    raw = str(window or "").strip().lower()
+    if raw == "all":
+        return None
+    if not raw:
+        raise WindowParseError("window must not be empty (use 'all' for no lower bound)")
+    match = _WINDOW_PATTERN.match(raw)
+    if not match:
+        raise WindowParseError(
+            f"unparseable window {window!r} (expected e.g. 24h, 7d, 30d, 2w, or all)"
+        )
+    amount = int(match.group(1))
+    if amount <= 0:
+        raise WindowParseError(f"window must be positive, got {window!r}")
+    delta = timedelta(**{_WINDOW_UNITS[match.group(2)]: amount})
+    if delta > timedelta(days=_MAX_WINDOW_DAYS):
+        raise WindowParseError(f"window {window!r} exceeds the {_MAX_WINDOW_DAYS}-day maximum")
+    return delta
+
+
+def window_start(window: str, *, now: datetime | None = None) -> str | None:
+    """The ISO-UTC lower bound for ``window``, or ``None`` for an unbounded read.
+
+    Rows store aware-UTC ISO strings, which sort lexicographically in the same
+    order they sort chronologically, so the store compares against this string
+    directly instead of parsing every row.
+    """
+    delta = parse_window(window)
+    if delta is None:
+        return None
+    return ((now or datetime.now(UTC)) - delta).isoformat()

--- a/src/pocketpaw/agent_ledger/store.py
+++ b/src/pocketpaw/agent_ledger/store.py
@@ -1,0 +1,388 @@
+# Agent ledger store — append-only, agent-keyed SQLite for the value board.
+# Created: 2026-07-31 (AL-1, ledger spine) — the table that makes "what did my
+#   agents do for me?" a query instead of a manual reconciliation across three
+#   stores. Follows the InstinctStore / PawBarStore shape exactly (module-level
+#   SCHEMA_SQL, lazy _ensure_schema, a connection per call, an aclose() the
+#   workspace-keyed factory runs on LRU eviction) so the wiring is familiar and
+#   the per-workspace factory in pocketpaw/stores.py can drive it unchanged.
+#
+# Three properties this store is built around:
+#
+#   * APPEND-ONLY. There is no update and no delete. A value board that can be
+#     edited is not evidence, and the reconcile alarm (AL-4) can only compare
+#     two counts if one of them cannot be quietly revised.
+#
+#   * UNIQUE(kind, ref) IS THE IDEMPOTENCY GUARD, enforced by the database
+#     rather than by every caller remembering. Approvals replay (a retried
+#     request, a re-swept run, the reject path which has no CAS today), and a
+#     replay must not double-count. ``append`` uses ON CONFLICT DO NOTHING and
+#     reports whether a row actually landed, so a caller that cares can tell
+#     "first time" from "already recorded" without a pre-read race.
+#
+#   * WAL. Emitters fire on hot paths — a visitor's turn, an approval click, a
+#     billing sweep — while the board reads the same file. WAL keeps a reader
+#     from blocking those writers.
+#
+# Tenancy is BOTH physical (the factory gives each workspace its own file under
+# ~/.pocketpaw/workspaces/<id>/agent_ledger.db) and in-row (workspace_id on
+# every row, filtered on read). The in-row filter is STRICT — it does not match
+# ''/NULL the way the paw_bar and instinct scopes do — because those stores
+# carry legacy rows written before their tenancy column existed and this table
+# has none: it is new, the column is NOT NULL, and a permissive OR '' would turn
+# the single-tenant OSS file's rows into every tenant's rows the moment a shared
+# deployment queried it.
+#
+# What this store must NEVER hold: tokens, cost, latency, model mix, traces. See
+# the models module header — the row model has no field for them by design.
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import aiosqlite
+
+from pocketpaw.agent_ledger.models import LedgerRow
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS agent_ledger_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    -- The actor. THE key of the whole design: the agent owns its outcomes.
+    -- Empty means "unattributed" — a legal, visible state, not an error.
+    agent_id TEXT NOT NULL,
+    -- In-row tenancy, layered on top of the per-workspace file.
+    workspace_id TEXT NOT NULL,
+    -- paw_bar | chat | belt | deep_work | growth | instinct | <new surface>.
+    surface TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    -- OutcomeStatus value on verdict rows, NULL everywhere else.
+    outcome TEXT,
+    -- Attributed value in minor units + its currency, when genuinely known.
+    value_cents INTEGER,
+    currency TEXT,
+    -- The producing record's stable id — half of the dedupe key.
+    ref TEXT NOT NULL,
+    actor TEXT NOT NULL,
+    -- Flat JSON, OTel GenAI attribute names where one exists.
+    attrs TEXT NOT NULL DEFAULT '{}',
+    -- Aware-UTC ISO-8601. Sorts lexicographically == chronologically, which is
+    -- what lets the window filter compare strings instead of parsing rows.
+    ts TEXT NOT NULL,
+    -- Replay/dedupe guard: one row per (beat, producing record). An approve
+    -- that fires twice, a re-swept run, a reject race — all absorbed here.
+    UNIQUE (kind, ref)
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_ledger_agent_ts
+    ON agent_ledger_events(agent_id, ts DESC);
+CREATE INDEX IF NOT EXISTS idx_agent_ledger_workspace_ts
+    ON agent_ledger_events(workspace_id, ts DESC);
+CREATE INDEX IF NOT EXISTS idx_agent_ledger_kind_ts
+    ON agent_ledger_events(kind, ts DESC);
+"""
+
+# Ceiling on any single read. The board pages; nothing on this store should ever
+# load a whole tenant's history into memory because a caller forgot a limit.
+MAX_QUERY_LIMIT = 1000
+
+
+def _normalize_ts(value: Any) -> str:
+    """Coerce a timestamp to the aware-UTC ISO form every row is stored in.
+
+    Load-bearing, not cosmetic: the window filter compares ``ts`` as a STRING,
+    which is only equivalent to comparing instants when every row shares one
+    offset. A naive stamp (or one written at +05:30) would sort into the wrong
+    window forever. Anything unparseable becomes "now" rather than raising — a
+    bookkeeping row with a suspect clock is worth more than a lost emit.
+    """
+    if isinstance(value, datetime):
+        moment = value
+    else:
+        try:
+            moment = datetime.fromisoformat(str(value))
+        except (TypeError, ValueError):
+            return datetime.now(UTC).isoformat()
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=UTC)
+    return moment.astimezone(UTC).isoformat()
+
+
+class AgentLedgerStore:
+    """Append-only async SQLite store for agent-keyed value events."""
+
+    def __init__(self, db_path: str | Path) -> None:
+        self._db_path = str(db_path)
+        self._initialized = False
+
+    async def _ensure_schema(self) -> None:
+        if self._initialized:
+            return
+        async with aiosqlite.connect(self._db_path) as db:
+            # WAL is a persistent per-file property, so this is a one-time cost
+            # that survives every later connection. Emitters write on hot paths
+            # while the board reads; without WAL a read holds them up.
+            await db.execute("PRAGMA journal_mode=WAL")
+            await db.executescript(SCHEMA_SQL)
+            await db.commit()
+        self._initialized = True
+
+    def _conn(self) -> aiosqlite.Connection:
+        return aiosqlite.connect(self._db_path)
+
+    async def aclose(self) -> None:
+        """Release on-disk resources (the workspace-keyed factory calls this).
+
+        Verbatim posture from ``InstinctStore.aclose``: the store holds no
+        long-lived connection, so the only thing to clean up is the WAL sidecar
+        an idle tenant would otherwise leave growing behind an evicted handle.
+        Best-effort and idempotent — eviction must never raise.
+        """
+        self._initialized = False
+        try:
+            async with aiosqlite.connect(self._db_path) as db:
+                await db.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        except Exception:  # noqa: BLE001 — eviction cleanup is best-effort
+            logger.debug("AgentLedgerStore.aclose checkpoint skipped", exc_info=True)
+
+    # ---------------- Write ----------------
+
+    async def append(self, row: LedgerRow) -> bool:
+        """Append one row. Returns True when a NEW row landed.
+
+        ``False`` means ``(kind, ref)`` was already recorded — a replay, not a
+        failure, and the single most useful thing a caller can learn here. The
+        dedupe is done by the UNIQUE constraint via ``ON CONFLICT DO NOTHING``
+        rather than by a read-then-write, so two concurrent emitters for the
+        same beat cannot both see "absent" and both insert.
+
+        This method does NOT swallow errors. Fail-soft is the EMITTER's job
+        (each wraps its own call), because a store that silently eats every
+        write would also hide a broken schema from the tests that exist to
+        catch it.
+        """
+        await self._ensure_schema()
+        async with self._conn() as db:
+            cur = await db.execute(
+                "INSERT INTO agent_ledger_events"
+                " (agent_id, workspace_id, surface, kind, outcome, value_cents,"
+                "  currency, ref, actor, attrs, ts)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+                " ON CONFLICT (kind, ref) DO NOTHING",
+                (
+                    row.agent_id,
+                    row.workspace_id,
+                    row.surface,
+                    row.kind,
+                    row.outcome,
+                    row.value_cents,
+                    row.currency,
+                    row.ref,
+                    row.actor,
+                    json.dumps(row.attrs or {}, sort_keys=True),
+                    _normalize_ts(row.ts),
+                ),
+            )
+            await db.commit()
+            return (cur.rowcount or 0) > 0
+
+    # ---------------- Read ----------------
+
+    @staticmethod
+    def _filters(
+        *,
+        agent_id: str | None,
+        workspace_id: str | None,
+        since: str | None,
+        kinds: list[str] | tuple[str, ...] | None,
+        surface: str | None,
+    ) -> tuple[str, list[Any]]:
+        """Build the shared WHERE clause every read goes through.
+
+        One place, so the row list, the counts, and the value sum can never
+        disagree about which rows are in the window — the failure mode that
+        produced the chart-vs-wallet bug in the first place.
+        """
+        conditions: list[str] = []
+        params: list[Any] = []
+        # An empty-string agent_id is a MEANINGFUL filter (the unattributed
+        # bucket), so the check is `is not None`, not truthiness.
+        if agent_id is not None:
+            conditions.append("agent_id = ?")
+            params.append(agent_id)
+        if workspace_id is not None:
+            conditions.append("workspace_id = ?")
+            params.append(workspace_id)
+        if since:
+            conditions.append("ts >= ?")
+            params.append(since)
+        if kinds:
+            placeholders = ", ".join("?" for _ in kinds)
+            conditions.append(f"kind IN ({placeholders})")
+            params.extend(kinds)
+        if surface:
+            conditions.append("surface = ?")
+            params.append(surface)
+        where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+        return where, params
+
+    async def query(
+        self,
+        *,
+        agent_id: str | None = None,
+        workspace_id: str | None = None,
+        since: str | None = None,
+        kinds: list[str] | tuple[str, ...] | None = None,
+        surface: str | None = None,
+        limit: int = 100,
+    ) -> list[LedgerRow]:
+        """Rows matching the filters, newest first.
+
+        ``since`` is an aware-UTC ISO string (see
+        :func:`pocketpaw.agent_ledger.models.window_start`). ``limit`` is capped
+        at :data:`MAX_QUERY_LIMIT`.
+        """
+        where, params = self._filters(
+            agent_id=agent_id,
+            workspace_id=workspace_id,
+            since=since,
+            kinds=kinds,
+            surface=surface,
+        )
+        params.append(max(1, min(int(limit), MAX_QUERY_LIMIT)))
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                f"SELECT * FROM agent_ledger_events {where} ORDER BY ts DESC, id DESC LIMIT ?",
+                params,
+            ) as cur:
+                return [self._row_to_model(row) async for row in cur]
+
+    async def counts_by_kind(
+        self,
+        *,
+        agent_id: str | None = None,
+        workspace_id: str | None = None,
+        since: str | None = None,
+        kinds: list[str] | tuple[str, ...] | None = None,
+        surface: str | None = None,
+    ) -> dict[str, int]:
+        """``{kind: count}`` over the window — the value board's spine.
+
+        Aggregated in SQL, not by loading rows, so the board stays cheap as a
+        workspace's ledger grows (v1 deliberately ships without rollups).
+        """
+        where, params = self._filters(
+            agent_id=agent_id,
+            workspace_id=workspace_id,
+            since=since,
+            kinds=kinds,
+            surface=surface,
+        )
+        await self._ensure_schema()
+        async with self._conn() as db:
+            async with db.execute(
+                f"SELECT kind, COUNT(*) FROM agent_ledger_events {where} GROUP BY kind",
+                params,
+            ) as cur:
+                return {row[0]: row[1] async for row in cur}
+
+    async def counts_by_outcome(
+        self,
+        *,
+        agent_id: str | None = None,
+        workspace_id: str | None = None,
+        since: str | None = None,
+        surface: str | None = None,
+    ) -> dict[str, int]:
+        """``{outcome: count}`` over the verdict rows in the window.
+
+        Rows with a NULL outcome are excluded — they carry no verdict, and
+        folding them into an "unknown" bucket here would make the solved-ratio
+        denominator silently include every approval that was never verified.
+        """
+        where, params = self._filters(
+            agent_id=agent_id,
+            workspace_id=workspace_id,
+            since=since,
+            kinds=None,
+            surface=surface,
+        )
+        clause = f"{where} AND outcome IS NOT NULL" if where else "WHERE outcome IS NOT NULL"
+        await self._ensure_schema()
+        async with self._conn() as db:
+            async with db.execute(
+                f"SELECT outcome, COUNT(*) FROM agent_ledger_events {clause} GROUP BY outcome",
+                params,
+            ) as cur:
+                return {row[0]: row[1] async for row in cur}
+
+    async def value_by_currency(
+        self,
+        *,
+        agent_id: str | None = None,
+        workspace_id: str | None = None,
+        since: str | None = None,
+        surface: str | None = None,
+    ) -> dict[str, int]:
+        """``{currency: summed minor units}`` over the window.
+
+        Grouped by currency rather than returning one total on purpose: adding
+        cents to pence produces a number that is wrong in a way nobody can see.
+        A caller that wants a single headline figure picks the currency itself
+        and is forced to notice when there is more than one.
+        """
+        where, params = self._filters(
+            agent_id=agent_id,
+            workspace_id=workspace_id,
+            since=since,
+            kinds=None,
+            surface=surface,
+        )
+        clause = (
+            f"{where} AND value_cents IS NOT NULL" if where else "WHERE value_cents IS NOT NULL"
+        )
+        await self._ensure_schema()
+        async with self._conn() as db:
+            async with db.execute(
+                f"SELECT COALESCE(currency, ''), SUM(value_cents)"
+                f" FROM agent_ledger_events {clause} GROUP BY COALESCE(currency, '')",
+                params,
+            ) as cur:
+                return {row[0]: int(row[1] or 0) async for row in cur}
+
+    @staticmethod
+    def _row_to_model(row: Any) -> LedgerRow:
+        """Rebuild a :class:`LedgerRow` from a DB row.
+
+        ``attrs`` decodes permissively: a corrupt JSON blob yields an empty dict
+        rather than breaking a whole page of the board over one bad row. The
+        ``kind`` validator still runs — a row whose kind left the vocabulary
+        between write and read SHOULD be loud, because that means the closed
+        core moved under a deployed store.
+        """
+        try:
+            attrs = json.loads(row["attrs"]) if row["attrs"] else {}
+        except (TypeError, ValueError):
+            attrs = {}
+        if not isinstance(attrs, dict):
+            attrs = {}
+        return LedgerRow(
+            id=row["id"],
+            agent_id=row["agent_id"] or "",
+            workspace_id=row["workspace_id"] or "",
+            surface=row["surface"],
+            kind=row["kind"],
+            outcome=row["outcome"],
+            value_cents=row["value_cents"],
+            currency=row["currency"],
+            ref=row["ref"],
+            actor=row["actor"],
+            attrs=attrs,
+            ts=row["ts"],
+        )

--- a/src/pocketpaw/instinct/models.py
+++ b/src/pocketpaw/instinct/models.py
@@ -1,5 +1,14 @@
 # Instinct data models — decision pipeline types.
 # Created: 2026-03-28
+# Updated: 2026-07-31 (AL-1, agent ledger spine) — added an ADDITIVE, optional
+#   ``Action.actor_agent_id``. Until now the only record of WHICH agent proposed
+#   an action was a free-text ``trigger.source`` string ("paw_bar:<widget_id>",
+#   "belt:develop") — parseable by a human, not joinable by a query. That gap is
+#   why "what did my agents do for me?" could not be asked: the approval
+#   pipeline every agent kind funnels through did not carry the agent. The field
+#   is a plain str defaulting to "" and nothing validates it as non-empty on
+#   purpose: an unattributed proposal must stay legal, land its row, and show up
+#   in an honest "unattributed" bucket rather than being dropped or blocked.
 # Updated: 2026-06-18 (feat/branch-primitive-instinct-gate, BP-3) — added an
 #   ADDITIVE, nullable ``Action.scope_type`` so an Action can be scoped to a
 #   GENERIC artifact (pocket / site / dashboard / …) instead of being implicitly
@@ -133,6 +142,14 @@ class Action(BaseModel):
     # scope_type. Purely additive — nothing was renamed, so the pocket pipeline
     # is unchanged.
     scope_type: str | None = None
+    # ``actor_agent_id`` (AL-1) names the AGENT that proposed this action, so an
+    # approval can be attributed to the worker that asked for it rather than
+    # inferred from a trigger string. Stamped best-effort at the propose call
+    # sites that know it (paw-bar reads its widget's bound agent; a chat run
+    # knows its own; a belt station knows its identity). "" is legal and
+    # permanent-by-design: an action nobody could attribute still belongs in the
+    # ledger, counted honestly as unattributed.
+    actor_agent_id: str = ""
     pocket_id: str
     title: str
     description: str

--- a/src/pocketpaw/instinct/store.py
+++ b/src/pocketpaw/instinct/store.py
@@ -1,5 +1,31 @@
 # Instinct store — async SQLite operations for the decision pipeline.
 # Created: 2026-03-28 — Action lifecycle + audit log.
+# Updated: 2026-07-31 (AL-1, agent ledger spine) — two additions, one column and
+#   one emit:
+#   * ``instinct_actions`` gains ``actor_agent_id TEXT DEFAULT ''`` (additive
+#     ALTER, same swallow-the-duplicate pattern as assignee / workspace_id /
+#     scope_type). ``propose`` stamps it; ``_row_to_action`` key-checks it back.
+#     Attribution has to be persisted at PROPOSE time because that is the only
+#     moment anyone still knows which agent asked — by approval time the request
+#     is just a row in a queue.
+#   * ``_update_status`` emits ONE agent-ledger row after its transaction
+#     commits. This is THE CHOKE POINT, chosen over the EE instinct router
+#     because every lifecycle write in the codebase funnels through here:
+#     approve / auto_approve / reject / bulk_approve / bulk_reject /
+#     mark_executed / mark_failed, called from the EE instinct router, the
+#     auto-triager, Mission Control's bulk bar, the cloud approvals service, the
+#     discovery orchestrator, and half a dozen executors. Emitting at the router
+#     would have missed most of those; emitting at each call site would BE the
+#     fragmentation this ledger exists to end. Because every agent kind proposes
+#     through this gate, belt stations and deep-work get ledger rows for free.
+#     The emit runs AFTER the commit and OUTSIDE the AuditChainError try block,
+#     and can never raise — see ``_emit_ledger``. A ledger failure must not cost
+#     anyone an approval. NOTE the deliberate asymmetry with the W2b audit
+#     ledger directly above it: the audit ledger is LOUD (a decision that cannot
+#     be audited must not succeed, because it is the legal trail), while the
+#     agent ledger is SILENT (it is analytics, and analytics is never worth
+#     failing a human's click over). Two ledgers, two failure postures, on
+#     purpose.
 # Updated: 2026-07-05 (fix/atlas-admin-security-hardening, FINDING B) — closed a
 #   TOCTOU double-flip in ``_update_status``. The ``require_status`` guard was a
 #   Python pre-check between ``get_action`` and the UPDATE, whose WHERE was
@@ -151,6 +177,12 @@ from typing import Any
 
 import aiosqlite
 
+from pocketpaw.agent_ledger.models import (
+    KIND_ACTION_APPROVED,
+    KIND_ACTION_OUTCOME,
+    KIND_ACTION_REJECTED,
+    LedgerActor,
+)
 from pocketpaw.instinct.correction import Correction, CorrectionPatch
 from pocketpaw.instinct.models import (
     Action,
@@ -161,11 +193,75 @@ from pocketpaw.instinct.models import (
     ActionTrigger,
     AuditCategory,
     AuditEntry,
+    OutcomeStatus,
     OutcomeVerdict,
 )
 from pocketpaw.instinct.trace import FabricObjectSnapshot, ReasoningTrace
 
 logger = logging.getLogger(__name__)
+
+# AL-1 — which lifecycle events become ledger rows, and what verdict (if any)
+# the event itself implies. ``None`` in the second slot means "read the verdict
+# off the action's own outcome".
+#
+# ``action_auto_approved`` maps to the SAME kind as a human approval: the funnel
+# question is "did this get through", and splitting the kind would make every
+# consumer sum two things to answer it. The machine-ness rides as an attribute
+# instead (see ``_emit_ledger``).
+#
+# ``action_failed`` is a real ``not_solved`` verdict, not a missing one: an
+# action that errored demonstrably did not solve the problem, and a board that
+# counts only successes is the kind of dashboard people stop trusting.
+#
+# ``action_proposed`` is absent on purpose — it is written by ``propose``, not by
+# ``_update_status``, and belongs to a later slice. Anything unmapped is skipped
+# rather than guessed at.
+_LEDGER_KIND_BY_EVENT: dict[str, tuple[str, str | None]] = {
+    "action_approved": (KIND_ACTION_APPROVED, None),
+    "action_auto_approved": (KIND_ACTION_APPROVED, None),
+    "action_rejected": (KIND_ACTION_REJECTED, None),
+    "action_executed": (KIND_ACTION_OUTCOME, None),
+    "action_failed": (KIND_ACTION_OUTCOME, OutcomeStatus.NOT_SOLVED.value),
+}
+
+# Lifecycle events whose decider is a machine, whatever string is in ``actor``.
+_MACHINE_EVENTS = frozenset({"action_auto_approved", "action_executed", "action_failed"})
+
+
+def _ledger_outcome(action: Action, event_verdict: str | None) -> str | None:
+    """The OutcomeStatus value for a ledger row, or None when there is no verdict.
+
+    An approval and a rejection carry no verdict — whether the thing worked is a
+    separate, later question (issue #1162's whole point: a completed action is an
+    *output*; whether it solved the problem is an *outcome*). Only the outcome
+    kinds resolve to a value here, and a legacy free-text outcome resolves to
+    ``unknown`` rather than being parsed for optimism.
+    """
+    if event_verdict is not None:
+        return event_verdict
+    if isinstance(action.outcome, OutcomeVerdict):
+        return action.outcome.status.value
+    return None
+
+
+def _ledger_actor(event: str, actor: str) -> str:
+    """Classify the decider as visitor / owner / agent / system.
+
+    The raw ``actor`` string is kept verbatim in ``attrs`` — this is the coarse
+    bucket the board groups by. Anything the system did to itself (auto-triage,
+    execution, failure) or that carries a ``system``/``agent`` prefix classifies
+    as such; everything else is a human operator, because the only other thing
+    that reaches this code path is a person clicking approve or reject.
+    """
+
+    if event in _MACHINE_EVENTS:
+        return LedgerActor.SYSTEM.value
+    raw = str(actor or "").strip().lower()
+    if raw.startswith("system"):
+        return LedgerActor.SYSTEM.value
+    if raw.startswith("agent"):
+        return LedgerActor.AGENT.value
+    return LedgerActor.OWNER.value
 
 
 def _serialize_outcome(outcome: str | OutcomeVerdict | None) -> str | None:
@@ -329,6 +425,11 @@ CREATE TABLE IF NOT EXISTS instinct_actions (
     -- Tenancy (W4a): the owning workspace. NULL = legacy/global row written
     -- before tenancy or by a non-cloud OSS caller; a scoped read still sees it.
     workspace_id TEXT,
+    -- Attribution (AL-1): the agent that PROPOSED this action, so the agent
+    -- ledger can key the approval to the worker that asked for it. '' means
+    -- unattributed, which stays legal forever — the proposer is not always
+    -- knowable, and refusing the proposal over it would be absurd.
+    actor_agent_id TEXT DEFAULT '',
     created_at TEXT DEFAULT (datetime('now')),
     updated_at TEXT DEFAULT (datetime('now')),
     executed_at TEXT
@@ -477,6 +578,17 @@ class InstinctStore:
                 await db.execute("ALTER TABLE instinct_actions ADD COLUMN scope_type TEXT")
             except aiosqlite.OperationalError:
                 pass
+            # Additive migration (AL-1): the proposing agent's id on a
+            # pre-existing actions table. Same swallow-the-duplicate pattern.
+            # Pre-existing rows keep '' (unattributed) — deliberately NOT
+            # backfilled from trigger.source, because a guessed attribution in
+            # an evidence table is worse than an honest blank.
+            try:
+                await db.execute(
+                    "ALTER TABLE instinct_actions ADD COLUMN actor_agent_id TEXT DEFAULT ''"
+                )
+            except aiosqlite.OperationalError:
+                pass
             # Tenancy indexes created only after the column is guaranteed to
             # exist — see _WORKSPACE_INDEX_SQL note above. Inside SCHEMA_SQL this
             # would fail on a pre-W4a DB. The scope index follows the same rule.
@@ -530,9 +642,18 @@ class InstinctStore:
         assignee: str | None = None,
         workspace_id: str | None = None,
         scope_type: str | None = None,
+        actor_agent_id: str = "",
     ) -> Action:
+        """Raise a proposal for a human to decide.
+
+        ``actor_agent_id`` (AL-1) names the agent doing the asking. It is
+        optional and defaults to "" so every existing caller is unaffected;
+        callers that know their agent should pass it, because propose time is
+        the last moment that knowledge exists in the request.
+        """
         action = Action(
             scope_type=scope_type,
+            actor_agent_id=str(actor_agent_id or ""),
             pocket_id=pocket_id,
             title=title,
             description=description,
@@ -551,8 +672,8 @@ class InstinctStore:
                 " (id, pocket_id, title, description,"
                 " category, status, priority, trigger,"
                 " recommendation, parameters, context, assignee, workspace_id,"
-                " scope_type)"
-                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                " scope_type, actor_agent_id)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     action.id,
                     pocket_id,
@@ -568,6 +689,7 @@ class InstinctStore:
                     assignee,
                     workspace_id,
                     scope_type,
+                    action.actor_agent_id,
                 ),
             )
             await db.commit()
@@ -848,6 +970,10 @@ class InstinctStore:
             description=f"{event.replace('_', ' ').title()}: {action.title}{extra_desc}",
             context=audit_context or {},
         )
+        # Declared out here (not inside the `async with`) so the post-commit
+        # agent-ledger emit can route to the same tenant's ledger file the
+        # action itself belongs to.
+        workspace_id: str | None = None
         try:
             async with self._log_lock, self._conn() as db:
                 await db.execute("BEGIN")
@@ -868,7 +994,6 @@ class InstinctStore:
                 # audit row (approve / reject / execute / fail) is stamped with
                 # the same tenant the action belongs to. Done with a tiny direct
                 # read rather than widening the Action model.
-                workspace_id: str | None = None
                 db.row_factory = aiosqlite.Row
                 async with db.execute(
                     "SELECT workspace_id FROM instinct_actions WHERE id = ?", (action_id,)
@@ -889,7 +1014,115 @@ class InstinctStore:
                 f"failed to append audit entry {entry.id} ({event}) to the "
                 f"tamper-evident ledger: {exc}"
             ) from exc
-        return await self.get_action(action_id)
+        updated = await self.get_action(action_id)
+        # AL-1 — the agent-ledger emit. Deliberately placed HERE: after the
+        # commit (so we only ever record something that actually happened) and
+        # after the reload (so the row carries the final outcome), and outside
+        # the try above so it can never be mistaken for an audit-chain failure.
+        if updated is not None:
+            await self._emit_ledger(updated, event=event, actor=actor, workspace_id=workspace_id)
+        return updated
+
+    async def _emit_ledger(
+        self,
+        action: Action,
+        *,
+        event: str,
+        actor: str,
+        workspace_id: str | None,
+    ) -> None:
+        """Record one lifecycle beat in the agent ledger. NEVER raises.
+
+        The fail-soft contract is the whole point and is not negotiable: this
+        function sits on the approval hot path, and an operator's click must not
+        fail because an analytics table was locked, missing, or misconfigured.
+        Every failure mode — a workspace that can't resolve a store
+        (``WorkspaceScopeRequired`` in cloud mode is a REAL possibility here for
+        a NULL-workspace action), a disk error, a vocabulary rejection — is
+        caught and logged at debug. Same posture as ``paw_bar/notify.py``.
+
+        The cost of that silence is that a broken emitter is INVISIBLE, which is
+        exactly why the design pairs it with a reconcile endpoint (AL-4)
+        comparing Instinct's own counts against the ledger's. Fail-soft plus a
+        drift alarm; fail-soft alone would be how you find out in a quarter.
+
+        Deliberately absent from the row: tokens, cost, latency. They live in
+        the run doc / usage tracker and are read federated. Two meters for one
+        number is a bug we have already paid for once.
+        """
+        try:
+            # The row vocabulary is a plain leaf module (no cycle) — imported
+            # here only to keep the whole emit inside one try, so even an import
+            # failure degrades to "no ledger row" instead of "no approval".
+            from pocketpaw.agent_ledger.models import (
+                ATTR_ACTION_CATEGORY,
+                ATTR_ACTION_ID,
+                ATTR_AGENT_ID,
+                ATTR_APPROVAL_AUTO,
+                ATTR_DECISION_ACTOR,
+                ATTR_INSTINCT_EVENT,
+                ATTR_POCKET_ID,
+                ATTR_SCOPE_TYPE,
+                LedgerRow,
+                surface_from_trigger,
+            )
+
+            # The store factory, on the other hand, MUST be lazy:
+            # pocketpaw.stores imports THIS module at module level, so a
+            # top-level import would be circular. Same trick the ``_log_lock``
+            # property uses for ``_store_locks``.
+            from pocketpaw.stores import get_agent_ledger_store
+
+            mapped = _LEDGER_KIND_BY_EVENT.get(event)
+            if mapped is None:
+                # Not every lifecycle event is a value beat — ``action_proposed``
+                # is emitted by ``propose`` (a different write path), and a
+                # future event should be added here consciously rather than
+                # landing under a guessed kind.
+                return
+            kind, outcome_for_event = mapped
+
+            attrs: dict[str, Any] = {
+                ATTR_ACTION_ID: action.id,
+                ATTR_ACTION_CATEGORY: action.category.value,
+                ATTR_INSTINCT_EVENT: event,
+                ATTR_DECISION_ACTOR: actor,
+                ATTR_POCKET_ID: action.pocket_id,
+            }
+            if action.actor_agent_id:
+                attrs[ATTR_AGENT_ID] = action.actor_agent_id
+            if action.scope_type:
+                attrs[ATTR_SCOPE_TYPE] = action.scope_type
+            if event == "action_auto_approved":
+                # Same KIND as a human approval — an approval is an approval —
+                # with the machine-ness as an attribute. That keeps the funnel
+                # count honest while still letting AL-5 draw the trust curve
+                # (autonomy rising) off one flag instead of two kinds.
+                attrs[ATTR_APPROVAL_AUTO] = True
+
+            row = LedgerRow(
+                agent_id=action.actor_agent_id or "",
+                workspace_id=workspace_id or "",
+                surface=surface_from_trigger(action.trigger.type, action.trigger.source),
+                kind=kind,
+                outcome=_ledger_outcome(action, outcome_for_event),
+                # ``ref`` is the action id, so UNIQUE(kind, ref) means one
+                # approved / rejected / outcome row per action no matter how
+                # many times a retry, a bulk replay, or the un-CAS'd reject path
+                # fires the same transition.
+                ref=action.id,
+                actor=_ledger_actor(event, actor),
+                attrs=attrs,
+            )
+            store = get_agent_ledger_store(workspace_id=(workspace_id or None))
+            await store.append(row)
+        except Exception:  # noqa: BLE001 — bookkeeping never breaks a decision
+            logger.debug(
+                "agent-ledger emit skipped for action %s (%s)",
+                getattr(action, "id", "<unknown>"),
+                event,
+                exc_info=True,
+            )
 
     async def get_action(self, action_id: str) -> Action | None:
         await self._ensure_schema()
@@ -1548,6 +1781,10 @@ class InstinctStore:
         # so a pre-migration row missing the column doesn't raise. NULL/absent
         # stays None (legacy pocket scope).
         scope_type = row["scope_type"] if "scope_type" in row.keys() else None
+        # AL-1 — the proposing agent. Key-checked like the two above so a row
+        # from a DB that has not run the ALTER yet reads as unattributed rather
+        # than raising IndexError on every list.
+        actor_agent_id = (row["actor_agent_id"] if "actor_agent_id" in row.keys() else "") or ""
         # The SQLite layer stamps created_at/updated_at as ISO strings.
         # Forward them on the rebuilt Action so consumers (outcome window
         # filters, age sorting) see real history instead of "now". Old
@@ -1557,6 +1794,7 @@ class InstinctStore:
         return Action(
             id=row["id"],
             scope_type=scope_type,
+            actor_agent_id=actor_agent_id,
             pocket_id=row["pocket_id"],
             title=row["title"],
             description=row["description"] or "",

--- a/src/pocketpaw/instinct/store.py
+++ b/src/pocketpaw/instinct/store.py
@@ -1051,9 +1051,16 @@ class InstinctStore:
         number is a bug we have already paid for once.
         """
         try:
-            # The row vocabulary is a plain leaf module (no cycle) — imported
-            # here only to keep the whole emit inside one try, so even an import
-            # failure degrades to "no ledger row" instead of "no approval".
+            # Re-imported inside the guard so a monkeypatched module is picked up
+            # at call time. Note what this does NOT buy: the same names are
+            # imported at MODULE level (see the top of this file), so a broken
+            # vocabulary module fails the import of pocketpaw.instinct.store
+            # itself, long before this guard runs. An earlier version of this
+            # comment claimed the guard covered import failure too. It does not,
+            # and pretending otherwise is worse than the gap — the fail-soft
+            # promise here covers the STORE (locked, full, misconfigured, or
+            # workspace-unresolvable), which is the failure that actually happens
+            # in production.
             from pocketpaw.agent_ledger.models import (
                 ATTR_ACTION_CATEGORY,
                 ATTR_ACTION_ID,
@@ -1067,11 +1074,10 @@ class InstinctStore:
                 surface_from_trigger,
             )
 
-            # The store factory, on the other hand, MUST be lazy:
-            # pocketpaw.stores imports THIS module at module level, so a
-            # top-level import would be circular. Same trick the ``_log_lock``
-            # property uses for ``_store_locks``.
-            from pocketpaw.stores import get_agent_ledger_store
+            # The ledger store class MUST be imported lazily: pocketpaw.stores
+            # imports THIS module at module level, so a top-level import would
+            # be circular. Same trick the ``_log_lock`` property uses for
+            # ``_store_locks``.
 
             mapped = _LEDGER_KIND_BY_EVENT.get(event)
             if mapped is None:
@@ -1114,7 +1120,15 @@ class InstinctStore:
                 actor=_ledger_actor(event, actor),
                 attrs=attrs,
             )
-            store = get_agent_ledger_store(workspace_id=(workspace_id or None))
+            # Route the ledger file BESIDE this instinct.db rather than
+            # re-resolving the in-row ``workspace_id`` through the factory: that
+            # column is not guaranteed to be a store-path token. See
+            # ``get_agent_ledger_store_beside`` for the full reasoning — it lives
+            # in stores.py so this stays inside the ISO-4 store-isolation seam
+            # instead of being the one direct construction that erodes it.
+            from pocketpaw.stores import get_agent_ledger_store_beside
+
+            store = get_agent_ledger_store_beside(self._db_path)
             await store.append(row)
         except Exception:  # noqa: BLE001 — bookkeeping never breaks a decision
             logger.debug(

--- a/src/pocketpaw/stores.py
+++ b/src/pocketpaw/stores.py
@@ -516,6 +516,36 @@ def get_agent_ledger_store(*, workspace_id: str | None = None) -> AgentLedgerSto
     return _get_workspace_store(_AGENT_LEDGER_KIND, workspace_id)
 
 
+def get_agent_ledger_store_beside(sibling_db_path: str | Path) -> AgentLedgerStore:
+    """Return the AgentLedgerStore living NEXT TO an already-resolved store file.
+
+    For emitters that hold an open store but no trustworthy workspace TOKEN.
+
+    The Instinct emitter is the case this exists for. It runs inside
+    ``InstinctStore``, which knows only its own ``db_path`` — and the workspace
+    value nearest to hand there is the action's IN-ROW ``workspace_id``, which is
+    not guaranteed to be a store-path token. The paw-bar decision loop
+    deliberately keeps two different values apart (see its module header): a real
+    workspace for file routing, and ``resolve_workspace_id``, which falls back to
+    the widget OWNER label for in-row scope only. Feeding that owner label to
+    :func:`get_agent_ledger_store` either raises inside ``_safe_workspace_dir``
+    (swallowed by the emitter's guard → the row silently vanishes) or writes into
+    a directory keyed by a user id that no reader ever opens. Either way the
+    primary producer under-counts in silence.
+
+    Whoever opened the sibling store already resolved the workspace correctly, so
+    the directory is the answer — no second resolution, no second chance to get it
+    wrong. Kept HERE rather than at the call site on purpose: ``stores.py`` is the
+    approved seam, so this stays inside the ISO-4 store-isolation guard instead of
+    becoming the one direct construction that erodes it.
+
+    Deliberately NOT cached: the caller already holds a long-lived store, these
+    objects are thin path wrappers, and keying an LRU by path would be a second
+    cache that can disagree with the workspace-keyed one.
+    """
+    return AgentLedgerStore(Path(sibling_db_path).with_name(f"{_AGENT_LEDGER_KIND.name}.db"))
+
+
 # ---------------------------------------------------------------------------
 # Paw Bar — plain process-wide singleton (NOT workspace-isolated yet)
 # ---------------------------------------------------------------------------

--- a/src/pocketpaw/stores.py
+++ b/src/pocketpaw/stores.py
@@ -1,3 +1,14 @@
+# Updated: 2026-07-31 (AL-1, agent ledger spine) — registered a THIRD
+#   workspace-keyed store kind, ``agent_ledger``, and its public factory
+#   ``get_agent_ledger_store``. It is wired through the same generic
+#   ``_StoreKind`` engine Fabric (ISO-1) and Instinct (ISO-2) use, which the
+#   module docstring already promised would make a third store a one-liner —
+#   this is that one-liner. Doing it this way (rather than a Paw-Bar-style
+#   process-wide singleton) is deliberate: the ledger is per-tenant analytics, so
+#   it must inherit the per-workspace file routing, the path-traversal allowlist,
+#   the fail-closed ``POCKETPAW_REQUIRE_WORKSPACE_SCOPE`` guard, and the bounded
+#   LRU that aclose()s evicted handles — every one of which would have to be
+#   re-implemented (and could drift) if it got its own factory.
 # Updated: 2026-07-08 — Renamed widget "Paw Print" → "Paw Bar": get_paw_print_store→
 #   get_paw_bar_store, PawPrintStore→PawBarStore, paw_print.db→paw_bar.db. The separate
 #   one-word audit feed (past-tense record) is a DIFFERENT feature and is not affected.
@@ -76,6 +87,7 @@ from pathlib import Path
 from typing import Any
 
 from pocketpaw._registry import first
+from pocketpaw.agent_ledger.store import AgentLedgerStore
 from pocketpaw.fabric.store import FabricStore
 from pocketpaw.instinct.store import InstinctStore
 from pocketpaw.paw_bar.store import PawBarStore
@@ -235,10 +247,12 @@ class _StoreKind:
 
 
 # The registry of workspace-keyed store kinds. Fabric is wired by ISO-1, Instinct
-# by ISO-2. Paw Bar stays a plain shared singleton (not tenant-isolated yet).
+# by ISO-2, the agent ledger by AL-1. Paw Bar stays a plain shared singleton (not
+# tenant-isolated yet).
 _FABRIC_KIND = _StoreKind(name="fabric", cls=FabricStore)
 _INSTINCT_KIND = _StoreKind(name="instinct", cls=InstinctStore)
-_STORE_KINDS: tuple[_StoreKind, ...] = (_FABRIC_KIND, _INSTINCT_KIND)
+_AGENT_LEDGER_KIND = _StoreKind(name="agent_ledger", cls=AgentLedgerStore)
+_STORE_KINDS: tuple[_StoreKind, ...] = (_FABRIC_KIND, _INSTINCT_KIND, _AGENT_LEDGER_KIND)
 _KIND_BY_NAME: dict[str, _StoreKind] = {k.name: k for k in _STORE_KINDS}
 
 
@@ -476,6 +490,30 @@ def get_instinct_store(*, workspace_id: str | None = None) -> InstinctStore:
     inherited from the generic factory.
     """
     return _get_workspace_store(_INSTINCT_KIND, workspace_id)
+
+
+def get_agent_ledger_store(*, workspace_id: str | None = None) -> AgentLedgerStore:
+    """Return the AgentLedgerStore for the resolved workspace (AL-1).
+
+    Same contract as :func:`get_instinct_store`, through the same generic
+    factory: explicit ``workspace_id`` arg → ``current_workspace`` ContextVar →
+    ``None``.
+
+    * A resolved workspace returns a per-workspace store at
+      ``~/.pocketpaw/workspaces/<workspace_id>/agent_ledger.db``.
+    * No workspace + ``POCKETPAW_REQUIRE_WORKSPACE_SCOPE`` truthy → raises
+      :class:`WorkspaceScopeRequired` (fail-closed; never a shared read).
+    * No workspace + flag unset → the legacy shared
+      ``~/.pocketpaw/agent_ledger.db`` singleton, so a self-hosted single-tenant
+      box works with no cloud at all.
+
+    The in-row ``workspace_id`` column on every ledger row is the second layer,
+    exactly as W4a is for Instinct. Note that EVERY caller of this factory is a
+    fail-soft emitter or a read endpoint: the fail-closed raise above is real and
+    an emitter with no workspace WILL hit it in cloud mode, which is why each
+    emitter wraps its own resolve-and-append rather than assuming this returns.
+    """
+    return _get_workspace_store(_AGENT_LEDGER_KIND, workspace_id)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cloud/test_agent_ledger_endpoint.py
+++ b/tests/cloud/test_agent_ledger_endpoint.py
@@ -1,0 +1,224 @@
+# tests/cloud/test_agent_ledger_endpoint.py — GET /agents/{id}/ledger (AL-1).
+# Created: 2026-07-31. Covers the read side of the ledger spine:
+#   * the payload shape the AL-5 value strip is built against;
+#   * that every aggregate is computed over the SAME window and agrees with the
+#     rows listed beneath it (the chart-vs-wallet lesson, asserted rather than
+#     hoped for);
+#   * that a bad window is a 422, not a silent fallback to the default;
+#   * that value is reported per-currency and gets NO headline total when the
+#     ledger holds more than one currency;
+#   * that an agent with no rows returns a well-formed empty payload instead of
+#     a broken grid;
+#   * that the visibility gate runs BEFORE any read, so a private agent's track
+#     record is not readable by another member.
+#
+# The router is mounted standalone with the auth/licence dependencies overridden
+# and the agents service stubbed, so this exercises the endpoint's own logic
+# without a Mongo round-trip. The ledger itself is real — the whole point is to
+# prove the endpoint and the store agree.
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from pocketpaw import stores
+from pocketpaw.agent_ledger.models import (
+    KIND_ACTION_APPROVED,
+    KIND_ACTION_OUTCOME,
+    KIND_ACTION_REJECTED,
+    KIND_VISITOR_ACTION,
+    SURFACE_PAW_BAR,
+    LedgerActor,
+    LedgerRow,
+)
+from pocketpaw.instinct.models import OutcomeStatus
+
+_WS = "ws1"
+_AGENT = "agent-42"
+
+
+def _row(**overrides) -> LedgerRow:
+    base = dict(
+        agent_id=_AGENT,
+        workspace_id=_WS,
+        surface=SURFACE_PAW_BAR,
+        kind=KIND_ACTION_APPROVED,
+        ref="act_1",
+        actor=LedgerActor.OWNER.value,
+    )
+    base.update(overrides)
+    return LedgerRow(**base)
+
+
+@pytest_asyncio.fixture
+async def client(tmp_path, monkeypatch):
+    """A standalone app around the agents router, on an isolated ledger file."""
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.cloud.agents import service as agents_service
+    from pocketpaw_ee.cloud.agents.router import router
+    from pocketpaw_ee.cloud.license import require_license
+    from pocketpaw_ee.cloud.shared.deps import current_user_id, current_workspace_id
+
+    monkeypatch.setattr(stores, "_DATA_DIR", tmp_path)
+    monkeypatch.delenv("POCKETPAW_REQUIRE_WORKSPACE_SCOPE", raising=False)
+    stores.reset_store_caches()
+
+    async def _allow(agent_id, workspace_id, user_id):  # noqa: ARG001
+        return None
+
+    monkeypatch.setattr(agents_service, "ensure_can_read", _allow)
+
+    app = FastAPI()
+    # The real app installs this; without it a domain error (NotFound) escapes
+    # as an unhandled exception instead of the 404 the client would really get.
+    add_error_handler(app)
+    app.include_router(router)
+    app.dependency_overrides[require_license] = lambda: None
+    app.dependency_overrides[current_workspace_id] = lambda: _WS
+    app.dependency_overrides[current_user_id] = lambda: "user:maya"
+
+    ledger = stores.get_agent_ledger_store(workspace_id=_WS)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        yield c, ledger
+    # Deliberately NO reset_store_caches() here: eviction schedules an async
+    # WAL checkpoint on the loop that is about to close, which surfaces as
+    # "Event loop is closed" thread noise. The setup-side reset above (which
+    # runs on a live loop) is what actually keeps tests isolated.
+
+
+@pytest.mark.asyncio
+async def test_ledger_payload_reports_the_full_track_record(client):
+    c, ledger = client
+    await ledger.append(_row(ref="a1", kind=KIND_ACTION_APPROVED))
+    await ledger.append(_row(ref="a2", kind=KIND_ACTION_APPROVED))
+    await ledger.append(_row(ref="a3", kind=KIND_ACTION_REJECTED))
+    await ledger.append(
+        _row(ref="a4", kind=KIND_ACTION_OUTCOME, outcome=OutcomeStatus.SOLVED.value)
+    )
+    await ledger.append(
+        _row(ref="a5", kind=KIND_ACTION_OUTCOME, outcome=OutcomeStatus.NOT_SOLVED.value)
+    )
+    await ledger.append(
+        _row(
+            ref="a6",
+            kind=KIND_VISITOR_ACTION,
+            value_cents=4200,
+            currency="USD",
+            actor=LedgerActor.VISITOR.value,
+        )
+    )
+
+    res = await c.get(f"/agents/{_AGENT}/ledger?window=30d")
+    assert res.status_code == 200
+    body = res.json()
+
+    assert body["agent_id"] == _AGENT
+    assert body["window"] == "30d"
+    assert body["counts_by_kind"] == {
+        KIND_ACTION_APPROVED: 2,
+        KIND_ACTION_REJECTED: 1,
+        KIND_ACTION_OUTCOME: 2,
+        KIND_VISITOR_ACTION: 1,
+    }
+    assert body["total_events"] == 6
+
+    # The ratio ships with its denominator: "50% solved" out of two is a very
+    # different claim from "50% solved" out of two hundred.
+    assert body["outcome"]["decided"] == 2
+    assert body["outcome"]["counts"] == {
+        OutcomeStatus.SOLVED.value: 1,
+        OutcomeStatus.NOT_SOLVED.value: 1,
+    }
+    assert body["outcome"]["ratio"] == {
+        OutcomeStatus.SOLVED.value: 0.5,
+        OutcomeStatus.NOT_SOLVED.value: 0.5,
+    }
+
+    assert body["value"] == {"by_currency": {"USD": 4200}, "currency": "USD", "total_cents": 4200}
+
+    # The rows agree with the aggregates above them — same filter, one source.
+    assert len(body["recent"]) == 6
+    assert sum(1 for r in body["recent"] if r["kind"] == KIND_ACTION_APPROVED) == 2
+    # Ops metrics stay federated: nothing here leaks a token or cost field.
+    assert all(
+        not any(k in r["attrs"] for k in ("tokens", "cost", "latency")) for r in body["recent"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_mixed_currencies_get_no_headline_total(client):
+    """Summing cents and pence produces a number that is wrong invisibly."""
+    c, ledger = client
+    await ledger.append(_row(ref="v1", kind=KIND_VISITOR_ACTION, value_cents=100, currency="USD"))
+    await ledger.append(_row(ref="v2", kind=KIND_VISITOR_ACTION, value_cents=200, currency="GBP"))
+
+    body = (await c.get(f"/agents/{_AGENT}/ledger")).json()
+    assert body["value"]["by_currency"] == {"USD": 100, "GBP": 200}
+    assert body["value"]["currency"] == ""
+    assert body["value"]["total_cents"] == 0
+
+
+@pytest.mark.asyncio
+async def test_window_filters_and_all_is_unbounded(client):
+    c, ledger = client
+    await ledger.append(_row(ref="ancient", ts="2020-01-01T00:00:00+00:00"))
+    await ledger.append(_row(ref="fresh", kind=KIND_ACTION_REJECTED))
+
+    recent = (await c.get(f"/agents/{_AGENT}/ledger?window=7d")).json()
+    assert recent["total_events"] == 1
+    assert [r["ref"] for r in recent["recent"]] == ["fresh"]
+
+    everything = (await c.get(f"/agents/{_AGENT}/ledger?window=all")).json()
+    assert everything["total_events"] == 2
+
+
+@pytest.mark.parametrize("window", ["banana", "30", "0d", "9999d", ""])
+@pytest.mark.asyncio
+async def test_a_bad_window_is_a_422_not_a_silent_default(client, window):
+    c, _ledger = client
+    res = await c.get(f"/agents/{_AGENT}/ledger?window={window}")
+    assert res.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_an_agent_with_no_rows_returns_a_clean_empty_payload(client):
+    """A brand-new agent must render a teaching empty state, not a broken grid."""
+    c, _ledger = client
+    body = (await c.get("/agents/agent-brand-new/ledger")).json()
+    assert body["counts_by_kind"] == {}
+    assert body["total_events"] == 0
+    assert body["outcome"] == {"counts": {}, "decided": 0, "ratio": {}}
+    assert body["value"] == {"by_currency": {}, "currency": "", "total_cents": 0}
+    assert body["recent"] == []
+
+
+@pytest.mark.asyncio
+async def test_another_workspaces_rows_are_never_returned(client):
+    """In-row tenancy is the second layer under the per-workspace file."""
+    c, ledger = client
+    await ledger.append(_row(ref="mine", workspace_id=_WS))
+    await ledger.append(_row(ref="theirs", workspace_id="ws-other"))
+
+    body = (await c.get(f"/agents/{_AGENT}/ledger?window=all")).json()
+    assert [r["ref"] for r in body["recent"]] == ["mine"]
+
+
+@pytest.mark.asyncio
+async def test_the_visibility_gate_runs_before_any_read(client, monkeypatch):
+    """A private agent's track record is as protected as its config."""
+    from pocketpaw_ee.cloud.agents import service as agents_service
+    from pocketpaw_ee.cloud.shared.errors import NotFound
+
+    c, ledger = client
+    await ledger.append(_row(ref="secret"))
+
+    async def _deny(agent_id, workspace_id, user_id):  # noqa: ARG001
+        raise NotFound("agent", agent_id)
+
+    monkeypatch.setattr(agents_service, "ensure_can_read", _deny)
+    res = await c.get(f"/agents/{_AGENT}/ledger")
+    assert res.status_code in (403, 404, 500)
+    assert "secret" not in res.text

--- a/tests/test_agent_ledger.py
+++ b/tests/test_agent_ledger.py
@@ -23,6 +23,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import aiosqlite
 import pytest
 
@@ -190,6 +192,47 @@ def test_bad_windows_raise_instead_of_falling_back(window):
     """A misread window must be a refusal, never a silently different answer."""
     with pytest.raises(WindowParseError):
         parse_window(window)
+
+
+@pytest.mark.parametrize("window", ["99999999999d", "1000000000d", "999999999999w", "99999999999h"])
+def test_absurd_windows_are_a_refusal_not_a_server_error(window):
+    """An over-large window must be WindowParseError (422), never OverflowError (500).
+
+    Regression, found in review: the max-window check ran AFTER the timedelta was
+    built, and timedelta raises OverflowError — not ValueError — past C-int range
+    or its own 999999999-day cap. OverflowError is not a WindowParseError, so it
+    sailed through the router's 422 handler and surfaced as a 500. Verified live
+    before the fix: '9999d' → 422 but '99999999999d' → 500. The parametrize above
+    stopped one order of magnitude short of the bug, which is why this gets its
+    own case rather than another entry in that list.
+    """
+    with pytest.raises(WindowParseError):
+        parse_window(window)
+
+
+def test_the_ledger_is_routed_beside_the_store_that_emitted_it(tmp_path):
+    """Route by the sibling PATH, never by re-resolving an in-row workspace value.
+
+    Regression, found in review: the emitter passed the action's in-row
+    ``workspace_id`` back through the store factory. That column is not
+    guaranteed to be a store-path token — the paw-bar decision loop deliberately
+    lets it fall back to the widget OWNER label (colon-qualified) for in-row scope
+    only. Feeding that to the factory either raises inside the path allowlist
+    (swallowed by the emitter's fail-soft guard, so the row vanishes silently) or
+    writes into a directory keyed by a user id no reader opens. Either way the
+    primary producer under-counts and nothing says so.
+    """
+    from pocketpaw.stores import get_agent_ledger_store_beside
+
+    instinct_db = tmp_path / "workspaces" / "wreal01" / "instinct.db"
+    instinct_db.parent.mkdir(parents=True)
+
+    store = get_agent_ledger_store_beside(instinct_db)
+
+    assert Path(store._db_path).parent == instinct_db.parent
+    assert Path(store._db_path).name == "agent_ledger.db"
+    # A str path must resolve identically — the emitter holds ``self._db_path``.
+    assert get_agent_ledger_store_beside(str(instinct_db))._db_path == store._db_path
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_agent_ledger.py
+++ b/tests/test_agent_ledger.py
@@ -1,0 +1,562 @@
+# tests/test_agent_ledger.py — the agent ledger spine (AL-1).
+# Created: 2026-07-31. Covers the store, the vocabulary, the attribution field,
+# and the Instinct emitter, in the layers that actually protect the design:
+#
+#   * Vocabulary: a core kind is accepted, a vendor kind is accepted, an unknown
+#     paw.* kind and a malformed id are REJECTED. The closed core is a promise
+#     the model boundary has to keep, not a comment.
+#   * Store: round-trip, the UNIQUE(kind, ref) dedupe that makes a replayed
+#     approve idempotent, workspace scoping, and the SQL aggregates (a board that
+#     computed its counts differently from its rows is the chart-vs-wallet bug).
+#   * Attribution: actor_agent_id survives propose -> read, and a LEGACY
+#     instinct.db that predates the column migrates additively instead of raising
+#     "no such column" on the next list.
+#   * Emitter: an approval lands exactly one agent-keyed row, a reject and an
+#     execute land theirs, a replayed approve does NOT double-write, and — the
+#     load-bearing one — A RAISING LEDGER STORE DOES NOT BREAK THE APPROVAL.
+#     That last test is the whole fail-soft contract; if it ever goes red, the
+#     ledger has started charging an operator's click for its own bookkeeping.
+#
+# Store isolation: every test that goes through the FACTORY points
+# ``stores._DATA_DIR`` at tmp_path and resets the caches, so nothing here ever
+# reads or writes the developer's real ~/.pocketpaw.
+
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+
+from pocketpaw import stores
+from pocketpaw.agent_ledger.models import (
+    ATTR_AGENT_ID,
+    ATTR_APPROVAL_AUTO,
+    ATTR_INSTINCT_EVENT,
+    KIND_ACTION_APPROVED,
+    KIND_ACTION_OUTCOME,
+    KIND_ACTION_REJECTED,
+    KIND_VISITOR_ACTION,
+    SURFACE_BELT,
+    SURFACE_CHAT,
+    SURFACE_INSTINCT,
+    SURFACE_PAW_BAR,
+    LedgerActor,
+    LedgerKindValidationError,
+    LedgerRow,
+    WindowParseError,
+    parse_window,
+    surface_from_trigger,
+    validate_ledger_kind,
+    window_start,
+)
+from pocketpaw.agent_ledger.store import AgentLedgerStore
+from pocketpaw.instinct.models import (
+    ActionStatus,
+    ActionTrigger,
+    OutcomeStatus,
+    OutcomeVerdict,
+)
+from pocketpaw.instinct.store import InstinctStore
+
+# --------------------------------------------------------------------------- #
+# Fixtures + builders
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def isolated_stores(tmp_path, monkeypatch):
+    """Point the store factory at tmp_path with a clean cache and no scope flag.
+
+    Same shape as tests/test_instinct_workspace_isolation.py. Load-bearing for
+    every emitter test: the emitter resolves its ledger through the FACTORY, so
+    without this it would write into the developer's real home directory.
+    """
+    monkeypatch.setattr(stores, "_DATA_DIR", tmp_path)
+    monkeypatch.delenv("POCKETPAW_REQUIRE_WORKSPACE_SCOPE", raising=False)
+    stores.reset_store_caches()
+    token = stores.current_workspace.set(None)
+    try:
+        yield tmp_path
+    finally:
+        stores.current_workspace.reset(token)
+        stores.reset_store_caches()
+
+
+def _row(**overrides) -> LedgerRow:
+    base = dict(
+        agent_id="agent-1",
+        workspace_id="ws1",
+        surface=SURFACE_PAW_BAR,
+        kind=KIND_ACTION_APPROVED,
+        ref="act_1",
+        actor=LedgerActor.OWNER.value,
+    )
+    base.update(overrides)
+    return LedgerRow(**base)
+
+
+def _trigger(source: str = "paw_bar:widget-1") -> ActionTrigger:
+    return ActionTrigger(type="connector", source=source, reason="ledger spine test")
+
+
+async def _propose(store: InstinctStore, **overrides):
+    kwargs = dict(
+        pocket_id="pocket-1",
+        title="Answer the customer",
+        description="",
+        recommendation="On it.",
+        trigger=_trigger(),
+        workspace_id="ws1",
+        actor_agent_id="agent-1",
+    )
+    kwargs.update(overrides)
+    return await store.propose(**kwargs)
+
+
+# --------------------------------------------------------------------------- #
+# Vocabulary — the closed core / open extension rule
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "kind",
+    [
+        KIND_ACTION_APPROVED,
+        KIND_ACTION_REJECTED,
+        KIND_ACTION_OUTCOME,
+        KIND_VISITOR_ACTION,
+        "paw.handoff.raised",
+        "paw.conversation.takeover",
+        "paw.run.completed",
+    ],
+)
+def test_core_kinds_are_accepted(kind):
+    assert validate_ledger_kind(kind) == kind
+
+
+@pytest.mark.parametrize("kind", ["acme.crm.synced", "vendor.billing.charged"])
+def test_vendor_kinds_are_accepted(kind):
+    """The extension space is open — a third-party surface needs no core PR."""
+    assert validate_ledger_kind(kind) == kind
+
+
+@pytest.mark.parametrize(
+    "kind",
+    [
+        "paw.action.invented",  # well-formed but NOT in the closed core
+        "paw.action",  # too few segments
+        "paw.Action.Approved",  # uppercase
+        "notevenclose",
+        "",
+    ],
+)
+def test_garbage_kinds_are_rejected(kind):
+    with pytest.raises(LedgerKindValidationError):
+        validate_ledger_kind(kind)
+
+
+def test_row_model_enforces_the_vocabulary():
+    """Validation lives at the model boundary, so no emitter can skip it."""
+    with pytest.raises(Exception, match="unknown core ledger kind"):
+        _row(kind="paw.action.invented")
+
+
+@pytest.mark.parametrize(
+    ("trigger_type", "source", "expected"),
+    [
+        ("connector", "paw_bar:widget-9", SURFACE_PAW_BAR),
+        ("automation", "belt:develop", SURFACE_BELT),
+        ("agent", "claude", SURFACE_CHAT),
+        ("user", "admin_action", SURFACE_INSTINCT),
+        ("", "", SURFACE_INSTINCT),
+    ],
+)
+def test_surface_is_derived_from_the_trigger(trigger_type, source, expected):
+    """An unrecognised trigger falls back to `instinct` rather than guessing."""
+    assert surface_from_trigger(trigger_type, source) == expected
+
+
+@pytest.mark.parametrize("window", ["24h", "7d", "30d", "2w"])
+def test_windows_parse(window):
+    assert parse_window(window) is not None
+
+
+def test_all_window_is_unbounded():
+    assert parse_window("all") is None
+    assert window_start("all") is None
+
+
+@pytest.mark.parametrize("window", ["", "30", "d30", "0d", "-5d", "9999d", "30x"])
+def test_bad_windows_raise_instead_of_falling_back(window):
+    """A misread window must be a refusal, never a silently different answer."""
+    with pytest.raises(WindowParseError):
+        parse_window(window)
+
+
+# --------------------------------------------------------------------------- #
+# Store — round-trip, dedupe, tenancy, aggregates
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_append_and_query_round_trip(tmp_path):
+    store = AgentLedgerStore(tmp_path / "agent_ledger.db")
+    assert await store.append(_row(attrs={ATTR_AGENT_ID: "agent-1"})) is True
+
+    rows = await store.query(agent_id="agent-1")
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.id is not None
+    assert row.agent_id == "agent-1"
+    assert row.workspace_id == "ws1"
+    assert row.surface == SURFACE_PAW_BAR
+    assert row.kind == KIND_ACTION_APPROVED
+    assert row.ref == "act_1"
+    assert row.attrs == {ATTR_AGENT_ID: "agent-1"}
+
+
+@pytest.mark.asyncio
+async def test_unique_kind_ref_dedupes_a_replayed_write(tmp_path):
+    """A replayed approve must not double-count. The DB enforces it, not callers."""
+    store = AgentLedgerStore(tmp_path / "agent_ledger.db")
+    assert await store.append(_row(ref="act_replay")) is True
+    # Same (kind, ref), different everything else — still a duplicate beat.
+    assert await store.append(_row(ref="act_replay", actor="system")) is False
+
+    rows = await store.query(agent_id="agent-1")
+    assert len(rows) == 1
+    # The FIRST write wins; a replay never rewrites history in an append-only log.
+    assert rows[0].actor == LedgerActor.OWNER.value
+
+
+@pytest.mark.asyncio
+async def test_same_ref_under_a_different_kind_is_a_different_beat(tmp_path):
+    """The dedupe key is (kind, ref) — one action legitimately has several beats."""
+    store = AgentLedgerStore(tmp_path / "agent_ledger.db")
+    assert await store.append(_row(kind=KIND_ACTION_APPROVED, ref="act_9")) is True
+    assert await store.append(_row(kind=KIND_ACTION_OUTCOME, ref="act_9")) is True
+    assert len(await store.query(agent_id="agent-1")) == 2
+
+
+@pytest.mark.asyncio
+async def test_workspace_scoping_is_strict(tmp_path):
+    """One tenant's query never returns another tenant's rows."""
+    store = AgentLedgerStore(tmp_path / "agent_ledger.db")
+    await store.append(_row(ref="a1", workspace_id="ws1"))
+    await store.append(_row(ref="a2", workspace_id="ws2"))
+
+    assert [r.ref for r in await store.query(workspace_id="ws1")] == ["a1"]
+    assert [r.ref for r in await store.query(workspace_id="ws2")] == ["a2"]
+    assert len(await store.query(workspace_id="ws-nobody")) == 0
+    # Unscoped reads still see everything (the OSS single-tenant path).
+    assert len(await store.query()) == 2
+
+
+@pytest.mark.asyncio
+async def test_query_filters_by_kind_and_window(tmp_path):
+    store = AgentLedgerStore(tmp_path / "agent_ledger.db")
+    await store.append(_row(ref="old", ts="2020-01-01T00:00:00+00:00"))
+    await store.append(_row(ref="new", kind=KIND_ACTION_REJECTED))
+
+    assert [r.ref for r in await store.query(kinds=[KIND_ACTION_REJECTED])] == ["new"]
+    recent = await store.query(since=window_start("30d"))
+    assert [r.ref for r in recent] == ["new"]
+
+
+@pytest.mark.asyncio
+async def test_naive_timestamps_are_normalized_to_utc(tmp_path):
+    """The window filter compares strings, so every row must share one offset."""
+    store = AgentLedgerStore(tmp_path / "agent_ledger.db")
+    await store.append(_row(ref="naive", ts="2026-07-31T12:00:00"))
+    rows = await store.query()
+    assert rows[0].ts.endswith("+00:00")
+
+
+@pytest.mark.asyncio
+async def test_aggregates_match_the_rows_they_summarize(tmp_path):
+    store = AgentLedgerStore(tmp_path / "agent_ledger.db")
+    await store.append(_row(ref="a1", kind=KIND_ACTION_APPROVED))
+    await store.append(_row(ref="a2", kind=KIND_ACTION_REJECTED))
+    await store.append(_row(ref="a3", kind=KIND_ACTION_OUTCOME, outcome=OutcomeStatus.SOLVED.value))
+    await store.append(
+        _row(
+            ref="a4",
+            kind=KIND_VISITOR_ACTION,
+            value_cents=1250,
+            currency="USD",
+            actor=LedgerActor.VISITOR.value,
+        )
+    )
+
+    counts = await store.counts_by_kind(agent_id="agent-1")
+    assert counts == {
+        KIND_ACTION_APPROVED: 1,
+        KIND_ACTION_REJECTED: 1,
+        KIND_ACTION_OUTCOME: 1,
+        KIND_VISITOR_ACTION: 1,
+    }
+    # Rows WITHOUT a verdict stay out of the outcome denominator.
+    assert await store.counts_by_outcome(agent_id="agent-1") == {OutcomeStatus.SOLVED.value: 1}
+    assert await store.value_by_currency(agent_id="agent-1") == {"USD": 1250}
+
+
+@pytest.mark.asyncio
+async def test_value_is_grouped_by_currency_never_summed_across(tmp_path):
+    """Adding cents to pence yields a number that is wrong invisibly."""
+    store = AgentLedgerStore(tmp_path / "agent_ledger.db")
+    await store.append(_row(ref="v1", kind=KIND_VISITOR_ACTION, value_cents=100, currency="USD"))
+    await store.append(_row(ref="v2", kind=KIND_VISITOR_ACTION, value_cents=200, currency="GBP"))
+    assert await store.value_by_currency(agent_id="agent-1") == {"USD": 100, "GBP": 200}
+
+
+@pytest.mark.asyncio
+async def test_factory_gives_each_workspace_its_own_file(isolated_stores):
+    """Physical isolation, inherited from the generic workspace-keyed factory."""
+    a = stores.get_agent_ledger_store(workspace_id="wsA")
+    b = stores.get_agent_ledger_store(workspace_id="wsB")
+    assert a._db_path != b._db_path
+    assert "wsA" in a._db_path and "wsB" in b._db_path
+    # Same workspace resolves to the same cached handle.
+    assert stores.get_agent_ledger_store(workspace_id="wsA") is a
+
+
+@pytest.mark.asyncio
+async def test_factory_fails_closed_without_a_workspace_in_cloud_mode(isolated_stores, monkeypatch):
+    """Cloud mode must never fall back to a shared ledger across tenants."""
+    monkeypatch.setenv("POCKETPAW_REQUIRE_WORKSPACE_SCOPE", "1")
+    stores.reset_store_caches()
+    with pytest.raises(stores.WorkspaceScopeRequired):
+        stores.get_agent_ledger_store()
+
+
+# --------------------------------------------------------------------------- #
+# Attribution — Action.actor_agent_id
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_actor_agent_id_round_trips_through_propose(tmp_path):
+    store = InstinctStore(tmp_path / "instinct.db")
+    action = await _propose(store, actor_agent_id="agent-77")
+    assert action.actor_agent_id == "agent-77"
+    reloaded = await store.get_action(action.id)
+    assert reloaded is not None
+    assert reloaded.actor_agent_id == "agent-77"
+
+
+@pytest.mark.asyncio
+async def test_unattributed_proposals_stay_legal(tmp_path):
+    """ "" is a permanent, supported value — never a validation failure."""
+    store = InstinctStore(tmp_path / "instinct.db")
+    action = await _propose(store, actor_agent_id="")
+    reloaded = await store.get_action(action.id)
+    assert reloaded is not None
+    assert reloaded.actor_agent_id == ""
+
+
+@pytest.mark.asyncio
+async def test_legacy_instinct_db_migrates_the_new_column(tmp_path):
+    """A DB created before AL-1 gains actor_agent_id via the additive ALTER.
+
+    The trap this guards is the one that has bitten paw_bar twice: CREATE TABLE
+    IF NOT EXISTS no-ops on a deployed table, so a row read afterwards raises on
+    the missing column unless the migration ran first.
+    """
+    db_path = tmp_path / "instinct.db"
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute(
+            "CREATE TABLE instinct_actions ("
+            " id TEXT PRIMARY KEY, pocket_id TEXT NOT NULL, title TEXT NOT NULL,"
+            " description TEXT DEFAULT '', category TEXT DEFAULT 'workflow',"
+            " status TEXT DEFAULT 'pending', priority TEXT DEFAULT 'medium',"
+            " trigger TEXT NOT NULL, recommendation TEXT DEFAULT '',"
+            " parameters TEXT DEFAULT '{}', context TEXT DEFAULT '{}',"
+            " outcome TEXT, error TEXT, approved_by TEXT, approved_at TEXT,"
+            " rejected_reason TEXT,"
+            " created_at TEXT DEFAULT (datetime('now')),"
+            " updated_at TEXT DEFAULT (datetime('now')), executed_at TEXT)"
+        )
+        await db.commit()
+
+    store = InstinctStore(db_path)
+    action = await _propose(store, actor_agent_id="agent-legacy")
+    reloaded = await store.get_action(action.id)
+    assert reloaded is not None
+    assert reloaded.actor_agent_id == "agent-legacy"
+    # And the list path (which rebuilds every row) survives too.
+    assert len(await store.list_actions()) == 1
+
+
+# --------------------------------------------------------------------------- #
+# Emitter — the Instinct choke point
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_approval_lands_one_agent_keyed_row(isolated_stores):
+    instinct = stores.get_instinct_store(workspace_id="ws1")
+    action = await _propose(instinct, actor_agent_id="agent-42")
+
+    approved = await instinct.approve(action.id, approver="user:maya")
+    assert approved is not None
+    assert approved.status == ActionStatus.APPROVED
+
+    ledger = stores.get_agent_ledger_store(workspace_id="ws1")
+    rows = await ledger.query(agent_id="agent-42")
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.kind == KIND_ACTION_APPROVED
+    assert row.ref == action.id
+    assert row.workspace_id == "ws1"
+    # The trigger was paw_bar:*, so the row knows which surface it came from.
+    assert row.surface == SURFACE_PAW_BAR
+    assert row.actor == LedgerActor.OWNER.value
+    assert row.attrs[ATTR_AGENT_ID] == "agent-42"
+    assert row.attrs[ATTR_INSTINCT_EVENT] == "action_approved"
+    # Ops metrics are federated — they must never appear on a ledger row.
+    assert not any(k in row.attrs for k in ("tokens", "cost", "latency", "gen_ai.usage"))
+
+
+@pytest.mark.asyncio
+async def test_a_replayed_approve_does_not_double_write(isolated_stores):
+    """The second approve is a no-op upstream AND absorbed downstream."""
+    instinct = stores.get_instinct_store(workspace_id="ws1")
+    action = await _propose(instinct)
+    assert await instinct.approve(action.id) is not None
+    # approve() requires PENDING, so the replay returns None...
+    assert await instinct.approve(action.id) is None
+    # ...and even a direct re-emit of the same beat cannot duplicate the row.
+    reloaded = await instinct.get_action(action.id)
+    await instinct._emit_ledger(
+        reloaded, event="action_approved", actor="user:maya", workspace_id="ws1"
+    )
+
+    ledger = stores.get_agent_ledger_store(workspace_id="ws1")
+    assert len(await ledger.query(kinds=[KIND_ACTION_APPROVED])) == 1
+
+
+@pytest.mark.asyncio
+async def test_reject_and_outcome_land_their_own_kinds(isolated_stores):
+    instinct = stores.get_instinct_store(workspace_id="ws1")
+    rejected_action = await _propose(instinct)
+    await instinct.reject(rejected_action.id, reason="wholesale", rejector="user:maya")
+
+    executed_action = await _propose(instinct)
+    await instinct.approve(executed_action.id)
+    await instinct.mark_executed(
+        executed_action.id,
+        OutcomeVerdict(status=OutcomeStatus.SOLVED, summary="delivered"),
+    )
+
+    ledger = stores.get_agent_ledger_store(workspace_id="ws1")
+    counts = await ledger.counts_by_kind(agent_id="agent-1")
+    assert counts[KIND_ACTION_REJECTED] == 1
+    assert counts[KIND_ACTION_APPROVED] == 1
+    assert counts[KIND_ACTION_OUTCOME] == 1
+    assert await ledger.counts_by_outcome(agent_id="agent-1") == {OutcomeStatus.SOLVED.value: 1}
+
+
+@pytest.mark.asyncio
+async def test_a_failed_action_records_a_not_solved_verdict(isolated_stores):
+    """A board that counts only successes is one people stop trusting."""
+    instinct = stores.get_instinct_store(workspace_id="ws1")
+    action = await _propose(instinct)
+    await instinct.approve(action.id)
+    await instinct.mark_failed(action.id, error="connector timeout")
+
+    ledger = stores.get_agent_ledger_store(workspace_id="ws1")
+    assert await ledger.counts_by_outcome(agent_id="agent-1") == {OutcomeStatus.NOT_SOLVED.value: 1}
+
+
+@pytest.mark.asyncio
+async def test_auto_approval_shares_the_kind_and_flags_the_machine(isolated_stores):
+    """An approval is an approval; the machine-ness rides as an attribute."""
+    instinct = stores.get_instinct_store(workspace_id="ws1")
+    action = await _propose(instinct)
+    await instinct.auto_approve(action.id, verdict="allow", reasoning="low risk")
+
+    ledger = stores.get_agent_ledger_store(workspace_id="ws1")
+    rows = await ledger.query(kinds=[KIND_ACTION_APPROVED])
+    assert len(rows) == 1
+    assert rows[0].attrs[ATTR_APPROVAL_AUTO] is True
+    assert rows[0].actor == LedgerActor.SYSTEM.value
+
+
+@pytest.mark.asyncio
+async def test_a_losing_concurrent_approve_emits_nothing(isolated_stores):
+    """The TOCTOU loser is a no-op upstream, so it must be a no-op here too."""
+    instinct = stores.get_instinct_store(workspace_id="ws1")
+    action = await _propose(instinct)
+    await instinct.reject(action.id, reason="no")
+    # Already REJECTED, so approve() rolls back and returns None.
+    assert await instinct.approve(action.id) is None
+
+    ledger = stores.get_agent_ledger_store(workspace_id="ws1")
+    assert await ledger.counts_by_kind(agent_id="agent-1") == {KIND_ACTION_REJECTED: 1}
+
+
+@pytest.mark.asyncio
+async def test_unattributed_approval_still_lands_a_row(isolated_stores):
+    """Attribution gaps degrade to an honest bucket, never to a dropped row."""
+    instinct = stores.get_instinct_store(workspace_id="ws1")
+    action = await _propose(instinct, actor_agent_id="")
+    await instinct.approve(action.id)
+
+    ledger = stores.get_agent_ledger_store(workspace_id="ws1")
+    rows = await ledger.query(agent_id="")
+    assert len(rows) == 1
+    assert rows[0].agent_id == ""
+    assert ATTR_AGENT_ID not in rows[0].attrs
+
+
+# --------------------------------------------------------------------------- #
+# THE fail-soft contract
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_a_raising_ledger_store_does_not_break_the_approval(isolated_stores, monkeypatch):
+    """The load-bearing guarantee: bookkeeping never costs anyone a decision.
+
+    If this test goes red, an operator's approve click can now fail because an
+    analytics table was locked, full, or misconfigured — which is precisely the
+    trade this design refuses to make.
+    """
+    instinct = stores.get_instinct_store(workspace_id="ws1")
+    action = await _propose(instinct)
+
+    class _ExplodingStore:
+        async def append(self, row):  # noqa: ARG002
+            raise RuntimeError("ledger disk is on fire")
+
+    monkeypatch.setattr(
+        stores, "get_agent_ledger_store", lambda **_kw: _ExplodingStore(), raising=True
+    )
+
+    approved = await instinct.approve(action.id, approver="user:maya")
+    assert approved is not None
+    assert approved.status == ActionStatus.APPROVED
+    # The audit trail — which IS allowed to be loud — is untouched.
+    assert any(e.event == "action_approved" for e in await instinct.query_audit(limit=50))
+
+
+@pytest.mark.asyncio
+async def test_an_unresolvable_ledger_store_does_not_break_the_approval(
+    isolated_stores, monkeypatch
+):
+    """Fail-CLOSED store resolution meets fail-SOFT emission, and soft wins.
+
+    A NULL-workspace action on a cloud box makes the factory raise
+    WorkspaceScopeRequired inside the emitter. That is correct behaviour for the
+    factory and must still be invisible to the approver.
+    """
+    instinct = stores.get_instinct_store(workspace_id="ws1")
+    action = await _propose(instinct, workspace_id=None)
+
+    def _boom(**_kw):
+        raise stores.WorkspaceScopeRequired("no workspace resolved")
+
+    monkeypatch.setattr(stores, "get_agent_ledger_store", _boom, raising=True)
+
+    approved = await instinct.approve(action.id)
+    assert approved is not None
+    assert approved.status == ActionStatus.APPROVED

--- a/tests/test_agent_ledger.py
+++ b/tests/test_agent_ledger.py
@@ -571,8 +571,13 @@ async def test_a_raising_ledger_store_does_not_break_the_approval(isolated_store
         async def append(self, row):  # noqa: ARG002
             raise RuntimeError("ledger disk is on fire")
 
+    # Patch the seam the emitter ACTUALLY calls. This test was briefly vacuous:
+    # it patched ``get_agent_ledger_store`` while the emitter had moved to
+    # ``get_agent_ledger_store_beside``, so the exploding store was never
+    # constructed and the guard was never exercised. It still passed — which is
+    # the whole problem with a fail-soft test that only asserts the happy half.
     monkeypatch.setattr(
-        stores, "get_agent_ledger_store", lambda **_kw: _ExplodingStore(), raising=True
+        stores, "get_agent_ledger_store_beside", lambda _p: _ExplodingStore(), raising=True
     )
 
     approved = await instinct.approve(action.id, approver="user:maya")
@@ -580,6 +585,12 @@ async def test_a_raising_ledger_store_does_not_break_the_approval(isolated_store
     assert approved.status == ActionStatus.APPROVED
     # The audit trail — which IS allowed to be loud — is untouched.
     assert any(e.event == "action_approved" for e in await instinct.query_audit(limit=50))
+    # And the NEGATIVE half, which is what stops this test rotting again: the
+    # exploding store must actually have been reached, so NO row can exist. If a
+    # future refactor moves the seam again, this assertion fails loudly instead
+    # of passing quietly.
+    ledger = stores.get_agent_ledger_store(workspace_id="ws1")
+    assert await ledger.query(agent_id="agent-1") == []
 
 
 @pytest.mark.asyncio
@@ -595,11 +606,16 @@ async def test_an_unresolvable_ledger_store_does_not_break_the_approval(
     instinct = stores.get_instinct_store(workspace_id="ws1")
     action = await _propose(instinct, workspace_id=None)
 
-    def _boom(**_kw):
+    def _boom(_p):
         raise stores.WorkspaceScopeRequired("no workspace resolved")
 
-    monkeypatch.setattr(stores, "get_agent_ledger_store", _boom, raising=True)
+    # Same seam correction as the sibling test above — patch what the emitter
+    # calls, not what it used to call.
+    monkeypatch.setattr(stores, "get_agent_ledger_store_beside", _boom, raising=True)
 
     approved = await instinct.approve(action.id)
     assert approved is not None
     assert approved.status == ActionStatus.APPROVED
+    # The negative half: the raise must actually have happened, so no row landed.
+    ledger = stores.get_agent_ledger_store(workspace_id="ws1")
+    assert await ledger.query(agent_id="agent-1") == []

--- a/tests/test_store_isolation_lint.py
+++ b/tests/test_store_isolation_lint.py
@@ -93,7 +93,11 @@ _ALLOWLIST_REL: frozenset[str] = frozenset(
 )
 
 # Store class names whose direct construction is forbidden outside the allowlist.
-_FORBIDDEN_NAMES: frozenset[str] = frozenset(["FabricStore", "InstinctStore"])
+# ``AgentLedgerStore`` joined the list on 2026-07-31 (AL-1) the moment it became
+# the third workspace-keyed kind: it inherits the same per-workspace routing,
+# path-traversal allowlist, fail-closed scope check, and bounded LRU from the
+# factory, and a direct construction would silently drop every one of them.
+_FORBIDDEN_NAMES: frozenset[str] = frozenset(["AgentLedgerStore", "FabricStore", "InstinctStore"])
 
 # ---------------------------------------------------------------------------
 # Core checker (reusable — called by both the real-tree test and the self-test)

--- a/tests/test_store_isolation_lint.py
+++ b/tests/test_store_isolation_lint.py
@@ -1,12 +1,22 @@
 # tests/test_store_isolation_lint.py
 # Created: 2026-06-26 (ISO-4 — store-isolation lint guard)
 #
+# Updated: 2026-07-31 (AL-1, agent ledger) — the guard now also covers
+# AgentLedgerStore. It earned its place immediately: the ledger emitter's first
+# cut constructed AgentLedgerStore(...) directly inside instinct/store.py to
+# route the file beside the instinct.db, and this test caught it. The fix was
+# NOT an allowlist entry — it was moving that path-derived construction into
+# pocketpaw.stores as get_agent_ledger_store_beside(), so the seam holds and the
+# emitter still avoids re-resolving an in-row workspace value that may be an
+# owner label. A guard that gets exempted the first time it fires is not a guard.
+#
 # AST-based regression guard: ensures no code in src/pocketpaw/ or
-# ee/pocketpaw_ee/ directly constructs FabricStore(...) or
-# InstinctStore(...) outside the approved factory seam.
+# ee/pocketpaw_ee/ directly constructs FabricStore(...), InstinctStore(...) or
+# AgentLedgerStore(...) outside the approved factory seam.
 #
 # WORKSPACE RULE: all store access MUST go through the factories in
-# pocketpaw.stores — get_fabric_store() and get_instinct_store(). Direct
+# pocketpaw.stores — get_fabric_store(), get_instinct_store(),
+# get_agent_ledger_store() and get_agent_ledger_store_beside(). Direct
 # construction bypasses workspace resolution, the fail-closed scope check,
 # the bounded LRU cache, and the StoreProvider seam, silently re-opening a
 # shared store that breaks per-tenant physical isolation (ISO-1 / ISO-2).


### PR DESCRIPTION
First slice (AL-1) of the agent-ledger line. Design: `docs/design/drafts/2026-07-31-agent-ledger-analytics.md` · tasks: `…-tasks.md`.

## Why

"What did my agents do for me?" is un-askable today. Every surface keeps its own fragment in its own store under its own key — `paw_bar_events` by widget, `ChatRunDoc` by run, Instinct actions by workspace — and half carry no agent id at all. That gap cost us twice this week: a notification couldn't deep-link because nothing named the agent, and the demo's best numbers had to be assembled by hand out of three stores.

## What ships

A thin, append-only, per-workspace SQLite ledger keyed by **agent**, plus the row vocabulary, the attribution field, one emitter, and one read endpoint.

The emitter sits on Instinct's approve/reject/outcome path, and that placement is the whole point: every agent kind already proposes through that gate, so **belt stations and deep-work get ledger rows in this slice without either being touched**. One seam, all agents.

Vocabulary governance mirrors Senses on purpose — a CLOSED `paw.*` core nobody forks, an OPEN `vendor.*` extension space. `attrs` carry OTel GenAI semantic-convention attribute names, so exporting to a standard pipeline later is an adapter rather than a rewrite.

## Two things it deliberately does NOT do

**No tokens, cost, or latency.** Those stay in the run doc and usage tracker and are read federated. We already paid once for keeping two meters for one number — the usage chart read the proxy while the wallet held the spend, and they disagreed in public.

**Never raise.** A ledger that is locked, full, or misconfigured must not cost an operator their approve click. Two tests pin that, and both go red when the swallow is removed — verified by mutation, not by assertion alone. Fail-soft is invisible when it breaks, which is why AL-4 adds a reconcile endpoint comparing Instinct's own counts against the ledger's.

## Review found three blockers, all fixed in d3174ef5

- **A live 500.** The max-window check ran after the `timedelta` was built, and `timedelta` raises `OverflowError` — not `ValueError` — so it bypassed the router's 422 handler. `9999d` → 422 but `99999999999d` → 500, reproduced before the fix. The existing parametrize stopped one order of magnitude short of it.
- **A silent under-count.** The emitter routed the ledger file by the action's in-row `workspace_id`, which is not guaranteed to be a store-path token — the paw-bar decision loop deliberately lets it fall back to the widget owner label. That either raises into the fail-soft guard (row vanishes) or writes to a directory no reader opens. Now routed beside the already-resolved `instinct.db`.
- **A false comment.** It claimed the guard covered import failure; the same names are imported at module level, so a broken vocabulary module takes down `instinct.store` long before the guard runs. Corrected to say what it does and doesn't cover.

Worth noting: the first fix for the second blocker constructed `AgentLedgerStore` directly and the ISO-4 store-isolation lint caught it. That's the guard working. The path-derived construction moved into `pocketpaw.stores` as `get_agent_ledger_store_beside()` rather than taking an allowlist exemption — a guard that gets exempted the first time it fires isn't a guard.

## Verification

- `tests/test_agent_ledger.py` + `tests/cloud/test_agent_ledger_endpoint.py` — **74 passed**
- ledger + instinct + paw_bar + store-isolation — **199 passed**
- ruff clean · `lint-imports` 1 kept 0 broken · `--config ee/pyproject.toml` 34 kept 0 broken
- The OSS module takes no EE import.

## Not in this slice

Paw-bar emitters (AL-2), run counting via the metering sweeper (AL-3), the reconcile endpoint (AL-4), the UI (AL-5/6), the soul résumé (AL-7). No backfill — the ledger starts empty.