### PR TITLE
Give the about-member block an id, because a name is not one

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -85,6 +85,17 @@ gained a ``pocket_id`` kwarg and ``current_pocket_id()`` was added beside
 The identity-token tuple grew from 3 to 4 entries; existing 3-arg callers are
 unaffected (``pocket_id`` defaults to ``None``).
 
+Changes: 2026-08-03 (feat/about-member-id) — the ``<about-member>`` block
+carries the member's ``user_id``. It described people by ``name · role · team``
+and nothing else, so two members called the same thing rendered byte-identical
+blocks and the agent had no way to tell which one it was addressing. That is not
+an edge case here: ``_resolve_about_member`` runs from every scope resolver and
+is NOT gated on room type, unlike the member-private ``user:`` KB scope, so it
+is live in shared rooms. The id is ``person.user_id`` — the same opaque cloud id
+the KB scope keys on — and not ``person.id``, which is
+``person-{workspace}-{user}`` and would put a tenant id in the prompt for no
+gain. An id-less Person still renders its block, minus the line.
+
 Changes: 2026-06-08 (feat/vip-agent-block, pp#1367) — ``ScopeContext`` carries
 an optional ``about_member_block``: a concise, token-capped "about this member"
 string (name · role · team · one-line focus) rendered from the member's Fabric
@@ -825,6 +836,16 @@ def _render_about_member_block(person: Person) -> str:
         "tailor your help to their role and focus.",
         f"  who: {identity}",
     ]
+    # The id, because a name does not identify anybody. Rooms are shared and two
+    # members can be called the same thing; without this the block renders
+    # identically for both, the agent cannot tell which one it is addressing, and
+    # anything it attributes to "Alex" is ambiguous the moment a second Alex
+    # joins. ``user_id`` and not ``person.id`` — the latter is
+    # ``person-{workspace}-{user}``, which carries the same information plus a
+    # tenant id the model has no use for. Same opaque cloud id the KB scope
+    # already keys on, never an email.
+    if person.user_id:
+        lines.append(f"  id: {person.user_id}")
     if focus:
         lines.append(f"  focus: {focus}")
     lines.append("</about-member>")

--- a/tests/cloud/chat/test_about_member_block.py
+++ b/tests/cloud/chat/test_about_member_block.py
@@ -1,5 +1,8 @@
 # tests/cloud/chat/test_about_member_block.py — agent member-orientation block.
 # Created: 2026-06-08 (feat/vip-agent-block, pp#1367).
+# Updated: 2026-08-03 (feat/about-member-id) — adds contract 5: the block carries
+#   the member's user_id, so two members sharing a name are distinguishable. The
+#   block identified people by name alone, and rooms are shared.
 #
 # Locks the contract for the "about this member" block that orients the chat
 # agent to who is talking (pp#1367):
