### PR TITLE
feat(tasks): due-dated tasks show up on the calendar

### DIFF
--- a/docs/concepts/calendar.mdx
+++ b/docs/concepts/calendar.mdx
@@ -166,6 +166,34 @@ The #1132 review surfaced a stack of gaps. PR #1143 closed the high-severity one
 
 The remaining items from the review are tracked in issue #1142.
 
+## Bridged Sources — Meetings and Tasks on /calendar
+
+Two in-process bridges mint calendar events from other domains, so /calendar
+shows everything with a time on it, not just hand-created appointments. Both
+follow the same conventions: a **synthetic calendar id** (no `_CalendarDoc`
+row needed — `service._load_calendar` synthesizes a workspace-public default),
+a **`fabric_object_id` linkage** stamped on every bridge-minted event, and
+**hard containment** (a calendar failure never breaks the source domain's
+write).
+
+| Source | Bridge | Synthetic calendar | Linkage | Lifecycle |
+|--------|--------|--------------------|---------|-----------|
+| Meetings | `ee/pocketpaw_ee/cloud/meetings/bridges/calendar.py` | `meetings` | `meeting:{meeting_id}` | Bidirectional: `meeting.scheduled` mints an event, `meeting.cancelled` deletes it; forward, a calendar event carrying a Zoom/Meet URL auto-creates a Meeting |
+| Tasks | `ee/pocketpaw_ee/cloud/tasks/bridges/calendar.py` | `tasks` | `task:{task_id}` | One-way: a task with `due_at` mints an event timed at the due date; due moved → event moves; due cleared or task resolved → event deleted |
+
+The tasks bridge subscribes the typed `task.proposed` / `task.updated` /
+`task.resolved` events on the `_core.realtime` bus and runs one reconciler:
+the event exists iff the task has a `due_at` and a still-active status
+(`proposed` / `in_progress` / `blocked`). That invariant makes re-delivered
+bus events converge instead of duplicating.
+
+Loop guards: the meetings forward handler skips any calendar event whose
+`fabric_object_id` starts with `meeting:` or `task:`, so bridge-minted events
+are never re-scanned for join URLs (a task titled with a Zoom link would
+otherwise spawn a phantom Meeting). Both bridges are registered in
+`mount_cloud` after `init_realtime`, and the registration is pinned by
+`tests/cloud/test_integration.py::test_task_calendar_bridge_registered_at_mount`.
+
 ## Frontend Pairing
 
 paw-enterprise wires the routes into a calendar widget that pairs with the [Pocket Templates](/concepts/pocket-templates) `calendar-planner` bundled template. The widget calls `GET /api/v1/calendar/events` for the visible window and `POST /api/v1/calendar/events` from the composer. Live-source state seeding (see `feat/pockets` work in the live recovery cascade) keeps the widget reactive after every mutation without a full pocket rebuild.

--- a/ee/pocketpaw_ee/calendar/models.py
+++ b/ee/pocketpaw_ee/calendar/models.py
@@ -1,4 +1,7 @@
 # Calendar module — Beanie document models.
+# Updated: 2026-08-06 (feat/coupling-tasks-on-calendar) — added the
+#   (workspace, fabric_object_id) composite index: the tasks bridge
+#   resolves its linked event by fabric_object_id on every task.* emit.
 # Updated: 2026-05-19 (fix/calendar-security-hardening, #1142 H-NEW-1).
 #
 # Changes:
@@ -109,4 +112,9 @@ class _EventDoc(Document):
             # personal-view, modify-allowlist UI). Composite with workspace
             # to honour the tenant filter rule.
             IndexModel([("workspace", ASCENDING), ("created_by_user_id", ASCENDING)]),
+            # Task/meeting bridge linkage lookup — the tasks bridge resolves
+            # its event by fabric_object_id on EVERY task.* emit, so the
+            # query pattern deserves its own composite (tenant-first per the
+            # filter rule).
+            IndexModel([("workspace", ASCENDING), ("fabric_object_id", ASCENDING)]),
         ]

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -904,6 +904,15 @@ def mount_cloud(app: FastAPI) -> None:
 
     register_task_listeners()
 
+    # Task → Calendar bridge — a task with a due_at shows up on /calendar
+    # (synthetic 'tasks' calendar, fabric_object_id='task:{id}'). One-way:
+    # due set → event minted, due moved → event moves, task resolved or
+    # due cleared → event deleted. Same lifecycle constraint as the other
+    # bus subscribers: register AFTER init_realtime installed the bus.
+    from pocketpaw_ee.cloud.tasks.bridges.calendar import register_task_calendar_listeners
+
+    register_task_calendar_listeners()
+
     # Planner — when a plan is generated, auto-execute unblocked tasks
 
     # Meeting bridges — meeting.* events → in-app notifications, and

