### PR TITLE
feat(people): keep the Fabric Person fresh across role and profile changes

### DIFF
--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -1,5 +1,10 @@
 """PocketPaw Enterprise Cloud — domain-driven architecture.
 
+Modified: 2026-08-05 (feat/coupling-person-freshness, T-2) — Registers
+    ``register_people_listeners`` after the task listeners: the
+    workspace.member_role and profile.updated bus subscribers that keep the
+    Fabric Person (the identity spine agents orient on) fresh across role
+    changes and profile edits.
 Modified: 2026-07-11 (feat/real-pipeline-s1) — Mounts the fabric_ingest
     transform-surface router (``/fabric/ingest/mappings`` CRUD +
     ``/fabric/ingest/run`` run-now) next to the fabric router under
@@ -903,6 +908,15 @@ def mount_cloud(app: FastAPI) -> None:
     from pocketpaw_ee.cloud.tasks.listeners import register_task_listeners
 
     register_task_listeners()
+
+    # People — keep the Fabric Person (the identity spine agents orient on)
+    # fresh: workspace.member_role → re-materialize that member's role;
+    # profile.updated → re-materialize name/avatar in every workspace the
+    # user belongs to (T-2, feat/coupling-person-freshness). Same
+    # register-after-init_realtime constraint as the other bus subscribers.
+    from pocketpaw_ee.cloud.people.listeners import register_people_listeners
+
+    register_people_listeners()
 
     # Planner — when a plan is generated, auto-execute unblocked tasks
 

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -27,6 +27,11 @@ Modified: 2026-07-27 (feat/growth-g1) — Mounts the growth prospect-store
     router (``/growth/prospects`` create / get / list / update) under
     ``/api/v1``. License gate + ``request_context`` on every route;
     workspace-scoped reads inside the service (cross-tenant ids 404).
+Modified: 2026-08-05 (feat/coupling-person-freshness, T-2) — Registers
+    ``register_people_listeners`` after the task listeners: the
+    workspace.member_role and profile.updated bus subscribers that keep the
+    Fabric Person (the identity spine agents orient on) fresh across role
+    changes and profile edits.
 Modified: 2026-07-11 (feat/real-pipeline-s1) — Mounts the fabric_ingest
     transform-surface router (``/fabric/ingest/mappings`` CRUD +
     ``/fabric/ingest/run`` run-now) next to the fabric router under
@@ -1107,6 +1112,15 @@ def mount_cloud(app: FastAPI) -> None:
     from pocketpaw_ee.cloud.tasks.listeners import register_task_listeners
 
     register_task_listeners()
+
+    # People — keep the Fabric Person (the identity spine agents orient on)
+    # fresh: workspace.member_role → re-materialize that member's role;
+    # profile.updated → re-materialize name/avatar in every workspace the
+    # user belongs to (T-2, feat/coupling-person-freshness). Same
+    # register-after-init_realtime constraint as the other bus subscribers.
+    from pocketpaw_ee.cloud.people.listeners import register_people_listeners
+
+    register_people_listeners()
 
     # Planner — when a plan is generated, auto-execute unblocked tasks
 

--- a/ee/pocketpaw_ee/cloud/_core/realtime/events.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/events.py
@@ -51,6 +51,12 @@
 #   ``WebSandboxStatusChanged`` (type="websandbox.status_changed") for the Web
 #   Cursor sandbox registry. Emitted by ``websandbox.service`` on every
 #   state-mutating call per cloud rule 9.
+# Updated: 2026-08-05 (feat/coupling-person-freshness, T-2) — added
+#   ``ProfileUpdated`` (type="profile.updated"), emitted by
+#   ``auth.service.update_profile`` after a profile write. Payload carries
+#   ``user_id`` + ``changed`` (list of field names). Subscribed by
+#   ``people/listeners.py`` to re-materialize the member's Fabric Person in
+#   every workspace so agents never orient on a stale name/avatar.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -146,6 +152,19 @@ class WorkspaceInviteAccepted(Event):
 @dataclass
 class WorkspaceInviteRevoked(Event):
     EVENT_TYPE: ClassVar[str] = "workspace.invite.revoked"
+
+
+# Auth / profile
+@dataclass
+class ProfileUpdated(Event):
+    """A user edited their auth profile (full_name / avatar / status).
+
+    Payload: ``{user_id, changed: [field, ...]}`` — field names only, not
+    values. Consumers that need the fresh values re-read the user record
+    (source of truth) rather than trusting an event snapshot.
+    """
+
+    EVENT_TYPE: ClassVar[str] = "profile.updated"
 
 
 # Groups

--- a/ee/pocketpaw_ee/cloud/_core/realtime/events.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/events.py
@@ -60,6 +60,12 @@
 #   ``AgentPlanUpdated`` (type="agent.plan_updated") for the agent plan panel.
 #   Emitted by ``shared/agent_bridge.py`` when a backend's plan tool call
 #   normalizes to a plan that actually changed.
+# Updated: 2026-08-05 (feat/coupling-person-freshness, T-2) — added
+#   ``ProfileUpdated`` (type="profile.updated"), emitted by
+#   ``auth.service.update_profile`` after a profile write. Payload carries
+#   ``user_id`` + ``changed`` (list of field names). Subscribed by
+#   ``people/listeners.py`` to re-materialize the member's Fabric Person in
+#   every workspace so agents never orient on a stale name/avatar.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -155,6 +161,19 @@ class WorkspaceInviteAccepted(Event):
 @dataclass
 class WorkspaceInviteRevoked(Event):
     EVENT_TYPE: ClassVar[str] = "workspace.invite.revoked"
+
+
+# Auth / profile
+@dataclass
+class ProfileUpdated(Event):
+    """A user edited their auth profile (full_name / avatar / status).
+
+    Payload: ``{user_id, changed: [field, ...]}`` — field names only, not
+    values. Consumers that need the fresh values re-read the user record
+    (source of truth) rather than trusting an event snapshot.
+    """
+
+    EVENT_TYPE: ClassVar[str] = "profile.updated"
 
 
 # Groups

--- a/ee/pocketpaw_ee/cloud/auth/service.py
+++ b/ee/pocketpaw_ee/cloud/auth/service.py
@@ -17,6 +17,14 @@ resolved id here so it survives across sessions and devices; routing the
 read/write through this service keeps ``models.user`` writes inside the
 auth entity. ``claim_home_pocket_id`` is a compare-and-swap (not a plain
 write) so a first-login provision race resolves to a single home pocket.
+Updated: 2026-08-05 (feat/coupling-person-freshness, T-2) —
+``update_profile`` now emits ``ProfileUpdated`` (type="profile.updated")
+with the changed field names, per cloud rule 9 (emit on every write); the
+people module subscribes it to keep the Fabric Person's name/avatar fresh
+in every workspace. Also added ``get_profile_by_id`` — the plain-user_id
+read (same style as ``get_active_workspace``) non-HTTP callers like the
+people refresh/backfill paths use to reach profile + membership data
+without minting a RequestContext.
 """
 
 from __future__ import annotations
@@ -25,6 +33,8 @@ from beanie import PydanticObjectId
 
 from pocketpaw_ee.cloud._core.context import RequestContext
 from pocketpaw_ee.cloud._core.errors import Forbidden, NotFound, ValidationError
+from pocketpaw_ee.cloud._core.realtime.emit import emit
+from pocketpaw_ee.cloud._core.realtime.events import ProfileUpdated
 from pocketpaw_ee.cloud.auth.domain import AuthUser, WorkspaceMembershipRef
 from pocketpaw_ee.cloud.models.user import User as _UserDoc
 
