### PR TITLE
feat(cloud): new cloud agents default to the in-process backend

### DIFF
--- a/docs/handoff/2026-08-01-cloud-backend-default.md
+++ b/docs/handoff/2026-08-01-cloud-backend-default.md
@@ -1,0 +1,85 @@
+# Cloud agents default to `pydantic_ai`
+
+2026-08-01. What changed, what deliberately did not, and what has to be true
+before the rest of it happens.
+
+## What changed
+
+A **new** cloud agent that does not name a backend now gets `pydantic_ai`
+instead of `claude_agent_sdk`. The value lives in one place,
+`pocketpaw_ee.cloud.agents.defaults.CLOUD_DEFAULT_AGENT_BACKEND`, and the four
+schemas an agent can arrive through read it: the Beanie document
+(`models/agent.py`), the domain value object (`agents/domain.py`), the
+create-request DTO (`agents/dto.py`) and the planner's agent creation.
+
+They were four independent literals before, which is how a default ends up
+depending on which caller created the agent.
+
+## What did not change, and why
+
+**The self-hosted default.** `Settings.agent_backend` is still
+`claude_agent_sdk`, and `pocketpaw_ee` is not importable from OSS core anyway.
+`pydantic_ai` is dispatch-only by design — no shell, no filesystem — because one
+process serves every tenant and PocketPaw's builtin tools jail against a
+process-global path. That trade is right in a multi-tenant cloud and wrong on a
+laptop, where "a self-hosted AI agent that runs locally" is the product. These
+are two different correct answers, not one someone forgot to unify.
+
+**Existing agents.** Every `AgentDoc` in Mongo stores its backend explicitly, so
+a default change is invisible to them. They keep running `claude_agent_sdk`
+until something rewrites the field, and nothing here does. That is the safe
+behaviour, and it is also a decision deferred rather than made.
+
+**The pool's fallback.** `AgentPool._build` still reads
+`config.get("backend", "claude_agent_sdk")`. `AgentConfig` carries a default, so
+`model_dump()` always includes the key and that fallback only fires for a
+document written before the field existed — which is to say a document from when
+`claude_agent_sdk` was the default. Answering with today's default would
+silently re-home the oldest agents in the estate.
+
+## Before migrating existing agents
+
+Two things are unfinished, and both bear on whether a migration is a good idea.
+
+**PA-1 has not been run.** The concurrency measurement that justifies this
+backend over `deep_agents` — 250 concurrent runs, memory and throughput — is
+still unrun; there are no results under `scripts/loadtest/`. The premise is
+sound (a CLI subprocess per run at 300-500 MB RSS does not fit a box) but it is
+a premise. New agents are a small, reversible population to test it on. Every
+existing agent is not.
+
+**Composio tools do not reach this backend.** `composio_tools_for()` is called
+by `deep_agents`, `google_adk` and `openai_agents`, and not by the pydantic-ai
+tool builder. A Composio-configured workspace that migrates an existing agent
+would lose those integrations. Fixing it needs a decision, because Composio tool
+names are dynamic (`GMAIL_SEND_EMAIL`) and the backend's tool allowlist approves
+by name — they would have to be approved by provenance instead.
+
+## The migration, when it is wanted
+
+Not written as a script on purpose: it is a one-line update against a
+production collection and it should be run by someone who has read the two
+caveats above.
+
+```js
+// Agents that never chose a backend explicitly cannot be distinguished from
+// those that chose the old default — the field records the value, not the
+// intent. So this migrates BOTH, which is why it wants a decision rather than
+// a cron job.
+db.agents.updateMany(
+  { "config.backend": "claude_agent_sdk" },
+  { $set: { "config.backend": "pydantic_ai" } }
+)
+```
+
+Do it per workspace first, not estate-wide. `POCKETPAW_PYDANTIC_AI_MODEL` has to
+be set for the deployment, and the surfaces those agents run on should be
+checked against the gating work in PR #1815 — the other six non-Claude backends
+still crash on a surface that sets `deny_mcp_tool_ids`, so a workspace with a
+fallback chain configured needs that looked at first.
+
+## Rollback
+
+Change `CLOUD_DEFAULT_AGENT_BACKEND` back. Nothing else stores a copy, which was
+the point of introducing it. Agents already created keep whatever they were
+given, in both directions.

