### PR TITLE
feat(instinct): the audit ledger joins the decision chain

### DIFF
--- a/docs/concepts/decision-graph.mdx
+++ b/docs/concepts/decision-graph.mdx
@@ -77,6 +77,18 @@ Both are exposed on the `Action` model and on every action view the Instinct rou
 
 The per-kind blobs (`_external_action`, `_pocket_write`, `_code_change`) still carry their own copies of these ids for blob-schema compatibility, but the **columns are the source of truth**: they land with the INSERT, so the join survives a failed best-effort back-write. `NULL` is legal and permanent — an OSS proposal opens no chain, and rows written before the columns existed were never backfilled (a guessed correlation in an evidence table is worse than an honest blank).
 
+### The audit ledger joins too
+
+The Instinct audit ledger (`instinct_audit`) is the tamper-evident legal record: a sha256 hash chain where each row folds in the previous row's hash, so an insertion, edit or deletion is detectable. On its own it could prove *action X was approved by Y at time T* and nothing more. Why the approval happened — the inputs, the policy evaluation, the precedents — lived in the Decision chain, with no key joining the two records of the same event.
+
+Audit rows now carry `correlation_id` as well, copied at append time from the action's own column (never re-derived from a `parameters` blob). Both writers stamp it, since the propose-time entry and every lifecycle entry (approve / reject / auto-approve / execute / fail) share one append chokepoint. It rides on `AuditEntry`, so `GET /instinct/audit`, `GET /instinct/audit/{id}` and `export_audit` all expose it with no router change.
+
+The id is **copied rather than joined at read time** on purpose: an exported trail has to stand alone, and by the time an auditor reads it the actions table may be purged, archived, or in another tenant's file.
+
+**It is not chain material.** `correlation_id` is deliberately outside `_canonical_audit_payload` and never reaches `compute_audit_hash` — exactly how `workspace_id` has been treated since tenancy landed. Only content fields are hashed, so a ledger written before the column existed still verifies byte-for-byte after the migration. Folding a join column into the hash would silently invalidate every historical chain, so `tests/instinct/test_audit_correlation.py` pins a known-good canonical payload and digest and fails loudly if anyone tries.
+
+`NULL` is legal and permanent here too: an OSS proposal opens no chain, a system event written through `log()` has no action at all, and pre-existing rows were never backfilled.
+
 ## The Python API
 
 `pocketpaw_ee.cloud.decisions.service.DecisionGraph` is the in-process surface. One instance per process (per org), accessed via `get_decision_graph()`. All methods are `async`:

--- a/src/pocketpaw/instinct/models.py
+++ b/src/pocketpaw/instinct/models.py
@@ -1,5 +1,17 @@
 # Instinct data models — decision pipeline types.
 # Created: 2026-03-28
+# Updated: 2026-08-06 (T-4, coupling-gap wave) — added an ADDITIVE, nullable
+#   ``AuditEntry.correlation_id`` (the INSTINCT AuditEntry below, not the
+#   unrelated class of the same name in ``pocketpaw/audit/models.py``). The
+#   tamper-evident ledger could prove "action X was approved by Y at T" but not
+#   WHY: the legal record and the Decision-Graph explainability record were two
+#   chains over the same event with no key between them. The store now copies
+#   the id off the action's own ``correlation_id`` column (T-3) at append time.
+#   ``None`` stays legal forever — an OSS proposal opens no chain, a ``log()``
+#   system event has no action at all, and pre-T-4 rows were never backfilled.
+#   The field is NOT hash material: it lives outside the store's
+#   ``_canonical_audit_payload``, exactly as tenancy does, so ledgers written
+#   before it existed still verify byte-for-byte.
 # Updated: 2026-08-05 (T-3, coupling-gap wave) — added ADDITIVE, nullable
 #   ``Action.correlation_id`` + ``Action.proposed_event_id``. Until now the
 #   Decision-Graph chain ids were smuggled inside the per-kind untyped JSON
@@ -226,3 +238,14 @@ class AuditEntry(BaseModel):
     context: dict[str, Any] = Field(default_factory=dict)
     ai_recommendation: str | None = None
     outcome: str | None = None
+    # ``correlation_id`` (T-4) — the Decision-Graph chain key of the action this
+    # entry records, copied off ``instinct_actions.correlation_id`` (T-3) when
+    # the row is appended. It turns the legal ledger row into a joinable one:
+    # "approved by whom" now reaches the inputs, policy evaluation and
+    # precedents that explain the approval. Nullable and last in the field
+    # order so an existing export's key order is undisturbed.
+    # DO NOT hash it. The W2b chain hashes only the fields above it, via the
+    # store's ``_canonical_audit_payload``; this column sits outside that
+    # payload exactly as ``workspace_id`` does. Folding it in would make every
+    # ledger written before T-4 read as tampered.
+    correlation_id: str | None = None

--- a/src/pocketpaw/instinct/store.py
+++ b/src/pocketpaw/instinct/store.py
@@ -1,5 +1,40 @@
 # Instinct store — async SQLite operations for the decision pipeline.
 # Created: 2026-03-28 — Action lifecycle + audit log.
