### PR TITLE
Carry the Code Mode delegate rendezvous across processes

### DIFF
--- a/ee/pocketpaw_ee/cloud/codeagent/bridge.py
+++ b/ee/pocketpaw_ee/cloud/codeagent/bridge.py
@@ -1,0 +1,219 @@
+# bridge.py — the delegate rendezvous ACROSS processes.
+#
+# Created 2026-08-07 (fix/code-delegate-cross-process).
+#
+# THE PROBLEM. ``delegates.PendingDelegates`` is in-process and single-loop by
+# construction, and says so: "a resolve that lands on a different worker finds
+# no entry and is rejected as unknown". In the deployed cloud stack that is not
+# an edge case, it is EVERY delegate. deploy/coolify/docker-compose.yaml runs
+# two containers off one image with ``POCKETPAW_CLOUD_RUN_EXECUTOR: arq``:
+#
+#     backend (web)   serves POST /codeagent/resolve
+#     worker  (arq)   runs the chat turn, parks the 180s future
+#
+# The outbound leg already crosses that boundary — the worker XADDs SSE frames
+# to ``run:{run_id}:events`` and the web process relays them (see
+# runs/redis_stream.py). The RETURN leg had no such path: the browser posts its
+# answer to the web process, whose registry is empty, so ``resolve_pending``
+# raises NotFound and the worker's future runs out the full budget. Every Code
+# Mode file tool therefore failed with "The browser did not finish the
+# delegated task in 180s" while the browser had in fact finished it instantly.
+#
+# It does not reproduce on a single-process rig (``inprocess`` executor, which
+# is the default and what local dev runs), which is why the in-process
+# discovery fix that preceded this one tested clean and still failed in prod.
+#
+# WHY A LIST AND NOT PUB/SUB. Pub/sub drops a message with no subscriber
+# attached, which would turn a fast browser into a lost answer and a full-budget
+# park — the exact failure this module exists to prevent. A list is durable:
+# ``deliver`` can RPUSH before or after ``listen`` starts and the value is still
+# there, so there is no ordering race to reason about.
+#
+# WHY A SEPARATE PENDING KEY. ``resolve`` must keep answering honestly. The
+# pending key is the shared existence record — written by the process that
+# parks, read by the process that resolves — so an unknown id, an expired park
+# and a wrong-tenant resolve all still produce NotFound rather than a silent
+# success. It carries the workspace for the same reason ``_Pending`` does:
+# tenancy that rests on an unguessable correlation id is not tenancy.
+#
+# The bridge is INERT without Redis (single-process dev, tests, CLI runs), and
+# everything degrades to today's purely in-process behaviour.
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Protocol
+
+logger = logging.getLogger(__name__)
+
+# Slack on the pending key's TTL, so the record outlives the park it describes.
+# If the key expired first, a browser answering at the very edge of the budget
+# would be told the id never existed — a confusing lie in place of a clean
+# timeout.
+_PENDING_TTL_SLACK_SECONDS = 30
+
+# How long a delivered result waits to be collected before Redis reclaims it.
+# Only reachable when the parked caller died between the deliver and the
+# collect, so this is garbage collection rather than a functional window.
+_RESULT_TTL_SECONDS = 60
+
+
+def _pending_key(corr_id: str) -> str:
+    return f"code_delegate:pending:{corr_id}"
+
+
+def _result_key(corr_id: str) -> str:
+    return f"code_delegate:result:{corr_id}"
+
+
+class DelegateBridge(Protocol):
+    """Cross-process half of the delegate rendezvous."""
+
+    @property
+    def enabled(self) -> bool:
+        """False when there is no second process to reach (no Redis)."""
+        ...
+
+    async def announce(self, corr_id: str, workspace_id: str, *, ttl_seconds: int) -> None: ...
+
+    async def listen(self, corr_id: str, *, timeout: float) -> dict[str, Any] | None:
+        """Block until a result is delivered for ``corr_id``, or ``timeout``."""
+        ...
+
+    async def deliver(self, corr_id: str, workspace_id: str, result: dict) -> bool:
+        """Hand a result to whichever process parked ``corr_id``.
+
+        False when no park is on record for that id, or it belongs to another
+        workspace — the caller turns that into the same NotFound an unknown id
+        gets locally.
+        """
+        ...
+
+    async def forget(self, corr_id: str) -> None: ...
+
+
+class NullDelegateBridge:
+    """No Redis, so no second process to reach. Every operation is a no-op and
+    ``deliver`` always misses, which leaves the in-process registry as the only
+    path — exactly the behaviour before this module existed."""
+
+    @property
+    def enabled(self) -> bool:
+        return False
+
+    async def announce(self, corr_id: str, workspace_id: str, *, ttl_seconds: int) -> None:
+        return None
+
+    async def listen(self, corr_id: str, *, timeout: float) -> dict[str, Any] | None:
+        return None
+
+    async def deliver(self, corr_id: str, workspace_id: str, result: dict) -> bool:
+        return False
+
+    async def forget(self, corr_id: str) -> None:
+        return None
+
+
+class RedisDelegateBridge:
+    """Redis-backed rendezvous: a pending record plus a one-shot result list."""
+
+    def __init__(self, redis: Any) -> None:
+        self._redis = redis
+
+    @property
+    def enabled(self) -> bool:
+        return True
+
+    async def announce(self, corr_id: str, workspace_id: str, *, ttl_seconds: int) -> None:
+        """Publish that this process is parked on ``corr_id``.
+
+        Must happen BEFORE the delegate frame is pushed, for the same reason
+        ``PendingDelegates.open`` is split from ``wait``: the browser can answer
+        faster than the next await, and a resolve that arrives before the record
+        exists would be rejected as unknown.
+        """
+        await self._redis.set(_pending_key(corr_id), workspace_id, ex=ttl_seconds)
+
+    async def listen(self, corr_id: str, *, timeout: float) -> dict[str, Any] | None:
+        # COST: a blocking pop holds one connection from the pool for as long as
+        # the park lasts, so concurrent delegates cost concurrent connections
+        # (bounded in practice by how many file tools one turn runs at once, and
+        # redis-py's pool grows on demand). Polling would trade that for latency
+        # on every call; blocking is the right side of that trade while the
+        # delegate count per turn is small. Revisit if a turn ever fans out file
+        # operations in parallel.
+        #
+        # BLPOP returns as soon as a value is there, including one pushed before
+        # this call — the durability that makes the ordering race disappear.
+        # Redis takes an integer timeout; round UP so the bridge never gives up
+        # marginally before the caller's own budget.
+        blocking_for = max(1, int(timeout + 0.999))
+        popped = await self._redis.blpop([_result_key(corr_id)], timeout=blocking_for)
+        if popped is None:
+            return None
+        _key, raw = popped
+        try:
+            payload = json.loads(raw)
+        except (TypeError, ValueError):
+            logger.warning("codeagent.bridge: undecodable result corr=%s", corr_id)
+            return None
+        return payload if isinstance(payload, dict) else None
+
+    async def deliver(self, corr_id: str, workspace_id: str, result: dict) -> bool:
+        owner = await self._redis.get(_pending_key(corr_id))
+        if owner is None:
+            return False
+        if owner != workspace_id:
+            # Same posture as PendingDelegates.resolve: a mismatch is a miss, so
+            # the caller cannot learn that the id exists.
+            logger.warning("codeagent.bridge deliver rejected: workspace mismatch corr=%s", corr_id)
+            return False
+        await self._redis.rpush(_result_key(corr_id), json.dumps(result))
+        await self._redis.expire(_result_key(corr_id), _RESULT_TTL_SECONDS)
+        return True
+
+    async def forget(self, corr_id: str) -> None:
+        await self._redis.delete(_pending_key(corr_id), _result_key(corr_id))
+
+
+_bridge: DelegateBridge | None = None
+
+
+def get_delegate_bridge() -> DelegateBridge:
+    """Redis bridge when a URL is configured, otherwise inert.
+
+    Mirrors ``runs.transport.get_stream_transport``'s auto-detection so the two
+    halves of the same crossing are configured by one env var. No WARN on the
+    null path: single-process is a legitimate deployment, and the loud warning
+    already exists on the stream transport that would notice first.
+    """
+    global _bridge
+    if _bridge is None:
+        if os.environ.get("POCKETPAW_REDIS_URL", "").strip():
+            from pocketpaw_ee.cloud._core.redis_client import get_redis
+
+            _bridge = RedisDelegateBridge(get_redis())
+        else:
+            _bridge = NullDelegateBridge()
+    return _bridge
+
+
+def set_delegate_bridge(bridge: DelegateBridge | None) -> None:
+    """Inject a bridge (tests, and any future explicit wiring)."""
+    global _bridge
+    _bridge = bridge
+
+
+def _reset_for_tests() -> None:
+    global _bridge
+    _bridge = None
+
+
+__all__ = [
+    "DelegateBridge",
+    "NullDelegateBridge",
+    "RedisDelegateBridge",
+    "get_delegate_bridge",
+    "set_delegate_bridge",
+]

