### PR TITLE
Design taste stops recommending a package no Paw Site can install

### DIFF
--- a/src/pocketpaw/bundled_skills/_bundled/skills/pocketpaw-design-taste/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/skills/pocketpaw-design-taste/SKILL.md
@@ -37,14 +37,14 @@ You must explicitly declare these 5 parameters in a single, compact `<!-- Creati
 5. **The Art Director's Critique:** Self-correct the most obvious layout trap before rendering.
 
 ### 1.B The Visual DNA Token
-Generate a one-line Design Read following this exact pattern. Example:
+Generate a one-line Design Read on this exact pattern:
 > **"Reading this as: an advanced cloud IDE for software engineers, aiming for an Immersive Technology feel, driving an Innovation emotional palette via Dark Kinetic with a WebGL fluid background and a geometric sans-serif typography pairing."**
 
 ### 1.C Read these signals (feed the Ledger)
 Infer the Ledger from what the business actually is:
 1. **Business kind** — SaaS / dev-tool, agency / studio, premium consumer or DTC, local service (dentist, bakery, gym), event, portfolio, editorial.
-2. **Vibe words the user used** — "minimal", "calm", "Linear-style", "bold", "premium", "Apple-y", "playful", "serious B2B", "editorial", "brutalist", "warm", "luxury".
-3. **Reference signals** — any URL, screenshot, or brand they named or want to compete with. If they linked something, that is the strongest signal in the room; match its family, don't override it.
+2. **Vibe words the user used** — "minimal", "premium", "Apple-y", "playful", "brutalist", "warm". They map onto the dial table in 1.D.
+3. **Reference signals** — any URL, screenshot, or brand they named or want to compete with. A link is the strongest signal in the room; match its family, don't override it.
 4. **Audience** — a procurement buyer, a design-conscious consumer, a local walk-in, a recruiter. The audience picks the aesthetic, not your taste.
 5. **Existing brand assets** — a named color, a logo, a font. Honour them.
 6. **Quiet constraints** — trust-first / regulated / accessibility-critical audiences OVERRIDE aesthetic preference toward calm and legible.
@@ -52,7 +52,7 @@ Infer the Ledger from what the business actually is:
 ### 1.D The three dials
 After the read, set three dials. Every layout, motion, and density decision below is gated by them.
 - **DESIGN_VARIANCE: 7** — 1 = perfect symmetry, 10 = artsy chaos. A selling page wants confident asymmetry.
-- **MOTION_INTENSITY: 5** — 1 = fully static, 10 = cinematic. Held moderate: the page paints before JS, so baseline motion is CSS-first and never load-bearing (Module 3.C).
+- **MOTION_INTENSITY: 5** — 1 = fully static, 10 = cinematic. Held moderate: the page paints before JS, so baseline motion is CSS-first and never load-bearing (Module 3.E).
 - **VISUAL_DENSITY: 3** — 1 = art gallery / airy, 10 = cockpit. Landing pages breathe; generous whitespace reads as "expensive".
 
 **Dial inference (read → values):**
@@ -64,7 +64,7 @@ After the read, set three dials. Every layout, motion, and density decision belo
 | landing / marketing site (default) | 7 | 5 | 3 |
 | trust-first / regulated / accessibility-critical | 4 | 3 | 4 |
 
-**What the dials mean:** VARIANCE 4-7 → offset overlaps, mixed aspect ratios, left-aligned headers, asymmetric fractional grids (`grid-template-columns: 2fr 1fr`), deliberate empty zones (any asymmetry collapses to one clean column below 768px). MOTION 4-7 → CSS transitions + reveal cascades on `transform`/`opacity`, still degrading. DENSITY 1-3 → big section gaps (`padding: 6rem 0` to `9rem 0`); 4-7 → standard (`4rem`-`6rem`). Honour an explicit user request that moves a dial.
+**What the dials mean:** VARIANCE 4-7 → offset overlaps, mixed aspect ratios, left-aligned headers, asymmetric fractional grids (`grid-template-columns: 2fr 1fr`), deliberate empty zones. MOTION 4-7 → CSS transitions + reveal cascades on `transform`/`opacity`, still degrading. DENSITY 1-3 → big section gaps (`padding: 6rem 0` to `9rem 0`); 4-7 → standard (`4rem`-`6rem`). Honour an explicit user request that moves a dial.
 
 ### 1.E Do NOT ask the user what look to use — infer it
 Choosing the visual direction is YOUR expertise; infer it and go. Only ask the user about real-world FACTS you genuinely cannot know and cannot sensibly placeholder (a specific offering list, real contact details, real pricing), and even then prefer to proceed with a clearly-flagged placeholder over blocking. Never ask "what style / theme / colors do you want?" — that is the one question forbidden here.
@@ -80,32 +80,30 @@ Select exactly **ONE** primary visual identity to rule the system assets. Do not
 
 *   **Dark Kinetic (Terminal / Tech):** Deep near-black OLED grounds, heavily utilizing CSS noise/film grain filters, subtle scanlines, and one neon accent (cyan or emerald) used sparingly.
 *   **Tactile Brutalism (The 2026 Elite):** Sharp geometric layouts, 1px solid borders, and stark typography to project engineered precision. Zero drop shadows.
-*   **Immersive WebGL:** Interactive GLSL shaders, 3D particle swarms, or raymarched glass geometries sitting behind high-contrast typography.
+*   **Immersive WebGL:** Interactive GLSL shaders or raymarched glass geometries sitting behind high-contrast typography.
 *   **Aurora Mesh:** Multi-layered, deeply soft color fields smoothly warping into each other.
 *   **Liquid Glass:** Refractive glass paneling displaying dynamic light bending and extreme specular edges.
 *   **Frosted Editorial:** Oversized classic serif headlines layered delicately over deeply blurred, muted tones.
 
 ### 2.B Background Intelligence (Mandatory Grounding)
-Plain `#fff` or `#000` solid pages are completely forbidden. Every page must map a distinct background architecture. Select a structural layout from below:
+Plain `#fff` or `#000` pages are forbidden. Every page must map a distinct background architecture. Select one:
 
 | Background Identity | Execution Architecture |
 | :--- | :--- |
