### PR TITLE
The card stops lying after a republish

### DIFF
--- a/ee/pocketpaw_ee/cloud/models/site.py
+++ b/ee/pocketpaw_ee/cloud/models/site.py
@@ -170,6 +170,17 @@
 # card falls back to its text layout on empty — so it is always optional and never
 # a gate on publishing. Defaults "" so every existing row reads "no preview" — no
 # migration.
+#
+# Updated 2026-08-07 (SC-3 — the card stops lying after a republish): no schema
+# change, only the write POLICY for that field, recorded where the field lives.
+# ``preview_image_url`` is rewritten on EVERY successful deploy (a republish
+# included — there is no TTL and no "only if empty" guard, since a republish is
+# exactly the case where a value exists and is wrong) and by an explicit
+# POST /sites/{site_id}/preview-refresh. Every capture stores a NEW uploads row, so
+# the value changes each time and nothing overwrites bytes behind a stable URL —
+# a reader may treat an unchanged value as unchanged art. Written by targeted
+# ``set()``, never ``save()``: the capture lands seconds after the publish that
+# scheduled it, holding a doc snapshotted before it.
 
 from __future__ import annotations
 

--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -127,6 +127,16 @@
 # fetch. None when no screenshot has landed (never deployed, no public url,
 # capture failed, Cloudflare unconfigured) — the card then falls back to its text
 # layout, so the field is optional, empty-safe and backward-compatible.
+# Updated 2026-08-07 (SC-3 — the card stops lying after a republish): the refresh
+# POLICY is now written onto both ``preview_image_url`` fields instead of being
+# inferrable only from where the capture is called — re-captured on every
+# successful deploy (so a republish updates the card), plus an explicit refresh, no
+# TTL, and a different uploads link every capture. New DTO
+# ``SitePreviewRefreshResponse`` ({site_id, preview_image_url}) backs that explicit
+# path, POST /sites/{site_id}/preview-refresh. It is deliberately its own response
+# rather than a reused ``SiteResponse``: the call answers one question ("what is
+# the new picture"), and unlike every deploy-triggered capture it REPORTS failure
+# — a person asked for it and is waiting on the answer.
 
 from __future__ import annotations
 
@@ -208,7 +218,37 @@ class SiteResponse(BaseModel):
     # whenever the capture failed, the site has no public url yet, or Cloudflare
     # Browser Rendering is unconfigured. The card falls back to its text layout on
     # None, so the field is optional and backward-compatible.
+    #
+    # SC-3 — WHEN THIS CHANGES (the refresh policy, written down so a reader does
+    # not have to infer it from behaviour):
+    #   * on EVERY successful deploy, including a republish. A deploy is the only
+    #     moment the design is known to have changed, it is user-initiated and
+    #     already slow, and it is the only trigger with no staleness window. There
+    #     is no TTL and no "only if empty" guard — the republish case is exactly
+    #     the one where a picture exists and shows the wrong design.
+    #   * on an explicit request to POST /sites/{site_id}/preview-refresh, for the
+    #     cases a deploy cannot cover (a capture that failed, a deployment that was
+    #     unconfigured then, a draft whose markup only became buildable later).
+    # The value is a DIFFERENT uploads link every capture (each one mints its own
+    # uuid-keyed row), so a client may treat a changed value as new art and a
+    # cached one as unchanged — nothing ever overwrites bytes behind a stable URL.
     preview_image_url: str | None = None
+
+
+class SitePreviewRefreshResponse(BaseModel):
+    """The result of an explicit preview re-capture (SC-3) —
+    POST /sites/{site_id}/preview-refresh.
+
+    ``preview_image_url`` is the NEWLY stored image, never the previous one: the
+    endpoint only answers 200 once a capture has landed and been recorded on the
+    Site. Everything else (Cloudflare unconfigured or refusing, a draft with no
+    buildable markup) surfaces as an error, because unlike the deploy-triggered
+    capture this one was asked for by a person who is watching — the never-fail
+    rule protects publishes, not this call.
+    """
+
+    site_id: str
+    preview_image_url: str
 
 
 class SitePreviewResponse(BaseModel):
@@ -270,6 +310,11 @@ class SiteStatusResponse(BaseModel):
     # field the list response carries, so a by-pocket status read can show the
     # page too. None until a capture lands (and whenever one failed, the site has
     # no public url, or Cloudflare Browser Rendering is unconfigured).
+    #
+    # SC-3 — same refresh policy as ``SiteResponse.preview_image_url`` above, which
+    # is the fuller write-up: re-captured on every successful deploy (so a
+    # republish updates it), plus POST /sites/{site_id}/preview-refresh on demand,
+    # and the value is a different uploads link every capture.
     preview_image_url: str | None = None
 
 

--- a/ee/pocketpaw_ee/sites/router.py
+++ b/ee/pocketpaw_ee/sites/router.py
@@ -8,6 +8,13 @@
 # name) and RAISES NotFound when missing / access-denied (it does not return
 # None). theme is pulled from the rippleSpec subtree.
 #
+# Updated 2026-08-07 (SC-3 — the card stops lying after a republish): new
+# POST /sites/{site_id}/preview-refresh, the manual half of the preview policy
+# (automatic capture on every successful deploy + an explicit refresh). It is the
+# one capture in this subsystem that REPORTS failure rather than swallowing it —
+# every other one hangs off a publish, which it may never endanger; this one hangs
+# off a button press, whose whole value is the answer.
+#
 # Updated 2026-07-17 (fix/sites-prewarm-origin): ``publish_site`` and
 # ``apply_leaf_edits_by_pocket`` now thread the request ``Origin`` header into the
 # service as ``prewarm_origin`` so the background native-artifact pre-warm builds with
