### PR TITLE
Tell the site-building agent its site ships with a concierge

### DIFF
--- a/ee/pocketpaw_ee/cloud/surface/handlers/sites.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/sites.py
@@ -113,6 +113,22 @@
 # THE SAME TURN only when the user's request already asked to go live ("publish",
 # "make it live", "ship it"). The publish tool is still NAMED (the on-request path),
 # so nothing regresses for an explicit publish. Refine/chat branches untouched.
+#
+# Updated: 2026-08-02 (fix/concierge-tools-for-site-agent) — EVERY preamble in this
+# module now carries `_CONCIERGE_NOTE`. The reported bug was that an agent building
+# a site "sometimes does not know about concierge at all"; the cause was not a
+# tool-access gate but a total awareness blackout — "concierge" appeared zero times
+# in this file, zero times in the sites MCP tool descriptions, and zero times in the
+# bundled skills, so the only channel through which the agent could learn a site
+# ships with one was model sampling. That is what made it intermittent. The block is
+# unconditional: it is appended by `_create_preamble` (all three engines),
+# `_refine_preamble`, `_chat_preamble`, and `_frontend_preamble`, so no engine, mode,
+# flag, or lazily-loaded tool-id import can gate it off. It states what the concierge
+# is, that PUBLISHING (not drafting) provisions it, that it answers visitors from the
+# site's own synced knowledge, and that it can always reach a human — and it names NO
+# tool, because widget catalog/actions are owner-authored and configuring them from
+# chat is a real gap, not a capability to imply. See `_CONCIERGE_NOTE` for the
+# per-claim code citations.
 
 from __future__ import annotations
 
@@ -121,6 +137,69 @@ from typing import Any
 
 from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
 from pocketpaw_ee.sites_crew.models import DesignBrief
+
+# --- The concierge block (fix/concierge-tools-for-site-agent) -----------------
+#
+# THE BUG: "the agent building sites sometimes does not know about concierge at
+# all." It was not a tool-access gate — it was a total AWARENESS blackout. Before
+# this constant, the string "concierge" appeared ZERO times in every preamble in
+# this module, ZERO times in the sites MCP tool descriptions
+# (``agent/mcp_servers/sites.py`` + ``sites_create.py``), and ZERO times anywhere
+# in ``src/pocketpaw/bundled_skills/``. The publish tool's own result payload
+# (``sites.py::_publish_handler``) returns only ``{ok, site:{id, pocket_id, name,
+# url, deployed}}``, so not even a successful publish told the agent a bar had
+# just been grown onto the pages it deployed.
+#
+# With no source at all, whether the agent brought up the concierge was decided
+# by model sampling and by whatever the user happened to type. That is the whole
+# explanation for "sometimes": the gate was in the sampler, not in the code. One
+# always-present block replaces a coin flip with a fact.
+#
+# Every claim below is pinned to a code path, because a preamble that oversells
+# trades a blind agent for a confidently wrong one:
+#   * embedded on every published page — ``sites/service.py::_embed_concierge_bar``
+#     injects the snippet into the built tree between build and deploy;
+#   * provisioned at PUBLISH, not at draft — that same function is reached only on
+#     a live publish (a preview returns from ``publish_pocket`` well before it),
+#     and it funnels into ``paw_bar/agent_provisioning.py::ensure_site_widget`` →
+#     ``ensure_site_agent``, the third of the three provisioning triggers;
+#   * on by default — ``Site.concierge_enabled`` defaults True, and the embed
+#     reads an absent doc as enabled so a FIRST publish still gets its bar;
+#   * grounded in the site's own content — ``sites/kb_ingest.py``'s sync is
+#     scheduled at publish and at bind, so the concierge answers from the pages;
+#   * always able to fetch a human — ``agent/mcp_servers/pawbar.py`` registers the
+#     built-in ``pawbar_request_human`` on EVERY concierge run bound to a widget,
+#     declared actions or not.
+#
+# And the honest LIMIT, which is the reason this block names no tool: widget
+# ``catalog`` and ``actions`` are owner-authored only. No agent tool declares
+# them, on this surface or any other, so the block routes the user to the
+# dashboard instead of promising something that would hard-error. The word
+# "republish" is deliberately absent — the chat-mode preamble is a no-mutation
+# surface and its test forbids that string.
+_CONCIERGE_NOTE = (
+    "<site-concierge>\n"
+    "Every Paw Site we publish ships with a CONCIERGE: a Paw Bar chat widget "
+    "embedded on the live page, backed by a dedicated agent that belongs to that "
+    "one site. You do not build it and you do not wire it up — it is provisioned "
+    "automatically the moment the site goes live (publishing is what creates it, "
+    "so a draft does not have one yet), and it is ON by default for every site.\n"
+    "What it does for the business: it answers their VISITORS' questions about "
+    "the site, grounded in the site's own published content, which is synced into "
+    "its knowledge automatically. Every concierge can also hand a conversation to "
+    "a real person when a visitor asks for one.\n"
+    "KNOW THIS AND SAY IT when it is relevant — when the user asks what happens "
+    "after publishing, asks about chat / support / lead handling / answering "
+    "visitors, or is deciding whether to go live. It is a real part of the "
+    "deliverable, so never tell a user their site has no chat or no way to "
+    "capture a visitor's question.\n"
+    "WHAT YOU CANNOT DO: the greeting, the product catalog, and the concierge's "
+    "actions are owner-authored — the user sets them from the site's settings in "
+    "the dashboard. You have no tool for any of that, so point them at the "
+    "dashboard rather than offering to configure it from chat, and never claim you "
+    "changed a concierge setting.\n"
+    "</site-concierge>"
+)
 
 
 @functools.lru_cache(maxsize=1)
