### PR TITLE
Give freshly provisioned site widgets a default booking action

### DIFF
--- a/ee/pocketpaw_ee/paw_bar/agent_provisioning.py
+++ b/ee/pocketpaw_ee/paw_bar/agent_provisioning.py
@@ -1,6 +1,16 @@
 # ee/pocketpaw_ee/paw_bar/agent_provisioning.py — auto-provision a DEDICATED
 # concierge agent per Paw Site.
 #
+# Updated 2026-08-01 (default booking action): a widget MINTED by
+# ``ensure_site_widget`` now declares one gated ``booking_request`` action
+# (``_default_booking_action``). An empty ``spec.actions`` means the concierge
+# preamble renders NO form-card instructions (see the concierge handler), so
+# every from-scratch published site shipped a chat-only concierge that declined
+# bookings — found live 2026-08-01 on a hosted deploy. MINT-ONLY: an existing
+# widget's actions are never touched (owners may have removed or customized
+# them), and the dashboard widget-create path is untouched too — its spec is
+# authored by the caller, never synthesized here.
+#
 # Updated 2026-07-30 (Paw Bar inbox D5): added ``widget_for_agent(agent_id,
 # workspace_id)`` — the REVERSE of the bind ``ensure_site_agent`` writes. D5 lets a
 # concierge run read its own ``agent:<id>`` knowledge scope, which makes "is this
@@ -380,6 +390,32 @@ async def widget_for_agent(agent_id: str, workspace_id: str) -> Any | None:
     return None
 
 
