### PR TITLE
feat(instinct): decision-chain ids become real columns on Actions

### DIFF
--- a/docs/concepts/decision-graph.mdx
+++ b/docs/concepts/decision-graph.mdx
@@ -64,6 +64,19 @@ The terminal-action set is pinned by `_TERMINAL_ACTIONS = frozenset({"decision.g
 
 Precedent supply order (A3): the agent's own payload first, then a projection fallback (same-pocket / same-action / nearest-ts) if the proposer didn't supply any. Out-of-band reconciler is deferred.
 
+## Joining a Decision Back to Its Instinct Action
+
+A gated proposal that opens a chain is also a row in the Instinct decision pipeline — the item a human sees in The Tray. That row carries the chain ids as **first-class, nullable columns** on `instinct_actions`:
+
+| Column | Meaning |
+|---|---|
+| `correlation_id` | The chain key, written at INSERT by the proposer that minted it |
+| `proposed_event_id` | The id of the chain-opening `agent.proposed` event, filled in once that event is durable |
+
+Both are exposed on the `Action` model and on every action view the Instinct router returns (`GET /instinct/actions`, `GET /instinct/actions/pending`), so a Tray row joins to its Decision chain without parsing the per-kind `parameters` blob.
+
+The per-kind blobs (`_external_action`, `_pocket_write`, `_code_change`) still carry their own copies of these ids for blob-schema compatibility, but the **columns are the source of truth**: they land with the INSERT, so the join survives a failed best-effort back-write. `NULL` is legal and permanent — an OSS proposal opens no chain, and rows written before the columns existed were never backfilled (a guessed correlation in an evidence table is worse than an honest blank).
+
 ## The Python API
 
 `pocketpaw_ee.cloud.decisions.service.DecisionGraph` is the in-process surface. One instance per process (per org), accessed via `get_decision_graph()`. All methods are `async`:

--- a/ee/pocketpaw_ee/agent/mcp_servers/belt.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/belt.py
@@ -2,6 +2,15 @@
 # code-change gate to the claude_agent_sdk cloud chat backend. Created:
 # 2026-06-10 (feat/belt-gate, BS-3).
 #
+# Updated: 2026-08-05 (T-3, coupling-gap wave) — the chain ids are now
+#   FIRST-CLASS columns on the Action row. ``store.propose`` is called with
+#   ``correlation_id=str(correlation_id)`` so the correlation join lands with
+#   the INSERT; ``_persist_chain_ids`` no longer runs raw SQL — it writes the
+#   ``proposed_event_id`` column via the store's ``set_chain_ids`` and
+#   refreshes the blob copies via ``update_parameters`` (the schema-2 blob
+#   keeps carrying both ids for compat). A failed back-write now only loses
+#   the event-id column + blob copies, never the correlation join.
+#
 # Updated: 2026-06-10 (feat/belt-trace, BS-4 — Decision-Graph chain) —
 #   ``belt_propose_change`` now MINTS a Decision-Graph ``correlation_id``
 #   at propose time and emits the chain-opening ``agent.proposed`` event
@@ -344,24 +353,27 @@ async def _persist_chain_ids(
     correlation_id: str,
     proposed_event_id: str | None,
 ) -> None:
-    """Write ``correlation_id`` + ``proposed_event_id`` onto the persisted
-    Action's ``parameters._code_change`` blob after ``agent.proposed`` fired.
+    """Write ``proposed_event_id`` (+ refresh the blob's chain-id copies) onto
+    the persisted Action after ``agent.proposed`` fired.
 
-    The blob is built with these fields already set from the in-memory values,
-    so this re-write only matters when the proposed event id was unknown at
-    propose-build time. We mint the correlation_id BEFORE building the blob, so
-    that field is already correct on the stored row; ``proposed_event_id`` is
-    the one this back-write fills in. Direct SQL update — same pattern as the
-    pocket-write bridge's ``_persist_parked_policy_event_id``. Best-effort:
+    T-3: the ``correlation_id`` COLUMN already landed with the INSERT (the
+    propose call passes it), so the governance-chain join no longer depends on
+    this back-write. The one late-arriving id is the ``agent.proposed`` event
+    id — unknowable before the row is durable. Written via the store's
+    ``set_chain_ids`` (a proper column write, no raw SQL); the blob copies are
+    refreshed via ``update_parameters`` for schema-2 blob compat. Best-effort:
     failure leaves ``proposed_event_id`` None and the eventual
     ``human.corrected`` emits without a causation_id (the chain still folds;
-    causation_id is optional on EventEntry).
+    causation_id is optional on EventEntry) — the correlation join via the
+    column survives regardless.
     """
-    import json as _json
-
-    import aiosqlite
-
     try:
+        await store.set_chain_ids(
+            action_id,
+            correlation_id=correlation_id,
+            proposed_event_id=proposed_event_id,
+        )
+        # Blob-compat copies — schema-2 blob readers keep seeing both ids.
         action = await store.get_action(action_id)
         if action is None:
             return
@@ -373,14 +385,7 @@ async def _persist_chain_ids(
         blob["correlation_id"] = correlation_id
         blob["proposed_event_id"] = proposed_event_id
         params[CODE_CHANGE_PARAM_KEY] = blob
-
-        async with aiosqlite.connect(store._db_path) as db:
-            await db.execute(
-                "UPDATE instinct_actions SET parameters = ?,"
-                " updated_at = datetime('now') WHERE id = ?",
-                (_json.dumps(params), action_id),
-            )
-            await db.commit()
+        await store.update_parameters(action_id, params)
     except Exception:  # noqa: BLE001 — write-back is best-effort
         logger.warning(
             "belt: failed to persist chain ids onto action %s — the chain's "
@@ -523,6 +528,11 @@ async def _propose_change_handler(args: dict) -> dict:
             priority=ActionPriority.HIGH,
             parameters={CODE_CHANGE_PARAM_KEY: blob},
             assignee=user_id,
+            # T-3 — the chain correlation id lands as a FIRST-CLASS column with
+            # the INSERT itself, so the Tray↔Decision join exists even if the
+            # best-effort emit / back-write below fails. The blob copy above
+            # stays for schema-2 compat.
+            correlation_id=str(correlation_id),
         )
     except Exception as exc:  # noqa: BLE001
         logger.warning("belt: propose raised (no Action stored)", exc_info=True)

--- a/ee/pocketpaw_ee/cloud/belt/headless.py
+++ b/ee/pocketpaw_ee/cloud/belt/headless.py
@@ -1,6 +1,13 @@
 # ee/pocketpaw_ee/cloud/belt/headless.py — the HEADLESS develop runner.
 # Created: 2026-06-13 (feat/belt-headless-exec).
 #
+# Updated: 2026-08-05 (T-3, coupling-gap wave) — when ``_attach_diff`` mints the
+#   chain ``correlation_id`` for a queued run (the mandate dispatcher files it
+#   without one), the id is now ALSO written to the Action's first-class
+#   ``correlation_id`` COLUMN via ``store.set_chain_ids``, not just the blob.
+#   Otherwise a headless-produced run would carry a chain id the governance
+#   join can't see. The blob copy stays for schema-2 compat.
+#
 # Updated: 2026-06-13 (PR #1464 review) — store the produced diff VERBATIM (only
 #   normalizing a single trailing newline) instead of the leading/trailing-
 #   stripped value: stripping a real diff's trailing newline corrupts it for
@@ -243,6 +250,10 @@ class HeadlessDevelopRunner:
 
         import aiosqlite
 
+        # T-3 — the chain id mirrored onto the first-class column after the blob
+        # attach commits. Declared up here so the post-attach write below reads a
+        # bound name on every path.
+        chain_correlation_id = ""
         try:
             action = await store.get_action(action_id)
             if action is None:
@@ -269,6 +280,11 @@ class HeadlessDevelopRunner:
             if not blob.get("correlation_id"):
                 blob["correlation_id"] = str(uuid4())
             blob.setdefault("proposed_event_id", None)
+            # T-3 — the chain id also belongs on the first-class column, or the
+            # governance join can't see a headless-produced run's chain. Written
+            # after the blob update below (so a failed column write never blocks
+            # the diff attach); captured here while the value is in hand.
+            chain_correlation_id = str(blob["correlation_id"])
             # Provenance — record that this diff was produced headlessly.
             blob["headless"] = True
             blob.pop("headless_error", None)
@@ -291,6 +307,21 @@ class HeadlessDevelopRunner:
                 store, action_id, "headless failed to persist the produced diff"
             )
             return
+
+        # T-3 — mirror the minted chain id onto the first-class column. Written
+        # AFTER the blob attach committed so a column-write failure never costs
+        # the diff, and best-effort for the same reason: the run is applyable
+        # either way, the join is what degrades.
+        try:
+            if chain_correlation_id:
+                await store.set_chain_ids(action_id, correlation_id=chain_correlation_id)
+        except Exception:  # noqa: BLE001 — the chain-id column write is best-effort
+            logger.warning(
+                "headless: failed to persist correlation_id column on action %s "
+                "(the diff IS attached) — the Decision join falls back to the blob",
+                action_id,
+                exc_info=True,
+            )
 
         # Audit trail — this is the FIRST place LLM-produced content enters the
         # Instinct store without a human typing it, so leave an operator trail of

--- a/ee/pocketpaw_ee/cloud/belt/service.py
+++ b/ee/pocketpaw_ee/cloud/belt/service.py
@@ -1,4 +1,9 @@
 # ee/pocketpaw_ee/cloud/belt/service.py
+# Updated: 2026-08-05 (T-3, coupling-gap wave) — the runs read model reads a
+#   run's ``correlation_id`` off the Action's first-class COLUMN, falling back
+#   to the ``_code_change`` blob copy for rows written before the column
+#   existed. The column lands at INSERT, so the run→Decision join survives a
+#   failed best-effort blob back-write.
 # Updated: 2026-06-11 (feat/belt-autopilot) — the runs read model now renders a
 #   QUEUED STATION RUN. A pending ``code_change`` Action whose blob carries
 #   ``station_pending=True`` (filed by the mandate ``StationTaskDispatcher`` with
@@ -706,7 +711,15 @@ def _run_summary(action: Any, blob: dict[str, Any]) -> dict[str, Any]:
         "pr_url": blob.get("pr_url") or None,
         "commit_sha": blob.get("commit_sha") or None,
         "created_at": created.isoformat() if hasattr(created, "isoformat") else None,
-        "correlation_id": str(blob.get("correlation_id") or "") or None,
+        # T-3 — read the chain id off the first-class Action COLUMN, falling back
+        # to the blob copy for rows written before the column existed. The column
+        # is the source of truth: it lands at INSERT, so it survives a failed
+        # best-effort blob back-write.
+        "correlation_id": (
+            str(getattr(action, "correlation_id", None) or "")
+            or str(blob.get("correlation_id") or "")
+            or None
+        ),
     }
 
 

--- a/ee/pocketpaw_ee/cloud/external_actions/propose.py
+++ b/ee/pocketpaw_ee/cloud/external_actions/propose.py
@@ -1,5 +1,14 @@
 # ee/cloud/external_actions/propose.py — propose a gated external-action call.
 # Created: 2026-06-11 (feat/external-action-proposal).
+# Updated: 2026-08-05 (T-3, coupling-gap wave) — the chain ids are now
+#   FIRST-CLASS columns on the Action row. ``store.propose`` is called with
+#   ``correlation_id=corr`` so the correlation join lands with the INSERT and
+#   can never be lost to a failed back-write. ``_persist_chain_ids`` no longer
+#   runs raw SQL: it writes the ``proposed_event_id`` column via the store's
+#   ``set_chain_ids`` and refreshes the blob copies via ``update_parameters``
+#   (the blob keeps carrying both ids for schema-1 compat — readers of the
+#   blob are unchanged). Still best-effort: a failure now only loses the
+#   event-id column + blob copies, never the correlation join.
 #
 # What this module does (the propose half of the external-action gate): an
 # agent (or any caller) proposes a call to an external system through a bound
@@ -166,22 +175,27 @@ async def _persist_chain_ids(
     correlation_id: str,
     proposed_event_id: str | None,
 ) -> None:
-    """Write ``correlation_id`` + ``proposed_event_id`` onto the persisted
-    Action's ``parameters._external_action`` blob after ``agent.proposed`` fired.
+    """Write ``proposed_event_id`` (+ refresh the blob's chain-id copies) onto
+    the persisted Action after ``agent.proposed`` fired.
 
-    The blob is built with ``correlation_id`` already set (minted before build);
-    ``proposed_event_id`` is the field this back-write fills in. Direct SQL
-    update — the same pattern belt.py's ``_persist_chain_ids`` and the
-    pocket-write bridge's ``_persist_parked_policy_event_id`` use. Best-effort:
-    a write failure leaves ``proposed_event_id`` None and the eventual
+    T-3: the ``correlation_id`` COLUMN already landed with the INSERT (propose
+    passes it), so the governance-chain join no longer depends on this
+    back-write at all. What still has to land late is the ``agent.proposed``
+    event id — unknowable before the row is durable. This writes it via the
+    store's ``set_chain_ids`` (a proper column write, no raw SQL) and keeps the
+    blob copies fresh via ``update_parameters`` for schema-1 blob compat.
+    Best-effort: a failure leaves the event-id column NULL and the eventual
     ``human.corrected`` emits without a causation_id (the chain still folds;
-    causation_id is optional on EventEntry).
+    causation_id is optional on EventEntry) — but the correlation join via the
+    column survives regardless.
     """
-    import json as _json
-
-    import aiosqlite
-
     try:
+        await store.set_chain_ids(
+            action_id,
+            correlation_id=correlation_id,
+            proposed_event_id=proposed_event_id,
+        )
+        # Blob-compat copies — schema-1 blob readers keep seeing both ids.
         action = await store.get_action(action_id)
         if action is None:
             return
@@ -193,14 +207,7 @@ async def _persist_chain_ids(
         blob["correlation_id"] = correlation_id
         blob["proposed_event_id"] = proposed_event_id
         params[EXTERNAL_ACTION_PARAM_KEY] = blob
-
-        async with aiosqlite.connect(store._db_path) as db:
-            await db.execute(
-                "UPDATE instinct_actions SET parameters = ?,"
-                " updated_at = datetime('now') WHERE id = ?",
-                (_json.dumps(params), action_id),
-            )
-            await db.commit()
+        await store.update_parameters(action_id, params)
     except Exception:  # noqa: BLE001 — write-back is best-effort
         logger.warning(
             "external_action: failed to persist chain ids onto action %s — the "
@@ -334,6 +341,11 @@ async def propose_external_action(
         parameters={EXTERNAL_ACTION_PARAM_KEY: blob},
         assignee=assignee or requested_by or None,
         workspace_id=workspace_id,
+        # T-3 — the chain correlation id lands as a FIRST-CLASS column with the
+        # INSERT itself, so the Tray↔Decision join exists even if every
+        # best-effort emit / back-write below fails. The blob copy above stays
+        # for schema-1 compat.
+        correlation_id=corr,
     )
 
     logger.info(

--- a/ee/pocketpaw_ee/cloud/pockets/instinct_bridge.py
+++ b/ee/pocketpaw_ee/cloud/pockets/instinct_bridge.py
@@ -1,4 +1,13 @@
 # instinct_bridge.py — Routes a parked pocket write through Instinct.
+# Updated: 2026-08-05 (T-3, coupling-gap wave) — ``propose_pocket_write`` now
+#   passes the parked write's ``correlation_id`` into ``store.propose`` so it
+#   lands as a FIRST-CLASS column on the Action row at INSERT (the blob copy
+#   under ``_pocket_write.correlation_id`` stays for schema-2 compat). The
+#   Tray↔Decision join for parked writes no longer depends on parsing the
+#   untyped blob. ``parked_policy_event_id`` is a DIFFERENT event (the parked
+#   ``policy.evaluated``, not ``agent.proposed``) and deliberately stays
+#   blob-only — the ``proposed_event_id`` column is reserved for the
+#   chain-opening event id, which this path never holds.
 # Created: 2026-05-22 (RFC 05 M2b.1) — the impure counterpart to the pure
 #   `action_executor`. When `run_action` parks a `requires_instinct`
 #   write it returns an `instinct_pending` sentinel with the resolved
@@ -222,6 +231,13 @@ async def propose_pocket_write(
 
     approver = _resolve_approver(pocket, backend_config)
 
+    # T-3 — the executor-minted chain correlation id (when the parked write
+    # carries one) lands as a FIRST-CLASS column with the INSERT, so the
+    # Decision join never depends on the blob copy. A parked write without a
+    # chain id stays NULL — legal forever.
+    _blob_corr = pocket_write.get("correlation_id")
+    column_correlation_id = str(_blob_corr) if isinstance(_blob_corr, str) and _blob_corr else None
+
     # ISO: this propose path is reached from BOTH the agent stream (ContextVar
     # set) AND the REST run_action endpoint (FastAPI Depends, no ContextVar) —
     # so scope the store to the pocket's workspace explicitly. When the
@@ -237,6 +253,7 @@ async def propose_pocket_write(
         category=ActionCategory.EXTERNAL,
         parameters={"_pocket_write": pocket_write},
         assignee=approver or None,
+        correlation_id=column_correlation_id,
     )
     logger.info(
         "parked pocket write '%s' on pocket %s → Instinct action %s (approver=%s)",

--- a/ee/pocketpaw_ee/instinct/router.py
+++ b/ee/pocketpaw_ee/instinct/router.py
@@ -1,5 +1,14 @@
 # ee/instinct/router.py — FastAPI router for the Instinct decision pipeline API.
 # Created: 2026-03-28 — Propose, approve/reject, list pending, query audit.
+# Updated: 2026-08-05 (T-3, coupling-gap wave) — the action views returned by
+#   this router (``GET /instinct/actions``, ``GET /instinct/actions/pending``,
+#   and every endpoint whose response_model is ``Action``) now carry the
+#   Decision-Graph chain ids ``correlation_id`` + ``proposed_event_id`` as
+#   first-class, additive, nullable fields. No router code changed: the fields
+#   ride on the OSS ``Action`` model this router already serializes, so the FE
+#   can join a Tray row to its Decision chain without parsing the per-kind
+#   untyped ``parameters`` blob. Pinned by
+#   ``tests/instinct/test_correlation_columns.py::test_router_action_view_exposes_chain_ids``.
 # Updated: 2026-07-15 (B0 H2 — _customer_reply tenancy gate) — closed a gap in the
 #   FOUR-path dispatch: the paw-bar ``_customer_reply`` blob (carried by
 #   ``decision_loop.propose_customer_decision``) had a delivery hook on the

--- a/src/pocketpaw/instinct/models.py
+++ b/src/pocketpaw/instinct/models.py
@@ -1,5 +1,15 @@
 # Instinct data models — decision pipeline types.
 # Created: 2026-03-28
+# Updated: 2026-08-05 (T-3, coupling-gap wave) — added ADDITIVE, nullable
+#   ``Action.correlation_id`` + ``Action.proposed_event_id``. Until now the
+#   Decision-Graph chain ids were smuggled inside the per-kind untyped JSON
+#   parameter blobs (``_external_action`` / ``_pocket_write`` / ``_code_change``)
+#   and back-written after propose via best-effort raw SQL — a failed back-write
+#   left the action permanently unjoinable against its Decision chain. The ids
+#   are now first-class columns written at INSERT by the proposers that hold
+#   them; ``None`` stays legal forever (OSS propose paths and legacy rows carry
+#   no chain). The blob copies remain for blob-schema compat — the columns are
+#   the joinable source of truth.
 # Updated: 2026-07-31 (AL-1, agent ledger spine) — added an ADDITIVE, optional
 #   ``Action.actor_agent_id``. Until now the only record of WHICH agent proposed
 #   an action was a free-text ``trigger.source`` string ("paw_bar:<widget_id>",
@@ -150,6 +160,18 @@ class Action(BaseModel):
     # permanent-by-design: an action nobody could attribute still belongs in the
     # ledger, counted honestly as unattributed.
     actor_agent_id: str = ""
+    # ``correlation_id`` / ``proposed_event_id`` (T-3) — the Decision-Graph
+    # chain ids as FIRST-CLASS columns. ``correlation_id`` is the chain key
+    # every Decision event for this action shares (minted at propose time by
+    # the gated EE proposers); ``proposed_event_id`` is the id of the
+    # chain-opening ``agent.proposed`` event, when one was emitted. Both are
+    # nullable and default None: OSS propose paths carry no chain, and legacy
+    # rows predate the columns. The per-kind parameter blobs keep their own
+    # copies for blob-schema compat, but these columns are the joinable truth —
+    # Tray↔Decision navigation must never depend on a best-effort blob
+    # back-write again.
+    correlation_id: str | None = None
+    proposed_event_id: str | None = None
     pocket_id: str
     title: str
     description: str

--- a/src/pocketpaw/instinct/store.py
+++ b/src/pocketpaw/instinct/store.py
@@ -1,5 +1,23 @@
 # Instinct store — async SQLite operations for the decision pipeline.
 # Created: 2026-03-28 — Action lifecycle + audit log.
+# Updated: 2026-08-05 (T-3, coupling-gap wave) — the Decision-Graph chain ids
+#   become FIRST-CLASS columns on ``instinct_actions``:
+#   * ``correlation_id TEXT`` + ``proposed_event_id TEXT`` (additive ALTERs,
+#     same swallow-the-duplicate pattern as assignee / workspace_id /
+#     scope_type / actor_agent_id; NULL on legacy rows and OSS proposals).
+#   * ``propose`` gains keyword-only ``correlation_id`` / ``proposed_event_id``
+#     params (default None — every existing caller is untouched) and stamps
+#     the columns at INSERT; ``_row_to_action`` key-checks them back.
+#   * new ``set_chain_ids(action_id, ...)`` — a thin, status-preserving column
+#     write for the one id that is genuinely unknowable at insert time (the
+#     ``agent.proposed`` event id, emitted only after the row is durable).
+#     This replaces the EE proposers' raw-SQL blob back-writes as the joinable
+#     record: a failed back-write now only loses the event-id column, never
+#     the correlation join (that column landed at INSERT).
+#   * ``idx_actions_correlation`` index, created after the ALTER (same
+#     ordering rule as the workspace/scope indexes).
+#   The per-kind parameter blobs keep carrying their id copies for
+#   blob-schema compat; the columns are the source of truth for joins.
 # Updated: 2026-07-31 (AL-1, agent ledger spine) — two additions, one column and
 #   one emit:
 #   * ``instinct_actions`` gains ``actor_agent_id TEXT DEFAULT ''`` (additive
@@ -430,6 +448,11 @@ CREATE TABLE IF NOT EXISTS instinct_actions (
     -- unattributed, which stays legal forever — the proposer is not always
     -- knowable, and refusing the proposal over it would be absurd.
     actor_agent_id TEXT DEFAULT '',
+    -- Chain ids (T-3): the Decision-Graph correlation key + the chain-opening
+    -- ``agent.proposed`` event id, first-class instead of smuggled inside the
+    -- per-kind parameter blobs. NULL = no chain (OSS proposal or legacy row).
+    correlation_id TEXT,
+    proposed_event_id TEXT,
     created_at TEXT DEFAULT (datetime('now')),
     updated_at TEXT DEFAULT (datetime('now')),
     executed_at TEXT
@@ -504,6 +527,13 @@ _WORKSPACE_INDEX_SQL = (
 # serves the scope-aware (scope_type, scope_id) read; scope_id reuses pocket_id.
 _SCOPE_INDEX_SQL = (
     "CREATE INDEX IF NOT EXISTS idx_actions_scope ON instinct_actions(scope_type, pocket_id)",
+)
+
+# Chain-id index (T-3). Created AFTER the ALTER that adds correlation_id, for
+# the same pre-existing-DB reason as the workspace/scope indexes. Serves the
+# governance-chain join: "which Action belongs to this Decision chain".
+_CHAIN_INDEX_SQL = (
+    "CREATE INDEX IF NOT EXISTS idx_actions_correlation ON instinct_actions(correlation_id)",
 )
 
 
@@ -589,10 +619,22 @@ class InstinctStore:
                 )
             except aiosqlite.OperationalError:
                 pass
+            # Additive migration (T-3): the Decision-Graph chain-id columns on a
+            # pre-existing actions table. Same swallow-the-duplicate pattern.
+            # Pre-existing rows keep NULL (no chain recorded at insert; the ids
+            # may still live inside their parameter blobs from the old
+            # back-write era — the columns are only authoritative for rows
+            # written after this migration).
+            for _col in ("correlation_id", "proposed_event_id"):
+                try:
+                    await db.execute(f"ALTER TABLE instinct_actions ADD COLUMN {_col} TEXT")
+                except aiosqlite.OperationalError:
+                    pass
             # Tenancy indexes created only after the column is guaranteed to
             # exist — see _WORKSPACE_INDEX_SQL note above. Inside SCHEMA_SQL this
-            # would fail on a pre-W4a DB. The scope index follows the same rule.
-            for _idx in (*_WORKSPACE_INDEX_SQL, *_SCOPE_INDEX_SQL):
+            # would fail on a pre-W4a DB. The scope + chain indexes follow the
+            # same rule.
+            for _idx in (*_WORKSPACE_INDEX_SQL, *_SCOPE_INDEX_SQL, *_CHAIN_INDEX_SQL):
                 await db.execute(_idx)
             await db.commit()
         self._initialized = True
@@ -643,6 +685,9 @@ class InstinctStore:
         workspace_id: str | None = None,
         scope_type: str | None = None,
         actor_agent_id: str = "",
+        *,
+        correlation_id: str | None = None,
+        proposed_event_id: str | None = None,
     ) -> Action:
         """Raise a proposal for a human to decide.
 
@@ -650,10 +695,20 @@ class InstinctStore:
         optional and defaults to "" so every existing caller is unaffected;
         callers that know their agent should pass it, because propose time is
         the last moment that knowledge exists in the request.
+
+        ``correlation_id`` / ``proposed_event_id`` (T-3) are the Decision-Graph
+        chain ids, keyword-only and defaulting None so OSS callers are
+        untouched. The gated EE proposers mint the correlation_id BEFORE
+        calling propose, so it lands with the INSERT and the governance-chain
+        join can never be lost to a failed back-write. ``proposed_event_id`` is
+        usually unknown here (the ``agent.proposed`` event fires only after the
+        row is durable) — use :meth:`set_chain_ids` to fill it in.
         """
         action = Action(
             scope_type=scope_type,
             actor_agent_id=str(actor_agent_id or ""),
+            correlation_id=correlation_id,
+            proposed_event_id=proposed_event_id,
             pocket_id=pocket_id,
             title=title,
             description=description,
@@ -672,8 +727,8 @@ class InstinctStore:
                 " (id, pocket_id, title, description,"
                 " category, status, priority, trigger,"
                 " recommendation, parameters, context, assignee, workspace_id,"
-                " scope_type, actor_agent_id)"
-                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                " scope_type, actor_agent_id, correlation_id, proposed_event_id)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     action.id,
                     pocket_id,
@@ -690,6 +745,8 @@ class InstinctStore:
                     workspace_id,
                     scope_type,
                     action.actor_agent_id,
+                    correlation_id,
+                    proposed_event_id,
                 ),
             )
             await db.commit()
@@ -1164,6 +1221,50 @@ class InstinctStore:
                 "UPDATE instinct_actions SET parameters = ?, "
                 "updated_at = datetime('now') WHERE id = ?",
                 (json.dumps(parameters or {}), action_id),
+            )
+            await db.commit()
+            if cur.rowcount == 0:
+                return None
+        return await self.get_action(action_id)
+
+    async def set_chain_ids(
+        self,
+        action_id: str,
+        *,
+        correlation_id: str | None = None,
+        proposed_event_id: str | None = None,
+    ) -> Action | None:
+        """Persist the Decision-Graph chain-id columns on an Action (T-3).
+
+        A thin, status-preserving column write, sibling of
+        :meth:`update_parameters`: it touches ``correlation_id`` /
+        ``proposed_event_id`` + ``updated_at`` and NEVER ``status`` /
+        ``approved_*`` / the parameter blobs. Exists for the one id that is
+        genuinely unknowable at INSERT time — the ``agent.proposed`` event id,
+        which is minted only after the row is durable (the correlation_id
+        itself should ride in through :meth:`propose` at insert). Only the
+        arguments passed non-None are written, so filling the event id later
+        can never blank an already-stored correlation. Returns the reloaded
+        Action, or ``None`` when the id doesn't resolve (or nothing was
+        given to write).
+        """
+        sets: list[str] = []
+        params: list[Any] = []
+        if correlation_id is not None:
+            sets.append("correlation_id = ?")
+            params.append(correlation_id)
+        if proposed_event_id is not None:
+            sets.append("proposed_event_id = ?")
+            params.append(proposed_event_id)
+        if not sets:
+            return None
+        sets.append("updated_at = datetime('now')")
+        params.append(action_id)
+        await self._ensure_schema()
+        async with self._conn() as db:
+            cur = await db.execute(
+                f"UPDATE instinct_actions SET {', '.join(sets)} WHERE id = ?",
+                params,
             )
             await db.commit()
             if cur.rowcount == 0:
@@ -1799,6 +1900,11 @@ class InstinctStore:
         # from a DB that has not run the ALTER yet reads as unattributed rather
         # than raising IndexError on every list.
         actor_agent_id = (row["actor_agent_id"] if "actor_agent_id" in row.keys() else "") or ""
+        # T-3 — the Decision-Graph chain-id columns. Key-checked like the three
+        # above so a pre-migration row reads as chain-less (None) rather than
+        # raising IndexError.
+        correlation_id = row["correlation_id"] if "correlation_id" in row.keys() else None
+        proposed_event_id = row["proposed_event_id"] if "proposed_event_id" in row.keys() else None
         # The SQLite layer stamps created_at/updated_at as ISO strings.
         # Forward them on the rebuilt Action so consumers (outcome window
         # filters, age sorting) see real history instead of "now". Old
@@ -1809,6 +1915,8 @@ class InstinctStore:
             id=row["id"],
             scope_type=scope_type,
             actor_agent_id=actor_agent_id,
+            correlation_id=correlation_id,
+            proposed_event_id=proposed_event_id,
             pocket_id=row["pocket_id"],
             title=row["title"],
             description=row["description"] or "",

--- a/tests/cloud/test_belt_headless.py
+++ b/tests/cloud/test_belt_headless.py
@@ -2,6 +2,12 @@
 # the mandate→belt autonomy gap (feat/belt-headless-exec).
 #
 # Created: 2026-06-13.
+# Updated: 2026-08-05 (T-3, coupling-gap wave) — the success-path test now also
+#   pins that the minted chain ``correlation_id`` is mirrored onto the Action's
+#   first-class COLUMN (``after.correlation_id``), not just the ``_code_change``
+#   blob. The column is the joinable truth for Tray↔Decision navigation; the
+#   matching mutation (drop the ``set_chain_ids`` mirror in ``_attach_diff``)
+#   lives in tests/mutations/instinct_chain_columns.json.
 #
 # THE GAP UNDER TEST — before this, an approved mandate plan task became a
 # QUEUED ``code_change`` Instinct Action (``station_pending=True``, NO diff) and
@@ -137,6 +143,12 @@ async def test_headless_runner_produces_pending_diff(store: InstinctStore):
     # It is APPLYABLE-SHAPED: a chain correlation id was minted so the gate
     # closes the Decision-Graph chain on approve.
     assert cc.get("correlation_id")
+    # T-3 — the minted id is ALSO mirrored onto the first-class Action column
+    # (the joinable truth); a headless run whose mirror silently vanished would
+    # regress exactly what T-3 fixed. Mutation that must break this: drop the
+    # ``set_chain_ids`` call in headless.py's ``_attach_diff`` (codified in
+    # tests/mutations/instinct_chain_columns.json).
+    assert after.correlation_id == cc["correlation_id"]
     # CRITICAL — still PENDING. Not auto-approved, not executed.
     assert after.status == ActionStatus.PENDING
 

--- a/tests/cloud/test_instinct_correlation_columns.py
+++ b/tests/cloud/test_instinct_correlation_columns.py
@@ -110,6 +110,9 @@ async def test_external_action_join_survives_back_write_failure(store, monkeypat
         seen["called"] = True
         raise RuntimeError("simulated back-write failure (locked db)")
 
+    # (``seen`` is asserted after the propose below — it proves the failure was
+    # injected at the real back-write seam, not skipped by a code path change.)
+
     # Fail the back-write at its own seam — everything before it is the real
     # production path.
     monkeypatch.setattr(ea_propose, "_persist_chain_ids", _boom)
@@ -125,6 +128,10 @@ async def test_external_action_join_survives_back_write_failure(store, monkeypat
             params={"application_id": "app-9"},
             requested_by=USER,
         )
+
+    # The stub really fired at the back-write seam — the RuntimeError above came
+    # from OUR injection, not from an unrelated code path.
+    assert seen.get("called") is True
 
     # The proposal DID land (propose committed before the emit/back-write) and
     # carries its correlation on the column despite the failed back-write.

--- a/tests/cloud/test_instinct_correlation_columns.py
+++ b/tests/cloud/test_instinct_correlation_columns.py
@@ -1,0 +1,327 @@
+# tests/cloud/test_instinct_correlation_columns.py
+# Created: 2026-08-05 (T-3, coupling-gap wave) — the EE half of the first-class
+# Decision-Graph chain-id columns. The OSS store half lives in
+# tests/instinct/test_correlation_columns.py.
+#
+# What this pins — for all THREE gated proposers that hold a chain id:
+#   * external_actions.propose_external_action (``_external_action``),
+#   * pockets.instinct_bridge.propose_pocket_write (``_pocket_write``),
+#   * agent.mcp_servers.belt._propose_change_handler (``_code_change``):
+#   1. the ``correlation_id`` COLUMN is written at INSERT and the per-kind blob
+#      keeps its own copy (blob-schema compat — no reader breaks);
+#   2. the join no longer depends on the post-propose back-write: with the
+#      back-write forced to FAIL, the Action is still joinable to its chain via
+#      the column (pre-T-3 this left the row permanently unjoinable);
+#   3. a parked write with NO chain id stores NULL — nothing is invented;
+#   4. the cloud instinct router's action view exposes both ids additively, so
+#      the FE can join a Tray row to its Decision chain without parsing the
+#      untyped ``parameters`` blob.
+#
+# ``pocketpaw_ee`` is import-skipped on an OSS-only install. The Instinct store
+# is patched to a tmp file; nothing touches a real connector, journal, or repo
+# remote.
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+import pocketpaw_ee.agent.mcp_servers.belt as belt  # noqa: E402
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from pocketpaw_ee.cloud._core.deps import current_workspace_id  # noqa: E402
+from pocketpaw_ee.cloud._core.http import add_error_handler  # noqa: E402
+from pocketpaw_ee.cloud.auth import current_active_user  # noqa: E402
+from pocketpaw_ee.cloud.chat.agent_service import (  # noqa: E402
+    attach_agent_identity,
+    detach_agent_identity,
+)
+from pocketpaw_ee.cloud.external_actions import propose as ea_propose  # noqa: E402
+from pocketpaw_ee.cloud.license import require_license  # noqa: E402
+from pocketpaw_ee.cloud.pockets import instinct_bridge  # noqa: E402
+from pocketpaw_ee.instinct.router import router  # noqa: E402
+
+from pocketpaw.instinct.store import InstinctStore  # noqa: E402
+
+WS = "w1"
+USER = "u1"
+PARKED_CORR = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+
+@pytest.fixture
+def store(tmp_path: Path, monkeypatch) -> InstinctStore:
+    """Isolated InstinctStore wired everywhere the proposers read it (each
+    lazy-imports ``pocketpaw.stores.get_instinct_store``); the router's
+    ``_store`` indirection is pointed at it too for the read-path test."""
+    st = InstinctStore(tmp_path / "instinct_chain_ids.db")
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: st)
+    return st
+
+
+# ---------------------------------------------------------------------------
+# external_actions — the kind whose back-write was the original failure mode
+# ---------------------------------------------------------------------------
+
+
+async def test_external_action_propose_writes_column_and_keeps_blob(store, monkeypatch):
+    """propose_external_action lands the chain id on the COLUMN at INSERT, and
+    the schema-1 blob still carries its own copy.
+
+    The emit is stubbed to return None so the post-propose back-write never
+    runs — otherwise this would pass on the OLD behaviour too (the back-write
+    would fill the column). Mutation that must break it: drop
+    ``correlation_id=corr`` from the ``store.propose`` call.
+    """
+    monkeypatch.setattr(ea_propose, "_emit_agent_proposed", lambda **kwargs: None)
+
+    action_id = await ea_propose.propose_external_action(
+        workspace_id=WS,
+        connector_name="crm",
+        action="approveApplication",
+        params={"application_id": "app-7"},
+        requested_by=USER,
+    )
+    action = await store.get_action(action_id)
+    assert action is not None
+
+    blob = action.parameters["_external_action"]
+    assert blob["correlation_id"], "the blob copy must survive (schema-1 compat)"
+    # The column is the joinable record and agrees with the blob.
+    assert action.correlation_id == blob["correlation_id"]
+
+
+async def test_external_action_join_survives_back_write_failure(store, monkeypatch):
+    """THE regression this slice exists for: force the post-propose back-write to
+    fail and the Action is STILL joinable to its Decision chain via the column.
+
+    Pre-T-3 the correlation id only reached the row through this best-effort
+    write, so a failure left the action permanently unjoinable.
+    """
+    seen: dict[str, Any] = {}
+
+    async def _boom(**kwargs):
+        seen["called"] = True
+        raise RuntimeError("simulated back-write failure (locked db)")
+
+    # Fail the back-write at its own seam — everything before it is the real
+    # production path.
+    monkeypatch.setattr(ea_propose, "_persist_chain_ids", _boom)
+
+    with pytest.raises(RuntimeError):
+        # The emit path calls the back-write directly; a raising stub surfaces
+        # here, which is stricter than production's swallow — we only need the
+        # row to already carry the column by this point.
+        await ea_propose.propose_external_action(
+            workspace_id=WS,
+            connector_name="crm",
+            action="approveApplication",
+            params={"application_id": "app-9"},
+            requested_by=USER,
+        )
+
+    # The proposal DID land (propose committed before the emit/back-write) and
+    # carries its correlation on the column despite the failed back-write.
+    rows = await store.list_actions(pocket_id=WS)
+    assert len(rows) == 1
+    assert rows[0].correlation_id, "the chain join must not depend on the back-write"
+    assert rows[0].parameters["_external_action"]["correlation_id"] == rows[0].correlation_id
+
+
+async def test_external_action_back_write_fills_event_id_column(store, monkeypatch):
+    """When the back-write DOES run, it writes the ``agent.proposed`` event id to
+    the column (not just the blob) — the id that is genuinely unknowable at
+    insert time."""
+    fake_event_id = "12345678-1234-5678-1234-567812345678"
+    monkeypatch.setattr(
+        ea_propose,
+        "_emit_agent_proposed",
+        lambda **kwargs: __import__("uuid").UUID(fake_event_id),
+    )
+    action_id = await ea_propose.propose_external_action(
+        workspace_id=WS,
+        connector_name="crm",
+        action="approveApplication",
+        requested_by=USER,
+    )
+    action = await store.get_action(action_id)
+    assert action.proposed_event_id == fake_event_id
+    # Blob copies stay in sync for schema-1 readers.
+    assert action.parameters["_external_action"]["proposed_event_id"] == fake_event_id
+    assert action.parameters["_external_action"]["correlation_id"] == action.correlation_id
+
+
+# ---------------------------------------------------------------------------
+# instinct_bridge — the ``_pocket_write`` parked-write kind
+# ---------------------------------------------------------------------------
+
+
+def _pocket() -> dict[str, Any]:
+    return {"_id": "p1", "workspace": WS, "name": "Sales", "owner": USER}
+
+
+async def test_pocket_write_propose_writes_column_from_parked_correlation(store):
+    """The executor-minted chain id on the parked write lands on the COLUMN and
+    stays on the schema-2 blob."""
+    action_id = await instinct_bridge.propose_pocket_write(
+        pocket=_pocket(),
+        backend_config=None,
+        parked_write={
+            "action": "create_lead",
+            "method": "POST",
+            "path": "/leads",
+            "params": {"name": "acme"},
+            "correlation_id": PARKED_CORR,
+        },
+        requested_by=USER,
+    )
+    action = await store.get_action(action_id)
+    assert action is not None
+    assert action.correlation_id == PARKED_CORR
+    assert action.parameters["_pocket_write"]["correlation_id"] == PARKED_CORR
+
+
+async def test_pocket_write_without_correlation_stores_null(store):
+    """A parked write with no chain id stores NULL — nothing is invented."""
+    action_id = await instinct_bridge.propose_pocket_write(
+        pocket=_pocket(),
+        backend_config=None,
+        parked_write={"action": "create_lead", "method": "POST", "path": "/leads"},
+        requested_by=USER,
+    )
+    action = await store.get_action(action_id)
+    assert action is not None
+    assert action.correlation_id is None
+    assert action.proposed_event_id is None
+
+
+# ---------------------------------------------------------------------------
+# belt — the ``_code_change`` kind
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A minimal git repo — propose only validates that ``.git`` exists inside
+    the allowlist; nothing is applied or pushed here."""
+    work = tmp_path / "work"
+    work.mkdir()
+    subprocess.run(["git", "init", "-q", str(work)], check=True)
+    (work / "app.py").write_text("def hello():\n    return 'hi'\n", encoding="utf-8")
+    return work
+
+
+@pytest.fixture
+def allowlist(repo: Path, monkeypatch) -> None:
+    from pocketpaw.config import get_settings
+
+    real = get_settings()
+
+    class _S:
+        belt_repo_allowlist = [str(repo.parent)]
+
+        def __getattr__(self, name):
+            return getattr(real, name)
+
+    monkeypatch.setattr("pocketpaw.config.get_settings", lambda: _S())
+
+
+async def test_belt_propose_writes_column_and_keeps_blob(store, repo, allowlist, monkeypatch):
+    """The belt develop-station propose lands its minted chain id on the COLUMN
+    at INSERT; the schema-2 blob keeps its copy.
+
+    The emit is stubbed to return None so the post-propose back-write never
+    runs — otherwise this would pass on the OLD behaviour too. Mutation that
+    must break it: drop ``correlation_id=str(correlation_id)`` from the
+    ``store.propose`` call in ``_propose_change_handler``.
+    """
+    monkeypatch.setattr(belt, "_emit_agent_proposed", lambda **kwargs: None)
+
+    tokens = attach_agent_identity(workspace_id=WS, user_id=USER, session_mongo_id="sess-1")
+    try:
+        res = await belt._propose_change_handler(
+            {
+                "repo": str(repo),
+                "base_branch": "main",
+                "diff": (
+                    "--- a/app.py\n+++ b/app.py\n@@ -1,2 +1,2 @@\n"
+                    " def hello():\n-    return 'hi'\n+    return 'hello'\n"
+                ),
+                "summary": "Friendlier greeting.",
+                "task": "Make the greeting friendlier.",
+            }
+        )
+    finally:
+        detach_agent_identity(tokens)
+
+    assert res.get("is_error") is not True, res
+    rows = await store.list_actions(pocket_id=WS)
+    assert len(rows) == 1
+    action = rows[0]
+    blob = action.parameters["_code_change"]
+    assert blob["correlation_id"], "the blob copy must survive (schema-2 compat)"
+    assert action.correlation_id == blob["correlation_id"]
+
+
+# ---------------------------------------------------------------------------
+# read path — the cloud instinct router's action view
+# ---------------------------------------------------------------------------
+
+
+class _FakeUser:
+    def __init__(self, user_id: str = USER, workspace_id: str = WS) -> None:
+        self.id = user_id
+        self.active_workspace = workspace_id
+
+        class _M:
+            def __init__(self, ws):
+                self.workspace = ws
+                self.role = "admin"
+
+        self.workspaces = [_M(workspace_id)]
+
+
+def _make_client(monkeypatch) -> TestClient:
+    import pocketpaw_ee.cloud.workspace.service as ws_svc
+
+    monkeypatch.setattr(ws_svc, "get_workspace_plan", AsyncMock(return_value="enterprise"))
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(router)
+    app.dependency_overrides[require_license] = lambda: None
+    app.dependency_overrides[current_active_user] = lambda: _FakeUser()
+    app.dependency_overrides[current_workspace_id] = lambda: WS
+    return TestClient(app)
+
+
+async def test_router_action_view_exposes_chain_ids(store, monkeypatch):
+    """Both list views expose ``correlation_id`` + ``proposed_event_id`` on the
+    wire (additively) so the FE can join a Tray row to its Decision chain."""
+    action_id = await ea_propose.propose_external_action(
+        workspace_id=WS,
+        connector_name="crm",
+        action="approveApplication",
+        requested_by=USER,
+    )
+    stored = await store.get_action(action_id)
+
+    client = _make_client(monkeypatch)
+
+    listed = client.get("/instinct/actions", params={"pocket_id": WS})
+    assert listed.status_code == 200, listed.text
+    row = next(a for a in listed.json()["actions"] if a["id"] == action_id)
+    assert "correlation_id" in row
+    assert "proposed_event_id" in row
+    assert row["correlation_id"] == stored.correlation_id
+
+    pending = client.get("/instinct/actions/pending", params={"pocket_id": WS})
+    assert pending.status_code == 200, pending.text
+    prow = next(a for a in pending.json() if a["id"] == action_id)
+    assert prow["correlation_id"] == stored.correlation_id

--- a/tests/instinct/test_correlation_columns.py
+++ b/tests/instinct/test_correlation_columns.py
@@ -1,0 +1,214 @@
+# tests/instinct/test_correlation_columns.py
+# Created: 2026-08-05 (T-3, coupling-gap wave) — coverage for the ADDITIVE
+# Decision-Graph chain-id columns on the Instinct store. Until T-3 the chain ids
+# lived only inside the per-kind untyped ``parameters`` blobs and were
+# back-written by best-effort raw SQL after propose, so a failed back-write left
+# an action permanently unjoinable against its Decision chain. These are OSS
+# store tests — no cloud extras, no beanie, just a tmp SQLite db. Pins that:
+#   1. propose(correlation_id=..., proposed_event_id=...) populates the columns
+#      and they round-trip through get_action / list_actions / pending.
+#   2. A plain OSS propose (no ids) stores NULLs and nothing breaks — the
+#      pre-T-3 behaviour, unchanged.
+#   3. set_chain_ids writes each column independently, is status-preserving,
+#      never blanks an already-stored id, and returns None for an unknown id.
+#   4. A pre-T-3 DB file (columns stripped from the schema) upgrades cleanly on
+#      open and its old rows read as NULL.
+from __future__ import annotations
+
+import re
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from pocketpaw.instinct.models import ActionStatus, ActionTrigger
+from pocketpaw.instinct.store import SCHEMA_SQL, InstinctStore
+
+pytestmark = pytest.mark.asyncio
+
+TRIGGER = ActionTrigger(type="agent", source="claude", reason="chain-id test")
+
+CORR = "11111111-2222-3333-4444-555555555555"
+EVENT = "99999999-8888-7777-6666-555555555555"
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> InstinctStore:
+    return InstinctStore(tmp_path / "chain.db")
+
+
+async def test_propose_with_chain_ids_populates_columns(store: InstinctStore) -> None:
+    """propose with the chain ids stores them as COLUMNS, readable back on the
+    Action without touching ``parameters``."""
+    action = await store.propose(
+        pocket_id="w1",
+        title="gated call",
+        description="",
+        recommendation="",
+        trigger=TRIGGER,
+        correlation_id=CORR,
+        proposed_event_id=EVENT,
+    )
+    assert action.correlation_id == CORR
+    assert action.proposed_event_id == EVENT
+
+    fetched = await store.get_action(action.id)
+    assert fetched is not None
+    assert fetched.correlation_id == CORR
+    assert fetched.proposed_event_id == EVENT
+
+    # And the ids survive the list / pending read paths too (same row mapper).
+    listed = await store.list_actions(pocket_id="w1")
+    assert [r.correlation_id for r in listed] == [CORR]
+    pending = await store.pending(pocket_id="w1")
+    assert [r.proposed_event_id for r in pending] == [EVENT]
+
+
+async def test_propose_with_chain_ids_keeps_blob_copies(store: InstinctStore) -> None:
+    """The columns are ADDITIVE — a caller that also carries the ids inside its
+    per-kind blob keeps that copy verbatim (blob-schema compat)."""
+    blob = {"kind": "external_action", "schema": 1, "correlation_id": CORR}
+    action = await store.propose(
+        pocket_id="w1",
+        title="gated call",
+        description="",
+        recommendation="",
+        trigger=TRIGGER,
+        parameters={"_external_action": blob},
+        correlation_id=CORR,
+    )
+    fetched = await store.get_action(action.id)
+    assert fetched is not None
+    assert fetched.correlation_id == CORR
+    assert fetched.parameters["_external_action"]["correlation_id"] == CORR
+    assert fetched.parameters["_external_action"]["schema"] == 1
+
+
+async def test_propose_without_chain_ids_stores_nulls(store: InstinctStore) -> None:
+    """The plain OSS propose path is untouched: no chain ids given → both
+    columns NULL, every read still works."""
+    action = await store.propose(
+        pocket_id="pocket-1",
+        title="ordinary proposal",
+        description="",
+        recommendation="",
+        trigger=TRIGGER,
+    )
+    assert action.correlation_id is None
+    assert action.proposed_event_id is None
+
+    fetched = await store.get_action(action.id)
+    assert fetched is not None
+    assert fetched.correlation_id is None
+    assert fetched.proposed_event_id is None
+
+    # The lifecycle still runs end-to-end on a chain-less action.
+    approved = await store.approve(action.id, approver="u1")
+    assert approved is not None
+    assert approved.status == ActionStatus.APPROVED
+    assert approved.correlation_id is None
+
+    # And the raw column really is NULL, not the string "None".
+    with sqlite3.connect(store._db_path) as conn:
+        row = conn.execute(
+            "SELECT correlation_id, proposed_event_id FROM instinct_actions WHERE id = ?",
+            (action.id,),
+        ).fetchone()
+    assert row == (None, None)
+
+
+async def test_set_chain_ids_fills_event_id_without_touching_status(
+    store: InstinctStore,
+) -> None:
+    """The late-arriving ``agent.proposed`` event id lands via set_chain_ids —
+    a status-preserving column write that leaves the correlation intact."""
+    action = await store.propose(
+        pocket_id="w1",
+        title="gated call",
+        description="",
+        recommendation="",
+        trigger=TRIGGER,
+        correlation_id=CORR,
+    )
+    assert action.proposed_event_id is None
+
+    updated = await store.set_chain_ids(action.id, proposed_event_id=EVENT)
+    assert updated is not None
+    # The correlation that landed at INSERT is NOT blanked by a partial write.
+    assert updated.correlation_id == CORR
+    assert updated.proposed_event_id == EVENT
+    # Status-preserving — this is not a lifecycle write.
+    assert updated.status == ActionStatus.PENDING
+
+
+async def test_set_chain_ids_unknown_action_and_empty_call(store: InstinctStore) -> None:
+    """An id that doesn't resolve returns None; so does a call with nothing to
+    write (no accidental ``updated_at``-only churn)."""
+    assert await store.set_chain_ids("act_missing", correlation_id=CORR) is None
+
+    action = await store.propose(
+        pocket_id="w1",
+        title="gated call",
+        description="",
+        recommendation="",
+        trigger=TRIGGER,
+    )
+    assert await store.set_chain_ids(action.id) is None
+
+
+def _strip_chain_columns(schema_sql: str) -> str:
+    """Return ``schema_sql`` with the T-3 chain-id column declarations removed —
+    reconstructing the pre-T-3 CREATE TABLE text. Same technique as
+    tests/cloud/test_w4a_migration.py's ``_strip_workspace_id`` (an ALTER ...
+    DROP COLUMN can't always be rewritten by SQLite)."""
+    for col in ("correlation_id", "proposed_event_id"):
+        schema_sql = re.sub(rf"\n[ \t]*{col} TEXT,", "", schema_sql)
+    return schema_sql
+
+
+async def test_pre_t3_db_upgrades_cleanly_and_old_rows_read_null(tmp_path: Path) -> None:
+    """A DB file written BEFORE the chain-id columns existed opens cleanly (the
+    guarded ALTERs run), its pre-existing rows read as NULL, and a fresh propose
+    on the migrated file can carry the ids."""
+    db = tmp_path / "instinct_pre_t3.db"
+    pre_t3_schema = _strip_chain_columns(SCHEMA_SQL)
+    assert "correlation_id" not in pre_t3_schema  # the fixture really is pre-T-3
+
+    conn = sqlite3.connect(db)
+    conn.executescript(pre_t3_schema)
+    # A legacy row written by the old code — no chain-id columns to write to.
+    conn.execute(
+        "INSERT INTO instinct_actions (id, pocket_id, title, trigger, parameters)"
+        " VALUES (?, ?, ?, ?, ?)",
+        (
+            "act_legacy",
+            "pocket-old",
+            "legacy proposal",
+            TRIGGER.model_dump_json(),
+            '{"_external_action": {"correlation_id": "blob-only-id"}}',
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    store = InstinctStore(db)
+    # Pre-fix this raised OperationalError: no such column: correlation_id.
+    legacy = await store.get_action("act_legacy")
+    assert legacy is not None
+    assert legacy.correlation_id is None
+    assert legacy.proposed_event_id is None
+    # The old blob copy is untouched — nothing was backfilled or guessed.
+    assert legacy.parameters["_external_action"]["correlation_id"] == "blob-only-id"
+
+    # The migrated file takes new chain-carrying rows.
+    fresh = await store.propose(
+        pocket_id="pocket-old",
+        title="post-migration",
+        description="",
+        recommendation="",
+        trigger=TRIGGER,
+        correlation_id=CORR,
+    )
+    assert (await store.get_action(fresh.id)).correlation_id == CORR
+    # Both rows co-exist on the legacy read path.
+    assert len(await store.list_actions(pocket_id="pocket-old")) == 2

--- a/tests/mutations/instinct_chain_columns.json
+++ b/tests/mutations/instinct_chain_columns.json
@@ -1,0 +1,44 @@
+[
+  {
+    "label": "external_actions propose drops the insert-time correlation column write",
+    "file": "ee/pocketpaw_ee/cloud/external_actions/propose.py",
+    "find": "        # for schema-1 compat.\n        correlation_id=corr,\n",
+    "replace": "        # for schema-1 compat.\n",
+    "tests": ["tests/cloud/test_instinct_correlation_columns.py"]
+  },
+  {
+    "label": "instinct_bridge propose drops the insert-time correlation column write",
+    "file": "ee/pocketpaw_ee/cloud/pockets/instinct_bridge.py",
+    "find": "        correlation_id=column_correlation_id,\n",
+    "replace": "",
+    "tests": ["tests/cloud/test_instinct_correlation_columns.py"]
+  },
+  {
+    "label": "belt propose drops the insert-time correlation column write",
+    "file": "ee/pocketpaw_ee/agent/mcp_servers/belt.py",
+    "find": "            # stays for schema-2 compat.\n            correlation_id=str(correlation_id),\n",
+    "replace": "            # stays for schema-2 compat.\n",
+    "tests": ["tests/cloud/test_instinct_correlation_columns.py"]
+  },
+  {
+    "label": "store drops the guarded ALTER that adds the chain-id columns to old DBs",
+    "file": "src/pocketpaw/instinct/store.py",
+    "find": "            for _col in (\"correlation_id\", \"proposed_event_id\"):\n                try:\n                    await db.execute(f\"ALTER TABLE instinct_actions ADD COLUMN {_col} TEXT\")\n                except aiosqlite.OperationalError:\n                    pass\n",
+    "replace": "",
+    "tests": ["tests/instinct/test_correlation_columns.py"]
+  },
+  {
+    "label": "external_actions back-write stops filling the proposed_event_id column",
+    "file": "ee/pocketpaw_ee/cloud/external_actions/propose.py",
+    "find": "        await store.set_chain_ids(\n            action_id,\n            correlation_id=correlation_id,\n            proposed_event_id=proposed_event_id,\n        )\n",
+    "replace": "",
+    "tests": ["tests/cloud/test_instinct_correlation_columns.py"]
+  },
+  {
+    "label": "headless _attach_diff stops mirroring the minted correlation onto the column",
+    "file": "ee/pocketpaw_ee/cloud/belt/headless.py",
+    "find": "            if chain_correlation_id:\n                await store.set_chain_ids(action_id, correlation_id=chain_correlation_id)\n",
+    "replace": "            pass\n",
+    "tests": ["tests/cloud/test_belt_headless.py"]
+  }
+]


### PR DESCRIPTION
The decision-chain correlation id — the key that joins an Instinct action to the Decision explaining it — lived inside per-kind JSON parameter blobs, written after the fact by a best-effort raw-SQL UPDATE. A failed back-write left the action permanently unjoinable, and the core Action model had no correlation column at all. Tray-to-Decision navigation and the whole governance-join story dead-ended there.

correlation_id and proposed_event_id are now nullable columns on instinct_actions and the Action model, written at INSERT by all three gated proposers (external actions, the parked pocket-write bridge, the belt develop station). The raw-SQL blob back-writes are gone; what remains is a set_chain_ids column write for the agent.proposed event id — genuinely unknowable at insert — plus a blob refresh for schema compat. Old DB files upgrade through a guarded ALTER and read NULL; OSS propose paths are untouched (keyword-only params defaulting None).

Judgment calls a reviewer should see rather than discover:

- belt's headless runner mints its chain id during diff-attach, not insert (the mandate dispatcher files the row with no chain id in hand), so it mirrors to the column best-effort after the attach commits — a column failure can never cost the diff.
- The parked pocket-write's policy event id stays blob-only on purpose: it is the parked policy.evaluated, a different event, and putting it in proposed_event_id would corrupt that column's meaning.
- The other gated kinds (_admin_action, _instinct_rule, _fabric_objects, _pocket_create, _fabric_conflict) still use the old pattern and read NULL — documented as legal, migrated when their slices come up.

Tests: 22 across the OSS store, cloud wire, and belt headless paths, plus a 6-mutation plan (each proposer's insert-time write dropped, the migration dropped, the back-write seam, the headless mirror) — all caught. Two first-draft tests originally passed under mutation because the legacy back-write refilled the column; they were tightened to stub the emit and pin insert-time, which is why the plan is trustworthy. Full suite: failure name sets identical to a clean dev baseline (+6 = exactly the new tests). Note for anyone re-running: pyproject's addopts hides tests/cloud from bare pytest — run it explicitly.

Stacked child: the audit hash-chain gains the same join in a follow-up PR based on this branch. Merge this one with --rebase, not --squash, so the stack survives.