### PR TITLE
Assemble the channel prompt from the same layers, and carry its digest to the backend

### DIFF
--- a/src/pocketpaw/agents/backend.py
+++ b/src/pocketpaw/agents/backend.py
@@ -3,6 +3,16 @@
 Every agent backend (Claude SDK, OpenAI Agents, Gemini CLI, OpenCode CLI)
 must expose a ``info()`` staticmethod and an async ``run()`` generator.
 
+Updated: 2026-08-03 (PA-7b, feat/prompt-assembler-channel) — the two signature
+guards that decide who RECEIVES ``system_prompt_digest`` moved here from
+``AgentPool``, plus a ``forward_prompt_digest`` helper for callers holding a
+backend instance. The channel path now has a digest too, and it reaches backends
+through ``AgentRouter`` (both its own fallback loop and the failover runner's
+chain) rather than through the pool — three call sites for one question. Keeping
+the definition next to the ``run`` signature it inspects is what stops a second
+copy appearing that counts ``**kwargs``; ``pool`` re-imports the names so its own
+callers and tests are unmoved.
+
 Updated: 2026-08-02 (PA-1, feat/prompt-assembler-seam) — the shared ``run``
 signature grows ``system_prompt_digest: str = ""``: a hash over the layers of
 the assembled system prompt that declared themselves cacheable (see
@@ -73,9 +83,11 @@ replaying Mongo history into the prompt). ``None`` is the unchanged legacy path.
 
 from __future__ import annotations
 
+import inspect
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from enum import Flag, auto
+from functools import cache
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
@@ -90,6 +102,71 @@ from pocketpaw.agents.protocol import AgentEvent  # re-export for convenience
 _DEFAULT_IDENTITY = (
     "You are PocketPaw, a helpful AI assistant running locally on the user's computer."
 )
+
+
+@cache
+def _accepts_prompt_digest(backend_cls: type) -> bool:
+    """Does this backend's ``run`` take a ``system_prompt_digest`` keyword?
+
+    The digest (PA-1) is non-empty on every run, so the withhold-when-empty
+    idiom the other per-run kwargs use cannot gate it — passing it to a backend
+    with the narrower signature would raise TypeError. Asking the signature is
+    the same answer ``_accepts_policy`` gives: a backend opts in by accepting
+    the argument, and the backends that have not been ported yet are untouched.
+    ``**kwargs`` does NOT count — a backend that swallows the digest silently
+    would look ported without keying on anything.
+
+    Cached because this runs once per turn, and a backend class's signature
+    cannot change at runtime.
+
+    LIVES HERE, NOT IN ``AgentPool`` (moved at PA-7b). Three call sites now ask
+    it — the pool, ``AgentRouter`` and ``BackendFailoverRunner`` — and the
+    question is a fact about the BACKEND PROTOCOL, which is this module. A
+    second copy in the router would be the failure this guard exists to prevent:
+    two definitions of "declares the digest" drifting apart, one of them
+    counting ``**kwargs``. ``pool`` re-imports both names, so
+    ``from pocketpaw.agents.pool import _accepts_prompt_digest`` still resolves.
+    """
+    run = getattr(backend_cls, "run", None)
+    if run is None:  # pragma: no cover - not a backend
+        return False
+    return _accepts_prompt_digest_kwarg(run)
+
+
+def _accepts_prompt_digest_kwarg(func: Any) -> bool:
+    """Does ``func`` name ``system_prompt_digest`` in its signature?
+
+    Split out of ``_accepts_prompt_digest`` at PA-6 because ``prewarm`` needs the
+    same question asked of a BOUND METHOD rather than of a backend class. Not
+    cached: a bound method is a fresh object per access, so a cache keyed on it
+    would grow without ever hitting, and the check is one ``inspect.signature``
+    on a path that already builds SDK options.
+    """
+    try:
+        return "system_prompt_digest" in inspect.signature(func).parameters
+    except (TypeError, ValueError):  # pragma: no cover - exotic callables
+        return False
+
+
+def forward_prompt_digest(backend: Any, run_kwargs: dict[str, Any], digest: str) -> dict[str, Any]:
+    """Return ``run_kwargs`` carrying ``digest`` iff ``backend`` declares it.
+
+    The one-line form of the rule above, for the callers that hold a backend
+    INSTANCE rather than a class: ``AgentRouter.run`` (primary + each generic
+    fallback) and ``BackendFailoverRunner.run`` (each harness in the chain).
+    Returns the SAME dict when the backend does not declare the parameter, so a
+    caller can build one kwargs dict and hand it to several backends of
+    different vintages — which is exactly what the failover chain does.
+
+    Sent whenever the signature accepts it, INCLUDING an empty digest, matching
+    ``AgentPool.run``'s rule rather than inventing a second one. An empty digest
+    is not a silent no-op either: every consumer branches on truthiness and
+    falls back to hashing what it can see, so ``""`` means "this caller has no
+    digest" in exactly one place per backend.
+    """
+    if not _accepts_prompt_digest(type(backend)):
+        return run_kwargs
+    return {**run_kwargs, "system_prompt_digest": digest}
 
 
 class Capability(Flag):

--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -1580,11 +1580,22 @@ class ClaudeSDKBackend(BaseAgentBackend):
         splices a GROWING ``# Recent Conversation`` block into
         ``options.system_prompt`` (see the history injection in
         ``_build_options``) — so the warm subprocess would be torn down and
-        respawned every turn. With this prefix it held 7/7. That number is also
-        why PA-7b is not claimed as a cache win on the channel path: 7/7 was
-        already the baseline there. What the prefix cannot do is see a REAL
-        behaviour change that sits below the marker it cuts at, and no
-        pattern-match ever will.
+        respawned every turn. With this prefix it held 7/7. So PA-7b claims no
+        cache-rate win on the channel path — 7/7 was already the baseline that
+        measurement recorded, and what the prefix genuinely cannot do is see a
+        REAL behaviour change sitting below the marker it cuts at.
+
+        ONE CAVEAT ON THAT 7/7, found while threading PA-7b and worth stating
+        where it will be read. ``_VOLATILE_PROMPT_MARKERS`` are the CLOUD path's
+        block headers. The channel path emits ``# Memory Context (already
+        loaded…)`` and ``# Knowledge Base (relevant articles…)``, and NEITHER is
+        in the tuple — so the per-message recall stays inside the prefix, and a
+        two-turn probe (``tests/test_channel_prompt_digest.py::
+        test_a_changed_recall_moves_the_prefix_and_not_the_digest``) shows the
+        prefix moving when only that recall changes, while the digest holds. The
+        7/7 is presumably a run whose recall did not vary between turns. That is
+        a mechanism, not a rate: nobody has measured how often a real channel
+        turn changes its recall, and this note is not a licence to assume.
 
         What it is worse at than the digest, measured on the cloud path over the
         same 8 turns: it retains ``## Self-Understanding``, which

--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -561,6 +561,21 @@ def _mcp_server_of(tool_id: str) -> str:
 # to walk without changing what any process can read (same OS user, same home).
 _WINDOWS_PROMPT_SPILL_CHARS = 24_000
 
+
+def _prompt_must_spill(prompt: str) -> bool:
+    """Is this prompt too long to pass inline on this platform?
+
+    A function rather than an inline ``os.name == "nt" and len(...)`` so a test
+    can force the Windows branch on Linux by patching THIS, and not ``os.name``.
+    Patching ``os.name`` looks equivalent and is not: ``pathlib`` decides at
+    IMPORT time whether ``WindowsPath.__new__`` is the real one or a stub that
+    raises, so a POSIX process with ``os.name`` forced to ``"nt"`` dispatches
+    every ``Path(...)`` to the raising stub. The spill test did exactly that and
+    only CI could see it — on Windows both spellings pass.
+    """
+    return os.name == "nt" and len(prompt) > _WINDOWS_PROMPT_SPILL_CHARS
+
+
 # How many spilled prompts survive a prune. They are 24k+ chars each and they
 # accumulate in the user's HOME, so an unbounded pile is not an acceptable price
 # for a cache key. 32 is chosen to be larger than any plausible count of live
@@ -2252,7 +2267,7 @@ class ClaudeSDKBackend(BaseAgentBackend):
         # see ``_spill_prompt_to_file`` and the block above it for why one fixed
         # path was both a cross-run race and a cache-key collapse.
         system_prompt_arg: Any = final_prompt