+# Updated: 2026-08-06 (T-4, coupling-gap wave) — the tamper-evident
+#   ``instinct_audit`` ledger now carries the Decision-Graph ``correlation_id``,
+#   so the LEGAL record ("action X was approved by Y at T") joins to the
+#   EXPLAINABILITY record ("…and here are the inputs, the policy evaluation and
+#   the precedents that produced it"). They were two disconnected chains over
+#   the same event.
+#   * ``instinct_audit`` gains ``correlation_id TEXT`` (additive ALTER, same
+#     swallow-the-duplicate pattern as prev_hash/entry_hash, workspace_id and
+#     the T-3 action columns) plus ``idx_audit_correlation``, created after the
+#     ALTER for the same pre-existing-DB reason as every other index here.
+#   * ``_append_audit_locked`` stamps it from the ACTION ROW'S OWN COLUMN (the
+#     T-3 first-class ``instinct_actions.correlation_id``) — never re-derived
+#     from the per-kind parameter blobs. One read at the single append
+#     chokepoint, so both writers (``_log`` and the in-transaction
+#     ``_update_status``) record it identically.
+#   * ``_row_to_audit`` key-checks it back onto the AuditEntry model, so every
+#     read path (``query_audit`` / ``get_audit_entry`` / ``export_audit``) and
+#     the EE audit views that serialize that model carry it with no change.
+#   Why COPY it instead of joining through ``action_id`` at read time: the
+#   ledger is the legal record and has to stand alone. An exported trail must
+#   carry the chain key even when the actions table has been purged, archived,
+#   or lives in another tenant's file.
+#   AUDIT-CHAIN INVARIANT (do not break): ``correlation_id`` is deliberately NOT
+#   part of ``_canonical_audit_payload`` and NOT folded into the hash — EXACTLY
+#   the treatment ``workspace_id`` gets (W4a, below). It is a JOIN column, not
+#   chain content: every ledger written before T-4 must keep verifying
+#   byte-for-byte, so the hash material is frozen. ``verify_audit_chain``'s
+#   explicit SELECT list omits the column for the same reason, and
+#   tests/instinct/test_audit_correlation.py pins a known-good canonical payload
+#   + digest so a refactor that folds it in fails loudly instead of silently
+#   invalidating every historical chain.
+#   The lookup is FAIL-QUIET (any error yields None). The chain append stays
+#   LOUD, but an explainability join must never be able to fail a human's
+#   approval — the pre-T-4 posture was no join at all, and degrading to that is
+#   always better than refusing the decision.
 # Updated: 2026-08-05 (T-3, coupling-gap wave) — the Decision-Graph chain ids
 #   become FIRST-CLASS columns on ``instinct_actions``:
 #   * ``correlation_id TEXT`` + ``proposed_event_id TEXT`` (additive ALTERs,
