### PR TITLE
feat(instinct): template approvals join the governance record

### DIFF
--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -921,6 +921,19 @@ def mount_cloud(app: FastAPI) -> None:
     register_meeting_notification_listeners()
     register_meeting_calendar_listeners()
 
+    # Instinct-approval bridge (T-5) — instinct.approval.created → a PERSISTED
+    # in-app notification for the workspace owner + admins, so a decision that
+    # authorises a whole class of future writes reaches an owner who was
+    # offline when it was requested. Distinct from the push listener below,
+    # which notifies the REQUESTER over web-push/WS and persists nothing.
+    # Pinned by tests/cloud/test_instinct_approvals_governance.py — deleting
+    # this call fails that test rather than silently unwiring the bridge.
+    from pocketpaw_ee.cloud.instinct_approvals.bridges.notifications import (
+        register_instinct_approval_notification_listeners,
+    )
+
+    register_instinct_approval_notification_listeners()
+
     # Push notifications fan-out (#1393) — v1 product events
     # (agent.stream_end / instinct.approval.created / meeting.started) →
     # ``dispatch.notify``, which forks WS-vs-Web-Push so a user with both the

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -1153,6 +1153,19 @@ def mount_cloud(app: FastAPI) -> None:
 
     register_alert_notification_listeners()
 
+    # Instinct-approval bridge (T-5) — instinct.approval.created → a PERSISTED
+    # in-app notification for the workspace owner + admins, so a decision that
+    # authorises a whole class of future writes reaches an owner who was
+    # offline when it was requested. Distinct from the push listener below,
+    # which notifies the REQUESTER over web-push/WS and persists nothing.
+    # Pinned by tests/cloud/test_instinct_approvals_governance.py — deleting
+    # this call fails that test rather than silently unwiring the bridge.
+    from pocketpaw_ee.cloud.instinct_approvals.bridges.notifications import (
+        register_instinct_approval_notification_listeners,
+    )
+
+    register_instinct_approval_notification_listeners()
+
     # Push notifications fan-out (#1393) — ``notification.new`` (every
     # persisted notification, so the OS surface can't drift from the bell)
     # plus ``agent.stream_end`` (the one product event that persists no

--- a/ee/pocketpaw_ee/cloud/instinct_approvals/bridges/__init__.py
+++ b/ee/pocketpaw_ee/cloud/instinct_approvals/bridges/__init__.py
@@ -1,0 +1,8 @@
+# ee/pocketpaw_ee/cloud/instinct_approvals/bridges/__init__.py
+# Created: 2026-08-06 (feat/coupling-template-approvals, T-5) — package marker
+# for the instinct-approval event bridges. Mirrors ``meetings/bridges/``: a
+# bridge translates an ``instinct_approvals`` domain event into another
+# domain's write (today: a persisted notification) without either domain
+# importing the other.
+
+"""Event bridges for ``instinct_approvals``."""

--- a/ee/pocketpaw_ee/cloud/instinct_approvals/bridges/notifications.py
+++ b/ee/pocketpaw_ee/cloud/instinct_approvals/bridges/notifications.py
@@ -1,0 +1,144 @@
+# ee/pocketpaw_ee/cloud/instinct_approvals/bridges/notifications.py —
+# template-level approval requested → in-app notification fan-out.
+#
+# Created 2026-08-06 (feat/coupling-template-approvals, T-5), built to the shape
+# of ``meetings/bridges/notifications.py``. Subscribes to
+# ``instinct.approval.created`` on ``shared.events.event_bus`` and turns each
+# one into a PERSISTED notification via ``notifications_service.create``.
+#
+# Why it exists: creating a template-level approval already emitted a realtime
+# event, but that is a websocket fan-out — it reaches whoever happens to have a
+# socket open and nobody else. The decision it is asking for authorises a whole
+# CLASS of future writes, so an owner who was offline at that moment learned
+# nothing and the write sat parked indefinitely. A notification row survives the
+# owner being away.
+#
+# Recipients are the workspace's owner + admins via the existing
+# ``workspace_service.list_admin_ids`` (the resolver the uploads router and the
+# realtime AudienceResolver already use) — no new recipient scheme. It is the
+# tenancy boundary too: the query filters memberships by workspace, so an
+# approval raised in workspace A can never notify anyone in workspace B.
+#
+# The notification ``source`` is ``{type: "instinct_action", id: <approval id>,
+# pocket_id: <pocket>}``. ``type`` is the ENTITY kind, not the notification
+# kind — the frontend's navigation resolver switches on it — while the
+# notification ``kind`` stays ``approval_pending``.
+#
+# Nothing here may break the approval flow: the recipient lookup and each
+# ``create`` are individually wrapped, and ``event_bus.emit`` guards handlers on
+# top of that. Worst case an approval lands with no notification, which is the
+# behaviour that existed before this bridge.
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pocketpaw_ee.cloud.instinct_approvals.service import CREATED_TOPIC
+from pocketpaw_ee.cloud.notifications.domain import NotificationSource
+from pocketpaw_ee.cloud.shared.events import event_bus
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Handler
+# ---------------------------------------------------------------------------
+
+
+async def _on_instinct_approval_created(data: dict[str, Any]) -> None:
+    """``instinct.approval.created`` → one notification per workspace owner/admin.
+
+    A payload missing the workspace or the approval id is malformed — without
+    the workspace there is no tenant to scope the recipient lookup to, and
+    without the id the notification points at nothing — so it no-ops rather
+    than minting a dead notification or, worse, a workspace-less one.
+    """
+    workspace_id = data.get("workspace_id")
+    approval_id = data.get("id")
+    if not (workspace_id and approval_id):
+        logger.warning(
+            "instinct.approval.created ignored — incomplete payload keys=%s", sorted(data)
+        )
+        return
+
+    recipients = await _workspace_admin_ids(str(workspace_id))
+    if not recipients:
+        return
+
+    action_name = data.get("action_name") or "an action"
+    pocket_id = data.get("pocket_id") or None
+    row_id = data.get("row_id") or ""
+    target = f"row {row_id}" if row_id else "a set of rows"
+    body = f"{action_name} on {target} needs approval before it can run."
+
+    for recipient in recipients:
+        await _create(
+            workspace_id=str(workspace_id),
+            recipient=recipient,
+            approval_id=str(approval_id),
+            pocket_id=str(pocket_id) if pocket_id else None,
+            body=body,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _workspace_admin_ids(workspace_id: str) -> list[str]:
+    """Owner + admin user ids for a workspace. Returns [] on any error — a
+    lookup failure must not break the approval that triggered it."""
+    try:
+        from pocketpaw_ee.cloud.workspace import service as workspace_service
+
+        return await workspace_service.list_admin_ids(workspace_id)
+    except Exception:
+        logger.exception("Failed to list admins for workspace=%s", workspace_id)
+        return []
+
+
+async def _create(
+    *,
+    workspace_id: str,
+    recipient: str,
+    approval_id: str,
+    pocket_id: str | None,
+    body: str,
+) -> None:
+    """Wrap notifications_service.create — late import to avoid circular deps
+    and tolerate the service being unavailable in unit-test contexts.
+
+    Per-recipient, deliberately: one recipient's delivery blowing up must not
+    cost the other admins their notification.
+    """
+    try:
+        from pocketpaw_ee.cloud.notifications import service as notifications_service
+
+        await notifications_service.create(
+            workspace_id=workspace_id,
+            recipient=recipient,
+            kind="approval_pending",
+            title="Approval needed",
+            body=body,
+            source=NotificationSource(type="instinct_action", id=approval_id, pocket_id=pocket_id),
+        )
+    except Exception:
+        logger.exception(
+            "Failed to create approval_pending notification for approval=%s", approval_id
+        )
+
+
+# ---------------------------------------------------------------------------
+# Registration — called from mount_cloud() after init_realtime.
+# ---------------------------------------------------------------------------
+
+
+def register_instinct_approval_notification_listeners() -> None:
+    """Wire the ``instinct.approval.created`` → notification subscriber."""
+    event_bus.subscribe(CREATED_TOPIC, _on_instinct_approval_created)
+    logger.info("registered %s → notifications subscriber", CREATED_TOPIC)
+
+
+__all__ = ["register_instinct_approval_notification_listeners"]

--- a/ee/pocketpaw_ee/cloud/instinct_approvals/domain.py
+++ b/ee/pocketpaw_ee/cloud/instinct_approvals/domain.py
@@ -4,6 +4,12 @@
 # frozen dataclass with REQUIRED tenancy fields (workspace_id has no
 # default) — constructing an ``InstinctApproval`` domain object without
 # tenancy is a type error. EE rule 3.
+# Updated: 2026-08-06 (feat/coupling-template-approvals, T-5) — added
+# ``correlation_id``, the Decision-Graph chain id minted on the row at
+# create time. Without it a template-level approval — the human decision
+# that authorises a whole CLASS of future writes — was invisible to
+# /decisions and /activity, because every governance surface joins on the
+# chain id and this object carried none.
 
 """Domain value object for ``instinct_approvals``."""
 
@@ -39,6 +45,7 @@ class InstinctApproval:
     status: str
     decided_at: datetime | None = None
     decided_by: str | None = None
+    correlation_id: str = ""
     park: dict[str, Any] | None = None
     created_at: datetime | None = None
     notify_rules: list[dict[str, Any]] = field(default_factory=list)

--- a/ee/pocketpaw_ee/cloud/instinct_approvals/dto.py
+++ b/ee/pocketpaw_ee/cloud/instinct_approvals/dto.py
@@ -3,6 +3,12 @@
 # DTOs for the RFC 03 v2 template-level approval queue. Distinct
 # request and response classes per EE cloud rule 4 — never reuse one
 # model for input and output.
+# Updated: 2026-08-06 (feat/coupling-template-approvals, T-5) —
+# ``ApprovalResponse`` now carries ``correlation_id``, the Decision-Graph
+# chain id minted on the row at create time. It rides the wire (and
+# therefore the realtime event payload) so the approvals UI can deep-link a
+# decided approval to its /decisions chain without a second lookup, and so
+# the notification bridge can read it straight off the bus payload.
 
 """Wire-format DTOs for the ``instinct_approvals`` entity."""
 
@@ -90,6 +96,7 @@ class ApprovalResponse(BaseModel):
     decided_at: str | None
     decided_by: str | None
     created_at: str | None
+    correlation_id: str = ""
 
 
 def approval_to_dto(a: InstinctApproval) -> ApprovalResponse:
@@ -116,6 +123,7 @@ def approval_to_dto(a: InstinctApproval) -> ApprovalResponse:
         decided_at=iso_utc(a.decided_at) if a.decided_at else None,
         decided_by=a.decided_by,
         created_at=iso_utc(a.created_at) if a.created_at else None,
+        correlation_id=a.correlation_id,
     )
 
 

--- a/ee/pocketpaw_ee/cloud/instinct_approvals/service.py
+++ b/ee/pocketpaw_ee/cloud/instinct_approvals/service.py
@@ -4,6 +4,42 @@
 # level ``async def`` API per EE cloud rule 5. Every state-mutating
 # function:
 #