@@ -191,6 +198,7 @@ from pocketpaw_ee.sites.dto import (
     RequestPublishResponse,
     SiteDataRowsResponse,
     SiteDataTablesResponse,
+    SitePreviewRefreshResponse,
     SitePreviewResponse,
     SiteResponse,
     SiteStatusResponse,
@@ -658,6 +666,36 @@ async def revert_version_by_pocket(
         author=draft.author,
         created_at=draft.created_at.isoformat(),
     )
+
+
+@router.post("/sites/{site_id}/preview-refresh", response_model=SitePreviewRefreshResponse)
+async def refresh_site_preview(
+    site_id: str,
+    ctx: RequestContext = Depends(request_context),
+    _: object = Depends(require_action_any_workspace("fabric.write")),
+) -> SitePreviewRefreshResponse:
+    """Re-photograph the site's gallery card image on demand (SC-3).
+
+    Capture is automatic on every successful deploy, which handles the case that
+    matters — the design changed — so this exists for the ones a deploy cannot fix:
+    a capture that failed at the time (Cloudflare unconfigured, quota, a render that
+    timed out), or a draft whose markup only became buildable later. Without it, the
+    only way to correct a card was to republish an unchanged site.
+
+    A POST because it spends a paid remote render and rewrites the Site, and
+    ``fabric.write`` for the same reason. Named ``preview-refresh`` rather than
+    ``preview`` deliberately: on this router ``by-pocket/{id}/preview`` already means
+    the draft CONTENT the builder renders, and two different meanings of "preview"
+    one path segment apart is how a client ends up calling the wrong one.
+
+    SYNCHRONOUS, and it can fail. Every other capture in this subsystem is
+    fire-and-forget behind a swallow, because a picture may never cost anyone a
+    publish. This one was asked for by a person who is watching a spinner, so it
+    waits for the render (seconds) and surfaces a real error instead of a 200
+    carrying the same stale url they pressed the button to replace. A site in
+    another workspace is a 404; nothing renderable yet is a 422.
+    """
+    return await sites_service.refresh_site_preview(workspace_id=ctx.workspace_id, site_id=site_id)
 
 
 @router.post("/sites/{site_id}/domains", response_model=DomainStatusResponse)

--- a/ee/pocketpaw_ee/sites/screenshot.py
+++ b/ee/pocketpaw_ee/sites/screenshot.py
@@ -55,12 +55,48 @@
 # never-built ripple pocket is deliberately not built just for a thumbnail — see
 # ``draft_markup.build_allowed``), which is why SC-2 also ships the card's themed
 # placeholder rather than relying on this landing.
+#
+# Updated 2026-08-07 (SC-3 — the card stops lying after a republish). THE POLICY,
+# now settled and written down here rather than inferred from where the calls sit:
+# **capture on every successful deploy, plus a manual refresh affordance.** A deploy
+# is the only moment the design is known to have changed; it is user-initiated and
+# already slow (a full build + smoke + upload), so one more remote render adds
+# nothing perceptible; and it is the only policy with no staleness window. A TTL was
+# considered and rejected — it would re-shoot unchanged sites forever AND still show
+# stale art for the length of the gap. The manual path
+# (``sites.service.refresh_site_preview``) covers the cases a deploy cannot: a
+# capture that failed, a deployment that was unconfigured at the time, a draft whose
+# markup only became buildable later.
+#
+# Two things had to be true for a REPUBLISH to actually change the card, and both
+# were checked rather than assumed:
+#   * nothing short-circuits on an existing picture. ``take_site_screenshot`` has no
+#     "already has a preview" guard and must not grow one — a republish is exactly
+#     the case where a preview exists and is wrong.
+#   * the recorded URL is NEW every capture, so no cache can serve the old bytes.
+#     ``_store_screenshot`` mints a fresh uploads row per call (``new_storage_key``
+#     is uuid4-tailed), so ``preview_image_url`` changes value on every capture and
+#     the card re-fetches a URL it has never seen. Nothing overwrites a stable key,
+#     which is the variant that WOULD need cache-busting headers.
+# The cost of that: each republish leaves the previous preview in the tenant's
+# ``/site-previews`` folder. Accumulation was accepted at SC-1 (that folder exists
+# precisely so the strays do not bury the owner's real files) and is left alone
+# here — a delete inside the never-fail capture tail would add failure surface to
+# the one path that may not have any, and buys the card nothing.
+#
+# The one staleness vector left is the PAGE, not the picture: Browser Rendering
+# fetches the site through Cloudflare's edge, which can still be holding the
+# pre-republish document. ``_shot_url`` appends a unique per-capture query param so
+# each shot addresses a URL the cache has never seen. That behaviour cannot be
+# proven from here — the tests pin that the param is sent and differs per capture,
+# not that Cloudflare honours it.
 
 from __future__ import annotations
 
 import asyncio
 import io
 import logging
+import uuid
 from pathlib import Path
 from typing import Any
 
@@ -95,6 +131,29 @@ _GOTO_OPTIONS = {"waitUntil": "networkidle0", "timeout": 20_000}
 # Where the screenshot lands in the owner's Files panel. Its own folder so a
 # workspace that republishes often does not bury the owner's real files.
 _FOLDER = "/site-previews"
+
+# SC-3: the cache-busting parameter each capture addresses the page with. The name
+# is namespaced and obviously ours so an operator reading their access logs can tell
+# what it is, and so it cannot collide with a query param the site itself reads.
+_SHOT_PARAM = "_paw_shot"
+
+
+def _shot_url(url: str) -> str:
+    """Return the site url with a unique per-capture cache-buster appended (SC-3).
+
+    A republish ships new content at the SAME address. Cloudflare's edge caches by
+    full URL including the query string, so an unmodified request can be answered
+    with the document that was there before the deploy — and the card would show a
+    fresh screenshot of the old design, which is the exact failure this slice
+    exists to remove. A parameter no cache has seen forces the origin.
+
+    Deliberately additive and ignorable: every engine we deploy serves static
+    assets or routes on the PATH, so an unknown query param changes nothing about
+    what renders. Appended with the right separator so a url that already carries a
+    query string stays valid.
+    """
+    sep = "&" if "?" in url else "?"
+    return f"{url}{sep}{_SHOT_PARAM}={uuid.uuid4().hex}"
 
 
 async def _store_screenshot(site: Any, image: bytes) -> str:
@@ -152,6 +211,12 @@ async def take_site_screenshot(site: Any, *, cloudflare: Any | None = None) -> s
     SAME account / token / configuration check every other Cloudflare call here
     does, and an unconfigured deployment raises a clean "Cloudflare is not
     configured" instead of a KeyError.
+
+    SC-3 — there is deliberately NO "this site already has a preview, skip"
+    branch. A republish is precisely the case where a preview exists and is a
+    picture of the wrong design; short-circuiting on one is what would make the
+    card lie. Every call captures, stores under a fresh uploads id, and records
+    the new URL over the old one.
     """
     url = (getattr(site, "url", "") or "").strip()
     if not url:
@@ -166,7 +231,9 @@ async def take_site_screenshot(site: Any, *, cloudflare: Any | None = None) -> s
 
     cf = cloudflare or _cf_client()
     image = await cf.capture_screenshot(
-        url=url,
+        # SC-3: cache-busted, so a republish is photographed as it is NOW and not
+        # as the edge last cached it. See ``_shot_url``.
+        url=_shot_url(url),
         viewport=dict(_VIEWPORT),
         goto_options=dict(_GOTO_OPTIONS),
         screenshot_options=dict(_SCREENSHOT_OPTIONS),

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -32,6 +32,21 @@
 # way to photograph a live site: the resolved doc has a url, which the draft capture
 # declines.
 #
+# Updated 2026-08-07 (SC-3 — the card stops lying after a republish). The
+# deploy-time capture SC-1 added already fires on a republish, and the republish
+# path was verified end to end rather than assumed: ``_deploy_site_doc`` upserts the
+# EXISTING doc (so ``preview_image_url`` survives the republish and is overwritten,
+# not reset), nothing short-circuits on a preview already being present, and each
+# capture stores under a fresh uploads id — so the field takes a new value the card
+# has never fetched, and no cache can serve the old bytes behind it. New
+# ``refresh_site_preview`` adds the manual half of the policy: an explicit,
+# synchronous re-capture that ROUTES itself (live page vs draft markup) the same way
+# the automatic path does, and — unlike every deploy-triggered capture — reports
+# failure to its caller. That asymmetry is the point: ``safe_take_*`` exists so a
+# picture can never cost anyone a publish, while a person who pressed "refresh
+# preview" needs to be told when it did not work rather than handed back the stale
+# url they were trying to replace.
+#
 # Updated 2026-08-02 (draft render): the PREVIEW deploy in ``publish`` is now
 # engine-aware, closing the half of HE-4 that was missed. HE-4 taught the LIVE
 # deploy that a built site's servable files live somewhere different per engine
@@ -704,6 +719,7 @@ from pocketpaw_ee.sites.dto import (
     SiteDataRowsResponse,
     SiteDataTableInfo,
     SiteDataTablesResponse,
+    SitePreviewRefreshResponse,
     SitePreviewResponse,
     SiteResponse,
     SiteStatusResponse,
@@ -2522,6 +2538,54 @@ def _schedule_draft_screenshot_for_pocket(*, workspace_id: str, pocket_id: str) 
             pocket_id,
             exc_info=True,
         )
+
+
+async def refresh_site_preview(*, workspace_id: str, site_id: str) -> SitePreviewRefreshResponse:
+    """Re-capture a site's card image NOW, and report what happened (SC-3).
+
+    The manual half of the preview policy. Automatic capture fires on every
+    successful deploy, which covers the case that matters (the design changed), but
+    it cannot cover a capture that FAILED — Cloudflare unconfigured at the time,
+    quota exhausted, a render that timed out — or a draft whose markup only became
+    buildable after it was minted. Without this the only way to fix a card was to
+    republish an unchanged site.
+
+    Deliberately the mirror image of the deploy path on the one axis that matters:
+    **this one raises.** ``safe_take_*`` exists so a picture can never cost anybody
+    a publish; here a person pressed a button and is waiting, so a Cloudflare
+    failure must reach them as an error rather than a 200 carrying the same stale
+    url they were trying to replace. The unsafe forms are called on purpose.
+
+    Also deliberately SYNCHRONOUS. A remote browser render takes seconds, which is
+    too long to block a publish and exactly right for a request whose entire
+    purpose is the answer.
+
+    Routes itself the same way the automatic path does: a site with a url is
+    photographed live, a draft is photographed from its own markup. Tenant-scoped
+    via ``_load``, so another workspace's site is a 404, never a render.
+    """
+    from pocketpaw_ee.sites.screenshot import take_draft_screenshot, take_site_screenshot
+
+    site = await _load(workspace_id, site_id)
+
+    if (getattr(site, "url", "") or "").strip():
+        image_url = await take_site_screenshot(site)
+    else:
+        image_url = await take_draft_screenshot(site)
+
+    if not image_url:
+        # The capture declined rather than failed: a draft with nothing renderable
+        # yet, or a build this deployment has not opted into (see
+        # ``draft_markup.build_allowed``). Returning 200 with the previous url would
+        # report success for a refresh that did not happen, and a 500 would blame
+        # the server for a site that simply has no page to photograph.
+        raise ValidationError(
+            "sites.preview_unavailable",
+            "There's nothing to photograph yet — publish the site, or open its "
+            "preview once so there's a page to capture.",
+        )
+
+    return SitePreviewRefreshResponse(site_id=site_id, preview_image_url=image_url)
 
 
 # How long a Site may sit in ``provision_status="provisioning"`` before a new

--- a/tests/ee/sites/test_preview_refresh.py
+++ b/tests/ee/sites/test_preview_refresh.py
@@ -144,7 +144,22 @@ def published_url(monkeypatch):
 @pytest.fixture
 def uploads_in_tmp(monkeypatch, tmp_path):
     """Land stored screenshots under the test's tmp dir rather than the developer's
-    real ~/.pocketpaw. Returns the storage root so a test can read the bytes back."""
+    real ~/.pocketpaw. Returns the storage root so a test can read the bytes back.
+
+    Patching ``Path.home`` alone is NOT enough, and the reason is worth knowing
+    because it makes these tests silently useless on a configured machine.
+    ``_store_screenshot`` builds its adapter through
+    ``pocketpaw.uploads.factory.build_adapter``, which calls ``load_dotenv()`` —
+    so a developer whose ``.env`` sets ``POCKETPAW_UPLOAD_ADAPTER=s3`` uploads the
+    screenshot to the REAL bucket. The bytes never touch ``tmp_path``, and the
+    read-back below fails with FileNotFoundError pointing at a path that looks
+    correct.
+
+    Worse, it fails in the direction that flatters us: the assertion is the only
+    thing distinguishing url rotation from an overwrite, so on an s3-configured box
+    the proof of this slice does not run at all. Pinning the adapter keeps the test
+    measuring the property it claims to measure, wherever it runs."""
+    monkeypatch.setenv("POCKETPAW_UPLOAD_ADAPTER", "local")
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
     return tmp_path / ".pocketpaw" / "uploads"
 

--- a/tests/ee/sites/test_preview_refresh.py
+++ b/tests/ee/sites/test_preview_refresh.py
@@ -1,0 +1,487 @@
+# tests/ee/sites/test_preview_refresh.py — the card stops lying after a republish
+# (SC-3), and there is a way to fix a card without republishing.
+#
+# Created 2026-08-07. SC-1 made a deploy take a screenshot; this file is about what
+# happens the SECOND time. The claim under test is not "a capture is scheduled" —
+# SC-1 pins that — but the end-to-end one a user would make: **edit a site,
+# republish it, and the gallery card shows the new design.** So the republish test
+# here does not assert on a scheduler or a mock call count; it publishes twice with
+# two genuinely different images, reads the row the gallery renders, resolves the
+# url it carries all the way down to the stored bytes, and asserts those bytes are
+# the SECOND image. Everything between (the doc upsert preserving the field, the
+# uploads row, the DTO) is exercised rather than assumed, because a card can lie at
+# any one of those layers while every layer above it looks correct.
+#
+# What that test proved about the two failure modes worth ruling out:
+#   * NOT a stable-key overwrite. Each capture mints its own uploads row, so
+#     ``preview_image_url`` takes a NEW value every time and the old url still
+#     resolves to the old bytes (asserted). No cache — CDN or browser — can serve
+#     stale art behind a url the client has never fetched.
+#   * NOT a skip-if-present no-op. ``take_site_screenshot`` has no "already has a
+#     preview" guard, and the mutation plan (tests/mutations/site_preview_refresh.json)
+#     adds one to watch this test fail.
+# The remaining staleness vector is the PAGE rather than the picture — Browser
+# Rendering fetches through Cloudflare's edge, which may still hold the
+# pre-republish document — so each capture appends a unique cache-busting param.
+# The tests pin that the param is sent and differs per capture. They CANNOT pin
+# that Cloudflare honours it; nothing in a unit test can.
+#
+# And the asymmetry SC-3 introduces, which is the thing most at risk of being
+# "tidied" later: the deploy-triggered capture may never raise, while the manual
+# refresh must. Same broken Cloudflare, two opposite behaviours, pinned in one test
+# (``test_the_deploy_path_swallows_the_failure_the_manual_path_reports``).
+#
+# Mutations that break these tests (run via scripts/mutate.py — a gate nobody has
+# watched fail is not a gate): making ``take_site_screenshot`` return early when a
+# preview already exists breaks the republish test; dropping the cache-buster from
+# the capture url breaks the fresh-url test; calling ``safe_take_site_screenshot``
+# from ``refresh_site_preview`` breaks the reports-failure test; returning the
+# previous url instead of raising when a capture declines breaks the
+# nothing-to-photograph test.
+from __future__ import annotations
+
+import struct
+import zlib
+from pathlib import Path
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import NotFound, ValidationError
+from pocketpaw_ee.sites import draft_markup as draft_markup_mod
+from pocketpaw_ee.sites import screenshot as screenshot_mod
+from pocketpaw_ee.sites import service as sites_service
+
+
+def _png(red: int, green: int, blue: int) -> bytes:
+    """A real, minimal 1x1 PNG of the given colour.
+
+    Real because the upload pipeline sniffs magic bytes and would reject a
+    placeholder — a fake payload would make the happy path pass for the wrong
+    reason. Generated rather than pasted as base64 so that "these two images are
+    different" is visible in the source instead of being two opaque blobs.
+    """
+
+    def chunk(tag: bytes, data: bytes) -> bytes:
+        body = tag + data
+        return struct.pack(">I", len(data)) + body + struct.pack(">I", zlib.crc32(body))
+
+    ihdr = struct.pack(">IIBBBBB", 1, 1, 8, 2, 0, 0, 0)  # 1x1, 8-bit truecolour
+    idat = zlib.compress(bytes([0, red, green, blue]))  # one row, no filter
+    return b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", ihdr) + chunk(b"IDAT", idat) + chunk(b"IEND", b"")
+
+
+# The design before the edit, and the design after it. The whole slice is the
+# question of which one the card ends up showing.
+_BEFORE = _png(255, 0, 0)
+_AFTER = _png(0, 0, 255)
+
+
+class _ShotSequence:
+    """A Cloudflare client that hands back a DIFFERENT image on each capture.
+
+    Recording both ``url`` and ``html`` matters: which one a call arrives with is
+    how a test tells the live path (photograph the deployed page) from the draft
+    path (photograph the markup) without reaching inside either.
+    """
+
+    def __init__(self, *results: bytes | Exception) -> None:
+        self._results = list(results) or [_BEFORE]
+        self.calls: list[dict] = []
+
+    async def capture_screenshot(self, *, url=None, html=None, **_kw):
+        self.calls.append({"url": url, "html": html})
+        # The last result repeats, so a test that only cares about one image does
+        # not have to count captures.
+        result = self._results.pop(0) if len(self._results) > 1 else self._results[0]
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    @property
+    def urls(self) -> list[str]:
+        return [c["url"] for c in self.calls]
+
+
+class _FakeGenerator:
+    async def build(self, **kw):
+        from pocketpaw_ee.sites.generator_client import BuildResult
+
+        return BuildResult(project_dir="/tmp/site", ripple_version="0.2.0")
+
+
+class _FakeCF:
+    async def put_worker(self, *, script_name, bundle, bindings=None):
+        return True
+
+
+async def _publish():
+    """Publish pocket-1 live. Called twice by the republish test — the Site doc is
+    upserted on the stable per-(workspace, pocket) id, so the second call is a real
+    republish of the same site at the same url, not a second site."""
+    return await sites_service.publish(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id="pocket-1",
+        ripple_spec={"type": "container"},
+        theme={},
+        name="Brew and Co",
+        preview=False,
+        _generator=_FakeGenerator(),
+        _cloudflare=_FakeCF(),
+        _bundle_reader=lambda d: b"x",
+        _local_deploy=(lambda site_id, project_dir: f"http://localhost/{site_id}"),
+    )
+
+
+@pytest.fixture
+def published_url(monkeypatch):
+    """Give the Workers-for-Platforms publish a public address. Without
+    PAW_CF_SITES_DOMAIN a WfP deploy stamps ``url=""`` and the capture correctly
+    skips a site with no page to photograph — a test that wants to prove a capture
+    RAN has to configure the domain or it passes for the wrong reason."""
+    monkeypatch.setenv("PAW_CF_SITES_DOMAIN", "paw-sites.test")
+
+
+@pytest.fixture
+def uploads_in_tmp(monkeypatch, tmp_path):
+    """Land stored screenshots under the test's tmp dir rather than the developer's
+    real ~/.pocketpaw. Returns the storage root so a test can read the bytes back."""
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    return tmp_path / ".pocketpaw" / "uploads"
+
+
+def _run_captures_inline(monkeypatch) -> list:
+    """Make the fire-and-forget capture run on the publish's own loop and hand back
+    the tasks, so a test can await the background work instead of racing it."""
+    ran: list = []
+
+    def _inline(coro):
+        import asyncio
+
+        ran.append(asyncio.get_running_loop().create_task(coro))
+
+    monkeypatch.setattr(screenshot_mod, "_default_screenshot_scheduler", _inline)
+    return ran
+
+
+async def _card_image_url() -> str | None:
+    """The preview url on the row the gallery actually renders — read through
+    ``list_for_workspace`` rather than off the doc, so the DTO is in the path."""
+    rows = await sites_service.list_for_workspace("ws1")
+    assert len(rows) == 1, f"expected one site, got {len(rows)}"
+    return rows[0].preview_image_url
+
+
+async def _stored_bytes(preview_url: str, root: Path) -> bytes:
+    """Resolve ``/api/v1/uploads/{id}`` to the bytes actually on disk.
+
+    This is what makes the republish test a proof rather than an assertion: the
+    card's url is followed through the uploads row to the stored blob, so "the card
+    shows the new design" is checked against the image itself.
+    """
+    from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+
+    file_id = preview_url.rsplit("/", 1)[-1]
+    rec = await MongoFileStore().get_scoped(file_id, workspace="ws1")
+    assert rec is not None, f"no uploads row behind {preview_url}"
+    return (root / rec.storage_key).read_bytes()
+
+
+# --------------------------------------------------------------------------- #
+# The slice: a republish changes the card
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_a_republish_replaces_the_card_art_with_the_new_design(
+    beanie_test_db, monkeypatch, published_url, uploads_in_tmp
+):
+    """THE SLICE, end to end. Publish, then republish with a different design, and
+    the image behind the gallery card is the SECOND design.
+
+    Deliberately proved by resolving the card's url down to the stored bytes. Every
+    weaker check passes on a broken implementation: a changed url proves nothing
+    about what it points at, and a mock call count proves nothing about what was
+    persisted.
+
+    Mutation: give ``take_site_screenshot`` an early return when the site already
+    has a ``preview_image_url`` and this fails — the card keeps the old design.
+    """
+    cf = _ShotSequence(_BEFORE, _AFTER)
+    monkeypatch.setattr(sites_service, "_cf_client", lambda: cf)
+    ran = _run_captures_inline(monkeypatch)
+
+    await _publish()
+    for task in ran:
+        await task
+    ran.clear()
+    before = await _card_image_url()
+
+    # The site is edited and shipped again: same pocket, same site, same url.
+    await _publish()
+    for task in ran:
+        await task
+    after = await _card_image_url()
+
+    # The republish really did re-shoot — otherwise this passes on a site that was
+    # simply photographed once.
+    assert len(cf.calls) == 2
+
+    assert before and after
+    assert after != before, "the card is still pointing at the first capture"
+    assert await _stored_bytes(after, uploads_in_tmp) == _AFTER
+
+    # The old url still resolves to the old bytes: this is url rotation, not an
+    # overwrite behind a stable key — so no CDN or browser cache is in a position
+    # to serve the previous design.
+    assert await _stored_bytes(before, uploads_in_tmp) == _BEFORE
+
+
+@pytest.mark.asyncio
+async def test_a_republish_photographs_the_same_site_not_a_second_one(
+    beanie_test_db, monkeypatch, published_url, uploads_in_tmp
+):
+    """The republish must land on the SAME Site doc. If a publish inserted a fresh
+    row the gallery would grow a duplicate card and the "stale art" symptom would
+    have a completely different cause — worth pinning next to the test above, which
+    reads ``rows[0]`` and would otherwise be reading an arbitrary row."""
+    cf = _ShotSequence(_BEFORE, _AFTER)
+    monkeypatch.setattr(sites_service, "_cf_client", lambda: cf)
+    ran = _run_captures_inline(monkeypatch)
+
+    first = await _publish()
+    second = await _publish()
+    for task in ran:
+        await task
+
+    assert str(first.id) == str(second.id)
+    assert len(await sites_service.list_for_workspace("ws1")) == 1
+
+
+@pytest.mark.asyncio
+async def test_each_capture_asks_for_a_url_no_cache_has_seen(
+    beanie_test_db, monkeypatch, published_url, uploads_in_tmp
+):
+    """The picture is fresh (the test above); the PAGE is what could still be stale.
+    Browser Rendering fetches through Cloudflare's edge, which can answer with the
+    document that was there before the deploy — and the card would then show a
+    brand-new screenshot of the old design.
+
+    This pins that each capture addresses a distinct url on the site's own address.
+    Whether Cloudflare honours the cache-buster is not testable here.
+
+    Mutation: pass ``url=url`` instead of ``url=_shot_url(url)`` and this fails.
+    """
+    cf = _ShotSequence(_BEFORE, _AFTER)
+    monkeypatch.setattr(sites_service, "_cf_client", lambda: cf)
+    ran = _run_captures_inline(monkeypatch)
+
+    site = await _publish()
+    await _publish()
+    for task in ran:
+        await task
+
+    assert len(cf.urls) == 2
+    assert cf.urls[0] != cf.urls[1], "two captures asked the edge for the same url"
+    for url in cf.urls:
+        assert url.startswith(site.url), f"capture left the site's own address: {url}"
+        assert screenshot_mod._SHOT_PARAM in url
+
+
+def test_the_cache_buster_respects_a_url_that_already_has_a_query_string():
+    """A site reached with query params (a campaign link on a custom domain) must
+    still get a VALID url, not a second ``?``."""
+    out = screenshot_mod._shot_url("https://brew.example.test/?utm_source=x")
+    assert out.startswith("https://brew.example.test/?utm_source=x&_paw_shot=")
+    assert out.count("?") == 1
+
+
+# --------------------------------------------------------------------------- #
+# The manual refresh
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_a_manual_refresh_recaptures_a_live_site_and_returns_the_new_image(
+    beanie_test_db, monkeypatch, published_url, uploads_in_tmp
+):
+    """The affordance itself: with no republish and no edit, ask for a new picture
+    and get one. This is what fixes a card whose capture failed at deploy time —
+    previously the only remedy was republishing an unchanged site."""
+    cf = _ShotSequence(_BEFORE, _AFTER)
+    monkeypatch.setattr(sites_service, "_cf_client", lambda: cf)
+    ran = _run_captures_inline(monkeypatch)
+
+    site = await _publish()
+    for task in ran:
+        await task
+    before = await _card_image_url()
+
+    out = await sites_service.refresh_site_preview(workspace_id="ws1", site_id=str(site.id))
+
+    assert out.site_id == str(site.id)
+    assert out.preview_image_url.startswith("/api/v1/uploads/")
+    assert out.preview_image_url != before
+    # The returned url is the NEW image, and the card agrees with the response.
+    assert await _stored_bytes(out.preview_image_url, uploads_in_tmp) == _AFTER
+    assert await _card_image_url() == out.preview_image_url
+
+
+@pytest.mark.asyncio
+async def test_a_manual_refresh_of_a_draft_shoots_its_markup_not_a_page(
+    beanie_test_db, monkeypatch, uploads_in_tmp
+):
+    """A draft has no url, so there is no page to photograph — the refresh must
+    route to the markup capture rather than skipping, or a never-published site
+    could never gain a card image on demand."""
+    from bson import ObjectId
+    from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
+
+    oid = ObjectId()
+    await _SiteDoc(
+        id=oid,
+        workspace="ws1",
+        pocket_id="pocket-draft",
+        owner="u1",
+        name="Not shipped yet",
+        script_name=str(oid),
+        deployed=False,
+        url="",
+        signed_key="k",
+    ).insert()
+
+    async def _markup(_site):
+        return "<html><body>draft</body></html>"
+
+    monkeypatch.setattr(draft_markup_mod, "build_draft_markup", _markup)
+    cf = _ShotSequence(_AFTER)
+    monkeypatch.setattr(sites_service, "_cf_client", lambda: cf)
+
+    out = await sites_service.refresh_site_preview(workspace_id="ws1", site_id=str(oid))
+
+    assert out.preview_image_url.startswith("/api/v1/uploads/")
+    # The draft path posts an ``html`` body and no url — which is how we know it
+    # did not try to photograph a page that does not exist.
+    assert cf.calls == [{"url": None, "html": "<html><body>draft</body></html>"}]
+
+
+@pytest.mark.asyncio
+async def test_a_manual_refresh_will_not_photograph_another_workspaces_site(
+    beanie_test_db, monkeypatch, published_url, uploads_in_tmp
+):
+    """Tenant scoping. A cross-workspace site id is a 404 and — the part that would
+    be a real leak — no render is attempted, so a caller cannot use this endpoint to
+    make us fetch a page they have no claim to."""
+    cf = _ShotSequence(_BEFORE)
+    monkeypatch.setattr(sites_service, "_cf_client", lambda: cf)
+    ran = _run_captures_inline(monkeypatch)
+
+    site = await _publish()
+    for task in ran:
+        await task
+    cf.calls.clear()
+
+    with pytest.raises(NotFound):
+        await sites_service.refresh_site_preview(workspace_id="ws-other", site_id=str(site.id))
+
+    assert cf.calls == []
+
+
+@pytest.mark.asyncio
+async def test_a_manual_refresh_that_finds_nothing_to_photograph_says_so(
+    beanie_test_db, monkeypatch, uploads_in_tmp
+):
+    """A draft whose markup is not buildable is the NORMAL case, not an exotic one
+    (a never-built ripple pocket is deliberately not built just for a thumbnail).
+    The refresh must say that plainly — a 200 carrying the previous url would report
+    success for a refresh that did not happen.
+
+    Mutation: return the site's existing ``preview_image_url`` instead of raising
+    and this fails.
+    """
+    from bson import ObjectId
+    from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
+
+    oid = ObjectId()
+    await _SiteDoc(
+        id=oid,
+        workspace="ws1",
+        pocket_id="pocket-draft",
+        owner="u1",
+        name="Nothing to shoot",
+        script_name=str(oid),
+        deployed=False,
+        url="",
+        signed_key="k",
+        preview_image_url="/api/v1/uploads/stale",
+    ).insert()
+
+    async def _no_markup(_site):
+        return ""
+
+    monkeypatch.setattr(draft_markup_mod, "build_draft_markup", _no_markup)
+    monkeypatch.setattr(sites_service, "_cf_client", lambda: _ShotSequence(_AFTER))
+
+    with pytest.raises(ValidationError) as exc:
+        await sites_service.refresh_site_preview(workspace_id="ws1", site_id=str(oid))
+    assert exc.value.code == "sites.preview_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_the_deploy_path_swallows_the_failure_the_manual_path_reports(
+    beanie_test_db, monkeypatch, published_url, uploads_in_tmp
+):
+    """THE ASYMMETRY, in one test so nobody unifies the two by accident.
+
+    Same broken Cloudflare, two opposite obligations. A deploy-triggered capture may
+    never raise: the site is already live and serving, and a picture is not worth
+    failing a publish over. A manual refresh MUST raise: a person pressed a button
+    and is waiting, and handing them back a 200 with the same stale url they were
+    trying to replace is a lie.
+
+    Mutation: call ``safe_take_site_screenshot`` from ``refresh_site_preview`` and
+    the second half fails — the refresh reports success having captured nothing.
+    """
+    boom = ValidationError("sites.cloudflare_error", "browser rendering is down")
+    cf = _ShotSequence(boom)
+    monkeypatch.setattr(sites_service, "_cf_client", lambda: cf)
+    ran = _run_captures_inline(monkeypatch)
+
+    # The publish survives a capture that raises on its own stack.
+    site = await _publish()
+    for task in ran:
+        await task
+    assert site.deployed is True
+    assert cf.calls, "the capture was never attempted — this would pass vacuously"
+    assert await _card_image_url() is None
+
+    # The same failure, asked for explicitly, reaches the caller.
+    with pytest.raises(ValidationError) as exc:
+        await sites_service.refresh_site_preview(workspace_id="ws1", site_id=str(site.id))
+    assert exc.value.code == "sites.cloudflare_error"
+
+
+@pytest.mark.asyncio
+async def test_a_failed_manual_refresh_leaves_the_existing_card_alone(
+    beanie_test_db, monkeypatch, published_url, uploads_in_tmp
+):
+    """Reporting failure must not also DESTROY the picture the site already had. A
+    card showing a slightly stale design beats a card showing nothing."""
+    cf = _ShotSequence(_BEFORE)
+    monkeypatch.setattr(sites_service, "_cf_client", lambda: cf)
+    ran = _run_captures_inline(monkeypatch)
+
+    site = await _publish()
+    for task in ran:
+        await task
+    good = await _card_image_url()
+    assert good
+
+    monkeypatch.setattr(
+        sites_service,
+        "_cf_client",
+        lambda: _ShotSequence(ValidationError("sites.cloudflare_error", "quota exceeded")),
+    )
+    with pytest.raises(ValidationError):
+        await sites_service.refresh_site_preview(workspace_id="ws1", site_id=str(site.id))
+
+    assert await _card_image_url() == good