-| **WebGL / Shader Canvas** | High-fidelity interactive fluid simulations or custom GLSL shaders (See Section 2.C). |
+| **WebGL / Shader Canvas** | Hand-written GLSL: fluid simulation, noise, gradient flow (See Section 2.C). |
 | **Mesh/Liquid Aurora** | Multi-stop `radial-gradient` patterns shifting positions slowly via an infinite CSS `@keyframes` looping animation. |
 | **Architectural Lines** | Ultra-faint `linear-gradient` repetition grids mimicking blueprint lines or technical structures. |
 | **Tactile Grain Overlay** | A permanent SVG noise filter or high-frequency dark/light noise utilizing `mix-blend-mode: overlay`. |
-| **Radial Spotlight** | A highly-focused, massive viewport gradient that keeps readable areas illuminated while darkening edges. |
+| **Radial Spotlight** | A massive viewport gradient keeping readable areas lit while the edges darken. |
 
-### 2.C WebGL & Interactive Canvas Engines
-For top-tier "Immersive" visual richness targets, deploy canvas-based backgrounds. Use the appropriate library based on the engine track:
+### 2.C WebGL & Interactive Canvas
+For "Immersive" richness targets, deploy a canvas background — hand-written, **no library**. A Paw Site's `package.json` is generator-owned and your source map supplies FILES ONLY, so `three`, `ogl`, `threlte`, `gsap` and every other npm import NEVER resolve.
 
-*   **Three.js** (`https://threejs.org/`) — The standard for complex particle systems, floating 3D primitives, and orbital mechanics.
-*   **OGL** (`https://github.com/oframe/ogl`) — A minimal WebGL framework. Best for high-performance, lightweight GLSL shader planes (e.g., fluid color mixing, noise shaders) directly in static HTML.
-*   **Threlte** (`https://threlte.xyz/`) — The absolute standard for declarative 3D on the Svelte track. Use this to orchestrate Three.js scenes cleanly within Svelte components.
-*   *THE CANVAS GUARDRAIL:* Because JS may be disabled or slow to hydrate, the `<canvas>` element MUST sit on top of a highly polished CSS fallback (e.g., a static CSS mesh gradient). The page must look premium *before* the WebGL context ever initializes.
+*   **Raw WebGL, ~40 lines.** `canvas.getContext('webgl')`, a pass-through vertex shader and one fragment shader over a full-screen quad (`gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4)`), animated from `u_time` / `u_resolution` in a `requestAnimationFrame` loop, buffer capped at 2x DPR and the loop stopped off-screen. That buys what sells: fluid color mixing, noise fields, gradient flow, aurora warping. Scene graphs and particle swarms are what the library bought you; skip them.
+*   *THE CANVAS GUARDRAIL:* Because JS may be disabled, pruned, or slow, the `<canvas>` element MUST sit on top of a highly polished CSS fallback (e.g., a static CSS mesh gradient). The page must look premium *before* the WebGL context ever initializes. A canvas also needs a site that keeps its client bundle (3.E); without that, ship the CSS background alone.
 
 ### 2.D Typography Pairings 2.0
