### PR TITLE
Two test guards that could not fail

### DIFF
--- a/scripts/gen_topics.py
+++ b/scripts/gen_topics.py
@@ -1,20 +1,81 @@
 """Generate paw-enterprise/src/lib/core/shared/topics.gen.ts from EVENT_REGISTRY.
 
 Run via:  uv run python scripts/gen_topics.py
+
+Updated 2026-08-07 (fix/test-guard-blindness). Three changes, all in service of
+the staleness guard in ``tests/cloud/realtime/test_topics_gen.py``, which used
+to run this script as a subprocess and diff the file before and after.
+
+1. ``DEFAULT_OUT`` is the ONE derivation of the output path. The guard used to
+   re-derive the same location from its own ``__file__`` at a different depth
+   (``parents[3].parent`` there vs ``parents[2]`` here). Two derivations that
+   agree only by directory depth are not a contract: move either file and they
+   quietly point at different places, at which point ``before == after`` is
+   trivially true and the gate passes forever. The guard now imports this
+   constant instead of computing its own.
+
+2. ``render()`` is pure. The guard can compare what the generator WOULD write
+   against the committed file without writing anything, which matters because
+   the output lives in a DIFFERENT REPO. A test in pocketpaw had no business
+   mutating a tracked file in paw-enterprise while other agents work in it.
+
+3. The write pins ``newline="\\n"``. ``write_text`` with the default
+   ``newline=None`` translates to ``os.linesep``, so this script emitted CRLF on
+   Windows and LF everywhere else — the same registry produced different bytes
+   depending on who ran it. The old guard could not see that: ``read_text``
+   normalises newlines before comparing, so a Linux runner rewrote the tracked
+   file and the test still passed. LF is the right pin: the target file is one
+   of ~10 CRLF files among ~190 LF ones in paw-enterprise/src, which makes its
+   CRLF a Windows generation artifact rather than a convention.
+
+   CONSEQUENCE, deliberately not handled here: the committed topics.gen.ts is
+   still CRLF, so the next deliberate run of this script rewrites it LF and
+   shows a whole-file, whitespace-only diff. That belongs in a paw-enterprise
+   commit, not in a pocketpaw PR. Nothing does it automatically — the guard no
+   longer writes.
+
+WHAT THIS SCRIPT'S OUTPUT DEPENDS ON, which is the reason for ``--print``.
+``EVENT_REGISTRY`` is populated by ``Event.__init_subclass__``, so it holds
+exactly the events whose defining module has been IMPORTED — not every event in
+the codebase. This script imports only ``_core.realtime.events``, so the file it
+writes is a snapshot of that minimal import chain, and running the same function
+inside a process that has imported more of ``pocketpaw_ee`` produces MORE topics.
+``--print`` gives the guard a clean interpreter to render in, so the check is
+independent of whatever else the test session imported. The old guard got this
+isolation by accident, from running the script as a subprocess; losing it silently
+would have made the check order-dependent.
+
+(That the registry under-counts at all is a real defect in what this script
+generates — measured 2026-08-07: 136 topics here versus 146 after importing the
+whole ``pocketpaw_ee`` tree, the difference being the belt, mandate and meeting
+events. Fixing it changes the generated file in another repo, so it is filed as a
+follow-up rather than smuggled into a test-guard PR.)
 """
 
+import sys
 from pathlib import Path
 
 from pocketpaw_ee.cloud._core.realtime.events import EVENT_REGISTRY
 
-OUT = Path(__file__).resolve().parents[2] / "paw-enterprise/src/lib/core/shared/topics.gen.ts"
+#: The generated file, in the paw-enterprise sibling repo. The single source of
+#: truth for this location — import it, never re-derive it.
+DEFAULT_OUT = (
+    Path(__file__).resolve().parents[2] / "paw-enterprise/src/lib/core/shared/topics.gen.ts"
+)
 
 HEADER = """// GENERATED -- do not edit. Run `uv run python backend/scripts/gen_topics.py`.
 // Mirrors backend EVENT_REGISTRY keys.
 """
 
 
