### PR TITLE
Public sites: concierge assets 401 for anonymous visitors

### DIFF
--- a/src/pocketpaw/dashboard_auth.py
+++ b/src/pocketpaw/dashboard_auth.py
@@ -130,6 +130,7 @@ async def verify_token(
     if (
         request.url.path.startswith("/static")
         or request.url.path.startswith("/uploads")
+        or request.url.path.startswith("/pawbar-app")
         or request.url.path == "/favicon.ico"
     ):
         return True
@@ -437,6 +438,10 @@ async def _auth_dispatch(request: Request) -> Response | None:
         "/static",
         "/uploads",
         "/favicon.ico",
+        # Paw Bar glass app bundle (pawbar.js/css) — loaded by the public
+        # concierge iframe on published sites; visitors have no session.
+        # Read-only StaticFiles mount, same trust class as /static.
+        "/pawbar-app",
         # NOTE: /ws, /v1/ws, /api/v1/ws are no longer exempted here — WebSocket
         # scopes are now authenticated at the middleware level (issue #883).
         "/api/auth/login",

--- a/tests/test_dashboard_security.py
+++ b/tests/test_dashboard_security.py
@@ -790,3 +790,44 @@ class TestFullAccessApiLimiterExemption:
             assert resp is not None
             assert resp.status_code == 429
             mock_auth_limiter.check.assert_called_once_with("127.0.0.1")
+
+
+class TestPawbarAppExempt:
+    """The public concierge iframe loads pawbar.js/css from /pawbar-app with no
+    session — the mount must pass the auth middleware anonymously, like /static."""
+
+    def _request(self, path):
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+
+        req = MagicMock()
+        req.method = "GET"
+        req.url.path = path
+        req.client.host = "203.0.113.7"
+        req.headers = {}
+        req.cookies = {}
+        req.query_params = {}
+        # Real (attribute-less) state: a MagicMock here fabricates a truthy
+        # ``full_access`` and short-circuits the cascade to valid.
+        req.state = SimpleNamespace()
+        return req
+
+    @pytest.mark.asyncio
+    async def test_pawbar_app_assets_pass_anonymously(self):
+        from unittest.mock import patch
+
+        from pocketpaw.dashboard_auth import _auth_dispatch
+
+        with patch("pocketpaw.dashboard_auth.get_access_token", return_value="tok"):
+            result = await _auth_dispatch(self._request("/pawbar-app/pawbar.js"))
+        assert result is None  # allowed through, no 401
+
+    @pytest.mark.asyncio
+    async def test_unrelated_root_path_still_rejected(self):
+        from unittest.mock import patch
+
+        from pocketpaw.dashboard_auth import _auth_dispatch
+
+        with patch("pocketpaw.dashboard_auth.get_access_token", return_value="tok"):
+            result = await _auth_dispatch(self._request("/pawbar-secrets/x.js"))
+        assert result is not None  # control: prefix must not over-match


### PR DESCRIPTION
The bar never renders on a deployed site for a real visitor: the frame HTML loads pawbar.js/css from the /pawbar-app mount, and the auth middleware's require-auth-for-all-remaining-paths gate 401s any request without a session. Logged-in browsers (dashboards, previews, local testing) sail through on their cookies, which is how this stayed invisible until an anonymous client hit a hosted deployment tonight.

Fix: /pawbar-app joins /static and /uploads in both exemption spots (middleware exempt list + verify_token's static skip). It's a read-only StaticFiles mount serving the built widget bundle, same trust class as /static.

Test drives _auth_dispatch anonymously against the asset path plus a lookalike prefix (/pawbar-secrets) to pin the prefix from over-matching. Verified red with the fix reverted, green with it applied. Full test_dashboard_security.py: 52 passed.