### PR TITLE
Register the react engine and split the deploy-shape question out

### DIFF
--- a/ee/pocketpaw_ee/sites/engines.py
+++ b/ee/pocketpaw_ee/sites/engines.py
@@ -4,9 +4,19 @@
 # engine do", replacing scattered ``== "svelte"`` / ``!= "svelte"`` string-equality
 # checks across the sites + cloud/surface code. Workspace-charter principle: one
 # canonical reference module beats phased propagation.
+#
+# Edited 2026-08-07 (RX-1 — the react engine): registered ``"react"`` across the
+# four predicates and added a FIFTH, :func:`emits_server_worker`. react is the first
+# engine that needs a per-site Node build yet emits NO server entry, which broke the
+# assumption ``workers_deploy`` had been making — that ``needs_node_build`` could
+# stand in for "there is a ``_worker.js`` to deploy". Those were the same fact for
+# ripple/svelte/html and are not for react, so the deploy shape now reads its own
+# predicate. That is this module's whole design: capabilities stay orthogonal, and a
+# new engine that combines them in a new way adds a predicate rather than overloading
+# one.
 """Engine capability predicates for Paw Sites.
 
-Three site-generation engines are modeled:
+Four site-generation engines are modeled:
 
 * ``"ripple"`` — the DEFAULT. The pocket's authored content is a ``rippleSpec`` (a
   widget tree). Publishing runs a per-site Node build (``bun install`` + Vite +
@@ -20,17 +30,26 @@ Three site-generation engines are modeled:
   (HE-1/3/4/6) — this module already KNOWS about it (that is the point) so the rest
   of the codebase can branch on a capability instead of a string as html lands, but
   no behaviour changes for html today.
+* ``"react"`` — the pocket's content is a ``{path: contents}`` source map of
+  hand-written React files. Publishing runs a per-site Node build (``bun install`` +
+  Vite), but that build is a plain **SSG**: it emits a static ``dist/`` with the
+  markup prerendered by ``react-dom/server`` and NO server entry. So react is the
+  first engine that is source-map-backed AND build-requiring AND server-less — the
+  combination that motivated :func:`emits_server_worker`.
 
-The four predicates split the engine question into orthogonal capabilities:
+The five predicates split the engine question into orthogonal capabilities:
 
 * :func:`is_source_engine` — is the content a ``{path: contents}`` source map
-  (svelte, html) or a rippleSpec (ripple)?
+  (svelte, html, react) or a rippleSpec (ripple)?
 * :func:`content_key` — which pocket-dict key holds the authored content
   (``"source"`` vs ``"rippleSpec"``)?
 * :func:`needs_node_build` — does publishing run a per-site Node build (ripple,
-  svelte) or not (html)?
+  svelte, react) or not (html)?
 * :func:`static_output_rel` — where, relative to the generated project dir, do the
   deployable static assets land?
+* :func:`emits_server_worker` — does that output include a ``_worker.js`` server
+  entry that must be deployed as a Worker *script* (ripple, svelte), or is it a
+  purely static asset tree deployed as an assets-only Worker (html, react)?
 
 Unknown-engine policy — **fall back to ripple, never raise.** The codebase reads
 ``pocket.get("engine") or "ripple"`` in roughly a dozen places: an empty or missing
@@ -50,22 +69,41 @@ _DEFAULT_ENGINE = "ripple"
 
 # Engines whose pocket content is a {path: contents} source map (as opposed to a
 # rippleSpec). The one place the "source map vs rippleSpec" fact is encoded.
-_SOURCE_MAP_ENGINES: frozenset[str] = frozenset({"svelte", "html"})
+_SOURCE_MAP_ENGINES: frozenset[str] = frozenset({"svelte", "html", "react"})
 
-# Engines that require a per-site Node build (bun install + Vite/SvelteKit build +
-# workerd smoke render) before deploy. Note html is source-map-backed yet needs NO
-# build — "source map" and "node build" are deliberately distinct capabilities.
-_NODE_BUILD_ENGINES: frozenset[str] = frozenset({"ripple", "svelte"})
+# Engines that require a per-site Node build (bun install + a Vite/SvelteKit build +
+# for the SvelteKit tracks a workerd smoke render) before deploy. Note html is
+# source-map-backed yet needs NO build — "source map" and "node build" are
+# deliberately distinct capabilities.
+_NODE_BUILD_ENGINES: frozenset[str] = frozenset({"ripple", "svelte", "react"})
+
+# Engines whose build emits a ``_worker.js`` SERVER entry that must be deployed as a
+# Worker script (with ``main`` + ``nodejs_compat``), as opposed to a purely static
+# tree deployed as an assets-only Worker.
+#
+# This is NOT a synonym for ``_NODE_BUILD_ENGINES``, and conflating the two is the
+# specific bug RX-1 had to avoid: react runs a full Node build and still emits no
+# server entry, because its build is an SSG that prerenders to static HTML. Pointing
+# a wrangler config's ``main`` at a ``dist/_worker.js`` that a react build never
+# writes fails the deploy outright. html reaches the same assets-only shape from the
+# other direction (no build at all), which is why this predicate is about the OUTPUT
+# and never about how the output was produced.
+_SERVER_WORKER_ENGINES: frozenset[str] = frozenset({"ripple", "svelte"})
 
 # Per-engine deployable static-output dir, relative to the generated project dir.
 # ripple/svelte emit the SvelteKit Cloudflare adapter output (``_CF_OUTPUT_REL`` in
 # ``sites/workers_deploy.py`` today); html has no build, so the project dir itself
 # IS the static root (``"."``) — the emitted ``index.html`` is the deploy root and
-# the served artifact stays byte-identical to the authored source (HE-1/HE-4).
+# the served artifact stays byte-identical to the authored source (HE-1/HE-4);
+# react emits Vite's default client-build dir (``dist``), which the generator's
+# prerender pass rewrites in place so the served index.html carries the rendered
+# markup. The react SSR bundle deliberately builds OUTSIDE this dir, so the
+# prerenderer is never uploaded to the edge.
 _STATIC_OUTPUT_REL: dict[str, str] = {
     "ripple": ".svelte-kit/cloudflare",
     "svelte": ".svelte-kit/cloudflare",
     "html": ".",
+    "react": "dist",
 }
 
 
@@ -85,8 +123,8 @@ def normalize_engine(engine: str | None) -> str:
 def is_source_engine(engine: str | None) -> bool:
     """True when the engine's content is a ``{path: contents}`` source map.
 
