### PR TITLE
feat(cloud): operational alerts reach the workspace bell

### DIFF
--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -1,5 +1,10 @@
 """PocketPaw Enterprise Cloud — domain-driven architecture.
 
+Modified: 2026-08-06 (feat/coupling-alerts-to-bell, T-10) — Registers the
+    OSS operational-alert bridge (``notifications/bridges/alerts.py``):
+    SystemEvent(event_type="alert") on the OSS MessageBus now fans into
+    ``notifications_service.create`` for the default (operator)
+    workspace's admins, lighting the bell + Slack/webhook delivery.
 Modified: 2026-07-11 (feat/real-pipeline-s1) — Mounts the fabric_ingest
     transform-surface router (``/fabric/ingest/mappings`` CRUD +
     ``/fabric/ingest/run`` run-now) next to the fabric router under
@@ -920,6 +925,24 @@ def mount_cloud(app: FastAPI) -> None:
 
     register_meeting_notification_listeners()
     register_meeting_calendar_listeners()
+
+    # OSS operational alerts → workspace bell (T-10). The OSS AlertManager
+    # publishes SystemEvent(event_type="alert") on the in-process pocketpaw
+    # MessageBus (budget_exhausted / error_spike / channel_disconnect / …);
+    # without this bridge those events die in the OSS ring buffer and never
+    # become Notification rows — no bell, no Slack/webhook delivery. The
+    # bridge fans each alert to the DEFAULT (first-created / operator)
+    # workspace's admins only — instance-scoped alerts have no tenant
+    # attribution, see notifications/bridges/alerts.py for the full
+    # workspace-resolution rationale. Subscribes on the OSS bus (not the
+    # realtime EventBus), the same seam the session-title listener uses,
+    # so it has no init_realtime ordering constraint — kept with the other
+    # bridge registrations for locality.
+    from pocketpaw_ee.cloud.notifications.bridges.alerts import (
+        register_alert_notification_listeners,
+    )
+
+    register_alert_notification_listeners()
 
     # Push notifications fan-out (#1393) — v1 product events
     # (agent.stream_end / instinct.approval.created / meeting.started) →

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -1,5 +1,10 @@
 """PocketPaw Enterprise Cloud — domain-driven architecture.
 
+Modified: 2026-08-06 (feat/coupling-alerts-to-bell, T-10) — Registers the
+    OSS operational-alert bridge (``notifications/bridges/alerts.py``):
+    SystemEvent(event_type="alert") on the OSS MessageBus now fans into
+    ``notifications_service.create`` for the default (operator)
+    workspace's admins, lighting the bell + Slack/webhook delivery.
 Modified: 2026-08-06 (feat/coupling-lead-captured, T-6) — Registers the leads
     notification bridge (``leads.bridges.notifications``) alongside the meeting
     bridges, after ``init_realtime``. It subscribes to the new ``lead.captured``
@@ -985,6 +990,24 @@ def mount_cloud(app: FastAPI) -> None:
     )
 
     register_lead_notification_listeners()
+
+    # OSS operational alerts → workspace bell (T-10). The OSS AlertManager
+    # publishes SystemEvent(event_type="alert") on the in-process pocketpaw
+    # MessageBus (budget_exhausted / error_spike / channel_disconnect / …);
+    # without this bridge those events die in the OSS ring buffer and never
+    # become Notification rows — no bell, no Slack/webhook delivery. The
+    # bridge fans each alert to the DEFAULT (first-created / operator)
+    # workspace's admins only — instance-scoped alerts have no tenant
+    # attribution, see notifications/bridges/alerts.py for the full
+    # workspace-resolution rationale. Subscribes on the OSS bus (not the
+    # realtime EventBus), the same seam the session-title listener uses,
+    # so it has no init_realtime ordering constraint — kept with the other
+    # bridge registrations for locality.
+    from pocketpaw_ee.cloud.notifications.bridges.alerts import (
+        register_alert_notification_listeners,
+    )
+
+    register_alert_notification_listeners()
 
     # Push notifications fan-out (#1393) — ``notification.new`` (every
     # persisted notification, so the OS surface can't drift from the bell)

--- a/ee/pocketpaw_ee/cloud/notifications/bridges/__init__.py
+++ b/ee/pocketpaw_ee/cloud/notifications/bridges/__init__.py
@@ -1,0 +1,10 @@
+"""Bridges that turn external event streams into in-app notifications.
+
+Created 2026-08-06 (feat/coupling-alerts-to-bell) — houses the OSS
+operational-alert bridge (``alerts.py``). Mirrors the house bridge shape
+used by ``meetings/bridges/``; this package lives under ``notifications/``
+because the SOURCE here (the OSS ``pocketpaw.alert_manager``) has no cloud
+entity of its own, so the bridge hangs off the entity it produces into —
+the same placement logic that puts ``sessions/title_listener.py`` (the
+other OSS-bus subscriber) under its target entity.
+"""

