### PR TITLE
Don't photograph a site page that isn't serving yet

### DIFF
--- a/ee/pocketpaw_ee/sites/screenshot.py
+++ b/ee/pocketpaw_ee/sites/screenshot.py
@@ -26,11 +26,15 @@
 #
 # SOURCE — the site's own live URL. Unlike kb_ingest, which reads the pocket
 # precisely to avoid a server-side fetch of a customer hostname, a screenshot has
-# no other source: the point is a picture of the page as deployed. The fetch does
-# not happen on our network either — Cloudflare's browser does it — so this is
-# not the SSRF surface ``url_crawler`` had to be hardened against. A site with no
-# url (a WfP deploy with PAW_CF_SITES_DOMAIN unset) is skipped rather than
-# guessed at.
+# no other source: the point is a picture of the page as deployed. The RENDER does
+# not happen on our network — Cloudflare's browser does it — and the readiness
+# probe added below, which does, addresses a hostname WE composed
+# (``<site_id>.<PAW_CF_SITES_DOMAIN>``, or the local-mode base) rather than one a
+# customer supplied, so neither is the SSRF surface ``url_crawler`` had to be
+# hardened against. Every write of ``Site.url`` in ``sites.service`` builds it from
+# the site id plus operator configuration; a connected custom domain is appended to
+# ``allowed_origins`` and never becomes ``url``. A site with no url (a WfP deploy
+# with PAW_CF_SITES_DOMAIN unset) is skipped rather than guessed at.
 #
 # PERSISTENCE — ``site.set({...})``, never ``site.save()``. This runs seconds to
 # minutes after the publish that scheduled it, holding a Site instance
@@ -90,6 +94,56 @@
 # each shot addresses a URL the cache has never seen. That behaviour cannot be
 # proven from here — the tests pin that the param is sent and differs per capture,
 # not that Cloudflare honours it.
+#
+# Updated 2026-08-08 (a preview is never a photograph of a page that was not
+# serving yet). THE DEFECT: capture fired at the tail of a successful publish and
+# navigated IMMEDIATELY, but a deploy is live at Cloudflare before it is live at the
+# edge — for a few seconds the site's own address answers 404, or an edge
+# placeholder. Browser Rendering renders that page perfectly happily, and a
+# screenshot of a 404 is a valid PNG: 2xx, ``image/png``, non-empty. Every
+# fail-closed check SC-1 shipped passed, because all three ask whether the CAPTURE
+# succeeded and none asked whether the PAGE was worth capturing. The bytes landed on
+# the Site and stayed there — nothing re-captures on its own, so the card showed a
+# picture of nothing until somebody republished an unchanged site.
+#
+# THE GATE: ``take_site_screenshot`` now polls the site's own url until it answers
+# 2xx (``wait_until_serving``) before spending a Browser Rendering call. Shape, and
+# why each part is the way it is:
+#   * a plain GET from this process, not a rendered page. It costs no Browser
+#     Rendering quota, so the poll is free and the paid call happens once, against a
+#     page known to exist. The body is never read — ``_url_is_serving`` streams and
+#     looks only at the status.
+#   * READY IS 2xx AND NOTHING ELSE. 404 is the ordinary pre-live answer; a 5xx or
+#     Cloudflare's own 530 is the other; a connection that never opens (DNS for a
+#     brand-new subdomain) is the earliest form of the same thing. All read
+#     not-ready, none propagate.
+#   * each probe is cache-busted through ``_shot_url``, for the reason SC-3 added
+#     that helper: an un-busted probe could be answered 200 from the document the
+#     edge held BEFORE the deploy, and the gate would open on the strength of the
+#     old page.
+#   * ON TIMEOUT THE PREVIEW IS LEFT ABSENT, and one plain log line says so. A card
+#     with no image is honest, has a themed placeholder already (SC-2), and — the
+#     part that matters — does not overwrite a good picture from a previous deploy
+#     with a worse one. There is deliberately no re-schedule: a retry that outlives
+#     the poll is a second timer to reason about, and the recovery path already
+#     exists and is now reachable from the UI (POST /sites/{id}/preview-refresh,
+#     wired into the site card in paw-enterprise).
+#   * THE FOUNDING RULE IS INTACT. The poll runs inside the fire-and-forget capture
+#     — the same background task the render already ran in — so ``publish()`` gains
+#     no latency, and a probe that raises lands in the same swallow every other
+#     capture failure does. Nothing here is ever awaited on the publish's stack.
+#
+# The manual half runs the SAME gate on a SHORT schedule (``_READY_DELAYS_MANUAL``):
+# a person pressed a button and is watching a spinner, so holding the request for
+# the post-deploy budget would be worse than telling them the site is not up yet.
+# ``sites.service.refresh_site_preview`` probes first so it can answer with its own
+# ``sites.preview_not_serving`` — ``preview_unavailable`` advises "publish the site,
+# or open its preview once", which is exactly the wrong advice for a site that IS
+# published and is merely still coming up.
+#
+# The DRAFT path is deliberately ungated: it renders markup at ``about:blank``, so
+# there is no address that could be unready, and a gate there would poll nothing and
+# reject every draft.
 
 from __future__ import annotations
 
@@ -156,6 +210,93 @@ def _shot_url(url: str) -> str:
     return f"{url}{sep}{_SHOT_PARAM}={uuid.uuid4().hex}"
 
 