-    ``"svelte"`` and ``"html"`` are source engines; ``"ripple"`` is not (its content
-    is a rippleSpec). Accepts ``str | None`` because most call sites pass
+    ``"svelte"``, ``"html"`` and ``"react"`` are source engines; ``"ripple"`` is not
+    (its content is a rippleSpec). Accepts ``str | None`` because most call sites pass
     ``pocket.get("engine")`` directly.
     """
     return normalize_engine(engine) in _SOURCE_MAP_ENGINES
@@ -95,7 +133,8 @@ def is_source_engine(engine: str | None) -> bool:
 def content_key(engine: str | None) -> str:
     """The pocket-dict key holding this engine's authored content.
 
-    ``"source"`` for a source-map engine (svelte, html); ``"rippleSpec"`` for ripple.
+    ``"source"`` for a source-map engine (svelte, html, react); ``"rippleSpec"`` for
+    ripple.
     """
     return "source" if is_source_engine(engine) else "rippleSpec"
 
@@ -104,10 +143,30 @@ def needs_node_build(engine: str | None) -> bool:
     """True when publishing this engine runs a per-site Node build.
 
     ``"ripple"`` and ``"svelte"`` run ``bun install`` + a Vite/SvelteKit build + a
-    workerd smoke render. ``"html"`` does not — the generator emits a plain static
-    dir with no build step.
+    workerd smoke render. ``"react"`` runs ``bun install`` + a Vite build (client
+    bundle, SSR bundle, prerender pass) — a real build, but an SSG with no workerd
+    step. ``"html"`` does not build at all — the generator emits a plain static dir.
     """
     return normalize_engine(engine) in _NODE_BUILD_ENGINES
+
+
+def emits_server_worker(engine: str | None) -> bool:
+    """True when this engine's build output includes a ``_worker.js`` server entry.
+
+    ``"ripple"`` / ``"svelte"`` → True: adapter-cloudflare emits a SvelteKit worker
+    inside the static-output dir, so the deploy config needs ``main`` pointed at it
+    plus ``nodejs_compat``, and an ``.assetsignore`` that keeps wrangler from
+    uploading the server entry as a public asset.
+
+    ``"html"`` / ``"react"`` → False: the output is a purely static tree, deployed as
+    an assets-only Worker (``assets.directory`` and nothing else).
+
+    Deliberately SEPARATE from :func:`needs_node_build`. Those two agreed for every
+    engine until react, which builds and yet emits no server entry — so a deploy path
+    that asked "does it build?" when it meant "is there a script to run?" would point
+    ``main`` at a ``dist/_worker.js`` that does not exist and fail the deploy.
+    """
+    return normalize_engine(engine) in _SERVER_WORKER_ENGINES
 
 
 def static_output_rel(engine: str | None) -> str:
@@ -118,5 +177,9 @@ def static_output_rel(engine: str | None) -> str:
     * html → ``"."`` — the generator writes the static site directly into the
       project dir (a plain ``{path: contents}`` tree, no framework build subdir), so
       the project dir IS the static root.
+    * react → ``"dist"`` — Vite's client-build output, whose ``index.html`` the
+      generator's prerender pass rewrites in place to carry the server-rendered
+      markup. Explicitly NOT the SvelteKit path: nothing on the react track produces
+      ``.svelte-kit/cloudflare``.
     """
     return _STATIC_OUTPUT_REL[normalize_engine(engine)]

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -2138,8 +2138,9 @@ async def _deploy_site_doc(
         from pocketpaw_ee.sites import workers_deploy as workers_deploy_mod
 
         deploy_w = workers_deploy or workers_deploy_mod.deploy_workers
-        # HE-4: pass the engine so an html site deploys as an assets-only Worker
-        # (no server script), while ripple/svelte keep the SvelteKit-worker config.
+        # HE-4 / RX-1: pass the engine so an html OR react site deploys as an
+        # assets-only Worker (no server script — react builds, but to a prerendered
+        # static dist/), while ripple/svelte keep the SvelteKit-worker config.
         url = await deploy_w(site_id, build.project_dir, engine=engine)
     else:  # "wfp"
         cf = cloudflare or _cf_client()

--- a/ee/pocketpaw_ee/sites/workers_deploy.py
+++ b/ee/pocketpaw_ee/sites/workers_deploy.py
@@ -16,6 +16,17 @@
 # SvelteKit-worker config + the ``_worker.js`` ``.assetsignore`` (the default engine is
 # ``"ripple"``, so every existing caller is byte-for-byte unchanged).
 #
+# Updated 2026-08-07 (RX-1 — the react engine) — the assets-only branch now keys on
+# ``emits_server_worker(engine)`` instead of ``not needs_node_build(engine)``. Those
+# two questions had the same answer for ripple/svelte/html, so the old condition read
+# correctly by coincidence. ``engine="react"`` breaks the coincidence: it runs a full
+# ``bun install`` + Vite build and STILL emits no server entry, because that build is
+# an SSG that prerenders to a static ``dist/``. Under the old condition react would
+# have taken the SvelteKit branch and written ``main: "dist/_worker.js"`` for a file
+# no react build produces, failing the deploy on a missing ``main``. So react joins
+# html on the assets-only path — with ``assets.directory: "dist"`` — and the question
+# this module asks is now about the OUTPUT SHAPE, never about how it was produced.
+#
 # This is the third deploy target for a Paw Site, beside the LOCAL static server
 # (local_server.deploy_local — dev/smoke) and Workers-for-Platforms
 # (cloudflare_client.put_worker — the multi-tenant dispatch namespace). The
@@ -70,7 +81,7 @@ from pathlib import Path
 
 from pocketpaw_ee.cloud._core.errors import Internal, ValidationError
 from pocketpaw_ee.sites._wrangler import wrangler_argv as _wrangler_argv
-from pocketpaw_ee.sites.engines import needs_node_build, static_output_rel
+from pocketpaw_ee.sites.engines import emits_server_worker, static_output_rel
 
 logger = logging.getLogger(__name__)
 
@@ -88,13 +99,20 @@ _CF_OUTPUT_REL = ".svelte-kit/cloudflare"
 # deploy step writes it.
 _ASSETSIGNORE_LINES = ("_worker.js", "_routes.json", "_headers")
 
-# The .assetsignore contents for an html deploy. An html site's ``assets.directory``
-# is the project ROOT (``static_output_rel("html") == "."``), which also holds the
-# deploy scaffold — ``wrangler.jsonc`` and this ``.assetsignore`` — so wrangler would
-# otherwise upload the config file as a public asset (it only auto-excludes the config
-# when the asset dir is a SUBDIR, per the Cloudflare static-assets docs). There is no
-# ``_worker.js`` on this path; the exclusion is the config files, not a server entry.
-_HTML_ASSETSIGNORE_LINES = ("wrangler.jsonc", ".assetsignore")
+# The .assetsignore contents for an ASSETS-ONLY deploy (html, react — anything with
+# no ``_worker.js``). An html site's ``assets.directory`` is the project ROOT
+# (``static_output_rel("html") == "."``), which also holds the deploy scaffold —
+# ``wrangler.jsonc`` and this ``.assetsignore`` — so wrangler would otherwise upload
+# the config file as a public asset (it only auto-excludes the config when the asset
+# dir is a SUBDIR, per the Cloudflare static-assets docs). There is no ``_worker.js``
+# on these paths; the exclusion is the config files, not a server entry.
+#
+# react's asset dir IS a subdir (``dist``), so wrangler already excludes the config —
+# but ``.assetsignore`` itself is written INSIDE the asset dir on every engine, and
+# excluding it is what stops it being served. Naming a ``wrangler.jsonc`` that isn't
+# in ``dist/`` is a harmless no-op, so both engines share one list rather than
+# maintaining a near-identical second one.
+_ASSETS_ONLY_ASSETSIGNORE_LINES = ("wrangler.jsonc", ".assetsignore")
 
 # wrangler reads the worker name + name-segment of the workers.dev URL from
 # ``wrangler.jsonc``'s ``name``. It must match this (lowercase alnum + hyphen,
@@ -144,20 +162,28 @@ def _worker_name(site_id: str) -> str:
 def _wrangler_jsonc(name: str, engine: str = "ripple", d1_database_id: str | None = None) -> str:
     """The clean wrangler config for a workers.dev deploy (the proven recipe).
 
-    HE-4 — the config is ENGINE-AWARE:
+    HE-4 — the config is ENGINE-AWARE. RX-1 — it keys on ``emits_server_worker``,
+    NOT ``needs_node_build``:
 
-    * html (``not needs_node_build``) → an ASSETS-ONLY Worker. The generator emits a
-      raw static tree (no ``_worker.js``), so the config drops ``main`` and
-      ``nodejs_compat`` and just serves ``assets.directory`` (``static_output_rel`` →
-      ``"."``, the project root). An assets-only Worker with no ``main`` is legal —
-      ``assets.directory`` is the only required key — and it ships ZERO bytes of
-      JavaScript for a form-less brochure.
-    * ripple / svelte (``needs_node_build``) → the SvelteKit Cloudflare worker,
+    * html / react (``not emits_server_worker``) → an ASSETS-ONLY Worker. The build
+      output is a static tree with no ``_worker.js``, so the config drops ``main``
+      and ``nodejs_compat`` and just serves ``assets.directory``
+      (``static_output_rel`` → ``"."`` for html, ``"dist"`` for react). An
+      assets-only Worker with no ``main`` is legal — ``assets.directory`` is the only
+      required key — and it ships ZERO bytes of JavaScript for a form-less brochure.
+    * ripple / svelte (``emits_server_worker``) → the SvelteKit Cloudflare worker,
       UNCHANGED. ``main`` points at the worker entry adapter-cloudflare emits INSIDE
       the asset dir (``static_output_rel`` → ``.svelte-kit/cloudflare``), and
       ``assets.directory`` points at that SAME dir (the ``.assetsignore`` we write
       keeps wrangler from uploading the worker entry as an asset). ``nodejs_compat``
       is what the SvelteKit worker needs at runtime.
+
+    Why the predicate changed: until react, "runs a Node build" and "emits a server
+    entry" were the same set, so ``needs_node_build`` read correctly here by
+    coincidence. react runs a full Vite build and prerenders to a purely static
+    ``dist/`` — asking the build question would have written ``main:
+    "dist/_worker.js"`` for a file that is never generated, and wrangler fails the
+    deploy on a missing ``main``.
 
     ``workers_dev: true`` publishes to the free ``<name>.<subdomain>.workers.dev`` URL.
 
@@ -174,9 +200,11 @@ def _wrangler_jsonc(name: str, engine: str = "ripple", d1_database_id: str | Non
     API; ``writeback.ts`` warns and skips), so omitting them costs durability
     buffering, never a dropped lead."""
     output_rel = static_output_rel(engine)
-    # html: an assets-only Worker — no server script, so no ``main`` / ``nodejs_compat``
-    # and no D1 (dynamic html is out of scope). Just serve the static tree.
-    if not needs_node_build(engine):
+    # html / react: an assets-only Worker — no server script, so no ``main`` /
+    # ``nodejs_compat`` and no D1 (dynamic sites on these tracks are out of scope,
+    # since neither has a server runtime to read a binding). Just serve the static
+    # tree the build left behind.
+    if not emits_server_worker(engine):
         config: dict[str, object] = {
             "name": name,
             "compatibility_date": "2024-09-23",
@@ -233,14 +261,16 @@ def _write_deploy_files(
     re-publish so a stale config can never linger.
 
     HE-4 — engine-aware. The asset dir is ``static_output_rel(engine)``
-    (``.svelte-kit/cloudflare`` for ripple/svelte, ``"."`` for html). The
-    ``.assetsignore`` differs by engine:
+    (``.svelte-kit/cloudflare`` for ripple/svelte, ``"."`` for html, ``"dist"`` for
+    react). The ``.assetsignore`` differs by whether the engine emits a server entry
+    (RX-1 — ``emits_server_worker``, not ``needs_node_build``):
 
     * ripple/svelte → drops the Pages worker entry (``_worker.js`` + friends) so
       wrangler does not upload the server entry as a static asset.
-    * html → the asset dir IS the project root, which also holds ``wrangler.jsonc`` +
-      ``.assetsignore``, so it drops THOSE (the deploy scaffold) — otherwise wrangler
-      serves the config file as a public asset.
+    * html/react → there is no server entry to hide; what must not be served is the
+      deploy scaffold itself (``wrangler.jsonc`` + ``.assetsignore``). For html the
+      asset dir IS the project root, so both files sit in it; for react only
+      ``.assetsignore`` does, and naming the other is a harmless no-op.
 
     ``d1_database_id`` adds the dynamic site's D1 binding to the emitted config
     (ripple/svelte only)."""
@@ -253,7 +283,9 @@ def _write_deploy_files(
             "sites.workers_no_build",
             "The static build output is missing — the site must be built before a workers deploy.",
         )
-    ignore_lines = _ASSETSIGNORE_LINES if needs_node_build(engine) else _HTML_ASSETSIGNORE_LINES
+    ignore_lines = (
+        _ASSETSIGNORE_LINES if emits_server_worker(engine) else _ASSETS_ONLY_ASSETSIGNORE_LINES
+    )
     (out_dir / ".assetsignore").write_text("\n".join(ignore_lines) + "\n")
     Path(project_dir, _CONFIG_FILENAME).write_text(_wrangler_jsonc(name, engine, d1_database_id))
 
@@ -277,12 +309,13 @@ async def deploy_workers(
     ``https://<name>.<subdomain>.workers.dev`` URL (parsed from wrangler's stdout,
     falling back to constructing it from PAW_CF_WORKERS_SUBDOMAIN).
 
-    HE-4 — ``engine`` selects the config shape. html deploys as an ASSETS-ONLY Worker
-    (no ``main`` / ``_worker.js``, ``assets.directory == "."``, and an ``.assetsignore``
-    that keeps the config out of the served tree); ripple/svelte deploy the SvelteKit
-    Cloudflare worker unchanged. The default (``"ripple"``) preserves the exact prior
-    behaviour for every existing caller — svelte resolves to the same
-    ``.svelte-kit/cloudflare`` output.
+    HE-4 / RX-1 — ``engine`` selects the config shape, via ``emits_server_worker``.
+    html and react deploy as an ASSETS-ONLY Worker (no ``main`` / ``_worker.js``, an
+    ``assets.directory`` of ``"."`` and ``"dist"`` respectively, and an
+    ``.assetsignore`` that keeps the deploy scaffold out of the served tree);
+    ripple/svelte deploy the SvelteKit Cloudflare worker unchanged. The default
+    (``"ripple"``) preserves the exact prior behaviour for every existing caller —
+    svelte resolves to the same ``.svelte-kit/cloudflare`` output.
 
     ``d1_database_id`` (DYNAMIC ripple/svelte sites) binds the site's per-tenant D1 as
     ``DB``, so a dynamic site can serve its live data WITHOUT a Workers-for-Platforms

--- a/tests/ee/sites/test_engines.py
+++ b/tests/ee/sites/test_engines.py
@@ -4,6 +4,14 @@
 # Created 2026-07-10 (HE-2). Covers all three modeled engines (ripple / svelte /
 # html) plus the empty / missing / unknown-engine fallback contract that the
 # scattered ``pocket.get("engine") or "ripple"`` call sites relied on.
+#
+# Edited 2026-08-07 (RX-1 — the react engine): added react to every predicate's
+# coverage and to the fallback parametrizations, plus a class for the new fifth
+# predicate ``emits_server_worker``. The load-bearing new case is react's
+# combination — source-map-backed AND build-requiring AND server-less — because it
+# is the one that proves ``needs_node_build`` and ``emits_server_worker`` are not
+# the same question. The existing three engines' assertions are untouched, so a
+# regression in ripple/svelte/html still fails here.
 
 from __future__ import annotations
 
@@ -17,6 +25,9 @@ class TestIsSourceEngine:
 
     def test_html_is_source(self) -> None:
         assert engines.is_source_engine("html") is True
+
+    def test_react_is_source(self) -> None:
+        assert engines.is_source_engine("react") is True
 
     def test_ripple_is_not_source(self) -> None:
         assert engines.is_source_engine("ripple") is False
@@ -35,6 +46,9 @@ class TestContentKey:
     def test_html_reads_source(self) -> None:
         assert engines.content_key("html") == "source"
 
+    def test_react_reads_source(self) -> None:
+        assert engines.content_key("react") == "source"
+
     def test_ripple_reads_ripplespec(self) -> None:
         assert engines.content_key("ripple") == "rippleSpec"
 
@@ -49,6 +63,11 @@ class TestNeedsNodeBuild:
 
     def test_svelte_needs_build(self) -> None:
         assert engines.needs_node_build("svelte") is True
+
+    def test_react_needs_build(self) -> None:
+        # A react site is an SSG, not a raw tree: `bun install` + a Vite build (client
+        # bundle, SSR bundle, prerender pass) must run before there is anything to deploy.
+        assert engines.needs_node_build("react") is True
 
     def test_html_skips_build(self) -> None:
         assert engines.needs_node_build("html") is False
@@ -69,19 +88,51 @@ class TestStaticOutputRel:
     def test_html_output_is_project_root(self) -> None:
         assert engines.static_output_rel("html") == "."
 
+    def test_react_output_is_vite_dist(self) -> None:
+        assert engines.static_output_rel("react") == "dist"
+
+    def test_react_output_is_not_the_sveltekit_path(self) -> None:
+        # Nothing on the react track produces .svelte-kit/cloudflare. Were react to
+        # fall through to the ripple default, the deploy would upload an empty dir.
+        assert engines.static_output_rel("react") != ".svelte-kit/cloudflare"
+
     @pytest.mark.parametrize("value", [None, "", "unknown"])
     def test_default_output_matches_ripple(self, value: str | None) -> None:
         assert engines.static_output_rel(value) == ".svelte-kit/cloudflare"
 
 
 class TestNormalizeEngine:
-    @pytest.mark.parametrize("value", ["ripple", "svelte", "html"])
+    @pytest.mark.parametrize("value", ["ripple", "svelte", "html", "react"])
     def test_known_engines_pass_through(self, value: str) -> None:
         assert engines.normalize_engine(value) == value
 
-    @pytest.mark.parametrize("value", [None, "", "  ", "nope", "Svelte", "RIPPLE"])
+    @pytest.mark.parametrize(
+        "value", [None, "", "  ", "nope", "Svelte", "RIPPLE", "React", "reactjs"]
+    )
     def test_empty_missing_unknown_fall_back_to_ripple(self, value: str | None) -> None:
         assert engines.normalize_engine(value) == "ripple"
+
+
+class TestEmitsServerWorker:
+    def test_ripple_emits_a_worker(self) -> None:
+        assert engines.emits_server_worker("ripple") is True
+
+    def test_svelte_emits_a_worker(self) -> None:
+        assert engines.emits_server_worker("svelte") is True
+
+    def test_html_is_assets_only(self) -> None:
+        assert engines.emits_server_worker("html") is False
+
+    def test_react_is_assets_only(self) -> None:
+        # The one that matters: react runs a full Node build and STILL has no server
+        # entry, because that build prerenders to a static dist/.
+        assert engines.emits_server_worker("react") is False
+
+    @pytest.mark.parametrize("value", [None, "", "unknown"])
+    def test_default_emits_a_worker(self, value: str | None) -> None:
+        # Unknown → ripple → the SvelteKit worker config (the safe, least-capable
+        # default: it never skips a guard the real engine would have run).
+        assert engines.emits_server_worker(value) is True
 
 
 def test_source_and_build_are_distinct_capabilities() -> None:
@@ -92,3 +143,28 @@ def test_source_and_build_are_distinct_capabilities() -> None:
     # ... while svelte is both source-map-backed AND build-requiring.
     assert engines.is_source_engine("svelte") is True
     assert engines.needs_node_build("svelte") is True
+
+
+def test_build_and_server_worker_are_distinct_capabilities() -> None:
+    # RX-1's reason for a fifth predicate. Before react, "runs a Node build" and
+    # "emits a _worker.js" picked out the SAME set of engines, so a caller could use
+    # either name and be accidentally right. react separates them: it builds, and it
+    # emits no server entry.
+    assert engines.needs_node_build("react") is True
+    assert engines.emits_server_worker("react") is False
+    # html reaches the same assets-only shape from the other direction — no build.
+    assert engines.needs_node_build("html") is False
+    assert engines.emits_server_worker("html") is False
+    # ... while svelte both builds AND emits a worker, which is why the two questions
+    # were indistinguishable until now.
+    assert engines.needs_node_build("svelte") is True
+    assert engines.emits_server_worker("svelte") is True
+
+
+def test_react_combines_all_three_capabilities_uniquely() -> None:
+    # react is the first engine that is source-map-backed AND build-requiring AND
+    # server-less. Any future refactor that collapses these predicates into fewer
+    # flags has to break one of these three lines.
+    assert engines.is_source_engine("react") is True
+    assert engines.needs_node_build("react") is True
+    assert engines.emits_server_worker("react") is False

--- a/tests/ee/sites/test_workers_deploy.py
+++ b/tests/ee/sites/test_workers_deploy.py
@@ -242,6 +242,108 @@ async def test_html_deploy_passes_config_flag(tmp_path, monkeypatch):
     assert captured["cwd"] == project
 
 
+# ── react engine: builds, yet still assets-only (RX-1) ───────────────────────
+#
+# The section that exists because "runs a Node build" stopped implying "emits a
+# server entry". A react project has a package.json and a real Vite build, so under
+# the old ``needs_node_build`` condition it would have taken the SvelteKit branch —
+# writing ``main: "dist/_worker.js"`` for a file no react build produces, which
+# wrangler rejects. The deploy shape now reads ``emits_server_worker``.
+
+
+def _build_react_project(tmp_path: Path) -> str:
+    """Create a minimal BUILT react project: the Vite client output at ``dist/``
+    (``static_output_rel("react")``) holding the PRERENDERED index.html, plus the
+    project-root package.json a react project genuinely carries — the file whose
+    presence would tempt a deploy path into assuming a server worker exists.
+
+    Deliberately writes NO ``_worker.js`` anywhere: that is the fact under test."""
+    (tmp_path / "package.json").write_text('{"name":"paw-site-x","private":true}')
+    out = tmp_path / "dist"
+    (out / "assets").mkdir(parents=True)
+    (out / "index.html").write_text("<!doctype html><div id=root><main><h1>hi</h1></main></div>")
+    (out / "assets" / "index-abc.css").write_text("h1{color:#111}")
+    return str(tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_react_deploy_is_assets_only_no_main(tmp_path, monkeypatch):
+    """A react site builds to a PRERENDERED static tree with no server worker, so its
+    wrangler config is assets-only — despite the engine needing a full Node build.
+
+    This is the assertion that separates the two capabilities: ``main`` must be
+    absent even though ``needs_node_build("react")`` is True."""
+    project = _build_react_project(tmp_path)
+    site_id = "507f1f77bcf86cd799439011"
+    proc = _FakeProc(0, b"https://paw-site-507f1f77bcf86cd799439011.acct.workers.dev\n", b"")
+    _patch_subprocess(monkeypatch, proc)
+
+    url = await workers_deploy.deploy_workers(site_id, project, engine="react")
+
+    cfg = json.loads(Path(project, "wrangler.jsonc").read_text())
+    assert cfg["name"] == f"paw-site-{site_id}"
+    assert cfg["workers_dev"] is True
+    # Vite's client output, NOT the SvelteKit adapter path.
+    assert cfg["assets"] == {"directory": "dist"}
+    # The assets-only shape drops every server-worker key. A ``main`` here would
+    # point at a dist/_worker.js that react never writes, and wrangler would fail.
+    assert "main" not in cfg
+    assert "compatibility_flags" not in cfg
+    assert "d1_databases" not in cfg
+    assert url == "https://paw-site-507f1f77bcf86cd799439011.acct.workers.dev"
+
+
+@pytest.mark.asyncio
+async def test_react_deploy_never_names_a_worker_entry(tmp_path, monkeypatch):
+    """Belt-and-braces on the same fact, stated as the failure it prevents: nothing
+    in the emitted config may reference a ``_worker.js`` on the react track."""
+    project = _build_react_project(tmp_path)
+    proc = _FakeProc(0, b"https://x.y.workers.dev\n", b"")
+    _patch_subprocess(monkeypatch, proc)
+
+    await workers_deploy.deploy_workers("507f1f77bcf86cd799439011", project, engine="react")
+
+    raw = Path(project, "wrangler.jsonc").read_text()
+    assert "_worker.js" not in raw
+    assert ".svelte-kit" not in raw
+
+
+@pytest.mark.asyncio
+async def test_react_assetsignore_lands_in_dist_and_excludes_itself(tmp_path, monkeypatch):
+    """``.assetsignore`` is written INSIDE the asset dir on every engine, so on react
+    it lands in ``dist/`` — where wrangler would otherwise serve it as a public
+    asset. It must exclude itself, and must NOT list the Pages worker entry (there is
+    no ``_worker.js`` to hide on this track)."""
+    project = _build_react_project(tmp_path)
+    proc = _FakeProc(0, b"https://x.y.workers.dev\n", b"")
+    _patch_subprocess(monkeypatch, proc)
+
+    await workers_deploy.deploy_workers("507f1f77bcf86cd799439011", project, engine="react")
+
+    assetsignore = Path(project, "dist", ".assetsignore").read_text().splitlines()
+    assert ".assetsignore" in assetsignore
+    assert "_worker.js" not in assetsignore
+    # The prerendered page is still there to serve — the deploy scaffold did not
+    # clobber the build output.
+    assert Path(project, "dist", "index.html").read_text().startswith("<!doctype html>")
+
+
+@pytest.mark.asyncio
+async def test_react_deploy_without_a_build_fails_cleanly(tmp_path, monkeypatch):
+    """react needs its build to have RUN — unlike html, generate alone leaves no
+    servable tree. A missing ``dist/`` must raise the clean ValidationError before
+    any subprocess, not produce a config pointing at a directory that isn't there."""
+    (tmp_path / "package.json").write_text('{"name":"paw-site-x"}')
+    proc = _FakeProc(0, b"https://x.y.workers.dev\n", b"")
+    captured = _patch_subprocess(monkeypatch, proc)
+
+    with pytest.raises(ValidationError):
+        await workers_deploy.deploy_workers(
+            "507f1f77bcf86cd799439011", str(tmp_path), engine="react"
+        )
+    assert captured.get("argv") is None
+
+
 @pytest.mark.asyncio
 async def test_static_svelte_config_unchanged_by_engine_default(tmp_path, monkeypatch):
     """Regression guard: the default engine (ripple/svelte) keeps the exact

--- a/tests/mutations/react_engine.json
+++ b/tests/mutations/react_engine.json
@@ -1,0 +1,59 @@
+[
+  {
+    "label": "react deploys as a SvelteKit worker (main points at a dist/_worker.js that no react build writes)",
+    "file": "ee/pocketpaw_ee/sites/engines.py",
+    "find": "_SERVER_WORKER_ENGINES: frozenset[str] = frozenset({\"ripple\", \"svelte\"})",
+    "replace": "_SERVER_WORKER_ENGINES: frozenset[str] = frozenset({\"ripple\", \"svelte\", \"react\"})",
+    "tests": [
+      "tests/ee/sites/test_workers_deploy.py",
+      "tests/ee/sites/test_engines.py"
+    ]
+  },
+  {
+    "label": "emits_server_worker answers the BUILD question instead (the exact conflation RX-1 exists to prevent)",
+    "file": "ee/pocketpaw_ee/sites/engines.py",
+    "find": "    return normalize_engine(engine) in _SERVER_WORKER_ENGINES",
+    "replace": "    return normalize_engine(engine) in _NODE_BUILD_ENGINES",
+    "tests": [
+      "tests/ee/sites/test_workers_deploy.py",
+      "tests/ee/sites/test_engines.py"
+    ]
+  },
+  {
+    "label": "react falls back to ripple's static output (the deploy uploads an empty .svelte-kit dir)",
+    "file": "ee/pocketpaw_ee/sites/engines.py",
+    "find": "    \"react\": \"dist\",",
+    "replace": "",
+    "tests": [
+      "tests/ee/sites/test_engines.py",
+      "tests/ee/sites/test_workers_deploy.py"
+    ]
+  },
+  {
+    "label": "react stops being a source-map engine (publish reads rippleSpec and finds nothing)",
+    "file": "ee/pocketpaw_ee/sites/engines.py",
+    "find": "_SOURCE_MAP_ENGINES: frozenset[str] = frozenset({\"svelte\", \"html\", \"react\"})",
+    "replace": "_SOURCE_MAP_ENGINES: frozenset[str] = frozenset({\"svelte\", \"html\"})",
+    "tests": [
+      "tests/ee/sites/test_engines.py"
+    ]
+  },
+  {
+    "label": "react skips its node build (nothing is ever built, so there is no dist to deploy)",
+    "file": "ee/pocketpaw_ee/sites/engines.py",
+    "find": "_NODE_BUILD_ENGINES: frozenset[str] = frozenset({\"ripple\", \"svelte\", \"react\"})",
+    "replace": "_NODE_BUILD_ENGINES: frozenset[str] = frozenset({\"ripple\", \"svelte\"})",
+    "tests": [
+      "tests/ee/sites/test_engines.py"
+    ]
+  },
+  {
+    "label": "the assets-only .assetsignore stops excluding itself (wrangler serves it as a public asset)",
+    "file": "ee/pocketpaw_ee/sites/workers_deploy.py",
+    "find": "_ASSETS_ONLY_ASSETSIGNORE_LINES = (\"wrangler.jsonc\", \".assetsignore\")",
+    "replace": "_ASSETS_ONLY_ASSETSIGNORE_LINES = (\"wrangler.jsonc\",)",
+    "tests": [
+      "tests/ee/sites/test_workers_deploy.py"
+    ]
+  }
+]


### PR DESCRIPTION
Registers `react` as a fourth site engine, paired with qbtrix/paw-sites#43 which adds the generator side. React is a source-map engine that runs a Node build and emits its static output to `dist`, not to `.svelte-kit/cloudflare`.

## A fifth predicate, and why it isn't the one that was cut

`workers_deploy` decided whether a `_worker.js` exists by asking `needs_node_build(engine)`. That read correctly for ripple, svelte and html purely by coincidence: the two questions — "does this run a Node build" and "does this emit a server worker" — happened to pick out the same engines.

React breaks the coincidence. It runs a full Vite build and emits no server entry. Registering it against the four existing predicates alone produces a config with `main: "dist/_worker.js"` pointing at a file react never writes.

Confirmed against real wrangler (4.101.0) rather than reasoned about, using `deploy --dry-run` on that exact config:

```
✘ [ERROR] The entry-point file at "dist\_worker.js" was not found.
```

The same dry run accepts the assets-only shape react needs. So `emits_server_worker` exists and the deploy branches on it — a question about the OUTPUT shape, never about how the output was produced.

This is a different question from the per-engine JS tier that was deliberately dropped from this program earlier. That one was a per-engine answer to a per-site question, duplicating a fact the route manifest already carried. This one is genuinely per-engine and has no other home: nothing else in the codebase knows whether a build emits a server entry.

The four existing predicates are unchanged for ripple/svelte/html, and an unknown engine still normalizes to ripple — asserted, and covered by a mutation.

## Tests

`tests/ee/sites/test_engines.py` + `test_workers_deploy.py` — 74 passed.

The full `tests/ee/sites` suite does not complete on this box, so it was run in batches: 517 passed, 4 skipped, 4 failed, 6 not run. The 4 failures are the known `test_generator_client_timeout.py` Windows asyncio flakes, which reproduce on clean `dev`. The 6 not-run are `test_plan_gate.py`, which hangs — verified pre-existing by reverting the three changed modules and watching it hang identically. The arithmetic closes: 517 minus 16 new tests is 501, which is the 507 baseline minus plan_gate's 6. No regressions.

All 6 mutations in `tests/mutations/react_engine.json` caught. ruff, format and mypy clean.

## What this does not do

The authoring agent cannot select react yet — the sites surface preamble accepts only html, svelte and ripple. Adding react there without a create-react-site skill would have the preamble name a capability the agent cannot exercise, which this repo has a rule against and a bug from. That work is its own slice.

No react edit lane, as scoped. `builderOrigin` is accepted and does nothing, the same seam html left.