### PR TITLE
A new chat was running the previous session's system prompt

### DIFF
--- a/src/pocketpaw/agents/deep_agents.py
+++ b/src/pocketpaw/agents/deep_agents.py
@@ -22,8 +22,19 @@ Updated 2026-06-26 (integration/model-catalog-v2, MCG-11):
     counts (``_accumulate_cache_usage``) and emits a ``token_usage`` AgentEvent
     (via ``report_savings``) before ``done``, so the margin is measurable on this
     backend (mirrors the claude_sdk hook).
+
+Updated 2026-08-01 (fix/agent-system-prompt-per-run): the compiled-graph cache
+key carries a digest of ``instructions``. ``system_prompt`` is baked into the
+graph at compile time, and ``AgentPool`` keeps ONE instance per agent across
+every session and surface, so the key's silence about prompt text meant turn N+1
+ran turn N's system prompt — which is how a brand-new chat greeted the user with
+the site they had just built in a different session. Recompiles cost ~14 ms
+(measured), and prompt caching is unaffected: the marker is applied to the
+request the graph sends, not to the graph. See the same note in
+``pydantic_ai.py`` for why that backend fixes it per-run instead.
 """
 
+import hashlib
 import logging
 from collections.abc import AsyncIterator
 from typing import Any
@@ -766,8 +777,22 @@ class DeepAgentsBackend:
         # Invalidate cache if any input that shapes the compiled graph changed.
         # is_pocket_session is part of the key so flipping between pocket and
         # non-pocket sessions in the same backend recompiles the agent.
+        #
+        # The prompt DIGEST is in the key because ``instructions`` is baked into
+        # the compiled graph below (``kwargs["system_prompt"]``) while
+        # ``AgentPool`` keeps ONE instance per agent across every session. Without
+        # it, turn N+1 was served the graph compiled for turn N — carrying turn
+        # N's surface preamble, ``<current-pocket>`` tag and soul-memory recall.
+        # That is how a brand-new chat opened by offering to continue the last
+        # session's work. ``pydantic_ai`` solves this by passing instructions
+        # per-run; ``create_deep_agent`` takes ``str | SystemMessage`` only, so
+        # here the fix is to recompile. Measured 2026-08-01: ~14 ms per compile,
+        # against an LLM turn of seconds — the prompt tail varies per message
+        # (``pool._assemble_system_prompt`` appends a recall keyed on the user's
+        # text), so budget for a rebuild most turns.
         model_key = (
             self.settings.deep_agents_model,
+            hashlib.sha256((instructions or "").encode("utf-8", "replace")).hexdigest(),
             tuple(skills),
             tuple(memory),
             is_pocket_session,

--- a/src/pocketpaw/agents/langchain_react.py
+++ b/src/pocketpaw/agents/langchain_react.py
@@ -20,6 +20,13 @@ tenant — and the prefix wins over ``llm_provider`` (regression-guarded in
 test_langchain_react_backend.py). The warning names the required override
 (``deep_agents_model=ollama:<model>``) so the operator is told their
 config still hits the cloud.
+
+Change (2026-08-01, fix/agent-system-prompt-per-run): the agent cache key now
+carries a digest of ``instructions``. It was the model name ALONE, so one
+compiled graph — built with the first turn's system prompt — served every
+session on that instance forever. A new chat therefore opened already knowing
+the previous session's surface, open pocket and recalled memories. Same fix as
+the parent backend; ``pydantic_ai`` solves it per-run instead.
 """
 
 from __future__ import annotations
@@ -119,9 +126,21 @@ class LangchainReactBackend(DeepAgentsBackend):
     def _get_or_create_agent(
         self, model: Any, instructions: str, mcp_tools: list | None = None
     ) -> Any:
+        import hashlib
+
         from langgraph.prebuilt import create_react_agent
 