-        if os.name == "nt" and len(final_prompt) > _WINDOWS_PROMPT_SPILL_CHARS:
+        if _prompt_must_spill(final_prompt):
             prompt_path = _spill_prompt_to_file(final_prompt)
             system_prompt_arg = {"type": "file", "path": str(prompt_path)}
             logger.info(

--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -1,5 +1,22 @@
 """
 Claude Agent SDK backend for PocketPaw.
+Updated: 2026-08-03 (PA-7b, feat/prompt-assembler-channel) — two things, and the
+  first is a docstring that had become false. ``_behavior_prefix`` said PA-7
+  would delete it once the channel path produced a digest of its own. The channel
+  path now does, and the function is NOT deletable: the pocket specialist calls
+  ``backend.run`` directly (bypassing the router that forwards the digest) and so
+  can any out-of-tree embedder, and both would key a warm client on a constant
+  without it. The correction is in the docstring itself rather than here, where a
+  reader of the function would not find it.
+  Second, ``_build_options``' Windows prompt spill is content-addressed:
+  ``~/.pocketpaw/runtime/prompts/system_prompt-<sha256>.md`` instead of one fixed
+  path. The fixed path was two bugs at once — two concurrent large-prompt runs on
+  one box overwrote each other's file (the pool holds an instance per agent, so
+  this is reachable on the desktop app), and ``_behavior_prefix`` returns
+  ``file:<path>`` for the dict form, which was CONSTANT, so every prompt over 24k
+  hashed identically and the warm client stopped rebuilding on prompt changes for
+  exactly the prompts big enough to spill. The hash in the name fixes both with no
+  I/O in the key function.
 Updated: 2026-08-03 (PA-6, feat/prompt-assembler-seam) — ``run`` / ``prewarm`` take
   ``system_prompt_digest`` and the warm-client key prefers it over
   ``_behavior_prefix``. The prefix INFERS which bytes are stable by cutting the
@@ -8,8 +25,8 @@ Updated: 2026-08-03 (PA-6, feat/prompt-assembler-seam) — ``run`` / ``prewarm``
   ``## Self-Understanding`` renders above that block, so the strip never reached
   it and an ordinary turn respawned the subprocess. Measured over 8 turns on a
   live soul, the prefix held 1 of 7 turn boundaries and the digest held 7 of 7.
-  The prefix STAYS as the no-digest fallback — the channel path builds its prompt
-  in ``AgentContextBuilder`` until PA-7, and ``run`` splices a growing
+  The prefix STAYS as the no-digest fallback — see the PA-7b note above for who
+  still reaches it now that the channel path does not, and ``run`` splices a growing
   ``# Recent Conversation`` block into ``options.system_prompt`` after assembly,
   so a whole-prompt key would rebuild there every turn (measured 0 of 7). The two
   slots are prefixed ``d:`` / ``t:`` so a client warmed under one rule can never
@@ -324,6 +341,7 @@ Uses the official Claude Agent SDK (pip install claude-agent-sdk) which provides
 import asyncio
 import hashlib
 import logging
+import os
 import re
 from collections.abc import AsyncIterator, Callable
 from pathlib import Path
@@ -498,6 +516,146 @@ def _mcp_server_of(tool_id: str) -> str:
     """Extract ``<server>`` from an ``mcp__<server>__<tool>`` id (else "")."""
     parts = tool_id.split("__")
     return parts[1] if len(parts) >= 2 and parts[0] == "mcp" else ""
+
+
+# ── the Windows prompt spill ────────────────────────────────────────────────
+#
+# Windows caps a whole command line at ~32,767 chars (CreateProcess), and the SDK
+# passes a string ``system_prompt`` inline via ``--system-prompt``. A long
+# identity/KB prompt blows that limit and surfaces as a misleading
+# ``CLINotFoundError``, so since SDK 0.1.72 we hand it a
+# ``{"type": "file", "path": ...}`` dict instead and the CLI reads
+# ``--system-prompt-file``.
+#
+# THE FILENAME CARRIES A HASH OF THE CONTENT (PA-7b), where it used to be one
+# fixed path, ``~/.pocketpaw/runtime/system_prompt.md``. That single path was two
+# bugs wearing one coat:
+#
+# * A CROSS-RUN RACE. ``AgentPool`` holds one backend instance per agent, so two
+#   concurrent large-prompt runs on one box both wrote that file and whichever
+#   CLI subprocess started second read the other's prompt. Windows-only, so the
+#   cloud never saw it — but the desktop app runs a pool.
+# * A CACHE-KEY COLLAPSE. ``_behavior_prefix`` has no text to cut when the prompt
+#   arrives as a dict, so it returns ``file:<path>`` — which was CONSTANT. Every
+#   prompt over the threshold hashed identically, so the warm client stopped
+#   rebuilding on prompt changes for exactly the prompts big enough to spill:
+#   the staleness the behavioural-prefix key exists to prevent, restored at the
+#   top of the size range.
+#
+# Content-addressing fixes both at once and adds no I/O to ``_client_cache_key``,
+# which reads the path it is given and nothing else. What it costs: the name
+# hashes the WHOLE prompt, volatile tail included, so a no-digest caller on
+# Windows now rebuilds its warm client on every spilled turn instead of never.
+# That is the right side of the trade — never rebuilding meant serving the wrong
+# prompt — and it is close to free in practice, because the callers still without
+# a digest (the pocket specialist, out-of-tree embedders) build an isolated
+# backend per run and stop it in a ``finally``, so they have no warm client to
+# lose. Hashing the STABLE PREFIX instead would keep the key still, and would be
+# wrong: two prompts with the same prefix and different tails would share a
+# filename, and the CLI would read one of them for both.
+#
+# NOT SCOPED PER AGENT, deliberately. A hash of the content already separates two
+# tenants' prompts, because their prompts differ; two runs that land on one
+# filename have byte-identical content, so there is nothing one could learn from
+# the other. An agent/session directory would multiply the surface the pruner has
+# to walk without changing what any process can read (same OS user, same home).
+_WINDOWS_PROMPT_SPILL_CHARS = 24_000
+
+# How many spilled prompts survive a prune. They are 24k+ chars each and they
+# accumulate in the user's HOME, so an unbounded pile is not an acceptable price
+# for a cache key. 32 is chosen to be larger than any plausible count of live
+# concurrent sessions on one desktop (a file is only load-bearing between the
+# spill and the CLI's read at process start) while still bounding the directory
+# at a few MB.
+_SPILLED_PROMPT_KEEP = 32
+_SPILLED_PROMPT_STEM = "system_prompt-"
+
+
+def _spilled_prompt_path(prompt: str) -> Path:
+    """The content-addressed path a given prompt spills to.
+
+    32 hex chars (128 bits), wider than the 16 used by ``_client_cache_key`` and
+    ``_plugin_digest``, because a collision means something different here. A
+    collision in a CACHE key costs a wrong reuse of an in-memory object; a
+    collision in this name means the write is skipped and the CLI reads ANOTHER
+    prompt off disk. Cheap insurance for 16 characters of filename.
+    """
+    digest = hashlib.sha256(prompt.encode("utf-8", "replace")).hexdigest()[:32]
+    return Path.home() / ".pocketpaw" / "runtime" / "prompts" / f"{_SPILLED_PROMPT_STEM}{digest}.md"
+
+
+def _spill_prompt_to_file(prompt: str) -> Path:
+    """Write ``prompt`` to its content-addressed path and return it.
+
+    Skips the write when the file is already there: the name IS the content, so
+    an existing file has the bytes we were about to write. That also removes the
+    common concurrent case — two turns on the same prompt — from the race
+    entirely, rather than relying on the write being atomic.
+
+    For the uncommon case (two processes spilling the same NEW prompt at once)
+    the write goes to a pid-suffixed temp and is moved into place. On Windows the
+    move fails if the destination exists or is open; both mean somebody else
+    landed the identical bytes first, so the failure is swallowed and their file
+    is used.
+    """
+    path = _spilled_prompt_path(prompt)
+    if path.exists():
+        return path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+    tmp.write_text(prompt, encoding="utf-8")
+    try:
+        os.replace(tmp, path)
+    except OSError:
+        try:
+            tmp.unlink()
+        except OSError:  # pragma: no cover - best effort
+            pass
+        return path
+    _prune_spilled_prompts(path.parent, protect=path)
+    return path
+
+
+def _prune_spilled_prompts(
+    directory: Path, keep: int = _SPILLED_PROMPT_KEEP, *, protect: Path | None = None
+) -> None:
+    """Keep the ``keep`` newest spilled prompts in ``directory``; drop the rest.
+
+    Runs only after a NEW file was created, which is the only moment the
+    directory grows.
+
+    ``protect`` is the file the caller is about to hand to the CLI, and it is
+    excluded from the candidates rather than trusted to sort first. Newest-by-
+    mtime would USUALLY put it at the head, but "usually" is not a property to
+    hang a turn on: filesystem timestamp resolution is coarse enough that a burst
+    of spills can tie, and a tie resolves to glob order. One slot of the budget is
+    reserved for it so the total stays at ``keep``.
+
+    Best-effort throughout: a prompt file that cannot be deleted (a live CLI
+    holding it open on Windows) is left for the next prune and never fails the
+    turn. The glob is deliberately wider than ``*.md`` so an orphaned ``.tmp``
+    from a process that died mid-write is bounded too.
+    """
+    try:
+        files = sorted(
+            (p for p in directory.glob(f"{_SPILLED_PROMPT_STEM}*") if p.is_file()),
+            key=lambda p: p.stat().st_mtime_ns,
+            reverse=True,
+        )
+    except OSError:  # pragma: no cover - unreadable dir
+        return
+    budget = keep - 1 if protect is not None else keep
+    survivors = 0
+    for candidate in files:
+        if candidate == protect:
+            continue
+        if survivors < budget:
+            survivors += 1
+            continue
+        try:
+            candidate.unlink()
+        except OSError:
+            logger.debug("could not prune spilled system prompt %s", candidate)
 
 
 class ClaudeSDKBackend(BaseAgentBackend):
@@ -1392,16 +1550,41 @@ class ClaudeSDKBackend(BaseAgentBackend):
         ``system_prompt_digest`` and this function is never consulted for its
         key — the digest is a claim the LAYERS made about themselves, where this
         is a guess made by pattern-matching two modules away. PA-6 was filed as
-        "delete it"; it is kept because ``AgentLoop`` (Telegram / Discord /
-        Slack / CLI) builds its prompt in ``AgentContextBuilder`` and has no
-        digest until PA-7, and the number says what deleting it would cost
-        there. Measured 2026-08-03 over 8 turns of a realistic channel prompt:
-        keying on the whole prompt instead held 0/7 boundaries, because ``run``
-        itself splices a GROWING ``# Recent Conversation`` block into
-        ``options.system_prompt`` (see the history injection in ``_build_options``)
-        — so the warm subprocess would be torn down and respawned every turn.
-        With this prefix it held 7/7. PA-7 deletes it when the channel path
-        produces a digest of its own.
+        "delete it" and PA-7 was expected to finish the job when the channel path
+        gained a digest.
+
+        IT IS NOT DELETABLE, and PA-7b is where that gets said in the right
+        place. The channel path DOES have a digest now (``AgentLoop`` forwards
+        ``AgentContextBuilder``'s through ``AgentRouter``), which was the whole
+        premise of the deletion — and two callers reach ``run`` without one
+        anyway, so this function still keys real traffic:
+
+        * the pocket specialist, which builds an isolated backend via
+          ``AgentRouter.create_isolated_backend`` and calls ``backend.run(
+          user_message, system_prompt=...)`` DIRECTLY, bypassing the router that
+          does the forwarding (``ee/pocketpaw_ee/agent/pocket_specialist/
+          runtime.py``, the create path and the edit path). Its prompt is built
+          by its own ``_build_system_prompt``, not by the assembler, so there is
+          no digest to forward even in principle;
+        * any out-of-tree embedder holding a backend and calling ``run`` itself,
+          which is a supported thing to do — ``system_prompt`` is a public
+          parameter of the ``AgentBackend`` protocol.
+
+        Deleting this would hand both of them a constant key: every prompt would
+        look identical to the warm client and a changed persona would be served
+        the previous one. That is #1842, restored for the callers least able to
+        notice.
+
+        Measured 2026-08-03 over 8 turns of a realistic channel prompt: keying on
+        the whole prompt instead held 0/7 boundaries, because ``run`` itself
+        splices a GROWING ``# Recent Conversation`` block into
+        ``options.system_prompt`` (see the history injection in
+        ``_build_options``) — so the warm subprocess would be torn down and
+        respawned every turn. With this prefix it held 7/7. That number is also
+        why PA-7b is not claimed as a cache win on the channel path: 7/7 was
+        already the baseline there. What the prefix cannot do is see a REAL
+        behaviour change that sits below the marker it cuts at, and no
+        pattern-match ever will.
 
         What it is worse at than the digest, measured on the cloud path over the
         same 8 turns: it retains ``## Self-Understanding``, which
@@ -1427,9 +1610,17 @@ class ClaudeSDKBackend(BaseAgentBackend):
         ``instructions``) still lands in the retained text, so it changes the
         digest and forces a warm-client rebuild. The boundary rule keeps that
         true: a marker mid-prompt without its blank line is content, not a
-        section header, and is left alone. On Windows the SDK may pass
-        ``system_prompt`` as a ``{type: "file", path: ...}`` dict — there is no
-        inline text to key on, so fall back to the path (stable per connect).
+        section header, and is left alone.
+
+        On Windows the SDK may pass ``system_prompt`` as a
+        ``{type: "file", path: ...}`` dict — there is no inline text to key on,
+        so fall back to the path. That path is CONTENT-ADDRESSED as of PA-7b
+        (``_spill_prompt_to_file``), which is what makes the fallback a real key:
+        it used to be one fixed filename, so every spilled prompt hashed alike
+        and the warm client never rebuilt for them. It keys on the whole prompt
+        rather than on the stable prefix — no cut is possible without reading the
+        file, and a key function that does disk I/O per turn is not a trade worth
+        making. See the module-level block above ``_spill_prompt_to_file``.
         """
         if isinstance(system_prompt, dict):
             return f"file:{system_prompt.get('path', '')}"
@@ -1541,10 +1732,13 @@ class ClaudeSDKBackend(BaseAgentBackend):
         into ``options.system_prompt`` after assembly is per-turn volatile and is
         outside both, which is the intended answer in both cases.
 
-        ``t:`` is not a transitional wart to be deleted on sight: ``AgentLoop``'s
-        channel path builds its prompt in ``AgentContextBuilder`` and has no
-        digest until PA-7. On that path, keying on the whole prompt instead held
-        0 of 7 boundaries against the prefix's 7 of 7 — see ``_behavior_prefix``.
+        ``t:`` is not a transitional wart to be deleted on sight, and PA-7b did
+        NOT retire it. The channel path gained a digest there, but the pocket
+        specialist calls ``backend.run`` directly (bypassing the router that
+        forwards it) and so does any out-of-tree embedder; both would key on a
+        constant without this branch. See ``_behavior_prefix`` for the full
+        argument and for the measurement — on a channel-shaped prompt, keying on
+        the whole prompt held 0 of 7 boundaries against the prefix's 7 of 7.
 
         The prefix digest is what makes a mid-session backend config change
         (configured:false -> configured:true, baked into the static home
@@ -1779,8 +1973,6 @@ class ClaudeSDKBackend(BaseAgentBackend):
         ``stderr`` callback appends to (so ``run`` keeps capturing CLI stderr for
         diagnostics; ``prewarm`` passes a throwaway list).
         """
-        import os
-
         run_skills_root: Path | None = None
         skills_dir_adopted = False
         plugin_digest = ""
@@ -2044,18 +2236,13 @@ class ClaudeSDKBackend(BaseAgentBackend):
 
         # Build options
         #
-        # Windows note: CreateProcess caps the entire command line at
-        # ~32,767 chars. The SDK passes string ``system_prompt`` inline
-        # via ``--system-prompt``; long KB/identity blobs blow that limit
-        # and surface as a misleading ``CLINotFoundError``. Since SDK
-        # 0.1.72 we can pass a ``SystemPromptFile`` dict instead, which
-        # the CLI reads via ``--system-prompt-file <path>``.
+        # Windows note: an oversized prompt is spilled to a file and passed as a
+        # ``SystemPromptFile`` dict. The path is content-addressed and pruned —
+        # see ``_spill_prompt_to_file`` and the block above it for why one fixed
+        # path was both a cross-run race and a cache-key collapse.
         system_prompt_arg: Any = final_prompt
-        if os.name == "nt" and len(final_prompt) > 24_000:
-            runtime_dir = Path.home() / ".pocketpaw" / "runtime"
-            runtime_dir.mkdir(parents=True, exist_ok=True)
-            prompt_path = runtime_dir / "system_prompt.md"
-            prompt_path.write_text(final_prompt, encoding="utf-8")
+        if os.name == "nt" and len(final_prompt) > _WINDOWS_PROMPT_SPILL_CHARS:
+            prompt_path = _spill_prompt_to_file(final_prompt)
             system_prompt_arg = {"type": "file", "path": str(prompt_path)}
             logger.info(
                 "System prompt %d chars exceeds Windows CLI safe limit; "
@@ -2603,9 +2790,11 @@ class ClaudeSDKBackend(BaseAgentBackend):
         caller that has one. Declared rather than swallowed by ``**kwargs``:
         ``AgentPool._accepts_prompt_digest`` reads this signature to decide
         whether to pass it, and a backend that accepted it silently would look
-        ported while keying on nothing. Empty = a caller outside the assembler
-        (the channel path until PA-7), which keeps the prefix. See
-        ``_client_cache_key``.
+        ported while keying on nothing. Empty = a caller outside the assembler,
+        which keeps the prefix. As of PA-7b that is no longer the channel path
+        (``AgentLoop`` forwards a digest through ``AgentRouter``); it is the
+        pocket specialist calling ``backend.run`` directly and any out-of-tree
+        embedder doing the same. See ``_client_cache_key``.
 
         ``session_handle`` (feat/session-supervisor SS-1) carries native-resume
         identity. When it holds a non-None ``cli_session_id``, the SDK options
@@ -2690,8 +2879,6 @@ class ClaudeSDKBackend(BaseAgentBackend):
                 ),
             )
             return
-
-        import os
 
         self._stop_flag = False
 

--- a/src/pocketpaw/agents/deep_agents.py
+++ b/src/pocketpaw/agents/deep_agents.py
@@ -33,6 +33,12 @@ the site they had just built in a different session. Recompiles cost ~14 ms
 request the graph sends, not to the graph. See the same note in
 ``pydantic_ai.py`` for why that backend fixes it per-run instead.
 
+Updated 2026-08-03 (PA-7b, feat/prompt-assembler-channel): the ``t:`` fallback's
+justification below named a caller that no longer needs it — ``AgentLoop``'s
+channel path now assembles a digest and ``AgentRouter`` forwards it. The branch
+stays; the reason changed to the two callers that reach ``run`` without going
+through the router at all. No code changed in this module.
+
 Updated 2026-08-03 (PA-6, feat/prompt-assembler-seam): ``run`` takes
 ``system_prompt_digest`` and the graph key prefers it over the text hash above.
 The text hash fixed the leak and paid for it with the cache — measured over 8
@@ -42,11 +48,13 @@ the layers that declared themselves cacheable rather than the rendered text, and
 over the same 8 turns produced ONE key. Same correctness, no per-turn recompile.
 
 The text hash SURVIVES as the fallback for a caller that has no digest, and that
-is not tidiness — ``AgentLoop`` (Telegram / Discord / Slack / CLI) builds its
-prompt in ``AgentContextBuilder``, not in the assembler, until PA-7. Dropping the
-hash outright would give those callers a key that cannot see the prompt at all,
-which is #1842 restored on every channel. The two are prefixed so a digest and a
-text hash can never collide.
+is not tidiness. ``AgentLoop`` (Telegram / Discord / Slack / CLI) was the reason
+when this was written; PA-7b gave that path a digest and the fallback still is
+not dead, because the callers that need it never went through ``AgentRouter``:
+the pocket specialist calls ``backend.run`` directly on an isolated backend, and
+so can any OSS embedder. Dropping the hash would give them a key that cannot see
+the prompt at all, which is #1842 restored for the callers least able to notice.
+The two are prefixed so a digest and a text hash can never collide.
 """
 
 import hashlib
@@ -79,8 +87,13 @@ def _prompt_identity(instructions: str, system_prompt_digest: str) -> str:
     cacheable, so the per-message soul recall (an unkeyed layer) does not move it
     and a warm graph survives an ordinary turn. ``t:`` is #1842's hash of the
     rendered text, kept for callers that do not build their prompt through the
-    assembler yet: ``AgentLoop``'s channel path until PA-7 ports it, and any OSS
-    embedder calling ``run`` directly.
+    assembler: the pocket specialist, which builds an isolated backend and calls
+    ``backend.run(user_message, system_prompt=...)`` itself — bypassing the
+    ``AgentRouter`` that does the forwarding — and any OSS embedder doing the
+    same. ``AgentLoop``'s channel path was on that list until PA-7b threaded a
+    digest through the router; the branch did NOT become dead when it left,
+    because the other two callers never went through the router in the first
+    place.
 
     Prefixed rather than concatenated because the two are different CLAIMS about
     the same 16-64 hex chars — "these layers are the same" versus "these bytes
@@ -974,8 +987,9 @@ class DeepAgentsBackend:
         ``AgentPool._accepts_prompt_digest`` inspects this signature to decide
         whether to pass it, and a backend that accepted it silently would look
         ported while keying on nothing. Empty means the caller does not build its
-        prompt through the assembler (the channel path until PA-7), and the graph
-        key falls back to hashing the prompt text — see ``_prompt_identity``.
+        prompt through the assembler — since PA-7b that is the pocket specialist
+        and out-of-tree embedders, not the channel path — and the graph key falls
+        back to hashing the prompt text; see ``_prompt_identity``.
         """
         if not self._sdk_available:
             yield AgentEvent(

--- a/src/pocketpaw/agents/failover.py
+++ b/src/pocketpaw/agents/failover.py
@@ -2,6 +2,16 @@
 #
 # Created: 2026-06-26 (integration/model-catalog-v2, WU-D / MCG-10).
 #
+# Updated: 2026-08-03 (PA-7b, feat/prompt-assembler-channel) — ``run`` now filters
+# ``system_prompt_digest`` per harness instead of forwarding every kwarg verbatim.
+# The channel path assembles a digest for every turn and the chain deliberately
+# mixes backends that declare the parameter with backends that never grew it, so
+# a verbatim forward would raise TypeError on the SECOND harness — during a
+# failover, which is the one moment nothing else is going right either. The
+# signature guard is imported from ``agents.backend`` rather than re-implemented;
+# a local copy is how one of the three call sites ends up counting ``**kwargs``
+# and silently keying on nothing.
+#
 # What this is: the MECHANISM for failing over between agent HARNESSES when a
 # whole backend lane is down. This is the *second* failover level:
 #   * L1 (model / account) is owned by LiteLLM (multi-account weighted failover
@@ -37,6 +47,7 @@ import re
 from collections.abc import AsyncIterator, Callable
 from typing import Any
 
+from pocketpaw.agents.backend import forward_prompt_digest
 from pocketpaw.agents.protocol import AgentEvent
 
 logger = logging.getLogger(__name__)
@@ -177,7 +188,17 @@ class BackendFailoverRunner:
 
         ``run_kwargs`` (system_prompt / history / session_key / the optional
         per-surface frozensets) are forwarded verbatim to each backend's
-        ``run`` — the runner does not interpret them.
+        ``run`` — the runner does not interpret them, with ONE named exception.
+
+        ``system_prompt_digest`` (PA-7b) is dropped for any harness whose ``run``
+        does not declare it. It is the only kwarg here that does not ride the
+        withhold-when-empty contract — it is set on every channel turn — so
+        "forward verbatim" would hand it to a backend with the narrower
+        signature and raise TypeError. The chain mixes vintages by design
+        (claude_agent_sdk -> codex_cli -> opencode), so the question has to be
+        re-asked per harness rather than once by the caller. Asked via the shared
+        ``agents.backend`` guard, which refuses ``**kwargs`` — a harness that
+        swallowed the digest would key on nothing while looking ported.
         """
         last_error: str | None = "All configured harnesses failed"
         tried_any = False
@@ -201,8 +222,16 @@ class BackendFailoverRunner:
             # the generator is fully exhausted/closed before we move on.
             failed_over = False
 
+            attempt_kwargs = run_kwargs
+            if "system_prompt_digest" in run_kwargs:
+                digest = run_kwargs["system_prompt_digest"]
+                attempt_kwargs = {
+                    k: v for k, v in run_kwargs.items() if k != "system_prompt_digest"
+                }
+                attempt_kwargs = forward_prompt_digest(backend, attempt_kwargs, digest)
+
             try:
-                async for event in backend.run(message, **run_kwargs):
+                async for event in backend.run(message, **attempt_kwargs):
                     etype = getattr(event, "type", None)
 
                     # An error event: decide failover BEFORE forwarding it, so a

--- a/src/pocketpaw/agents/loop.py
+++ b/src/pocketpaw/agents/loop.py
@@ -6,6 +6,20 @@ and streams AgentEvent responses back to channels.
 
 PII scanning before memory storage is opt-in via pii_scan_enabled + pii_scan_memory settings.
 
+Updated: 2026-08-03 (PA-7b, feat/prompt-assembler-channel) — the channel turn
+carries its prompt's ``stable_digest`` to the backend. ``_process_message_inner``
+calls ``AgentContextBuilder.assemble_system_prompt`` (which returns the digest
+alongside the text) instead of ``build_system_prompt``, and passes
+``system_prompt_digest`` to ``AgentRouter.run``, which forwards it only to
+backends whose ``run`` declares it. Everything this module does to the prompt
+AFTER assembly — ``_reinforce_identity``'s every-fifth-message identity append —
+moves the text and NOT the digest, on purpose: a backend caching an agent object
+should not rebuild it for a block the prompt already contained. Before this, the
+warm Claude client on Telegram / Discord / Slack / CLI keyed on
+``claude_sdk._behavior_prefix``, which infers the stable region by pattern-
+matching the rendered text and so cannot see a real behaviour change hiding below
+its cut.
+
 Updated: feat/pocketpaw-cognitive-engine
 - start() now builds a PocketPawCognitiveEngine backed by the active AgentRouter
   and passes it to SoulManager.initialize() so the soul's cognition pipeline
@@ -1122,8 +1136,14 @@ class AgentLoop:
             else:
                 agents_md_dir = str(self.settings.file_jail_path)
 
-            system_prompt, history = await asyncio.gather(
-                self.context_builder.build_system_prompt(
+            # ``assemble_system_prompt`` rather than ``build_system_prompt``
+            # (PA-7b): the same assembly, but it hands back the digest as well as
+            # the text. The digest goes to the backend UNMODIFIED while the text
+            # below is still mutated per turn (identity reinforcement, and the
+            # backend's own history splice) — that asymmetry is the point of a
+            # digest over layer keys rather than over bytes.
+            assembled_prompt, history = await asyncio.gather(
+                self.context_builder.assemble_system_prompt(
                     user_query=content,
                     channel=message.channel,
                     sender_id=sender_id,
@@ -1140,6 +1160,7 @@ class AgentLoop:
                     llm_summarize=self.settings.compaction_llm_summarize,
                 ),
             )
+            system_prompt = assembled_prompt.text
 
             # 2a. Emit AGENTS.md event for the dashboard Activity panel
             try:
@@ -1177,6 +1198,13 @@ class AgentLoop:
             if asyncio.iscoroutine(bootstrap_context):
                 bootstrap_context = await bootstrap_context
             identity_block = bootstrap_context.to_identity_block()
+            # Mutates the TEXT and deliberately not the digest: this appends a
+            # copy of a block the prompt already contains, so two turns that
+            # differ only by reinforcement are the same prompt as far as a
+            # backend caching an agent object is concerned. Moving the digest
+            # here would rebuild the warm client every fifth message for no
+            # change in behaviour. Pinned by
+            # ``tests/test_channel_prompt_digest.py``.
             system_prompt = _reinforce_identity(system_prompt, identity_block, message_count)
 
             # 2c. Emit agent_start + thinking events
@@ -1257,7 +1285,15 @@ class AgentLoop:
 
             await _policy_ctx.__aenter__()
             run_iter = router.run(
-                content, system_prompt=system_prompt, history=history, session_key=session_key
+                content,
+                system_prompt=system_prompt,
+                history=history,
+                session_key=session_key,
+                # The router decides per BACKEND whether this is deliverable —
+                # an out-of-tree backend whose ``run`` never declared the
+                # parameter must keep working, so the check is on the signature
+                # and it lives in ``agents.backend``.
+                system_prompt_digest=assembled_prompt.stable_digest,
             )
             try:
                 async for event in run_iter:

--- a/src/pocketpaw/agents/pool.py
+++ b/src/pocketpaw/agents/pool.py
@@ -3,6 +3,14 @@
 Each cloud Agent gets its own AgentBackend + SoulManager + memory namespace.
 Instances are cached and evicted when idle (default 5 minutes).
 
+Updated: 2026-08-03 (PA-7b, feat/prompt-assembler-channel) — ``_accepts_prompt_digest``
+  and ``_accepts_prompt_digest_kwarg`` no longer live here; they moved to
+  ``pocketpaw.agents.backend`` and are re-imported. The channel path grew a
+  digest of its own, so ``AgentRouter`` and ``BackendFailoverRunner`` have to ask
+  the same signature question the pool asks — and three copies of "does this
+  backend declare the digest" is how one of them ends up counting ``**kwargs``.
+  Nothing about the pool's behaviour changed: same functions, same call sites,
+  same name resolution for anything importing them from here.
 Updated: 2026-08-03 (PA-6, feat/prompt-assembler-seam) — ``prewarm`` forwards the
   digest too, and ``_accepts_prompt_digest_kwarg`` is split out to ask the same
   signature question of a bound ``prewarm`` as of a backend class's ``run``. With
@@ -155,9 +163,14 @@ import logging
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from functools import cache
 from typing import TYPE_CHECKING, Any
 
+# Both guards moved to ``agents.backend`` at PA-7b — the router and the failover
+# runner ask the same question now, and the answer is a fact about the backend
+# protocol. Re-imported (not re-implemented) so ``AgentPool``'s own call sites
+# below and the existing ``from pocketpaw.agents.pool import ...`` importers
+# resolve to the ONE definition.
+from pocketpaw.agents.backend import _accepts_prompt_digest, _accepts_prompt_digest_kwarg
 from pocketpaw.agents.errors import (
     AgentBackendUnavailable,
     AgentDisabled,
@@ -304,44 +317,6 @@ def _accepts_policy(backend_cls: type) -> bool:
 
     try:
         return "policy" in inspect.signature(backend_cls.__init__).parameters
-    except (TypeError, ValueError):  # pragma: no cover - exotic callables
-        return False
-
-
-@cache
-def _accepts_prompt_digest(backend_cls: type) -> bool:
-    """Does this backend's ``run`` take a ``system_prompt_digest`` keyword?
-
-    The digest (PA-1) is non-empty on every run, so the withhold-when-empty
-    idiom the other per-run kwargs use cannot gate it — passing it to a backend
-    with the narrower signature would raise TypeError. Asking the signature is
-    the same answer ``_accepts_policy`` gives: a backend opts in by accepting
-    the argument, and the backends that have not been ported yet are untouched.
-    ``**kwargs`` does NOT count — a backend that swallows the digest silently
-    would look ported without keying on anything.
-
-    Cached because this runs once per turn, and a backend class's signature
-    cannot change at runtime.
-    """
-    run = getattr(backend_cls, "run", None)
-    if run is None:  # pragma: no cover - not a backend
-        return False
-    return _accepts_prompt_digest_kwarg(run)
-
-
-def _accepts_prompt_digest_kwarg(func: Any) -> bool:
-    """Does ``func`` name ``system_prompt_digest`` in its signature?
-
-    Split out of ``_accepts_prompt_digest`` at PA-6 because ``prewarm`` needs the
-    same question asked of a BOUND METHOD rather than of a backend class. Not
-    cached: a bound method is a fresh object per access, so a cache keyed on it
-    would grow without ever hitting, and the check is one ``inspect.signature``
-    on a path that already builds SDK options.
-    """
-    import inspect
-
-    try:
-        return "system_prompt_digest" in inspect.signature(func).parameters
     except (TypeError, ValueError):  # pragma: no cover - exotic callables
         return False
 

--- a/src/pocketpaw/agents/router.py
+++ b/src/pocketpaw/agents/router.py
@@ -5,6 +5,17 @@ configured agent backend. Supports optional user-configured fallback
 backends if the primary backend fails.
 
 Changes:
+  - 2026-08-03 (PA-7b, feat/prompt-assembler-channel): ``run`` and
+    ``run_with_failover`` accept ``system_prompt_digest`` — the assembler's
+    ``stable_digest`` for the prompt they were handed — and forward it to a
+    backend only when that backend's ``run`` declares the parameter
+    (``agents.backend.forward_prompt_digest``). The check is per BACKEND, on
+    every one of the three dispatch points here and in ``BackendFailoverRunner``,
+    because both fallback lists mix backends that took the kwarg with backends
+    that never did; a router-level decision would either crash the old ones or
+    withhold from the new ones. This is what lets the channel path's warm Claude
+    subprocess key on the prompt's LAYERS instead of on a pattern-match of its
+    rendered text.
   - 2026-06-26 (MCG-10): Added ``run_with_failover`` — the OSS hook for L2
     cross-backend HARNESS failover. When ``settings.backend_failover_enabled``
     is True it drives the run through ``BackendFailoverRunner`` over
@@ -22,7 +33,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Any
 
-from pocketpaw.agents.backend import BackendInfo
+from pocketpaw.agents.backend import BackendInfo, forward_prompt_digest
 from pocketpaw.agents.failover import BackendFailoverRunner
 from pocketpaw.agents.protocol import AgentEvent
 from pocketpaw.agents.registry import get_backend_class
@@ -159,19 +170,36 @@ class AgentRouter:
         system_prompt: str | None = None,
         history: list[dict] | None = None,
         session_key: str | None = None,
+        system_prompt_digest: str = "",
     ) -> AsyncIterator[AgentEvent]:
-        """Run the agent with optional fallback backends."""
+        """Run the agent with optional fallback backends.
+
+        ``system_prompt_digest`` (PA-7b) is the assembler's ``stable_digest`` for
+        ``system_prompt``, supplied by ``AgentLoop`` on the channel path. It is
+        forwarded to a backend ONLY when that backend's ``run`` declares the
+        parameter — see ``agents.backend.forward_prompt_digest``. That check is
+        per BACKEND and not per router because the fallback list is heterogeneous
+        by construction: the primary may be the Claude SDK backend (which keys
+        its warm subprocess on the digest) while a fallback is one of the
+        backends that never grew the kwarg, and passing it to the latter would
+        raise TypeError mid-failover — a crash on the path taken when something
+        is already wrong. Callers with no digest (``paw/cli``, deep-work,
+        mission-control) leave it "" and nothing about their call changes.
+        """
 
         last_error: str | None = None
+        base_kwargs: dict[str, Any] = {
+            "system_prompt": system_prompt,
+            "history": history,
+            "session_key": session_key,
+        }
 
         # Primary backend (streaming, no buffering, no error-event fallback)
         if self._backend is not None:
             try:
                 async for event in self._backend.run(
                     message,
-                    system_prompt=system_prompt,
-                    history=history,
-                    session_key=session_key,
+                    **forward_prompt_digest(self._backend, base_kwargs, system_prompt_digest),
                 ):
                     yield event
 
@@ -199,9 +227,7 @@ class AgentRouter:
             try:
                 async for event in backend.run(
                     message,
-                    system_prompt=system_prompt,
-                    history=history,
-                    session_key=session_key,
+                    **forward_prompt_digest(backend, base_kwargs, system_prompt_digest),
                 ):
                     yield event
 
@@ -243,6 +269,7 @@ class AgentRouter:
         system_prompt: str | None = None,
         history: list[dict] | None = None,
         session_key: str | None = None,
+        system_prompt_digest: str = "",
     ) -> AsyncIterator[AgentEvent]:
         """Run with L2 cross-backend (harness) failover when enabled.
 
@@ -255,6 +282,14 @@ class AgentRouter:
 
         The EE cloud run path (``run_core``) calling this is a follow-up; the
         mechanism + this hook ship in the OSS slice.
+
+        ``system_prompt_digest`` (PA-7b) travels down BOTH branches. Threading
+        only :meth:`run` would drop it exactly when the flag is on and the chain
+        is in use — a silent downgrade to text-hash keying on the path taken when
+        the primary harness is already down, which is the worst moment to also
+        start rebuilding the warm client every turn. The runner re-asks the
+        signature question per harness, because the chain deliberately mixes
+        backends of different vintages.
         """
         if not self.settings.backend_failover_enabled:
             async for event in self.run(
@@ -262,6 +297,7 @@ class AgentRouter:
                 system_prompt=system_prompt,
                 history=history,
                 session_key=session_key,
+                system_prompt_digest=system_prompt_digest,
             ):
                 yield event
             return
@@ -273,6 +309,7 @@ class AgentRouter:
             system_prompt=system_prompt,
             history=history,
             session_key=session_key,
+            system_prompt_digest=system_prompt_digest,
         ):
             yield event
 

--- a/src/pocketpaw/bootstrap/context_builder.py
+++ b/src/pocketpaw/bootstrap/context_builder.py
@@ -1,6 +1,16 @@
 """
 Builder for assembling the full agent context.
 Created: 2026-02-02
+Updated: 2026-08-03 (PA-7b, feat/prompt-assembler-channel) — the digest stops
+being thrown away. The assembler call moved into a new
+``assemble_system_prompt`` that returns the whole ``AssembledPrompt``;
+``build_system_prompt`` is now a delegate returning its ``.text``. The return
+type stayed ``str`` because this is public OSS API and ~30 in-tree call sites
+(the byte goldens among them) read it as one — the same courtesy the digest
+threading extends to an out-of-tree backend whose ``run`` never declared the
+parameter. One body, so the text a caller reads and the text the digest was
+computed over cannot drift. ``AgentLoop`` calls the new method and forwards
+``stable_digest`` to the backend; see ``agents/loop.py`` and ``agents/router.py``.
 Updated: 2026-08-03 (PA-7a, feat/prompt-assembler-channel) — THIS MODULE NO
 LONGER ASSEMBLES ANYTHING. ``build_system_prompt`` resolves the fifteen
 ``channel.*`` layers from ``pocketpaw.prompt.registry`` and calls
@@ -89,7 +99,7 @@ from pocketpaw.bootstrap.default_provider import DefaultBootstrapProvider
 from pocketpaw.bootstrap.protocol import BootstrapProviderProtocol
 from pocketpaw.bus.events import Channel
 from pocketpaw.memory.manager import MemoryManager, get_memory_manager
-from pocketpaw.prompt import PromptContext, assemble, prompt_layer_registry
+from pocketpaw.prompt import AssembledPrompt, PromptContext, assemble, prompt_layer_registry
 from pocketpaw.prompt.channel import CHANNEL_PROMPT_LAYERS, ChannelInputs
 
 logger = logging.getLogger(__name__)
@@ -209,7 +219,73 @@ class AgentContextBuilder:
         kb_ctx: KbContext | None = None,
         skill_names: frozenset[str] | None = None,
     ) -> str:
-        """Build the complete system prompt.
+        """The assembled prompt TEXT. See :meth:`assemble_system_prompt` for the rest.
+
+        STILL RETURNS ``str``, and that is PA-7b's return-type decision rather
+        than an omission. The digest had to reach ``AgentLoop`` and this method
+        had two things to hand back; the options were to widen the return type
+        or to split the method, and the split wins on one argument that the
+        surrounding sprint already accepts elsewhere: this is public OSS API. An
+        out-of-tree embedder calling it gets a string today, and the same
+        reasoning that leaves an out-of-tree BACKEND whose ``run`` lacks
+        ``system_prompt_digest`` working untouched (see
+        ``agents.backend._accepts_prompt_digest``) applies to a caller that does
+        ``len(prompt)`` on the result. Thirty in-tree call sites — every golden,
+        every bootstrap test — also keep working unedited, which means the byte
+        baseline is checked by the tests that already existed rather than by
+        thirty edited ones.
+
+        There is exactly ONE body: this delegates, so the text can never drift
+        from the text the digest was computed over. Every argument is forwarded
+        unchanged; they are documented on ``assemble_system_prompt``.
+        """
+        return (
+            await self.assemble_system_prompt(
+                include_memory=include_memory,
+                user_query=user_query,
+                channel=channel,
+                sender_id=sender_id,
+                session_key=session_key,
+                file_context=file_context,
+                agents_md_dir=agents_md_dir,
+                metadata=metadata,
+                budget_chars=budget_chars,
+                image_bytes=image_bytes,
+                kb_ctx=kb_ctx,
+                skill_names=skill_names,
+            )
+        ).text
+
+    async def assemble_system_prompt(
+        self,
+        include_memory: bool = True,
+        user_query: str | None = None,
+        channel: Channel | None = None,
+        sender_id: str | None = None,
+        session_key: str | None = None,
+        file_context: dict | None = None,
+        agents_md_dir: str | None = None,
+        metadata: dict | None = None,
+        budget_chars: int = _DEFAULT_BUDGET_CHARS,
+        image_bytes: bytes | None = None,
+        kb_ctx: KbContext | None = None,
+        skill_names: frozenset[str] | None = None,
+    ) -> AssembledPrompt:
+        """Build the complete system prompt, and the digest of its stable layers.
+
+        The real body; ``build_system_prompt`` is its ``.text``. Named to match
+        ``AgentPool._assemble_system_prompt``, which returns the same type on the
+        cloud path — one shape for "assemble a prompt", two callers.
+
+        ``stable_digest`` is a hash over the KEYED layers' ``cache_key`` values,
+        NOT over the returned text (see ``pocketpaw.prompt.assembler``). What it
+        deliberately does not cover is everything done to the text AFTER this
+        returns: ``AgentLoop._reinforce_identity`` appends the identity block
+        every 5th message, and ``ClaudeSDKBackend.run`` splices a growing
+        ``# Recent Conversation`` block into ``options.system_prompt``. Both are
+        per-turn mutations of stable content, and a digest that moved for them
+        would rebuild the warm client on the turns they fire — the exact churn
+        the layered digest exists to remove.
 
         Args:
             include_memory: Whether to include memory context.
@@ -312,12 +388,14 @@ class AgentContextBuilder:
             ),
         )
         layers = [prompt_layer_registry.get(name) for name in CHANNEL_PROMPT_LAYERS]
-        assembled = await assemble(layers, ctx, budget_chars=budget_chars)
-        # ``assembled.stable_digest`` is deliberately dropped. Nothing on the
-        # channel path caches an agent object with the prompt baked in, so there
-        # is nothing to fold it into yet; the layers answer ``cache_key``
-        # honestly anyway so the digest is correct the day one does.
-        return assembled.text
+        # Returned WHOLE as of PA-7b. Until then this method took ``.text`` and
+        # threw the digest away, because nothing downstream could receive it;
+        # ``AgentLoop`` now forwards it through ``AgentRouter`` to any backend
+        # whose ``run`` declares the parameter, so the channel path's warm client
+        # keys on what the LAYERS said about themselves instead of on
+        # ``claude_sdk._behavior_prefix``'s guess at where the volatile region
+        # starts.
+        return await assemble(layers, ctx, budget_chars=budget_chars)
 
     @staticmethod
     def _build_atlas_primer() -> str:

--- a/src/pocketpaw/bootstrap/context_builder.py
+++ b/src/pocketpaw/bootstrap/context_builder.py
@@ -1,6 +1,25 @@
 """
 Builder for assembling the full agent context.
 Created: 2026-02-02
+Updated: 2026-08-03 (PA-7a, feat/prompt-assembler-channel) — THIS MODULE NO
+LONGER ASSEMBLES ANYTHING. ``build_system_prompt`` resolves the fifteen
+``channel.*`` layers from ``pocketpaw.prompt.registry`` and calls
+``pocketpaw.prompt.assemble``; ``_assemble_with_budget``, ``_Priority`` and
+``_INJECTION_CAPS`` are deleted. The runtime had two prompt assemblers with two
+sets of rules for caps and budgets — the cloud path moved to the layered one in
+PR #1851 and this is the channel half following it. The block bodies moved into
+``pocketpaw.prompt.channel``; the caps moved onto each layer's ``max_chars``
+unchanged, including the two blocks (``pocket_context``, ``current_pocket``)
+that ``_INJECTION_CAPS`` never had an entry for and which are therefore still
+uncapped. What STAYS here is the ``asyncio.gather``: the bootstrap, memory and
+kb fetches run concurrently and their results are handed to the layers as plain
+data, because ``assemble`` renders sequentially and three self-fetching layers
+would pay their sum where the gather pays their max. One intended behaviour
+change: a CRITICAL block that overruns the budget is now emitted WHOLE rather
+than cut to ``remaining`` — a budget-sized cut is sized from what the block's
+SIBLINGS rendered, so one cache key would name two different texts (see
+``prompt.layer.Priority``). The assembled digest is available and DISCARDED;
+nothing on the channel path caches an agent on it yet.
 Updated: 2026-07-02 (feat/atlas-surface, AT-3) — new always-on "Paw OS
 primer" block (#8b, ``atlas_primer``): a compact OS-identity paragraph, the
 primitive one-liners generated at build time from the atlas store (never
@@ -63,15 +82,15 @@ Updated: 2026-02-10 - Channel-aware format hints
 from __future__ import annotations
 
 import asyncio
-import enum
 import logging
 from dataclasses import dataclass
 
 from pocketpaw.bootstrap.default_provider import DefaultBootstrapProvider
 from pocketpaw.bootstrap.protocol import BootstrapProviderProtocol
 from pocketpaw.bus.events import Channel
-from pocketpaw.bus.format import CHANNEL_FORMAT_HINTS
 from pocketpaw.memory.manager import MemoryManager, get_memory_manager
+from pocketpaw.prompt import PromptContext, assemble, prompt_layer_registry
+from pocketpaw.prompt.channel import CHANNEL_PROMPT_LAYERS, ChannelInputs
 
 logger = logging.getLogger(__name__)
 
@@ -137,32 +156,16 @@ def _resolve_kb_scopes(ctx: KbContext | None, settings) -> list[str]:
     return scopes
 
 
-class _Priority(enum.IntEnum):
-    """Injection block priority — lower value = higher priority."""
-
-    CRITICAL = 0  # Always include, truncate only as last resort
-    HIGH = 1  # Include if budget allows, truncate to cap
-    MEDIUM = 2  # Include if budget allows, skip if tight
-    LOW = 3  # First to drop when budget is exceeded
-
-
-# Default character caps per injection block (None = no cap, use remaining budget)
-_INJECTION_CAPS: dict[str, int | None] = {
-    "identity": None,  # Critical — never capped
-    "instructions": None,  # Critical — never capped
-    "memory_context": 4000,
-    "kb_context": 3000,
-    "sender_block": 500,
-    "channel_hints": 500,
-    "channel_instructions": 1000,
-    "session_key": 200,
-    "file_context": 2000,
-    "health_state": 300,
-    "skills_list": 2000,
-    "atlas_primer": 2000,  # ~500 tokens hard ceiling for the Paw OS primer
-    "agents_md": 3000,
-    "gws_instructions": 1000,
-}
+# ``_Priority`` and ``_INJECTION_CAPS`` lived here until PA-7a. The drop order
+# is now ``pocketpaw.prompt.layer.Priority`` — one enum for the whole runtime,
+# with the same members and the same values, so nothing had to be translated.
+# The caps are now each layer's ``max_chars`` in ``pocketpaw.prompt.channel``,
+# with the numbers carried across unchanged. Two things the old table got wrong
+# were carried across too rather than fixed, because PA-9 is the task with the
+# measurements: it capped ``instructions``, a block this path never produced,
+# and it had no entry at all for ``pocket_context`` or ``current_pocket``, which
+# are therefore uncapped — ``current_pocket`` ``json.dumps`` a widget summary
+# into the prompt with no bound.
 
 _DEFAULT_BUDGET_CHARS = 32_000
 
@@ -174,10 +177,13 @@ class AgentContextBuilder:
     2. Dynamic Memory (MemoryManager)
     3. Current State (e.g., date/time, active tasks)
 
-    Uses a priority-based budget system to prevent unbounded prompt growth.
-    Each injection block has a priority (_Priority) and optional per-block cap
-    (_INJECTION_CAPS). When the total exceeds budget_chars, lower-priority
-    blocks are dropped first while CRITICAL blocks are truncated as a last resort.
+    Since PA-7a it does not do the assembling. It resolves the inputs — running
+    the three independent fetches concurrently — hands them to the
+    ``channel.*`` layers as a :class:`~pocketpaw.prompt.channel.inputs.ChannelInputs`,
+    and lets :func:`pocketpaw.prompt.assemble` apply the per-layer caps and the
+    budget. Lower-priority layers are dropped whole when the budget is tight;
+    a CRITICAL one is emitted whole and the budget overruns, because a
+    budget-sized cut cannot be reconciled with a cache key.
     """
 
     def __init__(
@@ -235,11 +241,22 @@ class AgentContextBuilder:
                 legacy all-skills advertisement — every non-entity run is
                 unchanged.
         """
-        blocks: list[tuple[str, _Priority, str]] = []
-
         # 1. Load static identity, memory context, and kb context concurrently
         # (independent I/O — identity is a function call, memory hits disk/vector db,
         # kb shells out to a subprocess). asyncio.gather keeps the critical path fast.
+        #
+        # THIS STAYS HERE RATHER THAN MOVING INTO THREE LAYERS, and it is the one
+        # structural decision PA-7a made that is not "move the block". ``assemble``
+        # renders layers in a sequential ``for`` loop, so a memory layer and a kb
+        # layer each awaiting their own fetch would cost their SUM on every channel
+        # turn where this gather costs their MAX — and the kb one spawns a
+        # subprocess. Making ``assemble`` render concurrently would fix it too, and
+        # was rejected: it changes the CLOUD path's execution model to solve a
+        # channel-path problem, and no cloud layer has been audited for
+        # order-independence. So the fetches stay batched here and their results
+        # cross as plain data, which is the discipline ``surface_preamble`` and
+        # ``atlas_primer`` already use. Pinned by
+        # ``tests/test_channel_prompt_layers.py::test_the_three_io_fetches_still_run_concurrently``.
         if include_memory:
             if user_query:
                 memory_coro = self.memory.get_semantic_context(user_query, sender_id=sender_id)
@@ -257,351 +274,64 @@ class AgentContextBuilder:
             )
             memory_context = ""
 
-        base_prompt = context.to_system_prompt()
-        blocks.append(("identity", _Priority.CRITICAL, base_prompt))
-
-        # 2. Inject memory context (scoped to sender)
         # When soul is active, soul's bootstrap provider already handles persistent
         # memory (identity, personality, knowledge domains). Skip regular long-term
         # memory injection to avoid duplication — the agent should use soul_recall
-        # for fact retrieval instead. Session history is still managed by regular memory.
+        # for fact retrieval instead. Session history is still managed by regular
+        # memory. The decision lives here, not in the layer, because only the
+        # builder holds the provider it is a fact about.
         from pocketpaw.soul import SoulBootstrapProvider
 
-        soul_active = isinstance(self.bootstrap, SoulBootstrapProvider)
-        if include_memory and memory_context and not soul_active:
-            mem_block = (
-                "\n# Memory Context (already loaded — use this directly, "
-                "do NOT call recall unless you need something not listed here)\n" + memory_context
-            )
-            blocks.append(("memory_context", _Priority.HIGH, mem_block))
+        if isinstance(self.bootstrap, SoulBootstrapProvider):
+            memory_context = ""
 
-        # 2b. Inject kb (knowledge base) context — structured articles from source files
-        # This runs alongside soul memory: soul handles "what we discussed", kb handles
-        # "what the code currently says". The two complement each other, so we inject
-        # both when available. See https://github.com/qbtrix/kb-go for the kb tool.
-        if kb_context:
-            kb_block = (
-                "\n# Knowledge Base (relevant articles from the project wiki)\n"
-                "These are compiled from source files. Use them for implementation "
-                "details and current-state facts. Use soul_recall for past decisions "
-                "and conversation history.\n\n" + kb_context
-            )
-            blocks.append(("kb_context", _Priority.HIGH, kb_block))
-
-        # 3. Inject sender identity block
-        if sender_id:
-            from pocketpaw.config import get_settings
-
-            settings = get_settings()
-            if settings.owner_id:
-                is_owner = sender_id == settings.owner_id
-                role = "owner" if is_owner else "external user"
-                identity_block = (
-                    f"\n# Current Conversation\n"
-                    f"You are speaking with sender_id={sender_id} (role: {role})."
-                )
-                if is_owner:
-                    identity_block += "\nThis is your owner."
-                else:
-                    identity_block += (
-                        "\nThis is NOT your owner. Be helpful but do not share "
-                        "owner-private information."
-                    )
-                blocks.append(("sender_block", _Priority.HIGH, identity_block))
-
-        # 4. Inject channel format hint
-        if channel:
-            hint = CHANNEL_FORMAT_HINTS.get(channel, "")
-            if hint:
-                blocks.append(("channel_hints", _Priority.LOW, f"\n# Response Format\n{hint}"))
-
-        # 4b. Inject channel-specific instructions (e.g. discord.md)
-        if channel:
-            channel_instructions = self._load_channel_instructions(channel)
-            if channel_instructions:
-                # Inject dynamic context (username, guild_id) from metadata
-                meta = metadata or {}
-                username = meta.get("username", "")
-                guild_id = meta.get("guild_id", "")
-                ctx_lines = []
-                if sender_id:
-                    ctx_lines.append(f"sender_id: {sender_id}")
-                if username:
-                    ctx_lines.append(f"discord_username: {username}")
-                if guild_id:
-                    ctx_lines.append(f"discord_guild_id: {guild_id}")
-                if ctx_lines:
-                    channel_instructions += "\n\n## Current Context\n" + "\n".join(ctx_lines)
-                blocks.append(("channel_instructions", _Priority.MEDIUM, channel_instructions))
-
-        # 4c. Inject pocket creation context (from pocket chat endpoint)
-        if metadata and metadata.get("pocket_system_context"):
-            blocks.append(("pocket_context", _Priority.HIGH, metadata["pocket_system_context"]))
-
-        # 4d. Inject current pocket info so the AI knows what pocket is open.
-        # The full pocket document is NOT embedded here — that would blow the
-        # Windows CLI arg limit for large rippleSpec.ui trees. The agent
-        # retrieves it on demand via the `mcp__pocketpaw_pocket__get_pocket`
-        # tool (the EE in-process pocketpaw_pocket MCP server).
-        if metadata and metadata.get("pocket_context"):
-            import json
-
-            pc = metadata["pocket_context"]
-            pocket_id = pc.get("id", "unknown")
-            widget_summary = pc.get("widgets", [])
-            pocket_tag = (
-                f"\n<current-pocket>\n"
-                f"id: {pocket_id}\n"
-                f"name: {pc.get('name', 'Untitled')}\n"
-                f"widgets_summary: {json.dumps(widget_summary)}\n"
-                f"\n"
-                f"SCOPE — read this carefully before doing anything:\n"
-                f'In this conversation, "pocket" / "this pocket" / "the\n'
-                f'pocket" always means THIS workspace dashboard\n'
-                f"(id ``{pocket_id}``) — a MongoDB document the user is\n"
-                f"viewing on screen. It is NOT the PocketPaw application,\n"
-                f"NOT the source tree on disk, NOT any file under\n"
-                f'``D:\\paw`` or ``backend/`` or ``ee/cloud/``. "Edit the\n'
-                f'pocket", "add a widget", "more widgets" all refer to\n'
-                f"this document — operate on it through the\n"
-                f"``mcp__pocketpaw_pocket__*`` tools ONLY. Do NOT use\n"
-                f"shell, file_edit, grep, or web_search for pocket\n"
-                f"operations — they cannot read or write the document.\n"
-                f"\n"
-                f"NOTE: `widgets_summary` is a shallow hint (names + types)\n"
-                f"and is OFTEN EMPTY for UISpec-tree pockets — absence here\n"
-                f"does NOT mean the pocket is empty. The real content lives\n"
-                f"in rippleSpec.ui.\n"
-                f"\n"
-                f"BEFORE answering any question about this pocket's contents,\n"
-                f"widgets, layout, data, or configuration, you MUST first call:\n"
-                f"  tool: mcp__pocketpaw_pocket__get_pocket\n"
-                f'  args: {{"pocket_id": "{pocket_id}"}}\n'
-                f"That returns the full document (rippleSpec, widgets,\n"
-                f"metadata, visibility). Base your answer on that, not on\n"
-                f"the summary above.\n"
-                f"</current-pocket>\n"
-            )
-            blocks.append(("current_pocket", _Priority.HIGH, pocket_tag))
-
-        # 5. Inject session key for session management tools
-        if session_key:
-            session_block = (
-                f"\n# Session Management\n"
-                f"Current session_key: {session_key}\n"
-                f"Pass this value to any session tool (new_session, list_sessions, "
-                f"switch_session, clear_session, rename_session, delete_session)."
-            )
-            blocks.append(("session_key", _Priority.MEDIUM, session_block))
-
-        # 6. Inject file context from desktop client
-        if file_context:
-            import re
-
-            def _sanitize_path(p: str) -> str:
-                """Strip non-path characters to prevent prompt injection."""
-                return re.sub(r"[^\w\s\-./\\:~]", "", p).strip()
-
-            fc_parts = []
-            if file_context.get("current_dir"):
-                fc_parts.append(f"Working directory: {_sanitize_path(file_context['current_dir'])}")
-            if file_context.get("open_file"):
-                fc_parts.append(f"Open file: {_sanitize_path(file_context['open_file'])}")
-            if file_context.get("selected_files"):
-                safe_files = [_sanitize_path(f) for f in file_context["selected_files"]]
-                fc_parts.append(f"Selected files: {', '.join(safe_files)}")
-            if fc_parts:
-                blocks.append(
-                    (
-                        "file_context",
-                        _Priority.MEDIUM,
-                        "\n# File Context\n" + "\n".join(fc_parts),
-                    )
-                )
-
-        # 7. Inject health state (only when degraded/unhealthy — saves context window)
-        try:
-            from pocketpaw.health import get_health_engine
-
-            health_block = get_health_engine().get_health_prompt_section()
-            if health_block:
-                blocks.append(("health_state", _Priority.LOW, health_block))
-        except Exception as exc:  # noqa: BLE001
-            logger.debug("Health engine failure (non-fatal, skipping health block): %s", exc)
-
-        # 8. Inject available skills so the agent knows what exists
-        try:
-            from pocketpaw.skills import get_skill_loader
-
-            loader = get_skill_loader()
-            skills = loader.get_all()
-            # entity-rooms A2: when the entity pins a non-empty skill subset,
-            # advertise ONLY those skills (the non-SDK equivalent of the SDK's
-            # per-run materialized plugin). Empty / None → legacy all-skills
-            # behavior, so every non-entity run is unchanged.
-            if skill_names:
-                skills = {n: s for n, s in skills.items() if n in skill_names}
-            if skills:
-                skill_lines = []
-                for s in skills.values():
-                    invocable = " (user-invocable)" if s.user_invocable else ""
-                    skill_lines.append(f"- **{s.name}**: {s.description}{invocable}")
-                search_dirs = ", ".join(str(p) for p in loader.paths)
-                skills_block = (
-                    "\n# Available Skills\n"
-                    "The following skills have been created and are available. "
-                    "Do NOT recreate them or forget they exist.\n"
-                    + "\n".join(skill_lines)
-                    + f"\n\nSkills directories: {search_dirs}"
-                )
-                blocks.append(("skills_list", _Priority.MEDIUM, skills_block))
-        except Exception as exc:
-            logger.debug("Skill injection skipped: %s", exc)
-
-        # 8b. Inject the Paw OS primer (atlas) — OS identity, the primitive
-        # one-liners (generated from the atlas store so they can't drift from
-        # the seed), and the atlas_search / surface-route instructions. Same
-        # MEDIUM priority as the skills block; an atlas failure never breaks
-        # prompt building.
-        try:
-            primer = self._build_atlas_primer()
-            if primer:
-                blocks.append(("atlas_primer", _Priority.MEDIUM, primer))
-        except Exception as exc:  # noqa: BLE001
-            logger.debug("Atlas primer skipped (non-fatal): %s", exc)
-
-        # 9. Inject AGENTS.md constraints from the target repo
-        if agents_md_dir:
-            try:
-                from pocketpaw.agents_md import AgentsMdLoader
-
-                agents_md = AgentsMdLoader().find_and_load(agents_md_dir)
-                if agents_md:
-                    blocks.append(("agents_md", _Priority.MEDIUM, agents_md.constraints_block))
-            except Exception:
-                pass  # AGENTS.md failure never breaks prompt building
-
-        # 10. Inject GWS CLI guidance when google-workspace MCP server is active
-        try:
-            gws_block = self._load_gws_instructions()
-            if gws_block:
-                blocks.append(("gws_instructions", _Priority.MEDIUM, gws_block))
-        except Exception:
-            pass  # GWS injection failure never breaks prompt building
-
-        return self._assemble_with_budget(blocks, budget_chars=budget_chars)
-
-    @staticmethod
-    def _assemble_with_budget(
-        blocks: list[tuple[str, _Priority, str]],
-        budget_chars: int = _DEFAULT_BUDGET_CHARS,
-    ) -> str:
-        """Assemble system prompt blocks respecting a character budget.
-
-        Blocks are processed in priority order (CRITICAL first).
-        Each block is capped by _INJECTION_CAPS if defined.
-        Lower-priority blocks are skipped when budget is exceeded.
-        """
-        # Sort by priority (CRITICAL=0 first), preserving insertion order for ties
-        sorted_blocks = sorted(blocks, key=lambda b: b[1])
-        result_parts: list[str] = []
-        remaining = budget_chars
-
-        for name, priority, content in sorted_blocks:
-            if not content or not content.strip():
-                continue
-
-            # Apply per-block cap
-            cap = _INJECTION_CAPS.get(name)
-            if cap and len(content) > cap:
-                content = content[:cap] + "\n[...truncated]"
-
-            # Check budget
-            if len(content) > remaining:
-                if priority == _Priority.CRITICAL:
-                    # Critical blocks get truncated to fit
-                    content = content[:remaining]
-                    logger.warning(
-                        "Truncated CRITICAL block '%s' to %d chars (budget exhausted)",
-                        name,
-                        remaining,
-                    )
-                else:
-                    logger.info(
-                        "Skipped block '%s' (%d chars, priority %s) — budget exhausted"
-                        " (%d remaining)",
-                        name,
-                        len(content),
-                        priority.name,
-                        remaining,
-                    )
-                    continue
-
-            result_parts.append(content)
-            remaining -= len(content)
-
-        return "\n\n".join(result_parts)
+        ctx = PromptContext(
+            # No ``AgentInstance`` on this path and none faked: the pool's
+            # instance is a cloud concept, and every field the channel layers
+            # read arrives on ``channel_inputs`` instead. The cloud-only fields
+            # take their no-content defaults, so a cloud layer that ever appears
+            # in a channel list renders nothing rather than reading a stub.
+            instance=None,
+            agent_id="",
+            message=user_query or "",
+            instructions="",
+            knowledge_context="",
+            system_message_override=None,
+            channel_inputs=ChannelInputs(
+                identity=context.to_system_prompt(),
+                identity_cache_key=getattr(context, "identity_cache_key", None),
+                memory_context=memory_context,
+                kb_context=kb_context,
+                channel=channel,
+                sender_id=sender_id,
+                session_key=session_key,
+                file_context=file_context,
+                metadata=metadata,
+                agents_md_dir=agents_md_dir,
+                skill_names=skill_names,
+            ),
+        )
+        layers = [prompt_layer_registry.get(name) for name in CHANNEL_PROMPT_LAYERS]
+        assembled = await assemble(layers, ctx, budget_chars=budget_chars)
+        # ``assembled.stable_digest`` is deliberately dropped. Nothing on the
+        # channel path caches an agent object with the prompt baked in, so there
+        # is nothing to fold it into yet; the layers answer ``cache_key``
+        # honestly anyway so the digest is correct the day one does.
+        return assembled.text
 
     @staticmethod
     def _build_atlas_primer() -> str:
-        """Build the compact always-on "Paw OS primer" block (AT-3).
+        """Delegate to the atlas layer's builder (moved there in PA-7a).
 
-        Three parts, ~500 tokens hard ceiling (enforced twice: the seed keeps
-        each line short, and ``_INJECTION_CAPS['atlas_primer']`` caps the
-        rendered block at 2000 chars):
-
-        1. One-paragraph OS identity ("you run inside paw-os ...").
-        2. One line per primitive — name + gist, generated at build time from
-           the atlas store so a seed edit can never drift from the prompt.
-           Prefer the entry's authored ``gist`` (a complete, self-contained
-           one-liner that ends on a full clause). Only when a primitive has no
-           ``gist`` fall back to a clause-aware truncation of ``summary`` — cut
-           at the last full word before the cap so a line never dangles
-           mid-phrase (the old fixed-108-char cut dropped load-bearing words
-           like Belt's "Instinct gate" and Branch's "review/merge/publish").
-        3. The standing instruction: ``atlas_search`` before guessing about
-           OS capabilities, and include the ``surface`` route when pointing
-           a user somewhere.
-
-        Returns "" when the store has no primitives. Raises on store load
-        failure — the caller wraps this in try/except (same pattern as the
-        skills block) so prompt building never breaks.
+        The body moved to ``pocketpaw.prompt.channel.environment`` so it renders
+        inside a layer and under the assembler's render guard, which is what
+        replaced this block's ``try/except``. The name stays because
+        ``tests/atlas/test_primer_block.py`` drives the seed's content through
+        it, and that content is worth keeping under test at a stable name.
         """
-        from pocketpaw.atlas.store import get_atlas_store
+        from pocketpaw.prompt.channel.environment import build_atlas_primer
 
-        primitives = [e for e in get_atlas_store().entries if e.kind == "primitive"]
-        if not primitives:
-            return ""
-
-        lines: list[str] = []
-        for entry in primitives:
-            gist = (entry.gist or "").strip().rstrip(".")
-            if not gist:
-                # No authored gist — fall back to the summary's first clause,
-                # cut clause-aware at the last full word before the cap so the
-                # line still ends cleanly rather than mid-phrase.
-                gist = entry.summary.split(";")[0].strip().rstrip(".")
-                if len(gist) > 110:
-                    gist = gist[:108].rsplit(" ", 1)[0]
-                    if gist.count("(") > gist.count(")"):
-                        gist = gist[: gist.rindex("(")]
-                    gist = gist.rstrip(" ,.:;(") + "…"
-            suffix = "" if gist.endswith("…") else "."
-            lines.append(f"- {entry.name}: {gist}{suffix}")
-
-        return (
-            "\n# Paw OS Primer\n"
-            "You run inside paw-os, an agentic workspace OS. Its primitives "
-            "carry paw-specific meanings (a Pocket is a workspace app, not "
-            "clothing), and users see results on frontend surfaces — routes "
-            "like /sites.\n\n"
-            "OS primitives:\n" + "\n".join(lines) + "\n\n"
-            "Before guessing whether the OS can do something or which "
-            "primitive fits, call atlas_search with your intent, then "
-            "atlas_describe on the best id. When an action has a home "
-            "surface, tell the user where to see it by route (e.g. "
-            '"see it at /sites") — entries carry it in their `surface` field.'
-        )
+        return build_atlas_primer()
 
     @staticmethod
     async def _get_kb_context(
@@ -868,39 +598,3 @@ class AgentContextBuilder:
             elif title:
                 parts.append(f"- {title}")
         return "\n".join(parts)
-
-    @staticmethod
-    def _load_channel_instructions(channel: Channel) -> str:
-        """Load channel-specific instruction file (e.g. discord.md)."""
-        from pathlib import Path
-
-        _channel_files = {
-            Channel.DISCORD: "discord.md",
-        }
-        filename = _channel_files.get(channel)
-        if not filename:
-            return ""
-        path = Path(__file__).parent / filename
-        if not path.exists():
-            return ""
-        try:
-            return path.read_text(encoding="utf-8").strip()
-        except Exception:
-            return ""
-
-    @staticmethod
-    def _load_gws_instructions() -> str:
-        """Load GWS CLI guidance if the google-workspace MCP server is active."""
-        from pathlib import Path
-
-        from pocketpaw.mcp.config import load_mcp_config
-
-        configs = load_mcp_config()
-        gws_active = any(c.name == "google-workspace" and c.enabled for c in configs)
-        if not gws_active:
-            return ""
-
-        path = Path(__file__).parent / "gws.md"
-        if not path.exists():
-            return ""
-        return path.read_text(encoding="utf-8").strip()

--- a/src/pocketpaw/prompt/__init__.py
+++ b/src/pocketpaw/prompt/__init__.py
@@ -20,6 +20,15 @@ Updated: 2026-08-03 (PA-5) — exports :class:`Priority`, :class:`AtlasPrimerLay
   with caps that can bite, and neither has a producer yet — wiring them moves
   bytes, which is PA-6/PA-7's business, not this task's.
 
+Updated: 2026-08-03 (PA-7a) — exports :class:`ChannelInputs` and
+  ``CHANNEL_PROMPT_LAYERS``. The channel path (Telegram / Discord / Slack / CLI)
+  assembles here now, which retires ``context_builder._assemble_with_budget``
+  and leaves the runtime with one prompt assembler. The fifteen channel layers
+  themselves live in :mod:`pocketpaw.prompt.channel` and are reached through the
+  registry by name; only the input type and the ordered name list are worth
+  re-exporting, because a caller needs exactly those two to assemble a channel
+  prompt.
+
 The public surface for anyone writing a prompt layer or consuming an assembled
 prompt. Start at :class:`LayerOutput` — its ``cache_key`` field is what makes
 the "is this content volatile" question unskippable, and that question is the
@@ -28,6 +37,7 @@ one three backends independently got wrong before PR #1842.
 
 from pocketpaw.prompt.assembler import AssembledPrompt, DroppedLayer, assemble
 from pocketpaw.prompt.atlas import AtlasPrimerLayer
+from pocketpaw.prompt.channel import CHANNEL_PROMPT_LAYERS, ChannelInputs
 from pocketpaw.prompt.identity import AgentIdentityLayer
 from pocketpaw.prompt.instructions import InstructionsLayer
 from pocketpaw.prompt.layer import LayerOutput, Priority, PromptContext, PromptLayer
@@ -38,9 +48,11 @@ from pocketpaw.prompt.surface import SurfaceContextLayer
 from pocketpaw.prompt.user import UserInfoLayer
 
 __all__ = [
+    "CHANNEL_PROMPT_LAYERS",
     "AgentIdentityLayer",
     "AssembledPrompt",
     "AtlasPrimerLayer",
+    "ChannelInputs",
     "DroppedLayer",
     "InstructionsLayer",
     "LayerOutput",

--- a/src/pocketpaw/prompt/channel/__init__.py
+++ b/src/pocketpaw/prompt/channel/__init__.py
@@ -1,0 +1,154 @@
+"""The channel path's fifteen layers, and the order they are emitted in.
+
+Created: 2026-08-03 (PA-7a, feat/prompt-assembler-channel).
+
+Telegram, Discord, Slack and the CLI used to assemble their system prompt with
+``AgentContextBuilder._assemble_with_budget`` while the cloud path used
+``pocketpaw.prompt.assemble``. Two assemblers, two sets of rules for caps and
+budgets, one of them with a digest and one without. This package is the channel
+half moved onto the shared one; the builder now fills a
+:class:`~pocketpaw.prompt.channel.inputs.ChannelInputs`, resolves the layers by
+name and calls ``assemble``.
+
+THE ORDER IS THE PART THAT WILL BITE YOU, so it is derived here in full.
+
+The old assembler took blocks in the order the builder APPENDED them and
+``sorted`` them by priority — a stable sort, so ties kept their append order —
+then emitted that. The new assembler emits in the order the caller lists layers
+and NEVER reorders (see ``_Rendered``: "the budget decides in priority order but
+never reorders what is emitted"). Those two produce the same prompt only if this
+list is written in the OLD PATH'S SORTED ORDER, which is not the order the
+blocks are appended in and does not look like it.
+
+``_CHANNEL_BLOCK_SOURCE_ORDER`` below is the append order, straight down
+``build_system_prompt`` as it stood before the cutover. ``CHANNEL_PROMPT_LAYERS``
+is that list stably sorted by priority. The gap between them is not subtle:
+``channel_hints`` is appended FIFTH and emitted SECOND TO LAST, because it is
+the only LOW-priority block near the top of the function. Get this wrong and
+every channel prompt reorders while every test that checks for a block's
+PRESENCE still passes.
+
+``tests/test_channel_prompt_layers.py::test_the_emission_order_is_the_old_priority_sort``
+re-derives the sort from ``_CHANNEL_BLOCK_SOURCE_ORDER`` and the layers' own
+declared priorities and asserts it equals ``CHANNEL_PROMPT_LAYERS``, so the rule
+is checked rather than the answer transcribed.
+
+NAMES ARE PREFIXED ``channel.``. The registry is one flat name-keyed dict shared
+with the cloud layers, and three names would otherwise collide outright —
+``identity`` is already ``AgentIdentityLayer``. A silent overwrite there would
+swap the cloud path's persona layer for a channel one that renders nothing
+outside a channel turn.
+"""
+
+from __future__ import annotations
+
+from pocketpaw.prompt.channel.environment import (
+    ChannelAgentsMdLayer,
+    ChannelAtlasPrimerLayer,
+    ChannelGwsLayer,
+    ChannelHealthLayer,
+    ChannelSkillsLayer,
+)
+from pocketpaw.prompt.channel.inputs import ChannelInputs
+from pocketpaw.prompt.channel.request import (
+    ChannelCurrentPocketLayer,
+    ChannelFileContextLayer,
+    ChannelFormatHintLayer,
+    ChannelIdentityLayer,
+    ChannelInstructionsLayer,
+    ChannelKnowledgeBaseLayer,
+    ChannelMemoryLayer,
+    ChannelPocketContextLayer,
+    ChannelSenderLayer,
+    ChannelSessionKeyLayer,
+)
+from pocketpaw.prompt.layer import PromptLayer
+
+# Every channel layer, keyed by name. The registry registers from this, so a new
+# layer is added in exactly one place and cannot be half-wired.
+CHANNEL_LAYER_TYPES: tuple[type, ...] = (
+    ChannelIdentityLayer,
+    ChannelMemoryLayer,
+    ChannelKnowledgeBaseLayer,
+    ChannelSenderLayer,
+    ChannelFormatHintLayer,
+    ChannelInstructionsLayer,
+    ChannelPocketContextLayer,
+    ChannelCurrentPocketLayer,
+    ChannelSessionKeyLayer,
+    ChannelFileContextLayer,
+    ChannelHealthLayer,
+    ChannelSkillsLayer,
+    ChannelAtlasPrimerLayer,
+    ChannelAgentsMdLayer,
+    ChannelGwsLayer,
+)
+
+# The order ``build_system_prompt`` APPENDED these blocks, before PA-7a. Kept
+# because it is the input to the sort, not because anything emits in it. If you
+# add a block, add it here in its append position and let the test re-derive the
+# emission order rather than editing ``CHANNEL_PROMPT_LAYERS`` by hand.
+_CHANNEL_BLOCK_SOURCE_ORDER: tuple[str, ...] = (
+    "channel.identity",  # 1.  CRITICAL
+    "channel.memory_context",  # 2.  HIGH
+    "channel.kb_context",  # 2b. HIGH
+    "channel.sender_block",  # 3.  HIGH
+    "channel.channel_hints",  # 4.  LOW   <- appended 5th, emitted 14th
+    "channel.channel_instructions",  # 4b. MEDIUM
+    "channel.pocket_context",  # 4c. HIGH
+    "channel.current_pocket",  # 4d. HIGH
+    "channel.session_key",  # 5.  MEDIUM
+    "channel.file_context",  # 6.  MEDIUM
+    "channel.health_state",  # 7.  LOW
+    "channel.skills_list",  # 8.  MEDIUM
+    "channel.atlas_primer",  # 8b. MEDIUM
+    "channel.agents_md",  # 9.  MEDIUM
+    "channel.gws_instructions",  # 10. MEDIUM
+)
+
+# What ``assemble`` emits, in order: ``_CHANNEL_BLOCK_SOURCE_ORDER`` stably
+# sorted by priority. CRITICAL, then the five HIGH blocks in append order, then
+# the seven MEDIUM, then the two LOW.
+CHANNEL_PROMPT_LAYERS: tuple[str, ...] = (
+    # CRITICAL
+    "channel.identity",
+    # HIGH
+    "channel.memory_context",
+    "channel.kb_context",
+    "channel.sender_block",
+    "channel.pocket_context",
+    "channel.current_pocket",
+    # MEDIUM
+    "channel.channel_instructions",
+    "channel.session_key",
+    "channel.file_context",
+    "channel.skills_list",
+    "channel.atlas_primer",
+    "channel.agents_md",
+    "channel.gws_instructions",
+    # LOW
+    "channel.channel_hints",
+    "channel.health_state",
+)
+
+__all__ = [
+    "CHANNEL_LAYER_TYPES",
+    "CHANNEL_PROMPT_LAYERS",
+    "ChannelAgentsMdLayer",
+    "ChannelAtlasPrimerLayer",
+    "ChannelCurrentPocketLayer",
+    "ChannelFileContextLayer",
+    "ChannelFormatHintLayer",
+    "ChannelGwsLayer",
+    "ChannelHealthLayer",
+    "ChannelIdentityLayer",
+    "ChannelInputs",
+    "ChannelInstructionsLayer",
+    "ChannelKnowledgeBaseLayer",
+    "ChannelMemoryLayer",
+    "ChannelPocketContextLayer",
+    "ChannelSenderLayer",
+    "ChannelSessionKeyLayer",
+    "ChannelSkillsLayer",
+    "PromptLayer",
+]

--- a/src/pocketpaw/prompt/channel/environment.py
+++ b/src/pocketpaw/prompt/channel/environment.py
@@ -1,0 +1,257 @@
+"""The channel blocks built from the BOX — health, skills, the OS, the repo, GWS.
+
+Created: 2026-08-03 (PA-7a, feat/prompt-assembler-channel).
+
+Five of the channel path's fifteen blocks, and they are exactly the five
+``AgentContextBuilder.build_system_prompt`` had to wrap in ``try/except``:
+health, skills, the atlas primer, AGENTS.md and the Google Workspace guidance.
+That is not a coincidence and it is why they share a module. Each one reaches
+for a loader that can be absent, stale or broken — a health engine that has not
+started, a skills directory that does not exist, a corrupt atlas seed, an
+unreadable AGENTS.md, an MCP config that fails to parse — and none of those may
+cost the user their turn.
+
+THE FIVE ``except`` CLAUSES ARE GONE, REPLACED BY ONE.
+:func:`~pocketpaw.prompt.assembler.assemble` guards every ``layer.render()``: a
+raising layer is logged with a traceback, contributes no text, and lands in
+``AssembledPrompt.dropped``. Four of the five old handlers were ``logger.debug``
+or a bare ``pass``, so this is strictly more visible than what it replaces —
+``pass  # AGENTS.md failure never breaks prompt building`` swallowed the
+exception type, the message and the traceback. It is also broader: the old
+handlers wrapped only the block they were written for, whereas the guard covers
+whatever a layer does. Pinned by
+``tests/test_channel_prompt_layers.py::test_a_raising_environment_layer_does_not_fail_the_turn``,
+which drives a real exception through each of the five and asserts the other
+fourteen blocks still assemble.
+
+ONE BEHAVIOURAL DIFFERENCE, AND IT IS INVISIBLE IN THE TEXT: the guard also
+records the failed layer in the digest under a reserved failure key, which the
+old code did not do (it had no digest). The channel path returns only
+``AssembledPrompt.text``, so no channel byte moves; the effect is that if a
+future channel caller ever reads ``stable_digest``, "the atlas failed" and "the
+atlas rendered" are already different identities rather than the same one.
+
+WHY THE ATLAS PRIMER'S BUILDER LIVES HERE. ``_build_atlas_primer`` was a
+``@staticmethod`` on the builder whose only caller was the block it fed. Moving
+it into the layer is what puts it under the render guard;
+``AgentContextBuilder._build_atlas_primer`` stays as a one-line delegate because
+``tests/atlas/test_primer_block.py`` calls it directly and the seed content it
+pins is worth keeping under test at that name.
+
+NOT the cloud path's :class:`~pocketpaw.prompt.atlas.AtlasPrimerLayer`, which
+renders ``ctx.atlas_primer`` as plain data and is reserved for the day the cloud
+path decides to pay ~1.5k chars a turn for the primer. Same block, same 2000-char
+cap, two producers — the channel one builds it, the cloud one is handed it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from pocketpaw.prompt.channel.inputs import ChannelInputs
+from pocketpaw.prompt.layer import LayerOutput, Priority, PromptContext
+
+_NO_INPUTS = ChannelInputs()
+
+
+def _inputs(ctx: PromptContext) -> ChannelInputs:
+    return ctx.channel_inputs or _NO_INPUTS
+
+
+def _nonblank(text: str) -> str:
+    """``""`` unless there is something other than whitespace to say.
+
+    See :mod:`pocketpaw.prompt.channel.request` — the new assembler skips only
+    EMPTY text where the old one skipped whitespace-only content too.
+    """
+    return text if text.strip() else ""
+
+
+def _short_digest(value: str) -> str:
+    """16 hex chars of sha256 — the bound the rest of this package uses."""
+    return hashlib.sha256(value.encode("utf-8", "replace")).hexdigest()[:16]
+
+
+class ChannelSkillsLayer:
+    """What skills exist, so the agent stops recreating them."""
+
+    name = "channel.skills_list"
+    priority: Priority = Priority.MEDIUM
+    max_chars: int | None = 2000  # _INJECTION_CAPS["skills_list"]
+
+    async def render(self, ctx: PromptContext) -> LayerOutput:
+        from pocketpaw.skills import get_skill_loader
+
+        loader = get_skill_loader()
+        skills = loader.get_all()
+        # entity-rooms A2: when the entity pins a non-empty skill subset,
+        # advertise ONLY those skills (the non-SDK equivalent of the SDK's
+        # per-run materialized plugin). Empty / None → legacy all-skills
+        # behavior, so every non-entity run is unchanged.
+        skill_names = _inputs(ctx).skill_names
+        if skill_names:
+            skills = {n: s for n, s in skills.items() if n in skill_names}
+        if not skills:
+            return LayerOutput(text="", cache_key=_short_digest(""))
+
+        skill_lines = []
+        for s in skills.values():
+            invocable = " (user-invocable)" if s.user_invocable else ""
+            skill_lines.append(f"- **{s.name}**: {s.description}{invocable}")
+        search_dirs = ", ".join(str(p) for p in loader.paths)
+        block = (
+            "\n# Available Skills\n"
+            "The following skills have been created and are available. "
+            "Do NOT recreate them or forget they exist.\n"
+            + "\n".join(skill_lines)
+            + f"\n\nSkills directories: {search_dirs}"
+        )
+        return LayerOutput(text=_nonblank(block), cache_key=_short_digest(block))
+
+
+class ChannelAtlasPrimerLayer:
+    """The Paw OS primer — what the OS is and what its words mean here."""
+
+    name = "channel.atlas_primer"
+    priority: Priority = Priority.MEDIUM
+    # ~500 tokens, from ``_INJECTION_CAPS["atlas_primer"]``. Same number the
+    # cloud-side ``AtlasPrimerLayer`` carries, and for the same reason: it has
+    # bounded this exact block on the channel path since 2026-04-01.
+    max_chars: int | None = 2000
+
+    async def render(self, ctx: PromptContext) -> LayerOutput:
+        primer = build_atlas_primer()
+        return LayerOutput(text=_nonblank(primer), cache_key=_short_digest(primer))
+
+
+class ChannelAgentsMdLayer:
+    """The target repo's AGENTS.md constraints."""
+
+    name = "channel.agents_md"
+    priority: Priority = Priority.MEDIUM
+    max_chars: int | None = 3000  # _INJECTION_CAPS["agents_md"]
+
+    async def render(self, ctx: PromptContext) -> LayerOutput:
+        agents_md_dir = _inputs(ctx).agents_md_dir
+        if not agents_md_dir:
+            return LayerOutput(text="", cache_key=_short_digest(""))
+
+        from pocketpaw.agents_md import AgentsMdLoader
+
+        agents_md = AgentsMdLoader().find_and_load(agents_md_dir)
+        if not agents_md:
+            return LayerOutput(text="", cache_key=_short_digest(""))
+        block = agents_md.constraints_block
+        return LayerOutput(text=_nonblank(block), cache_key=_short_digest(block))
+
+
+class ChannelGwsLayer:
+    """Google Workspace CLI guidance, when that MCP server is actually active."""
+
+    name = "channel.gws_instructions"
+    priority: Priority = Priority.MEDIUM
+    max_chars: int | None = 1000  # _INJECTION_CAPS["gws_instructions"]
+
+    async def render(self, ctx: PromptContext) -> LayerOutput:
+        block = load_gws_instructions()
+        return LayerOutput(text=_nonblank(block), cache_key=_short_digest(block))
+
+
+class ChannelHealthLayer:
+    """The health engine's section — present ONLY while something is wrong."""
+
+    name = "channel.health_state"
+    priority: Priority = Priority.LOW
+    max_chars: int | None = 300  # _INJECTION_CAPS["health_state"]
+
+    async def render(self, ctx: PromptContext) -> LayerOutput:
+        from pocketpaw.health import get_health_engine
+
+        block = get_health_engine().get_health_prompt_section()
+        return LayerOutput(text=_nonblank(block or ""), cache_key=_short_digest(block or ""))
+
+
+def build_atlas_primer() -> str:
+    """Build the compact always-on "Paw OS primer" block (AT-3).
+
+    Moved verbatim from ``AgentContextBuilder._build_atlas_primer`` (PA-7a), so
+    it renders inside a layer and under the assembler's render guard. Three
+    parts, ~500 tokens hard ceiling (enforced twice: the seed keeps each line
+    short, and ``ChannelAtlasPrimerLayer.max_chars`` caps the rendered block at
+    2000 chars):
+
+    1. One-paragraph OS identity ("you run inside paw-os ...").
+    2. One line per primitive — name + gist, generated at build time from the
+       atlas store so a seed edit can never drift from the prompt. Prefer the
+       entry's authored ``gist`` (a complete, self-contained one-liner that ends
+       on a full clause). Only when a primitive has no ``gist`` fall back to a
+       clause-aware truncation of ``summary`` — cut at the last full word before
+       the cap so a line never dangles mid-phrase (the old fixed-108-char cut
+       dropped load-bearing words like Belt's "Instinct gate" and Branch's
+       "review/merge/publish").
+    3. The standing instruction: ``atlas_search`` before guessing about OS
+       capabilities, and include the ``surface`` route when pointing a user
+       somewhere.
+
+    Returns "" when the store has no primitives. RAISES on store load failure —
+    the assembler's render guard is what keeps that from breaking the turn,
+    where the caller's ``try/except`` used to.
+    """
+    from pocketpaw.atlas.store import get_atlas_store
+
+    primitives = [e for e in get_atlas_store().entries if e.kind == "primitive"]
+    if not primitives:
+        return ""
+
+    lines: list[str] = []
+    for entry in primitives:
+        gist = (entry.gist or "").strip().rstrip(".")
+        if not gist:
+            # No authored gist — fall back to the summary's first clause, cut
+            # clause-aware at the last full word before the cap so the line
+            # still ends cleanly rather than mid-phrase.
+            gist = entry.summary.split(";")[0].strip().rstrip(".")
+            if len(gist) > 110:
+                gist = gist[:108].rsplit(" ", 1)[0]
+                if gist.count("(") > gist.count(")"):
+                    gist = gist[: gist.rindex("(")]
+                gist = gist.rstrip(" ,.:;(") + "…"
+        suffix = "" if gist.endswith("…") else "."
+        lines.append(f"- {entry.name}: {gist}{suffix}")
+
+    return (
+        "\n# Paw OS Primer\n"
+        "You run inside paw-os, an agentic workspace OS. Its primitives "
+        "carry paw-specific meanings (a Pocket is a workspace app, not "
+        "clothing), and users see results on frontend surfaces — routes "
+        "like /sites.\n\n"
+        "OS primitives:\n" + "\n".join(lines) + "\n\n"
+        "Before guessing whether the OS can do something or which "
+        "primitive fits, call atlas_search with your intent, then "
+        "atlas_describe on the best id. When an action has a home "
+        "surface, tell the user where to see it by route (e.g. "
+        '"see it at /sites") — entries carry it in their `surface` field.'
+    )
+
+
+def load_gws_instructions() -> str:
+    """Load GWS CLI guidance if the google-workspace MCP server is active.
+
+    Moved from ``AgentContextBuilder._load_gws_instructions`` (PA-7a). ``gws.md``
+    still ships beside the bootstrap package, so the directory is resolved from
+    the installed ``pocketpaw`` package — see
+    ``request.load_channel_instructions`` for why not ``__file__``.
+    """
+    from pocketpaw.mcp.config import load_mcp_config
+
+    configs = load_mcp_config()
+    gws_active = any(c.name == "google-workspace" and c.enabled for c in configs)
+    if not gws_active:
+        return ""
+
+    from pocketpaw.prompt.channel.request import _bootstrap_dir
+
+    path = _bootstrap_dir() / "gws.md"
+    if not path.exists():
+        return ""
+    return path.read_text(encoding="utf-8").strip()

--- a/src/pocketpaw/prompt/channel/inputs.py
+++ b/src/pocketpaw/prompt/channel/inputs.py
@@ -1,0 +1,65 @@
+"""What a channel turn hands the assembler — one object, all plain data.
+
+Created: 2026-08-03 (PA-7a, feat/prompt-assembler-channel).
+
+Fifteen channel blocks need inputs, and putting fifteen fields on
+:class:`~pocketpaw.prompt.layer.PromptContext` would bury the four the cloud
+path reads under a dozen that only Telegram and Discord ever set. So the channel
+path's inputs travel together in one frozen object hung off a single
+``channel_inputs`` slot, defaulted to ``None`` — a cloud assembly is unchanged
+and a channel layer that somehow lands in a cloud list renders nothing rather
+than raising.
+
+THE FIRST THREE FIELDS ARE THE LATENCY DECISION, and they are why this class
+exists at all rather than the layers doing their own I/O.
+``AgentContextBuilder.build_system_prompt`` runs the bootstrap fetch, the memory
+fetch and the kb fetch CONCURRENTLY through one ``asyncio.gather``; the kb one
+shells out to a subprocess. :func:`~pocketpaw.prompt.assembler.assemble` renders
+layers in a sequential ``for`` loop, so three layers each awaiting their own
+fetch would pay their SUM on every channel turn where the gather pays their MAX.
+The gather therefore stays in the builder and its three results arrive here as
+finished strings — the same discipline ``surface_preamble`` and ``atlas_primer``
+already use for content produced somewhere the layer cannot reach. The
+alternative (make ``assemble`` render concurrently) was rejected: it changes the
+CLOUD path's execution model to fix a channel-path problem, and the cloud layers
+have never been audited for order-independence. Pinned by
+``tests/test_channel_prompt_layers.py::test_the_three_io_fetches_still_run_concurrently``.
+
+``identity_cache_key`` is the provider's own claim about its identity bytes (see
+``BootstrapContext.identity_cache_key``), carried so the identity layer can key
+on a claim rather than on a soul rendering whose mood and memory counters drift
+every turn.
+
+Everything else is exactly what ``build_system_prompt`` was already given by its
+caller, forwarded unchanged.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ChannelInputs:
+    """The per-turn inputs the channel layers render against."""
+
+    # --- resolved concurrently by the builder's asyncio.gather -------------
+    identity: str = ""
+    identity_cache_key: str | None = None
+    memory_context: str = ""
+    kb_context: str = ""
+
+    # --- forwarded verbatim from build_system_prompt's arguments ----------
+    # ``channel`` is typed ``Any`` rather than ``Channel`` for the reason
+    # ``PromptContext.instance`` is: this package is imported by the prompt
+    # registry, which ``bootstrap`` imports, and a hard dependency on
+    # ``pocketpaw.bus`` here buys nothing the layers cannot get by importing it
+    # themselves at the point of use.
+    channel: Any = None
+    sender_id: str | None = None
+    session_key: str | None = None
+    file_context: dict | None = None
+    metadata: dict | None = None
+    agents_md_dir: str | None = None
+    skill_names: frozenset[str] | None = None

--- a/src/pocketpaw/prompt/channel/request.py
+++ b/src/pocketpaw/prompt/channel/request.py
@@ -102,9 +102,22 @@ class ChannelIdentityLayer:
         # interaction, and only the provider knows which of those bytes mean
         # anything. With no claim, hash the text: it over-keys (the digest moves
         # when a counter does) and over-keying is the safe direction.
+        #
+        # ONLY A NON-EMPTY ``str`` COUNTS AS A CLAIM, and the ``isinstance`` is
+        # load-bearing rather than defensive habit. ``BootstrapContext`` declares
+        # the field ``str | None``, but the bootstrap provider is a Protocol and
+        # this layer reads whatever the object actually carries. Anything else
+        # reaching ``LayerOutput`` lands in ``assembler._digest``, which calls
+        # ``.encode`` on it — and that is OUTSIDE the render guard, so it does
+        # not degrade the layer, it kills the turn. On this path that trade is
+        # all downside: ``build_system_prompt`` discards the digest entirely.
+        # Found by ``tests/test_memory_isolation.py`` and ``tests/test_mem0_store.py``,
+        # whose providers are ``MagicMock``s — a mock's attribute is truthy, so
+        # a bare ``or`` forwarded it and six suites went red.
+        claim = ci.identity_cache_key
         return LayerOutput(
             text=_nonblank(ci.identity),
-            cache_key=ci.identity_cache_key or _short_digest(ci.identity),
+            cache_key=claim if isinstance(claim, str) and claim else _short_digest(ci.identity),
         )
 
 

--- a/src/pocketpaw/prompt/channel/request.py
+++ b/src/pocketpaw/prompt/channel/request.py
@@ -1,0 +1,409 @@
+"""The channel blocks built from THIS REQUEST — who asked, where, about what.
+
+Created: 2026-08-03 (PA-7a, feat/prompt-assembler-channel).
+
+Ten of the channel path's fifteen blocks, lifted out of
+``AgentContextBuilder.build_system_prompt`` byte for byte. Every one of them is
+a function of what the caller sent — the bootstrap identity resolved for this
+turn, the memories and articles retrieved for this message, who is speaking,
+which channel they are on, which pocket is open, which files the desktop client
+has selected. The other five come from the box the process is running on and
+live in :mod:`.environment`.
+
+WHY THAT SPLIT AND NOT ONE MODULE PER LAYER. Fifteen files of thirty lines each
+buries the one thing worth seeing — that these blocks share an input object and
+those blocks share a failure mode. The five in :mod:`.environment` are exactly
+the five the old builder had to wrap in ``try/except`` (health, skills, atlas,
+AGENTS.md, GWS), because each reaches for a loader that can be missing or
+broken; :func:`~pocketpaw.prompt.assembler.assemble`'s render guard is what
+replaces those five ``except`` clauses. Nothing in THIS module can raise on a
+resource, so nothing in it needed a guard before and nothing does now. The line
+between the two files is that property, not file size.
+
+NOT ONE BYTE MOVED. Each ``render`` reproduces its block's text exactly,
+including the leading ``\\n`` most of them carry, the em dashes, and the
+``\\n\\n## Current Context`` the channel-instructions block appends. The block
+ORDER moved out of this file entirely — see :mod:`pocketpaw.prompt.channel`,
+which owns it, because the old assembler re-sorted by priority and the new one
+never reorders.
+
+EVERY LAYER RENDERS ``""`` FOR "NOTHING TO SAY", VIA :func:`_nonblank`.
+``_assemble_with_budget`` skipped a block when ``not content.strip()``;
+``assemble`` skips one only when the text is EMPTY. Those agree only while a
+layer with nothing to contribute returns ``""`` rather than whitespace, and a
+layer returning ``"   "`` would silently add a separator to every prompt. Two of
+these blocks (``pocket_context``, ``identity``) render caller-supplied text and
+so cannot promise otherwise on their own, which is why the guard is applied by
+all ten rather than argued per layer.
+
+THE CAPS ARE ``_INJECTION_CAPS``' NUMBERS, UNCHANGED, now declared on the layer
+that owns each one. Two of them were MISSING from that table and are therefore
+``None`` here: ``pocket_context`` and ``current_pocket`` have never been capped
+on any channel turn. That is recorded as an explicit ``max_chars = None`` with a
+note rather than left to read as an oversight — PA-9 is the task with the
+measurements to change it, and PA-7a's acceptance is that no byte moves.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+
+from pocketpaw.prompt.channel.inputs import ChannelInputs
+from pocketpaw.prompt.layer import LayerOutput, Priority, PromptContext
+
+_NO_INPUTS = ChannelInputs()
+
+
+def _inputs(ctx: PromptContext) -> ChannelInputs:
+    """The channel inputs, or an empty set for a caller that has none.
+
+    A cloud assembly never sets ``channel_inputs``. Returning the empty default
+    rather than raising means a channel layer that finds its way into a cloud
+    layer list renders nothing and costs nothing, which is how every other
+    plain-data layer in this package already behaves when its channel is unset.
+    """
+    return ctx.channel_inputs or _NO_INPUTS
+
+
+def _nonblank(text: str) -> str:
+    """``""`` unless there is something other than whitespace to say.
+
+    Reproduces ``_assemble_with_budget``'s ``not content.strip()`` skip. See the
+    module docstring — the new assembler only skips EMPTY text, so the guard has
+    to move into the layers or a whitespace-only block starts contributing a
+    separator.
+    """
+    return text if text.strip() else ""
+
+
+def _short_digest(value: str) -> str:
+    """16 hex chars of sha256 — the bound the rest of this package uses."""
+    return hashlib.sha256(value.encode("utf-8", "replace")).hexdigest()[:16]
+
+
+class ChannelIdentityLayer:
+    """The bootstrap provider's system prompt — persona, soul, style, profile."""
+
+    name = "channel.identity"
+    priority: Priority = Priority.CRITICAL
+    # UNCAPPED, from ``_INJECTION_CAPS["identity"] = None``, and for the reason
+    # ``prompt.identity`` spells out at length: this key deliberately
+    # under-reports its text when a soul provider made a claim, and a cap on a
+    # key like that would let a growing counter push stable persona bytes off
+    # the end.
+    max_chars: int | None = None
+
+    async def render(self, ctx: PromptContext) -> LayerOutput:
+        ci = _inputs(ctx)
+        # The provider's own claim wins when it made one — a soul renders mood,
+        # energy, bond level and a memory count that all move on ordinary
+        # interaction, and only the provider knows which of those bytes mean
+        # anything. With no claim, hash the text: it over-keys (the digest moves
+        # when a counter does) and over-keying is the safe direction.
+        return LayerOutput(
+            text=_nonblank(ci.identity),
+            cache_key=ci.identity_cache_key or _short_digest(ci.identity),
+        )
+
+
+class ChannelMemoryLayer:
+    """Memories retrieved for this message, already fetched by the builder."""
+
+    name = "channel.memory_context"
+    priority: Priority = Priority.HIGH
+    max_chars: int | None = 4000  # _INJECTION_CAPS["memory_context"]
+
+    async def render(self, ctx: PromptContext) -> LayerOutput:
+        memory_context = _inputs(ctx).memory_context
+        if not memory_context:
+            return LayerOutput(text="", cache_key=None)
+        return LayerOutput(
+            text=_nonblank(
+                "\n# Memory Context (already loaded — use this directly, "
+                "do NOT call recall unless you need something not listed here)\n" + memory_context
+            ),
+            # VOLATILE. A semantic recall is keyed on the user's message, so a
+            # key over these bytes would move every turn and make every turn
+            # look like a new agent — the exact churn ``cache_key=None`` exists
+            # to prevent (``RetrievalLayer`` answers the same way).
+            cache_key=None,
+        )
+
+
+class ChannelKnowledgeBaseLayer:
+    """kb-go articles retrieved for this message, already fetched by the builder."""
+
+    name = "channel.kb_context"
+    priority: Priority = Priority.HIGH
+    max_chars: int | None = 3000  # _INJECTION_CAPS["kb_context"]
+
+    async def render(self, ctx: PromptContext) -> LayerOutput:
+        kb_context = _inputs(ctx).kb_context
+        if not kb_context:
+            return LayerOutput(text="", cache_key=None)
+        return LayerOutput(
+            text=_nonblank(
+                "\n# Knowledge Base (relevant articles from the project wiki)\n"
+                "These are compiled from source files. Use them for implementation "
+                "details and current-state facts. Use soul_recall for past decisions "
+                "and conversation history.\n\n" + kb_context
+            ),
+            cache_key=None,  # Per-message retrieval, same as the memory block.
+        )
+
+
+class ChannelSenderLayer:
+    """Who is speaking, and whether they own this agent."""
+
+    name = "channel.sender_block"
+    priority: Priority = Priority.HIGH
+    max_chars: int | None = 500  # _INJECTION_CAPS["sender_block"]
+
+    async def render(self, ctx: PromptContext) -> LayerOutput:
+        sender_id = _inputs(ctx).sender_id
+        if not sender_id:
+            return LayerOutput(text="", cache_key=_short_digest(""))
+
+        from pocketpaw.config import get_settings
+
+        settings = get_settings()
+        if not settings.owner_id:
+            # No configured owner means the agent cannot say whether this
+            # sender is one, so it says nothing rather than guessing.
+            return LayerOutput(text="", cache_key=_short_digest(""))
+
+        is_owner = sender_id == settings.owner_id
+        role = "owner" if is_owner else "external user"
+        block = (
+            f"\n# Current Conversation\n"
+            f"You are speaking with sender_id={sender_id} (role: {role})."
+        )
+        if is_owner:
+            block += "\nThis is your owner."
+        else:
+            block += (
+                "\nThis is NOT your owner. Be helpful but do not share "
+                "owner-private information."
+            )
+        # The text carries both the id and the role, so a digest of it moves on
+        # a sender change AND on an owner-config change. Nothing is left for a
+        # separate id half to discriminate.
+        return LayerOutput(text=_nonblank(block), cache_key=_short_digest(block))
+
+
+class ChannelPocketContextLayer:
+    """The pocket-creation preamble the pocket chat endpoint hands in."""
+
+    name = "channel.pocket_context"
+    priority: Priority = Priority.HIGH
+    # UNCAPPED — and it always has been. ``_INJECTION_CAPS`` has no
+    # ``pocket_context`` entry, so ``_assemble_with_budget``'s
+    # ``_INJECTION_CAPS.get(name)`` returned ``None`` and this block went into
+    # every prompt at whatever length its caller chose. Written out rather than
+    # omitted so it reads as inherited, not overlooked. PA-9 owns cap
+    # arithmetic and is the task with the measurements.
+    max_chars: int | None = None
+
+    async def render(self, ctx: PromptContext) -> LayerOutput:
+        metadata = _inputs(ctx).metadata or {}
+        text = metadata.get("pocket_system_context") or ""
+        return LayerOutput(text=_nonblank(text), cache_key=_short_digest(text))
+
+
+class ChannelCurrentPocketLayer:
+    """Which pocket is open, and the standing order to fetch it before answering."""
+
+    name = "channel.current_pocket"
+    priority: Priority = Priority.HIGH
+    # UNCAPPED, inherited — see ``ChannelPocketContextLayer``. This is the more
+    # interesting of the two missing entries: the block ``json.dumps`` the
+    # widget summary straight into the prompt with no bound, so a pocket with
+    # many widgets writes an unbounded block. Left as-is deliberately; a cap
+    # here would move bytes on live pockets, which is PA-9's call to make with
+    # numbers rather than PA-7a's to make in passing.
+    max_chars: int | None = None
+
+    async def render(self, ctx: PromptContext) -> LayerOutput:
+        metadata = _inputs(ctx).metadata or {}
+        pc = metadata.get("pocket_context")
+        if not pc:
+            return LayerOutput(text="", cache_key=_short_digest(""))
+
+        pocket_id = pc.get("id", "unknown")
+        widget_summary = pc.get("widgets", [])
+        pocket_tag = (
+            f"\n<current-pocket>\n"
+            f"id: {pocket_id}\n"
+            f"name: {pc.get('name', 'Untitled')}\n"
+            f"widgets_summary: {json.dumps(widget_summary)}\n"
+            f"\n"
+            f"SCOPE — read this carefully before doing anything:\n"
+            f'In this conversation, "pocket" / "this pocket" / "the\n'
+            f'pocket" always means THIS workspace dashboard\n'
+            f"(id ``{pocket_id}``) — a MongoDB document the user is\n"
+            f"viewing on screen. It is NOT the PocketPaw application,\n"
+            f"NOT the source tree on disk, NOT any file under\n"
+            f'``D:\\paw`` or ``backend/`` or ``ee/cloud/``. "Edit the\n'
+            f'pocket", "add a widget", "more widgets" all refer to\n'
+            f"this document — operate on it through the\n"
+            f"``mcp__pocketpaw_pocket__*`` tools ONLY. Do NOT use\n"
+            f"shell, file_edit, grep, or web_search for pocket\n"
+            f"operations — they cannot read or write the document.\n"
+            f"\n"
+            f"NOTE: `widgets_summary` is a shallow hint (names + types)\n"
+            f"and is OFTEN EMPTY for UISpec-tree pockets — absence here\n"
+            f"does NOT mean the pocket is empty. The real content lives\n"
+            f"in rippleSpec.ui.\n"
+            f"\n"
+            f"BEFORE answering any question about this pocket's contents,\n"
+            f"widgets, layout, data, or configuration, you MUST first call:\n"
+            f"  tool: mcp__pocketpaw_pocket__get_pocket\n"
+            f'  args: {{"pocket_id": "{pocket_id}"}}\n'
+            f"That returns the full document (rippleSpec, widgets,\n"
+            f"metadata, visibility). Base your answer on that, not on\n"
+            f"the summary above.\n"
+            f"</current-pocket>\n"
+        )
+        return LayerOutput(text=_nonblank(pocket_tag), cache_key=_short_digest(pocket_tag))
+
+
+class ChannelInstructionsLayer:
+    """The per-channel behaviour file (today: ``discord.md``) plus live context."""
+
+    name = "channel.channel_instructions"
+    priority: Priority = Priority.MEDIUM
+    max_chars: int | None = 1000  # _INJECTION_CAPS["channel_instructions"]
+
+    async def render(self, ctx: PromptContext) -> LayerOutput:
+        ci = _inputs(ctx)
+        if ci.channel is None:
+            return LayerOutput(text="", cache_key=_short_digest(""))
+
+        text = load_channel_instructions(ci.channel)
+        if not text:
+            return LayerOutput(text="", cache_key=_short_digest(""))
+
+        meta = ci.metadata or {}
+        username = meta.get("username", "")
+        guild_id = meta.get("guild_id", "")
+        ctx_lines = []
+        if ci.sender_id:
+            ctx_lines.append(f"sender_id: {ci.sender_id}")
+        if username:
+            ctx_lines.append(f"discord_username: {username}")
+        if guild_id:
+            ctx_lines.append(f"discord_guild_id: {guild_id}")
+        if ctx_lines:
+            text += "\n\n## Current Context\n" + "\n".join(ctx_lines)
+        return LayerOutput(text=_nonblank(text), cache_key=_short_digest(text))
+
+
+class ChannelSessionKeyLayer:
+    """The session key the session-management tools need as an argument."""
+
+    name = "channel.session_key"
+    priority: Priority = Priority.MEDIUM
+    max_chars: int | None = 200  # _INJECTION_CAPS["session_key"]
+
+    async def render(self, ctx: PromptContext) -> LayerOutput:
+        session_key = _inputs(ctx).session_key
+        if not session_key:
+            return LayerOutput(text="", cache_key=_short_digest(""))
+        block = (
+            f"\n# Session Management\n"
+            f"Current session_key: {session_key}\n"
+            f"Pass this value to any session tool (new_session, list_sessions, "
+            f"switch_session, clear_session, rename_session, delete_session)."
+        )
+        return LayerOutput(text=_nonblank(block), cache_key=_short_digest(block))
+
+
+class ChannelFileContextLayer:
+    """What the desktop client has open, with the paths sanitised."""
+
+    name = "channel.file_context"
+    priority: Priority = Priority.MEDIUM
+    max_chars: int | None = 2000  # _INJECTION_CAPS["file_context"]
+
+    async def render(self, ctx: PromptContext) -> LayerOutput:
+        file_context = _inputs(ctx).file_context
+        if not file_context:
+            return LayerOutput(text="", cache_key=_short_digest(""))
+
+        parts = []
+        if file_context.get("current_dir"):
+            parts.append(f"Working directory: {_sanitize_path(file_context['current_dir'])}")
+        if file_context.get("open_file"):
+            parts.append(f"Open file: {_sanitize_path(file_context['open_file'])}")
+        if file_context.get("selected_files"):
+            safe_files = [_sanitize_path(f) for f in file_context["selected_files"]]
+            parts.append(f"Selected files: {', '.join(safe_files)}")
+        if not parts:
+            return LayerOutput(text="", cache_key=_short_digest(""))
+
+        block = "\n# File Context\n" + "\n".join(parts)
+        return LayerOutput(text=_nonblank(block), cache_key=_short_digest(block))
+
+
+class ChannelFormatHintLayer:
+    """How to format a reply so the channel renders it natively."""
+
+    name = "channel.channel_hints"
+    priority: Priority = Priority.LOW
+    max_chars: int | None = 500  # _INJECTION_CAPS["channel_hints"]
+
+    async def render(self, ctx: PromptContext) -> LayerOutput:
+        channel = _inputs(ctx).channel
+        if channel is None:
+            return LayerOutput(text="", cache_key=_short_digest(""))
+
+        from pocketpaw.bus.format import CHANNEL_FORMAT_HINTS
+
+        hint = CHANNEL_FORMAT_HINTS.get(channel, "")
+        if not hint:
+            return LayerOutput(text="", cache_key=_short_digest(""))
+        block = f"\n# Response Format\n{hint}"
+        return LayerOutput(text=_nonblank(block), cache_key=_short_digest(block))
+
+
+def load_channel_instructions(channel) -> str:  # noqa: ANN001 - opaque Channel
+    """Read the per-channel behaviour file, or ``""`` when there isn't one.
+
+    Moved here from ``AgentContextBuilder._load_channel_instructions``. The file
+    still lives beside the bootstrap package, so the directory is resolved from
+    the installed ``pocketpaw`` package rather than from ``__file__`` — this
+    module is two directories away and importing ``pocketpaw.bootstrap`` to ask
+    would close an import cycle (bootstrap imports the prompt registry, which
+    imports this). Pinned by
+    ``tests/test_channel_prompt_layers.py::test_the_channel_files_resolve_to_the_bootstrap_package``.
+    """
+    from pocketpaw.bus.events import Channel
+
+    _channel_files = {
+        Channel.DISCORD: "discord.md",
+    }
+    filename = _channel_files.get(channel)
+    if not filename:
+        return ""
+    path = _bootstrap_dir() / filename
+    if not path.exists():
+        return ""
+    try:
+        return path.read_text(encoding="utf-8").strip()
+    except Exception:
+        return ""
+
+
+def _bootstrap_dir():  # noqa: ANN202 - Path, but keep the import local
+    from pathlib import Path
+
+    import pocketpaw
+
+    return Path(pocketpaw.__file__).resolve().parent / "bootstrap"
+
+
+def _sanitize_path(p: str) -> str:
+    """Strip non-path characters to prevent prompt injection."""
+    return re.sub(r"[^\w\s\-./\\:~]", "", p).strip()

--- a/src/pocketpaw/prompt/layer.py
+++ b/src/pocketpaw/prompt/layer.py
@@ -21,6 +21,13 @@ Updated: 2026-08-03 (PA-5) — three additions, all in service of the budget:
   more important and nothing read it, and it is now a ``Priority`` where
   SMALLER is, matching ``context_builder._Priority`` so PA-7 can delete that
   enum instead of translating between two conventions.
+Updated: 2026-08-03 (PA-7a) — ``PromptContext`` carries ``channel_inputs``, the
+  channel path's fifteen per-turn inputs bundled into one frozen object. PA-5's
+  prediction above came true on schedule: ``context_builder._Priority`` and
+  ``_INJECTION_CAPS`` are deleted and :class:`Priority` is the only drop order
+  in the runtime. One field rather than fifteen because the cloud path reads
+  none of them, and defaulted to ``None`` so no caller that predates it moves a
+  byte.
 
 The system prompt used to be one long string built by appending blocks in
 ``AgentPool._assemble_system_prompt``. That worked until three backends
@@ -41,7 +48,10 @@ from __future__ import annotations
 
 import enum
 from dataclasses import dataclass
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:  # pragma: no cover - typing only, and a cycle if imported
+    from pocketpaw.prompt.channel.inputs import ChannelInputs
 
 
 class Priority(enum.IntEnum):
@@ -129,6 +139,14 @@ class PromptContext:
     ``None`` (no surface, or a producer that would not claim stability) means
     the layer keeps its text out of the digest.
 
+    ``channel_inputs`` (PA-7a) is the CHANNEL path's fifteen inputs in one
+    frozen object rather than fifteen more fields here — see
+    :class:`~pocketpaw.prompt.channel.inputs.ChannelInputs`. ``None`` is the
+    cloud path and every caller that predates PA-7a; the channel layers read the
+    empty default and render nothing, so the slot cannot change what an existing
+    caller assembles. It is a forward reference because the channel package
+    imports this module.
+
     ``atlas_primer`` / ``tenant_scope`` and ``user_info`` / ``user_id`` (PA-5)
     are the two channels the budget was built for. Same plain-data shape as the
     surface pair and for the same reason, but note the asymmetry: the surface
@@ -151,6 +169,7 @@ class PromptContext:
     tenant_scope: str | None = None
     user_info: str = ""
     user_id: str | None = None
+    channel_inputs: ChannelInputs | None = None
 
 
 class PromptLayer(Protocol):

--- a/src/pocketpaw/prompt/registry.py
+++ b/src/pocketpaw/prompt/registry.py
@@ -11,6 +11,14 @@ Updated: 2026-08-02 (PA-4) — registers ``instructions``, the authoritative
   behaviour rules, also extracted from ``legacy_tail``. Stateless in the
   strongest sense of the four: it renders ``ctx.instructions`` and keys on it,
   reaching for nothing else at all.
+Updated: 2026-08-03 (PA-7a) — registers the fifteen ``channel.*`` layers, which
+  is the whole of the channel path's prompt and the end of the second
+  assembler. They are stateless in the same sense as the rest: every per-turn
+  input arrives on ``PromptContext.channel_inputs``, and the five that read the
+  BOX (skills, atlas, health, AGENTS.md, GWS) hold no handle on it between runs
+  — each resolves its loader inside ``render``. Names are prefixed ``channel.``
+  because this dict is flat and ``identity`` was already taken; an unprefixed
+  registration would have silently replaced the cloud path's persona layer.
 Updated: 2026-08-03 (PA-5) — registers ``atlas`` and ``user``, the first two
   layers with caps that can bite. Both are stateless in ``instructions``' sense:
   they render a ``PromptContext`` field and key on it plus the id/scope beside
@@ -27,6 +35,7 @@ safe to share across tenants.
 from __future__ import annotations
 
 from pocketpaw.prompt.atlas import AtlasPrimerLayer
+from pocketpaw.prompt.channel import CHANNEL_LAYER_TYPES
 from pocketpaw.prompt.identity import AgentIdentityLayer
 from pocketpaw.prompt.instructions import InstructionsLayer
 from pocketpaw.prompt.layer import PromptLayer
@@ -65,3 +74,10 @@ prompt_layer_registry.register(SurfaceContextLayer.name, SurfaceContextLayer())
 prompt_layer_registry.register(InstructionsLayer.name, InstructionsLayer())
 prompt_layer_registry.register(LegacyTailLayer.name, LegacyTailLayer())
 prompt_layer_registry.register(RetrievalLayer.name, RetrievalLayer())
+
+# The channel path's fifteen (PA-7a). Registered from one tuple rather than
+# fifteen lines so a new channel layer is wired in exactly one place — the
+# module that also owns the emission order — and cannot end up defined but
+# unregistered.
+for _channel_layer in CHANNEL_LAYER_TYPES:
+    prompt_layer_registry.register(_channel_layer.name, _channel_layer())

--- a/tests/atlas/test_primer_block.py
+++ b/tests/atlas/test_primer_block.py
@@ -12,6 +12,14 @@
 # survive intact (Belt ends on "Instinct gate", Branch keeps "merge/publish"
 # and "revert", Soul keeps "5-tier memory") and that no gist-backed line ends
 # in the truncation ellipsis — the class of miss the fix targets.
+# Updated: 2026-08-03 (PA-7a, feat/prompt-assembler-channel) — the primer's
+# builder moved into ``pocketpaw.prompt.channel.environment`` so it renders
+# inside a layer and under the assembler's render guard;
+# ``AgentContextBuilder._build_atlas_primer`` is now a delegate and every call
+# below still reaches the same code. The cap assertion reads the layer's
+# ``max_chars`` because ``_INJECTION_CAPS`` is deleted. The resilience test is
+# the interesting one: it used to prove the builder's own try/except, and now
+# proves the render guard that replaced it.
 
 from __future__ import annotations
 
@@ -20,8 +28,9 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 import pocketpaw.atlas.store as atlas_store_mod
-from pocketpaw.bootstrap.context_builder import _INJECTION_CAPS, AgentContextBuilder
+from pocketpaw.bootstrap.context_builder import AgentContextBuilder
 from pocketpaw.bootstrap.protocol import BootstrapContext
+from pocketpaw.prompt.channel import ChannelAtlasPrimerLayer
 
 pytestmark = pytest.mark.asyncio
 
@@ -121,8 +130,12 @@ class TestPrimerBudget:
         )
 
     async def test_injection_cap_matches_budget(self):
-        """The assembler-side cap must also enforce the ~500-token ceiling."""
-        cap = _INJECTION_CAPS.get("atlas_primer")
+        """The assembler-side cap must also enforce the ~500-token ceiling.
+
+        PA-7a moved this number off ``_INJECTION_CAPS['atlas_primer']`` and onto
+        the layer that renders the block. Same 2000, one owner.
+        """
+        cap = ChannelAtlasPrimerLayer.max_chars
         assert cap is not None
         assert cap <= _TOKEN_BUDGET * _CHARS_PER_TOKEN
 

--- a/tests/data/channel_prompt_goldens/cli.txt
+++ b/tests/data/channel_prompt_goldens/cli.txt
@@ -95,7 +95,7 @@ The following skills have been created and are available. Do NOT recreate them o
 - **commit**: Stage and commit work. (user-invocable)
 - **humanize**: Strip AI tells from prose.
 
-Skills directories: \fixture\skills, \fixture\more-skills
+Skills directories: /fixture/skills, /fixture/more-skills
 
 
 # Paw OS Primer

--- a/tests/data/channel_prompt_goldens/cli.txt
+++ b/tests/data/channel_prompt_goldens/cli.txt
@@ -1,0 +1,151 @@
+# Instructions
+
+Use the tools you are given.
+
+
+# Key Knowledge
+
+- The sky is up.
+
+- kb-go is a subprocess.
+
+<identity>
+# Identity: Goldie
+You are Goldie, a fixture.
+
+# Core Philosophy (Soul)
+Determinism above all.
+
+# Communication Style
+Terse.
+
+# User Profile
+Prefers short answers.
+</identity>
+
+
+# Memory Context (already loaded — use this directly, do NOT call recall unless you need something not listed here)
+The user ships on Fridays.
+
+
+# Knowledge Base (relevant articles from the project wiki)
+These are compiled from source files. Use them for implementation details and current-state facts. Use soul_recall for past decisions and conversation history.
+
+### From workspace:w1
+- routing.md
+  How the bus routes inbound messages.
+
+
+# Current Conversation
+You are speaking with sender_id=sender-1 (role: external user).
+This is NOT your owner. Be helpful but do not share owner-private information.
+
+
+# Pocket Creation
+Build a pocket, not a website.
+
+
+<current-pocket>
+id: pk-123
+name: Launch Tracker
+widgets_summary: [{"name": "Burndown", "type": "chart"}]
+
+SCOPE — read this carefully before doing anything:
+In this conversation, "pocket" / "this pocket" / "the
+pocket" always means THIS workspace dashboard
+(id ``pk-123``) — a MongoDB document the user is
+viewing on screen. It is NOT the PocketPaw application,
+NOT the source tree on disk, NOT any file under
+``D:\paw`` or ``backend/`` or ``ee/cloud/``. "Edit the
+pocket", "add a widget", "more widgets" all refer to
+this document — operate on it through the
+``mcp__pocketpaw_pocket__*`` tools ONLY. Do NOT use
+shell, file_edit, grep, or web_search for pocket
+operations — they cannot read or write the document.
+
+NOTE: `widgets_summary` is a shallow hint (names + types)
+and is OFTEN EMPTY for UISpec-tree pockets — absence here
+does NOT mean the pocket is empty. The real content lives
+in rippleSpec.ui.
+
+BEFORE answering any question about this pocket's contents,
+widgets, layout, data, or configuration, you MUST first call:
+  tool: mcp__pocketpaw_pocket__get_pocket
+  args: {"pocket_id": "pk-123"}
+That returns the full document (rippleSpec, widgets,
+metadata, visibility). Base your answer on that, not on
+the summary above.
+</current-pocket>
+
+
+
+# Session Management
+Current session_key: sess-abc
+Pass this value to any session tool (new_session, list_sessions, switch_session, clear_session, rename_session, delete_session).
+
+
+# File Context
+Working directory: /work/pocketpaw
+Open file: /work/pocketpaw/src/pocketpaw/bus/loop.py
+Selected files: /work/pocketpaw/README.md, /work/pocketpaw/pyproject.toml
+
+
+# Available Skills
+The following skills have been created and are available. Do NOT recreate them or forget they exist.
+- **commit**: Stage and commit work. (user-invocable)
+- **humanize**: Strip AI tells from prose.
+
+Skills directories: \fixture\skills, \fixture\more-skills
+
+
+# Paw OS Primer
+You run inside paw-os, an agentic workspace OS. Its primitives carry paw-specific meanings (a Pocket is a workspace app, not clothing), and users see results on frontend surfaces — routes like /sites.
+
+OS primitives:
+- Pocket: a workspace app you build and share.
+- Site: a published page rendered to the edge.
+- Soul: portable identity with 5-tier memory.
+
+Before guessing whether the OS can do something or which primitive fits, call atlas_search with your intent, then atlas_describe on the best id. When an action has a home surface, tell the user where to see it by route (e.g. "see it at /sites") — entries carry it in their `surface` field.
+
+
+# Project Constraints (AGENTS.md)
+- Never push to main.
+- Use uv.
+
+# Google Workspace CLI
+
+The Google Workspace CLI (`gws`) is active as an MCP server. It gives you
+access to the full Google Workspace API surface via shell commands.
+
+## When to Use GWS CLI vs Built-in Tools
+
+**Use built-in OAuth tools** (gmail_search, gmail_send, calendar_list, etc.)
+for simple, single-step operations on Gmail, Calendar, Drive, and Docs.
+They are faster and require no subprocess.
+
+**Use GWS CLI** for:
+- **Services only available via gws:** Sheets, Chat, Admin, Meet, Keep,
+  Forms, Slides, Tasks, Classroom, People
+- **Advanced operations:** batch modifications, complex queries, schema
+  introspection, pagination, output formatting
+- **Workflow skills:** multi-service workflows like meeting prep, inbox
+  triage, weekly digests
+
+## Command Pattern
+
+```bash
+gws <service> <resource> [sub-resource] <method> [flags]
+```
+
+### Key Flags
+
+| Flag | Description |
+|------|-------------|
+| `--params '{"key": "val"}'` | URL/query parameters |
+| `--json '{"key": "val"}'` | Request bo
+[...truncated]
+
+
+# System Health
+Status: degraded (memory backend slow).

--- a/tests/data/channel_prompt_goldens/discord.txt
+++ b/tests/data/channel_prompt_goldens/discord.txt
@@ -1,0 +1,231 @@
+# Instructions
+
+Use the tools you are given.
+
+
+# Key Knowledge
+
+- The sky is up.
+
+- kb-go is a subprocess.
+
+<identity>
+# Identity: Goldie
+You are Goldie, a fixture.
+
+# Core Philosophy (Soul)
+Determinism above all.
+
+# Communication Style
+Terse.
+
+# User Profile
+Prefers short answers.
+</identity>
+
+
+# Memory Context (already loaded — use this directly, do NOT call recall unless you need something not listed here)
+The user ships on Fridays.
+
+
+# Knowledge Base (relevant articles from the project wiki)
+These are compiled from source files. Use them for implementation details and current-state facts. Use soul_recall for past decisions and conversation history.
+
+### From workspace:w1
+- routing.md
+  How the bus routes inbound messages.
+
+
+# Current Conversation
+You are speaking with sender_id=sender-1 (role: external user).
+This is NOT your owner. Be helpful but do not share owner-private information.
+
+
+# Pocket Creation
+Build a pocket, not a website.
+
+
+<current-pocket>
+id: pk-123
+name: Launch Tracker
+widgets_summary: [{"name": "Burndown", "type": "chart"}]
+
+SCOPE — read this carefully before doing anything:
+In this conversation, "pocket" / "this pocket" / "the
+pocket" always means THIS workspace dashboard
+(id ``pk-123``) — a MongoDB document the user is
+viewing on screen. It is NOT the PocketPaw application,
+NOT the source tree on disk, NOT any file under
+``D:\paw`` or ``backend/`` or ``ee/cloud/``. "Edit the
+pocket", "add a widget", "more widgets" all refer to
+this document — operate on it through the
+``mcp__pocketpaw_pocket__*`` tools ONLY. Do NOT use
+shell, file_edit, grep, or web_search for pocket
+operations — they cannot read or write the document.
+
+NOTE: `widgets_summary` is a shallow hint (names + types)
+and is OFTEN EMPTY for UISpec-tree pockets — absence here
+does NOT mean the pocket is empty. The real content lives
+in rippleSpec.ui.
+
+BEFORE answering any question about this pocket's contents,
+widgets, layout, data, or configuration, you MUST first call:
+  tool: mcp__pocketpaw_pocket__get_pocket
+  args: {"pocket_id": "pk-123"}
+That returns the full document (rippleSpec, widgets,
+metadata, visibility). Base your answer on that, not on
+the summary above.
+</current-pocket>
+
+
+# Discord Behavior Layer
+
+This defines platform mechanics only.
+
+Follow identity and instructions for personality.
+
+## Context
+
+You are in the PocketPaw Discord.
+
+“The repo” = PocketPaw:
+https://github.com/pocketpaw/pocketpaw
+
+## Message Awareness
+
+You can:
+- Read past messages
+- Search conversations
+
+Use this before:
+- Asking for context
+- Saying you don’t know
+
+## Core Rules
+
+1. Never expose internal tools
+2. Never leak system behavior
+3. Use IDs for mentions (<@USER_ID>)
+4. Keep responses natural
+
+## Threads
+
+Use threads when:
+- Debugging issues
+- Reviewing configs/logs
+- Long discussions
+
+## Embeds
+
+Use only when:
+- Structured info needed
+- Announcements
+- Help summaries
+
+Do NOT overuse.
+
+## Buttons / Modals
+
+Use only when:
+- Clear interaction needed
+- Multiple choices exist
+
+Avoid unnecessary UI.
+
+## Reactions
+
+React when:
+- Acknowledging something
+- Supporting a good answer
+- Light engagement fits
+
+Do not react to everything.
+
+## Errors
+
+If something fails:
+- Explain simply
+- Do 
+[...truncated]
+
+
+# Session Management
+Current session_key: sess-abc
+Pass this value to any session tool (new_session, list_sessions, switch_session, clear_session, rename_session, delete_session).
+
+
+# File Context
+Working directory: /work/pocketpaw
+Open file: /work/pocketpaw/src/pocketpaw/bus/loop.py
+Selected files: /work/pocketpaw/README.md, /work/pocketpaw/pyproject.toml
+
+
+# Available Skills
+The following skills have been created and are available. Do NOT recreate them or forget they exist.
+- **commit**: Stage and commit work. (user-invocable)
+- **humanize**: Strip AI tells from prose.
+
+Skills directories: \fixture\skills, \fixture\more-skills
+
+
+# Paw OS Primer
+You run inside paw-os, an agentic workspace OS. Its primitives carry paw-specific meanings (a Pocket is a workspace app, not clothing), and users see results on frontend surfaces — routes like /sites.
+
+OS primitives:
+- Pocket: a workspace app you build and share.
+- Site: a published page rendered to the edge.
+- Soul: portable identity with 5-tier memory.
+
+Before guessing whether the OS can do something or which primitive fits, call atlas_search with your intent, then atlas_describe on the best id. When an action has a home surface, tell the user where to see it by route (e.g. "see it at /sites") — entries carry it in their `surface` field.
+
+
+# Project Constraints (AGENTS.md)
+- Never push to main.
+- Use uv.
+
+# Google Workspace CLI
+
+The Google Workspace CLI (`gws`) is active as an MCP server. It gives you
+access to the full Google Workspace API surface via shell commands.
+
+## When to Use GWS CLI vs Built-in Tools
+
+**Use built-in OAuth tools** (gmail_search, gmail_send, calendar_list, etc.)
+for simple, single-step operations on Gmail, Calendar, Drive, and Docs.
+They are faster and require no subprocess.
+
+**Use GWS CLI** for:
+- **Services only available via gws:** Sheets, Chat, Admin, Meet, Keep,
+  Forms, Slides, Tasks, Classroom, People
+- **Advanced operations:** batch modifications, complex queries, schema
+  introspection, pagination, output formatting
+- **Workflow skills:** multi-service workflows like meeting prep, inbox
+  triage, weekly digests
+
+## Command Pattern
+
+```bash
+gws <service> <resource> [sub-resource] <method> [flags]
+```
+
+### Key Flags
+
+| Flag | Description |
+|------|-------------|
+| `--params '{"key": "val"}'` | URL/query parameters |
+| `--json '{"key": "val"}'` | Request bo
+[...truncated]
+
+
+# Response Format
+Format: Discord Markdown.
+- Bold: **text**, Italic: *text* or _text_, Strikethrough: ~~text~~
+- Code: `inline` or ```language\nblock```. Headings: # ## ###
+- Links auto-embed; use <url> to suppress preview.
+- Lists: - or 1. work. Use \n between paragraphs.
+- Max message length: 2000 chars. Split long responses into multiple paragraphs.
+- Avoid bare underscores in non-italic text (e.g. write `variable_name` in backticks).
+
+
+# System Health
+Status: degraded (memory backend slow).

--- a/tests/data/channel_prompt_goldens/discord.txt
+++ b/tests/data/channel_prompt_goldens/discord.txt
@@ -165,7 +165,7 @@ The following skills have been created and are available. Do NOT recreate them o
 - **commit**: Stage and commit work. (user-invocable)
 - **humanize**: Strip AI tells from prose.
 
-Skills directories: \fixture\skills, \fixture\more-skills
+Skills directories: /fixture/skills, /fixture/more-skills
 
 
 # Paw OS Primer

--- a/tests/data/channel_prompt_goldens/minimal.txt
+++ b/tests/data/channel_prompt_goldens/minimal.txt
@@ -37,7 +37,7 @@ The following skills have been created and are available. Do NOT recreate them o
 - **commit**: Stage and commit work. (user-invocable)
 - **humanize**: Strip AI tells from prose.
 
-Skills directories: \fixture\skills, \fixture\more-skills
+Skills directories: /fixture/skills, /fixture/more-skills
 
 
 # Paw OS Primer

--- a/tests/data/channel_prompt_goldens/minimal.txt
+++ b/tests/data/channel_prompt_goldens/minimal.txt
@@ -1,0 +1,88 @@
+# Instructions
+
+Use the tools you are given.
+
+
+# Key Knowledge
+
+- The sky is up.
+
+- kb-go is a subprocess.
+
+<identity>
+# Identity: Goldie
+You are Goldie, a fixture.
+
+# Core Philosophy (Soul)
+Determinism above all.
+
+# Communication Style
+Terse.
+
+# User Profile
+Prefers short answers.
+</identity>
+
+
+# Knowledge Base (relevant articles from the project wiki)
+These are compiled from source files. Use them for implementation details and current-state facts. Use soul_recall for past decisions and conversation history.
+
+### From workspace:w1
+- routing.md
+  How the bus routes inbound messages.
+
+
+# Available Skills
+The following skills have been created and are available. Do NOT recreate them or forget they exist.
+- **commit**: Stage and commit work. (user-invocable)
+- **humanize**: Strip AI tells from prose.
+
+Skills directories: \fixture\skills, \fixture\more-skills
+
+
+# Paw OS Primer
+You run inside paw-os, an agentic workspace OS. Its primitives carry paw-specific meanings (a Pocket is a workspace app, not clothing), and users see results on frontend surfaces — routes like /sites.
+
+OS primitives:
+- Pocket: a workspace app you build and share.
+- Site: a published page rendered to the edge.
+- Soul: portable identity with 5-tier memory.
+
+Before guessing whether the OS can do something or which primitive fits, call atlas_search with your intent, then atlas_describe on the best id. When an action has a home surface, tell the user where to see it by route (e.g. "see it at /sites") — entries carry it in their `surface` field.
+
+# Google Workspace CLI
+
+The Google Workspace CLI (`gws`) is active as an MCP server. It gives you
+access to the full Google Workspace API surface via shell commands.
+
+## When to Use GWS CLI vs Built-in Tools
+
+**Use built-in OAuth tools** (gmail_search, gmail_send, calendar_list, etc.)
+for simple, single-step operations on Gmail, Calendar, Drive, and Docs.
+They are faster and require no subprocess.
+
+**Use GWS CLI** for:
+- **Services only available via gws:** Sheets, Chat, Admin, Meet, Keep,
+  Forms, Slides, Tasks, Classroom, People
+- **Advanced operations:** batch modifications, complex queries, schema
+  introspection, pagination, output formatting
+- **Workflow skills:** multi-service workflows like meeting prep, inbox
+  triage, weekly digests
+
+## Command Pattern
+
+```bash
+gws <service> <resource> [sub-resource] <method> [flags]
+```
+
+### Key Flags
+
+| Flag | Description |
+|------|-------------|
+| `--params '{"key": "val"}'` | URL/query parameters |
+| `--json '{"key": "val"}'` | Request bo
+[...truncated]
+
+
+# System Health
+Status: degraded (memory backend slow).

--- a/tests/data/channel_prompt_goldens/no_channel.txt
+++ b/tests/data/channel_prompt_goldens/no_channel.txt
@@ -95,7 +95,7 @@ The following skills have been created and are available. Do NOT recreate them o
 - **commit**: Stage and commit work. (user-invocable)
 - **humanize**: Strip AI tells from prose.
 
-Skills directories: \fixture\skills, \fixture\more-skills
+Skills directories: /fixture/skills, /fixture/more-skills
 
 
 # Paw OS Primer

--- a/tests/data/channel_prompt_goldens/no_channel.txt
+++ b/tests/data/channel_prompt_goldens/no_channel.txt
@@ -1,0 +1,151 @@
+# Instructions
+
+Use the tools you are given.
+
+
+# Key Knowledge
+
+- The sky is up.
+
+- kb-go is a subprocess.
+
+<identity>
+# Identity: Goldie
+You are Goldie, a fixture.
+
+# Core Philosophy (Soul)
+Determinism above all.
+
+# Communication Style
+Terse.
+
+# User Profile
+Prefers short answers.
+</identity>
+
+
+# Memory Context (already loaded — use this directly, do NOT call recall unless you need something not listed here)
+The user ships on Fridays.
+
+
+# Knowledge Base (relevant articles from the project wiki)
+These are compiled from source files. Use them for implementation details and current-state facts. Use soul_recall for past decisions and conversation history.
+
+### From workspace:w1
+- routing.md
+  How the bus routes inbound messages.
+
+
+# Current Conversation
+You are speaking with sender_id=sender-1 (role: external user).
+This is NOT your owner. Be helpful but do not share owner-private information.
+
+
+# Pocket Creation
+Build a pocket, not a website.
+
+
+<current-pocket>
+id: pk-123
+name: Launch Tracker
+widgets_summary: [{"name": "Burndown", "type": "chart"}]
+
+SCOPE — read this carefully before doing anything:
+In this conversation, "pocket" / "this pocket" / "the
+pocket" always means THIS workspace dashboard
+(id ``pk-123``) — a MongoDB document the user is
+viewing on screen. It is NOT the PocketPaw application,
+NOT the source tree on disk, NOT any file under
+``D:\paw`` or ``backend/`` or ``ee/cloud/``. "Edit the
+pocket", "add a widget", "more widgets" all refer to
+this document — operate on it through the
+``mcp__pocketpaw_pocket__*`` tools ONLY. Do NOT use
+shell, file_edit, grep, or web_search for pocket
+operations — they cannot read or write the document.
+
+NOTE: `widgets_summary` is a shallow hint (names + types)
+and is OFTEN EMPTY for UISpec-tree pockets — absence here
+does NOT mean the pocket is empty. The real content lives
+in rippleSpec.ui.
+
+BEFORE answering any question about this pocket's contents,
+widgets, layout, data, or configuration, you MUST first call:
+  tool: mcp__pocketpaw_pocket__get_pocket
+  args: {"pocket_id": "pk-123"}
+That returns the full document (rippleSpec, widgets,
+metadata, visibility). Base your answer on that, not on
+the summary above.
+</current-pocket>
+
+
+
+# Session Management
+Current session_key: sess-abc
+Pass this value to any session tool (new_session, list_sessions, switch_session, clear_session, rename_session, delete_session).
+
+
+# File Context
+Working directory: /work/pocketpaw
+Open file: /work/pocketpaw/src/pocketpaw/bus/loop.py
+Selected files: /work/pocketpaw/README.md, /work/pocketpaw/pyproject.toml
+
+
+# Available Skills
+The following skills have been created and are available. Do NOT recreate them or forget they exist.
+- **commit**: Stage and commit work. (user-invocable)
+- **humanize**: Strip AI tells from prose.
+
+Skills directories: \fixture\skills, \fixture\more-skills
+
+
+# Paw OS Primer
+You run inside paw-os, an agentic workspace OS. Its primitives carry paw-specific meanings (a Pocket is a workspace app, not clothing), and users see results on frontend surfaces — routes like /sites.
+
+OS primitives:
+- Pocket: a workspace app you build and share.
+- Site: a published page rendered to the edge.
+- Soul: portable identity with 5-tier memory.
+
+Before guessing whether the OS can do something or which primitive fits, call atlas_search with your intent, then atlas_describe on the best id. When an action has a home surface, tell the user where to see it by route (e.g. "see it at /sites") — entries carry it in their `surface` field.
+
+
+# Project Constraints (AGENTS.md)
+- Never push to main.
+- Use uv.
+
+# Google Workspace CLI
+
+The Google Workspace CLI (`gws`) is active as an MCP server. It gives you
+access to the full Google Workspace API surface via shell commands.
+
+## When to Use GWS CLI vs Built-in Tools
+
+**Use built-in OAuth tools** (gmail_search, gmail_send, calendar_list, etc.)
+for simple, single-step operations on Gmail, Calendar, Drive, and Docs.
+They are faster and require no subprocess.
+
+**Use GWS CLI** for:
+- **Services only available via gws:** Sheets, Chat, Admin, Meet, Keep,
+  Forms, Slides, Tasks, Classroom, People
+- **Advanced operations:** batch modifications, complex queries, schema
+  introspection, pagination, output formatting
+- **Workflow skills:** multi-service workflows like meeting prep, inbox
+  triage, weekly digests
+
+## Command Pattern
+
+```bash
+gws <service> <resource> [sub-resource] <method> [flags]
+```
+
+### Key Flags
+
+| Flag | Description |
+|------|-------------|
+| `--params '{"key": "val"}'` | URL/query parameters |
+| `--json '{"key": "val"}'` | Request bo
+[...truncated]
+
+
+# System Health
+Status: degraded (memory backend slow).

--- a/tests/data/channel_prompt_goldens/slack.txt
+++ b/tests/data/channel_prompt_goldens/slack.txt
@@ -95,7 +95,7 @@ The following skills have been created and are available. Do NOT recreate them o
 - **commit**: Stage and commit work. (user-invocable)
 - **humanize**: Strip AI tells from prose.
 
-Skills directories: \fixture\skills, \fixture\more-skills
+Skills directories: /fixture/skills, /fixture/more-skills
 
 
 # Paw OS Primer

--- a/tests/data/channel_prompt_goldens/slack.txt
+++ b/tests/data/channel_prompt_goldens/slack.txt
@@ -1,0 +1,162 @@
+# Instructions
+
+Use the tools you are given.
+
+
+# Key Knowledge
+
+- The sky is up.
+
+- kb-go is a subprocess.
+
+<identity>
+# Identity: Goldie
+You are Goldie, a fixture.
+
+# Core Philosophy (Soul)
+Determinism above all.
+
+# Communication Style
+Terse.
+
+# User Profile
+Prefers short answers.
+</identity>
+
+
+# Memory Context (already loaded — use this directly, do NOT call recall unless you need something not listed here)
+The user ships on Fridays.
+
+
+# Knowledge Base (relevant articles from the project wiki)
+These are compiled from source files. Use them for implementation details and current-state facts. Use soul_recall for past decisions and conversation history.
+
+### From workspace:w1
+- routing.md
+  How the bus routes inbound messages.
+
+
+# Current Conversation
+You are speaking with sender_id=sender-1 (role: external user).
+This is NOT your owner. Be helpful but do not share owner-private information.
+
+
+# Pocket Creation
+Build a pocket, not a website.
+
+
+<current-pocket>
+id: pk-123
+name: Launch Tracker
+widgets_summary: [{"name": "Burndown", "type": "chart"}]
+
+SCOPE — read this carefully before doing anything:
+In this conversation, "pocket" / "this pocket" / "the
+pocket" always means THIS workspace dashboard
+(id ``pk-123``) — a MongoDB document the user is
+viewing on screen. It is NOT the PocketPaw application,
+NOT the source tree on disk, NOT any file under
+``D:\paw`` or ``backend/`` or ``ee/cloud/``. "Edit the
+pocket", "add a widget", "more widgets" all refer to
+this document — operate on it through the
+``mcp__pocketpaw_pocket__*`` tools ONLY. Do NOT use
+shell, file_edit, grep, or web_search for pocket
+operations — they cannot read or write the document.
+
+NOTE: `widgets_summary` is a shallow hint (names + types)
+and is OFTEN EMPTY for UISpec-tree pockets — absence here
+does NOT mean the pocket is empty. The real content lives
+in rippleSpec.ui.
+
+BEFORE answering any question about this pocket's contents,
+widgets, layout, data, or configuration, you MUST first call:
+  tool: mcp__pocketpaw_pocket__get_pocket
+  args: {"pocket_id": "pk-123"}
+That returns the full document (rippleSpec, widgets,
+metadata, visibility). Base your answer on that, not on
+the summary above.
+</current-pocket>
+
+
+
+# Session Management
+Current session_key: sess-abc
+Pass this value to any session tool (new_session, list_sessions, switch_session, clear_session, rename_session, delete_session).
+
+
+# File Context
+Working directory: /work/pocketpaw
+Open file: /work/pocketpaw/src/pocketpaw/bus/loop.py
+Selected files: /work/pocketpaw/README.md, /work/pocketpaw/pyproject.toml
+
+
+# Available Skills
+The following skills have been created and are available. Do NOT recreate them or forget they exist.
+- **commit**: Stage and commit work. (user-invocable)
+- **humanize**: Strip AI tells from prose.
+
+Skills directories: \fixture\skills, \fixture\more-skills
+
+
+# Paw OS Primer
+You run inside paw-os, an agentic workspace OS. Its primitives carry paw-specific meanings (a Pocket is a workspace app, not clothing), and users see results on frontend surfaces — routes like /sites.
+
+OS primitives:
+- Pocket: a workspace app you build and share.
+- Site: a published page rendered to the edge.
+- Soul: portable identity with 5-tier memory.
+
+Before guessing whether the OS can do something or which primitive fits, call atlas_search with your intent, then atlas_describe on the best id. When an action has a home surface, tell the user where to see it by route (e.g. "see it at /sites") — entries carry it in their `surface` field.
+
+
+# Project Constraints (AGENTS.md)
+- Never push to main.
+- Use uv.
+
+# Google Workspace CLI
+
+The Google Workspace CLI (`gws`) is active as an MCP server. It gives you
+access to the full Google Workspace API surface via shell commands.
+
+## When to Use GWS CLI vs Built-in Tools
+
+**Use built-in OAuth tools** (gmail_search, gmail_send, calendar_list, etc.)
+for simple, single-step operations on Gmail, Calendar, Drive, and Docs.
+They are faster and require no subprocess.
+
+**Use GWS CLI** for:
+- **Services only available via gws:** Sheets, Chat, Admin, Meet, Keep,
+  Forms, Slides, Tasks, Classroom, People
+- **Advanced operations:** batch modifications, complex queries, schema
+  introspection, pagination, output formatting
+- **Workflow skills:** multi-service workflows like meeting prep, inbox
+  triage, weekly digests
+
+## Command Pattern
+
+```bash
+gws <service> <resource> [sub-resource] <method> [flags]
+```
+
+### Key Flags
+
+| Flag | Description |
+|------|-------------|
+| `--params '{"key": "val"}'` | URL/query parameters |
+| `--json '{"key": "val"}'` | Request bo
+[...truncated]
+
+
+# Response Format
+Format: Slack mrkdwn.
+- Bold: *text*, Italic: _text_, Strike: ~text~, Code: `inline` or ```block```
+- Links: <url|display text>. Do NOT use [text](url).
+- NO headings (#). Use *bold on its own line* as a section header.
+- Lists: use - or * (bullet) or 1. (numbered). Indent with spaces for nesting.
+- Blank lines between sections for readability.
+- Blockquotes: > text
+- Avoid bare underscores outside _italic_ — they break mrkdwn parsing.
+
+
+# System Health
+Status: degraded (memory backend slow).

--- a/tests/data/channel_prompt_goldens/telegram.txt
+++ b/tests/data/channel_prompt_goldens/telegram.txt
@@ -95,7 +95,7 @@ The following skills have been created and are available. Do NOT recreate them o
 - **commit**: Stage and commit work. (user-invocable)
 - **humanize**: Strip AI tells from prose.
 
-Skills directories: \fixture\skills, \fixture\more-skills
+Skills directories: /fixture/skills, /fixture/more-skills
 
 
 # Paw OS Primer

--- a/tests/data/channel_prompt_goldens/telegram.txt
+++ b/tests/data/channel_prompt_goldens/telegram.txt
@@ -1,0 +1,163 @@
+# Instructions
+
+Use the tools you are given.
+
+
+# Key Knowledge
+
+- The sky is up.
+
+- kb-go is a subprocess.
+
+<identity>
+# Identity: Goldie
+You are Goldie, a fixture.
+
+# Core Philosophy (Soul)
+Determinism above all.
+
+# Communication Style
+Terse.
+
+# User Profile
+Prefers short answers.
+</identity>
+
+
+# Memory Context (already loaded — use this directly, do NOT call recall unless you need something not listed here)
+The user ships on Fridays.
+
+
+# Knowledge Base (relevant articles from the project wiki)
+These are compiled from source files. Use them for implementation details and current-state facts. Use soul_recall for past decisions and conversation history.
+
+### From workspace:w1
+- routing.md
+  How the bus routes inbound messages.
+
+
+# Current Conversation
+You are speaking with sender_id=sender-1 (role: external user).
+This is NOT your owner. Be helpful but do not share owner-private information.
+
+
+# Pocket Creation
+Build a pocket, not a website.
+
+
+<current-pocket>
+id: pk-123
+name: Launch Tracker
+widgets_summary: [{"name": "Burndown", "type": "chart"}]
+
+SCOPE — read this carefully before doing anything:
+In this conversation, "pocket" / "this pocket" / "the
+pocket" always means THIS workspace dashboard
+(id ``pk-123``) — a MongoDB document the user is
+viewing on screen. It is NOT the PocketPaw application,
+NOT the source tree on disk, NOT any file under
+``D:\paw`` or ``backend/`` or ``ee/cloud/``. "Edit the
+pocket", "add a widget", "more widgets" all refer to
+this document — operate on it through the
+``mcp__pocketpaw_pocket__*`` tools ONLY. Do NOT use
+shell, file_edit, grep, or web_search for pocket
+operations — they cannot read or write the document.
+
+NOTE: `widgets_summary` is a shallow hint (names + types)
+and is OFTEN EMPTY for UISpec-tree pockets — absence here
+does NOT mean the pocket is empty. The real content lives
+in rippleSpec.ui.
+
+BEFORE answering any question about this pocket's contents,
+widgets, layout, data, or configuration, you MUST first call:
+  tool: mcp__pocketpaw_pocket__get_pocket
+  args: {"pocket_id": "pk-123"}
+That returns the full document (rippleSpec, widgets,
+metadata, visibility). Base your answer on that, not on
+the summary above.
+</current-pocket>
+
+
+
+# Session Management
+Current session_key: sess-abc
+Pass this value to any session tool (new_session, list_sessions, switch_session, clear_session, rename_session, delete_session).
+
+
+# File Context
+Working directory: /work/pocketpaw
+Open file: /work/pocketpaw/src/pocketpaw/bus/loop.py
+Selected files: /work/pocketpaw/README.md, /work/pocketpaw/pyproject.toml
+
+
+# Available Skills
+The following skills have been created and are available. Do NOT recreate them or forget they exist.
+- **commit**: Stage and commit work. (user-invocable)
+- **humanize**: Strip AI tells from prose.
+
+Skills directories: \fixture\skills, \fixture\more-skills
+
+
+# Paw OS Primer
+You run inside paw-os, an agentic workspace OS. Its primitives carry paw-specific meanings (a Pocket is a workspace app, not clothing), and users see results on frontend surfaces — routes like /sites.
+
+OS primitives:
+- Pocket: a workspace app you build and share.
+- Site: a published page rendered to the edge.
+- Soul: portable identity with 5-tier memory.
+
+Before guessing whether the OS can do something or which primitive fits, call atlas_search with your intent, then atlas_describe on the best id. When an action has a home surface, tell the user where to see it by route (e.g. "see it at /sites") — entries carry it in their `surface` field.
+
+
+# Project Constraints (AGENTS.md)
+- Never push to main.
+- Use uv.
+
+# Google Workspace CLI
+
+The Google Workspace CLI (`gws`) is active as an MCP server. It gives you
+access to the full Google Workspace API surface via shell commands.
+
+## When to Use GWS CLI vs Built-in Tools
+
+**Use built-in OAuth tools** (gmail_search, gmail_send, calendar_list, etc.)
+for simple, single-step operations on Gmail, Calendar, Drive, and Docs.
+They are faster and require no subprocess.
+
+**Use GWS CLI** for:
+- **Services only available via gws:** Sheets, Chat, Admin, Meet, Keep,
+  Forms, Slides, Tasks, Classroom, People
+- **Advanced operations:** batch modifications, complex queries, schema
+  introspection, pagination, output formatting
+- **Workflow skills:** multi-service workflows like meeting prep, inbox
+  triage, weekly digests
+
+## Command Pattern
+
+```bash
+gws <service> <resource> [sub-resource] <method> [flags]
+```
+
+### Key Flags
+
+| Flag | Description |
+|------|-------------|
+| `--params '{"key": "val"}'` | URL/query parameters |
+| `--json '{"key": "val"}'` | Request bo
+[...truncated]
+
+
+# Response Format
+Format: Telegram Markdown.
+- Bold: *text*, Italic: _text_, Code: `inline` or ```block```
+- Links: [display text](url)
+- NO headings (#) — use *bold* on its own line as a header.
+- Lists: use - for bullets. Numbered lists work as plain text (1. 2. 3.).
+- Use \n between paragraphs for readability.
+- IMPORTANT: Escape _ inside words with \_ (e.g. variable\_name) or wrap in `backticks` — unmatched underscores cause parse errors.
+- Avoid nested or adjacent formatting (e.g. *_bold i
+[...truncated]
+
+
+# System Health
+Status: degraded (memory backend slow).

--- a/tests/e2e/test_tool_output_summary_e2e.py
+++ b/tests/e2e/test_tool_output_summary_e2e.py
@@ -1,6 +1,12 @@
 # E2E test for the tool-output budget (#1160).
 # Created: 2026-05-21
 #
+# Updated: 2026-08-03 (PA-7b, feat/prompt-assembler-channel) — the stubbed builder
+# returns an ``AssembledPrompt`` from ``assemble_system_prompt`` and the mocked
+# backend declares ``system_prompt_digest``, because ``AgentLoop`` now carries the
+# assembled prompt's stable digest through the router to the backend. Nothing
+# about what this test proves changed; only the shape of the two things it fakes.
+#
 # Proves that an oversized tool result is capped before it reaches agent
 # context, through the real production tool paths:
 #
@@ -27,6 +33,7 @@ import pytest
 from pocketpaw.agents.loop import AgentLoop
 from pocketpaw.agents.protocol import AgentEvent
 from pocketpaw.bus import Channel, InboundMessage
+from pocketpaw.prompt import AssembledPrompt
 from pocketpaw.tools.output_budget import TOOL_OUTPUT_CHAR_CAP
 from pocketpaw.tools.protocol import BaseTool
 from pocketpaw.tools.registry import ToolRegistry
@@ -158,7 +165,9 @@ async def test_agent_loop_tool_result_is_capped(mock_bus, mock_memory):
     # so the test can assert on the exact string that flowed into the loop.
     captured: dict[str, str] = {}
 
-    async def mock_run(message, *, system_prompt=None, history=None, session_key=None):
+    async def mock_run(
+        message, *, system_prompt=None, history=None, session_key=None, system_prompt_digest=""
+    ):
         """Stand-in for the LLM backend. A real backend would call the tool
         and stream a tool_result; here we run the real registry and yield
         the real (capped) result."""
@@ -204,7 +213,9 @@ async def test_agent_loop_tool_result_is_capped(mock_bus, mock_memory):
         patch("pocketpaw.agents.loop.Settings") as mock_settings_cls,
     ):
         mock_settings_cls.load.return_value = settings
-        mock_builder_cls.return_value.build_system_prompt = AsyncMock(return_value="System Prompt")
+        mock_builder_cls.return_value.assemble_system_prompt = AsyncMock(
+            return_value=AssembledPrompt(text="System Prompt", stable_digest="0123456789abcdef")
+        )
 
         loop = AgentLoop()
         msg = InboundMessage(

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1,5 +1,15 @@
 # Tests for Unified Agent Loop
 # Updated for AgentEvent-based architecture (no more dict chunks)
+#
+# Updated: 2026-08-03 (PA-7b, feat/prompt-assembler-channel) — the loop now calls
+# ``AgentContextBuilder.assemble_system_prompt`` (which returns text AND the
+# prompt's ``stable_digest``) instead of ``build_system_prompt``, so every stub
+# builder here returns an ``AssembledPrompt`` rather than a bare string, and the
+# fake routers declare ``system_prompt_digest`` because the loop passes it. The
+# builder mocks were NOT left on the old name: a mock naming a method the code no
+# longer calls records nothing and reads as coverage. The digest's own behaviour
+# is pinned in ``tests/test_channel_prompt_digest.py``; these tests are unchanged
+# in what they assert.
 
 import asyncio
 import logging
@@ -10,6 +20,16 @@ import pytest
 from pocketpaw.agents.loop import AgentLoop
 from pocketpaw.agents.protocol import AgentEvent
 from pocketpaw.bus import Channel, InboundMessage
+from pocketpaw.prompt import AssembledPrompt
+
+# Any non-empty digest: these tests care that the loop threads ONE through, not
+# which one. ``test_channel_prompt_digest.py`` owns what makes it move.
+_STUB_DIGEST = "0123456789abcdef"
+
+
+def _assembled(text: str = "System Prompt") -> AssembledPrompt:
+    """What the real builder hands the loop back."""
+    return AssembledPrompt(text=text, stable_digest=_STUB_DIGEST)
 
 
 @pytest.fixture
@@ -36,7 +56,9 @@ def mock_router():
     """Mock AgentRouter that yields AgentEvent objects."""
     router = MagicMock()
 
-    async def mock_run(message, *, system_prompt=None, history=None, session_key=None):
+    async def mock_run(
+        message, *, system_prompt=None, history=None, session_key=None, system_prompt_digest=""
+    ):
         yield AgentEvent(type="message", content="Hello ")
         yield AgentEvent(type="message", content="world!")
         yield AgentEvent(
@@ -76,7 +98,7 @@ async def test_agent_loop_process_message(
     mock_router_cls.return_value = mock_router
 
     mock_builder_instance = mock_builder_cls.return_value
-    mock_builder_instance.build_system_prompt = AsyncMock(return_value="System Prompt")
+    mock_builder_instance.assemble_system_prompt = AsyncMock(return_value=_assembled())
 
     with patch("pocketpaw.agents.loop.get_settings") as mock_settings:
         settings = MagicMock()
@@ -148,7 +170,7 @@ async def test_agent_loop_handles_error(
     mock_router_cls.return_value = error_router
 
     mock_builder_instance = mock_builder_cls.return_value
-    mock_builder_instance.build_system_prompt = AsyncMock(return_value="System Prompt")
+    mock_builder_instance.assemble_system_prompt = AsyncMock(return_value=_assembled())
 
     with patch("pocketpaw.agents.loop.get_settings") as mock_settings:
         settings = MagicMock()
@@ -250,7 +272,7 @@ async def test_recent_file_tracker_failures_are_logged(
     mock_router_cls.return_value = mock_router
 
     mock_builder_instance = mock_builder_cls.return_value
-    mock_builder_instance.build_system_prompt = AsyncMock(return_value="System Prompt")
+    mock_builder_instance.assemble_system_prompt = AsyncMock(return_value=_assembled())
 
     with patch("pocketpaw.agents.loop.get_settings") as mock_settings:
         settings = MagicMock()
@@ -307,7 +329,7 @@ async def test_agent_loop_emits_tool_events(
     mock_router_cls.return_value = mock_router
 
     mock_builder_instance = mock_builder_cls.return_value
-    mock_builder_instance.build_system_prompt = AsyncMock(return_value="System Prompt")
+    mock_builder_instance.assemble_system_prompt = AsyncMock(return_value=_assembled())
 
     with patch("pocketpaw.agents.loop.get_settings") as mock_settings:
         settings = MagicMock()
@@ -356,7 +378,9 @@ async def test_agent_loop_builds_context_and_passes_to_router(
 
     captured_kwargs = {}
 
-    async def capturing_run(message, *, system_prompt=None, history=None, session_key=None):
+    async def capturing_run(
+        message, *, system_prompt=None, history=None, session_key=None, system_prompt_digest=""
+    ):
         captured_kwargs["system_prompt"] = system_prompt
         captured_kwargs["history"] = history
         yield AgentEvent(type="message", content="OK")
@@ -368,8 +392,8 @@ async def test_agent_loop_builds_context_and_passes_to_router(
     mock_router_cls.return_value = router
 
     mock_builder_instance = mock_builder_cls.return_value
-    mock_builder_instance.build_system_prompt = AsyncMock(
-        return_value="You are PocketPaw with identity and memory."
+    mock_builder_instance.assemble_system_prompt = AsyncMock(
+        return_value=_assembled("You are PocketPaw with identity and memory.")
     )
     mock_builder_instance.bootstrap.get_context = AsyncMock(
         return_value=MagicMock(to_identity_block=lambda: "<identity>Test</identity>")
@@ -402,7 +426,7 @@ async def test_agent_loop_builds_context_and_passes_to_router(
 
             await loop._process_message(msg)
 
-            mock_builder_instance.build_system_prompt.assert_called_once()
+            mock_builder_instance.assemble_system_prompt.assert_called_once()
             mock_memory.get_compacted_history.assert_called_once()
             assert captured_kwargs["system_prompt"] == "You are PocketPaw with identity and memory."
             assert captured_kwargs["history"] == session_history
@@ -429,7 +453,7 @@ async def test_agent_loop_handles_error_before_router_init(
     )
 
     mock_builder_instance = mock_builder_cls.return_value
-    mock_builder_instance.build_system_prompt = AsyncMock(return_value="System Prompt")
+    mock_builder_instance.assemble_system_prompt = AsyncMock(return_value=_assembled())
 
     with patch("pocketpaw.agents.loop.get_settings") as mock_settings:
         settings = MagicMock()
@@ -491,7 +515,9 @@ async def test_identity_reinforcement_appended_on_long_conversations(
 
     captured: dict = {}
 
-    async def capturing_run(message, *, system_prompt=None, history=None, session_key=None):
+    async def capturing_run(
+        message, *, system_prompt=None, history=None, session_key=None, system_prompt_digest=""
+    ):
         captured["system_prompt"] = system_prompt
         yield AgentEvent(type="message", content="OK")
         yield AgentEvent(type="done", content="")
@@ -516,8 +542,8 @@ async def test_identity_reinforcement_appended_on_long_conversations(
     )
 
     mock_builder_instance = mock_builder_cls.return_value
-    mock_builder_instance.build_system_prompt = AsyncMock(
-        return_value="<identity>You are PocketPaw</identity>"
+    mock_builder_instance.assemble_system_prompt = AsyncMock(
+        return_value=_assembled("<identity>You are PocketPaw</identity>")
     )
     mock_builder_instance.bootstrap = mock_bootstrap
 
@@ -573,7 +599,9 @@ async def test_identity_reinforcement_not_appended_on_short_conversations(
 
     captured: dict = {}
 
-    async def capturing_run(message, *, system_prompt=None, history=None, session_key=None):
+    async def capturing_run(
+        message, *, system_prompt=None, history=None, session_key=None, system_prompt_digest=""
+    ):
         captured["system_prompt"] = system_prompt
         yield AgentEvent(type="message", content="OK")
         yield AgentEvent(type="done", content="")
@@ -598,8 +626,8 @@ async def test_identity_reinforcement_not_appended_on_short_conversations(
     )
 
     mock_builder_instance = mock_builder_cls.return_value
-    mock_builder_instance.build_system_prompt = AsyncMock(
-        return_value="<identity>You are PocketPaw</identity>"
+    mock_builder_instance.assemble_system_prompt = AsyncMock(
+        return_value=_assembled("<identity>You are PocketPaw</identity>")
     )
     mock_builder_instance.bootstrap = mock_bootstrap
 
@@ -798,7 +826,9 @@ async def test_auto_tts_triggered_by_voice_message(
     mock_get_memory.return_value = mock_memory
 
     # Mock router yields text response without calling text_to_speech tool
-    async def mock_run(message, *, system_prompt=None, history=None, session_key=None):
+    async def mock_run(
+        message, *, system_prompt=None, history=None, session_key=None, system_prompt_digest=""
+    ):
         yield AgentEvent(type="message", content="I heard your voice message!")
         yield AgentEvent(type="done", content="")
 
@@ -808,7 +838,7 @@ async def test_auto_tts_triggered_by_voice_message(
     mock_router_cls.return_value = router
 
     mock_builder_instance = mock_builder_cls.return_value
-    mock_builder_instance.build_system_prompt = AsyncMock(return_value="System Prompt")
+    mock_builder_instance.assemble_system_prompt = AsyncMock(return_value=_assembled())
 
     with patch("pocketpaw.agents.loop.get_settings") as mock_settings:
         settings = MagicMock()
@@ -868,7 +898,9 @@ async def test_auto_tts_skipped_when_agent_already_sent_audio(
     mock_get_memory.return_value = mock_memory
 
     # Mock router yields tool_result with media tag (agent already generated audio)
-    async def mock_run(message, *, system_prompt=None, history=None, session_key=None):
+    async def mock_run(
+        message, *, system_prompt=None, history=None, session_key=None, system_prompt_digest=""
+    ):
         yield AgentEvent(type="message", content="Here's my voice reply")
         yield AgentEvent(
             type="tool_result",
@@ -883,7 +915,7 @@ async def test_auto_tts_skipped_when_agent_already_sent_audio(
     mock_router_cls.return_value = router
 
     mock_builder_instance = mock_builder_cls.return_value
-    mock_builder_instance.build_system_prompt = AsyncMock(return_value="System Prompt")
+    mock_builder_instance.assemble_system_prompt = AsyncMock(return_value=_assembled())
 
     with patch("pocketpaw.agents.loop.get_settings") as mock_settings:
         settings = MagicMock()
@@ -933,7 +965,9 @@ async def test_auto_tts_disabled_by_setting(
     mock_get_bus.return_value = mock_bus
     mock_get_memory.return_value = mock_memory
 
-    async def mock_run(message, *, system_prompt=None, history=None, session_key=None):
+    async def mock_run(
+        message, *, system_prompt=None, history=None, session_key=None, system_prompt_digest=""
+    ):
         yield AgentEvent(type="message", content="Response")
         yield AgentEvent(type="done", content="")
 
@@ -943,7 +977,7 @@ async def test_auto_tts_disabled_by_setting(
     mock_router_cls.return_value = router
 
     mock_builder_instance = mock_builder_cls.return_value
-    mock_builder_instance.build_system_prompt = AsyncMock(return_value="System Prompt")
+    mock_builder_instance.assemble_system_prompt = AsyncMock(return_value=_assembled())
 
     with patch("pocketpaw.agents.loop.get_settings") as mock_settings:
         settings = MagicMock()
@@ -993,7 +1027,9 @@ async def test_auto_tts_handles_synthesis_failure_gracefully(
     mock_get_bus.return_value = mock_bus
     mock_get_memory.return_value = mock_memory
 
-    async def mock_run(message, *, system_prompt=None, history=None, session_key=None):
+    async def mock_run(
+        message, *, system_prompt=None, history=None, session_key=None, system_prompt_digest=""
+    ):
         yield AgentEvent(type="message", content="Response text")
         yield AgentEvent(type="done", content="")
 
@@ -1003,7 +1039,7 @@ async def test_auto_tts_handles_synthesis_failure_gracefully(
     mock_router_cls.return_value = router
 
     mock_builder_instance = mock_builder_cls.return_value
-    mock_builder_instance.build_system_prompt = AsyncMock(return_value="System Prompt")
+    mock_builder_instance.assemble_system_prompt = AsyncMock(return_value=_assembled())
 
     with patch("pocketpaw.agents.loop.get_settings") as mock_settings:
         settings = MagicMock()
@@ -1087,7 +1123,7 @@ async def test_agents_md_discovery_failure_is_silently_logged(
     mock_router_cls.return_value = mock_router
 
     mock_builder_instance = mock_builder_cls.return_value
-    mock_builder_instance.build_system_prompt = AsyncMock(return_value="System Prompt")
+    mock_builder_instance.assemble_system_prompt = AsyncMock(return_value=_assembled())
 
     with (
         patch("pocketpaw.agents.loop.get_settings") as mock_settings,
@@ -1145,7 +1181,7 @@ async def test_token_metrics_persist_failure_is_logged_at_debug(
     token_router = MagicMock()
 
     async def mock_run_with_token_usage(
-        message, *, system_prompt=None, history=None, session_key=None
+        message, *, system_prompt=None, history=None, session_key=None, system_prompt_digest=""
     ):
         yield AgentEvent(
             type="token_usage",
@@ -1166,7 +1202,7 @@ async def test_token_metrics_persist_failure_is_logged_at_debug(
     mock_router_cls.return_value = token_router
 
     mock_builder_instance = mock_builder_cls.return_value
-    mock_builder_instance.build_system_prompt = AsyncMock(return_value="System Prompt")
+    mock_builder_instance.assemble_system_prompt = AsyncMock(return_value=_assembled())
 
     with (
         patch("pocketpaw.agents.loop.get_settings") as mock_settings,
@@ -1222,7 +1258,7 @@ async def test_budget_exhaustion_blocks_before_router_run(
     mock_router_cls.return_value = MagicMock()
 
     mock_builder_instance = mock_builder_cls.return_value
-    mock_builder_instance.build_system_prompt = AsyncMock(return_value="System Prompt")
+    mock_builder_instance.assemble_system_prompt = AsyncMock(return_value=_assembled())
 
     tracker = MagicMock()
     tracker.get_summary.return_value = {"total_cost_usd": 12.0}
@@ -1292,7 +1328,7 @@ async def test_budget_warning_event_emitted_on_threshold_cross(
     warning_router = MagicMock()
 
     async def mock_run_with_token_usage(
-        message, *, system_prompt=None, history=None, session_key=None
+        message, *, system_prompt=None, history=None, session_key=None, system_prompt_digest=""
     ):
         yield AgentEvent(
             type="token_usage",
@@ -1313,7 +1349,7 @@ async def test_budget_warning_event_emitted_on_threshold_cross(
     mock_router_cls.return_value = warning_router
 
     mock_builder_instance = mock_builder_cls.return_value
-    mock_builder_instance.build_system_prompt = AsyncMock(return_value="System Prompt")
+    mock_builder_instance.assemble_system_prompt = AsyncMock(return_value=_assembled())
 
     class MutableTracker:
         def __init__(self, initial_total: float) -> None:
@@ -1407,7 +1443,7 @@ async def test_health_engine_persist_failure_logged_as_warning(
     mock_router_cls.return_value = boom_router
 
     mock_builder_instance = mock_builder_cls.return_value
-    mock_builder_instance.build_system_prompt = AsyncMock(return_value="System Prompt")
+    mock_builder_instance.assemble_system_prompt = AsyncMock(return_value=_assembled())
 
     with (
         patch("pocketpaw.agents.loop.get_settings") as mock_settings,
@@ -1469,7 +1505,7 @@ async def test_router_stop_failure_logged_as_warning(
     mock_router_cls.return_value = flaky_router
 
     mock_builder_instance = mock_builder_cls.return_value
-    mock_builder_instance.build_system_prompt = AsyncMock(return_value="System Prompt")
+    mock_builder_instance.assemble_system_prompt = AsyncMock(return_value=_assembled())
 
     with (
         patch("pocketpaw.agents.loop.get_settings") as mock_settings,

--- a/tests/test_channel_prompt_digest.py
+++ b/tests/test_channel_prompt_digest.py
@@ -15,6 +15,14 @@
 # those layers said about themselves. No cache-rate number is claimed here
 # because none was measured.
 #
+# ONE MECHANISM WAS measured, in `test_a_changed_recall_moves_the_prefix_and_not_
+# the_digest`, and it is worth reading before concluding this buys nothing: the
+# prefix's volatile markers are the CLOUD path's block headers, and the channel
+# path's memory / kb headers are not among them. So the per-message recall stays
+# inside the channel prefix and moves it, while the layers that render it declare
+# `cache_key=None` and the digest holds. That is a two-turn probe of a mechanism,
+# not a rate over live traffic, and it is deliberately not converted into one.
+#
 # THE SIGNATURE GATE IS THE LOAD-BEARING PART. The digest is set on every channel
 # turn, so it cannot ride the withhold-when-empty contract the other per-run
 # kwargs use; it is gated on whether a backend's `run` DECLARES the parameter
@@ -396,6 +404,56 @@ async def test_the_disabled_failover_flag_still_delivers_the_digest(monkeypatch)
 # ---------------------------------------------------------------------------
 # 4 — what the digest does NOT cover, which is the design and not a gap
 # ---------------------------------------------------------------------------
+
+
+async def test_a_changed_recall_moves_the_prefix_and_not_the_digest():
+    """What the prefix was never able to cut on THIS path, measured rather than assumed.
+
+    `_behavior_prefix` cuts the volatile tail at `_VOLATILE_PROMPT_MARKERS`:
+    `## Your Knowledge Base`, `## Relevant Past Memories`, `# Recent Conversation`.
+    Those are the CLOUD path's block headers. The channel path emits
+    `# Memory Context (already loaded…)` and `# Knowledge Base (relevant
+    articles…)`, and neither matches — so the per-message recall stays INSIDE the
+    prefix and moves it on any turn where the recall changes, which on a semantic
+    memory backend is most turns. The two channel layers that produce those blocks
+    declare `cache_key=None`, so the digest does not move.
+
+    READ THIS NARROWLY. It is a two-turn probe of a MECHANISM, run here, not a
+    hit-rate over live traffic: no turn count, no percentage, nothing comparable
+    to PA-6's 8-turn measurement on a live soul. It says the prefix and the digest
+    disagree about the recall on this path and which one is right. It does not say
+    how often that costs a rebuild for a real user.
+
+    THE MUTATION THAT BREAKS THIS: add `"\\n\\n# Memory Context"` to
+    `ClaudeSDKBackend._VOLATILE_PROMPT_MARKERS`. Run: the prefix started cutting
+    at the memory block, the two prefixes became equal, and the first assertion
+    failed.
+    """
+    from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
+    from pocketpaw.bootstrap.context_builder import AgentContextBuilder
+
+    async def _assemble(recall: str):
+        memory = MagicMock()
+        memory.get_semantic_context = AsyncMock(return_value=recall)
+        memory.get_context_for_agent = AsyncMock(return_value=recall)
+        return await AgentContextBuilder(memory_manager=memory).assemble_system_prompt(
+            include_memory=True, user_query="hi", channel=Channel.TELEGRAM, sender_id="s1"
+        )
+
+    turn_1 = await _assemble("user asked about asyncpg pools")
+    turn_2 = await _assemble("user asked about rollback semantics")
+
+    prefix_1 = ClaudeSDKBackend._behavior_prefix(turn_1.text)
+    prefix_2 = ClaudeSDKBackend._behavior_prefix(turn_2.text)
+
+    assert "# Memory Context" in prefix_1, (
+        "the per-message recall left the prefix — re-read this test before trusting it"
+    )
+    assert prefix_1 != prefix_2, "the prefix stopped moving on a changed recall"
+    assert turn_1.stable_digest == turn_2.stable_digest, (
+        "a changed recall moved the digest — the memory/kb layers stopped declaring "
+        "themselves volatile"
+    )
 
 
 @patch("pocketpaw.agents.loop.get_message_bus")

--- a/tests/test_channel_prompt_digest.py
+++ b/tests/test_channel_prompt_digest.py
@@ -1,0 +1,514 @@
+# tests/test_channel_prompt_digest.py
+# Created: 2026-08-03 (PA-7b, feat/prompt-assembler-channel) — pins the delivery
+# of the channel path's `stable_digest` from the assembler to the backend, and
+# the two things that delivery is deliberately blind to.
+#
+# WHAT THIS IS AND IS NOT. PA-7a moved Telegram / Discord / Slack / CLI onto the
+# layered assembler, which computed a digest and dropped it on the floor. PA-7b
+# threads it. That is a CORRECTNESS change, not a hit-rate one, and the
+# difference matters for reading these tests: `claude_sdk._behavior_prefix`
+# already held 7/7 turn boundaries on a realistic channel prompt (measured at
+# PA-6), so nothing here should be read as "the cache got warmer". What the
+# prefix cannot do is see a REAL behaviour change that happens to sit below the
+# volatile marker it cuts at — it infers which bytes are stable by pattern-
+# matching text two modules away from the layers that know. The digest is what
+# those layers said about themselves. No cache-rate number is claimed here
+# because none was measured.
+#
+# THE SIGNATURE GATE IS THE LOAD-BEARING PART. The digest is set on every channel
+# turn, so it cannot ride the withhold-when-empty contract the other per-run
+# kwargs use; it is gated on whether a backend's `run` DECLARES the parameter
+# (`agents.backend._accepts_prompt_digest`, which refuses `**kwargs`). Three
+# dispatch points now ask that question — `AgentRouter.run`'s primary branch, its
+# generic fallback loop, and `BackendFailoverRunner`'s chain — and the two
+# fallback paths are the ones a careless thread drops, because they only run when
+# something else has already failed.
+#
+# EACH TEST NAMES THE MUTATION THAT BREAKS IT, and every mutation below was
+# applied to the production file, run, observed to fail, and reverted.
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from pocketpaw.agents.backend import BackendInfo, Capability
+from pocketpaw.agents.protocol import AgentEvent
+from pocketpaw.agents.router import AgentRouter
+from pocketpaw.bus import Channel, InboundMessage
+from pocketpaw.config import Settings
+from pocketpaw.prompt import AssembledPrompt
+
+pytestmark = pytest.mark.asyncio
+
+_DIGEST = "c0ffee0000000000"
+
+
+def _info(name: str) -> BackendInfo:
+    """The registry path calls ``cls.info()``; a fake without one logs an error
+    and leaves ``_active_backend_name`` unset, which is a different backend than
+    the one under test."""
+    return BackendInfo(name=name, display_name=name, capabilities=Capability.STREAMING)
+
+
+# ---------------------------------------------------------------------------
+# Fake backends. Each one exists to be a DIFFERENT answer to "does this backend
+# declare the digest", so they are written out rather than parameterised — the
+# signatures ARE the fixtures.
+# ---------------------------------------------------------------------------
+
+
+class _Declares:
+    """A ported backend: names `system_prompt_digest` in `run`."""
+
+    seen: dict[str, Any] = {}
+
+    @staticmethod
+    def info() -> BackendInfo:
+        return _info("declares")
+
+    def __init__(self, settings=None):  # noqa: ARG002 - registry calls with settings
+        pass
+
+    async def run(  # noqa: ARG002 - the fake ignores everything but the digest
+        self,
+        message: str,
+        *,
+        system_prompt: str | None = None,
+        history: list[dict] | None = None,
+        session_key: str | None = None,
+        system_prompt_digest: str = "",
+    ):
+        type(self).seen["digest"] = system_prompt_digest
+        yield AgentEvent(type="message", content="declares")
+        yield AgentEvent(type="done", content="")
+
+
+class _NarrowSignature:
+    """An out-of-tree backend written before the digest existed.
+
+    Not a contrived shape: `codex_cli` and `opencode` — the two harnesses the
+    shipped failover chain falls back to — have exactly this signature. Passing
+    the kwarg to it raises TypeError.
+    """
+
+    ran = False
+
+    @staticmethod
+    def info() -> BackendInfo:
+        return _info("narrow")
+
+    def __init__(self, settings=None):  # noqa: ARG002
+        pass
+
+    async def run(  # noqa: ARG002
+        self,
+        message: str,
+        *,
+        system_prompt: str | None = None,
+        history: list[dict] | None = None,
+        session_key: str | None = None,
+    ):
+        type(self).ran = True
+        yield AgentEvent(type="message", content="narrow")
+        yield AgentEvent(type="done", content="")
+
+
+class _SwallowsKwargs:
+    """The dangerous shape: accepts anything, declares nothing.
+
+    Sending it the digest would raise no error and key on nothing — it would
+    look ported forever. The guard refuses `**kwargs` for this reason.
+    """
+
+    seen: dict[str, Any] = {}
+
+    @staticmethod
+    def info() -> BackendInfo:
+        return _info("swallows")
+
+    def __init__(self, settings=None):  # noqa: ARG002
+        pass
+
+    async def run(self, message: str, **kwargs: Any):  # noqa: ARG002
+        type(self).seen = dict(kwargs)
+        yield AgentEvent(type="message", content="swallows")
+        yield AgentEvent(type="done", content="")
+
+
+class _RaisesLaneDown:
+    """A harness whose lane is down before it streams anything."""
+
+    @staticmethod
+    def info() -> BackendInfo:
+        return _info("lane_down")
+
+    def __init__(self, settings=None):  # noqa: ARG002
+        pass
+
+    async def run(self, message: str, **kwargs: Any):  # noqa: ARG002
+        raise RuntimeError("anthropic.APIStatusError: 529 {'type': 'overloaded_error'}")
+        yield  # pragma: no cover — makes this an async generator
+
+
+def _register(monkeypatch, name: str, cls_name: str) -> None:
+    from pocketpaw.agents import registry
+
+    monkeypatch.setitem(
+        registry._BACKEND_REGISTRY, name, ("tests.test_channel_prompt_digest", cls_name)
+    )
+
+
+def _reset() -> None:
+    _Declares.seen = {}
+    _SwallowsKwargs.seen = {}
+    _NarrowSignature.ran = False
+
+
+# ---------------------------------------------------------------------------
+# 1 — the builder stopped discarding what it computed
+# ---------------------------------------------------------------------------
+
+
+async def test_the_channel_builder_hands_back_the_digest_it_used_to_drop():
+    """`assemble_system_prompt` returns both halves; `build_system_prompt` is `.text`.
+
+    The second assertion is the byte guarantee in its smallest form: the two
+    methods share ONE body, so the text a caller reads cannot drift from the text
+    the digest was computed over. (The bytes themselves are pinned against six
+    committed golden files in `test_channel_prompt_goldens.py`, which still call
+    `build_system_prompt` and were not edited for PA-7b — that is the point of
+    keeping its return type.)
+
+    THE MUTATION THAT BREAKS THIS: return `AssembledPrompt(text=..., stable_digest="")`
+    from `AgentContextBuilder.assemble_system_prompt`. Run: the digest assertion
+    failed while the text assertion still passed, which is exactly the state
+    PA-7a left the code in and why an "it still works" test would not have
+    noticed it.
+    """
+    from pocketpaw.bootstrap.context_builder import AgentContextBuilder
+
+    memory = MagicMock()
+    memory.get_context_for_agent = AsyncMock(return_value="")
+    memory.get_semantic_context = AsyncMock(return_value="")
+    builder = AgentContextBuilder(memory_manager=memory)
+
+    assembled = await builder.assemble_system_prompt(include_memory=False, channel=Channel.TELEGRAM)
+    text = await builder.build_system_prompt(include_memory=False, channel=Channel.TELEGRAM)
+
+    assert assembled.stable_digest, "the assembler computed a digest and it was dropped again"
+    assert assembled.text == text, "the delegate and the assembler disagree about the bytes"
+
+
+# ---------------------------------------------------------------------------
+# 2 — AgentRouter, which is where the channel path meets a backend
+# ---------------------------------------------------------------------------
+
+
+async def test_a_backend_that_declares_the_digest_receives_it(monkeypatch):
+    """The primary path: the whole point of the task.
+
+    THE MUTATION THAT BREAKS THIS: in `AgentRouter.run`, call
+    `self._backend.run(message, **base_kwargs)` instead of wrapping in
+    `forward_prompt_digest`. Run: the backend recorded "" and the assertion
+    failed.
+    """
+    _reset()
+    _register(monkeypatch, "declares", "_Declares")
+    router = AgentRouter(Settings(agent_backend="declares"))
+
+    async for _ in router.run("hi", system_prompt="P", system_prompt_digest=_DIGEST):
+        pass
+
+    assert _Declares.seen["digest"] == _DIGEST
+
+
+async def test_a_backend_that_never_declared_the_parameter_still_runs(monkeypatch):
+    """The out-of-tree contract: a narrower signature keeps working untouched.
+
+    This is the assertion that decides the whole shape of the change. Sending the
+    digest on the basis of anything other than the signature — a class list, a
+    "everyone has it by now" assumption — turns a working third-party backend
+    into a TypeError on its first turn.
+
+    THE MUTATION THAT BREAKS THIS: set `base_kwargs["system_prompt_digest"] =
+    system_prompt_digest` unconditionally in `AgentRouter.run`. Run: TypeError,
+    `_NarrowSignature.run() got an unexpected keyword argument`.
+    """
+    _reset()
+    _register(monkeypatch, "narrow", "_NarrowSignature")
+    router = AgentRouter(Settings(agent_backend="narrow"))
+
+    events = [e async for e in router.run("hi", system_prompt="P", system_prompt_digest=_DIGEST)]
+
+    assert _NarrowSignature.ran
+    assert [e.content for e in events if e.type == "message"] == ["narrow"]
+    assert not any(e.type == "error" for e in events)
+
+
+async def test_a_backend_that_only_swallows_kwargs_is_not_counted_as_ported(monkeypatch):
+    """`**kwargs` is not a declaration, at the router as at the pool.
+
+    A backend that accepts the digest into `**kwargs` and never uses it would
+    take delivery of every turn's digest and key on nothing — permanently, and
+    invisibly, because nothing raises. The guard refuses it, so such a backend
+    keeps its old text-hash behaviour instead of a silent no-op.
+
+    THE MUTATION THAT BREAKS THIS: make `_accepts_prompt_digest_kwarg` return
+    True when the signature has a VAR_KEYWORD parameter. Run: the swallowing
+    backend recorded the digest and the assertion failed.
+    """
+    _reset()
+    _register(monkeypatch, "swallows", "_SwallowsKwargs")
+    router = AgentRouter(Settings(agent_backend="swallows"))
+
+    async for _ in router.run("hi", system_prompt="P", system_prompt_digest=_DIGEST):
+        pass
+
+    assert "system_prompt_digest" not in _SwallowsKwargs.seen
+    assert _SwallowsKwargs.seen["system_prompt"] == "P", "the other kwargs must still arrive"
+
+
+async def test_the_generic_fallback_backend_gets_the_digest_too(monkeypatch):
+    """`AgentRouter.run` has TWO dispatch points and the second is easy to miss.
+
+    The fallback loop runs when the primary already failed, so a digest dropped
+    here downgrades the warm-client key to a text hash exactly when the user is
+    already having a bad turn — and it never shows up in a normal test run,
+    because the fallback is not normally reached.
+
+    THE MUTATION THAT BREAKS THIS: restore the fallback loop's explicit
+    `system_prompt=` / `history=` / `session_key=` call. Run: the fallback
+    backend recorded "".
+    """
+    _reset()
+    _register(monkeypatch, "lane_down", "_RaisesLaneDown")
+    _register(monkeypatch, "declares", "_Declares")
+    router = AgentRouter(
+        Settings(agent_backend="lane_down", fallback_backends=["declares"]),
+    )
+
+    events = [e async for e in router.run("hi", system_prompt="P", system_prompt_digest=_DIGEST)]
+
+    assert [e.content for e in events if e.type == "message"] == ["declares"]
+    assert _Declares.seen["digest"] == _DIGEST
+
+
+# ---------------------------------------------------------------------------
+# 3 — the failover chain, the other path that only runs when things are wrong
+# ---------------------------------------------------------------------------
+
+
+async def test_the_failover_chain_carries_the_digest_to_the_harness_that_takes_it(monkeypatch):
+    """L2 harness failover: the switched-to harness must key like the first would.
+
+    THE MUTATION THAT BREAKS THIS: drop `system_prompt_digest=system_prompt_digest`
+    from `run_with_failover`'s `runner.run(...)` call. Run: the recovering harness
+    recorded "".
+    """
+    _reset()
+    _register(monkeypatch, "lane_down", "_RaisesLaneDown")
+    _register(monkeypatch, "declares", "_Declares")
+    monkeypatch.setattr(
+        "pocketpaw.agents.failover.BackendFailoverRunner._audit_switch",
+        lambda self, **kw: None,
+    )
+    router = AgentRouter(
+        Settings(
+            agent_backend="lane_down",
+            backend_failover_chain=["lane_down", "declares"],
+            backend_failover_enabled=True,
+        )
+    )
+
+    events = [
+        e
+        async for e in router.run_with_failover(
+            "hi", system_prompt="P", system_prompt_digest=_DIGEST
+        )
+    ]
+
+    assert [e.content for e in events if e.type == "message"] == ["declares"]
+    assert _Declares.seen["digest"] == _DIGEST
+
+
+async def test_a_narrow_harness_in_the_chain_does_not_crash_the_switch(monkeypatch):
+    """The runner forwards `run_kwargs` verbatim, and that is why it needs a filter.
+
+    The shipped chain is claude_agent_sdk -> codex_cli -> opencode, and only the
+    first declares the digest. Forwarding verbatim turns a survivable lane-down
+    into a TypeError on the harness that was supposed to rescue the turn.
+
+    THE MUTATION THAT BREAKS THIS: delete the `attempt_kwargs` filter in
+    `BackendFailoverRunner.run` and pass `**run_kwargs`. Run: TypeError out of
+    `_NarrowSignature.run`, the recovery event never arrived, and the runner
+    surfaced the crash as the turn's error.
+    """
+    _reset()
+    _register(monkeypatch, "lane_down", "_RaisesLaneDown")
+    _register(monkeypatch, "narrow", "_NarrowSignature")
+    monkeypatch.setattr(
+        "pocketpaw.agents.failover.BackendFailoverRunner._audit_switch",
+        lambda self, **kw: None,
+    )
+    router = AgentRouter(
+        Settings(
+            agent_backend="lane_down",
+            backend_failover_chain=["lane_down", "narrow"],
+            backend_failover_enabled=True,
+        )
+    )
+
+    events = [
+        e
+        async for e in router.run_with_failover(
+            "hi", system_prompt="P", system_prompt_digest=_DIGEST
+        )
+    ]
+
+    assert _NarrowSignature.ran, "the second harness never got to run"
+    assert [e.content for e in events if e.type == "message"] == ["narrow"]
+
+
+async def test_the_disabled_failover_flag_still_delivers_the_digest(monkeypatch):
+    """The default configuration, which is the one almost every install runs.
+
+    `backend_failover_enabled` is False by default, so `run_with_failover`
+    delegates to `run`. A digest threaded only into the enabled branch would
+    reach nobody in production.
+
+    THE MUTATION THAT BREAKS THIS: drop `system_prompt_digest=system_prompt_digest`
+    from the delegating `self.run(...)` call in `run_with_failover`. Run: the
+    backend recorded "".
+    """
+    _reset()
+    _register(monkeypatch, "declares", "_Declares")
+    router = AgentRouter(Settings(agent_backend="declares", backend_failover_enabled=False))
+
+    async for _ in router.run_with_failover("hi", system_prompt="P", system_prompt_digest=_DIGEST):
+        pass
+
+    assert _Declares.seen["digest"] == _DIGEST
+
+
+# ---------------------------------------------------------------------------
+# 4 — what the digest does NOT cover, which is the design and not a gap
+# ---------------------------------------------------------------------------
+
+
+@patch("pocketpaw.agents.loop.get_message_bus")
+@patch("pocketpaw.agents.loop.get_memory_manager")
+@patch("pocketpaw.agents.loop.AgentContextBuilder")
+@patch("pocketpaw.agents.loop.AgentRouter")
+async def test_identity_reinforcement_moves_the_text_and_never_the_digest(
+    mock_router_cls,
+    mock_builder_cls,
+    mock_get_memory,
+    mock_get_bus,
+):
+    """Two turns differing ONLY by identity reinforcement must key identically.
+
+    `AgentLoop` appends the whole identity block again every fifth message. It is
+    a per-turn mutation of content the prompt ALREADY contains, so a digest that
+    moved for it would tear down and respawn the warm CLI subprocess every fifth
+    message in every long conversation, for no change in what the agent is. This
+    is the same decision `claude_sdk`'s volatile markers and the `retrieval`
+    layer's `cache_key=None` already encode, arriving from a third direction.
+
+    The test asserts the TEXT moved first. Without that it would pass against a
+    digest computed from nothing at all, which is the failure a "the digests
+    matched" assertion cannot tell apart from a win.
+
+    (The backend's own `# Recent Conversation` splice is the same class of
+    mutation and is outside the digest for the same reason. It is not re-tested
+    here: it happens inside `ClaudeSDKBackend.run`, downstream of everything this
+    file can observe, and `_client_cache_key`'s `d:` branch never reads
+    `options.system_prompt` at all.)
+
+    THE MUTATION THAT BREAKS THIS: in `AgentLoop._process_message_inner`, pass
+    `system_prompt_digest=hashlib.sha256(system_prompt.encode()).hexdigest()[:16]`
+    — i.e. re-derive the digest from the reinforced text instead of forwarding
+    `assembled_prompt.stable_digest`. Run: the two turns produced different
+    digests and the equality assertion failed.
+    """
+    from pocketpaw.agents.loop import AgentLoop
+    from pocketpaw.bootstrap.protocol import BootstrapContext
+
+    bus = MagicMock()
+    bus.consume_inbound = AsyncMock()
+    bus.publish_outbound = AsyncMock()
+    bus.publish_system = AsyncMock()
+    mock_get_bus.return_value = bus
+
+    memory = MagicMock()
+    memory.add_to_session = AsyncMock()
+    memory.get_compacted_history = AsyncMock(return_value=[])
+    memory.resolve_session_key = AsyncMock(side_effect=lambda k: k)
+    mock_get_memory.return_value = memory
+
+    turns: list[tuple[str, str]] = []
+
+    async def capturing_run(
+        message, *, system_prompt=None, history=None, session_key=None, system_prompt_digest=""
+    ):
+        turns.append((system_prompt, system_prompt_digest))
+        yield AgentEvent(type="done", content="")
+
+    router = MagicMock()
+    router.run = capturing_run
+    router.stop = AsyncMock()
+    mock_router_cls.return_value = router
+
+    bootstrap = MagicMock()
+    bootstrap.get_context = AsyncMock(
+        return_value=BootstrapContext(
+            name="TestAgent",
+            identity="You are a test agent",
+            soul="Test soul",
+            style="Test style",
+            user_profile="Test profile",
+        )
+    )
+    builder = mock_builder_cls.return_value
+    builder.bootstrap = bootstrap
+    builder.assemble_system_prompt = AsyncMock(
+        return_value=AssembledPrompt(
+            text="<identity>You are PocketPaw</identity>", stable_digest=_DIGEST
+        )
+    )
+
+    with patch("pocketpaw.agents.loop.get_settings") as get_settings:
+        settings = MagicMock()
+        settings.agent_backend = "claude_agent_sdk"
+        settings.max_concurrent_conversations = 5
+        get_settings.return_value = settings
+        with patch("pocketpaw.agents.loop.Settings") as settings_cls:
+            settings_cls.load.return_value = settings
+            loop = AgentLoop()
+
+            for count in (4, 5):  # 5 is the reinforcement boundary; 4 is not
+                memory._store.get_session = AsyncMock(
+                    return_value=[MagicMock(role="user", content=f"m{i}") for i in range(count)]
+                )
+                await loop._process_message(
+                    InboundMessage(
+                        channel=Channel.CLI,
+                        sender_id="user1",
+                        chat_id="chat1",
+                        content="keep going",
+                    )
+                )
+
+    assert len(turns) == 2, "both turns must have reached the router"
+    plain_text, plain_digest = turns[0]
+    reinforced_text, reinforced_digest = turns[1]
+
+    assert reinforced_text != plain_text, (
+        "the fixture no longer reinforces on the 5th message — this test proves nothing"
+    )
+    assert reinforced_text.count("<identity>") > plain_text.count("<identity>")
+    assert plain_digest == _DIGEST == reinforced_digest, (
+        "identity reinforcement moved the digest — every 5th message now respawns the CLI"
+    )

--- a/tests/test_channel_prompt_goldens.py
+++ b/tests/test_channel_prompt_goldens.py
@@ -1,0 +1,374 @@
+# tests/test_channel_prompt_goldens.py
+# Created: 2026-08-03 (PA-7a, feat/prompt-assembler-channel) — the safety net
+# for moving the CHANNEL path (Telegram / Discord / Slack / CLI) off
+# ``AgentContextBuilder._assemble_with_budget`` and onto
+# ``pocketpaw.prompt.assemble``.
+#
+# WHY BYTES AND NOT BEHAVIOUR. PA-7a's whole acceptance is that a channel turn
+# assembles the SAME prompt after the cutover as before it. A behavioural test
+# ("the skills block is present") passes just as happily when a block moved from
+# position 7 to position 11, or lost its leading newline, or picked up a second
+# ``\n\n`` because an empty block stopped being skipped. Every one of those
+# changes the prompt the model reads and every one of them is invisible to an
+# ``in`` assertion. So these tests pin the exact bytes, for a fixed input, on
+# five channel shapes, and they are committed BEFORE a line of the cutover is
+# written.
+#
+# WHAT IS STUBBED AND WHY. Everything the builder reaches for that is not the
+# assembly under test: the bootstrap provider, the memory manager, the kb
+# subprocess, the health engine, the skill loader, the atlas store, the
+# AGENTS.md loader, and the MCP config that gates the GWS block. They are
+# stubbed AT THE RESOURCE, not at the builder's own private helpers, because
+# the cutover moves several of those helpers into layer modules — a stub aimed
+# at ``AgentContextBuilder._build_atlas_primer`` would have to move with it, and
+# a golden that needs editing to survive a refactor is not a golden. The two
+# real files the builder reads (``bootstrap/discord.md``, ``bootstrap/gws.md``)
+# are deliberately NOT stubbed: their contents are part of the shipped prompt,
+# and the goldens are the thing that notices if the cutover stops finding them.
+#
+# REGENERATING. Set ``PAW_WRITE_CHANNEL_GOLDENS=1`` and run this file; every
+# golden is rewritten from the current implementation. That is a loud, explicit,
+# opt-in action on purpose. A regenerated golden must land in its OWN commit
+# with the reason in the message — "the test failed" is not a reason.
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pocketpaw.bootstrap.context_builder import AgentContextBuilder
+from pocketpaw.bootstrap.protocol import BootstrapContext
+from pocketpaw.bus.events import Channel
+
+pytestmark = pytest.mark.asyncio
+
+_GOLDEN_DIR = Path(__file__).parent / "data" / "channel_prompt_goldens"
+_WRITE_GOLDENS = os.environ.get("PAW_WRITE_CHANNEL_GOLDENS") == "1"
+
+
+# ---------------------------------------------------------------------------
+# The fixed world every golden renders against
+# ---------------------------------------------------------------------------
+
+
+class _StubBootstrap:
+    """A bootstrap provider with no I/O and no clock in it."""
+
+    async def get_context(self) -> BootstrapContext:
+        return BootstrapContext(
+            name="Goldie",
+            identity="You are Goldie, a fixture.",
+            soul="Determinism above all.",
+            style="Terse.",
+            instructions="Use the tools you are given.",
+            knowledge=["The sky is up.", "kb-go is a subprocess."],
+            user_profile="Prefers short answers.",
+        )
+
+
+class _StubSkill:
+    def __init__(self, name: str, description: str, user_invocable: bool) -> None:
+        self.name = name
+        self.description = description
+        self.user_invocable = user_invocable
+
+
+class _StubSkillLoader:
+    paths = (Path("/fixture/skills"), Path("/fixture/more-skills"))
+
+    def get_all(self) -> dict[str, _StubSkill]:
+        return {
+            "commit": _StubSkill("commit", "Stage and commit work.", True),
+            "humanize": _StubSkill("humanize", "Strip AI tells from prose.", False),
+        }
+
+
+class _StubHealthEngine:
+    def get_health_prompt_section(self) -> str:
+        return "\n# System Health\nStatus: degraded (memory backend slow)."
+
+
+class _StubAgentsMd:
+    constraints_block = "\n# Project Constraints (AGENTS.md)\n- Never push to main.\n- Use uv."
+
+
+class _StubAgentsMdLoader:
+    def find_and_load(self, directory: str):  # noqa: ANN201 - test stub
+        return _StubAgentsMd()
+
+
+class _StubAtlasEntry:
+    def __init__(self, name: str, gist: str) -> None:
+        self.name = name
+        self.kind = "primitive"
+        self.gist = gist
+        self.summary = gist
+
+
+class _StubAtlasStore:
+    entries = (
+        _StubAtlasEntry("Pocket", "a workspace app you build and share"),
+        _StubAtlasEntry("Site", "a published page rendered to the edge"),
+        _StubAtlasEntry("Soul", "portable identity with 5-tier memory"),
+    )
+
+
+class _StubMcpConfig:
+    def __init__(self, name: str, enabled: bool) -> None:
+        self.name = name
+        self.enabled = enabled
+
+
+@pytest.fixture(autouse=True)
+def _stub_world(monkeypatch):
+    """Pin every input the builder reaches for outside the assembly itself.
+
+    Stubs land on the RESOURCE (``pocketpaw.atlas.store.get_atlas_store``,
+    ``pocketpaw.skills.get_skill_loader``, ...) rather than on the builder's
+    private helpers, so the cutover can move a helper into a layer module
+    without touching a single line of this file.
+    """
+    settings = MagicMock()
+    settings.owner_id = "owner-9"
+    settings.kb_scopes = []
+    settings.kb_binary = "kb"
+    settings.kb_limit = 3
+    monkeypatch.setattr("pocketpaw.config.get_settings", lambda: settings)
+
+    async def _fake_kb(*args, **kwargs) -> str:
+        return "### From workspace:w1\n- routing.md\n  How the bus routes inbound messages."
+
+    monkeypatch.setattr(AgentContextBuilder, "_get_kb_context", staticmethod(_fake_kb))
+    monkeypatch.setattr("pocketpaw.health.get_health_engine", lambda: _StubHealthEngine())
+    monkeypatch.setattr("pocketpaw.skills.get_skill_loader", lambda: _StubSkillLoader())
+    monkeypatch.setattr("pocketpaw.atlas.store.get_atlas_store", lambda: _StubAtlasStore())
+    monkeypatch.setattr("pocketpaw.agents_md.AgentsMdLoader", _StubAgentsMdLoader)
+    monkeypatch.setattr(
+        "pocketpaw.mcp.config.load_mcp_config",
+        lambda: [_StubMcpConfig("google-workspace", True)],
+    )
+    return settings
+
+
+def _builder() -> AgentContextBuilder:
+    memory = MagicMock()
+    memory.get_semantic_context = AsyncMock(return_value="The user ships on Fridays.")
+    memory.get_context_for_agent = AsyncMock(return_value="The user ships on Fridays.")
+    return AgentContextBuilder(bootstrap_provider=_StubBootstrap(), memory_manager=memory)
+
+
+_METADATA = {
+    "username": "dizzy",
+    "guild_id": "guild-77",
+    "pocket_system_context": "\n# Pocket Creation\nBuild a pocket, not a website.",
+    "pocket_context": {
+        "id": "pk-123",
+        "name": "Launch Tracker",
+        "widgets": [{"name": "Burndown", "type": "chart"}],
+    },
+}
+
+_FILE_CONTEXT = {
+    "current_dir": "/work/pocketpaw",
+    "open_file": "/work/pocketpaw/src/pocketpaw/bus/loop.py",
+    "selected_files": ["/work/pocketpaw/README.md", "/work/pocketpaw/pyproject.toml"],
+}
+
+
+async def _full_prompt(channel: Channel | None, **overrides) -> str:
+    """The fully-populated call every golden is taken from."""
+    kwargs = {
+        "include_memory": True,
+        "user_query": "how do I publish a site?",
+        "channel": channel,
+        "sender_id": "sender-1",
+        "session_key": "sess-abc",
+        "file_context": _FILE_CONTEXT,
+        "agents_md_dir": "/work/pocketpaw",
+        "metadata": _METADATA,
+    }
+    kwargs.update(overrides)
+    return await _builder().build_system_prompt(**kwargs)
+
+
+def _check_golden(name: str, actual: str) -> None:
+    path = _GOLDEN_DIR / f"{name}.txt"
+    if _WRITE_GOLDENS:
+        _GOLDEN_DIR.mkdir(parents=True, exist_ok=True)
+        path.write_text(actual, encoding="utf-8", newline="")
+        pytest.skip(f"wrote golden {path}")
+    expected = path.read_text(encoding="utf-8")
+    assert actual == expected, (
+        f"channel prompt bytes moved against {path}. If the move is INTENDED, "
+        f"regenerate with PAW_WRITE_CHANNEL_GOLDENS=1 in its own commit and put "
+        f"the reason in the message."
+    )
+
+
+# ---------------------------------------------------------------------------
+# The goldens
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("golden", "channel"),
+    [
+        ("telegram", Channel.TELEGRAM),
+        ("discord", Channel.DISCORD),
+        ("slack", Channel.SLACK),
+        ("cli", Channel.CLI),
+        ("no_channel", None),
+    ],
+)
+async def test_the_assembled_channel_prompt_is_byte_identical(golden, channel):
+    """The exact bytes ``build_system_prompt`` emits for a fixed, full input.
+
+    MUTATION: change ``_JOIN`` in ``prompt/assembler.py`` from ``"\\n\\n"`` to
+    ``"\\n"``, or reorder any entry of the channel layer list, or drop the
+    ``.strip()``-empty skip. Each moves at least one of these five files.
+    """
+    _check_golden(golden, await _full_prompt(channel))
+
+
+async def test_the_full_input_actually_exercises_every_block():
+    """A golden is only a safety net over the blocks it contains.
+
+    Fifteen blocks are appended by ``build_system_prompt``; this pins that the
+    fixture reaches all fifteen, so a cutover that silently stops emitting one
+    cannot hide behind an input that never produced it.
+
+    MUTATION: delete any ``blocks.append(...)`` in ``build_system_prompt`` (or,
+    after the cutover, remove its layer from the channel layer list). One of
+    these markers goes missing.
+    """
+    prompt = await _full_prompt(Channel.DISCORD)
+    markers = {
+        "identity": "<identity>",
+        "memory_context": "# Memory Context (already loaded",
+        "kb_context": "# Knowledge Base (relevant articles",
+        "sender_block": "You are speaking with sender_id=sender-1",
+        "channel_hints": "# Response Format",
+        # Both file-backed blocks are capped BELOW the file's length, so the
+        # marker has to live in the surviving head — the tail (discord.md's
+        # appended "## Current Context", gws.md's own name) is cut away.
+        "channel_instructions": "# Discord Behavior Layer",
+        "pocket_context": "# Pocket Creation",
+        "current_pocket": "<current-pocket>",
+        "session_key": "# Session Management",
+        "file_context": "# File Context",
+        "health_state": "# System Health",
+        "skills_list": "# Available Skills",
+        "atlas_primer": "# Paw OS Primer",
+        "agents_md": "# Project Constraints (AGENTS.md)",
+        "gws_instructions": "# Google Workspace CLI",
+    }
+    missing = [name for name, marker in markers.items() if marker not in prompt]
+    assert not missing, f"golden fixture never produced these blocks: {missing}"
+
+
+async def test_a_prompt_with_the_optional_inputs_absent_is_byte_identical():
+    """A block that does not apply must leave NO gap — not a doubled ``\\n\\n``.
+
+    The old assembler skips a block whose content is empty or whitespace-only;
+    the new one skips empty text at the join. Those agree only while every layer
+    renders ``""`` rather than ``"   "`` for "nothing to say", which is exactly
+    what this golden would catch.
+
+    MUTATION: make any layer return whitespace instead of ``""`` when its input
+    is absent, or drop the ``not content.strip()`` guard. This golden grows a
+    separator.
+    """
+    prompt = await _builder().build_system_prompt(
+        include_memory=False,
+        user_query=None,
+        channel=Channel.CLI,
+        sender_id=None,
+        session_key=None,
+        file_context=None,
+        agents_md_dir=None,
+        metadata=None,
+    )
+    _check_golden("minimal", prompt)
+
+
+async def test_a_block_over_its_cap_is_cut_to_the_cap_plus_the_marker():
+    """``memory_context`` is capped at 4000, and the marker pushes it to 4015.
+
+    The 15 extra chars are a shipped quirk of ``_assemble_with_budget``:
+    ``content[:cap] + "\\n[...truncated]"`` overshoots the cap it is enforcing.
+    ``prompt/assembler.py`` reproduces it deliberately. Pinning the EXACT
+    resulting length is what makes this test notice a "fix" of that arithmetic,
+    which would move every over-cap block on every channel turn.
+
+    MUTATION: change ``_INJECTION_CAPS["memory_context"]`` to 3000 (or, after
+    the cutover, the memory layer's ``max_chars``), or drop the ``+ marker``.
+    The length assertion fails.
+    """
+    memory = MagicMock()
+    memory.get_semantic_context = AsyncMock(return_value="M" * 5000)
+    memory.get_context_for_agent = AsyncMock(return_value="M" * 5000)
+    builder = AgentContextBuilder(bootstrap_provider=_StubBootstrap(), memory_manager=memory)
+    prompt = await builder.build_system_prompt(
+        include_memory=True,
+        user_query="how do I publish a site?",
+        channel=Channel.TELEGRAM,
+        sender_id="sender-1",
+    )
+
+    marker = "\n[...truncated]"
+    start = prompt.index("\n# Memory Context (already loaded")
+    block = prompt[start : start + 4000 + len(marker)]
+    assert block.endswith(marker)
+    assert len(block) == 4015
+    # And the block really does end there — what follows is the join, not more
+    # of the memory text.
+    assert prompt[start + 4015 : start + 4017] == "\n\n"
+
+
+async def test_a_tight_budget_drops_the_low_and_medium_blocks():
+    """A budget that fits CRITICAL + nothing else drops everything droppable.
+
+    The budget is sized so the CRITICAL identity block fits WHOLE, deliberately:
+    a budget that cuts CRITICAL is the one place PA-7a changes behaviour on
+    purpose (see ``test_a_critical_block_over_budget_is_truncated_today``), and
+    a golden must not straddle an intended divergence.
+
+    MUTATION: make ``_assemble_with_budget`` ignore ``budget_chars``, or sort
+    LOW before MEDIUM. The dropped blocks reappear.
+    """
+    identity_len = len((await _StubBootstrap().get_context()).to_system_prompt())
+    prompt = await _full_prompt(Channel.TELEGRAM, budget_chars=identity_len + 20)
+
+    assert "<identity>" in prompt
+    for marker in (
+        "# Memory Context (already loaded",  # HIGH
+        "# Session Management",  # MEDIUM
+        "# Available Skills",  # MEDIUM
+        "# Paw OS Primer",  # MEDIUM
+        "# Response Format",  # LOW
+        "# System Health",  # LOW
+    ):
+        assert marker not in prompt, f"{marker!r} survived a budget that cannot hold it"
+
+
+async def test_a_critical_block_over_budget_is_truncated_today():
+    """TODAY a CRITICAL block over budget is CUT TO ``remaining``.
+
+    This pins the CURRENT behaviour so the cutover's one intended divergence is
+    visible as a deliberate edit to this file rather than as a silent drift.
+    PA-7a replaces it with the opposite assertion — a CRITICAL layer is emitted
+    WHOLE and the budget overruns — in its own commit, because a budget-sized
+    cut is the one cut that breaks a cache key (``Priority``'s docstring).
+
+    MUTATION: remove the ``if priority == _Priority.CRITICAL`` branch from
+    ``_assemble_with_budget``. The identity block vanishes entirely and the
+    length assertion fails.
+    """
+    identity = (await _StubBootstrap().get_context()).to_system_prompt()
+    prompt = await _full_prompt(Channel.CLI, budget_chars=len(identity) - 100)
+
+    assert prompt == identity[: len(identity) - 100]
+    assert len(prompt) == len(identity) - 100

--- a/tests/test_channel_prompt_goldens.py
+++ b/tests/test_channel_prompt_goldens.py
@@ -42,7 +42,7 @@
 from __future__ import annotations
 
 import os
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -85,7 +85,13 @@ class _StubSkill:
 
 
 class _StubSkillLoader:
-    paths = (Path("/fixture/skills"), Path("/fixture/more-skills"))
+    # ``PurePosixPath``, NOT ``Path``. The skills block renders
+    # ``", ".join(str(p) for p in loader.paths)``, and ``str(Path("/fixture/skills"))``
+    # is ``\fixture\skills`` on Windows and ``/fixture/skills`` on Linux — so a
+    # golden generated on one OS cannot pass on the other. CI caught it; a
+    # Windows-only run never can. ``PurePosixPath`` still exercises the ``str(p)``
+    # conversion the production code does, and renders the same bytes everywhere.
+    paths = (PurePosixPath("/fixture/skills"), PurePosixPath("/fixture/more-skills"))
 
     def get_all(self) -> dict[str, _StubSkill]:
         return {

--- a/tests/test_channel_prompt_goldens.py
+++ b/tests/test_channel_prompt_goldens.py
@@ -26,6 +26,14 @@
 # are deliberately NOT stubbed: their contents are part of the shipped prompt,
 # and the goldens are the thing that notices if the cutover stops finding them.
 #
+# Updated: 2026-08-03 (PA-7a, after the cutover) — all six golden files are
+# byte-identical through the move to ``pocketpaw.prompt.assemble``; not one was
+# regenerated. Exactly one assertion in this file changed:
+# ``test_a_critical_block_over_budget_is_truncated_today`` became
+# ``test_a_critical_block_over_budget_is_emitted_whole``, which is PA-7a's one
+# intended divergence and is argued at length in
+# ``tests/test_channel_prompt_layers.py``.
+#
 # REGENERATING. Set ``PAW_WRITE_CHANNEL_GOLDENS=1`` and run this file; every
 # golden is rewritten from the current implementation. That is a loud, explicit,
 # opt-in action on purpose. A regenerated golden must land in its OWN commit
@@ -354,21 +362,29 @@ async def test_a_tight_budget_drops_the_low_and_medium_blocks():
         assert marker not in prompt, f"{marker!r} survived a budget that cannot hold it"
 
 
-async def test_a_critical_block_over_budget_is_truncated_today():
-    """TODAY a CRITICAL block over budget is CUT TO ``remaining``.
+async def test_a_critical_block_over_budget_is_emitted_whole():
+    """PA-7a's ONE intended behaviour change, in the file that pinned the old one.
 
-    This pins the CURRENT behaviour so the cutover's one intended divergence is
-    visible as a deliberate edit to this file rather than as a silent drift.
-    PA-7a replaces it with the opposite assertion — a CRITICAL layer is emitted
-    WHOLE and the budget overruns — in its own commit, because a budget-sized
-    cut is the one cut that breaks a cache key (``Priority``'s docstring).
+    This test used to read ``test_a_critical_block_over_budget_is_truncated_today``
+    and assert ``prompt == identity[:budget]`` — ``_assemble_with_budget`` cut a
+    CRITICAL block to ``remaining``. It was written that way deliberately, before
+    the cutover, so this change had to be made by editing an assertion rather
+    than by drifting past one.
 
-    MUTATION: remove the ``if priority == _Priority.CRITICAL`` branch from
-    ``_assemble_with_budget``. The identity block vanishes entirely and the
-    length assertion fails.
+    The reasoning is in
+    ``tests/test_channel_prompt_layers.py::test_a_critical_block_over_budget_is_emitted_whole_not_cut_to_fit``
+    — in one line, a cut sized from ``remaining`` depends on what the block's
+    siblings rendered, so one cache key would name two different prompts. What
+    is asserted HERE is the consequence for a real channel turn: the prompt can
+    now exceed ``budget_chars``, and by exactly the identity block.
+
+    No golden FILE moved for this. All six are byte-identical across the
+    cutover; this is the only assertion in the suite that changed.
+
+    MUTATION: restore the truncation in ``_fit_to_budget``. Fails.
     """
     identity = (await _StubBootstrap().get_context()).to_system_prompt()
     prompt = await _full_prompt(Channel.CLI, budget_chars=len(identity) - 100)
 
-    assert prompt == identity[: len(identity) - 100]
-    assert len(prompt) == len(identity) - 100
+    assert prompt == identity
+    assert len(prompt) > len(identity) - 100

--- a/tests/test_channel_prompt_layers.py
+++ b/tests/test_channel_prompt_layers.py
@@ -250,9 +250,7 @@ class _StubBootstrap:
         ("channel.health_state", "pocketpaw.health.get_health_engine"),
     ],
 )
-async def test_a_raising_environment_layer_does_not_fail_the_turn(
-    monkeypatch, layer_name, target
-):
+async def test_a_raising_environment_layer_does_not_fail_the_turn(monkeypatch, layer_name, target):
     """Each of the five ex-``try/except`` blocks, made to raise for real.
 
     ``build_system_prompt`` used to wrap these five itself. It does not any
@@ -323,9 +321,7 @@ async def test_the_guard_records_the_failure_rather_than_swallowing_it():
         system_message_override=None,
         channel_inputs=ChannelInputs(identity="persona"),
     )
-    assembled = await assemble(
-        [prompt_layer_registry.get("channel.identity"), _Boom()], ctx
-    )
+    assembled = await assemble([prompt_layer_registry.get("channel.identity"), _Boom()], ctx)
     assert assembled.text == "persona"
     assert [(d.name, d.reason) for d in assembled.dropped] == [
         ("channel.health_state", "render raised RuntimeError")

--- a/tests/test_channel_prompt_layers.py
+++ b/tests/test_channel_prompt_layers.py
@@ -259,11 +259,18 @@ async def test_a_raising_environment_layer_does_not_fail_the_turn(
     more; ``assemble``'s render guard is the whole of the protection, and this
     drives a genuine exception through each resource to check that the guard
     actually reaches it rather than assuming a ``try`` somewhere covers it. The
-    turn must still produce a prompt, the failure must be RECORDED, and the
-    other layers must be unaffected.
+    turn must still produce a prompt, and the layers after it must be
+    unaffected.
+
+    ``agents_md_dir`` is set for ALL five parametrisations, not just the
+    AGENTS.md one, and that is not tidiness. The first draft left it unset; the
+    narrowed-guard mutation below is what caught it, because the agents_md layer
+    returns early on a missing directory, so that case never reached
+    ``AgentsMdLoader`` and passed the mutation while the other four failed. A
+    parametrisation that cannot reach the resource it names tests nothing.
 
     MUTATION: narrow ``assemble``'s ``except Exception`` to
-    ``except ValueError``. Every parametrisation fails.
+    ``except ValueError``. All five parametrisations fail.
     """
 
     def _boom(*args, **kwargs):
@@ -279,7 +286,9 @@ async def test_a_raising_environment_layer_does_not_fail_the_turn(
     memory.get_context_for_agent = AsyncMock(return_value="")
     builder = AgentContextBuilder(bootstrap_provider=_StubBootstrap(), memory_manager=memory)
 
-    prompt = await builder.build_system_prompt(include_memory=False, session_key="s-1")
+    prompt = await builder.build_system_prompt(
+        include_memory=False, session_key="s-1", agents_md_dir="/does/not/matter"
+    )
     assert "the persona" in prompt  # the turn survived
     assert "# Session Management" in prompt  # and so did the layers after it
 

--- a/tests/test_channel_prompt_layers.py
+++ b/tests/test_channel_prompt_layers.py
@@ -1,0 +1,410 @@
+# tests/test_channel_prompt_layers.py
+# Created: 2026-08-03 (PA-7a, feat/prompt-assembler-channel) — the properties
+# the goldens cannot see.
+#
+# tests/test_channel_prompt_goldens.py pins the BYTES, which is the acceptance
+# criterion, but bytes only prove today's inputs produce today's output. Four
+# things about the cutover would survive a byte-identical prompt and break
+# later, and each gets a test here:
+#
+#   1. THE EMISSION ORDER IS A DERIVED FACT, not a list someone typed. The old
+#      assembler sorted blocks by priority; the new one emits in list order and
+#      never sorts. So the list must BE the old sort. Asserting the fifteen
+#      names would pass just as happily if someone later changed a priority and
+#      "fixed" the list to match — the rule would be gone and the test still
+#      green. So the sort is re-derived from the append order and the layers'
+#      own priorities.
+#   2. THE THREE I/O FETCHES STILL RUN CONCURRENTLY. Moving bootstrap, memory
+#      and kb into self-fetching layers would serialize them (``assemble``
+#      renders in a for-loop) and add their SUM to every channel turn where the
+#      gather adds their MAX — with a subprocess in the middle. A byte-identical
+#      prompt is exactly what that regression produces.
+#   3. ONE LAYER RAISING DOES NOT FAIL THE TURN. Five blocks had their own
+#      ``try/except`` and now rely on the assembler's render guard. "The guard
+#      exists" is not the claim; "the guard covers these five" is, so each of
+#      the five is made to raise for real.
+#   4. THE TWO .md FILES ARE STILL FOUND. They ship beside ``bootstrap/`` and
+#      are now read from a module two directories away.
+#
+# Every test names the mutation that must break it. Each was applied and re-run
+# on 2026-08-03; the outcomes are in the commit body.
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pocketpaw.bootstrap.context_builder import AgentContextBuilder
+from pocketpaw.bootstrap.protocol import BootstrapContext
+from pocketpaw.prompt import PromptContext, assemble, prompt_layer_registry
+from pocketpaw.prompt.channel import (
+    CHANNEL_LAYER_TYPES,
+    CHANNEL_PROMPT_LAYERS,
+    ChannelInputs,
+)
+from pocketpaw.prompt.channel import __dict__ as _channel_pkg
+
+pytestmark = pytest.mark.asyncio
+
+_SOURCE_ORDER = _channel_pkg["_CHANNEL_BLOCK_SOURCE_ORDER"]
+
+
+# ---------------------------------------------------------------------------
+# 1. The order
+# ---------------------------------------------------------------------------
+
+
+async def test_the_emission_order_is_the_old_priority_sort():
+    """THE RULE: ``CHANNEL_PROMPT_LAYERS`` == append order, stably sorted by priority.
+
+    ``_assemble_with_budget`` did ``sorted(blocks, key=lambda b: b[1])`` — a
+    stable sort on priority alone, so ties kept the order the builder appended
+    them in — and emitted that. ``assemble`` emits the caller's list order and
+    never reorders. The two agree only while the list IS that sort, and this
+    re-derives it rather than transcribing the answer: change a layer's
+    ``priority`` without moving it in the list and this fails, which is the
+    whole point.
+
+    MUTATION: swap any two adjacent names in ``CHANNEL_PROMPT_LAYERS``, or flip
+    ``ChannelHealthLayer.priority`` from LOW to MEDIUM. Both fail here.
+    """
+    priority_of = {name: prompt_layer_registry.get(name).priority for name in _SOURCE_ORDER}
+    derived = sorted(_SOURCE_ORDER, key=lambda name: priority_of[name])
+    assert list(CHANNEL_PROMPT_LAYERS) == derived
+
+
+async def test_the_sort_is_stable_within_a_priority():
+    """Ties keep their APPEND order, which is what ``sorted`` guarantees.
+
+    Stated separately because it is the half of the rule a reimplementation
+    would lose: a sort that reversed ties, or one keyed on ``(priority, name)``,
+    would still be "sorted by priority" and would reorder five HIGH blocks.
+
+    MUTATION: key the derivation in the test above on ``(priority, name)``.
+    Alphabetical order puts ``current_pocket`` before ``kb_context`` and this
+    fails.
+    """
+    for priority in {prompt_layer_registry.get(n).priority for n in _SOURCE_ORDER}:
+        in_source = [n for n in _SOURCE_ORDER if prompt_layer_registry.get(n).priority == priority]
+        in_emission = [
+            n for n in CHANNEL_PROMPT_LAYERS if prompt_layer_registry.get(n).priority == priority
+        ]
+        assert in_source == in_emission, f"{priority.name} blocks reordered within their tie"
+
+
+async def test_channel_hints_is_appended_fifth_and_emitted_second_to_last():
+    """The one case where append order and emission order visibly disagree.
+
+    Worth pinning by name: it is the block most likely to be "corrected" back to
+    its source position by someone reading ``build_system_prompt``'s history,
+    and doing so reorders every channel prompt while every presence assertion in
+    the suite stays green.
+
+    MUTATION: move ``channel.channel_hints`` to index 4 of
+    ``CHANNEL_PROMPT_LAYERS``. Fails here and moves four golden files.
+    """
+    assert _SOURCE_ORDER.index("channel.channel_hints") == 4
+    assert CHANNEL_PROMPT_LAYERS.index("channel.channel_hints") == len(CHANNEL_PROMPT_LAYERS) - 2
+
+
+async def test_every_channel_layer_is_registered_and_ordered_exactly_once():
+    """No layer defined-but-unregistered, none listed twice, none missing.
+
+    MUTATION: drop ``ChannelGwsLayer`` from ``CHANNEL_LAYER_TYPES``. The
+    registry lookup in ``build_system_prompt`` would raise ``KeyError`` on every
+    channel turn; this fails first.
+    """
+    defined = {layer.name for layer in CHANNEL_LAYER_TYPES}
+    assert defined == set(CHANNEL_PROMPT_LAYERS) == set(_SOURCE_ORDER)
+    assert len(CHANNEL_PROMPT_LAYERS) == len(set(CHANNEL_PROMPT_LAYERS)) == 15
+    for name in CHANNEL_PROMPT_LAYERS:
+        assert prompt_layer_registry.get(name).name == name
+
+
+async def test_the_channel_layers_did_not_displace_a_cloud_layer():
+    """The registry is one flat dict, and ``identity`` was already taken.
+
+    An unprefixed ``identity`` registration would silently REPLACE
+    ``AgentIdentityLayer`` — the cloud path would keep assembling, keep passing
+    its byte tests against layers it resolves by the same names, and serve every
+    cloud agent a persona block that renders only from ``channel_inputs``.
+
+    MUTATION: rename ``ChannelIdentityLayer.name`` to ``"identity"``. This fails,
+    and so does most of tests/test_prompt_*.py.
+    """
+    from pocketpaw.prompt import AgentIdentityLayer, AtlasPrimerLayer, UserInfoLayer
+
+    assert type(prompt_layer_registry.get("identity")) is AgentIdentityLayer
+    assert type(prompt_layer_registry.get("atlas")) is AtlasPrimerLayer
+    assert type(prompt_layer_registry.get("user")) is UserInfoLayer
+    assert all(name.startswith("channel.") for name in CHANNEL_PROMPT_LAYERS)
+
+
+# ---------------------------------------------------------------------------
+# 2. The latency property
+# ---------------------------------------------------------------------------
+
+
+class _GatheredBootstrap:
+    """A bootstrap provider that will not finish until the other two have started."""
+
+    def __init__(self, barrier: asyncio.Barrier) -> None:
+        self._barrier = barrier
+
+    async def get_context(self) -> BootstrapContext:
+        await self._barrier.wait()
+        return BootstrapContext(name="B", identity="i", soul="s", style="st")
+
+
+async def test_the_three_io_fetches_still_run_concurrently(monkeypatch):
+    """bootstrap, memory and kb must be IN FLIGHT AT THE SAME TIME.
+
+    An ``asyncio.Barrier(3)`` is the assertion: each of the three stubs waits
+    for the other two to arrive before it returns. All three in one
+    ``asyncio.gather`` pass it immediately. Any arrangement that awaits them one
+    after another — three self-fetching layers rendered by ``assemble``'s
+    sequential for-loop is the obvious one — deadlocks on the first, and the
+    ``wait_for`` below turns that into a failure rather than a hung suite.
+
+    This is a TIMING-FREE test on purpose. A wall-clock assertion ("under 150ms")
+    is exactly the test that goes flaky on a loaded CI box and gets deleted; a
+    rendezvous either happens or it does not.
+
+    MUTATION: replace the ``asyncio.gather`` in ``build_system_prompt`` with
+    three sequential awaits. Times out and fails. (Applied 2026-08-03.)
+    """
+    barrier = asyncio.Barrier(3)
+
+    async def _memory(*args, **kwargs) -> str:
+        await barrier.wait()
+        return "mem"
+
+    async def _kb(*args, **kwargs) -> str:
+        await barrier.wait()
+        return "kb"
+
+    monkeypatch.setattr(AgentContextBuilder, "_get_kb_context", staticmethod(_kb))
+    memory = MagicMock()
+    memory.get_semantic_context = AsyncMock(side_effect=_memory)
+    memory.get_context_for_agent = AsyncMock(side_effect=_memory)
+    builder = AgentContextBuilder(
+        bootstrap_provider=_GatheredBootstrap(barrier), memory_manager=memory
+    )
+
+    prompt = await asyncio.wait_for(
+        builder.build_system_prompt(include_memory=True, user_query="q"), timeout=5.0
+    )
+    # And the results really did reach the prompt — a rendezvous that returned
+    # nothing would pass the barrier and prove nothing.
+    assert "mem" in prompt
+    assert "kb" in prompt
+
+
+async def test_the_memory_fetch_is_the_semantic_one_when_there_is_a_query(monkeypatch):
+    """Which coroutine goes into the gather is still chosen by ``user_query``.
+
+    The gather stayed in the builder, so this choice stayed with it. Pinned
+    because the layers now render whatever they are handed and would look
+    identical either way.
+
+    MUTATION: always call ``get_context_for_agent``. Fails.
+    """
+
+    async def _kb(*args, **kwargs) -> str:
+        return ""
+
+    monkeypatch.setattr(AgentContextBuilder, "_get_kb_context", staticmethod(_kb))
+    memory = MagicMock()
+    memory.get_semantic_context = AsyncMock(return_value="semantic")
+    memory.get_context_for_agent = AsyncMock(return_value="plain")
+    builder = AgentContextBuilder(bootstrap_provider=_StubBootstrap(), memory_manager=memory)
+
+    with_query = await builder.build_system_prompt(include_memory=True, user_query="q")
+    assert "semantic" in with_query
+    memory.get_context_for_agent.assert_not_called()
+
+    without_query = await builder.build_system_prompt(include_memory=True, user_query=None)
+    assert "plain" in without_query
+
+
+# ---------------------------------------------------------------------------
+# 3. The render guard
+# ---------------------------------------------------------------------------
+
+
+class _StubBootstrap:
+    async def get_context(self) -> BootstrapContext:
+        return BootstrapContext(name="B", identity="the persona", soul="s", style="st")
+
+
+@pytest.mark.parametrize(
+    ("layer_name", "target"),
+    [
+        ("channel.skills_list", "pocketpaw.skills.get_skill_loader"),
+        ("channel.atlas_primer", "pocketpaw.atlas.store.get_atlas_store"),
+        ("channel.agents_md", "pocketpaw.agents_md.AgentsMdLoader"),
+        ("channel.gws_instructions", "pocketpaw.mcp.config.load_mcp_config"),
+        ("channel.health_state", "pocketpaw.health.get_health_engine"),
+    ],
+)
+async def test_a_raising_environment_layer_does_not_fail_the_turn(
+    monkeypatch, layer_name, target
+):
+    """Each of the five ex-``try/except`` blocks, made to raise for real.
+
+    ``build_system_prompt`` used to wrap these five itself. It does not any
+    more; ``assemble``'s render guard is the whole of the protection, and this
+    drives a genuine exception through each resource to check that the guard
+    actually reaches it rather than assuming a ``try`` somewhere covers it. The
+    turn must still produce a prompt, the failure must be RECORDED, and the
+    other layers must be unaffected.
+
+    MUTATION: narrow ``assemble``'s ``except Exception`` to
+    ``except ValueError``. Every parametrisation fails.
+    """
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError(f"{target} is broken")
+
+    monkeypatch.setattr(target, _boom)
+
+    async def _kb(*args, **kwargs) -> str:
+        return ""
+
+    monkeypatch.setattr(AgentContextBuilder, "_get_kb_context", staticmethod(_kb))
+    memory = MagicMock()
+    memory.get_context_for_agent = AsyncMock(return_value="")
+    builder = AgentContextBuilder(bootstrap_provider=_StubBootstrap(), memory_manager=memory)
+
+    prompt = await builder.build_system_prompt(include_memory=False, session_key="s-1")
+    assert "the persona" in prompt  # the turn survived
+    assert "# Session Management" in prompt  # and so did the layers after it
+
+
+async def test_the_guard_records_the_failure_rather_than_swallowing_it():
+    """A failed layer lands in ``dropped`` and keys as a failure.
+
+    This is what the five old handlers did NOT do — four of them were a
+    ``logger.debug`` or a bare ``pass``, which threw away the exception type,
+    the message and the traceback. Invisible in the channel prompt's bytes (the
+    channel path returns only ``text``), which is why it is asserted here rather
+    than left to the goldens.
+
+    MUTATION: delete the ``dropped.append(...)`` from ``assemble``'s except
+    clause. Fails.
+    """
+
+    class _Boom:
+        name = "channel.health_state"
+        priority = prompt_layer_registry.get("channel.health_state").priority
+        max_chars = None
+
+        async def render(self, ctx):
+            raise RuntimeError("engine down")
+
+    ctx = PromptContext(
+        instance=None,
+        agent_id="",
+        message="",
+        instructions="",
+        knowledge_context="",
+        system_message_override=None,
+        channel_inputs=ChannelInputs(identity="persona"),
+    )
+    assembled = await assemble(
+        [prompt_layer_registry.get("channel.identity"), _Boom()], ctx
+    )
+    assert assembled.text == "persona"
+    assert [(d.name, d.reason) for d in assembled.dropped] == [
+        ("channel.health_state", "render raised RuntimeError")
+    ]
+
+
+# ---------------------------------------------------------------------------
+# 4. The files that did not move
+# ---------------------------------------------------------------------------
+
+
+async def test_the_channel_files_resolve_to_the_bootstrap_package():
+    """``discord.md`` and ``gws.md`` still ship beside ``context_builder.py``.
+
+    The loaders moved into ``prompt/channel/`` and used to resolve their path
+    from ``__file__``. They now resolve it from the installed ``pocketpaw``
+    package, because importing ``pocketpaw.bootstrap`` to ask would close an
+    import cycle (bootstrap imports the prompt registry, which imports the
+    channel package). A wrong directory is silent — both loaders return ``""``
+    on a missing file — so it is asserted rather than trusted.
+
+    MUTATION: change ``_bootstrap_dir`` to ``.parent / "bootstrapp"``. Fails
+    here; the goldens fail too, which is the belt to this test's braces.
+    """
+    import pocketpaw.bootstrap.context_builder as ctx_mod
+    from pocketpaw.prompt.channel.request import _bootstrap_dir
+
+    assert _bootstrap_dir() == Path(ctx_mod.__file__).resolve().parent
+    assert (_bootstrap_dir() / "discord.md").exists()
+    assert (_bootstrap_dir() / "gws.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# 5. The intended divergence
+# ---------------------------------------------------------------------------
+
+
+async def test_a_critical_block_over_budget_is_emitted_whole_not_cut_to_fit():
+    """THE ONE BEHAVIOUR PA-7a CHANGED ON PURPOSE.
+
+    BEFORE: ``_assemble_with_budget`` cut a CRITICAL block to ``remaining`` —
+    ``content = content[:remaining]`` — and logged a warning. The identity block
+    arrived at whatever length the budget had left, mid-sentence.
+
+    AFTER: it is emitted WHOLE and the budget overruns, loudly.
+
+    WHY: a cut sized from ``remaining`` is sized from what the block's SIBLINGS
+    rendered. Two turns with the same persona and different memory blocks would
+    carry different amounts of that persona under one cache key, so one key
+    would name two different prompts — which is #1842 arriving through the
+    budget instead of through the backend (``prompt.layer.Priority``'s
+    docstring). A layer that must be bounded takes a constant ``max_chars``,
+    which is a pure function of its own bytes and composes with any key.
+    ``channel.identity`` deliberately does not, because its key under-reports
+    its text when a soul provider makes a claim.
+
+    THE COST, stated plainly: a channel turn whose identity block alone exceeds
+    ``budget_chars`` now returns a prompt LONGER than the budget. Everything
+    else is still dropped, so the overrun is bounded by the identity block. The
+    32,000-char default is far above any measured identity block; PA-9 is the
+    task that gets to size it with numbers.
+
+    This test replaced ``test_a_critical_block_over_budget_is_truncated_today``
+    in tests/test_channel_prompt_goldens.py, which pinned the old behaviour so
+    this change could not land silently.
+
+    MUTATION: restore the old behaviour — truncate CRITICAL to ``remaining`` in
+    ``_fit_to_budget``. Fails.
+    """
+    ctx = PromptContext(
+        instance=None,
+        agent_id="",
+        message="",
+        instructions="",
+        knowledge_context="",
+        system_message_override=None,
+        channel_inputs=ChannelInputs(identity="P" * 500, session_key="s-1"),
+    )
+    assembled = await assemble(
+        [
+            prompt_layer_registry.get("channel.identity"),
+            prompt_layer_registry.get("channel.session_key"),
+        ],
+        ctx,
+        budget_chars=100,
+    )
+    assert assembled.text == "P" * 500
+    assert len(assembled.text) > 100
+    # The overrun does not become a licence: everything droppable still went.
+    assert "# Session Management" not in assembled.text
+    assert [d.name for d in assembled.dropped] == ["channel.session_key"]

--- a/tests/test_channel_prompt_layers.py
+++ b/tests/test_channel_prompt_layers.py
@@ -332,6 +332,55 @@ async def test_the_guard_records_the_failure_rather_than_swallowing_it():
     ]
 
 
+async def test_a_bootstrap_provider_that_claims_a_non_string_key_cannot_kill_the_turn():
+    """A malformed ``identity_cache_key`` must not reach the digest.
+
+    ``BootstrapContext`` declares the field ``str | None``, but the bootstrap
+    provider is a Protocol and the identity layer reads whatever the returned
+    object actually carries. A ``MagicMock`` — which is what several existing
+    suites pass — has a truthy attribute for every name, so a bare ``or``
+    forwards the mock as a cache key. ``assembler._digest`` then calls
+    ``.encode`` on it and raises, and THAT IS OUTSIDE THE RENDER GUARD: it does
+    not degrade one layer, it fails the whole turn. On the channel path that is
+    all cost and no benefit, because ``build_system_prompt`` throws the digest
+    away.
+
+    This is a bug PA-7a introduced and the existing suite caught (six failures
+    across tests/test_memory_isolation.py and tests/test_mem0_store.py) — the
+    old channel path never read the field at all.
+
+    MUTATION: change the layer back to ``claim or _short_digest(...)``. Fails
+    with ``TypeError: object supporting the buffer API required``.
+    """
+    provider = MagicMock()
+    context = MagicMock()
+    context.to_system_prompt.return_value = "base prompt"
+    provider.get_context = AsyncMock(return_value=context)
+    memory = MagicMock()
+    memory.get_context_for_agent = AsyncMock(return_value="")
+    builder = AgentContextBuilder(bootstrap_provider=provider, memory_manager=memory)
+
+    prompt = await builder.build_system_prompt(include_memory=False)
+    assert "base prompt" in prompt
+
+    # And the layer still produces a usable key rather than dropping to None,
+    # which would quietly take the persona out of any future digest.
+    from pocketpaw.prompt.channel.request import ChannelIdentityLayer
+
+    out = await ChannelIdentityLayer().render(
+        PromptContext(
+            instance=None,
+            agent_id="",
+            message="",
+            instructions="",
+            knowledge_context="",
+            system_message_override=None,
+            channel_inputs=ChannelInputs(identity="p", identity_cache_key=context.whatever),
+        )
+    )
+    assert isinstance(out.cache_key, str) and out.cache_key
+
+
 # ---------------------------------------------------------------------------
 # 4. The files that did not move
 # ---------------------------------------------------------------------------

--- a/tests/test_claude_sdk_prompt_spill.py
+++ b/tests/test_claude_sdk_prompt_spill.py
@@ -1,0 +1,229 @@
+# tests/test_claude_sdk_prompt_spill.py
+# Created: 2026-08-03 (PA-7b, feat/prompt-assembler-channel) — the FILE half of
+# the Windows spilled-prompt bug. The cache-key half lives in
+# `test_prompt_backend_digest.py`, in the test named
+# `..._spilled_windows_prompt_no_longer_collapses_into_one_cache_key`; both come
+# from the same single line of code.
+#
+# THE BUG. Windows caps a command line at ~32,767 chars, so a system prompt over
+# 24,000 is written to disk and passed to the CLI as `--system-prompt-file`.
+# Until PA-7b it was written to ONE fixed path, `~/.pocketpaw/runtime/system_prompt.md`.
+# `AgentPool` holds one backend instance per agent, so two concurrent
+# large-prompt runs on one machine both wrote that file and whichever CLI
+# subprocess started second read the other agent's prompt. Windows-only, so the
+# cloud never saw it — the desktop app runs a pool.
+#
+# THE FIX is a hash of the content in the filename, which also closes the cache
+# key (the path is what `_behavior_prefix` returns for a spilled prompt, and a
+# constant path is a constant key). The tests here are about the file: two
+# prompts get two files, the same prompt is not rewritten, and the directory is
+# bounded — an unbounded pile of 24k+ files in the user's home would be a worse
+# bug than the one being fixed.
+#
+# Every test redirects `Path.home()` at a tmp dir. A test that writes to the real
+# `~/.pocketpaw` would pass and then pollute the machine it ran on.
+#
+# EACH TEST NAMES THE MUTATION THAT BREAKS IT, and every one was applied, run,
+# observed to fail, and reverted.
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from pocketpaw.agents.claude_sdk import (
+    _SPILLED_PROMPT_KEEP,
+    _WINDOWS_PROMPT_SPILL_CHARS,
+    _prune_spilled_prompts,
+    _spill_prompt_to_file,
+    _spilled_prompt_path,
+)
+
+pytestmark = pytest.mark.asyncio
+
+_BIG = "You are Paw.\n\n## THE LAW\nNever fabricate.\n" + "x" * _WINDOWS_PROMPT_SPILL_CHARS
+
+
+@pytest.fixture(autouse=True)
+def _home(tmp_path, monkeypatch):
+    """Point `Path.home()` at a tmp dir for every test in this file."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    return tmp_path
+
+
+def _spill_dir(home: Path) -> Path:
+    return home / ".pocketpaw" / "runtime" / "prompts"
+
+
+async def test_two_concurrent_prompts_no_longer_land_on_one_file(_home):
+    """The race, in the form the pool can actually produce.
+
+    Two agents, two different large prompts, one machine. Under the fixed path
+    the second write clobbered the first and the first agent's CLI — if it had
+    not yet read the file — launched on the second agent's prompt. Here they are
+    two files and each holds its own bytes.
+
+    THE MUTATION THAT BREAKS THIS: make `_spilled_prompt_path` ignore its
+    argument and return the pre-PA-7b `Path.home() / ".pocketpaw" / "runtime" /
+    "system_prompt.md"`. Run: one path, and the first file's content assertion
+    failed with the second prompt's bytes.
+    """
+    prompt_a = _BIG + "\n<agent>alpha</agent>"
+    prompt_b = _BIG + "\n<agent>bravo</agent>"
+
+    path_a = _spill_prompt_to_file(prompt_a)
+    path_b = _spill_prompt_to_file(prompt_b)
+
+    assert path_a != path_b
+    assert path_a.read_text(encoding="utf-8") == prompt_a
+    assert path_b.read_text(encoding="utf-8") == prompt_b
+
+
+async def test_the_same_prompt_is_written_once_and_then_reused(_home):
+    """The write is skipped when the file is already there.
+
+    The name IS the content, so an existing file has the bytes we were about to
+    write. Skipping is what keeps a repeated turn from rewriting 24k+ chars under
+    a CLI that may be reading them, and it removes the common concurrent case
+    from the race without relying on the write being atomic.
+
+    The assertion is deliberately blunt: the file's bytes are replaced with a
+    marker on disk, and the marker must SURVIVE the second call. That is direct
+    evidence no write happened, and it is honest about the consequence — a
+    content-addressed cache trusts the name, which is why the name carries 128
+    bits and not 64.
+
+    THE MUTATION THAT BREAKS THIS: delete the `if path.exists(): return path`
+    guard in `_spill_prompt_to_file`. Run: the marker was overwritten with the
+    prompt and the assertion failed.
+    """
+    first = _spill_prompt_to_file(_BIG)
+    first.write_text("MARKER — nothing should overwrite this", encoding="utf-8")
+
+    second = _spill_prompt_to_file(_BIG)
+
+    assert second == first
+    assert second.read_text(encoding="utf-8").startswith("MARKER")
+
+
+async def test_the_spill_directory_stays_bounded(_home):
+    """An unbounded pile of 24k+ files in the user's home is not an acceptable trade.
+
+    The point of content-addressing is that the names differ, so a long-lived
+    desktop session would otherwise leave one file per distinct prompt, forever.
+    Spilling more than the bound and finding the directory still at the bound is
+    the whole assertion.
+
+    THE MUTATION THAT BREAKS THIS: remove the `_prune_spilled_prompts(...)` call
+    from `_spill_prompt_to_file`. Run: 40 files, and the count assertion failed.
+    """
+    over = _SPILLED_PROMPT_KEEP + 8
+    for i in range(over):
+        _spill_prompt_to_file(f"{_BIG}\n<turn>{i}</turn>")
+
+    files = list(_spill_dir(_home).iterdir())
+    assert len(files) <= _SPILLED_PROMPT_KEEP, f"{len(files)} spilled prompts survived"
+
+
+async def test_the_prompt_just_spilled_is_never_the_one_pruned(_home):
+    """The file the CLI is about to read must outlive its own prune.
+
+    Newest-by-mtime would USUALLY protect it, and "usually" is not a property to
+    hand a launching subprocess: filesystem timestamp resolution is coarse enough
+    that a burst of spills can tie, and a tie resolves to whatever order the
+    directory listing came back in — which, for content-hash filenames, is
+    arbitrary. So the file is excluded from the candidate list outright.
+
+    The mtimes here are FORCED so the protected file is the oldest thing in the
+    directory. That is the adversarial case, and it is the only way to test this
+    deterministically: driving it through a natural burst of spills passes with
+    the guard removed roughly as often as it fails, because the tie-break is luck.
+
+    THE MUTATION THAT BREAKS THIS: drop the `candidate == protect` skip (and the
+    reserved budget slot) from `_prune_spilled_prompts`. Run: the protected file
+    was deleted and `exists()` failed.
+    """
+    paths = [_spill_prompt_to_file(f"{_BIG}\n<turn>{i}</turn>") for i in range(5)]
+    doomed = paths[0]
+    # Oldest by a wide margin: any mtime-ordered prune reaches it first.
+    os.utime(doomed, (1_000_000, 1_000_000))
+
+    _prune_spilled_prompts(_spill_dir(_home), keep=2, protect=doomed)
+
+    assert doomed.exists(), "the prune deleted the prompt the CLI was about to read"
+    assert len(list(_spill_dir(_home).iterdir())) == 2, "the protected file must fit in the bound"
+
+
+async def test_build_options_actually_uses_the_content_addressed_path(monkeypatch, _home):
+    """The helpers above are correct; this proves `_build_options` CALLS them.
+
+    A spill helper that is right but unreached is the original bug intact. Drives
+    the real option build with `os.name` forced to "nt" so the branch runs on any
+    platform, and checks the built options carry the file dict pointing at the
+    hashed path — not a string prompt, and not the old fixed name.
+
+    THE MUTATION THAT BREAKS THIS: restore `_build_options`' inline
+    `runtime_dir / "system_prompt.md"` write. Run: the path assertion failed —
+    the built options pointed at the constant filename.
+    """
+    from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
+    from pocketpaw.config import get_settings
+
+    monkeypatch.setattr(os, "name", "nt")
+    backend = ClaudeSDKBackend(get_settings())
+    monkeypatch.setattr(backend, "_collect_mcp_tool_ids", lambda: [])
+
+    built = await backend._build_options(
+        "hello",
+        system_prompt=_BIG,
+        history=None,
+        session_key=None,
+        deny_mcp_tool_ids=frozenset(),
+        allow_sdk_tools=frozenset(),
+        allow_mcp_tool_ids=frozenset(),
+        skill_names=frozenset(),
+        stderr_sink=[],
+    )
+
+    spilled = built.options_kwargs["system_prompt"]
+    assert isinstance(spilled, dict), "a prompt over the Windows limit was passed inline"
+    assert spilled["type"] == "file"
+    # ``final_prompt`` is the assembled prompt plus whatever ``_build_options``
+    # splices in, so the name is derived from what actually landed on disk rather
+    # than from ``_BIG``.
+    written = Path(spilled["path"])
+    assert written.parent == _spill_dir(_home)
+    assert written == _spilled_prompt_path(written.read_text(encoding="utf-8"))
+    assert written.name != "system_prompt.md", "the constant filename is back"
+
+
+async def test_a_prompt_under_the_limit_is_still_passed_inline(monkeypatch, _home):
+    """The spill is for oversized prompts only — nothing else changed shape.
+
+    THE MUTATION THAT BREAKS THIS: change `_build_options`' threshold test to
+    `>= 0`. Run: the small prompt came back as a file dict and the isinstance
+    assertion failed.
+    """
+    from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
+    from pocketpaw.config import get_settings
+
+    monkeypatch.setattr(os, "name", "nt")
+    backend = ClaudeSDKBackend(get_settings())
+    monkeypatch.setattr(backend, "_collect_mcp_tool_ids", lambda: [])
+
+    built = await backend._build_options(
+        "hello",
+        system_prompt="You are Paw.",
+        history=None,
+        session_key=None,
+        deny_mcp_tool_ids=frozenset(),
+        allow_sdk_tools=frozenset(),
+        allow_mcp_tool_ids=frozenset(),
+        skill_names=frozenset(),
+        stderr_sink=[],
+    )
+
+    assert isinstance(built.options_kwargs["system_prompt"], str)
+    assert not _spill_dir(_home).exists(), "a small prompt still touched the spill directory"

--- a/tests/test_claude_sdk_prompt_spill.py
+++ b/tests/test_claude_sdk_prompt_spill.py
@@ -171,7 +171,14 @@ async def test_build_options_actually_uses_the_content_addressed_path(monkeypatc
     from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
     from pocketpaw.config import get_settings
 
-    monkeypatch.setattr(os, "name", "nt")
+    # Force the Windows branch by patching the PREDICATE, never ``os.name``.
+    # ``pathlib`` binds ``WindowsPath.__new__`` to a raising stub at import time
+    # on POSIX, so a Linux process with ``os.name`` forced to "nt" sends every
+    # ``Path(...)`` into that stub — this test died on CI and passed on Windows.
+    monkeypatch.setattr(
+        "pocketpaw.agents.claude_sdk._prompt_must_spill",
+        lambda prompt: len(prompt) > _WINDOWS_PROMPT_SPILL_CHARS,
+    )
     backend = ClaudeSDKBackend(get_settings())
     monkeypatch.setattr(backend, "_collect_mcp_tool_ids", lambda: [])
 
@@ -209,7 +216,14 @@ async def test_a_prompt_under_the_limit_is_still_passed_inline(monkeypatch, _hom
     from pocketpaw.agents.claude_sdk import ClaudeSDKBackend
     from pocketpaw.config import get_settings
 
-    monkeypatch.setattr(os, "name", "nt")
+    # Force the Windows branch by patching the PREDICATE, never ``os.name``.
+    # ``pathlib`` binds ``WindowsPath.__new__`` to a raising stub at import time
+    # on POSIX, so a Linux process with ``os.name`` forced to "nt" sends every
+    # ``Path(...)`` into that stub — this test died on CI and passed on Windows.
+    monkeypatch.setattr(
+        "pocketpaw.agents.claude_sdk._prompt_must_spill",
+        lambda prompt: len(prompt) > _WINDOWS_PROMPT_SPILL_CHARS,
+    )
     backend = ClaudeSDKBackend(get_settings())
     monkeypatch.setattr(backend, "_collect_mcp_tool_ids", lambda: [])
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -22,6 +22,7 @@ def _assembled(text: str = "sys prompt") -> AssembledPrompt:
     """What ``AgentContextBuilder.assemble_system_prompt`` hands the loop back."""
     return AssembledPrompt(text=text, stable_digest="0123456789abcdef")
 
+
 # =========================================================================
 # Helpers
 # =========================================================================

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,4 +1,12 @@
-"""Tests for cross-channel command handler and session aliases."""
+"""Tests for cross-channel command handler and session aliases.
+
+Updated: 2026-08-03 (PA-7b, feat/prompt-assembler-channel) — the stubbed context
+builders return an ``AssembledPrompt`` from ``assemble_system_prompt``, which is
+what ``AgentLoop`` calls now that the channel turn carries its prompt's stable
+digest to the backend. These tests are about commands and never reached the
+prompt build, so the old ``build_system_prompt`` stubs kept passing while naming
+a method the loop no longer calls — renamed rather than left as false coverage.
+"""
 
 import asyncio
 import json
@@ -7,6 +15,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from pocketpaw.bus.events import Channel, InboundMessage, OutboundMessage
 from pocketpaw.memory.file_store import FileMemoryStore
+from pocketpaw.prompt import AssembledPrompt
+
+
+def _assembled(text: str = "sys prompt") -> AssembledPrompt:
+    """What ``AgentContextBuilder.assemble_system_prompt`` hands the loop back."""
+    return AssembledPrompt(text=text, stable_digest="0123456789abcdef")
 
 # =========================================================================
 # Helpers
@@ -1048,7 +1062,7 @@ class TestAgentLoopCommandIntegration:
 
             with patch.object(loop, "context_builder") as mock_ctx:
                 mock_ctx.memory = mm
-                mock_ctx.build_system_prompt = AsyncMock(return_value="sys prompt")
+                mock_ctx.assemble_system_prompt = AsyncMock(return_value=_assembled())
                 await loop._process_message_inner(msg, "discord:12345")
 
         # User message WAS stored in memory
@@ -1201,7 +1215,7 @@ class TestWelcomeHint:
 
             with patch.object(loop, "context_builder") as mock_ctx:
                 mock_ctx.memory = mm
-                mock_ctx.build_system_prompt = AsyncMock(return_value="sys prompt")
+                mock_ctx.assemble_system_prompt = AsyncMock(return_value=_assembled())
                 await loop._process_message_inner(msg, "discord:12345")
 
         # Discord is excluded from welcome hints
@@ -1257,7 +1271,7 @@ class TestWelcomeHint:
 
             with patch.object(loop, "context_builder") as mock_ctx:
                 mock_ctx.memory = mm
-                mock_ctx.build_system_prompt = AsyncMock(return_value="sys prompt")
+                mock_ctx.assemble_system_prompt = AsyncMock(return_value=_assembled())
                 await loop._process_message_inner(msg, "discord:12345")
 
         outbound_calls = bus.publish_outbound.call_args_list
@@ -1312,7 +1326,7 @@ class TestWelcomeHint:
 
             with patch.object(loop, "context_builder") as mock_ctx:
                 mock_ctx.memory = mm
-                mock_ctx.build_system_prompt = AsyncMock(return_value="sys prompt")
+                mock_ctx.assemble_system_prompt = AsyncMock(return_value=_assembled())
                 await loop._process_message_inner(msg, "websocket:12345")
 
         # get_session_history should NOT have been called (channel excluded)
@@ -1370,7 +1384,7 @@ class TestWelcomeHint:
 
             with patch.object(loop, "context_builder") as mock_ctx:
                 mock_ctx.memory = mm
-                mock_ctx.build_system_prompt = AsyncMock(return_value="sys prompt")
+                mock_ctx.assemble_system_prompt = AsyncMock(return_value=_assembled())
                 await loop._process_message_inner(msg, "discord:12345")
 
         # get_session_history should NOT have been called (feature disabled)
@@ -1429,7 +1443,7 @@ class TestWelcomeHint:
 
             with patch.object(loop, "context_builder") as mock_ctx:
                 mock_ctx.memory = mm
-                mock_ctx.build_system_prompt = AsyncMock(return_value="sys prompt")
+                mock_ctx.assemble_system_prompt = AsyncMock(return_value=_assembled())
                 await loop._process_message_inner(msg, "discord:12345")
 
         # add_to_session should be called for user msg + assistant response

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,14 +1,27 @@
-"""Tests for concurrency controls: session locks, global semaphore, async clients."""
+"""Tests for concurrency controls: session locks, global semaphore, async clients.
+
+Updated: 2026-08-03 (PA-7b, feat/prompt-assembler-channel) — the stub builders
+return an ``AssembledPrompt`` from ``assemble_system_prompt`` and the fake routers
+declare ``system_prompt_digest``, because ``AgentLoop`` now carries the assembled
+prompt's stable digest through the router to the backend. Nothing about what
+these tests prove changed; only the shape of the two things they fake.
+"""
 
 import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from pocketpaw.bus import Channel, InboundMessage
+from pocketpaw.prompt import AssembledPrompt
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _assembled(text: str = "system") -> AssembledPrompt:
+    """What ``AgentContextBuilder.assemble_system_prompt`` hands the loop back."""
+    return AssembledPrompt(text=text, stable_digest="0123456789abcdef")
 
 
 def _make_inbound(chat_id: str, content: str = "hi") -> InboundMessage:
@@ -25,7 +38,9 @@ def _make_slow_router(delay: float = 0.1):
     """Return a mock router whose run() sleeps for *delay* seconds."""
     router = MagicMock()
 
-    async def mock_run(message, *, system_prompt=None, history=None, session_key=None):
+    async def mock_run(
+        message, *, system_prompt=None, history=None, session_key=None, system_prompt_digest=""
+    ):
         await asyncio.sleep(delay)
         yield {"type": "message", "content": "ok", "metadata": {}}
         yield {"type": "done", "content": ""}
@@ -81,7 +96,7 @@ async def test_session_lock_serialises_same_session(
     mock_get_mem.return_value = mem
 
     ctx = MagicMock()
-    ctx.build_system_prompt = AsyncMock(return_value="system")
+    ctx.assemble_system_prompt = AsyncMock(return_value=_assembled("system"))
     mock_ctx_cls.return_value = ctx
 
     scanner = MagicMock()
@@ -94,7 +109,9 @@ async def test_session_lock_serialises_same_session(
     order = []
     delay = 0.05
 
-    async def slow_run(message, *, system_prompt=None, history=None, session_key=None):
+    async def slow_run(
+        message, *, system_prompt=None, history=None, session_key=None, system_prompt_digest=""
+    ):
         order.append(f"start:{message}")
         await asyncio.sleep(delay)
         order.append(f"end:{message}")
@@ -167,7 +184,7 @@ async def test_cross_session_runs_in_parallel(
     mock_get_mem.return_value = mem
 
     ctx = MagicMock()
-    ctx.build_system_prompt = AsyncMock(return_value="system")
+    ctx.assemble_system_prompt = AsyncMock(return_value=_assembled("system"))
     mock_ctx_cls.return_value = ctx
 
     scanner = MagicMock()
@@ -179,7 +196,9 @@ async def test_cross_session_runs_in_parallel(
 
     order = []
 
-    async def slow_run(message, *, system_prompt=None, history=None, session_key=None):
+    async def slow_run(
+        message, *, system_prompt=None, history=None, session_key=None, system_prompt_digest=""
+    ):
         order.append(f"start:{message}")
         await asyncio.sleep(0.05)
         order.append(f"end:{message}")
@@ -256,7 +275,7 @@ async def test_global_semaphore_caps_concurrency(
     mock_get_mem.return_value = mem
 
     ctx = MagicMock()
-    ctx.build_system_prompt = AsyncMock(return_value="system")
+    ctx.assemble_system_prompt = AsyncMock(return_value=_assembled("system"))
     mock_ctx_cls.return_value = ctx
 
     scanner = MagicMock()
@@ -268,7 +287,9 @@ async def test_global_semaphore_caps_concurrency(
 
     order = []
 
-    async def slow_run(message, *, system_prompt=None, history=None, session_key=None):
+    async def slow_run(
+        message, *, system_prompt=None, history=None, session_key=None, system_prompt_digest=""
+    ):
         order.append(f"start:{message}")
         await asyncio.sleep(0.05)
         order.append(f"end:{message}")

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -76,6 +76,7 @@ _OLD_PRIORITIES: dict[str, Priority] = {
     "channel.health_state": Priority.LOW,
 }
 
+
 def _ctx(**channel_inputs) -> PromptContext:
     return PromptContext(
         instance=None,

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -1,163 +1,217 @@
 """
 Tests for context window budget tracking in AgentContextBuilder.
 Created: 2026-04-01 - Priority-based injection with per-block character caps.
+Updated: 2026-08-03 (PA-7a, feat/prompt-assembler-channel) - the subject moved.
+``_assemble_with_budget``, ``_Priority`` and ``_INJECTION_CAPS`` are deleted;
+the channel path assembles through ``pocketpaw.prompt.assemble`` over the
+fifteen ``channel.*`` layers, each carrying its own ``max_chars`` and
+``Priority``. The budget MECHANICS are therefore tested once, generically, in
+``tests/test_prompt_budget.py``. What is left here is the thing only this file
+can check: that every cap and every priority came across the cutover with the
+number it had, and that the two blocks the old table had NO entry for are still
+uncapped rather than quietly given one.
+
+The behavioural tests below drive the REQUEST layers only
+(``tests/test_channel_prompt_goldens.py`` covers the full fifteen against real
+bytes). Request layers read nothing but their ``ChannelInputs``, so these stay
+hermetic without stubbing the machine.
 """
 
 from __future__ import annotations
 
 from pocketpaw.bootstrap.context_builder import (
     _DEFAULT_BUDGET_CHARS,
-    _INJECTION_CAPS,
     AgentContextBuilder,
-    _Priority,
 )
+from pocketpaw.prompt import Priority, PromptContext, assemble, prompt_layer_registry
+from pocketpaw.prompt.channel import CHANNEL_PROMPT_LAYERS, ChannelInputs
+
+# The table as ``_INJECTION_CAPS`` held it the moment before PA-7a deleted it,
+# transcribed here so the assertion below compares the layers against the OLD
+# numbers rather than against themselves. ``None`` means uncapped.
+#
+# Two things in it are not what a reader would guess, and both are inherited
+# rather than chosen:
+#   * ``pocket_context`` and ``current_pocket`` were MISSING from the table, so
+#     ``_INJECTION_CAPS.get(name)`` returned ``None`` and they went into the
+#     prompt at whatever length the caller produced. ``current_pocket``
+#     ``json.dumps`` a widget summary in with no bound.
+#   * the table also capped ``instructions``, a block this path never appended.
+#     There is no ``channel.instructions`` layer and the entry has no successor.
+# PA-9 owns cap arithmetic; PA-7a's job was to move the numbers, not judge them.
+_OLD_INJECTION_CAPS: dict[str, int | None] = {
+    "channel.identity": None,
+    "channel.memory_context": 4000,
+    "channel.kb_context": 3000,
+    "channel.sender_block": 500,
+    "channel.channel_hints": 500,
+    "channel.channel_instructions": 1000,
+    "channel.session_key": 200,
+    "channel.file_context": 2000,
+    "channel.health_state": 300,
+    "channel.skills_list": 2000,
+    "channel.atlas_primer": 2000,
+    "channel.agents_md": 3000,
+    "channel.gws_instructions": 1000,
+    "channel.pocket_context": None,
+    "channel.current_pocket": None,
+}
+
+# The priority each block was appended with, same source, same moment.
+_OLD_PRIORITIES: dict[str, Priority] = {
+    "channel.identity": Priority.CRITICAL,
+    "channel.memory_context": Priority.HIGH,
+    "channel.kb_context": Priority.HIGH,
+    "channel.sender_block": Priority.HIGH,
+    "channel.pocket_context": Priority.HIGH,
+    "channel.current_pocket": Priority.HIGH,
+    "channel.channel_instructions": Priority.MEDIUM,
+    "channel.session_key": Priority.MEDIUM,
+    "channel.file_context": Priority.MEDIUM,
+    "channel.skills_list": Priority.MEDIUM,
+    "channel.atlas_primer": Priority.MEDIUM,
+    "channel.agents_md": Priority.MEDIUM,
+    "channel.gws_instructions": Priority.MEDIUM,
+    "channel.channel_hints": Priority.LOW,
+    "channel.health_state": Priority.LOW,
+}
+
+def _ctx(**channel_inputs) -> PromptContext:
+    return PromptContext(
+        instance=None,
+        agent_id="",
+        message="",
+        instructions="",
+        knowledge_context="",
+        system_message_override=None,
+        channel_inputs=ChannelInputs(**channel_inputs),
+    )
 
 
-class TestAssembleWithBudget:
-    """Unit tests for _assemble_with_budget — the budget-aware block assembler."""
+def _layers(*names):
+    return [prompt_layer_registry.get(name) for name in names]
 
-    def test_all_blocks_fit_within_budget(self):
-        """Small blocks should all be included when they fit comfortably."""
-        blocks = [
-            ("identity", _Priority.CRITICAL, "I am PocketPaw."),
-            ("memory_context", _Priority.HIGH, "User likes coffee."),
-            ("channel_hints", _Priority.LOW, "Keep it short."),
+
+class TestChannelLayerBudget:
+    """The caps, the priorities, and the budget behaviour they drive."""
+
+    async def test_every_cap_came_across_with_the_number_it_had(self):
+        """Each layer's ``max_chars`` is its old ``_INJECTION_CAPS`` entry.
+
+        MUTATION: change any ``max_chars`` in ``prompt/channel/request.py`` or
+        ``prompt/channel/environment.py``. The offending name is named.
+        """
+        actual = {name: prompt_layer_registry.get(name).max_chars for name in CHANNEL_PROMPT_LAYERS}
+        assert actual == _OLD_INJECTION_CAPS
+
+    async def test_the_two_uncapped_blocks_are_still_uncapped(self):
+        """``pocket_context`` and ``current_pocket`` never had a cap entry.
+
+        Called out separately from the table above because "``None`` because the
+        old table said ``None``" and "``None`` because the old table had no row"
+        are different facts, and only the second is a gap PA-9 should look at.
+
+        MUTATION: give ``ChannelCurrentPocketLayer`` a ``max_chars``. Fails —
+        and would also move bytes on any live pocket big enough to hit it.
+        """
+        assert prompt_layer_registry.get("channel.pocket_context").max_chars is None
+        assert prompt_layer_registry.get("channel.current_pocket").max_chars is None
+
+    async def test_the_dead_instructions_cap_has_no_successor(self):
+        """``_INJECTION_CAPS['instructions']`` capped a block this path never built.
+
+        MUTATION: register a ``channel.instructions`` layer. Fails, and it
+        should — the cloud path's ``instructions`` layer is a different block
+        with a different producer, and a channel twin would put the EE behaviour
+        stack into channel prompts.
+        """
+        assert "channel.instructions" not in CHANNEL_PROMPT_LAYERS
+        assert "channel.instructions" not in prompt_layer_registry.list()
+
+    async def test_every_priority_came_across_with_the_rank_it_had(self):
+        """Each layer's ``priority`` is the one its block was appended with.
+
+        MUTATION: flip ``ChannelFormatHintLayer.priority`` to MEDIUM. Fails
+        here, and the emission-order test in
+        ``tests/test_channel_prompt_layers.py`` fails too — the two together are
+        what make a priority change impossible to land by accident.
+        """
+        actual = {name: prompt_layer_registry.get(name).priority for name in CHANNEL_PROMPT_LAYERS}
+        assert actual == _OLD_PRIORITIES
+
+    async def test_all_blocks_fit_within_a_generous_budget(self):
+        """Small blocks are all included when they fit comfortably."""
+        assembled = await assemble(
+            _layers("channel.identity", "channel.memory_context", "channel.session_key"),
+            _ctx(identity="I am PocketPaw.", memory_context="User likes coffee.", session_key="s"),
+            budget_chars=10_000,
+        )
+        assert "I am PocketPaw." in assembled.text
+        assert "User likes coffee." in assembled.text
+        assert "Current session_key: s" in assembled.text
+
+    async def test_low_priority_is_dropped_before_critical(self):
+        """When the budget is tight, LOW goes and CRITICAL stays."""
+        from pocketpaw.bus.events import Channel
+
+        assembled = await assemble(
+            _layers("channel.identity", "channel.channel_hints"),
+            _ctx(identity="X" * 800, channel=Channel.TELEGRAM),
+            budget_chars=850,
+        )
+        assert "X" * 800 in assembled.text
+        assert "# Response Format" not in assembled.text
+        # Two entries, and they are two different cuts: the Telegram hint is
+        # over its own 500-char cap FIRST (unconditional, before the budget is
+        # consulted), and the capped 515 chars are then what the budget cannot
+        # afford. ``dropped`` records both because neither is the other.
+        assert [(d.name, d.reason.split()[0]) for d in assembled.dropped] == [
+            ("channel.channel_hints", "truncated"),
+            ("channel.channel_hints", "dropped"),
         ]
-        result = AgentContextBuilder._assemble_with_budget(blocks, budget_chars=10_000)
-        assert "I am PocketPaw." in result
-        assert "User likes coffee." in result
-        assert "Keep it short." in result
 
-    def test_low_priority_dropped_first(self):
-        """When budget is tight, LOW blocks should be dropped before CRITICAL ones."""
-        critical_block = "X" * 800
-        high_block = "Y" * 100
-        low_block = "Z" * 200
+    async def test_a_block_over_its_cap_is_truncated_with_a_marker(self):
+        """A block above ``max_chars`` is cut and says so, budget notwithstanding."""
+        assembled = await assemble(
+            _layers("channel.memory_context"),
+            _ctx(memory_context="M" * 9000),
+            budget_chars=50_000,
+        )
+        assert "[...truncated]" in assembled.text
+        assert len(assembled.text) == 4000 + len("\n[...truncated]")
 
-        blocks = [
-            ("identity", _Priority.CRITICAL, critical_block),
-            ("memory_context", _Priority.HIGH, high_block),
-            ("channel_hints", _Priority.LOW, low_block),
-        ]
-        # Budget fits critical + high but not low (800 + 100 + separators < 950 < 800+100+200)
-        result = AgentContextBuilder._assemble_with_budget(blocks, budget_chars=950)
-        assert critical_block in result
-        assert high_block in result
-        assert low_block not in result
-
-    def test_critical_never_dropped(self):
-        """Even with a tiny budget, CRITICAL blocks are truncated but still present."""
-        critical_content = "A" * 500
-        medium_content = "B" * 200
-
-        blocks = [
-            ("identity", _Priority.CRITICAL, critical_content),
-            ("sender_block", _Priority.MEDIUM, medium_content),
-        ]
-        result = AgentContextBuilder._assemble_with_budget(blocks, budget_chars=100)
-        # Critical block should be truncated to 100 chars, but present
-        assert len(result) <= 100
-        assert result.startswith("A")
-        # Medium block should be dropped entirely
-        assert "B" not in result
-
-    def test_per_block_caps_applied(self):
-        """A block exceeding its per-block cap should be truncated with a marker."""
-        memory_cap = _INJECTION_CAPS["memory_context"]
-        assert memory_cap is not None  # sanity check
-
-        oversized_content = "M" * (memory_cap + 5000)
-        blocks = [
-            ("memory_context", _Priority.HIGH, oversized_content),
-        ]
-        result = AgentContextBuilder._assemble_with_budget(blocks, budget_chars=50_000)
-        # Should be capped to memory_cap + truncation marker, not the full content
-        assert len(result) <= memory_cap + len("\n[...truncated]") + 10
-        assert "[...truncated]" in result
-
-    def test_empty_blocks_skipped(self):
-        """Empty or whitespace-only blocks should not consume any budget."""
-        blocks = [
-            ("identity", _Priority.CRITICAL, "Hello"),
-            ("memory_context", _Priority.HIGH, ""),
-            ("channel_hints", _Priority.LOW, "   "),
-            ("sender_block", _Priority.MEDIUM, "World"),
-        ]
-        result = AgentContextBuilder._assemble_with_budget(blocks, budget_chars=10_000)
-        assert "Hello" in result
-        assert "World" in result
-        # Only two non-empty blocks joined by \n\n
-        assert result == "Hello\n\nWorld"
-
-    def test_default_budget_is_generous(self):
-        """The default 32K budget should accommodate typical prompt assemblies."""
+    async def test_the_default_budget_is_still_generous(self):
+        """The 32K default accommodates a typical assembly."""
         assert _DEFAULT_BUDGET_CHARS == 32_000
+        assembled = await assemble(
+            _layers("channel.identity", "channel.memory_context"),
+            _ctx(identity="X" * 2000, memory_context="Y" * 1500),
+        )
+        assert "X" * 2000 in assembled.text
+        assert "Y" * 1500 in assembled.text
 
-        # A reasonable set of blocks totalling ~5K should all fit
-        blocks = [
-            ("identity", _Priority.CRITICAL, "X" * 2000),
-            ("memory_context", _Priority.HIGH, "Y" * 1500),
-            ("sender_block", _Priority.MEDIUM, "Z" * 500),
-            ("channel_hints", _Priority.LOW, "W" * 300),
-            ("skills_list", _Priority.MEDIUM, "S" * 700),
-        ]
-        result = AgentContextBuilder._assemble_with_budget(blocks)
-        # All blocks should be present
-        assert "X" * 2000 in result
-        assert "Y" * 1500 in result
-        assert "Z" * 500 in result
-        assert "W" * 300 in result
-        assert "S" * 700 in result
+    async def test_an_uncapped_block_is_never_truncated(self):
+        """``channel.identity`` has no cap, so 20k chars arrive whole."""
+        big = "I" * 20_000
+        assembled = await assemble(
+            _layers("channel.identity"), _ctx(identity=big), budget_chars=25_000
+        )
+        assert assembled.text == big
 
-    def test_budget_chars_kwarg(self):
-        """Caller should be able to pass a custom budget_chars value."""
-        blocks = [
-            ("identity", _Priority.CRITICAL, "A" * 100),
-            ("memory_context", _Priority.HIGH, "B" * 100),
-        ]
-        # With budget=150, only the critical block fits (100 chars + need room for second)
-        result = AgentContextBuilder._assemble_with_budget(blocks, budget_chars=150)
-        assert "A" * 100 in result
-        # 100 chars used, 50 remaining — not enough for 100 chars of B
-        assert "B" * 100 not in result
+    async def test_blank_blocks_leave_no_separator(self):
+        """A layer with nothing to say contributes no text AND no ``\\n\\n``.
 
-    def test_priority_ordering_preserved(self):
-        """Blocks should be assembled in priority order, not insertion order."""
-        blocks = [
-            ("channel_hints", _Priority.LOW, "low"),
-            ("identity", _Priority.CRITICAL, "critical"),
-            ("memory_context", _Priority.HIGH, "high"),
-            ("sender_block", _Priority.MEDIUM, "medium"),
-        ]
-        result = AgentContextBuilder._assemble_with_budget(blocks, budget_chars=10_000)
-        # CRITICAL should come before HIGH, which should come before MEDIUM, then LOW
-        crit_pos = result.index("critical")
-        high_pos = result.index("high")
-        med_pos = result.index("medium")
-        low_pos = result.index("low")
-        assert crit_pos < high_pos < med_pos < low_pos
-
-    def test_uncapped_block_uses_remaining_budget(self):
-        """A block with no cap (None) should use whatever budget remains."""
-        # identity has no cap in _INJECTION_CAPS
-        large_identity = "I" * 20_000
-        blocks = [
-            ("identity", _Priority.CRITICAL, large_identity),
-        ]
-        result = AgentContextBuilder._assemble_with_budget(blocks, budget_chars=25_000)
-        assert result == large_identity
-
-    def test_multiple_blocks_same_priority(self):
-        """Multiple blocks at the same priority should all be included if budget allows."""
-        blocks = [
-            ("sender_block", _Priority.MEDIUM, "sender"),
-            ("session_key", _Priority.MEDIUM, "session"),
-            ("file_context", _Priority.MEDIUM, "files"),
-        ]
-        result = AgentContextBuilder._assemble_with_budget(blocks, budget_chars=10_000)
-        assert "sender" in result
-        assert "session" in result
-        assert "files" in result
+        MUTATION: drop ``_nonblank`` from ``ChannelIdentityLayer.render``. A
+        whitespace-only identity starts contributing a separator and the
+        assertion below fails.
+        """
+        assembled = await assemble(
+            _layers("channel.identity", "channel.session_key", "channel.file_context"),
+            _ctx(identity="   ", session_key="s-1", file_context=None),
+            budget_chars=10_000,
+        )
+        assert assembled.text.startswith("\n# Session Management")
+        assert "\n\n" not in assembled.text.strip()
 
 
 class TestKbContext:
@@ -230,6 +284,6 @@ class TestKbContext:
 
     def test_kb_context_has_injection_cap(self):
         """kb_context should have a reasonable cap to avoid blowing the context window."""
-        cap = _INJECTION_CAPS.get("kb_context")
+        cap = prompt_layer_registry.get("channel.kb_context").max_chars
         assert cap is not None
         assert 1000 <= cap <= 5000  # sanity range

--- a/tests/test_oss_artifact_delivery.py
+++ b/tests/test_oss_artifact_delivery.py
@@ -12,6 +12,12 @@
 #   4. MemoryManager.get_session_history — persisted attachments are lifted to a
 #      TOP-LEVEL ``attachments`` key (the shape the client reads on reload), so a
 #      delivered card survives a refresh; plain messages return an empty list.
+#
+# Updated: 2026-08-03 (PA-7b, feat/prompt-assembler-channel) — the stub builder
+# returns an ``AssembledPrompt`` from ``assemble_system_prompt`` and the fake
+# backend declares ``system_prompt_digest``, because ``AgentLoop`` now carries the
+# assembled prompt's stable digest through the router. Seam 2 above is the only
+# one affected, and only in what it fakes.
 
 from __future__ import annotations
 
@@ -22,6 +28,7 @@ import pytest
 from pocketpaw.agents.loop import AgentLoop
 from pocketpaw.agents.protocol import AgentEvent
 from pocketpaw.bus import Channel, InboundMessage
+from pocketpaw.prompt import AssembledPrompt
 
 
 # ── 1. upload_local_artifact ────────────────────────────────────────────────
@@ -127,7 +134,9 @@ async def _run_loop_with(router, mock_bus, mock_memory, artifact_meta):
         patch("pocketpaw.agents.loop.Settings") as settings_cls,
     ):
         settings_cls.load.return_value = _settings()
-        builder_cls.return_value.build_system_prompt = AsyncMock(return_value="SP")
+        builder_cls.return_value.assemble_system_prompt = AsyncMock(
+            return_value=AssembledPrompt(text="SP", stable_digest="0123456789abcdef")
+        )
 
         loop = AgentLoop()
         loop._deliver_oss_artifact = AsyncMock(return_value=artifact_meta)
@@ -163,7 +172,9 @@ class TestLoopArtifactEmission:
     async def test_media_tag_emits_event_and_persists_attachment(self, mock_bus, mock_memory):
         meta = {"file_id": "fid1", "name": "chart.png", "mime": "image/png", "size": 42}
 
-        async def run(message, *, system_prompt=None, history=None, session_key=None):
+        async def run(
+            message, *, system_prompt=None, history=None, session_key=None, system_prompt_digest=""
+        ):
             yield AgentEvent(type="message", content="Here is your chart.")
             yield AgentEvent(
                 type="tool_result",
@@ -195,7 +206,9 @@ class TestLoopArtifactEmission:
         # still be persisted so its artifact attachment survives a reload.
         meta = {"file_id": "fid2", "name": "export.zip", "mime": "application/zip", "size": 9}
 
-        async def run(message, *, system_prompt=None, history=None, session_key=None):
+        async def run(
+            message, *, system_prompt=None, history=None, session_key=None, system_prompt_digest=""
+        ):
             yield AgentEvent(
                 type="tool_result",
                 content="<!-- media:/tmp/export.zip -->",
@@ -218,7 +231,9 @@ class TestLoopArtifactEmission:
 
     @pytest.mark.asyncio
     async def test_no_media_no_artifact_and_no_attachment(self, mock_bus, mock_memory):
-        async def run(message, *, system_prompt=None, history=None, session_key=None):
+        async def run(
+            message, *, system_prompt=None, history=None, session_key=None, system_prompt_digest=""
+        ):
             yield AgentEvent(type="message", content="Just a plain answer.")
             yield AgentEvent(type="done", content="")
 

--- a/tests/test_prompt_backend_digest.py
+++ b/tests/test_prompt_backend_digest.py
@@ -34,11 +34,19 @@
 # and what `claude_sdk`'s volatile markers have always done. What a reused object
 # can never carry is a different agent, surface, override or instruction set.
 #
-# EACH TEST NAMES THE MUTATION THAT BREAKS IT, and each mutation was run. Two
-# say in their own docstrings that they do not, and why: the Windows
-# spilled-prompt test asserts a fallback behaviour whose fix is covered
-# elsewhere, and the section-5 tripwire characterises pydantic-ai rather than our
-# code (it was checked by flipping its own fixture instead).
+# EACH TEST NAMES THE MUTATION THAT BREAKS IT, and each mutation was run. One
+# says in its own docstring that it does not, and why: the section-5 tripwire
+# characterises pydantic-ai rather than our code (it was checked by flipping its
+# own fixture instead).
+#
+# Updated: 2026-08-03 (PA-7b, feat/prompt-assembler-channel) — the Windows
+# spilled-prompt test used to ASSERT the collapse: one fixed filename, so every
+# prompt over 24k hashed alike and the warm client stopped rebuilding for exactly
+# the prompts big enough to spill. PA-6 recorded it as expected behaviour with
+# the fix out of scope. It is now content-addressed, so that test pins the fix
+# and would fail if any constant filename came back. The file-level half of the
+# same bug — two concurrent runs overwriting one path — lives in
+# `test_claude_sdk_prompt_spill.py`.
 
 from __future__ import annotations
 
@@ -355,46 +363,62 @@ async def test_a_caller_without_a_digest_keeps_the_behaviour_prefix():
     ) != ClaudeSDKBackend._client_cache_key(_opts(changed), session_key="s1")
 
 
-async def test_a_windows_file_prompt_is_keyed_by_the_digest_and_was_not_before():
-    """A Windows-only cache bug PA-6 closes as a side effect, pinned so it stays closed.
+async def test_a_spilled_windows_prompt_no_longer_collapses_into_one_cache_key():
+    """A Windows-only cache bug. PA-6 pinned it as expected behaviour; PA-7b closed it.
 
-    `_build_options` spills a system prompt over 24,000 chars to
-    `~/.pocketpaw/runtime/system_prompt.md` and passes `{type: file, path: …}`
-    instead of the text, because the CLI's inline argument blows the Windows
-    command-line limit. `_behavior_prefix` has no text to cut there, so it falls
-    back to `file:<path>` — and the path is a CONSTANT. Every large prompt on a
+    `_build_options` spills a system prompt over 24,000 chars to a file and passes
+    `{type: file, path: …}` instead of the text, because the CLI's inline argument
+    blows the Windows command-line limit. `_behavior_prefix` has no text to cut
+    there, so it falls back to `file:<path>` — and until PA-7b that path was a
+    CONSTANT, `~/.pocketpaw/runtime/system_prompt.md`. Every large prompt on a
     Windows box therefore hashed identically, so the warm client never rebuilt on
-    a prompt change: the exact staleness the 2026-05-31 behavioural-prefix fix
-    exists to prevent, defeated for the prompts big enough to need spilling.
+    a prompt change: exactly the staleness the behavioural-prefix key exists to
+    prevent, defeated for the prompts big enough to need spilling. (The same
+    single path also let two concurrent runs overwrite each other's prompt; that
+    half is pinned in `test_claude_sdk_prompt_spill.py`.)
 
-    The digest never sees the transport, so it keys correctly regardless. Held as
-    the pair — the old behaviour is asserted too, because a test that only shows
-    the fix cannot tell you whether there was ever anything to fix.
+    PA-7b puts a hash of the CONTENT in the filename, so the fallback key moves
+    when the prompt moves and no I/O is added to the key function. This test
+    reads the paths from `_spilled_prompt_path` rather than writing them out,
+    which is what makes it the tripwire the brief asked for: a revert to any
+    constant name collapses the two paths and the first assertion fails.
 
-    THE MUTATION THAT BREAKS THIS: none needed on the second assertion — it is
-    covered by `test_a_changed_identity_still_evicts_the_warm_client`. The first
-    is a characterisation of the fallback: it fails if `_behavior_prefix` starts
-    reading the spilled FILE, which would fix the same bug a different way and is
-    worth noticing rather than silently double-covering.
+    THE MUTATION THAT BREAKS THIS: make `_spilled_prompt_path` return
+    `Path.home() / ".pocketpaw" / "runtime" / "system_prompt.md"` — the pre-PA-7b
+    name. Run: the two spilled prompts produced one path and one key, and both of
+    the first two assertions failed.
     """
-    spilled = {"type": "file", "path": "C:/Users/x/.pocketpaw/runtime/system_prompt.md"}
+    from pocketpaw.agents.claude_sdk import _spilled_prompt_path
+
+    big_a = "You are Paw.\n\n## THE LAW\nNever fabricate.\n" + "A" * 24_000
+    big_b = "You are Paw.\n\n## THE LAW\nAlways fabricate.\n" + "A" * 24_000
 
     from types import SimpleNamespace
 
-    def _file_opts():
+    def _file_opts(prompt: str):
         return SimpleNamespace(
-            model="claude-x", allowed_tools=["Agent"], system_prompt=spilled, cwd="/jail"
+            model="claude-x",
+            allowed_tools=["Agent"],
+            cwd="/jail",
+            system_prompt={"type": "file", "path": str(_spilled_prompt_path(prompt))},
         )
 
+    assert _spilled_prompt_path(big_a) != _spilled_prompt_path(big_b)
     assert ClaudeSDKBackend._client_cache_key(
-        _file_opts(), session_key="s1"
-    ) == ClaudeSDKBackend._client_cache_key(_file_opts(), session_key="s1"), (
-        "the no-digest fallback stopped collapsing spilled prompts — re-read this test"
+        _file_opts(big_a), session_key="s1"
+    ) != ClaudeSDKBackend._client_cache_key(_file_opts(big_b), session_key="s1"), (
+        "two spilled prompts share a warm client again — the constant filename is back"
     )
+    # Stable in the other direction: the same prompt must not churn the key, or
+    # the warm client rebuilds every turn for no reason.
     assert ClaudeSDKBackend._client_cache_key(
-        _file_opts(), session_key="s1", system_prompt_digest="aaaaaaaaaaaaaaaa"
+        _file_opts(big_a), session_key="s1"
+    ) == ClaudeSDKBackend._client_cache_key(_file_opts(big_a), session_key="s1")
+    # And the digest still wins over the transport where a caller has one.
+    assert ClaudeSDKBackend._client_cache_key(
+        _file_opts(big_a), session_key="s1", system_prompt_digest="aaaaaaaaaaaaaaaa"
     ) != ClaudeSDKBackend._client_cache_key(
-        _file_opts(), session_key="s1", system_prompt_digest="bbbbbbbbbbbbbbbb"
+        _file_opts(big_a), session_key="s1", system_prompt_digest="bbbbbbbbbbbbbbbb"
     ), "a spilled Windows prompt still cannot tell two identities apart"
 
 

--- a/tests/test_stream_event.py
+++ b/tests/test_stream_event.py
@@ -1,7 +1,14 @@
 # Tests for StreamEvent token-by-token streaming integration
 # Created: 2026-02-06
+# Updated: 2026-08-03 (PA-7b, feat/prompt-assembler-channel) — the stub builder
+# returns an ``AssembledPrompt`` from ``assemble_system_prompt`` and the fake
+# router declares ``system_prompt_digest``, because ``AgentLoop`` now carries the
+# assembled prompt's stable digest through the router to the backend. What these
+# tests assert about streaming is unchanged.
 
 from unittest.mock import AsyncMock, MagicMock, patch
+
+from pocketpaw.prompt import AssembledPrompt
 
 # ---------------------------------------------------------------------------
 # Helpers — lightweight fakes for SDK types
@@ -257,8 +264,8 @@ class TestLoopThinkingIntegration:
             mem.get_compacted_history = AsyncMock(return_value=[])
             mem.resolve_session_key = AsyncMock(side_effect=lambda k: k)
             mock_mem_fn.return_value = mem
-            mock_builder_cls.return_value.build_system_prompt = AsyncMock(
-                return_value="System Prompt"
+            mock_builder_cls.return_value.assemble_system_prompt = AsyncMock(
+                return_value=AssembledPrompt(text="System Prompt", stable_digest="0123456789abcdef")
             )
 
             from pocketpaw.agents.loop import AgentLoop
@@ -273,7 +280,14 @@ class TestLoopThinkingIntegration:
             # Mock router to yield thinking + done
             router = MagicMock()
 
-            async def fake_run(msg, *, system_prompt=None, history=None, session_key=None):
+            async def fake_run(
+                msg,
+                *,
+                system_prompt=None,
+                history=None,
+                session_key=None,
+                system_prompt_digest="",
+            ):
                 from pocketpaw.agents.protocol import AgentEvent
 
                 yield AgentEvent(type="thinking", content="Deep thought")
@@ -327,8 +341,8 @@ class TestLoopThinkingIntegration:
             mem.get_compacted_history = AsyncMock(return_value=[])
             mem.resolve_session_key = AsyncMock(side_effect=lambda k: k)
             mock_mem_fn.return_value = mem
-            mock_builder_cls.return_value.build_system_prompt = AsyncMock(
-                return_value="System Prompt"
+            mock_builder_cls.return_value.assemble_system_prompt = AsyncMock(
+                return_value=AssembledPrompt(text="System Prompt", stable_digest="0123456789abcdef")
             )
 
             from pocketpaw.agents.loop import AgentLoop
@@ -340,7 +354,14 @@ class TestLoopThinkingIntegration:
 
             router = MagicMock()
 
-            async def fake_run(msg, *, system_prompt=None, history=None, session_key=None):
+            async def fake_run(
+                msg,
+                *,
+                system_prompt=None,
+                history=None,
+                session_key=None,
+                system_prompt_digest="",
+            ):
                 from pocketpaw.agents.protocol import AgentEvent
 
                 yield AgentEvent(type="thinking", content="secret reasoning")

--- a/tests/test_trace_integration.py
+++ b/tests/test_trace_integration.py
@@ -1,4 +1,11 @@
-"""Trace propagation tests for AgentLoop integration."""
+"""Trace propagation tests for AgentLoop integration.
+
+Updated: 2026-08-03 (PA-7b, feat/prompt-assembler-channel) — the stub builder
+returns an ``AssembledPrompt`` from ``assemble_system_prompt`` and the fake router
+declares ``system_prompt_digest``, because ``AgentLoop`` now carries the assembled
+prompt's stable digest through the router to the backend. Trace propagation
+itself is unchanged.
+"""
 
 from __future__ import annotations
 
@@ -9,6 +16,7 @@ import pytest
 from pocketpaw.agents.loop import AgentLoop
 from pocketpaw.agents.protocol import AgentEvent
 from pocketpaw.bus import Channel, InboundMessage
+from pocketpaw.prompt import AssembledPrompt
 
 
 @patch("pocketpaw.agents.loop.get_message_bus")
@@ -37,8 +45,10 @@ async def test_loop_emits_trace_lifecycle_and_normalized_token_usage(
 
     router = MagicMock()
 
-    async def run_with_usage(message, *, system_prompt=None, history=None, session_key=None):
-        _ = message, system_prompt, history, session_key
+    async def run_with_usage(
+        message, *, system_prompt=None, history=None, session_key=None, system_prompt_digest=""
+    ):
+        _ = message, system_prompt, history, session_key, system_prompt_digest
         yield AgentEvent(type="message", content="hello")
         yield AgentEvent(
             type="token_usage",
@@ -59,7 +69,9 @@ async def test_loop_emits_trace_lifecycle_and_normalized_token_usage(
     mock_router_cls.return_value = router
 
     builder = mock_builder_cls.return_value
-    builder.build_system_prompt = AsyncMock(return_value="System prompt")
+    builder.assemble_system_prompt = AsyncMock(
+        return_value=AssembledPrompt(text="System prompt", stable_digest="0123456789abcdef")
+    )
     builder.bootstrap.get_context = AsyncMock(return_value=MagicMock(to_identity_block=lambda: ""))
 
     class Tracker:


### PR DESCRIPTION
Stacked on #1851. Review that one first; this branch is based on its head, not on `dev`.

## What this does

The channel path (Telegram, Discord, Slack, CLI) built its system prompt in `AgentContextBuilder._assemble_with_budget`, with its own priority enum and its own cap table. #1851 moved the cloud path onto the layered assembler in `src/pocketpaw/prompt/`. This is the other half. Fifteen `channel.*` layers now carry the blocks, the caps live on the layers as `max_chars`, and `_assemble_with_budget`, `_Priority` and `_INJECTION_CAPS` are gone.

The digest that assembly produces then travels to the backend, through `AgentRouter.run` and `run_with_failover`, guarded by the signature check `AgentPool` already used. A backend whose `run` does not declare the parameter keeps working untouched, and `**kwargs` deliberately does not count as declaring it.

## The prompt does not move

Every channel prompt is byte-for-byte what it was. That was checked two ways rather than one, because the goldens in this PR were written by the same process that did the cutover.

Six golden files (Telegram, Discord, Slack, CLI, no-channel, minimal) were committed against the unchanged implementation first, in `9f8a9040`, before a single layer existed. Separately, a probe outside the repo captured six input shapes at the pre-cutover commit and was re-run after each stage. Same hashes, same block order, every time, including the case where a tight budget drops six blocks.

The emission order is the part that would have broken quietly. The old assembler sorted by priority and emitted sorted; the new one emits in the caller's order. `channel_hints` is appended fifth in the source and comes out second to last. `CHANNEL_PROMPT_LAYERS` is therefore derived by stably sorting the source order, and the test re-derives that sort instead of transcribing its answer.

Layer names carry a `channel.` prefix. The registry is one flat dict shared with the cloud layers, and `identity` would otherwise have silently replaced `AgentIdentityLayer`.

## One intended behaviour change

A CRITICAL block that overruns the budget used to be truncated to whatever was left. It is now emitted whole and the budget overruns. A budget-sized cut is sized from what the block's siblings rendered, so one cache key would name two different texts. A test pins the new behaviour and its docstring says what the old one was.

## A cache bug fixed on the way

On Windows a prompt over 24,000 chars spills to a file. It spilled to one fixed path, `~/.pocketpaw/runtime/system_prompt.md`, and two defects fell out of that single filename.

Two concurrent large-prompt runs both wrote it, and whichever CLI started second read the other's prompt. `AgentPool` holds one instance per `agent_id`, so the desktop app can do this. Separately, `_behavior_prefix` returned `file:<path>` for the dict form, identical for every spilled prompt, so the warm client stopped rebuilding on prompt changes for exactly the prompts big enough to spill.

The name is now the content hash, which closes both. An identical prompt reuses the existing file instead of rewriting it, a new one lands via a pid-suffixed temp and an atomic replace, and the directory is pruned to a bounded number of files. The prune excludes the file about to be handed to the CLI rather than trusting it to sort newest, because filesystem timestamps are coarse enough for a burst of spills to tie.

## What this does not claim

`_behavior_prefix` is still not deleted, and its docstring now says why in the right place instead of promising that this PR would remove it. Two callers reach `run` without a digest: the pocket specialist, which builds an isolated backend and calls `backend.run` directly, bypassing the router that forwards; and any out-of-tree embedder, since `system_prompt` is a public parameter of the backend protocol. Deleting it would hand both a constant key, which is #1842 restored for the callers least able to notice.

On cache rate, the claim here is deliberately narrow. `_VOLATILE_PROMPT_MARKERS` are the cloud path's block headers, and the channel path emits `# Memory Context (already loaded...)` and `# Knowledge Base (relevant articles...)`, neither of which is in the tuple. So the per-message recall sits inside the retained prefix and can move it without any behaviour changing, which the digest does not do. That is a mechanism. Nobody has measured how often a live channel turn actually moves its recall, so this PR claims no hit-rate number. PA-9 has the harness for it.

## Found while measuring, not fixed here

`current_pocket` has no cap, because `_INJECTION_CAPS` never had an entry for it. A 300-widget pocket renders it at 34,988 chars, larger than the whole 32,000 budget, so the budget drops it whole and the agent loses the pocket id along with the instruction telling it to call `get_pocket`. On the pockets big enough to need that fetch, the agent is told the fetch does not exist. The old assembler skipped over-budget blocks the same way, so this is carried across rather than introduced, and both uncapped blocks are now explicit `max_chars = None` with the reason written down.

The 32,000 budget itself has no recorded justification. It arrived in April 2026 as "default 32K" with no measurement and no model named, and it is about 8,000 tokens. Raising it alone would make the pocket case worse, since the 35k block would then be included and the block's own text tells the model not to trust the widget summary it carries. The cap and the budget both wait on PA-9, which has the measurement harness, and on the follow-up that moves bulk pocket detail to the tool-result channel.

## Tests

42 new tests across the two stages. Each names in its docstring the mutation that must break it, and each mutation was applied and re-run rather than reasoned about. Two of the commits here exist because of that: `70c750d2` found a render-guard parametrisation that never reached the loader it claimed to exercise, and `171059cb` fixes a bug this refactor introduced, where a `MagicMock` bootstrap provider answering truthy to every attribute became the cache key and the digest called `.encode` on it.

The concurrency guard is worth a note. The bootstrap, memory and kb fetches run in one `asyncio.gather` and the kb one spawns a subprocess, but `assemble` renders layers in a sequential loop. Three self-fetching layers would pay their sum where the gather pays their max, so the gather stays in the builder and its results cross as plain data. An `asyncio.Barrier(3)` pins it: each stub waits for the other two, so any sequential arrangement deadlocks and the `wait_for` turns that into a failure rather than a hung suite.

Suite: 135 failed, 8886 passed, 14 skipped. The 135 are pre-existing and identical to the count on #1851's head; passed rose 42, which is the number of tests added.

## Docs

No files under `docs/` changed. This is internal prompt-assembly and cache-key work and nothing in `docs/` describes these internals. The rule asks for that to be said rather than left as an omission.