-Never isolate a single font family. Systematically cycle through distinct display-to-body pairings:
+Never isolate a single font family. Cycle through distinct display-to-body pairings:
 
 1.  **The Engineering Elite:** `Space Grotesk` or `Cabinet Grotesk` (Display) + `General Sans` (Body) + `Fira Code` (Numbers)
 2.  **The High-Energy Consumer:** `Clash Display` (Display) + `Satoshi` (Body) + `Geist Mono` (Numbers)
@@ -149,7 +147,7 @@ The Trend Engine primitive sets the surface; the family below sets the whole tok
 ## MODULE 3: LAYOUT & MOTION ENGINE
 
 ### 3.A Section Composition Diversification
-**The Default AI Sequence (Hero → 3 Cards → CTA → FAQ → Footer) is strictly banned.** No two consecutive sections may employ the same design pattern. Alternate composition archetypes:
+**The Default AI Sequence (Hero → 3 Cards → CTA → FAQ → Footer) is strictly banned.** No two consecutive sections use the same design pattern. Alternate composition archetypes:
 
 *   **Magazine Split:** Massive multi-column text block with hard rule columns framing raw typography and imagery.
 *   **Asymmetric Bento:** Highly unequal fractional sizing layouts (`grid-template-columns: 1.6fr 0.8fr 1.2fr`).
@@ -176,59 +174,38 @@ A marketing page is a *sequence* of sections; give them different shapes so the 
 - **Real glass, not just blur.** Add a 1px inner-light border (`border: 1px solid color-mix(in srgb, white 12%, transparent)`) and an inset highlight (`box-shadow: inset 0 1px 0 rgba(255,255,255,0.08)`) so the edge refracts. Solid fallback under `prefers-reduced-transparency`.
 - **Shape-consistency lock.** Pick ONE radius scale and apply it everywhere (or a documented rule: buttons pill, cards 16px, inputs 8px, followed consistently). Round buttons on a sharp-cornered layout is broken.
 
-**3.C.A The double-bezel (soft-premium family).** Never place a card flatly on the background — nest it like machined hardware: an **outer shell** (faint fill `rgba(255,255,255,0.05)`, hairline border, small padding `0.375rem`-`0.5rem`, large radius `2rem`) wrapping an **inner core** (its own background, inner highlight `box-shadow: inset 0 1px 1px rgba(255,255,255,0.15)`, concentric smaller radius `calc(2rem - 0.375rem)`). The CTA is a **button-in-button**: a trailing arrow inside its own circular wrapper flush with the button's right padding.
+**3.C.A The double-bezel (soft-premium family).** Never place a card flatly on the background — nest it like machined hardware: an **outer shell** (faint fill `rgba(255,255,255,0.05)`, hairline border, padding `0.375rem`, radius `2rem`) wrapping an **inner core** (its own background, inner highlight `inset 0 1px 1px rgba(255,255,255,0.15)`, concentric radius `calc(2rem - 0.375rem)`). The CTA is a **button-in-button**: a trailing arrow in its own circular wrapper, flush with the button's right padding.
 
 ### 3.D Premium Motion Vocabulary (Tier-0 Framework)
