### PR TITLE
activity_by_day — the shape, not just the totals

### DIFF
--- a/ee/pocketpaw_ee/cloud/agents/router.py
+++ b/ee/pocketpaw_ee/cloud/agents/router.py
@@ -529,6 +529,13 @@ async def get_agent_ledger(
     outcomes = await store.counts_by_outcome(**scope)
     value_by_currency = await store.value_by_currency(**scope)
     recent = await store.query(**scope, limit=limit)
+    # Day-bucketed activity for the trend line, aggregated over the SAME filter as
+    # every other number in this payload — so the shape of the line can never
+    # disagree with the totals printed above it. A chart drawn from a different
+    # read than its own headline is the two-meters bug in a nicer hat.
+    # The store fills gaps with zeros: a series of only the days that had rows
+    # draws a straight line across a silent week and calls it activity.
+    series = await store.activity_by_day(**scope, days=_series_days(window))
 
     # Ratios are reported over the rows that actually carry a verdict, and the
     # denominator ships with them. "60% solved" out of five is a different claim
@@ -561,7 +568,24 @@ async def get_agent_ledger(
             "total_cents": value_by_currency.get(single_currency, 0) if single_currency else 0,
         },
         "recent": [row.model_dump() for row in recent],
+        # Oldest-first [{day, count}] for the trend line. Named ``series`` rather
+        # than ``sparkline`` because the shape is the data's business, not the
+        # chart's.
+        "series": series,
     }
+
+
+def _series_days(window: str) -> int:
+    """How many daily points the trend line should carry for ``window``.
+
+    Not simply "the window in days": a 24h window has ONE day-bucket, which is a
+    dot rather than a line, so it gets a week of context around today instead of
+    a chart that cannot show change. And ``all`` is capped at 90 — an unbounded
+    line is unreadable long before it is expensive, and the honest answer to "show
+    me two years" is a rollup, which v1 deliberately does not have yet.
+    """
+    key = (window or "").strip().lower()
+    return {"24h": 7, "7d": 7, "2w": 14, "30d": 30}.get(key, 90 if key == "all" else 30)
 
 
 # How many approved actions the reconcile scan reads before it stops. A cap is

--- a/src/pocketpaw/agent_ledger/store.py
+++ b/src/pocketpaw/agent_ledger/store.py
@@ -39,7 +39,7 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -291,6 +291,56 @@ class AgentLedgerStore:
                 params,
             ) as cur:
                 return {row[0]: row[1] async for row in cur}