+# --------------------------------------------------------------------------- #
+# The readiness gate — is there a page here worth photographing?
+# --------------------------------------------------------------------------- #
+
+# How long ONE probe may take. Short: a serving edge answers in milliseconds, and a
+# request that hangs is itself the answer we are looking for.
+_READY_PROBE_TIMEOUT = 5.0
+
+# The waits BETWEEN probes on the post-deploy path, in seconds. A probe fires
+# immediately first, so this is five retries over ~59s — call it a ninety-second
+# ceiling once the probe timeouts are counted. Generous on purpose: it runs in a
+# background task nobody is waiting on, and the cost of waiting too long is a card
+# that fills in a minute late, while the cost of giving up too early is no card at
+# all until somebody presses refresh. Backed off rather than evenly spaced because
+# the overwhelming majority of deploys are live on the first or second look.
+_READY_DELAYS: tuple[float, ...] = (2.0, 4.0, 8.0, 15.0, 30.0)
+
+# The waits for the MANUAL path (``sites.service.refresh_site_preview``). A person is
+# watching a spinner, so two probes ~2s apart: enough to ride out a single blip,
+# short enough that "the site isn't up yet" arrives as an answer rather than a
+# timeout.
+_READY_DELAYS_MANUAL: tuple[float, ...] = (2.0,)
+
+# Identifies the probe in an operator's access logs, next to ``_paw_shot``.
+_PROBE_UA = "PocketPaw-SitePreview/1.0 (+readiness-probe)"
+
+
+async def _url_is_serving(url: str, *, transport: Any = None) -> bool:
+    """One probe: does this address answer 2xx right now?
+
+    A plain GET from this process — no Browser Rendering quota is spent deciding
+    whether a page is worth rendering. The response body is never read (the request
+    is streamed and the context closed on the status line), so a probe costs a
+    round trip, not a page download.
+
+    Everything that is not 2xx is NOT ready, and nothing raises: 404 is the ordinary
+    answer from an edge that has not finished going live, a 5xx or Cloudflare's 530
+    is the other, and a connection that never opens is DNS for a brand-new subdomain
+    not having propagated. All three are "come back in a moment", not errors to
+    report — the caller's only decision is capture or don't.
+
+    ``transport`` is the injectable httpx seam, so the probe's semantics are pinned
+    against a real client rather than a stubbed function.
+    """
+    import httpx
+
+    kwargs: dict[str, Any] = {
+        "timeout": _READY_PROBE_TIMEOUT,
+        # A site that redirects (http→https, bare→www) IS serving, and following the
+        # hop is what the browser about to photograph it will do.
+        "follow_redirects": True,
+    }
+    if transport is not None:
+        kwargs["transport"] = transport
+    try:
+        async with httpx.AsyncClient(**kwargs) as client:
+            async with client.stream("GET", url, headers={"user-agent": _PROBE_UA}) as resp:
+                return resp.status_code // 100 == 2
+    except Exception:  # noqa: BLE001 — an unreachable address is a NO, not a failure
+        return False
+
+
+async def wait_until_serving(url: str, *, delays: Any = None, transport: Any = None) -> bool:
+    """Poll ``url`` until it answers 2xx. True when it did, False when the budget ran
+    out.
+
+    ``delays`` is the schedule of waits BETWEEN probes; ``None`` means
+    :data:`_READY_DELAYS` (the post-deploy budget) and ``()`` means a single probe
+    with no retry. One probe always fires immediately, so an edge that is already
+    live costs one fast GET and no waiting at all — the common case pays nothing.
+
+    Each probe addresses a cache-busted url (:func:`_shot_url`, a fresh value every
+    time) for the reason SC-3 minted that helper: Cloudflare's edge caches by full
+    URL, so an unmodified probe could be answered 200 from the document that was
+    there before this deploy, and the gate would open on the strength of the page it
+    exists to stop us photographing.
+    """
+    schedule = _READY_DELAYS if delays is None else tuple(delays)
+    if await _url_is_serving(_shot_url(url), transport=transport):
+        return True
+    for delay in schedule:
+        await asyncio.sleep(delay)
+        if await _url_is_serving(_shot_url(url), transport=transport):
+            return True
+    return False
+
+
 async def _store_screenshot(site: Any, image: bytes) -> str:
     """Put the bytes in the tenant's blob storage, return the stable URL.
 
@@ -198,13 +339,21 @@ async def _store_screenshot(site: Any, image: bytes) -> str:
     return f"/api/v1/uploads/{rec.id}"
 
 
-async def take_site_screenshot(site: Any, *, cloudflare: Any | None = None) -> str:
+async def take_site_screenshot(
+    site: Any, *, cloudflare: Any | None = None, ready_delays: Any = None
+) -> str:
     """Screenshot the site's live page, store it, record it on the Site.
 
-    Returns the stored image's URL, or "" when there was nothing to shoot (no
-    live url yet) or the shot produced no bytes. Raises on a Cloudflare or
-    upload failure — callers on the publish path use
-    :func:`safe_take_site_screenshot`, which is the form that cannot.
+    Returns the stored image's URL, or "" when there was nothing worth shooting —
+    no live url yet, the page not serving before the readiness budget ran out, or a
+    shot that produced no bytes. Raises on a Cloudflare or upload failure — callers
+    on the publish path use :func:`safe_take_site_screenshot`, which is the form
+    that cannot.
+
+    ``ready_delays`` is the readiness poll's retry schedule, passed straight to
+    :func:`wait_until_serving`: ``None`` for the generous post-deploy budget, ``()``
+    for a single probe. There is no way to switch the gate OFF, deliberately — a
+    bypass parameter is a bypass somebody eventually passes.
 
     ``cloudflare`` is the injectable client seam; production resolves the
     configured one through ``sites.service._cf_client`` so screenshots read the
@@ -225,6 +374,23 @@ async def take_site_screenshot(site: Any, *, cloudflare: Any | None = None) -> s
         # There is no page to photograph, and guessing one would photograph
         # somebody else's.
         logger.debug("sites.screenshot: site %s has no url — nothing to capture", site.id)
+        return ""
+
+    # THE GATE. A deploy is live at Cloudflare before it is live at the edge, so the
+    # address can still be answering 404 when this runs. Browser Rendering would
+    # render that 404 into a perfectly valid PNG and it would sit on the card until
+    # somebody republished. Poll first; a page that never comes up is left with no
+    # picture, which is honest and — unlike a photograph of a 404 — does not
+    # overwrite a good preview from the previous deploy.
+    if not await wait_until_serving(url, delays=ready_delays):
+        logger.warning(
+            "sites.screenshot: %s was not serving within the readiness budget — no "
+            "preview captured for site %s (the card keeps its previous image; "
+            "POST /sites/%s/preview-refresh re-tries on demand)",
+            url,
+            getattr(site, "id", "?"),
+            getattr(site, "id", "?"),
+        )
         return ""
 
     from pocketpaw_ee.sites.service import _cf_client
