### PR TITLE
feat(sessions): keyset-cursor pagination for chat history

### DIFF
--- a/ee/pocketpaw_ee/cloud/sessions/router.py
+++ b/ee/pocketpaw_ee/cloud/sessions/router.py
@@ -245,16 +245,22 @@ async def delete_session(
 @router.get("/{session_id}/history")
 async def get_session_history(
     session_id: str,
-    limit: int = 50,
+    limit: int = Query(50, ge=1, le=200),
+    before: str | None = None,
     user_id: str = Depends(current_user_id),
 ) -> dict:
-    """Return session history from the unified Mongo messages store."""
+    """Return session history from the unified Mongo messages store.
+
+    ``before`` is a ``{createdAt}|{_id}`` keyset cursor — pass the oldest
+    loaded message's cursor to fetch the previous (older) page. The response
+    carries ``has_more`` so the client can stop once history is exhausted.
+    """
     from pocketpaw_ee.cloud.shared.errors import NotFound
 
     try:
-        return await sessions_service.get_history(session_id, user_id, limit=limit)
+        return await sessions_service.get_history(session_id, user_id, limit=limit, before=before)
     except NotFound:
-        return {"messages": []}
+        return {"messages": [], "active_run": None, "has_more": False}
 
 
 @router.post("/{session_id}/touch", status_code=204)

--- a/ee/pocketpaw_ee/cloud/sessions/service.py
+++ b/ee/pocketpaw_ee/cloud/sessions/service.py
@@ -526,11 +526,67 @@ async def _active_run_for_session(session: _SessionDoc) -> dict | None:
     return None
 
 
-async def get_history(session_id: str, user_id: str, limit: int = 100) -> dict:
+def _encode_history_cursor(created_at: datetime, oid: str) -> str:
+    """Opaque keyset cursor for history paging — ``{createdAt}|{_id}``.
+
+    Same ``{field}|{oid}`` shape as the session-list cursor
+    (:func:`_encode_session_cursor`) so the frontend can page a transcript
+    backward by handing back the oldest message's ``createdAt`` + ``_id``.
+    """
+    return f"{created_at.isoformat()}|{oid}"
+
+
+def _decode_history_cursor(cursor: str) -> tuple[datetime, PydanticObjectId]:
+    """Inverse of :func:`_encode_history_cursor`."""
+    try:
+        at_iso, oid_str = cursor.split("|", 1)
+        return datetime.fromisoformat(at_iso), PydanticObjectId(oid_str)
+    except (ValueError, TypeError) as exc:
+        raise NotFound("session.bad_cursor", "Invalid history cursor") from exc
+
+
+def _message_to_dict(m: Any, role: str) -> dict[str, Any]:
+    """Serialize a Message row the way the client expects (display path)."""
+    return {
+        "_id": str(m.id),
+        "role": role,
+        "content": m.content,
+        "sender": m.sender,
+        "senderType": m.sender_type,
+        "createdAt": iso_utc(m.createdAt),
+        "attachments": [a.model_dump() for a in (m.attachments or [])],
+    }
+
+
+def _wire_role(m: Any, *, group: bool) -> str:
+    """Display role for a wire message.
+
+    Session / pocket rows carry ``role`` directly (``m.role or "user"``);
+    group rows derive it from ``sender_type`` (agents render as
+    ``assistant``).
+    """
+    if group:
+        return "assistant" if m.sender_type == "agent" else "user"
+    return m.role or "user"
+
+
+async def get_history(
+    session_id: str,
+    user_id: str,
+    limit: int = 100,
+    before: str | None = None,
+) -> dict:
     """Return session chat history from the unified Mongo messages store.
 
     Spans three context types (session/group/pocket). Response includes
     ``active_run`` for frontend auto-resume of an in-flight agent reply.
+
+    Pagination: pages NEWEST-first under the hood (so a transcript opens on
+    the latest messages), then returns ``messages`` ASCENDING for display.
+    ``before`` is a ``{createdAt}|{_id}`` keyset cursor — hand back the
+    OLDEST message's cursor to fetch the previous (older) page. ``has_more``
+    tells the client whether any older pages remain, so scroll-up history
+    loading knows when to stop.
     """
     from pocketpaw_ee.cloud.models.message import Message
 
@@ -546,93 +602,60 @@ async def get_history(session_id: str, user_id: str, limit: int = 100) -> dict:
         # ``session.agent`` would miss those rows entirely — symptom: user
         # sees their optimistic message with no agent reply.
         prefix = f"cloud:session:{session.id}:"
-        messages = (
-            await Message.find(
+        clauses: list[dict[str, Any]] = [
+            {"context_type": "session"},
+            {"session_key": {"$regex": f"^{re.escape(prefix)}"}},
+        ]
+    elif session.context_type == "group" and session.group:
+        clauses = [
+            {"context_type": "group"},
+            {"group": session.group},
+            {"deleted": False},
+        ]
+    else:
+        # Pocket context — three writer paths land here with different
+        # session_key shapes; preserved verbatim from the legacy implementation.
+        pocket_candidate_keys = [session.sessionId]
+        if session.pocket and session.agent:
+            pocket_candidate_keys.append(f"cloud:pocket:{session.pocket}:{session.agent}")
+        or_clauses: list[dict[str, Any]] = [
+            {"context_type": "pocket", "session_key": {"$in": pocket_candidate_keys}}
+        ]
+        if session.agent:
+            or_clauses.append(
                 {
                     "context_type": "session",
-                    "session_key": {"$regex": f"^{re.escape(prefix)}"},
+                    "session_key": f"cloud:session:{session.id}:{session.agent}",
                 }
             )
-            .sort("createdAt")
-            .limit(limit)
-            .to_list()
-        )
-        return {
-            "messages": [
-                {
-                    "_id": str(m.id),
-                    "role": m.role or "user",
-                    "content": m.content,
-                    "sender": m.sender,
-                    "senderType": m.sender_type,
-                    "createdAt": iso_utc(m.createdAt),
-                    "attachments": [a.model_dump() for a in (m.attachments or [])],
-                }
-                for m in messages
-            ],
-            "active_run": active_run,
-        }
+        clauses = [{"$or": or_clauses}]
 
-    if session.context_type == "group" and session.group:
-        messages = (
-            await Message.find(
-                {
-                    "context_type": "group",
-                    "group": session.group,
-                    "deleted": False,
-                }
-            )
-            .sort("createdAt")
-            .limit(limit)
-            .to_list()
-        )
-        return {
-            "messages": [
-                {
-                    "_id": str(m.id),
-                    "role": "assistant" if m.sender_type == "agent" else "user",
-                    "content": m.content,
-                    "sender": m.sender,
-                    "senderType": m.sender_type,
-                    "createdAt": iso_utc(m.createdAt),
-                    "attachments": [a.model_dump() for a in (m.attachments or [])],
-                }
-                for m in messages
-            ],
-            "active_run": active_run,
-        }
-
-    # Pocket context — three writer paths land here with different
-    # session_key shapes; preserved verbatim from the legacy implementation.
-    pocket_candidate_keys = [session.sessionId]
-    if session.pocket and session.agent:
-        pocket_candidate_keys.append(f"cloud:pocket:{session.pocket}:{session.agent}")
-    or_clauses: list[dict[str, Any]] = [
-        {"context_type": "pocket", "session_key": {"$in": pocket_candidate_keys}}
-    ]
-    if session.agent:
-        or_clauses.append(
+    # Keyset cursor: strictly older than the given (createdAt, _id).
+    if before:
+        before_ts, before_oid = _decode_history_cursor(before)
+        clauses.append(
             {
-                "context_type": "session",
-                "session_key": f"cloud:session:{session.id}:{session.agent}",
+                "$or": [
+                    {"createdAt": {"$lt": before_ts}},
+                    {"createdAt": before_ts, "_id": {"$lt": before_oid}},
+                ]
             }
         )
 
-    messages = await Message.find({"$or": or_clauses}).sort("createdAt").limit(limit).to_list()
+    mongo_filter: dict[str, Any] = clauses[0] if len(clauses) == 1 else {"$and": clauses}
+    docs = (
+        await Message.find(mongo_filter)
+        .sort([("createdAt", -1), ("_id", -1)])  # type: ignore[list-item]
+        .limit(limit + 1)
+        .to_list()
+    )
+    is_group = session.context_type == "group" and bool(session.group)
+    has_more = len(docs) > limit
+    page = list(reversed(docs[:limit]))  # newest-first fetch → oldest→newest display
     return {
-        "messages": [
-            {
-                "_id": str(m.id),
-                "role": m.role or "user",
-                "content": m.content,
-                "sender": m.sender,
-                "senderType": m.sender_type,
-                "createdAt": iso_utc(m.createdAt),
-                "attachments": [a.model_dump() for a in (m.attachments or [])],
-            }
-            for m in messages
-        ],
+        "messages": [_message_to_dict(m, _wire_role(m, group=is_group)) for m in page],
         "active_run": active_run,
+        "has_more": has_more,
     }
 
 

--- a/src/pocketpaw/api/v1/sessions.py
+++ b/src/pocketpaw/api/v1/sessions.py
@@ -137,14 +137,23 @@ async def search_sessions(q: str = Query(""), limit: int = Query(20, ge=1, le=20
 
 
 @router.get("/sessions/{session_id}/history")
-async def get_session_history(session_id: str, limit: int = Query(50, ge=1, le=500)):
-    """Get session message history."""
+async def get_session_history(
+    session_id: str,
+    limit: int = Query(50, ge=1, le=500),
+    before: str | None = Query(None),
+):
+    """Get session message history.
+
+    Returns ``{"messages": [...], "has_more": bool}`` — messages newest-window
+    first, ASCENDING. Pass ``before`` (the oldest loaded message's
+    ``{createdAt}|{id}`` cursor) to page backward into older history.
+    """
     from pocketpaw.memory import get_memory_manager
 
     if not session_id:
-        return []
+        return {"messages": [], "has_more": False}
     manager = get_memory_manager()
-    return await manager.get_session_history(session_id, limit=limit)
+    return await manager.get_session_history_page(session_id, limit=limit, before=before)
 
 
 @router.get("/sessions/{session_id}/export")

--- a/src/pocketpaw/memory/manager.py
+++ b/src/pocketpaw/memory/manager.py
@@ -343,6 +343,47 @@ class MemoryManager:
             )
         return history
 
+    async def get_session_history_page(
+        self,
+        session_key: str,
+        limit: int = 50,
+        before: str | None = None,
+    ) -> dict[str, Any]:
+        """Keyset-paginated chat history for the /chat transcript.
+
+        Returns ``{"messages": [...], "has_more": bool}`` where ``messages``
+        is the most recent ``limit`` rows ASCENDING (oldest→newest), matching
+        the cloud history shape plus ``has_more`` so the client can page
+        backward. ``before`` is a ``{createdAt}|{entry_id}`` cursor — pass
+        the oldest loaded message's cursor to fetch the previous (older)
+        page. An invalid cursor yields an empty page (defensive; the client
+        only ever echoes back a cursor it received).
+        """
+        entries = await self._store.get_session(session_key)
+        try:
+            if before:
+                before_iso, before_id = before.split("|", 1)
+                before_ts = datetime.fromisoformat(before_iso)
+                entries = [e for e in entries if (e.created_at, e.id) < (before_ts, before_id)]
+        except (ValueError, TypeError):
+            return {"messages": [], "has_more": False}
+
+        has_more = len(entries) > limit
+        page = entries[-limit:]
+        return {
+            "messages": [
+                {
+                    "_id": e.id,
+                    "role": e.role or "user",
+                    "content": e.content,
+                    "createdAt": e.created_at.isoformat(),
+                    "attachments": (e.metadata or {}).get("attachments") or [],
+                }
+                for e in page
+            ],
+            "has_more": has_more,
+        }
+
     async def search(
         self,
         query: str,


### PR DESCRIPTION
## What
Adds scroll-up pagination for chat history at the backend.

## Problem
`GET /sessions/{id}/history` returned one fixed 50-row window with no way to fetch older messages — scrolling up in /chat dead-ended at the 50th-newest message (e.g. everything before a given date was unreachable).

## Change
- `get_history` now pages **newest-first** under the hood and returns an **ASCENDING** window plus `has_more`.
- New `before` keyset cursor (`{createdAt}|{_id}`) — pass the oldest loaded message's cursor to fetch the previous (older) page.
- Works across all three context types: **session / group / pocket**.
- OSS file-store path (`get_session_history_page`) gets the same paged shape.
- Router: `GET /sessions/{id}/history?before=…&limit=…` (limit 1–200), returns `{messages, active_run, has_more}`.

## Frontend half
Lands in paw-enterprise (scroll-up load-older): `qbtrix/paw-enterprise` → `fix/chat/pagination`.

## Tests
- `ruff check` + `ruff format` clean on changed files.
- `py_compile` passes.