### PR TITLE
fix(uploads): deleting a file now removes its extracted knowledge

### DIFF
--- a/ee/pocketpaw_ee/cloud/agents/knowledge.py
+++ b/ee/pocketpaw_ee/cloud/agents/knowledge.py
@@ -1,4 +1,11 @@
 # knowledge.py — Agent knowledge service via the kb-go binary.
+# Updated: 2026-08-05 — Coupling T-1 "file→KB provenance". Added
+#   source_with_file_id(filename, file_id) → "<filename>#file:<file_id>" so the
+#   FileReady listener can stamp the originating upload's id into the kb-go
+#   --source string (a plain string on kb-go's side; flagStr in kb.go). The
+#   separator lives in KB_SOURCE_FILE_ID_SEP; _lang_for_source now strips the
+#   fragment before the suffix lookup so a stamped code file ("main.py#file:f1")
+#   still gets its --lang AST hint.
 # Updated: 2026-08-04 — Ingest hardening (silent-poisoning fix). On boxes with
 #   no ANTHROPIC_API_KEY (the Claude Code agent backend deployment), kb's own
 #   LLM compile used to fail and kb silently stored every doc VERBATIM — a
@@ -111,9 +118,27 @@ _CODE_LANG_BY_SUFFIX = {
 }
 
 
+# Separator for stamping an upload's file_id into the kb-go --source string
+# (Coupling T-1). kb-go treats --source as a plain opaque string, so the
+# provenance rides along as "<filename>#file:<file_id>" — enough to join a KB
+# article back to the FileUpload row it came from.
+KB_SOURCE_FILE_ID_SEP = "#file:"
+
+
+def source_with_file_id(filename: str, file_id: str) -> str:
+    """Build the kb-go ``--source`` string carrying the upload's file id."""
+    return f"{filename}{KB_SOURCE_FILE_ID_SEP}{file_id}"
+
+
 def _lang_for_source(source: str) -> str | None:
-    """Language hint for a source filename, or ``None`` for non-code docs."""
-    return _CODE_LANG_BY_SUFFIX.get(Path(source).suffix.lower())
+    """Language hint for a source filename, or ``None`` for non-code docs.
+
+    Strips a trailing ``#file:<id>`` provenance fragment first — a stamped
+    source like ``"main.py#file:f1"`` must still resolve ``.py`` (Path.suffix
+    would otherwise see ``".py#file:f1"`` and miss the lookup).
+    """
+    filename = source.split(KB_SOURCE_FILE_ID_SEP, 1)[0]
+    return _CODE_LANG_BY_SUFFIX.get(Path(filename).suffix.lower())
 
 
 def _resolve_kb_bin() -> str:

--- a/ee/pocketpaw_ee/cloud/agents/knowledge.py
+++ b/ee/pocketpaw_ee/cloud/agents/knowledge.py
@@ -6,6 +6,13 @@
 #   _check_ingest_result's key order (id, article_id, article) and is now the
 #   one place receipt-shape knowledge lives; the FileReady listener and the
 #   /knowledge reingest routes both use it.
+# Updated: 2026-08-05 — Coupling T-1 "file→KB provenance". Added
+#   source_with_file_id(filename, file_id) → "<filename>#file:<file_id>" so the
+#   FileReady listener can stamp the originating upload's id into the kb-go
+#   --source string (a plain string on kb-go's side; flagStr in kb.go). The
+#   separator lives in KB_SOURCE_FILE_ID_SEP; _lang_for_source now strips the
+#   fragment before the suffix lookup so a stamped code file ("main.py#file:f1")
+#   still gets its --lang AST hint.
 # Updated: 2026-08-04 — Ingest hardening (silent-poisoning fix). On boxes with
 #   no ANTHROPIC_API_KEY (the Claude Code agent backend deployment), kb's own
 #   LLM compile used to fail and kb silently stored every doc VERBATIM — a
@@ -118,9 +125,27 @@ _CODE_LANG_BY_SUFFIX = {
 }
 
 
+# Separator for stamping an upload's file_id into the kb-go --source string
+# (Coupling T-1). kb-go treats --source as a plain opaque string, so the
+# provenance rides along as "<filename>#file:<file_id>" — enough to join a KB
+# article back to the FileUpload row it came from.
+KB_SOURCE_FILE_ID_SEP = "#file:"
+
+
+def source_with_file_id(filename: str, file_id: str) -> str:
+    """Build the kb-go ``--source`` string carrying the upload's file id."""
+    return f"{filename}{KB_SOURCE_FILE_ID_SEP}{file_id}"
+
+
 def _lang_for_source(source: str) -> str | None:
-    """Language hint for a source filename, or ``None`` for non-code docs."""
-    return _CODE_LANG_BY_SUFFIX.get(Path(source).suffix.lower())
+    """Language hint for a source filename, or ``None`` for non-code docs.
+
+    Strips a trailing ``#file:<id>`` provenance fragment first — a stamped
+    source like ``"main.py#file:f1"`` must still resolve ``.py`` (Path.suffix
+    would otherwise see ``".py#file:f1"`` and miss the lookup).
+    """
+    filename = source.split(KB_SOURCE_FILE_ID_SEP, 1)[0]
+    return _CODE_LANG_BY_SUFFIX.get(Path(filename).suffix.lower())
 
 
 def _resolve_kb_bin() -> str:

--- a/ee/pocketpaw_ee/cloud/uploads/listeners.py
+++ b/ee/pocketpaw_ee/cloud/uploads/listeners.py
@@ -1,4 +1,16 @@
 # listeners.py — In-process subscribers for upload-related bus events.
