### PR TITLE
fix(kb): compile via agent backend, reject uncompiled ingests, guard chat search

### DIFF
--- a/Dockerfile.enterprise
+++ b/Dockerfile.enterprise
@@ -77,7 +77,7 @@
 # `go install` on the host. Pinned (not @latest) for reproducible builds; bump
 # KB_GO_VERSION to upgrade.
 FROM golang:1.25-bookworm AS kb
-ARG KB_GO_VERSION=v0.1.0
+ARG KB_GO_VERSION=v0.2.0
 # Produces /go/bin/kb-go; we expose it as `kb` (the name the resolver prefers).
 RUN go install github.com/qbtrix/kb-go@${KB_GO_VERSION} && \
     cp /go/bin/kb-go /usr/local/bin/kb

--- a/docs/concepts/concierge-knowledge.mdx
+++ b/docs/concepts/concierge-knowledge.mdx
@@ -87,6 +87,17 @@ to the kb binary. If compilation fails on either path, the ingest **fails loudly
 — the document is never stored verbatim, because uncompiled raw text poisons the
 scope and makes every chat turn pay full-corpus search cost for junk snippets.
 
+Two bounds on the agent-backend path are worth knowing:
+
+- **The compiler sees at most the first 80,000 characters** of a document. The
+  full raw text is still stored alongside the article, but for a very large
+  document the compiled article reflects that first slice only.
+- **The compression sanity check applies to documents over 4,000 characters.**
+  A compiled article for a large document must be meaningfully shorter than the
+  input the compiler saw, or it is rejected as a verbatim echo. Short documents
+  are exempt — an article about a two-paragraph note can legitimately be about
+  as long as the note itself.
+
 ### When it runs
 
 - **On publish.** The site's content just changed, so what the concierge can quote

--- a/docs/concepts/concierge-knowledge.mdx
+++ b/docs/concepts/concierge-knowledge.mdx
@@ -76,6 +76,17 @@ Pages that extract to almost nothing (an empty layout, a redirect stub) are skip
 rather than indexed, and a very large site is truncated rather than allowed to turn
 one publish into an unbounded run of article compilations.
 
+### Every article is LLM-compiled — never stored verbatim
+
+Ingest always compiles the extracted text into a structured article (title, summary,
+compressed wiki-style content) before it is stored. On deployments with an
+`ANTHROPIC_API_KEY`, the kb binary runs that compilation itself. On deployments
+without one (for example the Claude Code agent-backend cloud box), PocketPaw
+compiles the article with its own agent backend and hands the pre-compiled article
+to the kb binary. If compilation fails on either path, the ingest **fails loudly**
+— the document is never stored verbatim, because uncompiled raw text poisons the
+scope and makes every chat turn pay full-corpus search cost for junk snippets.
+
 ### When it runs
 
 - **On publish.** The site's content just changed, so what the concierge can quote

--- a/ee/pocketpaw_ee/cloud/agents/knowledge.py
+++ b/ee/pocketpaw_ee/cloud/agents/knowledge.py
@@ -8,11 +8,18 @@
 #   absent and pipes the pre-compiled article to `kb ingest --article-json`;
 #   compile failure RAISES — never a verbatim fallback. (2) Any ingest result
 #   with compiled_with == "none (fallback)" is rejected loudly (defense in
-#   depth against older binaries / --allow-fallback misuse). (3) The chat-turn
+#   depth against older binaries / --allow-fallback misuse). Note: the
+#   missing-compiled_with old-binary detector below applies ONLY to the
+#   --article-json path — the keyed plain-ingest path deliberately tolerates
+#   old-style output so a healthy keyed deployment on an old binary keeps
+#   working. (3) The chat-turn
 #   search path (search_context_for_scope) got a hard 5s timeout and fails
 #   soft (returns "") so a slow KB can never stall a chat turn; _kb translates
 #   subprocess timeouts into clear RuntimeErrors. ingest_file's text-file path
-#   now routes through ingest_text_to_scope so it gets the same guarantees.
+#   now routes through ingest_text_to_scope so it gets the same guarantees;
+#   code files keep their AST treatment via a --lang hint derived from the
+#   source filename (stdin has no path for kb-go's own detectLanguage), and
+#   the keyless compile prompt is steered to document code structure.
 #   Requires the kb-go binary with --article-json support. Old-binary
 #   detection (2026-08-04 follow-up): kb-go silently IGNORES unknown flags,
 #   so an old binary exits 0 after storing the payload verbatim — the
@@ -88,6 +95,25 @@ _MAX_COMPILED_RATIO = 0.6
 
 # kb-go's marker for "compile failed, stored verbatim". We never accept it.
 _FALLBACK_COMPILED_WITH = "none (fallback)"
+
+# Mirror of kb-go's detectLanguage: source-filename suffixes whose stdin
+# ingest should carry a ``--lang`` hint so kb-go runs its AST parse
+# (parseCode) on the text — the file PATH no longer reaches kb, so the
+# hint is the only way it learns the language. Values are the canonical
+# spellings kb-go's langToExt accepts.
+_CODE_LANG_BY_SUFFIX = {
+    ".go": "go",
+    ".py": "python",
+    ".ts": "typescript",
+    ".tsx": "typescript",
+    ".js": "javascript",
+    ".jsx": "javascript",
+}
+
+
+def _lang_for_source(source: str) -> str | None:
+    """Language hint for a source filename, or ``None`` for non-code docs."""
+    return _CODE_LANG_BY_SUFFIX.get(Path(source).suffix.lower())
 
 
 def _resolve_kb_bin() -> str:
@@ -279,21 +305,36 @@ def _validate_compiled_article(article: dict, *, compile_input_len: int, source:
     }
 
 
-async def _compile_article_with_agent(text: str, source: str) -> dict:
+async def _compile_article_with_agent(text: str, source: str, lang: str | None = None) -> dict:
     """Compile ``text`` into a kb article using PocketPaw's own agent backend.
 
     This is the no-ANTHROPIC_API_KEY path: kb's internal LLM compile cannot
     run, so we produce the article with the same backend infrastructure the
     chat runtime uses (``PocketPawCompilerBackend`` → agent registry → the
     active backend, e.g. the Claude Code SDK backend which authenticates via
-    the CLI, not the API key). Raises ``RuntimeError`` on any failure —
-    callers must NEVER fall back to verbatim ingestion.
+    the CLI, not the API key).
+
+    ``lang`` (when the source is a recognized code file) steers the article
+    toward documenting code structure instead of prose-summarizing — the
+    keyless stand-in for the AST parse kb-go runs on the keyed path.
+
+    Failures raise: compile timeouts and invalid/garbage articles are
+    translated to ``RuntimeError``; backend-level errors (an unavailable
+    backend, a failing completion) propagate as raised. Either way callers
+    must NEVER fall back to verbatim ingestion.
     """
     from pocketpaw.config import get_settings
     from pocketpaw_ee.cloud.kb.backend_adapter import PocketPawCompilerBackend
 
     excerpt = text[:_COMPILE_INPUT_CAP_CHARS]
     truncated = len(text) > len(excerpt)
