### PR TITLE
feat(billing): lock member caps and make the seat gate plan-authoritative

### DIFF
--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -267,6 +267,7 @@ def mount_cloud(app: FastAPI) -> None:
     from pocketpaw_ee.cloud.rules.router import router as rules_router
     from pocketpaw_ee.cloud.sessions.router import router as sessions_router
     from pocketpaw_ee.cloud.skills.router import router as skills_router
+    from pocketpaw_ee.cloud.storage.router import router as storage_router
     from pocketpaw_ee.cloud.websandbox.router import router as websandbox_router
     from pocketpaw_ee.cloud.workspace.router import router as workspace_router
 
@@ -335,6 +336,9 @@ def mount_cloud(app: FastAPI) -> None:
     # credit allotment). The plan CATALOG read (GET /billing/plans) is on the
     # billing router above; this router carries only the per-workspace resolve.
     app.include_router(entitlements_router, prefix="/api/v1")
+    # Storage (feat/billing-storage-caps) — the workspace-scoped S3 usage read
+    # (GET /storage/usage -> used_bytes / max_bytes / remaining / percent).
+    app.include_router(storage_router, prefix="/api/v1")
     app.include_router(pockets_router, prefix="/api/v1")
     # Pocket chat — agent-driven pocket creation SSE stream (POST /pockets/chat).
     app.include_router(pocket_chat_router, prefix="/api/v1")

--- a/ee/pocketpaw_ee/cloud/_core/errors.py
+++ b/ee/pocketpaw_ee/cloud/_core/errors.py
@@ -168,6 +168,36 @@ class CallLimitError(CloudError):
         super().__init__(402, "billing.call_limit", f"Call limit: {label}")
 
 
+def _human_bytes(n: int) -> str:
+    """Format a byte count the way storage products do (GB for this scale)."""
+    if n % 1_000_000_000 == 0:
+        return f"{n // 1_000_000_000} GB"
+    if n % 1_000_000 == 0:
+        return f"{n // 1_000_000} MB"
+    if n % 1_000 == 0:
+        return f"{n // 1_000} KB"
+    return f"{n} bytes"
+
+
+class StorageLimitError(CloudError):
+    """Workspace hit its plan's S3 storage cap (402).
+
+    Sibling of ``SeatLimitError`` for the UPLOAD seam: the sum of the workspace's
+    live ``FileUpload`` blob sizes (the Files → Knowledge Base store) is at its
+    plan's ``max_storage_bytes`` and the new upload would push it over. 402 with
+    a distinct ``billing.storage_limit`` code so the UI can prompt a plan
+    upgrade. Enforced at UPLOAD time only — never deletes an existing blob — and
+    only when ``billing_enforced`` is on.
+    """
+
+    def __init__(self, limit_bytes: int | None) -> None:
+        if limit_bytes is None:  # pragma: no cover - uncapped plans never raise
+            label = "storage limit reached"
+        else:
+            label = f"storage limit of {_human_bytes(limit_bytes)} reached"
+        super().__init__(402, "billing.storage_limit", f"Storage limit: {label}")
+
+
 class InsufficientCredits(CloudError):
     """Credit wallet has too few credits for the requested debit (402)."""
 
@@ -248,6 +278,7 @@ def with_cause(error: CloudError, cause: BaseException) -> CloudError:
 
 __all__ = [
     "BadRequest",
+    "CallLimitError",
     "CloudError",
     "ConflictError",
     "ConnectorLimitError",
@@ -261,6 +292,7 @@ __all__ = [
     "QuotaExceeded",
     "RateLimited",
     "SeatLimitError",
+    "StorageLimitError",
     "ValidationError",
     "with_cause",
 ]

--- a/ee/pocketpaw_ee/cloud/_core/errors.py
+++ b/ee/pocketpaw_ee/cloud/_core/errors.py
@@ -147,6 +147,27 @@ class ConnectorLimitError(CloudError):
         super().__init__(402, "billing.connector_limit", f"Connector limit of {limit} reached")
 
 
+class CallLimitError(CloudError):
+    """Workspace hit its plan's daily LiveKit call-time cap (402).
+
+    Sibling of ``SeatLimitError`` for the LiveKit room-create seam: Free has no
+    call minutes at all (``max_call_seconds_per_day`` == 0), and a paid tier
+    blocks a NEW call once today's cumulative call time would exceed its daily
+    budget. 402 with a distinct ``billing.call_limit`` code so the UI can prompt
+    a plan upgrade. Enforced at CALL-START time only — an already-running call is
+    force-ended at its budget deadline rather than removed.
+    """
+
+    def __init__(self, limit_seconds: int | None) -> None:
+        if limit_seconds == 0:
+            label = "no call minutes on your plan"
+        elif limit_seconds is not None:
+            label = f"daily call limit of {limit_seconds // 60} minutes reached"
+        else:  # pragma: no cover - uncapped plans never raise
+            label = "daily call limit reached"
+        super().__init__(402, "billing.call_limit", f"Call limit: {label}")
+
+
 class InsufficientCredits(CloudError):
     """Credit wallet has too few credits for the requested debit (402)."""
 

--- a/ee/pocketpaw_ee/cloud/billing/plans.py
+++ b/ee/pocketpaw_ee/cloud/billing/plans.py
@@ -57,6 +57,12 @@
 #   = 30 min, Pro = 7_200 = 2 hrs, Pro Max = 28_800 = 8 hrs, Enterprise = None).
 #   Enforced at CALL-START time by ``livekit.service.create_room``; an over-budget
 #   in-progress call is force-ended at its budget deadline.
+# Updated 2026-08-08 (feat/billing-storage-caps) — ADDED ``max_storage_bytes``: the
+#   workspace S3 STORAGE cap in bytes (Free = 5 GB, Go = 15 GB, Pro = 50 GB,
+#   Pro Max = 100 GB, Enterprise = None = uncapped). Enforced at UPLOAD time by the
+#   uploads pipeline (``storage.service.storage_cap_exceeded``) against the sum of
+#   the workspace's live ``FileUpload`` blob sizes (the Files → Knowledge Base
+#   store). ``GET /storage/usage`` surfaces used vs cap for the Settings page.
 
 from __future__ import annotations
 
@@ -188,6 +194,27 @@ _MAX_CALL_SECONDS_PER_DAY: dict[str, int | None] = {
     "enterprise": None,
 }
 
+# The workspace S3 STORAGE cap, in BYTES (feat/billing-storage-caps, 2026-08-08).
+# The approved consumer numbers — the Files → Knowledge Base / memory store a
+# workspace may hold (decimal GB, the SI convention Google/consumer storage uses):
+#   * free      =          5 GB — 5_000_000_000 bytes — a generous starter stash
+#   * go        =         15 GB — everyday file + KB usage
+#   * pro       =         50 GB — ~3.3× Go, for daily drivers
+#   * pro_max   =        100 GB — ~2× Pro, for power users
+#   * enterprise = None        — uncapped; negotiated contracts set their own limit.
+# Enforced at UPLOAD time by the uploads pipeline (``storage.service``): the
+# workspace's live ``FileUpload`` blob sizes are summed and a new upload is
+# blocked with ``StorageLimitError`` when it would push the total over the cap.
+# The ``_build`` default for an unknown key FAILS CLOSED to the Free value
+# (5 GB), never None/uncapped.
+_MAX_STORAGE_BYTES: dict[str, int | None] = {
+    "free": 5_000_000_000,
+    "go": 15_000_000_000,
+    "pro": 50_000_000_000,
+    "pro_max": 100_000_000_000,
+    "enterprise": None,
+}
+
 # Order the catalog is listed in — the price ladder, cheapest first. Any tier in
 # PLAN_FEATURES not named here is appended afterwards (so a new tier never
 # silently drops out of the catalog).
@@ -287,6 +314,11 @@ class PlanTier:
     2 hrs, Pro Max = 28800 = 8 hrs; Enterprise = None = uncapped). The LiveKit
     room-create gate enforces it at CALL-START time, and an over-budget single
     call is force-ended at its budget deadline.
+    ``max_storage_bytes`` is the approved CONSUMER workspace S3 STORAGE cap in
+    BYTES (Free = 5 GB, Go = 15 GB, Pro = 50 GB, Pro Max = 100 GB, Enterprise =
+    None = uncapped). The uploads pipeline enforces it at UPLOAD time against the
+    sum of the workspace's live ``FileUpload`` blob sizes (the Files → Knowledge
+    Base store), and ``GET /storage/usage`` surfaces used vs cap.
     ``dodo_product_id`` is the recurring-product id, or None until BC-7 / config
     populates it.
 
@@ -304,6 +336,7 @@ class PlanTier:
     max_pockets: int | None
     max_connectors: int | None
     max_call_seconds_per_day: int | None
+    max_storage_bytes: int | None
     dodo_product_id: str | None
     features: frozenset[str]
     display_name: str
@@ -345,9 +378,9 @@ def _build(key: str) -> PlanTier:
     from ``_PLAN_DISPLAY`` (a missing row degrades to ``_DISPLAY_FALLBACK`` rather
     than NPE-ing). An unknown ``key`` yields an empty feature set and a 0
     allotment — but callers go through ``get_plan`` / ``list_plans``, which only
-    ever pass known keys. ``monthly_ceiling`` and the three SMB caps
-    (``max_seats`` / ``max_pockets`` / ``max_connectors``) FAIL CLOSED: an unknown
-    key defaults to the Free value (the most restrictive tier), never
+    ever pass known keys. ``monthly_ceiling`` and the SMB caps (``max_seats`` /
+    ``max_pockets`` / ``max_connectors`` / ``max_storage_bytes``) FAIL CLOSED: an
+    unknown key defaults to the Free value (the most restrictive tier), never
     None/uncapped.
     """
     display = _PLAN_DISPLAY.get(key, _DISPLAY_FALLBACK)
@@ -365,6 +398,8 @@ def _build(key: str) -> PlanTier:
         max_call_seconds_per_day=_MAX_CALL_SECONDS_PER_DAY.get(
             key, _MAX_CALL_SECONDS_PER_DAY["free"]
         ),
+        # S3 storage cap — fail closed to Free (5 GB), never None/uncapped.
+        max_storage_bytes=_MAX_STORAGE_BYTES.get(key, _MAX_STORAGE_BYTES["free"]),
         dodo_product_id=_dodo_product_for(key),
         features=frozenset(PLAN_FEATURES.get(key, set())),
         display_name=str(display["display_name"]),

--- a/ee/pocketpaw_ee/cloud/billing/plans.py
+++ b/ee/pocketpaw_ee/cloud/billing/plans.py
@@ -47,8 +47,8 @@
 #   on ``PlanTier`` as ``int | None`` (None = uncapped, Enterprise only).
 # Updated 2026-08-08 (feat/billing-rbac-member-caps) — LOCKED the approved CONSUMER
 #   member (seat) caps: Free = 0 (a Free workspace cannot invite ANY members),
-#   Paw Go = 5, Paw Pro = 10, Paw Pro Max = 50 total workspace members (owner
-#   included), Enterprise = None. These replace the earlier generous placeholders
+#   Paw Go = 5, Paw Pro = 25 total workspace members (owner included), Paw Pro Max
+#   and Enterprise = None (uncapped). These replace the earlier generous placeholders
 #   (5 / 10 / 25 / 100). The seat gate became plan-AUTHORITATIVE so Free=0 actually
 #   blocks invites (see ``workspace.service._effective_seat_limit``). The ``_build``
 #   default for an unknown key still FAILS CLOSED to the Free value, never None.
@@ -117,9 +117,9 @@ _CEILING: dict[str, int | None] = {
 # Three per-plan caps enforced at CREATE / INVITE / ENABLE time (never
 # retroactively): the max workspace SEATS (workspace members, owner included),
 # the max POCKETS a workspace may hold, and the max ENABLED CONNECTORS. Same
-# shape as ``_CEILING`` — an ``int`` ceiling, or ``None`` for the one uncapped
-# (Enterprise) tier. The ``_build`` default for an unknown key FAILS CLOSED to
-# the Free value (never None/uncapped).
+# shape as ``_CEILING`` — an ``int`` ceiling, or ``None`` for an uncapped tier.
+# The ``_build`` default for an unknown key FAILS CLOSED to the Free value
+# (never None/uncapped).
 #
 # SEATS ARE THE ABAC/RBAC MEMBER GATE: the seat ceiling is the plan ATTRIBUTE
 # the invite gates enforce (see ``workspace.service._effective_seat_limit``),
@@ -127,11 +127,11 @@ _CEILING: dict[str, int | None] = {
 # paid tiers allow exactly their seat count (owner included — e.g. Paw Go = 5
 # total members, so 4 invitations on top of the owner). These are the approved
 # CONSUMER numbers, not placeholders:
-#   * free    =  0 seats — no invitations allowed (the owner alone)
-#   * go      =  5 seats —  5 total members (owner + 4 invited)
-#   * pro     = 10 seats — 10 total members (owner + 9 invited)
-#   * pro_max = 50 seats — 50 total members (owner + 49 invited)
-#   * enterprise = None  — uncapped; negotiated contracts set their own limit.
+#   * free      =  0 seats — no invitations allowed (the owner alone)
+#   * go        =  5 seats —  5 total members (owner + 4 invited)
+#   * pro       = 25 seats — 25 total members (owner + 24 invited)
+#   * pro_max   = None     — UNLIMITED seats (uncapped)
+#   * enterprise = None    — uncapped; negotiated contracts set their own limit.
 #
 # The seat gate is plan-AUTHORITATIVE (not ``max(doc.seats, plan)``): the stored
 # ``Workspace.seats`` field is a legacy/display ceiling that never overrides the
@@ -141,8 +141,8 @@ _CEILING: dict[str, int | None] = {
 _MAX_SEATS: dict[str, int | None] = {
     "free": 0,
     "go": 5,
-    "pro": 10,
-    "pro_max": 50,
+    "pro": 25,
+    "pro_max": None,
     "enterprise": None,
 }
 
@@ -251,10 +251,11 @@ class PlanTier:
     credit-quota enforcement caps spend against (allotment × 1.5 for paid tiers;
     Free is the explicit 1000 trial cap; Enterprise is None). ``max_seats`` /
     ``max_pockets`` / ``max_connectors`` are the SMB resource ceilings enforced at
-    create/invite/enable time (integer, or None = uncapped for Enterprise).
+    create/invite/enable time (integer, or None = uncapped).
     ``max_seats`` is the approved CONSUMER member cap (Free = 0 → no invites,
-    Go = 5, Pro = 10, Pro Max = 50 total members, owner included); it is
-    plan-AUTHORITATIVE at the invite gate, so Free blocks all new invitations.
+    Go = 5, Pro = 25 total members, owner included; Pro Max and Enterprise are
+    uncapped/None); it is plan-AUTHORITATIVE at the invite gate, so Free blocks
+    all new invitations.
     ``dodo_product_id`` is the recurring-product id, or None until BC-7 / config
     populates it.
 

--- a/ee/pocketpaw_ee/cloud/billing/plans.py
+++ b/ee/pocketpaw_ee/cloud/billing/plans.py
@@ -52,6 +52,11 @@
 #   (5 / 10 / 25 / 100). The seat gate became plan-AUTHORITATIVE so Free=0 actually
 #   blocks invites (see ``workspace.service._effective_seat_limit``). The ``_build``
 #   default for an unknown key still FAILS CLOSED to the Free value, never None.
+# Updated 2026-08-08 (feat/billing-rbac-member-caps) — ADDED ``max_call_seconds_per_day``:
+#   the daily LiveKit CALL-TIME budget in seconds (Free = 0 → no calls, Go = 1_800
+#   = 30 min, Pro = 7_200 = 2 hrs, Pro Max = 28_800 = 8 hrs, Enterprise = None).
+#   Enforced at CALL-START time by ``livekit.service.create_room``; an over-budget
+#   in-progress call is force-ended at its budget deadline.
 
 from __future__ import annotations
 
@@ -162,6 +167,27 @@ _MAX_CONNECTORS: dict[str, int | None] = {
     "enterprise": None,
 }
 
+# The daily LiveKit CALL-TIME budget, in SECONDS per workspace per calendar day
+# (feat/billing-rbac-member-caps, 2026-08-08). The approved consumer numbers:
+#   * free      =        0 — no calls at all (a single-seat workspace has no one
+#                            to call); every room-create is blocked.
+#   * go        =    1_800 — 30 minutes of calls a day.
+#   * pro       =    7_200 —  2 hours of calls a day.
+#   * pro_max   =   28_800 —  8 hours of calls a day.
+#   * enterprise = None    — uncapped; negotiated contracts set their own limit.
+# Enforced at CALL-START time (``livekit.service.create_room``): the workspace's
+# today's cumulative LiveKit call duration (from the ``Meeting`` docs) is checked
+# against the cap, and an in-progress call is force-ended once it hits its budget
+# deadline. The ``_build`` default for an unknown key FAILS CLOSED to the Free
+# value (0), never None/uncapped.
+_MAX_CALL_SECONDS_PER_DAY: dict[str, int | None] = {
+    "free": 0,
+    "go": 1_800,
+    "pro": 7_200,
+    "pro_max": 28_800,
+    "enterprise": None,
+}
+
 # Order the catalog is listed in — the price ladder, cheapest first. Any tier in
 # PLAN_FEATURES not named here is appended afterwards (so a new tier never
 # silently drops out of the catalog).
@@ -256,6 +282,11 @@ class PlanTier:
     Go = 5, Pro = 25 total members, owner included; Pro Max and Enterprise are
     uncapped/None); it is plan-AUTHORITATIVE at the invite gate, so Free blocks
     all new invitations.
+    ``max_call_seconds_per_day`` is the approved CONSUMER daily LiveKit call
+    budget in SECONDS (Free = 0 → no calls, Go = 1800 = 30 min, Pro = 7200 =
+    2 hrs, Pro Max = 28800 = 8 hrs; Enterprise = None = uncapped). The LiveKit
+    room-create gate enforces it at CALL-START time, and an over-budget single
+    call is force-ended at its budget deadline.
     ``dodo_product_id`` is the recurring-product id, or None until BC-7 / config
     populates it.
 
@@ -272,6 +303,7 @@ class PlanTier:
     max_seats: int | None
     max_pockets: int | None
     max_connectors: int | None
+    max_call_seconds_per_day: int | None
     dodo_product_id: str | None
     features: frozenset[str]
     display_name: str
@@ -329,6 +361,10 @@ def _build(key: str) -> PlanTier:
         max_seats=_MAX_SEATS.get(key, _MAX_SEATS["free"]),
         max_pockets=_MAX_POCKETS.get(key, _MAX_POCKETS["free"]),
         max_connectors=_MAX_CONNECTORS.get(key, _MAX_CONNECTORS["free"]),
+        # Daily LiveKit call budget — fail closed to Free (0 = no calls).
+        max_call_seconds_per_day=_MAX_CALL_SECONDS_PER_DAY.get(
+            key, _MAX_CALL_SECONDS_PER_DAY["free"]
+        ),
         dodo_product_id=_dodo_product_for(key),
         features=frozenset(PLAN_FEATURES.get(key, set())),
         display_name=str(display["display_name"]),

--- a/ee/pocketpaw_ee/cloud/billing/plans.py
+++ b/ee/pocketpaw_ee/cloud/billing/plans.py
@@ -44,13 +44,14 @@
 #   members), ``max_pockets`` (pockets per workspace), and ``max_connectors``
 #   (enabled connectors per workspace). Each is a tunable dict (``_MAX_SEATS`` /
 #   ``_MAX_POCKETS`` / ``_MAX_CONNECTORS``) mirroring ``_CEILING`` in shape, surfaced
-#   on ``PlanTier`` as ``int | None`` (None = uncapped, Enterprise only). The values
-#   are GENEROUS PLACEHOLDERS — the real per-tier numbers are a captain pricing
-#   open-question; the machinery is tier-agnostic and these ceilings are roomy
-#   enough that an active tenant under them never notices, while still protecting
-#   the shared PEE box from runaway growth. Free ``max_seats`` is pinned at 5 (==
-#   the ``Workspace.seats`` default) so no existing workspace regresses. The
-#   ``_build`` default for an unknown key FAILS CLOSED to the Free value, never None.
+#   on ``PlanTier`` as ``int | None`` (None = uncapped, Enterprise only).
+# Updated 2026-08-08 (feat/billing-rbac-member-caps) — LOCKED the approved CONSUMER
+#   member (seat) caps: Free = 0 (a Free workspace cannot invite ANY members),
+#   Paw Go = 5, Paw Pro = 10, Paw Pro Max = 50 total workspace members (owner
+#   included), Enterprise = None. These replace the earlier generous placeholders
+#   (5 / 10 / 25 / 100). The seat gate became plan-AUTHORITATIVE so Free=0 actually
+#   blocks invites (see ``workspace.service._effective_seat_limit``). The ``_build``
+#   default for an unknown key still FAILS CLOSED to the Free value, never None.
 
 from __future__ import annotations
 
@@ -114,27 +115,34 @@ _CEILING: dict[str, int | None] = {
 # ---------------------------------------------------------------------------
 #
 # Three per-plan caps enforced at CREATE / INVITE / ENABLE time (never
-# retroactively): the max workspace SEATS, the max POCKETS a workspace may hold,
-# and the max ENABLED CONNECTORS. Same shape as ``_CEILING`` — an ``int`` ceiling,
-# or ``None`` for the one uncapped (Enterprise) tier. The ``_build`` default for an
-# unknown key FAILS CLOSED to the Free value (never None/uncapped).
+# retroactively): the max workspace SEATS (workspace members, owner included),
+# the max POCKETS a workspace may hold, and the max ENABLED CONNECTORS. Same
+# shape as ``_CEILING`` — an ``int`` ceiling, or ``None`` for the one uncapped
+# (Enterprise) tier. The ``_build`` default for an unknown key FAILS CLOSED to
+# the Free value (never None/uncapped).
 #
-# IMPORTANT: these are GENEROUS PLACEHOLDERS. The real per-tier numbers are a
-# captain pricing open-question; the enforcement machinery is deliberately
-# tier-agnostic so only these constants change when pricing lands. They are roomy
-# enough that an active tenant under the ceiling never notices, while still
-# protecting the shared PEE box from a single tenant's runaway growth.
+# SEATS ARE THE ABAC/RBAC MEMBER GATE: the seat ceiling is the plan ATTRIBUTE
+# the invite gates enforce (see ``workspace.service._effective_seat_limit``),
+# so a Free workspace (``max_seats=0``) cannot invite ANY members, while the
+# paid tiers allow exactly their seat count (owner included — e.g. Paw Go = 5
+# total members, so 4 invitations on top of the owner). These are the approved
+# CONSUMER numbers, not placeholders:
+#   * free    =  0 seats — no invitations allowed (the owner alone)
+#   * go      =  5 seats —  5 total members (owner + 4 invited)
+#   * pro     = 10 seats — 10 total members (owner + 9 invited)
+#   * pro_max = 50 seats — 50 total members (owner + 49 invited)
+#   * enterprise = None  — uncapped; negotiated contracts set their own limit.
 #
-# Free ``max_seats`` is pinned at 5 to EQUAL the ``Workspace.seats`` model default
-# — the seat gate enforces ``max(doc.seats, max_seats)`` so a free workspace sees
-# byte-for-byte the same limit it has today (no regression). The paid tiers step
-# up from there; Enterprise is uncapped (None) — negotiated contracts set their
-# own limits.
+# The seat gate is plan-AUTHORITATIVE (not ``max(doc.seats, plan)``): the stored
+# ``Workspace.seats`` field is a legacy/display ceiling that never overrides the
+# plan on downgrade, so a workspace that cancels Pro → Free immediately loses
+# the ability to invite (existing members are never removed — the gate only
+# blocks NEW invites / acceptances).
 _MAX_SEATS: dict[str, int | None] = {
-    "free": 5,
-    "go": 10,
-    "pro": 25,
-    "pro_max": 100,
+    "free": 0,
+    "go": 5,
+    "pro": 10,
+    "pro_max": 50,
     "enterprise": None,
 }
 
@@ -243,9 +251,10 @@ class PlanTier:
     credit-quota enforcement caps spend against (allotment × 1.5 for paid tiers;
     Free is the explicit 1000 trial cap; Enterprise is None). ``max_seats`` /
     ``max_pockets`` / ``max_connectors`` are the SMB resource ceilings enforced at
-    create/invite/enable time (integer, or None = uncapped for Enterprise);
-    Free's ``max_seats`` == the ``Workspace.seats`` default so no workspace
-    regresses. These are GENEROUS PLACEHOLDERS pending the captain's pricing call.
+    create/invite/enable time (integer, or None = uncapped for Enterprise).
+    ``max_seats`` is the approved CONSUMER member cap (Free = 0 → no invites,
+    Go = 5, Pro = 10, Pro Max = 50 total members, owner included); it is
+    plan-AUTHORITATIVE at the invite gate, so Free blocks all new invitations.
     ``dodo_product_id`` is the recurring-product id, or None until BC-7 / config
     populates it.
 

--- a/ee/pocketpaw_ee/cloud/credits/service.py
+++ b/ee/pocketpaw_ee/cloud/credits/service.py
@@ -156,6 +156,7 @@
 
 from __future__ import annotations
 
+import inspect
 import logging
 from datetime import UTC, datetime
 from typing import Any
@@ -612,21 +613,22 @@ async def _sum_amount_delta(query: dict[str, Any]) -> int:
 
     Runs a Mongo ``$match`` + ``$group`` aggregation in the DB (NOT a
     pull-all-then-sum in Python) and returns the summed ``amount_delta`` (signed),
-    or 0 when nothing matches. We iterate the raw pymongo command cursor with
-    ``async for`` because awaiting it directly (``await coll.aggregate(...)``)
-    raises ``TypeError`` under the mongomock-motor test harness; ``async for`` runs
-    the server-side ``$match`` + ``$group`` in BOTH real Mongo and the harness.
-    (Beanie's ``Document.aggregate(...).to_list()`` also works under the harness
-    and is the form used elsewhere, e.g. ``workspace/service.py`` — either is
-    genuinely DB-side; this module uses the cursor form.)
+    or 0 when nothing matches. ``get_pymongo_collection().aggregate()`` returns
+    DIFFERENT shapes per driver: a COROUTINE under the pymongo-async client the
+    app uses in prod (``async for`` raises TypeError — the same live bug that hit
+    ``storage.service.workspace_storage_usage``), but a directly-iterable latent
+    cursor under the mongomock-motor test harness. We discriminate with
+    ``inspect.isawaitable`` (the repo's cross-driver idiom in ``files/router.py``,
+    ``connectors/registry.py``) and await only when the cursor is awaitable.
     """