@@ -74,13 +84,39 @@ async def update_profile(
     doc = await _UserDoc.get(PydanticObjectId(ctx.user_id))
     if doc is None:
         raise NotFound("user", ctx.user_id)
-    if full_name is not None:
+    changed: list[str] = []
+    if full_name is not None and doc.full_name != full_name:
         doc.full_name = full_name
-    if avatar is not None:
+        changed.append("full_name")
+    if avatar is not None and doc.avatar != avatar:
         doc.avatar = avatar
-    if status is not None:
+        changed.append("avatar")
+    if status is not None and doc.status != status:
         doc.status = status
+        changed.append("status")
     await doc.save()
+    if changed:
+        # Field names only — consumers (people/listeners.py re-materializing
+        # the Fabric Person) re-read the user record for the fresh values.
+        await emit(ProfileUpdated(data={"user_id": ctx.user_id, "changed": changed}))
+    # no-event: nothing changed — the save was a no-op write.
+    return _to_domain(doc)
+
+
+async def get_profile_by_id(user_id: str) -> AuthUser:
+    """Return a user's profile (incl. membership refs) by plain ``user_id``.
+
+    Takes a plain ``user_id`` (not a ``RequestContext``) so non-HTTP
+    callers — notably the people module's Person refresh/backfill paths,
+    which run from bus listeners and journal-read misses — can reach the
+    profile fields + workspace membership list without minting a context.
+    Keeps ``models.user`` reads inside the auth entity (Rule 2), same
+    style as ``get_active_workspace``. Raises ``NotFound`` when the user
+    record is missing.
+    """
+    doc = await _UserDoc.get(PydanticObjectId(user_id))
+    if doc is None:
+        raise NotFound("user", user_id)
     return _to_domain(doc)
 
 
@@ -222,6 +258,7 @@ __all__ = [
     "claim_home_pocket_id",
     "get_home_pocket_id",
     "get_profile",
+    "get_profile_by_id",
     "resolve_display_names",
     "set_active_workspace",
     "set_avatar_path",

--- a/ee/pocketpaw_ee/cloud/auth/service.py
+++ b/ee/pocketpaw_ee/cloud/auth/service.py
@@ -25,6 +25,14 @@ resolved id here so it survives across sessions and devices; routing the
 read/write through this service keeps ``models.user`` writes inside the
 auth entity. ``claim_home_pocket_id`` is a compare-and-swap (not a plain
 write) so a first-login provision race resolves to a single home pocket.
+Updated: 2026-08-05 (feat/coupling-person-freshness, T-2) —
+``update_profile`` now emits ``ProfileUpdated`` (type="profile.updated")
+with the changed field names, per cloud rule 9 (emit on every write); the
+people module subscribes it to keep the Fabric Person's name/avatar fresh
+in every workspace. Also added ``get_profile_by_id`` — the plain-user_id
+read (same style as ``get_active_workspace``) non-HTTP callers like the
+people refresh/backfill paths use to reach profile + membership data
+without minting a RequestContext.
 """
 
 from __future__ import annotations
@@ -33,6 +41,8 @@ from beanie import PydanticObjectId
 
 from pocketpaw_ee.cloud._core.context import RequestContext
 from pocketpaw_ee.cloud._core.errors import Forbidden, NotFound, ValidationError
+from pocketpaw_ee.cloud._core.realtime.emit import emit
+from pocketpaw_ee.cloud._core.realtime.events import ProfileUpdated
 from pocketpaw_ee.cloud.auth.domain import AuthUser, UserIdentity, WorkspaceMembershipRef
 from pocketpaw_ee.cloud.models.user import User as _UserDoc
 
@@ -83,13 +93,39 @@ async def update_profile(
     doc = await _UserDoc.get(PydanticObjectId(ctx.user_id))
     if doc is None:
         raise NotFound("user", ctx.user_id)
-    if full_name is not None:
+    changed: list[str] = []
+    if full_name is not None and doc.full_name != full_name:
         doc.full_name = full_name
-    if avatar is not None:
+        changed.append("full_name")
+    if avatar is not None and doc.avatar != avatar:
         doc.avatar = avatar
-    if status is not None:
+        changed.append("avatar")
+    if status is not None and doc.status != status:
         doc.status = status
+        changed.append("status")
     await doc.save()
+    if changed:
+        # Field names only — consumers (people/listeners.py re-materializing
+        # the Fabric Person) re-read the user record for the fresh values.
+        await emit(ProfileUpdated(data={"user_id": ctx.user_id, "changed": changed}))
+    # no-event: nothing changed — the save was a no-op write.
+    return _to_domain(doc)
+
+
+async def get_profile_by_id(user_id: str) -> AuthUser:
+    """Return a user's profile (incl. membership refs) by plain ``user_id``.
+
+    Takes a plain ``user_id`` (not a ``RequestContext``) so non-HTTP
+    callers — notably the people module's Person refresh/backfill paths,
+    which run from bus listeners and journal-read misses — can reach the
+    profile fields + workspace membership list without minting a context.
+    Keeps ``models.user`` reads inside the auth entity (Rule 2), same
+    style as ``get_active_workspace``. Raises ``NotFound`` when the user
+    record is missing.
+    """
+    doc = await _UserDoc.get(PydanticObjectId(user_id))
+    if doc is None:
+        raise NotFound("user", user_id)
     return _to_domain(doc)
 
 
@@ -269,6 +305,7 @@ __all__ = [
     "claim_home_pocket_id",
     "get_home_pocket_id",
     "get_profile",
+    "get_profile_by_id",
     "resolve_display_names",
     "set_active_workspace",
     "set_avatar_path",

--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -9,6 +9,12 @@ handles *what the agent sees*:
 * ``load_history_for_scope`` rehydrates prior chat turns from Mongo so the
   agent carries context across backend restarts and pool evictions.
 
+Changes: 2026-08-05 (feat/coupling-person-freshness, T-2) — updated the
+``_resolve_about_member`` docstring: the Fabric Person is no longer a
+one-time invite snapshot (owner materialized at create, role/profile
+refresh listeners, lazy get_person backfill), so the user-record fallback
+now covers transient failures, not a structural gap. No behavior change here.
+
 Changes: 2026-07-14 (Paw Bar concierge seam, T2) — added ``ScopeKind.CONCIERGE``
 and ``_resolve_concierge``: a PUBLIC, anonymous Paw Bar concierge run resolves
 its ``ScopeContext`` from the server-authoritative spec (Site pocket + widget
@@ -866,15 +872,21 @@ async def _resolve_about_member(workspace_id: str, user_id: str) -> str | None:
     ``build_behavior_instructions`` can append it without awaiting.
 
     TWO SOURCES, IN ORDER, and the second one is why "who am I?" used to fail.
-    The Fabric ``Person`` is the rich source — name, role, team, focus — but it
-    is created by exactly one path, ``materialize_person_from_invite``. A member
-    who was never invited has no Person, and the founding admin of a workspace
-    is never invited: they created it. So the one block in the whole prompt that
-    says who the human is rendered NOTHING for the person most likely to be
-    using the product, and the agent answered "I don't know who you are" while
-    ``full_name`` sat in their user document the entire time. Confirmed live on
-    2026-08-04: ``about_member_block`` was ``None`` and the 36,608-char
-    instruction stack contained neither the member's name nor their id.
+    The Fabric ``Person`` is the rich source — name, role, team, focus. It used
+    to be created by exactly one path, ``materialize_person_from_invite``, so a
+    member who was never invited had no Person, and the founding admin of a
+    workspace is never invited: they created it. So the one block in the whole
+    prompt that says who the human is rendered NOTHING for the person most
+    likely to be using the product, and the agent answered "I don't know who
+    you are" while ``full_name`` sat in their user document the entire time.
+    Confirmed live on 2026-08-04: ``about_member_block`` was ``None`` and the
+    36,608-char instruction stack contained neither the member's name nor
+    their id. Since T-2 (feat/coupling-person-freshness, 2026-08-05) the
+    owner is materialized at workspace-create, role changes and profile edits
+    re-materialize via bus listeners, and ``get_person`` lazily backfills a
+    live member on a miss — so this fallback now covers transient Fabric
+    failures rather than a permanent structural gap. It stays: degraded
+    identity beats no identity.
 
     So a missing Person now falls back to the authenticated user record, which
     always exists — that is what "authenticated" means. The fallback block is

--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -29,6 +29,12 @@ identity and never the sink. The registry lets such a caller find the stream by
 session id instead. ``push_sse_event`` is unchanged and still a deliberate
 no-op outside a stream.
 
+Changes: 2026-08-05 (feat/coupling-person-freshness, T-2) — updated the
+``_resolve_about_member`` docstring: the Fabric Person is no longer a
+one-time invite snapshot (owner materialized at create, role/profile
+refresh listeners, lazy get_person backfill), so the user-record fallback
+now covers transient failures, not a structural gap. No behavior change here.
+
 Changes: 2026-07-14 (Paw Bar concierge seam, T2) — added ``ScopeKind.CONCIERGE``
 and ``_resolve_concierge``: a PUBLIC, anonymous Paw Bar concierge run resolves
 its ``ScopeContext`` from the server-authoritative spec (Site pocket + widget
@@ -1030,15 +1036,21 @@ async def _resolve_about_member(workspace_id: str, user_id: str) -> str | None:
     ``build_behavior_instructions`` can append it without awaiting.
 
     TWO SOURCES, IN ORDER, and the second one is why "who am I?" used to fail.
-    The Fabric ``Person`` is the rich source — name, role, team, focus — but it
-    is created by exactly one path, ``materialize_person_from_invite``. A member
-    who was never invited has no Person, and the founding admin of a workspace
-    is never invited: they created it. So the one block in the whole prompt that
-    says who the human is rendered NOTHING for the person most likely to be
-    using the product, and the agent answered "I don't know who you are" while
-    ``full_name`` sat in their user document the entire time. Confirmed live on
-    2026-08-04: ``about_member_block`` was ``None`` and the 36,608-char
-    instruction stack contained neither the member's name nor their id.
+    The Fabric ``Person`` is the rich source — name, role, team, focus. It used
+    to be created by exactly one path, ``materialize_person_from_invite``, so a
+    member who was never invited had no Person, and the founding admin of a
+    workspace is never invited: they created it. So the one block in the whole
+    prompt that says who the human is rendered NOTHING for the person most
+    likely to be using the product, and the agent answered "I don't know who
+    you are" while ``full_name`` sat in their user document the entire time.
+    Confirmed live on 2026-08-04: ``about_member_block`` was ``None`` and the
+    36,608-char instruction stack contained neither the member's name nor
+    their id. Since T-2 (feat/coupling-person-freshness, 2026-08-05) the
+    owner is materialized at workspace-create, role changes and profile edits
+    re-materialize via bus listeners, and ``get_person`` lazily backfills a
+    live member on a miss — so this fallback now covers transient Fabric
+    failures rather than a permanent structural gap. It stays: degraded
+    identity beats no identity.
 
     So a missing Person now falls back to the authenticated user record, which
     always exists — that is what "authenticated" means. The fallback block is

--- a/ee/pocketpaw_ee/cloud/people/__init__.py
+++ b/ee/pocketpaw_ee/cloud/people/__init__.py
@@ -10,11 +10,32 @@
 # side, ``get_person``, so the agent-orientation flow can fetch a member's
 # Person to render an "about this member" block in the system prompt.
 #
+# Changes: 2026-08-05 (feat/coupling-person-freshness, T-2) — the Person is
+# no longer a one-time invite snapshot. Added ``listeners.py`` (bus
+# subscribers: workspace.member_role + profile.updated re-run the idempotent
+# upsert) and exported the freshness surface:
+# ``materialize_person_from_membership`` (owner-at-create + every non-invite
+# path), ``refresh_person_role``, ``refresh_person_profile``. ``get_person``
+# now lazily backfills a missing Person for a live member on first read.
+#
 # No router yet: the entry points are the service functions the workspace
-# accept_invite path (write) and the chat agent-orientation path (read) call.
-# A read API can land in a later slice.
+# accept_invite / create paths (write), the bus listeners (refresh), and the
+# chat agent-orientation path (read) call. A read API can land in a later slice.
 
 from pocketpaw_ee.cloud.people.domain import Person
-from pocketpaw_ee.cloud.people.service import get_person, materialize_person_from_invite
+from pocketpaw_ee.cloud.people.service import (
+    get_person,
+    materialize_person_from_invite,
+    materialize_person_from_membership,
+    refresh_person_profile,
+    refresh_person_role,
+)
 
-__all__ = ["Person", "get_person", "materialize_person_from_invite"]
+__all__ = [
+    "Person",
+    "get_person",
+    "materialize_person_from_invite",
+    "materialize_person_from_membership",
+    "refresh_person_profile",
+    "refresh_person_role",
+]

--- a/ee/pocketpaw_ee/cloud/people/domain.py
+++ b/ee/pocketpaw_ee/cloud/people/domain.py
@@ -7,6 +7,14 @@
 # the workspace tag is impossible to forget — constructing a ``Person``
 # without one is a TypeError, not a silent leak.
 #
+# Changes: 2026-08-05 (feat/coupling-person-freshness, T-2) — added
+# ``SOURCE_MEMBERSHIP``, the provenance marker for a Person materialized
+# from live membership data rather than an invite's admin context: the
+# workspace owner at create, a pre-existing member lazily backfilled on a
+# ``get_person`` miss, or a role-change refresh for a member who never had
+# a Person. Distinguishes "seeded by an inviting admin" from "derived from
+# the membership record itself".
+#
 # STANDALONE by design: this models *identity* (who the member is), a
 # different axis from the per-pocket agent-policy surface profile
 # (``PocketSurfaceProfile`` / entity-pocket-profile work). No import of,
@@ -32,6 +40,13 @@ PERSON_TYPE_NAME = "Person"
 # the property bag (``source``) so a reader that only has the projected
 # object — not the journal event — can still tell where the row came from.
 SOURCE_ADMIN_CONTEXT = "admin_context"
+
+# Provenance marker for a Person materialized from live membership data
+# (no invite involved): the workspace owner at workspace-create, a lazy
+# backfill on a ``get_person`` miss, or a role-change refresh for a member
+# who never had a Person. ``invited_by`` is empty for these rows — nobody
+# invited them; the membership record itself is the source.
+SOURCE_MEMBERSHIP = "membership"
 
 
 @dataclass(frozen=True)
@@ -109,5 +124,6 @@ __all__ = [
     "PERSON_TYPE_ID",
     "PERSON_TYPE_NAME",
     "SOURCE_ADMIN_CONTEXT",
+    "SOURCE_MEMBERSHIP",
     "Person",
 ]

--- a/ee/pocketpaw_ee/cloud/people/listeners.py
+++ b/ee/pocketpaw_ee/cloud/people/listeners.py
@@ -1,0 +1,115 @@
+# listeners.py — in-process bus subscribers for People (Person freshness).
+# Created: 2026-08-05 (feat/coupling-person-freshness, T-2) — the Fabric
+#   ``Person`` used to be a one-time snapshot taken at invite-accept, so a
+#   role change or profile edit left agents orienting on stale identity
+#   (a stale-role Person has leaked wrong cards before). These subscribers
+#   re-run the idempotent Person upsert whenever the source data moves:
+#   ``workspace.member_role`` → refresh that member's role in that
+#   workspace; ``profile.updated`` → refresh name/avatar in EVERY
+#   workspace the user belongs to. Mirrors the tasks/listeners.py house
+#   pattern; wired into the bus from ``ee.cloud.__init__:mount_cloud``
+#   after ``init_realtime`` has installed the singleton bus.
+"""People bus subscribers — keep the Fabric ``Person`` fresh.
+
+The workspace service emits :class:`WorkspaceMemberRole` on every role
+change and the auth service emits :class:`ProfileUpdated` on every
+profile edit. This module subscribes both and re-materializes the
+affected Person(s) through the people service's shared upsert (keyed on
+the deterministic ``person-{workspace_id}-{user_id}`` id, so a refresh
+updates — never duplicates). Failures are logged and swallowed: the
+membership/profile write is the source of truth, the Person is a derived
+projection, and the lazy ``get_person`` backfill converges any miss.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from pocketpaw_ee.cloud._core.realtime.bus import get_bus
+from pocketpaw_ee.cloud._core.realtime.events import (
+    Event,
+    ProfileUpdated,
+    WorkspaceMemberRole,
+)
+
+logger = logging.getLogger(__name__)
+
+
+async def refresh_person_on_role_change(event: Event) -> None:
+    """Re-materialize a member's Person when their workspace role changes.
+
+    Payload: ``{workspace_id, user_id, role}`` (emitted by
+    ``workspace.service.update_member_role``). Malformed payloads are
+    skipped defensively — the bus should never deliver one, but a broken
+    handler must not take down the rest of the subscriber chain.
+    """
+
+    data = getattr(event, "data", None) or {}
+    workspace_id = data.get("workspace_id")
+    user_id = data.get("user_id")
+    role = data.get("role")
+    if not workspace_id or not user_id or not role:
+        return
+
+    try:
+        from pocketpaw_ee.cloud.people import service as people_service
+
+        await people_service.refresh_person_role(workspace_id, user_id, role)
+    except Exception:
+        logger.warning(
+            "workspace.member_role → Person refresh failed for user=%s workspace=%s",
+            user_id,
+            workspace_id,
+            exc_info=True,
+        )
+
+
+async def refresh_person_on_profile_update(event: Event) -> None:
+    """Re-materialize a user's Person everywhere when their profile changes.
+
+    Payload: ``{user_id, changed: [...]}`` (emitted by
+    ``auth.service.update_profile``). Only identity-bearing changes
+    (``full_name`` / ``avatar``) trigger a refresh — a status flip doesn't
+    touch the Person. The fresh values are re-read from the user record
+    inside the people service (source of truth), not trusted from the
+    event payload.
+    """
+
+    data = getattr(event, "data", None) or {}
+    user_id = data.get("user_id")
+    if not user_id:
+        return
+    changed = data.get("changed") or []
+    if not any(f in changed for f in ("full_name", "avatar")):
+        return
+
+    try:
+        from pocketpaw_ee.cloud.people import service as people_service
+
+        await people_service.refresh_person_profile(user_id)
+    except Exception:
+        logger.warning(
+            "profile.updated → Person refresh failed for user=%s",
+            user_id,
+            exc_info=True,
+        )
+
+
+def register_people_listeners() -> None:
+    """Wire the People subscribers into the bus.
+
+    Called once from ``mount_cloud`` after ``init_realtime`` has set the
+    singleton. Idempotent at the framework level only — calling twice
+    would double-register; the bootstrap path calls it exactly once.
+    """
+
+    bus = get_bus()
+    bus.subscribe(WorkspaceMemberRole.EVENT_TYPE, refresh_person_on_role_change)
+    bus.subscribe(ProfileUpdated.EVENT_TYPE, refresh_person_on_profile_update)
+
+
+__all__ = [
+    "refresh_person_on_profile_update",
+    "refresh_person_on_role_change",
+    "register_people_listeners",
+]

--- a/ee/pocketpaw_ee/cloud/people/service.py
+++ b/ee/pocketpaw_ee/cloud/people/service.py
@@ -8,11 +8,27 @@ property bag back to a typed :class:`Person`, or ``None`` when the member
 has no Person yet. The agent-orientation flow reads it to render an
 "about this member" block; the read mirrors the materializer's query +
 scope shape.
+Changes: 2026-08-05 (feat/coupling-person-freshness, T-2) — the Person is
+no longer a one-time invite-accept snapshot. Added:
+:func:`materialize_person_from_membership` (upsert from live membership
+data — used for the workspace owner at create and every non-invite path),
+:func:`refresh_person_role` (re-materialize on a ``workspace.member_role``
+event), :func:`refresh_person_profile` (re-materialize name/avatar in
+every workspace on a ``profile.updated`` event), and a LAZY BACKFILL in
+:func:`get_person` — a miss for a user who IS a live member materializes
+the Person on first read (chosen over a startup backfill sweep: no house
+pattern for data backfills exists, the read path is the only consumer, and
+lazy converges without a migration). The shared write path is
+:func:`_upsert_person`; every entry point funnels through it, keyed on the
+same deterministic id.
 
 When a workspace invite is accepted, ``accept_invite`` calls
 :func:`materialize_person_from_invite` to create (or update) a standalone
 Fabric ``Person`` object for the new member. The object is the identity
 "spine" a later VIP-onboarding flow reads. :func:`get_person` is that read.
+Role changes and profile edits re-run the same idempotent upsert via the
+``people/listeners.py`` bus subscribers, so agents never orient on a stale
+role, name, or avatar (a stale-role Person has leaked wrong cards before).
 
 Write path — the journal, not the legacy SQLite store
 -----------------------------------------------------
@@ -49,6 +65,7 @@ work) — that is a different axis. Keep them separate.
 from __future__ import annotations
 
 import logging