-        model_key = (self.settings.deep_agents_model,)
+        # The prompt digest is in the key for the same reason as the parent's
+        # (see ``DeepAgentsBackend._get_or_create_agent``): ``instructions`` is
+        # baked into the compiled graph as ``prompt=`` while ``AgentPool`` keeps
+        # ONE instance per agent across every session, so a key that ignores the
+        # prompt serves the next session the previous session's system prompt.
+        # This key was the narrowest of the three — the MODEL NAME alone — so it
+        # never rebuilt for anything else either.
+        model_key = (
+            self.settings.deep_agents_model,
+            hashlib.sha256((instructions or "").encode("utf-8", "replace")).hexdigest(),
+        )
         if self._cached_agent is not None and self._cached_model_key == model_key:
             return self._cached_agent
 

--- a/src/pocketpaw/agents/pydantic_ai.py
+++ b/src/pocketpaw/agents/pydantic_ai.py
@@ -179,6 +179,30 @@ claimed but did not deliver:
 5. Smaller: the agent cache key uses ``_tools_version`` rather than
    ``id(_custom_tools)``, and deferral is skipped on a surface that already
    named its tools.
+
+Updated 2026-08-01 (f) — **the system prompt is per-RUN, not per-agent.**
+Reported from the product side: create a site, open a BRAND-NEW chat, say "hi",
+and the agent offers to keep working on the site. Nothing was remembering it —
+it was being told. ``_get_or_create_agent`` passed ``instructions`` to the
+``Agent`` constructor while the cache key covered model, pocket-ness, toolset
+counts, skills and the gating sets but NOT the prompt text, and ``AgentPool``
+keeps one instance per agent across every session and surface. So turn N built
+the agent with turn N's prompt and turn N+1 — same tool surface, different
+session — was handed it back, still carrying the earlier turn's surface
+preamble, ``<current-pocket id=…>`` and ``## Relevant Past Memories`` block.
+
+Adding a prompt digest to the key would fix correctness and destroy the cache:
+the prompt's tail varies per MESSAGE (``pool._assemble_system_prompt`` appends a
+soul recall keyed on the user's text), so nearly every turn would rebuild.
+pydantic-ai takes ``instructions`` on ``run``/``run_stream_events`` and appends
+it to the agent-level set per run, so the agent is now built with NO
+instructions and each run supplies its own. One cached agent, this turn's
+prompt, no digest.
+
+The same bug lives in ``deep_agents`` and ``langchain_react`` and is fixed in
+the same change; ``claude_sdk`` never had it, because its warm-client key
+already carries ``session_key`` plus a digest of the prompt's behavioral prefix
+(``_client_cache_key``).
 """
 
 from __future__ import annotations
@@ -1642,6 +1666,12 @@ class PydanticAIBackend:
         Cached on everything that shapes the tool surface or the model, so
         flipping between pocket and non-pocket sessions on one instance rebuilds
         rather than silently reusing the wrong tool set.
+
+        ``instructions`` is READ here (its shape decides ``is_pocket_session``)
+        but deliberately NOT passed to the ``Agent`` — see the class docstring's
+        2026-08-01 (f) note. The agent is shared across sessions, so a prompt
+        baked in at construction is one session's prompt served to the next.
+        ``run`` passes it per-run instead.
         """
         from pydantic_ai import Agent
 
@@ -1719,7 +1749,13 @@ class PydanticAIBackend:
 
         agent = Agent(
             model,
-            instructions=instructions,
+            # NO ``instructions=`` here on purpose. The system prompt is
+            # per-TURN (surface preamble, ``<current-pocket>``, the soul-memory
+            # recall keyed on this message) while the agent is per-INSTANCE and
+            # this cache key cannot see prompt text. Baking it in served the
+            # NEXT session the PREVIOUS session's prompt. ``run`` passes
+            # ``instructions=`` to ``run_stream_events``, which pydantic-ai
+            # appends to the (now empty) agent-level set per run.
             tools=tools,
             toolsets=list(mcp_toolsets) or None,
             capabilities=self._build_capabilities(skill_names) or None,
@@ -1891,7 +1927,11 @@ class PydanticAIBackend:
             )
 
             kwargs: dict[str, Any] = {
-                "message_history": self._session_history(session_key, history)
+                "message_history": self._session_history(session_key, history),
+                "instructions": instructions,
+                # Per-RUN, not per-agent. The cached agent is built with no
+                # instructions at all, so this is the only system prompt on the
+                # wire — and it is THIS turn's. See ``_get_or_create_agent``.
             }
             max_turns = self.settings.pydantic_ai_max_turns
             if max_turns and max_turns > 0:

--- a/tests/test_deep_agents_backend.py
+++ b/tests/test_deep_agents_backend.py
@@ -388,6 +388,34 @@ class TestDeepAgentsSkillsMemoryPlumbing:
             agent2 = backend._get_or_create_agent(MagicMock(), "sys")
             assert agent2 is not agent1
 
+    def test_a_changed_system_prompt_rebuilds_the_graph(self):
+        """A new session must not be served the previous session's prompt.
+
+        ``system_prompt`` is compiled INTO the graph and ``AgentPool`` keeps ONE
+        instance per agent across every session and surface, so a cache key
+        that ignores the prompt hands session B the graph built for session A —
+        carrying A's surface preamble, ``<current-pocket>`` tag and soul recall.
+        That is how a brand-new chat greeted the user with the site they had
+        just built somewhere else.
+        """
+        from pocketpaw.agents.deep_agents import DeepAgentsBackend
+
+        backend = DeepAgentsBackend(Settings())
+        backend._custom_tools = []
+        captured: list[str] = []
+
+        def fake_create(**kwargs):
+            captured.append(kwargs.get("system_prompt"))
+            return MagicMock(name=f"graph:{len(captured)}")
+
+        with patch("deepagents.create_deep_agent", side_effect=fake_create):
+            a1 = backend._get_or_create_agent(MagicMock(), "SITE: Acme Dental")
+            a2 = backend._get_or_create_agent(MagicMock(), "CHAT: fresh session")
+
+        assert a1 is not a2, "prompt change did not rebuild the graph"
+        assert captured[-1] == "CHAT: fresh session"
+        assert "Acme Dental" not in (captured[-1] or "")
+
 
 class TestDeepAgentsAttachSpecialistTools:
     """attach_specialist_tools() merges into _custom_tools and invalidates the

--- a/tests/test_deep_agents_streaming_events.py
+++ b/tests/test_deep_agents_streaming_events.py
@@ -102,20 +102,19 @@ async def _drive_stream(backend: DeepAgentsBackend, chunks: list[dict]) -> list:
 
     backend._sdk_available = True
     backend._cached_agent = fake_agent
-    # Mirror the _get_or_create_agent cache-key shape (model, skills,
-    # memory, is_pocket_session). The default test prompt "hi" carries
-    # no <pocket-scope> marker so is_pocket_session is False.
-    backend._cached_model_key = (
-        backend.settings.deep_agents_model,
-        tuple(backend.settings.deep_agents_skills or []),
-        tuple(backend.settings.deep_agents_memory or []),
-        False,
-    )
 
+    # Stub the factory rather than hand-mirroring its cache-key shape. The
+    # fixture used to rebuild the key tuple itself, which meant every change to
+    # the key silently dropped these tests through to the REAL
+    # ``create_deep_agent`` with a MagicMock model — a confusing
+    # ``TypeError: '>' not supported between MagicMock and int`` from inside
+    # deepagents, nowhere near the actual cause. These tests are about the
+    # STREAM, so the agent is a stub and the key is not their business.
     events = []
     with (
         patch.object(backend, "_build_model", return_value=MagicMock()),
         patch.object(backend, "_build_mcp_tools", return_value=[]),
+        patch.object(backend, "_get_or_create_agent", return_value=fake_agent),
     ):
         async for evt in backend.run("hi"):
             events.append(evt)

--- a/tests/test_langchain_react_backend.py
+++ b/tests/test_langchain_react_backend.py
@@ -152,6 +152,30 @@ class TestLangchainReactAgentFactory:
         assert a1 is a2
         assert mock_factory.call_count == 1
 
+    def test_a_changed_system_prompt_rebuilds_the_graph(self):
+        """A new session must not be served the previous session's prompt.
+
+        ``prompt=`` is compiled into the graph and ``AgentPool`` keeps ONE
+        instance per agent across every session, so a cache key that ignores
+        the prompt hands session B the graph built for session A — which is how
+        a brand-new chat opened already knowing the site built in the last one.
+        This key was the model name alone.
+        """
+        from pocketpaw.agents.langchain_react import LangchainReactBackend
+
+        backend = LangchainReactBackend(Settings(deep_agents_model="anthropic:claude-sonnet-4-6"))
+        backend._custom_tools = []
+
+        with patch(
+            "langgraph.prebuilt.create_react_agent",
+            side_effect=lambda **kw: MagicMock(name=f"graph:{kw.get('prompt')}"),
+        ) as mock_factory:
+            backend._get_or_create_agent(MagicMock(), "SITE: Acme Dental", mcp_tools=[])
+            backend._get_or_create_agent(MagicMock(), "CHAT: fresh session", mcp_tools=[])
+
+        assert mock_factory.call_count == 2, "prompt change did not rebuild the graph"
+        assert mock_factory.call_args_list[-1].kwargs["prompt"] == "CHAT: fresh session"
+
 
 class TestLangchainReactStatus:
     async def test_status_reports_correct_backend_name(self):

--- a/tests/test_pydantic_ai_backend.py
+++ b/tests/test_pydantic_ai_backend.py
@@ -838,6 +838,70 @@ def test_skill_names_is_part_of_the_agent_cache_key(monkeypatch):
     assert wide is not narrow, "cached agent reused across different skill subsets"
 
 
+async def test_a_new_session_does_not_inherit_the_previous_prompt():
+    """The system prompt on the wire must be THIS turn's, not the last one's.
+
+    Reported from the product side: build a site, open a brand-new chat, say
+    "hi", and the agent offers to keep working on the site. The agent was not
+    remembering — ``_get_or_create_agent`` baked ``instructions`` into the
+    cached ``Agent`` while the cache key covered model / pocket-ness / tools /
+    skills / gating but NOT the prompt text, and ``AgentPool`` keeps ONE
+    instance per agent across every session.
+
+    Asserted at the MODEL boundary rather than on the Agent object, because
+    that is where the leak was actually observable.
+    """
+    seen: list[str | None] = []
+
+    async def stream_fn(messages: list[ModelMessage], info: AgentInfo):
+        seen.append(messages[-1].instructions)
+        yield "ok"
+
+    backend = _backend_with_model(FunctionModel(stream_function=stream_fn))
+
+    await _collect(
+        backend,
+        "build me a landing site",
+        system_prompt="You are Paw.\n<current-pocket id='p1' />\nProject: Acme Dental",
+        session_key="cloud:session:aaa:agent1",
+    )
+    await _collect(
+        backend,
+        "hi",
+        system_prompt="You are Paw.\n(no pocket open)",
+        session_key="cloud:session:bbb:agent1",
+    )
+
+    assert len(seen) == 2
+    # Capability instructions (the planning tool) legitimately ride in front of
+    # the per-run prompt, so this is containment rather than equality — the
+    # property under test is WHOSE turn prompt is on the wire.
+    assert "(no pocket open)" in (seen[1] or "")
+    assert "Acme Dental" not in (seen[1] or ""), (
+        "the new session ran with the previous session's system prompt"
+    )
+    assert "Acme Dental" in (seen[0] or ""), "turn 1 should still get its own prompt"
+
+
+async def test_the_cached_agent_carries_no_prompt_of_its_own():
+    """The mechanism behind the test above, pinned separately.
+
+    Two turns that differ ONLY in prompt must still share one cached agent —
+    rebuilding per prompt would be correct but would throw the cache away on
+    nearly every turn, since the prompt tail varies per message. Correctness
+    comes from the agent holding no instructions at all.
+    """
+    backend = _backend_with_model(TestModel())
+
+    a1 = backend._get_or_create_agent(TestModel(), "PROMPT A", [])
+    a2 = backend._get_or_create_agent(TestModel(), "PROMPT B", [])
+
+    assert a1 is a2, "a prompt change must not cost a rebuild"
+    assert not a1._instructions, (
+        "the shared agent must hold no instructions — they are passed per run"
+    )
+
+
 def test_the_skills_catalog_is_deferred_by_default(monkeypatch):
     """Read off the field, not off a constructed ``Settings``.
 