--- a/tests/ee/sites/test_screenshot_capture.py
+++ b/tests/ee/sites/test_screenshot_capture.py
@@ -165,7 +165,11 @@ async def test_a_capture_stores_the_image_and_records_it_on_the_site(monkeypatch
 
     url = await screenshot_mod.take_site_screenshot(site, cloudflare=cf)
 
-    assert cf.calls == ["https://brew.example.test/"]
+    # SC-3: the page is addressed with a per-capture cache-buster appended, so a
+    # republish is photographed as it is now rather than as the edge cached it.
+    # The base address is still the site's own — see test_preview_refresh.py.
+    assert len(cf.calls) == 1
+    assert cf.calls[0].startswith("https://brew.example.test/?_paw_shot=")
     assert url.startswith("/api/v1/uploads/")
     assert site.writes == [{"preview_image_url": url}]
 
@@ -319,8 +323,10 @@ async def test_publish_survives_a_cloudflare_that_refuses_to_screenshot(
         await task
 
     # The capture really was attempted and really did raise — otherwise this test
-    # would pass on a site that was simply never photographed.
-    assert cf.calls and cf.calls[0].endswith(".paw-sites.test")
+    # would pass on a site that was simply never photographed. (The url carries
+    # SC-3's cache-buster after the host, so this matches the host rather than the
+    # end of the string.)
+    assert cf.calls and ".paw-sites.test" in cf.calls[0]
     assert site.deployed is True
 
     rows = await sites_service.list_for_workspace("ws1")

--- a/tests/mutations/site_preview_refresh.json
+++ b/tests/mutations/site_preview_refresh.json
@@ -1,0 +1,47 @@
+[
+  {
+    "label": "preview refresh: a site that already has a picture is never re-photographed",
+    "file": "ee/pocketpaw_ee/sites/screenshot.py",
+    "find": "    from pocketpaw_ee.sites.service import _cf_client\n\n    cf = cloudflare or _cf_client()\n    image = await cf.capture_screenshot(\n        # SC-3: cache-busted, so a republish is photographed as it is NOW and not\n        # as the edge last cached it. See ``_shot_url``.\n        url=_shot_url(url),",
+    "replace": "    if (getattr(site, \"preview_image_url\", \"\") or \"\").strip():\n        return \"\"\n\n    from pocketpaw_ee.sites.service import _cf_client\n\n    cf = cloudflare or _cf_client()\n    image = await cf.capture_screenshot(\n        url=_shot_url(url),",
+    "tests": [
+      "tests/ee/sites/test_preview_refresh.py"
+    ]
+  },
+  {
+    "label": "preview refresh: every capture asks the edge for the same cacheable url",
+    "file": "ee/pocketpaw_ee/sites/screenshot.py",
+    "find": "    sep = \"&\" if \"?\" in url else \"?\"\n    return f\"{url}{sep}{_SHOT_PARAM}={uuid.uuid4().hex}\"",
+    "replace": "    return url",
+    "tests": [
+      "tests/ee/sites/test_preview_refresh.py"
+    ]
+  },
+  {
+    "label": "preview refresh: the manual path swallows the failure it was asked to report",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    from pocketpaw_ee.sites.screenshot import take_draft_screenshot, take_site_screenshot",
+    "replace": "    from pocketpaw_ee.sites.screenshot import (\n        safe_take_draft_screenshot as take_draft_screenshot,\n    )\n    from pocketpaw_ee.sites.screenshot import (\n        safe_take_site_screenshot as take_site_screenshot,\n    )",
+    "tests": [
+      "tests/ee/sites/test_preview_refresh.py"
+    ]
+  },
+  {
+    "label": "preview refresh: a refresh that captured nothing reports success with the stale url",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        raise ValidationError(\n            \"sites.preview_unavailable\",\n            \"There's nothing to photograph yet — publish the site, or open its \"\n            \"preview once so there's a page to capture.\",\n        )",
+    "replace": "        return SitePreviewRefreshResponse(\n            site_id=site_id,\n            preview_image_url=getattr(site, \"preview_image_url\", \"\") or \"\",\n        )",
+    "tests": [
+      "tests/ee/sites/test_preview_refresh.py"
+    ]
+  },
+  {
+    "label": "preview refresh: a cross-tenant site id is photographed instead of 404ing",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    site = await _load(workspace_id, site_id)\n\n    if (getattr(site, \"url\", \"\") or \"\").strip():\n        image_url = await take_site_screenshot(site)",
+    "replace": "    from bson import ObjectId as _Oid\n\n    site = await _SiteDoc.find_one({\"_id\": _Oid(site_id)})\n    if site is None:\n        raise NotFound(\"site\", site_id)\n\n    if (getattr(site, \"url\", \"\") or \"\").strip():\n        image_url = await take_site_screenshot(site)",
+    "tests": [
+      "tests/ee/sites/test_preview_refresh.py"
+    ]
+  }
+]


### PR DESCRIPTION
Stacked on #1879 — review that first; this PR's diff shows only the refresh work.

#1877 made a deploy take a screenshot. This is about the second time.

Republishing already re-fired the capture, but nobody had followed the url the gallery card carries all the way down to the bytes behind it, so "the card updates" was a guess. It holds — and now a test proves it, by publishing twice with two genuinely different images and asserting the card resolves to the second one.

## The hazard was not where I expected it

The obvious risk is stale bytes: if the upload overwrote a stable storage key, a CDN or browser cache could serve the old picture from the same address. That is not what happens. `_store_screenshot` mints a fresh uploads row per call, so the recorded url is new every capture and nothing overwrites bytes behind a stable key. A client sees a changed value as new art and a cached one as unchanged, which is correct on both counts.

The real hazard is one step upstream, on the capture side. **A republish ships new content at the same address, and Cloudflare's edge caches by full URL including the query string** — so an unmodified request can be answered with the document that was there *before* the deploy. The result would be a perfectly fresh screenshot of the old design, which is the exact failure this slice exists to remove.

So each capture appends a unique per-capture parameter, addressing a URL no cache has seen.

## What the tests do and do not prove

They pin that the parameter is sent and that it differs per capture. They do **not** prove that Cloudflare honours it — that cannot be verified from here, and the code says so where the next reader will meet it rather than only in a commit message.

## The policy, now written down

Capture on every successful deploy, plus a manual refresh. A deploy is the only moment the design is known to have changed; it is user-initiated and already slow, so one screenshot is imperceptible; and it is the only policy with no staleness window. A TTL would re-shoot unchanged sites forever and still show stale art in the gap. That reasoning now lives in the `preview_image_url` docstring instead of having to be inferred from behaviour.

## Tests

`PAW_CF_DEPLOY_MODE= uv run pytest tests/ee/sites/ --ignore=tests/ee/sites/test_generator_client_timeout.py` — **553 passed, 4 skipped, 0 failed** in 45s.

That ignore is worth adopting repo-wide: `test_generator_client_timeout.py` deliberately wedges subprocesses, and on Windows it does not merely fail — it can hang the entire run at ~0 CPU. Ignoring it also drops the known-failure count to zero, so a tolerated failure can no longer hide a real one.