+    code_rule = (
+        f"- The document is {lang} source code: in the content, document its "
+        "structure — the module's purpose, key functions and classes with their "
+        "signatures, and exports — rather than summarizing it as prose.\n"
+        if lang
+        else ""
+    )
     prompt = (
         "Compile the document below into a knowledge-base article. Respond with "
         "ONLY one JSON object, no prose and no markdown fences:\n"
@@ -305,7 +346,8 @@ async def _compile_article_with_agent(text: str, source: str) -> dict:
         "- content: a well-structured wiki-style article (markdown headings and "
         "lists) that COMPRESSES the document — capture the facts, structure, "
         "names, and numbers; do NOT reproduce the document verbatim.\n"
-        "- concepts: 3-10 key concepts.\n"
+        + code_rule
+        + "- concepts: 3-10 key concepts.\n"
         "- categories: 1-3 broad categories.\n\n"
         f"Source: {source}\n"
         + ("(Document truncated for compilation; compress what you see.)\n" if truncated else "")
@@ -367,13 +409,17 @@ class KnowledgeService:
         fallback — an uncompiled article poisons the scope and makes every
         chat turn pay O(raw corpus) search cost for junk snippets.
         """
+        lang = _lang_for_source(source)
         if os.environ.get("ANTHROPIC_API_KEY"):
-            result = await asyncio.to_thread(
-                _kb, "ingest", "--scope", scope, "--source", source, input_text=text
-            )
+            args = ["ingest", "--scope", scope, "--source", source]
+            if lang:
+                # Stdin carries no file path, so kb-go can't detect the
+                # language itself — the hint re-enables its AST parse.
+                args += ["--lang", lang]
+            result = await asyncio.to_thread(_kb, *args, input_text=text)
             return _check_ingest_result(result, scope)
 
-        article = await _compile_article_with_agent(text, source)
+        article = await _compile_article_with_agent(text, source, lang=lang)
         payload = json.dumps({"raw_text": text, "article": article})
         try:
             result = await asyncio.to_thread(

--- a/ee/pocketpaw_ee/cloud/agents/knowledge.py
+++ b/ee/pocketpaw_ee/cloud/agents/knowledge.py
@@ -1,4 +1,20 @@
 # knowledge.py — Agent knowledge service via the kb-go binary.
+# Updated: 2026-08-04 — Ingest hardening (silent-poisoning fix). On boxes with
+#   no ANTHROPIC_API_KEY (the Claude Code agent backend deployment), kb's own
+#   LLM compile used to fail and kb silently stored every doc VERBATIM — a
+#   54-article / 4M-word scope that every chat turn then paid to search.
+#   Three changes: (1) ingest_text_to_scope now compiles the article with
+#   PocketPaw's own agent backend (PocketPawCompilerBackend) when the key is
+#   absent and pipes the pre-compiled article to `kb ingest --article-json`;
+#   compile failure RAISES — never a verbatim fallback. (2) Any ingest result
+#   with compiled_with == "none (fallback)" is rejected loudly (defense in
+#   depth against older binaries / --allow-fallback misuse). (3) The chat-turn
+#   search path (search_context_for_scope) got a hard 5s timeout and fails
+#   soft (returns "") so a slow KB can never stall a chat turn; _kb translates
+#   subprocess timeouts into clear RuntimeErrors. ingest_file's text-file path
+#   now routes through ingest_text_to_scope so it gets the same guarantees.
+#   Requires the kb-go binary with --article-json support; an older binary
+#   errors loudly with an upgrade hint instead of poisoning the scope.
 # Updated: 2026-07-30 — Paw Bar reply sources. Added the scope-form read pair
 #   search_articles_for_scope / list_articles_for_scope (raw {id, title, summary}
 #   hit dicts, mirroring ingest_text_to_scope's "caller owns the scope shape"
@@ -39,9 +55,35 @@ import mimetypes
 import os
 import shutil
 import subprocess
+import time
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+# The chat turn budget: a KB search that takes longer than this gets killed
+# and the turn proceeds without a KB block. See search_context_for_scope.
+SEARCH_CONTEXT_TIMEOUT_S = 5
+
+# `kb ingest --article-json` does no LLM work (the article arrives
+# pre-compiled), so a minute is generous.
+_ARTICLE_JSON_INGEST_TIMEOUT_S = 60
+
+# Ceiling for the agent-backend compile call. Compilation is one completion
+# over a capped excerpt, but the backend may cold-start a CLI process.
+_AGENT_COMPILE_TIMEOUT_S = 300
+
+# The compiler only sees this much of the raw text. The FULL raw text is
+# still stored by kb (raw_text in the --article-json payload) — the cap only
+# bounds the LLM prompt.
+_COMPILE_INPUT_CAP_CHARS = 80_000
+
+# Above this size, a compiled article must be meaningfully shorter than the
+# text the compiler saw, or we treat it as a verbatim echo and reject it.
+_LARGE_DOC_CHARS = 4_000
+_MAX_COMPILED_RATIO = 0.6
+
+# kb-go's marker for "compile failed, stored verbatim". We never accept it.
+_FALLBACK_COMPILED_WITH = "none (fallback)"
 
 
 def _resolve_kb_bin() -> str:
@@ -99,6 +141,9 @@ def _kb(*args: str, input_text: str | None = None, timeout: int = 120) -> dict |
             "or set POCKETPAW_KB_BIN to the binary path (e.g. /path/to/kb-go/kb), "
             "or place the workspace-local checkout at <paw-workspace>/kb-go/kb."
         )
+    except subprocess.TimeoutExpired:
+        logger.warning("kb timed out after %ds: %s", timeout, " ".join(cmd[:4]))
+        raise RuntimeError(f"kb timed out after {timeout}s: {' '.join(cmd[:4])}")
     if result.returncode != 0:
         logger.warning("kb failed (exit %d): %s", result.returncode, result.stderr[:200])
         raise RuntimeError(f"kb failed: {result.stderr[:200]}")
@@ -106,6 +151,154 @@ def _kb(*args: str, input_text: str | None = None, timeout: int = 120) -> dict |
         return json.loads(result.stdout)
     except json.JSONDecodeError:
         return result.stdout.strip()
+
+
+def _check_ingest_result(result: dict | list | str, scope: str) -> dict | list | str:
+    """Reject verbatim-fallback articles (defense in depth).
+
+    kb-go marks an article it stored WITHOUT LLM compilation as
+    ``compiled_with == "none (fallback)"`` (older binaries did this silently
+    on compile failure; newer ones only with ``--allow-fallback``). A
+    verbatim article poisons the scope — search pays O(raw corpus) on every
+    chat turn for junk snippets — so any ingest that produced one is treated
+    as a failure, never a success.
+    """
+    if isinstance(result, dict) and result.get("compiled_with") == _FALLBACK_COMPILED_WITH:
+        article_id = result.get("id") or result.get("article_id") or result.get("article") or "?"
+        logger.warning(
+            "kb ingest stored a VERBATIM fallback article (scope=%s, article_id=%s); "
+            "rejecting — the scope may need a purge (kb delete %s --scope %s)",
+            scope,
+            article_id,
+            article_id,
+            scope,
+        )
+        raise RuntimeError(
+            f"kb ingest produced a verbatim fallback article (scope={scope}, "
+            f"article_id={article_id}); refusing to accept uncompiled content"
+        )
+    return result
+
+
+def _parse_article_json(raw: str) -> dict:
+    """Extract the article JSON object from an LLM response.
+
+    Tolerates markdown fences and stray prose around the object; raises
+    ``ValueError`` when no JSON object can be recovered.
+    """
+    text = (raw or "").strip()
+    if not text:
+        raise ValueError("empty compiler response")
+    candidates = [text]
+    if "```" in text:
+        # Take the first fenced block's body.
+        parts = text.split("```")
+        if len(parts) >= 3:
+            body = parts[1]
+            if body.startswith("json"):
+                body = body[4:]
+            candidates.append(body.strip())
+    start, end = text.find("{"), text.rfind("}")
+    if start != -1 and end > start:
+        candidates.append(text[start : end + 1])
+    for candidate in candidates:
+        try:
+            parsed = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict):
+            return parsed
+    raise ValueError(f"compiler response is not a JSON object: {text[:200]!r}")
+
+
+def _validate_compiled_article(article: dict, *, compile_input_len: int, source: str) -> dict:
+    """Normalize + sanity-check a backend-compiled article.
+
+    Raises ``ValueError`` on garbage: empty title/content, or (for large
+    docs) content that isn't meaningfully shorter than what the compiler
+    saw — that's a verbatim echo, exactly the poisoning we're preventing.
+    """
+    title = str(article.get("title") or "").strip()
+    content = str(article.get("content") or "").strip()
+    if not title or not content:
+        raise ValueError("compiled article is missing a title or content")
+    compiled_cap = compile_input_len * _MAX_COMPILED_RATIO
+    if compile_input_len > _LARGE_DOC_CHARS and len(content) > compiled_cap:
+        raise ValueError(
+            f"compiled article is not a compression: content is {len(content)} chars "
+            f"against a {compile_input_len}-char input (limit "
+            f"{_MAX_COMPILED_RATIO:.0%}) — looks like a verbatim echo"
+        )
+    summary = str(article.get("summary") or "").strip()
+    concepts = [str(c).strip() for c in article.get("concepts") or [] if str(c).strip()]
+    categories = [str(c).strip() for c in article.get("categories") or [] if str(c).strip()]
+    return {
+        "title": title,
+        "summary": summary,
+        "content": content,
+        "concepts": concepts,
+        "categories": categories,
+        "source": source,
+    }
+
+
+async def _compile_article_with_agent(text: str, source: str) -> dict:
+    """Compile ``text`` into a kb article using PocketPaw's own agent backend.
+
+    This is the no-ANTHROPIC_API_KEY path: kb's internal LLM compile cannot
+    run, so we produce the article with the same backend infrastructure the
+    chat runtime uses (``PocketPawCompilerBackend`` → agent registry → the
+    active backend, e.g. the Claude Code SDK backend which authenticates via
+    the CLI, not the API key). Raises ``RuntimeError`` on any failure —
+    callers must NEVER fall back to verbatim ingestion.
+    """
+    from pocketpaw.config import get_settings
+    from pocketpaw_ee.cloud.kb.backend_adapter import PocketPawCompilerBackend
+
+    excerpt = text[:_COMPILE_INPUT_CAP_CHARS]
+    truncated = len(text) > len(excerpt)
+    prompt = (
+        "Compile the document below into a knowledge-base article. Respond with "
+        "ONLY one JSON object, no prose and no markdown fences:\n"
+        '{"title": "...", "summary": "...", "content": "...", '
+        '"concepts": ["..."], "categories": ["..."]}\n\n'
+        "Rules:\n"
+        "- title: short and descriptive.\n"
+        "- summary: at most 2 sentences.\n"
+        "- content: a well-structured wiki-style article (markdown headings and "
+        "lists) that COMPRESSES the document — capture the facts, structure, "
+        "names, and numbers; do NOT reproduce the document verbatim.\n"
+        "- concepts: 3-10 key concepts.\n"
+        "- categories: 1-3 broad categories.\n\n"
+        f"Source: {source}\n"
+        + ("(Document truncated for compilation; compress what you see.)\n" if truncated else "")
+        + f'Document:\n"""\n{excerpt}\n"""'
+    )
+    backend = PocketPawCompilerBackend()
+    try:
+        raw = await asyncio.wait_for(
+            backend.complete(
+                prompt,
+                system_prompt=(
+                    "You are a knowledge-base article compiler. "
+                    "Output ONLY a single valid JSON object."
+                ),
+            ),
+            timeout=_AGENT_COMPILE_TIMEOUT_S,
+        )
+    except TimeoutError:
+        raise RuntimeError(
+            f"agent-backend article compile timed out after {_AGENT_COMPILE_TIMEOUT_S}s "
+            f"(source={source!r})"
+        )
+    try:
+        article = _validate_compiled_article(
+            _parse_article_json(raw), compile_input_len=len(excerpt), source=source
+        )
+    except ValueError as exc:
+        raise RuntimeError(f"agent-backend article compile failed for {source!r}: {exc}")
+    article["compiled_with"] = f"pocketpaw-agent:{get_settings().agent_backend}"
+    return article
 
 
 class KnowledgeService:
@@ -123,10 +316,48 @@ class KnowledgeService:
         ``scope`` is the literal scope string the kb binary understands
         (e.g. ``"workspace:w1"``, ``"agent:a1"``, ``"pocket:p1"``). No
         validation here — kb-go rejects unknown scope shapes itself.
+
+        Compilation strategy (2026-08-04 hardening):
+
+        * ``ANTHROPIC_API_KEY`` set → plain ``kb ingest``; kb compiles the
+          article with its own LLM call (fast, works, unchanged).
+        * No key (e.g. the Claude Code agent-backend deployment) → compile
+          the article with PocketPaw's OWN agent backend and hand kb the
+          pre-compiled article via ``kb ingest --article-json``. kb makes no
+          LLM call of its own on this path.
+
+        Either way, a compile failure RAISES. There is no verbatim
+        fallback — an uncompiled article poisons the scope and makes every
+        chat turn pay O(raw corpus) search cost for junk snippets.
         """
-        return await asyncio.to_thread(
-            _kb, "ingest", "--scope", scope, "--source", source, input_text=text
-        )
+        if os.environ.get("ANTHROPIC_API_KEY"):
+            result = await asyncio.to_thread(
+                _kb, "ingest", "--scope", scope, "--source", source, input_text=text
+            )
+            return _check_ingest_result(result, scope)
+
+        article = await _compile_article_with_agent(text, source)
+        payload = json.dumps({"raw_text": text, "article": article})
+        try:
+            result = await asyncio.to_thread(
+                _kb,
+                "ingest",
+                "--article-json",
+                "--scope",
+                scope,
+                input_text=payload,
+                timeout=_ARTICLE_JSON_INGEST_TIMEOUT_S,
+            )
+        except RuntimeError as exc:
+            msg = str(exc)
+            if "unknown flag" in msg or "flag provided but not defined" in msg:
+                raise RuntimeError(
+                    "kb binary does not support `ingest --article-json` — it predates "
+                    "the pre-compiled-article contract. Deploy the paired kb-go build "
+                    f"(binary: {KB_BIN}). Original error: {msg}"
+                ) from exc
+            raise
+        return _check_ingest_result(result, scope)
 
     @staticmethod
     async def ingest_text(agent_id: str, text: str, source: str = "manual") -> dict:
@@ -153,10 +384,11 @@ class KnowledgeService:
         if path.suffix.lower() in (".pdf", ".docx", ".doc", ".png", ".jpg", ".jpeg"):
             text = await _extract_file(file_path)
             return await KnowledgeService.ingest_text_to_scope(f"agent:{agent_id}", text, label)
-        # Text/code files go directly to kb (without intermediate extraction)
-        return await asyncio.to_thread(
-            _kb, "ingest", file_path, "--scope", f"agent:{agent_id}", "--source", label
-        )
+        # Text/code files: read in Python and route through the common ingest
+        # path so they get the same compile guarantees (agent-backend compile
+        # without an API key, verbatim-fallback rejection) as every other doc.
+        text = await asyncio.to_thread(path.read_text, encoding="utf-8", errors="replace")
+        return await KnowledgeService.ingest_text_to_scope(f"agent:{agent_id}", text, label)
 
     @staticmethod
     async def list_articles(agent_id: str) -> list[dict]:
@@ -247,22 +479,47 @@ class KnowledgeService:
         )
 
     @staticmethod