--- a/ee/pocketpaw_ee/cloud/codeagent/delegates.py
+++ b/ee/pocketpaw_ee/cloud/codeagent/delegates.py
@@ -1,5 +1,18 @@
 # delegates.py — The browser-delegate channel for Code Mode (CD-1).
 #
+# Modified 2026-08-07 (fix/code-delegate-cross-process): the rendezvous now
+# spans PROCESSES. This module's registry is in-process by construction, which
+# the deployed stack violates on every single delegate: the Coolify compose runs
+# `backend` (serves POST /codeagent/resolve) and `worker` (runs the turn, parks
+# the future) as two containers with POCKETPAW_CLOUD_RUN_EXECUTOR=arq. The
+# browser's answer therefore reached a process whose registry was empty, the
+# resolve 404'd, and the parked turn burned the full 180s — so every Code Mode
+# file tool "timed out" against a browser that had answered instantly. The park
+# now also announces itself through ``bridge.py`` (Redis) and a relay feeds a
+# cross-process answer into the same local future; ``resolve_pending_anywhere``
+# tries the local registry first and the bridge only on a miss. Single-process
+# deployments are byte-for-byte unchanged: without Redis the bridge is inert.
+#
 # Modified 2026-08-07 (fix/code-delegate-pooled-context): the outbound half no
 # longer decides "is anyone listening" from the SSE sink ContextVar alone. The
 # file tools that call in here run inside an in-process MCP server owned by a