@@ -478,7 +513,14 @@ CREATE TABLE IF NOT EXISTS instinct_audit (
     -- Tenancy (W4a): owning workspace. This is a READ-FILTER column only — it
     -- is intentionally NOT part of the canonical hash payload, so the global
     -- W2b chain linkage and verify are unaffected. NULL = legacy/global.
-    workspace_id TEXT
+    workspace_id TEXT,
+    -- Chain join (T-4): the Decision-Graph correlation id, COPIED from the
+    -- action this row records so the legal ledger joins to the Decision that
+    -- explains WHY it happened. Like workspace_id above, a plain column ONLY —
+    -- NOT in the canonical hash payload, so every pre-T-4 chain still verifies
+    -- byte-for-byte. NULL = the action opened no chain, the row records no
+    -- action at all (a ``log()`` system event), or it predates the column.
+    correlation_id TEXT
 );
 
 CREATE TABLE IF NOT EXISTS instinct_corrections (
@@ -529,11 +571,14 @@ _SCOPE_INDEX_SQL = (
     "CREATE INDEX IF NOT EXISTS idx_actions_scope ON instinct_actions(scope_type, pocket_id)",
 )
 
-# Chain-id index (T-3). Created AFTER the ALTER that adds correlation_id, for
-# the same pre-existing-DB reason as the workspace/scope indexes. Serves the
-# governance-chain join: "which Action belongs to this Decision chain".
+# Chain-id indexes (T-3 actions, T-4 audit). Created AFTER the ALTERs that add
+# the correlation columns, for the same pre-existing-DB reason as the
+# workspace/scope indexes. They serve the two halves of the governance join:
+# "which Action belongs to this Decision chain" and "which audit rows record
+# it" — the second is what lets an auditor pull a chain's whole legal trail.
 _CHAIN_INDEX_SQL = (
     "CREATE INDEX IF NOT EXISTS idx_actions_correlation ON instinct_actions(correlation_id)",
+    "CREATE INDEX IF NOT EXISTS idx_audit_correlation ON instinct_audit(correlation_id)",
 )
 
 
@@ -630,6 +675,20 @@ class InstinctStore:
                     await db.execute(f"ALTER TABLE instinct_actions ADD COLUMN {_col} TEXT")
                 except aiosqlite.OperationalError:
                     pass
+            # Additive migration (T-4): the Decision-Graph chain key on a
+            # pre-existing AUDIT ledger. Same swallow-the-duplicate pattern.
+            # Pre-existing rows keep NULL — deliberately NOT backfilled, for the
+            # same reason T-3 refused to: a guessed correlation in the legal
+            # record is worse than an honest blank. CRITICAL: this is a JOIN
+            # column only. It is not part of ``_canonical_audit_payload`` and
+            # never reaches ``compute_audit_hash``, so a ledger written before
+            # this ALTER still verifies byte-for-byte after it (see the header's
+            # AUDIT-CHAIN INVARIANT, and tests/instinct/test_audit_correlation.py
+            # which builds a pre-T-4 chain, migrates it, and re-verifies).
+            try:
+                await db.execute("ALTER TABLE instinct_audit ADD COLUMN correlation_id TEXT")
+            except aiosqlite.OperationalError:
+                pass
             # Tenancy indexes created only after the column is guaranteed to
             # exist — see _WORKSPACE_INDEX_SQL note above. Inside SCHEMA_SQL this
             # would fail on a pre-W4a DB. The scope + chain indexes follow the
@@ -1459,9 +1518,11 @@ class InstinctStore:
 
         CONTRACT: the caller MUST already hold ``self._log_lock`` so the chain
         read-head + insert stays serialized (REVIEW-1). The W2b canonical hash
-        is computed identically on both paths — ``workspace_id`` is appended as
-        a plain column ONLY and is deliberately absent from the canonical
-        payload and the hash (the chain is GLOBAL; tenancy is a read filter).
+        is computed identically on both paths — ``workspace_id`` (tenancy) and
+        ``correlation_id`` (T-4, the Decision-Graph join) are appended as plain
+        columns ONLY and are deliberately absent from the canonical payload and
+        the hash (the chain is GLOBAL; those two are a read filter and a join
+        key, not chain content).
         """
         # The SQLite ``timestamp`` column defaults to ``datetime('now')`` and is
         # what a reader sees, but the hash must be computed over a value we
@@ -1497,18 +1558,34 @@ class InstinctStore:
         prev_hash = prev_row[0] if prev_row else ""
         entry_hash = compute_audit_hash(canonical, prev_hash)
 
-        # ``workspace_id`` (W4a) is appended as a plain column ONLY. It is
-        # deliberately absent from ``canonical`` above and from
-        # ``compute_audit_hash`` — the W2b chain is GLOBAL and must hash
-        # identically on re-verification regardless of tenancy. Tenancy is a
-        # read filter, not chain content.
+        # T-4 — the Decision-Graph chain key, read from the ACTION ROW'S OWN
+        # COLUMN (T-3) rather than passed in by callers, so both append paths
+        # (``_log`` and the in-transaction ``_update_status``) stamp it
+        # identically and no proposer has to remember to thread it. Read AFTER
+        # the hash is computed, which is the point: it is not hash material.
+        # An entry that already carries one (a caller-supplied id on an
+        # action-less ``log()`` row) keeps it when the action lookup finds
+        # nothing — the action's column wins because it is the authoritative
+        # join, but a row with no action is not forced to lose its context.
+        correlation_id = await self._action_correlation_id(db, entry.action_id)
+        if correlation_id is None:
+            correlation_id = entry.correlation_id
+        entry.correlation_id = correlation_id
+
+        # ``workspace_id`` (W4a) and ``correlation_id`` (T-4) are appended as
+        # plain columns ONLY. Both are deliberately absent from ``canonical``
+        # above and from ``compute_audit_hash`` — the W2b chain is GLOBAL and
+        # must hash identically on re-verification regardless of tenancy, and
+        # must keep verifying on ledgers written before the join column
+        # existed. Tenancy is a read filter; the correlation is a join key.
+        # Neither is chain content.
         await db.execute(
             "INSERT INTO instinct_audit"
             " (id, action_id, pocket_id, timestamp, actor, event,"
             " category, description, context,"
             " ai_recommendation, outcome, prev_hash, entry_hash,"
-            " workspace_id)"
-            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            " workspace_id, correlation_id)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 entry.id,
                 entry.action_id,
@@ -1524,8 +1601,48 @@ class InstinctStore:
                 prev_hash,
                 entry_hash,
                 workspace_id,
+                correlation_id,
             ),
         )
+
+    async def _action_correlation_id(
+        self, db: aiosqlite.Connection, action_id: str | None
+    ) -> str | None:
+        """Read an Action's Decision-Graph correlation id from its COLUMN (T-4).
+
+        Reads ``instinct_actions.correlation_id`` — the first-class column T-3
+        added — and NEVER the per-kind ``parameters`` blobs. The blobs still
+        carry their own copies for schema compat, but they were the old
+        best-effort record; parsing them here would re-import exactly the
+        fragility T-3 removed.
+
+        Runs on the CALLER'S connection so the in-transaction append path
+        (``_update_status``) sees its own uncommitted row. Timing is not a
+        problem in practice: a proposer that mints a chain passes the id to
+        ``propose``, so it is already on the row before the first audit entry
+        is written (only ``proposed_event_id`` genuinely arrives late, and that
+        one is not copied here).
+
+        FAIL-QUIET by design — any SQLite error yields ``None``. The audit
+        append itself stays LOUD (``AuditChainError``: a decision that cannot
+        be recorded must not silently succeed), but that posture is about the
+        legal trail. Refusing a human's approval because an explainability
+        JOIN column could not be read would be absurd; the honest degradation
+        is a blank correlation, which is exactly what every pre-T-4 row has.
+        """
+        if not action_id:
+            return None
+        try:
+            async with db.execute(
+                "SELECT correlation_id FROM instinct_actions WHERE id = ?", (action_id,)
+            ) as cur:
+                row = await cur.fetchone()
+        except aiosqlite.Error:
+            logger.debug("instinct audit: could not read correlation_id for action %s", action_id)
+            return None
+        if row is None:
+            return None
+        return row[0]
 
     async def log(self, *, actor: str, event: str, description: str, **kwargs: Any) -> AuditEntry:
         """Public audit log method for non-action events."""
@@ -1667,6 +1784,13 @@ class InstinctStore:
         await self._ensure_schema()
         async with self._conn() as db:
             db.row_factory = aiosqlite.Row
+            # The SELECT list is the hash material plus the chain links, and
+            # nothing else. ``workspace_id`` (W4a) and ``correlation_id`` (T-4)
+            # are deliberately absent: they are a read filter and a join key,
+            # never hashed, so a verify that pulled them could only tempt a
+            # future edit into folding them in. Adding a column here without
+            # adding it to ``_canonical_audit_payload`` is a no-op; adding it to
+            # both invalidates every ledger ever written.
             async with db.execute(
                 "SELECT rowid, id, action_id, pocket_id, timestamp, actor,"
                 " event, category, description, context, ai_recommendation,"
@@ -1950,6 +2074,10 @@ class InstinctStore:
             context=json.loads(row["context"]) if row["context"] else {},
             ai_recommendation=row["ai_recommendation"],
             outcome=row["outcome"],
+            # T-4 — the Decision-Graph join key. Key-checked like the action
+            # mapper's chain columns, so a row read from a DB that has not run
+            # the ALTER yet reads as chain-less rather than raising IndexError.
+            correlation_id=(row["correlation_id"] if "correlation_id" in row.keys() else None),
         )
 
     def _row_to_correction(self, row: Any) -> Correction:

--- a/tests/cloud/test_instinct_audit_correlation.py
+++ b/tests/cloud/test_instinct_audit_correlation.py
@@ -1,0 +1,113 @@
+# tests/cloud/test_instinct_audit_correlation.py
+# Created: 2026-08-06 (T-4, coupling-gap wave) — the EE half of the audit-ledger
+# correlation id. The OSS store half (population, NULL handling, hash-material
+# freeze, pre-T-4 migration) lives in tests/instinct/test_audit_correlation.py.
+#
+# What this pins, end to end through a REAL gated proposer:
+#   1. a gated external action's audit rows carry the same correlation_id the
+#      Action row carries, so "approved by whom" joins to "why" without parsing
+#      the untyped ``parameters`` blob;
+#   2. the cloud instinct router's audit views expose it additively — both the
+#      list (``GET /instinct/audit``) and the single-entry fetch the Why? drawer
+#      uses (``GET /instinct/audit/{id}``) — with no router change, because both
+#      serialize the OSS AuditEntry model;
+#   3. the tamper-evident chain still verifies over those rows
+#      (``GET /instinct/audit/verify``), which is the whole point of keeping the
+#      column out of the hash material.
+#
+# ``pocketpaw_ee`` is import-skipped on an OSS-only install. The Instinct store
+# is patched to a tmp file; nothing touches a real connector or journal.
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from pocketpaw_ee.cloud._core.deps import current_workspace_id  # noqa: E402
+from pocketpaw_ee.cloud._core.http import add_error_handler  # noqa: E402
+from pocketpaw_ee.cloud.auth import current_active_user  # noqa: E402
+from pocketpaw_ee.cloud.external_actions import propose as ea_propose  # noqa: E402
+from pocketpaw_ee.cloud.license import require_license  # noqa: E402
+from pocketpaw_ee.instinct.router import router  # noqa: E402
+
+from pocketpaw.instinct.store import InstinctStore  # noqa: E402
+
+WS = "w1"
+USER = "u1"
+
+
+@pytest.fixture
+def store(tmp_path: Path, monkeypatch) -> InstinctStore:
+    st = InstinctStore(tmp_path / "instinct_audit_chain.db")
+    monkeypatch.setattr("pocketpaw.stores.get_instinct_store", lambda *a, **k: st)
+    monkeypatch.setattr("pocketpaw_ee.instinct.router._store", lambda *a, **k: st)
+    return st
+
+
+class _FakeUser:
+    def __init__(self, user_id: str = USER, workspace_id: str = WS) -> None:
+        self.id = user_id
+        self.active_workspace = workspace_id
+
+        class _M:
+            def __init__(self, ws):
+                self.workspace = ws
+                self.role = "admin"
+
+        self.workspaces = [_M(workspace_id)]
+
+
+def _make_client(monkeypatch) -> TestClient:
+    import pocketpaw_ee.cloud.workspace.service as ws_svc
+
+    monkeypatch.setattr(ws_svc, "get_workspace_plan", AsyncMock(return_value="enterprise"))
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(router)
+    app.dependency_overrides[require_license] = lambda: None
+    app.dependency_overrides[current_active_user] = lambda: _FakeUser()
+    app.dependency_overrides[current_workspace_id] = lambda: WS
+    return TestClient(app)
+
+
+async def test_audit_views_expose_the_chain_key(store, monkeypatch):
+    """A gated proposal's audit trail joins to its Decision chain on the wire."""
+    action_id = await ea_propose.propose_external_action(
+        workspace_id=WS,
+        connector_name="crm",
+        action="approveApplication",
+        requested_by=USER,
+    )
+    stored = await store.get_action(action_id)
+    assert stored is not None
+    assert stored.correlation_id  # the proposer minted a chain — T-3's column
+
+    approved = await store.approve(action_id, approver=USER)
+    assert approved is not None
+
+    client = _make_client(monkeypatch)
+
+    listed = client.get("/instinct/audit", params={"pocket_id": WS})
+    assert listed.status_code == 200, listed.text
+    rows = listed.json()["entries"]
+    assert rows, "expected the propose + approve audit rows"
+    for row in rows:
+        assert "correlation_id" in row
+        assert row["correlation_id"] == stored.correlation_id
+
+    # The single-entry fetch behind the Why? drawer carries it too.
+    one = client.get(f"/instinct/audit/{rows[0]['id']}")
+    assert one.status_code == 200, one.text
+    assert one.json()["entry"]["correlation_id"] == stored.correlation_id
+
+    # And the ledger still proves itself — the column is not chain material.
+    verify = client.get("/instinct/audit/verify")
+    assert verify.status_code == 200, verify.text
+    assert verify.json()["intact"] is True

--- a/tests/instinct/test_audit_correlation.py
+++ b/tests/instinct/test_audit_correlation.py
@@ -1,0 +1,300 @@
+# tests/instinct/test_audit_correlation.py
+# Created: 2026-08-06 (T-4, coupling-gap wave) — coverage for the Decision-Graph
+# ``correlation_id`` on the tamper-evident Instinct audit ledger. Before T-4 the
+# ledger could prove "action X was approved by Y" but could not be joined to the
+# Decision that explains WHY: the legal record and the explainability record were
+# two disconnected chains over the same event. An audit row now copies the
+# action's first-class ``correlation_id`` COLUMN (added by T-3).
+#
+# The load-bearing invariant is NEGATIVE: correlation_id must stay OUT of the
+# hash material, exactly as ``workspace_id`` (W4a) does — otherwise every ledger
+# written before this change reads as tampered. Pinned here:
+#   1. a new audit row carries its action's correlation id, on BOTH append paths
+#      (propose -> ``_log``, approve -> the in-transaction ``_update_status``);
+#   2. an action with no chain produces a NULL audit correlation, no crash, and
+#      an action-less ``log()`` row is fine too;
+#   3. the canonical payload + its digest are byte-identical to pre-T-4 (a
+#      hard-coded known-good string + two sha256s + a signature check), so a
+#      refactor that folds the field into the hash fails loudly;
+#   4. a pre-T-4 ledger of REAL chained rows still verifies after the guarded
+#      ALTER, and keeps verifying once new rows are appended on top of it.
+from __future__ import annotations
+
+import inspect
+import re
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from pocketpaw.instinct.models import ActionTrigger
+from pocketpaw.instinct.store import (
+    SCHEMA_SQL,
+    InstinctStore,
+    _canonical_audit_payload,
+    compute_audit_hash,
+)
+
+TRIGGER = ActionTrigger(type="agent", source="claude", reason="audit chain-id test")
+
+CORR = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> InstinctStore:
+    return InstinctStore(tmp_path / "audit_chain.db")
+
+
+def _audit_rows(store: InstinctStore) -> list[tuple]:
+    """Raw (id, correlation_id) straight out of SQLite, in insertion order —
+    so a NULL is proven to be a real NULL and not the string "None"."""
+    with sqlite3.connect(store._db_path) as conn:
+        return conn.execute(
+            "SELECT id, correlation_id FROM instinct_audit ORDER BY rowid"
+        ).fetchall()
+
+
+# ---------------------------------------------------------------------------
+# 1. the join lands — on both append paths
+# ---------------------------------------------------------------------------
+
+
+async def test_audit_rows_carry_the_actions_correlation_id(store: InstinctStore) -> None:
+    """A gated action's audit rows carry its chain key, so the legal record
+    joins to the Decision that explains it.
+
+    Covers BOTH writers: ``propose`` appends through ``_log`` (own connection,
+    own commit) and ``approve`` through ``_update_status`` (inside the status
+    UPDATE's transaction). They share ``_append_audit_locked``, which is where
+    the id is read from the action's column — mutating that read to ``None``
+    fails this test.
+    """
+    action = await store.propose(
+        pocket_id="w1",
+        title="gated call",
+        description="",
+        recommendation="",
+        trigger=TRIGGER,
+        correlation_id=CORR,
+    )
+    approved = await store.approve(action.id, approver="maya")
+    assert approved is not None
+
+    entries = {e.event: e for e in await store.query_audit(pocket_id="w1")}
+    assert set(entries) == {"action_proposed", "action_approved"}
+    assert entries["action_proposed"].correlation_id == CORR
+    assert entries["action_approved"].correlation_id == CORR
+
+    # The single-row read path (the Why? drawer's fetch) carries it too.
+    one = await store.get_audit_entry(entries["action_approved"].id)
+    assert one is not None
+    assert one.correlation_id == CORR
+
+    # It is a real stored column, not a model default.
+    assert [corr for _id, corr in _audit_rows(store)] == [CORR, CORR]
+
+    # And the tamper-evident chain is unaffected by the new column.
+    verdict = await store.verify_audit_chain()
+    assert verdict["intact"] is True
+    assert verdict["hashed"] == 2
+
+
+async def test_chainless_action_writes_null_and_never_crashes(store: InstinctStore) -> None:
+    """An OSS proposal opens no Decision chain. Its audit rows must store a real
+    NULL and the lifecycle must run end-to-end regardless — a missing
+    explainability join can never cost anyone an approval."""
+    action = await store.propose(
+        pocket_id="pocket-1",
+        title="ordinary proposal",
+        description="",
+        recommendation="",
+        trigger=TRIGGER,
+    )
+    assert action.correlation_id is None
+    approved = await store.approve(action.id, approver="maya")
+    assert approved is not None
+
+    entries = await store.query_audit(pocket_id="pocket-1")
+    assert [e.correlation_id for e in entries] == [None, None]
+    assert [corr for _id, corr in _audit_rows(store)] == [None, None]
+    assert (await store.verify_audit_chain())["intact"] is True
+
+
+async def test_action_less_audit_row_is_fine(store: InstinctStore) -> None:
+    """``log()`` writes audit rows with no ``action_id`` at all (system events).
+    The correlation lookup must short-circuit rather than query for NULL."""
+    entry = await store.log(actor="system", event="store_opened", description="boot")
+    assert entry.correlation_id is None
+    assert [corr for _id, corr in _audit_rows(store)] == [None]
+    assert (await store.verify_audit_chain())["intact"] is True
+
+
+# ---------------------------------------------------------------------------
+# 2. the hash material is frozen
+# ---------------------------------------------------------------------------
+
+# A known-good sample of the W2b hash material, captured from the code as it
+# stood BEFORE T-4 added the column. These constants are the alarm: fold
+# correlation_id (or anything else) into ``_canonical_audit_payload`` and the
+# serialization changes, the digests change, and every ledger ever written stops
+# verifying. Mutation-proven — see tests/mutations/audit_chain_correlation.json.
+PINNED_ROW: dict = {
+    "id": "aud_t4pin000000",
+    "action_id": "act_t4pin000000",
+    "pocket_id": "pocket-pin",
+    "timestamp": "2026-08-06T00:00:00",
+    "actor": "user:pin",
+    "event": "action_approved",
+    "category": "decision",
+    "description": "Action Approved: pinned row",
+    "context": {"b": 2, "a": 1},
+    "ai_recommendation": None,
+    "outcome": None,
+}
+PINNED_CANONICAL = (
+    '{"action_id":"act_t4pin000000","actor":"user:pin","ai_recommendation":null,'
+    '"category":"decision","context":"{\\"a\\":1,\\"b\\":2}",'
+    '"description":"Action Approved: pinned row","event":"action_approved",'
+    '"id":"aud_t4pin000000","outcome":null,"pocket_id":"pocket-pin",'
+    '"timestamp":"2026-08-06T00:00:00"}'
+)
+PINNED_GENESIS_HASH = "7ebe4128ad861ac007d723a79b27d3b5dc073e8414d47f5c1af25db3bf3d6e84"
+PINNED_LINKED_HASH = "c0217c21a270562ef792f337b20c72d1fa6e10b015bea1c3e3882a1b4b17688b"
+
+
+def test_canonical_payload_and_digest_are_frozen() -> None:
+    """The exact bytes an auditor's chain is built from. If this fails, the
+    change under review invalidates every existing ledger — that is the whole
+    signal, and it must never be "fixed" by re-pinning the constants."""
+    canonical = _canonical_audit_payload(**PINNED_ROW)
+    assert canonical == PINNED_CANONICAL
+    assert "correlation_id" not in canonical
+    assert compute_audit_hash(canonical, "") == PINNED_GENESIS_HASH
+    assert compute_audit_hash(canonical, "deadbeef") == PINNED_LINKED_HASH
+
+
+def test_join_columns_are_absent_from_the_hash_signature() -> None:
+    """Structural half of the freeze: the canonical payload has no PARAMETER for
+    the join columns, so folding one in cannot happen by accident at a call
+    site. ``workspace_id`` has been excluded this way since W4a; T-4's
+    ``correlation_id`` joins it on the same terms."""
+    params = set(inspect.signature(_canonical_audit_payload).parameters)
+    assert "workspace_id" not in params
+    assert "correlation_id" not in params
+
+
+# ---------------------------------------------------------------------------
+# 3. old ledgers migrate and keep verifying
+# ---------------------------------------------------------------------------
+
+
+def _strip_audit_correlation(schema_sql: str) -> str:
+    """Return ``schema_sql`` with the T-4 audit join column (and its comment)
+    removed — reconstructing the pre-T-4 CREATE TABLE text. Same technique as
+    tests/cloud/test_w4a_migration.py's ``_strip_workspace_id``: SQLite cannot
+    always rewrite an ALTER ... DROP COLUMN, so the fixture is built from the
+    real current schema with one column excised. The anchor is the table-final
+    ``correlation_id TEXT\n);`` — ``instinct_actions``' own correlation column
+    is mid-list (trailing comma) and is deliberately left in place, because a
+    pre-T-4 DB is post-T-3."""
+    return re.sub(
+        r",\n(?:[ \t]*--[^\n]*\n)*[ \t]*correlation_id TEXT\n\);",
+        "\n);",
+        schema_sql,
+    )
+
+
+def _write_pre_t4_chain(db: Path, rows: int = 2) -> list[str]:
+    """Materialize a pre-T-4 ledger holding GENUINELY chained rows, hashed by
+    the very helpers the store uses, so the chain is authentic rather than
+    hand-faked."""
+    conn = sqlite3.connect(db)
+    conn.executescript(_strip_audit_correlation(SCHEMA_SQL))
+    running_prev = ""
+    ids: list[str] = []
+    for i in range(1, rows + 1):
+        payload = {
+            "id": f"aud_old{i}",
+            "action_id": None,
+            "pocket_id": "pocket-old",
+            "timestamp": f"2026-07-0{i}T00:00:00",
+            "actor": "user:old",
+            "event": "action_approved",
+            "category": "decision",
+            "description": f"old row {i}",
+            "context": {},
+            "ai_recommendation": None,
+            "outcome": None,
+        }
+        entry_hash = compute_audit_hash(_canonical_audit_payload(**payload), running_prev)
+        conn.execute(
+            "INSERT INTO instinct_audit"
+            " (id, action_id, pocket_id, timestamp, actor, event, category,"
+            " description, context, ai_recommendation, outcome, prev_hash, entry_hash)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                payload["id"],
+                None,
+                payload["pocket_id"],
+                payload["timestamp"],
+                payload["actor"],
+                payload["event"],
+                payload["category"],
+                payload["description"],
+                "{}",
+                None,
+                None,
+                running_prev,
+                entry_hash,
+            ),
+        )
+        ids.append(payload["id"])
+        running_prev = entry_hash
+    conn.commit()
+    conn.close()
+    return ids
+
+
+async def test_pre_t4_ledger_verifies_after_migration_and_extends(tmp_path: Path) -> None:
+    """The upgrade gate. A ledger written before the column existed opens
+    through the guarded ALTER, its existing chain still verifies byte-for-byte,
+    and new rows extend the SAME chain while carrying their correlation.
+
+    Drop the T-4 ALTER and this fails at the post-migration append (the INSERT
+    names a column the old file doesn't have, which surfaces as
+    ``AuditChainError``). Fold correlation_id into the hash material and it
+    fails at the first ``verify_audit_chain``.
+    """
+    db = tmp_path / "instinct_pre_t4.db"
+    pre_t4 = _strip_audit_correlation(SCHEMA_SQL)
+    # The fixture really is pre-T-4: the audit table has no correlation column,
+    # while the T-3 actions columns are untouched.
+    assert "correlation_id TEXT\n);" not in pre_t4
+    assert "correlation_id TEXT," in pre_t4
+    _write_pre_t4_chain(db)
+
+    store = InstinctStore(db)
+    verdict = await store.verify_audit_chain()
+    assert verdict["intact"] is True
+    assert verdict["hashed"] == 2
+    assert verdict["checked"] == 2
+
+    action = await store.propose(
+        pocket_id="pocket-old",
+        title="post-migration",
+        description="",
+        recommendation="",
+        trigger=TRIGGER,
+        correlation_id=CORR,
+    )
+    approved = await store.approve(action.id, approver="maya")
+    assert approved is not None
+
+    after = await store.verify_audit_chain()
+    assert after["intact"] is True
+    assert after["hashed"] == 4
+    assert after["checked"] == 4
+
+    # Old rows read NULL — nothing was backfilled or guessed; new rows carry the
+    # chain key.
+    assert [corr for _id, corr in _audit_rows(store)] == [None, None, CORR, CORR]

