### PR TITLE
feat(agents): defer the skills catalog too, and fix the DeepSeek reasoning echo it exposed

### DIFF
--- a/src/pocketpaw/agents/pydantic_ai.py
+++ b/src/pocketpaw/agents/pydantic_ai.py
@@ -414,6 +414,71 @@ _SURFACE_TOOL_EQUIVALENTS: dict[str, frozenset[str]] = {
 }
 
 
+# Model-name substrings whose providers REJECT a request when an assistant
+# message comes back without the reasoning field they produced. DeepSeek and
+# Moonshot are the two that emit ``reasoning_content`` (see the field list in
+# ``pydantic_ai/models/openai.py::_process_thinking``).
+_REASONING_ECHO_REQUIRED = ("deepseek", "moonshot", "kimi")
+
+
+def _reasoning_echo_model_class(model_name: str) -> type | None:
+    """An ``OpenAIChatModel`` that never omits ``reasoning_content``, or ``None``.
+
+    DeepSeek in thinking mode 400s the WHOLE request if any assistant message
+    in the history lacks ``reasoning_content``::
+
+        The `reasoning_content` in the thinking mode must be passed back to the API.
+
+    pydantic-ai writes that field only when the ``ModelResponse`` carries a
+    ``ThinkingPart``, so any assistant turn produced without one — most
+    reliably the continuation after a deferred capability's
+    ``load_capability`` — poisons every following request in the run.
+
+    The fix is the empty string, and that is not a guess. Replaying one captured
+    failing request against the proxy four ways:
+
+    ====================================================  ======
+    variant                                               status
+    ====================================================  ======
+    as captured                                              400
+    ``reasoning_content`` stripped from every message        400
+    empty ``reasoning_content`` where missing                200
+    placeholder text where missing                           200
+    ====================================================  ======
+
+    Note the second row: leaving the field off entirely does NOT work, so this
+    cannot be fixed by suppressing thinking. ``pydantic_ai_thinking=off`` was
+    tried and the run still 400s.
+
+    Applied by model name rather than to every OpenAI-compatible model, because
+    an unknown ``reasoning_content`` on a provider that does not expect one is a
+    new failure mode in exchange for nothing. Returns ``None`` for models that
+    do not need it, and the caller falls back to the stock class.
+    """
+    name = (model_name or "").lower()
+    if not any(tag in name for tag in _REASONING_ECHO_REQUIRED):
+        return None
+    try:
+        from pydantic_ai.models.openai import OpenAIChatModel
+    except ImportError:  # pragma: no cover - pydantic-ai always present here
+        return None
+
+    class _ReasoningEchoChatModel(OpenAIChatModel):
+        """``_map_model_response`` is pydantic-ai's documented subclass hook."""
+
+        def _map_model_response(self, message: Any) -> Any:
+            param = super()._map_model_response(message)
+            if (
+                param is not None
+                and param.get("role") == "assistant"
+                and "reasoning_content" not in param
+            ):
+                param["reasoning_content"] = ""
+            return param
+
+    return _ReasoningEchoChatModel
+
+
 _AGENTAPI_GATED_SURFACE = (
     "This surface controls which tools the agent may use, and the `agentapi` "
     "model cannot honour that.\n\n"
@@ -764,7 +829,8 @@ class PydanticAIBackend:
             provider,
             base_url,
         )
