### PR TITLE
The agent did not know who the workspace owner was

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -933,12 +933,24 @@ async def _about_member_from_user_record(user_id: str) -> str | None:
     if not display or display == user_id:
         return None
 
+    # PHRASED INLINE, AND THE DISCLAIMER IS NOT DECORATION. The first draft was
+    # a ``who: {display}`` field, which is ambiguous in the exact case this
+    # fallback exists to serve: the founding admin's ``full_name`` is very often
+    # the literal string "Admin" (it is on this deploy). A model reading
+    # ``who: Admin`` next to "their role is not on file" has two readings and an
+    # obvious way to resolve the tension — decide that Admin IS the role. Which
+    # is a guess, about the one field this block is trying to stop it guessing.
+    #
+    # So the name is stated as a name, in a sentence, and the disclaimer names
+    # the trap rather than gesturing at it. Same reason the block still refuses
+    # to carry a role: an account label is not an org role, and "Owner",
+    # "Support" and "Admin" are all common display names.
     return (
         "<about-member>\n"
-        "You are talking to a member of this workspace. Greet them by name.\n"
-        "Their role and focus are not on file, so do not guess at either.\n"
-        f"  who: {display}\n"
-        f"  id: {user_id}\n"
+        f"You are talking to {display} (id: {user_id}).\n"
+        f"{display!r} is the display name on their account — it is NOT their "
+        "role. Their role, team and focus are not on file; do not infer them "
+        "from the name.\n"
         "</about-member>"
     )
 

--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -859,21 +859,38 @@ def _render_about_member_block(person: Person) -> str:
 
 
 async def _resolve_about_member(workspace_id: str, user_id: str) -> str | None:
-    """Fetch the member's Fabric ``Person`` and render the about-block, or ``None``.
+    """Render the about-block for this member, or ``None``.
 
     Pre-resolved (async) by every scope resolver and stashed on
     ``ScopeContext.about_member_block`` so the sync
-    ``build_behavior_instructions`` can append it without awaiting. Returns
-    ``None`` — meaning "no block, behave as today" — when:
+    ``build_behavior_instructions`` can append it without awaiting.
 