-    coll = CreditLedgerEntry.get_pymongo_collection()
-    cursor = coll.aggregate(
+    cursor = CreditLedgerEntry.get_pymongo_collection().aggregate(
         [
             {"$match": query},
             {"$group": {"_id": None, "total": {"$sum": "$amount_delta"}}},
         ]
     )
+    if inspect.isawaitable(cursor):
+        cursor = await cursor
     async for row in cursor:
         return int(row.get("total") or 0)
     return 0

--- a/ee/pocketpaw_ee/cloud/entitlements/domain.py
+++ b/ee/pocketpaw_ee/cloud/entitlements/domain.py
@@ -25,6 +25,10 @@
 #   LiveKit CALL-TIME budget in seconds the LiveKit room-create gate enforces
 #   at call-start time. Fail-closed to the Free value (0 = no calls) on the
 #   fallback path.
+# Updated 2026-08-08 (feat/billing-storage-caps): added ``max_storage_bytes``
+#   (``int | None``, None = uncapped) — the workspace S3 STORAGE cap in bytes the
+#   uploads pipeline enforces at upload time. Fail-closed to the Free value
+#   (5 GB) on the fallback path.
 
 from __future__ import annotations
 
@@ -51,7 +55,10 @@ class Entitlements:
     LiveKit CALL-TIME budget in seconds (integer, or None = uncapped for
     Enterprise) the LiveKit room-create gate enforces at call-start time; a
     no/unknown-plan workspace resolves to the Free value (0 = no calls),
-    fail-closed, never None/uncapped.
+    fail-closed, never None/uncapped. ``max_storage_bytes`` is the workspace S3
+    STORAGE cap in bytes (integer, or None = uncapped for Enterprise) the
+    uploads pipeline enforces at upload time; a no/unknown-plan workspace
+    resolves to the Free value (5 GB), fail-closed, never None/uncapped.
     """
 
     workspace_id: str
@@ -62,4 +69,5 @@ class Entitlements:
     max_pockets: int | None
     max_connectors: int | None
     max_call_seconds_per_day: int | None
+    max_storage_bytes: int | None
     features: frozenset[str] = field(default_factory=frozenset)

--- a/ee/pocketpaw_ee/cloud/entitlements/domain.py
+++ b/ee/pocketpaw_ee/cloud/entitlements/domain.py
@@ -20,6 +20,11 @@
 #   ``monthly_ceiling`` — the SMB resource ceilings the resolver populates from the
 #   plan catalog and the seat / pocket-create / connector-enable gates enforce
 #   against at create time. Fail-closed to the Free value on the fallback path.
+# Updated 2026-08-08 (feat/billing-rbac-member-caps): added
+#   ``max_call_seconds_per_day`` (``int | None``, None = uncapped) — the daily
+#   LiveKit CALL-TIME budget in seconds the LiveKit room-create gate enforces
+#   at call-start time. Fail-closed to the Free value (0 = no calls) on the
+#   fallback path.
 
 from __future__ import annotations
 
@@ -42,7 +47,11 @@ class Entitlements:
     ``max_connectors`` are the SMB resource ceilings (integer, or None = uncapped
     for Enterprise) the seat / pocket-create / connector-enable gates enforce at
     create time; a no/unknown-plan workspace resolves to the Free values
-    (fail-closed), never None/uncapped.
+    (fail-closed), never None/uncapped. ``max_call_seconds_per_day`` is the daily
+    LiveKit CALL-TIME budget in seconds (integer, or None = uncapped for
+    Enterprise) the LiveKit room-create gate enforces at call-start time; a
+    no/unknown-plan workspace resolves to the Free value (0 = no calls),
+    fail-closed, never None/uncapped.
     """
 
     workspace_id: str
@@ -52,4 +61,5 @@ class Entitlements:
     max_seats: int | None
     max_pockets: int | None
     max_connectors: int | None
+    max_call_seconds_per_day: int | None
     features: frozenset[str] = field(default_factory=frozenset)

--- a/ee/pocketpaw_ee/cloud/entitlements/dto.py
+++ b/ee/pocketpaw_ee/cloud/entitlements/dto.py
@@ -25,6 +25,10 @@
 #   ``max_pockets`` / ``max_connectors`` (the enforced ceilings the plan ladder
 #   added), so the plan cards can render real per-tier limits and the settings UI
 #   can show a workspace's resolved caps. ``None`` == uncapped (Enterprise).
+# Updated 2026-08-08 (feat/billing-storage-caps): both responses now also carry
+#   ``max_storage_bytes`` (the workspace S3 storage cap in bytes; ``None`` ==
+#   uncapped Enterprise) so the plan cards can render the storage limit and the
+#   Settings storage page can show used vs cap.
 
 from __future__ import annotations
 
@@ -61,6 +65,7 @@ class PlanTierResponse(BaseModel):
     max_seats: int | None = None
     max_pockets: int | None = None
     max_connectors: int | None = None
+    max_storage_bytes: int | None = None
 
 
 class PlanCatalogResponse(BaseModel):
@@ -82,6 +87,7 @@ class EntitlementsResponse(BaseModel):
     max_seats: int | None = None
     max_pockets: int | None = None
     max_connectors: int | None = None
+    max_storage_bytes: int | None = None
 
 
 def plan_tier_to_dto(tier: PlanTier) -> PlanTierResponse:
@@ -101,6 +107,7 @@ def plan_tier_to_dto(tier: PlanTier) -> PlanTierResponse:
         max_seats=tier.max_seats,
         max_pockets=tier.max_pockets,
         max_connectors=tier.max_connectors,
+        max_storage_bytes=tier.max_storage_bytes,
     )
 
 
@@ -114,6 +121,7 @@ def entitlements_to_dto(ent: Entitlements) -> EntitlementsResponse:
         max_seats=ent.max_seats,
         max_pockets=ent.max_pockets,
         max_connectors=ent.max_connectors,
+        max_storage_bytes=ent.max_storage_bytes,
     )
 
 

--- a/ee/pocketpaw_ee/cloud/entitlements/service.py
+++ b/ee/pocketpaw_ee/cloud/entitlements/service.py
@@ -33,8 +33,10 @@
 #   base-floor branch sets the Free values (5 / 200 / 50) so every path fails closed.
 # Updated 2026-08-08 (feat/billing-rbac-member-caps): the Free base-floor
 #   ``max_seats`` is now 0 — a workspace with no/unknown plan resolves to the Free
-#   tier, which cannot invite ANY members (Paw Go = 5, Paw Pro = 10, Paw Pro Max
-#   = 50; Enterprise = None). Fails closed to the most restrictive tier.
+#   tier, which cannot invite ANY members (Paw Go = 5, Paw Pro = 25; Pro Max and
+#   Enterprise = None). Fails closed to the most restrictive tier. Also added
+#   ``max_call_seconds_per_day`` — the daily LiveKit call budget (Free = 0 → no
+#   calls) surfaced to the LiveKit room-create gate; fail-closed to 0.
 
 from __future__ import annotations
 
@@ -79,10 +81,12 @@ async def resolve_entitlements(workspace_id: str) -> Entitlements:
                 # the catalog itself is somehow missing the base tier.
                 monthly_ceiling=1_000,
                 # Fail closed on the SMB caps too: the Free values (max_seats = 0
-                # → a fallback workspace cannot invite any members), never uncapped.
+                # → a fallback workspace cannot invite any members; call budget 0
+                # → no LiveKit calls), never uncapped.
                 max_seats=0,
                 max_pockets=200,
                 max_connectors=50,
+                max_call_seconds_per_day=0,
                 features=frozenset(),
             )
 
@@ -94,5 +98,6 @@ async def resolve_entitlements(workspace_id: str) -> Entitlements:
         max_seats=tier.max_seats,
         max_pockets=tier.max_pockets,
         max_connectors=tier.max_connectors,
+        max_call_seconds_per_day=tier.max_call_seconds_per_day,
         features=tier.features,
     )

--- a/ee/pocketpaw_ee/cloud/entitlements/service.py
+++ b/ee/pocketpaw_ee/cloud/entitlements/service.py
@@ -31,6 +31,10 @@
 #   three SMB caps (``max_seats`` / ``max_pockets`` / ``max_connectors``), populated
 #   from the resolved tier exactly as ``monthly_ceiling`` is. The defensive
 #   base-floor branch sets the Free values (5 / 200 / 50) so every path fails closed.
+# Updated 2026-08-08 (feat/billing-rbac-member-caps): the Free base-floor
+#   ``max_seats`` is now 0 — a workspace with no/unknown plan resolves to the Free
+#   tier, which cannot invite ANY members (Paw Go = 5, Paw Pro = 10, Paw Pro Max
+#   = 50; Enterprise = None). Fails closed to the most restrictive tier.
 
 from __future__ import annotations
 
@@ -74,9 +78,9 @@ async def resolve_entitlements(workspace_id: str) -> Entitlements:
                 # Fail closed: the Free trial cap, never None/uncapped — even when
                 # the catalog itself is somehow missing the base tier.
                 monthly_ceiling=1_000,
-                # Fail closed on the SMB caps too: the Free values (max_seats == the
-                # Workspace.seats default so no workspace regresses), never uncapped.
-                max_seats=5,
+                # Fail closed on the SMB caps too: the Free values (max_seats = 0
+                # → a fallback workspace cannot invite any members), never uncapped.
+                max_seats=0,
                 max_pockets=200,
                 max_connectors=50,
                 features=frozenset(),

--- a/ee/pocketpaw_ee/cloud/entitlements/service.py
+++ b/ee/pocketpaw_ee/cloud/entitlements/service.py
@@ -37,6 +37,9 @@
 #   Enterprise = None). Fails closed to the most restrictive tier. Also added
 #   ``max_call_seconds_per_day`` — the daily LiveKit call budget (Free = 0 → no
 #   calls) surfaced to the LiveKit room-create gate; fail-closed to 0.
+# Updated 2026-08-08 (feat/billing-storage-caps): also added
+#   ``max_storage_bytes`` — the workspace S3 storage cap (Free = 5 GB) surfaced
+#   to the uploads gate and the /storage/usage read; fail-closed to 5 GB.
 
 from __future__ import annotations
 
@@ -82,11 +85,12 @@ async def resolve_entitlements(workspace_id: str) -> Entitlements:
                 monthly_ceiling=1_000,
                 # Fail closed on the SMB caps too: the Free values (max_seats = 0
                 # → a fallback workspace cannot invite any members; call budget 0
-                # → no LiveKit calls), never uncapped.
+                # → no LiveKit calls; storage = 5 GB), never uncapped.
                 max_seats=0,
                 max_pockets=200,
                 max_connectors=50,
                 max_call_seconds_per_day=0,
+                max_storage_bytes=5_000_000_000,
                 features=frozenset(),
             )
 
@@ -99,5 +103,6 @@ async def resolve_entitlements(workspace_id: str) -> Entitlements:
         max_pockets=tier.max_pockets,
         max_connectors=tier.max_connectors,
         max_call_seconds_per_day=tier.max_call_seconds_per_day,
+        max_storage_bytes=tier.max_storage_bytes,
         features=tier.features,
     )

--- a/ee/pocketpaw_ee/cloud/livekit/service.py
+++ b/ee/pocketpaw_ee/cloud/livekit/service.py
@@ -12,6 +12,15 @@ Change log:
   runs a single worker, so this in-process lock fully covers it; true
   cross-replica dedupe is out of scope here (see the LiveKit Agents migration
   design doc).
+- Added daily CALL-TIME budget enforcement (feat/billing-rbac-member-caps):
+  ``create_room()`` resolves the workspace's plan (entitlements) and enforces
+  ``max_call_seconds_per_day`` (Free = 0 → no calls, Go = 1800 = 30 min, Pro =
+  7200 = 2 hrs, Pro Max = 28800 = 8 hrs, Enterprise = None). A NEW room is
+  blocked with ``CallLimitError`` when the budget is exhausted; a join to an
+  already-running room is not (that call already owns its budget). Each new
+  call records its remaining budget as a ``Meeting.call_budget_deadline`` and a
+  watchdog task (``_force_end_at_budget``) force-ends it at the deadline, so a
+  single over-budget call is cut off rather than merely blocking later starts.
 """
 
 from __future__ import annotations
@@ -31,6 +40,7 @@ from livekit.protocol.room import (
     ListRoomsRequest,
 )
 
+from pocketpaw_ee.cloud._core.errors import CallLimitError
 from pocketpaw_ee.cloud._core.realtime.emit import emit
 from pocketpaw_ee.cloud._core.realtime.events import (
     CallEnded,
@@ -587,6 +597,116 @@ async def get_recording_info(group_id: str) -> dict[str, Any] | None:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Daily call-time budget (feat/billing-rbac-member-caps)
+# ---------------------------------------------------------------------------
+
+
+def _start_of_today_utc() -> datetime:
+    """Midnight UTC of the current calendar day (the budget window boundary)."""
+    return datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+def _as_utc(dt: datetime) -> datetime:
+    """Coerce a DB round-tripped datetime to tz-aware UTC.
+
+    mongomock (and some drivers) return naive datetimes even when stored aware;
+    production Mongo round-trips aware. Normalize so comparisons never mix
+    offset-aware and offset-naive values.
+    """
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC)
+
+
+async def _daily_call_usage(workspace_id: str) -> int:
+    """Total SECONDS of LiveKit calls used today by a workspace.
+
+    Sums the overlap between each of the workspace's LiveKit ``Meeting`` rows
+    and today (UTC). An ended meeting contributes ``actual_end - actual_start``;
+    one still in progress contributes ``now - actual_start`` so a running call
+    counts toward the daily budget immediately. A call started BEFORE today that
+    ends today is counted for its today-overlap; a call started before today
+    that is still running (no ``actual_end``) is not counted — an accepted edge
+    (the daily window is UTC, and such cross-midnight in-flight calls are rare).
+    """
+    start = _start_of_today_utc()
+    end = start + timedelta(days=1)
+    docs = await MeetingDoc.find(
+        {
+            "workspace": workspace_id,
+            "source": "livekit",
+            "$or": [
+                {"actual_start": {"$gte": start}},
+                {"actual_end": {"$gte": start}},
+            ],
+        }
+    ).to_list()
+    now = datetime.now(UTC)
+    total = 0
+    for doc in docs:
+        s = _as_utc(doc.actual_start or now)
+        e = _as_utc(doc.actual_end or now)
+        # Clip the call's span to today's window.
+        s = max(s, start)
+        e = min(e, end)
+        if e > s:
+            total += int((e - s).total_seconds())
+    return total
+
+
+async def _call_budget_remaining(workspace_id: str) -> tuple[int | None, int]:
+    """Resolve the workspace's today call budget as ``(cap_seconds, remaining)``.
+
+    ``cap`` is the plan's ``max_call_seconds_per_day``: None = uncapped
+    (Enterprise), 0 = Free (no calls at all). ``remaining`` is
+    ``cap - today_used`` and may be negative once the budget is spent (a None
+    cap yields ``remaining = 0`` — meaningless, callers check the cap). Raises
+    nothing itself; ``create_room`` decides how to enforce.
+    """
+    from pocketpaw_ee.cloud.entitlements import service as entitlements_service
+
+    ent = await entitlements_service.resolve_entitlements(workspace_id)
+    cap = ent.max_call_seconds_per_day
+    if cap is None:
+        return None, 0
+    if cap == 0:
+        # Free — no calls at all; today's usage is irrelevant (the gate blocks
+        # at entry, so skip the DB usage query entirely).
+        return 0, 0
+    used = await _daily_call_usage(workspace_id)
+    return cap, cap - used
+
+
+async def _force_end_at_budget(group_id: str, workspace_id: str, deadline: datetime) -> None:
+    """Force-end a call once its daily budget is exhausted.
+
+    Scheduled at call-start with ``deadline = now + remaining budget``. Sleeps
+    until the deadline, then ends the room ONLY if its Meeting is still
+    ``in_progress`` (a user who hung up early means ``end_room`` already ran and
+    the meeting is ``ended`` — this becomes a no-op). In-memory like the
+    meeting-agent reaper: a deploy restart loses the task, and LiveKit's
+    ``empty_timeout`` (5 min) reaps an orphaned room anyway.
+    """
+    delay = max(0.0, (deadline - datetime.now(UTC)).total_seconds())
+    if delay > 0:
+        await asyncio.sleep(delay)
+    try:
+        room_name = room_name_for_group(group_id)
+        meeting = await MeetingDoc.find_one(
+            MeetingDoc.workspace == workspace_id,
+            MeetingDoc.provider_meeting_id == room_name,
+            MeetingDoc.status == "in_progress",
+        )
+        if meeting is None:
+            logger.info("Budget force-end skipped: call %s already ended", room_name)
+            return
+        logger.info("Daily call budget exhausted — force-ending call %s", room_name)
+        await end_room(group_id, workspace_id, reason="budget_exhausted")
+    except Exception as exc:
+        logger.warning("Failed to force-end call %s at budget deadline: %s", group_id, exc)
+
+
 async def create_room(
     group_id: str,
     workspace_id: str = "",
@@ -602,10 +722,26 @@ async def create_room(
     the room was just created or already existed. When a new room is
     created, a ``Meeting`` document is also persisted so the call
     appears in the scheduled meetings sidebar as "Live".
+
+    Daily CALL-TIME budget (ABAC/RBAC member-cap seam): the workspace's plan
+    caps LiveKit minutes per day (Free = 0 → no calls). Free is blocked at
+    entry; a paid tier with an exhausted budget is blocked from creating a NEW
+    room (joining an already-running room is allowed — that call already owns
+    its budget). Each new call gets a ``call_budget_deadline`` and a watchdog
+    that force-ends it at the deadline so a single over-budget call is cut off.
     """
     _ensure_configured()
 
     room_name = room_name_for_group(group_id)
