### PR TITLE
feat(calendar): the agent and the calendar page read one event store

### DIFF
--- a/ee/pocketpaw_ee/calendar/sync.py
+++ b/ee/pocketpaw_ee/calendar/sync.py
@@ -1,27 +1,71 @@
 # Calendar module — external calendar sync.
-# Updated: 2026-05-19 (fix/calendar-security-hardening, #1142 H-NEW-1).
+# Updated: 2026-08-06 (feat/coupling-calendar-sot, T-13).
 #
 # Changes:
-# - H-NEW-1: imported gcalendar events now carry created_by_user_id =
-#   ctx.user_id (the syncing user). The external creator isn't always a
-#   user in the workspace; the syncing user becomes the local steward
-#   and can edit / delete the imported event.
+# - T-13: added ``ingest_composio_events`` — the Composio Google Calendar
+#   pull (used by the agent preamble's ``cloud.calendar.list_upcoming``)
+#   now reconciles into ``_EventDoc`` through the same
+#   ``source_connector`` + ``source_external_id`` keys the native
+#   gcalendar pull uses, so /calendar and the agent read one store.
+# - T-13: cross-connector dedupe. A user may have BOTH the native
+#   gcalendar connector and Composio wired to the same Google account.
+#   The Google event id (``source_external_id``) is the upstream truth,
+#   so reconciliation for the google family matches
+#   ``source_connector in {"gcalendar", "composio_google"}`` rather than
+#   one exact connector. Whichever route ingests an event first stamps
+#   its connector; the other route UPDATES that row in place and never
+#   creates a second one. ``pull_from_gcalendar`` adopts the same
+#   matcher so the no-duplicate guarantee holds in both ingest orders.
+# - H-NEW-1 (2026-05-19): imported gcalendar events carry
+#   created_by_user_id = ctx.user_id (the syncing user acts as steward).
 #
-# Only Google Calendar is implemented in this PR. Outlook and iCloud are
-# placeholders that raise NotImplementedError so a future PR can wire them
-# without us pretending they work today. The gcalendar wrapper sits on top
-# of pocketpaw.integrations.gcalendar.CalendarClient.
+# Only Google Calendar is implemented. Outlook and iCloud are placeholders
+# that raise NotImplementedError so a future PR can wire them without us
+# pretending they work today. The gcalendar wrapper sits on top of
+# pocketpaw.clients.gcalendar.CalendarClient.
+#
+# Sync ingests are silent on the event bus — mirroring the original
+# gcalendar pull, neither path emits ``calendar.event.created`` per
+# imported row (a 250-row pull would flood the meeting bridge and
+# notifications). If bridge coverage for synced events is wanted, that's
+# a deliberate follow-up, not an accident of this module.
 
 from __future__ import annotations
 
 import logging
 from datetime import UTC, datetime, timedelta
+from typing import Any
 
 from pocketpaw_ee.calendar._context import RequestContext
 from pocketpaw_ee.calendar.domain import Event
 from pocketpaw_ee.calendar.models import _EventDoc
 
 logger = logging.getLogger(__name__)
