### PR TITLE
The system prompt was commanding tools the agent doesn't have

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -377,6 +377,61 @@ test will pass while reporting headroom that isn't there.
 
 ---
 
+## The prompt may not command a tool the agent doesn't have
+
+Applies to every system-prompt block — `src/pocketpaw/ripple/_inline.py`, the
+rule constants in `ee/pocketpaw_ee/cloud/chat/agent_service.py`, and any new
+block you add.
+
+**The rule:** before a prompt block names a tool, confirm the agent it reaches
+actually has that tool. If the answer depends on the backend, gate the block on
+`backend_name` — `build_behavior_instructions` already takes it.
+
+**Why it fails silently.** A model handed an unsatisfiable instruction does not
+raise; it improvises, and the improvisation looks like a normal reply. Two live
+examples, both found by dumping the wire body rather than reading the code:
+
+- `# MUST CALL BEFORE EMIT` made `get_inline_widget_help` mandatory and said "if
+  the tool returns an error, OMIT the widget". The tool was on the
+  `pocketpaw_widgets` MCP server, which only `agents/claude_sdk.py` builds — so
+  on every other backend it did not error, it was absent, and the agent's only
+  consistent move was to drop the widget. A block written to protect widget
+  quality was destroying it.
+- `<composio-auth-flow>` taught a four-step OAuth sequence on
+  `initiate_connection` / `verify_connection`, gated on credentials alone.
+  Composio builds tools for four backend kinds; this deploy runs a fifth. The
+  agent was told it had Gmail/Slack/GitHub — and told the *user* so.
+
+**Naming an existing-but-wrong tool is the same defect.** The MUST-CALL block
+was satisfiable on the SDK backend and still wrong: `get_inline_widget_help`
+returns hand-written design prose for 16 widgets, while `get_widget_spec` reads
+the manifest and returns the prop schema. For `definition-list` — the block's own
+cited failure — that is 18,623 chars without the answer versus 759 chars with it.
+
+**Gate from one source of truth.** `providers.py` owns
+`supports_composio_tools` / `supports_connection_tools` next to the code that
+builds the tools, so adding a wrapper widens the prompt in the same commit. Never
+hand-maintain a second backend list in the prompt layer.
+
+**Enforcement** (`tests/test_prompt_names_only_real_tools.py`): every backticked
+`tool(` call in the inline prompt must resolve in the runtime builtin registry —
+the registry every backend gets, not the SDK's MCP surface. Per-backend gating is
+tested next to the assembly in
+`tests/cloud/test_agent_service_tools_context.py`.
+
+**Bridging beats deleting.** When the instruction is right and the tool is
+merely unreachable, add it to `tools/builtin/` and `tools/cli.py::_TOOLS` (see
+`widget_spec.py`, and `flow_tool.py` before it) rather than dropping the rule.
+Then classify it in `pydantic_ai._TENANT_SAFE_TOOLS` — an unclassified tool is
+withheld, so registry presence alone still leaves the prompt lying.
+
+**A tool result is prompt too.** A lookup miss that returns the whole catalog is
+not "erring toward too much": `widget_help` answered any unknown type with all
+58,765 chars of the design rulebook, which never contained the answer. Return the
+miss, name what can answer it.
+
+---
+
 ## A gate is not a gate until a mutation has been observed to break it
 
 Applies to any test you are treating as protection — a contract test, a cap

--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -1742,18 +1742,36 @@ def build_behavior_instructions(ctx: ScopeContext, *, backend_name: str | None =
     # preamble.
     if override is None:
         parts.append(_DELIVER_ARTIFACT_RULE)
-    # Composio auth/search guidance is injected whenever Composio is
-    # enabled. An enabled deployment ALWAYS surfaces at least the
-    # discovery meta-tools — ``providers.py`` falls back to them when no
-    # toolkit is allow-listed — and the search-fallback rule matters MOST
-    # in that meta-tools-only mode. So gate on credentials (is_enabled),
-    # not on the toolkit allow-list: the prompt and the real tool list
-    # agree because enabled ⇒ tools present.
+    # Composio auth/search guidance. Gated on credentials AND on the backend
+    # actually receiving the tools each rule talks about.
+    #
+    # The credentials half is the original reasoning and still holds: an
+    # enabled deployment ALWAYS surfaces at least the discovery meta-tools —
+    # ``providers.py`` falls back to them when no toolkit is allow-listed — and
+    # the search-fallback rule matters MOST in that meta-tools-only mode, so
+    # gating on the toolkit allow-list would drop it exactly where it counts.
+    #
+    # The backend half is the part that was missing, and "enabled ⇒ tools
+    # present" was simply not true. Composio builds tools for four backend
+    # kinds; this deployment runs a fifth (``pydantic_ai``), which gets NONE.
+    # So 2,516 characters of instruction about a Gmail/Slack/GitHub tool
+    # surface rode in every turn describing tools that did not exist. That is
+    # worse than wasted context — an agent told it has those integrations
+    # tells the USER it has them.
+    #
+    # The two rules are gated separately because the tool sets differ:
+    # ``initiate_connection`` / ``verify_connection`` exist only on the Claude
+    # SDK backend, while the search meta-tools reach all four. Both predicates
+    # live next to the code that builds the tools, so a new wrapper widens the
+    # prompt in the same commit.
+    from pocketpaw_ee.cloud.composio import providers as _composio_providers
     from pocketpaw_ee.cloud.composio import service as _composio_service
 
     if _composio_service.is_enabled():
-        parts.append(_COMPOSIO_AUTH_FLOW_RULE)
-        parts.append(_COMPOSIO_SEARCH_FALLBACK_RULE)
+        if _composio_providers.supports_connection_tools(backend_name):
+            parts.append(_COMPOSIO_AUTH_FLOW_RULE)
+        if _composio_providers.supports_composio_tools(backend_name):
+            parts.append(_COMPOSIO_SEARCH_FALLBACK_RULE)
     # The home pocket is a special case: its agent mutates widgets directly
     # via the ``add_widget`` MCP tool — it does NOT delegate to the pocket
     # specialist. ``POCKET_DELEGATION_RULE`` ("never call add_widget,

--- a/ee/pocketpaw_ee/cloud/composio/providers.py
+++ b/ee/pocketpaw_ee/cloud/composio/providers.py
@@ -61,6 +61,31 @@ SUPPORTED_BACKENDS: frozenset[str] = frozenset(
     }
 )
 
+# Backends that get the ``initiate_connection`` / ``verify_connection`` pair.
+# Narrower than SUPPORTED_BACKENDS: the other three receive Composio's concrete
+# action tools but no auth wrappers, because only the Claude-SDK wrapper has
+# been written (see ``_build_initiate_connection_tool`` /
+# ``_build_verify_connection_tool``, which return None everywhere else).
+#
+# This exists so the SYSTEM PROMPT can ask the question instead of assuming the
+# answer. ``<composio-auth-flow>`` teaches a four-step sequence built on these
+# two tools and was gated on credentials alone, so a deployment with Composio
+# keys and a backend outside this set told its agent to call two tools that
+# were not on the wire — and the agent relayed the dead end to the user as
+# instructions. Widen this set in the same commit that adds a wrapper, and the
+# prompt follows automatically.
+CONNECTION_TOOL_BACKENDS: frozenset[str] = frozenset({BACKEND_CLAUDE_SDK})
+
+
+def supports_connection_tools(backend_kind: str | None) -> bool:
+    """Whether ``backend_kind`` receives the connection auth tool pair."""
+    return backend_kind in CONNECTION_TOOL_BACKENDS
+
+
+def supports_composio_tools(backend_kind: str | None) -> bool:
+    """Whether ``backend_kind`` receives ANY Composio tools at all."""
+    return backend_kind in SUPPORTED_BACKENDS
+
 
 @dataclass(frozen=True, slots=True)
 class _CachedTools:
@@ -570,7 +595,10 @@ __all__ = [
     "BACKEND_DEEP_AGENTS",
     "BACKEND_GOOGLE_ADK",
     "BACKEND_OPENAI_AGENTS",
+    "CONNECTION_TOOL_BACKENDS",
     "SUPPORTED_BACKENDS",
     "build_tools_for_backend",
     "reset_cache_for_tests",
+    "supports_composio_tools",
+    "supports_connection_tools",
 ]