@@ -447,4 +613,5 @@ __all__ = [
     "schedule_site_screenshot",
     "take_draft_screenshot",
     "take_site_screenshot",
+    "wait_until_serving",
 ]

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -47,6 +47,18 @@
 # preview" needs to be told when it did not work rather than handed back the stale
 # url they were trying to replace.
 #
+# Updated 2026-08-08 (a preview is never a photograph of a page that was not serving
+# yet). ``refresh_site_preview`` gained the READINESS branch: a deploy is live at
+# Cloudflare before it is live at the edge, so the capture path now polls the site's
+# url before spending a render (see ``sites.screenshot`` — that module's header holds
+# the full reasoning). This function runs the same gate on a SHORT budget, because
+# unlike the deploy-time capture it has somebody waiting on it, and raises its own
+# ``sites.preview_not_serving`` rather than reusing ``preview_unavailable``: the two
+# declines need opposite advice ("publish it" vs "it is published, try again in a
+# moment"), and the wrong one surfaces verbatim in the dashboard. This endpoint is
+# also the recovery path when the deploy-time gate times out and deliberately leaves
+# the card without a picture.
+#
 # Updated 2026-08-07 (MT-1 — an interactive site keeps its own JavaScript):
 # ``publish_pocket`` now reads the pocket's ``keepsClientBundle`` declaration and
 # threads it through ``publish`` -> ``_deploy_site_doc`` -> ``generator.build``, so a
@@ -2588,13 +2600,40 @@ async def refresh_site_preview(*, workspace_id: str, site_id: str) -> SitePrevie
     Routes itself the same way the automatic path does: a site with a url is
     photographed live, a draft is photographed from its own markup. Tenant-scoped
     via ``_load``, so another workspace's site is a 404, never a render.
+
+    Runs the same readiness gate the deploy path does, on a SHORT budget, and reports
+    a page that is not serving as its own ``sites.preview_not_serving`` — see the
+    comment at the branch. This is also the recovery path for a capture the deploy
+    path DECLINED: when an edge takes longer than the post-deploy budget to come up,
+    the card is deliberately left without a picture, and this is what fills it in.
     """
-    from pocketpaw_ee.sites.screenshot import take_draft_screenshot, take_site_screenshot
+    from pocketpaw_ee.sites.screenshot import (
+        _READY_DELAYS_MANUAL,
+        take_draft_screenshot,
+        take_site_screenshot,
+        wait_until_serving,
+    )
 
     site = await _load(workspace_id, site_id)
 
-    if (getattr(site, "url", "") or "").strip():
-        image_url = await take_site_screenshot(site)
+    url = (getattr(site, "url", "") or "").strip()
+    if url:
+        # The readiness gate, run HERE as well as inside the capture, purely so this
+        # path can name what went wrong. ``take_site_screenshot`` reports every
+        # decline the same way — with "" — and the two declines need opposite
+        # advice: a site with nothing renderable yet should be published, while a
+        # site that IS published and merely still coming up should just be retried.
+        # On a short budget, because a person is watching a spinner: the deploy
+        # path's minute is right for a background task and wrong for a request.
+        if not await wait_until_serving(url, delays=_READY_DELAYS_MANUAL):
+            raise ValidationError(
+                "sites.preview_not_serving",
+                "The site isn't answering yet. A deploy can take a moment to go "
+                "live at the edge — try the refresh again shortly.",
+            )
+        # A single confirming probe immediately before the paid render, so the gate
+        # has no bypass path: every call into ``take_site_screenshot`` is gated.
+        image_url = await take_site_screenshot(site, ready_delays=())
     else:
         image_url = await take_draft_screenshot(site)
 

--- a/tests/cloud/conftest.py
+++ b/tests/cloud/conftest.py
@@ -101,6 +101,37 @@ def local_store_home(tmp_path_factory):
 
 
 @pytest.fixture(autouse=True)
+def _site_pages_are_serving(monkeypatch):
+    """Never let a cloud test's site capture make a REAL request to the internet.
+
+    A site screenshot polls the site's own url before rendering it (a deploy is live
+    at Cloudflare before it is live at the edge, and a picture of the 404 in between
+    lands on the card permanently). Publish-driven tests live in this tree too, and
+    the poll's retry schedule runs to ~90s — so one test that happens to await after
+    a publish would stall CI on a DNS lookup for a hostname that does not exist,
+    which is a miserable thing to diagnose.
+
+    Nothing in this tree reaches the probe today (the capture is a detached task and
+    these tests end before it runs), so this is insurance, not a fix. It defaults the
+    probe to ready and zeroes both delay schedules; the gate's own tests live in
+    tests/ee/sites/test_capture_readiness.py and patch these same attributes.
+    """
+    try:
+        from pocketpaw_ee.sites import screenshot as screenshot_mod
+    except Exception:  # noqa: BLE001 — OSS-only install: nothing to stub
+        yield
+        return
+
+    async def _serving(_url: str, **_kw) -> bool:
+        return True
+
+    monkeypatch.setattr(screenshot_mod, "_url_is_serving", _serving)
+    monkeypatch.setattr(screenshot_mod, "_READY_DELAYS", ())
+    monkeypatch.setattr(screenshot_mod, "_READY_DELAYS_MANUAL", ())
+    yield
+
+
+@pytest.fixture(autouse=True)
 def recording_bus():
     """Install a RecordingBus for every test.
 

--- a/tests/ee/sites/conftest.py
+++ b/tests/ee/sites/conftest.py
@@ -1,5 +1,11 @@
 # tests/ee/sites/conftest.py
 # Created: 2026-06-18 (feat/sites-dedupe-migration, PERF-2).
