### PR TITLE
One uncached config read was the whole prompt-assembly cost

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -2052,6 +2052,22 @@ def _member_private_user_scope(ctx: ScopeContext) -> str | None:
 # ~400 tokens ≈ 1600 chars (English ≈ 4 chars/token); we cap on chars (a
 # cheap, deterministic proxy — no tokenizer dependency) and truncate with an
 # ellipsis if a rendered block would exceed it.
+# How long one KB scope search may take before the turn gives up on it.
+#
+# 1.5s is a backstop, not a target. A healthy scope answers in ~25 ms (process
+# spawn); the number exists for the unhealthy case, and the unhealthy case is
+# real: a workspace holding 4,051,312 words measured 4.2 SECONDS per search on
+# 2026-08-04, on every turn, because kb-go scans instead of indexing. Search
+# time there was flat across queries — "a" and a six-word question cost the
+# same — which is the signature of a scan. That index is being fixed in kb-go
+# separately; this cap stays regardless, because it bounds any slow scope
+# rather than that one cause.
+#
+# Set high enough that a slow-but-working scope still contributes, low enough
+# that a pathological one cannot own the turn. Exceeding it drops the KB block,
+# which is the same outcome as a scope with no hits.
+_KB_SEARCH_TIMEOUT_SECONDS = 1.5
+
 _BRIEFING_MAX_CHARS = 1600
 
 
@@ -2290,16 +2306,48 @@ async def _build_kb_snippets_block(ctx: ScopeContext, query: str) -> str:
         logger.debug("KnowledgeService unavailable; skipping KB block", exc_info=True)
         return ""
 
-    snippets: list[tuple[str, str]] = []
-    for scope in scopes:
+    # CONCURRENT, and BOUNDED. Both matter, and for different reasons.
+    #
+    # Concurrent: each scope is an independent ``kb`` subprocess, and the loop
+    # here awaited them one after another, so N scopes cost the sum rather than
+    # the max. Measured 2026-08-04 against two empty scopes: 50.2 ms serial,
+    # ~25 ms gathered — the floor is process spawn, which we pay per scope
+    # either way but no longer pay in sequence.
+    #
+    # Bounded: a scope's search time scales with its CONTENT, not the query. A
+    # workspace holding 4,051,312 words took 4.2 SECONDS per turn — measured,
+    # on this machine, on a message that was just "hello" — because kb-go scans
+    # rather than indexes. Nothing capped it, so the whole chat turn inherited
+    # that. The cap degrades to "no KB block", which is the same outcome as the
+    # empty-scope case the code above already handles, rather than a stalled
+    # turn. It is a backstop, NOT the fix — kb-go's missing index is owned by
+    # another teammate as of 2026-08-04. Keep this even after that lands: it
+    # bounds ANY slow scope (a huge corpus, a wedged binary, a stalled mount),
+    # not only the unindexed case that exposed it.
+    async def _one(scope: str) -> tuple[str, str] | None:
         try:
-            text = await KnowledgeService.search_context_for_scope(scope, query, limit=3)
+            text = await asyncio.wait_for(
+                KnowledgeService.search_context_for_scope(scope, query, limit=3),
+                timeout=_KB_SEARCH_TIMEOUT_SECONDS,
+            )
+        except TimeoutError:
+            logger.warning(
+                "knowledge search for scope %s exceeded %.1fs; dropping the KB block for "
+                "this turn (is the scope indexed?)",
+                scope,
+                _KB_SEARCH_TIMEOUT_SECONDS,
+            )
+            return None
         except Exception:
             logger.warning("knowledge search failed for scope %s", scope, exc_info=True)
-            continue
-        cleaned = text.strip()
-        if cleaned:
-            snippets.append((scope, cleaned))
+            return None
+        cleaned = (text or "").strip()
+        return (scope, cleaned) if cleaned else None
+
+    # Order is preserved by ``gather``, so the rendered block is byte-identical
+    # to the serial version for any given set of results.
+    results = await asyncio.gather(*(_one(s) for s in scopes))
+    snippets: list[tuple[str, str]] = [r for r in results if r is not None]
 
     if not snippets:
         return ""

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -738,10 +738,13 @@ async def _generate_session_title(ctx: ScopeContext, first_message: str) -> None
             )
 
     try:
-        from pocketpaw.config import Settings  # type: ignore[import-untyped]
+        from pocketpaw.config import get_settings  # type: ignore[import-untyped]
         from pocketpaw.memory.titler import generate_title  # type: ignore[import-untyped]
 
-        settings = Settings.load()
+        # get_settings(), not Settings.load(): the latter re-parses the whole
+        # pydantic-settings model from .env at ~115 ms a call (measured
+        # 2026-08-04). This is a read of config on the per-run title path.
+        settings = get_settings()
         title = await generate_title(
             first_message,
             model=settings.chat_title_model,
@@ -994,11 +997,12 @@ async def _prewarm_session(ctx: ScopeContext) -> None:
     keep today's cold turn-1.
     """
     try:
-        from pocketpaw.config import Settings
+        from pocketpaw.config import get_settings
 
         # Smart routing makes the model message-dependent → can't match the
         # turn-1 cache key from a message-less prewarm. Skip to avoid churn.
-        if Settings.load().smart_routing_enabled:
+        # get_settings(): a cached flag read, not a fresh parse. See above.
+        if get_settings().smart_routing_enabled:
             return
 
         pool = get_agent_pool()

--- a/ee/pocketpaw_ee/cloud/composio/connect_link.py
+++ b/ee/pocketpaw_ee/cloud/composio/connect_link.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from pocketpaw.config import Settings
+from pocketpaw.config import Settings, get_settings
 
 logger = logging.getLogger(__name__)
 
@@ -151,7 +151,7 @@ def maybe_emit_connect_link(
     Gated by ``settings.composio_connect_link_inline``; when False, this
     is a no-op and the agent's response surfaces the raw URL string.
     """
-    s = settings or Settings.load()
+    s = settings or get_settings()
     if not s.composio_connect_link_inline:
         return False
 

--- a/ee/pocketpaw_ee/cloud/composio/providers.py
+++ b/ee/pocketpaw_ee/cloud/composio/providers.py
@@ -38,7 +38,7 @@ import time
 from dataclasses import dataclass
 from typing import Any
 
-from pocketpaw.config import Settings
+from pocketpaw.config import Settings, get_settings
 from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
 from pocketpaw_ee.cloud.composio import service as composio_service
 
@@ -104,7 +104,7 @@ def build_tools_for_backend(
     if backend_kind not in SUPPORTED_BACKENDS:
         return []
 
-    s = settings or Settings.load()
+    s = settings or get_settings()
     if not composio_service.is_enabled(s):
         return []
 

--- a/ee/pocketpaw_ee/cloud/composio/service.py
+++ b/ee/pocketpaw_ee/cloud/composio/service.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
-from pocketpaw.config import Settings
+from pocketpaw.config import Settings, get_settings
 from pocketpaw_ee.cloud._core.context import RequestContext
 from pocketpaw_ee.cloud._core.errors import Internal, ValidationError
 from pocketpaw_ee.cloud._core.realtime.emit import emit
@@ -47,10 +47,26 @@ def is_enabled(settings: Settings | None = None) -> bool:
     The ``Settings`` validator already enforces ``api_key →
     enterprise_id``; this is a cheap helper for the call sites that
     just want a yes/no before deciding whether to inject the MCP
-    server. Accepts an optional ``Settings`` so callers that already
-    have one don't pay the ``Settings.load()`` cost twice.
+    server.
+
+    IT WAS NOT CHEAP. The docstring used to end "accepts an optional
+    ``Settings`` so callers that already have one don't pay the
+    ``Settings.load()`` cost twice" — an accurate warning that the default
+    path then ignored. ``Settings.load()`` re-parses the whole pydantic-settings
+    model from ``.env`` on every call: MEASURED 2026-08-04 at 114.9 ms, and
+    11.9M Python function calls for five invocations.
+
+    ``build_behavior_instructions`` calls this with no argument on EVERY chat
+    turn, so that 115 ms WAS the entire cost of assembling the system prompt —
+    profiling it looking for slow string work turned up one config load and
+    essentially nothing else. ``get_settings()`` is the ``lru_cache``d
+    accessor and measures 0.000 ms.
+
+    An explicit ``settings`` still wins, so a caller holding a fresher snapshot
+    is unaffected. Anything needing to observe a just-written config change
+    wants ``get_settings(force_reload=True)``, not a bare ``load()``.
     """
-    s = settings or Settings.load()
+    s = settings or get_settings()
     return bool(s.composio_api_key and s.composio_enterprise_id)
 
 
@@ -61,7 +77,7 @@ def composio_user_id(ctx: RequestContext, settings: Settings | None = None) -> C
     ``ComposioUserId`` value object so the tenancy invariants live
     in one place (domain), not scattered across f-strings.
     """
-    s = settings or Settings.load()
+    s = settings or get_settings()
     if not s.composio_enterprise_id:
         raise ValidationError(
             "composio.disabled",
@@ -84,7 +100,7 @@ async def _get_client(settings: Settings | None = None) -> object:
     if _client is not None:
         return _client
 
-    s = settings or Settings.load()
+    s = settings or get_settings()
     if not is_enabled(s):
         raise ValidationError(
             "composio.disabled",
@@ -130,7 +146,7 @@ async def list_available_toolkits(settings: Settings | None = None) -> list[str]
     integrations or an admin disables one upstream. Callers that
     want caching should wrap this themselves.
     """
-    s = settings or Settings.load()
+    s = settings or get_settings()
     client = await _get_client(s)
     try:
         toolkits = await asyncio.to_thread(_list_toolkits_sync, client)

--- a/tests/cloud/chat/test_kb_block_bounded.py
+++ b/tests/cloud/chat/test_kb_block_bounded.py
@@ -1,0 +1,205 @@
+# tests/cloud/chat/test_kb_block_bounded.py — the KB block cannot own the turn.
+# Created: 2026-08-04 (perf/prompt-assembly).
+#
+# WHY. ``_build_kb_snippets_block`` ran one ``kb`` subprocess per scope, in a
+# serial loop, with nothing bounding either. Both halves were measured on a live
+# local instance on 2026-08-04:
+#
+#   * SERIAL. Two scopes cost 50.2 ms even when BOTH were empty, because the
+#     floor is process spawn and the loop paid it twice in sequence.
+#   * UNBOUNDED. A workspace scope holding 4,051,312 words took 4.2 SECONDS per
+#     search, on every turn, on a message that was just "hello". Search time was
+#     flat across queries — "a" and a six-word question cost the same — which is
+#     a scan, not a lookup. kb-go has no index for a scope that size.
+#
+# So the turn inherited a multi-second stall from a subsystem it only wanted a
+# few hundred characters from. The timeout is a BACKSTOP for that defect, not a
+# fix: it converts "the chat hangs" into "this turn has no KB block", which is
+# the same outcome the code already produces for a scope with no hits.
+#
+# EACH TEST NAMES THE MUTATION THAT BREAKS IT, and every one was applied, run,
+# observed to fail, and reverted (``scripts/mutate.py``).
+
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import patch
+
+import pytest
+from pocketpaw_ee.cloud.chat import agent_service as A
+
+pytestmark = pytest.mark.asyncio
+
+
+def _ctx() -> A.ScopeContext:
+    return A.ScopeContext(
+        kind=A.ScopeKind.SESSION,
+        scope_id="s1",
+        workspace_id="ws1",
+        user_id="u1",
+        members=["u1"],
+        target_agent_id="a1",
+    )
+
+
+class TestTheBlockIsBounded:
+    async def test_a_slow_scope_is_dropped_not_waited_for(self) -> None:
+        """The 4.2-second scope, in test form.
+
+        THE MUTATION THAT BREAKS THIS: remove the ``asyncio.wait_for`` wrapper
+        in ``_build_kb_snippets_block``. Run: the call waited the full 5s and
+        the elapsed assertion failed. (Applied 2026-08-04.)
+        """
+
+        async def _glacial(scope, query, limit=3):
+            await asyncio.sleep(5)
+            return "never arrives"
+
+        with (
+            patch.object(A, "_kb_scopes_for_context", return_value=["workspace:ws1"]),
+            patch(
+                "pocketpaw_ee.cloud.agents.knowledge.KnowledgeService.search_context_for_scope",
+                new=_glacial,
+            ),
+        ):
+            t0 = time.perf_counter()
+            block = await A._build_kb_snippets_block(_ctx(), "hello")
+            elapsed = time.perf_counter() - t0
+
+        assert block == "", "a scope that never answered still contributed to the prompt"
+        assert elapsed < A._KB_SEARCH_TIMEOUT_SECONDS + 1.0, (
+            f"the turn waited {elapsed:.1f}s on a slow KB scope"
+        )
+
+    async def test_one_slow_scope_does_not_sink_a_healthy_one(self) -> None:
+        """Degrade per scope, not per block.
+
+        A shared workspace scope being unindexed must not cost the member their
+        own fast scope's hits. This is only true because the searches run
+        concurrently AND the timeout is applied per scope.
+
+        THE MUTATION THAT BREAKS THIS: move the ``wait_for`` outside the gather
+        so it bounds the whole block. Run: the healthy scope's snippet was lost
+        along with the slow one and the ``fast hit`` assertion failed.
+        """
+
+        async def _mixed(scope, query, limit=3):
+            if scope.startswith("workspace:"):
+                await asyncio.sleep(5)
+                return "never arrives"
+            return "fast hit"
+
+        with (
+            patch.object(A, "_kb_scopes_for_context", return_value=["user:u1", "workspace:ws1"]),
+            patch(
+                "pocketpaw_ee.cloud.agents.knowledge.KnowledgeService.search_context_for_scope",
+                new=_mixed,
+            ),
+        ):
+            block = await A._build_kb_snippets_block(_ctx(), "hello")
+
+        assert "fast hit" in block
+        assert "never arrives" not in block
+
+    async def test_the_timeout_is_a_backstop_not_a_budget(self) -> None:
+        """Guards the constant against being tuned down into a real limit.
+
+        A healthy scope answers in ~25 ms (process spawn). If this ever drops
+        near that, the cap stops being a backstop and starts silently trimming
+        working scopes.
+
+        THE MUTATION THAT BREAKS THIS: set ``_KB_SEARCH_TIMEOUT_SECONDS = 0.05``.
+        Run: below the 10x floor and this failed. (Applied 2026-08-04.)
+        """
+        assert A._KB_SEARCH_TIMEOUT_SECONDS >= 0.25, (
+            "a healthy scope costs ~25ms; a cap this tight would drop working scopes"
+        )
+
+
+class TestTheScopesRunConcurrently:
+    async def test_n_scopes_cost_the_slowest_not_the_sum(self) -> None:
+        """The serial loop this replaced.
+
+        Four scopes at 200 ms each: serial is 800 ms, concurrent is ~200 ms.
+        The margin is wide enough that this does not flake on a loaded machine.
+
+        THE MUTATION THAT BREAKS THIS: restore the ``for scope in scopes:``
+        serial await. Run: 800 ms elapsed and the assertion failed.
+        (Applied 2026-08-04.)
+        """
+        scopes = [f"pocket:p{i}" for i in range(4)]
+
+        async def _slowish(scope, query, limit=3):
+            await asyncio.sleep(0.2)
+            return f"hit for {scope}"
+
+        with (
+            patch.object(A, "_kb_scopes_for_context", return_value=scopes),
+            patch(
+                "pocketpaw_ee.cloud.agents.knowledge.KnowledgeService.search_context_for_scope",
+                new=_slowish,
+            ),
+        ):
+            t0 = time.perf_counter()
+            block = await A._build_kb_snippets_block(_ctx(), "hello")
+            elapsed = time.perf_counter() - t0
+
+        assert elapsed < 0.6, f"{len(scopes)} scopes took {elapsed:.2f}s — still serial?"
+        for scope in scopes:
+            assert scope in block
+
+    async def test_scope_order_survives_the_gather(self) -> None:
+        """The rendered block must be byte-identical to the serial version.
+
+        ``gather`` preserves input order, and the block is keyed by scope
+        headings, so a reordering would move prompt bytes and invalidate every
+        backend cache keyed on them for no reason.
+
+        THE MUTATION THAT BREAKS THIS: collect results with
+        ``asyncio.as_completed`` instead of ``gather``. Run: the ordering
+        assertion failed intermittently — which is exactly why it is asserted
+        rather than assumed. (Applied 2026-08-04.)
+        """
+        scopes = ["user:u1", "workspace:ws1", "pocket:p1"]
+
+        async def _by_scope(scope, query, limit=3):
+            # Reverse the natural completion order: the FIRST scope is slowest.
+            await asyncio.sleep(0.05 * (len(scopes) - scopes.index(scope)))
+            return f"hit {scope}"
+
+        with (
+            patch.object(A, "_kb_scopes_for_context", return_value=scopes),
+            patch(
+                "pocketpaw_ee.cloud.agents.knowledge.KnowledgeService.search_context_for_scope",
+                new=_by_scope,
+            ),
+        ):
+            block = await A._build_kb_snippets_block(_ctx(), "hello")
+
+        positions = [block.index(f"### {s}") for s in scopes]
+        assert positions == sorted(positions), f"scope order changed: {block}"
+
+    async def test_a_raising_scope_still_drops_only_itself(self) -> None:
+        """Pre-existing behaviour, preserved through the rewrite.
+
+        THE MUTATION THAT BREAKS THIS: drop the broad ``except`` in ``_one``.
+        Run: the exception propagated out of ``gather`` and the whole turn
+        raised instead of degrading. (Applied 2026-08-04.)
+        """
+
+        async def _one_bad(scope, query, limit=3):
+            if scope.startswith("workspace:"):
+                raise RuntimeError("kb exploded")
+            return "still here"
+
+        with (
+            patch.object(A, "_kb_scopes_for_context", return_value=["user:u1", "workspace:ws1"]),
+            patch(
+                "pocketpaw_ee.cloud.agents.knowledge.KnowledgeService.search_context_for_scope",
+                new=_one_bad,
+            ),
+        ):
+            block = await A._build_kb_snippets_block(_ctx(), "hello")
+
+        assert "still here" in block

--- a/tests/cloud/chat/test_prompt_assembly_cost.py
+++ b/tests/cloud/chat/test_prompt_assembly_cost.py
@@ -1,0 +1,150 @@
+# tests/cloud/chat/test_prompt_assembly_cost.py — the system prompt is not
+# allowed to re-parse the config.
+# Created: 2026-08-04 (perf/prompt-assembly).
+#
+# WHAT THIS CAUGHT. ``build_behavior_instructions`` measured 120.9 ms per chat
+# turn and produced 36,608 chars, so it looked like slow string assembly.
+# Profiling said otherwise — 11.9 MILLION Python function calls for five
+# invocations, essentially all of them under one line:
+#
+#     build_behavior_instructions
+#       -> composio.service.is_enabled()          (no settings argument)
+#         -> Settings.load()                      114.9 ms, measured
+#           -> pydantic_settings re-parses the whole model from .env
+#
+# One uncached config read WAS the entire cost. ``get_settings()`` is the
+# ``lru_cache``d accessor and measures 0.000 ms; after the swap the same call
+# is 0.0 ms warm.
+#
+# The irony is that ``is_enabled``'s own docstring warned about it — "accepts an
+# optional ``Settings`` so callers that already have one don't pay the
+# ``Settings.load()`` cost twice" — while its default path did exactly that.
+#
+# WHY THIS TEST IS NOT A TIMER. A "must run in under N ms" assertion flakes on a
+# loaded CI box and tells you nothing about why. The real invariant is
+# structural: assembling a prompt must not re-parse the config. That is exact,
+# fast, and names the defect when it fails.
+#
+# EACH TEST NAMES THE MUTATION THAT BREAKS IT, and every one was applied, run,
+# observed to fail, and reverted (``scripts/mutate.py``).
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from pocketpaw_ee.cloud.chat import agent_service as A
+
+from pocketpaw.config import Settings, get_settings
+
+
+def _ctx() -> A.ScopeContext:
+    return A.ScopeContext(
+        kind=A.ScopeKind.SESSION,
+        scope_id="s1",
+        workspace_id="ws1",
+        user_id="u1",
+        members=["u1"],
+        target_agent_id="a1",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _warm_settings_cache():
+    """Prime the cache so a legitimate first-ever read is not miscounted.
+
+    The invariant under test is "assembly does not re-parse", not "nothing ever
+    parses". Without this the very first ``get_settings()`` in the process would
+    itself call ``Settings.load()`` and the spy could not tell the two apart.
+    """
+    get_settings()
+    yield
+
+
+class TestAssemblyDoesNotReparseConfig:
+    def test_building_instructions_never_calls_settings_load(self) -> None:
+        """The regression guard, stated structurally rather than as a stopwatch.
+
+        THE MUTATION THAT BREAKS THIS: restore ``s = settings or
+        Settings.load()`` in ``composio.service.is_enabled``. Run: the spy
+        recorded one call and this failed. (Applied 2026-08-04.)
+        """
+        calls: list[int] = []
+        real = Settings.load
+
+        def _spy(*a, **k):
+            calls.append(1)
+            return real(*a, **k)
+
+        with patch.object(Settings, "load", _spy):
+            out = A.build_behavior_instructions(_ctx(), backend_name="pydantic_ai")
+
+        assert out, "assembly produced nothing — the test is measuring the wrong thing"
+        assert not calls, (
+            f"assembling the system prompt re-parsed the config {len(calls)}x. "
+            "Settings.load() costs ~115ms a call; use get_settings()."
+        )
+
+    def test_is_enabled_does_not_reparse_either(self) -> None:
+        """The specific offender, pinned on its own.
+
+        The test above would also fail if some OTHER call site regressed, which
+        makes it a good gate and a poor diagnosis. This one names the function.
+
+        THE MUTATION THAT BREAKS THIS: same as above. Run: one call recorded.
+        (Applied 2026-08-04.)
+        """
+        from pocketpaw_ee.cloud.composio import service as composio_service
+
+        calls: list[int] = []
+        real = Settings.load
+
+        def _spy(*a, **k):
+            calls.append(1)
+            return real(*a, **k)
+
+        with patch.object(Settings, "load", _spy):
+            composio_service.is_enabled()
+
+        assert not calls, "composio.is_enabled() re-parsed the whole config"
+
+    def test_an_explicit_settings_argument_still_wins(self) -> None:
+        """Callers holding a fresher snapshot must not be overridden by the cache.
+
+        This is the property that makes the swap safe: nothing that already had
+        a ``Settings`` changed behaviour, so a caller mid-config-write still
+        reads what it passed.
+
+        THE MUTATION THAT BREAKS THIS: ignore the argument and always use
+        ``get_settings()``. Run: the explicitly-disabled settings reported
+        enabled and this failed. (Applied 2026-08-04.)
+        """
+        from pocketpaw_ee.cloud.composio import service as composio_service
+
+        enabled = Settings(composio_api_key="k", composio_enterprise_id="e")
+        disabled = Settings(composio_api_key=None, composio_enterprise_id=None)
+
+        assert composio_service.is_enabled(enabled) is True
+        assert composio_service.is_enabled(disabled) is False
+
+    def test_a_config_write_is_still_observable(self) -> None:
+        """Caching must not make a config change invisible.
+
+        Every config-write path in this codebase already calls
+        ``get_settings.cache_clear()`` (api/v1/settings.py, budget.py,
+        memory.py, bus/commands.py, dashboard.py), so the invalidation contract
+        predates this change. This asserts the half that matters here: after a
+        clear, the next read reflects reality.
+
+        THE MUTATION THAT BREAKS THIS: make ``get_settings`` ignore
+        ``cache_clear`` (wrap it in a module-level singleton instead). Run: the
+        stale value survived the clear and this failed. (Applied 2026-08-04.)
+        """
+        first = get_settings()
+        get_settings.cache_clear()
+        second = get_settings()
+
+        assert first is not second, (
+            "get_settings() returned the same object after cache_clear() — a "
+            "config write would be invisible to every reader"
+        )

--- a/tests/cloud/composio/conftest.py
+++ b/tests/cloud/composio/conftest.py
@@ -1,0 +1,23 @@
+import pytest
+
+from pocketpaw.config import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _isolate_settings_cache():
+    """Give every test a clean ``get_settings()`` cache.
+
+    ``composio.service`` reads config through the ``lru_cache``d accessor
+    rather than ``Settings.load()`` — the latter re-parses the whole
+    pydantic-settings model at ~115 ms a call, which made it the single
+    largest cost in assembling a chat turn (measured 2026-08-04).
+
+    The cache is process-global, so without this a test that sets
+    ``composio_api_key`` leaks that value into every test that runs after it.
+    These tests previously got isolation for free from ``Settings.load()``'s
+    freshness; they now ask for it explicitly. Production invalidates the same
+    way — every config-write path already calls ``get_settings.cache_clear()``.
+    """
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()

--- a/tests/mutations/prompt_latency.json
+++ b/tests/mutations/prompt_latency.json
@@ -1,0 +1,47 @@
+[
+  {
+    "label": "perf: is_enabled goes back to the uncached Settings.load()",
+    "file": "ee/pocketpaw_ee/cloud/composio/service.py",
+    "find": "    s = settings or get_settings()\n    return bool(s.composio_api_key and s.composio_enterprise_id)",
+    "replace": "    s = settings or Settings.load()\n    return bool(s.composio_api_key and s.composio_enterprise_id)",
+    "tests": [
+      "tests/cloud/chat/test_prompt_assembly_cost.py"
+    ]
+  },
+  {
+    "label": "perf: the KB timeout is removed",
+    "file": "ee/pocketpaw_ee/cloud/chat/agent_service.py",
+    "find": "            text = await asyncio.wait_for(\n                KnowledgeService.search_context_for_scope(scope, query, limit=3),\n                timeout=_KB_SEARCH_TIMEOUT_SECONDS,\n            )",
+    "replace": "            text = await KnowledgeService.search_context_for_scope(scope, query, limit=3)",
+    "tests": [
+      "tests/cloud/chat/test_kb_block_bounded.py"
+    ]
+  },
+  {
+    "label": "perf: the KB timeout is tuned down to a real budget",
+    "file": "ee/pocketpaw_ee/cloud/chat/agent_service.py",
+    "find": "_KB_SEARCH_TIMEOUT_SECONDS = 1.5",
+    "replace": "_KB_SEARCH_TIMEOUT_SECONDS = 0.05",
+    "tests": [
+      "tests/cloud/chat/test_kb_block_bounded.py"
+    ]
+  },
+  {
+    "label": "perf: the KB scopes go back to a serial loop",
+    "file": "ee/pocketpaw_ee/cloud/chat/agent_service.py",
+    "find": "    results = await asyncio.gather(*(_one(s) for s in scopes))\n    snippets: list[tuple[str, str]] = [r for r in results if r is not None]",
+    "replace": "    snippets: list[tuple[str, str]] = [r for r in [await _one(s) for s in scopes] if r is not None]",
+    "tests": [
+      "tests/cloud/chat/test_kb_block_bounded.py"
+    ]
+  },
+  {
+    "label": "perf: a raising scope sinks the whole block",
+    "file": "ee/pocketpaw_ee/cloud/chat/agent_service.py",
+    "find": "        except Exception:\n            logger.warning(\"knowledge search failed for scope %s\", scope, exc_info=True)\n            return None",
+    "replace": "        except TypeError:\n            logger.warning(\"knowledge search failed for scope %s\", scope, exc_info=True)\n            return None",
+    "tests": [
+      "tests/cloud/chat/test_kb_block_bounded.py"
+    ]
+  }
+]


### PR DESCRIPTION
Stacked on #1857. Merge that first.

Chasing "why is `hello` slow", measured on a live local instance rather than reasoned about.

## `build_behavior_instructions`: 120.9 ms → 0.0 ms

It builds 36,608 chars a turn, so it looked like slow string assembly. Profiling said otherwise — **11.9 million Python function calls for five invocations**, almost all under one line:

```
build_behavior_instructions
  └ composio.service.is_enabled()      ← called with no settings
     └ Settings.load()                 114.9 ms, measured
        └ pydantic_settings re-parses the whole model from .env
```

One uncached config read **was** the entire cost of assembling the system prompt. `get_settings()` is the `lru_cache`d accessor and measures 0.000 ms.

The irony: `is_enabled`'s own docstring warned about it — *"accepts an optional `Settings` so callers that already have one don't pay the `Settings.load()` cost twice"* — while its default path did exactly that. Fixed there, in composio's other read-only helpers, and at the two `Settings.load()` calls on the per-run path in `run_core`.

**Why this is safe.** The invalidation contract already exists — every config-write path calls `get_settings.cache_clear()` (`api/v1/settings`, `budget`, `memory`, `bus/commands`, `dashboard`). An explicit `settings` argument still wins, so nothing that already passed one changed behaviour.

The composio tests had been getting isolation for free from `Settings.load()`'s freshness; they now ask for it explicitly via a conftest. They passed individually and failed together, which is how it surfaced.

## KB snippets: 50.2 ms → 18.5 ms, and no longer unbounded

The per-scope searches ran in a **serial loop**, each one a `kb` subprocess. Two *empty* scopes still cost 50.2 ms, because the floor is process spawn and the loop paid it twice in sequence. Now gathered, order preserved, so the rendered block is byte-identical.

They were also unbounded, which matters more: a workspace scope holding **4,051,312 words took 4.2 seconds per search**, every turn, on a message that was just "hello". Time was flat across queries — `"a"` and a six-word question cost the same — so it's a scan, not a lookup.

That index is being fixed in kb-go by someone else. **The cap stays either way**, because it bounds *any* slow scope (huge corpus, wedged binary, stalled mount), not just that one cause, and it degrades to "no KB block" — exactly what an empty scope already produces.

## Net

| | before | after |
|---|---|---|
| cloud-side prompt assembly, warm | 173.3 ms | **24.1 ms** |

## What's deliberately not in here

The backend half is already fine warm — 17 ms from `run()` to the first byte at LiteLLM. But a **cold process costs 3193 ms**: `build_mcp_tools` 1223 ms, `build_model` 876 ms. A new agent instance in a warm process is ~330 ms. Prewarming those at startup is the obvious next move and is a separate change.

## Tests

Structural invariants, not stopwatches. "Assembling a prompt must not re-parse the config" is exact and names the defect when it fails; an "under N ms" assertion flakes on CI and explains nothing. The one timing assertion that does exist (serial vs concurrent) has a 4x margin.

10 new tests. 5 mutations in `tests/mutations/prompt_latency.json`, all caught — including reverting `is_enabled` to `Settings.load()`, removing the timeout, tuning the timeout down into a real budget, and restoring the serial loop.

`tests/cloud/chat/` + `tests/cloud/composio/`: 204 passed, 0 failed.