+from dataclasses import replace
 from functools import lru_cache
 
 from soul_protocol.spec.journal import Actor
@@ -59,6 +76,7 @@ from pocketpaw_ee.cloud.people.domain import (
     PERSON_TYPE_ID,
     PERSON_TYPE_NAME,
     SOURCE_ADMIN_CONTEXT,
+    SOURCE_MEMBERSHIP,
     Person,
 )
 from pocketpaw_ee.cloud.workspace.domain import Invite
@@ -199,14 +217,35 @@ async def materialize_person_from_invite(
         avatar=avatar,
         invite=invite,
     )
-    scope = _person_scope(workspace_id)
+    # Provenance: the inviting admin is the journal Actor.
+    await _upsert_person(person, actor_user_id=person.invited_by, store=fabric)
+    return person
 
-    # Provenance: the inviting admin is the journal Actor. The scope_context
-    # mirrors the write scope so the recorded actor identity carries the
-    # same tenancy bound as the event.
+
+async def _upsert_person(
+    person: Person,
+    *,
+    actor_user_id: str,
+    store: FabricJournalStore,
+) -> None:
+    """Write ``person`` to the Fabric journal — create or update by id.
+
+    The shared write path every materialization entry point funnels through
+    (invite accept, workspace-create owner, role-change refresh, profile
+    refresh, lazy backfill). Idempotent: probes the projection for the
+    deterministic id first — present → ``update`` (every field is supplied,
+    so changed values overwrite cleanly), absent → ``create``.
+
+    ``actor_user_id`` becomes the journal ``Actor`` (the inviting admin on
+    the invite path; the member themselves on membership-derived paths).
+    The scope_context mirrors the write scope so the recorded actor
+    identity carries the same tenancy bound as the event.
+    """
+
+    scope = _person_scope(person.workspace_id)
     actor = Actor(
         kind="user",
-        id=f"user:{person.invited_by}",
+        id=f"user:{actor_user_id}",
         scope_context=list(scope),
     )
 