+# Updated: 2026-08-05 — Coupling T-1 "file delete prunes extracted knowledge".
+#   (1) FileDeleted finally has a subscriber: prune_deleted_file_knowledge reads
+#   the tombstoned FileUpload row (get_doc_scoped_any — the service soft-deletes
+#   BEFORE emitting) and deletes the tracked kb-go article via
+#   KnowledgeService.remove_article(kb_scope, kb_article_id), then clears the
+#   tracking on the tombstone. No tracked article → safe no-op. kb-go's delete
+#   also removes the article's vector-index entry and raw docs (see
+#   kb-go delete_test.go TestCmdDelete_RemovesArticleEverywhere), so the Stage
+#   2.D vector artifact needs no separate cleanup. (2) The FileReady ingest now
+#   stamps provenance the other way: --source carries
+#   "<filename>#file:<file_id>" (source_with_file_id) so a KB article can be
+#   joined back to the upload it came from.
 # Created: 2026-04-30 — Stage 1.B of "Files as Knowledge". Wires FileReady
 #   into the extraction chain and ingests the resulting text into the
 #   workspace KB scope. Pocket-scope routing lands in Stage 3.E.
@@ -71,7 +83,7 @@ import logging
 from pathlib import Path
 
 from pocketpaw_ee.cloud._core.realtime.bus import get_bus
-from pocketpaw_ee.cloud._core.realtime.events import Event, FileReady
+from pocketpaw_ee.cloud._core.realtime.events import Event, FileDeleted, FileReady
 from pocketpaw_ee.cloud.uploads.resolver import materialize_to_local_path
 
 logger = logging.getLogger(__name__)
@@ -186,12 +198,17 @@ async def index_uploaded_file(event: Event) -> None:
         else:
             scope = f"workspace:{workspace_id}"
         try:
-            from pocketpaw_ee.cloud.agents.knowledge import KnowledgeService
+            from pocketpaw_ee.cloud.agents.knowledge import (
+                KnowledgeService,
+                source_with_file_id,
+            )
 
+            # Coupling T-1: stamp the upload's file_id into the kb-go source
+            # string so the article carries a join back to the FileUpload row.
             ingest_result = await KnowledgeService.ingest_text_to_scope(
                 scope=scope,
                 text=text,
-                source=filename,
+                source=source_with_file_id(filename, file_id),
             )
         except Exception:
             logger.exception("KB ingest failed for file_id=%s", file_id)
@@ -514,6 +531,109 @@ def _resolve_adapter():
         return None
 
 
+async def prune_deleted_file_knowledge(event: Event) -> None:
+    """Delete the KB article extracted from a now-deleted file (Coupling T-1).
+
+    ``EEUploadService.delete`` soft-deletes the row, then emits
+    :class:`FileDeleted` "so subscribers can prune cached state" — this is that
+    subscriber. It recovers the tracked ``kb_article_id`` / ``kb_scope`` from
+    the tombstoned row (``get_doc_scoped_any`` — the live-row readers can't see
+    it post-tombstone), purges the article via ``kb delete``, and clears the
+    tracking on success. Without this, deleted (possibly sensitive) content
+    stayed agent-retrievable through KB search forever.
+
+    Safe no-ops: missing payload fields, an unresolvable row, or a row with no
+    tracked article all return quietly. kb-go's ``delete`` removes the vector
+    index entry and raw docs along with the article and is idempotent, so no
+    separate vector cleanup is needed and a re-fire is harmless. Fully
+    contained like every bus handler here — a purge failure logs and leaves the
+    tracking in place so a sweeper (or re-fire) can re-purge.
+    """
+    data = event.data or {}
+    workspace_id = data.get("workspace_id") or data.get("workspace")
+    file_id = data.get("file_id")
+    if not workspace_id or not file_id:
+        logger.debug(
+            "FileDeleted missing workspace_id or file_id; skipping KB prune "
+            "(workspace_id=%r, file_id=%r)",
+            workspace_id,
+            file_id,
+        )
+        return
+
+    try:
+        from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+
+        doc = await MongoFileStore().get_doc_scoped_any(file_id, str(workspace_id))
+    except Exception:
+        logger.exception(
+            "could not load FileUpload row for deleted file_id=%s; KB article "
+            "(if any) not pruned — sweeper can reconcile",
+            file_id,
+        )
+        return
+    if doc is None:
+        logger.debug("no FileUpload row for deleted file_id=%s; nothing to prune", file_id)
+        return
+
+    article_id = getattr(doc, "kb_article_id", None)
+    scope = getattr(doc, "kb_scope", None)
+    if not article_id or not scope:
+        logger.debug(
+            "deleted file_id=%s has no tracked KB article; nothing to prune",
+            file_id,
+        )
+        return
+
+    try:
+        from pocketpaw_ee.cloud.agents.knowledge import KnowledgeService
+
+        purged = await KnowledgeService.remove_article(scope, article_id)
+    except Exception:
+        # remove_article is fail-soft itself; this is belt-and-braces so a
+        # surprise never propagates back into the bus dispatch.
+        logger.exception(
+            "KB prune raised for deleted file_id=%s (article_id=%s scope=%s)",
+            file_id,
+            article_id,
+            scope,
+        )
+        return
+
+    if not purged:
+        logger.warning(
+            "KB prune failed for deleted file_id=%s (article_id=%s scope=%s); "
+            "tracking kept so a sweeper can re-purge",
+            file_id,
+            article_id,
+            scope,
+        )
+        return
+
+    logger.info(
+        "pruned KB article %s (scope=%s) for deleted file_id=%s",
+        article_id,
+        scope,
+        file_id,
+    )
+    try:
+        from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+
+        await MongoFileStore().set_kb_article(
+            file_id,
+            str(workspace_id),
+            article_id=None,
+            scope=None,
+            include_deleted=True,
+        )
+    except Exception:
+        logger.debug(
+            "clearing kb tracking failed for deleted file_id=%s; harmless — "
+            "kb delete is idempotent on a re-fire",
+            file_id,
+        )
+
+
 def register_upload_listeners() -> None:
     """Wire the upload subscribers into the bus.
 
@@ -524,6 +644,13 @@ def register_upload_listeners() -> None:
     """
     bus = get_bus()
     bus.subscribe(FileReady.EVENT_TYPE, index_uploaded_file)