--- a/ee/pocketpaw_ee/cloud/notifications/bridges/alerts.py
+++ b/ee/pocketpaw_ee/cloud/notifications/bridges/alerts.py
@@ -1,0 +1,158 @@
+"""OSS operational alerts → workspace-bell notifications.
+
+Created 2026-08-06 (feat/coupling-alerts-to-bell, T-10). The OSS
+``pocketpaw.alert_manager`` publishes ``SystemEvent(event_type="alert")``
+on the in-process pocketpaw MessageBus for budget_exhausted /
+budget_warning / error_spike / tool_degradation / channel_disconnect.
+Those events previously stopped at the OSS ring buffer + dashboard WS —
+they never became Notification rows, so the workspace bell (and the
+Slack/webhook external delivery that ``notifications_service.create``
+fans into) stayed dark exactly when nobody was watching the dashboard.
+
+This bridge subscribes to the OSS bus (the same seam
+``sessions/title_listener.py`` uses) and fans each alert into
+``notifications_service.create`` for the workspace admins. The
+AlertManager's ring buffer is untouched — the bridge is purely additive,
+and OSS-only deployments never load this module.
+
+WORKSPACE RESOLUTION (design decision — read before changing)
+-------------------------------------------------------------
+The OSS AlertManager is single-tenant: its alerts are INSTANCE-scoped
+(the process budget cap, the process error rate, the box's channel
+adapters) and carry no workspace attribution at all. On a cloud
+deployment we therefore notify the admins of the instance's FIRST-CREATED
+workspace only — the workspace ``seed_default_workspace`` mints for the
+platform operator at first boot. Rationale:
+
+- On the common deployment shapes (dedicated box / PEE / small cloud)
+  there is exactly one workspace, so "first workspace's admins" IS "the
+  admins".
+- On a multi-workspace box, instance internals (budget numbers, error
+  rates, channel state) belong to the operator; fanning them to every
+  tenant's admins would leak cross-tenant operational data. Conservative
+  choice: operator workspace only.
+- If alerts ever grow per-workspace attribution (e.g. per-tenant budget
+  caps), route attributable alerts to their own workspace's admins and
+  keep this default only for unattributable ones.
+
+Resolution goes through ``workspace_service.get_default_workspace_id()``
+(oldest workspace by ``_id``) + ``workspace_service.list_admin_ids()`` —
+the same admin-audience helper the realtime AudienceResolver uses.
+
+NOTIFICATION SHAPE / FE FOLLOW-UP
+---------------------------------
+``kind`` is ``f"alert_{alert_type}"`` (e.g. ``alert_budget_exhausted``).
+``source`` is ``NotificationSource(type="alert", id=<alert_type>)`` —
+alerts have no entity page, and paw-enterprise's
+``core/notifications/target.ts`` currently routes unknown source types to
+``/chat/{id}`` (a harmless dead link). FE follow-up: add a
+``case 'alert'`` to ``targetUrl()`` mapping to the ``/activity`` surface
+(the operational-events page), which is the sensible landing spot until a
+dedicated alerts surface exists.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pocketpaw.bus.events import SystemEvent
+
+logger = logging.getLogger(__name__)
+
+# Friendly titles per known alert_type; unknown types fall back to a
+# de-underscored capitalisation so a new OSS alert type still reads OK.
+_TITLES: dict[str, str] = {
+    "budget_exhausted": "Budget exhausted",
+    "budget_warning": "Budget warning",
+    "error_spike": "Error spike detected",
+    "tool_degradation": "Tool degraded",
+    "channel_disconnect": "Channel disconnected",
+}
+
+
+async def _on_system_event(event: SystemEvent) -> None:
+    """OSS-bus subscriber. MUST never raise — the AlertManager's publish
+    path gathers subscriber exceptions, but a raise here would still log
+    as a bus-level error and hide real fan-out bugs. All failure modes
+    log-and-return instead."""
+    if event.event_type != "alert":
+        return
+    try:
+        await _fan_out(event.data)
+    except Exception:
+        logger.exception("alert → notification fan-out failed")
+
+
+async def _fan_out(raw: Any) -> None:
+    data: dict[str, Any] = raw if isinstance(raw, dict) else {}
+    alert_type = data.get("alert_type")
+    if not isinstance(alert_type, str) or not alert_type:
+        logger.info("alert event missing alert_type; skipping: %r", data)
+        return
+
+    message = str(data.get("message") or "")
+
+    # Lazy imports: tolerate contexts where the cloud DB / Beanie is not
+    # initialized (OSS process that somehow loaded this module, unit
+    # tests without the mongo fixture) — same posture as the meetings
+    # bridge and the title listener.
+    try:
+        from pocketpaw_ee.cloud.workspace import service as workspace_service
+
+        workspace_id = await workspace_service.get_default_workspace_id()
+        if not workspace_id:
+            logger.info("no workspace exists yet; dropping alert %s", alert_type)
+            return
+        admins = await workspace_service.list_admin_ids(workspace_id)
+    except Exception:
+        logger.exception("could not resolve alert audience for %s", alert_type)
+        return
+
+    if not admins:
+        logger.info(
+            "default workspace %s has no admins; dropping alert %s", workspace_id, alert_type
+        )
+        return
+
+    kind = f"alert_{alert_type}"
+    title = _TITLES.get(alert_type, alert_type.replace("_", " ").capitalize())
+    body = message or f"Operational alert: {alert_type}"
+
+    from pocketpaw_ee.cloud.notifications.domain import NotificationSource
+
+    for recipient in admins:
+        # Per-recipient isolation: one failing insert must not starve the
+        # remaining admins of the alert.
+        try:
+            from pocketpaw_ee.cloud.notifications import service as notifications_service
+
+            await notifications_service.create(
+                workspace_id=workspace_id,
+                recipient=recipient,
+                kind=kind,
+                title=title,
+                body=body,
+                source=NotificationSource(type="alert", id=alert_type),
+            )
+        except Exception:
+            logger.exception("failed to create %s notification for admin=%s", kind, recipient)
+
+
+def register_alert_notification_listeners() -> None:
+    """Idempotently subscribe the alert bridge to the OSS MessageBus.
+
+    Unsubscribe-first (a no-op when absent) instead of a module-level
+    flag: the bus singleton is reset between tests via
+    ``pocketpaw.lifecycle``, and a sticky flag would silently skip
+    re-registration against the fresh bus.
+    """
+    from pocketpaw.bus import get_message_bus
+
+    bus = get_message_bus()
+    bus.unsubscribe_system(_on_system_event)
+    bus.subscribe_system(_on_system_event)
+    logger.info("registered OSS alert → notifications bridge")
+
+
+__all__ = ["register_alert_notification_listeners"]

--- a/ee/pocketpaw_ee/cloud/notifications/bridges/alerts.py
+++ b/ee/pocketpaw_ee/cloud/notifications/bridges/alerts.py
@@ -43,12 +43,15 @@ NOTIFICATION SHAPE / FE FOLLOW-UP
 ---------------------------------
 ``kind`` is ``f"alert_{alert_type}"`` (e.g. ``alert_budget_exhausted``).
 ``source`` is ``NotificationSource(type="alert", id=<alert_type>)`` —
-alerts have no entity page, and paw-enterprise's
-``core/notifications/target.ts`` currently routes unknown source types to
-``/chat/{id}`` (a harmless dead link). FE follow-up: add a
-``case 'alert'`` to ``targetUrl()`` mapping to the ``/activity`` surface
-(the operational-events page), which is the sensible landing spot until a
-dedicated alerts surface exists.
+alerts have no entity page. The PUSH side is handled:
+``push/listeners._target_url`` has an explicit ``alert`` arm returning
+None, so an alert push carries no deep link rather than a dead
+``/chat/<alert_type>`` one. Remaining FE follow-up (lands separately):
+paw-enterprise's ``core/notifications/target.ts`` still routes unknown
+source types to ``/chat/{id}`` in the bell — add a ``case 'alert'`` to
+``targetUrl()`` mapping to the ``/activity`` surface (the
+operational-events page), the sensible landing spot until a dedicated
+alerts surface exists.
 """
 
 from __future__ import annotations