@@ -214,7 +253,7 @@ async def materialize_person_from_invite(
 
     # Idempotency probe: is this member already materialized? Query the
     # projection for the Person type and look for our deterministic id.
-    existing = await fabric.query(
+    existing = await store.query(
         FabricQuery(type_id=PERSON_TYPE_ID, limit=10_000),
         requester_scopes=scope,
     )
@@ -223,7 +262,7 @@ async def materialize_person_from_invite(
     if already:
         # Update merges onto existing properties — every field we write is
         # supplied here, so a changed profile / context overwrites cleanly.
-        await fabric.update(person.id, properties, scope=scope, actor=actor)
+        await store.update(person.id, properties, scope=scope, actor=actor)
     else:
         obj = FabricObject(
             id=person.id,
@@ -233,12 +272,169 @@ async def materialize_person_from_invite(
             # Native Fabric provenance, in addition to the property-bag
             # copy: source_connector flags the origin, source_id is the
             # member's user id (the external key this row tracks).
-            source_connector=SOURCE_ADMIN_CONTEXT,
-            source_id=user_id,
+            source_connector=person.source,
+            source_id=person.user_id,
         )
-        await fabric.create(obj, scope=scope, actor=actor)
+        await store.create(obj, scope=scope, actor=actor)
 
+
+async def materialize_person_from_membership(
+    *,
+    workspace_id: str,
+    user_id: str,
+    name: str,
+    email: str,
+    avatar: str,
+    role: str,
+    group: str | None = None,
+    store: FabricJournalStore | None = None,
+) -> Person:
+    """Create or update a member's Fabric ``Person`` from live membership data.
+
+    The non-invite materialization path (T-2): the workspace OWNER at
+    workspace-create, the lazy backfill on a ``get_person`` miss, and a
+    role-change refresh for a member who never had a Person. Identity
+    fields come from the member's own profile; ``role`` comes from the
+    membership record. Onboarding fields (``focus`` / ``profile_pic``) are
+    empty — no admin context exists on this path — and ``invited_by`` is
+    empty because nobody invited them; ``source=membership`` records that
+    provenance.
+
+    Same idempotent upsert as the invite path (deterministic id), so a
+    later re-accept or refresh updates rather than duplicating. The member
+    themselves is the journal Actor.
+    """
+
+    fabric = store if store is not None else _default_store()
+    person = Person(
+        id=_person_object_id(workspace_id, user_id),
+        workspace_id=workspace_id,
+        user_id=user_id,
+        name=name,
+        email=email,
+        avatar=avatar,
+        role=role,
+        group=group,
+        focus="",
+        profile_pic="",
+        invited_by="",
+        source=SOURCE_MEMBERSHIP,
+    )
+    await _upsert_person(person, actor_user_id=user_id, store=fabric)
     return person
+
+
+async def _materialize_from_profile(
+    workspace_id: str,
+    user_id: str,
+    *,
+    role: str,
+    store: FabricJournalStore,
+) -> Person:
+    """Materialize a Person by reading the member's live auth profile.
+
+    Fetches ``full_name`` / ``email`` / ``avatar`` through the auth service
+    (the sole owner of ``models.user`` reads, per cloud rule 2) and funnels
+    into :func:`materialize_person_from_membership`. Lazy import: the auth
+    entity is only touched when a refresh/backfill actually runs, and the
+    people module stays import-light for unit tests that inject a store.
+
+    Raises ``NotFound`` when the user record is missing — callers on
+    best-effort paths (listeners, lazy backfill) catch and degrade.
+    """
+
+    from pocketpaw_ee.cloud.auth import service as auth_service
+
+    profile = await auth_service.get_profile_by_id(user_id)
+    return await materialize_person_from_membership(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        name=profile.full_name or "",
+        email=profile.email or "",
+        avatar=profile.avatar or "",
+        role=role,
+        store=store,
+    )
+
+
+async def refresh_person_role(
+    workspace_id: str,
+    user_id: str,
+    role: str,
+    *,
+    store: FabricJournalStore | None = None,
+) -> Person | None:
+    """Re-materialize a member's Person after a role change.
+
+    Called by the ``workspace.member_role`` bus subscriber. An existing
+    Person keeps every identity/onboarding field and gets the new ``role``;
+    a member with NO Person yet (pre-existing member, workspace owner from
+    before owners were materialized) is materialized fresh from their live
+    profile + the new role — the same convergence the lazy ``get_person``
+    backfill provides, just triggered by the role event instead of a read.
+
+    Returns the refreshed Person, or ``None`` if the member's user record
+    cannot be read (the caller treats that as a skipped refresh, never an
+    error — the lazy backfill converges it later).
+    """
+
+    fabric = store if store is not None else _default_store()
+    existing = await get_person(workspace_id, user_id, store=fabric, materialize_missing=False)
+    if existing is not None:
+        person = replace(existing, role=role)
+        await _upsert_person(person, actor_user_id=user_id, store=fabric)
+        return person
+    return await _materialize_from_profile(workspace_id, user_id, role=role, store=fabric)
+
+
+async def refresh_person_profile(
+    user_id: str,
+    *,
+    store: FabricJournalStore | None = None,
+) -> list[Person]:
+    """Re-materialize a user's Person in EVERY workspace they belong to.
+
+    Called by the ``profile.updated`` bus subscriber after an auth profile
+    edit (full_name / avatar). Reads the fresh profile + membership list
+    through the auth service (one call carries both), then per membership:
+    an existing Person keeps role/group/focus/pic/provenance and gets the
+    new name/email/avatar; a membership with no Person yet is materialized
+    fresh from the membership record (which doubles as backfill).
+
+    Returns the refreshed Persons. Raises ``NotFound`` when the user record
+    is missing — the listener catches and logs.
+    """
+
+    from pocketpaw_ee.cloud.auth import service as auth_service
+
+    fabric = store if store is not None else _default_store()
+    profile = await auth_service.get_profile_by_id(user_id)
+
+    refreshed: list[Person] = []
+    for membership in profile.workspaces:
+        existing = await get_person(
+            membership.workspace, user_id, store=fabric, materialize_missing=False
+        )
+        if existing is not None:
+            person = replace(
+                existing,
+                name=profile.full_name or "",
+                email=profile.email or existing.email,
+                avatar=profile.avatar or "",
+            )
+            await _upsert_person(person, actor_user_id=user_id, store=fabric)
+        else:
+            person = await materialize_person_from_membership(
+                workspace_id=membership.workspace,
+                user_id=user_id,
+                name=profile.full_name or "",
+                email=profile.email or "",
+                avatar=profile.avatar or "",
+                role=membership.role,
+                store=fabric,
+            )
+        refreshed.append(person)
+    return refreshed
 
 
 # ---------------------------------------------------------------------------
@@ -278,15 +474,25 @@ async def get_person(
     user_id: str,
     *,
     store: FabricJournalStore | None = None,
+    materialize_missing: bool = True,
 ) -> Person | None:
     """Read a member's materialized Fabric ``Person``, or ``None``.
 
     Queries the journal projection for the ``Person`` type under the member's
     own workspace scope and matches the deterministic id
     (``person-{workspace_id}-{user_id}``). Returns the typed :class:`Person`
-    when present, ``None`` when this member was never materialized — e.g. a
-    pre-existing / non-invited user. The caller treats ``None`` as "no block",
-    never an error.
+    when present. The caller treats ``None`` as "no block", never an error.
+
+    LAZY BACKFILL (T-2): on a miss, when ``materialize_missing`` is true
+    (the default), the member's live workspace role is checked — a user who
+    IS a member (pre-existing member, or a workspace owner from before
+    owners were materialized) gets a Person materialized from their auth
+    profile on this first read, and that Person is returned. A non-member
+    still returns ``None`` (tenancy holds), and ANY failure on the backfill
+    path — membership lookup, profile read, journal write — degrades to
+    ``None`` exactly as before, so unit contexts with no cloud DB behave
+    unchanged. Internal callers that must not recurse (the refresh paths)
+    pass ``materialize_missing=False``.
 
     Tenant-scoped: ``requester_scopes`` is the single workspace scope, so the
     read can only ever see this workspace's people. Mirrors the materializer's
@@ -307,7 +513,33 @@ async def get_person(
     for obj in result.objects:
         if obj.id == target_id:
             return _person_from_object(obj, workspace_id=workspace_id)
-    return None
+
+    if not materialize_missing:
+        return None
+
+    # Lazy backfill: a real member with no Person converges on first read.
+    # Fully defensive — the read contract stays "None, never an error".
+    try:
+        from pocketpaw_ee.cloud.workspace import service as workspace_service
+
+        role = await workspace_service.get_member_role(workspace_id, user_id)
+        if role is None:
+            return None
+        return await _materialize_from_profile(workspace_id, user_id, role=role, store=fabric)
+    except Exception:  # noqa: BLE001 — backfill is best-effort; the miss stays a miss
+        logger.debug(
+            "lazy Person backfill failed for user=%s workspace=%s",
+            user_id,
+            workspace_id,
+            exc_info=True,
+        )
+        return None
 
 
-__all__ = ["get_person", "materialize_person_from_invite"]
+__all__ = [
+    "get_person",
+    "materialize_person_from_invite",
+    "materialize_person_from_membership",
+    "refresh_person_profile",
+    "refresh_person_role",
+]

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -101,6 +101,14 @@ ALWAYS-ON (not behind ``billing_enforced``), unchanged from before; the Free
 ``max_seats`` == the model default (5) means a free tenant sees the identical
 limit. ``raise_seats_for_plan`` (upgrade-only) keeps the stored ``doc.seats`` in
 step with the plan on a subscription.active.
+2026-08-05 (feat/coupling-person-freshness, T-2): the workspace OWNER now gets
+a Fabric ``Person`` too. ``create()`` materializes one (role=owner) right after
+the owner membership write — BEST-EFFORT like the accept_invite materialization:
+a Fabric/journal hiccup logs and never fails workspace creation (the lazy
+``get_person`` backfill converges it later). Also exposed ``get_member_role``
+(public wrapper over ``_get_member_role``) so the people module's lazy backfill
+can check live membership without reaching into a private helper or the Beanie
+user model.
 """
 
 from __future__ import annotations
@@ -307,6 +315,17 @@ async def _get_member_role(workspace_id: str, user_id: str) -> str | None:
     return None
 
 
+async def get_member_role(workspace_id: str, user_id: str) -> str | None:
+    """Return ``user_id``'s role in ``workspace_id``, or ``None`` if not a member.
+
+    Public wrapper over the private membership lookup so cross-entity
+    callers (the people module's lazy Person backfill) can check live
+    membership through this service instead of touching ``models.user``
+    (Rule 2). Never raises — an unreadable user resolves to ``None``.
+    """
+    return await _get_member_role(workspace_id, user_id)
+
+
 async def _add_member(
     workspace_id: str,
     user_id: str,
@@ -373,6 +392,33 @@ async def create(ctx: RequestContext, body: CreateWorkspaceRequest) -> Workspace
     await doc.insert()
 
     await _add_member(str(doc.id), ctx.user_id, role="owner", set_active=True)
+
+    # Materialize the creator as a Fabric ``Person`` (role=owner) — T-2. The
+    # owner is never invited, so without this the one member every new
+    # workspace is guaranteed to have had no identity spine and agents
+    # answered "I don't know who you are". BEST-EFFORT like the
+    # accept_invite materialization: membership is the source of truth, the
+    # Person is a derived projection — a Fabric/journal hiccup must never
+    # fail workspace creation (the lazy get_person backfill converges it).
+    try:
+        creator = await _UserDoc.get(PydanticObjectId(ctx.user_id))
+        if creator is not None:
+            await people_service.materialize_person_from_membership(
+                workspace_id=str(doc.id),
+                user_id=ctx.user_id,
+                name=creator.full_name or "",
+                email=creator.email or "",
+                avatar=creator.avatar or "",
+                role="owner",
+            )
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "Fabric Person materialization skipped for owner=%s workspace=%s — "
+            "workspace create proceeds; the lazy backfill re-materializes later",
+            ctx.user_id,
+            doc.id,
+            exc_info=True,
+        )
 
     # Seed the default "pocketpaw" agent so the new workspace has a DM target
     # immediately. Idempotent; non-fatal — the boot-time back-fill is the

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -125,6 +125,14 @@ plan — can no longer invite anyone new; existing members are never removed.
 filters ``deleted_at == None`` so a soft-deleted first workspace is skipped and
 the next-oldest LIVE workspace receives instance-scoped alerts, instead of
 routing them to a tombstone.
+2026-08-05 (feat/coupling-person-freshness, T-2): the workspace OWNER now gets
+a Fabric ``Person`` too. ``create()`` materializes one (role=owner) right after
+the owner membership write — BEST-EFFORT like the accept_invite materialization:
+a Fabric/journal hiccup logs and never fails workspace creation (the lazy
+``get_person`` backfill converges it later). Also exposed ``get_member_role``
+(public wrapper over ``_get_member_role``) so the people module's lazy backfill
+can check live membership without reaching into a private helper or the Beanie
+user model.
 """
 
 from __future__ import annotations
@@ -331,6 +339,17 @@ async def _get_member_role(workspace_id: str, user_id: str) -> str | None:
     return None
 
 
+async def get_member_role(workspace_id: str, user_id: str) -> str | None:
+    """Return ``user_id``'s role in ``workspace_id``, or ``None`` if not a member.
+
+    Public wrapper over the private membership lookup so cross-entity
+    callers (the people module's lazy Person backfill) can check live
+    membership through this service instead of touching ``models.user``
+    (Rule 2). Never raises — an unreadable user resolves to ``None``.
+    """
+    return await _get_member_role(workspace_id, user_id)
+
+
 async def _add_member(
     workspace_id: str,
     user_id: str,
@@ -397,6 +416,33 @@ async def create(ctx: RequestContext, body: CreateWorkspaceRequest) -> Workspace
     await doc.insert()
 
     await _add_member(str(doc.id), ctx.user_id, role="owner", set_active=True)
+
+    # Materialize the creator as a Fabric ``Person`` (role=owner) — T-2. The
+    # owner is never invited, so without this the one member every new
+    # workspace is guaranteed to have had no identity spine and agents
+    # answered "I don't know who you are". BEST-EFFORT like the
+    # accept_invite materialization: membership is the source of truth, the
+    # Person is a derived projection — a Fabric/journal hiccup must never
+    # fail workspace creation (the lazy get_person backfill converges it).
+    try:
+        creator = await _UserDoc.get(PydanticObjectId(ctx.user_id))
+        if creator is not None:
+            await people_service.materialize_person_from_membership(
+                workspace_id=str(doc.id),
+                user_id=ctx.user_id,
+                name=creator.full_name or "",
+                email=creator.email or "",
+                avatar=creator.avatar or "",
+                role="owner",
+            )
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "Fabric Person materialization skipped for owner=%s workspace=%s — "
+            "workspace create proceeds; the lazy backfill re-materializes later",
+            ctx.user_id,
+            doc.id,
+            exc_info=True,
+        )
 
     # Seed the default "pocketpaw" agent so the new workspace has a DM target
     # immediately. Idempotent; non-fatal — the boot-time back-fill is the

--- a/tests/cloud/auth/test_service_v2.py
+++ b/tests/cloud/auth/test_service_v2.py
@@ -2,6 +2,12 @@
 
 Uses the shared ``mongo_db`` fixture so service functions exercise real
 Beanie reads/writes against an isolated mongomock-motor DB.
+
+Updated 2026-08-05 (T-2, feat/coupling-person-freshness): added coverage
+for ``get_profile_by_id`` (the plain-user_id profile read the people
+module's Person refresh paths use). ``update_profile``'s new
+``profile.updated`` emit is covered in
+tests/cloud/people/test_person_freshness.py next to its consumer.
 """
 
 from __future__ import annotations
@@ -81,6 +87,21 @@ async def test_update_profile_partial_only_full_name() -> None:
     assert refreshed is not None
     assert refreshed.full_name == "Bob"
     assert refreshed.avatar == ""  # untouched
+
+
+async def test_get_profile_by_id_returns_profile_and_memberships() -> None:
+    doc = await _seed_user(workspace_role="admin")
+    out = await auth_service.get_profile_by_id(str(doc.id))
+    assert out.id == str(doc.id)
+    assert out.full_name == "Alice"
+    assert [(m.workspace, m.role) for m in out.workspaces] == [("w1", "admin")]
+
+
+async def test_get_profile_by_id_raises_not_found() -> None:
+    from beanie import PydanticObjectId
+
+    with pytest.raises(NotFound):
+        await auth_service.get_profile_by_id(str(PydanticObjectId()))
 
 
 async def test_set_active_workspace_persists() -> None:

--- a/tests/cloud/conftest.py
+++ b/tests/cloud/conftest.py
@@ -11,6 +11,11 @@ Also installs, session-wide and autouse, ``local_store_home``: it redirects
 unpatched local-store factory writes there instead of into the developer's real
 ``~/.pocketpaw`` (see the fixture for what made this visible).
 
+Also installs, autouse, ``_isolated_person_store`` (T-2, 2026-08-05): lazily
+redirects the people service's default Fabric journal store at a per-test tmp
+journal so workspace create / invite accept / Person refresh paths never write
+into the developer's real ``~/.soul/journal.db``.
+
 Also exposes:
 - ``mongo_db`` — Beanie initialized against a fresh mongomock-motor DB
   for the test. Used by service-level tests that exercise real Beanie
@@ -98,6 +103,46 @@ def local_store_home(tmp_path_factory):
     stores._DATA_DIR = tmp_path_factory.mktemp("pocketpaw-home")
     yield stores._DATA_DIR
     stores._DATA_DIR = original
+
+
+@pytest.fixture(autouse=True)
+def _isolated_person_store(tmp_path, monkeypatch):
+    """Keep the people service's default Fabric store off the real org journal.
+
+    Added 2026-08-05 (T-2, feat/coupling-person-freshness). ``workspace.create``
+    now materializes an owner Person (and ``accept_invite`` has materialized
+    members since pp#1366) through ``people_service._default_store``, which
+    opens the REAL org journal at ``~/.soul/journal.db`` — so any cloud test
+    that creates a workspace would write Person rows into the developer's live
+    soul data. Same hazard class ``local_store_home`` guards against.
+
+    LAZY on purpose: the tmp journal is only opened if a test actually reaches
+    an unpatched ``_default_store()`` call, so the fixture costs nothing for
+    the vast majority of tests. Tests that want to READ the store install
+    their own (e.g. ``person_store`` in the workspace/people test files),
+    which simply re-patches over this one.
+    """
+    from pocketpaw_ee.cloud.people import service as people_service
+
+    state: dict = {}
+
+    def _tmp_store():
+        if "store" not in state:
+            from soul_protocol.engine.journal import open_journal
+
+            from pocketpaw.fabric.journal_store import FabricJournalStore
+
+            journal = open_journal(tmp_path / "person_journal.db")
+            store = FabricJournalStore(journal)
+            store.bootstrap()
+            state["journal"] = journal
+            state["store"] = store
+        return state["store"]
+
+    monkeypatch.setattr(people_service, "_default_store", _tmp_store)
+    yield
+    if "journal" in state:
+        state["journal"].close()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/cloud/conftest.py
+++ b/tests/cloud/conftest.py
@@ -11,6 +11,11 @@ Also installs, session-wide and autouse, ``local_store_home``: it redirects
 unpatched local-store factory writes there instead of into the developer's real
 ``~/.pocketpaw`` (see the fixture for what made this visible).
 
+Also installs, autouse, ``_isolated_person_store`` (T-2, 2026-08-05): lazily
+redirects the people service's default Fabric journal store at a per-test tmp
+journal so workspace create / invite accept / Person refresh paths never write
+into the developer's real ``~/.soul/journal.db``.
+
 Also exposes:
 - ``mongo_db`` — Beanie initialized against a fresh mongomock-motor DB
   for the test. Used by service-level tests that exercise real Beanie
@@ -182,6 +187,46 @@ def _site_pages_are_serving(monkeypatch):
     monkeypatch.setattr(screenshot_mod, "_READY_DELAYS", ())
     monkeypatch.setattr(screenshot_mod, "_READY_DELAYS_MANUAL", ())
     yield
+
+
+@pytest.fixture(autouse=True)
+def _isolated_person_store(tmp_path, monkeypatch):
+    """Keep the people service's default Fabric store off the real org journal.
+
+    Added 2026-08-05 (T-2, feat/coupling-person-freshness). ``workspace.create``
+    now materializes an owner Person (and ``accept_invite`` has materialized
+    members since pp#1366) through ``people_service._default_store``, which
+    opens the REAL org journal at ``~/.soul/journal.db`` — so any cloud test
+    that creates a workspace would write Person rows into the developer's live
+    soul data. Same hazard class ``local_store_home`` guards against.
+
+    LAZY on purpose: the tmp journal is only opened if a test actually reaches
+    an unpatched ``_default_store()`` call, so the fixture costs nothing for
+    the vast majority of tests. Tests that want to READ the store install
+    their own (e.g. ``person_store`` in the workspace/people test files),
+    which simply re-patches over this one.
+    """
+    from pocketpaw_ee.cloud.people import service as people_service
+
+    state: dict = {}
+
+    def _tmp_store():
+        if "store" not in state:
+            from soul_protocol.engine.journal import open_journal
+
+            from pocketpaw.fabric.journal_store import FabricJournalStore
+
+            journal = open_journal(tmp_path / "person_journal.db")
+            store = FabricJournalStore(journal)
+            store.bootstrap()
+            state["journal"] = journal
+            state["store"] = store
+        return state["store"]
+
+    monkeypatch.setattr(people_service, "_default_store", _tmp_store)
+    yield
+    if "journal" in state:
+        state["journal"].close()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/cloud/people/test_person_freshness.py
+++ b/tests/cloud/people/test_person_freshness.py
@@ -1,0 +1,457 @@
+# tests/cloud/people/test_person_freshness.py — Fabric Person freshness (T-2).
+# Created: 2026-08-05 (feat/coupling-person-freshness).
+#
+# Locks the contract that the Person is a LIVE projection, not a one-time
+# invite snapshot:
+#   1. Role change: ``update_member_role`` emits ``workspace.member_role``;
+#      the people listener re-materializes → ``get_person`` returns the NEW
+#      role. Works both when a Person already exists (fields preserved) and
+#      when the member never had one (materialized fresh from profile).
+#   2. Profile edit: ``update_profile`` emits ``profile.updated``; the
+#      listener refreshes name/avatar in EVERY workspace the user belongs
+#      to. A status-only change does not touch the Person.
+#   3. Owner: ``workspace.create`` materializes a Person (role=owner,
+#      source=membership) for the creator.
+#   4. Lazy backfill: ``get_person`` miss for a user who IS a live member
+#      materializes on first read; a non-member stays ``None``;
+#      ``materialize_missing=False`` disables the backfill.
+#
+# Spy-don't-mock: the real workspace/auth/people services run against
+# mongomock Beanie, events flow over a real InProcessBus with the real
+# listeners registered, and the Fabric store is a throwaway journal-backed
+# store injected via the people service's ``_default_store`` seam (same
+# shape as tests/cloud/workspace/test_service_v2.py's person_store).
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+import pytest_asyncio
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud._core.realtime import bus as bus_mod
+from pocketpaw_ee.cloud._core.realtime.audience import AudienceResolver
+from pocketpaw_ee.cloud._core.realtime.bus import InProcessBus
+from pocketpaw_ee.cloud.auth import service as auth_service
+from pocketpaw_ee.cloud.models.user import User as _UserDoc
+from pocketpaw_ee.cloud.models.user import WorkspaceMembership as _Membership
+from pocketpaw_ee.cloud.people import service as people_service
+from pocketpaw_ee.cloud.people.domain import SOURCE_ADMIN_CONTEXT, SOURCE_MEMBERSHIP
+from pocketpaw_ee.cloud.people.listeners import register_people_listeners
+from pocketpaw_ee.cloud.workspace import service as workspace_service
+from pocketpaw_ee.cloud.workspace.domain import Invite, InviteContext
+from pocketpaw_ee.cloud.workspace.dto import CreateWorkspaceRequest
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+class _StubConnManager:
+    async def send_to_user(self, user_id, payload) -> None:  # noqa: ARG002
+        return None
+
+
+class _StubResolver(AudienceResolver):
+    """No WebSocket recipients — only the in-process subscribers matter here."""
+
+    def __init__(self) -> None:
+        async def _empty(_):
+            return []
+
+        super().__init__(
+            group_members=_empty,
+            workspace_members=_empty,
+            workspace_admins=_empty,
+            workspace_peers=_empty,
+        )
+
+    async def audience(self, event):  # type: ignore[override]
+        return []
+
+
+@pytest.fixture
+def person_store(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    """Throwaway journal-backed Fabric store injected as the people default.
+
+    Patching ``_default_store`` covers every internal ``store=None`` call —
+    the listeners, the workspace create/accept paths, and the lazy
+    backfill — so nothing touches the real org journal at ~/.soul/.
+    """
+    from soul_protocol.engine.journal import open_journal
+
+    from pocketpaw.fabric.journal_store import FabricJournalStore
+
+    journal = open_journal(tmp_path / "people_journal.db")
+    store = FabricJournalStore(journal)
+    store.bootstrap()
+    monkeypatch.setattr(people_service, "_default_store", lambda: store)
+    yield store
+    journal.close()
+
+
+@pytest_asyncio.fixture
+async def real_bus():
+    """Install a real InProcessBus with the people listeners registered.
+
+    Overrides the autouse RecordingBus from the cloud conftest so emits
+    from the workspace/auth services actually dispatch to the subscribers.
+    """
+    prev = bus_mod._bus  # type: ignore[attr-defined]
+    bus = InProcessBus(resolver=_StubResolver(), conn_manager=_StubConnManager())
+    bus_mod._bus = bus  # type: ignore[attr-defined]
+    register_people_listeners()
+    try:
+        yield bus
+    finally:
+        bus_mod._bus = prev  # type: ignore[attr-defined]
+
+
+@pytest.fixture(autouse=True)
+def resolver_mock(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Stub the workspace service's cache resolver (needs init_realtime)."""
+    mock = MagicMock()
+    monkeypatch.setattr("pocketpaw_ee.cloud.workspace.service.get_resolver", lambda: mock)
+    return mock
+
+
+def _ctx(user_id: str, workspace_id: str | None = None) -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="r",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+async def _seed_user(
+    *,
+    email: str = "u@x.c",
+    full_name: str = "U",
+    avatar: str = "",
+    memberships: list[tuple[str, str]] | None = None,
+) -> _UserDoc:
+    doc = _UserDoc(
+        email=email,
+        hashed_password="x",
+        is_active=True,
+        is_verified=True,
+        full_name=full_name,
+        avatar=avatar,
+        workspaces=[
+            _Membership(workspace=w, role=r, joined_at=datetime.now(UTC))
+            for (w, r) in (memberships or [])
+        ],
+    )
+    await doc.insert()
+    return doc
+
+
+def _invite(*, workspace_id: str, email: str, role: str = "member") -> Invite:
+    return Invite(
+        id="inv1",
+        workspace_id=workspace_id,
+        email=email,
+        role=role,
+        invited_by="admin1",
+        token=None,
+        group_id="team-eng",
+        accepted=True,
+        revoked=False,
+        expired=False,
+        expires_at=datetime.now(UTC),
+        context=InviteContext(focus="Own billing", profile_pic="pic-1"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Role change → get_person shows the new role
+# ---------------------------------------------------------------------------
+
+
+class TestRoleChangeRefresh:
+    @pytest.mark.asyncio
+    async def test_promote_member_refreshes_person_role(self, person_store, real_bus) -> None:
+        """The acceptance case: promote a member → get_person returns admin."""
+        owner = await _seed_user(email="owner@x.c", full_name="Owner")
+        ws = await workspace_service.create(
+            _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+        )
+        member = await _seed_user(email="m@x.c", full_name="Mem", memberships=[(ws.id, "member")])
+        # Materialize the invite-time snapshot the old one-shot path left.
+        await people_service.materialize_person_from_invite(
+            workspace_id=ws.id,
+            user_id=str(member.id),
+            name="Mem",
+            email="m@x.c",
+            avatar="av-1",
+            invite=_invite(workspace_id=ws.id, email="m@x.c", role="member"),
+            store=person_store,
+        )
+        before = await people_service.get_person(ws.id, str(member.id), store=person_store)
+        assert before is not None and before.role == "member"
+
+        await workspace_service.update_member_role(ws.id, str(member.id), "admin", str(owner.id))
+
+        after = await people_service.get_person(ws.id, str(member.id), store=person_store)
+        assert after is not None
+        assert after.role == "admin"
+        # Identity + onboarding fields survive the refresh.
+        assert after.name == "Mem"
+        assert after.focus == "Own billing"
+        assert after.invited_by == "admin1"
+        assert after.source == SOURCE_ADMIN_CONTEXT
+
+    @pytest.mark.asyncio
+    async def test_role_change_materializes_missing_person(self, person_store, real_bus) -> None:
+        """A member with NO Person (pre-freshness data) gets one on role change."""
+        owner = await _seed_user(email="owner@x.c", full_name="Owner")
+        ws = await workspace_service.create(
+            _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+        )
+        member = await _seed_user(
+            email="m@x.c",
+            full_name="Mem",
+            avatar="av-9",
+            memberships=[(ws.id, "member")],
+        )
+
+        await workspace_service.update_member_role(ws.id, str(member.id), "admin", str(owner.id))
+
+        person = await people_service.get_person(
+            ws.id, str(member.id), store=person_store, materialize_missing=False
+        )
+        assert person is not None
+        assert person.role == "admin"
+        assert person.name == "Mem"
+        assert person.avatar == "av-9"
+        assert person.source == SOURCE_MEMBERSHIP
+        assert person.invited_by == ""
+
+
+# ---------------------------------------------------------------------------
+# 2. Profile edit → name/avatar refresh in all memberships
+# ---------------------------------------------------------------------------
+
+
+class TestProfileEditRefresh:
+    @pytest.mark.asyncio
+    async def test_profile_edit_refreshes_every_workspace(self, person_store, real_bus) -> None:
+        user = await _seed_user(
+            email="m@x.c",
+            full_name="Old Name",
+            avatar="old-av",
+            memberships=[("wsA", "member"), ("wsB", "admin")],
+        )
+        uid = str(user.id)
+        for ws_id, role in (("wsA", "member"), ("wsB", "admin")):
+            await people_service.materialize_person_from_membership(
+                workspace_id=ws_id,
+                user_id=uid,
+                name="Old Name",
+                email="m@x.c",
+                avatar="old-av",
+                role=role,
+                store=person_store,
+            )
+
+        await auth_service.update_profile(_ctx(uid), full_name="New Name", avatar="new-av")
+
+        for ws_id, role in (("wsA", "member"), ("wsB", "admin")):
+            person = await people_service.get_person(
+                ws_id, uid, store=person_store, materialize_missing=False
+            )
+            assert person is not None, ws_id
+            assert person.name == "New Name"
+            assert person.avatar == "new-av"
+            # Role is untouched by a profile refresh.
+            assert person.role == role
+
+    @pytest.mark.asyncio
+    async def test_profile_edit_backfills_missing_person(self, person_store, real_bus) -> None:
+        """A membership with no Person yet is materialized by the refresh."""
+        user = await _seed_user(email="m@x.c", full_name="Name", memberships=[("wsA", "member")])
+        uid = str(user.id)
+
+        await auth_service.update_profile(_ctx(uid), full_name="Renamed")
+
+        person = await people_service.get_person(
+            "wsA", uid, store=person_store, materialize_missing=False
+        )
+        assert person is not None
+        assert person.name == "Renamed"
+        assert person.role == "member"
+        assert person.source == SOURCE_MEMBERSHIP
+
+    @pytest.mark.asyncio
+    async def test_status_only_change_does_not_touch_person(self, person_store, real_bus) -> None:
+        user = await _seed_user(email="m@x.c", full_name="Name", memberships=[("wsA", "member")])
+        uid = str(user.id)
+
+        await auth_service.update_profile(_ctx(uid), status="away")
+
+        person = await people_service.get_person(
+            "wsA", uid, store=person_store, materialize_missing=False
+        )
+        assert person is None  # listener skipped — no identity field changed
+
+    @pytest.mark.asyncio
+    async def test_update_profile_emits_changed_fields(self, recording_bus) -> None:
+        """The emit contract the listener keys off: field names, no values."""
+        from pocketpaw_ee.cloud._core.realtime.events import ProfileUpdated
+
+        user = await _seed_user(email="m@x.c", full_name="Name")
+        uid = str(user.id)
+
+        await auth_service.update_profile(_ctx(uid), full_name="Other", status="dnd")
+
+        profile_events = [e for e in recording_bus.events if isinstance(e, ProfileUpdated)]
+        assert len(profile_events) == 1
+        assert profile_events[0].data == {
+            "user_id": uid,
+            "changed": ["full_name", "status"],
+        }
+
+    @pytest.mark.asyncio
+    async def test_noop_update_emits_nothing(self, recording_bus) -> None:
+        from pocketpaw_ee.cloud._core.realtime.events import ProfileUpdated
+
+        user = await _seed_user(email="m@x.c", full_name="Name")
+        await auth_service.update_profile(_ctx(str(user.id)), full_name="Name")
+
+        assert not any(isinstance(e, ProfileUpdated) for e in recording_bus.events)
+
+
+# ---------------------------------------------------------------------------
+# 3. Workspace create → owner has a Person
+# ---------------------------------------------------------------------------
+
+
+class TestOwnerPerson:
+    @pytest.mark.asyncio
+    async def test_create_materializes_owner_person(self, person_store) -> None:
+        owner = await _seed_user(email="owner@x.c", full_name="Founder", avatar="f-av")
+        ws = await workspace_service.create(
+            _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+        )
+
+        person = await people_service.get_person(
+            ws.id, str(owner.id), store=person_store, materialize_missing=False
+        )
+        assert person is not None
+        assert person.role == "owner"
+        assert person.name == "Founder"
+        assert person.email == "owner@x.c"
+        assert person.avatar == "f-av"
+        assert person.source == SOURCE_MEMBERSHIP
+        assert person.invited_by == ""
+
+    @pytest.mark.asyncio
+    async def test_create_survives_person_store_failure(self, person_store, monkeypatch) -> None:
+        """A Fabric hiccup must never fail workspace creation."""
+
+        async def _boom(**_kwargs):
+            raise RuntimeError("journal down")
+
+        monkeypatch.setattr(
+            "pocketpaw_ee.cloud.workspace.service.people_service."
+            "materialize_person_from_membership",
+            _boom,
+        )
+        owner = await _seed_user(email="owner@x.c", full_name="Founder")
+        ws = await workspace_service.create(
+            _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+        )
+        assert ws.id  # created fine
+
+
+# ---------------------------------------------------------------------------
+# 4. Lazy backfill on get_person miss
+# ---------------------------------------------------------------------------
+
+
+class TestLazyBackfill:
+    @pytest.mark.asyncio
+    async def test_miss_for_live_member_materializes(self, person_store) -> None:
+        """Pre-existing owner/member with no Person converges on first read."""
+        user = await _seed_user(
+            email="m@x.c",
+            full_name="Legacy Owner",
+            avatar="lo-av",
+            memberships=[("wsA", "owner")],
+        )
+        uid = str(user.id)
+
+        person = await people_service.get_person("wsA", uid, store=person_store)
+        assert person is not None
+        assert person.role == "owner"
+        assert person.name == "Legacy Owner"
+        assert person.source == SOURCE_MEMBERSHIP
+
+        # And it PERSISTED — a second read with the backfill disabled hits it.
+        again = await people_service.get_person(
+            "wsA", uid, store=person_store, materialize_missing=False
+        )
+        assert again is not None
+        assert again.id == person.id
+
+    @pytest.mark.asyncio
+    async def test_miss_for_non_member_stays_none(self, person_store) -> None:
+        user = await _seed_user(email="m@x.c", memberships=[("wsA", "member")])
+        person = await people_service.get_person("other-ws", str(user.id), store=person_store)
+        assert person is None
+
+    @pytest.mark.asyncio
+    async def test_materialize_missing_false_disables_backfill(self, person_store) -> None:
+        user = await _seed_user(email="m@x.c", memberships=[("wsA", "member")])
+        person = await people_service.get_person(
+            "wsA", str(user.id), store=person_store, materialize_missing=False
+        )
+        assert person is None
+
+
+# ---------------------------------------------------------------------------
+# Listener payload guards (defensive skips, no explosion)
+# ---------------------------------------------------------------------------
+
+
+class TestListenerGuards:
+    @pytest.mark.asyncio
+    async def test_role_listener_skips_malformed_payload(self, person_store) -> None:
+        from pocketpaw_ee.cloud._core.realtime.events import WorkspaceMemberRole
+        from pocketpaw_ee.cloud.people.listeners import refresh_person_on_role_change
+
+        # Missing user_id — handler returns without touching the store.
+        await refresh_person_on_role_change(
+            WorkspaceMemberRole(data={"workspace_id": "wsA", "role": "admin"})
+        )
+
+    @pytest.mark.asyncio
+    async def test_profile_listener_skips_non_identity_change(self, person_store) -> None:
+        from pocketpaw_ee.cloud._core.realtime.events import ProfileUpdated
+        from pocketpaw_ee.cloud.people.listeners import (
+            refresh_person_on_profile_update,
+        )
+
+        await refresh_person_on_profile_update(
+            ProfileUpdated(data={"user_id": "u1", "changed": ["status"]})
+        )
+
+    @pytest.mark.asyncio
+    async def test_role_listener_swallows_service_failure(self, person_store, monkeypatch) -> None:
+        from pocketpaw_ee.cloud._core.realtime.events import WorkspaceMemberRole
+        from pocketpaw_ee.cloud.people.listeners import refresh_person_on_role_change
+
+        async def _boom(*_a, **_k):
+            raise RuntimeError("journal down")
+
+        monkeypatch.setattr(people_service, "refresh_person_role", _boom)
+        # Must not raise — one broken refresh can't take down the bus chain.
+        await refresh_person_on_role_change(
+            WorkspaceMemberRole(data={"workspace_id": "wsA", "user_id": "u1", "role": "admin"})
+        )

--- a/tests/cloud/workspace/test_service_v2.py
+++ b/tests/cloud/workspace/test_service_v2.py
@@ -7,6 +7,13 @@ Asserts on:
 - Event emission via recording_bus + monkey-patched event_bus
 - Cache invalidation via get_resolver().invalidate_workspace
 - Cross-module side effects (Notification creation on invite-to-existing-user)
+
+Updated 2026-08-05 (T-2, feat/coupling-person-freshness): ``create()`` now
+materializes the OWNER's Fabric Person too, so the accept-invite person
+tests expect two rows (owner + invitee) and select the invitee's row by its
+deterministic id; added ``test_create_materializes_owner_person``. The
+freshness paths themselves (role change / profile edit / lazy backfill) are
+covered in tests/cloud/people/test_person_freshness.py.
 """
 
 from __future__ import annotations
@@ -150,6 +157,26 @@ async def test_create_emits_member_added_and_invalidates_cache(
     assert ws.member_count == 1
     assert any(isinstance(e, WorkspaceMemberAdded) for e in recording_bus.events)
     resolver_mock.invalidate_workspace.assert_called_once_with(ws.id)
+
+
+async def test_create_materializes_owner_person(owner, person_store) -> None:
+    """T-2: the creator gets a Fabric Person (role=owner, source=membership)
+    at workspace-create — the owner is never invited, so without this the
+    guaranteed first member of every workspace had no identity spine."""
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="Acme", slug="acme")
+    )
+
+    people = await _materialized_people(person_store)
+    assert len(people) == 1
+    obj = people[0]
+    assert obj.id == f"person-{ws.id}-{owner.id}"
+    props = obj.properties
+    assert props["role"] == "owner"
+    assert props["name"] == "Owner"
+    assert props["email"] == "owner@x.c"
+    assert props["source"] == "membership"
+    assert props["invited_by"] == ""
 
 
 async def test_create_rejects_duplicate_slug(owner) -> None:
@@ -1051,9 +1078,9 @@ async def test_accept_invite_materializes_person(
     await workspace_service.accept_invite(_ctx(str(invitee.id)), invite.token)
 
     people = await _materialized_people(person_store)
-    assert len(people) == 1
-    obj = people[0]
-    assert obj.id == f"person-{ws.id}-{invitee.id}"
+    # Two rows since T-2: the owner (materialized at create) + the invitee.
+    assert len(people) == 2
+    obj = next(p for p in people if p.id == f"person-{ws.id}-{invitee.id}")
     props = obj.properties
     # Identity — from the member's own profile.
     assert props["name"] == "New Hire"
@@ -1088,8 +1115,10 @@ async def test_accept_invite_no_context_still_materializes_person(
     await workspace_service.accept_invite(_ctx(str(invitee.id)), invite.token)
 
     people = await _materialized_people(person_store)
-    assert len(people) == 1
-    props = people[0].properties
+    # Two rows since T-2: the owner (materialized at create) + the invitee.
+    assert len(people) == 2
+    obj = next(p for p in people if p.id == f"person-{ws.id}-{invitee.id}")
+    props = obj.properties
     assert props["name"] == "Plain Hire"
     assert props["focus"] == ""
     assert props["profile_pic"] == ""
@@ -1150,8 +1179,11 @@ async def test_accept_invite_person_is_idempotent_no_duplicate(
     )
 
     people = await _materialized_people(person_store)
-    assert len(people) == 1  # still one — not duplicated.
-    assert people[0].properties["focus"] == "Second focus"
+    # Still exactly ONE row for the invitee — not duplicated. (The owner's
+    # create-time Person is the second row in the store since T-2.)
+    invitee_rows = [p for p in people if p.id == f"person-{ws.id}-{invitee.id}"]
+    assert len(invitee_rows) == 1
+    assert invitee_rows[0].properties["focus"] == "Second focus"
 
 
 async def test_accept_invite_survives_person_materialization_failure(

--- a/tests/cloud/workspace/test_service_v2.py
+++ b/tests/cloud/workspace/test_service_v2.py
@@ -7,6 +7,13 @@ Asserts on:
 - Event emission via recording_bus + monkey-patched event_bus
 - Cache invalidation via get_resolver().invalidate_workspace
 - Cross-module side effects (Notification creation on invite-to-existing-user)
+
+Updated 2026-08-05 (T-2, feat/coupling-person-freshness): ``create()`` now
+materializes the OWNER's Fabric Person too, so the accept-invite person
+tests expect two rows (owner + invitee) and select the invitee's row by its
+deterministic id; added ``test_create_materializes_owner_person``. The
+freshness paths themselves (role change / profile edit / lazy backfill) are
+covered in tests/cloud/people/test_person_freshness.py.
 """
 
 from __future__ import annotations
@@ -177,6 +184,26 @@ async def test_create_emits_member_added_and_invalidates_cache(
     assert ws.member_count == 1
     assert any(isinstance(e, WorkspaceMemberAdded) for e in recording_bus.events)
     resolver_mock.invalidate_workspace.assert_called_once_with(ws.id)
+
+
+async def test_create_materializes_owner_person(owner, person_store) -> None:
+    """T-2: the creator gets a Fabric Person (role=owner, source=membership)
+    at workspace-create — the owner is never invited, so without this the
+    guaranteed first member of every workspace had no identity spine."""
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="Acme", slug="acme")
+    )
+
+    people = await _materialized_people(person_store)
+    assert len(people) == 1
+    obj = people[0]
+    assert obj.id == f"person-{ws.id}-{owner.id}"
+    props = obj.properties
+    assert props["role"] == "owner"
+    assert props["name"] == "Owner"
+    assert props["email"] == "owner@x.c"
+    assert props["source"] == "membership"
+    assert props["invited_by"] == ""
 
 
 async def test_create_rejects_duplicate_slug(owner) -> None:
@@ -1094,9 +1121,9 @@ async def test_accept_invite_materializes_person(
     await workspace_service.accept_invite(_ctx(str(invitee.id)), invite.token)
 
     people = await _materialized_people(person_store)
-    assert len(people) == 1
-    obj = people[0]
-    assert obj.id == f"person-{ws.id}-{invitee.id}"
+    # Two rows since T-2: the owner (materialized at create) + the invitee.
+    assert len(people) == 2
+    obj = next(p for p in people if p.id == f"person-{ws.id}-{invitee.id}")
     props = obj.properties
     # Identity — from the member's own profile.
     assert props["name"] == "New Hire"
@@ -1131,8 +1158,10 @@ async def test_accept_invite_no_context_still_materializes_person(
     await workspace_service.accept_invite(_ctx(str(invitee.id)), invite.token)
 
     people = await _materialized_people(person_store)
-    assert len(people) == 1
-    props = people[0].properties
+    # Two rows since T-2: the owner (materialized at create) + the invitee.
+    assert len(people) == 2
+    obj = next(p for p in people if p.id == f"person-{ws.id}-{invitee.id}")
+    props = obj.properties
     assert props["name"] == "Plain Hire"
     assert props["focus"] == ""
     assert props["profile_pic"] == ""
@@ -1193,8 +1222,11 @@ async def test_accept_invite_person_is_idempotent_no_duplicate(
     )
 
     people = await _materialized_people(person_store)
-    assert len(people) == 1  # still one — not duplicated.
-    assert people[0].properties["focus"] == "Second focus"
+    # Still exactly ONE row for the invitee — not duplicated. (The owner's
+    # create-time Person is the second row in the store since T-2.)
+    invitee_rows = [p for p in people if p.id == f"person-{ws.id}-{invitee.id}"]
+    assert len(invitee_rows) == 1
+    assert invitee_rows[0].properties["focus"] == "Second focus"
 
 
 async def test_accept_invite_survives_person_materialization_failure(


### PR DESCRIPTION
The Fabric Person is what chat agents read to answer "who am I talking to" (agent_service renders an about-this-member block from it), but it was written exactly once, at invite-accept. Promote someone to admin and every agent kept orienting on their old role forever. Change your display name or avatar and the same thing. The workspace owner never had a Person at all, because owners do not go through accept_invite.

Person is now a live projection instead of a snapshot:

- New listeners in people/listeners.py, registered in mount_cloud, re-run the existing idempotent upsert when a member's role changes or a profile is edited. Auth's update_profile previously wrote name and avatar without emitting anything, so it now emits profile.updated carrying the changed field names, and the listener fans out across every workspace the user belongs to.
- The workspace creator gets a Person at create time, role owner. Workspace creation still succeeds if the journal write fails, which a test covers.
- For members who predate all this, get_person backfills lazily on a miss when the user really is a live member. A startup sweep would have been the alternative, but there is no house pattern for backfills and the read path is the only consumer, so lazy keeps it simple. Non-members still return None.

Tests: 555 passed across people, workspace and auth. Two failures in test_service_v2 delete-preview are pre-existing (verified by running them on a clean origin/dev checkout, same two fail).

One thing worth flagging in review: tests/cloud/conftest.py gains an autouse fixture that isolates the Person store. Without it, every workspace-creating test would write Person rows into the developer's real journal database, because create() now materializes through the default store. That hazard has existed latently since accept_invite started materializing; this change would have made it fire constantly.

Follow-up needed in paw-enterprise: the new profile.updated topic means topics.gen.ts has to be regenerated in a checkout that has both repos side by side. Tracked separately.