-    async def search_context_for_scope(scope: str, query: str, limit: int = 3) -> str:
+    async def search_context_for_scope(
+        scope: str,
+        query: str,
+        limit: int = 3,
+        *,
+        timeout: int = SEARCH_CONTEXT_TIMEOUT_S,
+    ) -> str:
         """Get formatted knowledge context for any kb-go scope.
 
         Runs ``_kb`` in a thread so the event loop isn't blocked by the
         subprocess call. See S2 in the code review for context.
+
+        This is the chat-turn path (``_build_kb_snippets_block`` calls it on
+        EVERY turn), so it is fail-soft with a hard timeout: on timeout or
+        any subprocess failure it logs a warning and returns ``""`` — the
+        caller simply skips the KB block. A slow or broken KB must never
+        stall a chat turn.
         """
-        result = await asyncio.to_thread(
-            _kb,
-            "search",
-            query,
-            "--scope",
-            scope,
-            "--limit",
-            str(limit),
-            "--context",
-        )
+        start = time.monotonic()
+        try:
+            result = await asyncio.to_thread(
+                _kb,
+                "search",
+                query,
+                "--scope",
+                scope,
+                "--limit",
+                str(limit),
+                "--context",
+                timeout=timeout,
+            )
+        except Exception:
+            logger.warning(
+                "kb search for chat context failed (scope=%s, elapsed=%.1fs, "
+                "timeout=%ds); returning empty context",
+                scope,
+                time.monotonic() - start,
+                timeout,
+                exc_info=True,
+            )
+            return ""
         return result if isinstance(result, str) else ""
 
     @staticmethod

--- a/ee/pocketpaw_ee/cloud/agents/knowledge.py
+++ b/ee/pocketpaw_ee/cloud/agents/knowledge.py
@@ -13,8 +13,12 @@
 #   soft (returns "") so a slow KB can never stall a chat turn; _kb translates
 #   subprocess timeouts into clear RuntimeErrors. ingest_file's text-file path
 #   now routes through ingest_text_to_scope so it gets the same guarantees.
-#   Requires the kb-go binary with --article-json support; an older binary
-#   errors loudly with an upgrade hint instead of poisoning the scope.
+#   Requires the kb-go binary with --article-json support. Old-binary
+#   detection (2026-08-04 follow-up): kb-go silently IGNORES unknown flags,
+#   so an old binary exits 0 after storing the payload verbatim — the
+#   version-proof signal is the MISSING compiled_with key in the result
+#   (the paired binary always emits it); on that path we raise with an
+#   upgrade hint and name the article for purging.
 # Updated: 2026-07-30 — Paw Bar reply sources. Added the scope-form read pair
 #   search_articles_for_scope / list_articles_for_scope (raw {id, title, summary}
 #   hit dicts, mirroring ingest_text_to_scope's "caller owns the scope shape"
@@ -153,7 +157,9 @@ def _kb(*args: str, input_text: str | None = None, timeout: int = 120) -> dict |
         return result.stdout.strip()
 
 