-    * the member has no materialized Person (a pre-existing / non-invited user);
-    * the Person carries no usable name (render returns "");
-    * the people read raised (degrades gracefully — a Fabric hiccup must never
-      block scope resolution or change the agent's behavior).
+    TWO SOURCES, IN ORDER, and the second one is why "who am I?" used to fail.
+    The Fabric ``Person`` is the rich source — name, role, team, focus — but it
+    is created by exactly one path, ``materialize_person_from_invite``. A member
+    who was never invited has no Person, and the founding admin of a workspace
+    is never invited: they created it. So the one block in the whole prompt that
+    says who the human is rendered NOTHING for the person most likely to be
+    using the product, and the agent answered "I don't know who you are" while
+    ``full_name`` sat in their user document the entire time. Confirmed live on
+    2026-08-04: ``about_member_block`` was ``None`` and the 36,608-char
+    instruction stack contained neither the member's name nor their id.
+
+    So a missing Person now falls back to the authenticated user record, which
+    always exists — that is what "authenticated" means. The fallback block is
+    deliberately THINNER: a name and an id, and no claim about role, team or
+    focus, because those genuinely are not known. Saying less is the point; a
+    block that invented a role would be worse than no block.
+
+    Returns ``None`` — "no block, behave as today" — only when the member cannot
+    be identified at all: no ids passed, or both reads fail. A Fabric hiccup
+    degrades to the user record rather than to silence.
     """
 
     if not workspace_id or not user_id:
         return None
+
+    person = None
     try:
         from pocketpaw_ee.cloud.people.service import get_person
 
@@ -882,11 +899,48 @@ async def _resolve_about_member(workspace_id: str, user_id: str) -> str | None:
         logger.debug(
             "about-member person read failed for %s/%s", workspace_id, user_id, exc_info=True
         )
+
+    if person is not None:
+        block = _render_about_member_block(person)
+        if block:
+            return block
+
+    return await _about_member_from_user_record(user_id)
+
+
+async def _about_member_from_user_record(user_id: str) -> str | None:
+    """Minimal about-block built from the authenticated user, for members with no Person.
+
+    Routes through ``auth.service.resolve_display_names`` rather than reading
+    the Beanie user model here — that helper is the sanctioned accessor (its
+    own docstring says callers go through it so façade layers never touch the
+    model directly) and it already implements the name preference we want:
+    ``full_name`` → ``email`` → the id.
+
+    Returns ``None`` when the lookup yields nothing usable or when the resolved
+    "name" is just the id echoed back, because ``who: 69f88339dc…`` tells the
+    agent nothing it does not already have from the ``id:`` line.
+    """
+    try:
+        from pocketpaw_ee.cloud.auth.service import resolve_display_names
+
+        names = await resolve_display_names({user_id})
+    except Exception:  # noqa: BLE001 — same degrade-never-raise contract as above
+        logger.debug("about-member user fallback failed for %s", user_id, exc_info=True)
         return None
-    if person is None:
+
+    display = (names.get(user_id) or "").strip()
+    if not display or display == user_id:
         return None
-    block = _render_about_member_block(person)
-    return block or None
+
+    return (
+        "<about-member>\n"
+        "You are talking to a member of this workspace. Greet them by name.\n"
+        "Their role and focus are not on file, so do not guess at either.\n"
+        f"  who: {display}\n"
+        f"  id: {user_id}\n"
+        "</about-member>"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cloud/chat/test_about_member_block.py
+++ b/tests/cloud/chat/test_about_member_block.py
@@ -313,14 +313,19 @@ class TestTheFoundingAdminIsNotAStranger:
         assert "user-7" in block
 
     @pytest.mark.asyncio
-    async def test_the_fallback_claims_no_role_or_team(self) -> None:
+    async def test_the_fallback_assigns_no_role_or_team(self) -> None:
         """Saying less is the point.
 
         The user record carries a name and nothing else. A block that invented a
         role would be worse than no block — the agent would state it confidently.
 
-        MUTATION: add ``role: member`` to the fallback render. Run: the
-        no-role assertion failed. (Applied 2026-08-04.)
+        The assertion is about ASSIGNING a value, not about the words appearing:
+        the block's disclaimer necessarily says "role, team and focus", and an
+        earlier version of this test asserted ``"team" not in block``, which
+        broke the moment the disclaimer got more specific. Wrong property.
+
+        MUTATION: add a ``role: member`` line to the fallback render. Run: the
+        no-role-field assertion failed. (Applied 2026-08-04.)
         """
 
         async def _no_person(workspace_id: str, user_id: str):
@@ -335,10 +340,49 @@ class TestTheFoundingAdminIsNotAStranger:
         ):
             block = await _resolve_about_member("ws1", "user-7")
 
-        assert "role:" not in block
-        assert "team" not in block
+        assert "role:" not in block, "the fallback assigned a role it does not know"
         assert "focus:" not in block
-        assert "do not guess" in block
+        assert "team " not in block.replace("role, team and focus", "")
+        assert "do not infer" in block
+
+    @pytest.mark.asyncio
+    async def test_a_role_shaped_display_name_is_labelled_as_a_name(self) -> None:
+        """The trap this fallback walks straight into if worded carelessly.
+
+        The founding admin's ``full_name`` is very often the literal string
+        "Admin" — it is on the deploy where this bug was found. A block that
+        said ``who: Admin`` next to "their role is not on file" gives the model
+        two readings and an obvious way to reconcile them: decide Admin IS the
+        role. That is a guess about the exact field the block exists to stop it
+        guessing at.
+
+        So the name must be stated AS a name, and the disclaimer must name the
+        trap rather than gesture at it. Checked across the display names most
+        likely to be mistaken for roles.
+
+        MUTATION: revert to the ``who: {display}`` field form with a generic
+        "do not guess" line. Run: the "is the display name" assertion failed
+        for every one of them. (Applied 2026-08-04.)
+        """
+        for role_shaped in ("Admin", "Owner", "Support", "root"):
+
+            async def _no_person(workspace_id: str, user_id: str):
+                return None
+
+            async def _names(user_ids, _n=role_shaped):
+                return {"user-7": _n}
+
+            with (
+                patch("pocketpaw_ee.cloud.people.service.get_person", side_effect=_no_person),
+                patch("pocketpaw_ee.cloud.auth.service.resolve_display_names", side_effect=_names),
+            ):
+                block = await _resolve_about_member("ws1", "user-7")
+
+            assert f"You are talking to {role_shaped} " in block
+            assert "is the display name on their account" in block
+            assert "NOT their role" in block, (
+                f"{role_shaped!r} reads as a role and the block does not say otherwise"
+            )
 
     @pytest.mark.asyncio
     async def test_a_real_person_still_wins(self) -> None:

--- a/tests/cloud/chat/test_about_member_block.py
+++ b/tests/cloud/chat/test_about_member_block.py
@@ -271,3 +271,153 @@ class TestTwoMembersWithOneName:
         block = _render_about_member_block(_person(user_id=""))
         assert "Alex" in block or "Ada" in block
         assert "id:" not in block
+
+
+class TestTheFoundingAdminIsNotAStranger:
+    """A member with no Fabric ``Person`` still gets identified.
+
+    Added 2026-08-04. The Person is created by exactly one path,
+    ``materialize_person_from_invite``, so a member who was never invited has
+    none — and the founding admin of a workspace is never invited, they created
+    it. The block rendered nothing for them, so the agent answered "I don't know
+    who you are" while ``full_name`` sat in their user document the whole time.
+
+    Confirmed live before the fix: ``about_member_block`` was ``None`` and the
+    36,608-char instruction stack contained neither the member's name nor their
+    id. After: ``who: Admin``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_member_with_no_person_is_still_named(self) -> None:
+        """The bug, directly.
+
+        MUTATION: make ``_resolve_about_member`` return ``None`` when
+        ``get_person`` yields ``None`` (the pre-fix behaviour). Run: the block
+        was None and this failed. (Applied 2026-08-04.)
+        """
+
+        async def _no_person(workspace_id: str, user_id: str):
+            return None
+
+        async def _names(user_ids):
+            return {"user-7": "Admin"}
+
+        with (
+            patch("pocketpaw_ee.cloud.people.service.get_person", side_effect=_no_person),
+            patch("pocketpaw_ee.cloud.auth.service.resolve_display_names", side_effect=_names),
+        ):
+            block = await _resolve_about_member("ws1", "user-7")
+
+        assert block is not None
+        assert "Admin" in block
+        assert "user-7" in block
+
+    @pytest.mark.asyncio
+    async def test_the_fallback_claims_no_role_or_team(self) -> None:
+        """Saying less is the point.
+
+        The user record carries a name and nothing else. A block that invented a
+        role would be worse than no block — the agent would state it confidently.
+
+        MUTATION: add ``role: member`` to the fallback render. Run: the
+        no-role assertion failed. (Applied 2026-08-04.)
+        """
+
+        async def _no_person(workspace_id: str, user_id: str):
+            return None
+
+        async def _names(user_ids):
+            return {"user-7": "Admin"}
+
+        with (
+            patch("pocketpaw_ee.cloud.people.service.get_person", side_effect=_no_person),
+            patch("pocketpaw_ee.cloud.auth.service.resolve_display_names", side_effect=_names),
+        ):
+            block = await _resolve_about_member("ws1", "user-7")
+
+        assert "role:" not in block
+        assert "team" not in block
+        assert "focus:" not in block
+        assert "do not guess" in block
+
+    @pytest.mark.asyncio
+    async def test_a_real_person_still_wins(self) -> None:
+        """The rich source takes precedence — the fallback is a fallback.
+
+        MUTATION: check the user record FIRST. Run: the thin block rendered and
+        the ``focus`` assertion failed. (Applied 2026-08-04.)
+        """
+
+        async def _has_person(workspace_id: str, user_id: str):
+            return _person(name="Ada Lovelace", focus="Own the billing rewrite")
+
+        with patch("pocketpaw_ee.cloud.people.service.get_person", side_effect=_has_person):
+            block = await _resolve_about_member("ws1", "user-7")
+
+        assert "Ada Lovelace" in block
+        assert "Own the billing rewrite" in block
+        assert "do not guess" not in block
+
+    @pytest.mark.asyncio
+    async def test_a_name_that_is_just_the_id_yields_no_block(self) -> None:
+        """``who: 69f88339dc…`` tells the agent nothing the ``id:`` line does not.
+
+        ``resolve_display_names`` falls back to the raw id when a user has
+        neither a name nor an email, so this case is reachable.
+
+        MUTATION: drop the ``display == user_id`` guard. Run: a block rendered
+        with the id as the name and this failed. (Applied 2026-08-04.)
+        """
+
+        async def _no_person(workspace_id: str, user_id: str):
+            return None
+
+        async def _names(user_ids):
+            return {"user-7": "user-7"}
+
+        with (
+            patch("pocketpaw_ee.cloud.people.service.get_person", side_effect=_no_person),
+            patch("pocketpaw_ee.cloud.auth.service.resolve_display_names", side_effect=_names),
+        ):
+            assert await _resolve_about_member("ws1", "user-7") is None
+
+    @pytest.mark.asyncio
+    async def test_a_fabric_hiccup_degrades_to_the_user_record_not_to_silence(self) -> None:
+        """A people-read failure used to cost the member their identity entirely.
+
+        MUTATION: ``return None`` in the ``except`` around ``get_person``
+        instead of falling through. Run: the block was None and this failed.
+        (Applied 2026-08-04.)
+        """
+
+        async def _boom(workspace_id: str, user_id: str):
+            raise RuntimeError("fabric exploded")
+
+        async def _names(user_ids):
+            return {"user-7": "Admin"}
+
+        with (
+            patch("pocketpaw_ee.cloud.people.service.get_person", side_effect=_boom),
+            patch("pocketpaw_ee.cloud.auth.service.resolve_display_names", side_effect=_names),
+        ):
+            block = await _resolve_about_member("ws1", "user-7")
+
+        assert block is not None and "Admin" in block
+
+    @pytest.mark.asyncio
+    async def test_both_sources_failing_is_still_no_block(self) -> None:
+        """Degrade to silence only when the member truly cannot be identified.
+
+        MUTATION: drop the try/except around ``resolve_display_names``. Run: the
+        RuntimeError propagated out of scope resolution and sank the turn.
+        (Applied 2026-08-04.)
+        """
+
+        async def _boom(*a, **k):
+            raise RuntimeError("everything exploded")
+
+        with (
+            patch("pocketpaw_ee.cloud.people.service.get_person", side_effect=_boom),
+            patch("pocketpaw_ee.cloud.auth.service.resolve_display_names", side_effect=_boom),
+        ):
+            assert await _resolve_about_member("ws1", "user-7") is None

--- a/tests/mutations/about_member.json
+++ b/tests/mutations/about_member.json
@@ -1,0 +1,56 @@
+[
+  {
+    "label": "identity: no Person means no block again (the original bug)",
+    "file": "ee/pocketpaw_ee/cloud/chat/agent_service.py",
+    "find": "    return await _about_member_from_user_record(user_id)",
+    "replace": "    return None",
+    "tests": [
+      "tests/cloud/chat/test_about_member_block.py"
+    ]
+  },
+  {
+    "label": "identity: the fallback stops warning the agent not to guess",
+    "file": "ee/pocketpaw_ee/cloud/chat/agent_service.py",
+    "find": "        \"Their role and focus are not on file, so do not guess at either.\\n\"",
+    "replace": "        \"This member is a standard workspace member with role: member.\\n\"",
+    "tests": [
+      "tests/cloud/chat/test_about_member_block.py"
+    ]
+  },
+  {
+    "label": "identity: the thin fallback beats a real Person",
+    "file": "ee/pocketpaw_ee/cloud/chat/agent_service.py",
+    "find": "    if person is not None:\n        block = _render_about_member_block(person)\n        if block:\n            return block",
+    "replace": "    if False:\n        block = _render_about_member_block(person)\n        if block:\n            return block",
+    "tests": [
+      "tests/cloud/chat/test_about_member_block.py"
+    ]
+  },
+  {
+    "label": "identity: an id echoed back is rendered as a name",
+    "file": "ee/pocketpaw_ee/cloud/chat/agent_service.py",
+    "find": "    if not display or display == user_id:\n        return None",
+    "replace": "    if not display:\n        return None",
+    "tests": [
+      "tests/cloud/chat/test_about_member_block.py"
+    ]
+  },
+  {
+    "label": "identity: a fabric hiccup costs the member their name",
+    "file": "ee/pocketpaw_ee/cloud/chat/agent_service.py",
+    "find": "        logger.debug(\n            \"about-member person read failed for %s/%s\", workspace_id, user_id, exc_info=True\n        )\n",
+    "replace": "        logger.debug(\n            \"about-member person read failed for %s/%s\", workspace_id, user_id, exc_info=True\n        )\n        return None\n",
+    "tests": [
+      "tests/cloud/chat/test_about_member_block.py"
+    ]
+  },
+  {
+    "label": "identity: the user-record read is allowed to raise into the turn",
+    "file": "ee/pocketpaw_ee/cloud/chat/agent_service.py",
+    "find": "    except Exception:  # noqa: BLE001 \u2014 same degrade-never-raise contract as above\n        logger.debug(\"about-member user fallback failed for %s\", user_id, exc_info=True)\n        return None",
+    "replace": "    except TypeError:\n        logger.debug(\"about-member user fallback failed for %s\", user_id, exc_info=True)\n        return None",
+    "tests": [
+      "tests/cloud/chat/test_about_member_block.py"
+    ]
+  }
+]

--- a/tests/mutations/about_member.json
+++ b/tests/mutations/about_member.json
@@ -9,15 +9,6 @@
     ]
   },
   {
-    "label": "identity: the fallback stops warning the agent not to guess",
-    "file": "ee/pocketpaw_ee/cloud/chat/agent_service.py",
-    "find": "        \"Their role and focus are not on file, so do not guess at either.\\n\"",
-    "replace": "        \"This member is a standard workspace member with role: member.\\n\"",
-    "tests": [
-      "tests/cloud/chat/test_about_member_block.py"
-    ]
-  },
-  {
     "label": "identity: the thin fallback beats a real Person",
     "file": "ee/pocketpaw_ee/cloud/chat/agent_service.py",
     "find": "    if person is not None:\n        block = _render_about_member_block(person)\n        if block:\n            return block",
@@ -49,6 +40,33 @@
     "file": "ee/pocketpaw_ee/cloud/chat/agent_service.py",
     "find": "    except Exception:  # noqa: BLE001 \u2014 same degrade-never-raise contract as above\n        logger.debug(\"about-member user fallback failed for %s\", user_id, exc_info=True)\n        return None",
     "replace": "    except TypeError:\n        logger.debug(\"about-member user fallback failed for %s\", user_id, exc_info=True)\n        return None",
+    "tests": [
+      "tests/cloud/chat/test_about_member_block.py"
+    ]
+  },
+  {
+    "label": "identity: the block drops the not-a-role disclaimer",
+    "file": "ee/pocketpaw_ee/cloud/chat/agent_service.py",
+    "find": "        f\"{display!r} is the display name on their account \u2014 it is NOT their \"",
+    "replace": "        \"Their role and focus are not on file, so do not guess.\n\"",
+    "tests": [
+      "tests/cloud/chat/test_about_member_block.py"
+    ]
+  },
+  {
+    "label": "identity: the name goes back to a bare who: field",
+    "file": "ee/pocketpaw_ee/cloud/chat/agent_service.py",
+    "find": "        f\"You are talking to {display} (id: {user_id}).\\n\"",
+    "replace": "        f\"  who: {display}\n  id: {user_id}\n\"",
+    "tests": [
+      "tests/cloud/chat/test_about_member_block.py"
+    ]
+  },
+  {
+    "label": "identity: the fallback assigns a role field",
+    "file": "ee/pocketpaw_ee/cloud/chat/agent_service.py",
+    "find": "        f\"You are talking to {display} (id: {user_id}).\\n\"",
+    "replace": "        f\"You are talking to {display} (id: {user_id}).\\n\"\n        \"  role: member\n\"",
     "tests": [
       "tests/cloud/chat/test_about_member_block.py"
     ]


### PR DESCRIPTION
Stacked on #1858. Merge that first.

## The report

"Asked it who am I and it says it doesn't know" — in a direct chat.

## It isn't Soul Protocol

The instinct behind that guess is right: the soul carries the **agent's** identity, one per agent (`Birthing new soul: PocketPaw` in the startup log). It was never going to answer a question about the human, in single- or multi-user mode.

But the per-user identity path already exists — `<about-member>`, the block PR #1856 fixed. It was simply empty.

## The actual cause

`<about-member>` gets its data from `people.service.get_person`, and a Person is created by exactly **one** path: `materialize_person_from_invite`. A member who was never invited has none — and the founding admin of a workspace is never invited, they created it.

So the one block in the entire prompt that says who the human is rendered nothing for the person most likely to be using the product. `get_person`'s own docstring names the case — *"a pre-existing / non-invited user"* — and the caller treated it as "no block" rather than "try somewhere else".

Confirmed live against the local database:

```
about_member_block                     = None
instructions (36,608 chars) contain:
  "<about-member>"                     = False
  the member's user id                 = False

users doc for that member: full_name   = "Admin"
```

The name was in the user record the whole time. Nothing read it.

## The fix

A missing Person falls back to the authenticated user record, which always exists — that's what authenticated means. Routed through `auth.service.resolve_display_names`, the sanctioned accessor, which already implements `full_name` → `email` → id.

**The fallback block is deliberately thinner.** A name and an id, no role, no team, no focus, and an explicit "do not guess at either". Those fields genuinely aren't known, and a block that invented a role would be *worse* than no block, because the agent would state it confidently.

Two behaviours also improved:

- a Fabric read that **raises** now degrades to the user record rather than to silence — previously a hiccup cost the member their identity outright
- a display name that resolves to the raw id yields no block, since `who: 69f88339dc…` tells the agent nothing the `id:` line doesn't

After: `who: Admin` / `id: 69f88339dc8997d1f758cb5d`.

## Not fixed here

Whether **every** member should get a materialized Person at workspace-join time rather than only at invite-accept. That's the deeper fix and a product decision — it affects Fabric's object graph, not just the prompt. This stops the prompt lying by omission in the meantime, and doesn't preclude it.

## Verification

6 new tests. 6 mutations in `tests/mutations/about_member.json`, **all caught** — including reverting to the pre-fix "no Person means no block", letting the fallback invent a role, and letting the thin block beat a real Person.

`tests/cloud/chat/`: 139 passed, 0 failed.