--- a/ee/pocketpaw_ee/cloud/push/listeners.py
+++ b/ee/pocketpaw_ee/cloud/push/listeners.py
@@ -47,6 +47,10 @@
 #                                  (added in the same change), so the guardian
 #                                  block rides the converged path.
 #
+# Updated: 2026-08-20 (feat/coupling-alerts-to-bell review) — ``_target_url``
+# grew an explicit ``alert`` arm returning None: operational alerts have no
+# room, so the default arm was building /chat/<alert_type>, a dead link.
+#
 # LOCK-SCREEN PRIVACY. A push body lands on a lock screen, so it must never
 # carry user-authored text. Several kinds persist exactly that — ``message`` /
 # ``mention`` / ``reaction`` store ``content[:200]`` and the concierge kinds
@@ -188,6 +192,9 @@ def _target_url(data: dict[str, Any]) -> str | None:
         opened via ``approvalsStore.openTray()``, not a route, so there is no
         URL to point at. The pre-convergence handler sent ``/?view=approvals``,
         which nothing in the frontend reads.
+      * ``alert`` — omitted. Operational alerts have no route yet on either
+        side; the FE bell arm is a separate follow-up (see
+        ``notifications/bridges/alerts.py``).
     """
     source_type = data.get("source_type")
     source_id = data.get("source_id")
@@ -219,6 +226,14 @@ def _target_url(data: dict[str, Any]) -> str | None:
         # Without this arm the default below builds /chat/<site_id> — a room
         # that cannot exist.
         return f"/sites/{nav_target}?view=leads"
+    if source_type == "alert":
+        # Instance-scoped operational alerts (source_id is the alert_type,
+        # e.g. ``budget_exhausted``) have no entity page and no room — without
+        # this arm the default below builds /chat/<alert_type>, a room that
+        # cannot exist. No alerts route exists yet, so a push with no URL is
+        # honest; the FE bell arm lands separately (see the FE follow-up note
+        # in notifications/bridges/alerts.py).
+        return None
     # Same default arm as the frontend: unknown source types resolve to the
     # chat room, which is where every other current backend kind lives.
     return f"/chat/{nav_target}"

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -16,6 +16,10 @@ Public API:
 - ``list_member_ids(workspace_id)``, ``list_admin_ids(workspace_id)``,
   ``list_peer_ids(user_id)`` — used as function refs by the realtime
   audience resolver
+- ``get_default_workspace_id()`` — id of the instance's first-created
+  (operator) workspace; used by the OSS operational-alert bridge
+  (``notifications/bridges/alerts.py``) to route instance-scoped alerts
+  that carry no tenant attribution (added 2026-08-06, T-10)
 - ``get_workspace_plan(workspace_id)`` — lightweight plan-tier lookup for
   the plan-feature gate dependency; returns None when the workspace is
   missing/soft-deleted/malformed (the gate maps that to a 404) and
@@ -1817,6 +1821,23 @@ async def list_peer_ids(user_id: str) -> list[str]:
     return [str(u.id) for u in peers]
 
 
+async def get_default_workspace_id() -> str | None:
+    """Return the id of the instance's FIRST-CREATED workspace, or None.
+
+    The first workspace is the one ``seed_default_workspace`` mints for
+    the platform operator at first boot (ObjectIds sort by creation
+    time, so ascending ``_id`` is creation order). Instance-scoped
+    signals with no tenant attribution — today only the OSS
+    operational-alert bridge — route to this workspace's admins rather
+    than fanning out cross-tenant. Returns None on an empty instance.
+    """
+    # global-read: instance-level signal routing — alerts from the OSS
+    # AlertManager have no workspace attribution, so this deliberately
+    # resolves the instance's first (operator) workspace.
+    doc = await _WorkspaceDoc.find().sort("+_id").first_or_none()
+    return str(doc.id) if doc else None
+
+
 async def seed_default_workspace(admin_id: str, *, name: str, slug: str) -> _WorkspaceDoc | None:
     """Insert a default workspace with enterprise plan + 50 seats and
     register ``admin_id`` as the owner. Skips silently if any workspace
@@ -2196,6 +2217,7 @@ __all__ = [
     "get",
     "get_action_permissions",
     "get_connector_permissions",
+    "get_default_workspace_id",
     "get_delete_preview",
     "get_member_action_overrides",
     "get_route_permissions",

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -114,6 +114,10 @@ included). A Free workspace — even one that still holds members from a cancell
 plan — can no longer invite anyone new; existing members are never removed.
 ``raise_seats_for_plan`` is unchanged (upgrade-only, keeps the persisted
 ``doc.seats`` display ceiling in step).
+2026-08-20 (feat/coupling-alerts-to-bell review): get_default_workspace_id now
+filters ``deleted_at == None`` so a soft-deleted first workspace is skipped and
+the next-oldest LIVE workspace receives instance-scoped alerts, instead of
+routing them to a tombstone.
 """
 
 from __future__ import annotations
@@ -1829,12 +1833,20 @@ async def get_default_workspace_id() -> str | None:
     time, so ascending ``_id`` is creation order). Instance-scoped
     signals with no tenant attribution — today only the OSS
     operational-alert bridge — route to this workspace's admins rather
-    than fanning out cross-tenant. Returns None on an empty instance.
+    than fanning out cross-tenant. Soft-deleted workspaces are skipped
+    (the ``deleted_at`` contract every other fetch here honours), so the
+    OLDEST LIVE workspace wins. Returns None on an empty instance.
     """
     # global-read: instance-level signal routing — alerts from the OSS
     # AlertManager have no workspace attribution, so this deliberately
     # resolves the instance's first (operator) workspace.
