### PR TITLE
Carry the keeps-client-bundle declaration from pocket to deploy

### DIFF
--- a/ee/pocketpaw_ee/cloud/models/pocket.py
+++ b/ee/pocketpaw_ee/cloud/models/pocket.py
@@ -47,6 +47,14 @@ leaf domain module) and is imported here. This lets ``pockets.dto`` import the
 same class from ``surface.domain`` instead of from ``models.pocket``, which
 the OSS-EE boundary contract forbids. No schema change — the embedded BSON
 shape is identical, so no Mongo migration.
+Updated: 2026-08-07 (MT-1 — an interactive site keeps its own JavaScript) —
+added ``Pocket.keeps_client_bundle`` (``bool``, default ``False``) beside
+``engine``. It declares that the site's hand-written client JS is
+load-bearing, so the generator emits ``csr = true`` instead of the static
+default and the ripple prune step leaves the hydration bundle in place. It
+sits on the pocket for the same reason ``engine`` does — it describes the
+authored artifact, not the deploy. Defaults ``False`` so every existing
+pocket reads back unchanged; additive, no Mongo migration.
 Updated: 2026-06-21 (DSV-5 — dynamic svelte sites write-side) — loosened
 ``Pocket.source`` from ``dict[str, str] | None`` to ``dict[str, Any] | None``
 so a DYNAMIC svelte site's ``source`` envelope can carry its live-data bindings
@@ -164,6 +172,14 @@ class Pocket(TimestampedDocument):
     # pockets; a STATIC svelte pocket carries only the str->str file map (a
     # subset of the looser type — no behaviour change).
     source: dict[str, Any] | None = None
+    # MT-1 — this site's own client JavaScript is load-bearing (an onMount, a
+    # ``use:`` action, an IntersectionObserver scroll-reveal, a WebGL canvas). A
+    # published site is otherwise generated with ``csr = false`` and, on ripple, has
+    # its emitted hydration bundle pruned after the build, so that code never runs.
+    # Lives on the pocket (beside ``engine``) because it describes the AUTHORED
+    # artifact, not the deployment. ``False`` for every legacy pocket — additive, no
+    # Mongo migration.
+    keeps_client_bundle: bool = False
     # Default "workspace": new pockets are visible to every workspace member.
     # Owner can tighten to "private" (owner-only + explicit shared_with) via
     # the visibility toggle in the pocket UI.

--- a/ee/pocketpaw_ee/cloud/pockets/domain.py
+++ b/ee/pocketpaw_ee/cloud/pockets/domain.py
@@ -13,6 +13,9 @@ Updated: 2026-06-03 (feat/sites-landing-brain) — added optional
 ``Pocket.pattern`` so the wire layer + sites generator can read the
 layout/conversion intent the pocket was authored as (``"landing"`` for
 marketing sites). ``None`` for legacy pockets.
+Updated: 2026-08-07 (MT-1) — added ``Pocket.keeps_client_bundle`` (default
+``False``), the per-site declaration that the authored client JS must ship
+and run. Mirrors the Beanie field; legacy pockets read back ``False``.
 Updated: 2026-06-04 (feat/sites-svelte-engine) — added the Paw Sites
 "Svelte track" fields ``Pocket.engine`` (``"ripple"`` | ``"svelte"``) and
 ``Pocket.source`` (the SvelteKit source map, or ``None``) so the wire
@@ -146,6 +149,10 @@ class Pocket:
     # dict — hence ``dict[str, Any]`` (DSV-5). ``None`` for ripple pockets; a
     # static svelte pocket carries only the str->str file map (a subset).
     source: dict[str, Any] | None = None
+    # MT-1 — the site's own client JavaScript is load-bearing, so the generator
+    # keeps CSR on instead of emitting the static ``csr = false`` default.
+    # ``False`` for legacy pockets and for every ordinary static site.
+    keeps_client_bundle: bool = False
     # Optional per-entity surface-profile override (the JSON-shaped dict that
     # mirrors the surface-domain ``SurfaceProfile``). Consumed by the
     # entity-aware resolve_profile (entity-rooms chunk ①). ``None`` = use the

--- a/ee/pocketpaw_ee/cloud/pockets/dto.py
+++ b/ee/pocketpaw_ee/cloud/pockets/dto.py
@@ -819,6 +819,10 @@ def pocket_to_wire_dict(p) -> dict:
         # ``source`` to ``None`` for legacy / ripple pockets.
         "engine": getattr(p, "engine", "ripple"),
         "source": getattr(p, "source", None),
+        # MT-1 — this site keeps its client bundle. camelCased like every other
+        # multi-word wire key, which also matches the generator's
+        # ``siteConfig.keepsClientBundle``. ``False`` for legacy pockets.
+        "keepsClientBundle": bool(getattr(p, "keeps_client_bundle", False)),
         # Entity-rooms chunk ② — optional per-entity surface-profile override
         # (JSON dict mirroring the surface-domain ``SurfaceProfile``), or
         # ``None`` for legacy pockets. Two-word key → camelCase wire form, like

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -525,6 +525,9 @@ def _pocket_to_domain(doc: _PocketDoc) -> Pocket:
         # as ``engine="ripple"``, ``source=None``).
         engine=getattr(doc, "engine", "ripple"),
         source=getattr(doc, "source", None),
