### PR TITLE
Make the Daytona build prove it completed, and give the sandbox bun

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,9 @@ output.txt
 
 # Load-test artifacts (scripts/loadtest)
 out/
+
+# scripts/mutate.py writes this while a sweep is live so a concurrent reader
+# knows a test failure is a deliberate mutation, not a regression. Ignored because
+# a sweep artifact must never be committable; discovery is via pytest's report
+# header (tests/conftest.py), which is the path a reader actually takes anyway.
+.mutation-sweep-active

--- a/ee/pocketpaw_ee/cloud/daytona/image.py
+++ b/ee/pocketpaw_ee/cloud/daytona/image.py
@@ -7,6 +7,7 @@ Default image includes:
   - Python 3.12 + pip + venv + UV
   - GCC / G++ / build-essential (for C, C++, Rust compilation)
   - Node.js 20 LTS + npm
+  - bun >= 1.2 (required by the Paw Sites source-lane build)
   - Docker CE + Compose plugin
   - Git, curl, wget, and other common CLI utilities
 
@@ -64,6 +65,8 @@ def build_paw_dev_image() -> Image:
 
     Adds:
       * Node.js 20 LTS (via NodeSource)
+      * bun >= 1.2 (the Paw Sites source-lane build runs ``bun install`` +
+        ``bun run build``; see the block below for why npm is not a substitute)
       * Docker CE + docker-compose-plugin
       * UV (fast Python package installer, from Astral)
       * Git, curl, wget, unzip, and other CLI essentials
@@ -84,6 +87,27 @@ def build_paw_dev_image() -> Image:
             "curl -fsSL https://deb.nodesource.com/setup_20.x | bash -",
             "apt-get install -y nodejs",
             "corepack enable",
