### PR TITLE
fix(tools): workspace-scope the builtin Fabric and Instinct tools

### DIFF
--- a/ee/pocketpaw_ee/cloud/shared/agent_bridge.py
+++ b/ee/pocketpaw_ee/cloud/shared/agent_bridge.py
@@ -473,6 +473,7 @@ async def _run_agent_response(
         attach_delivered_artifacts_collector,
         detach_agent_identity,
         detach_delivered_artifacts_collector,
+        mark_cloud_chat_run,
     )
 
     pool = get_agent_pool()
@@ -551,6 +552,17 @@ async def _run_agent_response(
     # it, so every ContextVar-scoped tool returned "requires workspace context
     # (call from a cloud chat session)". ``user_id`` is the agent itself — it is
     # the actor on this path, matching the cloud MCP tests' setup.
+    # C4-a: mark this as a live cloud run BEFORE identity is bound, exactly as
+    # ``run_core.execute_run`` does on the SSE path. The marker is what the
+    # builtin Fabric/Instinct tools key their fail-closed on, so without it this
+    # whole cloud path read False and a run that somehow reached here without a
+    # workspace would fall back to unscoped access instead of refusing. Today
+    # ``attach_agent_identity`` raises on an empty workspace, so the invariant
+    # already held — but by a separate accident, not by the guard. Entered
+    # manually (not via ``with``) to pair with the explicit attach/detach tokens
+    # around it; released in the same ``finally``.
+    cloud_run_marker = mark_cloud_chat_run()
+    cloud_run_marker.__enter__()
     identity_tokens = attach_agent_identity(workspace_id=workspace_id, user_id=agent_id)
     # ART-1: bind a per-run collector so a ``deliver_artifact`` call on THIS
     # (group/DM) path lands a ``{type:"artifact", meta}`` attachment on the agent
@@ -619,6 +631,7 @@ async def _run_agent_response(
     finally:
         detach_agent_identity(identity_tokens)
         detach_delivered_artifacts_collector(delivered_token)
+        cloud_run_marker.__exit__(None, None, None)
 
     if saw_error_event and not full_text.strip():
         details = f": {error_summary}" if error_summary else ""

--- a/ee/pocketpaw_ee/instinct/router.py
+++ b/ee/pocketpaw_ee/instinct/router.py
@@ -2243,7 +2243,8 @@ async def approve_action(
                 context_summary=summarize_correction(before, patches),
                 action_title=before.title,
             )
-            await store.record_correction(correction)
+            # C4-a: stamp the tenant so the corrections read filter is real.
+            await store.record_correction(correction, workspace_id=workspace_id)
             await _persist_edits(store, after, edited_fields)
             await _forward_to_soul(correction, after, workspace_id)
 
@@ -3155,7 +3156,8 @@ async def edit_proposal(
             context_summary=summarize_correction(before, patches),
             action_title=before.title,
         )
-        await store.record_correction(correction)
+        # C4-a: stamp the tenant so the corrections read filter is real.
+        await store.record_correction(correction, workspace_id=workspace_id)
         await _forward_to_soul(correction, after, workspace_id)
 
     note = correction.context_summary if correction is not None else None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -626,6 +626,14 @@ ignore_imports = [
     "pocketpaw.tools.builtin.library_verbs -> pocketpaw_ee.cloud._core.realtime.events",
     "pocketpaw.tools.builtin.library_verbs -> pocketpaw_ee.cloud.file_versions.service",
     "pocketpaw.tools.builtin.library_verbs -> pocketpaw_ee.cloud.agents.knowledge",
+    # C4-a builtin Fabric/Instinct tenancy: the shared _tenancy helper resolves
+    # the caller's workspace from the cloud chat stream's identity ContextVars
+    # and reads the per-run fail-closed marker (current_cloud_chat_run). Both
+    # reaches are lazy try/except runtime imports INSIDE functions — the module
+    # top level imports only OSS (logging), and on a community install both
+    # resolve to None/False so the Fabric + Instinct tools keep their legacy
+    # unscoped single-tenant behavior. Same pattern as library_verbs above.
+    "pocketpaw.tools.builtin._tenancy -> pocketpaw_ee.cloud.chat.agent_service",
     # FL-5 structural edit tools (port of dewani12's #1193): the edit_document /
     # edit_slides / edit_spreadsheet tools live in the OSS builtin tools package
     # (registered via _EE_TOOLS, guarded by ee/ availability) but edit a cloud

--- a/src/pocketpaw/fabric/store.py
+++ b/src/pocketpaw/fabric/store.py
@@ -649,8 +649,12 @@ def _workspace_scope(
 
     Returns ``(condition, params)``:
 
-    - ``workspace_id is None`` -> ``(None, [])`` — no scoping. OSS / agent-tool
-      callers that don't carry a workspace see everything, exactly as before.
+    - ``workspace_id is None`` -> ``(None, [])`` — no scoping. Callers that
+      don't carry a workspace (OSS single-tenant, CLI, background jobs) see
+      everything, exactly as before. As of C4-a the builtin agent tools are NO
+      LONGER in that group whenever a workspace is in context: they resolve the
+      caller's tenant and pass it, matching their MCP siblings. They reach this
+      branch only on a genuinely workspace-less run.
     - a concrete workspace -> ``("(<col> = ? OR <col> IS NULL)", [workspace_id])``
       — the caller's own rows PLUS legacy/global NULL-workspace rows that predate
       tenancy (see the module-header note on the legacy boundary). The value is

--- a/src/pocketpaw/instinct/store.py
+++ b/src/pocketpaw/instinct/store.py
@@ -469,7 +469,8 @@ CREATE TABLE IF NOT EXISTS instinct_corrections (
     patches TEXT NOT NULL,
     context_summary TEXT NOT NULL,
     action_title TEXT NOT NULL,
-    created_at TEXT DEFAULT (datetime('now'))
+    created_at TEXT DEFAULT (datetime('now')),
+    workspace_id TEXT
 );
 
 CREATE TABLE IF NOT EXISTS instinct_fabric_snapshots (
@@ -499,6 +500,7 @@ CREATE INDEX IF NOT EXISTS idx_snapshots_object ON instinct_fabric_snapshots(obj
 _WORKSPACE_INDEX_SQL = (
     "CREATE INDEX IF NOT EXISTS idx_actions_workspace ON instinct_actions(workspace_id)",
     "CREATE INDEX IF NOT EXISTS idx_audit_workspace ON instinct_audit(workspace_id)",
+    "CREATE INDEX IF NOT EXISTS idx_corrections_workspace ON instinct_corrections(workspace_id)",
 )
 
 # Generic-scope index (BP-3). Created AFTER the ALTER that adds scope_type for
@@ -568,7 +570,10 @@ class InstinctStore:
             # (legacy/global; a scoped read still sees them — see the header).
             # The audit ALTER is a READ-FILTER column ONLY: workspace_id is not
             # part of the canonical hash payload, so the W2b chain is untouched.
-            for _tbl in ("instinct_actions", "instinct_audit"):
+            # C4-a adds ``instinct_corrections`` to the same list: the
+            # corrections table shipped without tenancy, so the agent-facing
+            # instinct_corrections tool read it with a pocket_id filter only.
+            for _tbl in ("instinct_actions", "instinct_audit", "instinct_corrections"):
                 try:
                     await db.execute(f"ALTER TABLE {_tbl} ADD COLUMN workspace_id TEXT")
                 except aiosqlite.OperationalError:
@@ -1636,15 +1641,25 @@ class InstinctStore:
 
     # --- Corrections ---
 
-    async def record_correction(self, correction: Correction) -> Correction:
-        """Persist a Correction and log the event to the audit table."""
+    async def record_correction(
+        self, correction: Correction, workspace_id: str | None = None
+    ) -> Correction:
+        """Persist a Correction and log the event to the audit table.
+
+        ``workspace_id`` (C4-a) stamps the owning tenant. It is load-bearing for
+        the read filter, not decorative: ``_workspace_scope`` treats a NULL row
+        as legacy/global and returns it to EVERY tenant's scoped read, so a
+        corrections table nobody stamps makes ``get_corrections_for_pocket``'s
+        scoping a no-op. ``None`` keeps the legacy unscoped write for OSS /
+        single-tenant callers.
+        """
         await self._ensure_schema()
         async with self._conn() as db:
             await db.execute(
                 "INSERT INTO instinct_corrections"
                 " (id, action_id, pocket_id, actor, patches,"
-                " context_summary, action_title, created_at)"
-                " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                " context_summary, action_title, created_at, workspace_id)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     correction.id,
                     correction.action_id,
@@ -1654,6 +1669,7 @@ class InstinctStore:
                     correction.context_summary,
                     correction.action_title,
                     correction.created_at.isoformat(),
+                    workspace_id,
                 ),
             )
             await db.commit()
@@ -1673,16 +1689,28 @@ class InstinctStore:
         return correction
 
     async def get_corrections_for_pocket(
-        self, pocket_id: str, limit: int = 100
+        self, pocket_id: str, limit: int = 100, workspace_id: str | None = None
     ) -> list[Correction]:
+        """Recent corrections on a pocket, optionally scoped to a tenant (C4-a).
+
+        ``workspace_id`` is a READ FILTER with the same semantics as ``pending``
+        / ``query_audit``: the caller's own rows plus legacy NULL-workspace
+        rows. Before C4-a this method filtered on ``pocket_id`` ALONE, so the
+        agent-facing ``instinct_corrections`` tool could read any pocket id's
+        corrections on a shared file with no tenant filter whatsoever.
+        """
+        sql = "SELECT * FROM instinct_corrections WHERE pocket_id = ?"
+        params: list[Any] = [pocket_id]
+        ws_cond, ws_params = _workspace_scope(workspace_id)
+        if ws_cond:
+            sql += f" AND {ws_cond}"
+            params.extend(ws_params)
+        sql += " ORDER BY created_at DESC LIMIT ?"
+        params.append(limit)
         await self._ensure_schema()
         async with self._conn() as db:
             db.row_factory = aiosqlite.Row
-            async with db.execute(
-                "SELECT * FROM instinct_corrections"
-                " WHERE pocket_id = ? ORDER BY created_at DESC LIMIT ?",
-                (pocket_id, limit),
-            ) as cur:
+            async with db.execute(sql, params) as cur:
                 return [self._row_to_correction(row) async for row in cur]
 
     async def get_corrections_for_action(self, action_id: str) -> list[Correction]:

--- a/src/pocketpaw/instinct/store.py
+++ b/src/pocketpaw/instinct/store.py
@@ -381,9 +381,12 @@ def _workspace_scope(workspace_id: str | None) -> tuple[str | None, list[Any]]:
 
     Returns ``(condition, params)``:
 
-    - ``workspace_id is None`` -> ``(None, [])`` — no scoping. OSS / agent-tool
-      callers that don't carry a workspace see everything, exactly as before
-      W4a.
+    - ``workspace_id is None`` -> ``(None, [])`` — no scoping. Callers that
+      don't carry a workspace (OSS single-tenant, CLI, background jobs) see
+      everything, exactly as before W4a. As of C4-a the builtin agent tools are
+      NO LONGER in that group whenever a workspace is in context: they resolve
+      the caller's tenant and pass it, matching their MCP siblings. They reach
+      this branch only on a genuinely workspace-less run.
     - a concrete workspace -> ``("(workspace_id = ? OR workspace_id IS NULL)",
       [workspace_id])`` — the caller's own rows PLUS legacy/global
       NULL-workspace rows that predate tenancy (see the module header). The

--- a/src/pocketpaw/tools/builtin/_tenancy.py
+++ b/src/pocketpaw/tools/builtin/_tenancy.py
@@ -39,11 +39,12 @@
 # backend without binding identity, the real mis-tenanting bug, still trips
 # the guard).
 #
-# EE→OSS boundary: this module lives in OSS core and imports ``pocketpaw_ee``
-# only lazily, inside try/except, exactly like the sibling ``library_verbs.py``
-# / ``edit_document.py`` resolvers. A community install without the enterprise
-# package resolves ``None`` for both signals and keeps its legacy unscoped
-# behavior.
+# EE→OSS boundary: this module lives in OSS core. Workspace resolution reads
+# the OSS-core ContextVar only — no EE import at all. The single EE reach is
+# ``is_tenant_scoped_run``'s lazy import of the run marker, inside a narrow
+# ``except ImportError``, exactly like the sibling ``library_verbs.py`` /
+# ``edit_document.py`` resolvers. A community install without the enterprise
+# package gets ``False`` there and keeps its legacy unscoped behavior.
 
 from __future__ import annotations
 
@@ -61,35 +62,22 @@ __all__ = [
 def current_workspace() -> str | None:
     """Resolve the active workspace for this run, or ``None``.
 
-    Resolution order — both sources are set together by
-    ``attach_agent_identity``, so they agree whenever a cloud chat stream is
-    live; the fallback covers a pure-OSS process (connector ingest, tests)
-    that sets only the core ContextVar:
+    Reads the OSS-core ``pocketpaw.stores.current_workspace`` ContextVar and
+    nothing else. This deliberately does NOT also consult EE's
+    ``current_workspace_id()``: ``attach_agent_identity`` is the only setter of
+    either var and it sets BOTH in one return tuple, so an EE branch here would
+    be unreachable-by-construction — no test could distinguish its presence from
+    its absence, which makes it untestable weight rather than defense in depth.
+    Reading the in-package var also keeps this function free of any EE import.
 
-        EE per-stream agent identity  →  OSS ``stores.current_workspace``
-
-    A blank / whitespace-only value from either source is treated as "no
-    workspace" so an empty string can never satisfy the fail-closed check nor
-    be stamped onto a row.
+    A blank / whitespace-only value is treated as "no workspace" so an empty
+    string can never satisfy the fail-closed check nor be stamped onto a row.
     """
-    try:
-        from pocketpaw_ee.cloud.chat.agent_service import current_workspace_id
+    from pocketpaw.stores import current_workspace as _oss_current_workspace
 
-        candidate = current_workspace_id()
-        if candidate and candidate.strip():
-            return candidate.strip()
-    except Exception:  # noqa: BLE001 — no EE package, or no live stream
-        pass
-
-    try:
-        from pocketpaw.stores import current_workspace as _oss_current_workspace
-
-        candidate = _oss_current_workspace.get()
-        if candidate and candidate.strip():
-            return candidate.strip()
-    except Exception:  # noqa: BLE001 — defensive; the import is in-package
-        logger.debug("OSS workspace ContextVar unreadable", exc_info=True)
-
+    candidate = _oss_current_workspace.get()
+    if candidate and candidate.strip():
+        return candidate.strip()
     return None
 
 
@@ -105,13 +93,19 @@ def is_tenant_scoped_run() -> bool:
 
     Absent the EE package or outside a chat run, this is ``False`` and the
     tools keep their legacy unscoped behavior.
+
+    The except is narrowed to ``ImportError`` on purpose: this default is
+    fail-OPEN (``False`` means "no workspace needed"), so it must only fire for
+    the one condition it is meant to cover — the enterprise package, or that
+    symbol, not being installed. Swallowing every exception here would turn an
+    unrelated bug inside ``current_cloud_chat_run`` into a silently disabled
+    guard.
     """
     try:
         from pocketpaw_ee.cloud.chat.agent_service import current_cloud_chat_run
-
-        return bool(current_cloud_chat_run())
-    except Exception:  # noqa: BLE001 — no EE package / older EE build
+    except ImportError:  # no EE package / older EE build without the marker
         return False
+    return bool(current_cloud_chat_run())
 
 
 def workspace_required_message(tool_name: str) -> str:

--- a/src/pocketpaw/tools/builtin/_tenancy.py
+++ b/src/pocketpaw/tools/builtin/_tenancy.py
@@ -1,0 +1,126 @@
+# _tenancy.py — workspace resolution + fail-closed guard for the BUILTIN
+#   Fabric / Instinct agent tools.
+# Created: 2026-08-06 (C4-a — builtin MCP tools: stop cross-tenant leakage).
+#
+# Why this exists: the in-process MCP servers
+# (``ee/pocketpaw_ee/agent/mcp_servers/{fabric,instinct}.py``) resolve the
+# caller's tenant from the per-stream agent identity ContextVars and pass
+# ``workspace_id=`` into every store call, so an agent on the claude_agent_sdk
+# backend can neither read nor stamp another tenant's rows. Their BUILTIN
+# (BaseTool) siblings — the only Fabric/Instinct path the NON-SDK backends
+# (deep_agents, google_adk, openai_agents) ever see — passed NO workspace at
+# all. Two consequences, both live:
+#
+#   * every write landed with ``workspace_id = NULL``. That is not merely
+#     "unscoped": ``_workspace_scope()`` (instinct/store.py, fabric/store.py)
+#     renders a scoped read as ``(workspace_id = ? OR workspace_id IS NULL)``
+#     for W4a legacy compatibility, so a NULL row is ACTIVELY RETURNED to
+#     every tenant's scoped query against that database file. An Action
+#     proposed through ``instinct_propose`` surfaced in other tenants'
+#     approval queues.
+#   * every read ran unfiltered, so a query saw whatever rows shared the file.
+#
+# ISO-1/ISO-2 physical per-workspace files (``~/.pocketpaw/workspaces/<id>/``)
+# reduce the blast radius when a workspace IS in context, but they do not fix
+# either half: the row still lands NULL inside the tenant's own file, and when
+# NO workspace resolves and ``POCKETPAW_REQUIRE_WORKSPACE_SCOPE`` is unset the
+# factory hands back the SHARED legacy file — where a NULL row is visible to
+# every tenant that reads it.
+#
+# The fail-closed marker, and why it is NOT a process-global: refusing whenever
+# a workspace is missing would break every legitimate workspace-less run (OSS
+# self-hosted, CLI, background jobs, automations). Gating on a process-global
+# such as ``is_multi_tenant_cloud()`` is the specific mistake that turned dev
+# red in #1570 — it is true whenever the cloud Mongo client is connected, so it
+# fires for every unrelated run in the process. We key on the POSITIVE per-run
+# marker ``current_cloud_chat_run()`` instead (added by fix/cloud-artifacts-
+# reland for exactly this distinction, and set by ``run_core.execute_run`` via
+# ``mark_cloud_chat_run`` BEFORE identity is bound — so a run that reaches the
+# backend without binding identity, the real mis-tenanting bug, still trips
+# the guard).
+#
+# EE→OSS boundary: this module lives in OSS core and imports ``pocketpaw_ee``
+# only lazily, inside try/except, exactly like the sibling ``library_verbs.py``
+# / ``edit_document.py`` resolvers. A community install without the enterprise
+# package resolves ``None`` for both signals and keeps its legacy unscoped
+# behavior.
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "current_workspace",
+    "is_tenant_scoped_run",
+    "workspace_required_message",
+]
+
+
+def current_workspace() -> str | None:
+    """Resolve the active workspace for this run, or ``None``.
+
+    Resolution order — both sources are set together by
+    ``attach_agent_identity``, so they agree whenever a cloud chat stream is
+    live; the fallback covers a pure-OSS process (connector ingest, tests)
+    that sets only the core ContextVar:
+
+        EE per-stream agent identity  →  OSS ``stores.current_workspace``
+
+    A blank / whitespace-only value from either source is treated as "no
+    workspace" so an empty string can never satisfy the fail-closed check nor
+    be stamped onto a row.
+    """
+    try:
+        from pocketpaw_ee.cloud.chat.agent_service import current_workspace_id
+
+        candidate = current_workspace_id()
+        if candidate and candidate.strip():
+            return candidate.strip()
+    except Exception:  # noqa: BLE001 — no EE package, or no live stream
+        pass
+
+    try:
+        from pocketpaw.stores import current_workspace as _oss_current_workspace
+
+        candidate = _oss_current_workspace.get()
+        if candidate and candidate.strip():
+            return candidate.strip()
+    except Exception:  # noqa: BLE001 — defensive; the import is in-package
+        logger.debug("OSS workspace ContextVar unreadable", exc_info=True)
+
+    return None
+
+
+def is_tenant_scoped_run() -> bool:
+    """True when this run MUST carry a workspace — the fail-closed trigger.
+
+    A POSITIVE per-run marker, never a process-global: ``current_cloud_chat_run``
+    is set by ``run_core.execute_run`` for the duration of one cloud chat
+    dispatch and reset in a finally, so it distinguishes "a chat run that
+    should have bound a tenant" from "a legitimately workspace-less run in a
+    cloud-connected process" (CLI, background job, direct backend test). See
+    the module header for why ``is_multi_tenant_cloud()`` is the wrong signal.
+
+    Absent the EE package or outside a chat run, this is ``False`` and the
+    tools keep their legacy unscoped behavior.
+    """
+    try:
+        from pocketpaw_ee.cloud.chat.agent_service import current_cloud_chat_run
+
+        return bool(current_cloud_chat_run())
+    except Exception:  # noqa: BLE001 — no EE package / older EE build
+        return False
+
+
+def workspace_required_message(tool_name: str) -> str:
+    """The refusal string a builtin tool returns when tenancy is unresolvable.
+
+    Phrased like the sibling MCP servers' ``_error_response`` so the agent
+    relays the same reason on either backend.
+    """
+    return (
+        f"{tool_name} requires workspace context (call from a cloud chat session). "
+        "Refusing rather than falling back to unscoped access."
+    )

--- a/src/pocketpaw/tools/builtin/fabric_tools.py
+++ b/src/pocketpaw/tools/builtin/fabric_tools.py
@@ -21,10 +21,43 @@
 #   call sit inside this tool's try/except, so a too-deep path or a runaway
 #   fan-out surfaces as a readable "Error querying Fabric: …" string the LLM can
 #   act on — never a raised exception or a raw SQLite crash.
+# Updated: 2026-08-06 (C4-a — stop cross-tenant leakage) — every tool is now
+#   WORKSPACE-SCOPED, matching the in-process MCP sibling
+#   (ee/pocketpaw_ee/agent/mcp_servers/fabric.py) which already resolved tenancy
+#   from the per-stream agent identity and passed workspace_id into every store
+#   call. The builtin path — the ONLY Fabric surface the non-SDK backends
+#   (deep_agents, google_adk, openai_agents) see — passed none, so:
+#     * reads ran UNFILTERED. ``fabric_query`` returned, and ``fabric_stats``
+#       counted and NAMED, whatever objects/types shared the database file.
+#       Both now pass workspace_id, so a tenant sees only its own rows (plus
+#       legacy NULL-workspace rows, the W4a compatibility leg).
+#     * writes landed with workspace_id = NULL. Because ``_workspace_scope()``
+#       renders a scoped read as ``(workspace_id = ? OR workspace_id IS NULL)``,
+#       a NULL row is ACTIVELY RETURNED to every tenant's scoped query on that
+#       file — one tenant's object/type/link surfaced in another's ontology.
+#       ``define_type`` / ``create_object`` / ``link`` now stamp the resolved
+#       workspace, and ``get_type_by_name`` resolves scoped so a create can
+#       never bind to another tenant's type id (SZD-2).
+#   NOTE on gating: this does NOT route writes through the Instinct gate. The
+#   MCP sibling does not either — its header (2026-07-11, feat/paw-cli C2)
+#   records that the 2026-06-11 "writes arrive as gated proposals" posture was
+#   deliberately SUPERSEDED so the tool surface matches the REST surface, where
+#   ``fabric.write`` is MEMBER-tier. Making the builtin path stricter than both
+#   REST and MCP would be an inconsistency, not extra safety.
+#   Fail-closed: when the POSITIVE per-run marker ``is_tenant_scoped_run()``
+#   says this is a cloud chat dispatch and no workspace resolves, the tool
+#   REFUSES instead of falling back to NULL/global scope. The marker is
+#   deliberately not a process-global (see _tenancy.py for the #1570 rationale)
+#   so workspace-less OSS / CLI / background runs keep working unchanged.
 
 import logging
 from typing import Any
 
+from pocketpaw.tools.builtin._tenancy import (
+    current_workspace,
+    is_tenant_scoped_run,
+    workspace_required_message,
+)
 from pocketpaw.tools.protocol import BaseTool
 
 logger = logging.getLogger(__name__)
@@ -38,6 +71,21 @@ def _get_fabric_store():
         return get_fabric_store()
     except ImportError:
         return None
+
+
+def _resolve_scope(tool_name: str) -> tuple[str | None, str | None]:
+    """Resolve ``(workspace_id, refusal)`` for one tool invocation.
+
+    ``refusal`` is non-None when the run is tenant-scoped but no workspace
+    resolved — the caller returns it verbatim and performs NO store access.
+    """
+    workspace = current_workspace()
+    if workspace is None and is_tenant_scoped_run():
+        logger.warning(
+            "%s refused: tenant-scoped run with no resolvable workspace identity", tool_name
+        )
+        return None, workspace_required_message(tool_name)
+    return workspace, None
 
 
 async def _emit_trace_events(event_type: str, entries: list[dict[str, Any]]) -> None:
@@ -143,6 +191,10 @@ class FabricQueryTool(BaseTool):
         path: list[dict[str, Any]] | None = None,
         limit: int = 20,
     ) -> str:
+        workspace, refusal = _resolve_scope(self.name)
+        if refusal:
+            return refusal
+
         store = _get_fabric_store()
         if not store:
             return "Fabric is not available (enterprise feature)."
@@ -163,6 +215,7 @@ class FabricQueryTool(BaseTool):
                     except Exception as exc:  # pydantic ValidationError or TypeError
                         return f"Invalid path hop at index {i}: {exc}"
 
+            # C4-a: workspace-filtered read — never another tenant's objects.
             result = await store.query(
                 FabricQuery(
                     type_name=type_name,
@@ -171,7 +224,8 @@ class FabricQueryTool(BaseTool):
                     filters=filters or {},
                     path=hops,
                     limit=min(limit, 50),
-                )
+                ),
+                workspace_id=workspace,
             )
 
             # Emit a trace event per object so decision-time snapshots can
@@ -293,6 +347,10 @@ class FabricCreateTool(BaseTool):
         source_connector: str | None = None,
         source_id: str | None = None,
     ) -> str:
+        workspace, refusal = _resolve_scope(self.name)
+        if refusal:
+            return refusal
+
         store = _get_fabric_store()
         if not store:
             return "Fabric is not available (enterprise feature)."
@@ -310,7 +368,11 @@ class FabricCreateTool(BaseTool):
                             prop_defs.append(PropertyDef(**ptype))
                         else:
                             prop_defs.append(PropertyDef(name=name, type=str(ptype)))
-                obj_type = await store.define_type(name=type_name, properties=prop_defs)
+                # C4-a: stamp the owning tenant (SZD-2) so the type is not
+                # visible/reusable from another workspace.
+                obj_type = await store.define_type(
+                    name=type_name, properties=prop_defs, workspace_id=workspace
+                )
                 return (
                     f"Created object type '{obj_type.name}'"
                     f" (ID: {obj_type.id})"
@@ -320,7 +382,9 @@ class FabricCreateTool(BaseTool):
             elif action == "create_object":
                 if not type_name:
                     return "type_name is required for create_object"
-                obj_type = await store.get_type_by_name(type_name)
+                # C4-a: resolve the type SCOPED, so a create can never bind to
+                # another tenant's type id, then stamp the object's tenant.
+                obj_type = await store.get_type_by_name(type_name, workspace_id=workspace)
                 if not obj_type:
                     return (
                         f"Object type '{type_name}' not found."
@@ -331,6 +395,7 @@ class FabricCreateTool(BaseTool):
                     properties=properties or {},
                     source_connector=source_connector,
                     source_id=source_id,
+                    workspace_id=workspace,
                 )
                 props_str = ", ".join(f"{k}: {v}" for k, v in obj.properties.items())
                 return f"Created {type_name} object (ID: {obj.id}): {props_str}"
@@ -338,7 +403,14 @@ class FabricCreateTool(BaseTool):
             elif action == "link":
                 if not from_id or not to_id or not link_type:
                     return "from_id, to_id, and link_type are all required for link"
-                lnk = await store.link(from_id, to_id, link_type)
+                # C4-a: both endpoints must resolve in the CALLER's workspace
+                # before the link is written, mirroring the MCP sibling's
+                # _fabric_link_create. Without this an agent could name another
+                # tenant's object id and stitch it into its own ontology.
+                for field_name, obj_id in (("from_id", from_id), ("to_id", to_id)):
+                    if await store.get_object(obj_id, workspace_id=workspace) is None:
+                        return f"{field_name} '{obj_id}' was not found in this workspace."
+                lnk = await store.link(from_id, to_id, link_type, workspace_id=workspace)
                 return f"Linked {from_id} → {to_id} (type: {link_type}, link ID: {lnk.id})"
 
             else:
@@ -371,12 +443,20 @@ class FabricStatsTool(BaseTool):
         return {"type": "object", "properties": {}}
 
     async def execute(self) -> str:
+        workspace, refusal = _resolve_scope(self.name)
+        if refusal:
+            return refusal
+
         store = _get_fabric_store()
         if not store:
             return "Fabric is not available (enterprise feature)."
         try:
-            stats = await store.stats()
-            types = await store.list_types()
+            # C4-a: scope counts AND type names. Unscoped stats leaked another
+            # tenant's experimental type names into chat on a shared file —
+            # the same leak fix/fabric-stats-workspace-scope closed on the MCP
+            # side (#1437).
+            stats = await store.stats(workspace_id=workspace)
+            types = await store.list_types(workspace_id=workspace)
             lines = [
                 f"Fabric: {stats['types']} types,"
                 f" {stats['objects']} objects,"

--- a/src/pocketpaw/tools/builtin/instinct_corrections.py
+++ b/src/pocketpaw/tools/builtin/instinct_corrections.py
@@ -3,12 +3,30 @@
 # a pocket before proposing its next action, so past human edits shape the draft.
 # Pairs with the correction_soul_bridge, which also feeds the same signal into
 # soul-protocol's automatic memory injection when a soul is loaded.
+# Updated: 2026-08-06 (C4-a — stop cross-tenant leakage) — this tool was the
+#   SEVENTH sibling in the same _EE_TOOLS registry as the Fabric/Instinct tools
+#   and the last one left unscoped. It read ``get_corrections_for_pocket`` with
+#   a caller-supplied ``pocket_id`` and NOTHING else: that store method filtered
+#   on pocket_id alone and took no workspace at all, so on the exact scenario
+#   this wave exists for — a cloud run with no resolvable workspace against the
+#   shared legacy file — six tools refused and this one walked through, handing
+#   back another tenant's human-edit history (which quotes the before/after text
+#   of their proposals). It now takes the same ``_resolve_scope`` guard and
+#   passes the resolved workspace into the (newly scoped) store read.
+#   Note the store side needed BOTH halves: ``record_correction`` now stamps the
+#   tenant too, because ``_workspace_scope`` returns NULL rows to every tenant,
+#   so filtering reads against a table nobody stamps would have been a no-op.
 
 from __future__ import annotations
 
 import logging
 from typing import Any
 
+from pocketpaw.tools.builtin._tenancy import (
+    current_workspace,
+    is_tenant_scoped_run,
+    workspace_required_message,
+)
 from pocketpaw.tools.protocol import BaseTool
 
 logger = logging.getLogger(__name__)
@@ -22,6 +40,21 @@ def _get_instinct_store():
         return get_instinct_store()
     except ImportError:
         return None
+
+
+def _resolve_scope(tool_name: str) -> tuple[str | None, str | None]:
+    """Resolve ``(workspace_id, refusal)`` for one tool invocation.
+
+    ``refusal`` is non-None when the run is tenant-scoped but no workspace
+    resolved — the caller returns it verbatim and performs NO store access.
+    """
+    workspace = current_workspace()
+    if workspace is None and is_tenant_scoped_run():
+        logger.warning(
+            "%s refused: tenant-scoped run with no resolvable workspace identity", tool_name
+        )
+        return None, workspace_required_message(tool_name)
+    return workspace, None
 
 
 class InstinctCorrectionsTool(BaseTool):
@@ -64,14 +97,21 @@ class InstinctCorrectionsTool(BaseTool):
         }
 
     async def execute(self, pocket_id: str, limit: int = 10) -> str:
+        workspace, refusal = _resolve_scope(self.name)
+        if refusal:
+            return refusal
+
         store = _get_instinct_store()
         if not store:
             return "Instinct is not available (enterprise feature)."
 
         try:
+            # C4-a: workspace-filtered read — a caller-supplied pocket_id can no
+            # longer reach another tenant's correction history.
             corrections = await store.get_corrections_for_pocket(
                 pocket_id=pocket_id,
                 limit=min(max(limit, 1), 50),
+                workspace_id=workspace,
             )
         except Exception as exc:
             logger.error("instinct_corrections lookup failed: %s", exc)

--- a/src/pocketpaw/tools/builtin/instinct_tools.py
+++ b/src/pocketpaw/tools/builtin/instinct_tools.py
@@ -11,9 +11,11 @@
 #       ``(workspace_id = ? OR workspace_id IS NULL)`` for W4a legacy
 #       compatibility, a NULL Action was ACTIVELY RETURNED to every tenant's
 #       scoped pending query on that file — it showed up in other tenants'
-#       approval queues. Now the resolved workspace is stamped on the row
-#       (and the calling user is recorded as the assignee), so the proposal is
-#       visible only to its own tenant.
+#       approval queues. Now the resolved workspace is stamped on the row, so
+#       the proposal is visible only to its own tenant. (Assignee is left
+#       untouched: it drives Mission Control's per-human filter, and defaulting
+#       it to the calling user would silently narrow queues that today show the
+#       whole tenant's unassigned work.)
 #     * ``instinct_pending`` / ``instinct_audit`` read unfiltered. Both now
 #       pass workspace_id, so a tenant's queue and decision trail never
 #       include another tenant's rows.

--- a/src/pocketpaw/tools/builtin/instinct_tools.py
+++ b/src/pocketpaw/tools/builtin/instinct_tools.py
@@ -1,9 +1,36 @@
 # Instinct tools — agent tools for the decision pipeline.
 # Created: 2026-03-28 — Lets the agent propose actions, check pending, read audit.
+# Updated: 2026-08-06 (C4-a — stop cross-tenant leakage) — all three tools are
+#   now WORKSPACE-SCOPED, matching the in-process MCP sibling
+#   (ee/pocketpaw_ee/agent/mcp_servers/instinct.py) which already resolved
+#   tenancy from the per-stream agent identity and passed workspace_id into
+#   every store call. The builtin path — the ONLY Instinct surface the non-SDK
+#   backends (deep_agents, google_adk, openai_agents) see — passed none, so:
+#     * ``instinct_propose`` wrote Actions with workspace_id = NULL. Because
+#       ``_workspace_scope()`` renders a scoped read as
+#       ``(workspace_id = ? OR workspace_id IS NULL)`` for W4a legacy
+#       compatibility, a NULL Action was ACTIVELY RETURNED to every tenant's
+#       scoped pending query on that file — it showed up in other tenants'
+#       approval queues. Now the resolved workspace is stamped on the row
+#       (and the calling user is recorded as the assignee), so the proposal is
+#       visible only to its own tenant.
+#     * ``instinct_pending`` / ``instinct_audit`` read unfiltered. Both now
+#       pass workspace_id, so a tenant's queue and decision trail never
+#       include another tenant's rows.
+#   Fail-closed: when the POSITIVE per-run marker ``is_tenant_scoped_run()``
+#   says this is a cloud chat dispatch and no workspace resolves, the tool
+#   REFUSES instead of falling back to NULL/global scope. The marker is
+#   deliberately not a process-global (see _tenancy.py for the #1570 rationale)
+#   so workspace-less OSS / CLI / background runs keep working unchanged.
 
 import logging
 from typing import Any
 
+from pocketpaw.tools.builtin._tenancy import (
+    current_workspace,
+    is_tenant_scoped_run,
+    workspace_required_message,
+)
 from pocketpaw.tools.protocol import BaseTool
 
 logger = logging.getLogger(__name__)
@@ -17,6 +44,21 @@ def _get_instinct_store():
         return get_instinct_store()
     except ImportError:
         return None
+
+
+def _resolve_scope(tool_name: str) -> tuple[str | None, str | None]:
+    """Resolve ``(workspace_id, refusal)`` for one tool invocation.
+
+    ``refusal`` is non-None when the run is tenant-scoped but no workspace
+    resolved — the caller returns it verbatim and performs NO store access.
+    """
+    workspace = current_workspace()
+    if workspace is None and is_tenant_scoped_run():
+        logger.warning(
+            "%s refused: tenant-scoped run with no resolvable workspace identity", tool_name
+        )
+        return None, workspace_required_message(tool_name)
+    return workspace, None
 
 
 class InstinctProposeTool(BaseTool):
@@ -90,6 +132,10 @@ class InstinctProposeTool(BaseTool):
         category: str = "workflow",
         reason: str = "",
     ) -> str:
+        workspace, refusal = _resolve_scope(self.name)
+        if refusal:
+            return refusal
+
         store = _get_instinct_store()
         if not store:
             return "Instinct is not available (enterprise feature)."
@@ -97,6 +143,9 @@ class InstinctProposeTool(BaseTool):
         try:
             from pocketpaw.instinct.models import ActionCategory, ActionPriority, ActionTrigger
 
+            # C4-a: stamp the resolved tenant on the row. Without this the
+            # Action lands NULL and every tenant's scoped pending query
+            # returns it (the NULL leg of _workspace_scope's W4a filter).
             action = await store.propose(
                 pocket_id=pocket_id,
                 title=title,
@@ -105,6 +154,7 @@ class InstinctProposeTool(BaseTool):
                 trigger=ActionTrigger(type="agent", source="pocketpaw", reason=reason or title),
                 category=ActionCategory(category),
                 priority=ActionPriority(priority),
+                workspace_id=workspace,
             )
             return (
                 f"Action proposed: '{title}' (ID: {action.id})\n"
@@ -148,12 +198,17 @@ class InstinctPendingTool(BaseTool):
         }
 
     async def execute(self, pocket_id: str | None = None) -> str:
+        workspace, refusal = _resolve_scope(self.name)
+        if refusal:
+            return refusal
+
         store = _get_instinct_store()
         if not store:
             return "Instinct is not available (enterprise feature)."
 
         try:
-            pending = await store.pending(pocket_id)
+            # C4-a: workspace-filtered read — never another tenant's queue.
+            pending = await store.pending(pocket_id, workspace_id=workspace)
             if not pending:
                 return "No pending actions — all clear."
 
@@ -205,12 +260,19 @@ class InstinctAuditTool(BaseTool):
         }
 
     async def execute(self, pocket_id: str | None = None, limit: int = 10) -> str:
+        workspace, refusal = _resolve_scope(self.name)
+        if refusal:
+            return refusal
+
         store = _get_instinct_store()
         if not store:
             return "Instinct is not available (enterprise feature)."
 
         try:
-            entries = await store.query_audit(pocket_id=pocket_id, limit=min(limit, 50))
+            # C4-a: workspace-filtered read — never another tenant's trail.
+            entries = await store.query_audit(
+                pocket_id=pocket_id, limit=min(limit, 50), workspace_id=workspace
+            )
             if not entries:
                 return "No audit entries found."
 

--- a/tests/cloud/shared/test_agent_bridge_identity.py
+++ b/tests/cloud/shared/test_agent_bridge_identity.py
@@ -119,3 +119,71 @@ async def test_run_agent_response_resets_contextvar_after_run() -> None:
 
     # Reset after the run — no leak into the surrounding context.
     assert current_workspace_id() is None
+
+
+@pytest.mark.asyncio
+async def test_run_agent_response_marks_the_run_as_a_cloud_chat_run() -> None:
+    """C4-a: the group/DM path must also set the per-run cloud-chat MARKER.
+
+    The builtin Fabric/Instinct tools key their fail-closed on
+    ``current_cloud_chat_run()``, deliberately NOT on a process-global (that
+    choice is the #1570 lesson). This path bound identity but never entered
+    ``mark_cloud_chat_run``, so the marker read False for the whole cloud
+    group/DM path and the guard was inert there. No live leak today — because
+    ``attach_agent_identity`` happens to raise on an empty workspace — but the
+    invariant held by a separate accident rather than by the guard, and the
+    OSS-side tools cannot see that accident.
+
+    Mutation that breaks this: remove the ``cloud_run_marker`` enter/exit pair
+    from ``_run_agent_response``.
+    """
+    from pocketpaw_ee.cloud.chat.agent_service import current_cloud_chat_run
+    from pocketpaw_ee.cloud.shared import agent_bridge
+
+    from pocketpaw.tools.builtin._tenancy import is_tenant_scoped_run
+
+    seen: dict[str, bool] = {}
+
+    async def fake_run(agent_id, user_message, session_key, history, **kwargs):
+        seen["marker"] = current_cloud_chat_run()
+        # The OSS-side view the tools actually consult.
+        seen["tenant_scoped"] = is_tenant_scoped_run()
+        yield SimpleNamespace(type="message", content="ok")
+        yield SimpleNamespace(type="done", content="")
+
+    pool = SimpleNamespace(
+        get=AsyncMock(return_value=SimpleNamespace(agent_name="PocketPaw")),
+        run=fake_run,
+        observe=AsyncMock(return_value=None),
+    )
+
+    assert current_cloud_chat_run() is False
+
+    with (
+        patch("pocketpaw.agents.pool.get_agent_pool", return_value=pool),
+        patch(
+            "pocketpaw_ee.cloud.chat.message_service.list_recent_for_group",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch(
+            "pocketpaw_ee.cloud.chat.message_service.create_agent_message",
+            new=AsyncMock(return_value=SimpleNamespace(id="m1")),
+        ),
+        patch(
+            "pocketpaw_ee.cloud.agents.knowledge.KnowledgeService.search_context",
+            new=AsyncMock(return_value=""),
+        ),
+        patch("pocketpaw_ee.cloud.shared.agent_bridge.emit", new=AsyncMock()),
+    ):
+        await agent_bridge._run_agent_response(
+            agent_id="agent-z",
+            group_id="group-z",
+            workspace_id="ws-z",
+            user_message="hi",
+            group_members=["user-1"],
+        )
+
+    assert seen["marker"] is True
+    assert seen["tenant_scoped"] is True
+    # Released in the finally — never leaks past the run.
+    assert current_cloud_chat_run() is False

--- a/tests/mutations/builtin_tool_tenancy.json
+++ b/tests/mutations/builtin_tool_tenancy.json
@@ -110,17 +110,62 @@
   {
     "label": "tenancy: a blank workspace counts as resolved identity",
     "file": "src/pocketpaw/tools/builtin/_tenancy.py",
-    "find": "        candidate = _oss_current_workspace.get()\n        if candidate and candidate.strip():\n            return candidate.strip()",
-    "replace": "        candidate = _oss_current_workspace.get()\n        if candidate is not None:\n            return candidate",
+    "find": "    candidate = _oss_current_workspace.get()\n    if candidate and candidate.strip():\n        return candidate.strip()",
+    "replace": "    candidate = _oss_current_workspace.get()\n    if candidate is not None:\n        return candidate",
     "tests": [
       "tests/test_builtin_tools_workspace_scope.py"
     ]
   },
   {
+    "label": "corrections: the seventh sibling reads unfiltered again",
+    "file": "src/pocketpaw/tools/builtin/instinct_corrections.py",
+    "find": "                limit=min(max(limit, 1), 50),\n                workspace_id=workspace,\n            )",
+    "replace": "                limit=min(max(limit, 1), 50),\n            )",
+    "tests": [
+      "tests/test_builtin_tools_workspace_scope.py"
+    ]
+  },
+  {
+    "label": "corrections: the seventh sibling's fail-closed refusal is dropped",
+    "file": "src/pocketpaw/tools/builtin/instinct_corrections.py",
+    "find": "    workspace = current_workspace()\n    if workspace is None and is_tenant_scoped_run():",
+    "replace": "    workspace = current_workspace()\n    if False:",
+    "tests": [
+      "tests/test_builtin_tools_workspace_scope.py"
+    ]
+  },
+  {
+    "label": "corrections: the store read ignores the workspace it is handed",
+    "file": "src/pocketpaw/instinct/store.py",
+    "find": "        ws_cond, ws_params = _workspace_scope(workspace_id)\n        if ws_cond:\n            sql += f\" AND {ws_cond}\"\n            params.extend(ws_params)\n        sql += \" ORDER BY created_at DESC LIMIT ?\"",
+    "replace": "        sql += \" ORDER BY created_at DESC LIMIT ?\"",
+    "tests": [
+      "tests/test_builtin_tools_workspace_scope.py"
+    ]
+  },
+  {
+    "label": "corrections: the writer stops stamping the tenant (read filter becomes a no-op)",
+    "file": "src/pocketpaw/instinct/store.py",
+    "find": "                \" context_summary, action_title, created_at, workspace_id)\"\n                \" VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)\",",
+    "replace": "                \" context_summary, action_title, created_at, workspace_id)\"\n                \" VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)\",",
+    "tests": [
+      "tests/test_builtin_tools_workspace_scope.py"
+    ]
+  },
+  {
+    "label": "bridge: the group/DM path stops marking itself a cloud chat run",
+    "file": "ee/pocketpaw_ee/cloud/shared/agent_bridge.py",
+    "find": "    cloud_run_marker = mark_cloud_chat_run()\n    cloud_run_marker.__enter__()\n",
+    "replace": "    class _NoMarker:\n        def __enter__(self):\n            return None\n\n        def __exit__(self, *a):\n            return False\n\n    cloud_run_marker = _NoMarker()\n    cloud_run_marker.__enter__()\n",
+    "tests": [
+      "tests/cloud/shared/test_agent_bridge_identity.py"
+    ]
+  },
+  {
     "label": "tenancy: the guard becomes a process-global that fires for every run (#1570)",
     "file": "src/pocketpaw/tools/builtin/_tenancy.py",
-    "find": "        return bool(current_cloud_chat_run())",
-    "replace": "        return True",
+    "find": "    return bool(current_cloud_chat_run())",
+    "replace": "    return True",
     "tests": [
       "tests/test_builtin_tools_workspace_scope.py"
     ]

--- a/tests/mutations/builtin_tool_tenancy.json
+++ b/tests/mutations/builtin_tool_tenancy.json
@@ -1,0 +1,128 @@
+[
+  {
+    "label": "instinct: the proposal stops carrying its tenant (the reported leak)",
+    "file": "src/pocketpaw/tools/builtin/instinct_tools.py",
+    "find": "                priority=ActionPriority(priority),\n                workspace_id=workspace,\n            )",
+    "replace": "                priority=ActionPriority(priority),\n            )",
+    "tests": [
+      "tests/test_builtin_tools_workspace_scope.py"
+    ]
+  },
+  {
+    "label": "instinct: the pending queue reads unfiltered again",
+    "file": "src/pocketpaw/tools/builtin/instinct_tools.py",
+    "find": "            pending = await store.pending(pocket_id, workspace_id=workspace)",
+    "replace": "            pending = await store.pending(pocket_id)",
+    "tests": [
+      "tests/test_builtin_tools_workspace_scope.py"
+    ]
+  },
+  {
+    "label": "instinct: the audit trail reads unfiltered again",
+    "file": "src/pocketpaw/tools/builtin/instinct_tools.py",
+    "find": "                pocket_id=pocket_id, limit=min(limit, 50), workspace_id=workspace\n            )",
+    "replace": "                pocket_id=pocket_id, limit=min(limit, 50)\n            )",
+    "tests": [
+      "tests/test_builtin_tools_workspace_scope.py"
+    ]
+  },
+  {
+    "label": "instinct: the fail-closed refusal is dropped",
+    "file": "src/pocketpaw/tools/builtin/instinct_tools.py",
+    "find": "    workspace = current_workspace()\n    if workspace is None and is_tenant_scoped_run():",
+    "replace": "    workspace = current_workspace()\n    if False:",
+    "tests": [
+      "tests/test_builtin_tools_workspace_scope.py"
+    ]
+  },
+  {
+    "label": "fabric: the query reads unfiltered again",
+    "file": "src/pocketpaw/tools/builtin/fabric_tools.py",
+    "find": "                    limit=min(limit, 50),\n                ),\n                workspace_id=workspace,\n            )",
+    "replace": "                    limit=min(limit, 50),\n                ),\n            )",
+    "tests": [
+      "tests/test_builtin_tools_workspace_scope.py"
+    ]
+  },
+  {
+    "label": "fabric: a defined type stops carrying its tenant",
+    "file": "src/pocketpaw/tools/builtin/fabric_tools.py",
+    "find": "                obj_type = await store.define_type(\n                    name=type_name, properties=prop_defs, workspace_id=workspace\n                )",
+    "replace": "                obj_type = await store.define_type(\n                    name=type_name, properties=prop_defs\n                )",
+    "tests": [
+      "tests/test_builtin_tools_workspace_scope.py"
+    ]
+  },
+  {
+    "label": "fabric: a created object stops carrying its tenant",
+    "file": "src/pocketpaw/tools/builtin/fabric_tools.py",
+    "find": "                    source_id=source_id,\n                    workspace_id=workspace,\n                )",
+    "replace": "                    source_id=source_id,\n                )",
+    "tests": [
+      "tests/test_builtin_tools_workspace_scope.py"
+    ]
+  },
+  {
+    "label": "fabric: create binds to another tenant's type id (unscoped lookup)",
+    "file": "src/pocketpaw/tools/builtin/fabric_tools.py",
+    "find": "                obj_type = await store.get_type_by_name(type_name, workspace_id=workspace)",
+    "replace": "                obj_type = await store.get_type_by_name(type_name)",
+    "tests": [
+      "tests/test_builtin_tools_workspace_scope.py"
+    ]
+  },
+  {
+    "label": "fabric: the cross-tenant link endpoint check is removed",
+    "file": "src/pocketpaw/tools/builtin/fabric_tools.py",
+    "find": "                for field_name, obj_id in ((\"from_id\", from_id), (\"to_id\", to_id)):\n                    if await store.get_object(obj_id, workspace_id=workspace) is None:\n                        return f\"{field_name} '{obj_id}' was not found in this workspace.\"\n",
+    "replace": "",
+    "tests": [
+      "tests/test_builtin_tools_workspace_scope.py"
+    ]
+  },
+  {
+    "label": "fabric: stats counts unfiltered again",
+    "file": "src/pocketpaw/tools/builtin/fabric_tools.py",
+    "find": "            stats = await store.stats(workspace_id=workspace)",
+    "replace": "            stats = await store.stats()",
+    "tests": [
+      "tests/test_builtin_tools_workspace_scope.py"
+    ]
+  },
+  {
+    "label": "fabric: stats leaks another tenant's type NAMES",
+    "file": "src/pocketpaw/tools/builtin/fabric_tools.py",
+    "find": "            types = await store.list_types(workspace_id=workspace)",
+    "replace": "            types = await store.list_types()",
+    "tests": [
+      "tests/test_builtin_tools_workspace_scope.py"
+    ]
+  },
+  {
+    "label": "fabric: the fail-closed refusal is dropped",
+    "file": "src/pocketpaw/tools/builtin/fabric_tools.py",
+    "find": "    workspace = current_workspace()\n    if workspace is None and is_tenant_scoped_run():",
+    "replace": "    workspace = current_workspace()\n    if False:",
+    "tests": [
+      "tests/test_builtin_tools_workspace_scope.py"
+    ]
+  },
+  {
+    "label": "tenancy: a blank workspace counts as resolved identity",
+    "file": "src/pocketpaw/tools/builtin/_tenancy.py",
+    "find": "        candidate = _oss_current_workspace.get()\n        if candidate and candidate.strip():\n            return candidate.strip()",
+    "replace": "        candidate = _oss_current_workspace.get()\n        if candidate is not None:\n            return candidate",
+    "tests": [
+      "tests/test_builtin_tools_workspace_scope.py"
+    ]
+  },
+  {
+    "label": "tenancy: the guard becomes a process-global that fires for every run (#1570)",
+    "file": "src/pocketpaw/tools/builtin/_tenancy.py",
+    "find": "        return bool(current_cloud_chat_run())",
+    "replace": "        return True",
+    "tests": [
+      "tests/test_builtin_tools_workspace_scope.py"
+    ]
+  }
+]

--- a/tests/test_builtin_tools_workspace_scope.py
+++ b/tests/test_builtin_tools_workspace_scope.py
@@ -1,0 +1,506 @@
+# tests/test_builtin_tools_workspace_scope.py
+# Created: 2026-08-06 (C4-a — builtin Fabric/Instinct tools: stop cross-tenant
+#   leakage and fail closed on unresolvable tenancy).
+#
+# What these pin, and why they are written against a SHARED store handle:
+#
+# The defect is ROW-LEVEL. The builtin tools passed no ``workspace_id`` into any
+# store call, so every write landed with ``workspace_id = NULL`` and every read
+# ran unfiltered. NULL is not merely "unscoped": ``_workspace_scope()`` renders a
+# scoped read as ``(workspace_id = ? OR workspace_id IS NULL)`` for W4a legacy
+# compatibility, so a NULL row is ACTIVELY RETURNED to every tenant's scoped
+# query against that file.
+#
+# ISO-1/ISO-2 give each workspace its own database file when a workspace is in
+# context, which would mask the row-level bug: a test that let the factory route
+# by workspace would pass even with the fix reverted, because the two tenants
+# would never share a file. So each test pins ONE shared store handle for both
+# tenants (monkeypatching the tool module's ``_get_*_store``) — reproducing the
+# real shared-file condition (no workspace resolved and
+# POCKETPAW_REQUIRE_WORKSPACE_SCOPE unset -> the legacy singleton) and isolating
+# exactly the tenancy argument under test. Every mutation in
+# tests/mutations/builtin_tool_tenancy.json drops one of those arguments; each
+# has been observed to fail these tests.
+#
+# Covers:
+#   * instinct_propose stamps the caller's workspace; the Action is invisible to
+#     another tenant's scoped pending queue (the reported leak);
+#   * instinct_pending / instinct_audit read workspace-filtered;
+#   * fabric_create stamps objects/types/links; a link refuses an endpoint that
+#     does not resolve in the caller's workspace;
+#   * fabric_query / fabric_stats never surface another workspace's objects or
+#     type names;
+#   * fail-closed — inside a cloud chat run with NO resolvable identity, every
+#     tool REFUSES and performs no store access;
+#   * the legacy path — a workspace-less run with NO per-run marker (OSS, CLI,
+#     background job) keeps working unscoped, so nobody "tightens" the guard
+#     into a process-global without seeing this break.
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud.chat.agent_service import (  # noqa: E402
+    attach_agent_identity,
+    detach_agent_identity,
+    mark_cloud_chat_run,
+)
+
+import pocketpaw.stores as stores  # noqa: E402
+from pocketpaw.fabric.store import FabricStore  # noqa: E402
+from pocketpaw.instinct.store import InstinctStore  # noqa: E402
+from pocketpaw.tools.builtin import fabric_tools, instinct_tools  # noqa: E402
+
+WS_A = "ws-alpha"
+WS_B = "ws-bravo"
+
+
+async def _action_workspaces(store: InstinctStore) -> list[str | None]:
+    """Read the ``workspace_id`` COLUMN straight from SQLite.
+
+    ``Action`` (instinct/models.py) does not surface ``workspace_id`` as a model
+    field — it is persisted tenancy, not part of the artifact — so the only way
+    to assert what actually landed on the row is to read the column.
+    """
+    import aiosqlite
+
+    async with aiosqlite.connect(store._db_path) as db:
+        async with db.execute("SELECT workspace_id FROM instinct_actions ORDER BY rowid") as cur:
+            return [row[0] for row in await cur.fetchall()]
+
+
+@pytest.fixture(autouse=True)
+def _clean_context():
+    """No ambient workspace / marker leaking in from another test."""
+    token = stores.current_workspace.set(None)
+    try:
+        yield
+    finally:
+        try:
+            stores.current_workspace.reset(token)
+        except ValueError:
+            stores.current_workspace.set(None)
+
+
+@pytest.fixture
+def shared_instinct(tmp_path, monkeypatch) -> InstinctStore:
+    """ONE Instinct store both tenants use — the shared-file condition."""
+    store = InstinctStore(db_path=str(tmp_path / "shared_instinct.db"))
+    monkeypatch.setattr(instinct_tools, "_get_instinct_store", lambda: store)
+    return store
+
+
+@pytest.fixture
+def shared_fabric(tmp_path, monkeypatch) -> FabricStore:
+    """ONE Fabric store both tenants use — the shared-file condition."""
+    store = FabricStore(db_path=str(tmp_path / "shared_fabric.db"))
+    monkeypatch.setattr(fabric_tools, "_get_fabric_store", lambda: store)
+    return store
+
+
+class _identity:
+    """Bind a live cloud chat run for ``workspace`` (or, with None, a chat run
+    that never bound identity — the mis-tenanting case)."""
+
+    def __init__(self, workspace: str | None, user: str = "u1") -> None:
+        self._workspace = workspace
+        self._user = user
+        self._tokens = None
+        self._marker = None
+
+    def __enter__(self):
+        self._marker = mark_cloud_chat_run()
+        self._marker.__enter__()
+        if self._workspace is not None:
+            self._tokens = attach_agent_identity(workspace_id=self._workspace, user_id=self._user)
+        return self
+
+    def __exit__(self, *exc):
+        if self._tokens is not None:
+            detach_agent_identity(self._tokens)
+        self._marker.__exit__(*exc)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# (a) The reported leak: a builtin proposal must not reach another tenant
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_builtin_proposal_carries_workspace(shared_instinct: InstinctStore) -> None:
+    """instinct_propose stamps the caller's workspace, never NULL.
+
+    Mutation that breaks this: drop ``workspace_id=workspace`` from the
+    ``store.propose`` call in instinct_tools.InstinctProposeTool.execute.
+    """
+    with _identity(WS_A):
+        out = await instinct_tools.InstinctProposeTool().execute(
+            pocket_id="p1", title="Reorder oat milk", recommendation="Order 24 units"
+        )
+    assert "Action proposed" in out
+
+    assert await _action_workspaces(shared_instinct) == [WS_A], (
+        "the Action landed without its tenant — a NULL row is returned to EVERY "
+        "tenant's scoped query by the W4a NULL leg of _workspace_scope"
+    )
+
+
+@pytest.mark.asyncio
+async def test_builtin_proposal_is_invisible_to_another_tenant(
+    shared_instinct: InstinctStore,
+) -> None:
+    """The exact reported defect: tenant B must not see tenant A's proposal.
+
+    Both tenants share ONE database file here, so this passes only because the
+    row carries WS_A. Mutation that breaks it: drop ``workspace_id=workspace``
+    from the propose call — the row goes NULL and NULL matches B's scoped read.
+    """
+    with _identity(WS_A):
+        await instinct_tools.InstinctProposeTool().execute(
+            pocket_id="p1", title="A-only action", recommendation="do A"
+        )
+
+    with _identity(WS_B, user="u2"):
+        seen = await instinct_tools.InstinctPendingTool().execute()
+
+    assert "A-only action" not in seen
+    assert "No pending actions" in seen
+
+    # ...and tenant A still sees its own.
+    with _identity(WS_A):
+        own = await instinct_tools.InstinctPendingTool().execute()
+    assert "A-only action" in own
+
+
+@pytest.mark.asyncio
+async def test_builtin_pending_read_is_workspace_filtered(
+    shared_instinct: InstinctStore,
+) -> None:
+    """A row written directly for WS_A is not returned to WS_B's queue.
+
+    Mutation that breaks this: drop ``workspace_id=workspace`` from the
+    ``store.pending`` call in InstinctPendingTool.execute.
+    """
+    from pocketpaw.instinct.models import ActionTrigger
+
+    await shared_instinct.propose(
+        pocket_id="p1",
+        title="A-side",
+        description="",
+        recommendation="r",
+        trigger=ActionTrigger(type="agent", source="t", reason="r"),
+        workspace_id=WS_A,
+    )
+
+    with _identity(WS_B, user="u2"):
+        seen = await instinct_tools.InstinctPendingTool().execute()
+    assert "A-side" not in seen
+
+
+@pytest.mark.asyncio
+async def test_builtin_audit_read_is_workspace_filtered(
+    shared_instinct: InstinctStore,
+) -> None:
+    """WS_B's audit view excludes WS_A's decision trail.
+
+    Mutation that breaks this: drop ``workspace_id=workspace`` from the
+    ``store.query_audit`` call in InstinctAuditTool.execute.
+    """
+    with _identity(WS_A):
+        await instinct_tools.InstinctProposeTool().execute(
+            pocket_id="p1", title="A-audit-marker", recommendation="r"
+        )
+
+    with _identity(WS_B, user="u2"):
+        seen = await instinct_tools.InstinctAuditTool().execute()
+    assert "A-audit-marker" not in seen
+
+
+# ---------------------------------------------------------------------------
+# (b)/(c) Fabric writes are stamped; fabric reads are filtered
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fabric_create_stamps_workspace_on_type_and_object(
+    shared_fabric: FabricStore,
+) -> None:
+    """define_type / create_object carry the caller's tenant.
+
+    Mutation that breaks this: drop ``workspace_id=workspace`` from either the
+    ``store.define_type`` or the ``store.create_object`` call.
+    """
+    with _identity(WS_A):
+        await fabric_tools.FabricCreateTool().execute(
+            action="define_type", type_name="Customer", properties={"name": "string"}
+        )
+        out = await fabric_tools.FabricCreateTool().execute(
+            action="create_object", type_name="Customer", properties={"name": "Acme"}
+        )
+    assert "Created Customer object" in out
+
+    types = await shared_fabric.list_types()
+    assert [t.workspace_id for t in types] == [WS_A]
+
+    from pocketpaw.fabric.models import FabricQuery
+
+    res = await shared_fabric.query(FabricQuery(type_name="Customer"))
+    obj = await shared_fabric.get_object(res.objects[0].id, workspace_id=WS_A)
+    assert obj is not None, "the object did not land in the caller's workspace"
+
+
+@pytest.mark.asyncio
+async def test_fabric_query_never_returns_another_workspaces_objects(
+    shared_fabric: FabricStore,
+) -> None:
+    """Tenant B's fabric_query excludes tenant A's objects on a shared file.
+
+    Mutation that breaks this: drop ``workspace_id=workspace`` from the
+    ``store.query`` call in FabricQueryTool.execute.
+    """
+    with _identity(WS_A):
+        await fabric_tools.FabricCreateTool().execute(
+            action="define_type", type_name="Customer", properties={"name": "string"}
+        )
+        await fabric_tools.FabricCreateTool().execute(
+            action="create_object", type_name="Customer", properties={"name": "AcmeSecret"}
+        )
+
+    with _identity(WS_B, user="u2"):
+        seen = await fabric_tools.FabricQueryTool().execute(type_name="Customer")
+    assert "AcmeSecret" not in seen
+
+    with _identity(WS_A):
+        own = await fabric_tools.FabricQueryTool().execute(type_name="Customer")
+    assert "AcmeSecret" in own
+
+
+@pytest.mark.asyncio
+async def test_fabric_create_cannot_bind_to_another_tenants_type(
+    shared_fabric: FabricStore,
+) -> None:
+    """A type defined by WS_A is not reusable from WS_B (SZD-2).
+
+    With an UNSCOPED ``get_type_by_name`` the create silently resolves to the
+    other tenant's type id and writes an object against their schema. Mutation
+    that breaks this: drop ``workspace_id=workspace`` from the
+    ``store.get_type_by_name`` call in FabricCreateTool.execute.
+    """
+    with _identity(WS_A):
+        await fabric_tools.FabricCreateTool().execute(
+            action="define_type", type_name="Customer", properties={"name": "string"}
+        )
+
+    with _identity(WS_B, user="u2"):
+        out = await fabric_tools.FabricCreateTool().execute(
+            action="create_object", type_name="Customer", properties={"name": "BSpy"}
+        )
+
+    assert "not found" in out, "WS_B bound to WS_A's type"
+    from pocketpaw.fabric.models import FabricQuery
+
+    assert (await shared_fabric.query(FabricQuery(type_name="Customer"))).objects == []
+
+
+@pytest.mark.asyncio
+async def test_fabric_stats_counts_are_workspace_scoped(
+    shared_fabric: FabricStore,
+) -> None:
+    """Counts leak volume even when names are hidden — scope them too.
+
+    Mutation that breaks this: drop ``workspace_id=workspace`` from the
+    ``store.stats`` call in FabricStatsTool.execute.
+    """
+    with _identity(WS_A):
+        await fabric_tools.FabricCreateTool().execute(
+            action="define_type", type_name="Customer", properties={"name": "string"}
+        )
+        await fabric_tools.FabricCreateTool().execute(
+            action="create_object", type_name="Customer", properties={"name": "Acme"}
+        )
+
+    with _identity(WS_B, user="u2"):
+        seen = await fabric_tools.FabricStatsTool().execute()
+
+    assert "0 objects" in seen, f"WS_B was told how many objects WS_A holds: {seen!r}"
+
+    with _identity(WS_A):
+        own = await fabric_tools.FabricStatsTool().execute()
+    assert "1 objects" in own
+
+
+@pytest.mark.asyncio
+async def test_fabric_stats_never_names_another_workspaces_types(
+    shared_fabric: FabricStore,
+) -> None:
+    """Type NAMES are tenant data — B's stats must not list A's types.
+
+    Mutation that breaks this: drop ``workspace_id=workspace`` from either the
+    ``store.stats`` or the ``store.list_types`` call in FabricStatsTool.execute.
+    """
+    with _identity(WS_A):
+        await fabric_tools.FabricCreateTool().execute(
+            action="define_type", type_name="SecretProjectX", properties={}
+        )
+        await fabric_tools.FabricCreateTool().execute(
+            action="create_object", type_name="SecretProjectX", properties={"k": "v"}
+        )
+
+    with _identity(WS_B, user="u2"):
+        seen = await fabric_tools.FabricStatsTool().execute()
+    assert "SecretProjectX" not in seen
+
+
+@pytest.mark.asyncio
+async def test_fabric_link_refuses_cross_tenant_endpoint(
+    shared_fabric: FabricStore,
+) -> None:
+    """An object id belonging to another tenant cannot be linked into ours.
+
+    Mutation that breaks this: drop the scoped ``store.get_object`` endpoint
+    check in the ``link`` branch of FabricCreateTool.execute.
+    """
+    with _identity(WS_A):
+        await fabric_tools.FabricCreateTool().execute(
+            action="define_type", type_name="Customer", properties={"name": "string"}
+        )
+        await fabric_tools.FabricCreateTool().execute(
+            action="create_object", type_name="Customer", properties={"name": "Acme"}
+        )
+
+    from pocketpaw.fabric.models import FabricQuery
+
+    a_obj = (await shared_fabric.query(FabricQuery(type_name="Customer"))).objects[0]
+
+    with _identity(WS_B, user="u2"):
+        await fabric_tools.FabricCreateTool().execute(
+            action="define_type", type_name="Vendor", properties={"name": "string"}
+        )
+        await fabric_tools.FabricCreateTool().execute(
+            action="create_object", type_name="Vendor", properties={"name": "BCorp"}
+        )
+        b_obj = (
+            await shared_fabric.query(FabricQuery(type_name="Vendor"), workspace_id=WS_B)
+        ).objects[0]
+
+        out = await fabric_tools.FabricCreateTool().execute(
+            action="link", from_id=b_obj.id, to_id=a_obj.id, link_type="supplies"
+        )
+
+    assert "was not found in this workspace" in out
+    links, _total = await shared_fabric.list_links()
+    assert links == [], "the cross-tenant link was written anyway"
+
+
+# ---------------------------------------------------------------------------
+# (d) Fail closed on unresolvable identity — and ONLY inside a marked run
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("tool", "kwargs"),
+    [
+        (
+            instinct_tools.InstinctProposeTool,
+            {"pocket_id": "p", "title": "t", "recommendation": "r"},
+        ),
+        (instinct_tools.InstinctPendingTool, {}),
+        (instinct_tools.InstinctAuditTool, {}),
+        (fabric_tools.FabricQueryTool, {"type_name": "Customer"}),
+        (fabric_tools.FabricStatsTool, {}),
+        (fabric_tools.FabricCreateTool, {"action": "define_type", "type_name": "X"}),
+    ],
+)
+async def test_unresolvable_identity_refuses(tool, kwargs, monkeypatch) -> None:
+    """A cloud chat run that never bound a workspace REFUSES — it does not fall
+    back to NULL/global scope, and it never touches the store.
+
+    Mutation that breaks this: make ``is_tenant_scoped_run()`` return False, or
+    drop the ``if refusal: return refusal`` guard from the tool.
+    """
+
+    def _boom():
+        raise AssertionError("the tool reached the store without a resolved workspace")
+
+    monkeypatch.setattr(instinct_tools, "_get_instinct_store", _boom)
+    monkeypatch.setattr(fabric_tools, "_get_fabric_store", _boom)
+
+    # Marked as a live cloud chat run, but identity was never attached.
+    with _identity(None):
+        out = await tool().execute(**kwargs)
+
+    assert "requires workspace context" in out
+    assert "Refusing rather than falling back" in out
+
+
+@pytest.mark.asyncio
+async def test_blank_workspace_is_not_accepted_as_identity(monkeypatch) -> None:
+    """A whitespace-only workspace must not satisfy the guard nor be stamped.
+
+    Mutation that breaks this: drop the ``.strip()`` emptiness check in
+    _tenancy.current_workspace.
+    """
+
+    def _boom():
+        raise AssertionError("a blank workspace was treated as resolved")
+
+    monkeypatch.setattr(instinct_tools, "_get_instinct_store", _boom)
+
+    with mark_cloud_chat_run():
+        token = stores.current_workspace.set("   ")
+        try:
+            out = await instinct_tools.InstinctPendingTool().execute()
+        finally:
+            stores.current_workspace.reset(token)
+
+    assert "requires workspace context" in out
+
+
+# ---------------------------------------------------------------------------
+# The legacy path stays open — the guard is per-run, NOT a process-global
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_workspaceless_run_without_marker_still_works(
+    shared_instinct: InstinctStore,
+) -> None:
+    """OSS / CLI / background runs have no workspace AND no marker: they keep
+    the legacy unscoped behavior rather than being refused.
+
+    This is the #1570 guard. Gating the fail-closed on a PROCESS-GLOBAL (e.g.
+    ``is_multi_tenant_cloud()``) instead of the per-run marker would refuse
+    every one of these runs. Mutation that breaks this: make
+    ``is_tenant_scoped_run()`` return True unconditionally.
+    """
+    out = await instinct_tools.InstinctProposeTool().execute(
+        pocket_id="p1", title="local action", recommendation="r"
+    )
+    assert "Action proposed" in out
+
+    # legacy, unscoped — unchanged
+    assert await _action_workspaces(shared_instinct) == [None]
+
+    seen = await instinct_tools.InstinctPendingTool().execute()
+    assert "local action" in seen
+
+
+@pytest.mark.asyncio
+async def test_fabric_workspaceless_run_without_marker_still_works(
+    shared_fabric: FabricStore,
+) -> None:
+    """Same legacy guarantee on the Fabric side."""
+    await fabric_tools.FabricCreateTool().execute(
+        action="define_type", type_name="Customer", properties={"name": "string"}
+    )
+    out = await fabric_tools.FabricCreateTool().execute(
+        action="create_object", type_name="Customer", properties={"name": "LocalCo"}
+    )
+    assert "Created Customer object" in out
+
+    seen = await fabric_tools.FabricQueryTool().execute(type_name="Customer")
+    assert "LocalCo" in seen

--- a/tests/test_builtin_tools_workspace_scope.py
+++ b/tests/test_builtin_tools_workspace_scope.py
@@ -51,7 +51,11 @@ from pocketpaw_ee.cloud.chat.agent_service import (  # noqa: E402
 import pocketpaw.stores as stores  # noqa: E402
 from pocketpaw.fabric.store import FabricStore  # noqa: E402
 from pocketpaw.instinct.store import InstinctStore  # noqa: E402
-from pocketpaw.tools.builtin import fabric_tools, instinct_tools  # noqa: E402
+from pocketpaw.tools.builtin import (  # noqa: E402
+    fabric_tools,
+    instinct_corrections,
+    instinct_tools,
+)
 
 WS_A = "ws-alpha"
 WS_B = "ws-bravo"
@@ -98,6 +102,31 @@ def shared_fabric(tmp_path, monkeypatch) -> FabricStore:
     store = FabricStore(db_path=str(tmp_path / "shared_fabric.db"))
     monkeypatch.setattr(fabric_tools, "_get_fabric_store", lambda: store)
     return store
+
+
+@pytest.fixture
+def shared_corrections(tmp_path, monkeypatch) -> InstinctStore:
+    """ONE Instinct store for the corrections tool — shared-file condition."""
+    store = InstinctStore(db_path=str(tmp_path / "shared_corrections.db"))
+    monkeypatch.setattr(instinct_corrections, "_get_instinct_store", lambda: store)
+    return store
+
+
+async def _record_correction(store: InstinctStore, pocket_id: str, title: str, ws: str | None):
+    """Persist one Correction for ``ws`` (or unscoped when ws is None)."""
+    from pocketpaw.instinct.correction import Correction, CorrectionPatch
+
+    return await store.record_correction(
+        Correction(
+            action_id=f"act-{title}",
+            pocket_id=pocket_id,
+            actor="human",
+            patches=[CorrectionPatch(path="body", before="x", after="y")],
+            context_summary=f"summary-{title}",
+            action_title=title,
+        ),
+        workspace_id=ws,
+    )
 
 
 class _identity:
@@ -217,6 +246,91 @@ async def test_builtin_audit_read_is_workspace_filtered(
     with _identity(WS_B, user="u2"):
         seen = await instinct_tools.InstinctAuditTool().execute()
     assert "A-audit-marker" not in seen
+
+
+# ---------------------------------------------------------------------------
+# The SEVENTH sibling: instinct_corrections was the last unscoped tool
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_corrections_never_returns_another_tenants_history(
+    shared_corrections: InstinctStore,
+) -> None:
+    """WS_B cannot read WS_A's correction history by naming its pocket id.
+
+    Corrections quote the before/after text of a tenant's proposals, so this is
+    content leakage, not just metadata. The tool takes a caller-supplied
+    pocket_id, so the tenant filter is the only thing standing between B and A's
+    edits. Mutation that breaks this: drop ``workspace_id=workspace`` from the
+    ``store.get_corrections_for_pocket`` call.
+    """
+    await _record_correction(shared_corrections, "p-shared", "A-secret-edit", WS_A)
+
+    with _identity(WS_B, user="u2"):
+        seen = await instinct_corrections.InstinctCorrectionsTool().execute(pocket_id="p-shared")
+    assert "A-secret-edit" not in seen
+    assert "No corrections captured yet" in seen
+
+    with _identity(WS_A):
+        own = await instinct_corrections.InstinctCorrectionsTool().execute(pocket_id="p-shared")
+    assert "A-secret-edit" in own
+
+
+@pytest.mark.asyncio
+async def test_corrections_are_stamped_with_the_writing_tenant(
+    shared_corrections: InstinctStore,
+) -> None:
+    """record_correction persists the workspace.
+
+    Without the stamp every row is NULL, and ``_workspace_scope``'s NULL leg
+    hands NULL rows to EVERY tenant — so the read filter above would be a no-op.
+    The writer and the reader are one gate, not two. Mutation that breaks this:
+    drop ``workspace_id`` from the INSERT column list in record_correction.
+    """
+    import aiosqlite
+
+    await _record_correction(shared_corrections, "p1", "A-edit", WS_A)
+    await _record_correction(shared_corrections, "p1", "B-edit", WS_B)
+
+    async with aiosqlite.connect(shared_corrections._db_path) as db:
+        async with db.execute(
+            "SELECT action_title, workspace_id FROM instinct_corrections ORDER BY action_title"
+        ) as cur:
+            rows = await cur.fetchall()
+
+    assert [tuple(r) for r in rows] == [("A-edit", WS_A), ("B-edit", WS_B)]
+
+
+@pytest.mark.asyncio
+async def test_corrections_refuses_unresolvable_identity(monkeypatch) -> None:
+    """The seventh sibling fails closed like the other six.
+
+    This is the exact scenario the wave exists for: a cloud run with no
+    resolvable workspace. Six tools refused and this one used to walk through.
+    Mutation that breaks this: drop the ``if refusal: return refusal`` guard.
+    """
+
+    def _boom():
+        raise AssertionError("instinct_corrections reached the store unscoped")
+
+    monkeypatch.setattr(instinct_corrections, "_get_instinct_store", _boom)
+
+    with _identity(None):
+        out = await instinct_corrections.InstinctCorrectionsTool().execute(pocket_id="p1")
+
+    assert "requires workspace context" in out
+
+
+@pytest.mark.asyncio
+async def test_corrections_workspaceless_run_without_marker_still_works(
+    shared_corrections: InstinctStore,
+) -> None:
+    """OSS / CLI runs keep the legacy unscoped read."""
+    await _record_correction(shared_corrections, "p1", "local-edit", None)
+
+    out = await instinct_corrections.InstinctCorrectionsTool().execute(pocket_id="p1")
+    assert "local-edit" in out
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The builtin (non-SDK backend) Fabric and Instinct tools passed no workspace anywhere: proposals landed with a NULL workspace, fabric writes were attributed to nobody, and reads ran unfiltered. The sharp edge is that scoped reads render as (workspace_id = ? OR workspace_id IS NULL) for legacy compatibility — so a NULL row was not merely unscoped, it was actively returned to every tenant's scoped query.

What this does:

- Threads workspace identity into all seven builtin tools (instinct propose/pending/audit/corrections, fabric query/stats/types/create/link) through a shared resolver that mirrors the MCP servers' identity mechanism. Every store call now carries the workspace.
- The corrections tool needed more than a read filter: its table had no workspace column at all, so this adds one (guarded ALTER + index), stamps it at write time from the EE router's existing workspace, and filters the read. A read filter over an unstamped table would have been cosmetic.
- Fails closed the right way. Refusal keys on the positive per-run marker current_cloud_chat_run(), not on a process-global — the #1570 lesson, where gating on is_multi_tenant_cloud() fired for every unrelated run and turned dev red. A local OSS/CLI run with no marker keeps its legacy behavior; a cloud chat run that cannot resolve a workspace refuses before touching any store. The group/DM bridge path now sets the same marker, so the invariant holds there by design rather than by a coincidental raise downstream.
- One deliberate non-change, per review: builtin fabric writes are NOT routed through the Instinct gate. The audit claim that the MCP sibling gates them turned out to be wrong — that posture was deliberately superseded in June for REST parity, and reversing it is a design decision that belongs to a design discussion, not a security patch.

Tests: 26 across the scope suite and the bridge marker, all built against real stores on real SQLite asserting the workspace column directly. The mutation plan is the real evidence: 19 mutations — every scoping argument dropped, every guard defeated, the writer un-stamped, the mount un-registered — each caught by a failing test. Two escaped on the first pass, which is exactly why the plan exists; both got tests before this went up. Full standard suite: failure set byte-identical to a clean dev baseline. Targeted cloud lane (addopts hides tests/cloud — run it explicitly): identical failure sets, plus the new marker test.

What this deliberately does not fix: rows written by the old code path still carry NULL and are still returned to every tenant on a shared file — actions and corrections both. Cleaning those needs a decision about rows whose owning workspace may be unknowable (backfill, quarantine, or delete), tracked separately as the follow-up FU-5. This PR stops the bleeding; it does not rewrite history.