--- a/src/pocketpaw/agents/pydantic_ai.py
+++ b/src/pocketpaw/agents/pydantic_ai.py
@@ -366,6 +366,10 @@ _TENANT_SAFE_TOOLS = frozenset(
         "create_pocket",
         "start_flow",
         "run_step_pipeline",
+        # widget authoring reference — in-process reads of a static manifest
+        # and a static design catalog. No tenant data, no host state.
+        "get_widget_spec",
+        "get_inline_widget_help",
         # memory + sessions — scoped by the caller's own session key
         "remember",
         "recall",

--- a/src/pocketpaw/agents/sdk_mcp_widgets.py
+++ b/src/pocketpaw/agents/sdk_mcp_widgets.py
@@ -36,6 +36,15 @@ Changes:
     routes to ``build_flow`` (the preset shorthand), JSON-string args are
     coerced, and a ``FlowBuildError`` is surfaced verbatim so the model can
     fix the graph and retry.
+  - 2026-08-04 (fix/prompt-tells-the-truth — ONE CONTRACT, TWO SURFACES): the
+    ``start_flow`` description and JSON schema were a second hand-written copy
+    of the runtime builtin's (``tools/builtin/flow_tool.py``), 82.7% similar,
+    and had drifted — this copy carried four rules the runtime one lacked, so
+    the backend most deployments run got the weaker briefing. Both now read
+    ``_flows.START_FLOW_DESCRIPTION`` / ``_flows.start_flow_parameters()``,
+    beside the builder that enforces them. Note the entry below: that was the
+    FIRST split of this same pair. Twice is a pattern, and the pattern is two
+    copies.
   - 2026-07-03 (fix/mcp-tool-json-string-args): ``get_widget_spec`` and
     ``get_inline_widget_help`` now run their ``types`` array through the shared
     ``coerce_json_object_args`` helper, so a ``types`` value the model sent as a
@@ -314,133 +323,13 @@ def build_widgets_context_server() -> tuple[str, Any] | None:
 
     @tool(
         "start_flow",
-        (
-            "Scaffold a complete multi-step flow OR interactive mini-app (a "
-            "wizard, intake, survey, onboarding sequence, or a 'collect "
-            "details then DO something' flow) from a FLAT step-graph. DO NOT "
-            "hand-author nested chain / chain_map step trees and DO NOT fake a "
-            "flow with a single `set`-stepped spec — both render only the first "
-            "step and dead-end. You describe a flat list of steps; this tool "
-            "materializes the ENTIRE nested, validated flow tree as a "
-            "{version, ui} doc, ready to drop into a ```ui-spec fence. The flow "
-            "then advances entirely client-side with no further model calls "
-            "between steps.\n\n"
-            "AUTHOR A FLAT GRAPH (think in states, not screens):\n"
-            "- `flow`: a stable id for the flow (e.g. 'vendor_intake').\n"
-            "- `entry`: the id of the first step.\n"
-            "- `steps`: a list. Each step has an `id`, a `kind` "
-            "(select | form | confirm | info), a `title`, its content "
-            "(`options` for select, `fields` for form, `review` for confirm, "
-            "`body` for info), and where it goes next:\n"
-            '    * `next: "<id>"` — linear next step;\n'
-            '    * `branch: { "<optionId>": "<id>" }` — branch on the '
-            "picked option.\n"
-            "  A step with NEITHER `next` nor `branch` is the TERMINAL step and "
-            "carries `complete` (what to do with the answers). A terminal "
-            "`complete` uses `action:` (chat | navigate | emit | call_binding | "
-            "create_pocket | invoke_tool) — NEVER `type:`/`kind:`:\n"
-            "    chat → hand the answers back to you (default); navigate / emit "
-            "→ go somewhere / raise an event; call_binding → write to the "
-            "backend (works today); create_pocket → materialize a permanent "
-            "pocket; invoke_tool → run a named tool (may be unavailable until "
-            "the tool registry ships — prefer call_binding to act on data).\n"
-            "- Per-step `actions` (optional) are buttons that call a "
-            "tool/API/binding MID-FLOW without leaving the step (verb: "
-            "call_binding | api | invoke_tool). When the user says approve / "
-            "reject / fulfill / take action — that is a `call_binding` ACTION "
-            "BUTTON wired to the verb, not a yes/no select.\n"
-            "- Reference earlier answers with `{stepId.field}` "
-            "(e.g. `{pick_goal.label}`, `{enter_details.company}`) in review "
-            "rows and action args — this tool rewrites them correctly; you "
-            "NEVER write the raw `{state.…_selection/_formData}` form.\n\n"
-            "The builder REPAIRS recoverable slips (a missing terminal "
-            "`complete`, a dead-end last step) and REJECTS only genuine "
-            "structural bugs (a transition to an undeclared id, a duplicate "
-            "step id, a branch key that is not an option id) with a precise "
-            "error you can fix and retry.\n\n"
-            "PRESET SHORTHAND (optional): instead of `steps`, you may pass a "
-            "`flow_type` for one of the two known shapes — 'onboarding_wizard' "
-            "or 'due_diligence_intake' — plus an optional `config` for copy "
-            "tweaks. The flat `steps` graph is the general path; `flow_type` is "
-            "a convenience for those two exact shapes.\n\n"
-            "Returns the JSON doc to emit. Wrap it verbatim in a ```ui-spec "
-            "fence; do not edit the chain / chain_map structure."
-        ),
-        {
-            "type": "object",
-            "properties": {
-                "flow": {
-                    "type": "string",
-                    "description": (
-                        "A stable id for the flow (e.g. 'vendor_intake'). "
-                        "Required when authoring a flat `steps` graph."
-                    ),
-                },
-                "entry": {
-                    "type": "string",
-                    "description": (
-                        "The id of the FIRST step (must exist in `steps`). "
-                        "Required when authoring a flat `steps` graph."
-                    ),
-                },
-                "steps": {
-                    "type": "array",
-                    "items": {"type": "object"},
-                    "description": (
-                        "The flat step-graph: a list of step objects. Each step "
-                        "has `id`, `kind` (select | form | confirm | info), "
-                        "`title`, its kind-specific content (`options` / "
-                        "`fields` / `review` / `body`), and a transition "
-                        "(`next` or `branch`) — OR `complete` if it is the "
-                        "terminal step. Optional per-step `actions` run a "
-                        "tool/API/binding mid-flow. This is the general "
-                        "authoring path."
-                    ),
-                },
-                "title": {
-                    "type": "string",
-                    "description": "Optional title shown on the flow frame.",
-                },
-                "complete": {
-                    "type": "object",
-                    "description": (
-                        "Optional flow-level terminal default — the `complete` "
-                        "action a terminal step inherits when it declares none "
-                        "of its own (e.g. {action:'chat', message:'…'})."
-                    ),
-                },
-                "flow_type": {
-                    "type": "string",
-                    "enum": list(_flow_types_for_schema()),
-                    "description": (
-                        "OPTIONAL preset shorthand for the two known shapes "
-                        "('onboarding_wizard' | 'due_diligence_intake') instead "
-                        "of authoring a flat `steps` graph."
-                    ),
-                },
-                "domain": {
-                    "type": "string",
-                    "description": (
-                        "Optional domain hint (e.g. 'fintech', 'saas') for the "
-                        "preset path. Reserved for a future data-fresh path; "
-                        "does not change the tree today."
-                    ),
-                },
-                "config": {
-                    "type": "object",
-                    "description": (
-                        "Optional per-preset copy overrides (preset path only). "
-                        "Shape-stable: tweaks labels/text, never the chain "
-                        "structure."
-                    ),
-                },
-            },
-            # Nothing is hard-required at the schema level: the general path
-            # needs flow+entry+steps, the preset path needs flow_type. The
-            # handler validates the combination and returns an agent-readable
-            # error when neither is supplied.
-            "required": [],
-        },
+        # Shared with the runtime builtin (``tools/builtin/flow_tool.py``).
+        # These were two hand-written copies at 82.7% similarity, and they had
+        # drifted — this one carried four rules the runtime copy lacked, so the
+        # backend most deployments run got the weaker briefing. Second split of
+        # this exact pair; the 2026-06-15 SPLIT-BRAIN FIX was the first.
+        _start_flow_description(),
+        _start_flow_parameters(),
     )
     async def start_flow(args):  # type: ignore[no-untyped-def]
         return await _start_flow_handler(args)
@@ -453,19 +342,43 @@ def build_widgets_context_server() -> tuple[str, Any] | None:
     return SERVER_NAME, server
 
 
-def _flow_types_for_schema() -> tuple[str, ...]:
-    """The known flow templates, for the ``start_flow`` enum.
+def _start_flow_description() -> str:
+    """The canonical ``start_flow`` description, from the flow builder.
 
-    Imported lazily so the module stays importable without the ripple flow
-    builder loaded at definition time; falls back to an empty tuple (the SDK
-    accepts any string then) if the import is unavailable.
+    Lazy for the same reason ``_flow_types_for_schema`` was: this module must
+    stay importable without the ripple flow builder loaded at definition time.
+    The fallback is deliberately a POINTER rather than a shortened copy of the
+    contract — a second abbreviated description is exactly the drift this
+    change removes, and a model told to call the tool and read its error is in
+    better shape than one working from stale prose.
     """
     try:
-        from pocketpaw.ripple._flows import FLOW_TYPES
+        from pocketpaw.ripple._flows import START_FLOW_DESCRIPTION
 
-        return tuple(FLOW_TYPES)
+        return START_FLOW_DESCRIPTION
     except Exception:  # pragma: no cover - defensive
-        return ()
+        return (
+            "Scaffold a multi-step flow or interactive mini-app from a FLAT "
+            "step-graph. The flow builder is unavailable in this process, so "
+            "the full authoring contract cannot be shown; call the tool with a "
+            "`flow`, an `entry` and a `steps` list and it will name whatever "
+            "is wrong."
+        )
+
+
+def _start_flow_parameters() -> dict[str, Any]:
+    """The canonical ``start_flow`` JSON schema, from the flow builder.
+
+    Same lazy-import contract as the description. The fallback keeps the tool
+    callable with a permissive object schema rather than asserting a shape this
+    process cannot validate.
+    """
+    try:
+        from pocketpaw.ripple._flows import start_flow_parameters
+
+        return start_flow_parameters()
+    except Exception:  # pragma: no cover - defensive
+        return {"type": "object", "properties": {}, "required": []}
 
 
 __all__ = [

--- a/src/pocketpaw/ripple/_flows.py
+++ b/src/pocketpaw/ripple/_flows.py
@@ -164,6 +164,182 @@ FLOW_TYPES: tuple[str, ...] = (
     "due_diligence_intake",
 )
 
+
+# ---------------------------------------------------------------------------
+# The `start_flow` TOOL CONTRACT — one text, one schema, both surfaces.
+#
+# Added 2026-08-04 (fix/prompt-tells-the-truth). `start_flow` is exposed twice —
+# `tools/builtin/flow_tool.py` (every runtime backend) and
+# `agents/sdk_mcp_widgets.py` (the Claude SDK in-process MCP server) — and each
+# carried its OWN hand-written description and JSON schema. They were 82.7%
+# similar, which is the worst possible state: close enough that nobody notices,
+# different enough to matter.
+#
+# They HAD ALREADY DRIFTED, and not symmetrically. The SDK copy carried four
+# rules the runtime copy did not:
+#
+#   * "DO NOT fake a flow with a single `set`-stepped spec" — the anti-pattern
+#     that renders step 1 and dead-ends.
+#   * A terminal `complete` uses `action:`, NEVER `type:`/`kind:`.
+#   * approve / reject / fulfill is a `call_binding` ACTION BUTTON, not a
+#     yes/no select.
+#   * The builder REPAIRS recoverable slips and REJECTS only real structural
+#     bugs — the retry contract.
+#
+# So the backend most deployments actually run was getting the weaker briefing,
+# silently. This is the second time this exact pair split: the 2026-06-15
+# "SPLIT-BRAIN FIX" landed because the SDK handler was preset-only while the
+# prompt taught flat graphs. Twice is a pattern, and the pattern is two copies.
+#
+# The contract lives HERE, next to the builder that enforces it, so the text the
+# model reads and the code that validates it are edited in one place. Keep the
+# union of both copies — nothing was dropped in the merge.
+# ---------------------------------------------------------------------------
+
+START_FLOW_DESCRIPTION = (
+    "Scaffold a complete multi-step flow OR interactive mini-app (a "
+    "wizard, intake, survey, onboarding sequence, or a 'collect "
+    "details then DO something' flow) from a FLAT step-graph. DO NOT "
+    "hand-author nested chain / chain_map step trees and DO NOT fake a "
+    "flow with a single `set`-stepped spec — both render only the first "
+    "step and dead-end. You describe a flat list of steps; this tool "
+    "materializes the ENTIRE nested, validated flow tree as a "
+    "{version, ui} doc, ready to drop into a ```ui-spec fence. The flow "
+    "then advances entirely client-side with no further model calls "
+    "between steps.\n\n"
+    "AUTHOR A FLAT GRAPH (think in states, not screens):\n"
+    "- `flow`: a stable id for the flow (e.g. 'vendor_intake').\n"
+    "- `entry`: the id of the first step.\n"
+    "- `steps`: a list. Each step has an `id`, a `kind` "
+    "(select | form | confirm | info), a `title`, its content "
+    "(`options` for select, `fields` for form, `review` for confirm, "
+    "`body` for info), and where it goes next:\n"
+    '    * `next: "<id>"` — linear next step;\n'
+    '    * `branch: { "<optionId>": "<id>" }` — branch on the '
+    "picked option.\n"
+    "  A step with NEITHER `next` nor `branch` is the TERMINAL step and "
+    "carries `complete` (what to do with the answers). A terminal "
+    "`complete` uses `action:` (chat | navigate | emit | call_binding | "
+    "create_pocket | invoke_tool) — NEVER `type:`/`kind:`:\n"
+    "    chat → hand the answers back to you (default); navigate / emit "
+    "→ go somewhere / raise an event; call_binding → write to the "
+    "backend (works today); create_pocket → materialize a permanent "
+    "pocket; invoke_tool → run a named tool (a connector READ fires "
+    "immediately, a connector WRITE is proposed for the user's approval "
+    "in their Instinct Tray rather than running inline — prefer "
+    "call_binding to act on data).\n"
+    "- Per-step `actions` (optional) are buttons that call a "
+    "tool/API/binding MID-FLOW without leaving the step (verb: "
+    "call_binding | api | invoke_tool). When the user says approve / "
+    "reject / fulfill / take action — that is a `call_binding` ACTION "
+    "BUTTON wired to the verb, not a yes/no select.\n"
+    "- Reference earlier answers with `{stepId.field}` "
+    "(e.g. `{pick_goal.label}`, `{enter_details.company}`) in review "
+    "rows and action args — this tool rewrites them correctly; you "
+    "NEVER write the raw `{state.…_selection/_formData}` form.\n\n"
+    "The builder REPAIRS recoverable slips (a missing terminal "
+    "`complete`, a dead-end last step) and REJECTS only genuine "
+    "structural bugs (a transition to an undeclared id, a duplicate "
+    "step id, a branch key that is not an option id) with a precise "
+    "error you can fix and retry.\n\n"
+    "PRESET SHORTHAND (optional): instead of `steps`, you may pass a "
+    "`flow_type` for one of the two known shapes — 'onboarding_wizard' "
+    "or 'due_diligence_intake' — plus an optional `config` for copy "
+    "tweaks. The flat `steps` graph is the general path; `flow_type` is "
+    "a convenience for those two exact shapes.\n\n"
+    "Returns the JSON doc to emit. Wrap it verbatim in a ```ui-spec "
+    "fence; do not edit the chain / chain_map structure."
+)
+
+
+def start_flow_parameters() -> dict[str, Any]:
+    """The `start_flow` JSON schema, built fresh so the enum tracks FLOW_TYPES.
+
+    A function rather than a constant because the ``flow_type`` enum reads
+    ``FLOW_TYPES``, and a module-level dict would freeze it at import while
+    also handing every caller a shared mutable object.
+    """
+    return {
+        "type": "object",
+        "properties": {
+            "flow": {
+                "type": "string",
+                "description": (
+                    "A stable id for the flow (e.g. 'vendor_intake'). Seeds "
+                    "each step's flowId namespace. Required when authoring a "
+                    "flat `steps` graph."
+                ),
+            },
+            "entry": {
+                "type": "string",
+                "description": (
+                    "The id of the FIRST step (must exist in `steps`). "
+                    "Required when authoring a flat `steps` graph."
+                ),
+            },
+            "steps": {
+                "type": "array",
+                "items": {"type": "object"},
+                "description": (
+                    "The flat step-graph: a list of step objects. Each step "
+                    "has `id`, `kind` (select | form | confirm | info), "
+                    "`title`, its kind-specific content (`options` / "
+                    "`fields` / `review` / `body`), and a transition "
+                    "(`next` or `branch`) — OR `complete` if it is the "
+                    "terminal step. Optional per-step `actions` run a "
+                    "tool/API/binding mid-flow. This is the general "
+                    "authoring path."
+                ),
+            },
+            "title": {
+                "type": "string",
+                "description": "Optional title shown on the flow frame.",
+            },
+            "complete": {
+                "type": "object",
+                "description": (
+                    "Optional flow-level terminal default — the `complete` "
+                    "action a terminal step inherits when it declares none "
+                    "of its own (e.g. {action:'chat', message:'…'})."
+                ),
+            },
+            "flow_type": {
+                "type": "string",
+                "enum": list(FLOW_TYPES),
+                "description": (
+                    "OPTIONAL preset shorthand for the two known shapes "
+                    "('onboarding_wizard' | 'due_diligence_intake') instead "
+                    "of authoring a flat `steps` graph. The builder owns the "
+                    "full nested tree for this preset."
+                ),
+            },
+            "domain": {
+                "type": "string",
+                "description": (
+                    "Optional domain hint (e.g. 'fintech', 'saas') for the "
+                    "preset path. Reserved for a future data-fresh "
+                    "materialization path; does not change the tree today."
+                ),
+            },
+            "config": {
+                "type": "object",
+                "description": (
+                    "Optional per-preset copy overrides (preset path only). "
+                    "Shape-stable: tweaks labels/text, never the chain "
+                    "structure. onboarding_wizard accepts {product_name, "
+                    "goals, complete_message}; due_diligence_intake accepts "
+                    "{company_name, complete_message}."
+                ),
+            },
+        },
+        # Nothing is hard-required at the schema level: the general path needs
+        # flow+entry+steps, the preset path needs flow_type. The handler
+        # validates the combination and returns an agent-readable error when
+        # neither is supplied.
+        "required": [],
+    }
+
+
 # ---------------------------------------------------------------------------
 # Verb / action allow-sets (§2.4). Kept in lock-step with ripple's action VM
 # (`event-dispatcher.ts`) and pocketpaw's `manifest._KNOWN_ACTION_VERBS`. A
@@ -1899,6 +2075,7 @@ def build_flow(
 __all__ = [
     "FLOW_TYPES",
     "INLINE_SPEC_VERSION",
+    "START_FLOW_DESCRIPTION",
     "FlowBuildError",
     "FlowDescriptor",
     "FlowStep",
@@ -1909,4 +2086,5 @@ __all__ = [
     "build_flow",
     "build_flow_from_descriptor",
     "build_onboarding_wizard",
+    "start_flow_parameters",
 ]

--- a/src/pocketpaw/ripple/_inline.py
+++ b/src/pocketpaw/ripple/_inline.py
@@ -66,6 +66,23 @@
 #   button + referenced in the text guidance. Spliced into the assembled prompt
 #   after `_MULTI_STEP_FLOW_RULE` and added to the final self-check.
 
+# Modified: 2026-08-04 (fix/prompt-tells-the-truth) — two changes, both about
+#   the prompt saying only what is true and saying it once.
+#   1. `# MUST CALL BEFORE EMIT` mandated `get_inline_widget_help`, which reads
+#      a 16-widget design catalog. Prop schemas come from the manifest, which
+#      `get_widget_spec` reads — 759 chars of answer for `definition-list`
+#      against 18,623 chars that never named the field. The block cited that
+#      exact widget as a known failure while pointing at the tool that caused
+#      it. Now mandates `get_widget_spec`, and says what the other tool is for.
+#   2. `_MULTI_STEP_FLOW_RULE`'s HOW TO AUTHOR block restated the step shape
+#      (steps / kinds / next / branch / terminal complete / actions /
+#      {stepId.field}) that `start_flow`'s own schema specifies and the builder
+#      enforces — a THIRD copy of a contract that already existed twice. The
+#      prompt now routes to the schema and keeps only what a schema cannot say:
+#      when to reach for a flow, the two anti-patterns, and the skeletons.
+#      Section 8,733 -> 7,308 chars; nothing unique to the prompt was dropped
+#      (guarded by tests/test_start_flow_contract_is_shared.py).
+
 from pocketpaw.ripple._design import USE_THE_WIDGET_RULE, WIDGET_CATALOG
 
 _GROUND_TRUTH_RULE = """\
@@ -376,31 +393,12 @@ the tool materializes the nested, validated tree and returns a
 {version, ui} doc. Drop that doc VERBATIM into your `ui-spec` fence. The
 flow then advances entirely client-side — no model calls between steps.
 
-HOW TO AUTHOR (think in states, not screens):
-  steps: a list. Each step has an `id`, a `kind`
-    (select | form | confirm | info), a title, its content
-    (options / fields / review rows), and where it goes next:
-      - `next: "<id>"`        → linear next step
-      - `branch: { "<optId>": "<id>" }` → branch on the picked option
-    A step with neither `next` nor `branch` is the TERMINAL step and
-    carries `complete` (what to do with the answers).
-
-  Actions make it a real mini-app, not just Q&A:
-    - per-step `actions`: buttons that call a tool/API mid-flow
-      (verb: call_binding | api | invoke_tool) without leaving the step.
-    - terminal `complete.action`:
-        chat        → hand the collected answers back to you (default)
-        call_binding→ write to the backend
-        create_pocket → materialize a permanent pocket from the answers
-        navigate / emit → go somewhere / raise an event
-        invoke_tool → run a named tool with the answers
-                      (connector reads fire; connector writes are
-                       proposed for the user's approval — the Tray)
-
-  Reference earlier answers with `{stepId.field}` (e.g.
-  `{pick_goal.label}`, `{enter_details.company}`) in review rows and
-  action args. The tool rewrites them correctly — you never write the
-  raw `{state.…_selection/_formData}` form.
+HOW TO AUTHOR: think in states, not screens. `start_flow`'s own schema
+is the authoring contract — the step shape, the transitions, the
+terminal `complete`, the per-step `actions`, and the `{stepId.field}`
+answer references are all specified there, and it is the one place that
+stays in step with the builder. Read it and author against it rather
+than working from memory.
 
 DO NOT hand-write a nested `chain` / `chain_map` tree, and do NOT fake a
 flow with a single `set`-stepped spec (that anti-pattern renders step 1
@@ -426,19 +424,13 @@ STATE GRAMMAR — the primitives every flow composes from:
   transition, every terminal state has a `complete`. (You can't violate
   this even if you try — the builder repairs or rejects it.)
 
-ACTION GRAMMAR — the rules that turn a flow into a real tool, not Q&A:
-  - A terminal `complete` uses `action:` (chat | navigate | emit |
-    call_binding | create_pocket) — NEVER `type:`/`kind:`. (If you slip and
-    write `type:`/`kind:`, the builder coerces it, but author `action:`.)
-  - When the user says approve / reject / fulfill / take action / do X —
-    that is a `call_binding` ACTION BUTTON wired to the verb, NOT a yes/no
-    select. Never leave an action flow as plain Q&A.
-  - To act on backend / connector data, use `call_binding` (works today).
-    `invoke_tool` runs a named tool the owner allow-listed on the pocket:
-    a connector READ fires immediately; a connector WRITE is proposed for
-    the user's approval (it lands in their Instinct Tray, fires on approve)
-    rather than running inline. Reach for `call_binding` first; use
-    `invoke_tool` when the action is a named tool/connector grant.
+ACTION GRAMMAR — the one rule the tool schema cannot tell you, because it
+is about reading the REQUEST rather than shaping the output:
+  - Never leave an action flow as plain Q&A. When the user says approve /
+    reject / fulfill / take action / do X, the flow must DO it — that is
+    an action button wired to the verb, not a select that collects an
+    opinion and hands it back. The tool's schema says how to write the
+    button; this says when the request demands one.
 
 SKELETON A — branching intake (collect, then hand answers to you):
 ```

--- a/src/pocketpaw/ripple/_inline.py
+++ b/src/pocketpaw/ripple/_inline.py
@@ -282,22 +282,32 @@ schema is NOT in this prompt.
 # MUST CALL BEFORE EMIT
 
 Before the FIRST node of any non-core type lands in your spec, you MUST
-call `get_inline_widget_help(types=[...])` and copy prop names FROM
-the returned schema. The widget name is not a contract — the manifest
-is. Guessing prop names has shipped broken UIs (e.g. `definition-list`
-with `description` instead of `definition`, `timeline` events with
-`description` instead of `detail`) that render as empty rows. Batch
-types in one call: `get_inline_widget_help(types=["chart", "sparkline",
-"definition-list"])` is one round-trip — there is no excuse to skip it.
+call `get_widget_spec(types=[...])` and copy prop names FROM the
+returned schema. The widget name is not a contract — the manifest is,
+and `get_widget_spec` is what reads it. Guessing prop names has shipped
+broken UIs (e.g. `definition-list` with `description` instead of
+`definition`, `timeline` events with `description` instead of `detail`)
+that render as empty rows. Batch types in one call:
+`get_widget_spec(types=["chart", "sparkline", "definition-list"])` is
+one round-trip — there is no excuse to skip it.
 
 Example: planning a candlestick + sparkline reply →
-  get_inline_widget_help(types=["chart", "sparkline"])
+  get_widget_spec(types=["chart", "sparkline"])
   → returns the OHLC data shape for candlestick and the values/labels
     shape for sparkline. Use the returned text verbatim as the prop
     contract.
 
-If the tool returns an error, OMIT the widget rather than guess. A
-partial UI is correct; a guessed-shape widget renders empty.
+`get_inline_widget_help` is a DIFFERENT tool and does not answer this
+question. It carries hand-written design guidance — layout, spacing,
+composition — for a handful of widgets. Reach for it when you want to
+know how something should LOOK. For what props a widget TAKES, it is
+`get_widget_spec`, always.
+
+If `get_widget_spec` reports a type as unknown, this deployment's
+manifest does not carry that widget: OMIT it and choose one the
+manifest has. Do not emit it anyway and do not guess its props — it
+would render as nothing. A partial UI is correct; a guessed-shape
+widget renders empty.
 
 # ASK-USER-QUESTIONS — STRUCTURED DISAMBIGUATION
 

--- a/src/pocketpaw/ripple/_inline_core.py
+++ b/src/pocketpaw/ripple/_inline_core.py
@@ -9,6 +9,17 @@
 # (per-widget WIDGET_SHAPES first, section search second). Reworked
 # from PR #1106.
 #
+# Modified: 2026-08-04 (fix/prompt-tells-the-truth) — A LOOKUP MISS NO
+# LONGER RETURNS THE WHOLE CATALOG. This module knows 16 widgets; the
+# manifest carries 150+. Asking about any of the other 130-odd fell
+# through both tiers and returned RIPPLE_DESIGN_RULES entire — 58,765
+# characters, larger than the whole system prompt, and never once
+# mentioning the widget that was asked about. The inline prompt drives
+# the agent here for exactly the widgets this catalog does not cover, so
+# the miss path WAS the common path. It now returns a short note that
+# names the miss and routes to `get_widget_spec`, which reads the
+# manifest and answers the same question in ~700-1,400 chars.
+#
 # Lookup is two-tier:
 #  1. Per-widget canonical shapes via WIDGET_SHAPES — preferred.
 #     Asking for ["chart"] returns just the chart shape (~2k chars),
@@ -16,6 +27,8 @@
 #  2. Section search across the rest of RIPPLE_DESIGN_RULES — for
 #     niche rules (TABULAR_PICKER, ACTIVITY_PICKER, etc.) or widgets
 #     not in WIDGET_SHAPES, we still split-by-heading and fuzzy-match.
+#  3. Anything still unresolved gets `_unknown_types_note` — never the
+#     full blob.
 
 from __future__ import annotations
 
@@ -39,11 +52,16 @@ def widget_help(types: list[str] | None = None) -> str:
       2. OPTIONAL_DESIGN_SECTIONS[type] — niche layout sections that
          aren't eagerly in RIPPLE_DESIGN_RULES (tabular-picker,
          activity-picker, visual-variation, etc.).
-      3. Fall back to section search across RIPPLE_DESIGN_RULES.
+      3. Section search across RIPPLE_DESIGN_RULES.
+      4. Still nothing — say so, and point at ``get_widget_spec``.
 
-    Errs toward returning too much rather than too little — the agent
-    already paid the round-trip; better to over-deliver than leave it
-    guessing.
+    Step 4 is the important one. This catalog is hand-written design
+    guidance for a *small* set of widgets; the manifest is the source of
+    truth for prop schemas and covers an order of magnitude more. A type
+    this module has never heard of is not a reason to hand back every
+    word it knows — that buries the answer in ~59k characters and still
+    doesn't contain it. An honest miss is shorter AND more useful,
+    because it names the tool that can answer.
     """
     if not types:
         return RIPPLE_DESIGN_RULES
@@ -54,7 +72,7 @@ def widget_help(types: list[str] | None = None) -> str:
 
     parts: list[str] = []
     unresolved: set[str] = set()
-    for t in wanted:
+    for t in sorted(wanted):
         if t in WIDGET_SHAPES:
             parts.append(WIDGET_SHAPES[t])
         elif t in OPTIONAL_DESIGN_SECTIONS:
@@ -64,12 +82,30 @@ def widget_help(types: list[str] | None = None) -> str:
 
     if unresolved:
         # Section search across RIPPLE_DESIGN_RULES for any type we
-        # couldn't resolve directly.
-        sections = _split_sections(RIPPLE_DESIGN_RULES)
-        for sect in sections:
-            body = sect.lower()
-            if any(t in body for t in unresolved):
+        # couldn't resolve directly. Two changes from the original, both
+        # for the same reason — the old search answered the wrong
+        # question:
+        #
+        #  * It matched the type ANYWHERE in a section body, so every
+        #    lookup hit `# WIDGET CATALOG` (a bare list of names) and
+        #    `# CANONICAL SHAPES` (13,479 chars covering every widget).
+        #    Asking about `sparkline` returned 40,177 characters, none of
+        #    which was the sparkline prop schema. That is the documented
+        #    failure this catalog's caller was built to prevent — the
+        #    inline prompt cites `definition-list` shipping with
+        #    `description` instead of `definition`, and a lookup for
+        #    `definition-list` returned exactly two sections that merely
+        #    NAME it. The agent paid the round-trip and still guessed.
+        #    A section now has to name the type in its HEADING to count
+        #    as being about it.
+        #  * It could not tell "a section matched" from "nothing
+        #    matched", so a miss was indistinguishable from a hit.
+        for sect in _split_sections(RIPPLE_DESIGN_RULES):
+            heading = sect.split("\n", 1)[0].lower().replace("_", "-")
+            hits = {t for t in unresolved if t in heading}
+            if hits:
                 parts.append(sect)
+                unresolved -= hits
 
     # Always tack the interactive-state rule on the end. Bindings,
     # {state.x} expressions, and action-chain vocabulary apply to every
@@ -77,8 +113,41 @@ def widget_help(types: list[str] | None = None) -> str:
     # the toolkit alongside any retrieval avoids a follow-up round-trip.
     if parts:
         parts.append(INTERACTIVE_STATE_RULE)
+        if unresolved:
+            # A partial hit still owes the caller the truth about the
+            # half that missed, or it reads as full coverage.
+            parts.append(_unknown_types_note(unresolved))
         return "\n\n".join(parts)
-    return RIPPLE_DESIGN_RULES
+    return _unknown_types_note(wanted)
+
+
+def _unknown_types_note(types: set[str]) -> str:
+    """Report a lookup miss and route to the tool that can answer it.
+
+    Deliberately short. The agent asked a question this catalog cannot
+    answer; the useful reply is "not here, ask over there", not a
+    document dump. The closing line makes a stale manifest pin
+    self-diagnosing: if ``get_widget_spec`` also reports the type
+    unknown, the deployment's manifest genuinely lacks that widget and
+    emitting it would render nothing.
+    """
+    asked = ", ".join(sorted(types))
+    known = ", ".join(sorted(set(WIDGET_SHAPES) | set(OPTIONAL_DESIGN_SECTIONS)))
+    return (
+        f"# NO INLINE DESIGN GUIDANCE FOR: {asked}\n"
+        "\n"
+        "This catalog carries hand-written *design* guidance for a small set of "
+        f"widgets only:\n{known}\n"
+        "\n"
+        "That is not the full widget list — it is the subset with extra design "
+        "notes. For every other widget, call `get_widget_spec(types=[...])`: it "
+        "reads the Ripple manifest and returns the canonical prop schema, which "
+        "is what you need to author a spec.\n"
+        "\n"
+        "If `get_widget_spec` ALSO reports the type as unknown, this deployment's "
+        "manifest does not carry that widget — it would render as nothing. Pick a "
+        "widget the manifest does have."
+    )
 
 
 def _split_sections(text: str) -> list[str]:

--- a/src/pocketpaw/tools/builtin/__init__.py
+++ b/src/pocketpaw/tools/builtin/__init__.py
@@ -30,6 +30,11 @@
 #   - 2026-07-04: Added StockImageTool — search free Pexels/Unsplash stock photos
 #     for Paw Sites imagery (shared search_stock_images() helper; EE MCP surface
 #     for the SDK backend).
+#   - 2026-08-04: Added WidgetSpecTool + InlineWidgetHelpTool. Both tools already
+#     existed on the `pocketpaw_widgets` in-process MCP server, which only
+#     `agents/claude_sdk.py` builds — so every other backend ran without them
+#     while the chat-inline system prompt called one of them MANDATORY before
+#     emitting a non-core widget. Same gap, same fix, as StartFlowTool above.
 
 import importlib as _importlib
 
@@ -100,6 +105,8 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "AddWidgetTool": (".pocket", "AddWidgetTool"),
     "RemoveWidgetTool": (".pocket", "RemoveWidgetTool"),
     "StartFlowTool": (".flow_tool", "StartFlowTool"),
+    "WidgetSpecTool": (".widget_spec", "WidgetSpecTool"),
+    "InlineWidgetHelpTool": (".widget_spec", "InlineWidgetHelpTool"),
     "StepPipelineTool": (".step_pipeline_tool", "StepPipelineTool"),
     "DiscordCLITool": (".discord", "DiscordCLITool"),
     "ConnectorListTool": (".connector_tools", "ConnectorListTool"),

--- a/src/pocketpaw/tools/builtin/flow_tool.py
+++ b/src/pocketpaw/tools/builtin/flow_tool.py
@@ -18,6 +18,17 @@
 #     screens), mirroring the inline-prompt rule (`_inline.py`
 #     `_MULTI_STEP_FLOW_RULE`).
 #
+# Updated: 2026-08-04 (fix/prompt-tells-the-truth — ONE CONTRACT, TWO SURFACES):
+#   - `description` and `parameters` now return `_flows.START_FLOW_DESCRIPTION`
+#     and `_flows.start_flow_parameters()`. They used to be hand-written copies
+#     of the text in `agents/sdk_mcp_widgets.py`, 82.7% similar — and they had
+#     already drifted. THIS copy, the one every runtime backend reads, was the
+#     poorer of the two: it was missing the `set`-stepped anti-pattern, the
+#     "terminal `complete` uses `action:`, never `type:`/`kind:`" rule, the
+#     approve/reject-is-a-call_binding-button rule, and the repair-vs-reject
+#     retry contract. Second split of this pair; the 2026-06-15 SPLIT-BRAIN FIX
+#     was the first. The contract now lives beside the builder that enforces it.
+#
 # A `start_flow`-style builtin tool. The contract that makes it reliable: the
 # agent NEVER hand-writes the recursively-nested chain/chain_map tree — it
 # describes a FLAT graph (impossible to mis-nest), and a DETERMINISTIC builder
@@ -37,9 +48,11 @@ from typing import Any
 
 from pocketpaw.ripple._flows import (
     FLOW_TYPES,
+    START_FLOW_DESCRIPTION,
     FlowBuildError,
     build_flow,
     build_flow_from_descriptor,
+    start_flow_parameters,
 )
 from pocketpaw.tools.protocol import BaseTool
 
@@ -60,51 +73,13 @@ class StartFlowTool(BaseTool):
 
     @property
     def description(self) -> str:
-        return (
-            "Scaffold a complete multi-step flow OR interactive mini-app (a "
-            "wizard, intake, survey, onboarding sequence, or a 'collect "
-            "details then DO something' flow) from a FLAT step-graph. DO NOT "
-            "hand-author nested chain / chain_map step trees — they are fragile "
-            "to write by hand. You describe a flat list of steps; this tool "
-            "materializes the ENTIRE nested, validated flow tree as a "
-            "{version, ui} doc, ready to drop into a ```ui-spec fence. The flow "
-            "then advances entirely client-side with no further model calls "
-            "between steps.\n\n"
-            "AUTHOR A FLAT GRAPH (think in states, not screens):\n"
-            "- `flow`: a stable id for the flow (e.g. 'vendor_intake').\n"
-            "- `entry`: the id of the first step.\n"
-            "- `steps`: a list. Each step has an `id`, a `kind` "
-            "(select | form | confirm | info), a `title`, its content "
-            "(`options` for select, `fields` for form, `review` for confirm, "
-            "`body` for info), and where it goes next:\n"
-            '    * `next: "<id>"` — linear next step;\n'
-            '    * `branch: { "<optionId>": "<id>" }` — branch on the '
-            "picked option.\n"
-            "  A step with NEITHER `next` nor `branch` is the TERMINAL step and "
-            "carries `complete` (what to do with the answers):\n"
-            "    chat → hand the answers back to you (default); navigate / emit "
-            "→ go somewhere / raise an event; call_binding → write to the "
-            "backend; create_pocket → materialize a permanent pocket; "
-            "invoke_tool → run a tool (may be unavailable until the tool "
-            "registry ships).\n"
-            "- Per-step `actions` (optional) are buttons that call a "
-            "tool/API/binding MID-FLOW without leaving the step (verb: "
-            "call_binding | api | invoke_tool).\n"
-            "- Reference earlier answers with `{stepId.field}` "
-            "(e.g. `{pick_goal.label}`, `{enter_details.company}`) in review "
-            "rows and action args — this tool rewrites them correctly; you "
-            "NEVER write the raw `{state.…_selection/_formData}` form.\n\n"
-            "The builder REJECTS any graph that would dead-end (a select step "
-            "that goes nowhere, a dangling transition, a missing terminal, an "
-            "unknown verb) with a precise error you can fix and retry.\n\n"
-            "PRESET SHORTHAND (optional): instead of `steps`, you may pass a "
-            "`flow_type` for one of the two known shapes — 'onboarding_wizard' "
-            "or 'due_diligence_intake' — plus an optional `config` for copy "
-            "tweaks. The flat `steps` graph is the general path; `flow_type` is "
-            "a convenience for those two exact shapes.\n\n"
-            "Returns the JSON doc to emit. Wrap it verbatim in a ```ui-spec "
-            "fence in your reply — do not edit the chain / chain_map structure."
-        )
+        # Shared with the SDK MCP surface (``agents/sdk_mcp_widgets.py``). This
+        # used to be a second hand-written copy that had already drifted: it was
+        # missing the `set`-stepped anti-pattern, the "`action:` never
+        # `type:`/`kind:`" rule, the approve/reject-is-a-call_binding-button
+        # rule, and the repair-vs-reject retry contract. Every runtime backend
+        # read the weaker text. See ``_flows.START_FLOW_DESCRIPTION``.
+        return START_FLOW_DESCRIPTION
 
     @property
     def trust_level(self) -> str:
@@ -112,84 +87,10 @@ class StartFlowTool(BaseTool):
 
     @property
     def parameters(self) -> dict[str, Any]:
-        return {
-            "type": "object",
-            "properties": {
-                "flow": {
-                    "type": "string",
-                    "description": (
-                        "A stable id for the flow (e.g. 'vendor_intake'). Seeds "
-                        "each step's flowId namespace. Required when authoring a "
-                        "flat `steps` graph."
-                    ),
-                },
-                "entry": {
-                    "type": "string",
-                    "description": (
-                        "The id of the FIRST step (must exist in `steps`). "
-                        "Required when authoring a flat `steps` graph."
-                    ),
-                },
-                "steps": {
-                    "type": "array",
-                    "items": {"type": "object"},
-                    "description": (
-                        "The flat step-graph: a list of step objects. Each step "
-                        "has `id`, `kind` (select | form | confirm | info), "
-                        "`title`, its kind-specific content (`options` / "
-                        "`fields` / `review` / `body`), and a transition "
-                        "(`next` or `branch`) — OR `complete` if it is the "
-                        "terminal step. Optional per-step `actions` run a "
-                        "tool/API mid-flow. This is the general authoring path."
-                    ),
-                },
-                "title": {
-                    "type": "string",
-                    "description": "Optional title shown on the flow frame.",
-                },
-                "complete": {
-                    "type": "object",
-                    "description": (
-                        "Optional flow-level terminal default — the `complete` "
-                        "action a terminal step inherits when it declares none "
-                        "of its own (e.g. {action:'chat', message:'…'})."
-                    ),
-                },
-                "flow_type": {
-                    "type": "string",
-                    "enum": list(FLOW_TYPES),
-                    "description": (
-                        "OPTIONAL preset shorthand for the two known shapes "
-                        "('onboarding_wizard' | 'due_diligence_intake') instead "
-                        "of authoring a flat `steps` graph. The builder owns the "
-                        "full nested tree for this preset."
-                    ),
-                },
-                "domain": {
-                    "type": "string",
-                    "description": (
-                        "Optional domain hint (e.g. 'fintech', 'saas') for the "
-                        "preset path. Reserved for a future data-fresh "
-                        "materialization path; does not change the tree today."
-                    ),
-                },
-                "config": {
-                    "type": "object",
-                    "description": (
-                        "Optional per-preset copy overrides (preset path only). "
-                        "Shape-stable: tweaks labels/text, never the chain "
-                        "structure. onboarding_wizard accepts {product_name, "
-                        "goals, complete_message}; due_diligence_intake accepts "
-                        "{company_name, complete_message}."
-                    ),
-                },
-            },
-            # Nothing is hard-required at the schema level: the general path
-            # needs flow+entry+steps, the preset path needs flow_type. `execute`
-            # validates the combination and returns an agent-readable error when
-            # neither is supplied.
-            "required": [],
-        }
+        # Shared with the SDK MCP surface — see the description note above.
+        # The schema was the second copy: same seven properties, written out
+        # twice, with the ``flow_type`` enum read from FLOW_TYPES in both.
+        return start_flow_parameters()
 
     async def execute(
         self,

--- a/src/pocketpaw/tools/builtin/widget_spec.py
+++ b/src/pocketpaw/tools/builtin/widget_spec.py
@@ -1,0 +1,214 @@
+# pocketpaw/tools/builtin/widget_spec.py — `get_widget_spec` +
+# `get_inline_widget_help` as RUNTIME builtin tools.
+#
+# Created: 2026-08-04 (fix/prompt-tells-the-truth).
+#
+# WHY THIS FILE EXISTS. Both tools already shipped — on the in-process MCP
+# server `pocketpaw_widgets` (`agents/sdk_mcp_widgets.py`), which is built in
+# exactly one place: `agents/claude_sdk.py`. Every other backend runs without
+# them.
+#
+# That would be an ordinary gap except the chat-inline system prompt makes
+# calling one of them MANDATORY:
+#
+#     "Before the FIRST node of any non-core type lands in your spec, you MUST
+#      call `get_inline_widget_help(types=[...])` … there is no excuse to skip
+#      it."
+#
+# followed by "If the tool returns an error, OMIT the widget rather than
+# guess." On a backend where the tool is absent rather than erroring, the
+# agent's only consistent reading is to omit — so the deployment silently
+# loses every widget outside the core six. The instruction was right; the
+# tool was unreachable. `start_flow` had the identical problem and was fixed
+# the identical way (`flow_tool.py`), which is the precedent this follows.
+#
+# WHICH TOOL ANSWERS WHICH QUESTION. They are not interchangeable, and the
+# prompt block above named the weaker one:
+#
+#   get_widget_spec          reads the Ripple MANIFEST. Returns the canonical
+#                            prop schema for any widget in it. 664–1,425 chars
+#                            measured across definition-list / sparkline /
+#                            gauge / kanban / timeline / navbar.
+#   get_inline_widget_help   reads a hand-written design-guidance catalog
+#                            covering 16 widgets. Returns layout and
+#                            composition advice, not a schema.
+#
+# For `definition-list` — the widget the prompt itself cites as having shipped
+# broken, with `description` where the schema says `definition` —
+# get_widget_spec returns the 759-char schema that names the field, while
+# get_inline_widget_help returned 18,623 characters that never did. Prop names
+# come from the manifest; design guidance comes from the catalog.
+
+from __future__ import annotations
+
+from typing import Any
+
+from pocketpaw.tools.protocol import BaseTool
+
+
+class WidgetSpecTool(BaseTool):
+    """Return the manifest prop schema for one or more Ripple widgets.
+
+    The authoritative answer to "what props does this widget take" — it reads
+    the same manifest the renderer does, so a schema it returns is a schema
+    that renders, and a type it rejects is a type this deployment cannot draw.
+    """
+
+    @property
+    def name(self) -> str:
+        return "get_widget_spec"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Get the canonical prop schema, types, and a runnable example for "
+            "one or more Ripple widgets, straight from the widget manifest. "
+            "Pass `types` as an array of widget type names (e.g. "
+            "['definition-list', 'timeline', 'sparkline']) — batch them in a "
+            "single call. MANDATORY before you emit any widget whose props you "
+            "have not been shown: the widget's NAME is not a contract, the "
+            "manifest is, and guessed prop names render as empty rows. If this "
+            "tool reports a type as unknown, this deployment's manifest does "
+            "not carry that widget — do not emit it, pick one the manifest has."
+        )
+
+    @property
+    def trust_level(self) -> str:
+        return "standard"
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "types": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "Widget type names to look up, e.g. "
+                        "['chart', 'definition-list']. Required and non-empty."
+                    ),
+                },
+            },
+            "required": ["types"],
+        }
+
+    async def execute(self, types: list[str] | str | None = None, **kwargs: Any) -> str:
+        """Look the requested types up in the manifest.
+
+        Mirrors ``sdk_mcp_widgets._get_widget_spec_handler`` so the SDK backend
+        and every runtime backend answer the same question identically. Reuses
+        the shared JSON-string coercion for the same reason it exists there:
+        a model that cannot pass an array through a flat signature sends
+        ``'["chart"]'``, and treating that as a single type name named a widget
+        nobody has.
+        """
+        from pocketpaw.agents.mcp_arg_coercion import coerce_json_object_args
+        from pocketpaw.config import get_settings
+        from pocketpaw.ripple.manifest import format_for_prompt, get_manifest
+
+        coerced = coerce_json_object_args({"types": types}, ("types",))
+        raw = coerced.get("types") or []
+        if isinstance(raw, str):
+            raw = [raw]
+        requested = [t for t in raw if isinstance(t, str) and t.strip()]
+        if not requested:
+            return self._error("Pass `types` as a non-empty array of widget type names.")
+
+        settings = get_settings()
+        manifest = await get_manifest(
+            settings.ripple_manifest_url,
+            ttl_seconds=settings.ripple_manifest_ttl_seconds,
+        )
+        if manifest is None:
+            return self._error(
+                "Ripple manifest unavailable — cannot verify prop schemas. "
+                "Stick to core widgets (text, heading, stat, button, table, flex) "
+                "rather than guessing props for anything else."
+            )
+
+        by_type = {w.get("type"): w for w in (manifest.get("widgets") or []) if w.get("type")}
+        matched = [by_type[t] for t in requested if t in by_type]
+        missing = [t for t in requested if t not in by_type]
+
+        if not matched:
+            # Naming the misses is the whole value here: it is how a stale
+            # manifest pin becomes visible instead of producing a widget that
+            # renders as nothing.
+            return self._error(
+                f"No such widget(s) in this deployment's manifest: {', '.join(missing)}. "
+                "Do not emit them — they would render as nothing. Pick a widget the "
+                "manifest carries."
+            )
+
+        block = format_for_prompt({"widgets": matched})
+        if missing:
+            block += f"\n\n_Not in this deployment's manifest, do not emit: {', '.join(missing)}_"
+        return self._success(block)
+
+
+class InlineWidgetHelpTool(BaseTool):
+    """Return hand-written design guidance for the widgets that have it.
+
+    Distinct from :class:`WidgetSpecTool`: this is composition and layout
+    advice for 16 widgets, not a prop schema. A miss returns a short note
+    pointing at ``get_widget_spec`` rather than the whole catalog.
+    """
+
+    @property
+    def name(self) -> str:
+        return "get_inline_widget_help"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Get hand-written DESIGN guidance (layout, composition, visual "
+            "variation) for chat-inline Ripple widgets. Covers a small set of "
+            "high-traffic widgets; for a widget it does not cover it will say "
+            "so and send you to `get_widget_spec`. Use this for 'how should "
+            "this look' — use `get_widget_spec` for 'what props does this "
+            "take'. Called with no `types` it returns the entire design "
+            "rulebook, which is large: pass the types you actually need."
+        )
+
+    @property
+    def trust_level(self) -> str:
+        return "standard"
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "types": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "Widget kinds you plan to use, e.g. ['chart', 'kanban']. "
+                        "Omit to get the full design rulebook (large — prefer "
+                        "naming types)."
+                    ),
+                },
+            },
+        }
+
+    async def execute(self, types: list[str] | str | None = None, **kwargs: Any) -> str:
+        from pocketpaw.agents.mcp_arg_coercion import coerce_json_object_args
+        from pocketpaw.ripple._inline_core import widget_help
+        from pocketpaw.tools.output_budget import cap_tool_output
+
+        coerced = coerce_json_object_args({"types": types}, ("types",))
+        raw = coerced.get("types") or []
+        if isinstance(raw, str):
+            raw = [raw]
+        if not isinstance(raw, list):
+            raw = []
+        body = widget_help([str(t) for t in raw])
+        # NOT ``_success``. Its default 12,000-char cap sits BELOW a legitimate
+        # single-widget payload — `chart` guidance is 14,699 chars — and a
+        # head+tail slice of a prop schema is the guessed-prop-name failure this
+        # tool exists to prevent, arriving by a different route. 20,000 clears
+        # every measured per-type lookup untouched (largest: 14,699) while still
+        # bounding the one call that can run away: `types=[]`, which is
+        # documented as rare and returns the entire 58,765-char rulebook.
+        return cap_tool_output(body, cap=20_000, tool_name=self.name)

