### PR TITLE
Social sign-in for Google and GitHub, connected accounts, and a route guard audit

### DIFF
--- a/.env.enterprise.example
+++ b/.env.enterprise.example
@@ -49,6 +49,48 @@ POCKETPAW_LICENSE_KEY=
 # ADMIN_NAME=Admin
 # ADMIN_PASSWORD=            # leave unset to auto-generate (printed to logs once)
 
+# ── OPTIONAL: social sign-in (Google / GitHub) ────────────────────
+# Leave unset to hide the provider's button entirely — a button that opens a
+# broken consent screen is worse than no button. Email + password is unaffected.
+#
+# GitHub needs an OAuth App — NOT a GitHub App. Different products, different
+# consent screens, different token models; picking the wrong one costs an hour
+# before anything works. Create it under Settings > Developer settings >
+# "OAuth Apps".
+#
+# These are NOT the same credentials as:
+#   * the Drive connector's GOOGLE_OAUTH_CLIENT_ID/SECRET (per-install data
+#     integration, OSS core), or
+#   * POCKETPAW_GITHUB_APP_* (codeconnect repo access via installation tokens).
+# Sign-in uses its own GitHub OAuth App so the account-creation consent screen
+# asks for identity only, never repository permissions.
+#
+# Redirect / callback URL for both: <backend-origin>/api/v1/auth/social/callback
+# GitHub scopes are requested at runtime: read:user + user:email. user:email is
+# required — the verified flag comes from GET /user/emails, and the /user
+# payload's own email field is not proof of verification.
+# POCKETPAW_GOOGLE_OAUTH_CLIENT_ID=
+# POCKETPAW_GOOGLE_OAUTH_CLIENT_SECRET=
+# POCKETPAW_GITHUB_OAUTH_CLIENT_ID=
+# POCKETPAW_GITHUB_OAUTH_CLIENT_SECRET=
+
+# The three URLs the social flow builds its redirects from. Defaults suit local
+# dev; a split-origin or proxied deploy must set them, and getting one wrong
+# fails in a way that looks like a broken login rather than a config error.
+#   PUBLIC_BASE_URL     — backend origin. The callback URL is derived from it,
+#                         so it must match what you registered with the provider.
+#   SOCIAL_REDIRECT_URI — overrides that derived callback outright. Use it when
+#                         the backend sits behind a proxy whose public origin it
+#                         cannot infer.
+#   FRONTEND_BASE_URL   — where the SPA lives. Every redirect out of the social
+#                         routes is ABSOLUTE against this, because a relative one
+#                         resolves against the API origin — the same host only
+#                         when both are served from one domain. Locally they are
+#                         not, and a signed-in user lands on the API root.
+# POCKETPAW_PUBLIC_BASE_URL=http://localhost:8888
+# POCKETPAW_SOCIAL_REDIRECT_URI=
+# POCKETPAW_FRONTEND_BASE_URL=http://localhost:1420
+
 # ── OPTIONAL: TLS / reverse-proxy posture ─────────────────────────────────
 # Set true when serving over HTTPS behind a reverse proxy (also counts as a
 # production signal). Leave unset for plain-HTTP local testing.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -72,6 +72,27 @@ workspace's source→Fabric mappings, now with a "connector" source_kind that
 dispatches through the OSS FABRIC_INGESTORS registry — gcalendar first) and
 POST /fabric/ingest/run (run one mapping immediately; misconfiguration reports
 status="error" in the body, never a 5xx).
+
+Updated: 2026-08-01 (AM-6 desktop) — documented POST /auth/social/link/complete
+and the desktop link handoff. Worth knowing before touching it: a Tauri webview
+carries no cookie for our origin, so the callback cannot authenticate the
+acting user and does NOT attach on flow=desktop. It parks the identity behind
+a one-time code and the app redeems it under its bearer, where the account can
+actually be proved. Also records the /oauth-callback contract that separates a
+desktop LINK (link=) from a desktop SIGN-IN (xc=).
+
+Updated: 2026-08-01 (AM-2..AM-6, feat/auth-social-providers) — documented the
+Social Sign-In & Connected Accounts section: the four sign-in endpoints
+(providers / login / callback / exchange) and the three connected-accounts ones
+(GET identities, POST {provider}/link, DELETE identities/{provider}), the nine
+refusal codes the frontend maps to copy, and the security model — why a
+provider-VERIFIED email is the only join key on sign-in, and why the link path
+deliberately does not use email as a join key at all. Also records two things
+that are easy to get wrong and cost real time here: cloud routes authenticate
+at the route level, because the global AuthMiddleware does not gate /api/v1/,
+so a new cloud route needs its own guard; and localhost_auth_bypass defaults to
+TRUE, so verifying an auth change with curl from your own machine cannot tell
+you whether the guard is there.
 -->
 
 # Cloud REST API Reference
@@ -79,6 +100,11 @@ status="error" in the body, never a 5xx).
 This file documents cloud (`pocketpaw-ee`) REST endpoints that do not yet
 have a dedicated page under `docs/api/`. All cloud endpoints require a
 valid enterprise license and an authenticated workspace context.
+
+That second requirement is enforced **per route, not by the global
+middleware**, which does not gate `/api/v1/`. If you are adding or reviewing a
+cloud route, read "Cloud routes authenticate at the route level" in the Social
+Sign-In section below — the route's own guard is what carries it.
 
 ## Pockets — Backend Binding & Live Data Sources
 