-All baseline UI animations must remain fully native to CSS or SVG paths so they look flawless instantly upon paint.
+All baseline UI animation must stay native to CSS or SVG paths, so it looks flawless instantly upon paint.
 *   **Kinetic Type Masking:** Headlines utilizing `clip-path` bounding boxes to reveal letters gracefully via cubic-bezier timings.
 *   **Self-Drawing Vectors:** Core decorative shapes running `stroke-dasharray` loops to dynamically draw themselves.
 *   **Micro-Interactions (Magnetic UI):** Buttons scaling subtly, shifting internal arrows on hover, or running controlled internal light sweeps via moving linear gradients.
 *   **Organic Drifting:** Decorative elements executing minor non-linear floating paths via CSS keyframes.
 
 ```css
-/* Example Tier-0 Kinetic Shifting for Fallback Backgrounds */
-@keyframes auroraDrift {
-  0% { background-position: 0% 50%; }
-  50% { background-position: 100% 50%; }
-  100% { background-position: 0% 50%; }
-}
+/* Tier-0 kinetic drift for a fallback background */
+@keyframes auroraDrift { 0%, 100% { background-position: 0% 50%; } 50% { background-position: 100% 50%; } }
 @media (prefers-reduced-motion: no-preference) {
-  .kinetic-fallback-bg {
-    background-size: 200% 200%;
-    animation: auroraDrift 20s ease infinite;
-  }
+  .kinetic-fallback-bg { background-size: 200% 200%; animation: auroraDrift 20s ease infinite; }
 }
 ```
 
 ### 3.E Motion principles + engine tracks
+**Motion vocabulary is gated by one fact: does this site keep its client bundle?** Default NO — the page prerenders with `csr = false` and on ripple the bundle is pruned, so `onMount`, `use:` actions, IntersectionObserver and WebGL NEVER run. Only the per-site `keepsClientBundle` flag keeps them, off unless this site declared it.
+- **Bundle off (assume this):** all motion is CSS — 3.D's vocabulary plus `animation-timeline: view()` for scroll reveal and `<details>` for accordions. Cap MOTION_INTENSITY at 4.
+- **Bundle on:** those JS paths run, and still only ENHANCE markup that already renders correctly (3.F).
 - **Motion must be motivated.** Name what it communicates (hierarchy, sequence, feedback, state change) before adding it. "It looked cool" is not a reason.
-- **Motion claimed = motion shown.** If MOTION_INTENSITY > 4 the page actually moves (hero entrance, scroll-reveal on key sections, CTA hover). If you can't ship working motion, drop the dial to 3 and ship a clean static page — never half-built motion.
+- **Motion claimed = motion shown.** If MOTION_INTENSITY > 4 the page actually moves (hero entrance, scroll-reveal on key sections, CTA hover). Motion that needs JS this site doesn't keep is a claim, not a page: rebuild it in CSS or confirm the bundle. If you can't ship working motion, drop the dial to 3 and ship a clean static page — never half-built motion.
 - **Hardware-accelerate.** Animate only `transform` and `opacity` — never `top`/`left`/`width`/`height`. `will-change` sparingly. No `window.addEventListener('scroll')` (re-runs every frame) — use IntersectionObserver, a `use:` action, or CSS scroll-driven animations. No custom cursors, scroll-hijacking, or mouse-follow. Blur/noise only on fixed, `pointer-events: none` overlays.
 - **Custom easing = premium.** For soft-premium use `cubic-bezier(0.32, 0.72, 0, 1)` and 600-800ms fade-up, not `linear`/`ease`.
 
-**Svelte-track specifics** (only on the Svelte engine): Scroll reveal → a `use:` action + CSS class (a tiny `reveal` action adds `.in` when the element enters the viewport; CSS transitions `opacity`/`transform`; reveal immediately under `prefers-reduced-motion`). State → runes (`let open = $state(false)`, `let active = $state(0)`, `const total = $derived(...)`) with the resting value set in the initializer so it prerenders. Count-ups → `tweened`/`spring` seeded from the FINAL value (markup bakes the real total), then in `onMount` reset to 0 and animate up client-only:
-```svelte
-<script>
-  import { tweened } from 'svelte/motion';
-  import { cubicOut } from 'svelte/easing';
-  import { onMount } from 'svelte';
-  const total = 3850;
-  const n = tweened(total, { duration: 900, easing: cubicOut }); // resting = real
-  onMount(() => {
-    if (matchMedia('(prefers-reduced-motion: reduce)').matches) return;
-    n.set(0, { duration: 0 });
-    n.set(total);            // animate up, client-only
-  });
-</script>
-<span>{$n.toLocaleString()}</span>   <!-- prerenders as 3,850 -->
-```
-Enter/leave within a section → Svelte `transition:`/`in:`/`out:` on elements whose *content* is already present — polish an existing frame, never gate it. Ambient motion → CSS keyframes (no JS, free at prerender).
+**Svelte-track specifics** (only on the Svelte engine): State → runes (`let open = $state(false)`, `const total = $derived(...)`) with the resting value set in the initializer so it prerenders — free either way. **The next two need the bundle kept:** scroll reveal → a `use:` action adding `.in` on viewport entry (CSS transitions `opacity`/`transform`; reveal immediately under `prefers-reduced-motion`). Count-ups → `tweened` seeded from the FINAL value so the markup prerenders the real total, then reset to 0 and animated up in `onMount` behind a `prefers-reduced-motion` check. Enter/leave within a section → Svelte `transition:`/`in:`/`out:` on elements whose *content* is already present — polish an existing frame, never gate it. Ambient motion → CSS keyframes (no JS, free at prerender).
 
 ### 3.F The static / prerender guardrail (non-negotiable, every engine)
 These pages render to HTML before any JS runs. Taste must never depend on JS to look finished:
 - **Resting state lives in MARKUP.** Every animated/interactive default's final visual state is rendered in the DOM. Never set the resting state only in `onMount` — the prerendered HTML would bake the *start* frame (the empty hero, the `$0` counter, the collapsed accordion). Ask: *"with all JS off, does this section look done?"* If not, move the final state into markup.