+        # MT-1 — the authored "my client JS is load-bearing" declaration.
+        # ``getattr`` for legacy docs that pre-date the field (read back False).
+        keeps_client_bundle=bool(getattr(doc, "keeps_client_bundle", False)),
         # Entity-rooms chunk ② — optional per-entity surface-profile override.
         # ``getattr`` for legacy docs that pre-date the field. Dumped to a plain
         # JSON dict so the domain layer carries the wire shape, not the Beanie
@@ -4484,6 +4487,7 @@ async def agent_create(
     ripple_spec: dict | None = None,
     engine: str = "ripple",
     source: dict[str, Any] | None = None,
+    keeps_client_bundle: bool = False,
     trusted: bool = False,
 ) -> tuple[dict | None, str | None, str | None]:
     """Insert a brand-new pocket owned by ``owner_id`` in ``workspace_id``.
@@ -4515,6 +4519,16 @@ async def agent_create(
     ride the versioned content and the generator extracts them at publish.
     Both keep today's defaults (``engine="ripple"``, ``source=None``) for
     ripple callers — additive, no Mongo migration.
+
+    ``keeps_client_bundle`` (MT-1) declares that the site's hand-written client
+    JavaScript is load-bearing — an ``onMount``, a ``use:`` action, an
+    IntersectionObserver scroll-reveal, a raw-WebGL canvas. A published site is
+    otherwise generated with ``csr = false`` (and, on ripple, has its emitted
+    hydration bundle pruned after the build), so that code never runs in the
+    browser. It sits beside ``engine`` because it describes the AUTHORED artifact
+    rather than the deploy, and it rides ``siteConfig.keepsClientBundle`` to the
+    generator at publish. Defaults ``False`` — an ordinary static site is
+    unchanged.
 
     ``trusted=True`` skips the STRICT catalog gate — use it ONLY for a
     code-assembled spec the caller fully controls (the deterministic Paw Site
@@ -4569,6 +4583,7 @@ async def agent_create(
             rippleSpec=normalized,
             engine=engine,
             source=source,
+            keeps_client_bundle=keeps_client_bundle,
             visibility="workspace",
         )
         await doc.insert()

--- a/ee/pocketpaw_ee/sites/generator_client.py
+++ b/ee/pocketpaw_ee/sites/generator_client.py
@@ -15,6 +15,19 @@
 # prerender. Comment-only; the default and the code are unchanged (see the
 # ``_DEFAULT_BUILD_TIMEOUT_SEC`` block for the measurement and the operator note).
 #
+# Updated 2026-08-07 (MT-1 — an interactive site keeps its own JavaScript):
+# build()/_build_one() gained an optional ``keeps_client_bundle: bool = False`` that
+# rides ``siteConfig.keepsClientBundle`` — ONLY when True, so a site that declares
+# nothing keeps byte-identical wire bytes (the SE-2b ``builderOrigin`` pattern, not the
+# DP0-1 always-present one, because the generator treats an absent flag as false).
+# A published site is generated with ``csr = false`` and, on ripple, has its emitted
+# hydration bundle deleted by prune-client, so the author's own client JS never runs
+# (no onMount, no ``use:`` action, no IntersectionObserver, no WebGL canvas). The
+# paw-sites generator reads this flag to emit ``csr = true`` and to mark the route
+# manifest. This is ONLY the pass-through: a caller CAN now declare it. Reading the
+# per-pocket fact at the caller (service.publish) is a LATER task — the same split
+# DP0-1 made for ``d1_database_id`` below.
+#
 # Updated 2026-07-17 (feat/sites-native-artifact-no-build): added ``artifact_home()``
 # (the ~/.pocketpaw/site-artifacts root for the native-artifact read-through cache,
 # mirroring build_home) and ``generator_version()`` (an artifact-format + dep epoch
@@ -1204,6 +1217,7 @@ class GeneratorClient:
         assets: dict[str, str] | None = None,
         builder_origin: str | None = None,
         d1_database_id: str = "",
+        keeps_client_bundle: bool = False,
         pocket_id: str | None = None,
         smoke: bool = True,
         static_build: bool = True,
@@ -1250,6 +1264,18 @@ class GeneratorClient:
         the right D1. This is only the pass-through — the real id is supplied by the
         provision job at the caller in a later task (DP0-3/DP0-4).
 
+        ``keeps_client_bundle`` (MT-1) declares that this site's own JavaScript is
+        load-bearing — an ``onMount``, a ``use:`` action, an IntersectionObserver
+        scroll-reveal, a raw-WebGL canvas. A published site is otherwise generated
+        with ``csr = false`` (and, on ripple, has its emitted hydration bundle deleted
+        after the build), so that code never runs in the browser. When True it rides
+        ``siteConfig.keepsClientBundle`` and the paw-sites generator emits
+        ``csr = true`` + marks the route manifest; the page stays PRERENDERED, so the
+        content is still in view-source and hydration only arms the motion on top. The
+        key is OMITTED when False, so a site that declares nothing keeps the exact
+        prior wire bytes. Pass-through only — reading the per-pocket fact at the caller
+        is a later task, mirroring ``d1_database_id`` above.
+
         ``pocket_id`` (PERF-3) builds into a STABLE per-pocket working dir under
         build_home() (``<build_home>/<pocket_id>/``) so node_modules persists and
         `bun install` is cached across builds (preview AND publish). When None,
@@ -1288,6 +1314,7 @@ class GeneratorClient:
                 assets=assets,
                 builder_origin=builder_origin,
                 d1_database_id=d1_database_id,
+                keeps_client_bundle=keeps_client_bundle,
                 pocket_id=None,
                 smoke=smoke,
                 static_build=static_build,
@@ -1305,6 +1332,7 @@ class GeneratorClient:
                 assets=assets,
                 builder_origin=builder_origin,
                 d1_database_id=d1_database_id,
+                keeps_client_bundle=keeps_client_bundle,
                 pocket_id=pocket_id,
                 smoke=smoke,
                 static_build=static_build,
@@ -1323,6 +1351,7 @@ class GeneratorClient:
         source: dict[str, Any] | None,
         builder_origin: str | None,
         d1_database_id: str,
+        keeps_client_bundle: bool,
         pocket_id: str | None,
         smoke: bool,
         static_build: bool = True,
@@ -1355,6 +1384,14 @@ class GeneratorClient:
         # non-editable publish's payload is byte-identical to before this change.
         if builder_origin:
             site_config["builderOrigin"] = builder_origin
+        # MT-1: only present when the site DECLARES that its own client JS is
+        # load-bearing. The generator then emits ``csr = true`` (the page stays
+        # prerendered) and marks the route manifest, so the hand-written onMount /
+        # ``use:`` action / IntersectionObserver / WebGL code actually runs and the
+        # ripple build's prune step leaves the hydration bundle alone. Omitted when
+        # False so a plain static site's payload is byte-identical to before.
+        if keeps_client_bundle:
+            site_config["keepsClientBundle"] = True
         input_json: dict[str, Any] = {
             "engine": engine,
             "theme": theme,

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -47,6 +47,25 @@
 # preview" needs to be told when it did not work rather than handed back the stale
 # url they were trying to replace.
 #
+# Updated 2026-08-07 (MT-1 — an interactive site keeps its own JavaScript):
+# ``publish_pocket`` now reads the pocket's ``keepsClientBundle`` declaration and
+# threads it through ``publish`` -> ``_deploy_site_doc`` -> ``generator.build``, so a
+# site whose hand-written client JS is load-bearing is generated with ``csr = true``
+# instead of the static ``csr = false`` default (and the ripple prune step then leaves
+# the hydration bundle alone). Two things make it survive the paths that historically
+# lose per-site facts:
+#   * It lives on the POCKET, not on the Site doc, so a republish — an
+#     ``edit_svelte_component`` or a ``make_site_editable``, both of which route back
+#     through ``publish_pocket`` — re-reads it rather than needing to carry it. That
+#     is the failure mode ``builder_origin`` had to be taught to recover from.
+#   * It is captured in ``pending_deploy_inputs`` alongside engine/source/pattern, so
+#     the charge-first deferred deploy replays it at ``subscription.active``. That
+#     snapshot IS the definition of what a deferred publish can reproduce; a field
+#     missing from it is silently dropped, and a PAID interactive site would go live
+#     with its JavaScript stripped. Pending docs written before this field read the
+#     key as absent -> False -> the prior behaviour.
+# Defaults False everywhere, so an ordinary static site is byte-identical.
+#
 # Updated 2026-08-02 (draft render): the PREVIEW deploy in ``publish`` is now
 # engine-aware, closing the half of HE-4 that was missed. HE-4 taught the LIVE
 # deploy that a built site's servable files live somewhere different per engine
@@ -1789,6 +1808,7 @@ async def publish(
     assets: dict[str, str] | None = None,
     pattern: str | None = None,
     builder_origin: str | None = None,
+    keeps_client_bundle: bool = False,
     preview: bool = False,
     _generator: GeneratorClient | None = None,
     _cloudflare: Any | None = None,
@@ -1913,6 +1933,7 @@ async def publish(
             engine=engine,
             source=source,
             builder_origin=builder_origin,
+            keeps_client_bundle=keeps_client_bundle,
             pocket_id=pocket_id,
             # A preview/edit/arm build skips only the SSR fail-gate (smoke=False); a
             # live publish keeps it (see _deploy_site_doc). It still BUILDS fresh +
@@ -2017,6 +2038,7 @@ async def publish(
         assets=assets,
         pattern=pattern,
         builder_origin=builder_origin,
+        keeps_client_bundle=keeps_client_bundle,
         generator=generator,
         cloudflare=_cloudflare,
         bundle_reader=_bundle_reader,
@@ -2040,6 +2062,7 @@ async def _deploy_site_doc(
     assets: dict[str, str] | None = None,
     pattern: str | None = None,
     builder_origin: str | None = None,
+    keeps_client_bundle: bool = False,
     generator: GeneratorClient | None = None,
     cloudflare: Any | None = None,
     bundle_reader: Callable[[str], bytes] = _default_bundle_reader,
@@ -2123,6 +2146,7 @@ async def _deploy_site_doc(
         engine=engine,
         source=source,
         builder_origin=builder_origin,
+        keeps_client_bundle=keeps_client_bundle,
         **_asset_kwargs,
         # PERF-3: build into the STABLE per-pocket working dir so node_modules
         # persists and `bun install` is cached across builds, cutting the dominant
@@ -3178,6 +3202,12 @@ async def publish_pocket(
     # (stamped by the create-dynamic-site tool) tells ``publish`` the site is
     # backed by a per-tenant D1, so its deployed Worker gets a D1 binding.
     pattern = pocket.get("pattern")
+    # MT-1: the pocket's authored declaration that its own client JS is
+    # load-bearing. Rides ``siteConfig.keepsClientBundle`` to the generator, which
+    # then emits ``csr = true`` instead of the static default. camelCase because
+    # that is the pocket WIRE dict (``keeps_client_bundle`` is the Beanie/domain
+    # name). Absent on every legacy pocket → False → today's behaviour.
+    keeps_client_bundle = bool(pocket.get("keepsClientBundle"))
 
     # charge-first: a PREVIEW publish never persists a Site doc and never bills, so
     # it stays the unchanged Branch-primitive preview path — build + smoke-gate +
@@ -3194,6 +3224,7 @@ async def publish_pocket(
             pattern=pattern,
             name=name or pocket.get("name", ""),
             builder_origin=builder_origin,
+            keeps_client_bundle=keeps_client_bundle,
             preview=True,
             _generator=_generator,
             _cloudflare=_cloudflare,
@@ -3239,6 +3270,7 @@ async def publish_pocket(
             pattern=pattern,
             name=name or pocket.get("name", ""),
             builder_origin=builder_origin,
+            keeps_client_bundle=keeps_client_bundle,
             tier=tier,
             provider=_billing_provider,
         )
@@ -3255,6 +3287,7 @@ async def publish_pocket(
         pattern=pattern,
         name=name or pocket.get("name", ""),
         builder_origin=builder_origin,
+        keeps_client_bundle=keeps_client_bundle,
         preview=False,
         _generator=_generator,
         _cloudflare=_cloudflare,
@@ -3404,6 +3437,7 @@ async def _publish_pending_site(
     pattern: str | None,
     name: str,
     builder_origin: str | None,
+    keeps_client_bundle: bool,
     tier: Any,
     provider: Any | None,
 ) -> _SiteDoc:
@@ -3465,6 +3499,11 @@ async def _publish_pending_site(
         "source": source,
         "pattern": pattern,
         "builder_origin": builder_origin,
+        # MT-1 — MUST be captured here. This dict is the complete record of what a
+        # deferred deploy replays; anything the publish path reads that is missing
+        # here is silently lost when the ``subscription.active`` webhook deploys,
+        # and a paid interactive site would go live with its JavaScript stripped.
+        "keeps_client_bundle": keeps_client_bundle,
         "name": site_name,
     }
 
@@ -3627,6 +3666,9 @@ async def activate_site(
         source=inputs.get("source"),
         pattern=inputs.get("pattern"),
         builder_origin=inputs.get("builder_origin"),
+        # MT-1 — replay the authored declaration. A pending doc captured before
+        # this field existed has no key and reads False (the prior behaviour).
+        keeps_client_bundle=bool(inputs.get("keeps_client_bundle")),
         generator=_generator,
         cloudflare=_cloudflare,
         bundle_reader=_bundle_reader,

--- a/tests/cloud/sites/test_keeps_client_bundle_publish.py
+++ b/tests/cloud/sites/test_keeps_client_bundle_publish.py
@@ -1,0 +1,322 @@
+# tests/cloud/sites/test_keeps_client_bundle_publish.py — MT-1: the pocket's
+# "my client JavaScript is load-bearing" declaration survives every publish path.
+# Created 2026-08-07 (feat/sites-keep-client-bundle).
+#
+# A published Paw Site is generated with ``csr = false`` and, on ripple, has its
+# emitted hydration bundle pruned after the build — so an author's own onMount /
+# ``use:`` action / IntersectionObserver / WebGL code never runs. ``Pocket``
+# now carries ``keeps_client_bundle``; it rides ``siteConfig.keepsClientBundle`` to
+# the generator, which emits ``csr = true`` instead.
+#
+# THE TEST THAT MATTERS HERE IS THE DEFERRED ONE. A paid publish does not deploy:
+# it snapshots the deploy inputs onto ``Site.pending_deploy_inputs`` and defers until
+# the ``subscription.active`` webhook fires, and that webhook carries only
+# workspace_id + site_id — it never re-reads the pocket. So any field the publish
+# path reads but the snapshot omits is silently dropped, and a PAID interactive site
+# would go live with its JavaScript stripped while every free-path test stayed green.
+# ``test_deferred_paid_publish_preserves_the_flag`` runs the real charge-first flow
+# (pending publish → signed webhook → activation) and asserts the flag reaches the
+# generator at activation time.
+#
+# The generator / Cloudflare / Dodo provider are mocked exactly like the sibling
+# test_charge_first.py (never touches Bun/workerd/Dodo); the webhook path signs with
+# the REAL standardwebhooks library so activation runs through the verified route.
+
+from __future__ import annotations
+
+import base64
+import json
+from datetime import UTC, datetime
+
+from pocketpaw_ee.cloud.billing import service as billing
+from pocketpaw_ee.cloud.billing import site_plans
+from pocketpaw_ee.cloud.billing.domain import SubscriptionCheckout
+from pocketpaw_ee.cloud.billing.providers.dodo import DodoProvider
+from pocketpaw_ee.cloud.models.site import Site
+from pocketpaw_ee.sites import service as sites_service
+from standardwebhooks import Webhook
+
+SECRET = "whsec_" + base64.b64encode(b"keeps-bundle-test-secret-32bytes!").decode()
+SITE_SUB_ID = "sub_site_keeps_bundle"
+CHECKOUT_URL = "https://checkout.dodopayments.test/site/keeps-bundle"
+
+
+class _RecordingGenerator:
+    """Stand-in generator — records the build kwargs, never touches Bun."""
+
+    def __init__(self):
+        self.build_calls: list[dict] = []
+
+    async def build(self, **kw):
+        from pocketpaw_ee.sites.generator_client import BuildResult
+
+        self.build_calls.append(dict(kw))
+        return BuildResult(project_dir="/tmp/site", ripple_version="0.2.0")
+
+
+class _RecordingCF:
+    def __init__(self):
+        self.put_calls: list[str] = []
+
+    async def put_worker(self, *, script_name, bundle, bindings=None):
+        self.put_calls.append(script_name)
+        return True
+
+
+class _RecordingBillingProvider:
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    async def create_subscription(
+        self, *, plan_key, product_id, workspace_id, customer_email, metadata
+    ) -> SubscriptionCheckout:
+        self.calls.append({"metadata": dict(metadata)})
+        return SubscriptionCheckout(checkout_url=CHECKOUT_URL, subscription_id=SITE_SUB_ID)
+
+
+def _provider() -> DodoProvider:
+    return DodoProvider(
+        api_key="dodo_test_key",
+        environment="test_mode",
+        webhook_secret=SECRET,
+        credit_product_id="prod_credits_sku",
+        plan_products={},
+    )
+
+
+async def _make_workspace() -> str:
+    from pocketpaw_ee.cloud.models.workspace import Workspace
+
+    ws = Workspace(
+        name="Acme", slug=f"acme-mt1-{datetime.now(UTC).timestamp()}", owner="u1", plan="pro"
+    )
+    await ws.insert()
+    return str(ws.id)
+
+
+async def _make_pocket(*, workspace_id: str, keeps_client_bundle: bool) -> str:
+    """A site pocket that either declares its client JS is load-bearing, or doesn't."""
+    from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
+
+    doc = _PocketDoc(
+        workspace=workspace_id,
+        name="Motion Landing",
+        owner="u1",
+        type="site",
+        pattern="landing",
+        keeps_client_bundle=keeps_client_bundle,
+    )
+    await doc.insert()
+    return str(doc.id)
+
+
+def _sign(body: str, *, msg_id: str) -> dict[str, str]:
+    ts = datetime.now(UTC)
+    sig = Webhook(SECRET).sign(msg_id=msg_id, timestamp=ts, data=body)
+    return {
+        "webhook-id": msg_id,
+        "webhook-timestamp": str(int(ts.timestamp())),
+        "webhook-signature": sig,
+    }
+
+
+def _site_subscription_body(*, workspace_id: str, site_id: str) -> str:
+    return json.dumps(
+        {
+            "business_id": "biz_1",
+            "type": "subscription.active",
+            "timestamp": datetime.now(UTC).isoformat(),
+            "data": {
+                "subscription_id": SITE_SUB_ID,
+                "product_id": "prod_site_pro",
+                "metadata": {
+                    "workspace_id": workspace_id,
+                    "site_id": site_id,
+                    "plan_key": "pro",
+                },
+            },
+        }
+    )
+
+
+def _paid_tier(monkeypatch) -> None:
+    """Make the "pro" site tier chargeable so publish defers the deploy."""
+    monkeypatch.setattr(
+        site_plans, "_dodo_product_for", lambda key: {"pro": "prod_site_pro"}.get(key)
+    )
+
+
+# ---------------------------------------------------------------------------
+# The free / immediate publish path.
+# ---------------------------------------------------------------------------
+
+
+async def test_live_publish_forwards_the_declared_flag(mongo_db, recording_bus):
+    """A declaring pocket published on the free path hands the flag to the
+    generator, which is what makes the emitted +layout.ts carry csr=true."""
+    ws = await _make_workspace()
+    pocket_id = await _make_pocket(workspace_id=ws, keeps_client_bundle=True)
+    gen = _RecordingGenerator()
+
+    await sites_service.publish_pocket(
+        workspace_id=ws,
+        user_id="u1",
+        pocket_id=pocket_id,
+        _generator=gen,
+        _cloudflare=_RecordingCF(),
+        _bundle_reader=lambda d: b"x",
+    )
+
+    assert len(gen.build_calls) == 1
+    assert gen.build_calls[0]["keeps_client_bundle"] is True
+
+
+async def test_live_publish_of_a_plain_pocket_does_not_declare(mongo_db, recording_bus):
+    """REGRESSION: a pocket that declares nothing publishes exactly as before —
+    the generator is told False, so csr stays off and the prune still runs."""
+    ws = await _make_workspace()
+    pocket_id = await _make_pocket(workspace_id=ws, keeps_client_bundle=False)
+    gen = _RecordingGenerator()
+
+    await sites_service.publish_pocket(
+        workspace_id=ws,
+        user_id="u1",
+        pocket_id=pocket_id,
+        _generator=gen,
+        _cloudflare=_RecordingCF(),
+        _bundle_reader=lambda d: b"x",
+    )
+
+    assert len(gen.build_calls) == 1
+    assert gen.build_calls[0]["keeps_client_bundle"] is False
+
+
+# ---------------------------------------------------------------------------
+# The charge-first DEFERRED path — the one that silently loses fields.
+# ---------------------------------------------------------------------------
+
+
+async def test_paid_publish_captures_the_flag_in_the_deploy_snapshot(mongo_db, monkeypatch):
+    """A paid publish defers the deploy, so the flag must land in
+    ``pending_deploy_inputs`` — that snapshot is all the webhook will ever see."""
+    _paid_tier(monkeypatch)
+    ws = await _make_workspace()
+    pocket_id = await _make_pocket(workspace_id=ws, keeps_client_bundle=True)
+    gen = _RecordingGenerator()
+
+    doc = await sites_service.publish_pocket(
+        workspace_id=ws,
+        user_id="u1",
+        pocket_id=pocket_id,
+        site_plan_key="pro",
+        _generator=gen,
+        _cloudflare=_RecordingCF(),
+        _bundle_reader=lambda d: b"x",
+        _billing_provider=_RecordingBillingProvider(),
+    )
+
+    # Deploy really was deferred (nothing built yet) …
+    assert doc.deployed is False
+    assert gen.build_calls == []
+    # … and the declaration is persisted for the webhook to replay.
+    persisted = await Site.find_one(Site.id == doc.id)
+    assert persisted is not None
+    assert persisted.pending_deploy_inputs["keeps_client_bundle"] is True
+
+
+async def test_deferred_paid_publish_preserves_the_flag(mongo_db, recording_bus, monkeypatch):
+    """THE ONE THAT MATTERS: publish paid → pending, then let the real signed
+    ``subscription.active`` webhook drive activation, and assert the generator is
+    still told the site keeps its client bundle.
+
+    The webhook carries only workspace_id + site_id and never re-reads the pocket,
+    so this fails the moment the flag stops being captured in / replayed from
+    ``pending_deploy_inputs`` — the failure mode no free-path test can see.
+    """
+    _paid_tier(monkeypatch)
+    # Local deploy mode + a patched GeneratorClient, because the webhook-driven
+    # activation takes no injected seams.
+    monkeypatch.setenv("PAW_SITES_LOCAL", "1")
+    activation_gen = _RecordingGenerator()
+    monkeypatch.setattr(sites_service, "GeneratorClient", lambda *a, **k: activation_gen)
+    from pocketpaw_ee.sites import local_server
+
+    monkeypatch.setattr(
+        local_server, "deploy_local", lambda site_id, project_dir, **kw: f"http://local/{site_id}/"
+    )
+
+    ws = await _make_workspace()
+    pocket_id = await _make_pocket(workspace_id=ws, keeps_client_bundle=True)
+    doc = await sites_service.publish_pocket(
+        workspace_id=ws,
+        user_id="u1",
+        pocket_id=pocket_id,
+        site_plan_key="pro",
+        _generator=_RecordingGenerator(),  # publish-path generator: must NOT run
+        _billing_provider=_RecordingBillingProvider(),
+    )
+    site_id = str(doc.id)
+    assert doc.deployed is False
+
+    body = _site_subscription_body(workspace_id=ws, site_id=site_id)
+    result = await billing.handle_webhook(
+        payload=body.encode(),
+        headers=_sign(body, msg_id="evt_active_keeps_bundle_1"),
+        provider=_provider(),
+    )
+    assert result == {"ok": True, "granted": False}
+
+    # The deferred deploy ran — and it still knows the site keeps its JavaScript.
+    assert len(activation_gen.build_calls) == 1
+    assert activation_gen.build_calls[0]["keeps_client_bundle"] is True
+
+    updated = await Site.find_one(Site.id == doc.id)
+    assert updated is not None
+    assert updated.deployed is True
+    assert updated.subscription_status == "active"
+
+
+async def test_activation_of_a_pre_mt1_pending_site_defaults_to_false(mongo_db, monkeypatch):
+    """BACK-COMPAT: a site that went pending BEFORE this field existed has no
+    ``keeps_client_bundle`` key in its snapshot. Activation must read that as False
+    and deploy normally, not raise."""
+    _paid_tier(monkeypatch)
+    monkeypatch.setenv("PAW_SITES_LOCAL", "1")
+    activation_gen = _RecordingGenerator()
+    monkeypatch.setattr(sites_service, "GeneratorClient", lambda *a, **k: activation_gen)
+    from pocketpaw_ee.sites import local_server
+
+    monkeypatch.setattr(
+        local_server, "deploy_local", lambda site_id, project_dir, **kw: f"http://local/{site_id}/"
+    )
+
+    ws = await _make_workspace()
+    pocket_id = await _make_pocket(workspace_id=ws, keeps_client_bundle=True)
+    doc = await sites_service.publish_pocket(
+        workspace_id=ws,
+        user_id="u1",
+        pocket_id=pocket_id,
+        site_plan_key="pro",
+        _generator=_RecordingGenerator(),
+        _billing_provider=_RecordingBillingProvider(),
+    )
+    site_id = str(doc.id)
+
+    # Rewrite the snapshot to the PRE-MT-1 shape: the key simply isn't there.
+    persisted = await Site.find_one(Site.id == doc.id)
+    assert persisted is not None
+    legacy_inputs = dict(persisted.pending_deploy_inputs)
+    legacy_inputs.pop("keeps_client_bundle")
+    persisted.pending_deploy_inputs = legacy_inputs
+    await persisted.save()
+
+    body = _site_subscription_body(workspace_id=ws, site_id=site_id)
+    await billing.handle_webhook(
+        payload=body.encode(),
+        headers=_sign(body, msg_id="evt_active_keeps_bundle_legacy"),
+        provider=_provider(),
+    )
+
+    # Deployed fine, with the historical (non-declaring) behaviour.
+    assert len(activation_gen.build_calls) == 1
+    assert activation_gen.build_calls[0]["keeps_client_bundle"] is False