+# Updated 2026-08-08 (capture readiness): added the autouse ``_site_pages_are_serving``
+#   fixture. Screenshot capture now polls the site's url before rendering it, so
+#   without this every existing capture test would fire a real request at a hostname
+#   that does not resolve and then wait out the retry schedule. It defaults the probe
+#   to ready and zeroes both delay schedules; test_capture_readiness.py patches the
+#   same attributes to exercise the gate itself.
 # Updated 2026-07-17 (feat/sites-native-artifact-no-build): added two autouse fixtures
 #   for the native-artifact read-through cache — ``_artifact_store_tmp`` points
 #   PAW_SITES_ARTIFACT_DIR at a temp dir so a cache MISS never writes the real home, and
@@ -113,6 +119,32 @@ def _captured_prewarms(monkeypatch):
     yield captured
     for coro in captured:
         coro.close()
+
+
+@pytest.fixture(autouse=True)
+def _site_pages_are_serving(monkeypatch):
+    """Default the screenshot readiness probe to "the page is up", with no waits.
+
+    A capture now polls the site's own url before spending a Browser Rendering call
+    (a deploy is live at Cloudflare before it is live at the edge, and a screenshot
+    of the 404 in between is a valid PNG that lands on the card forever). Left
+    un-stubbed, every existing capture test would make a REAL request to
+    ``brew.example.test`` / ``*.paw-sites.test``, get nothing, and then sit through
+    the retry schedule before failing — slow, flaky, and offline-hostile.
+
+    Defaulting the gate OPEN is the right default here: these tests are about what
+    happens once there is a page. The tests that are about the GATE
+    (test_capture_readiness.py) patch the same two attributes themselves, and an
+    inner patch of the same target wins while it is active."""
+    from pocketpaw_ee.sites import screenshot as screenshot_mod
+
+    async def _serving(_url: str, **_kw) -> bool:
+        return True
+
+    monkeypatch.setattr(screenshot_mod, "_url_is_serving", _serving)
+    monkeypatch.setattr(screenshot_mod, "_READY_DELAYS", ())
+    monkeypatch.setattr(screenshot_mod, "_READY_DELAYS_MANUAL", ())
+    yield
 
 
 @pytest.fixture(autouse=True)