+        )
+        # ── bun (Paw Sites source-lane builds) ──────────────────────
+        # REQUIRED, not a convenience: the sites build pipeline is bun-shaped
+        # (``bun install`` + ``bun run build`` in ``sites/generator_client.py``),
+        # and ``corepack`` shims yarn/pnpm only — it does NOT provide bun.
+        #
+        # WHY NOT SUBSTITUTE npm, which is already here: every lockfile in the
+        # workspace is the TEXT format (bun >= 1.2), and npm ignores a
+        # ``bun.lock`` entirely and resolves independently. That would forfeit
+        # pinned resolution and make a sandbox build's dependency tree differ
+        # from the local builder's — the exact artifact parity the offload lane
+        # exists to establish. So bun goes in the image.
+        #
+        # Pinned to a MINIMUM (>= 1.2) rather than an exact version because the
+        # text lockfile format is the hard requirement; ``BUN_INSTALL`` +
+        # ``/usr/local/bin`` symlink puts it on PATH for non-login shells, which
+        # is how ``execute_command`` runs.
+        .run_commands(
+            "curl -fsSL https://bun.sh/install | BUN_INSTALL=/opt/bun bash",
+            "ln -sf /opt/bun/bin/bun /usr/local/bin/bun",
+            "bun --version",
         )
         # ── Docker CE (Docker-in-Docker style) ──────────────────────
         .run_commands(

--- a/ee/pocketpaw_ee/cloud/models/site.py
+++ b/ee/pocketpaw_ee/cloud/models/site.py
@@ -241,6 +241,34 @@ class Site(TimestampedDocument):
     # stale, which is the safe direction (a redundant enqueue costs one
     # idempotent job, a stuck guard costs every future publish).
     provision_started_at: datetime | None = None
+    # ── SG-9i: the ephemeral-build lane's own lifecycle ─────────────────────
+    # Deliberately SEPARATE from the provision_* trio rather than reusing it. A site
+    # is provisioned once (its D1 created and migrated) but REBUILT many times, so
+    # collapsing them would make a rebuild look like a re-provision and would let one
+    # overwrite the other's status.
+    #
+    # ``build_status`` — none | queued | building | built | failed.
+    # ``queued`` is a FIRST-CLASS state, not cosmetic. Once a concurrency cap exists a
+    # publish can wait before it starts, and a queued build is indistinguishable from
+    # a hung one unless the wire says so — which turns the cap into support tickets.
+    build_status: str = "none"
+    # When the CURRENT build attempt entered queued/building (UTC). Same bounded
+    # single-flight reasoning as ``provision_started_at``, and the same asymmetry: a
+    # row with no stamp reads as STALE, because a redundant enqueue costs one
+    # idempotent build while a stuck guard costs the pocket every future publish.
+    #
+    # Do NOT substitute ``updated_at`` for this. The DP0-4 comment above says the same
+    # thing and it is worth repeating where the field is: this model has no such
+    # field, so reading one would make every row look stale and silently disable the
+    # guard entirely.
+    build_started_at: datetime | None = None
+    # The build job's id — PERSISTED, unlike ``_provision_job_id`` below, which is a
+    # transient PrivateAttr that only exists on the response object that enqueued it.
+    # That works for a provision the caller watches synchronously and fails for a
+    # build: a queued build is exactly the case where the user reloads the page, and
+    # on reload a transient id is gone, so the client loses its polling handle at the
+    # precise moment the wait is longest.
+    build_job_id: str | None = None
     # BC-9: per-site annual plan (the Webflow model — each published site has its
     # OWN recurring annual plan on a tier, distinct from the workspace plan).
     # ``plan_tier`` is the site-plan catalog key (basic | pro | business — see

--- a/ee/pocketpaw_ee/sites/build_state.py
+++ b/ee/pocketpaw_ee/sites/build_state.py
@@ -28,10 +28,30 @@
 # WHY ``queued`` IS A SEPARATE STATE FROM ``building``: without it, a publish waiting
 # behind the concurrency cap looks identical to one that is stuck, and the cap converts
 # a crash into a support ticket. This is the state that makes a cap safe to turn on.
+#
+# ┌───────────────────────────────────────────────────────────────────────────────────┐
+# │ ADDING A NEW IN-FLIGHT STATE HAS A DEPLOY-ORDERING CONSTRAINT.                     │
+# └───────────────────────────────────────────────────────────────────────────────────┘
+#
+# The two halves of this feature resolve an UNKNOWN status in opposite directions, and
+# both are right on their own axis:
+#
+#   * the wire (``SiteResponse``) tells clients to treat an unrecognised status as
+#     IN-PROGRESS, so growing the vocabulary never shows a user a spurious error;
+#   * ``should_enqueue`` here treats an unrecognised status as TERMINAL and enqueues,
+#     because a redundant build costs one sandbox while a stuck guard costs the site
+#     every future publish.
+#
+# The consequence: a new in-flight state must be present in ``IN_FLIGHT_STATUSES`` on
+# EVERY READER before any writer is allowed to emit it. Get that backwards during a
+# rolling deploy and an old reader sees a new writer's in-flight row as terminal and
+# starts a second sandbox on top of a live build — two bills and two artifacts racing to
+# deploy, which is precisely the case this guard exists to prevent. Deploy readers first,
+# writers second.
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
-from typing import Any, Literal
+from typing import Any, Literal, get_args
 
 #: none     — never built.
 #: queued   — enqueued, no sandbox yet. Waiting on the concurrency cap.
@@ -41,10 +61,16 @@ from typing import Any, Literal
 BuildStatus = Literal["none", "queued", "building", "built", "failed"]
 
 #: The states a build can be in while still in flight. Anything else is terminal, and a
-#: terminal row never blocks a new publish.
+#: terminal row never blocks a new publish. This is the SOLE authority — ``should_enqueue``
+#: gates on it directly.
 IN_FLIGHT_STATUSES: frozenset[str] = frozenset({"queued", "building"})
 
-TERMINAL_STATUSES: frozenset[str] = frozenset({"none", "built", "failed"})
+#: DERIVED, never hand-listed. Written out by hand it was decorative and nothing read it,
+#: which made it a latent lie: add a state to ``BuildStatus`` and forget one of the two
+#: sets and the exported constant starts misdescribing the machine. Deriving makes them
+#: impossible to desync, and the subtraction fails loudly if a state is ever in
+#: IN_FLIGHT but missing from the Literal.
+TERMINAL_STATUSES: frozenset[str] = frozenset(get_args(BuildStatus)) - IN_FLIGHT_STATUSES
 
 #: Added to the build timeout to get the staleness window. Covers the parts of a build
 #: attempt that sit OUTSIDE the in-sandbox timeout — sandbox create, upload, artifact

--- a/ee/pocketpaw_ee/sites/build_state.py
+++ b/ee/pocketpaw_ee/sites/build_state.py
@@ -1,0 +1,133 @@
+# ee/pocketpaw_ee/sites/build_state.py — the ephemeral-build lane's lifecycle state
+# machine and bounded single-flight guard. Pure functions; no Beanie, no I/O.
+#
+# Created 2026-08-09 (SG-9i): a cold-per-build lane cannot sit in a request-synchronous
+# publish path, so a publish has to enqueue and return. That needs somewhere to record
+# where a build got to, and a guard that stops two publishes of the same site racing
+# into two sandboxes.
+#
+# MODELLED ON DP0-4 (``sites/service.py:_provisioning_is_stale``) because that pattern
+# already solved the hard half correctly: status alone is a ONE-WAY DOOR. A job that no
+# worker ever consumed, or that died before writing a terminal status, pins the row in
+# ``building`` forever and turns every later publish into a silent no-op — an
+# unpublishable site with no error to see. Stamping the entry is what lets the service
+# re-enqueue once the window lapses.
+#
+# TWO THINGS DP0-4 GOT WRONG THAT THIS DOES DIFFERENTLY, both deliberate:
+#
+#   1. ITS WINDOW IS A CONSTANT (30 minutes). Here the window is derived from the
+#      build's OWN timeout, because that timeout already bounds how long a live build
+#      can legitimately run. A constant is wrong in both directions: too short and it
+#      re-enqueues on top of a healthy long build (two sandboxes, two bills, a racing
+#      artifact), too long and a stuck row blocks publishes for half an hour.
+#
+#   2. ITS JOB ID IS A TRANSIENT ``PrivateAttr``. Ours is persisted. A queued build is
+#      precisely when a user reloads, and a transient id is gone on reload — so the
+#      client loses its polling handle at the moment the wait is longest.
+#
+# WHY ``queued`` IS A SEPARATE STATE FROM ``building``: without it, a publish waiting
+# behind the concurrency cap looks identical to one that is stuck, and the cap converts
+# a crash into a support ticket. This is the state that makes a cap safe to turn on.
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any, Literal
+
+#: none     — never built.
+#: queued   — enqueued, no sandbox yet. Waiting on the concurrency cap.
+#: building — a sandbox exists and the build is running.
+#: built    — a verified artifact was produced.
+#: failed   — terminal. Either the user's build broke or we gave up retrying.
+BuildStatus = Literal["none", "queued", "building", "built", "failed"]
+
+#: The states a build can be in while still in flight. Anything else is terminal, and a
+#: terminal row never blocks a new publish.
+IN_FLIGHT_STATUSES: frozenset[str] = frozenset({"queued", "building"})
+
+TERMINAL_STATUSES: frozenset[str] = frozenset({"none", "built", "failed"})
+
+#: Added to the build timeout to get the staleness window. Covers the parts of a build
+#: attempt that sit OUTSIDE the in-sandbox timeout — sandbox create, upload, artifact
+#: download, teardown — plus queue wait. Measured live at ~5s of overhead per build
+#: (react 8.7s total against a 2.9s build), so 10 minutes is generous on purpose: the
+#: window exists to unstick a dead row, not to police a slow one.
+STALE_MARGIN = timedelta(minutes=10)
+
+
+def stale_after(timeout_seconds: int) -> timedelta:
+    """The staleness window for a build whose own budget is ``timeout_seconds``.
+
+    Derived rather than constant — see the module header for why a fixed window is
+    wrong in both directions. A non-positive timeout falls back to the margin alone
+    rather than producing a zero or negative window, which would make every in-flight
+    build read as stale and defeat the guard.
+    """
+    return timedelta(seconds=max(0, timeout_seconds)) + STALE_MARGIN
+
+
+def _read_stamp(value: Any) -> datetime | None:
+    """Coerce a stamp to an aware datetime, or ``None`` when it is unusable.
+
+    A naive datetime is assumed UTC — the writers all stamp UTC, and treating a naive
+    stamp as unreadable would make every row written by an older writer look stale.
+    """
+    if not isinstance(value, datetime):
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value
+
+
+def build_is_stale(doc: Any, timeout_seconds: int, *, now: datetime | None = None) -> bool:
+    """True when an in-flight build's stamp is older than its window.
+
+    A MISSING OR UNREADABLE STAMP READS AS STALE. That is the same asymmetric-failure
+    call DP0-4 made and it is the safe direction: a redundant enqueue costs one
+    idempotent build, while a stuck guard costs the site every future publish. Getting
+    this backwards produces a site that silently cannot be republished.
+    """
+    stamp = _read_stamp(getattr(doc, "build_started_at", None))
+    if stamp is None:
+        return True
+    reference = now or datetime.now(UTC)
+    if reference.tzinfo is None:  # pragma: no cover - defensive
+        reference = reference.replace(tzinfo=UTC)
+    return reference - stamp > stale_after(timeout_seconds)
+
+
+def should_enqueue(doc: Any, timeout_seconds: int, *, now: datetime | None = None) -> bool:
+    """Should a publish enqueue a build for this site?
+
+    Yes unless a build is genuinely in flight — i.e. the status is ``queued`` or
+    ``building`` AND its stamp is inside the window. A terminal status never blocks:
+    ``built`` and ``failed`` are both legitimate starting points for a rebuild, and
+    treating ``failed`` as blocking would mean one bad build wedges the site until
+    someone edits the database.
+    """
+    status = getattr(doc, "build_status", None)
+    if status not in IN_FLIGHT_STATUSES:
+        return True
+    return build_is_stale(doc, timeout_seconds, now=now)
+
+
+def is_in_flight(doc: Any) -> bool:
+    """True when the row CLAIMS a build is running, ignoring staleness.
+
+    Distinct from ``not should_enqueue(...)`` on purpose: this is what a UI should read
+    to decide whether to show progress, while ``should_enqueue`` is what the service
+    reads to decide whether to spend money. A stale row should still render as
+    in-flight to a viewer — it just must not block the next publish.
+    """
+    return getattr(doc, "build_status", None) in IN_FLIGHT_STATUSES
+
+
+__all__ = [
+    "IN_FLIGHT_STATUSES",
+    "STALE_MARGIN",
+    "TERMINAL_STATUSES",
+    "BuildStatus",
+    "build_is_stale",
+    "is_in_flight",
+    "should_enqueue",
+    "stale_after",
+]

--- a/ee/pocketpaw_ee/sites/daytona_build.py
+++ b/ee/pocketpaw_ee/sites/daytona_build.py
@@ -35,12 +35,16 @@
 from __future__ import annotations
 
 import json
+import logging
 import math
+import os
 import shlex
 from dataclasses import dataclass
 from typing import Any, Literal
 
 from pocketpaw_ee.sites.engines import normalize_engine, static_output_rel
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # The sentinel
@@ -98,6 +102,55 @@ TIMEOUT_FLOOR_SECONDS = 600
 #: Multiplier over measured p95. A cold sandbox has no page cache and may hit a
 #: busier registry than the machine the measurement was taken on.
 TIMEOUT_SAFETY_FACTOR = 1.5
+
+
+#: Shared env knob for the build timeout. Deliberately the SAME name SG-P2 is about
+#: (``PAW_SITES_BUILD_TIMEOUT_SEC``, read by ``generator_client._build_timeout_sec``):
+#: one constant serves the local builder and this lane, so an operator tuning a slow
+#: deploy does not have to discover two names. Set nowhere in deploy config today.
+_TIMEOUT_ENV = "PAW_SITES_BUILD_TIMEOUT_SEC"
+
+#: Per-engine override, checked before the shared knob:
+#: ``PAW_SITES_BUILD_TIMEOUT_SEC_REACT`` / ``..._SVELTE``. Engines differ by more than
+#: a constant factor — react installs 4 direct deps, svelte pulls the whole
+#: SvelteKit + adapter-cloudflare toolchain — so a single number is either wasteful for
+#: one or fatal for the other.
+_TIMEOUT_ENV_PER_ENGINE = "PAW_SITES_BUILD_TIMEOUT_SEC_{engine}"
+
+
+def resolve_build_timeout_seconds(engine: str | None) -> int:
+    """The timeout to use for ``engine`` right now, with no measured inputs.
+
+    Resolution order: per-engine env → shared env → :data:`TIMEOUT_FLOOR_SECONDS`.
+
+    Both engines currently land on the 600s floor, because measurement was descoped and
+    :func:`build_timeout_seconds` has nothing to compute from. That is deliberately
+    LOOSE rather than tight — a timeout is a wedge detector, and the cost of one that is
+    too generous is a slow failure, while the cost of one that is too tight is a healthy
+    build reported to the user as broken. When real p95s exist, feed them to
+    :func:`build_timeout_seconds` and set these env vars from its output; the shape is
+    already here so nothing needs restructuring.
+
+    A malformed value falls back rather than raising: the timeout is a safety net and
+    must never itself be the thing that breaks a build.
+    """
+    names = [
+        _TIMEOUT_ENV_PER_ENGINE.format(engine=normalize_engine(engine).upper()),
+        _TIMEOUT_ENV,
+    ]
+    for name in names:
+        raw = os.environ.get(name, "").strip()
+        if not raw:
+            continue
+        try:
+            value = int(raw)
+        except ValueError:
+            logger.warning("sites: ignoring non-int %s=%r", name, raw)
+            continue
+        if value > 0:
+            return value
+        logger.warning("sites: ignoring non-positive %s=%r", name, raw)
+    return TIMEOUT_FLOOR_SECONDS
 
 
 def build_timeout_seconds(
@@ -520,4 +573,5 @@ __all__ = [
     "build_timeout_seconds",
     "build_wrapper_script",
     "classify_build",
+    "resolve_build_timeout_seconds",
 ]

--- a/ee/pocketpaw_ee/sites/daytona_build.py
+++ b/ee/pocketpaw_ee/sites/daytona_build.py
@@ -1,0 +1,523 @@
+# ee/pocketpaw_ee/sites/daytona_build.py — the ephemeral Daytona build lane's
+# DECISION CORE. Pure functions only: no Daytona client, no network, no filesystem.
+#
+# Created 2026-08-09 (SG-9i): the captain's ruling is that a site build runs in a
+# Daytona sandbox with a strict timeout which then deletes itself. That ruling makes
+# the previously-specified failure discriminator impossible, and this module is the
+# replacement.
+#
+# WHY THIS EXISTS — the problem the ruling creates. SR-2 established that mid-build
+# sandbox death is INDISTINGUISHABLE from a build failure: both surface as a failed
+# ``execute_command``. Its fix was to re-query the sandbox afterwards
+# (``get_sandbox_by_id``) and branch on whether it was still alive. A SELF-DELETING
+# sandbox cannot be re-queried — and worse, "not found" then means BOTH "deleted
+# normally" and "died and was reaped", so the query is not merely unavailable, it is
+# actively misleading. A strict timeout also makes death-by-timeout more frequent.
+#
+# THE FIX — invert the inference. Do not try to detect infrastructure failure.
+# Require the build to PROVE it completed, and treat the ABSENCE of that proof as
+# infrastructure failure. A build that ran to completion can write evidence; a killed
+# container cannot. Absence is unambiguous in a way a failed exec never is.
+#
+# So the in-sandbox wrapper writes ``.paw-build-result.json`` from a shell ``trap ...
+# EXIT``, which fires even when the build itself exits non-zero. The caller reads that
+# sentinel BEFORE any teardown. ``classify_build`` then maps (sentinel, our elapsed
+# clock, the configured timeout) onto exactly one outcome.
+#
+# WHY THE CLOCK IS OURS. The elapsed time is measured by the enqueuing process,
+# started before ``create_sandbox``. It therefore survives the sandbox's death, costs
+# no API call, and cannot be lost with the container — unlike anything Daytona could
+# tell us after the fact.
+#
+# WHAT THIS MODULE DELIBERATELY DOES NOT DO: talk to Daytona. The whole point is that
+# the decision procedure is testable without a sandbox, because it is the part that
+# must be right. Wiring lives in the caller.
+from __future__ import annotations
+
+import json
+import math
+import shlex
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from pocketpaw_ee.sites.engines import normalize_engine, static_output_rel
+
+# ---------------------------------------------------------------------------
+# The sentinel
+# ---------------------------------------------------------------------------
+
+#: Filename the in-sandbox wrapper writes its result to, relative to the project dir.
+#: Read by the caller BEFORE teardown; it is the only evidence the caller trusts.
+BUILD_RESULT_FILENAME = ".paw-build-result.json"
+
+#: Sentinel schema version. Bump when a field's MEANING changes (adding an optional
+#: field does not need a bump). ``classify_build`` refuses a version it does not know
+#: rather than guessing at the fields — a sentinel we cannot read is exactly as
+#: uninformative as no sentinel, and must classify the same way.
+SENTINEL_SCHEMA = 1
+
+#: How much of the build's stderr the wrapper carries back. Enough to show a stack or
+#: a compiler error without dwarfing the response; mirrors the bounded-output posture
+#: of ``websandbox/scaffold.py``.
+STDERR_TAIL_BYTES = 8192
+
+# ---------------------------------------------------------------------------
+# Exit codes that mean "the environment killed us", not "the code is wrong"
+# ---------------------------------------------------------------------------
+#
+# These are the residual gap in the sentinel design, and missing them would undo it.
+# A process killed by a signal STILL RUNS THE TRAP, so it produces a sentinel with a
+# non-zero ``build_exit`` and would naively classify as a genuine build failure — the
+# exact mis-report the whole mechanism exists to prevent. The shell reports a
+# signalled death as 128+signum.
+
+#: ``timeout(1)``'s exit code when it kills the supervised command. Evidence of a
+#: timeout WITH a sentinel, which is strictly better than inferring one from the
+#: clock: we know it was the in-sandbox limit, and we still have the stderr tail.
+_EXIT_TIMEOUT = 124
+
+#: 128+9 (SIGKILL). In a memory-capped container this is overwhelmingly the OOM
+#: killer, i.e. capacity loss, not a broken build. Retry it; never blame the user.
+_EXIT_SIGKILL = 137
+
+#: 128+15 (SIGTERM). The container is being stopped underneath us.
+_EXIT_SIGTERM = 143
+
+_INFRA_EXIT_CODES = frozenset({_EXIT_SIGKILL, _EXIT_SIGTERM})
+
+# ---------------------------------------------------------------------------
+# Timeout sizing
+# ---------------------------------------------------------------------------
+
+#: Floor for any build timeout, in seconds. NOT arbitrary: ``websandbox/scaffold.py``
+#: budgets 600s for a cold install of this very toolchain, and a cold-per-build lane
+#: pays that install EVERY time. A floor below it guarantees timeouts on healthy
+#: builds — the failure mode a "strict" timeout is most likely to introduce.
+TIMEOUT_FLOOR_SECONDS = 600
+
+#: Multiplier over measured p95. A cold sandbox has no page cache and may hit a
+#: busier registry than the machine the measurement was taken on.
+TIMEOUT_SAFETY_FACTOR = 1.5
+
+
+def build_timeout_seconds(
+    install_p95_seconds: float,
+    build_p95_seconds: float,
+    *,
+    floor_seconds: int = TIMEOUT_FLOOR_SECONDS,
+    safety_factor: float = TIMEOUT_SAFETY_FACTOR,
+) -> int:
+    """Return the strict per-build timeout, in whole seconds.
+
+    Sized over ``install + build``, NOT build alone. That distinction is the whole
+    point: this lane is cold-per-build, so the dependency install is paid on every
+    single build and is usually the larger of the two terms. A timeout sized on the
+    build alone would kill every healthy build in the lane, which is the specific way
+    a "strict timeout" instruction goes wrong.
+
+    Takes **p95**, not mean — the timeout's job is to catch a wedged build, not to
+    trim a slow tail. Negative inputs are clamped to zero so a malformed measurement
+    degrades to the floor rather than producing a nonsense (or negative) budget.
+    """
+    install = max(0.0, install_p95_seconds)
+    build = max(0.0, build_p95_seconds)
+    scaled = math.ceil((install + build) * safety_factor)
+    return max(floor_seconds, scaled)
+
+
+# ---------------------------------------------------------------------------
+# Outcomes
+# ---------------------------------------------------------------------------
+
+#: The four mutually-exclusive outcomes of a build attempt.
+#:
+#: ``build_failed`` is the ONLY one that may reach the user as "your site did not
+#: build", and reaching it requires positive proof of completion. The other three are
+#: ours to absorb — which is what stops capacity loss being reported as the user's
+#: fault.
+BuildOutcome = Literal["completed_ok", "build_failed", "timed_out", "infra_lost"]
+
+
+@dataclass(frozen=True)
+class BuildClassification:
+    """The verdict on one build attempt.
+
+    ``retryable`` and ``blames_user`` are deliberately separate flags rather than one
+    enum: a timeout is retryable AND honestly reportable to the user ("your build
+    exceeded N seconds" is actionable — they may have an enormous site), whereas
+    ``infra_lost`` is retryable and must NEVER be shown as a build problem. Collapsing
+    them would force every call site to re-derive the distinction.
+    """
+
+    outcome: BuildOutcome
+    #: Short machine-readable reason, for logs and metrics. Never user-facing prose.
+    reason: str
+    #: May the lane retry (and then fall back to the local builder)?
+    retryable: bool
+    #: Is this the user's build being wrong? Only ever True for ``build_failed``.
+    blames_user: bool
+    #: Build stderr tail when we have one, else ``""``. Empty is meaningful: it means
+    #: no sentinel survived, which is precisely why the outcome is not ``build_failed``.
+    stderr_tail: str = ""
+
+    @property
+    def deployable(self) -> bool:
+        """True only when there is a verified artifact to deploy."""
+        return self.outcome == "completed_ok"
+
+
+def _parse_sentinel(raw: str | bytes | dict[str, Any] | None) -> dict[str, Any] | None:
+    """Coerce a sentinel to a dict, or ``None`` when it is unusable.
+
+    A TRUNCATED or malformed sentinel returns ``None`` on purpose. A partial write
+    means the container died mid-write, which is infrastructure loss — the same
+    conclusion as no sentinel at all. Trusting a half-written sentinel would be the
+    one way to turn this mechanism back into a guess.
+    """
+    if raw is None:
+        return None
+    if isinstance(raw, dict):
+        parsed: Any = raw
+    else:
+        try:
+            parsed = json.loads(raw)
+        except (ValueError, TypeError, UnicodeDecodeError):
+            return None
+    if not isinstance(parsed, dict):
+        return None
+    if parsed.get("schema") != SENTINEL_SCHEMA:
+        # An unknown schema is unreadable, and unreadable is indistinguishable from
+        # absent. Refuse rather than guess at field meanings.
+        return None
+    return parsed
+
+
+def _coerce_exit(value: Any) -> int | None:
+    """Read an exit code, or ``None`` when it is missing/unusable.
+
+    ``bool`` is rejected explicitly: ``True``/``False`` are ``int`` subclasses that
+    would otherwise read as exit 1 / exit 0 and silently invert a verdict.
+    """
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    return value
+
+
+def classify_build(
+    sentinel: str | bytes | dict[str, Any] | None,
+    *,
+    elapsed_seconds: float,
+    timeout_seconds: int,
+) -> BuildClassification:
+    """Classify one build attempt into exactly one :data:`BuildOutcome`.
+
+    ``sentinel`` is the raw content of :data:`BUILD_RESULT_FILENAME` read from the
+    sandbox BEFORE teardown, or ``None`` when it could not be read (which includes
+    "the sandbox was already gone").
+
+    The order of the checks is load-bearing and is documented inline: signalled
+    deaths must be recognised BEFORE a non-zero exit is read as a build failure, or a
+    container OOM would be reported as the user's bug.
+    """
+    parsed = _parse_sentinel(sentinel)
+
+    # ── No usable sentinel: the build did not prove it completed. ───────────
+    # This is the inversion the whole module rests on. We do not ask "did the
+    # sandbox die"; we observe that nothing proved it lived, which is the same
+    # evidence and is available after the container is gone.
+    if parsed is None:
+        if elapsed_seconds >= timeout_seconds:
+            return BuildClassification(
+                outcome="timed_out",
+                reason="no_sentinel_at_timeout",
+                retryable=True,
+                # Honest and actionable: the build really did exceed the budget.
+                blames_user=False,
+            )
+        return BuildClassification(
+            outcome="infra_lost",
+            reason="no_sentinel_before_timeout",
+            retryable=True,
+            blames_user=False,
+        )
+
+    stderr_tail = str(parsed.get("stderr_tail") or "")
+    install_exit = _coerce_exit(parsed.get("install_exit"))
+    build_exit = _coerce_exit(parsed.get("build_exit"))
+
+    # ── Signalled deaths FIRST. ─────────────────────────────────────────────
+    # A signalled process still runs the trap, so these arrive WITH a sentinel and
+    # would otherwise be read as a genuine failure. Checking them after the
+    # non-zero-exit branch would reintroduce the exact mis-report this module exists
+    # to prevent, which is why they are checked here and not below.
+    for label, code in (("install", install_exit), ("build", build_exit)):
+        if code in _INFRA_EXIT_CODES:
+            return BuildClassification(
+                outcome="infra_lost",
+                reason=f"{label}_killed_by_signal_{code}",
+                retryable=True,
+                blames_user=False,
+                stderr_tail=stderr_tail,
+            )
+        if code == _EXIT_TIMEOUT:
+            # ``timeout(1)`` fired inside the sandbox. Better than the clock-inferred
+            # case above: we know which step overran AND we kept its stderr.
+            return BuildClassification(
+                outcome="timed_out",
+                reason=f"{label}_exceeded_in_sandbox_timeout",
+                retryable=True,
+                blames_user=False,
+                stderr_tail=stderr_tail,
+            )
+
+    # ── A missing exit code is not a success. ───────────────────────────────
+    # Fail closed: a sentinel that parsed but carries no build_exit tells us nothing
+    # about the build, so it must not be allowed to deploy.
+    if install_exit is None or build_exit is None:
+        return BuildClassification(
+            outcome="infra_lost",
+            reason="sentinel_missing_exit_code",
+            retryable=True,
+            blames_user=False,
+            stderr_tail=stderr_tail,
+        )
+
+    if install_exit != 0:
+        # A failed dependency install is genuinely reportable — a bad manifest is the
+        # user's to fix — but it is also what a registry outage looks like. It is
+        # retryable AND user-visible; the caller decides which to lead with, and the
+        # retry is cheap because nothing was built.
+        return BuildClassification(
+            outcome="build_failed",
+            reason="install_failed",
+            retryable=True,
+            blames_user=True,
+            stderr_tail=stderr_tail,
+        )
+
+    if build_exit != 0:
+        return BuildClassification(
+            outcome="build_failed",
+            reason="build_failed",
+            retryable=False,
+            blames_user=True,
+            stderr_tail=stderr_tail,
+        )
+
+    # ── Exit 0 is not sufficient. ───────────────────────────────────────────
+    # A build that "succeeds" and emits nothing is the empty-deploy failure: every
+    # step reports success and a blank site goes live. The artifact size is the
+    # positive check that catches it, and it is checked here rather than at the
+    # deploy call site so no caller can forget it.
+    artifact_bytes = parsed.get("artifact_bytes")
+    if not isinstance(artifact_bytes, int) or isinstance(artifact_bytes, bool):
+        return BuildClassification(
+            outcome="build_failed",
+            reason="artifact_size_unknown",
+            retryable=False,
+            blames_user=True,
+            stderr_tail=stderr_tail,
+        )
+    if artifact_bytes <= 0:
+        return BuildClassification(
+            outcome="build_failed",
+            reason="artifact_empty",
+            retryable=False,
+            blames_user=True,
+            stderr_tail=stderr_tail,
+        )
+
+    return BuildClassification(
+        outcome="completed_ok",
+        reason="ok",
+        retryable=False,
+        blames_user=False,
+        stderr_tail=stderr_tail,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Artifact extraction — an INCLUDE-list of exactly one directory
+# ---------------------------------------------------------------------------
+
+
+def artifact_tar_command(
+    engine: str | None,
+    project_dir: str,
+    dest_path: str,
+) -> str:
+    """The in-sandbox command that packs ONLY the deployable output.
+
+    Deliberately an **include-list of one directory** rather than an exclude-list of
+    junk, and deliberately NOT ``_SNAPSHOT_EXCLUDED_SEGMENTS`` (whose frozenset the
+    dev-workspace prune depends on not seeing those paths — widening it would break
+    an unrelated subsystem).
+
+    Two properties follow, and both are the reason for the choice:
+
+    * ``node_modules`` is excluded **by construction** for every engine whose output
+      is a subdirectory (``dist``, ``.svelte-kit/cloudflare``). There is no filter to
+      get wrong, so the 500 MB-on-the-wire failure cannot occur.
+    * The failure mode inverts usefully. A wrong exclude-list ships junk SILENTLY; a
+      wrong include-list ships NOTHING, LOUDLY — caught by ``artifact_bytes <= 0`` in
+      :func:`classify_build` before anything is deployed.
+
+    Raises ``ValueError`` for an engine whose static output is the project root
+    (``html``): tarring ``.`` would sweep in ``node_modules`` and defeat the whole
+    design. html needs no build and so never reaches this lane; a caller that gets
+    here with it has a routing bug and should hear about it loudly.
+    """
+    rel = static_output_rel(engine)
+    if rel == ".":
+        raise ValueError(
+            f"engine {normalize_engine(engine)!r} emits its static output at the "
+            "project root, so an include-list cannot exclude node_modules; this "
+            "lane is for engines whose build writes a subdirectory"
+        )
+    output_dir = f"{project_dir.rstrip('/')}/{rel}"
+    return f"tar -czf {shlex.quote(dest_path)} -C {shlex.quote(output_dir)} ."
+
+
+# ---------------------------------------------------------------------------
+# The in-sandbox wrapper
+# ---------------------------------------------------------------------------
+
+#: Serializing the sentinel with python3 rather than hand-rolled shell string
+#: concatenation is a correctness decision, not a style one: stderr routinely contains
+#: quotes, newlines and control characters, and a shell-escaped JSON writer would
+#: produce an unparseable sentinel exactly when there is an error worth reading — i.e.
+#: it would fail in the case it exists to serve. python3.12 is in the Daytona image by
+#: construction (``daytona/image.py`` builds from ``Image.debian_slim("3.12")``).
+_SENTINEL_WRITER = r"""
+python3 - "$RESULT" "$STDERR_LOG" "$STARTED" "$INSTALL_EXIT" "$BUILD_EXIT" \
+         "$ARTIFACT_BYTES" "$ENGINE" "$ARTIFACT_REL" <<'PYEOF'
+import datetime, json, os, sys
+result, log, started, inst, bld, abytes, engine, rel = sys.argv[1:9]
+tail = ""
+try:
+    with open(log, "rb") as fh:
+        try:
+            fh.seek(-TAIL_BYTES, os.SEEK_END)
+        except OSError:
+            fh.seek(0)
+        tail = fh.read().decode("utf-8", "replace")
+except OSError:
+    pass
+
+
+def _int(value):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+payload = {
+    "schema": 1,
+    "engine": engine,
+    "install_exit": _int(inst),
+    "build_exit": _int(bld),
+    "started_at": started,
+    "finished_at": datetime.datetime.now(datetime.timezone.utc)
+    .strftime("%Y-%m-%dT%H:%M:%SZ"),
+    "artifact_rel": rel,
+    "artifact_bytes": _int(abytes) or 0,
+    "stderr_tail": tail,
+}
+with open(result, "w", encoding="utf-8") as fh:
+    json.dump(payload, fh)
+PYEOF
+"""
+
+
+def build_wrapper_script(
+    engine: str | None,
+    project_dir: str,
+    *,
+    timeout_seconds: int,
+    artifact_path: str,
+    install_command: str = "bun install",
+    build_command: str = "bun run build",
+) -> str:
+    """Render the bash wrapper the sandbox runs.
+
+    Contract, in order:
+
+    1. ``trap … EXIT`` is installed **before anything can fail**, so the sentinel is
+       written on every path — including a non-zero build, which is the case the
+       classifier most needs evidence for.
+    2. Install, then build, each under ``timeout(1)`` so an overrun surfaces as exit
+       124 *with* a sentinel rather than as a silent hang the caller can only infer
+       from its own clock.
+    3. Tar exactly the engine's output dir (:func:`artifact_tar_command`) and record
+       its byte size, so ``artifact_bytes`` can catch an empty build before deploy.
+
+    ``set -u`` but deliberately **not** ``set -e``: the whole design depends on
+    reaching the sentinel write with the real exit codes in hand, and ``-e`` would
+    abort the script at the first failing step, which is precisely when the evidence
+    matters. Every command's status is captured explicitly instead.
+    """
+    tar_cmd = artifact_tar_command(engine, project_dir, artifact_path)
+    result_path = f"{project_dir.rstrip('/')}/{BUILD_RESULT_FILENAME}"
+    writer = _SENTINEL_WRITER.replace("TAIL_BYTES", str(STDERR_TAIL_BYTES))
+
+    return f"""#!/usr/bin/env bash
+# Generated by pocketpaw_ee.sites.daytona_build — do not edit in place.
+set -u
+
+PROJECT={shlex.quote(project_dir)}
+RESULT={shlex.quote(result_path)}
+STDERR_LOG=/tmp/paw-build-stderr.log
+ARTIFACT={shlex.quote(artifact_path)}
+ENGINE={shlex.quote(normalize_engine(engine))}
+ARTIFACT_REL={shlex.quote(static_output_rel(engine))}
+STARTED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# -1 distinguishes "never ran" from "ran and returned 0". A step that never ran
+# leaves -1, which classify_build reads as a missing exit code and fails closed.
+INSTALL_EXIT=-1
+BUILD_EXIT=-1
+ARTIFACT_BYTES=0
+
+: > "$STDERR_LOG"
+
+# Installed BEFORE the first command that can fail, so no path skips the sentinel.
+write_result() {{{writer}}}
+trap write_result EXIT
+
+cd "$PROJECT" || exit 1
+
+timeout {timeout_seconds}s {install_command} >>"$STDERR_LOG" 2>&1
+INSTALL_EXIT=$?
+if [ "$INSTALL_EXIT" -ne 0 ]; then
+  exit "$INSTALL_EXIT"
+fi
+
+timeout {timeout_seconds}s {build_command} >>"$STDERR_LOG" 2>&1
+BUILD_EXIT=$?
+if [ "$BUILD_EXIT" -ne 0 ]; then
+  exit "$BUILD_EXIT"
+fi
+
+{tar_cmd} >>"$STDERR_LOG" 2>&1
+if [ -f "$ARTIFACT" ]; then
+  ARTIFACT_BYTES=$(wc -c < "$ARTIFACT" | tr -d '[:space:]')
+fi
+
+exit 0
+"""
+
+
+__all__ = [
+    "BUILD_RESULT_FILENAME",
+    "SENTINEL_SCHEMA",
+    "STDERR_TAIL_BYTES",
+    "TIMEOUT_FLOOR_SECONDS",
+    "TIMEOUT_SAFETY_FACTOR",
+    "BuildClassification",
+    "BuildOutcome",
+    "artifact_tar_command",
+    "build_timeout_seconds",
+    "build_wrapper_script",
+    "classify_build",
+]

--- a/ee/pocketpaw_ee/sites/daytona_runner.py
+++ b/ee/pocketpaw_ee/sites/daytona_runner.py
@@ -28,25 +28,30 @@
 # │ INVARIANT — THIS LANE NEVER SNAPSHOTS THE SANDBOX.                                │
 # └───────────────────────────────────────────────────────────────────────────────────┘
 #
-# Load-bearing, and specifically load-bearing FOR SVELTE — not a general principle.
+# HISTORY, because the reason CHANGED and the rule did not. This invariant was
+# originally load-bearing for a specific secret: a svelte project carried
+# ``__CAPTURE_SIGNED_KEY__`` substituted into ``src/routes/api/submit/+server.ts``
+# (verified 2026-08-09 — it was the only file in a generated svelte project containing
+# it), so a per-site secret was uploaded INTO the sandbox on that track. React never had
+# it, having no server route at all. The decision that the exposure was acceptable
+# rested entirely on the key living only in a container that is then destroyed.
 #
-# A svelte project carries ``__CAPTURE_SIGNED_KEY__`` substituted into
-# ``src/routes/api/submit/+server.ts`` (verified 2026-08-09: it is the only file in a
-# generated svelte project containing it). So on the svelte track a per-site secret is
-# uploaded INTO the sandbox. React does not have this problem at all — it has no server
-# route, so no key ever enters its sandbox.
+# Lead capture was then dropped (2026-08-09, captain: do not serve ``/api/submit``), so
+# no route and no key enters any sandbox on either engine, and that specific
+# justification is gone.
 #
-# The decision that this exposure is acceptable (SR-3) rests entirely on the key living
-# only in an ephemeral container that is then destroyed. A snapshot would persist it
-# into blob storage and convert a bounded, transient exposure into a durable one —
-# which is the exact case the condition was written to prevent (compare
-# ``websandbox/provision.py:51``, where a credential in a VM's git config persists into
-# snapshots).
+# THE RULE STAYS ANYWAY, on two grounds that do not depend on it:
+#   1. Build inputs are customer content. A snapshot moves them from an ephemeral
+#      container into durable blob storage, which is a different data-residency
+#      question than the one this lane was cleared for (SG-0 conditions 4 and 6).
+#   2. Lead capture is "we will see what we can do about leads" — not deleted forever.
+#      If a server route returns, the secret returns with it, and an invariant quietly
+#      dropped in the meantime would not come back on its own.
 #
-# CACHING ``node_modules`` IN A SNAPSHOT IS THE OBVIOUS OPTIMISATION HERE, and it is
-# the thing that would silently undo the reasoning above. If you are reading this
-# because you were about to do that: the security decision has to be re-made first, not
-# inherited.
+# CACHING ``node_modules`` IN A SNAPSHOT IS THE OBVIOUS OPTIMISATION HERE, and it is the
+# thing that would undo this. If you are reading this because you were about to do it:
+# re-make the decision on the two grounds above rather than noting that the signed key
+# is gone.
 from __future__ import annotations
 
 import logging

--- a/ee/pocketpaw_ee/sites/daytona_runner.py
+++ b/ee/pocketpaw_ee/sites/daytona_runner.py
@@ -24,12 +24,29 @@
 # act on. Deleting after the read costs exactly the same and keeps the stderr. The
 # auto-delete backstop still guarantees no sandbox outlives us if THIS process dies.
 #
-# INVARIANT — THIS LANE NEVER SNAPSHOTS THE SANDBOX. Not an oversight and not merely
-# unnecessary: the SR-3 decision (that a per-site signed key in the build inputs is an
-# acceptable, bounded exposure) rests on the key living only in an ephemeral container
-# that is then destroyed. A snapshot would persist it into blob storage and turn a
-# transient exposure into a durable one. If anyone later wants to cache node_modules
-# in a snapshot to cut install time, that decision has to be re-made first.
+# ┌───────────────────────────────────────────────────────────────────────────────────┐
+# │ INVARIANT — THIS LANE NEVER SNAPSHOTS THE SANDBOX.                                │
+# └───────────────────────────────────────────────────────────────────────────────────┘
+#
+# Load-bearing, and specifically load-bearing FOR SVELTE — not a general principle.
+#
+# A svelte project carries ``__CAPTURE_SIGNED_KEY__`` substituted into
+# ``src/routes/api/submit/+server.ts`` (verified 2026-08-09: it is the only file in a
+# generated svelte project containing it). So on the svelte track a per-site secret is
+# uploaded INTO the sandbox. React does not have this problem at all — it has no server
+# route, so no key ever enters its sandbox.
+#
+# The decision that this exposure is acceptable (SR-3) rests entirely on the key living
+# only in an ephemeral container that is then destroyed. A snapshot would persist it
+# into blob storage and convert a bounded, transient exposure into a durable one —
+# which is the exact case the condition was written to prevent (compare
+# ``websandbox/provision.py:51``, where a credential in a VM's git config persists into
+# snapshots).
+#
+# CACHING ``node_modules`` IN A SNAPSHOT IS THE OBVIOUS OPTIMISATION HERE, and it is
+# the thing that would silently undo the reasoning above. If you are reading this
+# because you were about to do that: the security decision has to be re-made first, not
+# inherited.
 from __future__ import annotations
 
 import logging

--- a/ee/pocketpaw_ee/sites/daytona_runner.py
+++ b/ee/pocketpaw_ee/sites/daytona_runner.py
@@ -68,6 +68,12 @@
 # or inject them at deploy via wrangler ``[vars]``. Today's protection is the accident that
 # nothing calls ``run_build``.
 #
+# Recorded as an OBLIGATION, not a note, in the proving-phase findings record — see §9a of
+# ``docs/design/drafts/2026-08-09-sites-proving-SG12-findings.md`` in paw-workspace, which
+# also carries the three options and why patching the built output is the worst of them.
+# Cross-referenced deliberately: whoever finds this header while about to add a caller
+# should land on the obligation, not just on the history of a corrected claim.
+#
 # CACHING ``node_modules`` IN A SNAPSHOT IS THE OBVIOUS OPTIMISATION HERE, and it is the
 # thing that would undo this. If you are reading this because you were about to do it: the
 # primary reason above is live, so re-make the security decision first — do not reason from

--- a/ee/pocketpaw_ee/sites/daytona_runner.py
+++ b/ee/pocketpaw_ee/sites/daytona_runner.py
@@ -1,0 +1,315 @@
+# ee/pocketpaw_ee/sites/daytona_runner.py — drives one ephemeral Daytona build
+# round-trip: create → upload → build → read the sentinel → extract → delete.
+#
+# Created 2026-08-09 (SG-9i slice 1). The decision procedure lives next door in
+# ``daytona_build.py`` as pure functions; this module is the I/O half that feeds it.
+# Split that way on purpose: the part that must be right (what happened, and who is
+# to blame) is testable without a sandbox, and this part is testable with a fake
+# client.
+#
+# THE ORDER OF STEPS IS THE CONTRACT, not an implementation detail:
+#
+#   1. Our clock starts BEFORE ``create_sandbox``. It is the only timing signal that
+#      survives the sandbox's death, and it is what separates a timeout from an
+#      eviction when no sentinel comes back.
+#   2. The sentinel is read BEFORE any teardown. Once the sandbox is gone the
+#      evidence is gone with it, and "not found" cannot distinguish "deleted
+#      normally" from "died and was reaped".
+#   3. Teardown is EXPLICIT and in a ``finally``, with Daytona's own auto-delete as a
+#      backstop rather than the primary mechanism (see ``_lifecycle_minutes``).
+#
+# WHY NOT LET THE SANDBOX SELF-DELETE UNCONDITIONALLY, which is the literal ruling:
+# an unconditional immediate self-delete also destroys the build log, so a genuine
+# build failure would reach the user as "your site failed to build" with no reason to
+# act on. Deleting after the read costs exactly the same and keeps the stderr. The
+# auto-delete backstop still guarantees no sandbox outlives us if THIS process dies.
+#
+# INVARIANT — THIS LANE NEVER SNAPSHOTS THE SANDBOX. Not an oversight and not merely
+# unnecessary: the SR-3 decision (that a per-site signed key in the build inputs is an
+# acceptable, bounded exposure) rests on the key living only in an ephemeral container
+# that is then destroyed. A snapshot would persist it into blob storage and turn a
+# transient exposure into a durable one. If anyone later wants to cache node_modules
+# in a snapshot to cut install time, that decision has to be re-made first.
+from __future__ import annotations
+
+import logging
+import math
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from pocketpaw_ee.sites.daytona_build import (
+    BUILD_RESULT_FILENAME,
+    BuildClassification,
+    artifact_tar_command,
+    build_wrapper_script,
+    classify_build,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from pocketpaw_ee.cloud.daytona.client import DaytonaClient
+
+logger = logging.getLogger(__name__)
+
+#: Where the project is materialized inside the sandbox. Under the image's workdir
+#: (``/home/daytona``) so it is writable by the sandbox user without a chown.
+SANDBOX_PROJECT_DIR = "/home/daytona/paw-build"
+
+#: Where the wrapper and the packed artifact live. ``/tmp`` on purpose: neither is
+#: part of the project, and keeping them out of it means the include-list tar cannot
+#: accidentally pick them up.
+SANDBOX_WRAPPER_PATH = "/tmp/paw-build.sh"
+SANDBOX_ARTIFACT_PATH = "/tmp/paw-artifact.tgz"
+
+#: Seconds added to the in-sandbox timeout for our own ``execute_command`` budget.
+#: The inner ``timeout(1)`` should always fire first, because that path still runs the
+#: trap and produces a sentinel; ours is only the backstop for a sandbox that has
+#: stopped responding altogether. If they were equal, a race would decide whether we
+#: get evidence.
+EXEC_TIMEOUT_SLACK_SECONDS = 120
+
+#: Minutes of headroom between the build's own timeout and Daytona's idle auto-stop.
+_LIFECYCLE_MARGIN_MINUTES = 10
+
+
+def _lifecycle_minutes(timeout_seconds: int) -> int:
+    """Idle auto-stop window, in MINUTES, for a build sandbox.
+
+    Derived from the build timeout rather than a constant, because a fixed value is
+    wrong in the dangerous direction: an auto-stop shorter than the build would kill
+    healthy long builds, and Daytona counts *inactivity* — which a long ``bun install``
+    with no API traffic may well look like. So the window always exceeds the build's
+    own budget with margin.
+
+    Note the SDK counts this in minutes while every timeout in this lane is in
+    seconds; conflating them is how the shipped default became 60 HOURS (see
+    ``DaytonaClient.create_sandbox``'s docstring).
+    """
+    return math.ceil(timeout_seconds / 60) + _LIFECYCLE_MARGIN_MINUTES
+
+
+@dataclass(frozen=True)
+class BuildTimings:
+    """Measured wall-clock per phase, in seconds. These are the S / U / (I+B) / D
+    terms the cost model and the timeout formula both consume."""
+
+    create_seconds: float
+    upload_seconds: float
+    exec_seconds: float
+    extract_seconds: float
+    total_seconds: float
+
+    def as_dict(self) -> dict[str, float]:
+        return {
+            "S_create": round(self.create_seconds, 2),
+            "U_upload": round(self.upload_seconds, 2),
+            "IB_exec": round(self.exec_seconds, 2),
+            "D_extract": round(self.extract_seconds, 2),
+            "total": round(self.total_seconds, 2),
+        }
+
+
+@dataclass(frozen=True)
+class BuildRunResult:
+    classification: BuildClassification
+    timings: BuildTimings
+    artifact: bytes | None
+    artifact_bytes: int
+    sandbox_id: str | None
+    sandbox_deleted: bool
+
+    @property
+    def ok(self) -> bool:
+        return self.classification.deployable and self.artifact_bytes > 0
+
+
+async def _read_sentinel(client: DaytonaClient, sandbox_id: str) -> bytes | None:
+    """Read the result sentinel, or ``None`` when it cannot be read.
+
+    Every failure here — file absent, sandbox already gone, transport error — maps to
+    ``None``, which the classifier reads as "the build did not prove it completed".
+    That is the correct reading in all of those cases, so there is nothing to
+    distinguish and no reason to raise.
+    """
+    remote = f"{SANDBOX_PROJECT_DIR}/{BUILD_RESULT_FILENAME}"
+    try:
+        return await client.download_file(sandbox_id, remote)
+    except Exception as exc:  # noqa: BLE001 — any failure means "no evidence"
+        logger.info("daytona_runner: no sentinel readable from %s (%s)", sandbox_id, exc)
+        return None
+
+
+async def run_build(
+    files: dict[str, str | bytes],
+    *,
+    engine: str,
+    timeout_seconds: int,
+    client: DaytonaClient | None = None,
+    sandbox_name: str | None = None,
+    cpu: int = 2,
+    memory_gb: int = 4,
+    disk_gb: int = 10,
+    install_command: str = "bun install",
+    build_command: str = "bun run build",
+) -> BuildRunResult:
+    """Build ``files`` in a fresh Daytona sandbox and return the verdict + artifact.
+
+    ``files`` is a ``{relative_path: contents}`` map — the same shape a source-engine
+    pocket stores, so the generator's output can be passed straight through with no
+    intermediate temp directory.
+
+    ``timeout_seconds`` is a parameter and deliberately has no default: the value comes
+    from ``daytona_build.build_timeout_seconds`` over measured p95s, and baking a guess
+    in here would quietly become the real policy.
+
+    Never raises for a build outcome — a failed build, a timeout and a lost sandbox are
+    all *results*, and the caller needs the classification to decide between reporting
+    and retrying. It may still raise if the sandbox cannot be created at all, which is
+    a distinct condition the caller must handle as retryable (nothing has run yet).
+    """
+    if client is None:
+        from pocketpaw_ee.cloud.daytona.client import get_daytona_client
+
+        client = get_daytona_client()
+        if client is None:
+            raise RuntimeError(
+                "Daytona is not configured (DAYTONA_API_URL / DAYTONA_API_KEY unset)"
+            )
+
+    wrapper = build_wrapper_script(
+        engine,
+        SANDBOX_PROJECT_DIR,
+        timeout_seconds=timeout_seconds,
+        artifact_path=SANDBOX_ARTIFACT_PATH,
+        install_command=install_command,
+        build_command=build_command,
+    )
+    # Rendered here rather than inside the wrapper so an engine whose output is the
+    # project root fails BEFORE a sandbox is created and billed.
+    artifact_tar_command(engine, SANDBOX_PROJECT_DIR, SANDBOX_ARTIFACT_PATH)
+
+    name = sandbox_name or f"paw-build-{int(time.time() * 1000)}"
+    idle_minutes = _lifecycle_minutes(timeout_seconds)
+
+    # ── The clock starts here, before anything exists. ──────────────────────
+    t_start = time.monotonic()
+    sandbox_id: str | None = None
+    deleted = False
+    t_created = t_uploaded = t_exec_done = t_extracted = t_start
+
+    try:
+        info = await client.create_sandbox(
+            name=name,
+            cpu=cpu,
+            memory=memory_gb,
+            disk=disk_gb,
+            # Idle auto-stop EXCEEDS the build budget (see _lifecycle_minutes).
+            auto_stop_interval=idle_minutes,
+            # 0 = delete immediately on stop. This is the BACKSTOP for our own process
+            # dying, not the primary teardown — the explicit delete below is.
+            auto_delete_interval=0,
+        )
+        sandbox_id = info.id
+        await client.wait_for_sandbox(sandbox_id, target_state="started")
+        t_created = time.monotonic()
+
+        uploads: list[tuple[str | bytes, str]] = [
+            (
+                contents.encode() if isinstance(contents, str) else contents,
+                f"{SANDBOX_PROJECT_DIR}/{rel}",
+            )
+            for rel, contents in files.items()
+        ]
+        uploads.append((wrapper.encode(), SANDBOX_WRAPPER_PATH))
+        await client.bulk_upload(sandbox_id, uploads)
+        t_uploaded = time.monotonic()
+
+        # Our budget is deliberately LOOSER than the in-sandbox one, so the inner
+        # timeout wins the race and we get a sentinel instead of a bare exec failure.
+        try:
+            await client.execute_command(
+                sandbox_id,
+                f"bash {SANDBOX_WRAPPER_PATH}",
+                timeout=timeout_seconds + EXEC_TIMEOUT_SLACK_SECONDS,
+            )
+        except Exception as exc:  # noqa: BLE001
+            # NOT fatal, and this is the crux: an exec that raises is exactly what
+            # both a real build failure and a dead sandbox look like. We do not guess
+            # here — we go read the sentinel and let the evidence decide.
+            logger.info("daytona_runner: exec did not return cleanly (%s)", exc)
+        t_exec_done = time.monotonic()
+
+        # ── Read the evidence BEFORE teardown. ─────────────────────────────
+        sentinel = await _read_sentinel(client, sandbox_id)
+        elapsed = time.monotonic() - t_start
+        classification = classify_build(
+            sentinel, elapsed_seconds=elapsed, timeout_seconds=timeout_seconds
+        )
+
+        artifact: bytes | None = None
+        if classification.deployable:
+            try:
+                artifact = await client.download_file(sandbox_id, SANDBOX_ARTIFACT_PATH)
+            except Exception as exc:  # noqa: BLE001
+                # The sentinel said the artifact existed and was non-empty, so failing
+                # to fetch it is transport loss, not a build problem.
+                logger.warning("daytona_runner: artifact download failed (%s)", exc)
+                classification = BuildClassification(
+                    outcome="infra_lost",
+                    reason="artifact_download_failed",
+                    retryable=True,
+                    blames_user=False,
+                    stderr_tail=classification.stderr_tail,
+                )
+        t_extracted = time.monotonic()
+    finally:
+        # Explicit teardown. Swallows its own errors: a delete that fails must not mask
+        # the build result, and the auto-delete backstop still reaps the sandbox.
+        #
+        # Deliberately NOT recorded in module state. An earlier draft stashed the
+        # delete outcome in a module-level dict so it could be folded into the return
+        # value after the ``finally`` ran — which would have been a real bug in exactly
+        # this lane, since the whole point of the concurrency ceiling is that several
+        # builds run at once and would have raced on that dict. Assembling the result
+        # AFTER the try/finally gets the same information with no shared state.
+        if sandbox_id is not None:
+            try:
+                await client.delete_sandbox(sandbox_id)
+                deleted = True
+                logger.info("daytona_runner: deleted sandbox %s", sandbox_id)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "daytona_runner: explicit delete of %s failed (%s); "
+                    "auto_delete_interval=0 remains the backstop",
+                    sandbox_id,
+                    exc,
+                )
+
+    # Reached only when the try-block completed: an exception during create/upload
+    # propagates through the ``finally`` and never gets here, which is correct — there
+    # is no build result to report for a sandbox that never ran anything.
+    return BuildRunResult(
+        classification=classification,
+        timings=BuildTimings(
+            create_seconds=t_created - t_start,
+            upload_seconds=t_uploaded - t_created,
+            exec_seconds=t_exec_done - t_uploaded,
+            extract_seconds=t_extracted - t_exec_done,
+            total_seconds=t_extracted - t_start,
+        ),
+        artifact=artifact,
+        artifact_bytes=len(artifact) if artifact else 0,
+        sandbox_id=sandbox_id,
+        sandbox_deleted=deleted,
+    )
+
+
+__all__ = [
+    "EXEC_TIMEOUT_SLACK_SECONDS",
+    "SANDBOX_ARTIFACT_PATH",
+    "SANDBOX_PROJECT_DIR",
+    "SANDBOX_WRAPPER_PATH",
+    "BuildRunResult",
+    "BuildTimings",
+    "run_build",
+]

--- a/ee/pocketpaw_ee/sites/daytona_runner.py
+++ b/ee/pocketpaw_ee/sites/daytona_runner.py
@@ -68,6 +68,23 @@
 # or inject them at deploy via wrangler ``[vars]``. Today's protection is the accident that
 # nothing calls ``run_build``.
 #
+# WHAT WOULD ENTER IS NO LONGER AN INFERENCE — it has a filename. A canary build on
+# 2026-08-10 (a real generated svelte project built with a marked
+# ``capture_signed_key``, run by SG-7) found the key in
+# ``src/routes/api/submit/+server.ts`` — i.e. in the source map this runner UPLOADS — and
+# compiled into ``.svelte-kit/output/server/entries/endpoints/api/submit/_server.ts.js``.
+# The contract above is therefore checkable rather than merely cautionary: the file is
+# known by name before anyone writes the wiring.
+#
+# THE SAME CANARY FOUND THE KEY NOWHERE IN THE DEPLOYABLE ARTIFACT
+# (``.svelte-kit/cloudflare/``), including under ``_app/`` on the widest client-bundle
+# setting. DO NOT read that as reassurance about this lane. The key is absent from the
+# artifact because the compiled server route is absent from it — and that same missing file
+# is what the shipped ``_worker.js`` imports (``./../output/server/index.js``, verified on
+# a local adapter-cloudflare build). So the svelte artifact this lane tars CANNOT EXECUTE.
+# The security pass and the correctness bug are one fact; see §8 item 14 of the findings
+# record cited below.
+#
 # Recorded as an OBLIGATION, not a note, in the proving-phase findings record — see §9a of
 # ``docs/design/drafts/2026-08-09-sites-proving-SG12-findings.md`` in paw-workspace, which
 # also carries the three options and why patching the built output is the worst of them.

--- a/ee/pocketpaw_ee/sites/daytona_runner.py
+++ b/ee/pocketpaw_ee/sites/daytona_runner.py
@@ -28,30 +28,50 @@
 # │ INVARIANT — THIS LANE NEVER SNAPSHOTS THE SANDBOX.                                │
 # └───────────────────────────────────────────────────────────────────────────────────┘
 #
-# HISTORY, because the reason CHANGED and the rule did not. This invariant was
-# originally load-bearing for a specific secret: a svelte project carried
-# ``__CAPTURE_SIGNED_KEY__`` substituted into ``src/routes/api/submit/+server.ts``
-# (verified 2026-08-09 — it was the only file in a generated svelte project containing
-# it), so a per-site secret was uploaded INTO the sandbox on that track. React never had
-# it, having no server route at all. The decision that the exposure was acceptable
-# rested entirely on the key living only in a container that is then destroyed.
+# THE PRIMARY REASON IS LIVE. A svelte project carries ``__CAPTURE_SIGNED_KEY__``
+# substituted into ``src/routes/api/submit/+server.ts`` — a real per-site secret, minted at
+# ``sites/service.py:1068`` and substituted by ``paw-sites/src/scaffold.ts:71`` (and again
+# for the dynamic track at ``dynamic-scaffold.ts:232``). React has no server route and so
+# no key. The decision that this exposure is acceptable rests ENTIRELY on the key living
+# only in a container that is then destroyed. A snapshot would make it durable.
 #
-# Lead capture was then dropped (2026-08-09, captain: do not serve ``/api/submit``), so
-# no route and no key enters any sandbox on either engine, and that specific
-# justification is gone.
+# ── CORRECTION, 2026-08-09. This header previously said the opposite. ────────────────
 #
-# THE RULE STAYS ANYWAY, on two grounds that do not depend on it:
+# It read: *"Lead capture was then dropped (captain: do not serve ``/api/submit``), so no
+# route and no key enters any sandbox on either engine, and that specific justification is
+# gone."* Quoted rather than deleted, because a reader one ``git blame`` away should be able
+# to see the correction happened rather than assume the header was always right.
+#
+# THAT WAS FALSE, and the distinction is the whole lesson. The captain's ruling was about
+# SERVING ``/api/submit``, not about GENERATING it, and it was never implemented in the
+# generator: the route template still exists and the key is still substituted into every
+# svelte build. What WAS true is narrower — no key enters a DAYTONA sandbox today, but only
+# because NOTHING does, since this lane has no callers yet. That narrow truth was
+# generalised into a claim about "either engine", which is false about the path that
+# actually runs.
+#
+# THE GAP WORTH REMEMBERING: the distance between "the captain decided X" and "X is true of
+# the artifact" was ONE GREP, and nobody ran it for several turns — including the author of
+# this header, while writing this header. A decision reported as made arrives formatted as a
+# fact about the code. It is not one until you have looked.
+#
+# TWO FURTHER GROUNDS, now ADDITIONAL rather than replacements:
 #   1. Build inputs are customer content. A snapshot moves them from an ephemeral
 #      container into durable blob storage, which is a different data-residency
 #      question than the one this lane was cleared for (SG-0 conditions 4 and 6).
 #   2. Lead capture is "we will see what we can do about leads" — not deleted forever.
-#      If a server route returns, the secret returns with it, and an invariant quietly
-#      dropped in the meantime would not come back on its own.
+#      Even once the generator does stop emitting the route, a returning server route
+#      brings the secret back with it.
+#
+# WIRING CONTRACT THIS IMPLIES: the moment this lane gets callers, the key enters the
+# sandbox unless the wiring strips it — substitute the tokens after the artifact returns,
+# or inject them at deploy via wrangler ``[vars]``. Today's protection is the accident that
+# nothing calls ``run_build``.
 #
 # CACHING ``node_modules`` IN A SNAPSHOT IS THE OBVIOUS OPTIMISATION HERE, and it is the
-# thing that would undo this. If you are reading this because you were about to do it:
-# re-make the decision on the two grounds above rather than noting that the signed key
-# is gone.
+# thing that would undo this. If you are reading this because you were about to do it: the
+# primary reason above is live, so re-make the security decision first — do not reason from
+# the retracted claim that the signed key is gone.
 from __future__ import annotations
 
 import logging

--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -205,6 +205,24 @@ class SiteResponse(BaseModel):
     # caller can poll the job. None for a static publish, and None on a single-flight
     # no-op (a second publish while already provisioning does not enqueue a job).
     provision_job_id: str | None = None
+    # ── SG-9i: the ephemeral-build lane's state, on the wire ────────────────
+    # ``build_status`` — none | queued | building | built | failed.
+    #
+    # ``queued`` is the reason this pair exists at all. Once builds run in an ephemeral
+    # sandbox behind a concurrency cap, a publish can WAIT before it starts, and a
+    # queued build is indistinguishable from a hung one unless the wire says which it
+    # is. Without this the cap converts a crash into a support ticket.
+    #
+    # A client MUST treat an unrecognised status as in-progress rather than as an
+    # error: this vocabulary will grow, and a client that errors on unknown values
+    # turns every future state addition into a visible outage.
+    build_status: str = "none"
+    # The build job's id, so a caller can poll it. Unlike ``provision_job_id`` — which
+    # comes from a transient PrivateAttr and therefore only exists on the response that
+    # enqueued it — this is read from a PERSISTED field, so a client that reloads mid-
+    # build still gets it. That matters precisely because a queued build is the case
+    # where the user reloads.
+    build_job_id: str | None = None
     # SI-4: the persisted import summary for an IMPORTED site — {pages: [{path,
     # title}], asset_count, asset_bytes, forms: [{page, original_action, rewired}],
     # scripts, warnings} (from-url adds status/source_url). None for every

--- a/scripts/mutate.py
+++ b/scripts/mutate.py
@@ -46,9 +46,17 @@ the tests mid-sweep, saw a bun-PATH assertion fail, and reported it as a
 regression. It was this script, working correctly.
 
 So a sweep now leaves ``.mutation-sweep-active`` at the repo root for its
-duration, naming the plan, the PID and the mutation currently applied. It is
-removed by the same ``finally`` that restores the files, and a pre-existing
-marker is reported on the next start rather than silently overwritten.
+duration, naming the plan and the mutation currently applied. It is removed by
+the same ``finally`` that restores the files.
+
+AND A PRE-EXISTING MARKER REFUSES THE RUN, rather than warning and continuing.
+That is not caution for its own sake — continuing is the step that makes a
+crashed sweep's damage permanent. This script snapshots each file's CURRENT bytes
+as "the original", so if a previous run died with a file mutated, the next run
+adopts the mutation as the original and faithfully restores it forever, then
+deletes the marker that was the only evidence. Two files in this repo were found
+in exactly that state. ``--force`` is the escape hatch, for a marker whose files
+have already been verified clean.
 
 The marker IS gitignored — a sweep artifact must never be committable. Discovery
 therefore does not rely on ``git status``: ``tests/conftest.py`` prints a loud
@@ -110,9 +118,15 @@ def _write_marker(plan: Path, current: str | None) -> None:
         "later. Do not report them as regressions; re-run once this file is gone.",
         "",
         f"plan    : {plan}",
-        f"pid     : {os.getpid()}",
+        f"pid     : {os.getpid()}   (INFORMATIONAL ONLY - see below)",
         f"started : {datetime.now(UTC).isoformat(timespec='seconds')}",
         f"current : {current or '(validating the plan)'}",
+        "",
+        "THE PRESENCE OF THIS FILE IS THE AUTHORITATIVE SIGNAL. Do not decide",
+        '"live vs stranded" from the pid: checking it is racy (the process can exit',
+        "between reading this file and looking the pid up), and a dead-looking pid",
+        "on a live sweep is exactly the combination that gets someone to clobber a",
+        "running job. Treat this file as busy until it disappears.",
         "",
         "If this file outlived its sweep, a run crashed hard. Check `git status`/",
         "`git diff` for a file left mutated, then delete this file.",
@@ -159,37 +173,69 @@ def marker_age(text: str, *, now: datetime | None = None) -> timedelta | None:
     return None
 
 
-def _warn_if_stale_marker() -> None:
-    """Report a pre-existing marker instead of silently overwriting it.
+def _refuse_on_existing_marker(*, force: bool) -> None:
+    """REFUSE to run when a marker already exists, unless explicitly forced.
 
-    Silently reusing it would hide the one case where a file may STILL be mutated on
-    disk — the failure mode this script's restoration discipline exists to prevent — so
-    it is always loud. The AGE only changes which of two very different things it says:
+    This used to only warn, and warning is not enough — the failure it must stop is both
+    worse than a confusing test run and completely silent.
 
-    * recent (or undatable) -> another sweep may be running RIGHT NOW, in which case
-      this run would fight it over the same files and both results are worthless.
-    * older than ``STALE_MARKER_AFTER`` -> abandoned by a crashed run, safe to proceed,
-      but a file may have been left mutated so the diff is worth a look.
+    THE FAILURE, observed for real on 2026-08-09. Sweep A is killed hard, leaving a file
+    mutated and the marker behind. Sweep B starts and reads its ``originals`` snapshot
+    FROM DISK — which now contains A's mutation — runs, and on the way out faithfully
+    "restores" that mutation as though it were the original. B's cleanup then deletes the
+    marker, destroying the only remaining evidence. The mutation is now permanent,
+    indistinguishable from real code, and nothing will ever warn about it again. Two
+    files in this repo were found in exactly that state with no marker left to explain
+    them.
+
+    So a second run must not proceed on its own judgement: PROCEEDING IS THE STEP THAT
+    BAKES THE MUTATION IN. The operator has to look at the diff first — seconds of work,
+    and the only thing that distinguishes "a crashed sweep left junk" from "this is real
+    code".
+
+    Refusing also must not delete the marker: it is the only thing that explains a
+    mutated file, so destroying it here would reproduce the incident.
+
+    ``--force`` covers the one legitimate case — a marker whose files are already
+    verified clean — and is deliberately awkward to reach for.
     """
     if not MARKER_PATH.exists():
         return
     try:
-        age = marker_age(MARKER_PATH.read_text(encoding="utf-8"))
+        text = MARKER_PATH.read_text(encoding="utf-8")
     except OSError:
-        age = None
+        text = ""
+    age = marker_age(text)
+    age_note = (
+        f"{int(age.total_seconds() // 60)}m old"
+        if age is not None
+        else "undatable (treat as possibly live)"
+    )
+    live_or_dead = (
+        "A PREVIOUS SWEEP CRASHED without cleaning up."
+        if age is not None and age > STALE_MARKER_AFTER
+        else "ANOTHER SWEEP MAY BE RUNNING RIGHT NOW."
+    )
 
-    if age is not None and age > STALE_MARKER_AFTER:
-        print(
-            f"NOTE: {MARKER_PATH.name} is {int(age.total_seconds() // 60)}m old — a previous\n"
-            "      sweep crashed without cleaning up. Proceeding, but check `git diff`:\n"
-            "      that run may have left a file mutated.\n"
-        )
+    if force:
+        print(f"NOTE: proceeding past {MARKER_PATH.name} ({age_note}) because --force was given.\n")
         return
 
-    print(
-        f"WARNING: {MARKER_PATH.name} exists and is recent — ANOTHER SWEEP MAY BE RUNNING.\n"
-        "         Two sweeps mutating the same files produce meaningless results for both.\n"
-        "         Check for a live run before trusting anything this prints.\n"
+    raise SystemExit(
+        f"REFUSING TO RUN: {MARKER_PATH.name} already exists ({age_note}).\n"
+        f"  {live_or_dead}\n"
+        "\n"
+        "  Running now is not safe. This script snapshots each file's CURRENT bytes as\n"
+        "  the original, so if a crashed sweep left a file mutated, this run would treat\n"
+        "  that mutation as the original and restore it permanently.\n"
+        "\n"
+        "  Do this instead:\n"
+        "    1. git status / git diff     <- look for a file left mutated\n"
+        "    2. git checkout -- <file>   <- restore anything that is a mutation\n"
+        f"    3. rm {MARKER_PATH.name}\n"
+        "    4. re-run\n"
+        "\n"
+        "  If you have already verified the tree is clean, pass --force.\n"
     )
 
 
@@ -235,6 +281,11 @@ def main() -> int:
     parser.add_argument("--plan", required=True, type=Path, help="path to a JSON mutation plan")
     parser.add_argument("--only", default="", help="run only mutations whose label contains this")
     parser.add_argument("--list", action="store_true", help="print the plan's mutations and exit")
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="run despite an existing sweep marker (only after verifying the tree is clean)",
+    )
     args = parser.parse_args()
 
     mutations = _load_plan(args.plan if args.plan.is_absolute() else REPO_ROOT / args.plan)
@@ -248,7 +299,7 @@ def main() -> int:
             print(f"  {m.label}  ->  {m.file.relative_to(REPO_ROOT)}")
         return 0
 
-    _warn_if_stale_marker()
+    _refuse_on_existing_marker(force=args.force)
     _write_marker(args.plan, None)
     # Registered IMMEDIATELY after the marker exists, and via atexit rather than the
     # try/finally below, because the upfront plan validation raises SystemExit — which

--- a/scripts/mutate.py
+++ b/scripts/mutate.py
@@ -47,10 +47,14 @@ regression. It was this script, working correctly.
 
 So a sweep now leaves ``.mutation-sweep-active`` at the repo root for its
 duration, naming the plan, the PID and the mutation currently applied. It is
-deliberately NOT gitignored: the point is that ``git status`` surfaces it, so a
-second reader has something to see. It is removed by the same ``finally`` that
-restores the files, and a leftover marker from a crashed run is reported on the
-next start rather than silently overwritten.
+removed by the same ``finally`` that restores the files, and a pre-existing
+marker is reported on the next start rather than silently overwritten.
+
+The marker IS gitignored — a sweep artifact must never be committable. Discovery
+therefore does not rely on ``git status``: ``tests/conftest.py`` prints a loud
+banner in pytest's own report header whenever the marker exists, which is the
+path a reader actually takes. Someone chasing a failure runs the suite; they may
+never run ``git status`` at all.
 
 PLAN FORMAT — a JSON list of objects:
 
@@ -78,14 +82,15 @@ import os
 import signal
 import subprocess
 import sys
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 #: Written for the duration of a sweep so a CONCURRENT reader can tell that a test
-#: failure is a live mutation rather than a regression. Not gitignored on purpose —
-#: ``git status`` surfacing it is the entire mechanism.
+#: failure is a live mutation rather than a regression. Gitignored (a sweep artifact
+#: must never be committable); the reader-facing signal is the pytest report-header
+#: banner in ``tests/conftest.py``, which fires on the path a reader actually takes.
 MARKER_PATH = REPO_ROOT / ".mutation-sweep-active"
 
 
@@ -126,19 +131,65 @@ def _clear_marker() -> None:
         pass
 
 
+#: Past this age a marker is treated as definitely abandoned rather than possibly live.
+#: A sweep is bounded by (mutations x test-suite time) and the plans in this repo finish
+#: in seconds to a couple of minutes, so an hour is already far outside any real run.
+#: Erring LONG is deliberate: calling a live sweep "stale" is the expensive mistake,
+#: because it tells a reader to trust results taken while a file was mutated. Calling an
+#: abandoned one "possibly live" only costs someone a wait.
+STALE_MARKER_AFTER = timedelta(hours=1)
+
+
+def marker_age(text: str, *, now: datetime | None = None) -> timedelta | None:
+    """Age of a marker from its ``started :`` line, or ``None`` if undatable.
+
+    Undatable reads as ``None`` and callers treat that as POSSIBLY LIVE, not as stale —
+    a marker we cannot date is exactly when we should be most cautious.
+    """
+    for line in text.splitlines():
+        if line.startswith("started"):
+            _, _, stamp = line.partition(":")
+            try:
+                started = datetime.fromisoformat(stamp.strip())
+            except ValueError:
+                return None
+            if started.tzinfo is None:
+                started = started.replace(tzinfo=UTC)
+            return (now or datetime.now(UTC)) - started
+    return None
+
+
 def _warn_if_stale_marker() -> None:
-    """Report a marker left behind by a crashed run instead of overwriting it.
+    """Report a pre-existing marker instead of silently overwriting it.
 
     Silently reusing it would hide the one case where a file may STILL be mutated on
-    disk — which is the failure mode this script's restoration discipline exists to
-    prevent, so it must be loud.
+    disk — the failure mode this script's restoration discipline exists to prevent — so
+    it is always loud. The AGE only changes which of two very different things it says:
+
+    * recent (or undatable) -> another sweep may be running RIGHT NOW, in which case
+      this run would fight it over the same files and both results are worthless.
+    * older than ``STALE_MARKER_AFTER`` -> abandoned by a crashed run, safe to proceed,
+      but a file may have been left mutated so the diff is worth a look.
     """
     if not MARKER_PATH.exists():
         return
+    try:
+        age = marker_age(MARKER_PATH.read_text(encoding="utf-8"))
+    except OSError:
+        age = None
+
+    if age is not None and age > STALE_MARKER_AFTER:
+        print(
+            f"NOTE: {MARKER_PATH.name} is {int(age.total_seconds() // 60)}m old — a previous\n"
+            "      sweep crashed without cleaning up. Proceeding, but check `git diff`:\n"
+            "      that run may have left a file mutated.\n"
+        )
+        return
+
     print(
-        f"WARNING: {MARKER_PATH.name} already exists — a previous sweep did not clean up.\n"
-        "         A file may still be mutated on disk. Check `git diff` before trusting\n"
-        "         this run's results.\n"
+        f"WARNING: {MARKER_PATH.name} exists and is recent — ANOTHER SWEEP MAY BE RUNNING.\n"
+        "         Two sweeps mutating the same files produce meaningless results for both.\n"
+        "         Check for a live run before trusting anything this prints.\n"
     )
 
 

--- a/scripts/mutate.py
+++ b/scripts/mutate.py
@@ -37,6 +37,21 @@ once up front, every apply is wrapped in try/finally, SIGINT is trapped, and a
 final pass restores everything again on the way out. A crashed run that left a
 mutated file behind would be a far worse bug than any it could find.
 
+A SWEEP IS INVISIBLE TO EVERYONE ELSE, WHICH BURNED US. Mutations are applied
+IN PLACE, so for the seconds each one is live the working tree genuinely
+contains broken code. Anyone who runs the suite or reads the tree during a
+sweep sees a real failure of code that is about to be restored — and nothing
+distinguishes it from a regression. That happened on 2026-08-09: a reviewer ran
+the tests mid-sweep, saw a bun-PATH assertion fail, and reported it as a
+regression. It was this script, working correctly.
+
+So a sweep now leaves ``.mutation-sweep-active`` at the repo root for its
+duration, naming the plan, the PID and the mutation currently applied. It is
+deliberately NOT gitignored: the point is that ``git status`` surfaces it, so a
+second reader has something to see. It is removed by the same ``finally`` that
+restores the files, and a leftover marker from a crashed run is reported on the
+next start rather than silently overwritten.
+
 PLAN FORMAT — a JSON list of objects:
 
     [
@@ -57,13 +72,74 @@ meaningless result that still looks like a pass.
 from __future__ import annotations
 
 import argparse
+import atexit
 import json
+import os
 import signal
 import subprocess
 import sys
+from datetime import UTC, datetime
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+
+#: Written for the duration of a sweep so a CONCURRENT reader can tell that a test
+#: failure is a live mutation rather than a regression. Not gitignored on purpose —
+#: ``git status`` surfacing it is the entire mechanism.
+MARKER_PATH = REPO_ROOT / ".mutation-sweep-active"
+
+
+def _write_marker(plan: Path, current: str | None) -> None:
+    """Stamp the marker with what is mutated RIGHT NOW.
+
+    Rewritten per mutation rather than once per sweep, because "a sweep is running"
+    is much less useful to a reader than "this exact line in this exact file is
+    currently broken on purpose". Best-effort: a marker that cannot be written must
+    never take down the sweep, since the sweep is the thing with real value.
+    """
+    body = [
+        "A mutation sweep is running in this worktree RIGHT NOW.",
+        "",
+        "Test failures and unexpected file contents are EXPECTED while this file",
+        "exists — mutate.py applies each mutation in place and restores it seconds",
+        "later. Do not report them as regressions; re-run once this file is gone.",
+        "",
+        f"plan    : {plan}",
+        f"pid     : {os.getpid()}",
+        f"started : {datetime.now(UTC).isoformat(timespec='seconds')}",
+        f"current : {current or '(validating the plan)'}",
+        "",
+        "If this file outlived its sweep, a run crashed hard. Check `git status`/",
+        "`git diff` for a file left mutated, then delete this file.",
+    ]
+    try:
+        MARKER_PATH.write_text("\n".join(body) + "\n", encoding="utf-8")
+    except OSError:  # pragma: no cover - best effort by design
+        pass
+
+
+def _clear_marker() -> None:
+    """Remove the marker. Called from the same ``finally`` that restores files."""
+    try:
+        MARKER_PATH.unlink(missing_ok=True)
+    except OSError:  # pragma: no cover - best effort by design
+        pass
+
+
+def _warn_if_stale_marker() -> None:
+    """Report a marker left behind by a crashed run instead of overwriting it.
+
+    Silently reusing it would hide the one case where a file may STILL be mutated on
+    disk — which is the failure mode this script's restoration discipline exists to
+    prevent, so it must be loud.
+    """
+    if not MARKER_PATH.exists():
+        return
+    print(
+        f"WARNING: {MARKER_PATH.name} already exists — a previous sweep did not clean up.\n"
+        "         A file may still be mutated on disk. Check `git diff` before trusting\n"
+        "         this run's results.\n"
+    )
 
 
 class Mutation:
@@ -121,6 +197,15 @@ def main() -> int:
             print(f"  {m.label}  ->  {m.file.relative_to(REPO_ROOT)}")
         return 0
 
+    _warn_if_stale_marker()
+    _write_marker(args.plan, None)
+    # Registered IMMEDIATELY after the marker exists, and via atexit rather than the
+    # try/finally below, because the upfront plan validation raises SystemExit — which
+    # happens BEFORE that try block is entered. Without this, a plan with a bad anchor
+    # would abort correctly and leave a marker claiming a sweep is running forever,
+    # which would then warn on every subsequent run and train people to ignore it.
+    atexit.register(_clear_marker)
+
     # Read every original ONCE, before touching anything. If a file is missing
     # or an anchor is bad, fail before the first mutation rather than half way
     # through a run that then has to unwind.
@@ -142,6 +227,7 @@ def main() -> int:
     def _restore_all(*_signal_args: object) -> None:
         for path, data in originals.items():
             path.write_bytes(data)
+        _clear_marker()
 
     signal.signal(signal.SIGINT, lambda *a: (_restore_all(), sys.exit(130)))
 
@@ -150,6 +236,7 @@ def main() -> int:
         for m in mutations:
             original = originals[m.file]
             mutated = original.decode("utf-8").replace(m.find, m.replace, 1)
+            _write_marker(args.plan, f"{m.label}  [{m.file.relative_to(REPO_ROOT)}]")
             try:
                 m.file.write_bytes(mutated.encode("utf-8"))
                 passed = _run_tests(m.tests)

--- a/scripts/mutate.py
+++ b/scripts/mutate.py
@@ -276,9 +276,149 @@ def _run_tests(targets: list[str]) -> bool:
     return proc.returncode == 0
 
 
+def _marker_field(text: str, name: str) -> str:
+    """Value of a ``name : value`` line in the marker, or ``""``."""
+    for line in text.splitlines():
+        if line.startswith(name):
+            return line.partition(":")[2].strip()
+    return ""
+
+
+def _git(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args], capture_output=True, text=True, cwd=REPO_ROOT, encoding="utf-8"
+    )
+
+
+def restore_from_marker() -> int:
+    """``--restore``: undo what a hard-killed sweep left behind.
+
+    WHY THIS HAS TO EXIST AND CANNOT BE SOLVED IN-PROCESS. A hard kill bypasses both
+    cleanup paths BY CONSTRUCTION — the ``finally`` never runs and neither does the
+    ``atexit`` handler. An agent interrupt is a hard kill; one was observed on
+    2026-08-09, a second after a sweep started, leaving ``daytona_build.py`` carrying the
+    "timeout floor is dropped" mutation and the marker stranded. So in-place restore can
+    never be made crash-safe, and the durable protection can only ever be
+    DETECT-AND-RECOVER. The marker was already the detect half; this is the recover half.
+
+    Restores from GIT, never from an in-memory or on-disk copy — a copy is one more thing
+    that dies with the process, while ``git checkout --`` is idempotent and survives
+    anything.
+
+    REFUSES rather than guesses in the two cases where guessing is destructive:
+
+    * the marker looks LIVE — recovering a running sweep is worse than not recovering a
+      dead one, so the age logic is reused and the bias is toward "leave it alone";
+    * the file carries changes BEYOND the mutation — someone's real edits are mixed in,
+      and this cannot know which lines were theirs. Blowing them away to save three
+      manual steps is a bad trade, so it explains and stops.
+
+    Safe to run blind: no marker means nothing to do and exit 0.
+    """
+    if not MARKER_PATH.exists():
+        print("Nothing to restore: no sweep marker.")
+        return 0
+
+    try:
+        text = MARKER_PATH.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"Cannot read {MARKER_PATH.name}: {exc}")
+        return 1
+
+    age = marker_age(text)
+    if age is None or age <= STALE_MARKER_AFTER:
+        age_note = "undatable" if age is None else f"{int(age.total_seconds() // 60)}m old"
+        print(
+            f"REFUSING: {MARKER_PATH.name} looks LIVE ({age_note}).\n"
+            "  A sweep may be running right now, and restoring under a live sweep would\n"
+            "  fight it over the same file. Wait for the marker to disappear.\n"
+            f"  If you are certain it is abandoned, delete {MARKER_PATH.name} and re-run."
+        )
+        return 1
+
+    current = _marker_field(text, "current")
+    plan_field = _marker_field(text, "plan")
+    if not current or "[" not in current:
+        print(
+            f"Marker names no applied mutation (current: {current!r}).\n"
+            "  The sweep died before applying one, so nothing was mutated. Clearing."
+        )
+        _clear_marker()
+        return 0
+
+    label = current.split("[")[0].strip()
+    rel = current.split("[")[-1].rstrip("]").strip().replace("\\", "/")
+    target = REPO_ROOT / rel
+    print(f"Marker says the live mutation was:\n  {label}\n  in {rel}\n")
+
+    if not target.exists():
+        print(f"REFUSING: {rel} does not exist.")
+        return 1
+
+    head = _git("show", f"HEAD:{rel}")
+    if head.returncode != 0:
+        print(f"REFUSING: cannot read {rel} from HEAD ({head.stderr.strip()}).")
+        return 1
+    head_text = head.stdout
+    current_text = target.read_text(encoding="utf-8")
+
+    if current_text == head_text:
+        print(f"  {rel} already matches HEAD — nothing to restore.")
+        _clear_marker()
+        print(f"\nCleared {MARKER_PATH.name}. Re-run the plan to confirm the gate still fires.")
+        return 0
+
+    # Is the ONLY difference the mutation itself? Un-apply it and compare to HEAD. This is
+    # what distinguishes "sweep debris" from "someone's real edit", and it is exact rather
+    # than heuristic — no line counting, no diff parsing.
+    mutation = None
+    if plan_field:
+        plan_path = Path(plan_field)
+        plan_path = plan_path if plan_path.is_absolute() else REPO_ROOT / plan_path
+        try:
+            for raw in json.loads(plan_path.read_text(encoding="utf-8")):
+                if raw.get("label") == label:
+                    mutation = raw
+                    break
+        except (OSError, json.JSONDecodeError, TypeError):
+            mutation = None
+
+    if mutation is None:
+        print(
+            f"REFUSING: could not find the mutation {label!r} in plan {plan_field!r},\n"
+            f"  so there is no way to prove {rel}'s only change is the mutation.\n"
+            f"  Inspect it yourself: git diff -- {rel}"
+        )
+        return 1
+
+    unapplied = current_text.replace(mutation["replace"], mutation["find"], 1)
+    if unapplied != head_text:
+        print(
+            f"REFUSING: {rel} has changes BEYOND the mutation.\n"
+            "  Someone's real edits are mixed in with sweep debris, and this cannot tell\n"
+            "  which lines are theirs. Restoring would delete real work.\n"
+            f"  Do it by hand: git diff -- {rel}, keep what is yours, drop the mutation."
+        )
+        return 1
+
+    checkout = _git("checkout", "--", rel)
+    if checkout.returncode != 0:
+        print(f"REFUSING: git checkout failed ({checkout.stderr.strip()}).")
+        return 1
+
+    print(f"  RESTORED {rel} from HEAD (the mutation was its only change).")
+    _clear_marker()
+    print(
+        f"  CLEARED  {MARKER_PATH.name}\n"
+        "\nRe-run the plan now. A restore is not proof the gate still catches:\n"
+        f"  uv run python scripts/mutate.py --plan {plan_field}"
+    )
+    return 0
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
-    parser.add_argument("--plan", required=True, type=Path, help="path to a JSON mutation plan")
+    parser.add_argument("--plan", type=Path, help="path to a JSON mutation plan")
     parser.add_argument("--only", default="", help="run only mutations whose label contains this")
     parser.add_argument("--list", action="store_true", help="print the plan's mutations and exit")
     parser.add_argument(
@@ -286,7 +426,19 @@ def main() -> int:
         action="store_true",
         help="run despite an existing sweep marker (only after verifying the tree is clean)",
     )
+    parser.add_argument(
+        "--restore",
+        action="store_true",
+        help="undo what a hard-killed sweep left behind, then clear the marker",
+    )
     args = parser.parse_args()
+
+    # --restore reads the plan path out of the marker, so it needs no --plan. Checked
+    # here rather than with argparse groups so the error names the actual requirement.
+    if args.restore:
+        return restore_from_marker()
+    if args.plan is None:
+        parser.error("--plan is required (or use --restore)")
 
     mutations = _load_plan(args.plan if args.plan.is_absolute() else REPO_ROOT / args.plan)
     if args.only:

--- a/scripts/sg9_daytona_roundtrip.py
+++ b/scripts/sg9_daytona_roundtrip.py
@@ -10,12 +10,24 @@
 #
 # Usage (from the repo root, with DAYTONA_* in .env):
 #
-#     uv run python scripts/sg9_daytona_roundtrip.py <path-to-generated-react-project>
+#     uv run python scripts/sg9_daytona_roundtrip.py <project-dir> [engine] [out.tgz]
+#
+# ``out.tgz`` writes the extracted artifact to disk so it can be inspected — the point
+# of this slice is evidence, and "artifact_bytes > 0" is weaker evidence than a tarball
+# you can list.
+#
+# ``engine`` is react (default) or svelte. Both run bun install + Vite, and extraction
+# is parameterised on ``static_output_rel(engine)`` — react's ``dist`` and svelte's
+# ``.svelte-kit/cloudflare`` — so the build path is identical for both. What is NOT
+# identical is the DEPLOY shape: ``emits_server_worker()`` is False for react and True
+# for svelte, so svelte's output carries a ``_worker.js`` server entry that has to be
+# deployed as a Worker script rather than as static files. Deploy is out of scope here.
 #
 # The project directory should be REAL generator output — produce it with
-# ``materializeReact`` from paw-sites rather than hand-writing one, so the dependency
-# set and the build script are the ones production actually uses (notably the build
-# runs ``bun paw-prerender.mjs``, which is why bun is not optional).
+# ``materializeReact`` (react) or ``scaffoldProject`` + ``materializeSource`` (svelte)
+# from paw-sites rather than hand-writing one, so the dependency set and the build
+# script are the ones production actually uses (notably react's build runs
+# ``bun paw-prerender.mjs``, which is why bun is not optional).
 from __future__ import annotations
 
 import asyncio
@@ -37,7 +49,7 @@ for _stream in (sys.stdout, sys.stderr):
 
 # Text extensions only: the generated react project is all source. A binary asset would
 # need bytes, and bulk_upload accepts them — this probe just does not need it.
-_SKIP_DIRS = {"node_modules", ".git", "dist", ".paw-ssr"}
+_SKIP_DIRS = {"node_modules", ".git", "dist", ".paw-ssr", ".svelte-kit"}
 
 #: Teardown is eventually consistent (see the verification block), so poll rather than
 #: check once. ~30s total is well past the few seconds observed in practice.
@@ -55,6 +67,30 @@ def collect(project: Path) -> dict[str, str | bytes]:
             continue
         files[rel] = path.read_text(encoding="utf-8")
     return files
+
+
+def _describe_artifact(blob: bytes) -> None:
+    """List what actually came back, and check the two things that matter.
+
+    ``node_modules`` absent is the include-list working (it is excluded by construction
+    because the output dir is a subdirectory, not by any filter). ``_worker.js`` present
+    is svelte's server entry — the shape difference react does not have, and the reason
+    svelte cannot be deployed as pure static assets.
+    """
+    import io
+    import tarfile
+
+    with tarfile.open(fileobj=io.BytesIO(blob), mode="r:gz") as tar:
+        names = tar.getnames()
+    workers = [n for n in names if n.endswith("_worker.js")]
+    node_modules = [n for n in names if "node_modules" in n]
+    print(f"  entries: {len(names)}")
+    for name in sorted(names)[:12]:
+        print(f"    {name}")
+    if len(names) > 12:
+        print(f"    ... and {len(names) - 12} more")
+    print(f"  _worker.js       : {workers or 'absent (expected for react)'}")
+    print(f"  node_modules     : {len(node_modules)} entries (must be 0)")
 
 
 def load_env() -> None:
@@ -85,7 +121,11 @@ async def main() -> int:
         print(f"not a directory: {project}")
         return 2
 
-    timeout_seconds = int(os.environ.get("SG9_TIMEOUT_SECONDS", "900"))
+    engine = (sys.argv[2] if len(sys.argv) > 2 else "react").strip().lower()
+
+    from pocketpaw_ee.sites.daytona_build import resolve_build_timeout_seconds
+
+    timeout_seconds = resolve_build_timeout_seconds(engine)
 
     print("=== credentials ===")
     load_env()
@@ -106,19 +146,21 @@ async def main() -> int:
     # closed even when reporting blows up. The first run of this probe leaked one
     # because the close sat after a print that raised.
     try:
-        return await _run_and_report(client, files, timeout_seconds)
+        return await _run_and_report(client, files, timeout_seconds, engine)
     finally:
         await client.close()
 
 
-async def _run_and_report(client: Any, files: dict[str, str | bytes], timeout_seconds: int) -> int:
+async def _run_and_report(
+    client: Any, files: dict[str, str | bytes], timeout_seconds: int, engine: str
+) -> int:
     from pocketpaw_ee.sites.daytona_runner import run_build
 
     print(f"\n=== running (timeout {timeout_seconds}s) ===")
     try:
         result = await run_build(
             files,
-            engine="react",
+            engine=engine,
             timeout_seconds=timeout_seconds,
             client=client,
         )
@@ -137,6 +179,15 @@ async def _run_and_report(client: Any, files: dict[str, str | bytes], timeout_se
     if result.classification.stderr_tail:
         tail = result.classification.stderr_tail[-1500:]
         print(f"\n  --- stderr tail ---\n{tail}")
+
+    # Land the artifact somewhere inspectable. "artifact_bytes > 0" is weaker evidence
+    # than a tarball whose entries can be listed — for svelte in particular, the thing
+    # worth confirming is that ``_worker.js`` came through and ``node_modules`` did not.
+    out_path = sys.argv[3] if len(sys.argv) > 3 else None
+    if out_path and result.artifact:
+        Path(out_path).write_bytes(result.artifact)
+        print(f"\n  artifact written to {out_path}")
+        _describe_artifact(result.artifact)
 
     print("\n=== measured timings (seconds) ===")
     for k, v in result.timings.as_dict().items():

--- a/scripts/sg9_daytona_roundtrip.py
+++ b/scripts/sg9_daytona_roundtrip.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python
+# scripts/sg9_daytona_roundtrip.py — LIVE probe: build a real react project in a real
+# Daytona sandbox and report the measured S / (I+B) / D terms.
+#
+# Created 2026-08-09 (SG-9i slice 1). This is deliberately a script and not a test: it
+# costs sandbox time, needs live credentials, and its output is MEASUREMENTS rather than
+# assertions. The driver's sequencing contract is unit-tested against a fake in
+# tests/ee/sites/test_daytona_runner.py; a fake passing is not evidence the lane works,
+# which is why this exists.
+#
+# Usage (from the repo root, with DAYTONA_* in .env):
+#
+#     uv run python scripts/sg9_daytona_roundtrip.py <path-to-generated-react-project>
+#
+# The project directory should be REAL generator output — produce it with
+# ``materializeReact`` from paw-sites rather than hand-writing one, so the dependency
+# set and the build script are the ones production actually uses (notably the build
+# runs ``bun paw-prerender.mjs``, which is why bun is not optional).
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+# Vite prints U+2713 on success and the Windows console defaults to cp1252, which
+# raises UnicodeEncodeError mid-report — losing the measurements AFTER the build has
+# already been paid for. Reconfigure rather than sanitize each print: the build log is
+# arbitrary third-party output and there is no reason to assume it is ASCII.
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr]
+    except (AttributeError, ValueError):  # pragma: no cover - non-reconfigurable stream
+        pass
+
+# Text extensions only: the generated react project is all source. A binary asset would
+# need bytes, and bulk_upload accepts them — this probe just does not need it.
+_SKIP_DIRS = {"node_modules", ".git", "dist", ".paw-ssr"}
+
+#: Teardown is eventually consistent (see the verification block), so poll rather than
+#: check once. ~30s total is well past the few seconds observed in practice.
+_TEARDOWN_POLL_ATTEMPTS = 10
+_TEARDOWN_POLL_SECONDS = 3
+
+
+def collect(project: Path) -> dict[str, str | bytes]:
+    files: dict[str, str | bytes] = {}
+    for path in sorted(project.rglob("*")):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(project).as_posix()
+        if any(seg in _SKIP_DIRS for seg in rel.split("/")):
+            continue
+        files[rel] = path.read_text(encoding="utf-8")
+    return files
+
+
+def load_env() -> None:
+    """Load .env the way the app does, and report WHICH credential won.
+
+    The repo's .env carries duplicate DAYTONA_API_KEY entries pointing at different
+    accounts; python-dotenv resolves the LAST assignment. Printing the fingerprint (not
+    the key) makes it unambiguous which account a given run was billed to.
+    """
+    from dotenv import dotenv_values
+
+    vals = dotenv_values(".env")
+    for name in ("DAYTONA_API_KEY", "DAYTONA_API_URL"):
+        val = vals.get(name)
+        if val:
+            os.environ[name] = val
+    key = os.environ.get("DAYTONA_API_KEY", "")
+    print(f"  api_url = {os.environ.get('DAYTONA_API_URL')}")
+    print(f"  api_key = <len {len(key)}, sha256:{hashlib.sha256(key.encode()).hexdigest()[:12]}>")
+
+
+async def main() -> int:
+    if len(sys.argv) < 2:
+        print(__doc__)
+        return 2
+    project = Path(sys.argv[1])
+    if not project.is_dir():
+        print(f"not a directory: {project}")
+        return 2
+
+    timeout_seconds = int(os.environ.get("SG9_TIMEOUT_SECONDS", "900"))
+
+    print("=== credentials ===")
+    load_env()
+
+    from pocketpaw_ee.cloud.daytona.client import get_daytona_client
+
+    files = collect(project)
+    print(f"\n=== input ===\n  {len(files)} files from {project}")
+    for rel in files:
+        print(f"    {rel}")
+
+    client = get_daytona_client()
+    if client is None:
+        print("\nBLOCKED: Daytona is not configured")
+        return 1
+
+    # One try/finally around everything that uses the client, so the aiohttp session is
+    # closed even when reporting blows up. The first run of this probe leaked one
+    # because the close sat after a print that raised.
+    try:
+        return await _run_and_report(client, files, timeout_seconds)
+    finally:
+        await client.close()
+
+
+async def _run_and_report(client: Any, files: dict[str, str | bytes], timeout_seconds: int) -> int:
+    from pocketpaw_ee.sites.daytona_runner import run_build
+
+    print(f"\n=== running (timeout {timeout_seconds}s) ===")
+    try:
+        result = await run_build(
+            files,
+            engine="react",
+            timeout_seconds=timeout_seconds,
+            client=client,
+        )
+    except Exception as exc:  # noqa: BLE001 — a probe reports rather than crashes
+        print(f"\nBLOCKED: could not run the build: {type(exc).__name__}: {exc}")
+        return 1
+
+    print("\n=== outcome ===")
+    print(f"  outcome        : {result.classification.outcome}")
+    print(f"  reason         : {result.classification.reason}")
+    print(f"  blames_user    : {result.classification.blames_user}")
+    print(f"  retryable      : {result.classification.retryable}")
+    print(f"  artifact_bytes : {result.artifact_bytes}")
+    print(f"  sandbox_id     : {result.sandbox_id}")
+    print(f"  deleted        : {result.sandbox_deleted}")
+    if result.classification.stderr_tail:
+        tail = result.classification.stderr_tail[-1500:]
+        print(f"\n  --- stderr tail ---\n{tail}")
+
+    print("\n=== measured timings (seconds) ===")
+    for k, v in result.timings.as_dict().items():
+        print(f"  {k:<12} {v}")
+
+    # Prove the sandbox is actually gone rather than trusting the delete call.
+    #
+    # POLLED, not checked once. Measured 2026-08-09: Daytona's delete is
+    # EVENTUALLY CONSISTENT — a sandbox deleted successfully still appeared in
+    # ``list()`` immediately afterwards and drained a few seconds later. A single check
+    # therefore reports a false "still present" and would fail this slice's acceptance
+    # criterion on a teardown that actually worked. It also means an account-level
+    # concurrent-sandbox count lags reality, which the concurrency cap has to allow for.
+    if result.sandbox_id:
+        print("\n=== teardown verification ===")
+        gone = False
+        remaining: list[Any] = []
+        for attempt in range(_TEARDOWN_POLL_ATTEMPTS):
+            try:
+                remaining = await client.list_sandboxes()
+            except Exception as exc:  # noqa: BLE001
+                print(f"  could not verify: {exc}")
+                break
+            if result.sandbox_id not in {s.id for s in remaining}:
+                gone = True
+                print(f"  gone from the account listing after ~{attempt * _TEARDOWN_POLL_SECONDS}s")
+                break
+            await asyncio.sleep(_TEARDOWN_POLL_SECONDS)
+        if not gone:
+            waited = _TEARDOWN_POLL_ATTEMPTS * _TEARDOWN_POLL_SECONDS
+            print(f"  STILL PRESENT after ~{waited}s — teardown did not take effect")
+        print(f"  total sandboxes now: {len(remaining)}")
+
+    return 0 if result.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/tests/cloud/test_daytona_image.py
+++ b/tests/cloud/test_daytona_image.py
@@ -1,0 +1,94 @@
+# tests/cloud/test_daytona_image.py — pins the Daytona sandbox image's toolchain
+# contract (ee/pocketpaw_ee/cloud/daytona/image.py).
+#
+# Created 2026-08-09 (SG-9i). The image was previously untested, which is how it came
+# to ship Node without bun while the Paw Sites build pipeline is entirely bun-shaped
+# (``bun install`` + ``bun run build``). A sandbox missing bun does not fail at build
+# time with a useful message — it fails per-build, in the sandbox, as a command-not-
+# found buried in a build log.
+#
+# These are dockerfile-TEXT assertions, deliberately. Actually building the image needs
+# Docker and a Daytona account, so it cannot run in unit tests; the dockerfile is the
+# closest artifact to the contract that is cheap to assert. It catches the regression
+# that matters (a toolchain silently dropped from the image) without pretending to
+# verify the built result.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.daytona.image import (
+    build_paw_dev_image,
+    resolve_sandbox_image,
+    sandbox_image_override,
+)
+
+
+@pytest.fixture
+def dockerfile() -> str:
+    return build_paw_dev_image().dockerfile()
+
+
+class TestToolchainIsPresent:
+    def test_bun_is_installed(self, dockerfile: str) -> None:
+        """The load-bearing one. Removing the bun block makes every source-lane build
+        fail inside the sandbox with a command-not-found."""
+        assert "bun.sh/install" in dockerfile
+
+    def test_bun_is_on_path_for_non_login_shells(self, dockerfile: str) -> None:
+        """``execute_command`` does not run a login shell, so a bun that only exists in
+        ``~/.bashrc``'s PATH is invisible to it. The symlink is what makes it reachable —
+        this is the difference between "bun is installed" and "bun can be run"."""
+        assert "/usr/local/bin/bun" in dockerfile
+
+    def test_bun_install_is_verified_at_image_build_time(self, dockerfile: str) -> None:
+        """``bun --version`` in the image build turns a broken install into a failed
+        IMAGE build (one loud failure) instead of a failed build per site (many quiet
+        ones)."""
+        assert "bun --version" in dockerfile
+
+    def test_node_is_still_installed(self, dockerfile: str) -> None:
+        """bun was ADDED, not substituted: the generated project's build script invokes
+        ``node`` directly (``vite build && node scripts/prune-client.mjs``), and the
+        vendored paw-sites CLI runs under node."""
+        assert "nodesource.com" in dockerfile
+
+    def test_python_base_is_retained(self, dockerfile: str) -> None:
+        """The in-sandbox build wrapper serializes its result sentinel with python3
+        rather than hand-rolled shell JSON. Losing the python base would silently break
+        the sentinel — and a missing sentinel is read as infrastructure loss, so the
+        lane would retry forever instead of reporting anything."""
+        assert "python" in dockerfile.lower()
+
+
+class TestOverrideContract:
+    def test_unset_uses_the_prebuilt_image(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("DAYTONA_SANDBOX_IMAGE", raising=False)
+        assert sandbox_image_override() is None
+
+    @pytest.mark.parametrize("value", ["standard", "default", "STANDARD", "  "])
+    def test_standard_and_blank_mean_the_prebuilt_image(
+        self, monkeypatch: pytest.MonkeyPatch, value: str
+    ) -> None:
+        monkeypatch.setenv("DAYTONA_SANDBOX_IMAGE", value)
+        assert sandbox_image_override() is None
+
+    def test_an_explicit_image_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An operator override is honoured — but note it replaces the WHOLE image, so
+        pointing this at e.g. ``oven/bun`` would strip python/uv/git that other Daytona
+        consumers rely on. It must not be set globally to get bun; bun is in the
+        prebuilt image for exactly that reason."""
+        monkeypatch.setenv("DAYTONA_SANDBOX_IMAGE", "oven/bun:1.2")
+        assert sandbox_image_override() == "oven/bun:1.2"
+
+    def test_resolver_returns_an_image_object_when_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("DAYTONA_SANDBOX_IMAGE", raising=False)
+        resolved = resolve_sandbox_image()
+        assert not isinstance(resolved, str)
+
+    def test_resolver_returns_the_string_when_overridden(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("DAYTONA_SANDBOX_IMAGE", "python:3.12-slim")
+        assert resolve_sandbox_image() == "python:3.12-slim"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ YAMLs on a dev machine can't leak into test registries.
 import asyncio
 import os
 import sys
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -23,6 +24,44 @@ from pocketpaw.security.audit import AuditLogger
 # we relax the check so Settings() instantiates cleanly. Tests that need the
 # strict behaviour monkeypatch POCKETPAW_ALLOW_INTERNAL_URLS=false themselves.
 os.environ.setdefault("POCKETPAW_ALLOW_INTERNAL_URLS", "true")
+
+
+def pytest_report_header() -> str | None:
+    """Say so, loudly, when a mutation sweep is running in this worktree.
+
+    Added 2026-08-09 after this cost real time twice in one day. ``scripts/mutate.py``
+    applies each mutation IN PLACE, so while one is live the tree genuinely contains
+    broken code and any test run against it fails for a reason that looks exactly like a
+    regression. It happened to a reviewer, and then to me while verifying the fix.
+
+    This hook is the reader's ACTUAL path — someone investigating a failure runs the
+    suite; they do not necessarily run ``git status``. So the warning belongs in pytest's
+    own header, where it is impossible to miss and where it still works with the marker
+    gitignored.
+
+    A header, deliberately, not a hard failure: a sweep runs the suite itself, over and
+    over, and erroring out would make the tool unable to do its job.
+    """
+    marker = Path(__file__).resolve().parents[1] / ".mutation-sweep-active"
+    if not marker.exists():
+        return None
+    current = ""
+    try:
+        for line in marker.read_text(encoding="utf-8").splitlines():
+            if line.startswith("current"):
+                current = line.partition(":")[2].strip()
+                break
+    except OSError:  # pragma: no cover - best effort
+        pass
+    return (
+        "\n"
+        "  ****************************************************************\n"
+        "  *  A MUTATION SWEEP IS RUNNING IN THIS WORKTREE.               *\n"
+        "  *  Failures below are EXPECTED and are NOT regressions.        *\n"
+        "  *  Re-run once .mutation-sweep-active is gone.                 *\n"
+        "  ****************************************************************\n"
+        f"  currently mutated: {current or '(unknown)'}\n"
+    )
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/ee/sites/test_build_state.py
+++ b/tests/ee/sites/test_build_state.py
@@ -1,0 +1,215 @@
+# tests/ee/sites/test_build_state.py — the ephemeral-build lane's lifecycle guard
+# (ee/pocketpaw_ee/sites/build_state.py).
+#
+# Created 2026-08-09 (SG-9i, async publish).
+#
+# THE TWO FAILURES THESE GUARD, both of which have shipped before in the provision path:
+#
+#   1. A ONE-WAY DOOR. A build that dies without writing a terminal status pins the row
+#      in ``building`` and every later publish becomes a silent no-op — a site nobody
+#      can republish, with no error anywhere to see. The staleness window is the only
+#      thing that reopens it, so the tests below care much more about "does a dead row
+#      unstick" than about "does a live row block".
+#
+#   2. SPENDING TWICE. The mirror failure: re-enqueueing on top of a healthy long build
+#      means two sandboxes, two bills, and two artifacts racing to be the one that
+#      deploys. That is why the window is derived from the build's own timeout rather
+#      than a constant.
+#
+# Mutations in tests/mutations/build_state.json, run and caught.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+from pocketpaw_ee.sites import build_state as bs
+
+TIMEOUT = 600
+
+
+def _site(status: str, *, age_seconds: float | None = None, stamp: object = ...) -> SimpleNamespace:
+    """A Site-shaped stand-in. ``age_seconds`` sets a stamp that far in the past;
+    ``stamp`` sets one verbatim (for the unusable-value cases)."""
+    if stamp is not ...:
+        return SimpleNamespace(build_status=status, build_started_at=stamp)
+    started = None if age_seconds is None else datetime.now(UTC) - timedelta(seconds=age_seconds)
+    return SimpleNamespace(build_status=status, build_started_at=started)
+
+
+class TestATerminalRowNeverBlocks:
+    @pytest.mark.parametrize("status", ["none", "built", "failed"])
+    def test_terminal_statuses_allow_a_new_build(self, status: str) -> None:
+        assert bs.should_enqueue(_site(status, age_seconds=1), TIMEOUT) is True
+
+    def test_failed_does_not_wedge_the_site(self) -> None:
+        """If ``failed`` blocked, one bad build would wedge the site until somebody
+        edited the database by hand."""
+        assert bs.should_enqueue(_site("failed", age_seconds=0), TIMEOUT) is True
+
+    def test_built_allows_a_rebuild(self) -> None:
+        """A site is provisioned once and rebuilt many times — that is the whole reason
+        these fields are separate from the provision_* trio."""
+        assert bs.should_enqueue(_site("built", age_seconds=0), TIMEOUT) is True
+
+
+class TestALiveBuildBlocks:
+    def test_fresh_building_blocks(self) -> None:
+        assert bs.should_enqueue(_site("building", age_seconds=5), TIMEOUT) is False
+
+    def test_fresh_queued_blocks(self) -> None:
+        """A queued build has no sandbox yet, but it is still in flight — enqueueing a
+        second would spend twice for one publish."""
+        assert bs.should_enqueue(_site("queued", age_seconds=5), TIMEOUT) is False
+
+    def test_a_build_inside_its_own_timeout_still_blocks(self) -> None:
+        """The mirror failure: re-enqueueing on top of a healthy long build means two
+        sandboxes and two artifacts racing to deploy."""
+        assert bs.should_enqueue(_site("building", age_seconds=TIMEOUT - 1), TIMEOUT) is False
+
+
+class TestADeadRowUnsticks:
+    def test_past_the_window_a_stuck_row_allows_a_new_build(self) -> None:
+        """The one-way-door fix. Without this the site is permanently unpublishable."""
+        age = TIMEOUT + bs.STALE_MARGIN.total_seconds() + 60
+        assert bs.should_enqueue(_site("building", age_seconds=age), TIMEOUT) is True
+
+    def test_a_missing_stamp_reads_as_stale(self) -> None:
+        """Asymmetric failure, deliberately biased: a redundant enqueue costs one
+        idempotent build, a stuck guard costs every future publish. Mutation: flip this
+        to False and a row with no stamp becomes permanently unpublishable."""
+        assert bs.build_is_stale(_site("building", age_seconds=None), TIMEOUT) is True
+        assert bs.should_enqueue(_site("building", age_seconds=None), TIMEOUT) is True
+
+    @pytest.mark.parametrize("bad", [None, "2026-08-09", 0, object()])
+    def test_an_unreadable_stamp_reads_as_stale(self, bad: object) -> None:
+        assert bs.build_is_stale(_site("building", stamp=bad), TIMEOUT) is True
+
+    def test_a_naive_stamp_is_assumed_utc_not_rejected(self) -> None:
+        """Treating a naive datetime as unreadable would make every row written by an
+        older writer look stale, which quietly disables the guard."""
+        naive = datetime.now(UTC).replace(tzinfo=None)
+        assert bs.build_is_stale(_site("building", stamp=naive), TIMEOUT) is False
+
+
+class TestTheWindowIsDerivedNotConstant:
+    def test_window_scales_with_the_build_timeout(self) -> None:
+        """DP0-4 used a flat 30 minutes. A constant is wrong in both directions — too
+        short re-enqueues onto a healthy long build, too long leaves a stuck row
+        blocking publishes."""
+        assert bs.stale_after(600) < bs.stale_after(3600)
+
+    def test_window_always_exceeds_the_timeout(self) -> None:
+        """Sandbox create, upload, extract and teardown all sit OUTSIDE the in-sandbox
+        timeout, so the window has to cover more than the build itself."""
+        for timeout in (0, 60, 600, 3600):
+            assert bs.stale_after(timeout) > timedelta(seconds=timeout)
+
+    def test_a_nonpositive_timeout_still_yields_a_positive_window(self) -> None:
+        """A zero or negative window would make every in-flight build read as stale and
+        defeat the guard entirely."""
+        assert bs.stale_after(0) == bs.STALE_MARGIN
+        assert bs.stale_after(-999) == bs.STALE_MARGIN
+
+    def test_a_long_build_is_not_declared_stale_by_a_short_window(self) -> None:
+        age = 3000
+        assert bs.should_enqueue(_site("building", age_seconds=age), 600) is True
+        assert bs.should_enqueue(_site("building", age_seconds=age), 7200) is False
+
+
+class TestInFlightIsForTheUiNotTheWallet:
+    def test_a_stale_row_still_reads_as_in_flight_to_a_viewer(self) -> None:
+        """Deliberately different from ``not should_enqueue``: a stale row must not
+        BLOCK a publish, but it should still render as in-progress rather than
+        silently as idle."""
+        stale = _site("building", age_seconds=99_999)
+        assert bs.is_in_flight(stale) is True
+        assert bs.should_enqueue(stale, TIMEOUT) is True
+
+    @pytest.mark.parametrize("status", ["none", "built", "failed"])
+    def test_terminal_is_not_in_flight(self, status: str) -> None:
+        assert bs.is_in_flight(_site(status, age_seconds=1)) is False
+
+    def test_queued_is_in_flight(self) -> None:
+        """The state that makes the concurrency cap safe to turn on: a publish waiting
+        behind the cap has to be visibly waiting, not silently absent."""
+        assert bs.is_in_flight(_site("queued", age_seconds=1)) is True
+
+
+class TestStatusVocabulary:
+    def test_queued_exists_as_a_distinct_state(self) -> None:
+        """Without it, a publish waiting behind the cap is indistinguishable from a hung
+        one and the cap turns crashes into support tickets."""
+        assert "queued" in bs.IN_FLIGHT_STATUSES
+        assert "queued" not in bs.TERMINAL_STATUSES
+
+    def test_in_flight_and_terminal_partition_the_vocabulary(self) -> None:
+        assert bs.IN_FLIGHT_STATUSES.isdisjoint(bs.TERMINAL_STATUSES)
+        assert bs.IN_FLIGHT_STATUSES | bs.TERMINAL_STATUSES == {
+            "none",
+            "queued",
+            "building",
+            "built",
+            "failed",
+        }
+
+    def test_an_unknown_status_does_not_block_a_publish(self) -> None:
+        """Fail open on garbage: an unrecognised status is far likelier to be drift or a
+        bad write than a live build, and blocking on it recreates the one-way door."""
+        assert bs.should_enqueue(_site("wat", age_seconds=1), TIMEOUT) is True
+
+
+class TestSiteModelCarriesTheFields:
+    def test_build_job_id_is_persisted_not_a_private_attr(self) -> None:
+        """The DP0-4 mistake this fixes. ``_provision_job_id`` is a transient
+        PrivateAttr, so a client that reloads loses its handle — and a queued build is
+        exactly when a user reloads. Mutation: make it a PrivateAttr and this fails."""
+        from pocketpaw_ee.cloud.models.site import Site
+
+        assert "build_job_id" in Site.model_fields
+        assert "build_status" in Site.model_fields
+        assert "build_started_at" in Site.model_fields
+
+    def test_build_fields_default_to_never_built(self) -> None:
+        from pocketpaw_ee.cloud.models.site import Site
+
+        assert Site.model_fields["build_status"].default == "none"
+        assert Site.model_fields["build_started_at"].default is None
+        assert Site.model_fields["build_job_id"].default is None
+
+    def test_build_status_is_separate_from_provision_status(self) -> None:
+        """A site is provisioned once and rebuilt many times; collapsing them would let
+        a rebuild overwrite provisioning state."""
+        from pocketpaw_ee.cloud.models.site import Site
+
+        assert "provision_status" in Site.model_fields
+        assert Site.model_fields["build_status"] is not Site.model_fields["provision_status"]
+
+
+class TestTheWireCarriesTheState:
+    """A queued build has to be visible to the client, or the concurrency cap turns a
+    crash into a support ticket. These pin the wire contract, not the guard."""
+
+    def test_site_response_exposes_build_status_and_job_id(self) -> None:
+        from pocketpaw_ee.sites.dto import SiteResponse
+
+        assert "build_status" in SiteResponse.model_fields
+        assert "build_job_id" in SiteResponse.model_fields
+
+    def test_wire_defaults_match_a_never_built_site(self) -> None:
+        from pocketpaw_ee.sites.dto import SiteResponse
+
+        assert SiteResponse.model_fields["build_status"].default == "none"
+        assert SiteResponse.model_fields["build_job_id"].default is None
+
+    def test_the_wire_vocabulary_matches_the_state_machine(self) -> None:
+        """Drift between the model's states and the wire's is the kind of thing that
+        ships a status the client has never heard of."""
+        assert bs.IN_FLIGHT_STATUSES | bs.TERMINAL_STATUSES == {
+            "none",
+            "queued",
+            "building",
+            "built",
+            "failed",
+        }

--- a/tests/ee/sites/test_daytona_build.py
+++ b/tests/ee/sites/test_daytona_build.py
@@ -334,3 +334,52 @@ class TestWrapperScript:
         )
         assert "bun install --frozen-lockfile" in script
         assert "bun run build:prod" in script
+
+
+class TestResolveBuildTimeout:
+    """The shipped default, with measurement descoped. Both engines land on the floor,
+    and the floor is deliberately loose: a too-generous timeout costs a slow failure,
+    a too-tight one reports a healthy build as broken."""
+
+    def _clear(self, mp: pytest.MonkeyPatch) -> None:
+        for name in (
+            "PAW_SITES_BUILD_TIMEOUT_SEC",
+            "PAW_SITES_BUILD_TIMEOUT_SEC_REACT",
+            "PAW_SITES_BUILD_TIMEOUT_SEC_SVELTE",
+        ):
+            mp.delenv(name, raising=False)
+
+    def test_defaults_to_the_floor_for_both_engines(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._clear(monkeypatch)
+        assert db.resolve_build_timeout_seconds("react") == db.TIMEOUT_FLOOR_SECONDS
+        assert db.resolve_build_timeout_seconds("svelte") == db.TIMEOUT_FLOOR_SECONDS
+
+    def test_shared_env_knob_is_the_same_name_sg_p2_uses(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """One constant serves the local builder and this lane, so an operator tuning a
+        slow deploy does not have to find two names."""
+        self._clear(monkeypatch)
+        monkeypatch.setenv("PAW_SITES_BUILD_TIMEOUT_SEC", "1200")
+        assert db.resolve_build_timeout_seconds("react") == 1200
+
+    def test_per_engine_override_beats_the_shared_knob(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Engines differ by more than a constant factor — react installs 4 direct deps,
+        svelte pulls the whole SvelteKit toolchain — so one number is either wasteful for
+        one or fatal for the other."""
+        self._clear(monkeypatch)
+        monkeypatch.setenv("PAW_SITES_BUILD_TIMEOUT_SEC", "1200")
+        monkeypatch.setenv("PAW_SITES_BUILD_TIMEOUT_SEC_SVELTE", "2400")
+        assert db.resolve_build_timeout_seconds("svelte") == 2400
+        assert db.resolve_build_timeout_seconds("react") == 1200
+
+    @pytest.mark.parametrize("bad", ["", "abc", "0", "-5", "  "])
+    def test_malformed_values_fall_back_rather_than_raise(
+        self, monkeypatch: pytest.MonkeyPatch, bad: str
+    ) -> None:
+        """The timeout is a safety net and must never itself break a build."""
+        self._clear(monkeypatch)
+        monkeypatch.setenv("PAW_SITES_BUILD_TIMEOUT_SEC", bad)
+        assert db.resolve_build_timeout_seconds("react") == db.TIMEOUT_FLOOR_SECONDS

--- a/tests/ee/sites/test_daytona_build.py
+++ b/tests/ee/sites/test_daytona_build.py
@@ -1,0 +1,336 @@
+# tests/ee/sites/test_daytona_build.py — unit tests for the ephemeral Daytona build
+# lane's decision core (ee/pocketpaw_ee/sites/daytona_build.py).
+#
+# Created 2026-08-09 (SG-9i). The module under test is the replacement for a failure
+# discriminator the captain's ruling made impossible: a self-deleting sandbox cannot be
+# re-queried after the fact, so the build must PROVE it completed and absence of proof
+# is read as infrastructure loss.
+#
+# WHAT THESE TESTS ARE PROTECTING, stated plainly because it is the point of the whole
+# module: the lane must never tell a user "your site failed to build" when what
+# actually happened is that we lost the container. Every test below that asserts
+# ``blames_user is False`` is guarding that specific mis-report, and the
+# signalled-death cases (137/143) are the subtle ones — a signalled process still runs
+# the shell trap, so it arrives WITH a sentinel and a non-zero exit, which is exactly
+# what a genuine build failure looks like.
+#
+# Mutations that break these tests live in tests/mutations/daytona_build.json and have
+# been run (per the workspace rule that a gate is not a gate until a mutation has been
+# observed to break it).
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pocketpaw_ee.sites import daytona_build as db
+
+
+def _sentinel(**overrides: object) -> dict[str, object]:
+    """A well-formed, successful sentinel. Tests override single fields so each case
+    differs from the happy path by exactly one thing."""
+    payload: dict[str, object] = {
+        "schema": db.SENTINEL_SCHEMA,
+        "engine": "react",
+        "install_exit": 0,
+        "build_exit": 0,
+        "started_at": "2026-08-09T00:00:00Z",
+        "finished_at": "2026-08-09T00:02:00Z",
+        "artifact_rel": "dist",
+        "artifact_bytes": 4096,
+        "stderr_tail": "",
+    }
+    payload.update(overrides)
+    return payload
+
+
+class TestTheFourRowMatrix:
+    """The core contract. One row each, plus the property that only row 2 blames the
+    user."""
+
+    def test_row1_sentinel_exit0_under_timeout_is_completed_ok(self) -> None:
+        got = db.classify_build(_sentinel(), elapsed_seconds=30.0, timeout_seconds=600)
+        assert got.outcome == "completed_ok"
+        assert got.deployable is True
+        assert got.blames_user is False
+
+    def test_row2_sentinel_nonzero_exit_is_build_failed_and_blames_user(self) -> None:
+        got = db.classify_build(
+            _sentinel(build_exit=1, stderr_tail="TS2304: cannot find name 'foo'"),
+            elapsed_seconds=30.0,
+            timeout_seconds=600,
+        )
+        assert got.outcome == "build_failed"
+        assert got.blames_user is True
+        assert got.retryable is False
+        assert "TS2304" in got.stderr_tail
+
+    def test_row3_no_sentinel_at_or_over_timeout_is_timed_out(self) -> None:
+        got = db.classify_build(None, elapsed_seconds=600.0, timeout_seconds=600)
+        assert got.outcome == "timed_out"
+        assert got.retryable is True
+        assert got.blames_user is False
+
+    def test_row4_no_sentinel_under_timeout_is_infra_lost(self) -> None:
+        got = db.classify_build(None, elapsed_seconds=12.0, timeout_seconds=600)
+        assert got.outcome == "infra_lost"
+        assert got.retryable is True
+        assert got.blames_user is False
+
+    def test_only_build_failed_ever_blames_the_user(self) -> None:
+        """The invariant the whole module exists to hold. If any non-``build_failed``
+        outcome can blame the user, capacity loss becomes the user's problem."""
+        cases = [
+            db.classify_build(None, elapsed_seconds=1.0, timeout_seconds=600),
+            db.classify_build(None, elapsed_seconds=999.0, timeout_seconds=600),
+            db.classify_build(
+                _sentinel(build_exit=db._EXIT_SIGKILL), elapsed_seconds=5.0, timeout_seconds=600
+            ),
+            db.classify_build(
+                _sentinel(build_exit=db._EXIT_TIMEOUT), elapsed_seconds=5.0, timeout_seconds=600
+            ),
+            db.classify_build(_sentinel(), elapsed_seconds=5.0, timeout_seconds=600),
+        ]
+        for got in cases:
+            if got.outcome != "build_failed":
+                assert got.blames_user is False, got
+
+
+class TestSignalledDeathsAreNotBuildFailures:
+    """The residual gap in the sentinel design, and the subtlest part of the module.
+
+    A signalled process STILL RUNS THE TRAP, so an OOM kill produces a sentinel with a
+    non-zero ``build_exit`` — indistinguishable from a real build failure unless the
+    exit code is inspected. Mutation: reorder the signal check below the
+    ``build_exit != 0`` branch and every one of these becomes ``build_failed``.
+    """
+
+    def test_sigkill_137_is_infra_lost_not_build_failed(self) -> None:
+        got = db.classify_build(
+            _sentinel(build_exit=137), elapsed_seconds=45.0, timeout_seconds=600
+        )
+        assert got.outcome == "infra_lost"
+        assert got.blames_user is False
+        assert got.retryable is True
+
+    def test_sigterm_143_is_infra_lost(self) -> None:
+        got = db.classify_build(
+            _sentinel(build_exit=143), elapsed_seconds=45.0, timeout_seconds=600
+        )
+        assert got.outcome == "infra_lost"
+        assert got.blames_user is False
+
+    def test_install_killed_by_signal_is_also_infra_lost(self) -> None:
+        """The install step is the long one in a cold-per-build lane, so it is the more
+        likely OOM victim — it must get the same treatment as the build step."""
+        got = db.classify_build(
+            _sentinel(install_exit=137, build_exit=-1), elapsed_seconds=45.0, timeout_seconds=600
+        )
+        assert got.outcome == "infra_lost"
+        assert "install" in got.reason
+
+    def test_exit_124_is_timed_out_with_evidence_retained(self) -> None:
+        """``timeout(1)`` fired in-sandbox. Better than the clock-inferred timeout: we
+        keep the stderr tail, so the user learns WHICH step overran."""
+        got = db.classify_build(
+            _sentinel(build_exit=124, stderr_tail="vite building..."),
+            elapsed_seconds=610.0,
+            timeout_seconds=600,
+        )
+        assert got.outcome == "timed_out"
+        assert got.blames_user is False
+        assert got.stderr_tail == "vite building..."
+
+    def test_signal_check_wins_even_when_clock_says_under_timeout(self) -> None:
+        """A 137 five seconds in is an OOM, not a slow build. The exit code is stronger
+        evidence than the clock and must not be overridden by it."""
+        got = db.classify_build(_sentinel(build_exit=137), elapsed_seconds=5.0, timeout_seconds=600)
+        assert got.outcome == "infra_lost"
+
+
+class TestUnusableSentinelsFailClosed:
+    """A sentinel we cannot trust must classify exactly like no sentinel at all —
+    never as a success, and never as the user's fault."""
+
+    def test_truncated_json_is_treated_as_absent(self) -> None:
+        got = db.classify_build(
+            '{"schema": 1, "build_exit"', elapsed_seconds=5.0, timeout_seconds=600
+        )
+        assert got.outcome == "infra_lost"
+
+    def test_non_dict_json_is_treated_as_absent(self) -> None:
+        got = db.classify_build("[1, 2, 3]", elapsed_seconds=5.0, timeout_seconds=600)
+        assert got.outcome == "infra_lost"
+
+    def test_unknown_schema_is_treated_as_absent(self) -> None:
+        """Refusing an unknown schema rather than guessing at field meanings: an
+        unreadable sentinel carries no information, so it must not be read as one."""
+        got = db.classify_build(_sentinel(schema=999), elapsed_seconds=5.0, timeout_seconds=600)
+        assert got.outcome == "infra_lost"
+
+    def test_missing_build_exit_does_not_deploy(self) -> None:
+        payload = _sentinel()
+        del payload["build_exit"]
+        got = db.classify_build(payload, elapsed_seconds=5.0, timeout_seconds=600)
+        assert got.outcome == "infra_lost"
+        assert got.deployable is False
+
+    def test_bool_exit_code_is_rejected_not_coerced(self) -> None:
+        """``True`` is an ``int`` subclass that would read as exit 1 and ``False`` as
+        exit 0 — the latter would deploy an unbuilt site. Mutation: drop the ``bool``
+        guard in ``_coerce_exit`` and the ``False`` case starts reporting
+        ``completed_ok``."""
+        got = db.classify_build(
+            _sentinel(build_exit=False), elapsed_seconds=5.0, timeout_seconds=600
+        )
+        assert got.outcome != "completed_ok"
+
+    def test_accepts_bytes_as_well_as_str(self) -> None:
+        got = db.classify_build(
+            json.dumps(_sentinel()).encode(), elapsed_seconds=5.0, timeout_seconds=600
+        )
+        assert got.outcome == "completed_ok"
+
+    def test_undecodable_bytes_are_treated_as_absent(self) -> None:
+        got = db.classify_build(b"\xff\xfe not json", elapsed_seconds=5.0, timeout_seconds=600)
+        assert got.outcome == "infra_lost"
+
+
+class TestEmptyArtifactIsCaughtBeforeDeploy:
+    """The empty-deploy failure: every step reports success and a blank site goes live.
+    Exit 0 alone is not sufficient evidence."""
+
+    def test_zero_bytes_is_build_failed_not_completed_ok(self) -> None:
+        got = db.classify_build(
+            _sentinel(artifact_bytes=0), elapsed_seconds=30.0, timeout_seconds=600
+        )
+        assert got.outcome == "build_failed"
+        assert got.reason == "artifact_empty"
+        assert got.deployable is False
+
+    def test_missing_artifact_bytes_is_not_deployable(self) -> None:
+        payload = _sentinel()
+        del payload["artifact_bytes"]
+        got = db.classify_build(payload, elapsed_seconds=30.0, timeout_seconds=600)
+        assert got.deployable is False
+
+    def test_install_failure_is_reported_but_retryable(self) -> None:
+        """A bad manifest is the user's to fix, but a registry outage looks identical
+        and nothing was built yet, so the retry is cheap. Both flags are set."""
+        got = db.classify_build(
+            _sentinel(install_exit=1, build_exit=-1), elapsed_seconds=30.0, timeout_seconds=600
+        )
+        assert got.outcome == "build_failed"
+        assert got.reason == "install_failed"
+        assert got.retryable is True
+        assert got.blames_user is True
+
+
+class TestTimeoutSizing:
+    def test_covers_install_plus_build_not_build_alone(self) -> None:
+        """The specific way a "strict timeout" instruction goes wrong: sizing on the
+        build alone kills every build in a cold-per-build lane. Mutation: drop the
+        install term and this drops to the floor, hiding the bug."""
+        got = db.build_timeout_seconds(500.0, 400.0)
+        assert got == pytest.approx(1350)  # (500 + 400) * 1.5
+
+    def test_floor_applies_when_measurements_are_small(self) -> None:
+        assert db.build_timeout_seconds(10.0, 10.0) == db.TIMEOUT_FLOOR_SECONDS
+
+    def test_floor_is_at_least_the_existing_cold_install_budget(self) -> None:
+        """scaffold.py already budgets 600s for a cold install of this toolchain; a
+        floor below that guarantees timeouts on healthy builds."""
+        assert db.TIMEOUT_FLOOR_SECONDS >= 600
+
+    def test_negative_measurements_clamp_to_the_floor(self) -> None:
+        assert db.build_timeout_seconds(-100.0, -100.0) == db.TIMEOUT_FLOOR_SECONDS
+
+    def test_returns_whole_seconds(self) -> None:
+        assert isinstance(db.build_timeout_seconds(101.3, 7.9), int)
+
+
+class TestArtifactIncludeList:
+    def test_react_tars_only_dist(self) -> None:
+        cmd = db.artifact_tar_command("react", "/home/daytona/proj", "/tmp/a.tgz")
+        assert "/home/daytona/proj/dist" in cmd
+        assert "node_modules" not in cmd  # excluded by construction, not by a filter
+
+    def test_svelte_tars_only_the_adapter_output(self) -> None:
+        cmd = db.artifact_tar_command("svelte", "/home/daytona/proj", "/tmp/a.tgz")
+        assert "/home/daytona/proj/.svelte-kit/cloudflare" in cmd
+
+    def test_html_is_refused_because_its_output_is_the_project_root(self) -> None:
+        """Tarring ``.`` would sweep in node_modules and defeat the include-list. html
+        needs no build so never reaches this lane; a caller that gets here is buggy and
+        should hear about it. Mutation: remove the guard and html silently ships a
+        node_modules-laden artifact."""
+        with pytest.raises(ValueError, match="project root"):
+            db.artifact_tar_command("html", "/home/daytona/proj", "/tmp/a.tgz")
+
+    def test_paths_are_shell_quoted(self) -> None:
+        cmd = db.artifact_tar_command("react", "/home/daytona/my proj", "/tmp/a b.tgz")
+        assert "'/home/daytona/my proj/dist'" in cmd
+        assert "'/tmp/a b.tgz'" in cmd
+
+
+class TestWrapperScript:
+    def test_trap_is_installed_before_any_command_that_can_fail(self) -> None:
+        """If the trap is registered after the install, a failing install produces NO
+        sentinel and is misclassified as infrastructure loss. Order is the contract."""
+        script = db.build_wrapper_script(
+            "react", "/p", timeout_seconds=600, artifact_path="/tmp/a.tgz"
+        )
+        assert script.index("trap write_result EXIT") < script.index("bun install")
+
+    def test_does_not_use_set_e(self) -> None:
+        """``set -e`` would abort before the sentinel is written with the real exit
+        codes — precisely when the evidence matters most."""
+        script = db.build_wrapper_script(
+            "react", "/p", timeout_seconds=600, artifact_path="/tmp/a.tgz"
+        )
+        assert "set -e" not in script
+        assert "set -u" in script
+
+    def test_both_steps_run_under_the_in_sandbox_timeout(self) -> None:
+        script = db.build_wrapper_script(
+            "react", "/p", timeout_seconds=777, artifact_path="/tmp/a.tgz"
+        )
+        assert script.count("timeout 777s") == 2
+
+    def test_exit_codes_start_at_minus_one_so_a_step_that_never_ran_fails_closed(
+        self,
+    ) -> None:
+        script = db.build_wrapper_script(
+            "react", "/p", timeout_seconds=600, artifact_path="/tmp/a.tgz"
+        )
+        assert "INSTALL_EXIT=-1" in script
+        assert "BUILD_EXIT=-1" in script
+
+    def test_sentinel_is_serialized_by_python_not_shell_string_concat(self) -> None:
+        """stderr routinely contains quotes and newlines; a shell-escaped JSON writer
+        would emit an unparseable sentinel exactly when there is an error worth
+        reading."""
+        script = db.build_wrapper_script(
+            "react", "/p", timeout_seconds=600, artifact_path="/tmp/a.tgz"
+        )
+        assert "python3 -" in script
+        assert "json.dump" in script
+
+    def test_tail_bytes_placeholder_is_substituted(self) -> None:
+        script = db.build_wrapper_script(
+            "react", "/p", timeout_seconds=600, artifact_path="/tmp/a.tgz"
+        )
+        assert "TAIL_BYTES" not in script
+        assert str(db.STDERR_TAIL_BYTES) in script
+
+    def test_install_and_build_commands_are_overridable(self) -> None:
+        script = db.build_wrapper_script(
+            "react",
+            "/p",
+            timeout_seconds=600,
+            artifact_path="/tmp/a.tgz",
+            install_command="bun install --frozen-lockfile",
+            build_command="bun run build:prod",
+        )
+        assert "bun install --frozen-lockfile" in script
+        assert "bun run build:prod" in script

--- a/tests/ee/sites/test_daytona_runner.py
+++ b/tests/ee/sites/test_daytona_runner.py
@@ -1,0 +1,270 @@
+# tests/ee/sites/test_daytona_runner.py — the ephemeral Daytona round-trip driver
+# (ee/pocketpaw_ee/sites/daytona_runner.py), exercised against a recording fake client.
+#
+# Created 2026-08-09 (SG-9i slice 1).
+#
+# WHY A FAKE AND NOT A MOCK OF THE SDK: the contract this module has to hold is about
+# ORDER and CLEANUP, not about return values. A fake that records the call sequence lets
+# the tests assert the two properties that actually matter and cannot be checked by
+# inspection — that the sentinel is read BEFORE teardown, and that teardown happens on
+# every path including the ones where the build blew up.
+#
+# The real round-trip against live Daytona lives in
+# scripts/sg9_daytona_roundtrip.py, because it costs sandbox time and needs
+# credentials. These tests are not a substitute for it and do not claim to be: a fake
+# passing is not evidence the lane works, only that the driver sequences correctly.
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+from pocketpaw_ee.sites import daytona_build as db
+from pocketpaw_ee.sites import daytona_runner as dr
+
+REACT_FILES = {"src/App.tsx": "export default function App() { return <p>hi</p>; }"}
+
+
+@dataclass
+class _SandboxInfo:
+    id: str
+
+
+class FakeClient:
+    """Records every call in order so the tests can assert sequencing.
+
+    ``sentinel`` is what ``download_file`` returns for the result path: bytes for a
+    readable sentinel, ``None`` to simulate one that cannot be read (a dead or already
+    reaped sandbox).
+    """
+
+    def __init__(
+        self,
+        *,
+        sentinel: dict[str, Any] | None,
+        exec_raises: bool = False,
+        artifact: bytes = b"tgz-bytes",
+        delete_raises: bool = False,
+    ) -> None:
+        self.calls: list[str] = []
+        self.create_kwargs: dict[str, Any] = {}
+        self.exec_timeout: int | None = None
+        self._sentinel = sentinel
+        self._exec_raises = exec_raises
+        self._artifact = artifact
+        self._delete_raises = delete_raises
+
+    async def create_sandbox(self, **kwargs: Any) -> _SandboxInfo:
+        self.calls.append("create")
+        self.create_kwargs = kwargs
+        return _SandboxInfo(id="sb-1")
+
+    async def wait_for_sandbox(self, sandbox_id: str, target_state: str = "started") -> None:
+        self.calls.append("wait")
+
+    async def bulk_upload(self, sandbox_id: str, files: list[tuple[Any, str]]) -> None:
+        self.calls.append("upload")
+        self.uploaded = files
+
+    async def execute_command(self, sandbox_id: str, command: str, timeout: int = 30) -> Any:
+        self.calls.append("exec")
+        self.exec_timeout = timeout
+        if self._exec_raises:
+            raise RuntimeError("sandbox went away mid-build")
+        return object()
+
+    async def download_file(self, sandbox_id: str, remote_path: str) -> bytes:
+        if remote_path.endswith(db.BUILD_RESULT_FILENAME):
+            self.calls.append("read_sentinel")
+            if self._sentinel is None:
+                raise FileNotFoundError(remote_path)
+            return json.dumps(self._sentinel).encode()
+        self.calls.append("download_artifact")
+        return self._artifact
+
+    async def delete_sandbox(self, sandbox_id: str) -> None:
+        self.calls.append("delete")
+        if self._delete_raises:
+            raise RuntimeError("delete failed")
+
+
+def _ok_sentinel(**over: Any) -> dict[str, Any]:
+    base = {
+        "schema": db.SENTINEL_SCHEMA,
+        "engine": "react",
+        "install_exit": 0,
+        "build_exit": 0,
+        "artifact_rel": "dist",
+        "artifact_bytes": 4096,
+        "stderr_tail": "",
+    }
+    base.update(over)
+    return base
+
+
+class TestTheFourRowsThroughTheDriver:
+    """All four outcomes, driven end to end. Two of them (``timed_out``,
+    ``infra_lost``) can only be reached by inducing them, which is the point of the
+    fake."""
+
+    async def test_row1_completed_ok_returns_the_artifact(self) -> None:
+        c = FakeClient(sentinel=_ok_sentinel())
+        got = await dr.run_build(REACT_FILES, engine="react", timeout_seconds=600, client=c)
+        assert got.classification.outcome == "completed_ok"
+        assert got.ok is True
+        assert got.artifact_bytes == len(b"tgz-bytes")
+
+    async def test_row2_build_failed_surfaces_stderr_and_no_artifact(self) -> None:
+        c = FakeClient(sentinel=_ok_sentinel(build_exit=1, stderr_tail="TS2304"))
+        got = await dr.run_build(REACT_FILES, engine="react", timeout_seconds=600, client=c)
+        assert got.classification.outcome == "build_failed"
+        assert got.classification.blames_user is True
+        assert "TS2304" in got.classification.stderr_tail
+        assert got.artifact is None
+        assert "download_artifact" not in c.calls
+
+    async def test_row3_timed_out_when_no_sentinel_and_clock_expired(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Induced: no readable sentinel, and our own clock past the budget. A tiny
+        timeout makes any real elapsed time exceed it."""
+        c = FakeClient(sentinel=None, exec_raises=True)
+        got = await dr.run_build(REACT_FILES, engine="react", timeout_seconds=0, client=c)
+        assert got.classification.outcome == "timed_out"
+        assert got.classification.retryable is True
+        assert got.classification.blames_user is False
+
+    async def test_row4_infra_lost_when_no_sentinel_before_the_budget(self) -> None:
+        """Induced: the exec blows up and no sentinel survives, well inside the budget.
+        This is the row that must NOT reach the user as a build failure — if it does,
+        the local-builder fallback never fires."""
+        c = FakeClient(sentinel=None, exec_raises=True)
+        got = await dr.run_build(REACT_FILES, engine="react", timeout_seconds=100_000, client=c)
+        assert got.classification.outcome == "infra_lost"
+        assert got.classification.retryable is True
+        assert got.classification.blames_user is False
+
+    async def test_oom_killed_build_is_infra_lost_not_build_failed(self) -> None:
+        """The residual gap: a signalled process still runs the trap, so this arrives
+        WITH a sentinel and a non-zero exit and looks exactly like a real failure."""
+        c = FakeClient(sentinel=_ok_sentinel(build_exit=137))
+        got = await dr.run_build(REACT_FILES, engine="react", timeout_seconds=600, client=c)
+        assert got.classification.outcome == "infra_lost"
+        assert got.classification.blames_user is False
+
+
+class TestSequencingIsTheContract:
+    async def test_sentinel_is_read_before_teardown(self) -> None:
+        """The single most important ordering in the module. Delete first and the
+        evidence is gone, and "not found" can no longer distinguish a normal delete
+        from a death."""
+        c = FakeClient(sentinel=_ok_sentinel())
+        await dr.run_build(REACT_FILES, engine="react", timeout_seconds=600, client=c)
+        assert c.calls.index("read_sentinel") < c.calls.index("delete")
+
+    async def test_artifact_is_downloaded_before_teardown(self) -> None:
+        c = FakeClient(sentinel=_ok_sentinel())
+        await dr.run_build(REACT_FILES, engine="react", timeout_seconds=600, client=c)
+        assert c.calls.index("download_artifact") < c.calls.index("delete")
+
+    async def test_full_happy_path_order(self) -> None:
+        c = FakeClient(sentinel=_ok_sentinel())
+        await dr.run_build(REACT_FILES, engine="react", timeout_seconds=600, client=c)
+        assert c.calls == [
+            "create",
+            "wait",
+            "upload",
+            "exec",
+            "read_sentinel",
+            "download_artifact",
+            "delete",
+        ]
+
+    async def test_the_wrapper_is_uploaded_alongside_the_project(self) -> None:
+        c = FakeClient(sentinel=_ok_sentinel())
+        await dr.run_build(REACT_FILES, engine="react", timeout_seconds=600, client=c)
+        dests = [dest for _, dest in c.uploaded]
+        assert dr.SANDBOX_WRAPPER_PATH in dests
+        assert f"{dr.SANDBOX_PROJECT_DIR}/src/App.tsx" in dests
+
+
+class TestTeardownAlwaysHappens:
+    async def test_delete_runs_when_the_build_fails(self) -> None:
+        c = FakeClient(sentinel=_ok_sentinel(build_exit=1))
+        got = await dr.run_build(REACT_FILES, engine="react", timeout_seconds=600, client=c)
+        assert "delete" in c.calls
+        assert got.sandbox_deleted is True
+
+    async def test_delete_runs_when_the_exec_raises(self) -> None:
+        c = FakeClient(sentinel=None, exec_raises=True)
+        await dr.run_build(REACT_FILES, engine="react", timeout_seconds=600, client=c)
+        assert "delete" in c.calls
+
+    async def test_a_failing_delete_does_not_mask_the_build_result(self) -> None:
+        """A cleanup error must not turn a successful build into an exception — the
+        auto-delete backstop still reaps the sandbox."""
+        c = FakeClient(sentinel=_ok_sentinel(), delete_raises=True)
+        got = await dr.run_build(REACT_FILES, engine="react", timeout_seconds=600, client=c)
+        assert got.classification.outcome == "completed_ok"
+        assert got.sandbox_deleted is False
+
+    async def test_no_snapshot_is_ever_taken(self) -> None:
+        """A stated invariant, not an accident: the SR-3 decision that a per-site signed
+        key in the build inputs is acceptable rests on the key living only in a
+        container that is destroyed. A snapshot would make it durable."""
+        c = FakeClient(sentinel=_ok_sentinel())
+        await dr.run_build(REACT_FILES, engine="react", timeout_seconds=600, client=c)
+        assert not any("snapshot" in call for call in c.calls)
+
+
+class TestLifecycleAndTimeoutWiring:
+    async def test_idle_auto_stop_exceeds_the_build_timeout(self) -> None:
+        """The bug this guards is subtle and expensive: Daytona counts INACTIVITY, and a
+        long cold install makes no API calls. An auto-stop shorter than the build would
+        kill healthy builds — and it would arrive as a mid-build death, which is the
+        hardest failure to diagnose."""
+        c = FakeClient(sentinel=_ok_sentinel())
+        await dr.run_build(REACT_FILES, engine="react", timeout_seconds=600, client=c)
+        idle_minutes = c.create_kwargs["auto_stop_interval"]
+        assert idle_minutes * 60 > 600
+
+    async def test_auto_delete_is_the_backstop(self) -> None:
+        """0 = delete immediately on stop, so a sandbox orphaned by OUR process dying is
+        still reaped without human action."""
+        c = FakeClient(sentinel=_ok_sentinel())
+        await dr.run_build(REACT_FILES, engine="react", timeout_seconds=600, client=c)
+        assert c.create_kwargs["auto_delete_interval"] == 0
+
+    async def test_our_exec_budget_is_looser_than_the_in_sandbox_one(self) -> None:
+        """The inner ``timeout(1)`` must win the race, because that path still runs the
+        trap and produces a sentinel. If ours fired first we would lose the evidence."""
+        c = FakeClient(sentinel=_ok_sentinel())
+        await dr.run_build(REACT_FILES, engine="react", timeout_seconds=600, client=c)
+        assert c.exec_timeout is not None and c.exec_timeout > 600
+
+    async def test_timeout_is_not_hardcoded(self) -> None:
+        c = FakeClient(sentinel=_ok_sentinel())
+        await dr.run_build(REACT_FILES, engine="react", timeout_seconds=1234, client=c)
+        assert c.exec_timeout == 1234 + dr.EXEC_TIMEOUT_SLACK_SECONDS
+
+    async def test_timings_are_recorded_for_every_phase(self) -> None:
+        c = FakeClient(sentinel=_ok_sentinel())
+        got = await dr.run_build(REACT_FILES, engine="react", timeout_seconds=600, client=c)
+        d = got.timings.as_dict()
+        assert set(d) == {"S_create", "U_upload", "IB_exec", "D_extract", "total"}
+        assert all(v >= 0 for v in d.values())
+
+
+class TestFailsBeforeSpendingMoney:
+    async def test_an_engine_whose_output_is_the_project_root_is_refused_pre_create(
+        self,
+    ) -> None:
+        """html's static output is ``.``, so an include-list cannot exclude
+        node_modules. Refusing BEFORE create_sandbox means a routing bug costs nothing
+        instead of a billed sandbox."""
+        c = FakeClient(sentinel=_ok_sentinel())
+        with pytest.raises(ValueError, match="project root"):
+            await dr.run_build(REACT_FILES, engine="html", timeout_seconds=600, client=c)
+        assert c.calls == []

--- a/tests/fixtures/mutate_restore_target.txt
+++ b/tests/fixtures/mutate_restore_target.txt
@@ -1,0 +1,7 @@
+# Inert, tracked fixture for scripts/mutate.py --restore tests.
+#
+# --restore recovers a file via `git checkout --`, so its target must be TRACKED;
+# a tmp-dir file cannot exercise that path at all. This file exists so those tests
+# never have to mutate a real module — nothing imports it, nothing reads it, and a
+# mutation left in it by a failed test cannot break anything.
+RESTORE_TARGET_SENTINEL = "original"

--- a/tests/mutations/_restore_fixture.json
+++ b/tests/mutations/_restore_fixture.json
@@ -1,0 +1,9 @@
+[
+  {
+    "label": "flip the restore fixture sentinel",
+    "file": "tests/fixtures/mutate_restore_target.txt",
+    "find": "RESTORE_TARGET_SENTINEL = \"original\"",
+    "replace": "RESTORE_TARGET_SENTINEL = \"mutated\"",
+    "tests": ["tests/test_mutate_sweep_marker.py::TestTheMarkerNeverOutlivesItsSweep::test_cleared_after_a_sweep_where_the_mutation_is_caught"]
+  }
+]

--- a/tests/mutations/build_state.json
+++ b/tests/mutations/build_state.json
@@ -1,0 +1,58 @@
+[
+  {
+    "label": "a missing build stamp reads as FRESH instead of stale, so a row that never got a stamp is permanently unpublishable with no error to see",
+    "file": "ee/pocketpaw_ee/sites/build_state.py",
+    "find": "    if stamp is None:\n        return True",
+    "replace": "    if stamp is None:\n        return False",
+    "tests": ["tests/ee/sites/test_build_state.py"]
+  },
+  {
+    "label": "the staleness window becomes a constant again, so a healthy long build gets a second sandbox enqueued on top of it",
+    "file": "ee/pocketpaw_ee/sites/build_state.py",
+    "find": "    return timedelta(seconds=max(0, timeout_seconds)) + STALE_MARGIN",
+    "replace": "    return STALE_MARGIN",
+    "tests": ["tests/ee/sites/test_build_state.py"]
+  },
+  {
+    "label": "a non-positive timeout yields a zero window, so every in-flight build reads as stale and the guard stops guarding",
+    "file": "ee/pocketpaw_ee/sites/build_state.py",
+    "find": "    return timedelta(seconds=max(0, timeout_seconds)) + STALE_MARGIN",
+    "replace": "    return timedelta(seconds=timeout_seconds)",
+    "tests": ["tests/ee/sites/test_build_state.py"]
+  },
+  {
+    "label": "queued stops counting as in-flight, so a publish waiting behind the cap enqueues a second build and spends twice",
+    "file": "ee/pocketpaw_ee/sites/build_state.py",
+    "find": "IN_FLIGHT_STATUSES: frozenset[str] = frozenset({\"queued\", \"building\"})",
+    "replace": "IN_FLIGHT_STATUSES: frozenset[str] = frozenset({\"building\"})",
+    "tests": ["tests/ee/sites/test_build_state.py"]
+  },
+  {
+    "label": "a terminal 'failed' status blocks a new build, so one bad build wedges the site until someone edits the database",
+    "file": "ee/pocketpaw_ee/sites/build_state.py",
+    "find": "    if status not in IN_FLIGHT_STATUSES:\n        return True",
+    "replace": "    if status in TERMINAL_STATUSES and status != \"failed\":\n        return True",
+    "tests": ["tests/ee/sites/test_build_state.py"]
+  },
+  {
+    "label": "a naive datetime is rejected as unreadable, so every row from an older writer looks stale and the guard silently stops blocking",
+    "file": "ee/pocketpaw_ee/sites/build_state.py",
+    "find": "    if value.tzinfo is None:\n        return value.replace(tzinfo=UTC)",
+    "replace": "    if value.tzinfo is None:\n        return None",
+    "tests": ["tests/ee/sites/test_build_state.py"]
+  },
+  {
+    "label": "is_in_flight is aliased to the spend decision, so a stale row renders as idle to a viewer while a build may still be running",
+    "file": "ee/pocketpaw_ee/sites/build_state.py",
+    "find": "    return getattr(doc, \"build_status\", None) in IN_FLIGHT_STATUSES\n\n\n__all__",
+    "replace": "    return not should_enqueue(doc, 600)\n\n\n__all__",
+    "tests": ["tests/ee/sites/test_build_state.py"]
+  },
+  {
+    "label": "build_job_id becomes transient like DP0-4's, so a client that reloads during a queued build loses its polling handle",
+    "file": "ee/pocketpaw_ee/cloud/models/site.py",
+    "find": "    build_job_id: str | None = None",
+    "replace": "    _build_job_id: str | None = PrivateAttr(default=None)",
+    "tests": ["tests/ee/sites/test_build_state.py"]
+  }
+]

--- a/tests/mutations/daytona_build.json
+++ b/tests/mutations/daytona_build.json
@@ -4,62 +4,98 @@
     "file": "ee/pocketpaw_ee/sites/daytona_build.py",
     "find": "_INFRA_EXIT_CODES = frozenset({_EXIT_SIGKILL, _EXIT_SIGTERM})",
     "replace": "_INFRA_EXIT_CODES = frozenset()",
-    "tests": ["tests/ee/sites/test_daytona_build.py"]
+    "tests": [
+      "tests/ee/sites/test_daytona_build.py"
+    ]
   },
   {
     "label": "the in-sandbox timeout exit code is no longer recognised, so a timeout is reported as a build failure with no retry",
     "file": "ee/pocketpaw_ee/sites/daytona_build.py",
     "find": "_EXIT_TIMEOUT = 124",
     "replace": "_EXIT_TIMEOUT = -999",
-    "tests": ["tests/ee/sites/test_daytona_build.py"]
+    "tests": [
+      "tests/ee/sites/test_daytona_build.py"
+    ]
   },
   {
     "label": "bool exit codes are coerced instead of rejected, so build_exit=False deploys an unbuilt site",
     "file": "ee/pocketpaw_ee/sites/daytona_build.py",
     "find": "    if isinstance(value, bool) or not isinstance(value, int):",
     "replace": "    if not isinstance(value, int):",
-    "tests": ["tests/ee/sites/test_daytona_build.py"]
+    "tests": [
+      "tests/ee/sites/test_daytona_build.py"
+    ]
   },
   {
     "label": "an unknown sentinel schema is trusted instead of refused, so field meanings are guessed at",
     "file": "ee/pocketpaw_ee/sites/daytona_build.py",
     "find": "    if parsed.get(\"schema\") != SENTINEL_SCHEMA:",
     "replace": "    if False:",
-    "tests": ["tests/ee/sites/test_daytona_build.py"]
+    "tests": [
+      "tests/ee/sites/test_daytona_build.py"
+    ]
   },
   {
     "label": "the empty-artifact check is removed, so a build that emits nothing deploys a blank site with every step reporting success",
     "find": "    if artifact_bytes <= 0:",
     "file": "ee/pocketpaw_ee/sites/daytona_build.py",
     "replace": "    if False:",
-    "tests": ["tests/ee/sites/test_daytona_build.py"]
+    "tests": [
+      "tests/ee/sites/test_daytona_build.py"
+    ]
   },
   {
     "label": "the timeout is sized on build alone, dropping the cold install that this lane pays on every build",
     "file": "ee/pocketpaw_ee/sites/daytona_build.py",
     "find": "    scaled = math.ceil((install + build) * safety_factor)",
     "replace": "    scaled = math.ceil(build * safety_factor)",
-    "tests": ["tests/ee/sites/test_daytona_build.py"]
+    "tests": [
+      "tests/ee/sites/test_daytona_build.py"
+    ]
   },
   {
     "label": "the timeout floor is dropped, so a small measurement produces a budget below the known cold-install cost",
     "file": "ee/pocketpaw_ee/sites/daytona_build.py",
     "find": "    return max(floor_seconds, scaled)",
     "replace": "    return scaled",
-    "tests": ["tests/ee/sites/test_daytona_build.py"]
+    "tests": [
+      "tests/ee/sites/test_daytona_build.py"
+    ]
   },
   {
     "label": "the project-root guard is removed, so html tars '.' and silently ships a node_modules-laden artifact",
     "file": "ee/pocketpaw_ee/sites/daytona_build.py",
     "find": "    if rel == \".\":",
     "replace": "    if False:",
-    "tests": ["tests/ee/sites/test_daytona_build.py"]
+    "tests": [
+      "tests/ee/sites/test_daytona_build.py"
+    ]
   },
   {
     "label": "the trap is registered AFTER the install, so a failing install writes no sentinel and is misclassified as infrastructure loss",
     "file": "ee/pocketpaw_ee/sites/daytona_build.py",
-    "find": "write_result() {{{writer}}}\ntrap write_result EXIT\n\ncd \"$PROJECT\" || exit 1",
-    "replace": "write_result() {{{writer}}}\n\ncd \"$PROJECT\" || exit 1",
-    "tests": ["tests/ee/sites/test_daytona_build.py"]
+    "find": "trap write_result EXIT\n\ncd \"$PROJECT\" || exit 1",
+    "replace": "cd \"$PROJECT\" || exit 1",
+    "tests": [
+      "tests/ee/sites/test_daytona_build.py"
+    ]
+  },
+  {
+    "label": "the per-engine timeout override is ignored, so svelte inherits react's budget even though its toolchain install is ~3x larger",
+    "file": "ee/pocketpaw_ee/sites/daytona_build.py",
+    "find": "        _TIMEOUT_ENV_PER_ENGINE.format(engine=normalize_engine(engine).upper()),",
+    "replace": "",
+    "tests": [
+      "tests/ee/sites/test_daytona_build.py"
+    ]
+  },
+  {
+    "label": "a non-positive timeout env value is accepted, so PAW_SITES_BUILD_TIMEOUT_SEC=0 disables the wedge detector entirely",
+    "file": "ee/pocketpaw_ee/sites/daytona_build.py",
+    "find": "        if value > 0:\n            return value",
+    "replace": "        return value",
+    "tests": [
+      "tests/ee/sites/test_daytona_build.py"
+    ]
   }
 ]

--- a/tests/mutations/daytona_build.json
+++ b/tests/mutations/daytona_build.json
@@ -1,0 +1,65 @@
+[
+  {
+    "label": "signalled deaths (SIGKILL/SIGTERM) stop being recognised, so a container OOM is reported to the user as their build failing",
+    "file": "ee/pocketpaw_ee/sites/daytona_build.py",
+    "find": "_INFRA_EXIT_CODES = frozenset({_EXIT_SIGKILL, _EXIT_SIGTERM})",
+    "replace": "_INFRA_EXIT_CODES = frozenset()",
+    "tests": ["tests/ee/sites/test_daytona_build.py"]
+  },
+  {
+    "label": "the in-sandbox timeout exit code is no longer recognised, so a timeout is reported as a build failure with no retry",
+    "file": "ee/pocketpaw_ee/sites/daytona_build.py",
+    "find": "_EXIT_TIMEOUT = 124",
+    "replace": "_EXIT_TIMEOUT = -999",
+    "tests": ["tests/ee/sites/test_daytona_build.py"]
+  },
+  {
+    "label": "bool exit codes are coerced instead of rejected, so build_exit=False deploys an unbuilt site",
+    "file": "ee/pocketpaw_ee/sites/daytona_build.py",
+    "find": "    if isinstance(value, bool) or not isinstance(value, int):",
+    "replace": "    if not isinstance(value, int):",
+    "tests": ["tests/ee/sites/test_daytona_build.py"]
+  },
+  {
+    "label": "an unknown sentinel schema is trusted instead of refused, so field meanings are guessed at",
+    "file": "ee/pocketpaw_ee/sites/daytona_build.py",
+    "find": "    if parsed.get(\"schema\") != SENTINEL_SCHEMA:",
+    "replace": "    if False:",
+    "tests": ["tests/ee/sites/test_daytona_build.py"]
+  },
+  {
+    "label": "the empty-artifact check is removed, so a build that emits nothing deploys a blank site with every step reporting success",
+    "find": "    if artifact_bytes <= 0:",
+    "file": "ee/pocketpaw_ee/sites/daytona_build.py",
+    "replace": "    if False:",
+    "tests": ["tests/ee/sites/test_daytona_build.py"]
+  },
+  {
+    "label": "the timeout is sized on build alone, dropping the cold install that this lane pays on every build",
+    "file": "ee/pocketpaw_ee/sites/daytona_build.py",
+    "find": "    scaled = math.ceil((install + build) * safety_factor)",
+    "replace": "    scaled = math.ceil(build * safety_factor)",
+    "tests": ["tests/ee/sites/test_daytona_build.py"]
+  },
+  {
+    "label": "the timeout floor is dropped, so a small measurement produces a budget below the known cold-install cost",
+    "file": "ee/pocketpaw_ee/sites/daytona_build.py",
+    "find": "    return max(floor_seconds, scaled)",
+    "replace": "    return scaled",
+    "tests": ["tests/ee/sites/test_daytona_build.py"]
+  },
+  {
+    "label": "the project-root guard is removed, so html tars '.' and silently ships a node_modules-laden artifact",
+    "file": "ee/pocketpaw_ee/sites/daytona_build.py",
+    "find": "    if rel == \".\":",
+    "replace": "    if False:",
+    "tests": ["tests/ee/sites/test_daytona_build.py"]
+  },
+  {
+    "label": "the trap is registered AFTER the install, so a failing install writes no sentinel and is misclassified as infrastructure loss",
+    "file": "ee/pocketpaw_ee/sites/daytona_build.py",
+    "find": "write_result() {{{writer}}}\ntrap write_result EXIT\n\ncd \"$PROJECT\" || exit 1",
+    "replace": "write_result() {{{writer}}}\n\ncd \"$PROJECT\" || exit 1",
+    "tests": ["tests/ee/sites/test_daytona_build.py"]
+  }
+]

--- a/tests/mutations/daytona_image.json
+++ b/tests/mutations/daytona_image.json
@@ -1,0 +1,37 @@
+[
+  {
+    "label": "bun is dropped from the sandbox image, so every source-lane build dies in-sandbox with a command-not-found buried in a build log",
+    "file": "ee/pocketpaw_ee/cloud/daytona/image.py",
+    "find": "            \"curl -fsSL https://bun.sh/install | BUN_INSTALL=/opt/bun bash\",\n",
+    "replace": "",
+    "tests": ["tests/cloud/test_daytona_image.py"]
+  },
+  {
+    "label": "the bun PATH symlink is dropped, so bun is installed but invisible to execute_command (which runs no login shell)",
+    "file": "ee/pocketpaw_ee/cloud/daytona/image.py",
+    "find": "            \"ln -sf /opt/bun/bin/bun /usr/local/bin/bun\",\n",
+    "replace": "",
+    "tests": ["tests/cloud/test_daytona_image.py"]
+  },
+  {
+    "label": "the image-build-time bun verification is dropped, so a broken install becomes one failed build per site instead of one failed image build",
+    "file": "ee/pocketpaw_ee/cloud/daytona/image.py",
+    "find": "            \"bun --version\",\n",
+    "replace": "",
+    "tests": ["tests/cloud/test_daytona_image.py"]
+  },
+  {
+    "label": "node is substituted away by bun, breaking the generated project's `node scripts/prune-client.mjs` build step and the vendored paw-sites CLI",
+    "file": "ee/pocketpaw_ee/cloud/daytona/image.py",
+    "find": "            \"curl -fsSL https://deb.nodesource.com/setup_20.x | bash -\",\n",
+    "replace": "",
+    "tests": ["tests/cloud/test_daytona_image.py"]
+  },
+  {
+    "label": "a blank DAYTONA_SANDBOX_IMAGE is treated as a real image reference instead of meaning 'use the prebuilt one'",
+    "file": "ee/pocketpaw_ee/cloud/daytona/image.py",
+    "find": "    if not val or val.lower() in (\"standard\", \"default\"):",
+    "replace": "    if val.lower() in (\"standard\", \"default\"):",
+    "tests": ["tests/cloud/test_daytona_image.py"]
+  }
+]

--- a/tests/test_mutate_sweep_marker.py
+++ b/tests/test_mutate_sweep_marker.py
@@ -226,3 +226,97 @@ class TestPytestSeesTheMarker:
             assert "some-mutation" in header
         finally:
             MARKER.unlink(missing_ok=True)
+
+
+class TestAPreExistingMarkerRefusesTheRun:
+    """The serious one, from a real incident on 2026-08-09.
+
+    Two files were found permanently mutated with NO marker to explain them. The
+    mechanism: sweep A is killed leaving a file mutated and the marker behind. Sweep B
+    starts, snapshots its "originals" FROM DISK — now containing A's mutation — runs, and
+    faithfully restores the mutation as though it were the original. B's cleanup then
+    deletes the marker, destroying the only evidence.
+
+    Warning was not enough, because CONTINUING is the step that bakes the mutation in.
+    So a pre-existing marker now refuses, and refusing must not destroy the evidence.
+    """
+
+    def _plan(self, tmp_path: Path) -> Path:
+        return _write_plan(
+            tmp_path,
+            [
+                {
+                    "label": "queued stops counting as in-flight",
+                    "file": _target(),
+                    "find": _ANCHOR,
+                    "replace": 'IN_FLIGHT_STATUSES: frozenset[str] = frozenset({"building"})',
+                    "tests": ["tests/ee/sites/test_build_state.py"],
+                }
+            ],
+        )
+
+    def test_refuses_and_exits_non_zero(self, tmp_path: Path) -> None:
+        MARKER.write_text("started : 2026-08-09T10:00:00+00:00\ncurrent : x\n", encoding="utf-8")
+        try:
+            proc = _run(self._plan(tmp_path))
+            assert proc.returncode != 0
+            assert "REFUSING TO RUN" in (proc.stdout + proc.stderr)
+        finally:
+            MARKER.unlink(missing_ok=True)
+
+    def test_refusing_preserves_the_evidence(self, tmp_path: Path) -> None:
+        """The marker is the only thing that explains a mutated file. Deleting it on
+        refusal would reproduce the exact incident this guard exists to stop."""
+        MARKER.write_text("started : 2026-08-09T10:00:00+00:00\ncurrent : x\n", encoding="utf-8")
+        try:
+            _run(self._plan(tmp_path))
+            assert MARKER.exists(), "refusal must preserve the marker for inspection"
+        finally:
+            MARKER.unlink(missing_ok=True)
+
+    def test_refusing_applies_no_mutation(self, tmp_path: Path) -> None:
+        target = REPO_ROOT / _target()
+        before = target.read_bytes()
+        MARKER.write_text("started : 2026-08-09T10:00:00+00:00\ncurrent : x\n", encoding="utf-8")
+        try:
+            _run(self._plan(tmp_path))
+            assert target.read_bytes() == before
+        finally:
+            MARKER.unlink(missing_ok=True)
+
+    def test_force_proceeds_past_the_marker(self, tmp_path: Path) -> None:
+        """The escape hatch, for a marker whose files are already verified clean.
+        Deliberately explicit — the default must be refusal."""
+        MARKER.write_text("started : 2026-08-09T10:00:00+00:00\ncurrent : x\n", encoding="utf-8")
+        try:
+            proc = subprocess.run(
+                [sys.executable, str(MUTATE), "--plan", str(self._plan(tmp_path)), "--force"],
+                capture_output=True,
+                text=True,
+                cwd=REPO_ROOT,
+            )
+            assert proc.returncode == 0, proc.stdout + proc.stderr
+            assert "caught" in proc.stdout
+        finally:
+            MARKER.unlink(missing_ok=True)
+
+
+class TestTheMarkerTellsReadersNotToTrustThePid:
+    def test_pid_is_labelled_informational(self) -> None:
+        """A reviewer used the pid to decide "live or stranded", found it not running,
+        and was about to restore a file from under a healthy sweep. Any pid check is racy
+        by construction — the process can exit between reading the file and looking it up
+        — so the file's presence has to be the authority."""
+        import sys as _sys
+
+        _sys.path.insert(0, str(REPO_ROOT / "scripts"))
+        import mutate
+
+        mutate._write_marker(Path("some/plan.json"), "a-mutation")
+        try:
+            text = MARKER.read_text(encoding="utf-8")
+            assert "INFORMATIONAL ONLY" in text
+            assert "PRESENCE OF THIS FILE IS THE AUTHORITATIVE SIGNAL" in text
+            assert "racy" in text
+        finally:
+            MARKER.unlink(missing_ok=True)

--- a/tests/test_mutate_sweep_marker.py
+++ b/tests/test_mutate_sweep_marker.py
@@ -146,3 +146,83 @@ class TestABadAnchorIsLoud:
         # Validation is upfront, so NOTHING ran — not even the valid first mutation.
         assert "caught" not in proc.stdout
         assert "ESCAPED" not in proc.stdout
+
+
+class TestMarkerAgeDecidesLiveVsAbandoned:
+    """A pre-existing marker is always reported, but the age changes WHAT it says:
+    recent means another sweep may be racing this one, old means a crashed run left it.
+    Biased toward "possibly live" because that is the cheap mistake — calling a live
+    sweep stale tells a reader to trust results taken while a file was mutated."""
+
+    def test_our_own_stamp_format_parses(self) -> None:
+        """Pinned because the stamp is an ISO timestamp full of colons and the parser
+        splits on the first one. It works because the writer emits ``started : <iso>``
+        with a space before the colon — a formatting change would silently break dating
+        and every marker would read as undatable."""
+        import sys
+
+        sys.path.insert(0, str(REPO_ROOT / "scripts"))
+        from datetime import UTC, datetime
+
+        import mutate
+
+        line = f"started : {datetime.now(UTC).isoformat(timespec='seconds')}"
+        age = mutate.marker_age(line)
+        assert age is not None
+        assert age.total_seconds() < 60
+
+    def test_an_undatable_marker_is_not_treated_as_stale(self) -> None:
+        import sys
+
+        sys.path.insert(0, str(REPO_ROOT / "scripts"))
+        import mutate
+
+        assert mutate.marker_age("no start line here") is None
+
+    def test_a_recent_marker_warns_about_a_concurrent_sweep(self) -> None:
+        import sys
+
+        sys.path.insert(0, str(REPO_ROOT / "scripts"))
+        from datetime import UTC, datetime, timedelta
+
+        import mutate
+
+        recent = datetime.now(UTC) - timedelta(minutes=2)
+        age = mutate.marker_age(f"started : {recent.isoformat(timespec='seconds')}")
+        assert age is not None and age < mutate.STALE_MARKER_AFTER
+
+    def test_an_old_marker_is_past_the_abandoned_threshold(self) -> None:
+        import sys
+
+        sys.path.insert(0, str(REPO_ROOT / "scripts"))
+        from datetime import UTC, datetime, timedelta
+
+        import mutate
+
+        old = datetime.now(UTC) - timedelta(hours=3)
+        age = mutate.marker_age(f"started : {old.isoformat(timespec='seconds')}")
+        assert age is not None and age > mutate.STALE_MARKER_AFTER
+
+
+class TestPytestSeesTheMarker:
+    """The compensating channel for gitignoring the marker: pytest's own report header,
+    which fires on the path a reader actually takes."""
+
+    def test_report_header_is_silent_when_no_sweep_is_running(self) -> None:
+        from tests.conftest import pytest_report_header
+
+        assert not MARKER.exists()
+        assert pytest_report_header() is None
+
+    def test_report_header_shouts_when_a_marker_exists(self) -> None:
+        from tests.conftest import pytest_report_header
+
+        MARKER.write_text("current : some-mutation [a/b.py]\n", encoding="utf-8")
+        try:
+            header = pytest_report_header()
+            assert header is not None
+            assert "MUTATION SWEEP IS RUNNING" in header
+            assert "NOT regressions" in header
+            assert "some-mutation" in header
+        finally:
+            MARKER.unlink(missing_ok=True)

--- a/tests/test_mutate_sweep_marker.py
+++ b/tests/test_mutate_sweep_marker.py
@@ -1,0 +1,148 @@
+# tests/test_mutate_sweep_marker.py — the sweep marker in scripts/mutate.py.
+#
+# Created 2026-08-09. mutate.py had no tests, which is a little ironic for the tool
+# whose whole argument is that untested code agrees with untested tests.
+#
+# WHY THE MARKER EXISTS, since that is what these assert. Mutations are applied IN
+# PLACE, so while one is live the working tree really does contain broken code. On
+# 2026-08-09 a reviewer ran the suite during a sweep, saw a bun-PATH assertion fail,
+# and reported it as a regression — it was this script working correctly. The marker
+# gives a concurrent reader something `git status` will surface.
+#
+# The marker must never OUTLIVE its sweep, because a permanent marker trains people to
+# ignore it, and the one case it needs to be believed is a crashed run that left a file
+# mutated. So the tests below care most about the cleanup paths — including the
+# SystemExit path, which does not pass through the try/finally and needed atexit.
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MUTATE = REPO_ROOT / "scripts" / "mutate.py"
+MARKER = REPO_ROOT / ".mutation-sweep-active"
+
+
+def _run(plan_path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(MUTATE), "--plan", str(plan_path)],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+
+
+def _write_plan(tmp_path: Path, mutations: list[dict]) -> Path:
+    # Plans resolve `file` against REPO_ROOT, so the target must be a real repo file;
+    # the plan itself can live anywhere.
+    plan = tmp_path / "plan.json"
+    plan.write_text(json.dumps(mutations), encoding="utf-8")
+    return plan
+
+
+def _target() -> str:
+    """A repo file with a stable, unique anchor. build_state.py is this sprint's and
+    its frozenset literal appears exactly once."""
+    return "ee/pocketpaw_ee/sites/build_state.py"
+
+
+_ANCHOR = 'IN_FLIGHT_STATUSES: frozenset[str] = frozenset({"queued", "building"})'
+
+
+class TestTheMarkerNeverOutlivesItsSweep:
+    def test_cleared_after_a_sweep_where_the_mutation_is_caught(self, tmp_path: Path) -> None:
+        plan = _write_plan(
+            tmp_path,
+            [
+                {
+                    "label": "queued stops counting as in-flight",
+                    "file": _target(),
+                    "find": _ANCHOR,
+                    "replace": 'IN_FLIGHT_STATUSES: frozenset[str] = frozenset({"building"})',
+                    "tests": ["tests/ee/sites/test_build_state.py"],
+                }
+            ],
+        )
+        proc = _run(plan)
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        assert not MARKER.exists()
+
+    def test_cleared_when_the_plan_aborts_on_a_bad_anchor(self, tmp_path: Path) -> None:
+        """The path that needed ``atexit``. Plan validation raises SystemExit BEFORE the
+        try/finally is entered, so a marker written just beforehand would otherwise
+        survive forever — and a permanent marker trains people to ignore it."""
+        plan = _write_plan(
+            tmp_path,
+            [
+                {
+                    "label": "anchor that does not exist",
+                    "file": _target(),
+                    "find": "this text is definitely not in the file",
+                    "replace": "nor is this",
+                    "tests": ["tests/ee/sites/test_build_state.py"],
+                }
+            ],
+        )
+        proc = _run(plan)
+        assert proc.returncode != 0
+        assert "anchor not found" in (proc.stdout + proc.stderr)
+        assert not MARKER.exists()
+
+    def test_the_file_is_restored_after_the_sweep(self, tmp_path: Path) -> None:
+        """Restoration is the thing this script must never get wrong; the marker is
+        only the signal. Asserted together because a leftover marker and a leftover
+        mutation are the same incident."""
+        target = REPO_ROOT / _target()
+        before = target.read_bytes()
+        plan = _write_plan(
+            tmp_path,
+            [
+                {
+                    "label": "queued stops counting as in-flight",
+                    "file": _target(),
+                    "find": _ANCHOR,
+                    "replace": 'IN_FLIGHT_STATUSES: frozenset[str] = frozenset({"building"})',
+                    "tests": ["tests/ee/sites/test_build_state.py"],
+                }
+            ],
+        )
+        _run(plan)
+        assert target.read_bytes() == before
+        assert not MARKER.exists()
+
+
+class TestABadAnchorIsLoud:
+    def test_an_unmatched_anchor_exits_non_zero_and_runs_nothing(self, tmp_path: Path) -> None:
+        """This already worked — recorded as a test because I reported it as broken.
+
+        The real trap is on the CALLER's side: chaining sweeps with ``;`` and piping
+        through ``tail`` discards the non-zero exit, so an aborted plan looks like a
+        pass next to another plan's success line. Use ``&&``, or check ``$?`` per plan.
+        """
+        plan = _write_plan(
+            tmp_path,
+            [
+                {
+                    "label": "good anchor that would be caught",
+                    "file": _target(),
+                    "find": _ANCHOR,
+                    "replace": 'IN_FLIGHT_STATUSES: frozenset[str] = frozenset({"building"})',
+                    "tests": ["tests/ee/sites/test_build_state.py"],
+                },
+                {
+                    "label": "bad anchor later in the same plan",
+                    "file": _target(),
+                    "find": "definitely absent",
+                    "replace": "x",
+                    "tests": ["tests/ee/sites/test_build_state.py"],
+                },
+            ],
+        )
+        proc = _run(plan)
+        assert proc.returncode != 0
+        # Validation is upfront, so NOTHING ran — not even the valid first mutation.
+        assert "caught" not in proc.stdout
+        assert "ESCAPED" not in proc.stdout

--- a/tests/test_mutate_sweep_marker.py
+++ b/tests/test_mutate_sweep_marker.py
@@ -320,3 +320,126 @@ class TestTheMarkerTellsReadersNotToTrustThePid:
             assert "racy" in text
         finally:
             MARKER.unlink(missing_ok=True)
+
+
+# --- --restore --------------------------------------------------------------------
+#
+# A hard kill bypasses BOTH cleanup paths by construction: the ``finally`` never runs and
+# neither does ``atexit``. An agent interrupt is a hard kill, and one on 2026-08-09 left
+# a source file carrying a mutation with the marker stranded. So in-place restore can
+# never be made crash-safe and the durable protection has to be detect-and-recover. The
+# marker was the detect half; ``--restore`` is the recover half.
+#
+# These use an inert TRACKED fixture rather than a real module: ``--restore`` recovers via
+# ``git checkout --``, so a tmp-dir file cannot exercise the path at all, and mutating a
+# module another agent owns to test recovery would be its own hazard.
+
+RESTORE_TARGET_REL = "tests/fixtures/mutate_restore_target.txt"
+RESTORE_PLAN_REL = "tests/mutations/_restore_fixture.json"
+_STALE_STAMP = "2026-08-09T01:00:00+00:00"
+_MUTATED = 'RESTORE_TARGET_SENTINEL = "mutated"'
+_ORIGINAL = 'RESTORE_TARGET_SENTINEL = "original"'
+
+
+def _write_marker_file(stamp: str, current: str) -> None:
+    MARKER.write_text(
+        f"plan    : {RESTORE_PLAN_REL}\nstarted : {stamp}\ncurrent : {current}\n",
+        encoding="utf-8",
+    )
+
+
+def _restore() -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(MUTATE), "--restore"],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+
+
+def _current_marker_line() -> str:
+    return f"flip the restore fixture sentinel  [{RESTORE_TARGET_REL}]"
+
+
+class TestRestoreRecoversFromAHardKill:
+    def _target(self) -> Path:
+        return REPO_ROOT / RESTORE_TARGET_REL
+
+    def _mutate_fixture(self) -> None:
+        t = self._target()
+        t.write_text(t.read_text(encoding="utf-8").replace(_ORIGINAL, _MUTATED), encoding="utf-8")
+
+    def teardown_method(self) -> None:
+        MARKER.unlink(missing_ok=True)
+        subprocess.run(["git", "checkout", "--", RESTORE_TARGET_REL], cwd=REPO_ROOT, check=False)
+
+    def test_no_marker_does_nothing_and_exits_zero(self) -> None:
+        """Safe to run blind — that is the point of a recovery command."""
+        MARKER.unlink(missing_ok=True)
+        proc = _restore()
+        assert proc.returncode == 0
+        assert "Nothing to restore" in proc.stdout
+
+    def test_restores_a_file_whose_only_change_is_the_mutation(self) -> None:
+        self._mutate_fixture()
+        _write_marker_file(_STALE_STAMP, _current_marker_line())
+        proc = _restore()
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        assert _ORIGINAL in self._target().read_text(encoding="utf-8")
+        assert not MARKER.exists()
+
+    def test_tells_the_operator_to_re_run_the_plan(self) -> None:
+        """A restore is not proof the gate still catches — the whole point of the tool is
+        that a passing-looking state can be a lie."""
+        self._mutate_fixture()
+        _write_marker_file(_STALE_STAMP, _current_marker_line())
+        proc = _restore()
+        assert "Re-run the plan" in proc.stdout
+        assert RESTORE_PLAN_REL in proc.stdout
+
+    def test_refuses_when_the_marker_looks_live(self) -> None:
+        """Recovering a RUNNING sweep is worse than not recovering a dead one, so the bias
+        is toward leaving it alone."""
+        from datetime import UTC, datetime
+
+        self._mutate_fixture()
+        _write_marker_file(datetime.now(UTC).isoformat(timespec="seconds"), _current_marker_line())
+        proc = _restore()
+        assert proc.returncode != 0
+        assert "looks LIVE" in proc.stdout
+        assert _MUTATED in self._target().read_text(encoding="utf-8"), "must not touch the file"
+        assert MARKER.exists(), "must not destroy the evidence"
+
+    def test_refuses_when_real_edits_are_mixed_in_with_the_mutation(self) -> None:
+        """The case where guessing is destructive. This cannot tell which lines are
+        someone's real work, so it stops rather than deleting them to save three manual
+        steps."""
+        self._mutate_fixture()
+        target = self._target()
+        target.write_text(
+            target.read_text(encoding="utf-8") + "# a real edit that must survive\n",
+            encoding="utf-8",
+        )
+        _write_marker_file(_STALE_STAMP, _current_marker_line())
+        proc = _restore()
+        assert proc.returncode != 0
+        assert "BEYOND the mutation" in proc.stdout
+        body = target.read_text(encoding="utf-8")
+        assert "# a real edit that must survive" in body
+        assert MARKER.exists()
+
+    def test_clears_a_stale_marker_when_the_file_is_already_clean(self) -> None:
+        """A crash between restoring the file and clearing the marker leaves exactly this
+        state, and it must resolve to "nothing to do" rather than an error."""
+        _write_marker_file(_STALE_STAMP, _current_marker_line())
+        proc = _restore()
+        assert proc.returncode == 0
+        assert "already matches HEAD" in proc.stdout
+        assert not MARKER.exists()
+
+    def test_clears_a_marker_that_died_before_applying_a_mutation(self) -> None:
+        _write_marker_file(_STALE_STAMP, "(validating the plan)")
+        proc = _restore()
+        assert proc.returncode == 0
+        assert "no applied mutation" in proc.stdout
+        assert not MARKER.exists()


### PR DESCRIPTION
Builds a Daytona-backed ephemeral build lane for source-engine Paw Sites, and proves it against live Daytona rather than a mock. Nothing is wired into the publish path yet — this is the build lane and its decision core.

## Measured live, per engine

```
react    S 3.08  U 1.08  install+build  2.95  D 1.59  total  8.70   61,487 B   4 entries
svelte   S 1.70  U 1.33  install+build 10.11  D 1.53  total 14.67   33,104 B  24 entries
```

Real generator output, uploaded to a real sandbox, built, artifact extracted, sandbox verified gone after every run. Svelte's install-and-build is ~3.4x react's, matching the dep sets: react pulls 4 direct dependencies, svelte pulls SvelteKit plus adapter-cloudflare.

These numbers correct an earlier projection in the design docs by roughly three orders of magnitude. That projection extrapolated cold-install cost from `scaffold.py`'s `INSTALL_TIMEOUT = 600`, which is sized for the SvelteKit toolchain. React installs in about 455ms. The consequence is that both engines fit inside a synchronous request comfortably, so making publish asynchronous is less urgent than the design docs claim — though it remains a prerequisite before this lane can serve a real publish.

## The decision core: make the build prove it finished

A self-deleting container cannot be asked whether it died, and "sandbox not found" means both "deleted normally" and "died and was reaped". So the inference is inverted: the build must produce positive evidence that it completed, and absence of evidence is treated as infrastructure loss.

An in-sandbox wrapper writes a sentinel under a shell `trap … EXIT`, so even a failing build produces one carrying its exit code and stderr tail. It is read before teardown. The wall clock is ours, started before the sandbox exists, so it survives the container's death with no API call.

| sentinel | exit | clock | outcome |
|---|---|---|---|
| present | 0 | under budget | deploy |
| present | non-zero | under budget | build failed — surface stderr, no retry |
| absent | — | at or over | timed out — retry eligible |
| absent | — | under budget | infrastructure lost — retry, then fall back |

Only the second row reaches a user as their problem, and getting there needs proof. Signalled deaths (137/143) classify as infrastructure rather than build failure, because a signalled process still runs the trap and would otherwise be indistinguishable from a genuine failure. Exit 0 alone is not accepted either: an empty artifact is a build failure, checked inside the classifier so no caller can forget it.

## Artifact extraction, and what the tarballs actually contain

Extraction is an include-list of one directory — `static_output_rel(engine)` — rather than an exclude-list. `node_modules` is excluded by construction, and the failure mode inverts usefully: a wrong exclude-list ships junk silently, a wrong include-list ships nothing loudly.

Verified from the extracted tarballs rather than inferred from a predicate:

- svelte's artifact contains `./_worker.js`, the server entry
- react's does not — four entries, pure static
- neither contains any `node_modules` entry

Note for the deploy slice: `.assetsignore` is absent from svelte's artifact and adapter-cloudflare does not emit it, so the deploy step must add it or wrangler 4.x hard-errors with "Uploading a Pages `_worker.js` file as an asset". React never hits this.

## Timeout

Ships a 600s floor as the default, resolved per-engine env, then shared env, then floor. The shared name is `PAW_SITES_BUILD_TIMEOUT_SEC` — deliberately the same knob the local builder path uses, so an operator has one name rather than two. A per-engine override exists because svelte and react differ by more than a constant factor.

## Two things measurement forced out

Daytona's delete is eventually consistent: a successful teardown still appears in the account listing for a few seconds. A single check reported a false failure on a teardown that had worked, so teardown is now polled. This also means a concurrency cap read off a live listing would over-admit.

The idle auto-stop window is derived from the build budget rather than fixed. Daytona counts inactivity, and a long install makes no API calls, so a fixed window shorter than the build would kill healthy builds — arriving as the hardest failure to diagnose.

## Scope

No Cloudflare deploy, no async publish, no queue, no `queued` state. The build sandbox is never snapshotted; that is stated as an invariant in the runner's header, because caching `node_modules` in a snapshot is the obvious optimisation that would undo it.

## Verification

```
$ python -m pytest tests/ee/sites/test_daytona_build.py tests/ee/sites/test_daytona_runner.py tests/cloud/test_daytona_image.py -q
76 passed

$ python scripts/mutate.py --plan tests/mutations/daytona_build.json
all 11 mutations caught
```

Run independently of the authoring agent. One caveat a reviewer should know: `mutate.py` reports `anchor not found` without failing the run, so a multi-line anchor against a CRLF file looks like a pass while the gate is actually skipped. That happened during development and is fixed; both files are back to LF. It is worth knowing generally, since every other mutation plan in the repo uses single-line anchors.

## Settled after review: svelte still needs a Worker

A reviewer asked whether svelte would still emit `_worker.js` once the lead-capture route is removed, since the tarball above was built from a project that still had it. Tested against real build output: with `src/routes/api/` deleted and `prerender = true`, `.svelte-kit/cloudflare/` still contains `_worker.js` at 4,335 bytes.

The capture route was never the reason. `_worker.js` imports SvelteKit's `Server` and the route manifest — `adapter-cloudflare` always emits a Server shell. `_routes.json` shows what it takes: `include: ["/*"]` with only immutable assets and the root excluded, so the worker handles 404s and any non-prerendered path.

So `emits_server_worker("svelte")` has not drifted from reality, and Cloudflare Pages does not fit the surface as long as svelte is an engine. A worker-free svelte build would mean switching to `adapter-static`, which is a different adapter rather than a config change, and gives up the 404 route and the non-prerendered fallback.

One more thing the deploy slice needs: `_headers` **is** emitted, carrying the immutable-asset cache policy and `X-Robots-Tag: noindex` on `/_app/*`. Whatever deploys this has to preserve it rather than treat the output as an opaque asset directory.
