### PR TITLE
feat(agents): model controls, provider-side web tools, and a way to measure them

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,29 +156,48 @@ pydantic-ai = [
     # PINNED EXACTLY, and to a version that is NOT the newest. Two reasons:
     # (1) pre-1.0-shaped release cadence — 16 releases in 3.5 months — so a
     # floating range puts breaking changes on the request path; (2) the
-    # workspace's 7-day minimum-release-age supply-chain policy. 2.14.1 is the
-    # newest release that is >=7 days old as of 2026-07-29 (2.15.0 landed
-    # 2026-07-22 and every version above it is newer still).
+    # workspace's 7-day minimum-release-age supply-chain policy. 2.18.0 is the
+    # newest release clearing that window as of 2026-08-01 (2.19.0 landed
+    # 2026-07-28 and every version above it is newer still).
+    #
+    # 2.14.1 -> 2.18.0 reviewed for breaking changes across the four releases:
+    # none touch our surface. 2.17.0 caches per-message OpenTelemetry
+    # serialization to avoid an O(n^2) instrumentation cost, which is the
+    # release that makes the Instrumentation capability affordable on a long
+    # tool loop.
     #
     # The ``mcp`` extra pulls fastmcp, which moves ``starlette`` to the 1.x
     # line. That is INSIDE this project's declared range, not a violation of it:
     # the core ``fastapi>=0.134.0`` pin exists precisely because 0.134.0 dropped
     # starlette's upper bound, and fastapi 0.135.x requires only
     # ``starlette>=0.46.0``.
-    "pydantic-ai-slim[openai,mcp]==2.14.1",
+    "pydantic-ai-slim[openai,mcp]==2.18.0",
     # Harness capabilities (compaction, subagents, skills, planning, tool
-    # output limits, step persistence). 0.8.0 is likewise the newest release
-    # clearing the 7-day window — note this CORRECTS the PRD, which specified
-    # 0.12.x while citing the same policy that excludes it (0.12.0 shipped
-    # 2026-07-28, one day before this was written).
-    "pydantic-ai-harness==0.8.0",
+    # output limits, step persistence). 0.11.0 is likewise the newest release
+    # clearing the 7-day window as of 2026-08-01 (0.12.0 shipped 2026-07-28).
+    "pydantic-ai-harness==0.11.0",
     # Agent Skills with progressive disclosure — the model sees names and
     # descriptions and pulls a skill's body only when it uses one, rather than
     # every skill riding in the system prompt each turn. The harness has no
     # skills capability of its own. Third-party (MIT); 1.2.0 is the newest
-    # release clearing the 7-day minimum-release-age window (1.3.0 landed
-    # 2026-07-25). Used programmatically only — see _build_skills_capability.
-    "pydantic-ai-skills==1.2.0",
+    # release clearing the 7-day minimum-release-age window (1.4.0 landed
+    # 2026-07-28). Used programmatically only — see _build_skills_capability.
+    "pydantic-ai-skills==1.3.0",
+    # Observability. Pydantic's own OpenTelemetry platform, and the thing that
+    # turns "the model feels slow" into a span with a number on it. Optional at
+    # runtime: the Instrumentation capability is only wired when a token is
+    # configured, so an install that never sets one pays nothing. Ranged rather
+    # than pinned because it is a 4.x line on a normal cadence, unlike the
+    # pre-1.0-shaped packages above.
+    "logfire>=4.39.0,<5",
+]
+pydantic-ai-evals = [
+    # Evaluation harness, kept OUT of the runtime extra on purpose: it is a
+    # development and CI dependency, and nothing in the request path imports it.
+    # Version-locked to pydantic-ai-slim above — they ship from one workspace on
+    # one version line, so a mismatch is a real risk rather than a theoretical
+    # one.
+    "pydantic-evals==2.18.0",
 ]
 litellm = [
     "litellm>=1.40.0",

--- a/scripts/evals/tool_search_eval.py
+++ b/scripts/evals/tool_search_eval.py
@@ -170,6 +170,10 @@ async def main() -> None:
         results.append(await run_arm(label, overrides, cases))
 
     print("\n" + "=" * 78)
+    if any(r.total and len(r.errors) == r.total for r in results):
+        print("NO RESULT — every case in an arm errored, so these are not")
+        print("scores. The model was unreachable. Check the proxy's /health")
+        print("before reading anything into the table below.")
     for r in results:
         print(r.row())
     print("=" * 78)

--- a/scripts/evals/tool_search_eval.py
+++ b/scripts/evals/tool_search_eval.py
@@ -1,0 +1,194 @@
+"""A/B the Pydantic AI backend's tool surface against real user phrasings.
+
+Created 2026-08-01.
+
+Exists to answer the one question the deferred-loading work could not answer by
+measurement: hiding 97 tools behind ``search_tools`` saves ~24,600 tokens per
+request, but only if the model still finds the tool it needs. Token counts are
+arithmetic; whether a given model searches rather than answering without looking
+is behaviour, and behaviour needs cases.
+
+This is a script, not a test. It spends real tokens against whatever
+``POCKETPAW_PYDANTIC_AI_MODEL`` points at, so nothing runs it implicitly.
+
+    uv run python scripts/evals/tool_search_eval.py                  # A/B deferral
+    uv run python scripts/evals/tool_search_eval.py --thinking low   # add an effort level
+    uv run python scripts/evals/tool_search_eval.py --cases 3        # a cheap smoke run
+
+What it reports per arm: how often the expected tool was called, how many model
+requests it took, and the input tokens spent. A saving that costs you the task
+is not a saving, and that trade is what the table is for.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+from dataclasses import dataclass, field
+
+os.environ.setdefault("POCKETPAW_AGENT_BACKEND", "pydantic_ai")
+
+
+@dataclass
+class Case:
+    """One user turn, and the tool a correct run reaches for."""
+
+    name: str
+    prompt: str
+    expect_any_of: tuple[str, ...]
+
+
+# Phrasings a user actually types, not the tool's own vocabulary. The gap
+# between the two is the whole point: "make me a webpage" shares no token with
+# ``pocketpaw_sites_manager_create_html_site``.
+CASES: list[Case] = [
+    Case(
+        "build-site",
+        "Build me a one-page site for a bakery called Flour & Ash.",
+        ("create_html_site", "create_svelte_site", "create_landing_site"),
+    ),
+    Case(
+        "webpage-word",
+        "Make me a webpage for my dentist practice.",
+        ("create_html_site", "create_svelte_site", "create_landing_site"),
+    ),
+    Case("publish", "Publish it.", ("publish",)),
+    Case("deploy-word", "Ship the draft live please.", ("publish",)),
+    Case(
+        "edit-section",
+        "Change the hero section copy to something warmer.",
+        ("edit_svelte_component", "create_html_site"),
+    ),
+    Case("widget", "Add a revenue chart to the dashboard.", ("add_widget",)),
+    Case(
+        "image",
+        "Generate a picture of a croissant for the header.",
+        ("image_generate", "search_stock_images"),
+    ),
+    Case(
+        "connector",
+        "Connect my gmail so it can read the enquiries.",
+        ("connector_connect", "connector_execute", "sense_execute"),
+    ),
+]
+
+
+@dataclass
+class ArmResult:
+    label: str
+    hits: int = 0
+    misses: list[str] = field(default_factory=list)
+    requests: int = 0
+    input_tokens: int = 0
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def total(self) -> int:
+        return self.hits + len(self.misses)
+
+    def row(self) -> str:
+        pct = (100 * self.hits // self.total) if self.total else 0
+        return (
+            f"{self.label:<28} {self.hits}/{self.total} ({pct:3d}%)  "
+            f"requests={self.requests:<4} input_tokens={self.input_tokens:,}"
+        )
+
+
+async def run_case(settings_overrides: dict, case: Case) -> tuple[bool, int, int, str | None]:
+    """One case, one configuration. Returns (hit, requests, input_tokens, error)."""
+    from pocketpaw.agents.pydantic_ai import PydanticAIBackend
+    from pocketpaw.config import Settings
+
+    backend = PydanticAIBackend(Settings(**settings_overrides))
+    called: list[str] = []
+    requests = 0
+    tokens = 0
+    error: str | None = None
+    try:
+        async for ev in backend.run(case.prompt, session_key=f"eval-{case.name}"):
+            if ev.type == "tool_use":
+                called.append((ev.metadata or {}).get("name", ""))
+            elif ev.type == "token_usage":
+                tokens = int((ev.metadata or {}).get("input_tokens", 0) or 0)
+            elif ev.type == "error":
+                error = ev.content[:200]
+    except Exception as exc:  # noqa: BLE001
+        error = f"{type(exc).__name__}: {exc}"[:200]
+    finally:
+        await backend.stop()
+
+    requests = len(called)
+    hit = any(any(want in name for want in case.expect_any_of) for name in called)
+    return hit, requests, tokens, error
+
+
+async def run_arm(label: str, overrides: dict, cases: list[Case]) -> ArmResult:
+    result = ArmResult(label=label)
+    for case in cases:
+        hit, requests, tokens, error = await run_case(overrides, case)
+        result.requests += requests
+        result.input_tokens += tokens
+        if error:
+            result.errors.append(f"{case.name}: {error}")
+        if hit:
+            result.hits += 1
+        else:
+            result.misses.append(case.name)
+        print(f"  {'HIT ' if hit else 'MISS'} {case.name}", flush=True)
+    return result
+
+
+async def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--cases", type=int, default=0, help="run only the first N cases")
+    ap.add_argument("--thinking", default="", help="also A/B this reasoning effort level")
+    args = ap.parse_args()
+
+    cases = CASES[: args.cases] if args.cases else CASES
+
+    base: dict = {}
+    arms = [
+        ("deferral off (today's default)", {**base, "pydantic_ai_defer_mcp_tools": False}),
+        ("deferral on", {**base, "pydantic_ai_defer_mcp_tools": True}),
+    ]
+    if args.thinking:
+        arms.append(
+            (
+                f"deferral on + thinking={args.thinking}",
+                {
+                    **base,
+                    "pydantic_ai_defer_mcp_tools": True,
+                    "pydantic_ai_thinking": args.thinking,
+                },
+            )
+        )
+
+    results: list[ArmResult] = []
+    for label, overrides in arms:
+        print(f"\n=== {label} ===", flush=True)
+        results.append(await run_arm(label, overrides, cases))
+
+    print("\n" + "=" * 78)
+    for r in results:
+        print(r.row())
+    print("=" * 78)
+    for r in results:
+        if r.misses:
+            print(f"{r.label}: missed {', '.join(r.misses)}")
+        for err in r.errors[:3]:
+            print(f"{r.label}: ERROR {err}")
+
+    # The trade, stated rather than implied: tokens saved against tasks lost.
+    if len(results) >= 2:
+        off, on = results[0], results[1]
+        saved = off.input_tokens - on.input_tokens
+        lost = off.hits - on.hits
+        print(
+            f"\ndeferral: {saved:+,} input tokens, {-lost:+d} tasks. "
+            + ("Worth it." if lost <= 0 and saved > 0 else "Read the misses before shipping it.")
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/pocketpaw/agents/pydantic_ai.py
+++ b/src/pocketpaw/agents/pydantic_ai.py
@@ -209,6 +209,10 @@ _OPENAI_COMPATIBLE = frozenset({"litellm", "openai", "openai_compatible", "openr
 _POCKET_SCOPE_SENTINEL = "<pocket-scope>"
 
 # Bounds on the per-session transcript cache (see ``_session_messages``).
+# ``logfire.configure`` is process-global and one backend instance exists per
+# agent, so the capability builder would otherwise reconfigure it per agent.
+_LOGFIRE_CONFIGURED = False
+
 _MAX_TRACKED_SESSIONS = 200
 _MAX_SESSION_MESSAGES = 60
 
@@ -670,15 +674,21 @@ class PydanticAIBackend:
 
     # -- model --------------------------------------------------------------
 
-    def _parse_provider_model(self) -> tuple[str, str]:
-        """Split ``pydantic_ai_model`` into ``(provider, model)``.
+    def _parse_provider_model(self, model_spec: str | None = None) -> tuple[str, str]:
+        """Split a ``provider:model`` spec into its parts.
+
+        Defaults to ``pydantic_ai_model``; ``model_spec`` lets the fast-model
+        selector reuse the same parsing and fallback chain rather than growing a
+        second, subtly different one.
 
         Accepts ``provider:model`` or a bare model name, falling back to
         ``pydantic_ai_provider`` then ``llm_provider`` then ``litellm``.
         Mirrors ``DeepAgentsBackend._parse_provider_model`` so an operator can
         move a value between the two settings without reformatting it.
         """
-        model_str = (self.settings.pydantic_ai_model or "").strip()
+        model_str = (
+            model_spec if model_spec is not None else (self.settings.pydantic_ai_model or "")
+        ).strip()
         if ":" in model_str:
             provider, _, model = model_str.partition(":")
             return provider.strip(), model.strip()
@@ -690,9 +700,9 @@ class PydanticAIBackend:
             provider = "litellm"
         return provider, model_str
 
-    def _build_model(self) -> Any:
+    def _build_model(self, model_spec: str | None = None) -> Any:
         """Build the pydantic-ai model client for the configured provider."""
-        provider, model = self._parse_provider_model()
+        provider, model = self._parse_provider_model(model_spec)
 
         if provider == "agentapi":
             # Development path: borrow a local CLI's own authentication instead
@@ -1098,9 +1108,16 @@ class PydanticAIBackend:
         # pydantic-ai core, so turning the harness off must not silently drop
         # our ranking function back to the built-in one.
         capabilities: list = []
-        tool_search = self._build_tool_search_capability()
-        if tool_search is not None:
-            capabilities.append(tool_search)
+        for build in (
+            self._build_tool_search_capability,
+            self._build_thinking_capability,
+            self._build_select_model_capability,
+            self._build_instrumentation_capability,
+        ):
+            cap = build()
+            if cap is not None:
+                capabilities.append(cap)
+        capabilities += self._build_web_capabilities()
 
         if not getattr(self.settings, "pydantic_ai_harness_enabled", True):
             return capabilities
@@ -1349,6 +1366,160 @@ class PydanticAIBackend:
             return None
         return ToolSearch(strategy=pocketpaw_tool_search)
 
+    # Bridged tool -> the capability that supersedes it when native web tools
+    # are on. The bridged tool is not dropped; it becomes that capability's
+    # LOCAL fallback, which is what keeps one implementation serving both paths
+    # and stops the model being offered two tools for one job.
+    _NATIVE_WEB_EQUIVALENTS: dict[str, str] = {"web_search": "WebSearch", "url_extract": "WebFetch"}
+
+    def _build_instrumentation_capability(self) -> Any:
+        """OTel spans for the run, so latency claims can be checked.
+
+        This backend's whole argument is a cost curve, and PA-1 — the
+        concurrency measurement that decides whether it beats ``deep_agents`` —
+        is still unrun. Spans are what make that measurable from the inside
+        rather than by wrapping a stopwatch around the whole request.
+
+        ``logfire.configure`` is called with ``send_to_logfire='if-token-present'``
+        so this is safe to enable on a deployment with no Logfire account: the
+        spans go to whatever OTel exporter is already configured, or nowhere.
+        Configuration is process-global and guarded by a module flag, because
+        one instance per agent means this method runs many times.
+        """
+        if not getattr(self.settings, "pydantic_ai_instrumentation", False):
+            return None
+        try:
+            from pydantic_ai.capabilities import Instrumentation
+        except ImportError:  # pragma: no cover - pydantic-ai too old
+            return None
+
+        global _LOGFIRE_CONFIGURED
+        if not _LOGFIRE_CONFIGURED:
+            _LOGFIRE_CONFIGURED = True
+            try:
+                import logfire
+
+                logfire.configure(
+                    send_to_logfire="if-token-present",
+                    service_name="pocketpaw-pydantic-ai",
+                    console=False,
+                )
+            except Exception as exc:  # noqa: BLE001
+                # Instrumentation is observability, never load-bearing: a
+                # misconfigured exporter must not stop a tenant's run.
+                logger.warning("Could not configure logfire, spans stay local: %s", exc)
+        return Instrumentation()
+
+    def _build_web_capabilities(self) -> list:
+        """Move web search and fetch provider-side, keeping ours as the fallback.
+
+        The win is specific to this backend. A bridged web tool makes its HTTP
+        call from inside the agent process, so on one process serving every
+        tenant our event loop does the waiting; a native tool is executed by the
+        provider and arrives as a result. ``research`` is deliberately left
+        alone — it is a multi-step routine of ours, not a single fetch, so no
+        native tool is equivalent to it.
+
+        ``local=`` takes our own ``Tool`` rather than pydantic-ai's DuckDuckGo
+        fallback on purpose: a second search implementation would drift from the
+        one the other backends use, and the charter's one-canonical-module rule
+        is the reason the in-process MCP bridge exists at all.
+        """
+        if not getattr(self.settings, "pydantic_ai_native_web_tools", False):
+            return []
+        try:
+            from pydantic_ai.capabilities import WebFetch, WebSearch
+        except ImportError:  # pragma: no cover - pydantic-ai too old
+            return []
+
+        by_name = {getattr(t, "name", ""): t for t in self._build_custom_tools()}
+        out: list = []
+        for tool_name, cap_name in self._NATIVE_WEB_EQUIVALENTS.items():
+            local = by_name.get(tool_name)
+            if local is None:
+                # The surface withheld it, so there is nothing to fall back to.
+                # Registering the native tool anyway would GRANT a capability
+                # the policy just removed.
+                logger.info("Native %s not wired: %r is not on this surface", cap_name, tool_name)
+                continue
+            cap = WebSearch if cap_name == "WebSearch" else WebFetch
+            out.append(cap(local=local))
+        return out
+
+    def _build_thinking_capability(self) -> Any:
+        """Set reasoning effort explicitly instead of inheriting the provider's.
+
+        ``Thinking`` writes pydantic-ai's portable ``thinking`` model setting,
+        so one value works across Anthropic, OpenAI and the proxy rather than
+        needing each vendor's own spelling. Returns ``None`` for ``default``,
+        which leaves the setting absent entirely — not the same as ``off``,
+        which actively disables thinking on a model that would otherwise use it.
+        """
+        raw = str(getattr(self.settings, "pydantic_ai_thinking", "default") or "default").lower()
+        if raw == "default":
+            return None
+        try:
+            from pydantic_ai.capabilities import Thinking
+        except ImportError:  # pragma: no cover - pydantic-ai too old
+            return None
+        if raw in ("off", "false", "no"):
+            return Thinking(effort=False)
+        if raw in ("minimal", "low", "medium", "high", "xhigh"):
+            return Thinking(effort=raw)
+        logger.warning(
+            "Ignoring POCKETPAW_PYDANTIC_AI_THINKING=%r — expected one of "
+            "default, off, minimal, low, medium, high, xhigh",
+            raw,
+        )
+        return None
+
+    def _build_select_model_capability(self) -> Any:
+        """Downshift to a cheaper model part-way through a long run.
+
+        Off unless a fast model AND at least one threshold are configured, so
+        the default path is byte-for-byte what it was: one model, first step to
+        last.
+
+        The selector is deliberately dumb. ``ModelSelectionContext`` offers the
+        step number, the accumulated usage and the whole message history, and a
+        cleverer policy is easy to write and hard to justify — which of them
+        actually pays is a per-model empirical question, and answering it is
+        what the evals harness is for. This ships the mechanism with the two
+        thresholds that can be reasoned about without a benchmark: a step count
+        and a token ceiling.
+        """
+        spec = str(getattr(self.settings, "pydantic_ai_fast_model", "") or "").strip()
+        after_step = int(getattr(self.settings, "pydantic_ai_fast_model_after_step", 0) or 0)
+        after_tokens = int(getattr(self.settings, "pydantic_ai_fast_model_after_tokens", 0) or 0)
+        if not spec or (after_step <= 0 and after_tokens <= 0):
+            return None
+        try:
+            from pydantic_ai.capabilities import SelectModel
+        except ImportError:  # pragma: no cover - pydantic-ai too old
+            return None
+
+        # Built once, not per step. The fast model shares the instance HTTP
+        # client through ``_build_model``, so this does not reintroduce the
+        # per-turn connection pool the anthropic branch used to leak.
+        fast_model = self._build_model(spec)
+
+        def _select(ctx: Any) -> Any:
+            step = getattr(ctx, "run_step", 1) or 1
+            used = int(getattr(getattr(ctx, "usage", None), "input_tokens", 0) or 0)
+            if (after_step > 0 and step >= after_step) or (
+                after_tokens > 0 and used >= after_tokens
+            ):
+                return fast_model
+            return ctx.model
+
+        logger.info(
+            "Pydantic AI: downshifting to %r after step %s / %s input tokens",
+            spec,
+            after_step or "never",
+            after_tokens or "never",
+        )
+        return SelectModel(selector=_select)
+
     def _get_or_create_agent(
         self,
         model: Any,
@@ -1431,6 +1602,14 @@ class PydanticAIBackend:
         # (they are private to one specialist run), so screening them against it
         # would strip the very tools the caller just attached.
         tools = [t for t in tools if getattr(t, "name", "") not in _WITHHELD_TOOLS]
+
+        # A tool that is now a native capability's LOCAL fallback must not also
+        # ride the plain tool list: the capability puts it on the wire itself on
+        # a provider without native support, and two entries for one job is the
+        # duplicate problem this backend already has four of.
+        if getattr(self.settings, "pydantic_ai_native_web_tools", False):
+            superseded = set(self._NATIVE_WEB_EQUIVALENTS)
+            tools = [t for t in tools if getattr(t, "name", "") not in superseded]
 
         agent = Agent(
             model,

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -676,6 +676,80 @@ class Settings(BaseSettings):
             "tool surface entirely."
         ),
     )
+    pydantic_ai_instrumentation: bool = Field(
+        default=False,
+        description=(
+            "Emit OpenTelemetry spans for Pydantic AI agent runs (model "
+            "requests, tool calls, token usage, time to first chunk). Calls "
+            "``logfire.configure`` once per process with "
+            "``send_to_logfire='if-token-present'``, so without a LOGFIRE_TOKEN "
+            "the spans stay local and reach whatever OTel exporter is already "
+            "configured. Off by default. Cheap since pydantic-ai 2.17.0, which "
+            "caches per-message span serialization — before that it was O(n^2) "
+            "over a run's history and a long tool loop paid for it."
+        ),
+    )
+    pydantic_ai_native_web_tools: bool = Field(
+        default=False,
+        description=(
+            "Let the model run web search and page fetch PROVIDER-SIDE on "
+            "backends that support it, instead of PocketPaw's own tools making "
+            "those HTTP calls from inside the agent process. On an in-process "
+            "backend serving every tenant, a bridged web fetch means our event "
+            "loop does the waiting. PocketPaw's ``web_search`` / ``url_extract`` "
+            "stay wired as the LOCAL fallback, so a provider without native "
+            "support behaves exactly as before and the model never sees two "
+            "tools for one job. Off by default: the profile that advertises "
+            "native support describes the OpenAI API, and whether a LiteLLM "
+            "proxy forwards the native tool to its upstream is a per-deployment "
+            "question."
+        ),
+    )
+    pydantic_ai_thinking: str = Field(
+        default="default",
+        description=(
+            "Reasoning effort for the Pydantic AI backend: 'default' (leave the "
+            "provider's own setting alone), 'off', or one of 'minimal', 'low', "
+            "'medium', 'high', 'xhigh'. Maps to pydantic-ai's portable "
+            "``thinking`` model setting, so it works across providers rather "
+            "than needing the Anthropic or OpenAI spelling. This is the "
+            "largest latency dial on a reasoning model and it is currently "
+            "whatever the provider picked; 'default' keeps that, and any other "
+            "value makes the choice ours."
+        ),
+    )
+    pydantic_ai_fast_model: str = Field(
+        default="",
+        description=(
+            "Optional cheaper/faster model in ``provider:model`` form that the "
+            "Pydantic AI backend downshifts to part-way through a long run. "
+            "Empty disables model selection entirely, which is the default: a "
+            "run stays on ``pydantic_ai_model`` from first step to last. "
+            "Requires one of the two thresholds below to be non-zero."
+        ),
+    )
+    pydantic_ai_fast_model_after_step: int = Field(
+        default=0,
+        description=(
+            "Downshift to ``pydantic_ai_fast_model`` once a run reaches this "
+            "request step (0 = never). A long tool chain front-loads its hard "
+            "judgement and spends its later steps digesting tool results, "
+            "which is also where the context — and so the cost — is largest. "
+            "Whether that trade is worth making is an empirical question per "
+            "model, which is what the evals harness is for; this ships the "
+            "mechanism, off."
+        ),
+    )
+    pydantic_ai_fast_model_after_tokens: int = Field(
+        default=0,
+        description=(
+            "Downshift to ``pydantic_ai_fast_model`` once a run's accumulated "
+            "input tokens exceed this (0 = never). A cost ceiling rather than a "
+            "step count: it turns a runaway loop into a cheap one instead of a "
+            "larger bill. Applied with ``pydantic_ai_fast_model_after_step`` — "
+            "whichever trips first wins."
+        ),
+    )
     pydantic_ai_defer_mcp_tools: bool = Field(
         default=False,
         description=(

--- a/tests/test_pydantic_ai_backend.py
+++ b/tests/test_pydantic_ai_backend.py
@@ -22,6 +22,7 @@ no provider key and no network are required.
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
 
 import pytest
 
@@ -2128,3 +2129,214 @@ async def test_a_surface_that_named_its_tools_is_not_deferred():
     names = await _deferred_surface(backend, allow_mcp_tool_ids=frozenset({"mcp__srv__publish"}))
     assert "srv_publish" in names, "a narrowed surface should see its tools directly"
     assert "search_tools" not in names
+
+
+# --------------------------------------------------------------------------
+# model controls — reasoning effort and per-step model selection
+# --------------------------------------------------------------------------
+
+
+def _caps(backend) -> dict:
+    """Capability instances by class name, as the agent would receive them."""
+    return {type(c).__name__: c for c in backend._build_capabilities()}
+
+
+def test_thinking_is_absent_by_default():
+    """``default`` must leave the setting off the request entirely.
+
+    Not the same as ``off``: absent inherits whatever the provider does, while
+    ``off`` actively disables thinking on a model that would otherwise use it.
+    Collapsing the two would silently turn reasoning off for everyone on upgrade.
+    """
+    assert "Thinking" not in _caps(PydanticAIBackend(_settings()))
+
+
+@pytest.mark.parametrize(
+    ("setting", "expected"),
+    [("off", False), ("low", "low"), ("high", "high"), ("xhigh", "xhigh")],
+)
+def test_thinking_effort_reaches_the_model_settings(setting, expected):
+    backend = PydanticAIBackend(_settings(pydantic_ai_thinking=setting))
+    cap = _caps(backend)["Thinking"]
+    assert cap.effort == expected
+    # Through the capability's own contract, not just its field: this is what
+    # actually lands on the request.
+    assert cap.get_model_settings()["thinking"] == expected
+
+
+def test_an_unknown_thinking_value_is_ignored_not_guessed():
+    """A typo must not silently pick an effort level for the operator."""
+    assert "Thinking" not in _caps(PydanticAIBackend(_settings(pydantic_ai_thinking="hihg")))
+
+
+def test_model_selection_is_off_unless_a_model_and_a_threshold_are_set():
+    """Half a configuration is not a configuration. A fast model with no
+    threshold would never fire; a threshold with no model has nothing to
+    downshift to."""
+    for overrides in (
+        {},
+        {"pydantic_ai_fast_model": "litellm:cheap"},
+        {"pydantic_ai_fast_model_after_step": 3},
+        {"pydantic_ai_fast_model_after_tokens": 50_000},
+    ):
+        assert "SelectModel" not in _caps(PydanticAIBackend(_settings(**overrides))), overrides
+
+
+def test_the_run_downshifts_on_the_step_threshold():
+    backend = PydanticAIBackend(
+        _settings(pydantic_ai_fast_model="litellm:cheap", pydantic_ai_fast_model_after_step=3)
+    )
+    select = _caps(backend)["SelectModel"].selector
+
+    class _Ctx:
+        def __init__(self, step):
+            self.run_step = step
+            self.usage = SimpleNamespace(input_tokens=0)
+            self.model = "MAIN"
+
+    assert select(_Ctx(1)) == "MAIN"
+    assert select(_Ctx(2)) == "MAIN"
+    assert getattr(select(_Ctx(3)), "model_name", None) == "cheap", "step 3 must downshift"
+    assert getattr(select(_Ctx(9)), "model_name", None) == "cheap"
+
+
+def test_the_run_downshifts_on_the_token_ceiling():
+    """A cost ceiling, independent of how many steps it took to get there."""
+    backend = PydanticAIBackend(
+        _settings(
+            pydantic_ai_fast_model="litellm:cheap", pydantic_ai_fast_model_after_tokens=50_000
+        )
+    )
+    select = _caps(backend)["SelectModel"].selector
+
+    class _Ctx:
+        def __init__(self, used):
+            self.run_step = 1
+            self.usage = SimpleNamespace(input_tokens=used)
+            self.model = "MAIN"
+
+    assert select(_Ctx(49_999)) == "MAIN"
+    assert getattr(select(_Ctx(50_000)), "model_name", None) == "cheap"
+
+
+def test_the_fast_model_shares_the_instance_http_client():
+    """The selector builds a second model, which is exactly the shape that
+    leaked a connection pool per turn on the anthropic branch."""
+    backend = PydanticAIBackend(
+        _settings(pydantic_ai_fast_model="litellm:cheap", pydantic_ai_fast_model_after_step=2)
+    )
+    _caps(backend)  # builds the fast model
+    main = backend._build_model()
+    fast = backend._build_model("litellm:cheap")
+    assert main._provider.client._client is fast._provider.client._client
+
+
+async def test_native_web_tools_are_off_by_default():
+    backend = _backend_with_model(TestModel())
+    backend._custom_tools = _bridged("web_search", "url_extract", "research")
+    names = await _tool_surface(backend)
+    assert {"web_search", "url_extract"} <= names
+    caps = {type(c).__name__ for c in backend._build_capabilities()}
+    assert not caps & {"WebSearch", "WebFetch"}
+
+
+async def test_the_bridged_web_tool_becomes_the_local_fallback_not_a_duplicate():
+    """The model must never be offered two tools for one job.
+
+    ``WebSearch(local=...)`` puts our tool on the wire itself when the provider
+    has no native web search, so leaving it in the plain tool list as well is
+    how the surface grows a duplicate pair — this backend already carries four.
+    """
+    backend = _backend_with_model(TestModel(), pydantic_ai_native_web_tools=True)
+    backend._custom_tools = _bridged("web_search", "url_extract", "research")
+
+    caps = {type(c).__name__: c for c in backend._build_capabilities()}
+    assert "WebSearch" in caps and "WebFetch" in caps
+    assert getattr(caps["WebSearch"].local, "name", "") == "web_search", (
+        "our own tool must be the fallback, not pydantic-ai's DuckDuckGo one"
+    )
+
+    names = await _tool_surface(backend)
+    assert "web_search" not in names, "superseded tool still on the plain tool list"
+    assert "url_extract" not in names
+    assert "research" in names, "research has no native equivalent and must survive"
+
+
+def test_a_withheld_web_tool_is_not_granted_back_by_the_native_capability():
+    """A surface that removed ``web_search`` must not get it re-granted
+    provider-side. Registering the native tool with no local fallback would do
+    exactly that."""
+    backend = PydanticAIBackend(_settings(pydantic_ai_native_web_tools=True))
+    backend._custom_tools = _bridged("url_extract")  # web_search deliberately absent
+
+    caps = {type(c).__name__ for c in backend._build_capabilities()}
+    assert "WebFetch" in caps
+    assert "WebSearch" not in caps
+
+
+def test_instrumentation_is_off_by_default_and_configures_logfire_once():
+    """One backend instance exists per agent, so a per-instance
+    ``logfire.configure`` would reconfigure the process on every agent built."""
+    import pocketpaw.agents.pydantic_ai as mod
+
+    assert "Instrumentation" not in {
+        type(c).__name__ for c in PydanticAIBackend(_settings())._build_capabilities()
+    }
+
+    calls: list = []
+    original_flag = mod._LOGFIRE_CONFIGURED
+    mod._LOGFIRE_CONFIGURED = False
+    import sys
+
+    fake = SimpleNamespace(configure=lambda **kw: calls.append(kw))
+    saved, sys.modules["logfire"] = sys.modules.get("logfire"), fake
+    try:
+        for _ in range(3):
+            caps = {
+                type(c).__name__
+                for c in PydanticAIBackend(
+                    _settings(pydantic_ai_instrumentation=True)
+                )._build_capabilities()
+            }
+            assert "Instrumentation" in caps
+    finally:
+        if saved is not None:
+            sys.modules["logfire"] = saved
+        else:
+            sys.modules.pop("logfire", None)
+        mod._LOGFIRE_CONFIGURED = original_flag
+
+    assert len(calls) == 1, f"logfire configured {len(calls)} times across 3 backends"
+    assert calls[0]["send_to_logfire"] == "if-token-present", (
+        "must be safe to enable without a Logfire account"
+    )
+
+
+def test_a_broken_logfire_does_not_break_the_run():
+    """Observability is never load-bearing."""
+    import sys
+
+    import pocketpaw.agents.pydantic_ai as mod
+
+    def _boom(**kw):
+        raise RuntimeError("no exporter")
+
+    original_flag = mod._LOGFIRE_CONFIGURED
+    mod._LOGFIRE_CONFIGURED = False
+    saved = sys.modules.get("logfire")
+    sys.modules["logfire"] = SimpleNamespace(configure=_boom)
+    try:
+        caps = {
+            type(c).__name__
+            for c in PydanticAIBackend(
+                _settings(pydantic_ai_instrumentation=True)
+            )._build_capabilities()
+        }
+    finally:
+        if saved is not None:
+            sys.modules["logfire"] = saved
+        else:
+            sys.modules.pop("logfire", None)
+        mod._LOGFIRE_CONFIGURED = original_flag
+
+    assert "Instrumentation" in caps, "a dead exporter must not drop instrumentation"

--- a/uv.lock
+++ b/uv.lock
@@ -1524,6 +1524,15 @@ wheels = [
 ]
 
 [[package]]
+name = "executing"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
+]
+
+[[package]]
 name = "fakeredis"
 version = "2.35.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3548,6 +3557,24 @@ wheels = [
 ]
 
 [[package]]
+name = "logfire"
+version = "4.39.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "executing" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-sdk" },
+    { name = "protobuf" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/7d/9d04b6c716c7963cc0176b0aafee1b7becd0d3c3b2febe704dc9ae5a4318/logfire-4.39.0.tar.gz", hash = "sha256:7291ae695a145c21b4fa9baea2ffaf42b23c79a08e1f3edcef5a4cad41867a0d", size = 1242395, upload-time = "2026-07-24T18:31:34.698Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/57/b40307cdfd81d07433ad5ae38de70fe6e543f3fb7e764bdf6944695a386b/logfire-4.39.0-py3-none-any.whl", hash = "sha256:e6046e03ce45098c15a9dbf42ced8b95dfcb60cc1f3600a6250c8f515755be5f", size = 405126, upload-time = "2026-07-24T18:31:30.844Z" },
+]
+
+[[package]]
 name = "logfire-api"
 version = "4.39.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5253,9 +5280,13 @@ postgresql = [
     { name = "sqlalchemy", extra = ["asyncio"] },
 ]
 pydantic-ai = [
+    { name = "logfire" },
     { name = "pydantic-ai-harness" },
     { name = "pydantic-ai-skills" },
     { name = "pydantic-ai-slim", extra = ["mcp", "openai"] },
+]
+pydantic-ai-evals = [
+    { name = "pydantic-evals" },
 ]
 recommended = [
     { name = "mem0ai" },
@@ -5422,6 +5453,7 @@ requires-dist = [
     { name = "langchain-openai", marker = "extra == 'deep-agents'", specifier = ">=1.2.0,<2.0.0" },
     { name = "langchain-openai", marker = "extra == 'dev'", specifier = ">=1.2.0,<2.0.0" },
     { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.40.0" },
+    { name = "logfire", marker = "extra == 'pydantic-ai'", specifier = ">=4.39.0,<5" },
     { name = "matrix-nio", marker = "extra == 'all'", specifier = ">=0.24.0" },
     { name = "matrix-nio", marker = "extra == 'all-channels'", specifier = ">=0.24.0" },
     { name = "matrix-nio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
@@ -5471,9 +5503,10 @@ requires-dist = [
     { name = "pyautogui", marker = "extra == 'dev'", specifier = ">=0.9.54" },
     { name = "pyautogui", marker = "extra == 'recommended'", specifier = ">=0.9.54" },
     { name = "pydantic", specifier = ">=2.10.0" },
-    { name = "pydantic-ai-harness", marker = "extra == 'pydantic-ai'", specifier = "==0.8.0" },
-    { name = "pydantic-ai-skills", marker = "extra == 'pydantic-ai'", specifier = "==1.2.0" },
-    { name = "pydantic-ai-slim", extras = ["openai", "mcp"], marker = "extra == 'pydantic-ai'", specifier = "==2.14.1" },
+    { name = "pydantic-ai-harness", marker = "extra == 'pydantic-ai'", specifier = "==0.11.0" },
+    { name = "pydantic-ai-skills", marker = "extra == 'pydantic-ai'", specifier = "==1.3.0" },
+    { name = "pydantic-ai-slim", extras = ["openai", "mcp"], marker = "extra == 'pydantic-ai'", specifier = "==2.18.0" },
+    { name = "pydantic-evals", marker = "extra == 'pydantic-ai-evals'", specifier = "==2.18.0" },
     { name = "pydantic-settings", specifier = ">=2.1.0" },
     { name = "pypdf", marker = "extra == 'knowledge'" },
     { name = "pytesseract", marker = "extra == 'all'", specifier = ">=0.3.10" },
@@ -5512,7 +5545,7 @@ requires-dist = [
     { name = "trafilatura", marker = "extra == 'knowledge'" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.31.1" },
 ]
-provides-extras = ["vector", "knowledge", "databases", "postgresql", "mysql", "mongodb", "s3", "graph", "dashboard", "telegram", "browser", "desktop", "openai-agents", "codex-sdk", "google-adk", "copilot-sdk", "deep-agents", "pydantic-ai", "litellm", "memory", "soul", "discord", "slack", "whatsapp-personal", "matrix", "teams", "gchat", "drive", "image", "extract", "voice", "ocr", "sarvam", "mcp", "recommended", "channels", "all-channels", "all-tools", "all-backends", "all", "dev"]
+provides-extras = ["vector", "knowledge", "databases", "postgresql", "mysql", "mongodb", "s3", "graph", "dashboard", "telegram", "browser", "desktop", "openai-agents", "codex-sdk", "google-adk", "copilot-sdk", "deep-agents", "pydantic-ai", "pydantic-ai-evals", "litellm", "memory", "soul", "discord", "slack", "whatsapp-personal", "matrix", "teams", "gchat", "drive", "image", "extract", "voice", "ocr", "sarvam", "mcp", "recommended", "channels", "all-channels", "all-tools", "all-backends", "all", "dev"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -6136,34 +6169,34 @@ email = [
 
 [[package]]
 name = "pydantic-ai-harness"
-version = "0.8.0"
+version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic-ai-slim" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6c/56/ac4a037904fa7afc28e85435473c12f3ffb6b22b9bc55b87e32f53e458a0/pydantic_ai_harness-0.8.0.tar.gz", hash = "sha256:19618493243c830d27cf506b766ebb41eace38bc97f8cd0555c749e93cdf9052", size = 1026717, upload-time = "2026-07-21T01:36:31.806Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/99/25a7f4f4db7ed6e40785a2c2a02ca895e9ea810324bf3a82916e8ab2be6a/pydantic_ai_harness-0.11.0.tar.gz", hash = "sha256:2a36a7d4ae3b1f8cdf91bc4f19defe94b0bdb11e4b2a65da41e4e3efd88954f5", size = 1277646, upload-time = "2026-07-25T01:21:09.129Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/6d/3e25df57b58343fde1878a1c8d72b4d10ef81a55034c13d92aa8e6e0fb0b/pydantic_ai_harness-0.8.0-py3-none-any.whl", hash = "sha256:75f50cfbd0ed9352303eb55d9036a0b22bf43122b117580cd7f9b6c24c7b7ce5", size = 316654, upload-time = "2026-07-21T01:36:30.115Z" },
+    { url = "https://files.pythonhosted.org/packages/12/8a/6bafcc983a227f01cdce28becc36ab6fe4baec365ae10bdbec70a986c5b8/pydantic_ai_harness-0.11.0-py3-none-any.whl", hash = "sha256:c849725d467a98fb01e035a526b7b7c488952935e3f5c9b74f517a3ec11fc47a", size = 402345, upload-time = "2026-07-25T01:21:07.18Z" },
 ]
 
 [[package]]
 name = "pydantic-ai-skills"
-version = "1.2.0"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "pydantic-ai-slim" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/90/5f20728badc7d17ca0e81f24dc35a96c02f008323dce393d0e70a8465144/pydantic_ai_skills-1.2.0.tar.gz", hash = "sha256:e52f7e8243343dfa94206aae11cd142120edb8990fc392b1d8af32f99b6d351e", size = 9031839, upload-time = "2026-07-15T02:37:26.37Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/36/d5746c3d5f7dbcdd9b30e5dd2dc4babc397b1fb21de300e3dc15c34aee3a/pydantic_ai_skills-1.3.0.tar.gz", hash = "sha256:9940240170fa315640b76ec94be430bea1df55ac6d625a285725b4994f07f86d", size = 9060859, upload-time = "2026-07-25T22:35:24.367Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/74/143ca60dd9bfa11ce0349ee58bbdd646798c8bdc031588d67a8bea96797d/pydantic_ai_skills-1.2.0-py3-none-any.whl", hash = "sha256:7ff4eb4b307deb6ef3bf31a6d9493c1e3a8e9b866a13b866a9ea4606bd914206", size = 63883, upload-time = "2026-07-15T02:37:24.117Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/5d/a93d33b5eb69f03b95c7de4f10ed04cd2135c0fc14fa73293c0610699df2/pydantic_ai_skills-1.3.0-py3-none-any.whl", hash = "sha256:4a8e001054b8c458d9b9b1d7688f0a30602246473ed8dfbe235dc4557b458dff", size = 59132, upload-time = "2026-07-25T22:35:22.603Z" },
 ]
 
 [[package]]
 name = "pydantic-ai-slim"
-version = "2.14.1"
+version = "2.18.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "genai-prices" },
@@ -6174,9 +6207,9 @@ dependencies = [
     { name = "pydantic-graph" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/20/0e/33989e7bcd2abaefdc2534129055dce0943bbcdcc5212d2296f79fd604b7/pydantic_ai_slim-2.14.1.tar.gz", hash = "sha256:3ce0afde81cd50fcd434ccdd46774f4386bee8cc0ed3e75d7dc8784fdca303ff", size = 866335, upload-time = "2026-07-21T05:40:59.91Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/39/c3a941027be87f6bc07e50e1e72ae93e66a1b11b838e33ad5d135d2fe2f0/pydantic_ai_slim-2.18.0.tar.gz", hash = "sha256:dfe47a3602049f779223702a684ed8091b111cfae1851236616d6b0eb3b0b077", size = 902113, upload-time = "2026-07-25T01:21:05.614Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/74/51/8682b564598571d7056971d62221fafda2ce513481cc241f3ac621e6460e/pydantic_ai_slim-2.14.1-py3-none-any.whl", hash = "sha256:64687be32deb8075eb99edba837a61d22daf1801cd3b1e6925e8519c13838934", size = 1050646, upload-time = "2026-07-21T05:40:52.205Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/a0/a0619bddf602f69a754540cb82147f9b53dfa2d093e1fe7051c5e6a8eceb/pydantic_ai_slim-2.18.0-py3-none-any.whl", hash = "sha256:4c4076166a63ad96fe6ed5a517223c4a5aba6c9682a17d8d0ac42839cbc83622", size = 1091565, upload-time = "2026-07-25T01:20:57.323Z" },
 ]
 
 [package.optional-dependencies]
@@ -6278,8 +6311,25 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-evals"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "logfire-api" },
+    { name = "pydantic" },
+    { name = "pydantic-ai-slim" },
+    { name = "pyyaml" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fd/4a/e2b629f4724a6026c792a5bd7ceb470bf38d48c6a2ebe8cec091ed85485f/pydantic_evals-2.18.0.tar.gz", hash = "sha256:d26ab006290564a5e56394b9033fbd5925e4a172d9e23be5f3c034ae3637eb18", size = 85222, upload-time = "2026-07-25T01:21:07.101Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/8d/be8abc897f9cd9ef83e000bfaa8d9bec0d93fe2f59f219d2c3835d66b033/pydantic_evals-2.18.0-py3-none-any.whl", hash = "sha256:98d20973df83c3ca6d7341ce2f704ae59b53e02698b55df765f9a1cd5ec5ea1d", size = 100524, upload-time = "2026-07-25T01:20:59.284Z" },
+]
+
+[[package]]
 name = "pydantic-graph"
-version = "2.14.1"
+version = "2.18.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -6287,9 +6337,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e8/e7/db61f8c7a323feb55884ca701f138ae18911126628595375ff9d0d47397a/pydantic_graph-2.14.1.tar.gz", hash = "sha256:8f3a577a3ae278012d168c0db07a9bdf1b0021d21e48831c0b05518f2230730e", size = 43934, upload-time = "2026-07-21T05:41:02.136Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/f9/1554e818e6d38bcb3f66ec7da7abe17c28dcd00caa1550b034e175b8841f/pydantic_graph-2.18.0.tar.gz", hash = "sha256:9423defa047b477a561a06eadfd37aaf101a2b690d044adb79de80d7ea203e4e", size = 44017, upload-time = "2026-07-25T01:21:08.152Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/03/ff2ee9174ea0083638c1e31b5f5c92ffd3e795024db23caa0ea297458cd5/pydantic_graph-2.14.1-py3-none-any.whl", hash = "sha256:4e4b2afb0751b5495fce9f253a5b4ccac9a0f86989fa7479ee8d517f76bd449f", size = 51658, upload-time = "2026-07-21T05:40:55.711Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/29/fd05a4a84db9dae16c0417d8bcd6847148439a55329d000ef101d7243ded/pydantic_graph-2.18.0-py3-none-any.whl", hash = "sha256:48df74e3ae12ca44f99890e9b4f7020ae70a5a38d20df02db7cb16b0db3c3711", size = 51662, upload-time = "2026-07-25T01:21:00.764Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Stacked on #1815. Four capabilities pydantic-ai already ships that this backend
was not using, plus the dependency move that makes one of them affordable, and a
harness to tell whether any of it helps.

Everything is off by default. The current path is byte-for-byte unchanged until
someone opts in.

## Versions

Every pin moves to the newest release clearing the workspace's 7-day minimum
release age. The next release of each landed inside the window, so this is the
ceiling rather than a preference.

| Package | Was | Now |
|---|---|---|
| `pydantic-ai-slim` | 2.14.1 | 2.18.0 |
| `pydantic-ai-harness` | 0.8.0 | 0.11.0 |
| `pydantic-ai-skills` | 1.2.0 | 1.3.0 |
| `logfire` | — | 4.39.0 |
| `pydantic-evals` | — | 2.18.0 |

Four slim releases reviewed for breaking changes; none reach our surface. 2.17.0
is the one worth having: it caches per-message OpenTelemetry serialization to
avoid an O(n²) cost, which is what makes instrumentation affordable on a long
tool loop instead of a tax on it. No source changes were needed, and the
deferred-loading measurement is unchanged.

`logfire` is ranged rather than pinned exactly, being a 4.x line on a normal
cadence rather than one of the pre-1.0-shaped packages the exact pins exist for.
`pydantic-evals` sits in its own extra: it is a development dependency and
nothing on the request path imports it.

## Thinking

Sets reasoning effort through pydantic-ai's portable setting, so one value works
across Anthropic, OpenAI and the proxy rather than needing each vendor's
spelling. This is the largest latency dial on a reasoning model and it was
whatever the provider happened to pick.

`default` leaves the setting absent entirely, which is not the same as `off`.
Off actively disables thinking on a model that would otherwise use it, and
collapsing the two would silently change behaviour for everyone on upgrade. A
typo is ignored with a warning rather than resolved to a guess.

## SelectModel

Downshifts to a cheaper model part-way through a long run, on a step count or a
token ceiling, whichever trips first.

The selector is deliberately dumb. The context offers step number, accumulated
usage and the whole message history, and a cleverer policy is easy to write and
hard to justify, and which one actually pays is a per-model empirical question. So
this ships the mechanism with the two thresholds that can be reasoned about
without a benchmark, and leaves the answer to the harness below.

Half a configuration does nothing: a fast model with no threshold would never
fire, a threshold with no model has nothing to downshift to, and both cases are
pinned. The fast model shares the instance HTTP client, since building a second
model is exactly the shape that leaked a connection pool per turn on the
anthropic branch.

## Native web tools

`WebSearch` and `WebFetch` move web work provider-side. That matters more here
than elsewhere: a bridged web tool makes its HTTP call from inside the agent
process, so on one process serving every tenant our event loop does the waiting.

PocketPaw's own `web_search` and `url_extract` become the capability's local
fallback rather than being dropped. A provider without native support behaves
exactly as before, there is one implementation rather than two, and the model is
never offered two tools for one job: this backend already carries four
duplicate pairs and did not need more. A surface that withheld `web_search` does
not get it re-granted provider-side.

Off by default because the profile advertising native support describes the
OpenAI API, and whether a LiteLLM proxy forwards the native tool to its upstream
is a per-deployment question I could not answer here.

## Instrumentation

OTel spans per run, tool call and token count. This backend's whole argument is a
cost curve and PA-1 is still unrun; spans are what make that measurable from the
inside rather than by wrapping a stopwatch around the request.

`logfire.configure` runs once per process with
`send_to_logfire='if-token-present'`, so it is safe to enable without a Logfire
account, and a dead exporter logs a warning rather than dropping instrumentation
or failing a tenant's run. One backend instance exists per agent, so the
once-per-process guard is load-bearing and tested.

## The harness

`scripts/evals/tool_search_eval.py` A/Bs deferral against phrasings a user
actually types, and reports tokens saved against tasks lost. That trade is the
open question the deferred-loading work could not settle: the saving is
arithmetic, whether a model searches rather than answering without looking is
behaviour.

A script, never a test. It spends real tokens.

The first live run against the proxy returned 503 on every case, and the harness
dutifully reported 0/3 twice with a confident verdict underneath, wrapped in a
thousand lines of traceback. Both are fixed: the backend's logger is quieted for
the duration, and an arm where every case errored now says NO RESULT above the
numbers. A harness that reports a confident zero when the model was simply down
is worse than no harness.

So the behavioural question is still open. The proxy's upstreams were unhealthy
at the time of writing.

## Not done

`composio_tools_for()` is called by `deep_agents`, `google_adk` and
`openai_agents`, and not by the pydantic-ai tool builder, so Composio's hosted
tools do not reach this backend. Fixing it interacts with the tool allowlist:
Composio names are dynamic, so they would need approving by provenance rather
than by name. That is a design call, not a one-liner.