--- a/tests/ee/sites/test_capture_readiness.py
+++ b/tests/ee/sites/test_capture_readiness.py
@@ -1,0 +1,530 @@
+# tests/ee/sites/test_capture_readiness.py — a preview is never a photograph of a
+# page that was not serving yet.
+#
+# Created 2026-08-08. THE BUG THIS REPRODUCES: a publish returns, the site's worker
+# is uploaded, and the capture fires immediately — but Cloudflare takes time to go
+# live after a deploy, so the address the browser is pointed at is still answering
+# 404 (or an edge placeholder). Browser Rendering renders that page happily, the
+# result is a perfectly valid PNG, every fail-closed check downstream passes, and
+# the bytes land on the Site as ``preview_image_url``. The card then shows a picture
+# of nothing, permanently: nothing re-captures on its own, so the only escape was to
+# republish an unchanged site.
+#
+# The failure is invisible to every guard SC-1 shipped, which is the point. Those
+# guards check that a capture SUCCEEDED — 2xx, an ``image/*`` content type, non-empty
+# bytes. A screenshot of a 404 satisfies all three. Nothing anywhere asked whether
+# the page was worth photographing.
+#
+# What is pinned here:
+#   * the reproduction — a publish whose url is not serving yet must end with NO
+#     stored preview, and must not spend a paid Browser Rendering call on a dead
+#     page;
+#   * the poll — an edge that comes up on the third probe is captured, not
+#     abandoned, and each probe addresses a cache-busted url so a stale 200 from the
+#     edge cannot pass the gate;
+#   * the probe's own semantics, over a real httpx transport — 2xx is ready,
+#     everything else (404, 5xx, a connection that never opens) is not;
+#   * the rule the module was founded on, unbroken — the gate lives in the
+#     background capture, never on the publish's stack, and a probe that explodes
+#     still cannot fail a publish;
+#   * the manual half — ``refresh_site_preview`` runs a SHORT budget (a person is
+#     watching a spinner) and reports a page that is not serving as its own error,
+#     distinct from "there is nothing to photograph yet";
+#   * the draft path is untouched — markup rendered at about:blank has no address
+#     that could be unready.
+#
+# The mutations that break these tests (run via scripts/mutate.py — a gate nobody has
+# watched fail is not a gate) live in tests/mutations/site_screenshot.json: removing
+# the readiness gate from ``take_site_screenshot``; making ``_url_is_serving`` report
+# any response as ready; and dropping the manual path's ``preview_not_serving``
+# branch.
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+
+import httpx
+import pytest
+from pocketpaw_ee.cloud._core.errors import ValidationError
+from pocketpaw_ee.sites import screenshot as screenshot_mod
+from pocketpaw_ee.sites import service as sites_service
+
+# A real 1x1 PNG — the upload pipeline sniffs magic bytes, so a fake payload would
+# be rejected as an unsupported mime and a happy-path test would pass for the wrong
+# reason. Same constant, same reason, as test_screenshot_capture.py.
+_PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+)
+
+
+class _FakeCFScreenshot:
+    """A Cloudflare client that only knows how to take a screenshot — and takes one
+    of WHATEVER it is pointed at. That is the real Browser Rendering behaviour and
+    the whole reason this bug exists: it does not care that the page is a 404."""
+
+    def __init__(self, result: bytes | Exception = _PNG) -> None:
+        self.result = result
+        self.calls: list[str] = []
+
+    async def capture_screenshot(self, *, url="", html="", **_kw):
+        self.calls.append(url or "<html>")
+        if isinstance(self.result, Exception):
+            raise self.result
+        return self.result
+
+
+class _Edge:
+    """A stand-in for the deployed page's readiness, answering a scripted sequence.
+
+    ``ready_after=2`` means the first two probes see an edge that is not serving yet
+    and the third sees the site live — the actual shape of a Cloudflare deploy."""
+
+    def __init__(self, *, ready_after: int = 0) -> None:
+        self.ready_after = ready_after
+        self.probes: list[str] = []
+
+    async def __call__(self, url: str, **_kw) -> bool:
+        self.probes.append(url)
+        return len(self.probes) > self.ready_after
+
+
+def _site(**over):
+    """An in-memory stand-in for a deployed Site doc, recording its own ``set``."""
+    sets: list[dict] = []
+
+    class _S:
+        id = over.get("id", "site-1")
+        owner = "u1"
+        workspace = "ws1"
+        pocket_id = "pocket-1"
+        url = over.get("url", "https://brew.example.test/")
+        preview_image_url = over.get("preview_image_url", None)
+        writes = sets
+
+        async def set(self, updates):
+            sets.append(updates)
+
+    return _S()
+
+
+def _gate(monkeypatch, edge: _Edge) -> _Edge:
+    """Point the readiness gate at a scripted edge and take the waits out.
+
+    ``raising=False`` on purpose: this test file was written BEFORE the gate existed,
+    against a build where these attributes are absent and the capture fires blind.
+    That is the reproduction — the seam is installed, ignored, and a picture of a
+    dead page is stored anyway."""
+    monkeypatch.setattr(screenshot_mod, "_url_is_serving", edge, raising=False)
+    monkeypatch.setattr(screenshot_mod, "_READY_DELAYS", (0, 0, 0, 0, 0), raising=False)
+    return edge
+
+
+# --------------------------------------------------------------------------- #
+# THE REPRODUCTION
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_a_page_that_is_not_serving_yet_is_never_photographed(monkeypatch, tmp_path):
+    """THE BUG, at the capture itself. Cloudflare has not finished going live, so the
+    site's address answers 404. Browser Rendering would render that 404 into a valid
+    PNG and the Site would remember it forever.
+
+    Mutation: delete the readiness gate in ``take_site_screenshot`` and this stores a
+    preview of a page that was never serving."""
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    cf = _FakeCFScreenshot()
+    edge = _gate(monkeypatch, _Edge(ready_after=99))  # never comes up
+    site = _site()
+
+    out = await screenshot_mod.take_site_screenshot(site, cloudflare=cf)
+
+    # Nothing recorded: a card with no image is honest and the gallery already has a
+    # placeholder for it. A screenshot of a 404 is a lie that outlives the deploy.
+    assert site.writes == []
+    assert out == ""
+    # And no paid render was spent on a page that had nothing to show.
+    assert cf.calls == []
+    assert edge.probes, "the readiness gate never ran"
+
+
+@pytest.mark.asyncio
+async def test_a_publish_whose_edge_is_not_live_yet_stores_no_preview(
+    beanie_test_db, monkeypatch, tmp_path, published_url
+):
+    """THE BUG, end to end from a real publish — the captain's report exactly. The
+    publish succeeds, the worker is uploaded, and the capture fires while Cloudflare
+    is still bringing the address up.
+
+    The site must still deploy (a screenshot may never cost anybody a publish) and
+    the card must be left with no image rather than a picture of nothing."""
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    cf = _FakeCFScreenshot()
+    monkeypatch.setattr(sites_service, "_cf_client", lambda: cf)
+    _gate(monkeypatch, _Edge(ready_after=99))
+    ran = _run_captures_inline(monkeypatch)
+
+    site = await _publish()
+    for task in ran:
+        await task
+
+    rows = await sites_service.list_for_workspace("ws1")
+    assert rows[0].preview_image_url is None
+    assert cf.calls == []
+    # THE RULE, unbroken: the site is live regardless of what the picture did.
+    assert site.deployed is True
+
+
+# --------------------------------------------------------------------------- #
+# The poll — an edge that comes up late is still captured
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_an_edge_that_comes_up_on_the_third_probe_is_captured(monkeypatch, tmp_path):
+    """The gate is a poll, not a single look. Cloudflare going live takes seconds, so
+    a capture that gave up on the first 404 would be the same bug with extra steps —
+    it would just fail to a missing preview instead of a wrong one."""
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    cf = _FakeCFScreenshot()
+    edge = _gate(monkeypatch, _Edge(ready_after=2))
+    site = _site()
+
+    out = await screenshot_mod.take_site_screenshot(site, cloudflare=cf)
+
+    assert len(edge.probes) == 3
+    assert out.startswith("/api/v1/uploads/")
+    assert site.writes == [{"preview_image_url": out}]
+    assert len(cf.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_every_probe_addresses_a_url_the_edge_cache_has_never_seen(monkeypatch, tmp_path):
+    """The probe carries SC-3's per-capture cache-buster, and a fresh one each time.
+
+    Without it the readiness check has the same defect the screenshot had before
+    SC-3: Cloudflare's edge caches by full URL, so a probe could be answered 200 from
+    the document that was there BEFORE the deploy — the gate would open on the
+    strength of the old page and the capture would photograph whatever came next."""
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    edge = _gate(monkeypatch, _Edge(ready_after=3))
+
+    await screenshot_mod.take_site_screenshot(_site(), cloudflare=_FakeCFScreenshot())
+
+    assert len(edge.probes) == 4
+    for probe in edge.probes:
+        assert probe.startswith("https://brew.example.test/?_paw_shot=")
+    assert len(set(edge.probes)) == len(edge.probes), "a probe reused a cached address"
+
+
+@pytest.mark.asyncio
+async def test_a_site_with_no_url_is_still_skipped_before_any_probe(monkeypatch):
+    """A Workers-for-Platforms deploy with no sites domain has no address at all.
+    That was already skipped and stays skipped — there is nothing to poll, and
+    polling "" would be a request to our own host."""
+    edge = _gate(monkeypatch, _Edge())
+    cf = _FakeCFScreenshot()
+    site = _site(url="")
+
+    assert await screenshot_mod.take_site_screenshot(site, cloudflare=cf) == ""
+    assert edge.probes == []
+    assert cf.calls == []
+
+
+# --------------------------------------------------------------------------- #
+# The probe itself, over a real transport
+# --------------------------------------------------------------------------- #
+
+
+def _probe_transport(handler) -> httpx.MockTransport:
+    return httpx.MockTransport(handler)
+
+
+# The REAL probe, bound at import — before the autouse ``_site_pages_are_serving``
+# fixture in conftest.py replaces the module attribute with a stub that answers True
+# without opening a connection. These four tests are the only ones in the suite about
+# the probe's own semantics, so reaching it through ``screenshot_mod._url_is_serving``
+# would run them against the stub and they would all pass while proving nothing.
+#
+# They are self-checking about it: the stub never touches the transport, so every
+# ``is False`` case and the redirect's hop count fail loudly if this binding is ever
+# replaced by the module attribute.
+_probe = screenshot_mod._url_is_serving
+
+
+@pytest.mark.asyncio
+async def test_a_serving_page_reads_ready():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, html="<h1>Brew and Co</h1>")
+
+    assert await _probe("https://brew.example.test/", transport=_probe_transport(handler)) is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [404, 403, 500, 502, 530])
+async def test_an_edge_that_is_not_serving_the_site_reads_not_ready(status):
+    """404 is the ordinary pre-live answer; 5xx and Cloudflare's own 530 are the
+    others. None of them is a page worth a paid render."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status, html="<h1>Not found</h1>")
+
+    assert await _probe("https://brew.example.test/", transport=_probe_transport(handler)) is False
+
+
+@pytest.mark.asyncio
+async def test_a_connection_that_never_opens_reads_not_ready():
+    """DNS for a brand-new subdomain may not resolve yet. A transport failure is the
+    earliest form of "not serving", not an error to propagate."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("name or service not known")
+
+    assert await _probe("https://brew.example.test/", transport=_probe_transport(handler)) is False
+
+
+@pytest.mark.asyncio
+async def test_a_redirect_to_the_live_page_reads_ready():
+    """A site that redirects (http→https, bare→www) is serving. Following the hop is
+    what the browser about to photograph it will do."""
+    hops: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        hops.append(str(request.url))
+        if len(hops) == 1:
+            return httpx.Response(301, headers={"location": "https://brew.example.test/home"})
+        return httpx.Response(200, html="<h1>Brew and Co</h1>")
+
+    assert await _probe("https://brew.example.test/", transport=_probe_transport(handler)) is True
+    assert len(hops) == 2
+
+
+# --------------------------------------------------------------------------- #
+# THE FOUNDING RULE — the gate may not cost anybody a publish
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_a_probe_that_explodes_cannot_fail_a_publish(
+    beanie_test_db, monkeypatch, published_url
+):
+    """The readiness poll runs inside the fire-and-forget capture, so even a probe
+    that raises outright lands in the same swallow every other capture failure does.
+
+    Run INLINE, so the exception is on the publish's own stack — the strictest form
+    of the rule this module was founded on."""
+
+    async def _boom(url, **_kw):
+        raise RuntimeError("dns resolver is down")
+
+    monkeypatch.setattr(screenshot_mod, "_url_is_serving", _boom, raising=False)
+    monkeypatch.setattr(screenshot_mod, "_READY_DELAYS", (), raising=False)
+    cf = _FakeCFScreenshot()
+    monkeypatch.setattr(sites_service, "_cf_client", lambda: cf)
+    ran = _run_captures_inline(monkeypatch)
+
+    site = await _publish()
+    for task in ran:
+        await task
+
+    assert site.deployed is True
+    rows = await sites_service.list_for_workspace("ws1")
+    assert rows[0].preview_image_url is None
+
+
+@pytest.mark.asyncio
+async def test_the_gate_never_runs_on_the_publishs_own_stack(
+    beanie_test_db, monkeypatch, published_url, captured_screenshots
+):
+    """A poll that waits up to a minute would be catastrophic in ``publish()``. It is
+    only ever reached through the background scheduler, so a publish with the
+    scheduler stubbed out never probes at all."""
+    edge = _gate(monkeypatch, _Edge(ready_after=99))
+
+    await _publish()
+
+    assert len(captured_screenshots) == 1
+    assert edge.probes == []
+
+
+@pytest.mark.asyncio
+async def test_a_previous_good_preview_survives_an_unready_recapture(monkeypatch, tmp_path):
+    """SC-3 re-shoots on every republish, which is right — but a republish whose edge
+    has not come up yet must leave the existing picture alone rather than regress it
+    to a photograph of a 404."""
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    _gate(monkeypatch, _Edge(ready_after=99))
+    site = _site(preview_image_url="/api/v1/uploads/the-good-one")
+
+    assert await screenshot_mod.take_site_screenshot(site, cloudflare=_FakeCFScreenshot()) == ""
+    assert site.writes == []
+    assert site.preview_image_url == "/api/v1/uploads/the-good-one"
+
+
+# --------------------------------------------------------------------------- #
+# The DRAFT path — no address, so nothing to be unready
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_a_draft_capture_never_probes(monkeypatch, tmp_path):
+    """A draft is photographed from its own markup, which renders at about:blank.
+    There is no address involved, so a readiness gate there would poll nothing and
+    reject every draft."""
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    edge = _gate(monkeypatch, _Edge(ready_after=99))
+    cf = _FakeCFScreenshot()
+
+    async def _markup(_site):
+        return "<!doctype html><h1>draft</h1>"
+
+    from pocketpaw_ee.sites import draft_markup
+
+    monkeypatch.setattr(draft_markup, "build_draft_markup", _markup)
+    site = _site(url="")
+
+    out = await screenshot_mod.take_draft_screenshot(site, cloudflare=cf)
+
+    assert edge.probes == []
+    assert out.startswith("/api/v1/uploads/")
+    assert cf.calls == ["<html>"]
+
+
+# --------------------------------------------------------------------------- #
+# The MANUAL half — a person is watching a spinner
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_a_manual_refresh_of_a_page_that_is_not_serving_says_so(
+    beanie_test_db, monkeypatch, tmp_path
+):
+    """The deploy path waits a minute because nobody is watching. This one is a
+    request whose whole purpose is the answer, so it probes briefly and reports the
+    real reason.
+
+    The reason has to be its OWN error: ``preview_unavailable`` tells the operator to
+    "publish the site, or open its preview once", which is exactly the wrong advice
+    for a site that IS published and is merely still coming up.
+
+    Mutation: drop the ``preview_not_serving`` branch and this fails with the
+    misleading ``preview_unavailable`` instead."""
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.setattr(sites_service, "_cf_client", lambda: _FakeCFScreenshot())
+    edge = _gate(monkeypatch, _Edge(ready_after=99))
+    doc = await _publish_doc(monkeypatch)
+
+    with pytest.raises(ValidationError) as exc:
+        await sites_service.refresh_site_preview(workspace_id="ws1", site_id=str(doc.id))
+
+    assert exc.value.code == "sites.preview_not_serving"
+    assert edge.probes, "the manual refresh never checked whether the page was up"
+
+
+@pytest.mark.asyncio
+async def test_a_manual_refresh_does_not_wait_the_full_deploy_budget(
+    beanie_test_db, monkeypatch, tmp_path
+):
+    """A person pressing a button must not be held for the post-deploy budget. The
+    manual schedule is its own, short one."""
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.setattr(sites_service, "_cf_client", lambda: _FakeCFScreenshot())
+    edge = _Edge(ready_after=99)
+    monkeypatch.setattr(screenshot_mod, "_url_is_serving", edge, raising=False)
+    # Deliberately NOT zeroing _READY_DELAYS: if the manual path used the deploy
+    # schedule this test would sit through it.
+    doc = await _publish_doc(monkeypatch)
+
+    with pytest.raises(ValidationError):
+        await sites_service.refresh_site_preview(workspace_id="ws1", site_id=str(doc.id))
+
+    assert len(edge.probes) <= 3, f"the manual refresh probed {len(edge.probes)} times"
+
+
+@pytest.mark.asyncio
+async def test_a_manual_refresh_of_a_serving_page_still_captures(
+    beanie_test_db, monkeypatch, tmp_path
+):
+    """The gate must not break the affordance it exists to make useful."""
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    cf = _FakeCFScreenshot()
+    monkeypatch.setattr(sites_service, "_cf_client", lambda: cf)
+    _gate(monkeypatch, _Edge(ready_after=0))
+    doc = await _publish_doc(monkeypatch)
+
+    out = await sites_service.refresh_site_preview(workspace_id="ws1", site_id=str(doc.id))
+
+    assert out.preview_image_url.startswith("/api/v1/uploads/")
+    assert len(cf.calls) == 1
+
+
+# --------------------------------------------------------------------------- #
+# Publish plumbing — shared with test_screenshot_capture.py
+# --------------------------------------------------------------------------- #
+
+
+class _FakeGenerator:
+    async def build(self, **kw):
+        from pocketpaw_ee.sites.generator_client import BuildResult
+
+        return BuildResult(project_dir="/tmp/site", ripple_version="0.2.0")
+
+
+class _FakeCF:
+    async def put_worker(self, *, script_name, bundle, bindings=None):
+        return True
+
+
+async def _publish(*, preview: bool = False):
+    return await sites_service.publish(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id="pocket-1",
+        ripple_spec={"type": "container"},
+        theme={},
+        name="Brew and Co",
+        preview=preview,
+        _generator=_FakeGenerator(),
+        _cloudflare=None if preview else _FakeCF(),
+        _bundle_reader=lambda d: b"x",
+        _local_deploy=(lambda site_id, project_dir: f"http://localhost/{site_id}"),
+    )
+
+
+async def _publish_doc(monkeypatch):
+    """Publish a live site WITHOUT letting the automatic capture run, and hand back
+    the persisted doc — the starting state a manual refresh acts on."""
+    monkeypatch.setenv("PAW_CF_SITES_DOMAIN", "paw-sites.test")
+    monkeypatch.setattr(sites_service, "_schedule_site_screenshot", lambda site: None)
+    return await _publish()
+
+
+@pytest.fixture
+def captured_screenshots(monkeypatch):
+    """Record the sites a publish schedules a screenshot for, without taking one."""
+    seen: list = []
+    monkeypatch.setattr(sites_service, "_schedule_site_screenshot", seen.append)
+    return seen
+
+
+@pytest.fixture
+def published_url(monkeypatch):
+    """Give the Workers-for-Platforms publish a public address. Without
+    PAW_CF_SITES_DOMAIN a WfP deploy stamps ``url=""`` and the capture correctly
+    skips a site with no page to photograph — a test that wants to prove the GATE
+    ran has to configure the domain, or it passes for the wrong reason."""
+    monkeypatch.setenv("PAW_CF_SITES_DOMAIN", "paw-sites.test")
+
+
+def _run_captures_inline(monkeypatch) -> list:
+    """Make the fire-and-forget capture run on the publish's own loop and hand back
+    the tasks, so a test can await the background work instead of racing it."""
+    ran: list = []
+
+    def _inline(coro):
+        import asyncio
+
+        ran.append(asyncio.get_running_loop().create_task(coro))
+
+    monkeypatch.setattr(screenshot_mod, "_default_screenshot_scheduler", _inline)
+    return ran