+    # Coupling T-1: FileDeleted had zero subscribers — deleted files left
+    # their extracted knowledge agent-retrievable forever. This closes it.
+    bus.subscribe(FileDeleted.EVENT_TYPE, prune_deleted_file_knowledge)
 
 
-__all__ = ["index_uploaded_file", "register_upload_listeners"]
+__all__ = [
+    "index_uploaded_file",
+    "prune_deleted_file_knowledge",
+    "register_upload_listeners",
+]

--- a/ee/pocketpaw_ee/cloud/uploads/listeners.py
+++ b/ee/pocketpaw_ee/cloud/uploads/listeners.py
@@ -73,6 +73,18 @@
 #   receipt keys the id as "article" (finishIngest), which the inline
 #   id/article_id lookup never matched — so FL-11b tracking and the vector
 #   path silently never ran on real receipts.
+# Updated: 2026-08-05 — Coupling T-1 "file delete prunes extracted knowledge".
+#   (1) FileDeleted finally has a subscriber: prune_deleted_file_knowledge reads
+#   the tombstoned FileUpload row (get_doc_scoped_any — the service soft-deletes
+#   BEFORE emitting) and deletes the tracked kb-go article via
+#   KnowledgeService.remove_article(kb_scope, kb_article_id), then clears the
+#   tracking on the tombstone. No tracked article → safe no-op. kb-go's delete
+#   also removes the article's vector-index entry and raw docs (see
+#   kb-go delete_test.go TestCmdDelete_RemovesArticleEverywhere), so the Stage
+#   2.D vector artifact needs no separate cleanup. (2) The FileReady ingest now
+#   stamps provenance the other way: --source carries
+#   "<filename>#file:<file_id>" (source_with_file_id) so a KB article can be
+#   joined back to the upload it came from.
 # Created: 2026-04-30 — Stage 1.B of "Files as Knowledge". Wires FileReady
 #   into the extraction chain and ingests the resulting text into the
 #   workspace KB scope. Pocket-scope routing lands in Stage 3.E.
@@ -146,7 +158,7 @@ from pathlib import Path
 
 from pocketpaw_ee.cloud._core.realtime.bus import get_bus
 from pocketpaw_ee.cloud._core.realtime.emit import emit
-from pocketpaw_ee.cloud._core.realtime.events import Event, FileReady
+from pocketpaw_ee.cloud._core.realtime.events import Event, FileDeleted, FileReady
 from pocketpaw_ee.cloud.extraction.adapter import ExtractionResult
 from pocketpaw_ee.cloud.uploads.extracted_text import persist_extracted_text
 from pocketpaw_ee.cloud.uploads.resolver import materialize_to_local_path
@@ -338,12 +350,17 @@ async def index_uploaded_file(event: Event) -> None:
         else:
             scope = f"workspace:{workspace_id}"
         try:
-            from pocketpaw_ee.cloud.agents.knowledge import KnowledgeService
+            from pocketpaw_ee.cloud.agents.knowledge import (
+                KnowledgeService,
+                source_with_file_id,
+            )
 
+            # Coupling T-1: stamp the upload's file_id into the kb-go source
+            # string so the article carries a join back to the FileUpload row.
             ingest_result = await KnowledgeService.ingest_text_to_scope(
                 scope=scope,
                 text=text,
-                source=filename,
+                source=source_with_file_id(filename, file_id),
             )
         except Exception:
             logger.exception("KB ingest failed for file_id=%s", file_id)
@@ -852,6 +869,109 @@ def _resolve_adapter():
         return None
 
 
