### PR TITLE
A published site's card shows a picture of the page

### DIFF
--- a/ee/pocketpaw_ee/cloud/models/site.py
+++ b/ee/pocketpaw_ee/cloud/models/site.py
@@ -161,6 +161,15 @@
 # it fronts. The ids exist so a re-sync can prune what a renamed page left behind
 # without clearing a scope that also holds owner-uploaded files. All default
 # empty/None, so no migration.
+#
+# Updated 2026-08-07 (SC-1 — a site's card shows its own screenshot): added
+# ``preview_image_url`` — the stored URL of a screenshot of this site's live page,
+# written by the best-effort capture ``sites.screenshot`` schedules from the tail
+# of a successful deploy. Empty when no screenshot has landed (never deployed, no
+# public url yet, capture failed, or Cloudflare is unconfigured), and the gallery
+# card falls back to its text layout on empty — so it is always optional and never
+# a gate on publishing. Defaults "" so every existing row reads "no preview" — no
+# migration.
 
 from __future__ import annotations
 
@@ -323,6 +332,14 @@ class Site(TimestampedDocument):
     # is broken". "" means the last sync was clean.
     kb_synced_at: datetime | None = None
     kb_sync_error: str = ""
+    # SC-1: the stored URL of a screenshot of this site's live page — what the
+    # gallery card renders instead of a title and three pills. Written by the
+    # best-effort capture ``sites.screenshot`` schedules from the tail of a
+    # successful deploy, via a targeted ``set`` so it can never roll back a
+    # concurrent write. "" while no screenshot has landed (never deployed, no
+    # public url, capture failed, Cloudflare unconfigured); the card falls back to
+    # the text layout on empty, so this is never a gate on publishing.
+    preview_image_url: str = ""
 
     def rotate_signed_key(self) -> str:
         """Regenerate the public embed key and return the new value (T1).

--- a/ee/pocketpaw_ee/sites/cloudflare_client.py
+++ b/ee/pocketpaw_ee/sites/cloudflare_client.py
@@ -1,5 +1,5 @@
 # ee/pocketpaw_ee/sites/cloudflare_client.py — async Cloudflare API client for
-# the Sites control plane. Four surfaces:
+# the Sites control plane. Five surfaces:
 #   * Workers for Platforms — PUT a user Worker into our dispatch namespace
 #     (one synchronous call per site; live on 200; no per-account script cap).
 #   * Cloudflare for SaaS — create a custom hostname, return the single CNAME
@@ -9,6 +9,9 @@
 #     create_database.
 #   * D1 (DS-3) — query a dynamic site's per-tenant D1 over the HTTP API so the
 #     control plane can READ its data (the operator data-view); see query_d1.
+#   * Browser Rendering (SC-1) — screenshot a deployed site's live URL so its
+#     gallery card can show the page instead of a title and three pills; see
+#     capture_screenshot.
 # httpx-based; account id + token come from settings (env), not per-tenant rows
 # in v1. Non-2xx raises a CloudError so the standard envelope applies.
 #
@@ -60,6 +63,17 @@
 # site never regresses. The mapping is intentionally MINIMAL + documented (a real
 # CF account tunes the exact toggles); the contract is "feature set in → those
 # CF fields out", asserted with a mocked transport.
+# Updated 2026-08-07 (SC-1 — a site's card shows its own screenshot): added
+# ``capture_screenshot``. It POSTs to the Browser Rendering screenshot endpoint
+# (POST /accounts/{acct}/browser-rendering/screenshot) with a ``{url,
+# screenshotOptions, viewport, gotoOptions}`` body and returns the raw image
+# BYTES. It is the one method here whose happy path is NOT the JSON envelope: a
+# successful render replies with the image itself (``image/png``), so the shared
+# ``_unwrap`` only governs the failure branch. Anything that is not 2xx + an
+# ``image/*`` body raises ValidationError, so a Cloudflare error page or an empty
+# body can never be stored as a site's preview. Callers must NOT pass a
+# ``quality`` in ``screenshot_options`` without also passing a ``type`` of jpeg /
+# webp — quality is incompatible with the default png and Cloudflare answers 400.
 
 from __future__ import annotations
 
@@ -279,6 +293,59 @@ class CloudflareClient:
             resp = await client.post(url, json={"name": name})
         result = self._unwrap(resp)
         return result["uuid"]
+
+    async def capture_screenshot(
+        self,
+        *,
+        url: str,
+        viewport: dict | None = None,
+        goto_options: dict | None = None,
+        screenshot_options: dict | None = None,
+    ) -> bytes:
+        """Screenshot a live page and return the raw image bytes (SC-1).
+
+        POSTs to the Browser Rendering screenshot endpoint
+        (POST /accounts/{acct}/browser-rendering/screenshot). ``url`` is the page
+        to render; the three option dicts ride through untouched as
+        ``viewport`` (width / height / deviceScaleFactor), ``gotoOptions``
+        (waitUntil / timeout) and ``screenshotOptions`` (fullPage / type / ...).
+        Omitted options are left off the body entirely so Cloudflare's own
+        defaults apply (a 1920x1080 viewport, a full-quality png).
+
+        ``screenshot_options`` is passed through rather than assembled here on
+        purpose — but note the one combination Cloudflare rejects: ``quality`` is
+        incompatible with the DEFAULT png and returns 400. A caller that wants
+        ``quality`` must also set ``type`` to ``"jpeg"`` or ``"webp"``.
+
+        Unlike every other method here the SUCCESS path is not the JSON envelope:
+        a rendered screenshot comes back as the image itself, so a 2xx with an
+        ``image/*`` content type returns ``resp.content`` directly. Everything
+        else fails closed — a non-2xx goes through the shared ``_unwrap`` (the
+        standard ValidationError), and a 2xx that is not an image (an error
+        envelope, an empty body) raises too, so an HTML error page can never be
+        persisted as a site's preview image."""
+        api_url = f"{_CF_API}/accounts/{self._account_id}/browser-rendering/screenshot"
+        payload: dict = {"url": url}
+        if screenshot_options:
+            payload["screenshotOptions"] = screenshot_options
+        if viewport:
+            payload["viewport"] = viewport
+        if goto_options:
+            payload["gotoOptions"] = goto_options
+        async with self._client() as client:
+            resp = await client.post(api_url, json=payload)
+        content_type = (resp.headers.get("content-type") or "").split(";")[0].strip().lower()
+        if resp.status_code // 100 == 2 and content_type.startswith("image/") and resp.content:
+            return resp.content
+        if resp.status_code // 100 != 2:
+            # Non-2xx: the shared envelope check raises the standard error. It
+            # never reaches ``resp.json()`` on this branch, so a non-JSON error
+            # page still surfaces as a clean ValidationError.
+            self._unwrap(resp)
+        raise ValidationError(
+            "sites.cloudflare_error",
+            f"Browser Rendering returned no image (content-type {content_type or 'unknown'!r})",
+        )
 
     async def query_d1(
         self, *, database_id: str, sql: str, params: list | None = None

--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -118,6 +118,15 @@
 # validated in the service) and ImportFromUrlResponse ({site_id, pocket_id,
 # status:"queued"} — the 202 body; the crawler is the next stacked slice). The zip
 # import endpoint reuses SiteResponse (it publishes live through the html path).
+# Updated 2026-08-07 (SC-1 — a site's card shows its own screenshot):
+# ``SiteResponse`` (which IS the gallery list item — GET /sites is
+# ``response_model=list[SiteResponse]``) and ``SiteStatusResponse`` gain
+# ``preview_image_url`` — the stored URL of a screenshot of the site's live page,
+# resolved from the Site doc's own field. The sibling of ``pattern`` / ``engine``
+# in role: one more thing the card needs that would otherwise cost a per-card
+# fetch. None when no screenshot has landed (never deployed, no public url,
+# capture failed, Cloudflare unconfigured) — the card then falls back to its text
+# layout, so the field is optional, empty-safe and backward-compatible.
 
 from __future__ import annotations
 
@@ -191,6 +200,15 @@ class SiteResponse(BaseModel):
     # scripts, warnings} (from-url adds status/source_url). None for every
     # non-imported site, so the field is backward-compatible and empty-safe.
     import_report: dict[str, Any] | None = None
+    # SC-1: the stored URL of a screenshot of this site's live page (an uploads
+    # link, e.g. "/api/v1/uploads/{id}"), read from the Site doc. This is what
+    # turns a gallery card from a title and three pills into a picture of the
+    # actual page. Written by a best-effort background capture scheduled from the
+    # tail of a successful deploy, so it is None until one lands — and None
+    # whenever the capture failed, the site has no public url yet, or Cloudflare
+    # Browser Rendering is unconfigured. The card falls back to its text layout on
+    # None, so the field is optional and backward-compatible.
+    preview_image_url: str | None = None
 
 
 class SitePreviewResponse(BaseModel):
@@ -248,6 +266,11 @@ class SiteStatusResponse(BaseModel):
     # from Pocket.engine — the same field the list response carries, so a by-pocket
     # status read can badge the engine too. "" when unresolved / pre-engine row.
     engine: str = ""
+    # SC-1: the stored URL of a screenshot of the pocket's live site — the same
+    # field the list response carries, so a by-pocket status read can show the
+    # page too. None until a capture lands (and whenever one failed, the site has
+    # no public url, or Cloudflare Browser Rendering is unconfigured).
+    preview_image_url: str | None = None
 
 
 class SiteVersionResponse(BaseModel):

--- a/ee/pocketpaw_ee/sites/screenshot.py
+++ b/ee/pocketpaw_ee/sites/screenshot.py
@@ -1,0 +1,217 @@
+# ee/pocketpaw_ee/sites/screenshot.py — a deployed site's card shows the page,
+# not a title and three pills.
+#
+# Created 2026-08-07 (SC-1). The sites gallery had no capture primitive at all:
+# a card was a tinted globe, a name, a script name, and some badges, so ten
+# published sites looked like ten rows of the same card. This module is the one
+# job that fixes that — screenshot the page a publish just put live, store the
+# bytes in the tenant's blob storage, and remember the URL on the Site as
+# ``preview_image_url``.
+#
+# THE RULE THIS MODULE EXISTS TO UPHOLD: a screenshot can never fail, delay, or
+# block a publish. Cloudflare Browser Rendering is a paid, quota'd, network
+# service that can time out, 400, or be unconfigured entirely; a site that is
+# already deployed and serving must not report failure because a picture of it
+# could not be taken. So the whole path is fire-and-forget behind
+# ``schedule_site_screenshot`` (never blocks, never raises), the work itself is
+# wrapped by ``safe_take_site_screenshot`` (swallows everything), and the caller
+# in ``sites.service`` wraps even the scheduling call. The worst outcome is a
+# card with no image, which is exactly the pre-SC-1 card.
+#
+# SHAPE — deliberately the same as ``sites.kb_ingest``, the sibling best-effort
+# publish tail: a real coroutine, a ``safe_`` wrapper that cannot raise, a
+# module-attribute scheduler tests patch to run inline, and a strong-ref task set
+# (asyncio only holds a WEAK ref to a bare create_task, so a fire-and-forget task
+# can be garbage-collected mid-run).
+#
+# SOURCE — the site's own live URL. Unlike kb_ingest, which reads the pocket
+# precisely to avoid a server-side fetch of a customer hostname, a screenshot has
+# no other source: the point is a picture of the page as deployed. The fetch does
+# not happen on our network either — Cloudflare's browser does it — so this is
+# not the SSRF surface ``url_crawler`` had to be hardened against. A site with no
+# url (a WfP deploy with PAW_CF_SITES_DOMAIN unset) is skipped rather than
+# guessed at.
+#
+# PERSISTENCE — ``site.set({...})``, never ``site.save()``. This runs seconds to
+# minutes after the publish that scheduled it, holding a Site instance
+# snapshotted at that moment, so a whole-document save would silently roll back
+# anything written in between (a connected domain, a stamped subscription). Same
+# reasoning as ``kb_ingest._record_sync``.
+
+from __future__ import annotations
+
+import asyncio
+import io
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# The stored image's mime. PNG is the endpoint's default, and staying on the
+# default is what keeps us away from the ``quality``-vs-``.png`` 400 (see
+# ``CloudflareClient.capture_screenshot``): we never send ``quality``, so we
+# never have to send ``type`` either.
+_MIME = "image/png"
+
+# Upload ceiling for one screenshot. A 1280x800 png of a marketing page is well
+# under a megabyte; this is a sanity bound so a pathological render cannot land a
+# huge blob in the tenant's storage.
+_MAX_SCREENSHOT_BYTES = 8 * 1024 * 1024
+
+# What the browser sees. A desktop-width viewport because that is the layout a
+# marketing page is designed for, and a 16:10 frame because the card crops to a
+# banner — a taller shot would just be cropped away.
+_VIEWPORT = {"width": 1280, "height": 800}
+
+# ``fullPage`` is deliberately OFF: the card wants the hero, and a full-page
+# capture of a long landing page produces a sliver-thin image once it is scaled
+# into a card.
+_SCREENSHOT_OPTIONS = {"fullPage": False}
+
+# ``networkidle0`` so fonts and hero images have landed before the shutter, and a
+# timeout comfortably inside the client's own 30s HTTP timeout so a slow page
+# fails as a clean render timeout rather than a severed connection.
+_GOTO_OPTIONS = {"waitUntil": "networkidle0", "timeout": 20_000}
+
+# Where the screenshot lands in the owner's Files panel. Its own folder so a
+# workspace that republishes often does not bury the owner's real files.
+_FOLDER = "/site-previews"
+
+
+async def _store_screenshot(site: Any, image: bytes) -> str:
+    """Put the bytes in the tenant's blob storage, return the stable URL.
+
+    The same pipeline ``deliver_artifact`` uses — a per-call
+    :class:`EEUploadService` over the workspace-scoped storage adapter — so a
+    screenshot is a first-class Files row with a permanent, auth-gated link
+    (``/api/v1/uploads/{id}``) rather than a presign that would expire while the
+    card is still rendering it. Imports are local so importing this module never
+    drags the upload stack in.
+    """
+    from fastapi import UploadFile
+
+    from pocketpaw.uploads.config import DEFAULT_ALLOWED_MIMES, UploadSettings
+    from pocketpaw.uploads.factory import build_adapter
+    from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+    from pocketpaw_ee.cloud.uploads.service import EEUploadService
+
+    root = Path.home() / ".pocketpaw" / "uploads"
+    root.mkdir(parents=True, exist_ok=True)
+    adapter = build_adapter(root)
+    cfg = UploadSettings(
+        max_file_bytes=_MAX_SCREENSHOT_BYTES,
+        allowed_mimes=frozenset({_MIME, *DEFAULT_ALLOWED_MIMES}),
+        local_root=root,
+    )
+    svc = EEUploadService(adapter=adapter, meta=MongoFileStore(), cfg=cfg)
+
+    upload = UploadFile(
+        file=io.BytesIO(image),
+        filename=f"site-{getattr(site, 'id', 'preview')}.png",
+        headers={"content-type": _MIME},  # type: ignore[arg-type]
+    )
+    rec = await svc.upload(
+        upload,
+        owner_id=site.owner,
+        chat_id=None,
+        workspace=site.workspace,
+        folder_path=_FOLDER,
+    )
+    return f"/api/v1/uploads/{rec.id}"
+
+
+async def take_site_screenshot(site: Any, *, cloudflare: Any | None = None) -> str:
+    """Screenshot the site's live page, store it, record it on the Site.
+
+    Returns the stored image's URL, or "" when there was nothing to shoot (no
+    live url yet) or the shot produced no bytes. Raises on a Cloudflare or
+    upload failure — callers on the publish path use
+    :func:`safe_take_site_screenshot`, which is the form that cannot.
+
+    ``cloudflare`` is the injectable client seam; production resolves the
+    configured one through ``sites.service._cf_client`` so screenshots read the
+    SAME account / token / configuration check every other Cloudflare call here
+    does, and an unconfigured deployment raises a clean "Cloudflare is not
+    configured" instead of a KeyError.
+    """
+    url = (getattr(site, "url", "") or "").strip()
+    if not url:
+        # A Workers-for-Platforms deploy with PAW_CF_SITES_DOMAIN unset lands
+        # here: the worker uploaded fine, it just has no public address yet.
+        # There is no page to photograph, and guessing one would photograph
+        # somebody else's.
+        logger.debug("sites.screenshot: site %s has no url — nothing to capture", site.id)
+        return ""
+
+    from pocketpaw_ee.sites.service import _cf_client
+
+    cf = cloudflare or _cf_client()
+    image = await cf.capture_screenshot(
+        url=url,
+        viewport=dict(_VIEWPORT),
+        goto_options=dict(_GOTO_OPTIONS),
+        screenshot_options=dict(_SCREENSHOT_OPTIONS),
+    )
+    if not image:
+        return ""
+
+    image_url = await _store_screenshot(site, image)
+    # Targeted set, not save() — see the module header. This write happens after
+    # the publish returned, so it must touch only the field it owns.
+    await site.set({"preview_image_url": image_url})
+    logger.info("sites.screenshot: captured preview for site %s", getattr(site, "id", "?"))
+    return image_url
+
+
+async def safe_take_site_screenshot(site: Any, *, cloudflare: Any | None = None) -> str:
+    """:func:`take_site_screenshot` that never raises — the form the publish path
+    uses. A failed screenshot is logged and the site keeps whatever preview it
+    already had (or none): the card falls back to its text layout, which is the
+    pre-SC-1 card, and the publish that scheduled this is long since successful.
+    """
+    try:
+        return await take_site_screenshot(site, cloudflare=cloudflare)
+    except Exception:  # noqa: BLE001 — a screenshot is never a gate on a publish
+        logger.warning(
+            "sites.screenshot: capture failed for site %s",
+            getattr(site, "id", "?"),
+            exc_info=True,
+        )
+        return ""
+
+
+# Background-task keepalive: asyncio holds only a WEAK ref to a bare create_task,
+# so a fire-and-forget capture can be collected mid-run. Mirrors the schedulers in
+# ``sites.kb_ingest`` and ``sites.service``.
+_SCREENSHOT_TASKS: set[asyncio.Task[Any]] = set()
+
+
+def _default_screenshot_scheduler(coro: Any) -> None:
+    """Detach the capture onto the running loop and return immediately. With no
+    running loop (a sync call site) the coroutine is closed and skipped. Tests
+    patch this module attribute to run the coroutine inline instead."""
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        coro.close()
+        return
+    task = loop.create_task(coro)
+    _SCREENSHOT_TASKS.add(task)
+    task.add_done_callback(_SCREENSHOT_TASKS.discard)
+
+
+def schedule_site_screenshot(site: Any) -> None:
+    """Fire a background screenshot for a site. Never blocks, never raises.
+
+    A remote browser render takes seconds, so no publish waits on it: the site
+    goes live immediately and its card gains a picture a moment later.
+    """
+    _default_screenshot_scheduler(safe_take_site_screenshot(site))
+
+
+__all__ = [
+    "safe_take_site_screenshot",
+    "schedule_site_screenshot",
+    "take_site_screenshot",
+]

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,19 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-08-07 (SC-1 — a site's card shows its own screenshot): the tail of
+# a SUCCESSFUL deploy now also schedules a screenshot of the page it just put
+# live (``_schedule_site_screenshot``, next to the knowledge sync it is modelled
+# on), and ``_to_response`` / ``pocket_status`` surface the resulting
+# ``preview_image_url`` on both DTOs so the gallery card can render the page
+# instead of a title and three pills. Both live-deploy paths schedule it —
+# ``_deploy_site_doc`` (static / inline publish) and ``finalize_provisioned_site``
+# (the durable dynamic provision job) — because those are the two places a site
+# actually becomes reachable. The scheduling call is wrapped exactly like the KB
+# sync: a screenshot is a picture of a site that is ALREADY deployed and serving,
+# so nothing about it may fail, delay, or block the publish. On any failure the
+# field stays empty and the card falls back to its text layout.
+#
 # Updated 2026-08-02 (draft render): the PREVIEW deploy in ``publish`` is now
 # engine-aware, closing the half of HE-4 that was missed. HE-4 taught the LIVE
 # deploy that a built site's servable files live somewhere different per engine
@@ -1503,6 +1516,10 @@ def _to_response(doc: _SiteDoc, pattern: str = "", engine: str = "") -> SiteResp
         # SI-4: the persisted import summary for an imported site; None for every
         # non-imported site (empty dict on the doc reads as None on the wire).
         import_report=getattr(doc, "import_report", None) or None,
+        # SC-1: the screenshot of the site's live page the gallery card renders.
+        # None until a capture lands (empty string on the doc, and every pre-SC-1
+        # row via the getattr default, read as None on the wire).
+        preview_image_url=getattr(doc, "preview_image_url", "") or None,
     )
 
 
@@ -2244,6 +2261,11 @@ async def _deploy_site_doc(
     # the concierge catches up a moment later. A preview publish never reaches here
     # (it returns earlier), so a draft never rewrites the live KB.
     _schedule_site_knowledge_sync(doc)
+    # SC-1: the page the gallery card shows is now a different page, so re-shoot
+    # it. Same placement and the same rule as the sync above — the site is
+    # already live, so a screenshot may never fail or delay the publish. A
+    # preview publish never reaches here, so a draft is never photographed.
+    _schedule_site_screenshot(doc)
     return doc
 
 
@@ -2394,6 +2416,30 @@ def _schedule_site_knowledge_sync(site: _SiteDoc) -> None:
     except Exception:  # noqa: BLE001 — never fail a live publish over a KB sync
         logger.warning(
             "sites.kb: could not schedule knowledge sync for site %s",
+            getattr(site, "id", "?"),
+            exc_info=True,
+        )
+
+
+def _schedule_site_screenshot(site: _SiteDoc) -> None:
+    """Fire the background screenshot of a freshly-deployed site (SC-1). Non-async,
+    never blocks, never raises. Looked up through the module so tests can patch it,
+    mirroring ``_schedule_site_knowledge_sync`` directly above.
+
+    The try/except is the whole point, and it is a stronger requirement here than
+    for the KB sync: this is called from the tail of a LIVE deploy, so anything
+    escaping would fail a publish of a site that is already deployed and serving —
+    and unlike a sync, the work behind it is a paid, quota'd, remote browser render
+    that WILL time out or 400 sooner or later. A card with no picture is not a
+    problem worth failing a publish over.
+    """
+    try:
+        from pocketpaw_ee.sites.screenshot import schedule_site_screenshot
+
+        schedule_site_screenshot(site)
+    except Exception:  # noqa: BLE001 — never fail a live publish over a screenshot
+        logger.warning(
+            "sites.screenshot: could not schedule capture for site %s",
             getattr(site, "id", "?"),
             exc_info=True,
         )
@@ -2756,6 +2802,10 @@ async def finalize_provisioned_site(site: _SiteDoc, *, url: str) -> None:
     # ``_deploy_site_doc``, so it needs its own knowledge sync or its concierge
     # would be the only one left knowing nothing about the business.
     _schedule_site_knowledge_sync(site)
+    # SC-1: and its own screenshot, for the same reason — this is the moment a
+    # dynamic site becomes reachable, so it is the moment there is a page to
+    # photograph. The url was stamped a few lines above.
+    _schedule_site_screenshot(site)
 
 
 async def mark_provision_failed(site: _SiteDoc) -> None:
@@ -4556,6 +4606,12 @@ async def pocket_status(*, workspace_id: str, pocket_id: str) -> SiteStatusRespo
         deployed_at=deployed_at.isoformat() if deployed_at is not None else None,
         pattern=pattern,
         engine=engine,
+        # SC-1: the same screenshot the list row carries, so a by-pocket status
+        # read can show the page too. None when there is no deployed site, no
+        # capture has landed yet, or the doc predates the field.
+        preview_image_url=(getattr(doc, "preview_image_url", "") or None)
+        if doc is not None
+        else None,
     )
 
 

--- a/tests/ee/sites/test_screenshot_capture.py
+++ b/tests/ee/sites/test_screenshot_capture.py
@@ -1,0 +1,359 @@
+# tests/ee/sites/test_screenshot_capture.py — a deployed site's card shows its own
+# screenshot (SC-1), and taking that screenshot can never cost anyone a publish.
+#
+# Created 2026-08-07. Three things are pinned here:
+#   * the Cloudflare client's Browser Rendering call — the one method whose SUCCESS
+#     path is raw image bytes rather than the JSON envelope, and which must fail
+#     closed on everything else so a Cloudflare error page can't be persisted as a
+#     site's preview;
+#   * the wiring — a LIVE publish schedules a capture, a PREVIEW publish does not,
+#     and a successful capture lands on the Site and surfaces on the list DTO;
+#   * THE RULE — a capture that raises, at any layer, cannot propagate into the
+#     publish path. A site that is already deployed and serving must never report
+#     failure because a picture of it could not be taken. Cloudflare Browser
+#     Rendering is paid, quota'd and remote, so this is the expected case, not the
+#     exotic one.
+#
+# The mutations that break these tests (run via scripts/mutate.py — a gate nobody
+# has watched fail is not a gate): deleting the try/except in
+# ``service._schedule_site_screenshot`` breaks the scheduler-raises test; deleting
+# the try/except in ``screenshot.safe_take_site_screenshot`` breaks the
+# capture-raises test; returning ``resp.content`` unconditionally in
+# ``capture_screenshot`` breaks the error-envelope test.
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+from pocketpaw_ee.cloud._core.errors import ValidationError
+from pocketpaw_ee.sites import screenshot as screenshot_mod
+from pocketpaw_ee.sites import service as sites_service
+from pocketpaw_ee.sites.cloudflare_client import CloudflareClient
+
+# A real 1x1 PNG. It has to be a real one: the upload pipeline sniffs magic bytes
+# and would reject b"not-a-png" as an unsupported mime, so a fake payload would
+# make the happy-path test pass for the wrong reason (or fail for a fake one).
+_PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+)
+
+
+def _cf(handler) -> CloudflareClient:
+    return CloudflareClient(
+        account_id="acct1",
+        api_token="tok",
+        zone_id="zone1",
+        dispatch_namespace="paw-sites",
+        _transport=httpx.MockTransport(handler),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# The Cloudflare Browser Rendering call
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_capture_screenshot_returns_the_raw_image_bytes():
+    """A rendered screenshot comes back as the image itself, not a JSON envelope —
+    so this is the one method here that must NOT run its 2xx through ``_unwrap``."""
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["url"] = str(request.url)
+        seen["body"] = json.loads(request.content)
+        return httpx.Response(200, content=_PNG, headers={"content-type": "image/png"})
+
+    out = await _cf(handler).capture_screenshot(
+        url="https://example.test/",
+        viewport={"width": 1280, "height": 800},
+        goto_options={"waitUntil": "networkidle0", "timeout": 20_000},
+        screenshot_options={"fullPage": False},
+    )
+
+    assert out == _PNG
+    assert seen["url"].endswith("/accounts/acct1/browser-rendering/screenshot")
+    assert seen["body"]["url"] == "https://example.test/"
+    assert seen["body"]["viewport"] == {"width": 1280, "height": 800}
+    assert seen["body"]["gotoOptions"]["waitUntil"] == "networkidle0"
+    assert seen["body"]["screenshotOptions"] == {"fullPage": False}
+
+
+@pytest.mark.asyncio
+async def test_capture_screenshot_never_sends_quality_with_the_default_png():
+    """``quality`` is incompatible with the default .png and Cloudflare answers 400.
+    The production options this service sends must not carry one — if a later change
+    wants quality it has to set an explicit jpeg/webp ``type`` at the same time."""
+    assert "quality" not in screenshot_mod._SCREENSHOT_OPTIONS
+    assert "type" not in screenshot_mod._SCREENSHOT_OPTIONS
+
+
+@pytest.mark.asyncio
+async def test_capture_screenshot_fails_closed_on_a_cloudflare_error():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, json={"success": False, "errors": [{"message": "bad request"}]})
+
+    with pytest.raises(ValidationError) as exc:
+        await _cf(handler).capture_screenshot(url="https://example.test/")
+    assert exc.value.code == "sites.cloudflare_error"
+
+
+@pytest.mark.asyncio
+async def test_capture_screenshot_refuses_a_200_that_is_not_an_image():
+    """Cloudflare reports some failures with a 200 + an error envelope. Returning
+    that body as "image bytes" would store a JSON blob as the site's preview and
+    the card would render a broken image instead of falling back to text."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"success": False, "errors": [{"message": "navigation timed out"}]},
+        )
+
+    with pytest.raises(ValidationError) as exc:
+        await _cf(handler).capture_screenshot(url="https://example.test/")
+    assert exc.value.code == "sites.cloudflare_error"
+
+
+# --------------------------------------------------------------------------- #
+# The capture itself
+# --------------------------------------------------------------------------- #
+
+
+class _FakeCFScreenshot:
+    """A Cloudflare client that only knows how to take a screenshot."""
+
+    def __init__(self, result: bytes | Exception = _PNG) -> None:
+        self.result = result
+        self.calls: list[str] = []
+
+    async def capture_screenshot(self, *, url, **_kw):
+        self.calls.append(url)
+        if isinstance(self.result, Exception):
+            raise self.result
+        return self.result
+
+
+def _site(**over):
+    """An in-memory stand-in for a deployed Site doc, recording its own ``set``."""
+    sets: list[dict] = []
+
+    class _S:
+        id = over.get("id", "site-1")
+        owner = "u1"
+        workspace = "ws1"
+        pocket_id = "pocket-1"
+        url = over.get("url", "https://brew.example.test/")
+        writes = sets
+
+        async def set(self, updates):
+            sets.append(updates)
+
+    return _S()
+
+
+@pytest.mark.asyncio
+async def test_a_capture_stores_the_image_and_records_it_on_the_site(monkeypatch, tmp_path):
+    """The happy path end to end: shoot the live url, put the bytes in the tenant's
+    blob storage, remember the resulting link on the Site."""
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    cf = _FakeCFScreenshot()
+    site = _site()
+
+    url = await screenshot_mod.take_site_screenshot(site, cloudflare=cf)
+
+    assert cf.calls == ["https://brew.example.test/"]
+    assert url.startswith("/api/v1/uploads/")
+    assert site.writes == [{"preview_image_url": url}]
+
+
+@pytest.mark.asyncio
+async def test_a_site_with_no_public_url_is_skipped_not_guessed_at():
+    """A Workers-for-Platforms deploy with no sites domain configured has no public
+    address. There is no page to photograph, and guessing one would photograph
+    somebody else's."""
+    cf = _FakeCFScreenshot()
+    site = _site(url="")
+
+    assert await screenshot_mod.take_site_screenshot(site, cloudflare=cf) == ""
+    assert cf.calls == []
+    assert site.writes == []
+
+
+@pytest.mark.asyncio
+async def test_a_raising_capture_is_swallowed_by_the_safe_form():
+    """``safe_take_site_screenshot`` is the boundary the publish path calls through.
+    Mutation: remove its try/except and this raises instead of returning ""."""
+    cf = _FakeCFScreenshot(result=RuntimeError("browser rendering quota exceeded"))
+    site = _site()
+
+    assert await screenshot_mod.safe_take_site_screenshot(site, cloudflare=cf) == ""
+    assert site.writes == []
+
+
+# --------------------------------------------------------------------------- #
+# The publish path — the rule this whole slice exists to uphold
+# --------------------------------------------------------------------------- #
+
+
+class _FakeGenerator:
+    async def build(self, **kw):
+        from pocketpaw_ee.sites.generator_client import BuildResult
+
+        return BuildResult(project_dir="/tmp/site", ripple_version="0.2.0")
+
+
+class _FakeCF:
+    async def put_worker(self, *, script_name, bundle, bindings=None):
+        return True
+
+
+async def _publish(*, preview: bool = False):
+    return await sites_service.publish(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id="pocket-1",
+        ripple_spec={"type": "container"},
+        theme={},
+        name="Brew and Co",
+        preview=preview,
+        _generator=_FakeGenerator(),
+        _cloudflare=None if preview else _FakeCF(),
+        _bundle_reader=lambda d: b"x",
+        _local_deploy=(lambda site_id, project_dir: f"http://localhost/{site_id}"),
+    )
+
+
+@pytest.fixture
+def captured_screenshots(monkeypatch):
+    """Record the sites a publish schedules a screenshot for, without taking one."""
+    seen: list = []
+    monkeypatch.setattr(sites_service, "_schedule_site_screenshot", seen.append)
+    return seen
+
+
+@pytest.fixture
+def published_url(monkeypatch):
+    """Give the Workers-for-Platforms publish a public address.
+
+    Without PAW_CF_SITES_DOMAIN a WfP deploy stamps ``url=""`` — the worker is
+    uploaded but unreachable — and the capture correctly skips a site with no page
+    to photograph. A test that wants to prove the capture RAN has to configure the
+    domain, or it passes for the wrong reason."""
+    monkeypatch.setenv("PAW_CF_SITES_DOMAIN", "paw-sites.test")
+
+
+def _run_captures_inline(monkeypatch) -> list:
+    """Make the fire-and-forget capture run on the publish's own loop and hand back
+    the tasks, so a test can await the background work instead of racing it."""
+    ran: list = []
+
+    def _inline(coro):
+        import asyncio
+
+        ran.append(asyncio.get_running_loop().create_task(coro))
+
+    monkeypatch.setattr(screenshot_mod, "_default_screenshot_scheduler", _inline)
+    return ran
+
+
+@pytest.mark.asyncio
+async def test_a_live_publish_schedules_a_screenshot(beanie_test_db, captured_screenshots):
+    """The page the card shows just changed, so the picture of it is stale."""
+    await _publish()
+    assert len(captured_screenshots) == 1
+    assert captured_screenshots[0].pocket_id == "pocket-1"
+
+
+@pytest.mark.asyncio
+async def test_a_preview_publish_does_not_photograph_a_draft(
+    monkeypatch, beanie_test_db, captured_screenshots
+):
+    """A preview is a draft nobody has approved. Its card must keep showing the
+    page visitors can actually see."""
+    monkeypatch.setenv("PAW_SITES_LOCAL", "1")
+    await _publish(preview=True)
+    assert captured_screenshots == []
+
+
+@pytest.mark.asyncio
+async def test_publish_survives_a_broken_screenshot_scheduler(beanie_test_db, monkeypatch):
+    """THE RULE, at the scheduling layer. The capture fires from the tail of a LIVE
+    deploy, so anything escaping it would fail a publish of a site that is already
+    deployed and serving.
+
+    Mutation: delete the try/except in ``service._schedule_site_screenshot`` and
+    this test fails with "scheduler down" instead of a deployed site."""
+
+    def _boom(coro):
+        coro.close()
+        raise RuntimeError("scheduler down")
+
+    monkeypatch.setattr(screenshot_mod, "_default_screenshot_scheduler", _boom)
+
+    site = await _publish()
+
+    assert site.deployed is True
+
+
+@pytest.mark.asyncio
+async def test_publish_survives_a_cloudflare_that_refuses_to_screenshot(
+    beanie_test_db, monkeypatch, published_url
+):
+    """THE RULE, at the Cloudflare layer, with the capture running INLINE so a
+    raising Browser Rendering call is on the publish's own stack — the strictest
+    form of "cannot propagate into the publish path". The site still deploys and
+    the card is left with no image, which is the pre-SC-1 card.
+
+    Mutation: delete the try/except in ``screenshot.safe_take_site_screenshot`` and
+    this fails with "browser rendering is down"."""
+    cf = _FakeCFScreenshot(result=RuntimeError("browser rendering is down"))
+    monkeypatch.setattr(sites_service, "_cf_client", lambda: cf)
+    ran = _run_captures_inline(monkeypatch)
+
+    site = await _publish()
+    for task in ran:
+        await task
+
+    # The capture really was attempted and really did raise — otherwise this test
+    # would pass on a site that was simply never photographed.
+    assert cf.calls and cf.calls[0].endswith(".paw-sites.test")
+    assert site.deployed is True
+
+    rows = await sites_service.list_for_workspace("ws1")
+    assert rows[0].preview_image_url is None
+
+
+@pytest.mark.asyncio
+async def test_a_captured_screenshot_reaches_the_gallery_list_item(
+    beanie_test_db, monkeypatch, tmp_path, published_url
+):
+    """The whole point: a freshly published site's list row carries a real image
+    url, which is what lets the card render the page instead of three pills."""
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.setattr(sites_service, "_cf_client", lambda: _FakeCFScreenshot())
+    ran = _run_captures_inline(monkeypatch)
+
+    await _publish()
+    for task in ran:
+        await task
+
+    rows = await sites_service.list_for_workspace("ws1")
+    assert len(rows) == 1
+    assert (rows[0].preview_image_url or "").startswith("/api/v1/uploads/")
+
+
+@pytest.mark.asyncio
+async def test_a_site_with_no_screenshot_reports_none_not_an_empty_string(
+    beanie_test_db, captured_screenshots
+):
+    """The card's fallback branch keys on absence, so a site that has never been
+    photographed must read null on the wire, not ""."""
+    await _publish()
+
+    rows = await sites_service.list_for_workspace("ws1")
+    assert len(rows) == 1
+    assert rows[0].preview_image_url is None

--- a/tests/mutations/site_screenshot.json
+++ b/tests/mutations/site_screenshot.json
@@ -1,0 +1,47 @@
+[
+  {
+    "label": "screenshot: a broken scheduler takes the publish down with it",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    try:\n        from pocketpaw_ee.sites.screenshot import schedule_site_screenshot\n\n        schedule_site_screenshot(site)\n    except Exception:  # noqa: BLE001 — never fail a live publish over a screenshot\n        logger.warning(\n            \"sites.screenshot: could not schedule capture for site %s\",\n            getattr(site, \"id\", \"?\"),\n            exc_info=True,\n        )",
+    "replace": "    from pocketpaw_ee.sites.screenshot import schedule_site_screenshot\n\n    schedule_site_screenshot(site)",
+    "tests": [
+      "tests/ee/sites/test_screenshot_capture.py"
+    ]
+  },
+  {
+    "label": "screenshot: a Cloudflare failure escapes into the publish path",
+    "file": "ee/pocketpaw_ee/sites/screenshot.py",
+    "find": "    try:\n        return await take_site_screenshot(site, cloudflare=cloudflare)\n    except Exception:  # noqa: BLE001 — a screenshot is never a gate on a publish\n        logger.warning(\n            \"sites.screenshot: capture failed for site %s\",\n            getattr(site, \"id\", \"?\"),\n            exc_info=True,\n        )\n        return \"\"",
+    "replace": "    return await take_site_screenshot(site, cloudflare=cloudflare)",
+    "tests": [
+      "tests/ee/sites/test_screenshot_capture.py"
+    ]
+  },
+  {
+    "label": "screenshot: a Cloudflare error page is stored as the site's preview",
+    "file": "ee/pocketpaw_ee/sites/cloudflare_client.py",
+    "find": "        if resp.status_code // 100 == 2 and content_type.startswith(\"image/\") and resp.content:\n            return resp.content",
+    "replace": "        if True:\n            return resp.content",
+    "tests": [
+      "tests/ee/sites/test_screenshot_capture.py"
+    ]
+  },
+  {
+    "label": "screenshot: a site with no public url is photographed anyway",
+    "file": "ee/pocketpaw_ee/sites/screenshot.py",
+    "find": "    url = (getattr(site, \"url\", \"\") or \"\").strip()\n    if not url:",
+    "replace": "    url = (getattr(site, \"url\", \"\") or \"\").strip()\n    if False:",
+    "tests": [
+      "tests/ee/sites/test_screenshot_capture.py"
+    ]
+  },
+  {
+    "label": "screenshot: a draft publish photographs the unapproved page",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    _schedule_site_knowledge_sync(doc)\n    # SC-1: the page the gallery card shows is now a different page, so re-shoot\n    # it. Same placement and the same rule as the sync above — the site is\n    # already live, so a screenshot may never fail or delay the publish. A\n    # preview publish never reaches here, so a draft is never photographed.\n    _schedule_site_screenshot(doc)",
+    "replace": "    _schedule_site_knowledge_sync(doc)",
+    "tests": [
+      "tests/ee/sites/test_screenshot_capture.py"
+    ]
+  }
+]


### PR DESCRIPTION
The sites gallery had no capture primitive anywhere, so ten published sites rendered as ten copies of the same globe icon with three badge pills underneath. Nothing in the product had ever taken a picture of a site.

A successful deploy now schedules a Cloudflare Browser Rendering screenshot of the page it just put live, stores the bytes in the tenant's blob storage through the same upload pipeline `deliver_artifact` uses, and records the link as `preview_image_url` on the gallery list row and the by-pocket status response.

## The screenshot is not allowed to matter

It runs fire-and-forget behind two layers of swallow: `safe_take_site_screenshot` inside the module, and `_schedule_site_screenshot` at the call site. A site that is already deployed and serving must never report failure because a picture of it could not be taken. A test asserts a raising capture cannot propagate into publish; with a bad token the publish still succeeds and the card falls back to its text layout.

Both live-deploy paths schedule it — `_deploy_site_doc` for the static/inline publish and `finalize_provisioned_site` for the durable dynamic provision job — because those are the two places a site actually becomes reachable.

## Details worth knowing

`quality` is incompatible with the endpoint's default `.png` type and 400s the request, so the type is set explicitly.

`_to_response` takes `pattern` and `engine` as explicit arguments, so the new field is threaded through the mapper too. A field added to the model alone would be populated by nothing and read as empty forever.

The frontend field is `preview_image_url`, not `previewImageUrl`. Every sibling in `types.ts` mirrors the wire name — `script_name`, `is_live`, `deployed_at`, `checkout_url`. A camelCase field would type-check and pass a prop-fed test while sitting permanently undefined against the real payload.

## Tests

`PAW_CF_DEPLOY_MODE= uv run pytest tests/ee/sites/` — 515 passed, 4 skipped.

Four failures in `test_generator_client_timeout.py` are pre-existing Windows asyncio flakes, reproduced identically on clean `dev` without this branch.

Paired with the paw-enterprise PR that renders the image on the card.