### PR TITLE
Measure the inherited prompt caps instead of guessing them

### DIFF
--- a/ee/pocketpaw_ee/cloud/surface/handlers/_helpers.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/_helpers.py
@@ -7,6 +7,14 @@
 # audit-snapshot lines, etc.). Pulling these out keeps each handler
 # small (≤80 LOC) per the PR brief.
 #
+# Changes: 2026-08-03 (PA-9, feat/prompt-budget-measurement) — both preamble
+# caps now carry their measured cost, and the 12-widget cut moved here from a
+# bare literal in ``handlers/pocket.py`` as ``WIDGET_PREVIEW_LIMIT`` so the two
+# caps that jointly bound the pocket preamble live together. Measurement showed
+# they do not currently interact (12 widgets renders at 609 of 1500 chars), which
+# is exactly the kind of thing that was previously true by luck and unasserted;
+# ``tests/cloud/surface/test_preamble_caps.py`` now holds it.
+#
 # Changes: 2026-08-02 (PA-2, feat/prompt-assembler-seam) — added the two
 # cache-key builders every handler now needs to answer ``SurfacePreamble``'s
 # ``cache_key``. The split is by what the handler READS, and there are only two
@@ -31,7 +39,33 @@ logger = logging.getLogger(__name__)
 
 # Preamble length cap. Soft cap — we never split mid-tag, just truncate
 # the trailing lines and append an ellipsis marker.
+#
+# MEASURED 2026-08-03 (PA-9): 1500 chars is 378 tokens on the live route
+# (scripts/evals/prompt_cache_eval.py --arm caps). That is the per-turn,
+# per-surface price of this cap, and it is small enough that the number alone
+# argues for neither raising nor lowering it. KEPT at 1500. What was NOT
+# measured is fit — whether real preambles are losing content to the truncation
+# — because that needs production pocket data this harness has no access to. If
+# you are here because a preamble looks cut off, that is the unmeasured half.
 PREAMBLE_MAX_CHARS = 1500
+
+# How many widgets the pocket preamble lists before collapsing the rest into a
+# "... (+N more)" line. Extracted from a bare ``widgets[:12]`` literal in
+# ``handlers/pocket.py`` by PA-9 so the two caps that jointly bound this preamble
+# sit together and their interaction is visible — and testable.
+#
+# MEASURED 2026-08-03 (PA-9): a rendered widget line averages 36.2 chars, so 12
+# lines cost 434 chars and the full 300-widget preamble renders at 609 chars —
+# 41% of PREAMBLE_MAX_CHARS. The two caps do NOT interact today: ~36 widgets
+# would still fit under 1500.
+#
+# KEPT at 12 anyway, and the reason is not token cost. This preamble's text is
+# digested into the surface ``cache_key`` (see ``handlers/pocket.py``), so every
+# extra widget listed is another edit that moves the key and buys a cache
+# invalidation — roughly a 12s reconnect on the Claude SDK backend. Raising the
+# limit trades ~30 tokens per extra widget (cheap, measured) against a reconnect
+# rate (expensive, NOT measured). Measure the invalidation side before moving it.
+WIDGET_PREVIEW_LIMIT = 12
 
 
 def truncate_preamble(text: str, *, limit: int = PREAMBLE_MAX_CHARS) -> str:
