### PR TITLE
feat(kb): knowledge REST surface for the living-wiki rebuild

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1795,7 +1795,9 @@ Response is the row shape above plus `content` (markdown), `backlinks`
 (list of article ids), `source_docs` (raw-doc ids), `scope`, and `orphan`.
 An orphan raw-doc id returns `orphan: true` with the raw text as `content`
 and `compiled_with: null`. Unknown id or an id outside the scope →
-`404 article.not_found`.
+`404 article.not_found`. A kb failure that is NOT a genuine miss (timeout,
+missing binary, transient error) → `500 knowledge.kb_unavailable` — a kb
+outage never reads as "the article vanished".
 
 ### `GET /knowledge/stats`
 
@@ -1833,11 +1835,18 @@ an orphan raw-doc id. Response:
 {
   "scope": "workspace:w1",
   "article_id": "deploy-runbook",
+  "new_article_id": "deploy-runbook-v2",
   "raw_doc_id": "raw-1",
   "source": "notes.txt",
-  "result": { "id": "deploy-runbook", "compiled_with": "llm", "...": "kb ingest output" }
+  "result": { "article": "deploy-runbook-v2", "title": "...", "words": 250, "compiled_with": "llm" }
 }
 ```
+
+`result` is kb-go's ingest receipt passed through verbatim — note the id key
+is `article` (finishIngest's shape), not `id`. `new_article_id` is the
+server-extracted id of the article the recompile produced; when it differs
+from `article_id` (the compile landed under a new slug) the FL-11b tracking
+on any upload row pointing at the old id is re-pointed automatically.
 
 Errors: `404 article.not_found` / `404 raw_doc.not_found`,
 `422 knowledge.empty_raw_doc`, `500 knowledge.reingest_failed`.
@@ -1857,22 +1866,34 @@ FL-11b `kb_article_id`/`kb_scope` tracking on the upload row. Response:
   "scope": "workspace:w1",
   "upload_id": "up-1",
   "filename": "report.pdf",
-  "result": { "id": "report-pdf", "compiled_with": "llm", "...": "kb ingest output" }
+  "article_id": "report-pdf",
+  "result": { "article": "report-pdf", "title": "...", "words": 300, "compiled_with": "llm" }
 }
 ```
 
+`article_id` is the server-extracted id from kb-go's receipt (whose own id
+key is `article`, not `id`) — clients should read the top-level field.
+Pocket-scoped uploads are refused on this workspace surface: ingesting them
+into workspace KB would lift pocket-private content across the pocket ACL
+boundary; reingest those from the pocket surface instead.
+
 Errors: `404 upload.not_found`, `403 knowledge.upload_hidden`
-(`hide_from_ai` files are not ingestable), `422 knowledge.extraction_empty`,
+(`hide_from_ai` files are not ingestable),
+`403 knowledge.upload_pocket_scoped` (pocket files belong to the pocket
+surface), `422 knowledge.extraction_empty`,
 `500 knowledge.extraction_failed` / `knowledge.upload_unreadable` /
 `knowledge.reingest_failed`.
 
 ### `GET /knowledge/uploads?scope=`
 
