### PR TITLE
feat(tools): search the web through the LiteLLM gateway

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -92,6 +92,13 @@
 # POCKETPAW_WEB_SEARCH_PROVIDER=litellm
 # POCKETPAW_LITELLM_SEARCH_TOOL_NAME=web_search
 #
+# Only needed if you chain something in FRONT of the gateway — a compression
+# or observability proxy intercepts /v1/chat/completions and knows nothing
+# about /v1/search, so repointing POCKETPAW_LITELLM_API_BASE at it would 404
+# every search while completions kept working. Send search straight to the
+# real gateway:
+# POCKETPAW_LITELLM_SEARCH_API_BASE=https://your-gateway
+#
 # Tool names are chosen by whoever configured the proxy, not by convention.
 # Ask yours rather than guessing:
 #   curl -H "Authorization: Bearer $POCKETPAW_LITELLM_API_KEY" \

--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,23 @@
 # POCKETPAW_OLLAMA_MODEL=llama3.2
 
 # ── Agent Backend ─────────────────────────────────────────
-# POCKETPAW_AGENT_BACKEND=claude_agent_sdk    # claude_agent_sdk | openai_agents | google_adk | codex_cli | opencode | copilot_sdk
+# POCKETPAW_AGENT_BACKEND=claude_agent_sdk    # claude_agent_sdk | openai_agents | google_adk | codex_cli | opencode | copilot_sdk | deep_agents | pydantic_ai
+
+# pydantic_ai backend — in-process agent loop. Both deferral settings default
+# to ON; these are the escape hatches, not things you need to set.
+# POCKETPAW_PYDANTIC_AI_MODEL=litellm:deepseek-v4-flash
+#
+# Hides the bridged MCP tools behind search_tools instead of putting every
+# schema on every request (measured: 133 tools / ~32k tokens down to 37 /
+# ~6.6k). Tool schemas do not prompt-cache, so that was paid on every turn,
+# including one that uses no tools. Set false if a model will not search.
+# POCKETPAW_PYDANTIC_AI_DEFER_MCP_TOOLS=true
+#
+# Same idea for the skills catalog (~18.7k chars of system prompt down to
+# ~750). Smaller win — the system prompt DOES cache, so mainly a cold turn
+# pays. Set false if a model will not call load_capability, since it then
+# loses every skill.
+# POCKETPAW_PYDANTIC_AI_DEFER_SKILLS=true
 
 # ── Telegram ──────────────────────────────────────────────
 # POCKETPAW_TELEGRAM_BOT_TOKEN=
@@ -65,9 +81,29 @@
 # POCKETPAW_MEM0_OLLAMA_BASE_URL=http://ollama:11434  # use service name in Docker
 
 # ── Web Search ────────────────────────────────────────────
-# POCKETPAW_WEB_SEARCH_PROVIDER=tavily # tavily | brave
+# POCKETPAW_WEB_SEARCH_PROVIDER=tavily # tavily | brave | parallel | litellm
 # POCKETPAW_TAVILY_API_KEY=
 # POCKETPAW_BRAVE_SEARCH_API_KEY=
+# POCKETPAW_PARALLEL_API_KEY=
+#
+# 'litellm' searches through your LiteLLM gateway's Search API
+# (POST /v1/search) instead of a vendor, reusing POCKETPAW_LITELLM_API_BASE
+# and POCKETPAW_LITELLM_API_KEY — no second key, no second egress path.
+# POCKETPAW_WEB_SEARCH_PROVIDER=litellm
+# POCKETPAW_LITELLM_SEARCH_TOOL_NAME=web_search
+#
+# Tool names are chosen by whoever configured the proxy, not by convention.
+# Ask yours rather than guessing:
+#   curl -H "Authorization: Bearer $POCKETPAW_LITELLM_API_KEY" \
+#        "$POCKETPAW_LITELLM_API_BASE/v1/search/tools"
+# An unregistered name fails with
+#   Search tool '<name>' not found in router.search_tools
+#
+# NOTE: a gateway's search is a SEPARATE endpoint from chat completions.
+# Asking the model's provider to search inside chat/completions (via
+# web_search_options or a {"type":"web_search"} server tool) is silently
+# ignored when the model has no native search — 200, no citations, and an
+# answer from training data. Use this provider instead.
 
 # ── Image Generation ──────────────────────────────────────
 # POCKETPAW_GOOGLE_API_KEY=