-    doc = await _WorkspaceDoc.find().sort("+_id").first_or_none()
+    doc = (
+        await _WorkspaceDoc.find(
+            _WorkspaceDoc.deleted_at == None,  # noqa: E711
+        )
+        .sort("+_id")
+        .first_or_none()
+    )
     return str(doc.id) if doc else None
 
 

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -16,6 +16,10 @@ Public API:
 - ``list_member_ids(workspace_id)``, ``list_admin_ids(workspace_id)``,
   ``list_peer_ids(user_id)`` — used as function refs by the realtime
   audience resolver
+- ``get_default_workspace_id()`` — id of the instance's first-created
+  (operator) workspace; used by the OSS operational-alert bridge
+  (``notifications/bridges/alerts.py``) to route instance-scoped alerts
+  that carry no tenant attribution (added 2026-08-06, T-10)
 - ``get_workspace_plan(workspace_id)`` — lightweight plan-tier lookup for
   the plan-feature gate dependency; returns None when the workspace is
   missing/soft-deleted/malformed (the gate maps that to a 404) and
@@ -1807,6 +1811,23 @@ async def list_peer_ids(user_id: str) -> list[str]:
     return [str(u.id) for u in peers]
 
 
+async def get_default_workspace_id() -> str | None:
+    """Return the id of the instance's FIRST-CREATED workspace, or None.
+
+    The first workspace is the one ``seed_default_workspace`` mints for
+    the platform operator at first boot (ObjectIds sort by creation
+    time, so ascending ``_id`` is creation order). Instance-scoped
+    signals with no tenant attribution — today only the OSS
+    operational-alert bridge — route to this workspace's admins rather
+    than fanning out cross-tenant. Returns None on an empty instance.
+    """
+    # global-read: instance-level signal routing — alerts from the OSS
+    # AlertManager have no workspace attribution, so this deliberately
+    # resolves the instance's first (operator) workspace.
+    doc = await _WorkspaceDoc.find().sort("+_id").first_or_none()
+    return str(doc.id) if doc else None
+
+
 async def seed_default_workspace(admin_id: str, *, name: str, slug: str) -> _WorkspaceDoc | None:
     """Insert a default workspace with enterprise plan + 50 seats and
     register ``admin_id`` as the owner. Skips silently if any workspace
@@ -2186,6 +2207,7 @@ __all__ = [
     "get",
     "get_action_permissions",
     "get_connector_permissions",
+    "get_default_workspace_id",
     "get_delete_preview",
     "get_member_action_overrides",
     "get_route_permissions",

--- a/tests/cloud/notifications/test_alerts_bridge.py
+++ b/tests/cloud/notifications/test_alerts_bridge.py
@@ -1,0 +1,258 @@
+"""Tests for the OSS operational-alert → notification bridge (T-10).
+
+Created 2026-08-06 (feat/coupling-alerts-to-bell). Covers:
+- alert SystemEvent → one notification per default-workspace admin
+  (kind=alert_<type>, source type="alert")
+- non-alert SystemEvents are ignored
+- malformed alert payloads (None / non-dict / missing alert_type) are safe
+- a notifications_service.create failure never raises out of the handler
+  (and doesn't starve the remaining admins)
+- registration is idempotent and survives a bus reset
+- cross-tenant safety: only the FIRST-created workspace's admins are
+  notified on a multi-workspace instance (real Beanie path via mongo_db)
+
+Mutation plan: tests/mutations/alerts_bridge.json — each gate here names
+the mutation that breaks it.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from pocketpaw_ee.cloud.notifications.bridges import alerts as alerts_bridge
+
+from pocketpaw.bus import get_message_bus
+from pocketpaw.bus.events import SystemEvent
+
+
+@pytest.fixture
+def patched_audience(monkeypatch):
+    """Resolve the default workspace + admins without Mongo."""
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.get_default_workspace_id",
+        AsyncMock(return_value="ws-default"),
+    )
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.list_admin_ids",
+        AsyncMock(return_value=["admin-1", "admin-2"]),
+    )
+
+
+@pytest.fixture
+def patched_create(monkeypatch):
+    fake = AsyncMock()
+    monkeypatch.setattr("pocketpaw_ee.cloud.notifications.service.create", fake)
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# Fan-out
+# ---------------------------------------------------------------------------
+
+
+async def test_alert_creates_notification_per_admin(patched_audience, patched_create):
+    """Mutation 'drop-fanout' (make _fan_out return early) breaks this."""
+    await alerts_bridge._on_system_event(
+        SystemEvent(
+            event_type="alert",
+            data={
+                "alert_type": "budget_exhausted",
+                "severity": "critical",
+                "message": "Budget exhausted: $5.0000 spent against $5.0000 cap",
+            },
+        )
+    )
+    assert patched_create.call_count == 2
+    recipients = {c.kwargs["recipient"] for c in patched_create.call_args_list}
+    assert recipients == {"admin-1", "admin-2"}
+    kw = patched_create.call_args_list[0].kwargs
+    assert kw["workspace_id"] == "ws-default"
+    assert kw["kind"] == "alert_budget_exhausted"
+    assert kw["title"] == "Budget exhausted"
+    assert "Budget exhausted:" in kw["body"]
+    assert kw["source"].type == "alert"
+    assert kw["source"].id == "budget_exhausted"
+
+
+async def test_unknown_alert_type_still_fans_out(patched_audience, patched_create):
+    """A NEW OSS alert type must not be silently dropped. Mutation
+    'gate-on-known-titles' (skip types missing from _TITLES) breaks this."""
+    await alerts_bridge._on_system_event(
+        SystemEvent(event_type="alert", data={"alert_type": "disk_pressure"})
+    )
+    assert patched_create.call_count == 2
+    kw = patched_create.call_args_list[0].kwargs
+    assert kw["kind"] == "alert_disk_pressure"
+    assert kw["title"] == "Disk pressure"
+    assert kw["body"]  # non-empty fallback body even without a message
+
+
+async def test_non_alert_system_events_ignored(patched_audience, patched_create):
+    """Mutation 'drop-event-type-filter' breaks this."""
+    for event_type in ("tool_start", "session_titled", "channel_disconnected", "error"):
+        await alerts_bridge._on_system_event(
+            SystemEvent(event_type=event_type, data={"alert_type": "budget_exhausted"})
+        )
+    patched_create.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Malformed payloads
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        None,
+        {},
+        {"alert_type": ""},
+        {"alert_type": 42},
+        {"severity": "critical", "message": "no type"},
+        "not-a-dict",
+        ["also", "not", "a", "dict"],
+    ],
+)
+async def test_malformed_alert_payload_is_safe(patched_audience, patched_create, data):
+    """Neither raises nor creates. Mutation 'drop-alert-type-guard' breaks
+    this (an int alert_type would raise inside f-string/replace path or
+    create a garbage notification)."""
+    await alerts_bridge._on_system_event(SystemEvent(event_type="alert", data=data))
+    patched_create.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Failure isolation — the alert path must never break
+# ---------------------------------------------------------------------------
+
+
+async def test_notification_failure_never_raises(patched_audience, monkeypatch):
+    """Mutation 'unwrap-create' (remove the per-recipient try/except)
+    breaks this."""
+    boom = AsyncMock(side_effect=RuntimeError("mongo down"))
+    monkeypatch.setattr("pocketpaw_ee.cloud.notifications.service.create", boom)
+    # Must not raise.
+    await alerts_bridge._on_system_event(
+        SystemEvent(event_type="alert", data={"alert_type": "error_spike"})
+    )
+    # And the failure must not starve the second admin — both attempted.
+    assert boom.call_count == 2
+
+
+async def test_handler_never_raises_even_if_fanout_bugs(monkeypatch):
+    """The subscriber contract is never-raise, even on a bug in _fan_out
+    itself. Mutation 'unwrap-handler' (re-raise in _on_system_event)
+    breaks this."""
+    monkeypatch.setattr(
+        alerts_bridge, "_fan_out", AsyncMock(side_effect=RuntimeError("bug in fan-out"))
+    )
+    await alerts_bridge._on_system_event(
+        SystemEvent(event_type="alert", data={"alert_type": "error_spike"})
+    )
+
+
+async def test_audience_resolution_failure_never_raises(monkeypatch, patched_create):
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.get_default_workspace_id",
+        AsyncMock(side_effect=RuntimeError("beanie not initialized")),
+    )
+    await alerts_bridge._on_system_event(
+        SystemEvent(event_type="alert", data={"alert_type": "error_spike"})
+    )
+    patched_create.assert_not_called()
+
+
+async def test_no_workspace_yet_drops_alert(monkeypatch, patched_create):
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.workspace.service.get_default_workspace_id",
+        AsyncMock(return_value=None),
+    )
+    await alerts_bridge._on_system_event(
+        SystemEvent(event_type="alert", data={"alert_type": "error_spike"})
+    )
+    patched_create.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def test_register_is_idempotent():
+    """Registering twice yields exactly one subscription. Mutation
+    'drop-unsubscribe-first' breaks this (double fan-out per alert)."""
+    alerts_bridge.register_alert_notification_listeners()
+    alerts_bridge.register_alert_notification_listeners()
+    subs = get_message_bus()._system_subscribers
+    assert subs.count(alerts_bridge._on_system_event) == 1
+
+
+async def test_registered_handler_receives_published_alert(patched_audience, patched_create):
+    """End-to-end through the real OSS bus: publish_system → handler →
+    create. Mutation 'drop-subscribe' (register never subscribes) breaks
+    this."""
+    alerts_bridge.register_alert_notification_listeners()
+    await get_message_bus().publish_system(
+        SystemEvent(event_type="alert", data={"alert_type": "channel_disconnect"})
+    )
+    assert patched_create.call_count == 2
+    assert patched_create.call_args.kwargs["kind"] == "alert_channel_disconnect"
+
+
+# ---------------------------------------------------------------------------
+# Cross-tenant safety — real Beanie path (mongomock)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("mongo_db")
+async def test_only_first_workspace_admins_notified(patched_create):
+    """Multi-workspace instance: instance-scoped alerts go to the FIRST
+    (operator) workspace's admins only — never to other tenants. Mutation
+    'notify-all-workspaces' and mutation 'admins-to-members' break this."""
+    from pocketpaw_ee.cloud.models.user import User, WorkspaceMembership
+    from pocketpaw_ee.cloud.models.workspace import Workspace, WorkspaceSettings
+
+    ws1 = Workspace(name="Operator", slug="operator", owner="op", settings=WorkspaceSettings())
+    await ws1.insert()
+    ws2 = Workspace(name="Tenant B", slug="tenant-b", owner="tb", settings=WorkspaceSettings())
+    await ws2.insert()
+
+    async def _user(email: str, ws_id: str, role: str) -> User:
+        u = User(
+            email=email,
+            hashed_password="x",
+            workspaces=[WorkspaceMembership(workspace=ws_id, role=role)],
+        )
+        await u.insert()
+        return u
+
+    op_owner = await _user("owner@op.example", str(ws1.id), "owner")
+    op_admin = await _user("admin@op.example", str(ws1.id), "admin")
+    await _user("member@op.example", str(ws1.id), "member")
+    await _user("owner@b.example", str(ws2.id), "owner")
+    await _user("admin@b.example", str(ws2.id), "admin")
+
+    await alerts_bridge._on_system_event(
+        SystemEvent(event_type="alert", data={"alert_type": "budget_exhausted"})
+    )
+
+    recipients = {c.kwargs["recipient"] for c in patched_create.call_args_list}
+    assert recipients == {str(op_owner.id), str(op_admin.id)}
+    for c in patched_create.call_args_list:
+        assert c.kwargs["workspace_id"] == str(ws1.id)
+
+
+@pytest.mark.usefixtures("mongo_db")
+async def test_get_default_workspace_id_orders_by_creation():
+    from pocketpaw_ee.cloud.models.workspace import Workspace, WorkspaceSettings
+    from pocketpaw_ee.cloud.workspace import service as workspace_service
+
+    assert await workspace_service.get_default_workspace_id() is None
+
+    first = Workspace(name="First", slug="first", owner="a", settings=WorkspaceSettings())
+    await first.insert()
+    second = Workspace(name="Second", slug="second", owner="b", settings=WorkspaceSettings())
+    await second.insert()
+
+    assert await workspace_service.get_default_workspace_id() == str(first.id)