-        return OpenAIChatModel(model, provider=OpenAIProvider(**provider_kwargs))
+        cls = _reasoning_echo_model_class(model) or OpenAIChatModel
+        return cls(model, provider=OpenAIProvider(**provider_kwargs))
 
     def _get_http_client(self) -> Any:
         """The instance's shared HTTP client, built once.

--- a/src/pocketpaw/agents/pydantic_ai.py
+++ b/src/pocketpaw/agents/pydantic_ai.py
@@ -208,6 +208,12 @@ _OPENAI_COMPATIBLE = frozenset({"litellm", "openai", "openai_compatible", "openr
 # (see below), because it was never really about pocket sessions.
 _POCKET_SCOPE_SENTINEL = "<pocket-scope>"
 
+# The name the model uses to pull the skills catalog when
+# ``pydantic_ai_defer_skills`` is on. ``SkillsCapability`` requires an id once
+# ``defer_loading`` is set, and it appears in the model's ``load_capability``
+# call, so it is stable and readable rather than generated per run.
+_SKILLS_CAPABILITY_ID = "pocketpaw-skills"
+
 # Bounds on the per-session transcript cache (see ``_session_messages``).
 # ``logfire.configure`` is process-global and one backend instance exists per
 # agent, so the capability builder would otherwise reconfigure it per agent.
@@ -1230,11 +1236,45 @@ class PydanticAIBackend:
         if not skills:
             return None
 
-        logger.info("Pydantic AI: exposing %d PocketPaw skills", len(skills))
+        defer = bool(getattr(self.settings, "pydantic_ai_defer_skills", False))
+        logger.info(
+            "Pydantic AI: exposing %d PocketPaw skills%s",
+            len(skills),
+            " (deferred behind load_capability)" if defer else "",
+        )
+        if not defer:
+            return SkillsCapability(
+                skills=skills,
+                exclude_tools={"run_skill_script", "read_skill_resource"},
+                validate=False,
+            )
+
+        # Deferred: the catalog leaves the system prompt and the model pulls it
+        # with ``load_capability`` first. ``id`` is REQUIRED once
+        # ``defer_loading`` is set, and it is what the model names to load this,
+        # so it is a stable string rather than anything per-run.
+        #
+        # The description is written rather than left to the library's default.
+        # That default is ``'Provides specialized skills: ' + ', '.join(names)``,
+        # and our names alone ("pocketpaw-create-paw-site",
+        # "foresight-create-sim") do not tell a model that a request to build a
+        # landing page is one of these. A deferred capability nobody loads is
+        # strictly worse than no deferral: the skills are still built, still
+        # cost the round trip to discover, and never reach the model.
         return SkillsCapability(
             skills=skills,
             exclude_tools={"run_skill_script", "read_skill_resource"},
             validate=False,
+            id=_SKILLS_CAPABILITY_ID,
+            defer_loading=True,
+            description=(
+                "PocketPaw's own skills. Load this before building or editing "
+                "anything the product owns — pockets, dashboards, Paw Sites "
+                "(landing, dynamic, Svelte), Foresight scenarios, connector "
+                "workflows (Gmail, GitHub) and design/taste guidance. Each "
+                "skill carries the step-by-step procedure and the exact tools "
+                "for that job, so load this first rather than improvising one."
+            ),
         )
 
     @staticmethod

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -777,6 +777,39 @@ class Settings(BaseSettings):
             "that is the escape hatch for one that turns out not to."
         ),
     )
+    pydantic_ai_defer_skills: bool = Field(
+        default=False,
+        description=(
+            "Hide the Pydantic AI backend's skills catalog behind the agent's "
+            "``load_capability`` tool instead of listing every skill's name and "
+            "description in the system prompt. Measured against the proxy, the "
+            "19 bundled skills are 18,717 chars (~4,679 tokens) of the system "
+            "prompt; deferring drops that to 751 chars (~187), and a trivial "
+            "turn from 6.3s to 2.9s. "
+            "OFF BY DEFAULT, AND CURRENTLY BROKEN ON DEEPSEEK. Turning it on "
+            "makes a skill-using turn die with a 400 from the provider — "
+            "``The reasoning_content in the thinking mode must be passed back "
+            "to the API`` — immediately after the ``load_capability`` call. "
+            "Reproduced 2026-08-01 on deepseek-v4-flash AND deepseek-v4-pro: "
+            "4 of 4 deferred runs of 'build me a landing page' failed after "
+            "exactly one tool call, against 4 of 4 passing with this off. "
+            "``pydantic_ai_thinking=off`` does NOT avoid it. The traceback goes "
+            "through ``pydantic_ai/models/_continuation.py``, so the "
+            "deferred-capability continuation appears to rebuild the request "
+            "without echoing the reasoning field DeepSeek requires — an "
+            "upstream problem, not a setting we can tune. "
+            "Note this is NOT the same trade as ``pydantic_ai_defer_mcp_tools`` "
+            "even once that is fixed: the skills catalog rides in the system "
+            "prompt, which DOES prompt-cache on the proxy, so only a cold turn "
+            "or a cache miss pays for it. And a model that never calls "
+            "``load_capability`` loses every skill — skills are how pocket "
+            "creation, Paw Sites and Foresight know their own procedures, so "
+            "failing to load one degrades the product rather than just costing "
+            "a round trip. Worth turning on for a non-DeepSeek model where "
+            "cold-turn latency matters more than skill reliability; verify "
+            "a skill-using turn end to end before trusting it."
+        ),
+    )
     pydantic_ai_harness_enabled: bool = Field(
         default=True,
         description=(

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -778,7 +778,7 @@ class Settings(BaseSettings):
         ),
     )
     pydantic_ai_defer_skills: bool = Field(
-        default=False,
+        default=True,
         description=(
             "Hide the Pydantic AI backend's skills catalog behind the agent's "
             "``load_capability`` tool instead of listing every skill's name and "
@@ -786,28 +786,23 @@ class Settings(BaseSettings):
             "19 bundled skills are 18,717 chars (~4,679 tokens) of the system "
             "prompt; deferring drops that to 751 chars (~187), and a trivial "
             "turn from 6.3s to 2.9s. "
-            "OFF BY DEFAULT, AND CURRENTLY BROKEN ON DEEPSEEK. Turning it on "
-            "makes a skill-using turn die with a 400 from the provider — "
-            "``The reasoning_content in the thinking mode must be passed back "
-            "to the API`` — immediately after the ``load_capability`` call. "
-            "Reproduced 2026-08-01 on deepseek-v4-flash AND deepseek-v4-pro: "
-            "4 of 4 deferred runs of 'build me a landing page' failed after "
-            "exactly one tool call, against 4 of 4 passing with this off. "
-            "``pydantic_ai_thinking=off`` does NOT avoid it. The traceback goes "
-            "through ``pydantic_ai/models/_continuation.py``, so the "
-            "deferred-capability continuation appears to rebuild the request "
-            "without echoing the reasoning field DeepSeek requires — an "
-            "upstream problem, not a setting we can tune. "
-            "Note this is NOT the same trade as ``pydantic_ai_defer_mcp_tools`` "
-            "even once that is fixed: the skills catalog rides in the system "
-            "prompt, which DOES prompt-cache on the proxy, so only a cold turn "
-            "or a cache miss pays for it. And a model that never calls "
-            "``load_capability`` loses every skill — skills are how pocket "
-            "creation, Paw Sites and Foresight know their own procedures, so "
-            "failing to load one degrades the product rather than just costing "
-            "a round trip. Worth turning on for a non-DeepSeek model where "
-            "cold-turn latency matters more than skill reliability; verify "
-            "a skill-using turn end to end before trusting it."
+            "This depends on the ``reasoning_content`` echo fix in "
+            "``agents/pydantic_ai.py`` (``_reasoning_echo_model_class``) and "
+            "must not be enabled without it. Deferral is what reliably produces "
+            "an assistant turn with no thinking part — the continuation after "
+            "``load_capability`` — and DeepSeek 400s the whole request when one "
+            "comes back without ``reasoning_content``. Before that fix this "
+            "setting failed 4 of 4 landing-page runs on both v4-flash and "
+            "v4-pro, dying after exactly one tool call; after it, 4 of 4 pass "
+            "(7 to 28 tool calls each). "
+            "Worth knowing the saving is smaller than "
+            "``pydantic_ai_defer_mcp_tools``: tool schemas never prompt-cache "
+            "on the proxy, while this catalog rides in the system prompt, which "
+            "does — so mainly a cold turn or a cache miss pays for it. The "
+            "downside is also sharper. A model that never calls "
+            "``load_capability`` loses every skill, and skills are how pocket "
+            "creation, Paw Sites and Foresight know their own procedures. Set "
+            "false if a model turns out not to load them."
         ),
     )
     pydantic_ai_harness_enabled: bool = Field(

--- a/tests/test_pydantic_ai_backend.py
+++ b/tests/test_pydantic_ai_backend.py
@@ -838,6 +838,67 @@ def test_skill_names_is_part_of_the_agent_cache_key(monkeypatch):
     assert wide is not narrow, "cached agent reused across different skill subsets"
 
 
+def test_skills_are_listed_in_the_prompt_unless_deferral_is_asked_for(monkeypatch):
+    """Default stays eager: the catalog is in the system prompt.
+
+    Pinned because deferral is measurably cheaper and it would be easy to flip
+    on that basis alone — but it is broken on DeepSeek (see the setting's own
+    description), so the default moving is a decision, never a drift.
+    """
+    pytest.importorskip("pydantic_ai_skills", reason="pydantic-ai-skills not installed")
+
+    _fake_skills(monkeypatch, "alpha")
+
+    assert Settings.model_fields["pydantic_ai_defer_skills"].default is False
+    cap = PydanticAIBackend(_settings())._build_skills_capability()
+    assert cap.defer_loading is False
+    assert cap.id is None
+
+
+def test_deferred_skills_carry_an_id_and_a_description(monkeypatch):
+    """Both are load-bearing, and neither is checked by anything else.
+
+    ``id`` is REQUIRED by ``SkillsCapability`` once ``defer_loading`` is set,
+    and it is the name the model passes to ``load_capability``.
+
+    The description matters more than it looks. Left unset the library
+    synthesises ``'Provides specialized skills: ' + names``, and our names
+    ("pocketpaw-create-paw-site", "foresight-create-sim") do not tell a model
+    that "build me a landing page" is one of these. A deferred capability
+    nobody loads is worse than no deferral at all: the skills are still built,
+    still cost a round trip to find, and never reach the model.
+    """
+    pytest.importorskip("pydantic_ai_skills", reason="pydantic-ai-skills not installed")
+
+    _fake_skills(monkeypatch, "alpha")
+
+    cap = PydanticAIBackend(_settings(pydantic_ai_defer_skills=True))._build_skills_capability()
+
+    assert cap.defer_loading is True
+    assert cap.id, "defer_loading without an id is a construction error upstream"
+    described = cap.get_description() or ""
+    assert "pocket" in described.lower() and "site" in described.lower(), described
+    assert described != "Provides specialized skills: alpha.", "left on the library default"
+
+
+def test_deferral_does_not_change_which_skills_are_offered(monkeypatch):
+    """Deferral moves the catalog; it must not silently narrow it.
+
+    Same skills, same excluded tools — only where the catalog lives changes.
+    """
+    pytest.importorskip("pydantic_ai_skills", reason="pydantic-ai-skills not installed")
+
+    _fake_skills(monkeypatch, "alpha", "beta")
+
+    eager = PydanticAIBackend(_settings())._build_skills_capability()
+    deferred = PydanticAIBackend(
+        _settings(pydantic_ai_defer_skills=True)
+    )._build_skills_capability()
+
+    assert {s.name for s in eager.skills} == {s.name for s in deferred.skills}
+    assert set(eager.exclude_tools) == set(deferred.exclude_tools)
+
+
 def test_skills_disabled_returns_none():
     assert (
         PydanticAIBackend(_settings(pydantic_ai_skills_enabled=False))._build_skills_capability()

--- a/tests/test_pydantic_ai_backend.py
+++ b/tests/test_pydantic_ai_backend.py
@@ -838,19 +838,30 @@ def test_skill_names_is_part_of_the_agent_cache_key(monkeypatch):
     assert wide is not narrow, "cached agent reused across different skill subsets"
 
 
-def test_skills_are_listed_in_the_prompt_unless_deferral_is_asked_for(monkeypatch):
-    """Default stays eager: the catalog is in the system prompt.
+def test_the_skills_catalog_is_deferred_by_default(monkeypatch):
+    """Read off the field, not off a constructed ``Settings``.
 
-    Pinned because deferral is measurably cheaper and it would be easy to flip
-    on that basis alone — but it is broken on DeepSeek (see the setting's own
-    description), so the default moving is a decision, never a drift.
+    Same reason as ``test_mcp_tools_are_deferred_without_anyone_asking``:
+    ``load_dotenv()`` at import puts the developer's ``.env`` in ``os.environ``
+    before any test builds settings, so a constructed value proves nothing
+    about what ships.
     """
     pytest.importorskip("pydantic_ai_skills", reason="pydantic-ai-skills not installed")
 
     _fake_skills(monkeypatch, "alpha")
 
