### PR TITLE
The topics generator was missing ten events

### DIFF
--- a/ee/pocketpaw_ee/cloud/_core/realtime/events.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/events.py
@@ -1,6 +1,19 @@
 # events.py — Realtime Event dataclass registry for the cloud bus.
 # Each subclass pins an EVENT_TYPE literal that routes both the WebSocket
 # fan-out and any in-process bus subscribers.
+# Updated: 2026-08-07 (fix/topics-gen-collection) — REMOVED three dead duplicate
+#   classes: MeetingScheduled, MeetingStarted and MeetingCancelled were declared
+#   both here and in ``pocketpaw_ee.cloud.meetings.events``, each pair claiming the
+#   same EVENT_TYPE. EVENT_REGISTRY is a dict keyed on that literal, so whichever
+#   module imported LAST won and ``rebuild_event`` reconstructed a different class
+#   depending on import order. The copies here were the dead half — every emitter
+#   and test imports the documented classes from ``cloud.meetings.events``, and
+#   nothing imported these names from this module.
+#   This was ALREADY failing ``test_registry_includes_every_subclass_with_event_type``
+#   on dev whenever tests/cloud/meetings ran in the same session as
+#   tests/cloud/realtime; it looked green in narrower runs only because no session
+#   had imported both modules. ``MeetingUpdated`` stays — this is its only
+#   declaration. See the comment at the class for the full account.
 # Updated: 2026-05-22 (RFC 05 M2b.2) — added PocketOutcomeEvent
 #   (type="pocket.outcome"), emitted after a successful write action whose
 #   binding declared a named `outcome`. Feeds the outcomes JSONL ledger.
@@ -669,25 +682,27 @@ class CallParticipantLeft(Event):
     EVENT_TYPE: ClassVar[str] = "call.participant_left"
 
 
-# Meetings — scheduled group meeting lifecycle
-@dataclass
-class MeetingScheduled(Event):
-    EVENT_TYPE: ClassVar[str] = "meeting.scheduled"
-
-
+# Meetings — scheduled group meeting lifecycle.
+#
+# ONLY ``meeting.updated`` lives here. ``MeetingScheduled``, ``MeetingStarted``
+# and ``MeetingCancelled`` were declared here AND in
+# ``pocketpaw_ee.cloud.meetings.events``, both claiming the same EVENT_TYPE — so
+# ``EVENT_REGISTRY`` mapped each of those three to whichever module was imported
+# LAST, and ``rebuild_event`` reconstructed a different class depending on import
+# order. The stubs here were the dead half: every emitter and every test imports
+# the documented classes from ``cloud.meetings.events`` (livekit/service.py,
+# meetings/service.py, meetings/scheduling/service.py, push listeners), and
+# nothing anywhere imported these names from this module.
+#
+# The collision was invisible until 2026-08-07 because no test session had ever
+# imported both modules — ``test_registry_includes_every_subclass_with_event_type``
+# asserts exactly this invariant and passed only for want of an import. Removed
+# while fixing the topics generator, which imports the meetings module and so
+# made the conflict real. ``meeting.updated`` stays because this is its only
+# declaration; ``cloud.meetings.events`` has no counterpart for it.
 @dataclass
 class MeetingUpdated(Event):
     EVENT_TYPE: ClassVar[str] = "meeting.updated"
-
-
-@dataclass
-class MeetingCancelled(Event):
-    EVENT_TYPE: ClassVar[str] = "meeting.cancelled"
-
-
-@dataclass
-class MeetingStarted(Event):
-    EVENT_TYPE: ClassVar[str] = "meeting.started"
 
 
 # Foresight — RFC 08 scenario runs. ``ForesightRunCreated`` fires when a

--- a/scripts/gen_topics.py
+++ b/scripts/gen_topics.py
@@ -45,17 +45,43 @@ independent of whatever else the test session imported. The old guard got this
 isolation by accident, from running the script as a subprocess; losing it silently
 would have made the check order-dependent.
 