--- a/tests/instinct/test_correlation_columns.py
+++ b/tests/instinct/test_correlation_columns.py
@@ -13,6 +13,13 @@
 #      never blanks an already-stored id, and returns None for an unknown id.
 #   4. A pre-T-3 DB file (columns stripped from the schema) upgrades cleanly on
 #      open and its old rows read as NULL.
+# Updated: 2026-08-06 (T-4, coupling-gap wave) — ``_strip_chain_columns`` now
+# also strips the TABLE-FINAL form of a chain column. T-4 put a second
+# ``correlation_id`` on ``instinct_audit`` (the audit ledger's join key), which
+# is declared last in its table and so carries no trailing comma; the original
+# mid-list-only regex left it standing and the "fixture really is pre-T-3"
+# assertion failed. Nothing about what this file tests changed — the fixture is
+# simply faithful again.
 from __future__ import annotations
 
 import re
@@ -157,12 +164,21 @@ async def test_set_chain_ids_unknown_action_and_empty_call(store: InstinctStore)
 
 
 def _strip_chain_columns(schema_sql: str) -> str:
-    """Return ``schema_sql`` with the T-3 chain-id column declarations removed —
+    """Return ``schema_sql`` with the chain-id column declarations removed —
     reconstructing the pre-T-3 CREATE TABLE text. Same technique as
     tests/cloud/test_w4a_migration.py's ``_strip_workspace_id`` (an ALTER ...