--- a/tests/cloud/notifications/test_alerts_bridge.py
+++ b/tests/cloud/notifications/test_alerts_bridge.py
@@ -10,6 +10,9 @@ Created 2026-08-06 (feat/coupling-alerts-to-bell). Covers:
 - registration is idempotent and survives a bus reset
 - cross-tenant safety: only the FIRST-created workspace's admins are
   notified on a multi-workspace instance (real Beanie path via mongo_db)
+- 2026-08-20 (review): get_default_workspace_id skips soft-deleted
+  workspaces (oldest LIVE wins), and push's _target_url returns None for
+  source_type="alert" (no alerts route — no deep link)
 
 Mutation plan: tests/mutations/alerts_bridge.json — each gate here names
 the mutation that breaks it.
@@ -256,3 +259,44 @@ async def test_get_default_workspace_id_orders_by_creation():
     await second.insert()
 
     assert await workspace_service.get_default_workspace_id() == str(first.id)
+
+
+@pytest.mark.usefixtures("mongo_db")
+async def test_get_default_workspace_id_skips_soft_deleted():
+    """A soft-deleted first workspace must NOT swallow instance alerts —
+    the next-oldest LIVE workspace's admins get them. Mutation
+    'workspace: default workspace ignores soft-delete' breaks this."""
+    from datetime import UTC, datetime
+
+    from pocketpaw_ee.cloud.models.workspace import Workspace, WorkspaceSettings
+    from pocketpaw_ee.cloud.workspace import service as workspace_service
+
+    first = Workspace(name="First", slug="first", owner="a", settings=WorkspaceSettings())
+    await first.insert()
+    second = Workspace(name="Second", slug="second", owner="b", settings=WorkspaceSettings())
+    await second.insert()
+
+    first.deleted_at = datetime.now(UTC)
+    await first.save()
+
+    assert await workspace_service.get_default_workspace_id() == str(second.id)
+
+    # Every workspace deleted → no default at all.
+    second.deleted_at = datetime.now(UTC)
+    await second.save()
+    assert await workspace_service.get_default_workspace_id() is None
+
+
+# ---------------------------------------------------------------------------
+# Push deep link — alerts carry NO url
+# ---------------------------------------------------------------------------
+
+
+def test_alert_push_has_no_deep_link():
+    """source_type="alert" has no room and no alerts route, so push's
+    ``_target_url`` must return None instead of the default
+    /chat/<alert_type> (a room that cannot exist). Mutation
+    'push: remove the alert arm from _target_url' breaks this."""
+    from pocketpaw_ee.cloud.push.listeners import _target_url
+
+    assert _target_url({"source_type": "alert", "source_id": "budget_exhausted"}) is None