--- a/src/pocketpaw/tools/cli.py
+++ b/src/pocketpaw/tools/cli.py
@@ -54,6 +54,7 @@ from pocketpaw.tools.builtin import (
     GmailTrashTool,
     HealthCheckTool,
     ImageGenerateTool,
+    InlineWidgetHelpTool,
     ListSessionsTool,
     NewSessionTool,
     OCRTool,
@@ -77,6 +78,7 @@ from pocketpaw.tools.builtin import (
     TranslateTool,
     UrlExtractTool,
     WebSearchTool,
+    WidgetSpecTool,
 )
 
 # All tools available via CLI (excluding shell/filesystem — those are SDK built-in)
@@ -136,6 +138,8 @@ _TOOLS = {
         AddWidgetTool(),
         RemoveWidgetTool(),
         StartFlowTool(),
+        WidgetSpecTool(),
+        InlineWidgetHelpTool(),
         ConnectorListTool(),
         ConnectorActionsTool(),
         ConnectorConnectTool(),

--- a/tests/cloud/test_agent_service_tools_context.py
+++ b/tests/cloud/test_agent_service_tools_context.py
@@ -793,13 +793,23 @@ def _session_ctx() -> ScopeContext:
 
 
 def _force_settings(monkeypatch, **overrides):
-    """Make ``Settings.load()`` return a controlled instance for the
-    Composio gating checks inside ``build_behavior_instructions``.
+    """Make the config read return a controlled instance for the Composio
+    gating checks inside ``build_behavior_instructions``.
 
     Clears the Composio env vars first so the result depends only on the
     explicit overrides, not on whatever the host machine has exported.
+
+    Patches ``Settings.load`` AND drops the ``get_settings`` cache, because
+    production reads through the cached accessor. Patching ``load`` alone used
+    to be equivalent; it stopped being equivalent when ``composio.is_enabled``
+    moved to ``get_settings()`` (the 115 ms-per-turn ``Settings.load`` fix), and
+    the helper silently kept handing back a value nothing read — the disabled
+    case then asserted "no Composio rules" against a machine that had Composio
+    credentials exported. Clearing the cache after the patch makes the next read
+    go through the patched ``load`` again. ``_isolate_settings_cache`` below
+    handles the teardown half.
     """
-    from pocketpaw.config import Settings
+    from pocketpaw.config import Settings, get_settings
 
     for var in (
         "POCKETPAW_COMPOSIO_API_KEY",
@@ -809,7 +819,34 @@ def _force_settings(monkeypatch, **overrides):
         monkeypatch.delenv(var, raising=False)
     s = Settings(_env_file=None, **overrides)
     monkeypatch.setattr(Settings, "load", classmethod(lambda cls: s))
+    get_settings.cache_clear()
     return s
+
+
+@pytest.fixture(autouse=True)
+def _isolate_settings_cache():
+    """Keep one test's forced ``Settings`` out of every later test.
+
+    ``get_settings`` is process-wide and ``lru_cache``d, so a controlled
+    instance installed by ``_force_settings`` outlives the monkeypatch that
+    created it — the patch on ``Settings.load`` is undone, but the cached
+    OBJECT it produced is not. That is an order-dependent failure: the suite
+    passes file-by-file and fails as a whole, or vice versa.
+
+    NOT MUTATION-PROVEN, deliberately recorded as such. Removing this fixture
+    escapes ``tests/mutations/prompt_truth.json`` — and correctly so, because
+    what it protects is the NEXT file in the process, and that harness runs one
+    file at a time. ``_force_settings`` clears the cache itself, which is what
+    makes this file's own tests pass without the fixture. Rather than invent a
+    weak assertion that would "prove" it, the honest note: this is teardown
+    hygiene, its value is cross-file, and the repo convention of naming a
+    verified mutation does not apply to it.
+    """
+    from pocketpaw.config import get_settings
+
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
 
 
 def test_composio_rules_injected_when_enabled_without_toolkits(monkeypatch):
@@ -858,6 +895,143 @@ def test_composio_rules_omitted_when_disabled(monkeypatch):
     assert "<composio-auth-flow>" not in block
     assert "<composio-search-fallback>" not in block
     assert "<runtime-identity>" in block
+
+
+# ── Composio rules are gated on the BACKEND, not just the credentials ────────
+#
+# The gate above answers "does this deployment have Composio?". It did not ask
+# "does THIS BACKEND get Composio tools?", and the two are not the same
+# question. ``providers.py`` builds tools for four backend kinds; this
+# deployment runs a fifth (``pydantic_ai``), which gets none. So 2,516
+# characters describing a Gmail/Slack/GitHub tool surface rode in every turn,
+# naming tools that were not on the wire.
+#
+# The cost is not context. An agent told it has those integrations tells the
+# USER it has them, and a user who asks it to read their mail gets a four-step
+# OAuth walkthrough ending at a tool that does not exist. Wrong capability
+# claims are worse than absent ones.
+#
+# The two rules are gated separately because their tool sets differ:
+# ``initiate_connection`` / ``verify_connection`` are built only for the Claude
+# SDK backend, while the search meta-tools reach all four supported kinds.
+#
+# EACH TEST NAMES THE MUTATION THAT BREAKS IT, and every one was applied, run,
+# observed to fail, and reverted (``scripts/mutate.py``).
+
+
+def _enabled_composio(monkeypatch):
+    return _force_settings(
+        monkeypatch,
+        composio_api_key="ck_test",
+        composio_enterprise_id="ent_acme",
+        composio_toolkits=[],
+    )
+
+
+def test_force_settings_takes_effect_on_a_second_call(monkeypatch):
+    """The reason ``_force_settings`` clears the cache itself.
+
+    ``_isolate_settings_cache`` clears once per test, which covers the common
+    single-call shape — so a mutation removing the helper's own clear escaped
+    at first. It only bites on a SECOND call: the first read populates the
+    cache, and without a clear the second forced value is never seen. That is
+    a silent wrong-answer bug in a helper whose whole job is controlling the
+    answer, and it would land on whoever next writes a test that toggles
+    Composio on and off in one function.
+
+    THE MUTATION THAT BREAKS THIS: drop ``get_settings.cache_clear()`` from
+    ``_force_settings``. Run: the second read returned the first instance and
+    this failed. (Applied 2026-08-04.)
+    """
+    from pocketpaw_ee.cloud.composio import service as composio_service
+
+    _force_settings(monkeypatch)
+    assert composio_service.is_enabled() is False
+
+    _force_settings(monkeypatch, composio_api_key="ck_test", composio_enterprise_id="ent_acme")
+    assert composio_service.is_enabled() is True, (
+        "the second _force_settings did not take effect — a stale cached Settings outlived it"
+    )
+
+
+def test_composio_rules_omitted_on_a_backend_with_no_composio_tools(monkeypatch):
+    """Credentials present, but ``pydantic_ai`` receives no Composio tools.
+
+    THE MUTATION THAT BREAKS THIS: drop the ``supports_composio_tools`` /
+    ``supports_connection_tools`` conditions and gate on ``is_enabled()``
+    alone. Run: both blocks were injected and this failed. (Applied
+    2026-08-04.)
+    """
+    from pocketpaw_ee.cloud.chat.agent_service import build_behavior_instructions
+
+    _enabled_composio(monkeypatch)
+    block = build_behavior_instructions(_session_ctx(), backend_name="pydantic_ai")
+    assert "<composio-auth-flow>" not in block, (
+        "the auth flow names initiate_connection / verify_connection, which this "
+        "backend does not have"
+    )
+    assert "<composio-search-fallback>" not in block, (
+        "the search fallback names COMPOSIO_SEARCH_TOOLS, which this backend does not have"
+    )
+
+
+def test_auth_flow_omitted_on_a_backend_with_tools_but_no_auth_wrapper(monkeypatch):
+    """The narrow middle case, and the reason the two rules gate separately.
+
+    ``openai_agents`` DOES get Composio's concrete action tools, so the search
+    fallback is honest there — but the connection wrappers were only ever
+    written for the Claude SDK, so the auth flow is not.
+
+    THE MUTATION THAT BREAKS THIS: gate the auth flow on
+    ``supports_composio_tools`` instead of ``supports_connection_tools``. Run:
+    the auth flow appeared for openai_agents and this failed. (Applied
+    2026-08-04.)
+    """
+    from pocketpaw_ee.cloud.chat.agent_service import build_behavior_instructions
+
+    _enabled_composio(monkeypatch)
+    block = build_behavior_instructions(_session_ctx(), backend_name="openai_agents")
+    assert "<composio-auth-flow>" not in block
+    assert "<composio-search-fallback>" in block
+
+
+def test_the_prompt_gate_reads_the_same_source_as_the_tool_builder(monkeypatch):
+    """The gate must not be a second, hand-maintained copy of the backend list.
+
+    A duplicated list is how this drifts back: someone adds an openai_agents
+    auth wrapper, and the prompt keeps withholding the block because nobody
+    remembered a second file. Both predicates live in ``providers.py`` next to
+    the code that builds the tools.
+
+    THE MUTATION THAT BREAKS THIS: add ``pydantic_ai`` to
+    ``CONNECTION_TOOL_BACKENDS``. Run: the auth flow appeared for pydantic_ai
+    and this failed — which is the point: widening the tool set widens the
+    prompt, automatically. (Applied 2026-08-04.)
+    """
+    from pocketpaw_ee.cloud.chat.agent_service import build_behavior_instructions
+    from pocketpaw_ee.cloud.composio import providers
+
+    _enabled_composio(monkeypatch)
+    for backend in ("claude_agent_sdk", "openai_agents", "google_adk", "pydantic_ai"):
+        block = build_behavior_instructions(_session_ctx(), backend_name=backend)
+        assert ("<composio-auth-flow>" in block) is providers.supports_connection_tools(backend)
+        assert ("<composio-search-fallback>" in block) is providers.supports_composio_tools(backend)
+
+
+def test_an_unknown_backend_name_gets_no_composio_claims(monkeypatch):
+    """Fail closed. An unrecognised backend is one whose tool surface we cannot
+    vouch for, so it must not be told it has integrations.
+
+    THE MUTATION THAT BREAKS THIS: make ``supports_composio_tools`` return True
+    for anything not explicitly excluded. Run: failed. (Applied 2026-08-04.)
+    """
+    from pocketpaw_ee.cloud.chat.agent_service import build_behavior_instructions
+
+    _enabled_composio(monkeypatch)
+    for backend in (None, "", "some_future_backend"):
+        block = build_behavior_instructions(_session_ctx(), backend_name=backend)
+        assert "<composio-auth-flow>" not in block
+        assert "<composio-search-fallback>" not in block
 
 
 @pytest.mark.asyncio

--- a/tests/mutations/prompt_truth.json
+++ b/tests/mutations/prompt_truth.json
@@ -1,0 +1,107 @@
+[
+  {
+    "label": "widget_help miss returns the whole 58,765-char rulebook again",
+    "file": "src/pocketpaw/ripple/_inline_core.py",
+    "find": "    return _unknown_types_note(wanted)",
+    "replace": "    return RIPPLE_DESIGN_RULES",
+    "tests": ["tests/test_widget_help_lookup.py"]
+  },
+  {
+    "label": "tier 3 matches the section BODY again, so every lookup hits WIDGET CATALOG",
+    "file": "src/pocketpaw/ripple/_inline_core.py",
+    "find": "            heading = sect.split(\"\\n\", 1)[0].lower().replace(\"_\", \"-\")\n            hits = {t for t in unresolved if t in heading}",
+    "replace": "            heading = sect.lower()\n            hits = {t for t in unresolved if t in heading}",
+    "tests": ["tests/test_widget_help_lookup.py"]
+  },
+  {
+    "label": "a partial hit stops reporting the half that missed",
+    "file": "src/pocketpaw/ripple/_inline_core.py",
+    "find": "            parts.append(_unknown_types_note(unresolved))",
+    "replace": "            unresolved = unresolved",
+    "tests": ["tests/test_widget_help_lookup.py"]
+  },
+  {
+    "label": "the miss note stops naming the type that missed",
+    "file": "src/pocketpaw/ripple/_inline_core.py",
+    "find": "        f\"# NO INLINE DESIGN GUIDANCE FOR: {asked}\\n\"",
+    "replace": "        \"# NO INLINE DESIGN GUIDANCE\\n\"",
+    "tests": ["tests/test_widget_help_lookup.py"]
+  },
+  {
+    "label": "the miss note stops routing to get_widget_spec",
+    "file": "src/pocketpaw/ripple/_inline_core.py",
+    "find": "        \"notes. For every other widget, call `get_widget_spec(types=[...])`: it \"\n        \"reads the Ripple manifest and returns the canonical prop schema, which \"\n        \"is what you need to author a spec.\\n\"",
+    "replace": "        \"notes.\\n\"",
+    "tests": ["tests/test_widget_help_lookup.py"]
+  },
+  {
+    "label": "the miss note stops explaining what an unknown type means",
+    "file": "src/pocketpaw/ripple/_inline_core.py",
+    "find": "manifest does not carry that widget",
+    "replace": "manifest may lack that widget",
+    "tests": ["tests/test_widget_help_lookup.py"]
+  },
+  {
+    "label": "the MUST-CALL block points back at get_inline_widget_help",
+    "file": "src/pocketpaw/ripple/_inline.py",
+    "find": "call `get_widget_spec(types=[...])` and copy prop names FROM the",
+    "replace": "call `get_inline_widget_help(types=[...])` and copy prop names FROM the",
+    "tests": ["tests/test_prompt_names_only_real_tools.py"]
+  },
+  {
+    "label": "the block stops distinguishing the two widget tools",
+    "file": "src/pocketpaw/ripple/_inline.py",
+    "find": "`get_inline_widget_help` is a DIFFERENT tool and does not answer this\nquestion.",
+    "replace": "Widget help is available.",
+    "tests": ["tests/test_prompt_names_only_real_tools.py"]
+  },
+  {
+    "label": "get_widget_spec is dropped from the runtime builtin registry",
+    "file": "src/pocketpaw/tools/cli.py",
+    "find": "        WidgetSpecTool(),\n",
+    "replace": "",
+    "tests": ["tests/test_prompt_names_only_real_tools.py"]
+  },
+  {
+    "label": "the widget tools go unclassified, so pydantic_ai withholds them",
+    "file": "src/pocketpaw/agents/pydantic_ai.py",
+    "find": "        \"get_widget_spec\",\n        \"get_inline_widget_help\",\n",
+    "replace": "",
+    "tests": ["tests/test_prompt_names_only_real_tools.py"]
+  },
+  {
+    "label": "composio rules go back to gating on credentials alone",
+    "file": "ee/pocketpaw_ee/cloud/chat/agent_service.py",
+    "find": "        if _composio_providers.supports_connection_tools(backend_name):\n            parts.append(_COMPOSIO_AUTH_FLOW_RULE)\n        if _composio_providers.supports_composio_tools(backend_name):\n            parts.append(_COMPOSIO_SEARCH_FALLBACK_RULE)",
+    "replace": "        parts.append(_COMPOSIO_AUTH_FLOW_RULE)\n        parts.append(_COMPOSIO_SEARCH_FALLBACK_RULE)",
+    "tests": ["tests/cloud/test_agent_service_tools_context.py"]
+  },
+  {
+    "label": "the auth flow is gated on the wider predicate",
+    "file": "ee/pocketpaw_ee/cloud/chat/agent_service.py",
+    "find": "        if _composio_providers.supports_connection_tools(backend_name):",
+    "replace": "        if _composio_providers.supports_composio_tools(backend_name):",
+    "tests": ["tests/cloud/test_agent_service_tools_context.py"]
+  },
+  {
+    "label": "CONNECTION_TOOL_BACKENDS is widened without a wrapper existing",
+    "file": "ee/pocketpaw_ee/cloud/composio/providers.py",
+    "find": "CONNECTION_TOOL_BACKENDS: frozenset[str] = frozenset({BACKEND_CLAUDE_SDK})",
+    "replace": "CONNECTION_TOOL_BACKENDS: frozenset[str] = frozenset({BACKEND_CLAUDE_SDK, \"pydantic_ai\"})",
+    "tests": ["tests/cloud/test_agent_service_tools_context.py"]
+  },
+  {
+    "label": "supports_composio_tools fails OPEN for an unknown backend",
+    "file": "ee/pocketpaw_ee/cloud/composio/providers.py",
+    "find": "    \"\"\"Whether ``backend_kind`` receives ANY Composio tools at all.\"\"\"\n    return backend_kind in SUPPORTED_BACKENDS",
+    "replace": "    \"\"\"Whether ``backend_kind`` receives ANY Composio tools at all.\"\"\"\n    return backend_kind not in {\"definitely_not_a_backend\"}",
+    "tests": ["tests/cloud/test_agent_service_tools_context.py"]
+  },
+  {
+    "label": "_force_settings stops clearing the get_settings cache",
+    "file": "tests/cloud/test_agent_service_tools_context.py",
+    "find": "    monkeypatch.setattr(Settings, \"load\", classmethod(lambda cls: s))\n    get_settings.cache_clear()\n    return s",
+    "replace": "    monkeypatch.setattr(Settings, \"load\", classmethod(lambda cls: s))\n    return s",
+    "tests": ["tests/cloud/test_agent_service_tools_context.py"]
+  }
+]

--- a/tests/mutations/start_flow_contract.json
+++ b/tests/mutations/start_flow_contract.json
@@ -1,0 +1,79 @@
+[
+  {
+    "label": "the SDK surface gets its own description literal again",
+    "file": "src/pocketpaw/agents/sdk_mcp_widgets.py",
+    "find": "        from pocketpaw.ripple._flows import START_FLOW_DESCRIPTION\n\n        return START_FLOW_DESCRIPTION",
+    "replace": "        return \"Scaffold a multi-step flow from a flat step-graph.\"",
+    "tests": ["tests/test_start_flow_contract_is_shared.py"]
+  },
+  {
+    "label": "the SDK surface gets its own schema literal again",
+    "file": "src/pocketpaw/agents/sdk_mcp_widgets.py",
+    "find": "        from pocketpaw.ripple._flows import start_flow_parameters\n\n        return start_flow_parameters()",
+    "replace": "        return {\"type\": \"object\", \"properties\": {\"steps\": {\"type\": \"array\"}}, \"required\": []}",
+    "tests": ["tests/test_start_flow_contract_is_shared.py"]
+  },
+  {
+    "label": "start_flow_parameters returns a cached shared mutable",
+    "file": "src/pocketpaw/ripple/_flows.py",
+    "find": "def start_flow_parameters() -> dict[str, Any]:",
+    "replace": "@lru_cache(maxsize=1)\ndef start_flow_parameters() -> dict[str, Any]:",
+    "tests": ["tests/test_start_flow_contract_is_shared.py"]
+  },
+  {
+    "label": "the flow_type enum is hardcoded instead of read from FLOW_TYPES",
+    "file": "src/pocketpaw/ripple/_flows.py",
+    "find": "                \"enum\": list(FLOW_TYPES),",
+    "replace": "                \"enum\": [\"onboarding_wizard\"],",
+    "tests": ["tests/test_start_flow_contract_is_shared.py"]
+  },
+  {
+    "label": "the set-stepped anti-pattern is dropped from the shared contract",
+    "file": "src/pocketpaw/ripple/_flows.py",
+    "find": "    \"hand-author nested chain / chain_map step trees and DO NOT fake a \"\n    \"flow with a single `set`-stepped spec — both render only the first \"\n    \"step and dead-end. You describe a flat list of steps; this tool \"",
+    "replace": "    \"hand-author nested chain / chain_map step trees. You describe a flat list of steps; this tool \"",
+    "tests": ["tests/test_start_flow_contract_is_shared.py"]
+  },
+  {
+    "label": "the action-vs-type rule is dropped from the shared contract",
+    "file": "src/pocketpaw/ripple/_flows.py",
+    "find": "    \"create_pocket | invoke_tool) — NEVER `type:`/`kind:`:\\n\"",
+    "replace": "    \"create_pocket | invoke_tool):\\n\"",
+    "tests": ["tests/test_start_flow_contract_is_shared.py"]
+  },
+  {
+    "label": "the approve/reject-is-an-action-button rule is dropped",
+    "file": "src/pocketpaw/ripple/_flows.py",
+    "find": "    \"reject / fulfill / take action — that is a `call_binding` ACTION \"\n    \"BUTTON wired to the verb, not a yes/no select.\\n\"",
+    "replace": "    \"reject / fulfill / take action, handle it in the flow.\\n\"",
+    "tests": ["tests/test_start_flow_contract_is_shared.py"]
+  },
+  {
+    "label": "the repair-vs-reject retry contract is dropped",
+    "file": "src/pocketpaw/ripple/_flows.py",
+    "find": "    \"The builder REPAIRS recoverable slips (a missing terminal \"",
+    "replace": "    \"The builder handles slips (a missing terminal \"",
+    "tests": ["tests/test_start_flow_contract_is_shared.py"]
+  },
+  {
+    "label": "the tool returns a COPY of the contract instead of the constant",
+    "file": "src/pocketpaw/tools/builtin/flow_tool.py",
+    "find": "        return START_FLOW_DESCRIPTION",
+    "replace": "        return \"\".join(list(START_FLOW_DESCRIPTION))",
+    "tests": ["tests/test_start_flow_contract_is_shared.py"]
+  },
+  {
+    "label": "the prompt restates the transition keys the schema owns",
+    "file": "src/pocketpaw/ripple/_inline.py",
+    "find": "HOW TO AUTHOR: think in states, not screens. `start_flow`'s own schema",
+    "replace": "HOW TO AUTHOR (think in states, not screens):\n  steps: a list. Each step has an `id`, a `kind`\n    (select | form | confirm | info), a title, its content\n    (options / fields / review rows), and where it goes next:\n      - `next: \"<id>\"`        → linear next step\n      - `branch: { \"<optId>\": \"<id>\" }` → branch on the picked option\nOLD BLOCK RESTORED. `start_flow`'s own schema",
+    "tests": ["tests/test_start_flow_contract_is_shared.py"]
+  },
+  {
+    "label": "deduplication deletes a worked skeleton the prompt alone had",
+    "file": "src/pocketpaw/ripple/_inline.py",
+    "find": "SKELETON C — APPROVE / REJECT (the buttons ARE the action, not a select):",
+    "replace": "SKELETON_REMOVED — APPROVE / REJECT:",
+    "tests": ["tests/test_start_flow_contract_is_shared.py"]
+  }
+]

--- a/tests/test_prompt_names_only_real_tools.py
+++ b/tests/test_prompt_names_only_real_tools.py
@@ -1,0 +1,183 @@
+# tests/test_prompt_names_only_real_tools.py — a prompt may not command a tool
+# the agent does not have.
+# Created: 2026-08-04 (fix/prompt-tells-the-truth).
+#
+# WHAT THIS CAUGHT. The chat-inline system prompt carried a block titled
+# ``# MUST CALL BEFORE EMIT`` that read, in part, "you MUST call
+# `get_inline_widget_help(types=[...])` … there is no excuse to skip it",
+# closing with "if the tool returns an error, OMIT the widget rather than
+# guess."
+#
+# That tool lives on the ``pocketpaw_widgets`` in-process MCP server, which is
+# constructed in exactly one file — ``agents/claude_sdk.py``. Every other
+# backend, this deployment's ``pydantic_ai`` included, ran without it. The tool
+# did not error; it was absent. The agent's only consistent reading of an
+# unsatisfiable precondition was the stated fallback, so the deployment quietly
+# lost every widget outside the core six, which is the opposite of what the
+# block was written to achieve.
+#
+# WHY A CONTRACT AND NOT A FIX. The specific defect is one line. The CLASS is
+# that prompt text and tool wiring live in different files, are edited by
+# different changes, and nothing compares them — so the prompt drifts into
+# commanding tools that no longer exist, and the failure is silent because a
+# model given an impossible instruction improvises rather than raising.
+# ``start_flow`` had the same defect and the same cause (it shipped in the
+# runtime registry and was never bridged to the MCP surface; the prompt taught
+# a flat step-graph while the tool accepted only presets).
+#
+# WHAT THIS DOES NOT COVER. Only the inline ripple prompt, and only tools it
+# names in call form. Blocks assembled in the EE cloud layer are gated per
+# backend and tested next to that assembly, in
+# ``tests/cloud/test_agent_service_tools_context.py``.
+#
+# EACH TEST NAMES THE MUTATION THAT BREAKS IT, and every one was applied, run,
+# observed to fail, and reverted (``scripts/mutate.py``).
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+# A backticked call: `get_widget_spec(` — the form the prompt uses when it
+# tells the model to invoke something. Bare backticked words are excluded on
+# purpose: the prompt also quotes prop names, widget types and JSON keys, and
+# treating those as tool names would make the test noise.
+_CALL_IN_PROMPT = re.compile(r"`([a-z_][a-z0-9_]{2,})\(")
+
+
+def _inline_prompt() -> str:
+    from pocketpaw.ripple._inline import INLINE_RIPPLE_SYSTEM_PROMPT
+
+    return INLINE_RIPPLE_SYSTEM_PROMPT
+
+
+def _runtime_tool_names() -> set[str]:
+    """Tools every backend gets, via the runtime builtin registry."""
+    from pocketpaw.tools.cli import _TOOLS
+
+    return set(_TOOLS)
+
+
+class TestEveryToolTheInlinePromptCommandsExists:
+    def test_called_tools_are_all_in_the_runtime_registry(self) -> None:
+        """The gate itself.
+
+        The inline prompt is backend-agnostic — it is appended for every
+        backend — so a tool it names in call form has to be reachable from
+        every backend, which means the runtime builtin registry. Reaching only
+        the SDK's MCP surface is precisely the bug.
+
+        THE MUTATION THAT BREAKS THIS: point the MUST-CALL block back at
+        ``get_inline_widget_help`` before that tool was bridged into the
+        registry (i.e. revert both the prompt line and the registry entry).
+        Run: the name resolved nowhere and this failed naming it.
+        (Applied 2026-08-04.)
+        """
+        named = set(_CALL_IN_PROMPT.findall(_inline_prompt()))
+        assert named, "extractor found no tool calls at all — it has stopped measuring anything"
+
+        missing = sorted(named - _runtime_tool_names())
+        assert not missing, (
+            f"the inline prompt tells the agent to call {missing}, which no backend "
+            "can reach — it is not in the runtime builtin registry. Either bridge the "
+            "tool (see tools/builtin/widget_spec.py) or stop naming it."
+        )
+
+    @pytest.mark.parametrize("tool_name", ["get_widget_spec", "get_inline_widget_help"])
+    def test_the_widget_reference_tools_reach_every_backend(self, tool_name: str) -> None:
+        """Pins the specific pair, so a registry cleanup cannot quietly drop them.
+
+        The test above only fires if the PROMPT still names the tool. Someone
+        removing a tool and its prompt mention together would pass it while
+        re-opening the capability gap, so the pair is asserted directly.
+
+        THE MUTATION THAT BREAKS THIS: delete the ``WidgetSpecTool()`` entry
+        from ``tools/cli.py::_TOOLS``. Run: this failed for get_widget_spec.
+        (Applied 2026-08-04.)
+        """
+        assert tool_name in _runtime_tool_names()
+
+    def test_they_are_offered_and_not_withheld_on_a_shared_process(self) -> None:
+        """Present in the registry is not the same as offered to the model.
+
+        ``pydantic_ai`` withholds any bridged tool it has not explicitly
+        classified — a deliberate fail-closed default — so a registry entry
+        alone would still leave the prompt commanding an absent tool. Both
+        tools are in-process reads of a static manifest and a static catalog:
+        no tenant data, no host state.
+
+        THE MUTATION THAT BREAKS THIS: remove ``get_widget_spec`` from
+        ``_TENANT_SAFE_TOOLS``. Run: it landed in the withheld set and this
+        failed. (Applied 2026-08-04.)
+        """
+        from pocketpaw.agents.pydantic_ai import _TENANT_SAFE_TOOLS, _WITHHELD_TOOLS
+
+        for tool_name in ("get_widget_spec", "get_inline_widget_help"):
+            assert tool_name in _TENANT_SAFE_TOOLS, (
+                f"{tool_name} is unclassified, so pydantic_ai withholds it — the "
+                "prompt would command a tool the model cannot see"
+            )
+            assert tool_name not in _WITHHELD_TOOLS
+
+
+class TestTheMandateNamesTheToolThatCanAnswerIt:
+    """The second half of the defect, and the subtler one.
+
+    Both tools existed on the SDK backend, so the mandate was satisfiable
+    there — it just pointed at the tool that could not answer. Measured on the
+    same widgets:
+
+        get_widget_spec         definition-list  759 chars, the prop schema
+        get_inline_widget_help  definition-list  18,623 chars, no schema
+
+    ``definition-list`` is the example the block itself cites as having shipped
+    broken with ``description`` where the manifest says ``definition``. The
+    agent called the mandated tool, received 18k characters that named the
+    widget only in a catalog listing, and guessed. Prop names come from the
+    manifest; ``get_widget_spec`` is what reads it.
+    """
+
+    def test_the_prop_schema_mandate_names_get_widget_spec(self) -> None:
+        """Asserts the MANDATE SENTENCE, not a mention anywhere in the block.
+
+        A first draft checked ``"get_widget_spec(types=" in block``, and the
+        mutation that swapped the mandate back to ``get_inline_widget_help``
+        escaped it: the block names ``get_widget_spec`` three more times, in
+        the batching line and the worked example. Whichever tool the MUST
+        sentence names is the one the model calls, so that sentence is what has
+        to be pinned.
+
+        THE MUTATION THAT BREAKS THIS: swap the tool named in the MUST-CALL
+        sentence back to ``get_inline_widget_help``. Run: failed. (Applied
+        2026-08-04.)
+        """
+        prompt = _inline_prompt()
+        start = prompt.index("# MUST CALL BEFORE EMIT")
+        # The prompt is hard-wrapped, so the mandate spans lines. Collapse
+        # whitespace before matching or the assertion tracks line breaks.
+        block = " ".join(prompt[start : start + 2000].split())
+
+        assert "you MUST call `get_widget_spec(types=[...])`" in block, (
+            "the prop-schema mandate must name get_widget_spec — it is the tool "
+            "that reads the manifest"
+        )
+
+    def test_the_block_keeps_the_two_tools_distinct(self) -> None:
+        """The fix is only durable if the block says WHY they differ.
+
+        Naming the right tool without distinguishing it invites the next editor
+        to 'simplify' by collapsing them again — they have near-identical names
+        and adjacent purposes.
+
+        THE MUTATION THAT BREAKS THIS: delete the paragraph separating the two
+        tools. Run: failed. (Applied 2026-08-04.)
+        """
+        prompt = _inline_prompt()
+        start = prompt.index("# MUST CALL BEFORE EMIT")
+        block = prompt[start : start + 2000]
+
+        assert "get_inline_widget_help" in block, (
+            "the block must say what the OTHER tool is for, or the two get conflated again"
+        )
+        assert "DIFFERENT" in block or "does not answer" in block

--- a/tests/test_start_flow_contract_is_shared.py
+++ b/tests/test_start_flow_contract_is_shared.py
@@ -1,0 +1,188 @@
+# tests/test_start_flow_contract_is_shared.py — one tool, one contract.
+# Created: 2026-08-04 (fix/prompt-tells-the-truth).
+#
+# WHAT THIS CAUGHT. ``start_flow`` is exposed on two surfaces —
+# ``tools/builtin/flow_tool.py`` (every runtime backend) and
+# ``agents/sdk_mcp_widgets.py`` (the Claude SDK in-process MCP server) — and
+# each carried its own hand-written description and JSON schema. They measured
+# 82.7% similar: close enough that nobody reading either one would notice, far
+# enough apart to change behaviour.
+#
+# THEY HAD ALREADY DRIFTED, ASYMMETRICALLY. The SDK copy carried four rules the
+# runtime copy did not:
+#
+#   * "DO NOT fake a flow with a single ``set``-stepped spec" — the anti-pattern
+#     that renders step 1 and dead-ends, and the reason start_flow exists.
+#   * a terminal ``complete`` uses ``action:``, NEVER ``type:``/``kind:``.
+#   * approve / reject / fulfill is a ``call_binding`` ACTION BUTTON, not a
+#     yes/no select.
+#   * the builder REPAIRS recoverable slips and REJECTS only real structural
+#     bugs — the retry contract that makes a failed call worth retrying.
+#
+# So the backend most deployments actually run was briefed worse than the one
+# fewer of them run, and nothing said so. This is the SECOND split of this exact
+# pair; the 2026-06-15 "SPLIT-BRAIN FIX" landed because the SDK handler was
+# preset-only while the prompt taught flat graphs. Twice is a pattern, and the
+# pattern is two copies.
+#
+# WHY EQUALITY AND NOT A CHECKLIST. Asserting the four recovered rules alone
+# would let the copies re-fork anywhere else. Equality is the invariant that
+# actually holds: there is one text and one schema, and both surfaces return
+# it. The rule checks below are kept as well, because equality would still pass
+# if someone deleted a rule from the shared constant.
+#
+# EACH TEST NAMES THE MUTATION THAT BREAKS IT, and every one was applied, run,
+# observed to fail, and reverted (``scripts/mutate.py``).
+
+from __future__ import annotations
+
+import pytest
+
+
+def _runtime_tool():
+    from pocketpaw.tools.builtin.flow_tool import StartFlowTool
+
+    return StartFlowTool()
+
+
+def _sdk_description() -> str:
+    from pocketpaw.agents.sdk_mcp_widgets import _start_flow_description
+
+    return _start_flow_description()
+
+
+def _sdk_parameters() -> dict:
+    from pocketpaw.agents.sdk_mcp_widgets import _start_flow_parameters
+
+    return _start_flow_parameters()
+
+
+class TestBothSurfacesShareOneContract:
+    def test_the_descriptions_are_identical(self) -> None:
+        """THE MUTATION THAT BREAKS THIS: give the SDK surface its own text
+        again by returning a literal from ``_start_flow_description``. Run:
+        failed. (Applied 2026-08-04.)"""
+        assert _runtime_tool().description == _sdk_description(), (
+            "the two start_flow surfaces describe the tool differently — that is "
+            "how the last split-brain started"
+        )
+
+    def test_the_schemas_are_identical(self) -> None:
+        """The schema was the quieter half of the duplication: same seven
+        properties, written out twice, with the ``flow_type`` enum read from
+        ``FLOW_TYPES`` in both places.
+
+        THE MUTATION THAT BREAKS THIS: drop the ``title`` property from
+        ``start_flow_parameters`` and hand the SDK a literal schema. Run:
+        failed. (Applied 2026-08-04.)
+        """
+        assert _runtime_tool().parameters == _sdk_parameters()
+
+    def test_the_shared_contract_comes_from_the_builder(self) -> None:
+        """The contract lives next to the code that enforces it.
+
+        ``_flows.py`` owns both the builder and the text describing it, so the
+        prose and the validator are edited in one place. Anywhere else and they
+        drift again.
+
+        THE MUTATION THAT BREAKS THIS: move ``START_FLOW_DESCRIPTION`` into
+        ``flow_tool.py`` and import it from there. Run: failed. (Applied
+        2026-08-04.)
+        """
+        from pocketpaw.ripple._flows import START_FLOW_DESCRIPTION, start_flow_parameters
+
+        assert _runtime_tool().description is START_FLOW_DESCRIPTION
+        assert _runtime_tool().parameters == start_flow_parameters()
+
+    def test_the_schema_is_not_a_shared_mutable(self) -> None:
+        """Two callers must not be able to corrupt each other's schema.
+
+        ``start_flow_parameters`` is a function partly for this: a module-level
+        dict would hand every caller the same object, and one in-place edit
+        would silently change the other surface's tool definition.
+
+        THE MUTATION THAT BREAKS THIS: cache the dict in a module global and
+        return it. Run: the mutation leaked into the second call and this
+        failed. (Applied 2026-08-04.)
+        """
+        from pocketpaw.ripple._flows import start_flow_parameters
+
+        first = start_flow_parameters()
+        first["properties"]["flow"]["description"] = "clobbered"
+        assert start_flow_parameters()["properties"]["flow"]["description"] != "clobbered"
+
+    def test_the_flow_type_enum_tracks_the_builder(self) -> None:
+        """A hardcoded enum is how the preset list goes stale.
+
+        THE MUTATION THAT BREAKS THIS: hardcode the enum to
+        ``["onboarding_wizard"]``. Run: failed. (Applied 2026-08-04.)
+        """
+        from pocketpaw.ripple._flows import FLOW_TYPES
+
+        assert _runtime_tool().parameters["properties"]["flow_type"]["enum"] == list(FLOW_TYPES)
+
+
+class TestTheRulesThatHadDrifted:
+    """Equality alone would still pass if a rule were deleted from the shared
+    constant, so the four rules the runtime backends were missing are pinned by
+    name. Each is here because it was absent from the copy that shipped to most
+    deployments."""
+
+    @pytest.mark.parametrize(
+        ("rule", "why"),
+        [
+            ("`set`-stepped", "the anti-pattern start_flow exists to prevent"),
+            ("NEVER `type:`/`kind:`", "the terminal action key the model reaches for wrongly"),
+            ("ACTION BUTTON", "approve/reject is an action, not a yes/no select"),
+            ("REPAIRS recoverable", "the repair-vs-reject contract that makes a retry worthwhile"),
+        ],
+    )
+    def test_runtime_backends_get_the_rule(self, rule: str, why: str) -> None:
+        """THE MUTATION THAT BREAKS THIS: delete the rule from
+        ``START_FLOW_DESCRIPTION``. Run: failed for each of the four.
+        (Applied 2026-08-04.)"""
+        assert rule in _runtime_tool().description, f"lost: {why}"
+
+
+class TestThePromptDoesNotRestateTheSchema:
+    """The third copy, and the reason this file is not only about two files.
+
+    ``_MULTI_STEP_FLOW_RULE`` re-taught the step shape in prose — steps, kinds,
+    next/branch, the terminal complete, per-step actions, ``{stepId.field}`` —
+    all of which the tool schema already specifies and the builder already
+    enforces. The prompt now routes to the schema and keeps what the schema
+    cannot say: when to reach for a flow at all, the two anti-patterns, and the
+    worked skeletons.
+    """
+
+    def test_the_prompt_points_at_the_schema_rather_than_repeating_it(self) -> None:
+        """THE MUTATION THAT BREAKS THIS: restore the HOW TO AUTHOR prose block
+        listing the step keys. Run: failed. (Applied 2026-08-04.)"""
+        from pocketpaw.ripple._inline import INLINE_RIPPLE_SYSTEM_PROMPT as prompt
+
+        assert "start_flow`'s own schema" in prompt, (
+            "the prompt must send the model to the tool schema for the step shape"
+        )
+        assert '- `next: "<id>"`        → linear next step' not in prompt, (
+            "the prompt is restating the transition keys the schema owns"
+        )
+
+    def test_the_prompt_keeps_what_the_schema_cannot_say(self) -> None:
+        """Deduplication must not become deletion. Routing rules, anti-patterns
+        and worked examples are not in the tool schema and have to survive.
+
+        THE MUTATION THAT BREAKS THIS: delete SKELETON C from the prompt. Run:
+        failed. (Applied 2026-08-04.)
+        """
+        from pocketpaw.ripple._inline import INLINE_RIPPLE_SYSTEM_PROMPT as prompt
+
+        for kept in (
+            "`set`-stepped",  # the anti-pattern, stated where the model plans
+            "cannot mis-nest",  # why a flat graph is safe
+            "Never leave an action flow",  # reading the request, not shaping output
+            "ask-user-questions",  # the routing boundary
+            "SKELETON A",
+            "SKELETON C",
+            "SKELETON E",
+        ):
+            assert kept in prompt, f"deduplication removed something only the prompt had: {kept}"

--- a/tests/test_widget_help_lookup.py
+++ b/tests/test_widget_help_lookup.py
@@ -1,0 +1,179 @@
+# tests/test_widget_help_lookup.py — a lookup miss must not return the library.
+# Created: 2026-08-04 (fix/prompt-tells-the-truth).
+#
+# WHAT THIS CAUGHT. ``widget_help`` resolves a widget type in three tiers, and
+# both the miss path and the third tier were broken in the same direction:
+# they answered a question nobody asked, at enormous size.
+#
+#   * A TOTAL MISS returned ``RIPPLE_DESIGN_RULES`` — the entire 58,765-char
+#     design rulebook, larger than the whole system prompt, never once
+#     mentioning the widget that was asked about. This module carries guidance
+#     for 16 widgets; the manifest carries 150+. The inline prompt sends the
+#     agent here for widgets outside the core six, so the miss path WAS the
+#     common path.
+#   * TIER 3 matched the type ANYWHERE in a section body, so every lookup hit
+#     ``# WIDGET CATALOG`` (a bare list of every widget name) and
+#     ``# CANONICAL SHAPES`` (13,479 chars covering all of them). Measured
+#     before the fix: sparkline 40,177 chars, gauge 34,629, definition-list
+#     18,623 — none containing that widget's prop schema, because a listing
+#     that names a widget is not documentation of it.
+#
+# The two compounded into the exact failure the caller was built to prevent.
+# The inline prompt cites ``definition-list`` shipping with ``description``
+# where the manifest says ``definition``; a lookup for ``definition-list``
+# returned 18,623 characters that named it only in a catalog line, and the
+# agent guessed. After the fix that lookup is 746 chars and says which tool
+# has the schema.
+#
+# WHY SIZE IS ASSERTED AS A CEILING, NOT A NUMBER. Guidance text gets edited;
+# pinning exact lengths would fail on every wording change and teach people to
+# bump the number. The invariant is the ORDER OF MAGNITUDE — a miss must not
+# be catalog-sized.
+#
+# EACH TEST NAMES THE MUTATION THAT BREAKS IT, and every one was applied, run,
+# observed to fail, and reverted (``scripts/mutate.py``).
+
+from __future__ import annotations
+
+import pytest
+
+# A widget that is real (it is in the ripple manifest) but has no hand-written
+# guidance here — the case the old code answered with the whole rulebook.
+UNCOVERED = "navbar"
+# A widget this module genuinely documents.
+COVERED = "chart"
+
+
+def _help(*types: str) -> str:
+    from pocketpaw.ripple._inline_core import widget_help
+
+    return widget_help(list(types))
+
+
+def _rulebook() -> str:
+    from pocketpaw.ripple._design import RIPPLE_DESIGN_RULES
+
+    return RIPPLE_DESIGN_RULES
+
+
+class TestAMissIsShortAndHonest:
+    def test_an_uncovered_type_does_not_return_the_whole_rulebook(self) -> None:
+        """The headline regression.
+
+        THE MUTATION THAT BREAKS THIS: restore ``return RIPPLE_DESIGN_RULES``
+        as the no-parts fallback. Run: 58,765 chars came back and this failed.
+        (Applied 2026-08-04.)
+        """
+        out = _help(UNCOVERED)
+        assert out != _rulebook()
+        assert len(out) < 3_000, (
+            f"a lookup miss returned {len(out)} chars — that is a document dump, not an answer"
+        )
+
+    def test_the_miss_names_the_type_that_missed(self) -> None:
+        """An answer that doesn't name the question is indistinguishable from
+        a wrong answer. The old dump never mentioned the requested widget.
+
+        THE MUTATION THAT BREAKS THIS: drop ``asked`` from the note's first
+        line. Run: failed. (Applied 2026-08-04.)
+        """
+        assert UNCOVERED in _help(UNCOVERED)
+
+    def test_the_miss_routes_to_the_tool_that_can_answer(self) -> None:
+        """A dead end makes the model improvise; a redirect does not.
+
+        Asserts the CALL, not the bare name. A first draft checked only that
+        the string ``get_widget_spec`` appeared somewhere in the note, and a
+        mutation that deleted the entire routing sentence escaped it — the
+        name survived in a later paragraph that merely mentions the tool. A
+        mention is not a redirect.
+
+        THE MUTATION THAT BREAKS THIS: replace the routing sentence in
+        ``_unknown_types_note`` with a bare "That is not the full widget
+        list." Run: failed. (Applied 2026-08-04.)
+        """
+        assert "call `get_widget_spec(types=[...])`" in _help(UNCOVERED)
+
+    def test_the_miss_explains_what_an_unknown_type_means(self) -> None:
+        """This is what makes a stale manifest pin self-diagnosing rather than
+        silent: if get_widget_spec also rejects the type, the deployment
+        genuinely cannot render it, and the agent is told to pick another
+        widget instead of emitting one that draws nothing.
+
+        Asserts the consequence, not the word "manifest" — which appears three
+        times in the note for unrelated reasons and let a mutation of this very
+        paragraph escape.
+
+        THE MUTATION THAT BREAKS THIS: soften "manifest does not carry that
+        widget" to "manifest may lack that widget". Run: failed. (Applied
+        2026-08-04.)
+        """
+        out = _help(UNCOVERED)
+        assert "manifest does not carry" in out, (
+            "the note must state the unknown type is genuinely absent, not merely undocumented here"
+        )
+        assert "render as nothing" in out, "the note must state the consequence of emitting it"
+
+
+class TestCoverageIsNotLost:
+    def test_a_covered_type_still_returns_its_full_guidance(self) -> None:
+        """The fix must not become a regression in the other direction.
+
+        THE MUTATION THAT BREAKS THIS: route the WIDGET_SHAPES tier through
+        ``_unknown_types_note`` too. Run: chart guidance collapsed to the miss
+        note and this failed. (Applied 2026-08-04.)
+        """
+        out = _help(COVERED)
+        assert len(out) > 5_000, "a documented widget must still get its real guidance"
+        assert "get_widget_spec" not in out, "a hit must not be dressed up as a miss"
+
+    def test_no_types_still_returns_the_full_rulebook(self) -> None:
+        """Pre-existing, deliberate behaviour: asking for everything is a real
+        request. Only the MISS path changed.
+
+        THE MUTATION THAT BREAKS THIS: make the empty-types call return the
+        unknown-types note. Run: failed. (Applied 2026-08-04.)
+        """
+        from pocketpaw.ripple._inline_core import widget_help
+
+        assert widget_help([]) == _rulebook()
+        assert widget_help(None) == _rulebook()
+
+    def test_a_partial_hit_reports_the_half_that_missed(self) -> None:
+        """Silently dropping the miss reads as full coverage, and the agent
+        emits the undocumented widget on the strength of the other one's
+        schema.
+
+        THE MUTATION THAT BREAKS THIS: skip the ``if unresolved`` append in the
+        parts branch. Run: navbar vanished from a chart+navbar lookup and this
+        failed. (Applied 2026-08-04.)
+        """
+        out = _help(COVERED, UNCOVERED)
+        assert "bar" in out.lower(), "the covered widget's guidance must survive"
+        assert UNCOVERED in out, "the uncovered widget's miss must be reported"
+
+
+class TestTier3MatchesHeadingsNotProse:
+    def test_a_listing_that_merely_names_a_widget_is_not_guidance(self) -> None:
+        """``# WIDGET CATALOG`` names every widget, so a body-substring search
+        matched it for every lookup and returned a name list as though it were
+        documentation.
+
+        THE MUTATION THAT BREAKS THIS: match on the section BODY
+        (``t in sect.lower()``) instead of the heading. Run: the lookup ballooned
+        past the ceiling and this failed. (Applied 2026-08-04.)
+        """
+        out = _help(UNCOVERED)
+        assert "WIDGET CATALOG" not in out, (
+            "a section that merely lists widget names came back as guidance"
+        )
+
+    @pytest.mark.parametrize("widget", ["sparkline", "gauge", "definition-list"])
+    def test_the_measured_regressions_stay_fixed(self, widget: str) -> None:
+        """The three widgets measured before the fix at 40,177 / 34,629 /
+        18,623 chars. Named individually because they are the evidence.
+
+        THE MUTATION THAT BREAKS THIS: same as above — body-substring search.
+        Run: all three failed. (Applied 2026-08-04.)
+        """
+        assert len(_help(widget)) < 3_000


### PR DESCRIPTION
Four blocks in the system prompt were telling the agent things that were not true. I found them by dumping the request body actually going over the wire, not by reading the code, which is why they had survived this long.

## The MUST-CALL block mandated a tool this backend does not have

`# MUST CALL BEFORE EMIT` says the agent must call `get_inline_widget_help` before emitting any non-core widget, and closes with "if the tool returns an error, OMIT the widget rather than guess."

That tool lives on the `pocketpaw_widgets` MCP server, which is built in exactly one file: `agents/claude_sdk.py:1245`. On every other backend it does not error. It is absent. The only consistent reading of an unsatisfiable precondition is the stated fallback, so this deployment has been quietly dropping every widget outside the core six. A rule written to protect widget quality was destroying it.

Both tools are now runtime builtins in `tools/builtin/widget_spec.py`, reaching every backend. `start_flow` had the same defect for the same reason and was fixed the same way, so this follows an existing precedent rather than inventing one.

## It also named the wrong tool where it did work

This is the part I would have missed without measuring. The two tools answer different questions:

| widget | `get_widget_spec` | `get_inline_widget_help` |
|---|---|---|
| definition-list | 759 chars, the prop schema | 18,623 chars, no schema |
| sparkline | 856 | 40,177 |
| gauge | 664 | 34,629 |
| navbar | 903 | 58,765 |

`definition-list` is the example the block itself cites as having shipped broken, with `description` where the manifest says `definition`. The agent called the mandated tool, got 18k of prose that named the widget only in a catalog listing, and guessed. The block even says "the widget name is not a contract, the manifest is" and then names the tool that does not read the manifest.

The mandate now names `get_widget_spec`, and a short paragraph says what the other tool is for so nobody merges them back together.

## A lookup miss returned the entire rulebook

`widget_help` answered any unknown type with all 58,765 characters of `RIPPLE_DESIGN_RULES`. That is larger than the whole system prompt and never contained the answer.

The cause was tier 3, which matched a type anywhere in a section body. Every lookup therefore hit `# WIDGET CATALOG` (a bare list of every widget name) and `# CANONICAL SHAPES` (13,479 chars covering all of them). A listing that names a widget is not documentation of it.

Tier 3 now matches headings. A miss returns about 740 chars naming the tool that can answer. The 16 widgets with real guidance are unchanged: chart is still 14,699, kanban 12,908, timeline 12,925.

## Composio blocks rode in on credentials alone

`<composio-auth-flow>` and `<composio-search-fallback>` were gated on `is_enabled()`. Composio builds tools for four backend kinds and this deploy runs a fifth, so 2,516 characters described a Gmail/Slack/GitHub surface that was not there. The cost is not context. An agent told it has those integrations tells the user it has them, then walks them through a four-step OAuth flow ending at a tool that does not exist.

Both rules now gate on `supports_composio_tools` and `supports_connection_tools`, which live in `providers.py` next to the code that builds the tools. They gate separately because the tool sets differ: the connection wrappers are Claude SDK only, the search meta-tools reach all four. Adding a wrapper widens the prompt in the same commit, instead of leaving a second backend list to drift.

Per-turn prompt after gating: pydantic_ai 34,573 chars, claude_agent_sdk 43,264, openai_agents 41,755. Each now describes only the tools it has.

## Not in this PR

The manifest pin is stale. `.env` points at `ripple-iui@v0.3.1`, which carries 153 widgets, while paw-enterprise pins `file:../ripple` at 0.5.0 with 189. The renderer in the browser can draw 36 widgets the agent is never told about, including the whole marketing-site vocabulary Paw Sites needs (navbar, footer, cta, faq, marketing-hero, logo-cloud, newsletter, feature-grid, testimonial) and agent-native ones like approval-gate and reasoning-trace. That is a config change and I did not touch anyone's `.env`.

What this PR does is make the skew visible instead of silent. `get_widget_spec("navbar")` now answers "not in this deployment's manifest, do not emit it" rather than letting the agent emit a widget that draws nothing.

`start_flow` is also taught twice, once in the ripple block and once in its own tool description, in different words. They agree today, so it is drift risk rather than a live bug, and collapsing it is a size optimization I deliberately left alone.

## Testing

15 mutations in `tests/mutations/prompt_truth.json`, all caught.

Four escaped on the first run and were real weaknesses in my own tests. The worst was the mandate test: it passed while the mandate pointed at the wrong tool, because the block names `get_widget_spec` three other times, in the batching line and the worked example. It now pins the MUST sentence itself.

One mutation I removed rather than fake. The autouse settings-cache fixture protects the next file in the process, which a per-file harness cannot prove. That is recorded in its docstring as unproven instead of dressed up as a gate.

This also repairs three composio gating tests that the earlier `Settings.load()` to `get_settings()` change had silently broken. `_force_settings` patched `Settings.load`, which nothing read anymore, so they passed only where Composio happened to be unset.

Full suite compared against a baseline worktree at the parent commit with `.env` copied across. Exactly one test failed on this branch and not the baseline, `test_touch_bumps_activity`, and it passes 10 out of 10 in isolation. It is a Windows clock-granularity flake asserting `12195.796 > 12195.796`. One caveat worth stating: the baseline worktree turned out to be missing `pydantic_ai`, so its failure count is inflated and I am not claiming credit for the tests that differ in the other direction. That confound can only add baseline failures, so it cannot hide a regression on this side.