@@ -421,6 +500,7 @@ def _create_preamble(meta: SurfaceMeta) -> str:
         "at the in-app Preview, don't invent a live link.\n"
         "- Keep the 'site' / 'page' vocabulary throughout; never say 'pocket'.\n"
         "</sites-procedure>\n"
+        f"{_CONCIERGE_NOTE}\n"
         f"{_design_taste_system()}"
     )
 
@@ -486,7 +566,8 @@ def _refine_preamble(meta: SurfaceMeta) -> str:
         "`parallax`, or `spotlight` (they need client JS and hide content on a "
         'static page). Keep `type="site"` + `pattern="landing"` on the pocket. '
         "Keep talking 'site' / 'page', never 'pocket'.\n"
-        "</sites-procedure>"
+        "</sites-procedure>\n"
+        f"{_CONCIERGE_NOTE}"
     )
 
 
@@ -657,7 +738,8 @@ def _frontend_preamble(meta: SurfaceMeta, brief: DesignBrief) -> str:
         "After it publishes, relay any publish error — never claim a phantom "
         "publish — and SHOW the live `url` plus a link to /sites. Keep talking "
         "'site' / 'page', never 'pocket'.\n"
-        "</sites-procedure>"
+        "</sites-procedure>\n"
+        f"{_CONCIERGE_NOTE}"
     )
 
 
@@ -695,7 +777,8 @@ def _chat_preamble(meta: SurfaceMeta) -> str:
         "site. If the user actually wants a CHANGE applied, tell them to switch "
         "the toggle to BUILD — in Chat mode you only answer questions and never "
         "touch the live page. Keep talking 'site' / 'page', never 'pocket'.\n"
-        "</sites-procedure>"
+        "</sites-procedure>\n"
+        f"{_CONCIERGE_NOTE}"
     )
 
 

--- a/tests/cloud/surface/test_sites_handler.py
+++ b/tests/cloud/surface/test_sites_handler.py
@@ -82,6 +82,18 @@
 # go-live request instead of auto-publishing off a plain "create a site". Asserts the
 # draft/preview framing + the explicit-go-live gate across all engines, and that the
 # publish tool is still named (the on-request path) so an explicit publish is unbroken.
+#
+# Updated: 2026-08-02 (fix/concierge-tools-for-site-agent) — added the concierge
+# awareness block at the bottom. The reported bug ("the agent building sites
+# sometimes does not know about concierge at all") was failure mode (2) AWARENESS
+# and it was TOTAL: "concierge" appeared zero times in every /sites preamble, zero
+# times in the sites MCP tool descriptions, and zero times in the bundled skills,
+# so whether the agent mentioned one was decided by model sampling alone. The new
+# tests are parametrized across all FIVE dispatched (engine, mode) combinations —
+# determinism is the fix, so spot-checking one mode would not prove it — and they
+# also pin the block's two honest limits: it must not claim a draft already has a
+# concierge (provisioning is live-publish-only) and must not name a configuration
+# tool that does not exist (catalog/actions are owner-authored only).
 
 from __future__ import annotations
 
@@ -737,3 +749,132 @@ async def test_mode_threads_through_meta_from_request() -> None:
     # Default preserves current (build) behavior when the client omits it.
     default_meta = _meta_from_request(SurfaceMetaRequest(route_path="/sites"))
     assert default_meta.mode == "build"