@@ -51,8 +64,21 @@ from typing import Any
 from uuid import uuid4
 
 from pocketpaw_ee.cloud._core.errors import NotFound, ValidationError
+from pocketpaw_ee.cloud.codeagent.bridge import DelegateBridge, get_delegate_bridge
 
 logger = logging.getLogger(__name__)
+
+# Extra life on the bridge's pending record beyond the park it describes, so a
+# browser answering at the very edge of the budget meets a clean timeout rather
+# than being told the correlation id never existed.
+_BRIDGE_TTL_SLACK_SECONDS = 30
+
+# Ceiling on the announce, which is the one bridge call on the critical path
+# between minting a correlation id and pushing the frame. A local Redis SET is
+# sub-millisecond; this only ever fires when Redis is unreachable or sick, and
+# it keeps that fault costing one bounded pause instead of a connect timeout per
+# file tool call.
+_BRIDGE_ANNOUNCE_TIMEOUT_SECONDS = 2.0
 
 # ── The park budget ─────────────────────────────────────────────────────────
 # How long the backend will hold a turn open waiting for the browser.
@@ -331,6 +357,7 @@ async def delegate_call_to_browser(
     timeout: float = CODE_DELEGATE_TIMEOUT_SECONDS,
     registry: PendingDelegates | None = None,
     push: Callable[[str, dict[str, Any]], None] | None = None,
+    bridge: DelegateBridge | None = None,
 ) -> DelegateOutcome:
     """Hand one file tool call to the browser and wait for its result.
 
@@ -420,6 +447,34 @@ async def delegate_call_to_browser(
                 _q.put_nowait((name, data))
 
     corr_id = reg.open(workspace_id)
+
+    # Announce the park to the OTHER process before the frame goes out. In the
+    # deployed stack the turn runs in the arq worker while POST
+    # /codeagent/resolve is served by the web container, so without this record
+    # the browser's answer reaches a process whose registry is empty and this
+    # future runs the full budget. Ordered before the push for the same reason
+    # ``open`` precedes it: the browser can answer faster than our next await.
+    # Inert when no Redis is configured (single-process dev).
+    active_bridge = get_delegate_bridge() if bridge is None else bridge
+    if active_bridge.enabled:
+        try:
+            # Bounded: this await sits BETWEEN minting the correlation id and
+            # pushing the frame, so an unreachable or slow Redis would otherwise
+            # add its full connect timeout to EVERY file tool call before the
+            # browser even hears about the work. A couple of seconds is orders of
+            # magnitude more than a local SET needs and far below anything a user
+            # would read as a stall.
+            await asyncio.wait_for(
+                active_bridge.announce(
+                    corr_id, workspace_id, ttl_seconds=int(timeout) + _BRIDGE_TTL_SLACK_SECONDS
+                ),
+                timeout=_BRIDGE_ANNOUNCE_TIMEOUT_SECONDS,
+            )
+        except Exception:  # noqa: BLE001 — a broken bridge must not kill the turn
+            # Degrade to in-process only: same-process resolves still work and a
+            # cross-process one times out as it did before this existed.
+            logger.warning("codeagent.bridge announce failed corr=%s", corr_id, exc_info=True)
+
     try:
         push(DELEGATE_EVENT, {"corrId": corr_id, "tool": tool, "input": tool_input})
     except Exception:  # noqa: BLE001 — a failed push must not kill the turn
@@ -427,6 +482,7 @@ async def delegate_call_to_browser(
         # Nobody is parked on this future yet, so drop the slot rather than
         # settling it — an abort here would wake a waiter that does not exist.
         reg.discard(corr_id)
+        await _forget_quietly(active_bridge, corr_id)
         return DelegateOutcome(
             ok=False,
             error=ERROR_NO_CLIENT,
@@ -440,7 +496,59 @@ async def delegate_call_to_browser(
         tool,
         timeout,
     )
-    return await reg.wait(corr_id, timeout=timeout)
+
+    # The relay feeds a cross-process answer into the SAME local future the
+    # in-process path settles, so ``wait`` keeps one wake-up mechanism and its
+    # anti-leak ``finally`` unchanged.
+    relay: asyncio.Task[None] | None = None
+    if active_bridge.enabled:
+        relay = asyncio.create_task(
+            _relay_bridge_result(active_bridge, reg, corr_id, workspace_id, timeout)
+        )
+    try:
+        return await reg.wait(corr_id, timeout=timeout)
+    finally:
+        if relay is not None:
+            relay.cancel()
+        await _forget_quietly(active_bridge, corr_id)
+
+
+async def _forget_quietly(bridge: DelegateBridge, corr_id: str) -> None:
+    """Drop the bridge's records. Never raises: this runs on the teardown path
+    of a turn that has already produced its outcome, and a Redis blip must not
+    turn a completed delegation into an exception."""
+    try:
+        await bridge.forget(corr_id)
+    except Exception:  # noqa: BLE001
+        logger.debug("codeagent.bridge forget failed corr=%s", corr_id, exc_info=True)
+
+
+async def _relay_bridge_result(
+    bridge: DelegateBridge,
+    reg: PendingDelegates,
+    corr_id: str,
+    workspace_id: str,
+    timeout: float,
+) -> None:
+    """Wait for a result delivered by another process and settle it locally.
+
+    Deliberately routed through ``reg.resolve`` rather than touching the future
+    directly: that keeps the duplicate-resolve and workspace checks in ONE
+    place, so a cross-process answer cannot bypass a guard the in-process path
+    enforces.
+    """
+    try:
+        result = await bridge.listen(corr_id, timeout=timeout)
+    except asyncio.CancelledError:
+        raise
+    except Exception:  # noqa: BLE001
+        logger.warning("codeagent.bridge listen failed corr=%s", corr_id, exc_info=True)
+        return
+    if result is None:
+        return
+    if not reg.resolve(corr_id, result, workspace_id=workspace_id):
+        # Already settled in-process, or the park is gone. Both are benign.
+        logger.debug("codeagent.bridge result arrived with nobody parked corr=%s", corr_id)
 
 
 def resolve_pending(
@@ -463,6 +571,49 @@ def resolve_pending(
     reg = get_pending_delegates() if registry is None else registry
     if not reg.resolve(corr_id, result, workspace_id=workspace_id):
         raise NotFound("code_delegate", corr_id)
+
+
+async def resolve_pending_anywhere(
+    workspace_id: str,
+    corr_id: str,
+    result: dict,
+    *,
+    registry: PendingDelegates | None = None,
+    bridge: DelegateBridge | None = None,
+) -> None:
+    """Deliver the browser's answer to the parked caller, in THIS process or another.
+
+    The HTTP entry point for a resolve. In the deployed stack the request lands
+    on the web container while the turn is parked in the arq worker, so a purely
+    in-process lookup misses every time and the worker times out — see
+    ``bridge.py`` for the full account.
+
+    Order matters: the local registry is tried FIRST, so a single-process
+    deployment (the ``inprocess`` executor, and every test) behaves exactly as it
+    did, and the bridge is only consulted on a miss.
+
+    Raises ``NotFound`` when neither path has a park on record. The four cases
+    the sync version folds together stay folded, and the bridge adds no fifth:
+    an id it does not know, and one whose workspace does not match, are both
+    misses there too.
+    """
+    _guard_result_size(result)
+    reg = get_pending_delegates() if registry is None else registry
+    if reg.resolve(corr_id, result, workspace_id=workspace_id):
+        return
+
+    active_bridge = get_delegate_bridge() if bridge is None else bridge
+    if active_bridge.enabled:
+        try:
+            if await active_bridge.deliver(corr_id, workspace_id, result):
+                return
+        except Exception:  # noqa: BLE001
+            # A broken bridge must not turn into a 500 for the browser. Fall
+            # through to NotFound: the parked caller will time out cleanly,
+            # which is the behaviour this deployment had before the bridge.
+            logger.warning("codeagent.bridge deliver failed corr=%s", corr_id, exc_info=True)
+
+    raise NotFound("code_delegate", corr_id)
 
 
 def _guard_result_size(result: dict) -> None:
@@ -498,4 +649,5 @@ __all__ = [
     "delegate_call_to_browser",
     "get_pending_delegates",
     "resolve_pending",
+    "resolve_pending_anywhere",
 ]

--- a/ee/pocketpaw_ee/cloud/codeagent/service.py
+++ b/ee/pocketpaw_ee/cloud/codeagent/service.py
@@ -53,7 +53,9 @@ async def resolve_delegate(
         user_id,
         body.corrId,
     )
-    delegates.resolve_pending(workspace_id, body.corrId, body.result)
+    # Cross-process aware: in the deployed stack this request lands on the web
+    # container while the turn is parked in the arq worker.
+    await delegates.resolve_pending_anywhere(workspace_id, body.corrId, body.result)
     return DelegateResolveResponse(accepted=True)
 
 

--- a/src/pocketpaw/atlas/data/atlas.json
+++ b/src/pocketpaw/atlas/data/atlas.json
@@ -1810,6 +1810,20 @@
     },
     {
       "gist": "",
+      "how": "a user invokes it as /pocketpaw-create-react-site in chat; the agent loads it via the Skill tool (bundled Claude Code plugin). Workspace-installed skills are discovered via the system-prompt skills block, not atlas.",
+      "id": "skill:pocketpaw-create-react-site",
+      "keywords": [
+        "pocketpaw-create-react-site"
+      ],
+      "kind": "skill",
+      "name": "pocketpaw-create-react-site",
+      "narrative": "Build a marketing landing page as a Paw Site on the REACT TRACK — a real, standalone website you author as hand-written React components, PRERENDERED to static HTML at build time and deployed to the edge. Decide by the REQUIREMENT: reach for this when the user EXPLICITLY asks for React (\"build it in React\", \"use React\", \"a React landing page\") or when the page genuinely needs React-shaped client interactivity. Do NOT default to it for a plain static marketing page (\"build a dentist landing page\", \"a marketing page for my bakery\") — that is the common case and belongs to the html track (create_html_site) or pocketpaw-create-paw-site. When you DO use it: YOU write the React components (Hero, Pricing, Faq, ...) at the quality bar set by pocketpaw-design-taste, assemble them into a source map rooted at src/App.tsx, and a deterministic tool persists the pocket stamped type=\"site\" + pattern=\"landing\" + engine=\"react\". You do NOT compose a rippleSpec, do NOT call get_widget_spec, do NOT use the pocket specialist. CRITICAL: a React page with client state (a menu toggle, tabs, a counter) is INERT unless you pass interactive=true — the site ships zero JavaScript by default. Loading this skill keeps the chat agent's always-on system prompt small while still delivering the full React authoring brain when a site actually needs React.",
+      "requires": [],
+      "summary": "Build a marketing landing page as a Paw Site on the REACT TRACK — a real, standalone website you author as hand-written React components, PRERENDERED to static HTML at build time and deployed to the…",
+      "surface": ""
+    },
+    {
+      "gist": "",
       "how": "a user invokes it as /pocketpaw-create-site in chat; the agent loads it via the Skill tool (bundled Claude Code plugin). Workspace-installed skills are discovered via the system-prompt skills block, not atlas.",
       "id": "skill:pocketpaw-create-site",
       "keywords": [

--- a/tests/cloud/conftest.py
+++ b/tests/cloud/conftest.py
@@ -101,6 +101,27 @@ def local_store_home(tmp_path_factory):
 
 
 @pytest.fixture(autouse=True)
+def inert_delegate_bridge():
+    """Keep the Code Mode delegate bridge off the network in unit tests.
+
+    ``get_delegate_bridge()`` auto-enables whenever ``POCKETPAW_REDIS_URL`` is
+    set — and this conftest sets it to the stub ``redis://test:6379/0`` purely so
+    the arq worker module imports (see the note at the top of this file).
+    Without this fixture that stub hands every test a LIVE Redis bridge pointed
+    at a host that does not resolve, so each delegate pays a connect timeout
+    before pushing its frame and any test that reads the pushed frame races it.
+
+    Tests covering the cross-process path inject their own bridge explicitly,
+    which is the honest way to test a two-process rendezvous anyway.
+    """
+    from pocketpaw_ee.cloud.codeagent import bridge as bridge_mod
+
+    bridge_mod.set_delegate_bridge(bridge_mod.NullDelegateBridge())
+    yield
+    bridge_mod._reset_for_tests()
+
+
+@pytest.fixture(autouse=True)
 def recording_bus():
     """Install a RecordingBus for every test.
 

