### PR TITLE
fix(dashboard): stop logging aborted-accept tracebacks on Windows

### DIFF
--- a/src/pocketpaw/asyncio_noise.py
+++ b/src/pocketpaw/asyncio_noise.py
@@ -1,0 +1,106 @@
+"""Keep benign Windows accept-aborts out of the asyncio error log.
+
+Created: 2026-08-01
+Changes:
+  - 2026-08-01: initial — ``install_accept_noise_filter()`` swallows the
+    ``Accept failed on a socket`` / orphaned ``accept_coro`` pair that the
+    Windows ProactorEventLoop logs (with a full traceback) every time a
+    client aborts a TCP connection between ``AcceptEx`` and its completion.
+
+Why a loop exception handler and not a log filter: both messages are emitted
+by ``loop.call_exception_handler()``, which formats and logs them itself, so
+they arrive at the ``asyncio`` logger already rendered at ERROR. Intercepting
+at the handler is the only place the pair can be dropped as a unit.
+
+Why not switch event loops: ``SelectorEventLoop`` does not log this, but it
+cannot spawn subprocesses on Windows, which would break every stdio MCP
+server. The noise is the cheaper problem.
+"""
+
+import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Windows error codes a pending AcceptEx reports when the peer goes away
+# before the overlapped operation completes. Operationally identical: the
+# client vanished, the listening socket is fine, asyncio re-arms the accept.
+_BENIGN_ACCEPT_WINERRORS = frozenset(
+    {
+        64,  # ERROR_NETNAME_DELETED — "The specified network name is no longer available"
+        121,  # ERROR_SEM_TIMEOUT — half-open connection timed out mid-accept
+        995,  # ERROR_OPERATION_ABORTED — pending accept cancelled during shutdown
+        1236,  # ERROR_CONNECTION_ABORTED — peer sent RST
+    }
+)
+
+# Substrings that identify the proactor's own accept coroutine. Used to scope
+# the very generic "Task exception was never retrieved" message so an
+# application task's unretrieved error is never mistaken for accept noise.
+_ACCEPT_COROUTINE_MARKERS = ("accept_coro", "IocpProactor.accept")
+
+
+def _is_benign_accept_error(context: dict) -> bool:
+    """True when ``context`` is the Windows aborted-accept noise, nothing else.
+
+    ``context`` is an asyncio exception-handler context dict. Two distinct
+    messages arrive per aborted connection: the proactor's own
+    ``Accept failed on a socket``, and a ``Task exception was never
+    retrieved`` when the orphaned accept coroutine is finalized.
+    """
+    exc = context.get("exception")
+    if not isinstance(exc, OSError):
+        return False
+
+    # ``winerror`` only exists on Windows, so this is inert on POSIX — which
+    # is correct: the selector loop handles ECONNABORTED itself and never
+    # reaches the exception handler.
+    if getattr(exc, "winerror", None) not in _BENIGN_ACCEPT_WINERRORS:
+        return False
+
+    message = context.get("message") or ""
+    if message == "Accept failed on a socket":
+        return True
+
+    if message.startswith("Task exception was never retrieved"):
+        target = repr(context.get("future") or context.get("task"))
+        return any(marker in target for marker in _ACCEPT_COROUTINE_MARKERS)
+
+    return False
+
+
+def install_accept_noise_filter(loop: asyncio.AbstractEventLoop | None = None) -> bool:
+    """Install the filter on ``loop`` (default: the running loop).
+
+    Anything that is not an aborted accept is passed to whatever handler was
+    already installed, falling back to asyncio's default — so this suppresses
+    noise without ever hiding a real error.
+
+    Returns ``True`` once a filter is in place, ``False`` if there was no loop
+    to install it on. Safe to call more than once; the second call is a no-op.
+    """
+    if loop is None:
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return False
+
+    previous = loop.get_exception_handler()
+    if getattr(previous, "_pocketpaw_accept_filter", False):
+        return True
+
+    def handler(loop_: asyncio.AbstractEventLoop, context: dict) -> None:
+        if _is_benign_accept_error(context):
+            logger.debug(
+                "Dropped aborted-accept noise (client disconnected before AcceptEx completed): %s",
+                context.get("exception"),
+            )
+            return
+        if previous is not None:
+            previous(loop_, context)
+        else:
+            loop_.default_exception_handler(context)
+
+    handler._pocketpaw_accept_filter = True  # type: ignore[attr-defined]
+    loop.set_exception_handler(handler)
+    return True

--- a/src/pocketpaw/dashboard_lifecycle.py
+++ b/src/pocketpaw/dashboard_lifecycle.py
@@ -7,6 +7,11 @@ Extracted from dashboard.py — contains:
 - ``shutdown_event()`` — tears down all services
 
 Changes:
+- 2026-08-01: ``startup_event`` installs the asyncio accept-noise filter
+  (``pocketpaw.asyncio_noise``) as its first act, so the Windows proactor
+  stops logging a full traceback every time a client aborts a connection
+  mid-accept. Covers both server modes — ``dashboard.py`` and
+  ``api/serve.py`` share this lifespan. (fix/asyncio-accept-noise)
 - 2026-07-12: removed the ``bundled_kb`` (ripple-recipes) boot-time mirror.
   The hand-authored ripple pattern recipes biased the agent toward fixed
   layouts; design breadth now comes from live design references, not a