+
+
+# --- Concierge awareness (fix/concierge-tools-for-site-agent) -----------------
+#
+# THE BUG: an agent building a site "sometimes does not know about concierge at
+# all". Diagnosis was failure mode (2) AWARENESS, and it was total: before this
+# fix the string "concierge" appeared ZERO times in every /sites preamble
+# (create/refine/chat/frontend), ZERO times in the sites MCP tool descriptions
+# (`agent/mcp_servers/sites.py`, `sites_create.py`), and ZERO times anywhere in
+# `src/pocketpaw/bundled_skills/`. Nothing in the code path ever stated a
+# concierge exists, so whether the agent mentioned one was decided purely by
+# model sampling — which is exactly what "sometimes" looks like from outside.
+#
+# These tests make the awareness DETERMINISTIC: every live /sites mode, on every
+# engine, must carry the concierge block. They also pin the two honest LIMITS of
+# that block, because an over-promising preamble would trade a blind agent for a
+# lying one:
+#   * it must NOT claim a create/draft already has a concierge (provisioning is
+#     live-publish-only — `sites/service.py::_embed_concierge_bar` runs after the
+#     build, and a preview returns from `publish` long before it);
+#   * it must NOT claim the agent can configure the concierge's catalog/actions
+#     (owner-authored only — no agent tool declares them; the known gap).
+
+_CONCIERGE_MODES: list[tuple[str, SurfaceMeta]] = [
+    ("create/html", SurfaceMeta(route_path="/sites")),
+    ("create/svelte", SurfaceMeta(route_path="/sites", engine="svelte")),
+    ("create/ripple", SurfaceMeta(route_path="/sites", engine="ripple")),
+    (
+        "refine",
+        SurfaceMeta(route_path="/sites/site-abc", pocket_id="pkt-c", mode="build"),
+    ),
+    (
+        "chat",
+        SurfaceMeta(route_path="/sites/site-abc", pocket_id="pkt-c", mode="chat"),
+    ),
+]
+
+
+@pytest.mark.parametrize("label,meta", _CONCIERGE_MODES, ids=[m[0] for m in _CONCIERGE_MODES])
+async def test_every_sites_mode_knows_the_concierge_exists(label: str, meta: SurfaceMeta) -> None:
+    """DETERMINISM: the concierge block is present in EVERY live /sites mode.
+
+    Not "usually" and not on one engine — the reported bug was intermittent
+    precisely because no mode carried it, so this is parametrized across all
+    five dispatched (engine, mode) combinations rather than spot-checking one.
+    """
+    preamble = await sites_handler.build_preamble(WORKSPACE, USER, meta)
+    lower = preamble.lower()
+
+    assert "concierge" in lower, f"{label}: preamble never mentions the concierge"
+    # Named as the thing the visitor actually sees on the page.
+    assert "paw bar" in lower or "paw-bar" in lower, f"{label}: the bar is not named"
+    # It must say the concierge answers the SITE's visitors, not the builder.
+    assert "visitor" in lower, f"{label}: no visitor framing"
+
+
+@pytest.mark.parametrize("label,meta", _CONCIERGE_MODES, ids=[m[0] for m in _CONCIERGE_MODES])
+async def test_concierge_block_never_promises_a_configuration_tool(
+    label: str, meta: SurfaceMeta
+) -> None:
+    """The block must not invent authority the agent does not have.
+
+    Widget `catalog` and `actions` are owner-authored only — no agent tool
+    declares them — so the preamble has to route the user to the dashboard
+    instead of naming a tool that would hard-error.
+    """
+    preamble = await sites_handler.build_preamble(WORKSPACE, USER, meta)
+    lower = preamble.lower()
+
+    # No fabricated tool ids for concierge configuration.
+    for phantom in (
+        "mcp__pocketpaw_sites_manager__configure_concierge",
+        "mcp__pawbar_actions__",
+        "set_concierge",
+        "configure_concierge",
+    ):
+        assert phantom not in lower, f"{label}: preamble names a non-existent tool {phantom!r}"
+    # It points at where the owner really configures it.
+    assert "dashboard" in lower, f"{label}: no pointer to the owner-facing surface"
+
+
+async def test_create_ties_the_concierge_to_publish_not_to_the_draft() -> None:
+    """A DRAFT has no concierge — provisioning is live-publish-only.
+
+    `sites/service.py::_embed_concierge_bar` (and the `ensure_site_widget`
+    trigger inside it) runs between the build and the deploy of a LIVE publish;
+    a preview returns from `publish_pocket` long before it. Since the create
+    flow is draft-first, an agent that told the user "your site has a concierge"
+    right after a create would be wrong. The create block must tie the concierge
+    to publishing.
+    """
+    for engine in (None, "svelte", "ripple"):
+        meta = SurfaceMeta(route_path="/sites", engine=engine)
+        preamble = await sites_handler.build_preamble(WORKSPACE, USER, meta)
+        lower = preamble.lower()
+        # The concierge arrives WITH the publish, not with the draft.
+        assert "publish" in lower
+        concierge_at = lower.index("concierge")
+        window = lower[concierge_at : concierge_at + 700]
+        assert "publish" in window, (
+            f"engine={engine}: the concierge block does not tie provisioning to publish"
+        )
+
+
+async def test_concierge_awareness_does_not_depend_on_the_mcp_tool_id_import() -> None:
+    """Awareness must survive the degraded profile path.
+
+    `surface_registry._load_mcp_tool_ids` degrades to all-`None` (no MCP
+    restriction) when the EE agent-layer import fails, and it MEMOIZES that
+    result for the life of the process. Preamble knowledge must not be coupled
+    to that cache, or a poisoned memo would take the concierge block with it.
+    """
+    import pocketpaw_ee.cloud.surface.surface_registry as registry
+
+    original = registry._MCP_TOOL_IDS_CACHE
+    try:
+        registry._MCP_TOOL_IDS_CACHE = registry._McpToolIds(
+            loaded=False,
+            foresight_allow=None,
+            sites_allow=None,
+            studio_allow=None,
+            belt_allow=None,
+        )
+        preamble = await sites_handler.build_preamble(
+            WORKSPACE, USER, SurfaceMeta(route_path="/sites")
+        )
+        assert "concierge" in preamble.lower()
+    finally:
+        registry._MCP_TOOL_IDS_CACHE = original