--- a/tests/ee/sites/test_keeps_client_bundle.py
+++ b/tests/ee/sites/test_keeps_client_bundle.py
@@ -1,0 +1,140 @@
+# tests/ee/sites/test_keeps_client_bundle.py — MT-1: an interactive site keeps its
+# own JavaScript. Created: 2026-08-07 (feat/sites-keep-client-bundle).
+#
+# A published Paw Site is generated with ``csr = false``, and on the ripple track the
+# post-build prune then deletes the emitted hydration dirs — so an author's own client
+# JS never runs in the browser: no ``onMount``, no ``use:`` action, no
+# IntersectionObserver scroll-reveal, no WebGL canvas. The paw-sites generator (this
+# slice's sibling change) reads ``siteConfig.keepsClientBundle`` to emit ``csr = true``
+# and mark the route manifest.
+#
+# These tests pin the pocketpaw HALF of that cross-repo contract: the exact wire shape
+# ``GeneratorClient.build()`` hands ``paw-sites-gen``. The fake runner captures the
+# input_json so the payload is asserted without spawning bun/node/workerd (the
+# _CapturingRunner pattern from test_generator_client_svelte.py).
+#
+# The load-bearing test here is the REGRESSION one: a build that does not declare the
+# flag must emit a byte-identical siteConfig — the key is OMITTED, never sent as
+# False. That follows SE-2b's ``builderOrigin`` (omit-when-unset) rather than DP0-1's
+# ``d1DatabaseId`` (always-present), because the generator treats an absent flag as
+# false and every existing static site must keep its exact prior payload.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.sites.generator_client import GeneratorClient
+
+_SOURCE_MAP = {
+    "src/routes/+page.svelte": "<script>import { reveal } from '$lib/reveal.js';</script>",
+    "src/routes/+layout.svelte": "<script>import '../app.css';</script>",
+    "src/routes/+page.ts": "export const prerender = true;",
+    "src/app.css": ":root{}",
+    "src/lib/reveal.js": "export function reveal(node) { new IntersectionObserver(() => {}); }",
+}
+
+# The siteConfig a build emitted BEFORE MT-1. A site that declares nothing must still
+# send exactly these keys — no keepsClientBundle, in any form.
+_PRE_MT1_SITE_CONFIG_KEYS = {
+    "siteId",
+    "title",
+    "captureApiBase",
+    "captureSignedKey",
+    "d1DatabaseId",
+}
+
+
+class _CapturingRunner:
+    """Records the input_json build() hands generate(), so the wire contract can be
+    asserted without spawning bun/workerd."""
+
+    def __init__(self) -> None:
+        self.input_json: dict | None = None
+
+    async def generate(self, input_json: dict, out_dir: str) -> dict:
+        self.input_json = input_json
+        return {"projectDir": "/tmp/site", "rippleVersion": "0.2.0"}
+
+    async def install(self, project_dir: str) -> tuple[bool, str]:
+        return True, "ok"
+
+    async def smoke(self, project_dir: str) -> tuple[bool, str]:
+        return True, "ok"
+
+
+async def _build(**kw) -> dict:
+    """Run a build through a capturing runner and return the sent payload."""
+    runner = _CapturingRunner()
+    client = GeneratorClient(_runner=runner)
+    await client.build(
+        theme={},
+        site_id="site_mt1",
+        title="Motion",
+        capture_api_base="https://api.paw.example",
+        capture_signed_key="pp_tok_x",
+        **kw,
+    )
+    assert runner.input_json is not None
+    return runner.input_json
+
+
+@pytest.mark.asyncio
+async def test_declared_flag_rides_site_config_on_svelte() -> None:
+    """build(keeps_client_bundle=True) puts keepsClientBundle on siteConfig so the
+    generator emits csr=true and the author's own JS actually runs."""
+    sent = await _build(
+        engine="svelte", source=_SOURCE_MAP, ripple_spec=None, keeps_client_bundle=True
+    )
+    assert sent["siteConfig"]["keepsClientBundle"] is True
+
+
+@pytest.mark.asyncio
+async def test_declared_flag_rides_site_config_on_ripple() -> None:
+    """The flag is a per-SITE fact, not an engine one — it rides the ripple payload
+    the same way. (On ripple it is also what stops the post-build prune from deleting
+    the hydration bundle.)"""
+    sent = await _build(ripple_spec={"type": "container"}, keeps_client_bundle=True)
+    assert sent["engine"] == "ripple"
+    assert sent["siteConfig"]["keepsClientBundle"] is True
+
+
+@pytest.mark.asyncio
+async def test_omitted_flag_leaves_the_payload_byte_identical() -> None:
+    """THE REGRESSION GUARD: a site that declares nothing sends the exact pre-MT-1
+    siteConfig — the key is absent, not present-and-False. A False would still be a
+    changed payload for every existing static site."""
+    sent = await _build(ripple_spec={"type": "container"})
+    site_config = sent["siteConfig"]
+    assert "keepsClientBundle" not in site_config
+    assert set(site_config) == _PRE_MT1_SITE_CONFIG_KEYS
+
+
+@pytest.mark.asyncio
+async def test_explicit_false_is_also_omitted() -> None:
+    """Passing the flag explicitly False is the same as not passing it — nothing is
+    added to the payload, so a caller that always forwards a stored bool cannot
+    accidentally change the wire bytes of every static site."""
+    sent = await _build(
+        engine="svelte", source=_SOURCE_MAP, ripple_spec=None, keeps_client_bundle=False
+    )
+    assert "keepsClientBundle" not in sent["siteConfig"]
+    assert set(sent["siteConfig"]) == _PRE_MT1_SITE_CONFIG_KEYS
+
+
+@pytest.mark.asyncio
+async def test_flag_composes_with_the_other_site_config_fields() -> None:
+    """The flag is additive: it does not disturb the builderOrigin (SE-2b) or
+    d1DatabaseId (DP0-1) fields that share siteConfig."""
+    sent = await _build(
+        engine="svelte",
+        source=_SOURCE_MAP,
+        ripple_spec=None,
+        keeps_client_bundle=True,
+        builder_origin="https://app.paw.example",
+        d1_database_id="abc123",
+    )
+    site_config = sent["siteConfig"]
+    assert site_config["keepsClientBundle"] is True
+    assert site_config["builderOrigin"] == "https://app.paw.example"
+    assert site_config["d1DatabaseId"] == "abc123"
+    # The source map still rides the svelte track untouched.
+    assert sent["source"] == _SOURCE_MAP