-The workspace's uploaded files eligible for ingest (soft-deleted and
-`hide_from_ai` rows excluded). `has_article` is derived cheaply: the FL-11b
-tracking column matched against the resolved scope, with a
-filename-vs-article-sources fallback for uploads indexed before the column
-existed.
+The WORKSPACE's uploaded files eligible for ingest. Excluded: soft-deleted
+rows, `hide_from_ai` rows, and any pocket-scoped upload (pocket files are
+ACL-gated on the pocket surface and never list here). `has_article` is
+derived cheaply: primarily the FL-11b tracking column matched against the
+resolved scope; untracked rows fall back to a filename-vs-article-sources
+match that only counts when the upload predates the matching article's
+`compiled_at` — a fresh re-upload of a same-named file reads as pending,
+not compiled.
 
 ```json
 {

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -93,6 +93,14 @@ at the route level, because the global AuthMiddleware does not gate /api/v1/,
 so a new cloud route needs its own guard; and localhost_auth_bypass defaults to
 TRUE, so verifying an auth change with curl from your own machine cannot tell
 you whether the guard is there.
+
+Updated: 2026-08-04 (feat/knowledge-wiki-api) — documented the Knowledge —
+Living Wiki API section: the enriched GET /knowledge/articles rows, the new
+GET /knowledge/articles/{id}, GET /knowledge/stats, GET /knowledge/uploads,
+and the two reingest routes (POST /knowledge/reingest,
+POST /knowledge/reingest-upload) that re-run content through the hardened
+KnowledgeService ingest funnel. Design doc:
+docs/design/drafts/2026-08-04-knowledge-wiki-redesign.md (workspace repo).
 -->
 
 # Cloud REST API Reference
@@ -1729,3 +1737,156 @@ the split is the security model:
 Owner replies are stored in their own table rather than as chat runs, because
 the metering sweeper bills every terminal run and would otherwise charge the
 owner credits for typing their own sentence.
+
+## Knowledge — Living Wiki API
+
+The workspace knowledge browser (`/api/v1/knowledge/*`) is the read/reingest
+surface the living-wiki frontend renders. It aggregates the workspace kb-go
+scope (`workspace:{wid}`) with every agent scope in the workspace
+(`agent:{aid}`). All routes require a valid license plus `kb.read`
+(`kb.write` for the reingest POSTs) on the active workspace; routes that
+accept a `scope` bind it to the caller through the same allowlist the `/kb`
+router uses (own workspace + visible pockets + workspace agents + the
+caller's own `user:` scope) and answer `403 kb.scope_forbidden` otherwise.
+Errors use the standard envelope `{"error": {"code", "message"}}`.
+
+### `GET /knowledge/articles`
+
+Query params: `workspace_id` (optional, must match the active workspace),
+`agent_id` (optional filter; `"workspace"` = workspace-only).
+
+Response:
+
+```json
+{
+  "articles": [
+    {
+      "id": "deploy-runbook",
+      "title": "Deploy runbook",
+      "source": "",
+      "scope": "workspace:w1",
+      "agent_id": null,
+      "updated_at": "2026-08-01T12:00:00Z",
+      "summary": "How we deploy.",
+      "word_count": 250,
+      "compiled_with": "claude-haiku-4-5",
+      "version": 3,
+      "categories": ["Ops"],
+      "concepts": ["deploys", "rollbacks"],
+      "compiled_at": "2026-08-01T12:00:00Z"
+    }
+  ],
+  "total": 1,
+  "agent_ids": ["agent-1"]
+}
+```
+
+The first six keys are the pre-2026-08-04 row shape, unchanged. The wiki
+metadata after them comes from `kb list --json` plus the article's wiki
+frontmatter (kb list doesn't emit categories/concepts/compiled_at);
+`updated_at` falls back to `compiled_at`. Orphan raw docs — ingested files
+whose compile never completed — still appear as synthetic rows with
+`compiled_with: null` and `version: null`.
+
+### `GET /knowledge/articles/{article_id}?scope=`
+
+Full article for the reader view. `scope` defaults to the active workspace.
+Response is the row shape above plus `content` (markdown), `backlinks`
+(list of article ids), `source_docs` (raw-doc ids), `scope`, and `orphan`.
+An orphan raw-doc id returns `orphan: true` with the raw text as `content`
+and `compiled_with: null`. Unknown id or an id outside the scope →
+`404 article.not_found`.
+
+### `GET /knowledge/stats`
+
+Per-scope `kb stats` rollup across the workspace scope and every agent
+scope. A scope whose stats call fails is skipped, never a 500.
+
+```json
+{
+  "stats": [
+    {
+      "scope": "workspace:w1",
+      "agent_id": null,
+      "articles": 4,
+      "words": 1000,
+      "raw_docs": 5,
+      "concepts": 12,
+      "categories": 3
+    }
+  ],
+  "agent_ids": ["agent-1"]
+}
+```
+
+### `POST /knowledge/reingest`
+
+Body: `{"article_id": "<id>", "scope": "<scope>" | null}`.
+
+Re-runs an article's linked raw doc through the hardened
+`KnowledgeService.ingest_text_to_scope` funnel (agent-backend compile on
+keyless boxes, verbatim-fallback rejection). `article_id` may be a compiled
+article (its frontmatter's first `source_docs` entry names the raw doc) or
+an orphan raw-doc id. Response:
+
+```json
+{
+  "scope": "workspace:w1",
+  "article_id": "deploy-runbook",
+  "raw_doc_id": "raw-1",
+  "source": "notes.txt",
+  "result": { "id": "deploy-runbook", "compiled_with": "llm", "...": "kb ingest output" }
+}
+```
+
+Errors: `404 article.not_found` / `404 raw_doc.not_found`,
+`422 knowledge.empty_raw_doc`, `500 knowledge.reingest_failed`.
+
+### `POST /knowledge/reingest-upload`
+
+Body: `{"upload_id": "<file id>", "scope": "<scope>" | null}`.
+
+Synchronous counterpart of the FileReady auto-index listener, one upload per
+call: resolves the uploaded blob (local or S3 via a temp file), extracts
+text through the configured extraction chain, funnels it through
+`ingest_text_to_scope` with the original filename as source, and stamps the
+FL-11b `kb_article_id`/`kb_scope` tracking on the upload row. Response:
+
+```json
+{
+  "scope": "workspace:w1",
+  "upload_id": "up-1",
+  "filename": "report.pdf",
+  "result": { "id": "report-pdf", "compiled_with": "llm", "...": "kb ingest output" }
+}
+```
+
+Errors: `404 upload.not_found`, `403 knowledge.upload_hidden`
+(`hide_from_ai` files are not ingestable), `422 knowledge.extraction_empty`,
+`500 knowledge.extraction_failed` / `knowledge.upload_unreadable` /
+`knowledge.reingest_failed`.
+
+### `GET /knowledge/uploads?scope=`
+
+The workspace's uploaded files eligible for ingest (soft-deleted and
+`hide_from_ai` rows excluded). `has_article` is derived cheaply: the FL-11b
+tracking column matched against the resolved scope, with a
+filename-vs-article-sources fallback for uploads indexed before the column
+existed.
+
+```json
+{
+  "uploads": [
+    {
+      "id": "up-1",
+      "filename": "report.pdf",
+      "mime": "application/pdf",
+      "size": 12345,
+      "uploaded_at": "2026-08-01T10:00:00+00:00",
+      "has_article": true
+    }
+  ],
+  "total": 1,
+  "scope": "workspace:w1"
+}
+```

--- a/ee/pocketpaw_ee/cloud/agents/knowledge.py
+++ b/ee/pocketpaw_ee/cloud/agents/knowledge.py
@@ -1,4 +1,11 @@
 # knowledge.py — Agent knowledge service via the kb-go binary.
+# Updated: 2026-08-04 (living-wiki review follow-up) — Added
+#   extract_ingest_article_id(): kb-go's finishIngest receipt keys the new
+#   article as "article" (not "id"), so callers that read result["id"] never
+#   saw it and FL-11b tracking writes silently never fired. The helper mirrors
+#   _check_ingest_result's key order (id, article_id, article) and is now the
+#   one place receipt-shape knowledge lives; the FileReady listener and the
+#   /knowledge reingest routes both use it.
 # Updated: 2026-08-04 — Ingest hardening (silent-poisoning fix). On boxes with
 #   no ANTHROPIC_API_KEY (the Claude Code agent backend deployment), kb's own
 #   LLM compile used to fail and kb silently stored every doc VERBATIM — a
@@ -241,6 +248,25 @@ def _check_ingest_result(
             f"and purge the article (kb delete {article_id} --scope {scope})."
         )
     return result
+
+
+def extract_ingest_article_id(result: dict | list | str | None) -> str | None:
+    """Article id from a kb ingest receipt, or ``None``.
+
+    kb-go's ``finishIngest`` emits ``{"article": "<id>", "title": ...,
+    "words": ..., "compiled_with": ...}`` — the id key is ``article``, not
+    ``id``. Older/other shapes used ``id``/``article_id``; mirror
+    ``_check_ingest_result``'s key order so every receipt shape resolves.
+    Callers that read ``result["id"]`` directly never saw the id (FL-11b
+    tracking silently never fired) — always go through this helper.
+    """
+    if not isinstance(result, dict):
+        return None
+    for key in ("id", "article_id", "article"):
+        value = result.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
 
 
 def _parse_article_json(raw: str) -> dict:

--- a/ee/pocketpaw_ee/cloud/kb/dto.py
+++ b/ee/pocketpaw_ee/cloud/kb/dto.py
@@ -1,3 +1,7 @@
+# dto.py — Wire DTOs for the knowledge base REST API.
+# Updated: 2026-08-04 — Living-wiki API: added ReingestRequest and
+# ReingestUploadRequest for the new POST /knowledge/reingest and
+# POST /knowledge/reingest-upload routes.
 """Wire DTOs for the knowledge base REST API.
 
 Renamed from ``schemas.py`` to ``dto.py`` in Phase 6b for naming
@@ -32,3 +36,17 @@ class IngestUrlRequest(BaseModel):
 
 class LintRequest(BaseModel):
     scope: str | None = None
+
+
+class ReingestRequest(BaseModel):
+    """POST /knowledge/reingest — re-run an article's raw doc through the funnel."""
+
+    article_id: str = Field(min_length=1)
+    scope: str | None = None  # None = caller's active workspace
+
+
+class ReingestUploadRequest(BaseModel):
+    """POST /knowledge/reingest-upload — extract + ingest one uploaded file."""
+
+    upload_id: str = Field(min_length=1)
+    scope: str | None = None  # None = caller's active workspace

--- a/ee/pocketpaw_ee/cloud/kb/knowledge_router.py
+++ b/ee/pocketpaw_ee/cloud/kb/knowledge_router.py
@@ -1,4 +1,24 @@
 # knowledge_router.py — Workspace-level knowledge browser router.
+# Updated: 2026-08-04 (review follow-up) — security + tracking fixes:
+#   * GET /uploads is WORKSPACE-scoped only: rows with a pocket_id are
+#     excluded (files-service precedent — pocket reads are ACL-gated on
+#     their own surface, and listing pocket-private metadata workspace-wide
+#     was a bleed).
+#   * POST /reingest-upload REFUSES pocket-scoped uploads (403
+#     knowledge.upload_pocket_scoped) — ingesting them into workspace KB
+#     lifted pocket-private content across the pocket ACL boundary.
+#   * FL-11b tracking now actually fires: kb-go's ingest receipt keys the
+#     id as "article" (not "id"); both reingest routes extract via
+#     knowledge.extract_ingest_article_id and return a top-level article_id.
+#   * POST /reingest re-points tracking rows when the recompile lands under
+#     a new slug (MongoFileStore.reassign_kb_article, contained).
+#   * GET /articles/{id} distinguishes kb outage (500
+#     knowledge.kb_unavailable) from a genuine miss (404) instead of
+#     404ing existing articles during a kb timeout.
+#   * has_article: primary signal is the FL-11b column; the filename
+#     fallback only applies to untracked uploads created BEFORE the
+#     matching article was compiled (a fresh same-named re-upload is
+#     pending, not compiled).
 # Updated: 2026-08-04 — Living-wiki API for the /knowledge frontend rebuild:
 #   * GET /articles rows now carry wiki metadata (summary, word_count,
 #     compiled_with, version, categories, concepts, compiled_at) — kb list
@@ -50,12 +70,17 @@ import json
 import logging
 import os
 import re
+from datetime import UTC, datetime
 from typing import Any
 
 from fastapi import APIRouter, Depends, Query
 
 from pocketpaw_ee.cloud._core.errors import CloudError, Forbidden, NotFound, ValidationError
-from pocketpaw_ee.cloud.agents.knowledge import KnowledgeService, _kb
+from pocketpaw_ee.cloud.agents.knowledge import (
+    KnowledgeService,
+    _kb,
+    extract_ingest_article_id,
+)
 from pocketpaw_ee.cloud.kb import service as kb_service
 from pocketpaw_ee.cloud.kb.dto import ReingestRequest, ReingestUploadRequest
 from pocketpaw_ee.cloud.kb.workspace_aggregator import aggregate_workspace_articles
@@ -355,7 +380,16 @@ async def get_workspace_article(
     _contained_article_id(article_id)
     try:
         result = await asyncio.to_thread(_kb, "show", article_id, "--scope", resolved)
-    except RuntimeError:
+    except RuntimeError as exc:
+        # A genuine miss surfaces as kb-go's `fatal("Article not found: ...")`
+        # on stderr (exit 1) — fall through to the orphan raw-doc lookup.
+        # Anything else (timeout, missing binary, transient failure) is an
+        # OUTAGE: answering 404 there would tell the UI an existing article
+        # vanished. Distinguish and 500 instead. Match the full "article not
+        # found" phrase — the missing-BINARY error also says "not found".
+        if "article not found" not in str(exc).lower():
+            logger.warning("kb show failed for article=%s scope=%s: %s", article_id, resolved, exc)
+            raise CloudError(500, "knowledge.kb_unavailable", str(exc)) from exc
         result = None
     if not isinstance(result, dict):
         raw = await asyncio.to_thread(_load_raw_doc, resolved, article_id)
@@ -500,9 +534,38 @@ async def reingest_article(
         logger.error("KB reingest failed (scope=%s): %s", resolved, exc, exc_info=True)
         raise CloudError(500, "knowledge.reingest_failed", str(exc)) from exc
 
+    # kb-go's receipt keys the id as "article" — extract via the shared
+    # helper, never result["id"] (that read is always None on real receipts).
+    new_article_id = extract_ingest_article_id(result)
+
+    # The recompile can land under a NEW slug; any upload row still tracking
+    # the old id would purge a dead article on a later hide-from-AI toggle
+    # while the live copy survives. Re-point the tracking. Contained — a
+    # tracking failure never undoes the ingest that succeeded.
+    if new_article_id and new_article_id != body.article_id:
+        try:
+            from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+
+            await MongoFileStore().reassign_kb_article(
+                workspace_id,
+                old_article_id=body.article_id,
+                new_article_id=new_article_id,
+                scope=resolved,
+            )
+        except Exception:
+            logger.exception(
+                "kb-article tracking reassign failed (old=%s new=%s)",
+                body.article_id,
+                new_article_id,
+            )
+
+    # no-event: KB state lives in kb-go's own store, outside the cloud
+    # entity/event system; search-index refresh happens inside kb ingest and
+    # no bus consumer subscribes to article changes today.
     return {
         "scope": resolved,
         "article_id": body.article_id,
+        "new_article_id": new_article_id,
         "raw_doc_id": raw_doc_id,
         "source": source,
         "result": result,
@@ -536,6 +599,15 @@ async def reingest_upload(
         raise Forbidden(
             "knowledge.upload_hidden",
             "this file is hidden from AI and cannot be ingested",
+        )
+    # Pocket-scoped uploads are ACL-gated per pocket (has_edit_access); this
+    # v1 workspace surface has no pocket ACL check, and ingesting a pocket
+    # file into workspace KB would lift pocket-private content across that
+    # boundary. Refuse — pocket content reingests on the pocket surface.
+    if getattr(doc, "pocket_id", None):
+        raise Forbidden(
+            "knowledge.upload_pocket_scoped",
+            "this file belongs to a pocket; reingest it from the pocket surface",
         )
 
     adapter = _resolve_upload_adapter()
@@ -582,20 +654,27 @@ async def reingest_upload(
         raise CloudError(500, "knowledge.reingest_failed", str(exc)) from exc
 
     # FL-11b tracking so a later hide-from-AI toggle can purge the article.
-    # Contained — a tracking failure never undoes the ingest.
-    article_id = result.get("id") if isinstance(result, dict) else None
-    if isinstance(article_id, str) and article_id:
+    # Contained — a tracking failure never undoes the ingest. The id comes
+    # from the shared receipt helper: kb-go keys it as "article", not "id".
+    article_id = extract_ingest_article_id(result)
+    if article_id:
         try:
+            # no-event: FL-11b tracking is a bookkeeping column consumed only
+            # by the hide-from-AI purge read path; no bus consumer exists.
             await store.set_kb_article(
                 body.upload_id, workspace_id, article_id=article_id, scope=resolved
             )
         except Exception:
             logger.exception("kb-article tracking failed for upload=%s", body.upload_id)
 
+    # no-event: KB state lives in kb-go's own store, outside the cloud
+    # entity/event system; search-index refresh happens inside kb ingest and
+    # no bus consumer subscribes to article changes today.
     return {
         "scope": resolved,
         "upload_id": body.upload_id,
         "filename": doc.filename,
+        "article_id": article_id,
         "result": result,
     }
 
@@ -620,20 +699,28 @@ def _resolve_upload_adapter():
         return None
 
 
-def _sources_with_articles(scope: str) -> set[str]:
-    """Source filenames of *scope*'s compiled articles (via raw source_docs).
+def _sources_with_articles(scope: str) -> dict[str, str | None]:
+    """Source filename → latest ``compiled_at`` of *scope*'s compiled articles.
 
     Fallback signal for ``has_article`` on uploads that predate the FL-11b
-    ``kb_article_id`` tracking column: an upload whose filename matches a
-    compiled article's raw-doc source was (almost certainly) ingested.
+    ``kb_article_id`` tracking column. The compiled_at value lets the caller
+    reject false positives: a FRESH re-upload of a same-named file matches
+    the filename but was created AFTER the article was compiled, so it is
+    pending, not compiled.
     """
     sanitized = _sanitize_scope(scope)
-    referenced: set[str] = set()
+    # raw-doc id → compiled_at of the (latest) article referencing it.
+    referenced: dict[str, str | None] = {}
     for fm in _read_scope_frontmatter(scope).values():
+        compiled_at = fm.get("compiled_at")
+        compiled_at = str(compiled_at) if compiled_at else None
         for sd in fm.get("source_docs") or []:
-            referenced.add(str(sd))
-    sources: set[str] = set()
-    for raw_id in referenced:
+            raw_id = str(sd)
+            existing = referenced.get(raw_id)
+            if existing is None or (compiled_at is not None and compiled_at > existing):
+                referenced[raw_id] = compiled_at
+    sources: dict[str, str | None] = {}
+    for raw_id, compiled_at in referenced.items():
         raw_path = os.path.join(KB_HOME, sanitized, "raw", f"{raw_id}.json")
         try:
             with open(raw_path, encoding="utf-8", errors="replace") as fh:
@@ -641,8 +728,31 @@ def _sources_with_articles(scope: str) -> set[str]:
         except (OSError, json.JSONDecodeError):
             continue
         if isinstance(doc, dict) and doc.get("source"):
-            sources.add(str(doc["source"]))
+            source = str(doc["source"])
+            existing = sources.get(source)
+            if source not in sources or (
+                compiled_at is not None and (existing is None or compiled_at > existing)
+            ):
+                sources[source] = compiled_at
     return sources
+
+
+def _parse_compiled_at(value: str | None) -> datetime | None:
+    """Parse kb-go's RFC3339 ``compiled_at`` to an aware datetime, or ``None``."""
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+
+
+def _as_aware_utc(value: datetime | None) -> datetime | None:
+    """Naive datetimes from the Mongo store are UTC by convention — tag them."""
+    if value is None:
+        return None
+    return value if value.tzinfo else value.replace(tzinfo=UTC)
 
 
 @router.get(
@@ -654,14 +764,20 @@ async def list_ingestable_uploads(
     workspace_id: str = Depends(current_workspace_id),
     user_id: str = Depends(current_user_id),
 ) -> dict:
-    """The workspace's uploaded files eligible for KB ingest.
+    """The WORKSPACE's uploaded files eligible for KB ingest.
 
-    ``has_article`` is derived cheaply, no new tracking: the FL-11b
-    ``kb_article_id`` column (stamped by the FileReady listener and the
-    reingest-upload route) matched against the resolved scope, with a
-    filename-vs-article-sources fallback for uploads indexed before the
-    tracking column existed. Files hidden from AI are excluded — they are
-    not eligible for ingest.
+    Workspace-scoped only: rows with a ``pocket_id`` are excluded (files-
+    service precedent — pocket files are ACL-gated on the pocket surface,
+    and listing their metadata workspace-wide would bleed pocket privacy).
+    Files hidden from AI are excluded too — they are not eligible.
+
+    ``has_article`` is derived cheaply, no new tracking: primarily the
+    FL-11b ``kb_article_id`` column (stamped by the FileReady listener and
+    the reingest-upload route) matched against the resolved scope. For
+    untracked rows only, a filename-vs-article-sources fallback covers
+    uploads indexed before the tracking column existed — guarded by
+    compiled_at so a FRESH re-upload of a same-named file (created after
+    the article was compiled) reads as pending, not compiled.
     """
     resolved = await _resolve_scope(workspace_id, user_id, scope, action="kb.read")
 
@@ -671,19 +787,32 @@ async def list_ingestable_uploads(
         known_sources = await asyncio.to_thread(_sources_with_articles, resolved)
     except Exception:
         logger.debug("source scan failed for scope=%s", resolved, exc_info=True)
-        known_sources = set()
+        known_sources = {}
 
     uploads: list[dict[str, Any]] = []
     async for row in MongoFileStore().iter_by_workspace(workspace_id):
         if row.get("hide_from_ai"):
             continue
+        if row.get("pocket_id"):
+            continue  # pocket-private — not listable on the workspace surface
+        created_at = row.get("created_at")
         kb_article_id = row.get("kb_article_id")
         kb_scope = row.get("kb_scope")
-        has_article = bool(
-            (kb_article_id and (kb_scope is None or kb_scope == resolved))
-            or (row.get("filename") in known_sources)
-        )
-        created_at = row.get("created_at")
+        if kb_article_id:
+            has_article = bool(kb_scope is None or kb_scope == resolved)
+        else:
+            # Legacy fallback: only trust the filename match when THIS upload
+            # predates the article's compile — otherwise a new same-named
+            # upload would instantly read as compiled and drop out of the
+            # rebuild/poll candidates.
+            filename = row.get("filename")
+            compiled_at = _parse_compiled_at(
+                known_sources.get(filename) if filename in known_sources else None
+            )
+            created_cmp = _as_aware_utc(created_at)
+            has_article = bool(
+                compiled_at is not None and created_cmp is not None and created_cmp <= compiled_at
+            )
         uploads.append(
             {
                 "id": row.get("file_id"),

--- a/ee/pocketpaw_ee/cloud/kb/knowledge_router.py
+++ b/ee/pocketpaw_ee/cloud/kb/knowledge_router.py
@@ -1,4 +1,23 @@
 # knowledge_router.py — Workspace-level knowledge browser router.
+# Updated: 2026-08-04 — Living-wiki API for the /knowledge frontend rebuild:
+#   * GET /articles rows now carry wiki metadata (summary, word_count,
+#     compiled_with, version, categories, concepts, compiled_at) — kb list
+#     output enriched from the scope's wiki frontmatter, since `kb list --json`
+#     doesn't emit categories/concepts/compiled_at. The kb subprocess now runs
+#     off the event loop (asyncio.to_thread) — it used to block the handler.
+#   * NEW GET /articles/{article_id}?scope= — full article via `kb show`
+#     (+ content, backlinks, compiled_at, source_docs); orphan raw docs are
+#     served as synthetic uncompiled articles; 404 on unknown id/scope.
+#   * NEW GET /stats — per-scope `kb stats` rollup across the workspace scope
+#     and every agent scope visible to the caller.
+#   * NEW POST /reingest — re-run an article's linked raw doc through the
+#     hardened KnowledgeService.ingest_text_to_scope funnel.
+#   * NEW POST /reingest-upload — resolve an uploaded file, extract via the
+#     configured extraction chain, funnel through ingest_text_to_scope.
+#   * NEW GET /uploads — the workspace's uploaded files eligible for ingest,
+#     with a cheap has_article marker (FL-11b tracking + source-filename match).
+#   Scope-accepting routes bind the client scope through the kb router's
+#   allowlist pattern (kb.service.validate_scope_override + log_denial).
 # Created: 2026-04-19 (Cluster C / PR1) — Adds GET /api/v1/knowledge/articles,
 # a workspace-level rollup that unions the workspace KB with every per-agent
 # KB inside the workspace. See docs/plans/FEATURE-HARDENING-PLAN.md §Cluster C
@@ -11,16 +30,21 @@ fans out across every agent in the workspace, whereas ``/kb/articles`` is a
 single-scope list.
 
 Auth model:
-    - ``kb.read`` action required on the active workspace.
+    - ``kb.read`` action required on the active workspace for reads;
+      ``kb.write`` for the reingest routes.
     - ``workspace_id`` query param, if provided, must match the caller's
       active workspace. We intentionally do not allow cross-workspace reads
       from this endpoint — the guard ``require_action_any_workspace('kb.read')``
       already pins the caller to their active workspace, and honouring a
       different ``workspace_id`` would leak KB across tenants.
+    - Routes that accept a client ``scope`` bind it to the caller via
+      ``kb.service.validate_scope_override`` (the same allowlist the /kb
+      router uses), audit-logging denials.
 """
 
 from __future__ import annotations
 
+import asyncio
 import glob
 import json
 import logging
@@ -30,7 +54,10 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, Query
 
-from pocketpaw_ee.cloud._core.errors import Forbidden
+from pocketpaw_ee.cloud._core.errors import CloudError, Forbidden, NotFound, ValidationError
+from pocketpaw_ee.cloud.agents.knowledge import KnowledgeService, _kb
+from pocketpaw_ee.cloud.kb import service as kb_service
+from pocketpaw_ee.cloud.kb.dto import ReingestRequest, ReingestUploadRequest
 from pocketpaw_ee.cloud.kb.workspace_aggregator import aggregate_workspace_articles
 from pocketpaw_ee.cloud.license import require_license
 from pocketpaw_ee.cloud.shared.deps import (
@@ -38,6 +65,7 @@ from pocketpaw_ee.cloud.shared.deps import (
     current_workspace_id,
     require_action_any_workspace,
 )
+from pocketpaw_ee.guards.audit import log_denial
 
 logger = logging.getLogger(__name__)
 
@@ -70,6 +98,92 @@ def _sanitize_scope(scope: str) -> str:
     return _SANITIZE_RE.sub("_", scope)
 
 
+async def _resolve_scope(
+    workspace_id: str,
+    user_id: str,
+    override: str | None,
+    *,
+    action: str,
+) -> str:
+    """Bind a client-supplied ``scope`` to the caller's allowlist.
+
+    Same pattern as the /kb router: delegates to
+    ``kb.service.validate_scope_override`` (own workspace + visible pockets +
+    workspace agents + the caller's OWN ``user:``), audit-logs denials at
+    ALERT, and re-raises ``Forbidden`` for ``_core.http`` to map to 403 JSON.
+    """
+    try:
+        return await kb_service.validate_scope_override(workspace_id, user_id, override)
+    except Forbidden:
+        log_denial(
+            actor=user_id,
+            action=action,
+            code="kb.scope_forbidden",
+            resource_id=override or "",
+            workspace_id=workspace_id,
+            detail="KB scope override not bound to caller",
+        )
+        raise
+
+
+def _contained_article_id(article_id: str) -> None:
+    """Reject ids that could escape the scope dir on our direct file reads.
+
+    Mirror of kb-go's ``containedID`` (issue #23): every id kb-go mints is
+    slug-like, so a path separator or ``..`` is always hostile. Raising
+    ``NotFound`` (not 400) avoids acting as a traversal oracle.
+    """
+    if not article_id or "/" in article_id or "\\" in article_id or ".." in article_id:
+        raise NotFound("article", article_id)
+
+
+def _read_frontmatter_file(md_path: str) -> dict[str, Any] | None:
+    """Parse the JSON frontmatter block of one wiki ``.md`` file, or ``None``."""
+    try:
+        with open(md_path, encoding="utf-8", errors="replace") as fh:
+            text = fh.read()
+    except OSError:
+        return None
+    if not text.startswith("---"):
+        return None
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return None
+    try:
+        fm = json.loads(parts[1])
+    except json.JSONDecodeError:
+        return None
+    return fm if isinstance(fm, dict) else None
+
+
+def _read_scope_frontmatter(scope: str) -> dict[str, dict[str, Any]]:
+    """Frontmatter for every wiki article in *scope*, keyed by article id.
+
+    ``kb list --json`` doesn't emit categories/concepts/compiled_at, so the
+    articles listing enriches its rows from the frontmatter kb-go itself
+    writes (the same on-disk layout ``_list_orphan_raw_docs`` already reads).
+    """
+    wiki_dir = os.path.join(KB_HOME, _sanitize_scope(scope), "wiki")
+    out: dict[str, dict[str, Any]] = {}
+    for md_path in glob.glob(os.path.join(wiki_dir, "*.md")):
+        fm = _read_frontmatter_file(md_path)
+        if fm is not None:
+            out[os.path.splitext(os.path.basename(md_path))[0]] = fm
+    return out
+
+
+def _load_raw_doc(scope: str, raw_id: str) -> dict[str, Any] | None:
+    """Read one raw doc JSON (``raw/{id}.json``) for *scope*, or ``None``."""
+    _contained_article_id(raw_id)
+    raw_path = os.path.join(KB_HOME, _sanitize_scope(scope), "raw", f"{raw_id}.json")
+    try:
+        with open(raw_path, encoding="utf-8", errors="replace") as fh:
+            doc = json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return None
+    return doc if isinstance(doc, dict) else None
+
+
 def _list_orphan_raw_docs(scope: str) -> list[dict[str, Any]]:
     """Read raw docs that have *no* corresponding wiki article for *scope*.
 
@@ -92,19 +206,12 @@ def _list_orphan_raw_docs(scope: str) -> list[dict[str, Any]]:
     referenced_raws: set[str] = set()
     if os.path.isdir(wiki_dir):
         for md_path in glob.glob(os.path.join(wiki_dir, "*.md")):
-            try:
-                with open(md_path, encoding="utf-8", errors="replace") as fh:
-                    text = fh.read()
-                if not text.startswith("---"):
-                    continue
-                parts = text.split("---", 2)
-                if len(parts) < 3:
-                    continue
-                fm = json.loads(parts[1])
-                for sd in fm.get("source_docs", []) or []:
-                    referenced_raws.add(str(sd))
-            except Exception:
-                logger.debug("Failed to read wiki article %s", md_path, exc_info=True)
+            fm = _read_frontmatter_file(md_path)
+            if fm is None:
+                logger.debug("Failed to read wiki article %s", md_path)
+                continue
+            for sd in fm.get("source_docs", []) or []:
+                referenced_raws.add(str(sd))
 
     orphans: list[dict[str, Any]] = []
     for raw_path in glob.glob(os.path.join(raw_dir, "*.json")):
@@ -118,12 +225,14 @@ def _list_orphan_raw_docs(scope: str) -> list[dict[str, Any]]:
             logger.debug("Failed to read raw doc %s", raw_path, exc_info=True)
             continue
 
+        word_count = doc.get("word_count")
         orphans.append(
             {
                 "id": raw_id,
                 "title": doc.get("source") or doc.get("filename") or raw_id,
                 "source": doc.get("source") or "",
                 "updated_at": doc.get("ingested_at"),
+                "word_count": word_count if isinstance(word_count, int) else 0,
             }
         )
 
@@ -134,11 +243,13 @@ def _call_kb_list(scope: str) -> list[Any]:
     """Wrap the kb-go ``list`` command. Non-list returns are coerced to ``[]``
     so the aggregator never sees surprising shapes.
 
+    Enriches each kb row with the wiki-frontmatter fields ``kb list --json``
+    doesn't emit (categories, concepts, compiled_at) so the living-wiki UI
+    gets full rows without one ``kb show`` per article.
+
     Also folds in *orphan* raw docs — ingested files whose wiki compilation
     never completed — so the workspace knowledge browser surfaces every piece
     of content, not just fully-compiled articles."""
-    from pocketpaw_ee.cloud.agents.knowledge import _kb
-
     wiki_articles: list[Any] = []
     try:
         result = _kb("list", "--scope", scope)
@@ -146,6 +257,19 @@ def _call_kb_list(scope: str) -> list[Any]:
             wiki_articles = result
     except Exception as exc:  # noqa: BLE001
         logger.debug("kb list raised for scope=%s: %s", scope, exc)
+
+    try:
+        frontmatter = _read_scope_frontmatter(scope)
+    except Exception:
+        logger.debug("frontmatter scan failed for scope=%s", scope, exc_info=True)
+        frontmatter = {}
+    for row in wiki_articles:
+        if not isinstance(row, dict):
+            continue
+        fm = frontmatter.get(str(row.get("id")), {})
+        row.setdefault("categories", fm.get("categories") or [])
+        row.setdefault("concepts", fm.get("concepts") or [])
+        row.setdefault("compiled_at", fm.get("compiled_at"))
 
     # Append orphan raw docs as synthetic articles so they show up in the UI.
     try:
@@ -192,7 +316,9 @@ async def list_workspace_articles(
     articles = await aggregate_workspace_articles(
         workspace_id=active_workspace_id,
         agent_ids=agent_ids,
-        kb_list=_call_kb_list,
+        # Off the event loop: _call_kb_list shells out to the kb binary per
+        # scope; the aggregator awaits each returned coroutine.
+        kb_list=lambda scope: asyncio.to_thread(_call_kb_list, scope),
         agent_filter=agent_id,
     )
 
@@ -201,3 +327,371 @@ async def list_workspace_articles(
         "total": len(articles),
         "agent_ids": agent_ids,
     }
+
+
+# ---------------------------------------------------------------------------
+# Single article — full body for the wiki reader
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/articles/{article_id}",
+    dependencies=[Depends(require_action_any_workspace("kb.read"))],
+)
+async def get_workspace_article(
+    article_id: str,
+    scope: str | None = Query(None, description="kb scope; defaults to the active workspace"),
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> dict:
+    """Full article for the wiki reader: list-row fields + content + backlinks.
+
+    ``scope`` is bound to the caller via the kb allowlist. Unknown id or an
+    id outside the scope → 404. An *orphan* raw doc (ingested but never
+    compiled — the synthetic rows the listing surfaces) is served as an
+    uncompiled article with ``orphan: true`` and the raw text as content.
+    """
+    resolved = await _resolve_scope(workspace_id, user_id, scope, action="kb.read")
+    _contained_article_id(article_id)
+    try:
+        result = await asyncio.to_thread(_kb, "show", article_id, "--scope", resolved)
+    except RuntimeError:
+        result = None
+    if not isinstance(result, dict):
+        raw = await asyncio.to_thread(_load_raw_doc, resolved, article_id)
+        if raw is None:
+            raise NotFound("article", article_id)
+        word_count = raw.get("word_count")
+        return {
+            "id": article_id,
+            "title": raw.get("source") or raw.get("filename") or article_id,
+            "summary": "",
+            "content": raw.get("raw_text") or "",
+            "concepts": [],
+            "categories": [],
+            "backlinks": [],
+            "word_count": word_count if isinstance(word_count, int) else 0,
+            "compiled_with": None,
+            "version": None,
+            "compiled_at": None,
+            "source_docs": [article_id],
+            "scope": resolved,
+            "orphan": True,
+        }
+
+    # `kb show --json` omits compiled_at and source_docs — read them from the
+    # article's own frontmatter (kb-go's on-disk format).
+    fm = (
+        await asyncio.to_thread(
+            _read_frontmatter_file,
+            os.path.join(KB_HOME, _sanitize_scope(resolved), "wiki", f"{article_id}.md"),
+        )
+        or {}
+    )
+    result.setdefault("backlinks", [])
+    result["compiled_at"] = fm.get("compiled_at")
+    result["source_docs"] = [str(sd) for sd in fm.get("source_docs") or []]
+    result["scope"] = resolved
+    result["orphan"] = False
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Stats — per-scope rollup for the wiki header
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/stats",
+    dependencies=[Depends(require_action_any_workspace("kb.read"))],
+)
+async def workspace_knowledge_stats(
+    active_workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> dict:
+    """`kb stats` per scope visible to the caller (workspace + its agents).
+
+    Mirrors the articles aggregator's visibility rules and resilience: a
+    scope whose stats call fails is skipped with a warning, never a 500.
+    """
+    agent_ids = await _list_workspace_agent_ids(active_workspace_id)
+    scopes: list[tuple[str, str | None]] = [(f"workspace:{active_workspace_id}", None)]
+    scopes += [(f"agent:{aid}", aid) for aid in agent_ids]
+
+    rows: list[dict[str, Any]] = []
+    for scope, agent_id in scopes:
+        try:
+            stats = await asyncio.to_thread(_kb, "stats", "--scope", scope)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("kb stats failed for scope=%s: %s", scope, exc)
+            continue
+        if not isinstance(stats, dict):
+            continue
+        rows.append(
+            {
+                "scope": scope,
+                "agent_id": agent_id,
+                "articles": stats.get("articles", 0),
+                "words": stats.get("words", 0),
+                "raw_docs": stats.get("raw_docs", 0),
+                "concepts": stats.get("concepts", 0),
+                "categories": stats.get("categories", 0),
+            }
+        )
+    return {"stats": rows, "agent_ids": agent_ids}
+
+
+# ---------------------------------------------------------------------------
+# Reingest — re-run a raw doc through the hardened ingest funnel
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/reingest",
+    dependencies=[Depends(require_action_any_workspace("kb.write"))],
+)
+async def reingest_article(
+    body: ReingestRequest,
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> dict:
+    """Re-run an article's linked raw doc through the ingest funnel.
+
+    Resolution order for the raw text:
+      1. ``article_id`` is a compiled article → its frontmatter's first
+         ``source_docs`` entry names the raw doc.
+      2. ``article_id`` IS a raw-doc id (the orphan rows the listing
+         surfaces) → read ``raw/{article_id}.json`` directly.
+
+    The ingest itself goes through
+    :meth:`KnowledgeService.ingest_text_to_scope` — agent-backend compile on
+    keyless boxes, verbatim-fallback rejection, subprocess off the loop.
+    """
+    resolved = await _resolve_scope(workspace_id, user_id, body.scope, action="kb.write")
+    _contained_article_id(body.article_id)
+
+    raw_doc_id = body.article_id
+    fm = await asyncio.to_thread(
+        _read_frontmatter_file,
+        os.path.join(KB_HOME, _sanitize_scope(resolved), "wiki", f"{body.article_id}.md"),
+    )
+    if fm is not None:
+        source_docs = [str(sd) for sd in fm.get("source_docs") or []]
+        if not source_docs:
+            raise NotFound("raw_doc", body.article_id)
+        raw_doc_id = source_docs[0]
+
+    raw = await asyncio.to_thread(_load_raw_doc, resolved, raw_doc_id)
+    if raw is None:
+        raise NotFound("article", body.article_id)
+    text = str(raw.get("raw_text") or "")
+    if not text.strip():
+        raise ValidationError(
+            "knowledge.empty_raw_doc",
+            f"raw doc '{raw_doc_id}' has no text to reingest",
+        )
+    source = str(raw.get("source") or raw.get("filename") or raw_doc_id)
+
+    try:
+        result = await KnowledgeService.ingest_text_to_scope(resolved, text, source)
+    except CloudError:
+        raise
+    except Exception as exc:
+        logger.error("KB reingest failed (scope=%s): %s", resolved, exc, exc_info=True)
+        raise CloudError(500, "knowledge.reingest_failed", str(exc)) from exc
+
+    return {
+        "scope": resolved,
+        "article_id": body.article_id,
+        "raw_doc_id": raw_doc_id,
+        "source": source,
+        "result": result,
+    }
+
+
+@router.post(
+    "/reingest-upload",
+    dependencies=[Depends(require_action_any_workspace("kb.write"))],
+)
+async def reingest_upload(
+    body: ReingestUploadRequest,
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> dict:
+    """Extract one uploaded file and ingest it through the funnel.
+
+    Mirrors the FileReady listener's pipeline (resolve → extract → funnel)
+    but synchronously, returning the ingest result — the client drives the
+    loop one upload per call. Hidden files (``hide_from_ai``) are refused.
+    """
+    resolved = await _resolve_scope(workspace_id, user_id, body.scope, action="kb.write")
+
+    from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+
+    store = MongoFileStore()
+    doc = await store.get_doc_scoped(body.upload_id, workspace_id)
+    if doc is None:
+        raise NotFound("upload", body.upload_id)
+    if getattr(doc, "hide_from_ai", False):
+        raise Forbidden(
+            "knowledge.upload_hidden",
+            "this file is hidden from AI and cannot be ingested",
+        )
+
+    adapter = _resolve_upload_adapter()
+    if adapter is None:
+        raise CloudError(500, "knowledge.upload_adapter_unavailable", "upload storage not mounted")
+
+    from pocketpaw.config import get_settings
+    from pocketpaw_ee.cloud.extraction import build_chain
+    from pocketpaw_ee.cloud.uploads.resolver import materialize_to_local_path
+
+    mime = doc.mime or "application/octet-stream"
+    async with materialize_to_local_path(
+        adapter, doc.storage_key, mime=mime, filename=doc.filename
+    ) as path:
+        if path is None:
+            raise CloudError(
+                500, "knowledge.upload_unreadable", f"could not read upload '{body.upload_id}'"
+            )
+        try:
+            extraction = await build_chain(get_settings()).run(path, mime)
+        except Exception as exc:
+            logger.error("extraction failed for upload=%s: %s", body.upload_id, exc, exc_info=True)
+            raise CloudError(500, "knowledge.extraction_failed", str(exc)) from exc
+
+    text = (extraction.text or "").strip()
+    if not text:
+        raise ValidationError(
+            "knowledge.extraction_empty",
+            f"no text could be extracted from '{doc.filename}'",
+        )
+
+    try:
+        result = await KnowledgeService.ingest_text_to_scope(resolved, text, doc.filename)
+    except CloudError:
+        raise
+    except Exception as exc:
+        logger.error(
+            "KB reingest-upload failed (scope=%s, upload=%s): %s",
+            resolved,
+            body.upload_id,
+            exc,
+            exc_info=True,
+        )
+        raise CloudError(500, "knowledge.reingest_failed", str(exc)) from exc
+
+    # FL-11b tracking so a later hide-from-AI toggle can purge the article.
+    # Contained — a tracking failure never undoes the ingest.
+    article_id = result.get("id") if isinstance(result, dict) else None
+    if isinstance(article_id, str) and article_id:
+        try:
+            await store.set_kb_article(
+                body.upload_id, workspace_id, article_id=article_id, scope=resolved
+            )
+        except Exception:
+            logger.exception("kb-article tracking failed for upload=%s", body.upload_id)
+
+    return {
+        "scope": resolved,
+        "upload_id": body.upload_id,
+        "filename": doc.filename,
+        "result": result,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Uploads — the workspace's files eligible for ingest
+# ---------------------------------------------------------------------------
+
+
+def _resolve_upload_adapter():
+    """The EE upload singleton's storage adapter, or ``None`` when unmounted.
+
+    Same lazy-import pattern as the FileReady listener so test harnesses can
+    monkeypatch the router singleton.
+    """
+    try:
+        from pocketpaw_ee.cloud.uploads.router import _ADAPTER
+
+        return _ADAPTER
+    except Exception:
+        logger.exception("upload adapter import failed")
+        return None
+
+
+def _sources_with_articles(scope: str) -> set[str]:
+    """Source filenames of *scope*'s compiled articles (via raw source_docs).
+
+    Fallback signal for ``has_article`` on uploads that predate the FL-11b
+    ``kb_article_id`` tracking column: an upload whose filename matches a
+    compiled article's raw-doc source was (almost certainly) ingested.
+    """
+    sanitized = _sanitize_scope(scope)
+    referenced: set[str] = set()
+    for fm in _read_scope_frontmatter(scope).values():
+        for sd in fm.get("source_docs") or []:
+            referenced.add(str(sd))
+    sources: set[str] = set()
+    for raw_id in referenced:
+        raw_path = os.path.join(KB_HOME, sanitized, "raw", f"{raw_id}.json")
+        try:
+            with open(raw_path, encoding="utf-8", errors="replace") as fh:
+                doc = json.load(fh)
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(doc, dict) and doc.get("source"):
+            sources.add(str(doc["source"]))
+    return sources
+
+
+@router.get(
+    "/uploads",
+    dependencies=[Depends(require_action_any_workspace("kb.read"))],
+)
+async def list_ingestable_uploads(
+    scope: str | None = Query(None, description="kb scope; defaults to the active workspace"),
+    workspace_id: str = Depends(current_workspace_id),
+    user_id: str = Depends(current_user_id),
+) -> dict:
+    """The workspace's uploaded files eligible for KB ingest.
+
+    ``has_article`` is derived cheaply, no new tracking: the FL-11b
+    ``kb_article_id`` column (stamped by the FileReady listener and the
+    reingest-upload route) matched against the resolved scope, with a
+    filename-vs-article-sources fallback for uploads indexed before the
+    tracking column existed. Files hidden from AI are excluded — they are
+    not eligible for ingest.
+    """
+    resolved = await _resolve_scope(workspace_id, user_id, scope, action="kb.read")
+
+    from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+
+    try:
+        known_sources = await asyncio.to_thread(_sources_with_articles, resolved)
+    except Exception:
+        logger.debug("source scan failed for scope=%s", resolved, exc_info=True)
+        known_sources = set()
+
+    uploads: list[dict[str, Any]] = []
+    async for row in MongoFileStore().iter_by_workspace(workspace_id):
+        if row.get("hide_from_ai"):
+            continue
+        kb_article_id = row.get("kb_article_id")
+        kb_scope = row.get("kb_scope")
+        has_article = bool(
+            (kb_article_id and (kb_scope is None or kb_scope == resolved))
+            or (row.get("filename") in known_sources)
+        )
+        created_at = row.get("created_at")
+        uploads.append(
+            {
+                "id": row.get("file_id"),
+                "filename": row.get("filename"),
+                "mime": row.get("mime"),
+                "size": row.get("size"),
+                "uploaded_at": created_at.isoformat() if created_at else None,
+                "has_article": has_article,
+            }
+        )
+    return {"uploads": uploads, "total": len(uploads), "scope": resolved}

--- a/ee/pocketpaw_ee/cloud/kb/workspace_aggregator.py
+++ b/ee/pocketpaw_ee/cloud/kb/workspace_aggregator.py
@@ -1,4 +1,9 @@
 # workspace_aggregator.py — Workspace-level KB aggregator for Cluster C / PR 1.
+# Updated: 2026-08-04 — Living-wiki API. AggregatedArticle rows now carry the
+# wiki metadata the /knowledge frontend renders: summary, word_count,
+# compiled_with, version, categories, concepts, compiled_at. All additive with
+# safe defaults, so pre-existing consumers of the row shape are unchanged;
+# updated_at falls back to compiled_at when the kb row has no timestamp.
 # Created: 2026-04-19 — Powers GET /api/v1/knowledge/articles by merging the
 # workspace-scoped KB (`workspace:{id}`) with every per-agent KB
 # (`agent:{agent_id}`) that lives inside the same workspace. Scope checks are
@@ -21,7 +26,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -29,7 +34,12 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class AggregatedArticle:
-    """One row in the workspace KB browser."""
+    """One row in the workspace KB browser.
+
+    The wiki-metadata fields (``summary`` onwards) default to empty values so
+    rows built from sources that lack them (orphan raw docs, older kb
+    binaries) still construct cleanly.
+    """
 
     id: str
     title: str
@@ -37,6 +47,13 @@ class AggregatedArticle:
     scope: str  # "workspace:{id}" or "agent:{agent_id}"
     agent_id: str | None
     updated_at: str | None
+    summary: str = ""
+    word_count: int = 0
+    compiled_with: str | None = None
+    version: int | None = None
+    categories: list[str] = field(default_factory=list)
+    concepts: list[str] = field(default_factory=list)
+    compiled_at: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -46,6 +63,13 @@ class AggregatedArticle:
             "scope": self.scope,
             "agent_id": self.agent_id,
             "updated_at": self.updated_at,
+            "summary": self.summary,
+            "word_count": self.word_count,
+            "compiled_with": self.compiled_with,
+            "version": self.version,
+            "categories": self.categories,
+            "concepts": self.concepts,
+            "compiled_at": self.compiled_at,
         }
 
 
@@ -62,7 +86,10 @@ def _row_to_article(row: Any, *, scope: str, agent_id: str | None) -> Aggregated
         return None
     title = row.get("title") or row.get("name") or row.get("source") or f"article:{article_id}"
     source = row.get("source") or row.get("origin") or ""
-    updated_at = row.get("updated_at") or row.get("updatedAt") or row.get("modified")
+    compiled_at = row.get("compiled_at")
+    updated_at = row.get("updated_at") or row.get("updatedAt") or row.get("modified") or compiled_at
+    word_count = row.get("word_count")
+    version = row.get("version")
     return AggregatedArticle(
         id=str(article_id),
         title=str(title),
@@ -70,6 +97,13 @@ def _row_to_article(row: Any, *, scope: str, agent_id: str | None) -> Aggregated
         scope=scope,
         agent_id=agent_id,
         updated_at=str(updated_at) if updated_at else None,
+        summary=str(row.get("summary") or ""),
+        word_count=int(word_count) if isinstance(word_count, int | float) else 0,
+        compiled_with=str(row["compiled_with"]) if row.get("compiled_with") else None,
+        version=int(version) if isinstance(version, int) else None,
+        categories=[str(c) for c in row.get("categories") or [] if str(c).strip()],
+        concepts=[str(c) for c in row.get("concepts") or [] if str(c).strip()],
+        compiled_at=str(compiled_at) if compiled_at else None,
     )
 
 

--- a/ee/pocketpaw_ee/cloud/uploads/listeners.py
+++ b/ee/pocketpaw_ee/cloud/uploads/listeners.py
@@ -1,4 +1,9 @@
 # listeners.py — In-process subscribers for upload-related bus events.
+# Updated: 2026-08-04 (living-wiki review follow-up) — _extract_article_id now
+#   delegates to knowledge.extract_ingest_article_id: kb-go's real ingest
+#   receipt keys the id as "article" (finishIngest), which the inline
+#   id/article_id lookup never matched — so FL-11b tracking and the vector
+#   path silently never ran on real receipts.
 # Created: 2026-04-30 — Stage 1.B of "Files as Knowledge". Wires FileReady
 #   into the extraction chain and ingests the resulting text into the
 #   workspace KB scope. Pocket-scope routing lands in Stage 3.E.
@@ -227,16 +232,16 @@ async def index_uploaded_file(event: Event) -> None:
 
 
 def _extract_article_id(ingest_result) -> str | None:
-    """Pull the article id out of a kb-go ingest response.
+    """Pull the article id out of a kb-go ingest receipt.
 
-    kb-go returns ``{"id": "<uuid-or-slug>"}`` on success. We handle the
-    str-fallback case (kb-go falls through to raw stdout when JSON parsing
-    fails — a known shape from agents/knowledge.py:_kb).
+    Delegates to ``knowledge.extract_ingest_article_id`` — kb-go's actual
+    receipt keys the id as ``article`` (finishIngest), which the old inline
+    ``id``/``article_id`` lookup here never matched, so the FL-11b tracking
+    write (and the vector path) silently never ran for real receipts.
     """
-    if isinstance(ingest_result, dict):
-        article_id = ingest_result.get("id") or ingest_result.get("article_id")
-        return article_id if isinstance(article_id, str) else None
-    return None
+    from pocketpaw_ee.cloud.agents.knowledge import extract_ingest_article_id
+
+    return extract_ingest_article_id(ingest_result)
 
 
 async def _maybe_attach_vector(

--- a/ee/pocketpaw_ee/cloud/uploads/mongo_store.py
+++ b/ee/pocketpaw_ee/cloud/uploads/mongo_store.py
@@ -1,5 +1,9 @@
 """Mongo-backed metadata store, workspace-scoped.
 
+2026-08-04 (Living-wiki API): ``iter_by_workspace`` rows now also carry
+``kb_article_id`` and ``kb_scope`` (the FL-11b ingest-tracking columns) so
+GET /knowledge/uploads can derive ``has_article`` without a second query.
+Additive — existing consumers of the dict shape are unchanged.
 2026-07-03 (FL-11b "hide-from-AI purge"): added ``set_kb_article`` — a
 workspace-scoped setter the FileReady listener uses to record the kb-go
 ``article_id`` + ``scope`` on a row after a successful ingest, and the PATCH
@@ -276,6 +280,10 @@ class MongoFileStore:
                 "tags": list(getattr(doc, "tags", []) or []),
                 "collections": list(getattr(doc, "collections", []) or []),
                 "hide_from_ai": bool(getattr(doc, "hide_from_ai", False)),
+                # Living-wiki API: FL-11b ingest tracking, so /knowledge/uploads
+                # can derive has_article without a second query.
+                "kb_article_id": getattr(doc, "kb_article_id", None),
+                "kb_scope": getattr(doc, "kb_scope", None),
             }
 
     async def list_by_workspace(

--- a/ee/pocketpaw_ee/cloud/uploads/mongo_store.py
+++ b/ee/pocketpaw_ee/cloud/uploads/mongo_store.py
@@ -2,7 +2,11 @@
 
 2026-08-04 (Living-wiki API): ``iter_by_workspace`` rows now also carry
 ``kb_article_id`` and ``kb_scope`` (the FL-11b ingest-tracking columns) so
-GET /knowledge/uploads can derive ``has_article`` without a second query.
+GET /knowledge/uploads can derive ``has_article`` without a second query,
+plus ``pocket_id`` so workspace-level listings can exclude pocket-private
+rows. Added ``reassign_kb_article`` — after a reingest recompiles an
+article under a new slug, the tracking rows pointing at the old id are
+moved to the new one so a later hide-from-AI purge hits the live copy.
 Additive — existing consumers of the dict shape are unchanged.
 2026-07-03 (FL-11b "hide-from-AI purge"): added ``set_kb_article`` — a
 workspace-scoped setter the FileReady listener uses to record the kb-go
@@ -145,6 +149,36 @@ class MongoFileStore:
         await doc.save()
         return doc
 
+    async def reassign_kb_article(
+        self,
+        workspace: str,
+        *,
+        old_article_id: str,
+        new_article_id: str,
+        scope: str,
+    ) -> int:
+        """Move FL-11b tracking from one article id to another (living-wiki).
+
+        A reingest can recompile an article under a NEW slug; any upload row
+        still tracking the old id would purge a dead article on a later
+        hide-from-AI toggle while the live copy survives. Workspace-scoped
+        like every other write here. Returns the number of rows updated
+        (usually 0 or 1). No-op when the ids are equal.
+        """
+        if old_article_id == new_article_id:
+            return 0
+        updated = 0
+        docs = await FileUpload.find(
+            FileUpload.workspace == workspace,
+            FileUpload.kb_article_id == old_article_id,
+        ).to_list()
+        for doc in docs:
+            doc.kb_article_id = new_article_id
+            doc.kb_scope = scope
+            await doc.save()
+            updated += 1
+        return updated
+
     async def rewrite_folder_prefix(
         self,
         workspace: str,
@@ -281,9 +315,11 @@ class MongoFileStore:
                 "collections": list(getattr(doc, "collections", []) or []),
                 "hide_from_ai": bool(getattr(doc, "hide_from_ai", False)),
                 # Living-wiki API: FL-11b ingest tracking, so /knowledge/uploads
-                # can derive has_article without a second query.
+                # can derive has_article without a second query; pocket_id so
+                # workspace-level listings can exclude pocket-private rows.
                 "kb_article_id": getattr(doc, "kb_article_id", None),
                 "kb_scope": getattr(doc, "kb_scope", None),
+                "pocket_id": getattr(doc, "pocket_id", None),
             }
 
     async def list_by_workspace(

--- a/tests/cloud/test_knowledge_aggregator.py
+++ b/tests/cloud/test_knowledge_aggregator.py
@@ -1,4 +1,8 @@
 # test_knowledge_aggregator.py — Unit tests for the workspace KB aggregator.
+# Updated: 2026-08-04 — Living-wiki API: to_dict shape extended with wiki
+# metadata (summary, word_count, compiled_with, version, categories, concepts,
+# compiled_at); added a mapping test for the enriched rows including the
+# updated_at → compiled_at fallback.
 # Created: 2026-04-19 (Cluster C / PR1) — Pins the aggregator's merge and
 # scope-filter contract before it becomes the /knowledge/articles endpoint's
 # only test harness. See ee/cloud/kb/workspace_aggregator.py for the code
@@ -22,6 +26,7 @@ from __future__ import annotations
 import pytest
 from pocketpaw_ee.cloud.kb.workspace_aggregator import (
     AggregatedArticle,
+    _row_to_article,
     aggregate_workspace_articles,
 )
 
@@ -209,4 +214,40 @@ def test_aggregated_article_to_dict_shape():
         "scope": "workspace:ws1",
         "agent_id": None,
         "updated_at": "2026-04-19T00:00:00Z",
+        # Living-wiki metadata (2026-08-04) — defaults when the kb row
+        # doesn't carry them (orphan raw docs, older binaries).
+        "summary": "",
+        "word_count": 0,
+        "compiled_with": None,
+        "version": None,
+        "categories": [],
+        "concepts": [],
+        "compiled_at": None,
     }
+
+
+def test_row_wiki_metadata_maps_through():
+    """kb rows enriched with wiki frontmatter surface the full wiki row."""
+    row = {
+        "id": "art-1",
+        "title": "T",
+        "summary": "S.",
+        "word_count": 321,
+        "compiled_with": "claude-haiku-4-5",
+        "version": 2,
+        "categories": ["Ops"],
+        "concepts": ["deploys", "rollbacks"],
+        "compiled_at": "2026-08-01T00:00:00Z",
+    }
+    article = _row_to_article(row, scope="workspace:ws1", agent_id=None)
+    assert article is not None
+    assert article.summary == "S."
+    assert article.word_count == 321
+    assert article.compiled_with == "claude-haiku-4-5"
+    assert article.version == 2
+    assert article.categories == ["Ops"]
+    assert article.concepts == ["deploys", "rollbacks"]
+    assert article.compiled_at == "2026-08-01T00:00:00Z"
+    # No explicit updated_at on kb rows — falls back to compiled_at so the
+    # newest-first sort keeps working.
+    assert article.updated_at == "2026-08-01T00:00:00Z"

--- a/tests/cloud/test_knowledge_wiki_api.py
+++ b/tests/cloud/test_knowledge_wiki_api.py
@@ -1,0 +1,565 @@
+# test_knowledge_wiki_api.py — Integration tests for the living-wiki API.
+# Created: 2026-08-04 — Covers the /knowledge REST surface the wiki frontend
+# rebuild codes against: enriched GET /articles rows, GET /articles/{id}
+# (full body + orphan fallback + 404), GET /stats, GET /uploads, and the two
+# reingest routes. kb output is faked at the subprocess boundary (the spy
+# pattern from tests/cloud/kb/test_router_ingest_funnel.py) so the REAL
+# KnowledgeService funnel runs and the reingest argv stays pinned; the wiki
+# frontmatter / raw-doc reads hit a real temp KB home.
+"""Integration tests for the workspace living-wiki API."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pocketpaw_ee.cloud.kb.knowledge_router as knowledge_router_module
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pocketpaw_ee.cloud.agents import knowledge
+from pocketpaw_ee.cloud.auth import current_active_user
+from pocketpaw_ee.cloud.license import require_license
+
+WORKSPACE = "ws-alpha"
+WS_SCOPE = f"workspace:{WORKSPACE}"
+WS_DIR = f"workspace_{WORKSPACE.replace('-', '-')}"  # sanitize() keeps '-'
+
+
+class _SubprocessSpy:
+    """Records kb argv + stdin; answers via a matcher on the subcommand."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+        self.responses: dict[str, tuple[int, str, str]] = {}
+        self._real_run = subprocess.run
+
+    def __call__(self, cmd, input=None, timeout=None, **kwargs):  # noqa: A002
+        if not cmd or cmd[0] != knowledge.KB_BIN:
+            return self._real_run(cmd, input=input, timeout=timeout, **kwargs)
+        self.calls.append({"cmd": list(cmd), "input": input, "timeout": timeout})
+        subcommand = cmd[1]
+        returncode, stdout, stderr = self.responses.get(subcommand, (1, "", "no fake response"))
+        return subprocess.CompletedProcess(cmd, returncode, stdout=stdout, stderr=stderr)
+
+
+def _write_article(kb_home: str, scope_dir: str, article_id: str, fm: dict, content: str) -> None:
+    wiki = os.path.join(kb_home, scope_dir, "wiki")
+    os.makedirs(wiki, exist_ok=True)
+    with open(os.path.join(wiki, f"{article_id}.md"), "w", encoding="utf-8") as fh:
+        fh.write(f"---\n{json.dumps(fm)}\n---\n\n{content}")
+
+
+def _write_raw_doc(kb_home: str, scope_dir: str, raw_id: str, doc: dict) -> None:
+    raw = os.path.join(kb_home, scope_dir, "raw")
+    os.makedirs(raw, exist_ok=True)
+    with open(os.path.join(raw, f"{raw_id}.json"), "w", encoding="utf-8") as fh:
+        json.dump(doc, fh)
+
+
+@pytest.fixture()
+def kb_home(tmp_path, monkeypatch) -> str:
+    home = str(tmp_path / "knowledge-base")
+    os.makedirs(home, exist_ok=True)
+    monkeypatch.setattr(knowledge_router_module, "KB_HOME", home)
+    return home
+
+
+@pytest.fixture()
+def spy(monkeypatch) -> _SubprocessSpy:
+    spy = _SubprocessSpy()
+    monkeypatch.setattr(knowledge.subprocess, "run", spy)
+    return spy
+
+
+@pytest.fixture()
+def client(monkeypatch) -> TestClient:
+    async def fake_list_workspace_agent_ids(workspace_id: str) -> list[str]:
+        return ["agent-1"] if workspace_id == WORKSPACE else []
+
+    monkeypatch.setattr(
+        knowledge_router_module,
+        "_list_workspace_agent_ids",
+        fake_list_workspace_agent_ids,
+    )
+
+    # Scope-override allowlist: the caller may use the workspace + its agent.
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.kb.service._candidate_scopes",
+        AsyncMock(return_value=[WS_SCOPE, "agent:agent-1"]),
+    )
+
+    # Stub RBAC (see test_knowledge_router.py for why this seam works here).
+    from pocketpaw_ee.guards import deps as guards_deps
+
+    monkeypatch.setattr(guards_deps, "check_workspace_action", lambda *a, **k: None)
+
+    fake_user = SimpleNamespace(
+        id="user-1",
+        active_workspace=WORKSPACE,
+        workspaces=[SimpleNamespace(workspace=WORKSPACE, role="owner")],
+    )
+
+    async def fake_current_active_user():
+        return fake_user
+
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.dependency_overrides[require_license] = lambda: None
+    app.dependency_overrides[current_active_user] = fake_current_active_user
+    app.include_router(knowledge_router_module.router, prefix="/api/v1")
+    return TestClient(app)
+
+
+class _FakeMongoFileStore:
+    """Async-iterable stand-in for MongoFileStore (Beanie isn't initialised)."""
+
+    rows: list[dict] = []
+    doc: SimpleNamespace | None = None
+    kb_article_calls: list[dict] = []
+
+    async def iter_by_workspace(self, workspace: str, **kwargs):
+        for row in type(self).rows:
+            yield row
+
+    async def get_doc_scoped(self, file_id: str, workspace: str):
+        doc = type(self).doc
+        if doc is not None and doc.file_id == file_id:
+            return doc
+        return None
+
+    async def set_kb_article(self, file_id, workspace, *, article_id, scope):
+        type(self).kb_article_calls.append(
+            {"file_id": file_id, "workspace": workspace, "article_id": article_id, "scope": scope}
+        )
+        return SimpleNamespace()
+
+
+@pytest.fixture()
+def fake_store(monkeypatch) -> type[_FakeMongoFileStore]:
+    _FakeMongoFileStore.rows = []
+    _FakeMongoFileStore.doc = None
+    _FakeMongoFileStore.kb_article_calls = []
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.uploads.mongo_store.MongoFileStore", _FakeMongoFileStore
+    )
+    return _FakeMongoFileStore
+
+
+# ---------------------------------------------------------------------------
+# GET /knowledge/articles — enriched rows
+# ---------------------------------------------------------------------------
+
+
+def test_articles_rows_carry_wiki_metadata(client, kb_home, spy) -> None:
+    spy.responses["list"] = (
+        0,
+        json.dumps(
+            [
+                {
+                    "id": "art-1",
+                    "title": "Deploy runbook",
+                    "summary": "How we deploy.",
+                    "word_count": 250,
+                    "compiled_with": "claude-haiku-4-5",
+                    "version": 3,
+                }
+            ]
+        ),
+        "",
+    )
+    _write_article(
+        kb_home,
+        WS_DIR,
+        "art-1",
+        {
+            "title": "Deploy runbook",
+            "categories": ["Ops"],
+            "concepts": ["deploys", "rollbacks"],
+            "compiled_at": "2026-08-01T12:00:00Z",
+            "source_docs": ["raw-1"],
+        },
+        "# Deploy runbook",
+    )
+    _write_raw_doc(
+        kb_home,
+        WS_DIR,
+        "raw-orphan",
+        {"source": "notes.txt", "raw_text": "some notes", "word_count": 2},
+    )
+
+    response = client.get("/api/v1/knowledge/articles")
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert set(body) == {"articles", "total", "agent_ids"}
+    rows = {a["id"]: a for a in body["articles"]}
+
+    # kb list rows appear once per scope (workspace + agent-1 both answered
+    # by the same fake) — check the workspace one.
+    art = next(a for a in body["articles"] if a["id"] == "art-1" and a["scope"] == WS_SCOPE)
+    assert art["word_count"] == 250
+    assert art["compiled_with"] == "claude-haiku-4-5"
+    assert art["version"] == 3
+    assert art["summary"] == "How we deploy."
+    assert art["categories"] == ["Ops"]
+    assert art["concepts"] == ["deploys", "rollbacks"]
+    assert art["compiled_at"] == "2026-08-01T12:00:00Z"
+    # No updated_at from kb list — falls back to compiled_at.
+    assert art["updated_at"] == "2026-08-01T12:00:00Z"
+
+    # The orphan raw doc surfaces as a synthetic uncompiled row.
+    orphan = rows["raw-orphan"]
+    assert orphan["title"] == "notes.txt"
+    assert orphan["compiled_with"] is None
+    assert orphan["word_count"] == 2
+
+
+# ---------------------------------------------------------------------------
+# GET /knowledge/articles/{article_id}
+# ---------------------------------------------------------------------------
+
+
+def test_get_article_full_body(client, kb_home, spy) -> None:
+    spy.responses["show"] = (
+        0,
+        json.dumps(
+            {
+                "id": "art-1",
+                "title": "Deploy runbook",
+                "summary": "How we deploy.",
+                "content": "# Deploy runbook\n\nSteps.",
+                "concepts": ["deploys"],
+                "categories": ["Ops"],
+                "backlinks": ["art-2"],
+                "word_count": 250,
+                "compiled_with": "claude-haiku-4-5",
+                "version": 3,
+            }
+        ),
+        "",
+    )
+    _write_article(
+        kb_home,
+        WS_DIR,
+        "art-1",
+        {"compiled_at": "2026-08-01T12:00:00Z", "source_docs": ["raw-1"]},
+        "# Deploy runbook",
+    )
+
+    response = client.get("/api/v1/knowledge/articles/art-1")
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["content"] == "# Deploy runbook\n\nSteps."
+    assert body["backlinks"] == ["art-2"]
+    assert body["compiled_at"] == "2026-08-01T12:00:00Z"
+    assert body["source_docs"] == ["raw-1"]
+    assert body["scope"] == WS_SCOPE
+    assert body["orphan"] is False
+    # kb show must have been asked for exactly this article + scope.
+    assert spy.calls[0]["cmd"][1:] == ["show", "art-1", "--scope", WS_SCOPE, "--json"]
+
+
+def test_get_article_unknown_id_404(client, kb_home, spy) -> None:
+    # kb show exits 1 ("Article not found") and there is no raw doc either.
+    response = client.get("/api/v1/knowledge/articles/nope")
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "article.not_found"
+
+
+def test_get_article_orphan_raw_doc_fallback(client, kb_home, spy) -> None:
+    _write_raw_doc(
+        kb_home,
+        WS_DIR,
+        "raw-orphan",
+        {"source": "notes.txt", "raw_text": "some notes", "word_count": 2},
+    )
+    response = client.get("/api/v1/knowledge/articles/raw-orphan")
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["orphan"] is True
+    assert body["content"] == "some notes"
+    assert body["compiled_with"] is None
+    assert body["title"] == "notes.txt"
+
+
+def test_get_article_scope_guard_denies_foreign_user_scope(client, kb_home, spy) -> None:
+    response = client.get("/api/v1/knowledge/articles/art-1?scope=user:someone-else")
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "kb.scope_forbidden"
+    assert spy.calls == []  # denied before any kb call
+
+
+# ---------------------------------------------------------------------------
+# GET /knowledge/stats
+# ---------------------------------------------------------------------------
+
+
+def test_stats_rolls_up_workspace_and_agent_scopes(client, kb_home, spy) -> None:
+    spy.responses["stats"] = (
+        0,
+        json.dumps(
+            {
+                "scope": "x",
+                "articles": 4,
+                "raw_docs": 5,
+                "words": 1000,
+                "concepts": 12,
+                "categories": 3,
+                "vectors": 0,
+            }
+        ),
+        "",
+    )
+    response = client.get("/api/v1/knowledge/stats")
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["agent_ids"] == ["agent-1"]
+    assert [r["scope"] for r in body["stats"]] == [WS_SCOPE, "agent:agent-1"]
+    ws_row = body["stats"][0]
+    assert ws_row == {
+        "scope": WS_SCOPE,
+        "agent_id": None,
+        "articles": 4,
+        "words": 1000,
+        "raw_docs": 5,
+        "concepts": 12,
+        "categories": 3,
+    }
+    # One kb stats call per scope.
+    assert [c["cmd"][1] for c in spy.calls] == ["stats", "stats"]
+
+
+# ---------------------------------------------------------------------------
+# POST /knowledge/reingest
+# ---------------------------------------------------------------------------
+
+
+def test_reingest_routes_raw_doc_through_funnel(client, kb_home, spy, monkeypatch) -> None:
+    """The reingest argv is pinned to the funnel's plain-ingest shape."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    _write_article(
+        kb_home,
+        WS_DIR,
+        "art-1",
+        {"title": "Notes", "source_docs": ["raw-1"]},
+        "# Notes",
+    )
+    _write_raw_doc(
+        kb_home,
+        WS_DIR,
+        "raw-1",
+        {"source": "notes.txt", "raw_text": "the raw text", "word_count": 3},
+    )
+    spy.responses["ingest"] = (0, json.dumps({"id": "art-1", "compiled_with": "llm"}), "")
+
+    response = client.post(
+        "/api/v1/knowledge/reingest", json={"article_id": "art-1", "scope": WS_SCOPE}
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["scope"] == WS_SCOPE
+    assert body["raw_doc_id"] == "raw-1"
+    assert body["source"] == "notes.txt"
+    assert body["result"]["id"] == "art-1"
+
+    assert len(spy.calls) == 1
+    assert spy.calls[0]["cmd"][1:] == [
+        "ingest",
+        "--scope",
+        WS_SCOPE,
+        "--source",
+        "notes.txt",
+        "--json",
+    ]
+    assert spy.calls[0]["input"] == "the raw text"
+
+
+def test_reingest_orphan_raw_id_directly(client, kb_home, spy, monkeypatch) -> None:
+    """An orphan raw-doc id (no wiki article) reingests its own raw doc."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    _write_raw_doc(
+        kb_home,
+        WS_DIR,
+        "raw-orphan",
+        {"source": "orphan.txt", "raw_text": "orphan text", "word_count": 2},
+    )
+    spy.responses["ingest"] = (0, json.dumps({"id": "art-new", "compiled_with": "llm"}), "")
+
+    response = client.post("/api/v1/knowledge/reingest", json={"article_id": "raw-orphan"})
+    assert response.status_code == 200, response.text
+    assert response.json()["raw_doc_id"] == "raw-orphan"
+    assert spy.calls[0]["input"] == "orphan text"
+
+
+def test_reingest_unknown_article_404(client, kb_home, spy) -> None:
+    response = client.post("/api/v1/knowledge/reingest", json={"article_id": "missing"})
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "article.not_found"
+    assert spy.calls == []
+
+
+def test_reingest_scope_guard_denies_foreign_user_scope(client, kb_home, spy) -> None:
+    response = client.post(
+        "/api/v1/knowledge/reingest",
+        json={"article_id": "art-1", "scope": "user:someone-else"},
+    )
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "kb.scope_forbidden"
+    assert spy.calls == []
+
+
+# ---------------------------------------------------------------------------
+# POST /knowledge/reingest-upload
+# ---------------------------------------------------------------------------
+
+
+def _install_upload_pipeline(monkeypatch, tmp_path, *, text: str) -> None:
+    """Fake adapter + extraction chain around a real temp file."""
+    blob = tmp_path / "report.pdf"
+    blob.write_bytes(b"%PDF-fake")
+
+    adapter = SimpleNamespace(local_path=lambda key: blob)
+    monkeypatch.setattr(knowledge_router_module, "_resolve_upload_adapter", lambda: adapter)
+
+    class _FakeChain:
+        async def run(self, path, mime):
+            assert str(path) == str(blob)
+            return SimpleNamespace(text=text)
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.extraction.build_chain", lambda settings: _FakeChain())
+
+
+def test_reingest_upload_extracts_and_funnels(
+    client, kb_home, spy, fake_store, monkeypatch, tmp_path
+) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    fake_store.doc = SimpleNamespace(
+        file_id="up-1",
+        storage_key="ws/up-1",
+        filename="report.pdf",
+        mime="application/pdf",
+        hide_from_ai=False,
+    )
+    _install_upload_pipeline(monkeypatch, tmp_path, text="extracted report text")
+    spy.responses["ingest"] = (0, json.dumps({"id": "art-up", "compiled_with": "llm"}), "")
+
+    response = client.post(
+        "/api/v1/knowledge/reingest-upload", json={"upload_id": "up-1", "scope": WS_SCOPE}
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["filename"] == "report.pdf"
+    assert body["result"]["id"] == "art-up"
+
+    # The funnel argv carries the ORIGINAL filename as source.
+    assert spy.calls[0]["cmd"][1:] == [
+        "ingest",
+        "--scope",
+        WS_SCOPE,
+        "--source",
+        "report.pdf",
+        "--json",
+    ]
+    assert spy.calls[0]["input"] == "extracted report text"
+
+    # FL-11b tracking recorded for the later hide-from-AI purge.
+    assert fake_store.kb_article_calls == [
+        {"file_id": "up-1", "workspace": WORKSPACE, "article_id": "art-up", "scope": WS_SCOPE}
+    ]
+
+
+def test_reingest_upload_hidden_file_refused(client, kb_home, spy, fake_store) -> None:
+    fake_store.doc = SimpleNamespace(
+        file_id="up-hidden",
+        storage_key="ws/up-hidden",
+        filename="secret.pdf",
+        mime="application/pdf",
+        hide_from_ai=True,
+    )
+    response = client.post("/api/v1/knowledge/reingest-upload", json={"upload_id": "up-hidden"})
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "knowledge.upload_hidden"
+    assert spy.calls == []
+
+
+def test_reingest_upload_unknown_id_404(client, kb_home, spy, fake_store) -> None:
+    response = client.post("/api/v1/knowledge/reingest-upload", json={"upload_id": "nope"})
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "upload.not_found"
+
+
+# ---------------------------------------------------------------------------
+# GET /knowledge/uploads
+# ---------------------------------------------------------------------------
+
+
+def test_list_uploads_has_article_markers(client, kb_home, fake_store) -> None:
+    uploaded_at = datetime(2026, 8, 1, 10, 0, tzinfo=UTC)
+    fake_store.rows = [
+        {
+            "file_id": "up-tracked",
+            "filename": "tracked.pdf",
+            "mime": "application/pdf",
+            "size": 100,
+            "created_at": uploaded_at,
+            "hide_from_ai": False,
+            "kb_article_id": "art-1",
+            "kb_scope": WS_SCOPE,
+        },
+        {
+            "file_id": "up-legacy",
+            "filename": "legacy.txt",
+            "mime": "text/plain",
+            "size": 50,
+            "created_at": uploaded_at,
+            "hide_from_ai": False,
+            "kb_article_id": None,
+            "kb_scope": None,
+        },
+        {
+            "file_id": "up-pending",
+            "filename": "pending.docx",
+            "mime": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "size": 75,
+            "created_at": uploaded_at,
+            "hide_from_ai": False,
+            "kb_article_id": None,
+            "kb_scope": None,
+        },
+        {
+            "file_id": "up-hidden",
+            "filename": "hidden.pdf",
+            "mime": "application/pdf",
+            "size": 10,
+            "created_at": uploaded_at,
+            "hide_from_ai": True,
+            "kb_article_id": None,
+            "kb_scope": None,
+        },
+    ]
+    # legacy.txt predates FL-11b tracking but IS compiled in the scope —
+    # article frontmatter → raw doc → source filename match.
+    _write_article(
+        kb_home, WS_DIR, "art-legacy", {"title": "Legacy", "source_docs": ["raw-legacy"]}, "# L"
+    )
+    _write_raw_doc(
+        kb_home, WS_DIR, "raw-legacy", {"source": "legacy.txt", "raw_text": "x", "word_count": 1}
+    )
+
+    response = client.get("/api/v1/knowledge/uploads")
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["scope"] == WS_SCOPE
+    rows = {u["id"]: u for u in body["uploads"]}
+    assert set(rows) == {"up-tracked", "up-legacy", "up-pending"}  # hidden excluded
+    assert rows["up-tracked"]["has_article"] is True
+    assert rows["up-legacy"]["has_article"] is True  # filename fallback
+    assert rows["up-pending"]["has_article"] is False
+    assert rows["up-tracked"]["uploaded_at"] == uploaded_at.isoformat()
+    assert rows["up-tracked"]["size"] == 100

--- a/tests/cloud/test_knowledge_wiki_api.py
+++ b/tests/cloud/test_knowledge_wiki_api.py
@@ -1,4 +1,8 @@
 # test_knowledge_wiki_api.py — Integration tests for the living-wiki API.
+# Updated: 2026-08-04 (review follow-up) — two guard pins: a path-traversal
+# article_id on POST /reingest answers 404 with no kb call and nothing served
+# from outside the scope dir (sentinel file proves it), and GET /uploads
+# denies a foreign user: scope with 403 kb.scope_forbidden before any kb call.
 # Created: 2026-08-04 — Covers the /knowledge REST surface the wiki frontend
 # rebuild codes against: enriched GET /articles rows, GET /articles/{id}
 # (full body + orphan fallback + 404), GET /stats, GET /uploads, and the two
@@ -404,6 +408,30 @@ def test_reingest_unknown_article_404(client, kb_home, spy) -> None:
     assert spy.calls == []
 
 
+def test_reingest_traversal_article_id_is_404(client, kb_home, spy) -> None:
+    """A path-traversal article_id never reaches kb or the filesystem walk.
+
+    The containment guard (mirror of kb-go's containedID) rejects the id
+    before any frontmatter/raw read, answering 404 — not 400 — so the route
+    can't be used as a traversal oracle. A sentinel file OUTSIDE the scope
+    dir proves nothing beyond the guard is ever served.
+    """
+    outside = os.path.join(kb_home, "..", "outside-secret.json")
+    with open(outside, "w", encoding="utf-8") as fh:
+        json.dump({"raw_text": "must never surface", "source": "secret"}, fh)
+    try:
+        response = client.post(
+            "/api/v1/knowledge/reingest",
+            json={"article_id": "../../etc/passwd", "scope": WS_SCOPE},
+        )
+        assert response.status_code == 404
+        assert response.json()["error"]["code"] == "article.not_found"
+        assert "must never surface" not in response.text
+        assert spy.calls == []  # rejected before any kb subprocess call
+    finally:
+        os.unlink(outside)
+
+
 def test_reingest_scope_guard_denies_foreign_user_scope(client, kb_home, spy) -> None:
     response = client.post(
         "/api/v1/knowledge/reingest",
@@ -497,6 +525,13 @@ def test_reingest_upload_unknown_id_404(client, kb_home, spy, fake_store) -> Non
 # ---------------------------------------------------------------------------
 # GET /knowledge/uploads
 # ---------------------------------------------------------------------------
+
+
+def test_list_uploads_scope_guard_denies_foreign_user_scope(client, kb_home, spy) -> None:
+    response = client.get("/api/v1/knowledge/uploads?scope=user:someone-else")
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "kb.scope_forbidden"
+    assert spy.calls == []  # denied before any kb call or store read
 
 
 def test_list_uploads_has_article_markers(client, kb_home, fake_store) -> None:

--- a/tests/cloud/test_knowledge_wiki_api.py
+++ b/tests/cloud/test_knowledge_wiki_api.py
@@ -1,4 +1,12 @@
 # test_knowledge_wiki_api.py — Integration tests for the living-wiki API.
+# Updated: 2026-08-04 (final review fixes) — pins for the security + tracking
+# round: pocket-private rows excluded from GET /uploads; pocket-scoped upload
+# reingest refused (403 knowledge.upload_pocket_scoped); FL-11b tracking fires
+# on kb-go's REAL receipt shape ({"article": id}, not {"id": ...}) including
+# the reassign on a new slug; kb outage on GET /articles/{id} answers 500
+# knowledge.kb_unavailable (404 only on a genuine "Article not found" miss);
+# and the has_article filename fallback rejects a fresh same-named re-upload
+# (created after the article's compiled_at).
 # Updated: 2026-08-04 (review follow-up) — two guard pins: a path-traversal
 # article_id on POST /reingest answers 404 with no kb call and nothing served
 # from outside the scope dir (sentinel file proves it), and GET /uploads
@@ -127,6 +135,7 @@ class _FakeMongoFileStore:
     rows: list[dict] = []
     doc: SimpleNamespace | None = None
     kb_article_calls: list[dict] = []
+    reassign_calls: list[dict] = []
 
     async def iter_by_workspace(self, workspace: str, **kwargs):
         for row in type(self).rows:
@@ -144,12 +153,24 @@ class _FakeMongoFileStore:
         )
         return SimpleNamespace()
 
+    async def reassign_kb_article(self, workspace, *, old_article_id, new_article_id, scope):
+        type(self).reassign_calls.append(
+            {
+                "workspace": workspace,
+                "old_article_id": old_article_id,
+                "new_article_id": new_article_id,
+                "scope": scope,
+            }
+        )
+        return 1
+
 
 @pytest.fixture()
 def fake_store(monkeypatch) -> type[_FakeMongoFileStore]:
     _FakeMongoFileStore.rows = []
     _FakeMongoFileStore.doc = None
     _FakeMongoFileStore.kb_article_calls = []
+    _FakeMongoFileStore.reassign_calls = []
     monkeypatch.setattr(
         "pocketpaw_ee.cloud.uploads.mongo_store.MongoFileStore", _FakeMongoFileStore
     )
@@ -270,13 +291,23 @@ def test_get_article_full_body(client, kb_home, spy) -> None:
 
 
 def test_get_article_unknown_id_404(client, kb_home, spy) -> None:
-    # kb show exits 1 ("Article not found") and there is no raw doc either.
+    # kb show exits 1 with kb-go's fatal text and there is no raw doc either.
+    spy.responses["show"] = (1, "", "Error: Article not found: nope")
     response = client.get("/api/v1/knowledge/articles/nope")
     assert response.status_code == 404
     assert response.json()["error"]["code"] == "article.not_found"
 
 
+def test_get_article_kb_outage_is_500_not_404(client, kb_home, spy) -> None:
+    """A kb failure that ISN'T a miss must not tell the UI the article vanished."""
+    spy.responses["show"] = (1, "", "some transient failure")
+    response = client.get("/api/v1/knowledge/articles/art-1")
+    assert response.status_code == 500
+    assert response.json()["error"]["code"] == "knowledge.kb_unavailable"
+
+
 def test_get_article_orphan_raw_doc_fallback(client, kb_home, spy) -> None:
+    spy.responses["show"] = (1, "", "Error: Article not found: raw-orphan")
     _write_raw_doc(
         kb_home,
         WS_DIR,
@@ -384,8 +415,13 @@ def test_reingest_routes_raw_doc_through_funnel(client, kb_home, spy, monkeypatc
     assert spy.calls[0]["input"] == "the raw text"
 
 
-def test_reingest_orphan_raw_id_directly(client, kb_home, spy, monkeypatch) -> None:
-    """An orphan raw-doc id (no wiki article) reingests its own raw doc."""
+def test_reingest_orphan_raw_id_directly(client, kb_home, spy, fake_store, monkeypatch) -> None:
+    """An orphan raw-doc id (no wiki article) reingests its own raw doc.
+
+    Uses kb-go's REAL receipt shape ({"article": id}) — and since the compile
+    landed under a new id, the FL-11b tracking reassign must be attempted so
+    upload rows pointing at the old id keep purging the live copy.
+    """
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
     _write_raw_doc(
         kb_home,
@@ -393,12 +429,26 @@ def test_reingest_orphan_raw_id_directly(client, kb_home, spy, monkeypatch) -> N
         "raw-orphan",
         {"source": "orphan.txt", "raw_text": "orphan text", "word_count": 2},
     )
-    spy.responses["ingest"] = (0, json.dumps({"id": "art-new", "compiled_with": "llm"}), "")
+    spy.responses["ingest"] = (
+        0,
+        json.dumps({"article": "art-new", "title": "Orphan", "words": 2, "compiled_with": "llm"}),
+        "",
+    )
 
     response = client.post("/api/v1/knowledge/reingest", json={"article_id": "raw-orphan"})
     assert response.status_code == 200, response.text
-    assert response.json()["raw_doc_id"] == "raw-orphan"
+    body = response.json()
+    assert body["raw_doc_id"] == "raw-orphan"
+    assert body["new_article_id"] == "art-new"  # extracted from the "article" key
     assert spy.calls[0]["input"] == "orphan text"
+    assert fake_store.reassign_calls == [
+        {
+            "workspace": WORKSPACE,
+            "old_article_id": "raw-orphan",
+            "new_article_id": "art-new",
+            "scope": WS_SCOPE,
+        }
+    ]
 
 
 def test_reingest_unknown_article_404(client, kb_home, spy) -> None:
@@ -475,7 +525,14 @@ def test_reingest_upload_extracts_and_funnels(
         hide_from_ai=False,
     )
     _install_upload_pipeline(monkeypatch, tmp_path, text="extracted report text")
-    spy.responses["ingest"] = (0, json.dumps({"id": "art-up", "compiled_with": "llm"}), "")
+    # kb-go's REAL ingest receipt: the id key is "article", not "id"
+    # (finishIngest). Reading result["id"] was the bug that left FL-11b
+    # tracking dead — this receipt shape is what pins the fix.
+    spy.responses["ingest"] = (
+        0,
+        json.dumps({"article": "art-up", "title": "Report", "words": 3, "compiled_with": "llm"}),
+        "",
+    )
 
     response = client.post(
         "/api/v1/knowledge/reingest-upload", json={"upload_id": "up-1", "scope": WS_SCOPE}
@@ -483,7 +540,8 @@ def test_reingest_upload_extracts_and_funnels(
     assert response.status_code == 200, response.text
     body = response.json()
     assert body["filename"] == "report.pdf"
-    assert body["result"]["id"] == "art-up"
+    assert body["article_id"] == "art-up"  # extracted from the "article" key
+    assert body["result"]["article"] == "art-up"
 
     # The funnel argv carries the ORIGINAL filename as source.
     assert spy.calls[0]["cmd"][1:] == [
@@ -516,6 +574,22 @@ def test_reingest_upload_hidden_file_refused(client, kb_home, spy, fake_store) -
     assert spy.calls == []
 
 
+def test_reingest_upload_pocket_scoped_refused(client, kb_home, spy, fake_store) -> None:
+    """A pocket-private upload must not be liftable into workspace KB."""
+    fake_store.doc = SimpleNamespace(
+        file_id="up-pocket",
+        storage_key="ws/up-pocket",
+        filename="pocket-notes.pdf",
+        mime="application/pdf",
+        hide_from_ai=False,
+        pocket_id="pocket-1",
+    )
+    response = client.post("/api/v1/knowledge/reingest-upload", json={"upload_id": "up-pocket"})
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "knowledge.upload_pocket_scoped"
+    assert spy.calls == []  # refused before extraction or any kb call
+
+
 def test_reingest_upload_unknown_id_404(client, kb_home, spy, fake_store) -> None:
     response = client.post("/api/v1/knowledge/reingest-upload", json={"upload_id": "nope"})
     assert response.status_code == 404
@@ -536,6 +610,8 @@ def test_list_uploads_scope_guard_denies_foreign_user_scope(client, kb_home, spy
 
 def test_list_uploads_has_article_markers(client, kb_home, fake_store) -> None:
     uploaded_at = datetime(2026, 8, 1, 10, 0, tzinfo=UTC)
+    compiled_at = "2026-08-01T11:00:00Z"  # after uploaded_at, before re-upload
+    reuploaded_at = datetime(2026, 8, 4, 9, 0, tzinfo=UTC)
     fake_store.rows = [
         {
             "file_id": "up-tracked",
@@ -546,6 +622,7 @@ def test_list_uploads_has_article_markers(client, kb_home, fake_store) -> None:
             "hide_from_ai": False,
             "kb_article_id": "art-1",
             "kb_scope": WS_SCOPE,
+            "pocket_id": None,
         },
         {
             "file_id": "up-legacy",
@@ -556,6 +633,20 @@ def test_list_uploads_has_article_markers(client, kb_home, fake_store) -> None:
             "hide_from_ai": False,
             "kb_article_id": None,
             "kb_scope": None,
+            "pocket_id": None,
+        },
+        {
+            # FRESH re-upload of the same filename, created AFTER the article
+            # was compiled — the filename fallback must NOT mark it compiled.
+            "file_id": "up-reupload",
+            "filename": "legacy.txt",
+            "mime": "text/plain",
+            "size": 55,
+            "created_at": reuploaded_at,
+            "hide_from_ai": False,
+            "kb_article_id": None,
+            "kb_scope": None,
+            "pocket_id": None,
         },
         {
             "file_id": "up-pending",
@@ -566,6 +657,7 @@ def test_list_uploads_has_article_markers(client, kb_home, fake_store) -> None:
             "hide_from_ai": False,
             "kb_article_id": None,
             "kb_scope": None,
+            "pocket_id": None,
         },
         {
             "file_id": "up-hidden",
@@ -576,12 +668,30 @@ def test_list_uploads_has_article_markers(client, kb_home, fake_store) -> None:
             "hide_from_ai": True,
             "kb_article_id": None,
             "kb_scope": None,
+            "pocket_id": None,
+        },
+        {
+            # Pocket-private — must not list on the workspace surface at all.
+            "file_id": "up-pocket",
+            "filename": "pocket-notes.pdf",
+            "mime": "application/pdf",
+            "size": 20,
+            "created_at": uploaded_at,
+            "hide_from_ai": False,
+            "kb_article_id": "art-p",
+            "kb_scope": "pocket:pocket-1",
+            "pocket_id": "pocket-1",
         },
     ]
     # legacy.txt predates FL-11b tracking but IS compiled in the scope —
-    # article frontmatter → raw doc → source filename match.
+    # article frontmatter (compiled AFTER the original upload) → raw doc →
+    # source filename match.
     _write_article(
-        kb_home, WS_DIR, "art-legacy", {"title": "Legacy", "source_docs": ["raw-legacy"]}, "# L"
+        kb_home,
+        WS_DIR,
+        "art-legacy",
+        {"title": "Legacy", "source_docs": ["raw-legacy"], "compiled_at": compiled_at},
+        "# L",
     )
     _write_raw_doc(
         kb_home, WS_DIR, "raw-legacy", {"source": "legacy.txt", "raw_text": "x", "word_count": 1}
@@ -592,9 +702,11 @@ def test_list_uploads_has_article_markers(client, kb_home, fake_store) -> None:
     body = response.json()
     assert body["scope"] == WS_SCOPE
     rows = {u["id"]: u for u in body["uploads"]}
-    assert set(rows) == {"up-tracked", "up-legacy", "up-pending"}  # hidden excluded
+    # hidden + pocket-private excluded entirely.
+    assert set(rows) == {"up-tracked", "up-legacy", "up-reupload", "up-pending"}
     assert rows["up-tracked"]["has_article"] is True
-    assert rows["up-legacy"]["has_article"] is True  # filename fallback
+    assert rows["up-legacy"]["has_article"] is True  # fallback: upload predates compile
+    assert rows["up-reupload"]["has_article"] is False  # fresh re-upload stays pending
     assert rows["up-pending"]["has_article"] is False
     assert rows["up-tracked"]["uploaded_at"] == uploaded_at.isoformat()
     assert rows["up-tracked"]["size"] == 100


### PR DESCRIPTION
## What this does

The /knowledge frontend is being rebuilt as a living wiki, and the old aggregator endpoint didn't carry enough for it to render anything beyond a title list. This PR extends the read surface and adds reingest, all as thin wrappers — the heavy lifting stays in the hardened `KnowledgeService` funnel that landed earlier today (#1859).

### Extended
- `GET /knowledge/articles` — rows now carry `summary`, `word_count`, `compiled_with`, `version`, `categories`, `concepts`, `compiled_at`. `kb list --json` only emits the first three, so the rest come from the article's own wiki frontmatter (the same on-disk format the orphan scan already reads). `updated_at` falls back to `compiled_at` so newest-first sorting works on real data. Existing keys and the `{articles, total, agent_ids}` shape are unchanged.
- The per-scope kb subprocess now runs off the event loop; it used to block the handler for the whole aggregation.

### New
- `GET /knowledge/articles/{id}?scope=` — full article via `kb show` plus `content`, `backlinks`, `compiled_at`, `source_docs`. Orphan raw docs (ingested, never compiled) return `orphan: true` with the raw text, so the rows the listing surfaces are all clickable. Unknown id or scope → 404.
- `GET /knowledge/stats` — `kb stats` per scope visible to the caller (workspace + its agents), skipping scopes that fail instead of 500ing.
- `POST /knowledge/reingest` — re-runs an article's linked raw doc through `ingest_text_to_scope`. Accepts either a compiled article id (frontmatter `source_docs` names the raw doc) or an orphan raw-doc id directly.
- `POST /knowledge/reingest-upload` — the synchronous sibling of the FileReady listener: resolve the upload (local or S3 via temp file), extract through the configured chain, funnel with the original filename as source, stamp the FL-11b tracking columns. One upload per call; hidden files are refused.
- `GET /knowledge/uploads` — files eligible for ingest with a cheap `has_article` marker: the FL-11b `kb_article_id` column matched against the resolved scope, with a filename-vs-article-sources fallback for uploads indexed before that column existed. No new tracking built.

### Security
Every scope-accepting route binds the client scope through the /kb router's allowlist (`validate_scope_override`), with denials audit-logged at ALERT. Direct file reads guard against path traversal the same way kb-go's `containedID` does, answering 404 rather than acting as an oracle. `hide_from_ai` files are excluded from the uploads listing and refused by reingest-upload.

## Tests

`tests/cloud/test_knowledge_wiki_api.py` (16 tests) fakes kb at the subprocess boundary so the real funnel runs — the reingest argv is pinned to the funnel's ingest shape, same pattern as `tests/cloud/kb/test_router_ingest_funnel.py`. Covers each endpoint's happy path, the scope-guard denial, the 404s, the orphan fallback, and reingest-upload with a faked adapter + extraction chain against a real temp KB home.

```
uv run pytest tests/cloud/test_knowledge_wiki_api.py tests/cloud/test_knowledge_router.py \
  tests/cloud/test_knowledge_aggregator.py tests/cloud/kb tests/cloud/test_site_kb_ingest.py \
  tests/cloud/files -q
158 passed
```

`lint-imports` (core and ee configs) and ruff are clean. The 23 failures in `tests/cloud/uploads/` are pre-existing on origin/dev (401s from the auth env, identical with the branch stashed).

Contract shapes are documented in `docs/api-reference.md` (Knowledge — Living Wiki API). Design doc: `docs/design/drafts/2026-08-04-knowledge-wiki-redesign.md` in the workspace repo.