@@ -182,6 +216,7 @@ def format_widget_line(widget: Any) -> str:
 
 __all__ = [
     "PREAMBLE_MAX_CHARS",
+    "WIDGET_PREVIEW_LIMIT",
     "composio_tool_names",
     "content_key",
     "format_widget_line",

--- a/ee/pocketpaw_ee/cloud/surface/handlers/pocket.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/pocket.py
@@ -1,5 +1,14 @@
 # pocket.py — Pocket-surface preamble.
 #
+# Updated: 2026-08-03 (PA-9, feat/prompt-budget-measurement) — the 12-widget cut
+# is no longer a bare literal; it is ``WIDGET_PREVIEW_LIMIT`` in ``_helpers.py``,
+# beside ``PREAMBLE_MAX_CHARS``, because the two caps jointly bound this preamble
+# and neither could be reasoned about without the other. Measured: a widget line
+# is 36.2 chars, so this preamble renders at 609 chars against a 1500 cap. The
+# limit stays 12 — not for token cost, which is negligible, but because this
+# text is digested into ``cache_key`` below, so each extra widget listed is one
+# more edit that invalidates and costs a reconnect. That side is unmeasured.
+#
 # Updated: 2026-08-02 (PA-2, feat/prompt-assembler-seam) — returns a
 # ``SurfacePreamble``: the same text, plus the cache key the ``surface`` prompt
 # layer is keyed on. This handler is the reason the key is the HANDLER's answer
@@ -59,6 +68,7 @@ import logging
 
 from pocketpaw_ee.cloud.surface.domain import SurfaceMeta, SurfacePreamble
 from pocketpaw_ee.cloud.surface.handlers._helpers import (
+    WIDGET_PREVIEW_LIMIT,
     content_key,
     format_widget_line,
     meta_key,
@@ -107,9 +117,9 @@ async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> 
         f'<current-pocket id="{pocket_id}" name="{name}" widgets="{len(widgets)}" />',
     ]
     if widgets:
-        rows = [format_widget_line(_AttrDict(w)) for w in widgets[:12]]
-        if len(widgets) > 12:
-            rows.append(f"... (+{len(widgets) - 12} more)")
+        rows = [format_widget_line(_AttrDict(w)) for w in widgets[:WIDGET_PREVIEW_LIMIT]]
+        if len(widgets) > WIDGET_PREVIEW_LIMIT:
+            rows.append(f"... (+{len(widgets) - WIDGET_PREVIEW_LIMIT} more)")
         parts.append(
             f'<pocket-widgets count="{len(widgets)}">\n' + "\n".join(rows) + "\n</pocket-widgets>"
         )

--- a/scripts/evals/prompt_cache_eval.py
+++ b/scripts/evals/prompt_cache_eval.py
@@ -40,12 +40,29 @@ nothing runs it implicitly and no test imports it.
     uv run python scripts/evals/prompt_cache_eval.py --arm summary-ab
     uv run python scripts/evals/prompt_cache_eval.py --arm all
 
-Route: OpenRouter (``settings.openrouter_api_key``). The LiteLLM gateway at
-``settings.litellm_api_base`` 502s every chat completion behind a
-``headroom-compression`` guardrail that 404s, and the direct DeepSeek route
-returns 401 — both were probed on 2026-08-03 and neither is a fault in this
-repo. OpenRouter is passed ``{"usage": {"include": true}}`` so every response
-carries ``usage.cost`` and ``usage.prompt_tokens_details.cached_tokens``.
+TWO ROUTES, and they answer different questions — ``--route openrouter``
+(default) or ``--route litellm``.
+
+  openrouter  The only route that reaches ANTHROPIC models, so the only one that
+      can answer anything about ``cache_control`` or the per-model floors.
+      Passed ``{"usage": {"include": true}}`` so each response carries
+      ``usage.cost`` and ``usage.prompt_tokens_details.cached_tokens``.
+
+  litellm     The gateway at ``settings.litellm_api_base``. It serves DeepSeek
+      only, and DeepSeek caches AUTOMATICALLY — ``cache_control`` is ignored
+      entirely — so this route CANNOT speak to the Anthropic floor questions,
+      and ``--arm threshold`` prints a warning saying so. What it is good for is
+      the warm-turn harness, which needs no marker. Cost arrives in the
+      ``x-litellm-response-cost`` header rather than the usage body.
+
+Both usage shapes are read by the SAME ``report_savings`` (OpenAI-shaped
+``cached_tokens`` on one, DeepSeek's ``prompt_cache_hit_tokens`` on the other),
+which is why this script carries no savings reporter of its own.
+
+A ``headroom-compression`` pre-call guardrail on the gateway 502s on large
+prompts — 40,000 chars passes, 67,563 fails (measured 2026-08-03) — so the
+litellm route cannot take the whole specialist prompt in one request. Use
+``--prefix-chars 40000``.
 
 The key is read from settings at run time and never printed. Every arm skips
 with a clear message (exit 0) when no key is configured, so this file is safe
@@ -66,11 +83,34 @@ from pocketpaw.llm.caching import CACHE_MIN_TOKENS, build_cacheable, report_savi
 
 OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
 
+# Two routes, because neither answers every question alone.
+#
+#   openrouter — the only route that reaches ANTHROPIC models, so it is the only
+#       one that can answer the cache_control / per-model-floor questions. Marker
+#       placement is meaningful here.
+#   litellm — the captain's gateway (``settings.litellm_api_base``). Serves
+#       DeepSeek only, which caches AUTOMATICALLY: ``cache_control`` markers are
+#       ignored, and the usage shape is
+#       ``prompt_cache_hit_tokens``/``prompt_cache_miss_tokens``. It therefore
+#       cannot speak to Anthropic floors at all, but it CAN run the warm-turn
+#       harness, and it is not metered against a personal balance.
+#
+# A ``headroom-compression`` pre-call guardrail on the gateway 502s on large
+# prompts: 40,000 chars succeeds, 67,563 fails (measured 2026-08-03). Keep the
+# litellm-route prefix under that ceiling.
+ROUTES = ("openrouter", "litellm")
+ROUTE = "openrouter"
+
 # Haiku 4.5 carries the HIGHEST documented Anthropic cache floor (4096 tokens),
 # which makes it the strictest test of a chars-based threshold and also the
 # cheapest model to run the test on. A threshold that is safe here is safe on
 # every other Anthropic model.
 MODEL = "anthropic/claude-haiku-4.5"
+
+DEFAULT_MODEL_BY_ROUTE = {
+    "openrouter": "anthropic/claude-haiku-4.5",
+    "litellm": "deepseek/deepseek-v4-flash",
+}
 
 # Per-model cache floors, in TOKENS, for the models this harness can target.
 # Haiku 4.5 has the highest floor and so needs the largest request to
@@ -80,6 +120,8 @@ MODEL_FLOOR_TOKENS = {
     "anthropic/claude-haiku-4.5": 4096,
     "anthropic/claude-sonnet-4.5": 1024,
     "anthropic/claude-opus-4.5": 4096,
+    "deepseek/deepseek-v4-flash": 1024,
+    "deepseek/deepseek-v4-pro": 1024,
 }
 
 # Keep every completion tiny — this harness measures INPUT accounting, and
@@ -128,30 +170,44 @@ class Ledger:
 
 
 def _api_key() -> str | None:
-    """Read the OpenRouter key from settings at run time. Never logged."""
+    """Read the active route's key from settings at run time. Never logged."""
     from pocketpaw.config import get_settings
 
-    return get_settings().openrouter_api_key or None
+    settings = get_settings()
+    if ROUTE == "litellm":
+        return settings.litellm_api_key or None
+    return settings.openrouter_api_key or None
+
+
+def _endpoint() -> str:
+    """The chat-completions URL for the active route."""
+    if ROUTE == "litellm":
+        from pocketpaw.config import get_settings
+
+        base = str(get_settings().litellm_api_base).rstrip("/")
+        return f"{base}/v1/chat/completions"
+    return OPENROUTER_URL
 
 
 def _post(client: httpx.Client, key: str, system: Any, user: str, label: str) -> Call:
     """One completion. ``system`` is a str or a content-block list."""
-    body = {
+    body: dict[str, Any] = {
         "model": MODEL,
         "max_tokens": MAX_TOKENS,
         "messages": [
             {"role": "system", "content": system},
             {"role": "user", "content": user},
         ],
-        # Without this OpenRouter omits cost and the cached-token breakdown,
-        # which is the entire measurement.
-        "usage": {"include": True},
     }
+    if ROUTE == "openrouter":
+        # Without this OpenRouter omits cost and the cached-token breakdown,
+        # which is the entire measurement. LiteLLM rejects the field.
+        body["usage"] = {"include": True}
     resp = client.post(
-        OPENROUTER_URL,
+        _endpoint(),
         headers={"Authorization": f"Bearer {key}", "Content-Type": "application/json"},
         json=body,
-        timeout=120.0,
+        timeout=180.0,
     )
     if resp.status_code == 402:
         # A free-tier OpenRouter key caps the size of a SINGLE request, so a
@@ -165,18 +221,38 @@ def _post(client: httpx.Client, key: str, system: Any, user: str, label: str) ->
             "exhaustion — smaller prefixes still succeed. Re-run with a "
             "smaller --prefix-chars, or fund the key."
         )
+    if resp.status_code == 502 and "headroom-compression" in resp.text:
+        # The gateway's pre-call guardrail, not the model and not this script.
+        # It passes at 40,000 chars and fails at 67,563 (measured 2026-08-03),
+        # so the fix is a smaller prefix rather than a retry.
+        raise BudgetExhausted(
+            f"LiteLLM gateway 502 on the headroom-compression guardrail for "
+            f"{label} (system prompt ~{len(str(system)):,} chars). The guardrail "
+            "rejects large prompts before the model sees them; 40,000 chars is "
+            "known good. Re-run with a smaller --prefix-chars."
+        )
     resp.raise_for_status()
     usage = resp.json().get("usage", {}) or {}
 
-    # Reuse the shipped reporter rather than re-deriving the hit rate here.
-    # OpenRouter returns the OpenAI shape (prompt_tokens +
-    # prompt_tokens_details.cached_tokens), which report_savings already reads.
+    # Reuse the shipped reporter rather than re-deriving the hit rate here, and
+    # note it needs no branch per route: OpenRouter returns the OpenAI shape
+    # (prompt_tokens + prompt_tokens_details.cached_tokens) and the gateway
+    # returns DeepSeek's (prompt_cache_hit_tokens / prompt_cache_miss_tokens).
+    # report_savings already discriminates both, which is the reason this script
+    # does not carry a second savings reporter.
     savings = report_savings(usage)
+
+    # Cost: OpenRouter puts it in the usage body; LiteLLM returns it in a
+    # response header instead.
+    cost = float(usage.get("cost") or 0.0)
+    if not cost:
+        cost = float(resp.headers.get("x-litellm-response-cost") or 0.0)
+
     return Call(
         label=label,
         prompt_tokens=savings.prompt_tokens or int(usage.get("prompt_tokens", 0)),
         cached_tokens=savings.cache_read_tokens,
-        cost=float(usage.get("cost", 0.0)),
+        cost=cost,
         raw_usage=usage,
     )
 
@@ -251,31 +327,73 @@ def arm_threshold(client: httpx.Client, key: str, ledger: Ledger, run_id: str) -
     biggest = rows[-1]
     cpt = biggest[0] / biggest[1] if biggest[1] else 0.0
     print(f"\nmeasured chars/token on our own prompt text: {cpt:.2f}")
-    floor_tokens = CACHE_MIN_TOKENS["anthropic-haiku"]
-    print(f"=> {floor_tokens}-token floor is about {floor_tokens * cpt:,.0f} chars")
+    floor_tokens = MODEL_FLOOR_TOKENS.get(MODEL, CACHE_MIN_TOKENS["default"])
+    print(f"=> {MODEL}'s documented {floor_tokens}-token floor is ~{floor_tokens * cpt:,.0f} chars")
 
     caching = [r for r in rows if r[4]]
     if caching:
-        print(f"=> smallest prefix that cached: {caching[0][0]:,} chars")
+        smallest = caching[0]
+        print(f"=> smallest prefix that cached: {smallest[0]:,} chars ({smallest[1]:,} tokens)")
+        if smallest[1] < floor_tokens:
+            print(
+                f"   NOTE: that is BELOW the documented {floor_tokens}-token floor — "
+                "the documented figure is conservative for this model."
+            )
     else:
         print("=> NOTHING in the sweep cached")
 
     # The write-premium question: does marking a SUB-FLOOR prompt cost extra?
-    # If the provider silently declines to cache, marked and unmarked cold calls
-    # cost the same and the marker is merely inert, not wasteful.
+    #
+    # THE TWO ARMS MUST USE DIFFERENT PREFIXES. An earlier version reused one
+    # prefix for both, which is only sound when nothing caches at that size: on
+    # a provider that DOES cache there, the second call reads the cache the
+    # first one just wrote and the comparison reports a ~13x "premium" that is
+    # really just a warm turn. Distinct salts keep both arms genuinely cold.
     print("\n--- write-premium check at 4000 chars (the live threshold) ---")
-    prefix = _prefix(4_000, run_id + "-wp")
-    marked = ledger.add(_post(client, key, build_cacheable([prefix]), "1", "wp-marked"))
-    unmarked = ledger.add(_post(client, key, prefix, "1", "wp-unmarked"))
-    print(f"  marked   cold: prompt={marked.prompt_tokens} cost=${marked.cost:.6f}")
-    print(f"  unmarked cold: prompt={unmarked.prompt_tokens} cost=${unmarked.cost:.6f}")
-    if unmarked.cost > 0:
+    marked = ledger.add(
+        _post(client, key, build_cacheable([_prefix(4_000, run_id + "-wpA")]), "1", "wp-marked")
+    )
+    unmarked = ledger.add(_post(client, key, _prefix(4_000, run_id + "-wpB"), "1", "wp-unmarked"))
+    print(
+        f"  marked:   prompt={marked.prompt_tokens} cached={marked.cached_tokens} "
+        f"cost=${marked.cost:.6f}"
+    )
+    print(
+        f"  unmarked: prompt={unmarked.prompt_tokens} cached={unmarked.cached_tokens} "
+        f"cost=${unmarked.cost:.6f}"
+    )
+
+    if marked.cached_tokens or unmarked.cached_tokens:
+        # Either arm reading from cache invalidates the comparison outright.
+        print(
+            "  => INVALID: one arm read from cache, so this is a warm-vs-cold\n"
+            "     difference, not a marker difference. The premium question is\n"
+            "     only answerable at a size where nothing caches."
+        )
+    elif unmarked.cost > 0:
         ratio = marked.cost / unmarked.cost
         print(f"  marked/unmarked cost ratio: {ratio:.3f}")
+        # The conclusion depends on which side of the model's floor 4000 chars
+        # lands, and the two readings are NOT interchangeable. Below the floor
+        # this answers "does a marker that cannot cache still cost anything";
+        # above it, on a provider that ignores cache_control, it only says the
+        # marker is a no-op there. Printing one wording for both would let a
+        # DeepSeek run be quoted as evidence about Anthropic floors.
+        floor = MODEL_FLOOR_TOKENS.get(MODEL, CACHE_MIN_TOKENS["default"])
+        below = marked.prompt_tokens < floor
+        where = "BELOW" if below else "ABOVE"
+        print(f"  ({marked.prompt_tokens} tokens is {where} {MODEL}'s {floor}-token floor)")
         if ratio > 1.10:
-            print("  => a write premium IS charged below the floor (marker is wasteful)")
-        else:
+            print("  => marking costs extra here (the marker is not free)")
+        elif below:
             print("  => NO write premium below the floor (marker is inert, not costly)")
+        else:
+            print(
+                "  => marker is a no-op at a CACHEABLE size — expected on a\n"
+                "     provider that caches automatically and ignores cache_control.\n"
+                "     This says nothing about sub-floor behaviour; re-run on a\n"
+                "     model whose floor is above this size for that."
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -468,8 +586,18 @@ def arm_summary_ab(client: httpx.Client, key: str, ledger: Ledger) -> None:
 
 
 def main() -> int:
-    global MODEL
+    global MODEL, ROUTE
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--route",
+        default="openrouter",
+        choices=ROUTES,
+        help=(
+            "openrouter reaches Anthropic models (the only route that can answer "
+            "the cache_control / floor questions); litellm is the gateway, which "
+            "serves DeepSeek only and caches automatically."
+        ),
+    )
     parser.add_argument(
         "--arm",
         default="all",
@@ -488,25 +616,40 @@ def main() -> int:
     )
     parser.add_argument(
         "--model",
-        default=MODEL,
-        help="OpenRouter model id. Lower-floor models need a smaller request to cache.",
+        default=None,
+        help=(
+            "Model id. Defaults per route (Haiku 4.5 on openrouter, "
+            "deepseek-v4-flash on litellm). Lower-floor models need a smaller "
+            "request to demonstrate a cache hit."
+        ),
     )
     args = parser.parse_args()
-    MODEL = args.model
+    ROUTE = args.route
+    MODEL = args.model or DEFAULT_MODEL_BY_ROUTE[ROUTE]
 
     key = _api_key()
     if not key:
         # Skip cleanly: this file must never fail a suite run just because the
         # machine has no key configured.
-        print(
-            "SKIP: no OpenRouter key configured "
-            "(set POCKETPAW_OPENROUTER_API_KEY to run this eval)."
-        )
+        env = "POCKETPAW_LITELLM_API_KEY" if ROUTE == "litellm" else "POCKETPAW_OPENROUTER_API_KEY"
+        print(f"SKIP: no {ROUTE} key configured (set {env} to run this eval).")
         return 0
+
+    if ROUTE == "litellm" and args.arm in ("all", "threshold"):
+        # Say this rather than produce a table that looks like an answer. The
+        # gateway serves DeepSeek, which caches automatically at a flat 1024
+        # tokens and ignores cache_control entirely, so a threshold sweep here
+        # measures DeepSeek's floor and says nothing about the Anthropic
+        # per-model floors the threshold question is actually about.
+        print(
+            "NOTE: --arm threshold is meaningful only on --route openrouter. "
+            "The gateway serves DeepSeek, which caches automatically and ignores "
+            "cache_control, so this sweep cannot speak to the Anthropic floors."
+        )
 
     run_id = f"pa9-{int(time.time())}"
     ledger = Ledger()
-    print(f"run_id={run_id}  model={MODEL}")
+    print(f"run_id={run_id}  route={ROUTE}  model={MODEL}")
 
     rc = 0
     try:

--- a/scripts/evals/prompt_cache_eval.py
+++ b/scripts/evals/prompt_cache_eval.py
@@ -1,0 +1,533 @@
+"""Measure what our prompt caps and cache markers actually cost (PA-9).
+
+Created 2026-08-03 (PA-9, feat/prompt-budget-measurement).
+
+Exists because every cap in the prompt path was inherited rather than measured:
+``PREAMBLE_MAX_CHARS = 1500``, the 12-widget cut in ``handlers/pocket.py``, and
+``_DEFAULT_BUDGET_CHARS = 32_000`` were all set by judgement and carried
+forward. PA-9 is the task that replaces the judgement with numbers.
+
+It answers four questions, one per arm:
+
+  ``--arm threshold``  The headline. ``_ANTHROPIC_CACHE_MIN_CHARS = 4000`` in
+      ``agents/deep_agents.py`` gates cache marking in CHARS, while
+      ``llm/caching.CACHE_MIN_TOKENS`` states the provider floors in TOKENS.
+      4000 chars is ~1000 tokens, well under Haiku 4.5's 4096-token floor. This
+      arm sweeps prefix sizes across that floor and reports, per size, whether a
+      warm turn actually read from cache — and whether marking a sub-floor
+      prompt costs anything (the write premium question).
+
+  ``--arm warm``  The filed ``RunUsage`` harness: >=6 warm turns over a real
+      marked prefix (``POCKET_SPECIALIST_PROMPT``, ~67.5k chars), reporting
+      ``cache_read`` vs the uncached remainder per turn.
+
+  ``--arm caps``  The per-cap cost. Converts each cap from chars to MEASURED
+      tokens (not the /4 rule of thumb) and prices it per turn.
+
+  ``--arm summary-ab``  A/B of ``prompt_pocket_summary_only`` rendered through
+      the REAL ``ChannelCurrentPocketLayer``, not a hand-built blob — the
+      distinction is the finding. PA-8a's ``_WIDGET_SUMMARY_MAX_CHARS`` bounds
+      the widget dump before serialisation, so the OFF arm plateaus near 3.2k
+      chars instead of growing to the ~41k a synthetic dump would suggest, and
+      the flag's real saving is ~50% rather than ~96%.
+
+This is a script, not a test. It spends real money against a live API, so
+nothing runs it implicitly and no test imports it.
+
+    uv run python scripts/evals/prompt_cache_eval.py --arm threshold
+    uv run python scripts/evals/prompt_cache_eval.py --arm warm --turns 6
+    uv run python scripts/evals/prompt_cache_eval.py --arm caps
+    uv run python scripts/evals/prompt_cache_eval.py --arm summary-ab
+    uv run python scripts/evals/prompt_cache_eval.py --arm all
+
+Route: OpenRouter (``settings.openrouter_api_key``). The LiteLLM gateway at
+``settings.litellm_api_base`` 502s every chat completion behind a
+``headroom-compression`` guardrail that 404s, and the direct DeepSeek route
+returns 401 — both were probed on 2026-08-03 and neither is a fault in this
+repo. OpenRouter is passed ``{"usage": {"include": true}}`` so every response
+carries ``usage.cost`` and ``usage.prompt_tokens_details.cached_tokens``.
+
+The key is read from settings at run time and never printed. Every arm skips
+with a clear message (exit 0) when no key is configured, so this file is safe
+to leave in a repo that CI checks out.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+
+from pocketpaw.llm.caching import CACHE_MIN_TOKENS, build_cacheable, report_savings
+
+OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
+
+# Haiku 4.5 carries the HIGHEST documented Anthropic cache floor (4096 tokens),
+# which makes it the strictest test of a chars-based threshold and also the
+# cheapest model to run the test on. A threshold that is safe here is safe on
+# every other Anthropic model.
+MODEL = "anthropic/claude-haiku-4.5"
+
+# Per-model cache floors, in TOKENS, for the models this harness can target.
+# Haiku 4.5 has the highest floor and so needs the largest request to
+# demonstrate a hit; a key with a small per-request cap may only be able to
+# afford the warm arm on a lower-floor model.
+MODEL_FLOOR_TOKENS = {
+    "anthropic/claude-haiku-4.5": 4096,
+    "anthropic/claude-sonnet-4.5": 1024,
+    "anthropic/claude-opus-4.5": 4096,
+}
+
+# Keep every completion tiny — this harness measures INPUT accounting, and
+# output tokens are pure cost with no signal.
+MAX_TOKENS = 1
+
+
+# ---------------------------------------------------------------------------
+# Transport
+# ---------------------------------------------------------------------------
+
+
+class BudgetExhausted(RuntimeError):
+    """The API refused on funding/size grounds, not on anything we control."""
+
+
+@dataclass
+class Call:
+    """One completion's input accounting."""
+
+    label: str
+    prompt_tokens: int
+    cached_tokens: int
+    cost: float
+    raw_usage: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def uncached(self) -> int:
+        """The remainder we paid full price for."""
+        return max(0, self.prompt_tokens - self.cached_tokens)
+
+
+class Ledger:
+    """Running total of what this run spent, so the report can state it."""
+
+    def __init__(self) -> None:
+        self.calls: list[Call] = []
+
+    def add(self, call: Call) -> Call:
+        self.calls.append(call)
+        return call
+
+    @property
+    def total_cost(self) -> float:
+        return sum(c.cost for c in self.calls)
+
+
+def _api_key() -> str | None:
+    """Read the OpenRouter key from settings at run time. Never logged."""
+    from pocketpaw.config import get_settings
+
+    return get_settings().openrouter_api_key or None
+
+
+def _post(client: httpx.Client, key: str, system: Any, user: str, label: str) -> Call:
+    """One completion. ``system`` is a str or a content-block list."""
+    body = {
+        "model": MODEL,
+        "max_tokens": MAX_TOKENS,
+        "messages": [
+            {"role": "system", "content": system},
+            {"role": "user", "content": user},
+        ],
+        # Without this OpenRouter omits cost and the cached-token breakdown,
+        # which is the entire measurement.
+        "usage": {"include": True},
+    }
+    resp = client.post(
+        OPENROUTER_URL,
+        headers={"Authorization": f"Bearer {key}", "Content-Type": "application/json"},
+        json=body,
+        timeout=120.0,
+    )
+    if resp.status_code == 402:
+        # A free-tier OpenRouter key caps the size of a SINGLE request, so a
+        # large prefix 402s while small ones keep succeeding. Say so plainly:
+        # a bare traceback here reads like a broken script rather than a
+        # funding limit, and that misdiagnosis costs more than the run.
+        raise BudgetExhausted(
+            f"OpenRouter returned 402 for {label} "
+            f"(system prompt ~{len(str(system)):,} chars). "
+            "On a free-tier key this is a per-request size cap, not total "
+            "exhaustion — smaller prefixes still succeed. Re-run with a "
+            "smaller --prefix-chars, or fund the key."
+        )
+    resp.raise_for_status()
+    usage = resp.json().get("usage", {}) or {}
+
+    # Reuse the shipped reporter rather than re-deriving the hit rate here.
+    # OpenRouter returns the OpenAI shape (prompt_tokens +
+    # prompt_tokens_details.cached_tokens), which report_savings already reads.
+    savings = report_savings(usage)
+    return Call(
+        label=label,
+        prompt_tokens=savings.prompt_tokens or int(usage.get("prompt_tokens", 0)),
+        cached_tokens=savings.cache_read_tokens,
+        cost=float(usage.get("cost", 0.0)),
+        raw_usage=usage,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Corpus
+# ---------------------------------------------------------------------------
+
+
+def _corpus() -> str:
+    """Real prompt text, so the measured chars-per-token ratio is OURS.
+
+    The whole char-vs-token question turns on this ratio, and prose, JSON and
+    XML-ish markup tokenize differently. Using the actual specialist prompt
+    means the answer applies to the prompts we actually send.
+    """
+    from pocketpaw.ripple._pockets import POCKET_SPECIALIST_PROMPT
+
+    return POCKET_SPECIALIST_PROMPT
+
+
+def _prefix(size_chars: int, run_id: str) -> str:
+    """A byte-stable prefix of ``size_chars``, unique to this run.
+
+    The run id goes FIRST so the prefix differs across runs (guaranteeing a
+    genuinely cold turn 1) while staying byte-identical within a run
+    (guaranteeing turns 2..N can hit). Any drift here silently destroys the
+    measurement, which is the same failure mode the caching module warns about.
+    """
+    head = f"<eval-run id={run_id} size={size_chars}>\n"
+    body = _corpus()
+    while len(body) < size_chars:
+        body += body
+    return head + body[: max(0, size_chars - len(head))]
+
+
+# ---------------------------------------------------------------------------
+# Arm 1 — the threshold sweep
+# ---------------------------------------------------------------------------
+
+# Bracket Haiku 4.5's 4096-token floor. 4000 is the live
+# ``_ANTHROPIC_CACHE_MIN_CHARS``; 16000 is roughly where 4096 tokens lands if a
+# token averages ~4 chars. Measuring both sides of the floor is the point.
+SWEEP_SIZES = (2_000, 4_000, 8_000, 12_000, 16_000, 20_000)
+
+
+def arm_threshold(client: httpx.Client, key: str, ledger: Ledger, run_id: str) -> None:
+    """Find the prefix size at which a warm turn actually reads from cache."""
+    print("\n=== ARM: threshold — where does caching actually start? ===")
+    print(f"model={MODEL}  documented floor={CACHE_MIN_TOKENS['anthropic-haiku']} tokens\n")
+    print(
+        f"{'chars':>7} {'prompt_tok':>11} {'cold_cached':>12} "
+        f"{'warm_cached':>12} {'cold_$':>9} {'warm_$':>9}  verdict"
+    )
+
+    rows = []
+    for size in SWEEP_SIZES:
+        prefix = _prefix(size, run_id)
+        system = build_cacheable([prefix])
+        cold = ledger.add(_post(client, key, system, "1", f"marked-cold-{size}"))
+        # A warm turn must reuse the identical prefix; only the user turn moves.
+        warm = ledger.add(_post(client, key, system, "2", f"marked-warm-{size}"))
+        cached = warm.cached_tokens > 0
+        verdict = "CACHES" if cached else "no cache"
+        print(
+            f"{size:>7} {warm.prompt_tokens:>11} {cold.cached_tokens:>12} "
+            f"{warm.cached_tokens:>12} {cold.cost:>9.5f} {warm.cost:>9.5f}  {verdict}"
+        )
+        rows.append((size, warm.prompt_tokens, cold, warm, cached))
+
+    # Chars-per-token, measured rather than assumed.
+    biggest = rows[-1]
+    cpt = biggest[0] / biggest[1] if biggest[1] else 0.0
+    print(f"\nmeasured chars/token on our own prompt text: {cpt:.2f}")
+    floor_tokens = CACHE_MIN_TOKENS["anthropic-haiku"]
+    print(f"=> {floor_tokens}-token floor is about {floor_tokens * cpt:,.0f} chars")
+
+    caching = [r for r in rows if r[4]]
+    if caching:
+        print(f"=> smallest prefix that cached: {caching[0][0]:,} chars")
+    else:
+        print("=> NOTHING in the sweep cached")
+
+    # The write-premium question: does marking a SUB-FLOOR prompt cost extra?
+    # If the provider silently declines to cache, marked and unmarked cold calls
+    # cost the same and the marker is merely inert, not wasteful.
+    print("\n--- write-premium check at 4000 chars (the live threshold) ---")
+    prefix = _prefix(4_000, run_id + "-wp")
+    marked = ledger.add(_post(client, key, build_cacheable([prefix]), "1", "wp-marked"))
+    unmarked = ledger.add(_post(client, key, prefix, "1", "wp-unmarked"))
+    print(f"  marked   cold: prompt={marked.prompt_tokens} cost=${marked.cost:.6f}")
+    print(f"  unmarked cold: prompt={unmarked.prompt_tokens} cost=${unmarked.cost:.6f}")
+    if unmarked.cost > 0:
+        ratio = marked.cost / unmarked.cost
+        print(f"  marked/unmarked cost ratio: {ratio:.3f}")
+        if ratio > 1.10:
+            print("  => a write premium IS charged below the floor (marker is wasteful)")
+        else:
+            print("  => NO write premium below the floor (marker is inert, not costly)")
+
+
+# ---------------------------------------------------------------------------
+# Arm 2 — the RunUsage warm-turn harness
+# ---------------------------------------------------------------------------
+
+
+def arm_warm(
+    client: httpx.Client,
+    key: str,
+    ledger: Ledger,
+    run_id: str,
+    turns: int,
+    prefix_chars: int = 0,
+) -> None:
+    """>=6 warm turns over a real marked prefix.
+
+    ``prefix_chars`` truncates ``POCKET_SPECIALIST_PROMPT`` when the key cannot
+    afford the whole 67.5k-char thing in one request. Any value comfortably
+    above the measured cache floor (~14,300 chars) exercises the same code
+    path and reports the same accounting.
+    """
+    print(f"\n=== ARM: warm — {turns} turns over the real POCKET_SPECIALIST_PROMPT ===")
+    corpus = _corpus()
+    prefix = f"<eval-run id={run_id}>\n" + corpus
+    if prefix_chars:
+        prefix = prefix[:prefix_chars]
+    system = build_cacheable([prefix])
+    print(f"prefix: {len(prefix):,} chars\n")
+    print(f"{'turn':>5} {'prompt_tok':>11} {'cache_read':>11} {'uncached':>9} {'$':>10}")
+
+    first_cost = None
+    warm_costs = []
+    for i in range(1, turns + 1):
+        # Only the user turn varies; the marked prefix stays byte-identical.
+        call = ledger.add(_post(client, key, system, f"turn {i}", f"warm-{i}"))
+        print(
+            f"{i:>5} {call.prompt_tokens:>11} {call.cached_tokens:>11} "
+            f"{call.uncached:>9} {call.cost:>10.6f}"
+        )
+        if i == 1:
+            first_cost = call.cost
+        else:
+            warm_costs.append(call.cost)
+        time.sleep(0.4)
+
+    if warm_costs and first_cost:
+        avg_warm = sum(warm_costs) / len(warm_costs)
+        print(f"\ncold turn:      ${first_cost:.6f}")
+        print(f"avg warm turn:  ${avg_warm:.6f}")
+        if avg_warm > 0:
+            print(f"warm is {first_cost / avg_warm:.1f}x cheaper than cold")
+
+
+# ---------------------------------------------------------------------------
+# Arm 3 — what each cap costs
+# ---------------------------------------------------------------------------
+
+
+def _measure_tokens(client: httpx.Client, key: str, ledger: Ledger, text: str, label: str) -> Call:
+    """Real token count for ``text`` (no cache marker, so nothing is reused)."""
+    return ledger.add(_post(client, key, text, "1", label))
+
+
+def arm_caps(client: httpx.Client, key: str, ledger: Ledger) -> None:
+    """Price each inherited cap in measured tokens and dollars-per-turn."""
+    print("\n=== ARM: caps — what each inherited cap actually costs ===")
+
+    from pocketpaw_ee.cloud.surface.handlers._helpers import PREAMBLE_MAX_CHARS
+
+    from pocketpaw.bootstrap.context_builder import _DEFAULT_BUDGET_CHARS
+
+    corpus = _corpus()
+    # An empty system prompt still bills a few tokens of chat scaffolding;
+    # subtract that baseline so each cap's cost is the cap's own.
+    base = _measure_tokens(client, key, ledger, "x", "caps-baseline")
+
+    caps = [
+        ("PREAMBLE_MAX_CHARS", PREAMBLE_MAX_CHARS),
+        ("_DEFAULT_BUDGET_CHARS", _DEFAULT_BUDGET_CHARS),
+    ]
+    print(f"\n{'cap':>24} {'chars':>8} {'tokens':>8} {'chars/tok':>10} {'$/turn':>10}")
+    for name, chars in caps:
+        call = _measure_tokens(client, key, ledger, corpus[:chars], f"cap-{name}")
+        tokens = max(0, call.prompt_tokens - base.prompt_tokens)
+        cpt = chars / tokens if tokens else 0.0
+        cost = max(0.0, call.cost - base.cost)
+        print(f"{name:>24} {chars:>8,} {tokens:>8,} {cpt:>10.2f} {cost:>10.6f}")
+
+    print(f"\nbaseline (empty-ish prompt): {base.prompt_tokens} tokens, ${base.cost:.6f}")
+
+
+# ---------------------------------------------------------------------------
+# Arm 4 — the pocket-summary A/B
+# ---------------------------------------------------------------------------
+
+
+def _render_pocket_block(widget_count: int, summary_only: bool) -> str:
+    """Render ``<current-pocket>`` through the REAL layer, both flag states.
+
+    Hand-rolling the block here would measure a blob the runtime never sends —
+    and would miss the whole point, because PA-8a's
+    ``_WIDGET_SUMMARY_MAX_CHARS`` bounds the widget dump BEFORE serialisation.
+    A synthetic ``json.dumps`` of 300 widgets looks like ~40k chars; what the
+    layer actually emits is ~3.2k. Only the layer knows that.
+    """
+    from unittest.mock import MagicMock
+
+    import pocketpaw.config as cfg
+    from pocketpaw.prompt.channel import ChannelInputs
+    from pocketpaw.prompt.channel.request import ChannelCurrentPocketLayer
+    from pocketpaw.prompt.layer import PromptContext
+
+    pocket_context = {
+        "id": "pk-123",
+        "name": "Launch Tracker",
+        "widgets": [
+            {
+                "id": f"w-{i:03d}",
+                "name": f"Widget {i}",
+                "type": "chart",
+                "title": f"Some widget title {i}",
+                "props": {"source": "api", "refresh": 30},
+            }
+            for i in range(widget_count)
+        ],
+    }
+    ctx = PromptContext(
+        instance=None,
+        agent_id="",
+        message="",
+        instructions="",
+        knowledge_context="",
+        system_message_override=None,
+        channel_inputs=ChannelInputs(metadata={"pocket_context": pocket_context}),
+    )
+    settings = MagicMock()
+    settings.prompt_pocket_summary_only = summary_only
+    original = cfg.get_settings
+    cfg.get_settings = lambda *a, **k: settings
+    try:
+        import asyncio
+
+        return asyncio.run(ChannelCurrentPocketLayer().render(ctx)).text
+    finally:
+        cfg.get_settings = original
+
+
+def arm_summary_ab(client: httpx.Client, key: str, ledger: Ledger) -> None:
+    """A/B ``prompt_pocket_summary_only`` through the real layer."""
+    print("\n=== ARM: summary-ab — prompt_pocket_summary_only, via the real layer ===")
+
+    # Char counts are free and exact, so take them across a range of pocket
+    # sizes. The interesting result is that the OFF arm PLATEAUS: the block
+    # stops growing with the pocket, because the widget summary is bounded
+    # before it is serialised.
+    print(f"\n{'widgets':>8} {'OFF chars':>10} {'ON chars':>9} {'saved':>8} {'saved %':>8}")
+    for n in (12, 50, 300, 1000):
+        off = _render_pocket_block(n, False)
+        on = _render_pocket_block(n, True)
+        pct = 100 * (1 - len(on) / len(off)) if off else 0.0
+        print(f"{n:>8} {len(off):>10,} {len(on):>9,} {len(off) - len(on):>8,} {pct:>7.1f}%")
+
+    # Then price the 300-widget case in real tokens.
+    off = _render_pocket_block(300, False)
+    on = _render_pocket_block(300, True)
+    base = _measure_tokens(client, key, ledger, "x", "ab-baseline")
+    a = _measure_tokens(client, key, ledger, off, "ab-full")
+    b = _measure_tokens(client, key, ledger, on, "ab-summary-only")
+
+    a_tok = max(0, a.prompt_tokens - base.prompt_tokens)
+    b_tok = max(0, b.prompt_tokens - base.prompt_tokens)
+    a_cost = max(0.0, a.cost - base.cost)
+    b_cost = max(0.0, b.cost - base.cost)
+
+    print(f"\n{'arm':>26} {'chars':>9} {'tokens':>8} {'$/turn':>10}")
+    print(f"{'summary_only=False (today)':>26} {len(off):>9,} {a_tok:>8,} {a_cost:>10.6f}")
+    print(f"{'summary_only=True':>26} {len(on):>9,} {b_tok:>8,} {b_cost:>10.6f}")
+    if a_tok:
+        print(f"\nflag saves {a_tok - b_tok:,} tokens/turn ({100 * (1 - b_tok / a_tok):.1f}%)")
+    # The block VARIES per pocket and per edit, so it lands after the cache
+    # breakpoint and is re-paid every turn — this saving is never amortised by
+    # caching, unlike the specialist prefix measured in --arm warm.
+    print("(per-turn: this block varies, so it never sits inside a cached prefix)")
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    global MODEL
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--arm",
+        default="all",
+        choices=("all", "threshold", "warm", "caps", "summary-ab"),
+    )
+    parser.add_argument("--turns", type=int, default=6, help="warm turns (min 6 per PA-9)")
+    parser.add_argument(
+        "--prefix-chars",
+        type=int,
+        default=0,
+        help=(
+            "truncate the warm-arm prefix to N chars (0 = the whole 67.5k "
+            "specialist prompt). Use ~16000 on a key whose per-request cap "
+            "rejects the full prompt; it is still above the measured floor."
+        ),
+    )
+    parser.add_argument(
+        "--model",
+        default=MODEL,
+        help="OpenRouter model id. Lower-floor models need a smaller request to cache.",
+    )
+    args = parser.parse_args()
+    MODEL = args.model
+
+    key = _api_key()
+    if not key:
+        # Skip cleanly: this file must never fail a suite run just because the
+        # machine has no key configured.
+        print(
+            "SKIP: no OpenRouter key configured "
+            "(set POCKETPAW_OPENROUTER_API_KEY to run this eval)."
+        )
+        return 0
+
+    run_id = f"pa9-{int(time.time())}"
+    ledger = Ledger()
+    print(f"run_id={run_id}  model={MODEL}")
+
+    rc = 0
+    try:
+        with httpx.Client() as client:
+            if args.arm in ("all", "threshold"):
+                arm_threshold(client, key, ledger, run_id)
+            if args.arm in ("all", "warm"):
+                arm_warm(client, key, ledger, run_id, max(6, args.turns), args.prefix_chars)
+            if args.arm in ("all", "caps"):
+                arm_caps(client, key, ledger)
+            if args.arm in ("all", "summary-ab"):
+                arm_summary_ab(client, key, ledger)
+    except BudgetExhausted as exc:
+        # Report the partial run rather than losing the arms that did land.
+        print(f"\nSTOPPED: {exc}")
+        rc = 1
+    finally:
+        print(f"\n=== SPEND: ${ledger.total_cost:.6f} over {len(ledger.calls)} calls ===")
+
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/pocketpaw/agents/deep_agents.py
+++ b/src/pocketpaw/agents/deep_agents.py
@@ -134,7 +134,10 @@ _ANTHROPIC_PATCHED = False
 #   * "false positives only cost the cache-write overhead" — they cost nothing.
 #     A marked and an unmarked sub-floor call billed identically ($0.001079 vs
 #     $0.001079). Below the floor the provider declines to cache silently; there
-#     is no write to pay for.
+#     is no write to pay for. Both calls were verifiably COLD, which is what
+#     makes that a marker comparison rather than a warm-vs-cold one: the sweep
+#     reports 0 cached tokens at 4000 chars on BOTH the cold and the warm turn,
+#     so nothing cached at that size for the second call to read.
 #
 # So this threshold is wrong in the harmless direction, and RAISING it to a
 # "correct" ~14,300 would be the actual regression: it would stop marking on

--- a/src/pocketpaw/agents/deep_agents.py
+++ b/src/pocketpaw/agents/deep_agents.py
@@ -8,6 +8,13 @@ Uses the Deep Agents SDK (pip install deepagents) which provides:
 
 Requires: pip install deepagents
 
+Updated 2026-08-03 (PA-9, feat/prompt-budget-measurement): ``_ANTHROPIC_CACHE_MIN_CHARS``
+is now measured. The value is unchanged at 4000, but the reasoning attached to it
+was wrong on all three counts — the chars/token ratio, the per-model floors, and
+the claim that a sub-floor marker costs a wasted cache write (it costs nothing).
+The constant's comment carries the numbers and the reason raising it would be a
+regression rather than a fix. Harness: ``scripts/evals/prompt_cache_eval.py``.
+
 Updated 2026-06-26 (integration/model-catalog-v2, MCG-11):
   * The Anthropic prompt-cache patch sources its ``cache_control`` marker from
     the universal ``pocketpaw.llm.caching._cache_control`` helper (single source
@@ -113,11 +120,31 @@ _OPENAI_PATCHED = False
 _ANTHROPIC_PATCHED = False
 
 # Threshold above which we tag the system block with ``cache_control``.
-# Anthropic's prompt-cache minimum is ~1024 tokens on Sonnet/Opus and
-# ~2048 on Haiku; one English token ≈ 4 chars, so 4000 chars is well
-# clear of the Sonnet floor but still excludes the small lifestyle
-# prompts the chat agent uses for greetings / one-shot facts. Tuned
-# conservatively — false positives only cost the cache-write overhead.
+#
+# MEASURED 2026-08-03 (PA-9, scripts/evals/prompt_cache_eval.py --arm threshold).
+# The value stays 4000, but every number in the comment that used to justify it
+# was wrong, and the conclusion it drew was backwards:
+#
+#   * "one English token ~ 4 chars" — our own prompt text measures 3.48
+#     chars/token, so 4000 chars is ~1,150 tokens, not 1,000.
+#   * "~1024 on Sonnet/Opus and ~2048 on Haiku" — Haiku 4.5's floor is 4096
+#     tokens (measured: 3,304 tokens did not cache, 4,478 did), and Opus runs
+#     512..4096 by generation. 4000 chars clears NO Anthropic floor except
+#     Opus 5's 512. In chars, Haiku 4.5's floor is about 14,300.
+#   * "false positives only cost the cache-write overhead" — they cost nothing.
+#     A marked and an unmarked sub-floor call billed identically ($0.001079 vs
+#     $0.001079). Below the floor the provider declines to cache silently; there
+#     is no write to pay for.
+#
+# So this threshold is wrong in the harmless direction, and RAISING it to a
+# "correct" ~14,300 would be the actual regression: it would stop marking on
+# Opus 4.8 (floor 1024) and Opus 5 (floor 512), where prompts between 4k and
+# 14k chars cache today. A gate that is too permissive is inert; one that is
+# too strict silently forfeits a ~12x warm-turn saving. It stays at 4000.
+#
+# What this constant genuinely buys is therefore NOT cost avoidance — it is
+# keeping the marker off the small greeting/one-shot prompts, where it would be
+# noise in the request. Judge future edits on that, and on ``CACHE_MIN_TOKENS``.
 _ANTHROPIC_CACHE_MIN_CHARS = 4000
 
 # MCG-11 — byte-stable sentinel that identifies the pocket/site-GENERATOR

--- a/src/pocketpaw/bootstrap/context_builder.py
+++ b/src/pocketpaw/bootstrap/context_builder.py
@@ -173,10 +173,29 @@ def _resolve_kb_scopes(ctx: KbContext | None, settings) -> list[str]:
 # with the numbers carried across unchanged. Two things the old table got wrong
 # were carried across too rather than fixed, because PA-9 is the task with the
 # measurements: it capped ``instructions``, a block this path never produced,
-# and it had no entry at all for ``pocket_context`` or ``current_pocket``, which
-# are therefore uncapped — ``current_pocket`` ``json.dumps`` a widget summary
-# into the prompt with no bound.
+# and it had no entry at all for ``pocket_context`` or ``current_pocket``.
+#
+# PA-9 (2026-08-03) closed that loop, and the second half above is now stale in
+# a way worth recording: ``current_pocket`` is NO LONGER unbounded. PA-8a put the
+# ceiling on the layer's INPUTS (``_WIDGET_SUMMARY_MAX_CHARS``) rather than on
+# its rendered text, which is why it is invisible from here — there is still no
+# ``max_chars``, and there correctly never will be, since this assembler's cap
+# truncates the tail and this block's tail is the ``get_pocket`` instruction.
+# Measured against the live layer: the block renders at 3,240 chars for a
+# 300-widget pocket and 3,241 for a 1,000-widget one, so it does not grow with
+# pocket size. ``pocket_context`` remains genuinely uncapped and unmeasured.
 
+# MEASURED 2026-08-03 (PA-9, scripts/evals/prompt_cache_eval.py --arm caps):
+# 32,000 chars is 8,874 tokens on the live route — our own prompt text runs 3.61
+# chars/token here, not the 4.0 the rules of thumb assume.
+#
+# KEPT at 32,000. The measurement that argues for keeping it is a caching one:
+# 8,874 tokens is comfortably above every Anthropic cache floor (512..4096, see
+# ``pocketpaw.llm.caching.CACHE_MIN_TOKENS``), so a byte-stable prompt assembled
+# at this budget is large enough to cache. Cutting the budget toward ~14,000
+# chars would drop a Haiku-4.5 prompt under its 4096-token floor and silently
+# forfeit the ~12x warm-turn saving — the budget would look thriftier per turn
+# and cost more per conversation.
 _DEFAULT_BUDGET_CHARS = 32_000
 
 

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -1,6 +1,12 @@
 """Configuration management for PocketPaw.
 
 Changes:
+  - 2026-08-03 (PA-9): Re-measured ``prompt_pocket_summary_only``'s payoff against
+    the live layer and corrected its description. The flag saves ~1,631 chars/turn
+    (3,240 -> 1,609 on a 300-widget pocket), not the ~39.6k the old note implied —
+    PA-8a's ``_WIDGET_SUMMARY_MAX_CHARS`` had already bounded the block, so the
+    dramatic figure described behaviour that no longer exists. Default is
+    unchanged; only the docstring was wrong.
   - 2026-08-03 (PA-8a): Added ``prompt_pocket_summary_only`` (default False, env
     POCKETPAW_PROMPT_POCKET_SUMMARY_ONLY) — takes the bulk widget dump out of
     the channel prompt's ``<current-pocket>`` block, leaving the pocket id, the
@@ -2041,8 +2047,17 @@ class Settings(BaseSettings):
             "pocket id, name, widget count, a snapshot stamp — plus the same "
             "standing order to call ``mcp__pocketpaw_pocket__get_pocket`` for "
             "the detail, which is the tool-result path the detail belongs on. "
-            "Measured on a 300-widget pocket the block drops from ~41k chars to "
-            "~1.4k. Read per-render by "
+            "RE-MEASURED 2026-08-03 (PA-9) against the live layer: on a "
+            "300-widget pocket the block is 3,240 chars / 1,092 tokens OFF and "
+            "1,609 chars / 444 tokens ON, so the flag saves 648 tokens (59%) per "
+            "turn — NOT the ~39.6k chars the old '~41k chars to ~1.4k' note "
+            "implied. That figure described the "
+            "pre-PA-8a block; _WIDGET_SUMMARY_MAX_CHARS now bounds the dump at "
+            "2,000 chars before serialisation, so the block plateaus around "
+            "3,240 chars from ~50 widgets upward and does not grow with pocket "
+            "size. The block is per-turn (it varies, so it never sits inside a "
+            "cached prefix), but the saving is now modest rather than dramatic. "
+            "Read per-render by "
             "``pocketpaw.prompt.channel.request.ChannelCurrentPocketLayer``, so "
             "flipping it is a config or env change and takes effect on the next "
             "settings load — no code deploy. Set via "

--- a/src/pocketpaw/llm/caching.py
+++ b/src/pocketpaw/llm/caching.py
@@ -1,13 +1,16 @@
 # src/pocketpaw/llm/caching.py — universal LLM prompt-caching helper (MCG-11).
 #
 # Updated: 2026-08-03 (PA-9, feat/prompt-budget-measurement) — ``CACHE_MIN_TOKENS``
-# is now measured rather than recited, and two of its rows were wrong. A live
+# is now measured rather than recited, and THREE of its rows were wrong. A live
 # sweep either side of the Haiku 4.5 floor (see the constant) confirmed 4096 and
-# pinned our own text at 3.48 chars/token. Two corrections fell out: the
+# pinned our own text at 3.48 chars/token. The corrections: the
 # ``anthropic-sonnet`` row read 2048, which is not the floor of ANY shipping
-# Sonnet (all are 1024) and only ever cost us caching; and ``anthropic-opus``
+# Sonnet (all are 1024) and only ever cost us caching; ``anthropic-opus``
 # cannot be a single number, because Opus floors run 512 (Opus 5) to 4096 (Opus
-# 4.5/4.6) and are NOT monotonic across generations. Also corrected here: the
+# 4.5/4.6) and are NOT monotonic across generations; and ``deepseek`` read 1024
+# while a 595-token prefix demonstrably cached, so it is 512. Every one of the
+# three erred toward being too STRICT, which is the direction that silently
+# forfeits caching rather than the one that merely wastes a marker. Also corrected: the
 # note below that a sub-floor write is "wasted". It is not — the provider
 # declines silently and charges nothing extra (marked and unmarked sub-floor
 # calls billed identically to six significant figures), so an over-permissive
@@ -25,8 +28,10 @@
 #       content goes first, the variable suffix last, so the cached
 #       longest-common-prefix is maximised. Marker placement respects
 #       Anthropic's 4-breakpoint hard cap. For automatic-caching providers
-#       (OpenAI/DeepSeek cache >=1024 tokens with no markup) the structure is
-#       still correct — the markers are simply ignored.
+#       (OpenAI, and DeepSeek from ~512 tokens with no markup) the structure is
+#       still correct — the markers are simply ignored. Confirmed live on
+#       2026-08-03: a DeepSeek run of 7 turns over an unmarked-in-effect 10,578
+#       token prefix read 10,496 from cache on every warm turn.
 #
 #   * ``report_savings(usage)``
 #       Reads ``cache_creation_input_tokens`` / ``cache_read_input_tokens``
@@ -101,7 +106,16 @@ CACHE_MIN_TOKENS: dict[str, int] = {
     "anthropic-opus-4.8": 1024,
     "anthropic-opus-5": 512,
     "openai": 1024,
-    "deepseek": 1024,
+    # MEASURED 2026-08-03 (PA-9) on deepseek-v4-flash via the LiteLLM gateway:
+    # a 595-token prefix cached (512 read on the warm turn), so the effective
+    # floor is at or below 512 — the documented 1024 was conservative and would
+    # have skipped prompts that cache. Reads arrive in 512-token blocks, which
+    # is why a 595-token prompt reports 512 cached rather than 595.
+    #
+    # DeepSeek caches AUTOMATICALLY and ignores ``cache_control`` entirely, so
+    # this row gates nothing on that route today; it is here so a caller that
+    # does gate on it is not told 1024 when the truth is 512.
+    "deepseek": 512,
 }
 
 # Valid Anthropic ``cache_control`` TTL strings. "5m" is the free default;

--- a/src/pocketpaw/llm/caching.py
+++ b/src/pocketpaw/llm/caching.py
@@ -1,5 +1,18 @@
 # src/pocketpaw/llm/caching.py — universal LLM prompt-caching helper (MCG-11).
 #
+# Updated: 2026-08-03 (PA-9, feat/prompt-budget-measurement) — ``CACHE_MIN_TOKENS``
+# is now measured rather than recited, and two of its rows were wrong. A live
+# sweep either side of the Haiku 4.5 floor (see the constant) confirmed 4096 and
+# pinned our own text at 3.48 chars/token. Two corrections fell out: the
+# ``anthropic-sonnet`` row read 2048, which is not the floor of ANY shipping
+# Sonnet (all are 1024) and only ever cost us caching; and ``anthropic-opus``
+# cannot be a single number, because Opus floors run 512 (Opus 5) to 4096 (Opus
+# 4.5/4.6) and are NOT monotonic across generations. Also corrected here: the
+# note below that a sub-floor write is "wasted". It is not — the provider
+# declines silently and charges nothing extra (marked and unmarked sub-floor
+# calls billed identically to six significant figures), so an over-permissive
+# threshold is inert, while an over-strict one loses real money.
+#
 # Created 2026-06-26 (integration/model-catalog-v2, MCG-11): generalizes the
 # ad-hoc Anthropic cache-control monkey-patch in
 # ``src/pocketpaw/agents/deep_agents.py`` into a reusable, provider-agnostic,
@@ -30,9 +43,11 @@
 #     trailing-whitespace difference) busts the cache for every downstream call.
 #     ``build_cacheable`` therefore never mutates the prefix text and keeps every
 #     variable part strictly after the last cache breakpoint.
-#   * Min-token thresholds: 1024 tokens (most models), 2048 (Anthropic Sonnet),
-#     4096 (Anthropic Haiku / Opus 4.5+). Below the floor the provider declines
-#     to cache and the write is wasted — callers should gate on prefix size.
+#   * Min-token thresholds: see ``CACHE_MIN_TOKENS`` — 512 to 4096 depending on
+#     the exact model, NOT the family. Below the floor the provider declines to
+#     cache; measured 2026-08-03, it declines FOR FREE, so a caller that gates
+#     too permissively loses nothing and one that gates too strictly loses the
+#     whole saving. When in doubt, mark it.
 #   * 1h TTL costs 2x a 5m write on the create call; only worth it when the same
 #     prefix recurs within the hour (the site-gen / pocket-gen case). 5m is the
 #     default.
@@ -51,15 +66,40 @@ from typing import Any
 # clamps to it.
 MAX_CACHE_BREAKPOINTS = 4
 
-# Per-model minimum cacheable prefix sizes (tokens). Below the floor the
-# provider silently declines to cache and the write is wasted. These are the
-# documented Anthropic floors; the 1024 default also covers OpenAI/DeepSeek
-# automatic caching. Keyed by a coarse model family the caller can look up.
+# Per-model minimum cacheable prefix sizes (TOKENS, never chars). Below the
+# floor the provider silently declines to cache — measured 2026-08-03 (PA-9),
+# see below — so the write is not "wasted", it simply never happens.
+#
+# MEASURED 2026-08-03 (PA-9, scripts/evals/prompt_cache_eval.py --arm threshold)
+# on anthropic/claude-haiku-4.5. A prefix sweep either side of the 4096 floor:
+#
+#     prompt_tokens   warm cache_read
+#             3,304                 0   <- below floor, never caches
+#             4,478             4,470   <- above floor, caches
+#
+# The crossover brackets 4096 exactly, confirming the Haiku 4.5 row. The same
+# run measured 3.48 chars/token on our own prompt text, which is the conversion
+# any chars-expressed threshold has to use.
+#
+# THE FLOORS ARE NOT MONOTONIC ACROSS GENERATIONS, which is why "anthropic-opus"
+# cannot be one number: Opus 4.5/4.6 sit at 4096 while Opus 4.8 is 1024 and Opus
+# 5 is 512. A single coarse key here is what makes a caller either skip caching
+# it could have had, or believe it cached when it did not.
 CACHE_MIN_TOKENS: dict[str, int] = {
     "default": 1024,
-    "anthropic-sonnet": 2048,
-    "anthropic-haiku": 4096,
-    "anthropic-opus": 4096,  # Opus 4.5+ raised the floor to 4096
+    # Every shipping Sonnet (4, 4.5, 4.6, 5) is 1024. This row previously read
+    # 2048, which is not the floor for any Sonnet — it only ever cost caching.
+    "anthropic-sonnet": 1024,
+    "anthropic-haiku": 4096,  # Haiku 4.5 — MEASURED above
+    # Opus spans 512..4096 by generation; the family key keeps the most
+    # conservative value so a caller that cannot resolve the generation is
+    # never told a prefix will cache when it will not.
+    "anthropic-opus": 4096,
+    "anthropic-opus-4.5": 4096,
+    "anthropic-opus-4.6": 4096,
+    "anthropic-opus-4.7": 2048,
+    "anthropic-opus-4.8": 1024,
+    "anthropic-opus-5": 512,
     "openai": 1024,
     "deepseek": 1024,
 }

--- a/tests/cloud/surface/test_preamble_caps.py
+++ b/tests/cloud/surface/test_preamble_caps.py
@@ -1,0 +1,122 @@
+"""The two caps that jointly bound the pocket preamble stay consistent (PA-9).
+
+Created 2026-08-03 (PA-9, feat/prompt-budget-measurement).
+
+``PREAMBLE_MAX_CHARS`` and ``WIDGET_PREVIEW_LIMIT`` are set independently, in
+different units, and bound the same text. PA-9 measured that they do not
+currently collide — a full 300-widget preamble renders at 609 chars against a
+1500-char cap — but nothing asserted it, so the property held by luck.
+
+It matters because ``truncate_preamble`` cuts the TAIL. In
+``handlers/pocket.py`` the widget rows are emitted BEFORE the node and backend
+summaries, so a widget limit raised past the char cap does not truncate the
+widget list that caused the overflow; it silently deletes ``<pocket-nodes>`` and
+``<pocket-backend>`` instead. The agent would lose the pocket's wiring state and
+nothing in the preamble would say so.
+
+These are pure-function tests over the two helpers — no DB, no fixtures.
+"""
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.surface.handlers._helpers import (
+    PREAMBLE_MAX_CHARS,
+    WIDGET_PREVIEW_LIMIT,
+    format_widget_line,
+    truncate_preamble,
+)
+
+
+class _Widget:
+    """A widget with realistic field lengths.
+
+    ``format_widget_line`` reads ``name`` / ``type`` / ``spec`` off a duck-typed
+    object. Names must be plausible: a ``(unnamed)`` fallback renders ~7 chars
+    shorter per line and would flatter the measurement.
+    """
+
+    def __init__(self, i: int) -> None:
+        self.name = f"Revenue by region {i}"
+        self.type = "spec"
+        self.spec = {"kind": "chart"}
+
+
+def _render_preamble(widget_count: int) -> str:
+    """Rebuild the widest preamble ``handlers/pocket.py`` can emit.
+
+    Mirrors that handler's assembly order — surface tag, current-pocket tag,
+    widget rows, then the node and backend summaries that sit in the truncation
+    firing line.
+    """
+    widgets = [_Widget(i) for i in range(widget_count)]
+    parts = [
+        '<surface kind="pocket" route="/pockets/pk-123" />',
+        f'<current-pocket id="pk-123" name="Launch Tracker" widgets="{widget_count}" />',
+    ]
+    rows = [format_widget_line(w) for w in widgets[:WIDGET_PREVIEW_LIMIT]]
+    if widget_count > WIDGET_PREVIEW_LIMIT:
+        rows.append(f"... (+{widget_count - WIDGET_PREVIEW_LIMIT} more)")
+    parts.append(
+        f'<pocket-widgets count="{widget_count}">\n' + "\n".join(rows) + "\n</pocket-widgets>"
+    )
+    # The two blocks that get deleted first when the preamble overflows.
+    parts.append("<pocket-nodes>3 nodes: fetch, transform, render</pocket-nodes>")
+    parts.append("<pocket-backend>backend: connected (postgres)</pocket-backend>")
+    return "\n".join(parts)
+
+
+def test_widget_preview_limit_fits_inside_the_preamble_char_cap():
+    """A full widget preview must not push the preamble over its own cap.
+
+    MUTATION: set ``WIDGET_PREVIEW_LIMIT = 60`` in
+    ``ee/pocketpaw_ee/cloud/surface/handlers/_helpers.py``. 60 lines at ~36
+    chars is ~2,170 chars against a 1,500 cap, ``truncate_preamble`` fires, and
+    both assertions below fail.
+    """
+    raw = _render_preamble(300)
+
+    assert len(raw) <= PREAMBLE_MAX_CHARS, (
+        f"{WIDGET_PREVIEW_LIMIT} widgets render a {len(raw)}-char preamble, over "
+        f"the {PREAMBLE_MAX_CHARS}-char cap — truncation would eat the node and "
+        "backend summaries, not the widget list that overflowed it."
+    )
+    assert truncate_preamble(raw) == raw
+
+
+def test_truncation_would_eat_the_wiring_summaries_not_the_widgets():
+    """Why the cap above is load-bearing rather than cosmetic.
+
+    Pins the failure MODE: ``truncate_preamble`` drops trailing lines, so an
+    over-long preamble loses the blocks that come last. If a future refactor
+    made truncation cut the widget rows instead, the test above would be
+    guarding a risk that no longer exists and should be revisited.
+
+    MUTATION: change ``truncate_preamble`` to keep the LAST lines rather than
+    the first (iterate ``reversed(lines)``). Verified 2026-08-03: the head
+    assertion is the one that fires — the surface tag is dropped — and the
+    backend summary survives, so the last assertion would fail too.
+    """
+    raw = _render_preamble(300)
+    # Force overflow independent of the real cap, so this test documents the
+    # helper's behaviour rather than today's cap values.
+    cut = truncate_preamble(raw, limit=300)
+
+    assert cut != raw
+    assert cut.endswith("... (truncated)")
+    assert "<surface kind=" in cut, "truncation must keep the head"
+    assert "<pocket-backend>" not in cut, "truncation drops the tail — that is the risk"
+
+
+def test_a_small_pocket_is_never_truncated():
+    """The common case stays whole.
+
+    Most pockets hold fewer widgets than the preview limit, and that preamble
+    must survive intact — it is the agent's only view of the surface.
+
+    MUTATION: set ``PREAMBLE_MAX_CHARS = 200`` in ``_helpers.py``; the 5-widget
+    preamble (~400 chars) is then cut and both assertions fail.
+    """
+    raw = _render_preamble(5)
+
+    assert truncate_preamble(raw) == raw
+    assert "<pocket-backend>" in raw

--- a/tests/llm/test_caching.py
+++ b/tests/llm/test_caching.py
@@ -313,3 +313,71 @@ class TestConstants:
         assert CACHE_MIN_TOKENS["default"] == 1024
         assert CACHE_MIN_TOKENS["anthropic-haiku"] == 4096
         assert CACHE_MIN_TOKENS["anthropic-opus"] == 4096
+
+    def test_no_sonnet_floor_is_above_the_default(self):
+        """Every shipping Sonnet caches from 1024 tokens (PA-9, 2026-08-03).
+
+        This row read 2048 until PA-9, which is not the floor of any Sonnet that
+        has ever shipped. Being too STRICT is the expensive direction: it skips
+        marking prompts that would have cached, forfeiting the saving outright.
+        (Being too permissive is free — a sub-floor marker is declined at no
+        charge, measured the same day.)
+
+        MUTATION: set ``anthropic-sonnet`` back to 2048 in
+        ``src/pocketpaw/llm/caching.py``; this fails.
+        """
+        assert CACHE_MIN_TOKENS["anthropic-sonnet"] == 1024
+
+    def test_opus_floors_are_not_monotonic_across_generations(self):
+        """Opus cannot be one number, which is why the per-generation rows exist.
+
+        The floor FALLS as the generation rises — 4096 on Opus 4.5/4.6 down to
+        512 on Opus 5 — so any single "the Opus floor" value is wrong for most
+        Opus models. The family key deliberately keeps the most conservative
+        value for callers that cannot resolve a generation.
+
+        MUTATION: delete the ``anthropic-opus-5`` row (or set it to 4096) in
+        ``src/pocketpaw/llm/caching.py``; the ordering assertion fails.
+        """
+        assert CACHE_MIN_TOKENS["anthropic-opus-5"] == 512
+        assert CACHE_MIN_TOKENS["anthropic-opus-4.8"] == 1024
+        assert CACHE_MIN_TOKENS["anthropic-opus-4.5"] == 4096
+        # Newer generation, LOWER floor — the property a single key destroys.
+        assert CACHE_MIN_TOKENS["anthropic-opus-5"] < CACHE_MIN_TOKENS["anthropic-opus-4.5"]
+        # The family key must never promise more than the strictest generation.
+        assert CACHE_MIN_TOKENS["anthropic-opus"] == max(
+            CACHE_MIN_TOKENS[k] for k in CACHE_MIN_TOKENS if k.startswith("anthropic-opus-")
+        )
+
+    def test_deep_agents_char_threshold_is_deliberately_below_the_haiku_floor(self):
+        """The PA-9 headline, in executable form.
+
+        ``_ANTHROPIC_CACHE_MIN_CHARS`` gates cache marking in CHARS while the
+        floors are in TOKENS. Measured 2026-08-03 at 3.48 chars/token on our own
+        prompt text, 4000 chars is ~1,149 tokens — a quarter of Haiku 4.5's
+        4096-token floor, which sits near 14,250 chars.
+
+        This is asserted rather than fixed BECAUSE the low value is correct. A
+        sub-floor marker is declined free of charge (marked and unmarked calls
+        billed identically), so an over-permissive gate costs nothing, while
+        raising this to ~14,250 would stop marking on Opus 4.8 (floor 1024) and
+        Opus 5 (floor 512) where 4k-14k prompts cache today — turning a harmless
+        inaccuracy into a real regression. This test exists so that anyone
+        "correcting" the threshold trips a failure and reads the reasoning first.
+
+        MUTATION: set ``_ANTHROPIC_CACHE_MIN_CHARS = 20000`` in
+        ``src/pocketpaw/agents/deep_agents.py``; this fails.
+        """
+        from pocketpaw.agents.deep_agents import _ANTHROPIC_CACHE_MIN_CHARS
+
+        measured_chars_per_token = 3.48
+        threshold_tokens = _ANTHROPIC_CACHE_MIN_CHARS / measured_chars_per_token
+
+        assert threshold_tokens < CACHE_MIN_TOKENS["anthropic-haiku"], (
+            "The chars threshold now clears the Haiku floor. That is not a fix — "
+            "it stops marking on Opus 4.8/5, whose floors are 1024/512. See the "
+            "constant's comment in deep_agents.py before changing this."
+        )
+        # ...but it must still clear the lowest floor we ship against, or the
+        # gate would be excluding prompts that cache on every modern Opus.
+        assert threshold_tokens > CACHE_MIN_TOKENS["anthropic-opus-5"]

--- a/tests/llm/test_caching.py
+++ b/tests/llm/test_caching.py
@@ -314,6 +314,22 @@ class TestConstants:
         assert CACHE_MIN_TOKENS["anthropic-haiku"] == 4096
         assert CACHE_MIN_TOKENS["anthropic-opus"] == 4096
 
+    def test_deepseek_floor_is_the_measured_512_not_the_documented_1024(self):
+        """DeepSeek cached a 595-token prefix (PA-9, 2026-08-03).
+
+        Measured on deepseek-v4-flash through the LiteLLM gateway: a 595-token
+        prompt reported 512 cached tokens on the warm turn, so the real floor is
+        at or below 512 and reads arrive in 512-token blocks. The documented
+        1024 was conservative in the direction that costs money — it would skip
+        prompts between 512 and 1024 that do in fact cache.
+
+        MUTATION: set ``deepseek`` back to 1024 in
+        ``src/pocketpaw/llm/caching.py``; this fails.
+        """
+        assert CACHE_MIN_TOKENS["deepseek"] == 512
+        # Below the generic default, which is the whole point of the row.
+        assert CACHE_MIN_TOKENS["deepseek"] < CACHE_MIN_TOKENS["default"]
+
     def test_no_sonnet_floor_is_above_the_default(self):
         """Every shipping Sonnet caches from 1024 tokens (PA-9, 2026-08-03).
 


### PR DESCRIPTION
Stacked on #1854, which is stacked on #1852, which is stacked on #1851. Review down the stack first; this branch is based on #1854's head, not on `dev`.

## What this does

Every cap in the prompt path was set by judgement and carried forward. This puts numbers on them. Two of the numbers changed a conclusion, and one changed the conclusion I expected it to change in the opposite direction.

## The threshold is wrong and stays anyway

`deep_agents` gates `cache_control` marking on a 4000-CHAR system prompt, while the provider floors in `CACHE_MIN_TOKENS` are in TOKENS. Measured on Haiku 4.5: a 3,304-token prefix never caches and a 4,478-token one does, bracketing the documented 4096 floor exactly. At 3.48 chars per token, measured on our own prompt text rather than the divide-by-four rule of thumb, the 4000-char gate is about 1,150 tokens. It clears no Anthropic floor except Opus 5's.

The obvious fix is to raise it, and the obvious fix is wrong. The other half of the old comment was also mistaken: a sub-floor marker does not cost a wasted cache write. A marked and an unmarked sub-floor call billed identically to six significant figures, because the provider declines silently and charges nothing. So an over-permissive gate is inert, while "correcting" it to about 14,300 chars would stop marking on Opus 4.8 and Opus 5 and forfeit a real saving.

It stays at 4000, and a test now asserts the relationship so the next person who notices the discrepancy reads the reasoning before fixing it.

## `CACHE_MIN_TOKENS` had three wrong rows

`anthropic-sonnet` read 2048, which is not the floor of any Sonnet that has shipped. `anthropic-opus` cannot be one number at all, because the floors run 512 to 4096 and fall as the generation rises, so it is per-generation now. `deepseek` read 1024, but a 595-token prefix cached with 512 read, so it is 512 and reads arrive in 512-token blocks.

All three erred toward being too strict, which is the direction that silently forfeits caching rather than the one that merely wastes a marker.

## The warm-turn table

Seven turns over a 40,000-char slice of the specialist prompt, through the gateway:

```
turn  prompt_tok  cache_read  uncached          $
   1       10578           0     10578   0.001481
   2       10578       10496        82   0.000041
 ...
   7       10578       10496        82   0.000041
```

99.2% of the prefix is served from cache on every warm turn, and a warm turn is 36x cheaper than the cold one. The 82-token remainder is the varying user turn, which is the prefix/suffix split behaving as `build_cacheable` intends.

**Read that as DeepSeek, not as Anthropic.** The gateway serves DeepSeek only, and DeepSeek caches automatically and ignores `cache_control` entirely. So this validates the harness and the byte-stable-prefix discipline the three PRs below this one built, and says nothing about whether a marker reaches the wire on Anthropic. That question was answered separately on the OpenRouter route.

## A defect in the harness, fixed rather than shipped around

The write-premium check reused ONE prefix for both arms, so the second call read the cache the first had just written. That is invisible on Anthropic at 4000 chars, where nothing caches and both arms are genuinely cold, but on DeepSeek it reported a 13x "write premium" that was only a warm turn.

The arms now use distinct salts, the check refuses to conclude anything if either arm reads from cache, and it words its verdict differently above and below the model's floor so a DeepSeek run cannot be quoted as evidence about Anthropic. The sub-floor finding above survives this, on different evidence: the sweep independently shows 0 cached tokens at 4000 chars on both the cold and the warm turn.

## Caps left alone, with reasons

`_DEFAULT_BUDGET_CHARS` is 8,874 tokens and stays at 32,000, now for a caching reason that runs opposite to the intuition: trimming it toward 14,000 chars would drop a Haiku prompt under its cache floor and cost more per conversation than it saves per turn. Note this justifies not shrinking it. It still does not justify 32,000 over any other number above the floor.

`PREAMBLE_MAX_CHARS` costs 378 tokens a turn. The 12-widget cut renders at 609 of 1500 chars, so about 36 widgets would still fit, and it stays at 12 because the preamble is digested into the surface cache key: each extra widget is another edit that invalidates and buys a reconnect. Cheap in tokens, unmeasured in reconnects. The cut moved out of a bare literal into `WIDGET_PREVIEW_LIMIT` beside `PREAMBLE_MAX_CHARS`, and a test holds an interaction that was previously true only by luck, since overflow truncates the tail and a raised widget limit would silently delete the pocket's wiring summary rather than the widget list that caused the overflow.

## A correction to #1854

`prompt_pocket_summary_only` saves 648 tokens a turn, taking a 300-widget block from 1,092 to 444 tokens. The config docstring in #1854 implied about 39.6k chars, which described the pre-bound block. `_WIDGET_SUMMARY_MAX_CHARS` already removed that, so the block plateaus near 3,240 chars and no longer grows with pocket size.

## Harness

`scripts/evals/prompt_cache_eval.py`. Route selection is `--route {openrouter,litellm}`, and `--arm threshold` warns that it is meaningless on the gateway. It skips cleanly when no key is configured, reads keys from settings at run time, and reuses `report_savings` rather than adding a second savings reporter. No key is committed anywhere.

Total spend across every measurement in this PR, taken from account usage rather than summed per-call: about $0.13.

## Suite

132 failed, 8911 passed, 14 skipped on this branch. The failure count is lower than the 135 the earlier PRs in this stack reported because the stack was rebased onto a moved `dev` partway through, and `dev`'s own changes fixed three. All 57 tests across the three files this PR and #1854 touch pass.

A caveat on attribution: because the rebase moved the baseline under this branch, I have not re-run a full suite on the rebased #1854 tip, so I cannot give an exact passed-count delta for this PR alone. The check that matters is that failures went down rather than up.