--- a/docs/tools/web-search.mdx
+++ b/docs/tools/web-search.mdx
@@ -1,19 +1,19 @@
 ---
-title: "Web Search Tool: Tavily & Brave Search Integration"
-description: "Search the web from PocketPaw using Tavily or Brave Search APIs. Returns structured results the agent can reason over. Configure your preferred search provider with a single environment variable."
+title: "Web Search Tool: Tavily, Brave, Parallel & LiteLLM Search"
+description: "Search the web from PocketPaw using Tavily, Brave, Parallel AI, or your LiteLLM gateway's Search API. Returns structured results the agent can reason over. Configure your preferred search provider with a single environment variable."
 section: Tools
 ogType: article
-keywords: ["web search", "tavily", "brave search", "search api", "internet search"]
+keywords: ["web search", "tavily", "brave search", "parallel ai", "litellm", "search api", "internet search"]
 tags: ["tools", "search"]
 ---
 
-# Web Search Tool: Tavily & Brave Search Integration
+# Web Search Tool: Tavily, Brave, Parallel & LiteLLM Search
 
 The web search tool enables PocketPaw to search the internet for real-time information.
 
 ## Providers
 
-Two search providers are supported:
+Four search providers are supported.
 
 ### Tavily (Recommended)
 
@@ -32,6 +32,59 @@ export POCKETPAW_TAVILY_API_KEY="tvly-your-key"
 export POCKETPAW_WEB_SEARCH_PROVIDER="brave"
 export POCKETPAW_BRAVE_SEARCH_API_KEY="your-key"
 ```
+
+### Parallel AI
+
+[Parallel](https://parallel.ai) called directly, with its own key.
+
+```bash
+export POCKETPAW_WEB_SEARCH_PROVIDER="parallel"
+export POCKETPAW_PARALLEL_API_KEY="your-key"
+```
+
+### LiteLLM gateway
+
+If you already run a [LiteLLM](https://docs.litellm.ai) proxy, register your
+search tools there and PocketPaw will call them through it. No second vendor
+key to distribute, no second egress path to allow, and the proxy keeps usage
+accounting for search next to completions.
+
+```bash
+export POCKETPAW_WEB_SEARCH_PROVIDER="litellm"
+export POCKETPAW_LITELLM_API_BASE="https://your-gateway"
+export POCKETPAW_LITELLM_API_KEY="sk-..."
+export POCKETPAW_LITELLM_SEARCH_TOOL_NAME="web_search"
+```
+
+`POCKETPAW_LITELLM_SEARCH_TOOL_NAME` picks which registered tool to call. Those
+names are chosen by whoever configured the proxy, so ask yours:
+
+```bash
+curl -H "Authorization: Bearer $POCKETPAW_LITELLM_API_KEY" \
+  "$POCKETPAW_LITELLM_API_BASE/v1/search/tools"
+```
+
+```json
+{"object": "list", "data": [
+  {"search_tool_name": "web_search", "search_provider": "parallel_ai"},
+  {"search_tool_name": "tinyfish_web_Search", "search_provider": "tinyfish"}
+]}
+```
+
+A name that isn't registered fails with
+`Search tool '<name>' not found in router.search_tools`, and the tool echoes
+that back along with the URL above.
+
+<Note>
+A LiteLLM gateway's search lives at `POST /v1/search`, which is a **different
+endpoint from chat completions**. Asking the model's own provider to search
+inside `chat/completions` — via `web_search_options` or a
+`{"type": "web_search"}` server tool — is silently ignored on a gateway
+fronting a model without native search: the request returns 200, no citations
+come back, and the model answers from training data as though nothing was
+asked. Use this provider rather than a provider-side web capability when your
+search lives on the gateway.
+</Note>
 
 ## Usage
 

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1457,6 +1457,21 @@ class Settings(BaseSettings):
             "``GET {litellm_api_base}/v1/search/tools``."
         ),
     )
+    litellm_search_api_base: str | None = Field(
+        default=None,
+        description=(
+            "Base URL for the search API when "
+            "``web_search_provider='litellm'``. Defaults to "
+            "``litellm_api_base``, which is right until something is chained in "
+            "front of the gateway. A compression or observability proxy "
+            "(Headroom, for one) intercepts ``/v1/chat/completions``, "
+            "``/v1/messages`` and ``/v1/responses`` and knows nothing about "
+            "``/v1/search`` — so pointing ``litellm_api_base`` at it moves the "
+            "model traffic and 404s every web search. Set this to the real "
+            "gateway to send search straight there while completions take the "
+            "detour."
+        ),
+    )
     litellm_search_tool_name: str = Field(
         default="web_search",
         description=(

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1444,7 +1444,30 @@ class Settings(BaseSettings):
 
     # Web Search
     web_search_provider: str = Field(
-        default="tavily", description="Web search provider: 'tavily' or 'brave'"
+        default="tavily",
+        description=(
+            "Web search provider: 'tavily', 'brave', 'parallel', or 'litellm'. "
+            "'litellm' routes through the LiteLLM proxy's Search API "
+            "(``POST {litellm_api_base}/v1/search``) instead of calling a "
+            "vendor directly, so it reuses the proxy credentials already "
+            "configured and inherits whatever search tools the operator "
+            "registered there — no second key to distribute, and the proxy "
+            "keeps the usage accounting. Pick which registered tool with "
+            "``litellm_search_tool_name``; list them with "
+            "``GET {litellm_api_base}/v1/search/tools``."
+        ),
+    )
+    litellm_search_tool_name: str = Field(
+        default="web_search",
+        description=(
+            "Which search tool to call when ``web_search_provider='litellm'``. "
+            "These names are defined by whoever configured the proxy, not by a "
+            "convention — on the reference gateway they are 'web_search' "
+            "(provider parallel_ai) and 'tinyfish_web_Search' (provider "
+            "tinyfish). ``GET {litellm_api_base}/v1/search/tools`` lists what a "
+            "given proxy actually has; a name that is not registered fails with "
+            "``Search tool '<name>' not found in router.search_tools``."
+        ),
     )
     tavily_api_key: str | None = Field(default=None, description="Tavily search API key")
     brave_search_api_key: str | None = Field(default=None, description="Brave Search API key")

--- a/src/pocketpaw/tools/builtin/web_search.py
+++ b/src/pocketpaw/tools/builtin/web_search.py
@@ -215,12 +215,22 @@ class WebSearchTool(BaseTool):
         distribute, no second egress path to allow, and the proxy keeps the
         usage accounting for search alongside completions.
         """
-        base = str(getattr(settings, "litellm_api_base", "") or "").rstrip("/")
+        # ``litellm_search_api_base`` wins when set. It exists for the case
+        # where something is chained in FRONT of the gateway: a compression or
+        # observability proxy intercepts /v1/chat/completions and friends and
+        # knows nothing about /v1/search, so a deployment that repoints
+        # ``litellm_api_base`` at it would 404 every search while completions
+        # kept working — a break that shows up only in the tool.
+        base = str(
+            getattr(settings, "litellm_search_api_base", None)
+            or getattr(settings, "litellm_api_base", "")
+            or ""
+        ).rstrip("/")
         key = getattr(settings, "litellm_api_key", None)
         if not base:
             return self._error(
-                "LiteLLM base URL not configured. "
-                "Set POCKETPAW_LITELLM_API_BASE or switch to 'tavily'/'brave'."
+                "LiteLLM base URL not configured. Set POCKETPAW_LITELLM_API_BASE "
+                "(or POCKETPAW_LITELLM_SEARCH_API_BASE) or switch to 'tavily'/'brave'."
             )
         tool_name = str(getattr(settings, "litellm_search_tool_name", "") or "web_search")
 

--- a/src/pocketpaw/tools/builtin/web_search.py
+++ b/src/pocketpaw/tools/builtin/web_search.py
@@ -1,6 +1,12 @@
-# Web Search tool — search the web via Tavily or Brave APIs.
+# Web Search tool — search the web via Tavily, Brave, Parallel, or the
+# LiteLLM proxy's Search API.
 # Created: 2026-02-06
 # Part of Phase 1 Quick Wins
+# 2026-08-01: added the 'litellm' provider. It POSTs to the proxy's
+#   /v1/search with a `search_tool_name`, so a deployment that already talks
+#   to a LiteLLM gateway gets web search with no second vendor key and no
+#   second egress path. Whatever the operator registered there (parallel_ai,
+#   tinyfish, …) is reachable by name.
 
 import logging
 from typing import Any
@@ -67,9 +73,12 @@ class WebSearchTool(BaseTool):
             return await self._search_brave(query, num_results, settings.brave_search_api_key)
         elif provider == "parallel":
             return await self._search_parallel(query, num_results, settings.parallel_api_key)
+        elif provider == "litellm":
+            return await self._search_litellm(query, num_results, settings)
         else:
             return self._error(
-                f"Unknown search provider '{provider}'. Use 'tavily', 'brave', or 'parallel'."
+                f"Unknown search provider '{provider}'. "
+                "Use 'tavily', 'brave', 'parallel', or 'litellm'."
             )
 
     async def _search_tavily(self, query: str, num_results: int, api_key: str | None) -> str:
@@ -185,6 +194,86 @@ class WebSearchTool(BaseTool):
 
         except httpx.HTTPStatusError as e:
             return self._error(f"Parallel AI API error: {e.response.status_code}")
+        except Exception as e:
+            return self._error(f"Search failed: {e}")
+
+    async def _search_litellm(self, query: str, num_results: int, settings: Any) -> str:
+        """Search through the LiteLLM proxy's Search API rather than a vendor.
+
+        Worth being precise about why this is a TOOL provider and not one of
+        the pydantic_ai backend's native web capabilities, because the native
+        route looks like it should work and does not. pydantic-ai's
+        ``WebSearch`` asks the model's own provider to run the search inside
+        ``chat/completions``. Sending that at this gateway returns 200 and
+        searches NOTHING — measured 2026-08-01, both ``web_search_options={}``
+        and ``tools=[{"type": "web_search"}]`` came back with no citations and
+        a model that still said it had no live access. The gateway's search
+        lives behind a SEPARATE endpoint, so a tool is what can reach it.
+
+        Going through the proxy rather than straight to the vendor is what
+        makes this worth having next to ``_search_parallel``: no second key to
+        distribute, no second egress path to allow, and the proxy keeps the
+        usage accounting for search alongside completions.
+        """
+        base = str(getattr(settings, "litellm_api_base", "") or "").rstrip("/")
+        key = getattr(settings, "litellm_api_key", None)
+        if not base:
+            return self._error(
+                "LiteLLM base URL not configured. "
+                "Set POCKETPAW_LITELLM_API_BASE or switch to 'tavily'/'brave'."
+            )
+        tool_name = str(getattr(settings, "litellm_search_tool_name", "") or "web_search")
+
+        try:
+            async with httpx.AsyncClient(timeout=30) as client:
+                resp = await client.post(
+                    f"{base}/v1/search",
+                    headers={
+                        # The proxy accepts an unauthenticated call only if it
+                        # was configured that way; sending an empty bearer is
+                        # worse than sending none.
+                        **({"Authorization": f"Bearer {key}"} if key else {}),
+                        "Content-Type": "application/json",
+                    },
+                    json={
+                        "search_tool_name": tool_name,
+                        "query": query,
+                        "max_results": num_results,
+                    },
+                )
+                resp.raise_for_status()
+                data = resp.json()
+
+            results = data.get("results", [])
+            if not results:
+                return f"No results found for: {query}"
+
+            # The gateway returns ``snippet``; ``_format_results`` reads
+            # ``content``. Normalising here keeps one output shape across all
+            # four providers rather than teaching the formatter a second one.
+            normalized = [
+                {
+                    "title": r.get("title", ""),
+                    "url": r.get("url", ""),
+                    "content": r.get("snippet") or r.get("content") or "",
+                }
+                for r in results[:num_results]
+            ]
+            return self._format_results(query, normalized)
+
+        except httpx.HTTPStatusError as e:
+            # A wrong ``search_tool_name`` is the likely misconfiguration and
+            # the proxy names it in the body, so pass that through instead of
+            # reporting a bare status code.
+            detail = ""
+            try:
+                detail = f" — {e.response.json().get('error', {}).get('message', '')}"
+            except Exception:  # noqa: BLE001
+                detail = ""
+            return self._error(
+                f"LiteLLM search API error: {e.response.status_code}{detail}. "
+                f"Registered tools: GET {base}/v1/search/tools"
+            )
         except Exception as e:
             return self._error(f"Search failed: {e}")
 

--- a/tests/test_web_search.py
+++ b/tests/test_web_search.py
@@ -260,3 +260,119 @@ class TestWebSearchTool:
             result = await tool.execute(query="test", num_results=50)
 
         assert "A" in result
+
+
+class TestLiteLLMSearchProvider:
+    """The 'litellm' provider — search through the proxy, not a vendor.
+
+    Exists because the obvious-looking route does not work: pydantic-ai's
+    native ``WebSearch`` asks the MODEL's provider to search inside
+    ``chat/completions``, and the reference gateway answers 200 while
+    searching nothing. Its search lives behind ``POST /v1/search``, which only
+    a tool can reach.
+    """
+
+    @staticmethod
+    def _client(mock_resp):
+        client = AsyncMock()
+        client.post.return_value = mock_resp
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=False)
+        return client
+
+    @patch("pocketpaw.tools.builtin.web_search.get_settings")
+    async def test_posts_to_the_proxy_search_endpoint_with_the_configured_tool(
+        self, mock_settings, tool
+    ):
+        mock_settings.return_value = MagicMock(
+            web_search_provider="litellm",
+            litellm_api_base="https://gw.example.com/",
+            litellm_api_key="sk-proxy",
+            litellm_search_tool_name="web_search",
+        )
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json.return_value = {"results": [{"title": "T", "url": "https://u", "snippet": "S"}]}
+
+        with patch("httpx.AsyncClient") as cls:
+            client = self._client(resp)
+            cls.return_value = client
+            result = await tool.execute(query="who won", num_results=3)
+
+        url, kwargs = client.post.call_args[0][0], client.post.call_args[1]
+        # Trailing slash on the base must not produce '//v1/search'.
+        assert url == "https://gw.example.com/v1/search", url
+        assert kwargs["json"]["search_tool_name"] == "web_search"
+        assert kwargs["json"]["query"] == "who won"
+        assert kwargs["headers"]["Authorization"] == "Bearer sk-proxy"
+        assert "T" in result and "https://u" in result
+
+    @patch("pocketpaw.tools.builtin.web_search.get_settings")
+    async def test_snippet_is_normalised_into_the_shared_result_shape(self, mock_settings, tool):
+        """The gateway returns ``snippet``; every other provider yields ``content``.
+
+        Without the rename the formatter prints an empty body for every hit —
+        results that look present and say nothing.
+        """
+        mock_settings.return_value = MagicMock(
+            web_search_provider="litellm",
+            litellm_api_base="https://gw.example.com",
+            litellm_api_key="sk-proxy",
+            litellm_search_tool_name="web_search",
+        )
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json.return_value = {
+            "results": [{"title": "T", "url": "https://u", "snippet": "the useful part"}]
+        }
+
+        with patch("httpx.AsyncClient") as cls:
+            cls.return_value = self._client(resp)
+            result = await tool.execute(query="q")
+
+        assert "the useful part" in result
+
+    @patch("pocketpaw.tools.builtin.web_search.get_settings")
+    async def test_an_unregistered_tool_name_reports_what_to_do(self, mock_settings, tool):
+        """The likely misconfiguration, and the proxy names it in the body.
+
+        A bare '500' would send someone reading gateway logs; the registered
+        names are one documented GET away.
+        """
+        mock_settings.return_value = MagicMock(
+            web_search_provider="litellm",
+            litellm_api_base="https://gw.example.com",
+            litellm_api_key="sk-proxy",
+            litellm_search_tool_name="nope",
+        )
+        resp = MagicMock()
+        resp.status_code = 500
+        resp.json.return_value = {
+            "error": {"message": "Search tool 'nope' not found in router.search_tools"}
+        }
+        resp.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError("boom", request=MagicMock(), response=resp)
+        )
+
+        with patch("httpx.AsyncClient") as cls:
+            cls.return_value = self._client(resp)
+            result = await tool.execute(query="q")
+
+        assert "not found in router.search_tools" in result
+        assert "/v1/search/tools" in result
+
+    @patch("pocketpaw.tools.builtin.web_search.get_settings")
+    async def test_missing_base_url_says_so_instead_of_calling_nothing(self, mock_settings, tool):
+        mock_settings.return_value = MagicMock(
+            web_search_provider="litellm",
+            litellm_api_base="",
+            litellm_api_key="sk-proxy",
+            litellm_search_tool_name="web_search",
+        )
+        result = await tool.execute(query="q")
+        assert "LITELLM_API_BASE" in result
+
+    @patch("pocketpaw.tools.builtin.web_search.get_settings")
+    async def test_unknown_provider_lists_litellm_as_an_option(self, mock_settings, tool):
+        mock_settings.return_value = MagicMock(web_search_provider="bogus")
+        assert "litellm" in await tool.execute(query="q")

--- a/tests/test_web_search.py
+++ b/tests/test_web_search.py
@@ -287,6 +287,7 @@ class TestLiteLLMSearchProvider:
         mock_settings.return_value = MagicMock(
             web_search_provider="litellm",
             litellm_api_base="https://gw.example.com/",
+            litellm_search_api_base=None,
             litellm_api_key="sk-proxy",
             litellm_search_tool_name="web_search",
         )
@@ -366,6 +367,7 @@ class TestLiteLLMSearchProvider:
         mock_settings.return_value = MagicMock(
             web_search_provider="litellm",
             litellm_api_base="",
+            litellm_search_api_base=None,
             litellm_api_key="sk-proxy",
             litellm_search_tool_name="web_search",
         )
@@ -376,3 +378,66 @@ class TestLiteLLMSearchProvider:
     async def test_unknown_provider_lists_litellm_as_an_option(self, mock_settings, tool):
         mock_settings.return_value = MagicMock(web_search_provider="bogus")
         assert "litellm" in await tool.execute(query="q")
+
+
+class TestSearchBaseUrlOverride:
+    """Search must survive a proxy being chained in front of the gateway."""
+
+    @staticmethod
+    def _client(resp):
+        client = AsyncMock()
+        client.post.return_value = resp
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=False)
+        return client
+
+    @staticmethod
+    def _resp():
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json.return_value = {"results": [{"title": "T", "url": "u", "snippet": "s"}]}
+        return resp
+
+    @patch("pocketpaw.tools.builtin.web_search.get_settings")
+    async def test_search_can_bypass_a_proxy_that_only_handles_completions(
+        self, mock_settings, tool
+    ):
+        """The Headroom case, and the reason this override exists.
+
+        A compression proxy intercepts /v1/chat/completions, /v1/messages and
+        /v1/responses. It knows nothing about /v1/search. So a deployment that
+        repoints ``litellm_api_base`` at it keeps completions working and 404s
+        every web search — a break visible only in the tool.
+        """
+        mock_settings.return_value = MagicMock(
+            web_search_provider="litellm",
+            litellm_api_base="https://headroom.internal",  # completions detour
+            litellm_search_api_base="https://gw.example.com",  # real gateway
+            litellm_api_key="sk-proxy",
+            litellm_search_tool_name="web_search",
+        )
+
+        with patch("httpx.AsyncClient") as cls:
+            client = self._client(self._resp())
+            cls.return_value = client
+            await tool.execute(query="q")
+
+        assert client.post.call_args[0][0] == "https://gw.example.com/v1/search"
+
+    @patch("pocketpaw.tools.builtin.web_search.get_settings")
+    async def test_it_falls_back_to_the_shared_base_when_unset(self, mock_settings, tool):
+        """The override is opt-in; nothing changes for a normal deployment."""
+        mock_settings.return_value = MagicMock(
+            web_search_provider="litellm",
+            litellm_api_base="https://gw.example.com",
+            litellm_search_api_base=None,
+            litellm_api_key="sk-proxy",
+            litellm_search_tool_name="web_search",
+        )
+
+        with patch("httpx.AsyncClient") as cls:
+            client = self._client(self._resp())
+            cls.return_value = client
+            await tool.execute(query="q")
+
+        assert client.post.call_args[0][0] == "https://gw.example.com/v1/search"


### PR DESCRIPTION
Stacked on #1839.

Wires PocketPaw's `web_search` tool to a LiteLLM gateway's Search API, so a deployment that already talks to one gets web search with no second vendor key, no second egress path, and search usage accounted next to completions.

```bash
export POCKETPAW_WEB_SEARCH_PROVIDER="litellm"
export POCKETPAW_LITELLM_SEARCH_TOOL_NAME="web_search"
```

Whatever the operator registered on the proxy is reachable by name. Ask a gateway what it has:

```bash
curl -H "Authorization: Bearer $KEY" "$BASE/v1/search/tools"
{"data":[{"search_tool_name":"web_search","search_provider":"parallel_ai"},
         {"search_tool_name":"tinyfish_web_Search","search_provider":"tinyfish"}]}