-- **Tier-0 = CSS-only motion is the default.** Reveal-on-scroll, hovers, gradient drift, marquees — done in CSS run at paint with no JS.
-- **JS motion (and the WebGL canvas) is opt-in and degrades.** It may ENHANCE a resting state already correct in markup — never CREATE it. The WebGL `<canvas>` always sits over a polished CSS fallback (Module 2.C guardrail).
+- **Tier-0 = CSS-only motion is the default, and the only option without the client bundle (3.E).** JS motion may ENHANCE a resting state already correct in markup, never CREATE it, and the `<canvas>` always sits over a polished CSS fallback (2.C).
 - **Respect `prefers-reduced-motion`.** Wrap non-essential motion in `@media (prefers-reduced-motion: no-preference)`, or reveal immediately on opt-out. Never trap content behind an animation.
 - **No layout shift.** Set `width`/`height` (or `aspect-ratio`) on every image and media element so the page doesn't jump as assets load.
 - **Support light AND dark** where the family allows: use `prefers-color-scheme` and design both variants so hierarchy and contrast hold in each.
@@ -267,9 +244,9 @@ These pages render to HTML before any JS runs. Taste must never depend on JS to 
 
 Before finalizing any section output, you must strictly pass this checklist:
 - [ ] **Vision Ledger Declared:** the `<!-- Creative Direction Declaration -->` block is at the absolute top; a one-line **Design Read** (Visual DNA Token) is stated; a **family** (2.E) and ONE Trend Engine identity (2.A) are picked — inferred, not defaulted, and not asked of the user. **Dials** set from the read (1.D).
-- [ ] **Background Identity Established:** the background architecture is explicitly styled and contextualized (with a CSS fallback if WebGL is active); no plain `#fff`/`#000` page. No layout shift (media has width/height/aspect-ratio).
+- [ ] **Background Identity Established:** the background architecture is explicitly styled (with a CSS fallback if WebGL is active); no plain `#fff`/`#000` page. No layout shift (media has width/height/aspect-ratio).
 - [ ] **Zero Component Repetition:** no two sections use the identical layout composition; no three-equal-card feature row; ≥ 4 different layout families; no 3rd consecutive image+text split. Eyebrow count ≤ `ceil(sectionCount / 3)`; no section-number eyebrows.
-- [ ] **No JavaScript Reliance for UI:** aside from the WebGL canvas, every asset, interaction, state transformation, and mask functions flawlessly with all client JS disabled — resting state in markup, not `onMount` (3.F).
+- [ ] **No JavaScript Reliance for UI:** every asset, interaction, state transformation, and mask functions flawlessly with all client JS disabled — resting state in markup, not `onMount` (3.F). Without the client bundle (3.E), zero author JS: no `onMount`, no `use:`, no observer, no canvas.
 - [ ] **Hero discipline:** not centered-over-gradient; ≤ 2-line headline, ≤ 20-word subtext, CTA above the fold, ≤ 4 text elements, `min-height: 100dvh`.
 - [ ] **Color:** one accent < 80% saturation, no purple/neon glow; color-consistency lock holds; highest contrast reserved for the primary CTA; premium-consumer palette not the banned beige+brass default; off-black not `#000`, off-white not `#fff`.
 - [ ] **Type:** distinctive display face (not Inter for premium); serif only if the family/brief justifies it and it isn't Fraunces/Instrument; body measure-capped at ~62ch. **Shape-consistency lock:** one radius system throughout.