--- a/tests/mutations/site_screenshot.json
+++ b/tests/mutations/site_screenshot.json
@@ -43,5 +43,50 @@
     "tests": [
       "tests/ee/sites/test_screenshot_capture.py"
     ]
+  },
+  {
+    "label": "readiness: the capture fires at a page that is not serving yet",
+    "file": "ee/pocketpaw_ee/sites/screenshot.py",
+    "find": "    if not await wait_until_serving(url, delays=ready_delays):\n        logger.warning(\n            \"sites.screenshot: %s was not serving within the readiness budget — no \"\n            \"preview captured for site %s (the card keeps its previous image; \"\n            \"POST /sites/%s/preview-refresh re-tries on demand)\",\n            url,\n            getattr(site, \"id\", \"?\"),\n            getattr(site, \"id\", \"?\"),\n        )\n        return \"\"",
+    "replace": "    pass",
+    "tests": [
+      "tests/ee/sites/test_capture_readiness.py"
+    ]
+  },
+  {
+    "label": "readiness: a 404 from the edge reads as a page worth photographing",
+    "file": "ee/pocketpaw_ee/sites/screenshot.py",
+    "find": "                return resp.status_code // 100 == 2",
+    "replace": "                return resp.status_code is not None",
+    "tests": [
+      "tests/ee/sites/test_capture_readiness.py"
+    ]
+  },
+  {
+    "label": "readiness: the gate gives up after one look instead of polling",
+    "file": "ee/pocketpaw_ee/sites/screenshot.py",
+    "find": "    for delay in schedule:\n        await asyncio.sleep(delay)\n        if await _url_is_serving(_shot_url(url), transport=transport):\n            return True\n    return False",
+    "replace": "    return False",
+    "tests": [
+      "tests/ee/sites/test_capture_readiness.py"
+    ]
+  },
+  {
+    "label": "readiness: a probe is answered from the edge's pre-deploy cache",
+    "file": "ee/pocketpaw_ee/sites/screenshot.py",
+    "find": "    if await _url_is_serving(_shot_url(url), transport=transport):\n        return True\n    for delay in schedule:\n        await asyncio.sleep(delay)\n        if await _url_is_serving(_shot_url(url), transport=transport):\n            return True",
+    "replace": "    if await _url_is_serving(url, transport=transport):\n        return True\n    for delay in schedule:\n        await asyncio.sleep(delay)\n        if await _url_is_serving(url, transport=transport):\n            return True",
+    "tests": [
+      "tests/ee/sites/test_capture_readiness.py"
+    ]
+  },
+  {
+    "label": "readiness: a manual refresh blames the site instead of the deploy",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        if not await wait_until_serving(url, delays=_READY_DELAYS_MANUAL):\n            raise ValidationError(\n                \"sites.preview_not_serving\",\n                \"The site isn't answering yet. A deploy can take a moment to go \"\n                \"live at the edge — try the refresh again shortly.\",\n            )",
+    "replace": "        pass",
+    "tests": [
+      "tests/ee/sites/test_capture_readiness.py"
+    ]
   }
 ]