-(That the registry under-counts at all is a real defect in what this script
-generates — measured 2026-08-07: 136 topics here versus 146 after importing the
-whole ``pocketpaw_ee`` tree, the difference being the belt, mandate and meeting
-events. Fixing it changes the generated file in another repo, so it is filed as a
-follow-up rather than smuggled into a test-guard PR.)
+Updated 2026-08-07 (fix/topics-gen-collection). Collection is now EXPLICIT — see
+the imports below. The script used to render whatever its own import chain
+happened to register, which was 136 of the 146 events that exist; ten were
+missing from the frontend's ``Topic`` union entirely (``belt_plan``, five
+``mandate.*``, four ``meeting.*``). Two imports fix it, and the completeness test
+in ``tests/cloud/realtime/test_topics_gen.py`` fails if a declared event is ever
+missing from the render again.
+
+A full ``pkgutil.walk_packages`` over ``pocketpaw_ee`` would also work and was
+rejected: it takes 29 seconds, and 8 modules raise on import (the vendored oasis
+substrate, a worker), so it would need failures swallowed — which is how events
+went missing in the first place. Two named imports plus a test that checks every
+declared event reached the output is cheaper and fails louder.
 """
 
 import sys
 from pathlib import Path
 
+import pocketpaw_ee.cloud.mandates.events  # noqa: F401  (import registers the events)
+import pocketpaw_ee.cloud.meetings.events  # noqa: F401  (import registers the events)
 from pocketpaw_ee.cloud._core.realtime.events import EVENT_REGISTRY
+
+# COLLECTION IS EXPLICIT, and it has to be. ``EVENT_REGISTRY`` fills from
+# ``Event.__init_subclass__``, so importing the registry module alone yields only
+# the events declared in it. The two ``pocketpaw_ee.cloud.*.events`` imports above
+# are what add the ten that were simply absent from the generated file, and that
+# the frontend's ``Topic`` union never had: ``belt_plan`` and five ``mandate.*``
+# from the first, four ``meeting.*`` from the second.
+#
+# Those imports look unused. They are not — importing the module is what registers
+# its events, which is why they carry ``noqa: F401``. Deleting one silently
+# shrinks the generated file.
+#
+# ADDING AN EVENT MODULE: if you declare events in a new module, import it here.
+# ``test_every_declared_event_reaches_the_generated_file`` fails until you do,
+# naming the topic it could not find — nobody should have to learn this rule by
+# reading this comment.
 
 #: The generated file, in the paw-enterprise sibling repo. The single source of
 #: truth for this location — import it, never re-derive it.
@@ -102,11 +128,20 @@ def main(out: Path | None = None) -> Path:
 
 
 if __name__ == "__main__":
-    if "--print" in sys.argv[1:]:
+    args = sys.argv[1:]
+    if "--print" in args:
         # Render to stdout and write nothing. The staleness guard uses this so it
         # renders in a CLEAN interpreter (see the module docstring) without
         # touching a tracked file in the paw-enterprise repo.
+        #
+        # NOT a substitute for the write path: on Windows, text-mode stdout
+        # translates to CRLF, so `gen_topics.py --print > file` produces
+        # different bytes than `main()` does. Redirecting this is not a
+        # supported way to generate the file — pass a path instead.
         sys.stdout.write(render())
     else:
-        written = main()
+        # An explicit destination, for regenerating into a checkout that is not
+        # the sibling working copy DEFAULT_OUT resolves to.
+        positional = [a for a in args if not a.startswith("-")]
+        written = main(Path(positional[0]) if positional else None)
         print(f"wrote {len(EVENT_REGISTRY)} topics -> {written}")

--- a/tests/cloud/realtime/test_topics_gen.py
+++ b/tests/cloud/realtime/test_topics_gen.py
@@ -33,11 +33,14 @@ through a fixture that snapshots its mtime — that nothing here touches the
 sibling repo.
 """
 
+import importlib
 import importlib.util
+import re
 import subprocess
 import sys
 from pathlib import Path
 
+import pocketpaw_ee
 import pytest
 
 # The generator lives in THIS repo, so deriving its path from this test's own
@@ -116,7 +119,21 @@ def _render_in_clean_interpreter() -> str:
 
 
 def test_topics_gen_is_committed_state() -> None:
-    """The committed file matches what the generator would produce now."""
+    """The committed file matches what the generator would produce now.
+
+    EXPECTED RED on fix/topics-gen-collection, and deliberately not weakened.
+    That branch makes the generator collect the ten events it was missing, so
+    this now compares 146 rendered topics against a file paw-enterprise still
+    has at 136. The failure diff IS the defect, listed. It goes green when the
+    paired paw-enterprise PR lands the regenerated file on that repo's dev.
+
+    Not marked xfail: an xfail that flips to XPASS the moment another repo
+    merges is a second cross-repo timing bomb, and the whole point of this
+    thread is guards that report the wrong thing. A red test with an
+    explanation is honest; a green one that is green for a scheduling reason is
+    not. DEFAULT_OUT resolves to the working sibling checkout, which this test
+    may never write, so it cannot be made green from here.
+    """
     out = gen_topics.DEFAULT_OUT
     assert out.exists(), f"topics.gen.ts missing at {out} -- run scripts/gen_topics.py"
     # read_text normalises newlines, so this compares CONTENT and tolerates the
@@ -143,6 +160,83 @@ def test_render_covers_every_registered_event() -> None:
     assert EVENT_REGISTRY, "EVENT_REGISTRY is empty — this guard would prove nothing"
     for topic in EVENT_REGISTRY:
         assert f"  {topic!r}," in rendered, f"{topic!r} is registered but not in the output"
+
+
+# ── Completeness + determinism of the collection (fix/topics-gen-collection) ──
+# The generator renders EVENT_REGISTRY, which fills from Event.__init_subclass__
+# — so it holds only the events whose module was imported. That made the output a
+# function of the import chain rather than of the codebase, and ten events never
+# reached the frontend's Topic union at all. These two tests pin the fix from
+# both ends: nothing declared is missing, and the answer does not depend on who
+# is asking.
+
+_EVENT_TYPE_DECL = re.compile(r"""EVENT_TYPE\s*(?::\s*ClassVar\[str\]\s*)?=\s*["']([^"']+)["']""")
+
+
+def _declared_event_types() -> set[str]:
+    """Every EVENT_TYPE literal declared anywhere in the pocketpaw_ee package.
+
+    This IS a source scan, which this sprint has spent a while distrusting, so
+    it earns its place by pinning its own liveness: the test below asserts the
+    scan found known sentinels and a plausible floor. A refactor that changes
+    how EVENT_TYPE is declared therefore breaks the scan LOUDLY instead of
+    quietly finding nothing and reporting success — which is the exact failure
+    mode that made the other scans worthless.
+
+    The root is derived from the imported package, not from another parents[N]
+    walk, so it cannot drift the way the two output-path derivations did.
+    """
+    root = Path(pocketpaw_ee.__file__).resolve().parent
+    found: set[str] = set()
+    for path in root.rglob("*.py"):
+        found.update(_EVENT_TYPE_DECL.findall(path.read_text(encoding="utf-8", errors="ignore")))
+    return found
+
+
+def test_the_scan_that_checks_completeness_is_itself_alive() -> None:
+    """The completeness scan must actually be finding declarations."""
+    declared = _declared_event_types()
+    # Sentinels from three different modules: the core registry, the mandates
+    # module, and the meetings module. If a declaration-style change stops the
+    # regex matching, at least one of these disappears and this fails.
+    assert "pocket.created" in declared, "scan lost the core events"
+    assert "belt_plan" in declared, "scan lost the mandates events"
+    assert "meeting.transcript_ready" in declared, "scan lost the meetings events"
+    # A floor, so a scan that silently degrades to a handful of matches fails
+    # instead of vacuously passing the completeness test below.
+    assert len(declared) >= 140, f"scan found only {len(declared)} EVENT_TYPE declarations"
+
+
+def test_every_declared_event_reaches_the_generated_file() -> None:
+    """No event declared in the codebase is missing from the render.
+
+    This is the guard for the defect: the generator collects by importing, so an
+    event module nobody imports is invisible to it. Declaring events in a NEW
+    module fails here until that module is imported in gen_topics.py.
+    """
+    rendered = gen_topics.render()
+    missing = sorted(t for t in _declared_event_types() if f"  {t!r}," not in rendered)
+    assert not missing, (
+        f"{len(missing)} declared event(s) never reach topics.gen.ts: {missing}. "
+        "Import the module that declares them in scripts/gen_topics.py."
+    )
+
+
+def test_collection_does_not_depend_on_what_the_process_imported() -> None:
+    """The render is the same in a loaded process and in a clean one.
+
+    Before the explicit imports, these two differed: a process that had imported
+    the mandates or meetings modules rendered more topics than the generator's
+    own minimal chain did. Importing them here FORCES the divergence to exist if
+    collection is still lazy, so this does not depend on which other test
+    modules ran first.
+    """
+    importlib.import_module("pocketpaw_ee.cloud.mandates.events")
+    importlib.import_module("pocketpaw_ee.cloud.meetings.events")
+    assert gen_topics.render() == _render_in_clean_interpreter(), (
+        "the generated topics depend on what the calling process imported — "
+        "collection in scripts/gen_topics.py is not explicit"
+    )
 
 
 def test_main_writes_where_it_is_told(tmp_path: Path) -> None:

--- a/tests/mutations/topics_collection.json
+++ b/tests/mutations/topics_collection.json
@@ -1,0 +1,40 @@
+[
+  {
+    "label": "collection: the mandates events module is no longer imported, so belt_plan and five mandate.* vanish from the output",
+    "file": "scripts/gen_topics.py",
+    "find": "import pocketpaw_ee.cloud.mandates.events  # noqa: F401  (import registers the events)",
+    "replace": "",
+    "tests": [
+      "tests/cloud/realtime/test_topics_gen.py::test_every_declared_event_reaches_the_generated_file",
+      "tests/cloud/realtime/test_topics_gen.py::test_collection_does_not_depend_on_what_the_process_imported"
+    ]
+  },
+  {
+    "label": "collection: the meetings events module is no longer imported, so four meeting.* vanish from the output",
+    "file": "scripts/gen_topics.py",
+    "find": "import pocketpaw_ee.cloud.meetings.events  # noqa: F401  (import registers the events)",
+    "replace": "",
+    "tests": [
+      "tests/cloud/realtime/test_topics_gen.py::test_every_declared_event_reaches_the_generated_file",
+      "tests/cloud/realtime/test_topics_gen.py::test_collection_does_not_depend_on_what_the_process_imported"
+    ]
+  },
+  {
+    "label": "collection: the completeness scan silently matches nothing (the blindness class this whole thread is about)",
+    "file": "tests/cloud/realtime/test_topics_gen.py",
+    "find": "_EVENT_TYPE_DECL = re.compile(r\"\"\"EVENT_TYPE\\s*(?::\\s*ClassVar\\[str\\]\\s*)?=\\s*[\"']([^\"']+)[\"']\"\"\")",
+    "replace": "_EVENT_TYPE_DECL = re.compile(r\"\"\"EVENT_TYPE_RENAMED\\s*=\\s*[\"']([^\"']+)[\"']\"\"\")",
+    "tests": [
+      "tests/cloud/realtime/test_topics_gen.py::test_the_scan_that_checks_completeness_is_itself_alive"
+    ]
+  },
+  {
+    "label": "collection: the scan reads the wrong package root, so it finds no declarations to check",
+    "file": "tests/cloud/realtime/test_topics_gen.py",
+    "find": "    root = Path(pocketpaw_ee.__file__).resolve().parent",
+    "replace": "    root = Path(pocketpaw_ee.__file__).resolve().parent / \"cloud\" / \"composio\"",
+    "tests": [
+      "tests/cloud/realtime/test_topics_gen.py::test_the_scan_that_checks_completeness_is_itself_alive"
+    ]
+  }
+]