-    DROP COLUMN can't always be rewritten by SQLite)."""
+    DROP COLUMN can't always be rewritten by SQLite).
+
+    Two forms, because T-4 added a SECOND column named ``correlation_id`` (the
+    join key on ``instinct_audit``): the actions columns are mid-list and end
+    with a comma, the audit one is table-final and does not. A DB predating T-3
+    also predates T-4, so both come out and the store's guarded ALTERs put both
+    back."""
     for col in ("correlation_id", "proposed_event_id"):
-        schema_sql = re.sub(rf"\n[ \t]*{col} TEXT,", "", schema_sql)
+        schema_sql = re.sub(rf"\n[ \t]*{col} TEXT,", "", schema_sql)  # mid-list
+        schema_sql = re.sub(  # table-final, with any comment lines above it
+            rf",\n(?:[ \t]*--[^\n]*\n)*[ \t]*{col} TEXT\n", "\n", schema_sql
+        )
     return schema_sql
 
 

--- a/tests/mutations/audit_chain_correlation.json
+++ b/tests/mutations/audit_chain_correlation.json
@@ -1,0 +1,37 @@
+[
+  {
+    "label": "hash material: fold the correlation id into the canonical payload",
+    "file": "src/pocketpaw/instinct/store.py",
+    "find": "            \"ai_recommendation\": ai_recommendation,\n            \"outcome\": outcome,\n        },",
+    "replace": "            \"ai_recommendation\": ai_recommendation,\n            \"outcome\": outcome,\n            \"correlation_id\": None,\n        },",
+    "tests": ["tests/instinct/test_audit_correlation.py"]
+  },
+  {
+    "label": "hash material: give the canonical payload a correlation parameter",
+    "file": "src/pocketpaw/instinct/store.py",
+    "find": "    ai_recommendation: str | None,\n    outcome: str | None,\n) -> str:",
+    "replace": "    ai_recommendation: str | None,\n    outcome: str | None,\n    correlation_id: str | None = None,\n) -> str:",
+    "tests": ["tests/instinct/test_audit_correlation.py"]
+  },
+  {
+    "label": "migration: drop the T-4 audit ALTER",
+    "file": "src/pocketpaw/instinct/store.py",
+    "find": "await db.execute(\"ALTER TABLE instinct_audit ADD COLUMN correlation_id TEXT\")",
+    "replace": "await db.execute(\"SELECT 1\")",
+    "tests": ["tests/instinct/test_audit_correlation.py"]
+  },
+  {
+    "label": "population: stop reading the action's correlation column",
+    "file": "src/pocketpaw/instinct/store.py",
+    "find": "correlation_id = await self._action_correlation_id(db, entry.action_id)",
+    "replace": "correlation_id = None",
+    "tests": ["tests/instinct/test_audit_correlation.py"]
+  },
+  {
+    "label": "read path: drop the correlation from the audit row mapper",
+    "file": "src/pocketpaw/instinct/store.py",
+    "find": "            correlation_id=(row[\"correlation_id\"] if \"correlation_id\" in row.keys() else None),",
+    "replace": "            correlation_id=None,",
+    "tests": ["tests/instinct/test_audit_correlation.py"]
+  }
+]


### PR DESCRIPTION
Stacked on #1869 — review and merge that one first (with --rebase).

The tamper-evident instinct audit ledger could prove that action X was approved by Y, but could not be joined to the Decision explaining why — the legal record and the explainability record were two disconnected chains over the same event.

instinct_audit and the instinct AuditEntry now carry correlation_id, stamped at append time from the action row's column (added in #1869; never re-derived from blobs). The critical property is what did NOT change: the field sits outside the canonical hash payload, treated exactly like workspace_id, so every pre-existing chain verifies byte-for-byte after the guarded ALTER.

That claim is not taken on faith. A pinned-digest test hard-codes known-good canonical bytes and both sha256 digests as literals — the reviewer recomputed all three independently with plain hashlib to confirm they encode pre-change behavior — so any future refactor that folds the field into the hash material fails loudly. The migration test builds a genuinely chained pre-migration ledger, migrates, verifies, and extends the same chain. A 5-mutation plan (fold the field into the hash, add it to the payload signature, drop the migration, stop reading the action's column, drop it from the row reader) is all caught.

The lookup is deliberately fail-quiet — an explainability join should never block a human's approval — and that asymmetry is documented at the helper, the model, the schema comment, and in docs/concepts/decision-graph.mdx, which this PR extends.

Known limit, tracked as follow-up rather than fixed here: the workspace-split migration copies instinct_audit by explicit column list and would drop the join key from migrated rows (no integrity risk — the column is not chain material). That migration carries its own tamper gate and deserves its own careful change.