+
+# Connector slugs for the two routes that pull the same upstream Google
+# calendar. They share ``source_external_id`` (the Google event id), so
+# reconciliation treats them as one family — see _find_google_event.
+SOURCE_CONNECTOR_GCALENDAR = "gcalendar"
+SOURCE_CONNECTOR_COMPOSIO = "composio_google"
+_GOOGLE_CONNECTOR_FAMILY = [SOURCE_CONNECTOR_GCALENDAR, SOURCE_CONNECTOR_COMPOSIO]
+
+
+async def _find_google_event(workspace_id: str, external_id: str) -> _EventDoc | None:
+    """Find the local row for a Google event id, whichever connector minted it.
+
+    Cross-connector dedupe: the same Google account can be wired through
+    the native gcalendar OAuth client AND Composio at once. Matching on
+    the exact connector would store the same upstream event twice (one
+    row per connector). Matching the family keyed on the Google event id
+    collapses them to one row.
+    """
+    return await _EventDoc.find_one(
+        {
+            "workspace": workspace_id,
+            "source_connector": {"$in": _GOOGLE_CONNECTOR_FAMILY},
+            "source_external_id": external_id,
+        }
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -35,14 +79,14 @@ async def pull_from_gcalendar(ctx: RequestContext, calendar_id: str) -> int:
     Reconciles by (source_connector="gcalendar", source_external_id=<google id>).
     Returns the count of events created OR updated.
 
-    This is a thin wrapper around pocketpaw.integrations.gcalendar.CalendarClient.
+    This is a thin wrapper around pocketpaw.clients.gcalendar.CalendarClient.
     OAuth must already be set up — if it isn't, the underlying client raises
     RuntimeError and we propagate (the caller is responsible for showing the
     OAuth re-auth flow).
     """
     # Lazy import — keeps ee.calendar importable even when the OAuth deps
     # haven't been configured at process start.
-    from pocketpaw.integrations.gcalendar import CalendarClient  # type: ignore[import-untyped]
+    from pocketpaw.clients.gcalendar import CalendarClient  # type: ignore[import-untyped]
 
     client = CalendarClient()
     time_min = datetime.now(UTC) - timedelta(days=1)
@@ -75,11 +119,12 @@ async def pull_from_gcalendar(ctx: RequestContext, calendar_id: str) -> int:
             if email
         ]
 
-        existing = await _EventDoc.find_one(
-            _EventDoc.workspace == ctx.workspace_id,
-            _EventDoc.source_connector == "gcalendar",
-            _EventDoc.source_external_id == external_id,
-        )
+        # T-13: match the whole google connector family, not just
+        # "gcalendar" — if Composio ingested this event first, update that
+        # row instead of minting a duplicate. The row keeps its original
+        # connector tag (provenance is who ingested first; both routes
+        # keep the row fresh).
+        existing = await _find_google_event(ctx.workspace_id, external_id)
         if existing:
             existing.title = ext.get("summary") or existing.title
             existing.starts_at = starts_at
@@ -107,7 +152,7 @@ async def pull_from_gcalendar(ctx: RequestContext, calendar_id: str) -> int:
                 created_by_user_id=ctx.user_id,
                 location=ext.get("location") or None,
                 attendees=attendees,
-                source_connector="gcalendar",
+                source_connector=SOURCE_CONNECTOR_GCALENDAR,
                 source_external_id=external_id,
             )
             await doc.insert()
@@ -116,16 +161,125 @@ async def pull_from_gcalendar(ctx: RequestContext, calendar_id: str) -> int:
     return touched
 
 
+async def ingest_composio_events(
+    ctx: RequestContext,
+    items: list[dict[str, Any]],
+    calendar_id: str = "primary",
+) -> int:
+    """Reconcile raw Google-shaped event items (from Composio's
+    ``GOOGLECALENDAR_LIST_EVENTS``) into our store.
+
+    ``items`` are Google API ``events.list`` rows: ``id``, ``summary``,
+    ``start.dateTime`` / ``start.date``, ``end.*``, ``attendees`` as a
+    list of ``{"email": ...}`` dicts. The transport (Composio client,
+    user-id namespacing) stays in ``pocketpaw_ee.cloud.calendar.service``
+    — this function owns only the store reconciliation, so it can be
+    tested without a Composio double.
+
+    Reconciles by (workspace, google-family connector, source_external_id)
+    via ``_find_google_event`` — see the cross-connector dedupe note at
+    the top of this module. New rows are stamped
+    ``source_connector="composio_google"``; rows the native gcalendar
+    pull minted first keep their "gcalendar" tag and are updated in place.
+
+    Returns the count of events created OR updated.
+    """
+    touched = 0
+    for raw in items:
+        external_id = raw.get("id")
+        if not isinstance(external_id, str) or not external_id:
+            continue
+
+        starts_at = _parse_google_time(raw.get("start"))
+        ends_at = _parse_google_time(raw.get("end"))
+        if starts_at is None or ends_at is None:
+            logger.warning("Skipping composio event with bad time: id=%r", external_id)
+            continue
+        if ends_at <= starts_at:
+            # _EventDoc has no window validator, but the domain layer and
+            # every write path enforce starts < ends — don't let a bad
+            # upstream row poison reads.
+            logger.warning("Skipping composio event with inverted window: id=%r", external_id)
+            continue
+
+        attendees = [
+            {"email": email, "response": "needs_action", "is_organizer": False}
+            for email in _attendee_emails(raw.get("attendees"))
+        ]
+
+        existing = await _find_google_event(ctx.workspace_id, external_id)
+        if existing:
+            existing.title = raw.get("summary") or existing.title
+            existing.starts_at = starts_at
+            existing.ends_at = ends_at
+            existing.description = raw.get("description") or ""
+            existing.location = raw.get("location") or None
+            existing.attendees = attendees
+            existing.updated_at = datetime.now(UTC)
+            # no-event: sync ingests are silent on the bus (see module header).
+            await existing.save()
+        else:
+            doc = _EventDoc(
+                workspace=ctx.workspace_id,
+                calendar_id=calendar_id,
+                title=raw.get("summary") or "(no title)",
+                description=raw.get("description") or "",
+                starts_at=starts_at,
+                ends_at=ends_at,
+                # Google's dateTime carries its own offset; UTC is the
+                # canonical store (same call as the gcalendar pull).
+                timezone="UTC",
+                # H-NEW-1 pattern: the user whose Composio connection
+                # fetched the event becomes the local steward.
+                created_by_user_id=ctx.user_id,
+                location=raw.get("location") or None,
+                attendees=attendees,
+                source_connector=SOURCE_CONNECTOR_COMPOSIO,
+                source_external_id=external_id,
+            )
+            # no-event: sync ingests are silent on the bus (see module header).
+            await doc.insert()
+        touched += 1
+
+    return touched
+
+
+def _parse_google_time(block: Any) -> datetime | None:
+    """Parse a Google API ``start`` / ``end`` block into a datetime.
+
+    ``{"dateTime": <RFC 3339>}`` for timed events, ``{"date": "YYYY-MM-DD"}``
+    for all-day events (parsed as midnight, matching _parse_iso's
+    date-only handling)."""
+    if not isinstance(block, dict):
+        return None
+    raw = block.get("dateTime") or block.get("date") or ""
+    if not isinstance(raw, str):
+        return None
+    return _parse_iso(raw)
+
+
+def _attendee_emails(raw: Any) -> list[str]:
+    """Extract plain emails from Google's attendees list-of-dicts shape."""
+    emails: list[str] = []
+    if isinstance(raw, list):
+        for entry in raw:
+            if isinstance(entry, dict):
+                email = entry.get("email")
+                if isinstance(email, str) and email:
+                    emails.append(email)
+    return emails
+
+
 async def push_to_gcalendar(ctx: RequestContext, event: Event) -> str:
     """Push a local Event to Google Calendar. Returns the external id.
 
-    Reads the same `pocketpaw.integrations.gcalendar.CalendarClient` used by
+    Reads the same `pocketpaw.clients.gcalendar.CalendarClient` used by
     pull; mutation is one-way (this PR doesn't track the local event's
     source_external_id once it's been pushed — the next pull will reconcile).
     """
     # ctx is accepted so future per-workspace OAuth scoping has a home.
     del ctx
-    from pocketpaw.integrations.gcalendar import CalendarClient  # type: ignore[import-untyped]
+    from pocketpaw.clients.gcalendar import CalendarClient  # type: ignore[import-untyped]
 
     client = CalendarClient()
     response = await client.create_event(

--- a/ee/pocketpaw_ee/calendar/sync.py
+++ b/ee/pocketpaw_ee/calendar/sync.py
@@ -1,5 +1,5 @@
 # Calendar module — external calendar sync.
-# Updated: 2026-08-06 (feat/coupling-calendar-sot, T-13).
+# Updated: 2026-08-06 (feat/coupling-calendar-sot, T-13 + review round 2).
 #
 # Changes:
 # - T-13: added ``ingest_composio_events`` — the Composio Google Calendar
@@ -7,15 +7,30 @@
 #   now reconciles into ``_EventDoc`` through the same
 #   ``source_connector`` + ``source_external_id`` keys the native
 #   gcalendar pull uses, so /calendar and the agent read one store.
-# - T-13: cross-connector dedupe. A user may have BOTH the native
-#   gcalendar connector and Composio wired to the same Google account.
-#   The Google event id (``source_external_id``) is the upstream truth,
-#   so reconciliation for the google family matches
-#   ``source_connector in {"gcalendar", "composio_google"}`` rather than
-#   one exact connector. Whichever route ingests an event first stamps
-#   its connector; the other route UPDATES that row in place and never
-#   creates a second one. ``pull_from_gcalendar`` adopts the same
-#   matcher so the no-duplicate guarantee holds in both ingest orders.
+# - T-13 review round 2 (CRITICAL fix): Composio connections are
+#   PER-USER (``composio_user_id`` namespaces enterprise:user), so what
+#   the ingest lands is one member's personal Google feed. Ingested rows
+#   now live on a per-user calendar backed by a real ``_CalendarDoc``
+#   with ``visibility="private"``, owner = the syncing user, auto-created
+#   on first ingest (``_ensure_composio_calendar``). The existing policy
+#   machinery then keeps member A's personal events out of member B's
+#   /calendar and agent preamble. (The first cut used the synthetic
+#   workspace-public "primary" calendar — a cross-member privacy leak.)
+# - T-13: cross-connector dedupe, scoped per-user for Composio rows. The
+#   Google event id (``source_external_id``) is the upstream truth, so
+#   reconciliation for the google family matches EITHER the native
+#   "gcalendar" connector (workspace-visible, single-OAuth legacy) OR a
+#   "composio_google" row synced BY THE SAME USER. Two members invited to
+#   the same meeting each get their own private row — deduping those
+#   across users would strand member B's copy on member A's private
+#   calendar where B can't see it. Within one user, whichever route
+#   ingests first stamps its connector; the other route UPDATES that row
+#   in place and never creates a second one. ``pull_from_gcalendar``
+#   uses the same matcher so the guarantee holds in both ingest orders.
+# - T-13: timezone capture. Google's ``start.timeZone`` (IANA) is stored
+#   on the row when present so the preamble can render event-local wall
+#   time; otherwise the store keeps the "UTC" canonical stamp the native
+#   pull established.
 # - H-NEW-1 (2026-05-19): imported gcalendar events carry
 #   created_by_user_id = ctx.user_id (the syncing user acts as steward).
 #
@@ -35,10 +50,11 @@ from __future__ import annotations
 import logging
 from datetime import UTC, datetime, timedelta
 from typing import Any
+from zoneinfo import ZoneInfo
 
 from pocketpaw_ee.calendar._context import RequestContext
 from pocketpaw_ee.calendar.domain import Event
-from pocketpaw_ee.calendar.models import _EventDoc
+from pocketpaw_ee.calendar.models import _CalendarDoc, _EventDoc
 
 logger = logging.getLogger(__name__)
 
@@ -49,23 +65,72 @@ SOURCE_CONNECTOR_GCALENDAR = "gcalendar"
 SOURCE_CONNECTOR_COMPOSIO = "composio_google"
 _GOOGLE_CONNECTOR_FAMILY = [SOURCE_CONNECTOR_GCALENDAR, SOURCE_CONNECTOR_COMPOSIO]
 
+# Name marker for the per-user private calendar that Composio-synced
+# events land on. The (workspace, owner_user_id, name) triple is the
+# lookup key; the calendar's real id is its ObjectId.
+_COMPOSIO_CALENDAR_NAME = "Google Calendar (Composio)"
 
-async def _find_google_event(workspace_id: str, external_id: str) -> _EventDoc | None:
-    """Find the local row for a Google event id, whichever connector minted it.
 
-    Cross-connector dedupe: the same Google account can be wired through
-    the native gcalendar OAuth client AND Composio at once. Matching on
-    the exact connector would store the same upstream event twice (one
-    row per connector). Matching the family keyed on the Google event id
-    collapses them to one row.
+async def _find_google_event(workspace_id: str, external_id: str, user_id: str) -> _EventDoc | None:
+    """Find the local row for a Google event id, for cross-connector dedupe.
+
+    Matches (a) native "gcalendar" rows — workspace-visible, from the
+    legacy single-OAuth pull — for ANY user, and (b) "composio_google"
+    rows synced by THIS user (``created_by_user_id``). Composio rows are
+    per-user private data, so another member's row for the same upstream
+    event must not be matched: each invitee keeps their own private copy.
     """
     return await _EventDoc.find_one(
         {
             "workspace": workspace_id,
-            "source_connector": {"$in": _GOOGLE_CONNECTOR_FAMILY},
             "source_external_id": external_id,
+            "$or": [
+                {"source_connector": SOURCE_CONNECTOR_GCALENDAR},
+                {
+                    "source_connector": SOURCE_CONNECTOR_COMPOSIO,
+                    "created_by_user_id": user_id,
+                },
+            ],
         }
     )
+
+
+async def _ensure_composio_calendar(ctx: RequestContext) -> str:
+    """Resolve (creating on first ingest) the per-user PRIVATE calendar
+    that Composio-synced events land on. Returns its id.
+
+    The Composio connection is per-user, so its events are one member's
+    personal feed — landing them on the synthetic workspace-public
+    default calendar would render them in every other member's /calendar
+    and agent preamble. A real ``_CalendarDoc`` with
+    ``visibility="private"`` and owner = the syncing user lets the
+    existing policy machinery (``check_calendar_read`` /
+    ``can_read_calendar``) do the filtering.
+    """
+    existing = await _CalendarDoc.find_one(
+        {
+            "workspace": ctx.workspace_id,
+            "owner_user_id": ctx.user_id,
+            "name": _COMPOSIO_CALENDAR_NAME,
+        }
+    )
+    if existing is not None:
+        return str(existing.id)
+
+    doc = _CalendarDoc(
+        workspace=ctx.workspace_id,
+        name=_COMPOSIO_CALENDAR_NAME,
+        owner_user_id=ctx.user_id,
+        timezone="UTC",
+        visibility="private",
+    )
+    await doc.insert()
+    logger.info(
+        "calendar.sync: created private composio calendar id=%s for user=%s",
+        doc.id,
+        ctx.user_id,
+    )
+    return str(doc.id)
 
 
 # ---------------------------------------------------------------------------
@@ -119,12 +184,12 @@ async def pull_from_gcalendar(ctx: RequestContext, calendar_id: str) -> int:
             if email
         ]
 
-        # T-13: match the whole google connector family, not just
-        # "gcalendar" — if Composio ingested this event first, update that
-        # row instead of minting a duplicate. The row keeps its original
-        # connector tag (provenance is who ingested first; both routes
-        # keep the row fresh).
-        existing = await _find_google_event(ctx.workspace_id, external_id)
+        # T-13: match the google connector family (native rows for any
+        # user, composio rows for THIS user), not just "gcalendar" — if
+        # Composio ingested this event first, update that row instead of
+        # minting a duplicate. The row keeps its original connector tag
+        # (provenance is who ingested first; both routes keep it fresh).
+        existing = await _find_google_event(ctx.workspace_id, external_id, ctx.user_id)
         if existing:
             existing.title = ext.get("summary") or existing.title
             existing.starts_at = starts_at
@@ -164,7 +229,6 @@ async def pull_from_gcalendar(ctx: RequestContext, calendar_id: str) -> int:
 async def ingest_composio_events(
     ctx: RequestContext,
     items: list[dict[str, Any]],
-    calendar_id: str = "primary",
 ) -> int:
     """Reconcile raw Google-shaped event items (from Composio's
     ``GOOGLECALENDAR_LIST_EVENTS``) into our store.
@@ -176,14 +240,20 @@ async def ingest_composio_events(
     — this function owns only the store reconciliation, so it can be
     tested without a Composio double.
 
-    Reconciles by (workspace, google-family connector, source_external_id)
-    via ``_find_google_event`` — see the cross-connector dedupe note at
-    the top of this module. New rows are stamped
+    New rows land on the syncing user's PRIVATE composio calendar
+    (``_ensure_composio_calendar`` — the Composio connection is per-user,
+    so its events are personal data; the private calendar keeps them out
+    of other members' /calendar and preamble via the existing policy).
+
+    Reconciles via ``_find_google_event`` — native gcalendar rows for any
+    user, composio rows for this user only; see the cross-connector
+    dedupe note at the top of this module. New rows are stamped
     ``source_connector="composio_google"``; rows the native gcalendar
     pull minted first keep their "gcalendar" tag and are updated in place.
 
     Returns the count of events created OR updated.
     """
+    calendar_id: str | None = None  # resolved lazily — only when a new row lands
     touched = 0
     for raw in items:
         external_id = raw.get("id")
@@ -206,8 +276,9 @@ async def ingest_composio_events(
             {"email": email, "response": "needs_action", "is_organizer": False}
             for email in _attendee_emails(raw.get("attendees"))
         ]
+        explicit_tz = _google_timezone(raw)
 
-        existing = await _find_google_event(ctx.workspace_id, external_id)
+        existing = await _find_google_event(ctx.workspace_id, external_id, ctx.user_id)
         if existing:
             existing.title = raw.get("summary") or existing.title
             existing.starts_at = starts_at
@@ -215,10 +286,16 @@ async def ingest_composio_events(
             existing.description = raw.get("description") or ""
             existing.location = raw.get("location") or None
             existing.attendees = attendees
+            if explicit_tz is not None:
+                # Upgrade the row's timezone only when Google named one —
+                # never clobber a real IANA zone with the UTC fallback.
+                existing.timezone = explicit_tz
             existing.updated_at = datetime.now(UTC)
             # no-event: sync ingests are silent on the bus (see module header).
             await existing.save()
         else:
+            if calendar_id is None:
+                calendar_id = await _ensure_composio_calendar(ctx)
             doc = _EventDoc(
                 workspace=ctx.workspace_id,
                 calendar_id=calendar_id,
@@ -226,9 +303,11 @@ async def ingest_composio_events(
                 description=raw.get("description") or "",
                 starts_at=starts_at,
                 ends_at=ends_at,
-                # Google's dateTime carries its own offset; UTC is the
-                # canonical store (same call as the gcalendar pull).
-                timezone="UTC",
+                # UTC datetimes are the canonical store (same call as the
+                # gcalendar pull); the timezone field carries the event's
+                # IANA zone when Google named one, so read paths can
+                # render event-local wall time.
+                timezone=explicit_tz or "UTC",
                 # H-NEW-1 pattern: the user whose Composio connection
                 # fetched the event becomes the local steward.
                 created_by_user_id=ctx.user_id,
@@ -256,6 +335,29 @@ def _parse_google_time(block: Any) -> datetime | None:
     if not isinstance(raw, str):
         return None
     return _parse_iso(raw)
+
+
+def _google_timezone(raw: dict[str, Any]) -> str | None:
+    """Extract a valid IANA timezone from a Google event item, if named.
+
+    Google puts ``timeZone`` on the ``start`` / ``end`` blocks (required
+    for recurring events, common on UI-created ones). Returns ``None``
+    when absent or not a resolvable IANA name — callers fall back to the
+    store's "UTC" canonical stamp rather than persisting garbage.
+    """
+    for key in ("start", "end"):
+        block = raw.get(key)
+        if not isinstance(block, dict):
+            continue
+        tz_name = block.get("timeZone")
+        if isinstance(tz_name, str) and tz_name:
+            try:
+                ZoneInfo(tz_name)
+            except Exception:  # noqa: BLE001 — zoneinfo raises several types
+                logger.warning("Ignoring unknown timezone %r on composio event", tz_name)
+                return None
+            return tz_name
+    return None
 
 
 def _attendee_emails(raw: Any) -> list[str]:

--- a/ee/pocketpaw_ee/cloud/calendar/domain.py
+++ b/ee/pocketpaw_ee/cloud/calendar/domain.py
@@ -1,5 +1,12 @@
 # domain.py — Cloud calendar entity value objects.
 #
+# Updated: 2026-08-06 (feat/coupling-calendar-sot, T-13) — events are now
+# built from the canonical calendar store (``pocketpaw_ee.calendar``)
+# instead of raw Composio payloads. ``id`` is the canonical local event
+# id (the /calendar row id); the upstream Google id lives on the store
+# row as ``source_external_id``. ``source`` gains the "local" slug for
+# rows with no external connector (native /calendar or bridge-minted).
+#
 # Created: 2026-05-24 (feat/calendar-entity-surface, #1214) — frozen
 # dataclass with workspace_id required at construction. Mirrors the
 # ee/cloud rule: domain enforces multi-tenancy at construction time so
@@ -7,11 +14,8 @@
 # workspace_id first after id, so any positional construction lands
 # tenancy in front; missing workspace_id is a TypeError, not silent.
 #
-# ISO-string start/end (not datetime). The data flows in from Composio
-# as JSON strings (Google Calendar returns RFC 3339 timestamps) and
-# flows back out to the surface preamble as strings — there's no
-# date math in the read path, so parsing the strings would be pure
-# overhead. Domain stays as plain pass-through value objects.
+# ISO-string start/end (not datetime) — the preamble renders strings and
+# does no date math, so parsing would be pure overhead.
 
 from __future__ import annotations
 
@@ -27,22 +31,23 @@ class CalendarEvent:
     without one is a TypeError. Same rule as the rest of ``ee/cloud``.
 
     Fields:
-      * ``id`` — the upstream provider's event id (Google Calendar
-        event id when sourced from Composio).
+      * ``id`` — the canonical local event id (the /calendar row id).
+        The upstream Google event id, when there is one, lives on the
+        store row as ``source_external_id``.
       * ``workspace_id`` — owning workspace. Tagged at construction so
         downstream code can fan out events across workspaces without
         accidentally bleeding one tenant into another.
-      * ``title`` — event title (Google Calendar ``summary``). Defaults
-        only to a placeholder when the upstream payload omits it.
-      * ``start`` / ``end`` — ISO 8601 strings. RFC 3339 ``dateTime``
-        when the event has a time component; date-only ``YYYY-MM-DD``
-        when the event is all-day. Empty string when missing upstream.
+      * ``title`` — event title. Defaults only to a placeholder when
+        the upstream payload omitted it at ingest time.
+      * ``start`` / ``end`` — ISO 8601 strings rendered from the store's
+        UTC datetimes. Empty string when missing.
       * ``attendees`` — list of email strings. Optional; defaults to
         an empty list. Each entry is the raw email — no normalization
         is applied at this layer (downstream services may dedupe).
-      * ``source`` — upstream system slug (e.g. ``"google"``, ``"ical"``).
-        Distinct from "the connector" so future providers can ship
-        without renaming the field.
+      * ``source`` — upstream system slug: ``"google"`` for google-family
+        connectors (native gcalendar OAuth or Composio), ``"local"`` for
+        rows with no external connector (native /calendar creates and
+        bridge-minted meetings), other connector slugs pass through.
     """
 
     id: str

--- a/ee/pocketpaw_ee/cloud/calendar/service.py
+++ b/ee/pocketpaw_ee/cloud/calendar/service.py
@@ -31,6 +31,12 @@
 #      dicts. The dataclass stays the preamble's wire shape; only its
 #      construction source changed.
 #
+# Privacy (review round 2): the Composio connection is PER-USER, so the
+# ingest lands one member's personal feed — on a per-user PRIVATE
+# calendar (see calendar.sync._ensure_composio_calendar), which the
+# projection's policy filtering (list_events → can_read_calendar) keeps
+# out of every other member's preamble and /calendar.
+#
 # Field semantics that changed with T-13:
 #   * ``id`` is now the CANONICAL LOCAL event id (the /calendar row id),
 #     not the upstream Google id. The Google id lives on the store row as
@@ -40,6 +46,10 @@
 #   * ``source`` maps from the row's ``source_connector``:
 #     google-family connectors → "google"; other connectors pass through;
 #     no connector (native /calendar or bridge-minted rows) → "local".
+#   * ``start`` / ``end`` render EVENT-LOCAL (store UTC converted through
+#     the row's IANA timezone) so the preamble shows wall-clock time —
+#     matching the old Composio pass-through. All-day events render
+#     date-only, matching Google's ``start.date`` shape.
 #
 # Failure modes — all degrade to serving what the store has (or ``[]``):
 #   * Composio disabled                       → store contents (no refresh)
@@ -53,6 +63,7 @@ import asyncio
 import logging
 import time
 from datetime import UTC, datetime, timedelta
+from datetime import time as dt_time
 from typing import Any
 
 from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
@@ -95,6 +106,9 @@ _UPCOMING_WINDOW_DAYS = 30
 # (workspace_id, user_id) → monotonic timestamp of the last refresh
 # ATTEMPT. In-process only — a restart simply refreshes on first read.
 _last_refresh: dict[tuple[str, str], float] = {}
+
+# Local-midnight sentinel for the all-day rendering heuristic.
+_MIDNIGHT = dt_time(0, 0, 0)
 
 
 def _reset_refresh_cache() -> None:
@@ -191,16 +205,76 @@ async def _upcoming_from_store(workspace_id: str, user_id: str, limit: int) -> l
 def _event_from_response(ev: Any, *, workspace_id: str) -> CalendarEvent:
     """Map one ``calendar.dto.EventResponse`` onto the preamble's wire
     dataclass. Tenancy is re-tagged from the requesting workspace at
-    construction (the domain object refuses to build without it)."""
+    construction (the domain object refuses to build without it).
+
+    ``start`` / ``end`` render EVENT-LOCAL: the store keeps UTC datetimes
+    plus the event's IANA ``timezone``, and the preamble formats
+    time-of-day straight off the string — emitting UTC here would show a
+    10:30 IST meeting as "5:00 AM". This matches the old Composio
+    pass-through behaviour (Google sent local-offset dateTimes).
+    All-day events (midnight-to-midnight, whole-day multiples in the
+    event's zone) render date-only so the handler's date branch fires,
+    matching Google's ``start.date`` wire shape.
+    """
+    tz = _zone_for(getattr(ev, "timezone", None))
+    if _is_all_day(ev.starts_at, ev.ends_at, tz):
+        start = _as_utc(ev.starts_at).astimezone(tz).date().isoformat() if ev.starts_at else ""
+        end = _as_utc(ev.ends_at).astimezone(tz).date().isoformat() if ev.ends_at else ""
+    else:
+        start = _render_local_iso(ev.starts_at, tz)
+        end = _render_local_iso(ev.ends_at, tz)
     return CalendarEvent(
         id=str(ev.id),
         workspace_id=workspace_id,
         title=ev.title,
-        start=ev.starts_at.isoformat() if ev.starts_at else "",
-        end=ev.ends_at.isoformat() if ev.ends_at else "",
+        start=start,
+        end=end,
         source=_source_for_connector(ev.source_connector),
         attendees=[str(a.email) for a in (ev.attendees or [])],
     )
+
+
+def _zone_for(tz_name: Any) -> Any:
+    """Resolve the row's IANA timezone, falling back to UTC on anything
+    unresolvable — a bad zone must degrade the rendering, not the read."""
+    from zoneinfo import ZoneInfo
+
+    if isinstance(tz_name, str) and tz_name:
+        try:
+            return ZoneInfo(tz_name)
+        except Exception:  # noqa: BLE001 — zoneinfo raises several types
+            logger.debug("calendar.list_upcoming: unknown timezone %r", tz_name)
+    return UTC
+
+
+def _as_utc(dt: datetime) -> datetime:
+    """Stamp naive datetimes as UTC (the store's canonical zone)."""
+    return dt.replace(tzinfo=UTC) if dt.tzinfo is None else dt
+
+
+def _render_local_iso(dt: datetime | None, tz: Any) -> str:
+    """ISO string in the event's own timezone (UTC store → local wall time)."""
+    if dt is None:
+        return ""
+    return _as_utc(dt).astimezone(tz).isoformat()
+
+
+def _is_all_day(starts_at: datetime | None, ends_at: datetime | None, tz: Any) -> bool:
+    """Heuristic all-day detection: both bounds at local midnight and the
+    span a whole multiple of 24h. Google all-day events arrive as
+    ``{"date": ...}`` blocks and are stored as midnights, so this
+    round-trips them back to date-only strings. A genuinely timed
+    midnight-to-midnight event renders date-only too — acceptable, it IS
+    a whole-day block."""
+    if starts_at is None or ends_at is None:
+        return False
+    local_start = _as_utc(starts_at).astimezone(tz)
+    local_end = _as_utc(ends_at).astimezone(tz)
+    if local_start.time() != _MIDNIGHT or local_end.time() != _MIDNIGHT:
+        return False
+    span = local_end - local_start
+    day = timedelta(days=1)
+    return span >= day and span % day == timedelta(0)
 
 
 def _source_for_connector(connector: str | None) -> str:

--- a/ee/pocketpaw_ee/cloud/calendar/service.py
+++ b/ee/pocketpaw_ee/cloud/calendar/service.py
@@ -1,42 +1,58 @@
 # service.py — Cloud calendar entity service.
 #
-# Created: 2026-05-24 (feat/calendar-entity-surface, #1214) —
-# ``list_upcoming(workspace_id, user_id, limit=10)`` returns wire dicts
-# for the next N events on the user's connected calendar. Reads only;
-# no Beanie touches; no router.
+# Updated: 2026-08-06 (feat/coupling-calendar-sot, T-13) — ``list_upcoming``
+# is now a PROJECTION over the canonical calendar store
+# (``pocketpaw_ee.calendar``), not a direct Composio read. One source of
+# truth: the agent's "your upcoming events" preamble and the /calendar
+# page read the same ``_EventDoc`` rows, so bridge-minted meetings,
+# natively synced gcalendar events, and Composio-fetched events all show
+# up in both places, deduped by the Google event id.
 #
-# Today's data path:
-#   1. Gate on ``composio_service.is_enabled()``. If Composio isn't
-#      configured, return ``[]`` quietly so the surface handler can
-#      fall back to its hint text.
-#   2. Build the namespaced ``user_id`` via ``composio_user_id`` so
-#      cross-tenant calls collide at the Composio layer (defense in
-#      depth — the ``workspace_id`` filter at our layer is the primary
-#      guard).
-#   3. Call ``GOOGLECALENDAR_LIST_EVENTS`` through ``tools.execute``.
-#      The action wraps Google's standard ``events.list`` endpoint;
-#      we pass ``maxResults`` so the upstream limit matches ours.
-#   4. Parse Google's response shape (``items[]`` with ``start.dateTime``
-#      / ``start.date`` etc.), tag every event with the requesting
-#      ``workspace_id`` at construction time, and emit wire dicts.
+# Data path per call:
+#   1. Validate tenancy + bounds (unchanged — refuse, don't degrade).
+#   2. FRESHNESS — sync-on-read with a TTL. If Composio is enabled and
+#      this (workspace, user) hasn't refreshed within
+#      ``_REFRESH_TTL_SECONDS``, fetch ``GOOGLECALENDAR_LIST_EVENTS``
+#      once and reconcile the rows into the store via
+#      ``calendar.sync.ingest_composio_events`` (source_connector
+#      "composio_google", cross-connector deduped against "gcalendar").
+#      Any failure here is swallowed: the store still serves. Tradeoff
+#      chosen deliberately: ee/calendar/sync provides on-demand pulls and
+#      no scheduler, and the audit forbids new background services, so
+#      sync-on-read is the reuse path. Worst-case staleness = the TTL
+#      (5 min) for upstream edits; local writes (bridge, /calendar UI)
+#      are visible immediately since reads hit the store directly. The
+#      attempt timestamp is recorded on failure too, so a Composio outage
+#      costs at most one failed round-trip per TTL window, not one per
+#      preamble build.
+#   3. PROJECT — query ``calendar.service.list_events`` (workspace-
+#      filtered, per-calendar policy applied) for the window [now,
+#      now + 30d], map to the ``CalendarEvent`` wire dataclass, emit wire
+#      dicts. The dataclass stays the preamble's wire shape; only its
+#      construction source changed.
 #
-# Failure modes — all degrade to ``[]`` (never raise to the handler):
-#   * Composio disabled                                 → ``[]``
-#   * SDK missing                                       → ``[]``
-#   * User hasn't connected a calendar                  → ``[]``
-#   * Upstream timeout / 5xx / parse error              → ``[]``
-#   * Cross-workspace query (workspace_id empty)        → ``ValidationError``
+# Field semantics that changed with T-13:
+#   * ``id`` is now the CANONICAL LOCAL event id (the /calendar row id),
+#     not the upstream Google id. The Google id lives on the store row as
+#     ``source_external_id``. Nothing consumed the old id (the preamble
+#     renders unaddressed lines), and the local id is the one /calendar
+#     and future tools can address.
+#   * ``source`` maps from the row's ``source_connector``:
+#     google-family connectors → "google"; other connectors pass through;
+#     no connector (native /calendar or bridge-minted rows) → "local".
 #
-# The handler always sees a list — it decides whether to render the
-# events block or the Composio hint based on len(events). The only
-# raised error is the tenancy guard (the same pattern other cloud
-# services use to refuse a missing workspace).
+# Failure modes — all degrade to serving what the store has (or ``[]``):
+#   * Composio disabled                       → store contents (no refresh)
+#   * SDK missing / upstream error / timeout  → store contents (stale ok)
+#   * Store unavailable (no Beanie init)      → ``[]``
+#   * Cross-workspace query (workspace empty) → ``ValidationError``
 
 from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import UTC, datetime
+import time
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from pocketpaw_ee.cloud._core.context import RequestContext, ScopeKind
@@ -52,26 +68,54 @@ logger = logging.getLogger(__name__)
 # ever renames, this is the one line to update.
 _GOOGLECALENDAR_LIST_EVENTS = "GOOGLECALENDAR_LIST_EVENTS"
 
-# Source tag stamped onto every event the Composio path produces.
-# Independent of the toolkit slug so future providers (ical, outlook)
-# can be added without renaming the field.
+# Source tag stamped onto events that came from a Google-family
+# connector (native gcalendar OAuth or Composio). Independent of the
+# connector slug so future providers (ical, outlook) can be added
+# without renaming the field.
 _SOURCE_GOOGLE = "google"
+
+# Source tag for events with no external connector: created on /calendar
+# directly, or minted by the meetings bridge.
+_SOURCE_LOCAL = "local"
+
+# Sync-on-read cadence. Within this window repeated preamble builds read
+# the store without touching Composio. See the freshness note in the
+# module header for the tradeoff.
+_REFRESH_TTL_SECONDS = 300.0
+
+# How many rows to ask Composio for per refresh. Decoupled from the
+# caller's ``limit`` (a preamble asking for 10 shouldn't starve the
+# store of the rest of the week).
+_REFRESH_FETCH_LIMIT = 50
+
+# How far ahead the "upcoming" projection looks. Matches the native
+# gcalendar pull's 30-day horizon in ``calendar.sync``.
+_UPCOMING_WINDOW_DAYS = 30
+
+# (workspace_id, user_id) → monotonic timestamp of the last refresh
+# ATTEMPT. In-process only — a restart simply refreshes on first read.
+_last_refresh: dict[tuple[str, str], float] = {}
+
+
+def _reset_refresh_cache() -> None:
+    """Test hook — clear the sync-on-read TTL memory."""
+    _last_refresh.clear()
 
 
 async def list_upcoming(workspace_id: str, user_id: str, limit: int = 10) -> list[dict[str, Any]]:
-    """Return wire dicts of the user's next ``limit`` calendar events.
+    """Return wire dicts of the workspace's next ``limit`` calendar events.
 
-    Read-only — no writes, no events emitted. Workspace-scoped: each
-    event domain object is tagged with ``workspace_id`` at construction
-    so the caller can fan results across workspaces without crossing
-    tenancy. Empty list is the graceful-degradation signal — the caller
-    decides what to render when nothing comes back.
+    Projection over the canonical calendar store — the same rows
+    /calendar lists — refreshed from Composio at most once per TTL
+    window. Workspace-scoped; per-calendar read policy applied by the
+    underlying ``calendar.service.list_events``. Empty list is the
+    graceful-degradation signal — the caller decides what to render
+    when nothing comes back.
 
-    Raises ``ValidationError`` only when ``workspace_id`` is empty or
-    ``limit`` is non-positive. All other failure modes (Composio
-    disabled, SDK missing, upstream error, parse failure) return ``[]``
-    so the surface handler can fall back to its hint text without
-    needing to catch.
+    Raises ``ValidationError`` only when ``workspace_id`` / ``user_id``
+    is empty or ``limit`` is non-positive. All other failure modes
+    (Composio disabled, SDK missing, upstream error, store unavailable)
+    degrade to whatever the store can serve, down to ``[]``.
     """
     # Tenancy + bounds guard — refuse to issue the call when the basic
     # invariants aren't met. Mirrors the pattern other cloud services
@@ -92,66 +136,18 @@ async def list_upcoming(workspace_id: str, user_id: str, limit: int = 10) -> lis
             "limit must be a positive integer",
         )
 
-    # Lazy import composio service — it pulls the upstream SDK behind
-    # ``_get_client`` and we want a fast-path "disabled" return without
-    # paying the import cost on cold paths.
+    # Freshness — sync-on-read, TTL-gated, never raises.
+    await _maybe_refresh_from_composio(workspace_id, user_id)
+
+    # Projection — the store is the source of truth.
     try:
-        from pocketpaw_ee.cloud.composio import service as composio_service
+        events = await _upcoming_from_store(workspace_id, user_id, limit)
     except Exception:
-        logger.debug("calendar.list_upcoming: composio service import failed", exc_info=True)
+        # Store unavailable (Beanie not initialized in this deploy shape,
+        # or an internal query error) — degrade to empty; the handler
+        # renders its hint text.
+        logger.debug("calendar.list_upcoming: store projection failed", exc_info=True)
         return []
-
-    if not composio_service.is_enabled():
-        # Composio not configured at all — the handler will render the
-        # static hint instead. No error: this is the expected state for
-        # any deploy that hasn't wired Composio yet.
-        return []
-
-    # Build a RequestContext so ``composio_user_id`` can namespace the
-    # call the same way every other Composio-using surface does. The
-    # context never leaves this function — it's a transport-layer shim.
-    ctx = RequestContext(
-        user_id=user_id,
-        workspace_id=workspace_id,
-        request_id="calendar-list-upcoming",
-        scope=ScopeKind.WORKSPACE,
-        started_at=datetime.now(UTC),
-    )
-
-    try:
-        namespaced = composio_service.composio_user_id(ctx)
-        client = await composio_service._get_client()
-    except Exception:
-        # Most likely paths: ValidationError (composio.disabled raced
-        # is_enabled), Internal (sdk_missing). Either way: graceful empty.
-        logger.debug("calendar.list_upcoming: composio init failed", exc_info=True)
-        return []
-
-    # Cap the upstream limit at our limit. Composio honors maxResults
-    # as a hint; if the upstream returns more we still trim below.
-    args = {"maxResults": int(limit)}
-
-    try:
-        result = await asyncio.to_thread(
-            _execute_list_events_sync,
-            client,
-            _GOOGLECALENDAR_LIST_EVENTS,
-            str(namespaced),
-            args,
-        )
-    except Exception:
-        # Network errors, "no connected account" errors from Composio,
-        # 5xx from Google — all degrade to empty. The handler renders
-        # its fallback hint and the chat continues.
-        logger.debug("calendar.list_upcoming: GOOGLECALENDAR_LIST_EVENTS failed", exc_info=True)
-        return []
-
-    items = _extract_items(result)
-    events: list[CalendarEvent] = []
-    for raw in items[:limit]:
-        event = _event_from_google_item(raw, workspace_id=workspace_id)
-        if event is not None:
-            events.append(event)
 
     # Pydantic round-trip: domain → response → dict. Same shape as the
     # canonical pockets/cycles wire path (Rule 8: mapping via Pydantic,
@@ -162,8 +158,151 @@ async def list_upcoming(workspace_id: str, user_id: str, limit: int = 10) -> lis
 
 
 # ---------------------------------------------------------------------------
-# Composio helpers — private to this module.
+# Store projection — private to this module.
 # ---------------------------------------------------------------------------
+
+
+async def _upcoming_from_store(workspace_id: str, user_id: str, limit: int) -> list[CalendarEvent]:
+    """Query the canonical calendar store for the upcoming window and map
+    rows to the wire dataclass.
+
+    Lazy import — ``pocketpaw_ee.calendar`` pulls its router/service
+    graph; keep that off this module's import path the same way the
+    Composio import is deferred.
+    """
+    from pocketpaw_ee.calendar._context import RequestContext as CalendarContext
+    from pocketpaw_ee.calendar.dto import ListEventsRequest
+    from pocketpaw_ee.calendar.service import list_events
+
+    ctx = CalendarContext(workspace_id=workspace_id, user_id=user_id)
+    # Naive UTC boundaries — matches the router's FastAPI default;
+    # list_events stamps tzinfo=UTC before comparing with the
+    # timezone-aware datetimes its mapper produces.
+    now = datetime.now(UTC).replace(tzinfo=None)
+    body = ListEventsRequest(
+        starts_after=now,
+        starts_before=now + timedelta(days=_UPCOMING_WINDOW_DAYS),
+        limit=min(max(limit, 1), 500),
+    )
+    listed = await list_events(ctx, body)
+    return [_event_from_response(ev, workspace_id=workspace_id) for ev in listed.events]
+
+
+def _event_from_response(ev: Any, *, workspace_id: str) -> CalendarEvent:
+    """Map one ``calendar.dto.EventResponse`` onto the preamble's wire
+    dataclass. Tenancy is re-tagged from the requesting workspace at
+    construction (the domain object refuses to build without it)."""
+    return CalendarEvent(
+        id=str(ev.id),
+        workspace_id=workspace_id,
+        title=ev.title,
+        start=ev.starts_at.isoformat() if ev.starts_at else "",
+        end=ev.ends_at.isoformat() if ev.ends_at else "",
+        source=_source_for_connector(ev.source_connector),
+        attendees=[str(a.email) for a in (ev.attendees or [])],
+    )
+
+
+def _source_for_connector(connector: str | None) -> str:
+    """Collapse a store row's ``source_connector`` to the wire ``source``
+    slug: google-family connectors → "google"; other connectors pass
+    through as-is; no connector → "local" (native + bridge-minted)."""
+    if connector is None or connector == "":
+        return _SOURCE_LOCAL
+    from pocketpaw_ee.calendar.sync import _GOOGLE_CONNECTOR_FAMILY
+
+    if connector in _GOOGLE_CONNECTOR_FAMILY:
+        return _SOURCE_GOOGLE
+    return connector
+
+
+# ---------------------------------------------------------------------------
+# Composio refresh — private to this module.
+# ---------------------------------------------------------------------------
+
+
+async def _maybe_refresh_from_composio(workspace_id: str, user_id: str) -> None:
+    """Sync-on-read: pull the user's Google calendar through Composio and
+    reconcile into the store, at most once per TTL window. Never raises.
+
+    The attempt timestamp is stamped up front so a hard upstream outage
+    costs one failed round-trip per window, not one per preamble build.
+    Composio-disabled deploys skip without stamping (the check is cheap
+    and a mid-session enable should take effect immediately).
+    """
+    key = (workspace_id, user_id)
+    last = _last_refresh.get(key)
+    if last is not None and (time.monotonic() - last) < _REFRESH_TTL_SECONDS:
+        return
+
+    # Lazy import composio service — it pulls the upstream SDK behind
+    # ``_get_client`` and we want a fast-path "disabled" return without
+    # paying the import cost on cold paths.
+    try:
+        from pocketpaw_ee.cloud.composio import service as composio_service
+    except Exception:
+        logger.debug("calendar.refresh: composio service import failed", exc_info=True)
+        return
+
+    if not composio_service.is_enabled():
+        # Composio not configured — nothing to refresh from. The store
+        # still serves native + bridge-minted events.
+        return
+
+    _last_refresh[key] = time.monotonic()
+
+    # Build a RequestContext so ``composio_user_id`` can namespace the
+    # call the same way every other Composio-using surface does. The
+    # context never leaves this function — it's a transport-layer shim.
+    ctx = RequestContext(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        request_id="calendar-refresh",
+        scope=ScopeKind.WORKSPACE,
+        started_at=datetime.now(UTC),
+    )
+
+    try:
+        namespaced = composio_service.composio_user_id(ctx)
+        client = await composio_service._get_client()
+    except Exception:
+        # Most likely paths: ValidationError (composio.disabled raced
+        # is_enabled), Internal (sdk_missing). Either way: stale-ok.
+        logger.debug("calendar.refresh: composio init failed", exc_info=True)
+        return
+
+    args = {"maxResults": _REFRESH_FETCH_LIMIT}
+    try:
+        result = await asyncio.to_thread(
+            _execute_list_events_sync,
+            client,
+            _GOOGLECALENDAR_LIST_EVENTS,
+            str(namespaced),
+            args,
+        )
+    except Exception:
+        # Network errors, "no connected account" errors from Composio,
+        # 5xx from Google — all stale-ok. The store serves what it has.
+        logger.debug("calendar.refresh: GOOGLECALENDAR_LIST_EVENTS failed", exc_info=True)
+        return
+
+    items = _extract_items(result)
+    if not items:
+        return
+
+    try:
+        from pocketpaw_ee.calendar._context import RequestContext as CalendarContext
+        from pocketpaw_ee.calendar.sync import ingest_composio_events
+
+        touched = await ingest_composio_events(
+            CalendarContext(workspace_id=workspace_id, user_id=user_id),
+            items,
+        )
+        logger.debug("calendar.refresh: reconciled %d composio events", touched)
+    except Exception:
+        # Store write failure — the read path below still serves
+        # whatever the store already had.
+        logger.debug("calendar.refresh: ingest failed", exc_info=True)
 
 
 def _execute_list_events_sync(
@@ -207,48 +346,6 @@ def _extract_items(result: Any) -> list[dict[str, Any]]:
         if isinstance(items, list):
             return [item for item in items if isinstance(item, dict)]
     return []
-
-
-def _event_from_google_item(raw: dict[str, Any], *, workspace_id: str) -> CalendarEvent | None:
-    """Build a tenant-tagged ``CalendarEvent`` from one Google API item.
-
-    Returns ``None`` when the upstream payload is missing the bare
-    minimum we need (``id``) — better to skip a single bad row than
-    surface a partial event with confusing fields. ``start`` /
-    ``end`` collapse Google's date vs dateTime variants into a single
-    string field (the date or the dateTime, whichever is present).
-    """
-    event_id = raw.get("id")
-    if not isinstance(event_id, str) or not event_id:
-        return None
-
-    start_raw = raw.get("start") or {}
-    end_raw = raw.get("end") or {}
-    start = ""
-    end = ""
-    if isinstance(start_raw, dict):
-        start = str(start_raw.get("dateTime") or start_raw.get("date") or "")
-    if isinstance(end_raw, dict):
-        end = str(end_raw.get("dateTime") or end_raw.get("date") or "")
-
-    attendees_raw = raw.get("attendees") or []
-    attendees: list[str] = []
-    if isinstance(attendees_raw, list):
-        for a in attendees_raw:
-            if isinstance(a, dict):
-                email = a.get("email")
-                if isinstance(email, str) and email:
-                    attendees.append(email)
-
-    return CalendarEvent(
-        id=event_id,
-        workspace_id=workspace_id,
-        title=str(raw.get("summary") or "(no title)"),
-        start=start,
-        end=end,
-        source=_SOURCE_GOOGLE,
-        attendees=attendees,
-    )
 
 
 __all__ = ["list_upcoming"]

--- a/ee/pocketpaw_ee/cloud/surface/handlers/calendar.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/calendar.py
@@ -1,24 +1,28 @@
 # calendar.py — /calendar surface preamble.
 #
-# Updated: 2026-05-24 (feat/calendar-entity-surface, #1218) — restored
-# the third rendering state so "Composio off" and "Composio on but no
-# events" no longer collapse to the same hint. Three distinct branches
-# now drive the snapshot block:
+# Updated: 2026-08-06 (feat/coupling-calendar-sot, T-13) — no code change,
+# but the data source behind ``list_upcoming`` moved: it is now a
+# projection over the canonical calendar store (``pocketpaw_ee.calendar``,
+# refreshed from Composio on a TTL), so the events listed here are the
+# SAME rows /calendar renders — native creates, bridge-minted meetings,
+# and Composio-synced events alike. Branch semantics shift accordingly:
 #
 #   1. Events present — render one line per event ("- 10:30 AM ·
 #      Sync with Sarah") inside the snapshot block.
-#   2. Composio enabled but no upcoming events — render
-#      ``<calendar-snapshot>(no upcoming events)</calendar-snapshot>``
-#      so the agent knows the integration works and the calendar is
-#      genuinely empty.
-#   3. Composio disabled OR the service raised — render the static
+#   2. Composio enabled but no events — the store is genuinely empty
+#      for the upcoming window; render
+#      ``<calendar-snapshot>(no upcoming events)</calendar-snapshot>``.
+#   3. Composio disabled AND the store has nothing — render the static
 #      hint pointing at GOOGLECALENDAR_LIST_EVENTS so the agent still
 #      discovers the action and the user can be guided to connect.
+#      (A workspace with native/bridge events renders branch 1 even
+#      with Composio off — the store serves regardless.)
 #
-# We probe ``composio_service.is_enabled()`` from the handler (lazy
-# import, same as ``list_upcoming``) to split branches 2 and 3 without
-# changing the service signature — the brief calls this out as the
-# minimum-blast-radius split.
+# History: 2026-05-24 (feat/calendar-entity-surface, #1218) restored the
+# third rendering state via the ``composio_service.is_enabled()`` probe
+# (lazy import, same as ``list_upcoming``) so "no integration" and
+# "genuinely empty" stay distinguishable without changing the service
+# signature.
 #
 # Surface tag is always emitted so the agent always knows which route
 # the user is on, regardless of which branch above ran.

--- a/ee/pocketpaw_ee/cloud/surface/handlers/calendar.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/calendar.py
@@ -95,9 +95,11 @@ async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> 
         )
 
     if not events:
-        # No events AND no error. Two sub-states the agent needs to tell
-        # apart: Composio is on (calendar genuinely empty) vs Composio
-        # is off (no integration at all). Probe is_enabled() to pick.
+        # No events AND no raise. Two sub-states the agent needs to tell
+        # apart: Composio on — the store's upcoming window is empty (or,
+        # rarely, the store read failed and the service degraded to []) —
+        # vs Composio off AND nothing in the store (no integration at
+        # all). Probe is_enabled() to pick.
         # Lazy import mirrors the list_upcoming pattern above — keeps
         # the cold-path cheap and the test monkeypatch surface clean.
         try:

--- a/tests/cloud/calendar/test_service.py
+++ b/tests/cloud/calendar/test_service.py
@@ -433,3 +433,164 @@ async def test_limit_caps_results_sorted_by_start(
     assert [ev["id"] for ev in out] == ids[:3]
     starts = [ev["start"] for ev in out]
     assert starts == sorted(starts)
+
+
+# ---------------------------------------------------------------------------
+# Per-user privacy — composio feeds are personal data
+# ---------------------------------------------------------------------------
+
+
+async def test_member_b_never_sees_member_a_composio_events(
+    monkeypatch: pytest.MonkeyPatch, mongo_db: Any
+) -> None:
+    """CRITICAL (review round 2): the Composio connection is per-user, so
+    member A's refresh ingests A's PERSONAL Google feed. It must land on
+    A's private calendar — member B's preamble AND B's /calendar view
+    stay empty, while A keeps seeing their own events."""
+    # Member A's refresh ingests their personal feed.
+    _patch_composio(
+        monkeypatch,
+        enabled=True,
+        execute_return={
+            "data": {"items": [_google_event(id="gid-a", summary="A's 1:1 with therapist")]},
+            "successful": True,
+        },
+    )
+    out_a = await calendar_service.list_upcoming("ws_acme", "user_a", limit=10)
+    assert [ev["title"] for ev in out_a] == ["A's 1:1 with therapist"]
+
+    # Member B has no Composio connection — upstream refuses B's refresh.
+    _patch_composio(
+        monkeypatch,
+        enabled=True,
+        execute_side_effect=RuntimeError("composio: no connected account"),
+    )
+    out_b = await calendar_service.list_upcoming("ws_acme", "user_b", limit=10)
+    assert out_b == []
+    assert await _calendar_page_ids("ws_acme", "user_b") == set()
+
+    # Member A still sees their own event (store read, TTL suppresses
+    # the second upstream call).
+    out_a2 = await calendar_service.list_upcoming("ws_acme", "user_a", limit=10)
+    assert [ev["title"] for ev in out_a2] == ["A's 1:1 with therapist"]
+    assert await _calendar_page_ids("ws_acme", "user_a") == {out_a[0]["id"]}
+
+
+async def test_declared_private_calendar_respected_by_projection(
+    monkeypatch: pytest.MonkeyPatch, mongo_db: Any
+) -> None:
+    """A calendar explicitly declared private (real _CalendarDoc row, not
+    the synthetic default) must filter through ``list_upcoming``
+    specifically — the projection path, not just the /calendar router."""
+    from pocketpaw_ee.calendar.models import _CalendarDoc
+
+    _patch_composio(monkeypatch, enabled=False)
+
+    cal = _CalendarDoc(
+        workspace="ws_acme",
+        name="X's private calendar",
+        owner_user_id="user_x",
+        timezone="UTC",
+        visibility="private",
+    )
+    await cal.insert()
+    event_id = await _seed_event(
+        "ws_acme", "X's private event", user_id="user_x", calendar_id=str(cal.id)
+    )
+
+    out_x = await calendar_service.list_upcoming("ws_acme", "user_x", limit=10)
+    assert [ev["id"] for ev in out_x] == [event_id]
+
+    out_y = await calendar_service.list_upcoming("ws_acme", "user_y", limit=10)
+    assert out_y == []
+
+
+# ---------------------------------------------------------------------------
+# Rendering — event-local wall time + all-day dates
+# ---------------------------------------------------------------------------
+
+
+async def test_start_renders_event_local_wall_time(
+    monkeypatch: pytest.MonkeyPatch, mongo_db: Any
+) -> None:
+    """The store keeps UTC; the wire must render the event's OWN zone.
+    A 10:30 IST meeting rendered from raw UTC would show "5:00 AM" in
+    the preamble — the exact regression the old Composio pass-through
+    never had."""
+    from zoneinfo import ZoneInfo
+
+    ist = ZoneInfo("Asia/Kolkata")
+    start_local = (datetime.now(ist) + timedelta(days=1)).replace(
+        hour=10, minute=30, second=0, microsecond=0
+    )
+    _patch_composio(
+        monkeypatch,
+        enabled=True,
+        execute_return={
+            "data": {
+                "items": [
+                    {
+                        "id": "gid-ist",
+                        "summary": "IST meeting",
+                        "start": {
+                            "dateTime": start_local.isoformat(),
+                            "timeZone": "Asia/Kolkata",
+                        },
+                        "end": {
+                            "dateTime": (start_local + timedelta(hours=1)).isoformat(),
+                            "timeZone": "Asia/Kolkata",
+                        },
+                    }
+                ]
+            },
+            "successful": True,
+        },
+    )
+
+    out = await calendar_service.list_upcoming("ws_acme", "user_test", limit=5)
+    assert len(out) == 1
+    assert "T10:30:00" in out[0]["start"]
+    assert out[0]["start"].endswith("+05:30")
+
+    # And the preamble's own formatter renders the wall time the user
+    # would see on their Google Calendar.
+    from pocketpaw_ee.cloud.surface.handlers.calendar import _format_start_time
+
+    assert _format_start_time(out[0]["start"]) == "10:30 AM"
+
+
+async def test_all_day_events_render_date_only(
+    monkeypatch: pytest.MonkeyPatch, mongo_db: Any
+) -> None:
+    """Google all-day events arrive as ``{"date": ...}``; the wire must
+    round-trip them as date-only strings so the handler's date branch
+    fires instead of rendering "12:00 AM · Title"."""
+    tomorrow = (datetime.now(UTC) + timedelta(days=1)).date().isoformat()
+    day_after = (datetime.now(UTC) + timedelta(days=2)).date().isoformat()
+    _patch_composio(
+        monkeypatch,
+        enabled=True,
+        execute_return={
+            "data": {
+                "items": [
+                    {
+                        "id": "gid-allday",
+                        "summary": "Offsite",
+                        "start": {"date": tomorrow},
+                        "end": {"date": day_after},
+                    }
+                ]
+            },
+            "successful": True,
+        },
+    )
+
+    out = await calendar_service.list_upcoming("ws_acme", "user_test", limit=5)
+    assert len(out) == 1
+    assert out[0]["start"] == tomorrow
+    assert "T" not in out[0]["start"]
+
+    from pocketpaw_ee.cloud.surface.handlers.calendar import _format_start_time
+
+    # The handler's date-only branch surfaces the date itself.
+    assert _format_start_time(out[0]["start"]) == tomorrow

--- a/tests/cloud/calendar/test_service.py
+++ b/tests/cloud/calendar/test_service.py
@@ -1,43 +1,74 @@
 # tests/cloud/calendar/test_service.py — Cloud calendar service.
 #
-# Updated: 2026-05-24 (feat/calendar-entity-surface, #1218) — added a
-# fifth guarantee: cross-workspace calls against the same mock
-# upstream payload tag each returned event with the requesting
-# workspace_id. Protects the tenancy invariant when the same Composio
-# response (in this contrived test) is read by two workspaces in
-# sequence — the wire dicts must carry their own workspace_id, not
-# leak whichever workspace happened to run first.
+# Updated: 2026-08-06 (feat/coupling-calendar-sot, T-13) — rewritten for
+# the projection architecture: ``list_upcoming`` now reads the canonical
+# calendar store (``pocketpaw_ee.calendar``) and refreshes it from
+# Composio at most once per TTL window, instead of returning raw
+# Composio payloads. Tests run against a real (mongomock) Beanie store
+# via the ``mongo_db`` fixture because the guarantee under test is
+# store/preamble parity — faking the store would mock the seam.
 #
-# Five guarantees:
-#   1. Composio disabled  → ``[]`` (no SDK touch, no error).
-#   2. Happy path         → events flow through with workspace tagging.
-#   3. Workspace required → empty workspace_id raises ``ValidationError``.
-#   4. Limit parameter    → caps the returned slice even when upstream
-#                            returns more rows than asked for.
-#   5. Cross-workspace    → two calls with different workspace_ids
-#                            against one upstream payload return wire
-#                            dicts each tagged with their own workspace.
+# Guarantees:
+#   1. Tenancy + bounds guards refuse bad input (unchanged from #1214).
+#   2. PARITY — the agent preamble's event set equals what /calendar's
+#      ``list_events`` returns: native, bridge-minted, and
+#      Composio-synced events all appear in both.
+#   3. A Composio-only event becomes visible on /calendar after the
+#      sync-on-read ingest.
+#   4. The same Google event arriving via BOTH connectors renders once.
+#   5. Composio outage → the preamble still serves from the store
+#      (degraded freshness, not a broken surface).
+#   6. TTL — repeated preamble builds within the window hit Composio at
+#      most once.
+#   7. Cross-workspace isolation on the store read path.
 #
-# Tests monkeypatch the composio service boundary
-# (``is_enabled`` / ``_get_client`` / ``composio_user_id``) rather than
-# the upstream SDK — we're testing the calendar adapter's contract,
-# not Composio's wire format. The one place we DO exercise Composio's
-# wire shape is the happy-path test, which feeds a Google-shaped
-# payload through the real parsing helpers.
+# Composio is doubled at the service boundary (``is_enabled`` /
+# ``_get_client`` / ``composio_user_id``) exactly as before — we test
+# the calendar service's contract, not Composio's wire format.
+#
+# Mutation gates (tests/mutations/calendar_sot.json): skipping the store
+# projection, dropping the workspace filter, breaking the source
+# mapping, and removing the TTL check are each caught here.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+from pocketpaw_ee.calendar._context import RequestContext as CalendarContext
+from pocketpaw_ee.calendar.dto import CreateEventRequest, ListEventsRequest
 from pocketpaw_ee.cloud._core.errors import ValidationError
 from pocketpaw_ee.cloud.calendar import service as calendar_service
 from pocketpaw_ee.cloud.composio.domain import ComposioUserId
 
 # ---------------------------------------------------------------------------
-# Helpers
+# Fixtures + helpers
 # ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _fresh_refresh_cache():
+    """The sync-on-read TTL memory is module-level state — reset it per
+    test so one test's refresh doesn't suppress another's."""
+    calendar_service._reset_refresh_cache()
+    yield
+    calendar_service._reset_refresh_cache()
+
+
+@pytest.fixture(autouse=True)
+def _silence_calendar_bus(monkeypatch: pytest.MonkeyPatch):
+    """Seeding events via ``calendar.service.create_event`` emits on the
+    shared event bus; if another test module registered the meetings
+    bridge in this process, the fan-out would mint Meeting rows mid-test.
+    Silence emission — bridge behaviour is tested in its own suite."""
+    from pocketpaw_ee.cloud.shared.events import event_bus
+
+    async def _no_emit(_topic: str, _data: dict) -> None:
+        return None
+
+    monkeypatch.setattr(event_bus, "emit", _no_emit)
 
 
 def _patch_composio(
@@ -83,35 +114,66 @@ def _google_event(
     *,
     id: str,
     summary: str,
-    start: str,
-    end: str | None = None,
+    start: datetime | None = None,
+    end: datetime | None = None,
     attendees: list[str] | None = None,
-    all_day: bool = False,
 ) -> dict[str, Any]:
-    """Build a Google-Calendar-shaped event dict (the ``items[]`` row).
-
-    Mirrors Google's wire format closely enough that the adapter's
-    parser is exercised the same way it would be in production: nested
-    ``start.dateTime`` (or ``start.date`` for all-day), ``attendees``
-    list of ``{"email": ...}`` dicts, ``summary`` for the title.
-    """
-    start_block = {"date": start} if all_day else {"dateTime": start}
-    end_block: dict[str, Any]
-    if end is None:
-        end_block = start_block
-    elif all_day:
-        end_block = {"date": end}
-    else:
-        end_block = {"dateTime": end}
+    """Build a Google-Calendar-shaped ``items[]`` row for the mocked
+    Composio response. Times default to tomorrow so the event lands in
+    the projection's upcoming window."""
+    start = start or (datetime.now(UTC) + timedelta(days=1))
+    end = end or (start + timedelta(hours=1))
     item: dict[str, Any] = {
         "id": id,
         "summary": summary,
-        "start": start_block,
-        "end": end_block,
+        "start": {"dateTime": start.isoformat()},
+        "end": {"dateTime": end.isoformat()},
     }
     if attendees:
         item["attendees"] = [{"email": e} for e in attendees]
     return item
+
+
+async def _seed_event(
+    workspace_id: str,
+    title: str,
+    *,
+    user_id: str = "user_test",
+    calendar_id: str = "primary",
+    days_ahead: float = 1.0,
+    fabric_object_id: str | None = None,
+) -> str:
+    """Create a store event the way real writers do (the /calendar API
+    and the meetings reverse-bridge both go through ``create_event``).
+    Returns the canonical event id."""
+    from pocketpaw_ee.calendar.service import create_event
+
+    starts = datetime.now(UTC) + timedelta(days=days_ahead)
+    resp = await create_event(
+        CalendarContext(workspace_id=workspace_id, user_id=user_id),
+        CreateEventRequest(
+            calendar_id=calendar_id,
+            title=title,
+            starts_at=starts,
+            ends_at=starts + timedelta(hours=1),
+            timezone="UTC",
+            fabric_object_id=fabric_object_id,
+        ),
+    )
+    return resp.id
+
+
+async def _calendar_page_ids(workspace_id: str, user_id: str = "user_test") -> set[str]:
+    """The /calendar page's view of the upcoming window — the parity
+    oracle. Same store API the calendar router serves."""
+    from pocketpaw_ee.calendar.service import list_events
+
+    now = datetime.now(UTC).replace(tzinfo=None)
+    listed = await list_events(
+        CalendarContext(workspace_id=workspace_id, user_id=user_id),
+        ListEventsRequest(starts_after=now, starts_before=now + timedelta(days=30)),
+    )
+    return {ev.id for ev in listed.events}
 
 
 # ---------------------------------------------------------------------------
@@ -122,8 +184,7 @@ def _google_event(
 async def test_empty_workspace_id_raises_validation_error() -> None:
     """The first cloud entity rule is "domain enforces tenancy at
     construction". The service mirrors it: empty workspace_id is a
-    refusal, not a quiet degrade — same pattern other cloud services
-    use to refuse a missing workspace."""
+    refusal, not a quiet degrade."""
     with pytest.raises(ValidationError, match="workspace_required"):
         await calendar_service.list_upcoming("", "user_test", limit=5)
 
@@ -139,217 +200,236 @@ async def test_non_positive_limit_raises_validation_error() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Composio gating
+# Projection — the store is the source of truth
 # ---------------------------------------------------------------------------
 
 
-async def test_returns_empty_when_composio_disabled(
-    monkeypatch: pytest.MonkeyPatch,
+async def test_serves_store_events_when_composio_disabled(
+    monkeypatch: pytest.MonkeyPatch, mongo_db: Any
 ) -> None:
-    """The most common "no data" state: Composio not configured at all.
-    The handler will fall back to its hint; the service stays silent."""
+    """The old path returned ``[]`` whenever Composio was off — hiding
+    every native and bridge-minted event from the agent. The projection
+    serves the store regardless of Composio."""
     execute = _patch_composio(monkeypatch, enabled=False)
+    event_id = await _seed_event("ws_acme", "Native standup")
+
     out = await calendar_service.list_upcoming("ws_acme", "user_test", limit=5)
-    assert out == []
+
+    assert [ev["id"] for ev in out] == [event_id]
+    assert out[0]["title"] == "Native standup"
+    assert out[0]["workspace_id"] == "ws_acme"
+    assert out[0]["source"] == "local"
     execute.assert_not_called()
 
 
-async def test_returns_empty_when_upstream_errors(
-    monkeypatch: pytest.MonkeyPatch,
+async def test_preamble_parity_with_calendar_page(
+    monkeypatch: pytest.MonkeyPatch, mongo_db: Any
 ) -> None:
-    """Network or auth errors from Composio must degrade gracefully —
-    the handler always sees a list, never a raised exception."""
+    """THE T-13 invariant: the agent's "your upcoming events" and the
+    /calendar page list the same set — native, bridge-minted, and
+    Composio-synced events all present in both."""
+    native_id = await _seed_event("ws_acme", "Native standup")
+    bridge_id = await _seed_event(
+        "ws_acme",
+        "Client call",
+        calendar_id="meetings",
+        fabric_object_id="meeting:m1",
+        days_ahead=2.0,
+    )
     _patch_composio(
         monkeypatch,
         enabled=True,
-        execute_side_effect=RuntimeError("composio: no connected account"),
+        execute_return={
+            "data": {"items": [_google_event(id="gid-1", summary="Composio sync")]},
+            "successful": True,
+        },
     )
+
+    out = await calendar_service.list_upcoming("ws_acme", "user_test", limit=10)
+    preamble_ids = {ev["id"] for ev in out}
+
+    page_ids = await _calendar_page_ids("ws_acme")
+    assert preamble_ids == page_ids
+    assert {native_id, bridge_id} <= preamble_ids
+    assert len(preamble_ids) == 3
+    # Bridge-minted and native events carry the "local" source; the
+    # Composio-synced one maps to "google".
+    by_id = {ev["id"]: ev for ev in out}
+    assert by_id[native_id]["source"] == "local"
+    assert by_id[bridge_id]["source"] == "local"
+    composio_ev = next(ev for ev in out if ev["title"] == "Composio sync")
+    assert composio_ev["source"] == "google"
+
+
+async def test_composio_only_event_appears_on_calendar_after_ingest(
+    monkeypatch: pytest.MonkeyPatch, mongo_db: Any
+) -> None:
+    """The reverse half of the old split-brain: a Composio-only event
+    used to be invisible on /calendar. The sync-on-read ingest lands it
+    in the store, where the page's ``list_events`` sees it."""
+    _patch_composio(
+        monkeypatch,
+        enabled=True,
+        execute_return={
+            "data": {"items": [_google_event(id="gid-only", summary="Composio-only")]},
+            "successful": True,
+        },
+    )
+
+    assert await _calendar_page_ids("ws_acme") == set()
+
+    out = await calendar_service.list_upcoming("ws_acme", "user_test", limit=5)
+    assert [ev["title"] for ev in out] == ["Composio-only"]
+
+    from pocketpaw_ee.calendar.service import list_events
+
+    now = datetime.now(UTC).replace(tzinfo=None)
+    listed = await list_events(
+        CalendarContext(workspace_id="ws_acme", user_id="user_test"),
+        ListEventsRequest(starts_after=now, starts_before=now + timedelta(days=30)),
+    )
+    assert [ev.title for ev in listed.events] == ["Composio-only"]
+    assert listed.events[0].source_connector == "composio_google"
+    assert listed.events[0].source_external_id == "gid-only"
+
+
+async def test_same_google_event_via_both_connectors_renders_once(
+    monkeypatch: pytest.MonkeyPatch, mongo_db: Any
+) -> None:
+    """A user with the native gcalendar connector AND Composio wired to
+    one Google account: the shared upstream event must not double."""
+    from pocketpaw_ee.calendar import sync
+
+    # Native pull ingests the upstream event first.
+    class _FakeGCalClient:
+        async def list_events(self, **_kw: Any) -> list[dict[str, Any]]:
+            starts = datetime.now(UTC) + timedelta(days=1)
+            return [
+                {
+                    "id": "gid-shared",
+                    "summary": "Shared upstream event",
+                    "start": starts.isoformat(),
+                    "end": (starts + timedelta(hours=1)).isoformat(),
+                    "attendees": [],
+                }
+            ]
+
+    import pocketpaw.clients.gcalendar as gcal_module
+
+    monkeypatch.setattr(gcal_module, "CalendarClient", lambda: _FakeGCalClient())
+    await sync.pull_from_gcalendar(
+        CalendarContext(workspace_id="ws_acme", user_id="user_test"), "primary"
+    )
+
+    # Composio then returns the SAME Google event id.
+    _patch_composio(
+        monkeypatch,
+        enabled=True,
+        execute_return={
+            "data": {"items": [_google_event(id="gid-shared", summary="Shared upstream event")]},
+            "successful": True,
+        },
+    )
+
+    out = await calendar_service.list_upcoming("ws_acme", "user_test", limit=10)
+    assert len(out) == 1
+    assert out[0]["source"] == "google"
+    assert await _calendar_page_ids("ws_acme") == {out[0]["id"]}
+
+
+# ---------------------------------------------------------------------------
+# Degradation + freshness
+# ---------------------------------------------------------------------------
+
+
+async def test_composio_outage_still_serves_store(
+    monkeypatch: pytest.MonkeyPatch, mongo_db: Any
+) -> None:
+    """Upstream 5xx / network error / "no connected account": the old
+    path returned ``[]``; the projection serves what the store has —
+    degraded freshness, not a broken preamble."""
+    event_id = await _seed_event("ws_acme", "Survives the outage")
+    _patch_composio(
+        monkeypatch,
+        enabled=True,
+        execute_side_effect=RuntimeError("composio: upstream 502"),
+    )
+
+    out = await calendar_service.list_upcoming("ws_acme", "user_test", limit=5)
+    assert [ev["id"] for ev in out] == [event_id]
+
+
+async def test_refresh_is_ttl_gated(monkeypatch: pytest.MonkeyPatch, mongo_db: Any) -> None:
+    """Sync-on-read hits Composio at most once per TTL window — repeat
+    preamble builds within the window read the store only."""
+    execute = _patch_composio(
+        monkeypatch,
+        enabled=True,
+        execute_return={
+            "data": {"items": [_google_event(id="gid-1", summary="Synced")]},
+            "successful": True,
+        },
+    )
+
+    await calendar_service.list_upcoming("ws_acme", "user_test", limit=5)
+    await calendar_service.list_upcoming("ws_acme", "user_test", limit=5)
+    assert execute.call_count == 1
+
+    # A new TTL window (simulated via the test hook) refreshes again.
+    calendar_service._reset_refresh_cache()
+    await calendar_service.list_upcoming("ws_acme", "user_test", limit=5)
+    assert execute.call_count == 2
+
+
+async def test_store_projection_failure_degrades_to_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the store itself is unavailable (no Beanie init in this deploy
+    shape), the service keeps its never-raise contract."""
+    _patch_composio(monkeypatch, enabled=False)
+
+    async def _boom(*_a: Any, **_kw: Any) -> Any:
+        raise RuntimeError("store not initialized")
+
+    monkeypatch.setattr(calendar_service, "_upcoming_from_store", _boom)
     out = await calendar_service.list_upcoming("ws_acme", "user_test", limit=5)
     assert out == []
 
 
-async def test_returns_empty_when_upstream_returns_no_items(
-    monkeypatch: pytest.MonkeyPatch,
+# ---------------------------------------------------------------------------
+# Tenancy + limit on the read path
+# ---------------------------------------------------------------------------
+
+
+async def test_workspaces_see_only_their_own_events(
+    monkeypatch: pytest.MonkeyPatch, mongo_db: Any
 ) -> None:
-    """Composio call succeeded but the user's calendar is empty — same
-    end state as disabled. The handler folds these into one fallback."""
-    _patch_composio(
-        monkeypatch,
-        enabled=True,
-        execute_return={"data": {"items": []}, "successful": True},
-    )
-    out = await calendar_service.list_upcoming("ws_acme", "user_test", limit=5)
-    assert out == []
+    """Store rows are tenant-filtered and every wire dict carries the
+    requesting workspace's tag."""
+    _patch_composio(monkeypatch, enabled=False)
+    id_a = await _seed_event("ws_a", "A's event", user_id="user_a")
+    id_b = await _seed_event("ws_b", "B's event", user_id="user_b")
 
+    out_a = await calendar_service.list_upcoming("ws_a", "user_a", limit=10)
+    out_b = await calendar_service.list_upcoming("ws_b", "user_b", limit=10)
 
-# ---------------------------------------------------------------------------
-# Happy path + tenancy tagging
-# ---------------------------------------------------------------------------
-
-
-async def test_happy_path_renders_events_with_workspace_tag(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Five Google-shaped events flow through: titles, ISO timestamps,
-    attendees, and the workspace tag all land on each wire dict.
-    Implicitly verifies the domain object refuses to be built without
-    workspace_id (it would raise at construction otherwise)."""
-    items = [
-        _google_event(
-            id="ev1",
-            summary="Sync with Sarah",
-            start="2026-05-25T10:30:00-07:00",
-            end="2026-05-25T11:00:00-07:00",
-            attendees=["sarah@example.com", "me@example.com"],
-        ),
-        _google_event(
-            id="ev2",
-            summary="Q2 planning",
-            start="2026-05-26T14:00:00-07:00",
-            end="2026-05-26T15:30:00-07:00",
-        ),
-        _google_event(
-            id="ev3",
-            summary="All-hands",
-            start="2026-05-27",
-            end="2026-05-28",
-            all_day=True,
-        ),
-    ]
-    execute = _patch_composio(
-        monkeypatch,
-        enabled=True,
-        execute_return={"data": {"items": items}, "successful": True},
-    )
-
-    out = await calendar_service.list_upcoming("ws_acme", "user_test", limit=10)
-
-    assert len(out) == 3
-    assert {ev["id"] for ev in out} == {"ev1", "ev2", "ev3"}
-    # Every event carries the requesting workspace_id — tenancy tag
-    # applied at domain construction time, mirrored onto the wire dict.
-    assert all(ev["workspace_id"] == "ws_acme" for ev in out)
-    # Source is the upstream system slug, not the toolkit name.
-    assert all(ev["source"] == "google" for ev in out)
-    # Title flows from Google's ``summary`` field.
-    titles = [ev["title"] for ev in out]
-    assert "Sync with Sarah" in titles
-    # Attendees collapse to plain emails.
-    sarah_event = next(ev for ev in out if ev["id"] == "ev1")
-    assert sarah_event["attendees"] == ["sarah@example.com", "me@example.com"]
-    # All-day event keeps the date-only ISO string in ``start``.
-    allhands = next(ev for ev in out if ev["id"] == "ev3")
-    assert allhands["start"] == "2026-05-27"
-    # The Composio call was made exactly once with the right action.
-    execute.assert_called_once()
-    args, kwargs = execute.call_args
-    assert args[0] == "GOOGLECALENDAR_LIST_EVENTS"
-    assert kwargs["user_id"] == "ent_test:user_test"
-
-
-async def test_skips_items_missing_required_fields(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """An upstream payload missing ``id`` is dropped silently — better
-    than fabricating a placeholder that would confuse the agent."""
-    items = [
-        {"id": "ok", "summary": "Valid", "start": {"dateTime": "2026-05-25T10:00:00Z"}},
-        {"summary": "Missing id", "start": {"dateTime": "2026-05-25T11:00:00Z"}},
-        {"id": "", "summary": "Empty id"},
-    ]
-    _patch_composio(
-        monkeypatch,
-        enabled=True,
-        execute_return={"data": {"items": items}, "successful": True},
-    )
-    out = await calendar_service.list_upcoming("ws_acme", "user_test", limit=10)
-    assert [ev["id"] for ev in out] == ["ok"]
-
-
-# ---------------------------------------------------------------------------
-# Limit
-# ---------------------------------------------------------------------------
-
-
-async def test_limit_caps_results_even_if_upstream_returns_more(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Composio honors ``maxResults`` as a hint — if the upstream
-    returns more rows than asked for, the service trims to ``limit``
-    before mapping to wire dicts."""
-    items = [
-        _google_event(
-            id=f"ev{i}",
-            summary=f"Event {i}",
-            start=f"2026-05-2{i}T10:00:00-07:00",
-            end=f"2026-05-2{i}T11:00:00-07:00",
-        )
-        for i in range(1, 8)
-    ]
-    execute = _patch_composio(
-        monkeypatch,
-        enabled=True,
-        execute_return={"data": {"items": items}, "successful": True},
-    )
-
-    out = await calendar_service.list_upcoming("ws_acme", "user_test", limit=3)
-
-    assert len(out) == 3
-    assert [ev["id"] for ev in out] == ["ev1", "ev2", "ev3"]
-    # Forwarded the limit as ``maxResults`` so the upstream can
-    # short-circuit when possible.
-    _, kwargs = execute.call_args
-    assert kwargs["arguments"] == {"maxResults": 3}
-
-
-# ---------------------------------------------------------------------------
-# Cross-workspace tenancy tagging
-# ---------------------------------------------------------------------------
-
-
-async def test_cross_workspace_calls_tag_each_event_with_caller_workspace(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Two consecutive calls — one from ``ws_a``, one from ``ws_b`` —
-    against the same mocked Composio response. Every returned event
-    must carry the requesting workspace_id, never the other's.
-
-    The shared payload is contrived — in production each workspace
-    would have its own Composio connection. The point of this test is
-    the tag-at-construction invariant: the domain object refuses to
-    be built without a workspace_id and stamps the caller's tag onto
-    every event before it crosses the service boundary."""
-    items = [
-        _google_event(
-            id="shared_ev_1",
-            summary="Shared Event 1",
-            start="2026-05-25T10:00:00-07:00",
-            end="2026-05-25T11:00:00-07:00",
-        ),
-        _google_event(
-            id="shared_ev_2",
-            summary="Shared Event 2",
-            start="2026-05-26T14:00:00-07:00",
-            end="2026-05-26T15:00:00-07:00",
-        ),
-    ]
-    _patch_composio(
-        monkeypatch,
-        enabled=True,
-        execute_return={"data": {"items": items}, "successful": True},
-    )
-
-    out_a = await calendar_service.list_upcoming("ws_a", "user_test", limit=10)
-    out_b = await calendar_service.list_upcoming("ws_b", "user_test", limit=10)
-
-    # Both calls see the same upstream rows.
-    assert {ev["id"] for ev in out_a} == {"shared_ev_1", "shared_ev_2"}
-    assert {ev["id"] for ev in out_b} == {"shared_ev_1", "shared_ev_2"}
-    # But every wire dict carries the requesting workspace_id —
-    # never the other workspace's tag.
+    assert [ev["id"] for ev in out_a] == [id_a]
+    assert [ev["id"] for ev in out_b] == [id_b]
     assert all(ev["workspace_id"] == "ws_a" for ev in out_a)
     assert all(ev["workspace_id"] == "ws_b" for ev in out_b)
-    # Sanity: no event from out_a ended up tagged with ws_b (would
-    # signal shared-state leak between calls).
-    assert all(ev["workspace_id"] != "ws_b" for ev in out_a)
-    assert all(ev["workspace_id"] != "ws_a" for ev in out_b)
+
+
+async def test_limit_caps_results_sorted_by_start(
+    monkeypatch: pytest.MonkeyPatch, mongo_db: Any
+) -> None:
+    """More store rows than ``limit`` → the soonest ``limit`` events, in
+    start order."""
+    _patch_composio(monkeypatch, enabled=False)
+    ids = []
+    for i in range(5):
+        ids.append(await _seed_event("ws_acme", f"Event {i}", days_ahead=1.0 + i))
+
+    out = await calendar_service.list_upcoming("ws_acme", "user_test", limit=3)
+    assert [ev["id"] for ev in out] == ids[:3]
+    starts = [ev["start"] for ev in out]
+    assert starts == sorted(starts)

--- a/tests/ee/calendar/test_sync.py
+++ b/tests/ee/calendar/test_sync.py
@@ -146,6 +146,98 @@ async def test_ingest_creates_rows_with_composio_connector(
     ]
 
 
+async def test_ingest_lands_on_private_per_user_calendar(
+    calendar_db: Any, db_ctx: RequestContext
+) -> None:
+    """The Composio connection is per-user, so its events are one
+    member's personal feed. The ingest must auto-create a PRIVATE
+    calendar owned by the syncing user and land rows on it — landing on
+    the synthetic workspace-public default would expose member A's
+    personal events to every other member."""
+    await sync.ingest_composio_events(db_ctx, [_google_item(id="gid-1")])
+
+    cals = await _CalendarDoc.find({"workspace": "ws-sync"}).to_list()
+    assert len(cals) == 1
+    cal = cals[0]
+    assert cal.visibility == "private"
+    assert cal.owner_user_id == "user-sync"
+
+    row = await _EventDoc.find_one({"workspace": "ws-sync"})
+    assert row is not None
+    assert row.calendar_id == str(cal.id)
+    assert row.calendar_id != "primary"
+
+
+async def test_ingest_reuses_the_private_calendar(calendar_db: Any, db_ctx: RequestContext) -> None:
+    """Repeat ingests (every TTL window, forever) must reuse the one
+    private calendar, not mint a new doc per refresh."""
+    await sync.ingest_composio_events(db_ctx, [_google_item(id="gid-1")])
+    await sync.ingest_composio_events(db_ctx, [_google_item(id="gid-2")])
+
+    cals = await _CalendarDoc.find({"workspace": "ws-sync"}).to_list()
+    assert len(cals) == 1
+    rows = await _EventDoc.find({"workspace": "ws-sync"}).to_list()
+    assert {r.calendar_id for r in rows} == {str(cals[0].id)}
+
+
+async def test_two_members_same_upstream_event_get_their_own_rows(
+    calendar_db: Any,
+) -> None:
+    """Two members of ONE workspace both invited to the same Google
+    meeting, both with Composio wired: each gets their own private row.
+    Deduping across users would strand member B's copy on member A's
+    private calendar, where B cannot see it."""
+    ctx_a = RequestContext(workspace_id="ws-sync", user_id="member-a")
+    ctx_b = RequestContext(workspace_id="ws-sync", user_id="member-b")
+
+    await sync.ingest_composio_events(ctx_a, [_google_item(id="gid-shared", summary="Team sync")])
+    await sync.ingest_composio_events(ctx_b, [_google_item(id="gid-shared", summary="Team sync")])
+
+    rows = await _EventDoc.find(
+        {"workspace": "ws-sync", "source_external_id": "gid-shared"}
+    ).to_list()
+    assert len(rows) == 2
+    assert {r.created_by_user_id for r in rows} == {"member-a", "member-b"}
+    # Each row sits on its owner's own private calendar.
+    assert len({r.calendar_id for r in rows}) == 2
+    cals = await _CalendarDoc.find({"workspace": "ws-sync"}).to_list()
+    assert {c.owner_user_id for c in cals} == {"member-a", "member-b"}
+    assert all(c.visibility == "private" for c in cals)
+
+
+async def test_ingest_captures_google_timezone(calendar_db: Any, db_ctx: RequestContext) -> None:
+    """Google's ``start.timeZone`` (IANA) is persisted so read paths can
+    render event-local wall time; absent or garbage zones keep the UTC
+    canonical stamp."""
+    start = datetime(2026, 8, 10, 5, 0, tzinfo=UTC)  # 10:30 IST
+    items = [
+        {
+            "id": "gid-ist",
+            "summary": "IST meeting",
+            "start": {"dateTime": start.isoformat(), "timeZone": "Asia/Kolkata"},
+            "end": {
+                "dateTime": (start + timedelta(hours=1)).isoformat(),
+                "timeZone": "Asia/Kolkata",
+            },
+        },
+        _google_item(id="gid-no-tz"),
+        {
+            "id": "gid-bad-tz",
+            "summary": "Garbage zone",
+            "start": {"dateTime": start.isoformat(), "timeZone": "Not/AZone"},
+            "end": {"dateTime": (start + timedelta(hours=1)).isoformat()},
+        },
+    ]
+    await sync.ingest_composio_events(db_ctx, items)
+
+    ist = await _EventDoc.find_one({"workspace": "ws-sync", "source_external_id": "gid-ist"})
+    no_tz = await _EventDoc.find_one({"workspace": "ws-sync", "source_external_id": "gid-no-tz"})
+    bad_tz = await _EventDoc.find_one({"workspace": "ws-sync", "source_external_id": "gid-bad-tz"})
+    assert ist is not None and ist.timezone == "Asia/Kolkata"
+    assert no_tz is not None and no_tz.timezone == "UTC"
+    assert bad_tz is not None and bad_tz.timezone == "UTC"
+
+
 async def test_ingest_twice_updates_in_place(calendar_db: Any, db_ctx: RequestContext) -> None:
     """Re-ingesting the same Google event id updates the one row —
     the preamble's sync-on-read must not grow the store per refresh."""

--- a/tests/ee/calendar/test_sync.py
+++ b/tests/ee/calendar/test_sync.py
@@ -1,0 +1,261 @@
+# tests/ee/calendar/test_sync.py — external-sync reconciliation tests.
+#
+# Created: 2026-08-06 (feat/coupling-calendar-sot, T-13).
+#
+# Covers ``ingest_composio_events`` (the Composio → store reconciliation
+# the agent preamble's refresh path calls) and the cross-connector dedupe
+# guarantee: the same upstream Google event arriving via BOTH the native
+# gcalendar pull and the Composio pull lands as exactly ONE ``_EventDoc``
+# row, in either ingest order. Unlike test_service.py's FakeStore
+# approach, these run against a real (mongomock) Beanie store because the
+# thing under test IS the store reconciliation — faking find/insert here
+# would mock the seam under test.
+#
+# Mutation gates (tests/mutations/calendar_sot.json):
+#   * dropping the workspace filter from _find_google_event → the
+#     tenancy test fails (ingest would update another workspace's row).
+#   * narrowing the family matcher to composio-only → both dedupe
+#     tests fail (a second row appears).
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+from pocketpaw_ee.calendar import sync
+from pocketpaw_ee.calendar._context import RequestContext
+from pocketpaw_ee.calendar.models import _CalendarDoc, _EventDoc
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def calendar_db() -> Any:
+    """Beanie against a fresh mongomock DB — calendar documents only.
+
+    Mirrors tests/cloud/conftest.py's ``mongo_db`` (including the
+    ``list_collection_names`` kwargs shim) but stays local to the ee
+    calendar suite so these tests don't depend on the cloud conftest.
+    """
+    from beanie import init_beanie
+    from mongomock_motor import AsyncMongoMockClient
+
+    client = AsyncMongoMockClient()
+    db = client[f"test_{uuid.uuid4().hex[:8]}"]
+
+    original = db.list_collection_names
+
+    async def _safe_list_collection_names(*_args: Any, **_kwargs: Any):
+        return await original()
+
+    db.list_collection_names = _safe_list_collection_names  # type: ignore[method-assign]
+    await init_beanie(database=db, document_models=[_CalendarDoc, _EventDoc])
+    yield db
+
+
+@pytest.fixture
+def db_ctx() -> RequestContext:
+    return RequestContext(workspace_id="ws-sync", user_id="user-sync")
+
+
+def _google_item(
+    *,
+    id: str,
+    summary: str = "Synced event",
+    start: str | None = None,
+    end: str | None = None,
+    attendees: list[str] | None = None,
+    all_day: bool = False,
+    **extra: Any,
+) -> dict[str, Any]:
+    """One Google ``events.list`` row, as Composio hands it over."""
+    start = start or (datetime.now(UTC) + timedelta(days=1)).isoformat()
+    end = end or (datetime.now(UTC) + timedelta(days=1, hours=1)).isoformat()
+    key = "date" if all_day else "dateTime"
+    item: dict[str, Any] = {
+        "id": id,
+        "summary": summary,
+        "start": {key: start},
+        "end": {key: end},
+        **extra,
+    }
+    if attendees is not None:
+        item["attendees"] = [{"email": e} for e in attendees]
+    return item
+
+
+class _FakeGCalClient:
+    """Stand-in for pocketpaw.clients.gcalendar.CalendarClient.
+
+    The native pull's wire shape is flat ISO strings (not Google's nested
+    start/end blocks) — mirror that.
+    """
+
+    def __init__(self, events: list[dict[str, Any]]) -> None:
+        self._events = events
+
+    async def list_events(self, **_kwargs: Any) -> list[dict[str, Any]]:
+        return self._events
+
+
+def _native_event(*, id: str, summary: str = "Native event") -> dict[str, Any]:
+    return {
+        "id": id,
+        "summary": summary,
+        "start": (datetime.now(UTC) + timedelta(days=2)).isoformat(),
+        "end": (datetime.now(UTC) + timedelta(days=2, hours=1)).isoformat(),
+        "attendees": [],
+    }
+
+
+def _patch_native_client(monkeypatch: pytest.MonkeyPatch, events: list[dict[str, Any]]) -> None:
+    import pocketpaw.clients.gcalendar as gcal_module
+
+    monkeypatch.setattr(gcal_module, "CalendarClient", lambda: _FakeGCalClient(events))
+
+
+# ---------------------------------------------------------------------------
+# ingest_composio_events — creation + reconciliation
+# ---------------------------------------------------------------------------
+
+
+async def test_ingest_creates_rows_with_composio_connector(
+    calendar_db: Any, db_ctx: RequestContext
+) -> None:
+    """A Composio-only event lands in the store with the reconciliation
+    keys set — this is what makes it visible on /calendar."""
+    touched = await sync.ingest_composio_events(
+        db_ctx,
+        [_google_item(id="gid-1", summary="Standup", attendees=["a@example.com"])],
+    )
+    assert touched == 1
+
+    rows = await _EventDoc.find({"workspace": "ws-sync"}).to_list()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.source_connector == "composio_google"
+    assert row.source_external_id == "gid-1"
+    assert row.title == "Standup"
+    assert row.created_by_user_id == "user-sync"
+    assert row.attendees == [
+        {"email": "a@example.com", "response": "needs_action", "is_organizer": False}
+    ]
+
+
+async def test_ingest_twice_updates_in_place(calendar_db: Any, db_ctx: RequestContext) -> None:
+    """Re-ingesting the same Google event id updates the one row —
+    the preamble's sync-on-read must not grow the store per refresh."""
+    await sync.ingest_composio_events(db_ctx, [_google_item(id="gid-1", summary="Before")])
+    await sync.ingest_composio_events(db_ctx, [_google_item(id="gid-1", summary="After")])
+
+    rows = await _EventDoc.find({"workspace": "ws-sync"}).to_list()
+    assert len(rows) == 1
+    assert rows[0].title == "After"
+
+
+async def test_ingest_dedupes_against_native_gcalendar_row(
+    calendar_db: Any, db_ctx: RequestContext, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Native connector synced first; Composio pulls the SAME upstream
+    event (both wired to one Google account). One row, and the native
+    connector tag survives — provenance belongs to who ingested first."""
+    _patch_native_client(monkeypatch, [_native_event(id="gid-shared", summary="Native title")])
+    await sync.pull_from_gcalendar(db_ctx, calendar_id="primary")
+
+    await sync.ingest_composio_events(
+        db_ctx, [_google_item(id="gid-shared", summary="Composio title")]
+    )
+
+    rows = await _EventDoc.find(
+        {"workspace": "ws-sync", "source_external_id": "gid-shared"}
+    ).to_list()
+    assert len(rows) == 1
+    assert rows[0].source_connector == "gcalendar"
+    # Composio's fresher payload still updated the fields.
+    assert rows[0].title == "Composio title"
+
+
+async def test_native_pull_dedupes_against_composio_row(
+    calendar_db: Any, db_ctx: RequestContext, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reverse ingest order: Composio first, then the native gcalendar
+    pull sees the same Google event id. Still one row."""
+    await sync.ingest_composio_events(
+        db_ctx, [_google_item(id="gid-shared", summary="Composio title")]
+    )
+
+    _patch_native_client(monkeypatch, [_native_event(id="gid-shared", summary="Native title")])
+    touched = await sync.pull_from_gcalendar(db_ctx, calendar_id="primary")
+    assert touched == 1
+
+    rows = await _EventDoc.find(
+        {"workspace": "ws-sync", "source_external_id": "gid-shared"}
+    ).to_list()
+    assert len(rows) == 1
+    assert rows[0].source_connector == "composio_google"
+    assert rows[0].title == "Native title"
+
+
+# ---------------------------------------------------------------------------
+# ingest_composio_events — input hygiene
+# ---------------------------------------------------------------------------
+
+
+async def test_ingest_skips_malformed_items(calendar_db: Any, db_ctx: RequestContext) -> None:
+    """No id, unparseable time, or an inverted window → the row is
+    skipped, never a partial insert."""
+    good_start = (datetime.now(UTC) + timedelta(days=1)).isoformat()
+    good_end = (datetime.now(UTC) + timedelta(days=1, hours=1)).isoformat()
+    items = [
+        _google_item(id="ok-1"),
+        {"summary": "no id", "start": {"dateTime": good_start}, "end": {"dateTime": good_end}},
+        {"id": "", "summary": "empty id"},
+        {"id": "bad-time", "start": {"dateTime": "not-a-date"}, "end": {"dateTime": good_end}},
+        _google_item(id="inverted", start=good_end, end=good_start),
+    ]
+    touched = await sync.ingest_composio_events(db_ctx, items)
+    assert touched == 1
+
+    rows = await _EventDoc.find({"workspace": "ws-sync"}).to_list()
+    assert [r.source_external_id for r in rows] == ["ok-1"]
+
+
+async def test_ingest_handles_all_day_events(calendar_db: Any, db_ctx: RequestContext) -> None:
+    """Google all-day events carry ``start.date`` / ``end.date`` —
+    parsed as midnights, not skipped."""
+    tomorrow = (datetime.now(UTC) + timedelta(days=1)).date().isoformat()
+    day_after = (datetime.now(UTC) + timedelta(days=2)).date().isoformat()
+    touched = await sync.ingest_composio_events(
+        db_ctx, [_google_item(id="allday-1", start=tomorrow, end=day_after, all_day=True)]
+    )
+    assert touched == 1
+    row = await _EventDoc.find_one({"workspace": "ws-sync"})
+    assert row is not None
+    assert row.starts_at.date().isoformat() == tomorrow
+
+
+# ---------------------------------------------------------------------------
+# Tenancy
+# ---------------------------------------------------------------------------
+
+
+async def test_ingest_is_workspace_scoped(calendar_db: Any) -> None:
+    """The same Google event id in two workspaces is two rows — the
+    reconciliation match includes the workspace, so one tenant's ingest
+    can never update (or be deduped against) another tenant's row."""
+    ctx_a = RequestContext(workspace_id="ws-a", user_id="user-a")
+    ctx_b = RequestContext(workspace_id="ws-b", user_id="user-b")
+
+    await sync.ingest_composio_events(ctx_a, [_google_item(id="gid-1", summary="A's copy")])
+    await sync.ingest_composio_events(ctx_b, [_google_item(id="gid-1", summary="B's copy")])
+
+    rows_a = await _EventDoc.find({"workspace": "ws-a"}).to_list()
+    rows_b = await _EventDoc.find({"workspace": "ws-b"}).to_list()
+    assert len(rows_a) == 1
+    assert len(rows_b) == 1
+    assert rows_a[0].title == "A's copy"
+    assert rows_b[0].title == "B's copy"

--- a/tests/mutations/calendar_sot.json
+++ b/tests/mutations/calendar_sot.json
@@ -1,0 +1,51 @@
+[
+  {
+    "label": "ingest reconciliation ignores the workspace (cross-tenant update)",
+    "file": "ee/pocketpaw_ee/calendar/sync.py",
+    "find": "\"workspace\": workspace_id,",
+    "replace": "\"workspace\": {\"$exists\": true},",
+    "tests": ["tests/ee/calendar/test_sync.py"]
+  },
+  {
+    "label": "google-family matcher narrowed to composio only (native/composio dup)",
+    "file": "ee/pocketpaw_ee/calendar/sync.py",
+    "find": "\"source_connector\": {\"$in\": _GOOGLE_CONNECTOR_FAMILY},",
+    "replace": "\"source_connector\": SOURCE_CONNECTOR_COMPOSIO,",
+    "tests": ["tests/ee/calendar/test_sync.py", "tests/cloud/calendar/test_service.py"]
+  },
+  {
+    "label": "composio rows stamped with no connector (reconciliation keys dropped)",
+    "file": "ee/pocketpaw_ee/calendar/sync.py",
+    "find": "source_connector=SOURCE_CONNECTOR_COMPOSIO,",
+    "replace": "source_connector=None,",
+    "tests": ["tests/ee/calendar/test_sync.py"]
+  },
+  {
+    "label": "list_upcoming stops reading the store (old composio-only behaviour)",
+    "file": "ee/pocketpaw_ee/cloud/calendar/service.py",
+    "find": "events = await _upcoming_from_store(workspace_id, user_id, limit)",
+    "replace": "events = []",
+    "tests": ["tests/cloud/calendar/test_service.py"]
+  },
+  {
+    "label": "sync-on-read TTL removed (composio hit on every preamble build)",
+    "file": "ee/pocketpaw_ee/cloud/calendar/service.py",
+    "find": "if last is not None and (time.monotonic() - last) < _REFRESH_TTL_SECONDS:",
+    "replace": "if False:",
+    "tests": ["tests/cloud/calendar/test_service.py"]
+  },
+  {
+    "label": "google-family connectors stop collapsing to the google source slug",
+    "file": "ee/pocketpaw_ee/cloud/calendar/service.py",
+    "find": "if connector in _GOOGLE_CONNECTOR_FAMILY:",
+    "replace": "if False:",
+    "tests": ["tests/cloud/calendar/test_service.py"]
+  },
+  {
+    "label": "projection tags events with a fixed workspace (tenancy leak)",
+    "file": "ee/pocketpaw_ee/cloud/calendar/service.py",
+    "find": "workspace_id=workspace_id,\n        title=ev.title,",
+    "replace": "workspace_id=\"ws_leak\",\n        title=ev.title,",
+    "tests": ["tests/cloud/calendar/test_service.py"]
+  }
+]

--- a/tests/mutations/calendar_sot.json
+++ b/tests/mutations/calendar_sot.json
@@ -7,11 +7,18 @@
     "tests": ["tests/ee/calendar/test_sync.py"]
   },
   {
-    "label": "google-family matcher narrowed to composio only (native/composio dup)",
+    "label": "google-family matcher drops the native-gcalendar branch (dup across connectors)",
     "file": "ee/pocketpaw_ee/calendar/sync.py",
-    "find": "\"source_connector\": {\"$in\": _GOOGLE_CONNECTOR_FAMILY},",
-    "replace": "\"source_connector\": SOURCE_CONNECTOR_COMPOSIO,",
+    "find": "{\"source_connector\": SOURCE_CONNECTOR_GCALENDAR},",
+    "replace": "{\"source_connector\": \"__never__\"},",
     "tests": ["tests/ee/calendar/test_sync.py", "tests/cloud/calendar/test_service.py"]
+  },
+  {
+    "label": "composio reconcile loses its per-user scope (member B's copy lands on A's row)",
+    "file": "ee/pocketpaw_ee/calendar/sync.py",
+    "find": "                {\n                    \"source_connector\": SOURCE_CONNECTOR_COMPOSIO,\n                    \"created_by_user_id\": user_id,\n                },",
+    "replace": "                {\"source_connector\": SOURCE_CONNECTOR_COMPOSIO},",
+    "tests": ["tests/ee/calendar/test_sync.py"]
   },
   {
     "label": "composio rows stamped with no connector (reconciliation keys dropped)",
@@ -19,6 +26,20 @@
     "find": "source_connector=SOURCE_CONNECTOR_COMPOSIO,",
     "replace": "source_connector=None,",
     "tests": ["tests/ee/calendar/test_sync.py"]
+  },
+  {
+    "label": "composio calendar minted workspace-public (member A's feed leaks to member B)",
+    "file": "ee/pocketpaw_ee/calendar/sync.py",
+    "find": "visibility=\"private\",",
+    "replace": "visibility=\"public_to_workspace\",",
+    "tests": ["tests/ee/calendar/test_sync.py", "tests/cloud/calendar/test_service.py"]
+  },
+  {
+    "label": "per-user calendar collapsed back to the synthetic public primary",
+    "file": "ee/pocketpaw_ee/calendar/sync.py",
+    "find": "            if calendar_id is None:\n                calendar_id = await _ensure_composio_calendar(ctx)",
+    "replace": "            calendar_id = \"primary\"",
+    "tests": ["tests/ee/calendar/test_sync.py", "tests/cloud/calendar/test_service.py"]
   },
   {
     "label": "list_upcoming stops reading the store (old composio-only behaviour)",
@@ -46,6 +67,20 @@
     "file": "ee/pocketpaw_ee/cloud/calendar/service.py",
     "find": "workspace_id=workspace_id,\n        title=ev.title,",
     "replace": "workspace_id=\"ws_leak\",\n        title=ev.title,",
+    "tests": ["tests/cloud/calendar/test_service.py"]
+  },
+  {
+    "label": "wire times rendered in raw UTC instead of the event's zone (10:30 IST shows as 5:00 AM)",
+    "file": "ee/pocketpaw_ee/cloud/calendar/service.py",
+    "find": "return _as_utc(dt).astimezone(tz).isoformat()",
+    "replace": "return _as_utc(dt).isoformat()",
+    "tests": ["tests/cloud/calendar/test_service.py"]
+  },
+  {
+    "label": "all-day detection disabled (offsites render as 12:00 AM rows)",
+    "file": "ee/pocketpaw_ee/cloud/calendar/service.py",
+    "find": "if local_start.time() != _MIDNIGHT or local_end.time() != _MIDNIGHT:",
+    "replace": "if True:",
     "tests": ["tests/cloud/calendar/test_service.py"]
   }
 ]


### PR DESCRIPTION
Two calendar primitives existed. The rich one (recurrence, attendees, sync reconciliation) backs the /calendar page; a thin dataclass pulled the same Google calendar again through Composio, directly, for the agent's chat preamble. No shared id, no reconciliation — asking the agent "what's on my calendar" and looking at the calendar page could give different answers, and bridge-minted events (meetings, and tasks once #1871 lands) were invisible to the agent entirely.

The cloud service is now a projection over the canonical store. Composio results reconcile in through the existing sync keys, cross-connector dedupe keeps a native-synced and Composio-synced copy of the same Google event from duplicating, and the preamble reads the same policy-gated query the page serves. Freshness is sync-on-read with a five-minute per-user TTL — no new scheduler machinery — and a Composio outage degrades to store contents instead of an empty preamble.

Two findings from building this deserve the headline:

- The native Google Calendar pull was dead code. sync.py imported pocketpaw.integrations.gcalendar, a module that has never existed (the real client lives at pocketpaw.clients.gcalendar) — so the "two competing integrations" were actually one live path and one that could never run. The import is fixed; the pull functions still have no production caller, unchanged from before.
- The first build of this branch had a real privacy hole, caught in review before any PR: Composio connections are per-user, and ingesting that personal feed onto the default calendar landed it on a synthetic workspace-public fallback — member A's personal event titles, attendees, and locations would have rendered in member B's calendar and B's agent preamble. Composio events now land on a per-user calendar minted private on first ingest, with the existing policy machinery doing the rest. Deliberate consequence: two members invited to the same meeting keep separate private copies, because deduplicating across users would strand one member's copy where they cannot read it. Tests pin all of it: B sees nothing of A's feed on either surface, declared-private calendars filter through the projection path specifically, and mutations dropping the private stamp or collapsing the per-user calendar are caught.

Also fixed on the way: ingested rows keep Google's IANA timezone and the wire renders event-local, so an IST user's 10:30 meeting reads 10:30 AM in the preamble instead of 5:00 AM UTC; all-day events render date-only instead of 12:00 AM.

Tests: 113 across the sync, projection, and preamble-handler suites (baseline name sets unchanged), 12-mutation plan all caught. One accepted asymmetry, documented in the sync header: synced ingests do not emit calendar.event.created, so the meeting-URL auto-create bridge skips them — same as the old native pull's behavior, and a deliberate follow-up.

The preamble's semantics shift slightly by design: it now shows the workspace's policy-visible events (parity with the page) rather than only the requester's raw Google feed.