-    assert Settings.model_fields["pydantic_ai_defer_skills"].default is False
-    cap = PydanticAIBackend(_settings())._build_skills_capability()
+    assert Settings.model_fields["pydantic_ai_defer_skills"].default is True
+    cap = PydanticAIBackend(_settings(pydantic_ai_defer_skills=True))._build_skills_capability()
+    assert cap.defer_loading is True
+
+
+def test_the_eager_catalog_is_still_reachable(monkeypatch):
+    """The escape hatch, for a model that will not call ``load_capability``."""
+    pytest.importorskip("pydantic_ai_skills", reason="pydantic-ai-skills not installed")
+
+    _fake_skills(monkeypatch, "alpha")
+
+    cap = PydanticAIBackend(_settings(pydantic_ai_defer_skills=False))._build_skills_capability()
     assert cap.defer_loading is False
     assert cap.id is None
 
@@ -897,6 +908,81 @@ def test_deferral_does_not_change_which_skills_are_offered(monkeypatch):
 
     assert {s.name for s in eager.skills} == {s.name for s in deferred.skills}
     assert set(eager.exclude_tools) == set(deferred.exclude_tools)
+
+
+def _reasoning_model(name: str):
+    """Instantiate the reasoning-echo subclass for *name*, or return None."""
+    from pydantic_ai.providers.openai import OpenAIProvider
+
+    from pocketpaw.agents.pydantic_ai import _reasoning_echo_model_class
+
+    cls = _reasoning_echo_model_class(name)
+    if cls is None:
+        return None
+    return cls(name, provider=OpenAIProvider(base_url="http://localhost:4000/v1", api_key="sk-t"))
+
+
+def test_reasoning_echo_applies_only_to_providers_that_demand_it():
+    """An unknown ``reasoning_content`` elsewhere buys nothing and risks a 400."""
+    from pocketpaw.agents.pydantic_ai import _reasoning_echo_model_class
+
+    assert _reasoning_echo_model_class("deepseek/deepseek-v4-flash") is not None
+    assert _reasoning_echo_model_class("deepseek-v4-pro") is not None
+    assert _reasoning_echo_model_class("moonshot-v1-8k") is not None
+    assert _reasoning_echo_model_class("gpt-4o") is None
+    assert _reasoning_echo_model_class("claude-sonnet-4-6") is None
+    assert _reasoning_echo_model_class("") is None
+
+
+def test_an_assistant_turn_without_thinking_still_carries_reasoning_content():
+    """The actual bug. DeepSeek 400s the whole request without this field.
+
+    A turn with no ``ThinkingPart`` is what pydantic-ai produces for the
+    continuation after ``load_capability``, and stock ``OpenAIChatModel`` omits
+    ``reasoning_content`` for it. Replaying a captured failing request proved
+    the empty string is enough and that omitting the field is NOT (see
+    ``_reasoning_echo_model_class``).
+    """
+    from pydantic_ai.messages import ModelResponse, ToolCallPart
+
+    model = _reasoning_model("deepseek/deepseek-v4-flash")
+    assert model is not None
+
+    param = model._map_model_response(
+        ModelResponse(parts=[ToolCallPart(tool_name="search_tools", args={}, tool_call_id="c1")])
+    )
+    assert param is not None
+    assert param["reasoning_content"] == "", param
+
+
+def test_real_thinking_is_not_overwritten_by_the_echo_shim():
+    """The shim fills a gap; it must never clobber the model's own reasoning.
+
+    ``provider_name`` has to match the model's ``system`` or pydantic-ai routes
+    the thinking into ``<think>`` tags in the content instead of the
+    ``reasoning_content`` field (``_map_response_thinking_part``, 'auto' mode) —
+    which is how a real DeepSeek response arrives, and the only shape where
+    this test is asking the right question.
+    """
+    from pydantic_ai.messages import ModelResponse, TextPart, ThinkingPart
+
+    model = _reasoning_model("deepseek/deepseek-v4-flash")
+    assert model is not None
+
+    param = model._map_model_response(
+        ModelResponse(
+            parts=[
+                ThinkingPart(
+                    id="reasoning_content",
+                    content="the real chain of thought",
+                    provider_name=model.system,
+                ),
+                TextPart(content="hello"),
+            ]
+        )
+    )
+    assert param is not None
+    assert param["reasoning_content"] == "the real chain of thought", param
 
 
 def test_skills_disabled_returns_none():