+async def prune_deleted_file_knowledge(event: Event) -> None:
+    """Delete the KB article extracted from a now-deleted file (Coupling T-1).
+
+    ``EEUploadService.delete`` soft-deletes the row, then emits
+    :class:`FileDeleted` "so subscribers can prune cached state" — this is that
+    subscriber. It recovers the tracked ``kb_article_id`` / ``kb_scope`` from
+    the tombstoned row (``get_doc_scoped_any`` — the live-row readers can't see
+    it post-tombstone), purges the article via ``kb delete``, and clears the
+    tracking on success. Without this, deleted (possibly sensitive) content
+    stayed agent-retrievable through KB search forever.
+
+    Safe no-ops: missing payload fields, an unresolvable row, or a row with no
+    tracked article all return quietly. kb-go's ``delete`` removes the vector
+    index entry and raw docs along with the article and is idempotent, so no
+    separate vector cleanup is needed and a re-fire is harmless. Fully
+    contained like every bus handler here — a purge failure logs and leaves the
+    tracking in place so a sweeper (or re-fire) can re-purge.
+    """
+    data = event.data or {}
+    workspace_id = data.get("workspace_id") or data.get("workspace")
+    file_id = data.get("file_id")
+    if not workspace_id or not file_id:
+        logger.debug(
+            "FileDeleted missing workspace_id or file_id; skipping KB prune "
+            "(workspace_id=%r, file_id=%r)",
+            workspace_id,
+            file_id,
+        )
+        return
+
+    try:
+        from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+
+        doc = await MongoFileStore().get_doc_scoped_any(file_id, str(workspace_id))
+    except Exception:
+        logger.exception(
+            "could not load FileUpload row for deleted file_id=%s; KB article "
+            "(if any) not pruned — sweeper can reconcile",
+            file_id,
+        )
+        return
+    if doc is None:
+        logger.debug("no FileUpload row for deleted file_id=%s; nothing to prune", file_id)
+        return
+
+    article_id = getattr(doc, "kb_article_id", None)
+    scope = getattr(doc, "kb_scope", None)
+    if not article_id or not scope:
+        logger.debug(
+            "deleted file_id=%s has no tracked KB article; nothing to prune",
+            file_id,
+        )
+        return
+
+    try:
+        from pocketpaw_ee.cloud.agents.knowledge import KnowledgeService
+
+        purged = await KnowledgeService.remove_article(scope, article_id)
+    except Exception:
+        # remove_article is fail-soft itself; this is belt-and-braces so a
+        # surprise never propagates back into the bus dispatch.
+        logger.exception(
+            "KB prune raised for deleted file_id=%s (article_id=%s scope=%s)",
+            file_id,
+            article_id,
+            scope,
+        )
+        return
+
+    if not purged:
+        logger.warning(
+            "KB prune failed for deleted file_id=%s (article_id=%s scope=%s); "
+            "tracking kept so a sweeper can re-purge",
+            file_id,
+            article_id,
+            scope,
+        )
+        return
+
+    logger.info(
+        "pruned KB article %s (scope=%s) for deleted file_id=%s",
+        article_id,
+        scope,
+        file_id,
+    )
+    try:
+        from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+
+        await MongoFileStore().set_kb_article(
+            file_id,
+            str(workspace_id),
+            article_id=None,
+            scope=None,
+            include_deleted=True,
+        )
+    except Exception:
+        logger.debug(
+            "clearing kb tracking failed for deleted file_id=%s; harmless — "
+            "kb delete is idempotent on a re-fire",
+            file_id,
+        )
+
+
 def register_upload_listeners() -> None:
     """Wire the upload subscribers into the bus.
 
@@ -862,6 +982,13 @@ def register_upload_listeners() -> None:
     """
     bus = get_bus()
     bus.subscribe(FileReady.EVENT_TYPE, index_uploaded_file)
+    # Coupling T-1: FileDeleted had zero subscribers — deleted files left
+    # their extracted knowledge agent-retrievable forever. This closes it.
+    bus.subscribe(FileDeleted.EVENT_TYPE, prune_deleted_file_knowledge)
 
 
-__all__ = ["index_uploaded_file", "register_upload_listeners"]
+__all__ = [
+    "index_uploaded_file",
+    "prune_deleted_file_knowledge",
+    "register_upload_listeners",
+]

--- a/ee/pocketpaw_ee/cloud/uploads/mongo_store.py
+++ b/ee/pocketpaw_ee/cloud/uploads/mongo_store.py
@@ -1,5 +1,13 @@
 """Mongo-backed metadata store, workspace-scoped.
 
+2026-08-05 (Coupling T-1 "prune KB on file delete"): added
+``get_doc_scoped_any`` — a tombstone-inclusive read the FileDeleted subscriber
+uses to recover ``kb_article_id``/``kb_scope`` from a row that
+``EEUploadService.delete`` has already soft-deleted (the event fires AFTER the
+tombstone lands, so the live-row readers can't see it). ``set_kb_article`` grew
+an ``include_deleted`` flag so the subscriber can clear the tracking on that
+tombstoned row after a successful purge. Workspace filter unchanged on both.
+
 2026-07-03 (FL-11b "hide-from-AI purge"): added ``set_kb_article`` — a
 workspace-scoped setter the FileReady listener uses to record the kb-go
 ``article_id`` + ``scope`` on a row after a successful ingest, and the PATCH
@@ -87,6 +95,20 @@ class MongoFileStore:
             FileUpload.deleted_at == None,  # noqa: E711
         )
 
+    async def get_doc_scoped_any(self, file_id: str, workspace: str) -> FileUpload | None:
+        """Like :meth:`get_doc_scoped` but tombstone-inclusive (Coupling T-1).
+
+        The FileDeleted subscriber needs the row's ``kb_article_id`` /
+        ``kb_scope`` AFTER the service has soft-deleted it — the event is
+        emitted post-tombstone, so the live-row read returns ``None``. The
+        workspace filter is always applied, so cross-tenant reads are
+        impossible through this API.
+        """
+        return await FileUpload.find_one(
+            FileUpload.file_id == file_id,
+            FileUpload.workspace == workspace,
+        )
+
     async def set_library_metadata(
         self,
         file_id: str,
@@ -122,6 +144,7 @@ class MongoFileStore:
         *,
         article_id: str | None,
         scope: str | None,
+        include_deleted: bool = False,
     ) -> FileUpload | None:
         """Record (or clear) the tracked kb-go article on one row (FL-11b).
 
@@ -132,8 +155,16 @@ class MongoFileStore:
         re-populates it). Both fields are always written to the given values.
         Returns the updated doc, or ``None`` if no live row matches
         ``(file_id, workspace)``.
