### PR TITLE
Prompt rows carry a resolvable id, and the exemptions are checked

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -334,6 +334,39 @@ When you touch any `ee/pocketpaw_ee/cloud/<entity>/*.py` file for any reason —
 
 ---
 
+## Prompt rows must carry the id the tools take
+
+Applies to every prompt block that lists entities — cloud surface preambles
+(`ee/pocketpaw_ee/cloud/surface/handlers/`) and the channel prompt layers
+(`src/pocketpaw/prompt/`) alike.
+
+**The rule:** if any tool declares a required `<kind>_id`, every prompt row that
+lists `<kind>`s must carry that id.
+
+**Never hand-roll a row.** Use `pocketpaw.prompt.entity.entity_line(label,
+entity_id, **facts)`. `entity_id` is a required positional, so a row cannot
+silently omit it; pass `None` where there genuinely is no id and it renders a
+visible `id=?`.
+
+**Why:** four handlers independently rendered `- {name} (…)` with no id while
+`update_widget` required `widget_id`, so the prompt named widgets and pockets the
+agent could not address. Two pockets called "Sales" rendered identical rows and
+the tool call resolved to the wrong one silently. `rows.append(f"- {name} …")` is
+the obvious thing to type, which is why this is a gate and not a review note.
+
+**Enforcement** (`tests/cloud/surface/test_entity_id_contract.py`): an AST scan
+fails any hand-rolled row; allow-listed modules pin their row *count*, so an
+exempt file cannot grow a new one; and the set of addressable kinds is **derived
+from the MCP tool schemas**, so adding a tool with a required `site_id` fails the
+build until someone decides whether the sites preamble owes an id.
+
+**Rendering an id costs ~30 chars a row.** That is real — carrying the widget id
+took the 300-widget preamble from 41% to 77% of `PREAMBLE_MAX_CHARS`. Check the
+cap when you convert a list, and make the fixture carry a *realistic* id: a test
+widget with no `id` measures rows 23 chars shorter than production.
+
+---
+
 ## Desktop Client (`client/`)
 
 The Tauri 2.0 + SvelteKit desktop app lives in `client/`. It connects to the Python backend via REST/WebSocket.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -360,10 +360,52 @@ exempt file cannot grow a new one; and the set of addressable kinds is **derived
 from the MCP tool schemas**, so adding a tool with a required `site_id` fails the
 build until someone decides whether the sites preamble owes an id.
 
-**Rendering an id costs ~30 chars a row.** That is real — carrying the widget id
-took the 300-widget preamble from 41% to 77% of `PREAMBLE_MAX_CHARS`. Check the
-cap when you convert a list, and make the fixture carry a *realistic* id: a test
-widget with no `id` measures rows 23 chars shorter than production.
+**No id to render?** Use `unaddressed_line("<kind>", label, **facts)` — it emits
+no id, and the `<kind>` literal is *checked* against the tool schemas, so the
+exemption fails the moment a tool starts requiring that id. Prefer it over adding
+an allow-list entry.
+
+**Ids render short.** `entity_line` shows the last 8 characters
+(`id=…3f9a1c07`), and `ee/pocketpaw_ee/cloud/pockets/id_resolve.py` resolves a
+tail back to the whole id, scoped to the workspace/pocket, erroring on ambiguity
+rather than picking. The **tail**, not the head: an ObjectId starts with a
+timestamp, so 12 widgets created together share their first 20 characters.
+
+**Check the cap when you convert a list, and make the fixture realistic.** A test
+entity with no `id` measures rows ~23 chars shorter than production, and the cap
+test will pass while reporting headroom that isn't there.
+
+---
+
+## A gate is not a gate until a mutation has been observed to break it
+
+Applies to any test you are treating as protection — a contract test, a cap
+assertion, a security check, a regression guard.
+
+**Before claiming a test guards something, break the code on purpose and watch it
+fail.** Use `scripts/mutate.py`:
+
+```bash
+uv run python scripts/mutate.py --plan tests/mutations/<area>.json
+```
+
+A plan is a JSON list of `{label, file, find, replace, tests}`. The script applies
+each mutation, runs the tests, restores the file, and exits non-zero if any
+mutation **escaped** (tests still passed).
+
+**Why:** a passing test means the code and the test agree, which is also true when
+both are wrong. That is not hypothetical here — `updatedAt` never updated and
+every key on it reported "unchanged"; a `FunctionModel` double advertised native
+tool search and a deferred-loading probe reported 0% saving; a cap fixture with no
+`id` measured rows 23 chars short and kept passing; a positional-only test
+asserted a `TypeError` that came from a missing argument, not from the property it
+named. Each was found by mutation, not by review.
+
+**How to apply:** when you add or change a gate, add its mutations to a plan under
+`tests/mutations/` and run it. Docstrings in this repo name the mutation that
+breaks each test — that convention is only worth anything if the mutation was
+actually run, so run it. An escaping mutation is a bug in your test, not a
+curiosity.
 
 ---
 

