### PR TITLE
A draft resolves its own engine's build output

### DIFF
--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1880,9 +1880,7 @@ async def publish(
         if _local_deploy is not None:
             preview_url = _local_deploy(preview_id, build.project_dir)
         else:
-            preview_url = local_server.deploy_local(
-                preview_id, build.project_dir, engine=engine
-            )
+            preview_url = local_server.deploy_local(preview_id, build.project_dir, engine=engine)
         # SECOND, UNFIXED half of the draft-render bug — surfaced, not silenced.
         # Unlike the live deploy below, this path has NO deploy-mode fork: it
         # always serves from ``local_server``, which binds 127.0.0.1 inside THIS

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,18 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-08-02 (draft render): the PREVIEW deploy in ``publish`` is now
+# engine-aware, closing the half of HE-4 that was missed. HE-4 taught the LIVE
+# deploy that a built site's servable files live somewhere different per engine
+# (``engines.static_output_rel``) but only touched ``_deploy_site_doc``; the DRAFT
+# branch a few lines above kept calling ``deploy_local`` with no ``engine``, so an
+# html draft resolved a SvelteKit build dir it never emits. The failure was
+# invisible rather than loud, because ``deploy_local`` fails SOFT: with a prior
+# deploy on disk it re-served THAT, so every edit-then-reload showed the previous
+# page and nothing reported a problem. The live and draft halves of one function
+# must resolve the static root the same way — that is the whole point of routing
+# both through the shared predicate.
+#
 # Updated 2026-07-31 (provisioning brick): the dynamic single-flight guard is now
 # BOUNDED. A job that was never consumed — no worker running — or that died
 # without writing a terminal status used to leave the Site in
@@ -1856,8 +1868,40 @@ async def publish(
         # doc still carries the minted ObjectId in its ``id``/``script_name`` (it is
         # never persisted), but the served path + url use the stable preview id.
         preview_id = _preview_id(pocket_id)
-        deploy = _local_deploy or local_server.deploy_local
-        preview_url = deploy(preview_id, build.project_dir)
+        # HE-4 parity with the LIVE deploy below: WHERE the built draft's servable
+        # files sit is a per-engine fact (``static_output_rel``) — the SvelteKit
+        # adapter output for ripple/svelte, the project root for html — so the real
+        # deploy must be told the engine. Without it an html draft resolved
+        # ``.svelte-kit/cloudflare``, which an html build never emits, and
+        # ``deploy_local``'s fail-soft branch re-served the PRIOR deploy: the draft
+        # showed the previous page and nothing surfaced an error. The injected test
+        # seam stays 2-arg (a fake serves no real tree, so it ignores the engine),
+        # exactly as ``_deploy_site_doc`` splits it.
+        if _local_deploy is not None:
+            preview_url = _local_deploy(preview_id, build.project_dir)
+        else:
+            preview_url = local_server.deploy_local(
+                preview_id, build.project_dir, engine=engine
+            )
+        # SECOND, UNFIXED half of the draft-render bug — surfaced, not silenced.
+        # Unlike the live deploy below, this path has NO deploy-mode fork: it
+        # always serves from ``local_server``, which binds 127.0.0.1 inside THIS
+        # process. On a dev box that is also the operator's machine, so the draft
+        # frames fine and every local test passes. In a real deployment the browser
+        # is somewhere else entirely and the URL is unreachable — the draft renders
+        # broken in production for a reason no log ever mentioned. Giving the draft
+        # a reachable URL off-box means deploying a preview worker per pocket
+        # (cost, naming, teardown), which is a product call, not a bug fix. Until
+        # that call is made, say so loudly at the moment we hand back the address.
+        if not _local_mode() or _deploy_mode() not in (None, "local"):
+            logger.warning(
+                "sites: draft preview for pocket %s is served from this process's "
+                "loopback (%s) — a browser off this host CANNOT load it, so the "
+                "draft will render broken. The preview path has no workers/wfp "
+                "deploy target yet (the live path does).",
+                pocket_id,
+                preview_url,
+            )
         return _SiteDoc(
             id=ObjectId(site_id),
             workspace=workspace_id,

--- a/tests/ee/sites/test_preview_deploy_engine_aware.py
+++ b/tests/ee/sites/test_preview_deploy_engine_aware.py
@@ -1,0 +1,205 @@
+# tests/ee/sites/test_preview_deploy_engine_aware.py
+# Created: 2026-08-02 (fix/site-rendering-ripple-and-draft) — reproduce-first cover
+# for "a site renders BROKEN while it is in DRAFT state".
+#
+# WHY THIS EXISTS. HE-4 (c4275e46, "make the local deploy engine-aware") taught the
+# LIVE deploy that where a built site's servable files live depends on the engine:
+# ``.svelte-kit/cloudflare`` for ripple/svelte, the project root for html
+# (``engines.static_output_rel``). It only fixed ``_deploy_site_doc``. The DRAFT
+# half of the same function — ``publish(preview=True)``, the arm-for-edit path
+# behind ``POST /sites/by-pocket/{id}/editable`` — still calls
+# ``local_server.deploy_local(preview_id, project_dir)`` with NO ``engine=``, so it
+# falls back to the ``"ripple"`` default and looks for a SvelteKit build dir an html
+# site never emits. The draft then either 500s (``MissingBuildOutput``) or, worse,
+# takes ``deploy_local``'s fail-soft branch and silently re-serves the PREVIOUS
+# deploy — the draft shows stale content and nobody is told.
+#
+# These tests assert on the SERVED (deployed) draft — the bytes the builder iframe
+# actually loads — not on the build output, so they pin the whole preview→serve
+# seam rather than an internal detail. The build is faked behind the
+# ``GeneratorClient._runner`` seam (no bun / node / workerd spawns).
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pocketpaw_ee.sites import local_server
+
+pytestmark = pytest.mark.asyncio
+
+# A minimal, self-contained page: no local asset refs, so the html static smoke
+# (_html_static_smoke) passes without the test having to materialize a whole tree.
+_HTML_DRAFT = (
+    "<!doctype html>\n"
+    "<html lang='en'><head><meta charset='utf-8'><title>Draft</title></head>\n"
+    "<body><h1>draft html page</h1></body></html>\n"
+)
+
+_CLOUDFLARE_BUILD_REL = ".svelte-kit/cloudflare"
+
+
+@pytest.fixture(autouse=True)
+def recording_bus():
+    """Install a recording EventBus so the pockets service's ``emit`` calls don't
+    raise (the real bus is only wired by ``init_realtime()`` at boot)."""
+    from pocketpaw_ee.cloud._core.realtime import bus as bus_mod
+    from pocketpaw_ee.cloud._core.realtime.events import Event
+
+    class _RecordingBus:
+        def __init__(self) -> None:
+            self.events: list[Event] = []
+
+        async def publish(self, event: Event) -> None:
+            self.events.append(event)
+
+        def subscribe(self, event_type: str, handler) -> None:  # noqa: ARG002
+            return
+
+    rec = _RecordingBus()
+    prev = bus_mod._bus  # type: ignore[attr-defined]
+    bus_mod._bus = rec  # type: ignore[attr-defined]
+    yield rec
+    bus_mod._bus = prev  # type: ignore[attr-defined]
+
+
+class _HtmlRunner:
+    """Fake runner for the html lane: ``generate`` writes the raw static tree at the
+    project ROOT (what the real generator's ``materializeHtml`` emits) and nothing
+    else ever runs — html has ``needs_node_build == False``, so install /
+    build_static / smoke are never reached."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    async def generate(self, input_json: dict, out_dir: str) -> dict:
+        self.calls.append("generate")
+        root = Path(out_dir)
+        root.mkdir(parents=True, exist_ok=True)
+        (root / "index.html").write_text(_HTML_DRAFT, encoding="utf-8")
+        return {"projectDir": out_dir, "engine": "html", "staticDir": out_dir}
+
+    def install_inputs_hash(self, project_dir: str) -> str:
+        return "h1"
+
+    async def install(self, project_dir: str) -> tuple[bool, str]:
+        self.calls.append("install")
+        return True, "ok"
+
+    async def build_static(self, project_dir: str, *, gate: bool) -> tuple[bool, str]:
+        self.calls.append("build_static")
+        return True, "ok"
+
+
+async def test_html_draft_preview_serves_the_built_page(beanie_test_db, tmp_path, monkeypatch):
+    """An html site armed for editing must SERVE its draft.
+
+    Reproduce-first: on the pre-fix code the preview deploy drops the ``engine``
+    kwarg, so ``deploy_local`` resolves ``static_output_rel("ripple")`` —
+    ``.svelte-kit/cloudflare`` — which an html build never emits. With no prior
+    deploy to fall back on that raises ``MissingBuildOutput`` and the draft never
+    renders. After the fix the preview resolves the html static root (the project
+    dir) exactly like the LIVE deploy does, and the served file is the draft page.
+    """
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+    from pocketpaw_ee.sites import service as sites_service
+
+    monkeypatch.setenv("PAW_SITES_BUILD_DIR", str(tmp_path / "builds"))
+    monkeypatch.setenv("PAW_SITES_LOCAL_DIR", str(tmp_path / "sites"))
+    monkeypatch.setenv("PAW_SITES_LOCAL", "1")
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+    monkeypatch.delenv("PAW_CF_DEPLOY_MODE", raising=False)
+
+    _view, pocket_id, err = await pockets_service.agent_create(
+        workspace_id="ws1",
+        owner_id="u1",
+        name="Brochure",
+        type_="site",
+        pattern="landing",
+        ripple_spec=None,
+        engine="html",
+        source={"index.html": _HTML_DRAFT},
+        trusted=True,
+    )
+    assert err is None, err
+    assert pocket_id is not None
+
+    gen = sites_service.GeneratorClient(_runner=_HtmlRunner())
+
+    site = await sites_service.publish_pocket(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        preview=True,
+        builder_origin="http://localhost:8888",
+        _generator=gen,
+    )
+
+    served = local_server.sites_home() / f"preview-{pocket_id}" / "index.html"
+    assert served.is_file(), (
+        f"no served draft at {served} — the preview deploy resolved the wrong "
+        "static root for engine='html' (it used the ripple default)"
+    )
+    assert "draft html page" in served.read_text()
+    assert site.url.endswith(f"/preview-{pocket_id}/")
+    assert site.deployed is False  # a preview is never a live deploy
+
+
+async def test_html_draft_preview_does_not_silently_serve_a_stale_deploy(
+    beanie_test_db, tmp_path, monkeypatch
+):
+    """The nastier half of the same bug: SILENT staleness.
+
+    ``deploy_local`` fails SOFT — when the static root it was pointed at is
+    missing but a PRIOR deploy of the same id is on disk, it keeps that prior
+    deploy and returns its URL. With the wrong (ripple) root for an html site that
+    turns every draft re-arm into "serve whatever was there last": the operator
+    edits, the preview reloads, and the OLD page comes back with no error anywhere.
+    Seeding a stale prior deploy makes the pre-fix code return it; the fix must
+    overwrite it with the fresh draft.
+    """
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+    from pocketpaw_ee.sites import service as sites_service
+
+    monkeypatch.setenv("PAW_SITES_BUILD_DIR", str(tmp_path / "builds"))
+    monkeypatch.setenv("PAW_SITES_LOCAL_DIR", str(tmp_path / "sites"))
+    monkeypatch.setenv("PAW_SITES_LOCAL", "1")
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+    monkeypatch.delenv("PAW_CF_DEPLOY_MODE", raising=False)
+
+    _view, pocket_id, err = await pockets_service.agent_create(
+        workspace_id="ws1",
+        owner_id="u1",
+        name="Brochure",
+        type_="site",
+        pattern="landing",
+        ripple_spec=None,
+        engine="html",
+        source={"index.html": _HTML_DRAFT},
+        trusted=True,
+    )
+    assert err is None, err
+    assert pocket_id is not None
+
+    # A stale prior deploy sitting at the stable preview path.
+    stale_dir = local_server.sites_home() / f"preview-{pocket_id}"
+    stale_dir.mkdir(parents=True, exist_ok=True)
+    (stale_dir / "index.html").write_text("<h1>stale previous draft</h1>", encoding="utf-8")
+
+    gen = sites_service.GeneratorClient(_runner=_HtmlRunner())
+    await sites_service.publish_pocket(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        preview=True,
+        builder_origin="http://localhost:8888",
+        _generator=gen,
+    )
+
+    served = (stale_dir / "index.html").read_text()
+    assert "draft html page" in served, (
+        "the draft preview silently re-served the PRIOR deploy — deploy_local's "
+        "fail-soft branch fired because the preview looked for a SvelteKit build "
+        "dir an html site never emits"
+    )
+    assert "stale previous draft" not in served


### PR DESCRIPTION
Two reported symptoms, two different answers. One is a real code bug and is fixed here; the other turns out to be an environment gap, and saying so is more useful than a fix that changes nothing.

---

## Draft renders broken — a real bug, fixed

**It is (b): the earlier fix was never complete.** The fix I was pointed at — `pocketpaw#1345` (backend #1485/#1490, frontend `paw-enterprise#361`) — is **intact and has not regressed**.

The incomplete one is different: **HE-4 / `c4275e46`, "make the local deploy engine-aware"**, taught `_deploy_site_doc` that a built site's servable files live somewhere different per engine — and never touched the draft branch 200 lines above it. `publish(preview=True)` called `deploy_local(preview_id, project_dir)` with no `engine=`, so an **html** draft resolved `.svelte-kit/cloudflare`, which an html build never emits.

And it failed **silently**. `deploy_local` fails soft and re-serves the previous deploy, so edit-then-reload showed the *old* page with nothing surfaced:

```
WARNING local_server: sites: no fresh build at .../builds/<pocket>/.svelte-kit/cloudflare
        — serving the PRIOR deploy at .../sites/preview-<pocket>
```

**Why it resurfaced now:** `#1744`/`#1745` flipped every new site to draft-first and mint a draft Site doc at create, so nearly all traffic now runs the draft lane that was never finished.

The fix routes the draft deploy through the same per-engine predicate the live deploy already uses — making one function's two halves agree rather than adding a parallel path.

## The prod half — diagnosed, deliberately NOT fixed

The draft path has **no deploy-mode fork at all**. `_deploy_site_doc` forks local | workers | wfp; the preview branch always serves from `local_server`, which binds `127.0.0.1` **inside the backend process**. On a dev box that's the operator's own machine, so it frames fine and every local test passes. In a real deployment the browser is elsewhere and that URL is unreachable.

Fixing it means deploying a preview worker per pocket — cost, naming, teardown — which is a product call, not a bug fix. It now logs a loud warning at the moment it hands back the address.

---

## Ripple sites don't render — an environment gap, not a prod defect

`@ripple-ui/svelte` **is not on npm** (`npm view` → 404, re-verified). `_ripple_dep_source()` defaults to the bare registry spec `"0.2.0"`, which gets stamped into the generated `package.json`. Wherever `PAW_SITES_RIPPLE_DEP` is unset, `bun install` can't resolve → `SmokeGateFailed` → `sites.generator_failed`.

The other lanes are immune for different reasons: **html** never installs anything, and **svelte**'s materialized `package.json` drops the ripple dep entirely. That is exactly the "ripple broken, html and custom fine" pattern.

On-disk proof in `~/.pocketpaw/site-builds/`: three ripple projects still pinned `"0.2.0"` have **no** `node_modules` and **no** `.svelte-kit`; the one pinned `file:.../ripple` has both.

**Prod is already covered** — `Dockerfile.enterprise:381` sets `PAW_SITES_RIPPLE_DEP=file:/opt/ripple-ui-svelte-0.5.0.tgz`. So this explains ripple failing on **dev rigs launched without it** (`.claude/launch.json`'s `atlas-backend`/:8899 entry carries no `PAW_SITES_*` vars; `native-backend`/:8888 does). It does **not** explain a prod-only ripple fault, and I could not prove one: ripple and svelte share an identical output contract, so nothing separates them at deploy time.

**One thing to confirm:** if the wrong render is in the *builder canvas* rather than at the published URL, that path is in-app (`ChatRippleFrame` → paw-enterprise's bundled ripple) and never touches this pipeline.

## Verification

```
tests/ -k "site"      649 passed, 2 skipped
ruff                  clean
lint-imports          1 + 34 kept, 0 broken
```

Two tests, **written red first** (`3546da77`) then green (`f5cd487d`) — re-checked on this branch. They assert on the **served bytes** the builder iframe loads, covering both the hard failure and the silent-staleness variant.

## Also diagnosed, left alone (each wants its own PR)

- **Ripple install cache never re-installs after a ripple upgrade.** The PERF-3 fingerprint hashes `package.json` + lockfile; `PAW_SITES_RIPPLE_DEP` is a stable `file:` *path*, so a changed tarball doesn't move the hash, install is skipped, and the persisted `node_modules` keeps the old ripple indefinitely.
- **WfP uploads an unbundled worker.** Three deployed copies read 4.3 KB and still contain `import { Server } from "./../output/server/index.js"` — a module outside the uploaded dir. Workers mode is fine (wrangler bundles); WfP would fail to load, consistent with WfP never having served live.
- **A failed deploy still moves the published pointer** — `_promote_pocket_draft_to_published` runs *before* the deploy, so a ripple publish that fails to build leaves the status reading "published, up to date" while the live page serves old content. The docstring calls this deliberate, which is why a broken ripple publish looks like a stale render rather than an error.