### PR TITLE
Run counting on billing's walk, and the reconcile alarm

### DIFF
--- a/ee/pocketpaw_ee/cloud/agents/router.py
+++ b/ee/pocketpaw_ee/cloud/agents/router.py
@@ -57,6 +57,8 @@ id. ``GET /agents/{id}/scope`` was already owner-gated and is unchanged.
 
 from __future__ import annotations
 
+from typing import Any
+
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, UploadFile
 from fastapi import File as FastAPIFile
 from starlette.responses import Response
@@ -559,4 +561,127 @@ async def get_agent_ledger(
             "total_cents": value_by_currency.get(single_currency, 0) if single_currency else 0,
         },
         "recent": [row.model_dump() for row in recent],
+    }
+
+
+# How many approved actions the reconcile scan reads before it stops. A cap is
+# required — the comparison is a full scan by nature — and the response NAMES it
+# rather than silently truncating, because a capped count that looks like a total
+# would report false drift and train an owner to ignore the alarm.
+_RECONCILE_SCAN_CAP = 2000
+
+
+def _action_stamp(action: Any) -> str:
+    """When an action's APPROVAL happened, as an ISO-UTC string.
+
+    ``approved_at`` rather than ``created_at``: the ledger row is written at the
+    moment of the click, so comparing against creation time would count an action
+    proposed last month and approved today as outside a 7-day window while its
+    ledger row sits inside it — reporting drift that does not exist. Falls back to
+    creation only when the field is missing (a legacy row), and to the epoch when
+    neither parses, which puts an undatable action inside every window rather than
+    silently outside them all.
+    """
+    from datetime import UTC, datetime
+
+    stamp = getattr(action, "approved_at", None) or getattr(action, "created_at", None)
+    if not isinstance(stamp, datetime):
+        return datetime.min.replace(tzinfo=UTC).isoformat()
+    if stamp.tzinfo is None:
+        stamp = stamp.replace(tzinfo=UTC)
+    return stamp.astimezone(UTC).isoformat()
+
+
+@router.get("/analytics/reconcile")
+async def reconcile_agent_ledger(
+    window: str = Query(default="30d"),
+    workspace_id: str = Depends(current_workspace_id),
+) -> dict:
+    """Does the ledger agree with the systems it claims to mirror? (AL-4)
+
+    Every emitter in this design is FAIL-SOFT: a ledger failure is swallowed so
+    it can never cost an operator their approve click, a visitor their answer, or
+    a workspace its billing. The price of that promise is silence — a broken
+    emitter looks exactly like a quiet week. This endpoint is how the promise is
+    paid back, and it is the reason fail-soft was an acceptable trade at all.
+
+    It compares the ledger against the system that holds the same facts
+    independently:
+
+    * ``approved`` — Instinct's own approved actions vs ``paw.action.approved``
+      rows. Instinct is authoritative: it is where a human actually clicked.
+    * ``delivered`` — the approvals carrying a customer reply (the paw-bar
+      decisions that reach a visitor) vs ``paw.action.delivered`` rows.
+
+    ``delta = source - ledger``. POSITIVE means the ledger is BEHIND: an emitter
+    is failing silently, and ``behind`` names which check. NEGATIVE means the
+    ledger holds rows the source cannot account for — a duplicate or a mis-keyed
+    write, which is a different and worse bug — so it is reported rather than
+    clamped to zero.
+
+    Workspace-scoped with no ``agent_id`` filter on purpose: an emitter that
+    breaks breaks for every agent at once, and a per-agent question would require
+    the owner to already suspect which one.
+    """
+    from pocketpaw.agent_ledger.models import (
+        KIND_ACTION_APPROVED,
+        KIND_ACTION_DELIVERED,
+        WindowParseError,
+        window_start,
+    )
+    from pocketpaw.instinct.models import ActionStatus
+    from pocketpaw.stores import get_agent_ledger_store, get_instinct_store
+    from pocketpaw_ee.paw_bar.decision_loop import CUSTOMER_REPLY_KEY
+
+    try:
+        since = window_start(window)
+    except WindowParseError as exc:
+        # Same refusal as the ledger read above: a 422, never a silent fallback to
+        # the default window. This must also catch an OVER-LARGE window —
+        # ``timedelta`` raises OverflowError rather than ValueError past its own
+        # cap, which escaped this handler as a 500 until ``parse_window`` started
+        # bounding the amount before constructing one.
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    ws = workspace_id or ""
+    ledger = get_agent_ledger_store(workspace_id=workspace_id or None)
+    instinct = get_instinct_store(workspace_id=workspace_id or None)
+
+    counts = await ledger.counts_by_kind(workspace_id=ws, since=since)
+
+    # The source side. ``list_actions`` is the read the dashboard's own feeds use,
+    # so this compares against what an operator would actually see rather than
+    # against a private query shape only this endpoint knows.
+    approved = await instinct.list_actions(
+        status=ActionStatus.APPROVED,
+        workspace_id=workspace_id or None,
+        limit=_RECONCILE_SCAN_CAP,
+    )
+    in_window = [a for a in approved if since is None or _action_stamp(a) >= since]
+    # A delivered row exists only where the approval carried a customer reply.
+    # Comparing EVERY approval against deliveries would report a permanent,
+    # meaningless deficit for every non-paw-bar agent in the workspace — an alarm
+    # that is always ringing is an alarm nobody hears.
+    delivered_source = sum(1 for a in in_window if CUSTOMER_REPLY_KEY in (a.parameters or {}))
+
+    checks: dict[str, dict[str, Any]] = {
+        "approved": {"source": len(in_window), "ledger": counts.get(KIND_ACTION_APPROVED, 0)},
+        "delivered": {"source": delivered_source, "ledger": counts.get(KIND_ACTION_DELIVERED, 0)},
+    }
+    for name, pair in checks.items():
+        pair["delta"] = pair["source"] - pair["ledger"]
+        pair["behind"] = name if pair["delta"] > 0 else ""
+
+    drifting = [name for name, pair in checks.items() if pair["delta"] != 0]
+
+    return {
+        "window": window,
+        "since": since,
+        "workspace_id": ws,
+        "checks": checks,
+        # The one field a caller can act on without reading the rest.
+        "healthy": not drifting,
+        "drifting": drifting,
+        "scanned_cap": _RECONCILE_SCAN_CAP,
+        "capped": len(approved) >= _RECONCILE_SCAN_CAP,
     }

