### PR TITLE
Stop the current-pocket block from pricing itself out of the prompt

### DIFF
--- a/docs/api/configuration-reference.mdx
+++ b/docs/api/configuration-reference.mdx
@@ -9,6 +9,10 @@ tags: ["api", "configuration"]
 
 {/*
   docs/api/configuration-reference.mdx
+  Updated 2026-08-03 (feat/prompt-bulk-retrieval, PA-8a) — added the "Prompt
+  Assembly" section with prompt_pocket_summary_only, the default-off switch that
+  moves bulk pocket widget detail out of the system prompt and onto the
+  get_pocket tool-result path.
   Updated 2026-07-11 (feat/fst-8-harness, FST-8) — added the "Fabric" section
   with fabric_source_truth_mode (the off/shadow/enforce rollout switch) and
   its divergence-report enforce gate.
@@ -77,6 +81,14 @@ Cloud / subscription (PEE) only. The credit ledger and these knobs are inert on 
 | `tool_profile` | `POCKETPAW_TOOL_PROFILE` | enum | `full` | Tool profile (`minimal`, `coding`, `full`) |
 | `tools_allow` | `POCKETPAW_TOOLS_ALLOW` | string[] | `[]` | Allowed tools (comma-separated list) |
 | `tools_deny` | `POCKETPAW_TOOLS_DENY` | string[] | `[]` | Denied tools (comma-separated list) |
+
+## Prompt Assembly
+
+| Setting | Env Variable | Type | Default | Description |
+|---------|-------------|------|---------|-------------|
+| `prompt_pocket_summary_only` | `POCKETPAW_PROMPT_POCKET_SUMMARY_ONLY` | boolean | `false` | Keep bulk pocket widget detail out of the system prompt. `false` (default) is the block shipped today: `<current-pocket>` carries a JSON dump of the widget summary the client posted. `true` renders the cheap half only — pocket id, name, widget count and a snapshot stamp — plus the same standing order to call `mcp__pocketpaw_pocket__get_pocket`, so detail arrives as a tool result and costs nothing until it is asked for. On a 300-widget pocket the block drops from ~41,000 chars to ~1,700. |
+
+Independent of the flag, the `<current-pocket>` widget summary is bounded to 2,000 serialised characters (whole widgets only, with a `widgets_summary_truncated: showing N of M` line when anything is cut) and the pocket name to 200. Before that bound, a large pocket could render the block past the whole prompt budget, and the budget's answer was to drop the block whole — taking the pocket id and the `get_pocket` instruction with it, on exactly the pockets too large to answer without a fetch.
 
 ## Telegram
 

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1,6 +1,13 @@
 """Configuration management for PocketPaw.
 
 Changes:
+  - 2026-08-03 (PA-8a): Added ``prompt_pocket_summary_only`` (default False, env
+    POCKETPAW_PROMPT_POCKET_SUMMARY_ONLY) — takes the bulk widget dump out of
+    the channel prompt's ``<current-pocket>`` block, leaving the pocket id, the
+    name, the widget COUNT, a snapshot stamp and the standing order to call
+    ``get_pocket``. Default False is byte-for-byte today's block, so no deploy
+    is changed by shipping it; flipping it is a config/env change, not a code
+    change. Read by ``pocketpaw.prompt.channel.request.ChannelCurrentPocketLayer``.
   - 2026-07-11 (self-serve-analysis S1): Added ``fabric_analyst`` (default False,
     env POCKETPAW_FABRIC_ANALYST) — gates the Fabric transparent-analysis read
     engine (SQL GROUP BY aggregation + reasoning steps on FabricStore.query /
@@ -2023,6 +2030,24 @@ class Settings(BaseSettings):
     kb_limit: int = Field(
         default=3,
         description="Number of top articles to inject from kb search (default: 3)",
+    )
+    prompt_pocket_summary_only: bool = Field(
+        default=False,
+        description=(
+            "Keep bulk pocket widget detail OUT of the agent's system prompt. "
+            "False (default) is byte-for-byte the block shipped today: the "
+            "``<current-pocket>`` block carries a JSON dump of the widget "
+            "summary the client posted. True renders the CHEAP half only — "
+            "pocket id, name, widget count, a snapshot stamp — plus the same "
+            "standing order to call ``mcp__pocketpaw_pocket__get_pocket`` for "
+            "the detail, which is the tool-result path the detail belongs on. "
+            "Measured on a 300-widget pocket the block drops from ~41k chars to "
+            "~1.4k. Read per-render by "
+            "``pocketpaw.prompt.channel.request.ChannelCurrentPocketLayer``, so "
+            "flipping it is a config or env change and takes effect on the next "
+            "settings load — no code deploy. Set via "
+            "POCKETPAW_PROMPT_POCKET_SUMMARY_ONLY."
+        ),
     )
     ripple_manifest_url: str = Field(
         default="http://localhost:5174/manifest.json",

--- a/src/pocketpaw/prompt/channel/request.py
+++ b/src/pocketpaw/prompt/channel/request.py
@@ -1,6 +1,21 @@
 """The channel blocks built from THIS REQUEST — who asked, where, about what.
 
 Created: 2026-08-03 (PA-7a, feat/prompt-assembler-channel).
+Updated: 2026-08-03 (PA-8a, feat/prompt-bulk-retrieval) — ``current_pocket``
+  stops being able to price itself out of the prompt. The block dumped the
+  client's widget summary with no bound, so a 300-widget pocket rendered it at
+  ~41,000 chars against a 32,000-char budget and the budget dropped it WHOLE:
+  the id, the ``<current-pocket>`` tag and the ``get_pocket`` instruction went
+  with it, on exactly the pockets too big to answer without a fetch. Two changes
+  and one non-change. (1) The widget list is bounded BEFORE serialisation, whole
+  elements only, so the block has a constant ceiling and the tail — where the
+  instruction lives — is never what gets cut. (2) A new setting,
+  ``prompt_pocket_summary_only`` (default OFF), drops bulk detail entirely and
+  leaves id / name / widget COUNT / a snapshot stamp plus the same order to
+  fetch. (3) ``max_chars`` is still ``None``, and now for a reason: this
+  assembler's cap truncates the tail, so it would trade a missing block for a
+  corrupt one. Default-off, and byte-identical there for every input that does
+  not hit the new bound.
 
 Ten of the channel path's fifteen blocks, lifted out of
 ``AgentContextBuilder.build_system_prompt`` byte for byte. Every one of them is
@@ -42,6 +57,9 @@ that owns each one. Two of them were MISSING from that table and are therefore
 on any channel turn. That is recorded as an explicit ``max_chars = None`` with a
 note rather than left to read as an oversight — PA-9 is the task with the
 measurements to change it, and PA-7a's acceptance is that no byte moves.
+PA-8a came back with the measurements for ``current_pocket`` and the answer was
+NOT a cap: see :class:`ChannelCurrentPocketLayer`. ``pocket_context`` is still
+uncapped and still unmeasured.
 """
 
 from __future__ import annotations
@@ -49,6 +67,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+from typing import Any
 
 from pocketpaw.prompt.channel.inputs import ChannelInputs
 from pocketpaw.prompt.layer import LayerOutput, Priority, PromptContext
@@ -81,6 +100,143 @@ def _nonblank(text: str) -> str:
 def _short_digest(value: str) -> str:
     """16 hex chars of sha256 — the bound the rest of this package uses."""
     return hashlib.sha256(value.encode("utf-8", "replace")).hexdigest()[:16]
+
+
+# --------------------------------------------------------------------------
+# ``<current-pocket>`` bounds (PA-8a)
+# --------------------------------------------------------------------------
+# The two caller-supplied fields the block renders that have no bound on the
+# wire. ``api.v1.schemas.chat.PocketContext`` declares ``widgets: list[dict]``
+# and ``name: str`` with no ``max_length`` on either, and the block interpolates
+# both, so the block's length is whatever the client posted. Measured: a
+# 300-widget pocket renders it at ~41,000 chars, past the whole 32,000-char
+# default budget, and the budget answers by dropping the block WHOLE — taking
+# the pocket id and the ``get_pocket`` instruction with it. See
+# ``ChannelCurrentPocketLayer`` for why the bound is here and not a ``max_chars``.
+#
+# The numbers are the ones the cloud path already lives with: its pocket
+# preamble renders the first 12 widgets under a 1500-char ceiling
+# (``pocketpaw_ee.cloud.surface.handlers.pocket``), so 2000 chars of widget JSON
+# is a slightly more generous version of a bound that has been in production
+# since 2026-05-24. The name's 200 is not measured against anything — no real
+# pocket name is close to it, and it exists so the block's ceiling is a constant
+# rather than "a constant plus whatever the client sent".
+_WIDGET_SUMMARY_MAX_CHARS = 2000
+_POCKET_NAME_MAX_CHARS = 200
+
+
+def _bounded_widget_summary(widgets: Any) -> tuple[Any, int]:
+    """The head of ``widgets`` whose JSON fits the ceiling, and how many were cut.
+
+    WHOLE WIDGETS ONLY, and that is the entire point of doing this here rather
+    than letting the block be truncated after it is built. ``json.dumps`` output
+    cut at a character boundary is not JSON; the model reads a dangling
+    ``{"name": "Bur`` and has to guess whether the list ended. Admitting whole
+    elements keeps the value parseable at any bound.
+
+    Counted incrementally rather than by re-dumping the growing list, which
+    would be O(n^2) on the pockets this exists for. The arithmetic is exact
+    because ``json.dumps`` on a list at the default separators is
+    ``"[" + ", ".join(dumps(item)) + "]"`` — so one more element costs its own
+    dump plus the two-char ``", "``. Pinned by a test rather than trusted.
+
+    NON-LISTS AND UNSERIALISABLE ELEMENTS PASS STRAIGHT THROUGH, unbounded. Both
+    are shapes the wire schema says cannot happen and that ``metadata`` (a bare
+    ``dict`` on every channel) can nonetheless carry. Today the first renders as
+    whatever ``json.dumps`` makes of it and the second RAISES, which the
+    assembler's render guard turns into a dropped layer. Reproducing both
+    exactly keeps this function out of the byte-identity argument entirely: it
+    can only ever shorten a well-formed list.
+    """
+    if not isinstance(widgets, list):
+        return widgets, 0
+    kept: list = []
+    total = 2  # the enclosing "[]"
+    for widget in widgets:
+        try:
+            piece = json.dumps(widget)
+        except (TypeError, ValueError):
+            # Let the caller's own ``json.dumps`` raise on this input exactly as
+            # it does today, rather than inventing a rendering for it here.
+            return widgets, 0
+        cost = len(piece) + (2 if kept else 0)
+        if total + cost > _WIDGET_SUMMARY_MAX_CHARS:
+            break
+        kept.append(widget)
+        total += cost
+    return kept, len(widgets) - len(kept)
+
+
+def _bounded_name(value: Any) -> str:
+    """The pocket name as the block renders it, bounded to a constant.
+
+    Bounds the RENDERED form rather than the input, so a name that is not a
+    ``str`` (which the wire schema forbids and ``metadata`` permits) is bounded
+    too instead of interpolating a 10,000-element list into the prompt.
+    """
+    text = f"{value}"
+    if len(text) <= _POCKET_NAME_MAX_CHARS:
+        return text
+    return text[:_POCKET_NAME_MAX_CHARS] + "..."
+
+
+def _pocket_snapshot_stamp(pocket_context: dict) -> str:
+    """A content hash of the descriptor the block was rendered from.
+
+    THE FILED TASK ASKED FOR ``updatedAt`` AND IT IS THE ONE SIGNAL THAT CANNOT
+    BE USED. beanie's ``Initializer.init_actions`` skips ``_``-prefixed
+    attributes when it collects event hooks, and ``TimestampedDocument``'s hooks
+    are ``_set_created`` / ``_set_updated``, so neither ever registers and every
+    cloud document's ``updatedAt`` holds its construction-time value forever. A
+    stamp on it would review clean and report every edit as "unchanged" — a
+    freshness claim the field does not have. Same finding, independently, as
+    ``pocketpaw_ee.cloud.surface.handlers._helpers.content_key``'s note.
+
+    So: hash what we were actually given. ``sort_keys`` because a dict that
+    round-tripped through a client may not preserve order and a stamp that moved
+    on key order would report every turn as a change; ``default=str`` because
+    ``metadata`` is a bare ``dict`` and can carry a ``datetime``.
+
+    WHAT IT ATTESTS, precisely, because the name invites a stronger reading: the
+    DESCRIPTOR the client posted, not the stored pocket document. A pocket edited
+    by another user between two turns of this conversation moves this stamp only
+    once the client posts the new descriptor. It is the right signal anyway,
+    because the descriptor is what this block is a view of — a stamp over
+    something the block never read could not tell you whether the block is stale.
+    """
+    try:
+        serialised = json.dumps(pocket_context, sort_keys=True, default=str)
+    except (TypeError, ValueError, RecursionError):
+        # A descriptor that will not serialise still gets a stamp, because the
+        # alternative is raising out of ``render`` and losing the whole block —
+        # which is the failure PA-8a exists to close, arriving by a new route.
+        serialised = repr(pocket_context)
+    return _short_digest(serialised)
+
+
+def _summary_only() -> bool:
+    """Whether bulk widget detail is kept out of the block (PA-8a).
+
+    ``is True`` RATHER THAN A TRUTHINESS TEST, for the reason
+    :class:`ChannelIdentityLayer` spells out about ``isinstance``: several
+    suites hand this path a ``MagicMock`` settings object, and a mock's
+    auto-created attribute is TRUTHY. A bare ``if settings.x`` would silently
+    flip this flag ON inside every test that stubs settings — including the byte
+    goldens, whose entire job is to prove that it is OFF by default. The setting
+    is a pydantic ``bool``, so the real value is always ``True`` or ``False`` and
+    nothing legitimate is lost by demanding the former exactly.
+
+    Failures resolve to OFF rather than propagating. A layer that raises is
+    dropped by the assembler's render guard, and this is the layer whose absence
+    is the bug being fixed — a settings load that goes wrong must not cost the
+    agent its pocket id.
+    """
+    try:
+        from pocketpaw.config import get_settings
+
+        return getattr(get_settings(), "prompt_pocket_summary_only", False) is True
+    except Exception:  # pragma: no cover - defensive, see docstring
+        return False
 
 
 class ChannelIdentityLayer:
@@ -190,15 +346,13 @@ class ChannelSenderLayer:
         is_owner = sender_id == settings.owner_id
         role = "owner" if is_owner else "external user"
         block = (
-            f"\n# Current Conversation\n"
-            f"You are speaking with sender_id={sender_id} (role: {role})."
+            f"\n# Current Conversation\nYou are speaking with sender_id={sender_id} (role: {role})."
         )
         if is_owner:
             block += "\nThis is your owner."
         else:
             block += (
-                "\nThis is NOT your owner. Be helpful but do not share "
-                "owner-private information."
+                "\nThis is NOT your owner. Be helpful but do not share owner-private information."
             )
         # The text carries both the id and the role, so a digest of it moves on
         # a sender change AND on an owner-config change. Nothing is left for a
@@ -226,16 +380,49 @@ class ChannelPocketContextLayer:
 
 
 class ChannelCurrentPocketLayer:
-    """Which pocket is open, and the standing order to fetch it before answering."""
+    """Which pocket is open, and the standing order to fetch it before answering.
+
+    PA-8a IS ABOUT THE ONE LINE THAT MADE THIS BLOCK SELF-DEFEATING. It
+    ``json.dumps``-ed the client's widget summary with no bound, near the TOP,
+    while the SCOPE rules and the ``get_pocket`` instruction sit at the BOTTOM.
+    Measured on the real builder at the default 32,000-char budget, a
+    300-widget pocket rendered this at ~41,000 chars — larger than the whole
+    budget — so ``_fit_to_budget`` dropped it whole:
+
+        Dropped prompt layer 'channel.current_pocket' (34988 chars, priority
+        HIGH) — budget exhausted
+
+    and the agent lost the pocket id, the ``<current-pocket>`` tag AND the
+    instruction telling it the fetch exists. On exactly the pockets big enough
+    to need a fetch, it was told there was none.
+
+    A ``max_chars`` IS THE WRONG FIX AND STAYS ``None``. The assembler's cap
+    truncates the TAIL, so capping this block cuts away the instruction that
+    matters and leaves a half-serialised JSON dump where it used to be — it
+    turns a missing block into a corrupt one. The bound belongs on the widget
+    LIST, before serialisation, where it can drop whole elements and keep the
+    value parseable. See :func:`_bounded_widget_summary`. (Two tests also assert
+    this layer's ``max_chars`` is ``None``, on the grounds that the old
+    ``_INJECTION_CAPS`` never gave it one; they still pass, and now for a
+    reason rather than by inheritance.)
+
+    ``settings.prompt_pocket_summary_only`` (default OFF) is the second half:
+    ON, the block keeps the CHEAP summary — id, name, widget COUNT, a snapshot
+    stamp — and the same standing order to fetch, moving bulk detail onto the
+    tool-result path where a 300-widget pocket costs nothing until it is asked
+    for. OFF is byte-for-byte the block shipped before PA-8a for every input
+    that does not hit the bound.
+    """
 
     name = "channel.current_pocket"
     priority: Priority = Priority.HIGH
-    # UNCAPPED, inherited — see ``ChannelPocketContextLayer``. This is the more
-    # interesting of the two missing entries: the block ``json.dumps`` the
-    # widget summary straight into the prompt with no bound, so a pocket with
-    # many widgets writes an unbounded block. Left as-is deliberately; a cap
-    # here would move bytes on live pockets, which is PA-9's call to make with
-    # numbers rather than PA-7a's to make in passing.
+    # STILL UNCAPPED, and now on purpose rather than by inheritance from a table
+    # that had no row for it. The class docstring has the argument: this
+    # assembler's cap truncates the tail, and this block's tail is the
+    # ``get_pocket`` instruction. The ceiling this layer needs is enforced on its
+    # INPUTS instead (``_WIDGET_SUMMARY_MAX_CHARS``, ``_POCKET_NAME_MAX_CHARS``),
+    # which bounds the block to a constant plus the length of the pocket id
+    # without ever cutting a line of the text.
     max_chars: int | None = None
 
     async def render(self, ctx: PromptContext) -> LayerOutput:
@@ -244,13 +431,66 @@ class ChannelCurrentPocketLayer:
         if not pc:
             return LayerOutput(text="", cache_key=_short_digest(""))
 
+        # THE POCKET ID IS THE ONE FIELD WITH NO BOUND, deliberately. It is not
+        # display text — it is the literal argument of the ``get_pocket`` call
+        # this block exists to instruct, so a truncated id would produce a
+        # confidently wrong tool call, which is worse than the oversized block
+        # PA-8a is removing. Real ids are ObjectIds and uuids; the block's
+        # ceiling is therefore "a constant plus three times the id".
         pocket_id = pc.get("id", "unknown")
-        widget_summary = pc.get("widgets", [])
-        pocket_tag = (
-            f"\n<current-pocket>\n"
-            f"id: {pocket_id}\n"
-            f"name: {pc.get('name', 'Untitled')}\n"
-            f"widgets_summary: {json.dumps(widget_summary)}\n"
+        summary_only = _summary_only()
+
+        if summary_only:
+            widgets = pc.get("widgets", [])
+            count = len(widgets) if isinstance(widgets, (list, tuple, dict, str)) else 0
+            head = (
+                f"\n<current-pocket>\n"
+                f"id: {pocket_id}\n"
+                f"name: {_bounded_name(pc.get('name', 'Untitled'))}\n"
+                f"widgets_count: {count}\n"
+                f"snapshot: {_pocket_snapshot_stamp(pc)}\n"
+            )
+            note = (
+                "NOTE: this block deliberately carries NO widget detail.\n"
+                "`widgets_count` is the only shape hint here, and it reads 0\n"
+                "for a UISpec-tree pocket whose content lives in\n"
+                "rippleSpec.ui — 0 does NOT mean the pocket is empty. Widget\n"
+                "names, types, layout and data are NOT in this prompt; the\n"
+                "call below is the only way to see them.\n"
+                "`snapshot` is a content hash of the pocket descriptor this\n"
+                "block was built from. If you have seen a different snapshot\n"
+                "value in this conversation, the pocket changed and anything\n"
+                "you remember about its contents is stale — fetch it again.\n"
+            )
+        else:
+            bounded, omitted = _bounded_widget_summary(pc.get("widgets", []))
+            head = (
+                f"\n<current-pocket>\n"
+                f"id: {pocket_id}\n"
+                f"name: {_bounded_name(pc.get('name', 'Untitled'))}\n"
+                f"widgets_summary: {json.dumps(bounded)}\n"
+            )
+            if omitted:
+                # Emitted ONLY when something was actually cut, so a pocket
+                # inside the bound renders the bytes it always did. A truncated
+                # list that does not say it is truncated is a lie the model has
+                # no way to catch — it would read a complete-looking JSON array
+                # and conclude the pocket has 12 widgets.
+                head += (
+                    f"widgets_summary_truncated: showing {len(bounded)} of "
+                    f"{len(bounded) + omitted} — call get_pocket below for the rest\n"
+                )
+            note = (
+                "NOTE: `widgets_summary` is a shallow hint (names + types)\n"
+                "and is OFTEN EMPTY for UISpec-tree pockets — absence here\n"
+                "does NOT mean the pocket is empty. The real content lives\n"
+                "in rippleSpec.ui.\n"
+            )
+
+        # SCOPE and the fetch instruction are byte-identical in both modes and
+        # are written once. They are the part of the block that must survive
+        # every bound — the reason the block exists at all.
+        scope = (
             f"\n"
             f"SCOPE — read this carefully before doing anything:\n"
             f'In this conversation, "pocket" / "this pocket" / "the\n'
@@ -265,10 +505,8 @@ class ChannelCurrentPocketLayer:
             f"shell, file_edit, grep, or web_search for pocket\n"
             f"operations — they cannot read or write the document.\n"
             f"\n"
-            f"NOTE: `widgets_summary` is a shallow hint (names + types)\n"
-            f"and is OFTEN EMPTY for UISpec-tree pockets — absence here\n"
-            f"does NOT mean the pocket is empty. The real content lives\n"
-            f"in rippleSpec.ui.\n"
+        )
+        fetch = (
             f"\n"
             f"BEFORE answering any question about this pocket's contents,\n"
             f"widgets, layout, data, or configuration, you MUST first call:\n"
@@ -279,6 +517,14 @@ class ChannelCurrentPocketLayer:
             f"the summary above.\n"
             f"</current-pocket>\n"
         )
+        pocket_tag = head + scope + note + fetch
+        # KEYED ON WHAT WAS RENDERED, in both modes, which is the discipline
+        # ``surface.handlers._helpers.content_key`` argues for: the digest
+        # cannot hold still while the prompt moves, and what a bound dropped is
+        # not in the prompt, so no cached prompt is stale for it. In
+        # summary-only mode the snapshot stamp is IN the text, so this key
+        # reaches every descriptor change even though the rendered detail no
+        # longer does — the stamp is what buys that, not a second key rule.
         return LayerOutput(text=_nonblank(pocket_tag), cache_key=_short_digest(pocket_tag))
 
 

--- a/tests/test_prompt_pocket_summary.py
+++ b/tests/test_prompt_pocket_summary.py
@@ -1,0 +1,510 @@
+# tests/test_prompt_pocket_summary.py
+# Created: 2026-08-03 (PA-8a, feat/prompt-bulk-retrieval) — the bound on
+# ``channel.current_pocket`` and the setting that takes bulk widget detail out
+# of the prompt entirely.
+#
+# WHAT THIS FILE IS ABOUT. The block carried an unbounded ``json.dumps`` of the
+# client's widget summary near its TOP, and the SCOPE rules plus the
+# ``get_pocket`` instruction at its BOTTOM. Measured on the real builder at the
+# default 32,000-char budget, a 300-widget pocket rendered it at ~41,000 chars —
+# larger than the entire budget — so ``_fit_to_budget`` dropped it whole and the
+# agent lost the pocket id AND the standing order to fetch. The pockets big
+# enough to need a fetch were the pockets told there wasn't one.
+#
+# WHY NOT A ``max_chars``, since that is the obvious fix and the one this file
+# actively argues against: the assembler's cap truncates the TAIL. On this block
+# the tail is the instruction, so a cap turns a missing block into a corrupt one
+# with half a JSON array in it. ``test_capping_the_rendered_block_would_break_the_json``
+# demonstrates that failure directly rather than asserting it in prose.
+#
+# The byte-identity half of the acceptance lives in
+# ``tests/test_channel_prompt_goldens.py`` (six full-prompt shapes) and is
+# duplicated at the LAYER level here by
+# ``test_the_flag_off_block_is_the_shipped_bytes``, which hard-codes the
+# pre-PA-8a text rather than comparing the implementation with itself.
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from pocketpaw.bootstrap.context_builder import _DEFAULT_BUDGET_CHARS
+from pocketpaw.config import Settings
+from pocketpaw.prompt import assemble, prompt_layer_registry
+from pocketpaw.prompt.channel import ChannelInputs
+from pocketpaw.prompt.channel.request import (
+    _POCKET_NAME_MAX_CHARS,
+    _WIDGET_SUMMARY_MAX_CHARS,
+    ChannelCurrentPocketLayer,
+    _bounded_widget_summary,
+)
+from pocketpaw.prompt.layer import PromptContext
+
+pytestmark = pytest.mark.asyncio
+
+_LAYER = ChannelCurrentPocketLayer()
+
+
+def _ctx(pocket_context: dict | None) -> PromptContext:
+    return PromptContext(
+        instance=None,
+        agent_id="",
+        message="",
+        instructions="",
+        knowledge_context="",
+        system_message_override=None,
+        channel_inputs=ChannelInputs(metadata={"pocket_context": pocket_context}),
+    )
+
+
+def _widgets(count: int) -> list[dict]:
+    """The shape the measurement was taken on — a real pocket's widget rows."""
+    return [
+        {
+            "id": f"w-{i:03d}",
+            "name": f"Widget {i}",
+            "type": "chart",
+            "title": f"Some widget title {i}",
+            "props": {"source": "api", "refresh": 30},
+        }
+        for i in range(count)
+    ]
+
+
+def _pocket(count: int, **overrides) -> dict:
+    pc = {"id": "pk-123", "name": "Launch Tracker", "widgets": _widgets(count)}
+    pc.update(overrides)
+    return pc
+
+
+def _summary_line(block: str, key: str) -> str:
+    """The value of a ``key: value`` line in the block, or ``""`` if absent."""
+    for line in block.splitlines():
+        if line.startswith(f"{key}: "):
+            return line[len(key) + 2 :]
+    return ""
+
+
+def _flag_on(monkeypatch, value: bool = True) -> None:
+    """Flip ``prompt_pocket_summary_only`` with a REAL bool, not a mock attribute."""
+    settings = MagicMock()
+    settings.prompt_pocket_summary_only = value
+    monkeypatch.setattr("pocketpaw.config.get_settings", lambda *a, **k: settings)
+
+
+# ---------------------------------------------------------------------------
+# The failure PA-8a exists to close
+# ---------------------------------------------------------------------------
+
+
+async def test_a_300_widget_pocket_no_longer_loses_its_whole_block_to_the_budget():
+    """The headline. A big pocket keeps its id and its fetch instruction.
+
+    Assembled at ``_DEFAULT_BUDGET_CHARS`` — the budget the channel path
+    actually passes — which is the condition under which the unbounded block
+    was dropped whole.
+
+    MUTATION: set ``_WIDGET_SUMMARY_MAX_CHARS`` to ``10**9`` in
+    ``prompt/channel/request.py`` (the pre-PA-8a rendering). The block goes
+    back over 40,000 chars, ``_fit_to_budget`` removes it, and all four
+    assertions below fail at once.
+    """
+    layers = [prompt_layer_registry.get("channel.current_pocket")]
+    result = await assemble(layers, _ctx(_pocket(300)), budget_chars=_DEFAULT_BUDGET_CHARS)
+
+    assert [d.name for d in result.dropped] == []
+    assert "<current-pocket>" in result.text
+    assert "id: pk-123" in result.text
+    assert "mcp__pocketpaw_pocket__get_pocket" in result.text
+
+
+async def test_the_block_has_a_ceiling_no_pocket_can_push_past():
+    """Every caller-supplied field the block RENDERS is bounded, so its size is
+    a constant plus the pocket id.
+
+    ``widgets`` and ``name`` both arrive from the wire with no ``max_length``
+    (``api.v1.schemas.chat.PocketContext``), and ``metadata`` is a bare ``dict``
+    on every channel, so neither is a hypothetical. The id is deliberately NOT
+    bounded — it is the literal argument of the ``get_pocket`` call, and a
+    truncated id would produce a confidently wrong tool call.
+
+    MUTATION: delete the ``_bounded_name`` call in the layer's ``else`` branch.
+    The 20,000-char name lands in the block whole and the ceiling assertion
+    fails by an order of magnitude.
+    """
+    pathological = _pocket(10_000, name="N" * 20_000)
+    block = (await _LAYER.render(_ctx(pathological))).text
+
+    # 1215 chars of fixed text for a short id, plus the two bounds, plus slack.
+    ceiling = 1215 + _WIDGET_SUMMARY_MAX_CHARS + _POCKET_NAME_MAX_CHARS + 500
+    assert len(block) < ceiling
+    # And far enough under the budget that nothing plausible above it can push
+    # this block out — the property the whole task is about.
+    assert len(block) < _DEFAULT_BUDGET_CHARS // 8
+
+
+# ---------------------------------------------------------------------------
+# The bound: whole widgets, before serialisation
+# ---------------------------------------------------------------------------
+
+
+async def test_the_bounded_summary_is_still_parseable_json():
+    """The bound drops whole elements, so ``widgets_summary`` stays valid JSON.
+
+    MUTATION: in the layer's ``else`` branch, replace ``json.dumps(bounded)``
+    with ``json.dumps(pc.get("widgets", []))[:_WIDGET_SUMMARY_MAX_CHARS]`` —
+    the "cap the rendered text" fix. ``json.loads`` below raises
+    ``JSONDecodeError`` on the dangling object.
+    """
+    block = (await _LAYER.render(_ctx(_pocket(300)))).text
+    parsed = json.loads(_summary_line(block, "widgets_summary"))
+
+    assert isinstance(parsed, list)
+    assert parsed  # something survived; the bound is not "drop everything"
+    assert all(isinstance(w, dict) and "name" in w for w in parsed)
+
+
+async def test_the_bound_admits_the_longest_prefix_that_fits():
+    """The incremental char accounting is EXACT, not approximate.
+
+    ``json.dumps`` on a list at the default separators is
+    ``"[" + ", ".join(dumps(item)) + "]"``, so one more element costs its own
+    dump plus two chars. The function relies on that to avoid re-dumping a
+    growing list; this pins it from both sides — what was kept fits, and one
+    more would not.
+
+    TINY WIDGETS ARE THE CASE THAT CATCHES A WRONG SEPARATOR, and this test
+    initially had none. With ~130-char widgets the bound admits ~15 of them, so
+    forgetting the two-char separator under-counts by ~28 chars — not enough to
+    let one more 130-char element in, and the error is invisible. With 8-char
+    widgets it under-counts by hundreds and admits ~50 too many. A rounding bug
+    that only shows on small elements is exactly the kind a fixture of one shape
+    misses.
+
+    MUTATION: drop the separator from the cost in ``_bounded_widget_summary``
+    (``cost = len(piece)``). The tiny-widget row admits 249 elements that
+    serialise to 2,490 chars and the "what was kept fits" assertion fails.
+    """
+    shapes = {
+        "measured": _widgets,
+        # 8 chars each, so the separator is a fifth of the per-element cost.
+        "tiny": lambda n: [{"n": i} for i in range(n)],
+        # One element that on its own blows the whole ceiling.
+        "oversized": lambda n: [{"blob": "x" * 4000} for _ in range(n)],
+    }
+    for label, maker in shapes.items():
+        for count in (1, 5, 17, 300):
+            widgets = maker(count)
+            kept, omitted = _bounded_widget_summary(widgets)
+
+            assert len(json.dumps(kept)) <= _WIDGET_SUMMARY_MAX_CHARS, (label, count)
+            assert kept == widgets[: len(kept)], (label, count)
+            assert omitted == count - len(kept), (label, count)
+            if omitted:
+                one_more = widgets[: len(kept) + 1]
+                assert len(json.dumps(one_more)) > _WIDGET_SUMMARY_MAX_CHARS, (label, count)
+
+
+async def test_a_truncated_list_says_that_it_is_truncated():
+    """A cut list that looks complete is a lie the model cannot catch.
+
+    MUTATION: delete the ``if omitted:`` branch in the layer. The 300-widget
+    block then presents a complete-looking 12-element array and the marker
+    assertion fails; the small-pocket half of this test still passes, which is
+    the point of asserting both.
+    """
+    big = (await _LAYER.render(_ctx(_pocket(300)))).text
+    kept = len(json.loads(_summary_line(big, "widgets_summary")))
+    assert f"widgets_summary_truncated: showing {kept} of 300" in big
+
+    # ...and stays silent when nothing was cut, or every small pocket's bytes
+    # would move.
+    small = (await _LAYER.render(_ctx(_pocket(1)))).text
+    assert "widgets_summary_truncated" not in small
+
+
+async def test_an_unserialisable_widget_fails_exactly_as_it_did_before():
+    """The bound must not quietly RESCUE an input that used to raise.
+
+    ``json.dumps`` on a ``set`` raises ``TypeError`` today, the assembler's
+    render guard turns that into a dropped layer, and inventing a rendering
+    here would be a behaviour change smuggled in under a size fix. So the bound
+    steps aside and lets the original call raise.
+
+    MUTATION: in ``_bounded_widget_summary``, ``continue`` past an
+    unserialisable widget instead of returning. No exception is raised and
+    ``pytest.raises`` fails.
+    """
+    with pytest.raises(TypeError):
+        await _LAYER.render(_ctx({"id": "pk-1", "name": "N", "widgets": [{"tags": {1, 2}}]}))
+
+
+async def test_a_non_list_widgets_value_passes_through_untouched():
+    """``metadata`` is a bare dict on every channel and can carry anything.
+
+    MUTATION: drop the ``isinstance(widgets, list)`` guard in
+    ``_bounded_widget_summary``. Iterating a dict yields its KEYS, so the block
+    renders ``["a", "b"]`` instead of the object and this fails.
+    """
+    block = (await _LAYER.render(_ctx({"id": "pk-1", "name": "N", "widgets": {"a": 1}}))).text
+    assert _summary_line(block, "widgets_summary") == '{"a": 1}'
+
+
+# ---------------------------------------------------------------------------
+# Byte identity with the flag off
+# ---------------------------------------------------------------------------
+
+# The block EXACTLY as ``ChannelCurrentPocketLayer.render`` built it before
+# PA-8a, transcribed from the source rather than captured from the current
+# implementation — a golden generated by the thing it guards proves nothing.
+_SHIPPED_BLOCK = (
+    "\n<current-pocket>\n"
+    "id: pk-123\n"
+    "name: Launch Tracker\n"
+    'widgets_summary: [{"name": "Burndown", "type": "chart"}]\n'
+    "\n"
+    "SCOPE — read this carefully before doing anything:\n"
+    'In this conversation, "pocket" / "this pocket" / "the\n'
+    'pocket" always means THIS workspace dashboard\n'
+    "(id ``pk-123``) — a MongoDB document the user is\n"
+    "viewing on screen. It is NOT the PocketPaw application,\n"
+    "NOT the source tree on disk, NOT any file under\n"
+    '``D:\\paw`` or ``backend/`` or ``ee/cloud/``. "Edit the\n'
+    'pocket", "add a widget", "more widgets" all refer to\n'
+    "this document — operate on it through the\n"
+    "``mcp__pocketpaw_pocket__*`` tools ONLY. Do NOT use\n"
+    "shell, file_edit, grep, or web_search for pocket\n"
+    "operations — they cannot read or write the document.\n"
+    "\n"
+    "NOTE: `widgets_summary` is a shallow hint (names + types)\n"
+    "and is OFTEN EMPTY for UISpec-tree pockets — absence here\n"
+    "does NOT mean the pocket is empty. The real content lives\n"
+    "in rippleSpec.ui.\n"
+    "\n"
+    "BEFORE answering any question about this pocket's contents,\n"
+    "widgets, layout, data, or configuration, you MUST first call:\n"
+    "  tool: mcp__pocketpaw_pocket__get_pocket\n"
+    '  args: {"pocket_id": "pk-123"}\n'
+    "That returns the full document (rippleSpec, widgets,\n"
+    "metadata, visibility). Base your answer on that, not on\n"
+    "the summary above.\n"
+    "</current-pocket>\n"
+)
+
+
+async def test_the_flag_off_block_is_the_shipped_bytes():
+    """Default-off renders the pre-PA-8a block, byte for byte.
+
+    MUTATION: change one character of the SCOPE or fetch text in the layer —
+    e.g. ``must first call`` for ``MUST first call``. Fails on the diff.
+    """
+    pc = {
+        "id": "pk-123",
+        "name": "Launch Tracker",
+        "widgets": [{"name": "Burndown", "type": "chart"}],
+    }
+    assert (await _LAYER.render(_ctx(pc))).text == _SHIPPED_BLOCK
+
+
+async def test_a_mock_settings_object_does_not_flip_the_flag_on():
+    """A ``MagicMock``'s auto-created attribute is TRUTHY, and six suites stub
+    settings with one — including the byte goldens.
+
+    A bare ``if settings.prompt_pocket_summary_only`` would silently turn this
+    feature ON inside every one of them, and the goldens would fail with a
+    diff that looks like the feature working.
+
+    MUTATION: change ``is True`` to a plain truthiness test in
+    ``_summary_only``. The mock reads as ON, the block loses
+    ``widgets_summary``, and this fails.
+    """
+    settings = MagicMock()  # nothing configured — the trap
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("pocketpaw.config.get_settings", lambda *a, **k: settings)
+        block = (await _LAYER.render(_ctx(_pocket(1)))).text
+    assert "widgets_summary:" in block
+    assert "widgets_count:" not in block
+
+
+async def test_a_settings_failure_does_not_cost_the_agent_its_pocket_id():
+    """Reading the flag must not be able to raise out of ``render``.
+
+    A raising layer is dropped by the assembler's guard — which is precisely
+    the failure PA-8a closes, arriving through a new route.
+
+    MUTATION: remove the ``try/except`` from ``_summary_only``. The block is
+    dropped, ``result.text`` is empty, and both assertions fail.
+    """
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("config on fire")
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("pocketpaw.config.get_settings", _boom)
+        result = await assemble(
+            [prompt_layer_registry.get("channel.current_pocket")],
+            _ctx(_pocket(1)),
+            budget_chars=_DEFAULT_BUDGET_CHARS,
+        )
+    assert result.dropped == []
+    assert "mcp__pocketpaw_pocket__get_pocket" in result.text
+
+
+# ---------------------------------------------------------------------------
+# The setting
+# ---------------------------------------------------------------------------
+
+
+async def test_the_setting_is_off_by_default_and_reads_from_the_environment(monkeypatch):
+    """Default OFF, and flippable without a code change.
+
+    ``async`` only because this module carries a file-level ``asyncio`` mark; it
+    awaits nothing.
+
+    MUTATION: change the field's ``default`` to ``True`` in ``config.py``. The
+    first assertion fails — and so does every golden, which is the safety net
+    working as designed.
+    """
+    assert Settings().prompt_pocket_summary_only is False
+    monkeypatch.setenv("POCKETPAW_PROMPT_POCKET_SUMMARY_ONLY", "true")
+    assert Settings().prompt_pocket_summary_only is True
+
+
+async def test_the_flag_on_block_keeps_the_id_the_count_and_the_fetch_order(monkeypatch):
+    """ON: the cheap half survives, the bulk detail does not.
+
+    MUTATION: leave the ``widgets_summary`` line in the summary-only head. The
+    ``not in`` assertion fails and the block is no longer cheap.
+    """
+    _flag_on(monkeypatch)
+    block = (await _LAYER.render(_ctx(_pocket(300)))).text
+
+    assert "id: pk-123" in block
+    assert "name: Launch Tracker" in block
+    assert "widgets_count: 300" in block
+    assert "mcp__pocketpaw_pocket__get_pocket" in block
+    assert 'args: {"pocket_id": "pk-123"}' in block
+    # The whole point: no widget detail at all.
+    assert "widgets_summary" not in block
+    assert "Widget 0" not in block
+    assert "Some widget title" not in block
+
+
+async def test_the_flag_on_block_measurably_drops(monkeypatch):
+    """The number behind "drops measurably", on the 300-widget shape.
+
+    MUTATION: none needed to make it fail meaningfully — it fails the moment
+    the summary-only branch starts carrying detail again. Kept as a measured
+    assertion rather than a comment so the claim cannot rot.
+    """
+    off = (await _LAYER.render(_ctx(_pocket(300)))).text
+    _flag_on(monkeypatch)
+    on = (await _LAYER.render(_ctx(_pocket(300)))).text
+
+    assert len(on) < 2_000
+    assert len(on) < len(off) / 2
+
+
+# ---------------------------------------------------------------------------
+# The snapshot stamp
+# ---------------------------------------------------------------------------
+
+
+async def test_the_snapshot_moves_on_an_edit_the_summary_cannot_show(monkeypatch):
+    """The stamp is why a lossy summary is still safe to cache on.
+
+    Two pockets with the SAME widget count and a different widget: everything
+    the summary-only block prints is identical, so without the stamp the two
+    would render byte-identical text and hash to one cache key. A backend
+    caching an agent on the prompt digest would serve the first pocket's prompt
+    for the second.
+
+    MUTATION: delete the ``snapshot:`` line from the summary-only head. Both
+    assertions fail — the texts become equal and so do the keys.
+    """
+    _flag_on(monkeypatch)
+    before = await _LAYER.render(_ctx(_pocket(3)))
+
+    edited = _pocket(3)
+    edited["widgets"][1]["title"] = "renamed"
+    after = await _LAYER.render(_ctx(edited))
+
+    assert "widgets_count: 3" in before.text and "widgets_count: 3" in after.text
+    assert before.text != after.text
+    assert before.cache_key != after.cache_key
+
+
+async def test_the_snapshot_holds_still_when_nothing_moved(monkeypatch):
+    """...including across key ORDER, which a client round-trip can change.
+
+    A stamp that moved on key order would report every turn as a change and
+    rebuild the backend's cached agent for nothing — on the Claude SDK backend
+    that is a ~12s reconnect.
+
+    MUTATION: drop ``sort_keys=True`` from ``_pocket_snapshot_stamp``. The
+    reordered descriptor hashes differently and the second assertion fails.
+    """
+    _flag_on(monkeypatch)
+    first = (await _LAYER.render(_ctx(_pocket(3)))).text
+    again = (await _LAYER.render(_ctx(_pocket(3)))).text
+    assert _summary_line(first, "snapshot") == _summary_line(again, "snapshot")
+
+    reordered = {"widgets": _widgets(3), "name": "Launch Tracker", "id": "pk-123"}
+    shuffled = (await _LAYER.render(_ctx(reordered))).text
+    assert _summary_line(shuffled, "snapshot") == _summary_line(first, "snapshot")
+
+
+async def test_an_unserialisable_descriptor_still_gets_a_stamp(monkeypatch):
+    """A stamp that could raise would lose the block it is stamping.
+
+    ``metadata`` is a bare dict; a ``datetime`` in it is ordinary and a
+    self-referential dict is not impossible. Neither may cost the agent its
+    pocket id.
+
+    MUTATION: remove the ``try/except`` from ``_pocket_snapshot_stamp``.
+    ``render`` raises ``ValueError`` on the cycle and this fails.
+    """
+    _flag_on(monkeypatch)
+    cyclic: dict = {"id": "pk-1", "name": "N", "widgets": []}
+    cyclic["self"] = cyclic
+
+    block = (await _LAYER.render(_ctx(cyclic))).text
+    assert len(_summary_line(block, "snapshot")) == 16
+
+
+async def test_capping_the_rendered_block_would_break_the_json():
+    """The argument against ``max_chars``, demonstrated rather than asserted.
+
+    A cap sized to hold this block inside the budget lands mid-``json.dumps``,
+    so the model reads a dangling object AND loses the ``get_pocket``
+    instruction that lives at the bottom. This is what the layer would do if it
+    declared a ``max_chars`` instead of bounding its input, and it is why it
+    does not.
+
+    MUTATION: none — this test describes the rejected design, so it fails only
+    if the block's shape changes such that a tail cut becomes harmless (i.e.
+    the instruction moved to the top). That would be a real finding.
+    """
+    from pocketpaw.prompt.assembler import _apply_cap
+
+    block = (await _LAYER.render(_ctx(_pocket(300)))).text
+    capped = _apply_cap("channel.current_pocket", block, 1500, [])
+
+    assert "mcp__pocketpaw_pocket__get_pocket" not in capped
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(_summary_line(capped, "widgets_summary"))
+
+
+async def test_the_layer_still_declares_no_max_chars():
+    """``max_chars`` stays ``None`` — now for a reason, not by inheritance.
+
+    ``tests/test_context_budget.py`` asserts the same thing on the grounds that
+    the old ``_INJECTION_CAPS`` had no row for this block. This restates it as a
+    PA-8a decision so a future reader does not "finish the job" by adding one.
+
+    MUTATION: give ``ChannelCurrentPocketLayer`` a ``max_chars``. Fails here and
+    in ``test_context_budget.py``.
+    """
+    assert prompt_layer_registry.get("channel.current_pocket").max_chars is None


### PR DESCRIPTION
Stacked on #1852, which is stacked on #1851. Review those first; this branch is based on #1852's head, not on `dev`.

## The bug

`<current-pocket>` tells the agent which pocket is open, and ends with the standing order to call `mcp__pocketpaw_pocket__get_pocket` before answering anything about it. The block interpolated the client's widget summary with no bound, because the old `_INJECTION_CAPS` table had no entry for it.

Measured on the real builder at the default 32,000-char budget, a 300-widget pocket renders that block at 34,988 chars, which is larger than the entire budget:

```
Dropped prompt layer 'channel.current_pocket' (34988 chars, priority HIGH) — budget exhausted
```

The budget drops it whole. The agent then has no pocket id, no `<current-pocket>` tag, and no instruction to fetch. On exactly the pockets too big to answer without a fetch, it is told the fetch does not exist.

This is not new. The old assembler skipped over-budget blocks the same way, so it has been true for as long as the block has been uncapped.

## The fix, and why it is not a cap

The widget list is bounded before serialisation, whole elements only.

`max_chars` would have been the obvious lever and it is the wrong one. This assembler's cap truncates the tail, and in this block the widget JSON sits near the top while the SCOPE rules and the fetch instruction sit at the bottom. Capping it would cut off the instruction worth keeping and leave a dangling `{"name": "Bur` where the list used to be. Bounding whole elements keeps the value parseable at any size and keeps the tail intact. `max_chars` stays `None`, now with that reason written next to it.

The bound is 2000 chars of widget JSON, chosen against something rather than by feel: the cloud path's pocket preamble has rendered the first 12 widgets under a 1500-char ceiling since May, so this is a slightly more generous version of a bound already in production. The 200-char pocket-name bound is not measured against anything, and says so — it exists so the block's ceiling is a constant instead of a constant plus whatever the client sent.

## The setting, and what it is actually worth

`POCKETPAW_PROMPT_POCKET_SUMMARY_ONLY`, default off. On, the block keeps the id, the name, the widget count, a snapshot stamp and the same order to fetch, and drops the widget dump.

Being straight about the numbers, because the framing matters more than the win:

```
                    flag off     flag on
1-widget pocket      14,910      15,193     +283
300-widget pocket    16,775      15,195   -1,580
```

The bound does the work. It ships regardless of the flag and takes the block from 34,988 chars to under 2,000. The flag on top saves about 1,580 chars on a large pocket and costs 283 on a small one, because the stamp and count text outweigh the tiny widget dump they replace.

What the flag really buys is a block that is constant size: 2 chars of variance across that whole range instead of 1,865. That is worth having, since a block whose length tracks pocket size is a block that moves the cache key every time somebody adds a widget. It is not a large token saving, and this PR does not claim one.

## The snapshot stamp is not `updatedAt`

The task this came from asked for `updatedAt` as the freshness signal. It is the one field that cannot be used. beanie's `Initializer.init_actions` skips `_`-prefixed attributes when collecting event hooks, and `TimestampedDocument`'s hooks are `_set_created` and `_set_updated`, so neither ever registers and the field holds its construction-time value for the life of the document. A stamp on it would review clean and report every edit as unchanged. The same rejection is already documented in `surface/handlers/_helpers.content_key`, found independently at PA-2.

So the stamp is a content hash of the descriptor, with `sort_keys` so a client's key reordering does not read as an edit. It attests the descriptor the client posted, not the stored pocket document, and the docstring says so — a pocket edited by another user moves this stamp only once the client posts the new descriptor.

## Tests

18 new tests. Each names in its docstring the mutation that must break it, and each was applied and re-run rather than reasoned about. The load-bearing one: raise `_WIDGET_SUMMARY_MAX_CHARS` to ten million and three tests fail while the original 34,988-char drop returns exactly.

With the flag off, every channel prompt is byte-for-byte what it was before this whole line of work started. That is checked against a probe captured at the pre-refactor commit, independent of the goldens in the two PRs below this one.

Suite: 135 failed, 8904 passed, 14 skipped. The 135 are pre-existing and unchanged from #1852's head; passed rose 18, which is the number of tests added.

## Not done here

The filed task also asked to move KB injection to the tool-result path. There is no tool-result path for KB — nothing in `tools/`, `tools/builtin/` or the EE MCP servers exposes kb-go to the agent. That half needs a retrieval tool built first, and it carries a scope-isolation constraint worth stating before anyone starts: `_resolve_kb_scopes` currently runs server-side, and its docstring is explicit that the caller alone decides whether a member-private `user:` scope is in play, because the resolver cannot see room membership. A tool that accepts a scope argument would hand that decision to a model that can be prompt-injected.

The acceptance also asked for a live smoke on the real run path. Not run. Treat the end-to-end behaviour as unverified.

## Docs

`docs/api/configuration-reference.mdx` gains the new setting.