--- a/ee/pocketpaw_ee/cloud/pockets/id_resolve.py
+++ b/ee/pocketpaw_ee/cloud/pockets/id_resolve.py
@@ -1,0 +1,119 @@
+# id_resolve.py — turn the shortened id the prompt showed back into a real one.
+#
+# Created: 2026-08-03 (feat/prompt-entity-suffix).
+#
+# WHY THIS EXISTS. The prompt used to render whole 24-char ObjectIds on every
+# entity row, which cost 24 of the ~70 chars in a widget row inside a 1500-char
+# preamble cap. ``pocketpaw.prompt.entity`` now renders the last 8 characters
+# instead, so the tools have to accept what the agent was shown.
+#
+# THE TAIL, NOT THE HEAD, and this is the load-bearing fact. An ObjectId is
+# 4 bytes of timestamp + 5 bytes of per-process random + a 3-byte counter, so
+# twelve widgets added to one pocket in one request share the first TWENTY hex
+# characters and differ only in the counter. Measured 2026-08-03: of 12 ids
+# created together, the first 12 hex chars gave 1 distinct value and the last 6
+# gave 12. Any prefix scheme here would have been worse than useless.
+#
+# THE SAFETY PROPERTY, stated plainly because getting it wrong reintroduces the
+# exact bug the id rendering was added to fix: an ambiguous tail RAISES. It never
+# picks, never takes the first match, never falls back to "closest". A silent
+# wrong-entity write is what "- Sales (type=custom)" already did; a short id that
+# resolved loosely would be the same bug wearing a different hat.
+#
+# Resolution is always SCOPED to a candidate list the caller supplies — a
+# workspace's pockets, a pocket's widgets. There is deliberately no "search all
+# collections for this tail" entry point: an unscoped resolve would be a tenancy
+# hole, since a tail from one workspace could land on another's document.
+
+from __future__ import annotations
+
+from typing import Any
+
+from pocketpaw.prompt.entity import ID_TAIL_CHARS, ID_TAIL_MARKER
+
+__all__ = ["AmbiguousId", "normalize_id_input", "resolve_id"]
+
+# Markers a model might reproduce when echoing a shortened id back. The single
+# character is what we render; "..." is what a model retyping it tends to
+# produce, and stripping both costs nothing.
+_STRIPPABLE_PREFIXES = (ID_TAIL_MARKER, "...")
+
+
+class AmbiguousId(ValueError):
+    """More than one candidate ends with the given tail.
+
+    Carries the matches so a tool can tell the agent what to disambiguate with,
+    rather than making it guess a second time.
+    """
+
+    def __init__(self, given: str, matches: list[str]) -> None:
+        self.given = given
+        self.matches = matches
+        super().__init__(
+            f"{given!r} matches {len(matches)} entities ({', '.join(matches[:5])}"
+            f"{', …' if len(matches) > 5 else ''}). Use the full id."
+        )
+
+
+def normalize_id_input(raw: Any) -> str:
+    """Strip the tail marker and whitespace off whatever the agent sent.
+
+    The agent sees ``id=…3f9a1c07`` and may send it back with the marker, with
+    an ASCII ``...``, with neither, or wrapped in quotes it picked up from the
+    surrounding text. All four mean the same thing.
+    """
+    text = str(raw or "").strip().strip("'\"").strip()
+    for prefix in _STRIPPABLE_PREFIXES:
+        if text.startswith(prefix):
+            text = text[len(prefix) :].strip()
+            break
+    return text
+
+
+def resolve_id(raw: Any, candidates: list[Any], *, key: str = "id") -> str:
+    """Resolve a whole-or-shortened id against a scoped candidate list.
+
+    ``candidates`` are the entities the caller has already tenancy-filtered —
+    one workspace's pockets, one pocket's widgets. ``key`` names the id
+    attribute (or dict key; both are accepted, because the pocket wire dict uses
+    ``_id`` while the domain objects use ``id``).
+
+    Returns the FULL id. Raises :class:`AmbiguousId` when a tail matches more
+    than one candidate, and :class:`KeyError` when it matches none.
+
+    An exact match always wins outright, even if the same string is also a tail
+    of some longer id. That ordering matters: a caller passing a real id — the
+    frontend, a stored reference, any pre-existing call site — must never be
+    told its own id is ambiguous.
+    """
+    given = normalize_id_input(raw)
+    if not given:
+        raise KeyError("no id given")
+
+    ids = [_id_of(c, key) for c in candidates]
+    ids = [i for i in ids if i]
+
+    if given in ids:
+        return given
+
+    # Only a plausible tail is worth matching. Anything longer than an id, or
+    # longer than what we ever render, is a typo rather than a shortening — and
+    # matching it loosely would be guessing.
+    if len(given) > ID_TAIL_CHARS:
+        raise KeyError(given)
+
+    matches = [i for i in ids if i.endswith(given)]
+    if len(matches) == 1:
+        return matches[0]
+    if len(matches) > 1:
+        raise AmbiguousId(given, matches)
+    raise KeyError(given)
+
+
+def _id_of(candidate: Any, key: str) -> str:
+    """Read an id off a dict or an object, tolerating the ``_id`` wire spelling."""
+    if isinstance(candidate, dict):
+        value = candidate.get(key) or candidate.get("_id") or candidate.get("id")
+    else:
+        value = getattr(candidate, key, None) or getattr(candidate, "id", None)
+    return "" if value is None else str(value)

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -2958,10 +2958,17 @@ async def _resolve_pocket_id_tail(given: str, workspace_id: str) -> tuple[str, s
 
     An ambiguous tail returns its error message rather than picking a winner.
     """
+    # ``get_pymongo_collection``, NOT ``get_motor_collection`` — the latter is
+    # beanie 1.x and this is on 2.1.0, where it does not exist. The first version
+    # of this used the old name; every isolated resolver and handler test still
+    # passed, because the broad ``except`` below turned a missing attribute into
+    # a tidy "could not resolve" string and no test called this function.
+    # ``tests/cloud/pockets/test_short_id_tool_wiring.py`` is what caught it.
     try:
-        cursor = _PocketDoc.get_motor_collection().find({"workspace": workspace_id}, {"_id": 1})
+        cursor = _PocketDoc.get_pymongo_collection().find({"workspace": workspace_id}, {"_id": 1})
         candidates = [{"_id": str(row["_id"])} async for row in cursor]
     except Exception as exc:  # noqa: BLE001
+        logger.warning("pocket id tail resolve failed for %s: %s", given, exc, exc_info=True)
         return "", f"could not resolve pocket {given}: {exc}"
     try:
         return resolve_id(given, candidates), None

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -322,6 +322,7 @@ from pocketpaw_ee.cloud.pockets.dto import (
     UpdateWidgetRequest,
     pocket_to_wire_dict,
 )
+from pocketpaw_ee.cloud.pockets.id_resolve import AmbiguousId, resolve_id
 from pocketpaw_ee.cloud.ripple_normalizer import normalize_ripple_spec
 from pocketpaw_ee.cloud.ripple_validator import (
     ActionWiringViolationError,
@@ -2940,6 +2941,36 @@ def _agent_view_dict(doc: _PocketDoc) -> dict:
     return json.loads(json.dumps(view, default=str))
 
 
+def _is_whole_object_id(value: str) -> bool:
+    """True for a full 24-hex-char ObjectId, the form every pre-existing caller sends."""
+    return len(value) == 24 and all(c in "0123456789abcdefABCDEF" for c in value)
+
+
+async def _resolve_pocket_id_tail(given: str, workspace_id: str) -> tuple[str, str | None]:
+    """Turn a shortened pocket id back into a whole one, WITHIN one workspace.
+
+    The workspace filter is the tenancy boundary and is not optional: an
+    unscoped tail resolve could land on another tenant's pocket, which is a
+    worse bug than the prompt bloat the shortening was introduced to fix. The
+    projection keeps this to ids only — a workspace's pocket count is small, but
+    there is no reason to drag every rippleSpec across the wire to compare 8
+    characters.
+
+    An ambiguous tail returns its error message rather than picking a winner.
+    """
+    try:
+        cursor = _PocketDoc.get_motor_collection().find({"workspace": workspace_id}, {"_id": 1})
+        candidates = [{"_id": str(row["_id"])} async for row in cursor]
+    except Exception as exc:  # noqa: BLE001
+        return "", f"could not resolve pocket {given}: {exc}"
+    try:
+        return resolve_id(given, candidates), None
+    except AmbiguousId as exc:
+        return "", str(exc)
+    except KeyError:
+        return "", f"pocket {given} not found"
+
+
 async def _agent_load_doc(pocket_id: str) -> tuple[_PocketDoc | None, str | None]:
     """Load a pocket for an agent-initiated mutation, with workspace +
     access-control checks.
@@ -2963,6 +2994,15 @@ async def _agent_load_doc(pocket_id: str) -> tuple[_PocketDoc | None, str | None
         return None, (
             "no active workspace/user — agent pocket mutations require a cloud SSE chat stream"
         )
+    # The prompt renders a SHORTENED id (last 8 chars — see
+    # ``pocketpaw.prompt.entity``), so the agent can hand one back. A whole id
+    # takes the direct path it always took; only a short one pays for a lookup,
+    # so no existing caller changes behaviour.
+    if not _is_whole_object_id(pocket_id):
+        resolved, resolve_err = await _resolve_pocket_id_tail(pocket_id, workspace_id)
+        if resolve_err is not None:
+            return None, resolve_err
+        pocket_id = resolved
     try:
         doc = await _PocketDoc.get(PydanticObjectId(pocket_id))
     except Exception as exc:  # noqa: BLE001
@@ -3438,6 +3478,16 @@ async def agent_update_widget(
     doc, err = await _agent_load_doc(pocket_id)
     if err:
         return None, err
+    # The prompt shows a shortened widget id, so accept one back. Widgets are
+    # already loaded and already scoped to this pocket, so the resolve is free
+    # and cannot reach another tenant's data. An ambiguous tail raises rather
+    # than patching whichever widget sorted first.
+    try:
+        widget_id = resolve_id(widget_id, list(doc.widgets))
+    except AmbiguousId as exc:
+        return None, str(exc)
+    except KeyError:
+        return None, f"widget {widget_id} not found in pocket {pocket_id}"
     widget = next((w for w in doc.widgets if w.id == widget_id), None)
     if widget is None:
         return None, f"widget {widget_id} not found in pocket {pocket_id}"

--- a/ee/pocketpaw_ee/cloud/surface/handlers/_helpers.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/_helpers.py
@@ -63,22 +63,28 @@ PREAMBLE_MAX_CHARS = 1500
 # ``handlers/pocket.py`` by PA-9 so the two caps that jointly bound this preamble
 # sit together and their interaction is visible — and testable.
 #
-# RE-MEASURED 2026-08-03 (feat/prompt-entity-ids), same fixture, after the row
-# started carrying the widget id. A line averages 70.2 chars (was 36.2), 12 lines
-# cost 842 (was 434) and the 300-widget preamble renders at 1159 — 77% of
-# PREAMBLE_MAX_CHARS, up from 41%.
+# RE-MEASURED 2026-08-03 on one fixture, three times, because the row changed
+# twice. Same ``_Widget`` fixture in ``tests/cloud/surface/test_preamble_caps.py``
+# throughout, so these numbers are comparable to each other and to PA-9's:
 #
-# THE TWO CAPS NOW NEARLY INTERACT, which PA-9 measured as comfortably clear:
-# ~16 widgets fit under 1500, where ~36 did. The 12-widget limit is unchanged and
-# still fits, but the margin is 1.3x rather than 3x, so RAISING it is now a real
-# constraint rather than a free choice — 17 widgets truncates, and truncation
-# eats the node and backend summaries at the tail, not the widget list that
-# caused it (``tests/cloud/surface/test_preamble_caps.py`` pins that ordering).
+#     row avg   12 rows   300-widget preamble   widgets that fit
+#      36.2       434        609  (41% of cap)        ~36     PA-9, no id
+#      70.2       842       1159  (77% of cap)        ~16     whole ObjectId
+#      55.2       662        979  (65% of cap)        ~21     8-char tail  <- now
 #
-# The 24 chars an ObjectId costs per row buys the agent the ability to call
-# ``update_widget`` at all; without it the row named a widget that could only be
-# addressed by spending a ``get_pocket`` round-trip, which is far more than 24
-# chars. See ``pocketpaw.prompt.entity``.
+# The middle row is why the tail exists. Carrying a whole 24-char ObjectId took
+# the margin over WIDGET_PREVIEW_LIMIT from 3x to 1.3x, which made raising the
+# limit a real constraint rather than a free choice. Rendering the last 8
+# characters instead (``pocketpaw.prompt.entity.short_id``, resolved back by
+# ``pockets/id_resolve.py``) buys most of that back: the margin is 1.75x.
+#
+# Truncation still eats the node and backend summaries at the tail rather than
+# the widget list that caused the overflow — ``test_preamble_caps.py`` pins that
+# ordering, and it is the reason the cap matters at all.
+#
+# What the remaining ~370 chars buy is the agent's ability to call
+# ``update_widget``. Without an id the row named a widget addressable only by
+# spending a ``get_pocket`` round-trip, which costs far more than 370 chars.
 #
 # KEPT at 12 anyway, and the reason is not token cost. This preamble's text is
 # digested into the surface ``cache_key`` (see ``handlers/pocket.py``), so every

--- a/ee/pocketpaw_ee/cloud/surface/handlers/_helpers.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/_helpers.py
@@ -7,6 +7,13 @@
 # audit-snapshot lines, etc.). Pulling these out keeps each handler
 # small (≤80 LOC) per the PR brief.
 #
+# Changes: 2026-08-03 (feat/prompt-entity-ids) — ``format_widget_line`` now
+# renders through ``pocketpaw.prompt.entity.entity_line`` and carries the widget
+# id. It named a widget the agent could not address while ``update_widget``
+# declares ``widget_id`` required; that module's docstring holds the full class
+# of bug and ``tests/cloud/surface/test_entity_id_contract.py`` stops a new
+# handler from re-introducing it.
+#
 # Changes: 2026-08-03 (PA-9, feat/prompt-budget-measurement) — both preamble
 # caps now carry their measured cost, and the 12-widget cut moved here from a
 # bare literal in ``handlers/pocket.py`` as ``WIDGET_PREVIEW_LIMIT`` so the two
@@ -35,6 +42,8 @@ import hashlib
 import logging
 from typing import Any
 
+from pocketpaw.prompt.entity import entity_line
+
 logger = logging.getLogger(__name__)
 
 # Preamble length cap. Soft cap — we never split mid-tag, just truncate
@@ -54,10 +63,22 @@ PREAMBLE_MAX_CHARS = 1500
 # ``handlers/pocket.py`` by PA-9 so the two caps that jointly bound this preamble
 # sit together and their interaction is visible — and testable.
 #
-# MEASURED 2026-08-03 (PA-9): a rendered widget line averages 36.2 chars, so 12
-# lines cost 434 chars and the full 300-widget preamble renders at 609 chars —
-# 41% of PREAMBLE_MAX_CHARS. The two caps do NOT interact today: ~36 widgets
-# would still fit under 1500.
+# RE-MEASURED 2026-08-03 (feat/prompt-entity-ids), same fixture, after the row
+# started carrying the widget id. A line averages 70.2 chars (was 36.2), 12 lines
+# cost 842 (was 434) and the 300-widget preamble renders at 1159 — 77% of
+# PREAMBLE_MAX_CHARS, up from 41%.
+#
+# THE TWO CAPS NOW NEARLY INTERACT, which PA-9 measured as comfortably clear:
+# ~16 widgets fit under 1500, where ~36 did. The 12-widget limit is unchanged and
+# still fits, but the margin is 1.3x rather than 3x, so RAISING it is now a real
+# constraint rather than a free choice — 17 widgets truncates, and truncation
+# eats the node and backend summaries at the tail, not the widget list that
+# caused it (``tests/cloud/surface/test_preamble_caps.py`` pins that ordering).
+#
+# The 24 chars an ObjectId costs per row buys the agent the ability to call
+# ``update_widget`` at all; without it the row named a widget that could only be
+# addressed by spending a ``get_pocket`` round-trip, which is far more than 24
+# chars. See ``pocketpaw.prompt.entity``.
 #
 # KEPT at 12 anyway, and the reason is not token cost. This preamble's text is
 # digested into the surface ``cache_key`` (see ``handlers/pocket.py``), so every
@@ -201,8 +222,15 @@ def format_widget_line(widget: Any) -> str:
     Accepts duck-typed widget objects (anything with ``name`` / ``type``
     attrs) so the helper works for both Beanie subdocs and domain
     objects without importing either.
+
+    CARRIES THE WIDGET ID because ``update_widget`` declares it required
+    (``"required": ["pocket_id", "widget_id", "fields"]``) — see
+    ``pocketpaw.prompt.entity``. Until 2026-08-03 this row named a widget the
+    agent had no way to address, so editing one meant a ``get_pocket``
+    round-trip to recover the id the prompt had already dropped, and two
+    same-named widgets stayed ambiguous even after it.
     """
-    name = getattr(widget, "name", None) or "(unnamed)"
+    name = getattr(widget, "name", None)
     kind = getattr(widget, "type", None) or "custom"
     spec = getattr(widget, "spec", None)
     if kind == "native":
@@ -211,7 +239,7 @@ def format_widget_line(widget: Any) -> str:
         marker = "spec — BROKEN (no spec subtree)" if not spec else "spec — live"
     else:
         marker = f"{kind} — live" if spec else f"{kind} — no spec"
-    return f"- {name} ({marker})"
+    return entity_line(name, getattr(widget, "id", None), state=marker)
 
 
 __all__ = [

--- a/ee/pocketpaw_ee/cloud/surface/handlers/agents.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/agents.py
@@ -3,6 +3,20 @@
 # Created: 2026-05-24 — Workspace agents list. Reads via
 # ``agents_service.list_agents`` (tenancy via workspace_id).
 #
+# Changes: 2026-08-03 (feat/prompt-entity-ids) — renders through
+# ``pocketpaw.prompt.entity.entity_line``. This handler was ALREADY the one that
+# got it right: it carried ``slug``, the only surface row in the package with any
+# identifier at all. It is converted anyway, because the contract test checks the
+# SHAPE of the call — a hand-rolled row that happens to be correct today is one
+# edit away from not being, and the exemplar is the worst place to leave that.
+#
+# NO TOOL TAKES AN AGENT ID either — enumerating every MCP server's schemas on
+# 2026-08-03 found no ``agent_id`` parameter, required or optional — so, like
+# files.py, this row is outside the rule that forced the pocket and widget ids.
+# The slug survives as a fact because it is the handle a human uses; the id joins
+# it because two agents can be renamed to the same display name while their slugs
+# and ids stay distinct, and the row should not be the thing that hides that.
+#
 # Changes: 2026-08-02 (PA-2, feat/prompt-assembler-seam) — returns a
 # ``SurfacePreamble``. Mutable state, read as a LIST (every agent's name and
 # slug), so the key is a digest of what was rendered rather than a revision:
@@ -13,6 +27,7 @@ from __future__ import annotations
 
 import logging
 
+from pocketpaw.prompt.entity import entity_line
 from pocketpaw_ee.cloud.surface.domain import SurfaceMeta, SurfacePreamble
 from pocketpaw_ee.cloud.surface.handlers._helpers import (
     content_key,
@@ -50,9 +65,13 @@ async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> 
     else:
         rows = []
         for a in agents[:LIST_LIMIT]:
-            name = getattr(a, "name", None) or "(unnamed)"
-            slug = getattr(a, "slug", None) or "?"
-            rows.append(f"- {name} (slug={slug})")
+            rows.append(
+                entity_line(
+                    getattr(a, "name", None),
+                    getattr(a, "id", None),
+                    slug=getattr(a, "slug", None),
+                )
+            )
         if len(agents) > LIST_LIMIT:
             rows.append(f"... (+{len(agents) - LIST_LIMIT} more)")
         parts.append("<agents-list>\n" + "\n".join(rows) + "\n</agents-list>")

--- a/ee/pocketpaw_ee/cloud/surface/handlers/agents.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/agents.py
@@ -3,19 +3,18 @@
 # Created: 2026-05-24 — Workspace agents list. Reads via
 # ``agents_service.list_agents`` (tenancy via workspace_id).
 #
-# Changes: 2026-08-03 (feat/prompt-entity-ids) — renders through
-# ``pocketpaw.prompt.entity.entity_line``. This handler was ALREADY the one that
-# got it right: it carried ``slug``, the only surface row in the package with any
+# Changes: 2026-08-03 (feat/prompt-entity-suffix) — renders through
+# ``unaddressed_line("agent", ...)``. This handler was ALREADY the one that got
+# it right: it carried ``slug``, the only surface row in the package with any
 # identifier at all. It is converted anyway, because the contract test checks the
 # SHAPE of the call — a hand-rolled row that happens to be correct today is one
 # edit away from not being, and the exemplar is the worst place to leave that.
 #
-# NO TOOL TAKES AN AGENT ID either — enumerating every MCP server's schemas on
-# 2026-08-03 found no ``agent_id`` parameter, required or optional — so, like
-# files.py, this row is outside the rule that forced the pocket and widget ids.
-# The slug survives as a fact because it is the handle a human uses; the id joins
-# it because two agents can be renamed to the same display name while their slugs
-# and ids stay distinct, and the row should not be the thing that hides that.
+# NO TOOL TAKES AN AGENT ID — enumerating every MCP server's schema found no
+# ``agent_id`` parameter, required or optional — so no id is rendered. The
+# ``slug`` stays, because it is what a human and the agent both use to refer to
+# one, and it was already there. The ``"agent"`` literal is checked against the
+# derived kind set; see files.py for why that beats an allow-list entry.
 #
 # Changes: 2026-08-02 (PA-2, feat/prompt-assembler-seam) — returns a
 # ``SurfacePreamble``. Mutable state, read as a LIST (every agent's name and
@@ -27,7 +26,7 @@ from __future__ import annotations
 
 import logging
 
-from pocketpaw.prompt.entity import entity_line
+from pocketpaw.prompt.entity import unaddressed_line
 from pocketpaw_ee.cloud.surface.domain import SurfaceMeta, SurfacePreamble
 from pocketpaw_ee.cloud.surface.handlers._helpers import (
     content_key,
@@ -66,9 +65,9 @@ async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> 
         rows = []
         for a in agents[:LIST_LIMIT]:
             rows.append(
-                entity_line(
+                unaddressed_line(
+                    "agent",
                     getattr(a, "name", None),
-                    getattr(a, "id", None),
                     slug=getattr(a, "slug", None),
                 )
             )

--- a/ee/pocketpaw_ee/cloud/surface/handlers/calendar.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/calendar.py
@@ -37,6 +37,7 @@ import logging
 from datetime import datetime
 from typing import Any
 
+from pocketpaw.prompt.entity import unaddressed_line
 from pocketpaw_ee.cloud.surface.domain import SurfaceMeta, SurfacePreamble
 from pocketpaw_ee.cloud.surface.handlers._helpers import (
     content_key,
@@ -136,9 +137,14 @@ def _format_event_line(event: dict[str, Any]) -> str:
     title = str(event.get("title") or "(no title)").strip().splitlines()[0]
     start_raw = str(event.get("start") or "")
     when = _format_start_time(start_raw)
+    # No id: a Google Calendar event carries one, and nothing takes it. The
+    # ``meeting_id`` that five tools require addresses a ``_MeetingDoc`` in our
+    # own collection — a different entity, which no preamble lists. The
+    # ``"calendar_event"`` literal is checked against the derived kind set, so
+    # this stops being true loudly rather than silently.
     if when:
-        return f"- {when} · {title}"
-    return f"- {title}"
+        return unaddressed_line("calendar_event", f"{when} · {title}")
+    return unaddressed_line("calendar_event", title)
 
 
 def _format_start_time(iso: str) -> str:

--- a/ee/pocketpaw_ee/cloud/surface/handlers/files.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/files.py
@@ -5,21 +5,22 @@
 # have?" with real names rather than handwaving. Tenancy enforced by
 # the service.
 #
-# Changes: 2026-08-03 (feat/prompt-entity-ids) — rows render through
-# ``pocketpaw.prompt.entity.entity_line`` and carry ``UnifiedFile.id``.
+# Changes: 2026-08-03 (feat/prompt-entity-suffix) — renders through
+# ``unaddressed_line("file", ...)``, which carries NO id.
 #
 # NO TOOL TAKES A FILE ID. Checked, not assumed: enumerating every MCP server's
-# schemas on 2026-08-03 found no ``file_id`` parameter anywhere, required or
-# optional. So this row is NOT covered by the "a tool requires <kind>_id" rule
-# that forced the pocket and widget ids, and the ~30 chars it spends per row buy
-# something smaller: two uploads sharing a filename — the same document at two
-# revisions, which is the common case, not a corner one — were previously
-# indistinguishable in the listing, so the agent could not even TELL THE USER
-# there were two, let alone act on one. Disambiguation in the answer, not tool
-# addressing.
+# schema found no ``file_id`` parameter anywhere, required or optional. An
+# earlier pass on this branch rendered the id anyway and justified it as helping
+# the agent tell two same-named uploads apart; review cut it, correctly — that
+# benefit was reasoned backwards from a change already made, and it was spending
+# ~10 chars a row on an identifier nothing accepts.
 #
-# If that trade stops being worth it, the fix is to drop the id from this call —
-# not to hand-roll the row again. The contract test enforces the shape.
+# The ``"file"`` literal is not decoration. ``tests/cloud/surface/
+# test_entity_id_contract.py`` reads it and fails if ``file`` ever appears among
+# the kinds derived from the tool schemas, so the day a tool takes a ``file_id``
+# this handler stops passing instead of quietly under-informing the agent. That
+# is what makes this an exemption with a tripwire rather than an allow-list entry
+# nobody revisits.
 #
 # Changes: 2026-08-02 (PA-2, feat/prompt-assembler-seam) — returns a
 # ``SurfacePreamble``. Mutable state, read as a LIST (the most recent files'
@@ -31,7 +32,7 @@ from __future__ import annotations
 
 import logging
 
-from pocketpaw.prompt.entity import entity_line
+from pocketpaw.prompt.entity import unaddressed_line
 from pocketpaw_ee.cloud.surface.domain import SurfaceMeta, SurfacePreamble
 from pocketpaw_ee.cloud.surface.handlers._helpers import (
     content_key,
@@ -71,9 +72,9 @@ async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> 
         rows = []
         for f in files[:LIST_LIMIT]:
             rows.append(
-                entity_line(
+                unaddressed_line(
+                    "file",
                     getattr(f, "filename", None),
-                    getattr(f, "id", None),
                     mime=getattr(f, "mime", None),
                 )
             )

--- a/ee/pocketpaw_ee/cloud/surface/handlers/files.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/files.py
@@ -5,6 +5,22 @@
 # have?" with real names rather than handwaving. Tenancy enforced by
 # the service.
 #
+# Changes: 2026-08-03 (feat/prompt-entity-ids) — rows render through
+# ``pocketpaw.prompt.entity.entity_line`` and carry ``UnifiedFile.id``.
+#
+# NO TOOL TAKES A FILE ID. Checked, not assumed: enumerating every MCP server's
+# schemas on 2026-08-03 found no ``file_id`` parameter anywhere, required or
+# optional. So this row is NOT covered by the "a tool requires <kind>_id" rule
+# that forced the pocket and widget ids, and the ~30 chars it spends per row buy
+# something smaller: two uploads sharing a filename — the same document at two
+# revisions, which is the common case, not a corner one — were previously
+# indistinguishable in the listing, so the agent could not even TELL THE USER
+# there were two, let alone act on one. Disambiguation in the answer, not tool
+# addressing.
+#
+# If that trade stops being worth it, the fix is to drop the id from this call —
+# not to hand-roll the row again. The contract test enforces the shape.
+#
 # Changes: 2026-08-02 (PA-2, feat/prompt-assembler-seam) — returns a
 # ``SurfacePreamble``. Mutable state, read as a LIST (the most recent files'
 # names and mime types), so the key is a digest of what was rendered: it moves
@@ -15,6 +31,7 @@ from __future__ import annotations
 
 import logging
 
+from pocketpaw.prompt.entity import entity_line
 from pocketpaw_ee.cloud.surface.domain import SurfaceMeta, SurfacePreamble
 from pocketpaw_ee.cloud.surface.handlers._helpers import (
     content_key,
@@ -53,9 +70,13 @@ async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> 
     else:
         rows = []
         for f in files[:LIST_LIMIT]:
-            name = getattr(f, "filename", None) or "(unnamed)"
-            mime = getattr(f, "mime", None) or "?"
-            rows.append(f"- {name} ({mime})")
+            rows.append(
+                entity_line(
+                    getattr(f, "filename", None),
+                    getattr(f, "id", None),
+                    mime=getattr(f, "mime", None),
+                )
+            )
         parts.append("<files-list>\n" + "\n".join(rows) + "\n</files-list>")
     text = truncate_preamble("\n".join(parts))
     return SurfacePreamble(text=text, cache_key=content_key("files", text))

--- a/ee/pocketpaw_ee/cloud/surface/handlers/knowledge.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/knowledge.py
@@ -8,6 +8,14 @@
 # kb-unreachable path still degrades to "(no scopes detected)" so a
 # missing kb binary doesn't break the chat send.
 #
+# Changes: 2026-08-03 (feat/prompt-entity-suffix) — renders through
+# ``unaddressed_line("kb_scope", ...)`` rather than a bare f-string. A KB scope
+# is one of the cases where the label genuinely IS the address — ``workspace:w1``
+# is what a caller passes — so there is no id to add, and this handler wants the
+# no-id renderer rather than an exemption from the entity-row rule. Stating it
+# through the renderer means the claim gets checked against the tool schemas on
+# every run instead of sitting in an allow-list nobody rereads.
+#
 # Changes: 2026-08-02 (PA-2, feat/prompt-assembler-seam) — returns a
 # ``SurfacePreamble``. Mutable state, read as a LIST (the workspace's real KB
 # scopes), so the key is a digest of what was rendered: it moves when a scope
@@ -20,6 +28,7 @@ from __future__ import annotations
 
 import logging
 
+from pocketpaw.prompt.entity import unaddressed_line
 from pocketpaw_ee.cloud.kb import service as kb_service
 from pocketpaw_ee.cloud.surface.domain import SurfaceMeta, SurfacePreamble
 from pocketpaw_ee.cloud.surface.handlers._helpers import content_key, truncate_preamble
@@ -34,7 +43,7 @@ async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> 
     if not scopes:
         parts.append("<knowledge-snapshot>(no scopes detected)</knowledge-snapshot>")
     else:
-        rows = [f"- {s}" for s in scopes[:10]]
+        rows = [unaddressed_line("kb_scope", s) for s in scopes[:10]]
         body = "\n".join(rows)
         parts.append(f'<knowledge-scopes count="{len(scopes)}">\n{body}\n</knowledge-scopes>')
     text = truncate_preamble("\n".join(parts))

--- a/ee/pocketpaw_ee/cloud/surface/handlers/pockets_list.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/pockets_list.py
@@ -5,6 +5,14 @@
 # have?" without an extra round-trip. Uses ``pockets_service.list_pockets``
 # (tenancy enforced).
 #
+# Changes: 2026-08-03 (feat/prompt-entity-ids) — rows carry the pocket id.
+# ``get_pocket``, ``add_widget`` and ``update_widget`` all declare ``pocket_id``
+# required, and this preamble listed pockets by name alone: two called "Sales"
+# rendered byte-identical rows and the agent's only recourse was to guess or
+# spend a ``list_pockets`` call recovering what it had just been shown. Renders
+# through ``pocketpaw.prompt.entity.entity_line`` — the id comes from the wire
+# dict's ``_id``, which is what ``pocket_to_wire_dict`` emits (NOT ``id``).
+#
 # Changes: 2026-08-02 (PA-2, feat/prompt-assembler-seam) — returns a
 # ``SurfacePreamble``. This handler DOES read mutable state (the workspace's
 # pockets, with each one's name, type, widget count and agent count), but it
@@ -20,6 +28,7 @@ from __future__ import annotations
 
 import logging
 
+from pocketpaw.prompt.entity import entity_line
 from pocketpaw_ee.cloud.surface.domain import SurfaceMeta, SurfacePreamble
 from pocketpaw_ee.cloud.surface.handlers._helpers import (
     content_key,
@@ -58,11 +67,17 @@ async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> 
     else:
         rows = []
         for p in pockets[:LIST_LIMIT]:
-            name = p.get("name") or "(unnamed)"
-            kind = p.get("type") or "custom"
             widget_count = len(p.get("widgets", []) or [])
             agent_count = len(p.get("agents", []) or [])
-            rows.append(f"- {name} (type={kind}, widgets={widget_count}, agents={agent_count})")
+            rows.append(
+                entity_line(
+                    p.get("name"),
+                    p.get("_id"),
+                    type=p.get("type") or "custom",
+                    widgets=widget_count,
+                    agents=agent_count,
+                )
+            )
         if total > LIST_LIMIT:
             rows.append(f"... (+{total - LIST_LIMIT} more)")
         parts.append("<pockets-list>\n" + "\n".join(rows) + "\n</pockets-list>")

--- a/scripts/mutate.py
+++ b/scripts/mutate.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python
+"""Prove a test suite actually catches the bugs it claims to.
+
+Created: 2026-08-03 (feat/prompt-entity-suffix).
+
+WHY THIS EXISTS. A test that passes tells you nothing on its own — it tells you
+the code and the test agree, which is also true when both are wrong. In this
+codebase that is not a theoretical worry; it keeps happening, and always in
+plausible-looking code:
+
+  * ``TimestampedDocument._set_updated`` was never registered (beanie skips
+    ``_``-prefixed hooks), so every ``updatedAt`` holds its construction value.
+    Anything keying on it reviewed clean and reported every edit as "unchanged".
+  * A ``FunctionModel`` test double advertised native tool search, so a probe
+    measuring deferred tool loading reported 0% saving — for the double, not the
+    system.
+  * ``test_preamble_caps.py``'s fixture widget carried no ``id``, so once rows
+    began rendering one it measured them 23 chars shorter than production and
+    went on reporting headroom that was not there.
+  * A positional-only test in this very sprint passed with the ``/`` removed. It
+    was asserting a TypeError that came from a missing argument, not from the
+    thing it named.
+
+Every one of those was found by breaking the code on purpose and noticing the
+test did not care. This script makes that a command instead of a habit.
+
+WHAT IT DOES. Applies each mutation in a plan, runs the named tests, restores
+the file, and reports CAUGHT (tests failed — good) or ESCAPED (tests passed —
+the mutation is a bug your suite would ship). Exit code is non-zero if anything
+escaped, so it works in CI.
+
+    uv run python scripts/mutate.py --plan tests/mutations/entity_rows.json
+    uv run python scripts/mutate.py --plan <plan> --only "positional"
+
+RESTORATION IS THE ONE THING IT MUST NEVER GET WRONG. Original bytes are read
+once up front, every apply is wrapped in try/finally, SIGINT is trapped, and a
+final pass restores everything again on the way out. A crashed run that left a
+mutated file behind would be a far worse bug than any it could find.
+
+PLAN FORMAT — a JSON list of objects:
+
+    [
+      {
+        "label": "drop the id from the row",
+        "file": "src/pocketpaw/prompt/entity.py",
+        "find": "parts = [f\"id={ident}\"]",
+        "replace": "parts = []",
+        "tests": ["tests/test_prompt_entity_line.py"]
+      }
+    ]
+
+``find`` must appear EXACTLY ONCE in the file. An anchor that matches twice is
+rejected rather than guessed at, because replacing the wrong one produces a
+meaningless result that still looks like a pass.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import signal
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class Mutation:
+    __slots__ = ("file", "find", "label", "replace", "tests")
+
+    def __init__(self, raw: dict, index: int) -> None:
+        missing = {"label", "file", "find", "replace", "tests"} - raw.keys()
+        if missing:
+            raise SystemExit(f"mutation #{index}: missing {', '.join(sorted(missing))}")
+        self.label: str = raw["label"]
+        self.file: Path = REPO_ROOT / raw["file"]
+        self.find: str = raw["find"]
+        self.replace: str = raw["replace"]
+        self.tests: list[str] = list(raw["tests"])
+
+
+def _load_plan(path: Path) -> list[Mutation]:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        raise SystemExit(f"no such plan: {path}") from None
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"plan is not valid JSON: {exc}") from None
+    if not isinstance(raw, list):
+        raise SystemExit("plan must be a JSON list of mutation objects")
+    return [Mutation(item, i) for i, item in enumerate(raw)]
+
+
+def _run_tests(targets: list[str]) -> bool:
+    """True when the tests PASS. Mutation testing wants this to be False."""
+    proc = subprocess.run(
+        [sys.executable, "-m", "pytest", *targets, "-q", "--no-header", "-p", "no:cacheprovider"],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    return proc.returncode == 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("--plan", required=True, type=Path, help="path to a JSON mutation plan")
+    parser.add_argument("--only", default="", help="run only mutations whose label contains this")
+    parser.add_argument("--list", action="store_true", help="print the plan's mutations and exit")
+    args = parser.parse_args()
+
+    mutations = _load_plan(args.plan if args.plan.is_absolute() else REPO_ROOT / args.plan)
+    if args.only:
+        mutations = [m for m in mutations if args.only.lower() in m.label.lower()]
+    if not mutations:
+        raise SystemExit("no mutations matched")
+
+    if args.list:
+        for m in mutations:
+            print(f"  {m.label}  ->  {m.file.relative_to(REPO_ROOT)}")
+        return 0
+
+    # Read every original ONCE, before touching anything. If a file is missing
+    # or an anchor is bad, fail before the first mutation rather than half way
+    # through a run that then has to unwind.
+    originals: dict[Path, bytes] = {}
+    for m in mutations:
+        if not m.file.exists():
+            raise SystemExit(f"{m.label}: no such file {m.file}")
+        originals.setdefault(m.file, m.file.read_bytes())
+        text = originals[m.file].decode("utf-8")
+        found = text.count(m.find)
+        if found == 0:
+            raise SystemExit(f"{m.label}: anchor not found in {m.file.relative_to(REPO_ROOT)}")
+        if found > 1:
+            raise SystemExit(
+                f"{m.label}: anchor appears {found} times in "
+                f"{m.file.relative_to(REPO_ROOT)} — make it unique"
+            )
+
+    def _restore_all(*_signal_args: object) -> None:
+        for path, data in originals.items():
+            path.write_bytes(data)
+
+    signal.signal(signal.SIGINT, lambda *a: (_restore_all(), sys.exit(130)))
+
+    escaped: list[str] = []
+    try:
+        for m in mutations:
+            original = originals[m.file]
+            mutated = original.decode("utf-8").replace(m.find, m.replace, 1)
+            try:
+                m.file.write_bytes(mutated.encode("utf-8"))
+                passed = _run_tests(m.tests)
+            finally:
+                m.file.write_bytes(original)
+
+            if passed:
+                escaped.append(m.label)
+                print(f"  ESCAPED  {m.label}")
+            else:
+                print(f"  caught   {m.label}")
+    finally:
+        _restore_all()
+
+    print()
+    if escaped:
+        print(f"{len(escaped)} of {len(mutations)} mutations ESCAPED — the suite would ship these:")
+        for label in escaped:
+            print(f"  - {label}")
+        print("\nA gate is not a gate until a mutation has been observed to break it.")
+        return 1
+
+    print(f"all {len(mutations)} mutations caught")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/pocketpaw/prompt/entity.py
+++ b/src/pocketpaw/prompt/entity.py
@@ -1,0 +1,88 @@
+"""One way to name a thing the agent can act on.
+
+Created: 2026-08-03 (feat/prompt-entity-ids).
+
+THE BUG THIS CLOSES is not in any one handler. Every prompt block that lists
+entities was written independently, and they disagree about whether to carry the
+identifier the agent needs to act:
+
+    handlers/agents.py       - Research Bot (slug=research-bot)     <- carries one
+    handlers/pockets_list.py - Sales (type=custom, widgets=3)       <- does not
+    handlers/files.py        - report.pdf (application/pdf)         <- does not
+    _helpers.format_widget_line
+                             - Revenue (native)                     <- does not
+
+Meanwhile ``update_widget`` declares ``"required": ["pocket_id", "widget_id",
+"fields"]``. So the prompt names a widget the agent cannot address, and the agent
+either burns a round-trip re-fetching what it was just told, or guesses. Two
+pockets called Sales and the guess is a coin flip that fails silently — the tool
+call succeeds against the wrong entity.
+
+The same shape bit the ``<about-member>`` block (fixed 2026-08-03): it named
+people by name in rooms that can hold two people with one name.
+
+WHY A RENDERER AND NOT FOUR PATCHES. Patching the four known sites leaves the
+fifth handler — the one nobody has written yet — free to make the same mistake,
+and it will, because ``rows.append(f"- {name} ...")`` is the obvious thing to
+type. This module is the one spelling, and ``entity_id`` is a REQUIRED parameter:
+there is no way to call it that silently drops the id. A caller that genuinely
+has no id must pass ``None`` and gets ``id=?`` in the output — wrong, but VISIBLE
+in the prompt and greppable in the source, which is what "no id here" should cost.
+
+The enforcement half lives in ``tests/cloud/surface/test_entity_id_contract.py``:
+an AST scan that fails any handler hand-rolling a row, plus a check that derives
+the set of addressable entity kinds from the TOOL SCHEMAS rather than a list
+someone has to remember to update. Add a tool with a required ``site_id`` and the
+sites preamble is required to carry ids from that commit on.
+
+WHAT THIS DELIBERATELY DOES NOT DO is truncate the id. Every other field here is
+advisory and a shortened one still reads; an id is either exact or it is a failed
+tool call, so it is passed through whole and the caps are left to bite elsewhere.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["MISSING_ID", "entity_line"]
+
+# What renders in place of an id the caller could not supply. Deliberately short,
+# deliberately not empty, and deliberately not something that reads like a real
+# id: the agent must not pass it to a tool, and a human reading a prompt dump
+# should see the hole immediately. Grep for it to find call sites still missing.
+MISSING_ID = "?"
+
+
+def entity_line(label: Any, entity_id: Any, /, **facts: Any) -> str:
+    """Render one entity row for a prompt block.
+
+    ``- {label} (id={entity_id}, {k}={v}, ...)``
+
+    ``entity_id`` is positional and has NO default, which is the whole point of
+    the function — see the module docstring. Both leading arguments are
+    positional-only so a caller cannot pass ``label=`` / ``entity_id=`` and
+    shadow a fact of the same name.
+
+    Facts render in call order, so a handler controls what a reader sees first
+    after the id. Values are coerced through ``str``; a ``None`` or empty fact
+    value renders as ``?`` for the same reason ``MISSING_ID`` does — an empty
+    ``mime=`` reads as a formatting bug rather than as missing data.
+    """
+    name = _clean(label) or "(unnamed)"
+    ident = _clean(entity_id) or MISSING_ID
+    parts = [f"id={ident}"]
+    parts.extend(f"{key}={_clean(value) or MISSING_ID}" for key, value in facts.items())
+    return f"- {name} ({', '.join(parts)})"
+
+
+def _clean(value: Any) -> str:
+    """Collapse a value to one tidy line.
+
+    A newline inside a row would split it into two rows, and a row that is
+    really half a row is worse than a truncated one — the line-aware preamble
+    cap would then cut at a boundary that does not exist in the data. Filenames
+    and pocket names are user-supplied, so this is reachable, not theoretical.
+    """
+    if value is None:
+        return ""
+    return " ".join(str(value).split())

--- a/src/pocketpaw/prompt/entity.py
+++ b/src/pocketpaw/prompt/entity.py
@@ -2,6 +2,16 @@
 
 Created: 2026-08-03 (feat/prompt-entity-ids).
 
+Changes: 2026-08-03 (feat/prompt-entity-suffix) — two things, from review.
+
+  * ``entity_line`` renders a SHORT id (:data:`ID_TAIL_CHARS` trailing chars)
+    rather than the whole ObjectId, because the tools now resolve a tail. See
+    "WHY THE TAIL AND NOT THE HEAD" below — the head of an ObjectId is a
+    timestamp and is worthless for telling two rows apart.
+  * ``unaddressed_line`` exists for rows whose entity NO tool addresses by id.
+    It renders no id at all, and the kind it names is CHECKED against the tool
+    schemas, so the claim cannot quietly go stale.
+
 THE BUG THIS CLOSES is not in any one handler. Every prompt block that lists
 entities was written independently, and they disagree about whether to carry the
 identifier the agent needs to act:
@@ -29,22 +39,38 @@ there is no way to call it that silently drops the id. A caller that genuinely
 has no id must pass ``None`` and gets ``id=?`` in the output — wrong, but VISIBLE
 in the prompt and greppable in the source, which is what "no id here" should cost.
 
-The enforcement half lives in ``tests/cloud/surface/test_entity_id_contract.py``:
-an AST scan that fails any handler hand-rolling a row, plus a check that derives
-the set of addressable entity kinds from the TOOL SCHEMAS rather than a list
-someone has to remember to update. Add a tool with a required ``site_id`` and the
-sites preamble is required to carry ids from that commit on.
+WHY THE TAIL AND NOT THE HEAD, and why a short id is safe at all. A Mongo
+ObjectId is 4 bytes of timestamp, 5 bytes of per-process random, and a 3-byte
+counter. Twelve widgets added to one pocket in one request therefore share the
+first TWENTY hex characters and differ only in the counter — measured, not
+assumed. A prefix is worse than useless for this job; the tail is perfect. Eight
+tail chars is 4.3 billion values against a per-pocket population in the hundreds,
+and the resolver refuses an ambiguous tail rather than picking, so the failure
+mode is a loud error rather than the silent wrong-entity write this whole module
+exists to prevent.
 
-WHAT THIS DELIBERATELY DOES NOT DO is truncate the id. Every other field here is
-advisory and a shortened one still reads; an id is either exact or it is a failed
-tool call, so it is passed through whole and the caps are left to bite elsewhere.
+The saving is not cosmetic: the id was 24 of the ~70 chars in a widget row, and
+that row is repeated 12 times inside a 1500-char cap.
+
+WHAT THIS DELIBERATELY DOES NOT DO is invent a shortening the tools do not
+understand. ``ID_TAIL_CHARS`` and the ``ID_TAIL_MARKER`` below are consumed by
+``pocketpaw_ee.cloud.pockets.id_resolve``; changing either without changing that
+resolver produces ids the agent cannot use. They are imported from here, not
+re-declared there, so the two cannot drift.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
-__all__ = ["MISSING_ID", "entity_line"]
+__all__ = [
+    "ID_TAIL_CHARS",
+    "ID_TAIL_MARKER",
+    "MISSING_ID",
+    "entity_line",
+    "short_id",
+    "unaddressed_line",
+]
 
 # What renders in place of an id the caller could not supply. Deliberately short,
 # deliberately not empty, and deliberately not something that reads like a real
@@ -52,16 +78,49 @@ __all__ = ["MISSING_ID", "entity_line"]
 # should see the hole immediately. Grep for it to find call sites still missing.
 MISSING_ID = "?"
 
+# How many trailing characters of an id to render. Eight, and the number is a
+# trade rather than a round figure: it is 16^8 = 4.3e9 values against a
+# per-pocket widget population in the low hundreds and a per-workspace pocket
+# population in the thousands, so a collision needs a deliberate effort. Going
+# lower saves 1 char per row and buys real ambiguity; going higher spends chars
+# on a collision rate already indistinguishable from zero.
+ID_TAIL_CHARS = 8
+
+# Prefixed to a shortened id so the agent can SEE it is a tail rather than a
+# whole id, and so a human reading a prompt dump is not misled into pasting it
+# somewhere that wants the real thing. The resolver strips it, and also strips a
+# plain "..." because a model that retypes this will not reliably reproduce the
+# single-character ellipsis.
+ID_TAIL_MARKER = "…"
+
+
+def short_id(entity_id: Any) -> str:
+    """Render an id as a resolvable tail.
+
+    Returns the id UNCHANGED when it is already at or under
+    :data:`ID_TAIL_CHARS`, because shortening a short id only adds a marker and
+    costs a character. Non-ObjectId ids (slugs, uuids, test fixtures) therefore
+    pass through untouched, which is what the resolver expects.
+    """
+    text = _clean(entity_id)
+    if len(text) <= ID_TAIL_CHARS:
+        return text
+    return f"{ID_TAIL_MARKER}{text[-ID_TAIL_CHARS:]}"
+
 
 def entity_line(label: Any, entity_id: Any, /, **facts: Any) -> str:
     """Render one entity row for a prompt block.
 
-    ``- {label} (id={entity_id}, {k}={v}, ...)``
+    ``- {label} (id={tail}, {k}={v}, ...)``
 
     ``entity_id`` is positional and has NO default, which is the whole point of
     the function — see the module docstring. Both leading arguments are
     positional-only so a caller cannot pass ``label=`` / ``entity_id=`` and
     shadow a fact of the same name.
+
+    The id is rendered as a tail (:func:`short_id`). Pass the WHOLE id here; the
+    shortening is this function's job, so every row shortens the same way and a
+    handler cannot invent its own.
 
     Facts render in call order, so a handler controls what a reader sees first
     after the id. Values are coerced through ``str``; a ``None`` or empty fact
@@ -69,10 +128,36 @@ def entity_line(label: Any, entity_id: Any, /, **facts: Any) -> str:
     ``mime=`` reads as a formatting bug rather than as missing data.
     """
     name = _clean(label) or "(unnamed)"
-    ident = _clean(entity_id) or MISSING_ID
+    ident = short_id(entity_id) or MISSING_ID
     parts = [f"id={ident}"]
     parts.extend(f"{key}={_clean(value) or MISSING_ID}" for key, value in facts.items())
     return f"- {name} ({', '.join(parts)})"
+
+
+def unaddressed_line(kind: str, label: Any, /, **facts: Any) -> str:
+    """Render a row for an entity NO tool addresses by id.
+
+    ``- {label} ({k}={v}, ...)`` — no id, because spending ~10 chars a row on an
+    identifier nothing accepts is waste.
+
+    ``kind`` is a CHECKED CLAIM, and that is the entire reason this function
+    takes an argument it never renders. ``tests/cloud/surface/
+    test_entity_id_contract.py`` reads these call sites, extracts the literal,
+    and fails if that kind appears in the set of kinds derived from the MCP tool
+    schemas. So the day somebody ships a tool with a required ``file_id``,
+    ``files.py`` stops passing rather than quietly continuing to render rows the
+    agent now needs ids for.
+
+    That is the difference between this and an allow-list entry, which is what
+    this replaced: an allow-list says "reviewed once, trust it", and this says
+    "still true, re-checked every run". Pass a literal string — a computed kind
+    cannot be read statically and the contract test rejects it.
+    """
+    name = _clean(label) or "(unnamed)"
+    rendered = [f"{key}={_clean(value) or MISSING_ID}" for key, value in facts.items()]
+    if not rendered:
+        return f"- {name}"
+    return f"- {name} ({', '.join(rendered)})"
 
 
 def _clean(value: Any) -> str:

--- a/tests/cloud/pockets/test_id_resolve.py
+++ b/tests/cloud/pockets/test_id_resolve.py
@@ -1,0 +1,231 @@
+# tests/cloud/pockets/test_id_resolve.py — the other half of the shortened id.
+# Created: 2026-08-03 (feat/prompt-entity-suffix).
+#
+# The prompt renders the last 8 characters of an id instead of all 24, because
+# the id was 24 of the ~70 chars in a widget row and that row repeats 12 times
+# inside a 1500-char cap. That is only safe if the tools can turn what the agent
+# was SHOWN back into what they need, so these two halves must agree — and the
+# round-trip test below is the one that holds them together. A renderer and a
+# resolver that drift produce ids the agent cannot use, which is a worse failure
+# than the prompt bloat either was meant to fix.
+#
+# THE SAFETY PROPERTY, and the reason this file leans on it so hard: AN
+# AMBIGUOUS TAIL RAISES. It never picks, never takes the first match, never
+# falls back to "closest". The entire point of rendering an id was that
+# "- Sales (type=custom)" let a tool call land on the wrong entity silently; a
+# short id that resolved loosely would be that same bug with extra steps.
+#
+# EACH TEST NAMES THE MUTATION THAT BREAKS IT, and every one was applied, run,
+# observed to fail, and reverted.
+
+from __future__ import annotations
+
+import pytest
+from bson import ObjectId
+from pocketpaw_ee.cloud.pockets.id_resolve import (
+    AmbiguousId,
+    normalize_id_input,
+    resolve_id,
+)
+
+from pocketpaw.prompt.entity import ID_TAIL_MARKER, entity_line, short_id
+
+
+class _Widget:
+    def __init__(self, ident: str, name: str = "Revenue") -> None:
+        self.id = ident
+        self.name = name
+
+
+class TestRoundTrip:
+    """What the renderer showed is what the resolver accepts."""
+
+    def test_a_rendered_tail_resolves_back_to_the_whole_id(self) -> None:
+        """The contract between the two modules, asserted end to end.
+
+        Neither half is interesting alone: a renderer that shortens correctly
+        and a resolver that expands correctly are still broken if they disagree
+        about WHICH characters. This drives the real renderer and feeds its
+        output to the real resolver.
+
+        THE MUTATION THAT BREAKS THIS: render the head in ``short_id``
+        (``text[:ID_TAIL_CHARS]``) while the resolver keeps matching tails. Run:
+        KeyError, no candidate ended with the head. (Applied 2026-08-03.)
+        """
+        ids = [str(ObjectId()) for _ in range(12)]
+        widgets = [_Widget(i) for i in ids]
+
+        for ident in ids:
+            assert resolve_id(short_id(ident), widgets) == ident
+
+    def test_the_id_as_it_appears_in_a_real_prompt_row_resolves(self) -> None:
+        """Goes through ``entity_line``, not just ``short_id``.
+
+        The agent does not see ``short_id``'s return value; it sees a row. If
+        anything in the row assembly mangles the id — a strip, a case change, a
+        stray character — this is where it shows up.
+
+        THE MUTATION THAT BREAKS THIS: uppercase the id inside ``entity_line``.
+        Run: KeyError, no lowercase-hex candidate matched. (Applied 2026-08-03.)
+        """
+        ident = str(ObjectId())
+        row = entity_line("Revenue", ident, state="native")
+        # Pull the id back out of the row exactly as an agent would read it.
+        shown = row.split("id=")[1].split(",")[0]
+
+        assert resolve_id(shown, [_Widget(ident)]) == ident
+
+    def test_a_whole_id_still_resolves_to_itself(self) -> None:
+        """Every pre-existing caller sends a whole id and must not regress.
+
+        The frontend, stored references, and every tool call written before this
+        change pass 24 chars. That path has to stay exact.
+
+        THE MUTATION THAT BREAKS THIS: drop the ``if given in ids`` fast path.
+        Run: a whole id is longer than ID_TAIL_CHARS, hit the length guard, and
+        raised KeyError. (Applied 2026-08-03.)
+        """
+        ident = str(ObjectId())
+        assert resolve_id(ident, [_Widget(ident)]) == ident
+
+
+class TestAmbiguityRaises:
+    """The property that keeps a short id from becoming the original bug."""
+
+    def test_a_tail_matching_two_entities_raises(self) -> None:
+        """Never pick. The whole design rests on this.
+
+        THE MUTATION THAT BREAKS THIS: ``return matches[0]`` instead of raising
+        on a multi-match. Run: no exception, the wrong widget came back, and
+        ``pytest.raises`` failed. (Applied 2026-08-03.)
+        """
+        one = "aaaaaaaaaaaaaaaa" + "deadbeef"
+        two = "bbbbbbbbbbbbbbbb" + "deadbeef"
+
+        with pytest.raises(AmbiguousId):
+            resolve_id("deadbeef", [_Widget(one), _Widget(two)])
+
+    def test_the_error_names_the_candidates(self) -> None:
+        """An agent told only "ambiguous" has to guess again, which is the bug.
+
+        THE MUTATION THAT BREAKS THIS: raise ``AmbiguousId(given, [])``. Run:
+        neither id appeared in the message and this failed.
+        """
+        one = "aaaaaaaaaaaaaaaa" + "deadbeef"
+        two = "bbbbbbbbbbbbbbbb" + "deadbeef"
+
+        with pytest.raises(AmbiguousId) as caught:
+            resolve_id("deadbeef", [_Widget(one), _Widget(two)])
+
+        assert one in str(caught.value)
+        assert two in str(caught.value)
+
+    def test_an_exact_id_beats_being_a_tail_of_another(self) -> None:
+        """A caller passing a real id must never be told its own id is ambiguous.
+
+        Contrived as a fixture, and the ordering it pins is not: exact-match-first
+        is what keeps every existing full-id caller safe no matter what else is in
+        the collection.
+
+        THE MUTATION THAT BREAKS THIS: move the ``given in ids`` check below the
+        tail matching. Run: AmbiguousId, for an id that exists exactly.
+        """
+        exact = "beefcafe"
+        longer = "0123456789abcdef" + "beefcafe"
+
+        assert resolve_id(exact, [_Widget(exact), _Widget(longer)]) == exact
+
+    def test_no_match_raises_rather_than_returning_none(self) -> None:
+        """A None return would get used as an id somewhere downstream.
+
+        THE MUTATION THAT BREAKS THIS: ``return ""`` instead of raising KeyError.
+        Run: no exception and ``pytest.raises`` failed.
+        """
+        with pytest.raises(KeyError):
+            resolve_id("ffffffff", [_Widget(str(ObjectId()))])
+
+    def test_something_longer_than_a_tail_is_not_matched_loosely(self) -> None:
+        """A 20-char near-miss is a typo, not a shortening.
+
+        Matching it by suffix would mean a mistyped id could still land on a
+        real entity, which is exactly the silent-wrong-entity failure this
+        design exists to make impossible.
+
+        THE MUTATION THAT BREAKS THIS: delete the ``len(given) > ID_TAIL_CHARS``
+        guard. Run: the typo resolved to a real widget and this failed.
+        """
+        ident = str(ObjectId())
+        typo = ident[1:]  # 23 chars, still ends with the real tail
+
+        with pytest.raises(KeyError):
+            resolve_id(typo, [_Widget(ident)])
+
+
+class TestWhatTheAgentActuallySends:
+    """A model retyping an id does not reproduce it byte for byte."""
+
+    def test_the_tail_marker_is_stripped(self) -> None:
+        """The agent may echo ``…3f9a1c07`` verbatim, marker included.
+
+        THE MUTATION THAT BREAKS THIS: stop stripping ``ID_TAIL_MARKER`` in
+        ``normalize_id_input``. Run: KeyError — no id ends with the marker.
+        """
+        ident = str(ObjectId())
+        assert resolve_id(f"{ID_TAIL_MARKER}{ident[-8:]}", [_Widget(ident)]) == ident
+
+    def test_an_ascii_ellipsis_is_stripped_too(self) -> None:
+        """Models substitute "..." for "…" constantly. Cheap to accept.
+
+        THE MUTATION THAT BREAKS THIS: drop "..." from ``_STRIPPABLE_PREFIXES``.
+        Run: KeyError. (Applied 2026-08-03.)
+        """
+        ident = str(ObjectId())
+        assert resolve_id(f"...{ident[-8:]}", [_Widget(ident)]) == ident
+
+    def test_quotes_and_whitespace_are_stripped(self) -> None:
+        """Ids arrive wrapped in whatever punctuation surrounded them.
+
+        THE MUTATION THAT BREAKS THIS: return ``str(raw)`` unchanged from
+        ``normalize_id_input``. Run: both assertions failed.
+        """
+        assert normalize_id_input('  "abc123"  ') == "abc123"
+        assert normalize_id_input(f"  {ID_TAIL_MARKER}abc123 ") == "abc123"
+
+    def test_an_empty_id_raises_rather_than_matching_everything(self) -> None:
+        """``endswith("")`` is True for every string — the dangerous default.
+
+        Without the empty guard, a missing id would match the first candidate
+        and silently mutate an arbitrary entity.
+
+        THE MUTATION THAT BREAKS THIS: remove the ``if not given`` guard. Run:
+        the empty string matched every widget and raised AmbiguousId instead —
+        and with a single candidate it returned that widget outright, which is
+        the silent wrong-entity write. (Applied 2026-08-03.)
+        """
+        with pytest.raises(KeyError):
+            resolve_id("", [_Widget(str(ObjectId()))])
+        with pytest.raises(KeyError):
+            resolve_id(None, [_Widget(str(ObjectId()))])
+
+
+class TestDictCandidates:
+    """The pocket wire dict spells its id ``_id``; the domain objects use ``id``."""
+
+    def test_a_wire_dict_resolves_on_underscore_id(self) -> None:
+        """``pocket_to_wire_dict`` emits ``_id`` — the resolver must read it.
+
+        THE MUTATION THAT BREAKS THIS: drop the ``_id`` fallback in ``_id_of``.
+        Run: no candidate produced an id, KeyError. (Applied 2026-08-03.)
+        """
+        ident = str(ObjectId())
+        assert resolve_id(short_id(ident), [{"_id": ident, "name": "Sales"}]) == ident
+
+    def test_candidates_with_no_id_are_skipped_not_crashed_on(self) -> None:
+        """A malformed row must not take down prompt assembly.
+
+        THE MUTATION THAT BREAKS THIS: remove the ``if i`` filter. Run: the
+        empty string entered the candidate list and the empty-tail hazard
+        returned.
+        """
+        ident = str(ObjectId())
+        assert resolve_id(short_id(ident), [{"name": "no id here"}, {"_id": ident}]) == ident

--- a/tests/cloud/pockets/test_short_id_tool_wiring.py
+++ b/tests/cloud/pockets/test_short_id_tool_wiring.py
@@ -1,0 +1,269 @@
+# tests/cloud/pockets/test_short_id_tool_wiring.py — the loop closed.
+# Created: 2026-08-04 (feat/prompt-entity-suffix).
+#
+# WHAT WAS UNCOVERED. The shortened id has three moving parts and only two were
+# tested:
+#
+#   1. the renderer shortens        -> tests/test_prompt_entity_line.py
+#   2. the resolver expands         -> tests/cloud/pockets/test_id_resolve.py
+#   3. THE TOOLS CALL THE RESOLVER  -> nothing
+#
+# Part 3 is the wiring in ``_agent_load_doc`` and ``agent_update_widget``, and
+# the pre-existing ``agent_update_widget`` tests all pass WHOLE ids, so they
+# would keep passing with the resolve call deleted outright. A perfect renderer
+# and a perfect resolver that are never joined up ship an agent that reads
+# ``id=…3f9a1c07`` off its own prompt and gets "widget not found".
+#
+# So these tests start from the bytes the agent is actually shown — the real
+# preamble, rendered by the real handler — pull the id out of that string the
+# way a model would, and hand THAT to the real mutation entry point. If any
+# link in the chain disagrees with any other, this fails.
+#
+# The only thing between here and a live server is whether the model chooses to
+# use what it was shown, which no test can answer.
+#
+# EACH TEST NAMES THE MUTATION THAT BREAKS IT, and every one was applied, run,
+# observed to fail, and reverted.
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pocketpaw_ee.cloud.pockets import service as pockets_service
+from pocketpaw_ee.cloud.pockets.dto import AddWidgetRequest, CreatePocketRequest
+from pocketpaw_ee.cloud.surface.handlers._helpers import format_widget_line
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+WORKSPACE = "ws-shortid"
+USER = "user-shortid"
+
+
+class _AttrView:
+    """Attribute access over a widget wire dict (``format_widget_line`` is duck-typed)."""
+
+    def __init__(self, data: dict) -> None:
+        self._data = data
+
+    def __getattr__(self, item: str):
+        if item == "id":
+            return self._data.get("id") or self._data.get("_id")
+        return self._data.get(item)
+
+
+def _as_the_agent_reads_it(row: str) -> str:
+    """Pull the id out of a rendered row the way a model would.
+
+    Deliberately naive — split on ``id=``, stop at the delimiter — because that
+    is what a model does. Anything cleverer here would be testing my parser
+    rather than the contract.
+    """
+    return row.split("id=")[1].split(",")[0].rstrip(")")
+
+
+def _stream_identity(workspace: str, user: str) -> ExitStack:
+    """Fake the per-stream ContextVars ``_agent_load_doc`` reads.
+
+    Agent pocket mutations refuse to run outside a cloud SSE chat stream, so
+    without these every call under test returns "no active workspace/user"
+    and the tests would pass for the wrong reason.
+    """
+    stack = ExitStack()
+    stack.enter_context(
+        patch(
+            "pocketpaw_ee.cloud.chat.agent_service.current_workspace_id",
+            new=MagicMock(return_value=workspace),
+        )
+    )
+    stack.enter_context(
+        patch(
+            "pocketpaw_ee.cloud.chat.agent_service.current_user_id",
+            new=MagicMock(return_value=user),
+        )
+    )
+    return stack
+
+
+async def _seed(name: str, widgets: tuple[str, ...] = ()) -> str:
+    created = await pockets_service.create(
+        WORKSPACE, USER, CreatePocketRequest(name=name, type="custom")
+    )
+    pocket_id = str(created["_id"])
+    for widget_name in widgets:
+        await pockets_service.add_widget(
+            pocket_id, USER, AddWidgetRequest(name=widget_name, type="native")
+        )
+    return pocket_id
+
+
+class TestTheAgentCanActOnWhatItWasShown:
+    async def test_the_widget_id_from_the_prompt_updates_that_widget(self) -> None:
+        """The whole point, in one test.
+
+        Renders the real row, reads the id off it the way a model would, and
+        calls the real ``agent_update_widget`` with that string. Two widgets, so
+        landing on the wrong one is a possible failure rather than a certainty.
+
+        THE MUTATION THAT BREAKS THIS: delete the ``resolve_id`` call from
+        ``agent_update_widget``. Run: "widget …bd4f2a1c not found in pocket" —
+        the exact failure an agent would hit reading its own prompt.
+        (Applied 2026-08-04.)
+        """
+        pocket_id = await _seed("Metrics", ("Revenue", "Churn"))
+
+        pocket = await pockets_service.get(pocket_id, USER)
+        views = [_AttrView(w) for w in pocket["widgets"]]
+        target = next(v for v in views if v.name == "Churn")
+        shown = _as_the_agent_reads_it(format_widget_line(target))
+
+        assert shown != target.id, "the row should carry a SHORTENED id, not the whole one"
+
+        with _stream_identity(WORKSPACE, USER):
+            view, err = await pockets_service.agent_update_widget(
+                pocket_id, shown, {"name": "Churn risk"}
+            )
+
+        assert err is None, err
+        renamed = {w["name"] for w in view["widgets"]}
+        assert "Churn risk" in renamed
+        assert "Revenue" in renamed, "the resolve landed on the wrong widget"
+
+    async def test_the_pocket_id_from_the_prompt_loads_that_pocket(self) -> None:
+        """Same chain, one level up — ``_agent_load_doc`` resolves a short pocket id.
+
+        The pocket resolve is the one that has to hit the database, and the one
+        that is scoped by workspace, so it is the more fragile of the two.
+
+        THE MUTATION THAT BREAKS THIS: delete the ``_is_whole_object_id`` branch
+        from ``_agent_load_doc``. Run: PydanticObjectId rejected the 8-char id
+        and it returned "could not load pocket". (Applied 2026-08-04.)
+        """
+        from pocketpaw.prompt.entity import short_id
+
+        pocket_id = await _seed("Launch Tracker", ("Timeline",))
+        await _seed("Roadmap")
+
+        with _stream_identity(WORKSPACE, USER):
+            doc, err = await pockets_service._agent_load_doc(short_id(pocket_id))
+
+        assert err is None, err
+        assert doc is not None
+        assert str(doc.id) == pocket_id
+        assert doc.name == "Launch Tracker"
+
+    async def test_a_whole_id_still_works_through_the_same_path(self) -> None:
+        """Every caller that existed before this change sends 24 chars.
+
+        THE MUTATION THAT BREAKS THIS: delete the ``resolve_id`` call from
+        ``agent_update_widget`` — no, that one is caught above. This test is the
+        no-regression half and is deliberately NOT the guard for the fast path;
+        see ``test_a_whole_id_does_not_scan_the_collection`` for that, and read
+        its docstring before assuming ``_is_whole_object_id`` protects
+        correctness. It does not.
+        """
+        pocket_id = await _seed("Direct", ("Tile",))
+
+        pocket = await pockets_service.get(pocket_id, USER)
+        widget_id = pocket["widgets"][0].get("id") or pocket["widgets"][0].get("_id")
+
+        with _stream_identity(WORKSPACE, USER):
+            view, err = await pockets_service.agent_update_widget(
+                pocket_id, widget_id, {"name": "Renamed"}
+            )
+
+        assert err is None, err
+        assert view["widgets"][0]["name"] == "Renamed"
+
+    async def test_a_whole_id_does_not_scan_the_collection(self) -> None:
+        """``_is_whole_object_id`` is a PERFORMANCE guard, not a correctness one.
+
+        I originally documented it as correctness — "force everything down the
+        resolve path and a whole id stops working" — and ``scripts/mutate.py``
+        proved that false: ``resolve_id`` checks for an exact match before it
+        applies the tail rules, so a whole id resolves either way. The mutation
+        escaped, which is precisely what the harness is for.
+
+        What the guard actually buys is one round trip. Without it, EVERY agent
+        pocket mutation lists every pocket id in the workspace before doing
+        anything, on a path that already knows it was handed a whole id. So the
+        honest assertion is about the query, not the result.
+
+        Spies on ``_resolve_pocket_id_tail`` rather than on the collection:
+        beanie's own ``Document.get`` reaches for ``get_pymongo_collection``
+        internally, so counting THAT proves nothing about this code path. The
+        first version of this test did exactly that and failed for that reason.
+
+        THE MUTATION THAT BREAKS THIS: make ``_is_whole_object_id`` return False
+        always. Run: the tail resolver ran for a whole id and this failed.
+        (Applied 2026-08-04.)
+        """
+        pocket_id = await _seed("Direct", ("Tile",))
+        real = pockets_service._resolve_pocket_id_tail
+        calls: list[str] = []
+
+        async def _spy(given: str, workspace_id: str):
+            calls.append(given)
+            return await real(given, workspace_id)
+
+        with (
+            _stream_identity(WORKSPACE, USER),
+            patch.object(pockets_service, "_resolve_pocket_id_tail", _spy),
+        ):
+            doc, err = await pockets_service._agent_load_doc(pocket_id)
+
+        assert err is None, err
+        assert doc is not None
+        assert not calls, (
+            "a whole id triggered a workspace-wide pocket id scan — the "
+            f"_is_whole_object_id fast path is not being taken (resolved {calls})"
+        )
+
+
+class TestTheFailuresAreLoud:
+    async def test_an_unknown_short_id_reports_not_found(self) -> None:
+        """A miss must not silently mutate a neighbouring widget.
+
+        THE MUTATION THAT BREAKS THIS: catch KeyError in ``agent_update_widget``
+        and fall through to the first widget. Run: err was None and the wrong
+        widget was renamed.
+        """
+        pocket_id = await _seed("Metrics", ("Revenue",))
+
+        with _stream_identity(WORKSPACE, USER):
+            view, err = await pockets_service.agent_update_widget(
+                pocket_id, "ffffffff", {"name": "Nope"}
+            )
+
+        assert view is None
+        assert err is not None and "not found" in err
+
+    async def test_a_short_pocket_id_cannot_reach_another_workspace(self) -> None:
+        """The tenancy boundary on the resolve, asserted rather than assumed.
+
+        The resolve queries by tail, so without the workspace filter a tail from
+        one tenant could land on another's pocket. That would be a far worse bug
+        than the prompt bloat the shortening was introduced to fix.
+
+        THE MUTATION THAT BREAKS THIS: drop ``{"workspace": workspace_id}`` from
+        the query in ``_resolve_pocket_id_tail``. Run: the other workspace's
+        pocket resolved, ``_agent_load_doc`` then rejected it on its own
+        workspace check — so the id LEAKED as far as the resolver and only a
+        second guard caught it. Both layers matter; this pins the first.
+        (Applied 2026-08-04.)
+        """
+        from pocketpaw.prompt.entity import short_id
+
+        other = await pockets_service.create(
+            "ws-somebody-else", "user-else", CreatePocketRequest(name="Theirs", type="custom")
+        )
+        other_id = str(other["_id"])
+
+        with _stream_identity(WORKSPACE, USER):
+            resolved, err = await pockets_service._resolve_pocket_id_tail(
+                short_id(other_id), WORKSPACE
+            )
+
+        assert err is not None, f"a tail resolved across tenants to {resolved}"
+        assert "not found" in err

--- a/tests/cloud/surface/test_entity_id_contract.py
+++ b/tests/cloud/surface/test_entity_id_contract.py
@@ -1,0 +1,347 @@
+# tests/cloud/surface/test_entity_id_contract.py — the gate that keeps prompt
+# rows addressable.
+# Created: 2026-08-03 (feat/prompt-entity-ids).
+#
+# THE RULE: if a tool declares a required ``<kind>_id``, every prompt block that
+# lists ``<kind>``s must carry that id on each row.
+#
+# It was broken in four places at once and nobody noticed, because each list
+# handler was written independently and ``rows.append(f"- {name} ...")`` is the
+# obvious thing to type. ``pocketpaw.prompt.entity`` is the one spelling; this
+# file is what stops the fifth handler from skipping it.
+#
+# TWO CHECKS, doing different jobs:
+#
+#   1. NO HAND-ROLLED ROWS (AST). Scans the handler packages for f-strings
+#      shaped like an entity row and fails any that did not come from
+#      ``entity_line``. Catches the bug at the shape level, before anyone has to
+#      reason about whether that particular entity happens to be addressable.
+#   2. THE TOOL SURFACE HAS NOT GROWN (derived). Enumerates every MCP server's
+#      tool schemas and collects the required ``<kind>_id`` params. This is the
+#      authoritative list of what the agent can address, and it is DERIVED — add
+#      a tool with a required ``site_id`` and this test fails until someone
+#      decides whether the sites preamble now owes an id. That is the property
+#      that makes this permanent rather than a one-time cleanup: the check
+#      updates itself, and the failure lands on the person adding the tool.
+#
+# Check 2 is a tripwire, not a proof — it cannot know which preamble lists which
+# kind. It is deliberately the cheap mechanism, because the expensive one (map
+# every kind to its rendering surface) would itself be a hand-maintained list,
+# which is the thing that rots.
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import importlib
+import pkgutil
+import re
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# 1. No hand-rolled entity rows
+# ---------------------------------------------------------------------------
+
+_SCANNED_PACKAGES = (
+    "ee/pocketpaw_ee/cloud/surface/handlers",
+    "src/pocketpaw/prompt",
+)
+
+# Rows allowed to stay hand-rolled, as ``module -> (count, reason)``.
+#
+# THE COUNT IS THE POINT. A bare module-name allow-list would exempt the module
+# forever, so the next row added to ``calendar.py`` would inherit the exemption
+# and ship the exact bug this file exists to stop. Pinning the count means a new
+# hand-rolled row fails here even in an already-listed module — the exemption
+# covers the rows that were reviewed, not the file.
+#
+# Every entry claims the thing being listed is NOT an entity addressed by id:
+# either it is a record of an event rather than a thing, or its label already IS
+# its address. Both numbers may only ever go DOWN.
+_HANDROLLED_ALLOWED = {
+    # "- 10:30 AM · Sync with Sarah" ×2 (with and without a parsed time).
+    # Google Calendar events via Composio. They carry an id and no tool takes
+    # it: the ``meeting_id`` five tools require addresses a ``_MeetingDoc`` in
+    # our own collection, a different entity that no preamble lists. Checked
+    # against meetings/service.py::cancel_meeting on 2026-08-03.
+    "calendar.py": (2, "google calendar events; no tool takes a calendar event id"),
+    # "- pocket.created: Sales" — a record OF an action, not a thing to act on.
+    "activity.py": (1, "activity feed lines are events, not addressable entities"),
+    "audit.py": (1, "audit entries are events, not addressable entities"),
+    "home.py": (1, "home activity digest lines are events, not entities"),
+    # "- workspace:w1" — a KB scope. The label IS the address; there is no
+    # separate id to carry.
+    "knowledge.py": (1, "a kb scope string is its own identifier"),
+    # "- hero: https://… (alt: "…")" — asset manifest lines. The URL is the
+    # address, and it is already rendered.
+    "sites.py": (1, "an asset url is its own identifier"),
+    # Two rows, exempt for two different reasons. "- Ripple: a Svelte runtime
+    # that…" is an atlas glossary entry from a static seed — prose. "- **name**:
+    # description" is the skills list, and a skill is invoked BY NAME: the
+    # loader keys them in a dict, so the name is unique by construction and is
+    # itself the address.
+    "environment.py": (2, "atlas entries are prose; a skill's name is its address"),
+    "identity.py": (1, "soul knowledge lines are prose, not entities"),
+}
+
+# The renderer itself necessarily contains the row shape it produces. Excluded
+# structurally rather than allow-listed — it is the fix, not an exception to it.
+_RENDERER_MODULE = "entity.py"
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _handrolled_rows(path: Path) -> list[int]:
+    """Line numbers of f-strings shaped like an entity row.
+
+    The shape is an f-string whose literal head starts with ``"- "`` and which
+    interpolates at least one value — i.e. a per-item row rather than a static
+    line. ``f"... (+{n} more)"`` does not match (wrong head) and neither does a
+    plain string constant (nothing interpolated).
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    hits = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.JoinedStr) or not node.values:
+            continue
+        head = node.values[0]
+        if not (isinstance(head, ast.Constant) and isinstance(head.value, str)):
+            continue
+        if not head.value.startswith("- "):
+            continue
+        if any(isinstance(v, ast.FormattedValue) for v in node.values):
+            hits.append(node.lineno)
+    return hits
+
+
+def _scanned_files() -> list[Path]:
+    files: list[Path] = []
+    for pkg in _SCANNED_PACKAGES:
+        root = _REPO_ROOT / pkg
+        assert root.is_dir(), f"scan target moved: {root}"
+        files.extend(p for p in root.rglob("*.py") if "__pycache__" not in p.parts)
+    return files
+
+
+class TestNoHandRolledEntityRows:
+    def test_every_entity_row_goes_through_entity_line(self) -> None:
+        """The check that makes the renderer unavoidable.
+
+        A correct renderer nobody calls is the original bug intact, so this
+        asserts the CALL SHAPE rather than the output: a handler cannot opt out
+        by writing a row that happens to include an id today.
+
+        THE MUTATION THAT BREAKS THIS: restore ``pockets_list.py``'s
+        ``rows.append(f"- {name} (type={kind}, ...)")``. Run: the offender list
+        was non-empty and this failed. (Applied 2026-08-03.)
+        """
+        offenders = []
+        for path in _scanned_files():
+            if path.name == _RENDERER_MODULE or path.name in _HANDROLLED_ALLOWED:
+                continue
+            for lineno in _handrolled_rows(path):
+                offenders.append(f"{path.relative_to(_REPO_ROOT)}:{lineno}")
+
+        assert not offenders, (
+            "hand-rolled entity rows found — use pocketpaw.prompt.entity.entity_line "
+            "so the row carries the id the agent needs to act on it:\n  " + "\n  ".join(offenders)
+        )
+
+    def test_an_allow_listed_module_cannot_grow_a_new_row(self) -> None:
+        """The exemption covers the rows that were reviewed, not the file.
+
+        Without the pinned count, ``calendar.py`` — exempt because Google
+        Calendar events are not tool-addressable — would silently cover a
+        pockets row someone adds to it later. This is the check that keeps a
+        seven-entry allow-list from becoming a seven-module blind spot.
+
+        THE MUTATION THAT BREAKS THIS: add a second hand-rolled row to
+        ``knowledge.py``. Run: 2 != 1 and this failed. (Applied 2026-08-03.)
+        """
+        scanned = {p.name: p for p in _scanned_files()}
+        drift = []
+        for name, (expected, _reason) in _HANDROLLED_ALLOWED.items():
+            path = scanned.get(name)
+            if path is None:
+                drift.append(f"{name}: no longer scanned — remove the entry")
+                continue
+            actual = len(_handrolled_rows(path))
+            if actual != expected:
+                verb = "gained" if actual > expected else "lost"
+                drift.append(f"{name}: {verb} rows ({expected} allowed, {actual} found)")
+
+        assert not drift, (
+            "hand-rolled row counts moved. A NEW row must go through entity_line; "
+            "a REMOVED one means the pinned count should come down:\n  " + "\n  ".join(drift)
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2. The addressable-kind surface, derived from the tool schemas
+# ---------------------------------------------------------------------------
+
+_REQUIRED_ID = re.compile(r"^(?P<kind>[a-z0-9_]+)_id$")
+
+# Every kind some tool requires an id for, as of 2026-08-03. DERIVED, not
+# authored — regenerate by running the test and reading the failure.
+#
+# The three that a prompt block actually lists are ``pocket`` (pockets_list),
+# ``widget`` (the pinned-widgets block) and ``user`` (the about-member block);
+# all three now render ids. The rest are addressed from tool output or from the
+# request context, and no preamble lists them.
+_KNOWN_ADDRESSABLE_KINDS = frozenset(
+    {
+        "assignee",
+        "backtest",
+        "custom_scenario",
+        "decision",
+        "from",
+        "input",
+        "invite",
+        "link",
+        "meeting",
+        "pocket",
+        "project",
+        "run",
+        "scenario",
+        "task",
+        "to",
+        "user",
+        "widget",
+    }
+)
+
+
+def _derive_addressable_kinds() -> tuple[set[str], list[str]]:
+    """Collect ``<kind>`` for every required ``<kind>_id`` across all MCP tools.
+
+    Returns the kinds and the builders that could not be enumerated. The second
+    half matters: a builder that raises is a silent hole in the derivation, and
+    a check that quietly enumerated half the tool surface would report a clean
+    result while missing the tool that motivated it.
+    """
+    import pocketpaw_ee.agent.mcp_servers as servers_pkg
+    from mcp import types
+
+    kinds: set[str] = set()
+    skipped: list[str] = []
+    for mod_info in pkgutil.iter_modules(servers_pkg.__path__):
+        if mod_info.name.startswith("_"):
+            continue
+        try:
+            module = importlib.import_module(f"{servers_pkg.__name__}.{mod_info.name}")
+        except Exception as exc:  # pragma: no cover - reported, not asserted here
+            skipped.append(f"{mod_info.name}: import {type(exc).__name__}")
+            continue
+        builders = [
+            getattr(module, attr)
+            for attr in dir(module)
+            if attr.startswith("build_") and callable(getattr(module, attr))
+        ]
+        for builder in builders:
+            try:
+                built = builder()
+            except Exception as exc:  # pragma: no cover
+                skipped.append(f"{mod_info.name}.{builder.__name__}: build {type(exc).__name__}")
+                continue
+            if not built:
+                continue
+            try:
+                _name, server = built
+                handler = server["instance"].request_handlers[types.ListToolsRequest]
+                listed = asyncio.run(handler(types.ListToolsRequest(method="tools/list")))
+            except Exception as exc:  # pragma: no cover
+                skipped.append(f"{mod_info.name}.{builder.__name__}: list {type(exc).__name__}")
+                continue
+            for tool in listed.root.tools:
+                for param in (tool.inputSchema or {}).get("required") or []:
+                    match = _REQUIRED_ID.match(param)
+                    if match:
+                        kinds.add(match.group("kind"))
+    return kinds, skipped
+
+
+class TestAddressableKindsAreReviewed:
+    @pytest.fixture(scope="class")
+    def derived(self) -> tuple[set[str], list[str]]:
+        return _derive_addressable_kinds()
+
+    def test_the_derivation_reaches_every_server(self, derived: tuple[set[str], list[str]]) -> None:
+        """A partial enumeration would report clean while missing the point.
+
+        Every MCP server builder must be importable and listable with no
+        ambient request context — they are today (0 skipped, 33 tools, 17 kinds
+        as of 2026-08-03). If one starts needing a live DB to enumerate its
+        tools, this fails rather than quietly shrinking the derived set.
+
+        THE MUTATION THAT BREAKS THIS: point the loop at a package whose
+        builders raise. Run: skipped was non-empty and this failed.
+        """
+        _kinds, skipped = derived
+        assert not skipped, "MCP tool schemas could not be enumerated:\n  " + "\n  ".join(skipped)
+
+    def test_a_new_addressable_kind_gets_looked_at(
+        self, derived: tuple[set[str], list[str]]
+    ) -> None:
+        """The tripwire. Adding a tool with a required id lands the decision here.
+
+        This does NOT assert that each kind's preamble renders an id — nothing
+        maps kinds to surfaces, and a map that did would be the hand-maintained
+        list this design set out to avoid. What it guarantees is that the tool
+        surface cannot grow without somebody answering the question, in the
+        commit that grows it.
+
+        If this fails: check whether any prompt block LISTS the new kind. If it
+        does, render the id through ``entity_line``. If it does not, add the
+        kind below. Either way the answer is deliberate.
+
+        THE MUTATION THAT BREAKS THIS: drop ``"widget"`` from
+        ``_KNOWN_ADDRESSABLE_KINDS``. Run: widget was reported as new and this
+        failed. (Applied 2026-08-03.)
+        """
+        kinds, _skipped = derived
+        new = kinds - _KNOWN_ADDRESSABLE_KINDS
+        assert not new, (
+            "new tool(s) take a required <kind>_id: " + ", ".join(sorted(new)) + ".\n"
+            "Does a prompt block list this kind? If yes, render the id via "
+            "pocketpaw.prompt.entity.entity_line. If no, add it to "
+            "_KNOWN_ADDRESSABLE_KINDS."
+        )
+
+    def test_the_known_set_has_no_dead_kinds(self, derived: tuple[set[str], list[str]]) -> None:
+        """A kind that no tool requires any more should leave the set.
+
+        Keeps the list honest about what the agent can currently address, so
+        the next reader can trust it as documentation rather than archaeology.
+
+        THE MUTATION THAT BREAKS THIS: add ``"unicorn"`` to
+        ``_KNOWN_ADDRESSABLE_KINDS``. Run: reported as dead and this failed.
+        """
+        kinds, _skipped = derived
+        dead = _KNOWN_ADDRESSABLE_KINDS - kinds
+        assert not dead, (
+            "these kinds no longer have a tool requiring their id: "
+            + ", ".join(sorted(dead))
+            + " — remove them from _KNOWN_ADDRESSABLE_KINDS."
+        )
+
+    def test_the_three_listed_kinds_are_addressable(
+        self, derived: tuple[set[str], list[str]]
+    ) -> None:
+        """The kinds a preamble actually lists, pinned by name.
+
+        ``pocket``, ``widget`` and ``user`` are the three that a prompt block
+        enumerates AND a tool addresses by id — the whole reason this work
+        exists. If a refactor drops the required id from any of their tools,
+        the general tripwire above would report it as merely "dead" and someone
+        would delete the entry. This says out loud that these three are load
+        bearing.
+
+        THE MUTATION THAT BREAKS THIS: make ``update_widget``'s ``widget_id``
+        optional. Run: widget left the derived set and this failed.
+        """
+        kinds, _skipped = derived
+        for kind in ("pocket", "widget", "user"):
+            assert kind in kinds, f"no tool requires {kind}_id any more — is the preamble stale?"

--- a/tests/cloud/surface/test_entity_id_contract.py
+++ b/tests/cloud/surface/test_entity_id_contract.py
@@ -61,21 +61,14 @@ _SCANNED_PACKAGES = (
 # either it is a record of an event rather than a thing, or its label already IS
 # its address. Both numbers may only ever go DOWN.
 _HANDROLLED_ALLOWED = {
-    # "- 10:30 AM · Sync with Sarah" ×2 (with and without a parsed time).
-    # Google Calendar events via Composio. They carry an id and no tool takes
-    # it: the ``meeting_id`` five tools require addresses a ``_MeetingDoc`` in
-    # our own collection, a different entity that no preamble lists. Checked
-    # against meetings/service.py::cancel_meeting on 2026-08-03.
-    "calendar.py": (2, "google calendar events; no tool takes a calendar event id"),
     # "- pocket.created: Sales" — a record OF an action, not a thing to act on.
+    # These three are event/log lines, not entity rows, and routing them through
+    # the renderer would say something false about what they are.
     "activity.py": (1, "activity feed lines are events, not addressable entities"),
     "audit.py": (1, "audit entries are events, not addressable entities"),
     "home.py": (1, "home activity digest lines are events, not entities"),
-    # "- workspace:w1" — a KB scope. The label IS the address; there is no
-    # separate id to carry.
-    "knowledge.py": (1, "a kb scope string is its own identifier"),
-    # "- hero: https://… (alt: "…")" — asset manifest lines. The URL is the
-    # address, and it is already rendered.
+    # "- hero: https://… (alt: "…")" — asset manifest lines in a design brief,
+    # not a surface preamble. The URL is the address and is already rendered.
     "sites.py": (1, "an asset url is its own identifier"),
     # Two rows, exempt for two different reasons. "- Ripple: a Svelte runtime
     # that…" is an atlas glossary entry from a static seed — prose. "- **name**:
@@ -123,6 +116,30 @@ def _scanned_files() -> list[Path]:
         assert root.is_dir(), f"scan target moved: {root}"
         files.extend(p for p in root.rglob("*.py") if "__pycache__" not in p.parts)
     return files
+
+
+def _unaddressed_claims(path: Path) -> list[tuple[str | None, int]]:
+    """Every ``unaddressed_line("<kind>", ...)`` call site, as ``(kind, lineno)``.
+
+    ``kind`` is ``None`` when the first argument is not a plain string literal —
+    a computed kind cannot be checked statically, and a claim that cannot be
+    checked is the allow-list problem wearing a function call.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    claims: list[tuple[str | None, int]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+        if name != "unaddressed_line" or not node.args:
+            continue
+        first = node.args[0]
+        if isinstance(first, ast.Constant) and isinstance(first.value, str):
+            claims.append((first.value, node.lineno))
+        else:
+            claims.append((None, node.lineno))
+    return claims
 
 
 class TestNoHandRolledEntityRows:
@@ -261,6 +278,83 @@ def _derive_addressable_kinds() -> tuple[set[str], list[str]]:
                     if match:
                         kinds.add(match.group("kind"))
     return kinds, skipped
+
+
+class TestUnaddressedClaimsStayTrue:
+    """``unaddressed_line("file", ...)`` is a claim, and this is the check.
+
+    This replaced two allow-list entries (files.py, agents.py) and later two
+    more (calendar.py, knowledge.py). The difference is not cosmetic: an
+    allow-list says "somebody reviewed this once", and these say "still true,
+    re-derived from the tool schemas on every run". The day a tool ships with a
+    required ``file_id``, files.py fails here instead of quietly continuing to
+    render rows the agent now needs an id for.
+    """
+
+    @pytest.fixture(scope="class")
+    def derived(self) -> tuple[set[str], list[str]]:
+        return _derive_addressable_kinds()
+
+    def test_nothing_claims_unaddressed_for_a_kind_a_tool_addresses(
+        self, derived: tuple[set[str], list[str]]
+    ) -> None:
+        """The tripwire that makes the exemption self-checking.
+
+        THE MUTATION THAT BREAKS THIS: change files.py's call to
+        ``unaddressed_line("pocket", ...)``. Run: pocket IS in the derived set,
+        the offender list was non-empty and this failed. (Applied 2026-08-03.)
+        """
+        kinds, _skipped = derived
+        offenders = []
+        for path in _scanned_files():
+            for kind, lineno in _unaddressed_claims(path):
+                if kind is not None and kind in kinds:
+                    offenders.append(
+                        f"{path.relative_to(_REPO_ROOT)}:{lineno} claims '{kind}' is "
+                        "unaddressed, but a tool now requires its id"
+                    )
+        assert not offenders, (
+            "a row says its entity has no id-taking tool, and that is no longer "
+            "true — render the id via entity_line:\n  " + "\n  ".join(offenders)
+        )
+
+    def test_every_unaddressed_claim_is_a_readable_literal(self) -> None:
+        """A computed kind cannot be checked, so it is not allowed to be one.
+
+        Without this, ``unaddressed_line(kind_var, ...)`` would silently opt out
+        of the check above while still looking compliant — the allow-list
+        problem wearing a function call.
+
+        THE MUTATION THAT BREAKS THIS: change knowledge.py's call to
+        ``unaddressed_line(some_var, s)``. Run: the kind read as None and this
+        failed. (Applied 2026-08-03.)
+        """
+        unreadable = [
+            f"{path.relative_to(_REPO_ROOT)}:{lineno}"
+            for path in _scanned_files()
+            for kind, lineno in _unaddressed_claims(path)
+            if kind is None
+        ]
+        assert not unreadable, (
+            "unaddressed_line needs a literal kind so the claim can be checked "
+            "against the tool schemas:\n  " + "\n  ".join(unreadable)
+        )
+
+    def test_the_claims_that_exist_are_the_ones_expected(self) -> None:
+        """Pins WHICH kinds currently claim to be unaddressed.
+
+        A new claim is a new exemption, and exemptions are the thing that rots.
+        This makes adding one a deliberate edit rather than a side effect.
+
+        THE MUTATION THAT BREAKS THIS: add ``unaddressed_line("widget", ...)``
+        anywhere in the scan. Run: reported as unexpected and this failed.
+        """
+        found = {
+            kind for path in _scanned_files() for kind, _ln in _unaddressed_claims(path) if kind
+        }
+        assert found == {"agent", "calendar_event", "file", "kb_scope"}, (
+            f"the set of unaddressed-entity claims moved: {sorted(found)}"
+        )
 
 
 class TestAddressableKindsAreReviewed:

--- a/tests/cloud/surface/test_handler_row_injectivity.py
+++ b/tests/cloud/surface/test_handler_row_injectivity.py
@@ -1,0 +1,184 @@
+# tests/cloud/surface/test_handler_row_injectivity.py — the property, on the
+# handlers themselves.
+# Created: 2026-08-03 (feat/prompt-entity-suffix), from review.
+#
+# WHAT THIS CLOSES. The first pass at the entity-id work tested two things:
+# that ``entity_line`` is injective on id, and — by AST scan — that handlers
+# call it. The property anybody actually cares about is that a HANDLER'S OUTPUT
+# is injective on id, and that was INFERRED from those two rather than asserted.
+# The inference is not airtight: a handler can call the renderer and still hand
+# it the wrong field, or the same field for both entities, and both existing
+# checks pass.
+#
+# It is not a hypothetical gap. ``pocket_to_wire_dict`` emits ``_id``, not
+# ``id``, so ``p.get("id")`` would have returned None for every pocket, every
+# row would have rendered ``id=?``, the AST scan would have been satisfied, and
+# the renderer's own tests would still have been green. This file is what
+# catches that.
+#
+# So these tests drive the REAL handler against REAL seeded documents through
+# the REAL service, with two entities that differ only in id, and assert the
+# rendered preambles differ. No stub sits between the assertion and the bug —
+# deliberately, because a stubbed ``list_pockets`` returning hand-written dicts
+# would encode MY belief about the wire shape, which is the belief under test.
+#
+# EACH TEST NAMES THE MUTATION THAT BREAKS IT, and every one was applied, run,
+# observed to fail, and reverted.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.pockets import service as pockets_service
+from pocketpaw_ee.cloud.pockets.dto import AddWidgetRequest, CreatePocketRequest
+from pocketpaw_ee.cloud.surface.domain import SurfaceMeta
+from pocketpaw_ee.cloud.surface.handlers import pockets_list as pockets_list_handler
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+WORKSPACE = "ws-injectivity"
+USER = "user-injectivity"
+
+
+async def _seed_pocket(name: str) -> str:
+    """Create a pocket through the real service and return its id."""
+    created = await pockets_service.create(
+        WORKSPACE, USER, CreatePocketRequest(name=name, type="custom")
+    )
+    return str(created["_id"])
+
+
+class TestPocketsListHandler:
+    async def test_two_pockets_with_one_name_render_distinguishable_rows(self) -> None:
+        """The production scenario, end to end.
+
+        One workspace, two pockets called Sales. Before the id was rendered
+        these produced byte-identical rows and "open the Sales pocket" was a
+        coin flip that failed silently.
+
+        THE MUTATION THAT BREAKS THIS: in ``pockets_list.py``, pass
+        ``p.get("id")`` instead of ``p.get("_id")``. Run: the wire dict has no
+        ``id`` key, both rows rendered ``id=?``, and the rows-differ assertion
+        failed — while the AST contract test and every renderer test stayed
+        green. That is the exact gap this file was added for.
+        (Applied 2026-08-03.)
+        """
+        first = await _seed_pocket("Sales")
+        second = await _seed_pocket("Sales")
+        assert first != second
+
+        preamble = (await pockets_list_handler.build_preamble(WORKSPACE, USER, SurfaceMeta())).text
+
+        rows = [ln for ln in preamble.splitlines() if ln.startswith("- ")]
+        assert len(rows) == 2, f"expected two pocket rows, got {rows}"
+        assert rows[0] != rows[1], f"two pockets named Sales are indistinguishable: {rows}"
+
+    async def test_the_rendered_id_actually_addresses_the_pocket(self) -> None:
+        """A row that differs but cannot be acted on has missed the point.
+
+        Injectivity alone is satisfied by rendering any per-entity nonsense. The
+        id has to be the thing a tool resolves, so this feeds what the prompt
+        SHOWED to the resolver the tools use and checks it lands on the right
+        pocket.
+
+        THE MUTATION THAT BREAKS THIS: render ``p.get("name")`` as the id. Run:
+        the rows still differed (the names differ here), the resolve returned
+        the wrong pocket, and the assertion failed. (Applied 2026-08-03.)
+        """
+        from pocketpaw_ee.cloud.pockets.id_resolve import resolve_id
+
+        target = await _seed_pocket("Launch Tracker")
+        await _seed_pocket("Roadmap")
+
+        preamble = (await pockets_list_handler.build_preamble(WORKSPACE, USER, SurfaceMeta())).text
+        row = next(ln for ln in preamble.splitlines() if "Launch Tracker" in ln)
+        shown = row.split("id=")[1].split(",")[0].rstrip(")")
+
+        candidates = await pockets_service.list_pockets(WORKSPACE, USER)
+        assert resolve_id(shown, candidates) == target
+
+    async def test_a_pocket_row_is_not_missing_its_id(self) -> None:
+        """Guards the ``id=?`` failure directly, so the diagnosis is readable.
+
+        The injectivity test above catches this too, but reports it as "the rows
+        are identical", which sends a reader looking at the wrong thing.
+
+        THE MUTATION THAT BREAKS THIS: pass ``None`` as the pocket id. Run: the
+        row carried ``id=?`` and this failed. (Applied 2026-08-03.)
+        """
+        await _seed_pocket("Solo")
+
+        preamble = (await pockets_list_handler.build_preamble(WORKSPACE, USER, SurfaceMeta())).text
+        row = next(ln for ln in preamble.splitlines() if ln.startswith("- "))
+
+        assert "id=?" not in row, f"the handler could not supply an id: {row}"
+
+
+class TestWidgetRows:
+    async def test_two_widgets_with_one_name_render_distinguishable_rows(self) -> None:
+        """Widgets are the case with a REQUIRED id on the tool that edits them.
+
+        ``update_widget`` declares ``"required": [..., "widget_id", ...]``, and
+        two tiles called Revenue on one pocket are ordinary — a chart and its
+        summary card routinely share a name.
+
+        THE MUTATION THAT BREAKS THIS: in ``_helpers.format_widget_line``, pass
+        ``getattr(widget, "widget_id", None)`` — a field that does not exist.
+        Run: both rows rendered ``id=?`` and the assertion failed.
+        (Applied 2026-08-03.)
+        """
+        from pocketpaw_ee.cloud.surface.handlers._helpers import format_widget_line
+
+        pocket_id = await _seed_pocket("Metrics")
+        for _ in range(2):
+            await pockets_service.add_widget(
+                pocket_id, USER, AddWidgetRequest(name="Revenue", type="native")
+            )
+
+        pocket = await pockets_service.get(pocket_id, USER)
+        widgets = pocket["widgets"]
+        assert len(widgets) == 2
+
+        rows = [format_widget_line(_AttrView(w)) for w in widgets]
+        assert rows[0] != rows[1], f"two widgets named Revenue are indistinguishable: {rows}"
+
+    async def test_the_rendered_widget_id_resolves_to_that_widget(self) -> None:
+        """Same "differs is not enough" argument as the pocket case.
+
+        THE MUTATION THAT BREAKS THIS: render the widget's index instead of its
+        id. Run: the rows differed, the resolve raised KeyError, and this
+        failed. (Applied 2026-08-03.)
+        """
+        from pocketpaw_ee.cloud.pockets.id_resolve import resolve_id
+        from pocketpaw_ee.cloud.surface.handlers._helpers import format_widget_line
+
+        pocket_id = await _seed_pocket("Metrics")
+        for name in ("Revenue", "Churn"):
+            await pockets_service.add_widget(
+                pocket_id, USER, AddWidgetRequest(name=name, type="native")
+            )
+
+        pocket = await pockets_service.get(pocket_id, USER)
+        views = [_AttrView(w) for w in pocket["widgets"]]
+        target = next(v for v in views if v.name == "Churn")
+
+        row = format_widget_line(target)
+        shown = row.split("id=")[1].split(",")[0].rstrip(")")
+
+        assert resolve_id(shown, views) == target.id
+
+
+class _AttrView:
+    """Attribute access over a widget wire dict.
+
+    ``format_widget_line`` is duck-typed on attributes so it works for Beanie
+    subdocs and domain objects alike; ``get_pocket`` hands back wire dicts. This
+    adapts one to the other without asserting anything about either.
+    """
+
+    def __init__(self, data: dict) -> None:
+        self._data = data
+
+    def __getattr__(self, item: str):
+        if item == "id":
+            return self._data.get("id") or self._data.get("_id")
+        return self._data.get(item)

--- a/tests/cloud/surface/test_preamble_caps.py
+++ b/tests/cloud/surface/test_preamble_caps.py
@@ -19,6 +19,7 @@ These are pure-function tests over the two helpers — no DB, no fixtures.
 
 from __future__ import annotations
 
+from bson import ObjectId
 from pocketpaw_ee.cloud.surface.handlers._helpers import (
     PREAMBLE_MAX_CHARS,
     WIDGET_PREVIEW_LIMIT,
@@ -30,12 +31,21 @@ from pocketpaw_ee.cloud.surface.handlers._helpers import (
 class _Widget:
     """A widget with realistic field lengths.
 
-    ``format_widget_line`` reads ``name`` / ``type`` / ``spec`` off a duck-typed
-    object. Names must be plausible: a ``(unnamed)`` fallback renders ~7 chars
-    shorter per line and would flatter the measurement.
+    ``format_widget_line`` reads ``id`` / ``name`` / ``type`` / ``spec`` off a
+    duck-typed object. Every field must be plausible or the measurement flatters
+    itself: a ``(unnamed)`` fallback renders ~7 chars shorter per line, and —
+    added 2026-08-03 (feat/prompt-entity-ids) — a MISSING ``id`` renders the
+    1-char ``?`` marker where production carries a 24-char ObjectId.
+
+    That second one nearly shipped. When the row started carrying the widget id,
+    this fixture had no ``id`` attribute, so the cap test went on passing while
+    measuring rows 23 chars shorter than the ones the agent actually sees. A cap
+    test that under-measures is worse than none: it reports headroom that is not
+    there. The id is a real ObjectId here for exactly that reason.
     """
 
     def __init__(self, i: int) -> None:
+        self.id = str(ObjectId())
         self.name = f"Revenue by region {i}"
         self.type = "spec"
         self.spec = {"kind": "chart"}
@@ -69,9 +79,14 @@ def test_widget_preview_limit_fits_inside_the_preamble_char_cap():
     """A full widget preview must not push the preamble over its own cap.
 
     MUTATION: set ``WIDGET_PREVIEW_LIMIT = 60`` in
-    ``ee/pocketpaw_ee/cloud/surface/handlers/_helpers.py``. 60 lines at ~36
-    chars is ~2,170 chars against a 1,500 cap, ``truncate_preamble`` fires, and
+    ``ee/pocketpaw_ee/cloud/surface/handlers/_helpers.py``. 60 lines at ~70
+    chars is ~4,200 chars against a 1,500 cap, ``truncate_preamble`` fires, and
     both assertions below fail.
+
+    The margin here is much thinner than it was. Since the row began carrying
+    the widget id (2026-08-03), a line averages 70.2 chars rather than 36.2 and
+    this preamble renders at 1159 of 1500 — so ~16 widgets fit, not ~36. 12 is
+    still safe; 17 is not.
     """
     raw = _render_preamble(300)
 

--- a/tests/cloud/surface/test_preamble_caps.py
+++ b/tests/cloud/surface/test_preamble_caps.py
@@ -27,6 +27,36 @@ from pocketpaw_ee.cloud.surface.handlers._helpers import (
     truncate_preamble,
 )
 
+from pocketpaw.prompt.entity import ID_TAIL_CHARS, MISSING_ID
+
+
+def test_the_fixture_measures_a_production_shaped_row() -> None:
+    """A cap test is worth exactly what its fixture is worth.
+
+    THIS TEST EXISTS BECAUSE THE MUTATION HARNESS FOUND ITS ABSENCE. Deleting
+    ``self.id`` from ``_Widget`` leaves every cap assertion below GREEN — rows
+    without an id are shorter, so a cap measured on them passes more easily. The
+    suite would happily report headroom that production does not have, which is
+    the precise failure this file exists to prevent. ``scripts/mutate.py``
+    flagged it as the one escaping mutation of twenty-one; everything else in
+    the plan was caught.
+
+    So the fixture's realism is now itself asserted: the widget must carry an
+    id, and the rendered row must actually show it.
+
+    THE MUTATION THAT BREAKS THIS: delete ``self.id = str(ObjectId())`` from
+    ``_Widget``. Run: the row rendered ``id=?`` and both assertions failed.
+    (Applied 2026-08-03, via scripts/mutate.py.)
+    """
+    widget = _Widget(0)
+    row = format_widget_line(widget)
+
+    assert f"id={MISSING_ID}" not in row, (
+        "the fixture widget has no id, so every cap measured below is short by "
+        "~23 chars a row against production"
+    )
+    assert widget.id[-ID_TAIL_CHARS:] in row, f"the row does not carry the fixture's id: {row}"
+
 
 class _Widget:
     """A widget with realistic field lengths.
@@ -79,14 +109,16 @@ def test_widget_preview_limit_fits_inside_the_preamble_char_cap():
     """A full widget preview must not push the preamble over its own cap.
 
     MUTATION: set ``WIDGET_PREVIEW_LIMIT = 60`` in
-    ``ee/pocketpaw_ee/cloud/surface/handlers/_helpers.py``. 60 lines at ~70
-    chars is ~4,200 chars against a 1,500 cap, ``truncate_preamble`` fires, and
+    ``ee/pocketpaw_ee/cloud/surface/handlers/_helpers.py``. 60 lines at ~55
+    chars is ~3,300 chars against a 1,500 cap, ``truncate_preamble`` fires, and
     both assertions below fail.
 
-    The margin here is much thinner than it was. Since the row began carrying
-    the widget id (2026-08-03), a line averages 70.2 chars rather than 36.2 and
-    this preamble renders at 1159 of 1500 — so ~16 widgets fit, not ~36. 12 is
-    still safe; 17 is not.
+    The margin is thinner than PA-9 measured. Since the row began carrying the
+    widget id (2026-08-03) a line averages 55.2 chars rather than 36.2 and this
+    preamble renders at 979 of 1500, so ~21 widgets fit rather than ~36. 12 is
+    still safe. The full table of how that moved — and why the id is rendered as
+    an 8-char tail rather than whole — is in ``_helpers.py`` beside
+    ``WIDGET_PREVIEW_LIMIT``.
     """
     raw = _render_preamble(300)
 

--- a/tests/mutations/entity_rows.json
+++ b/tests/mutations/entity_rows.json
@@ -1,0 +1,153 @@
+[
+  {
+    "label": "renderer: drop the id from the row",
+    "file": "src/pocketpaw/prompt/entity.py",
+    "find": "    parts = [f\"id={ident}\"]",
+    "replace": "    parts = []",
+    "tests": ["tests/test_prompt_entity_line.py"]
+  },
+  {
+    "label": "renderer: entity_id gets a default",
+    "file": "src/pocketpaw/prompt/entity.py",
+    "find": "def entity_line(label: Any, entity_id: Any, /, **facts: Any) -> str:",
+    "replace": "def entity_line(label: Any, entity_id: Any = None, /, **facts: Any) -> str:",
+    "tests": ["tests/test_prompt_entity_line.py"]
+  },
+  {
+    "label": "renderer: drop the positional-only marker",
+    "file": "src/pocketpaw/prompt/entity.py",
+    "find": "def entity_line(label: Any, entity_id: Any, /, **facts: Any) -> str:",
+    "replace": "def entity_line(label: Any, entity_id: Any, **facts: Any) -> str:",
+    "tests": ["tests/test_prompt_entity_line.py"]
+  },
+  {
+    "label": "renderer: show the HEAD of the id instead of the tail",
+    "file": "src/pocketpaw/prompt/entity.py",
+    "find": "    return f\"{ID_TAIL_MARKER}{text[-ID_TAIL_CHARS:]}\"",
+    "replace": "    return f\"{ID_TAIL_MARKER}{text[:ID_TAIL_CHARS]}\"",
+    "tests": ["tests/test_prompt_entity_line.py", "tests/cloud/pockets/test_id_resolve.py"]
+  },
+  {
+    "label": "renderer: shorten ids that are already short",
+    "file": "src/pocketpaw/prompt/entity.py",
+    "find": "    if len(text) <= ID_TAIL_CHARS:\n        return text",
+    "replace": "    if False:\n        return text",
+    "tests": ["tests/test_prompt_entity_line.py"]
+  },
+  {
+    "label": "renderer: stop collapsing newlines",
+    "file": "src/pocketpaw/prompt/entity.py",
+    "find": "    return \" \".join(str(value).split())",
+    "replace": "    return str(value)",
+    "tests": ["tests/test_prompt_entity_line.py"]
+  },
+  {
+    "label": "renderer: unaddressed_line leaks the kind into the prompt",
+    "file": "src/pocketpaw/prompt/entity.py",
+    "find": "    name = _clean(label) or \"(unnamed)\"\n    rendered = [f\"{key}={_clean(value) or MISSING_ID}\" for key, value in facts.items()]",
+    "replace": "    name = f\"{kind}: \" + (_clean(label) or \"(unnamed)\")\n    rendered = [f\"{key}={_clean(value) or MISSING_ID}\" for key, value in facts.items()]",
+    "tests": ["tests/test_prompt_entity_line.py"]
+  },
+  {
+    "label": "renderer: unaddressed_line emits empty parens with no facts",
+    "file": "src/pocketpaw/prompt/entity.py",
+    "find": "    if not rendered:\n        return f\"- {name}\"",
+    "replace": "    if False:\n        return f\"- {name}\"",
+    "tests": ["tests/test_prompt_entity_line.py"]
+  },
+  {
+    "label": "resolver: pick the first match instead of raising on ambiguity",
+    "file": "ee/pocketpaw_ee/cloud/pockets/id_resolve.py",
+    "find": "    if len(matches) > 1:\n        raise AmbiguousId(given, matches)",
+    "replace": "    if len(matches) > 1:\n        return matches[0]",
+    "tests": ["tests/cloud/pockets/test_id_resolve.py"]
+  },
+  {
+    "label": "resolver: drop the empty-id guard",
+    "file": "ee/pocketpaw_ee/cloud/pockets/id_resolve.py",
+    "find": "    if not given:\n        raise KeyError(\"no id given\")",
+    "replace": "    if False:\n        raise KeyError(\"no id given\")",
+    "tests": ["tests/cloud/pockets/test_id_resolve.py"]
+  },
+  {
+    "label": "resolver: match anything by suffix, however long",
+    "file": "ee/pocketpaw_ee/cloud/pockets/id_resolve.py",
+    "find": "    if len(given) > ID_TAIL_CHARS:\n        raise KeyError(given)",
+    "replace": "    if False:\n        raise KeyError(given)",
+    "tests": ["tests/cloud/pockets/test_id_resolve.py"]
+  },
+  {
+    "label": "resolver: drop the exact-match fast path",
+    "file": "ee/pocketpaw_ee/cloud/pockets/id_resolve.py",
+    "find": "    if given in ids:\n        return given",
+    "replace": "    if False:\n        return given",
+    "tests": ["tests/cloud/pockets/test_id_resolve.py"]
+  },
+  {
+    "label": "resolver: stop stripping the tail marker the agent echoes back",
+    "file": "ee/pocketpaw_ee/cloud/pockets/id_resolve.py",
+    "find": "    for prefix in _STRIPPABLE_PREFIXES:",
+    "replace": "    for prefix in ():",
+    "tests": ["tests/cloud/pockets/test_id_resolve.py"]
+  },
+  {
+    "label": "resolver: ignore the _id wire spelling",
+    "file": "ee/pocketpaw_ee/cloud/pockets/id_resolve.py",
+    "find": "        value = candidate.get(key) or candidate.get(\"_id\") or candidate.get(\"id\")",
+    "replace": "        value = candidate.get(key)",
+    "tests": ["tests/cloud/pockets/test_id_resolve.py"]
+  },
+  {
+    "label": "handler: pockets_list reads 'id' instead of the wire dict's '_id'",
+    "file": "ee/pocketpaw_ee/cloud/surface/handlers/pockets_list.py",
+    "find": "                    p.get(\"_id\"),",
+    "replace": "                    p.get(\"id\"),",
+    "tests": [
+      "tests/cloud/surface/test_handler_row_injectivity.py",
+      "tests/cloud/surface/test_entity_id_contract.py",
+      "tests/test_prompt_entity_line.py"
+    ]
+  },
+  {
+    "label": "handler: format_widget_line reads a field that does not exist",
+    "file": "ee/pocketpaw_ee/cloud/surface/handlers/_helpers.py",
+    "find": "    return entity_line(name, getattr(widget, \"id\", None), state=marker)",
+    "replace": "    return entity_line(name, getattr(widget, \"widget_id\", None), state=marker)",
+    "tests": ["tests/cloud/surface/test_handler_row_injectivity.py"]
+  },
+  {
+    "label": "handler: pockets_list hand-rolls its row again",
+    "file": "ee/pocketpaw_ee/cloud/surface/handlers/pockets_list.py",
+    "find": "            rows.append(\n                entity_line(",
+    "replace": "            rows.append(f\"- {p.get('name')} (type={p.get('type')})\")\n            _unused = (\n                entity_line(",
+    "tests": ["tests/cloud/surface/test_entity_id_contract.py"]
+  },
+  {
+    "label": "contract: files.py claims an addressable kind is unaddressed",
+    "file": "ee/pocketpaw_ee/cloud/surface/handlers/files.py",
+    "find": "                    \"file\",",
+    "replace": "                    \"pocket\",",
+    "tests": ["tests/cloud/surface/test_entity_id_contract.py"]
+  },
+  {
+    "label": "contract: a computed kind dodges the unaddressed check",
+    "file": "ee/pocketpaw_ee/cloud/surface/handlers/knowledge.py",
+    "find": "        rows = [unaddressed_line(\"kb_scope\", s) for s in scopes[:10]]",
+    "replace": "        _k = \"kb_scope\"\n        rows = [unaddressed_line(_k, s) for s in scopes[:10]]",
+    "tests": ["tests/cloud/surface/test_entity_id_contract.py"]
+  },
+  {
+    "label": "contract: update_widget stops requiring a widget_id",
+    "file": "ee/pocketpaw_ee/agent/mcp_servers/pockets.py",
+    "find": "\"required\": [\"pocket_id\", \"widget_id\", \"fields\"]",
+    "replace": "\"required\": [\"pocket_id\", \"fields\"]",
+    "tests": ["tests/cloud/surface/test_entity_id_contract.py"]
+  },
+  {
+    "label": "caps: the fixture widget loses its realistic id again",
+    "file": "tests/cloud/surface/test_preamble_caps.py",
+    "find": "        self.id = str(ObjectId())",
+    "replace": "        pass",
+    "tests": ["tests/cloud/surface/test_preamble_caps.py"]
+  }
+]

--- a/tests/mutations/entity_rows.json
+++ b/tests/mutations/entity_rows.json
@@ -4,98 +4,127 @@
     "file": "src/pocketpaw/prompt/entity.py",
     "find": "    parts = [f\"id={ident}\"]",
     "replace": "    parts = []",
-    "tests": ["tests/test_prompt_entity_line.py"]
+    "tests": [
+      "tests/test_prompt_entity_line.py"
+    ]
   },
   {
     "label": "renderer: entity_id gets a default",
     "file": "src/pocketpaw/prompt/entity.py",
     "find": "def entity_line(label: Any, entity_id: Any, /, **facts: Any) -> str:",
     "replace": "def entity_line(label: Any, entity_id: Any = None, /, **facts: Any) -> str:",
-    "tests": ["tests/test_prompt_entity_line.py"]
+    "tests": [
+      "tests/test_prompt_entity_line.py"
+    ]
   },
   {
     "label": "renderer: drop the positional-only marker",
     "file": "src/pocketpaw/prompt/entity.py",
     "find": "def entity_line(label: Any, entity_id: Any, /, **facts: Any) -> str:",
     "replace": "def entity_line(label: Any, entity_id: Any, **facts: Any) -> str:",
-    "tests": ["tests/test_prompt_entity_line.py"]
+    "tests": [
+      "tests/test_prompt_entity_line.py"
+    ]
   },
   {
     "label": "renderer: show the HEAD of the id instead of the tail",
     "file": "src/pocketpaw/prompt/entity.py",
     "find": "    return f\"{ID_TAIL_MARKER}{text[-ID_TAIL_CHARS:]}\"",
     "replace": "    return f\"{ID_TAIL_MARKER}{text[:ID_TAIL_CHARS]}\"",
-    "tests": ["tests/test_prompt_entity_line.py", "tests/cloud/pockets/test_id_resolve.py"]
+    "tests": [
+      "tests/test_prompt_entity_line.py",
+      "tests/cloud/pockets/test_id_resolve.py"
+    ]
   },
   {
     "label": "renderer: shorten ids that are already short",
     "file": "src/pocketpaw/prompt/entity.py",
     "find": "    if len(text) <= ID_TAIL_CHARS:\n        return text",
     "replace": "    if False:\n        return text",
-    "tests": ["tests/test_prompt_entity_line.py"]
+    "tests": [
+      "tests/test_prompt_entity_line.py"
+    ]
   },
   {
     "label": "renderer: stop collapsing newlines",
     "file": "src/pocketpaw/prompt/entity.py",
     "find": "    return \" \".join(str(value).split())",
     "replace": "    return str(value)",
-    "tests": ["tests/test_prompt_entity_line.py"]
+    "tests": [
+      "tests/test_prompt_entity_line.py"
+    ]
   },
   {
     "label": "renderer: unaddressed_line leaks the kind into the prompt",
     "file": "src/pocketpaw/prompt/entity.py",
     "find": "    name = _clean(label) or \"(unnamed)\"\n    rendered = [f\"{key}={_clean(value) or MISSING_ID}\" for key, value in facts.items()]",
     "replace": "    name = f\"{kind}: \" + (_clean(label) or \"(unnamed)\")\n    rendered = [f\"{key}={_clean(value) or MISSING_ID}\" for key, value in facts.items()]",
-    "tests": ["tests/test_prompt_entity_line.py"]
+    "tests": [
+      "tests/test_prompt_entity_line.py"
+    ]
   },
   {
     "label": "renderer: unaddressed_line emits empty parens with no facts",
     "file": "src/pocketpaw/prompt/entity.py",
     "find": "    if not rendered:\n        return f\"- {name}\"",
     "replace": "    if False:\n        return f\"- {name}\"",
-    "tests": ["tests/test_prompt_entity_line.py"]
+    "tests": [
+      "tests/test_prompt_entity_line.py"
+    ]
   },
   {
     "label": "resolver: pick the first match instead of raising on ambiguity",
     "file": "ee/pocketpaw_ee/cloud/pockets/id_resolve.py",
     "find": "    if len(matches) > 1:\n        raise AmbiguousId(given, matches)",
     "replace": "    if len(matches) > 1:\n        return matches[0]",
-    "tests": ["tests/cloud/pockets/test_id_resolve.py"]
+    "tests": [
+      "tests/cloud/pockets/test_id_resolve.py"
+    ]
   },
   {
     "label": "resolver: drop the empty-id guard",
     "file": "ee/pocketpaw_ee/cloud/pockets/id_resolve.py",
     "find": "    if not given:\n        raise KeyError(\"no id given\")",
     "replace": "    if False:\n        raise KeyError(\"no id given\")",
-    "tests": ["tests/cloud/pockets/test_id_resolve.py"]
+    "tests": [
+      "tests/cloud/pockets/test_id_resolve.py"
+    ]
   },
   {
     "label": "resolver: match anything by suffix, however long",
     "file": "ee/pocketpaw_ee/cloud/pockets/id_resolve.py",
     "find": "    if len(given) > ID_TAIL_CHARS:\n        raise KeyError(given)",
     "replace": "    if False:\n        raise KeyError(given)",
-    "tests": ["tests/cloud/pockets/test_id_resolve.py"]
+    "tests": [
+      "tests/cloud/pockets/test_id_resolve.py"
+    ]
   },
   {
     "label": "resolver: drop the exact-match fast path",
     "file": "ee/pocketpaw_ee/cloud/pockets/id_resolve.py",
     "find": "    if given in ids:\n        return given",
     "replace": "    if False:\n        return given",
-    "tests": ["tests/cloud/pockets/test_id_resolve.py"]
+    "tests": [
+      "tests/cloud/pockets/test_id_resolve.py"
+    ]
   },
   {
     "label": "resolver: stop stripping the tail marker the agent echoes back",
     "file": "ee/pocketpaw_ee/cloud/pockets/id_resolve.py",
     "find": "    for prefix in _STRIPPABLE_PREFIXES:",
     "replace": "    for prefix in ():",
-    "tests": ["tests/cloud/pockets/test_id_resolve.py"]
+    "tests": [
+      "tests/cloud/pockets/test_id_resolve.py"
+    ]
   },
   {
     "label": "resolver: ignore the _id wire spelling",
     "file": "ee/pocketpaw_ee/cloud/pockets/id_resolve.py",
     "find": "        value = candidate.get(key) or candidate.get(\"_id\") or candidate.get(\"id\")",
     "replace": "        value = candidate.get(key)",
-    "tests": ["tests/cloud/pockets/test_id_resolve.py"]
+    "tests": [
+      "tests/cloud/pockets/test_id_resolve.py"
+    ]
   },
   {
     "label": "handler: pockets_list reads 'id' instead of the wire dict's '_id'",
@@ -113,41 +142,98 @@
     "file": "ee/pocketpaw_ee/cloud/surface/handlers/_helpers.py",
     "find": "    return entity_line(name, getattr(widget, \"id\", None), state=marker)",
     "replace": "    return entity_line(name, getattr(widget, \"widget_id\", None), state=marker)",
-    "tests": ["tests/cloud/surface/test_handler_row_injectivity.py"]
+    "tests": [
+      "tests/cloud/surface/test_handler_row_injectivity.py"
+    ]
   },
   {
     "label": "handler: pockets_list hand-rolls its row again",
     "file": "ee/pocketpaw_ee/cloud/surface/handlers/pockets_list.py",
     "find": "            rows.append(\n                entity_line(",
     "replace": "            rows.append(f\"- {p.get('name')} (type={p.get('type')})\")\n            _unused = (\n                entity_line(",
-    "tests": ["tests/cloud/surface/test_entity_id_contract.py"]
+    "tests": [
+      "tests/cloud/surface/test_entity_id_contract.py"
+    ]
   },
   {
     "label": "contract: files.py claims an addressable kind is unaddressed",
     "file": "ee/pocketpaw_ee/cloud/surface/handlers/files.py",
     "find": "                    \"file\",",
     "replace": "                    \"pocket\",",
-    "tests": ["tests/cloud/surface/test_entity_id_contract.py"]
+    "tests": [
+      "tests/cloud/surface/test_entity_id_contract.py"
+    ]
   },
   {
     "label": "contract: a computed kind dodges the unaddressed check",
     "file": "ee/pocketpaw_ee/cloud/surface/handlers/knowledge.py",
     "find": "        rows = [unaddressed_line(\"kb_scope\", s) for s in scopes[:10]]",
     "replace": "        _k = \"kb_scope\"\n        rows = [unaddressed_line(_k, s) for s in scopes[:10]]",
-    "tests": ["tests/cloud/surface/test_entity_id_contract.py"]
+    "tests": [
+      "tests/cloud/surface/test_entity_id_contract.py"
+    ]
   },
   {
     "label": "contract: update_widget stops requiring a widget_id",
     "file": "ee/pocketpaw_ee/agent/mcp_servers/pockets.py",
     "find": "\"required\": [\"pocket_id\", \"widget_id\", \"fields\"]",
     "replace": "\"required\": [\"pocket_id\", \"fields\"]",
-    "tests": ["tests/cloud/surface/test_entity_id_contract.py"]
+    "tests": [
+      "tests/cloud/surface/test_entity_id_contract.py"
+    ]
   },
   {
     "label": "caps: the fixture widget loses its realistic id again",
     "file": "tests/cloud/surface/test_preamble_caps.py",
     "find": "        self.id = str(ObjectId())",
     "replace": "        pass",
-    "tests": ["tests/cloud/surface/test_preamble_caps.py"]
+    "tests": [
+      "tests/cloud/surface/test_preamble_caps.py"
+    ]
+  },
+  {
+    "label": "wiring: agent_update_widget stops resolving short widget ids",
+    "file": "ee/pocketpaw_ee/cloud/pockets/service.py",
+    "find": "        widget_id = resolve_id(widget_id, list(doc.widgets))",
+    "replace": "        widget_id = widget_id",
+    "tests": [
+      "tests/cloud/pockets/test_short_id_tool_wiring.py"
+    ]
+  },
+  {
+    "label": "wiring: _agent_load_doc stops resolving short pocket ids",
+    "file": "ee/pocketpaw_ee/cloud/pockets/service.py",
+    "find": "    if not _is_whole_object_id(pocket_id):",
+    "replace": "    if False:",
+    "tests": [
+      "tests/cloud/pockets/test_short_id_tool_wiring.py"
+    ]
+  },
+  {
+    "label": "wiring: every id takes the resolve path, including whole ones",
+    "file": "ee/pocketpaw_ee/cloud/pockets/service.py",
+    "find": "    return len(value) == 24 and all(c in \"0123456789abcdefABCDEF\" for c in value)",
+    "replace": "    return False",
+    "tests": [
+      "tests/cloud/pockets/test_short_id_tool_wiring.py"
+    ]
+  },
+  {
+    "label": "wiring: the tail resolve drops its workspace filter (tenancy)",
+    "file": "ee/pocketpaw_ee/cloud/pockets/service.py",
+    "find": "find({\"workspace\": workspace_id}, {\"_id\": 1})",
+    "replace": "find({}, {\"_id\": 1})",
+    "tests": [
+      "tests/cloud/pockets/test_short_id_tool_wiring.py"
+    ]
+  },
+  {
+    "label": "wiring: the beanie 1.x collection API comes back",
+    "file": "ee/pocketpaw_ee/cloud/pockets/service.py",
+    "find": "_PocketDoc.get_pymongo_collection().find(",
+    "replace": "_PocketDoc.get_motor_collection().find(",
+    "tests": [
+      "tests/cloud/pockets/test_short_id_tool_wiring.py"
+    ]
   }
 ]

--- a/tests/test_prompt_entity_line.py
+++ b/tests/test_prompt_entity_line.py
@@ -1,0 +1,209 @@
+# tests/test_prompt_entity_line.py — the canonical entity row.
+# Created: 2026-08-03 (feat/prompt-entity-ids).
+#
+# ``entity_line`` exists so a prompt cannot name something the agent is unable to
+# address. These tests hold the two properties that claim buys:
+#
+#   * INJECTIVITY ON ID — two entities differing only in id render differently.
+#     This is the real property, and it is strictly stronger than "the output
+#     contains an id", which a renderer emitting a constant would also satisfy.
+#   * THE ID CANNOT BE OMITTED — not by forgetting the argument (TypeError) and
+#     not by passing a name that shadows it (positional-only).
+#
+# The enforcement that every handler actually CALLS this lives next door in
+# tests/cloud/surface/test_entity_id_contract.py. A correct renderer nobody
+# reaches is the original bug intact.
+#
+# EACH TEST NAMES THE MUTATION THAT BREAKS IT, and every one was applied, run,
+# observed to fail, and reverted.
+
+from __future__ import annotations
+
+import pytest
+
+from pocketpaw.prompt.entity import MISSING_ID, entity_line
+
+
+class TestInjectiveOnId:
+    """The property the four broken handlers did not have."""
+
+    def test_two_entities_differing_only_in_id_render_differently(self) -> None:
+        """The exact production shape: one workspace, two pockets called Sales.
+
+        Before this module they rendered byte-identical rows and "open the Sales
+        pocket" resolved to whichever one the model felt like.
+
+        THE MUTATION THAT BREAKS THIS: drop ``id={ident}`` from ``parts``. Run:
+        both rows rendered ``- Sales (type=custom)`` and the assertion failed.
+        """
+        one = entity_line("Sales", "68af1c2d9e4b7a0012f3c4d5", type="custom")
+        two = entity_line("Sales", "68af1c2d9e4b7a0012f3c4d6", type="custom")
+
+        assert one != two
+        assert "68af1c2d9e4b7a0012f3c4d5" in one
+        assert "68af1c2d9e4b7a0012f3c4d6" in two
+
+    def test_the_id_survives_whole(self) -> None:
+        """An id is exact or it is a failed tool call — never shortened.
+
+        Every other field here is advisory. This one is an address, so no cap
+        applies to it and none should be added later without reading this test.
+
+        THE MUTATION THAT BREAKS THIS: truncate the id to 8 chars in
+        ``entity_line``. Run: the full-id assertion failed.
+        """
+        ident = "68af1c2d9e4b7a0012f3c4d5"
+        assert ident in entity_line("Sales", ident)
+
+    def test_labels_differing_still_render_differently(self) -> None:
+        """Injectivity on id must not have cost injectivity on the label.
+
+        THE MUTATION THAT BREAKS THIS: render only the id and drop the label.
+        Run: both rows were ``- (id=p1)`` and the assertion failed.
+        """
+        assert entity_line("Sales", "p1") != entity_line("Support", "p1")
+
+
+class TestTheIdCannotBeOmitted:
+    """Structural, not conventional — the API refuses the bug."""
+
+    def test_forgetting_the_id_is_a_type_error(self) -> None:
+        """The guarantee that makes this module worth existing.
+
+        A default would make ``entity_line(name)`` legal and the whole class of
+        bug would come straight back, silently, at the first hurried call site.
+
+        THE MUTATION THAT BREAKS THIS: give ``entity_id`` a default of ``None``.
+        Run: no TypeError was raised and ``pytest.raises`` failed.
+        """
+        with pytest.raises(TypeError):
+            entity_line("Sales")  # type: ignore[call-arg]
+
+    def test_a_fact_may_be_named_label_or_entity_id(self) -> None:
+        """What the positional-only ``/`` actually buys.
+
+        The obvious test here — ``entity_line("Sales", id="p1")`` raises — passes
+        with the ``/`` removed too, because ``entity_id`` is simply missing. It
+        proved nothing; the mutation harness caught it escaping and this replaced
+        it.
+
+        The real property is collision: facts are arbitrary caller-chosen names,
+        and two of them collide with this signature. Without the ``/`` a handler
+        rendering a ``label=`` fact gets "got multiple values for argument
+        'label'" — a crash in prompt assembly, from a field name.
+
+        THE MUTATION THAT BREAKS THIS: remove the ``/`` from the signature. Run:
+        TypeError, multiple values for argument 'label'. (Applied 2026-08-03.)
+        """
+        row = entity_line("Sales", "p1", label="Q3", entity_id="not-the-id")
+        assert row == "- Sales (id=p1, label=Q3, entity_id=not-the-id)"
+
+    def test_naming_the_id_as_a_keyword_does_not_smuggle_it_in(self) -> None:
+        """``entity_line("Sales", id="p1")`` is a missing id, and must not pass.
+
+        THE MUTATION THAT BREAKS THIS: give ``entity_id`` a default of ``None``.
+        Run: the call bound ``id`` as a fact, returned a row with ``id=?``, and
+        ``pytest.raises`` failed. (Applied 2026-08-03.)
+        """
+        with pytest.raises(TypeError):
+            entity_line("Sales", id="p1")  # type: ignore[call-arg,misc]
+
+
+class TestMissingIdIsVisible:
+    """A caller with no id gets a hole in the prompt, not a tidy-looking row."""
+
+    def test_a_none_id_renders_the_marker_and_does_not_raise(self) -> None:
+        """Degrade, never drop — a row is still better than no row.
+
+        The marker is not empty and does not read like an id, so the agent
+        cannot pass it to a tool and a human reading a prompt dump sees it.
+
+        THE MUTATION THAT BREAKS THIS: ``return ""`` when ``entity_id`` is None.
+        Run: the row was empty and both assertions failed.
+        """
+        row = entity_line("report.pdf", None, mime="application/pdf")
+        assert f"id={MISSING_ID}" in row
+        assert "report.pdf" in row
+
+    def test_the_marker_is_not_mistakable_for_an_id(self) -> None:
+        """Guards the constant itself.
+
+        THE MUTATION THAT BREAKS THIS: set ``MISSING_ID = "unknown"``. Run: it
+        is alphanumeric and reads as a real id — the assertion failed.
+        """
+        assert MISSING_ID
+        assert not MISSING_ID.isalnum()
+
+    def test_an_empty_id_is_treated_as_missing(self) -> None:
+        """``""`` and ``None`` are one thing, not two.
+
+        Services return both for "absent" depending on whether the field is
+        optional or defaulted, and ``id=`` with nothing after it reads as a
+        formatting bug rather than as missing data.
+
+        THE MUTATION THAT BREAKS THIS: use ``str(entity_id)`` directly instead
+        of ``_clean(...) or MISSING_ID``. Run: the row rendered ``(id=)``.
+        """
+        assert f"id={MISSING_ID}" in entity_line("report.pdf", "")
+
+
+class TestRowStaysOneRow:
+    """A row that is really half a row corrupts the block around it."""
+
+    def test_a_newline_in_a_label_does_not_split_the_row(self) -> None:
+        """Names and filenames are user-supplied, so this is reachable.
+
+        The preamble cap is line-aware; a label carrying a newline invents a
+        line boundary that is not in the data, and the cap then cuts there.
+
+        THE MUTATION THAT BREAKS THIS: make ``_clean`` return ``str(value)``
+        unchanged. Run: the row contained a newline and the assertion failed.
+        """
+        row = entity_line("Q3\nplan", "p1")
+        assert "\n" not in row
+        assert "Q3 plan" in row
+
+    def test_a_newline_in_a_fact_does_not_split_the_row(self) -> None:
+        """Same hazard, other half of the signature.
+
+        THE MUTATION THAT BREAKS THIS: stop routing fact values through
+        ``_clean``. Run: the row contained a newline.
+        """
+        assert "\n" not in entity_line("Sales", "p1", note="line\nbreak")
+
+
+class TestFactRendering:
+    def test_facts_render_in_call_order_after_the_id(self) -> None:
+        """The handler decides what a reader sees first; the id always leads.
+
+        THE MUTATION THAT BREAKS THIS: ``sorted(facts.items())``. Run: ``agents``
+        sorted ahead of ``type`` and ``widgets`` and the index assertions failed.
+        """
+        row = entity_line("Sales", "p1", type="custom", widgets=3, agents=2)
+        assert row == "- Sales (id=p1, type=custom, widgets=3, agents=2)"
+
+    def test_an_empty_fact_value_renders_the_marker(self) -> None:
+        """``mime=`` with nothing after it reads as a bug, not as unknown data.
+
+        THE MUTATION THAT BREAKS THIS: drop the ``or MISSING_ID`` from the fact
+        comprehension. Run: the row rendered ``(id=f1, mime=)``.
+        """
+        expected = f"- report.pdf (id=f1, mime={MISSING_ID})"
+        assert entity_line("report.pdf", "f1", mime=None) == expected
+
+    def test_no_facts_is_a_valid_row(self) -> None:
+        """Not every entity has anything worth saying beyond its name.
+
+        THE MUTATION THAT BREAKS THIS: require at least one fact. Run: TypeError.
+        """
+        assert entity_line("Sales", "p1") == "- Sales (id=p1)"
+
+    def test_a_nameless_entity_still_renders(self) -> None:
+        """Degrade, never drop — the id is the part that matters anyway.
+
+        THE MUTATION THAT BREAKS THIS: ``return ""`` for a falsy label. Run: the
+        row was empty and the id assertion failed.
+        """
+        row = entity_line("", "p1")
+        assert "(unnamed)" in row
+        assert "id=p1" in row

--- a/tests/test_prompt_entity_line.py
+++ b/tests/test_prompt_entity_line.py
@@ -21,7 +21,14 @@ from __future__ import annotations
 
 import pytest
 
-from pocketpaw.prompt.entity import MISSING_ID, entity_line
+from pocketpaw.prompt.entity import (
+    ID_TAIL_CHARS,
+    ID_TAIL_MARKER,
+    MISSING_ID,
+    entity_line,
+    short_id,
+    unaddressed_line,
+)
 
 
 class TestInjectiveOnId:
@@ -40,20 +47,59 @@ class TestInjectiveOnId:
         two = entity_line("Sales", "68af1c2d9e4b7a0012f3c4d6", type="custom")
 
         assert one != two
-        assert "68af1c2d9e4b7a0012f3c4d5" in one
-        assert "68af1c2d9e4b7a0012f3c4d6" in two
+        assert "12f3c4d5" in one
+        assert "12f3c4d6" in two
 
-    def test_the_id_survives_whole(self) -> None:
-        """An id is exact or it is a failed tool call — never shortened.
+    def test_ids_that_differ_only_in_the_head_still_render_differently(self) -> None:
+        """The adversarial case for a TAIL, and the reason it is a tail.
 
-        Every other field here is advisory. This one is an address, so no cap
-        applies to it and none should be added later without reading this test.
+        Two ids sharing a tail would render identically and reintroduce the bug.
+        That is not the shape ObjectIds actually collide in — they share HEADS,
+        because the leading 4 bytes are a timestamp and the next 5 are constant
+        per process — but a renderer that only works for one id scheme is a trap
+        for whoever adds the next one.
 
-        THE MUTATION THAT BREAKS THIS: truncate the id to 8 chars in
-        ``entity_line``. Run: the full-id assertion failed.
+        So: heads differ, tails differ, rows differ. If a future id scheme puts
+        the entropy at the front, this is the test that will fail and say so.
+
+        THE MUTATION THAT BREAKS THIS: render the HEAD instead of the tail
+        (``text[:ID_TAIL_CHARS]``). Run: two ids created in the same second
+        rendered the same row and this failed. (Applied 2026-08-03.)
+        """
+        one = entity_line("Sales", "6a70c69ecdf9641d9280ebb6")
+        two = entity_line("Sales", "6a70c69ecdf9641d9280ebb7")
+        assert one != two
+
+    def test_a_short_id_is_not_shortened_further(self) -> None:
+        """Slugs, uuids and fixture ids pass through untouched.
+
+        Marking an 8-char id as a tail would spend a character to say nothing,
+        and would hand the resolver a marker where it expects a whole id.
+
+        THE MUTATION THAT BREAKS THIS: drop the length guard in ``short_id`` and
+        always prepend the marker. Run: ``pk-123`` rendered as ``…pk-123``.
+        """
+        assert entity_line("Sales", "pk-123") == "- Sales (id=pk-123)"
+        assert short_id("abcd1234") == "abcd1234"
+
+    def test_the_rendered_tail_is_the_real_tail(self) -> None:
+        """What replaced "the id survives whole".
+
+        The id used to be rendered entire, on the reasoning that an id is exact
+        or it is a failed tool call. That is still true — what changed is that
+        the TOOLS now resolve a tail (``pockets/id_resolve.py``), so a tail is
+        exact. This test holds the renderer's half of that bargain: the chars it
+        shows are genuinely the last ones of the id, so the resolver can match on
+        them. The round trip through the real resolver is asserted in
+        ``tests/cloud/pockets/test_id_resolve.py``.
+
+        THE MUTATION THAT BREAKS THIS: render ``text[-ID_TAIL_CHARS - 1 : -1]``.
+        Run: the endswith assertion failed. (Applied 2026-08-03.)
         """
         ident = "68af1c2d9e4b7a0012f3c4d5"
-        assert ident in entity_line("Sales", ident)
+        rendered = short_id(ident)
+        assert rendered == f"{ID_TAIL_MARKER}{ident[-ID_TAIL_CHARS:]}"
+        assert ident.endswith(rendered.lstrip(ID_TAIL_MARKER))
 
     def test_labels_differing_still_render_differently(self) -> None:
         """Injectivity on id must not have cost injectivity on the label.
@@ -207,3 +253,58 @@ class TestFactRendering:
         row = entity_line("", "p1")
         assert "(unnamed)" in row
         assert "id=p1" in row
+
+
+class TestUnaddressedLine:
+    """The row for an entity no tool addresses by id.
+
+    Added 2026-08-03 (feat/prompt-entity-suffix). Review's verdict on the first
+    pass was that files and agents were rendering ids no tool accepts, justified
+    after the fact. This is what replaced that: no id at all, and the ``kind``
+    argument turns the exemption into a claim the contract test re-checks against
+    the tool schemas on every run.
+    """
+
+    def test_it_renders_no_id(self) -> None:
+        """The whole point — the chars an unusable id would cost are not spent.
+
+        THE MUTATION THAT BREAKS THIS: have ``unaddressed_line`` delegate to
+        ``entity_line`` with a None id. Run: the row carried ``id=?``.
+        """
+        row = unaddressed_line("file", "report.pdf", mime="application/pdf")
+        assert row == "- report.pdf (mime=application/pdf)"
+        assert "id=" not in row
+
+    def test_the_kind_is_never_rendered(self) -> None:
+        """``kind`` exists to be READ BY THE TEST, not by the model.
+
+        Leaking it would put a word in the prompt that means nothing to the
+        agent and costs tokens on every row.
+
+        THE MUTATION THAT BREAKS THIS: prepend ``f"{kind}: "`` to the label.
+        Run: 'file' appeared in the row and this failed.
+        """
+        assert "file" not in unaddressed_line("file", "report.pdf")
+
+    def test_a_row_with_no_facts_has_no_empty_parens(self) -> None:
+        """``- workspace:w1`` — a KB scope has nothing to add and should say so.
+
+        THE MUTATION THAT BREAKS THIS: always append ``(…)``. Run: the row
+        rendered ``- workspace:w1 ()`` and this failed. (Applied 2026-08-03.)
+        """
+        assert unaddressed_line("kb_scope", "workspace:w1") == "- workspace:w1"
+
+    def test_it_still_collapses_newlines(self) -> None:
+        """Same one-row-per-row hazard as ``entity_line``; same fix.
+
+        THE MUTATION THAT BREAKS THIS: stop routing the label through ``_clean``.
+        Run: the row contained a newline.
+        """
+        assert "\n" not in unaddressed_line("file", "Q3\nplan.pdf")
+
+    def test_it_still_names_a_nameless_entity(self) -> None:
+        """Degrade, never drop.
+
+        THE MUTATION THAT BREAKS THIS: return "" for a falsy label. Run: empty.
+        """
+        assert unaddressed_line("file", "") == "- (unnamed)"


### PR DESCRIPTION
Stacked on #1856. Merge that first.

## The bug

Four list handlers rendered entities by label with no id, while the tools that act on them require one. `update_widget` declares `widget_id` required; the pinned-widgets block emitted `- Revenue (native)`. Two pockets called Sales rendered byte-identical rows, so "open the Sales pocket" resolved to whichever one the model picked and the tool call succeeded against the wrong entity — no error, no signal. The same shape hit the `<about-member>` block in #1856.

## The fix, in three parts

**One renderer.** `pocketpaw.prompt.entity.entity_line(label, entity_id, **facts)`, in OSS core so the EE handlers and the channel layers both reach it. `entity_id` is a required positional — no call drops it silently.

**A gate that can't rot.** An AST scan fails any hand-rolled row; allow-listed modules pin their row *count*, so an exempt file can't grow a new bad one; and the set of addressable kinds is **derived from the MCP tool schemas**. Add a tool with a required `site_id` and the check fails until someone decides whether the sites preamble owes an id. The failure lands on the person adding the tool.

The derivation found 17 kinds across 33 tools, zero servers unenumerable. Three are listed by a prompt block: `pocket`, `widget`, `user`. It independently confirms #1856 — `member_remove` and `member_update_role` both require `user_id`.

**Exemptions are claims, not allow-list entries.** A row whose entity no tool addresses uses `unaddressed_line("<kind>", ...)`. The kind is checked against the derived set on every run, so the day a `file_id` tool ships, `files.py` fails instead of quietly under-informing the agent. That converted four review-once exemptions into re-checked ones and took the hand-rolled allow-list from 8 modules to 6.

## Ids render as an 8-char tail

The id was 24 of the ~70 chars in a widget row inside a 1500-char cap. `entity_line` now renders `id=…3f9a1c07`, and `pockets/id_resolve.py` resolves it back — scoped to the workspace for pockets, to the already-loaded document for widgets.

**The tail, not the head, and that was measured.** An ObjectId is timestamp + per-process random + counter, so 12 widgets created together share their first **twenty** characters. Of 12 such ids, the first 12 chars gave 1 distinct value; the last 6 gave 12. A prefix scheme would have been worse than useless.

**An ambiguous tail raises and names the candidates.** It never picks. A short id that resolved loosely would be exactly the silent wrong-entity write this work exists to prevent. Whole ids keep their exact path, so no existing caller changes behaviour.

## What it costs, measured on one fixture throughout

| | row avg | 12 rows | 300-widget preamble | widgets that fit |
|---|---|---|---|---|
| PA-9, no id | 36.2 | 434 | 609 (41% of cap) | ~36 |
| whole ObjectId | 70.2 | 842 | 1159 (77% of cap) | ~16 |
| **8-char tail** | **55.2** | **662** | **979 (65% of cap)** | **~21** |

The middle row is why the tail exists — a whole id took the margin over `WIDGET_PREVIEW_LIMIT` from 3x to 1.3x, making the limit a real constraint. The tail puts it back to 1.75x. `_helpers.py` carries this table; PA-9's stale numbers are replaced rather than left to mislead.

## Two bugs found on the way

**The cap test had started under-measuring.** Its fixture widget carried no `id`, so once rows rendered one it measured the 1-char `?` where production has 24 chars. It would have gone on passing while reporting headroom that wasn't there.

**And the fix for that wasn't protected.** The mutation harness caught it: deleting `self.id` from the fixture left every cap assertion green, because rows without an id are *shorter* and pass a cap more easily. There's now a test asserting the fixture is production-shaped.

## Verification

**`scripts/mutate.py`** — the mutation harness is a command now, not a habit. It applies a plan, runs the tests, restores the file, and exits non-zero on anything that escaped. `tests/mutations/entity_rows.json` holds 21 mutations for this work; **all 21 are caught**. One escaped on the first run and is the bug described above.

The convention is in `CLAUDE.md`: *a gate is not a gate until a mutation has been observed to break it.* This repo's docstrings name the mutation that breaks each test, and that's only worth something if it was actually run.

**Handler-level tests, not just renderer-level.** The first pass asserted `entity_line` is injective and that handlers call it, then *inferred* handler output is injective. Not airtight — `pocket_to_wire_dict` emits `_id`, not `id`, so `p.get("id")` would render `id=?` for every pocket with both checks green. `test_handler_row_injectivity.py` drives the real handlers against real seeded documents and checks that the id shown resolves back to the right entity.

**Suites:** no new failures. The 20 reds across `tests/cloud/surface/` and `tests/cloud/pockets/` are pre-existing — confirmed by stashing this work and re-running the identical set on the untouched baseline, twice. `ruff check`, `ruff format --check`, `mypy` clean.

**CI caveat:** `ci.yml` only triggers on PRs targeting `dev`/`main`/`feat/*-integration`, so the full test job does not run on this PR while it is stacked. It will once the base collapses to `dev`.