-def main() -> None:
+def render() -> str:
+    """Return the full text of topics.gen.ts, newline-separated with LF.
+
+    Pure: no I/O, no dependence on the current platform or on what is already
+    on disk. Line-for-line what this script has always written — the guard
+    compares this against the committed file, so a cosmetic edit here is a
+    real change to another repo's tracked content.
+    """
     topics = sorted(EVENT_REGISTRY.keys())
     lines = [HEADER, "export const TOPICS = ["]
     for t in topics:
@@ -22,10 +83,30 @@ def main() -> None:
     lines.append("] as const;")
     lines.append("")
     lines.append("export type Topic = (typeof TOPICS)[number];")
-    OUT.parent.mkdir(parents=True, exist_ok=True)
-    OUT.write_text("\n".join(lines) + "\n", encoding="utf-8")
-    print(f"wrote {len(topics)} topics -> {OUT}")
+    return "\n".join(lines) + "\n"
+
+
+def main(out: Path | None = None) -> Path:
+    """Write the rendered topics to ``out`` (default: ``DEFAULT_OUT``).
+
+    Returns the path actually written so a caller can assert the write landed
+    where it asked — the old guard ran this as a subprocess and never checked
+    that anything had been written at all.
+    """
+    target = Path(out) if out is not None else DEFAULT_OUT
+    target.parent.mkdir(parents=True, exist_ok=True)
+    # newline="\n" (not the os.linesep default) so the bytes are identical on
+    # every platform. See the module docstring.
+    target.write_text(render(), encoding="utf-8", newline="\n")
+    return target
 
 
 if __name__ == "__main__":
-    main()
+    if "--print" in sys.argv[1:]:
+        # Render to stdout and write nothing. The staleness guard uses this so it
+        # renders in a CLEAN interpreter (see the module docstring) without
+        # touching a tracked file in the paw-enterprise repo.
+        sys.stdout.write(render())
+    else:
+        written = main()
+        print(f"wrote {len(EVENT_REGISTRY)} topics -> {written}")

--- a/tests/cloud/composio/test_providers.py
+++ b/tests/cloud/composio/test_providers.py
@@ -5,6 +5,19 @@ agent backend calls. It resolves the active user from per-stream
 contextvars, builds a Composio session via the documented provider for
 that backend, returns ``session.tools()``. Caching, fail-soft on errors,
 and namespace correctness are all tested here.
