### PR TITLE
A draft site's card gets a picture too

### DIFF
--- a/ee/pocketpaw_ee/sites/cloudflare_client.py
+++ b/ee/pocketpaw_ee/sites/cloudflare_client.py
@@ -74,6 +74,13 @@
 # body can never be stored as a site's preview. Callers must NOT pass a
 # ``quality`` in ``screenshot_options`` without also passing a ``type`` of jpeg /
 # webp — quality is incompatible with the default png and Cloudflare answers 400.
+# Updated 2026-08-07 (SC-2 — drafts get art too): ``capture_screenshot`` now takes
+# ``html`` as an alternative to ``url``. A DRAFT site has no address to point a
+# browser at — that is what makes it a draft — so it is rendered from its own
+# markup instead. Exactly one of the two is required; the method raises on both or
+# neither rather than letting Cloudflare answer 400. Note that an ``html`` body
+# renders at ``about:blank``, so nothing relative inside it resolves: assembling a
+# SELF-CONTAINED document is the caller's job (``sites.draft_markup``).
 
 from __future__ import annotations
 
@@ -297,16 +304,24 @@ class CloudflareClient:
     async def capture_screenshot(
         self,
         *,
-        url: str,
+        url: str = "",
+        html: str = "",
         viewport: dict | None = None,
         goto_options: dict | None = None,
         screenshot_options: dict | None = None,
     ) -> bytes:
-        """Screenshot a live page and return the raw image bytes (SC-1).
+        """Screenshot a page and return the raw image bytes (SC-1, SC-2).
 
         POSTs to the Browser Rendering screenshot endpoint
-        (POST /accounts/{acct}/browser-rendering/screenshot). ``url`` is the page
-        to render; the three option dicts ride through untouched as
+        (POST /accounts/{acct}/browser-rendering/screenshot). The endpoint takes
+        EITHER ``url`` (render the page at that address — a deployed site, SC-1) or
+        ``html`` (render this markup directly — a DRAFT, which by definition has no
+        address, SC-2); exactly one is required, and passing both or neither is a
+        caller bug, so it raises here rather than letting Cloudflare answer 400.
+
+        An ``html`` body renders at ``about:blank``, so NOTHING relative in it
+        resolves — the markup has to arrive self-contained (see
+        ``sites.draft_markup``). The three option dicts ride through untouched as
         ``viewport`` (width / height / deviceScaleFactor), ``gotoOptions``
         (waitUntil / timeout) and ``screenshotOptions`` (fullPage / type / ...).
         Omitted options are left off the body entirely so Cloudflare's own
@@ -324,8 +339,13 @@ class CloudflareClient:
         standard ValidationError), and a 2xx that is not an image (an error
         envelope, an empty body) raises too, so an HTML error page can never be
         persisted as a site's preview image."""
+        if bool(url) == bool(html):
+            raise ValidationError(
+                "sites.cloudflare_error",
+                "Browser Rendering needs exactly one of url or html.",
+            )
         api_url = f"{_CF_API}/accounts/{self._account_id}/browser-rendering/screenshot"
-        payload: dict = {"url": url}
+        payload: dict = {"url": url} if url else {"html": html}
         if screenshot_options:
             payload["screenshotOptions"] = screenshot_options
         if viewport:

--- a/ee/pocketpaw_ee/sites/draft_markup.py
+++ b/ee/pocketpaw_ee/sites/draft_markup.py
@@ -1,0 +1,486 @@
+# ee/pocketpaw_ee/sites/draft_markup.py — ONE self-contained HTML document for a
+# site pocket's CURRENT DRAFT content.
+#
+# Created 2026-08-07 (SC-2 — drafts get art too). SC-1 photographs a site by
+# pointing Cloudflare Browser Rendering at its live URL. A DRAFT has no live URL —
+# that is what makes it a draft — and the builder's own preview address is a
+# 127.0.0.1 bound inside the API process, which Cloudflare's browser cannot reach.
+# So a draft is captured from its MARKUP instead: the screenshot endpoint takes an
+# ``html`` body as an alternative to ``url``, and this module produces that html.
+#
+# THE ONE HARD CONSTRAINT ON THE OUTPUT: Browser Rendering renders an ``html`` body
+# at ``about:blank``. There is no origin, so NO relative reference resolves — not a
+# stylesheet, not an image, not a font. A built page handed over verbatim renders as
+# unstyled text. Everything local therefore has to be folded INTO the document
+# before it leaves here (``inline_document``), and anything local that cannot be
+# folded in is dropped rather than left to 404. Absolute http(s) references are left
+# exactly as they are: Cloudflare's browser is on the internet and can fetch them.
+#
+# WHERE THE MARKUP COMES FROM — a deliberate cost ladder, cheapest rung first,
+# because this runs for a picture on a gallery card and must never be worth its
+# cost:
+#   1. An EXISTING build on disk (``build_home()/<pocket>/<static_output_rel>``).
+#      A pocket that has ever been previewed, armed or published already has its
+#      built output sitting there (PERF-3 keeps the per-pocket build dir), so this
+#      rung costs a few file reads.
+#   2. NO BUILD NEEDED (the ``html`` engine — a zip/from-url import). ``engines``
+#      says an html site runs no Node build and its served artifact is byte-identical
+#      to the authored source, so the pocket's own ``source`` map IS the static tree.
+#      Zero subprocesses.
+#   3. A REAL BUILD (``ripple`` / ``svelte``, never built before). ``bun install`` +
+#      a Vite/SvelteKit build. This rung is gated by
+#      ``PAW_SITES_DRAFT_CAPTURE_BUILD`` and is OFF by default — see
+#      ``build_allowed`` for the measurement that decided that.
+#
+# MEASURED on this workspace (2026-08-07, a real paw-sites-gen + bun toolchain, a
+# small svelte marketing page, other work running alongside):
+#   rung 1  read an existing build and inline it   0.001s
+#   rung 2  html source map straight to a document 0.002s
+#   rung 3  svelte build, cold (no node_modules)  15.9s
+#   rung 3  svelte build, warm (install cached)    6.8s
+# Rungs 1 and 2 are free at any scale. Rung 3 is not, which is the whole reason the
+# ladder exists.
+#
+# Nothing here may raise into a caller: ``sites.screenshot`` wraps it, and that
+# wrapper is itself wrapped at the call site. A draft that cannot be rendered
+# returns "" and the gallery card shows its themed placeholder, which is the whole
+# reason the placeholder exists.
+
+from __future__ import annotations
+
+import base64
+import logging
+import os
+import re
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from pocketpaw_ee.sites.engines import is_source_engine, needs_node_build, static_output_rel
+
+logger = logging.getLogger(__name__)
+
+# Total RAW bytes we are willing to fold into one document as ``data:`` URIs.
+# Base64 inflates by ~4/3, so this is roughly a 4MB document ceiling — comfortably
+# inside a Browser Rendering request body, and far more than a landing page's CSS +
+# hero imagery actually needs. Stylesheets are inlined BEFORE images so the budget,
+# when it runs out, runs out on decoration rather than on layout.
+_MAX_INLINE_BYTES = 3 * 1024 * 1024
+
+# The document itself is capped too: a page whose markup alone is bigger than this
+# is not a marketing page, and posting it would trade a card thumbnail for a
+# multi-megabyte upload. Over the cap we send nothing and the card takes the
+# placeholder.
+_MAX_HTML_BYTES = 6 * 1024 * 1024
+
+# Extension → mime for the ``data:`` URIs. An extension that is not on this list is
+# NOT inlined: guessing a mime for an unknown asset is how you end up rendering a
+# broken image, which is the one outcome this slice promises never to produce.
+_MIME_BY_EXT: dict[str, str] = {
+    ".css": "text/css",
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".avif": "image/avif",
+    ".svg": "image/svg+xml",
+    ".ico": "image/x-icon",
+    ".woff": "font/woff",
+    ".woff2": "font/woff2",
+    ".ttf": "font/ttf",
+    ".otf": "font/otf",
+}
+
+# References that are already resolvable without an origin (or are not fetches at
+# all). Everything else is treated as local and must be inlined or dropped.
+_NON_LOCAL_PREFIXES = ("http://", "https://", "//", "data:", "blob:", "mailto:", "tel:", "#")
+
+
+def build_allowed() -> bool:
+    """May a draft capture run a full Node build to get markup (ladder rung 3)?
+
+    Default NO, and that default is a measurement rather than a preference. A
+    never-built svelte pocket measured 15.9s cold and 6.8s warm here. Three reasons
+    that is the wrong thing to spend on a card thumbnail by default:
+
+    * ``GeneratorClient`` serializes builds of the SAME pocket behind a per-pocket
+      lock, so a draft-capture build in flight is a build the user's next preview or
+      publish QUEUES BEHIND. A picture must not make the primary action slower.
+    * it fires at site-CREATE time, which is precisely when the user is still
+      chatting with the agent that made the site — the worst moment to take CPU.
+    * a created site is often published minutes later, and the live capture then
+      re-shoots it, so the render is paid for twice.
+
+    A never-built ripple/svelte draft therefore shows the card's themed placeholder,
+    and picks up real art the moment anything else builds the pocket — a preview
+    schedules a capture of its own, and by then rung 1 costs a millisecond.
+
+    Set ``PAW_SITES_DRAFT_CAPTURE_BUILD=1`` on a deployment that would rather spend
+    the build. The html engine never consults this — it needs no build at all, which
+    is why an imported draft gets a real picture under the default.
+    """
+    return (os.environ.get("PAW_SITES_DRAFT_CAPTURE_BUILD", "") or "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
+def _is_local_ref(ref: str) -> bool:
+    """True when a reference needs an origin to resolve — i.e. when it would simply
+    fail against ``about:blank`` and therefore has to be inlined or dropped."""
+    value = ref.strip()
+    if not value:
+        return False
+    return not value.lower().startswith(_NON_LOCAL_PREFIXES)
+
+
+def _norm_rel(ref: str, *, base: str = "") -> str:
+    """Normalize one local reference to a path relative to the static ROOT.
+
+    Strips the query/fragment, resolves ``./`` and ``../`` against ``base`` (the
+    directory of the file the reference was written in — a ``url()`` inside
+    ``css/app.css`` is relative to ``css/``, not to the root), and treats a leading
+    ``/`` as root-relative, which is how a SvelteKit build writes its ``/_app/…``
+    hrefs. Returns "" for anything that climbs out of the root.
+    """
+    value = ref.strip().split("?", 1)[0].split("#", 1)[0].replace("\\", "/")
+    if not value:
+        return ""
+    if value.startswith("/"):
+        parts = value.lstrip("/").split("/")
+    else:
+        parts = [p for p in base.split("/") if p] + value.split("/")
+    out: list[str] = []
+    for part in parts:
+        if part in ("", "."):
+            continue
+        if part == "..":
+            if not out:
+                return ""  # climbs above the static root — refuse it
+            out.pop()
+            continue
+        out.append(part)
+    return "/".join(out)
+
+
+def _data_uri(rel: str, data: bytes) -> str | None:
+    """``data:`` URI for an asset, or None when we do not know its mime."""
+    mime = _MIME_BY_EXT.get(Path(rel).suffix.lower())
+    if not mime:
+        return None
+    return f"data:{mime};base64,{base64.b64encode(data).decode('ascii')}"
+
+
+class _Budget:
+    """The shared inlining allowance. One object so stylesheets, the ``url()``
+    references inside them, and images all draw on the SAME cap — otherwise a page
+    with fifty images could each pass an individual size check and still assemble a
+    document nothing will accept."""
+
+    def __init__(self, limit: int = _MAX_INLINE_BYTES) -> None:
+        self.left = limit
+
+    def take(self, size: int) -> bool:
+        if size > self.left:
+            return False
+        self.left -= size
+        return True
+
+
+def _make_disk_reader(root: Path) -> Callable[[str], bytes | None]:
+    """Read assets out of a built static tree, contained to that tree.
+
+    The hrefs come from our own generator, but a source-engine site's markup is
+    author-controlled, so a ``../`` that survived ``_norm_rel`` still gets refused
+    here against the resolved root (symlinks included)."""
+    resolved = root.resolve()
+
+    def read(rel: str) -> bytes | None:
+        if not rel:
+            return None
+        try:
+            path = (resolved / rel).resolve()
+            path.relative_to(resolved)
+            if not path.is_file():
+                return None
+            return path.read_bytes()
+        except (OSError, ValueError):
+            return None
+
+    return read
+
+
+def _make_source_reader(
+    source: dict[str, Any], disk: Callable[[str], bytes | None] | None = None
+) -> Callable[[str], bytes | None]:
+    """Read assets out of an html pocket's ``{path: contents}`` source map, falling
+    back to ``disk`` for anything the map cannot hold.
+
+    A Pocket stores TEXT only — an imported zip's binary files ride a separate
+    ``assets`` sideband straight to the generator and are never persisted on the
+    pocket — so images and fonts are exactly the things the source map is missing.
+    When a previous publish left a built tree on disk, that tree has them.
+    """
+    by_path = {_norm_rel(k): v for k, v in source.items() if isinstance(v, str)}
+
+    def read(rel: str) -> bytes | None:
+        text = by_path.get(rel)
+        if isinstance(text, str):
+            return text.encode("utf-8")
+        return disk(rel) if disk is not None else None
+
+    return read
+
+
+_LINK_RE = re.compile(r"<link\b[^>]*>", re.IGNORECASE)
+_SCRIPT_SRC_RE = re.compile(
+    r"<script\b[^>]*\bsrc\s*=\s*[\"'][^\"']+[\"'][^>]*>\s*</script\s*>|"
+    r"<script\b[^>]*\bsrc\s*=\s*[\"'][^\"']+[\"'][^>]*/?>",
+    re.IGNORECASE,
+)
+_IMG_RE = re.compile(r"<img\b[^>]*>", re.IGNORECASE)
+_HREF_RE = re.compile(r"""href\s*=\s*["']([^"']+)["']""", re.IGNORECASE)
+_SRC_RE = re.compile(r"""src\s*=\s*["']([^"']+)["']""", re.IGNORECASE)
+_SRCSET_RE = re.compile(r"""\ssrcset\s*=\s*["'][^"']*["']""", re.IGNORECASE)
+_STYLESHEET_REL_RE = re.compile(r"""rel\s*=\s*["']?stylesheet""", re.IGNORECASE)
+_CSS_URL_RE = re.compile(r"""url\(\s*(["']?)([^"')]+)\1\s*\)""", re.IGNORECASE)
+_STYLE_BLOCK_RE = re.compile(r"<style([^>]*)>(.*?)</style\s*>", re.IGNORECASE | re.DOTALL)
+
+
+def _inline_css_urls(
+    css: str, *, base: str, read: Callable[[str], bytes | None], budget: _Budget
+) -> str:
+    """Fold a stylesheet's own local ``url(...)`` references in as data URIs.
+
+    This is where a hero background and the site's webfonts live, so a screenshot
+    that skips it looks like a different site. A reference we cannot resolve, cannot
+    type, or cannot afford is left alone: it will simply not load, which is a missing
+    background rather than a broken document.
+    """
+
+    def repl(m: re.Match[str]) -> str:
+        ref = m.group(2)
+        if not _is_local_ref(ref):
+            return m.group(0)
+        rel = _norm_rel(ref, base=base)
+        data = read(rel) if rel else None
+        if not data or not budget.take(len(data)):
+            return m.group(0)
+        uri = _data_uri(rel, data)
+        return f"url({uri})" if uri else m.group(0)
+
+    return _CSS_URL_RE.sub(repl, css)
+
+
+def inline_document(
+    html: str, read: Callable[[str], bytes | None], *, budget: _Budget | None = None
+) -> str:
+    """Fold every local reference into ``html`` so it renders with no origin.
+
+    * ``<link rel=stylesheet>`` → an inline ``<style>`` (with its own ``url()``
+      references folded in). A local stylesheet we cannot read is DROPPED.
+    * every other local ``<link>`` (icons, preloads, modulepreloads) → dropped; none
+      of them can resolve and none of them change the picture.
+    * ``<script src=…>`` → dropped whatever the origin. The capture is of the page's
+      RESTING state, the state a prerendered site is designed to look finished in;
+      client bundles cannot resolve their relative imports here anyway, and a remote
+      script is a tracker we have no business executing to take a thumbnail.
+    * an ALREADY-inline ``<style>`` block → kept, but its own ``url()`` references
+      folded in. SvelteKit inlines critical CSS, which is exactly the CSS the hero
+      needs, so leaving its background and font references dangling would undo the
+      point of inlining the rest.
+    * ``<img src=local>`` → a data URI, with any ``srcset`` on that tag removed so
+      the browser cannot prefer a candidate that will never load.
+
+    Order matters: stylesheets first, images second, one shared budget — so a page
+    with more assets than the budget loses pictures, not layout.
+    """
+    budget = budget or _Budget()
+
+    def link_repl(m: re.Match[str]) -> str:
+        tag = m.group(0)
+        href_m = _HREF_RE.search(tag)
+        if not href_m or not _is_local_ref(href_m.group(1)):
+            return tag
+        if not _STYLESHEET_REL_RE.search(tag):
+            return ""  # a local icon/preload/modulepreload — unresolvable, so gone
+        rel = _norm_rel(href_m.group(1))
+        data = read(rel) if rel else None
+        if not data or not budget.take(len(data)):
+            return ""
+        css = _inline_css_urls(
+            data.decode("utf-8", "replace"),
+            # A ``url()`` inside the stylesheet is relative to the STYLESHEET, not to
+            # the document — ``_app/…/app.css`` referencing ``./fonts/x.woff2`` means
+            # ``_app/…/fonts/x.woff2``.
+            base=rel.rsplit("/", 1)[0] if "/" in rel else "",
+            read=read,
+            budget=budget,
+        )
+        return f"<style>{css}</style>"
+
+    def img_repl(m: re.Match[str]) -> str:
+        tag = m.group(0)
+        src_m = _SRC_RE.search(tag)
+        if not src_m or not _is_local_ref(src_m.group(1)):
+            return tag
+        rel = _norm_rel(src_m.group(1))
+        data = read(rel) if rel else None
+        if not data or not budget.take(len(data)):
+            return tag
+        uri = _data_uri(rel, data)
+        if not uri:
+            return tag
+        return _SRCSET_RE.sub("", tag.replace(src_m.group(0), f'src="{uri}"'))
+
+    def style_repl(m: re.Match[str]) -> str:
+        # An ALREADY-inline block, so its url()s are relative to the DOCUMENT (base
+        # ""). Run before the link pass so it only ever sees the page's own blocks,
+        # never the ones link_repl is about to create (whose refs are already data:).
+        css = _inline_css_urls(m.group(2), base="", read=read, budget=budget)
+        return f"<style{m.group(1)}>{css}</style>"
+
+    out = _STYLE_BLOCK_RE.sub(style_repl, html)
+    out = _LINK_RE.sub(link_repl, out)
+    out = _SCRIPT_SRC_RE.sub("", out)
+    return _IMG_RE.sub(img_repl, out)
+
+
+def _built_root(pocket_id: str, engine: str) -> Path:
+    """Where a pocket's servable files land on disk: PERF-3's persistent per-pocket
+    build dir (``build_home()/<pocket_id>/``) plus the per-engine static-output
+    subdir (``.svelte-kit/cloudflare`` for ripple/svelte, ``.`` for html)."""
+    from pocketpaw_ee.sites.generator_client import build_home
+
+    return build_home() / pocket_id / static_output_rel(engine)
+
+
+def _built_static_dir(pocket_id: str, engine: str) -> Path | None:
+    """The already-built static output for a pocket, or None (ladder rung 1).
+
+    ``build_home()/<pocket_id>/`` is PERF-3's persistent per-pocket working dir, and
+    ``static_output_rel`` says where inside it the servable files land per engine.
+    An ``index.html`` there means some earlier preview / arm / publish already paid
+    for this build and the capture can just read it.
+    """
+    try:
+        static_dir = _built_root(pocket_id, engine)
+        return static_dir if (static_dir / "index.html").is_file() else None
+    except (OSError, KeyError):
+        return None
+
+
+async def _build_static_dir(
+    *, site: Any, pocket: dict[str, Any], engine: str, generator: Any | None
+) -> Path | None:
+    """Build the pocket's markup from scratch (ladder rung 3) and return its static
+    output dir. Returns None when the build rung is disabled.
+
+    ``smoke=False`` — a draft is not being served to anyone, so the workerd SSR
+    fail-gate has nothing to protect here; ``static_build=True`` because the static
+    output IS what we came for. ``pocket_id`` is passed so the build lands in the
+    persistent per-pocket dir, which means this expensive rung pays for itself: the
+    NEXT capture (and the next preview) finds rung 1.
+    """
+    if not build_allowed():
+        logger.debug(
+            "sites.draft_markup: pocket %s needs a node build for its draft capture "
+            "and PAW_SITES_DRAFT_CAPTURE_BUILD is off — card keeps its placeholder",
+            pocket.get("id") or getattr(site, "pocket_id", "?"),
+        )
+        return None
+
+    from pocketpaw_ee.sites.generator_client import GeneratorClient
+    from pocketpaw_ee.sites.service import _capture_base
+
+    ripple_spec = pocket.get("rippleSpec") or {}
+    theme = (ripple_spec.get("theme") if isinstance(ripple_spec, dict) else {}) or {}
+    build = await (generator or GeneratorClient()).build(
+        # The two tracks are mutually exclusive (design spec §4.2): a svelte site
+        # carries ``source`` and no rippleSpec, a ripple site the reverse.
+        ripple_spec={} if is_source_engine(engine) else ripple_spec,
+        theme=theme,
+        site_id=str(getattr(site, "id", "draft")),
+        title=(pocket.get("name") or getattr(site, "name", "") or "Untitled site"),
+        # The capture config makes no difference to a screenshot, but this build
+        # lands in the SHARED per-pocket dir, so it is built with the same capture
+        # base and key a publish would use rather than leaving a differently-wired
+        # tree on disk for something else to find.
+        capture_api_base=_capture_base(),
+        capture_signed_key=getattr(site, "signed_key", "") or "",
+        engine=engine,
+        source=pocket.get("source") or None,
+        pocket_id=getattr(site, "pocket_id", None),
+        smoke=False,
+    )
+    static_dir = Path(build.project_dir, static_output_rel(engine))
+    return static_dir if (static_dir / "index.html").is_file() else None
+
+
+async def build_draft_markup(
+    site: Any, *, generator: Any | None = None, pocket: dict[str, Any] | None = None
+) -> str:
+    """One self-contained HTML document for this site's current draft content, or ""
+    when there is nothing renderable (no pocket, no markup, no affordable way to get
+    markup, or a document over the size cap).
+
+    Raises on a genuine failure — a missing pocket, a build that blows up. The caller
+    on the capture path is ``screenshot.safe_take_draft_screenshot``, which is the
+    form that cannot raise.
+    """
+    pocket_id = getattr(site, "pocket_id", "") or ""
+    if not pocket_id:
+        return ""
+
+    if pocket is None:
+        from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+        pocket = await pockets_service.get(pocket_id, getattr(site, "owner", ""))
+    engine = (pocket.get("engine") or "ripple").strip()
+
+    # Rung 1 — somebody already paid for this build.
+    static_dir = _built_static_dir(pocket_id, engine)
+    read: Callable[[str], bytes | None]
+    if static_dir is not None:
+        index_html = (static_dir / "index.html").read_text(encoding="utf-8", errors="replace")
+        read = _make_disk_reader(static_dir)
+    elif not needs_node_build(engine):
+        # Rung 2 — an html site's served artifact IS its authored source (HE-1), so
+        # the pocket's own source map is the static tree. No subprocess at all.
+        source = pocket.get("source")
+        if not isinstance(source, dict):
+            return ""
+        index = source.get("index.html") or source.get("/index.html") or source.get("./index.html")
+        if not isinstance(index, str) or not index.strip():
+            return ""
+        index_html = index
+        # A Pocket stores TEXT, so an imported zip's BINARY assets are not in the
+        # source map — they only ever reached the generator on a separate sideband.
+        # A previous publish's build dir is where they survive, so it backs the map.
+        read = _make_source_reader(source, _make_disk_reader(_built_root(pocket_id, engine)))
+    else:
+        # Rung 3 — a real build, if this deployment is willing to spend one.
+        built = await _build_static_dir(
+            site=site, pocket=pocket, engine=engine, generator=generator
+        )
+        if built is None:
+            return ""
+        index_html = (built / "index.html").read_text(encoding="utf-8", errors="replace")
+        read = _make_disk_reader(built)
+
+    document = inline_document(index_html, read)
+    if len(document.encode("utf-8", "replace")) > _MAX_HTML_BYTES:
+        logger.info(
+            "sites.draft_markup: pocket %s assembled a document over the %d-byte cap "
+            "— skipping the capture",
+            pocket_id,
+            _MAX_HTML_BYTES,
+        )
+        return ""
+    return document
+
+
+__all__ = ["build_allowed", "build_draft_markup", "inline_document"]

--- a/ee/pocketpaw_ee/sites/screenshot.py
+++ b/ee/pocketpaw_ee/sites/screenshot.py
@@ -37,6 +37,24 @@
 # snapshotted at that moment, so a whole-document save would silently roll back
 # anything written in between (a connected domain, a stamped subscription). Same
 # reasoning as ``kb_ingest._record_sync``.
+#
+# Updated 2026-08-07 (SC-2 — drafts get art too): a second capture path for a site
+# that has NEVER been deployed. A draft has no url, so ``take_site_screenshot``
+# correctly skips it and its card stayed art-less forever; the Browser Rendering
+# endpoint also accepts ``html``, so a draft is photographed from its own MARKUP
+# (assembled by ``sites.draft_markup``) with nothing deployed anywhere. Same three
+# rules as the live path — never blocks, never raises, never a gate — plus two of
+# its own:
+#   * it refuses to run for a site that HAS a url. A live site's picture belongs to
+#     the live path, which shoots the page visitors actually see.
+#   * it re-reads the Site before recording, and drops the write if the site went
+#     live while the shutter was open. The import flow mints a draft and publishes
+#     it seconds later, so the two captures genuinely race; without this the slower
+#     draft shot could land on top of the live one.
+# A draft that cannot be captured is the NORMAL case, not the exotic one (a
+# never-built ripple pocket is deliberately not built just for a thumbnail — see
+# ``draft_markup.build_allowed``), which is why SC-2 also ships the card's themed
+# placeholder rather than relying on this landing.
 
 from __future__ import annotations
 
@@ -210,8 +228,156 @@ def schedule_site_screenshot(site: Any) -> None:
     _default_screenshot_scheduler(safe_take_site_screenshot(site))
 
 
+# --------------------------------------------------------------------------- #
+# SC-2 — the DRAFT path: no url, so shoot the markup instead.
+# --------------------------------------------------------------------------- #
+
+
+async def _still_a_draft(site: Any) -> bool:
+    """Re-read the Site and report whether it is STILL a draft.
+
+    Called immediately before recording a draft capture. The import flow mints a
+    draft Site and publishes it seconds later, so a draft capture and the live
+    capture that follows it genuinely overlap; without this re-read the slower draft
+    shot could land on top of the live one and the card would show the page as it
+    looked before it was published.
+
+    Fails OPEN — an unreadable / non-Beanie site (every unit-test double) reports
+    True and the write proceeds. The failure this guards is cosmetic; refusing to
+    write on a doubtful read would cost every draft its picture.
+    """
+    getter = getattr(type(site), "get", None)
+    if getter is None:
+        return True
+    try:
+        fresh = await getter(site.id)
+    except Exception:  # noqa: BLE001 — a re-read failure must not cost the capture
+        return True
+    if fresh is None:
+        return False  # deleted while the shutter was open — nothing to write to
+    return not (getattr(fresh, "url", "") or "").strip()
+
+
+async def take_draft_screenshot(site: Any, *, cloudflare: Any | None = None) -> str:
+    """Screenshot a DRAFT site from its own markup, store it, record it on the Site.
+
+    Returns the stored image's URL, or "" when there was nothing to shoot: the site
+    is live (the live path owns that picture), the draft has no renderable markup
+    yet, getting markup would cost a Node build this deployment has not opted into,
+    or the shot produced no bytes. Raises on a Cloudflare or upload failure —
+    :func:`safe_take_draft_screenshot` is the form that cannot.
+
+    The markup goes over as the endpoint's ``html`` body, which renders at
+    ``about:blank``: ``draft_markup`` is what makes that document self-contained.
+    """
+    if (getattr(site, "url", "") or "").strip():
+        # A deployed site — ``take_site_screenshot`` photographs the real page.
+        return ""
+
+    from pocketpaw_ee.sites.draft_markup import build_draft_markup
+
+    markup = await build_draft_markup(site)
+    if not markup:
+        return ""
+
+    from pocketpaw_ee.sites.service import _cf_client
+
+    cf = cloudflare or _cf_client()
+    image = await cf.capture_screenshot(
+        html=markup,
+        viewport=dict(_VIEWPORT),
+        goto_options=dict(_GOTO_OPTIONS),
+        screenshot_options=dict(_SCREENSHOT_OPTIONS),
+    )
+    if not image:
+        return ""
+
+    if not await _still_a_draft(site):
+        logger.debug(
+            "sites.screenshot: site %s went live while its draft was being captured "
+            "— leaving the live picture alone",
+            getattr(site, "id", "?"),
+        )
+        return ""
+
+    image_url = await _store_screenshot(site, image)
+    await site.set({"preview_image_url": image_url})
+    logger.info("sites.screenshot: captured draft preview for site %s", getattr(site, "id", "?"))
+    return image_url
+
+
+async def safe_take_draft_screenshot(site: Any, *, cloudflare: Any | None = None) -> str:
+    """:func:`take_draft_screenshot` that never raises — the form the draft-mint path
+    uses. A draft that cannot be photographed keeps the card's themed placeholder,
+    and the create/import that scheduled this is long since successful."""
+    try:
+        return await take_draft_screenshot(site, cloudflare=cloudflare)
+    except Exception:  # noqa: BLE001 — a screenshot is never a gate on a create
+        logger.warning(
+            "sites.screenshot: draft capture failed for site %s",
+            getattr(site, "id", "?"),
+            exc_info=True,
+        )
+        return ""
+
+
+def schedule_draft_screenshot(site: Any) -> None:
+    """Fire a background draft screenshot. Never blocks, never raises.
+
+    Shares ``_default_screenshot_scheduler`` (and its strong-ref task set) with the
+    live path, so a test that patches the scheduler to run inline governs both.
+    """
+    _default_screenshot_scheduler(safe_take_draft_screenshot(site))
+
+
+async def safe_take_draft_screenshot_for_pocket(*, workspace_id: str, pocket_id: str) -> str:
+    """Look the pocket's canonical Site doc up and capture it as a draft. Never raises.
+
+    The by-pocket form exists for the PREVIEW build. A preview returns a TRANSIENT,
+    never-persisted Site-shaped object, so there is nothing there to record a picture
+    on — but the real draft doc was minted at create and is sitting in Mongo under the
+    same stable per-(workspace, pocket) id ``publish`` upserts.
+
+    Why hang a capture off preview at all: a preview has just built the pocket, so the
+    markup is already on disk and the capture costs a millisecond (rung 1) instead of
+    the 16s build the create-time capture refuses to spend. It is what makes a
+    ripple/svelte draft's card fill in at all under the default policy. On an
+    already-LIVE site this resolves a doc with a url and ``take_draft_screenshot``
+    declines it, so previewing a live site can never replace the picture of the page
+    visitors actually see with a picture of an unapproved edit.
+    """
+    try:
+        from pocketpaw_ee.sites.service import _live_object_id
+        from pocketpaw_ee.sites.service import _SiteDoc as _Doc
+
+        doc = await _Doc.find_one(
+            {"_id": _live_object_id(workspace_id, pocket_id), "workspace": workspace_id}
+        )
+        if doc is None:
+            return ""
+        return await take_draft_screenshot(doc)
+    except Exception:  # noqa: BLE001 — a screenshot is never a gate on a preview
+        logger.warning(
+            "sites.screenshot: draft capture failed for pocket %s", pocket_id, exc_info=True
+        )
+        return ""
+
+
+def schedule_draft_screenshot_for_pocket(*, workspace_id: str, pocket_id: str) -> None:
+    """Fire a background draft capture for a pocket's Site doc. Never blocks, never
+    raises."""
+    _default_screenshot_scheduler(
+        safe_take_draft_screenshot_for_pocket(workspace_id=workspace_id, pocket_id=pocket_id)
+    )
+
+
 __all__ = [
+    "safe_take_draft_screenshot",
+    "safe_take_draft_screenshot_for_pocket",
     "safe_take_site_screenshot",
+    "schedule_draft_screenshot",
+    "schedule_draft_screenshot_for_pocket",
     "schedule_site_screenshot",
+    "take_draft_screenshot",
     "take_site_screenshot",
 ]

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -14,6 +14,24 @@
 # so nothing about it may fail, delay, or block the publish. On any failure the
 # field stays empty and the card falls back to its text layout.
 #
+# Updated 2026-08-07 (SC-2 — drafts get art too): ``create_draft_site`` now schedules
+# a capture of its own (``_schedule_draft_screenshot``). A draft has no url, so that
+# capture shoots the pocket's MARKUP rather than a page (``sites.draft_markup`` +
+# the Browser Rendering ``html`` body). It fires ONLY on a fresh mint — the mint is
+# idempotent, so a repeat create re-shoots nothing and an already-live doc never
+# gets a draft picture — and it is wrapped for a reason the live path does not have:
+# ``create_draft_site`` is called from the zip/from-url import tail WITHOUT a
+# swallow of its own, so an escaping error there would fail an import whose files
+# are already safely persisted.
+# The PREVIEW branch of ``publish`` schedules one too
+# (``_schedule_draft_screenshot_for_pocket``), for a cost reason: a preview has just
+# built the pocket, so the markup is on disk and the capture is a file read instead
+# of a ~16s build. That is what fills in a ripple/svelte draft's card, since the
+# create-time capture deliberately refuses to build one. It goes by POCKET because a
+# preview's return value is a transient doc nobody persists, and it is still not a
+# way to photograph a live site: the resolved doc has a url, which the draft capture
+# declines.
+#
 # Updated 2026-08-02 (draft render): the PREVIEW deploy in ``publish`` is now
 # engine-aware, closing the half of HE-4 that was missed. HE-4 taught the LIVE
 # deploy that a built site's servable files live somewhere different per engine
@@ -1629,6 +1647,13 @@ async def create_draft_site(
     # (search index, soul memory, ripple invalidation) keys on a draft Site doc;
     # publish emits SitePublished when the site actually goes live.
     await doc.insert()
+    # SC-2: this is the moment the draft becomes a card in the gallery, so it is the
+    # moment to try to give that card a picture. A draft has no url, so the capture
+    # shoots its MARKUP instead. Only on a fresh mint — the idempotent early return
+    # above means a repeat create never re-shoots, and a live doc never gets a draft
+    # picture. Wrapped like every other publish-tail side effect: a create must not
+    # fail because a thumbnail could not be taken.
+    _schedule_draft_screenshot(doc)
     return doc
 
 
@@ -1917,6 +1942,16 @@ async def publish(
                 pocket_id,
                 preview_url,
             )
+        # SC-2: this build just put the pocket's current markup on disk, so a draft
+        # capture here costs a file read rather than the 16s build the create-time
+        # capture declines to spend — this is what fills in a ripple/svelte draft's
+        # card at all. By POCKET, not by this object: a preview returns a transient,
+        # never-persisted doc with nothing to record a picture on, while the real
+        # draft doc is in Mongo under the stable per-pocket id. An already-LIVE site
+        # resolves a doc WITH a url, which the draft capture declines — so previewing
+        # a live site can never replace the picture of the page visitors see with a
+        # picture of an unapproved edit.
+        _schedule_draft_screenshot_for_pocket(workspace_id=workspace_id, pocket_id=pocket_id)
         return _SiteDoc(
             id=ObjectId(site_id),
             workspace=workspace_id,
@@ -2441,6 +2476,50 @@ def _schedule_site_screenshot(site: _SiteDoc) -> None:
         logger.warning(
             "sites.screenshot: could not schedule capture for site %s",
             getattr(site, "id", "?"),
+            exc_info=True,
+        )
+
+
+def _schedule_draft_screenshot(site: _SiteDoc) -> None:
+    """Fire the background screenshot of a freshly minted DRAFT site (SC-2). Non-async,
+    never blocks, never raises. Looked up through the module so tests can patch it,
+    mirroring ``_schedule_site_screenshot`` directly above.
+
+    The try/except matters just as much here as on the live path, for a different
+    reason: ``create_draft_site`` is called from the tail of a site CREATE and from
+    the tail of a zip/from-url IMPORT, and the import call site does NOT wrap it. An
+    escaping error would fail an import whose files are already safely persisted, in
+    exchange for a picture on a gallery card.
+    """
+    try:
+        from pocketpaw_ee.sites.screenshot import schedule_draft_screenshot
+
+        schedule_draft_screenshot(site)
+    except Exception:  # noqa: BLE001 — never fail a create over a thumbnail
+        logger.warning(
+            "sites.screenshot: could not schedule draft capture for site %s",
+            getattr(site, "id", "?"),
+            exc_info=True,
+        )
+
+
+def _schedule_draft_screenshot_for_pocket(*, workspace_id: str, pocket_id: str) -> None:
+    """Fire the background draft capture for a pocket's Site doc (SC-2), from the tail
+    of a PREVIEW build. Non-async, never blocks, never raises.
+
+    By pocket rather than by doc because a preview's return value is transient and
+    never persisted — the doc worth recording a picture on is the draft minted at
+    create, which the capture resolves for itself. The try/except keeps a preview
+    (the builder's inner loop, run on every edit) from ever failing over a thumbnail.
+    """
+    try:
+        from pocketpaw_ee.sites.screenshot import schedule_draft_screenshot_for_pocket
+
+        schedule_draft_screenshot_for_pocket(workspace_id=workspace_id, pocket_id=pocket_id)
+    except Exception:  # noqa: BLE001 — never fail a preview over a thumbnail
+        logger.warning(
+            "sites.screenshot: could not schedule draft capture for pocket %s",
+            pocket_id,
             exc_info=True,
         )
 

--- a/tests/ee/sites/test_draft_screenshot.py
+++ b/tests/ee/sites/test_draft_screenshot.py
@@ -1,0 +1,652 @@
+# tests/ee/sites/test_draft_screenshot.py — a DRAFT site's card gets a picture too
+# (SC-2), and getting it can never cost anyone a create, an import, or a build they
+# did not ask for.
+#
+# Created 2026-08-07. Four things are pinned here:
+#   * the Cloudflare call — the screenshot endpoint's ``html`` body, the alternative
+#     to ``url`` that lets a site with no address be photographed at all, and the
+#     exactly-one-of guard so a caller bug surfaces here rather than as a CF 400;
+#   * the document — Browser Rendering renders ``html`` at ``about:blank``, where
+#     NOTHING relative resolves, so the assembled markup has to be self-contained.
+#     These tests pin what gets folded in, what gets dropped, and what is deliberately
+#     left alone;
+#   * the COST LADDER — the reason this slice does not simply build every draft. An
+#     already-built pocket is read off disk, an html pocket needs no build at all,
+#     and a never-built ripple/svelte pocket is NOT built unless the deployment opts
+#     in. The test that a build does not happen is the important one;
+#   * THE RULE (inherited from SC-1) — a capture that fails, at any layer, cannot
+#     propagate into the caller. A draft that cannot be photographed shows the card's
+#     themed placeholder, silently.
+#
+# The mutations that break these tests (run via
+# ``uv run python scripts/mutate.py --plan tests/mutations/site_draft_screenshot.json``
+# — a gate nobody has watched fail is not a gate): dropping the exactly-one-of guard
+# in ``capture_screenshot``; making ``build_allowed`` return True unconditionally;
+# leaving local ``<link>``/``<script src>`` tags in the inlined document; deleting the
+# try/except in ``service._schedule_draft_screenshot`` or in
+# ``screenshot.safe_take_draft_screenshot``; and dropping the went-live re-read that
+# stops a slow draft shot landing on top of a live one.
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+from pocketpaw_ee.cloud._core.errors import ValidationError
+from pocketpaw_ee.sites import draft_markup
+from pocketpaw_ee.sites import screenshot as screenshot_mod
+from pocketpaw_ee.sites import service as sites_service
+from pocketpaw_ee.sites.cloudflare_client import CloudflareClient
+
+# A real 1x1 PNG — the upload pipeline sniffs magic bytes, so a b"fake" payload
+# would make the happy path fail for a reason that has nothing to do with SC-2.
+_PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+)
+
+
+def _cf(handler) -> CloudflareClient:
+    return CloudflareClient(
+        account_id="acct1",
+        api_token="tok",
+        zone_id="zone1",
+        dispatch_namespace="paw-sites",
+        _transport=httpx.MockTransport(handler),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# The Cloudflare call — html instead of url
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_capture_screenshot_sends_html_instead_of_a_url():
+    """The whole trick of this slice: a draft has no address, so the markup itself is
+    the subject. The body must carry ``html`` and NOT an empty ``url`` — Cloudflare
+    would reject a body with both."""
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["body"] = json.loads(request.content)
+        return httpx.Response(200, content=_PNG, headers={"content-type": "image/png"})
+
+    out = await _cf(handler).capture_screenshot(
+        html="<html><body>hi</body></html>",
+        viewport={"width": 1280, "height": 800},
+    )
+
+    assert out == _PNG
+    assert seen["body"]["html"] == "<html><body>hi</body></html>"
+    assert "url" not in seen["body"]
+    assert seen["body"]["viewport"] == {"width": 1280, "height": 800}
+
+
+@pytest.mark.asyncio
+async def test_capture_screenshot_refuses_both_or_neither():
+    """Exactly one of url/html. Caught here so a caller bug reads as a caller bug
+    instead of an opaque Cloudflare 400 in a fire-and-forget background task nobody
+    is watching.
+
+    Mutation: drop the guard and the ``both`` case sends a body with two subjects."""
+
+    def handler(request: httpx.Request) -> httpx.Response:  # pragma: no cover
+        raise AssertionError("the guard must fire before any request is made")
+
+    with pytest.raises(ValidationError):
+        await _cf(handler).capture_screenshot(url="https://x.test/", html="<p>x</p>")
+    with pytest.raises(ValidationError):
+        await _cf(handler).capture_screenshot()
+
+
+# --------------------------------------------------------------------------- #
+# The document — self-contained, or it renders as unstyled text
+# --------------------------------------------------------------------------- #
+
+
+def _reader(files: dict[str, bytes]):
+    return lambda rel: files.get(rel)
+
+
+def test_a_local_stylesheet_is_folded_into_the_document():
+    """``about:blank`` has no origin, so a ``<link href="app.css">`` fetches nothing
+    and the page renders unstyled. Mutation: return the link tag unchanged and the
+    stylesheet no longer reaches the document."""
+    html = '<html><head><link rel="stylesheet" href="/app.css"></head><body>x</body></html>'
+    out = draft_markup.inline_document(html, _reader({"app.css": b"body{color:red}"}))
+
+    assert "<style>body{color:red}</style>" in out
+    assert "<link" not in out
+
+
+def test_a_stylesheets_own_url_references_are_folded_in_too():
+    """A hero background and the site's webfonts live inside the CSS, not the markup.
+    A capture that skips them photographs a different-looking site. The reference is
+    resolved relative to the STYLESHEET, not to the document."""
+    html = '<head><link rel="stylesheet" href="/assets/app.css"></head>'
+    files = {
+        "assets/app.css": b'.hero{background:url("./bg.png")}',
+        "assets/bg.png": _PNG,
+    }
+    out = draft_markup.inline_document(html, _reader(files))
+
+    assert "url(data:image/png;base64," in out
+    assert "bg.png" not in out
+
+
+def test_an_already_inline_style_block_keeps_its_url_references_too():
+    """SvelteKit inlines critical CSS — which is exactly the CSS the hero needs. A
+    hero background left dangling in an inline block undoes the point of inlining
+    everything else."""
+    html = "<style>.hero{background:url(/img/bg.png)}</style><body>x</body>"
+    out = draft_markup.inline_document(html, _reader({"img/bg.png": _PNG}))
+
+    assert "url(data:image/png;base64," in out
+    assert "/img/bg.png" not in out
+
+
+def test_a_local_image_becomes_a_data_uri_and_loses_its_srcset():
+    """A ``srcset`` left behind would let the browser prefer a candidate that can
+    never load — a broken image, which is the one outcome this slice promises never
+    to produce."""
+    html = '<img src="hero.png" srcset="hero@2x.png 2x" alt="hero">'
+    out = draft_markup.inline_document(html, _reader({"hero.png": _PNG}))
+
+    assert 'src="data:image/png;base64,' in out
+    assert "srcset" not in out
+    assert 'alt="hero"' in out
+
+
+def test_local_scripts_are_dropped_and_remote_references_are_left_alone():
+    """A client bundle cannot resolve its relative imports with no origin, so it is
+    dead weight; the capture is of the page's prerendered RESTING state. Absolute
+    http(s) references are a different matter — Cloudflare's browser is on the
+    internet and can fetch them, so they ride through untouched."""
+    html = (
+        '<link rel="stylesheet" href="https://cdn.test/x.css">'
+        '<link rel="icon" href="/favicon.ico">'
+        '<script type="module" src="/_app/start.js"></script>'
+        '<img src="https://cdn.test/logo.png">'
+    )
+    out = draft_markup.inline_document(html, _reader({}))
+
+    assert 'href="https://cdn.test/x.css"' in out
+    assert 'src="https://cdn.test/logo.png"' in out
+    assert "_app/start.js" not in out
+    assert "favicon.ico" not in out  # a local icon link resolves to nothing — gone
+
+
+def test_an_unreadable_local_stylesheet_is_dropped_not_left_dangling():
+    html = '<link rel="stylesheet" href="/missing.css">'
+    assert draft_markup.inline_document(html, _reader({})) == ""
+
+
+def test_an_asset_over_the_budget_is_left_alone_rather_than_inlined():
+    """One pathological asset must not turn a card thumbnail into a multi-megabyte
+    upload. Over budget, the reference is simply left un-inlined."""
+    big = b"\x89PNG" + b"0" * (draft_markup._MAX_INLINE_BYTES + 1)
+    html = '<img src="huge.png">'
+    out = draft_markup.inline_document(html, _reader({"huge.png": big}))
+
+    assert out == html
+
+
+def test_a_traversal_reference_cannot_read_outside_the_static_root(tmp_path):
+    """The hrefs come from our own generator, but a source-engine site's markup is
+    author-controlled. ``../`` is refused against the resolved root."""
+    (tmp_path / "secret.css").write_bytes(b"body{color:red}")
+    root = tmp_path / "site"
+    root.mkdir()
+    read = draft_markup._make_disk_reader(root)
+
+    assert read(draft_markup._norm_rel("../secret.css")) is None
+    assert draft_markup._norm_rel("../secret.css") == ""
+
+
+# --------------------------------------------------------------------------- #
+# The cost ladder — the reason this slice does not just build every draft
+# --------------------------------------------------------------------------- #
+
+
+class _NeverBuilds:
+    """A generator that fails the test if anything asks it to build."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def build(self, **kw):  # pragma: no cover — reaching it IS the failure
+        self.calls.append(kw)
+        raise AssertionError("a draft capture must not run a node build here")
+
+
+def _draft(**over):
+    """An in-memory stand-in for a DRAFT Site doc, recording its own ``set``."""
+    sets: list[dict] = []
+
+    class _S:
+        id = over.get("id", "site-1")
+        owner = "u1"
+        workspace = "ws1"
+        pocket_id = over.get("pocket_id", "pocket-1")
+        name = "Bright Smile"
+        signed_key = "site_key_x"
+        url = over.get("url", "")
+        writes = sets
+
+        async def set(self, updates):
+            sets.append(updates)
+
+    return _S()
+
+
+@pytest.mark.asyncio
+async def test_an_html_pocket_needs_no_build_at_all(monkeypatch, tmp_path):
+    """RUNG 2, and the acceptance case: a zip/from-url import mints an html pocket
+    whose served artifact IS its authored source, so the source map is already the
+    static tree. Zero subprocesses — which is what makes an imported draft's picture
+    worth taking at all."""
+    monkeypatch.setenv("PAW_SITES_BUILD_DIR", str(tmp_path))
+    pocket = {
+        "engine": "html",
+        "source": {
+            "index.html": '<html><head><link rel="stylesheet" href="s.css">'
+            "</head><body><h1>Bright Smile</h1></body></html>",
+            "s.css": "h1{color:teal}",
+        },
+    }
+
+    out = await draft_markup.build_draft_markup(_draft(), generator=_NeverBuilds(), pocket=pocket)
+
+    assert "<style>h1{color:teal}</style>" in out
+    assert "Bright Smile" in out
+
+
+@pytest.mark.asyncio
+async def test_a_never_built_ripple_draft_is_not_built_just_for_a_thumbnail(monkeypatch, tmp_path):
+    """RUNG 3, defaulted OFF, and the measurement this whole design turns on: a first
+    ripple build is ``bun install`` + a Vite/SvelteKit build — tens of seconds of CPU
+    in the background at the exact moment the user is chatting with the agent that
+    just made the site. The card takes its placeholder instead.
+
+    Mutation: make ``build_allowed`` return True unconditionally and ``_NeverBuilds``
+    fires."""
+    monkeypatch.setenv("PAW_SITES_BUILD_DIR", str(tmp_path))
+    monkeypatch.delenv("PAW_SITES_DRAFT_CAPTURE_BUILD", raising=False)
+
+    out = await draft_markup.build_draft_markup(
+        _draft(), generator=_NeverBuilds(), pocket={"engine": "ripple", "rippleSpec": {}}
+    )
+
+    assert out == ""
+
+
+@pytest.mark.asyncio
+async def test_an_already_built_pocket_is_read_off_disk(monkeypatch, tmp_path):
+    """RUNG 1 — the cheap rung that makes this feature actually land for ripple and
+    svelte drafts. A pocket that has ever been previewed, armed or published already
+    has its build sitting in the persistent per-pocket dir, so the capture is a few
+    file reads and no generator at all."""
+    monkeypatch.setenv("PAW_SITES_BUILD_DIR", str(tmp_path))
+    built = tmp_path / "pocket-1" / ".svelte-kit" / "cloudflare"
+    built.mkdir(parents=True)
+    (built / "index.html").write_text(
+        '<html><head><link rel="stylesheet" href="/_app/a.css"></head>'
+        "<body><h1>Built</h1></body></html>",
+        encoding="utf-8",
+    )
+    (built / "_app").mkdir()
+    (built / "_app" / "a.css").write_text("h1{color:navy}", encoding="utf-8")
+
+    out = await draft_markup.build_draft_markup(
+        _draft(), generator=_NeverBuilds(), pocket={"engine": "ripple", "rippleSpec": {}}
+    )
+
+    assert "<style>h1{color:navy}</style>" in out
+    assert "Built" in out
+
+
+@pytest.mark.asyncio
+async def test_the_build_rung_runs_when_the_deployment_opts_in(monkeypatch, tmp_path):
+    """The escape hatch exists and is wired: with the env knob on, a never-built
+    ripple draft DOES build."""
+    monkeypatch.setenv("PAW_SITES_BUILD_DIR", str(tmp_path))
+    monkeypatch.setenv("PAW_SITES_DRAFT_CAPTURE_BUILD", "1")
+    project = tmp_path / "proj"
+    static = project / ".svelte-kit" / "cloudflare"
+    static.mkdir(parents=True)
+    (static / "index.html").write_text("<body><h1>Fresh</h1></body>", encoding="utf-8")
+
+    class _Builds:
+        def __init__(self) -> None:
+            self.calls: list[dict] = []
+
+        async def build(self, **kw):
+            from pocketpaw_ee.sites.generator_client import BuildResult
+
+            self.calls.append(kw)
+            return BuildResult(project_dir=str(project), ripple_version="0.2.0")
+
+    gen = _Builds()
+    out = await draft_markup.build_draft_markup(
+        _draft(), generator=gen, pocket={"engine": "ripple", "rippleSpec": {"type": "container"}}
+    )
+
+    assert "Fresh" in out
+    # The SSR fail-gate protects a page about to be served; a draft thumbnail is not.
+    assert gen.calls[0]["smoke"] is False
+    # Built into the persistent per-pocket dir, so the NEXT capture finds rung 1.
+    assert gen.calls[0]["pocket_id"] == "pocket-1"
+
+
+# --------------------------------------------------------------------------- #
+# The capture itself
+# --------------------------------------------------------------------------- #
+
+
+def _markup(value: str):
+    """Stand in for ``draft_markup.build_draft_markup`` — these tests are about the
+    capture, not about assembling the document (which has its own cases above)."""
+
+    async def _fake(site, **_kw):
+        return value
+
+    return _fake
+
+
+class _FakeCFScreenshot:
+    def __init__(self, result: bytes | Exception = _PNG) -> None:
+        self.result = result
+        self.calls: list[dict] = []
+
+    async def capture_screenshot(self, **kw):
+        self.calls.append(kw)
+        if isinstance(self.result, Exception):
+            raise self.result
+        return self.result
+
+
+@pytest.mark.asyncio
+async def test_a_draft_capture_stores_the_image_and_records_it(monkeypatch, tmp_path):
+    """The happy path end to end: render the draft's markup, put the bytes in the
+    tenant's blob storage, remember the link on the Site."""
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.setattr(draft_markup, "build_draft_markup", _markup("<h1>Draft</h1>"))
+    cf = _FakeCFScreenshot()
+    site = _draft()
+
+    url = await screenshot_mod.take_draft_screenshot(site, cloudflare=cf)
+
+    assert cf.calls[0]["html"] == "<h1>Draft</h1>"
+    assert "url" not in cf.calls[0]
+    assert url.startswith("/api/v1/uploads/")
+    assert site.writes == [{"preview_image_url": url}]
+
+
+@pytest.mark.asyncio
+async def test_a_live_site_is_left_to_the_live_capture(monkeypatch):
+    """A deployed site's picture belongs to SC-1, which shoots the page visitors can
+    actually see. Photographing its markup instead would quietly replace a picture of
+    the real thing with a picture of a rehearsal."""
+    monkeypatch.setattr(draft_markup, "build_draft_markup", _markup("<h1>x</h1>"))
+    cf = _FakeCFScreenshot()
+    site = _draft(url="https://brew.example.test/")
+
+    assert await screenshot_mod.take_draft_screenshot(site, cloudflare=cf) == ""
+    assert cf.calls == []
+    assert site.writes == []
+
+
+@pytest.mark.asyncio
+async def test_a_draft_with_no_renderable_markup_is_skipped(monkeypatch):
+    monkeypatch.setattr(draft_markup, "build_draft_markup", _markup(""))
+    cf = _FakeCFScreenshot()
+    site = _draft()
+
+    assert await screenshot_mod.take_draft_screenshot(site, cloudflare=cf) == ""
+    assert cf.calls == []
+    assert site.writes == []
+
+
+@pytest.mark.asyncio
+async def test_a_raising_draft_capture_is_swallowed_by_the_safe_form(monkeypatch):
+    """Mutation: remove the try/except in ``safe_take_draft_screenshot`` and this
+    raises instead of returning ""."""
+    monkeypatch.setattr(draft_markup, "build_draft_markup", _markup("<h1>x</h1>"))
+    cf = _FakeCFScreenshot(result=RuntimeError("browser rendering quota exceeded"))
+    site = _draft()
+
+    assert await screenshot_mod.safe_take_draft_screenshot(site, cloudflare=cf) == ""
+    assert site.writes == []
+
+
+@pytest.mark.asyncio
+async def test_a_site_that_went_live_mid_capture_keeps_its_live_picture(monkeypatch, tmp_path):
+    """The import flow mints a draft and publishes it seconds later, so the draft
+    capture and the live capture that follows it genuinely overlap. Without the
+    re-read, the slower draft shot lands on top of the live one and the card shows
+    the page as it looked before it was published.
+
+    Mutation: delete the ``_still_a_draft`` check and this test records a write."""
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.setattr(draft_markup, "build_draft_markup", _markup("<h1>x</h1>"))
+    monkeypatch.setattr(screenshot_mod, "_still_a_draft", _went_live)
+    site = _draft()
+
+    assert await screenshot_mod.take_draft_screenshot(site, cloudflare=_FakeCFScreenshot()) == ""
+    assert site.writes == []
+
+
+async def _went_live(site):
+    return False
+
+
+# --------------------------------------------------------------------------- #
+# The wiring — and THE RULE
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_minting_a_draft_schedules_its_capture(beanie_test_db, monkeypatch):
+    """The moment a draft becomes a card in the gallery is the moment to try to give
+    that card a picture."""
+    seen: list = []
+    monkeypatch.setattr(sites_service, "_schedule_draft_screenshot", seen.append)
+
+    await sites_service.create_draft_site(
+        workspace_id="ws1", user_id="u1", pocket_id="pk_draft", name="Bright Smile"
+    )
+
+    assert [s.pocket_id for s in seen] == ["pk_draft"]
+
+
+@pytest.mark.asyncio
+async def test_a_repeat_mint_does_not_re_shoot(beanie_test_db, monkeypatch):
+    """``create_draft_site`` is idempotent — a repeat create returns the existing doc
+    untouched, and must not spend another render on it. The same early return is what
+    stops an already-LIVE site being handed a draft picture."""
+    seen: list = []
+    monkeypatch.setattr(sites_service, "_schedule_draft_screenshot", seen.append)
+
+    await sites_service.create_draft_site(workspace_id="ws1", user_id="u1", pocket_id="pk1")
+    await sites_service.create_draft_site(workspace_id="ws1", user_id="u1", pocket_id="pk1")
+
+    assert len(seen) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_broken_scheduler_cannot_fail_a_create(beanie_test_db, monkeypatch):
+    """THE RULE, at the scheduling layer. ``create_draft_site`` is called from the
+    zip/from-url import tail WITHOUT a swallow of its own, so anything escaping here
+    fails an import whose files are already safely persisted.
+
+    Mutation: delete the try/except in ``service._schedule_draft_screenshot`` and this
+    fails with "scheduler down" instead of returning a draft."""
+
+    def _boom(coro):
+        coro.close()
+        raise RuntimeError("scheduler down")
+
+    monkeypatch.setattr(screenshot_mod, "_default_screenshot_scheduler", _boom)
+
+    doc = await sites_service.create_draft_site(
+        workspace_id="ws1", user_id="u1", pocket_id="pk_boom", name="Bright Smile"
+    )
+
+    assert doc.deployed is False
+
+
+@pytest.mark.asyncio
+async def test_a_captured_draft_reaches_the_gallery_list_item(
+    beanie_test_db, monkeypatch, tmp_path
+):
+    """The whole point: a draft that has never been deployed anywhere still carries a
+    real image url on its list row, which is what lets its card show the page instead
+    of an empty box."""
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.setattr(draft_markup, "build_draft_markup", _markup("<h1>Draft</h1>"))
+    monkeypatch.setattr(sites_service, "_cf_client", lambda: _FakeCFScreenshot())
+
+    ran: list = []
+
+    def _inline(coro):
+        import asyncio
+
+        ran.append(asyncio.get_running_loop().create_task(coro))
+
+    monkeypatch.setattr(screenshot_mod, "_default_screenshot_scheduler", _inline)
+
+    await sites_service.create_draft_site(
+        workspace_id="ws1", user_id="u1", pocket_id="pk_shot", name="Bright Smile"
+    )
+    for task in ran:
+        await task
+
+    rows = await sites_service.list_for_workspace("ws1")
+    assert len(rows) == 1
+    assert rows[0].deployed is False  # still a draft — nothing was deployed anywhere
+    assert (rows[0].preview_image_url or "").startswith("/api/v1/uploads/")
+
+
+# --------------------------------------------------------------------------- #
+# The preview tail — the trigger that makes a ripple/svelte draft's card fill in
+# --------------------------------------------------------------------------- #
+
+
+class _FakeGenerator:
+    async def build(self, **kw):
+        from pocketpaw_ee.sites.generator_client import BuildResult
+
+        return BuildResult(project_dir="/tmp/site", ripple_version="0.2.0")
+
+
+async def _preview(pocket_id: str = "pk_prev"):
+    return await sites_service.publish(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        ripple_spec={"type": "container"},
+        theme={},
+        name="Bright Smile",
+        preview=True,
+        _generator=_FakeGenerator(),
+        _cloudflare=None,
+        _bundle_reader=lambda d: b"x",
+        _local_deploy=(lambda site_id, project_dir: f"http://localhost/{site_id}"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_preview_build_schedules_a_draft_capture(beanie_test_db, monkeypatch):
+    """A preview has JUST built the pocket, so the markup is on disk and a capture
+    costs a file read rather than the ~16s build the create-time capture declines to
+    spend. Without this trigger a ripple/svelte draft never gets art at all under the
+    default policy."""
+    monkeypatch.setenv("PAW_SITES_LOCAL", "1")
+    seen: list = []
+    monkeypatch.setattr(
+        sites_service, "_schedule_draft_screenshot_for_pocket", lambda **kw: seen.append(kw)
+    )
+
+    await _preview()
+
+    assert seen == [{"workspace_id": "ws1", "pocket_id": "pk_prev"}]
+
+
+@pytest.mark.asyncio
+async def test_the_preview_capture_goes_by_pocket_not_by_the_transient_doc(
+    beanie_test_db, monkeypatch, tmp_path
+):
+    """A preview's return value is a transient Site-shaped object that is never
+    persisted, so recording a picture on it would write to nothing. The capture has to
+    resolve the DRAFT doc minted at create — the one the gallery actually lists."""
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.setattr(draft_markup, "build_draft_markup", _markup("<h1>Draft</h1>"))
+    monkeypatch.setattr(sites_service, "_cf_client", lambda: _FakeCFScreenshot())
+
+    await sites_service.create_draft_site(workspace_id="ws1", user_id="u1", pocket_id="pk_prev2")
+    out = await screenshot_mod.safe_take_draft_screenshot_for_pocket(
+        workspace_id="ws1", pocket_id="pk_prev2"
+    )
+
+    assert out.startswith("/api/v1/uploads/")
+    rows = await sites_service.list_for_workspace("ws1")
+    assert (rows[0].preview_image_url or "").startswith("/api/v1/uploads/")
+
+
+@pytest.mark.asyncio
+async def test_previewing_a_live_site_does_not_replace_its_live_picture(
+    beanie_test_db, monkeypatch, tmp_path
+):
+    """Previewing is how an unapproved EDIT is reviewed. Photographing that edit onto
+    the gallery card would show visitors' view of the site as something no visitor can
+    see. The resolved doc has a url, so the draft capture declines it."""
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.setattr(draft_markup, "build_draft_markup", _markup("<h1>Unapproved</h1>"))
+    cf = _FakeCFScreenshot()
+    monkeypatch.setattr(sites_service, "_cf_client", lambda: cf)
+
+    doc = await sites_service.create_draft_site(
+        workspace_id="ws1", user_id="u1", pocket_id="pk_live"
+    )
+    await doc.set({"url": "https://brew.example.test/", "deployed": True})
+
+    out = await screenshot_mod.safe_take_draft_screenshot_for_pocket(
+        workspace_id="ws1", pocket_id="pk_live"
+    )
+
+    assert out == ""
+    assert cf.calls == []
+
+
+@pytest.mark.asyncio
+async def test_a_missing_draft_doc_is_not_an_error(beanie_test_db):
+    """A pocket with no Site doc (a pre-draft-first row) simply has no card to put a
+    picture on."""
+    assert (
+        await screenshot_mod.safe_take_draft_screenshot_for_pocket(
+            workspace_id="ws1", pocket_id="pk_nothing"
+        )
+        == ""
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_broken_scheduler_cannot_fail_a_preview(beanie_test_db, monkeypatch):
+    """THE RULE at the preview tail. A preview is the builder's inner loop — it runs on
+    every edit — so it is the last thing that may fail over a thumbnail.
+
+    Mutation: delete the try/except in ``service._schedule_draft_screenshot_for_pocket``
+    and this fails with "scheduler down"."""
+    monkeypatch.setenv("PAW_SITES_LOCAL", "1")
+
+    def _boom(coro):
+        coro.close()
+        raise RuntimeError("scheduler down")
+
+    monkeypatch.setattr(screenshot_mod, "_default_screenshot_scheduler", _boom)
+
+    site = await _preview("pk_prev3")
+
+    assert site.deployed is False

--- a/tests/mutations/site_draft_screenshot.json
+++ b/tests/mutations/site_draft_screenshot.json
@@ -1,0 +1,92 @@
+[
+  {
+    "label": "draft screenshot: a broken scheduler takes the site CREATE down with it",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    try:\n        from pocketpaw_ee.sites.screenshot import schedule_draft_screenshot\n\n        schedule_draft_screenshot(site)\n    except Exception:  # noqa: BLE001 — never fail a create over a thumbnail\n        logger.warning(\n            \"sites.screenshot: could not schedule draft capture for site %s\",\n            getattr(site, \"id\", \"?\"),\n            exc_info=True,\n        )",
+    "replace": "    from pocketpaw_ee.sites.screenshot import schedule_draft_screenshot\n\n    schedule_draft_screenshot(site)",
+    "tests": [
+      "tests/ee/sites/test_draft_screenshot.py"
+    ]
+  },
+  {
+    "label": "draft screenshot: a broken scheduler takes the PREVIEW down with it",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    try:\n        from pocketpaw_ee.sites.screenshot import schedule_draft_screenshot_for_pocket\n\n        schedule_draft_screenshot_for_pocket(workspace_id=workspace_id, pocket_id=pocket_id)\n    except Exception:  # noqa: BLE001 — never fail a preview over a thumbnail",
+    "replace": "    if True:\n        from pocketpaw_ee.sites.screenshot import schedule_draft_screenshot_for_pocket\n\n        schedule_draft_screenshot_for_pocket(workspace_id=workspace_id, pocket_id=pocket_id)\n    if False:",
+    "tests": [
+      "tests/ee/sites/test_draft_screenshot.py"
+    ]
+  },
+  {
+    "label": "draft screenshot: a Cloudflare failure escapes into the create path",
+    "file": "ee/pocketpaw_ee/sites/screenshot.py",
+    "find": "    try:\n        return await take_draft_screenshot(site, cloudflare=cloudflare)\n    except Exception:  # noqa: BLE001 — a screenshot is never a gate on a create\n        logger.warning(\n            \"sites.screenshot: draft capture failed for site %s\",\n            getattr(site, \"id\", \"?\"),\n            exc_info=True,\n        )\n        return \"\"",
+    "replace": "    return await take_draft_screenshot(site, cloudflare=cloudflare)",
+    "tests": [
+      "tests/ee/sites/test_draft_screenshot.py"
+    ]
+  },
+  {
+    "label": "draft screenshot: a slow draft shot lands on top of a live one",
+    "file": "ee/pocketpaw_ee/sites/screenshot.py",
+    "find": "    if not await _still_a_draft(site):",
+    "replace": "    if False:",
+    "tests": [
+      "tests/ee/sites/test_draft_screenshot.py"
+    ]
+  },
+  {
+    "label": "draft screenshot: a LIVE site gets photographed as a draft",
+    "file": "ee/pocketpaw_ee/sites/screenshot.py",
+    "find": "    if (getattr(site, \"url\", \"\") or \"\").strip():\n        # A deployed site — ``take_site_screenshot`` photographs the real page.\n        return \"\"",
+    "replace": "    pass",
+    "tests": [
+      "tests/ee/sites/test_draft_screenshot.py"
+    ]
+  },
+  {
+    "label": "draft screenshot: every new ripple draft silently costs a 16s node build",
+    "file": "ee/pocketpaw_ee/sites/draft_markup.py",
+    "find": "    return (os.environ.get(\"PAW_SITES_DRAFT_CAPTURE_BUILD\", \"\") or \"\").strip().lower() in (\n        \"1\",\n        \"true\",\n        \"yes\",\n        \"on\",\n    )",
+    "replace": "    return True",
+    "tests": [
+      "tests/ee/sites/test_draft_screenshot.py"
+    ]
+  },
+  {
+    "label": "draft screenshot: local stylesheets are left dangling, so the shot is unstyled",
+    "file": "ee/pocketpaw_ee/sites/draft_markup.py",
+    "find": "        if not _STYLESHEET_REL_RE.search(tag):\n            return \"\"  # a local icon/preload/modulepreload — unresolvable, so gone",
+    "replace": "        if not _STYLESHEET_REL_RE.search(tag):\n            return tag",
+    "tests": [
+      "tests/ee/sites/test_draft_screenshot.py"
+    ]
+  },
+  {
+    "label": "draft screenshot: an oversized asset is inlined anyway",
+    "file": "ee/pocketpaw_ee/sites/draft_markup.py",
+    "find": "    def take(self, size: int) -> bool:\n        if size > self.left:\n            return False",
+    "replace": "    def take(self, size: int) -> bool:\n        if False:\n            return False",
+    "tests": [
+      "tests/ee/sites/test_draft_screenshot.py"
+    ]
+  },
+  {
+    "label": "draft screenshot: a traversal reference escapes the static root",
+    "file": "ee/pocketpaw_ee/sites/draft_markup.py",
+    "find": "        if part == \"..\":\n            if not out:\n                return \"\"  # climbs above the static root — refuse it\n            out.pop()\n            continue",
+    "replace": "        if part == \"..\":\n            out.append(part)\n            continue",
+    "tests": [
+      "tests/ee/sites/test_draft_screenshot.py"
+    ]
+  },
+  {
+    "label": "draft screenshot: the endpoint is sent both url and html",
+    "file": "ee/pocketpaw_ee/sites/cloudflare_client.py",
+    "find": "        if bool(url) == bool(html):",
+    "replace": "        if False:",
+    "tests": [
+      "tests/ee/sites/test_draft_screenshot.py"
+    ]
+  }
+]


### PR DESCRIPTION
Stacked on #1877 — review that first; this PR's diff shows only the draft work.

#1877 photographs a site by pointing Cloudflare Browser Rendering at its live URL. A draft has no live URL — that is what makes it a draft — and the builder's own preview address is a `127.0.0.1` bound inside the API process, which Cloudflare's browser cannot reach. So a draft is captured from its markup instead: the screenshot endpoint takes an `html` body as an alternative to `url`.

## The constraint that shapes the whole module

Browser Rendering renders an `html` body at `about:blank`. There is no origin, so **no relative reference resolves** — not a stylesheet, not an image, not a font. A built page handed over verbatim renders as unstyled text, and would do it silently: the request succeeds, the picture is just wrong.

So everything local is folded into the document before it leaves (`inline_document`), and anything local that cannot be folded in is dropped rather than left to 404. Absolute `http(s)` references are untouched — Cloudflare's browser is on the internet and can fetch them.

## A cost ladder, cheapest rung first

This runs for a picture on a gallery card, so it must never be worth its cost:

1. **An existing build on disk.** A pocket that has ever been previewed, armed or published already has its output sitting in the per-pocket build dir. A few file reads.
2. **No build needed** — the `html` engine (zip and from-url imports). That engine runs no Node build and its served artifact is byte-identical to the authored source, so the pocket's own source map *is* the static tree. Zero subprocesses.
3. **A real build** — ripple or svelte with nothing on disk yet. `bun install` plus a Vite build.

Rung 3 is gated behind `PAW_SITES_DRAFT_CAPTURE_BUILD` and is **off by default**. A gallery card is not worth a cold build, and turning it on is a deliberate decision rather than a default anyone inherits.

## Failure stays invisible

The two swallow layers from #1877 hold. A draft that cannot be captured shows the placeholder; nothing raises, nothing blocks, no caller learns about it.

## Tests

`PAW_CF_DEPLOY_MODE= uv run pytest tests/ee/sites/` — 543 passed, 4 skipped (baseline 515).

The 4 failures in `test_generator_client_timeout.py` are the known Windows asyncio flakes, reproduced on clean `dev`.

Mutations in `tests/mutations/site_draft_screenshot.json`.

Paired with the paw-enterprise PR that draws the placeholder.

## Measured, on a real generator run

| path | cost |
|---|---|
| existing build on disk, inlined | 0.001s |
| html source map straight to a document | 0.002s |
| svelte build, cold | 15.9s |
| svelte build, warm | 6.8s |

The 16 seconds is not the decisive number. `GeneratorClient` serialises builds of the same pocket behind a per-pocket lock, so a draft-capture build is a build the user's next preview or publish queues behind — a picture must never make the primary action slower. It would also fire at site-create time, while the user is still chatting with the agent that made the site, and the site is often published minutes later and re-shot anyway.

Everything else is effectively free, so the feature still lands under the default: an imported html draft gets a real capture in 2ms, and a ripple/svelte draft gets one for 1ms as soon as anything else builds the pocket.

## A second trigger, beyond the deploy path

Because the build path is off, a create-time capture alone would leave every ripple/svelte draft on the placeholder forever. So the preview build tail also schedules a capture. A preview has just built the pocket, so that capture is a file read rather than a build.

It goes by pocket, because a preview returns a transient never-persisted doc, and it declines when the resolved doc has a url — so it cannot photograph a live site.