@@ -42,11 +45,12 @@ def _person(
     role: str = "admin",
     group: str | None = "team-eng",
     focus: str = "Own the billing rewrite",
+    user_id: str = "user-7",
 ) -> Person:
     return Person(
-        id="person-ws1-user-7",
+        id=f"person-ws1-{user_id}",
         workspace_id="ws1",
-        user_id="user-7",
+        user_id=user_id,
         name=name,
         email="ada@x.c",
         avatar="",
@@ -221,3 +225,49 @@ class TestResolveAboutMember:
         # No workspace / user ⇒ no read attempted, None returned.
         assert await _resolve_about_member("", "user-7") is None
         assert await _resolve_about_member("ws1", "") is None
+
+
+class TestTwoMembersWithOneName:
+    """A name does not identify anybody, and rooms are shared.
+
+    Added 2026-08-03. The block carried name / role / team / focus and no id, so
+    two members called the same thing rendered byte-identical blocks: the agent
+    could not tell which one it was addressing, and anything it attributed to
+    "Alex" became ambiguous the moment a second Alex joined. Not hypothetical —
+    ``_resolve_about_member`` is called by every scope resolver and is NOT gated
+    on room type, unlike the member-private ``user:`` KB scope.
+    """
+
+    def test_same_name_and_role_still_render_different_blocks(self) -> None:
+        """MUTATION: drop the ``id:`` line from ``_render_about_member_block``.
+
+        Both members render identically and this fails. (Applied 2026-08-03.)
+        """
+        one = _render_about_member_block(_person(name="Alex", user_id="user-a"))
+        two = _render_about_member_block(_person(name="Alex", user_id="user-b"))
+        assert one != two, "two members sharing a name are indistinguishable to the agent"
+        assert "user-a" in one
+        assert "user-b" in two
+
+    def test_the_id_is_the_cloud_user_id_not_the_fabric_object_id(self) -> None:
+        """``person.id`` is ``person-{workspace}-{user}`` and leaks a tenant id.
+
+        The block should carry the same opaque cloud id the KB scope keys on, and
+        nothing more.
+
+        MUTATION: render ``person.id`` instead of ``person.user_id``. The
+        workspace assertion fails. (Applied 2026-08-03.)
+        """
+        block = _render_about_member_block(_person(user_id="user-7"))
+        assert "  id: user-7" in block
+        assert "ws1" not in block, "the block must not carry the workspace id"
+
+    def test_a_member_with_no_id_still_renders(self) -> None:
+        """An id-less Person must not lose its block — degrade, never drop.
+
+        MUTATION: make the ``id:`` line unconditional. This raises or renders a
+        bare ``id:`` line. (Applied 2026-08-03.)
+        """
+        block = _render_about_member_block(_person(user_id=""))
+        assert "Alex" in block or "Ada" in block
+        assert "id:" not in block


### PR DESCRIPTION
Top of the stack: #1851 → #1852 → #1854 → #1855 → this. Review down first.

## The problem

`<about-member>` orients the chat agent to whoever it is talking to. It carried `name · role · team` and a one-line focus, and no identifier.

Rooms are shared and two members can be called the same thing. When they are, the block renders byte-identical for both. The agent cannot tell which one it is addressing, and anything it attributes to "Alex" is ambiguous the moment a second Alex joins.

This is not a hypothetical corner. `_resolve_about_member` is called from every scope resolver and is **not** gated on room type — unlike the member-private `user:` KB scope, which the caller deliberately sets only in a member's own solo session. So the block is already live in group chats.

The `user` layer added in #1851 made this exact argument for its cache key: "letting two people share a key because neither has filled in a profile is the #1842 shape with a sympathetic cause." The reasoning was applied to the key and never to the text the key describes.

## The fix

One line, `  id: <user_id>`, next to `who:`.

It is `person.user_id`, not `person.id`. The latter is `person-{workspace_id}-{user_id}` — same information plus a tenant id the model has no use for. `user_id` is the same opaque cloud id the KB scope already keys on, and never an email, which is the property `KbContext` documents for the same field.

A Person with no `user_id` still renders its block, minus the line. Degrading is right here: the block exists to orient the agent, and dropping it entirely over a missing id would trade a partial answer for none.

## Tests

Three, each naming its mutation in the docstring, each mutation applied and re-run rather than argued:

- drop the `id:` line — two Alexes collide, and the same-name test fails
- render `person.id` instead — the workspace id appears in the prompt and the assertion fails
- make the line unconditional — an id-less member loses its block

`tests/cloud/chat/` is green at 123 passed.

## Cost

The block's bytes change, so the `instructions` layer's digest changes, which costs one agent-cache rebuild at deploy. That is the price every layer split in this sprint has paid and it is a one-off.

## Still open, deliberately not fixed here

Two members who have no materialized `Person` at all still render no block each, so they remain indistinguishable to the agent. Emitting an id-only block for them would change when the block appears at all, which is a bigger behaviour change than this PR wants to make.