+
+Updated 2026-08-07 (fix/test-guard-blindness): the pocket-specialist regression
+guard is now BEHAVIOURAL. ``test_deep_agents_skips_composio_on_pocket_session``
+read ``deep_agents.py`` as text and asserted two substrings existed somewhere in
+it, while claiming in its docstring that one CONTAINED the other — a claim no
+assertion checked, and one that an ordinary refactor could falsify while leaving
+both substrings in place. It is replaced by
+``test_deep_agents_withholds_composio_from_pocket_sessions``, which compiles the
+agent twice and asserts on the tool list each mode actually receives. See that
+test's docstring for the specific refactor that used to slip through.
+``test_pockets_prompts_has_no_composio_imports`` below is still a text scan; it
+asserts the ABSENCE of an import, which is a property source text can honestly
+answer, so it is left alone.
 """
 
 from __future__ import annotations
@@ -436,18 +449,99 @@ def test_pockets_prompts_has_no_composio_imports() -> None:
     assert "build_tools_for_backend" not in source
 
 
-def test_deep_agents_skips_composio_on_pocket_session() -> None:
-    """The deep_agents backend gates Composio injection behind
-    ``not is_pocket_session`` — pocket runs are surgical and exclude
-    Composio. Static check guards against regressions."""
-    path = Path(__file__).resolve().parents[3] / "src" / "pocketpaw" / "agents" / "deep_agents.py"
-    source = path.read_text(encoding="utf-8")
-    # The injection block must live inside an ``if not is_pocket_session:`` guard.
-    assert "if not is_pocket_session:" in source
-    # And the call must go through the ``pocketpaw.composio_tools`` entry-point
-    # helper with the right backend key — the OSS core never imports the EE
-    # composio package directly.
-    assert 'composio_tools_for("deep_agents"' in source
+def _install_fake_deepagents(
+    monkeypatch: pytest.MonkeyPatch, captured: list[dict[str, object]]
+) -> None:
+    """Stand in for the optional ``deepagents`` package and record its kwargs.
+
+    ``deepagents`` is an extra (``pocketpaw[deep-agents]``) and is not installed
+    in the dev environment, so the compiled-graph path is unreachable without
+    this. Recording ``create_deep_agent``'s kwargs is what makes the assertion
+    behavioural: ``kwargs["tools"]`` is the exact tool surface the pocket
+    specialist would run with.
+    """
+    module = types.ModuleType("deepagents")
+
+    def create_deep_agent(**kwargs: object) -> object:
+        captured.append(kwargs)
+        return object()
+
+    module.create_deep_agent = create_deep_agent  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "deepagents", module)
+
+
+def test_deep_agents_withholds_composio_from_pocket_sessions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pocket session's tool surface must not contain Composio tools.
+
+    REWRITTEN 2026-08-07 (fix/test-guard-blindness). This replaces a static
+    check that read ``deep_agents.py`` as TEXT and asserted two substrings
+    existed somewhere in it: ``"if not is_pocket_session:"`` and
+    ``'composio_tools_for("deep_agents"'``. Nothing tied the two together, while
+    the docstring and the inline comment both claimed the call lived INSIDE the
+    guard. There is a second ``is_pocket_session`` conditional a few lines below
+    (the shell/fs tool strip), so an ordinary tidy-up — hoist the call beside
+    ``all_tools`` and leave the guard wrapping only its log line — keeps both
+    substrings present, keeps the test green, and hands the pocket specialist
+    the exact Composio surface this test exists to withhold.
+
+    So: build the tool list twice off the one input that decides it (whether
+    ``<pocket-scope>`` is in the instructions) and assert the difference.
+
+    Two assertions, because the guard buys two different things. The tools must
+    not reach the agent, AND ``composio_tools_for`` must not be CALLED on a
+    pocket run — it builds a per-user Composio session over the network, which
+    is a cost the pocket path should never pay even if the result were dropped.
+    """
+    captured: list[dict[str, object]] = []
+    _install_fake_deepagents(monkeypatch, captured)
+
+    calls: list[str] = []
+    gmail = _named_tool("gmail_send_email")
+
+    def _composio_tools_for(backend: str, settings: object = None) -> list[object]:
+        calls.append(backend)
+        return [gmail]
+
+    from pocketpaw.agents import deep_agents as deep_agents_mod
+    from pocketpaw.agents import tool_bridge
+
+    # The guard imports this lazily, inside the branch, so patching the source
+    # module is what a real call would resolve.
+    monkeypatch.setattr(tool_bridge, "composio_tools_for", _composio_tools_for)
+
+    # _env_file=None: this box's .env must not decide what a guard test sees.
+    backend = deep_agents_mod.DeepAgentsBackend(Settings(_env_file=None))
+    # _build_custom_tools early-returns this cache, so the tool list under test
+    # is exactly what the Composio branch contributes and nothing else.
+    backend._custom_tools = []
+    # Unrelated to this guard: the tail of _get_or_create_agent patches a
+    # provider-specific message serializer. "google" matches no branch, so no
+    # optional langchain package gets imported here.
+    monkeypatch.setattr(backend, "_parse_provider_model", lambda: ("google", "gemini-2.0-flash"))
+
+    backend._get_or_create_agent(
+        model=object(), instructions="Help the user plan a trip.", mcp_tools=[]
+    )
+    backend._get_or_create_agent(
+        model=object(),
+        instructions="<pocket-scope>pocket_id=abc123</pocket-scope> Edit the widget.",
+        mcp_tools=[],
+    )
+
+    assert len(captured) == 2, "both builds must compile a graph (the cache key includes the mode)"
+    plain_tools = list(captured[0]["tools"])  # type: ignore[call-overload]
+    pocket_tools = list(captured[1]["tools"])  # type: ignore[call-overload]
+
+    assert [getattr(t, "name", None) for t in plain_tools] == ["gmail_send_email"], (
+        "a non-pocket session must receive the Composio tools"
+    )
+    assert pocket_tools == [], "a pocket session must receive NO Composio tools"
+    assert calls == ["deep_agents"], (
+        "composio_tools_for must be called once (the non-pocket build) and never "
+        "on a pocket build — building the session is itself the cost being avoided"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cloud/realtime/test_topics_gen.py
+++ b/tests/cloud/realtime/test_topics_gen.py
@@ -1,26 +1,190 @@
 """Guard: topics.gen.ts must stay in sync with EVENT_REGISTRY.
 
 If you change events.py, re-run `uv run python scripts/gen_topics.py` and
-commit the result alongside the events.py change.
+commit the result in paw-enterprise alongside the events.py change.
+
+REWRITTEN 2026-08-07 (fix/test-guard-blindness). The previous version had two
+defects, one silent and one operational.
+
+SILENT: it re-derived the output path itself — ``parents[3]`` then ``.parent``
+here, ``parents[2]`` in the script — so the guard and the generator agreed on
+where the file lives only by directory depth. Move either file and they point
+somewhere different, the subprocess writes to one place, the test diffs
+another, and ``before == after`` becomes trivially true. A staleness gate that
+can never fail is worse than no gate: it reports PASS forever. It also never
+checked that the subprocess had written anything at all, so a generator that
+silently no-opped read as "in sync". Now the location is imported from the
+generator (``DEFAULT_OUT``), which is the only place it is derived.
+
+OPERATIONAL: it ran the generator with ``check=True``, which WROTE
+``paw-enterprise/src/lib/core/shared/topics.gen.ts`` — a tracked file in a
+sibling repo other agents are working in. On Windows the round trip happened to
+be byte-stable so it only touched mtime, but the generator wrote with
+``os.linesep``, so on Linux or macOS the same run rewrote that tracked file from
+CRLF to LF. The test still passed, because ``read_text`` normalises newlines
+before comparing. A test in pocketpaw dirtying a checkout in paw-enterprise is
+not a tradeoff worth making for a staleness check, and it does not need to:
+comparing ``render()`` to the committed text proves the same thing with no
+writes at all.
+
+So this file now: imports the generator, compares the pure render against the
+committed file, exercises the write only into ``tmp_path``, and asserts —
+through a fixture that snapshots its mtime — that nothing here touches the
+sibling repo.
 """
 
+import importlib.util
 import subprocess
 import sys
 from pathlib import Path
 
+import pytest
 
-def test_topics_gen_is_committed_state():
-    repo_root = Path(__file__).resolve().parents[3]
-    out = repo_root.parent / "paw-enterprise/src/lib/core/shared/topics.gen.ts"
-    assert out.exists(), "topics.gen.ts missing -- run scripts/gen_topics.py"
-    before = out.read_text(encoding="utf-8")
-    subprocess.run(
-        [sys.executable, "scripts/gen_topics.py"],
-        cwd=repo_root,
+# The generator lives in THIS repo, so deriving its path from this test's own
+# location cannot disagree about where the SIBLING repo is — that question has
+# exactly one answer now, and it lives in gen_topics.DEFAULT_OUT. The assert is
+# the loud failure: move either file and the guard errors instead of quietly
+# passing, which is the whole defect being fixed.
+SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "gen_topics.py"
+assert SCRIPT.exists(), f"gen_topics.py not found at {SCRIPT} — fix this path, do not delete it"
+
+_spec = importlib.util.spec_from_file_location("gen_topics", SCRIPT)
+assert _spec is not None and _spec.loader is not None
+gen_topics = importlib.util.module_from_spec(_spec)
+sys.modules["gen_topics"] = gen_topics
+_spec.loader.exec_module(gen_topics)
+
+
+@pytest.fixture(autouse=True)
+def _sibling_repo_is_never_written():
+    """Fail if anything in this module writes the real topics.gen.ts — and undo it.
+
+    This is the operational half of the fix, kept honest: the guard may READ
+    paw-enterprise's tracked file and must never write it. Detection is on
+    mtime, which moves on every write even when the bytes are identical, so
+    re-introducing the old ``main()``-with-no-argument call trips this.
+
+    It RESTORES as well as reports, and that is not belt-and-braces. Proving
+    this guard works means writing the file once on purpose, and the bytes that
+    lands are LF while the committed file is still CRLF — so a detect-only
+    fixture would leave a dirty tracked file in another repo every time someone
+    mutation-tests this plan. A guard against damaging a sibling checkout that
+    damages a sibling checkout to prove itself is not a guard.
+    """
+    out = gen_topics.DEFAULT_OUT
+    existed = out.exists()
+    before_bytes = out.read_bytes() if existed else None
+    before_mtime = out.stat().st_mtime_ns if existed else None
+    try:
+        yield
+    finally:
+        after_mtime = out.stat().st_mtime_ns if out.exists() else None
+        touched = before_mtime != after_mtime
+        if touched and existed and before_bytes is not None:
+            if out.read_bytes() != before_bytes:
+                out.write_bytes(before_bytes)
+    assert not touched, (
+        f"a test in this module wrote {out} — that is a tracked file in the "
+        "paw-enterprise repo (its content has been restored). Render and "
+        "compare, or write to tmp_path."
+    )
+
+
+def _render_in_clean_interpreter() -> str:
+    """Render via ``gen_topics.py --print`` in a fresh process.
+
+    NOT the same as calling ``gen_topics.render()`` here, and the difference is
+    load-bearing. ``EVENT_REGISTRY`` is filled by ``Event.__init_subclass__``, so
+    it contains whatever events the current process has IMPORTED. In this test
+    session that depends on which other test modules ran first: measured
+    2026-08-07, ``tests/cloud/composio`` pulls in the belt events, so an
+    in-process render gains ``belt_plan`` and the comparison below fails purely
+    on collection order.
+
+    The old guard ran the generator as a subprocess and got this isolation
+    without anyone writing down that it needed it. Keeping the subprocess — but
+    for stdout instead of for a write into another repo — keeps the check
+    order-independent while dropping the part that was actually harmful.
+    """
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--print"],
+        capture_output=True,
+        text=True,  # normalises the pipe's newlines, so this is content, not bytes
         check=True,
     )
-    after = out.read_text(encoding="utf-8")
-    assert before == after, (
-        "topics.gen.ts is stale -- run `uv run python backend/scripts/gen_topics.py` "
-        "and commit the result"
+    return proc.stdout
+
+
+def test_topics_gen_is_committed_state() -> None:
+    """The committed file matches what the generator would produce now."""
+    out = gen_topics.DEFAULT_OUT
+    assert out.exists(), f"topics.gen.ts missing at {out} -- run scripts/gen_topics.py"
+    # read_text normalises newlines, so this compares CONTENT and tolerates the
+    # committed file's CRLF. The bytes the generator writes are pinned
+    # separately, below.
+    committed = out.read_text(encoding="utf-8")
+    assert committed == _render_in_clean_interpreter(), (
+        "topics.gen.ts is stale -- run `uv run python scripts/gen_topics.py` "
+        "and commit the result in paw-enterprise"
     )
+
+
+def test_render_covers_every_registered_event() -> None:
+    """Every EVENT_REGISTRY key reaches the generated file.
+
+    The comparison above passes if render() and the committed file agree, which
+    is also true when both are wrong. This pins render() to the registry
+    directly, so dropping a topic from the output fails here even if someone
+    regenerates the file to match.
+    """
+    from pocketpaw_ee.cloud._core.realtime.events import EVENT_REGISTRY
+
+    rendered = gen_topics.render()
+    assert EVENT_REGISTRY, "EVENT_REGISTRY is empty — this guard would prove nothing"
+    for topic in EVENT_REGISTRY:
+        assert f"  {topic!r}," in rendered, f"{topic!r} is registered but not in the output"
+
+
+def test_main_writes_where_it_is_told(tmp_path: Path) -> None:
+    """main(out) writes to out and reports the path it wrote.
+
+    The old guard ran the generator as a subprocess and never confirmed a write
+    happened, so a no-op generator read as "in sync".
+    """
+    target = tmp_path / "nested" / "topics.gen.ts"
+    written = gen_topics.main(target)
+    assert written == target
+    assert target.exists(), "main() returned a path it did not write"
+    assert target.read_text(encoding="utf-8") == gen_topics.render()
+
+
+def test_generated_bytes_are_lf_on_every_platform(tmp_path: Path) -> None:
+    """The generator pins LF instead of following os.linesep.
+
+    Without the pin this script emits CRLF on Windows and LF elsewhere, so the
+    same registry produces different bytes depending on who ran it — and the
+    content comparison above cannot see it, because read_text normalises.
+
+    NOTE: this assertion can only FAIL on a platform whose os.linesep is not
+    "\\n". On Linux and macOS the unpinned default already produces LF, so the
+    mutation that removes the pin escapes there. It is caught on Windows, which
+    is where the CRLF in the committed file came from.
+    """
+    target = tmp_path / "topics.gen.ts"
+    gen_topics.main(target)
+    raw = target.read_bytes()
+    assert b"\r\n" not in raw, "generator emitted CRLF — pin newline='\\n' in main()"
+    assert b"\n" in raw
+
+
+def test_default_out_points_at_the_generated_file() -> None:
+    """DEFAULT_OUT still resolves to the real file in the sibling repo.
+
+    Guards the derivation itself. If the repo layout moves and this constant
+    starts pointing at nothing, every other check here would still pass against
+    a path no one reads — the exact blindness this rewrite exists to remove.
+    """
+    out = gen_topics.DEFAULT_OUT
+    assert out.name == "topics.gen.ts"
+    assert out.parent.name == "shared"
+    assert out.exists(), f"DEFAULT_OUT does not resolve to a real file: {out}"

--- a/tests/mutations/composio_pocket_guard.json
+++ b/tests/mutations/composio_pocket_guard.json
@@ -1,0 +1,38 @@
+[
+  {
+    "label": "composio: the call is hoisted out of the guard, which keeps only its log line (the refactor the old text-scan could not see)",
+    "file": "src/pocketpaw/agents/deep_agents.py",
+    "find": "        if not is_pocket_session:\n            from pocketpaw.agents.tool_bridge import composio_tools_for\n\n            composio_tools = composio_tools_for(\"deep_agents\", self.settings)\n            if composio_tools:\n                all_tools = all_tools + list(composio_tools)\n                logger.info(\"Composio: appended %d langgraph tools\", len(composio_tools))",
+    "replace": "        from pocketpaw.agents.tool_bridge import composio_tools_for\n\n        composio_tools = composio_tools_for(\"deep_agents\", self.settings)\n        if composio_tools:\n            all_tools = all_tools + list(composio_tools)\n        if not is_pocket_session:\n            logger.info(\"Composio: appended %d langgraph tools\", len(composio_tools))",
+    "tests": [
+      "tests/cloud/composio/test_providers.py"
+    ]
+  },
+  {
+    "label": "composio: the guard is inverted — pocket sessions get the tools and everyone else does not",
+    "file": "src/pocketpaw/agents/deep_agents.py",
+    "find": "        if not is_pocket_session:\n            from pocketpaw.agents.tool_bridge import composio_tools_for",
+    "replace": "        if is_pocket_session:\n            from pocketpaw.agents.tool_bridge import composio_tools_for",
+    "tests": [
+      "tests/cloud/composio/test_providers.py"
+    ]
+  },
+  {
+    "label": "composio: the guard is removed entirely — every session gets the tools",
+    "file": "src/pocketpaw/agents/deep_agents.py",
+    "find": "        if not is_pocket_session:\n            from pocketpaw.agents.tool_bridge import composio_tools_for\n\n            composio_tools = composio_tools_for(\"deep_agents\", self.settings)",
+    "replace": "        if True:\n            from pocketpaw.agents.tool_bridge import composio_tools_for\n\n            composio_tools = composio_tools_for(\"deep_agents\", self.settings)",
+    "tests": [
+      "tests/cloud/composio/test_providers.py"
+    ]
+  },
+  {
+    "label": "composio: the pocket-session signal stops reading the prompt, so nothing is ever a pocket session",
+    "file": "src/pocketpaw/agents/deep_agents.py",
+    "find": "        is_pocket_session = \"<pocket-scope>\" in (instructions or \"\")",
+    "replace": "        is_pocket_session = False",
+    "tests": [
+      "tests/cloud/composio/test_providers.py"
+    ]
+  }
+]

--- a/tests/mutations/topics_gen.json
+++ b/tests/mutations/topics_gen.json
@@ -1,0 +1,66 @@
+[
+  {
+    "label": "topics: DEFAULT_OUT is derived one level off, so the guard reads a path nothing writes",
+    "file": "scripts/gen_topics.py",
+    "find": "    Path(__file__).resolve().parents[2] / \"paw-enterprise/src/lib/core/shared/topics.gen.ts\"",
+    "replace": "    Path(__file__).resolve().parents[3] / \"paw-enterprise/src/lib/core/shared/topics.gen.ts\"",
+    "tests": [
+      "tests/cloud/realtime/test_topics_gen.py"
+    ]
+  },
+  {
+    "label": "topics: a registered event is dropped from the rendered output",
+    "file": "scripts/gen_topics.py",
+    "find": "    topics = sorted(EVENT_REGISTRY.keys())",
+    "replace": "    topics = sorted(EVENT_REGISTRY.keys())[1:]",
+    "tests": [
+      "tests/cloud/realtime/test_topics_gen.py"
+    ]
+  },
+  {
+    "label": "topics: the rendered body drifts from the committed file",
+    "file": "scripts/gen_topics.py",
+    "find": "    lines.append(\"] as const;\")",
+    "replace": "    lines.append(\"] as const\")",
+    "tests": [
+      "tests/cloud/realtime/test_topics_gen.py"
+    ]
+  },
+  {
+    "label": "topics: main() writes somewhere other than the path it was given",
+    "file": "scripts/gen_topics.py",
+    "find": "    target = Path(out) if out is not None else DEFAULT_OUT",
+    "replace": "    target = (Path(out).parent / \"elsewhere.ts\") if out is not None else DEFAULT_OUT",
+    "tests": [
+      "tests/cloud/realtime/test_topics_gen.py"
+    ]
+  },
+  {
+    "label": "topics: a test in the guard module writes the real file in the sibling repo again (the operational defect this rewrite removed)",
+    "file": "tests/cloud/realtime/test_topics_gen.py",
+    "find": "    target = tmp_path / \"topics.gen.ts\"\n    gen_topics.main(target)\n    raw = target.read_bytes()",
+    "replace": "    target = tmp_path / \"topics.gen.ts\"\n    gen_topics.main(target)\n    gen_topics.main()\n    raw = target.read_bytes()",
+    "tests": [
+      "tests/cloud/realtime/test_topics_gen.py"
+    ]
+  },
+  {
+    "label": "topics: the staleness check renders IN-PROCESS, so it depends on what other tests imported (runs the composio suite first to create the pollution)",
+    "file": "tests/cloud/realtime/test_topics_gen.py",
+    "find": "    assert committed == _render_in_clean_interpreter(), (",
+    "replace": "    assert committed == gen_topics.render(), (",
+    "tests": [
+      "tests/cloud/composio/",
+      "tests/cloud/realtime/test_topics_gen.py"
+    ]
+  },
+  {
+    "label": "topics: the newline pin is dropped, so the bytes follow os.linesep again (CATCHABLE ON WINDOWS ONLY — os.linesep is already LF elsewhere)",
+    "file": "scripts/gen_topics.py",
+    "find": "    target.write_text(render(), encoding=\"utf-8\", newline=\"\\n\")",
+    "replace": "    target.write_text(render(), encoding=\"utf-8\")",
+    "tests": [
+      "tests/cloud/realtime/test_topics_gen.py"
+    ]
+  }
+]


### PR DESCRIPTION
Two tests that reported PASS regardless of whether the thing they guard still worked. Both came out of the guard audit; neither was found by reading the assertions, only by asking what a routine refactor would do to them.

## 1. The composio pocket guard asserted co-presence and claimed containment

`test_deep_agents_skips_composio_on_pocket_session` read `deep_agents.py` as text and checked that two substrings existed somewhere in it:

```python
assert "if not is_pocket_session:" in source
assert 'composio_tools_for("deep_agents"' in source
```

Nothing tied them together, while the docstring and the inline comment both said the call lived *inside* the guard. It does today. But there is a second `is_pocket_session` conditional a few lines below (the shell/fs tool strip), so this refactor keeps both substrings, keeps the test green, and hands the pocket specialist the entire Composio surface:

```python
composio_tools = composio_tools_for("deep_agents", self.settings)   # hoisted
if composio_tools:
    all_tools = all_tools + list(composio_tools)
if not is_pocket_session:                                            # now only logs
    logger.info("Composio: appended %d langgraph tools", len(composio_tools))
```

That is a tidy-up in a long method, not a contrived break. It is now the first mutation in the plan.

The replacement compiles the agent twice off the one input that decides the mode (whether `<pocket-scope>` is in the instructions) and asserts on the tool list each build actually receives. Two assertions, because the guard buys two things: the tools must not reach the agent, and `composio_tools_for` must not be *called* on a pocket run, since building a per-user Composio session is itself the cost being avoided.

`test_pockets_prompts_has_no_composio_imports` is left alone. It is also a text scan, but it asserts the *absence* of an import, which source text can honestly answer.

## 2. The topics staleness gate wrote into another repo, and could not fail

Two derivations of the same path, agreeing only by directory depth: `parents[2]` in `scripts/gen_topics.py`, `parents[3]` then `.parent` in the test. Move either file and they point at different places, the subprocess writes to one, the test diffs the other, and `before == after` is trivially true forever. It also never checked the subprocess had written anything, so a no-op generator read as "in sync".

The operational half is worse. The test ran the generator with `check=True`, which **writes `paw-enterprise/src/lib/core/shared/topics.gen.ts`** — a tracked file in a sibling repo other agents work in. On Windows the round trip is byte-stable so it only touched mtime, but the generator wrote with `os.linesep`, so on Linux or macOS the same run rewrote that tracked file from CRLF to LF. The test still passed, because `read_text` normalises newlines before comparing.

Now: the path is imported from the generator (`DEFAULT_OUT`, the only derivation), the write is pinned to `newline="\n"`, `main(out)` returns where it wrote so a caller can check, and the guard renders through a new `--print` mode instead of writing anything. An autouse fixture snapshots the real file's mtime and fails if anything in the module touches it — and restores the bytes, because proving that guard works means writing the file once on purpose, and a guard against damaging a sibling checkout that damages a sibling checkout to prove itself is not a guard.

## What the rewrite turned up on the way

Dropping the subprocess broke the suite, and the reason is worth writing down: `EVENT_REGISTRY` is filled by `Event.__init_subclass__`, so it holds whatever events the current process has **imported**. An in-process render therefore depends on which test modules ran first — `tests/cloud/composio` pulls in the belt events, and the comparison started failing on collection order alone. The old test got its isolation by accident, from running a subprocess. `--print` keeps that isolation deliberately, and drops the part that was actually harmful.

Which exposes a real defect I have **not** fixed here: the generator only sees events whose modules happen to be imported. Measured today, `scripts/gen_topics.py` renders 136 topics; importing the whole `pocketpaw_ee` tree yields 146. The ten missing from the frontend's `Topic` union:

```
belt_plan
mandate.autopilot_changed, mandate.created, mandate.shift_started,
mandate.shift_updated, mandate.sighting_added
meeting.ended, meeting.recording_ready, meeting.reminder, meeting.transcript_ready
```

Fixing it changes generated content in another repo, so it wants its own PR rather than riding along inside a test-guard change.

## Mutations

Eleven across two plans, every one applied and observed to fail the suite that should catch it. None escaped.

```
uv run python scripts/mutate.py --plan tests/mutations/composio_pocket_guard.json  -> 4 caught, 0 escaped
uv run python scripts/mutate.py --plan tests/mutations/topics_gen.json             -> 7 caught, 0 escaped
uv run pytest tests/cloud/composio/ tests/cloud/realtime/ -q -p no:randomly        -> 160 passed
uv run ruff check + format --check on the three edited files                       -> clean
```

One caveat worth stating rather than letting a reviewer find it: the mutation that drops `newline="\n"` can only fail on a platform whose `os.linesep` is not `\n`. On Linux and macOS the unpinned default already produces LF, so that mutation escapes there. It is caught on Windows, which is where the CRLF in the committed file came from. The label says so.

## Follow-up for paw-enterprise

`topics.gen.ts` is still committed as CRLF and is one of about ten CRLF files among ~190 LF ones under `src`. Nothing rewrites it automatically any more, so the next deliberate `uv run python scripts/gen_topics.py` produces a whole-file, whitespace-only diff. That is expected — commit it there.