### PR DESCRIPTION
## What happens

Build a site, open a brand-new chat, say "hi", and the agent offers to keep working on the site. A new session should not know about the last one.

It wasn't remembering. It was being told — the new session's turn ran the *previous* session's system prompt.

## Why

`pydantic_ai`, `deep_agents` and `langchain_react` each cache their agent object on the backend instance and bake the system prompt into it at construction. Their cache keys cover the model, the tool surface, the skill set and the gating sets, but never the prompt text. `AgentPool` keeps one instance per agent across every session and surface, so turn N built the agent with turn N's prompt and turn N+1 was handed it back — still carrying the earlier turn's surface preamble, its `<current-pocket>` tag and its `## Relevant Past Memories` block.

`claude_agent_sdk` never had this. Its warm-client key already carries `session_key` plus a digest of the prompt's behavioral prefix.

## The fix

The prompt genuinely varies per turn — `pool._assemble_system_prompt` appends a soul recall keyed on the user's own message — so putting a digest in the cache key is correct but throws the cache away on nearly every turn.

pydantic-ai takes `instructions` on `run_stream_events` and appends them to the agent-level set per run. That backend now builds its agent with no instructions at all and each run supplies its own: one cached agent, this turn's prompt, no digest.

`create_deep_agent` and `create_react_agent` take a string only, so those two get the digest and recompile. Measured at ~14 ms per compile, against an LLM turn of seconds.