### PR DESCRIPTION
The paw-sites generator gained a `keepsClientBundle` flag (qbtrix/paw-sites#40), but nothing set it, so a real publish could not turn it on. This wires it end to end.

## Where the declaration lives

On the Pocket, beside `engine`, because it describes the authored artifact rather than the deployment. That placement makes a republish safe for free: `edit_svelte_component` and `make_site_editable` both route back through `publish_pocket`, which re-reads the pocket, so the flag cannot be dropped the way `builder_origin` once was.

## Why it is also in the publish snapshot

`Site.pending_deploy_inputs` is the whole definition of what a deferred deploy can replay. The `subscription.active` webhook carries only `workspace_id` and `site_id` and never re-reads the pocket, so a field missing from that snapshot is silently lost.

The failure that would have caused is worth naming: a paid interactive site would go live with its JavaScript stripped, while every free-path test stayed green. The new test runs the real charge-first flow through a signed webhook and asserts the flag still reaches the generator at activation. Dropping it from the snapshot fails that test.

## Tests

`PAW_CF_DEPLOY_MODE= uv run pytest tests/ee/sites/` — 507 passed, 4 skipped.

Four failures in `test_generator_client_timeout.py` are pre-existing Windows asyncio flakes; they reproduce identically on clean `dev` with none of this branch's changes applied.

Nothing was added to `engines.py`. "Keeps its client bundle" is a per-site fact, and the generator already answers it once through the route manifest — a per-engine predicate beside it would be a second mechanism to keep in sync for no capability gained.