@@ -32,6 +37,7 @@ import logging
 from datetime import UTC
 
 import pocketpaw.dashboard_state as _state
+from pocketpaw.asyncio_noise import install_accept_noise_filter
 from pocketpaw.bus import get_message_bus
 from pocketpaw.config import Settings
 from pocketpaw.daemon import get_daemon
@@ -182,6 +188,10 @@ async def startup_event(
         Callable for starting a channel adapter. Injected from dashboard.py
         to avoid circular import with dashboard_channels.
     """
+    # Silence the Windows proactor's aborted-accept tracebacks before any
+    # socket work starts. Real errors still reach the default handler.
+    install_accept_noise_filter()
+
     # Start Message Bus Integration
     bus = get_message_bus()
     await ws_adapter.start(bus)

--- a/tests/test_asyncio_noise.py
+++ b/tests/test_asyncio_noise.py
@@ -1,0 +1,162 @@
+"""Tests for the asyncio accept-noise filter.
+
+Created: 2026-08-01
+Changes:
+  - 2026-08-01: initial — reproduces the Windows proactor accept storm
+    (``Accept failed on a socket`` + the orphaned ``accept_coro`` task) and
+    proves the filter swallows exactly those two while every other error
+    still reaches the previous handler.
+"""
+
+import asyncio
+
+from pocketpaw.asyncio_noise import _is_benign_accept_error, install_accept_noise_filter
+
+
+def _accept_oserror(winerror: int | None = 64) -> OSError:
+    """Build the OSError a Windows proactor raises when a peer aborts an accept."""
+    exc = OSError(22, "The specified network name is no longer available")
+    if winerror is not None:
+        exc.winerror = winerror
+    return exc
+
+
+class _FakeAcceptTask:
+    """Stands in for the orphaned ``IocpProactor.accept.<locals>.accept_coro`` task."""
+
+    def __repr__(self) -> str:
+        return (
+            "<Task finished name='Task-521' "
+            "coro=<IocpProactor.accept.<locals>.accept_coro() done> "
+            "exception=OSError(22, 'The specified network name is no longer available')>"
+        )
+
+
+class _FakeAppTask:
+    """An ordinary application task — its unretrieved exceptions must survive."""
+
+    def __repr__(self) -> str:
+        return "<Task finished name='Task-77' coro=<sync_pockets() done>>"
+
+
+# ---------------------------------------------------------------------------
+# Predicate
+# ---------------------------------------------------------------------------
+
+
+def test_accept_failed_on_socket_is_benign():
+    context = {"message": "Accept failed on a socket", "exception": _accept_oserror(64)}
+    assert _is_benign_accept_error(context) is True
+
+
+def test_orphaned_accept_task_is_benign():
+    context = {
+        "message": "Task exception was never retrieved",
+        "future": _FakeAcceptTask(),
+        "exception": _accept_oserror(64),
+    }
+    assert _is_benign_accept_error(context) is True
+
+
+def test_connection_aborted_during_accept_is_benign():
+    context = {"message": "Accept failed on a socket", "exception": _accept_oserror(1236)}
+    assert _is_benign_accept_error(context) is True
+
+
+def test_unrelated_task_exception_is_not_benign():
+    """Same message, ordinary task — must not be swallowed even with a matching winerror."""
+    context = {
+        "message": "Task exception was never retrieved",
+        "future": _FakeAppTask(),
+        "exception": _accept_oserror(64),
+    }
+    assert _is_benign_accept_error(context) is False
+
+
+def test_other_winerror_is_not_benign():
+    """WSAECONNREFUSED on the accept path is a real problem — keep it visible."""
+    context = {"message": "Accept failed on a socket", "exception": _accept_oserror(10061)}
+    assert _is_benign_accept_error(context) is False
+
+
+def test_posix_oserror_without_winerror_is_not_benign():
+    context = {"message": "Accept failed on a socket", "exception": _accept_oserror(None)}
+    assert _is_benign_accept_error(context) is False
+
+
+def test_non_oserror_is_not_benign():
+    context = {"message": "Accept failed on a socket", "exception": ValueError("nope")}
+    assert _is_benign_accept_error(context) is False
+
+
+def test_context_without_exception_is_not_benign():
+    assert _is_benign_accept_error({"message": "Accept failed on a socket"}) is False
+
+
+# ---------------------------------------------------------------------------
+# Installation
+# ---------------------------------------------------------------------------
+
+
+async def test_installed_filter_swallows_accept_noise():
+    loop = asyncio.get_running_loop()
+    seen: list[dict] = []
+    loop.set_exception_handler(lambda _loop, ctx: seen.append(ctx))
+    try:
+        assert install_accept_noise_filter() is True
+        loop.call_exception_handler(
+            {"message": "Accept failed on a socket", "exception": _accept_oserror(64)}
+        )
+        loop.call_exception_handler(
+            {
+                "message": "Task exception was never retrieved",
+                "future": _FakeAcceptTask(),
+                "exception": _accept_oserror(64),
+            }
+        )
+        assert seen == []
+    finally:
+        loop.set_exception_handler(None)
+
+
+async def test_installed_filter_delegates_real_errors():
+    loop = asyncio.get_running_loop()
+    seen: list[dict] = []
+    loop.set_exception_handler(lambda _loop, ctx: seen.append(ctx))
+    try:
+        install_accept_noise_filter()
+        context = {"message": "Something actually broke", "exception": RuntimeError("boom")}
+        loop.call_exception_handler(context)
+        assert seen == [context]
+    finally:
+        loop.set_exception_handler(None)
+
+
+async def test_installed_filter_falls_back_to_default_handler(monkeypatch):
+    """With no prior handler the filter must defer to asyncio's own default."""
+    loop = asyncio.get_running_loop()
+    loop.set_exception_handler(None)
+    seen: list[dict] = []
+    monkeypatch.setattr(loop, "default_exception_handler", lambda ctx: seen.append(ctx))
+    try:
+        install_accept_noise_filter()
+        context = {"message": "Something actually broke", "exception": RuntimeError("boom")}
+        loop.call_exception_handler(context)
+        assert seen == [context]
+    finally:
+        loop.set_exception_handler(None)
+
+
+async def test_install_is_idempotent():
+    loop = asyncio.get_running_loop()
+    try:
+        assert install_accept_noise_filter() is True
+        installed = loop.get_exception_handler()
+        assert install_accept_noise_filter() is True
+        assert loop.get_exception_handler() is installed
+    finally:
+        loop.set_exception_handler(None)
+
+
+def test_install_outside_a_running_loop_is_a_noop():
+    assert install_accept_noise_filter() is False


### PR DESCRIPTION
## What you see today

Boot the backend on Windows and the log fills with this, twice per event:

```
ERROR Task exception was never retrieved
      future: <Task finished coro=<IocpProactor.accept.<locals>.accept_coro() done>
      exception=OSError(22, 'The specified network name is no longer available', None, 64, None)>
      ... 20 lines of rich traceback ...
ERROR Accept failed on a socket
      socket: <asyncio.TransportSocket fd=1076 laddr=('127.0.0.1', 8888)>
      ... 10 more lines ...
```

Nothing is wrong when that fires. A client opened a TCP connection to the
backend and went away before `AcceptEx` completed, so Windows failed the
pending accept with `WinError 64`. The listening socket is healthy, asyncio
re-arms the accept, no request was lost. On a dev box the usual culprits are
browser preconnect, a dev-server proxy, and SSE or WebSocket clients redialling
while the server is still coming up.

It is still worth fixing. Thirty lines of traceback at every reconnect is where
a real error goes to hide.

## What this does

`startup_event` now installs a loop exception handler that drops that one pair
and hands everything else to whatever handler was already installed, falling
back to asyncio's own default. Both server modes share this lifespan, so
`dashboard.py` and `api/serve.py` are both covered.

The match is deliberately narrow. It wants an `OSError`, a `winerror` in the
aborted-accept set (64, 121, 995, 1236), and for the very generic
"Task exception was never retrieved" message it also wants the future to be the
proactor's own accept coroutine. Without that second check the filter would
happily eat an application task's unretrieved exception, which is the failure
mode I most wanted to avoid.

## Two dead ends, so nobody re-walks them

A logging filter cannot do this. Both lines come out of
`loop.call_exception_handler()`, which formats and logs them itself, so they
reach the `asyncio` logger already rendered at ERROR. The handler is the only
place the pair can be dropped as a unit. `logging_setup` already pins the
`asyncio` logger to WARNING and it makes no difference.

Switching to `SelectorEventLoop` also silences it and would be a bad trade.
Selector cannot spawn subprocesses on Windows, so it takes every stdio MCP
server down with it.

## Verification

13 new tests in `tests/test_asyncio_noise.py`, covering the predicate and the
install path. The ones that matter are the negatives: an ordinary task's
unretrieved exception, a non-benign `winerror` on the accept path, a POSIX
`OSError` with no `winerror` at all, and a real error reaching both a previous
handler and the asyncio default.

I also ran the two real contexts through a live loop with a log handler
attached. Three ERROR records before, one after, and the survivor is the
genuine `RuntimeError` planted as a control.

What I could not do is trigger the underlying race synthetically. Forcing RST
during the `AcceptEx` window needs the loop blocked at the moment the peer
aborts, and a loopback RST storm against a blocked proactor just deadlocks the
connects. The evidence here is the captured production log plus the unit
coverage, not a self-reproducing integration test.

`ruff check` and `ruff format` are clean. `test_channel_autostart` and
`test_broadcast_reminder_persist` (the two suites that exercise this lifespan)
still pass.

## Not covered

The filter is inert on POSIX. `winerror` does not exist there, the predicate
returns False, and the selector loop handles `ECONNABORTED` itself without ever
reaching the exception handler.