--- a/tests/cloud/test_codeagent_delegate_cross_process.py
+++ b/tests/cloud/test_codeagent_delegate_cross_process.py
@@ -1,0 +1,308 @@
+# test_codeagent_delegate_cross_process.py — the delegate rendezvous across
+# two processes.
+#
+# Created 2026-08-07 (fix/code-delegate-cross-process). Reproduces the second
+# layer of the Code Mode file-tool failure, the one that only appears in the
+# DEPLOYED topology and never on a developer machine.
+#
+# THE TOPOLOGY. deploy/coolify/docker-compose.yaml runs two containers off one
+# image with POCKETPAW_CLOUD_RUN_EXECUTOR=arq:
+#
+#     backend (web)   serves POST /codeagent/resolve
+#     worker  (arq)   runs the chat turn and parks the 180s future
+#
+# PendingDelegates is in-process and single-loop by construction — its own
+# docstring says a resolve landing on a different worker "finds no entry and is
+# rejected as unknown". In this topology that is not an edge case, it is every
+# delegate: the browser answers the WEB process, whose registry is empty, so the
+# worker's future runs the full budget and the user is told the browser did not
+# finish — about a browser that finished instantly.
+#
+# WHY IT HID. Local dev and every existing test run one process (the default
+# `inprocess` executor), where park and resolve share a registry. The in-process
+# discovery fix that shipped first (register_stream_sink) was verified on
+# exactly that rig and still failed in production, because the two bugs were
+# stacked: fixing the first exposed the second. The error class changing from an
+# instant "no browser session" to a 180s timeout is what distinguishes them.
+#
+# HOW THESE TESTS MODEL IT. Two SEPARATE PendingDelegates instances stand in for
+# the two processes — that is precisely what a second process is here, an
+# unrelated in-memory registry — with a fake bridge as the shared Redis. If the
+# park and the resolve could see one registry these tests would pass without the
+# fix, so they use different ones on purpose.
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import NotFound
+from pocketpaw_ee.cloud.codeagent.bridge import NullDelegateBridge
+from pocketpaw_ee.cloud.codeagent.delegates import (
+    DELEGATE_EVENT,
+    ERROR_TIMEOUT,
+    PendingDelegates,
+    delegate_call_to_browser,
+    resolve_pending_anywhere,
+)
+
+WS = "ws-xproc"
+OTHER_WS = "ws-someone-else"
+
+
+class FakeBridge:
+    """Stands in for Redis: one dict of pending records, one of result lists.
+
+    Mirrors RedisDelegateBridge's contract exactly — durable delivery (a result
+    delivered before anyone listens is still collected), tenancy checked on the
+    pending record, and a miss for anything it has not been told about.
+    """
+
+    def __init__(self) -> None:
+        self.pending: dict[str, str] = {}
+        self.results: dict[str, list[dict]] = {}
+        self.forgotten: list[str] = []
+
+    @property
+    def enabled(self) -> bool:
+        return True
+
+    async def announce(self, corr_id: str, workspace_id: str, *, ttl_seconds: int) -> None:
+        self.pending[corr_id] = workspace_id
+
+    async def listen(self, corr_id: str, *, timeout: float) -> dict[str, Any] | None:
+        # Poll rather than block: same observable behaviour as BLPOP (returns as
+        # soon as a value exists, including one pushed before the call).
+        deadline = timeout
+        while deadline > 0:
+            queued = self.results.get(corr_id)
+            if queued:
+                return queued.pop(0)
+            await asyncio.sleep(0.01)
+            deadline -= 0.01
+        return None
+
+    async def deliver(self, corr_id: str, workspace_id: str, result: dict) -> bool:
+        owner = self.pending.get(corr_id)
+        if owner is None or owner != workspace_id:
+            return False
+        self.results.setdefault(corr_id, []).append(json.loads(json.dumps(result)))
+        return True
+
+    async def forget(self, corr_id: str) -> None:
+        self.forgotten.append(corr_id)
+        self.pending.pop(corr_id, None)
+        self.results.pop(corr_id, None)
+
+
+def _capture_push(sink: list[tuple[str, dict]]):
+    def push(name: str, data: dict) -> None:
+        sink.append((name, data))
+
+    return push
+
+
+@pytest.mark.asyncio
+async def test_a_resolve_on_another_process_wakes_the_parked_turn() -> None:
+    """The whole bug, in one test.
+
+    The turn parks in the worker's registry; the browser answers the web
+    process, which has a DIFFERENT registry. Without the bridge the web process
+    404s and the worker times out after the full budget. With it, the answer
+    crosses and the turn completes.
+    """
+    bridge = FakeBridge()
+    worker_registry = PendingDelegates()  # the arq container
+    web_registry = PendingDelegates()  # the backend container
+    pushed: list[tuple[str, dict]] = []
+
+    park = asyncio.create_task(
+        delegate_call_to_browser(
+            WS,
+            "listDir",
+            {"path": "."},
+            timeout=5,
+            registry=worker_registry,
+            push=_capture_push(pushed),
+            bridge=bridge,
+        )
+    )
+
+    # Wait for the frame the browser would receive.
+    for _ in range(200):
+        if pushed:
+            break
+        await asyncio.sleep(0.01)
+    assert pushed, "no code_delegate frame was pushed"
+    name, frame = pushed[0]
+    assert name == DELEGATE_EVENT
+    corr_id = frame["corrId"]
+
+    # The browser POSTs to the WEB process — a registry that never saw the park.
+    await resolve_pending_anywhere(
+        WS,
+        corr_id,
+        {"output": "Test.html", "isError": False},
+        registry=web_registry,
+        bridge=bridge,
+    )
+
+    outcome = await asyncio.wait_for(park, timeout=5)
+    assert outcome.ok is True, f"parked turn did not receive the answer: {outcome}"
+    assert outcome.result["output"] == "Test.html"
+
+
+@pytest.mark.asyncio
+async def test_without_the_bridge_the_same_sequence_times_out() -> None:
+    """Pins WHY the bridge is needed rather than assuming it.
+
+    Identical to the test above except the bridge is inert. This is the
+    production behaviour before this change: the resolve finds nothing and the
+    parked turn burns its budget. Kept so nobody 'simplifies' the bridge away
+    and sees a green suite.
+    """
+    worker_registry = PendingDelegates()
+    web_registry = PendingDelegates()
+    pushed: list[tuple[str, dict]] = []
+
+    park = asyncio.create_task(
+        delegate_call_to_browser(
+            WS,
+            "listDir",
+            {"path": "."},
+            timeout=0.5,
+            registry=worker_registry,
+            push=_capture_push(pushed),
+            bridge=NullDelegateBridge(),
+        )
+    )
+    for _ in range(200):
+        if pushed:
+            break
+        await asyncio.sleep(0.01)
+    corr_id = pushed[0][1]["corrId"]
+
+    with pytest.raises(NotFound):
+        await resolve_pending_anywhere(
+            WS, corr_id, {"output": "x"}, registry=web_registry, bridge=NullDelegateBridge()
+        )
+
+    outcome = await asyncio.wait_for(park, timeout=5)
+    assert outcome.ok is False
+    assert outcome.error == ERROR_TIMEOUT
+
+
+@pytest.mark.asyncio
+async def test_the_local_registry_is_tried_first() -> None:
+    """Single-process deployments must not change behaviour.
+
+    The `inprocess` executor and every existing test share one registry, so the
+    answer has to be settled locally without the bridge being consulted at all.
+    """
+    bridge = FakeBridge()
+    registry = PendingDelegates()
+    pushed: list[tuple[str, dict]] = []
+
+    park = asyncio.create_task(
+        delegate_call_to_browser(
+            WS,
+            "listDir",
+            {"path": "."},
+            timeout=5,
+            registry=registry,
+            push=_capture_push(pushed),
+            bridge=bridge,
+        )
+    )
+    for _ in range(200):
+        if pushed:
+            break
+        await asyncio.sleep(0.01)
+    corr_id = pushed[0][1]["corrId"]
+
+    await resolve_pending_anywhere(
+        WS, corr_id, {"output": "local"}, registry=registry, bridge=bridge
+    )
+
+    outcome = await asyncio.wait_for(park, timeout=5)
+    assert outcome.ok is True
+    assert outcome.result["output"] == "local"
+    assert bridge.results == {}, "the bridge was used when the local registry could answer"
+
+
+@pytest.mark.asyncio
+async def test_a_cross_process_resolve_from_the_wrong_workspace_is_a_miss() -> None:
+    """Tenancy holds across the crossing too.
+
+    The bridge is a process-global keyed by an unguessable id, which is exactly
+    the shape `_Pending` warns about: "tenancy that rests on unguessability is
+    not tenancy". A foreign workspace must get the same NotFound an unknown id
+    gets, and the parked turn must stay parked.
+    """
+    bridge = FakeBridge()
+    worker_registry = PendingDelegates()
+    web_registry = PendingDelegates()
+    pushed: list[tuple[str, dict]] = []
+
+    park = asyncio.create_task(
+        delegate_call_to_browser(
+            WS,
+            "listDir",
+            {"path": "."},
+            timeout=1.5,
+            registry=worker_registry,
+            push=_capture_push(pushed),
+            bridge=bridge,
+        )
+    )
+    for _ in range(200):
+        if pushed:
+            break
+        await asyncio.sleep(0.01)
+    corr_id = pushed[0][1]["corrId"]
+
+    with pytest.raises(NotFound):
+        await resolve_pending_anywhere(
+            OTHER_WS, corr_id, {"output": "stolen"}, registry=web_registry, bridge=bridge
+        )
+
+    outcome = await asyncio.wait_for(park, timeout=5)
+    assert outcome.ok is False
+    assert outcome.error == ERROR_TIMEOUT, "a foreign resolve must not settle the park"
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_correlation_id_still_raises_not_found() -> None:
+    """The honest 404 survives. An id neither side has parked is still unknown,
+    so the bridge cannot become a silent success for a bogus resolve."""
+    bridge = FakeBridge()
+    with pytest.raises(NotFound):
+        await resolve_pending_anywhere(
+            WS, "nope-not-a-real-id", {"output": "x"}, registry=PendingDelegates(), bridge=bridge
+        )
+
+
+@pytest.mark.asyncio
+async def test_the_park_clears_its_bridge_record_on_the_way_out() -> None:
+    """A leaked pending record is a correlation id a late browser could deliver
+    into — the cross-process twin of the registry leak `wait`'s finally exists to
+    prevent. Cleared on every exit, including the timeout path."""
+    bridge = FakeBridge()
+    pushed: list[tuple[str, dict]] = []
+
+    outcome = await delegate_call_to_browser(
+        WS,
+        "listDir",
+        {"path": "."},
+        timeout=0.3,
+        registry=PendingDelegates(),
+        push=_capture_push(pushed),
+        bridge=bridge,
+    )
+
+    assert outcome.ok is False
+    assert outcome.error == ERROR_TIMEOUT
+    assert bridge.pending == {}, "a timed-out park left its bridge record behind"
+    assert bridge.forgotten, "forget() was never called"