--- a/tests/mutations/skill_budget.json
+++ b/tests/mutations/skill_budget.json
@@ -1,0 +1,29 @@
+[
+  {
+    "label": "budget: the skill grows past its ceiling and nothing notices",
+    "file": "src/pocketpaw/bundled_skills/_bundled/skills/pocketpaw-design-taste/SKILL.md",
+    "find": "# 2026 Creative Director System for Paw Sites",
+    "replace": "# 2026 Creative Director System for Paw Sites\n\n### 0.A Section Rhythm Calibration (added without measuring the budget)\nBefore composing, score the page's vertical rhythm so no two adjacent bands\nshare a silhouette. Assign each section a weight from 1 (a hairline stat row)\nto 5 (a full-bleed media band), then read the sequence aloud as a number\nstring. A good page reads 3-1-4-2-5-1-3; a slop page reads 3-3-3-3-3. If two\nneighbours share a weight, change one of them: swap a card grid for a divided\nlist, or promote a quote to a full-width band. Weight is not height. A tall\nsection of body copy is still a 1 if its silhouette is a single column, and a\nshort asymmetric bento is a 4 because the eye has to travel. Score the hero\nlast, since it inherits whatever contrast the second section fails to provide.\n\nCalibrate the rhythm against the density dial: at DENSITY 1-3 the string should\naverage below 3, at 4-7 it may average above. A page whose weights climb\nmonotonically reads as a pitch deck rather than a site, so plant at least one\ndescent before the final CTA. When a section resists scoring, that is the\nsignal it is doing two jobs and should be split. Re-score after every layout\nedit, because a single swap changes both neighbours.\n\n### 0.B Optical Alignment Pass (also unmeasured)\nMathematical alignment is not optical alignment. Circular and triangular marks\nread as misaligned when their bounding boxes agree, so nudge a play triangle\nright by about 8% of its width and let a circular badge overshoot a flat edge\nslightly. Punctuation hangs outside the measure: an opening quote sits in the\nmargin, not on the text edge. Uppercase tracking opens as size drops, so an\neyebrow at 12px wants more letter-spacing than the same words at 32px, and a\ndisplay headline usually wants negative tracking instead.\n\nCheck alignment against the strongest edge in the composition rather than the\ncontainer. If a section has a full-bleed image on the left, the text column\naligns to the image's optical edge, not to the page gutter. Baselines matter\nmore than boxes: two adjacent cards whose text baselines disagree read as\nbroken even when their tops match exactly.\n",
+    "tests": [
+      "tests/test_bundled_skill_budget.py"
+    ]
+  },
+  {
+    "label": "budget: the ceiling is measured in decoded chars, not wc -c bytes",
+    "file": "tests/test_bundled_skill_budget.py",
+    "find": "    return path.stat().st_size",
+    "replace": "    return len(path.read_text(encoding=\"utf-8\"))",
+    "tests": [
+      "tests/test_bundled_skill_budget.py"
+    ]
+  },
+  {
+    "label": "budget: the fixture reads a path that does not exist",
+    "file": "tests/test_bundled_skill_budget.py",
+    "find": "    return plugin_dir / \"skills\" / \"pocketpaw-design-taste\" / \"SKILL.md\"",
+    "replace": "    return plugin_dir / \"skills\" / \"pocketpaw-design-taste\" / \"SKILL.markdown\"",
+    "tests": [
+      "tests/test_bundled_skill_budget.py"
+    ]
+  }
+]