+
+        ``include_deleted=True`` (Coupling T-1) also matches a tombstoned row —
+        the FileDeleted subscriber uses it to clear tracking after purging a
+        deleted file's article. Default stays live-only so the FL-11b callers
+        keep their exact semantics.
         """
-        doc = await self.get_doc_scoped(file_id, workspace)
+        if include_deleted:
+            doc = await self.get_doc_scoped_any(file_id, workspace)
+        else:
+            doc = await self.get_doc_scoped(file_id, workspace)
         if doc is None:
             return None
         doc.kb_article_id = article_id

--- a/ee/pocketpaw_ee/cloud/uploads/mongo_store.py
+++ b/ee/pocketpaw_ee/cloud/uploads/mongo_store.py
@@ -57,6 +57,15 @@ rows. Added ``reassign_kb_article`` — after a reingest recompiles an
 article under a new slug, the tracking rows pointing at the old id are
 moved to the new one so a later hide-from-AI purge hits the live copy.
 Additive — existing consumers of the dict shape are unchanged.
+
+2026-08-05 (Coupling T-1 "prune KB on file delete"): added
+``get_doc_scoped_any`` — a tombstone-inclusive read the FileDeleted subscriber
+uses to recover ``kb_article_id``/``kb_scope`` from a row that
+``EEUploadService.delete`` has already soft-deleted (the event fires AFTER the
+tombstone lands, so the live-row readers can't see it). ``set_kb_article`` grew
+an ``include_deleted`` flag so the subscriber can clear the tracking on that
+tombstoned row after a successful purge. Workspace filter unchanged on both.
+
 2026-07-03 (FL-11b "hide-from-AI purge"): added ``set_kb_article`` — a
 workspace-scoped setter the FileReady listener uses to record the kb-go
 ``article_id`` + ``scope`` on a row after a successful ingest, and the PATCH
@@ -158,6 +167,20 @@ class MongoFileStore:
             FileUpload.deleted_at == None,  # noqa: E711
         )
 
+    async def get_doc_scoped_any(self, file_id: str, workspace: str) -> FileUpload | None:
+        """Like :meth:`get_doc_scoped` but tombstone-inclusive (Coupling T-1).
+
+        The FileDeleted subscriber needs the row's ``kb_article_id`` /
+        ``kb_scope`` AFTER the service has soft-deleted it — the event is
+        emitted post-tombstone, so the live-row read returns ``None``. The
+        workspace filter is always applied, so cross-tenant reads are
+        impossible through this API.
+        """
+        return await FileUpload.find_one(
+            FileUpload.file_id == file_id,
+            FileUpload.workspace == workspace,
+        )
+
     async def set_library_metadata(
         self,
         file_id: str,
@@ -205,6 +228,7 @@ class MongoFileStore:
         *,
         article_id: str | None,
         scope: str | None,
+        include_deleted: bool = False,
     ) -> FileUpload | None:
         """Record (or clear) the tracked kb-go article on one row (FL-11b).
 
@@ -215,8 +239,16 @@ class MongoFileStore:
         re-populates it). Both fields are always written to the given values.
         Returns the updated doc, or ``None`` if no live row matches
         ``(file_id, workspace)``.