### PR DESCRIPTION
A published site's card was showing a picture of nothing, and there was no way back.

## What happens

Capture fires at the tail of a successful publish and navigates immediately. But a deploy is live at Cloudflare before it is live at the edge, so for a few seconds the site's own address answers 404, or an edge placeholder. Browser Rendering renders that quite happily.

A screenshot of a 404 is a valid PNG. It is 2xx, it is `image/png`, it is non-empty. Every fail-closed check SC-1 shipped passed, because all three ask whether the capture succeeded and none asked whether the page was worth capturing. The bytes landed on the Site and stayed there. Nothing re-captures on its own, so the card stayed wrong until somebody republished an unchanged site.

## The gate

`take_site_screenshot` now polls the site's url until it answers 2xx before spending a render.

The poll is a plain GET from this process, not a rendered page, so it costs no Browser Rendering quota and the paid call happens once, against a page known to exist. The body is never read: the request is streamed and closed on the status line.

Ready means 2xx and nothing else. 404 is the ordinary pre-live answer, a 5xx or Cloudflare's own 530 is the other, and a connection that never opens is DNS for a brand-new subdomain not having propagated. None of them raise; the only decision is capture or don't.

Each probe carries the cache-buster SC-3 already minted. Without it the edge could answer 200 from the pre-deploy document, and the gate would open on the strength of the page it exists to keep us away from.

