### PR TITLE
feat(senses): agent-carried senses — mount list, provider preferences, concierge opt-in

### DIFF
--- a/docs/CONNECTORS.md
+++ b/docs/CONNECTORS.md
@@ -1,5 +1,10 @@
 <!--
   Connectors documentation.
+  Updated: 2026-08-02 (Sense Phase 2, SP2-3) — the Senses section now points at
+  the per-agent sense config (the `senses` mount list, exclusive when set, and
+  the `sense_prefs` provider choice). The field-level reference lives in
+  docs/api-reference.md → "Agents — Per-agent senses"; this file keeps the
+  concept and the agent tool surface.
   Updated: 2026-07-02 (AW-3 egress default-close) — clarified the "Development
   against localhost" section: the egress guard rejects internal/metadata IPs BY
   DEFAULT; POCKETPAW_ALLOW_INTERNAL_URLS opens the escape ONLY when set to an
@@ -617,6 +622,15 @@ sense_execute("paw.email.v1", "gmail_search",
 sense_execute("paw.email.v1", "gmail_send", {...})
   → refused: "needs approval … not executed in v1 (read-first)."
 ```
+
+**Per-agent senses.** By default an agent reaches every sense that resolves for
+its workspace. An agent can instead carry a **mount list** (`config.senses`) —
+then it lists exactly those senses and any other one is refused with
+`sense.not_carried`, before the resolver looks up a connector. A second field,
+`config.sense_prefs`, picks which provider that agent prefers per sense (it
+outranks the workspace preference row but never widens reach). Both are
+documented in
+[api-reference.md → Agents — Per-agent senses](./api-reference.md#agents--per-agent-senses-senses--sense_prefs).
 
 ## Using with Existing Integrations
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -72,6 +72,14 @@ workspace's source→Fabric mappings, now with a "connector" source_kind that
 dispatches through the OSS FABRIC_INGESTORS registry — gcalendar first) and
 POST /fabric/ingest/run (run one mapping immediately; misconfiguration reports
 status="error" in the body, never a 5xx).
+
+Updated: 2026-08-02 (Sense Phase 2, SP2-2 + SP2-3) — documented the two
+sense-shaped agent config fields in the new "Agents — Per-agent senses" section:
+`senses` (the mount list — empty inherits the workspace's whole sense surface,
+non-empty is EXCLUSIVE and anything else refuses with `sense.not_carried`) and
+`sense_prefs` (per-sense provider choice that outranks the stored
+pocket/workspace preference row but never widens reach). Both validate sense ids
+at write time; connector-name values stay unvalidated on purpose.
 -->
 
 # Cloud REST API Reference
@@ -814,6 +822,61 @@ missing / unreadable registry degrades to no plugin skills (it never fails
 the run). The agent set is UNIONed with any surface/entity skill subset, so
 both apply together. Per-agent MCP servers are **not** part of this — that
 is a separate, deferred slice.
+
+## Agents — Per-agent senses (`senses` + `sense_prefs`)
+
+A **Sense** is a provider-agnostic capability (`paw.email.v1` = email,
+`paw.code.v1` = repos/issues/PRs); the resolver binds it to whichever
+connector the tenant enabled. See [CONNECTORS.md](./CONNECTORS.md) for the
+Sense model and the `list_senses` / `sense_execute` agent tools. An agent's
+`config` carries two sense-shaped fields, set the same way `skill_refs` is —
+via `POST /agents` or `PATCH /agents/{id}` (nested `config` object):
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `senses` | `string[]` | The **mount list** — the capabilities this agent carries. |
+| `sense_prefs` | `{sense_id: connector_name}` | Which provider this agent prefers per sense. |
+
+Both default to empty, so every existing agent behaves exactly as before.
+
+**`senses` is exclusive when set.** Empty means "inherit" — the agent reaches
+every sense that resolves for the workspace, which is the legacy behaviour. A
+**non-empty** list is the agent's entire sense surface: `list_senses` returns
+only those, and `sense_execute` on anything else is refused with the stable
+code `sense.not_carried` before the resolver looks up a single connector. The
+refusal is identical whether or not the tenant has a provider for that sense,
+so it leaks nothing about the workspace. This is the same semantics as
+`tool_mode: "exclusive"`, applied to capabilities instead of tools — with no
+separate mode flag, because nothing ever persisted a non-empty `senses` under
+additive semantics.
+
+**`sense_prefs` picks a provider, it never widens reach.** When more than one
+enabled connector fills a sense, the agent's pref outranks the stored
+pocket/workspace preference row. Keys are validated as sense ids at write
+time; connector-name **values** are not, because whether a connector is a
+candidate is workspace state that changes under the agent — a pref naming a
+non-candidate is skipped at resolve time (one log line) and falls through to
+the stored preference rather than failing the sense. A pref for a sense
+outside `senses` is dead config: the mount gate refuses first.
+
+Entries in `senses` and keys in `sense_prefs` are both validated as sense ids
+on write, so an unknown or malformed id (`paw.telepathy.v1`, `not an id`)
+fails with a `422` rather than silently costing the agent a capability.
+Vendor-extension ids outside the closed `paw.*` set are accepted.
+
+```jsonc
+PATCH /agents/{id}
+{
+  "config": {
+    "senses": ["paw.email.v1", "paw.calendar.v1"],   // carries exactly these
+    "sense_prefs": {"paw.email.v1": "gmail"}          // …and prefers gmail for email
+  }
+}
+```
+
+That agent lists email and calendar, uses Gmail for email when several mail
+connectors are enabled, and is refused `paw.code.v1` even in a workspace with
+GitHub connected.
 
 ## Pockets — Catalog-as-Allowlist Ingest Gate
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -80,6 +80,13 @@ non-empty is EXCLUSIVE and anything else refuses with `sense.not_carried`) and
 `sense_prefs` (per-sense provider choice that outranks the stored
 pocket/workspace preference row but never widens reach). Both validate sense ids
 at write time; connector-name values stay unvalidated on purpose.
+
+Updated: 2026-08-02 (Sense Phase 2, SP2-5) — the same section now documents HOW
+to set and read those two fields, which until this slice it did not say: both are
+top-level fields on POST /agents and PATCH /agents/{id} (and PATCH still accepts
+them inside the nested `config` object), and both are returned under `config` on
+the agent reads. The 422-on-bogus-sense-id the section already promised is now
+actually a 422 on every path in, rather than a 500 from the nested-config one.
 -->
 
 # Cloud REST API Reference
@@ -829,8 +836,7 @@ A **Sense** is a provider-agnostic capability (`paw.email.v1` = email,
 `paw.code.v1` = repos/issues/PRs); the resolver binds it to whichever
 connector the tenant enabled. See [CONNECTORS.md](./CONNECTORS.md) for the
 Sense model and the `list_senses` / `sense_execute` agent tools. An agent's
-`config` carries two sense-shaped fields, set the same way `skill_refs` is —
-via `POST /agents` or `PATCH /agents/{id}` (nested `config` object):
+`config` carries two sense-shaped fields:
 
 | Field | Type | Meaning |
 |-------|------|---------|
@@ -838,6 +844,29 @@ via `POST /agents` or `PATCH /agents/{id}` (nested `config` object):
 | `sense_prefs` | `{sense_id: connector_name}` | Which provider this agent prefers per sense. |
 
 Both default to empty, so every existing agent behaves exactly as before.
+
+**Setting and reading them.** Both are accepted as top-level fields on
+`POST /agents` and `PATCH /agents/{id}`, and `PATCH` also accepts them inside
+the nested `config` object. Both are returned under `config` on
+`GET /agents/{id}` and `GET /agents`.
+
+Prefer the top-level form when you are changing one thing. The nested `config`
+form replaces the whole config object, so it is the one to use when you already
+hold a full config; the top-level form only touches the fields it names. On
+`PATCH`, omitting a field leaves it unchanged — sending `"senses": []` is a real
+value that clears the mount list back to "inherit".
+
+```jsonc
+POST /agents
+{
+  "name": "Mailer", "slug": "mailer",
+  "senses": ["paw.email.v1"],
+  "sense_prefs": {"paw.email.v1": "gmail"}
+}
+
+PATCH /agents/{id}
+{ "senses": ["paw.email.v1", "paw.calendar.v1"] }   // sense_prefs untouched
+```
 
 **`senses` is exclusive when set.** Empty means "inherit" — the agent reaches
 every sense that resolves for the workspace, which is the legacy behaviour. A

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -275,6 +275,14 @@ and the two reingest routes (POST /knowledge/reingest,
 POST /knowledge/reingest-upload) that re-run content through the hardened
 KnowledgeService ingest funnel. Design doc:
 docs/design/drafts/2026-08-04-knowledge-wiki-redesign.md (workspace repo).
+
+Updated: 2026-08-02 (Sense Phase 2, SP2-2 + SP2-3) — documented the two
+sense-shaped agent config fields in the new "Agents — Per-agent senses" section:
+`senses` (the mount list — empty inherits the workspace's whole sense surface,
+non-empty is EXCLUSIVE and anything else refuses with `sense.not_carried`) and
+`sense_prefs` (per-sense provider choice that outranks the stored
+pocket/workspace preference row but never widens reach). Both validate sense ids
+at write time; connector-name values stay unvalidated on purpose.
 -->
 
 # Cloud REST API Reference
@@ -1022,6 +1030,61 @@ missing / unreadable registry degrades to no plugin skills (it never fails
 the run). The agent set is UNIONed with any surface/entity skill subset, so
 both apply together. Per-agent MCP servers are **not** part of this — that
 is a separate, deferred slice.
+
+## Agents — Per-agent senses (`senses` + `sense_prefs`)
+
+A **Sense** is a provider-agnostic capability (`paw.email.v1` = email,
+`paw.code.v1` = repos/issues/PRs); the resolver binds it to whichever
+connector the tenant enabled. See [CONNECTORS.md](./CONNECTORS.md) for the
+Sense model and the `list_senses` / `sense_execute` agent tools. An agent's
+`config` carries two sense-shaped fields, set the same way `skill_refs` is —
+via `POST /agents` or `PATCH /agents/{id}` (nested `config` object):
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `senses` | `string[]` | The **mount list** — the capabilities this agent carries. |
+| `sense_prefs` | `{sense_id: connector_name}` | Which provider this agent prefers per sense. |
+
+Both default to empty, so every existing agent behaves exactly as before.
+
+**`senses` is exclusive when set.** Empty means "inherit" — the agent reaches
+every sense that resolves for the workspace, which is the legacy behaviour. A
+**non-empty** list is the agent's entire sense surface: `list_senses` returns
+only those, and `sense_execute` on anything else is refused with the stable
+code `sense.not_carried` before the resolver looks up a single connector. The
+refusal is identical whether or not the tenant has a provider for that sense,
+so it leaks nothing about the workspace. This is the same semantics as
+`tool_mode: "exclusive"`, applied to capabilities instead of tools — with no
+separate mode flag, because nothing ever persisted a non-empty `senses` under
+additive semantics.
+
+**`sense_prefs` picks a provider, it never widens reach.** When more than one
+enabled connector fills a sense, the agent's pref outranks the stored
+pocket/workspace preference row. Keys are validated as sense ids at write
+time; connector-name **values** are not, because whether a connector is a
+candidate is workspace state that changes under the agent — a pref naming a
+non-candidate is skipped at resolve time (one log line) and falls through to
+the stored preference rather than failing the sense. A pref for a sense
+outside `senses` is dead config: the mount gate refuses first.
+
+Entries in `senses` and keys in `sense_prefs` are both validated as sense ids
+on write, so an unknown or malformed id (`paw.telepathy.v1`, `not an id`)
+fails with a `422` rather than silently costing the agent a capability.
+Vendor-extension ids outside the closed `paw.*` set are accepted.
+
+```jsonc
+PATCH /agents/{id}
+{
+  "config": {
+    "senses": ["paw.email.v1", "paw.calendar.v1"],   // carries exactly these
+    "sense_prefs": {"paw.email.v1": "gmail"}          // …and prefers gmail for email
+  }
+}
+```
+
+That agent lists email and calendar, uses Gmail for email when several mail
+connectors are enabled, and is refused `paw.code.v1` even in a workspace with
+GitHub connected.
 
 ## Pockets — Catalog-as-Allowlist Ingest Gate
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -283,6 +283,13 @@ non-empty is EXCLUSIVE and anything else refuses with `sense.not_carried`) and
 `sense_prefs` (per-sense provider choice that outranks the stored
 pocket/workspace preference row but never widens reach). Both validate sense ids
 at write time; connector-name values stay unvalidated on purpose.
+
+Updated: 2026-08-02 (Sense Phase 2, SP2-5) — the same section now documents HOW
+to set and read those two fields, which until this slice it did not say: both are
+top-level fields on POST /agents and PATCH /agents/{id} (and PATCH still accepts
+them inside the nested `config` object), and both are returned under `config` on
+the agent reads. The 422-on-bogus-sense-id the section already promised is now
+actually a 422 on every path in, rather than a 500 from the nested-config one.
 -->
 
 # Cloud REST API Reference
@@ -1037,8 +1044,7 @@ A **Sense** is a provider-agnostic capability (`paw.email.v1` = email,
 `paw.code.v1` = repos/issues/PRs); the resolver binds it to whichever
 connector the tenant enabled. See [CONNECTORS.md](./CONNECTORS.md) for the
 Sense model and the `list_senses` / `sense_execute` agent tools. An agent's
-`config` carries two sense-shaped fields, set the same way `skill_refs` is —
-via `POST /agents` or `PATCH /agents/{id}` (nested `config` object):
+`config` carries two sense-shaped fields:
 
 | Field | Type | Meaning |
 |-------|------|---------|
@@ -1046,6 +1052,29 @@ via `POST /agents` or `PATCH /agents/{id}` (nested `config` object):
 | `sense_prefs` | `{sense_id: connector_name}` | Which provider this agent prefers per sense. |
 
 Both default to empty, so every existing agent behaves exactly as before.
+
+**Setting and reading them.** Both are accepted as top-level fields on
+`POST /agents` and `PATCH /agents/{id}`, and `PATCH` also accepts them inside
+the nested `config` object. Both are returned under `config` on
+`GET /agents/{id}` and `GET /agents`.
+
+Prefer the top-level form when you are changing one thing. The nested `config`
+form replaces the whole config object, so it is the one to use when you already
+hold a full config; the top-level form only touches the fields it names. On
+`PATCH`, omitting a field leaves it unchanged — sending `"senses": []` is a real
+value that clears the mount list back to "inherit".
+
+```jsonc
+POST /agents
+{
+  "name": "Mailer", "slug": "mailer",
+  "senses": ["paw.email.v1"],
+  "sense_prefs": {"paw.email.v1": "gmail"}
+}
+
+PATCH /agents/{id}
+{ "senses": ["paw.email.v1", "paw.calendar.v1"] }   // sense_prefs untouched
+```
 
 **`senses` is exclusive when set.** Empty means "inherit" — the agent reaches
 every sense that resolves for the workspace, which is the legacy behaviour. A

--- a/ee/pocketpaw_ee/agent/mcp_servers/connectors.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/connectors.py
@@ -59,6 +59,19 @@
 #   chokepoint contracts stay 0-broken. (``propose.py`` itself statically imports
 #   no Beanie document class — it lazy-imports ``pocketpaw.stores`` /
 #   ``pocketpaw.instinct.models`` internally.)
+# Updated: 2026-08-02 (Sense Phase 2, SP2-2 — agent-tier provider preference) —
+#   the two SENSE tools now resolve through the RUNNING AGENT. New
+#   ``_agent_sense_context()`` reads ``agent_service.current_agent_id()`` (the
+#   ContextVar SP2-1 bound), loads that agent through ``cloud.agents.service.get``
+#   — the module that OWNS the Beanie read, so no document class is imported
+#   here — and hands the resolver a pure-data ``AgentSenseContext``
+#   (agent_id + sense_prefs; the ``senses`` mount list stays empty until SP2-3
+#   adds the field). ``list_senses`` and ``sense_execute`` pass it as ``agent=``,
+#   so an agent that prefers gitlab for ``paw.code.v1`` gets gitlab even when the
+#   workspace preference row says github. No bound agent id, or an agent that
+#   fails to load, → ``agent=None`` → the exact pre-SP2-2 resolution. The load is
+#   lazy inside the helper (same discipline as the other cloud imports here) so
+#   the module's import surface is unchanged.
 """Agent-side MCP surface for executing a chat's reachable connectors.
 
 Tools registered:
@@ -149,6 +162,47 @@ def _identity() -> tuple[str | None, str | None, str | None]:
         return current_workspace_id(), current_user_id(), current_pocket_id()
     except Exception:  # noqa: BLE001 — agent_service import only fails off-stream
         return None, None, None
+
+
+async def _agent_sense_context() -> Any | None:
+    """Build the ``AgentSenseContext`` for the agent driving this turn (SP2-2).
+
+    Reads the agent id SP2-1 bound to the stream, then loads the agent through
+    ``cloud.agents.service`` — the module that owns the Beanie read — so neither
+    this module nor the resolver imports the Agent document class.
+
+    Returns ``None`` (meaning "resolve exactly as before") when no agent id is
+    bound (legacy / OSS callers, off-stream unit tests) or when the agent can't
+    be loaded. A provider preference is a convenience, never a gate: failing to
+    read it must degrade the resolution, not break the tool call.
+    """
+    try:
+        from pocketpaw_ee.cloud.chat.agent_service import current_agent_id
+
+        agent_id = current_agent_id()
+    except Exception:  # noqa: BLE001 — agent_service import only fails off-stream
+        return None
+
+    if not agent_id:
+        return None
+
+    try:
+        from pocketpaw_ee.cloud.agents import service as agents_service
+        from pocketpaw_ee.cloud.senses.resolver import AgentSenseContext
+
+        agent = await agents_service.get(agent_id)
+    except Exception:  # noqa: BLE001 — a missing/unreadable agent just means no prefs
+        logger.info("sense tools: agent %s not loadable — resolving without prefs", agent_id)
+        return None
+
+    config = agent.config
+    return AgentSenseContext(
+        agent_id=agent_id,
+        # The carried mount list lands in SP2-3; until then the field doesn't
+        # exist on the config and the context carries an empty tuple.
+        senses=tuple(getattr(config, "senses", ()) or ()),
+        prefs=dict(getattr(config, "sense_prefs", ()) or ()),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -555,9 +609,10 @@ async def _list_senses_handler(args: dict) -> dict:  # noqa: ARG001 — no args
     from pocketpaw_ee.cloud.senses.resolver import resolve_many
 
     # One enabled-connector read for all CORE_SENSES (was one query per sense).
+    agent_ctx = await _agent_sense_context()
     try:
         resolved_map = await resolve_many(
-            [s.id for s in CORE_SENSES], workspace_id, pocket_id=pocket_id
+            [s.id for s in CORE_SENSES], workspace_id, pocket_id=pocket_id, agent=agent_ctx
         )
     except Exception as exc:  # noqa: BLE001 — never let one sense break the list
         logger.warning("list_senses: resolve_many failed", exc_info=True)
@@ -633,6 +688,7 @@ async def _sense_execute_handler(args: dict) -> dict:
     from pocketpaw.senses import SenseValidationError
     from pocketpaw_ee.cloud.senses.resolver import execute_sense
 
+    agent_ctx = await _agent_sense_context()
     try:
         result = await execute_sense(
             sense,
@@ -641,6 +697,7 @@ async def _sense_execute_handler(args: dict) -> dict:
             workspace_id,
             pocket_id=pocket_id,
             user_id=user_id,
+            agent=agent_ctx,
         )
     except SenseValidationError as exc:
         _audit_connector_execute(

--- a/ee/pocketpaw_ee/agent/mcp_servers/connectors.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/connectors.py
@@ -72,6 +72,21 @@
 #   fails to load, → ``agent=None`` → the exact pre-SP2-2 resolution. The load is
 #   lazy inside the helper (same discipline as the other cloud imports here) so
 #   the module's import surface is unchanged.
+# Updated: 2026-08-02 (Sense Phase 2, SP2-3 — the sense MOUNT LIST) — the context
+#   now carries the agent's real ``config.senses``, and this surface enforces it.
+#   ``list_senses`` filters CORE_SENSES through ``resolver.is_sense_carried``
+#   BEFORE the batch resolve, so a non-carried sense never enters the query and
+#   never appears in the payload; the response carries ``carried_senses`` (empty
+#   when the agent inherits the full surface) and, when the list is non-empty,
+#   a note telling the model the listing is exhaustive so it stops retrying a
+#   sense it cannot reach. ``sense_execute`` needs no gate of its own —
+#   ``execute_sense`` refuses a non-carried sense with the structured
+#   ``sense.not_carried`` code before resolving, and the existing
+#   ``if not result.ok`` branch relays that message. An EMPTY mount list is
+#   today's surface exactly, so every pre-SP2-3 agent is unchanged.
+#   ``getattr(config, "senses", ())`` stays defensive on purpose: the helper
+#   must degrade to "inherit everything" for any config shape that predates the
+#   field rather than raising inside a tool call.
 """Agent-side MCP surface for executing a chat's reachable connectors.
 
 Tools registered:
@@ -198,8 +213,8 @@ async def _agent_sense_context() -> Any | None:
     config = agent.config
     return AgentSenseContext(
         agent_id=agent_id,
-        # The carried mount list lands in SP2-3; until then the field doesn't
-        # exist on the config and the context carries an empty tuple.
+        # The mount list (SP2-3). Empty here means "inherit the workspace's whole
+        # sense surface" — the resolver's gate reads it exactly that way.
         senses=tuple(getattr(config, "senses", ()) or ()),
         prefs=dict(getattr(config, "sense_prefs", ()) or ()),
     )
@@ -606,20 +621,27 @@ async def _list_senses_handler(args: dict) -> dict:  # noqa: ARG001 — no args
         )
 
     from pocketpaw.senses import CORE_SENSES
-    from pocketpaw_ee.cloud.senses.resolver import resolve_many
+    from pocketpaw_ee.cloud.senses.resolver import is_sense_carried, resolve_many
 
-    # One enabled-connector read for all CORE_SENSES (was one query per sense).
     agent_ctx = await _agent_sense_context()
+    # MOUNT LIST (SP2-3): an agent that carries senses sees EXACTLY those. The
+    # filter runs here as well as in the resolver so a non-carried sense costs
+    # nothing at all — it never enters the batch. ``is_sense_carried`` is the
+    # same predicate the resolver gates on, so the two can't drift apart.
+    listable = [s for s in CORE_SENSES if is_sense_carried(s.id, agent_ctx)]
+    carried = list(agent_ctx.senses) if agent_ctx is not None else []
+
+    # One enabled-connector read for the whole batch (was one query per sense).
     try:
         resolved_map = await resolve_many(
-            [s.id for s in CORE_SENSES], workspace_id, pocket_id=pocket_id, agent=agent_ctx
+            [s.id for s in listable], workspace_id, pocket_id=pocket_id, agent=agent_ctx
         )
     except Exception as exc:  # noqa: BLE001 — never let one sense break the list
         logger.warning("list_senses: resolve_many failed", exc_info=True)
         return _error_response(f"list_senses failed: {exc}")
 
     senses_out: list[dict[str, Any]] = []
-    for sense in CORE_SENSES:
+    for sense in listable:
         resolved = resolved_map.get(sense.id)
         if resolved is None:
             # No enabled connector fills this sense for the workspace — skip it
@@ -637,28 +659,47 @@ async def _list_senses_handler(args: dict) -> dict:  # noqa: ARG001 — no args
         )
 
     if not senses_out:
+        message = (
+            "No capabilities (Senses) are available here yet — no enabled "
+            "connector fills any core sense for this workspace. Connect a "
+            "provider (email, calendar, code, etc.) to use senses."
+        )
+        if carried:
+            message = (
+                "This agent carries " + ", ".join(carried) + ", but no enabled "
+                "connector fills any of them for this workspace. Connect a "
+                "provider for one of those capabilities — senses outside that "
+                "list are not available to this agent at all."
+            )
         return _success_response(
             {
                 "pocket_id": pocket_id,
                 "senses": [],
-                "message": (
-                    "No capabilities (Senses) are available here yet — no enabled "
-                    "connector fills any core sense for this workspace. Connect a "
-                    "provider (email, calendar, code, etc.) to use senses."
-                ),
+                "carried_senses": carried,
+                "message": message,
             }
+        )
+
+    note = (
+        "Call sense_execute(sense, action, params) to run a READ action "
+        "against a capability without naming the connector. If a sense is "
+        "ambiguous, the resolver picked the first candidate — the user can "
+        "set a preference to disambiguate. Write actions are blocked in v1."
+    )
+    if carried:
+        note += (
+            " This agent carries a fixed set of senses — the list above is ALL of "
+            "them. Any other sense is refused; don't retry one that isn't listed."
         )
 
     return _success_response(
         {
             "pocket_id": pocket_id,
             "senses": senses_out,
-            "note": (
-                "Call sense_execute(sense, action, params) to run a READ action "
-                "against a capability without naming the connector. If a sense is "
-                "ambiguous, the resolver picked the first candidate — the user can "
-                "set a preference to disambiguate. Write actions are blocked in v1."
-            ),
+            # Present (possibly empty) on every response so a caller can tell an
+            # agent with a mount list from one that inherits the full surface.
+            "carried_senses": carried,
+            "note": note,
         }
     )
 
@@ -889,8 +930,11 @@ def build_connectors_context_server() -> tuple[str, Any] | None:
             "read (auto-trust) actions run; WRITE actions (create/send/modify/"
             "delete) are refused with a 'needs approval' message and are NEVER "
             "executed. If no connector fills the sense for this workspace you get "
-            "a clear 'no provider' error. Always call list_senses first to see "
-            "which senses resolve and pick a valid action."
+            "a clear 'no provider' error. Some agents carry a fixed set of "
+            "senses — a sense outside that set is refused as 'not mounted on "
+            "this agent'; don't retry it, use one list_senses returned. Always "
+            "call list_senses first to see which senses resolve and pick a "
+            "valid action."
         ),
         {
             "type": "object",

--- a/ee/pocketpaw_ee/agent/mcp_servers/connectors.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/connectors.py
@@ -87,6 +87,27 @@
 #   ``getattr(config, "senses", ())`` stays defensive on purpose: the helper
 #   must degrade to "inherit everything" for any config shape that predates the
 #   field rather than raising inside a tool call.
+# Updated: 2026-08-02 (Sense Phase 2, SP2-4) — NO behavior change here; this note
+#   LOCKS IN a property that is easy to break by accident. The SENSE tools are
+#   POCKET-OPTIONAL, and have been since the 2026-06-12 workspace-scope reach
+#   above: a run with NO pocket bound (a DM / group thread, ``pocket_id=None``)
+#   resolves the WORKSPACE-tier sense surface and both LISTS and EXECUTES it.
+#   That is structural, not incidental — ``cloud.senses.filler`` ignores
+#   ``pocket_id`` entirely (any enabled connector in the workspace fills a
+#   sense) and ``execute_sense`` takes ``pocket_id=None`` natively. Do NOT
+#   re-add a "no pocket" guard to ``_list_senses_handler`` /
+#   ``_sense_execute_handler``: it would silently take the hands off every
+#   DM-driven and concierge-driven agent. The ONLY identity these two tools
+#   require is ``workspace_id`` (the tenant boundary); a pocket is a narrowing
+#   hint, never a precondition. Pinned by ``TestPocketlessSenseSurface`` in
+#   ``tests/ee/agent/test_connectors_mcp_server/test_mcp_tool.py``.
+#   The RAW connector tools are deliberately different and stay unchanged:
+#   ``connector_execute`` resolves credentials per scope, so an unanchored run
+#   reaches workspace-scoped connectors only — a pocket-bound connector stays
+#   room-private. Separately, whether a sense surface is EXPOSED on a given
+#   surface is a different question from whether it RESOLVES: the public
+#   concierge surface grants these two tool ids only to an agent carrying a
+#   non-empty mount list (``chat.runs.run_core._concierge_sense_policy``).
 """Agent-side MCP surface for executing a chat's reachable connectors.
 
 Tools registered:

--- a/ee/pocketpaw_ee/cloud/agents/domain.py
+++ b/ee/pocketpaw_ee/cloud/agents/domain.py
@@ -29,6 +29,13 @@ of pairs like ``soul_ocean``. It mirrors here rather than living doc-only becaus
 ``service.update`` round-trips doc -> domain -> doc: a field missing from the
 domain spec is silently ERASED the next time any other config field changes.
 Sense-id validation stays at the Beanie boundary — this module is pure data.
+Updated: 2026-08-02 (Sense Phase 2, SP2-3 — the sense mount list) — added
+``AgentConfigSpec.senses``, the frozen-friendly mirror of the Beanie
+``AgentConfig.senses`` list. Empty = inherit the workspace's resolvable senses;
+non-empty = the EXCLUSIVE set this agent carries. It mirrors here for the same
+erasure reason as ``sense_prefs``, plus a second one: the MCP layer builds its
+``AgentSenseContext`` from the DOMAIN agent (``service.get``), so a doc-only
+field would never reach the resolver at all.
 """
 
 from __future__ import annotations
@@ -66,8 +73,12 @@ class AgentConfigSpec:
     conversation_starters: tuple[str, ...] = ()  # frozen-friendly list
     voice: dict | None = None
     appearance: dict = field(default_factory=dict)
+    # Sense mount list (SP2-3). Empty = inherit every sense that resolves for
+    # the workspace; non-empty = the EXCLUSIVE set the agent carries.
+    senses: tuple[str, ...] = ()
     # Agent-tier provider preference (SP2-2). Frozen-friendly dict, same shape
-    # as ``soul_ocean``: sense_id -> connector_name.
+    # as ``soul_ocean``: sense_id -> connector_name. A pref for a sense outside
+    # ``senses`` is dead config — the mount gate refuses before the pref is read.
     sense_prefs: tuple[tuple[str, str], ...] = ()
 
 

--- a/ee/pocketpaw_ee/cloud/agents/domain.py
+++ b/ee/pocketpaw_ee/cloud/agents/domain.py
@@ -22,6 +22,13 @@ Updated: 2026-07-24 (CX-2, feat/code-agent-exclusive-tools) — added
 Beanie ``AgentConfig.tool_mode``. An ``"exclusive"`` agent's ``tools`` become the
 run's MCP allow-list and suppress the universal pocket/widget/atlas grant
 (CX-1); ``"additive"`` (the default) is the unchanged legacy grant-union.
+Updated: 2026-08-02 (Sense Phase 2, SP2-2 — agent-tier provider preference) —
+added ``AgentConfigSpec.sense_prefs``, the frozen-friendly mirror of the Beanie
+``AgentConfig.sense_prefs`` dict (sense_id -> connector_name), carried as a tuple
+of pairs like ``soul_ocean``. It mirrors here rather than living doc-only because
+``service.update`` round-trips doc -> domain -> doc: a field missing from the
+domain spec is silently ERASED the next time any other config field changes.
+Sense-id validation stays at the Beanie boundary — this module is pure data.
 """
 
 from __future__ import annotations
@@ -59,6 +66,9 @@ class AgentConfigSpec:
     conversation_starters: tuple[str, ...] = ()  # frozen-friendly list
     voice: dict | None = None
     appearance: dict = field(default_factory=dict)
+    # Agent-tier provider preference (SP2-2). Frozen-friendly dict, same shape
+    # as ``soul_ocean``: sense_id -> connector_name.
+    sense_prefs: tuple[tuple[str, str], ...] = ()
 
 
 @dataclass(frozen=True)

--- a/ee/pocketpaw_ee/cloud/agents/domain.py
+++ b/ee/pocketpaw_ee/cloud/agents/domain.py
@@ -29,6 +29,13 @@ of pairs like ``soul_ocean``. It mirrors here rather than living doc-only becaus
 ``service.update`` round-trips doc -> domain -> doc: a field missing from the
 domain spec is silently ERASED the next time any other config field changes.
 Sense-id validation stays at the Beanie boundary — this module is pure data.
+Updated: 2026-08-02 (Sense Phase 2, SP2-3 — the sense mount list) — added
+``AgentConfigSpec.senses``, the frozen-friendly mirror of the Beanie
+``AgentConfig.senses`` list. Empty = inherit the workspace's resolvable senses;
+non-empty = the EXCLUSIVE set this agent carries. It mirrors here for the same
+erasure reason as ``sense_prefs``, plus a second one: the MCP layer builds its
+``AgentSenseContext`` from the DOMAIN agent (``service.get``), so a doc-only
+field would never reach the resolver at all.
 """
 
 from __future__ import annotations
@@ -68,8 +75,12 @@ class AgentConfigSpec:
     conversation_starters: tuple[str, ...] = ()  # frozen-friendly list
     voice: dict | None = None
     appearance: dict = field(default_factory=dict)
+    # Sense mount list (SP2-3). Empty = inherit every sense that resolves for
+    # the workspace; non-empty = the EXCLUSIVE set the agent carries.
+    senses: tuple[str, ...] = ()
     # Agent-tier provider preference (SP2-2). Frozen-friendly dict, same shape
-    # as ``soul_ocean``: sense_id -> connector_name.
+    # as ``soul_ocean``: sense_id -> connector_name. A pref for a sense outside
+    # ``senses`` is dead config — the mount gate refuses before the pref is read.
     sense_prefs: tuple[tuple[str, str], ...] = ()
 
 

--- a/ee/pocketpaw_ee/cloud/agents/domain.py
+++ b/ee/pocketpaw_ee/cloud/agents/domain.py
@@ -22,6 +22,13 @@ Updated: 2026-07-24 (CX-2, feat/code-agent-exclusive-tools) — added
 Beanie ``AgentConfig.tool_mode``. An ``"exclusive"`` agent's ``tools`` become the
 run's MCP allow-list and suppress the universal pocket/widget/atlas grant
 (CX-1); ``"additive"`` (the default) is the unchanged legacy grant-union.
+Updated: 2026-08-02 (Sense Phase 2, SP2-2 — agent-tier provider preference) —
+added ``AgentConfigSpec.sense_prefs``, the frozen-friendly mirror of the Beanie
+``AgentConfig.sense_prefs`` dict (sense_id -> connector_name), carried as a tuple
+of pairs like ``soul_ocean``. It mirrors here rather than living doc-only because
+``service.update`` round-trips doc -> domain -> doc: a field missing from the
+domain spec is silently ERASED the next time any other config field changes.
+Sense-id validation stays at the Beanie boundary — this module is pure data.
 """
 
 from __future__ import annotations
@@ -61,6 +68,9 @@ class AgentConfigSpec:
     conversation_starters: tuple[str, ...] = ()  # frozen-friendly list
     voice: dict | None = None
     appearance: dict = field(default_factory=dict)
+    # Agent-tier provider preference (SP2-2). Frozen-friendly dict, same shape
+    # as ``soul_ocean``: sense_id -> connector_name.
+    sense_prefs: tuple[tuple[str, str], ...] = ()
 
 
 @dataclass(frozen=True)

--- a/ee/pocketpaw_ee/cloud/agents/dto.py
+++ b/ee/pocketpaw_ee/cloud/agents/dto.py
@@ -15,6 +15,24 @@ excludes other members' public agents). ``CreateAgentRequest`` /
 (``welcome_message`` / ``conversation_starters`` / ``voice`` / ``appearance`` /
 ``tags``); ``agent_to_dict`` (+ ``_config_to_dict``) and ``AgentResponse`` now
 emit them on the wire.
+
+Updated: 2026-08-02 (Sense Phase 2, SP2-5 — the config surface) — the two sense
+fields SP2-2/SP2-3 put on the model become OPERABLE over HTTP. Three changes,
+each load-bearing:
+
+  * ``CreateAgentRequest`` / ``UpdateAgentRequest`` gained explicit ``senses`` /
+    ``sense_prefs`` fields, so they are settable at create (the nested ``config``
+    dict does not exist on create at all) and settable on update without having
+    to send a whole ``config`` object.
+  * ``_config_to_dict`` emits both, so ``GET /agents/{id}`` actually SHOWS what
+    an agent carries. Without this the fields were write-only — persisted,
+    honoured at run time, invisible to the owner who set them.
+  * Sense ids are validated HERE as well as at the Beanie boundary, on the
+    explicit fields AND inside the ``config`` dict. The schema validator alone
+    raises a pydantic ``ValidationError`` from deep inside the service, which the
+    ``CloudError`` handler does not catch — it surfaces as a 500. Validating at
+    the DTO makes a bogus id a 422 carrying the vocabulary's own message, which
+    is what ``docs/api-reference.md`` has always promised.
 """
 
 from __future__ import annotations
@@ -24,9 +42,46 @@ from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
+from pocketpaw.senses import validate_sense_id
 from pocketpaw_ee.cloud._core.time import iso_utc
 from pocketpaw_ee.cloud.agents.domain import Agent, AgentConfigSpec
 from pocketpaw_ee.cloud.agents.scope_rules import normalise_and_validate_scopes
+
+# ---------------------------------------------------------------------------
+# Sense-id validation at the wire boundary
+# ---------------------------------------------------------------------------
+
+
+def _check_sense_ids(sense_ids: Any) -> None:
+    """Validate every id in an iterable of sense ids (a list, or a dict's keys).
+
+    ``validate_sense_id`` raises ``SenseValidationError`` (a ``ValueError``), so
+    pydantic turns it into a field error and FastAPI answers 422 with the
+    vocabulary's own message ("unknown core sense id ... the paw.* namespace is
+    closed. Known core senses: [...]") rather than a bare "invalid".
+    """
+    for sense_id in sense_ids:
+        validate_sense_id(sense_id)
+
+
+def _validate_config_sense_fields(config: dict | None) -> dict | None:
+    """Validate the sense fields carried inside an update's nested ``config``.
+
+    The ``config``-dict branch of ``service._apply_update`` writes ``senses`` /
+    ``sense_prefs`` straight through, so without this the only validation left is
+    the Beanie one — a 500 instead of a 422. Non-list / non-dict values are left
+    alone: the service's own ``.get`` fallbacks and the Beanie schema decide those.
+    """
+    if config is None:
+        return config
+    senses = config.get("senses")
+    if isinstance(senses, list):
+        _check_sense_ids(senses)
+    prefs = config.get("sense_prefs")
+    if isinstance(prefs, dict):
+        _check_sense_ids(prefs)
+    return config
+
 
 # ---------------------------------------------------------------------------
 # Requests (preserved from schemas.py)
@@ -60,11 +115,31 @@ class CreateAgentRequest(BaseModel):
     voice: dict | None = None
     appearance: dict | None = None
     tags: list[str] | None = None
+    # Sense fields (SP2-5). ``None`` == "leave at the model default" (empty), so
+    # an old client that never sends them creates the same agent as before.
+    senses: list[str] | None = None
+    sense_prefs: dict[str, str] | None = None
 
     @field_validator("scopes")
     @classmethod
     def _clean_scopes(cls, v: list[str] | None) -> list[str] | None:
         return None if v is None else normalise_and_validate_scopes(v)
+
+    @field_validator("senses")
+    @classmethod
+    def _clean_senses(cls, v: list[str] | None) -> list[str] | None:
+        if v is not None:
+            _check_sense_ids(v)
+        return v
+
+    @field_validator("sense_prefs")
+    @classmethod
+    def _clean_sense_prefs(cls, v: dict[str, str] | None) -> dict[str, str] | None:
+        # KEYS only — a connector name is workspace state, not schema state
+        # (same rule as ``models.agent.AgentConfig``).
+        if v is not None:
+            _check_sense_ids(v)
+        return v
 
 
 class UpdateAgentRequest(BaseModel):
@@ -93,11 +168,35 @@ class UpdateAgentRequest(BaseModel):
     voice: dict | None = None
     appearance: dict | None = None
     tags: list[str] | None = None
+    # Sense fields (SP2-5) — ``None`` == "leave unchanged", like every other
+    # explicit field here. Settable this way OR inside ``config``; both branches
+    # of ``service._apply_update`` carry them.
+    senses: list[str] | None = None
+    sense_prefs: dict[str, str] | None = None
 
     @field_validator("scopes")
     @classmethod
     def _clean_scopes(cls, v: list[str] | None) -> list[str] | None:
         return None if v is None else normalise_and_validate_scopes(v)
+
+    @field_validator("senses")
+    @classmethod
+    def _clean_senses(cls, v: list[str] | None) -> list[str] | None:
+        if v is not None:
+            _check_sense_ids(v)
+        return v
+
+    @field_validator("sense_prefs")
+    @classmethod
+    def _clean_sense_prefs(cls, v: dict[str, str] | None) -> dict[str, str] | None:
+        if v is not None:
+            _check_sense_ids(v)
+        return v
+
+    @field_validator("config")
+    @classmethod
+    def _clean_config_senses(cls, v: dict | None) -> dict | None:
+        return _validate_config_sense_fields(v)
 
 
 class ScopeAssignmentRequest(BaseModel):
@@ -152,6 +251,11 @@ def _config_to_dict(cfg: AgentConfigSpec) -> dict[str, Any]:
         "conversation_starters": list(cfg.conversation_starters),
         "voice": cfg.voice,
         "appearance": dict(cfg.appearance),
+        # SP2-5 — read them back. Persisted + honoured at run time since SP2-2/3,
+        # but until they were emitted here the owner had no way to SEE what their
+        # agent carries, which makes an exclusive mount list unauditable.
+        "senses": list(cfg.senses),
+        "sense_prefs": dict(cfg.sense_prefs),
     }
 
 

--- a/ee/pocketpaw_ee/cloud/agents/dto.py
+++ b/ee/pocketpaw_ee/cloud/agents/dto.py
@@ -15,6 +15,24 @@ excludes other members' public agents). ``CreateAgentRequest`` /
 (``welcome_message`` / ``conversation_starters`` / ``voice`` / ``appearance`` /
 ``tags``); ``agent_to_dict`` (+ ``_config_to_dict``) and ``AgentResponse`` now
 emit them on the wire.
+
+Updated: 2026-08-02 (Sense Phase 2, SP2-5 — the config surface) — the two sense
+fields SP2-2/SP2-3 put on the model become OPERABLE over HTTP. Three changes,
+each load-bearing:
+
+  * ``CreateAgentRequest`` / ``UpdateAgentRequest`` gained explicit ``senses`` /
+    ``sense_prefs`` fields, so they are settable at create (the nested ``config``
+    dict does not exist on create at all) and settable on update without having
+    to send a whole ``config`` object.
+  * ``_config_to_dict`` emits both, so ``GET /agents/{id}`` actually SHOWS what
+    an agent carries. Without this the fields were write-only — persisted,
+    honoured at run time, invisible to the owner who set them.
+  * Sense ids are validated HERE as well as at the Beanie boundary, on the
+    explicit fields AND inside the ``config`` dict. The schema validator alone
+    raises a pydantic ``ValidationError`` from deep inside the service, which the
+    ``CloudError`` handler does not catch — it surfaces as a 500. Validating at
+    the DTO makes a bogus id a 422 carrying the vocabulary's own message, which
+    is what ``docs/api-reference.md`` has always promised.
 """
 
 from __future__ import annotations
@@ -24,10 +42,47 @@ from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
+from pocketpaw.senses import validate_sense_id
 from pocketpaw_ee.cloud._core.time import iso_utc
 from pocketpaw_ee.cloud.agents.defaults import CLOUD_DEFAULT_AGENT_BACKEND
 from pocketpaw_ee.cloud.agents.domain import Agent, AgentConfigSpec
 from pocketpaw_ee.cloud.agents.scope_rules import normalise_and_validate_scopes
+
+# ---------------------------------------------------------------------------
+# Sense-id validation at the wire boundary
+# ---------------------------------------------------------------------------
+
+
+def _check_sense_ids(sense_ids: Any) -> None:
+    """Validate every id in an iterable of sense ids (a list, or a dict's keys).
+
+    ``validate_sense_id`` raises ``SenseValidationError`` (a ``ValueError``), so
+    pydantic turns it into a field error and FastAPI answers 422 with the
+    vocabulary's own message ("unknown core sense id ... the paw.* namespace is
+    closed. Known core senses: [...]") rather than a bare "invalid".
+    """
+    for sense_id in sense_ids:
+        validate_sense_id(sense_id)
+
+
+def _validate_config_sense_fields(config: dict | None) -> dict | None:
+    """Validate the sense fields carried inside an update's nested ``config``.
+
+    The ``config``-dict branch of ``service._apply_update`` writes ``senses`` /
+    ``sense_prefs`` straight through, so without this the only validation left is
+    the Beanie one — a 500 instead of a 422. Non-list / non-dict values are left
+    alone: the service's own ``.get`` fallbacks and the Beanie schema decide those.
+    """
+    if config is None:
+        return config
+    senses = config.get("senses")
+    if isinstance(senses, list):
+        _check_sense_ids(senses)
+    prefs = config.get("sense_prefs")
+    if isinstance(prefs, dict):
+        _check_sense_ids(prefs)
+    return config
+
 
 # ---------------------------------------------------------------------------
 # Requests (preserved from schemas.py)
@@ -61,11 +116,31 @@ class CreateAgentRequest(BaseModel):
     voice: dict | None = None
     appearance: dict | None = None
     tags: list[str] | None = None
+    # Sense fields (SP2-5). ``None`` == "leave at the model default" (empty), so
+    # an old client that never sends them creates the same agent as before.
+    senses: list[str] | None = None
+    sense_prefs: dict[str, str] | None = None
 
     @field_validator("scopes")
     @classmethod
     def _clean_scopes(cls, v: list[str] | None) -> list[str] | None:
         return None if v is None else normalise_and_validate_scopes(v)
+
+    @field_validator("senses")
+    @classmethod
+    def _clean_senses(cls, v: list[str] | None) -> list[str] | None:
+        if v is not None:
+            _check_sense_ids(v)
+        return v
+
+    @field_validator("sense_prefs")
+    @classmethod
+    def _clean_sense_prefs(cls, v: dict[str, str] | None) -> dict[str, str] | None:
+        # KEYS only — a connector name is workspace state, not schema state
+        # (same rule as ``models.agent.AgentConfig``).
+        if v is not None:
+            _check_sense_ids(v)
+        return v
 
 
 class UpdateAgentRequest(BaseModel):
@@ -94,11 +169,35 @@ class UpdateAgentRequest(BaseModel):
     voice: dict | None = None
     appearance: dict | None = None
     tags: list[str] | None = None
+    # Sense fields (SP2-5) — ``None`` == "leave unchanged", like every other
+    # explicit field here. Settable this way OR inside ``config``; both branches
+    # of ``service._apply_update`` carry them.
+    senses: list[str] | None = None
+    sense_prefs: dict[str, str] | None = None
 
     @field_validator("scopes")
     @classmethod
     def _clean_scopes(cls, v: list[str] | None) -> list[str] | None:
         return None if v is None else normalise_and_validate_scopes(v)
+
+    @field_validator("senses")
+    @classmethod
+    def _clean_senses(cls, v: list[str] | None) -> list[str] | None:
+        if v is not None:
+            _check_sense_ids(v)
+        return v
+
+    @field_validator("sense_prefs")
+    @classmethod
+    def _clean_sense_prefs(cls, v: dict[str, str] | None) -> dict[str, str] | None:
+        if v is not None:
+            _check_sense_ids(v)
+        return v
+
+    @field_validator("config")
+    @classmethod
+    def _clean_config_senses(cls, v: dict | None) -> dict | None:
+        return _validate_config_sense_fields(v)
 
 
 class ScopeAssignmentRequest(BaseModel):
@@ -153,6 +252,11 @@ def _config_to_dict(cfg: AgentConfigSpec) -> dict[str, Any]:
         "conversation_starters": list(cfg.conversation_starters),
         "voice": cfg.voice,
         "appearance": dict(cfg.appearance),
+        # SP2-5 — read them back. Persisted + honoured at run time since SP2-2/3,
+        # but until they were emitted here the owner had no way to SEE what their
+        # agent carries, which makes an exclusive mount list unauditable.
+        "senses": list(cfg.senses),
+        "sense_prefs": dict(cfg.sense_prefs),
     }
 
 

--- a/ee/pocketpaw_ee/cloud/agents/service.py
+++ b/ee/pocketpaw_ee/cloud/agents/service.py
@@ -76,6 +76,11 @@ spec from an explicit field list — so BOTH the mappers and ``_apply_update`` h
 to name the field or it is erased on the next unrelated edit.
 The MCP sense surface reads the prefs off this service's ``get(agent_id)``, which
 keeps ``cloud.senses.resolver`` free of any Beanie Agent import.
+Updated 2026-08-02 (Sense Phase 2, SP2-3 — the sense mount list): ``senses`` is
+threaded through the same three places for the same reason — both doc↔spec
+mappers and ``_apply_update``'s explicit field list. The stakes are higher than
+for ``sense_prefs``: erasing the mount list doesn't lose a provider preference,
+it silently WIDENS the agent's reach back to the full workspace sense surface.
 """
 
 from __future__ import annotations
@@ -138,6 +143,7 @@ def _config_to_domain(c: _AgentConfigDoc) -> AgentConfigSpec:
         conversation_starters=tuple(c.conversation_starters),
         voice=dict(c.voice) if c.voice is not None else None,
         appearance=dict(c.appearance),
+        senses=tuple(c.senses),
         sense_prefs=tuple(c.sense_prefs.items()),
     )
 
@@ -164,6 +170,7 @@ def _config_to_doc(c: AgentConfigSpec) -> _AgentConfigDoc:
         conversation_starters=list(c.conversation_starters),
         voice=dict(c.voice) if c.voice is not None else None,
         appearance=dict(c.appearance),
+        senses=list(c.senses),
         sense_prefs=dict(c.sense_prefs),
     )
 
@@ -272,6 +279,11 @@ def _apply_update(current: AgentConfigSpec, body: UpdateAgentRequest) -> AgentCo
             ),
             voice=c.get("voice", current.voice),
             appearance=dict(c.get("appearance", dict(current.appearance))),
+            # SP2-3 — the mount list, carried forward like ``tools``. Same
+            # erasure trap as ``sense_prefs`` below: omit it here and an agent
+            # loses every carried sense (i.e. silently re-inherits the whole
+            # workspace surface) the next time anyone edits an unrelated field.
+            senses=tuple(c.get("senses", list(current.senses))),
             # SP2-2 — carried forward like soul_ocean. This branch rebuilds the
             # spec from an explicit field list, so anything omitted here is
             # ERASED on the next config edit. Key validation stays at the Beanie

--- a/ee/pocketpaw_ee/cloud/agents/service.py
+++ b/ee/pocketpaw_ee/cloud/agents/service.py
@@ -67,6 +67,15 @@ Updated 2026-07-24 (CX-3, feat/code-agent-exclusive-tools): added
 and its persona reuses ``CODE_SYSTEM_PROMPT``, so every run it does is capped to
 exactly those ids — no pocket/planner/widget grant. Idempotent, mirrors the
 default-agent seed + boot back-fill.
+Updated 2026-08-02 (Sense Phase 2, SP2-2 — agent-tier provider preference):
+``sense_prefs`` is threaded through the doc↔spec mappers, so an agent's per-sense
+provider choice round-trips and — the load-bearing part — SURVIVES an unrelated
+config update. ``update`` rewrites the whole config sub-doc from the domain spec
+whenever any field changes, and its ``body.config``-dict branch rebuilds that
+spec from an explicit field list — so BOTH the mappers and ``_apply_update`` have
+to name the field or it is erased on the next unrelated edit.
+The MCP sense surface reads the prefs off this service's ``get(agent_id)``, which
+keeps ``cloud.senses.resolver`` free of any Beanie Agent import.
 """
 
 from __future__ import annotations
@@ -129,6 +138,7 @@ def _config_to_domain(c: _AgentConfigDoc) -> AgentConfigSpec:
         conversation_starters=tuple(c.conversation_starters),
         voice=dict(c.voice) if c.voice is not None else None,
         appearance=dict(c.appearance),
+        sense_prefs=tuple(c.sense_prefs.items()),
     )
 
 
@@ -154,6 +164,7 @@ def _config_to_doc(c: AgentConfigSpec) -> _AgentConfigDoc:
         conversation_starters=list(c.conversation_starters),
         voice=dict(c.voice) if c.voice is not None else None,
         appearance=dict(c.appearance),
+        sense_prefs=dict(c.sense_prefs),
     )
 
 
@@ -261,6 +272,16 @@ def _apply_update(current: AgentConfigSpec, body: UpdateAgentRequest) -> AgentCo
             ),
             voice=c.get("voice", current.voice),
             appearance=dict(c.get("appearance", dict(current.appearance))),
+            # SP2-2 — carried forward like soul_ocean. This branch rebuilds the
+            # spec from an explicit field list, so anything omitted here is
+            # ERASED on the next config edit. Key validation stays at the Beanie
+            # boundary (``_config_to_doc`` -> ``AgentConfig``), so an update
+            # carrying a bogus sense id still fails loudly.
+            sense_prefs=tuple(
+                c.get("sense_prefs", dict(current.sense_prefs)).items()
+                if isinstance(c.get("sense_prefs", dict(current.sense_prefs)), dict)
+                else current.sense_prefs
+            ),
         )
 
     overrides: dict[str, Any] = {}

--- a/ee/pocketpaw_ee/cloud/agents/service.py
+++ b/ee/pocketpaw_ee/cloud/agents/service.py
@@ -81,6 +81,14 @@ threaded through the same three places for the same reason — both doc↔spec
 mappers and ``_apply_update``'s explicit field list. The stakes are higher than
 for ``sense_prefs``: erasing the mount list doesn't lose a provider preference,
 it silently WIDENS the agent's reach back to the full workspace sense surface.
+Updated 2026-08-02 (Sense Phase 2, SP2-5 — the config surface): both sense fields
+are now settable at CREATE (``_build_create_config``) and via an explicit
+``senses`` / ``sense_prefs`` on ``UpdateAgentRequest`` (the second branch of
+``_apply_update``), not only through a nested ``config`` dict. Create needed it
+because the create DTO has no ``config`` dict at all — before this, the only way
+to mount a sense on a new agent was a follow-up PATCH. The explicit update branch
+is the safer of the two paths for a caller that wants to set ONE field: it uses
+``dataclasses.replace``, so omission can't erase a neighbour.
 """
 
 from __future__ import annotations
@@ -245,6 +253,14 @@ def _build_create_config(body: CreateAgentRequest) -> AgentConfigSpec:
         overrides["voice"] = dict(body.voice)
     if body.appearance is not None:
         overrides["appearance"] = dict(body.appearance)
+    # SP2-5 — the sense fields at CREATE. There is no ``config`` dict on the
+    # create DTO, so without these two an agent could only be given senses by a
+    # second PATCH (or by writing the doc directly, which is what the SP2-3 tests
+    # had to do). Ids are already validated on the DTO.
+    if body.senses is not None:
+        overrides["senses"] = tuple(body.senses)
+    if body.sense_prefs is not None:
+        overrides["sense_prefs"] = tuple(body.sense_prefs.items())
     return replace(base, **overrides) if overrides else base
 
 
@@ -330,6 +346,13 @@ def _apply_update(current: AgentConfigSpec, body: UpdateAgentRequest) -> AgentCo
         overrides["voice"] = dict(body.voice)
     if body.appearance is not None:
         overrides["appearance"] = dict(body.appearance)
+    # SP2-5 — the explicit-field twin of the ``config``-dict branch above. This
+    # branch REPLACES only what it names (``replace`` on the current spec), so
+    # unlike that branch it cannot erase a field by omission.
+    if body.senses is not None:
+        overrides["senses"] = tuple(body.senses)
+    if body.sense_prefs is not None:
+        overrides["sense_prefs"] = tuple(body.sense_prefs.items())
 
     return replace(current, **overrides) if overrides else current
 

--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -9,6 +9,18 @@ handles *what the agent sees*:
 * ``load_history_for_scope`` rehydrates prior chat turns from Mongo so the
   agent carries context across backend restarts and pool evictions.
 
+Changes: 2026-08-01 (Sense Phase 2, SP2-1 — agent identity at the MCP layer) —
+the per-stream identity now carries the RUNNING agent's id. New
+``_active_agent_id`` ContextVar beside ``_active_workspace_id`` /
+``_active_user_id`` / ``_active_session_mongo_id`` / ``_active_pocket_id``, a
+``current_agent_id()`` accessor mirroring the other ``current_*`` readers, and a
+keyword-only ``agent_id`` on ``attach_agent_identity`` bound as a SIXTH token
+(appended, so the ISO-3 OSS-workspace token keeps its fifth slot);
+``detach_agent_identity`` resets it in the same call. Any in-process MCP tool
+can now ask which agent is driving this turn without a request scope — the
+plumbing later agent-carried-sense slices consume. ``agent_id`` defaults to
+``None`` and the empty-workspace/user validation is untouched, so every existing
+caller is byte-for-byte unchanged.
 Changes: 2026-07-14 (Paw Bar concierge seam, T2) — added ``ScopeKind.CONCIERGE``
 and ``_resolve_concierge``: a PUBLIC, anonymous Paw Bar concierge run resolves
 its ``ScopeContext`` from the server-authoritative spec (Site pocket + widget
@@ -283,6 +295,14 @@ _active_session_mongo_id: ContextVar[str | None] = ContextVar(
 # can resolve which room they're in without a request scope. ``None`` when the
 # chat isn't bound to a pocket (a plain DM / group thread).
 _active_pocket_id: ContextVar[str | None] = ContextVar("agent_pocket_id", default=None)
+# The id of the Agent driving THIS turn (``ScopeContext.target_agent_id`` on the
+# SSE chat path, the dispatched agent on the group/DM bridge). Bound alongside
+# workspace / user / pocket so an in-process MCP tool can answer "which agent is
+# running me" without a request scope — the plumbing agent-carried senses read to
+# resolve the running agent's own configuration. ``None`` on any path with no
+# single unambiguous agent (and for every caller that doesn't pass one), which is
+# byte-for-byte the pre-existing behavior.
+_active_agent_id: ContextVar[str | None] = ContextVar("agent_agent_id", default=None)
 
 # Marks the active async context as a live cloud CHAT run — the dispatch path
 # that is REQUIRED to bind workspace identity (``run_core.execute_run`` sets it
@@ -307,13 +327,17 @@ def attach_agent_identity(
     user_id: str,
     session_mongo_id: str | None = None,
     pocket_id: str | None = None,
-) -> tuple[Token, Token, Token, Token, Token]:
-    """Bind workspace / user / session / pocket identity for the active
+    agent_id: str | None = None,
+) -> tuple[Token, Token, Token, Token, Token, Token]:
+    """Bind workspace / user / session / pocket / agent identity for the active
     stream's MCP tools. ``session_mongo_id`` is the ``Session._id`` the chat
     is streaming through — used by ``create_pocket`` to link the active
     session to the freshly-created pocket. ``pocket_id`` is the room the chat
     is anchored to (when any) — read by the connector-execution MCP server to
     scope ``list_connector_actions`` / ``connector_execute`` to this pocket.
+    ``agent_id`` is the agent driving this turn — read by tools that resolve
+    the RUNNING agent's own configuration (agent-carried senses). It is
+    OPTIONAL: omitting it binds ``None``, which is exactly today's behavior.
 
     Defense-in-depth (fix/worker-trusts-spec-workspace): REJECT an empty
     ``workspace_id`` / ``user_id`` instead of binding ``""`` to the contextvar.
@@ -335,7 +359,9 @@ def attach_agent_identity(
     scope); this bridges the agent path that doesn't. The OSS token is returned
     as a FIFTH tuple element — callers treat the tuple opaquely (only
     ``detach_agent_identity`` unpacks it), so the wider shape is invisible to
-    them. ``detach`` resets it."""
+    them. ``detach`` resets it. The agent token is appended as a SIXTH element
+    for the same reason: the ISO-3 element keeps its position, so nothing that
+    reasons about the fifth slot has to move."""
     if not workspace_id or not user_id:
         raise ValueError(
             "attach_agent_identity requires a non-empty workspace_id and user_id "
@@ -348,17 +374,19 @@ def attach_agent_identity(
         _active_pocket_id.set(pocket_id),
         # ISO-3: bridge the EE per-stream workspace onto the OSS store ContextVar.
         _oss_current_workspace.set(workspace_id),
+        _active_agent_id.set(agent_id),
     )
 
 
-def detach_agent_identity(tokens: tuple[Token, Token, Token, Token, Token]) -> None:
-    ws_token, user_token, session_token, pocket_token, oss_ws_token = tokens
+def detach_agent_identity(tokens: tuple[Token, Token, Token, Token, Token, Token]) -> None:
+    ws_token, user_token, session_token, pocket_token, oss_ws_token, agent_token = tokens
     _active_workspace_id.reset(ws_token)
     _active_user_id.reset(user_token)
     _active_session_mongo_id.reset(session_token)
     _active_pocket_id.reset(pocket_token)
     # ISO-3: clear the OSS store ContextVar bridged in attach_agent_identity.
     _oss_current_workspace.reset(oss_ws_token)
+    _active_agent_id.reset(agent_token)
 
 
 def current_workspace_id() -> str | None:
@@ -375,6 +403,12 @@ def current_session_mongo_id() -> str | None:
 
 def current_pocket_id() -> str | None:
     return _active_pocket_id.get()
+
+
+def current_agent_id() -> str | None:
+    """The Agent driving the active run, or ``None`` when the caller didn't
+    bind one (legacy callers, or a dispatch path with no single agent)."""
+    return _active_agent_id.get()
 
 
 # Per-stream Paw Bar action context (C1). Set by ``run_core`` for a CONCIERGE run

--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -29,6 +29,18 @@ identity and never the sink. The registry lets such a caller find the stream by
 session id instead. ``push_sse_event`` is unchanged and still a deliberate
 no-op outside a stream.
 
+Changes: 2026-08-01 (Sense Phase 2, SP2-1 — agent identity at the MCP layer) —
+the per-stream identity now carries the RUNNING agent's id. New
+``_active_agent_id`` ContextVar beside ``_active_workspace_id`` /
+``_active_user_id`` / ``_active_session_mongo_id`` / ``_active_pocket_id``, a
+``current_agent_id()`` accessor mirroring the other ``current_*`` readers, and a
+keyword-only ``agent_id`` on ``attach_agent_identity`` bound as a SIXTH token
+(appended, so the ISO-3 OSS-workspace token keeps its fifth slot);
+``detach_agent_identity`` resets it in the same call. Any in-process MCP tool
+can now ask which agent is driving this turn without a request scope — the
+plumbing later agent-carried-sense slices consume. ``agent_id`` defaults to
+``None`` and the empty-workspace/user validation is untouched, so every existing
+caller is byte-for-byte unchanged.
 Changes: 2026-07-14 (Paw Bar concierge seam, T2) — added ``ScopeKind.CONCIERGE``
 and ``_resolve_concierge``: a PUBLIC, anonymous Paw Bar concierge run resolves
 its ``ScopeContext`` from the server-authoritative spec (Site pocket + widget
@@ -324,6 +336,14 @@ _active_session_mongo_id: ContextVar[str | None] = ContextVar(
 # can resolve which room they're in without a request scope. ``None`` when the
 # chat isn't bound to a pocket (a plain DM / group thread).
 _active_pocket_id: ContextVar[str | None] = ContextVar("agent_pocket_id", default=None)
+# The id of the Agent driving THIS turn (``ScopeContext.target_agent_id`` on the
+# SSE chat path, the dispatched agent on the group/DM bridge). Bound alongside
+# workspace / user / pocket so an in-process MCP tool can answer "which agent is
+# running me" without a request scope — the plumbing agent-carried senses read to
+# resolve the running agent's own configuration. ``None`` on any path with no
+# single unambiguous agent (and for every caller that doesn't pass one), which is
+# byte-for-byte the pre-existing behavior.
+_active_agent_id: ContextVar[str | None] = ContextVar("agent_agent_id", default=None)
 
 # Marks the active async context as a live cloud CHAT run — the dispatch path
 # that is REQUIRED to bind workspace identity (``run_core.execute_run`` sets it
@@ -348,13 +368,17 @@ def attach_agent_identity(
     user_id: str,
     session_mongo_id: str | None = None,
     pocket_id: str | None = None,
-) -> tuple[Token, Token, Token, Token, Token]:
-    """Bind workspace / user / session / pocket identity for the active
+    agent_id: str | None = None,
+) -> tuple[Token, Token, Token, Token, Token, Token]:
+    """Bind workspace / user / session / pocket / agent identity for the active
     stream's MCP tools. ``session_mongo_id`` is the ``Session._id`` the chat
     is streaming through — used by ``create_pocket`` to link the active
     session to the freshly-created pocket. ``pocket_id`` is the room the chat
     is anchored to (when any) — read by the connector-execution MCP server to
     scope ``list_connector_actions`` / ``connector_execute`` to this pocket.
+    ``agent_id`` is the agent driving this turn — read by tools that resolve
+    the RUNNING agent's own configuration (agent-carried senses). It is
+    OPTIONAL: omitting it binds ``None``, which is exactly today's behavior.
 
     Defense-in-depth (fix/worker-trusts-spec-workspace): REJECT an empty
     ``workspace_id`` / ``user_id`` instead of binding ``""`` to the contextvar.
@@ -376,7 +400,9 @@ def attach_agent_identity(
     scope); this bridges the agent path that doesn't. The OSS token is returned
     as a FIFTH tuple element — callers treat the tuple opaquely (only
     ``detach_agent_identity`` unpacks it), so the wider shape is invisible to
-    them. ``detach`` resets it."""
+    them. ``detach`` resets it. The agent token is appended as a SIXTH element
+    for the same reason: the ISO-3 element keeps its position, so nothing that
+    reasons about the fifth slot has to move."""
     if not workspace_id or not user_id:
         raise ValueError(
             "attach_agent_identity requires a non-empty workspace_id and user_id "
@@ -389,17 +415,19 @@ def attach_agent_identity(
         _active_pocket_id.set(pocket_id),
         # ISO-3: bridge the EE per-stream workspace onto the OSS store ContextVar.
         _oss_current_workspace.set(workspace_id),
+        _active_agent_id.set(agent_id),
     )
 
 
-def detach_agent_identity(tokens: tuple[Token, Token, Token, Token, Token]) -> None:
-    ws_token, user_token, session_token, pocket_token, oss_ws_token = tokens
+def detach_agent_identity(tokens: tuple[Token, Token, Token, Token, Token, Token]) -> None:
+    ws_token, user_token, session_token, pocket_token, oss_ws_token, agent_token = tokens
     _active_workspace_id.reset(ws_token)
     _active_user_id.reset(user_token)
     _active_session_mongo_id.reset(session_token)
     _active_pocket_id.reset(pocket_token)
     # ISO-3: clear the OSS store ContextVar bridged in attach_agent_identity.
     _oss_current_workspace.reset(oss_ws_token)
+    _active_agent_id.reset(agent_token)
 
 
 def current_workspace_id() -> str | None:
@@ -416,6 +444,12 @@ def current_session_mongo_id() -> str | None:
 
 def current_pocket_id() -> str | None:
     return _active_pocket_id.get()
+
+
+def current_agent_id() -> str | None:
+    """The Agent driving the active run, or ``None`` when the caller didn't
+    bind one (legacy callers, or a dispatch path with no single agent)."""
+    return _active_agent_id.get()
 
 
 # Per-stream Paw Bar action context (C1). Set by ``run_core`` for a CONCIERGE run

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -235,6 +235,25 @@ Changes:
   CX-1 suppressible-grant cap so an exclusive agent (e.g. /code) gets EXACTLY its
   declared MCP ids, OVERRIDING any surface allow-list. "additive" (the default)
   is unchanged. The flag/allow-list cross into ``AgentPool.run`` as plain data.
+- 2026-08-02 (Sense Phase 2, SP2-4 — concierge surface opt-in for carried senses)
+  — ``_concierge_sense_policy(ctx, instance, deny, allow_mcp)`` is the ONE seam
+  that can give a public site concierge hands. On a ``ScopeKind.CONCIERGE`` run
+  it reads the running agent's SP2-3 mount list (``config.senses``) and either
+  UNIONS the two sense tool ids into the surface allow-list (mount non-empty) or
+  adds them to the DENY set (mount empty). Deny — rather than mere absence from
+  the allow-list — is the load-bearing half: the backend subtracts deny from the
+  final tool list before any grant re-adds anything, so "empty = inherit the
+  workspace sense surface" is UNREACHABLE on this public surface, including for
+  an ``exclusive`` agent that declared the ids itself. Called from BOTH profile
+  consumers (``_drive_agent_loop`` and the ``_prewarm_session`` mirror) at the
+  same point in the sequence, before the CX-2 branch, so agent-exclusive keeps
+  its allow-list precedence and the prewarmed client's cache key still matches
+  turn 1's. Every non-concierge run returns the inputs unchanged — DM / pocket /
+  session runs are byte-for-byte untouched. The chosen seam is deliberate: the
+  registry's ``_concierge_profile`` is a documented PURE, no-I/O sync lookup and
+  its ``SurfaceMeta`` is CLIENT-supplied, so a mount list read there would be
+  both an I/O violation and forgeable by an anonymous caller; here the config
+  comes from the server-side pooled agent doc and ``ctx.kind`` is server-resolved.
 """
 
 from __future__ import annotations
@@ -960,6 +979,81 @@ def _agent_tool_policy(instance: Any) -> tuple[bool, frozenset[str]]:
     return (True, frozenset(tools))
 
 
+def _concierge_sense_policy(
+    ctx: ScopeContext,
+    instance: Any,
+    deny: frozenset[str],
+    allow_mcp: frozenset[str] | None,
+) -> tuple[frozenset[str], frozenset[str] | None]:
+    """SP2-4 — the CONCIERGE surface's FAIL-CLOSED opt-in for carried senses.
+
+    The concierge (``/paw-bar``) is a PUBLIC, anonymous, prompt-injectable
+    surface, so ``surface_registry._concierge_allow_mcp`` locks its MCP surface
+    to (almost) nothing and the ``pocketpaw_connectors`` server — which owns
+    ``list_senses`` / ``sense_execute`` — is in NEITHER the always-allowed set
+    nor any grant. A site concierge therefore has no hands at all today.
+
+    This is the single seam that opens them, and only for an agent whose owner
+    explicitly MOUNTED senses on it (SP2-3's ``config.senses``):
+
+      * mount list NON-EMPTY → the two sense tool ids are unioned into the
+        surface allow-list, so they survive the concierge lockdown.
+      * mount list EMPTY → the two ids are added to the DENY set. Denial (not
+        merely "absence from the allow-list") is what makes the SP2-3
+        "empty = inherit the workspace surface" rule UNREACHABLE here: deny is
+        subtracted from the final tool list BEFORE any allow-grant re-adds
+        anything (``claude_sdk``), so no other path — the universal grant, an
+        always-allowed server, or an ``exclusive`` agent's own declared ids —
+        can put a sense tool back on a public surface. An unmounted concierge
+        never sees the tenant's sense surface.
+
+    Why this satisfies the intent of the lockdown warning at
+    ``surface_registry.py`` (the RESIDUAL GAP note: "a concierge pocket must
+    therefore have NO connectors bound"): that warning is about the RAW
+    connector surface, whose tool ids are dynamic/per-workspace and so cannot be
+    enumerated in a static deny set. It stays true and unchanged — the raw
+    ``list_connector_actions`` / ``connector_execute`` tools are NOT granted
+    here. What this opens is the narrow SENSE surface, which is enumerable (two
+    static ids), opt-in per agent, capability-scoped by the mount list, and
+    read-only: ``execute_sense`` runs ``trust_level == "auto"`` actions ONLY and
+    proposes nothing, so a prompt-injected visitor cannot reach a write.
+
+    Two independent gates must agree for a visitor to actually reach a sense:
+    THIS one (tool VISIBILITY, read from the pooled config) and the resolver's
+    mount gate in ``execute_sense`` (EXECUTION, which re-reads the agent doc
+    fresh on every call). A mount list edited mid-run can therefore only ever
+    fail closed at execution time, never open.
+
+    Non-concierge runs return the inputs unchanged, so DM / pocket / every other
+    surface is byte-for-byte untouched (``senses`` keeps its documented
+    empty=inherit semantics off this surface).
+    """
+    if ctx.kind is not ScopeKind.CONCIERGE:
+        return deny, allow_mcp
+
+    # Lazy import: keeps the MCP server package off this module's import graph,
+    # the same discipline the connector/instinct imports use elsewhere here.
+    from pocketpaw_ee.agent.mcp_servers.connectors import (
+        LIST_SENSES_TOOL_ID,
+        SENSE_EXECUTE_TOOL_ID,
+    )
+
+    sense_tool_ids = frozenset({LIST_SENSES_TOOL_ID, SENSE_EXECUTE_TOOL_ID})
+    config = getattr(instance, "config", None) or {}
+    if isinstance(config, dict):
+        carried = config.get("senses", []) or []
+    else:
+        carried = getattr(config, "senses", []) or []
+
+    if not carried:
+        return deny | sense_tool_ids, allow_mcp
+    # ``allow_mcp is None`` means the surface set NO restriction — unioning would
+    # invent one and strip every other tool. Leave it alone; the tools already flow.
+    if allow_mcp is None:
+        return deny, allow_mcp
+    return deny, allow_mcp | sense_tool_ids
+
+
 async def _prewarm_session(ctx: ScopeContext) -> None:
     """Eagerly warm the agent's CLI subprocess for this run's session BEFORE the
     first model turn (feat/claude-sdk-prewarm).
@@ -1021,6 +1115,13 @@ async def _prewarm_session(ctx: ScopeContext) -> None:
             surface_sys_override = ctx.resolved_profile.system_message_override
             surface_skills = ctx.resolved_profile.skill_names or frozenset()
         surface_skills = surface_skills | _agent_skill_set(instance)
+        # SP2-4 — mirror _drive_agent_loop's concierge sense policy at the SAME
+        # point in the sequence (before the CX-2 mirror below), so the prewarmed
+        # client's allowed_tools — and therefore its cache key — match turn 1's.
+        # Without this a mounted concierge would warm a client turn 1 discards.
+        surface_deny, surface_allow_mcp = _concierge_sense_policy(
+            ctx, instance, surface_deny, surface_allow_mcp
+        )
         # CX-2 — mirror _drive_agent_loop's exclusive-tool resolution EXACTLY so
         # the prewarmed client's options (and thus its cache key) MATCH turn 1's.
         # An exclusive agent caps its MCP surface, which changes ``allowed_tools``
@@ -1243,6 +1344,14 @@ async def _drive_agent_loop(
         # including the legacy ``resolved_profile is None`` path (no entity / no
         # profile). Still a plain ``frozenset[str]`` crossing into the OSS pool.
         surface_skills = surface_skills | _agent_skill_set(instance)
+        # SP2-4 — the concierge surface's fail-closed sense opt-in. Applied
+        # BEFORE the CX-2 exclusive branch below so agent-exclusive still WINS on
+        # the allow-list (CX-2's precedence is unchanged), while the DENY half
+        # survives every path — that asymmetry is what makes an unmounted
+        # concierge unable to reach the sense tools at all. No-op off /paw-bar.
+        surface_deny, surface_allow_mcp = _concierge_sense_policy(
+            ctx, instance, surface_deny, surface_allow_mcp
+        )
         run_kwargs: dict[str, Any] = dict(
             history=history,
             knowledge_context=knowledge_context,

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -1,6 +1,12 @@
 """Agent-run core — the loop the executor invokes for every chat run.
 
 Changes:
+- 2026-08-01 (Sense Phase 2, SP2-1) — both ``attach_agent_identity`` binds (the
+  ``_prewarm_session`` warm-up and the ``_drive_agent_loop`` run seam) now pass
+  ``agent_id=ctx.target_agent_id``, the agent ``pool.get`` / ``pool.run`` /
+  ``pool.prewarm`` already drive. In-process MCP tools read it back via
+  ``agent_service.current_agent_id()`` to resolve the RUNNING agent's own
+  configuration. Identity-affecting behavior is otherwise unchanged.
 - 2026-07-15 (fix/paw-bar-concierge-soul-policy) — ``_persist_and_complete``
   now gates the ``pool.observe`` soul-learning call: a Paw Bar concierge run
   (session_key prefix ``cloud:concierge:``) SKIPS it so anonymous, untrusted
@@ -1040,6 +1046,9 @@ async def _prewarm_session(ctx: ScopeContext) -> None:
             user_id=ctx.user_id,
             session_mongo_id=session_mongo_id,
             pocket_id=ctx.pocket_id,
+            # SP2-1 — the same agent ``pool.prewarm`` warms below, so a tool that
+            # resolves the running agent's own config during the warm sees turn 1's.
+            agent_id=ctx.target_agent_id,
         )
         # C1 — bind the concierge action context so the warm subprocess builds the
         # same pawbar_actions tool set turn 1 will resolve (None for every other run).
@@ -1143,6 +1152,10 @@ async def _drive_agent_loop(
         # chats (and session chats whose Session.pocket is set). ``None`` for
         # plain DM/group threads — the connector tools then say "no pocket".
         pocket_id=ctx.pocket_id,
+        # SP2-1 — the agent this run drives (``pool.get`` / ``pool.run`` use the
+        # same id), so an in-process MCP tool can resolve the RUNNING agent's own
+        # configuration instead of guessing from the scope.
+        agent_id=ctx.target_agent_id,
     )
     # C1 — bind this run's concierge action context (None for every non-concierge
     # or no-actions run). The pawbar_actions MCP server + tool handlers read it;

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -339,6 +339,25 @@ Changes:
   CX-1 suppressible-grant cap so an exclusive agent (e.g. /code) gets EXACTLY its
   declared MCP ids, OVERRIDING any surface allow-list. "additive" (the default)
   is unchanged. The flag/allow-list cross into ``AgentPool.run`` as plain data.
+- 2026-08-02 (Sense Phase 2, SP2-4 — concierge surface opt-in for carried senses)
+  — ``_concierge_sense_policy(ctx, instance, deny, allow_mcp)`` is the ONE seam
+  that can give a public site concierge hands. On a ``ScopeKind.CONCIERGE`` run
+  it reads the running agent's SP2-3 mount list (``config.senses``) and either
+  UNIONS the two sense tool ids into the surface allow-list (mount non-empty) or
+  adds them to the DENY set (mount empty). Deny — rather than mere absence from
+  the allow-list — is the load-bearing half: the backend subtracts deny from the
+  final tool list before any grant re-adds anything, so "empty = inherit the
+  workspace sense surface" is UNREACHABLE on this public surface, including for
+  an ``exclusive`` agent that declared the ids itself. Called from BOTH profile
+  consumers (``_drive_agent_loop`` and the ``_prewarm_session`` mirror) at the
+  same point in the sequence, before the CX-2 branch, so agent-exclusive keeps
+  its allow-list precedence and the prewarmed client's cache key still matches
+  turn 1's. Every non-concierge run returns the inputs unchanged — DM / pocket /
+  session runs are byte-for-byte untouched. The chosen seam is deliberate: the
+  registry's ``_concierge_profile`` is a documented PURE, no-I/O sync lookup and
+  its ``SurfaceMeta`` is CLIENT-supplied, so a mount list read there would be
+  both an I/O violation and forgeable by an anonymous caller; here the config
+  comes from the server-side pooled agent doc and ``ctx.kind`` is server-resolved.
 """
 
 from __future__ import annotations
@@ -1173,6 +1192,81 @@ def _agent_tool_policy(instance: Any) -> tuple[bool, frozenset[str]]:
     return (True, frozenset(tools))
 
 
+def _concierge_sense_policy(
+    ctx: ScopeContext,
+    instance: Any,
+    deny: frozenset[str],
+    allow_mcp: frozenset[str] | None,
+) -> tuple[frozenset[str], frozenset[str] | None]:
+    """SP2-4 — the CONCIERGE surface's FAIL-CLOSED opt-in for carried senses.
+
+    The concierge (``/paw-bar``) is a PUBLIC, anonymous, prompt-injectable
+    surface, so ``surface_registry._concierge_allow_mcp`` locks its MCP surface
+    to (almost) nothing and the ``pocketpaw_connectors`` server — which owns
+    ``list_senses`` / ``sense_execute`` — is in NEITHER the always-allowed set
+    nor any grant. A site concierge therefore has no hands at all today.
+
+    This is the single seam that opens them, and only for an agent whose owner
+    explicitly MOUNTED senses on it (SP2-3's ``config.senses``):
+
+      * mount list NON-EMPTY → the two sense tool ids are unioned into the
+        surface allow-list, so they survive the concierge lockdown.
+      * mount list EMPTY → the two ids are added to the DENY set. Denial (not
+        merely "absence from the allow-list") is what makes the SP2-3
+        "empty = inherit the workspace surface" rule UNREACHABLE here: deny is
+        subtracted from the final tool list BEFORE any allow-grant re-adds
+        anything (``claude_sdk``), so no other path — the universal grant, an
+        always-allowed server, or an ``exclusive`` agent's own declared ids —
+        can put a sense tool back on a public surface. An unmounted concierge
+        never sees the tenant's sense surface.
+
+    Why this satisfies the intent of the lockdown warning at
+    ``surface_registry.py`` (the RESIDUAL GAP note: "a concierge pocket must
+    therefore have NO connectors bound"): that warning is about the RAW
+    connector surface, whose tool ids are dynamic/per-workspace and so cannot be
+    enumerated in a static deny set. It stays true and unchanged — the raw
+    ``list_connector_actions`` / ``connector_execute`` tools are NOT granted
+    here. What this opens is the narrow SENSE surface, which is enumerable (two
+    static ids), opt-in per agent, capability-scoped by the mount list, and
+    read-only: ``execute_sense`` runs ``trust_level == "auto"`` actions ONLY and
+    proposes nothing, so a prompt-injected visitor cannot reach a write.
+
+    Two independent gates must agree for a visitor to actually reach a sense:
+    THIS one (tool VISIBILITY, read from the pooled config) and the resolver's
+    mount gate in ``execute_sense`` (EXECUTION, which re-reads the agent doc
+    fresh on every call). A mount list edited mid-run can therefore only ever
+    fail closed at execution time, never open.
+
+    Non-concierge runs return the inputs unchanged, so DM / pocket / every other
+    surface is byte-for-byte untouched (``senses`` keeps its documented
+    empty=inherit semantics off this surface).
+    """
+    if ctx.kind is not ScopeKind.CONCIERGE:
+        return deny, allow_mcp
+
+    # Lazy import: keeps the MCP server package off this module's import graph,
+    # the same discipline the connector/instinct imports use elsewhere here.
+    from pocketpaw_ee.agent.mcp_servers.connectors import (
+        LIST_SENSES_TOOL_ID,
+        SENSE_EXECUTE_TOOL_ID,
+    )
+
+    sense_tool_ids = frozenset({LIST_SENSES_TOOL_ID, SENSE_EXECUTE_TOOL_ID})
+    config = getattr(instance, "config", None) or {}
+    if isinstance(config, dict):
+        carried = config.get("senses", []) or []
+    else:
+        carried = getattr(config, "senses", []) or []
+
+    if not carried:
+        return deny | sense_tool_ids, allow_mcp
+    # ``allow_mcp is None`` means the surface set NO restriction — unioning would
+    # invent one and strip every other tool. Leave it alone; the tools already flow.
+    if allow_mcp is None:
+        return deny, allow_mcp
+    return deny, allow_mcp | sense_tool_ids
+
+
 async def _prewarm_session(ctx: ScopeContext, flow_context: dict[str, Any] | None = None) -> None:
     """Eagerly warm the agent's CLI subprocess for this run's session BEFORE the
     first model turn (feat/claude-sdk-prewarm).
@@ -1248,6 +1342,13 @@ async def _prewarm_session(ctx: ScopeContext, flow_context: dict[str, Any] | Non
             surface_sys_override = ctx.resolved_profile.system_message_override
             surface_skills = ctx.resolved_profile.skill_names or frozenset()
         surface_skills = surface_skills | _agent_skill_set(instance)
+        # SP2-4 — mirror _drive_agent_loop's concierge sense policy at the SAME
+        # point in the sequence (before the CX-2 mirror below), so the prewarmed
+        # client's allowed_tools — and therefore its cache key — match turn 1's.
+        # Without this a mounted concierge would warm a client turn 1 discards.
+        surface_deny, surface_allow_mcp = _concierge_sense_policy(
+            ctx, instance, surface_deny, surface_allow_mcp
+        )
         # CX-2 — mirror _drive_agent_loop's exclusive-tool resolution EXACTLY so
         # the prewarmed client's options (and thus its cache key) MATCH turn 1's.
         # An exclusive agent caps its MCP surface, which changes ``allowed_tools``
@@ -1549,6 +1650,14 @@ async def _drive_agent_loop(
         if ctx.surface_context is not None:
             surface_preamble = ctx.surface_context.preamble or ""
             surface_cache_key = ctx.surface_context.preamble_cache_key
+        # SP2-4 — the concierge surface's fail-closed sense opt-in. Applied
+        # BEFORE the CX-2 exclusive branch below so agent-exclusive still WINS on
+        # the allow-list (CX-2's precedence is unchanged), while the DENY half
+        # survives every path — that asymmetry is what makes an unmounted
+        # concierge unable to reach the sense tools at all. No-op off /paw-bar.
+        surface_deny, surface_allow_mcp = _concierge_sense_policy(
+            ctx, instance, surface_deny, surface_allow_mcp
+        )
         run_kwargs: dict[str, Any] = dict(
             history=history,
             knowledge_context=knowledge_context,

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -105,6 +105,12 @@ Changes:
   ``deny_mcp_tool_ids`` already uses. Unlike the other per-run kwargs these are
   NOT withhold-when-empty: they never reach a backend, they feed the assembler,
   and ``""`` / ``None`` is itself the meaningful "no surface" answer.
+- 2026-08-01 (Sense Phase 2, SP2-1) — both ``attach_agent_identity`` binds (the
+  ``_prewarm_session`` warm-up and the ``_drive_agent_loop`` run seam) now pass
+  ``agent_id=ctx.target_agent_id``, the agent ``pool.get`` / ``pool.run`` /
+  ``pool.prewarm`` already drive. In-process MCP tools read it back via
+  ``agent_service.current_agent_id()`` to resolve the RUNNING agent's own
+  configuration. Identity-affecting behavior is otherwise unchanged.
 - 2026-07-15 (fix/paw-bar-concierge-soul-policy) — ``_persist_and_complete``
   now gates the ``pool.observe`` soul-learning call: a Paw Bar concierge run
   (session_key prefix ``cloud:concierge:``) SKIPS it so anonymous, untrusted
@@ -1267,6 +1273,9 @@ async def _prewarm_session(ctx: ScopeContext, flow_context: dict[str, Any] | Non
             user_id=ctx.user_id,
             session_mongo_id=session_mongo_id,
             pocket_id=ctx.pocket_id,
+            # SP2-1 — the same agent ``pool.prewarm`` warms below, so a tool that
+            # resolves the running agent's own config during the warm sees turn 1's.
+            agent_id=ctx.target_agent_id,
         )
         # C1 — bind the concierge action context so the warm subprocess builds the
         # same pawbar_actions tool set turn 1 will resolve (None for every other run).
@@ -1422,6 +1431,10 @@ async def _drive_agent_loop(
         # chats (and session chats whose Session.pocket is set). ``None`` for
         # plain DM/group threads — the connector tools then say "no pocket".
         pocket_id=ctx.pocket_id,
+        # SP2-1 — the agent this run drives (``pool.get`` / ``pool.run`` use the
+        # same id), so an in-process MCP tool can resolve the RUNNING agent's own
+        # configuration instead of guessing from the scope.
+        agent_id=ctx.target_agent_id,
     )
     # C1 — bind this run's concierge action context (None for every non-concierge
     # or no-actions run). The pawbar_actions MCP server + tool handlers read it;

--- a/ee/pocketpaw_ee/cloud/models/agent.py
+++ b/ee/pocketpaw_ee/cloud/models/agent.py
@@ -25,14 +25,25 @@
 # run's MCP allow-list and suppresses the universal grant (CX-1); "additive"
 # (default) is the unchanged legacy grant-union, so existing agents persist and
 # behave exactly as before.
+# Updated 2026-08-02 (Sense Phase 2, SP2-2 — agent-tier provider preference):
+# added ``AgentConfig.sense_prefs: dict[str, str]`` (sense_id -> connector_name).
+# An agent carries its OWN provider choice per sense, and that choice outranks
+# the stored pocket/workspace preference rows at resolve time (see
+# ``cloud.senses.resolver._disambiguate``). KEYS are validated at the schema
+# boundary via ``pocketpaw.senses.validate_sense_id`` — an unknown or malformed
+# sense id fails loudly on write. VALUES (connector names) are deliberately NOT
+# validated here: a pref naming a connector that isn't currently a candidate for
+# the workspace is skipped at resolve time, never an error, so the pref survives
+# its provider being temporarily disabled. Defaulted → zero migration.
 
 """Agent configuration document."""
 
 from __future__ import annotations
 
 from beanie import Indexed
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
+from pocketpaw.senses import validate_sense_id
 from pocketpaw_ee.cloud.models.base import TimestampedDocument
 
 
@@ -77,6 +88,24 @@ class AgentConfig(BaseModel):
     conversation_starters: list[str] = Field(default_factory=list)
     voice: dict | None = None
     appearance: dict = Field(default_factory=dict)
+    # Agent-tier provider preference (SP2-2): sense_id -> connector_name. Wins
+    # over the stored pocket/workspace preference rows when the resolver has
+    # more than one candidate. Keys are validated below; values are not.
+    sense_prefs: dict[str, str] = Field(default_factory=dict)
+
+    @field_validator("sense_prefs")
+    @classmethod
+    def _validate_sense_pref_keys(cls, value: dict[str, str]) -> dict[str, str]:
+        """Reject an unknown / malformed sense id at the schema boundary.
+
+        ``validate_sense_id`` raises ``SenseValidationError`` (a ``ValueError``),
+        which pydantic surfaces as a ``ValidationError`` — so a bad key can never
+        be persisted. Connector-name values stay unvalidated on purpose: the
+        candidate set is workspace state, not schema state.
+        """
+        for sense_id in value:
+            validate_sense_id(sense_id)
+        return value
 
 
 class Agent(TimestampedDocument):

--- a/ee/pocketpaw_ee/cloud/models/agent.py
+++ b/ee/pocketpaw_ee/cloud/models/agent.py
@@ -35,6 +35,36 @@
 # validated here: a pref naming a connector that isn't currently a candidate for
 # the workspace is skipped at resolve time, never an error, so the pref survives
 # its provider being temporarily disabled. Defaulted → zero migration.
+# Updated 2026-08-02 (Sense Phase 2, SP2-3 — the sense MOUNT LIST): added
+# ``AgentConfig.senses: list[str]``, the set of Senses this agent carries.
+# Entries are validated as sense ids the same way ``sense_prefs`` keys are, so a
+# bogus id fails on write. Empty (the default) = inherit the workspace's whole
+# resolvable surface, i.e. today's behaviour; NON-EMPTY = EXCLUSIVE — the agent
+# lists only those senses and any other sense is refused with the structured
+# ``sense.not_carried`` code BEFORE any candidate lookup
+# (``cloud.senses.resolver``). Defaulted → zero migration.
+#
+# THE AGENT-CARRIED TIERS — one rule, documented once, here. An agent carries
+# three capability sets, and their empty-vs-set semantics differ ON PURPOSE:
+#
+#   * ``tools`` + ``tool_mode`` — the MCP tool surface. ``tools`` alone never
+#     narrows anything; the MODE decides. "additive" (default) UNIONs ``tools``
+#     with the universal grant; "exclusive" caps the run to exactly ``tools``.
+#     Two fields because a non-empty tool list has always meant "also grant
+#     these", and CX-2 could not retroactively make that exclusive.
+#   * ``skill_refs`` + ``plugins`` — the skill set. Purely ADDITIVE, no mode:
+#     these fold into (never replace) the surface/entity skill set on every run.
+#     There is no exclusive skill mode because a skill is context, not reach.
+#   * ``senses`` — the Sense mount list. EXCLUSIVE-WHEN-SET, no separate mode
+#     field: empty = inherit everything, non-empty = exactly these. It needs no
+#     ``sense_mode`` twin because the field is new — nothing persisted a
+#     non-empty ``senses`` under additive semantics, so "set = exclusive" is
+#     unambiguous from day one. Semantically it is ``tool_mode="exclusive"``
+#     applied to capabilities: a structural reach boundary, not a preference.
+#
+# ``sense_prefs`` is NOT a tier — it is a tie-break WITHIN the reach the mount
+# list allows. Prefs never widen: a pref for a sense the agent doesn't carry is
+# dead config, because the mount gate refuses that sense before the pref is read.
 
 """Agent configuration document."""
 
@@ -88,9 +118,14 @@ class AgentConfig(BaseModel):
     conversation_starters: list[str] = Field(default_factory=list)
     voice: dict | None = None
     appearance: dict = Field(default_factory=dict)
+    # Sense mount list (SP2-3): the capabilities this agent CARRIES. Empty =
+    # inherit the workspace's whole resolvable surface (legacy). Non-empty =
+    # EXCLUSIVE: every other sense is refused with ``sense.not_carried``.
+    senses: list[str] = Field(default_factory=list)
     # Agent-tier provider preference (SP2-2): sense_id -> connector_name. Wins
     # over the stored pocket/workspace preference rows when the resolver has
-    # more than one candidate. Keys are validated below; values are not.
+    # more than one candidate. Keys are validated below; values are not. A pref
+    # for a sense outside ``senses`` never fires — the mount gate refuses first.
     sense_prefs: dict[str, str] = Field(default_factory=dict)
 
     @field_validator("sense_prefs")
@@ -102,6 +137,18 @@ class AgentConfig(BaseModel):
         which pydantic surfaces as a ``ValidationError`` — so a bad key can never
         be persisted. Connector-name values stay unvalidated on purpose: the
         candidate set is workspace state, not schema state.
+        """
+        for sense_id in value:
+            validate_sense_id(sense_id)
+        return value
+
+    @field_validator("senses")
+    @classmethod
+    def _validate_mounted_sense_ids(cls, value: list[str]) -> list[str]:
+        """Same schema-boundary rule as ``sense_prefs`` keys, for the mount list.
+
+        A typo'd id here is worse than a typo'd pref: it silently costs the agent
+        a capability rather than a provider choice, so it fails on write.
         """
         for sense_id in value:
             validate_sense_id(sense_id)

--- a/ee/pocketpaw_ee/cloud/models/agent.py
+++ b/ee/pocketpaw_ee/cloud/models/agent.py
@@ -35,6 +35,36 @@
 # validated here: a pref naming a connector that isn't currently a candidate for
 # the workspace is skipped at resolve time, never an error, so the pref survives
 # its provider being temporarily disabled. Defaulted → zero migration.
+# Updated 2026-08-02 (Sense Phase 2, SP2-3 — the sense MOUNT LIST): added
+# ``AgentConfig.senses: list[str]``, the set of Senses this agent carries.
+# Entries are validated as sense ids the same way ``sense_prefs`` keys are, so a
+# bogus id fails on write. Empty (the default) = inherit the workspace's whole
+# resolvable surface, i.e. today's behaviour; NON-EMPTY = EXCLUSIVE — the agent
+# lists only those senses and any other sense is refused with the structured
+# ``sense.not_carried`` code BEFORE any candidate lookup
+# (``cloud.senses.resolver``). Defaulted → zero migration.
+#
+# THE AGENT-CARRIED TIERS — one rule, documented once, here. An agent carries
+# three capability sets, and their empty-vs-set semantics differ ON PURPOSE:
+#
+#   * ``tools`` + ``tool_mode`` — the MCP tool surface. ``tools`` alone never
+#     narrows anything; the MODE decides. "additive" (default) UNIONs ``tools``
+#     with the universal grant; "exclusive" caps the run to exactly ``tools``.
+#     Two fields because a non-empty tool list has always meant "also grant
+#     these", and CX-2 could not retroactively make that exclusive.
+#   * ``skill_refs`` + ``plugins`` — the skill set. Purely ADDITIVE, no mode:
+#     these fold into (never replace) the surface/entity skill set on every run.
+#     There is no exclusive skill mode because a skill is context, not reach.
+#   * ``senses`` — the Sense mount list. EXCLUSIVE-WHEN-SET, no separate mode
+#     field: empty = inherit everything, non-empty = exactly these. It needs no
+#     ``sense_mode`` twin because the field is new — nothing persisted a
+#     non-empty ``senses`` under additive semantics, so "set = exclusive" is
+#     unambiguous from day one. Semantically it is ``tool_mode="exclusive"``
+#     applied to capabilities: a structural reach boundary, not a preference.
+#
+# ``sense_prefs`` is NOT a tier — it is a tie-break WITHIN the reach the mount
+# list allows. Prefs never widen: a pref for a sense the agent doesn't carry is
+# dead config, because the mount gate refuses that sense before the pref is read.
 
 """Agent configuration document."""
 
@@ -89,9 +119,14 @@ class AgentConfig(BaseModel):
     conversation_starters: list[str] = Field(default_factory=list)
     voice: dict | None = None
     appearance: dict = Field(default_factory=dict)
+    # Sense mount list (SP2-3): the capabilities this agent CARRIES. Empty =
+    # inherit the workspace's whole resolvable surface (legacy). Non-empty =
+    # EXCLUSIVE: every other sense is refused with ``sense.not_carried``.
+    senses: list[str] = Field(default_factory=list)
     # Agent-tier provider preference (SP2-2): sense_id -> connector_name. Wins
     # over the stored pocket/workspace preference rows when the resolver has
-    # more than one candidate. Keys are validated below; values are not.
+    # more than one candidate. Keys are validated below; values are not. A pref
+    # for a sense outside ``senses`` never fires — the mount gate refuses first.
     sense_prefs: dict[str, str] = Field(default_factory=dict)
 
     @field_validator("sense_prefs")
@@ -103,6 +138,18 @@ class AgentConfig(BaseModel):
         which pydantic surfaces as a ``ValidationError`` — so a bad key can never
         be persisted. Connector-name values stay unvalidated on purpose: the
         candidate set is workspace state, not schema state.
+        """
+        for sense_id in value:
+            validate_sense_id(sense_id)
+        return value
+
+    @field_validator("senses")
+    @classmethod
+    def _validate_mounted_sense_ids(cls, value: list[str]) -> list[str]:
+        """Same schema-boundary rule as ``sense_prefs`` keys, for the mount list.
+
+        A typo'd id here is worse than a typo'd pref: it silently costs the agent
+        a capability rather than a provider choice, so it fails on write.
         """
         for sense_id in value:
             validate_sense_id(sense_id)

--- a/ee/pocketpaw_ee/cloud/models/agent.py
+++ b/ee/pocketpaw_ee/cloud/models/agent.py
@@ -25,14 +25,25 @@
 # run's MCP allow-list and suppresses the universal grant (CX-1); "additive"
 # (default) is the unchanged legacy grant-union, so existing agents persist and
 # behave exactly as before.
+# Updated 2026-08-02 (Sense Phase 2, SP2-2 — agent-tier provider preference):
+# added ``AgentConfig.sense_prefs: dict[str, str]`` (sense_id -> connector_name).
+# An agent carries its OWN provider choice per sense, and that choice outranks
+# the stored pocket/workspace preference rows at resolve time (see
+# ``cloud.senses.resolver._disambiguate``). KEYS are validated at the schema
+# boundary via ``pocketpaw.senses.validate_sense_id`` — an unknown or malformed
+# sense id fails loudly on write. VALUES (connector names) are deliberately NOT
+# validated here: a pref naming a connector that isn't currently a candidate for
+# the workspace is skipped at resolve time, never an error, so the pref survives
+# its provider being temporarily disabled. Defaulted → zero migration.
 
 """Agent configuration document."""
 
 from __future__ import annotations
 
 from beanie import Indexed
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
+from pocketpaw.senses import validate_sense_id
 from pocketpaw_ee.cloud.agents.defaults import CLOUD_DEFAULT_AGENT_BACKEND
 from pocketpaw_ee.cloud.models.base import TimestampedDocument
 
@@ -78,6 +89,24 @@ class AgentConfig(BaseModel):
     conversation_starters: list[str] = Field(default_factory=list)
     voice: dict | None = None
     appearance: dict = Field(default_factory=dict)
+    # Agent-tier provider preference (SP2-2): sense_id -> connector_name. Wins
+    # over the stored pocket/workspace preference rows when the resolver has
+    # more than one candidate. Keys are validated below; values are not.
+    sense_prefs: dict[str, str] = Field(default_factory=dict)
+
+    @field_validator("sense_prefs")
+    @classmethod
+    def _validate_sense_pref_keys(cls, value: dict[str, str]) -> dict[str, str]:
+        """Reject an unknown / malformed sense id at the schema boundary.
+
+        ``validate_sense_id`` raises ``SenseValidationError`` (a ``ValueError``),
+        which pydantic surfaces as a ``ValidationError`` — so a bad key can never
+        be persisted. Connector-name values stay unvalidated on purpose: the
+        candidate set is workspace state, not schema state.
+        """
+        for sense_id in value:
+            validate_sense_id(sense_id)
+        return value
 
 
 class Agent(TimestampedDocument):

--- a/ee/pocketpaw_ee/cloud/senses/resolver.py
+++ b/ee/pocketpaw_ee/cloud/senses/resolver.py
@@ -28,6 +28,27 @@
 #   ``agent=None`` is byte-for-byte the pre-SP2-2 path. The context is PURE
 #   DATA on purpose: this module must never import the Beanie Agent document
 #   (OSS-EE boundary) — the MCP layer loads the agent and hands the values in.
+# Updated: 2026-08-02 (Sense Phase 2, SP2-3) — the MOUNT GATE. The carried
+#   ``senses`` tuple is now CONSUMED: an agent whose mount list is non-empty
+#   reaches EXACTLY those senses and nothing else (the ``tool_mode="exclusive"``
+#   rule applied to capabilities). An EMPTY mount list still inherits the whole
+#   workspace surface, so every pre-SP2-3 caller is unchanged.
+#   The gate is a pure predicate, ``is_sense_carried(sense_id, agent)``, applied
+#   BEFORE any candidate work — no registry build, no Beanie read, no preference
+#   lookup for a sense the agent doesn't carry. ``resolve_many`` skips
+#   non-carried ids for free (the batch's single enabled-connector read still
+#   happens once for whatever remains).
+#   RETURN SHAPE — the deliberate choice: ``resolve`` / ``resolve_many`` keep
+#   returning ``None`` for a non-carried sense, exactly as they do for "no
+#   provider". Their contract is ``ResolvedSense | None`` and every existing
+#   caller branches on ``is None``; a truthy-but-different sentinel would make
+#   an un-updated caller read ``.connector_name`` off a refusal, and a raise
+#   would turn a policy decision into an exception path through code that
+#   currently cannot fail. Callers that must tell the two APART ask the
+#   predicate — it is pure, free, and needs no I/O. ``execute_sense``, which
+#   already owns a structured envelope, does exactly that and returns the stable
+#   ``error="sense.not_carried"`` code (namespaced like its siblings
+#   ``sense.no_provider`` / ``sense.action_needs_approval``).
 
 from __future__ import annotations
 
@@ -53,8 +74,13 @@ class AgentSenseContext:
 
     ``prefs`` maps sense_id -> connector_name and outranks the stored
     pocket/workspace preference rows; a pref naming a connector that isn't a
-    candidate is skipped, not an error. ``senses`` is the agent's carried mount
-    list — CARRIED HERE BUT NOT CONSUMED YET; SP2-3 makes it the exclusive set.
+    candidate is skipped, not an error.
+
+    ``senses`` is the agent's MOUNT LIST. Empty (the default) inherits every
+    sense the workspace can fill; NON-EMPTY is EXCLUSIVE — the agent reaches
+    those senses and only those, and everything else refuses with
+    ``sense.not_carried`` before any candidate lookup. Prefs never widen this:
+    a pref for a sense outside the mount list is dead config.
     """
 
     agent_id: str
@@ -83,19 +109,57 @@ class SenseExecutionResult:
     """Envelope for ``execute_sense``.
 
     Structured (never an HTTP 500): ``ok`` is False with a stable ``error``
-    code for the two refusal paths — no provider for the sense, and the
-    read-first block on a non-auto action. On success ``data`` carries the
-    underlying ``ExecuteActionResponse`` and ``connector_name`` records which
-    provider ran.
+    code for the three refusal paths — the agent doesn't carry the sense
+    (SP2-3), no provider fills it for the workspace, and the read-first block
+    on a non-auto action. On success ``data`` carries the underlying
+    ``ExecuteActionResponse`` and ``connector_name`` records which provider ran.
+    Only the read-first refusal names a ``connector_name``; the other two are
+    refused before one is chosen.
     """
 
     ok: bool
     sense_id: str
     connector_name: str | None = None
     action: str | None = None
-    error: str | None = None  # stable code: "sense.no_provider" | "sense.action_needs_approval"
+    error: str | None = None  # stable code — one of the SENSE_* constants below
     message: str | None = None
     data: object = None
+
+
+# Stable, caller-facing refusal codes for ``SenseExecutionResult.error``.
+SENSE_NOT_CARRIED = "sense.not_carried"
+SENSE_NO_PROVIDER = "sense.no_provider"
+SENSE_ACTION_NEEDS_APPROVAL = "sense.action_needs_approval"
+
+
+def is_sense_carried(sense_id: str, agent: AgentSenseContext | None) -> bool:
+    """Does this agent carry ``sense_id``? — the whole mount rule, in one place.
+
+    True when there is no agent context (legacy / OSS callers), when the agent's
+    mount list is EMPTY (inherit the workspace's full surface), or when the sense
+    is named in it. False only for the exclusive case: a non-empty mount list
+    that doesn't include this sense.
+
+    Pure and I/O-free on purpose. It is the gate ``resolve`` / ``resolve_many``
+    apply BEFORE touching the registry, and the predicate callers use to tell a
+    ``None`` that means "not carried" from one that means "no provider" — the
+    two cases ``resolve``'s ``ResolvedSense | None`` contract cannot distinguish
+    on its own.
+    """
+    if agent is None or not agent.senses:
+        return True
+    return sense_id in agent.senses
+
+
+def _not_carried_message(sense_id: str, agent: AgentSenseContext) -> str:
+    """The refusal text for a non-carried sense — names what the agent DOES
+    carry so the model stops retrying the one it can't reach."""
+    carried = ", ".join(agent.senses)
+    return (
+        f"sense {sense_id!r} is not mounted on this agent ({SENSE_NOT_CARRIED}) — "
+        f"it carries: {carried}. Use one of those, or ask the workspace owner to "
+        "mount this capability on the agent."
+    )
 
 
 async def _disambiguate(
@@ -178,19 +242,30 @@ async def resolve(
     """Bind ``sense_id`` to the connector that fills it for this workspace.
 
     Returns ``None`` when no enabled connector can fill the sense (the caller
-    decides what to do — typically prompt-to-connect). Raises
-    ``SenseValidationError`` for an unknown ``paw.*`` id. Pass ``agent`` to let
-    the running agent's own provider pref outrank the stored preference rows;
-    ``agent=None`` is the unchanged pre-SP2-2 behaviour.
+    decides what to do — typically prompt-to-connect) AND when the agent doesn't
+    carry the sense (SP2-3); ``is_sense_carried`` tells the two apart without a
+    query. Raises ``SenseValidationError`` for an unknown ``paw.*`` id. Pass
+    ``agent`` to apply the mount gate and let the running agent's own provider
+    pref outrank the stored preference rows; ``agent=None`` is the unchanged
+    pre-SP2-2 behaviour.
     """
     validate_sense_id(sense_id)
+
+    # Mount gate (SP2-3) — refuse BEFORE any candidate work. An id the agent
+    # doesn't carry costs no registry build and no Beanie read.
+    if not is_sense_carried(sense_id, agent):
+        logger.info(
+            "sense not carried: agent=%s sense=%s mounted=%s",
+            agent.agent_id,  # type: ignore[union-attr] — non-None whenever the gate trips
+            sense_id,
+            agent.senses,  # type: ignore[union-attr]
+        )
+        return None
 
     registry = connectors_service._get_registry()  # noqa: SLF001 — reuse the EE singleton
     filler = ConnectorSenseFiller(registry)
     candidates = await filler.candidates(sense_id, workspace_id, pocket_id=pocket_id)
-    return await _disambiguate(
-        sense_id, candidates, workspace_id, pocket_id=pocket_id, agent=agent
-    )
+    return await _disambiguate(sense_id, candidates, workspace_id, pocket_id=pocket_id, agent=agent)
 
 
 async def resolve_many(
@@ -212,9 +287,20 @@ async def resolve_many(
     (validated up front, same as ``resolve``). Duplicate ids collapse to one
     key. The >1-candidate preference lookup still runs per ambiguous id — that
     branch is rare, so it stays as-is.
+
+    Mount gate (SP2-3): a sense the ``agent`` doesn't carry maps to ``None``
+    without ANY candidate work — the intersection is skipped, not just the
+    disambiguation. Every input id still appears in the result, so the caller's
+    key set is unchanged. ``is_sense_carried`` distinguishes those ``None``s
+    from the no-provider ones.
     """
     for sense_id in sense_ids:
         validate_sense_id(sense_id)
+
+    # Nothing in the batch is carried — skip the batch read too, not just the
+    # per-sense intersection.
+    if not any(is_sense_carried(sense_id, agent) for sense_id in sense_ids):
+        return dict.fromkeys(sense_ids)
 
     registry = connectors_service._get_registry()  # noqa: SLF001 — reuse the EE singleton
     filler = ConnectorSenseFiller(registry)
@@ -223,6 +309,9 @@ async def resolve_many(
 
     out: dict[str, ResolvedSense | None] = {}
     for sense_id in sense_ids:
+        if not is_sense_carried(sense_id, agent):
+            out[sense_id] = None
+            continue
         candidates = filler.candidates_from(sense_id, enabled_names)
         out[sense_id] = await _disambiguate(
             sense_id, candidates, workspace_id, pocket_id=pocket_id, agent=agent
@@ -258,6 +347,11 @@ async def execute_sense(
 ) -> SenseExecutionResult:
     """Resolve a sense, enforce the read-first gate, then delegate to execute.
 
+    0. MOUNT GATE (SP2-3) — if the agent carries a non-empty mount list and this
+       sense isn't in it, refuse with ``sense.not_carried`` before resolving.
+       This runs FIRST: an un-carried sense must refuse identically whether or
+       not the workspace happens to have a provider for it, so the refusal never
+       leaks which connectors the tenant enabled.
     1. ``resolve`` — if no provider, return a structured ``sense.no_provider``
        result (never raise a 500).
     2. READ-FIRST GATE — the action's ``trust_level`` on the resolved
@@ -271,13 +365,23 @@ async def execute_sense(
     the connector this execution runs against. The read-first gate is unchanged
     and applies to whichever connector wins.
     """
+    validate_sense_id(sense_id)
+    if not is_sense_carried(sense_id, agent):
+        return SenseExecutionResult(
+            ok=False,
+            sense_id=sense_id,
+            action=action,
+            error=SENSE_NOT_CARRIED,
+            message=_not_carried_message(sense_id, agent),  # type: ignore[arg-type]
+        )
+
     resolved = await resolve(sense_id, workspace_id, pocket_id=pocket_id, agent=agent)
     if resolved is None:
         return SenseExecutionResult(
             ok=False,
             sense_id=sense_id,
             action=action,
-            error="sense.no_provider",
+            error=SENSE_NO_PROVIDER,
             message=(
                 f"no enabled connector can fill {sense_id!r} for this workspace — "
                 "connect a provider for this sense and retry."
@@ -293,7 +397,7 @@ async def execute_sense(
             sense_id=sense_id,
             connector_name=connector_name,
             action=action,
-            error="sense.action_needs_approval",
+            error=SENSE_ACTION_NEEDS_APPROVAL,
             message=(
                 f"action {action!r} on {connector_name!r} needs approval "
                 f"(trust_level={trust!r}) — not executed in v1 (read-first)."
@@ -316,10 +420,14 @@ async def execute_sense(
 
 
 __all__ = [
+    "SENSE_ACTION_NEEDS_APPROVAL",
+    "SENSE_NOT_CARRIED",
+    "SENSE_NO_PROVIDER",
     "AgentSenseContext",
     "ResolvedSense",
     "SenseExecutionResult",
     "execute_sense",
+    "is_sense_carried",
     "resolve",
     "resolve_many",
 ]

--- a/ee/pocketpaw_ee/cloud/senses/resolver.py
+++ b/ee/pocketpaw_ee/cloud/senses/resolver.py
@@ -14,9 +14,25 @@
 #   senses) and runs the pure intersection + shared disambiguation per id —
 #   replacing the per-sense ``resolve`` loops in ``_check_template_needs`` and
 #   the list_senses MCP handler. Behaviour is identical, just fewer queries.
+# Updated: 2026-08-02 (Sense Phase 2, SP2-2) — the resolver now accepts an
+#   AGENT tier above the stored preference rows. New ``AgentSenseContext``
+#   (agent_id + carried mount list + per-sense provider prefs) threads as an
+#   optional ``agent=`` keyword through ``resolve`` / ``resolve_many`` /
+#   ``execute_sense`` / ``_disambiguate``. Disambiguation order is now: agent
+#   pref (when it names a real candidate) -> the stored pocket-then-workspace
+#   preference row -> deterministic first + ``ambiguous``. An agent pref naming
+#   a NON-candidate (provider disabled, typo, another tenant's connector) is
+#   skipped with one INFO log and falls through — never an error, so a stale
+#   pref degrades to the old behaviour instead of breaking the sense. The
+#   ``senses`` mount list is CARRIED but NOT consumed yet (SP2-3 gates on it).
+#   ``agent=None`` is byte-for-byte the pre-SP2-2 path. The context is PURE
+#   DATA on purpose: this module must never import the Beanie Agent document
+#   (OSS-EE boundary) — the MCP layer loads the agent and hands the values in.
 
 from __future__ import annotations
 
+import logging
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 
 from pocketpaw.senses import validate_sense_id
@@ -24,6 +40,26 @@ from pocketpaw_ee.cloud.connectors import service as connectors_service
 from pocketpaw_ee.cloud.connectors.dto import ExecuteActionRequest
 from pocketpaw_ee.cloud.senses import preference
 from pocketpaw_ee.cloud.senses.filler import ConnectorSenseFiller
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class AgentSenseContext:
+    """The sense-relevant slice of the Agent driving the current run.
+
+    Pure data — the caller (the MCP layer) loads the Agent and hands the values
+    across, so the resolver never imports a Beanie document.
+
+    ``prefs`` maps sense_id -> connector_name and outranks the stored
+    pocket/workspace preference rows; a pref naming a connector that isn't a
+    candidate is skipped, not an error. ``senses`` is the agent's carried mount
+    list — CARRIED HERE BUT NOT CONSUMED YET; SP2-3 makes it the exclusive set.
+    """
+
+    agent_id: str
+    senses: tuple[str, ...] = ()
+    prefs: Mapping[str, str] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -68,17 +104,42 @@ async def _disambiguate(
     workspace_id: str,
     *,
     pocket_id: str | None = None,
+    agent: AgentSenseContext | None = None,
 ) -> ResolvedSense | None:
     """Pick the connector from a sorted candidate set — the ONE rule both
     ``resolve`` and ``resolve_many`` use.
 
-    0 candidates -> ``None`` (caller prompts-to-connect); 1 -> that connector;
-    >1 -> the stored preference if it's among candidates, else the deterministic
-    sorted-first with ``ambiguous=True``. The per-sense preference lookup only
-    runs on the rare >1 branch.
+    0 candidates -> ``None`` (caller prompts-to-connect). Otherwise, in order:
+    the running AGENT's own pref for this sense (SP2-2) when it names one of the
+    candidates; then a single candidate short-circuits; then the stored
+    pocket/workspace preference; else the deterministic sorted-first with
+    ``ambiguous=True``.
+
+    An agent pref that is NOT among the candidates is skipped with one INFO log
+    and falls through to the stored preference — a disabled or misnamed provider
+    degrades to the pre-agent behaviour instead of failing the sense. The stored
+    preference lookup still only runs on the rare >1 branch.
     """
     if not candidates:
         return None
+
+    # Agent tier — the running agent's own choice outranks the stored rows.
+    agent_pref = agent.prefs.get(sense_id) if agent is not None else None
+    if agent_pref is not None:
+        if agent_pref in candidates:
+            return ResolvedSense(
+                sense_id=sense_id,
+                connector_name=agent_pref,
+                ambiguous=False,
+                candidates=candidates,
+            )
+        logger.info(
+            "agent sense pref skipped: agent=%s sense=%s pref=%s not in candidates=%s",
+            agent.agent_id,
+            sense_id,
+            agent_pref,
+            candidates,
+        )
 
     if len(candidates) == 1:
         return ResolvedSense(
@@ -112,19 +173,24 @@ async def resolve(
     workspace_id: str,
     *,
     pocket_id: str | None = None,
+    agent: AgentSenseContext | None = None,
 ) -> ResolvedSense | None:
     """Bind ``sense_id`` to the connector that fills it for this workspace.
 
     Returns ``None`` when no enabled connector can fill the sense (the caller
     decides what to do — typically prompt-to-connect). Raises
-    ``SenseValidationError`` for an unknown ``paw.*`` id.
+    ``SenseValidationError`` for an unknown ``paw.*`` id. Pass ``agent`` to let
+    the running agent's own provider pref outrank the stored preference rows;
+    ``agent=None`` is the unchanged pre-SP2-2 behaviour.
     """
     validate_sense_id(sense_id)
 
     registry = connectors_service._get_registry()  # noqa: SLF001 — reuse the EE singleton
     filler = ConnectorSenseFiller(registry)
     candidates = await filler.candidates(sense_id, workspace_id, pocket_id=pocket_id)
-    return await _disambiguate(sense_id, candidates, workspace_id, pocket_id=pocket_id)
+    return await _disambiguate(
+        sense_id, candidates, workspace_id, pocket_id=pocket_id, agent=agent
+    )
 
 
 async def resolve_many(
@@ -132,6 +198,7 @@ async def resolve_many(
     workspace_id: str,
     *,
     pocket_id: str | None = None,
+    agent: AgentSenseContext | None = None,
 ) -> dict[str, ResolvedSense | None]:
     """Resolve many senses with ONE enabled-connector read.
 
@@ -157,7 +224,9 @@ async def resolve_many(
     out: dict[str, ResolvedSense | None] = {}
     for sense_id in sense_ids:
         candidates = filler.candidates_from(sense_id, enabled_names)
-        out[sense_id] = await _disambiguate(sense_id, candidates, workspace_id, pocket_id=pocket_id)
+        out[sense_id] = await _disambiguate(
+            sense_id, candidates, workspace_id, pocket_id=pocket_id, agent=agent
+        )
     return out
 
 
@@ -185,6 +254,7 @@ async def execute_sense(
     *,
     pocket_id: str | None = None,
     user_id: str | None = None,
+    agent: AgentSenseContext | None = None,
 ) -> SenseExecutionResult:
     """Resolve a sense, enforce the read-first gate, then delegate to execute.
 
@@ -196,8 +266,12 @@ async def execute_sense(
        ``sense.action_needs_approval`` and ``connectors_service.execute`` is
        NEVER called.
     3. Delegate to the existing execute path with the resolved connector.
+
+    ``agent`` (SP2-2) rides into step 1 so the agent's own provider pref picks
+    the connector this execution runs against. The read-first gate is unchanged
+    and applies to whichever connector wins.
     """
-    resolved = await resolve(sense_id, workspace_id, pocket_id=pocket_id)
+    resolved = await resolve(sense_id, workspace_id, pocket_id=pocket_id, agent=agent)
     if resolved is None:
         return SenseExecutionResult(
             ok=False,
@@ -241,4 +315,11 @@ async def execute_sense(
     )
 
 
-__all__ = ["ResolvedSense", "SenseExecutionResult", "execute_sense", "resolve", "resolve_many"]
+__all__ = [
+    "AgentSenseContext",
+    "ResolvedSense",
+    "SenseExecutionResult",
+    "execute_sense",
+    "resolve",
+    "resolve_many",
+]

--- a/ee/pocketpaw_ee/cloud/shared/agent_bridge.py
+++ b/ee/pocketpaw_ee/cloud/shared/agent_bridge.py
@@ -43,6 +43,12 @@ delivered-artifact collector around ``pool.run`` and drains it into a
 so a group/DM agent that delivers a file persists the structured signal too.
 This path has no run-transport SSE stream, so it emits no ``artifact`` event —
 that applies only to the streaming ``run_core`` path.
+Updated 2026-08-01 (Sense Phase 2, SP2-1): ``_run_agent_response`` passes
+``agent_id`` to ``attach_agent_identity`` as well as ``user_id``. This function is
+dispatched once PER responding agent — ``_dispatch_agent_responses`` fans a
+multi-agent room out into one call apiece — so the agent driving the run is
+unambiguous here even though the room isn't. In-process MCP tools read it back
+via ``agent_service.current_agent_id()``.
 """
 
 from __future__ import annotations
@@ -551,7 +557,12 @@ async def _run_agent_response(
     # it, so every ContextVar-scoped tool returned "requires workspace context
     # (call from a cloud chat session)". ``user_id`` is the agent itself — it is
     # the actor on this path, matching the cloud MCP tests' setup.
-    identity_tokens = attach_agent_identity(workspace_id=workspace_id, user_id=agent_id)
+    # SP2-1 — ``agent_id`` is BOTH the actor (``user_id``, as above) and the agent
+    # driving this run. This function is dispatched once per responding agent, so
+    # even a multi-agent room binds one unambiguous agent per call.
+    identity_tokens = attach_agent_identity(
+        workspace_id=workspace_id, user_id=agent_id, agent_id=agent_id
+    )
     # ART-1: bind a per-run collector so a ``deliver_artifact`` call on THIS
     # (group/DM) path lands a ``{type:"artifact", meta}`` attachment on the agent
     # message. This path has no run-transport SSE stream, so it persists the

--- a/ee/pocketpaw_ee/cloud/shared/agent_bridge.py
+++ b/ee/pocketpaw_ee/cloud/shared/agent_bridge.py
@@ -73,6 +73,13 @@ fail-open: a plan call whose arguments cannot be read falls back to the ordinary
 going silent. A per-run ``PlanTracker`` supplies the monotonic ``seq`` and
 suppresses re-emits of an unchanged plan (``write_plan`` fires at both the start
 and the end of every step and resends the whole list each time).
+
+Updated 2026-08-01 (Sense Phase 2, SP2-1): ``_run_agent_response`` passes
+``agent_id`` to ``attach_agent_identity`` as well as ``user_id``. This function is
+dispatched once PER responding agent — ``_dispatch_agent_responses`` fans a
+multi-agent room out into one call apiece — so the agent driving the run is
+unambiguous here even though the room isn't. In-process MCP tools read it back
+via ``agent_service.current_agent_id()``.
 """
 
 from __future__ import annotations
@@ -590,7 +597,12 @@ async def _run_agent_response(
     # it, so every ContextVar-scoped tool returned "requires workspace context
     # (call from a cloud chat session)". ``user_id`` is the agent itself — it is
     # the actor on this path, matching the cloud MCP tests' setup.
-    identity_tokens = attach_agent_identity(workspace_id=workspace_id, user_id=agent_id)
+    # SP2-1 — ``agent_id`` is BOTH the actor (``user_id``, as above) and the agent
+    # driving this run. This function is dispatched once per responding agent, so
+    # even a multi-agent room binds one unambiguous agent per call.
+    identity_tokens = attach_agent_identity(
+        workspace_id=workspace_id, user_id=agent_id, agent_id=agent_id
+    )
     # ART-1: bind a per-run collector so a ``deliver_artifact`` call on THIS
     # (group/DM) path lands a ``{type:"artifact", meta}`` attachment on the agent
     # message. This path has no run-transport SSE stream, so it persists the

--- a/ee/pocketpaw_ee/cloud/surface/surface_registry.py
+++ b/ee/pocketpaw_ee/cloud/surface/surface_registry.py
@@ -517,6 +517,18 @@ def _belt_profile(_meta: SurfaceMeta) -> SurfaceProfile:
 # reach them. A concierge pocket must therefore have NO connectors bound until
 # the OSS backend grows a true "public/untrusted" lockdown mode (drop the
 # universal grants). Tracked as the T2 follow-up.
+# SP2-4 (2026-08-02) — the RAW connector surface described above is unchanged and
+# still stripped here. What DID open is the narrow SENSE surface
+# (``list_senses`` / ``sense_execute``), and NOT from this module: that grant is
+# conditional on the running agent's mount list, which this resolver cannot see
+# (it is a pure, no-I/O sync lookup over CLIENT-supplied ``SurfaceMeta``, so a
+# read here would be both an I/O violation and forgeable by an anonymous
+# caller). It lives at the run seam instead —
+# ``chat.runs.run_core._concierge_sense_policy`` — which grants the two ids only
+# when the site agent carries a NON-EMPTY ``config.senses`` and DENIES them
+# outright when it does not, so an unmounted concierge can never inherit the
+# workspace sense surface. Unlike the composio ids, the sense ids are static and
+# enumerable, which is what makes a fail-closed deny expressible for them at all.
 _CONCIERGE_DENY: frozenset[str] = frozenset(
     {
         # Web (the explicit T2 requirement).

--- a/ee/pocketpaw_ee/cloud/surface/surface_registry.py
+++ b/ee/pocketpaw_ee/cloud/surface/surface_registry.py
@@ -725,6 +725,18 @@ def _ship_profile(_meta: SurfaceMeta) -> SurfaceProfile:
 # reach them. A concierge pocket must therefore have NO connectors bound until
 # the OSS backend grows a true "public/untrusted" lockdown mode (drop the
 # universal grants). Tracked as the T2 follow-up.
+# SP2-4 (2026-08-02) — the RAW connector surface described above is unchanged and
+# still stripped here. What DID open is the narrow SENSE surface
+# (``list_senses`` / ``sense_execute``), and NOT from this module: that grant is
+# conditional on the running agent's mount list, which this resolver cannot see
+# (it is a pure, no-I/O sync lookup over CLIENT-supplied ``SurfaceMeta``, so a
+# read here would be both an I/O violation and forgeable by an anonymous
+# caller). It lives at the run seam instead —
+# ``chat.runs.run_core._concierge_sense_policy`` — which grants the two ids only
+# when the site agent carries a NON-EMPTY ``config.senses`` and DENIES them
+# outright when it does not, so an unmounted concierge can never inherit the
+# workspace sense surface. Unlike the composio ids, the sense ids are static and
+# enumerable, which is what makes a fail-closed deny expressible for them at all.
 _CONCIERGE_DENY: frozenset[str] = frozenset(
     {
         # Web (the explicit T2 requirement).

--- a/ee/pocketpaw_ee/paw_bar/agent_provisioning.py
+++ b/ee/pocketpaw_ee/paw_bar/agent_provisioning.py
@@ -1,6 +1,29 @@
 # ee/pocketpaw_ee/paw_bar/agent_provisioning.py — auto-provision a DEDICATED
 # concierge agent per Paw Site.
 #
+# Updated 2026-08-02 (Sense Phase 2, SP2-5): ``ensure_site_agent`` gained the
+# keyword-only ``senses`` / ``sense_prefs``. Supplied, they pin the site's
+# concierge to a fixed capability set — written on CREATE, and on a RE-ensure
+# only when the stored value is still empty, so an owner's hand-edit survives
+# every later publish (``_seed_senses`` holds that rule and the reasoning).
+# ``None`` — what EVERY call site passes today — is byte-for-byte the old path.
+#
+# WHY THE HOOK IS INERT: the obvious thing to pass is "the sense for this site's
+# own API", and no such sense id exists. A Sense is filled by a CONNECTOR that
+# declares it (``connectors/<name>.yaml`` -> ``senses:``, indexed by
+# ``pocketpaw.senses.vocabulary.connectors_for_sense``), and a Paw Site's API is
+# not a connector — there is no site YAML under ``connectors/``, and the closed
+# core vocabulary (``CORE_SENSES``: email / calendar / code / payments / db /
+# docs) has no site-shaped member. Minting one would need a real connector def
+# behind it, which is the connector-distribution wave, not this slice.
+#
+# Even with an id in hand, a mounted sense would not reach a visitor yet: the
+# concierge chat endpoint refuses fail-closed (409 ``concierge_pocket_has_
+# connectors``) whenever the pocket's agent can reach ANY connector — see the
+# lockdown guard in ``paw_bar/router.py`` and its ``TODO(GA-blocker)``. So the
+# order is: GA lockdown mode -> a site connector that declares a sense -> pass it
+# here. The keywords exist now so that last step is one call-site edit.
+#
 # Updated 2026-07-30 (Paw Bar inbox D5): added ``widget_for_agent(agent_id,
 # workspace_id)`` — the REVERSE of the bind ``ensure_site_agent`` writes. D5 lets a
 # concierge run read its own ``agent:<id>`` knowledge scope, which makes "is this
@@ -181,11 +204,87 @@ async def _seed_connectors(agent: Any, site: Any) -> None:
     auto-binding). Intentionally a no-op today — the concierge is public and runs
     fail-closed with NO connectors until the untrusted/public claude_sdk lockdown
     mode ships (see ``concierge_chat``'s connector-lockdown guard). Present so the
-    provision path has one obvious place to wire connectors when that lands."""
+    provision path has one obvious place to wire connectors when that lands.
+
+    NOTE (SP2-5, the "is a site-API sense derivable?" question): no. A Sense is
+    filled by a CONNECTOR that declares it (``connectors/*.yaml`` -> ``senses:``),
+    and a Paw Site's own API is not a connector — nothing under ``connectors/``
+    represents it, and the core vocabulary
+    (``pocketpaw.senses.vocabulary.CORE_SENSES``: email / calendar / code /
+    payments / db / docs) has no site-shaped entry. So there is no id to pass, and
+    ``ensure_site_agent``'s sense keywords stay unpassed by every call site — see
+    the header for the full answer."""
     return None
 
 
-async def ensure_site_agent(site: Any, widget: Any) -> str | None:
+async def _seed_senses(
+    agent: Any,
+    owner_id: str,
+    workspace_id: str,
+    senses: list[str] | None,
+    sense_prefs: dict[str, str] | None,
+) -> None:
+    """Pin sense config onto an EXISTING concierge agent, never clobbering intent.
+
+    The re-ensure rule, in full: a field is written ONLY when the caller supplied
+    it AND the stored value is empty. Per field, not all-or-nothing — an agent
+    whose owner set ``senses`` by hand but left ``sense_prefs`` empty still gets
+    the provisioned pref. ``ensure_site_agent`` runs on three triggers and re-runs
+    on every publish, so anything else would mean an owner's hand-tuned mount list
+    silently reverting to the provisioned one the next time they hit publish.
+
+    Only touches an agent the SITE OWNER owns. A widget a human bound by hand to
+    someone else's agent is left completely alone — the module's existing
+    "manual binds are never overwritten" contract, extended to config.
+
+    Failure-soft like the rest of provisioning: a failed seed logs and leaves the
+    bind intact rather than un-provisioning a site.
+    """
+    if senses is None and sense_prefs is None:
+        return
+
+    from pocketpaw_ee.cloud.agents import service as agents_service
+    from pocketpaw_ee.cloud.agents.dto import UpdateAgentRequest
+
+    if str(getattr(agent, "owner", "")) != str(owner_id):
+        logger.debug(
+            "paw-bar concierge: agent %s is not owned by site owner %s; leaving sense config alone",
+            getattr(agent, "id", "?"),
+            owner_id,
+        )
+        return
+
+    config = getattr(agent, "config", None)
+    patch: dict[str, Any] = {}
+    if senses and not getattr(config, "senses", ()):
+        patch["senses"] = list(senses)
+    if sense_prefs and not getattr(config, "sense_prefs", ()):
+        patch["sense_prefs"] = dict(sense_prefs)
+    if not patch:
+        return
+
+    try:
+        await agents_service.update(
+            agents_service.legacy_ctx(owner_id, workspace_id),
+            agent.id,
+            UpdateAgentRequest(**patch),
+        )
+    except Exception:  # noqa: BLE001 — a sense seed is never a gate on a bind
+        logger.warning(
+            "paw-bar concierge: could not seed sense config %s onto agent %s",
+            sorted(patch),
+            getattr(agent, "id", "?"),
+            exc_info=True,
+        )
+
+
+async def ensure_site_agent(
+    site: Any,
+    widget: Any,
+    *,
+    senses: list[str] | None = None,
+    sense_prefs: dict[str, str] | None = None,
+) -> str | None:
     """Idempotently ensure ``widget`` is bound to a dedicated agent for ``site``.
 
     Returns the bound agent id, or ``None`` when provisioning could not complete
@@ -195,6 +294,15 @@ async def ensure_site_agent(site: Any, widget: Any) -> str | None:
     created in the SITE's workspace, owned by the site owner, and bound to the
     widget through the store — mirroring how the agents service derives ownership,
     never cross-tenant.
+
+    ``senses`` / ``sense_prefs`` (SP2-5) pin the site's concierge to a fixed set of
+    capabilities. A non-empty mount list is EXCLUSIVE — it is also what makes the
+    concierge sense surface reachable at all (SP2-4 grants the sense tools only to
+    an agent whose mount list is non-empty). Both are written on CREATE, and on a
+    RE-ensure only when the stored value is still empty, so an owner who edited
+    their concierge's senses in the dashboard keeps that edit through every later
+    publish. ``None`` (the default, and what every call site passes today) means no
+    behaviour change whatsoever — see ``_seed_senses`` and the module header.
     """
     from pocketpaw_ee.cloud._core.errors import ConflictError, NotFound
     from pocketpaw_ee.cloud.agents import service as agents_service
@@ -207,9 +315,9 @@ async def ensure_site_agent(site: Any, widget: Any) -> str | None:
     # (1) Respect an existing LIVE bind — a manual agent_id is never replaced.
     existing_id = getattr(widget, "agent_id", "") or ""
     if existing_id:
+        bound = None
         try:
-            await agents_service.get(existing_id)
-            return existing_id
+            bound = await agents_service.get(existing_id)
         except NotFound:
             # Stale bind (agent deleted) — fall through and re-provision.
             logger.info(
@@ -217,6 +325,9 @@ async def ensure_site_agent(site: Any, widget: Any) -> str | None:
                 widget.id,
                 existing_id,
             )
+        if bound is not None:
+            await _seed_senses(bound, owner_id, workspace_id, senses, sense_prefs)
+            return existing_id
 
     # (2) Resolve-or-create the dedicated agent. The slug is deterministic on the
     # site id, so a create that races or retries after a failed bind RESOLVES the
@@ -238,6 +349,10 @@ async def ensure_site_agent(site: Any, widget: Any) -> str | None:
             persona=concierge_persona(site.name),
             soul_archetype=_CONCIERGE_ARCHETYPE,
             # soul_enabled defaults True — the concierge carries a soul.
+            # SP2-5: the mount list lands at CREATE, so a brand-new concierge is
+            # sense-capable on its first run rather than after a follow-up PATCH.
+            senses=list(senses) if senses is not None else None,
+            sense_prefs=dict(sense_prefs) if sense_prefs is not None else None,
         )
         _seed_tags(body, site_id)
         _seed_identity(body, site, widget)
@@ -246,6 +361,10 @@ async def ensure_site_agent(site: Any, widget: Any) -> str | None:
         except ConflictError:
             # Lost a create race on the deterministic slug — adopt the winner.
             agent = await agents_service.get_by_slug(workspace_id, slug)
+            await _seed_senses(agent, owner_id, workspace_id, senses, sense_prefs)
+    else:
+        # Re-ensure on an agent that already exists under the deterministic slug.
+        await _seed_senses(agent, owner_id, workspace_id, senses, sense_prefs)
 
     # Connector seam (no-op today).
     await _seed_connectors(agent, site)
@@ -323,6 +442,9 @@ async def provision_widget_on_create(widget: Any, workspace_id: str) -> Any:
         site = await _canonical_site_for_pocket(workspace_id, widget.pocket_id)
         if site is None:
             return widget  # no site for this pocket — a plain widget, not a concierge
+        # No senses passed: there is no site-API sense id to pass yet, and the
+        # concierge connector lockdown would refuse anyway. See the header's
+        # "WHY THE HOOK IS INERT" — same at the other two triggers below.
         await ensure_site_agent(site, widget)
         refreshed = await _store().get_widget(widget.id, workspace_id=workspace_id)
         return refreshed or widget
@@ -398,6 +520,7 @@ async def ensure_site_widget(site: Any, workspace_id: str) -> Any | None:
         existing = await site_widget(site.pocket_id, workspace_id)
         if existing is not None:
             if not getattr(existing, "agent_id", ""):
+                # No senses — see the header's "WHY THE HOOK IS INERT".
                 await ensure_site_agent(site, existing)
                 refreshed = await _store().get_widget(existing.id, workspace_id=workspace_id)
                 return refreshed or existing
@@ -446,6 +569,7 @@ async def provision_on_concierge_enable(site: Any, workspace_id: str) -> None:
         widget = await site_widget(site.pocket_id, workspace_id)
         if widget is None or getattr(widget, "agent_id", ""):
             return
+        # No senses — see the header's "WHY THE HOOK IS INERT".
         await ensure_site_agent(site, widget)
     except Exception:  # noqa: BLE001 — provisioning must never 500 the settings PATCH
         logger.warning(

--- a/ee/pocketpaw_ee/paw_bar/agent_provisioning.py
+++ b/ee/pocketpaw_ee/paw_bar/agent_provisioning.py
@@ -11,6 +11,29 @@
 # them), and the dashboard widget-create path is untouched too — its spec is
 # authored by the caller, never synthesized here.
 #
+# Updated 2026-08-02 (Sense Phase 2, SP2-5): ``ensure_site_agent`` gained the
+# keyword-only ``senses`` / ``sense_prefs``. Supplied, they pin the site's
+# concierge to a fixed capability set — written on CREATE, and on a RE-ensure
+# only when the stored value is still empty, so an owner's hand-edit survives
+# every later publish (``_seed_senses`` holds that rule and the reasoning).
+# ``None`` — what EVERY call site passes today — is byte-for-byte the old path.
+#
+# WHY THE HOOK IS INERT: the obvious thing to pass is "the sense for this site's
+# own API", and no such sense id exists. A Sense is filled by a CONNECTOR that
+# declares it (``connectors/<name>.yaml`` -> ``senses:``, indexed by
+# ``pocketpaw.senses.vocabulary.connectors_for_sense``), and a Paw Site's API is
+# not a connector — there is no site YAML under ``connectors/``, and the closed
+# core vocabulary (``CORE_SENSES``: email / calendar / code / payments / db /
+# docs) has no site-shaped member. Minting one would need a real connector def
+# behind it, which is the connector-distribution wave, not this slice.
+#
+# Even with an id in hand, a mounted sense would not reach a visitor yet: the
+# concierge chat endpoint refuses fail-closed (409 ``concierge_pocket_has_
+# connectors``) whenever the pocket's agent can reach ANY connector — see the
+# lockdown guard in ``paw_bar/router.py`` and its ``TODO(GA-blocker)``. So the
+# order is: GA lockdown mode -> a site connector that declares a sense -> pass it
+# here. The keywords exist now so that last step is one call-site edit.
+#
 # Updated 2026-07-30 (Paw Bar inbox D5): added ``widget_for_agent(agent_id,
 # workspace_id)`` — the REVERSE of the bind ``ensure_site_agent`` writes. D5 lets a
 # concierge run read its own ``agent:<id>`` knowledge scope, which makes "is this
@@ -191,11 +214,87 @@ async def _seed_connectors(agent: Any, site: Any) -> None:
     auto-binding). Intentionally a no-op today — the concierge is public and runs
     fail-closed with NO connectors until the untrusted/public claude_sdk lockdown
     mode ships (see ``concierge_chat``'s connector-lockdown guard). Present so the
-    provision path has one obvious place to wire connectors when that lands."""
+    provision path has one obvious place to wire connectors when that lands.
+
+    NOTE (SP2-5, the "is a site-API sense derivable?" question): no. A Sense is
+    filled by a CONNECTOR that declares it (``connectors/*.yaml`` -> ``senses:``),
+    and a Paw Site's own API is not a connector — nothing under ``connectors/``
+    represents it, and the core vocabulary
+    (``pocketpaw.senses.vocabulary.CORE_SENSES``: email / calendar / code /
+    payments / db / docs) has no site-shaped entry. So there is no id to pass, and
+    ``ensure_site_agent``'s sense keywords stay unpassed by every call site — see
+    the header for the full answer."""
     return None
 
 
-async def ensure_site_agent(site: Any, widget: Any) -> str | None:
+async def _seed_senses(
+    agent: Any,
+    owner_id: str,
+    workspace_id: str,
+    senses: list[str] | None,
+    sense_prefs: dict[str, str] | None,
+) -> None:
+    """Pin sense config onto an EXISTING concierge agent, never clobbering intent.
+
+    The re-ensure rule, in full: a field is written ONLY when the caller supplied
+    it AND the stored value is empty. Per field, not all-or-nothing — an agent
+    whose owner set ``senses`` by hand but left ``sense_prefs`` empty still gets
+    the provisioned pref. ``ensure_site_agent`` runs on three triggers and re-runs
+    on every publish, so anything else would mean an owner's hand-tuned mount list
+    silently reverting to the provisioned one the next time they hit publish.
+
+    Only touches an agent the SITE OWNER owns. A widget a human bound by hand to
+    someone else's agent is left completely alone — the module's existing
+    "manual binds are never overwritten" contract, extended to config.
+
+    Failure-soft like the rest of provisioning: a failed seed logs and leaves the
+    bind intact rather than un-provisioning a site.
+    """
+    if senses is None and sense_prefs is None:
+        return
+
+    from pocketpaw_ee.cloud.agents import service as agents_service
+    from pocketpaw_ee.cloud.agents.dto import UpdateAgentRequest
+
+    if str(getattr(agent, "owner", "")) != str(owner_id):
+        logger.debug(
+            "paw-bar concierge: agent %s is not owned by site owner %s; leaving sense config alone",
+            getattr(agent, "id", "?"),
+            owner_id,
+        )
+        return
+
+    config = getattr(agent, "config", None)
+    patch: dict[str, Any] = {}
+    if senses and not getattr(config, "senses", ()):
+        patch["senses"] = list(senses)
+    if sense_prefs and not getattr(config, "sense_prefs", ()):
+        patch["sense_prefs"] = dict(sense_prefs)
+    if not patch:
+        return
+
+    try:
+        await agents_service.update(
+            agents_service.legacy_ctx(owner_id, workspace_id),
+            agent.id,
+            UpdateAgentRequest(**patch),
+        )
+    except Exception:  # noqa: BLE001 — a sense seed is never a gate on a bind
+        logger.warning(
+            "paw-bar concierge: could not seed sense config %s onto agent %s",
+            sorted(patch),
+            getattr(agent, "id", "?"),
+            exc_info=True,
+        )
+
+
+async def ensure_site_agent(
+    site: Any,
+    widget: Any,
+    *,
+    senses: list[str] | None = None,
+    sense_prefs: dict[str, str] | None = None,
+) -> str | None:
     """Idempotently ensure ``widget`` is bound to a dedicated agent for ``site``.
 
     Returns the bound agent id, or ``None`` when provisioning could not complete
@@ -205,6 +304,15 @@ async def ensure_site_agent(site: Any, widget: Any) -> str | None:
     created in the SITE's workspace, owned by the site owner, and bound to the
     widget through the store — mirroring how the agents service derives ownership,
     never cross-tenant.
+
+    ``senses`` / ``sense_prefs`` (SP2-5) pin the site's concierge to a fixed set of
+    capabilities. A non-empty mount list is EXCLUSIVE — it is also what makes the
+    concierge sense surface reachable at all (SP2-4 grants the sense tools only to
+    an agent whose mount list is non-empty). Both are written on CREATE, and on a
+    RE-ensure only when the stored value is still empty, so an owner who edited
+    their concierge's senses in the dashboard keeps that edit through every later
+    publish. ``None`` (the default, and what every call site passes today) means no
+    behaviour change whatsoever — see ``_seed_senses`` and the module header.
     """
     from pocketpaw_ee.cloud._core.errors import ConflictError, NotFound
     from pocketpaw_ee.cloud.agents import service as agents_service
@@ -217,9 +325,9 @@ async def ensure_site_agent(site: Any, widget: Any) -> str | None:
     # (1) Respect an existing LIVE bind — a manual agent_id is never replaced.
     existing_id = getattr(widget, "agent_id", "") or ""
     if existing_id:
+        bound = None
         try:
-            await agents_service.get(existing_id)
-            return existing_id
+            bound = await agents_service.get(existing_id)
         except NotFound:
             # Stale bind (agent deleted) — fall through and re-provision.
             logger.info(
@@ -227,6 +335,9 @@ async def ensure_site_agent(site: Any, widget: Any) -> str | None:
                 widget.id,
                 existing_id,
             )
+        if bound is not None:
+            await _seed_senses(bound, owner_id, workspace_id, senses, sense_prefs)
+            return existing_id
 
     # (2) Resolve-or-create the dedicated agent. The slug is deterministic on the
     # site id, so a create that races or retries after a failed bind RESOLVES the
@@ -248,6 +359,10 @@ async def ensure_site_agent(site: Any, widget: Any) -> str | None:
             persona=concierge_persona(site.name),
             soul_archetype=_CONCIERGE_ARCHETYPE,
             # soul_enabled defaults True — the concierge carries a soul.
+            # SP2-5: the mount list lands at CREATE, so a brand-new concierge is
+            # sense-capable on its first run rather than after a follow-up PATCH.
+            senses=list(senses) if senses is not None else None,
+            sense_prefs=dict(sense_prefs) if sense_prefs is not None else None,
         )
         _seed_tags(body, site_id)
         _seed_identity(body, site, widget)
@@ -256,6 +371,10 @@ async def ensure_site_agent(site: Any, widget: Any) -> str | None:
         except ConflictError:
             # Lost a create race on the deterministic slug — adopt the winner.
             agent = await agents_service.get_by_slug(workspace_id, slug)
+            await _seed_senses(agent, owner_id, workspace_id, senses, sense_prefs)
+    else:
+        # Re-ensure on an agent that already exists under the deterministic slug.
+        await _seed_senses(agent, owner_id, workspace_id, senses, sense_prefs)
 
     # Connector seam (no-op today).
     await _seed_connectors(agent, site)
@@ -333,6 +452,9 @@ async def provision_widget_on_create(widget: Any, workspace_id: str) -> Any:
         site = await _canonical_site_for_pocket(workspace_id, widget.pocket_id)
         if site is None:
             return widget  # no site for this pocket — a plain widget, not a concierge
+        # No senses passed: there is no site-API sense id to pass yet, and the
+        # concierge connector lockdown would refuse anyway. See the header's
+        # "WHY THE HOOK IS INERT" — same at the other two triggers below.
         await ensure_site_agent(site, widget)
         refreshed = await _store().get_widget(widget.id, workspace_id=workspace_id)
         return refreshed or widget
@@ -434,6 +556,7 @@ async def ensure_site_widget(site: Any, workspace_id: str) -> Any | None:
         existing = await site_widget(site.pocket_id, workspace_id)
         if existing is not None:
             if not getattr(existing, "agent_id", ""):
+                # No senses — see the header's "WHY THE HOOK IS INERT".
                 await ensure_site_agent(site, existing)
                 refreshed = await _store().get_widget(existing.id, workspace_id=workspace_id)
                 return refreshed or existing
@@ -488,6 +611,7 @@ async def provision_on_concierge_enable(site: Any, workspace_id: str) -> None:
         widget = await site_widget(site.pocket_id, workspace_id)
         if widget is None or getattr(widget, "agent_id", ""):
             return
+        # No senses — see the header's "WHY THE HOOK IS INERT".
         await ensure_site_agent(site, widget)
     except Exception:  # noqa: BLE001 — provisioning must never 500 the settings PATCH
         logger.warning(

--- a/tests/cloud/agents/test_agent_sense_prefs.py
+++ b/tests/cloud/agents/test_agent_sense_prefs.py
@@ -1,0 +1,119 @@
+# tests/cloud/agents/test_agent_sense_prefs.py
+# Created 2026-08-02 (Sense Phase 2, SP2-2 — agent-tier provider preference) —
+# pins ``AgentConfig.sense_prefs`` at both boundaries it has to hold:
+#   * SCHEMA — keys are validated as sense ids (unknown/malformed paw.* ids and
+#     non-ids are rejected at write time); vendor-extension ids are accepted;
+#     connector-name VALUES are deliberately unvalidated.
+#   * PERSISTENCE — the field round-trips through the doc<->spec mappers AND
+#     survives an unrelated config update. That second case is the load-bearing
+#     one: ``service.update`` rewrites the whole config sub-doc from the domain
+#     spec, so a doc-only field would be silently erased on the next edit.
+"""``AgentConfig.sense_prefs`` validates its keys and survives updates."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from beanie import PydanticObjectId  # noqa: E402
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind  # noqa: E402
+from pocketpaw_ee.cloud.agents import service as agents_service  # noqa: E402
+from pocketpaw_ee.cloud.agents.domain import AgentConfigSpec  # noqa: E402
+from pocketpaw_ee.cloud.agents.dto import CreateAgentRequest, UpdateAgentRequest  # noqa: E402
+from pocketpaw_ee.cloud.models.agent import Agent as AgentDoc  # noqa: E402
+from pocketpaw_ee.cloud.models.agent import AgentConfig  # noqa: E402
+from pydantic import ValidationError  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Schema boundary — key validation (no Mongo)
+# ---------------------------------------------------------------------------
+
+
+def test_default_is_empty() -> None:
+    assert AgentConfig().sense_prefs == {}
+
+
+def test_valid_core_sense_ids_accepted() -> None:
+    config = AgentConfig(sense_prefs={"paw.code.v1": "gitlab", "paw.email.v1": "gmail"})
+    assert config.sense_prefs["paw.code.v1"] == "gitlab"
+
+
+def test_vendor_extension_sense_id_accepted() -> None:
+    # The non-paw namespace is open — only the closed paw.* set is policed.
+    config = AgentConfig(sense_prefs={"acme.crm.v1": "salesforce"})
+    assert config.sense_prefs["acme.crm.v1"] == "salesforce"
+
+
+def test_unknown_core_sense_id_key_rejected() -> None:
+    with pytest.raises(ValidationError):
+        AgentConfig(sense_prefs={"paw.telepathy.v1": "gitlab"})
+
+
+def test_malformed_sense_id_key_rejected() -> None:
+    with pytest.raises(ValidationError):
+        AgentConfig(sense_prefs={"not a sense id": "gitlab"})
+
+
+def test_connector_name_values_are_not_validated() -> None:
+    # A value naming a connector that doesn't exist is legal at the schema
+    # boundary — the resolver skips it at resolve time instead.
+    config = AgentConfig(sense_prefs={"paw.code.v1": "no-such-connector"})
+    assert config.sense_prefs["paw.code.v1"] == "no-such-connector"
+
+
+# ---------------------------------------------------------------------------
+# Mapper round-trip (no Mongo)
+# ---------------------------------------------------------------------------
+
+
+def test_mapper_round_trip_preserves_sense_prefs() -> None:
+    spec = AgentConfigSpec(sense_prefs=(("paw.code.v1", "gitlab"),))
+    doc = agents_service._config_to_doc(spec)
+    assert doc.sense_prefs == {"paw.code.v1": "gitlab"}
+    assert agents_service._config_to_domain(doc).sense_prefs == (("paw.code.v1", "gitlab"),)
+
+
+def test_mapper_default_is_empty() -> None:
+    assert agents_service._config_to_domain(AgentConfig()).sense_prefs == ()
+    assert agents_service._config_to_doc(AgentConfigSpec()).sense_prefs == {}
+
+
+# ---------------------------------------------------------------------------
+# Persistence — the prefs survive an unrelated config update
+# ---------------------------------------------------------------------------
+
+
+def _ctx(user_id: str = "u1", workspace_id: str | None = "w1") -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="r",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+@pytest.mark.usefixtures("mongo_db")
+async def test_sense_prefs_survive_an_unrelated_config_update(recording_bus) -> None:
+    """``update`` rewrites the config sub-doc wholesale when any field changes.
+    A pref written directly on the doc (SP2-5 adds the CRUD surface) must still
+    be there afterwards."""
+    agent = await agents_service.create(
+        _ctx(), "w1", CreateAgentRequest(name="Coder", slug="coder", soul_enabled=False)
+    )
+
+    doc = await AgentDoc.get(PydanticObjectId(agent.id))
+    doc.config.sense_prefs = {"paw.code.v1": "gitlab"}
+    await doc.save()
+
+    # Touch something else entirely.
+    updated = await agents_service.update(
+        _ctx(), agent.id, UpdateAgentRequest(config={"temperature": 0.4})
+    )
+
+    assert updated.config.sense_prefs == (("paw.code.v1", "gitlab"),)
+    reloaded = await agents_service.get(agent.id)
+    assert reloaded.config.sense_prefs == (("paw.code.v1", "gitlab"),)

--- a/tests/cloud/agents/test_agent_senses.py
+++ b/tests/cloud/agents/test_agent_senses.py
@@ -1,0 +1,172 @@
+# tests/cloud/agents/test_agent_senses.py
+# Created 2026-08-02 (Sense Phase 2, SP2-3 — the sense mount list) — sibling of
+# test_agent_sense_prefs.py, pinning ``AgentConfig.senses`` at the same two
+# boundaries the prefs field has to hold:
+#   * SCHEMA — entries are validated as sense ids, so a bogus id fails on write
+#     rather than silently costing the agent a capability. Vendor-extension ids
+#     are accepted (only the closed paw.* set is policed).
+#   * PERSISTENCE — the field round-trips through the doc<->spec mappers AND
+#     survives an unrelated config update. That second case is load-bearing and
+#     the stakes are higher here than for prefs: erasing the mount list doesn't
+#     lose a provider choice, it silently WIDENS the agent's reach back to the
+#     workspace's whole sense surface.
+"""``AgentConfig.senses`` validates its entries and survives updates."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from beanie import PydanticObjectId  # noqa: E402
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind  # noqa: E402
+from pocketpaw_ee.cloud.agents import service as agents_service  # noqa: E402
+from pocketpaw_ee.cloud.agents.domain import AgentConfigSpec  # noqa: E402
+from pocketpaw_ee.cloud.agents.dto import CreateAgentRequest, UpdateAgentRequest  # noqa: E402
+from pocketpaw_ee.cloud.models.agent import Agent as AgentDoc  # noqa: E402
+from pocketpaw_ee.cloud.models.agent import AgentConfig  # noqa: E402
+from pydantic import ValidationError  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Schema boundary — entry validation (no Mongo)
+# ---------------------------------------------------------------------------
+
+
+def test_default_is_empty() -> None:
+    # Empty is the legacy "inherit every sense the workspace can fill".
+    assert AgentConfig().senses == []
+
+
+def test_valid_core_sense_ids_accepted() -> None:
+    config = AgentConfig(senses=["paw.email.v1", "paw.code.v1"])
+    assert config.senses == ["paw.email.v1", "paw.code.v1"]
+
+
+def test_vendor_extension_sense_id_accepted() -> None:
+    assert AgentConfig(senses=["acme.crm.v1"]).senses == ["acme.crm.v1"]
+
+
+def test_unknown_core_sense_id_rejected() -> None:
+    with pytest.raises(ValidationError):
+        AgentConfig(senses=["paw.telepathy.v1"])
+
+
+def test_malformed_sense_id_rejected() -> None:
+    with pytest.raises(ValidationError):
+        AgentConfig(senses=["not a sense id"])
+
+
+def test_one_bad_entry_rejects_the_whole_list() -> None:
+    with pytest.raises(ValidationError):
+        AgentConfig(senses=["paw.email.v1", "paw.telepathy.v1"])
+
+
+# ---------------------------------------------------------------------------
+# Mapper round-trip (no Mongo)
+# ---------------------------------------------------------------------------
+
+
+def test_mapper_round_trip_preserves_senses() -> None:
+    spec = AgentConfigSpec(senses=("paw.email.v1",))
+    doc = agents_service._config_to_doc(spec)
+    assert doc.senses == ["paw.email.v1"]
+    assert agents_service._config_to_domain(doc).senses == ("paw.email.v1",)
+
+
+def test_mapper_default_is_empty() -> None:
+    assert agents_service._config_to_domain(AgentConfig()).senses == ()
+    assert agents_service._config_to_doc(AgentConfigSpec()).senses == []
+
+
+# ---------------------------------------------------------------------------
+# Persistence — the mount list survives an unrelated config update
+# ---------------------------------------------------------------------------
+
+
+def _ctx(user_id: str = "u1", workspace_id: str | None = "w1") -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="r",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+@pytest.mark.usefixtures("mongo_db")
+async def test_senses_survive_an_unrelated_config_update(recording_bus) -> None:
+    """``update`` rewrites the config sub-doc wholesale when any field changes.
+    A mount list written directly on the doc (SP2-5 adds the CRUD surface) must
+    still be there afterwards — otherwise editing the temperature silently hands
+    the agent back the whole workspace sense surface."""
+    agent = await agents_service.create(
+        _ctx(), "w1", CreateAgentRequest(name="Mailer", slug="mailer", soul_enabled=False)
+    )
+
+    doc = await AgentDoc.get(PydanticObjectId(agent.id))
+    doc.config.senses = ["paw.email.v1"]
+    await doc.save()
+
+    # Touch something else entirely.
+    updated = await agents_service.update(
+        _ctx(), agent.id, UpdateAgentRequest(config={"temperature": 0.4})
+    )
+
+    assert updated.config.senses == ("paw.email.v1",)
+    reloaded = await agents_service.get(agent.id)
+    assert reloaded.config.senses == ("paw.email.v1",)
+
+
+@pytest.mark.usefixtures("mongo_db")
+async def test_senses_and_prefs_survive_together(recording_bus) -> None:
+    """Both sense fields ride the same erasure-prone path — pin them together so
+    a future field-list edit can't drop one and leave the other passing."""
+    agent = await agents_service.create(
+        _ctx(), "w1", CreateAgentRequest(name="Coder", slug="coder2", soul_enabled=False)
+    )
+
+    doc = await AgentDoc.get(PydanticObjectId(agent.id))
+    doc.config.senses = ["paw.code.v1"]
+    doc.config.sense_prefs = {"paw.code.v1": "gitlab"}
+    await doc.save()
+
+    updated = await agents_service.update(
+        _ctx(), agent.id, UpdateAgentRequest(config={"model": "claude-x"})
+    )
+
+    assert updated.config.senses == ("paw.code.v1",)
+    assert updated.config.sense_prefs == (("paw.code.v1", "gitlab"),)
+
+
+@pytest.mark.usefixtures("mongo_db")
+async def test_update_can_replace_the_mount_list(recording_bus) -> None:
+    """The carry-forward default must not make the field read-only."""
+    agent = await agents_service.create(
+        _ctx(), "w1", CreateAgentRequest(name="Swap", slug="swap", soul_enabled=False)
+    )
+    doc = await AgentDoc.get(PydanticObjectId(agent.id))
+    doc.config.senses = ["paw.email.v1"]
+    await doc.save()
+
+    updated = await agents_service.update(
+        _ctx(), agent.id, UpdateAgentRequest(config={"senses": ["paw.code.v1"]})
+    )
+
+    assert updated.config.senses == ("paw.code.v1",)
+
+
+@pytest.mark.usefixtures("mongo_db")
+async def test_update_rejects_a_bogus_mount_list(recording_bus) -> None:
+    """Validation lives at the Beanie boundary, which the update path crosses on
+    its way back to the doc — so a bad id can't be written through ``update``
+    either."""
+    agent = await agents_service.create(
+        _ctx(), "w1", CreateAgentRequest(name="Bad", slug="bad", soul_enabled=False)
+    )
+
+    with pytest.raises(ValidationError):
+        await agents_service.update(
+            _ctx(), agent.id, UpdateAgentRequest(config={"senses": ["paw.telepathy.v1"]})
+        )

--- a/tests/cloud/agents/test_agent_senses_router.py
+++ b/tests/cloud/agents/test_agent_senses_router.py
@@ -1,0 +1,268 @@
+# tests/cloud/agents/test_agent_senses_router.py
+# Created 2026-08-02 (Sense Phase 2, SP2-5 — the config surface) — the HTTP half
+# of the sense fields. test_agent_senses.py / test_agent_sense_prefs.py pin the
+# schema and the doc<->spec mappers; this module pins the wire, where three
+# separate things had to be true before an owner could actually use the feature:
+#   * SETTABLE at create (the create DTO has no nested ``config`` dict at all, so
+#     before SP2-5 a new agent could not be given senses in one call) and on
+#     update, both via the explicit fields and via a nested ``config``.
+#   * READABLE — ``GET /agents/{id}`` emits both. Until SP2-5 they were
+#     write-only, which makes an EXCLUSIVE mount list unauditable by the person
+#     who owns it.
+#   * SURVIVING — an unrelated PATCH must not erase them (the config-dict branch
+#     rebuilds the whole spec from an explicit field list).
+#   * REFUSED LOUDLY — a bogus sense id is a 422 carrying the vocabulary's own
+#     message, not a 500. The Beanie validator alone raises a pydantic
+#     ValidationError from inside the service, which the CloudError handler does
+#     not catch; ``docs/api-reference.md`` has promised 422 since SP2-3.
+"""The sense fields are settable, readable, and durable over HTTP."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+import pytest_asyncio  # noqa: E402
+from fastapi import FastAPI  # noqa: E402
+from httpx import ASGITransport, AsyncClient  # noqa: E402
+
+_USER = "u1"
+_WS = "w1"
+
+
+class _FakeMembership:
+    def __init__(self, workspace: str, role: str = "admin") -> None:
+        self.workspace = workspace
+        self.role = role
+
+
+class _FakeUser:
+    """Duck-typed stand-in for the cloud User (same shape test_rbac_routes uses).
+
+    Overriding ``current_active_user`` rather than ``current_user_id`` /
+    ``current_workspace_id`` keeps the REAL RBAC guards
+    (``require_action_any_workspace("agent.create")``,
+    ``require_agent_owner_or_admin``) in the path — they are wiring this module
+    depends on, so stubbing them out would let a guard regression pass here.
+    """
+
+    def __init__(self) -> None:
+        self.id = _USER
+        self.active_workspace = _WS
+        self.workspaces = [_FakeMembership(_WS)]
+
+
+@pytest_asyncio.fixture
+async def agents_client(mongo_db):
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.cloud.agents.router import router as agents_router
+    from pocketpaw_ee.cloud.auth import current_active_user
+    from pocketpaw_ee.cloud.license import require_license
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(agents_router, prefix="/api/v1")
+    app.dependency_overrides[require_license] = lambda: None
+    app.dependency_overrides[current_active_user] = lambda: _FakeUser()
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+def _create_body(**overrides):
+    body = {
+        "name": "Mailer",
+        "slug": "mailer",
+        # Soul materialization touches the filesystem; every sibling test opts out.
+        "soul_enabled": False,
+    }
+    body.update(overrides)
+    return body
+
+
+async def _create(client, **overrides):
+    resp = await client.post("/api/v1/agents", json=_create_body(**overrides))
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+# ---------------------------------------------------------------------------
+# Create → read
+# ---------------------------------------------------------------------------
+
+
+async def test_create_accepts_and_get_returns_both_fields(agents_client) -> None:
+    created = await _create(
+        agents_client,
+        senses=["paw.email.v1", "paw.calendar.v1"],
+        sense_prefs={"paw.email.v1": "gmail"},
+    )
+    assert created["config"]["senses"] == ["paw.email.v1", "paw.calendar.v1"]
+    assert created["config"]["sense_prefs"] == {"paw.email.v1": "gmail"}
+
+    fetched = await agents_client.get(f"/api/v1/agents/{created['_id']}")
+    assert fetched.status_code == 200, fetched.text
+    assert fetched.json()["config"]["senses"] == ["paw.email.v1", "paw.calendar.v1"]
+    assert fetched.json()["config"]["sense_prefs"] == {"paw.email.v1": "gmail"}
+
+
+async def test_create_without_sense_fields_is_unchanged(agents_client) -> None:
+    """Empty is "inherit the workspace surface" — an old client that never sends
+    the fields must still get exactly that."""
+    created = await _create(agents_client)
+    assert created["config"]["senses"] == []
+    assert created["config"]["sense_prefs"] == {}
+
+
+async def test_list_also_emits_the_fields(agents_client) -> None:
+    await _create(agents_client, senses=["paw.code.v1"])
+    resp = await agents_client.get("/api/v1/agents")
+    assert resp.status_code == 200, resp.text
+    rows = [a for a in resp.json() if a["uname"] == "mailer"]
+    assert rows and rows[0]["config"]["senses"] == ["paw.code.v1"]
+
+
+# ---------------------------------------------------------------------------
+# Update — both branches
+# ---------------------------------------------------------------------------
+
+
+async def test_patch_explicit_fields_sets_both(agents_client) -> None:
+    created = await _create(agents_client)
+    resp = await agents_client.patch(
+        f"/api/v1/agents/{created['_id']}",
+        json={"senses": ["paw.email.v1"], "sense_prefs": {"paw.email.v1": "gmail"}},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["config"]["senses"] == ["paw.email.v1"]
+    assert resp.json()["config"]["sense_prefs"] == {"paw.email.v1": "gmail"}
+
+
+async def test_patch_nested_config_sets_both(agents_client) -> None:
+    """The documented payload shape in docs/api-reference.md."""
+    created = await _create(agents_client)
+    resp = await agents_client.patch(
+        f"/api/v1/agents/{created['_id']}",
+        json={"config": {"senses": ["paw.code.v1"], "sense_prefs": {"paw.code.v1": "gitlab"}}},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["config"]["senses"] == ["paw.code.v1"]
+    assert resp.json()["config"]["sense_prefs"] == {"paw.code.v1": "gitlab"}
+
+
+async def test_unrelated_patch_does_not_erase_the_mount_list(agents_client) -> None:
+    """The load-bearing round-trip: the config-dict branch of ``_apply_update``
+    rebuilds the whole spec from an explicit field list, so a field it forgets to
+    name is ERASED — and erasing ``senses`` silently WIDENS the agent back to the
+    workspace's entire sense surface."""
+    created = await _create(
+        agents_client,
+        senses=["paw.email.v1"],
+        sense_prefs={"paw.email.v1": "gmail"},
+    )
+    agent_id = created["_id"]
+
+    # Touch something else entirely, once per update branch.
+    via_config = await agents_client.patch(
+        f"/api/v1/agents/{agent_id}", json={"config": {"temperature": 0.4}}
+    )
+    assert via_config.status_code == 200, via_config.text
+    assert via_config.json()["config"]["senses"] == ["paw.email.v1"]
+    assert via_config.json()["config"]["sense_prefs"] == {"paw.email.v1": "gmail"}
+
+    via_explicit = await agents_client.patch(
+        f"/api/v1/agents/{agent_id}", json={"model": "claude-x"}
+    )
+    assert via_explicit.status_code == 200, via_explicit.text
+    assert via_explicit.json()["config"]["senses"] == ["paw.email.v1"]
+    assert via_explicit.json()["config"]["sense_prefs"] == {"paw.email.v1": "gmail"}
+
+    # …and it is really persisted, not just echoed back.
+    fetched = await agents_client.get(f"/api/v1/agents/{agent_id}")
+    assert fetched.json()["config"]["senses"] == ["paw.email.v1"]
+
+
+async def test_patch_can_clear_the_mount_list(agents_client) -> None:
+    """Carry-forward must not make the field write-once: an explicit empty list is
+    a real value ("go back to inheriting"), not "leave unchanged"."""
+    created = await _create(agents_client, senses=["paw.email.v1"])
+    resp = await agents_client.patch(f"/api/v1/agents/{created['_id']}", json={"senses": []})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["config"]["senses"] == []
+
+
+# ---------------------------------------------------------------------------
+# Validation — a bogus id is a 4xx, on every path in
+# ---------------------------------------------------------------------------
+
+
+def _assert_422_mentions(resp, fragment: str) -> None:
+    assert resp.status_code == 422, f"expected 422, got {resp.status_code}: {resp.text}"
+    assert fragment in resp.text, resp.text
+
+
+async def test_create_rejects_unknown_core_sense_id(agents_client) -> None:
+    resp = await agents_client.post(
+        "/api/v1/agents", json=_create_body(senses=["paw.telepathy.v1"])
+    )
+    _assert_422_mentions(resp, "unknown core sense id")
+
+
+async def test_create_rejects_malformed_sense_pref_key(agents_client) -> None:
+    resp = await agents_client.post(
+        "/api/v1/agents", json=_create_body(sense_prefs={"not an id": "gmail"})
+    )
+    _assert_422_mentions(resp, "malformed")
+
+
+async def test_create_accepts_vendor_extension_ids(agents_client) -> None:
+    """Only the closed ``paw.*`` set is policed; the extension space is open."""
+    created = await _create(
+        agents_client, senses=["acme.crm.v1"], sense_prefs={"acme.crm.v1": "salesforce"}
+    )
+    assert created["config"]["senses"] == ["acme.crm.v1"]
+
+
+async def test_patch_explicit_field_rejects_bogus_id(agents_client) -> None:
+    created = await _create(agents_client)
+    resp = await agents_client.patch(
+        f"/api/v1/agents/{created['_id']}", json={"senses": ["paw.telepathy.v1"]}
+    )
+    _assert_422_mentions(resp, "unknown core sense id")
+
+
+async def test_patch_nested_config_rejects_bogus_id(agents_client) -> None:
+    """The path that used to reach the Beanie validator from inside the service —
+    a pydantic ValidationError the CloudError handler never sees, i.e. a 500."""
+    created = await _create(agents_client)
+    resp = await agents_client.patch(
+        f"/api/v1/agents/{created['_id']}", json={"config": {"senses": ["paw.telepathy.v1"]}}
+    )
+    _assert_422_mentions(resp, "unknown core sense id")
+
+
+async def test_patch_nested_config_rejects_bogus_pref_key(agents_client) -> None:
+    created = await _create(agents_client)
+    resp = await agents_client.patch(
+        f"/api/v1/agents/{created['_id']}",
+        json={"config": {"sense_prefs": {"paw.telepathy.v1": "gmail"}}},
+    )
+    _assert_422_mentions(resp, "unknown core sense id")
+
+
+async def test_a_rejected_update_leaves_the_stored_config_alone(agents_client) -> None:
+    """A 422 must be a no-op, not a half-applied write."""
+    created = await _create(agents_client, senses=["paw.email.v1"])
+    agent_id = created["_id"]
+
+    resp = await agents_client.patch(
+        f"/api/v1/agents/{agent_id}",
+        json={"model": "claude-x", "senses": ["paw.telepathy.v1"]},
+    )
+    assert resp.status_code == 422, resp.text
+
+    fetched = await agents_client.get(f"/api/v1/agents/{agent_id}")
+    assert fetched.json()["config"]["senses"] == ["paw.email.v1"]
+    assert fetched.json()["config"]["model"] == ""

--- a/tests/cloud/chat/test_execute_run_identity.py
+++ b/tests/cloud/chat/test_execute_run_identity.py
@@ -19,15 +19,25 @@
 # The fix must (1) fall back to the trusted spec workspace when the doc's is
 # empty, (2) reject a spec that DISAGREES with a non-empty doc workspace
 # (cross-tenant guard), and (3) make attach_agent_identity reject empty ids.
+#
+# Updated: 2026-08-01 (Sense Phase 2, SP2-1) — added the agent-identity block at
+# the bottom of this module: attach binds the running agent's id, an in-process
+# MCP-tool-shaped callee reads it back through current_agent_id() (including from
+# a spawned task, the shape an SDK tool call actually runs in), an unbound caller
+# still sees None, and detach leaves NO residue. The leak guard is the point: a
+# stale agent id surviving a detach is the same class of bug as the warm-client
+# role bleed, where one caller's identity froze onto a later caller's turn.
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from pocketpaw_ee.cloud.chat.agent_service import (
     attach_agent_identity,
+    current_agent_id,
     current_user_id,
     current_workspace_id,
     detach_agent_identity,
@@ -219,3 +229,92 @@ def test_attach_agent_identity_rejects_empty_workspace():
 def test_attach_agent_identity_rejects_empty_user():
     with pytest.raises(ValueError):
         attach_agent_identity(workspace_id=SPEC_WORKSPACE, user_id="")
+
+
+# ===========================================================================
+# SP2-1 — the running agent's id reaches the in-process MCP layer.
+#
+# An in-process MCP tool has no FastAPI request scope; it resolves who it is
+# running for off the identity ContextVars (the same way the fabric / connector
+# servers resolve workspace and pocket). These tests drive the real attach seam
+# and read the id back from a callee shaped like one of those tools.
+# ===========================================================================
+
+RUNNING_AGENT = "agent_pp"
+
+
+def _mcp_tool_reads_running_agent() -> str | None:
+    """Stand-in for an in-process MCP tool handler: no arguments, no request
+    scope, resolves the running agent purely from the ambient identity."""
+    return current_agent_id()
+
+
+def test_attach_binds_the_running_agent_for_mcp_tools():
+    tokens = attach_agent_identity(
+        workspace_id=SPEC_WORKSPACE, user_id=SPEC_USER, agent_id=RUNNING_AGENT
+    )
+    try:
+        assert _mcp_tool_reads_running_agent() == RUNNING_AGENT
+    finally:
+        detach_agent_identity(tokens)
+
+
+def test_agent_id_is_none_when_the_caller_binds_none():
+    """Every pre-SP2-1 caller omits ``agent_id``; they must keep binding None."""
+    tokens = attach_agent_identity(workspace_id=SPEC_WORKSPACE, user_id=SPEC_USER)
+    try:
+        assert _mcp_tool_reads_running_agent() is None
+        # The rest of the identity is untouched by the wider tuple.
+        assert current_workspace_id() == SPEC_WORKSPACE
+        assert current_user_id() == SPEC_USER
+    finally:
+        detach_agent_identity(tokens)
+
+
+def test_detach_leaves_no_agent_id_behind():
+    """Leak guard: an agent id that survives its own run would bleed onto the
+    next caller in the same context — the failure mode the warm-client role
+    bleed already cost us once."""
+    assert current_agent_id() is None
+    tokens = attach_agent_identity(
+        workspace_id=SPEC_WORKSPACE, user_id=SPEC_USER, agent_id=RUNNING_AGENT
+    )
+    assert current_agent_id() == RUNNING_AGENT
+    detach_agent_identity(tokens)
+    assert current_agent_id() is None
+
+
+def test_nested_binds_restore_the_outer_agent():
+    """A second agent bound inside the first's window must not outlive it."""
+    outer = attach_agent_identity(
+        workspace_id=SPEC_WORKSPACE, user_id=SPEC_USER, agent_id="agent_outer"
+    )
+    try:
+        inner = attach_agent_identity(
+            workspace_id=SPEC_WORKSPACE, user_id=SPEC_USER, agent_id="agent_inner"
+        )
+        assert current_agent_id() == "agent_inner"
+        detach_agent_identity(inner)
+        assert current_agent_id() == "agent_outer"
+    finally:
+        detach_agent_identity(outer)
+    assert current_agent_id() is None
+
+
+@pytest.mark.asyncio
+async def test_agent_id_propagates_into_a_spawned_task():
+    """MCP tool calls run inside tasks the SDK spawns under the run, so the
+    binding has to survive ``create_task``'s context copy — the same property
+    workspace/pocket rely on."""
+
+    async def _tool_call() -> str | None:
+        await asyncio.sleep(0)
+        return _mcp_tool_reads_running_agent()
+
+    tokens = attach_agent_identity(
+        workspace_id=SPEC_WORKSPACE, user_id=SPEC_USER, agent_id=RUNNING_AGENT
+    )
+    try:
+        assert await asyncio.create_task(_tool_call()) == RUNNING_AGENT
+    finally:
+        detach_agent_identity(tokens)

--- a/tests/cloud/runs/test_run_core_concierge_senses.py
+++ b/tests/cloud/runs/test_run_core_concierge_senses.py
@@ -1,0 +1,270 @@
+# tests/cloud/runs/test_run_core_concierge_senses.py
+# Created 2026-08-02 (Sense Phase 2, SP2-4 — concierge surface opt-in for carried
+# senses) — pins the FAIL-CLOSED conditional grant that gives a public site
+# concierge hands, and only when its owner mounted senses on the agent:
+#   * _concierge_sense_policy (pure unit): CONCIERGE + non-empty config.senses
+#     unions the two sense tool ids into the surface allow-list; CONCIERGE +
+#     empty/absent senses DENIES both ids instead (deny, not mere absence, is
+#     what makes SP2-3's "empty = inherit" unreachable on a public surface);
+#     every non-concierge scope returns its inputs untouched; dict AND object
+#     configs both work; an unrestricted (None) allow-list is never turned into
+#     a restriction.
+#   * _drive_agent_loop wiring: the run_kwargs a concierge run hands the pool
+#     carry the grant / the deny accordingly, an EXCLUSIVE concierge agent that
+#     declares the ids itself still cannot get them past the deny when unmounted
+#     (the airtight case), and a SESSION run is byte-identical to today.
+# The raw connector tool ids are asserted ABSENT throughout — this slice opens
+# the sense surface only.
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.agent.mcp_servers.connectors import (  # noqa: E402
+    CONNECTOR_EXECUTE_TOOL_ID,
+    LIST_CONNECTOR_ACTIONS_TOOL_ID,
+    LIST_SENSES_TOOL_ID,
+    SENSE_EXECUTE_TOOL_ID,
+)
+from pocketpaw_ee.cloud.chat.agent_service import ScopeContext, ScopeKind  # noqa: E402
+from pocketpaw_ee.cloud.chat.runs import run_core  # noqa: E402
+
+SENSE_IDS = frozenset({LIST_SENSES_TOOL_ID, SENSE_EXECUTE_TOOL_ID})
+RAW_CONNECTOR_IDS = frozenset({LIST_CONNECTOR_ACTIONS_TOOL_ID, CONNECTOR_EXECUTE_TOOL_ID})
+
+
+def _instance(config: Any) -> Any:
+    return SimpleNamespace(config=config)
+
+
+def _ctx(kind: ScopeKind = ScopeKind.CONCIERGE) -> ScopeContext:
+    return ScopeContext(
+        kind=kind,
+        scope_id="pk_site_1",
+        workspace_id="w1",
+        user_id="anon_visitor",
+        members=[],
+        target_agent_id="a_concierge",
+        pocket_id="pk_site_1",
+    )
+
+
+# ---------------------------------------------------------------------------
+# _concierge_sense_policy (pure unit)
+# ---------------------------------------------------------------------------
+
+
+def test_mounted_concierge_gets_the_sense_tools():
+    """A site agent carrying senses has the two ids unioned into the surface
+    allow-list, so they survive the concierge lockdown."""
+    deny, allow = run_core._concierge_sense_policy(
+        _ctx(),
+        _instance({"senses": ["paw.email.v1"]}),
+        frozenset({"WebFetch"}),
+        frozenset({"mcp__pawbar_actions__pawbar_book"}),
+    )
+    assert allow is not None
+    assert SENSE_IDS <= allow
+    # The widget's own action tool is preserved, not replaced.
+    assert "mcp__pawbar_actions__pawbar_book" in allow
+    # Deny is untouched, and the RAW connector surface is never granted.
+    assert deny == frozenset({"WebFetch"})
+    assert not (RAW_CONNECTOR_IDS & allow)
+
+
+def test_unmounted_concierge_is_denied_not_merely_ungranted():
+    """The load-bearing half: an EMPTY mount list DENIES the ids. Absence from
+    the allow-list alone would leave other grant paths able to re-add them."""
+    deny, allow = run_core._concierge_sense_policy(
+        _ctx(),
+        _instance({"senses": []}),
+        frozenset({"WebFetch"}),
+        frozenset(),
+    )
+    assert SENSE_IDS <= deny
+    assert "WebFetch" in deny
+    assert allow == frozenset()
+
+
+def test_concierge_with_no_senses_key_is_denied():
+    """A config predating the field (no ``senses`` key) is unmounted → denied.
+    Fail-closed is the default for anything that isn't an explicit opt-in."""
+    deny, allow = run_core._concierge_sense_policy(_ctx(), _instance({}), frozenset(), frozenset())
+    assert SENSE_IDS <= deny
+    assert allow == frozenset()
+
+
+def test_object_config_is_supported_both_ways():
+    """The reader tolerates an object config (getattr path), like _agent_tool_policy."""
+    mounted = SimpleNamespace(senses=["paw.calendar.v1"])
+    _, allow = run_core._concierge_sense_policy(
+        _ctx(), _instance(mounted), frozenset(), frozenset()
+    )
+    assert allow is not None and SENSE_IDS <= allow
+
+    unmounted = SimpleNamespace(senses=[])
+    deny, _ = run_core._concierge_sense_policy(
+        _ctx(), _instance(unmounted), frozenset(), frozenset()
+    )
+    assert SENSE_IDS <= deny
+
+
+def test_unrestricted_allow_list_is_not_turned_into_a_restriction():
+    """``allow_mcp is None`` means the surface set NO MCP restriction. Unioning
+    would invent one and strip every other tool, so a mounted agent leaves it
+    None (the tools already flow)."""
+    deny, allow = run_core._concierge_sense_policy(
+        _ctx(), _instance({"senses": ["paw.email.v1"]}), frozenset(), None
+    )
+    assert allow is None
+    assert deny == frozenset()
+
+
+def test_unmounted_concierge_is_denied_even_with_no_restriction():
+    """The deny half still applies when the allow-list is unrestricted — that is
+    the path an ``exclusive`` agent or a missing profile would otherwise take."""
+    deny, allow = run_core._concierge_sense_policy(
+        _ctx(), _instance({"senses": []}), frozenset(), None
+    )
+    assert SENSE_IDS <= deny
+    assert allow is None
+
+
+@pytest.mark.parametrize(
+    "kind",
+    [ScopeKind.SESSION, ScopeKind.POCKET, ScopeKind.DM, ScopeKind.GROUP],
+)
+def test_non_concierge_scopes_are_untouched(kind):
+    """DM / pocket / session runs keep SP2-3's documented empty=inherit
+    semantics — this slice changes nothing off the public surface."""
+    deny_in, allow_in = frozenset({"WebFetch"}), frozenset({"mcp__x__y"})
+    for config in ({"senses": []}, {"senses": ["paw.email.v1"]}, {}):
+        deny, allow = run_core._concierge_sense_policy(
+            _ctx(kind), _instance(config), deny_in, allow_in
+        )
+        assert deny == deny_in
+        assert allow == allow_in
+
+
+# ---------------------------------------------------------------------------
+# _drive_agent_loop → run_kwargs wiring
+# ---------------------------------------------------------------------------
+
+
+def _profile(*, allow_mcp: frozenset[str] | None, deny: frozenset[str] = frozenset()) -> Any:
+    return SimpleNamespace(
+        deny_mcp_tool_ids=deny,
+        allowed_sdk_tools=frozenset(),
+        allow_mcp_tool_ids=allow_mcp,
+        system_message_override=None,
+        skill_names=frozenset(),
+    )
+
+
+async def _drain_run_kwargs(monkeypatch, ctx, agent_config: dict[str, Any]) -> dict[str, Any]:
+    """Drive _drive_agent_loop far enough to capture the run_kwargs the pool.run
+    seam receives. Mirrors the harness in test_run_core_agent_tool_policy.py."""
+    captured: dict[str, Any] = {}
+
+    class _FakePool:
+        async def get(self, _agent_id):
+            return SimpleNamespace(config=agent_config, agent_name="Concierge")
+
+        def run(self, agent_id, content, session_key, **run_kwargs):
+            captured["run_kwargs"] = run_kwargs
+
+            async def _gen():
+                return
+                yield  # pragma: no cover
+
+            return _gen()
+
+    monkeypatch.setattr(run_core, "get_agent_pool", lambda: _FakePool())
+
+    async def _fake_knowledge(*a, **k):
+        return ""
+
+    monkeypatch.setattr(run_core, "build_knowledge_context", _fake_knowledge)
+    monkeypatch.setattr(run_core, "build_behavior_instructions", lambda ctx, backend_name=None: "")
+    monkeypatch.setattr(run_core, "attach_sse_event_sink", lambda q: None)
+    monkeypatch.setattr(run_core, "attach_agent_identity", lambda **k: None)
+    monkeypatch.setattr(run_core, "detach_sse_event_sink", lambda t: None)
+    monkeypatch.setattr(run_core, "detach_agent_identity", lambda t: None)
+
+    async def _never_cancelled():
+        return False
+
+    gen = run_core._drive_agent_loop(
+        ctx,
+        user_content="do you deliver on sundays?",
+        attachments_in=None,
+        mentions_in=None,
+        history=None,
+        is_cancelled=_never_cancelled,
+        emit_stream_start=False,
+    )
+    async for _ in gen:
+        pass
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_run_kwargs_grant_sense_tools_for_mounted_concierge(monkeypatch):
+    ctx = _ctx()
+    ctx.resolved_profile = _profile(allow_mcp=frozenset({"mcp__pawbar_actions__pawbar_book"}))
+    rk = (await _drain_run_kwargs(monkeypatch, ctx, {"senses": ["paw.email.v1"]}))["run_kwargs"]
+
+    assert SENSE_IDS <= rk["allow_mcp_tool_ids"]
+    assert "mcp__pawbar_actions__pawbar_book" in rk["allow_mcp_tool_ids"]
+    assert not (SENSE_IDS & rk["deny_mcp_tool_ids"])
+    # Raw connector tools are NOT part of this unlock.
+    assert not (RAW_CONNECTOR_IDS & rk["allow_mcp_tool_ids"])
+
+
+@pytest.mark.asyncio
+async def test_run_kwargs_deny_sense_tools_for_unmounted_concierge(monkeypatch):
+    ctx = _ctx()
+    ctx.resolved_profile = _profile(allow_mcp=frozenset())
+    rk = (await _drain_run_kwargs(monkeypatch, ctx, {"senses": []}))["run_kwargs"]
+
+    assert SENSE_IDS <= rk["deny_mcp_tool_ids"]
+    assert not (SENSE_IDS & rk["allow_mcp_tool_ids"])
+
+
+@pytest.mark.asyncio
+async def test_unmounted_exclusive_concierge_cannot_self_grant(monkeypatch):
+    """The airtight case. An EXCLUSIVE agent's declared tools OVERRIDE the
+    surface allow-list (CX-2), so the allow-list alone could not stop it. The
+    deny half still does: the backend subtracts deny from the final tool list
+    before any grant re-adds anything, so an unmounted public concierge cannot
+    hand itself the sense surface by declaring the ids."""
+    ctx = _ctx()
+    ctx.resolved_profile = _profile(allow_mcp=frozenset())
+    rk = (
+        await _drain_run_kwargs(
+            monkeypatch,
+            ctx,
+            {"tool_mode": "exclusive", "tools": list(SENSE_IDS), "senses": []},
+        )
+    )["run_kwargs"]
+
+    assert rk["exclusive_mcp_tools"] is True
+    # It kept its declared ids on the allow-list (CX-2 precedence is unchanged) …
+    assert SENSE_IDS <= rk["allow_mcp_tool_ids"]
+    # … and they are denied anyway, which is what the backend applies first.
+    assert SENSE_IDS <= rk["deny_mcp_tool_ids"]
+
+
+@pytest.mark.asyncio
+async def test_non_concierge_run_is_byte_identical(monkeypatch):
+    """A SESSION run with the same agent config is untouched — no grant, no deny."""
+    ctx = _ctx(ScopeKind.SESSION)
+    ctx.resolved_profile = _profile(allow_mcp=frozenset({"mcp__surface__tool"}))
+    rk = (await _drain_run_kwargs(monkeypatch, ctx, {"senses": []}))["run_kwargs"]
+
+    assert rk["allow_mcp_tool_ids"] == frozenset({"mcp__surface__tool"})
+    assert rk["deny_mcp_tool_ids"] == frozenset()

--- a/tests/cloud/senses/test_resolver.py
+++ b/tests/cloud/senses/test_resolver.py
@@ -10,6 +10,15 @@
 # all-resolve, partial-None, ambiguity preserved, and a query-count assertion
 # that the enabled-connector READ runs exactly ONCE for N senses (spying on
 # ConnectorSenseFiller.enabled_connector_names).
+# Updated: 2026-08-02 (Sense Phase 2, SP2-2) — coverage for the AGENT tier:
+# an ``AgentSenseContext`` pref beats both the workspace and the pocket
+# preference row; a pref for another sense doesn't leak; a pref naming a
+# NON-candidate is skipped (one INFO log) and falls through to the stored
+# preference (or to the ambiguous deterministic pick when there is none); a pref
+# can't conjure a provider where none is enabled; ``agent=None`` and the omitted
+# keyword resolve identically to the legacy path; ``resolve_many`` and
+# ``execute_sense`` honour the pref (execute runs against the PREFERRED
+# connector); and the carried ``senses`` mount list does NOT gate yet (SP2-3).
 
 from __future__ import annotations
 
@@ -281,3 +290,175 @@ async def test_execute_sense_delegates_with_preferred_provider(monkeypatch) -> N
     assert result.connector_name == "github"
     spy.assert_awaited_once()
     assert spy.await_args.args[1] == "github"
+
+
+# ---------------------------------------------------------------------------
+# Agent tier (SP2-2) — the running agent's own pref outranks the stored rows
+# ---------------------------------------------------------------------------
+
+
+def _agent(prefs: dict[str, str], agent_id: str = "ag-1") -> resolver.AgentSenseContext:
+    return resolver.AgentSenseContext(agent_id=agent_id, prefs=prefs)
+
+
+async def test_agent_pref_beats_workspace_preference_row() -> None:
+    await _enable("github")
+    await _enable("gitlab")
+    await preference.set_preference(WS, "paw.code.v1", "github")
+
+    result = await resolver.resolve("paw.code.v1", WS, agent=_agent({"paw.code.v1": "gitlab"}))
+
+    assert result is not None
+    assert result.connector_name == "gitlab"
+    assert result.ambiguous is False
+    assert result.candidates == ["github", "gitlab"]
+
+
+async def test_agent_pref_beats_pocket_preference_row() -> None:
+    # The pocket row is the narrowest stored scope — the agent still outranks it.
+    await _enable("github")
+    await _enable("gitlab")
+    await preference.set_preference(WS, "paw.code.v1", "github", pocket_id="pk1")
+
+    result = await resolver.resolve(
+        "paw.code.v1", WS, pocket_id="pk1", agent=_agent({"paw.code.v1": "gitlab"})
+    )
+
+    assert result is not None
+    assert result.connector_name == "gitlab"
+    assert result.ambiguous is False
+
+
+async def test_agent_pref_for_other_sense_does_not_leak() -> None:
+    # A pref keyed to a DIFFERENT sense must not steer this one.
+    await _enable("github")
+    await _enable("gitlab")
+    await preference.set_preference(WS, "paw.code.v1", "github")
+
+    result = await resolver.resolve("paw.code.v1", WS, agent=_agent({"paw.email.v1": "gitlab"}))
+
+    assert result is not None
+    assert result.connector_name == "github"  # the stored row still decides
+
+
+async def test_agent_pref_not_a_candidate_falls_through_to_stored_preference(caplog) -> None:
+    # A pref naming a provider that isn't a candidate (never enabled, disabled,
+    # typo) is SKIPPED — one log line, then the stored preference decides.
+    await _enable("github")
+    await _enable("gitlab")
+    await preference.set_preference(WS, "paw.code.v1", "gitlab")
+
+    with caplog.at_level("INFO", logger="pocketpaw_ee.cloud.senses.resolver"):
+        result = await resolver.resolve(
+            "paw.code.v1", WS, agent=_agent({"paw.code.v1": "bitbucket"})
+        )
+
+    assert result is not None
+    assert result.connector_name == "gitlab"  # stored preference, not the agent's
+    assert result.ambiguous is False
+    skips = [r for r in caplog.records if "agent sense pref skipped" in r.message]
+    assert len(skips) == 1
+
+
+async def test_agent_pref_not_a_candidate_and_no_stored_pref_is_ambiguous() -> None:
+    await _enable("github")
+    await _enable("gitlab")
+
+    result = await resolver.resolve("paw.code.v1", WS, agent=_agent({"paw.code.v1": "bitbucket"}))
+
+    assert result is not None
+    assert result.connector_name == "github"  # deterministic sorted-first
+    assert result.ambiguous is True
+
+
+async def test_agent_pref_with_single_candidate_is_a_no_op() -> None:
+    # One candidate: preferring it changes nothing, and preferring something
+    # else must not strand the sense.
+    await _enable("gmail")
+
+    preferred = await resolver.resolve("paw.email.v1", WS, agent=_agent({"paw.email.v1": "gmail"}))
+    assert preferred is not None
+    assert preferred.connector_name == "gmail"
+    assert preferred.ambiguous is False
+
+    bogus = await resolver.resolve("paw.email.v1", WS, agent=_agent({"paw.email.v1": "outlook"}))
+    assert bogus is not None
+    assert bogus.connector_name == "gmail"
+
+
+async def test_agent_pref_cannot_conjure_a_provider() -> None:
+    # No enabled connector fills the sense — an agent pref does NOT create one.
+    result = await resolver.resolve("paw.code.v1", WS, agent=_agent({"paw.code.v1": "gitlab"}))
+    assert result is None
+
+
+async def test_agent_none_matches_legacy_resolution() -> None:
+    await _enable("github")
+    await _enable("gitlab")
+    await preference.set_preference(WS, "paw.code.v1", "github")
+
+    explicit_none = await resolver.resolve("paw.code.v1", WS, agent=None)
+    omitted = await resolver.resolve("paw.code.v1", WS)
+
+    assert explicit_none == omitted
+    assert omitted is not None
+    assert omitted.connector_name == "github"
+
+
+async def test_resolve_many_honours_agent_prefs() -> None:
+    await _enable("gmail")
+    await _enable("github")
+    await _enable("gitlab")
+    await preference.set_preference(WS, "paw.code.v1", "github")
+
+    out = await resolver.resolve_many(
+        ["paw.email.v1", "paw.code.v1"], WS, agent=_agent({"paw.code.v1": "gitlab"})
+    )
+
+    assert out["paw.code.v1"].connector_name == "gitlab"
+    assert out["paw.code.v1"].ambiguous is False
+    # The unpreferred sense resolves exactly as before.
+    assert out["paw.email.v1"].connector_name == "gmail"
+
+
+async def test_resolve_many_matches_resolve_per_sense_with_agent() -> None:
+    await _enable("github")
+    await _enable("gitlab")
+    agent = _agent({"paw.code.v1": "gitlab"})
+
+    batch = await resolver.resolve_many(["paw.code.v1"], WS, agent=agent)
+    single = await resolver.resolve("paw.code.v1", WS, agent=agent)
+
+    assert batch["paw.code.v1"] == single
+
+
+async def test_execute_sense_runs_against_the_agent_preferred_connector(monkeypatch) -> None:
+    """End-to-end: the agent's pref decides which connector actually executes."""
+    await _enable("github")
+    await _enable("gitlab")
+    await preference.set_preference(WS, "paw.code.v1", "github")
+    spy = AsyncMock(return_value=ExecuteActionResponse(success=True, data=[]))
+    monkeypatch.setattr(connectors_service, "execute", spy)
+
+    # list_issues is trust_level=auto on BOTH providers, so the assertion is
+    # about WHICH connector ran, not about the action existing on one of them.
+    result = await resolver.execute_sense(
+        "paw.code.v1", "list_issues", {}, WS, agent=_agent({"paw.code.v1": "gitlab"})
+    )
+
+    assert result.ok is True
+    assert result.connector_name == "gitlab"
+    spy.assert_awaited_once()
+    assert spy.await_args.args[1] == "gitlab"
+
+
+async def test_agent_context_carries_but_does_not_gate_on_senses() -> None:
+    """SP2-2 CARRIES the mount list; gating on it is SP2-3. A sense that is NOT
+    in the agent's ``senses`` still resolves today."""
+    await _enable("gmail")
+    ctx = resolver.AgentSenseContext(agent_id="ag-1", senses=("paw.code.v1",), prefs={})
+
+    result = await resolver.resolve("paw.email.v1", WS, agent=ctx)
+
+    assert result is not None
+    assert result.connector_name == "gmail"

--- a/tests/cloud/senses/test_resolver.py
+++ b/tests/cloud/senses/test_resolver.py
@@ -19,6 +19,19 @@
 # keyword resolve identically to the legacy path; ``resolve_many`` and
 # ``execute_sense`` honour the pref (execute runs against the PREFERRED
 # connector); and the carried ``senses`` mount list does NOT gate yet (SP2-3).
+# Updated: 2026-08-02 (Sense Phase 2, SP2-3) — the mount list now GATES, so the
+# old "carries but doesn't gate" test is INVERTED (that was SP2-2's explicit
+# hand-off marker, not a behaviour we kept). New coverage: a carried sense
+# resolves normally; a non-carried one refuses even though a provider IS enabled
+# (and does zero candidate work — the filler is monkeypatched to explode);
+# ``is_sense_carried`` tells that None apart from a no-provider None; an EMPTY
+# mount list is byte-identical to ``agent=None`` / the legacy call; the gate runs
+# BEFORE the agent pref, so a pref for an unmounted sense is dead config;
+# ``resolve_many`` skips non-carried ids (keeping every input id as a key) and
+# skips even the shared enabled-connector READ when nothing is carried; and
+# ``execute_sense`` returns the structured ``sense.not_carried`` refusal without
+# ever reaching ``connectors_service.execute`` — identically whether or not the
+# workspace has a provider, so the refusal leaks no tenant state.
 
 from __future__ import annotations
 
@@ -452,13 +465,186 @@ async def test_execute_sense_runs_against_the_agent_preferred_connector(monkeypa
     assert spy.await_args.args[1] == "gitlab"
 
 
-async def test_agent_context_carries_but_does_not_gate_on_senses() -> None:
-    """SP2-2 CARRIES the mount list; gating on it is SP2-3. A sense that is NOT
-    in the agent's ``senses`` still resolves today."""
-    await _enable("gmail")
-    ctx = resolver.AgentSenseContext(agent_id="ag-1", senses=("paw.code.v1",), prefs={})
+# ---------------------------------------------------------------------------
+# Mount list (SP2-3) — a non-empty ``senses`` tuple is EXCLUSIVE
+# ---------------------------------------------------------------------------
 
-    result = await resolver.resolve("paw.email.v1", WS, agent=ctx)
+
+def _mounted(
+    senses: tuple[str, ...],
+    prefs: dict[str, str] | None = None,
+    agent_id: str = "ag-1",
+) -> resolver.AgentSenseContext:
+    return resolver.AgentSenseContext(agent_id=agent_id, senses=senses, prefs=prefs or {})
+
+
+async def test_carried_sense_resolves_normally() -> None:
+    await _enable("gmail")
+
+    result = await resolver.resolve("paw.email.v1", WS, agent=_mounted(("paw.email.v1",)))
 
     assert result is not None
     assert result.connector_name == "gmail"
+    assert result.ambiguous is False
+
+
+async def test_non_carried_sense_refuses_even_with_a_provider_enabled() -> None:
+    """The inversion of SP2-2's carry-but-don't-gate test. gmail IS enabled and
+    DOES fill paw.email.v1 — the agent still can't reach it, because its mount
+    list says paw.code.v1 and nothing else."""
+    await _enable("gmail")
+
+    result = await resolver.resolve("paw.email.v1", WS, agent=_mounted(("paw.code.v1",)))
+
+    assert result is None
+    # …and it's distinguishable from "no provider" without another query.
+    ctx = _mounted(("paw.code.v1",))
+    assert resolver.is_sense_carried("paw.email.v1", ctx) is False
+    assert resolver.is_sense_carried("paw.code.v1", ctx) is True
+
+
+async def test_non_carried_sense_does_no_candidate_work(monkeypatch) -> None:
+    """The gate runs BEFORE the registry / Beanie work — a sense the agent
+    doesn't carry costs nothing to refuse."""
+    await _enable("gmail")
+
+    def _boom(self, *a, **kw):  # pragma: no cover - must not run
+        raise AssertionError("candidate lookup ran for a non-carried sense")
+
+    monkeypatch.setattr(filler_mod.ConnectorSenseFiller, "candidates", _boom)
+
+    assert await resolver.resolve("paw.email.v1", WS, agent=_mounted(("paw.code.v1",))) is None
+
+
+async def test_empty_mount_list_is_the_legacy_full_surface() -> None:
+    """Empty == inherit. Identical to ``agent=None`` and to the no-agent call."""
+    await _enable("gmail")
+    empty = resolver.AgentSenseContext(agent_id="ag-1", senses=(), prefs={})
+
+    mounted_empty = await resolver.resolve("paw.email.v1", WS, agent=empty)
+    with_none = await resolver.resolve("paw.email.v1", WS, agent=None)
+    legacy = await resolver.resolve("paw.email.v1", WS)
+
+    assert mounted_empty == with_none == legacy
+    assert mounted_empty is not None
+    assert resolver.is_sense_carried("paw.code.v1", empty) is True
+
+
+async def test_mount_list_gates_before_the_agent_pref() -> None:
+    """A pref for a sense the agent doesn't carry is dead config — the mount
+    gate refuses before the pref is ever read."""
+    await _enable("github")
+    await _enable("gitlab")
+
+    result = await resolver.resolve(
+        "paw.code.v1", WS, agent=_mounted(("paw.email.v1",), {"paw.code.v1": "gitlab"})
+    )
+
+    assert result is None
+
+
+async def test_resolve_many_skips_non_carried_senses() -> None:
+    await _enable("gmail")
+    await _enable("github")
+
+    out = await resolver.resolve_many(
+        ["paw.email.v1", "paw.code.v1"], WS, agent=_mounted(("paw.email.v1",))
+    )
+
+    # Every input id is still a key — only the value changes.
+    assert set(out) == {"paw.email.v1", "paw.code.v1"}
+    assert out["paw.email.v1"] is not None
+    assert out["paw.email.v1"].connector_name == "gmail"
+    assert out["paw.code.v1"] is None
+
+
+async def test_resolve_many_does_no_candidate_work_for_non_carried(monkeypatch) -> None:
+    """The batch skips the intersection per non-carried id, and skips the shared
+    enabled-connector READ entirely when nothing in the batch is carried."""
+    await _enable("gmail")
+    await _enable("github")
+
+    reads = {"n": 0}
+    real_read = filler_mod.ConnectorSenseFiller.enabled_connector_names
+
+    async def _counting(self, workspace_id, *, pocket_id=None):
+        reads["n"] += 1
+        return await real_read(self, workspace_id, pocket_id=pocket_id)
+
+    def _boom(self, sense_id, enabled_names):  # pragma: no cover - must not run
+        raise AssertionError(f"intersection ran for non-carried sense {sense_id}")
+
+    monkeypatch.setattr(filler_mod.ConnectorSenseFiller, "enabled_connector_names", _counting)
+    monkeypatch.setattr(filler_mod.ConnectorSenseFiller, "candidates_from", _boom)
+
+    out = await resolver.resolve_many(
+        ["paw.email.v1", "paw.code.v1"], WS, agent=_mounted(("paw.payments.v1",))
+    )
+
+    assert out == {"paw.email.v1": None, "paw.code.v1": None}
+    assert reads["n"] == 0
+
+
+async def test_resolve_many_empty_mount_list_matches_legacy() -> None:
+    await _enable("gmail")
+    await _enable("github")
+    ids = ["paw.email.v1", "paw.code.v1", "paw.payments.v1"]
+
+    mounted_empty = await resolver.resolve_many(ids, WS, agent=_mounted(()))
+    legacy = await resolver.resolve_many(ids, WS)
+
+    assert mounted_empty == legacy
+
+
+async def test_execute_sense_refuses_a_non_carried_sense(monkeypatch) -> None:
+    """The structured refusal: ok=False with the stable ``sense.not_carried``
+    code, and ``connectors_service.execute`` is NEVER reached."""
+    await _enable("gmail")
+    spy = AsyncMock(return_value=ExecuteActionResponse(success=True, data=[]))
+    monkeypatch.setattr(connectors_service, "execute", spy)
+
+    result = await resolver.execute_sense(
+        "paw.email.v1", "gmail_search", {}, WS, agent=_mounted(("paw.code.v1",))
+    )
+
+    assert result.ok is False
+    assert result.error == resolver.SENSE_NOT_CARRIED == "sense.not_carried"
+    assert result.connector_name is None
+    assert "not mounted on this agent" in (result.message or "")
+    # The refusal names what the agent DOES carry, so the model can re-aim.
+    assert "paw.code.v1" in (result.message or "")
+    spy.assert_not_awaited()
+
+
+async def test_execute_sense_not_carried_refuses_the_same_without_a_provider() -> None:
+    """The refusal must not leak whether the tenant enabled a provider: an agent
+    that doesn't carry the sense gets ``sense.not_carried`` either way."""
+    # Nothing enabled for this workspace at all.
+    result = await resolver.execute_sense(
+        "paw.email.v1", "gmail_search", {}, WS, agent=_mounted(("paw.code.v1",))
+    )
+
+    assert result.error == resolver.SENSE_NOT_CARRIED
+
+
+async def test_execute_sense_runs_a_carried_sense(monkeypatch) -> None:
+    await _enable("gmail")
+    spy = AsyncMock(return_value=ExecuteActionResponse(success=True, data=[]))
+    monkeypatch.setattr(connectors_service, "execute", spy)
+
+    result = await resolver.execute_sense(
+        "paw.email.v1", "gmail_search", {}, WS, agent=_mounted(("paw.email.v1",))
+    )
+
+    assert result.ok is True
+    assert result.connector_name == "gmail"
+    spy.assert_awaited_once()
+
+
+async def test_execute_sense_validates_an_unknown_id_before_the_gate() -> None:
+    """The mount gate doesn't swallow a bogus id — validation runs first, so a
+    typo raises instead of silently reporting "not carried"."""
+    with pytest.raises(SenseValidationError):
+        await resolver.execute_sense(
+            "paw.telepathy.v1", "do_thing", {}, WS, agent=_mounted(("paw.email.v1",))
+        )

--- a/tests/cloud/test_paw_bar_agent_provisioning.py
+++ b/tests/cloud/test_paw_bar_agent_provisioning.py
@@ -15,6 +15,15 @@
 #   * Identity seeding: welcome_message/starters degrade gracefully because the
 #     ASG-1 identity fields are ABSENT on this branch (the created agent carries
 #     neither field); starters ride the frame config payload.
+#
+# Updated 2026-08-02 (Sense Phase 2, SP2-5): added TestSenseSeeding for
+# ``ensure_site_agent``'s ``senses`` / ``sense_prefs`` keywords — set on CREATE,
+# filled on a re-ensure only while the stored value is empty, per FIELD, and never
+# on an agent the site owner doesn't own. The clobber case is the one that matters:
+# provisioning re-runs on every publish, so an owner's hand-edited mount list has
+# to survive it. ``None`` (what every call site passes today) is pinned as a
+# no-behaviour-change path — the hook is deliberately inert, see the provisioning
+# module's header for why.
 
 from __future__ import annotations
 
@@ -677,3 +686,155 @@ class TestFirstPublishProvisioning:
         assert second.id == first.id
         widgets = await store.list_widgets(pocket_id=_POCKET, workspace_id=_WS, limit=10)
         assert len(widgets) == 1, "a second publish must not mint a sibling widget"
+
+
+# --------------------------------------------------------------------------- #
+# Sense seeding (SP2-5)
+# --------------------------------------------------------------------------- #
+
+
+@pytest_asyncio.fixture
+async def bare_store(tmp_path, mongo_db):
+    """A tmp paw-bar store patched in at the source, with no HTTP app.
+
+    ``ensure_site_agent``'s sense keywords are called directly here: no route
+    passes them yet (see the module header's "WHY THE HOOK IS INERT"), so there
+    is no request to fire.
+    """
+    from unittest.mock import patch
+
+    store = PawBarStore(tmp_path / "senses.db")
+    with patch("pocketpaw_ee.api.get_paw_bar_store", return_value=store):
+        yield store
+
+
+class TestSenseSeeding:
+    """``ensure_site_agent(senses=..., sense_prefs=...)`` — set on create, and on a
+    re-ensure only when the stored value is still empty."""
+
+    @pytest.mark.asyncio
+    async def test_create_carries_both_fields(self, bare_store) -> None:
+        from pocketpaw_ee.cloud.agents import service as agents_service
+        from pocketpaw_ee.paw_bar import agent_provisioning as ap
+
+        site = await _site()
+        widget = await bare_store.create_widget(_widget())
+
+        agent_id = await ap.ensure_site_agent(
+            site,
+            widget,
+            senses=["paw.email.v1"],
+            sense_prefs={"paw.email.v1": "gmail"},
+        )
+
+        assert agent_id
+        agent = await agents_service.get(agent_id)
+        assert agent.config.senses == ("paw.email.v1",)
+        assert agent.config.sense_prefs == (("paw.email.v1", "gmail"),)
+
+    @pytest.mark.asyncio
+    async def test_none_leaves_the_config_empty(self, bare_store) -> None:
+        """The default every call site uses today — byte-for-byte the old path."""
+        from pocketpaw_ee.cloud.agents import service as agents_service
+        from pocketpaw_ee.paw_bar import agent_provisioning as ap
+
+        site = await _site()
+        widget = await bare_store.create_widget(_widget())
+
+        agent_id = await ap.ensure_site_agent(site, widget)
+
+        agent = await agents_service.get(agent_id)
+        assert agent.config.senses == ()
+        assert agent.config.sense_prefs == ()
+
+    @pytest.mark.asyncio
+    async def test_reensure_fills_an_empty_mount_list(self, bare_store) -> None:
+        """The agent already exists and is already bound; a later ensure that DOES
+        carry senses still gets to pin them, because nothing is being overwritten."""
+        from pocketpaw_ee.cloud.agents import service as agents_service
+        from pocketpaw_ee.paw_bar import agent_provisioning as ap
+
+        site = await _site()
+        widget = await bare_store.create_widget(_widget())
+        agent_id = await ap.ensure_site_agent(site, widget)
+        bound = await bare_store.get_widget(widget.id, workspace_id=_WS)
+        assert bound.agent_id == agent_id
+
+        again = await ap.ensure_site_agent(site, bound, senses=["paw.email.v1"])
+
+        assert again == agent_id, "a re-ensure must not mint a second agent"
+        agent = await agents_service.get(agent_id)
+        assert agent.config.senses == ("paw.email.v1",)
+
+    @pytest.mark.asyncio
+    async def test_reensure_never_clobbers_an_owner_edit(self, bare_store) -> None:
+        """The rule that matters: ``ensure_site_agent`` re-runs on EVERY publish, so
+        an owner who narrowed their concierge by hand must not have it silently
+        reverted to whatever the provisioner wanted."""
+        from pocketpaw_ee.cloud.agents import service as agents_service
+        from pocketpaw_ee.cloud.agents.dto import UpdateAgentRequest
+        from pocketpaw_ee.paw_bar import agent_provisioning as ap
+
+        site = await _site()
+        widget = await bare_store.create_widget(_widget())
+        agent_id = await ap.ensure_site_agent(site, widget, senses=["paw.email.v1"])
+
+        # The owner edits it in the dashboard.
+        ctx = agents_service.legacy_ctx(_OWNER, _WS)
+        await agents_service.update(ctx, agent_id, UpdateAgentRequest(senses=["paw.code.v1"]))
+
+        bound = await bare_store.get_widget(widget.id, workspace_id=_WS)
+        again = await ap.ensure_site_agent(site, bound, senses=["paw.email.v1"])
+
+        assert again == agent_id
+        agent = await agents_service.get(agent_id)
+        assert agent.config.senses == ("paw.code.v1",), "the owner's edit must win"
+
+    @pytest.mark.asyncio
+    async def test_fields_are_seeded_independently(self, bare_store) -> None:
+        """Per FIELD, not all-or-nothing: an owner-set mount list keeps its value
+        while the still-empty pref is filled."""
+        from pocketpaw_ee.cloud.agents import service as agents_service
+        from pocketpaw_ee.cloud.agents.dto import UpdateAgentRequest
+        from pocketpaw_ee.paw_bar import agent_provisioning as ap
+
+        site = await _site()
+        widget = await bare_store.create_widget(_widget())
+        agent_id = await ap.ensure_site_agent(site, widget)
+
+        ctx = agents_service.legacy_ctx(_OWNER, _WS)
+        await agents_service.update(ctx, agent_id, UpdateAgentRequest(senses=["paw.code.v1"]))
+
+        bound = await bare_store.get_widget(widget.id, workspace_id=_WS)
+        await ap.ensure_site_agent(
+            site,
+            bound,
+            senses=["paw.email.v1"],
+            sense_prefs={"paw.code.v1": "gitlab"},
+        )
+
+        agent = await agents_service.get(agent_id)
+        assert agent.config.senses == ("paw.code.v1",)
+        assert agent.config.sense_prefs == (("paw.code.v1", "gitlab"),)
+
+    @pytest.mark.asyncio
+    async def test_a_foreign_owned_manual_bind_is_left_alone(self, bare_store) -> None:
+        """ "Manual binds are never overwritten" extended to config: a widget a human
+        pointed at somebody ELSE's agent is not reconfigured by this site's owner."""
+        from pocketpaw_ee.cloud.agents import service as agents_service
+        from pocketpaw_ee.cloud.agents.dto import CreateAgentRequest
+        from pocketpaw_ee.paw_bar import agent_provisioning as ap
+
+        site = await _site()
+        stranger_ctx = agents_service.legacy_ctx("user:stranger", _WS)
+        stranger = await agents_service.create(
+            stranger_ctx,
+            _WS,
+            CreateAgentRequest(name="Theirs", slug="theirs", soul_enabled=False),
+        )
+        widget = await bare_store.create_widget(_widget(agent_id=stranger.id))
+
+        bound_id = await ap.ensure_site_agent(site, widget, senses=["paw.email.v1"])
+
+        assert bound_id == stranger.id
+        assert (await agents_service.get(stranger.id)).config.senses == ()

--- a/tests/cloud/test_paw_bar_agent_provisioning.py
+++ b/tests/cloud/test_paw_bar_agent_provisioning.py
@@ -19,6 +19,15 @@
 #     ensure_site_widget carries one gated booking_request action (five str
 #     args, "Book a service visit" label); an EXISTING widget's actions are
 #     never modified by any ensure_site_widget pass (mint-only).
+#
+# Updated 2026-08-02 (Sense Phase 2, SP2-5): added TestSenseSeeding for
+# ``ensure_site_agent``'s ``senses`` / ``sense_prefs`` keywords — set on CREATE,
+# filled on a re-ensure only while the stored value is empty, per FIELD, and never
+# on an agent the site owner doesn't own. The clobber case is the one that matters:
+# provisioning re-runs on every publish, so an owner's hand-edited mount list has
+# to survive it. ``None`` (what every call site passes today) is pinned as a
+# no-behaviour-change path — the hook is deliberately inert, see the provisioning
+# module's header for why.
 
 from __future__ import annotations
 
@@ -741,3 +750,155 @@ class TestFirstPublishProvisioning:
         assert second.id == first.id
         widgets = await store.list_widgets(pocket_id=_POCKET, workspace_id=_WS, limit=10)
         assert len(widgets) == 1, "a second publish must not mint a sibling widget"
+
+
+# --------------------------------------------------------------------------- #
+# Sense seeding (SP2-5)
+# --------------------------------------------------------------------------- #
+
+
+@pytest_asyncio.fixture
+async def bare_store(tmp_path, mongo_db):
+    """A tmp paw-bar store patched in at the source, with no HTTP app.
+
+    ``ensure_site_agent``'s sense keywords are called directly here: no route
+    passes them yet (see the module header's "WHY THE HOOK IS INERT"), so there
+    is no request to fire.
+    """
+    from unittest.mock import patch
+
+    store = PawBarStore(tmp_path / "senses.db")
+    with patch("pocketpaw_ee.api.get_paw_bar_store", return_value=store):
+        yield store
+
+
+class TestSenseSeeding:
+    """``ensure_site_agent(senses=..., sense_prefs=...)`` — set on create, and on a
+    re-ensure only when the stored value is still empty."""
+
+    @pytest.mark.asyncio
+    async def test_create_carries_both_fields(self, bare_store) -> None:
+        from pocketpaw_ee.cloud.agents import service as agents_service
+        from pocketpaw_ee.paw_bar import agent_provisioning as ap
+
+        site = await _site()
+        widget = await bare_store.create_widget(_widget())
+
+        agent_id = await ap.ensure_site_agent(
+            site,
+            widget,
+            senses=["paw.email.v1"],
+            sense_prefs={"paw.email.v1": "gmail"},
+        )
+
+        assert agent_id
+        agent = await agents_service.get(agent_id)
+        assert agent.config.senses == ("paw.email.v1",)
+        assert agent.config.sense_prefs == (("paw.email.v1", "gmail"),)
+
+    @pytest.mark.asyncio
+    async def test_none_leaves_the_config_empty(self, bare_store) -> None:
+        """The default every call site uses today — byte-for-byte the old path."""
+        from pocketpaw_ee.cloud.agents import service as agents_service
+        from pocketpaw_ee.paw_bar import agent_provisioning as ap
+
+        site = await _site()
+        widget = await bare_store.create_widget(_widget())
+
+        agent_id = await ap.ensure_site_agent(site, widget)
+
+        agent = await agents_service.get(agent_id)
+        assert agent.config.senses == ()
+        assert agent.config.sense_prefs == ()
+
+    @pytest.mark.asyncio
+    async def test_reensure_fills_an_empty_mount_list(self, bare_store) -> None:
+        """The agent already exists and is already bound; a later ensure that DOES
+        carry senses still gets to pin them, because nothing is being overwritten."""
+        from pocketpaw_ee.cloud.agents import service as agents_service
+        from pocketpaw_ee.paw_bar import agent_provisioning as ap
+
+        site = await _site()
+        widget = await bare_store.create_widget(_widget())
+        agent_id = await ap.ensure_site_agent(site, widget)
+        bound = await bare_store.get_widget(widget.id, workspace_id=_WS)
+        assert bound.agent_id == agent_id
+
+        again = await ap.ensure_site_agent(site, bound, senses=["paw.email.v1"])
+
+        assert again == agent_id, "a re-ensure must not mint a second agent"
+        agent = await agents_service.get(agent_id)
+        assert agent.config.senses == ("paw.email.v1",)
+
+    @pytest.mark.asyncio
+    async def test_reensure_never_clobbers_an_owner_edit(self, bare_store) -> None:
+        """The rule that matters: ``ensure_site_agent`` re-runs on EVERY publish, so
+        an owner who narrowed their concierge by hand must not have it silently
+        reverted to whatever the provisioner wanted."""
+        from pocketpaw_ee.cloud.agents import service as agents_service
+        from pocketpaw_ee.cloud.agents.dto import UpdateAgentRequest
+        from pocketpaw_ee.paw_bar import agent_provisioning as ap
+
+        site = await _site()
+        widget = await bare_store.create_widget(_widget())
+        agent_id = await ap.ensure_site_agent(site, widget, senses=["paw.email.v1"])
+
+        # The owner edits it in the dashboard.
+        ctx = agents_service.legacy_ctx(_OWNER, _WS)
+        await agents_service.update(ctx, agent_id, UpdateAgentRequest(senses=["paw.code.v1"]))
+
+        bound = await bare_store.get_widget(widget.id, workspace_id=_WS)
+        again = await ap.ensure_site_agent(site, bound, senses=["paw.email.v1"])
+
+        assert again == agent_id
+        agent = await agents_service.get(agent_id)
+        assert agent.config.senses == ("paw.code.v1",), "the owner's edit must win"
+
+    @pytest.mark.asyncio
+    async def test_fields_are_seeded_independently(self, bare_store) -> None:
+        """Per FIELD, not all-or-nothing: an owner-set mount list keeps its value
+        while the still-empty pref is filled."""
+        from pocketpaw_ee.cloud.agents import service as agents_service
+        from pocketpaw_ee.cloud.agents.dto import UpdateAgentRequest
+        from pocketpaw_ee.paw_bar import agent_provisioning as ap
+
+        site = await _site()
+        widget = await bare_store.create_widget(_widget())
+        agent_id = await ap.ensure_site_agent(site, widget)
+
+        ctx = agents_service.legacy_ctx(_OWNER, _WS)
+        await agents_service.update(ctx, agent_id, UpdateAgentRequest(senses=["paw.code.v1"]))
+
+        bound = await bare_store.get_widget(widget.id, workspace_id=_WS)
+        await ap.ensure_site_agent(
+            site,
+            bound,
+            senses=["paw.email.v1"],
+            sense_prefs={"paw.code.v1": "gitlab"},
+        )
+
+        agent = await agents_service.get(agent_id)
+        assert agent.config.senses == ("paw.code.v1",)
+        assert agent.config.sense_prefs == (("paw.code.v1", "gitlab"),)
+
+    @pytest.mark.asyncio
+    async def test_a_foreign_owned_manual_bind_is_left_alone(self, bare_store) -> None:
+        """ "Manual binds are never overwritten" extended to config: a widget a human
+        pointed at somebody ELSE's agent is not reconfigured by this site's owner."""
+        from pocketpaw_ee.cloud.agents import service as agents_service
+        from pocketpaw_ee.cloud.agents.dto import CreateAgentRequest
+        from pocketpaw_ee.paw_bar import agent_provisioning as ap
+
+        site = await _site()
+        stranger_ctx = agents_service.legacy_ctx("user:stranger", _WS)
+        stranger = await agents_service.create(
+            stranger_ctx,
+            _WS,
+            CreateAgentRequest(name="Theirs", slug="theirs", soul_enabled=False),
+        )
+        widget = await bare_store.create_widget(_widget(agent_id=stranger.id))
+
+        bound_id = await ap.ensure_site_agent(site, widget, senses=["paw.email.v1"])
+
+        assert bound_id == stranger.id
+        assert (await agents_service.get(stranger.id)).config.senses == ()

--- a/tests/ee/agent/test_connectors_mcp_server/test_mcp_tool.py
+++ b/tests/ee/agent/test_connectors_mcp_server/test_mcp_tool.py
@@ -28,6 +28,17 @@
 #   ``agent=None`` rather than failing the tool call. ``_patch_identity`` leaves
 #   ``current_agent_id`` alone (it returns None off-stream), so every pre-SP2-2
 #   test here exercises the unchanged ``agent=None`` path.
+# Updated: 2026-08-02 (Sense Phase 2, SP2-3 — the sense MOUNT LIST) — new
+#   ``TestSenseMountList``: the context now carries the agent's real
+#   ``config.senses``; ``list_senses`` batches ONLY carried ids (asserted on the
+#   list handed to ``resolve_many``), reports only the carried set even when the
+#   resolver answers for more, publishes ``carried_senses`` plus a "this is ALL
+#   of them" note, and names the carried senses in its empty-result message; an
+#   EMPTY mount list still batches every CORE sense (today's surface). The
+#   ``sense_execute`` refusal test runs the REAL ``execute_sense`` with the
+#   connector service's ``execute`` spied — which also proves the
+#   ``sense.not_carried`` gate short-circuits ahead of every I/O path, since the
+#   test needs no Mongo at all.
 """MCP server registration + handler tests for connector execution."""
 
 from __future__ import annotations
@@ -952,3 +963,236 @@ class TestAgentSensePrefs:
 
         assert not out.get("is_error")
         assert mock_resolve.await_args.kwargs["agent"] is None
+
+
+# ---------------------------------------------------------------------------
+# Mount list (SP2-3) — list_senses is filtered, sense_execute refuses outside it
+# ---------------------------------------------------------------------------
+
+
+class _StubMountedConfig:
+    """The config surface ``_agent_sense_context`` reads, with a mount list."""
+
+    def __init__(
+        self,
+        senses: tuple[str, ...] = (),
+        sense_prefs: tuple[tuple[str, str], ...] = (),
+    ) -> None:
+        self.senses = senses
+        self.sense_prefs = sense_prefs
+
+
+class _StubMountedAgent:
+    def __init__(
+        self,
+        senses: tuple[str, ...] = (),
+        sense_prefs: tuple[tuple[str, str], ...] = (),
+    ) -> None:
+        self.config = _StubMountedConfig(senses, sense_prefs)
+
+
+class TestSenseMountList:
+    @pytest.mark.asyncio
+    async def test_context_carries_the_agents_mount_list(self) -> None:
+        """The placeholder is gone — the context now carries config.senses."""
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+
+        mock_resolve = AsyncMock(return_value={})
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", "pk_1")
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            _patch_running_agent("ag_1"),
+            patch(
+                "pocketpaw_ee.cloud.agents.service.get",
+                new=AsyncMock(return_value=_StubMountedAgent(senses=("paw.email.v1",))),
+            ),
+            patch("pocketpaw_ee.cloud.senses.resolver.resolve_many", new=mock_resolve),
+        ):
+            await connectors_mcp._list_senses_handler({})
+
+        agent_ctx = mock_resolve.await_args.kwargs["agent"]
+        assert agent_ctx.senses == ("paw.email.v1",)
+
+    @pytest.mark.asyncio
+    async def test_list_senses_only_batches_carried_senses(self) -> None:
+        """A non-carried sense never even enters the resolve_many batch."""
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+
+        mock_resolve = AsyncMock(return_value={})
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", "pk_1")
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            _patch_running_agent("ag_1"),
+            patch(
+                "pocketpaw_ee.cloud.agents.service.get",
+                new=AsyncMock(return_value=_StubMountedAgent(senses=("paw.email.v1",))),
+            ),
+            patch("pocketpaw_ee.cloud.senses.resolver.resolve_many", new=mock_resolve),
+        ):
+            await connectors_mcp._list_senses_handler({})
+
+        assert mock_resolve.await_args.args[0] == ["paw.email.v1"]
+
+    @pytest.mark.asyncio
+    async def test_list_senses_reports_only_the_carried_set(self) -> None:
+        """Even if the resolver answered for a sense outside the mount list, the
+        payload carries only what the agent mounts."""
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+        from pocketpaw_ee.cloud.senses.resolver import ResolvedSense
+
+        async def fake_resolve_many(sense_ids, workspace_id, *, pocket_id=None, agent=None):
+            # Answer for BOTH, including the un-mounted one.
+            return {
+                sid: ResolvedSense(
+                    sense_id=sid,
+                    connector_name="gmail" if sid == "paw.email.v1" else "github",
+                    candidates=["gmail"],
+                )
+                for sid in ["paw.email.v1", "paw.code.v1"]
+            }
+
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", "pk_1")
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            _patch_running_agent("ag_1"),
+            patch(
+                "pocketpaw_ee.cloud.agents.service.get",
+                new=AsyncMock(return_value=_StubMountedAgent(senses=("paw.email.v1",))),
+            ),
+            patch(
+                "pocketpaw_ee.cloud.senses.resolver.resolve_many",
+                new=AsyncMock(side_effect=fake_resolve_many),
+            ),
+        ):
+            out = await connectors_mcp._list_senses_handler({})
+
+        body = _decode_payload(out)
+        assert [s["sense"] for s in body["senses"]] == ["paw.email.v1"]
+        assert body["carried_senses"] == ["paw.email.v1"]
+        # The model is told the listing is exhaustive so it stops retrying.
+        assert "ALL of them" in body["note"]
+
+    @pytest.mark.asyncio
+    async def test_empty_mount_list_lists_the_whole_surface(self) -> None:
+        """Today's behaviour, unchanged: no mount list = every CORE sense is a
+        candidate for listing, and ``carried_senses`` is empty."""
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+
+        from pocketpaw.senses import CORE_SENSES
+
+        mock_resolve = AsyncMock(return_value={})
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", "pk_1")
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            _patch_running_agent("ag_1"),
+            patch(
+                "pocketpaw_ee.cloud.agents.service.get",
+                new=AsyncMock(return_value=_StubMountedAgent(senses=())),
+            ),
+            patch("pocketpaw_ee.cloud.senses.resolver.resolve_many", new=mock_resolve),
+        ):
+            out = await connectors_mcp._list_senses_handler({})
+
+        assert mock_resolve.await_args.args[0] == [s.id for s in CORE_SENSES]
+        assert _decode_payload(out)["carried_senses"] == []
+
+    @pytest.mark.asyncio
+    async def test_empty_list_message_names_the_carried_senses(self) -> None:
+        """Nothing resolves, but the agent DOES carry senses — the message says
+        which, instead of the generic 'connect any provider' line."""
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", "pk_1")
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            _patch_running_agent("ag_1"),
+            patch(
+                "pocketpaw_ee.cloud.agents.service.get",
+                new=AsyncMock(return_value=_StubMountedAgent(senses=("paw.email.v1",))),
+            ),
+            patch(
+                "pocketpaw_ee.cloud.senses.resolver.resolve_many",
+                new=AsyncMock(return_value={"paw.email.v1": None}),
+            ),
+        ):
+            out = await connectors_mcp._list_senses_handler({})
+
+        body = _decode_payload(out)
+        assert body["senses"] == []
+        assert "paw.email.v1" in body["message"]
+        assert body["carried_senses"] == ["paw.email.v1"]
+
+    @pytest.mark.asyncio
+    async def test_sense_execute_outside_the_mount_list_is_refused(self) -> None:
+        """No gate of its own: the real ``execute_sense`` refuses the un-carried
+        sense structurally, and the handler relays it as an MCP error carrying
+        the ``sense.not_carried`` code."""
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+        from pocketpaw_ee.cloud.connectors import service as connectors_service
+
+        execute_spy = AsyncMock()
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", "pk_1")
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            _patch_running_agent("ag_1"),
+            patch(
+                "pocketpaw_ee.cloud.agents.service.get",
+                new=AsyncMock(return_value=_StubMountedAgent(senses=("paw.code.v1",))),
+            ),
+            patch.object(connectors_service, "execute", execute_spy),
+        ):
+            out = await connectors_mcp._sense_execute_handler(
+                {"sense": "paw.email.v1", "action": "gmail_search"}
+            )
+
+        assert out.get("is_error") is True
+        text = out["content"][0]["text"]
+        assert "sense.not_carried" in text
+        assert "paw.code.v1" in text  # tells the agent what it CAN reach
+        execute_spy.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_sense_execute_inside_the_mount_list_passes_through(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+        from pocketpaw_ee.cloud.connectors.dto import ExecuteActionResponse
+        from pocketpaw_ee.cloud.senses.resolver import SenseExecutionResult
+
+        mock_exec = AsyncMock(
+            return_value=SenseExecutionResult(
+                ok=True,
+                sense_id="paw.email.v1",
+                connector_name="gmail",
+                action="gmail_search",
+                data=ExecuteActionResponse(success=True, data=[]),
+            )
+        )
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", "pk_1")
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            _patch_running_agent("ag_1"),
+            patch(
+                "pocketpaw_ee.cloud.agents.service.get",
+                new=AsyncMock(return_value=_StubMountedAgent(senses=("paw.email.v1",))),
+            ),
+            patch("pocketpaw_ee.cloud.senses.resolver.execute_sense", new=mock_exec),
+        ):
+            out = await connectors_mcp._sense_execute_handler(
+                {"sense": "paw.email.v1", "action": "gmail_search"}
+            )
+
+        assert not out.get("is_error")
+        assert mock_exec.await_args.kwargs["agent"].senses == ("paw.email.v1",)

--- a/tests/ee/agent/test_connectors_mcp_server/test_mcp_tool.py
+++ b/tests/ee/agent/test_connectors_mcp_server/test_mcp_tool.py
@@ -19,6 +19,15 @@
 #   trust) actions PROPOSE without ever calling execute inline, connectors not
 #   bound to the pocket are rejected, and a missing pocket / workspace
 #   ContextVar (called off-stream) yields a clear error.
+# Updated: 2026-08-02 (Sense Phase 2, SP2-2 — agent-tier provider preference) —
+#   the two sense handlers now build an ``AgentSenseContext`` from the running
+#   agent (``current_agent_id`` → ``agents.service.get``) and pass it to the
+#   resolver as ``agent=``. New coverage: the context reaches ``resolve_many`` /
+#   ``execute_sense`` carrying the agent's ``sense_prefs``; no bound agent id
+#   passes ``agent=None``; and an agent that fails to load DEGRADES to
+#   ``agent=None`` rather than failing the tool call. ``_patch_identity`` leaves
+#   ``current_agent_id`` alone (it returns None off-stream), so every pre-SP2-2
+#   test here exercises the unchanged ``agent=None`` path.
 """MCP server registration + handler tests for connector execution."""
 
 from __future__ import annotations
@@ -592,7 +601,7 @@ class TestSenseTools:
         from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
         from pocketpaw_ee.cloud.senses.resolver import ResolvedSense
 
-        async def fake_resolve_many(sense_ids, workspace_id, *, pocket_id=None):
+        async def fake_resolve_many(sense_ids, workspace_id, *, pocket_id=None, agent=None):
             return {
                 sid: (
                     ResolvedSense(
@@ -808,3 +817,138 @@ class TestSenseTools:
 
         assert out.get("is_error") is True
         assert "unknown sense" in out["content"][0]["text"]
+
+
+# ---------------------------------------------------------------------------
+# Agent tier (SP2-2) — the running agent's prefs reach the resolver
+# ---------------------------------------------------------------------------
+
+
+class _StubConfig:
+    """Just the config surface ``_agent_sense_context`` reads."""
+
+    def __init__(self, sense_prefs: tuple[tuple[str, str], ...]) -> None:
+        self.sense_prefs = sense_prefs
+
+
+class _StubAgent:
+    def __init__(self, sense_prefs: tuple[tuple[str, str], ...]) -> None:
+        self.config = _StubConfig(sense_prefs)
+
+
+def _patch_running_agent(agent_id: str | None):
+    """Patch the agent-id ContextVar SP2-1 binds."""
+    return patch(
+        "pocketpaw_ee.cloud.chat.agent_service.current_agent_id",
+        return_value=agent_id,
+    )
+
+
+class TestAgentSensePrefs:
+    @pytest.mark.asyncio
+    async def test_list_senses_passes_agent_context_to_resolver(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+
+        mock_resolve = AsyncMock(return_value={})
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", "pk_1")
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            _patch_running_agent("ag_1"),
+            patch(
+                "pocketpaw_ee.cloud.agents.service.get",
+                new=AsyncMock(return_value=_StubAgent((("paw.code.v1", "gitlab"),))),
+            ),
+            patch("pocketpaw_ee.cloud.senses.resolver.resolve_many", new=mock_resolve),
+        ):
+            await connectors_mcp._list_senses_handler({})
+
+        agent_ctx = mock_resolve.await_args.kwargs["agent"]
+        assert agent_ctx is not None
+        assert agent_ctx.agent_id == "ag_1"
+        assert agent_ctx.prefs == {"paw.code.v1": "gitlab"}
+        # The mount list lands in SP2-3 — carried empty for now.
+        assert agent_ctx.senses == ()
+
+    @pytest.mark.asyncio
+    async def test_sense_execute_passes_agent_context_to_resolver(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+        from pocketpaw_ee.cloud.connectors.dto import ExecuteActionResponse
+        from pocketpaw_ee.cloud.senses.resolver import SenseExecutionResult
+
+        mock_exec = AsyncMock(
+            return_value=SenseExecutionResult(
+                ok=True,
+                sense_id="paw.code.v1",
+                connector_name="gitlab",
+                action="list_issues",
+                data=ExecuteActionResponse(success=True, data=[]),
+            )
+        )
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", "pk_1")
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            _patch_running_agent("ag_1"),
+            patch(
+                "pocketpaw_ee.cloud.agents.service.get",
+                new=AsyncMock(return_value=_StubAgent((("paw.code.v1", "gitlab"),))),
+            ),
+            patch("pocketpaw_ee.cloud.senses.resolver.execute_sense", new=mock_exec),
+        ):
+            out = await connectors_mcp._sense_execute_handler(
+                {"sense": "paw.code.v1", "action": "list_issues"}
+            )
+
+        assert not out.get("is_error")
+        agent_ctx = mock_exec.await_args.kwargs["agent"]
+        assert agent_ctx.agent_id == "ag_1"
+        assert agent_ctx.prefs == {"paw.code.v1": "gitlab"}
+
+    @pytest.mark.asyncio
+    async def test_no_bound_agent_resolves_with_agent_none(self) -> None:
+        """Legacy / OSS callers have no agent id bound — the resolver is called
+        exactly as it was before SP2-2, and the agent is never loaded."""
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+
+        mock_resolve = AsyncMock(return_value={})
+        mock_get = AsyncMock()
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", "pk_1")
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            _patch_running_agent(None),
+            patch("pocketpaw_ee.cloud.agents.service.get", new=mock_get),
+            patch("pocketpaw_ee.cloud.senses.resolver.resolve_many", new=mock_resolve),
+        ):
+            await connectors_mcp._list_senses_handler({})
+
+        assert mock_resolve.await_args.kwargs["agent"] is None
+        mock_get.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unloadable_agent_degrades_to_no_prefs(self) -> None:
+        """A pref is a convenience, never a gate: if the agent can't be loaded
+        the tool still resolves, just without the agent tier."""
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+
+        mock_resolve = AsyncMock(return_value={})
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", "pk_1")
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            _patch_running_agent("ag_gone"),
+            patch(
+                "pocketpaw_ee.cloud.agents.service.get",
+                new=AsyncMock(side_effect=RuntimeError("agent not found")),
+            ),
+            patch("pocketpaw_ee.cloud.senses.resolver.resolve_many", new=mock_resolve),
+        ):
+            out = await connectors_mcp._list_senses_handler({})
+
+        assert not out.get("is_error")
+        assert mock_resolve.await_args.kwargs["agent"] is None

--- a/tests/ee/agent/test_connectors_mcp_server/test_mcp_tool.py
+++ b/tests/ee/agent/test_connectors_mcp_server/test_mcp_tool.py
@@ -39,6 +39,17 @@
 #   connector service's ``execute`` spied — which also proves the
 #   ``sense.not_carried`` gate short-circuits ahead of every I/O path, since the
 #   test needs no Mongo at all.
+# Updated: 2026-08-02 (Sense Phase 2, SP2-4) — new ``TestPocketlessSenseSurface``
+#   is a REGRESSION LOCK, not new behavior: it pins that the sense tools are
+#   POCKET-OPTIONAL (a DM / group run with ``pocket_id=None`` lists and executes
+#   the workspace-tier surface, and the null pocket reaches the resolver as
+#   ``None``), that a mount list still scopes such a run, and that
+#   ``workspace_id`` is the ONE hard requirement. Re-adding a "no pocket" guard
+#   to either handler — the shape that existed before the 2026-06-12
+#   workspace-scope reach — now fails these tests loudly instead of silently
+#   disarming every DM-driven and concierge-driven agent. Where that surface is
+#   EXPOSED is a separate concern tested in
+#   ``tests/cloud/runs/test_run_core_concierge_senses.py``.
 """MCP server registration + handler tests for connector execution."""
 
 from __future__ import annotations
@@ -1196,3 +1207,138 @@ class TestSenseMountList:
 
         assert not out.get("is_error")
         assert mock_exec.await_args.kwargs["agent"].senses == ("paw.email.v1",)
+
+
+class TestPocketlessSenseSurface:
+    """SP2-4 regression lock — the SENSE tools are POCKET-OPTIONAL.
+
+    A run with no pocket bound (a DM / group thread) resolves the WORKSPACE-tier
+    sense surface: ``senses.filler`` ignores ``pocket_id`` entirely and
+    ``execute_sense`` takes ``pocket_id=None`` natively. Nothing here is new
+    behavior — these tests exist so that re-adding a "no pocket" guard to either
+    handler FAILS LOUDLY instead of silently taking the hands off every
+    DM-driven and concierge-driven agent. The only identity these tools require
+    is ``workspace_id``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_pocketless_list_senses_resolves_workspace_tier(self) -> None:
+        """No pocket AND no agent bound: still lists, with pocket_id=None reaching
+        the resolver (workspace-tier candidates), not a refusal."""
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+        from pocketpaw_ee.cloud.senses.resolver import ResolvedSense
+
+        seen: dict[str, object] = {}
+
+        async def fake_resolve_many(sense_ids, workspace_id, *, pocket_id=None, agent=None):
+            seen["pocket_id"] = pocket_id
+            seen["agent"] = agent
+            return {
+                sid: (
+                    ResolvedSense(
+                        sense_id="paw.email.v1",
+                        connector_name="gmail",
+                        ambiguous=False,
+                        candidates=["gmail"],
+                    )
+                    if sid == "paw.email.v1"
+                    else None
+                )
+                for sid in sense_ids
+            }
+
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", None)
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            patch(
+                "pocketpaw_ee.cloud.senses.resolver.resolve_many",
+                new=AsyncMock(side_effect=fake_resolve_many),
+            ),
+        ):
+            out = await connectors_mcp._list_senses_handler({})
+
+        assert not out.get("is_error"), "pocket-less list_senses must NOT refuse"
+        body = _decode_payload(out)
+        assert [s["sense"] for s in body["senses"]] == ["paw.email.v1"]
+        assert body["pocket_id"] is None
+        # The null pocket reached the resolver as None — a workspace-tier read.
+        assert seen["pocket_id"] is None
+        assert seen["agent"] is None
+
+    @pytest.mark.asyncio
+    async def test_pocketless_sense_execute_runs(self) -> None:
+        """The execute half of the same property: a pocket-less run executes,
+        delegating with pocket_id=None."""
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+        from pocketpaw_ee.cloud.connectors.dto import ExecuteActionResponse
+        from pocketpaw_ee.cloud.senses.resolver import SenseExecutionResult
+
+        mock_exec = AsyncMock(
+            return_value=SenseExecutionResult(
+                ok=True,
+                sense_id="paw.email.v1",
+                connector_name="gmail",
+                action="gmail_search",
+                data=ExecuteActionResponse(success=True, data=[{"id": "m1"}]),
+            )
+        )
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", None)
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            patch("pocketpaw_ee.cloud.senses.resolver.execute_sense", new=mock_exec),
+        ):
+            out = await connectors_mcp._sense_execute_handler(
+                {"sense": "paw.email.v1", "action": "gmail_search"}
+            )
+
+        assert not out.get("is_error"), "pocket-less sense_execute must NOT refuse"
+        assert _decode_payload(out)["executed"] is True
+        assert mock_exec.await_args.kwargs["pocket_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_pocketless_mounted_agent_keeps_the_mount_gate(self) -> None:
+        """Pocket-less does NOT mean unbounded: an agent carrying a mount list
+        still lists exactly its carried senses. Pocket-optional and
+        capability-scoped are independent properties."""
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+
+        mock_resolve = AsyncMock(return_value={})
+        ws_patch, user_patch, pocket_patch = _patch_identity("ws_1", "u_1", None)
+        with (
+            ws_patch,
+            user_patch,
+            pocket_patch,
+            _patch_running_agent("ag_1"),
+            patch(
+                "pocketpaw_ee.cloud.agents.service.get",
+                new=AsyncMock(return_value=_StubMountedAgent(senses=("paw.email.v1",))),
+            ),
+            patch("pocketpaw_ee.cloud.senses.resolver.resolve_many", new=mock_resolve),
+        ):
+            out = await connectors_mcp._list_senses_handler({})
+
+        assert not out.get("is_error")
+        assert mock_resolve.await_args.args[0] == ["paw.email.v1"]
+        assert mock_resolve.await_args.kwargs["pocket_id"] is None
+        assert _decode_payload(out)["carried_senses"] == ["paw.email.v1"]
+
+    @pytest.mark.asyncio
+    async def test_workspace_is_the_only_hard_requirement(self) -> None:
+        """The one identity these tools DO require. Pocket may be absent; a
+        workspace may not (it is the tenant boundary)."""
+        from pocketpaw_ee.agent.mcp_servers import connectors as connectors_mcp
+
+        ws_patch, user_patch, pocket_patch = _patch_identity(None, "u_1", None)
+        with ws_patch, user_patch, pocket_patch:
+            listed = await connectors_mcp._list_senses_handler({})
+            executed = await connectors_mcp._sense_execute_handler(
+                {"sense": "paw.email.v1", "action": "gmail_search"}
+            )
+
+        for out in (listed, executed):
+            assert out.get("is_error") is True
+            assert "no active workspace" in out["content"][0]["text"]


### PR DESCRIPTION
Agents now carry their own senses instead of inheriting whatever the room offers. `AgentConfig` gains two fields: `senses` (a mount list: empty inherits today's surface, non-empty is exclusive, same rule as `tool_mode`) and `sense_prefs` (per-sense provider choice). The resolver picks providers in order: agent preference, then the stored pocket row, then the workspace row. Run identity now carries the driving agent's id down to the in-process MCP tools.

## Review gate: one security decision needs your sign-off

**The concierge surface can now expose the two sense tools (`list_senses`, `sense_execute`) when the site's agent has a non-empty mount list.** This is a public, anonymous, prompt-injectable surface reaching read-only workspace data, so it is built fail-closed:

- Empty mount list = the tools are DENIED (not just ungranted), exactly today's posture. Deny is subtracted before any grant, which also blocks a CX-2 exclusive agent from self-granting the ids (there is a test for that hole).
- The grant decision runs at the run seam (`_concierge_sense_policy`, run_core.py) on server-truth inputs. The surface registry was rejected as a seam because its input is client-supplied and forgeable.
- Trust stays read-first: only `trust_level == "auto"` actions execute.
- It is **inert in prod today**: no concierge agent has a non-empty mount list, and concierge chat still 409s when the pocket has any connectors (the GA-blocker gate in paw_bar/router.py). The unlock ordering is documented in the provisioning module.

Reject this commit (d5129fd1) alone if you disagree; the other four slices stand without it.

## What shipped, slice per commit

| Commit | Slice |
|---|---|
| 5480c534 | Agent id threaded through run identity (sixth ContextVar token); `current_agent_id()` for MCP tools. Group/DM bridge binds one unambiguous agent per dispatch (it fans out one call per responding agent). |
| 6f0342af | `sense_prefs` + `AgentSenseContext`; agent tier outranks stored preference rows; a pref naming a non-candidate logs and falls through. Also threads the fields through the domain spec mappers, where a missing field gets silently erased on unrelated updates. |
| 7b0cd5df | `senses` mount list, `is_sense_carried` gate, `sense.not_carried` refusal, `list_senses` filtering. Docs in `docs/api-reference.md` + CONNECTORS.md. |
| d5129fd1 | The concierge opt-in above, plus regression tests locking pocket-less workspace-tier sense resolution (that behavior shipped 2026-06-12; the tests stop anyone re-adding a pocket refusal). |
| 7dd80544 | Both fields settable over the agents API (create/update/GET, 422 on unknown ids) and an `ensure_site_agent(senses=, sense_prefs=)` hook with a never-clobber rule for existing agents. |

## Design-doc corrections made mid-build

The original SP2-4 premise ("pocket-less runs refuse with no-pocket") was stale: the sense surface's pocket refusal was removed in June, and concierge runs carry the site's pocket. The real gate was the concierge MCP allow-list. Tasks doc updated (paw-workspace, `docs/design/drafts/2026-08-01-sense-phase2-agent-carried-tasks.md`).

Open questions from the PRD, answered in code:
- **Site-API sense id**: not derivable today. The `paw.*` vocabulary is closed and no connector represents a Paw Site's API. Hook wired, no call site passes it. Unlock ordering: GA lockdown mode, then a site connector declaring a sense, then one call-site edit.
- **Agent config freshness**: fresh Beanie read per tool call, no caching. Config edits apply next turn.

## Verification

- Targeted suites on the final tip: 180 passed. Import-linter: core 1 kept / 0 broken, ee 34 kept / 0 broken.
- Live smoke against a real backend + Mongo (worktree build): create agent with senses/prefs (200, fields echoed), GET round-trip, **unrelated rename does not erase the fields** (the mapper-erasure trap, proven live), unknown sense id 422 with the closed-namespace message. Smoke agents deleted after.
- Not live-tested: the concierge tool grant end to end (inert until provisioning wires a sense; see the ordering above).

## Known pre-existing reds (all proven on base d24d5406 or tip-with-changes-stashed, none from this branch)

- `tests/cloud/agents/test_agent_visibility_enforcement.py::test_knowledge_list_allowed_for_owner`
- `tests/cloud/runs/test_run_core.py::test_execute_run_threads_surface_meta_into_ctx`
- `tests/cloud/test_paw_bar_agent_provisioning.py` — `test_asg_identity_fields_absent_agent_has_neither` (asserts ASG-1 fields absent; they shipped 2026-07-15, test looks stale) and `test_knowledge_read_carries_the_flag`
- `tests/cloud/test_rbac_routes.py` — 15 reds, unrelated (workspace/invite routes)

Design docs in paw-workspace: `2026-08-01-sense-phase2-agent-carried.md` (design), `-prd.md`, `-tasks.md`.