--- a/ee/pocketpaw_ee/cloud/metering/sweeper.py
+++ b/ee/pocketpaw_ee/cloud/metering/sweeper.py
@@ -35,10 +35,24 @@
 # Created 2026-06-24 (integration/billing-credits, BC-3): new entity.
 # Updated 2026-06-26 (feat/litellm-billing-cutover, WU-F): gated OFF in ``live`` mode
 # — the single-meter guarantee. See "THE BC-3 OFF-SWITCH" above.
+# Updated 2026-08-01 (AL-3, agent ledger run counting): this sweep now also emits
+#   one ``paw.run.completed`` agent-ledger row per run it bills, via
+#   ``_emit_run_completed``. WHY HERE and nowhere else: the value board's run
+#   count and the wallet's spend must be derived from the SAME walk over the same
+#   docs. A second pass — a separate sweeper, a hook on run completion, a nightly
+#   job — is a second meter, and two meters over one quantity eventually disagree
+#   (the usage-chart-vs-wallet bug we have already paid for once). Riding this
+#   loop makes disagreement structurally impossible: a run is counted if and only
+#   if it was billed. COUNT ONLY — the ledger row carries agent, surface and the
+#   run id, and never tokens/cost/latency; those stay on the run doc and are read
+#   federated by joining on the run id. The emit is fail-soft and post-bill, so a
+#   broken ledger can never cost a workspace its billing (the drift that silence
+#   buys is what AL-4's reconcile endpoint exists to surface).
 
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from pocketpaw_ee.cloud.metering import service as metering_service
 from pocketpaw_ee.cloud.metering.domain import RateCard