--- a/tests/cloud/test_integration.py
+++ b/tests/cloud/test_integration.py
@@ -1,4 +1,9 @@
-"""Integration smoke test — verify all cloud routes mount correctly."""
+"""Integration smoke test — verify all cloud routes mount correctly.
+
+Updated 2026-08-06 (feat/coupling-alerts-to-bell, T-10): added
+test_alert_bridge_registered_on_mount — pins the OSS-alert → notification
+bridge registration inside mount_cloud().
+"""
 
 from __future__ import annotations
 
@@ -85,6 +90,23 @@ def test_cloud_error_handler_registered():
     app = FastAPI()
     mount_cloud(app)
     assert CloudError in app.exception_handlers
+
+
+def test_alert_bridge_registered_on_mount():
+    """mount_cloud() must subscribe the OSS-alert → notification bridge on
+    the OSS MessageBus (T-10). Deleting the register call in mount_cloud
+    fails this — the workspace bell would silently go dark for
+    budget_exhausted / error_spike / channel_disconnect."""
+    from pocketpaw.bus import get_message_bus
+    from pocketpaw.lifecycle import reset_all
+
+    reset_all()  # fresh bus so a prior test's registration can't mask a lost one
+    app = FastAPI()
+    mount_cloud(app)
+
+    from pocketpaw_ee.cloud.notifications.bridges.alerts import _on_system_event
+
+    assert get_message_bus()._system_subscribers.count(_on_system_event) == 1
 
 
 def test_total_route_count():

--- a/tests/mutations/alerts_bridge.json
+++ b/tests/mutations/alerts_bridge.json
@@ -4,70 +4,90 @@
     "file": "ee/pocketpaw_ee/cloud/notifications/bridges/alerts.py",
     "find": "    if event.event_type != \"alert\":\n        return",
     "replace": "    if False:\n        return",