### PR DESCRIPTION
Stacked on #1838.

The other half of the prompt bill, plus a provider bug that was hiding underneath it.

## The saving

The 19 bundled skills put 18,717 chars (~4,679 tokens) of names and descriptions in the system prompt on every request. `SkillsCapability` can hide that behind the agent's `load_capability` tool:

| | system prompt | trivial turn |
|---|---|---|
| eager | 18,717 chars (~4,679 tokens) | 6.3s |
| deferred | 751 chars (~187 tokens) | 2.9s |

## The bug it exposed

Turning deferral on killed every skill-using turn on DeepSeek with a 400:

```
The `reasoning_content` in the thinking mode must be passed back to the API.
```

Capturing the failing request showed the cause. The history had two assistant messages and only the first carried `reasoning_content`. pydantic-ai writes that field only when a `ModelResponse` has a `ThinkingPart`, and the continuation after `load_capability` produces one without.

Deferral didn't introduce this. It just produces that shape reliably, which is why it looked like a deferral bug.

Replaying the captured request against the proxy settled the fix:

| variant | status |
|---|---|
| as captured | 400 |
| `reasoning_content` stripped from every message | 400 |
| empty `reasoning_content` where missing | **200** |
| placeholder text where missing | **200** |

The second row is the useful one. Omitting the field entirely doesn't work either, so this could never have been fixed by suppressing thinking — which is why `POCKETPAW_PYDANTIC_AI_THINKING=off` didn't help when I tried it.