### PR DESCRIPTION
Every Code Mode file tool on the deployed cloud reported "The browser did not finish the delegated task in 180s" — about a browser that had answered instantly — and burned the full budget doing it. Three attempts per turn turned a one-line request into six minutes of spinning.

## What was happening

`PendingDelegates` is in-process and single-loop by construction, and says so: *"a resolve that lands on a different worker finds no entry and is rejected as unknown."* `deploy/coolify/docker-compose.yaml` makes that **every** delegate rather than an edge case — two containers off one image, both with `POCKETPAW_CLOUD_RUN_EXECUTOR: arq`:

```
backend (web)   serves POST /codeagent/resolve
worker  (arq)   runs the turn, parks the future — no HTTP server, no ports
```

The outbound leg already crossed that boundary: the worker `XADD`s SSE frames and the web process relays them (`runs/redis_stream.py`). The **return** leg had no path at all, so the browser's answer arrived at a registry that had never heard of the correlation id, `resolve_pending` raised `NotFound`, and the worker's future ran out the clock.

## The change

The park announces itself under a Redis key before the frame goes out, and a relay feeds a cross-process answer into the **same local future** — so `wait()` keeps one wake-up mechanism and its anti-leak `finally` untouched. `resolve_pending_anywhere` tries the local registry first and the bridge only on a miss.