-    "tests": ["tests/cloud/notifications/test_alerts_bridge.py"]
+    "tests": [
+      "tests/cloud/notifications/test_alerts_bridge.py"
+    ]
   },
   {
     "label": "bridge: drop the fan-out entirely",
     "file": "ee/pocketpaw_ee/cloud/notifications/bridges/alerts.py",
     "find": "        await _fan_out(event.data)",
     "replace": "        pass",
-    "tests": ["tests/cloud/notifications/test_alerts_bridge.py"]
+    "tests": [
+      "tests/cloud/notifications/test_alerts_bridge.py"
+    ]
   },
   {
     "label": "bridge: re-raise from the top-level handler",
     "file": "ee/pocketpaw_ee/cloud/notifications/bridges/alerts.py",
     "find": "    except Exception:\n        logger.exception(\"alert → notification fan-out failed\")",
     "replace": "    except Exception:\n        raise",
-    "tests": ["tests/cloud/notifications/test_alerts_bridge.py"]
+    "tests": [
+      "tests/cloud/notifications/test_alerts_bridge.py"
+    ]
   },
   {
     "label": "bridge: weaken the alert_type guard to None-only",
     "file": "ee/pocketpaw_ee/cloud/notifications/bridges/alerts.py",
     "find": "    if not isinstance(alert_type, str) or not alert_type:",
     "replace": "    if alert_type is None:",
-    "tests": ["tests/cloud/notifications/test_alerts_bridge.py"]
+    "tests": [
+      "tests/cloud/notifications/test_alerts_bridge.py"
+    ]
   },
   {
     "label": "bridge: silently drop unknown alert types",
     "file": "ee/pocketpaw_ee/cloud/notifications/bridges/alerts.py",
     "find": "    title = _TITLES.get(alert_type, alert_type.replace(\"_\", \" \").capitalize())",
     "replace": "    title = _TITLES[alert_type]",
-    "tests": ["tests/cloud/notifications/test_alerts_bridge.py"]
+    "tests": [
+      "tests/cloud/notifications/test_alerts_bridge.py"
+    ]
   },
   {
     "label": "bridge: drop the alert_ kind prefix",
     "file": "ee/pocketpaw_ee/cloud/notifications/bridges/alerts.py",
     "find": "    kind = f\"alert_{alert_type}\"",
     "replace": "    kind = alert_type",
-    "tests": ["tests/cloud/notifications/test_alerts_bridge.py"]
+    "tests": [
+      "tests/cloud/notifications/test_alerts_bridge.py"
+    ]
   },
   {
     "label": "bridge: drop the NotificationSource",
     "file": "ee/pocketpaw_ee/cloud/notifications/bridges/alerts.py",
     "find": "                source=NotificationSource(type=\"alert\", id=alert_type),",
     "replace": "                source=None,",
-    "tests": ["tests/cloud/notifications/test_alerts_bridge.py"]
+    "tests": [
+      "tests/cloud/notifications/test_alerts_bridge.py"
+    ]
   },
   {
     "label": "bridge: per-recipient failure starves the remaining admins",
     "file": "ee/pocketpaw_ee/cloud/notifications/bridges/alerts.py",
     "find": "        except Exception:\n            logger.exception(\"failed to create %s notification for admin=%s\", kind, recipient)",
     "replace": "        except Exception:\n            raise",
-    "tests": ["tests/cloud/notifications/test_alerts_bridge.py"]
+    "tests": [
+      "tests/cloud/notifications/test_alerts_bridge.py"
+    ]
   },
   {
     "label": "bridge: notify members instead of admins",
     "file": "ee/pocketpaw_ee/cloud/notifications/bridges/alerts.py",
     "find": "        admins = await workspace_service.list_admin_ids(workspace_id)",
     "replace": "        admins = await workspace_service.list_member_ids(workspace_id)",
-    "tests": ["tests/cloud/notifications/test_alerts_bridge.py"]
+    "tests": [
+      "tests/cloud/notifications/test_alerts_bridge.py"
+    ]
   },
   {
     "label": "bridge: register without dedup (double subscription)",
     "file": "ee/pocketpaw_ee/cloud/notifications/bridges/alerts.py",
     "find": "    bus.unsubscribe_system(_on_system_event)\n    bus.subscribe_system(_on_system_event)",
     "replace": "    bus.subscribe_system(_on_system_event)\n    bus.subscribe_system(_on_system_event)",
-    "tests": ["tests/cloud/notifications/test_alerts_bridge.py"]
+    "tests": [
+      "tests/cloud/notifications/test_alerts_bridge.py"
+    ]
   },
   {
     "label": "bridge: register never subscribes",
@@ -82,15 +102,37 @@
   {
     "label": "workspace: default workspace resolves NEWEST instead of oldest",
     "file": "ee/pocketpaw_ee/cloud/workspace/service.py",
-    "find": "    doc = await _WorkspaceDoc.find().sort(\"+_id\").first_or_none()",
-    "replace": "    doc = await _WorkspaceDoc.find().sort(\"-_id\").first_or_none()",
-    "tests": ["tests/cloud/notifications/test_alerts_bridge.py"]
+    "find": "        .sort(\"+_id\")\n        .first_or_none()",
+    "replace": "        .sort(\"-_id\")\n        .first_or_none()",
+    "tests": [
+      "tests/cloud/notifications/test_alerts_bridge.py"
+    ]
   },
   {
     "label": "mount: delete the bridge registration from mount_cloud",
     "file": "ee/pocketpaw_ee/cloud/__init__.py",
     "find": "    register_alert_notification_listeners()",
     "replace": "    pass  # mutation: registration dropped",
-    "tests": ["tests/cloud/test_integration.py"]
+    "tests": [
+      "tests/cloud/test_integration.py"
+    ]
+  },
+  {
+    "label": "workspace: default workspace ignores soft-delete",
+    "file": "ee/pocketpaw_ee/cloud/workspace/service.py",
+    "find": "        await _WorkspaceDoc.find(\n            _WorkspaceDoc.deleted_at == None,  # noqa: E711\n        )",
+    "replace": "        await _WorkspaceDoc.find()",
+    "tests": [
+      "tests/cloud/notifications/test_alerts_bridge.py"
+    ]
+  },
+  {
+    "label": "push: remove the alert arm from _target_url",
+    "file": "ee/pocketpaw_ee/cloud/push/listeners.py",
+    "find": "    if source_type == \"alert\":",
+    "replace": "    if source_type == \"alert_NEVER\":",
+    "tests": [
+      "tests/cloud/notifications/test_alerts_bridge.py"
+    ]
   }
 ]