--- a/ee/pocketpaw_ee/cloud/agents/defaults.py
+++ b/ee/pocketpaw_ee/cloud/agents/defaults.py
@@ -1,0 +1,37 @@
+"""The backend a cloud agent gets when nobody chooses one.
+
+Created 2026-08-01.
+
+One name instead of the five literals this replaced (``agents/domain.py``,
+``agents/dto.py``, ``models/agent.py``, ``planner/service.py``, and the pool's
+fallback). They had drifted apart in kind if not in value: three were schema
+defaults, one was a call-site argument, one was a ``dict.get`` fallback, and
+nothing tied them together, so changing the default meant finding all five.
+
+**Cloud only, deliberately.** ``Settings.agent_backend`` — the OSS
+self-hosted default — stays ``claude_agent_sdk`` and is not imported here.
+PocketPaw self-hosted is a local agent, and ``pydantic_ai`` is dispatch-only by
+design: no shell, no filesystem, because one process serves every tenant and
+the builtin jail is process-global. That trade is right in a multi-tenant cloud
+and wrong on a laptop, so the two defaults are genuinely different values rather
+than one value someone forgot to unify.
+
+**Existing agents do not move.** Every ``AgentDoc`` already in Mongo stores its
+backend explicitly, so a default change is invisible to them; they keep running
+``claude_agent_sdk`` until something rewrites the field. That is the safe
+behaviour and it is also a decision deferred, not a decision made — see
+``docs/handoff/2026-08-01-cloud-backend-default.md`` for the migration and the
+measurement that should precede it.
+"""
+
+from __future__ import annotations
+
+CLOUD_DEFAULT_AGENT_BACKEND = "pydantic_ai"
+"""Backend for a NEW cloud agent that does not name one.
+
+``pydantic_ai`` rather than ``claude_agent_sdk`` because the cloud's binding
+constraint is concurrency: the Claude SDK backend spawns a CLI subprocess per
+concurrent run at roughly 300-500 MB RSS, which is most of a box before any
+other cost, while this one runs the agent loop in-process and pays roughly the
+conversation context per run.
+"""

--- a/ee/pocketpaw_ee/cloud/agents/domain.py
+++ b/ee/pocketpaw_ee/cloud/agents/domain.py
@@ -29,12 +29,14 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime
 
+from pocketpaw_ee.cloud.agents.defaults import CLOUD_DEFAULT_AGENT_BACKEND
+
 
 @dataclass(frozen=True)
 class AgentConfigSpec:
     """Configuration data for an agent. Mirrors ``models.agent.AgentConfig``."""
 
-    backend: str = "claude_agent_sdk"
+    backend: str = CLOUD_DEFAULT_AGENT_BACKEND
     model: str = ""
     system_prompt: str = ""
     tools: tuple[str, ...] = ()

--- a/ee/pocketpaw_ee/cloud/agents/dto.py
+++ b/ee/pocketpaw_ee/cloud/agents/dto.py
@@ -25,6 +25,7 @@ from typing import Any
 from pydantic import BaseModel, Field, field_validator
 
 from pocketpaw_ee.cloud._core.time import iso_utc
+from pocketpaw_ee.cloud.agents.defaults import CLOUD_DEFAULT_AGENT_BACKEND
 from pocketpaw_ee.cloud.agents.domain import Agent, AgentConfigSpec
 from pocketpaw_ee.cloud.agents.scope_rules import normalise_and_validate_scopes
 
@@ -38,7 +39,7 @@ class CreateAgentRequest(BaseModel):
     slug: str = Field(min_length=1, max_length=50)
     avatar: str = ""
     visibility: str = Field(default="private", pattern="^(private|workspace|public)$")
-    backend: str = "claude_agent_sdk"
+    backend: str = CLOUD_DEFAULT_AGENT_BACKEND
     model: str = ""
     persona: str = ""
     temperature: float | None = None

--- a/ee/pocketpaw_ee/cloud/models/agent.py
+++ b/ee/pocketpaw_ee/cloud/models/agent.py
@@ -33,11 +33,12 @@ from __future__ import annotations
 from beanie import Indexed
 from pydantic import BaseModel, Field
 
+from pocketpaw_ee.cloud.agents.defaults import CLOUD_DEFAULT_AGENT_BACKEND
 from pocketpaw_ee.cloud.models.base import TimestampedDocument
 
 
 class AgentConfig(BaseModel):
-    backend: str = "claude_agent_sdk"
+    backend: str = CLOUD_DEFAULT_AGENT_BACKEND
     model: str = ""  # empty = use backend default
     system_prompt: str = ""
     tools: list[str] = Field(default_factory=list)

--- a/ee/pocketpaw_ee/cloud/planner/service.py
+++ b/ee/pocketpaw_ee/cloud/planner/service.py
@@ -116,6 +116,7 @@ from pocketpaw_ee.cloud._core.context import RequestContext
 from pocketpaw_ee.cloud._core.errors import NotFound, ValidationError
 from pocketpaw_ee.cloud._core.realtime.emit import emit
 from pocketpaw_ee.cloud._core.realtime.events import PlanGapResolved, PlanGenerated