+
+        ``include_deleted=True`` (Coupling T-1) also matches a tombstoned row —
+        the FileDeleted subscriber uses it to clear tracking after purging a
+        deleted file's article. Default stays live-only so the FL-11b callers
+        keep their exact semantics.
         """
-        doc = await self.get_doc_scoped(file_id, workspace)
+        if include_deleted:
+            doc = await self.get_doc_scoped_any(file_id, workspace)
+        else:
+            doc = await self.get_doc_scoped(file_id, workspace)
         if doc is None:
             return None
         doc.kb_article_id = article_id

--- a/tests/cloud/uploads/test_kb_prune_on_delete.py
+++ b/tests/cloud/uploads/test_kb_prune_on_delete.py
@@ -1,0 +1,294 @@
+# test_kb_prune_on_delete.py — Coupling T-1 "file delete prunes extracted knowledge".
+# Created: 2026-08-05. Covers the full slice:
+#   (1) The FileReady ingest stamps the upload's file_id into the kb-go
+#       --source string ("<filename>#file:<file_id>") so the article joins
+#       back to the file; the lang hint survives the stamp.
+#   (2) The FileDeleted subscriber reads the TOMBSTONED row (the service
+#       soft-deletes before emitting), calls KnowledgeService.remove_article
+#       with the tracked scope + article id, and clears the tracking.
+#   (3) Delete with no tracked article (or no resolvable row / bad payload)
+#       is a safe no-op — remove_article never called.
+#   (4) A purge failure keeps the tracking so a sweeper can re-purge.
+#   (5) register_upload_listeners subscribes the prune handler to
+#       FileDeleted.EVENT_TYPE (the event service.delete emits).
+# Spy-don't-mock: remove_article is spied at the KnowledgeService seam (the
+# subprocess boundary), the store and listener under test run real code
+# against the mongomock-backed Beanie fixtures from conftest.
+"""Tests for the Coupling T-1 KB prune-on-delete path."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from pocketpaw_ee.cloud._core.realtime.events import FileDeleted, FileReady
+from pocketpaw_ee.cloud.extraction.adapter import ExtractionResult
+
+from pocketpaw.uploads.file_store import FileRecord
+
+pytestmark = pytest.mark.asyncio
+
+
+# --- fixtures / helpers (mirrors test_kb_purge.py) ------------------------
+
+
+class _FakeChain:
+    def __init__(self, result: ExtractionResult):
+        self._result = result
+
+    async def run(self, path: Path, mime: str) -> ExtractionResult:
+        return self._result
+
+
+class _FakeAdapter:
+    def __init__(self, local_path_value: Path):
+        self._local = local_path_value
+
+    def local_path(self, key: str) -> Path | None:
+        return self._local
+
+    async def open(self, key: str):  # pragma: no cover — local path wins
+        yield b""
+
+
+def _record(**overrides) -> FileRecord:
+    defaults = {
+        "id": "f1",
+        "storage_key": "chat/202608/aaa.pdf",
+        "filename": "notes.pdf",
+        "mime": "application/pdf",
+        "size": 1,
+        "owner_id": "u1",
+        "chat_id": "c1",
+        "created": datetime.now(UTC),
+    }
+    defaults.update(overrides)
+    return FileRecord(**defaults)
+
+
+def _wire(monkeypatch, *, chain: _FakeChain, adapter: _FakeAdapter, ingest: AsyncMock):
+    from pocketpaw_ee.cloud.agents import knowledge as kn
+    from pocketpaw_ee.cloud.uploads import listeners
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.extraction.build_chain", lambda settings: chain)
+    monkeypatch.setattr(listeners, "_resolve_adapter", lambda: adapter)
+    monkeypatch.setattr(kn.KnowledgeService, "ingest_text_to_scope", ingest)
+
+
+async def _seed_tracked(store, fid: str = "f1", *, article: str | None = "art-1") -> None:
+    await store.save_scoped(_record(id=fid, filename=f"{fid}.pdf"), workspace="w1")
+    if article:
+        await store.set_kb_article(fid, "w1", article_id=article, scope="workspace:w1")
+
+
+# --- (1) provenance stamp on ingest ---------------------------------------
+
+
+async def test_ingest_source_carries_file_id(monkeypatch, store, tmp_path):
+    """The kb-go --source string is "<filename>#file:<file_id>"."""
+    from pocketpaw_ee.cloud.uploads.listeners import index_uploaded_file
+
+    await store.save_scoped(_record(), workspace="w1")
+    fake_path = tmp_path / "notes.pdf"
+    fake_path.write_bytes(b"unused; chain mocked")
+    chain = _FakeChain(ExtractionResult(text="meeting notes", backend="local"))
+    ingest = AsyncMock(return_value={"id": "art-1"})
+    _wire(monkeypatch, chain=chain, adapter=_FakeAdapter(fake_path), ingest=ingest)
+
+    await index_uploaded_file(
+        FileReady(
+            data={
+                "workspace_id": "w1",
+                "file_id": "f1",
+                "filename": "notes.pdf",
+                "mime": "application/pdf",
+                "storage_key": "chat/202608/aaa.pdf",
+            }
+        )
+    )
+
+    ingest.assert_awaited_once_with(
+        scope="workspace:w1",
+        text="meeting notes",
+        source="notes.pdf#file:f1",
+    )
+
+
+async def test_lang_hint_survives_file_id_stamp():
+    """A stamped code-file source still resolves its --lang AST hint."""
+    from pocketpaw_ee.cloud.agents.knowledge import _lang_for_source, source_with_file_id
+
+    stamped = source_with_file_id("main.py", "f1")
+    assert stamped == "main.py#file:f1"
+    assert _lang_for_source(stamped) == "python"
+    # Plain filenames keep working; non-code stays None either way.
+    assert _lang_for_source("main.py") == "python"
+    assert _lang_for_source(source_with_file_id("notes.pdf", "f1")) is None
+
+
+# --- (2) FileDeleted subscriber purges the tracked article ----------------
+
+
+async def test_prune_deletes_tracked_article_from_tombstoned_row(monkeypatch, store):
+    """Subscriber purges via the persisted ids and clears the tracking.
+
+    The row is soft-deleted BEFORE the event fires (service order), so this
+    also proves the tombstone-inclusive read path.
+    """
+    from pocketpaw_ee.cloud.agents import knowledge as kn
+    from pocketpaw_ee.cloud.uploads.listeners import prune_deleted_file_knowledge
+    from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+
+    await _seed_tracked(store, "f1")
+    await store.soft_delete_scoped("f1", "w1")
+
+    remove = AsyncMock(return_value=True)
+    monkeypatch.setattr(kn.KnowledgeService, "remove_article", remove)
+
+    await prune_deleted_file_knowledge(FileDeleted(data={"workspace_id": "w1", "file_id": "f1"}))
+
+    remove.assert_awaited_once_with("workspace:w1", "art-1")
+    # Tracking cleared on the tombstone (mirrors the FL-11b purge contract).
+    doc = await MongoFileStore().get_doc_scoped_any("f1", "w1")
+    assert doc is not None
+    assert doc.deleted_at is not None
+    assert doc.kb_article_id is None
+    assert doc.kb_scope is None
+
+
+async def test_prune_workspace_scoped_lookup(monkeypatch, store):
+    """Wrong workspace in the payload → no cross-tenant purge."""
+    from pocketpaw_ee.cloud.agents import knowledge as kn
+    from pocketpaw_ee.cloud.uploads.listeners import prune_deleted_file_knowledge
+
+    await _seed_tracked(store, "f1")
+    await store.soft_delete_scoped("f1", "w1")
+
+    remove = AsyncMock(return_value=True)
+    monkeypatch.setattr(kn.KnowledgeService, "remove_article", remove)
+
+    await prune_deleted_file_knowledge(FileDeleted(data={"workspace_id": "OTHER", "file_id": "f1"}))
+    remove.assert_not_awaited()
+
+
+# --- (3) safe no-ops ------------------------------------------------------
+
+
+async def test_prune_no_tracked_article_is_noop(monkeypatch, store):
+    """A deleted file that was never KB-indexed triggers no kb delete."""
+    from pocketpaw_ee.cloud.agents import knowledge as kn
+    from pocketpaw_ee.cloud.uploads.listeners import prune_deleted_file_knowledge
+
+    await _seed_tracked(store, "f2", article=None)
+    await store.soft_delete_scoped("f2", "w1")
+
+    remove = AsyncMock(return_value=True)
+    monkeypatch.setattr(kn.KnowledgeService, "remove_article", remove)
+
+    await prune_deleted_file_knowledge(FileDeleted(data={"workspace_id": "w1", "file_id": "f2"}))
+    remove.assert_not_awaited()
+
+
+async def test_prune_missing_payload_fields_is_noop(monkeypatch):
+    """No workspace_id / file_id → quiet return, no store or kb calls."""
+    from pocketpaw_ee.cloud.agents import knowledge as kn
+    from pocketpaw_ee.cloud.uploads.listeners import prune_deleted_file_knowledge
+
+    remove = AsyncMock(return_value=True)
+    monkeypatch.setattr(kn.KnowledgeService, "remove_article", remove)
+
+    await prune_deleted_file_knowledge(FileDeleted(data={"file_id": "f1"}))
+    await prune_deleted_file_knowledge(FileDeleted(data={"workspace_id": "w1"}))
+    await prune_deleted_file_knowledge(FileDeleted(data=None))
+    remove.assert_not_awaited()
+
+
+async def test_prune_unresolvable_row_is_noop(monkeypatch, store):
+    """No row at all for the id → quiet return."""
+    from pocketpaw_ee.cloud.agents import knowledge as kn
+    from pocketpaw_ee.cloud.uploads.listeners import prune_deleted_file_knowledge
+
+    remove = AsyncMock(return_value=True)
+    monkeypatch.setattr(kn.KnowledgeService, "remove_article", remove)
+
+    await prune_deleted_file_knowledge(FileDeleted(data={"workspace_id": "w1", "file_id": "ghost"}))
+    remove.assert_not_awaited()
+
+
+# --- (4) purge failure keeps tracking -------------------------------------
+
+
+async def test_prune_failure_keeps_tracking(monkeypatch, store):
+    """remove_article returning False leaves the ids for a sweeper re-purge."""
+    from pocketpaw_ee.cloud.agents import knowledge as kn
+    from pocketpaw_ee.cloud.uploads.listeners import prune_deleted_file_knowledge
+    from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+
+    await _seed_tracked(store, "f3", article="art-3")
+    await store.soft_delete_scoped("f3", "w1")
+
+    remove = AsyncMock(return_value=False)
+    monkeypatch.setattr(kn.KnowledgeService, "remove_article", remove)
+
+    await prune_deleted_file_knowledge(FileDeleted(data={"workspace_id": "w1", "file_id": "f3"}))
+
+    remove.assert_awaited_once_with("workspace:w1", "art-3")
+    doc = await MongoFileStore().get_doc_scoped_any("f3", "w1")
+    assert doc.kb_article_id == "art-3"
+    assert doc.kb_scope == "workspace:w1"
+
+
+# --- (5) registration ------------------------------------------------------
+
+
+async def test_register_upload_listeners_subscribes_to_file_deleted():
+    """Bootstrap path: the prune handler is wired to FileDeleted.EVENT_TYPE."""
+    from pocketpaw_ee.cloud._core.realtime import bus as bus_mod
+    from pocketpaw_ee.cloud._core.realtime.audience import AudienceResolver
+    from pocketpaw_ee.cloud._core.realtime.bus import InProcessBus
+    from pocketpaw_ee.cloud.uploads.listeners import (
+        prune_deleted_file_knowledge,
+        register_upload_listeners,
+    )
+
+    real_bus = InProcessBus(resolver=AudienceResolver(), conn_manager=AsyncMock())
+    prev = bus_mod._bus  # type: ignore[attr-defined]
+    bus_mod._bus = real_bus  # type: ignore[attr-defined]
+    try:
+        register_upload_listeners()
+        handlers = real_bus._handlers.get(FileDeleted.EVENT_TYPE, [])
+        assert prune_deleted_file_knowledge in handlers
+    finally:
+        bus_mod._bus = prev  # type: ignore[attr-defined]
+
+
+# --- store: tombstone-inclusive read/write --------------------------------
+
+
+async def test_get_doc_scoped_any_sees_tombstones(store):
+    await store.save_scoped(_record(id="f4"), workspace="w1")
+    await store.soft_delete_scoped("f4", "w1")
+
+    assert await store.get_doc_scoped("f4", "w1") is None
+    doc = await store.get_doc_scoped_any("f4", "w1")
+    assert doc is not None and doc.file_id == "f4"
+    # Workspace filter still applies.
+    assert await store.get_doc_scoped_any("f4", "w2") is None
+
+
+async def test_set_kb_article_include_deleted(store):
+    await store.save_scoped(_record(id="f5"), workspace="w1")
+    await store.set_kb_article("f5", "w1", article_id="a5", scope="workspace:w1")
+    await store.soft_delete_scoped("f5", "w1")
+
+    # Default (live-only) semantics unchanged: tombstone not matched.
+    assert await store.set_kb_article("f5", "w1", article_id=None, scope=None) is None
+    # include_deleted reaches the tombstone.
+    updated = await store.set_kb_article(
+        "f5", "w1", article_id=None, scope=None, include_deleted=True
+    )
+    assert updated is not None
+    doc = await store.get_doc_scoped_any("f5", "w1")
+    assert doc.kb_article_id is None and doc.kb_scope is None