--- a/tests/mutations/topics_gen.json
+++ b/tests/mutations/topics_gen.json
@@ -5,7 +5,7 @@
     "find": "    Path(__file__).resolve().parents[2] / \"paw-enterprise/src/lib/core/shared/topics.gen.ts\"",
     "replace": "    Path(__file__).resolve().parents[3] / \"paw-enterprise/src/lib/core/shared/topics.gen.ts\"",
     "tests": [
-      "tests/cloud/realtime/test_topics_gen.py"
+      "tests/cloud/realtime/test_topics_gen.py::test_default_out_points_at_the_generated_file"
     ]
   },
   {
@@ -14,16 +14,17 @@
     "find": "    topics = sorted(EVENT_REGISTRY.keys())",
     "replace": "    topics = sorted(EVENT_REGISTRY.keys())[1:]",
     "tests": [
-      "tests/cloud/realtime/test_topics_gen.py"
+      "tests/cloud/realtime/test_topics_gen.py::test_render_covers_every_registered_event",
+      "tests/cloud/realtime/test_topics_gen.py::test_every_declared_event_reaches_the_generated_file"
     ]
   },
   {
-    "label": "topics: the rendered body drifts from the committed file",
+    "label": "topics: the rendered body drifts from the committed file (ONLY witness is the committed-state test, which is RED on this branch by design — verified caught on fix/test-guard-blindness where it is green)",
     "file": "scripts/gen_topics.py",
     "find": "    lines.append(\"] as const;\")",
     "replace": "    lines.append(\"] as const\")",
     "tests": [
-      "tests/cloud/realtime/test_topics_gen.py"
+      "tests/cloud/realtime/test_topics_gen.py::test_topics_gen_is_committed_state"
     ]
   },
   {
@@ -32,26 +33,16 @@
     "find": "    target = Path(out) if out is not None else DEFAULT_OUT",
     "replace": "    target = (Path(out).parent / \"elsewhere.ts\") if out is not None else DEFAULT_OUT",
     "tests": [
-      "tests/cloud/realtime/test_topics_gen.py"
+      "tests/cloud/realtime/test_topics_gen.py::test_main_writes_where_it_is_told"
     ]
   },
   {
-    "label": "topics: a test in the guard module writes the real file in the sibling repo again (the operational defect this rewrite removed)",
+    "label": "topics: a test in the guard module writes the real file in the sibling repo again (the operational defect the rewrite removed)",
     "file": "tests/cloud/realtime/test_topics_gen.py",
     "find": "    target = tmp_path / \"topics.gen.ts\"\n    gen_topics.main(target)\n    raw = target.read_bytes()",
     "replace": "    target = tmp_path / \"topics.gen.ts\"\n    gen_topics.main(target)\n    gen_topics.main()\n    raw = target.read_bytes()",
     "tests": [
-      "tests/cloud/realtime/test_topics_gen.py"
-    ]
-  },
-  {
-    "label": "topics: the staleness check renders IN-PROCESS, so it depends on what other tests imported (runs the composio suite first to create the pollution)",
-    "file": "tests/cloud/realtime/test_topics_gen.py",
-    "find": "    assert committed == _render_in_clean_interpreter(), (",
-    "replace": "    assert committed == gen_topics.render(), (",
-    "tests": [
-      "tests/cloud/composio/",
-      "tests/cloud/realtime/test_topics_gen.py"
+      "tests/cloud/realtime/test_topics_gen.py::test_generated_bytes_are_lf_on_every_platform"
     ]
   },
   {
@@ -60,7 +51,7 @@
     "find": "    target.write_text(render(), encoding=\"utf-8\", newline=\"\\n\")",
     "replace": "    target.write_text(render(), encoding=\"utf-8\")",
     "tests": [
-      "tests/cloud/realtime/test_topics_gen.py"
+      "tests/cloud/realtime/test_topics_gen.py::test_generated_bytes_are_lf_on_every_platform"
     ]
   }
 ]


### PR DESCRIPTION
**Stacked on #1885** (`fix/test-guard-blindness`). Merge that one first, and merge it with `--rebase` — squashing a base gives its dependents duplicate-content conflicts.

**Paired with paw-enterprise #757**, which regenerates `topics.gen.ts`. They want to land together; see the red test below.

## The defect

`EVENT_REGISTRY` fills from `Event.__init_subclass__`, so it contains the events whose module has been *imported* — not the events that exist. `scripts/gen_topics.py` imported the registry module and nothing else, so it rendered 136 of 146 and ten never reached the frontend's `Topic` union at all:

```
belt_plan
mandate.autopilot_changed, mandate.created, mandate.shift_started,
mandate.shift_updated, mandate.sighting_added
meeting.ended, meeting.recording_ready, meeting.reminder, meeting.transcript_ready
```

