### PR TITLE
Fix Code Mode file tools reporting no browser when one is attached

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -9,6 +9,16 @@ handles *what the agent sees*:
 * ``load_history_for_scope`` rehydrates prior chat turns from Mongo so the
   agent carries context across backend restarts and pool evictions.
 
+Changes: 2026-08-07 (fix/code-delegate-pooled-context) — added the session-keyed
+stream registry (``register_stream_sink`` / ``unregister_stream_sink`` /
+``stream_sink_for_session``) alongside the ``_sse_event_sink`` ContextVar. The
+ContextVar answers "is there a sink in MY context", which is right for an
+observability frame and wrong for a caller that WAITS on one: Code Mode's file
+tools run in a pooled SDK client's task created during prewarm, so they see
+identity and never the sink. The registry lets such a caller find the stream by
+session id instead. ``push_sse_event`` is unchanged and still a deliberate
+no-op outside a stream.
+
 Changes: 2026-07-14 (Paw Bar concierge seam, T2) — added ``ScopeKind.CONCIERGE``
 and ``_resolve_concierge``: a PUBLIC, anonymous Paw Bar concierge run resolves
 its ``ScopeContext`` from the server-authoritative spec (Site pocket + widget

--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -545,7 +545,8 @@ def detach_sse_event_sink(token: Token) -> None:
 # posture this module holds itself to: "the correlation id is unguessable, but
 # tenancy that rests on unguessability is not tenancy". A caller must prove it
 # belongs to the tenant whose stream it is about to push into.
-_stream_sinks_by_session: dict[str, tuple[str | None, asyncio.Queue[tuple[str, dict[str, Any]]]]] = {}
+_StreamEntry = tuple[str | None, asyncio.Queue[tuple[str, dict[str, Any]]]]
+_stream_sinks_by_session: dict[str, _StreamEntry] = {}
 
 
 def register_stream_sink(
@@ -611,7 +612,11 @@ def stream_sink_for_session(
     if entry is None:
         return None
     owner_workspace_id, queue = entry
-    if workspace_id is not None and owner_workspace_id is not None and owner_workspace_id != workspace_id:
+    if (
+        workspace_id is not None
+        and owner_workspace_id is not None
+        and owner_workspace_id != workspace_id
+    ):
         return None
     return queue
 

--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -538,12 +538,20 @@ def detach_sse_event_sink(token: Token) -> None:
 # Keyed by ``session_mongo_id`` rather than by workspace: one workspace can
 # have two streams open in two windows, and a workspace-keyed lookup would hand
 # a file write to whichever one it happened to find.
-_stream_sinks_by_session: dict[str, asyncio.Queue[tuple[str, dict[str, Any]]]] = {}
+# The workspace is stored BESIDE the queue, not just the queue, because this
+# dict is process-global and therefore cross-tenant. The ContextVar path could
+# not get tenancy wrong — the sink was the caller's own stream by construction —
+# but a lookup keyed on a session id can, and ``delegates._Pending`` states the
+# posture this module holds itself to: "the correlation id is unguessable, but
+# tenancy that rests on unguessability is not tenancy". A caller must prove it
+# belongs to the tenant whose stream it is about to push into.
+_stream_sinks_by_session: dict[str, tuple[str | None, asyncio.Queue[tuple[str, dict[str, Any]]]]] = {}
 
 
 def register_stream_sink(
     session_mongo_id: str | None,
     queue: asyncio.Queue[tuple[str, dict[str, Any]]],
+    workspace_id: str | None = None,
 ) -> None:
     """Publish ``queue`` as the live stream for ``session_mongo_id``.
 
@@ -552,7 +560,7 @@ def register_stream_sink(
     """
     if not session_mongo_id:
         return
-    _stream_sinks_by_session[session_mongo_id] = queue
+    _stream_sinks_by_session[session_mongo_id] = (workspace_id, queue)
 
 
 def unregister_stream_sink(
@@ -578,18 +586,34 @@ def unregister_stream_sink(
     """
     if not session_mongo_id:
         return
-    if queue is not None and _stream_sinks_by_session.get(session_mongo_id) is not queue:
-        return
+    if queue is not None:
+        entry = _stream_sinks_by_session.get(session_mongo_id)
+        if entry is None or entry[1] is not queue:
+            return
     _stream_sinks_by_session.pop(session_mongo_id, None)
 
 
 def stream_sink_for_session(
     session_mongo_id: str | None,
+    workspace_id: str | None = None,
 ) -> asyncio.Queue[tuple[str, dict[str, Any]]] | None:
-    """The live stream for ``session_mongo_id``, or None when none is open."""
+    """The live stream for ``session_mongo_id``, or None when none is open.
+
+    When ``workspace_id`` is given it must MATCH the tenant that registered the
+    stream, otherwise this returns None. Callers reaching a process-global dict
+    have to prove tenancy rather than rely on the session id being unguessable;
+    the inbound half (``PendingDelegates.resolve``) already holds that line and
+    the outbound half must too.
+    """
     if not session_mongo_id:
         return None
-    return _stream_sinks_by_session.get(session_mongo_id)
+    entry = _stream_sinks_by_session.get(session_mongo_id)
+    if entry is None:
+        return None
+    owner_workspace_id, queue = entry
+    if workspace_id is not None and owner_workspace_id is not None and owner_workspace_id != workspace_id:
+        return None
+    return queue
 
 
 # Legacy aliases retained for callers that were written against the

--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -555,14 +555,30 @@ def register_stream_sink(
     _stream_sinks_by_session[session_mongo_id] = queue
 
 
-def unregister_stream_sink(session_mongo_id: str | None) -> None:
+def unregister_stream_sink(
+    session_mongo_id: str | None,
+    queue: asyncio.Queue[tuple[str, dict[str, Any]]] | None = None,
+) -> None:
     """Remove the stream for ``session_mongo_id``.
 
     Idempotent, and must run in the same ``finally`` that detaches the sink. A
     leaked entry is a queue nobody drains, which would convert the next turn's
     honest fast refusal into a full-budget park.
+
+    ``queue`` makes the removal IDENTITY-CHECKED, and callers should always
+    pass it. Nothing serializes runs per session — a second tab on the same
+    conversation, or a second send while the first stream is still tailing,
+    gives two concurrent ``_drive_agent_loop`` runs with the same scope id, and
+    the later ``register_stream_sink`` overwrites the earlier entry. An
+    unconditional pop then lets whichever run finishes FIRST delete the entry
+    belonging to the one still streaming, which resurrects the exact
+    "no browser session is attached" failure this registry exists to fix, for
+    the rest of that run's turn. Popping only when the stored queue is still
+    ours makes a stale teardown a no-op.
     """
     if not session_mongo_id:
+        return
+    if queue is not None and _stream_sinks_by_session.get(session_mongo_id) is not queue:
         return
     _stream_sinks_by_session.pop(session_mongo_id, None)
 

--- a/ee/pocketpaw_ee/cloud/chat/agent_service.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_service.py
@@ -504,6 +504,68 @@ def detach_sse_event_sink(token: Token) -> None:
     _sse_event_sink.reset(token)
 
 
+# ── Session-keyed stream registry ───────────────────────────────────────────
+#
+# The ContextVar above answers "is there a sink in MY context", which is the
+# right question for an observability frame — a caller that has drifted out of
+# the stream's context simply should not emit one.
+#
+# It is the WRONG question for a caller that then WAITS on the frame. Code
+# Mode's file tools run inside an in-process MCP server owned by a POOLED SDK
+# client, and that client's task is created during ``_prewarm_session`` —
+# before the stream loop binds anything. A task inherits a copy of the context
+# as it stood at creation, so those tools read identity (bound during prewarm
+# as well; see ART-2 2026-06-26 and the two ``attach_agent_identity`` sites in
+# run_core) and never see the sink, which is bound only in the stream loop
+# afterwards. The tool then reports "no browser attached" about a browser that
+# is attached and streaming.
+#
+# Binding the sink during prewarm too — the shape ART-2 used for identity —
+# does NOT work here: prewarm has no live stream, so it would publish a queue
+# belonging to no turn, and a stale queue is worse than none. The fix is to
+# make the stream findable by IDENTITY instead of by inheritance.
+#
+# Keyed by ``session_mongo_id`` rather than by workspace: one workspace can
+# have two streams open in two windows, and a workspace-keyed lookup would hand
+# a file write to whichever one it happened to find.
+_stream_sinks_by_session: dict[str, asyncio.Queue[tuple[str, dict[str, Any]]]] = {}
+
+
+def register_stream_sink(
+    session_mongo_id: str | None,
+    queue: asyncio.Queue[tuple[str, dict[str, Any]]],
+) -> None:
+    """Publish ``queue`` as the live stream for ``session_mongo_id``.
+
+    A run whose scope is not a session has no id to publish under, and no Code
+    Mode surface to delegate to either, so it is skipped rather than refused.
+    """
+    if not session_mongo_id:
+        return
+    _stream_sinks_by_session[session_mongo_id] = queue
+
+
+def unregister_stream_sink(session_mongo_id: str | None) -> None:
+    """Remove the stream for ``session_mongo_id``.
+
+    Idempotent, and must run in the same ``finally`` that detaches the sink. A
+    leaked entry is a queue nobody drains, which would convert the next turn's
+    honest fast refusal into a full-budget park.
+    """
+    if not session_mongo_id:
+        return
+    _stream_sinks_by_session.pop(session_mongo_id, None)
+
+
+def stream_sink_for_session(
+    session_mongo_id: str | None,
+) -> asyncio.Queue[tuple[str, dict[str, Any]]] | None:
+    """The live stream for ``session_mongo_id``, or None when none is open."""
+    if not session_mongo_id:
+        return None
+    return _stream_sinks_by_session.get(session_mongo_id)
+
+
 # Legacy aliases retained for callers that were written against the
 # pocket-specific names. Both pairs operate on the same underlying sink.
 attach_pocket_event_sink = attach_sse_event_sink

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -1178,13 +1178,6 @@ async def _drive_agent_loop(
     side_channel_queue: asyncio.Queue[tuple[str, dict[str, Any]]] = asyncio.Queue()
     sink_token = attach_sse_event_sink(side_channel_queue)
     session_mongo_id = ctx.scope_id if ctx.kind is ScopeKind.SESSION else None
-    # Publish the same queue under this session's id, so a caller that cannot
-    # see the ContextVar above can still find the stream. Code Mode's file
-    # tools are exactly that caller: they run in the POOLED SDK client's task,
-    # created during _prewarm_session before this line ever executes, so they
-    # inherit a context with identity bound (ART-2 added the prewarm bind at
-    # ~1054) and no sink. Torn down in the same finally that detaches the sink.
-    register_stream_sink(session_mongo_id, side_channel_queue)
     identity_tokens = attach_agent_identity(
         workspace_id=ctx.workspace_id,
         user_id=ctx.user_id,
@@ -1244,6 +1237,19 @@ async def _drive_agent_loop(
     sup_session_id = ctx.scope_id
     sup_agent_id = ctx.target_agent_id
     try:
+        # Publish the same queue under this session's id, so a caller that
+        # cannot see the sink ContextVar can still find the stream. Code Mode's
+        # file tools are exactly that caller: they run in the POOLED SDK
+        # client's task, created during _prewarm_session before this function
+        # binds anything, so they inherit a context with identity bound (ART-2
+        # added the prewarm bind at ~1054) and no sink.
+        #
+        # Registered INSIDE the try, not beside attach_sse_event_sink above:
+        # everything between them — attach_agent_identity in particular, which
+        # rejects an unbound identity by design — can raise, and this entry is
+        # a process-level dict rather than a ContextVar, so a leak here would
+        # outlive the task and hand a dead queue to the next turn.
+        register_stream_sink(session_mongo_id, side_channel_queue)
         session_key = session_key_for(ctx)
         # Read the per-run tool policy from the PRE-RESOLVED, ENTITY-AWARE
         # profile (entity-rooms chunk ①). ``ctx.resolved_profile`` was resolved
@@ -1633,7 +1639,10 @@ async def _drive_agent_loop(
         # the next turn would park for the full delegate budget instead of
         # refusing at once.
         try:
-            unregister_stream_sink(session_mongo_id)
+            # Identity-checked: nothing serializes runs per session, so a
+            # second concurrent run on the same session may already own the
+            # entry. Popping it here would break the run still streaming.
+            unregister_stream_sink(session_mongo_id, side_channel_queue)
         except Exception:
             pass
         try:

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -296,9 +296,9 @@ from pocketpaw_ee.cloud.chat.agent_service import (
     mark_cloud_chat_run,
     push_sse_event,
     register_stream_sink,
-    unregister_stream_sink,
     session_key_for,
     unbind_pawbar_run,
+    unregister_stream_sink,
 )
 from pocketpaw_ee.cloud.chat.agent_service import (
     resolve_scope_context as resolve_scope_context,

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -1,6 +1,19 @@
 """Agent-run core — the loop the executor invokes for every chat run.
 
 Changes:
+- 2026-08-07 (fix/code-delegate-pooled-context) — ``_drive_agent_loop`` now
+  PUBLISHES its side-channel queue under the run's ``session_mongo_id``
+  (``register_stream_sink``, beside the existing ``attach_sse_event_sink``)
+  and withdraws it in the same ``finally`` that detaches the sink. The sink
+  ContextVar alone was not reachable by Code Mode's file tools: they run in an
+  in-process MCP server owned by a POOLED SDK client whose task is created
+  during ``_prewarm_session``, i.e. before this function binds anything, so
+  they inherited a context carrying identity (bound at prewarm too, per ART-2
+  below) and no sink — and reported "no browser attached" for a browser that
+  was attached and streaming. Binding the sink at prewarm as ART-2 did for
+  identity is wrong here, because prewarm has no live stream and would publish
+  a queue belonging to no turn; publishing by session id makes the stream
+  findable regardless of which task calls the tool.
 - 2026-08-02 (PA-2, feat/prompt-assembler-seam) — ``_drive_agent_loop`` and
   ``_prewarm_session`` thread the resolved surface into ``pool.run`` /
   ``pool.prewarm`` as ``surface_preamble`` + ``surface_cache_key``. The

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -1249,7 +1249,7 @@ async def _drive_agent_loop(
         # rejects an unbound identity by design — can raise, and this entry is
         # a process-level dict rather than a ContextVar, so a leak here would
         # outlive the task and hand a dead queue to the next turn.
-        register_stream_sink(session_mongo_id, side_channel_queue)
+        register_stream_sink(session_mongo_id, side_channel_queue, ctx.workspace_id)
         session_key = session_key_for(ctx)
         # Read the per-run tool policy from the PRE-RESOLVED, ENTITY-AWARE
         # profile (entity-rooms chunk ①). ``ctx.resolved_profile`` was resolved

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -282,6 +282,8 @@ from pocketpaw_ee.cloud.chat.agent_service import (
     detach_sse_event_sink,
     mark_cloud_chat_run,
     push_sse_event,
+    register_stream_sink,
+    unregister_stream_sink,
     session_key_for,
     unbind_pawbar_run,
 )
@@ -1163,6 +1165,13 @@ async def _drive_agent_loop(
     side_channel_queue: asyncio.Queue[tuple[str, dict[str, Any]]] = asyncio.Queue()
     sink_token = attach_sse_event_sink(side_channel_queue)
     session_mongo_id = ctx.scope_id if ctx.kind is ScopeKind.SESSION else None
+    # Publish the same queue under this session's id, so a caller that cannot
+    # see the ContextVar above can still find the stream. Code Mode's file
+    # tools are exactly that caller: they run in the POOLED SDK client's task,
+    # created during _prewarm_session before this line ever executes, so they
+    # inherit a context with identity bound (ART-2 added the prewarm bind at
+    # ~1054) and no sink. Torn down in the same finally that detaches the sink.
+    register_stream_sink(session_mongo_id, side_channel_queue)
     identity_tokens = attach_agent_identity(
         workspace_id=ctx.workspace_id,
         user_id=ctx.user_id,
@@ -1605,6 +1614,13 @@ async def _drive_agent_loop(
             await asyncio.gather(*pending, return_exceptions=True)
         try:
             detach_sse_event_sink(sink_token)
+        except Exception:
+            pass
+        # Must not outlive the sink: a stale entry is a queue nobody drains, so
+        # the next turn would park for the full delegate budget instead of
+        # refusing at once.
+        try:
+            unregister_stream_sink(session_mongo_id)
         except Exception:
             pass
         try:

--- a/ee/pocketpaw_ee/cloud/codeagent/delegates.py
+++ b/ee/pocketpaw_ee/cloud/codeagent/delegates.py
@@ -1,5 +1,16 @@
 # delegates.py — The browser-delegate channel for Code Mode (CD-1).
 #
+# Modified 2026-08-07 (fix/code-delegate-pooled-context): the outbound half no
+# longer decides "is anyone listening" from the SSE sink ContextVar alone. The
+# file tools that call in here run inside an in-process MCP server owned by a
+# POOLED SDK client, and that client's task is created during prewarm — before
+# the stream loop binds its sink — so they inherited a context with identity
+# and no sink, and this module refused every call with ``no_client`` while the
+# browser was attached and streaming. It now tries the ContextVar first and
+# falls back to looking the stream up by ``session_mongo_id``. The fast refusal
+# is unchanged for callers that genuinely have no browser (a CLI run, a
+# background job, a test), which is the property the park budget depends on.
+#
 # Created 2026-07-22 (feat/code-delegate-channel). Reshaped 2026-07-24
 # (feat/code-mode-file-tools): the main chat agent no longer hands a whole
 # ``task`` to a browser sub-agent — that sub-agent is gone. It now drives the

--- a/ee/pocketpaw_ee/cloud/codeagent/delegates.py
+++ b/ee/pocketpaw_ee/cloud/codeagent/delegates.py
@@ -345,19 +345,58 @@ async def delegate_call_to_browser(
         # Deferred import: every other cloud module reaches ``agent_service``
         # this way, because importing it at module scope pulls the chat stack
         # into anything that touches codeagent and reintroduces a cycle.
-        from pocketpaw_ee.cloud.chat.agent_service import has_sse_event_sink, push_sse_event
+        from pocketpaw_ee.cloud.chat.agent_service import (
+            current_session_mongo_id,
+            has_sse_event_sink,
+            push_sse_event,
+            stream_sink_for_session,
+        )
 
-        if not has_sse_event_sink():
-            logger.debug("codeagent.delegate refused: no SSE stream in scope")
-            return DelegateOutcome(
-                ok=False,
-                error=ERROR_NO_CLIENT,
-                message=(
-                    "No browser session is attached to this conversation, so the "
-                    "code cannot be reached."
-                ),
-            )
-        push = push_sse_event
+        if has_sse_event_sink():
+            # Same async context as the stream loop. Nothing to resolve.
+            push = push_sse_event
+        else:
+            # No sink in THIS context, which is not the same as no browser.
+            #
+            # The file tools calling us run inside an in-process MCP server
+            # owned by a POOLED SDK client, and that client's task is created
+            # during ``_prewarm_session`` — before the stream loop binds its
+            # sink. A task carries a copy of the context as it stood when it
+            # was created, so these callers see identity (bound during prewarm
+            # too, per ART-2) and never the sink. Refusing here reported "no
+            # browser attached" for a browser that was attached and streaming,
+            # which is what made every Code Mode file tool fail.
+            #
+            # Identity IS visible, so use it: find the stream by session id
+            # rather than by context inheritance.
+            session_mongo_id = current_session_mongo_id()
+            queue = stream_sink_for_session(session_mongo_id)
+            if queue is None:
+                # Genuinely nobody listening — a CLI run, a background job, a
+                # test. Keep failing FAST rather than parking for the full
+                # budget to discover it.
+                logger.debug(
+                    "codeagent.delegate refused: no SSE stream in scope and none "
+                    "registered for session=%s",
+                    session_mongo_id,
+                )
+                return DelegateOutcome(
+                    ok=False,
+                    error=ERROR_NO_CLIENT,
+                    message=(
+                        "No browser session is attached to this conversation, so the "
+                        "code cannot be reached."
+                    ),
+                )
+
+            def push(name: str, data: dict[str, Any], _q: Any = queue) -> None:
+                """Push straight into the resolved stream's queue.
+
+                ``push_sse_event`` reads the ContextVar we just established is
+                empty here, so calling it would silently drop the frame and
+                park the caller for the full timeout.
+                """
+                _q.put_nowait((name, data))
 
     corr_id = reg.open(workspace_id)
     try:

--- a/ee/pocketpaw_ee/cloud/codeagent/delegates.py
+++ b/ee/pocketpaw_ee/cloud/codeagent/delegates.py
@@ -339,11 +339,19 @@ async def delegate_call_to_browser(
     frame carrying ``{tool, input}``, park. The browser runs the matching
     ``CodeFileSession`` verb and resolves with ``{output, isError}``.
 
-    It FAILS FAST when there is no SSE stream in scope. ``push_sse_event`` is a
-    documented no-op outside a stream, so without that check a tool invoked from
-    a CLI handler, a background job, or a unit test would push into nothing and
-    then park for the full budget before reporting a timeout that was knowable
-    at once. The distinct ``no_client`` code also gives the model something true
+    It FAILS FAST when there is no stream to reach — but "no stream in scope" is
+    NOT the same question as "no stream". A sink in the caller's context is the
+    happy path; when it is absent the stream is looked up by
+    ``session_mongo_id`` (tenancy-checked), because the file tools calling here
+    run in a pooled SDK client's task created before the stream bound its sink,
+    and refusing on the ContextVar alone told users no browser was attached
+    while one was attached and streaming. Only when BOTH miss does this refuse.
+
+    That refusal still has to be immediate. ``push_sse_event`` is a documented
+    no-op outside a stream, so without the check a tool invoked from a CLI
+    handler, a background job, or a unit test would push into nothing and then
+    park for the full budget before reporting a timeout that was knowable at
+    once. The distinct ``no_client`` code also gives the model something true
     to say — "there is no browser attached" is a different problem from "the
     browser was slow".
 

--- a/ee/pocketpaw_ee/cloud/codeagent/delegates.py
+++ b/ee/pocketpaw_ee/cloud/codeagent/delegates.py
@@ -381,7 +381,9 @@ async def delegate_call_to_browser(
             # Identity IS visible, so use it: find the stream by session id
             # rather than by context inheritance.
             session_mongo_id = current_session_mongo_id()
-            queue = stream_sink_for_session(session_mongo_id)
+            # workspace_id is passed so the lookup refuses a stream
+            # belonging to another tenant; see stream_sink_for_session.
+            queue = stream_sink_for_session(session_mongo_id, workspace_id)
             if queue is None:
                 # Genuinely nobody listening — a CLI run, a background job, a
                 # test. Keep failing FAST rather than parking for the full

--- a/tests/cloud/test_codeagent_delegate_context.py
+++ b/tests/cloud/test_codeagent_delegate_context.py
@@ -159,3 +159,36 @@ async def test_delegate_still_refuses_when_no_stream_exists_at_all(
     assert outcome.ok is False
     assert outcome.error == ERROR_NO_CLIENT
     assert len(reg) == 0, "a refused delegate must not leak a registry slot"
+
+
+@pytest.mark.asyncio
+async def test_a_finished_run_does_not_unregister_a_concurrent_run_on_the_same_session() -> None:
+    """Teardown must not delete a stream that belongs to somebody else.
+
+    Nothing serializes runs per session: a second tab on the same conversation,
+    or a second send while the first stream is still tailing, gives two
+    concurrent `_drive_agent_loop` runs with the same scope id, and the later
+    `register_stream_sink` overwrites the earlier entry. If teardown popped by
+    key alone, whichever run finished FIRST would delete the entry belonging to
+    the run still streaming — resurrecting the exact "no browser session is
+    attached" failure this registry exists to fix, for the rest of that turn.
+    """
+    queue_a: asyncio.Queue[tuple[str, dict]] = asyncio.Queue()
+    queue_b: asyncio.Queue[tuple[str, dict]] = asyncio.Queue()
+
+    register_stream_sink(SESSION, queue_a)
+    register_stream_sink(SESSION, queue_b)  # run B overwrites run A's entry
+
+    # Run A finishes first and tears down. Its queue is no longer the
+    # registered one, so this must be a no-op.
+    unregister_stream_sink(SESSION, queue_a)
+
+    from pocketpaw_ee.cloud.chat.agent_service import stream_sink_for_session
+
+    assert stream_sink_for_session(SESSION) is queue_b, (
+        "run A's teardown deleted run B's live stream"
+    )
+
+    # B's own teardown still clears it.
+    unregister_stream_sink(SESSION, queue_b)
+    assert stream_sink_for_session(SESSION) is None

--- a/tests/cloud/test_codeagent_delegate_context.py
+++ b/tests/cloud/test_codeagent_delegate_context.py
@@ -1,0 +1,161 @@
+# test_codeagent_delegate_context.py — the delegate channel must survive the
+# task boundary that the pooled SDK client puts between the stream loop and the
+# tool.
+#
+# Created 2026-08-07 (fix/code-delegate-pooled-context). Reproduces a defect
+# observed end to end: every Code Mode file tool fails with
+# `code_delegate.no_client` — "No browser session is attached to this
+# conversation" — even though the browser is attached and streaming.
+#
+# WHY THE EXISTING SUITE MISSES IT: test_codeagent_delegates.py injects `push`
+# on every call, and `delegate_call_to_browser` only consults
+# `has_sse_event_sink()` when `push is None`. The production path is therefore
+# the one path the suite never exercises.
+#
+# THE MECHANISM, from run_core.py:
+#
+#   attach_agent_identity   is bound at TWO sites — 1054 (inside
+#                           _prewarm_session) and 1166 (the stream loop)
+#   attach_sse_event_sink   is bound at ONE  site — 1164 (the stream loop)
+#
+# The SDK client is pooled and prewarmed. `_prewarm_session` fires in its own
+# `create_task` context, which is created BEFORE the stream loop binds anything,
+# and a child task inherits a COPY of the context as it stood at creation. The
+# MCP tool in agent/mcp_servers/code.py runs in that pooled task, so it reads
+# identity (bound during prewarm) but never sees the sink (bound afterwards, in
+# a context it already copied). ART-2 hit exactly this wall on 2026-06-26 with
+# the per-tenant cwd jail and fixed it by adding the second identity bind; the
+# sink never got the same treatment.
+#
+# The observed signature is the proof: the failure logs a REAL workspace id
+# (`code.listDir delegate failed ws=69d0f4d0…`) while the sink reads as absent.
+# One ContextVar from the module is visible and its neighbour is not, which only
+# happens when the two were bound at different times relative to the task.
+#
+# A third bind is the WRONG fix: prewarm has no live stream, so it would capture
+# a queue belonging to no turn, and a stale queue is worse than no queue. The
+# channel has to be resolvable by IDENTITY rather than by inheritance —
+# `delegate_call_to_browser` already receives the workspace id, and identity
+# also carries `session_mongo_id`, which is the correct key because one
+# workspace can hold two streams open in two windows and a workspace-keyed
+# lookup would deliver a file operation to the wrong one.
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from pocketpaw_ee.cloud.chat.agent_service import (
+    attach_agent_identity,
+    attach_sse_event_sink,
+    detach_agent_identity,
+    detach_sse_event_sink,
+    register_stream_sink,
+    unregister_stream_sink,
+)
+from pocketpaw_ee.cloud.codeagent.delegates import (
+    ERROR_NO_CLIENT,
+    PendingDelegates,
+    delegate_call_to_browser,
+)
+
+WS = "ws-pooled-1"
+SESSION = "session-pooled-1"
+
+
+@pytest.fixture
+def reg() -> PendingDelegates:
+    return PendingDelegates()
+
+
+async def _run_in_task_created_before(
+    bind: asyncio.Event,
+    released: asyncio.Event,
+    out: dict,
+    reg: PendingDelegates,
+) -> None:
+    """Stand in for the pooled SDK client's tool task.
+
+    Created before the sink is bound, so it carries the prewarm-era context —
+    the same position agent/mcp_servers/code.py runs from.
+    """
+    bind.set()
+    await released.wait()
+    out["outcome"] = await delegate_call_to_browser(
+        WS,
+        "listDir",
+        {"path": "."},
+        timeout=0.25,
+        registry=reg,
+        # push deliberately left as None: this is the production path, the one
+        # that consults has_sse_event_sink().
+    )
+
+
+@pytest.mark.asyncio
+async def test_delegate_reaches_a_stream_bound_after_the_tool_task_was_created(
+    reg: PendingDelegates,
+) -> None:
+    """A live stream must be reachable from a task that predates its binding.
+
+    This is the end-to-end failure reduced to its mechanism. The browser IS
+    attached — the sink is bound and a queue is waiting — but the tool runs in a
+    task whose context was copied before that bind, so the ContextVar lookup
+    misses and the channel refuses a browser that is right there.
+
+    The assertion is deliberately weak: NOT no_client. Whether the call then
+    times out waiting for a resolve is irrelevant here — a timeout proves the
+    frame was pushed and the caller parked, which is the behaviour under test.
+    """
+    queue: asyncio.Queue[tuple[str, dict]] = asyncio.Queue()
+    bind = asyncio.Event()
+    released = asyncio.Event()
+    out: dict = {}
+
+    # Prewarm binds identity (ART-2, run_core ~1054) BEFORE the pooled task
+    # exists, which is why the tool can read a session id but not the sink.
+    identity = attach_agent_identity(workspace_id=WS, user_id="user-1", session_mongo_id=SESSION)
+    try:
+        # Created FIRST — snapshots the context as it stands now: identity, no sink.
+        task = asyncio.create_task(_run_in_task_created_before(bind, released, out, reg))
+        await bind.wait()
+
+        # The stream binds its sink and publishes itself only now, exactly as
+        # _drive_agent_loop does — after the pooled task already exists.
+        token = attach_sse_event_sink(queue)
+        register_stream_sink(SESSION, queue)
+        try:
+            released.set()
+            await asyncio.wait_for(task, timeout=5)
+        finally:
+            detach_sse_event_sink(token)
+            unregister_stream_sink(SESSION)
+    finally:
+        detach_agent_identity(identity)
+
+    outcome = out["outcome"]
+    assert outcome.error != ERROR_NO_CLIENT, (
+        "The delegate refused a browser that is attached and streaming. The sink "
+        "was bound before the call ran, but in a context the tool's task had "
+        "already copied — so the channel must resolve by identity, not by "
+        "context inheritance."
+    )
+
+
+@pytest.mark.asyncio
+async def test_delegate_still_refuses_when_no_stream_exists_at_all(
+    reg: PendingDelegates,
+) -> None:
+    """The fast refusal must SURVIVE the fix.
+
+    A CLI run, a background job or a test genuinely has no browser, and the
+    delegate must keep failing immediately instead of parking for the full
+    budget. Pinned here so a fix for the case above cannot make every caller
+    wait out the timeout to discover nobody is listening.
+    """
+    outcome = await delegate_call_to_browser(
+        WS, "listDir", {"path": "."}, timeout=0.25, registry=reg
+    )
+
+    assert outcome.ok is False
+    assert outcome.error == ERROR_NO_CLIENT
+    assert len(reg) == 0, "a refused delegate must not leak a registry slot"


### PR DESCRIPTION
Every Code Mode file tool failed with `code_delegate.no_client` — "No browser session is attached to this conversation" — while the browser was attached and streaming. Asking the agent to create a file in a local project always failed, and the agent correctly refused to pretend otherwise.

## What was happening

The file tools run inside an in-process MCP server owned by a **pooled** SDK client. That client's task is created during `_prewarm_session`, before the stream loop binds anything, and a task inherits a copy of the context as it stood at creation.

```
attach_agent_identity   bound at TWO sites:  run_core ~1054 (_prewarm_session)
                                             run_core ~1166 (stream loop)
attach_sse_event_sink   bound at ONE  site:  run_core ~1164 (stream loop only)
```

So the pooled task sees identity and never sees the sink. `has_sse_event_sink()` returns false and the channel refuses a browser that is right there.

The log signature is the proof: `code.listDir delegate failed ws=69d0f4d0…` carries a **real workspace id** while the sink reads as absent. One ContextVar from the module visible, its neighbour not, which only happens when the two were bound at different times relative to the task.

This is the same wall ART-2 hit on 2026-06-26, when the per-tenant cwd jail failed closed during warm-up. That was fixed by adding the second identity bind. The sink never got the same treatment.

## Why not just add a third bind

Prewarm has no live stream. Binding the sink there would publish a queue belonging to no turn, and a stale queue is worse than no queue — the caller would park on something nobody drains instead of failing honestly.

The channel needs to be findable by identity rather than by inheritance. It already receives the ids it needs.

## The change

The stream publishes itself under its `session_mongo_id` when it opens and withdraws in the same `finally` that detaches the sink. `delegate_call_to_browser` tries the context first, and falls back to that lookup when the context is empty.

Keyed by session rather than workspace: one workspace can hold two streams open in two windows, and a workspace-keyed lookup would hand a file write to whichever one it found first.

The fast refusal is deliberately preserved. A CLI run, a background job or a test genuinely has no browser and must keep failing at once rather than parking for the full delegate budget to discover it. That behaviour has its own test so a future change here cannot quietly turn every such caller into a timeout.

## Why the existing suite missed it

All twelve tests in `test_codeagent_delegates.py` inject `push`, and `delegate_call_to_browser` only consults the sink when `push is None`. The production path was the one path never exercised. The new test file drives the real path.

## Verification

- New tests: reproduction (fails before, passes after) plus the fast-refusal guard
- `tests/cloud/test_codeagent_delegates.py` + new file: 25 passed
- Reproduced and then confirmed **live** — local backend, desktop client, real `local` runtime project. The file tool failed before the change and writes the file after it.

The wider `tests/cloud` run is slow enough that it was still going at the time of writing; CI covers it.