Three decisions worth pushing on in review:

**A durable list, not pub/sub.** Pub/sub drops a message when no subscriber is attached, which would turn a fast browser into a lost answer and a full-budget park — precisely the failure this fixes. A list means deliver-before-listen is safe and there is no ordering race to reason about.

**A separate pending key.** It carries the workspace, so an unknown id, an expired park and a wrong-tenant resolve all remain one honest `NotFound`. The bridge is a process-global keyed by an unguessable correlation id, which is exactly what `_Pending`'s docstring warns against: *"tenancy that rests on unguessability is not tenancy."* Covered by its own test.

**The announce is bounded at 2s.** It sits between minting the id and pushing the frame, so an unreachable Redis would otherwise add its full connect timeout to every file tool call.

Single-process deployments are unchanged: without `POCKETPAW_REDIS_URL` the bridge is inert, and the local registry is always tried first.

## Why this hid behind the previous fix

Local dev and every existing test run one process (the `inprocess` executor default), where park and resolve share a registry. #1883 was verified on exactly that rig and still failed in production, because the two bugs were stacked — fixing in-process discovery turned an instant "no browser session" into a 180s timeout. The error class changing is what distinguishes them.

## Verification

- **6 new tests**, including the pre-fix reproduction: the same sequence with an inert bridge still 404s and times out, so the bridge cannot be removed without a red suite. Plus tenancy, local-first, unknown-id, and record cleanup.
- 32 delegate tests green; `tests/cloud/chat` + delegate suites: **172 passed**.
- `tests/cloud/runs`: 159 passed, **1 failure** (`test_execute_run_threads_surface_meta_into_ctx`) confirmed **pre-existing** by stashing every change here and re-running on clean `origin/dev`, where it fails identically.
- The full `tests/cloud` tree does not complete on this machine — it deadlocks on Mongo at 0% CPU, the documented non-hermetic-suite problem, unrelated to this change. Flagging rather than claiming a clean sweep.

The `tests/cloud/conftest.py` fixture is required, not incidental: that conftest sets a **stub** `POCKETPAW_REDIS_URL` so the arq worker module imports, and the bridge's auto-detection would otherwise hand every test a live Redis client pointed at a host that does not resolve.

## Deploying

Inert until the Coolify image is rebuilt with `--no-cache` — it clones `pocketpaw@dev` at build time and a plain redeploy reuses the cached clone. No new infrastructure or env vars: both containers already share `redis://redis:6379/0` for the stream transport.