Two of those (`meeting.recording_ready`, `meeting.transcript_ready`) are already wired in the frontend dispatcher and only type-check because the subscription map is cast. That cast is reported separately and not touched here.

The old staleness guard could never have caught this: it compared the file before and after a run of the same minimal-import subprocess, so both sides were short by the same ten.

## The fix, and why not a package walk

Two explicit imports. A full `pkgutil.walk_packages` over `pocketpaw_ee` also works and was rejected on measurement: it takes **29 seconds**, and 8 modules raise on import (the vendored oasis substrate, a worker), so it would need failures swallowed — which is exactly how events went missing in the first place.

Two imports plus a test that checks every declared event reached the output is cheaper and fails louder. `test_every_declared_event_reaches_the_generated_file` scans the package for `EVENT_TYPE` declarations and names any topic missing from the render, so declaring events in a new module fails the build until it is imported in the generator.

That scan is a source scan, which this sprint has spent a while distrusting, so it pins its own liveness: `test_the_scan_that_checks_completeness_is_itself_alive` asserts it finds sentinels from three different modules and a floor of 140 declarations. A refactor of how `EVENT_TYPE` is declared breaks the scan loudly instead of quietly finding nothing and reporting success. Both blinding modes are in the mutation plan.

`test_collection_does_not_depend_on_what_the_process_imported` force-imports the two modules and compares the in-process render to a clean-interpreter one, so it does not depend on collection order to detect a regression.

## The second defect, found by fixing the first

Importing the meetings module made a latent conflict real. `MeetingScheduled`, `MeetingStarted` and `MeetingCancelled` were declared **twice** — bare stubs in `_core/realtime/events.py`, documented classes in `cloud/meetings/events.py` — each pair claiming the same `EVENT_TYPE`. `EVENT_REGISTRY` is keyed on that literal, so those three mapped to whichever module imported last, and `rebuild_event` reconstructed a different class depending on import order.

The core copies were the dead half: every emitter and every test imports from `cloud.meetings.events` (`livekit/service.py`, `meetings/service.py`, `meetings/scheduling/service.py`, the push listeners), and nothing anywhere imported those names from the core module. Removed. `MeetingUpdated` stays — it is the only declaration of `meeting.updated`.

This was **already failing on `dev`**, not something this branch introduced. `test_registry_includes_every_subclass_with_event_type` asserts exactly this invariant; it passed only because no test session had ever imported both modules. Run `tests/cloud/realtime/ tests/cloud/meetings/` together on clean `dev` and it fails.

## One test is RED on this branch, deliberately

`test_topics_gen_is_committed_state` compares 146 rendered topics against a file paw-enterprise still has at 136. **The failure diff is the defect, listed.** It goes green when the paired PR lands.

It is not marked `xfail`: an xfail that flips to XPASS the moment another repo merges is the same class of problem this stack is about, and `DEFAULT_OUT` resolves to the working sibling checkout, which the test may never write. A red test with an explanation is honest; a green one that is green for a scheduling reason is not.

Consequence for reviewers: a red baseline makes every mutation in `topics_gen.json` look "caught", so those entries are now scoped to individual test node ids rather than the whole file. The one entry whose only witness is the red test is labelled as such — it was verified caught on #1885, where that test is green.

## Numbers

```
uv run python scripts/mutate.py --plan tests/mutations/topics_collection.json  -> 4 caught, 0 escaped
uv run python scripts/mutate.py --plan tests/mutations/topics_gen.json         -> 6 caught, 0 escaped
uv run pytest tests/cloud/realtime/ tests/cloud/composio/ tests/cloud/meetings/ tests/cloud/push/ -q -p no:randomly
   this branch -> 419 passed, 3 failed
   clean dev   -> 412 passed, 3 failed
uv run ruff check + format --check on the four edited files -> clean
```

Same failure count, different composition. This branch **fixes** `test_registry_includes_every_subclass_with_event_type` and **adds** the intentional red above. The other two (`test_bridges.py::test_meeting_scheduled_notification_fired`, `test_router.py::test_create_meeting_with_scheduled_start`) fail identically on clean `dev` and are untouched by this work.

Manual check of the pair: `gen_topics.py --print` output is byte-identical to the file the paired PR commits, 146 topics, pure LF.