--- a/tests/cloud/uploads/test_listener.py
+++ b/tests/cloud/uploads/test_listener.py
@@ -1,4 +1,6 @@
 # test_listener.py — tests for the FileReady KB-indexing subscriber.
+# Updated: 2026-08-05 — Coupling T-1. Ingest source assertions now expect the
+#   provenance-stamped form "<filename>#file:<file_id>".
 # Created: 2026-04-30 — Stage 1.B "Files as Knowledge". Verifies the
 #   listener resolves the storage path, runs extraction, ingests into
 #   workspace KB, and contains failures so they don't propagate back to
@@ -149,7 +151,7 @@ async def test_index_uploaded_file_calls_chain_then_kb(monkeypatch, tmp_path):
     ingest.assert_awaited_once_with(
         scope="workspace:w1",
         text="hello world",
-        source="doc.pdf",
+        source="doc.pdf#file:f1",
     )
 
 
@@ -247,7 +249,7 @@ async def test_remote_adapter_streams_into_temp_then_extracts(monkeypatch):
     ingest.assert_awaited_once_with(
         scope="workspace:w1",
         text="caption from gemini",
-        source="whiteboard.png",
+        source="whiteboard.png#file:f1",
     )
 
 

--- a/tests/cloud/uploads/test_listener_pocket_route.py
+++ b/tests/cloud/uploads/test_listener_pocket_route.py
@@ -1,4 +1,6 @@
 # test_listener_pocket_route.py — listener pocket-scope routing tests.