--- a/tests/test_bundled_skill_budget.py
+++ b/tests/test_bundled_skill_budget.py
@@ -1,0 +1,148 @@
+# tests/test_bundled_skill_budget.py
+# Created: 2026-08-07 (MT-3, feat/design-taste-real-webgl) — bounds the byte
+# size of the one bundled skill that is embedded WHOLE into a system prompt.
+# Nothing else in the repo measures it, so every edit to that file silently
+# changed a per-turn runtime cost.
+"""``pocketpaw-design-taste/SKILL.md`` stays under a stated byte ceiling.
+
+WHY A SIZE TEST EXISTS FOR ONE MARKDOWN FILE. This skill is not merely
+installed for on-demand invocation. ``sites.py``'s ``_design_system_block``
+reads it off disk and inlines its body into the ``/sites`` surface preamble,
+wrapped in ``<design-system name="pocketpaw-design-taste">`` and labelled
+ALREADY LOADED so the agent applies it without a skill call. Every
+site-authoring turn on that surface therefore pays for this file's length, in
+tokens, forever. A prose edit to a SKILL.md reads like a docs change and is
+priced like a prompt change.
+
+The failure mode this guards is documented in ``pocketpaw/CLAUDE.md``: a file
+in this exact class answered a lookup miss with 58,765 chars that did not
+contain the answer. Growth here is not free and it is not visible in review —
+a diff showing "+40 lines of guidance" looks like an improvement.
+
+WHY 34,000 AND NOT THE CURRENT SIZE. The file measured 32,599 before MT-3 and
+32,578 after. A ceiling pinned to the current size fails on the next honest
+one-line fix, which trains people to bump the constant reflexively and turns
+the gate into a formality. 34,000 leaves roughly 4% of headroom: enough for
+ordinary maintenance, far too little to absorb a new module. Raising it is
+allowed and should be argued for in the commit body, not done in passing.
+
+WHAT IT DOES NOT COVER. Only this one skill. The other bundled skills are
+invoked on demand rather than inlined, so their bytes are paid only when used;
+if another skill is ever embedded whole into a preamble, it belongs here too.
+The ceiling is measured on the WHOLE file, matching ``wc -c``, while the
+preamble embeds the frontmatter-stripped body — so the assertion is slightly
+stricter than the runtime cost, which is the right direction for a budget.
+
+Mutations: ``tests/mutations/skill_budget.json``. Run them; a size assertion
+nobody watched fail is precisely the class of gate ``pocketpaw/CLAUDE.md``
+warns about.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pocketpaw.bundled_skills.installer import bundled_skills_plugin_dir
+
+# The ceiling, in bytes, for the design-taste skill. See the module docstring
+# for why this number and not the file's current size.
+DESIGN_TASTE_MAX_BYTES = 34_000
+
+# A read that returns far less than this is a broken path, not a lean skill.
+# Without it, renaming the skill directory would make every assertion below
+# pass on an empty string.
+_IMPLAUSIBLY_SMALL = 10_000
+
+
+def _design_taste_skill() -> Path:
+    """Resolve the skill file through the accessor the SHIPPING code uses.
+
+    ``sites.py`` reaches the file via ``bundled_skills_plugin_dir()``. Reading
+    it any other way here (a hand-built relative path, a copy under tests/)
+    would measure a file that is not necessarily the one served.
+    """
+
+    plugin_dir = bundled_skills_plugin_dir()
+    if plugin_dir is None:
+        pytest.fail(
+            "bundled_skills_plugin_dir() returned None — the bundled plugin "
+            "manifest or skills/ directory is missing from the installed "
+            "package, so the /sites preamble would silently fall back to its "
+            "one-line 'invoke the skill' stub."
+        )
+    return plugin_dir / "skills" / "pocketpaw-design-taste" / "SKILL.md"
+
+
+def _skill_bytes(path: Path) -> int:
+    """Measure the skill the way ``wc -c`` does: bytes on disk.
+
+    The ceiling test goes through this helper rather than measuring inline, so
+    the unit is a single named thing a mutation can flip. ``len(read_text())``
+    would be several hundred short — the file is UTF-8 and full of em-dashes,
+    arrows and typographic quotes — and a ceiling reviewed as "wc -c" but
+    asserted in decoded characters grants unearned headroom.
+    """
+
+    return path.stat().st_size
+
+
+def test_the_fixture_reads_the_real_shipped_skill() -> None:
+    """The measurement is worth exactly what the path is worth.
+
+    MUTATION: point ``_design_taste_skill`` at a name that does not exist, or
+    have it return an empty file. Without this test the ceiling assertion goes
+    green on 0 bytes and reports headroom that does not exist — the same shape
+    as the ``test_preamble_caps.py`` fixture that measured id-less rows.
+    """
+
+    path = _design_taste_skill()
+    assert path.is_file(), f"design-taste SKILL.md not found at {path}"
+
+    size = path.stat().st_size
+    assert size > _IMPLAUSIBLY_SMALL, (
+        f"{path} is only {size} bytes. That is not a lean skill, it is a "
+        "broken read — the ceiling below would pass vacuously."
+    )
+
+
+def test_design_taste_skill_stays_under_its_ceiling() -> None:
+    """The skill's bytes stay inside the budget the /sites preamble pays.
+
+    MUTATION: append ~1,500 chars of plausible guidance to SKILL.md (see
+    ``tests/mutations/skill_budget.json``). Before this test, that edit was
+    invisible: every other assertion on the file checks for the PRESENCE of
+    text, so growth could only ever make them greener.
+    """
+
+    path = _design_taste_skill()
+    size = _skill_bytes(path)
+
+    assert size <= DESIGN_TASTE_MAX_BYTES, (
+        f"{path.name} is {size} bytes, over the {DESIGN_TASTE_MAX_BYTES}-byte "
+        f"ceiling by {size - DESIGN_TASTE_MAX_BYTES}. This file is inlined "
+        "whole into the /sites system prompt, so every byte is a cost on every "
+        "site-authoring turn. Cut something before raising the ceiling, and if "
+        "you do raise it, say why in the commit body."
+    )
+
+
+def test_the_ceiling_is_measured_in_bytes_not_decoded_characters() -> None:
+    """``_skill_bytes`` is ``wc -c``, and for this file that is not ``len()``.
+
+    MUTATION: ``return len(path.read_text(encoding="utf-8"))`` in
+    ``_skill_bytes``. The ceiling test alone does NOT catch that — the file is
+    under the ceiling in either unit, so it stays green while silently
+    measuring a smaller number. This test is what makes the swap visible.
+    """
+
+    path = _design_taste_skill()
+    char_len = len(path.read_text(encoding="utf-8"))
+
+    assert _skill_bytes(path) == len(path.read_bytes())
+    assert _skill_bytes(path) > char_len, (
+        "Expected multi-byte characters in the skill (em-dashes, arrows). If "
+        "this ever becomes equal the file went plain-ASCII, and the ceiling "
+        "unit no longer needs distinguishing — but check before relaxing it."
+    )


### PR DESCRIPTION
Module 2.C sent the creative director to OGL for GLSL shader planes, Three.js for particle swarms, and Threlte on the Svelte track. A Paw Site can install none of them: `templates/package.json.tmpl` is generator-owned and an author's source map supplies files only, so those imports never resolve. The skill was teaching a technique that dies at build time.

## What replaces it

2.C now teaches the canvas by hand — `getContext('webgl')`, a pass-through vertex shader and one fragment shader over a full-screen quad, animated from `u_time` / `u_resolution` in a rAF loop, buffer capped at 2x DPR and the loop stopped off-screen. Then what the technique buys (fluid colour mixing, noise fields, gradient flow) and what it does not (scene graphs, particle swarms).

The canvas guardrail is unchanged: the `<canvas>` sits over a polished CSS fallback, and the page must look premium before the WebGL context initializes. It now also notes that a canvas needs a site that keeps its client bundle.

Motion guidance branches on that flag in five places, defaulting to off. It was spread wider than expected — the MOTION_INTENSITY dial, the Tier-0 vocabulary, the Svelte-track paragraph, all of 3.F, and two checklist items — and the dial cross-referenced the wrong section (motion is 3.E, not 3.C). Fixed.

## The file got smaller

32,599 → 32,578 bytes. No rule, check or ban was dropped. The savings came from prose that carried no rule: a spelled-out devicePixelRatio calculation the reader can derive, a redundant null-context clause the guardrail already covers, a count-up code block folded into prose, and phrase-level compression. Module 2.C is now shorter than the three library bullets it replaced.

## The size guard

`sites.py`'s `_design_system_block` reads this file off disk and inlines its body into the `/sites` surface preamble, labelled ALREADY LOADED. Every site-authoring turn on that surface pays for its length. Nothing measured that, so a prose edit reading like a docs change was quietly repricing a system prompt, and the next one could add 5k without a test noticing.

The ceiling is 34,000 bytes — deliberate headroom, not today's size. A ceiling pinned to the current byte count fails the next legitimate one-line fix and trains people to bump the constant, which is how a gate becomes a formality.

Three tests, because two of them protect the first from passing vacuously.

## Mutations

Written and run per CLAUDE.md, not just described. All three caught. The growth mutation appends 2,123 bytes of plausible new guidance — enough to trip the ceiling, sized like a real edit rather than a token.

Running them also exposed a false docstring in this PR's own first test: it claimed to catch a bytes-versus-chars swap, and could not, because the file is under the ceiling in either unit. That is precisely the failure the mutation rule exists to find, and it was found by mutating rather than by reading.