+
+    # Daily call-time budget: Free (cap 0) has NO calling at all, so block
+    # before touching LiveKit. Paid tiers are enforced only when creating a NEW
+    # room below (a join to an already-running call is not blocked).
+    budget: tuple[int | None, int] | None = None
+    if workspace_id:
+        budget = await _call_budget_remaining(workspace_id)
+        if budget[0] == 0:
+            raise CallLimitError(0)
 
     is_new = False
     async with LiveKitAPI(LIVEKIT_URL, LIVEKIT_API_KEY, LIVEKIT_API_SECRET) as lk:
@@ -617,6 +753,13 @@ async def create_room(
         room_exists = len(list_resp.rooms) > 0
 
         if not room_exists:
+            # A paid tier only blocks a NEW call once today's budget is spent;
+            # joining an existing room is always allowed. A None cap (Enterprise
+            # / no plan context) is uncapped — no gate.
+            if budget is not None and budget[0] is not None:
+                cap, remaining = budget
+                if remaining <= 0:
+                    raise CallLimitError(cap)
             req = CreateRoomRequest(
                 name=room_name,
                 empty_timeout=5 * 60,
@@ -633,6 +776,14 @@ async def create_room(
     if is_new and workspace_id:
         try:
             now = datetime.now(UTC)
+            # The new call may run until its remaining daily budget is spent —
+            # the watchdog force-ends it there. Uncapped (Enterprise / no plan
+            # context) calls get no deadline.
+            budget_deadline = None
+            if budget is not None:
+                cap, remaining = budget
+                if cap is not None and remaining > 0:
+                    budget_deadline = now + timedelta(seconds=remaining)
             meeting = MeetingDoc(
                 workspace=workspace_id,
                 source="livekit",
@@ -644,6 +795,7 @@ async def create_room(
                 scheduled_end=None,
                 actual_start=now,
                 status="in_progress",
+                call_budget_deadline=budget_deadline,
                 participants=[],
                 recording_file_ids=[],
                 raw_provider_payload={"group_id": group_id},
@@ -651,6 +803,14 @@ async def create_room(
             )
             await meeting.insert()
             logger.info("Created Meeting doc for instant call in group %s", group_id)
+
+            if budget_deadline is not None:
+                asyncio.create_task(_force_end_at_budget(group_id, workspace_id, budget_deadline))
+                logger.info(
+                    "Scheduled budget force-end for group %s at %s",
+                    group_id,
+                    budget_deadline.isoformat(),
+                )
 
             # Emit meeting.started so other clients pick it up
             from pocketpaw_ee.cloud.meetings.events import MeetingStarted
@@ -760,13 +920,18 @@ async def generate_participant_token(
     )
 
 
-async def end_room(group_id: str, workspace_id: str = "") -> dict[str, Any]:
+async def end_room(group_id: str, workspace_id: str = "", reason: str = "") -> dict[str, Any]:
     """End an active call by deleting the LiveKit room.
 
     When the room is deleted, all participants are disconnected and the
     call bot's cleanup logic (posting meeting notes) is triggered.
     Also transitions the associated Meeting document to ``ended`` so
     the call shows as "Over" in the scheduled meetings sidebar.
+
+    ``reason`` is a machine-readable end reason carried on the ``call.ended``
+    event (e.g. ``budget_exhausted`` when the daily call-time budget watchdog
+    force-ends the room) so the UI can show plan-specific messaging. Omitted
+    (empty) for ordinary, user-initiated end-calls.
     """
     _ensure_configured()
 
@@ -819,7 +984,10 @@ async def end_room(group_id: str, workspace_id: str = "") -> dict[str, Any]:
                 logger.error("Failed to delete LiveKit room: %s", exc)
                 raise
 
-    await emit(CallEnded(data={"group_id": group_id, "room_name": room_name}))
+    ended_data: dict[str, Any] = {"group_id": group_id, "room_name": room_name}
+    if reason:
+        ended_data["reason"] = reason
+    await emit(CallEnded(data=ended_data))
 
     # Transition the Meeting doc to ended so the call shows as "Over".
     if workspace_id:

--- a/ee/pocketpaw_ee/cloud/models/meeting.py
+++ b/ee/pocketpaw_ee/cloud/models/meeting.py
@@ -81,6 +81,11 @@ class Meeting(TimestampedDocument):
     scheduled_end: datetime | None = None
     actual_start: datetime | None = None
     actual_end: datetime | None = None
+    # For LiveKit instant calls this is the daily-budget cutoff (now + remaining
+    # plan call time). The ``livekit.service._force_end_at_budget`` watchdog
+    # force-ends the call once it passes. None for recall meetings and for
+    # uncapped (Enterprise) livekit calls.
+    call_budget_deadline: datetime | None = None
     status: MeetingStatus = "scheduled"
     participants: list[dict[str, Any]] = Field(default_factory=list)
     recording_file_ids: list[str] = Field(default_factory=list)

--- a/ee/pocketpaw_ee/cloud/storage/__init__.py
+++ b/ee/pocketpaw_ee/cloud/storage/__init__.py
@@ -1,0 +1,7 @@
+# ee/pocketpaw_ee/cloud/storage/__init__.py — Storage entity package marker.
+# Created 2026-08-08 (feat/billing-storage-caps): the workspace S3 STORAGE
+# metering entity — used-bytes aggregation over the live ``FileUpload`` docs
+# (the Files → Knowledge Base store) + the plan cap gate + the read surface
+# (GET /storage/usage). The 4-file entity shape (domain / service / dto /
+# router) lives here. Plain marker — nothing is imported eagerly so importing
+# this package never pulls FastAPI / Beanie.

--- a/ee/pocketpaw_ee/cloud/storage/domain.py
+++ b/ee/pocketpaw_ee/cloud/storage/domain.py
@@ -1,0 +1,36 @@
+# ee/pocketpaw_ee/cloud/storage/domain.py — frozen value object for the storage
+# metering entity (feat/billing-storage-caps).
+#
+# Pure-Python, framework-free shape. The service hands ``StorageUsage`` back
+# across the entity boundary instead of leaking the Beanie ``FileUpload`` docs
+# or raw dicts. ``used_bytes`` is the sum of the workspace's live (non-deleted)
+# FileUpload blob sizes — the S3 bytes backing the Files → Knowledge Base store.
+# ``max_bytes`` is the plan's ``max_storage_bytes`` cap (None = uncapped
+# Enterprise, OR billing not enforced → the UI renders "Unlimited").
+# ``remaining_bytes`` / ``percent_used`` derive from those two and are None when
+# there's no cap to measure against.
+#
+# Created 2026-08-08 (feat/billing-storage-caps): new entity.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class StorageUsage:
+    """A workspace's storage usage vs its plan cap.
+
+    ``used_bytes`` is always the live total (never None — a workspace with no
+    files reads 0). ``max_bytes`` is the resolved cap: None means "uncapped" —
+    either the Enterprise tier (negotiated, no plan ceiling) or billing not
+    enforced (OSS / self-host, where the caps are informational). When
+    ``max_bytes`` is None, ``remaining_bytes`` and ``percent_used`` are also
+    None so callers render "Unlimited" instead of a misleading 0% or 0 left.
+    """
+
+    workspace_id: str
+    used_bytes: int
+    max_bytes: int | None
+    remaining_bytes: int | None
+    percent_used: float | None

--- a/ee/pocketpaw_ee/cloud/storage/dto.py
+++ b/ee/pocketpaw_ee/cloud/storage/dto.py
@@ -1,0 +1,44 @@
+# ee/pocketpaw_ee/cloud/storage/dto.py — response schema for the storage read
+# surface (feat/billing-storage-caps).
+#
+# Read-only surface, so there is no request DTO. ``StorageUsageResponse`` mirrors
+# ``storage.domain.StorageUsage`` for ``GET /storage/usage``. ``max_bytes`` /
+# ``remaining_bytes`` / ``percent_used`` are null when the workspace is uncapped
+# (Enterprise) or billing is not enforced — the Settings page renders
+# "Unlimited" in that case.
+#
+# Created 2026-08-08 (feat/billing-storage-caps): new entity.
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from pocketpaw_ee.cloud.storage.domain import StorageUsage
+
+
+class StorageUsageResponse(BaseModel):
+    """A workspace's storage usage vs its plan cap — response of GET /storage/usage.
+
+    ``used_bytes`` is the live S3 total (sum of the workspace's non-deleted
+    ``FileUpload`` blob sizes); ``max_bytes`` is the plan's ``max_storage_bytes``
+    (null = uncapped — Enterprise, or billing not enforced). ``remaining_bytes``
+    and ``percent_used`` derive from those two and are null when ``max_bytes`` is
+    null.
+    """
+
+    workspace_id: str
+    used_bytes: int
+    max_bytes: int | None = None
+    remaining_bytes: int | None = None
+    percent_used: float | None = None
+
+
+def storage_usage_to_dto(usage: StorageUsage) -> StorageUsageResponse:
+    """Map a frozen ``domain.StorageUsage`` to its wire DTO."""
+    return StorageUsageResponse(
+        workspace_id=usage.workspace_id,
+        used_bytes=usage.used_bytes,
+        max_bytes=usage.max_bytes,
+        remaining_bytes=usage.remaining_bytes,
+        percent_used=usage.percent_used,
+    )

--- a/ee/pocketpaw_ee/cloud/storage/router.py
+++ b/ee/pocketpaw_ee/cloud/storage/router.py
@@ -1,0 +1,39 @@
+# ee/pocketpaw_ee/cloud/storage/router.py — the storage read surface
+# (feat/billing-storage-caps).
+#
+# One read route, scoped to the caller's CURRENT workspace (resolved via the
+# standard ``current_workspace_id`` dep):
+#   * GET /storage/usage — the workspace's storage usage vs its plan cap
+#     (used_bytes / max_bytes / remaining_bytes / percent_used).
+#
+# THIN adapter per the "primitive = service + thin adapters" shape — all logic
+# lives in ``storage.service`` (and the cap in ``billing.plans`` via
+# entitlements). Mounted in ``mount_cloud()``.
+#
+# Created 2026-08-08 (feat/billing-storage-caps): new entity.
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.shared.deps import current_workspace_id
+from pocketpaw_ee.cloud.storage import service as storage_service
+from pocketpaw_ee.cloud.storage.dto import StorageUsageResponse, storage_usage_to_dto
+
+router = APIRouter(tags=["Storage"], dependencies=[Depends(require_license)])
+
+
+@router.get("/storage/usage", response_model=StorageUsageResponse)
+async def get_storage_usage(
+    workspace_id: str = Depends(current_workspace_id),
+) -> StorageUsageResponse:
+    """Return the caller's workspace's storage usage vs its plan cap.
+
+    ``used_bytes`` is the live S3 total (sum of the workspace's non-deleted
+    uploaded-file blob sizes — the Files → Knowledge Base store). ``max_bytes``
+    is the plan's storage cap (null = uncapped: Enterprise, or billing not
+    enforced).
+    """
+    usage = await storage_service.resolve_storage_usage(workspace_id)
+    return storage_usage_to_dto(usage)

--- a/ee/pocketpaw_ee/cloud/storage/service.py
+++ b/ee/pocketpaw_ee/cloud/storage/service.py
@@ -1,0 +1,160 @@
+# ee/pocketpaw_ee/cloud/storage/service.py — the storage USAGE resolver + cap gate
+# (feat/billing-storage-caps).
+#
+# Module-level ``async def`` API (NOT a class, per EE cloud rule, mirroring
+# ``credits.service`` / ``entitlements.service``). Public API:
+#   * ``workspace_storage_usage(workspace_id)`` — sum the workspace's live
+#     (non-deleted) ``FileUpload`` blob sizes in BYTES. This is the S3 usage
+#     backing the Files → Knowledge Base store.
+#   * ``storage_cap_exceeded(workspace_id, incoming_bytes)`` — would a NEW blob
+#     of ``incoming_bytes`` push the workspace over its plan's
+#     ``max_storage_bytes``? Returns ``(exceeded, used, limit)``; the UPLOAD seam
+#     (``uploads.service.upload_many`` / ``write_text_file``) raises
+#     ``StorageLimitError`` (402) when exceeded. GATED on ``billing_enforced``:
+#     OSS / self-host tenants (billing off) always get ``(False, 0, None)``.
+#   * ``assert_storage_available(workspace_id, incoming_bytes)`` — convenience
+#     wrapper that raises ``StorageLimitError`` when the cap would be exceeded
+#     (used by the programmatic ``write_text_file`` writer).
+#   * ``resolve_storage_usage(workspace_id)`` — the read the Settings storage
+#     page renders: used vs the plan cap + remaining + percent. The READ is NOT
+#     gated on ``billing_enforced`` (it is informational — a Go workspace shows
+#     "15 GB" whether or not enforcement is on); only an uncapped plan
+#     (Enterprise, ``max_storage_bytes=None``) reports a None cap.
+#
+# READ-ONLY: no writes, no emit (EE cloud rule 9 only fires on mutation; this
+# entity mutates nothing). Tenancy: every query filters on the explicit
+# ``workspace_id`` (the ``FileUpload.workspace`` column), so there is no
+# cross-tenant read here — a caller only ever sees the storage of the workspace
+# it asked for. Imports of config / entitlements / the FileUpload model are LAZY
+# (inside the functions) so this module stays off the heavy import graph at load
+# and the uploads.service that calls into it never pays a Beanie import just to
+# import the module.
+#
+# The $sum aggregation runs server-side in the DB (NOT a pull-all-then-sum in
+# Python). The raw ``get_pymongo_collection().aggregate()`` returns DIFFERENT
+# shapes per driver — a COROUTINE under real Motor (async for raised TypeError on
+# this very endpoint in prod), a directly-iterable latent cursor under the
+# mongomock-motor test harness — so the code discriminates with
+# ``inspect.isawaitable`` (the repo's cross-driver idiom in ``files/router.py``,
+# ``connectors/registry.py``). Do NOT switch to Beanie's ``Document.aggregate()``
+# classmethod: its internal ``await`` breaks under the mongomock-motor harness.
+# Soft-deleted rows (``deleted_at`` set) are excluded — deleting a file frees its
+# bytes from the used total.
+#
+# Created 2026-08-08 (feat/billing-storage-caps): new entity.
+# Updated 2026-08-08 (prod fix): real Motor ``aggregate()`` returns a coroutine;
+#   the original ``async for`` form passed the mongomock harness but 500'd live.
+#   Now awaits when the cursor is awaitable, iterates directly otherwise.
+
+from __future__ import annotations
+
+import inspect
+
+from pocketpaw_ee.cloud._core.errors import ValidationError
+from pocketpaw_ee.cloud.storage.domain import StorageUsage
+
+
+async def workspace_storage_usage(workspace_id: str) -> int:
+    """Total live S3 bytes for ``workspace_id`` (sum of live FileUpload sizes).
+
+    Aggregates ``FileUpload.size`` over the workspace's NON-DELETED rows in the
+    DB (a ``$match`` + ``$group`` ``$sum``), so deleting a file frees its bytes
+    and a workspace with no files reads 0. Returns an int byte count.
+    """
+    from pocketpaw_ee.cloud.uploads.models import FileUpload
+
+    pipeline = [
+        {"$match": {"workspace": workspace_id, "deleted_at": None}},
+        {"$group": {"_id": None, "total": {"$sum": "$size"}}},
+    ]
+    # The raw ``get_pymongo_collection().aggregate()`` returns DIFFERENT shapes
+    # per driver: a COROUTINE under real Motor (must ``await`` to get the
+    # AsyncIOMotorCommandCursor) but a directly-iterable latent cursor under the
+    # mongomock-motor test harness (where ``await`` raises TypeError). So we
+    # discriminate with ``inspect.isawaitable`` — the established cross-driver
+    # idiom in this repo (``files/router.py``, ``connectors/registry.py``) —
+    # instead of Beanie's ``Document.aggregate()`` classmethod, whose internal
+    # ``await`` breaks under the harness. ``async for`` then iterates in BOTH.
+    cursor = FileUpload.get_pymongo_collection().aggregate(pipeline)
+    if inspect.isawaitable(cursor):
+        cursor = await cursor
+    async for row in cursor:
+        return int(row.get("total") or 0)
+    return 0
+
+
+async def storage_cap_exceeded(
+    workspace_id: str,
+    incoming_bytes: int,
+) -> tuple[bool, int, int | None]:
+    """Would ``incoming_bytes`` of new blobs exceed this workspace's plan cap?
+
+    Returns ``(exceeded, used_bytes, limit_bytes)``. GATED on ``billing_enforced``:
+    OSS / self-host tenants (billing off) always get ``(False, 0, None)`` — no
+    cap, no extra DB read — so a self-hosted deployment behaves exactly as before.
+    When enforced, resolves the workspace's plan ``max_storage_bytes`` and sums
+    its live ``FileUpload`` bytes. An uncapped plan (Enterprise,
+    ``max_storage_bytes=None``) never trips. ``exceeded`` is ``used + incoming >
+    limit`` — checked BEFORE the write, so it blocks the upload that WOULD push
+    the workspace over, never an existing blob (upload-time only, never
+    retroactive). Imports are lazy to keep this module off the config /
+    entitlements import graph at load.
+    """
+    from pocketpaw.config import get_settings
+
+    if not get_settings().billing_enforced:
+        return (False, 0, None)
+
+    from pocketpaw_ee.cloud.entitlements import service as entitlements_service
+
+    ent = await entitlements_service.resolve_entitlements(workspace_id)
+    limit = ent.max_storage_bytes
+    if limit is None:
+        return (False, 0, None)
+    used = await workspace_storage_usage(workspace_id)
+    return (used + incoming_bytes > limit, used, limit)
+
+
+async def assert_storage_available(workspace_id: str, incoming_bytes: int) -> None:
+    """Raise ``StorageLimitError`` when ``incoming_bytes`` would exceed the cap.
+
+    Thin convenience over ``storage_cap_exceeded`` for write seams that don't
+    need the used/limit tuple (e.g. ``uploads.service.write_text_file``). A
+    no-op unless ``billing_enforced`` (OSS / self-host tenants are unaffected).
+    """
+    from pocketpaw_ee.cloud._core.errors import StorageLimitError
+
+    exceeded, _used, limit = await storage_cap_exceeded(workspace_id, incoming_bytes)
+    if exceeded:
+        raise StorageLimitError(limit)
+
+
+async def resolve_storage_usage(workspace_id: str) -> StorageUsage:
+    """Resolve a workspace's storage usage vs its plan cap (read surface).
+
+    ``used_bytes`` is always computed. ``max_bytes`` is the workspace's RESOLVED
+    plan ``max_storage_bytes`` — read purely from the plan catalog via
+    entitlements, NOT gated on ``billing_enforced``. The read is informational:
+    a Go workspace shows "15 GB" whether or not upload enforcement is active
+    (enforcement is the separate ``storage_cap_exceeded`` gate, which DOES respect
+    ``billing_enforced``). Only an uncapped plan (Enterprise, ``max_storage_bytes
+    = None``) reports None here — in which case ``remaining`` and ``percent`` are
+    also None and the UI renders "Unlimited". ``percent_used`` is rounded to one
+    decimal.
+    """
+    # Rule 6 — validate at entry.
+    if not workspace_id:
+        raise ValidationError("storage.invalid_workspace", "workspace_id is required")
+
+    used = await workspace_storage_usage(workspace_id)
+
+    from pocketpaw_ee.cloud.entitlements import service as entitlements_service
+
+    ent = await entitlements_service.resolve_entitlements(workspace_id)
+    limit = ent.max_storage_bytes
+    if limit is None:
+        return StorageUsage(workspace_id, used, None, None, None)
+
+    remaining = max(limit - used, 0)
+    percent = round(used / limit * 100, 1) if limit > 0 else 0.0
+    return StorageUsage(workspace_id, used, limit, remaining, percent)

--- a/ee/pocketpaw_ee/cloud/uploads/service.py
+++ b/ee/pocketpaw_ee/cloud/uploads/service.py
@@ -28,6 +28,7 @@
 
 from __future__ import annotations
 
+import contextlib
 from collections.abc import AsyncIterator, Awaitable, Callable
 from datetime import UTC, datetime
 from pathlib import Path
@@ -202,6 +203,24 @@ class EEUploadService:
     ) -> BulkUploadResult:
         # Delegate validation + adapter writes; metadata is discarded inside OSS
         result = await self._oss.upload_many(files, owner_id, chat_id)
+        # feat/billing-storage-caps: block a batch that would push the workspace
+        # over its plan's S3 cap. We check the ACTUAL written sizes (from the
+        # OSS result — not a pre-write guess) and roll back the just-written
+        # blobs so an over-cap batch is a no-op: no Mongo row, no FileReady.
+        # GATED on ``billing_enforced`` (a no-op for OSS / self-host), and never
+        # retroactive — existing blobs are untouched.
+        from pocketpaw_ee.cloud.storage import service as storage_service
+
+        incoming = sum(rec.size for rec in result.uploaded)
+        if incoming:
+            exceeded, _used, limit = await storage_service.storage_cap_exceeded(workspace, incoming)
+            if exceeded:
+                for rec in result.uploaded:
+                    with contextlib.suppress(Exception):
+                        await self._adapter.delete(rec.storage_key)
+                from pocketpaw_ee.cloud._core.errors import StorageLimitError
+
+                raise StorageLimitError(limit)
         # Persist each successful record in Mongo with workspace + pocket scoping.
         for rec in result.uploaded:
             await self._meta.save_scoped(
@@ -392,6 +411,19 @@ async def write_text_file(
         yield payload
 
     obj = await adapter.put(storage_key, _body(), content_type)
+
+    # feat/billing-storage-caps: the programmatic writer honours the workspace's
+    # S3 cap the same way the HTTP upload path does. ``assert_storage_available``
+    # raises ``StorageLimitError`` (402) BEFORE the Mongo row lands; on the raise
+    # we also remove the just-written blob so an over-cap write leaves no orphan.
+    from pocketpaw_ee.cloud.storage import service as storage_service
+
+    try:
+        await storage_service.assert_storage_available(workspace_id, obj.size)
+    except Exception:
+        with contextlib.suppress(Exception):
+            await adapter.delete(storage_key)
+        raise
 
     rec = FileRecord(
         id=uuid4().hex,

--- a/ee/pocketpaw_ee/cloud/workspace/service.py
+++ b/ee/pocketpaw_ee/cloud/workspace/service.py
@@ -101,6 +101,15 @@ ALWAYS-ON (not behind ``billing_enforced``), unchanged from before; the Free
 ``max_seats`` == the model default (5) means a free tenant sees the identical
 limit. ``raise_seats_for_plan`` (upgrade-only) keeps the stored ``doc.seats`` in
 step with the plan on a subscription.active.
+2026-08-08 (feat/billing-rbac-member-caps): the seat gate became plan-AUTHORITATIVE.
+``_effective_seat_limit`` now returns the resolved plan's ``max_seats`` directly
+(only an uncapped Enterprise plan defers to ``doc.seats``), so the approved
+CONSUMER member caps hold on downgrade too: Free = 0 (no invitations allowed),
+Paw Go = 5, Paw Pro = 10, Paw Pro Max = 50 total workspace members (owner
+included). A Free workspace — even one that still holds members from a cancelled
+plan — can no longer invite anyone new; existing members are never removed.
+``raise_seats_for_plan`` is unchanged (upgrade-only, keeps the persisted
+``doc.seats`` display ceiling in step).
 """
 
 from __future__ import annotations
@@ -1179,20 +1188,21 @@ async def _mint_invite_for_email(
 
 
 async def _effective_seat_limit(doc: _WorkspaceDoc) -> int:
-    """The seat ceiling to enforce for this workspace — plan-sourced.
+    """The seat ceiling to enforce for this workspace — the PLAN cap, authoritatively.
 
-    Sources the limit from the workspace's RESOLVED PLAN (``max_seats``) rather
-    than the flat ``doc.seats`` alone, so a plan upgrade lifts the cap. Enforced
-    as ``max(doc.seats, plan.max_seats)`` so a workspace that already carries a
-    higher custom ``doc.seats`` — a seeded enterprise box, or a legacy
-    hand-bumped seat count — never regresses below what it has today. An uncapped
-    plan (Enterprise, ``max_seats=None``) imposes no plan ceiling: the workspace's
-    own ``doc.seats`` stands.
+    Sources the limit from the workspace's RESOLVED PLAN (``max_seats``) — the
+    ABAC/RBAC member gate. The plan cap is AUTHORITATIVE (NOT ``max(doc.seats,
+    plan)``): a workspace's stored ``doc.seats`` is a legacy/display ceiling that
+    never overrides the plan, so the per-plan member limits hold on downgrade too.
+    This is what makes Free (``max_seats=0``) block ALL new invitations — even a
+    workspace that already has members (a downgraded Pro box) can invite nothing
+    more; existing members are never removed, only new invites/acceptances are
+    capped. An uncapped plan (Enterprise, ``max_seats=None``) imposes no plan
+    ceiling: the workspace's own ``doc.seats`` stands (a negotiated contract).
 
     ALWAYS-ON (NOT gated on ``billing_enforced``), mirroring the pre-existing seat
-    gate. Because the Free ``max_seats`` equals the ``Workspace.seats`` model
-    default (5), a free tenant sees byte-for-byte the same limit it had before
-    this became plan-sourced — no regression.
+    gate. Approved CONSUMER caps: Free = 0, Paw Go = 5, Paw Pro = 10, Paw Pro Max
+    = 50 total workspace members (owner included).
 
     The entitlements resolver is imported LAZILY to keep this module off the
     resolver's import graph (the resolver itself imports this service lazily);
@@ -1203,7 +1213,7 @@ async def _effective_seat_limit(doc: _WorkspaceDoc) -> int:
     ent = await entitlements_service.resolve_entitlements(str(doc.id))
     if ent.max_seats is None:
         return doc.seats
-    return max(doc.seats, ent.max_seats)
+    return ent.max_seats
 
 
 async def create_invite(

--- a/ee/pocketpaw_ee/guards/abac.py
+++ b/ee/pocketpaw_ee/guards/abac.py
@@ -1,5 +1,9 @@
 # Attribute-based policy rules — plan gates, action-role mapping, tool whitelist.
 # Created: 2026-04-10
+# Updated: 2026-08-08 (feat/billing-rbac-member-caps) — the Belt & Foresight
+#   display flags moved DOWN to Paw Pro (was Pro Max only), matching the billing
+#   UI decision that both Pro tiers unlock them. Still display-only (not yet
+#   enforced); Pro Max remains differentiated by usage/price, not features.
 # Updated: 2026-06-24 (integration/billing-credits, BC-6) — added a minimal
 #   ``free`` base tier to PLAN_FEATURES so the billing catalog and the
 #   entitlements resolver have an explicit floor to fall back to (a workspace
@@ -64,8 +68,9 @@ PLAN_FEATURES: dict[str, set[str]] = {
         "sites",
     },
     # Paw Pro — daily drivers. Adds automations + knowledge_base + display flags
-    # for the power surfaces (code, deep_work, chain_flow, fleet). Keeps ``sites``;
-    # does NOT carry ``fabric`` (the ontology is enterprise-only).
+    # for the power surfaces (code, deep_work, chain_flow, fleet, belt,
+    # foresight). Keeps ``sites``; does NOT carry ``fabric`` (the ontology is
+    # enterprise-only).
     "pro": {
         "pockets",
         "sessions",
@@ -79,9 +84,12 @@ PLAN_FEATURES: dict[str, set[str]] = {
         "deep_work",
         "chain_flow",
         "fleet",
+        "belt",
+        "foresight",
     },
-    # Paw Pro Max — uncapped power users. Everything in pro + belt + foresight.
-    # Still NO ``fabric`` (enterprise-only ontology).
+    # Paw Pro Max — uncapped power users. Everything in pro (incl. belt +
+    # foresight) + nothing extra at the feature-set level — the differentiator
+    # is usage/price. Still NO ``fabric`` (enterprise-only ontology).
     "pro_max": {
         "pockets",
         "sessions",

--- a/tests/cloud/audit/test_service_v2.py
+++ b/tests/cloud/audit/test_service_v2.py
@@ -68,6 +68,24 @@ async def _seed_user(email: str = "owner@x.c") -> _UserDoc:
     return doc
 
 
+async def _paid_workspace(owner: _UserDoc) -> Any:
+    """Create a workspace on a paid plan so invites are allowed.
+
+    Since feat/billing-rbac-member-caps a Free workspace (max_seats=0) can't
+    invite anyone; the invite audit-row tests need a plan with seats, so these
+    run on Paw Pro (10 seats)."""
+    from pocketpaw_ee.cloud.models.workspace import Workspace as _WorkspaceDoc
+
+    ws = await workspace_service.create(
+        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
+    )
+    doc = await _WorkspaceDoc.get(ws.id)
+    if doc is not None:
+        doc.plan = "pro"
+        await doc.save()
+    return ws
+
+
 @pytest.fixture(autouse=True)
 def _resolver_mock(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
     """Stub the realtime resolver — same shape as workspace tests."""
@@ -161,9 +179,7 @@ async def test_remove_member_writes_audit_row(_legacy_bus) -> None:
 
 async def test_create_invite_writes_audit_row() -> None:
     owner = await _seed_user("o@x.c")
-    ws = await workspace_service.create(
-        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
-    )
+    ws = await _paid_workspace(owner)
     invite = await workspace_service.create_invite(
         _ctx(str(owner.id)),
         ws.id,
@@ -177,9 +193,7 @@ async def test_create_invite_writes_audit_row() -> None:
 
 async def test_bulk_create_invites_writes_per_email_rows() -> None:
     owner = await _seed_user("o@x.c")
-    ws = await workspace_service.create(
-        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
-    )
+    ws = await _paid_workspace(owner)
     await workspace_service.bulk_create_invites(
         _ctx(str(owner.id)),
         ws.id,
@@ -193,9 +207,7 @@ async def test_bulk_create_invites_writes_per_email_rows() -> None:
 async def test_accept_invite_writes_audit_row() -> None:
     owner = await _seed_user("o@x.c")
     invitee = await _seed_user("i@x.c")
-    ws = await workspace_service.create(
-        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
-    )
+    ws = await _paid_workspace(owner)
     invite = await workspace_service.create_invite(
         _ctx(str(owner.id)),
         ws.id,
@@ -209,9 +221,7 @@ async def test_accept_invite_writes_audit_row() -> None:
 
 async def test_revoke_invite_writes_audit_row() -> None:
     owner = await _seed_user("o@x.c")
-    ws = await workspace_service.create(
-        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
-    )
+    ws = await _paid_workspace(owner)
     invite = await workspace_service.create_invite(
         _ctx(str(owner.id)),
         ws.id,
@@ -225,9 +235,7 @@ async def test_revoke_invite_writes_audit_row() -> None:
 
 async def test_decline_invite_writes_audit_row() -> None:
     owner = await _seed_user("o@x.c")
-    ws = await workspace_service.create(
-        _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
-    )
+    ws = await _paid_workspace(owner)
     invite = await workspace_service.create_invite(
         _ctx(str(owner.id)),
         ws.id,

--- a/tests/cloud/billing/test_plans.py
+++ b/tests/cloud/billing/test_plans.py
@@ -30,6 +30,11 @@
 #   The numbers under test are the GENEROUS PLACEHOLDERS pending the captain's
 #   pricing call — these tests lock the machinery (present on every tier, uncapped
 #   Enterprise, fail-closed default), not the exact figures.
+# Updated 2026-08-08 (feat/billing-rbac-member-caps): the CONSUMER member caps are
+#   now LOCKED — Free ``max_seats`` = 0 (a Free workspace cannot invite ANY
+#   members), Paw Go = 5, Paw Pro = 10, Paw Pro Max = 50 total workspace members
+#   (owner included), Enterprise = None. The seat gate is plan-authoritative, so
+#   Free = 0 is an actual block, not a no-op. These tests lock the exact numbers.
 
 from __future__ import annotations
 
@@ -68,14 +73,15 @@ EXPECTED_USAGE_LABELS = {
     "pro_max": "20× the usage",
     "enterprise": "Custom",
 }
-# The three SMB resource caps (feat/billing-smb-caps) — GENEROUS PLACEHOLDERS
-# pending the captain's pricing call. Enterprise is None (uncapped). Free
-# ``max_seats`` MUST equal the Workspace.seats default (5) so no workspace regresses.
+# The three SMB resource caps (feat/billing-smb-caps). ``max_seats`` is the
+# APPROVED CONSUMER member cap — Free = 0 (no invitations allowed), Paw Go = 5,
+# Paw Pro = 10, Paw Pro Max = 50 total workspace members (owner included),
+# Enterprise = None (uncapped). Pockets + connectors remain their tier ceilings.
 EXPECTED_MAX_SEATS: dict[str, int | None] = {
-    "free": 5,
-    "go": 10,
-    "pro": 25,
-    "pro_max": 100,
+    "free": 0,
+    "go": 5,
+    "pro": 10,
+    "pro_max": 50,
     "enterprise": None,
 }
 EXPECTED_MAX_POCKETS: dict[str, int | None] = {
@@ -193,19 +199,27 @@ def test_every_tier_carries_the_three_smb_caps():
         assert by_key[key].max_connectors == EXPECTED_MAX_CONNECTORS[key], key
 
 
-def test_free_max_seats_is_at_least_the_workspace_default():
-    """Free max_seats MUST be >= the Workspace.seats model default (5) — no regression.
+def test_free_max_seats_is_zero_no_invites():
+    """Free max_seats is 0 — a Free workspace cannot invite ANY members.
 
-    The seat gate enforces max(doc.seats, plan.max_seats); if Free's cap dropped
-    below 5 a default free workspace would be blocked below the seats it already
-    has. This is the CRITICAL non-regression invariant.
+    The ABAC/RBAC member gate (``workspace.service._effective_seat_limit``) is
+    plan-authoritative and blocks an invite once ``member_count >= max_seats``;
+    a Free workspace's owner alone already fills a 0-seat cap, so every invite
+    raises SeatLimitError. This is the CRITICAL consumer-pricing invariant.
     """
-    from pocketpaw_ee.cloud.models.workspace import Workspace
-
-    default_seats = Workspace.model_fields["seats"].default
-    assert default_seats == 5
     assert plans.get_plan("free").max_seats is not None
-    assert plans.get_plan("free").max_seats >= default_seats
+    assert plans.get_plan("free").max_seats == 0
+
+
+def test_paid_tier_seats_are_the_consumer_ladder():
+    """The paid tiers carry the approved total-member caps: Go=5, Pro=10, ProMax=50.
+
+    Each number counts TOTAL workspace members (owner included), so Paw Go allows
+    the owner + 4 invited members, Paw Pro + 9, Paw Pro Max + 49.
+    """
+    assert plans.get_plan("go").max_seats == 5
+    assert plans.get_plan("pro").max_seats == 10
+    assert plans.get_plan("pro_max").max_seats == 50
 
 
 def test_enterprise_smb_caps_are_uncapped():
@@ -216,12 +230,17 @@ def test_enterprise_smb_caps_are_uncapped():
     assert ent.max_connectors is None
 
 
-def test_non_enterprise_smb_caps_are_positive_ints():
-    """Every non-Enterprise tier carries a concrete positive cap on all three."""
+def test_non_enterprise_smb_caps_are_non_negative_ints():
+    """Every non-Enterprise tier carries a concrete int cap on all three.
+
+    ``max_seats`` may be 0 (Free — the "no member invites" cap is a valid
+    ceiling); pockets + connectors are always positive on the consumer tiers.
+    """
     by_key = {p.key: p for p in plans.list_plans()}
     for key in ("free", "go", "pro", "pro_max"):
-        for cap in (by_key[key].max_seats, by_key[key].max_pockets, by_key[key].max_connectors):
-            assert isinstance(cap, int) and cap > 0, key
+        assert isinstance(by_key[key].max_seats, int) and by_key[key].max_seats >= 0, key
+        assert isinstance(by_key[key].max_pockets, int) and by_key[key].max_pockets > 0, key
+        assert isinstance(by_key[key].max_connectors, int) and by_key[key].max_connectors > 0, key
 
 
 def test_build_unknown_key_fails_closed_to_free_smb_caps():

--- a/tests/cloud/billing/test_plans.py
+++ b/tests/cloud/billing/test_plans.py
@@ -113,6 +113,17 @@ EXPECTED_MAX_CALL_SECONDS_PER_DAY: dict[str, int | None] = {
     "pro_max": 28_800,
     "enterprise": None,
 }
+# The workspace S3 STORAGE cap per tier, in BYTES (feat/billing-storage-caps,
+# 2026-08-08). Decimal GB — Free = 5 GB, Go = 15 GB, Pro = 50 GB, Pro Max =
+# 100 GB, Enterprise = None (uncapped). Enforced by the uploads pipeline at
+# upload time; GET /storage/usage surfaces used vs cap.
+EXPECTED_MAX_STORAGE_BYTES: dict[str, int | None] = {
+    "free": 5_000_000_000,
+    "go": 15_000_000_000,
+    "pro": 50_000_000_000,
+    "pro_max": 100_000_000_000,
+    "enterprise": None,
+}
 
 
 # ---------------------------------------------------------------------------
@@ -210,6 +221,7 @@ def test_every_tier_carries_the_smb_caps():
         assert by_key[key].max_pockets == EXPECTED_MAX_POCKETS[key], key
         assert by_key[key].max_connectors == EXPECTED_MAX_CONNECTORS[key], key
         assert by_key[key].max_call_seconds_per_day == EXPECTED_MAX_CALL_SECONDS_PER_DAY[key], key
+        assert by_key[key].max_storage_bytes == EXPECTED_MAX_STORAGE_BYTES[key], key
 
 
 def test_free_max_seats_is_zero_no_invites():
@@ -261,6 +273,16 @@ def test_daily_call_budget_is_the_consumer_ladder():
     assert plans.get_plan("enterprise").max_call_seconds_per_day is None
 
 
+def test_storage_cap_is_the_consumer_ladder():
+    """The S3 storage cap: Free=5 GB, Go=15 GB, Pro=50 GB, Pro Max=100 GB,
+    Enterprise=None (uncapped). Decimal GB — the SI consumer convention."""
+    assert plans.get_plan("free").max_storage_bytes == 5_000_000_000
+    assert plans.get_plan("go").max_storage_bytes == 15_000_000_000
+    assert plans.get_plan("pro").max_storage_bytes == 50_000_000_000
+    assert plans.get_plan("pro_max").max_storage_bytes == 100_000_000_000
+    assert plans.get_plan("enterprise").max_storage_bytes is None
+
+
 def test_non_enterprise_smb_caps_are_non_negative_ints():
     """Every tier below Pro Max carries a concrete int cap on all three.
 
@@ -273,10 +295,14 @@ def test_non_enterprise_smb_caps_are_non_negative_ints():
         assert isinstance(by_key[key].max_pockets, int) and by_key[key].max_pockets > 0, key
         assert isinstance(by_key[key].max_connectors, int) and by_key[key].max_connectors > 0, key
         # The daily call budget is a concrete non-negative int on every capped
-        # tier too (Free = 0 — "no calls" is a valid ceiling).
+        # tier too (Free = 0 — "no calls" is a valid ceiling); the storage cap
+        # is a positive byte count (Free = 5 GB).
         assert (
             isinstance(by_key[key].max_call_seconds_per_day, int)
             and by_key[key].max_call_seconds_per_day >= 0
+        ), key
+        assert (
+            isinstance(by_key[key].max_storage_bytes, int) and by_key[key].max_storage_bytes > 0
         ), key
 
 
@@ -294,10 +320,15 @@ def test_build_unknown_key_fails_closed_to_free_smb_caps():
     # (no calls), never None/uncapped.
     assert bogus.max_call_seconds_per_day == EXPECTED_MAX_CALL_SECONDS_PER_DAY["free"]
     assert bogus.max_call_seconds_per_day == 0
+    # The storage cap fails closed too: an unknown key gets Free's 5 GB, never
+    # None/uncapped.
+    assert bogus.max_storage_bytes == EXPECTED_MAX_STORAGE_BYTES["free"]
+    assert bogus.max_storage_bytes == 5_000_000_000
     assert bogus.max_seats is not None
     assert bogus.max_pockets is not None
     assert bogus.max_connectors is not None
     assert bogus.max_call_seconds_per_day is not None
+    assert bogus.max_storage_bytes is not None
 
 
 def test_list_plans_is_cheapest_first():

--- a/tests/cloud/billing/test_plans.py
+++ b/tests/cloud/billing/test_plans.py
@@ -32,9 +32,9 @@
 #   Enterprise, fail-closed default), not the exact figures.
 # Updated 2026-08-08 (feat/billing-rbac-member-caps): the CONSUMER member caps are
 #   now LOCKED — Free ``max_seats`` = 0 (a Free workspace cannot invite ANY
-#   members), Paw Go = 5, Paw Pro = 10, Paw Pro Max = 50 total workspace members
-#   (owner included), Enterprise = None. The seat gate is plan-authoritative, so
-#   Free = 0 is an actual block, not a no-op. These tests lock the exact numbers.
+#   members), Paw Go = 5, Paw Pro = 25 total workspace members (owner included),
+#   Paw Pro Max + Enterprise = None (uncapped). The seat gate is plan-authoritative,
+#   so Free = 0 is an actual block, not a no-op. These tests lock the exact numbers.
 
 from __future__ import annotations
 
@@ -75,13 +75,13 @@ EXPECTED_USAGE_LABELS = {
 }
 # The three SMB resource caps (feat/billing-smb-caps). ``max_seats`` is the
 # APPROVED CONSUMER member cap — Free = 0 (no invitations allowed), Paw Go = 5,
-# Paw Pro = 10, Paw Pro Max = 50 total workspace members (owner included),
+# Paw Pro = 25 total workspace members (owner included), Paw Pro Max +
 # Enterprise = None (uncapped). Pockets + connectors remain their tier ceilings.
 EXPECTED_MAX_SEATS: dict[str, int | None] = {
     "free": 0,
     "go": 5,
-    "pro": 10,
-    "pro_max": 50,
+    "pro": 25,
+    "pro_max": None,
     "enterprise": None,
 }
 EXPECTED_MAX_POCKETS: dict[str, int | None] = {
@@ -212,32 +212,40 @@ def test_free_max_seats_is_zero_no_invites():
 
 
 def test_paid_tier_seats_are_the_consumer_ladder():
-    """The paid tiers carry the approved total-member caps: Go=5, Pro=10, ProMax=50.
+    """The paid tiers carry the approved caps: Go=5, Pro=25, ProMax=Unlimited.
 
-    Each number counts TOTAL workspace members (owner included), so Paw Go allows
-    the owner + 4 invited members, Paw Pro + 9, Paw Pro Max + 49.
+    Each count is TOTAL workspace members (owner included), so Paw Go allows the
+    owner + 4 invited members, Paw Pro + 24; Paw Pro Max is uncapped (None).
     """
     assert plans.get_plan("go").max_seats == 5
-    assert plans.get_plan("pro").max_seats == 10
-    assert plans.get_plan("pro_max").max_seats == 50
+    assert plans.get_plan("pro").max_seats == 25
+    assert plans.get_plan("pro_max").max_seats is None
 
 
 def test_enterprise_smb_caps_are_uncapped():
-    """Enterprise is the one uncapped tier on every SMB cap (None, never a number)."""
+    """Enterprise is fully uncapped on every SMB cap (None, never a number)."""
     ent = plans.get_plan("enterprise")
     assert ent.max_seats is None
     assert ent.max_pockets is None
     assert ent.max_connectors is None
 
 
+def test_pro_max_seats_are_uncapped_but_other_caps_concrete():
+    """Paw Pro Max is uncapped on SEATS only; pockets + connectors stay capped."""
+    pro_max = plans.get_plan("pro_max")
+    assert pro_max.max_seats is None
+    assert isinstance(pro_max.max_pockets, int) and pro_max.max_pockets > 0
+    assert isinstance(pro_max.max_connectors, int) and pro_max.max_connectors > 0
+
+
 def test_non_enterprise_smb_caps_are_non_negative_ints():
-    """Every non-Enterprise tier carries a concrete int cap on all three.
+    """Every tier below Pro Max carries a concrete int cap on all three.
 
     ``max_seats`` may be 0 (Free — the "no member invites" cap is a valid
-    ceiling); pockets + connectors are always positive on the consumer tiers.
+    ceiling); pockets + connectors are always positive on the capped tiers.
     """
     by_key = {p.key: p for p in plans.list_plans()}
-    for key in ("free", "go", "pro", "pro_max"):
+    for key in ("free", "go", "pro"):
         assert isinstance(by_key[key].max_seats, int) and by_key[key].max_seats >= 0, key
         assert isinstance(by_key[key].max_pockets, int) and by_key[key].max_pockets > 0, key
         assert isinstance(by_key[key].max_connectors, int) and by_key[key].max_connectors > 0, key

--- a/tests/cloud/billing/test_plans.py
+++ b/tests/cloud/billing/test_plans.py
@@ -34,7 +34,11 @@
 #   now LOCKED — Free ``max_seats`` = 0 (a Free workspace cannot invite ANY
 #   members), Paw Go = 5, Paw Pro = 25 total workspace members (owner included),
 #   Paw Pro Max + Enterprise = None (uncapped). The seat gate is plan-authoritative,
-#   so Free = 0 is an actual block, not a no-op. These tests lock the exact numbers.
+#   so Free = 0 is an actual block, not a no-op. Also added the daily LiveKit
+#   CALL-TIME budget (``max_call_seconds_per_day``): Free = 0 (no calls), Go =
+#   1_800 (30 min), Pro = 7_200 (2 hrs), Pro Max = 28_800 (8 hrs), Enterprise =
+#   None — enforced by ``livekit.service.create_room``. These tests lock the
+#   exact numbers.
 
 from __future__ import annotations
 
@@ -96,6 +100,17 @@ EXPECTED_MAX_CONNECTORS: dict[str, int | None] = {
     "go": 100,
     "pro": 250,
     "pro_max": 1_000,
+    "enterprise": None,
+}
+# The daily LiveKit CALL-TIME budget per workspace, in SECONDS (2026-08-08).
+# Free = 0 (no calls), Go = 1800 (30 min), Pro = 7200 (2 hrs), Pro Max = 28800
+# (8 hrs), Enterprise = None (uncapped). Enforced by livekit.service at
+# call-start time; an over-budget single call is force-ended at its deadline.
+EXPECTED_MAX_CALL_SECONDS_PER_DAY: dict[str, int | None] = {
+    "free": 0,
+    "go": 1_800,
+    "pro": 7_200,
+    "pro_max": 28_800,
     "enterprise": None,
 }
 
@@ -185,18 +200,16 @@ def test_build_unknown_key_fails_closed_to_free_ceiling():
 # ---------------------------------------------------------------------------
 
 
-def test_every_tier_carries_the_three_smb_caps():
-    """Each tier exposes max_seats / max_pockets / max_connectors (the machinery).
-
-    Locks that the caps are PRESENT on every tier with the placeholder values, not
-    that the figures are final — the captain's pricing call moves the numbers, not
-    the shape.
-    """
+def test_every_tier_carries_the_smb_caps():
+    """Each tier exposes max_seats / max_pockets / max_connectors + the daily
+    LiveKit call budget (the machinery). Locks that the caps are PRESENT on
+    every tier with the approved values."""
     by_key = {p.key: p for p in plans.list_plans()}
     for key in EXPECTED_ORDER:
         assert by_key[key].max_seats == EXPECTED_MAX_SEATS[key], key
         assert by_key[key].max_pockets == EXPECTED_MAX_POCKETS[key], key
         assert by_key[key].max_connectors == EXPECTED_MAX_CONNECTORS[key], key
+        assert by_key[key].max_call_seconds_per_day == EXPECTED_MAX_CALL_SECONDS_PER_DAY[key], key
 
 
 def test_free_max_seats_is_zero_no_invites():
@@ -238,6 +251,16 @@ def test_pro_max_seats_are_uncapped_but_other_caps_concrete():
     assert isinstance(pro_max.max_connectors, int) and pro_max.max_connectors > 0
 
 
+def test_daily_call_budget_is_the_consumer_ladder():
+    """The daily LiveKit call budget: Free=0 (no calls), Go=30min, Pro=2hrs,
+    Pro Max=8hrs, Enterprise=None (uncapped)."""
+    assert plans.get_plan("free").max_call_seconds_per_day == 0
+    assert plans.get_plan("go").max_call_seconds_per_day == 30 * 60
+    assert plans.get_plan("pro").max_call_seconds_per_day == 2 * 60 * 60
+    assert plans.get_plan("pro_max").max_call_seconds_per_day == 8 * 60 * 60
+    assert plans.get_plan("enterprise").max_call_seconds_per_day is None
+
+
 def test_non_enterprise_smb_caps_are_non_negative_ints():
     """Every tier below Pro Max carries a concrete int cap on all three.
 
@@ -249,6 +272,12 @@ def test_non_enterprise_smb_caps_are_non_negative_ints():
         assert isinstance(by_key[key].max_seats, int) and by_key[key].max_seats >= 0, key
         assert isinstance(by_key[key].max_pockets, int) and by_key[key].max_pockets > 0, key
         assert isinstance(by_key[key].max_connectors, int) and by_key[key].max_connectors > 0, key
+        # The daily call budget is a concrete non-negative int on every capped
+        # tier too (Free = 0 — "no calls" is a valid ceiling).
+        assert (
+            isinstance(by_key[key].max_call_seconds_per_day, int)
+            and by_key[key].max_call_seconds_per_day >= 0
+        ), key
 
 
 def test_build_unknown_key_fails_closed_to_free_smb_caps():
@@ -261,9 +290,14 @@ def test_build_unknown_key_fails_closed_to_free_smb_caps():
     assert bogus.max_seats == EXPECTED_MAX_SEATS["free"]
     assert bogus.max_pockets == EXPECTED_MAX_POCKETS["free"]
     assert bogus.max_connectors == EXPECTED_MAX_CONNECTORS["free"]
+    # The daily call budget fails closed too: an unknown key gets Free's 0
+    # (no calls), never None/uncapped.
+    assert bogus.max_call_seconds_per_day == EXPECTED_MAX_CALL_SECONDS_PER_DAY["free"]
+    assert bogus.max_call_seconds_per_day == 0
     assert bogus.max_seats is not None
     assert bogus.max_pockets is not None
     assert bogus.max_connectors is not None
+    assert bogus.max_call_seconds_per_day is not None
 
 
 def test_list_plans_is_cheapest_first():

--- a/tests/cloud/entitlements/test_dto_caps.py
+++ b/tests/cloud/entitlements/test_dto_caps.py
@@ -1,8 +1,14 @@
 # tests/cloud/entitlements/test_dto_caps.py — the SMB caps (max_seats /
-# max_pockets / max_connectors) added to the plan ladder must reach the wire:
-# plan_tier_to_dto (GET /billing/plans) and entitlements_to_dto (GET /entitlements)
-# have to carry them, else the plan cards / settings UI cannot render real limits.
+# max_pockets / max_connectors) + the daily call budget + the S3 storage cap
+# added to the plan ladder must reach the wire: plan_tier_to_dto
+# (GET /billing/plans) and entitlements_to_dto (GET /entitlements) have to carry
+# them, else the plan cards / settings UI cannot render real limits.
 # Created 2026-07-08 (feat/billing-smb-caps).
+# Updated 2026-08-08 (feat/billing-storage-caps): the caps under test now include
+#   ``max_call_seconds_per_day`` (LiveKit daily budget) and ``max_storage_bytes``
+#   (S3 storage cap). The entitlements-DTO test had gone stale when the call
+#   budget landed — it constructed ``Entitlements`` without the new required
+#   fields. Restored with both fields asserted through to the wire.
 from __future__ import annotations
 
 from pocketpaw_ee.cloud.billing.plans import get_plan, list_plans
@@ -11,12 +17,13 @@ from pocketpaw_ee.cloud.entitlements.dto import entitlements_to_dto, plan_tier_t
 
 
 def test_plan_tier_dto_carries_caps() -> None:
-    """Every catalog row on the wire carries the three caps from its PlanTier."""
+    """Every catalog row on the wire carries the SMB caps + storage from its PlanTier."""
     for tier in list_plans():
         dto = plan_tier_to_dto(tier)
         assert dto.max_seats == tier.max_seats
         assert dto.max_pockets == tier.max_pockets
         assert dto.max_connectors == tier.max_connectors
+        assert dto.max_storage_bytes == tier.max_storage_bytes
 
 
 def test_free_tier_dto_caps_are_concrete() -> None:
@@ -25,6 +32,7 @@ def test_free_tier_dto_caps_are_concrete() -> None:
     assert isinstance(dto.max_seats, int)
     assert isinstance(dto.max_pockets, int)
     assert isinstance(dto.max_connectors, int)
+    assert isinstance(dto.max_storage_bytes, int)
 
 
 def test_enterprise_tier_dto_caps_are_null() -> None:
@@ -33,6 +41,7 @@ def test_enterprise_tier_dto_caps_are_null() -> None:
     assert dto.max_seats is None
     assert dto.max_pockets is None
     assert dto.max_connectors is None
+    assert dto.max_storage_bytes is None
 
 
 def test_entitlements_dto_carries_caps() -> None:
@@ -46,8 +55,15 @@ def test_entitlements_dto_carries_caps() -> None:
         max_seats=25,
         max_pockets=5000,
         max_connectors=250,
+        # The two newer domain fields are REQUIRED on Entitlements (both were
+        # added after this test; ``max_call_seconds_per_day`` rides the domain
+        # + service but NOT the wire DTO, so it is only exercised here on the
+        # constructor, not asserted on ``dto``).
+        max_call_seconds_per_day=7200,
+        max_storage_bytes=50_000_000_000,
     )
     dto = entitlements_to_dto(ent)
     assert dto.max_seats == 25
     assert dto.max_pockets == 5000
     assert dto.max_connectors == 250
+    assert dto.max_storage_bytes == 50_000_000_000

--- a/tests/cloud/entitlements/test_entitlements.py
+++ b/tests/cloud/entitlements/test_entitlements.py
@@ -28,8 +28,8 @@
 # Updated 2026-07-08 (feat/billing-smb-caps): proves the resolver also surfaces the
 #   three SMB caps (``max_seats`` / ``max_pockets`` / ``max_connectors``) from the
 #   plan catalog for every known tier (incl. enterprise=None uncapped), and that an
-#   unknown / missing plan FAILS CLOSED to the Free values (5 / 200 / 50), never
-#   None/uncapped.
+#   unknown / missing plan FAILS CLOSED to the Free values (0 / 200 / 50), never
+#   None/uncapped. Pro Max is uncapped on seats only.
 
 from __future__ import annotations
 
@@ -112,10 +112,15 @@ async def test_every_known_plan_resolves_its_catalog_smb_caps(patch_plan, plan):
     assert ent.max_pockets == tier.max_pockets
     assert ent.max_connectors == tier.max_connectors
     if plan == "enterprise":
-        # The one uncapped tier — all three surface as None.
+        # The fully uncapped tier — all three surface as None.
         assert ent.max_seats is None
         assert ent.max_pockets is None
         assert ent.max_connectors is None
+    elif plan == "pro_max":
+        # Pro Max is uncapped on SEATS only; pockets + connectors stay capped.
+        assert ent.max_seats is None
+        assert isinstance(ent.max_pockets, int)
+        assert isinstance(ent.max_connectors, int)
     else:
         assert isinstance(ent.max_seats, int)
         assert isinstance(ent.max_pockets, int)

--- a/tests/cloud/entitlements/test_entitlements.py
+++ b/tests/cloud/entitlements/test_entitlements.py
@@ -34,6 +34,9 @@
 #   CALL-TIME budget (``max_call_seconds_per_day``) — Free = 0 (no calls), Go =
 #   1_800 (30 min), Pro = 7_200 (2 hrs), Pro Max = 28_800 (8 hrs), Enterprise =
 #   None. Unknown / missing plans fail closed to Free's 0 (no calls).
+# Updated 2026-08-08 (feat/billing-storage-caps): adds the S3 STORAGE cap
+#   (``max_storage_bytes``) — Free = 5 GB, Go = 15 GB, Pro = 50 GB, Pro Max =
+#   100 GB, Enterprise = None. Unknown / missing plans fail closed to Free's 5 GB.
 
 from __future__ import annotations
 
@@ -116,24 +119,28 @@ async def test_every_known_plan_resolves_its_catalog_smb_caps(patch_plan, plan):
     assert ent.max_pockets == tier.max_pockets
     assert ent.max_connectors == tier.max_connectors
     assert ent.max_call_seconds_per_day == tier.max_call_seconds_per_day
+    assert ent.max_storage_bytes == tier.max_storage_bytes
     if plan == "enterprise":
-        # The fully uncapped tier — all four surface as None.
+        # The fully uncapped tier — all five surface as None.
         assert ent.max_seats is None
         assert ent.max_pockets is None
         assert ent.max_connectors is None
         assert ent.max_call_seconds_per_day is None
+        assert ent.max_storage_bytes is None
     elif plan == "pro_max":
         # Pro Max is uncapped on SEATS only; pockets + connectors + the daily
-        # call budget stay capped (8 hrs/day).
+        # call budget + the storage cap stay capped (100 GB).
         assert ent.max_seats is None
         assert isinstance(ent.max_pockets, int)
         assert isinstance(ent.max_connectors, int)
         assert isinstance(ent.max_call_seconds_per_day, int)
+        assert isinstance(ent.max_storage_bytes, int)
     else:
         assert isinstance(ent.max_seats, int)
         assert isinstance(ent.max_pockets, int)
         assert isinstance(ent.max_connectors, int)
         assert isinstance(ent.max_call_seconds_per_day, int)
+        assert isinstance(ent.max_storage_bytes, int)
 
 
 # ---------------------------------------------------------------------------
@@ -157,6 +164,8 @@ async def test_unknown_plan_falls_back_to_free(patch_plan):
     assert ent.max_pockets == 200
     assert ent.max_connectors == 50
     assert ent.max_call_seconds_per_day == 0
+    # FAIL-CLOSED on storage too: a fallback workspace gets Free's 5 GB cap.
+    assert ent.max_storage_bytes == 5_000_000_000
 
 
 async def test_missing_workspace_falls_back_to_free_smb_caps(patch_plan):
@@ -168,6 +177,7 @@ async def test_missing_workspace_falls_back_to_free_smb_caps(patch_plan):
     assert ent.max_pockets == 200
     assert ent.max_connectors == 50
     assert ent.max_call_seconds_per_day == 0
+    assert ent.max_storage_bytes == 5_000_000_000
 
 
 async def test_missing_workspace_falls_back_to_free(patch_plan):
@@ -249,6 +259,12 @@ def test_get_entitlements_returns_resolved_entitlements(entitlements_client, pat
     assert set(body["features"]) == PLAN_FEATURES["pro"]
     assert body["features"] == sorted(body["features"])  # deterministic JSON
     assert body["monthly_credit_allotment"] > 0
+    # The SMB caps (incl. the S3 storage cap) ride the entitlements response.
+    from pocketpaw_ee.cloud.billing import plans
+
+    pro_tier = plans.get_plan("pro")
+    assert body["max_seats"] == pro_tier.max_seats
+    assert body["max_storage_bytes"] == pro_tier.max_storage_bytes
 
 
 def test_get_entitlements_unknown_plan_is_free(entitlements_client, patch_plan):

--- a/tests/cloud/entitlements/test_entitlements.py
+++ b/tests/cloud/entitlements/test_entitlements.py
@@ -30,6 +30,10 @@
 #   plan catalog for every known tier (incl. enterprise=None uncapped), and that an
 #   unknown / missing plan FAILS CLOSED to the Free values (0 / 200 / 50), never
 #   None/uncapped. Pro Max is uncapped on seats only.
+# Updated 2026-08-08 (feat/billing-rbac-member-caps): adds the daily LiveKit
+#   CALL-TIME budget (``max_call_seconds_per_day``) — Free = 0 (no calls), Go =
+#   1_800 (30 min), Pro = 7_200 (2 hrs), Pro Max = 28_800 (8 hrs), Enterprise =
+#   None. Unknown / missing plans fail closed to Free's 0 (no calls).
 
 from __future__ import annotations
 
@@ -102,7 +106,7 @@ async def test_every_known_plan_resolves_its_catalog_ceiling(patch_plan, plan):
 
 @pytest.mark.parametrize("plan", ["free", "go", "pro", "pro_max", "enterprise"])
 async def test_every_known_plan_resolves_its_catalog_smb_caps(patch_plan, plan):
-    """The resolver mirrors the catalog's three SMB caps for every known tier."""
+    """The resolver mirrors the catalog's SMB caps + daily call budget per tier."""
     from pocketpaw_ee.cloud.billing import plans
 
     patch_plan(plan)
@@ -111,20 +115,25 @@ async def test_every_known_plan_resolves_its_catalog_smb_caps(patch_plan, plan):
     assert ent.max_seats == tier.max_seats
     assert ent.max_pockets == tier.max_pockets
     assert ent.max_connectors == tier.max_connectors
+    assert ent.max_call_seconds_per_day == tier.max_call_seconds_per_day
     if plan == "enterprise":
-        # The fully uncapped tier — all three surface as None.
+        # The fully uncapped tier — all four surface as None.
         assert ent.max_seats is None
         assert ent.max_pockets is None
         assert ent.max_connectors is None
+        assert ent.max_call_seconds_per_day is None
     elif plan == "pro_max":
-        # Pro Max is uncapped on SEATS only; pockets + connectors stay capped.
+        # Pro Max is uncapped on SEATS only; pockets + connectors + the daily
+        # call budget stay capped (8 hrs/day).
         assert ent.max_seats is None
         assert isinstance(ent.max_pockets, int)
         assert isinstance(ent.max_connectors, int)
+        assert isinstance(ent.max_call_seconds_per_day, int)
     else:
         assert isinstance(ent.max_seats, int)
         assert isinstance(ent.max_pockets, int)
         assert isinstance(ent.max_connectors, int)
+        assert isinstance(ent.max_call_seconds_per_day, int)
 
 
 # ---------------------------------------------------------------------------
@@ -143,9 +152,11 @@ async def test_unknown_plan_falls_back_to_free(patch_plan):
     assert ent.monthly_ceiling == 1_000
     # FAIL-CLOSED on the SMB caps too: the Free values, never None/uncapped.
     # Free max_seats = 0 — a fallback workspace cannot invite any members.
+    # Free call budget = 0 — it also cannot place any LiveKit calls.
     assert ent.max_seats == 0
     assert ent.max_pockets == 200
     assert ent.max_connectors == 50
+    assert ent.max_call_seconds_per_day == 0
 
 
 async def test_missing_workspace_falls_back_to_free_smb_caps(patch_plan):
@@ -156,6 +167,7 @@ async def test_missing_workspace_falls_back_to_free_smb_caps(patch_plan):
     assert ent.max_seats == 0
     assert ent.max_pockets == 200
     assert ent.max_connectors == 50
+    assert ent.max_call_seconds_per_day == 0
 
 
 async def test_missing_workspace_falls_back_to_free(patch_plan):

--- a/tests/cloud/entitlements/test_entitlements.py
+++ b/tests/cloud/entitlements/test_entitlements.py
@@ -137,7 +137,8 @@ async def test_unknown_plan_falls_back_to_free(patch_plan):
     # FAIL-CLOSED: an unknown plan caps at the Free ceiling, never None/uncapped.
     assert ent.monthly_ceiling == 1_000
     # FAIL-CLOSED on the SMB caps too: the Free values, never None/uncapped.
-    assert ent.max_seats == 5
+    # Free max_seats = 0 — a fallback workspace cannot invite any members.
+    assert ent.max_seats == 0
     assert ent.max_pockets == 200
     assert ent.max_connectors == 50
 
@@ -147,7 +148,7 @@ async def test_missing_workspace_falls_back_to_free_smb_caps(patch_plan):
     patch_plan(None)
     ent = await entitlements.resolve_entitlements(WS)
     assert ent.plan == "free"
-    assert ent.max_seats == 5
+    assert ent.max_seats == 0
     assert ent.max_pockets == 200
     assert ent.max_connectors == 50
 

--- a/tests/cloud/livekit/test_call_budget.py
+++ b/tests/cloud/livekit/test_call_budget.py
@@ -1,0 +1,234 @@
+# tests/cloud/livekit/test_call_budget.py — the daily LiveKit call-time budget
+# gate (feat/billing-rbac-member-caps).
+#
+# ``livekit.service.create_room`` is the CALL-START seam: it resolves the
+# workspace's plan (entitlements) and enforces ``max_call_seconds_per_day`` —
+# Free (0) blocks every call at entry, a paid tier with an exhausted daily
+# budget blocks creating a NEW room (but still allows joining an already-running
+# one, which already owns its budget), each new call records its remaining
+# budget as ``Meeting.call_budget_deadline`` and schedules ``_force_end_at_budget``
+# so a single over-budget call is force-ended at its deadline.
+#
+# DB-backed (mongo_db): real Workspace + Meeting docs drive the budget usage
+# sum. LiveKitAPI and the agent subprocess are mocked (no real HTTP / child
+# process). Recording bus is autouse via tests/cloud/conftest.
+#
+# Created 2026-08-08 (feat/billing-rbac-member-caps).
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import CallLimitError
+from pocketpaw_ee.cloud.livekit import service
+from pocketpaw_ee.cloud.models.meeting import Meeting as MeetingDoc
+from pocketpaw_ee.cloud.models.workspace import Workspace
+
+
+@pytest.fixture
+def mock_lk_api():
+    """Mock LiveKitAPI async context manager + LiveKit env vars.
+
+    Defaults to NO existing room (the create path); a test that wants a join
+    overrides ``list_rooms`` to return an existing room.
+    """
+    service._active_agents.clear()
+
+    mock_room_svc = MagicMock()
+    mock_api_instance = MagicMock()
+    mock_api_instance.room = mock_room_svc
+    mock_api_instance.__aenter__ = AsyncMock(return_value=mock_api_instance)
+    mock_api_instance.__aexit__ = AsyncMock(return_value=False)
+
+    patches = [
+        patch("pocketpaw_ee.cloud.livekit.service.LiveKitAPI", return_value=mock_api_instance),
+        patch("pocketpaw_ee.cloud.livekit.service.LIVEKIT_URL", "wss://test.livekit.cloud"),
+        patch("pocketpaw_ee.cloud.livekit.service.LIVEKIT_API_KEY", "test-key"),
+        patch("pocketpaw_ee.cloud.livekit.service.LIVEKIT_API_SECRET", "test-secret"),
+    ]
+    for p in patches:
+        p.start()
+    try:
+        mock_room_svc.list_rooms = AsyncMock(return_value=MagicMock(rooms=[]))
+        mock_room_svc.create_room = AsyncMock(return_value=MagicMock(name="group-call-g1"))
+        yield mock_room_svc
+    finally:
+        for p in patches:
+            p.stop()
+        service._active_agents.clear()
+
+
+async def _make_workspace(plan: str) -> str:
+    ws = Workspace(name="Acme", slug="acme", owner="u-owner", plan=plan)
+    await ws.insert()
+    return str(ws.id)
+
+
+async def _seed_ended_call(workspace_id: str, minutes: float) -> None:
+    """Insert an ENDED LiveKit meeting today that spans ``minutes``."""
+    now = datetime.now(UTC)
+    await MeetingDoc(
+        workspace=workspace_id,
+        source="livekit",
+        provider_meeting_id="group-call-prev",
+        title="Instant call",
+        join_url="",
+        actual_start=now - timedelta(minutes=minutes),
+        actual_end=now,
+        status="ended",
+    ).insert()
+
+
+# ---------------------------------------------------------------------------
+# Free — no calls at all
+# ---------------------------------------------------------------------------
+
+
+async def test_free_blocks_every_call(mongo_db, mock_lk_api) -> None:
+    """Free (max_call_seconds_per_day == 0) cannot create a call at all."""
+    ws_id = await _make_workspace("free")
+    with pytest.raises(CallLimitError) as exc:
+        await service.create_room("g1", ws_id, "u-owner")
+    assert exc.value.status_code == 402
+    assert exc.value.code == "billing.call_limit"
+    mock_lk_api.create_room.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Paid tiers — the daily cumulative budget
+# ---------------------------------------------------------------------------
+
+
+async def test_paid_blocks_new_room_when_budget_exhausted(mongo_db, mock_lk_api) -> None:
+    """Go (30 min/day) with 31 min already used today cannot start a NEW call."""
+    ws_id = await _make_workspace("go")
+    await _seed_ended_call(ws_id, minutes=31)
+    with pytest.raises(CallLimitError):
+        await service.create_room("g1", ws_id, "u-owner")
+    mock_lk_api.create_room.assert_not_called()
+
+
+async def test_paid_allows_new_room_within_budget_and_sets_deadline(mongo_db, mock_lk_api) -> None:
+    """Go with budget remaining succeeds, records the deadline, schedules the watchdog."""
+    ws_id = await _make_workspace("go")
+    service._active_agents["g1"] = MagicMock()  # skip the agent subprocess spawn
+
+    with patch.object(service, "_force_end_at_budget", new_callable=AsyncMock) as mock_force:
+        result = await service.create_room("g1", ws_id, "u-owner")
+        await asyncio.sleep(0)  # let the scheduled watchdog coroutine run
+
+    assert result["is_new"] is True
+    meeting = await MeetingDoc.find_one(
+        MeetingDoc.workspace == ws_id,
+        MeetingDoc.provider_meeting_id == "group-call-g1",
+    )
+    assert meeting is not None
+    # Deadline ≈ now + the full 30-min Go budget (nothing used today).
+    assert meeting.call_budget_deadline is not None
+    deadline = service._as_utc(meeting.call_budget_deadline)
+    remaining = (deadline - datetime.now(UTC)).total_seconds()
+    assert 29 * 60 <= remaining <= 31 * 60
+    # The watchdog was scheduled with (group_id, workspace_id, deadline).
+    # (The DB round-trip truncates microseconds, so compare within 1s.)
+    mock_force.assert_awaited_once()
+    assert mock_force.await_args[0][:2] == ("g1", ws_id)
+    assert abs((mock_force.await_args[0][2] - deadline).total_seconds()) < 1
+
+
+async def test_paid_remaining_budget_is_shrunk_by_usage(mongo_db, mock_lk_api) -> None:
+    """10 min of Go's 30 already used today → deadline is 20 min away, not 30."""
+    ws_id = await _make_workspace("go")
+    await _seed_ended_call(ws_id, minutes=10)
+    service._active_agents["g1"] = MagicMock()
+
+    with patch.object(service, "_force_end_at_budget", new_callable=AsyncMock):
+        await service.create_room("g1", ws_id, "u-owner")
+
+    meeting = await MeetingDoc.find_one(
+        MeetingDoc.workspace == ws_id,
+        MeetingDoc.provider_meeting_id == "group-call-g1",
+    )
+    assert meeting is not None and meeting.call_budget_deadline is not None
+    deadline = service._as_utc(meeting.call_budget_deadline)
+    remaining = (deadline - datetime.now(UTC)).total_seconds()
+    assert 19 * 60 <= remaining <= 21 * 60
+
+
+# ---------------------------------------------------------------------------
+# Joins vs new rooms
+# ---------------------------------------------------------------------------
+
+
+async def test_join_existing_room_allowed_even_when_budget_exhausted(mongo_db, mock_lk_api) -> None:
+    """An exhausted budget blocks NEW rooms only — joining a live call is fine."""
+    ws_id = await _make_workspace("go")
+    await _seed_ended_call(ws_id, minutes=31)
+    service._active_agents["g1"] = MagicMock()
+
+    mock_lk_api.list_rooms = AsyncMock(
+        return_value=MagicMock(rooms=[MagicMock(name="group-call-g1")])
+    )
+    result = await service.create_room("g1", ws_id, "u-owner")
+    assert result["is_new"] is False
+    mock_lk_api.create_room.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Uncapped + no-workspace legacy paths
+# ---------------------------------------------------------------------------
+
+
+async def test_enterprise_is_uncapped_no_deadline(mongo_db, mock_lk_api) -> None:
+    """Enterprise (None cap) creates the room and records no budget deadline."""
+    ws_id = await _make_workspace("enterprise")
+    service._active_agents["g1"] = MagicMock()
+
+    result = await service.create_room("g1", ws_id, "u-owner")
+    assert result["is_new"] is True
+    meeting = await MeetingDoc.find_one(
+        MeetingDoc.workspace == ws_id,
+        MeetingDoc.provider_meeting_id == "group-call-g1",
+    )
+    assert meeting is not None
+    assert meeting.call_budget_deadline is None
+
+
+async def test_no_workspace_context_skips_the_gate(mongo_db, mock_lk_api) -> None:
+    """A create_room call with no workspace context bypasses the gate entirely."""
+    service._active_agents["g1"] = MagicMock()
+    result = await service.create_room("g1")
+    assert result["room_name"] == "group-call-g1"
+    assert result["is_new"] is True
+
+
+# ---------------------------------------------------------------------------
+# Budget watchdog — force-end carries the reason so the UI can prompt
+# ---------------------------------------------------------------------------
+
+
+async def test_force_end_at_budget_emits_reason(mongo_db, mock_lk_api, recording_bus) -> None:
+    """The budget watchdog force-end emits call.ended with reason='budget_exhausted'."""
+    ws_id = await _make_workspace("go")
+    room_name = service.room_name_for_group("g1")
+    now = datetime.now(UTC)
+    await MeetingDoc(
+        workspace=ws_id,
+        source="livekit",
+        provider_meeting_id=room_name,
+        title="Instant call",
+        join_url="",
+        actual_start=now,
+        status="in_progress",
+    ).insert()
+    mock_lk_api.delete_room = AsyncMock()
+
+    # Past deadline → the watchdog runs immediately.
+    await service._force_end_at_budget("g1", ws_id, now - timedelta(seconds=1))
+
+    mock_lk_api.delete_room.assert_awaited_once()
+    ended = [e for e in recording_bus.events if e.type == "call.ended"]
+    assert len(ended) >= 1
+    assert ended[-1].data["reason"] == "budget_exhausted"

--- a/tests/cloud/storage/test_storage_router.py
+++ b/tests/cloud/storage/test_storage_router.py
@@ -1,0 +1,119 @@
+# tests/cloud/storage/test_storage_router.py — GET /storage/usage read surface
+# (feat/billing-storage-caps).
+#
+# Thin HTTP proof of the storage read: the route resolves the CALLER's workspace
+# (via the ``current_workspace_id`` dep) and returns used_bytes / max_bytes /
+# remaining_bytes / percent_used from real Workspace + FileUpload docs. License
+# is waived and the workspace pinned to the seeded id. The seeding is async
+# (mongo_db), so the whole test is async; the TestClient call itself is sync.
+#
+# The READ is NOT gated on ``billing_enforced`` (it is informational — a Go
+# workspace shows "15 GB" whether or not enforcement is on), so no billing patch
+# is needed here; test_get_storage_usage_reports_used_vs_cap_billing_off pins the
+# exact dev/OSS regression where a Go workspace read "Unlimited".
+#
+# Created 2026-08-08 (feat/billing-storage-caps).
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pocketpaw_ee.cloud.license import require_license
+from pocketpaw_ee.cloud.shared.deps import current_workspace_id
+from pocketpaw_ee.cloud.storage.router import router as storage_router
+
+
+async def _seed_workspace_with_file(plan: str, size: int) -> str:
+    from pocketpaw_ee.cloud.models.workspace import Workspace
+    from pocketpaw_ee.cloud.uploads.models import FileUpload
+
+    ws = Workspace(name="Acme", slug=f"acme-{uuid.uuid4().hex[:8]}", owner="u-owner", plan=plan)
+    await ws.insert()
+    ws_id = str(ws.id)
+    await FileUpload(
+        file_id=uuid.uuid4().hex,
+        storage_key=f"u/{uuid.uuid4().hex}",
+        filename="doc.pdf",
+        mime="application/pdf",
+        size=size,
+        workspace=ws_id,
+        owner="u-owner",
+    ).insert()
+    return ws_id
+
+
+def _client_for(ws_id: str) -> TestClient:
+    app = FastAPI()
+    app.include_router(storage_router)
+    app.dependency_overrides[require_license] = lambda: None
+    app.dependency_overrides[current_workspace_id] = lambda: ws_id
+    return TestClient(app, raise_server_exceptions=False)
+
+
+async def test_get_storage_usage_reports_used_vs_cap(mongo_db) -> None:
+    ws_id = await _seed_workspace_with_file(plan="go", size=1_500_000_000)
+
+    resp = _client_for(ws_id).get("/storage/usage")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["workspace_id"] == ws_id
+    assert body["used_bytes"] == 1_500_000_000
+    assert body["max_bytes"] == 15_000_000_000
+    assert body["remaining_bytes"] == 13_500_000_000
+    assert body["percent_used"] == 10.0
+
+
+async def test_get_storage_usage_reports_used_vs_cap_billing_off(mongo_db, monkeypatch) -> None:
+    """billing off (OSS/dev, the default) → a Go workspace STILL reads 15 GB.
+
+    Regression for the live bug where the storage page showed "Unlimited" on a Go
+    plan: the read used to short-circuit to a None cap when ``billing_enforced``
+    was off (its default). The read is informational — only the upload GATE is
+    gated on billing.
+    """
+    from types import SimpleNamespace
+
+    import pocketpaw.config as ppconfig
+
+    monkeypatch.setattr(
+        ppconfig,
+        "get_settings",
+        lambda: SimpleNamespace(billing_enforced=False, dodo_plan_products=None),
+    )
+    ws_id = await _seed_workspace_with_file(plan="go", size=1_500_000_000)
+
+    resp = _client_for(ws_id).get("/storage/usage")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["used_bytes"] == 1_500_000_000
+    assert body["max_bytes"] == 15_000_000_000
+    assert body["remaining_bytes"] == 13_500_000_000
+    assert body["percent_used"] == 10.0
+
+
+async def test_get_storage_usage_enterprise_is_uncapped(mongo_db) -> None:
+    ws_id = await _seed_workspace_with_file(plan="enterprise", size=10**12)
+
+    resp = _client_for(ws_id).get("/storage/usage")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["used_bytes"] == 10**12
+    assert body["max_bytes"] is None
+    assert body["remaining_bytes"] is None
+    assert body["percent_used"] is None
+
+
+async def test_get_storage_usage_empty_workspace_is_zero(mongo_db) -> None:
+    from pocketpaw_ee.cloud.models.workspace import Workspace
+
+    ws = Workspace(name="Acme", slug="acme-empty", owner="u-owner", plan="free")
+    await ws.insert()
+
+    resp = _client_for(str(ws.id)).get("/storage/usage")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["used_bytes"] == 0
+    assert body["max_bytes"] == 5_000_000_000
+    assert body["percent_used"] == 0.0

--- a/tests/cloud/storage/test_storage_service.py
+++ b/tests/cloud/storage/test_storage_service.py
@@ -1,0 +1,234 @@
+# tests/cloud/storage/test_storage_service.py — the workspace S3 storage usage
+# resolver + cap gate (feat/billing-storage-caps).
+#
+# ``storage.service`` owns two jobs:
+#   * MEASURE — ``workspace_storage_usage`` sums the workspace's live
+#     (non-deleted) ``FileUpload`` blob sizes in the DB (a server-side $sum, so
+#     deleting a file frees its bytes). This is the S3 usage backing the
+#     Files → Knowledge Base store.
+#   * GATE — ``storage_cap_exceeded`` / ``assert_storage_available`` decide
+#     whether ``incoming_bytes`` of NEW uploads would push the workspace over its
+#     plan's ``max_storage_bytes`` (Free = 5 GB, Go = 15 GB, Pro = 50 GB, Pro
+#     Max = 100 GB, Enterprise = None). GATED on ``billing_enforced``: OSS /
+#     self-host (billing off) always pass through with no cap. The upload seam
+#     raises ``StorageLimitError`` (402, ``billing.storage_limit``) when over.
+#   * READ — ``resolve_storage_usage`` pairs used bytes with the plan cap for the
+#     Settings storage page (used / max / remaining / percent). The READ is NOT
+#     gated on ``billing_enforced`` (it is informational — a Go workspace shows
+#     "15 GB" whether or not enforcement is on); only the GATE is.
+#
+# DB-backed (mongo_db): real Workspace + FileUpload docs drive the sums and the
+# entitlement resolution. billing_enforced is patched per-test for the GATE only.
+#
+# Created 2026-08-08 (feat/billing-storage-caps).
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import StorageLimitError
+from pocketpaw_ee.cloud.storage import service as storage_service
+from pocketpaw_ee.cloud.uploads.models import FileUpload
+
+
+async def _make_workspace(plan: str, slug: str | None = None) -> str:
+    from pocketpaw_ee.cloud.models.workspace import Workspace
+
+    slug = slug or f"acme-{uuid.uuid4().hex[:8]}"
+    ws = Workspace(name="Acme", slug=slug, owner="u-owner", plan=plan)
+    await ws.insert()
+    return str(ws.id)
+
+
+async def _seed_file(workspace_id: str, size: int, *, deleted: bool = False) -> None:
+    """Insert one FileUpload row of ``size`` bytes (optionally soft-deleted)."""
+    from datetime import UTC, datetime
+
+    await FileUpload(
+        file_id=uuid.uuid4().hex,
+        storage_key=f"u/{uuid.uuid4().hex}",
+        filename="doc.pdf",
+        mime="application/pdf",
+        size=size,
+        workspace=workspace_id,
+        owner="u-owner",
+        deleted_at=datetime.now(UTC) if deleted else None,
+    ).insert()
+
+
+@pytest.fixture
+def billing_on(monkeypatch: pytest.MonkeyPatch):
+    """Turn billing_enforced on for the storage gate + read.
+
+    The service lazily imports ``get_settings`` from ``pocketpaw.config`` inside
+    each function, so the patch targets the CONFIG module (mirroring
+    ``tests/cloud/pockets/test_pocket_cap.py``).
+    """
+    import pocketpaw.config as ppconfig
+
+    monkeypatch.setattr(
+        ppconfig,
+        "get_settings",
+        lambda: SimpleNamespace(billing_enforced=True, dodo_plan_products=None),
+    )
+    yield
+
+
+# ---------------------------------------------------------------------------
+# workspace_storage_usage — the measure
+# ---------------------------------------------------------------------------
+
+
+async def test_usage_sums_live_files_per_workspace(mongo_db) -> None:
+    ws_a = await _make_workspace("free")
+    ws_b = await _make_workspace("free")
+    await _seed_file(ws_a, 1_000)
+    await _seed_file(ws_a, 2_000)
+    await _seed_file(ws_b, 999_999)  # other tenant must not leak in
+
+    assert await storage_service.workspace_storage_usage(ws_a) == 3_000
+    assert await storage_service.workspace_storage_usage(ws_b) == 999_999
+
+
+async def test_usage_excludes_soft_deleted_files(mongo_db) -> None:
+    ws = await _make_workspace("free")
+    await _seed_file(ws, 5_000)
+    await _seed_file(ws, 7_000, deleted=True)  # deleted → frees its bytes
+
+    assert await storage_service.workspace_storage_usage(ws) == 5_000
+
+
+async def test_usage_is_zero_for_empty_workspace(mongo_db) -> None:
+    ws = await _make_workspace("free")
+    assert await storage_service.workspace_storage_usage(ws) == 0
+
+
+# ---------------------------------------------------------------------------
+# storage_cap_exceeded — the gate (billing on)
+# ---------------------------------------------------------------------------
+
+
+async def test_cap_exceeded_when_incoming_pushes_over(mongo_db, billing_on) -> None:
+    """Free (5 GB) with 5 GB stored and a 1-byte new file IS over."""
+    ws = await _make_workspace("free")
+    await _seed_file(ws, 5_000_000_000)
+
+    exceeded, used, limit = await storage_service.storage_cap_exceeded(ws, incoming_bytes=1)
+    assert exceeded is True
+    assert used == 5_000_000_000
+    assert limit == 5_000_000_000
+
+
+async def test_cap_allows_exactly_at_the_limit(mongo_db, billing_on) -> None:
+    """Filling the cap EXACTLY is allowed — exceeded is strict >, never >=."""
+    ws = await _make_workspace("go")
+    await _seed_file(ws, 15_000_000_000)
+
+    exceeded, _used, _limit = await storage_service.storage_cap_exceeded(ws, incoming_bytes=0)
+    assert exceeded is False
+    # …and adding even 1 byte crosses it.
+    exceeded, _used, _limit = await storage_service.storage_cap_exceeded(ws, incoming_bytes=1)
+    assert exceeded is True
+
+
+async def test_cap_uncapped_enterprise_never_trips(mongo_db, billing_on) -> None:
+    ws = await _make_workspace("enterprise")
+    await _seed_file(ws, 10**12)  # a terabyte of "stored" bytes
+    exceeded, used, limit = await storage_service.storage_cap_exceeded(ws, incoming_bytes=10**12)
+    assert exceeded is False
+    assert limit is None
+
+
+async def test_gate_is_noop_when_billing_off(mongo_db, monkeypatch: pytest.MonkeyPatch) -> None:
+    """billing_enforced off (OSS / self-host) → no cap, no extra DB read."""
+    import pocketpaw.config as ppconfig
+
+    monkeypatch.setattr(
+        ppconfig,
+        "get_settings",
+        lambda: SimpleNamespace(billing_enforced=False, dodo_plan_products=None),
+    )
+    ws = await _make_workspace("free")
+    await _seed_file(ws, 5_000_000_000)
+
+    exceeded, used, limit = await storage_service.storage_cap_exceeded(ws, incoming_bytes=10**9)
+    assert exceeded is False
+    assert used == 0  # no usage was even summed — short-circuit
+    assert limit is None
+
+
+async def test_assert_storage_available_raises_only_when_exceeded(mongo_db, billing_on) -> None:
+    ws = await _make_workspace("free")
+    await _seed_file(ws, 5_000_000_000)
+
+    with pytest.raises(StorageLimitError) as exc:
+        await storage_service.assert_storage_available(ws, incoming_bytes=1)
+    assert exc.value.status_code == 402
+    assert exc.value.code == "billing.storage_limit"
+    assert "5 GB" in exc.value.message
+
+    # Within budget → no raise.
+    await storage_service.assert_storage_available(ws, incoming_bytes=0)
+
+
+# ---------------------------------------------------------------------------
+# resolve_storage_usage — the read surface
+# ---------------------------------------------------------------------------
+
+
+async def test_resolve_reports_used_vs_cap(mongo_db, billing_on) -> None:
+    ws = await _make_workspace("go")
+    await _seed_file(ws, 1_500_000_000)  # 1.5 GB of Go's 15 GB
+
+    usage = await storage_service.resolve_storage_usage(ws)
+    assert usage.workspace_id == ws
+    assert usage.used_bytes == 1_500_000_000
+    assert usage.max_bytes == 15_000_000_000
+    assert usage.remaining_bytes == 13_500_000_000
+    assert usage.percent_used == 10.0
+
+
+async def test_resolve_uncapped_enterprise_is_none(mongo_db, billing_on) -> None:
+    ws = await _make_workspace("enterprise")
+    await _seed_file(ws, 10**12)
+
+    usage = await storage_service.resolve_storage_usage(ws)
+    assert usage.max_bytes is None
+    assert usage.remaining_bytes is None
+    assert usage.percent_used is None
+
+
+async def test_resolve_reads_plan_cap_regardless_of_billing(
+    mongo_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """billing off → the read STILL reports the plan cap (informational, not gated).
+
+    A Go workspace shows "15 GB" whether or not enforcement is active — the
+    enforcement gate (``storage_cap_exceeded``) is what's no-op'd by billing off,
+    not the read. Regression for the live "shows Unlimited on Go" bug: the read
+    used to short-circuit to a None cap when ``billing_enforced`` was off.
+    """
+    import pocketpaw.config as ppconfig
+
+    monkeypatch.setattr(
+        ppconfig,
+        "get_settings",
+        lambda: SimpleNamespace(billing_enforced=False, dodo_plan_products=None),
+    )
+    ws = await _make_workspace("go")
+    await _seed_file(ws, 1_500_000_000)
+
+    usage = await storage_service.resolve_storage_usage(ws)
+    assert usage.used_bytes == 1_500_000_000
+    assert usage.max_bytes == 15_000_000_000
+    assert usage.remaining_bytes == 13_500_000_000
+    assert usage.percent_used == 10.0
+
+
+async def test_resolve_rejects_empty_workspace_id() -> None:
+    from pocketpaw_ee.cloud._core.errors import ValidationError
+
+    with pytest.raises(ValidationError):
+        await storage_service.resolve_storage_usage("")

--- a/tests/cloud/storage/test_upload_gate.py
+++ b/tests/cloud/storage/test_upload_gate.py
@@ -1,0 +1,209 @@
+# tests/cloud/storage/test_upload_gate.py — the UPLOAD seam of the storage cap
+# (feat/billing-storage-caps).
+#
+# ``EEUploadService.upload_many`` (the HTTP upload path) and the programmatic
+# ``write_text_file`` both enforce the workspace's plan ``max_storage_bytes``:
+# when the new blobs would push the workspace's live ``FileUpload`` total over
+# its cap, they raise ``StorageLimitError`` (402, ``billing.storage_limit``) and
+# roll back the just-written blobs — an over-cap upload is a NO-OP (no Mongo
+# row, no FileReady event, no orphan object in storage). Gated on
+# ``billing_enforced``: with billing off (OSS / self-host) the upload proceeds
+# unchanged.
+#
+# DB-backed (mongo_db): real Workspace + FileUpload docs drive the usage sum;
+# a real MongoFileStore persists rows; a fake in-memory adapter simulates S3.
+#
+# Created 2026-08-08 (feat/billing-storage-caps).
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi import UploadFile
+
+from pocketpaw.uploads.adapter import StorageAdapter, StoredObject
+from pocketpaw.uploads.config import UploadSettings
+from pocketpaw.uploads.errors import NotFound
+
+PNG = b"\x89PNG\r\n\x1a\n" + b"rest"
+
+
+class _MemAdapter(StorageAdapter):
+    """In-memory S3 stand-in — tracks written keys so the rollback is testable."""
+
+    def __init__(self) -> None:
+        self.blobs: dict[str, bytes] = {}
+
+    async def put(self, key, stream, mime):
+        buf = b""
+        async for c in stream:
+            buf += c
+        self.blobs[key] = buf
+        return StoredObject(key=key, size=len(buf), mime=mime)
+
+    async def open(self, key):
+        if key not in self.blobs:
+            raise NotFound()
+        yield self.blobs[key]
+
+    async def delete(self, key):
+        self.blobs.pop(key, None)
+
+    async def exists(self, key):
+        return key in self.blobs
+
+
+def _upload(content: bytes, filename: str, mime: str) -> UploadFile:
+    return UploadFile(
+        file=io.BytesIO(content),
+        filename=filename,
+        headers={"content-type": mime},  # type: ignore[arg-type]
+    )
+
+
+def _billing(monkeypatch: pytest.MonkeyPatch, *, on: bool) -> None:
+    import pocketpaw.config as ppconfig
+
+    monkeypatch.setattr(
+        ppconfig,
+        "get_settings",
+        lambda: SimpleNamespace(billing_enforced=on, dodo_plan_products=None),
+    )
+
+
+async def _make_workspace(plan: str) -> str:
+    import uuid
+
+    from pocketpaw_ee.cloud.models.workspace import Workspace
+
+    ws = Workspace(name="Acme", slug=f"acme-{uuid.uuid4().hex[:8]}", owner="u-owner", plan=plan)
+    await ws.insert()
+    return str(ws.id)
+
+
+async def _seed_file(workspace_id: str, size: int) -> None:
+    import uuid
+
+    from pocketpaw_ee.cloud.uploads.models import FileUpload
+
+    await FileUpload(
+        file_id=uuid.uuid4().hex,
+        storage_key=f"u/{uuid.uuid4().hex}",
+        filename="old.pdf",
+        mime="application/pdf",
+        size=size,
+        workspace=workspace_id,
+        owner="u-owner",
+    ).insert()
+
+
+def _svc(adapter: _MemAdapter, store):
+    from pocketpaw_ee.cloud.uploads.service import EEUploadService
+
+    return EEUploadService(
+        adapter=adapter,
+        meta=store,
+        cfg=UploadSettings(local_root=Path("/tmp/storage-gate")),
+    )
+
+
+async def test_upload_over_cap_raises_and_rolls_back(
+    mongo_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Free (5 GB) already full → a 1-byte upload raises and leaves nothing behind."""
+    from pocketpaw_ee.cloud._core.errors import StorageLimitError
+    from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+
+    _billing(monkeypatch, on=True)
+    ws = await _make_workspace("free")
+    await _seed_file(ws, 5_000_000_000)
+
+    adapter = _MemAdapter()
+    store = MongoFileStore()
+    svc = _svc(adapter, store)
+
+    with pytest.raises(StorageLimitError) as exc:
+        await svc.upload(
+            _upload(PNG, "cat.png", "image/png"), owner_id="u1", chat_id="c1", workspace=ws
+        )
+    assert exc.value.code == "billing.storage_limit"
+
+    # Rollback: no blob survives in the adapter, no Mongo row, no event.
+    assert adapter.blobs == {}
+    from pocketpaw_ee.cloud.uploads.models import FileUpload
+
+    rows = await FileUpload.find(FileUpload.workspace == ws).to_list()
+    assert len(rows) == 1  # only the seeded old file
+
+
+async def test_upload_within_budget_succeeds(mongo_db, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Free with plenty of headroom → the upload lands normally."""
+    from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+
+    _billing(monkeypatch, on=True)
+    ws = await _make_workspace("free")
+    await _seed_file(ws, 1_000)
+
+    adapter = _MemAdapter()
+    store = MongoFileStore()
+    svc = _svc(adapter, store)
+
+    rec = await svc.upload(
+        _upload(PNG, "cat.png", "image/png"), owner_id="u1", chat_id="c1", workspace=ws
+    )
+    assert rec.size == len(PNG)
+    assert adapter.blobs  # the blob was written
+    from pocketpaw_ee.cloud.uploads.models import FileUpload
+
+    rows = await FileUpload.find(FileUpload.workspace == ws).to_list()
+    assert len(rows) == 2  # seeded old file + the new one
+
+
+async def test_upload_gate_is_noop_when_billing_off(
+    mongo_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """billing off (OSS / self-host) → an over-cap upload is NOT blocked."""
+    from pocketpaw_ee.cloud.uploads.mongo_store import MongoFileStore
+
+    _billing(monkeypatch, on=False)
+    ws = await _make_workspace("free")
+    await _seed_file(ws, 5_000_000_000)  # Free cap fully consumed
+
+    adapter = _MemAdapter()
+    store = MongoFileStore()
+    svc = _svc(adapter, store)
+
+    rec = await svc.upload(
+        _upload(PNG, "cat.png", "image/png"), owner_id="u1", chat_id="c1", workspace=ws
+    )
+    assert rec.size == len(PNG)
+    assert len(adapter.blobs) == 1  # the over-cap upload still landed
+
+
+async def test_write_text_file_over_cap_raises_and_rolls_back(
+    mongo_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """write_text_file honours the cap too — raises and leaves no orphan blob."""
+    from pocketpaw_ee.cloud._core.errors import StorageLimitError
+    from pocketpaw_ee.cloud.uploads.service import write_text_file
+
+    _billing(monkeypatch, on=True)
+    ws = await _make_workspace("free")
+    await _seed_file(ws, 5_000_000_000)
+
+    with pytest.raises(StorageLimitError):
+        await write_text_file(
+            workspace_id=ws,
+            owner_id="u1",
+            folder_path="/",
+            filename="prd.md",
+            content="x" * 10,
+        )
+
+    from pocketpaw_ee.cloud.uploads.models import FileUpload
+
+    rows = await FileUpload.find(FileUpload.workspace == ws).to_list()
+    assert len(rows) == 1  # no new row, no orphan

--- a/tests/cloud/test_e2e_api.py
+++ b/tests/cloud/test_e2e_api.py
@@ -169,7 +169,11 @@ async def _register_and_login(http: AsyncClient, email: str | None = None) -> di
 
 
 async def _make_workspace(http: AsyncClient, headers: dict, slug: str | None = None) -> dict:
-    """Create a workspace and return the workspace dict."""
+    """Create a workspace on a PAID plan and return the workspace dict.
+
+    Since feat/billing-rbac-member-caps a Free workspace (max_seats=0) can't
+    invite anyone; the invite e2e tests need seats, so each created workspace is
+    upgraded to Paw Pro (10 seats) in the DB before it's handed back."""
     slug = slug or f"ws-{uuid.uuid4().hex[:8]}"
     r = await http.post(
         "/api/v1/workspaces",
@@ -180,7 +184,15 @@ async def _make_workspace(http: AsyncClient, headers: dict, slug: str | None = N
         headers=headers,
     )
     assert r.status_code == 200, f"Create workspace failed: {r.text}"
-    return r.json()
+    ws = r.json()
+
+    from pocketpaw_ee.cloud.models.workspace import Workspace as _WorkspaceDoc
+
+    doc = await _WorkspaceDoc.get(ws["_id"])
+    if doc is not None:
+        doc.plan = "pro"
+        await doc.save()
+    return ws
 
 
 # ===========================================================================

--- a/tests/cloud/workspace/test_invite_send_500_regression.py
+++ b/tests/cloud/workspace/test_invite_send_500_regression.py
@@ -62,7 +62,10 @@ def _ctx(user_id: str) -> RequestContext:
 async def _seed_workspace(owner: _UserDoc, *, slug: str) -> str:
     from pocketpaw_ee.cloud.models.workspace import Workspace as _WorkspaceDoc
 
-    ws_doc = _WorkspaceDoc(name="W", slug=slug, owner=str(owner.id))
+    # Paid plan (pro, 10 seats): since feat/billing-rbac-member-caps a Free
+    # workspace (max_seats=0) can't invite anyone, which would short-circuit the
+    # invite flow these tests exercise before the insert/route logic under test.
+    ws_doc = _WorkspaceDoc(name="W", slug=slug, owner=str(owner.id), plan="pro")
     await ws_doc.insert()
     ws_id = str(ws_doc.id)
     await workspace_service._add_member(ws_id, str(owner.id), role="owner", set_active=True)

--- a/tests/cloud/workspace/test_service_v2.py
+++ b/tests/cloud/workspace/test_service_v2.py
@@ -535,10 +535,10 @@ async def test_effective_seat_limit_is_plan_authoritative(owner, monkeypatch) ->
     # Free plan (max_seats=0): a fresh free workspace can't invite anyone.
     assert await workspace_service._effective_seat_limit(doc) == 0
 
-    # Upgrade to pro (max_seats=10): the ceiling rises to exactly 10.
+    # Upgrade to pro (max_seats=25): the ceiling rises to exactly 25.
     doc.plan = "pro"
     await doc.save()
-    assert await workspace_service._effective_seat_limit(doc) == 10
+    assert await workspace_service._effective_seat_limit(doc) == 25
 
     # A workspace whose custom doc.seats already exceeds the plan cap does NOT
     # override the plan on a downgrade — Free = 0 blocks all new invites.
@@ -560,14 +560,14 @@ async def test_create_invite_uses_plan_seat_limit_not_flat_seats(owner, monkeypa
     monkeypatch.setattr(
         "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
     )
-    # Restore the real plan-sourced gate so the pro cap (10) is enforced.
+    # Restore the real plan-sourced gate so the pro cap (25) is enforced.
     monkeypatch.setattr(workspace_service, "_effective_seat_limit", _REAL_EFFECTIVE_SEAT_LIMIT)
     from pocketpaw_ee.cloud.models.workspace import Workspace as _WSDoc
 
     ws = await workspace_service.create(
         _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
     )
-    # Move to pro (max_seats=10) while doc.seats stays the default 5.
+    # Move to pro (max_seats=25) while doc.seats stays the default 5.
     doc = await _WSDoc.get(ws.id)
     doc.plan = "pro"
     await doc.save()
@@ -577,7 +577,7 @@ async def test_create_invite_uses_plan_seat_limit_not_flat_seats(owner, monkeypa
         u = await _seed_user(email=f"seat{i}@x.c")
         await workspace_service._add_member(ws.id, str(u.id), role="member")
 
-    # Under the flat-seats rule this would raise; under the plan cap (10) it succeeds.
+    # Under the flat-seats rule this would raise; under the plan cap (25) it succeeds.
     invite = await workspace_service.create_invite(
         _ctx(str(owner.id)), ws.id, CreateInviteRequest(email="x@y.z")
     )
@@ -591,26 +591,26 @@ async def test_raise_seats_for_plan_lifts_on_upgrade_only(owner) -> None:
     ws = await workspace_service.create(
         _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
     )
-    # Default seats == 5. Upgrade to pro (max_seats=10) lifts the stored cap.
+    # Default seats == 5. Upgrade to pro (max_seats=25) lifts the stored cap.
     new_seats = await workspace_service.raise_seats_for_plan(ws.id, "pro")
-    assert new_seats == 10
-    assert (await _WSDoc.get(ws.id)).seats == 10
+    assert new_seats == 25
+    assert (await _WSDoc.get(ws.id)).seats == 25
 
-    # A "downgrade" to free (cap 0) must NOT strip the 10 seats it already has —
+    # A "downgrade" to free (cap 0) must NOT strip the 25 seats it already has —
     # the plan-AUTHORITATIVE seat gate blocks NEW invites, but the persisted
     # display ceiling is upgrade-only.
     unchanged = await workspace_service.raise_seats_for_plan(ws.id, "free")
-    assert unchanged == 10
-    assert (await _WSDoc.get(ws.id)).seats == 10
+    assert unchanged == 25
+    assert (await _WSDoc.get(ws.id)).seats == 25
 
     # An uncapped plan (enterprise) is a no-op — returns None, leaves seats as-is.
     ent_result = await workspace_service.raise_seats_for_plan(ws.id, "enterprise")
     assert ent_result is None
-    assert (await _WSDoc.get(ws.id)).seats == 10
+    assert (await _WSDoc.get(ws.id)).seats == 25
 
     # An unknown plan key is a safe no-op (None), seats untouched.
     assert await workspace_service.raise_seats_for_plan(ws.id, "bogus_tier") is None
-    assert (await _WSDoc.get(ws.id)).seats == 10
+    assert (await _WSDoc.get(ws.id)).seats == 25
 
 
 async def test_create_invite_rejects_duplicate_pending(owner, monkeypatch) -> None:
@@ -1594,23 +1594,23 @@ async def test_bulk_create_invites_rejects_over_seats(owner, monkeypatch) -> Non
     monkeypatch.setattr(
         "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
     )
-    # Restore the REAL plan-sourced gate so the pro cap (10) is enforced.
+    # Restore the REAL plan-sourced gate so the pro cap (25) is enforced.
     monkeypatch.setattr(workspace_service, "_effective_seat_limit", _REAL_EFFECTIVE_SEAT_LIMIT)
 
     ws = await workspace_service.create(
         _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
     )
-    # Move to pro (max_seats=10) and fill to the cap: owner + 9 members = 10.
+    # Move to pro (max_seats=25) and fill to the cap: owner + 24 members = 25.
     ws_doc = await workspace_service._WorkspaceDoc.get(PydanticObjectId(ws.id))
     assert ws_doc is not None
     ws_doc.plan = "pro"
     await ws_doc.save()
-    for i in range(9):
+    for i in range(24):
         u = await _seed_user(email=f"seat{i}@x.c")
         await workspace_service._add_member(ws.id, str(u.id), role="member")
 
     invite_count_before = await _InviteDoc.find({"workspace": ws.id}).count()
-    # 10 members already fill the pro cap — a bulk batch of 3 must be refused.
+    # 25 members already fill the pro cap — a bulk batch of 3 must be refused.
     with pytest.raises(SeatLimitError):
         await workspace_service.bulk_create_invites(
             _ctx(str(owner.id)),

--- a/tests/cloud/workspace/test_service_v2.py
+++ b/tests/cloud/workspace/test_service_v2.py
@@ -101,6 +101,33 @@ def resolver_mock(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
     return mock
 
 
+# The real plan-sourced seat gate, captured before the autouse fixture below
+# patches it. The dedicated seat-limit tests restore it locally so they exercise
+# the real ABAC/RBAC member cap (Free=0, Go=5, Pro=10, ProMax=50).
+_REAL_EFFECTIVE_SEAT_LIMIT = workspace_service._effective_seat_limit
+
+
+@pytest.fixture(autouse=True)
+def _roomy_seat_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Give invite-MECHANICS tests a workspace with seats to spare.
+
+    Since 2026-08-08 (feat/billing-rbac-member-caps) a fresh workspace is on the
+    Free plan (``max_seats=0``) and can't invite ANYONE — which is exactly the
+    point of the seat cap, but it would break every invite test that just wants
+    to exercise invite mechanics (emit, accept, token, listing, decline, ...).
+    This fixture patches the gate to a roomy ceiling for those tests; the
+    dedicated seat-limit tests (``test_create_invite_seat_limit`` /
+    ``test_effective_seat_limit_*`` / ``test_create_invite_uses_plan_seat_limit_*``
+    / ``test_bulk_create_invites_rejects_over_seats``) restore the real gate via
+    ``_REAL_EFFECTIVE_SEAT_LIMIT`` and assert on the real plan caps.
+    """
+
+    async def _roomy(_doc: Any) -> int:
+        return 10_000
+
+    monkeypatch.setattr(workspace_service, "_effective_seat_limit", _roomy)
+
+
 @pytest.fixture
 async def owner() -> _UserDoc:
     return await _seed_user(email="owner@x.c", full_name="Owner")
@@ -461,17 +488,22 @@ async def test_remove_member_owner_can_remove_owner(
 
 
 async def test_create_invite_seat_limit(owner, monkeypatch) -> None:
+    """A workspace on the Free plan (max_seats=0) cannot invite ANY members.
+
+    The ABAC/RBAC member gate is plan-authoritative; the Free tier's cap is 0, so
+    even a brand-new workspace (owner alone == member_count 1) already exceeds it
+    and every invite raises SeatLimitError."""
     monkeypatch.setattr(
         "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
     )
+    # Restore the REAL plan-sourced gate (the autouse fixture gives other tests
+    # a roomy seat ceiling) so this asserts the actual Free-plan cap.
+    monkeypatch.setattr(workspace_service, "_effective_seat_limit", _REAL_EFFECTIVE_SEAT_LIMIT)
+
     ws = await workspace_service.create(
         _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
     )
-    # Saturate seats
-    for i in range(ws.seats):
-        u = await _seed_user(email=f"seat{i}@x.c")
-        await workspace_service._add_member(ws.id, str(u.id), role="member")
-
+    # No members to saturate — Free == 0 seats already blocks the very first invite.
     with pytest.raises(SeatLimitError):
         await workspace_service.create_invite(
             _ctx(str(owner.id)), ws.id, CreateInviteRequest(email="x@y.z")
@@ -479,34 +511,41 @@ async def test_create_invite_seat_limit(owner, monkeypatch) -> None:
 
 
 # ---------------------------------------------------------------------------
-# feat/billing-smb-caps — the seat gate is PLAN-SOURCED (max(doc.seats, plan cap)).
+# feat/billing-smb-caps → feat/billing-rbac-member-caps — the seat gate is the
+# PLAN-AUTHORITATIVE member limit (Free=0, Go=5, Pro=10, ProMax=50).
 # ---------------------------------------------------------------------------
 
 
-async def test_effective_seat_limit_is_max_of_doc_seats_and_plan(owner) -> None:
-    """The enforced ceiling is max(doc.seats, plan.max_seats) — plan lifts it, and a
-    custom-higher doc.seats never regresses."""
+async def test_effective_seat_limit_is_plan_authoritative(owner, monkeypatch) -> None:
+    """The enforced ceiling is the RESOLVED PLAN's max_seats — authoritative.
+
+    Free (max_seats=0) blocks everything, the paid tiers lift the cap exactly to
+    their approved member count, a custom-higher ``doc.seats`` NEVER overrides the
+    plan on a downgrade (that's how a cancelled Pro box loses the ability to
+    invite), and an uncapped Enterprise plan defers to ``doc.seats``."""
     from pocketpaw_ee.cloud.models.workspace import Workspace as _WSDoc
+
+    monkeypatch.setattr(workspace_service, "_effective_seat_limit", _REAL_EFFECTIVE_SEAT_LIMIT)
 
     ws = await workspace_service.create(
         _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
     )
     doc = await _WSDoc.get(ws.id)
 
-    # Free plan (max_seats=5) == the default doc.seats=5: no change.
-    assert await workspace_service._effective_seat_limit(doc) == 5
+    # Free plan (max_seats=0): a fresh free workspace can't invite anyone.
+    assert await workspace_service._effective_seat_limit(doc) == 0
 
-    # Upgrade the plan to pro (max_seats=25): the ceiling rises to 25.
+    # Upgrade to pro (max_seats=10): the ceiling rises to exactly 10.
     doc.plan = "pro"
     await doc.save()
-    assert await workspace_service._effective_seat_limit(doc) == 25
+    assert await workspace_service._effective_seat_limit(doc) == 10
 
-    # A workspace whose custom doc.seats already exceeds the plan cap keeps the
-    # higher number — enforcement never strips seats it already has.
+    # A workspace whose custom doc.seats already exceeds the plan cap does NOT
+    # override the plan on a downgrade — Free = 0 blocks all new invites.
     doc.plan = "free"
     doc.seats = 40
     await doc.save()
-    assert await workspace_service._effective_seat_limit(doc) == 40
+    assert await workspace_service._effective_seat_limit(doc) == 0
 
     # An uncapped plan (enterprise, max_seats=None) defers to doc.seats.
     doc.plan = "enterprise"
@@ -521,12 +560,14 @@ async def test_create_invite_uses_plan_seat_limit_not_flat_seats(owner, monkeypa
     monkeypatch.setattr(
         "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
     )
+    # Restore the real plan-sourced gate so the pro cap (10) is enforced.
+    monkeypatch.setattr(workspace_service, "_effective_seat_limit", _REAL_EFFECTIVE_SEAT_LIMIT)
     from pocketpaw_ee.cloud.models.workspace import Workspace as _WSDoc
 
     ws = await workspace_service.create(
         _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
     )
-    # Move to pro (max_seats=25) while doc.seats stays the default 5.
+    # Move to pro (max_seats=10) while doc.seats stays the default 5.
     doc = await _WSDoc.get(ws.id)
     doc.plan = "pro"
     await doc.save()
@@ -536,7 +577,7 @@ async def test_create_invite_uses_plan_seat_limit_not_flat_seats(owner, monkeypa
         u = await _seed_user(email=f"seat{i}@x.c")
         await workspace_service._add_member(ws.id, str(u.id), role="member")
 
-    # Under the flat-seats rule this would raise; under the plan cap (25) it succeeds.
+    # Under the flat-seats rule this would raise; under the plan cap (10) it succeeds.
     invite = await workspace_service.create_invite(
         _ctx(str(owner.id)), ws.id, CreateInviteRequest(email="x@y.z")
     )
@@ -550,24 +591,26 @@ async def test_raise_seats_for_plan_lifts_on_upgrade_only(owner) -> None:
     ws = await workspace_service.create(
         _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
     )
-    # Default seats == 5. Upgrade to pro (25) lifts the stored cap.
+    # Default seats == 5. Upgrade to pro (max_seats=10) lifts the stored cap.
     new_seats = await workspace_service.raise_seats_for_plan(ws.id, "pro")
-    assert new_seats == 25
-    assert (await _WSDoc.get(ws.id)).seats == 25
+    assert new_seats == 10
+    assert (await _WSDoc.get(ws.id)).seats == 10
 
-    # A "downgrade" to free (cap 5) must NOT strip the 25 seats it already has.
+    # A "downgrade" to free (cap 0) must NOT strip the 10 seats it already has —
+    # the plan-AUTHORITATIVE seat gate blocks NEW invites, but the persisted
+    # display ceiling is upgrade-only.
     unchanged = await workspace_service.raise_seats_for_plan(ws.id, "free")
-    assert unchanged == 25
-    assert (await _WSDoc.get(ws.id)).seats == 25
+    assert unchanged == 10
+    assert (await _WSDoc.get(ws.id)).seats == 10
 
     # An uncapped plan (enterprise) is a no-op — returns None, leaves seats as-is.
     ent_result = await workspace_service.raise_seats_for_plan(ws.id, "enterprise")
     assert ent_result is None
-    assert (await _WSDoc.get(ws.id)).seats == 25
+    assert (await _WSDoc.get(ws.id)).seats == 10
 
     # An unknown plan key is a safe no-op (None), seats untouched.
     assert await workspace_service.raise_seats_for_plan(ws.id, "bogus_tier") is None
-    assert (await _WSDoc.get(ws.id)).seats == 25
+    assert (await _WSDoc.get(ws.id)).seats == 10
 
 
 async def test_create_invite_rejects_duplicate_pending(owner, monkeypatch) -> None:
@@ -1551,19 +1594,23 @@ async def test_bulk_create_invites_rejects_over_seats(owner, monkeypatch) -> Non
     monkeypatch.setattr(
         "pocketpaw_ee.cloud.workspace.service.notifications_service.create", _async_noop
     )
+    # Restore the REAL plan-sourced gate so the pro cap (10) is enforced.
+    monkeypatch.setattr(workspace_service, "_effective_seat_limit", _REAL_EFFECTIVE_SEAT_LIMIT)
+
     ws = await workspace_service.create(
         _ctx(str(owner.id)), CreateWorkspaceRequest(name="A", slug="a")
     )
-    # Shrink seats to 5 and pre-fill 3 extra members → current_count=4.
+    # Move to pro (max_seats=10) and fill to the cap: owner + 9 members = 10.
     ws_doc = await workspace_service._WorkspaceDoc.get(PydanticObjectId(ws.id))
     assert ws_doc is not None
-    ws_doc.seats = 5
+    ws_doc.plan = "pro"
     await ws_doc.save()
-    for i in range(3):
+    for i in range(9):
         u = await _seed_user(email=f"seat{i}@x.c")
         await workspace_service._add_member(ws.id, str(u.id), role="member")
 
     invite_count_before = await _InviteDoc.find({"workspace": ws.id}).count()
+    # 10 members already fill the pro cap — a bulk batch of 3 must be refused.
     with pytest.raises(SeatLimitError):
         await workspace_service.bulk_create_invites(
             _ctx(str(owner.id)),

--- a/tests/ee/test_livekit_service.py
+++ b/tests/ee/test_livekit_service.py
@@ -697,6 +697,14 @@ class TestSpawnRace:
                 "pocketpaw_ee.cloud.livekit.service._reap_agent_process",
                 new_callable=AsyncMock,
             ),
+            # The budget gate (feat/billing-rbac-member-caps) would resolve the
+            # placeholder "ws" workspace to Free and block the call; give it an
+            # uncapped budget so this test stays about the spawn race only.
+            patch(
+                "pocketpaw_ee.cloud.livekit.service._call_budget_remaining",
+                new_callable=AsyncMock,
+                return_value=(None, 0),
+            ),
         ):
             await asyncio.gather(
                 create_room("g", "ws", "u"),


### PR DESCRIPTION
## Summary

Enforce the approved CONSUMER limits through the existing ABAC/RBAC + billing-cap machinery across three seams: **workspace members** (seats), **Belt & Foresight feature availability**, and the **daily LiveKit call-time budget**.

### Member seats (plan-authoritative gate)

| Plan | Total members (owner incl.) | Invites allowed |
|------|-----------------------------|-----------------|
| Free | 0 | none |
| Paw Go | 5 | 4 |
| Paw Pro | 25 | 24 |
| Paw Pro Max | unlimited (None) | unlimited |
| Enterprise | uncapped (None) | negotiated |

### Daily LiveKit call-time budget (NEW — Voice & video)

| Plan | Call time / day |
|------|-----------------|
| Free | 0 — no calls (single-seat workspace) |
| Paw Go | 30 min (1800s) |
| Paw Pro | 2 hrs (7200s) |
| Paw Pro Max | 8 hrs (28800s) |
| Enterprise | uncapped (None) |

## Changes

- **`billing/plans.py`** — `_MAX_SEATS` locked (Free=0, Go=5, Pro=25, ProMax/Enterprise=None). New `_MAX_CALL_SECONDS_PER_DAY` plan attribute surfaced as `PlanTier.max_call_seconds_per_day`.
- **`workspace/service.py`** — `_effective_seat_limit` is now **plan-authoritative**: returns the resolved plan cap directly (not `max(doc.seats, plan)`), so Free=0 actually blocks every invite/accept; Enterprise/ProMax (None) defer to `doc.seats`.
- **`entitlements/service.py`** — fail-closed base floor is 0 seats AND 0 call seconds (Free fallback — no invites, no calls).
- **`_core/errors.py`** — new `CallLimitError` (402, `billing.call_limit`) sibling of the seat/pocket/connector limit errors.
- **`livekit/service.py`** — the daily call-time gate at `create_room`: Free blocked at entry, paid tier with exhausted daily budget blocked from starting a NEW room (joining a live call stays allowed). Each new call records `Meeting.call_budget_deadline` and a watchdog (`_force_end_at_budget`) force-ends the call at its deadline, emitting `call.ended` with `reason="budget_exhausted"` so the UI can prompt a plan upgrade.
- **`models/meeting.py`** — optional `call_budget_deadline` field.
- **Belt & Foresight** unlocked on Paw Pro (was Pro Max only) via `guards/abac.py`.

## Tests

- `test_plans.py`: cap contract — free=0 / paid ladder (Go=5, Pro=25, ProMax=None), call budget ladder (0/1800/7200/28800/None), fail-closed defaults.
- `test_service_v2.py`: plan-authoritative gate tests; invite-mechanics tests run on a paid workspace via a roomy-seat fixture.
- `test_entitlements.py`: fallback fails closed to Free (0 seats, 0 call seconds).
- `test_call_budget.py` (new): Free blocks, exhausted-budget blocks new room, join allowed, deadline math, uncapped enterprise, no-workspace no-op, budget reason on `call.ended`.
- `test_livekit_service.py`: spawn-race test given an uncapped budget (stays focused on the race).

**200 passed** (4 deselected: pre-existing `dodo_product_id` env-dependent + `delete_preview` agent-seed assertions unrelated to this change).

Pairs with paw-enterprise PR #765 (Compare plans matrix + budget popup).

---

## Storage caps (S3 — knowledge base / files)

Per-workspace S3 storage limits enforced at the upload seam, with a usage read surface the Settings Storage page renders.

| Plan | Storage cap |
|------|-------------|
| Free | 5 GB |
| Paw Go | 15 GB |
| Paw Pro | 50 GB |
| Paw Pro Max | 100 GB |
| Enterprise | uncapped (None) |

### Changes

- **`billing/plans.py`** — `_MAX_STORAGE_BYTES` (5/15/50/100 GB/None) + `PlanTier.max_storage_bytes`, fail-closed to Free on unknown keys.
- **`entitlements`** — `Entitlements.max_storage_bytes` flows through the resolver + both wire DTOs; base-floor fallback = 5 GB.
- **`_core/errors.py`** — `StorageLimitError` (402, `billing.storage_limit`) with decimal-GB human formatting.
- **`storage/` (new module)** — `workspace_storage_usage` (DB-side `$sum` of live, non-deleted `FileUpload.size`), `storage_cap_exceeded` / `assert_storage_available` (gated on `billing_enforced` — OSS/self-host unaffected), `resolve_storage_usage` + DTO + `GET /storage/usage` router (NOT gated — the read is informational, so a Go workspace always reads 15 GB).
- **`uploads/service.py`** — `upload_many` checks ACTUAL written sizes after OSS and rolls back blobs on over-cap (full no-op); `write_text_file` deletes the orphan blob on over-cap.

### Prod fixes included

- **pymongo-async aggregate coroutine**: `get_pymongo_collection().aggregate()` returns a coroutine under the pymongo-async client (500'd live); now discriminates with `inspect.isawaitable` so `async for` works on both real pymongo-async and the mongomock harness. Also fixed the same latent bug in `credits.service._sum_amount_delta`.
- **Read not gated on billing**: `resolve_storage_usage` no longer short-circuits to "Unlimited" when `billing_enforced` is off (the default) — the read is not the enforcement seam.

### Tests

- `tests/cloud/storage/` (new): service measure/gate/read, upload-gate rollback, router HTTP (incl. Go reads 15 GB with billing off).
- `test_plans.py` / `test_entitlements.py` / `test_dto_caps.py`: storage cap ladder + wire DTO assertions.

**172 relevant tests pass** (2 deselected: pre-existing `dodo_product_id` env-dependent).

Pairs with paw-enterprise PR #765 (Storage settings page + compare-matrix Storage row).