+# Updated: 2026-08-05 — Coupling T-1. Ingest source assertions now expect the
+#   provenance-stamped form "<filename>#file:<file_id>".
 # Created: 2026-05-03 — Stage 3.E "Files as Knowledge". Verifies that
 # FileReady events with ``pocket_id`` route into ``pocket:{id}`` and
 # events without ``pocket_id`` keep the Stage 1.B ``workspace:{wid}``
@@ -80,7 +82,7 @@ async def test_pocket_id_routes_to_pocket_scope(monkeypatch, tmp_path):
     ingest.assert_awaited_once_with(
         scope="pocket:PA",
         text="slide content",
-        source="deck.pdf",
+        source="deck.pdf#file:f1",
     )
 
 
@@ -111,7 +113,7 @@ async def test_no_pocket_id_keeps_workspace_scope(monkeypatch, tmp_path):
     ingest.assert_awaited_once_with(
         scope="workspace:w1",
         text="hello",
-        source="doc.pdf",
+        source="doc.pdf#file:f1",
     )
 
 
@@ -143,5 +145,5 @@ async def test_empty_pocket_id_falls_back_to_workspace(monkeypatch, tmp_path):
     ingest.assert_awaited_once_with(
         scope="workspace:w1",
         text="hello",
-        source="doc.pdf",
+        source="doc.pdf#file:f1",
     )

--- a/tests/cloud/uploads/test_listener_vector.py
+++ b/tests/cloud/uploads/test_listener_vector.py
@@ -1,4 +1,6 @@
 # test_listener_vector.py — listener vector-path coverage.
+# Updated: 2026-08-05 — Coupling T-1. Ingest source assertions now expect the
+#   provenance-stamped form "<filename>#file:<file_id>".
 # Created: 2026-04-30 — Phase 2 of "Files as Knowledge" plan, Stage 2.D.
 # Covers the post-text-ingest hook: vectors enabled → embedder called →
 # kb subprocess invoked with --vec; cap hit → vector skipped, text still
@@ -194,7 +196,9 @@ async def test_vector_path_runs_when_enabled(monkeypatch, tmp_path):
     )
 
     # Text ingest happened first.
-    ingest.assert_awaited_once_with(scope="workspace:w1", text="caption", source="diagram.png")
+    ingest.assert_awaited_once_with(
+        scope="workspace:w1", text="caption", source="diagram.png#file:f1"
+    )
     # Embedder ran on the same path the chain saw.
     assert embedder.calls == [(direct, "image/png")]
     # Cost was recorded.


### PR DESCRIPTION
Deleting an uploaded file used to leave its extracted knowledge behind: the FileDeleted event had no subscribers, so the kb article built from the file stayed searchable by every agent in the scope after the user thought the content was gone. That is a privacy problem, and it needed to land before anything public.

What this adds:

- A FileDeleted subscriber in uploads/listeners.py that purges the kb article using the kb_article_id/kb_scope pair persisted on the FileUpload doc. The service soft-deletes the row before emitting, so the subscriber reads through a new tombstone-inclusive store method (get_doc_scoped_any).
- Article provenance now runs both ways. Ingest stamps the kb-go source as filename#file:<file_id>, and the language hint still resolves correctly because _lang_for_source strips the fragment before the suffix lookup.
- 11 new tests covering the prune path, cross-tenant isolation, missing-tracking no-ops, malformed payloads, and purge-failure behavior (tracking is kept so a future sweeper can retry). Full uploads suite matches the dev baseline exactly; the targeted set is 78 passed.

The join fields themselves (kb_article_id/kb_scope on FileUpload) already shipped in FL-11b, so this PR builds only the missing pieces on top of them.

One known limitation, deliberately out of scope: a file deleted while its ingest is still mid-flight can leave an orphan article, because tracking may be recorded after the prune ran. That race predates this change and wants a periodic sweeper rather than more locking here.