+
+    async def activity_by_day(
+        self,
+        *,
+        agent_id: str | None = None,
+        workspace_id: str | None = None,
+        since: str | None = None,
+        kinds: list[str] | tuple[str, ...] | None = None,
+        surface: str | None = None,
+        days: int = 30,
+    ) -> list[dict[str, Any]]:
+        """``[{day, count}]`` per UTC day, oldest first, WITH THE GAPS FILLED.
+
+        The zero days are the point. A series built only from days that have rows
+        draws a continuous line straight across a silent week and turns the x-axis
+        into "days when something happened" — which is not time. It reads as
+        steady activity when the truth is a gap. Every day in the window gets a
+        point, so a quiet stretch looks quiet.
+
+        Bucketed by ``substr(ts, 1, 10)``: ``ts`` is always ISO-8601 UTC (the row
+        model normalizes it), so the first ten characters are the calendar day —
+        no parsing a month of timestamps in Python to find out.
+
+        ``days`` bounds the returned series independently of ``since``, so a
+        caller asking for "all" cannot accidentally request a line with ten
+        thousand points in it.
+        """
+        where, params = self._filters(
+            agent_id=agent_id,
+            workspace_id=workspace_id,
+            since=since,
+            kinds=kinds,
+            surface=surface,
+        )
+        await self._ensure_schema()
+        async with self._conn() as db:
+            async with db.execute(
+                f"SELECT substr(ts, 1, 10) AS day, COUNT(*) FROM agent_ledger_events"
+                f" {where} GROUP BY day ORDER BY day",
+                params,
+            ) as cur:
+                counted = {row[0]: int(row[1]) async for row in cur}
+
+        span = max(1, min(int(days or 1), 366))
+        today = datetime.now(UTC).date()
+        series: list[dict[str, Any]] = []
+        for offset in range(span - 1, -1, -1):
+            day = (today - timedelta(days=offset)).isoformat()
+            series.append({"day": day, "count": counted.get(day, 0)})
+        return series
 
     async def counts_by_outcome(
         self,

--- a/tests/test_agent_ledger.py
+++ b/tests/test_agent_ledger.py
@@ -23,6 +23,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import aiosqlite
@@ -30,6 +31,7 @@ import pytest
 
 from pocketpaw import stores
 from pocketpaw.agent_ledger.models import (
+    KIND_RUN_COMPLETED,
     ATTR_AGENT_ID,
     ATTR_APPROVAL_AUTO,
     ATTR_INSTINCT_EVENT,
@@ -603,3 +605,72 @@ async def test_an_unresolvable_ledger_store_does_not_break_the_approval(
     approved = await instinct.approve(action.id)
     assert approved is not None
     assert approved.status == ActionStatus.APPROVED
+
+
+# --------------------------------------------------------------------------- #
+# activity_by_day — the trend line's data
+# --------------------------------------------------------------------------- #
+
+
+async def test_the_series_fills_silent_days_with_zeros(isolated_stores):
+    """A day with no rows is a POINT AT ZERO, never a missing point.
+
+    This is the whole correctness argument for the trend line. A series built
+    only from days that have rows draws a straight line across a silent week and
+    turns the x-axis into "days when something happened" — which is not time. It
+    reads as steady activity when the truth is a gap.
+    """
+    store = stores.get_agent_ledger_store(workspace_id="ws1")
+    today = datetime.now(UTC)
+    for offset in (0, 4):  # two days of activity inside a 7-day window
+        await store.append(
+            LedgerRow(
+                agent_id="agent-1", workspace_id="ws1", surface="chat",
+                kind=KIND_RUN_COMPLETED, ref=f"r{offset}", actor="system",
+                ts=(today - timedelta(days=offset)).isoformat(),
+            )
+        )
+
+    series = await store.activity_by_day(agent_id="agent-1", workspace_id="ws1", days=7)
+
+    assert len(series) == 7, "every day in the window gets a point, not just the busy ones"
+    assert sum(p["count"] for p in series) == 2
+    assert [p["count"] for p in series].count(0) == 5
+
+
+async def test_the_series_runs_oldest_first(isolated_stores):
+    """Chart order. Reversed, the line reads as the exact opposite trend."""
+    store = stores.get_agent_ledger_store(workspace_id="ws1")
+    series = await store.activity_by_day(workspace_id="ws1", days=5)
+    days = [p["day"] for p in series]
+    assert days == sorted(days)
+    assert days[-1] == datetime.now(UTC).date().isoformat(), "last point is today"
+
+
+async def test_the_series_is_workspace_scoped(isolated_stores):
+    """Another tenant's rows never enter this line."""
+    for ws in ("ws1", "ws2"):
+        store = stores.get_agent_ledger_store(workspace_id=ws)
+        await store.append(
+            LedgerRow(
+                agent_id="agent-1", workspace_id=ws, surface="chat",
+                kind=KIND_RUN_COMPLETED, ref=f"run-{ws}", actor="system",
+                ts=datetime.now(UTC).isoformat(),
+            )
+        )
+    series = await stores.get_agent_ledger_store(workspace_id="ws1").activity_by_day(
+        workspace_id="ws1", days=3
+    )
+    assert sum(p["count"] for p in series) == 1
+
+
+@pytest.mark.parametrize("requested,expected", [(0, 1), (-5, 1), (10_000, 366)])
+async def test_the_series_length_is_bounded(isolated_stores, requested, expected):
+    """``days`` is clamped, so no caller can ask for a line with 10k points.
+
+    An unbounded series is unreadable long before it is expensive, and "show me
+    two years" is a rollup question, which v1 deliberately does not answer yet.
+    """
+    store = stores.get_agent_ledger_store(workspace_id="ws1")
+    series = await store.activity_by_day(workspace_id="ws1", days=requested)
+    assert len(series) == expected


### PR DESCRIPTION
Stacked on the ledger line (`#1831 ← #1832 ← #1836 ← this`). Base is `feat/agent-ledger-runs-and-reconcile`; merge bases with `--rebase`, not `--squash`.

## Why

The ledger could say *how much* an agent did and never *what shape* the work had — picking up, tailing off, working in bursts. Totals can't show that, and it's usually the first thing an owner wants to know.

This is also the data the analytics tab's trend line needs. That chart's frontend is already in `qbtrix/paw-enterprise#718`; without this it renders nothing, because the only alternative source was the `recent` list — capped at 50 rows, so a 30-day line drawn from it would have lied about its own window.

## Two decisions that are load-bearing

**Gaps are filled with zeros.** A series built only from days that *have* rows draws a straight line across a silent week and turns the x-axis into "days when something happened" — which is not time. It reads as steady activity when the truth is a gap. Five of the six new tests go red if the fill is removed.

**The length is clamped independently of the window** (1–366). An unbounded line is unreadable long before it's expensive, and the honest answer to "show me two years" is a rollup, which v1 deliberately doesn't have. The endpoint also maps `24h` to a week of context rather than the single bucket a literal reading gives — one point is a dot, not a line.

## Correctness

Aggregated over the **same filter** as every other number in the payload, so the chart can never disagree with the headline printed above it. Bucketed by `substr(ts, 1, 10)`: `ts` is normalised aware-UTC on write, so the first ten characters *are* the calendar day — no parsing a month of timestamps to find that out.

Exposed as `series`, named for the data rather than the chart.

## Verification

- `tests/test_agent_ledger.py` — **65 passed** (6 new)
- ledger suites — **90 passed**
- gap-fill mutation-checked: removing it fails 5 of the 6
- ruff clean · both import-linter configs pass