### PR TITLE
feat(agents): defer the pydantic_ai MCP tools by default

### DIFF
--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -751,7 +751,7 @@ class Settings(BaseSettings):
         ),
     )
     pydantic_ai_defer_mcp_tools: bool = Field(
-        default=False,
+        default=True,
         description=(
             "Hide the Pydantic AI backend's MCP tools behind tool search "
             "instead of advertising every one of them on every model request. "
@@ -759,10 +759,22 @@ class Settings(BaseSettings):
             "tokens per request; deferring the 97 bridged ones leaves 38 on "
             "the wire for ~5,900, and the model calls ``search_tools`` to pull "
             "what it needs. Costs one extra model request per discovery, and "
-            "buys little on a surface that already gates hard. Off by default: "
-            "the token saving is measured, but whether a given model reliably "
-            "searches rather than giving up is a behaviour question that has "
-            "to be answered per model."
+            "buys little on a surface that already gates hard. "
+            "On by default since 2026-08-01. It shipped off because the saving "
+            "was measured but 'does this model search rather than give up' was "
+            "not, and that had to be answered per model. Answered: on "
+            "deepseek-v4-pro and deepseek-v4-flash, three prompts needing "
+            "deferred tools (tasks / icons / create-pocket) each called "
+            "``search_tools``, got the right tool back and called it. What "
+            "decided the default is the shape of the cost rather than the size "
+            "of it — tool schemas do NOT prompt-cache on the proxy (the "
+            "caching table in ``agents/pydantic_ai.py`` covers the text "
+            "prefix), so the full block is re-read on every turn including one "
+            "that uses no tools at all. Measured end to end against the proxy: "
+            "'hey' cost 133 tools / 32,225 schema tokens / 15.7s with this off "
+            "and 37 tools / 6,594 / 7.6s with it on. Set false to go back — a "
+            "model that will not search loses the deferred tools entirely, so "
+            "that is the escape hatch for one that turns out not to."
         ),
     )
     pydantic_ai_harness_enabled: bool = Field(

--- a/tests/test_pydantic_ai_backend.py
+++ b/tests/test_pydantic_ai_backend.py
@@ -881,10 +881,16 @@ def test_step_persistence_store_is_in_memory():
 
 
 def test_harness_can_be_disabled():
-    """Escape hatch: the dependency is pre-1.0 in cadence and pinned exactly."""
-    assert (
-        PydanticAIBackend(_settings(pydantic_ai_harness_enabled=False))._build_capabilities() == []
-    )
+    """Escape hatch: the dependency is pre-1.0 in cadence and pinned exactly.
+
+    Asserts no HARNESS capability survives rather than an empty list.
+    ``ToolSearch`` does not come from the harness — it is the deferral
+    override, on by default — so an empty list would tie this escape hatch to
+    an unrelated setting.
+    """
+    caps = PydanticAIBackend(_settings(pydantic_ai_harness_enabled=False))._build_capabilities()
+
+    assert not [c for c in caps if type(c).__module__.startswith("pydantic_ai_harness")], caps
 
 
 async def test_planning_capability_engages_on_a_real_run():
@@ -1626,12 +1632,44 @@ async def test_deferral_takes_the_mcp_tools_off_the_wire_and_leaves_the_builtins
 
 
 async def test_deferral_off_leaves_the_surface_exactly_as_it_was():
-    backend = _backend_with_model(_local_only(TestModel()))
+    """The escape hatch. Explicit ``False`` — deferral is the default now.
+
+    Kept because turning it off is the documented recovery for a model that
+    will not search, and a recovery path nobody exercises is not a recovery
+    path.
+    """
+    backend = _backend_with_model(_local_only(TestModel()), pydantic_ai_defer_mcp_tools=False)
     backend._mcp_tools = [_mcp_toolset("srv", "create_svelte_site", "publish")]
 
     names = await _deferred_surface(backend)
     assert "srv_publish" in names
     assert "search_tools" not in names
+
+
+def test_mcp_tools_are_deferred_without_anyone_asking(monkeypatch):
+    """The shipped default, read straight off the field.
+
+    Every other deferral test opts in through ``_deferring_backend``, so all of
+    them stayed green the whole time the default sent 32,225 tokens of schema
+    on every request. This one pins the default itself.
+
+    Read off ``model_fields`` rather than by constructing ``Settings``, because
+    a constructed one is NOT hermetic: ``security/url_validators.py`` calls
+    ``load_dotenv()`` at import time, so the developer's own ``.env`` is in
+    ``os.environ`` by the time any test builds settings. A behavioural version
+    of this test passed against ``default=False`` on the machine where the
+    change was written, purely because that machine had the flag set locally —
+    which is exactly the failure this test exists to catch.
+    """
+    assert Settings.model_fields["pydantic_ai_defer_mcp_tools"].default is True
+
+    # And the constructed value agrees once the local environment is out of the
+    # way — the field default is what a clean deployment actually gets.
+    monkeypatch.delenv("POCKETPAW_PYDANTIC_AI_DEFER_MCP_TOOLS", raising=False)
+    assert (
+        Settings(pydantic_ai_model="litellm:test-model", _env_file=None).pydantic_ai_defer_mcp_tools
+        is True
+    )
 
 
 async def test_a_denied_tool_cannot_be_discovered_by_searching_for_it():


### PR DESCRIPTION
Stacked on #1834.

## What this fixes

Saying "hey" to the `pydantic_ai` backend took 15.7 seconds. Not because of MCP startup, which is what it looks like from the boot logs, but because 133 tool schemas rode on every model request and tool schemas don't prompt-cache on our proxy the way the text prefix does. The whole block got re-read on every turn, including turns that touch no tools at all.

Measured end to end against the LiteLLM proxy by capturing the request body:

| | tools | schema tokens | total input | "hey" |
|---|---|---|---|---|
| before | 133 | 32,225 | ~36,900 | 15.7s |
| after | 37 | 6,594 | ~11,274 | 7.6s |

## Why now

The deferral machinery already landed in bb25583e and already fixed this. It shipped **off** because only half the question was answered: the token saving was measured, but whether a given model reliably calls `search_tools` instead of giving up is a behaviour question, and it had to be answered per model.

It's answered for both DeepSeek variants we actually run. Three prompts that each need a deferred tool, on `deepseek-v4-pro` and `deepseek-v4-flash`:

```
'What tasks are on my list right now?'    searched → pocketpaw_tasks_list_my_tasks
'Show me the icons available...'          searched → pocketpaw_icons_search_icons
'Create a pocket that tracks...'          searched → pocketpaw_pocket_specialist_create
```

Six for six. Flash needs more round trips than pro (4/6/8 vs 3/3/5 requests), so tool-heavy turns pay more for discovery there. The trivial-turn win is unaffected, and that's the case the complaint was about.

Gated surfaces are untouched — deferral already skips itself when a surface sets `exclusive_mcp_tools` or `allow_mcp_tool_ids`, so `/sites` and friends keep their explicit tool lists.

## Two tests move with the default

`test_harness_can_be_disabled` asserted the capability list came back empty. `ToolSearch` isn't a harness capability, so that assertion quietly tied the harness escape hatch to an unrelated setting. It now asserts no harness capability survives.

`test_deferral_off_leaves_the_surface_exactly_as_it_was` now sets the flag off explicitly.

## A trap worth knowing about

That second test was **already failing on any machine with the flag set in a local `.env`**, and that's the same thing that nearly let a broken test through here.

`security/url_validators.py` calls `load_dotenv()` at import time, and `config.py` imports it. So a developer's `.env` is in `os.environ` before any test constructs `Settings`. The first version of the new default test was behavioural, and it passed against `default=False` — purely because the machine it was written on had the flag set locally. It reads the field default instead, and fails in both directions now.

That's a broader fragility than this PR: the suite inherits whatever is in your `.env`. Worth a separate look.

## Testing

- `tests/test_pydantic_ai_backend.py` — 113 passed
- Sweep of `-k "config or agent or backend or tool"`: **18 failures before this change, 16 after**. No new ones, and two go green (the deferral-off test, plus one downstream of it). The rest are pre-existing `.env`-leak failures and one unrelated sites failure, all reproduced on a clean tree.
- Mutation-checked both directions: reverting the default fails the new test, restoring it passes.

## Rolling back

`POCKETPAW_PYDANTIC_AI_DEFER_MCP_TOOLS=false`. A model that won't search loses the deferred tools entirely, so that's the hatch if one turns out not to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