--- a/tests/mutations/alerts_bridge.json
+++ b/tests/mutations/alerts_bridge.json
@@ -1,0 +1,96 @@
+[
+  {
+    "label": "bridge: drop the event_type filter",
+    "file": "ee/pocketpaw_ee/cloud/notifications/bridges/alerts.py",
+    "find": "    if event.event_type != \"alert\":\n        return",
+    "replace": "    if False:\n        return",
+    "tests": ["tests/cloud/notifications/test_alerts_bridge.py"]
+  },
+  {
+    "label": "bridge: drop the fan-out entirely",
+    "file": "ee/pocketpaw_ee/cloud/notifications/bridges/alerts.py",
+    "find": "        await _fan_out(event.data)",
+    "replace": "        pass",
+    "tests": ["tests/cloud/notifications/test_alerts_bridge.py"]
+  },
+  {
+    "label": "bridge: re-raise from the top-level handler",
+    "file": "ee/pocketpaw_ee/cloud/notifications/bridges/alerts.py",
+    "find": "    except Exception:\n        logger.exception(\"alert → notification fan-out failed\")",
+    "replace": "    except Exception:\n        raise",
+    "tests": ["tests/cloud/notifications/test_alerts_bridge.py"]
+  },
+  {
+    "label": "bridge: weaken the alert_type guard to None-only",
+    "file": "ee/pocketpaw_ee/cloud/notifications/bridges/alerts.py",
+    "find": "    if not isinstance(alert_type, str) or not alert_type:",
+    "replace": "    if alert_type is None:",
+    "tests": ["tests/cloud/notifications/test_alerts_bridge.py"]
+  },
+  {
+    "label": "bridge: silently drop unknown alert types",
+    "file": "ee/pocketpaw_ee/cloud/notifications/bridges/alerts.py",
+    "find": "    title = _TITLES.get(alert_type, alert_type.replace(\"_\", \" \").capitalize())",
+    "replace": "    title = _TITLES[alert_type]",
+    "tests": ["tests/cloud/notifications/test_alerts_bridge.py"]
+  },
+  {
+    "label": "bridge: drop the alert_ kind prefix",
+    "file": "ee/pocketpaw_ee/cloud/notifications/bridges/alerts.py",
+    "find": "    kind = f\"alert_{alert_type}\"",
+    "replace": "    kind = alert_type",
+    "tests": ["tests/cloud/notifications/test_alerts_bridge.py"]
+  },
+  {
+    "label": "bridge: drop the NotificationSource",
+    "file": "ee/pocketpaw_ee/cloud/notifications/bridges/alerts.py",
+    "find": "                source=NotificationSource(type=\"alert\", id=alert_type),",
+    "replace": "                source=None,",
+    "tests": ["tests/cloud/notifications/test_alerts_bridge.py"]
+  },
+  {
+    "label": "bridge: per-recipient failure starves the remaining admins",
+    "file": "ee/pocketpaw_ee/cloud/notifications/bridges/alerts.py",
+    "find": "        except Exception:\n            logger.exception(\"failed to create %s notification for admin=%s\", kind, recipient)",
+    "replace": "        except Exception:\n            raise",
+    "tests": ["tests/cloud/notifications/test_alerts_bridge.py"]
+  },
+  {
+    "label": "bridge: notify members instead of admins",
+    "file": "ee/pocketpaw_ee/cloud/notifications/bridges/alerts.py",
+    "find": "        admins = await workspace_service.list_admin_ids(workspace_id)",
+    "replace": "        admins = await workspace_service.list_member_ids(workspace_id)",
+    "tests": ["tests/cloud/notifications/test_alerts_bridge.py"]
+  },
+  {
+    "label": "bridge: register without dedup (double subscription)",
+    "file": "ee/pocketpaw_ee/cloud/notifications/bridges/alerts.py",
+    "find": "    bus.unsubscribe_system(_on_system_event)\n    bus.subscribe_system(_on_system_event)",
+    "replace": "    bus.subscribe_system(_on_system_event)\n    bus.subscribe_system(_on_system_event)",
+    "tests": ["tests/cloud/notifications/test_alerts_bridge.py"]
+  },
+  {
+    "label": "bridge: register never subscribes",
+    "file": "ee/pocketpaw_ee/cloud/notifications/bridges/alerts.py",
+    "find": "    bus.unsubscribe_system(_on_system_event)\n    bus.subscribe_system(_on_system_event)",
+    "replace": "    bus.unsubscribe_system(_on_system_event)",
+    "tests": [
+      "tests/cloud/notifications/test_alerts_bridge.py",
+      "tests/cloud/test_integration.py"
+    ]
+  },
+  {
+    "label": "workspace: default workspace resolves NEWEST instead of oldest",
+    "file": "ee/pocketpaw_ee/cloud/workspace/service.py",
+    "find": "    doc = await _WorkspaceDoc.find().sort(\"+_id\").first_or_none()",
+    "replace": "    doc = await _WorkspaceDoc.find().sort(\"-_id\").first_or_none()",
+    "tests": ["tests/cloud/notifications/test_alerts_bridge.py"]
+  },
+  {
+    "label": "mount: delete the bridge registration from mount_cloud",
+    "file": "ee/pocketpaw_ee/cloud/__init__.py",
+    "find": "    register_alert_notification_listeners()",
+    "replace": "    pass  # mutation: registration dropped",
+    "tests": ["tests/cloud/test_integration.py"]
+  }
+]


### PR DESCRIPTION
The alerts that matter most when nobody is watching the dashboard — budget exhausted, error spike, a channel adapter dying — lived in a process-local ring buffer and an OSS bus event nothing cloud-side consumed. They never became notifications, never hit the bell, never reached the Slack/webhook delivery that already exists on dev.

A new bridge under notifications/bridges subscribes to the OSS SystemEvent stream (the same seam the session-title listener uses), filters for alerts, and creates persisted notifications. The ring buffer is untouched; OSS-only deployments behave exactly as before.

The design question worth reading closely is who gets told. OSS alerts are instance-scoped with zero tenant attribution, so the bridge routes them to the first-created workspace's admins — the operator workspace, which the boot sequence guarantees exists before any customer workspace can be created. The review pushed hard on whether this leaks tenant information and concluded the opposite: budget, channels, and error rates are platform-operator surfaces by the codebase's own auth-bridge rules, the information flows tenant-to-operator (who already has full visibility), and the bridge forwards only the alert message, never the details payload. Fanning to every workspace's admins would have been the leaky design.

Tests: 18 on the bridge (event filtering, malformed payloads, per-recipient containment, tenancy) plus a mount pin, and a 13-mutation plan — all caught, including weakening the type filter, swapping admins for members, dropping the fan-out, and deleting the registration.

Two follow-ups flagged by review, deliberately not crammed in here: if first-boot seeding ever fails, the "default workspace" anchor could land on a customer (fix: anchor to the first superuser's workspace with oldest-as-fallback); and channel_disconnect alerts bypass the transition-gating that throttles the other types — dormant today since nothing publishes channel_disconnected yet, but whichever slice adds that publisher should add a cooldown. The frontend also needs a small follow-up to route alert notifications to /activity instead of the generic chat fallback.