The budget is one immediate probe plus five backed-off retries over about 59 seconds, or roughly 90 counting probe timeouts. Generous because nothing is waiting on it, and backed off because most deploys are live on the first or second look.

On timeout the preview is left absent and one log line says so. A card with no image is honest, it keeps the themed placeholder SC-2 shipped, and it does not overwrite a good picture from the previous deploy with a worse one. There is deliberately no re-schedule: a retry that outlives the poll is a second timer to reason about, and the recovery path already existed. It just was not reachable, which is the companion PR.

The founding rule is intact. The poll runs inside the fire-and-forget capture, the same background task the render already ran in, so `publish()` gains no latency, and a probe that raises lands in the same swallow every other capture failure does. One test runs the whole thing inline on the publish's own stack to prove it.

The draft path is ungated. Markup renders at `about:blank`, so there is no address that could be unready.

## The manual half

`refresh_site_preview` runs the same gate on a short schedule, two probes about 2s apart, because a person is watching a spinner. It raises its own `sites.preview_not_serving`. Reusing `preview_unavailable` would have told them to "publish the site, or open its preview once", which is exactly the wrong advice for a site that is published and is merely still coming up, and that sentence surfaces verbatim in the dashboard.

## Reproduction

`tests/ee/sites/test_capture_readiness.py` fails on `dev` with a stored `preview_image_url` pointing at a photograph of nothing:

```
>       assert rows[0].preview_image_url is None
E       AssertionError: assert '/api/v1/uploads/c0185824825c4e5bb11232e50427150e' is None
```

20 tests: the reproduction at both the capture and the full-publish level, the poll (an edge that comes up on the third probe is captured, not abandoned), the probe's own semantics over a real httpx transport, the founding rule, the manual half, and the draft path.

## Verification

`PAW_CF_DEPLOY_MODE= uv run pytest tests/ee/sites/ --ignore=tests/ee/sites/test_generator_client_timeout.py --ignore=tests/ee/sites/test_plan_gate.py -q -p no:randomly` gives 593 passed, 4 skipped, 0 failed. 573 of those are pre-existing.

`uv run python scripts/mutate.py --plan tests/mutations/site_screenshot.json` catches all 10, including five new ones: removing the gate, treating any response as ready, giving up after one look, dropping the cache-buster, and dropping the manual path's error branch.

## What I could not prove here

Whether Cloudflare's edge actually honours the cache-buster on the probe, and the real distribution of edge-propagation delay. Both need a live deploy. The ~60s budget is a judgement call; if real deploys turn out slower, the symptom is a card that is briefly art-less with a refresh button next to it, not a wrong picture.

One accepted rare case: the manual path probes, then `take_site_screenshot` probes once more immediately before the render, so the gate has no bypass. A site that goes down between those two probes answers `preview_unavailable` rather than `preview_not_serving`, which is slightly wrong advice in a race that needs the site to fail inside a sub-second window.