`_reasoning_echo_model_class` subclasses `OpenAIChatModel` and fills an empty `reasoning_content` on any assistant message missing one, through `_map_model_response` — the hook pydantic-ai documents for exactly this. It's applied by model name (DeepSeek, Moonshot, Kimi) rather than to every OpenAI-compatible model, because an unknown `reasoning_content` on a provider that doesn't expect one is a new failure mode bought for nothing.

**Live verification.** "Build me a landing page for my bakery" now runs to completion 4 of 4 on both `v4-flash` and `v4-pro`, 7 to 28 tool calls each, against 4 of 4 dying after exactly one call before. The repeated tool-loop trial is 3 of 3 with deferral both on and off.

This likely fixes intermittent 400s outside deferral too — any turn that lands without a thinking part hits it.

## Defaults

`pydantic_ai_defer_skills` ships on, now that it works.

Worth knowing the saving is smaller than #1838's. Tool schemas never prompt-cache on the proxy; this catalog rides in the system prompt, which does, so mainly a cold turn or a cache miss pays for it. The downside is sharper too: a model that never calls `load_capability` loses every skill, and skills are how pocket creation, Paw Sites and Foresight know their procedures. `POCKETPAW_PYDANTIC_AI_DEFER_SKILLS=false` is the way back.

## One detail worth review

The description handed to the capability is written out rather than left to the library, which would synthesise `'Provides specialized skills: ' + names`. Our names (`pocketpaw-create-paw-site`, `foresight-create-sim`) don't tell a model that "build me a landing page" is one of these, and a deferred capability nobody loads is worse than no deferral: still built, still a round trip to find, never reaching the model. A test pins it against the library default.

## Testing

- `tests/test_pydantic_ai_backend.py` — 120 passed, 7 new
- Same sweep as #1838: 16 failures before and after, all pre-existing `.env`-leak failures reproduced on a clean tree
- Mutation-checked both the shim and the deferral wiring: removing either fails its test

`test_real_thinking_is_not_overwritten_by_the_echo_shim` needed a correction worth noting. It first built a `ThinkingPart` with no `provider_name`, and pydantic-ai routes those into `<think>` tags in the content instead of the field — so it was passing judgement on a shape a real DeepSeek response never has. It now sets `provider_name` to the model's `system`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