-def _check_ingest_result(result: dict | list | str, scope: str) -> dict | list | str:
+def _check_ingest_result(
+    result: dict | list | str, scope: str, *, require_compiled_with: bool = False
+) -> dict | list | str:
     """Reject verbatim-fallback articles (defense in depth).
 
     kb-go marks an article it stored WITHOUT LLM compilation as
@@ -162,6 +168,16 @@ def _check_ingest_result(result: dict | list | str, scope: str) -> dict | list |
     verbatim article poisons the scope — search pays O(raw corpus) on every
     chat turn for junk snippets — so any ingest that produced one is treated
     as a failure, never a success.
+
+    ``require_compiled_with`` is the old-binary detector for the
+    ``--article-json`` path. kb-go parses flags by hand and silently IGNORES
+    unknown flags — an old binary never errors on ``--article-json``; it
+    reads the ``{"raw_text": ..., "article": ...}`` payload from stdin as
+    raw text, stores the JSON wrapper verbatim via its keyless fallback, and
+    exits 0 with old-style output that predates the ``compiled_with`` field.
+    So on that path a MISSING ``compiled_with`` key IS the old-binary signal
+    (the paired binary always emits it), and the poison has already landed —
+    the error names the article so an operator can purge it.
     """
     if isinstance(result, dict) and result.get("compiled_with") == _FALLBACK_COMPILED_WITH:
         article_id = result.get("id") or result.get("article_id") or result.get("article") or "?"
@@ -176,6 +192,27 @@ def _check_ingest_result(result: dict | list | str, scope: str) -> dict | list |
         raise RuntimeError(
             f"kb ingest produced a verbatim fallback article (scope={scope}, "
             f"article_id={article_id}); refusing to accept uncompiled content"
+        )
+    if require_compiled_with and (not isinstance(result, dict) or "compiled_with" not in result):
+        article_id = "?"
+        if isinstance(result, dict):
+            article_id = (
+                result.get("id") or result.get("article_id") or result.get("article") or "?"
+            )
+        logger.warning(
+            "kb ingest --article-json returned no compiled_with (scope=%s, article_id=%s): "
+            "the kb binary silently ignored the flag and stored the payload VERBATIM. "
+            "Purge the article (kb delete %s --scope %s) and deploy the paired kb-go build.",
+            scope,
+            article_id,
+            article_id,
+            scope,
+        )
+        raise RuntimeError(
+            f"kb binary does not support `ingest --article-json` — it silently ignored "
+            f"the flag and stored the payload verbatim (scope={scope}, "
+            f"article_id={article_id}). Deploy the paired kb-go build (binary: {KB_BIN}) "
+            f"and purge the article (kb delete {article_id} --scope {scope})."
         )
     return result
 
@@ -349,6 +386,10 @@ class KnowledgeService:
                 timeout=_ARTICLE_JSON_INGEST_TIMEOUT_S,
             )
         except RuntimeError as exc:
+            # Belt-and-braces only: current kb-go parses flags by hand and
+            # silently IGNORES unknown ones, so an old binary never produces
+            # a flag error. The PRIMARY old-binary detector is the missing
+            # ``compiled_with`` key below (require_compiled_with).
             msg = str(exc)
             if "unknown flag" in msg or "flag provided but not defined" in msg:
                 raise RuntimeError(
@@ -357,7 +398,10 @@ class KnowledgeService:
                     f"(binary: {KB_BIN}). Original error: {msg}"
                 ) from exc
             raise
-        return _check_ingest_result(result, scope)
+        # The paired binary ALWAYS emits compiled_with on this path; a result
+        # without it means the flag was silently ignored (old binary) and the
+        # payload was stored verbatim — reject loudly, naming the article.
+        return _check_ingest_result(result, scope, require_compiled_with=True)
 
     @staticmethod
     async def ingest_text(agent_id: str, text: str, source: str = "manual") -> dict:

--- a/ee/pocketpaw_ee/cloud/kb/backend_adapter.py
+++ b/ee/pocketpaw_ee/cloud/kb/backend_adapter.py
@@ -2,6 +2,10 @@
 # usable as a knowledge_base CompilerBackend.
 #
 # Created: 2026-04-06
+# Updated: 2026-08-04 — an unavailable backend now raises RuntimeError instead
+#   of returning "" (which surfaced downstream as a misleading "empty compiler
+#   response"). The ingest-hardening compile path treats any failure as fatal,
+#   so the error must say what actually went wrong.
 # This bridges the standalone knowledge-base package with PocketPaw's
 # agent registry, so KB compilation uses whatever LLM backend is active.
 
@@ -43,7 +47,10 @@ class PocketPawCompilerBackend:
         backend_cls = get_backend_class(backend_name)
         if not backend_cls:
             logger.warning("KB compiler backend '%s' not available", backend_name)
-            return ""
+            raise RuntimeError(
+                f"agent backend {backend_name!r} is not available for KB compilation "
+                "(not registered in the agent registry)"
+            )
 
         agent = backend_cls(settings)
         chunks: list[str] = []

--- a/ee/pocketpaw_ee/cloud/kb/router.py
+++ b/ee/pocketpaw_ee/cloud/kb/router.py
@@ -1,4 +1,13 @@
 # router.py — Knowledge base domain router for ee/cloud.
+# Updated: 2026-08-04 — Ingest hardening: the two ingest routes
+# (POST /kb/ingest/text, POST /kb/ingest/url) now route through
+# ``KnowledgeService.ingest_text_to_scope`` instead of calling ``_kb`` directly.
+# They were the last ingest paths outside the hardened funnel — direct ``_kb``
+# calls got no agent-backend compile on keyless boxes and no verbatim-fallback
+# rejection, re-opening the silent-poisoning hole the funnel closed. Routing
+# through the service also moves the subprocess call off the event loop
+# (``asyncio.to_thread`` inside the service) — the direct calls blocked the
+# async handler for the whole kb run.
 # Updated: 2026-06-08 (VIP Onboarding Phase B) — bound the client ``scope``
 # override to the caller. The four override-accepting endpoints (search,
 # ingest/text, ingest/url, lint) now resolve ``body.scope`` through
@@ -22,7 +31,7 @@ import logging
 
 from fastapi import APIRouter, Depends
 