+from pocketpaw_ee.cloud.agents.defaults import CLOUD_DEFAULT_AGENT_BACKEND
 from pocketpaw_ee.cloud.models.planner import PlanSession as _PlanSessionDoc
 from pocketpaw_ee.cloud.models.planner import PlanSessionAgentGap as _PlanSessionAgentGapDoc
 from pocketpaw_ee.cloud.planner.domain import AgentGap, PlanSession, PlanSessionSummary
@@ -1485,7 +1486,7 @@ async def _ensure_agent(workspace_id: str, spec_name: str) -> str | None:
                 name=spec_name,
                 slug=slug,
                 description=f"Auto-created for planner spec: {spec_name}",
-                backend="claude_agent_sdk",
+                backend=CLOUD_DEFAULT_AGENT_BACKEND,
             ),
         )
         logger.info("_ensure_agent: created agent %s for %s", str(created.id), spec_name)

--- a/src/pocketpaw/agents/pool.py
+++ b/src/pocketpaw/agents/pool.py
@@ -689,6 +689,13 @@ class AgentPool:
 
         # Clone settings and override with agent config
         settings = Settings.load()
+        # The literal stays ``claude_agent_sdk`` on purpose, and is NOT the
+        # cloud default (``pocketpaw_ee.cloud.agents.defaults``, which OSS core
+        # cannot import anyway). ``AgentConfig`` carries a default, so
+        # ``model_dump`` always includes the key and this fallback only fires
+        # for a document written before the field existed — which is to say a
+        # document from when ``claude_agent_sdk`` WAS the default. Answering
+        # with today's default would silently re-home the oldest agents.
         settings.agent_backend = config.get("backend", "claude_agent_sdk")
 
         # Map the per-agent model onto the Settings field the chosen backend

--- a/tests/cloud/test_agent_schemas.py
+++ b/tests/cloud/test_agent_schemas.py
@@ -8,6 +8,7 @@ new ScopeAssignmentRequest / ScopeAssignmentResponse envelopes.
 from __future__ import annotations
 
 import pytest