--- a/ee/pocketpaw_ee/cloud/meetings/bridges/calendar.py
+++ b/ee/pocketpaw_ee/cloud/meetings/bridges/calendar.py
@@ -1,3 +1,7 @@
+# Updated: 2026-08-06 (feat/coupling-tasks-on-calendar) — the forward
+#   loop guard now also skips events whose ``fabric_object_id`` carries a
+#   ``task:`` link (minted by the tasks/bridges/calendar.py bridge), so a
+#   task titled with a Zoom/Meet URL can't spawn a phantom Meeting.
 """Calendar ↔ Meeting bidirectional bridge.
 
 Forward (calendar → meeting): when a calendar event lands with a
@@ -110,12 +114,15 @@ async def _on_calendar_event_created(data: dict[str, Any]) -> None:
     if doc is None:
         return
 
-    # Reverse-bridge loop guard: this calendar event was minted by us from
-    # a Meeting that already exists. Re-detecting the URL would create a
-    # second Meeting row pointing at the same call. ``getattr`` keeps the
-    # check forward-compatible with test doubles that omit the attribute.
+    # Reverse-bridge loop guard: this calendar event was minted by a
+    # bridge from an object that already exists — either our own reverse
+    # bridge (``meeting:``) or the tasks bridge (``task:``). Re-detecting
+    # a URL in its text would create a phantom Meeting row (for tasks: a
+    # task titled with a Zoom link would spawn a Meeting out of thin
+    # air). ``getattr`` keeps the check forward-compatible with test
+    # doubles that omit the attribute.
     fabric_link = getattr(doc, "fabric_object_id", None)
-    if isinstance(fabric_link, str) and fabric_link.startswith("meeting:"):
+    if isinstance(fabric_link, str) and fabric_link.startswith(("meeting:", "task:")):
         return
 
     haystack = " ".join(filter(None, [doc.description, doc.location, doc.title]))

--- a/ee/pocketpaw_ee/cloud/tasks/bridges/__init__.py
+++ b/ee/pocketpaw_ee/cloud/tasks/bridges/__init__.py
@@ -1,0 +1,5 @@
+# bridges/__init__.py — cross-domain bridges for the Tasks entity.
+# Created: 2026-08-06 (feat/coupling-tasks-on-calendar). Mirrors the
+#   meetings/bridges/ layout: listeners.py keeps the notifications +
+#   planner fan-out; anything that couples Tasks to another domain's
+#   surface (calendar today) lives here as its own module.

--- a/ee/pocketpaw_ee/cloud/tasks/bridges/calendar.py
+++ b/ee/pocketpaw_ee/cloud/tasks/bridges/calendar.py
@@ -1,4 +1,8 @@
 # bridges/calendar.py — Task → Calendar one-way bridge.
+# Updated: 2026-08-06 (review follow-up) — slim-payload guard: an emit
+#   whose task dict OMITS the due_at key (planner requeue's hand-built
+#   payload) no longer deletes a live event; absent != cleared. Also
+#   swapped the due_at assert for a real branch (-O strips asserts).
 # Created: 2026-08-06 (feat/coupling-tasks-on-calendar, coupling wave T-12).
 #   A task with a ``due_at`` now shows up on /calendar so the user plans
 #   their day against real deadlines instead of a separate task feed.
@@ -174,6 +178,20 @@ async def _sync_task_calendar(task: dict[str, Any]) -> None:
     if not (task_id and workspace_id):
         return
 
+    status = task.get("status") or ""
+
+    # Slim-payload guard: not every task.* emit ships the full DTO. The
+    # planner terminal's requeue path (``_plan_task_event_payload``)
+    # hand-builds ``data.task`` WITHOUT a ``due_at`` key while flipping a
+    # still-live, still-due-dated task back to ``proposed``. Key ABSENT
+    # means "unknown", not "cleared" — deleting on unknown would wrongly
+    # remove a live deadline. Leave the event untouched and let the next
+    # full-DTO emit reconcile. An explicit ``due_at: None`` (full DTO,
+    # deadline cleared) still falls through and deletes as intended, and
+    # terminal-status emits still delete regardless of the key.
+    if "due_at" not in task and status in _CALENDAR_ELIGIBLE_STATUSES:
+        return
+
     # Late imports — the calendar package is enterprise-only and its
     # absence must disable the bridge, not break task writes. Mirrors the
     # meetings bridge exactly.
@@ -190,7 +208,6 @@ async def _sync_task_calendar(task: dict[str, Any]) -> None:
         return
 
     due_at = _parse_due_at(task.get("due_at"))
-    status = task.get("status") or ""
     should_exist = due_at is not None and status in _CALENDAR_ELIGIBLE_STATUSES
 
     fabric_id = f"{_FABRIC_PREFIX}{task_id}"
@@ -213,7 +230,9 @@ async def _sync_task_calendar(task: dict[str, Any]) -> None:
             )
         return
 
-    assert due_at is not None  # narrowed by should_exist
+    if due_at is None:  # narrowed by should_exist already; never trips.
+        # Kept as a real branch, not an assert — asserts strip under -O.
+        return
     title = task.get("title") or "Untitled task"
     starts_at = due_at
     ends_at = due_at + _DEFAULT_DURATION

--- a/ee/pocketpaw_ee/cloud/tasks/bridges/calendar.py
+++ b/ee/pocketpaw_ee/cloud/tasks/bridges/calendar.py
@@ -1,0 +1,327 @@
+# bridges/calendar.py — Task → Calendar one-way bridge.
+# Created: 2026-08-06 (feat/coupling-tasks-on-calendar, coupling wave T-12).
+#   A task with a ``due_at`` now shows up on /calendar so the user plans
+#   their day against real deadlines instead of a separate task feed.
+#   Modeled directly on ``meetings/bridges/calendar.py`` (the reverse
+#   meeting→calendar bridge): synthetic calendar id, ``fabric_object_id``
+#   linkage, idempotency via find-before-create, and hard containment so
+#   a calendar failure can never break a task write.
+"""Task → Calendar bridge.
+
+One direction only (tasks → calendar). When a Task carries a ``due_at``,
+mint a CalendarEvent on the synthetic ``tasks`` calendar so the deadline
+shows up on /calendar next to meetings and appointments. The event is
+stamped with ``fabric_object_id="task:{task_id}"`` — the same linkage
+convention the meetings bridge uses (``meeting:{id}``) — so re-emits
+converge instead of duplicating, and so other calendar consumers can
+recognise bridge-minted rows.
+
+Subscribes the typed Task events on the ``_core.realtime`` bus (the bus
+``tasks/service.py`` actually emits on — NOT ``shared.events.event_bus``,
+which carries the calendar/meeting topics):
+
+* ``task.proposed``  → task created; mint an event when ``due_at`` is set
+* ``task.updated``   → converge: due date moved → move the event; due date
+  cleared → delete the event; due date newly set (or task reverted back
+  to an active status) → mint the event
+* ``task.resolved``  → task completed (``done`` or ``awaiting_approval``)
+  → delete the event; the deadline no longer needs day-planning
+
+Every handler runs the same reconciler: *the calendar event for a task
+exists iff the task has a ``due_at`` and its status still needs doing*.
+That invariant makes each handler idempotent under bus re-delivery and
+keeps the two surfaces convergent no matter which event arrives.
+
+Containment: the realtime bus already swallows per-handler exceptions,
+and every calendar call here is additionally wrapped — a task write must
+always succeed even when the calendar service is down (mirrors the
+meetings bridge's ``# bridge must not break meeting create`` posture).
+
+Loop guard: this bridge consumes only ``task.*`` events, so it cannot
+re-trigger itself. The calendar events it mints DO fire
+``calendar.event.created`` on the shared bus, where the meetings forward
+bridge scans descriptions for Zoom/Meet URLs — that handler skips any
+event whose ``fabric_object_id`` names a bridge-owned object (``task:``
+included), so a task titled with a meeting link can't mint a phantom
+Meeting.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from pocketpaw_ee.cloud._core.realtime.bus import get_bus
+from pocketpaw_ee.cloud._core.realtime.events import (
+    Event,
+    TaskProposed,
+    TaskResolved,
+    TaskUpdated,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# All task-derived calendar events land on one synthetic calendar so they
+# group cleanly in /calendar UIs. Per ``calendar.service._load_calendar``,
+# no Calendar row needs to exist — the service synthesizes a default
+# workspace-public Calendar with this id, owned by the request actor.
+# Mirrors the meetings bridge's ``_MEETING_CALENDAR_ID = "meetings"``.
+_TASK_CALENDAR_ID = "tasks"
+
+# The linkage prefix stamped into ``fabric_object_id``. Convention shared
+# with the meetings bridge (``meeting:{id}``).
+_FABRIC_PREFIX = "task:"
+
+# A task's deadline belongs on the calendar only while the work still
+# needs doing. ``done`` / ``reverted`` / ``failed`` are terminal;
+# ``awaiting_approval`` means the assignee finished and is waiting on
+# sign-off — the deadline no longer needs day-planning, and excluding it
+# here keeps an unrelated later edit (title tweak while awaiting
+# approval) from resurrecting a deleted event.
+_CALENDAR_ELIGIBLE_STATUSES = frozenset({"proposed", "in_progress", "blocked"})
+
+# Due dates are points in time; calendar events need a window. Same
+# default the meetings bridge uses for events without an end.
+_DEFAULT_DURATION = timedelta(minutes=30)
+
+
+# ---------------------------------------------------------------------------
+# Payload helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_task(event: Event) -> dict | None:
+    """Pull the task dict from a task.* event payload, or ``None`` when
+    absent. ``task.updated`` fired for a task-comment ships ``task=None``
+    on purpose — that emit must be a no-op here, not a crash."""
+
+    data = getattr(event, "data", None) or {}
+    task = data.get("task")
+    if not isinstance(task, dict):
+        return None
+    return task
+
+
+def _parse_due_at(value: Any) -> datetime | None:
+    """Coerce the payload's ``due_at`` into an aware UTC datetime.
+
+    The task DTO serialises ``due_at`` via ``iso_utc`` (an ISO-8601
+    string); accept a raw ``datetime`` too so internal callers that pass
+    domain objects straight through keep working. Anything unparseable
+    is treated as absent rather than raising — a malformed field must
+    not take down the subscriber chain.
+    """
+
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        dt = value
+    elif isinstance(value, str):
+        try:
+            dt = datetime.fromisoformat(value)
+        except ValueError:
+            return None
+    else:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt
+
+
+def _bridge_ctx(workspace_id: str, user_id: str) -> Any:
+    """Build the calendar RequestContext carrying the task's workspace.
+
+    Single chokepoint for tenancy: every calendar call this bridge makes
+    goes through here, so the event can only ever land in (and be looked
+    up from) the task's own workspace.
+    """
+
+    from pocketpaw_ee.calendar._context import RequestContext
+
+    return RequestContext(workspace_id=workspace_id, user_id=user_id)
+
+
+def _format_description(task: dict[str, Any]) -> str:
+    """Terse provenance blurb, mirroring the meetings bridge's format."""
+
+    lines = ["Task due"]
+    priority = task.get("priority")
+    if priority:
+        lines.append(f"Priority: {priority}")
+    lines.append("— Synced from Tasks")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Reconciler — the single convergence point every handler calls
+# ---------------------------------------------------------------------------
+
+
+async def _sync_task_calendar(task: dict[str, Any]) -> None:
+    """Converge the calendar to the task's current state.
+
+    Invariant: an event with ``fabric_object_id="task:{id}"`` exists on
+    the ``tasks`` calendar iff the task has a ``due_at`` and an eligible
+    (still-needs-doing) status. Create / move / delete whatever is needed
+    to restore the invariant; do nothing when it already holds — which is
+    what makes bus re-delivery safe.
+    """
+
+    task_id = task.get("id")
+    workspace_id = task.get("workspace_id")
+    if not (task_id and workspace_id):
+        return
+
+    # Late imports — the calendar package is enterprise-only and its
+    # absence must disable the bridge, not break task writes. Mirrors the
+    # meetings bridge exactly.
+    try:
+        from pocketpaw_ee.calendar.dto import CreateEventRequest, UpdateEventRequest
+
+        # Read-only linkage lookup, same precedent as the meetings
+        # forward bridge reading _EventDoc directly. All WRITES go
+        # through the calendar service (policy + events fire there).
+        from pocketpaw_ee.calendar.models import _EventDoc
+        from pocketpaw_ee.calendar.service import create_event, delete_event, update_event
+    except ImportError:
+        logger.warning("calendar package unavailable — task calendar bridge disabled")
+        return
+
+    due_at = _parse_due_at(task.get("due_at"))
+    status = task.get("status") or ""
+    should_exist = due_at is not None and status in _CALENDAR_ELIGIBLE_STATUSES
+
+    fabric_id = f"{_FABRIC_PREFIX}{task_id}"
+    doc = await _EventDoc.find_one({"workspace": workspace_id, "fabric_object_id": fabric_id})
+
+    if not should_exist:
+        if doc is None:
+            return  # invariant already holds
+        # Act as the event's creator so ``policy.check_event_modify``
+        # passes regardless of which workspace member touched the task.
+        actor = getattr(doc, "created_by_user_id", None) or task.get("creator_id") or "system"
+        ctx = _bridge_ctx(workspace_id, actor)
+        try:
+            await delete_event(ctx, str(doc.id))
+        except Exception:  # noqa: BLE001 — bridge must not break the task flow
+            logger.exception(
+                "task calendar bridge: failed to delete CalendarEvent=%s for task=%s",
+                doc.id,
+                task_id,
+            )
+        return
+
+    assert due_at is not None  # narrowed by should_exist
+    title = task.get("title") or "Untitled task"
+    starts_at = due_at
+    ends_at = due_at + _DEFAULT_DURATION
+
+    if doc is None:
+        ctx = _bridge_ctx(workspace_id, task.get("creator_id") or "system")
+        body = CreateEventRequest(
+            calendar_id=_TASK_CALENDAR_ID,
+            title=title,
+            starts_at=starts_at,
+            ends_at=ends_at,
+            timezone="UTC",
+            description=_format_description(task),
+            # Linkage + loop-prevention marker — the meetings forward
+            # bridge skips events carrying a bridge-owned fabric link.
+            fabric_object_id=fabric_id,
+        )
+        try:
+            await create_event(ctx, body)
+        except Exception:  # noqa: BLE001 — bridge must not break the task flow
+            logger.exception(
+                "task calendar bridge: failed to mint CalendarEvent for task=%s", task_id
+            )
+            return
+        logger.info("task calendar bridge: minted CalendarEvent for task=%s", task_id)
+        return
+
+    # Event exists and should exist — move/retitle it only when something
+    # material changed (idempotency under bus re-delivery).
+    doc_starts = getattr(doc, "starts_at", None)
+    if doc_starts is not None and doc_starts.tzinfo is None:
+        doc_starts = doc_starts.replace(tzinfo=UTC)
+    if doc_starts == starts_at and getattr(doc, "title", None) == title:
+        return
+
+    actor = getattr(doc, "created_by_user_id", None) or task.get("creator_id") or "system"
+    ctx = _bridge_ctx(workspace_id, actor)
+    body = UpdateEventRequest(title=title, starts_at=starts_at, ends_at=ends_at)
+    try:
+        await update_event(ctx, str(doc.id), body)
+    except Exception:  # noqa: BLE001 — bridge must not break the task flow
+        logger.exception(
+            "task calendar bridge: failed to update CalendarEvent=%s for task=%s",
+            doc.id,
+            task_id,
+        )
+        return
+    logger.info("task calendar bridge: moved CalendarEvent=%s for task=%s", doc.id, task_id)
+
+
+# ---------------------------------------------------------------------------
+# Handlers
+# ---------------------------------------------------------------------------
+
+
+async def _on_task_proposed(event: Event) -> None:
+    """Task created — mint the calendar event when ``due_at`` is set."""
+
+    task = _extract_task(event)
+    if task is None:
+        return
+    try:
+        await _sync_task_calendar(task)
+    except Exception:  # noqa: BLE001 — belt and braces on top of the bus's own swallow
+        logger.warning("task.proposed → calendar sync failed", exc_info=True)
+
+
+async def _on_task_updated(event: Event) -> None:
+    """Task metadata changed — converge the calendar to the new state."""
+
+    task = _extract_task(event)
+    if task is None:
+        return  # task-comment emits ship task=None on purpose
+    try:
+        await _sync_task_calendar(task)
+    except Exception:  # noqa: BLE001
+        logger.warning("task.updated → calendar sync failed", exc_info=True)
+
+
+async def _on_task_resolved(event: Event) -> None:
+    """Task completed — the reconciler deletes the now-stale event."""
+
+    task = _extract_task(event)
+    if task is None:
+        return
+    try:
+        await _sync_task_calendar(task)
+    except Exception:  # noqa: BLE001
+        logger.warning("task.resolved → calendar sync failed", exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def register_task_calendar_listeners() -> None:
+    """Wire the Task → Calendar bridge onto the realtime bus.
+
+    Called once from ``mount_cloud`` after ``init_realtime`` has set the
+    singleton — same lifecycle as ``register_task_listeners``.
+    """
+
+    bus = get_bus()
+    bus.subscribe(TaskProposed.EVENT_TYPE, _on_task_proposed)
+    bus.subscribe(TaskUpdated.EVENT_TYPE, _on_task_updated)
+    bus.subscribe(TaskResolved.EVENT_TYPE, _on_task_resolved)
+    logger.info("registered task → calendar bridge")
+
+
+__all__ = ["register_task_calendar_listeners"]

--- a/tests/cloud/meetings/test_bridges.py
+++ b/tests/cloud/meetings/test_bridges.py
@@ -492,3 +492,30 @@ async def test_calendar_event_skips_when_minted_by_reverse_bridge(mongo_db, fake
     )
 
     assert await _MeetingDoc.find({"workspace": "ws-1"}).count() == 0
+
+
+async def test_calendar_event_skips_when_minted_by_task_bridge(mongo_db, fake_event_doc_class):
+    """Cross-bridge loop guard: calendar events carrying a ``task:``
+    fabric link were minted by the tasks bridge (tasks/bridges/calendar).
+    A task titled with a Zoom URL must NOT spawn a phantom Meeting."""
+    from types import SimpleNamespace
+
+    from pocketpaw_ee.cloud.models.meeting import Meeting as _MeetingDoc
+
+    starts_at = datetime.now(UTC) + timedelta(hours=1)
+    fake_event_doc_class["evt-task"] = SimpleNamespace(
+        id="evt-task",
+        title="Prep https://zoom.us/j/42 talking points",
+        description="Task due\n— Synced from Tasks",
+        location=None,
+        starts_at=starts_at,
+        ends_at=starts_at + timedelta(minutes=30),
+        created_by_user_id="user-1",
+        fabric_object_id="task:65f0aa000000000000000001",
+    )
+
+    await calendar_bridge._on_calendar_event_created(
+        {"event_id": "evt-task", "workspace_id": "ws-1"}
+    )
+
+    assert await _MeetingDoc.find({"workspace": "ws-1"}).count() == 0

--- a/tests/cloud/tasks/test_tasks_calendar_bridge.py
+++ b/tests/cloud/tasks/test_tasks_calendar_bridge.py
@@ -326,6 +326,76 @@ async def test_task_complete_survives_calendar_failure(real_bus, monkeypatch) ->
     assert done.status == "done"
 
 
+async def test_slim_payload_without_due_key_does_not_delete_event(real_bus) -> None:
+    """A task.updated whose payload OMITS the due_at key entirely (the
+    planner terminal's requeue emit, ``_plan_task_event_payload``) must
+    NOT delete the event of a still-live, still-due-dated task — key
+    absent means unknown, not cleared.
+
+    Mutation that breaks this: remove the slim-payload guard
+    ('treat an absent due_at key as cleared')."""
+
+    from pocketpaw_ee.cloud._core.realtime.events import TaskUpdated
+    from pocketpaw_ee.cloud.tasks.bridges.calendar import _on_task_updated
+
+    task = await _create_task()
+    assert len(await _events_in("ws-a")) == 1
+
+    # Planner-shaped slim payload: no due_at key, status back to proposed.
+    await _on_task_updated(
+        TaskUpdated(
+            data={
+                "task_id": task.id,
+                "workspace_id": "ws-a",
+                "project_id": "proj-1",
+                "task": {
+                    "id": task.id,
+                    "workspace_id": "ws-a",
+                    "project_id": "proj-1",
+                    "title": task.title,
+                    "summary": None,
+                    "status": "proposed",
+                    "assignee": {"kind": "agent", "id": "agent-1", "name": "planner"},
+                },
+            }
+        )
+    )
+
+    events = await _events_in("ws-a")
+    assert len(events) == 1  # event survived the slim emit
+    assert events[0].fabric_object_id == f"task:{task.id}"
+
+
+async def test_slim_payload_with_terminal_status_still_deletes(real_bus) -> None:
+    """The slim-payload guard only protects live tasks — a hand-built
+    payload with a terminal status (planner escalation → failed) still
+    deletes the event, due_at key or no due_at key."""
+
+    from pocketpaw_ee.cloud._core.realtime.events import TaskUpdated
+    from pocketpaw_ee.cloud.tasks.bridges.calendar import _on_task_updated
+
+    task = await _create_task()
+    assert len(await _events_in("ws-a")) == 1
+
+    await _on_task_updated(
+        TaskUpdated(
+            data={
+                "task_id": task.id,
+                "workspace_id": "ws-a",
+                "task": {
+                    "id": task.id,
+                    "workspace_id": "ws-a",
+                    "title": task.title,
+                    "status": "failed",
+                    "assignee": {"kind": "agent", "id": "agent-1", "name": "planner"},
+                },
+            }
+        )
+    )
+
+    assert await _events_in("ws-a") == []
+
+
 async def test_comment_emit_with_task_none_is_a_noop(real_bus) -> None:
     """task.updated fired for a task comment ships task=None — the
     bridge must treat it as a no-op, not a crash."""

--- a/tests/cloud/tasks/test_tasks_calendar_bridge.py
+++ b/tests/cloud/tasks/test_tasks_calendar_bridge.py
@@ -1,0 +1,347 @@
+# test_tasks_calendar_bridge.py — Task → Calendar bridge integration.
+# Created: 2026-08-06 (feat/coupling-tasks-on-calendar, coupling wave T-12).
+#   End-to-end through the REAL tasks service, a REAL InProcessBus, and
+#   the REAL calendar service against mongomock (the cloud mongo_db
+#   fixture initializes the calendar Beanie docs via ALL_DOCUMENTS) —
+#   the seam under test is the coupling itself, so mocking it would
+#   prove nothing (spy-don't-mock). Docstrings name the mutation that
+#   breaks each test; the plan lives in
+#   tests/mutations/tasks_calendar_bridge.json.
+"""Tests for the task.* → calendar bridge (tasks/bridges/calendar.py)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+import pytest_asyncio
+from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
+from pocketpaw_ee.cloud._core.realtime import bus as bus_mod
+from pocketpaw_ee.cloud._core.realtime.bus import InProcessBus
+from pocketpaw_ee.cloud.tasks import service as tasks_service
+from pocketpaw_ee.cloud.tasks.bridges.calendar import register_task_calendar_listeners
+from pocketpaw_ee.cloud.tasks.dto import (
+    AssigneeDTO,
+    CompleteTaskRequest,
+    CreateTaskRequest,
+    UpdateTaskRequest,
+)
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+DUE = datetime(2026, 9, 1, 15, 0, tzinfo=UTC)
+
+
+class _StubConnManager:
+    async def send_to_user(self, user_id, payload) -> None:  # noqa: ARG002
+        return None
+
+
+@pytest_asyncio.fixture
+async def real_bus():
+    """Install a real InProcessBus wired with ONLY the calendar bridge.
+
+    Overrides the autouse RecordingBus so the task.* subscribers actually
+    fire. The notification listener is deliberately not registered — its
+    fan-out is covered in test_tasks_notification_fanout.py.
+    """
+
+    from pocketpaw_ee.cloud._core.realtime.audience import AudienceResolver
+
+    async def _empty(_):
+        return []
+
+    resolver = AudienceResolver(
+        group_members=_empty,
+        workspace_members=_empty,
+        workspace_admins=_empty,
+        workspace_peers=_empty,
+    )
+
+    async def _no_audience(event):  # noqa: ARG001
+        return []
+
+    resolver.audience = _no_audience  # type: ignore[method-assign]
+
+    prev = bus_mod._bus  # type: ignore[attr-defined]
+    bus = InProcessBus(resolver=resolver, conn_manager=_StubConnManager())
+    bus_mod._bus = bus  # type: ignore[attr-defined]
+    register_task_calendar_listeners()
+    try:
+        yield bus
+    finally:
+        bus_mod._bus = prev  # type: ignore[attr-defined]
+
+
+def _ctx(user_id: str = "creator-1", workspace_id: str = "ws-a") -> RequestContext:
+    return RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="r",
+        scope=ScopeKind.NONE,
+        started_at=datetime.now(UTC),
+    )
+
+
+async def _events_in(workspace_id: str) -> list:
+    from pocketpaw_ee.calendar.models import _EventDoc
+
+    return await _EventDoc.find({"workspace": workspace_id}).to_list()
+
+
+async def _create_task(due_at=DUE, workspace_id: str = "ws-a", **overrides):
+    body = CreateTaskRequest(
+        title=overrides.pop("title", "Ship the audit report"),
+        assignee=overrides.pop("assignee", AssigneeDTO(kind="human", id="creator-1", name="Me")),
+        due_at=due_at,
+        **overrides,
+    )
+    return await tasks_service.agent_create_task(_ctx(workspace_id=workspace_id), body)
+
+
+# ---------------------------------------------------------------------------
+# Create — due date lands on the calendar
+# ---------------------------------------------------------------------------
+
+
+async def test_task_with_due_date_appears_on_tasks_calendar(real_bus) -> None:
+    """Creating a task with a due_at mints an event on the synthetic
+    'tasks' calendar, timed at due_at, linked via fabric_object_id.
+
+    Mutation that breaks this: bridge never calls create_event
+    ('drop the create' in tests/mutations/tasks_calendar_bridge.json).
+    """
+
+    task = await _create_task()
+
+    events = await _events_in("ws-a")
+    assert len(events) == 1
+    evt = events[0]
+    assert evt.calendar_id == "tasks"
+    assert evt.fabric_object_id == f"task:{task.id}"
+    assert evt.title == "Ship the audit report"
+    starts = evt.starts_at.replace(tzinfo=UTC) if evt.starts_at.tzinfo is None else evt.starts_at
+    assert starts == DUE
+    assert evt.ends_at > evt.starts_at
+
+
+async def test_task_without_due_date_mints_nothing(real_bus) -> None:
+    """No due_at → no calendar event. Most tasks are not deadlined."""
+
+    await _create_task(due_at=None)
+    assert await _events_in("ws-a") == []
+
+
+async def test_duplicate_proposed_emit_converges_to_one_event(real_bus) -> None:
+    """Re-delivering task.proposed for the same task must not duplicate
+    the event — find-before-create on fabric_object_id dedupes."""
+
+    from pocketpaw_ee.cloud._core.realtime.events import TaskProposed
+    from pocketpaw_ee.cloud.tasks.bridges.calendar import _on_task_proposed
+
+    task = await _create_task()
+    # Replay the same payload the service emitted (bus re-delivery).
+    await _on_task_proposed(
+        TaskProposed(
+            data={
+                "task_id": task.id,
+                "task": task.model_dump(),
+                "workspace_id": "ws-a",
+                "recipient_ids": [],
+            }
+        )
+    )
+
+    assert len(await _events_in("ws-a")) == 1
+
+
+# ---------------------------------------------------------------------------
+# Update — due date moves / clears
+# ---------------------------------------------------------------------------
+
+
+async def test_due_date_change_moves_the_event(real_bus) -> None:
+    """Changing due_at moves the calendar event to the new time.
+
+    Mutation that breaks this: bridge's update_event call becomes a
+    no-op ('drop the update-on-change')."""
+
+    task = await _create_task()
+    new_due = DUE + timedelta(days=2)
+
+    await tasks_service.agent_update_task(_ctx(), task.id, UpdateTaskRequest(due_at=new_due))
+
+    events = await _events_in("ws-a")
+    assert len(events) == 1
+    starts = events[0].starts_at
+    starts = starts.replace(tzinfo=UTC) if starts.tzinfo is None else starts
+    assert starts == new_due
+
+
+async def test_title_change_retitles_the_event(real_bus) -> None:
+    """Renaming a deadlined task renames its calendar event too."""
+
+    task = await _create_task()
+    await tasks_service.agent_update_task(_ctx(), task.id, UpdateTaskRequest(title="New name"))
+
+    events = await _events_in("ws-a")
+    assert len(events) == 1
+    assert events[0].title == "New name"
+
+
+async def test_clearing_due_date_deletes_the_event(real_bus) -> None:
+    """Explicit due_at=null removes the deadline → event disappears.
+
+    Mutation that breaks this: bridge's delete_event call becomes a
+    no-op ('drop the delete')."""
+
+    task = await _create_task()
+    assert len(await _events_in("ws-a")) == 1
+
+    await tasks_service.agent_update_task(_ctx(), task.id, UpdateTaskRequest(due_at=None))
+
+    assert await _events_in("ws-a") == []
+
+
+async def test_adding_due_date_later_mints_the_event(real_bus) -> None:
+    """A task created without a deadline gains one via update → the
+    event appears (the reconciler converges from any starting state)."""
+
+    task = await _create_task(due_at=None)
+    assert await _events_in("ws-a") == []
+
+    await tasks_service.agent_update_task(_ctx(), task.id, UpdateTaskRequest(due_at=DUE))
+
+    events = await _events_in("ws-a")
+    assert len(events) == 1
+    assert events[0].fabric_object_id == f"task:{task.id}"
+
+
+# ---------------------------------------------------------------------------
+# Resolve — completing the task clears the calendar
+# ---------------------------------------------------------------------------
+
+
+async def test_completing_task_deletes_the_event(real_bus) -> None:
+    """Archiving a deadlined task removes its calendar event.
+
+    Mutations that break this: 'drop the delete' and 'terminal statuses
+    stay calendar-eligible'."""
+
+    task = await _create_task()
+    assert len(await _events_in("ws-a")) == 1
+
+    await tasks_service.agent_complete_task(
+        _ctx(), task.id, CompleteTaskRequest(next_action="archive")
+    )
+
+    assert await _events_in("ws-a") == []
+
+
+async def test_edit_while_awaiting_approval_does_not_resurrect_event(real_bus) -> None:
+    """After completion into awaiting_approval, an unrelated metadata
+    edit must NOT re-mint the event — awaiting_approval is not a
+    calendar-eligible status."""
+
+    task = await _create_task()
+    await tasks_service.agent_complete_task(
+        _ctx(), task.id, CompleteTaskRequest(next_action="request_approval")
+    )
+    assert await _events_in("ws-a") == []
+
+    await tasks_service.agent_update_task(_ctx(), task.id, UpdateTaskRequest(summary="note"))
+
+    assert await _events_in("ws-a") == []
+
+
+# ---------------------------------------------------------------------------
+# Tenancy — the event carries the task's workspace, and only that one
+# ---------------------------------------------------------------------------
+
+
+async def test_event_is_stamped_with_the_tasks_workspace(real_bus) -> None:
+    """The minted event's workspace equals the task's workspace, and a
+    lookup (or list) from another workspace sees nothing.
+
+    Mutation that breaks this: bridge ctx hardcodes another workspace
+    ('leak the workspace stamp')."""
+
+    from pocketpaw_ee.calendar._context import RequestContext as CalCtx
+    from pocketpaw_ee.calendar.dto import ListEventsRequest
+    from pocketpaw_ee.calendar.service import list_events
+
+    await _create_task(workspace_id="ws-a")
+
+    events_a = await _events_in("ws-a")
+    assert len(events_a) == 1
+    assert events_a[0].workspace == "ws-a"
+    # Nothing minted into any other tenant's calendar...
+    assert await _events_in("ws-b") == []
+    # ...and the calendar read surface for ws-b can't see it either.
+    listed_b = await list_events(
+        CalCtx(workspace_id="ws-b", user_id="intruder"),
+        ListEventsRequest(
+            starts_after=DUE - timedelta(days=30),
+            starts_before=DUE + timedelta(days=30),
+        ),
+    )
+    assert listed_b.events == []
+
+
+# ---------------------------------------------------------------------------
+# Containment — a broken calendar must never break the task flow
+# ---------------------------------------------------------------------------
+
+
+async def test_task_create_survives_calendar_failure(real_bus, monkeypatch) -> None:
+    """When create_event raises, the task write still succeeds — the
+    bridge contains the failure exactly like the meetings bridge does."""
+
+    async def _boom(ctx, body):  # noqa: ARG001
+        raise RuntimeError("calendar is down")
+
+    monkeypatch.setattr("pocketpaw_ee.calendar.service.create_event", _boom)
+
+    task = await _create_task()
+
+    assert task.title == "Ship the audit report"  # write committed
+    got = await tasks_service.agent_get_task(_ctx(), task.id)
+    assert got.id == task.id
+    assert await _events_in("ws-a") == []  # no event, but no crash either
+
+
+async def test_task_complete_survives_calendar_failure(real_bus, monkeypatch) -> None:
+    """When delete_event raises, completing the task still succeeds."""
+
+    task = await _create_task()
+
+    async def _boom(ctx, event_id):  # noqa: ARG001
+        raise RuntimeError("calendar is down")
+
+    monkeypatch.setattr("pocketpaw_ee.calendar.service.delete_event", _boom)
+
+    done = await tasks_service.agent_complete_task(
+        _ctx(), task.id, CompleteTaskRequest(next_action="archive")
+    )
+    assert done.status == "done"
+
+
+async def test_comment_emit_with_task_none_is_a_noop(real_bus) -> None:
+    """task.updated fired for a task comment ships task=None — the
+    bridge must treat it as a no-op, not a crash."""
+
+    from pocketpaw_ee.cloud._core.realtime.events import TaskUpdated
+    from pocketpaw_ee.cloud.tasks.bridges.calendar import _on_task_updated
+
+    await _on_task_updated(
+        TaskUpdated(
+            data={
+                "task_id": "t-1",
+                "task": None,
+                "workspace_id": "ws-a",
+                "recipient_ids": [],
+            }
+        )
+    )
+
+    assert await _events_in("ws-a") == []

--- a/tests/cloud/test_integration.py
+++ b/tests/cloud/test_integration.py
@@ -94,3 +94,26 @@ def test_total_route_count():
     paths = _get_route_paths(app)
     # We have ~50+ endpoints across 6 domains + license + ws
     assert len(paths) >= 40, f"Only {len(paths)} routes mounted — expected 40+"
+
+
+def test_task_calendar_bridge_registered_at_mount():
+    """mount_cloud must wire the Task → Calendar bridge onto the realtime
+    bus. Pinned here because the bridge's own tests self-register on a
+    fixture bus — they'd stay green even if mount_cloud silently dropped
+    the production registration (self-registering e2e fixtures have
+    hidden exactly this before).
+
+    Mutation that breaks this: remove the register_task_calendar_listeners()
+    call from mount_cloud ('drop the mount registration' in
+    tests/mutations/tasks_calendar_bridge.json).
+    """
+    from pocketpaw_ee.cloud._core.realtime.bus import get_bus
+    from pocketpaw_ee.cloud.tasks.bridges import calendar as task_cal_bridge
+
+    app = FastAPI()
+    mount_cloud(app)  # init_realtime installs a real InProcessBus
+
+    handlers = get_bus()._handlers  # type: ignore[attr-defined]
+    assert task_cal_bridge._on_task_proposed in handlers.get("task.proposed", [])
+    assert task_cal_bridge._on_task_updated in handlers.get("task.updated", [])
+    assert task_cal_bridge._on_task_resolved in handlers.get("task.resolved", [])

--- a/tests/mutations/tasks_calendar_bridge.json
+++ b/tests/mutations/tasks_calendar_bridge.json
@@ -1,0 +1,58 @@
+[
+  {
+    "label": "drop the create — due dates never reach the calendar",
+    "file": "ee/pocketpaw_ee/cloud/tasks/bridges/calendar.py",
+    "find": "await create_event(ctx, body)",
+    "replace": "None",
+    "tests": ["tests/cloud/tasks/test_tasks_calendar_bridge.py"]
+  },
+  {
+    "label": "drop the update-on-change — moved due dates leave the event stale",
+    "file": "ee/pocketpaw_ee/cloud/tasks/bridges/calendar.py",
+    "find": "await update_event(ctx, str(doc.id), body)",
+    "replace": "None",
+    "tests": ["tests/cloud/tasks/test_tasks_calendar_bridge.py"]
+  },
+  {
+    "label": "drop the delete — resolved tasks and cleared due dates leave ghosts",
+    "file": "ee/pocketpaw_ee/cloud/tasks/bridges/calendar.py",
+    "find": "await delete_event(ctx, str(doc.id))",
+    "replace": "None",
+    "tests": ["tests/cloud/tasks/test_tasks_calendar_bridge.py"]
+  },
+  {
+    "label": "leak the workspace stamp — bridge ctx hardcodes another tenant",
+    "file": "ee/pocketpaw_ee/cloud/tasks/bridges/calendar.py",
+    "find": "return RequestContext(workspace_id=workspace_id, user_id=user_id)",
+    "replace": "return RequestContext(workspace_id=\"ws-b\", user_id=user_id)",
+    "tests": ["tests/cloud/tasks/test_tasks_calendar_bridge.py"]
+  },
+  {
+    "label": "terminal statuses stay calendar-eligible — done tasks keep their event",
+    "file": "ee/pocketpaw_ee/cloud/tasks/bridges/calendar.py",
+    "find": "_CALENDAR_ELIGIBLE_STATUSES = frozenset({\"proposed\", \"in_progress\", \"blocked\"})",
+    "replace": "_CALENDAR_ELIGIBLE_STATUSES = frozenset({\"proposed\", \"in_progress\", \"blocked\", \"awaiting_approval\", \"done\"})",
+    "tests": ["tests/cloud/tasks/test_tasks_calendar_bridge.py"]
+  },
+  {
+    "label": "drop the fabric linkage — re-emits duplicate instead of converging",
+    "file": "ee/pocketpaw_ee/cloud/tasks/bridges/calendar.py",
+    "find": "            fabric_object_id=fabric_id,",
+    "replace": "            fabric_object_id=None,",
+    "tests": ["tests/cloud/tasks/test_tasks_calendar_bridge.py"]
+  },
+  {
+    "label": "drop the mount registration — bridge exists but is never wired",
+    "file": "ee/pocketpaw_ee/cloud/__init__.py",
+    "find": "    register_task_calendar_listeners()",
+    "replace": "    pass",
+    "tests": ["tests/cloud/test_integration.py::test_task_calendar_bridge_registered_at_mount"]
+  },
+  {
+    "label": "narrow the meetings loop guard — task-minted events get URL-scanned again",
+    "file": "ee/pocketpaw_ee/cloud/meetings/bridges/calendar.py",
+    "find": "if isinstance(fabric_link, str) and fabric_link.startswith((\"meeting:\", \"task:\")):",
+    "replace": "if isinstance(fabric_link, str) and fabric_link.startswith(\"meeting:\"):",
+    "tests": ["tests/cloud/meetings/test_bridges.py::test_calendar_event_skips_when_minted_by_task_bridge"]
+  }
+]

--- a/tests/mutations/tasks_calendar_bridge.json
+++ b/tests/mutations/tasks_calendar_bridge.json
@@ -42,6 +42,13 @@
     "tests": ["tests/cloud/tasks/test_tasks_calendar_bridge.py"]
   },
   {
+    "label": "treat an absent due_at key as cleared — slim planner payloads delete live events",
+    "file": "ee/pocketpaw_ee/cloud/tasks/bridges/calendar.py",
+    "find": "    if \"due_at\" not in task and status in _CALENDAR_ELIGIBLE_STATUSES:\n        return",
+    "replace": "    if False:\n        return",
+    "tests": ["tests/cloud/tasks/test_tasks_calendar_bridge.py"]
+  },
+  {
     "label": "drop the mount registration — bridge exists but is never wired",
     "file": "ee/pocketpaw_ee/cloud/__init__.py",
     "find": "    register_task_calendar_listeners()",


### PR DESCRIPTION
A task with a due date never appeared on /calendar — deadlines lived only in the deep-work feed while the user planned their day on a calendar that didn't know about them. The meetings module solved this exact problem months ago; this PR gives tasks the same bridge.

A task gaining a due date mints an event on a synthetic tasks calendar (fabric_object_id task:<id>, the meetings convention). Due date moves, the event moves; task completes or the due date clears, the event goes. One reconciler owns the invariant — event exists iff the task is due-dated and in a live status — so replayed or duplicate events converge instead of drifting.

Three things in here beyond the happy path:

- The brief assumed tasks emit on the shared cross-domain bus like meetings do. They don't — the tasks service emits typed events on the realtime bus, so the bridge subscribes there. Premise checked against the service code before building, not after.
- A real cross-bridge loop got closed: calendar events flow through the meetings bridge's URL scanner, so a task titled with a Zoom link would have spawned a phantom Meeting row. The meetings bridge now skips bridge-owned events (task: alongside the existing meeting:), and a test pins that genuine user events still forward.
- The planner emits slim task payloads without a due_at key at all. The first build read absence as "due cleared" and deleted a live task's event — self-healing on the next full update, which is exactly why it would have survived unnoticed. The reconciler now treats an absent key on a live status as "unknown, don't touch", while explicit nulls and terminal statuses still delete. Both directions are tested.

Snooze behavior is worth a sentence: snoozing moves the event, because due_at is the snooze column by pre-existing design — the calendar shows when the task next needs attention. If snooze ever gets its own field, the bridge follows automatically.

Tests: 15 on the bridge covering the lifecycle, tenancy through the real read path, containment (task writes survive a raising calendar service), replay convergence, and both slim-payload directions; a mount-registration pin; and a 9-mutation plan, all caught. Failure name sets across tasks, calendar, and integration suites are identical to a clean dev baseline. A composite (workspace, fabric_object_id) index backs the new lookup pattern.