@@ -54,6 +68,107 @@ _TERMINAL_STATES = ["completed", "interrupted", "failed", "cancelled"]
 # Cap per tick so a long-outage backlog can't wedge the heartbeat (mirrors the
 # stale-run sweeper's batch limit). The next tick drains the next batch.
 _SWEEP_BATCH_LIMIT = 200
+
+# The one ChatRunDoc context type that is NOT a member chatting in the app. A
+# concierge run is a Paw Bar run, so it shares the surface bucket with AL-2's
+# funnel rows and an owner reading "paw_bar" sees the conversation beats and the
+# runs that produced them together. Every other context type (dm / group /
+# pocket / session) maps to SURFACE_CHAT. The mapping lives HERE rather than in
+# the OSS vocabulary module because ``context_type`` is ChatRunDoc's own EE-side
+# vocabulary; the OSS ``surface_from_trigger`` maps Instinct's.
+_CONCIERGE_CONTEXT_TYPE = "concierge"
+
+
+async def _emit_run_completed(doc: Any) -> bool:
+    """Count one billed terminal run in the agent ledger. NEVER raises.
+
+    Emitter #5 of the agent-ledger design, and the only one that does not sit on
+    a human's hot path — but the fail-soft contract is if anything stricter here:
+    this runs inside the billing sweep, and BOOKKEEPING MUST NEVER COST A
+    WORKSPACE ITS BILLING. Every failure mode is swallowed and logged at debug: a
+    workspace the store factory refuses (``WorkspaceScopeRequired`` is real in
+    cloud mode for a run with an empty workspace), a locked database, a duck-typed
+    doc from a test. Same posture as ``instinct/store.py::_emit_ledger`` and
+    ``paw_bar/ledger.py``.
+
+    Four choices, each of which fails silently if it is wrong:
+
+    * ``ref`` IS THE RUN ID. ``UNIQUE(kind, ref)`` therefore makes a re-sweep of
+      the same run a no-op at the database, not at the caller — so the flag-loss
+      path (``billed`` reset by a crash between debit and save, which the metering
+      tests exercise deliberately) re-bills nothing and re-counts nothing.
+
+    * WORKSPACE ROUTING USES ``doc.workspace`` — the SAME value this sweep already
+      routes its own work by (``bill_run`` debits ``run_doc.workspace``). It is
+      not re-derived from anything else in the row. Feeding the factory a value
+      that is not a real workspace token makes ``_safe_workspace_dir`` raise
+      INSIDE the guard above, and the row then vanishes with no trace at all —
+      the exact silent under-count that was a review blocker on AL-1. The in-row
+      ``workspace_id`` column takes the same value, so the ledger's tenancy filter
+      and the wallet's debit agree by construction.
+
+    * ``ts`` IS THE RUN'S OWN MOMENT (``ended_at``, else ``createdAt``), never the
+      sweep's. The sweep drains a backlog FIFO and may run long after an outage;
+      stamping sweep-time would pile a week of runs into one window and make every
+      windowed count — including AL-4's reconcile — wrong in a way that looks like
+      a traffic spike.
+
+    * COUNT ONLY. No tokens, no cost, no latency, no status. All of it is already
+      on the run doc, and the ref IS the run id, so a consumer that wants any of
+      it joins on the key rather than reading a second copy that can drift from
+      the first. That second copy is the two-meters bug in miniature and the row
+      model has no field for it on purpose.
+
+    Returns True when a NEW row landed; False on a replay OR on a swallowed
+    failure. The sweep ignores the answer — it is here for tests and for a future
+    caller that wants to distinguish the two.
+    """
+    try:
+        from pocketpaw.agent_ledger.models import (
+            ATTR_AGENT_ID,
+            KIND_RUN_COMPLETED,
+            SURFACE_CHAT,
+            SURFACE_PAW_BAR,
+            LedgerActor,
+            LedgerRow,
+        )
+        from pocketpaw.stores import get_agent_ledger_store
+
+        workspace = str(getattr(doc, "workspace", "") or "")
+        agent_id = str(getattr(doc, "agent_id", "") or "")
+        context_type = str(getattr(doc, "context_type", "") or "")
+        # ``LedgerRow.ts`` is a string; the store's ``_normalize_ts`` coerces
+        # whatever we hand it to aware-UTC ISO (a naive stamp — which is what
+        # Mongo hands back — is read as UTC, which is what Mongo stores). Only
+        # fall through to the model's "now" default when the doc carries no
+        # moment at all.
+        moment = getattr(doc, "ended_at", None) or getattr(doc, "createdAt", None)
+        fields: dict[str, Any] = {"ts": moment.isoformat()} if moment is not None else {}
+
+        row = LedgerRow(
+            agent_id=agent_id,
+            workspace_id=workspace,
+            surface=(SURFACE_PAW_BAR if context_type == _CONCIERGE_CONTEXT_TYPE else SURFACE_CHAT),
+            kind=KIND_RUN_COMPLETED,
+            ref=str(getattr(doc, "run_id", "") or ""),
+            # The sweep counted it, not a person — a run the agent did on its own
+            # authority is still machinery from the board's point of view.
+            actor=LedgerActor.SYSTEM.value,
+            # The column is the key; the attribute is the copy, mirroring both
+            # other emitters. An unattributed run omits it rather than carrying an
+            # empty string that reads like a real id.
+            attrs={ATTR_AGENT_ID: agent_id} if agent_id else {},
+            **fields,
+        )
+        store = get_agent_ledger_store(workspace_id=workspace or None)
+        return bool(await store.append(row))
+    except Exception:  # noqa: BLE001 — bookkeeping never breaks a billing sweep
+        logger.debug(
+            "agent-ledger run count skipped for run %s",
+            getattr(doc, "run_id", "<unknown>"),
+            exc_info=True,
+        )
+        return False
 
 
 async def sweep_unbilled_runs(
@@ -114,7 +229,6 @@ async def sweep_unbilled_runs(
     for doc in unbilled:
         try:
             await metering_service.bill_run(doc, rate_card=card)
-            billed += 1
         except Exception:
             # Leave ``billed`` False so the next tick retries this run; the
             # run:{run_id} key keeps any partial debit from double-applying.
@@ -123,6 +237,18 @@ async def sweep_unbilled_runs(
                 doc.run_id,
                 doc.workspace,
             )
+        else:
+            billed += 1
+            # AL-3 — count the run in the agent ledger, on the ELSE branch so it
+            # runs only for a run that was actually billed and so its own
+            # failures cannot land in the handler above. Inside that ``except``
+            # a bookkeeping error would be logged as "failed to bill … will
+            # retry" — a false statement about a run that WAS billed — and would
+            # skip the ``billed`` increment, making the sweep under-report
+            # itself. The emitter is fail-soft in its own right (see
+            # ``_emit_run_completed``), so this line cannot raise; the ``else``
+            # is the structural belt to that braces.
+            await _emit_run_completed(doc)
 
     if billed:
         logger.info("sweep_unbilled_runs: billed %d terminal runs", billed)

--- a/tests/cloud/metering/test_sweeper_ledger.py
+++ b/tests/cloud/metering/test_sweeper_ledger.py
@@ -1,0 +1,172 @@
+# tests/cloud/metering/test_sweeper_ledger.py — run counting rides billing's walk (AL-3).
+#
+# Created: 2026-08-01. Emitter #5 of the agent ledger, and the only one that sits
+# inside the BILLING sweep rather than on a human's hot path. That placement is
+# the whole design: the value board's run count and the wallet's spend come from
+# the SAME pass over the SAME docs, so a run is counted if and only if it was
+# billed. A second walk — a separate job, a completion hook — would be a second
+# meter, and two meters over one quantity eventually disagree. We have paid for
+# that once already (the usage chart read the proxy while the wallet held the
+# spend, and they disagreed in public).
+#
+# What these tests hold, in the order the slice fails if any one is wrong:
+#
+#   * ONE ROW PER BILLED RUN. Not per terminal run — per BILLED run. The emit is
+#     on the else branch, so a run the sweep failed to bill is not counted.
+#   * IDEMPOTENT RE-SWEEP. ``ref`` is the run id, so UNIQUE(kind, ref) absorbs a
+#     re-sweep at the database. This matters beyond tidiness: the metering tests
+#     deliberately exercise a flag-loss path (``billed`` reset by a crash between
+#     debit and save), and a ledger that double-counted there would inflate the
+#     board every time billing recovered.
+#   * NEVER COSTS THE BILLING. A raising ledger must not stop, skip, or unwind a
+#     debit. Bookkeeping charging a workspace its billing is the one outcome this
+#     design refuses outright.
+#   * COUNT ONLY. No tokens, no cost, no latency on the row — those stay on the
+#     run doc and are read federated by joining on the run id.
+#
+# The fail-soft test patches the seam the emitter ACTUALLY calls and asserts the
+# NEGATIVE half (no row landed). AL-1 shipped a fail-soft test that patched a
+# function the emitter no longer used; it passed while testing nothing. A
+# fail-soft test that only asserts the happy half cannot tell "guarded" from
+# "never attempted".
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud.credits import service as credits  # noqa: E402
+from pocketpaw_ee.cloud.metering.domain import RateCard  # noqa: E402
+from pocketpaw_ee.cloud.metering.sweeper import sweep_unbilled_runs  # noqa: E402
+from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc  # noqa: E402
+
+from pocketpaw.agent_ledger.models import KIND_RUN_COMPLETED  # noqa: E402
+from pocketpaw.agent_ledger.store import AgentLedgerStore  # noqa: E402
+
+pytestmark = pytest.mark.asyncio
+
+WS = "ws_sweeper_ledger"
+RATE = RateCard(markup=2.5, credit_usd=0.01)
+
+
+async def _run(*, run_id: str, agent_id: str = "a1", context_type: str = "dm") -> ChatRunDoc:
+    """One terminal, unbilled run with real usage the sweep will charge for."""
+    doc = ChatRunDoc(
+        run_id=run_id,
+        workspace=WS,
+        context_type=context_type,
+        scope_id="scope-1",
+        session_key="sk-1",
+        user_id="u1",
+        agent_id=agent_id,
+        client_message_id=f"cmid-{run_id}",
+        user_message_id=f"umid-{run_id}",
+        status="completed",  # type: ignore[arg-type]
+        usage={"total_cost_usd": 0.04, "model": "gpt-4o"},
+        billed=False,
+    )
+    await doc.insert()
+    return doc
+
+
+@pytest.fixture
+def ledger(tmp_path, monkeypatch) -> AgentLedgerStore:
+    """A tmp ledger on the factory the sweeper's emitter lazy-imports.
+
+    Records nothing else: the assertions read the store directly, because the
+    failure this guards against (no row, silently) has no other symptom.
+    """
+    store = AgentLedgerStore(tmp_path / "agent_ledger.db")
+    monkeypatch.setattr("pocketpaw.stores.get_agent_ledger_store", lambda **_kw: store)
+    return store
+
+
+async def _seed_credits() -> None:
+    await credits.grant(WS, 10_000, cause="top_up", idempotency_key=f"seed-{WS}")
+
+
+class TestOneRowPerBilledRun:
+    async def test_n_billed_runs_produce_exactly_n_rows(self, mongo_db, ledger) -> None:  # noqa: ARG002
+        await _seed_credits()
+        for i in range(3):
+            await _run(run_id=f"run-{i}")
+
+        billed = await sweep_unbilled_runs(rate_card=RATE, mode="shadow")
+
+        rows = await ledger.query(kinds=[KIND_RUN_COMPLETED])
+        assert billed == 3
+        assert len(rows) == 3
+        assert {r.ref for r in rows} == {"run-0", "run-1", "run-2"}
+        assert all(r.agent_id == "a1" for r in rows)
+
+    async def test_a_re_sweep_counts_nothing_twice(self, mongo_db, ledger) -> None:  # noqa: ARG002
+        """UNIQUE(kind, ref) absorbs the replay at the DATABASE, not the caller.
+
+        The metering suite deliberately exercises a flag-loss path — ``billed``
+        reset by a crash between the debit and the save — so a re-sweep of an
+        already-counted run is a real scenario, not a hypothetical.
+        """
+        await _seed_credits()
+        await _run(run_id="run-replay")
+
+        await sweep_unbilled_runs(rate_card=RATE, mode="shadow")
+        # Force the flag-loss path: the run looks unbilled again.
+        doc = await ChatRunDoc.find_one(ChatRunDoc.run_id == "run-replay")
+        assert doc is not None
+        doc.billed = False
+        await doc.save()
+        await sweep_unbilled_runs(rate_card=RATE, mode="shadow")
+
+        rows = await ledger.query(kinds=[KIND_RUN_COMPLETED])
+        assert len(rows) == 1, "a re-swept run was counted twice"
+
+    async def test_the_row_carries_no_ops_metric(self, mongo_db, ledger) -> None:  # noqa: ARG002
+        """Tokens, cost and latency stay on the run doc. Two meters, one number."""
+        await _seed_credits()
+        await _run(run_id="run-ops")
+
+        await sweep_unbilled_runs(rate_card=RATE, mode="shadow")
+
+        row = (await ledger.query(kinds=[KIND_RUN_COMPLETED]))[0]
+        assert row.value_cents is None
+        assert not any(
+            k in row.attrs for k in ("tokens", "cost", "latency", "gen_ai.usage", "total_cost_usd")
+        )
+
+
+class TestTheSweepNeverPaysForBookkeeping:
+    async def test_a_raising_ledger_does_not_break_the_billing(
+        self,
+        mongo_db,  # noqa: ARG002
+        tmp_path,
+        monkeypatch,
+    ) -> None:
+        """The load-bearing guarantee: a broken ledger must not cost a debit.
+
+        Patches the seam the emitter ACTUALLY calls, and asserts the negative
+        half — no row landed — so this cannot rot into a test that passes because
+        the exploding store was never reached.
+        """
+        await _seed_credits()
+        await _run(run_id="run-boom")
+        before = await credits.balance(WS)
+
+        class _ExplodingStore:
+            async def append(self, row):  # noqa: ARG002
+                raise RuntimeError("ledger disk is on fire")
+
+        monkeypatch.setattr(
+            "pocketpaw.stores.get_agent_ledger_store", lambda **_kw: _ExplodingStore()
+        )
+
+        billed = await sweep_unbilled_runs(rate_card=RATE, mode="shadow")
+
+        assert billed == 1, "the sweep skipped a run because bookkeeping failed"
+        assert await credits.balance(WS) < before, "the run was not actually charged"
+        reloaded = await ChatRunDoc.find_one(ChatRunDoc.run_id == "run-boom")
+        assert reloaded is not None
+        assert reloaded.billed is True, "the billed flag was not set"
+        # The negative half: the exploding store really was reached.
+        quiet = AgentLedgerStore(tmp_path / "agent_ledger.db")
+        assert await quiet.query(kinds=[KIND_RUN_COMPLETED]) == []

--- a/tests/cloud/test_agent_ledger_endpoint.py
+++ b/tests/cloud/test_agent_ledger_endpoint.py
@@ -222,3 +222,127 @@ async def test_the_visibility_gate_runs_before_any_read(client, monkeypatch):
     res = await c.get(f"/agents/{_AGENT}/ledger")
     assert res.status_code in (403, 404, 500)
     assert "secret" not in res.text
+
+
+# --------------------------------------------------------------------------- #
+# AL-4 — the reconcile drift alarm
+#
+# Every emitter in this design is fail-soft, so a broken one is SILENT: it looks
+# exactly like a quiet week. This endpoint is what makes fail-soft an acceptable
+# trade rather than a slow leak, which means the tests that matter here are the
+# ones proving the alarm actually FIRES — a reconcile that always says "healthy"
+# is worse than none, because it is trusted.
+# --------------------------------------------------------------------------- #
+
+
+async def _approve_one(*, ref: str, customer_reply: bool = False) -> str:
+    """Approve one real Instinct action in _WS. Returns its id.
+
+    Goes through the real store rather than a fake so the comparison is against
+    the same rows the dashboard's own feeds read — a reconcile validated against
+    a stub proves the stub agrees with itself.
+    """
+    from pocketpaw.instinct.models import ActionCategory, ActionTrigger
+
+    instinct = stores.get_instinct_store(workspace_id=_WS)
+    params = {"_customer_reply": {"widget_id": "w1"}} if customer_reply else {}
+    action = await instinct.propose(
+        pocket_id="pocket-1",
+        title=f"ask {ref}",
+        description="",
+        recommendation="ok",
+        trigger=ActionTrigger(type="connector", source="paw_bar:w1", reason="test"),
+        category=ActionCategory.EXTERNAL,
+        parameters=params,
+        workspace_id=_WS,
+    )
+    await instinct.approve(action.id, approver="user:maya")
+    return action.id
+
+
+@pytest.mark.asyncio
+async def test_reconcile_is_healthy_when_every_emitter_kept_up(client):
+    """The baseline: sources and ledger agree, so nothing is drifting."""
+    c, ledger = client
+    act = await _approve_one(ref="r1")
+    # AL-1's emitter already wrote the approved row through the real path; the
+    # delivered row is AL-2's, emitted on a different path, so write it here.
+    await ledger.append(_row(ref=act, kind=KIND_ACTION_APPROVED))
+
+    res = await c.get("/agents/analytics/reconcile?window=30d")
+
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["checks"]["approved"]["source"] == 1
+    assert body["checks"]["approved"]["ledger"] == 1
+    assert body["checks"]["approved"]["delta"] == 0
+    assert body["healthy"] is True
+    assert body["drifting"] == []
+
+
+@pytest.mark.asyncio
+async def test_a_silently_failing_emitter_shows_up_as_drift_and_is_NAMED(client):
+    """The alarm's whole reason to exist.
+
+    An approval happened and no ledger row followed — exactly what a broken
+    fail-soft emitter looks like from the outside. The response must not merely
+    say "unhealthy": it must name WHICH source is behind, or the owner is left
+    diffing two systems by hand.
+    """
+    c, ledger = client
+
+    # Simulate the failure FAITHFULLY: break the emitter's store seam so the
+    # approvals happen and no rows follow. Deleting rows after the fact would
+    # test the same arithmetic while proving nothing about the real path — this
+    # is the actual shape of a silently-failing fail-soft emitter.
+    class _ExplodingStore:
+        async def append(self, row):  # noqa: ARG002
+            raise RuntimeError("ledger disk is on fire")
+
+    original = stores.get_agent_ledger_store_beside
+    stores.get_agent_ledger_store_beside = lambda _p: _ExplodingStore()  # type: ignore[assignment]
+    try:
+        await _approve_one(ref="r1")
+        await _approve_one(ref="r2")
+    finally:
+        stores.get_agent_ledger_store_beside = original  # type: ignore[assignment]
+
+    assert await ledger.query(kinds=[KIND_ACTION_APPROVED]) == [], (
+        "the emitter still wrote — this test is not simulating the failure"
+    )
+
+    res = await c.get("/agents/analytics/reconcile?window=30d")
+
+    body = res.json()
+    assert body["checks"]["approved"]["source"] == 2
+    assert body["checks"]["approved"]["delta"] > 0, "drift was not detected"
+    assert body["checks"]["approved"]["behind"] == "approved", "the alarm did not name the source"
+    assert body["healthy"] is False
+    assert "approved" in body["drifting"]
+
+
+@pytest.mark.asyncio
+async def test_delivered_only_counts_approvals_that_carry_a_customer_reply(client):
+    """An always-ringing alarm is an alarm nobody hears.
+
+    Only paw-bar decisions produce a delivered row. Comparing EVERY approval
+    against deliveries would report a permanent deficit for every ordinary agent
+    in the workspace and train the owner to ignore the endpoint.
+    """
+    c, _ledger = client
+    await _approve_one(ref="plain")  # an ordinary approval — no delivery expected
+    await _approve_one(ref="bar", customer_reply=True)
+
+    body = (await c.get("/agents/analytics/reconcile?window=30d")).json()
+
+    assert body["checks"]["approved"]["source"] == 2
+    assert body["checks"]["delivered"]["source"] == 1, "a non-paw-bar approval was counted"
+
+
+@pytest.mark.asyncio
+async def test_a_hostile_window_is_a_refusal_not_a_server_error(client):
+    """422, never 500 — including the over-large case that once escaped as one."""
+    c, _ledger = client
+    for window in ("nonsense", "0d", "99999999999d"):
+        res = await c.get(f"/agents/analytics/reconcile?window={window}")
+        assert res.status_code == 422, f"{window} → {res.status_code}"


### PR DESCRIPTION
AL-3 + AL-4 of the agent-ledger line. **Stacked on pocketpaw#1832** (AL-2) → which stacks on #1831 (AL-1). Merge bases with `--rebase`, not `--squash`.

## AL-3 — run counting rides billing's own walk

A terminal run now leaves a `paw.run.completed` row, emitted from inside `sweep_unbilled_runs` as it bills.

The placement *is* the design. The board's run count and the wallet's spend must come from the same pass over the same docs, so a run is counted if and only if it was billed. A separate job or a completion hook would be a second meter over one quantity — and we have already paid for that once, when the usage chart read the proxy while the wallet held the spend and they disagreed in public.

It sits on the `else` branch, so a run the sweep failed to bill is not counted, and a bookkeeping error can never be logged as "failed to bill, will retry" — a false statement about a run that *was* billed, which would also skip the `billed` increment and make the sweep under-report itself.

`ref` is the run id, so `UNIQUE(kind, ref)` absorbs a re-sweep at the database. Not tidiness: the metering suite deliberately exercises a flag-loss path where `billed` is reset by a crash between the debit and the save, and a ledger that double-counted there would inflate the board every time billing recovered.

**Count only.** No tokens, cost or latency on the row.

## AL-4 — the reconcile alarm

`GET /agents/analytics/reconcile?window=30d`.

Every emitter here swallows its failures so nobody loses a click or a debit to bookkeeping. The price is silence — a broken emitter looks exactly like a quiet week. This is what makes that trade acceptable rather than a slow leak.

It compares the ledger against the system holding the same facts independently: Instinct's approved actions vs `paw.action.approved`, and the approvals carrying a customer reply vs `paw.action.delivered`.

`delta = source - ledger`. Positive means the ledger is **behind** and `behind` names which check — an owner told only "unhealthy" is left diffing two systems by hand. Negative is reported rather than clamped: it means the ledger holds rows the source can't account for, which is a duplicate or mis-keyed write, a different and worse bug.

Two decisions that keep the alarm worth listening to:

- **Delivered compares only against approvals carrying a customer reply.** Every approval would report a permanent deficit for every ordinary agent in the workspace, and an alarm that is always ringing is an alarm nobody hears.
- **The scan is capped and the response names the cap.** A capped count presented as a total would report false drift — the same failure in the other direction.

## Verification

Both fail-soft guarantees checked by mutation, not by assertion alone:

- AL-3's guard: make it re-raise → the test goes red.
- AL-4's alarm: silence the delta → the test goes red. A reconcile that always says "healthy" is worse than none, because it is trusted.

The drift test breaks the emitter's **store seam** so the approvals happen and no rows follow, rather than deleting rows afterwards — which would exercise the arithmetic while proving nothing about the real path. That distinction matters here: AL-1 shipped a fail-soft test that patched a function the emitter no longer called, and it passed while testing nothing.

- `tests/cloud/metering/test_sweeper_ledger.py` — **4 passed**
- `tests/cloud/test_agent_ledger_endpoint.py` — **15 passed**
- ledger + metering + paw_bar — **89 passed**
- ruff clean · `lint-imports` 1 kept · `--config ee/pyproject.toml` 34 kept, 0 broken