+from pocketpaw_ee.cloud.agents.defaults import CLOUD_DEFAULT_AGENT_BACKEND
 from pocketpaw_ee.cloud.agents.dto import (
     AgentResponse,
     CreateAgentRequest,
@@ -21,7 +22,10 @@ from pydantic import ValidationError as PydanticValidationError
 
 def test_create_agent_required_fields():
     req = CreateAgentRequest(name="My Agent", slug="my-agent")
-    assert req.name == "My Agent" and req.backend == "claude_agent_sdk"
+    # Against the constant, not a literal: this assertion broke when the cloud
+    # default moved to pydantic_ai, which is the third time a default change has
+    # had to chase copies of itself through the tests.
+    assert req.name == "My Agent" and req.backend == CLOUD_DEFAULT_AGENT_BACKEND
 
 
 def test_create_agent_with_backend():
@@ -33,7 +37,7 @@ def test_create_agent_defaults():
     req = CreateAgentRequest(name="Test", slug="test")
     assert req.avatar == ""
     assert req.visibility == "private"
-    assert req.backend == "claude_agent_sdk"
+    assert req.backend == CLOUD_DEFAULT_AGENT_BACKEND
     assert req.model == ""
 
 

--- a/tests/test_cloud_backend_default.py
+++ b/tests/test_cloud_backend_default.py
@@ -1,0 +1,90 @@
+"""The cloud's default agent backend, and the line it must not cross.
+
+Created 2026-08-01.
+
+Lives in ``tests/`` rather than ``tests/cloud/`` deliberately: the pyproject
+addopts carry ``--ignore=tests/cloud``, so a guard placed there runs on nobody's
+machine but the author's and never in CI. The EE assertions skip individually
+when ``pocketpaw_ee`` is absent, which keeps the OSS-only job running the two
+that matter most to it.
+
+A new cloud agent should run ``pydantic_ai``: the cloud's binding constraint is
+concurrency, and the Claude SDK backend spawns a CLI subprocess per concurrent
+run. A self-hosted install should not, because ``pydantic_ai`` is dispatch-only
+- no shell, no filesystem - and PocketPaw self-hosted is a local agent. Two
+different right answers, so both ends are pinned.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _cloud_default() -> str:
+    pytest.importorskip("pocketpaw_ee", reason="pocketpaw-ee not installed")
+    from pocketpaw_ee.cloud.agents.defaults import CLOUD_DEFAULT_AGENT_BACKEND
+
+    return CLOUD_DEFAULT_AGENT_BACKEND
+
+
+def test_a_new_cloud_agent_defaults_to_the_in_process_backend():
+    """Every schema a new agent can arrive through, not just one.
+
+    These were three independent literals: the Beanie document, the domain value
+    object and the create-request DTO. An agent created through the API arrives
+    via the DTO, one created by the planner via the domain, one written directly
+    via the document - so a default living in only two of them is a default that
+    depends on the caller.
+    """
+    default = _cloud_default()
+    from pocketpaw_ee.cloud.agents.domain import AgentConfigSpec
+    from pocketpaw_ee.cloud.agents.dto import CreateAgentRequest
+    from pocketpaw_ee.cloud.models.agent import AgentConfig
+
+    assert default == "pydantic_ai"
+    assert AgentConfig().backend == default
+    assert AgentConfigSpec().backend == default
+    assert CreateAgentRequest(name="A", slug="a").backend == default
+
+
+def test_an_explicit_backend_still_wins():
+    """A default is not a policy. An operator who picked a backend keeps it."""
+    _cloud_default()
+    from pocketpaw_ee.cloud.models.agent import AgentConfig
+
+    assert AgentConfig(backend="claude_agent_sdk").backend == "claude_agent_sdk"
+
+
+def test_the_self_hosted_default_is_untouched():
+    """The scope line, and the reason this change is cloud-only.
+
+    ``pydantic_ai`` has no shell and no filesystem by design, because one
+    process serves every tenant and the builtin jail is process-global. That
+    trade is right in cloud and wrong on a laptop, so flipping this one too
+    would quietly take local execution away from every self-hosted user.
+    """
+    from pocketpaw.config import Settings
+
+    assert Settings.model_fields["agent_backend"].default == "claude_agent_sdk"
+
+
+def test_the_pool_fallback_does_not_follow_the_cloud_default():
+    """A document with no ``backend`` key predates the field, which means it
+    predates this change - so the right answer for it is the OLD default, not
+    today's. Following the cloud default here would silently re-home the oldest
+    agents in the estate."""
+    import inspect
+
+    from pocketpaw.agents.pool import AgentPool
+
+    src = inspect.getsource(AgentPool._build)
+    assert 'config.get("backend", "claude_agent_sdk")' in src
+
+
+def test_the_default_names_a_registered_backend():
+    """A default that does not resolve is a boot failure for every new agent."""
+    from pocketpaw.agents.registry import get_backend_class, list_backends
+
+    default = _cloud_default()
+    assert default in list_backends()
+    assert get_backend_class(default) is not None


### PR DESCRIPTION
Stacked on #1833. A new cloud agent that does not name a backend now gets
`pydantic_ai` instead of `claude_agent_sdk`.

The cloud's binding constraint is concurrency, and `claude_agent_sdk` spawns a
Claude Code CLI subprocess per concurrent run at roughly 300-500 MB RSS, which
is most of a box before anything else. The in-process backend pays roughly the
conversation context per run instead.

## One value, not five

The default was four independent literals across the Beanie document, the domain
value object, the create-request DTO and the planner's agent creation. Different
in kind, too: three schema defaults, one call-site argument. Nothing tied them
together, so changing the default meant finding all of them.

They now read `CLOUD_DEFAULT_AGENT_BACKEND`. Two existing tests asserted the old
value as a string literal and have been pointed at the constant, so the next
change does not have to chase copies of itself again.

## Three things deliberately unchanged

**Self-hosted keeps `claude_agent_sdk`.** `pydantic_ai` is dispatch-only by
design, with no shell and no filesystem, because one process serves every tenant
and the builtin jail is process-global. That trade is right in a multi-tenant
cloud and wrong on a laptop, where "a self-hosted AI agent that runs locally" is
the product. Two different correct answers, not one nobody unified. Pinned by a
test.

**Existing agents keep what they have.** Every document stores its backend
explicitly, so a default change is invisible to them, and nothing here rewrites
the field.

**The pool's fallback stays `claude_agent_sdk`.** This reads like an oversight
and is not. `AgentConfig` carries a default, so `model_dump()` always includes
the key and the fallback only fires for a document written before the field
existed, which is a document from when `claude_agent_sdk` was the default.
Answering with today's default would silently re-home the oldest agents in the
estate.

## Before migrating existing agents

The migration is written down in `docs/handoff/2026-08-01-cloud-backend-default.md`
rather than run, because two things should be true first.

PA-1 has not been run. The concurrency measurement that justifies this backend
over `deep_agents` is still unrun, with no results under `scripts/loadtest/`.
The premise is sound but it is a premise, and new agents are a small reversible
population to test it on where the whole estate is not.

Composio tools do not reach this backend. `composio_tools_for()` is called by
three other backends and not by the pydantic-ai builder, so a Composio-configured
workspace migrating an existing agent would lose those integrations.

## Testing

The guard lives in `tests/` rather than `tests/cloud/`, because the pyproject
addopts carry `--ignore=tests/cloud` and a guard placed there would run in CI for
nobody. The EE assertions skip individually when `pocketpaw_ee` is absent, so the
OSS-only job still runs the two that matter most to it.

One pre-existing failure in `tests/cloud/agents/test_agent_visibility_enforcement.py`
is unrelated: a knowledge-list response gained a field from the concierge work.
It has been failing unnoticed for the same addopts reason.