One visible side effect on pydantic_ai, worth knowing before it shows up in a prompt dump: pydantic-ai composes instructions as agent-level, then capability, then per-run. Moving ours from the first slot to the last means the capability blurb (the `write_plan` planning-tool text) now sits in front of the persona instead of behind it. Both parts are stable across turns, so the cacheable prefix is still a prefix and caching is unaffected. I kept the library's own per-run API rather than smuggling a callable over a ContextVar to preserve the old byte order — the ordering is cosmetic, and the documented API is the one that survives an upgrade.

## Ruled out on the way

Recorded so nobody re-walks it:

- chat history is session-scoped and empty on a new session
- the retained pydantic-ai transcript is keyed by `session_key`
- soul recall returns nothing for a bare greeting — probed live, BM25 has nothing to match on "hi"

## Tests

Four new ones, each mutation-checked by reverting the fix and confirming the test fails:

- pydantic_ai, asserted at the model boundary: turn 2's `ModelRequest.instructions` is turn 2's prompt and carries nothing from turn 1
- pydantic_ai: the shared agent holds no instructions of its own, and a prompt change still costs no rebuild
- deep_agents and langchain_react: a changed prompt rebuilds the graph

One existing fixture needed fixing. The deep_agents streaming test hand-mirrored the cache-key tuple, so changing the key dropped it through to the real `create_deep_agent` with a MagicMock model — a `TypeError` raised from inside deepagents, nowhere near the cause. It stubs the factory now instead of rebuilding the key by hand.

## Docs

None needed; this is internal to the backends, with no setting, CLI or API surface. The prompt-caching section of `docs/backends/pydantic-ai.mdx` still holds — the wire format is unchanged (instructions land on `ModelRequest.instructions` either way) and the cacheable stable prefix is untouched.

## Base

Stacked on `feat/litellm-search-provider` (#1840). It touches `pydantic_ai.py`, which that stack is actively changing.