+def _default_booking_action() -> Any:
+    """The one action a MINTED site widget declares: a gated booking request.
+
+    A spec with no gated-with-args actions renders no form-card instructions in
+    the concierge preamble, leaving the agent unable to take a booking at all —
+    a service site's one job. ``gated`` never executes; it raises an Instinct
+    proposal for the owner (SS-2: ``auto`` is reserved for visitor-scoped
+    verbs). Applied ONLY when minting: an existing widget's actions belong to
+    its owner.
+    """
+    from pocketpaw.paw_bar.models import PawBarActionSpec
+
+    return PawBarActionSpec(
+        verb="booking_request",
+        policy="gated",
+        args={
+            "name": "str",
+            "phone": "str",
+            "address": "str",
+            "issue": "str",
+            "preferred_window": "str",
+        },
+        label="Book a service visit",
+    )
+
+
 async def ensure_site_widget(site: Any, workspace_id: str) -> Any | None:
     """Publish-time trigger: a concierge-enabled site must HAVE a paw-bar widget.
 
@@ -411,9 +447,15 @@ async def ensure_site_widget(site: Any, workspace_id: str) -> Any | None:
             owner=str(getattr(site, "owner", "") or "site"),
             workspace_id=workspace_id,
             name=f"{site_name} concierge",
-            # The glass bar renders its own chat surface; blocks stay empty and
-            # the spec is the same "pending" shell the dashboard flow starts from.
-            spec=PawBarSpec(widget_id="pending", pocket_id=site.pocket_id, blocks=[]),
+            # The glass bar renders its own chat surface; blocks stay empty. The
+            # spec ships with the default gated booking action — an empty
+            # ``actions`` yields a concierge that cannot take a booking.
+            spec=PawBarSpec(
+                widget_id="pending",
+                pocket_id=site.pocket_id,
+                blocks=[],
+                actions=[_default_booking_action()],
+            ),
         )
         created = await _store().create_widget(widget)
         logger.info(

--- a/tests/cloud/test_paw_bar_agent_provisioning.py
+++ b/tests/cloud/test_paw_bar_agent_provisioning.py
@@ -15,6 +15,10 @@
 #   * Identity seeding: welcome_message/starters degrade gracefully because the
 #     ASG-1 identity fields are ABSENT on this branch (the created agent carries
 #     neither field); starters ride the frame config payload.
+#   * Default booking action (2026-08-01 live regression): a widget MINTED by
+#     ensure_site_widget carries one gated booking_request action (five str
+#     args, "Book a service visit" label); an EXISTING widget's actions are
+#     never modified by any ensure_site_widget pass (mint-only).
 
 from __future__ import annotations
 
@@ -331,6 +335,63 @@ class TestPublishTimeTrigger:
 
         widget = await ap.ensure_site_widget(site, _WS)
         assert widget is not None and widget.id == existing_id
+
+    @pytest.mark.asyncio
+    async def test_minted_widget_carries_default_booking_action(self, client) -> None:
+        """A MINTED widget must declare the default gated booking action.
+
+        Live regression (2026-08-01, hosted deploy): the minted spec shipped with
+        ``actions=[]``, the concierge preamble rendered no form-card instructions
+        (widgets with no gated-with-args actions render none), and every
+        from-scratch published site got a concierge that could answer questions
+        but declined every booking request.
+        """
+        from pocketpaw_ee.paw_bar import agent_provisioning as ap
+
+        _c, _store = client
+        site = await _site()
+
+        widget = await ap.ensure_site_widget(site, _WS)
+        assert widget is not None
+        actions = widget.spec.actions
+        assert len(actions) == 1, "a minted widget must carry exactly the default action"
+        action = actions[0]
+        assert action.verb == "booking_request"
+        assert action.policy == "gated"
+        assert action.args == {
+            "name": "str",
+            "phone": "str",
+            "address": "str",
+            "issue": "str",
+            "preferred_window": "str",
+        }
+        assert action.label == "Book a service visit"
+
+    @pytest.mark.asyncio
+    async def test_existing_widget_actions_are_never_modified(self, client) -> None:
+        """The default is mint-only: an EXISTING widget's actions stay untouched.
+
+        An owner may have deliberately removed or customized the actions, so a
+        re-publish (a second ``ensure_site_widget`` pass, bound or unbound) must
+        never re-add or reshape them.
+        """
+        from pocketpaw_ee.paw_bar import agent_provisioning as ap
+
+        _c, store = client
+        site = await _site()
+        # Owner stripped the actions (spec has none) and the widget is unbound —
+        # the pass that DOES bind an agent must still leave actions alone.
+        existing = await store.create_widget(_widget(agent_id="", spec=_spec()))
+
+        widget = await ap.ensure_site_widget(site, _WS)
+        assert widget is not None and widget.id == existing.id
+        assert widget.agent_id, "the unbound existing widget gains an agent"
+        assert widget.spec.actions == [], "but its actions are never touched"
+
+        # Second pass on the now-bound widget (the idempotent early return).
+        again = await ap.ensure_site_widget(site, _WS)
+        assert again is not None and again.id == existing.id
+        assert again.spec.actions == []
 
 
 class TestConciergeEnableTrigger:


### PR DESCRIPTION
## What happened

On a hosted deployment yesterday, a from-scratch published site (paw-site-6e1aa1543ad8fb3ecfe99383, widget pp-19fc16fff75-z7qk) got a concierge that answered questions fine but refused every booking. The visitor asked to book a visit and the agent honestly replied that it can't book and pointed at the phone number. It only started taking bookings after the action was declared manually in the DB.

Root cause: when a site is published, ensure_site_widget mints the paw-bar widget with an empty spec.actions. The concierge preamble builds its form-card instructions from gated actions that take args, and with none declared it renders no form instructions at all, so the agent has no way to take a booking. Demo and seeded widgets always declared actions by hand, which is why this never surfaced locally. Every real from-scratch publish hit it.

## The fix

The minted spec now declares one gated booking_request action with five string args (name, phone, address, issue, preferred_window) and the label "Book a service visit". Gated means it never executes on its own; it raises an Instinct proposal for the site owner, per SS-2. A side benefit is that the action label now feeds the derived conversation starters, so minted bars also surface "Book a service visit?" as a starter.

This is deliberately mint-only. If a widget already exists, ensure_site_widget returns it without touching its actions, whether it takes the bound early-return path or the bind-an-agent path. Owners may have removed or customized their actions on purpose and a re-publish must not reshape them. The failure-soft contract is unchanged: any error still logs and returns None, since a site going live matters more than its bar.

The dashboard widget-create path (provision_widget_on_create through the router) is intentionally untouched. That path never synthesizes a spec; the creator supplies spec in the request body, so an empty actions list there is an authored choice, not a provisioning gap. The only place a spec is minted from nothing is ensure_site_widget.

## Tests (written first, per TDD)

New tests in tests/cloud/test_paw_bar_agent_provisioning.py:

test_minted_widget_carries_default_booking_action pins the minted widget to exactly one gated booking_request action with the five args and the label. Before the fix it failed with "assert 0 == 1, where 0 = len([])". After the fix it passes.

test_existing_widget_actions_are_never_modified creates an existing unbound widget whose owner stripped the actions, runs ensure_site_widget twice (the bind pass and the idempotent early return), and asserts the actions stay empty both times. This one passed before and after, pinning the mint-only behavior.

Targeted run across the paw_bar suites plus sites consumers (21 files, 1105 passed): the only reds are pre-existing on a clean origin/dev checkout and unrelated to this change. Two are stale ASG-1 pins in TestIdentityAndFrameStarters and TestSiteVisitorVisibility that assert welcome_message does not exist on the Agent model when it now does, and one is an order-dependent flake in tests/ee/sites/test_html_e2e.py that passes in isolation. All three reproduce identically without this branch's changes.