```

Verified against the reference gateway — both tools return live results, dated today.

## Why a tool provider and not a native web capability

This is the part worth a reviewer's attention, because the other route looks correct and isn't.

The `pydantic_ai` backend already has `pydantic_ai_native_web_tools` (#1833), which maps our `web_search` onto pydantic-ai's `WebSearch` capability. That asks **the model's own provider** to run the search inside `chat/completions`. Pointed at a gateway fronting a model with no native search, it returns **200 and searches nothing**:

| request | result |
|---|---|
| plain (control) | no citations, answers from training data |
| `web_search_options={}` | 200, no citations, *"I don't have access to live or recent results"* |
| `tools=[{"type":"web_search"}]` | 200, no citations, *"that is after my knowledge cutoff"* |

A gateway's search lives behind `POST /v1/search`, a different endpoint. So the tool is what can reach it, and enabling the native capability instead would look like it worked while quietly answering from training data. There's a `<Note>` in the docs saying exactly that, because "it returned 200" is the whole trap.

## Two details

**`snippet` vs `content`.** The gateway returns `snippet`; every other provider yields `content`. Without the rename the formatter prints an empty body for every hit — results that look present and say nothing. Normalised at the provider so there's one output shape across all four, and a test pins it (mutation-checked: dropping the rename fails).

**Errors name the fix.** A wrong `search_tool_name` is the likely misconfiguration and the proxy names it in the body, so that's passed through with the `/v1/search/tools` URL attached rather than a bare `500`.

```
Error: LiteLLM search API error: 500 — Search tool 'does-not-exist' not found in
router.search_tools. Registered tools: GET https://.../v1/search/tools
```

## Docs

`docs/tools/web-search.mdx` was already a version behind — it documented two providers when the code had three (`parallel` shipped undocumented). It now covers all four.

## Not included

`WebFetch`/`url_extract` stays as it is. The gateway's Search API is search-only; there's no extract endpoint exposed on it to route to.

## Testing

- `tests/test_web_search.py` — 19 passed, 5 new
- `test_web_search.py` + `test_research.py` + `test_pydantic_ai_backend.py` — 148 passed
- Live: both registered tools return real results; unregistered name produces the actionable error above
- Mutation-checked the `snippet` normalisation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