+# Updated: 2026-08-06 (feat/coupling-template-approvals, T-5) — a
+# template-level approval is now VISIBLE IN THE GOVERNANCE RECORD. It is the
+# highest-leverage governance act in the product (a human authorising a whole
+# CLASS of future writes) and until now it left no trace anywhere: the row
+# carried no chain id, ``_decide`` only saved the doc and emitted an ephemeral
+# realtime event, and an owner who was offline when the approval was requested
+# was never told. Three additions, all modelled on the row-level path in
+# ``ee/pocketpaw_ee/instinct/router.py`` + ``instinct/chain_emitters.py``:
+#
+#   1. CREATE mints a ``correlation_id`` onto the row and OPENS the
+#      Decision-Graph chain with ``agent.proposed``. The mint alone is not
+#      enough: ``decisions.projection`` only materialises a Decision row on a
+#      TERMINAL event, and ``_close_chain`` DROPS any chain that never saw
+#      ``agent.proposed`` (``chain.decided_by is None`` → "closed without
+#      proposed event — skipping"). Without the open, /decisions stays empty
+#      no matter what the decide path emits.
+#   2. DECIDE closes that same chain — ``human.corrected(accepted|rejected)``
+#      then ``decision.completed`` — and writes a workspace audit row
+#      (``instinct_approval.approved`` / ``.rejected``) so the decision also
+#      lands on /activity. Same pair the row-level path fires, plus the
+#      terminal the row-level path owns on its reject side. There is no double
+#      close: the correlation is minted HERE and known only to this row (the
+#      post-approval re-entry is still unwired — see ``approve``), so no other
+#      producer can close it.
+#   3. CREATE publishes ``instinct.approval.created`` on
+#      ``shared.events.event_bus``, where ``bridges/notifications.py`` turns it
+#      into a PERSISTED notification for the workspace owner + admins. The
+#      pre-existing realtime ``emit`` is a websocket fan-out only — an offline
+#      owner saw nothing.
+#
+# Every one of those is best-effort and cannot break the approval flow: the
+# chain emits go through ``_safe_chain_emit``, the audit write through
+# ``_record_audit_safe``, and the notification fan-out through
+# ``_publish_created_safe``. The Mongo row is the source of truth; the Slice 4
+# reconciler catches up any chain event that failed to land.
+#
 # Updated: 2026-06-19 (feat/instinct-gate-integration, security-review FIX 3) —
 # ``list_approvals`` now honors optional ``action_name`` + ``row_id`` query
 # filters. The gate's BATCH dedup pushes them into the Mongo query so a pocket
@@ -35,8 +71,10 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime
 from typing import Any
+from uuid import UUID, uuid4
 
 from beanie import PydanticObjectId
 
@@ -56,6 +94,15 @@ from pocketpaw_ee.cloud.instinct_approvals.dto import (
     approval_to_wire_dict,
 )
 from pocketpaw_ee.cloud.models.instinct_approval import InstinctApproval as _ApprovalDoc
+from pocketpaw_ee.cloud.shared.events import event_bus
+
+logger = logging.getLogger(__name__)
+
+# Bus topic the notification bridge subscribes to. Deliberately the same
+# string as ``InstinctApprovalCreated.EVENT_TYPE`` — the two buses are
+# different objects (realtime websocket fan-out vs. the cross-domain
+# side-effect bus), and one name for one fact keeps them readable together.
+CREATED_TOPIC = "instinct.approval.created"
 
 # ---------------------------------------------------------------------------
 # Private mapping helper — Beanie doc → domain
@@ -80,6 +127,7 @@ def _to_domain(doc: _ApprovalDoc) -> InstinctApproval:
         decided_by=doc.decided_by,
         park=dict(doc.park) if doc.park else None,
         created_at=getattr(doc, "createdAt", None),
+        correlation_id=getattr(doc, "correlation_id", "") or "",
     )
 
 