-from pocketpaw_ee.cloud.agents.knowledge import _extract_url, _kb
+from pocketpaw_ee.cloud.agents.knowledge import KnowledgeService, _extract_url, _kb
 from pocketpaw_ee.cloud.kb import service as kb_service
 from pocketpaw_ee.cloud.kb.dto import (
     IngestTextRequest,
@@ -114,10 +123,16 @@ async def ingest_text(
     workspace_id: str = Depends(current_workspace_id),
     user_id: str = Depends(current_user_id),
 ) -> dict:
-    """Ingest plain text into the workspace knowledge base."""
+    """Ingest plain text into the workspace knowledge base.
+
+    Routes through :meth:`KnowledgeService.ingest_text_to_scope` — the
+    hardened funnel (agent-backend compile on keyless boxes, verbatim-
+    fallback rejection, subprocess off the event loop). Never call ``_kb``
+    for ingest directly.
+    """
     scope = await _resolve_scope(workspace_id, user_id, body.scope, action="kb.write")
     try:
-        return _kb("ingest", "--scope", scope, "--source", body.source, input_text=body.text)
+        return await KnowledgeService.ingest_text_to_scope(scope, body.text, body.source)
     except Exception as exc:
         logger.error("KB text ingest failed: %s", exc, exc_info=True)
         raise CloudError(500, "kb.ingest_failed", str(exc)) from exc
@@ -129,11 +144,15 @@ async def ingest_url(
     workspace_id: str = Depends(current_workspace_id),
     user_id: str = Depends(current_user_id),
 ) -> dict:
-    """Fetch and ingest a URL into the workspace knowledge base."""
+    """Fetch and ingest a URL into the workspace knowledge base.
+
+    Extraction stays here (trafilatura via ``_extract_url``); the ingest
+    itself goes through the hardened funnel like every other path.
+    """
     scope = await _resolve_scope(workspace_id, user_id, body.scope, action="kb.write")
     try:
         text = await _extract_url(body.url)
-        return _kb("ingest", "--scope", scope, "--source", body.url, input_text=text)
+        return await KnowledgeService.ingest_text_to_scope(scope, text, body.url)
     except Exception as exc:
         logger.error("KB URL ingest failed: %s", exc, exc_info=True)
         raise CloudError(500, "kb.ingest_failed", str(exc)) from exc

--- a/tests/cloud/agents/test_knowledge_ingest_hardening.py
+++ b/tests/cloud/agents/test_knowledge_ingest_hardening.py
@@ -222,6 +222,33 @@ async def test_fallback_marker_rejected_and_warned(monkeypatch, caplog):
 
 
 # --------------------------------------------------------------------------- #
+# ingest_file text-path reroute
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_ingest_file_text_path_routes_through_ingest_funnel(monkeypatch, tmp_path):
+    """Text/code files no longer hand kb a file path — they are read in Python
+    and piped through ingest_text_to_scope, so they get the same compile
+    guarantees as every other doc."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    spy = _install_spy(monkeypatch, [(0, json.dumps({"id": "art-f1", "compiled_with": "llm"}), "")])
+
+    notes = tmp_path / "notes.md"
+    notes.write_text("# Notes\n\nremember the thing", encoding="utf-8")
+
+    result = await KnowledgeService.ingest_file("a1", str(notes))
+
+    assert result["id"] == "art-f1"
+    cmd = spy.calls[0]["cmd"]
+    # Funnel argv (stdin ingest), NOT the old direct file-path form
+    # ["ingest", "<path>", "--scope", ...].
+    assert cmd[1:] == ["ingest", "--scope", "agent:a1", "--source", "notes.md", "--json"]
+    assert str(notes) not in cmd
+    assert spy.calls[0]["input"] == "# Notes\n\nremember the thing"
+
+
+# --------------------------------------------------------------------------- #
 # Chat-turn search guard
 # --------------------------------------------------------------------------- #
 

--- a/tests/cloud/agents/test_knowledge_ingest_hardening.py
+++ b/tests/cloud/agents/test_knowledge_ingest_hardening.py
@@ -120,7 +120,10 @@ async def test_no_key_compiles_with_agent_and_pipes_article_json(monkeypatch):
 async def test_no_key_tolerates_fenced_json(monkeypatch):
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     _install_compiler(monkeypatch, f"```json\n{json.dumps(_ARTICLE)}\n```")
-    spy = _install_spy(monkeypatch, [(0, json.dumps({"id": "art-2"}), "")])
+    spy = _install_spy(
+        monkeypatch,
+        [(0, json.dumps({"id": "art-2", "compiled_with": "pocketpaw-agent:claude_agent_sdk"}), "")],
+    )
 
     result = await KnowledgeService.ingest_text_to_scope("pocket:p1", "some text", source="s")
 
@@ -189,14 +192,25 @@ async def test_compile_verbatim_echo_of_large_doc_rejected(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_old_binary_without_article_json_fails_loudly(monkeypatch):
-    """An old kb binary rejects --article-json; the error must say so, not poison."""
+async def test_old_binary_silently_ignoring_article_json_fails_loudly(monkeypatch, caplog):
+    """Reality check (live-smoke confirmed): kb-go parses flags by hand and
+    silently IGNORES unknown flags. An old binary never errors on
+    --article-json — it stores the JSON payload verbatim via its keyless
+    fallback and exits 0 with old-style output that has NO compiled_with key.
+    The missing key is the version-proof old-binary signal and must raise
+    with an upgrade hint naming the already-stored article for purging."""
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     _install_compiler(monkeypatch, json.dumps(_ARTICLE))
-    _install_spy(monkeypatch, [(1, "", "flag provided but not defined: -article-json")])
+    # Old-style success output: exit 0, id present, compiled_with absent.
+    _install_spy(monkeypatch, [(0, json.dumps({"id": "art-old", "title": "raw"}), "")])
 
-    with pytest.raises(RuntimeError, match="does not support `ingest --article-json`"):
-        await KnowledgeService.ingest_text_to_scope("workspace:w1", "doc", source="a.md")
+    with caplog.at_level(logging.WARNING, logger="pocketpaw_ee.cloud.agents.knowledge"):
+        with pytest.raises(RuntimeError, match="does not support `ingest --article-json`"):
+            await KnowledgeService.ingest_text_to_scope("workspace:w1", "doc", source="a.md")
+
+    warning = "\n".join(r.getMessage() for r in caplog.records)
+    assert "workspace:w1" in warning
+    assert "art-old" in warning
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/cloud/agents/test_knowledge_ingest_hardening.py
+++ b/tests/cloud/agents/test_knowledge_ingest_hardening.py
@@ -256,10 +256,38 @@ async def test_ingest_file_text_path_routes_through_ingest_funnel(monkeypatch, t
     assert result["id"] == "art-f1"
     cmd = spy.calls[0]["cmd"]
     # Funnel argv (stdin ingest), NOT the old direct file-path form
-    # ["ingest", "<path>", "--scope", ...].
+    # ["ingest", "<path>", "--scope", ...]. Non-code file → no --lang hint.
     assert cmd[1:] == ["ingest", "--scope", "agent:a1", "--source", "notes.md", "--json"]
     assert str(notes) not in cmd
     assert spy.calls[0]["input"] == "# Notes\n\nremember the thing"
+
+
+@pytest.mark.asyncio
+async def test_ingest_file_code_path_passes_lang_hint(monkeypatch, tmp_path):
+    """Stdin carries no file path, so kb-go can't detect the language itself.
+    Code files must carry --lang so kb-go still runs its AST parse — the
+    structure awareness the old file-path form provided."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    spy = _install_spy(monkeypatch, [(0, json.dumps({"id": "art-f2", "compiled_with": "llm"}), "")])
+
+    module = tmp_path / "utils.py"
+    module.write_text("def add(a, b):\n    return a + b\n", encoding="utf-8")
+
+    result = await KnowledgeService.ingest_file("a1", str(module))
+
+    assert result["id"] == "art-f2"
+    cmd = spy.calls[0]["cmd"]
+    assert cmd[1:] == [
+        "ingest",
+        "--scope",
+        "agent:a1",
+        "--source",
+        "utils.py",
+        "--lang",
+        "python",
+        "--json",
+    ]
+    assert spy.calls[0]["input"] == "def add(a, b):\n    return a + b\n"
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/cloud/agents/test_knowledge_ingest_hardening.py
+++ b/tests/cloud/agents/test_knowledge_ingest_hardening.py
@@ -1,0 +1,251 @@
+# test_knowledge_ingest_hardening.py — ingest compile hardening tests.
+# Created: 2026-08-04 — silent-poisoning fix. On boxes without an
+# ANTHROPIC_API_KEY, kb's own LLM compile failed and kb silently stored docs
+# VERBATIM, poisoning the scope. These tests pin the new contract:
+#   * no key → article compiled via PocketPaw's agent backend and piped to
+#     `kb ingest --article-json` (spied at the subprocess boundary: exact
+#     argv + stdin payload — the seam under test is NOT mocked away);
+#   * key present → the original plain `kb ingest` path, byte-identical argv;
+#   * compile failure / garbage / verbatim echo → raises, NO kb call at all;
+#   * compiled_with == "none (fallback)" in any ingest result → rejected
+#     loudly, warning names the scope and article id;
+#   * chat-turn search (search_context_for_scope) fails soft: timeout or
+#     subprocess failure → "" plus a warning naming the scope.
+"""Ingest hardening: agent-backend compile, fallback rejection, search guard."""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+
+import pytest
+from pocketpaw_ee.cloud.agents import knowledge
+from pocketpaw_ee.cloud.agents.knowledge import KnowledgeService
+from pocketpaw_ee.cloud.kb import backend_adapter
+
+
+class _SubprocessSpy:
+    """Stand-in for ``subprocess.run`` that records exact argv + stdin.
+
+    The seam under test is the kb CLI contract, so the spy captures what
+    would hit the binary instead of mocking ``_kb`` away.
+    """
+
+    def __init__(self, responses: list) -> None:
+        self.calls: list[dict] = []
+        self._responses = list(responses)
+        self._real_run = subprocess.run
+
+    def __call__(self, cmd, input=None, timeout=None, **kwargs):  # noqa: A002
+        # Only intercept kb invocations — other code (e.g. the credentials
+        # store behind get_settings) may legitimately shell out mid-test.
+        if not cmd or cmd[0] != knowledge.KB_BIN:
+            return self._real_run(cmd, input=input, timeout=timeout, **kwargs)
+        self.calls.append({"cmd": list(cmd), "input": input, "timeout": timeout})
+        response = self._responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        returncode, stdout, stderr = response
+        return subprocess.CompletedProcess(cmd, returncode, stdout=stdout, stderr=stderr)
+
+
+def _install_spy(monkeypatch, responses: list) -> _SubprocessSpy:
+    spy = _SubprocessSpy(responses)
+    monkeypatch.setattr(knowledge.subprocess, "run", spy)
+    return spy
+
+
+def _install_compiler(monkeypatch, response: str) -> list[dict]:
+    """Fake only the LLM boundary (the backend completion), nothing else."""
+    calls: list[dict] = []
+
+    async def fake_complete(self, prompt: str, system_prompt: str = "") -> str:
+        calls.append({"prompt": prompt, "system_prompt": system_prompt})
+        return response
+
+    monkeypatch.setattr(backend_adapter.PocketPawCompilerBackend, "complete", fake_complete)
+    return calls
+
+
+_ARTICLE = {
+    "title": "Acme onboarding runbook",
+    "summary": "How new Acme hires get access. Covers accounts and hardware.",
+    "content": "# Onboarding\n\n- Accounts on day one\n- Hardware by day three",
+    "concepts": ["onboarding", "access", "hardware"],
+    "categories": ["operations"],
+}
+
+
+# --------------------------------------------------------------------------- #
+# Agent-backend compile path (no ANTHROPIC_API_KEY)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_no_key_compiles_with_agent_and_pipes_article_json(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    compiler_calls = _install_compiler(monkeypatch, json.dumps(_ARTICLE))
+    spy = _install_spy(
+        monkeypatch,
+        [(0, json.dumps({"id": "art-1", "compiled_with": "pocketpaw-agent:claude_agent_sdk"}), "")],
+    )
+
+    raw_text = "Acme onboarding: accounts on day one, hardware by day three."
+    result = await KnowledgeService.ingest_text_to_scope(
+        "workspace:w1", raw_text, source="runbook.md"
+    )
+
+    assert result["id"] == "art-1"
+    # Exactly one completion, exactly one kb call.
+    assert len(compiler_calls) == 1
+    assert raw_text in compiler_calls[0]["prompt"]
+    assert len(spy.calls) == 1
+    cmd = spy.calls[0]["cmd"]
+    assert cmd[0] == knowledge.KB_BIN
+    assert cmd[1:] == ["ingest", "--article-json", "--scope", "workspace:w1", "--json"]
+    payload = json.loads(spy.calls[0]["input"])
+    assert payload["raw_text"] == raw_text
+    article = payload["article"]
+    assert article["title"] == _ARTICLE["title"]
+    assert article["summary"] == _ARTICLE["summary"]
+    assert article["content"] == _ARTICLE["content"]
+    assert article["concepts"] == _ARTICLE["concepts"]
+    assert article["categories"] == _ARTICLE["categories"]
+    assert article["source"] == "runbook.md"
+    assert article["compiled_with"].startswith("pocketpaw-agent:")
+
+
+@pytest.mark.asyncio
+async def test_no_key_tolerates_fenced_json(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    _install_compiler(monkeypatch, f"```json\n{json.dumps(_ARTICLE)}\n```")
+    spy = _install_spy(monkeypatch, [(0, json.dumps({"id": "art-2"}), "")])
+
+    result = await KnowledgeService.ingest_text_to_scope("pocket:p1", "some text", source="s")
+
+    assert result["id"] == "art-2"
+    payload = json.loads(spy.calls[0]["input"])
+    assert payload["article"]["title"] == _ARTICLE["title"]
+
+
+@pytest.mark.asyncio
+async def test_api_key_keeps_plain_ingest_path(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    compiler_calls = _install_compiler(monkeypatch, json.dumps(_ARTICLE))
+    spy = _install_spy(monkeypatch, [(0, json.dumps({"id": "art-3", "compiled_with": "llm"}), "")])
+
+    result = await KnowledgeService.ingest_text_to_scope("workspace:w1", "doc text", source="a.md")
+
+    assert result["id"] == "art-3"
+    assert compiler_calls == []  # no agent-backend compile when kb can do it itself
+    cmd = spy.calls[0]["cmd"]
+    assert cmd[1:] == ["ingest", "--scope", "workspace:w1", "--source", "a.md", "--json"]
+    assert spy.calls[0]["input"] == "doc text"
+
+
+# --------------------------------------------------------------------------- #
+# Compile failure → raises, never a verbatim ingest
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_compile_garbage_raises_and_never_touches_kb(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    _install_compiler(monkeypatch, "I'm sorry, I can't compile this document.")
+    spy = _install_spy(monkeypatch, [])
+
+    with pytest.raises(RuntimeError, match="compile failed"):
+        await KnowledgeService.ingest_text_to_scope("workspace:w1", "doc", source="a.md")
+
+    assert spy.calls == []  # no verbatim ingest attempted
+
+
+@pytest.mark.asyncio
+async def test_compile_empty_fields_rejected(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    _install_compiler(monkeypatch, json.dumps({"title": "", "content": "", "summary": "x"}))
+    spy = _install_spy(monkeypatch, [])
+
+    with pytest.raises(RuntimeError, match="missing a title or content"):
+        await KnowledgeService.ingest_text_to_scope("workspace:w1", "doc", source="a.md")
+
+    assert spy.calls == []
+
+
+@pytest.mark.asyncio
+async def test_compile_verbatim_echo_of_large_doc_rejected(monkeypatch):
+    """A large doc whose 'compiled' content is as big as the input is an echo."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    big = "word " * 3000  # 15k chars, over the large-doc threshold
+    echo = dict(_ARTICLE, content=big)
+    _install_compiler(monkeypatch, json.dumps(echo))
+    spy = _install_spy(monkeypatch, [])
+
+    with pytest.raises(RuntimeError, match="verbatim echo"):
+        await KnowledgeService.ingest_text_to_scope("workspace:w1", big, source="big.md")
+
+    assert spy.calls == []
+
+
+@pytest.mark.asyncio
+async def test_old_binary_without_article_json_fails_loudly(monkeypatch):
+    """An old kb binary rejects --article-json; the error must say so, not poison."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    _install_compiler(monkeypatch, json.dumps(_ARTICLE))
+    _install_spy(monkeypatch, [(1, "", "flag provided but not defined: -article-json")])
+
+    with pytest.raises(RuntimeError, match="does not support `ingest --article-json`"):
+        await KnowledgeService.ingest_text_to_scope("workspace:w1", "doc", source="a.md")
+
+
+# --------------------------------------------------------------------------- #
+# Fallback-marker rejection (defense in depth)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_fallback_marker_rejected_and_warned(monkeypatch, caplog):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    _install_spy(
+        monkeypatch,
+        [(0, json.dumps({"id": "art-9", "compiled_with": "none (fallback)"}), "")],
+    )
+
+    with caplog.at_level(logging.WARNING, logger="pocketpaw_ee.cloud.agents.knowledge"):
+        with pytest.raises(RuntimeError, match="verbatim fallback"):
+            await KnowledgeService.ingest_text_to_scope("workspace:w1", "doc", source="a.md")
+
+    warning = "\n".join(r.getMessage() for r in caplog.records)
+    assert "workspace:w1" in warning
+    assert "art-9" in warning
+
+
+# --------------------------------------------------------------------------- #
+# Chat-turn search guard
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_search_context_timeout_returns_empty_and_warns(monkeypatch, caplog):
+    spy = _install_spy(monkeypatch, [subprocess.TimeoutExpired(cmd=["kb"], timeout=5)])
+
+    with caplog.at_level(logging.WARNING, logger="pocketpaw_ee.cloud.agents.knowledge"):
+        result = await KnowledgeService.search_context_for_scope("workspace:w1", "query")
+
+    assert result == ""
+    assert spy.calls[0]["timeout"] == knowledge.SEARCH_CONTEXT_TIMEOUT_S
+    warning = "\n".join(r.getMessage() for r in caplog.records)
+    assert "workspace:w1" in warning
+
+
+@pytest.mark.asyncio
+async def test_search_context_subprocess_failure_returns_empty(monkeypatch, caplog):
+    _install_spy(monkeypatch, [(2, "", "index corrupt")])
+
+    with caplog.at_level(logging.WARNING, logger="pocketpaw_ee.cloud.agents.knowledge"):
+        result = await KnowledgeService.search_context_for_scope("pocket:p1", "query")
+
+    assert result == ""
+    warning = "\n".join(r.getMessage() for r in caplog.records)
+    assert "pocket:p1" in warning

--- a/tests/cloud/kb/test_router_ingest_funnel.py
+++ b/tests/cloud/kb/test_router_ingest_funnel.py
@@ -18,11 +18,11 @@ import subprocess
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from pocketpaw_ee.cloud._core.errors import CloudError
 from pocketpaw_ee.cloud.agents import knowledge
 from pocketpaw_ee.cloud.kb import backend_adapter
 from pocketpaw_ee.cloud.kb import router as kb_router
 from pocketpaw_ee.cloud.kb.dto import IngestTextRequest, IngestUrlRequest
-from pocketpaw_ee.cloud.shared.errors import CloudError
 
 WORKSPACE = "w1"
 CALLER = "memberA"

--- a/tests/cloud/kb/test_router_ingest_funnel.py
+++ b/tests/cloud/kb/test_router_ingest_funnel.py
@@ -72,7 +72,9 @@ async def test_ingest_text_without_key_uses_article_json_funnel(monkeypatch):
     """Keyless box: the route must produce the pre-compiled --article-json call."""
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     _install_compiler(monkeypatch)
-    spy = _SubprocessSpy([(0, json.dumps({"id": "art-r1"}), "")])
+    spy = _SubprocessSpy(
+        [(0, json.dumps({"id": "art-r1", "compiled_with": "pocketpaw-agent:claude_agent_sdk"}), "")]
+    )
     monkeypatch.setattr(knowledge.subprocess, "run", spy)
 
     with _patch_candidates():
@@ -123,7 +125,9 @@ async def test_ingest_url_routes_through_funnel(monkeypatch):
     """The URL route extracts here but ingests through the funnel."""
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     _install_compiler(monkeypatch)
-    spy = _SubprocessSpy([(0, json.dumps({"id": "art-r3"}), "")])
+    spy = _SubprocessSpy(
+        [(0, json.dumps({"id": "art-r3", "compiled_with": "pocketpaw-agent:claude_agent_sdk"}), "")]
+    )
     monkeypatch.setattr(knowledge.subprocess, "run", spy)
 
     with (
@@ -142,6 +146,28 @@ async def test_ingest_url_routes_through_funnel(monkeypatch):
     payload = json.loads(spy.calls[0]["input"])
     assert payload["raw_text"] == "page text"
     assert payload["article"]["source"] == "https://example.test/page"
+
+
+@pytest.mark.asyncio
+async def test_ingest_text_old_binary_missing_compiled_with_maps_to_500(monkeypatch):
+    """Old binaries silently ignore --article-json and exit 0 without a
+    compiled_with key; the funnel's missing-key detector must surface at the
+    REST door as a 500 — inherited automatically, not re-implemented here."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    _install_compiler(monkeypatch)
+    spy = _SubprocessSpy([(0, json.dumps({"id": "art-old-r"}), "")])
+    monkeypatch.setattr(knowledge.subprocess, "run", spy)
+
+    with _patch_candidates():
+        with pytest.raises(CloudError) as exc:
+            await kb_router.ingest_text(
+                IngestTextRequest(text="doc", source="manual"),
+                workspace_id=WORKSPACE,
+                user_id=CALLER,
+            )
+
+    assert exc.value.code == "kb.ingest_failed"
+    assert "does not support `ingest --article-json`" in exc.value.message
 
 
 @pytest.mark.asyncio

--- a/tests/cloud/kb/test_router_ingest_funnel.py
+++ b/tests/cloud/kb/test_router_ingest_funnel.py
@@ -1,0 +1,165 @@
+# tests/cloud/kb/test_router_ingest_funnel.py — REST ingest routes use the funnel.
+# Created: 2026-08-04 — ingest hardening follow-up. POST /kb/ingest/text and
+# POST /kb/ingest/url used to call ``_kb("ingest", ...)`` directly, bypassing
+# the hardened ``KnowledgeService.ingest_text_to_scope`` funnel: no
+# agent-backend compile on keyless boxes, no verbatim-fallback rejection —
+# the original silent-poisoning hole, re-opened through the REST door.
+# These tests drive the routes end-to-end through the REAL funnel and spy at
+# the subprocess boundary: whatever hits the kb binary must be one of the two
+# funnel argv shapes (plain ingest with a key, --article-json without one),
+# never a bare direct call; and fallback-marker rejection must surface as the
+# route's 500, not a stored article.
+"""REST ingest routes are pinned to the hardened ingest funnel."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pocketpaw_ee.cloud.agents import knowledge
+from pocketpaw_ee.cloud.kb import backend_adapter
+from pocketpaw_ee.cloud.kb import router as kb_router
+from pocketpaw_ee.cloud.kb.dto import IngestTextRequest, IngestUrlRequest
+from pocketpaw_ee.cloud.shared.errors import CloudError
+
+WORKSPACE = "w1"
+CALLER = "memberA"
+
+
+def _patch_candidates():
+    return patch(
+        "pocketpaw_ee.cloud.kb.service._candidate_scopes",
+        AsyncMock(return_value=[f"workspace:{WORKSPACE}"]),
+    )
+
+
+class _SubprocessSpy:
+    """Records kb argv + stdin; delegates non-kb subprocess calls."""
+
+    def __init__(self, responses: list) -> None:
+        self.calls: list[dict] = []
+        self._responses = list(responses)
+        self._real_run = subprocess.run
+
+    def __call__(self, cmd, input=None, timeout=None, **kwargs):  # noqa: A002
+        if not cmd or cmd[0] != knowledge.KB_BIN:
+            return self._real_run(cmd, input=input, timeout=timeout, **kwargs)
+        self.calls.append({"cmd": list(cmd), "input": input, "timeout": timeout})
+        returncode, stdout, stderr = self._responses.pop(0)
+        return subprocess.CompletedProcess(cmd, returncode, stdout=stdout, stderr=stderr)
+
+
+_ARTICLE = {
+    "title": "T",
+    "summary": "S.",
+    "content": "# T\n\n- fact",
+    "concepts": ["t"],
+    "categories": ["c"],
+}
+
+
+def _install_compiler(monkeypatch) -> None:
+    async def fake_complete(self, prompt: str, system_prompt: str = "") -> str:
+        return json.dumps(_ARTICLE)
+
+    monkeypatch.setattr(backend_adapter.PocketPawCompilerBackend, "complete", fake_complete)
+
+
+@pytest.mark.asyncio
+async def test_ingest_text_without_key_uses_article_json_funnel(monkeypatch):
+    """Keyless box: the route must produce the pre-compiled --article-json call."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    _install_compiler(monkeypatch)
+    spy = _SubprocessSpy([(0, json.dumps({"id": "art-r1"}), "")])
+    monkeypatch.setattr(knowledge.subprocess, "run", spy)
+
+    with _patch_candidates():
+        result = await kb_router.ingest_text(
+            IngestTextRequest(text="workspace note", source="manual"),
+            workspace_id=WORKSPACE,
+            user_id=CALLER,
+        )
+
+    assert result["id"] == "art-r1"
+    assert len(spy.calls) == 1
+    cmd = spy.calls[0]["cmd"]
+    assert cmd[1:] == ["ingest", "--article-json", "--scope", f"workspace:{WORKSPACE}", "--json"]
+    payload = json.loads(spy.calls[0]["input"])
+    assert payload["raw_text"] == "workspace note"
+    assert payload["article"]["title"] == _ARTICLE["title"]
+
+
+@pytest.mark.asyncio
+async def test_ingest_text_with_key_uses_plain_funnel(monkeypatch):
+    """With a key, the route emits the funnel's plain-ingest argv, no bare call."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    spy = _SubprocessSpy([(0, json.dumps({"id": "art-r2", "compiled_with": "llm"}), "")])
+    monkeypatch.setattr(knowledge.subprocess, "run", spy)
+
+    with _patch_candidates():
+        result = await kb_router.ingest_text(
+            IngestTextRequest(text="note", source="manual"),
+            workspace_id=WORKSPACE,
+            user_id=CALLER,
+        )
+
+    assert result["id"] == "art-r2"
+    cmd = spy.calls[0]["cmd"]
+    assert cmd[1:] == [
+        "ingest",
+        "--scope",
+        f"workspace:{WORKSPACE}",
+        "--source",
+        "manual",
+        "--json",
+    ]
+    assert spy.calls[0]["input"] == "note"
+
+
+@pytest.mark.asyncio
+async def test_ingest_url_routes_through_funnel(monkeypatch):
+    """The URL route extracts here but ingests through the funnel."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    _install_compiler(monkeypatch)
+    spy = _SubprocessSpy([(0, json.dumps({"id": "art-r3"}), "")])
+    monkeypatch.setattr(knowledge.subprocess, "run", spy)
+
+    with (
+        _patch_candidates(),
+        patch.object(kb_router, "_extract_url", AsyncMock(return_value="page text")),
+    ):
+        result = await kb_router.ingest_url(
+            IngestUrlRequest(url="https://example.test/page"),
+            workspace_id=WORKSPACE,
+            user_id=CALLER,
+        )
+
+    assert result["id"] == "art-r3"
+    cmd = spy.calls[0]["cmd"]
+    assert cmd[1:] == ["ingest", "--article-json", "--scope", f"workspace:{WORKSPACE}", "--json"]
+    payload = json.loads(spy.calls[0]["input"])
+    assert payload["raw_text"] == "page text"
+    assert payload["article"]["source"] == "https://example.test/page"
+
+
+@pytest.mark.asyncio
+async def test_ingest_text_fallback_marker_maps_to_500(monkeypatch):
+    """Fallback rejection applies at the REST door: 500, not a stored article."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    spy = _SubprocessSpy(
+        [(0, json.dumps({"id": "art-r4", "compiled_with": "none (fallback)"}), "")]
+    )
+    monkeypatch.setattr(knowledge.subprocess, "run", spy)
+
+    with _patch_candidates():
+        with pytest.raises(CloudError) as exc:
+            await kb_router.ingest_text(
+                IngestTextRequest(text="doc", source="manual"),
+                workspace_id=WORKSPACE,
+                user_id=CALLER,
+            )
+
+    assert exc.value.code == "kb.ingest_failed"
+    assert "verbatim fallback" in exc.value.message

--- a/tests/cloud/kb/test_router_scope.py
+++ b/tests/cloud/kb/test_router_scope.py
@@ -1,5 +1,10 @@
 # tests/cloud/kb/test_router_scope.py — REST-door scope-override leak-prevention.
 #
+# Updated: 2026-08-04 — ingest routes now go through the hardened
+# ``KnowledgeService.ingest_text_to_scope`` funnel; the happy-path ingest test
+# spies the funnel instead of ``_kb``. Deny-path assertions are unchanged (the
+# 403 fires before any ingest machinery runs).
+#
 # Created: 2026-06-08 (VIP Onboarding Phase B) — the SECOND door into the
 # kb-go scope store. The chat-path gate (``_member_private_user_scope`` in
 # chat/agent_service.py) is closed, but the ``/api/v1/kb/*`` REST router
@@ -254,13 +259,21 @@ async def test_search_allows_own_user_override():
 
 @pytest.mark.asyncio
 async def test_ingest_text_allows_own_user_override():
-    """WRITE to the caller's OWN private KB is allowed."""
-    spy = MagicMock(return_value={"ok": True})
-    with _patch_candidates(), _patch_kb(spy):
+    """WRITE to the caller's OWN private KB is allowed.
+
+    2026-08-04: the ingest routes go through the hardened
+    ``KnowledgeService.ingest_text_to_scope`` funnel now (not a direct
+    ``_kb`` call), so the spy sits on the funnel. The funnel's own argv
+    contract is pinned in tests/cloud/kb/test_router_ingest_funnel.py.
+    """
+    spy = AsyncMock(return_value={"ok": True})
+    with (
+        _patch_candidates(),
+        patch.object(kb_router.KnowledgeService, "ingest_text_to_scope", spy),
+    ):
         await kb_router.ingest_text(
             IngestTextRequest(text="note", source="manual", scope=f"user:{CALLER}"),
             workspace_id=WORKSPACE,
             user_id=CALLER,
         )
-    args = spy.call_args.args
-    assert args[args.index("--scope") + 1] == f"user:{CALLER}"
+    spy.assert_awaited_once_with(f"user:{CALLER}", "note", "manual")


### PR DESCRIPTION
## The bug this fixes

The cloud box runs PocketPaw on the Claude Code agent backend with no `ANTHROPIC_API_KEY`. `KnowledgeService.ingest_text_to_scope` shells out to `kb ingest`, whose internal LLM compile needs that key. Without it, the compile failed on every single ingest — and kb quietly stored each document verbatim as an "article". One workspace accumulated a 54-article / 4M-word scope this way, and `_build_kb_snippets_block` runs a kb search on every chat turn, paying about 5 seconds of O(corpus) subprocess time to retrieve 522 chars of junk.

The failure was silent at every layer: kb didn't error, the listener logged success, and chat just got slower and dumber.

## What changed

**Ingest compiles through our own backend when the key is absent.** `ingest_text_to_scope` now branches: with an `ANTHROPIC_API_KEY`, the plain `kb ingest` path is unchanged. Without one, the article is compiled by `PocketPawCompilerBackend` (`ee/pocketpaw_ee/cloud/kb/backend_adapter.py` — the agent-registry adapter built for exactly this, previously unused), then handed to kb pre-compiled via the new `kb ingest --article-json` stdin contract. kb makes no LLM call of its own on that path. An unavailable backend raises a distinct "agent backend not available" error rather than surfacing as an empty response.

**Compile failure raises. Always.** Garbage output, empty title/content, or a "compiled" article that is basically the input echoed back (large doc, content > 60% of what the compiler saw) all raise instead of ingesting. Callers already contain ingest exceptions per their existing patterns (the FileReady listener logs and skips, the site sync counts a skip), so the failure surfaces in logs instead of poisoning the scope.

**The REST ingest routes go through the same funnel.** `POST /kb/ingest/text` and `POST /kb/ingest/url` used to call `_kb("ingest", ...)` directly — no agent-backend compile, no fallback rejection, and a sync subprocess call blocking the async handler. Both now route through `ingest_text_to_scope`, so every ingest path in the codebase shares one hardened door.

**Fallback-marker rejection, defense in depth.** Any ingest result with `compiled_with == "none (fallback)"` — an older binary, or `--allow-fallback` misuse — is rejected with a warning naming the scope and article id. At the REST door this surfaces as the route's 500, never a stored article.

**Chat turns can't be stalled by the KB anymore.** `search_context_for_scope` gets a hard 5s timeout and fails soft: on timeout or subprocess failure it logs a warning (scope + elapsed) and returns `""`, so the KB block is skipped and the turn proceeds. `_kb` now also converts `subprocess.TimeoutExpired` into a clear `RuntimeError`.

**Text-file ingest unified.** `ingest_file`'s text/code path used to hand kb a file path directly, bypassing all of the above; it now reads the file and routes through `ingest_text_to_scope`.

## Deploy coupling

This code targets the kb-go CLI contract shipping in the parallel kb-go PR: `kb ingest` without `--allow-fallback` exits 1 on compile failure (no article), and `kb ingest --article-json --scope S --json` accepts a pre-compiled `{raw_text, article}` payload on stdin. The binary and this change ship to the box together (runbook covers deployment).

**Old-binary detection** (corrected after a live smoke against real binaries): kb-go parses flags by hand and silently ignores unknown ones, so an old binary never errors on `--article-json` — it reads the JSON payload from stdin as raw text, stores the wrapper verbatim via its keyless fallback, and exits 0 with old-style output. The version-proof signal is the `compiled_with` key: the paired binary always emits it on this path, so a result without it means the flag was ignored. The funnel raises with the upgrade hint and names the already-stored article (with the `kb delete` command) so the operator can purge it. The unknown-flag remap remains as belt-and-braces only.

## Tests

`tests/cloud/agents/test_knowledge_ingest_hardening.py` (11 tests) spies at the subprocess boundary — real `_kb`, captured argv + stdin — so the kb CLI contract itself is what's pinned. Only the LLM completion is faked. Covers: the exact `--article-json` argv and payload shape, the key-present path staying byte-identical, compile garbage/empty/echo raising with zero kb calls, the old-binary case modeled as it really behaves (exit 0, old-style JSON, no `compiled_with` → raise naming the article), fallback-marker rejection with the warning, the `ingest_file` text-path reroute, and both search fail-soft cases.

`tests/cloud/kb/test_router_ingest_funnel.py` (5 tests) drives both REST routes through the real funnel to the subprocess boundary: keyless → `--article-json` argv, key present → plain-ingest argv, never a bare direct call; the fallback marker and the old-binary missing-`compiled_with` case both mapping to the route's `kb.ingest_failed` 500 (inherited from the funnel, not re-implemented).

Consumer suites (uploads listeners, kb purge, kb router/service, site kb ingest, paw bar sources, library verbs, cloud chat) are green; the pre-existing failures in `tests/cloud/uploads/test_router*` and `test_agent_visibility_enforcement.py::test_knowledge_list_allowed_for_owner` reproduce identically on a clean checkout of this base. `lint-imports` passes on both configs.

Docs: added a compilation section to `docs/concepts/concierge-knowledge.mdx`, including the 80K compile-input cap and the small-doc exemption from the echo check.