### PR DESCRIPTION
Reported: *"sometimes it doesn't know about concierge at all."*

The "sometimes" was the tell. It isn't a filter that occasionally drops — it's that **nothing anywhere told the agent a concierge exists**, so whether it mentioned one came down to model sampling and whatever the user happened to type.

## Proven, not inferred

Before this change, the string `concierge` appeared **zero** times in:

- `cloud/surface/handlers/sites.py` — all four preambles (create / refine / chat / frontend)
- `agent/mcp_servers/sites.py` + `sites_create.py` — every tool description
- `src/pocketpaw/bundled_skills/` — every bundled skill

A live probe across all five dispatched `(engine, mode)` combinations returned `concierge_in_preamble=False` for every one. And `_publish_handler` returns only `{ok, site:{id, pocket_id, name, url, deployed}}` — so not even a successful publish told the agent a bar had just been grown onto the pages it deployed.

## It is NOT a tool-access problem

Worth stating clearly, because that was the obvious first hypothesis. `sites_allow` holds 13 ids and no pawbar id — **correctly**. The `mcp__pawbar_actions__*` tools only exist *during a concierge run*: `build_pawbar_actions_server` returns `None` when `current_pawbar_run()` is empty, and that's empty on every non-concierge surface. Those are visitor-facing verbs (`add_to_cart`, `request_human`), not builder tools. There is no builder-facing concierge tool being wrongly filtered.

## A second, compounding condition

Provisioning is **live-publish-only** — `_embed_concierge_bar` runs between build and deploy, and a preview returns from `publish_pocket` well before it — while the create flow has been **draft-first since 2026-07-17**. So on a plain "build me a site" the concierge genuinely doesn't exist yet, and an agent guessing either way was right about half the time.

## The fix

`_CONCIERGE_NOTE`, appended unconditionally by all four preamble builders across all three engines. No engine, mode, feature flag, or lazily-imported tool id can gate it off — that's what makes it deterministic rather than usually-fine.

It deliberately **names no tool** and routes the user to the dashboard instead. Widget `catalog`/`actions` are owner-authored only and there is no agent tool that declares them; an over-promising block would have traded a blind agent for a confidently wrong one.

## Verification

13 new tests, **written red first and committed red** (`5505789e`) before the fix (`1db0e92a`) — re-checked on this branch: 8 of 12 fail at the test commit, 43 pass on the fix. Parametrized across all five dispatched combinations, because determinism *is* the fix and spot-checking one mode wouldn't prove it. One test freezes a poisoned `_MCP_TOOL_IDS_CACHE` to prove awareness survives the degraded profile path.

```
tests/ -k "surface or paw_bar or sites"   654 passed, 2 skipped
ruff                                       clean
lint-imports (both configs)                1 + 34 kept, 0 broken
```

## Known gaps this does NOT close

- **No edit tool for html-engine sites.** You can create one; an agent cannot change one. Needs a new tool.
- **`catalog`/`actions` are owner-authored only** — no agent tool declares them.
- **`_publish_handler` returns no concierge signal.** A `concierge: {enabled, widget_id}` field would let the agent report real post-publish state instead of a general rule. Skipped deliberately: it adds I/O to the publish path, and the preamble was the smaller correct fix.