@@ -97,6 +145,20 @@ async def create_approval(
     template-level composer returns ``ESCALATE_APPROVAL``. Re-validates
     the body (FastAPI parsed it; internal callers re-parse so the
     schema is enforced uniformly — rule 6).
+
+    T-5 — this is the chain-OPEN moment. A fresh ``correlation_id`` is minted
+    onto the row and ``agent.proposed`` is emitted under it, so the eventual
+    human decision has a chain to close and /decisions has a row to show.
+    The executor mints its own correlation for the direct-write path, but on
+    the ``instinct_pending`` branch it returns BEFORE emitting
+    ``agent.proposed`` and never threads its id onto ``park`` — so there is no
+    existing chain to join here, and joining one would be joining an empty
+    chain. Minting is the correct move, and it also guarantees this row's
+    correlation is known to no other producer, so nothing else can close it.
+
+    The owner/admin notification rides ``shared.events.event_bus``, NOT the
+    return value — the caller (the gate) must not be able to fail because a
+    notification recipient lookup did.
     """
     body = CreateApprovalRequest.model_validate(body)
 
@@ -112,6 +174,7 @@ async def create_approval(
         )
 
     now = datetime.now(UTC)
+    correlation_id = uuid4()
     doc = _ApprovalDoc(
         workspace=workspace_id,
         pocket_id=body.pocket_id,
@@ -124,12 +187,26 @@ async def create_approval(
         requested_at=now,
         requested_by=user_id,
         status="pending",
+        correlation_id=str(correlation_id),
         park=body.park,
     )
     await doc.insert()
     domain = _to_domain(doc)
     wire = approval_to_wire_dict(domain)
+
+    _open_chain(
+        correlation_id=correlation_id,
+        workspace_id=workspace_id,
+        pocket_id=body.pocket_id,
+        user_id=user_id,
+        approval_id=domain.id,
+        action_name=body.action_name,
+        row_id=body.row_id,
+        reason=body.reason,
+    )
+
     await emit(InstinctApprovalCreated(data=dict(wire)))
+    await _publish_created_safe(dict(wire))
     return wire
 
 
@@ -335,6 +412,27 @@ async def _decide(
     await doc.save()
     domain = _to_domain(doc)
     wire = approval_to_wire_dict(domain)
+
+    # T-5 — the governance record. The Mongo row above is the source of
+    # truth and is already committed; everything below is best-effort and
+    # cannot fail the decision.
+    _close_chain(
+        correlation_id=_chain_id(domain.correlation_id),
+        workspace_id=workspace_id,
+        pocket_id=domain.pocket_id,
+        user_id=user_id,
+        approval_id=domain.id,
+        new_status=new_status,
+        note=note,
+    )
+    await _record_audit_safe(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        approval=domain,
+        new_status=new_status,
+        note=note,
+    )
+
     payload = dict(wire)
     if note:
         payload["note"] = note
@@ -342,7 +440,273 @@ async def _decide(
     return wire
 
 
+# ---------------------------------------------------------------------------
+# T-5 — governance-record helpers (chain emits, audit, notification publish)
+# ---------------------------------------------------------------------------
+
+
+def _chain_id(raw: str) -> UUID | None:
+    """Parse a stored ``correlation_id``, or ``None`` when absent/malformed.
+
+    Rows written before T-5 carry ``""``; an ``auto_approve`` row carries ""
+    too (the AUTO lane has no human chain). Both mean "no chain" — the emits
+    are skipped rather than fabricating a chain id that joins to nothing.
+    """
+    if not raw:
+        return None
+    try:
+        return UUID(raw)
+    except ValueError:
+        logger.warning("instinct_approval: malformed correlation_id %r — skipping chain", raw)
+        return None
+
+
+def _chain_actor(*, user_id: str, workspace_id: str, pocket_id: str) -> Any:
+    """Actor stamped on this approval's chain events.
+
+    ``kind="user"`` — mirrors ``instinct.chain_emitters._chain_actor_human``.
+    A template-level approval decision is a HUMAN act; the projection's
+    ``_fold_corrected`` attributes the ApproverRef from this actor, and
+    ``scope_context`` narrows ``DecisionStore``'s visibility filter to the
+    deciding workspace, which is also what keeps workspace B from seeing
+    workspace A's chain.
+    """
+    from soul_protocol.spec.journal import Actor
+
+    return Actor(
+        kind="user",
+        id=f"user:{user_id or 'unknown'}",
+        scope_context=[f"workspace:{workspace_id}", f"pocket:{pocket_id}"],
+    )
+
+
+def _chain_scope(*, workspace_id: str, pocket_id: str) -> list[str]:
+    """Tenancy tags on every chain event — the projection intersects these
+    with the requester's scopes, so they ARE the cross-tenant boundary."""
+    return [f"workspace:{workspace_id}", f"pocket:{pocket_id}"]
+
+
+def _safe_chain_emit(record_fn, *, correlation_id: UUID, **kwargs) -> Any | None:
+    """Best-effort Decision-Graph emit — peer of ``action_executor._safe_record``.
+
+    A journal/projection failure must never break an approval; the journal row
+    is the source of truth and the Slice 4 reconciler replays from the cursor.
+    Returns the emitted event id so the next event in the chain can cite it as
+    ``causation_id``, or ``None`` when the emit raised.
+    """
+    try:
+        entry = record_fn(correlation_id=correlation_id, **kwargs)
+        return entry.id
+    except Exception:  # noqa: BLE001 — chain emit is best-effort by contract
+        logger.warning(
+            "instinct_approval chain emit failed for %s correlation_id=%s",
+            getattr(record_fn, "__name__", "record_*"),
+            correlation_id,
+            exc_info=True,
+        )
+        return None
+
+
+def _open_chain(
+    *,
+    correlation_id: UUID,
+    workspace_id: str,
+    pocket_id: str,
+    user_id: str,
+    approval_id: str,
+    action_name: str,
+    row_id: str,
+    reason: str,
+) -> None:
+    """Emit ``agent.proposed`` — the chain-opening event for this approval.
+
+    Load-bearing, not decorative: ``projection._close_chain`` drops any chain
+    whose ``decided_by`` is unset, and only ``_fold_proposed`` sets it. Skip
+    this and the decide path's terminal is discarded with a "closed without
+    proposed event" warning, leaving /decisions empty.
+
+    ``policy.evaluated(passed=False)`` rides along because that IS what
+    happened: the template's Instinct rules adjudicated this write and
+    escalated it. It gives the projection the pre-human policy state the
+    row-level path gets from ``instinct_bridge.propose_pocket_write``.
+    """
+    from pocketpaw_ee.cloud.decisions.journal_writer import (
+        record_agent_proposed,
+        record_policy_evaluated,
+    )
+
+    actor = _chain_actor(user_id=user_id, workspace_id=workspace_id, pocket_id=pocket_id)
+    scope = _chain_scope(workspace_id=workspace_id, pocket_id=pocket_id)
+
+    proposed_id = _safe_chain_emit(
+        record_agent_proposed,
+        correlation_id=correlation_id,
+        actor=actor,
+        scope=scope,
+        payload={
+            # Fields ``projection._fold_proposed`` consumes.
+            "intent": f"template action {action_name} on row {row_id or '-'}",
+            "action": action_name,
+            "pocket_id": pocket_id,
+            "inputs": [],
+            # Ride-alongs for the explain narrator / future AgentProposal swap.
+            "proposal_kind": "instinct_approval",
+            "summary": f"template action {action_name} escalated for approval",
+            "approval_id": approval_id,
+            "row_id": row_id,
+        },
+    )
+    _safe_chain_emit(
+        record_policy_evaluated,
+        correlation_id=correlation_id,
+        actor=actor,
+        scope=scope,
+        payload={
+            "policy": "template_instinct_gate",
+            "passed": False,
+            "reason": reason or "escalated for human approval",
+            "approval_id": approval_id,
+            "evaluator": "instinct",
+        },
+        causation_id=proposed_id,
+    )
+
+
+def _close_chain(
+    *,
+    correlation_id: UUID | None,
+    workspace_id: str,
+    pocket_id: str,
+    user_id: str,
+    approval_id: str,
+    new_status: str,
+    note: str | None,
+) -> None:
+    """Emit ``human.corrected`` then ``decision.completed`` for a decision.
+
+    Both events are needed. ``human.corrected`` is what attributes the
+    decision to the human; ``decision.completed`` is the ONLY action in
+    ``projection._TERMINAL_ACTIONS``, and until a terminal lands the chain
+    accumulates in the projection's in-memory pending dict and never becomes
+    a queryable Decision row.
+
+    Unlike the row-level approve path — where the post-approval bridge owns
+    the close — nothing runs after a template-level approval today (see
+    ``approve``: the re-entry into ``run_action(from_instinct=True)`` is still
+    unwired), so this path owns the close on BOTH approve and reject. The
+    correlation was minted in ``create_approval`` and is on no other producer's
+    blob, so there is no second closer to race.
+    """
+    if correlation_id is None:
+        return
+
+    from pocketpaw_ee.cloud.decisions.journal_writer import (
+        record_decision_completed,
+        record_human_corrected,
+    )
+
+    approved = new_status == "approved"
+    disposition = "accepted" if approved else "rejected"
+    actor = _chain_actor(user_id=user_id, workspace_id=workspace_id, pocket_id=pocket_id)
+    scope = _chain_scope(workspace_id=workspace_id, pocket_id=pocket_id)
+
+    corrected_payload: dict[str, Any] = {
+        "disposition": disposition,
+        "approval_id": approval_id,
+    }
+    if note:
+        corrected_payload["note"] = note
+
+    human_event_id = _safe_chain_emit(
+        record_human_corrected,
+        correlation_id=correlation_id,
+        actor=actor,
+        scope=scope,
+        payload=corrected_payload,
+    )
+
+    terminal_payload: dict[str, Any] = {
+        "passed": approved,
+        "action_outcome": new_status,
+        "approval_id": approval_id,
+    }
+    if note:
+        terminal_payload["reason"] = note
+
+    _safe_chain_emit(
+        record_decision_completed,
+        correlation_id=correlation_id,
+        actor=actor,
+        scope=scope,
+        payload=terminal_payload,
+        causation_id=human_event_id,
+    )
+
+
+async def _record_audit_safe(
+    *,
+    workspace_id: str,
+    user_id: str,
+    approval: InstinctApproval,
+    new_status: str,
+    note: str | None,
+) -> None:
+    """Write the workspace audit row for a template-approval decision.
+
+    ``audit.service.record`` already swallows its own insert failures, but its
+    SIEM hand-off sits outside that guard — so the call is wrapped here too.
+    An audit sink must never be able to undo a decision the operator made.
+
+    ``metadata.category`` is ``pocket_router``, matching what the row-level
+    path's ``record_decision`` stamps, so a decided template approval lands in
+    the same /activity filter bucket as a decided row-level one.
+    """
+    try:
+        from pocketpaw_ee.cloud.audit import service as audit_service
+
+        await audit_service.record(
+            workspace_id=workspace_id,
+            actor_id=user_id or "unknown",
+            action=f"instinct_approval.{new_status}",
+            target_type="instinct_approval",
+            target_id=approval.id,
+            metadata={
+                "category": "pocket_router",
+                "pocket_id": approval.pocket_id,
+                "action_name": approval.action_name,
+                "row_id": approval.row_id,
+                "correlation_id": approval.correlation_id,
+                "note": note or "",
+            },
+        )
+    except Exception:  # noqa: BLE001 — audit must never break the decision
+        logger.warning(
+            "instinct_approval audit write failed for approval=%s status=%s",
+            approval.id,
+            new_status,
+            exc_info=True,
+        )
+
+
+async def _publish_created_safe(wire: dict) -> None:
+    """Publish ``instinct.approval.created`` for the notification bridge.
+
+    ``event_bus.emit`` already guards each handler, so a broken subscriber is
+    contained there; this wrapper covers the bus call itself. The approval row
+    is committed before we get here — no fan-out failure may unwind it.
+    """
+    try:
+        await event_bus.emit(CREATED_TOPIC, wire)
+    except Exception:  # noqa: BLE001 — fan-out must never break create
+        logger.warning(
+            "instinct_approval created fan-out failed for approval=%s",
+            wire.get("id"),
+            exc_info=True,
+        )
+
+
 __all__ = [
+    "CREATED_TOPIC",
     "approve",
     "auto_approve",
     "create_approval",

--- a/ee/pocketpaw_ee/cloud/instinct_approvals/service.py
+++ b/ee/pocketpaw_ee/cloud/instinct_approvals/service.py
@@ -20,8 +20,11 @@
 #      ``agent.proposed`` (``chain.decided_by is None`` → "closed without
 #      proposed event — skipping"). Without the open, /decisions stays empty
 #      no matter what the decide path emits.
-#   2. DECIDE closes that same chain — ``human.corrected(accepted|rejected)``
-#      then ``decision.completed`` — and writes a workspace audit row
+#   2. DECIDE closes that same chain — ``human.corrected(accepted|rejected)``,
+#      on approve a ``policy.evaluated(passed=True)`` flip (the projection
+#      keeps the LAST policy event, so without it an approved Decision would
+#      forever read as blocked by the gate), then ``decision.completed`` —
+#      and writes a workspace audit row
 #      (``instinct_approval.approved`` / ``.rejected``) so the decision also
 #      lands on /activity. Same pair the row-level path fires, plus the
 #      terminal the row-level path owns on its reject side. There is no double
@@ -582,13 +585,28 @@ def _close_chain(
     new_status: str,
     note: str | None,
 ) -> None:
-    """Emit ``human.corrected`` then ``decision.completed`` for a decision.
+    """Emit ``human.corrected`` (+ the approve-side policy flip) then
+    ``decision.completed`` for a decision.
 
-    Both events are needed. ``human.corrected`` is what attributes the
+    Both bookends are needed. ``human.corrected`` is what attributes the
     decision to the human; ``decision.completed`` is the ONLY action in
     ``projection._TERMINAL_ACTIONS``, and until a terminal lands the chain
     accumulates in the projection's in-memory pending dict and never becomes
     a queryable Decision row.
+
+    On APPROVE a ``policy.evaluated(passed=True)`` fires between them. The
+    projection's ``_fold_policy`` keeps the LAST policy event seen before the
+    terminal, and the only one so far is create's honest ``passed=False``
+    ("template escalated to human") — without the flip an APPROVED Decision
+    permanently reads ``instinct_policy_passed=False``, the explain narrator
+    renders "the Instinct policy template_instinct_gate blocked at decision
+    time" for a decision a human explicitly cleared, and the outcome-hint
+    ranker files it under the rejected hint. fail→pass is the projection's
+    own encoding of "asked for human → human approved" (projection.py
+    ``_fold_policy`` docstring), and the row-level approve path emits the
+    same flip (``chain_emitters._emit_policy_evaluated_approved``). Reject
+    emits no policy event, so the ``passed=False`` from create stands — which
+    is the correct final state for a rejection.
 
     Unlike the row-level approve path — where the post-approval bridge owns
     the close — nothing runs after a template-level approval today (see
@@ -603,6 +621,7 @@ def _close_chain(
     from pocketpaw_ee.cloud.decisions.journal_writer import (
         record_decision_completed,
         record_human_corrected,
+        record_policy_evaluated,
     )
 
     approved = new_status == "approved"
@@ -624,6 +643,25 @@ def _close_chain(
         scope=scope,
         payload=corrected_payload,
     )
+
+    if approved:
+        # The approve-side policy flip — see the docstring. Fires AFTER
+        # human.corrected (its causation) and BEFORE the terminal, so
+        # _fold_policy's last-seen-wins lands on passed=True at close.
+        _safe_chain_emit(
+            record_policy_evaluated,
+            correlation_id=correlation_id,
+            actor=actor,
+            scope=scope,
+            payload={
+                "policy": "template_instinct_gate",
+                "passed": True,
+                "reason": "approved_by_human",
+                "approval_id": approval_id,
+                "evaluator": "instinct",
+            },
+            causation_id=human_event_id,
+        )
 
     terminal_payload: dict[str, Any] = {
         "passed": approved,

--- a/ee/pocketpaw_ee/cloud/instinct_approvals/service.py
+++ b/ee/pocketpaw_ee/cloud/instinct_approvals/service.py
@@ -15,6 +15,42 @@
 # level ``async def`` API per EE cloud rule 5. Every state-mutating
 # function:
 #
+# Updated: 2026-08-06 (feat/coupling-template-approvals, T-5) — a
+# template-level approval is now VISIBLE IN THE GOVERNANCE RECORD. It is the
+# highest-leverage governance act in the product (a human authorising a whole
+# CLASS of future writes) and until now it left no trace anywhere: the row
+# carried no chain id, ``_decide`` only saved the doc and emitted an ephemeral
+# realtime event, and an owner who was offline when the approval was requested
+# was never told. Three additions, all modelled on the row-level path in
+# ``ee/pocketpaw_ee/instinct/router.py`` + ``instinct/chain_emitters.py``:
+#
+#   1. CREATE mints a ``correlation_id`` onto the row and OPENS the
+#      Decision-Graph chain with ``agent.proposed``. The mint alone is not
+#      enough: ``decisions.projection`` only materialises a Decision row on a
+#      TERMINAL event, and ``_close_chain`` DROPS any chain that never saw
+#      ``agent.proposed`` (``chain.decided_by is None`` → "closed without
+#      proposed event — skipping"). Without the open, /decisions stays empty
+#      no matter what the decide path emits.
+#   2. DECIDE closes that same chain — ``human.corrected(accepted|rejected)``
+#      then ``decision.completed`` — and writes a workspace audit row
+#      (``instinct_approval.approved`` / ``.rejected``) so the decision also
+#      lands on /activity. Same pair the row-level path fires, plus the
+#      terminal the row-level path owns on its reject side. There is no double
+#      close: the correlation is minted HERE and known only to this row (the
+#      post-approval re-entry is still unwired — see ``approve``), so no other
+#      producer can close it.
+#   3. CREATE publishes ``instinct.approval.created`` on
+#      ``shared.events.event_bus``, where ``bridges/notifications.py`` turns it
+#      into a PERSISTED notification for the workspace owner + admins. The
+#      pre-existing realtime ``emit`` is a websocket fan-out only — an offline
+#      owner saw nothing.
+#
+# Every one of those is best-effort and cannot break the approval flow: the
+# chain emits go through ``_safe_chain_emit``, the audit write through
+# ``_record_audit_safe``, and the notification fan-out through
+# ``_publish_created_safe``. The Mongo row is the source of truth; the Slice 4
+# reconciler catches up any chain event that failed to land.
+#
 # Updated: 2026-06-19 (feat/instinct-gate-integration, security-review FIX 3) —
 # ``list_approvals`` now honors optional ``action_name`` + ``row_id`` query
 # filters. The gate's BATCH dedup pushes them into the Mongo query so a pocket
@@ -49,6 +85,7 @@ from __future__ import annotations
 import logging
 from datetime import UTC, datetime
 from typing import Any
+from uuid import UUID, uuid4
 
 from beanie import PydanticObjectId
 
@@ -68,6 +105,15 @@ from pocketpaw_ee.cloud.instinct_approvals.dto import (
     approval_to_wire_dict,
 )
 from pocketpaw_ee.cloud.models.instinct_approval import InstinctApproval as _ApprovalDoc
+from pocketpaw_ee.cloud.shared.events import event_bus
+
+logger = logging.getLogger(__name__)
+
+# Bus topic the notification bridge subscribes to. Deliberately the same
+# string as ``InstinctApprovalCreated.EVENT_TYPE`` — the two buses are
+# different objects (realtime websocket fan-out vs. the cross-domain
+# side-effect bus), and one name for one fact keeps them readable together.
+CREATED_TOPIC = "instinct.approval.created"
 
 logger = logging.getLogger(__name__)
 
@@ -94,6 +140,7 @@ def _to_domain(doc: _ApprovalDoc) -> InstinctApproval:
         decided_by=doc.decided_by,
         park=dict(doc.park) if doc.park else None,
         created_at=getattr(doc, "createdAt", None),
+        correlation_id=getattr(doc, "correlation_id", "") or "",
     )
 
 
@@ -111,6 +158,20 @@ async def create_approval(
     template-level composer returns ``ESCALATE_APPROVAL``. Re-validates
     the body (FastAPI parsed it; internal callers re-parse so the
     schema is enforced uniformly — rule 6).
+
+    T-5 — this is the chain-OPEN moment. A fresh ``correlation_id`` is minted
+    onto the row and ``agent.proposed`` is emitted under it, so the eventual
+    human decision has a chain to close and /decisions has a row to show.
+    The executor mints its own correlation for the direct-write path, but on
+    the ``instinct_pending`` branch it returns BEFORE emitting
+    ``agent.proposed`` and never threads its id onto ``park`` — so there is no
+    existing chain to join here, and joining one would be joining an empty
+    chain. Minting is the correct move, and it also guarantees this row's
+    correlation is known to no other producer, so nothing else can close it.
+
+    The owner/admin notification rides ``shared.events.event_bus``, NOT the
+    return value — the caller (the gate) must not be able to fail because a
+    notification recipient lookup did.
     """
     body = CreateApprovalRequest.model_validate(body)
 
@@ -126,6 +187,7 @@ async def create_approval(
         )
 
     now = datetime.now(UTC)
+    correlation_id = uuid4()
     doc = _ApprovalDoc(
         workspace=workspace_id,
         pocket_id=body.pocket_id,
@@ -138,13 +200,27 @@ async def create_approval(
         requested_at=now,
         requested_by=user_id,
         status="pending",
+        correlation_id=str(correlation_id),
         park=body.park,
     )
     await doc.insert()
     domain = _to_domain(doc)
     wire = approval_to_wire_dict(domain)
+
+    _open_chain(
+        correlation_id=correlation_id,
+        workspace_id=workspace_id,
+        pocket_id=body.pocket_id,
+        user_id=user_id,
+        approval_id=domain.id,
+        action_name=body.action_name,
+        row_id=body.row_id,
+        reason=body.reason,
+    )
+
     await emit(InstinctApprovalCreated(data=dict(wire)))
     await _notify_requester(domain)
+    await _publish_created_safe(dict(wire))
     return wire
 
 
@@ -389,6 +465,27 @@ async def _decide(
     await doc.save()
     domain = _to_domain(doc)
     wire = approval_to_wire_dict(domain)
+
+    # T-5 — the governance record. The Mongo row above is the source of
+    # truth and is already committed; everything below is best-effort and
+    # cannot fail the decision.
+    _close_chain(
+        correlation_id=_chain_id(domain.correlation_id),
+        workspace_id=workspace_id,
+        pocket_id=domain.pocket_id,
+        user_id=user_id,
+        approval_id=domain.id,
+        new_status=new_status,
+        note=note,
+    )
+    await _record_audit_safe(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        approval=domain,
+        new_status=new_status,
+        note=note,
+    )
+
     payload = dict(wire)
     if note:
         payload["note"] = note
@@ -396,7 +493,273 @@ async def _decide(
     return wire
 
 
+# ---------------------------------------------------------------------------
+# T-5 — governance-record helpers (chain emits, audit, notification publish)
+# ---------------------------------------------------------------------------
+
+
+def _chain_id(raw: str) -> UUID | None:
+    """Parse a stored ``correlation_id``, or ``None`` when absent/malformed.
+
+    Rows written before T-5 carry ``""``; an ``auto_approve`` row carries ""
+    too (the AUTO lane has no human chain). Both mean "no chain" — the emits
+    are skipped rather than fabricating a chain id that joins to nothing.
+    """
+    if not raw:
+        return None
+    try:
+        return UUID(raw)
+    except ValueError:
+        logger.warning("instinct_approval: malformed correlation_id %r — skipping chain", raw)
+        return None
+
+
+def _chain_actor(*, user_id: str, workspace_id: str, pocket_id: str) -> Any:
+    """Actor stamped on this approval's chain events.
+
+    ``kind="user"`` — mirrors ``instinct.chain_emitters._chain_actor_human``.
+    A template-level approval decision is a HUMAN act; the projection's
+    ``_fold_corrected`` attributes the ApproverRef from this actor, and
+    ``scope_context`` narrows ``DecisionStore``'s visibility filter to the
+    deciding workspace, which is also what keeps workspace B from seeing
+    workspace A's chain.
+    """
+    from soul_protocol.spec.journal import Actor
+
+    return Actor(
+        kind="user",
+        id=f"user:{user_id or 'unknown'}",
+        scope_context=[f"workspace:{workspace_id}", f"pocket:{pocket_id}"],
+    )
+
+
+def _chain_scope(*, workspace_id: str, pocket_id: str) -> list[str]:
+    """Tenancy tags on every chain event — the projection intersects these
+    with the requester's scopes, so they ARE the cross-tenant boundary."""
+    return [f"workspace:{workspace_id}", f"pocket:{pocket_id}"]
+
+
+def _safe_chain_emit(record_fn, *, correlation_id: UUID, **kwargs) -> Any | None:
+    """Best-effort Decision-Graph emit — peer of ``action_executor._safe_record``.
+
+    A journal/projection failure must never break an approval; the journal row
+    is the source of truth and the Slice 4 reconciler replays from the cursor.
+    Returns the emitted event id so the next event in the chain can cite it as
+    ``causation_id``, or ``None`` when the emit raised.
+    """
+    try:
+        entry = record_fn(correlation_id=correlation_id, **kwargs)
+        return entry.id
+    except Exception:  # noqa: BLE001 — chain emit is best-effort by contract
+        logger.warning(
+            "instinct_approval chain emit failed for %s correlation_id=%s",
+            getattr(record_fn, "__name__", "record_*"),
+            correlation_id,
+            exc_info=True,
+        )
+        return None
+
+
+def _open_chain(
+    *,
+    correlation_id: UUID,
+    workspace_id: str,
+    pocket_id: str,
+    user_id: str,
+    approval_id: str,
+    action_name: str,
+    row_id: str,
+    reason: str,
+) -> None:
+    """Emit ``agent.proposed`` — the chain-opening event for this approval.
+
+    Load-bearing, not decorative: ``projection._close_chain`` drops any chain
+    whose ``decided_by`` is unset, and only ``_fold_proposed`` sets it. Skip
+    this and the decide path's terminal is discarded with a "closed without
+    proposed event" warning, leaving /decisions empty.
+
+    ``policy.evaluated(passed=False)`` rides along because that IS what
+    happened: the template's Instinct rules adjudicated this write and
+    escalated it. It gives the projection the pre-human policy state the
+    row-level path gets from ``instinct_bridge.propose_pocket_write``.
+    """
+    from pocketpaw_ee.cloud.decisions.journal_writer import (
+        record_agent_proposed,
+        record_policy_evaluated,
+    )
+
+    actor = _chain_actor(user_id=user_id, workspace_id=workspace_id, pocket_id=pocket_id)
+    scope = _chain_scope(workspace_id=workspace_id, pocket_id=pocket_id)
+
+    proposed_id = _safe_chain_emit(
+        record_agent_proposed,
+        correlation_id=correlation_id,
+        actor=actor,
+        scope=scope,
+        payload={
+            # Fields ``projection._fold_proposed`` consumes.
+            "intent": f"template action {action_name} on row {row_id or '-'}",
+            "action": action_name,
+            "pocket_id": pocket_id,
+            "inputs": [],
+            # Ride-alongs for the explain narrator / future AgentProposal swap.
+            "proposal_kind": "instinct_approval",
+            "summary": f"template action {action_name} escalated for approval",
+            "approval_id": approval_id,
+            "row_id": row_id,
+        },
+    )
+    _safe_chain_emit(
+        record_policy_evaluated,
+        correlation_id=correlation_id,
+        actor=actor,
+        scope=scope,
+        payload={
+            "policy": "template_instinct_gate",
+            "passed": False,
+            "reason": reason or "escalated for human approval",
+            "approval_id": approval_id,
+            "evaluator": "instinct",
+        },
+        causation_id=proposed_id,
+    )
+
+
+def _close_chain(
+    *,
+    correlation_id: UUID | None,
+    workspace_id: str,
+    pocket_id: str,
+    user_id: str,
+    approval_id: str,
+    new_status: str,
+    note: str | None,
+) -> None:
+    """Emit ``human.corrected`` then ``decision.completed`` for a decision.
+
+    Both events are needed. ``human.corrected`` is what attributes the
+    decision to the human; ``decision.completed`` is the ONLY action in
+    ``projection._TERMINAL_ACTIONS``, and until a terminal lands the chain
+    accumulates in the projection's in-memory pending dict and never becomes
+    a queryable Decision row.
+
+    Unlike the row-level approve path — where the post-approval bridge owns
+    the close — nothing runs after a template-level approval today (see
+    ``approve``: the re-entry into ``run_action(from_instinct=True)`` is still
+    unwired), so this path owns the close on BOTH approve and reject. The
+    correlation was minted in ``create_approval`` and is on no other producer's
+    blob, so there is no second closer to race.
+    """
+    if correlation_id is None:
+        return
+
+    from pocketpaw_ee.cloud.decisions.journal_writer import (
+        record_decision_completed,
+        record_human_corrected,
+    )
+
+    approved = new_status == "approved"
+    disposition = "accepted" if approved else "rejected"
+    actor = _chain_actor(user_id=user_id, workspace_id=workspace_id, pocket_id=pocket_id)
+    scope = _chain_scope(workspace_id=workspace_id, pocket_id=pocket_id)
+
+    corrected_payload: dict[str, Any] = {
+        "disposition": disposition,
+        "approval_id": approval_id,
+    }
+    if note:
+        corrected_payload["note"] = note
+
+    human_event_id = _safe_chain_emit(
+        record_human_corrected,
+        correlation_id=correlation_id,
+        actor=actor,
+        scope=scope,
+        payload=corrected_payload,
+    )
+
+    terminal_payload: dict[str, Any] = {
+        "passed": approved,
+        "action_outcome": new_status,
+        "approval_id": approval_id,
+    }
+    if note:
+        terminal_payload["reason"] = note
+
+    _safe_chain_emit(
+        record_decision_completed,
+        correlation_id=correlation_id,
+        actor=actor,
+        scope=scope,
+        payload=terminal_payload,
+        causation_id=human_event_id,
+    )
+
+
+async def _record_audit_safe(
+    *,
+    workspace_id: str,
+    user_id: str,
+    approval: InstinctApproval,
+    new_status: str,
+    note: str | None,
+) -> None:
+    """Write the workspace audit row for a template-approval decision.
+
+    ``audit.service.record`` already swallows its own insert failures, but its
+    SIEM hand-off sits outside that guard — so the call is wrapped here too.
+    An audit sink must never be able to undo a decision the operator made.
+
+    ``metadata.category`` is ``pocket_router``, matching what the row-level
+    path's ``record_decision`` stamps, so a decided template approval lands in
+    the same /activity filter bucket as a decided row-level one.
+    """
+    try:
+        from pocketpaw_ee.cloud.audit import service as audit_service
+
+        await audit_service.record(
+            workspace_id=workspace_id,
+            actor_id=user_id or "unknown",
+            action=f"instinct_approval.{new_status}",
+            target_type="instinct_approval",
+            target_id=approval.id,
+            metadata={
+                "category": "pocket_router",
+                "pocket_id": approval.pocket_id,
+                "action_name": approval.action_name,
+                "row_id": approval.row_id,
+                "correlation_id": approval.correlation_id,
+                "note": note or "",
+            },
+        )
+    except Exception:  # noqa: BLE001 — audit must never break the decision
+        logger.warning(
+            "instinct_approval audit write failed for approval=%s status=%s",
+            approval.id,
+            new_status,
+            exc_info=True,
+        )
+
+
+async def _publish_created_safe(wire: dict) -> None:
+    """Publish ``instinct.approval.created`` for the notification bridge.
+
+    ``event_bus.emit`` already guards each handler, so a broken subscriber is
+    contained there; this wrapper covers the bus call itself. The approval row
+    is committed before we get here — no fan-out failure may unwind it.
+    """
+    try:
+        await event_bus.emit(CREATED_TOPIC, wire)
+    except Exception:  # noqa: BLE001 — fan-out must never break create
+        logger.warning(
+            "instinct_approval created fan-out failed for approval=%s",
+            wire.get("id"),
+            exc_info=True,
+        )
+
+
 __all__ = [
+    "CREATED_TOPIC",
     "approve",
     "auto_approve",
     "create_approval",

--- a/ee/pocketpaw_ee/cloud/instinct_approvals/service.py
+++ b/ee/pocketpaw_ee/cloud/instinct_approvals/service.py
@@ -31,8 +31,11 @@
 #      ``agent.proposed`` (``chain.decided_by is None`` → "closed without
 #      proposed event — skipping"). Without the open, /decisions stays empty
 #      no matter what the decide path emits.
-#   2. DECIDE closes that same chain — ``human.corrected(accepted|rejected)``
-#      then ``decision.completed`` — and writes a workspace audit row
+#   2. DECIDE closes that same chain — ``human.corrected(accepted|rejected)``,
+#      on approve a ``policy.evaluated(passed=True)`` flip (the projection
+#      keeps the LAST policy event, so without it an approved Decision would
+#      forever read as blocked by the gate), then ``decision.completed`` —
+#      and writes a workspace audit row
 #      (``instinct_approval.approved`` / ``.rejected``) so the decision also
 #      lands on /activity. Same pair the row-level path fires, plus the
 #      terminal the row-level path owns on its reject side. There is no double
@@ -115,7 +118,6 @@ logger = logging.getLogger(__name__)
 # side-effect bus), and one name for one fact keeps them readable together.
 CREATED_TOPIC = "instinct.approval.created"
 
-logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Private mapping helper — Beanie doc → domain
@@ -635,13 +637,28 @@ def _close_chain(
     new_status: str,
     note: str | None,
 ) -> None:
-    """Emit ``human.corrected`` then ``decision.completed`` for a decision.
+    """Emit ``human.corrected`` (+ the approve-side policy flip) then
+    ``decision.completed`` for a decision.
 
-    Both events are needed. ``human.corrected`` is what attributes the
+    Both bookends are needed. ``human.corrected`` is what attributes the
     decision to the human; ``decision.completed`` is the ONLY action in
     ``projection._TERMINAL_ACTIONS``, and until a terminal lands the chain
     accumulates in the projection's in-memory pending dict and never becomes
     a queryable Decision row.
+
+    On APPROVE a ``policy.evaluated(passed=True)`` fires between them. The
+    projection's ``_fold_policy`` keeps the LAST policy event seen before the
+    terminal, and the only one so far is create's honest ``passed=False``
+    ("template escalated to human") — without the flip an APPROVED Decision
+    permanently reads ``instinct_policy_passed=False``, the explain narrator
+    renders "the Instinct policy template_instinct_gate blocked at decision
+    time" for a decision a human explicitly cleared, and the outcome-hint
+    ranker files it under the rejected hint. fail→pass is the projection's
+    own encoding of "asked for human → human approved" (projection.py
+    ``_fold_policy`` docstring), and the row-level approve path emits the
+    same flip (``chain_emitters._emit_policy_evaluated_approved``). Reject
+    emits no policy event, so the ``passed=False`` from create stands — which
+    is the correct final state for a rejection.
 
     Unlike the row-level approve path — where the post-approval bridge owns
     the close — nothing runs after a template-level approval today (see
@@ -656,6 +673,7 @@ def _close_chain(
     from pocketpaw_ee.cloud.decisions.journal_writer import (
         record_decision_completed,
         record_human_corrected,
+        record_policy_evaluated,
     )
 
     approved = new_status == "approved"
@@ -677,6 +695,25 @@ def _close_chain(
         scope=scope,
         payload=corrected_payload,
     )
+
+    if approved:
+        # The approve-side policy flip — see the docstring. Fires AFTER
+        # human.corrected (its causation) and BEFORE the terminal, so
+        # _fold_policy's last-seen-wins lands on passed=True at close.
+        _safe_chain_emit(
+            record_policy_evaluated,
+            correlation_id=correlation_id,
+            actor=actor,
+            scope=scope,
+            payload={
+                "policy": "template_instinct_gate",
+                "passed": True,
+                "reason": "approved_by_human",
+                "approval_id": approval_id,
+                "evaluator": "instinct",
+            },
+            causation_id=human_event_id,
+        )
 
     terminal_payload: dict[str, Any] = {
         "passed": approved,

--- a/ee/pocketpaw_ee/cloud/models/instinct_approval.py
+++ b/ee/pocketpaw_ee/cloud/models/instinct_approval.py
@@ -19,6 +19,18 @@
 # scoped to the RFC 03 v2 template flow only — the M2b.1 binding-level
 # park remains for backward compatibility.
 #
+# Updated: 2026-08-06 (feat/coupling-template-approvals, T-5) — added the
+# additive ``correlation_id`` field. A template-level approval is a human
+# decision that authorises a whole CLASS of future writes, but until now it
+# carried no Decision-Graph chain id, so an approved row reached neither
+# /decisions nor /activity. ``instinct_approvals.service.create_approval``
+# now MINTS a fresh uuid4 here and opens the chain with ``agent.proposed``;
+# the decide path closes it with ``human.corrected`` +
+# ``decision.completed`` under the SAME id, which is what makes a decided
+# approval joinable to its chain. Rows written before this change (and
+# ``auto_approve`` rows, which have no human chain) keep the "" default —
+# the field is additive, so no migration.
+#
 # Updated: 2026-06-18 (feat/instinct-gate-foundation, T3) — added the
 # additive ``"auto_approved"`` status value to ``ApprovalStatusT``. The
 # layered/learning gate's AUTO lane writes a row already-decided with this
@@ -75,6 +87,12 @@ class InstinctApproval(TimestampedDocument):
             future temporal sweeper.
         decided_at / decided_by: set when an operator approves or
             rejects. ``None`` while pending.
+        correlation_id: Decision-Graph chain id, minted at create time by
+            ``instinct_approvals.service.create_approval``. Every chain
+            event for this approval (``agent.proposed`` at create,
+            ``human.corrected`` + ``decision.completed`` at decide) carries
+            it, so /decisions and /activity rows join back to this row.
+            Empty on rows written before T-5 and on ``auto_approve`` rows.
         _park: the resolved write blob the executor parked (method,
             path, params, idempotency_key, outcome, workspace_id,
             requested_by). Re-loaded by a future post-approval re-entry
@@ -96,6 +114,7 @@ class InstinctApproval(TimestampedDocument):
     status: ApprovalStatusT = "pending"
     decided_at: datetime | None = None
     decided_by: str | None = None
+    correlation_id: str = ""
     park: dict[str, Any] | None = Field(default=None, alias="_park")
 
     model_config = {"populate_by_name": True}

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -452,6 +452,10 @@ source_modules = [
     "pocketpaw_ee.cloud.instinct_approvals.router",
     "pocketpaw_ee.cloud.instinct_approvals.dto",
     "pocketpaw_ee.cloud.instinct_approvals.domain",
+    # T-5 — the approval-requested → notification bridge. It reads the wire
+    # dict off the bus and writes through ``notifications.service``; it must
+    # never reach for the approval Beanie doc itself.
+    "pocketpaw_ee.cloud.instinct_approvals.bridges.notifications",
 ]
 forbidden_modules = ["pocketpaw_ee.cloud.models.instinct_approval"]
 

--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -529,6 +529,10 @@ source_modules = [
     "pocketpaw_ee.cloud.instinct_approvals.router",
     "pocketpaw_ee.cloud.instinct_approvals.dto",
     "pocketpaw_ee.cloud.instinct_approvals.domain",
+    # T-5 — the approval-requested → notification bridge. It reads the wire
+    # dict off the bus and writes through ``notifications.service``; it must
+    # never reach for the approval Beanie doc itself.
+    "pocketpaw_ee.cloud.instinct_approvals.bridges.notifications",
 ]
 forbidden_modules = ["pocketpaw_ee.cloud.models.instinct_approval"]
 

--- a/tests/cloud/test_instinct_approvals_governance.py
+++ b/tests/cloud/test_instinct_approvals_governance.py
@@ -1,0 +1,553 @@
+# tests/cloud/test_instinct_approvals_governance.py
+# Created: 2026-08-06 (feat/coupling-template-approvals, T-5) — pins the
+# governance record for TEMPLATE-level Instinct approvals: the one act in the
+# product where a human authorises a whole CLASS of future writes, and which
+# until now left no trace on /decisions, /activity, or any inbox.
+#
+# What each group protects (and the mutation that breaks it — every one was
+# run via tests/mutations/instinct_approval_governance.json, not assumed):
+#   * chain — a decided approval lands a real Decision row joinable by
+#     correlation_id. Deleting the create-time ``agent.proposed`` open, or the
+#     decide-time ``decision.completed`` terminal, kills the row: the projection
+#     only materialises on a terminal AND drops any chain that never saw a
+#     proposal.
+#   * audit — the decision writes ``instinct_approval.<status>`` to the
+#     workspace audit, which is what puts it on /activity.
+#   * notify — creating an approval notifies the workspace owner + admins with
+#     a PERSISTED row, so an owner who was offline still learns a decision is
+#     waiting. Recipients resolve through the real ``list_admin_ids`` against
+#     real membership rows, so the cross-tenant case is a real query, not a
+#     stubbed one.
+#   * resilience — a notification, journal, or audit failure never breaks the
+#     approval flow. Removing any of those try/except wrappers fails here.
+#   * tenancy — an approval in workspace A never notifies workspace B and never
+#     appears in workspace B's audit or its Decision-Graph scope.
+#   * wiring — ``mount_cloud`` actually subscribes the bridge. Without this a
+#     reviewer could delete the registration and the whole suite would stay
+#     green, because every other test in this file self-registers.
+
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+from pocketpaw_ee.cloud.instinct_approvals import service as approvals_service
+from pocketpaw_ee.cloud.instinct_approvals.bridges import notifications as approval_bridge
+from pocketpaw_ee.cloud.models.user import User, WorkspaceMembership
+from pocketpaw_ee.cloud.notifications import service as notifications_service
+from pocketpaw_ee.cloud.shared.events import event_bus
+from soul_protocol.engine.journal import open_journal
+
+import pocketpaw.journal_dep as journal_dep
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+WS_A = "ws-alpha"
+WS_B = "ws-beta"
+USER = "u-requester"
+DECIDER = "u-decider"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — real journal + real projection singletons, real bridge subscriber
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def journal(tmp_path: Path):
+    """Fresh on-disk journal wired into the lazy ``get_journal`` lookup that
+    ``journal_writer`` resolves, so production code and the test read the SAME
+    singleton (shape borrowed from tests/cloud/test_belt_trace.py)."""
+    j = open_journal(tmp_path / "journal.db")
+    journal_dep.reset_journal_cache()
+    original = journal_dep._cached_journal
+
+    def _stub() -> object:
+        return j
+
+    journal_dep._cached_journal = _stub  # type: ignore[assignment]
+    yield j
+    journal_dep._cached_journal = original  # type: ignore[assignment]
+    journal_dep.reset_journal_cache()
+    j.close()
+
+
+@pytest.fixture
+def graph(tmp_path: Path):
+    """Fresh DecisionGraph installed as the process-global singleton."""
+    from pocketpaw_ee.cloud.decisions.service import (
+        get_decision_graph,
+        reset_projection_for_tests,
+    )
+    from pocketpaw_ee.cloud.decisions.store import set_db_path
+
+    set_db_path(tmp_path / "decisions.db")
+    reset_projection_for_tests()
+    g = get_decision_graph()
+    yield g
+    reset_projection_for_tests()
+
+
+@pytest.fixture
+def bridge_subscribed():
+    """Subscribe the REAL bridge handler for the duration of one test.
+
+    Registered explicitly rather than relying on ``mount_cloud`` so these tests
+    stay unit-level — which is exactly why ``test_mount_cloud_subscribes_the_
+    approval_notification_bridge`` below has to exist separately.
+    """
+    approval_bridge.register_instinct_approval_notification_listeners()
+    yield
+    event_bus.unsubscribe(
+        approvals_service.CREATED_TOPIC, approval_bridge._on_instinct_approval_created
+    )
+
+
+def _create_body(**overrides) -> dict:
+    body: dict = {
+        "pocket_id": "pocket-1",
+        "action_name": "refund_customer",
+        "row_id": "row-9",
+        "row_data": {"amount": 500},
+        "verdict": "ESCALATE_APPROVAL",
+        "reason": "operator_overlay_escalated",
+        "matched_rules": [{"when": "amount > 100", "action": "require_approval"}],
+        "park": {"method": "POST", "path": "/refunds"},
+    }
+    body.update(overrides)
+    return body
+
+
+async def _seed_members(workspace_id: str, *, prefix: str) -> dict[str, str]:
+    """Create one owner, one admin and one plain member in ``workspace_id``.
+
+    Real ``User`` rows with real memberships so ``list_admin_ids`` runs its
+    actual ``$elemMatch`` query — a monkeypatched resolver would make the
+    cross-tenant assertion prove nothing.
+    """
+    ids: dict[str, str] = {}
+    for role in ("owner", "admin", "member"):
+        user = User(
+            email=f"{prefix}-{role}@test.local",
+            hashed_password="x",
+            workspaces=[WorkspaceMembership(workspace=workspace_id, role=role)],
+        )
+        await user.insert()
+        ids[role] = str(user.id)
+    return ids
+
+
+def _chain(journal, correlation_id: UUID) -> list:
+    return [e for e in journal.replay_from(0) if e.correlation_id == correlation_id]
+
+
+async def _audit_actions(workspace_id: str) -> list[str]:
+    from pocketpaw_ee.cloud.audit import service as audit_service
+
+    page = await audit_service.list_events(workspace_id, {})
+    return [e.action for e in page.items]
+
+
+# ---------------------------------------------------------------------------
+# (a) the decision lands a journal chain joinable by correlation_id
+# ---------------------------------------------------------------------------
+
+
+async def test_create_stamps_a_correlation_id_on_the_row(journal, graph) -> None:
+    wire = await approvals_service.create_approval(WS_A, USER, _create_body())
+
+    assert wire["correlation_id"], "create must mint a chain id — without one nothing joins"
+    UUID(wire["correlation_id"])  # parses, i.e. it is a real chain id
+
+    fetched = await approvals_service.get_approval(WS_A, USER, wire["id"])
+    assert fetched["correlation_id"] == wire["correlation_id"], "the id must be PERSISTED"
+
+
+async def test_approve_writes_a_journal_chain_joinable_by_correlation_id(journal, graph) -> None:
+    """Mutation: drop the ``agent.proposed`` open in ``_open_chain`` and the
+    terminal is discarded ("closed without proposed event"), so no Decision row
+    exists. Drop ``record_decision_completed`` and the chain never closes."""
+    wire = await approvals_service.create_approval(WS_A, USER, _create_body())
+    corr = UUID(wire["correlation_id"])
+
+    await approvals_service.approve(WS_A, DECIDER, wire["id"], {"note": "cleared by finance"})
+
+    actions = [e.action for e in _chain(journal, corr)]
+    assert "agent.proposed" in actions
+    assert "human.corrected" in actions
+    assert "decision.completed" in actions
+
+    corrected = next(e for e in _chain(journal, corr) if e.action == "human.corrected")
+    assert corrected.payload["disposition"] == "accepted"
+    assert corrected.payload["approval_id"] == wire["id"]
+    assert corrected.actor.id == f"user:{DECIDER}", "the DECIDING user is the actor"
+    assert f"workspace:{WS_A}" in corrected.scope
+
+    # The chain actually materialised a Decision — this is what /decisions reads.
+    decisions = [d for d in graph.store.iter_decisions() if d.correlation_id == corr]
+    assert len(decisions) == 1, "a decided approval must be joinable on /decisions"
+    assert any(a.actor.id == f"user:{DECIDER}" for a in decisions[0].approvers)
+
+
+async def test_reject_closes_the_chain_as_rejected(journal, graph) -> None:
+    wire = await approvals_service.create_approval(WS_A, USER, _create_body())
+    corr = UUID(wire["correlation_id"])
+
+    await approvals_service.reject(WS_A, DECIDER, wire["id"], {"note": "too risky"})
+
+    terminal = next(e for e in _chain(journal, corr) if e.action == "decision.completed")
+    assert terminal.payload["passed"] is False
+    assert terminal.payload["action_outcome"] == "rejected"
+
+    corrected = next(e for e in _chain(journal, corr) if e.action == "human.corrected")
+    assert corrected.payload["disposition"] == "rejected"
+
+    assert len([d for d in graph.store.iter_decisions() if d.correlation_id == corr]) == 1
+
+
+# ---------------------------------------------------------------------------
+# (b) the decision writes a workspace audit event (this is /activity)
+# ---------------------------------------------------------------------------
+
+
+async def test_approve_writes_an_audit_event(journal, graph) -> None:
+    """Mutation: delete the ``_record_audit_safe`` call in ``_decide`` and the
+    decision vanishes from /activity."""
+    wire = await approvals_service.create_approval(WS_A, USER, _create_body())
+    await approvals_service.approve(WS_A, DECIDER, wire["id"], {})
+
+    from pocketpaw_ee.cloud.audit import service as audit_service
+
+    page = await audit_service.list_events(WS_A, {"action": "instinct_approval.approved"})
+    assert len(page.items) == 1
+    row = page.items[0]
+    assert row.actor_id == DECIDER
+    assert row.target_id == wire["id"]
+    assert row.metadata["correlation_id"] == wire["correlation_id"]
+    assert row.metadata["action_name"] == "refund_customer"
+
+
+async def test_reject_writes_an_audit_event(journal, graph) -> None:
+    wire = await approvals_service.create_approval(WS_A, USER, _create_body())
+    await approvals_service.reject(WS_A, DECIDER, wire["id"], {"note": "no"})
+
+    assert "instinct_approval.rejected" in await _audit_actions(WS_A)
+
+
+# ---------------------------------------------------------------------------
+# (c) creating an approval notifies the workspace owner + admins
+# ---------------------------------------------------------------------------
+
+
+async def test_create_notifies_owner_and_admins(bridge_subscribed) -> None:
+    """Mutation: delete the ``_publish_created_safe`` call in ``create_approval``
+    and an offline owner is never told a decision is waiting."""
+    ids = await _seed_members(WS_A, prefix="alpha")
+
+    wire = await approvals_service.create_approval(WS_A, USER, _create_body())
+
+    for role in ("owner", "admin"):
+        got = await notifications_service.list_for_user(ids[role])
+        assert len(got) == 1, f"{role} must be notified"
+        note = got[0]
+        assert note.kind == "approval_pending"
+        assert note.workspace_id == WS_A
+        assert note.source is not None
+        assert note.source.type == "instinct_action"
+        assert note.source.id == wire["id"]
+        assert note.source.pocket_id == "pocket-1"
+
+    assert await notifications_service.list_for_user(ids["member"]) == [], (
+        "a plain member is not an approver — notifying them is noise, not governance"
+    )
+
+
+async def test_create_does_not_notify_without_the_bridge_registered() -> None:
+    """Control for the test above: with no subscriber nothing is written, which
+    is what makes the mount-wiring pin below meaningful."""
+    ids = await _seed_members(WS_A, prefix="alpha")
+    await approvals_service.create_approval(WS_A, USER, _create_body())
+    assert await notifications_service.list_for_user(ids["owner"]) == []
+
+
+# ---------------------------------------------------------------------------
+# (d) no governance write may break the approval flow
+# ---------------------------------------------------------------------------
+
+
+async def test_notification_failure_does_not_break_create(bridge_subscribed, monkeypatch) -> None:
+    """Mutation: remove the try/except in ``bridges.notifications._create`` and
+    a dead notification sink starts failing approvals."""
+    await _seed_members(WS_A, prefix="alpha")
+
+    async def _boom(**_kwargs):
+        raise RuntimeError("notification sink down")
+
+    monkeypatch.setattr(notifications_service, "create", _boom)
+
+    wire = await approvals_service.create_approval(WS_A, USER, _create_body())
+    assert wire["status"] == "pending"
+    # The row is really there — the approval was not rolled back.
+    assert (await approvals_service.get_approval(WS_A, USER, wire["id"]))["id"] == wire["id"]
+
+
+async def test_one_failing_recipient_does_not_cost_the_others(
+    bridge_subscribed, monkeypatch
+) -> None:
+    """The per-recipient wrap earns its keep here, and ONLY here.
+
+    Every other resilience test in this file is also satisfied by the bus's own
+    handler guard, so none of them can tell whether ``_create``'s try/except
+    exists. This one can: if the first recipient's failure propagates, the
+    fan-out loop aborts and the remaining admins are never notified.
+
+    Mutation: narrow ``bridges.notifications._create``'s ``except Exception``
+    and the second admin loses their notification.
+    """
+    await _seed_members(WS_A, prefix="alpha")
+
+    real_create = notifications_service.create
+    calls = {"n": 0}
+
+    async def _first_call_explodes(**kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("notification sink down for this recipient")
+        return await real_create(**kwargs)
+
+    monkeypatch.setattr(notifications_service, "create", _first_call_explodes)
+
+    await approvals_service.create_approval(WS_A, USER, _create_body())
+
+    assert calls["n"] == 2, "both admins must be attempted"
+
+
+async def test_recipient_lookup_failure_is_contained_inside_the_bridge(monkeypatch) -> None:
+    """Called DIRECTLY, not through the bus, on purpose.
+
+    Through the bus, ``event_bus.emit``'s guard would swallow the exception and
+    the test would pass whether or not ``_workspace_admin_ids`` has its own
+    try/except — a gate nothing can break is a gate nothing proves. Invoking the
+    handler directly removes the outer net.
+
+    Mutation: narrow ``_workspace_admin_ids``'s ``except Exception``.
+    """
+    from pocketpaw_ee.cloud.workspace import service as workspace_service
+
+    async def _boom(_workspace_id):
+        raise RuntimeError("membership query down")
+
+    monkeypatch.setattr(workspace_service, "list_admin_ids", _boom)
+
+    # Must return normally — no exception reaches the caller.
+    await approval_bridge._on_instinct_approval_created(
+        {"workspace_id": WS_A, "id": "approval-1", "pocket_id": "pocket-1"}
+    )
+
+
+async def test_recipient_lookup_failure_does_not_break_create(
+    bridge_subscribed, monkeypatch
+) -> None:
+    from pocketpaw_ee.cloud.workspace import service as workspace_service
+
+    async def _boom(_workspace_id):
+        raise RuntimeError("membership query down")
+
+    monkeypatch.setattr(workspace_service, "list_admin_ids", _boom)
+
+    wire = await approvals_service.create_approval(WS_A, USER, _create_body())
+    assert wire["status"] == "pending"
+
+
+async def test_a_broken_subscriber_does_not_starve_the_next_one() -> None:
+    """A raising subscriber must not cost the approval OR its siblings.
+
+    The sibling half is what pins the bus's own per-handler guard: with the
+    guard narrowed, the first raiser aborts the fan-out loop and the bridge
+    (registered after it) never runs — which is precisely how a notification
+    would go missing without anything looking broken.
+    """
+    seen: list[dict] = []
+
+    async def _boom(_data):
+        raise RuntimeError("subscriber exploded")
+
+    async def _after(data):
+        seen.append(data)
+
+    event_bus.subscribe(approvals_service.CREATED_TOPIC, _boom)
+    event_bus.subscribe(approvals_service.CREATED_TOPIC, _after)
+    try:
+        wire = await approvals_service.create_approval(WS_A, USER, _create_body())
+        assert wire["status"] == "pending"
+        assert len(seen) == 1, "a raising subscriber must not stop the next one"
+        assert seen[0]["id"] == wire["id"]
+    finally:
+        event_bus.unsubscribe(approvals_service.CREATED_TOPIC, _boom)
+        event_bus.unsubscribe(approvals_service.CREATED_TOPIC, _after)
+
+
+async def test_a_bus_level_failure_does_not_break_create(monkeypatch) -> None:
+    """The bus guards its handlers, but nothing guards the bus call itself —
+    that is ``_publish_created_safe``'s job.
+
+    Mutation: narrow ``_publish_created_safe``'s ``except Exception``.
+    """
+
+    async def _boom(_topic, _data):
+        raise RuntimeError("bus down")
+
+    monkeypatch.setattr(event_bus, "emit", _boom)
+
+    wire = await approvals_service.create_approval(WS_A, USER, _create_body())
+    assert wire["status"] == "pending"
+
+
+async def test_journal_failure_does_not_break_decide(journal, graph, monkeypatch) -> None:
+    """Mutation: remove the try/except in ``_safe_chain_emit`` and a
+    Decision-Graph hiccup starts rejecting operators' approvals."""
+    wire = await approvals_service.create_approval(WS_A, USER, _create_body())
+
+    import pocketpaw_ee.cloud.decisions.journal_writer as jw
+
+    def _boom(**_kwargs):
+        raise RuntimeError("journal locked")
+
+    monkeypatch.setattr(jw, "record_human_corrected", _boom)
+    monkeypatch.setattr(jw, "record_decision_completed", _boom)
+
+    out = await approvals_service.approve(WS_A, DECIDER, wire["id"], {})
+    assert out["status"] == "approved"
+    assert (await approvals_service.get_approval(WS_A, USER, wire["id"]))["status"] == "approved"
+
+
+async def test_audit_failure_does_not_break_decide(journal, graph, monkeypatch) -> None:
+    """Mutation: remove the try/except in ``_record_audit_safe``."""
+    wire = await approvals_service.create_approval(WS_A, USER, _create_body())
+
+    from pocketpaw_ee.cloud.audit import service as audit_service
+
+    async def _boom(**_kwargs):
+        raise RuntimeError("audit sink down")
+
+    monkeypatch.setattr(audit_service, "record", _boom)
+
+    out = await approvals_service.approve(WS_A, DECIDER, wire["id"], {})
+    assert out["status"] == "approved"
+
+
+async def test_chain_emit_failure_at_create_does_not_break_create(monkeypatch) -> None:
+    import pocketpaw_ee.cloud.decisions.journal_writer as jw
+
+    def _boom(**_kwargs):
+        raise RuntimeError("journal locked")
+
+    monkeypatch.setattr(jw, "record_agent_proposed", _boom)
+    monkeypatch.setattr(jw, "record_policy_evaluated", _boom)
+
+    wire = await approvals_service.create_approval(WS_A, USER, _create_body())
+    assert wire["status"] == "pending"
+
+
+async def test_decide_survives_a_row_with_no_correlation_id(journal, graph) -> None:
+    """Rows written before T-5 carry ``correlation_id=""``. Deciding one must
+    still work — it simply has no chain to close."""
+    from pocketpaw_ee.cloud.models.instinct_approval import InstinctApproval as _Doc
+
+    wire = await approvals_service.create_approval(WS_A, USER, _create_body())
+    doc = await _Doc.find_one({"workspace": WS_A})
+    doc.correlation_id = ""
+    await doc.save()
+
+    out = await approvals_service.approve(WS_A, DECIDER, wire["id"], {})
+    assert out["status"] == "approved"
+    assert [e for e in journal.replay_from(0) if e.action == "human.corrected"] == []
+
+
+# ---------------------------------------------------------------------------
+# (e) cross-tenant — workspace B learns nothing about workspace A's approval
+# ---------------------------------------------------------------------------
+
+
+async def test_approval_in_workspace_a_never_notifies_workspace_b(bridge_subscribed) -> None:
+    """Mutation: point ``_workspace_admin_ids`` at ``list_member_ids`` for a
+    hard-coded workspace, or drop the workspace filter, and B's owner is paged
+    about A's decision."""
+    a_ids = await _seed_members(WS_A, prefix="alpha")
+    b_ids = await _seed_members(WS_B, prefix="beta")
+
+    await approvals_service.create_approval(WS_A, USER, _create_body())
+
+    assert len(await notifications_service.list_for_user(a_ids["owner"])) == 1
+    for role in ("owner", "admin", "member"):
+        assert await notifications_service.list_for_user(b_ids[role]) == [], (
+            f"workspace B's {role} must not see workspace A's approval"
+        )
+
+
+async def test_decision_in_workspace_a_never_appears_in_workspace_b(journal, graph) -> None:
+    wire = await approvals_service.create_approval(WS_A, USER, _create_body())
+    corr = UUID(wire["correlation_id"])
+    await approvals_service.approve(WS_A, DECIDER, wire["id"], {})
+
+    # Audit: the row is filed under A only.
+    assert "instinct_approval.approved" in await _audit_actions(WS_A)
+    assert await _audit_actions(WS_B) == []
+
+    # Chain: every event is scoped to A, which is what the projection's
+    # visibility filter intersects against a requester's scopes.
+    for entry in _chain(journal, corr):
+        assert f"workspace:{WS_A}" in entry.scope
+        assert f"workspace:{WS_B}" not in entry.scope
+        assert f"workspace:{WS_B}" not in entry.actor.scope_context
+
+
+async def test_a_workspace_b_decider_cannot_decide_a_workspace_a_approval(journal, graph) -> None:
+    """Pre-existing tenancy guard, re-pinned here because the new journal +
+    audit writes now hang off the decide path — a leak would forge governance
+    records in the victim's workspace, not just flip a row."""
+    from pocketpaw_ee.cloud._core.errors import NotFound
+
+    wire = await approvals_service.create_approval(WS_A, USER, _create_body())
+
+    with pytest.raises(NotFound):
+        await approvals_service.approve(WS_B, DECIDER, wire["id"], {})
+
+    assert await _audit_actions(WS_B) == []
+    assert [e for e in journal.replay_from(0) if e.action == "human.corrected"] == []
+
+
+# ---------------------------------------------------------------------------
+# wiring — mount_cloud really subscribes the bridge
+# ---------------------------------------------------------------------------
+
+
+def test_mount_cloud_subscribes_the_approval_notification_bridge(journal, graph) -> None:
+    """Every other test here self-registers the bridge, so deleting the
+    ``mount_cloud`` registration would leave the suite green and the feature
+    dead in production. This asserts the real handler is subscribed to the real
+    topic AFTER mount.
+
+    Mutation: remove the
+    ``register_instinct_approval_notification_listeners()`` call from
+    ``ee/pocketpaw_ee/cloud/__init__.py`` — this test fails.
+
+    It takes ``journal`` + ``graph`` for HERMETICITY, not for the assertion:
+    ``mount_cloud`` runs ``init_decisions_projection(rebuild_from_journal=True)``,
+    which without those fixtures replays the DEVELOPER'S real
+    ``~/.soul/journal.db`` from seq 0 (this test measured 416s that way against
+    5s with them — and it was reading a real machine's journal to do it).
+    """
+    from fastapi import FastAPI
+    from pocketpaw_ee.cloud import mount_cloud
+
+    before = list(event_bus._handlers.get(approvals_service.CREATED_TOPIC, []))
+    try:
+        mount_cloud(FastAPI())
+        handlers = event_bus._handlers.get(approvals_service.CREATED_TOPIC, [])
+        assert approval_bridge._on_instinct_approval_created in handlers, (
+            "mount_cloud must subscribe the approval → notification bridge"
+        )
+    finally:
+        event_bus._handlers[approvals_service.CREATED_TOPIC] = before

--- a/tests/cloud/test_instinct_approvals_governance.py
+++ b/tests/cloud/test_instinct_approvals_governance.py
@@ -190,6 +190,58 @@ async def test_approve_writes_a_journal_chain_joinable_by_correlation_id(journal
     assert any(a.actor.id == f"user:{DECIDER}" for a in decisions[0].approvers)
 
 
+async def test_approved_decision_reads_policy_passed(journal, graph) -> None:
+    """An APPROVED template approval must not read as blocked forever.
+
+    The projection keeps the LAST ``policy.evaluated`` before the terminal
+    (``_fold_policy``, last-seen-wins), and create's honest ``passed=False``
+    encodes "template escalated to human". Without the approve-side
+    ``passed=True`` flip, the explain narrator says the gate "blocked at
+    decision time" for a decision a human explicitly cleared, and the
+    outcome-hint ranker files it under the rejected hint. fail→pass is the
+    projection's own encoding of "asked for human → human approved", and the
+    row-level approve path emits the same flip.
+
+    Mutation: drop the ``record_policy_evaluated`` flip in ``_close_chain``.
+    """
+    wire = await approvals_service.create_approval(WS_A, USER, _create_body())
+    corr = UUID(wire["correlation_id"])
+    await approvals_service.approve(WS_A, DECIDER, wire["id"], {})
+
+    # The chain carries the full fail→pass arc for the narrator...
+    policy_events = [e for e in _chain(journal, corr) if e.action == "policy.evaluated"]
+    assert [bool(e.payload.get("passed")) for e in policy_events] == [False, True]
+    assert policy_events[-1].payload["policy"] == "template_instinct_gate"
+    assert policy_events[-1].payload["reason"] == "approved_by_human"
+
+    # ...and the folded Decision row reads as passed, not blocked.
+    decision = next(d for d in graph.store.iter_decisions() if d.correlation_id == corr)
+    assert decision.instinct_policy_passed is True, (
+        "an approved template approval must not read as policy-blocked"
+    )
+
+
+async def test_rejected_decision_reads_policy_failed(journal, graph) -> None:
+    """The flip is approve-only: on reject, create's ``passed=False`` stands,
+    which IS the correct final policy state for a rejection.
+
+    Mutation: make ``_close_chain`` emit the flip unconditionally (``approved
+    = True``) — this asserts a rejected Decision would then wrongly read
+    passed.
+    """
+    wire = await approvals_service.create_approval(WS_A, USER, _create_body())
+    corr = UUID(wire["correlation_id"])
+    await approvals_service.reject(WS_A, DECIDER, wire["id"], {"note": "no"})
+
+    policy_events = [e for e in _chain(journal, corr) if e.action == "policy.evaluated"]
+    assert [bool(e.payload.get("passed")) for e in policy_events] == [False]
+
+    decision = next(d for d in graph.store.iter_decisions() if d.correlation_id == corr)
+    assert decision.instinct_policy_passed is False, (
+        "a rejected template approval must keep reading as policy-blocked"
+    )
+
+
 async def test_reject_closes_the_chain_as_rejected(journal, graph) -> None:
     wire = await approvals_service.create_approval(WS_A, USER, _create_body())
     corr = UUID(wire["correlation_id"])

--- a/tests/mutations/instinct_approval_governance.json
+++ b/tests/mutations/instinct_approval_governance.json
@@ -28,10 +28,17 @@
     "tests": ["tests/cloud/test_instinct_approvals_governance.py"]
   },
   {
-    "label": "chain: a reject closes the chain as passed",
+    "label": "chain: a reject closes the chain as passed (and flips policy)",
     "file": "ee/pocketpaw_ee/cloud/instinct_approvals/service.py",
     "find": "    approved = new_status == \"approved\"",
     "replace": "    approved = True",
+    "tests": ["tests/cloud/test_instinct_approvals_governance.py"]
+  },
+  {
+    "label": "chain: approve never flips policy to passed (approved reads blocked)",
+    "file": "ee/pocketpaw_ee/cloud/instinct_approvals/service.py",
+    "find": "        _safe_chain_emit(\n            record_policy_evaluated,",
+    "replace": "        _never = lambda **_k: _safe_chain_emit(\n            record_policy_evaluated,",
     "tests": ["tests/cloud/test_instinct_approvals_governance.py"]
   },
   {

--- a/tests/mutations/instinct_approval_governance.json
+++ b/tests/mutations/instinct_approval_governance.json
@@ -1,0 +1,135 @@
+[
+  {
+    "label": "chain: create never opens the chain (agent.proposed dropped)",
+    "file": "ee/pocketpaw_ee/cloud/instinct_approvals/service.py",
+    "find": "    proposed_id = _safe_chain_emit(\n        record_agent_proposed,",
+    "replace": "    proposed_id = None\n    _never = lambda **_k: _safe_chain_emit(\n        record_agent_proposed,",
+    "tests": ["tests/cloud/test_instinct_approvals_governance.py"]
+  },
+  {
+    "label": "chain: decide never closes the chain (decision.completed dropped)",
+    "file": "ee/pocketpaw_ee/cloud/instinct_approvals/service.py",
+    "find": "    _safe_chain_emit(\n        record_decision_completed,",
+    "replace": "    _never = lambda **_k: _safe_chain_emit(\n        record_decision_completed,",
+    "tests": ["tests/cloud/test_instinct_approvals_governance.py"]
+  },
+  {
+    "label": "chain: decide never records the human (human.corrected dropped)",
+    "file": "ee/pocketpaw_ee/cloud/instinct_approvals/service.py",
+    "find": "    human_event_id = _safe_chain_emit(\n        record_human_corrected,",
+    "replace": "    human_event_id = None\n    _never = lambda **_k: _safe_chain_emit(\n        record_human_corrected,",
+    "tests": ["tests/cloud/test_instinct_approvals_governance.py"]
+  },
+  {
+    "label": "chain: create mints no correlation_id",
+    "file": "ee/pocketpaw_ee/cloud/instinct_approvals/service.py",
+    "find": "        correlation_id=str(correlation_id),",
+    "replace": "        correlation_id=\"\",",
+    "tests": ["tests/cloud/test_instinct_approvals_governance.py"]
+  },
+  {
+    "label": "chain: a reject closes the chain as passed",
+    "file": "ee/pocketpaw_ee/cloud/instinct_approvals/service.py",
+    "find": "    approved = new_status == \"approved\"",
+    "replace": "    approved = True",
+    "tests": ["tests/cloud/test_instinct_approvals_governance.py"]
+  },
+  {
+    "label": "audit: the decision writes no workspace audit row",
+    "file": "ee/pocketpaw_ee/cloud/instinct_approvals/service.py",
+    "find": "    await _record_audit_safe(\n        workspace_id=workspace_id,",
+    "replace": "    _never = lambda **_k: _record_audit_safe(\n        workspace_id=workspace_id,",
+    "tests": ["tests/cloud/test_instinct_approvals_governance.py"]
+  },
+  {
+    "label": "audit: the row is filed under the wrong action name",
+    "file": "ee/pocketpaw_ee/cloud/instinct_approvals/service.py",
+    "find": "            action=f\"instinct_approval.{new_status}\",",
+    "replace": "            action=\"instinct_approval.decided\",",
+    "tests": ["tests/cloud/test_instinct_approvals_governance.py"]
+  },
+  {
+    "label": "audit: the actor is the requester, not the decider",
+    "file": "ee/pocketpaw_ee/cloud/instinct_approvals/service.py",
+    "find": "            actor_id=user_id or \"unknown\",",
+    "replace": "            actor_id=approval.requested_by or \"unknown\",",
+    "tests": ["tests/cloud/test_instinct_approvals_governance.py"]
+  },
+  {
+    "label": "notify: create never publishes to the notification bridge",
+    "file": "ee/pocketpaw_ee/cloud/instinct_approvals/service.py",
+    "find": "    await _publish_created_safe(dict(wire))",
+    "replace": "    _never = lambda: _publish_created_safe(dict(wire))",
+    "tests": ["tests/cloud/test_instinct_approvals_governance.py"]
+  },
+  {
+    "label": "notify: the bridge notifies every member, not just owner+admins",
+    "file": "ee/pocketpaw_ee/cloud/instinct_approvals/bridges/notifications.py",
+    "find": "        return await workspace_service.list_admin_ids(workspace_id)",
+    "replace": "        return await workspace_service.list_member_ids(workspace_id)",
+    "tests": ["tests/cloud/test_instinct_approvals_governance.py"]
+  },
+  {
+    "label": "tenancy: the bridge resolves recipients from a fixed workspace",
+    "file": "ee/pocketpaw_ee/cloud/instinct_approvals/bridges/notifications.py",
+    "find": "    recipients = await _workspace_admin_ids(str(workspace_id))",
+    "replace": "    recipients = await _workspace_admin_ids(\"ws-beta\")",
+    "tests": ["tests/cloud/test_instinct_approvals_governance.py"]
+  },
+  {
+    "label": "notify: the notification loses its source pointer",
+    "file": "ee/pocketpaw_ee/cloud/instinct_approvals/bridges/notifications.py",
+    "find": "            source=NotificationSource(type=\"instinct_action\", id=approval_id, pocket_id=pocket_id),",
+    "replace": "            source=None,",
+    "tests": ["tests/cloud/test_instinct_approvals_governance.py"]
+  },
+  {
+    "label": "resilience: a dead notification sink breaks the approval",
+    "file": "ee/pocketpaw_ee/cloud/instinct_approvals/bridges/notifications.py",
+    "find": "    except Exception:\n        logger.exception(\n            \"Failed to create approval_pending notification for approval=%s\", approval_id\n        )",
+    "replace": "    except TypeError:\n        logger.exception(\n            \"Failed to create approval_pending notification for approval=%s\", approval_id\n        )",
+    "tests": ["tests/cloud/test_instinct_approvals_governance.py"]
+  },
+  {
+    "label": "resilience: a broken membership query breaks the approval",
+    "file": "ee/pocketpaw_ee/cloud/instinct_approvals/bridges/notifications.py",
+    "find": "    except Exception:\n        logger.exception(\"Failed to list admins for workspace=%s\", workspace_id)\n        return []",
+    "replace": "    except TypeError:\n        logger.exception(\"Failed to list admins for workspace=%s\", workspace_id)\n        return []",
+    "tests": ["tests/cloud/test_instinct_approvals_governance.py"]
+  },
+  {
+    "label": "resilience: a journal failure breaks the decision",
+    "file": "ee/pocketpaw_ee/cloud/instinct_approvals/service.py",
+    "find": "    except Exception:  # noqa: BLE001 — chain emit is best-effort by contract",
+    "replace": "    except TypeError:",
+    "tests": ["tests/cloud/test_instinct_approvals_governance.py"]
+  },
+  {
+    "label": "resilience: an audit failure breaks the decision",
+    "file": "ee/pocketpaw_ee/cloud/instinct_approvals/service.py",
+    "find": "    except Exception:  # noqa: BLE001 — audit must never break the decision",
+    "replace": "    except TypeError:",
+    "tests": ["tests/cloud/test_instinct_approvals_governance.py"]
+  },
+  {
+    "label": "resilience: a raising subscriber starves the next one",
+    "file": "ee/pocketpaw_ee/cloud/shared/events.py",
+    "find": "            try:\n                await handler(data)\n            except Exception:",
+    "replace": "            try:\n                await handler(data)\n            except TypeError:",
+    "tests": ["tests/cloud/test_instinct_approvals_governance.py"]
+  },
+  {
+    "label": "resilience: a bus-level failure breaks the approval",
+    "file": "ee/pocketpaw_ee/cloud/instinct_approvals/service.py",
+    "find": "    except Exception:  # noqa: BLE001 — fan-out must never break create",
+    "replace": "    except TypeError:",
+    "tests": ["tests/cloud/test_instinct_approvals_governance.py"]
+  },
+  {
+    "label": "wiring: mount_cloud stops registering the bridge",
+    "file": "ee/pocketpaw_ee/cloud/__init__.py",
+    "find": "    register_instinct_approval_notification_listeners()",
+    "replace": "    _never = register_instinct_approval_notification_listeners",
+    "tests": ["tests/cloud/test_instinct_approvals_governance.py"]
+  }
+]


### PR DESCRIPTION
A template-level approval authorizes whole classes of future writes — the highest-leverage governance act in the product — and until now it was invisible everywhere. _decide saved the Mongo doc, emitted an ephemeral websocket event, and that was the whole record: nothing on /decisions, nothing on /activity, no audit row, and an owner who was offline when the approval was requested never learned it existed.

Now:

- Approvals carry a correlation_id minted at create, which opens a decision chain (agent.proposed plus a policy.evaluated recording why the template escalated to a human). Deciding closes it: human.corrected, then a policy flip to passed on approval, then the terminal decision.completed. An approved template reads as approved in the explain surfaces; a rejected one keeps its honest blocked state. auto_approve rows deliberately carry no chain — there is no human decision to record.
- Deciding writes an instinct_approval.approved/rejected audit row, so the decision shows on /activity.
- Creating one notifies the workspace owner and admins with a persisted notification, via a bridge shaped like the meetings and leads ones, registered at mount and pinned by a test (deleting the registration fails the suite).
- Failure isolation is layered so nothing here can break the approval flow itself: the save completes before any emit, and the chain writes, audit write, and each recipient's notification are wrapped separately. Every wrapper logs; nothing is silently swallowed.

Worth an honest note on how this diverged from its brief. The original instruction was to mirror the row-level path's journal+audit pair. That pair alone never reaches /decisions — the projection only materializes a Decision on a terminal event, and it drops chains that never saw a propose. The row-level path works because its propose site emits that event; the template path had no propose site at all. So this PR emits the full chain rather than the pair, and the review verified that reading of the projection line by line before agreeing.

Tests: 41 across governance and the approvals service, plus a 20-mutation plan — all caught, including dropping any single emit, mis-attributing the audit actor, notifying all members instead of admins, and deleting the mount registration. The first mutation pass had three escapes because the resilience wrappers masked each other; the tests were restructured to isolate each layer, which is why the plan is trustworthy now.

Known limits, tracked separately rather than snuck in here: notifications only fire in the web process (the arq worker never calls mount_cloud — true of the meetings and leads bridges too); the SQLite runtime-audit mirror is absent on this path; bulk parks produce one notification per row with no digest.