@@ -1350,3 +1376,306 @@ disabled, no ingestor registered under the connector id — reports
 `status: "error"` with the reason in `errors` (HTTP 200, matching the
 background sweep's never-raise, per-source isolation contract). Re-runs are
 idempotent: objects upsert by `(source_connector, source_id)`.
+
+---
+
+## Social Sign-In & Connected Accounts
+
+Google and GitHub sign-in, plus the Settings surface where a signed-in user
+connects and disconnects those identities. Seven endpoints in two groups, and
+the groups differ in what authorises them — which is the thing to get right
+before changing any of this.
+
+### Cloud routes authenticate at the route level
+
+**Every cloud route needs its own guard.** The global `AuthMiddleware` does not
+gate `/api/v1/`: it builds `is_auth_optional` from
+`auth_optional_prefixes = ("/api/v1/",)` and skips its final 401 for every
+match, so that ee routes resolve identity through fastapi-users instead. The
+cascade still runs and still populates `request.state` — session cookies, API
+keys, `full_access` — so routes mounted at the shared prefix can read it; it
+simply is not the thing that rejects.
+
+So when you add a cloud route, a session dependency (or an explicit in-handler
+check) is **required**, not belt-and-braces. `tests/cloud/auth/test_route_auth_audit.py`
+asserts this across every mounted router and keeps an allowlist of the routes
+that are public by design, each with its reason.
+
+### Verifying an auth change locally proves nothing by default
+
+`POCKETPAW_LOCALHOST_AUTH_BYPASS` **defaults to true** and grants
+`request.state.full_access` to any caller whose address is loopback. On a dev
+box you therefore cannot tell "this endpoint requires auth" from "this endpoint
+let me in because I am on localhost" — a `curl` from your own machine succeeds
+either way.
+
+Set it to false before testing an auth change by hand:
+
+```bash
+export POCKETPAW_LOCALHOST_AUTH_BYPASS=false
+```
+
+Better, assert it in a test against the ASGI app with no session, the way
+`tests/cloud/sessions/test_runtime_route_auth.py` does. The bypass refuses a
+spoofed `X-Forwarded-For`, so a remote caller cannot claim loopback — the trap
+here is local verification, not a production hole.
+
+### Sign-in endpoints (no session — that is the point)
+
+| Endpoint | Notes |
+|---|---|
+| `GET /auth/social/providers` | `{providers: [...]}` — only providers whose credentials are set. An unconfigured provider is **absent**, not present-and-broken. |
+| `GET /auth/social/{provider}/login` | Begins consent, 302s to the provider. Takes `flow=web` or `flow=desktop`, and `next=<relative path>`. |
+| `GET /auth/social/callback` | The provider's redirect. Redeems the code, applies the policy, then signs in **or** links. |
+| `POST /auth/social/exchange` | `{xc}` traded for a bearer token. How a desktop client gets its FIRST token. Rate-limited per IP. |
+
+Unauthenticated by necessity: the caller has no session yet. The control is the
+single-use `state` from `auth/_oauth_state.py` — server-side, 32 bytes,
+GET-then-DEL, 600s TTL, namespaced per flow so an SSO state cannot be spent on
+the social callback. Server-side rather than a signed token deliberately: a
+self-verifying state token verifies for *anyone* who presents it, which is
+CVE-2025-68481 against fastapi-users.
+
+Failures **redirect rather than return JSON**, because these are reached by a
+full-page browser navigation and a JSON body would render as raw text in the
+address bar. A refusal goes to `<frontend>/?auth=signin&auth_error=<code>` —
+the dialog reopened with an explanation, because a refusal is a UI state and
+not an error page.
+
+The desktop branch redirects to `<frontend>/oauth-callback?xc=<code>` carrying
+a **one-time reference, never a token**: 60-second TTL, single-use. A token in
+a URL leaks through browser history, `Referer`, window titles and every proxy
+log on the path; a spent reference is worthless.
+
+`flow` and `next` are read from the state payload, never from the callback's
+query string — a callback URL is attacker-influenced by definition. `next` is
+re-validated server-side to a same-origin relative path (one leading slash, no
+backslash), so `//evil.com` and absolute URLs degrade to `/`.
+
+### Connected-accounts endpoints (session required)
+
+| Endpoint | Notes |
+|---|---|
+| `GET /auth/social/identities` | `{identities: [{provider, account_email, linked_at}]}`. `linked_at` is null for rows linked before that field existed. |
+| `POST /auth/social/{provider}/link` | Returns `{authorize_url}` — a URL, **not** a 302. Takes `flow=web` (default) or `flow=desktop`, and `next=<relative path>`. |
+| `POST /auth/social/link/complete` | Desktop only. `{code}` → `{provider, identities}`. See below. |
+| `DELETE /auth/social/identities/{provider}` | 204 on success. |
+
+All three take `current_active_user`, and the acting account comes from that
+dependency only. The provider name is the sole caller-chosen value, so no
+request shape acts on somebody else's credentials. **A link endpoint that took
+its target user from a body or path parameter would be an account-takeover
+primitive, not a settings page** — do not add one.
+
+`POST .../link` returns a URL rather than redirecting because Settings calls it
+with `fetch`, which follows a 302 opaquely: the request would succeed against
+the provider's HTML and the page would never move. The client assigns the URL
+to `window.location`. These three return JSON errors in the shared `CloudError`
+envelope, unlike the sign-in routes above, because they are XHR with a caller
+waiting on a response.
+
+The link flow reuses the sign-in callback. The two are told apart by a
+`link_user_id` pinned into the state at authorize time, and **the callback
+re-checks that id against the session cookie**. That check is load-bearing:
+state is a bearer secret, so without it a stolen link state lets an attacker
+complete the flow with their OWN provider account, attach it to the victim, and
+sign in as them afterwards.
+
+Web link outcomes redirect to `<frontend><next>?social_linked=<provider>` on
+success and `?social_error=<code>` on refusal — never to the sign-in dialog,
+which would prompt an already-signed-in user to sign in.
+
+### Linking on desktop finishes somewhere else entirely
+
+A desktop client is not "the web client in a window", and this is the one place
+that difference is load-bearing. It authenticates with a bearer held in
+localStorage, and the Tauri webview that completes consent carries **no cookie
+for this origin**. So the callback cannot authenticate anyone at all — and
+attaching on the strength of the state alone is exactly the theft the web
+branch's cookie check exists to prevent.
+
+The proof therefore moves to a request the app can actually authenticate. Pass
+`flow=desktop` when starting the link, and the callback attaches nothing:
+
+```
+1. POST /auth/social/{provider}/link?flow=desktop     (Authorization: Bearer …)
+   -> {"authorize_url": "https://github.com/login/oauth/authorize?…"}
+
+2. app opens a webview at authorize_url; user consents
+
+3. callback parks the identity and redirects the webview to:
+      <frontend>/oauth-callback?link=<code>&provider=<provider>
+   or on failure:
+      <frontend>/oauth-callback?link_error=<code>
+
+4. webview closes; app redeems the code:
+   POST /auth/social/link/complete   {"code": "<code>"}   (Authorization: Bearer …)
+   -> 200 {"provider": "github", "identities": [...]}
+   -> 4xx CloudError envelope, same auth.* codes as everywhere else
+```
+
+`link=` is what distinguishes this from a desktop **sign-in**, which uses `xc=`
+on the same `/oauth-callback` route. They are not interchangeable: one attaches
+an identity, the other mints a bearer, and they live in separate single-use
+namespaces so a code from one is refused by the other.
+
+Step 4 is where authorisation happens. The parked record names the account the
+link was started for, and `complete` compares it against `current_active_user`.
+**A stolen link code is worth nothing without that account's bearer**, which
+makes the desktop path stronger than the cookie check rather than a concession
+to it. The code is single-use with a 60-second TTL.
+
+The response carries the refreshed identity list because the window that
+started the flow has already closed; a follow-up refetch that failed would
+leave the panel stale with no way to explain itself.
+
+Policy refusals (`auth.identity_claimed`, `auth.sso_enforced`,
+`auth.unverified_link`) surface as JSON from step 4, which the panel renders
+inline. Only a provider or network failure still refuses at the callback, and
+it redirects to `/oauth-callback?link_error=…` so the webview closes rather
+than sitting on a page it cannot use.
+
+The desktop redirect ignores `next` — the webview's job is to close, and the
+Settings panel that opened it is still mounted in the main window. Not building
+a `next`-derived URL there also means the hostile-value problem cannot reach
+that redirect at all.
+
+An unknown `flow` is **refused** (`social.unknown_flow`, 422) rather than
+defaulted to `web`. A desktop client that silently got the web branch would
+consent successfully and then attach nothing, which reads as a frontend bug for
+as long as it takes someone to find this paragraph.
+
+### Refusal codes
+
+The frontend maps each of these to its own copy in
+`core/auth/social-errors.ts`, so renaming one silently degrades a specific
+message to a generic fallback.
+
+| Code | Means | Path |
+|---|---|---|
+| `auth.unverified_link` | The provider would not vouch for any email address. | Both |
+| `auth.sso_enforced` | The user's workspace mandates SSO. | Both |
+| `auth.identity_claimed` | That identity is already attached to a **different** account. | Link |
+| `auth.link_session_mismatch` | The callback's session is not the account that started the link. | Link |
+| `auth.last_credential` | Unlinking would leave the account with no way to sign in. 409. | Unlink |
+| `auth.not_linked` | No identity from that provider is attached. 404. | Unlink |
+| `social.invalid_state` | State unknown, already spent, expired, or from another flow. | Both |
+| `social.provider_not_configured` | No credentials for that provider on this server. 503. | Both |
+| `social.unknown_provider` | Not `google` or `github`. 422. | Both |
+| `social.unknown_flow` | `flow` was neither `web` nor `desktop`. 422. | Both |
+| `social.invalid_link_code` | A parked desktop link record could not be rebuilt. | Link |
+
+### The security model — read this before adding provider #3
+
+**On sign-in, a provider-verified email is the only join key.** The policy, in
+order:
+
+1. This `(provider, account_id)` is already linked → sign in.
+2. No verified email from the provider → **REFUSE**.
+3. Verified email matches an existing account → link, then sign in.
+4. Verified email, no existing account → create, link, sign in.
+
+Step 2 before step 3 is the whole defence. Matching an **unverified** address
+against an existing account is how an attacker attaches `victim@corp.com` to
+their own provider profile and walks into the victim's account. Not
+hypothetical — this is nOAuth (Entra's mutable, unverified `email` claim) and
+GHSA-6g38-8j4p-j3pr. So the rule every adapter must hold to: **compute
+`email_verified` from the provider's authoritative source, and never infer it
+from the mere presence of an address.** GitHub's `/user` payload carries an
+`email` field that is *not* proof of verification; the flag comes from
+`GET /user/emails`, which is why the `user:email` scope is required.
+
+Where a provider gives no verified address the adapter reports `email=None`
+rather than guessing, and the service turns that into a refusal, not a link.
+
+Step 1 sitting *before* step 2 is also deliberate. A returning user whose
+provider has since stopped vouching for their address — they removed it, or
+declined the scope on a re-consent — is still the same person, because that
+match was on the provider's immutable id. Verification only gates the step that
+BINDS an identity to an account it was not already bound to.
+
+**On linking, email is deliberately NOT a join key at all.** The session
+already establishes who the user is, so the identity's address is not needed to
+resolve an account and must not be used to. The link path looks up only
+`(provider, account_id)`:
+
+- already attached to the caller → no-op, because clicking "Connect" twice is
+  not an error and reporting one would put the panel in a failure state over a
+  state it already has;
+- attached to a **different** account → refuse `auth.identity_claimed`. Never
+  re-point it. That would hand over this account *and* silently strip a
+  credential from the account that legitimately holds it;
+- attached to nobody → attach.
+
+Unverified identities are still refused on the link path, but for a different
+reason than on sign-in: it preserves the invariant that **every row in
+`oauth_accounts` was established from a provider-verified identity**, which is
+exactly what makes step 1 above safe when it signs a returning user in on a
+link alone. Break the invariant here and step 1 loses its foundation.
+
+**Unlinking refuses to remove the last credential**, and the check is
+`_has_usable_password`, not `bool(hashed_password)`. Accounts created by the
+social path and by SSO JIT provisioning store an *unusable sentinel*
+(`!social-only-...`, `!sso-only-...`) rather than an empty string, because an
+empty hash can compare-equal in some verifiers. A truthiness check therefore
+reports "has a password" for precisely the users who have none, and would let
+them delete their only way in. The test is positive — pwdlib and passlib hashes
+are Modular Crypt Format and begin with `$` — so a sentinel added later needs
+no change here. It over-refuses an SSO member who could still reach their IdP;
+that is the intended direction, because a false refusal costs one password
+reset and a false allow is a permanent lockout support cannot undo.
+
+**Enforced SSO refuses both sign-in and linking.** A workspace paying for SSO
+is buying the guarantee that its members authenticate through the IdP, and
+consumer Google must not become the documented way around it. Linking is
+guarded even though a link is not itself a bypass — sign-in re-checks every
+time, so an identity attached under enforced SSO could not be spent — because
+it would be a bypass lying in wait if that check ever regressed, and it stores
+exactly the credential the org enabled the control to exclude. The check also
+runs at `begin_link`, so Settings shows an explainable error instead of a round
+trip through Google that ends in a redirect.
+
+Provider access tokens are never stored. Sign-in needs identity, not ongoing
+API access, and a token we never use is avoidable breach surface. Repository
+access is codeconnect's job.
+
+### Configuration
+
+| Variable | Purpose |
+|---|---|
+| `POCKETPAW_GOOGLE_OAUTH_CLIENT_ID` / `_SECRET` | Google sign-in. Unset hides the button. |
+| `POCKETPAW_GITHUB_OAUTH_CLIENT_ID` / `_SECRET` | GitHub sign-in. Unset hides the button. |
+| `POCKETPAW_PUBLIC_BASE_URL` | Backend origin; the callback URL is derived from it. Default `http://localhost:8888`. |
+| `POCKETPAW_SOCIAL_REDIRECT_URI` | Overrides the derived callback outright. Set it when the backend sits behind a proxy whose public origin it cannot infer. |
+| `POCKETPAW_FRONTEND_BASE_URL` | Where the SPA lives. Default `http://localhost:1420`. |
+
+Callback URL, registered with both providers:
+
+```
+<backend-origin>/api/v1/auth/social/callback
+```
+
+**GitHub needs an OAuth App, not a GitHub App.** They are different products
+with different consent screens and different token models, and picking the
+wrong one costs an hour before anything works. Create it under Settings →
+Developer settings → **OAuth Apps**. These credentials are also distinct from
+two other Google/GitHub credentials already in this codebase, and reusing
+either will not work:
+
+- `POCKETPAW_GITHUB_APP_*` — codeconnect's **GitHub App**, for repository
+  access via installation tokens. Sign-in uses its own OAuth App so the
+  account-creation consent screen asks for identity only, never repository
+  permissions.
+- `GOOGLE_OAUTH_CLIENT_ID` / `_SECRET` (no `POCKETPAW_` prefix, OSS core) — the
+  Drive connector's per-install data integration.
+
+Scopes are requested at runtime and are identity-only: Google gets
+`openid email profile`, GitHub gets `read:user user:email`. `user:email` is not
+optional — without it `GET /user/emails` returns 403, no address can be treated
+as verified, and every GitHub sign-in refuses with `auth.unverified_link`.
+
+`POCKETPAW_FRONTEND_BASE_URL` matters more than it looks. Every redirect out of
+these routes is **absolute** against that origin, because a relative redirect
+resolves against the API origin — the same host only when both are served from
+one domain. In production they usually are; in local dev they are not, and a
+successfully signed-in user lands on the API root and sees nothing.

--- a/ee/pocketpaw_ee/cloud/_core/rate_limit.py
+++ b/ee/pocketpaw_ee/cloud/_core/rate_limit.py
@@ -13,7 +13,7 @@ assumption.
 
 from __future__ import annotations
 
-from fastapi import Depends
+from fastapi import Depends, Request
 
 from pocketpaw.security.rate_limiter import RateLimiter
 from pocketpaw_ee.cloud._core.context import RequestContext, request_context
@@ -26,6 +26,29 @@ _invite_create_limiter = RateLimiter(rate=50.0 / 86400.0, capacity=50)
 # 5 resends per 30 minutes per invite. Keyed on invite_id rather than actor
 # so an admin can't sidestep by rotating between teammates.
 _invite_resend_limiter = RateLimiter(rate=5.0 / 1800.0, capacity=5)
+
+
+# 10 social exchange-code redemptions per minute per IP. The code is already
+# single-use with a 60s TTL and 32 bytes of entropy, so this is defence in
+# depth against someone spraying guesses rather than the primary control.
+# Keyed on IP because the endpoint is UNAUTHENTICATED by nature - it is how a
+# desktop client turns a callback into its first token, so there is no actor
+# to key on yet.
+_social_exchange_limiter = RateLimiter(rate=10.0 / 60.0, capacity=10)
+
+
+async def rate_limit_social_exchange(request: Request) -> None:
+    """Per-IP bucket guarding POST /auth/social/exchange."""
+    client = request.client.host if request.client else "unknown"
+    forwarded = request.headers.get("x-forwarded-for", "")
+    if forwarded:
+        # Left-most entry is the originating client when behind a proxy.
+        client = forwarded.split(",")[0].strip() or client
+    if not _social_exchange_limiter.check(f"social-exchange:{client}").allowed:
+        raise RateLimited(
+            "social.exchange_rate_limited",
+            "Too many attempts - try again shortly.",
+        )
 
 
 async def rate_limit_invite_create(

--- a/ee/pocketpaw_ee/cloud/auth/_oauth_state.py
+++ b/ee/pocketpaw_ee/cloud/auth/_oauth_state.py
@@ -1,0 +1,114 @@
+"""Shared single-use OAuth state store — used by every OAuth-shaped login flow.
+
+Created 2026-07-29 (AM-1). Extracted verbatim from ``auth/sso/service.py`` so
+the enterprise SSO dance and the consumer social dance (Google / GitHub) share
+one implementation of the part that is easy to get catastrophically wrong.
+
+Why this is server-side rather than a signed stateless token
+------------------------------------------------------------
+``state`` exists to bind the callback to the browser that started the flow. A
+stateless, self-verifying state token cannot do that: it verifies for *anyone*
+who presents it, so an attacker can start a flow, capture the state, finish the
+upstream consent with their OWN provider account, and then trick a victim into
+loading ``…/callback?code=<attacker>&state=<attacker>``. Depending on what the
+callback does next, the victim is either logged into the attacker's account or
+has the attacker's identity linked into theirs.
+
+That is not hypothetical: it is CVE-2025-68481 / GHSA-5j53-63w8-8625 against
+fastapi-users, whose OAuth state was a JWT carrying nothing but an audience and
+an expiry. This module keeps the store server-side and single-use, so a state
+value is meaningless the instant it has been redeemed once.
+
+The properties this module guarantees, and which its tests pin:
+  * **unguessable** — 32 bytes from ``secrets``, URL-safe
+  * **single-use** — read and delete are one step; a replay finds nothing
+  * **expiring** — a TTL, so an abandoned flow cannot be resumed days later
+  * **opaque to the client** — the payload never leaves the server, so nothing
+    in it can be tampered with, only referenced
+
+The namespace argument keeps flows from redeeming each other's states: an SSO
+state cannot be spent on the social callback or vice versa, because they live
+under different key prefixes and the lookup is namespaced.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import secrets
+from collections.abc import Mapping
+from typing import Any
+
+from pocketpaw_ee.cloud._core import redis_client
+from pocketpaw_ee.cloud._core.errors import Forbidden
+
+#: How long a started-but-unfinished flow stays resumable.
+STATE_TTL_SECONDS = 600
+
+
+def _key(namespace: str, state: str) -> str:
+    return f"{namespace}_state:{state}"
+
+
+def new_state() -> str:
+    """A fresh, unguessable state value."""
+    return secrets.token_urlsafe(32)
+
+
+def new_nonce() -> str:
+    """A fresh nonce, for providers that echo one back in an id_token."""
+    return secrets.token_urlsafe(32)
+
+
+def pkce_pair() -> tuple[str, str]:
+    """Return ``(verifier, challenge)`` for PKCE S256.
+
+    The verifier stays server-side in the state payload; only the challenge
+    travels to the provider. Without PKCE, an authorization code intercepted in
+    transit is redeemable by whoever holds it.
+    """
+    verifier = base64.urlsafe_b64encode(secrets.token_bytes(32)).decode("ascii").rstrip("=")
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+    return verifier, challenge
+
+
+async def issue(
+    namespace: str,
+    payload: Mapping[str, Any],
+    *,
+    ttl_seconds: int = STATE_TTL_SECONDS,
+) -> str:
+    """Persist ``payload`` under a fresh state value and return that value.
+
+    Everything the callback will need must go in ``payload`` — it is the only
+    thing the callback can trust. Values that arrive on the callback's query
+    string are attacker-influenced by definition.
+    """
+    state = new_state()
+    redis = redis_client.get_redis()
+    await redis.setex(_key(namespace, state), ttl_seconds, json.dumps(dict(payload)))
+    return state
+
+
+async def consume(namespace: str, state: str) -> dict[str, Any]:
+    """Redeem ``state`` exactly once and return its payload.
+
+    Raises ``Forbidden("<namespace>.invalid_state")`` when the state is unknown,
+    already spent, expired, or belongs to a different flow. The delete happens
+    immediately after the read, so two concurrent callbacks cannot both proceed.
+    """
+    redis = redis_client.get_redis()
+    key = _key(namespace, state)
+    raw = await redis.get(key)
+    if raw is None:
+        raise Forbidden(f"{namespace}.invalid_state", "Login state is missing or expired")
+    await redis.delete(key)
+    try:
+        loaded = json.loads(raw)
+    except (TypeError, ValueError) as exc:
+        raise Forbidden(f"{namespace}.invalid_state", "Login state payload is malformed") from exc
+    if not isinstance(loaded, dict):
+        raise Forbidden(f"{namespace}.invalid_state", "Login state payload is malformed")
+    return loaded

--- a/ee/pocketpaw_ee/cloud/auth/router.py
+++ b/ee/pocketpaw_ee/cloud/auth/router.py
@@ -321,9 +321,11 @@ router.include_router(
 
 router.include_router(api_keys_router)
 
+from pocketpaw_ee.cloud.auth.social import router as social_router  # noqa: E402
 from pocketpaw_ee.cloud.auth.sso import router as sso_router  # noqa: E402
 
 router.include_router(sso_router)
+router.include_router(social_router)
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/cloud/auth/social/__init__.py
+++ b/ee/pocketpaw_ee/cloud/auth/social/__init__.py
@@ -1,0 +1,11 @@
+"""Consumer social sign-in (Google / GitHub).
+
+Created 2026-07-29 (AM-2). Distinct from ``auth/sso/`` — that is
+workspace-scoped enterprise OIDC configured by an admin; this is the
+consumer "Continue with Google/GitHub" path on the auth dialog. They share
+the single-use state store in ``auth/_oauth_state.py``.
+"""
+
+from pocketpaw_ee.cloud.auth.social.router import router
+
+__all__ = ["router"]

--- a/ee/pocketpaw_ee/cloud/auth/social/domain.py
+++ b/ee/pocketpaw_ee/cloud/auth/social/domain.py
@@ -1,0 +1,226 @@
+"""Social sign-in linking policy — the decision table, as pure functions.
+
+Created 2026-07-29 (AM-4). The IO lives in ``service.py``; the *policy* lives
+here so every branch can be tested without a database, and so the rule can be
+read in one screen.
+
+The policy, in order:
+
+    1. This provider account is ALREADY linked        -> sign in
+    2. No verified email from the provider            -> REFUSE
+    3. Verified email matches an existing account     -> link, then sign in
+    4. Verified email, no existing account            -> create, link, sign in
+
+Step 1 comes before step 2 deliberately. A returning user whose provider has
+since stopped vouching for their address (they removed it, or declined the
+`user:email` scope on a re-consent) is still *the same account* — we matched on
+the provider's immutable id, not on an email — so locking them out would be
+wrong. Verification only gates the step that BINDS an identity to an account
+it was not previously bound to.
+
+Step 2 before step 3 is the account-takeover defence. Matching an unverified
+address against an existing account is how an attacker attaches victim@corp.com
+to their own provider profile and walks into the victim's account.
+
+Updated 2026-08-01 (AM-6) with the SETTINGS-side policy — ``decide_link`` and
+``decide_unlink``, for a user who already has a session and is managing their
+connected accounts. Two rules there are worth stating up front, because both
+are the difference between a feature and a vulnerability:
+
+    * **Linking must not steal.** If the incoming provider identity already
+      belongs to a DIFFERENT account, refuse. Re-pointing it would hand the
+      attacker whatever that identity could previously sign into, and would
+      silently strip a credential from its real owner.
+    * **Never remove the last credential.** Unlinking the only way into an
+      account locks its owner out permanently, and support cannot undo it.
+
+A note on the cloud code rules: ``domain.py`` objects normally carry required
+tenancy fields. These deliberately do not. Sign-in happens BEFORE a tenant is
+known — the user may have no workspace at all (they land in the /welcome
+funnel) — so there is no ``workspace_id`` to construct with. Tenancy is
+enforced downstream, once a session exists.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from pocketpaw_ee.cloud.auth.social.providers.base import SocialIdentity
+
+#: What the caller should do with this identity.
+#:
+#: The first three are sign-in outcomes from :func:`decide`. ``attach`` and
+#: ``noop`` are link outcomes from :func:`decide_link` — a separate pair rather
+#: than reusing ``link``/``sign_in`` because the two paths differ in what
+#: authorises them: sign-in matched on a provider-verified email, linking is
+#: authorised by the caller's existing session.
+LinkAction = Literal["sign_in", "link", "create", "attach", "noop", "refuse"]
+
+#: Refusal codes. These reach the frontend as ``?reason=`` on the error
+#: redirect, so each maps to a specific piece of UI copy.
+REFUSE_UNVERIFIED = "auth.unverified_link"
+REFUSE_SSO_ENFORCED = "auth.sso_enforced"
+
+#: The incoming identity is already attached to somebody else's account.
+REFUSE_IDENTITY_CLAIMED = "auth.identity_claimed"
+#: The callback's session is not the account that started the link.
+REFUSE_LINK_SESSION_MISMATCH = "auth.link_session_mismatch"
+#: Unlinking this would leave the account with no way to sign in.
+REFUSE_LAST_CREDENTIAL = "auth.last_credential"
+#: Nothing to unlink — no identity from that provider is attached.
+REFUSE_NOT_LINKED = "auth.not_linked"
+
+
+@dataclass(frozen=True)
+class LinkDecision:
+    action: LinkAction
+    #: The account to act on. None for "create" and for refusals.
+    user_id: str | None = None
+    #: Set only when ``action == "refuse"``.
+    reason: str | None = None
+
+    @property
+    def refused(self) -> bool:
+        return self.action == "refuse"
+
+
+def decide(
+    *,
+    identity: SocialIdentity,
+    linked_user_id: str | None,
+    email_user_id: str | None,
+) -> LinkDecision:
+    """Resolve a provider identity to an action.
+
+    ``linked_user_id`` is the account already carrying this
+    ``(provider, account_id)`` pair — the strongest possible match, since the
+    provider's id is immutable.
+
+    ``email_user_id`` is an account whose email equals the identity's, and it
+    MUST have been looked up using ``identity.email``, which adapters only
+    populate when the provider vouched for the address. Passing a
+    caller-supplied or unverified address here would defeat the whole policy.
+    """
+    # 1. Already linked. Matched on the provider's immutable id, so the state
+    #    of their email today is irrelevant — this is the same person.
+    if linked_user_id:
+        return LinkDecision(action="sign_in", user_id=linked_user_id)
+
+    # 2. Nothing the provider will vouch for. Binding on an unverified address
+    #    is the takeover path, so refuse rather than guess.
+    if not identity.has_verified_email:
+        return LinkDecision(action="refuse", reason=REFUSE_UNVERIFIED)
+
+    # 3. Verified address belonging to someone we already know.
+    if email_user_id:
+        return LinkDecision(action="link", user_id=email_user_id)
+
+    # 4. Verified address, nobody has it.
+    return LinkDecision(action="create")
+
+
+@dataclass(frozen=True)
+class UnlinkDecision:
+    """Whether an identity may be detached, and why not."""
+
+    allowed: bool
+    #: Set only when ``allowed`` is False.
+    reason: str | None = None
+
+
+def decide_link(
+    *,
+    identity: SocialIdentity,
+    owner_user_id: str | None,
+    acting_user_id: str,
+) -> LinkDecision:
+    """Resolve "may this signed-in user attach this identity to themselves?".
+
+    ``owner_user_id`` is the account already carrying this
+    ``(provider, account_id)`` pair, or None. ``acting_user_id`` is the caller,
+    established from their SESSION — never from the request body. A link
+    endpoint that takes the target user from the payload is an
+    account-takeover primitive, which is why this function has no way to
+    express one.
+
+    Unlike :func:`decide`, no email matching happens here at all: the session
+    already says who this is, so the identity's address is not a join key and
+    cannot be used as one.
+    """
+    # Already mine. Idempotent — clicking "Connect" twice is not an error, and
+    # reporting one would send the UI into a failure state over a no-op.
+    if owner_user_id is not None and owner_user_id == acting_user_id:
+        return LinkDecision(action="noop", user_id=acting_user_id)
+
+    # Somebody else's. The takeover case: re-pointing the identity would let
+    # the claimant sign into THIS account, and would silently strip a
+    # credential from the account that legitimately holds it. Neither is ever
+    # what the user meant, so refuse instead of guessing which.
+    if owner_user_id is not None:
+        return LinkDecision(action="refuse", reason=REFUSE_IDENTITY_CLAIMED)
+
+    # No verified address. Not a takeover risk here — the session, not the
+    # email, authorises this — but it breaks a system-wide invariant that
+    # something else depends on: every row in ``oauth_accounts`` was
+    # established from a provider-verified identity. ``decide`` step 1 leans on
+    # exactly that when it signs a returning user in on a link alone, without
+    # re-checking verification. Admitting an unverified identity through this
+    # door would quietly remove the foundation that shortcut stands on.
+    if not identity.has_verified_email:
+        return LinkDecision(action="refuse", reason=REFUSE_UNVERIFIED)
+
+    return LinkDecision(action="attach", user_id=acting_user_id)
+
+
+def decide_unlink(
+    *,
+    provider: str,
+    linked_providers: tuple[str, ...] | list[str],
+    has_password: bool,
+) -> UnlinkDecision:
+    """Resolve "may this identity be detached?".
+
+    Refuses to remove the last credential. ``has_password`` MUST come from a
+    real check that the stored hash is usable, not from ``bool(hashed_password)``
+    — accounts created by the social and SSO paths carry an unusable sentinel
+    in that field, so the naive check reads "has a password" for precisely the
+    users who have none. See ``service._has_usable_password``.
+
+    Erring toward refusal is deliberate. A false refusal is an inconvenience
+    the user resolves by setting a password; a false allow is a permanent
+    lockout that support cannot reverse.
+    """
+    if provider not in linked_providers:
+        return UnlinkDecision(allowed=False, reason=REFUSE_NOT_LINKED)
+
+    remaining = [p for p in linked_providers if p != provider]
+    if not remaining and not has_password:
+        return UnlinkDecision(allowed=False, reason=REFUSE_LAST_CREDENTIAL)
+
+    return UnlinkDecision(allowed=True)
+
+
+def apply_sso_guard(decision: LinkDecision, *, enforced: bool) -> LinkDecision:
+    """Refuse a decision that would bypass a workspace's enforced SSO.
+
+    Applied after ``decide`` because it depends on the workspace of whichever
+    account the decision landed on. A workspace that has turned SSO on is
+    paying for the guarantee that its members authenticate through the IdP;
+    consumer Google must not become the documented way around it.
+
+    ``create`` is never guarded: a brand-new account belongs to no workspace,
+    so there is nothing to enforce yet.
+
+    It governs the AM-6 link outcomes (``attach`` / ``noop``) too, and that is
+    the point of routing them through here rather than writing a second guard.
+    A link is not itself a bypass — the sign-in path re-runs this check every
+    time, so an identity attached under enforced SSO still could not be spent.
+    But it would be a bypass lying in wait for the day that check regresses,
+    and it stores exactly the credential the org turned this control on to
+    keep out. Refusing at connect-time also beats connecting an identity that
+    then silently never works.
+    """
+    if not enforced or decision.action in ("refuse", "create"):
+        return decision
+    return LinkDecision(action="refuse", reason=REFUSE_SSO_ENFORCED)

--- a/ee/pocketpaw_ee/cloud/auth/social/dto.py
+++ b/ee/pocketpaw_ee/cloud/auth/social/dto.py
@@ -1,0 +1,91 @@
+"""Social sign-in wire types.
+
+Created 2026-07-29 (AM-2). Thin by design: the browser-facing endpoints are
+redirects, not JSON, so the only response body here is the provider list the
+auth dialog reads to decide which buttons exist.
+
+Updated 2026-08-01 (AM-6) with the connected-accounts shapes. These ARE JSON:
+Settings calls them with fetch, where a 302 is opaque and useless. Note what
+``LinkedIdentity`` does NOT carry — no ``access_token``, no ``account_id``, no
+provider payload. The response type is the enforcement: it can only serialize
+the three fields the panel renders, so a future field added to the stored
+``OAuthAccount`` cannot leak through this endpoint by default.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class SocialProvidersResponse(BaseModel):
+    """Which providers this deployment can actually complete a flow with.
+
+    The dialog renders one button per entry. A provider missing its
+    credentials is absent rather than present-and-broken — a button that opens
+    a dead consent screen is worse than no button.
+    """
+
+    providers: list[str] = Field(default_factory=list)
+
+
+class SocialExchangeRequest(BaseModel):
+    """Trade a one-time code from the desktop callback for a bearer token."""
+
+    xc: str = Field(min_length=1, max_length=512)
+
+
+class LinkedIdentity(BaseModel):
+    """One provider identity attached to the signed-in user.
+
+    ``account_email`` is what the PROVIDER had for them at link time, shown so
+    the user can tell two GitHub accounts apart. It is display-only and is
+    never a lookup key — see ``domain.decide_link``.
+    """
+
+    provider: str
+    account_email: str = ""
+    #: None for identities linked before the field existed — see the note in
+    #: ``models/user.py``. The panel shows "Connected" with no date.
+    linked_at: datetime | None = None
+
+
+class SocialIdentitiesResponse(BaseModel):
+    """Everything the connected-accounts panel needs to render."""
+
+    identities: list[LinkedIdentity] = Field(default_factory=list)
+
+
+class SocialLinkCompleteRequest(BaseModel):
+    """Redeem a desktop link code.
+
+    The desktop callback parks the consented identity instead of attaching it,
+    because a Tauri webview carries no cookie our backend can authenticate.
+    This request finishes the job over the bearer the app does hold.
+    """
+
+    code: str = Field(min_length=1, max_length=512)
+
+
+class SocialLinkCompleteResponse(BaseModel):
+    """The outcome of a desktop link, plus the panel's new state.
+
+    Returns the full identity list so the app renders the result without a
+    second round trip — the window that started this has already closed, and a
+    refetch that fails leaves the panel stale with no way to explain itself.
+    """
+
+    provider: str
+    identities: list[LinkedIdentity] = Field(default_factory=list)
+
+
+class SocialLinkStartResponse(BaseModel):
+    """Where to send the browser to attach a provider identity.
+
+    A URL rather than a 302, because Settings starts this with fetch and a
+    redirect there is followed opaquely by the browser instead of navigating
+    the page. The client assigns it to ``window.location``.
+    """
+
+    authorize_url: str

--- a/ee/pocketpaw_ee/cloud/auth/social/providers/__init__.py
+++ b/ee/pocketpaw_ee/cloud/auth/social/providers/__init__.py
@@ -1,0 +1,39 @@
+"""Social provider registry.
+
+Created 2026-07-29 (AM-2/AM-3). One lookup point so the service never
+branches on provider name, and so an unconfigured provider is reported as
+absent rather than offered and then failing at the consent screen.
+"""
+
+from __future__ import annotations
+
+from .base import SocialIdentity, SocialProvider
+from .github import GitHubProvider
+from .google import GoogleProvider
+
+_PROVIDERS: dict[str, SocialProvider] = {
+    "google": GoogleProvider(),
+    "github": GitHubProvider(),
+}
+
+
+def get_provider(name: str) -> SocialProvider | None:
+    """The adapter for ``name``, or None if unknown."""
+    return _PROVIDERS.get((name or "").strip().lower())
+
+
+def configured_providers() -> list[str]:
+    """Names of providers with credentials present, in stable order.
+
+    The frontend renders a button per entry, so a provider missing its
+    credentials simply does not appear.
+    """
+    return [name for name, p in _PROVIDERS.items() if p.is_configured()]
+
+
+__all__ = [
+    "SocialIdentity",
+    "SocialProvider",
+    "configured_providers",
+    "get_provider",
+]

--- a/ee/pocketpaw_ee/cloud/auth/social/providers/base.py
+++ b/ee/pocketpaw_ee/cloud/auth/social/providers/base.py
@@ -1,0 +1,96 @@
+"""Social identity provider contract.
+
+Created 2026-07-29 (AM-2/AM-3). One shape for "who is this person, and does
+their provider actually vouch for the email they claim".
+
+The whole design turns on ``email_verified``. Linking an incoming provider
+identity to an existing account by matching email addresses is safe ONLY when
+the provider asserts the address is verified. GitHub, for instance, lets any
+user attach an arbitrary address to their account; if we matched on that, an
+attacker adds victim@corp.com to their own GitHub, signs in, and lands inside
+the victim's account. The same class of bug is nOAuth (Entra's mutable,
+unverified ``email`` claim) and nhost GHSA-6g38-8j4p-j3pr.
+
+So the rule this module exists to enforce: **every adapter must compute
+``email_verified`` from the provider's authoritative source, and must never
+infer it from the mere presence of an address.** Where a provider gives no
+verified address, the adapter reports ``email=None`` rather than guessing —
+the service turns that into a refusal, not a link.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+
+@dataclass(frozen=True)
+class SocialIdentity:
+    """A person as a provider describes them, after verification checks."""
+
+    #: Provider key — "google" | "github". Half of the linking identity.
+    provider: str
+    #: The provider's own stable id for this account. NEVER the email: emails
+    #: change hands, provider ids do not. This is the primary match key.
+    account_id: str
+    #: A VERIFIED address, or None. None is meaningful — it means the provider
+    #: would not vouch for any address, so nothing may be matched on.
+    email: str | None
+    #: Display name, best effort. Cosmetic only, never used for matching.
+    full_name: str = ""
+    #: Avatar URL, best effort. Cosmetic only.
+    avatar: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.provider:
+            raise ValueError("SocialIdentity.provider is required")
+        if not self.account_id:
+            raise ValueError("SocialIdentity.account_id is required")
+
+    @property
+    def has_verified_email(self) -> bool:
+        """True when the provider vouched for an address.
+
+        A bare truthiness check on ``email`` is the same thing by construction:
+        adapters only ever populate the field with a verified address. This
+        property exists so call sites read as the security decision they are.
+        """
+        return bool(self.email)
+
+
+@runtime_checkable
+class SocialProvider(Protocol):
+    """What every provider adapter must offer the social service."""
+
+    #: Stable key, stored on the linked account. Never rename one in place.
+    name: str
+
+    def is_configured(self) -> bool:
+        """Whether credentials are present.
+
+        Unconfigured providers are hidden from the UI rather than offered and
+        then failing at the consent screen.
+        """
+        ...
+
+    def authorize_url(
+        self,
+        *,
+        state: str,
+        redirect_uri: str,
+        code_challenge: str | None = None,
+        nonce: str | None = None,
+    ) -> str:
+        """Where to send the browser to begin consent."""
+        ...
+
+    async def exchange(
+        self,
+        *,
+        code: str,
+        redirect_uri: str,
+        code_verifier: str | None = None,
+        nonce: str | None = None,
+    ) -> SocialIdentity:
+        """Redeem the authorization code and return the verified identity."""
+        ...

--- a/ee/pocketpaw_ee/cloud/auth/social/providers/github.py
+++ b/ee/pocketpaw_ee/cloud/auth/social/providers/github.py
@@ -1,0 +1,221 @@
+"""GitHub social sign-in adapter.
+
+Created 2026-07-29 (AM-3).
+
+GitHub is NOT an OIDC provider — no discovery document, no ``id_token`` — so it
+cannot ride the OIDC path Google uses. It needs a plain OAuth2 code exchange
+plus two REST calls, and *which* call answers "is this email verified" is the
+entire security question:
+
+    GET /user         -> id, login, name, avatar_url
+                         Its `email` field is the user's PUBLIC PROFILE email.
+                         It is self-asserted, freely editable, and carries NO
+                         verification signal whatsoever. Reading it as an
+                         identity is the account-takeover bug.
+
+    GET /user/emails  -> [{email, primary, verified, visibility}]
+                         The only authoritative source. Requires the
+                         `user:email` scope.
+
+So this adapter takes the primary address that is *also* ``verified: true``,
+falls back to any verified address, and otherwise reports ``email=None`` —
+which the service turns into a refusal rather than a link.
+
+A user may legitimately decline the `user:email` scope, in which case
+/user/emails returns 403 and we report no email. That is a normal outcome for a
+careful person, not an error, so it is handled rather than raised.
+
+Two further notes:
+  * This is a GitHub **OAuth App**, deliberately not the codeconnect **GitHub
+    App**. Sign-in asks for identity only; repository access stays a separate,
+    later consent. See the design doc for why.
+  * GitHub OAuth Apps do not support PKCE, so ``code_challenge`` is accepted
+    and ignored. The protections that do apply are the single-use ``state``
+    (see auth/_oauth_state.py) and the client secret on the token exchange.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+from urllib.parse import urlencode
+
+import httpx
+
+from pocketpaw_ee.cloud._core.errors import CloudError
+
+from .base import SocialIdentity
+
+logger = logging.getLogger(__name__)
+
+_AUTHORIZE_URL = "https://github.com/login/oauth/authorize"
+_TOKEN_URL = "https://github.com/login/oauth/access_token"
+
+#: Identity only. `user:email` is required — without it /user/emails 403s and
+#: no address can be verified, which downgrades every sign-in to a refusal.
+_SCOPES = ["read:user", "user:email"]
+
+_TIMEOUT = 10.0
+
+
+def _api_base() -> str:
+    # Mirrors websandbox/githubapp.py so GitHub Enterprise deploys work.
+    return os.environ.get("GITHUB_API_BASE", "https://api.github.com").strip().rstrip("/")
+
+
+def _client_id() -> str:
+    return os.environ.get("POCKETPAW_GITHUB_OAUTH_CLIENT_ID", "").strip()
+
+
+def _client_secret() -> str:
+    return os.environ.get("POCKETPAW_GITHUB_OAUTH_CLIENT_SECRET", "").strip()
+
+
+def pick_verified_email(rows: list[dict[str, Any]]) -> str | None:
+    """The best VERIFIED address from GET /user/emails, or None.
+
+    Order: verified+primary, then any verified. Unverified rows are never
+    eligible no matter how they are flagged — an unverified address on a
+    provider account proves only that someone typed it.
+    """
+    verified = [
+        r
+        for r in rows
+        if isinstance(r, dict) and r.get("verified") is True and isinstance(r.get("email"), str)
+    ]
+    if not verified:
+        return None
+    for row in verified:
+        if row.get("primary") is True:
+            return str(row["email"]).lower()
+    return str(verified[0]["email"]).lower()
+
+
+class GitHubProvider:
+    name = "github"
+
+    def is_configured(self) -> bool:
+        return bool(_client_id() and _client_secret())
+
+    def authorize_url(
+        self,
+        *,
+        state: str,
+        redirect_uri: str,
+        code_challenge: str | None = None,  # noqa: ARG002 — GitHub OAuth Apps lack PKCE
+        nonce: str | None = None,  # noqa: ARG002 — no id_token to bind a nonce to
+    ) -> str:
+        params = {
+            "client_id": _client_id(),
+            "redirect_uri": redirect_uri,
+            "scope": " ".join(_SCOPES),
+            "state": state,
+            # Force the account chooser rather than silently reusing whichever
+            # GitHub session the browser happens to hold.
+            "allow_signup": "true",
+        }
+        return f"{_AUTHORIZE_URL}?{urlencode(params)}"
+
+    async def exchange(
+        self,
+        *,
+        code: str,
+        redirect_uri: str,
+        code_verifier: str | None = None,  # noqa: ARG002 — no PKCE on GitHub OAuth Apps
+        nonce: str | None = None,  # noqa: ARG002
+    ) -> SocialIdentity:
+        async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+            token = await self._access_token(client, code, redirect_uri)
+            profile = await self._get(client, token, "/user")
+            email = await self._verified_email(client, token)
+
+        account_id = profile.get("id")
+        if account_id is None:
+            raise CloudError(502, "social.github_no_account_id", "GitHub returned no account id")
+
+        return SocialIdentity(
+            provider=self.name,
+            account_id=str(account_id),
+            email=email,
+            full_name=str(profile.get("name") or profile.get("login") or ""),
+            avatar=str(profile.get("avatar_url") or ""),
+        )
+
+    # -- internals ---------------------------------------------------------
+
+    async def _access_token(self, client: httpx.AsyncClient, code: str, redirect_uri: str) -> str:
+        resp = await client.post(
+            _TOKEN_URL,
+            # Without this header GitHub replies in form-urlencoded, not JSON.
+            headers={"Accept": "application/json"},
+            data={
+                "client_id": _client_id(),
+                "client_secret": _client_secret(),
+                "code": code,
+                "redirect_uri": redirect_uri,
+            },
+        )
+        resp.raise_for_status()
+        body = resp.json()
+
+        # GitHub reports exchange failures as HTTP 200 with an `error` key, so
+        # raise_for_status alone would let a failed exchange through.
+        if isinstance(body, dict) and body.get("error"):
+            raise CloudError(
+                401,
+                "social.github_token_exchange_failed",
+                str(body.get("error_description") or body["error"]),
+            )
+
+        token = body.get("access_token") if isinstance(body, dict) else None
+        if not token:
+            raise CloudError(
+                502, "social.github_token_exchange_failed", "GitHub returned no access token"
+            )
+        return str(token)
+
+    async def _get(self, client: httpx.AsyncClient, token: str, path: str) -> dict[str, Any]:
+        resp = await client.get(
+            f"{_api_base()}{path}",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+            },
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def _verified_email(self, client: httpx.AsyncClient, token: str) -> str | None:
+        """The verified address, or None when GitHub won't vouch for one.
+
+        Never falls back to /user's `email` field. That field is the public
+        profile address — self-asserted and unverified — and treating it as an
+        identity is precisely the takeover path this adapter exists to close.
+        """
+        try:
+            resp = await client.get(
+                f"{_api_base()}/user/emails",
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Accept": "application/vnd.github+json",
+                },
+            )
+        except httpx.HTTPError:
+            logger.warning("github: /user/emails request failed", exc_info=True)
+            return None
+
+        if resp.status_code in (403, 404):
+            # The user declined `user:email`. A normal choice, not an error —
+            # they land on the "sign in with your password, then connect this
+            # account" path.
+            logger.info("github: /user/emails denied (status=%s)", resp.status_code)
+            return None
+        if resp.status_code >= 400:
+            logger.warning("github: /user/emails returned %s", resp.status_code)
+            return None
+
+        rows = resp.json()
+        if not isinstance(rows, list):
+            return None
+        return pick_verified_email(rows)

--- a/ee/pocketpaw_ee/cloud/auth/social/providers/google.py
+++ b/ee/pocketpaw_ee/cloud/auth/social/providers/google.py
@@ -1,0 +1,149 @@
+"""Google social sign-in adapter.
+
+Created 2026-07-29 (AM-2).
+
+Google IS an OIDC provider, so this is thin: it reuses the discovery, token
+exchange and id_token verification already written for enterprise SSO in
+``auth/sso/oidc.py`` (``accounts.google.com`` is already a PROVIDER_PRESETS
+entry there). PKCE and the nonce both apply, unlike GitHub.
+
+Verification comes from the ``email_verified`` claim inside the SIGNED id_token
+— not from the userinfo endpoint and not from the mere presence of an ``email``
+claim. An unverified Google address is refused the same way an unverified
+GitHub one is: the identity is returned with ``email=None`` and the service
+turns that into a refusal rather than a link.
+
+These credentials are separate from the OSS Drive connector's
+``GOOGLE_OAUTH_CLIENT_ID/SECRET`` in ``src/pocketpaw/config.py`` — that one is a
+per-install data integration, this is cloud sign-in.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from urllib.parse import urlencode
+
+from pocketpaw_ee.cloud._core.errors import CloudError
+from pocketpaw_ee.cloud.auth.sso import oidc
+
+from .base import SocialIdentity
+
+logger = logging.getLogger(__name__)
+
+_ISSUER = "https://accounts.google.com"
+_SCOPES = ["openid", "email", "profile"]
+
+
+def _client_id() -> str:
+    return os.environ.get("POCKETPAW_GOOGLE_OAUTH_CLIENT_ID", "").strip()
+
+
+def _client_secret() -> str:
+    return os.environ.get("POCKETPAW_GOOGLE_OAUTH_CLIENT_SECRET", "").strip()
+
+
+def identity_from_claims(claims: dict) -> SocialIdentity:
+    """Map verified id_token claims onto a SocialIdentity.
+
+    Split out from the network path so the verification rule is testable
+    without standing up a fake Google.
+
+    `sub` is the match key: it is Google's stable per-account identifier and
+    survives the user changing their email. Matching on the email itself would
+    hand the account to whoever next owns that address.
+    """
+    sub = claims.get("sub")
+    if not sub:
+        raise CloudError(502, "social.google_no_subject", "Google id_token carried no sub claim")
+
+    raw_email = claims.get("email")
+    # The claim is a real boolean in Google's id_token. Anything else — absent,
+    # a string, null — is not an assertion of verification, so it is not one.
+    verified = claims.get("email_verified") is True
+    email = str(raw_email).lower() if (verified and isinstance(raw_email, str)) else None
+
+    if raw_email and not verified:
+        logger.info("google: refusing to trust an unverified email claim for sub=%s", sub)
+
+    return SocialIdentity(
+        provider="google",
+        account_id=str(sub),
+        email=email,
+        full_name=str(claims.get("name") or ""),
+        avatar=str(claims.get("picture") or ""),
+    )
+
+
+class GoogleProvider:
+    name = "google"
+
+    def is_configured(self) -> bool:
+        return bool(_client_id() and _client_secret())
+
+    def authorize_url(
+        self,
+        *,
+        state: str,
+        redirect_uri: str,
+        code_challenge: str | None = None,
+        nonce: str | None = None,
+    ) -> str:
+        params = {
+            "response_type": "code",
+            "client_id": _client_id(),
+            "redirect_uri": redirect_uri,
+            "scope": " ".join(_SCOPES),
+            "state": state,
+            # Always show the chooser: a shared browser must not silently sign
+            # in whichever Google account was last used.
+            "prompt": "select_account",
+        }
+        if nonce:
+            params["nonce"] = nonce
+        if code_challenge:
+            params["code_challenge"] = code_challenge
+            params["code_challenge_method"] = "S256"
+        # Discovery would give us this, but the authorize endpoint is stable and
+        # this keeps the redirect off the network path.
+        return f"https://accounts.google.com/o/oauth2/v2/auth?{urlencode(params)}"
+
+    async def exchange(
+        self,
+        *,
+        code: str,
+        redirect_uri: str,
+        code_verifier: str | None = None,
+        nonce: str | None = None,
+    ) -> SocialIdentity:
+        discovery = await oidc.discover(_ISSUER, "google")
+        token_endpoint = discovery.get("token_endpoint")
+        jwks_uri = discovery.get("jwks_uri")
+        if not token_endpoint or not jwks_uri:
+            raise CloudError(
+                502, "social.google_discovery_incomplete", "Google discovery doc was incomplete"
+            )
+
+        tokens = await oidc.exchange_code(
+            token_endpoint,
+            code,
+            _client_id(),
+            _client_secret(),
+            redirect_uri,
+            code_verifier=code_verifier,
+        )
+        id_token = tokens.get("id_token")
+        if not id_token:
+            raise CloudError(
+                502, "social.google_no_id_token", "Google returned no id_token"
+            )
+
+        # Verifies RS256 signature, audience, issuer, expiry, and the nonce.
+        claims = await oidc.parse_id_token(
+            id_token,
+            jwks_uri,
+            audience=_client_id(),
+            issuer=_ISSUER,
+            nonce=nonce,
+        )
+        return identity_from_claims(claims)

--- a/ee/pocketpaw_ee/cloud/auth/social/providers/google.py
+++ b/ee/pocketpaw_ee/cloud/auth/social/providers/google.py
@@ -134,9 +134,7 @@ class GoogleProvider:
         )
         id_token = tokens.get("id_token")
         if not id_token:
-            raise CloudError(
-                502, "social.google_no_id_token", "Google returned no id_token"
-            )
+            raise CloudError(502, "social.google_no_id_token", "Google returned no id_token")
 
         # Verifies RS256 signature, audience, issuer, expiry, and the nonce.
         claims = await oidc.parse_id_token(

--- a/ee/pocketpaw_ee/cloud/auth/social/router.py
+++ b/ee/pocketpaw_ee/cloud/auth/social/router.py
@@ -106,9 +106,7 @@ def _error_redirect(reason: str) -> RedirectResponse:
     scope needs the dialog back with an explanation, so that is where they go.
     """
     base = social_service.frontend_base_url()
-    return RedirectResponse(
-        url=f"{base}/?auth=signin&auth_error={quote(reason)}", status_code=302
-    )
+    return RedirectResponse(url=f"{base}/?auth=signin&auth_error={quote(reason)}", status_code=302)
 
 
 @router.get("/auth/social/providers", response_model=SocialProvidersResponse)
@@ -146,9 +144,7 @@ def _link_redirect(next_path: Any, **params: str) -> RedirectResponse:
     base = social_service.frontend_base_url()
     path = _safe_next(next_path)
     separator = "&" if "?" in path else "?"
-    return RedirectResponse(
-        url=f"{base}{path}{separator}{urlencode(params)}", status_code=302
-    )
+    return RedirectResponse(url=f"{base}{path}{separator}{urlencode(params)}", status_code=302)
 
 
 def _desktop_link_redirect(**params: str) -> RedirectResponse:
@@ -212,9 +208,7 @@ async def social_callback(
         # who it is, so the identity is parked and the app finishes the job
         # from POST /auth/social/link/complete under its bearer. The webview
         # recognises `link=` (the login branch uses `xc=`) and closes.
-        return _desktop_link_redirect(
-            link=result["link_code"], provider=result["provider"]
-        )
+        return _desktop_link_redirect(link=result["link_code"], provider=result["provider"])
 
     if result["mode"] == "link":
         # Web link. Already authenticated — no session to mint, nothing to set.
@@ -283,9 +277,7 @@ async def list_social_identities(
 ) -> SocialIdentitiesResponse:
     """Which provider identities are attached to the caller's own account."""
     rows = await social_service.list_identities(user)
-    return SocialIdentitiesResponse(
-        identities=[LinkedIdentity.model_validate(row) for row in rows]
-    )
+    return SocialIdentitiesResponse(identities=[LinkedIdentity.model_validate(row) for row in rows])
 
 
 @router.post("/auth/social/{provider}/link", response_model=SocialLinkStartResponse)

--- a/ee/pocketpaw_ee/cloud/auth/social/router.py
+++ b/ee/pocketpaw_ee/cloud/auth/social/router.py
@@ -1,0 +1,363 @@
+"""Social sign-in routes — the public OAuth dance for Google and GitHub.
+
+Created 2026-07-29 (AM-2/AM-3/AM-4/AM-5).
+
+Updated 2026-08-01 (AM-6): the connected-accounts surface — list, link, unlink,
+and the desktop link completion. Those four are the exception to the paragraph
+below and MUST carry ``current_active_user``. They act on the caller's own credentials, so the
+identity has to come from the session and from nowhere else: a link endpoint
+that took its target user from a path or body parameter would let anyone
+attach their own Google account to any user id they can name, which is an
+account-takeover primitive, not a settings page.
+
+Every OTHER route here is unauthenticated by necessity: the caller has no
+session yet, which is the entire point. That makes the single-use ``state``
+from ``auth/_oauth_state.py`` the load-bearing defence — see that module for
+why it is server-side rather than a signed token.
+
+Failures redirect rather than return JSON. These endpoints are reached by a
+full-page browser navigation back from the provider, so a JSON error body would
+render as raw text in the address bar. A refusal goes back to the app with the
+dialog reopened and the reason attached (``/?auth=signin&auth_error=<code>``),
+because ``auth.unverified_link`` is a normal outcome for a careful user who
+declined an email scope, not a malfunction.
+
+Every redirect out of here is ABSOLUTE against the frontend origin. A relative
+one resolves against the API origin, which only coincides with the app when both
+are served from a single domain.
+
+Two client shapes finish differently, decided by the ``flow`` pinned into the
+state payload at authorize time — never read from the callback's query string,
+which is attacker-influenced:
+
+  * **web** — mint the cookie session and redirect into the app.
+  * **desktop** — redirect to the SPA's /oauth-callback carrying a one-time
+    exchange CODE, which the app trades at POST /auth/social/exchange for a
+    bearer. The redirect never carries the token itself; a token in a URL leaks
+    through history, Referer, window titles, and proxy logs.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from urllib.parse import quote, urlencode
+
+from fastapi import APIRouter, Depends, Request
+from starlette.responses import RedirectResponse, Response
+
+from pocketpaw_ee.cloud._core.errors import CloudError
+from pocketpaw_ee.cloud._core.rate_limit import rate_limit_social_exchange
+from pocketpaw_ee.cloud.auth._login_helpers import mint_and_record
+from pocketpaw_ee.cloud.auth.core import (
+    bearer_backend,
+    cookie_backend,
+    current_active_user,
+    current_optional_user,
+)
+from pocketpaw_ee.cloud.auth.social import service as social_service
+from pocketpaw_ee.cloud.auth.social.dto import (
+    LinkedIdentity,
+    SocialExchangeRequest,
+    SocialIdentitiesResponse,
+    SocialLinkCompleteRequest,
+    SocialLinkCompleteResponse,
+    SocialLinkStartResponse,
+    SocialProvidersResponse,
+)
+from pocketpaw_ee.cloud.auth.social.providers import configured_providers
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["Social auth"])
+
+
+def _safe_next(next_path: Any) -> str:
+    """Reduce a caller-supplied ``next`` to a same-origin relative path.
+
+    The frontend validates this at parse time, but both endpoints that read it
+    are reachable directly, so it is re-checked rather than trusted. A single
+    leading slash and no backslash rules out absolute and protocol-relative
+    targets — the two shapes that turn a redirect into an open redirect.
+    """
+    if (
+        isinstance(next_path, str)
+        and next_path.startswith("/")
+        and not next_path.startswith("//")
+        and "\\" not in next_path
+    ):
+        return next_path
+    return "/"
+
+
+def _error_redirect(reason: str) -> RedirectResponse:
+    """Send a refusal back into the app with the dialog open and the reason.
+
+    Two things were wrong with the previous `/auth/error?reason=` target, both
+    found on the first live Google run:
+
+      * it was a RELATIVE path, so it resolved against the BACKEND origin. In
+        any split-origin setup (locally the SPA is :1420 and the API is :8888)
+        that lands the user on the API, not the app.
+      * the SPA has no /auth/error route at all — only forgot, reset, verify.
+        So the refusal was a dead end pointing at a 404.
+
+    A refusal is a UI state, not an error page: the user who declined an email
+    scope needs the dialog back with an explanation, so that is where they go.
+    """
+    base = social_service.frontend_base_url()
+    return RedirectResponse(
+        url=f"{base}/?auth=signin&auth_error={quote(reason)}", status_code=302
+    )
+
+
+@router.get("/auth/social/providers", response_model=SocialProvidersResponse)
+async def list_providers() -> SocialProvidersResponse:
+    """Which provider buttons the auth dialog should render."""
+    return SocialProvidersResponse(providers=configured_providers())
+
+
+@router.get("/auth/social/{provider}/login")
+async def social_login(
+    provider: str,
+    flow: str = "web",
+    next: str | None = None,  # noqa: A002 — matches the query-param name
+) -> RedirectResponse:
+    """Begin consent. Redirects to the provider."""
+    try:
+        url = await social_service.begin_login(provider, flow=flow, next_path=next)
+    except CloudError as exc:
+        return _error_redirect(exc.code)
+    except Exception:  # noqa: BLE001 — discovery / network failure
+        logger.exception("social.begin_login failed for provider=%s", provider)
+        return _error_redirect("social.begin_failed")
+    return RedirectResponse(url=url, status_code=302)
+
+
+def _link_redirect(next_path: Any, **params: str) -> RedirectResponse:
+    """Send a link OUTCOME back to whatever page started it.
+
+    Settings navigates the whole page away to the provider, so the result has
+    to arrive as a redirect carrying a marker the page reads on mount — the
+    same shape ``?auth=…`` already uses for the sign-in dialog. ``next`` is the
+    page that started the link, run through the same validator as the sign-in
+    path, so a hostile value degrades to "/" instead of leaving the origin.
+    """
+    base = social_service.frontend_base_url()
+    path = _safe_next(next_path)
+    separator = "&" if "?" in path else "?"
+    return RedirectResponse(
+        url=f"{base}{path}{separator}{urlencode(params)}", status_code=302
+    )
+
+
+def _desktop_link_redirect(**params: str) -> RedirectResponse:
+    """Send a desktop LINK outcome to the route the Tauri webview watches.
+
+    Always `<frontend>/oauth-callback`, and deliberately ignores ``next``. The
+    webview's whole job is to close and hand back a result; there is no page
+    for it to navigate to, and the Settings panel that opened it is still
+    mounted in the main window. Not interpolating ``next`` here also means the
+    hostile-value problem cannot reach this redirect at all — the safest
+    handling of an attacker-influenced path is not to build one.
+    """
+    base = social_service.frontend_base_url()
+    return RedirectResponse(url=f"{base}/oauth-callback?{urlencode(params)}", status_code=302)
+
+
+@router.get("/auth/social/callback")
+async def social_callback(
+    request: Request,
+    code: str | None = None,
+    state: str | None = None,
+    error: str | None = None,
+    user: Any = Depends(current_optional_user),
+):
+    """Finish consent: redeem the code, apply the policy, then sign in or link.
+
+    Which of those two it is comes from the single-use state payload, never
+    from this request. ``user`` is optional because a sign-in callback has no
+    session by definition — but a LINK callback must have one, and the service
+    refuses when it does not match the account the state names. This dependency
+    is what makes that session visible here; it never rejects anyone itself.
+    """
+    if error:
+        # The user pressed "Cancel" on the provider's consent screen, or the
+        # provider itself refused. Not our failure — send them back to the
+        # dialog rather than an error page that implies something broke.
+        return _error_redirect(error)
+    if not code or not state:
+        return _error_redirect("social.missing_code_or_state")
+
+    try:
+        result = await social_service.complete_callback(code, state, session_user=user)
+    except social_service.LinkRefused as exc:
+        # A link refusal must NOT reopen the sign-in dialog — this user is
+        # already signed in, and prompting them to sign in explains nothing.
+        # The exception carries ``next`` and ``flow`` because the state it came
+        # from has already been consumed, so neither is recoverable here.
+        if exc.flow == "desktop":
+            return _desktop_link_redirect(link_error=exc.code)
+        return _link_redirect(exc.next_path, social_error=exc.code)
+    except CloudError as exc:
+        # Includes the policy refusals (auth.unverified_link,
+        # auth.sso_enforced), which the dialog renders as guidance.
+        return _error_redirect(exc.code)
+    except Exception:  # noqa: BLE001
+        logger.exception("social.complete_callback failed")
+        return _error_redirect("social.callback_failed")
+
+    if result["mode"] == "link_pending":
+        # Desktop link. Nothing has been attached — this webview cannot prove
+        # who it is, so the identity is parked and the app finishes the job
+        # from POST /auth/social/link/complete under its bearer. The webview
+        # recognises `link=` (the login branch uses `xc=`) and closes.
+        return _desktop_link_redirect(
+            link=result["link_code"], provider=result["provider"]
+        )
+
+    if result["mode"] == "link":
+        # Web link. Already authenticated — no session to mint, nothing to set.
+        # Just report the outcome back to the page that started it.
+        return _link_redirect(result.get("next"), social_linked=result["provider"])
+
+    # Desktop: hand back a one-time REFERENCE, never a token. The Tauri client
+    # has no cookie jar we can write to from here, and putting the bearer in
+    # this redirect would leak it through history, Referer, window titles and
+    # any proxy log on the path. The existing /oauth-callback route picks the
+    # code up, emits its Tauri event, and the app trades it below.
+    #
+    # `flow` comes from the single-use state payload, pinned at authorize time
+    # — never from this request's query string.
+    if result["flow"] == "desktop":
+        xc = await social_service.issue_exchange_code(str(result["user"].id))
+        base = social_service.frontend_base_url()
+        return RedirectResponse(url=f"{base}/oauth-callback?xc={quote(xc)}", status_code=302)
+
+    response = await mint_and_record(cookie_backend, result["user"], request)
+
+    safe_next = _safe_next(result.get("next"))
+
+    # Absolute, against the FRONTEND origin. `safe_next` is a relative path, and
+    # a relative redirect from here resolves against the API origin — which is
+    # the same host only when both are served from one domain. In production
+    # they are; in local dev they are not, and the user lands on the API root.
+    redirect = RedirectResponse(
+        url=f"{social_service.frontend_base_url()}{safe_next}", status_code=302
+    )
+    for key, value in response.headers.items():
+        if key.lower() == "set-cookie":
+            redirect.headers.append("set-cookie", value)
+    return redirect
+
+
+@router.post("/auth/social/exchange", dependencies=[Depends(rate_limit_social_exchange)])
+async def social_exchange(body: SocialExchangeRequest, request: Request):
+    """Trade a desktop one-time code for a bearer token.
+
+    Unauthenticated by necessity — this is how a desktop client obtains its
+    FIRST token. The controls are the code itself: 32 bytes of entropy,
+    single-use via GET-then-DEL, a 60-second TTL, and a per-IP rate limit.
+
+    Returns the same body the password bearer login returns, so the client
+    stores it through exactly one code path.
+    """
+    body = SocialExchangeRequest.model_validate(body)
+    user = await social_service.redeem_exchange_code(body.xc)
+    return await mint_and_record(bearer_backend, user, request)
+
+
+# ---------------------------------------------------------------------------
+# Connected accounts (AM-6) — the signed-in half of this router
+# ---------------------------------------------------------------------------
+#
+# All three take ``current_active_user``. The user id is read from that
+# dependency and never from the path or body: the provider name is the only
+# thing a caller gets to choose, so there is no request shape that acts on
+# somebody else's credentials.
+
+
+@router.get("/auth/social/identities", response_model=SocialIdentitiesResponse)
+async def list_social_identities(
+    user: Any = Depends(current_active_user),
+) -> SocialIdentitiesResponse:
+    """Which provider identities are attached to the caller's own account."""
+    rows = await social_service.list_identities(user)
+    return SocialIdentitiesResponse(
+        identities=[LinkedIdentity.model_validate(row) for row in rows]
+    )
+
+
+@router.post("/auth/social/{provider}/link", response_model=SocialLinkStartResponse)
+async def start_social_link(
+    provider: str,
+    flow: str = "web",
+    next: str | None = None,  # noqa: A002 — matches the query-param name
+    user: Any = Depends(current_active_user),
+) -> SocialLinkStartResponse:
+    """Begin consent for an identity that will ATTACH to the caller.
+
+    Returns the URL instead of redirecting: Settings calls this with fetch,
+    where a 302 is followed opaquely by the browser and the page never moves.
+
+    ``flow`` selects how the callback will prove who the caller is — the
+    session cookie for ``web``, a bearer-authorised follow-up call for
+    ``desktop``. A desktop client that omits it gets the web branch, whose
+    cookie check it can never satisfy: consent succeeds and nothing attaches.
+    An unknown value is refused rather than defaulted, for the same reason.
+
+    Errors surface as JSON (``CloudError`` → the shared handler) rather than as
+    the redirects the sign-in routes use, because unlike those this is an XHR
+    with a caller waiting on a response, not a browser navigation.
+    """
+    url = await social_service.begin_link(user, provider, flow=flow, next_path=next)
+    return SocialLinkStartResponse(authorize_url=url)
+
+
+@router.post("/auth/social/link/complete", response_model=SocialLinkCompleteResponse)
+async def complete_social_link(
+    body: SocialLinkCompleteRequest,
+    user: Any = Depends(current_active_user),
+) -> SocialLinkCompleteResponse:
+    """Finish a DESKTOP link by redeeming the code the callback parked.
+
+    This endpoint exists because the desktop client cannot authenticate the
+    callback. It signs in with a bearer held in localStorage, and the Tauri
+    webview that completes consent carries no cookie for this origin — so the
+    callback has no way to tell whose account to attach to, and attaching on
+    the strength of the state alone is precisely the theft the web branch's
+    cookie check exists to prevent.
+
+    The proof therefore moves here, onto a request the app CAN authenticate.
+    The parked record names the account the link was started for, and the
+    service compares it against ``current_active_user``. A stolen code is
+    worth nothing without that account's bearer, which makes the desktop path
+    stronger than the cookie check rather than a concession to it.
+
+    Returns the refreshed identity list so the panel renders the outcome
+    without a second round trip — the window that started this has already
+    closed, and a follow-up refetch that fails would leave the panel stale
+    with no way to explain itself.
+    """
+    body = SocialLinkCompleteRequest.model_validate(body)
+    result = await social_service.complete_pending_link(user, body.code)
+    rows = await social_service.list_identities(result["user"])
+    return SocialLinkCompleteResponse(
+        provider=result["provider"],
+        identities=[LinkedIdentity.model_validate(row) for row in rows],
+    )
+
+
+@router.delete("/auth/social/identities/{provider}", status_code=204)
+async def unlink_social_identity(
+    provider: str,
+    user: Any = Depends(current_active_user),
+) -> Response:
+    """Detach one of the caller's identities.
+
+    409 ``auth.last_credential`` when it is the only way into the account —
+    the service refuses rather than letting a user lock themselves out of an
+    account support cannot restore them to.
+    """
+    await social_service.unlink_identity(user, provider)
+    return Response(status_code=204)

--- a/ee/pocketpaw_ee/cloud/auth/social/service.py
+++ b/ee/pocketpaw_ee/cloud/auth/social/service.py
@@ -1,0 +1,853 @@
+"""Social sign-in orchestration — begin the flow, complete it, apply the policy.
+
+Created 2026-07-29 (AM-2/AM-3/AM-4).
+
+Updated 2026-08-01 (AM-6): the same OAuth dance now serves a SECOND purpose —
+attaching an identity to an account that is already signed in. Both purposes
+land on one callback, so the distinction has to be carried somewhere the
+callback can trust. It is pinned into the single-use state payload as
+``link_user_id`` at authorize time, never inferred from the request.
+
+Two things about the link branch that are load-bearing:
+
+  * **The callback re-checks the session against the pinned id.** State is a
+    bearer secret: whoever presents it wins. For sign-in that costs an
+    attacker at most a session on their own account. For linking it would be
+    worse — completing someone else's link state with your OWN provider
+    account attaches your identity to their account, and you can then sign in
+    as them. Requiring the callback's session to BE the account named in the
+    state removes that, because the state alone stops being enough.
+  * **Desktop links finish somewhere else entirely.** The desktop client
+    authenticates with a bearer from localStorage, and the Tauri webview that
+    completes consent carries no cookie for this origin — so the session
+    re-check above can never pass there, and the callback has no way to
+    authenticate anyone at all. Rather than weaken the check for desktop, the
+    desktop branch attaches NOTHING at the callback: it parks the consented
+    identity behind a one-time code and redirects to ``/oauth-callback``, and
+    the app redeems that code at ``POST /auth/social/link/complete`` under its
+    bearer, where ``current_active_user`` can be compared against the account
+    the link was started for. Same property, moved to a request that can
+    actually carry proof — and strictly stronger, because possession of the
+    parked code is not sufficient without that account's token.
+
+Shape notes against the cloud code rules, since this module deviates twice and
+both are deliberate:
+
+  * **No ``workspace_id`` parameter.** Rule 5's signature assumes a tenant is
+    already known. Sign-in runs *before* that: the caller has no session, and
+    the resulting user may belong to no workspace at all (they land in the
+    /welcome funnel). Tenancy is enforced on every request after this one.
+  * **Global reads.** Resolving an identity to an account is inherently
+    cross-tenant — we are answering "who is this person", not "what may this
+    tenant see". Each such query carries an explicit ``# global-read:`` note.
+
+Everything the callback needs is pinned into the single-use state payload at
+authorize time and read back from there. Nothing on the callback's query string
+is trusted beyond ``code`` and ``state`` themselves, because a callback URL is
+attacker-influenced by definition.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import UTC, datetime
+from typing import Any
+
+from beanie import PydanticObjectId
+
+from pocketpaw_ee.cloud._core.errors import (
+    CloudError,
+    ConflictError,
+    Forbidden,
+    ValidationError,
+)
+from pocketpaw_ee.cloud.auth import _oauth_state
+from pocketpaw_ee.cloud.auth.social import domain
+from pocketpaw_ee.cloud.auth.social.providers import get_provider
+from pocketpaw_ee.cloud.auth.social.providers.base import SocialIdentity
+from pocketpaw_ee.cloud.models.user import OAuthAccount as _OAuthAccount
+from pocketpaw_ee.cloud.models.user import User as _UserDoc
+from pocketpaw_ee.cloud.models.workspace import Workspace as _WorkspaceDoc
+
+logger = logging.getLogger(__name__)
+
+_STATE_NAMESPACE = "social"
+
+#: Flows the callback knows how to finish. Pinned into state at authorize time,
+#: never read from the callback query string.
+_FLOWS = ("web", "desktop")
+
+class LinkRefused(Forbidden):
+    """A refusal from the LINK branch specifically.
+
+    A distinct type rather than a plain ``Forbidden`` so the router can route
+    the outcome without guessing. The two branches need different destinations
+    — a link refusal must not reopen the sign-in dialog at somebody who is
+    already signed in — and "is there a session?" is not a reliable proxy for
+    "was this a link?", since a signed-in user can still reach the sign-in
+    flow.
+
+    It carries ``next_path`` and ``flow`` because the state has already been
+    consumed by the time this is raised, so the router can recover neither.
+    Without ``next_path`` the user is dropped on the app root and the Settings
+    panel that started the flow never gets to explain what happened; without
+    ``flow`` a desktop refusal is sent to a web URL inside a Tauri webview,
+    which is a window that never closes and never says why.
+    """
+
+    def __init__(
+        self,
+        code: str,
+        message: str = "Access denied",
+        *,
+        next_path: str | None = None,
+        flow: str = "web",
+    ) -> None:
+        super().__init__(code, message)
+        self.next_path = next_path
+        self.flow = flow
+
+
+#: Key that marks a state payload as a LINK rather than a sign-in, carrying the
+#: id of the account the identity will be attached to. Its presence is the only
+#: thing that selects the link branch at the callback, and it can only be
+#: written by ``begin_link``, which requires a session.
+_LINK_KEY = "link_user_id"
+
+#: Namespace + TTL for the desktop PENDING LINK code (AM-6 desktop).
+#: Sibling of the exchange code below and deliberately a different namespace:
+#: one is redeemed for a token, the other authorises attaching an identity, and
+#: they must not be interchangeable. Same 60s reasoning.
+_LINK_XC_NAMESPACE = "social_link_xc"
+_LINK_XC_TTL_SECONDS = 60
+
+#: Namespace + TTL for the desktop one-time exchange code (AM-5).
+#: Sixty seconds is generous for "redirect fires, Tauri window emits, app
+#: POSTs" and short enough that a code lifted from shell history or a proxy
+#: log is dead before it is useful.
+_XC_NAMESPACE = "social_xc"
+_XC_TTL_SECONDS = 60
+
+
+def redirect_uri() -> str:
+    explicit = os.environ.get("POCKETPAW_SOCIAL_REDIRECT_URI", "").strip()
+    if explicit:
+        return explicit
+    base = os.environ.get("POCKETPAW_PUBLIC_BASE_URL", "http://localhost:8888").rstrip("/")
+    return f"{base}/api/v1/auth/social/callback"
+
+
+def frontend_base_url() -> str:
+    """Where the SPA lives.
+
+    The desktop branch bounces through the FRONTEND origin, not the backend:
+    /oauth-callback is a SvelteKit route served by Vite/Tauri on :1420, and
+    redirecting to the backend origin would land on nothing. Same variable the
+    codeconnect GitHub callback already uses.
+    """
+    return os.environ.get("POCKETPAW_FRONTEND_BASE_URL", "http://localhost:1420").rstrip("/")
+
+
+# ---------------------------------------------------------------------------
+# Begin
+# ---------------------------------------------------------------------------
+
+
+def _usable_provider(provider_name: str):
+    """Resolve a provider this deployment can actually complete a flow with."""
+    provider = get_provider(provider_name)
+    if provider is None:
+        raise ValidationError("social.unknown_provider", f"Unknown provider: {provider_name}")
+    if not provider.is_configured():
+        # Operational, not a bug: this deployment has no credentials for it.
+        raise CloudError(
+            503,
+            "social.provider_not_configured",
+            f"{provider.name} sign-in is not configured on this server",
+        )
+    return provider
+
+
+async def _issue_authorize_url(provider, *, extra: dict[str, Any]) -> str:
+    """Mint the PKCE pair + state, and return where to send the browser.
+
+    ``extra`` is folded into the state payload. Shared by sign-in and linking
+    so the two cannot drift on the parts that make state safe — a link flow
+    that quietly lost PKCE or the nonce would still work, and still be wrong.
+    """
+    verifier, challenge = _oauth_state.pkce_pair()
+    nonce = _oauth_state.new_nonce()
+    state = await _oauth_state.issue(
+        _STATE_NAMESPACE,
+        {**extra, "code_verifier": verifier, "nonce": nonce},
+    )
+    return provider.authorize_url(
+        state=state,
+        redirect_uri=redirect_uri(),
+        code_challenge=challenge,
+        nonce=nonce,
+    )
+
+
+async def begin_login(
+    provider_name: str, *, flow: str = "web", next_path: str | None = None
+) -> str:
+    """Build the provider's authorize URL and persist the flow state."""
+    provider = _usable_provider(provider_name)
+    if flow not in _FLOWS:
+        raise ValidationError("social.unknown_flow", f"Unknown flow: {flow}")
+
+    return await _issue_authorize_url(
+        provider,
+        extra={
+            "provider": provider.name,
+            "flow": flow,
+            "next": next_path or "",
+        },
+    )
+
+
+async def begin_link(
+    user: _UserDoc,
+    provider_name: str,
+    *,
+    flow: str = "web",
+    next_path: str | None = None,
+) -> str:
+    """Begin an OAuth flow that ATTACHES the result to ``user``.
+
+    ``user`` comes from the route's session dependency, and its id is pinned
+    into the state. What happens at the callback then depends on ``flow``,
+    because the two clients prove who they are by different means:
+
+      * **web** — the callback carries the session cookie, so it re-checks the
+        cookie against the pinned id and attaches there and then.
+      * **desktop** — the callback carries NOTHING. The Tauri client
+        authenticates with a bearer from localStorage, and a webview opened at
+        the provider has no cookie for our origin (verified: the desktop login
+        path returns a token and sets no cookie at all). So the callback
+        cannot authenticate anyone, does not attach, and instead parks the
+        identity behind a one-time code the app redeems from
+        ``POST /auth/social/link/complete`` with its bearer.
+
+    Unknown flows are refused rather than defaulted. Silently falling back to
+    "web" would send a desktop client down the branch whose session check it
+    can never satisfy, and the symptom — a webview that consents successfully
+    and then does nothing — looks like a frontend bug for as long as it takes
+    someone to read this function.
+
+    The SSO check runs here as well as at the callback. It is not redundant:
+    at the callback a refusal is a redirect the user reads after a round trip
+    through the provider, whereas here it is an immediate, explainable error
+    in the Settings panel before they hand any consent to Google.
+    """
+    provider = _usable_provider(provider_name)
+    if flow not in _FLOWS:
+        raise ValidationError("social.unknown_flow", f"Unknown flow: {flow}")
+
+    if await _sso_enforced_for(user):
+        raise Forbidden(
+            domain.REFUSE_SSO_ENFORCED,
+            "Your workspace requires signing in through its identity provider, "
+            "so accounts cannot be connected here.",
+        )
+
+    return await _issue_authorize_url(
+        provider,
+        extra={
+            "provider": provider.name,
+            # Pinned into the state, never read off the callback's query
+            # string — a callback URL is attacker-influenced, and this value
+            # selects which proof-of-identity the callback demands.
+            "flow": flow,
+            "next": next_path or "",
+            _LINK_KEY: str(user.id),
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lookups (pre-tenant by nature)
+# ---------------------------------------------------------------------------
+
+
+async def _find_by_oauth_account(provider: str, account_id: str) -> _UserDoc | None:
+    # global-read: resolving "which account owns this provider identity" is a
+    # pre-tenant identity question; there is no workspace to scope it to.
+    return await _UserDoc.find_one(
+        {"oauth_accounts.oauth_name": provider, "oauth_accounts.account_id": account_id}
+    )
+
+
+async def _find_by_email(email: str) -> _UserDoc | None:
+    # global-read: same — an email identifies a person across all tenants.
+    return await _UserDoc.find_one(_UserDoc.email == email.lower())
+
+
+async def _sso_enforced_for(user: _UserDoc) -> bool:
+    """Whether any workspace this user belongs to mandates SSO.
+
+    Fails CLOSED: if the workspace lookup errors we treat SSO as enforced
+    rather than waving the login through, because the failure mode of guessing
+    wrong is "the enterprise control we sell has a bypass".
+    """
+    # WorkspaceMembership.workspace is a STRING id; _id is an ObjectId. Querying
+    # $in with the raw strings matches nothing, which would silently disable
+    # this guard entirely rather than fail loudly. Caught by
+    # test_enforced_sso_refuses_social_sign_in.
+    ids: list[PydanticObjectId] = []
+    for m in user.workspaces or []:
+        try:
+            ids.append(PydanticObjectId(m.workspace))
+        except Exception:  # noqa: BLE001 — a malformed id cannot match anything
+            logger.warning("social: skipping unparseable workspace id on user %s", user.id)
+    if not ids:
+        return False
+    try:
+        # global-read: the user's own memberships, resolved by id.
+        async for ws in _WorkspaceDoc.find({"_id": {"$in": ids}}):
+            cfg = getattr(ws, "sso_config", None)
+            if cfg is not None and getattr(cfg, "enforced", False):
+                return True
+    except Exception:  # noqa: BLE001 — see docstring; fail closed
+        logger.exception("social: SSO enforcement check failed; refusing")
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Complete
+# ---------------------------------------------------------------------------
+
+
+async def complete_callback(
+    code: str, state: str, *, session_user: _UserDoc | None = None
+) -> dict[str, Any]:
+    """Redeem the callback and return ``{mode, user, flow, next}``.
+
+    ``mode`` is ``"login"`` or ``"link"``, decided by the state payload alone —
+    the callback's query string is attacker-influenced and says nothing about
+    which flow this is.
+
+    ``session_user`` is the account (if any) whose cookie arrived with the
+    callback. Ignored for sign-in, where by definition there is no session yet;
+    required to match for a link.
+
+    Raises ``Forbidden`` with a ``domain.REFUSE_*`` code when policy refuses;
+    the router turns that into the error redirect the dialog renders as
+    guidance rather than as a failure.
+    """
+    payload = await _oauth_state.consume(_STATE_NAMESPACE, state)
+
+    provider_name = str(payload.get("provider") or "")
+    provider = get_provider(provider_name)
+    if provider is None:
+        raise Forbidden("social.invalid_state", "Login state named an unknown provider")
+
+    flow = payload.get("flow") if payload.get("flow") in _FLOWS else "web"
+    next_path = str(payload.get("next") or "") or None
+
+    link_user_id = str(payload.get(_LINK_KEY) or "")
+
+    try:
+        identity = await provider.exchange(
+            code=code,
+            redirect_uri=redirect_uri(),
+            code_verifier=payload.get("code_verifier"),
+            nonce=payload.get("nonce"),
+        )
+    except Exception as exc:  # noqa: BLE001 — provider / network failure
+        if not link_user_id:
+            raise
+        # A LINK that dies here still has to land somewhere its client can act
+        # on. Re-raised as LinkRefused carrying the flow, so a desktop webview
+        # gets a URL it closes on instead of the sign-in dialog it cannot use.
+        logger.exception("social: provider exchange failed during a %s link", flow)
+        raise LinkRefused(
+            "social.callback_failed",
+            "We couldn't finish connecting that account. Try again.",
+            next_path=next_path,
+            flow=flow,
+        ) from exc
+
+    if link_user_id:
+        if flow == "desktop":
+            # Attach NOTHING here. This request arrived from a Tauri webview,
+            # which holds no cookie for our origin — the desktop client
+            # authenticates with a bearer that a provider redirect cannot
+            # carry. There is therefore no way to authenticate the acting user
+            # at this point, and attaching on the strength of the state alone
+            # is exactly the theft the web branch's session check exists to
+            # prevent. Park it instead; the app redeems it under its bearer.
+            link_code = await _park_pending_link(link_user_id, identity)
+            return {
+                "mode": "link_pending",
+                "user": None,
+                "provider": identity.provider,
+                "link_code": link_code,
+                "flow": "desktop",
+                "next": next_path,
+            }
+        user = await _complete_link(
+            link_user_id, identity, session_user, next_path=next_path
+        )
+        return {
+            "mode": "link",
+            "user": user,
+            "provider": identity.provider,
+            "flow": "web",
+            "next": next_path,
+        }
+
+    user = await _resolve_user(identity)
+    return {
+        "mode": "login",
+        "user": user,
+        "provider": identity.provider,
+        "flow": flow,
+        "next": next_path,
+    }
+
+
+async def _complete_link(
+    link_user_id: str,
+    identity: SocialIdentity,
+    session_user: _UserDoc | None,
+    *,
+    next_path: str | None = None,
+) -> _UserDoc:
+    """Attach ``identity`` to the account that started this link flow.
+
+    The session check is first and is the whole defence: state is a bearer
+    secret, so without it anyone holding a stolen link state could attach
+    their own provider account to the victim's and sign in as them
+    afterwards. With it, an attacker needs the victim's session too — at
+    which point they no longer need this endpoint.
+    """
+    if session_user is None or str(session_user.id) != link_user_id:
+        logger.warning(
+            "social: link callback session mismatch (state named %s, session is %s)",
+            link_user_id,
+            None if session_user is None else session_user.id,
+        )
+        raise LinkRefused(
+            domain.REFUSE_LINK_SESSION_MISMATCH,
+            "Sign in and start connecting the account again.",
+            next_path=next_path,
+        )
+
+    return await _apply_link_policy(session_user, identity, next_path=next_path)
+
+
+async def _apply_link_policy(
+    user: _UserDoc, identity: SocialIdentity, *, next_path: str | None = None
+) -> _UserDoc:
+    """Decide and perform the attach, for an ALREADY-AUTHENTICATED ``user``.
+
+    Shared by both clients on purpose. Web reaches it from the callback after
+    a cookie check; desktop reaches it from ``complete_pending_link`` after a
+    bearer check. Everything past "who is this, provably" is identical, and
+    keeping it in one function is what stops the desktop path quietly growing
+    a weaker version of the takeover and SSO rules.
+    """
+    owner = await _find_by_oauth_account(identity.provider, identity.account_id)
+    decision = domain.decide_link(
+        identity=identity,
+        owner_user_id=str(owner.id) if owner else None,
+        acting_user_id=str(user.id),
+    )
+    decision = domain.apply_sso_guard(decision, enforced=await _sso_enforced_for(user))
+
+    if decision.refused:
+        logger.info(
+            "social: refused to link %s identity to user %s reason=%s",
+            identity.provider,
+            user.id,
+            decision.reason,
+        )
+        await _audit(
+            user,
+            "auth.social.link_refused",
+            identity.provider,
+            reason=decision.reason or "",
+        )
+        raise LinkRefused(
+            decision.reason or domain.REFUSE_UNVERIFIED,
+            _link_refusal_message(decision),
+            next_path=next_path,
+        )
+
+    if decision.action == "noop":
+        return user
+
+    linked = await _attach_account(user, identity)
+    await _audit(linked, "auth.social.linked", identity.provider)
+    return linked
+
+
+# ---------------------------------------------------------------------------
+# Desktop link handoff — park at the callback, redeem under the bearer
+# ---------------------------------------------------------------------------
+
+
+async def _park_pending_link(link_user_id: str, identity: SocialIdentity) -> str:
+    """Stash a consented-but-unattached identity behind a one-time code.
+
+    Holds the identity fields rather than a re-runnable provider code: the
+    authorization code is single-use and already spent by the time we get
+    here, so there is nothing to replay even if this record leaked.
+
+    And a leaked code buys nothing on its own. Redemption requires an
+    authenticated caller who IS ``link_user_id`` — so unlike the web
+    callback, where possession of the state was the only thing standing
+    between an attacker and an attach, here possession is not sufficient at
+    all. That makes this handoff strictly stronger than the cookie check it
+    replaces, not a relaxation of it for desktop's convenience.
+    """
+    return await _oauth_state.issue(
+        _LINK_XC_NAMESPACE,
+        {
+            _LINK_KEY: link_user_id,
+            "provider": identity.provider,
+            "account_id": identity.account_id,
+            "email": identity.email or "",
+            "full_name": identity.full_name or "",
+            "avatar": identity.avatar or "",
+        },
+        ttl_seconds=_LINK_XC_TTL_SECONDS,
+    )
+
+
+async def complete_pending_link(user: _UserDoc, link_code: str) -> dict[str, Any]:
+    """Finish a desktop link: redeem the parked identity as ``user``.
+
+    ``user`` comes from the route's ``current_active_user`` dependency, which
+    the desktop client satisfies with its bearer. That is the whole point of
+    this endpoint existing — it moves the "prove you are the account this link
+    was started for" check off the callback, which desktop cannot satisfy, and
+    onto a request it can.
+
+    The pinned-id comparison is the same property the web callback enforces
+    against the cookie, so neither client can attach an identity to an account
+    that is not theirs.
+    """
+    payload = await _oauth_state.consume(_LINK_XC_NAMESPACE, link_code)
+
+    parked_user_id = str(payload.get(_LINK_KEY) or "")
+    if not parked_user_id or parked_user_id != str(user.id):
+        logger.warning(
+            "social: pending-link redeemed by the wrong account (parked for %s, caller %s)",
+            parked_user_id,
+            user.id,
+        )
+        raise LinkRefused(
+            domain.REFUSE_LINK_SESSION_MISMATCH,
+            "Sign in and start connecting the account again.",
+        )
+
+    try:
+        identity = SocialIdentity(
+            provider=str(payload.get("provider") or ""),
+            account_id=str(payload.get("account_id") or ""),
+            email=str(payload.get("email") or "") or None,
+            full_name=str(payload.get("full_name") or ""),
+            avatar=str(payload.get("avatar") or ""),
+        )
+    except ValueError as exc:
+        # SocialIdentity refuses an empty provider / account_id. A payload that
+        # cannot rebuild one is a corrupt record, not a policy decision.
+        raise LinkRefused(
+            "social.invalid_link_code", "That connection attempt is no longer valid."
+        ) from exc
+
+    linked = await _apply_link_policy(user, identity)
+    return {"user": linked, "provider": identity.provider}
+
+
+def _link_refusal_message(decision: domain.LinkDecision) -> str:
+    if decision.reason == domain.REFUSE_SSO_ENFORCED:
+        return "Your workspace requires signing in through its identity provider."
+    if decision.reason == domain.REFUSE_IDENTITY_CLAIMED:
+        return (
+            "That account is already connected to a different PocketPaw user. "
+            "Disconnect it there first."
+        )
+    return (
+        "We couldn't confirm a verified email from that account. "
+        "Verify your email with the provider, then try again."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Connected accounts (AM-6)
+# ---------------------------------------------------------------------------
+
+
+def _has_usable_password(user: _UserDoc) -> bool:
+    """Whether this account can actually be signed into with a password.
+
+    NOT ``bool(user.hashed_password)``, and the difference is the bug this
+    function exists to prevent. Accounts minted by the social path
+    (``_create_user`` below) and by SSO JIT provisioning (``sso/service.py``)
+    store an UNUSABLE sentinel — ``!social-only-…`` / ``!sso-only-…`` — rather
+    than an empty string, because an empty hash can compare-equal in some
+    verifiers. So the naive truthiness check answers "yes, they have a
+    password" for exactly the population that has none, and would happily let
+    them unlink their only identity and lock themselves out.
+
+    The test is positive rather than a blocklist of known sentinels: pwdlib
+    and passlib hashes are Modular Crypt Format and begin with ``$``
+    (``$argon2id$…``, ``$2b$…``). Anything else is not something we can verify
+    a password against, so a sentinel added later needs no change here. Being
+    wrong in this direction costs a user one refusal they can resolve by
+    setting a password; being wrong in the other direction is permanent.
+    """
+    raw = getattr(user, "hashed_password", "") or ""
+    return raw.startswith("$")
+
+
+async def list_identities(user: _UserDoc) -> list[dict[str, Any]]:
+    """The provider identities attached to ``user``.
+
+    Returns only what the panel renders. The stored row also holds an
+    ``access_token`` field and the provider's account id; neither is echoed,
+    because an endpoint that reads a credential store should hand back the
+    minimum that answers the question asked.
+    """
+    return [
+        {
+            "provider": account.oauth_name,
+            "account_email": account.account_email or "",
+            "linked_at": getattr(account, "linked_at", None),
+        }
+        for account in (user.oauth_accounts or [])
+    ]
+
+
+async def unlink_identity(user: _UserDoc, provider_name: str) -> None:
+    """Detach a provider identity, unless it is the last way in.
+
+    Note what is NOT consulted: whether the user could sign in through their
+    workspace's IdP. An SSO-provisioned member with one linked identity and no
+    password is refused here even though SSO would still let them in. That is
+    a deliberate over-refusal — resolving it means setting a password, whereas
+    guessing wrong the other way means an account nobody can reach.
+    """
+    decision = domain.decide_unlink(
+        provider=provider_name,
+        linked_providers=[a.oauth_name for a in (user.oauth_accounts or [])],
+        has_password=_has_usable_password(user),
+    )
+
+    if not decision.allowed:
+        if decision.reason == domain.REFUSE_NOT_LINKED:
+            # 404 for the status, but the DOMAIN's code on the wire. Building
+            # this as NotFound("social identity", …) produced the code
+            # "social identity.not_found" — NotFound derives it as
+            # f"{resource}.not_found", so the human-readable resource name
+            # became a machine-readable identifier, space and all. Clients then
+            # cannot key on the constant the domain defines for exactly this
+            # refusal, and the frontend had already grown a second lookup entry
+            # to cope. Name the code explicitly instead.
+            raise CloudError(
+                404,
+                domain.REFUSE_NOT_LINKED,
+                f"No {provider_name} account is connected to your profile.",
+            )
+        raise ConflictError(
+            domain.REFUSE_LAST_CREDENTIAL,
+            "That is the only way you can sign in. Set a password, or connect "
+            "another account, before disconnecting this one.",
+        )
+
+    user.oauth_accounts = [
+        a for a in (user.oauth_accounts or []) if a.oauth_name != provider_name
+    ]
+    await user.save()
+    logger.info("social: unlinked %s from user %s", provider_name, user.id)
+    await _audit(user, "auth.social.unlinked", provider_name)
+
+
+async def _audit(user: _UserDoc, action: str, provider: str, **extra: str) -> None:
+    """Best-effort audit row for a credential change.
+
+    Attaching or removing a way into an account is exactly what an audit trail
+    is for. It is skipped for a user with no active workspace because audit
+    rows are workspace-scoped and there is no tenant to file it under — the
+    ``logger`` calls at each site remain the record in that case.
+
+    ``audit_service.record`` never raises, so no failure here can block the
+    credential change that has already been persisted.
+    """
+    workspace_id = getattr(user, "active_workspace", None)
+    if not workspace_id:
+        return
+    # Local import: auth.core is imported broadly, and the audit package pulls
+    # in Beanie models the OSS-only startup path has no use for.
+    from pocketpaw_ee.cloud.audit import service as audit_service
+
+    await audit_service.record(
+        str(workspace_id),
+        str(user.id),
+        action,
+        target_type="user",
+        target_id=str(user.id),
+        metadata={"provider": provider, **extra},
+    )
+
+
+async def _resolve_user(identity: SocialIdentity) -> _UserDoc:
+    linked = await _find_by_oauth_account(identity.provider, identity.account_id)
+    # Only ever look up by an address the provider vouched for. `identity.email`
+    # is None unless the adapter verified it, which is what makes this safe.
+    by_email = (
+        await _find_by_email(identity.email)
+        if (linked is None and identity.has_verified_email and identity.email)
+        else None
+    )
+
+    decision = domain.decide(
+        identity=identity,
+        linked_user_id=str(linked.id) if linked else None,
+        email_user_id=str(by_email.id) if by_email else None,
+    )
+
+    target = linked or by_email
+    enforced = await _sso_enforced_for(target) if target is not None else False
+    decision = domain.apply_sso_guard(decision, enforced=enforced)
+
+    if decision.refused:
+        logger.info(
+            "social: refused %s identity (provider_account=%s) reason=%s",
+            identity.provider,
+            identity.account_id,
+            decision.reason,
+        )
+        raise Forbidden(decision.reason or domain.REFUSE_UNVERIFIED, _refusal_message(decision))
+
+    if decision.action == "sign_in":
+        assert linked is not None  # decide() only returns sign_in with a link
+        return linked
+
+    if decision.action == "link":
+        assert by_email is not None
+        return await _attach_account(by_email, identity)
+
+    return await _create_user(identity)
+
+
+def _refusal_message(decision: domain.LinkDecision) -> str:
+    if decision.reason == domain.REFUSE_SSO_ENFORCED:
+        return "Your workspace requires signing in through its identity provider."
+    return (
+        "We couldn't confirm a verified email from that account. "
+        "Sign in with your password, then connect it from Settings."
+    )
+
+
+async def _attach_account(user: _UserDoc, identity: SocialIdentity) -> _UserDoc:
+    """Bind a provider identity to an existing account."""
+    already = any(
+        a.oauth_name == identity.provider and a.account_id == identity.account_id
+        for a in (user.oauth_accounts or [])
+    )
+    if not already:
+        user.oauth_accounts.append(
+            _OAuthAccount(
+                oauth_name=identity.provider,
+                account_id=identity.account_id,
+                account_email=identity.email or "",
+                linked_at=datetime.now(UTC),
+                # We do not keep provider access tokens. Sign-in needs identity,
+                # not ongoing API access; storing a token we never use is
+                # avoidable breach surface. Repo access is codeconnect's job.
+                access_token="",  # noqa: S106 — intentionally empty, not a secret
+            )
+        )
+    if not user.avatar and identity.avatar:
+        user.avatar = identity.avatar
+    if not user.full_name and identity.full_name:
+        user.full_name = identity.full_name
+    await user.save()
+    return user
+
+
+async def _create_user(identity: SocialIdentity) -> _UserDoc:
+    """Create an account from a provider identity.
+
+    ``is_verified=True`` is honest here and only here: we reached this branch
+    because the provider asserted the address is verified.
+
+    ``hashed_password`` gets an unusable sentinel rather than an empty string.
+    An empty hash can compare-equal in some verifier implementations, which
+    would mean "no password set" reads as "any password works".
+    """
+    import secrets
+
+    assert identity.email  # decide() only returns create with a verified email
+
+    user = _UserDoc(
+        email=identity.email.lower(),
+        hashed_password="!social-only-" + secrets.token_urlsafe(48),
+        is_active=True,
+        is_verified=True,
+        is_superuser=False,
+        full_name=identity.full_name or "",
+        avatar=identity.avatar or "",
+        oauth_accounts=[
+            _OAuthAccount(
+                oauth_name=identity.provider,
+                account_id=identity.account_id,
+                account_email=identity.email,
+                linked_at=datetime.now(UTC),
+                access_token="",  # noqa: S106 — see _attach_account
+            )
+        ],
+        last_seen=datetime.now(UTC),
+    )
+    await user.insert()
+    logger.info("social: created account for %s via %s", user.email, identity.provider)
+    return user
+
+
+# ---------------------------------------------------------------------------
+# Desktop exchange code (AM-5)
+# ---------------------------------------------------------------------------
+
+
+async def issue_exchange_code(user_id: str) -> str:
+    """Mint a single-use code the desktop client trades for a bearer token.
+
+    The redirect carries THIS, never a token. A token in a URL leaks through
+    browser history, Referer headers, window titles, and any proxy log on the
+    path; a 60-second single-use reference does not, and is worthless the
+    instant it has been redeemed.
+    """
+    return await _oauth_state.issue(
+        _XC_NAMESPACE, {"user_id": user_id}, ttl_seconds=_XC_TTL_SECONDS
+    )
+
+
+async def redeem_exchange_code(xc: str) -> _UserDoc:
+    """Consume an exchange code and return its user.
+
+    Raises ``Forbidden`` on anything unexpected: unknown, already spent,
+    expired, or naming an account that has since been deactivated. The state
+    store's GET-then-DEL means two concurrent redemptions cannot both win.
+    """
+    payload = await _oauth_state.consume(_XC_NAMESPACE, xc)
+    user_id = payload.get("user_id")
+    if not user_id:
+        raise Forbidden("social.invalid_exchange_code", "Exchange code is not valid")
+
+    try:
+        user = await _UserDoc.get(PydanticObjectId(str(user_id)))
+    except Exception as exc:  # noqa: BLE001 — malformed id is just an invalid code
+        raise Forbidden("social.invalid_exchange_code", "Exchange code is not valid") from exc
+
+    # Re-check liveness at redemption: the account may have been deactivated in
+    # the seconds between the callback and this call.
+    if user is None or not getattr(user, "is_active", False):
+        raise Forbidden("social.invalid_exchange_code", "Exchange code is not valid")
+    return user

--- a/ee/pocketpaw_ee/cloud/auth/social/service.py
+++ b/ee/pocketpaw_ee/cloud/auth/social/service.py
@@ -78,6 +78,7 @@ _STATE_NAMESPACE = "social"
 #: never read from the callback query string.
 _FLOWS = ("web", "desktop")
 
+
 class LinkRefused(Forbidden):
     """A refusal from the LINK branch specifically.
 
@@ -389,9 +390,7 @@ async def complete_callback(
                 "flow": "desktop",
                 "next": next_path,
             }
-        user = await _complete_link(
-            link_user_id, identity, session_user, next_path=next_path
-        )
+        user = await _complete_link(link_user_id, identity, session_user, next_path=next_path)
         return {
             "mode": "link",
             "user": user,
@@ -661,9 +660,7 @@ async def unlink_identity(user: _UserDoc, provider_name: str) -> None:
             "another account, before disconnecting this one.",
         )
 
-    user.oauth_accounts = [
-        a for a in (user.oauth_accounts or []) if a.oauth_name != provider_name
-    ]
+    user.oauth_accounts = [a for a in (user.oauth_accounts or []) if a.oauth_name != provider_name]
     await user.save()
     logger.info("social: unlinked %s from user %s", provider_name, user.id)
     await _audit(user, "auth.social.unlinked", provider_name)

--- a/ee/pocketpaw_ee/cloud/auth/sso/service.py
+++ b/ee/pocketpaw_ee/cloud/auth/sso/service.py
@@ -4,13 +4,16 @@ State storage uses the shared Redis client (one-shot consume: GET then
 DEL) with a 10-minute TTL. The state key payload pins ``workspace_id``
 + optional PKCE ``code_verifier`` so the callback rebinds to the right
 workspace + verifier without trusting any query-string value.
+
+2026-07-29 (AM-1): the state machinery moved to ``auth/_oauth_state.py`` so the
+consumer social flow (Google / GitHub) reuses it instead of growing a second,
+subtly different copy. Behaviour here is unchanged — same ``sso_state:`` key
+prefix, same 600s TTL, same ``sso.invalid_state`` error code — so existing
+states in flight across a deploy still redeem.
 """
 
 from __future__ import annotations
 
-import base64
-import hashlib
-import json
 import logging
 import os
 import secrets
@@ -21,9 +24,9 @@ from urllib.parse import urlencode
 import httpx
 from beanie import PydanticObjectId
 
-from pocketpaw_ee.cloud._core import redis_client
 from pocketpaw_ee.cloud._core.errors import Forbidden, NotFound, ValidationError
 from pocketpaw_ee.cloud.audit import service as audit_service
+from pocketpaw_ee.cloud.auth import _oauth_state
 from pocketpaw_ee.cloud.auth.sso import crypto, oidc
 from pocketpaw_ee.cloud.models.user import User as _UserDoc
 from pocketpaw_ee.cloud.models.user import WorkspaceMembership as _Membership
@@ -32,12 +35,9 @@ from pocketpaw_ee.cloud.models.workspace import Workspace as _WorkspaceDoc
 
 logger = logging.getLogger(__name__)
 
-_STATE_TTL_SECONDS = 600
-_STATE_KEY_PREFIX = "sso_state:"
-
-
-def _state_key(state: str) -> str:
-    return f"{_STATE_KEY_PREFIX}{state}"
+#: Namespace for the shared state store. Produces the historical
+#: ``sso_state:<state>`` Redis key and the ``sso.invalid_state`` error code.
+_STATE_NAMESPACE = "sso"
 
 
 def _resolve_issuer(provider: str, issuer: str | None) -> str:
@@ -62,11 +62,9 @@ def _frontend_root() -> str:
     return os.environ.get("POCKETPAW_FRONTEND_BASE_URL", "/").rstrip("/") or "/"
 
 
-def _pkce_pair() -> tuple[str, str]:
-    verifier = base64.urlsafe_b64encode(secrets.token_bytes(32)).decode("ascii").rstrip("=")
-    digest = hashlib.sha256(verifier.encode("ascii")).digest()
-    challenge = base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
-    return verifier, challenge
+#: Re-exported for callers/tests that referenced the private helper here before
+#: it moved to the shared module in AM-1.
+_pkce_pair = _oauth_state.pkce_pair
 
 
 # ---------------------------------------------------------------------------
@@ -175,15 +173,13 @@ async def begin_login(workspace_slug: str) -> str:
         "scopes", ["openid", "email", "profile"]
     )
 
-    state = secrets.token_urlsafe(32)
-    verifier, challenge = _pkce_pair()
-    nonce = secrets.token_urlsafe(32)
+    verifier, challenge = _oauth_state.pkce_pair()
+    nonce = _oauth_state.new_nonce()
 
-    payload = json.dumps(
-        {"workspace_id": str(workspace.id), "code_verifier": verifier, "nonce": nonce}
+    state = await _oauth_state.issue(
+        _STATE_NAMESPACE,
+        {"workspace_id": str(workspace.id), "code_verifier": verifier, "nonce": nonce},
     )
-    redis = redis_client.get_redis()
-    await redis.setex(_state_key(state), _STATE_TTL_SECONDS, payload)
 
     params = {
         "response_type": "code",
@@ -199,16 +195,7 @@ async def begin_login(workspace_slug: str) -> str:
 
 
 async def _consume_state(state: str) -> dict[str, Any]:
-    redis = redis_client.get_redis()
-    key = _state_key(state)
-    raw = await redis.get(key)
-    if raw is None:
-        raise Forbidden("sso.invalid_state", "SSO state is missing or expired")
-    await redis.delete(key)
-    try:
-        return json.loads(raw)
-    except (TypeError, ValueError) as exc:
-        raise Forbidden("sso.invalid_state", "SSO state payload is malformed") from exc
+    return await _oauth_state.consume(_STATE_NAMESPACE, state)
 
 
 def _email_domain(email: str) -> str:

--- a/ee/pocketpaw_ee/cloud/memory/mongo_store.py
+++ b/ee/pocketpaw_ee/cloud/memory/mongo_store.py
@@ -313,15 +313,29 @@ class MongoMemoryStore:
         """
         return await Session.find_one(Session.sessionId == session_key)
 
-    async def _load_session_index_async(self) -> dict:
-        """Build a session-index dict from pocket-context Session docs.
+    async def _load_session_index_async(self, *, workspace_id: str, owner_id: str) -> dict:
+        """Build a session-index dict from one owner's pocket-context Sessions.
 
         Shape-compatible with ``FileMemoryStore._load_session_index`` so the
         ``GET /sessions/runtime`` endpoint is backend-agnostic. Returns a mapping
-        ``{sessionId: {title, channel, last_activity, message_count}}`` for all
-        non-deleted pocket sessions.
+        ``{sessionId: {title, channel, last_activity, message_count}}``.
+
+        The scope arguments are REQUIRED (2026-08-01). This index backs a
+        "your sessions" listing, so every read of it is per-owner within a
+        workspace and a deployment-wide variant has no legitimate caller.
+        Mandatory parameters rather than ones defaulting to None mean the
+        unscoped form cannot reappear by omission — a caller that forgets the
+        scope fails to call at all, rather than silently querying across
+        tenants.
         """
-        docs = await Session.find({"context_type": "pocket", "deleted_at": None}).to_list()
+        docs = await Session.find(
+            {
+                "context_type": "pocket",
+                "deleted_at": None,
+                "workspace": workspace_id,
+                "owner": owner_id,
+            }
+        ).to_list()
 
         index: dict[str, dict] = {}
         for doc in docs:

--- a/ee/pocketpaw_ee/cloud/models/user.py
+++ b/ee/pocketpaw_ee/cloud/models/user.py
@@ -1,5 +1,11 @@
 """User and OAuth account models (fastapi-users + Beanie).
 
+Updated: 2026-08-01 (AM-6) — added ``OAuthAccount.linked_at`` so the
+connected-accounts panel can say WHEN an identity was attached. Nullable with
+no default rather than ``default_factory=now``: rows written before this field
+existed have no honest timestamp, and stamping them with "now" on first read
+would invent one. They read back as ``None`` and the UI omits the date.
+
 Updated: 2026-05-21 — added ``home_pocket_id`` so the home page can be
 backed by a per-user "home pocket". Optional (default None) — the auth
 service resolves-or-provisions it lazily; existing users read back as
@@ -16,9 +22,13 @@ from pydantic import BaseModel, Field
 
 
 class OAuthAccount(BaseOAuthAccount):
-    """OAuth account linked to a User (Google, GitHub, etc.)."""
+    """OAuth account linked to a User (Google, GitHub, etc.).
 
-    pass
+    ``linked_at`` is ours, not fastapi-users'. See the module docstring for why
+    it is nullable instead of defaulting to now.
+    """
+
+    linked_at: datetime | None = None
 
 
 class WorkspaceMembership(BaseModel):

--- a/ee/pocketpaw_ee/cloud/sessions/router.py
+++ b/ee/pocketpaw_ee/cloud/sessions/router.py
@@ -1,4 +1,12 @@
-"""Sessions domain — FastAPI router."""
+"""Sessions domain — FastAPI router.
+
+Updated 2026-08-01: the three ``runtime`` / ``touch`` routes below now resolve
+identity through the same dependencies as every other route in this router, and
+their reads and writes are scoped to that identity. They were the last routes
+here relying on an in-handler decision instead. The invariants are pinned in
+``tests/cloud/sessions/test_runtime_route_auth.py``; the standing per-route
+audit lives in ``tests/cloud/auth/test_route_auth_audit.py``.
+"""
 
 from __future__ import annotations
 
@@ -135,12 +143,23 @@ async def list_pocket_creation_sessions(
     return await _mode_page("pocket_creation", cursor, limit, workspace_id, user_id)
 
 
-@router.get("/runtime")
-async def list_runtime_sessions(limit: int = 50) -> dict:
-    """List sessions from the active memory store's session index.
+@router.get("/runtime", dependencies=[Depends(require_action_any_workspace("session.read_own"))])
+async def list_runtime_sessions(
+    limit: int = 50,
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> dict:
+    """List the CALLER's sessions from the active memory store's index.
 
     Dispatches on the store: MongoMemoryStore exposes an async variant,
     FileMemoryStore a sync one. Stores without either return empty.
+
+    Guard and scope both added 2026-08-01, and both are load-bearing:
+    authenticating the caller without also scoping the store query would still
+    answer with rows that are not theirs. The guard mirrors the sibling listing
+    routes above so every listing in this router answers "the caller's own
+    sessions" the same way, and the store query carries the matching workspace
+    and owner filter.
     """
     from pocketpaw.memory import get_memory_manager
 
@@ -148,8 +167,14 @@ async def list_runtime_sessions(limit: int = 50) -> dict:
     store = manager._store
 
     if hasattr(store, "_load_session_index_async"):
-        index = await store._load_session_index_async()
+        index = await store._load_session_index_async(
+            workspace_id=workspace_id, owner_id=user_id
+        )
     elif hasattr(store, "_load_session_index"):
+        # The file store is single-tenant by construction — it is the OSS /
+        # dedicated-install backend, and a cloud deployment cannot reach this
+        # branch (``verify_cloud_memory_backend`` refuses to boot on anything
+        # but MongoMemoryStore). So there is no tenant to scope to here.
         index = store._load_session_index()
     else:
         return {"sessions": [], "total": 0}
@@ -166,8 +191,19 @@ async def list_runtime_sessions(limit: int = 50) -> dict:
 
 
 @router.post("/runtime/create")
-async def create_runtime_session() -> dict:
-    """Create a new runtime session (no MongoDB — just a session key)."""
+async def create_runtime_session(
+    user_id: str = Depends(current_user_id),  # noqa: ARG001 — identity gate, not input
+) -> dict:
+    """Create a new runtime session (no MongoDB — just a session key).
+
+    The dependency is unused by the body on purpose: this handler mints a
+    random key and touches nothing, so there is nothing here to scope. It
+    requires a session anyway, because "needs no session but is currently
+    harmless" stops holding the moment somebody makes this handler persist
+    something, and that change would not look like a security change to
+    whoever writes it. Only ``current_user_id`` — no workspace is needed to
+    generate a string.
+    """
     import uuid
 
     safe_key = f"websocket_{uuid.uuid4().hex[:12]}"
@@ -224,6 +260,17 @@ async def get_session_history(
 
 
 @router.post("/{session_id}/touch", status_code=204)
-async def touch_session(session_id: str) -> Response:
-    await sessions_service.touch(session_id)
+async def touch_session(
+    session_id: str,
+    user_id: str = Depends(current_user_id),
+) -> Response:
+    """Bump a session's activity — the caller's own sessions only.
+
+    Both the dependency and the ``user_id`` argument are new (2026-08-01).
+    Ownership is the requirement here, not merely a session: this writes
+    ``lastActivity`` / ``messageCount`` and emits a ``SessionUpdated`` onto the
+    OWNER's realtime feed, so a caller who cannot read the session must not be
+    able to move it either.
+    """
+    await sessions_service.touch(session_id, user_id)
     return Response(status_code=204)

--- a/ee/pocketpaw_ee/cloud/sessions/router.py
+++ b/ee/pocketpaw_ee/cloud/sessions/router.py
@@ -167,9 +167,7 @@ async def list_runtime_sessions(
     store = manager._store
 
     if hasattr(store, "_load_session_index_async"):
-        index = await store._load_session_index_async(
-            workspace_id=workspace_id, owner_id=user_id
-        )
+        index = await store._load_session_index_async(workspace_id=workspace_id, owner_id=user_id)
     elif hasattr(store, "_load_session_index"):
         # The file store is single-tenant by construction — it is the OSS /
         # dedicated-install backend, and a cloud deployment cannot reach this

--- a/ee/pocketpaw_ee/cloud/sessions/service.py
+++ b/ee/pocketpaw_ee/cloud/sessions/service.py
@@ -949,16 +949,32 @@ async def set_title(session_id: str, title: str) -> bool:
     return True
 
 
-async def touch(session_id: str) -> None:
-    """Update lastActivity and increment messageCount.
+async def touch(session_id: str, user_id: str) -> None:
+    """Update lastActivity and increment messageCount, for the OWNER only.
 
-    Called by chat persistence bridges on the hot path; kept on Beanie.
+    ``user_id`` is required rather than optional (2026-08-01), so that an
+    unscoped write cannot be reintroduced simply by leaving the argument out.
+    The ownership check matters as much as the identity: this writes to the
+    document and emits a ``SessionUpdated`` naming its owner onto that owner's
+    realtime feed, neither of which belongs to a caller who cannot read it.
+
+    Callers that already hold the doc use ``touch_doc``, which is the path the
+    memory store's write hook takes — it has established ownership by having
+    loaded the doc through an owned lookup, so it is unaffected.
     """
     doc = await _SessionDoc.find_one(_SessionDoc.sessionId == session_id)
     if not doc and session_id.startswith("websocket_"):
         doc = await _SessionDoc.find_one(_SessionDoc.sessionId == session_id[10:])
     if not doc:
         return
+    if doc.owner != user_id:
+        # Deliberately the same shape as ``_fetch_owned``. Note the asymmetry
+        # with the missing-session case above, which returns quietly: a caller
+        # probing ids learns "exists and is not yours" here. That is already
+        # true of every other per-session route (GET / PATCH / DELETE all raise
+        # Forbidden on a live session they don't own), so staying silent here
+        # would not close an oracle, only make this one route inconsistent.
+        raise Forbidden("session.not_owner", "Not the session owner")
     doc.lastActivity = datetime.now(UTC)
     doc.messageCount += 1
     await doc.save()

--- a/tests/cloud/auth/test_oauth_state.py
+++ b/tests/cloud/auth/test_oauth_state.py
@@ -1,0 +1,191 @@
+"""Shared single-use OAuth state store (AM-1).
+
+These pin the properties that make ``state`` worth having at all. The reference
+failure is CVE-2025-68481 / GHSA-5j53-63w8-8625 against fastapi-users, where
+OAuth state was a stateless JWT carrying only an audience and an expiry: it
+verified for anyone holding it, so an attacker could start a flow, finish the
+upstream consent with their own account, and hand the resulting
+``?code=…&state=…`` to a victim. Single-use server-side state is what makes
+that replay impossible, so "consume twice" is the most important test here.
+
+Uses fakeredis, matching tests/cloud/auth/test_sso.py, so TTL and delete
+semantics are the real ones rather than a hand-rolled dict.
+"""
+
+import os
+
+os.environ.setdefault("POCKETPAW_REDIS_URL", "redis://test:6379/0")
+
+import fakeredis.aioredis
+import pytest
+from pocketpaw_ee.cloud._core import redis_client
+from pocketpaw_ee.cloud._core.errors import Forbidden
+from pocketpaw_ee.cloud.auth import _oauth_state
+
+
+@pytest.fixture(autouse=True)
+def _fake_redis(monkeypatch):
+    fake = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    monkeypatch.setattr(redis_client, "get_redis", lambda: fake)
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# Issue / consume round trip
+# ---------------------------------------------------------------------------
+
+
+async def test_round_trip_returns_the_payload():
+    state = await _oauth_state.issue("social", {"provider": "google", "flow": "web"})
+    assert await _oauth_state.consume("social", state) == {
+        "provider": "google",
+        "flow": "web",
+    }
+
+
+async def test_state_is_unguessable_and_unique():
+    a = await _oauth_state.issue("social", {"n": 1})
+    b = await _oauth_state.issue("social", {"n": 2})
+    assert a != b
+    # 32 random bytes, urlsafe-base64 -> comfortably over 40 chars.
+    assert len(a) >= 40
+
+
+async def test_payload_is_not_recoverable_from_the_state_value():
+    # The state is a reference, not a container: nothing about the payload may
+    # be derivable from the value handed to the browser.
+    state = await _oauth_state.issue("social", {"provider": "github"})
+    assert "github" not in state
+
+
+# ---------------------------------------------------------------------------
+# Single use — the replay defence
+# ---------------------------------------------------------------------------
+
+
+async def test_consuming_twice_is_refused():
+    state = await _oauth_state.issue("social", {"provider": "google"})
+    await _oauth_state.consume("social", state)
+
+    with pytest.raises(Forbidden) as exc:
+        await _oauth_state.consume("social", state)
+    assert exc.value.code == "social.invalid_state"
+
+
+async def test_consume_deletes_even_when_the_caller_never_looks_again(_fake_redis):
+    state = await _oauth_state.issue("social", {"provider": "google"})
+    await _oauth_state.consume("social", state)
+    assert await _fake_redis.get(f"social_state:{state}") is None
+
+
+async def test_unknown_state_is_refused():
+    with pytest.raises(Forbidden) as exc:
+        await _oauth_state.consume("social", "never-issued")
+    assert exc.value.code == "social.invalid_state"
+
+
+# ---------------------------------------------------------------------------
+# Namespacing — one flow cannot spend another's state
+# ---------------------------------------------------------------------------
+
+
+async def test_a_state_issued_for_sso_cannot_be_spent_on_social():
+    state = await _oauth_state.issue("sso", {"workspace_id": "w1"})
+
+    with pytest.raises(Forbidden) as exc:
+        await _oauth_state.consume("social", state)
+    assert exc.value.code == "social.invalid_state"
+
+    # ...and is still redeemable by its own flow: the failed cross-flow attempt
+    # must not have consumed it.
+    assert await _oauth_state.consume("sso", state) == {"workspace_id": "w1"}
+
+
+async def test_namespace_drives_the_error_code():
+    with pytest.raises(Forbidden) as exc:
+        await _oauth_state.consume("sso", "nope")
+    assert exc.value.code == "sso.invalid_state"
+
+
+async def test_sso_namespace_keeps_its_historical_redis_key(_fake_redis):
+    # SSO states in flight across a deploy must still redeem, so the key shape
+    # is part of the contract, not an implementation detail.
+    state = await _oauth_state.issue("sso", {"workspace_id": "w1"})
+    assert await _fake_redis.get(f"sso_state:{state}") is not None
+
+
+# ---------------------------------------------------------------------------
+# Expiry
+# ---------------------------------------------------------------------------
+
+
+async def test_state_carries_a_ttl(_fake_redis):
+    state = await _oauth_state.issue("social", {"provider": "google"})
+    ttl = await _fake_redis.ttl(f"social_state:{state}")
+    assert 0 < ttl <= _oauth_state.STATE_TTL_SECONDS
+
+
+async def test_ttl_is_overridable():
+    state = await _oauth_state.issue("social", {"a": 1}, ttl_seconds=60)
+    assert await _oauth_state.consume("social", state) == {"a": 1}
+
+
+async def test_expired_state_is_refused(_fake_redis):
+    state = await _oauth_state.issue("social", {"provider": "google"})
+    # Simulate the TTL elapsing rather than sleeping through it.
+    await _fake_redis.delete(f"social_state:{state}")
+
+    with pytest.raises(Forbidden):
+        await _oauth_state.consume("social", state)
+
+
+# ---------------------------------------------------------------------------
+# Malformed payloads
+# ---------------------------------------------------------------------------
+
+
+async def test_malformed_payload_is_refused_not_returned(_fake_redis):
+    await _fake_redis.setex("social_state:corrupt", 600, "{not json")
+
+    with pytest.raises(Forbidden) as exc:
+        await _oauth_state.consume("social", "corrupt")
+    assert exc.value.code == "social.invalid_state"
+
+
+async def test_non_object_payload_is_refused(_fake_redis):
+    # A bare JSON scalar parses fine but is not a payload; callers index into
+    # the result, so returning it would raise somewhere far less obvious.
+    await _fake_redis.setex("social_state:scalar", 600, '"just-a-string"')
+
+    with pytest.raises(Forbidden) as exc:
+        await _oauth_state.consume("social", "scalar")
+    assert exc.value.code == "social.invalid_state"
+
+
+# ---------------------------------------------------------------------------
+# PKCE
+# ---------------------------------------------------------------------------
+
+
+def test_pkce_pair_is_s256_of_the_verifier():
+    import base64
+    import hashlib
+
+    verifier, challenge = _oauth_state.pkce_pair()
+    expected = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode("ascii")).digest())
+        .decode("ascii")
+        .rstrip("=")
+    )
+    assert challenge == expected
+
+
+def test_pkce_pair_is_unpadded_and_fresh_each_call():
+    v1, c1 = _oauth_state.pkce_pair()
+    v2, _ = _oauth_state.pkce_pair()
+    assert v1 != v2
+    assert "=" not in v1 and "=" not in c1
+
+
+def test_nonce_is_fresh_each_call():
+    assert _oauth_state.new_nonce() != _oauth_state.new_nonce()

--- a/tests/cloud/auth/test_route_auth_audit.py
+++ b/tests/cloud/auth/test_route_auth_audit.py
@@ -1,0 +1,345 @@
+"""Every mounted HTTP route requires auth, or is on the public allowlist.
+
+Created 2026-08-01, after a report that "I was logged out and the chat API
+still worked". The API turned out to be guarded — the browser was still
+holding a valid session cookie while the UI believed otherwise — but the only
+reason that could be established quickly was by reading the routers by hand.
+This makes it a standing assertion instead.
+
+THE INVARIANT THIS FILE EXISTS FOR:
+
+    **Cloud routes authenticate at the route level.** The global
+    ``AuthMiddleware`` does not gate ``/api/v1/``, so every cloud route needs
+    its own guard — either a session dependency, or an explicit in-handler
+    check that this file's allowlist names.
+
+That is by design, not an oversight. ``_auth_dispatch`` builds
+``is_auth_optional`` from ``auth_optional_prefixes = ("/api/v1/",)``, and its
+final gate reads
+
+    if not is_valid and not is_auth_optional:
+        return JSONResponse(status_code=401, ...)
+
+The cascade still runs and still populates ``request.state`` — dashboard
+session cookies, API keys, ``full_access`` — so routes mounted at the shared
+prefix can read it. It simply does not do the rejecting, because a caller who
+is mid-login has no session yet and ee routes resolve identity through
+fastapi-users instead. ``test_route_level_guards_are_required_under_api_v1``
+pins the behaviour so this stays a stated property rather than an assumption,
+and checks it against a public source address so the localhost bypass cannot
+make the result look better than it is.
+
+The practical consequence, and the reason to state it plainly: a route-level
+guard is **required**, not belt-and-braces. Anything on
+ALLOWED_WITHOUT_ROUTE_GUARD is relying on something else entirely, and each
+entry has to say what.
+
+How the walk works: every route's dependency tree is searched for a transitive
+dependency that rejects a caller with no session. There is more than one, which
+is why this walks by identity rather than grepping for a name:
+``current_active_user`` (fastapi-users, 401s without a session) and
+``request_context`` (resolves an API key or a session, 401s with neither).
+``current_user_id``, ``current_workspace_id`` and ``require_action`` all
+resolve through one of them.
+
+Adding a genuinely public endpoint means adding it to the allowlist with a
+reason. That is the point: it forces the decision to be explicit and reviewed
+rather than implicit in an omitted parameter.
+
+2026-08-01 — the seven ``REVIEW`` markers are resolved. The four pockets
+routes authenticate in-handler, and their entries below now name the specific
+check instead of deferring it. The three ``/sessions`` routes were brought onto
+route-level guards and have left the list; see
+tests/cloud/sessions/test_runtime_route_auth.py.
+
+The general lesson is about the category rather than those routes.
+"Authorisation happens inside the handler" held for four of the seven and not
+for the other three, and nothing distinguished them from the outside — which
+is why an entry here has to name the check it relies on, so the next reader
+can confirm it in one step instead of re-deriving it.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from fastapi.routing import APIRoute
+from pocketpaw_ee.cloud._core.context import loopback_or_request_context, request_context
+from pocketpaw_ee.cloud.auth.core import current_active_user
+
+#: Dependencies that REJECT an unauthenticated caller. There is more than one,
+#: which is exactly why this audit walks for them by identity rather than
+#: grepping for a single name:
+#:   * current_active_user — fastapi-users' active-session guard (401s).
+#:   * request_context     — resolves an API key OR a session, and raises 401
+#:                           when it has neither. Most entity routers use this.
+#:   * loopback_or_request_context — the same, plus a loopback-only internal
+#:                           header path for the local agent. An external
+#:                           caller still collapses to 403 auth.required.
+#: require_license is NOT a session guard: it checks entitlement, not identity,
+#: so a route carrying only that is still anonymous-reachable.
+#:
+#: A fourth family is matched by qualname rather than identity, because it is a
+#: closure minted per call: ``require_scope("...")`` from the OSS dashboard-auth
+#: cascade. It is fail-closed and accepts a master token, a dashboard session
+#: cookie, a scoped API key, an OAuth token — OR genuine localhost, when
+#: ``localhost_auth_bypass`` is on (it defaults to TRUE). See
+#: test_localhost_bypass_is_on_by_default for why that matters when testing.
+GUARD_QUALNAMES = frozenset({"require_scope.<locals>._check"})
+#: NOTE current_optional_user is deliberately NOT here: it yields None for an
+#: anonymous caller and leaves the decision to the handler, so a route that
+#: depends only on it has made no decision at the routing layer.
+SESSION_GUARDS = frozenset(
+    {id(current_active_user), id(request_context), id(loopback_or_request_context)}
+)
+
+# Every router mounted by cloud/__init__.py. Kept as strings so a router that
+# fails to import is a visible skip rather than a collection error.
+ROUTER_MODULES = [
+    ("agent_activity", "pocketpaw_ee.cloud.agent_activity.router"),
+    ("agents", "pocketpaw_ee.cloud.agents.router"),
+    ("audit", "pocketpaw_ee.cloud.audit.router"),
+    ("auth", "pocketpaw_ee.cloud.auth.router"),
+    ("billing", "pocketpaw_ee.cloud.billing.router"),
+    ("chat", "pocketpaw_ee.cloud.chat.router"),
+    ("chat_runs", "pocketpaw_ee.cloud.chat.runs.router"),
+    ("codeagent", "pocketpaw_ee.cloud.codeagent.router"),
+    ("codeconnect", "pocketpaw_ee.cloud.codeconnect.router"),
+    ("codegit", "pocketpaw_ee.cloud.codegit.router"),
+    ("codeproject", "pocketpaw_ee.cloud.codeproject.router"),
+    ("connectors", "pocketpaw_ee.cloud.connectors.router"),
+    ("credits", "pocketpaw_ee.cloud.credits.router"),
+    ("decisions", "pocketpaw_ee.cloud.decisions.router"),
+    ("discovery", "pocketpaw_ee.cloud.discovery.router"),
+    ("entitlements", "pocketpaw_ee.cloud.entitlements.router"),
+    ("files", "pocketpaw_ee.cloud.files.router"),
+    ("foresight", "pocketpaw_ee.cloud.foresight.router"),
+    ("meetings", "pocketpaw_ee.cloud.meetings.router"),
+    ("pockets", "pocketpaw_ee.cloud.pockets.router"),
+    ("pocket_chat", "pocketpaw_ee.cloud.pockets.chat_router"),
+    ("projects", "pocketpaw_ee.cloud.projects.router"),
+    ("sessions", "pocketpaw_ee.cloud.sessions.router"),
+    ("workspace", "pocketpaw_ee.cloud.workspace.router"),
+]
+
+#: Routes that are public BY DESIGN, each with the reason it has to be.
+#: Anything not here must require a session.
+ALLOWED_WITHOUT_ROUTE_GUARD: dict[str, str] = {
+    # You cannot hold a session before you have signed in.
+    "POST /auth/login": "issues the session",
+    "POST /auth/bearer/login": "issues the session (native/API transport)",
+    "POST /auth/register": "creates the account",
+    "POST /auth/mfa/challenge": "second factor, carries its own short-lived mfa_token",
+    "POST /auth/forgot-password": "user cannot sign in by definition",
+    "POST /auth/reset-password": "authorised by the emailed token, not a session",
+    "POST /auth/request-verify-token": "authorised by the emailed token",
+    "POST /auth/verify": "authorised by the emailed token",
+    "POST /auth/logout": "clearing a session must not require one",
+    "POST /auth/bearer/logout": "same, bearer transport",
+    # The OAuth dance: the browser arrives back from the provider with no
+    # session yet. Guarded by the single-use state store instead.
+    "GET /auth/social/providers": "which buttons to render, before sign-in",
+    "GET /auth/social/{provider}/login": "starts consent; no session exists yet",
+    "GET /auth/social/callback": "provider redirect; guarded by single-use state",
+    "POST /auth/social/exchange": "how a desktop client gets its FIRST token",
+    "GET /auth/sso/{workspace_slug}/login": "enterprise OIDC entry point",
+    "GET /auth/sso/callback": "IdP redirect; guarded by single-use state",
+    # Serves an image by opaque filename to an <img> tag, which cannot carry
+    # bearer auth. Pre-existing; flagged in the report below rather than
+    # silently blessed.
+    "GET /auth/avatar/{filename}": "served to <img>; opaque filename",
+    # --- token-authorised: the caller is logged out BY DEFINITION ---
+    "GET /workspaces/invites/{token}": "invitee has no account yet; the token authorises",
+    "GET /workspaces/invites/{token}/preview": "same, shown before accepting",
+    "POST /workspaces/invites/{token}/decline": "same, declining must not need an account",
+    "GET /pockets/shared/{token}": "public share link; the token IS the grant",
+    "GET /codeconnect/github/callback": "GitHub redirect; carries a signed state",
+    # --- static catalogues, no tenant data ---
+    "GET /billing/plans": "public price list",
+    "GET /billing/site-plans": "public price list",
+    "GET /agents/backends": "static list of backend names",
+    "GET /pockets/builtin-widgets": "static widget catalogue",
+    "GET /decisions/_ping": "liveness probe",
+    # --- git smart-HTTP: authenticates in-handler, not via a FastAPI dep ---
+    "GET /codegit/{owner}/{repo}/info/refs": "git protocol; own token auth in-handler",
+    "POST /codegit/{owner}/{repo}/git-upload-pack": "git protocol; own token auth in-handler",
+    "POST /codegit/{owner}/{repo}/git-receive-pack": "git protocol; own token auth in-handler",
+    # --- optional-user by design: the handler decides per resource ---
+    # These take fastapi-users' OPTIONAL dependency, so a caller with no
+    # session reaches the handler and authorisation happens inside it. Each
+    # entry names the specific in-handler check, so nobody has to re-derive it.
+    #
+    # All four were read line by line on 2026-08-01, replacing the REVIEW
+    # markers that stood here. Three /sessions routes carried the same marker
+    # and were moved onto route-level guards instead, so they have left this
+    # list; see tests/cloud/sessions/test_runtime_route_auth.py.
+    "GET /pockets/{pocket_id}": "optional-user; handler allows public pockets",
+    "POST /pockets/{pocket_id}/spec/merge": (
+        "optional-user; router raises 401 auth.required when neither the "
+        "loopback internal bypass nor a session yields an identity, then "
+        "merge_spec runs _check_domain_edit_access on the resolved user"
+    ),
+    "POST /pockets/{pocket_id}/reconcile/preview": (
+        "optional-user; _resolve_reconcile_identity raises 401 auth.required "
+        "with no session and no bypass, then _load_for_reconcile gates read "
+        "access"
+    ),
+    "POST /pockets/{pocket_id}/reconcile/apply": (
+        "optional-user; same 401 from _resolve_reconcile_identity, then "
+        "_load_for_reconcile(require_edit=True) gates edit access BEFORE the "
+        "idempotent-skip path, so a no-op reconcile by a non-editor still 403s"
+    ),
+    "POST /pockets/{pocket_id}/sources/{source}/refresh": (
+        "not a session route at all: authenticated by the per-pocket webhook "
+        "secret via resolve_webhook_pocket (constant-time compare, uniform 403 "
+        "for wrong/missing secret and for a missing pocket, so not an "
+        "existence oracle); an upstream system has no PocketPaw session"
+    ),
+}
+
+
+def _route_key(route: APIRoute) -> str:
+    methods = sorted(route.methods or set())
+    return f"{methods[0] if methods else 'ANY'} {route.path}"
+
+
+def _requires_auth(dependant, seen: set[int] | None = None) -> bool:
+    """Whether this route transitively depends on an active session."""
+    seen = seen if seen is not None else set()
+    if id(dependant) in seen:
+        return False
+    seen.add(id(dependant))
+    if id(dependant.call) in SESSION_GUARDS:
+        return True
+    if getattr(dependant.call, "__qualname__", "") in GUARD_QUALNAMES:
+        return True
+    return any(_requires_auth(d, seen) for d in dependant.dependencies)
+
+
+def _collect() -> list[tuple[str, str]]:
+    """(router_name, route_key) for every HTTP route that lacks a session guard."""
+    unguarded: list[tuple[str, str]] = []
+    for name, module_path in ROUTER_MODULES:
+        try:
+            router = importlib.import_module(module_path).router
+        except Exception as exc:  # noqa: BLE001 — reported, not swallowed
+            pytest.fail(f"router {name} ({module_path}) failed to import: {exc}")
+        for route in router.routes:
+            # WebSockets authenticate in-handler (ticket / JWT / cookie), since
+            # a dependency cannot 401 a socket. Covered by the chat WS tests.
+            if not isinstance(route, APIRoute):
+                continue
+            if not _requires_auth(route.dependant):
+                unguarded.append((name, _route_key(route)))
+    return unguarded
+
+
+def test_no_http_route_ships_without_an_auth_decision():
+    unguarded = _collect()
+    surprises = [
+        f"{name}: {key}" for name, key in unguarded if key not in ALLOWED_WITHOUT_ROUTE_GUARD
+    ]
+    assert not surprises, (
+        "These routes require no session and are not on the public allowlist.\n"
+        "Add a session dependency, or — if the route is public by design — add\n"
+        "it to the allowlist with the reason:\n  " + "\n  ".join(sorted(surprises))
+    )
+
+
+def test_the_chat_api_specifically_requires_a_session():
+    # The endpoint family behind the "I was logged out and chat still worked"
+    # report. Named separately so a regression here is unmistakable.
+    router = importlib.import_module("pocketpaw_ee.cloud.chat.router").router
+    http_routes = [r for r in router.routes if isinstance(r, APIRoute)]
+    assert http_routes, "expected the chat router to expose HTTP routes"
+
+    unguarded = [_route_key(r) for r in http_routes if not _requires_auth(r.dependant)]
+    assert unguarded == [], f"chat routes with no session guard: {unguarded}"
+
+
+def test_the_allowlist_does_not_rot():
+    # An entry that no longer matches a real route is dead weight, and dead
+    # weight is how a genuinely public route later hides in the noise.
+    live = {key for _, key in _collect()}
+    stale = sorted(set(ALLOWED_WITHOUT_ROUTE_GUARD) - live)
+    assert not stale, (
+        "ALLOWED_WITHOUT_ROUTE_GUARD entries that no longer match a route "
+        f"lacking a route-level guard — delete them: {stale}"
+    )
+
+
+async def test_route_level_guards_are_required_under_api_v1():
+    """Cloud routes must carry their own guard: the middleware does not gate them.
+
+    This is the invariant the rest of the file rests on, so it is measured
+    rather than described. It is deliberate — ee routes resolve identity
+    through fastapi-users, and gating the shared prefix globally would reject
+    callers who are mid-login — but it is easy to assume the opposite, so the
+    property is asserted here rather than left to a reader's memory.
+
+    The addresses rule out the two ways a green result could be misleading.
+    203.0.113.9 is TEST-NET-3, a public address, so no loopback rule can be
+    what produces the outcome; and ``/internal/whatever`` from that same
+    address confirms the dispatcher still rejects where it is meant to, so
+    this cannot pass by the dispatcher silently no-opping.
+    """
+    from starlette.requests import Request
+
+    from pocketpaw.dashboard_auth import _auth_dispatch
+
+    def _anonymous(path: str, ip: str) -> Request:
+        return Request(
+            {
+                "type": "http",
+                "http_version": "1.1",
+                "method": "GET",
+                "path": path,
+                "raw_path": path.encode(),
+                "query_string": b"",
+                "headers": [],
+                "client": (ip, 51234),
+                "server": ("api.example.com", 443),
+                "scheme": "https",
+                "root_path": "",
+            }
+        )
+
+    remote = "203.0.113.9"
+
+    # The control: a non-/api/v1 path from the same anonymous remote caller IS
+    # refused, so this test cannot pass by the dispatcher doing nothing.
+    control = await _auth_dispatch(_anonymous("/internal/whatever", remote))
+    assert control is not None and control.status_code == 401
+
+    for path in ("/api/v1/sessions/runtime", "/api/v1/pockets/pk-1/spec/merge"):
+        assert await _auth_dispatch(_anonymous(path, remote)) is None, (
+            f"{path} was refused by the global middleware. If that now holds "
+            "for all of /api/v1/, the invariant at the top of this file has "
+            "changed and the docstring needs updating to match."
+        )
+
+
+def test_localhost_bypass_is_on_by_default():
+    """The reason a signed-out browser can still reach the API locally.
+
+    ``_is_genuine_localhost`` grants ``request.state.full_access`` to any
+    request whose client address is loopback, which satisfies
+    ``require_scope`` and every other dashboard-auth check. It is deliberate
+    for self-hosted single-user installs, and it refuses spoofed
+    ``X-Forwarded-For`` so a remote caller cannot claim it.
+
+    The trap it creates: on localhost you CANNOT tell "this endpoint requires
+    auth" from "this endpoint let me in because I am on localhost". Verifying
+    an auth change locally means setting
+    ``POCKETPAW_LOCALHOST_AUTH_BYPASS=false`` first, or the test proves
+    nothing. Asserted here so the default is a known quantity rather than a
+    surprise during the next auth investigation.
+    """
+    from pocketpaw.config import Settings
+
+    field = Settings.model_fields["localhost_auth_bypass"]
+    assert field.default is True, (
+        "localhost_auth_bypass no longer defaults to True — update the note in "
+        "the auth docs and in this test's docstring."
+    )

--- a/tests/cloud/auth/test_social_link_unlink.py
+++ b/tests/cloud/auth/test_social_link_unlink.py
@@ -1,0 +1,959 @@
+"""Connected accounts (AM-6) — list / link / unlink, against the real app.
+
+test_social_linking.py proves the policy in isolation. This file proves the
+SERVICE and the ROUTES apply it, and it is the layer that matters most here:
+the enforced-SSO bug earlier on this branch passed every unit test in that file
+and was caught only by an end-to-end one, because the defect was in how the
+service fed the table, not in the table.
+
+Four properties are load-bearing, and each has a test that fails loudly if it
+regresses:
+
+  * the three routes REFUSE an anonymous caller (a link endpoint that trusts
+    anything but the session is an account-takeover primitive);
+  * completing a link state from a different session attaches NOTHING;
+  * an identity already owned by another account cannot be re-pointed;
+  * a user cannot unlink their way out of their own account — including the
+    social-only user whose stored password hash is an unusable sentinel, which
+    is the case a naive ``bool(hashed_password)`` check gets wrong.
+
+The provider is stubbed at the adapter boundary (``exchange``), so these
+exercise our orchestration rather than GitHub's HTTP.
+"""
+
+import os
+
+os.environ.setdefault("POCKETPAW_HIBP_ENABLED", "false")
+os.environ.setdefault("POCKETPAW_REDIS_URL", "redis://test:6379/0")
+os.environ.setdefault(
+    "POCKETPAW_SOCIAL_REDIRECT_URI",
+    "http://localhost:8888/api/v1/auth/social/callback",
+)
+
+import fakeredis.aioredis
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from pocketpaw_ee.cloud._core import redis_client
+from pocketpaw_ee.cloud._core.http import add_error_handler
+from pocketpaw_ee.cloud.auth.core import UserCreate, UserManager, get_user_db
+from pocketpaw_ee.cloud.auth.router import router as auth_router
+from pocketpaw_ee.cloud.auth.social import domain
+from pocketpaw_ee.cloud.auth.social import service as social_service
+from pocketpaw_ee.cloud.auth.social.providers.base import SocialIdentity
+from pocketpaw_ee.cloud.models.user import User, WorkspaceMembership
+from pocketpaw_ee.cloud.models.workspace import SsoConfig, Workspace
+
+_PASSWORD = "StrongPass123!"
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(auth_router, prefix="/api/v1")
+    return app
+
+
+async def _seed_user(email: str) -> User:
+    async for db in get_user_db():
+        manager = UserManager(db)
+        user = await manager.create(UserCreate(email=email, password=_PASSWORD))
+        break
+    return user
+
+
+@pytest_asyncio.fixture
+async def app(mongo_db, monkeypatch):  # noqa: ARG001
+    fake = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    monkeypatch.setattr(redis_client, "get_redis", lambda: fake)
+    monkeypatch.setenv("POCKETPAW_GITHUB_OAUTH_CLIENT_ID", "cid")
+    monkeypatch.setenv("POCKETPAW_GITHUB_OAUTH_CLIENT_SECRET", "csecret")
+    monkeypatch.setenv("POCKETPAW_FRONTEND_BASE_URL", "http://localhost:1420")
+    return _build_app()
+
+
+def _client(app: FastAPI) -> AsyncClient:
+    """A fresh client — i.e. a fresh browser, with its own cookie jar."""
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://t")
+
+
+@pytest_asyncio.fixture
+async def anon(app):
+    async with _client(app) as client:
+        yield client
+
+
+async def _sign_in(client: AsyncClient, email: str) -> None:
+    resp = await client.post(
+        "/api/v1/auth/login",
+        data={"username": email, "password": _PASSWORD},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert resp.status_code in (200, 204), resp.text
+    assert "paw_auth" in resp.cookies
+
+
+def _stub_exchange(monkeypatch, identity: SocialIdentity) -> None:
+    from pocketpaw_ee.cloud.auth.social.providers.github import GitHubProvider
+
+    async def fake_exchange(self, **kwargs):  # noqa: ANN001, ARG001
+        return identity
+
+    monkeypatch.setattr(GitHubProvider, "exchange", fake_exchange)
+
+
+async def _start_link(client: AsyncClient, *, next_path: str | None = None) -> str:
+    """Begin a link as the client's signed-in user; return the state value."""
+    params = {"next": next_path} if next_path else None
+    resp = await client.post("/api/v1/auth/social/github/link", params=params)
+    assert resp.status_code == 200, resp.text
+    url = resp.json()["authorize_url"]
+    return url.split("state=")[1].split("&")[0]
+
+
+async def _callback(client: AsyncClient, state: str):
+    return await client.get(
+        "/api/v1/auth/social/callback",
+        params={"code": "c", "state": state},
+        follow_redirects=False,
+    )
+
+
+async def _social_sign_in(client: AsyncClient, monkeypatch, identity: SocialIdentity):
+    """Create-or-sign-in through the social flow; leaves a cookie on ``client``."""
+    _stub_exchange(monkeypatch, identity)
+    resp = await client.get(
+        "/api/v1/auth/social/github/login", params={"flow": "web"}, follow_redirects=False
+    )
+    state = resp.headers["location"].split("state=")[1].split("&")[0]
+    return await _callback(client, state)
+
+
+# ---------------------------------------------------------------------------
+# The routes refuse an anonymous caller
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [
+        ("GET", "/api/v1/auth/social/identities"),
+        ("POST", "/api/v1/auth/social/github/link"),
+        ("DELETE", "/api/v1/auth/social/identities/github"),
+    ],
+)
+async def test_the_connected_account_routes_require_a_session(anon, method, path):
+    # The whole point of the feature. Any of these acting on a caller-supplied
+    # identity instead of a session would be an account-takeover primitive.
+    resp = await anon.request(method, path)
+    assert resp.status_code == 401, resp.text
+
+
+async def test_link_does_not_take_its_target_user_from_the_request(app, monkeypatch):
+    # There is no request shape that names a victim: the provider is the only
+    # caller-chosen value, and the account comes from the cookie. Asserted by
+    # showing a forged tenancy header changes nothing about who gets linked.
+    victim = await _seed_user("victim@acme.com")
+    await _seed_user("attacker@acme.com")
+    async with _client(app) as attacker:
+        await _sign_in(attacker, "attacker@acme.com")
+        resp = await attacker.post(
+            "/api/v1/auth/social/github/link",
+            headers={"X-PocketPaw-User-Id": str(victim.id)},
+        )
+        assert resp.status_code == 200
+        state = resp.json()["authorize_url"].split("state=")[1].split("&")[0]
+
+        _stub_exchange(
+            monkeypatch,
+            SocialIdentity(provider="github", account_id="gh-f", email="a@acme.com"),
+        )
+        await _callback(attacker, state)
+
+    assert (await User.get(victim.id)).oauth_accounts == []
+
+
+# ---------------------------------------------------------------------------
+# The happy path
+# ---------------------------------------------------------------------------
+
+
+async def test_a_signed_in_user_links_lists_and_unlinks(app, monkeypatch):
+    await _seed_user("alice@acme.com")
+    async with _client(app) as client:
+        await _sign_in(client, "alice@acme.com")
+
+        empty = await client.get("/api/v1/auth/social/identities")
+        assert empty.status_code == 200
+        assert empty.json()["identities"] == []
+
+        state = await _start_link(client, next_path="/settings")
+        _stub_exchange(
+            monkeypatch,
+            SocialIdentity(
+                provider="github", account_id="gh-alice", email="alice@github.com"
+            ),
+        )
+        done = await _callback(client, state)
+
+        assert done.status_code == 302
+        location = done.headers["location"]
+        # Back to the page that started it, on the FRONTEND origin, carrying
+        # the outcome — not to the sign-in dialog.
+        assert location.startswith("http://localhost:1420/settings?"), location
+        assert "social_linked=github" in location
+        assert "auth=signin" not in location
+
+        listed = await client.get("/api/v1/auth/social/identities")
+        rows = listed.json()["identities"]
+        assert len(rows) == 1
+        assert rows[0]["provider"] == "github"
+        assert rows[0]["account_email"] == "alice@github.com"
+        assert rows[0]["linked_at"] is not None
+
+        gone = await client.delete("/api/v1/auth/social/identities/github")
+        assert gone.status_code == 204
+        assert (await client.get("/api/v1/auth/social/identities")).json()["identities"] == []
+
+
+async def test_the_identity_list_never_leaks_tokens_or_provider_ids(app, monkeypatch):
+    await _seed_user("quiet@acme.com")
+    async with _client(app) as client:
+        await _sign_in(client, "quiet@acme.com")
+        state = await _start_link(client)
+        _stub_exchange(
+            monkeypatch,
+            SocialIdentity(provider="github", account_id="gh-secret", email="q@acme.com"),
+        )
+        await _callback(client, state)
+
+        row = (await client.get("/api/v1/auth/social/identities")).json()["identities"][0]
+
+    # An endpoint reading a credential store hands back the minimum that
+    # answers the question. The provider's account id is not part of that.
+    assert set(row) == {"provider", "account_email", "linked_at"}
+    assert "gh-secret" not in str(row)
+
+
+async def test_linking_the_same_identity_twice_is_idempotent(app, monkeypatch):
+    user = await _seed_user("twice@acme.com")
+    identity = SocialIdentity(provider="github", account_id="gh-2x", email="t@acme.com")
+    async with _client(app) as client:
+        await _sign_in(client, "twice@acme.com")
+        for _ in range(2):
+            state = await _start_link(client)
+            _stub_exchange(monkeypatch, identity)
+            done = await _callback(client, state)
+            assert "social_error" not in done.headers["location"]
+
+    assert len((await User.get(user.id)).oauth_accounts) == 1
+
+
+# ---------------------------------------------------------------------------
+# Linking must not steal
+# ---------------------------------------------------------------------------
+
+
+async def test_linking_an_identity_owned_by_another_user_is_REFUSED(app, monkeypatch):
+    # The takeover attempt: attacker connects the victim's already-linked
+    # GitHub to their own account, hoping we re-point it.
+    identity = SocialIdentity(provider="github", account_id="gh-owned", email="v@acme.com")
+    victim = await _seed_user("owner@acme.com")
+    async with _client(app) as victim_client:
+        await _sign_in(victim_client, "owner@acme.com")
+        state = await _start_link(victim_client)
+        _stub_exchange(monkeypatch, identity)
+        await _callback(victim_client, state)
+
+    attacker = await _seed_user("thief@acme.com")
+    async with _client(app) as thief_client:
+        await _sign_in(thief_client, "thief@acme.com")
+        state = await _start_link(thief_client)
+        _stub_exchange(monkeypatch, identity)
+        done = await _callback(thief_client, state)
+
+    assert f"social_error={domain.REFUSE_IDENTITY_CLAIMED}" in done.headers["location"]
+    # And nothing moved: the victim keeps it, the attacker gains nothing.
+    assert [a.account_id for a in (await User.get(victim.id)).oauth_accounts] == ["gh-owned"]
+    assert (await User.get(attacker.id)).oauth_accounts == []
+
+
+async def test_a_link_state_completed_by_a_DIFFERENT_session_attaches_nothing(
+    app, monkeypatch
+):
+    # State is a bearer secret: whoever holds it wins. That is survivable for
+    # sign-in, but for linking it would let a stolen state attach the thief's
+    # identity to the victim's account. The session re-check is what stops it.
+    victim = await _seed_user("target@acme.com")
+    await _seed_user("other@acme.com")
+
+    async with _client(app) as victim_client:
+        await _sign_in(victim_client, "target@acme.com")
+        stolen_state = await _start_link(victim_client)
+
+    async with _client(app) as other_client:
+        await _sign_in(other_client, "other@acme.com")
+        _stub_exchange(
+            monkeypatch,
+            SocialIdentity(provider="github", account_id="gh-thief", email="o@acme.com"),
+        )
+        done = await _callback(other_client, stolen_state)
+
+    assert f"social_error={domain.REFUSE_LINK_SESSION_MISMATCH}" in done.headers["location"]
+    assert (await User.get(victim.id)).oauth_accounts == []
+    assert (await User.find_one(User.email == "other@acme.com")).oauth_accounts == []
+
+
+async def test_a_link_state_completed_with_NO_session_attaches_nothing(app, monkeypatch):
+    victim = await _seed_user("nosession@acme.com")
+    async with _client(app) as victim_client:
+        await _sign_in(victim_client, "nosession@acme.com")
+        stolen_state = await _start_link(victim_client)
+
+    async with _client(app) as anonymous:
+        _stub_exchange(
+            monkeypatch,
+            SocialIdentity(provider="github", account_id="gh-anon", email="n@acme.com"),
+        )
+        done = await _callback(anonymous, stolen_state)
+
+    assert domain.REFUSE_LINK_SESSION_MISMATCH in done.headers["location"]
+    assert (await User.get(victim.id)).oauth_accounts == []
+    # And it did NOT fall through to the sign-in branch and mint a session.
+    assert "set-cookie" not in {k.lower() for k in done.headers.keys()}
+
+
+async def test_a_refusal_lands_back_on_the_page_that_started_the_link(app, monkeypatch):
+    # The state is consumed before the refusal is raised, so ``next`` has to
+    # travel on the exception. Without it the user is dropped on the app root
+    # and the Settings panel never gets to explain what happened.
+    await _seed_user("backhome@acme.com")
+    async with _client(app) as client:
+        await _sign_in(client, "backhome@acme.com")
+        state = await _start_link(client, next_path="/settings/accounts")
+        _stub_exchange(
+            monkeypatch, SocialIdentity(provider="github", account_id="gh-bh", email=None)
+        )
+        done = await _callback(client, state)
+
+    location = done.headers["location"]
+    assert location.startswith("http://localhost:1420/settings/accounts?"), location
+    assert f"social_error={domain.REFUSE_UNVERIFIED}" in location
+
+
+async def test_a_hostile_next_is_not_honoured_on_a_link_REFUSAL_either(app, monkeypatch):
+    # The refusal path builds its own redirect, so it needs the same validator
+    # as the success path rather than inheriting it by accident.
+    await _seed_user("hostilefail@acme.com")
+    async with _client(app) as client:
+        await _sign_in(client, "hostilefail@acme.com")
+        state = await _start_link(client, next_path="https://evil.com")
+        _stub_exchange(
+            monkeypatch, SocialIdentity(provider="github", account_id="gh-hf", email=None)
+        )
+        done = await _callback(client, state)
+
+    assert done.headers["location"].startswith("http://localhost:1420/?")
+    assert "evil.com" not in done.headers["location"]
+
+
+async def test_an_unverified_identity_cannot_be_linked(app, monkeypatch):
+    user = await _seed_user("unver@acme.com")
+    async with _client(app) as client:
+        await _sign_in(client, "unver@acme.com")
+        state = await _start_link(client)
+        _stub_exchange(
+            monkeypatch, SocialIdentity(provider="github", account_id="gh-un", email=None)
+        )
+        done = await _callback(client, state)
+
+    assert f"social_error={domain.REFUSE_UNVERIFIED}" in done.headers["location"]
+    assert (await User.get(user.id)).oauth_accounts == []
+
+
+# ---------------------------------------------------------------------------
+# Enforced SSO
+# ---------------------------------------------------------------------------
+
+
+async def _enforce_sso(user: User) -> None:
+    ws = Workspace(
+        name="SSO Corp",
+        slug="ssocorp",
+        owner=str(user.id),
+        sso_config=SsoConfig(
+            provider="okta",
+            issuer="https://idp.example.com",
+            client_id="x",
+            client_secret_encrypted="ciphertext",
+            allowed_domains=["sso.com"],
+            enforced=True,
+        ),
+    )
+    await ws.insert()
+    user.workspaces.append(WorkspaceMembership(workspace=str(ws.id), role="member"))
+    await user.save()
+
+
+async def test_enforced_sso_refuses_the_link_before_any_consent(app):
+    # Refused at the START, so the user gets an explainable error in Settings
+    # instead of a round trip through Google that ends in a redirect.
+    user = await _seed_user("member@sso.com")
+    await _enforce_sso(user)
+    async with _client(app) as client:
+        await _sign_in(client, "member@sso.com")
+        resp = await client.post("/api/v1/auth/social/github/link")
+
+    assert resp.status_code == 403
+    assert domain.REFUSE_SSO_ENFORCED in resp.text
+
+
+async def test_enforced_sso_refuses_the_link_at_the_CALLBACK_too(app, monkeypatch):
+    # Defence in depth: enforcement can be switched on between authorize and
+    # callback, and the begin-time check is a UX affordance, not the control.
+    user = await _seed_user("late@sso.com")
+    async with _client(app) as client:
+        await _sign_in(client, "late@sso.com")
+        state = await _start_link(client)
+
+        await _enforce_sso(user)
+
+        _stub_exchange(
+            monkeypatch,
+            SocialIdentity(provider="github", account_id="gh-late", email="l@sso.com"),
+        )
+        done = await _callback(client, state)
+
+    assert f"social_error={domain.REFUSE_SSO_ENFORCED}" in done.headers["location"]
+    assert (await User.get(user.id)).oauth_accounts == []
+
+
+# ---------------------------------------------------------------------------
+# Never remove the last credential
+# ---------------------------------------------------------------------------
+
+
+async def test_a_social_only_user_cannot_unlink_their_only_identity(app, monkeypatch):
+    # THE lockout case, and the one a naive bool(hashed_password) check gets
+    # wrong: this account has a NON-EMPTY hashed_password, because the social
+    # create path stores an unusable "!social-only-" sentinel there rather than
+    # an empty string. Read as "has a password", this unlink would succeed and
+    # leave an account nobody can ever sign into again.
+    async with _client(app) as client:
+        await _social_sign_in(
+            client,
+            monkeypatch,
+            SocialIdentity(provider="github", account_id="gh-only", email="only@acme.com"),
+        )
+        resp = await client.delete("/api/v1/auth/social/identities/github")
+
+    assert resp.status_code == 409
+    assert domain.REFUSE_LAST_CREDENTIAL in resp.text
+
+    user = await User.find_one(User.email == "only@acme.com")
+    assert [a.oauth_name for a in user.oauth_accounts] == ["github"]
+    # The trap, stated directly so the next reader sees why the check is not
+    # a truthiness test.
+    assert user.hashed_password
+    assert social_service._has_usable_password(user) is False
+
+
+async def test_a_password_user_may_unlink_their_only_identity(app, monkeypatch):
+    user = await _seed_user("haspw@acme.com")
+    async with _client(app) as client:
+        await _sign_in(client, "haspw@acme.com")
+        state = await _start_link(client)
+        _stub_exchange(
+            monkeypatch,
+            SocialIdentity(provider="github", account_id="gh-pw", email="h@acme.com"),
+        )
+        await _callback(client, state)
+
+        resp = await client.delete("/api/v1/auth/social/identities/github")
+
+    assert resp.status_code == 204
+    assert (await User.get(user.id)).oauth_accounts == []
+
+
+async def test_a_social_only_user_with_two_identities_may_unlink_one(app, monkeypatch):
+    async with _client(app) as client:
+        await _social_sign_in(
+            client,
+            monkeypatch,
+            SocialIdentity(provider="github", account_id="gh-a", email="two@acme.com"),
+        )
+        user = await User.find_one(User.email == "two@acme.com")
+        # A second identity, as if they had also connected Google.
+        user.oauth_accounts.append(
+            type(user.oauth_accounts[0])(
+                oauth_name="google",
+                account_id="goog-a",
+                account_email="two@acme.com",
+                access_token="",  # noqa: S106 — mirrors what the service stores
+            )
+        )
+        await user.save()
+
+        resp = await client.delete("/api/v1/auth/social/identities/github")
+
+    assert resp.status_code == 204
+    refreshed = await User.get(user.id)
+    assert [a.oauth_name for a in refreshed.oauth_accounts] == ["google"]
+
+
+async def test_unlinking_a_provider_that_was_never_linked_is_a_404(app):
+    await _seed_user("none@acme.com")
+    async with _client(app) as client:
+        await _sign_in(client, "none@acme.com")
+        resp = await client.delete("/api/v1/auth/social/identities/google")
+
+    assert resp.status_code == 404
+    # The DOMAIN's code, not one derived from a human-readable resource name.
+    # Raising NotFound("social identity", …) built the code as
+    # f"{resource}.not_found" and put a SPACE in a machine-readable identifier,
+    # which clients cannot key on — the frontend had grown a second lookup
+    # entry for the mangled spelling before this was fixed.
+    assert domain.REFUSE_NOT_LINKED in resp.text
+    assert "social identity" not in resp.text
+
+
+async def test_every_unlink_refusal_code_is_a_dotted_identifier(app, monkeypatch):
+    # One assertion over both refusals this route can produce: an error code is
+    # read by machines, so neither may carry a space. That is exactly what the
+    # not_linked case did before it stopped borrowing NotFound's derived code.
+    await _seed_user("codes@acme.com")
+    async with _client(app) as client:
+        await _sign_in(client, "codes@acme.com")
+        not_linked = await client.delete("/api/v1/auth/social/identities/google")
+
+    # A social-only account, so its single identity is the last credential.
+    # Needs its own client: it signs in through the social flow, not a password.
+    async with _client(app) as social_only:
+        await _social_sign_in(
+            social_only,
+            monkeypatch,
+            SocialIdentity(provider="github", account_id="gh-c", email="lastcred@acme.com"),
+        )
+        last_credential = await social_only.delete("/api/v1/auth/social/identities/github")
+
+    assert not_linked.status_code == 404
+    assert last_credential.status_code == 409
+    for resp in (not_linked, last_credential):
+        code = resp.json()["error"]["code"]
+        assert " " not in code, code
+        assert code.startswith("auth."), code
+
+
+async def test_unlink_only_ever_removes_the_named_provider(app, monkeypatch):
+    user = await _seed_user("multi@acme.com")
+    async with _client(app) as client:
+        await _sign_in(client, "multi@acme.com")
+        state = await _start_link(client)
+        _stub_exchange(
+            monkeypatch,
+            SocialIdentity(provider="github", account_id="gh-m", email="m@acme.com"),
+        )
+        await _callback(client, state)
+
+        resp = await client.delete("/api/v1/auth/social/identities/google")
+        assert resp.status_code == 404
+
+    # A 404 on one provider must not have disturbed the other.
+    assert [a.oauth_name for a in (await User.get(user.id)).oauth_accounts] == ["github"]
+
+
+# ---------------------------------------------------------------------------
+# The link flow does not disturb the sign-in flow
+# ---------------------------------------------------------------------------
+
+
+async def test_a_link_callback_never_mints_a_session(app, monkeypatch):
+    # The user already has one. Minting a second on this path would rotate
+    # their session as a side effect of visiting Settings.
+    await _seed_user("nomint@acme.com")
+    async with _client(app) as client:
+        await _sign_in(client, "nomint@acme.com")
+        state = await _start_link(client)
+        _stub_exchange(
+            monkeypatch,
+            SocialIdentity(provider="github", account_id="gh-nm", email="nm@acme.com"),
+        )
+        done = await _callback(client, state)
+
+    assert "set-cookie" not in {k.lower() for k in done.headers.keys()}
+
+
+async def test_a_plain_sign_in_still_works_while_signed_in_as_someone_else(
+    app, monkeypatch
+):
+    # The sign-in branch must not be captured by the link branch just because
+    # a session happens to be present — they are told apart by the state
+    # payload, not by whether a cookie arrived.
+    await _seed_user("already@acme.com")
+    async with _client(app) as client:
+        await _sign_in(client, "already@acme.com")
+        done = await _social_sign_in(
+            client,
+            monkeypatch,
+            SocialIdentity(provider="github", account_id="gh-sw", email="sw@acme.com"),
+        )
+
+    assert done.status_code == 302
+    assert "social_error" not in done.headers["location"]
+    # A sign-in DOES mint a session, unlike the link branch above.
+    assert "set-cookie" in {k.lower() for k in done.headers.keys()}
+    assert await User.find_one(User.email == "sw@acme.com") is not None
+
+
+async def test_a_link_state_cannot_be_spent_as_an_exchange_code(app):
+    # Namespaces already separate these, but the link payload now carries a
+    # user id — exactly the shape the exchange redeemer reads.
+    await _seed_user("ns@acme.com")
+    async with _client(app) as client:
+        await _sign_in(client, "ns@acme.com")
+        state = await _start_link(client)
+        resp = await client.post("/api/v1/auth/social/exchange", json={"xc": state})
+
+    assert resp.status_code == 403
+
+
+async def test_a_link_cannot_be_started_for_an_unconfigured_provider(app, monkeypatch):
+    # Cleared explicitly: a developer .env may well have real Google
+    # credentials, and the assertion is about the unconfigured branch.
+    monkeypatch.delenv("POCKETPAW_GOOGLE_OAUTH_CLIENT_ID", raising=False)
+    monkeypatch.delenv("POCKETPAW_GOOGLE_OAUTH_CLIENT_SECRET", raising=False)
+    await _seed_user("unconf@acme.com")
+    async with _client(app) as client:
+        await _sign_in(client, "unconf@acme.com")
+        resp = await client.post("/api/v1/auth/social/google/link")
+
+    assert resp.status_code == 503
+    assert "social.provider_not_configured" in resp.text
+
+
+async def test_a_link_cannot_be_started_for_an_unknown_provider(app):
+    await _seed_user("myspace@acme.com")
+    async with _client(app) as client:
+        await _sign_in(client, "myspace@acme.com")
+        resp = await client.post("/api/v1/auth/social/myspace/link")
+
+    assert resp.status_code == 422
+    assert "social.unknown_provider" in resp.text
+
+
+async def test_a_hostile_next_on_a_link_does_not_leave_the_origin(app, monkeypatch):
+    await _seed_user("hostile@acme.com")
+    async with _client(app) as client:
+        await _sign_in(client, "hostile@acme.com")
+        state = await _start_link(client, next_path="//evil.com")
+        _stub_exchange(
+            monkeypatch,
+            SocialIdentity(provider="github", account_id="gh-h", email="h2@acme.com"),
+        )
+        done = await _callback(client, state)
+
+    assert done.headers["location"].startswith("http://localhost:1420/?"), done.headers[
+        "location"
+    ]
+    assert "evil.com" not in done.headers["location"]
+
+
+# ---------------------------------------------------------------------------
+# Desktop linking (AM-6 desktop)
+# ---------------------------------------------------------------------------
+#
+# The desktop client is NOT "the web client in a window". It authenticates with
+# a bearer from localStorage and holds no cookie for this origin — verified:
+# the desktop login path returns a token and sets no Set-Cookie at all. So the
+# Tauri webview that finishes consent cannot prove who it is, the callback
+# cannot attach anything, and the identity is parked for the app to redeem
+# under its bearer.
+#
+# These tests drive a real bearer rather than the cookie jar for exactly that
+# reason. Driving them with a cookie would pass while proving nothing about
+# the client this code exists for.
+
+
+async def _bearer(client: AsyncClient, email: str) -> dict[str, str]:
+    """A real bearer token, the way the desktop client authenticates."""
+    resp = await client.post(
+        "/api/v1/auth/bearer/login",
+        data={"username": email, "password": _PASSWORD},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert resp.status_code == 200, resp.text
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+async def _start_desktop_link(client: AsyncClient, headers: dict[str, str]) -> str:
+    resp = await client.post(
+        "/api/v1/auth/social/github/link", params={"flow": "desktop"}, headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["authorize_url"].split("state=")[1].split("&")[0]
+
+
+def _link_code(response) -> str:
+    return response.headers["location"].split("link=")[1].split("&")[0]
+
+
+async def test_begin_link_refuses_an_unknown_flow(app):
+    # Refused rather than defaulted to web. A silent fallback would send a
+    # desktop client down the branch whose cookie check it can never satisfy,
+    # and the symptom is a webview that consents and then does nothing.
+    await _seed_user("badflow@acme.com")
+    async with _client(app) as client:
+        await _sign_in(client, "badflow@acme.com")
+        resp = await client.post(
+            "/api/v1/auth/social/github/link", params={"flow": "carrier-pigeon"}
+        )
+
+    assert resp.status_code == 422
+    assert "social.unknown_flow" in resp.text
+
+
+async def test_a_desktop_link_callback_parks_and_attaches_NOTHING(app, monkeypatch):
+    # The bug this path fixes: the webview has no cookie, so the callback
+    # cannot authenticate anyone. It must not attach on the state alone.
+    user = await _seed_user("desk@acme.com")
+    async with _client(app) as client:
+        headers = await _bearer(client, "desk@acme.com")
+        state = await _start_desktop_link(client, headers)
+        _stub_exchange(
+            monkeypatch,
+            SocialIdentity(provider="github", account_id="gh-dk", email="dk@acme.com"),
+        )
+        # No cookie on this request — exactly what a Tauri webview sends.
+        done = await _callback(client, state)
+
+    location = done.headers["location"]
+    assert location.startswith("http://localhost:1420/oauth-callback?"), location
+    assert "link=" in location
+    assert "provider=github" in location
+    # `xc=` is the LOGIN branch's marker. Using it here would make the webview
+    # try to trade this for a bearer, which is not what it is.
+    assert "xc=" not in location
+    assert "set-cookie" not in {k.lower() for k in done.headers.keys()}
+    # Nothing attached yet. That is the point.
+    assert (await User.get(user.id)).oauth_accounts == []
+
+
+async def test_the_desktop_app_completes_the_link_with_its_BEARER(app, monkeypatch):
+    user = await _seed_user("deskok@acme.com")
+    async with _client(app) as client:
+        headers = await _bearer(client, "deskok@acme.com")
+        state = await _start_desktop_link(client, headers)
+        _stub_exchange(
+            monkeypatch,
+            SocialIdentity(provider="github", account_id="gh-ok", email="ok@github.com"),
+        )
+        done = await _callback(client, state)
+
+        resp = await client.post(
+            "/api/v1/auth/social/link/complete",
+            json={"code": _link_code(done)},
+            headers=headers,
+        )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["provider"] == "github"
+    # The panel renders straight from this — the window that started the flow
+    # has already closed, so a failed refetch would have nothing to recover.
+    assert [i["provider"] for i in body["identities"]] == ["github"]
+    assert body["identities"][0]["account_email"] == "ok@github.com"
+    assert [a.account_id for a in (await User.get(user.id)).oauth_accounts] == ["gh-ok"]
+
+
+async def test_a_parked_desktop_link_is_single_use(app, monkeypatch):
+    await _seed_user("once@acme.com")
+    async with _client(app) as client:
+        headers = await _bearer(client, "once@acme.com")
+        state = await _start_desktop_link(client, headers)
+        _stub_exchange(
+            monkeypatch,
+            SocialIdentity(provider="github", account_id="gh-1x", email="1x@acme.com"),
+        )
+        done = await _callback(client, state)
+        code = _link_code(done)
+
+        first = await client.post(
+            "/api/v1/auth/social/link/complete", json={"code": code}, headers=headers
+        )
+        second = await client.post(
+            "/api/v1/auth/social/link/complete", json={"code": code}, headers=headers
+        )
+
+    assert first.status_code == 200
+    assert second.status_code == 403
+
+
+async def test_a_parked_link_redeemed_by_ANOTHER_account_attaches_nothing(app, monkeypatch):
+    # THE security property of this path. The parked record names the account
+    # the link was started for, so possession of the code is not enough.
+    victim = await _seed_user("victim2@acme.com")
+    await _seed_user("thief2@acme.com")
+
+    async with _client(app) as victim_client:
+        victim_headers = await _bearer(victim_client, "victim2@acme.com")
+        state = await _start_desktop_link(victim_client, victim_headers)
+        _stub_exchange(
+            monkeypatch,
+            SocialIdentity(provider="github", account_id="gh-st", email="st@acme.com"),
+        )
+        done = await _callback(victim_client, state)
+        stolen = _link_code(done)
+
+    async with _client(app) as thief_client:
+        thief_headers = await _bearer(thief_client, "thief2@acme.com")
+        resp = await thief_client.post(
+            "/api/v1/auth/social/link/complete",
+            json={"code": stolen},
+            headers=thief_headers,
+        )
+
+    assert resp.status_code == 403
+    assert domain.REFUSE_LINK_SESSION_MISMATCH in resp.text
+    assert (await User.get(victim.id)).oauth_accounts == []
+    assert (await User.find_one(User.email == "thief2@acme.com")).oauth_accounts == []
+
+
+async def test_completing_a_link_requires_a_session(app):
+    # A code with no caller attached is worth nothing — which is what makes
+    # parking it at the callback safe in the first place.
+    async with _client(app) as anonymous:
+        resp = await anonymous.post(
+            "/api/v1/auth/social/link/complete", json={"code": "made-up"}
+        )
+    assert resp.status_code == 401
+
+
+async def test_a_forged_link_code_is_refused(app):
+    await _seed_user("forge@acme.com")
+    async with _client(app) as client:
+        headers = await _bearer(client, "forge@acme.com")
+        resp = await client.post(
+            "/api/v1/auth/social/link/complete",
+            json={"code": "not-a-real-code"},
+            headers=headers,
+        )
+    assert resp.status_code == 403
+
+
+async def test_the_desktop_policy_refusals_match_the_web_ones(app, monkeypatch):
+    # Both clients share _apply_link_policy, and this is what stops the desktop
+    # path quietly growing a weaker version of the takeover rule.
+    identity = SocialIdentity(provider="github", account_id="gh-own2", email="o@acme.com")
+    owner = await _seed_user("owner2@acme.com")
+    async with _client(app) as owner_client:
+        await _sign_in(owner_client, "owner2@acme.com")
+        web_state = await _start_link(owner_client)
+        _stub_exchange(monkeypatch, identity)
+        await _callback(owner_client, web_state)
+
+    await _seed_user("desktopthief@acme.com")
+    async with _client(app) as thief:
+        headers = await _bearer(thief, "desktopthief@acme.com")
+        state = await _start_desktop_link(thief, headers)
+        _stub_exchange(monkeypatch, identity)
+        done = await _callback(thief, state)
+        resp = await thief.post(
+            "/api/v1/auth/social/link/complete",
+            json={"code": _link_code(done)},
+            headers=headers,
+        )
+
+    assert resp.status_code == 403
+    assert domain.REFUSE_IDENTITY_CLAIMED in resp.text
+    assert [a.account_id for a in (await User.get(owner.id)).oauth_accounts] == ["gh-own2"]
+
+
+async def test_a_desktop_link_failure_lands_where_the_webview_can_close(app, monkeypatch):
+    # A refusal that redirects to a web page leaves a Tauri window open with no
+    # explanation. Provider/network failure is the one refusal that still
+    # happens at the callback, so it has to target /oauth-callback too.
+    from pocketpaw_ee.cloud.auth.social.providers.github import GitHubProvider
+
+    await _seed_user("boom@acme.com")
+    async with _client(app) as client:
+        headers = await _bearer(client, "boom@acme.com")
+        state = await _start_desktop_link(client, headers)
+
+        async def explode(self, **kwargs):  # noqa: ANN001, ARG001
+            raise RuntimeError("github is down")
+
+        monkeypatch.setattr(GitHubProvider, "exchange", explode)
+        done = await _callback(client, state)
+
+    location = done.headers["location"]
+    assert location.startswith("http://localhost:1420/oauth-callback?"), location
+    assert "link_error=social.callback_failed" in location
+    # Not the sign-in dialog, which a webview cannot use.
+    assert "auth=signin" not in location
+
+
+async def test_a_hostile_next_cannot_reach_the_desktop_redirect(app, monkeypatch):
+    # The desktop redirect is built from the frontend origin plus fixed params,
+    # so `next` is never interpolated into it. Asserted rather than assumed:
+    # this branch learned once already that two redirects do not inherit each
+    # other's validation.
+    await _seed_user("deskhostile@acme.com")
+    async with _client(app) as client:
+        headers = await _bearer(client, "deskhostile@acme.com")
+        resp = await client.post(
+            "/api/v1/auth/social/github/link",
+            params={"flow": "desktop", "next": "//evil.com"},
+            headers=headers,
+        )
+        state = resp.json()["authorize_url"].split("state=")[1].split("&")[0]
+        _stub_exchange(
+            monkeypatch,
+            SocialIdentity(provider="github", account_id="gh-hn", email="hn@acme.com"),
+        )
+        done = await _callback(client, state)
+
+    location = done.headers["location"]
+    assert location.startswith("http://localhost:1420/oauth-callback?"), location
+    assert "evil.com" not in location
+
+
+async def test_a_parked_link_code_cannot_be_spent_as_a_login_exchange_code(app, monkeypatch):
+    # Different namespaces. One attaches an identity, the other mints a bearer;
+    # making them interchangeable would turn a link into a login.
+    await _seed_user("ns2@acme.com")
+    async with _client(app) as client:
+        headers = await _bearer(client, "ns2@acme.com")
+        state = await _start_desktop_link(client, headers)
+        _stub_exchange(
+            monkeypatch,
+            SocialIdentity(provider="github", account_id="gh-ns", email="ns2@acme.com"),
+        )
+        done = await _callback(client, state)
+
+        resp = await client.post(
+            "/api/v1/auth/social/exchange", json={"xc": _link_code(done)}
+        )
+
+    assert resp.status_code == 403
+
+
+async def test_the_web_link_flow_is_unchanged_by_the_desktop_branch(app, monkeypatch):
+    # flow defaults to web, and the web branch still attaches at the callback
+    # off the cookie. Guards against the desktop work regressing the path that
+    # already worked.
+    user = await _seed_user("stillweb@acme.com")
+    async with _client(app) as client:
+        await _sign_in(client, "stillweb@acme.com")
+        state = await _start_link(client, next_path="/settings/security")
+        _stub_exchange(
+            monkeypatch,
+            SocialIdentity(provider="github", account_id="gh-sw", email="sw@acme.com"),
+        )
+        done = await _callback(client, state)
+
+    location = done.headers["location"]
+    assert location.startswith("http://localhost:1420/settings/security?")
+    assert "social_linked=github" in location
+    assert "oauth-callback" not in location
+    assert [a.account_id for a in (await User.get(user.id)).oauth_accounts] == ["gh-sw"]

--- a/tests/cloud/auth/test_social_link_unlink.py
+++ b/tests/cloud/auth/test_social_link_unlink.py
@@ -191,9 +191,7 @@ async def test_a_signed_in_user_links_lists_and_unlinks(app, monkeypatch):
         state = await _start_link(client, next_path="/settings")
         _stub_exchange(
             monkeypatch,
-            SocialIdentity(
-                provider="github", account_id="gh-alice", email="alice@github.com"
-            ),
+            SocialIdentity(provider="github", account_id="gh-alice", email="alice@github.com"),
         )
         done = await _callback(client, state)
 
@@ -279,9 +277,7 @@ async def test_linking_an_identity_owned_by_another_user_is_REFUSED(app, monkeyp
     assert (await User.get(attacker.id)).oauth_accounts == []
 
 
-async def test_a_link_state_completed_by_a_DIFFERENT_session_attaches_nothing(
-    app, monkeypatch
-):
+async def test_a_link_state_completed_by_a_DIFFERENT_session_attaches_nothing(app, monkeypatch):
     # State is a bearer secret: whoever holds it wins. That is survivable for
     # sign-in, but for linking it would let a stolen state attach the thief's
     # identity to the victim's account. The session re-check is what stops it.
@@ -584,9 +580,7 @@ async def test_a_link_callback_never_mints_a_session(app, monkeypatch):
     assert "set-cookie" not in {k.lower() for k in done.headers.keys()}
 
 
-async def test_a_plain_sign_in_still_works_while_signed_in_as_someone_else(
-    app, monkeypatch
-):
+async def test_a_plain_sign_in_still_works_while_signed_in_as_someone_else(app, monkeypatch):
     # The sign-in branch must not be captured by the link branch just because
     # a session happens to be present — they are told apart by the state
     # payload, not by whether a cookie arrived.
@@ -653,9 +647,7 @@ async def test_a_hostile_next_on_a_link_does_not_leave_the_origin(app, monkeypat
         )
         done = await _callback(client, state)
 
-    assert done.headers["location"].startswith("http://localhost:1420/?"), done.headers[
-        "location"
-    ]
+    assert done.headers["location"].startswith("http://localhost:1420/?"), done.headers["location"]
     assert "evil.com" not in done.headers["location"]
 
 
@@ -823,9 +815,7 @@ async def test_completing_a_link_requires_a_session(app):
     # A code with no caller attached is worth nothing — which is what makes
     # parking it at the callback safe in the first place.
     async with _client(app) as anonymous:
-        resp = await anonymous.post(
-            "/api/v1/auth/social/link/complete", json={"code": "made-up"}
-        )
+        resp = await anonymous.post("/api/v1/auth/social/link/complete", json={"code": "made-up"})
     assert resp.status_code == 401
 
 
@@ -931,9 +921,7 @@ async def test_a_parked_link_code_cannot_be_spent_as_a_login_exchange_code(app, 
         )
         done = await _callback(client, state)
 
-        resp = await client.post(
-            "/api/v1/auth/social/exchange", json={"xc": _link_code(done)}
-        )
+        resp = await client.post("/api/v1/auth/social/exchange", json={"xc": _link_code(done)})
 
     assert resp.status_code == 403
 

--- a/tests/cloud/auth/test_social_linking.py
+++ b/tests/cloud/auth/test_social_linking.py
@@ -1,0 +1,307 @@
+"""Social sign-in linking policy (AM-4) — the account-takeover boundary.
+
+This is the highest-stakes table in the feature. Getting row 3 wrong hands an
+attacker someone else's account: they attach victim@corp.com to their own
+GitHub or Google profile, sign in, and the linker binds them to the victim.
+
+The policy is pure, so every branch is exercised here directly. Reversal cost
+is the reason for the coverage: once identities are bound under a wrong policy,
+undoing it means unpicking oauth_accounts rows per user.
+
+Extended 2026-08-01 (AM-6) with the settings-side table — ``decide_link`` and
+``decide_unlink``. Same argument for the coverage: linking the wrong way hands
+over an account, and unlinking the wrong way destroys access to one.
+"""
+
+import pytest
+from pocketpaw_ee.cloud.auth.social.domain import (
+    REFUSE_IDENTITY_CLAIMED,
+    REFUSE_LAST_CREDENTIAL,
+    REFUSE_NOT_LINKED,
+    REFUSE_SSO_ENFORCED,
+    REFUSE_UNVERIFIED,
+    LinkDecision,
+    apply_sso_guard,
+    decide,
+    decide_link,
+    decide_unlink,
+)
+from pocketpaw_ee.cloud.auth.social.providers.base import SocialIdentity
+
+
+def ident(*, email: str | None = "dev@corp.com", account_id: str = "acct-1") -> SocialIdentity:
+    return SocialIdentity(provider="github", account_id=account_id, email=email)
+
+
+# ---------------------------------------------------------------------------
+# Row 1 — already linked
+# ---------------------------------------------------------------------------
+
+
+def test_an_already_linked_account_signs_in():
+    d = decide(identity=ident(), linked_user_id="u1", email_user_id=None)
+    assert d == LinkDecision(action="sign_in", user_id="u1")
+
+
+def test_an_already_linked_account_signs_in_even_with_NO_verified_email():
+    # They removed the address, or declined user:email on a re-consent. We
+    # matched on the provider's immutable id, not on an email, so this is
+    # still the same person and locking them out would be wrong.
+    d = decide(identity=ident(email=None), linked_user_id="u1", email_user_id=None)
+    assert d.action == "sign_in"
+    assert d.user_id == "u1"
+
+
+def test_the_existing_link_wins_over_an_email_match_on_a_different_account():
+    # The provider id is the stronger signal: emails change hands, ids do not.
+    d = decide(identity=ident(), linked_user_id="u1", email_user_id="u2")
+    assert d.user_id == "u1"
+
+
+# ---------------------------------------------------------------------------
+# Row 2 — no verified email  (THE takeover defence)
+# ---------------------------------------------------------------------------
+
+
+def test_an_unverified_identity_is_refused_when_the_email_matches_an_account():
+    # The attack: attacker adds victim@corp.com to their own provider account
+    # without verifying it. If this linked, they would land inside u2.
+    d = decide(identity=ident(email=None), linked_user_id=None, email_user_id="u2")
+    assert d.action == "refuse"
+    assert d.reason == REFUSE_UNVERIFIED
+    assert d.user_id is None
+
+
+def test_an_unverified_identity_is_refused_even_with_no_account_to_match():
+    # Never silently create an account on an address nobody vouched for -
+    # that would squat an email its real owner may later want.
+    d = decide(identity=ident(email=None), linked_user_id=None, email_user_id=None)
+    assert d.action == "refuse"
+    assert d.reason == REFUSE_UNVERIFIED
+
+
+def test_refusal_never_carries_a_user_id():
+    d = decide(identity=ident(email=None), linked_user_id=None, email_user_id="u2")
+    assert d.user_id is None
+    assert d.refused is True
+
+
+# ---------------------------------------------------------------------------
+# Rows 3 and 4 — the happy paths
+# ---------------------------------------------------------------------------
+
+
+def test_a_verified_email_links_to_the_existing_account():
+    d = decide(identity=ident(), linked_user_id=None, email_user_id="u2")
+    assert d == LinkDecision(action="link", user_id="u2")
+
+
+def test_a_verified_email_with_no_account_creates_one():
+    d = decide(identity=ident(), linked_user_id=None, email_user_id=None)
+    assert d == LinkDecision(action="create", user_id=None)
+
+
+# ---------------------------------------------------------------------------
+# Enforced SSO — social must not be the way around it
+# ---------------------------------------------------------------------------
+
+
+def test_enforced_sso_refuses_a_sign_in():
+    d = apply_sso_guard(LinkDecision(action="sign_in", user_id="u1"), enforced=True)
+    assert d.action == "refuse"
+    assert d.reason == REFUSE_SSO_ENFORCED
+
+
+def test_enforced_sso_refuses_a_link():
+    d = apply_sso_guard(LinkDecision(action="link", user_id="u2"), enforced=True)
+    assert d.action == "refuse"
+    assert d.reason == REFUSE_SSO_ENFORCED
+
+
+def test_enforced_sso_does_not_touch_a_create():
+    # A brand-new account belongs to no workspace, so there is no enforcement
+    # to apply. Refusing here would make signup impossible for everyone the
+    # moment any one workspace enabled SSO.
+    d = apply_sso_guard(LinkDecision(action="create"), enforced=True)
+    assert d.action == "create"
+
+
+def test_the_guard_is_a_no_op_when_sso_is_not_enforced():
+    original = LinkDecision(action="sign_in", user_id="u1")
+    assert apply_sso_guard(original, enforced=False) == original
+
+
+def test_the_guard_does_not_overwrite_an_existing_refusal_reason():
+    # An unverified refusal must keep saying "unverified" - the user's next
+    # step differs from the SSO case, and the copy is chosen by this code.
+    original = LinkDecision(action="refuse", reason=REFUSE_UNVERIFIED)
+    assert apply_sso_guard(original, enforced=True).reason == REFUSE_UNVERIFIED
+
+
+# ---------------------------------------------------------------------------
+# Whole-table sweep
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("verified", "linked", "by_email", "enforced", "expected_action"),
+    [
+        # already linked -> always sign in, unless SSO is enforced
+        (True, "u1", None, False, "sign_in"),
+        (False, "u1", None, False, "sign_in"),
+        (True, "u1", "u2", False, "sign_in"),
+        (True, "u1", None, True, "refuse"),
+        # not linked, unverified -> always refuse
+        (False, None, None, False, "refuse"),
+        (False, None, "u2", False, "refuse"),
+        (False, None, "u2", True, "refuse"),
+        # not linked, verified, email matches -> link unless enforced
+        (True, None, "u2", False, "link"),
+        (True, None, "u2", True, "refuse"),
+        # not linked, verified, no match -> create, enforcement irrelevant
+        (True, None, None, False, "create"),
+        (True, None, None, True, "create"),
+    ],
+)
+def test_full_decision_table(verified, linked, by_email, enforced, expected_action):
+    identity = ident(email="dev@corp.com" if verified else None)
+    decision = apply_sso_guard(
+        decide(identity=identity, linked_user_id=linked, email_user_id=by_email),
+        enforced=enforced,
+    )
+    assert decision.action == expected_action
+
+
+# ---------------------------------------------------------------------------
+# decide_link — the settings-side table (AM-6)
+# ---------------------------------------------------------------------------
+
+
+def test_linking_an_unclaimed_verified_identity_attaches_it():
+    d = decide_link(identity=ident(), owner_user_id=None, acting_user_id="u1")
+    assert d == LinkDecision(action="attach", user_id="u1")
+
+
+def test_relinking_my_own_identity_is_a_no_op_not_an_error():
+    # Double-click on "Connect", or a retried callback. Reporting a failure
+    # here would put the panel in an error state over a state it already has.
+    d = decide_link(identity=ident(), owner_user_id="u1", acting_user_id="u1")
+    assert d == LinkDecision(action="noop", user_id="u1")
+
+
+def test_linking_an_identity_owned_by_SOMEONE_ELSE_is_REFUSED():
+    # THE takeover case for this endpoint. Re-pointing it would let u1 sign in
+    # as u2 afterwards, and would strip u2 of a credential without telling them.
+    d = decide_link(identity=ident(), owner_user_id="u2", acting_user_id="u1")
+    assert d.action == "refuse"
+    assert d.reason == REFUSE_IDENTITY_CLAIMED
+
+
+def test_the_claimed_check_runs_BEFORE_the_verification_check():
+    # Ordering matters for the message, not just the outcome: telling someone
+    # "verify your email" when the real problem is that the identity belongs
+    # to another account sends them round a loop that can never succeed.
+    d = decide_link(identity=ident(email=None), owner_user_id="u2", acting_user_id="u1")
+    assert d.reason == REFUSE_IDENTITY_CLAIMED
+
+
+def test_linking_an_unverified_identity_is_refused():
+    # Not a takeover risk here — the session says who this is — but it keeps
+    # the invariant that decide() step 1 leans on: every stored oauth_accounts
+    # row was established from a provider-verified identity.
+    d = decide_link(identity=ident(email=None), owner_user_id=None, acting_user_id="u1")
+    assert d.action == "refuse"
+    assert d.reason == REFUSE_UNVERIFIED
+
+
+def test_a_link_refusal_never_carries_a_user_id():
+    d = decide_link(identity=ident(email=None), owner_user_id=None, acting_user_id="u1")
+    assert d.user_id is None
+    assert d.refused is True
+
+
+def test_no_link_decision_ever_targets_an_account_other_than_the_caller():
+    # The invariant over the whole space: whatever happens, the only account
+    # this table will act on is the one that asked.
+    for owner in (None, "u1", "u2"):
+        for email in ("dev@corp.com", None):
+            d = decide_link(
+                identity=ident(email=email), owner_user_id=owner, acting_user_id="u1"
+            )
+            assert d.user_id in (None, "u1"), (owner, email)
+
+
+@pytest.mark.parametrize("action", ["attach", "noop"])
+def test_enforced_sso_refuses_a_settings_link(action):
+    # A link is not itself a bypass — sign-in re-checks every time — but it is
+    # one lying in wait if that check ever regresses, and it stores exactly the
+    # credential the org enabled this control to keep out.
+    d = apply_sso_guard(LinkDecision(action=action, user_id="u1"), enforced=True)
+    assert d.action == "refuse"
+    assert d.reason == REFUSE_SSO_ENFORCED
+
+
+# ---------------------------------------------------------------------------
+# decide_unlink — never remove the last credential (AM-6)
+# ---------------------------------------------------------------------------
+
+
+def test_unlinking_one_of_two_identities_is_allowed_without_a_password():
+    d = decide_unlink(
+        provider="github", linked_providers=["github", "google"], has_password=False
+    )
+    assert d.allowed is True
+    assert d.reason is None
+
+
+def test_unlinking_the_only_identity_is_allowed_when_a_password_exists():
+    d = decide_unlink(provider="github", linked_providers=["github"], has_password=True)
+    assert d.allowed is True
+
+
+def test_unlinking_the_LAST_credential_is_REFUSED():
+    # The lockout case. Support cannot undo this, which is why it fails closed.
+    d = decide_unlink(provider="github", linked_providers=["github"], has_password=False)
+    assert d.allowed is False
+    assert d.reason == REFUSE_LAST_CREDENTIAL
+
+
+def test_unlinking_something_that_was_never_linked_reports_that_specifically():
+    # Distinct from the lockout refusal: nothing is at stake, the caller just
+    # named a provider they never connected.
+    d = decide_unlink(provider="google", linked_providers=["github"], has_password=False)
+    assert d.allowed is False
+    assert d.reason == REFUSE_NOT_LINKED
+
+
+def test_no_unlink_is_allowed_that_would_leave_no_way_in():
+    # The invariant over the whole space, rather than one example of it.
+    for providers in ([], ["github"], ["github", "google"]):
+        for has_password in (False, True):
+            d = decide_unlink(
+                provider="github", linked_providers=providers, has_password=has_password
+            )
+            if d.allowed:
+                remaining = [p for p in providers if p != "github"]
+                assert remaining or has_password, (providers, has_password)
+
+
+def test_no_path_through_the_table_binds_an_unverified_identity():
+    # The invariant, stated once over the whole space: an identity the provider
+    # will not vouch for can never produce a link or a create.
+    for linked in (None, "u1"):
+        for by_email in (None, "u2"):
+            for enforced in (False, True):
+                d = apply_sso_guard(
+                    decide(
+                        identity=ident(email=None),
+                        linked_user_id=linked,
+                        email_user_id=by_email,
+                    ),
+                    enforced=enforced,
+                )
+                assert d.action in ("sign_in", "refuse"), (linked, by_email, enforced)
+                if d.action == "sign_in":
+                    # ...and the only way through is an ALREADY-linked account,
+                    # which was bound earlier under a verified email.
+                    assert linked is not None

--- a/tests/cloud/auth/test_social_linking.py
+++ b/tests/cloud/auth/test_social_linking.py
@@ -225,9 +225,7 @@ def test_no_link_decision_ever_targets_an_account_other_than_the_caller():
     # this table will act on is the one that asked.
     for owner in (None, "u1", "u2"):
         for email in ("dev@corp.com", None):
-            d = decide_link(
-                identity=ident(email=email), owner_user_id=owner, acting_user_id="u1"
-            )
+            d = decide_link(identity=ident(email=email), owner_user_id=owner, acting_user_id="u1")
             assert d.user_id in (None, "u1"), (owner, email)
 
 
@@ -247,9 +245,7 @@ def test_enforced_sso_refuses_a_settings_link(action):
 
 
 def test_unlinking_one_of_two_identities_is_allowed_without_a_password():
-    d = decide_unlink(
-        provider="github", linked_providers=["github", "google"], has_password=False
-    )
+    d = decide_unlink(provider="github", linked_providers=["github", "google"], has_password=False)
     assert d.allowed is True
     assert d.reason is None
 

--- a/tests/cloud/auth/test_social_providers.py
+++ b/tests/cloud/auth/test_social_providers.py
@@ -1,0 +1,311 @@
+"""Social provider adapters (AM-2 / AM-3) — the email-verification boundary.
+
+Every test here defends one rule: an adapter may only report an email that its
+provider actively vouches for. Getting this wrong is not a cosmetic bug, it is
+account takeover — an attacker attaches victim@corp.com to their own provider
+account, signs in, and the linking table hands them the victim's session.
+
+The GitHub cases matter most, because GitHub exposes two email fields and the
+obvious one is the wrong one: `/user`'s `email` is the public profile address,
+self-asserted and unverified, while only `/user/emails` carries `verified`.
+"""
+
+import os
+
+os.environ.setdefault("POCKETPAW_REDIS_URL", "redis://test:6379/0")
+
+import httpx
+import pytest
+from pocketpaw_ee.cloud._core.errors import CloudError
+from pocketpaw_ee.cloud.auth.social.providers import (
+    configured_providers,
+    get_provider,
+)
+from pocketpaw_ee.cloud.auth.social.providers.base import SocialIdentity
+from pocketpaw_ee.cloud.auth.social.providers.github import (
+    GitHubProvider,
+    pick_verified_email,
+)
+from pocketpaw_ee.cloud.auth.social.providers.google import (
+    GoogleProvider,
+    identity_from_claims,
+)
+
+# ---------------------------------------------------------------------------
+# SocialIdentity
+# ---------------------------------------------------------------------------
+
+
+def test_identity_requires_a_provider_account_id():
+    # account_id is the match key. An identity without one could only be
+    # matched by email, which is the thing we refuse to do.
+    with pytest.raises(ValueError):
+        SocialIdentity(provider="google", account_id="", email="a@b.c")
+
+
+def test_has_verified_email_is_false_without_an_email():
+    ident = SocialIdentity(provider="github", account_id="1", email=None)
+    assert ident.has_verified_email is False
+
+
+def test_has_verified_email_is_true_with_one():
+    ident = SocialIdentity(provider="github", account_id="1", email="a@b.c")
+    assert ident.has_verified_email is True
+
+
+# ---------------------------------------------------------------------------
+# GitHub — pick_verified_email
+# ---------------------------------------------------------------------------
+
+
+def test_github_prefers_the_primary_verified_address():
+    rows = [
+        {"email": "alt@corp.com", "primary": False, "verified": True},
+        {"email": "main@corp.com", "primary": True, "verified": True},
+    ]
+    assert pick_verified_email(rows) == "main@corp.com"
+
+
+def test_github_falls_back_to_any_verified_address():
+    rows = [
+        {"email": "alt@corp.com", "primary": False, "verified": True},
+        {"email": "main@corp.com", "primary": True, "verified": False},
+    ]
+    assert pick_verified_email(rows) == "alt@corp.com"
+
+
+def test_github_NEVER_returns_an_unverified_address():
+    # THE takeover case: the attacker adds the victim's address to their own
+    # GitHub account. GitHub reports it, unverified. It must not come back.
+    rows = [{"email": "victim@corp.com", "primary": True, "verified": False}]
+    assert pick_verified_email(rows) is None
+
+
+def test_github_ignores_a_primary_flag_on_an_unverified_row():
+    rows = [
+        {"email": "victim@corp.com", "primary": True, "verified": False},
+        {"email": "attacker@evil.com", "primary": False, "verified": True},
+    ]
+    # Primary does not outrank verified.
+    assert pick_verified_email(rows) == "attacker@evil.com"
+
+
+def test_github_returns_none_for_an_empty_list():
+    assert pick_verified_email([]) is None
+
+
+def test_github_lowercases_the_address():
+    rows = [{"email": "Main@Corp.COM", "primary": True, "verified": True}]
+    assert pick_verified_email(rows) == "main@corp.com"
+
+
+@pytest.mark.parametrize(
+    "rows",
+    [
+        [{"email": "a@b.c", "primary": True, "verified": "true"}],  # string, not bool
+        [{"email": "a@b.c", "primary": True, "verified": 1}],  # truthy, not True
+        [{"email": "a@b.c", "primary": True}],  # absent
+        [{"email": None, "primary": True, "verified": True}],  # no address
+        ["not-a-dict"],
+    ],
+)
+def test_github_treats_anything_but_boolean_true_as_unverified(rows):
+    # `verified` is a real boolean in GitHub's response. A truthy string or 1
+    # is not an assertion of verification, so it must not be read as one.
+    assert pick_verified_email(rows) is None
+
+
+# ---------------------------------------------------------------------------
+# GitHub — the full exchange, against a stubbed API
+# ---------------------------------------------------------------------------
+
+
+def _github_transport(*, emails_status=200, emails_body=None, user_body=None, token_body=None):
+    def handler(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        if "login/oauth/access_token" in url:
+            return httpx.Response(200, json=token_body or {"access_token": "gho_test"})
+        if url.endswith("/user/emails"):
+            if emails_status >= 400:
+                return httpx.Response(emails_status, json={"message": "denied"})
+            return httpx.Response(200, json=emails_body or [])
+        if url.endswith("/user"):
+            return httpx.Response(200, json=user_body or {"id": 42, "login": "octocat"})
+        return httpx.Response(404)
+
+    return httpx.MockTransport(handler)
+
+
+@pytest.fixture
+def github_env(monkeypatch):
+    monkeypatch.setenv("POCKETPAW_GITHUB_OAUTH_CLIENT_ID", "cid")
+    monkeypatch.setenv("POCKETPAW_GITHUB_OAUTH_CLIENT_SECRET", "csecret")
+
+
+async def _exchange(monkeypatch, transport) -> SocialIdentity:
+    real = httpx.AsyncClient
+
+    def patched(*args, **kwargs):
+        kwargs["transport"] = transport
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", patched)
+    return await GitHubProvider().exchange(code="c", redirect_uri="https://app/cb")
+
+
+async def test_github_exchange_returns_the_verified_address(monkeypatch, github_env):
+    transport = _github_transport(
+        emails_body=[{"email": "dev@corp.com", "primary": True, "verified": True}],
+        user_body={"id": 7, "login": "octocat", "name": "Octo", "avatar_url": "http://a/x.png"},
+    )
+    ident = await _exchange(monkeypatch, transport)
+
+    assert ident.provider == "github"
+    assert ident.account_id == "7"
+    assert ident.email == "dev@corp.com"
+    assert ident.full_name == "Octo"
+
+
+async def test_github_exchange_ignores_the_profile_email_field(monkeypatch, github_env):
+    # /user carries a plausible-looking `email`. It is unverified, and
+    # /user/emails says nothing is verified, so the result must be None.
+    transport = _github_transport(
+        emails_body=[{"email": "victim@corp.com", "primary": True, "verified": False}],
+        user_body={"id": 7, "login": "octocat", "email": "victim@corp.com"},
+    )
+    ident = await _exchange(monkeypatch, transport)
+    assert ident.email is None
+    assert ident.account_id == "7"
+
+
+async def test_github_declined_email_scope_yields_no_email_not_an_error(monkeypatch, github_env):
+    # Declining `user:email` is a reasonable choice; it must degrade to the
+    # refusal path, not a 500.
+    transport = _github_transport(emails_status=403)
+    ident = await _exchange(monkeypatch, transport)
+    assert ident.email is None
+    assert ident.account_id == "42"
+
+
+async def test_github_surfaces_a_failed_token_exchange(monkeypatch, github_env):
+    # GitHub reports exchange failures as HTTP 200 with an `error` key, so
+    # raise_for_status alone would let this through.
+    transport = _github_transport(
+        token_body={"error": "bad_verification_code", "error_description": "expired"}
+    )
+    with pytest.raises(CloudError) as exc:
+        await _exchange(monkeypatch, transport)
+    assert exc.value.code == "social.github_token_exchange_failed"
+
+
+async def test_github_rejects_a_profile_without_an_id(monkeypatch, github_env):
+    transport = _github_transport(user_body={"login": "octocat"})
+    with pytest.raises(CloudError) as exc:
+        await _exchange(monkeypatch, transport)
+    assert exc.value.code == "social.github_no_account_id"
+
+
+def test_github_authorize_url_requests_user_email_scope(github_env):
+    url = GitHubProvider().authorize_url(state="st", redirect_uri="https://app/cb")
+    assert "user%3Aemail" in url or "user:email" in url
+    assert "state=st" in url
+
+
+def test_github_authorize_url_does_not_request_repo_scope(github_env):
+    # Sign-in must never ask for repository permissions — that is the
+    # codeconnect App's job, as a separate and later consent.
+    url = GitHubProvider().authorize_url(state="st", redirect_uri="https://app/cb")
+    assert "repo" not in url.split("scope=")[1].split("&")[0]
+
+
+# ---------------------------------------------------------------------------
+# Google — claims mapping
+# ---------------------------------------------------------------------------
+
+
+def test_google_accepts_a_verified_claim():
+    ident = identity_from_claims(
+        {"sub": "1234", "email": "Dev@Corp.com", "email_verified": True, "name": "Dev"}
+    )
+    assert ident.account_id == "1234"
+    assert ident.email == "dev@corp.com"
+    assert ident.full_name == "Dev"
+
+
+@pytest.mark.parametrize(
+    "claims",
+    [
+        {"sub": "1", "email": "v@corp.com", "email_verified": False},
+        {"sub": "1", "email": "v@corp.com", "email_verified": "true"},  # string
+        {"sub": "1", "email": "v@corp.com", "email_verified": 1},  # truthy int
+        {"sub": "1", "email": "v@corp.com"},  # claim absent
+        {"sub": "1", "email": "v@corp.com", "email_verified": None},
+    ],
+)
+def test_google_refuses_anything_but_boolean_true(claims):
+    # nOAuth is exactly this: a mutable, unverified email claim read as an
+    # identity. Only a real boolean True counts.
+    assert identity_from_claims(claims).email is None
+
+
+def test_google_still_returns_the_identity_when_the_email_is_unusable():
+    # The account_id is valid, so the user CAN still be signed in if this
+    # provider account is already linked — only NEW linking is blocked.
+    ident = identity_from_claims({"sub": "1", "email": "v@corp.com", "email_verified": False})
+    assert ident.account_id == "1"
+    assert ident.has_verified_email is False
+
+
+def test_google_requires_a_sub_claim():
+    with pytest.raises(CloudError) as exc:
+        identity_from_claims({"email": "a@b.c", "email_verified": True})
+    assert exc.value.code == "social.google_no_subject"
+
+
+def test_google_authorize_url_carries_pkce_and_nonce(monkeypatch):
+    monkeypatch.setenv("POCKETPAW_GOOGLE_OAUTH_CLIENT_ID", "cid")
+    monkeypatch.setenv("POCKETPAW_GOOGLE_OAUTH_CLIENT_SECRET", "sec")
+    url = GoogleProvider().authorize_url(
+        state="st", redirect_uri="https://app/cb", code_challenge="chal", nonce="n1"
+    )
+    assert "code_challenge=chal" in url
+    assert "code_challenge_method=S256" in url
+    assert "nonce=n1" in url
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+def test_registry_resolves_both_providers():
+    assert get_provider("google").name == "google"
+    assert get_provider("github").name == "github"
+
+
+def test_registry_is_case_and_space_insensitive():
+    assert get_provider("  GitHub ").name == "github"
+
+
+def test_registry_returns_none_for_an_unknown_provider():
+    assert get_provider("myspace") is None
+    assert get_provider("") is None
+
+
+def test_unconfigured_providers_are_not_offered(monkeypatch):
+    for var in (
+        "POCKETPAW_GOOGLE_OAUTH_CLIENT_ID",
+        "POCKETPAW_GOOGLE_OAUTH_CLIENT_SECRET",
+        "POCKETPAW_GITHUB_OAUTH_CLIENT_ID",
+        "POCKETPAW_GITHUB_OAUTH_CLIENT_SECRET",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    assert configured_providers() == []
+
+
+def test_a_half_configured_provider_is_not_offered(monkeypatch):
+    # An id with no secret would render a button that dies at the consent
+    # screen. Both halves or nothing.
+    monkeypatch.setenv("POCKETPAW_GITHUB_OAUTH_CLIENT_ID", "cid")
+    monkeypatch.delenv("POCKETPAW_GITHUB_OAUTH_CLIENT_SECRET", raising=False)
+    assert "github" not in configured_providers()

--- a/tests/cloud/auth/test_social_service.py
+++ b/tests/cloud/auth/test_social_service.py
@@ -1,0 +1,611 @@
+"""Social sign-in service + routes (AM-2/AM-3/AM-4) against the real app.
+
+test_social_linking.py proves the policy in isolation. This file proves the
+service actually APPLIES it — that the right lookups feed the table, that a
+refusal never mints a session, and that a created account is only ever created
+from a verified address.
+
+The provider is stubbed at the adapter boundary (``exchange``), so these
+exercise our orchestration rather than Google's or GitHub's HTTP.
+"""
+
+import os
+
+os.environ.setdefault("POCKETPAW_HIBP_ENABLED", "false")
+os.environ.setdefault("POCKETPAW_REDIS_URL", "redis://test:6379/0")
+os.environ.setdefault(
+    "POCKETPAW_SOCIAL_REDIRECT_URI",
+    "http://localhost:8888/api/v1/auth/social/callback",
+)
+
+import fakeredis.aioredis
+import pytest
+import pytest_asyncio
+from beanie import PydanticObjectId
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from pocketpaw_ee.cloud._core import redis_client
+from pocketpaw_ee.cloud._core.errors import Forbidden
+from pocketpaw_ee.cloud._core.http import add_error_handler
+from pocketpaw_ee.cloud.auth.core import UserCreate, UserManager, get_user_db
+from pocketpaw_ee.cloud.auth.router import router as auth_router
+from pocketpaw_ee.cloud.auth.social import domain
+from pocketpaw_ee.cloud.auth.social import service as social_service
+from pocketpaw_ee.cloud.auth.social.providers.base import SocialIdentity
+from pocketpaw_ee.cloud.models.user import User, WorkspaceMembership
+from pocketpaw_ee.cloud.models.workspace import SsoConfig, Workspace
+
+_EXISTING_EMAIL = "existing@acme.com"
+_EXISTING_PASSWORD = "StrongPass123!"
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(auth_router, prefix="/api/v1")
+    return app
+
+
+async def _seed_user(email: str = _EXISTING_EMAIL) -> User:
+    async for db in get_user_db():
+        manager = UserManager(db)
+        user = await manager.create(UserCreate(email=email, password=_EXISTING_PASSWORD))
+        break
+    return user
+
+
+@pytest_asyncio.fixture
+async def env(mongo_db, monkeypatch):  # noqa: ARG001
+    fake = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    monkeypatch.setattr(redis_client, "get_redis", lambda: fake)
+    monkeypatch.setenv("POCKETPAW_GITHUB_OAUTH_CLIENT_ID", "cid")
+    monkeypatch.setenv("POCKETPAW_GITHUB_OAUTH_CLIENT_SECRET", "csecret")
+    monkeypatch.setenv("POCKETPAW_FRONTEND_BASE_URL", "http://localhost:1420")
+    app = _build_app()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+def _stub_exchange(monkeypatch, identity: SocialIdentity):
+    """Make the github adapter return ``identity`` without touching the network."""
+    from pocketpaw_ee.cloud.auth.social.providers.github import GitHubProvider
+
+    async def fake_exchange(self, **kwargs):  # noqa: ANN001, ARG001
+        return identity
+
+    monkeypatch.setattr(GitHubProvider, "exchange", fake_exchange)
+
+
+async def _begin(client) -> str:
+    """Start a real flow and return the state the provider would echo back."""
+    resp = await client.get(
+        "/api/v1/auth/social/github/login", params={"flow": "web"}, follow_redirects=False
+    )
+    assert resp.status_code == 302
+    location = resp.headers["location"]
+    return location.split("state=")[1].split("&")[0]
+
+
+# ---------------------------------------------------------------------------
+# Provider listing
+# ---------------------------------------------------------------------------
+
+
+async def test_configured_provider_is_listed(env):
+    resp = await env.get("/api/v1/auth/social/providers")
+    assert resp.status_code == 200
+    assert "github" in resp.json()["providers"]
+
+
+async def test_unconfigured_provider_login_is_a_clean_redirect_not_a_500(env, monkeypatch):
+    monkeypatch.delenv("POCKETPAW_GOOGLE_OAUTH_CLIENT_ID", raising=False)
+    monkeypatch.delenv("POCKETPAW_GOOGLE_OAUTH_CLIENT_SECRET", raising=False)
+    resp = await env.get("/api/v1/auth/social/google/login", follow_redirects=False)
+    assert resp.status_code == 302
+    assert "social.provider_not_configured" in resp.headers["location"]
+
+
+async def test_unknown_provider_is_refused(env):
+    resp = await env.get("/api/v1/auth/social/myspace/login", follow_redirects=False)
+    assert resp.status_code == 302
+    assert "social.unknown_provider" in resp.headers["location"]
+
+
+# ---------------------------------------------------------------------------
+# begin_login -> state
+# ---------------------------------------------------------------------------
+
+
+async def test_login_redirects_to_the_provider_with_a_state(env):
+    resp = await env.get("/api/v1/auth/social/github/login", follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers["location"].startswith("https://github.com/login/oauth/authorize")
+    assert "state=" in resp.headers["location"]
+
+
+async def test_the_state_is_single_use_across_the_callback(env, monkeypatch):
+    _stub_exchange(
+        monkeypatch,
+        SocialIdentity(provider="github", account_id="gh-1", email="new@acme.com"),
+    )
+    state = await _begin(env)
+
+    first = await env.get(
+        "/api/v1/auth/social/callback",
+        params={"code": "c", "state": state},
+        follow_redirects=False,
+    )
+    assert first.status_code == 302
+    assert "auth_error" not in first.headers["location"]
+
+    # Replaying the same state must not produce a second session.
+    second = await env.get(
+        "/api/v1/auth/social/callback",
+        params={"code": "c", "state": state},
+        follow_redirects=False,
+    )
+    assert "social.invalid_state" in second.headers["location"]
+
+
+async def test_a_forged_state_is_refused(env):
+    resp = await env.get(
+        "/api/v1/auth/social/callback",
+        params={"code": "c", "state": "made-up"},
+        follow_redirects=False,
+    )
+    assert "social.invalid_state" in resp.headers["location"]
+
+
+async def test_missing_code_or_state_is_refused(env):
+    resp = await env.get("/api/v1/auth/social/callback", follow_redirects=False)
+    assert "social.missing_code_or_state" in resp.headers["location"]
+
+
+async def test_provider_side_error_is_passed_through(env):
+    # The user pressed Cancel on the consent screen.
+    resp = await env.get(
+        "/api/v1/auth/social/callback",
+        params={"error": "access_denied"},
+        follow_redirects=False,
+    )
+    assert "access_denied" in resp.headers["location"]
+
+
+# ---------------------------------------------------------------------------
+# The policy, applied
+# ---------------------------------------------------------------------------
+
+
+async def test_verified_email_with_no_account_creates_one_and_sets_a_cookie(env, monkeypatch):
+    _stub_exchange(
+        monkeypatch,
+        SocialIdentity(
+            provider="github", account_id="gh-new", email="fresh@acme.com", full_name="Fresh"
+        ),
+    )
+    state = await _begin(env)
+    resp = await env.get(
+        "/api/v1/auth/social/callback",
+        params={"code": "c", "state": state},
+        follow_redirects=False,
+    )
+
+    assert resp.status_code == 302
+    assert "set-cookie" in {k.lower() for k in resp.headers.keys()}
+
+    created = await User.find_one(User.email == "fresh@acme.com")
+    assert created is not None
+    # Honest only because the provider asserted verification.
+    assert created.is_verified is True
+    assert created.oauth_accounts[0].oauth_name == "github"
+    assert created.oauth_accounts[0].account_id == "gh-new"
+
+
+async def test_created_accounts_never_store_a_provider_access_token(env, monkeypatch):
+    _stub_exchange(
+        monkeypatch,
+        SocialIdentity(provider="github", account_id="gh-tok", email="tok@acme.com"),
+    )
+    state = await _begin(env)
+    await env.get(
+        "/api/v1/auth/social/callback",
+        params={"code": "c", "state": state},
+        follow_redirects=False,
+    )
+    created = await User.find_one(User.email == "tok@acme.com")
+    # Sign-in needs identity, not ongoing API access. A stored token we never
+    # use is avoidable breach surface.
+    assert created.oauth_accounts[0].access_token == ""
+
+
+async def test_verified_email_links_to_the_existing_account(env, monkeypatch):
+    existing = await _seed_user()
+    _stub_exchange(
+        monkeypatch,
+        SocialIdentity(provider="github", account_id="gh-link", email=_EXISTING_EMAIL),
+    )
+    state = await _begin(env)
+    resp = await env.get(
+        "/api/v1/auth/social/callback",
+        params={"code": "c", "state": state},
+        follow_redirects=False,
+    )
+    assert "auth_error" not in resp.headers["location"]
+
+    refreshed = await User.get(existing.id)
+    assert [a.account_id for a in refreshed.oauth_accounts] == ["gh-link"]
+    # No duplicate account was minted for the same address.
+    assert await User.find(User.email == _EXISTING_EMAIL).count() == 1
+
+
+async def test_UNVERIFIED_email_matching_an_account_is_REFUSED(env, monkeypatch):
+    # The takeover attempt, end to end: attacker's provider account carries the
+    # victim's address, unverified. No session may be minted.
+    existing = await _seed_user()
+    _stub_exchange(
+        monkeypatch,
+        SocialIdentity(provider="github", account_id="gh-attacker", email=None),
+    )
+    state = await _begin(env)
+    resp = await env.get(
+        "/api/v1/auth/social/callback",
+        params={"code": "c", "state": state},
+        follow_redirects=False,
+    )
+
+    assert domain.REFUSE_UNVERIFIED in resp.headers["location"]
+    assert "set-cookie" not in {k.lower() for k in resp.headers.keys()}
+
+    refreshed = await User.get(existing.id)
+    assert refreshed.oauth_accounts == []
+
+
+async def test_a_returning_linked_account_signs_in_without_a_verified_email(env, monkeypatch):
+    existing = await _seed_user("returning@acme.com")
+    _stub_exchange(
+        monkeypatch,
+        SocialIdentity(provider="github", account_id="gh-ret", email="returning@acme.com"),
+    )
+    state = await _begin(env)
+    await env.get(
+        "/api/v1/auth/social/callback",
+        params={"code": "c", "state": state},
+        follow_redirects=False,
+    )
+
+    # Second visit: the provider no longer vouches for any address (scope
+    # declined on re-consent). They are still the same person.
+    _stub_exchange(
+        monkeypatch, SocialIdentity(provider="github", account_id="gh-ret", email=None)
+    )
+    state2 = await _begin(env)
+    resp = await env.get(
+        "/api/v1/auth/social/callback",
+        params={"code": "c", "state": state2},
+        follow_redirects=False,
+    )
+
+    assert "auth_error" not in resp.headers["location"]
+    assert await User.find(User.email == "returning@acme.com").count() == 1
+    assert str((await User.get(existing.id)).id) == str(existing.id)
+
+
+async def test_linking_twice_does_not_duplicate_the_oauth_account(env, monkeypatch):
+    existing = await _seed_user("dupe@acme.com")
+    ident = SocialIdentity(provider="github", account_id="gh-dupe", email="dupe@acme.com")
+    for _ in range(2):
+        _stub_exchange(monkeypatch, ident)
+        state = await _begin(env)
+        await env.get(
+            "/api/v1/auth/social/callback",
+            params={"code": "c", "state": state},
+            follow_redirects=False,
+        )
+    refreshed = await User.get(existing.id)
+    assert len(refreshed.oauth_accounts) == 1
+
+
+# ---------------------------------------------------------------------------
+# Enforced SSO
+# ---------------------------------------------------------------------------
+
+
+async def test_enforced_sso_refuses_social_sign_in(env, monkeypatch):
+    user = await _seed_user("member@sso.com")
+    ws = Workspace(
+        name="SSO Corp",
+        slug="ssocorp",
+        owner=str(user.id),
+        sso_config=SsoConfig(
+            provider="okta",
+            issuer="https://idp.example.com",
+            client_id="x",
+            client_secret_encrypted="ciphertext",
+            allowed_domains=["sso.com"],
+            enforced=True,
+        ),
+    )
+    await ws.insert()
+    user.workspaces.append(WorkspaceMembership(workspace=str(ws.id), role="member"))
+    await user.save()
+
+    _stub_exchange(
+        monkeypatch,
+        SocialIdentity(provider="github", account_id="gh-sso", email="member@sso.com"),
+    )
+    state = await _begin(env)
+    resp = await env.get(
+        "/api/v1/auth/social/callback",
+        params={"code": "c", "state": state},
+        follow_redirects=False,
+    )
+
+    # Social must not be the documented way around the control we sell.
+    assert domain.REFUSE_SSO_ENFORCED in resp.headers["location"]
+    assert "set-cookie" not in {k.lower() for k in resp.headers.keys()}
+
+
+async def test_sso_enforcement_check_fails_CLOSED(mongo_db, monkeypatch):  # noqa: ARG001
+    user = await _seed_user("closed@acme.com")
+    # A well-formed id, so the code reaches the query the stub blows up.
+    user.workspaces.append(
+        WorkspaceMembership(workspace=str(PydanticObjectId()), role="member")
+    )
+
+    def boom(*a, **k):  # noqa: ANN001, ARG001
+        raise RuntimeError("mongo is down")
+
+    monkeypatch.setattr(Workspace, "find", boom)
+    # A lookup failure must not be read as "no enforcement".
+    assert await social_service._sso_enforced_for(user) is True
+
+
+# ---------------------------------------------------------------------------
+# next=
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("hostile", ["//evil.com", "https://evil.com", "/\\evil.com"])
+async def test_hostile_next_is_not_honoured(env, monkeypatch, hostile):
+    _stub_exchange(
+        monkeypatch,
+        SocialIdentity(provider="github", account_id="gh-next", email="next@acme.com"),
+    )
+    resp = await env.get(
+        "/api/v1/auth/social/github/login",
+        params={"flow": "web", "next": hostile},
+        follow_redirects=False,
+    )
+    state = resp.headers["location"].split("state=")[1].split("&")[0]
+
+    done = await env.get(
+        "/api/v1/auth/social/callback",
+        params={"code": "c", "state": state},
+        follow_redirects=False,
+    )
+    # The endpoint is reachable directly, so it re-checks rather than trusting
+    # the frontend's parse-time validation.
+    assert done.headers["location"] == "http://localhost:1420/"
+
+
+async def test_a_safe_next_is_honoured(env, monkeypatch):
+    _stub_exchange(
+        monkeypatch,
+        SocialIdentity(provider="github", account_id="gh-ok", email="ok@acme.com"),
+    )
+    resp = await env.get(
+        "/api/v1/auth/social/github/login",
+        params={"flow": "web", "next": "/calendar"},
+        follow_redirects=False,
+    )
+    state = resp.headers["location"].split("state=")[1].split("&")[0]
+
+    done = await env.get(
+        "/api/v1/auth/social/callback",
+        params={"code": "c", "state": state},
+        follow_redirects=False,
+    )
+    assert done.headers["location"] == "http://localhost:1420/calendar"
+
+
+async def test_refusal_raises_forbidden_from_the_service_layer(mongo_db, monkeypatch):  # noqa: ARG001
+    # Belt and braces: the router turns this into a redirect, but the service
+    # must not return a user on a refusal under any circumstance.
+    with pytest.raises(Forbidden):
+        await social_service._resolve_user(
+            SocialIdentity(provider="github", account_id="nope", email=None)
+        )
+
+
+async def test_unparseable_workspace_id_is_skipped_not_crashed(mongo_db):  # noqa: ARG001
+    # A malformed id cannot name a real workspace, so there is no enforcement
+    # to miss - but it must not raise on the way past.
+    user = await _seed_user("junkws@acme.com")
+    user.workspaces.append(WorkspaceMembership(workspace="not-an-objectid", role="member"))
+    assert await social_service._sso_enforced_for(user) is False
+
+
+async def test_membership_ids_are_strings_and_must_be_cast(mongo_db):  # noqa: ARG001
+    # Pins the shape mismatch behind the enforcement bug: memberships store the
+    # workspace id as a STRING while _id is an ObjectId, so a raw $in matches
+    # nothing and would silently disable the guard.
+    user = await _seed_user("shape@acme.com")
+    ws = Workspace(name="Shape", slug="shape", owner=str(user.id))
+    await ws.insert()
+    user.workspaces.append(WorkspaceMembership(workspace=str(ws.id), role="member"))
+    assert isinstance(user.workspaces[-1].workspace, str)
+    # No sso_config -> not enforced, but the lookup must have actually MATCHED.
+    found = [w async for w in Workspace.find({"_id": {"$in": [PydanticObjectId(ws.id)]}})]
+    assert len(found) == 1
+    assert [w async for w in Workspace.find({"_id": {"$in": [str(ws.id)]}})] == []
+
+
+# ---------------------------------------------------------------------------
+# Desktop flow — the one-time exchange code (AM-5)
+# ---------------------------------------------------------------------------
+
+
+async def test_desktop_flow_redirects_with_a_code_and_NO_token(env, monkeypatch):
+    monkeypatch.setenv("POCKETPAW_FRONTEND_BASE_URL", "http://localhost:1420")
+    _stub_exchange(
+        monkeypatch,
+        SocialIdentity(provider="github", account_id="gh-desk", email="desk@acme.com"),
+    )
+    resp = await env.get(
+        "/api/v1/auth/social/github/login",
+        params={"flow": "desktop"},
+        follow_redirects=False,
+    )
+    state = resp.headers["location"].split("state=")[1].split("&")[0]
+
+    done = await env.get(
+        "/api/v1/auth/social/callback",
+        params={"code": "c", "state": state},
+        follow_redirects=False,
+    )
+    location = done.headers["location"]
+
+    # Goes to the FRONTEND origin, where /oauth-callback actually lives.
+    assert location.startswith("http://localhost:1420/oauth-callback?xc=")
+    # The whole point: a reference, never a credential.
+    assert "access_token" not in location
+    assert "token=" not in location
+    # And no cookie either - desktop uses bearer.
+    assert "set-cookie" not in {k.lower() for k in done.headers.keys()}
+
+
+async def _desktop_code(client, monkeypatch, email="desk2@acme.com", account="gh-d2") -> str:
+    monkeypatch.setenv("POCKETPAW_FRONTEND_BASE_URL", "http://localhost:1420")
+    _stub_exchange(
+        monkeypatch, SocialIdentity(provider="github", account_id=account, email=email)
+    )
+    resp = await client.get(
+        "/api/v1/auth/social/github/login",
+        params={"flow": "desktop"},
+        follow_redirects=False,
+    )
+    state = resp.headers["location"].split("state=")[1].split("&")[0]
+    done = await client.get(
+        "/api/v1/auth/social/callback",
+        params={"code": "c", "state": state},
+        follow_redirects=False,
+    )
+    return done.headers["location"].split("xc=")[1].split("&")[0]
+
+
+async def test_exchange_returns_a_bearer_token(env, monkeypatch):
+    xc = await _desktop_code(env, monkeypatch)
+    resp = await env.post("/api/v1/auth/social/exchange", json={"xc": xc})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["token_type"].lower() == "bearer"
+    assert body["access_token"]
+
+
+async def test_an_exchange_code_is_single_use(env, monkeypatch):
+    xc = await _desktop_code(env, monkeypatch)
+    first = await env.post("/api/v1/auth/social/exchange", json={"xc": xc})
+    assert first.status_code == 200
+
+    second = await env.post("/api/v1/auth/social/exchange", json={"xc": xc})
+    assert second.status_code == 403
+    assert "invalid" in second.text.lower()
+
+
+async def test_a_forged_exchange_code_is_refused(env):
+    resp = await env.post("/api/v1/auth/social/exchange", json={"xc": "made-up-code"})
+    assert resp.status_code == 403
+
+
+async def test_an_exchange_code_cannot_be_spent_as_a_login_state(env, monkeypatch):
+    # Different namespace: the two stores must not be interchangeable.
+    xc = await _desktop_code(env, monkeypatch)
+    resp = await env.get(
+        "/api/v1/auth/social/callback",
+        params={"code": "c", "state": xc},
+        follow_redirects=False,
+    )
+    assert "social.invalid_state" in resp.headers["location"]
+
+
+async def test_a_login_state_cannot_be_spent_as_an_exchange_code(env, monkeypatch):
+    _stub_exchange(
+        monkeypatch, SocialIdentity(provider="github", account_id="gh-x", email="x@acme.com")
+    )
+    state = await _begin(env)
+    resp = await env.post("/api/v1/auth/social/exchange", json={"xc": state})
+    assert resp.status_code == 403
+
+
+async def test_a_deactivated_account_cannot_redeem_its_code(env, monkeypatch):
+    # The window is 60s, but an admin may disable the account inside it.
+    xc = await _desktop_code(env, monkeypatch, email="gone@acme.com", account="gh-gone")
+    user = await User.find_one(User.email == "gone@acme.com")
+    user.is_active = False
+    await user.save()
+
+    resp = await env.post("/api/v1/auth/social/exchange", json={"xc": xc})
+    assert resp.status_code == 403
+
+
+async def test_exchange_rejects_an_empty_code(env):
+    resp = await env.post("/api/v1/auth/social/exchange", json={"xc": ""})
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Redirect targets (found on the first live Google run)
+# ---------------------------------------------------------------------------
+
+
+async def test_success_redirects_to_the_FRONTEND_not_the_api(env, monkeypatch):
+    # The bug: a relative redirect resolves against the API origin. Locally the
+    # SPA is :1420 and the API is :8888, so a signed-in user landed on the API
+    # root and saw nothing.
+    _stub_exchange(
+        monkeypatch,
+        SocialIdentity(provider="github", account_id="gh-origin", email="origin@acme.com"),
+    )
+    state = await _begin(env)
+    done = await env.get(
+        "/api/v1/auth/social/callback",
+        params={"code": "c", "state": state},
+        follow_redirects=False,
+    )
+    location = done.headers["location"]
+    assert location.startswith("http://localhost:1420"), location
+    # Absolute, so the browser cannot resolve it against the API origin.
+    assert not location.startswith("/")
+
+
+async def test_a_refusal_reopens_the_dialog_instead_of_a_dead_route(env, monkeypatch):
+    # /auth/error does not exist in the SPA - only forgot, reset, verify - so
+    # the old target was a 404 on the wrong origin. A refusal is a UI state.
+    _stub_exchange(
+        monkeypatch, SocialIdentity(provider="github", account_id="gh-nope", email=None)
+    )
+    state = await _begin(env)
+    done = await env.get(
+        "/api/v1/auth/social/callback",
+        params={"code": "c", "state": state},
+        follow_redirects=False,
+    )
+    location = done.headers["location"]
+
+    assert location.startswith("http://localhost:1420/?auth=signin"), location
+    assert "auth_error=auth.unverified_link" in location
+    assert "/auth/error" not in location
+
+
+async def test_every_error_path_targets_the_frontend(env):
+    for params in (
+        {"error": "access_denied"},
+        {},  # missing code/state
+        {"code": "c", "state": "forged"},
+    ):
+        resp = await env.get(
+            "/api/v1/auth/social/callback", params=params, follow_redirects=False
+        )
+        assert resp.headers["location"].startswith("http://localhost:1420/?auth=signin"), params

--- a/tests/cloud/auth/test_social_service.py
+++ b/tests/cloud/auth/test_social_service.py
@@ -276,9 +276,7 @@ async def test_a_returning_linked_account_signs_in_without_a_verified_email(env,
 
     # Second visit: the provider no longer vouches for any address (scope
     # declined on re-consent). They are still the same person.
-    _stub_exchange(
-        monkeypatch, SocialIdentity(provider="github", account_id="gh-ret", email=None)
-    )
+    _stub_exchange(monkeypatch, SocialIdentity(provider="github", account_id="gh-ret", email=None))
     state2 = await _begin(env)
     resp = await env.get(
         "/api/v1/auth/social/callback",
@@ -349,9 +347,7 @@ async def test_enforced_sso_refuses_social_sign_in(env, monkeypatch):
 async def test_sso_enforcement_check_fails_CLOSED(mongo_db, monkeypatch):  # noqa: ARG001
     user = await _seed_user("closed@acme.com")
     # A well-formed id, so the code reaches the query the stub blows up.
-    user.workspaces.append(
-        WorkspaceMembership(workspace=str(PydanticObjectId()), role="member")
-    )
+    user.workspaces.append(WorkspaceMembership(workspace=str(PydanticObjectId()), role="member"))
 
     def boom(*a, **k):  # noqa: ANN001, ARG001
         raise RuntimeError("mongo is down")
@@ -477,9 +473,7 @@ async def test_desktop_flow_redirects_with_a_code_and_NO_token(env, monkeypatch)
 
 async def _desktop_code(client, monkeypatch, email="desk2@acme.com", account="gh-d2") -> str:
     monkeypatch.setenv("POCKETPAW_FRONTEND_BASE_URL", "http://localhost:1420")
-    _stub_exchange(
-        monkeypatch, SocialIdentity(provider="github", account_id=account, email=email)
-    )
+    _stub_exchange(monkeypatch, SocialIdentity(provider="github", account_id=account, email=email))
     resp = await client.get(
         "/api/v1/auth/social/github/login",
         params={"flow": "desktop"},
@@ -583,9 +577,7 @@ async def test_success_redirects_to_the_FRONTEND_not_the_api(env, monkeypatch):
 async def test_a_refusal_reopens_the_dialog_instead_of_a_dead_route(env, monkeypatch):
     # /auth/error does not exist in the SPA - only forgot, reset, verify - so
     # the old target was a 404 on the wrong origin. A refusal is a UI state.
-    _stub_exchange(
-        monkeypatch, SocialIdentity(provider="github", account_id="gh-nope", email=None)
-    )
+    _stub_exchange(monkeypatch, SocialIdentity(provider="github", account_id="gh-nope", email=None))
     state = await _begin(env)
     done = await env.get(
         "/api/v1/auth/social/callback",
@@ -605,7 +597,5 @@ async def test_every_error_path_targets_the_frontend(env):
         {},  # missing code/state
         {"code": "c", "state": "forged"},
     ):
-        resp = await env.get(
-            "/api/v1/auth/social/callback", params=params, follow_redirects=False
-        )
+        resp = await env.get("/api/v1/auth/social/callback", params=params, follow_redirects=False)
         assert resp.headers["location"].startswith("http://localhost:1420/?auth=signin"), params

--- a/tests/cloud/memory/test_session_index.py
+++ b/tests/cloud/memory/test_session_index.py
@@ -3,6 +3,10 @@
 Covers the API path behind ``GET /sessions/runtime`` on MongoDB-backed
 deployments. The endpoint expects a dict compatible with the file store's
 ``_load_session_index`` so the router is backend-agnostic.
+
+Updated 2026-08-01: the scope arguments became required. The tenant-filtering
+assertions live in ``test_scoping`` at the bottom; the shape tests above pass
+the seed defaults so they keep measuring shape and nothing else.
 """
 
 from __future__ import annotations
@@ -46,7 +50,7 @@ async def _make_session(
 
 class TestLoadSessionIndexAsync:
     async def test_returns_empty_when_no_sessions(self, store):
-        index = await store._load_session_index_async()
+        index = await store._load_session_index_async(workspace_id="ws-1", owner_id="user-1")
         assert index == {}
 
     async def test_returns_entry_with_expected_shape(self, store):
@@ -56,7 +60,7 @@ class TestLoadSessionIndexAsync:
             last_activity=datetime(2026, 4, 10, 12, 0, tzinfo=UTC),
             message_count=3,
         )
-        index = await store._load_session_index_async()
+        index = await store._load_session_index_async(workspace_id="ws-1", owner_id="user-1")
         assert "websocket_abc123" in index
         entry = index["websocket_abc123"]
         assert entry == {
@@ -69,7 +73,7 @@ class TestLoadSessionIndexAsync:
     async def test_excludes_group_sessions(self, store):
         await _make_session(session_id="pocket-session", context_type="pocket", pocket="pocket-1")
         await _make_session(session_id="group-session", context_type="group", group="group-1")
-        index = await store._load_session_index_async()
+        index = await store._load_session_index_async(workspace_id="ws-1", owner_id="user-1")
         assert "pocket-session" in index
         assert "group-session" not in index
 
@@ -79,18 +83,47 @@ class TestLoadSessionIndexAsync:
             session_id="deleted",
             deleted_at=datetime.now(UTC) - timedelta(days=1),
         )
-        index = await store._load_session_index_async()
+        index = await store._load_session_index_async(workspace_id="ws-1", owner_id="user-1")
         assert "alive" in index
         assert "deleted" not in index
 
     async def test_channel_fallback_for_keys_without_underscore(self, store):
         await _make_session(session_id="noprefix")
-        index = await store._load_session_index_async()
+        index = await store._load_session_index_async(workspace_id="ws-1", owner_id="user-1")
         assert index["noprefix"]["channel"] == "unknown"
 
     async def test_empty_title_coerced_to_default(self, store):
         # Session model defaults title to "New Chat", so explicitly empty string
         # should still show something sensible in the index.
         await _make_session(session_id="websocket_x", title="")
-        index = await store._load_session_index_async()
+        index = await store._load_session_index_async(workspace_id="ws-1", owner_id="user-1")
         assert index["websocket_x"]["title"] == "New Chat"
+
+
+class TestScoping:
+    """The tenant filter, which is half of what makes ``GET /sessions/runtime``
+    correct — the route guard is the other half. This index backs a "your
+    sessions" listing, so a read that authenticated the caller but did not
+    scope the query would still answer with rows belonging to someone else.
+    """
+
+    async def test_another_workspaces_sessions_are_excluded(self, store):
+        await _make_session(session_id="mine", workspace="ws-1", owner="user-1")
+        await _make_session(session_id="theirs", workspace="ws-2", owner="user-2")
+        index = await store._load_session_index_async(workspace_id="ws-1", owner_id="user-1")
+        assert set(index) == {"mine"}
+
+    async def test_another_owner_in_the_SAME_workspace_is_excluded(self, store):
+        # Workspace alone is not enough — this index backs a "your sessions"
+        # listing, and a colleague's private chat titles are not the caller's.
+        await _make_session(session_id="mine", workspace="ws-1", owner="user-1")
+        await _make_session(session_id="colleague", workspace="ws-1", owner="user-2")
+        index = await store._load_session_index_async(workspace_id="ws-1", owner_id="user-1")
+        assert set(index) == {"mine"}
+
+    async def test_the_scope_arguments_are_not_optional(self, store):
+        # Required rather than defaulting to None, so the tenant-wide version
+        # cannot come back by omission: forgetting the scope fails to call.
+        await _make_session(session_id="mine")
+        with pytest.raises(TypeError):
+            await store._load_session_index_async()

--- a/tests/cloud/pockets/test_optional_user_routes_still_401.py
+++ b/tests/cloud/pockets/test_optional_user_routes_still_401.py
@@ -1,0 +1,105 @@
+"""The four pockets routes that authorise inside the handler, not at the door.
+
+Created 2026-08-01. These take fastapi-users' OPTIONAL user dependency, so a
+caller with no session reaches the handler and the routing layer makes no
+decision. That is legitimate — each has a reason it cannot use a normal guard,
+from the loopback internal bypass to a per-pocket webhook secret — but it means
+tests/cloud/auth/test_route_auth_audit.py cannot measure them, and until now
+nothing did.
+
+They were read by hand and found sound, and the audit's allowlist now names the
+specific in-handler check for each. This file exists because a named claim that
+nothing enforces decays: a refactor that drops the 401 branch out of
+``_resolve_reconcile_identity`` would leave the audit still cheerfully
+asserting the check is there. The point is not to re-prove authorisation logic
+the pockets suites already cover — it is to pin the ONE property the audit
+takes on faith, that a caller with no session is refused.
+
+Note why this cannot be checked by hand on a dev box: ``localhost_auth_bypass``
+defaults to True and grants full access to loopback callers, so a manual curl
+cannot distinguish "requires auth" from "let me in because I am on localhost".
+These run against the ASGI app with no session at all.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("POCKETPAW_HIBP_ENABLED", "false")
+os.environ.setdefault("POCKETPAW_REDIS_URL", "redis://test:6379/0")
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from pocketpaw_ee.cloud._core.http import add_error_handler
+from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.pockets.router import router as pockets_router
+
+
+@pytest_asyncio.fixture
+async def anon(mongo_db):  # noqa: ARG001
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(pockets_router, prefix="/api/v1")
+    # Entitlement, not identity — overridden so a licence denial cannot be
+    # mistaken for the auth refusal this file is measuring.
+    app.dependency_overrides[require_license] = lambda: None
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        yield c
+
+
+@pytest.mark.parametrize(
+    ("path", "body", "check"),
+    [
+        # Router raises 401 when neither the loopback internal bypass nor a
+        # session yields an identity; merge_spec then re-checks edit access.
+        ("/api/v1/pockets/pk-1/spec/merge", {"merge": {"state": {}}}, "auth.required"),
+        # _resolve_reconcile_identity raises the same 401 for both reconcile
+        # routes, which is why they share a helper.
+        ("/api/v1/pockets/pk-1/reconcile/preview", None, "auth.required"),
+        ("/api/v1/pockets/pk-1/reconcile/apply", None, "auth.required"),
+    ],
+)
+async def test_a_caller_with_no_session_is_refused(anon, path, body, check):
+    resp = await anon.post(path, json=body) if body else await anon.post(path)
+
+    assert resp.status_code == 401, f"{path} -> {resp.status_code}: {resp.text}"
+    assert check in resp.text
+
+
+async def test_identity_is_resolved_before_the_pocket_is_looked_up(anon):
+    # Both pocket ids below are nonexistent. Identical 401s mean the identity
+    # check runs first, so the route cannot be used to learn which pocket ids
+    # exist.
+    a = await anon.post("/api/v1/pockets/definitely-not-real/reconcile/preview")
+    b = await anon.post("/api/v1/pockets/also-not-real/reconcile/preview")
+
+    assert a.status_code == b.status_code == 401
+    assert a.json() == b.json()
+
+
+async def test_the_webhook_refresh_route_refuses_a_missing_secret(anon):
+    # The odd one out: authenticated by a per-pocket secret rather than a
+    # session, because the caller is an upstream backend with no PocketPaw
+    # account. A wrong secret, a missing secret, and a pocket that does not
+    # exist all return the same 403, which keeps it from answering "does this
+    # pocket exist".
+    resp = await anon.post("/api/v1/pockets/pk-1/sources/src-1/refresh")
+
+    assert resp.status_code == 403, resp.text
+    assert "pocket_webhook.unauthorized" in resp.text
+
+
+async def test_the_webhook_route_answers_a_wrong_secret_and_a_missing_pocket_alike(anon):
+    wrong_secret = await anon.post(
+        "/api/v1/pockets/pk-1/sources/src-1/refresh",
+        headers={"X-Pocket-Webhook-Secret": "not-the-secret"},
+    )
+    missing_pocket = await anon.post(
+        "/api/v1/pockets/no-such-pocket/sources/src-1/refresh",
+        headers={"X-Pocket-Webhook-Secret": "not-the-secret"},
+    )
+
+    assert wrong_secret.status_code == missing_pocket.status_code == 403
+    assert wrong_secret.json() == missing_pocket.json()

--- a/tests/cloud/sessions/test_runtime_route_auth.py
+++ b/tests/cloud/sessions/test_runtime_route_auth.py
@@ -1,0 +1,292 @@
+"""The /sessions runtime routes require a session, and are scoped to its owner.
+
+Created 2026-08-01, resolving three of the ``REVIEW`` entries in
+tests/cloud/auth/test_route_auth_audit.py. That audit measures the per-route
+FastAPI dependency layer only, so an entry filed under "authorisation happens
+inside the handler" has to be read by hand to know whether it does. These
+three now carry route-level guards instead, and this file is the standing
+assertion that they keep them.
+
+Two invariants, both of which need holding together — either alone is not
+enough:
+
+  * **A session is required.** ``GET /sessions/runtime``,
+    ``POST /sessions/runtime/create`` and ``POST /sessions/{id}/touch`` all
+    resolve identity through the same dependencies as their sibling routes in
+    this router.
+  * **Reads and writes are scoped to that identity.** The listing is filtered
+    to the caller's workspace AND owner in the store query, and ``touch``
+    refuses a session the caller does not own. Authenticating without scoping
+    would answer a valid request with rows that are not the caller's, so both
+    halves are asserted separately below.
+
+``POST /sessions/runtime/create`` mints a random string and touches nothing, so
+it has nothing to scope. It is guarded anyway: "reachable without a session
+but currently harmless" is a property that quietly stops holding the moment
+somebody makes the handler persist something, and that change would not look
+like a security change to whoever writes it.
+
+Why this file exists rather than a manual check: ``localhost_auth_bypass``
+defaults to True and grants full access to any loopback caller, so exercising
+these by hand on a dev box cannot distinguish "requires auth" from "let me in
+because I am on localhost". The assertions below run against the ASGI app with
+no session at all.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("POCKETPAW_HIBP_ENABLED", "false")
+os.environ.setdefault("POCKETPAW_REDIS_URL", "redis://test:6379/0")
+
+import fakeredis.aioredis
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from pocketpaw_ee.cloud._core import redis_client
+from pocketpaw_ee.cloud._core.http import add_error_handler
+from pocketpaw_ee.cloud.auth.core import UserCreate, UserManager, get_user_db
+from pocketpaw_ee.cloud.auth.router import router as auth_router
+from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.models.session import Session
+from pocketpaw_ee.cloud.models.user import User, WorkspaceMembership
+from pocketpaw_ee.cloud.models.workspace import Workspace
+from pocketpaw_ee.cloud.sessions.router import router as sessions_router
+
+_PASSWORD = "StrongPass123!"
+
+
+@pytest_asyncio.fixture
+async def app(mongo_db, monkeypatch):  # noqa: ARG001
+    fake = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    monkeypatch.setattr(redis_client, "get_redis", lambda: fake)
+
+    # Pin the runtime-sessions route to the Mongo store. Without this it
+    # resolves the process-wide memory manager, which in a test process is the
+    # FILE store reading the developer's own ~/.pocketpaw/memory — so the test
+    # would assert against whatever happens to be on the machine. Cloud always
+    # runs Mongo here (``verify_cloud_memory_backend`` refuses to boot
+    # otherwise), so this matches the deployment the guard is written for.
+    from pocketpaw_ee.cloud.memory.mongo_store import MongoMemoryStore
+
+    class _Manager:
+        _store = MongoMemoryStore()
+
+    monkeypatch.setattr("pocketpaw.memory.get_memory_manager", lambda: _Manager())
+
+    application = FastAPI()
+    add_error_handler(application)
+    application.include_router(auth_router, prefix="/api/v1")
+    application.include_router(sessions_router, prefix="/api/v1")
+    # Entitlement, not identity — overridden so a licence check cannot be
+    # mistaken for the auth result this file is measuring.
+    application.dependency_overrides[require_license] = lambda: None
+    return application
+
+
+def _client(app: FastAPI) -> AsyncClient:
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://t")
+
+
+@pytest_asyncio.fixture
+async def anon(app):
+    async with _client(app) as client:
+        yield client
+
+
+async def _seed_member(email: str, workspace_name: str) -> tuple[User, Workspace]:
+    """A user with a real workspace membership — the shape the guards expect."""
+    async for db in get_user_db():
+        user = await UserManager(db).create(UserCreate(email=email, password=_PASSWORD))
+        break
+    ws = Workspace(name=workspace_name, slug=workspace_name.lower(), owner=str(user.id))
+    await ws.insert()
+    user.workspaces.append(WorkspaceMembership(workspace=str(ws.id), role="owner"))
+    user.active_workspace = str(ws.id)
+    await user.save()
+    return user, ws
+
+
+async def _sign_in(client: AsyncClient, email: str) -> None:
+    resp = await client.post(
+        "/api/v1/auth/login",
+        data={"username": email, "password": _PASSWORD},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert resp.status_code in (200, 204), resp.text
+
+
+async def _seed_session(user: User, ws: Workspace, *, session_id: str, title: str) -> Session:
+    doc = Session(
+        sessionId=session_id,
+        context_type="pocket",
+        pocket="pk-1",
+        workspace=str(ws.id),
+        owner=str(user.id),
+        title=title,
+    )
+    await doc.insert()
+    return doc
+
+
+# ---------------------------------------------------------------------------
+# GET /sessions/runtime
+# ---------------------------------------------------------------------------
+
+
+async def test_runtime_session_list_requires_a_session(anon, app):
+    alice, ws = await _seed_member("alice@acme.com", "Acme")
+    await _seed_session(alice, ws, session_id="websocket_alice", title="Q3 revenue plan")
+
+    resp = await anon.get("/api/v1/sessions/runtime")
+
+    assert resp.status_code == 401, resp.text
+    # Titles are user-authored content, so the scope check is protecting
+    # more than metadata.
+    assert "Q3 revenue plan" not in resp.text
+
+
+async def test_runtime_session_list_is_scoped_to_the_caller(app):
+    alice, alice_ws = await _seed_member("alice@acme.com", "Acme")
+    bob, bob_ws = await _seed_member("bob@globex.com", "Globex")
+    await _seed_session(alice, alice_ws, session_id="websocket_alice", title="Acme roadmap")
+    await _seed_session(bob, bob_ws, session_id="websocket_bob", title="Globex layoffs")
+
+    async with _client(app) as client:
+        await _sign_in(client, "alice@acme.com")
+        resp = await client.get("/api/v1/sessions/runtime")
+
+    assert resp.status_code == 200, resp.text
+    ids = {row["id"] for row in resp.json()["sessions"]}
+    assert ids == {"websocket_alice"}
+    assert "Globex layoffs" not in resp.text
+    # ``total`` is part of the envelope and must count the same scoped set:
+    # a scoped list with an unscoped total is still an unscoped answer.
+    assert resp.json()["total"] == 1
+
+
+async def test_runtime_session_list_returns_the_callers_own_sessions(app):
+    alice, ws = await _seed_member("alice@acme.com", "Acme")
+    await _seed_session(alice, ws, session_id="websocket_mine", title="Mine")
+
+    async with _client(app) as client:
+        await _sign_in(client, "alice@acme.com")
+        resp = await client.get("/api/v1/sessions/runtime")
+
+    assert resp.status_code == 200
+    assert [row["id"] for row in resp.json()["sessions"]] == ["websocket_mine"]
+
+
+# ---------------------------------------------------------------------------
+# POST /sessions/runtime/create
+# ---------------------------------------------------------------------------
+
+
+async def test_runtime_session_create_requires_a_session(anon):
+    resp = await anon.post("/api/v1/sessions/runtime/create")
+    assert resp.status_code == 401, resp.text
+
+
+async def test_runtime_session_create_works_for_a_signed_in_caller(app):
+    await _seed_member("alice@acme.com", "Acme")
+    async with _client(app) as client:
+        await _sign_in(client, "alice@acme.com")
+        resp = await client.post("/api/v1/sessions/runtime/create")
+
+    assert resp.status_code == 200
+    assert resp.json()["id"].startswith("websocket_")
+
+
+# ---------------------------------------------------------------------------
+# POST /sessions/{session_id}/touch
+# ---------------------------------------------------------------------------
+
+
+async def test_touch_requires_a_session(anon, app):
+    alice, ws = await _seed_member("alice@acme.com", "Acme")
+    doc = await _seed_session(alice, ws, session_id="websocket_touch", title="Mine")
+    before = (await Session.get(doc.id)).lastActivity
+
+    resp = await anon.post("/api/v1/sessions/websocket_touch/touch")
+
+    assert resp.status_code == 401, resp.text
+    refreshed = await Session.get(doc.id)
+    assert refreshed.lastActivity == before
+    assert refreshed.messageCount == 0
+
+
+async def test_touch_requires_session_ownership(app):
+    alice, alice_ws = await _seed_member("alice@acme.com", "Acme")
+    await _seed_member("bob@globex.com", "Globex")
+    doc = await _seed_session(alice, alice_ws, session_id="websocket_alice", title="Mine")
+
+    async with _client(app) as client:
+        await _sign_in(client, "bob@globex.com")
+        resp = await client.post("/api/v1/sessions/websocket_alice/touch")
+
+    # Ownership, not merely authentication: touch writes to the document and
+    # emits SessionUpdated onto the OWNER's realtime feed, so a caller who
+    # cannot read the session must not be able to move it either.
+    assert resp.status_code == 403, resp.text
+    refreshed = await Session.get(doc.id)
+    assert refreshed.messageCount == 0
+
+
+async def test_touch_works_for_the_owner(app):
+    alice, ws = await _seed_member("alice@acme.com", "Acme")
+    doc = await _seed_session(alice, ws, session_id="websocket_owned", title="Mine")
+
+    async with _client(app) as client:
+        await _sign_in(client, "alice@acme.com")
+        resp = await client.post("/api/v1/sessions/websocket_owned/touch")
+
+    assert resp.status_code == 204, resp.text
+    refreshed = await Session.get(doc.id)
+    assert refreshed.messageCount == 1
+
+
+async def test_touch_still_resolves_the_websocket_prefix_fallback(app):
+    # ``touch`` strips a "websocket_" prefix when the literal id misses, for
+    # callers that hold the prefixed key. Ownership must be enforced on the
+    # session it lands on, not skipped because the first lookup failed.
+    alice, ws = await _seed_member("alice@acme.com", "Acme")
+    doc = await _seed_session(alice, ws, session_id="bare-id", title="Mine")
+
+    async with _client(app) as client:
+        await _sign_in(client, "alice@acme.com")
+        resp = await client.post("/api/v1/sessions/websocket_bare-id/touch")
+
+    assert resp.status_code == 204, resp.text
+    assert (await Session.get(doc.id)).messageCount == 1
+
+
+async def test_touching_a_missing_session_stays_quiet(app):
+    # An unknown id is a no-op, not an error — this is a fire-and-forget
+    # activity ping and a 404 storm from a stale client helps nobody. Note the
+    # asymmetry with the not-owned case above, which DOES raise: a caller can
+    # therefore tell "exists but isn't yours" from "doesn't exist". That is
+    # already true of GET / PATCH / DELETE on the same id, so this route is
+    # consistent with its siblings rather than opening anything new.
+    await _seed_member("alice@acme.com", "Acme")
+    async with _client(app) as client:
+        await _sign_in(client, "alice@acme.com")
+        resp = await client.post("/api/v1/sessions/websocket_nope/touch")
+
+    assert resp.status_code == 204, resp.text
+
+
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [
+        ("GET", "/api/v1/sessions/runtime"),
+        ("POST", "/api/v1/sessions/runtime/create"),
+        ("POST", "/api/v1/sessions/anything/touch"),
+    ],
+)
+async def test_every_runtime_route_requires_a_session(anon, method, path):
+    # Stated once over all three, so a route added to this family later
+    # inherits the requirement instead of having to remember it.
+    resp = await anon.request(method, path)
+    assert resp.status_code == 401, f"{method} {path} -> {resp.status_code}"

--- a/tests/cloud/sessions/test_service_v2.py
+++ b/tests/cloud/sessions/test_service_v2.py
@@ -164,7 +164,7 @@ async def test_touch_emits_session_updated(recording_bus) -> None:
     doc_stub.find_one = AsyncMock(return_value=session)
 
     with patch("pocketpaw_ee.cloud.sessions.service._SessionDoc", new=doc_stub):
-        await sessions_service.touch("websocket_abc")
+        await sessions_service.touch("websocket_abc", "u1")
 
     events = [e for e in recording_bus.events if isinstance(e, SessionUpdated)]
     assert len(events) == 1
@@ -181,6 +181,32 @@ async def test_touch_no_emit_when_session_missing(recording_bus) -> None:
     doc_stub.find_one = AsyncMock(return_value=None)
 
     with patch("pocketpaw_ee.cloud.sessions.service._SessionDoc", new=doc_stub):
-        await sessions_service.touch("missing")
+        await sessions_service.touch("missing", "u1")
 
+    assert not [e for e in recording_bus.events if isinstance(e, SessionUpdated)]
+
+
+async def test_touch_refuses_a_non_owner_and_emits_nothing(recording_bus) -> None:
+    # The write is what matters, but so is the event: SessionUpdated carries
+    # the owner's id and lands on the owner's realtime feed, so an accepted
+    # cross-owner touch would also inject into a stream the caller cannot read.
+    from pocketpaw_ee.cloud.shared.errors import Forbidden
+
+    session = MagicMock(
+        id="s_oid",
+        sessionId="websocket_abc",
+        owner="u1",
+        lastActivity=datetime.now(UTC),
+        messageCount=0,
+        save=AsyncMock(),
+    )
+    doc_stub = MagicMock()
+    doc_stub.find_one = AsyncMock(return_value=session)
+
+    with patch("pocketpaw_ee.cloud.sessions.service._SessionDoc", new=doc_stub):
+        with pytest.raises(Forbidden):
+            await sessions_service.touch("websocket_abc", "u2")
+
+    session.save.assert_not_awaited()
+    assert session.messageCount == 0
     assert not [e for e in recording_bus.events if isinstance(e, SessionUpdated)]

--- a/tests/cloud/test_e2e_api.py
+++ b/tests/cloud/test_e2e_api.py
@@ -1085,7 +1085,12 @@ class TestSessionsFlow:
         r1 = await http.post("/api/v1/sessions", json={"title": "Touch Me"}, headers=ctx["headers"])
         session_uuid = r1.json()["sessionId"]
 
-        r2 = await http.post(f"/api/v1/sessions/{session_uuid}/touch")
+        # Headers added 2026-08-01, when this route joined the rest of the
+        # router in requiring a session and session ownership. Guard coverage
+        # lives in tests/cloud/sessions/test_runtime_route_auth.py.
+        r2 = await http.post(
+            f"/api/v1/sessions/{session_uuid}/touch", headers=ctx["headers"]
+        )
         assert r2.status_code == 204
 
     async def test_create_session_linked_to_pocket(self, http: AsyncClient):

--- a/tests/cloud/test_e2e_api.py
+++ b/tests/cloud/test_e2e_api.py
@@ -1088,9 +1088,7 @@ class TestSessionsFlow:
         # Headers added 2026-08-01, when this route joined the rest of the
         # router in requiring a session and session ownership. Guard coverage
         # lives in tests/cloud/sessions/test_runtime_route_auth.py.
-        r2 = await http.post(
-            f"/api/v1/sessions/{session_uuid}/touch", headers=ctx["headers"]
-        )
+        r2 = await http.post(f"/api/v1/sessions/{session_uuid}/touch", headers=ctx["headers"])
         assert r2.status_code == 204
 
     async def test_create_session_linked_to_pocket(self, http: AsyncClient):


### PR DESCRIPTION
Adds Google and GitHub sign-in, connect/disconnect for provider accounts, and a standing audit that every mounted route carries a session guard. The session-route scoping fix came out of writing that audit.

## Social sign-in

Two adapters, one policy. Google is OIDC so the claims arrive signed in the `id_token`. GitHub is not OIDC and has no `id_token`, so `GET /user/emails` is the only thing that can say whether an address is verified.

The policy lives in `domain.py` as pure functions, with the I/O in `service.py`. It resolves a provider identity to an account in this order:

1. An existing link wins, and nothing else is consulted.
2. A provider-verified email may match an existing account.
3. An unverified email is refused, not treated as weaker evidence. An unverified provider address is an attacker-chosen string, and matching on one is the whole nOAuth takeover class.
4. A workspace enforcing SSO refuses the social path, so this cannot be used to sidestep it.

That SSO guard had a real bug worth mentioning: `WorkspaceMembership.workspace` is a string while `_id` is an ObjectId, so the `$in` query matched nothing and the guard never fired. Every unit test on the pure policy passed. Only an end-to-end test caught it, which is why there are end-to-end tests here and not just table-driven ones.

## Connect and disconnect

Three endpoints behind the session guard. The acting user always comes from the session, never from the request body — a link endpoint that trusts a body-supplied user id is an account-takeover primitive.

Two rules the link path deliberately does not share with sign-in. Email is not a join key here, because the session already says who this is. And an identity already attached to another account is refused rather than quietly re-pointed.

Unlink refuses to remove the last credential, and the interesting part is how it decides. It is not `bool(hashed_password)`: accounts minted by the social and SSO paths store an unusable sentinel in that field, so the obvious check answers "yes, they have a password" for precisely the people who have none, and would let them unlink their only way in. `_has_usable_password` tests for a real modular-crypt hash instead. Being wrong in that direction costs one refusal a user can fix by setting a password. Being wrong the other way is a permanent lockout support cannot reverse.

## Desktop

A Tauri webview carries no cookie for our origin, so both desktop flows finish over a one-time code rather than a cookie. Sign-in redeems `?xc=` for a bearer. Linking is different: the webview cannot prove which account is acting, so the callback parks the consented identity and hands `?link=` to the main window, which finishes the job over the bearer it already holds.

Those two are not interchangeable and live in separate single-use namespaces, so a code from one is refused by the other. An unknown `flow` is refused rather than defaulted, because a desktop client that silently got the web branch consents successfully and then attaches nothing, which reads as a frontend bug for as long as it takes someone to find the backend line that caused it.

## Route guard audit, and the session scoping

`test_route_auth_audit.py` walks every mounted route and requires it to reach a dependency that rejects an anonymous caller, with an explicit allowlist for routes that authenticate by other means.

Two things it pins that are easy to get wrong:

There is more than one guard family and they look nothing alike: `current_active_user`, `request_context`, `loopback_or_request_context`, and `require_scope`, which is a per-call closure and has to be matched by qualname. `require_license` is deliberately not one of them. It checks entitlement, not identity, and counting it would pass a route that never asks who the caller is.

The global middleware treats `/api/v1/` as auth-optional by design, since ee routes authenticate at the route level and a global 401 would reject callers mid-login. So a cloud route's own guard is the one that decides, and a route on the allowlist needs its in-handler check named rather than assumed. Eight were previously marked for review with no check named. Four turned out fine and now say which check covers them, and the three `/sessions/runtime` routes decide at the routing layer instead of in-handler.

Those three now carry the same session guard as the sibling listing routes, and scoping is enforced twice. `_load_session_index_async` takes its workspace and owner arguments as required rather than optional, so an unscoped listing cannot come back later by omission. `touch()` takes a required `user_id` and refuses a non-owner, matching how `_fetch_owned` already behaves for GET, PATCH and DELETE on the same id.

The file-store branch stays unscoped and that is correct: it is single-tenant by construction, and `verify_cloud_memory_backend` refuses to boot a cloud deployment on anything but `MongoMemoryStore`.

## Testing this locally will mislead you

`localhost_auth_bypass` defaults on and grants full access to any loopback caller. On a dev box you cannot tell "this endpoint requires auth" from "this endpoint let me in because I am on localhost". Set `POCKETPAW_LOCALHOST_AUTH_BYPASS=false`, or drive the ASGI app with no credentials, which is what these tests do.

The audit's assertions run against a public source address for that reason, with `/internal/*` from the same address included as a control so a green result cannot be the dispatcher no-opping.

## Known follow-up

The refusal table documents `auth.not_linked` and the service now emits it, but this branch also fixed a related shape problem worth knowing about: `NotFound(resource, id)` derives its code as `f"{resource}.not_found"`, so a human-readable resource name becomes a machine-readable identifier, spaces and all. There is now an assertion that no unlink refusal code contains a space. Other routes still build codes that way.

## Testing

620 passed across `tests/cloud/{auth,sessions,memory,pockets}`. 7 failures in `test_tool_executor.py` and `test_gallery_site_exclusion.py` are pre-existing and fail identically at the branch point. Ruff clean.
