### PR TITLE
Prove the build lane's fallback ladder by injecting the faults

### DIFF
--- a/ee/pocketpaw_ee/sites/daytona_build.py
+++ b/ee/pocketpaw_ee/sites/daytona_build.py
@@ -415,13 +415,21 @@ def classify_build(
 #: it packs one NESTED INSIDE it without complaint. Neither engine emits that shape today,
 #: so this closes a latent 500 MB-artifact path rather than a live bug.
 #:
-#: Written as the member name the tar actually produces. Under ``-C <dir> .`` members are
-#: recorded as ``./x``, so the pattern has to match that form. Verified against bsdtar 3.8.4,
-#: where it prunes the directory and everything under it and leaves an innocently-named
-#: ``node_modules_report.html`` alone. The Daytona image is ``debian_slim``, i.e. GNU tar —
-#: whose exclude-anchoring differs in the deeper-nesting case, so the real-sandbox round-trip
-#: is what confirms behaviour beyond the top level.
-_EXCLUDED_MEMBER = "./node_modules"
+#: DELIBERATELY UNANCHORED — no ``./`` prefix, and that is the whole point.
+#:
+#: This was ``"./node_modules"``, written to match the member form ``-C <dir> .`` produces,
+#: and verified against bsdtar, which matches an exclude pattern unanchored either way. The
+#: Daytona image is ``debian_slim``, i.e. GNU tar, which ANCHORS a pattern containing a
+#: slash — so ``./node_modules`` matched only the top-level directory there and a
+#: ``dist/sub/node_modules`` shipped. CI caught exactly that, and it is not hypothetical:
+#: measured on GNU tar 1.35, ``--exclude=./node_modules`` leaves ``./sub/node_modules/``
+#: in the archive while ``--exclude=node_modules`` removes every one at any depth.
+#:
+#: A bare name is matched unanchored by BOTH tars, so this form closes the hole on the
+#: image and keeps the dev box agreeing with CI. It still prunes only a path COMPONENT
+#: named exactly ``node_modules``, so an innocently-named ``node_modules_report.html``
+#: survives.
+_EXCLUDED_MEMBER = "node_modules"
 
 
 def artifact_tar_command(

--- a/ee/pocketpaw_ee/sites/daytona_build.py
+++ b/ee/pocketpaw_ee/sites/daytona_build.py
@@ -205,7 +205,12 @@ class BuildClassification:
     outcome: BuildOutcome
     #: Short machine-readable reason, for logs and metrics. Never user-facing prose.
     reason: str
-    #: May the lane retry (and then fall back to the local builder)?
+    #: May the lane attempt this build again? Corrected 2026-08-10 (SG-7): this used to
+    #: read "and then fall back to the local builder", which describes a fallback the
+    #: captain overrode — the ruling is Daytona-ONLY, so a lane that runs out of retries
+    #: fails loudly rather than building somewhere else. Nothing retries yet either; no
+    #: caller consumes this flag, so it is a contract for the wiring phase, not a
+    #: description of current behaviour.
     retryable: bool
     #: Is this the user's build being wrong? Only ever True for ``build_failed``.
     blames_user: bool
@@ -215,7 +220,17 @@ class BuildClassification:
 
     @property
     def deployable(self) -> bool:
-        """True only when there is a verified artifact to deploy."""
+        """True when the CLASSIFICATION cleared the build — not when its bytes were checked.
+
+        Corrected 2026-08-10 (SG-7): this used to claim "there is a verified artifact to
+        deploy", which overpromised in a way that matters. It is derived from the sentinel
+        alone, so it stays True when the download afterwards returns zero bytes or a
+        truncated payload — nothing here has seen the artifact.
+
+        A caller must therefore gate a deploy on ``BuildRunResult.ok`` (which also requires
+        bytes to have arrived), never on this flag by itself. Whoever wires this lane owns
+        the download verification; see the SG-7 wiring contracts.
+        """
         return self.outcome == "completed_ok"
 
 
@@ -394,6 +409,21 @@ def classify_build(
 # ---------------------------------------------------------------------------
 
 
+#: Excluded from the artifact even though the include-list already scopes the tar to the
+#: output dir. NOT redundant — SG-7 measured the gap: ``-C <project>/dist .`` cannot reach a
+#: ``node_modules`` that sits BESIDE the output dir (the shape ``bun install`` produces), but
+#: it packs one NESTED INSIDE it without complaint. Neither engine emits that shape today,
+#: so this closes a latent 500 MB-artifact path rather than a live bug.
+#:
+#: Written as the member name the tar actually produces. Under ``-C <dir> .`` members are
+#: recorded as ``./x``, so the pattern has to match that form. Verified against bsdtar 3.8.4,
+#: where it prunes the directory and everything under it and leaves an innocently-named
+#: ``node_modules_report.html`` alone. The Daytona image is ``debian_slim``, i.e. GNU tar —
+#: whose exclude-anchoring differs in the deeper-nesting case, so the real-sandbox round-trip
+#: is what confirms behaviour beyond the top level.
+_EXCLUDED_MEMBER = "./node_modules"
+
+
 def artifact_tar_command(
     engine: str | None,
     project_dir: str,
@@ -408,9 +438,11 @@ def artifact_tar_command(
 
     Two properties follow, and both are the reason for the choice:
 
-    * ``node_modules`` is excluded **by construction** for every engine whose output
-      is a subdirectory (``dist``, ``.svelte-kit/cloudflare``). There is no filter to
-      get wrong, so the 500 MB-on-the-wire failure cannot occur.
+    * ``node_modules`` is excluded for every engine whose output is a subdirectory
+      (``dist``, ``.svelte-kit/cloudflare``) — by the ``-C`` scope for a SIBLING copy, and
+      by :data:`_EXCLUDED_MEMBER` for one nested inside the output dir. The second half is
+      not redundant: SG-7 measured that ``-C dist .`` packs ``dist/node_modules/``, so the
+      scope alone did not make the 500 MB-on-the-wire failure impossible.
     * The failure mode inverts usefully. A wrong exclude-list ships junk SILENTLY; a
       wrong include-list ships NOTHING, LOUDLY — caught by ``artifact_bytes <= 0`` in
       :func:`classify_build` before anything is deployed.
@@ -428,7 +460,10 @@ def artifact_tar_command(
             "lane is for engines whose build writes a subdirectory"
         )
     output_dir = f"{project_dir.rstrip('/')}/{rel}"
-    return f"tar -czf {shlex.quote(dest_path)} -C {shlex.quote(output_dir)} ."
+    return (
+        f"tar -czf {shlex.quote(dest_path)} -C {shlex.quote(output_dir)} "
+        f"--exclude={shlex.quote(_EXCLUDED_MEMBER)} ."
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ee/sites/faults.py
+++ b/tests/ee/sites/faults.py
@@ -1,0 +1,453 @@
+# tests/ee/sites/faults.py — reusable FAULT INJECTORS for the sites build + deploy lane.
+#
+# Created 2026-08-10 (SG-7, the fault ladder).
+#
+# WHY THIS IS A MODULE AND NOT A FIXTURE FILE OR A BLOCK INSIDE ONE TEST. The two faults
+# the rest of the program keeps needing — "Daytona is unavailable" and "the deploy
+# answered 5xx" — are each injected at a boundary that took reading three modules to
+# locate. A sibling task re-deriving those patch points is not just slow, it is how two
+# tests end up injecting at DIFFERENT depths and disagreeing about what the lane does.
+# Import from here instead; if a patch point moves, it moves once.
+#
+# Deliberately a plain importable module (``from tests.ee.sites.faults import ...``,
+# which the tree already does in test_pipeline_regression_gate.py) rather than fixtures
+# in conftest.py. Fixtures are autouse-shaped and per-test; these are constructors a test
+# picks up when it wants one, and several tests need TWO of them in one call.
+#
+# WHAT EACH INJECTOR PROMISES: it fails at a real seam the production code actually
+# calls, with the exception type that seam actually raises. Where the real exception
+# comes from a third-party SDK whose type is not part of our contract (Daytona's 5xx),
+# the injector raises a documented stand-in and says so — every caller in this lane
+# treats sandbox exceptions uniformly, so the type is not what is under test.
+
+from __future__ import annotations
+
+import io
+import json
+import tarfile
+from dataclasses import dataclass, field
+from typing import Any
+
+from pocketpaw_ee.sites import daytona_build as db
+
+# ---------------------------------------------------------------------------
+# Sentinels — the evidence a build writes to prove it completed
+# ---------------------------------------------------------------------------
+
+#: Exit codes that must classify as infrastructure, never as the user's broken build.
+#: Re-exported from the module under test on purpose: hard-coding 137 here would let a
+#: rename in production drift past these tests silently.
+EXIT_TIMEOUT = 124
+EXIT_SIGKILL = 137
+EXIT_SIGTERM = 143
+
+
+def ok_sentinel(**over: Any) -> dict[str, Any]:
+    """A sentinel describing a clean react build. ``over`` mutates any field.
+
+    The base case is deliberately the HAPPY one so every degraded sentinel in the suite
+    reads as a one-field delta from success — which is what the classifier's callers care
+    about, and it keeps a test's intent visible on one line
+    (``ok_sentinel(build_exit=EXIT_SIGKILL)``).
+    """
+    base = {
+        "schema": db.SENTINEL_SCHEMA,
+        "engine": "react",
+        "install_exit": 0,
+        "build_exit": 0,
+        "artifact_rel": "dist",
+        # Promises what ``FaultyDaytonaClient`` actually hands back, rather than a round
+        # number. A TRUTHFULNESS fix, not scaffolding for a gate: nothing compares the two
+        # today, so a hardcoded 4096 beside a ~170-byte artifact is simply a fiction a
+        # reader would have to discover. It also matters the moment download verification
+        # arrives, since that is precisely the comparison it will make.
+        "artifact_bytes": len(clean_artifact()),
+        "stderr_tail": "",
+    }
+    base.update(over)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Artifacts — real gzip tars, so a verification gate is tested against real bytes
+# ---------------------------------------------------------------------------
+
+
+def tar_bytes(members: dict[str, bytes]) -> bytes:
+    """Pack ``{arcname: contents}`` into a real ``.tar.gz``.
+
+    A real tar rather than a sentinel string because the thing under test reads the
+    archive index. A fake byte-blob would prove only that the gate rejects garbage, which
+    is the easy half; the interesting half is that it accepts a well-formed artifact and
+    rejects a well-formed one carrying the wrong member.
+    """
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        for name, contents in members.items():
+            info = tarfile.TarInfo(name=name)
+            info.size = len(contents)
+            tar.addfile(info, io.BytesIO(contents))
+    return buf.getvalue()
+
+
+def clean_artifact() -> bytes:
+    """A static output tree as the include-list tar would produce it."""
+    return tar_bytes(
+        {
+            "./index.html": b"<!doctype html><title>hi</title>",
+            "./assets/app.js": b"console.log(1)",
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# F5 — exercising the include-list itself, with a real tar
+# ---------------------------------------------------------------------------
+#
+# WHY A REAL TAR AND NOT A HAND-BUILT ONE. The property under test is that
+# ``artifact_tar_command``'s include-list CANNOT pick up ``node_modules`` — and that is a
+# property of the COMMAND, not of any bytes we could assemble ourselves. Packing a fake
+# artifact and scanning it would test the scanner. Putting node_modules on disk and
+# running the real command is the only way the construction is the thing being exercised,
+# and it fails loudly if anyone ever regresses the include-list into an exclude-list.
+#
+# The fake Daytona client cannot do this job: it records ``execute_command`` and never
+# runs the wrapper, so no tar ever executes inside it.
+
+#: A project tree with ``node_modules`` in BOTH places it can occur: as a sibling of the
+#: build output (what ``bun install`` actually produces) and nested INSIDE the output dir
+#: (what a build that copies dependencies into ``dist`` would produce). The two are not
+#: the same test — the include-list excludes the first by construction and, as SG-7
+#: measured, does NOT exclude the second.
+NODE_MODULES_PROJECT: dict[str, bytes] = {
+    "dist/index.html": b"<!doctype html><title>hi</title>",
+    "dist/assets/app.js": b"console.log(1)",
+    "node_modules/react/index.js": b"module.exports = {}",
+    "node_modules/.bin/vite": b"#!/usr/bin/env node",
+}
+
+
+def write_project_tree(root: Any, files: dict[str, bytes]) -> str:
+    """Materialise ``{relpath: contents}`` under ``root``; return a POSIX-style path.
+
+    Forward slashes on purpose. ``artifact_tar_command`` renders a POSIX shell command
+    with ``shlex.quote``, and a Windows path full of backslashes would either be quoted
+    into something tar cannot open or have its separators eaten as escapes. The real
+    sandbox path is POSIX anyway, so this keeps the command under test identical to the
+    one production renders.
+    """
+    from pathlib import Path
+
+    base = Path(root)
+    for rel, contents in files.items():
+        target = base / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(contents)
+    return str(base).replace("\\", "/")
+
+
+def pack_with_real_tar(engine: str, project_dir: str, dest_path: str) -> list[str]:
+    """Run ``artifact_tar_command`` for real and return the member names it packed.
+
+    Executes the command with the actual ``tar`` binary rather than through a shell, so
+    the test does not depend on which ``bash`` a Windows Python resolves (``/tmp`` means
+    different things to git-bash and WSL, which is a real trap here). ``shlex.split`` is
+    faithful because the command is rendered with ``shlex.quote`` in the first place.
+
+    Raises ``RuntimeError`` when tar fails, rather than returning an empty list — an
+    empty member list is exactly what a passing "no node_modules" assertion looks like,
+    so a silent tar failure would turn this into a test that cannot fail.
+    """
+    import shlex
+    import subprocess
+    import tarfile
+
+    from pocketpaw_ee.sites.daytona_build import artifact_tar_command
+
+    command = artifact_tar_command(engine, project_dir, dest_path)
+    proc = subprocess.run(shlex.split(command), capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError(f"tar failed ({proc.returncode}): {proc.stderr.strip()}")
+    with tarfile.open(dest_path) as tar:
+        return sorted(tar.getnames())
+
+
+def tar_is_available() -> bool:
+    """Whether a real ``tar`` exists to run. The include-list tests skip without one
+    rather than silently degrading into an assertion about nothing."""
+    import shutil
+
+    return shutil.which("tar") is not None
+
+
+# ---------------------------------------------------------------------------
+# F1 / F2 — Daytona faults
+# ---------------------------------------------------------------------------
+
+
+class DaytonaUnavailable(RuntimeError):
+    """Stand-in for what the Daytona SDK raises on a 5xx or a create failure.
+
+    The SDK's own exception type is not part of this lane's contract: ``run_build``
+    catches ``Exception`` at the exec seam and lets create/upload failures propagate, so
+    every caller is type-agnostic by design. A named local exception makes a test's
+    intent legible and carries ``status`` for the cases that want to assert on it.
+    """
+
+    def __init__(self, message: str = "daytona unavailable", *, status: int | None = None) -> None:
+        super().__init__(message)
+        self.status = status
+
+
+def daytona_unconfigured(monkeypatch: Any) -> None:
+    """Make Daytona genuinely unconfigured for the duration of a test (F1).
+
+    Injects at the ENV, which is the real boundary: ``config.daytona_enabled()`` reads
+    ``DAYTONA_API_URL`` / ``DAYTONA_API_KEY`` on every call, and
+    ``client.get_daytona_client()`` returns ``None`` when it is False. Patching
+    ``get_daytona_client`` directly would test the mock instead — and would miss the
+    cached singleton, which is why that gets cleared too: a client built by an earlier
+    test in the same process would otherwise be handed out to a caller that must see
+    "unavailable".
+    """
+    from pocketpaw_ee.cloud.daytona import client as client_mod
+
+    monkeypatch.delenv("DAYTONA_API_URL", raising=False)
+    monkeypatch.delenv("DAYTONA_API_KEY", raising=False)
+    monkeypatch.setattr(client_mod, "_client", None, raising=False)
+
+
+@dataclass
+class _SandboxInfo:
+    id: str
+
+
+class _Unset:
+    """Distinguishes "the caller said nothing" from "the caller said None".
+
+    Needed because ``None`` is MEANINGFUL for both of this fake's payloads: a sentinel of
+    ``None`` is the central fault of the whole lane (no proof of completion), and an
+    artifact of ``None`` is an empty download. Defaulting those parameters to ``None``
+    would make the most important fault in the ladder unexpressible — and, worse, would
+    silently hand back a healthy build instead, so the test would pass while injecting
+    nothing.
+    """
+
+
+_UNSET = _Unset()
+
+
+class FaultyDaytonaClient:
+    """A Daytona client fake that fails at ONE chosen phase.
+
+    Phases, in the order ``run_build`` calls them: ``create``, ``wait``, ``upload``,
+    ``exec``, ``sentinel``, ``artifact``, ``delete``. ``fail_at=None`` is the happy path.
+
+    ``fail_times`` exists for a caller that RETRIES: the phase fails that many times and
+    then succeeds, so a retry-with-backoff test can prove it recovered on attempt N
+    rather than merely that it survived. Nothing in the lane retries today (see this
+    task's report), so the default is "fail every time" — the honest default, since a
+    helper that quietly healed on attempt two would make a non-existent retry look real.
+
+    Records every call in ``calls`` so a test can assert ORDER, which is most of what
+    this lane's contract actually is.
+    """
+
+    def __init__(
+        self,
+        *,
+        fail_at: str | None = None,
+        error: BaseException | None = None,
+        fail_times: int | None = None,
+        sentinel: dict[str, Any] | None | _Unset = _UNSET,
+        artifact: bytes | None | _Unset = _UNSET,
+    ) -> None:
+        self.fail_at = fail_at
+        self.error = error or DaytonaUnavailable(status=503)
+        self.fail_times = fail_times
+        self.calls: list[str] = []
+        self.create_kwargs: dict[str, Any] = {}
+        self.exec_timeout: int | None = None
+        self.uploaded: list[tuple[Any, str]] = []
+        self._failures: dict[str, int] = {}
+        # ``sentinel=None`` means the build left NO proof; omitting it means a healthy
+        # one. Same split for the artifact, where None means the download came back
+        # empty. See ``_Unset``.
+        self._sentinel = ok_sentinel() if isinstance(sentinel, _Unset) else sentinel
+        self._artifact = clean_artifact() if isinstance(artifact, _Unset) else artifact
+
+    # -- internals ---------------------------------------------------------
+
+    def _maybe_fail(self, phase: str) -> None:
+        """Raise if ``phase`` is the injected one and its failure budget is unspent."""
+        if phase != self.fail_at:
+            return
+        seen = self._failures.get(phase, 0)
+        if self.fail_times is not None and seen >= self.fail_times:
+            return
+        self._failures[phase] = seen + 1
+        raise self.error
+
+    @property
+    def failures(self) -> dict[str, int]:
+        """How many times each phase actually failed. A test asserting "it retried
+        three times" needs this, not a call count — ``calls`` also grows on success."""
+        return dict(self._failures)
+
+    # -- the client surface run_build uses ---------------------------------
+
+    async def create_sandbox(self, **kwargs: Any) -> _SandboxInfo:
+        self.calls.append("create")
+        self.create_kwargs = kwargs
+        self._maybe_fail("create")
+        return _SandboxInfo(id="sb-fault")
+
+    async def wait_for_sandbox(self, sandbox_id: str, target_state: str = "started") -> None:
+        self.calls.append("wait")
+        self._maybe_fail("wait")
+
+    async def bulk_upload(self, sandbox_id: str, files: list[tuple[Any, str]]) -> None:
+        self.calls.append("upload")
+        self.uploaded = files
+        self._maybe_fail("upload")
+
+    async def execute_command(self, sandbox_id: str, command: str, timeout: int = 30) -> Any:
+        self.calls.append("exec")
+        self.exec_timeout = timeout
+        self._maybe_fail("exec")
+        return object()
+
+    async def download_file(self, sandbox_id: str, remote_path: str) -> bytes:
+        if remote_path.endswith(db.BUILD_RESULT_FILENAME):
+            self.calls.append("read_sentinel")
+            self._maybe_fail("sentinel")
+            if self._sentinel is None:
+                raise FileNotFoundError(remote_path)
+            return json.dumps(self._sentinel).encode()
+        self.calls.append("download_artifact")
+        self._maybe_fail("artifact")
+        return b"" if self._artifact is None else self._artifact
+
+    async def delete_sandbox(self, sandbox_id: str) -> None:
+        self.calls.append("delete")
+        self._maybe_fail("delete")
+
+
+def sandbox_create_fails(**kw: Any) -> FaultyDaytonaClient:
+    """Daytona answers 5xx to ``create_sandbox`` — nothing has run yet (F2)."""
+    return FaultyDaytonaClient(fail_at="create", **kw)
+
+
+def sandbox_dies_mid_build(**kw: Any) -> FaultyDaytonaClient:
+    """The container goes away during the build: the exec raises AND no sentinel
+    survives. The pair matters — an exec failure with a readable sentinel is a build
+    failure, and only the absence of evidence makes it infrastructure loss."""
+    kw.setdefault("sentinel", None)
+    return FaultyDaytonaClient(fail_at="exec", **kw)
+
+
+# ---------------------------------------------------------------------------
+# F4 — deploy faults
+# ---------------------------------------------------------------------------
+
+
+def cloudflare_error(status: int = 503) -> BaseException:
+    """The exception the REAL Cloudflare client raises for a non-2xx.
+
+    ``cloudflare_client._unwrap`` maps any non-2xx to
+    ``ValidationError("sites.cloudflare_error", f"Cloudflare API {status}")`` — including
+    5xx, which is worth noticing: a Cloudflare outage surfaces through the lane as a
+    VALIDATION error. Reproducing the real type here rather than raising a generic
+    ``RuntimeError`` is the difference between testing the publish path's handling and
+    testing an exception nothing throws.
+    """
+    from pocketpaw_ee.cloud._core.errors import ValidationError
+
+    return ValidationError("sites.cloudflare_error", f"Cloudflare API {status}")
+
+
+@dataclass
+class FailingCloudflare:
+    """A CF client whose ``put_worker`` always fails (the WfP deploy target).
+
+    Counts attempts, so a test can state plainly whether the lane retried. It does not
+    today; the count is what makes that a measurement instead of a belief.
+    """
+
+    status: int = 503
+    attempts: int = 0
+    put_calls: list[str] = field(default_factory=list)
+
+    async def put_worker(
+        self, *, script_name: str, bundle: bytes, bindings: Any | None = None
+    ) -> bool:
+        self.attempts += 1
+        self.put_calls.append(script_name)
+        raise cloudflare_error(self.status)
+
+
+@dataclass
+class FailingWorkersDeploy:
+    """The ``workers`` deploy target failing — the ``_workers_deploy`` publish seam.
+
+    Kept separate from :class:`FailingCloudflare` because they are different targets on
+    different code paths (``deploy_workers`` vs ``cf.put_worker``), and a rung proven on
+    one is not proven on the other.
+    """
+
+    status: int = 503
+    attempts: int = 0
+
+    async def __call__(self, site_id: str, project_dir: str, **kw: Any) -> str:
+        self.attempts += 1
+        raise cloudflare_error(self.status)
+
+
+# ---------------------------------------------------------------------------
+# F6 — screenshot faults
+# ---------------------------------------------------------------------------
+
+
+def screenshot_always_fails(monkeypatch: Any) -> dict[str, int]:
+    """Make the post-deploy screenshot raise, and count the attempts (F6).
+
+    Patched on ``sites.screenshot`` rather than on the service, because the service
+    imports the function INSIDE ``_schedule_site_screenshot`` — so a module-level patch of
+    the service attribute would never be consulted. Returns a counter dict a test asserts
+    on; a rung claiming "the screenshot failed and the publish survived" is worthless
+    unless the screenshot was actually reached.
+    """
+    from pocketpaw_ee.sites import screenshot as screenshot_mod
+
+    counter = {"attempts": 0}
+
+    def _boom(*_args: Any, **_kw: Any) -> None:
+        counter["attempts"] += 1
+        raise RuntimeError("browser rendering quota exceeded")
+
+    monkeypatch.setattr(screenshot_mod, "schedule_site_screenshot", _boom, raising=False)
+    monkeypatch.setattr(screenshot_mod, "schedule_draft_screenshot", _boom, raising=False)
+    return counter
+
+
+__all__ = [
+    "EXIT_SIGKILL",
+    "EXIT_SIGTERM",
+    "EXIT_TIMEOUT",
+    "NODE_MODULES_PROJECT",
+    "DaytonaUnavailable",
+    "FailingCloudflare",
+    "FailingWorkersDeploy",
+    "FaultyDaytonaClient",
+    "clean_artifact",
+    "cloudflare_error",
+    "daytona_unconfigured",
+    "ok_sentinel",
+    "pack_with_real_tar",
+    "sandbox_create_fails",
+    "sandbox_dies_mid_build",
+    "screenshot_always_fails",
+    "tar_bytes",
+    "tar_is_available",
+    "write_project_tree",
+]

--- a/tests/ee/sites/test_daytona_build.py
+++ b/tests/ee/sites/test_daytona_build.py
@@ -260,7 +260,17 @@ class TestArtifactIncludeList:
         # string check fails on the very mention of the word. What the assertion was
         # protecting — that node_modules is not part of what gets packed — is checked
         # properly in test_fault_ladder_build.py by running the real tar over a real tree.
-        assert "--exclude=./node_modules" in cmd
+        #
+        # Updated again 2026-08-10: the pattern is ``node_modules``, NOT ``./node_modules``,
+        # and the missing ``./`` is the fix rather than a tidy-up. GNU tar — what the
+        # debian_slim image runs — anchors an exclude pattern that contains a slash, so
+        # ``./node_modules`` pruned only the top level there and a nested
+        # ``dist/sub/node_modules`` shipped. CI failed on exactly that. Measured on GNU tar
+        # 1.35: ``--exclude=./node_modules`` leaves ``./sub/node_modules/`` in the archive,
+        # ``--exclude=node_modules`` removes every one at any depth. A bare name is
+        # unanchored in bsdtar too, so both tars now agree.
+        assert "--exclude=node_modules" in cmd
+        assert "./node_modules" not in cmd
         # node_modules must appear ONLY as the exclusion, never as a packed path.
         assert cmd.count("node_modules") == 1
 

--- a/tests/ee/sites/test_daytona_build.py
+++ b/tests/ee/sites/test_daytona_build.py
@@ -253,7 +253,16 @@ class TestArtifactIncludeList:
     def test_react_tars_only_dist(self) -> None:
         cmd = db.artifact_tar_command("react", "/home/daytona/proj", "/tmp/a.tgz")
         assert "/home/daytona/proj/dist" in cmd
-        assert "node_modules" not in cmd  # excluded by construction, not by a filter
+        # Updated 2026-08-10 (SG-7): this used to assert ``"node_modules" not in cmd``,
+        # commented "excluded by construction, not by a filter". SG-7 measured that the
+        # ``-C`` scope excludes a SIBLING node_modules but packs one NESTED inside the
+        # output dir, so the command now carries an explicit ``--exclude`` and the old
+        # string check fails on the very mention of the word. What the assertion was
+        # protecting — that node_modules is not part of what gets packed — is checked
+        # properly in test_fault_ladder_build.py by running the real tar over a real tree.
+        assert "--exclude=./node_modules" in cmd
+        # node_modules must appear ONLY as the exclusion, never as a packed path.
+        assert cmd.count("node_modules") == 1
 
     def test_svelte_tars_only_the_adapter_output(self) -> None:
         cmd = db.artifact_tar_command("svelte", "/home/daytona/proj", "/tmp/a.tgz")

--- a/tests/ee/sites/test_daytona_runner.py
+++ b/tests/ee/sites/test_daytona_runner.py
@@ -23,6 +23,7 @@ from typing import Any
 import pytest
 from pocketpaw_ee.sites import daytona_build as db
 from pocketpaw_ee.sites import daytona_runner as dr
+from tests.ee.sites.faults import clean_artifact
 
 REACT_FILES = {"src/App.tsx": "export default function App() { return <p>hi</p>; }"}
 
@@ -45,9 +46,14 @@ class FakeClient:
         *,
         sentinel: dict[str, Any] | None,
         exec_raises: bool = False,
-        artifact: bytes = b"tgz-bytes",
+        artifact: bytes | None = None,
         delete_raises: bool = False,
     ) -> None:
+        # Updated 2026-08-10 (SG-7): the default was the placeholder ``b"tgz-bytes"``, which
+        # is not a readable tar and does not match the size ``_ok_sentinel`` promises. A
+        # TRUTHFULNESS fix — nothing reads either value today — but a fake asserting against
+        # a fiction is how a real mismatch later goes unnoticed.
+        artifact = clean_artifact() if artifact is None else artifact
         self.calls: list[str] = []
         self.create_kwargs: dict[str, Any] = {}
         self.exec_timeout: int | None = None
@@ -97,7 +103,8 @@ def _ok_sentinel(**over: Any) -> dict[str, Any]:
         "install_exit": 0,
         "build_exit": 0,
         "artifact_rel": "dist",
-        "artifact_bytes": 4096,
+        # Equals what FakeClient returns — see its __init__ comment.
+        "artifact_bytes": len(clean_artifact()),
         "stderr_tail": "",
     }
     base.update(over)
@@ -114,7 +121,7 @@ class TestTheFourRowsThroughTheDriver:
         got = await dr.run_build(REACT_FILES, engine="react", timeout_seconds=600, client=c)
         assert got.classification.outcome == "completed_ok"
         assert got.ok is True
-        assert got.artifact_bytes == len(b"tgz-bytes")
+        assert got.artifact_bytes == len(clean_artifact())
 
     async def test_row2_build_failed_surfaces_stderr_and_no_artifact(self) -> None:
         c = FakeClient(sentinel=_ok_sentinel(build_exit=1, stderr_tail="TS2304"))
@@ -138,8 +145,13 @@ class TestTheFourRowsThroughTheDriver:
 
     async def test_row4_infra_lost_when_no_sentinel_before_the_budget(self) -> None:
         """Induced: the exec blows up and no sentinel survives, well inside the budget.
-        This is the row that must NOT reach the user as a build failure — if it does,
-        the local-builder fallback never fires."""
+        This is the row that must NOT reach the user as a build failure.
+
+        Corrected 2026-08-10 (SG-7): this used to end "if it does, the local-builder
+        fallback never fires", which describes a fallback the captain overrode. The
+        ruling is Daytona-only. What actually goes wrong when this row is misclassified
+        is that the user is told their site is broken when we lost the container — the
+        mis-report the whole sentinel design exists to prevent."""
         c = FakeClient(sentinel=None, exec_raises=True)
         got = await dr.run_build(REACT_FILES, engine="react", timeout_seconds=100_000, client=c)
         assert got.classification.outcome == "infra_lost"

--- a/tests/ee/sites/test_daytona_runner.py
+++ b/tests/ee/sites/test_daytona_runner.py
@@ -23,6 +23,7 @@ from typing import Any
 import pytest
 from pocketpaw_ee.sites import daytona_build as db
 from pocketpaw_ee.sites import daytona_runner as dr
+
 from tests.ee.sites.faults import clean_artifact
 
 REACT_FILES = {"src/App.tsx": "export default function App() { return <p>hi</p>; }"}

--- a/tests/ee/sites/test_fault_ladder_build.py
+++ b/tests/ee/sites/test_fault_ladder_build.py
@@ -68,6 +68,7 @@ import pytest
 from pocketpaw_ee.sites import build_state as bs
 from pocketpaw_ee.sites import daytona_build as db
 from pocketpaw_ee.sites import daytona_runner as dr
+
 from tests.ee.sites.faults import (
     EXIT_SIGKILL,
     EXIT_SIGTERM,
@@ -380,7 +381,7 @@ class TestF5VerificationFailsSoNothingDeploys:
     """
 
     async def test_a_missing_sentinel_never_reaches_the_artifact_download(self) -> None:
-        """"No deploy" starts before the deploy: an unproven build must not even fetch an
+        """ "No deploy" starts before the deploy: an unproven build must not even fetch an
         artifact, because fetching one is the step that makes deploying it possible."""
         client = FaultyDaytonaClient(sentinel=None)
         got = await dr.run_build(
@@ -471,18 +472,14 @@ class TestF5TheIncludeListIsWhatExcludesNodeModules:
         produces: ``node_modules`` next to ``dist``. ``-C <project>/dist .`` cannot reach
         it, so there is no filter to get wrong."""
         project = write_project_tree(tmp_path / "proj", NODE_MODULES_PROJECT)
-        members = pack_with_real_tar(
-            "react", project, str(tmp_path / "out.tgz").replace("\\", "/")
-        )
+        members = pack_with_real_tar("react", project, str(tmp_path / "out.tgz").replace("\\", "/"))
         assert not any("node_modules" in m for m in members), members
 
     def test_the_static_output_is_actually_packed(self, tmp_path) -> None:
         """The other half, and the reason the assertion above is not vacuous: an empty tar
         would also contain no node_modules. The real output has to be in there."""
         project = write_project_tree(tmp_path / "proj", NODE_MODULES_PROJECT)
-        members = pack_with_real_tar(
-            "react", project, str(tmp_path / "out.tgz").replace("\\", "/")
-        )
+        members = pack_with_real_tar("react", project, str(tmp_path / "out.tgz").replace("\\", "/"))
         assert "./index.html" in members
         assert "./assets/app.js" in members
 
@@ -499,9 +496,7 @@ class TestF5TheIncludeListIsWhatExcludesNodeModules:
         tree["dist/node_modules/leaked/index.js"] = b"module.exports = {}"
         tree["dist/node_modules/.bin/vite"] = b"#!/usr/bin/env node"
         project = write_project_tree(tmp_path / "proj", tree)
-        members = pack_with_real_tar(
-            "react", project, str(tmp_path / "out.tgz").replace("\\", "/")
-        )
+        members = pack_with_real_tar("react", project, str(tmp_path / "out.tgz").replace("\\", "/"))
         assert not any("node_modules" in m for m in members), members
         # Not vacuous: an empty tar would also satisfy the assertion above.
         assert "./index.html" in members
@@ -518,9 +513,7 @@ class TestF5TheIncludeListIsWhatExcludesNodeModules:
         tree = dict(NODE_MODULES_PROJECT)
         tree["dist/sub/node_modules/dep/index.js"] = b"module.exports = {}"
         project = write_project_tree(tmp_path / "proj", tree)
-        members = pack_with_real_tar(
-            "react", project, str(tmp_path / "out.tgz").replace("\\", "/")
-        )
+        members = pack_with_real_tar("react", project, str(tmp_path / "out.tgz").replace("\\", "/"))
         assert not any("node_modules" in m for m in members), members
 
     def test_an_innocently_named_file_is_still_packed(self, tmp_path) -> None:
@@ -530,9 +523,7 @@ class TestF5TheIncludeListIsWhatExcludesNodeModules:
         tree = dict(NODE_MODULES_PROJECT)
         tree["dist/docs/node_modules_report.html"] = b"<p>size audit</p>"
         project = write_project_tree(tmp_path / "proj", tree)
-        members = pack_with_real_tar(
-            "react", project, str(tmp_path / "out.tgz").replace("\\", "/")
-        )
+        members = pack_with_real_tar("react", project, str(tmp_path / "out.tgz").replace("\\", "/"))
         assert "./docs/node_modules_report.html" in members
 
     def test_an_engine_whose_output_is_the_project_root_is_refused(self) -> None:
@@ -558,9 +549,7 @@ def _all_classifications() -> dict[str, db.BuildClassification]:
     long_budget = WELL_INSIDE_BUDGET
     return {
         "ok": db.classify_build(ok_sentinel(), elapsed_seconds=1, timeout_seconds=long_budget),
-        "no_sentinel_lost": db.classify_build(
-            None, elapsed_seconds=1, timeout_seconds=long_budget
-        ),
+        "no_sentinel_lost": db.classify_build(None, elapsed_seconds=1, timeout_seconds=long_budget),
         "no_sentinel_timeout": db.classify_build(None, elapsed_seconds=99, timeout_seconds=1),
         "unparseable": db.classify_build(
             b"{not json", elapsed_seconds=1, timeout_seconds=long_budget

--- a/tests/ee/sites/test_fault_ladder_build.py
+++ b/tests/ee/sites/test_fault_ladder_build.py
@@ -1,0 +1,740 @@
+# tests/ee/sites/test_fault_ladder_build.py — the BUILD half of the fault ladder:
+# rungs F1 (Daytona unconfigured), F2 (Daytona timeout / 5xx / create failure),
+# F3 (a build row that cannot be consumed), F5 (verification fails) and F7 (every
+# degraded path names its rung).
+#
+# Created 2026-08-10 (SG-7).
+#
+# WHY THIS FILE EXISTS AT ALL. The lane's whole design rests on one asymmetry: only a
+# build that PROVED it completed may be reported to the user as broken, and the absence
+# of proof is infrastructure loss. That claim is unfalsifiable by reading the code —
+# every branch looks right in isolation. It becomes falsifiable only by injecting each
+# fault for real and watching where the blame lands. An untested rung is a rung that
+# does not exist.
+#
+# WHAT IS DELIBERATELY NOT ASSERTED HERE, so nobody reads a green file as more than it
+# is. On this branch the lane has NO production callers: ``run_build`` is called by
+# tests only, ``build_state``'s guards are called by tests only, ``Site.build_status`` is
+# written by nothing, and there is no arq job for site builds — ``service._deploy_site_doc``
+# still builds through the local generator. So the parts of F2/F3 that need an
+# orchestrator (retry with backoff, a terminal ``failed`` row carrying a reason, an
+# enqueue that can fail) are NOT proven here, because there is nothing to inject into.
+# ``TestTheWiringGapIsRealAndTemporary`` pins that absence as a tripwire: when the lane
+# gets wired, those tests fail and name the rungs that must then be proven for real.
+#
+# NO NEW PRODUCTION LOGIC WAS ADDED FOR THIS LADDER, on purpose. The captain's constraint
+# on this program is to build the test scenarios first and wire the lane afterwards, so a
+# rung that "needs" a new runtime check is a rung that needs a better injection instead.
+#
+# F5's ``node_modules`` case is the worked example, and it took two wrong turns to land.
+# Draft one added a byte-scanning gate to ``daytona_build`` and asserted against it — which
+# tested the gate and left the include-list unexercised. Running the real tar over a real
+# node_modules tree tested the construction instead, and turned up the gap the gate would
+# have masked: ``-C dist .`` packs ``dist/node_modules/``. Draft two recorded that gap as a
+# passing characterisation test, which documented a 500 MB-artifact path without closing it.
+# The resolution is neither: ``--exclude=./node_modules`` on the existing command removes the
+# path BY CONSTRUCTION, so there is nothing to detect at runtime and nothing left open.
+#
+# WIRING CONTRACTS THIS TASK OWES THE NEXT ONE, recorded here because the code cannot hold
+# them yet:
+#
+#   1. GATE A DEPLOY ON ``BuildRunResult.ok``, NEVER ON ``classification.deployable``.
+#      ``deployable`` is derived from the sentinel alone and stays True when the download
+#      returns zero bytes — see its docstring. Nothing verifies delivered bytes today.
+#   2. WHEN DOWNLOAD VERIFICATION IS ADDED, SPLIT ITS FAILURES ON ``retryable``. A payload
+#      SHORTER than the sentinel's ``artifact_bytes`` is a property of the TRANSFER and is
+#      worth another attempt; one that arrives at full size and still will not open as a gzip
+#      tar is a property of what the BUILD produced, and retrying only spends a second
+#      sandbox reproducing it. The sentinel already carries ``artifact_bytes``, which is what
+#      makes the two distinguishable. Collapsing them into one non-retryable failure turns a
+#      network blip into a permanently burned publish. Keep "nothing arrived" and "half
+#      arrived" as SEPARATE reasons — they send an operator to different places.
+#
+#      This is not just a requirement list: it was BUILT and mutation-tested, then held back
+#      because 170 lines of new production logic in a lane with zero callers is a feature
+#      build, and the gate's correct shape depends on how the wiring ends up consuming it.
+#      The implementation lives on ``spike/sites-artifact-verification`` — a four-way
+#      classification (``artifact_empty`` / ``artifact_truncated`` / ``artifact_unreadable`` /
+#      ``artifact_contains_node_modules``), an ``ArtifactRejection`` carrying its own
+#      ``retryable``, and ``promised_artifact_bytes`` reading the size off the sentinel rather
+#      than widening ``BuildClassification``. Start there rather than from scratch.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from pocketpaw_ee.sites import build_state as bs
+from pocketpaw_ee.sites import daytona_build as db
+from pocketpaw_ee.sites import daytona_runner as dr
+from tests.ee.sites.faults import (
+    EXIT_SIGKILL,
+    EXIT_SIGTERM,
+    EXIT_TIMEOUT,
+    NODE_MODULES_PROJECT,
+    DaytonaUnavailable,
+    FaultyDaytonaClient,
+    clean_artifact,
+    daytona_unconfigured,
+    ok_sentinel,
+    pack_with_real_tar,
+    sandbox_create_fails,
+    sandbox_dies_mid_build,
+    tar_is_available,
+    write_project_tree,
+)
+
+REACT_FILES = {"src/App.tsx": "export default function App() { return <p>hi</p>; }"}
+
+#: Long enough that no real elapsed time in a unit test can reach it, so a missing
+#: sentinel classifies as ``infra_lost`` rather than ``timed_out``. The distinction is
+#: the point of several tests below, and a small budget would silently flip them.
+WELL_INSIDE_BUDGET = 100_000
+
+
+# ---------------------------------------------------------------------------
+# F1 — Daytona unconfigured
+# ---------------------------------------------------------------------------
+
+
+class TestF1DaytonaUnconfigured:
+    """No credentials, no configured sandbox target.
+
+    The captain overrode the recommended local-builder fallback in favour of
+    Daytona-only, which makes "fails loudly" a REQUIREMENT rather than an accident: a
+    lane that quietly built somewhere else would make a misconfigured deploy invisible
+    until the day the other builder also broke.
+    """
+
+    async def test_unconfigured_daytona_refuses_the_build(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        daytona_unconfigured(monkeypatch)
+        with pytest.raises(RuntimeError) as err:
+            await dr.run_build(REACT_FILES, engine="react", timeout_seconds=600)
+        assert "not configured" in str(err.value)
+
+    async def test_the_error_names_what_is_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An operator reading this in a log must learn which env vars to set. "Daytona
+        is not available" would be a true statement and a useless one."""
+        daytona_unconfigured(monkeypatch)
+        with pytest.raises(RuntimeError) as err:
+            await dr.run_build(REACT_FILES, engine="react", timeout_seconds=600)
+        message = str(err.value)
+        assert "DAYTONA_API_URL" in message
+        assert "DAYTONA_API_KEY" in message
+
+    async def test_it_raises_rather_than_returning_a_result(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The failure mode this rung guards is not an exception — it is a RETURN. A
+        result object carrying ``deployable=False`` would let a caller treat "we never
+        tried" as "the build did not work", and the user would be told their site is
+        broken because an env var is unset."""
+        daytona_unconfigured(monkeypatch)
+        with pytest.raises(RuntimeError):
+            result = await dr.run_build(REACT_FILES, engine="react", timeout_seconds=600)
+            pytest.fail(f"expected a raise, got a result: {result!r}")
+
+    def test_the_lane_has_no_local_builder_fallback(self) -> None:
+        """A structural guard, because this is the rung most likely to be "helpfully"
+        undone later. The obvious fix for a failing Daytona is to fall back to the local
+        generator, and it is exactly what the captain ruled out — a silent fallback makes
+        capacity loss undetectable. If a future change imports the local builder into
+        this lane, this fails and sends the author back to the ruling.
+
+        Note the residue this does NOT catch, reported rather than deleted per the task
+        brief: ``daytona_build.BuildClassification.retryable`` still documents itself as
+        "May the lane retry (and then fall back to the local builder)?", and
+        ``test_daytona_runner.py`` still refers to the fallback firing. Both are stale
+        prose from before the override; neither is executable.
+        """
+        source = Path(dr.__file__).read_text(encoding="utf-8")
+        for forbidden in ("GeneratorClient", "generator_client", "local_server"):
+            assert forbidden not in source, (
+                f"{forbidden} appeared in the Daytona lane — the captain's ruling is "
+                "Daytona-only, and a local fallback must not be reintroduced"
+            )
+
+
+# ---------------------------------------------------------------------------
+# F2 — Daytona timeout / 5xx / sandbox-create failure
+# ---------------------------------------------------------------------------
+
+
+class TestF2DaytonaInfrastructureFailure:
+    """Every way the sandbox itself can fail must classify as infrastructure.
+
+    The retry-with-backoff and terminal-``failed``-carrying-a-reason halves of this rung
+    are NOT proven here — no orchestrator exists to retry or to write a row. See
+    ``TestTheWiringGapIsRealAndTemporary``.
+    """
+
+    async def test_create_failure_propagates_and_bills_nothing(self) -> None:
+        """A create that 5xxes means nothing ran, so there is no build result to report —
+        the caller must see an exception and treat it as retryable. And with no sandbox,
+        there is nothing to tear down."""
+        client = sandbox_create_fails()
+        with pytest.raises(DaytonaUnavailable):
+            await dr.run_build(REACT_FILES, engine="react", timeout_seconds=600, client=client)
+        assert client.calls == ["create"]
+        assert "delete" not in client.calls
+
+    async def test_a_failure_after_create_still_tears_the_sandbox_down(self) -> None:
+        """The expensive mistake in this rung: a sandbox that outlives a failed build is
+        a bill nobody sees. ``wait_for_sandbox`` failing is the narrowest window — the
+        sandbox exists but nothing has run — and the teardown must still fire."""
+        client = FaultyDaytonaClient(fail_at="wait")
+        with pytest.raises(DaytonaUnavailable):
+            await dr.run_build(REACT_FILES, engine="react", timeout_seconds=600, client=client)
+        assert "delete" in client.calls
+
+    async def test_an_upload_failure_still_tears_the_sandbox_down(self) -> None:
+        client = FaultyDaytonaClient(fail_at="upload")
+        with pytest.raises(DaytonaUnavailable):
+            await dr.run_build(REACT_FILES, engine="react", timeout_seconds=600, client=client)
+        assert "delete" in client.calls
+
+    async def test_a_sandbox_that_dies_mid_build_is_infra_not_the_users_fault(self) -> None:
+        """The central case. An exec that raises looks IDENTICAL to a broken build; only
+        the absence of a sentinel separates them, and it must land on infrastructure."""
+        client = sandbox_dies_mid_build()
+        got = await dr.run_build(
+            REACT_FILES, engine="react", timeout_seconds=WELL_INSIDE_BUDGET, client=client
+        )
+        assert got.classification.outcome == "infra_lost"
+        assert got.classification.blames_user is False
+        assert got.classification.retryable is True
+
+    async def test_an_unreadable_sentinel_read_is_infra_not_the_users_fault(self) -> None:
+        """A transport failure ON THE READ, rather than a missing file. Same conclusion:
+        evidence we cannot obtain is evidence that does not exist."""
+        client = FaultyDaytonaClient(fail_at="sentinel")
+        got = await dr.run_build(
+            REACT_FILES, engine="react", timeout_seconds=WELL_INSIDE_BUDGET, client=client
+        )
+        assert got.classification.outcome == "infra_lost"
+        assert got.classification.blames_user is False
+
+    @pytest.mark.parametrize("signal_exit", [EXIT_SIGKILL, EXIT_SIGTERM])
+    @pytest.mark.parametrize("step", ["install_exit", "build_exit"])
+    async def test_a_signalled_death_is_infra_even_though_it_has_a_sentinel(
+        self, step: str, signal_exit: int
+    ) -> None:
+        """The residual gap the design calls out: a signalled process STILL RUNS THE
+        TRAP, so an OOM kill arrives with a sentinel and a non-zero exit — the exact
+        shape of a genuine failure. Getting this wrong reports a capacity problem as the
+        user's bug, on both steps and both signals."""
+        client = FaultyDaytonaClient(sentinel=ok_sentinel(**{step: signal_exit}))
+        got = await dr.run_build(REACT_FILES, engine="react", timeout_seconds=600, client=client)
+        assert got.classification.outcome == "infra_lost"
+        assert got.classification.blames_user is False
+        assert str(signal_exit) in got.classification.reason
+
+    @pytest.mark.parametrize("step", ["install_exit", "build_exit"])
+    async def test_the_in_sandbox_timeout_is_a_timeout_not_a_broken_build(self, step: str) -> None:
+        """``timeout(1)`` firing is better evidence than our clock: we know WHICH step
+        overran and we still have its stderr. It must not be read as exit-non-zero."""
+        client = FaultyDaytonaClient(
+            sentinel=ok_sentinel(**{step: EXIT_TIMEOUT}, stderr_tail="still installing")
+        )
+        got = await dr.run_build(REACT_FILES, engine="react", timeout_seconds=600, client=client)
+        assert got.classification.outcome == "timed_out"
+        assert got.classification.blames_user is False
+        assert "still installing" in got.classification.stderr_tail
+
+    async def test_no_sentinel_past_the_budget_is_a_timeout_not_a_loss(self) -> None:
+        """With the budget already exhausted, "no proof" is explained by the timeout, and
+        saying so is honest and actionable — an enormous site really did overrun."""
+        client = sandbox_dies_mid_build()
+        got = await dr.run_build(REACT_FILES, engine="react", timeout_seconds=0, client=client)
+        assert got.classification.outcome == "timed_out"
+        assert got.classification.retryable is True
+        assert got.classification.blames_user is False
+
+    async def test_only_a_proven_non_zero_build_ever_blames_the_user(self) -> None:
+        """The one rung that must reach the user, and the proof that the others are not
+        merely being suppressed: a real non-zero build DOES blame them, and carries the
+        compiler error that makes it actionable."""
+        client = FaultyDaytonaClient(sentinel=ok_sentinel(build_exit=1, stderr_tail="TS2304"))
+        got = await dr.run_build(REACT_FILES, engine="react", timeout_seconds=600, client=client)
+        assert got.classification.outcome == "build_failed"
+        assert got.classification.blames_user is True
+        assert "TS2304" in got.classification.stderr_tail
+
+
+# ---------------------------------------------------------------------------
+# F3 — a build row nothing will ever consume
+# ---------------------------------------------------------------------------
+
+
+class TestF3AnUnconsumableBuildRow:
+    """The rung that only exists because publish went async.
+
+    The specific harm: a publish enqueues, the enqueue fails (or the worker dies before
+    writing a terminal status), and the row sits in ``queued`` with nothing coming to
+    consume it. Status alone is a ONE-WAY DOOR, so every later publish becomes a silent
+    no-op and the site is permanently unpublishable with no error to see.
+
+    The enqueue itself cannot be fault-injected on this branch — there is no enqueue (see
+    the wiring-gap tests). What IS injectable, and is the property that actually protects
+    the user, is the recovery: whatever state a failed enqueue leaves behind, the site
+    must still be republishable afterwards.
+    """
+
+    class _Row:
+        """The two persisted fields the guard reads. A stand-in for the Site doc so these
+        stay pure — constructing a Beanie document would drag a DB into a decision that
+        touches neither."""
+
+        def __init__(self, status: str, started_at: datetime | None) -> None:
+            self.build_status = status
+            self.build_started_at = started_at
+
+    def test_a_fresh_in_flight_row_blocks_a_second_build(self) -> None:
+        """Single-flight works — the baseline the recovery must not break. Two publishes
+        of one site must not open two sandboxes and race on the artifact."""
+        row = self._Row("queued", datetime.now(UTC))
+        assert bs.should_enqueue(row, 600) is False
+
+    def test_a_row_stuck_in_queued_becomes_republishable_once_the_window_lapses(self) -> None:
+        """The recovery. A job no worker ever consumed leaves exactly this row, and the
+        derived window is what unsticks it."""
+        stamp = datetime.now(UTC) - bs.stale_after(600) - timedelta(seconds=1)
+        row = self._Row("queued", stamp)
+        assert bs.should_enqueue(row, 600) is True
+
+    def test_a_queued_row_with_no_stamp_is_republishable_immediately(self) -> None:
+        """The shape a HALF-COMPLETED enqueue leaves: status written, stamp not. It reads
+        as stale on purpose — a redundant build costs one idempotent job, while a stuck
+        guard costs the site every future publish. The asymmetry only pays off in this
+        direction."""
+        row = self._Row("queued", None)
+        assert bs.should_enqueue(row, 600) is True
+
+    def test_an_unreadable_stamp_is_republishable_too(self) -> None:
+        """A garbage stamp (a string from an older writer, a None-like) must not read as
+        "recent". Failing closed here would wedge the site."""
+        row = self._Row("queued", "2026-08-10T00:00:00Z")  # type: ignore[arg-type]
+        assert bs.should_enqueue(row, 600) is True
+
+    def test_a_building_row_recovers_on_the_same_terms(self) -> None:
+        """A worker that died mid-build leaves ``building``, not ``queued``. Both are
+        in-flight, so both must unstick."""
+        stamp = datetime.now(UTC) - bs.stale_after(600) - timedelta(seconds=1)
+        row = self._Row("building", stamp)
+        assert bs.should_enqueue(row, 600) is True
+
+    def test_a_stale_row_still_renders_as_in_flight_to_a_viewer(self) -> None:
+        """The deliberate divergence between the two predicates: the service may spend
+        money again while the UI still shows progress. Collapsing them would either
+        block the republish or blank the user's screen mid-build."""
+        stamp = datetime.now(UTC) - bs.stale_after(600) - timedelta(seconds=1)
+        row = self._Row("queued", stamp)
+        assert bs.should_enqueue(row, 600) is True
+        assert bs.is_in_flight(row) is True
+
+    def test_a_terminal_failure_never_blocks_the_next_publish(self) -> None:
+        """One bad build must not wedge the site until someone edits the database."""
+        for status in ("failed", "built", "none"):
+            row = self._Row(status, datetime.now(UTC))
+            assert bs.should_enqueue(row, 600) is True, status
+
+    def test_the_window_is_derived_from_the_build_budget_not_a_constant(self) -> None:
+        """A constant window is wrong in both directions — too short re-enqueues on top
+        of a healthy long build (two sandboxes, two bills), too long blocks publishes for
+        half an hour. So a bigger budget must produce a bigger window."""
+        assert bs.stale_after(1200) > bs.stale_after(600)
+        assert bs.stale_after(600) > timedelta(seconds=600)
+
+    def test_a_non_positive_budget_still_yields_a_usable_window(self) -> None:
+        """A zero or negative timeout must not collapse the window to nothing — every
+        in-flight build would read as stale and single-flight would be off entirely."""
+        assert bs.stale_after(0) == bs.STALE_MARGIN
+        assert bs.stale_after(-99) == bs.STALE_MARGIN
+
+    def test_a_long_healthy_build_is_not_re_enqueued_under_it(self) -> None:
+        """The other half of the derived window: a build 20 minutes into a 30-minute
+        budget is HEALTHY, and re-enqueueing it would be the expensive false positive."""
+        row = self._Row("building", datetime.now(UTC) - timedelta(minutes=20))
+        assert bs.should_enqueue(row, 1800) is False
+
+
+# ---------------------------------------------------------------------------
+# F5 — verification fails
+# ---------------------------------------------------------------------------
+
+
+class TestF5VerificationFailsSoNothingDeploys:
+    """Missing sentinel, empty artifact, or ``node_modules`` in the artifact.
+
+    The requirement is stronger than "the publish fails": there must be NO deploy. A
+    partial deploy and a blank site are worse than a failed publish, because they
+    overwrite something that was working.
+
+    The ``node_modules`` case is exercised against the REAL tar in
+    ``TestF5TheIncludeListIsWhatExcludesNodeModules`` below, not against a scanner here.
+    The property that protects the user is that the include-list cannot pick node_modules
+    up in the first place, and only running the command can show that.
+    """
+
+    async def test_a_missing_sentinel_never_reaches_the_artifact_download(self) -> None:
+        """"No deploy" starts before the deploy: an unproven build must not even fetch an
+        artifact, because fetching one is the step that makes deploying it possible."""
+        client = FaultyDaytonaClient(sentinel=None)
+        got = await dr.run_build(
+            REACT_FILES, engine="react", timeout_seconds=WELL_INSIDE_BUDGET, client=client
+        )
+        assert got.classification.deployable is False
+        assert "download_artifact" not in client.calls
+        assert got.artifact is None
+
+    async def test_a_sentinel_reporting_zero_bytes_never_downloads_either(self) -> None:
+        """The empty-deploy failure caught at the sentinel: every step reported success
+        and produced nothing. Exit 0 is not sufficient."""
+        client = FaultyDaytonaClient(sentinel=ok_sentinel(artifact_bytes=0))
+        got = await dr.run_build(REACT_FILES, engine="react", timeout_seconds=600, client=client)
+        assert got.classification.reason == "artifact_empty"
+        assert got.classification.deployable is False
+        assert "download_artifact" not in client.calls
+
+    async def test_a_sentinel_with_no_size_at_all_fails_closed(self) -> None:
+        """A sentinel that parsed but carries no size tells us nothing about the output,
+        so it must not deploy. Absent must not read as fine."""
+        client = FaultyDaytonaClient(sentinel=ok_sentinel(artifact_bytes=None))
+        got = await dr.run_build(REACT_FILES, engine="react", timeout_seconds=600, client=client)
+        assert got.classification.reason == "artifact_size_unknown"
+        assert got.classification.deployable is False
+
+    async def test_an_empty_download_is_reported_as_not_ok(self) -> None:
+        """A CHARACTERISATION test, recording a discrepancy rather than a fix.
+
+        The sentinel is the build's claim; the download is the fact. When the sentinel
+        promises bytes and the download delivers none, ``BuildRunResult.ok`` correctly
+        reads False — but ``classification.deployable`` still reads True, and that flag's
+        docstring promises "there is a verified artifact to deploy". So a caller gating on
+        ``deployable`` rather than ``ok`` would deploy nothing over something working.
+
+        Left as-is deliberately: this is the proving phase, no caller exists yet, and
+        adding production code to close it is the wiring phase's call. The contract for
+        whoever wires this lane is "gate on ``.ok``", and this test fails if the
+        discrepancy is closed — at which point the contract can be relaxed.
+        """
+        client = FaultyDaytonaClient(artifact=b"")
+        got = await dr.run_build(REACT_FILES, engine="react", timeout_seconds=600, client=client)
+        assert got.ok is False, "ok must not be True for a zero-byte artifact"
+        assert got.artifact_bytes == 0
+        assert got.classification.deployable is True, (
+            "deployable now disagrees with ok — if it was fixed, drop the 'gate on .ok' "
+            "contract from the SG-7 findings"
+        )
+
+    async def test_a_download_failure_is_transport_loss_not_a_build_failure(self) -> None:
+        """The sentinel proved the artifact existed and was non-empty, so failing to fetch
+        it cannot be the user's build being wrong."""
+        client = FaultyDaytonaClient(fail_at="artifact")
+        got = await dr.run_build(REACT_FILES, engine="react", timeout_seconds=600, client=client)
+        assert got.classification.reason == "artifact_download_failed"
+        assert got.classification.blames_user is False
+        assert got.classification.deployable is False
+
+    async def test_a_healthy_build_still_deploys(self) -> None:
+        """A ladder is worthless if every rung fails. This is what proves the rejections
+        above are discriminating rather than just failing."""
+        client = FaultyDaytonaClient(artifact=clean_artifact())
+        got = await dr.run_build(REACT_FILES, engine="react", timeout_seconds=600, client=client)
+        assert got.classification.outcome == "completed_ok"
+        assert got.classification.deployable is True
+        assert got.ok is True
+        assert got.artifact_bytes > 0
+
+
+@pytest.mark.skipif(not tar_is_available(), reason="needs a real tar binary")
+class TestF5TheIncludeListIsWhatExcludesNodeModules:
+    """F5's ``node_modules`` case, injected against the REAL tar.
+
+    ``node_modules`` goes on disk and the actual command from
+    :func:`daytona_build.artifact_tar_command` runs over it. That tests the CONSTRUCTION —
+    an include-list of exactly one directory — rather than a scanner's opinion about
+    bytes. The risk being guarded is somebody rewriting this as an exclude-list of junk,
+    which would ship node_modules the moment the list missed an entry, and this fails
+    loudly if they do.
+
+    A fake Daytona client cannot cover this: it records ``execute_command`` and never runs
+    the wrapper, so no tar executes inside it and the artifact is whatever the fake was
+    told to return.
+    """
+
+    def test_a_sibling_node_modules_is_not_packed(self, tmp_path) -> None:
+        """The 500 MB-on-the-wire failure, and the shape ``bun install`` actually
+        produces: ``node_modules`` next to ``dist``. ``-C <project>/dist .`` cannot reach
+        it, so there is no filter to get wrong."""
+        project = write_project_tree(tmp_path / "proj", NODE_MODULES_PROJECT)
+        members = pack_with_real_tar(
+            "react", project, str(tmp_path / "out.tgz").replace("\\", "/")
+        )
+        assert not any("node_modules" in m for m in members), members
+
+    def test_the_static_output_is_actually_packed(self, tmp_path) -> None:
+        """The other half, and the reason the assertion above is not vacuous: an empty tar
+        would also contain no node_modules. The real output has to be in there."""
+        project = write_project_tree(tmp_path / "proj", NODE_MODULES_PROJECT)
+        members = pack_with_real_tar(
+            "react", project, str(tmp_path / "out.tgz").replace("\\", "/")
+        )
+        assert "./index.html" in members
+        assert "./assets/app.js" in members
+
+    def test_a_node_modules_nested_inside_the_output_dir_is_excluded(self, tmp_path) -> None:
+        """The gap SG-7 measured, now closed BY CONSTRUCTION rather than detected at runtime.
+
+        ``-C <project>/dist .`` cannot reach a SIBLING node_modules, but it packs one nested
+        inside the output dir — so the scope alone never made the 500 MB artifact impossible.
+        ``--exclude=./node_modules`` prevents it instead of rejecting it after the fact, which
+        matters because a runtime rejection keeps firing while the command still looks
+        correct, and the cause never gets traced.
+        """
+        tree = dict(NODE_MODULES_PROJECT)
+        tree["dist/node_modules/leaked/index.js"] = b"module.exports = {}"
+        tree["dist/node_modules/.bin/vite"] = b"#!/usr/bin/env node"
+        project = write_project_tree(tmp_path / "proj", tree)
+        members = pack_with_real_tar(
+            "react", project, str(tmp_path / "out.tgz").replace("\\", "/")
+        )
+        assert not any("node_modules" in m for m in members), members
+        # Not vacuous: an empty tar would also satisfy the assertion above.
+        assert "./index.html" in members
+
+    def test_a_deeper_nested_node_modules_is_excluded_too(self, tmp_path) -> None:
+        """A copied dependency tree does not have to land at the top of the output.
+
+        Passes on bsdtar, whose exclude matching is unanchored. GNU tar — what the Daytona
+        image actually runs — anchors a pattern containing a slash, so this case is NOT
+        guaranteed there. Recorded as a test rather than a comment because it is the honest
+        boundary of what has been proven locally, and the real-sandbox round-trip is what
+        settles it.
+        """
+        tree = dict(NODE_MODULES_PROJECT)
+        tree["dist/sub/node_modules/dep/index.js"] = b"module.exports = {}"
+        project = write_project_tree(tmp_path / "proj", tree)
+        members = pack_with_real_tar(
+            "react", project, str(tmp_path / "out.tgz").replace("\\", "/")
+        )
+        assert not any("node_modules" in m for m in members), members
+
+    def test_an_innocently_named_file_is_still_packed(self, tmp_path) -> None:
+        """The exclusion must not fire on a legitimate ``node_modules_report.html`` in the
+        output. A pattern that rejects innocent sites is how a safety measure gets removed
+        rather than fixed."""
+        tree = dict(NODE_MODULES_PROJECT)
+        tree["dist/docs/node_modules_report.html"] = b"<p>size audit</p>"
+        project = write_project_tree(tmp_path / "proj", tree)
+        members = pack_with_real_tar(
+            "react", project, str(tmp_path / "out.tgz").replace("\\", "/")
+        )
+        assert "./docs/node_modules_report.html" in members
+
+    def test_an_engine_whose_output_is_the_project_root_is_refused(self) -> None:
+        """html's output IS the project root, so an include-list cannot exclude anything.
+        Refusing outright is what keeps the guarantee above true for every engine that
+        does reach this lane."""
+        with pytest.raises(ValueError, match="project root"):
+            db.artifact_tar_command("html", "/home/daytona/paw-build", "/tmp/out.tgz")
+
+
+# ---------------------------------------------------------------------------
+# F7 — every degraded path names its rung
+# ---------------------------------------------------------------------------
+
+
+def _all_classifications() -> dict[str, db.BuildClassification]:
+    """Every condition ``classify_build`` can be driven into, by name.
+
+    Enumerated as a table rather than asserted case by case because the property under
+    test is about the SET — that no two conditions collide on one reason, and that none
+    is nameless. Neither can be checked one test at a time.
+    """
+    long_budget = WELL_INSIDE_BUDGET
+    return {
+        "ok": db.classify_build(ok_sentinel(), elapsed_seconds=1, timeout_seconds=long_budget),
+        "no_sentinel_lost": db.classify_build(
+            None, elapsed_seconds=1, timeout_seconds=long_budget
+        ),
+        "no_sentinel_timeout": db.classify_build(None, elapsed_seconds=99, timeout_seconds=1),
+        "unparseable": db.classify_build(
+            b"{not json", elapsed_seconds=1, timeout_seconds=long_budget
+        ),
+        "unknown_schema": db.classify_build(
+            ok_sentinel(schema=99), elapsed_seconds=1, timeout_seconds=long_budget
+        ),
+        "install_oom": db.classify_build(
+            ok_sentinel(install_exit=EXIT_SIGKILL),
+            elapsed_seconds=1,
+            timeout_seconds=long_budget,
+        ),
+        "build_oom": db.classify_build(
+            ok_sentinel(build_exit=EXIT_SIGKILL), elapsed_seconds=1, timeout_seconds=long_budget
+        ),
+        "build_sigterm": db.classify_build(
+            ok_sentinel(build_exit=EXIT_SIGTERM), elapsed_seconds=1, timeout_seconds=long_budget
+        ),
+        "install_timeout": db.classify_build(
+            ok_sentinel(install_exit=EXIT_TIMEOUT), elapsed_seconds=1, timeout_seconds=long_budget
+        ),
+        "build_timeout": db.classify_build(
+            ok_sentinel(build_exit=EXIT_TIMEOUT), elapsed_seconds=1, timeout_seconds=long_budget
+        ),
+        "missing_exit": db.classify_build(
+            ok_sentinel(build_exit=None), elapsed_seconds=1, timeout_seconds=long_budget
+        ),
+        "install_failed": db.classify_build(
+            ok_sentinel(install_exit=1), elapsed_seconds=1, timeout_seconds=long_budget
+        ),
+        "build_failed": db.classify_build(
+            ok_sentinel(build_exit=1), elapsed_seconds=1, timeout_seconds=long_budget
+        ),
+        "size_unknown": db.classify_build(
+            ok_sentinel(artifact_bytes="big"), elapsed_seconds=1, timeout_seconds=long_budget
+        ),
+        "empty": db.classify_build(
+            ok_sentinel(artifact_bytes=0), elapsed_seconds=1, timeout_seconds=long_budget
+        ),
+    }
+
+
+class TestF7EveryDegradedPathNamesItsRung:
+    """No bare ``failed`` with no explanation.
+
+    The harm is diagnostic, and it lands on whoever is on call: a lane that reports
+    "failed" without naming the rung forces a live investigation to reconstruct which of
+    a dozen conditions occurred, from a container that no longer exists.
+    """
+
+    def test_every_condition_carries_a_reason(self) -> None:
+        for name, got in _all_classifications().items():
+            assert got.reason, f"{name} produced a classification with no reason"
+
+    def test_every_reason_is_machine_readable(self) -> None:
+        """Reasons ride logs and metrics, so they must be greppable identifiers rather
+        than prose — a reason with spaces or capitals becomes a dashboard nobody can
+        group by."""
+        for name, got in _all_classifications().items():
+            assert got.reason.replace("_", "").isalnum(), f"{name}: {got.reason!r}"
+            assert got.reason == got.reason.lower(), f"{name}: {got.reason!r}"
+
+    def test_distinct_conditions_do_not_share_a_reason(self) -> None:
+        """Two conditions with one reason is the same diagnostic failure as no reason at
+        all — an operator reading it still cannot tell which happened.
+
+        The two legitimate collisions are asserted rather than excused: unparseable and
+        unknown-schema really are the same fact (a sentinel we cannot read, which is
+        indistinguishable from absence), and it is on purpose that they classify
+        identically.
+        """
+        table = _all_classifications()
+        unreadable = {"unparseable", "unknown_schema", "no_sentinel_lost"}
+        assert len({table[k].reason for k in unreadable}) == 1
+
+        distinct = {k: v.reason for k, v in table.items() if k not in unreadable}
+        assert len(set(distinct.values())) == len(distinct), (
+            f"reasons collided across distinct conditions: {sorted(distinct.items())}"
+        )
+
+    def test_no_infrastructure_outcome_ever_blames_the_user(self) -> None:
+        """The cross-cutting rung, restated over the whole table: whatever else changes,
+        ``blames_user`` may only be True for a proven ``build_failed``."""
+        for name, got in _all_classifications().items():
+            if got.blames_user:
+                assert got.outcome == "build_failed", f"{name} blamed the user for {got.outcome}"
+
+    def test_only_a_proven_build_failure_can_blame_the_user(self) -> None:
+        """The converse: an outcome that is not ``build_failed`` must never be presentable
+        as the user's fault, and ``build_failed`` is only reachable WITH a sentinel."""
+        table = _all_classifications()
+        blamed = {k for k, v in table.items() if v.blames_user}
+        assert blamed == {"install_failed", "build_failed", "size_unknown", "empty"}
+
+    async def test_the_runner_preserves_the_reason_it_was_given(self) -> None:
+        """A reason that is correct in the classifier and dropped by the runner is not a
+        reason. This is the seam where it would be lost."""
+        client = FaultyDaytonaClient(sentinel=ok_sentinel(build_exit=EXIT_SIGKILL))
+        got = await dr.run_build(REACT_FILES, engine="react", timeout_seconds=600, client=client)
+        assert got.classification.reason == f"build_killed_by_signal_{EXIT_SIGKILL}"
+
+    async def test_the_runner_only_reason_is_named_too(self) -> None:
+        """One condition exists only in the runner and the classifier never sees it, which
+        makes it the one most likely to ship nameless."""
+        download = FaultyDaytonaClient(fail_at="artifact")
+        got = await dr.run_build(REACT_FILES, engine="react", timeout_seconds=600, client=download)
+        assert got.classification.reason == "artifact_download_failed"
+        assert got.classification.blames_user is False
+
+
+# ---------------------------------------------------------------------------
+# The gap — pinned so it cannot close silently
+# ---------------------------------------------------------------------------
+
+
+class TestTheWiringGapIsRealAndTemporary:
+    """Tripwires, not assertions that the gap is GOOD.
+
+    These pin the fact that the lane has no production callers on this branch, which is
+    why parts of F2/F3 are unproven. Each one FAILS the day someone wires the lane —
+    which is exactly when the rung it names becomes injectable and must be proven for
+    real. Deleting a failing test here instead of proving its rung is the one wrong
+    response.
+    """
+
+    def test_publish_does_not_consult_the_daytona_lane_yet(self) -> None:
+        """When this fails: F1's publish half is now provable — a publish with Daytona
+        unconfigured must report unavailable and leave the site's row untouched."""
+        from pocketpaw_ee.sites import service
+
+        source = Path(service.__file__).read_text(encoding="utf-8")
+        assert "daytona_runner" not in source, (
+            "the Daytona lane is now wired into publish — prove F1's publish half "
+            "(unavailable + site unchanged) and F2's terminal failed-with-reason"
+        )
+
+    def test_nothing_writes_the_build_lifecycle_fields_yet(self) -> None:
+        """When this fails: F2's "terminal ``failed`` carrying a reason" and F7's
+        "the recorded status names its rung" become provable, and must be proven. Note
+        there is no ``build_reason`` field on the model today — a rung name has nowhere
+        to be recorded, which is itself a finding for whoever wires this."""
+        from pocketpaw_ee.sites import service
+
+        source = Path(service.__file__).read_text(encoding="utf-8")
+        assert "build_status" not in source, (
+            "something now writes Site.build_status — prove that a terminal failure "
+            "records a reason naming its rung, and that a failed enqueue cannot pin "
+            "the row in queued"
+        )
+
+    def test_there_is_no_enqueue_for_site_builds_yet(self) -> None:
+        """When this fails: F3's enqueue injection becomes real — patch the arq pool to
+        raise and assert the row does not end up pinned in ``queued``."""
+        from pocketpaw_ee.sites import service
+
+        source = Path(service.__file__).read_text(encoding="utf-8")
+        # Two markers because either alone is evadable: a wiring that goes through a
+        # helper never names ``enqueue_job``, and one that skips the polling handle never
+        # names ``build_job_id``. Any enqueue a client can poll writes at least one.
+        for marker in ("enqueue_job", "build_job_id"):
+            assert marker not in source, (
+                f"site builds now reach an enqueue ({marker!r}) — inject an arq/Redis "
+                "failure at the enqueue and prove the site is still republishable"
+            )
+
+    def test_the_lane_still_classifies_one_attempt_at_a_time(self) -> None:
+        """When this fails: F2's retry-with-backoff becomes provable. ``FaultyDaytonaClient``
+        already takes ``fail_times`` for it — fail the first two attempts, assert the third
+        succeeded and that the backoff actually slept."""
+        import inspect
+
+        source = inspect.getsource(dr.run_build)
+        for retry_marker in ("for attempt", "while attempt", "backoff", "sleep"):
+            assert retry_marker not in source, (
+                f"run_build appears to retry ({retry_marker!r}) — prove F2's backoff and "
+                "the terminal failed-with-reason on give-up"
+            )

--- a/tests/ee/sites/test_fault_ladder_deploy.py
+++ b/tests/ee/sites/test_fault_ladder_deploy.py
@@ -1,0 +1,253 @@
+# tests/ee/sites/test_fault_ladder_deploy.py — the DEPLOY half of the fault ladder:
+# rung F4 (the deploy answers 5xx) and rung F6 (the screenshot fails).
+#
+# Created 2026-08-10 (SG-7).
+#
+# WHY THESE TWO ARE IN A SEPARATE FILE FROM THE BUILD RUNGS. They are the only rungs on
+# the ladder that inject into the REAL publish path (``sites.service.publish``), because
+# they are the only ones whose boundary that path actually crosses today: the Daytona
+# lane has no production callers on this branch, but Cloudflare and the screenshot are
+# wired and shipping. So a green result here is worth strictly more than a green result
+# in the build file — it is evidence about production behaviour, not about a module in
+# waiting.
+#
+# THE PROPERTY BOTH RUNGS SHARE, and the reason they are worth testing at all: a publish
+# that fails must fail WITHOUT damaging what is already live. A site that was serving
+# yesterday's page must still be serving it — not a blank page, not a 404, and not a row
+# claiming it deployed. Every assertion below is some version of that.
+#
+# ONE FINDING RECORDED HERE RATHER THAN ASSERTED, so it is not mistaken for verified: F4
+# specifies "retry, and the previous deployment stays live". There is NO retry. A non-2xx
+# from Cloudflare raises out of ``cloudflare_client._unwrap`` on the first attempt and
+# nothing catches it to try again, which the attempt counters below MEASURE (they assert
+# exactly one attempt). The "previous deployment stays live" half is real and is proven.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import ValidationError
+from pocketpaw_ee.sites import service as sites_service
+from tests.ee.sites.faults import (
+    FailingCloudflare,
+    FailingWorkersDeploy,
+    screenshot_always_fails,
+)
+
+
+class _FakeGenerator:
+    """A generator that "builds" without a toolchain. Mirrors the fake the rest of the
+    sites suite uses, so these tests exercise the deploy/persist half in isolation —
+    generator faults are a different rung and belong to the build file."""
+
+    def __init__(self) -> None:
+        self.builds = 0
+
+    async def build(self, **kw):
+        from pocketpaw_ee.sites.generator_client import BuildResult
+
+        self.builds += 1
+        self.built = kw
+        return BuildResult(project_dir="/tmp/site", ripple_version="0.2.0")
+
+
+class _OkCloudflare:
+    def __init__(self) -> None:
+        self.put_calls: list[str] = []
+
+    async def put_worker(self, *, script_name, bundle, bindings=None):
+        self.put_calls.append(script_name)
+        return True
+
+
+async def _publish(pocket_id: str, **over):
+    """Publish once with working fakes, unless a fault is passed in ``over``."""
+    kwargs = {
+        "workspace_id": "ws-fault",
+        "user_id": "u1",
+        "pocket_id": pocket_id,
+        "ripple_spec": {"type": "container"},
+        "theme": {"primary": "#0A84FF"},
+        "name": "Bright Smile",
+        "_generator": _FakeGenerator(),
+        "_cloudflare": _OkCloudflare(),
+        "_bundle_reader": lambda d: b"export default {}",
+    }
+    kwargs.update(over)
+    return await sites_service.publish(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# F4 — the deploy answers 5xx
+# ---------------------------------------------------------------------------
+
+
+class TestF4DeployFailsAndThePreviousDeploymentSurvives:
+    """A Cloudflare 5xx must not take the live site down with it.
+
+    The failure this rung guards against is not the error — it is a row updated before
+    the deploy is known to have worked. Flip ``deployed``/``url`` first and a CF outage
+    silently repoints every visitor at a worker that was never uploaded.
+    """
+
+    async def test_a_5xx_deploy_raises_rather_than_reporting_success(
+        self, beanie_test_db
+    ) -> None:
+        cf = FailingCloudflare(status=503)
+        with pytest.raises(ValidationError) as err:
+            await _publish("pk-f4-raise", _cloudflare=cf)
+        assert "cloudflare" in err.value.code.lower()
+        assert cf.attempts == 1
+
+    async def test_the_previous_deployment_is_untouched_by_a_failed_republish(
+        self, beanie_test_db
+    ) -> None:
+        """The rung itself. Publish successfully, then fail a republish, then read the row
+        back from the DB — not the returned object, which a failed publish never hands
+        back — and assert the live pointer never moved.
+
+        BOTH sides of the comparison are DB reads, deliberately. Comparing the row against
+        the in-memory doc the first publish returned fails on a difference that is not the
+        one under test: BSON truncates a datetime to milliseconds and drops the tzinfo, so
+        the same instant reads unequal and the test reports a re-stamp that never
+        happened.
+        """
+        first = await _publish("pk-f4-live")
+        assert first.deployed is True
+        site_id = first.id
+
+        before = await sites_service._SiteDoc.find_one({"_id": site_id})
+        assert before is not None
+        was_url, was_at = before.url, before.deployed_at
+
+        with pytest.raises(ValidationError):
+            await _publish("pk-f4-live", _cloudflare=FailingCloudflare())
+
+        after = await sites_service._SiteDoc.find_one({"_id": site_id})
+        assert after is not None
+        assert after.deployed is True, "a failed republish must not un-deploy a live site"
+        assert after.url == was_url, "the live URL moved during a failed deploy"
+        assert after.deployed_at == was_at, (
+            "deployed_at was re-stamped for a deploy that never happened — the card "
+            "would claim a deploy time for a site still serving the older build"
+        )
+
+    async def test_a_first_publish_that_fails_leaves_no_site_claiming_to_be_live(
+        self, beanie_test_db
+    ) -> None:
+        """The other side of the same coin: with no previous deployment, a failed deploy
+        must not leave a row that says it deployed. A site listed as live with nothing
+        behind it is worse than an absent one — the user clicks through to a 404."""
+        with pytest.raises(ValidationError):
+            await _publish("pk-f4-first", _cloudflare=FailingCloudflare())
+
+        status = await sites_service.pocket_status(
+            workspace_id="ws-fault", pocket_id="pk-f4-first"
+        )
+        assert status.is_live is False
+        assert status.deployed_at is None
+
+    async def test_the_workers_target_behaves_the_same_way(
+        self, beanie_test_db, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A rung proven on one deploy target is not proven on the others. ``workers`` is
+        a different code path (``deploy_workers``, not ``cf.put_worker``), so it gets its
+        own injection rather than an assumption of symmetry."""
+        monkeypatch.setenv("PAW_CF_DEPLOY_MODE", "workers")
+        first = await _publish("pk-f4-workers", _workers_deploy=_ok_workers_deploy())
+        was_url = first.url
+
+        failing = FailingWorkersDeploy()
+        with pytest.raises(ValidationError):
+            await _publish("pk-f4-workers", _cloudflare=None, _workers_deploy=failing)
+        assert failing.attempts == 1
+
+        after = await sites_service._SiteDoc.find_one({"_id": first.id})
+        assert after is not None
+        assert after.url == was_url
+        assert after.deployed is True
+
+    async def test_a_failed_deploy_does_not_retry_today(self, beanie_test_db) -> None:
+        """Recorded as a MEASUREMENT, not a wish. F4 asks for retry-with-backoff; the
+        publish path has none, and ``cloudflare_client._unwrap`` raises on the first
+        non-2xx. This test states the current behaviour so that adding a retry has to
+        come here and say so, rather than the rung quietly reading as satisfied."""
+        cf = FailingCloudflare()
+        with pytest.raises(ValidationError):
+            await _publish("pk-f4-noretry", _cloudflare=cf)
+        assert cf.attempts == 1, (
+            "put_worker was attempted more than once — a retry now exists, so F4's "
+            "retry half is provable and must be proven (attempts, backoff, give-up)"
+        )
+
+
+def _ok_workers_deploy():
+    async def _deploy(site_id: str, project_dir: str, **kw) -> str:
+        return f"https://{site_id}.workers.dev"
+
+    return _deploy
+
+
+# ---------------------------------------------------------------------------
+# F6 — the screenshot fails
+# ---------------------------------------------------------------------------
+
+
+class TestF6AScreenshotFailureNeverFailsThePublish:
+    """The site is ALREADY live by the time the screenshot runs.
+
+    That ordering is what makes this rung non-negotiable: anything escaping here fails a
+    publish of a site that is deployed and serving, so the user sees an error for a
+    publish that worked. And the work behind it is a paid, quota'd remote browser render —
+    it will time out sooner or later, so "sooner or later" must be a missing thumbnail
+    rather than a failed publish.
+    """
+
+    async def test_publish_succeeds_when_the_screenshot_raises(
+        self, beanie_test_db, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        attempts = screenshot_always_fails(monkeypatch)
+        site = await _publish("pk-f6-live")
+        assert site.deployed is True
+        assert attempts["attempts"] >= 1, (
+            "the screenshot was never reached, so this proves nothing — the rung needs "
+            "the capture to actually have failed"
+        )
+
+    async def test_the_deploy_is_fully_recorded_despite_the_failure(
+        self, beanie_test_db, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Not just "no exception": the row must be complete. A publish that swallowed the
+        screenshot error but skipped the rest of its tail would pass a weaker assertion
+        and still leave a half-written site."""
+        screenshot_always_fails(monkeypatch)
+        site = await _publish("pk-f6-recorded")
+
+        after = await sites_service._SiteDoc.find_one({"_id": site.id})
+        assert after is not None
+        assert after.deployed is True
+        assert after.deployed_at is not None
+        assert after.signed_key
+
+    async def test_the_site_is_still_reported_live(
+        self, beanie_test_db, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """What the user sees. A thumbnail is cosmetic; ``is_live`` is what the dashboard
+        renders the site's state from, and it must not degrade over a picture."""
+        screenshot_always_fails(monkeypatch)
+        await _publish("pk-f6-status")
+        status = await sites_service.pocket_status(
+            workspace_id="ws-fault", pocket_id="pk-f6-status"
+        )
+        assert status.is_live is True
+
+    async def test_a_republish_still_works_after_a_screenshot_failure(
+        self, beanie_test_db, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A failed capture must not leave anything that blocks the next publish — the
+        same "permanently unpublishable" harm F3 exists to prevent, arriving by a
+        different route."""
+        screenshot_always_fails(monkeypatch)
+        first = await _publish("pk-f6-again")
+        second = await _publish("pk-f6-again")
+        assert second.id == first.id
+        assert second.deployed is True

--- a/tests/ee/sites/test_fault_ladder_deploy.py
+++ b/tests/ee/sites/test_fault_ladder_deploy.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import pytest
 from pocketpaw_ee.cloud._core.errors import ValidationError
 from pocketpaw_ee.sites import service as sites_service
+
 from tests.ee.sites.faults import (
     FailingCloudflare,
     FailingWorkersDeploy,
@@ -89,9 +90,7 @@ class TestF4DeployFailsAndThePreviousDeploymentSurvives:
     silently repoints every visitor at a worker that was never uploaded.
     """
 
-    async def test_a_5xx_deploy_raises_rather_than_reporting_success(
-        self, beanie_test_db
-    ) -> None:
+    async def test_a_5xx_deploy_raises_rather_than_reporting_success(self, beanie_test_db) -> None:
         cf = FailingCloudflare(status=503)
         with pytest.raises(ValidationError) as err:
             await _publish("pk-f4-raise", _cloudflare=cf)
@@ -140,9 +139,7 @@ class TestF4DeployFailsAndThePreviousDeploymentSurvives:
         with pytest.raises(ValidationError):
             await _publish("pk-f4-first", _cloudflare=FailingCloudflare())
 
-        status = await sites_service.pocket_status(
-            workspace_id="ws-fault", pocket_id="pk-f4-first"
-        )
+        status = await sites_service.pocket_status(workspace_id="ws-fault", pocket_id="pk-f4-first")
         assert status.is_live is False
         assert status.deployed_at is None
 

--- a/tests/mutations/fault_ladder.json
+++ b/tests/mutations/fault_ladder.json
@@ -1,0 +1,173 @@
+[
+  {
+    "label": "the artifact is packed from the project root, so node_modules ships to the edge and a 30 KB site becomes a 500 MB upload",
+    "file": "ee/pocketpaw_ee/sites/daytona_build.py",
+    "find": "    output_dir = f\"{project_dir.rstrip('/')}/{rel}\"",
+    "replace": "    output_dir = project_dir.rstrip('/')",
+    "tests": [
+      "tests/ee/sites/test_fault_ladder_build.py"
+    ]
+  },
+  {
+    "label": "the include-list becomes an exclude-list that forgets node_modules, which is the regression that silently ships the whole dependency tree",
+    "file": "ee/pocketpaw_ee/sites/daytona_build.py",
+    "find": "    return (\n        f\"tar -czf {shlex.quote(dest_path)} -C {shlex.quote(output_dir)} \"\n        f\"--exclude={shlex.quote(_EXCLUDED_MEMBER)} .\"\n    )",
+    "replace": "    return (\n        f\"tar -czf {shlex.quote(dest_path)} --exclude=.git \"\n        f\"-C {shlex.quote(project_dir.rstrip('/'))} .\"\n    )",
+    "tests": [
+      "tests/ee/sites/test_fault_ladder_build.py"
+    ]
+  },
+  {
+    "label": "an engine whose output is the project root is packed anyway, so an html site's node_modules is uploaded with it",
+    "file": "ee/pocketpaw_ee/sites/daytona_build.py",
+    "find": "    rel = static_output_rel(engine)\n    if rel == \".\":",
+    "replace": "    rel = static_output_rel(engine)\n    if False:",
+    "tests": [
+      "tests/ee/sites/test_fault_ladder_build.py"
+    ]
+  },
+  {
+    "label": "a lost sandbox counts as deployable, so a publish ships from an artifact no build ever proved it produced",
+    "file": "ee/pocketpaw_ee/sites/daytona_build.py",
+    "find": "        return self.outcome == \"completed_ok\"",
+    "replace": "        return self.outcome != \"build_failed\"",
+    "tests": [
+      "tests/ee/sites/test_fault_ladder_build.py"
+    ]
+  },
+  {
+    "label": "an OOM kill is read as a broken build, so a capacity problem is reported to the user as their fault",
+    "file": "ee/pocketpaw_ee/sites/daytona_build.py",
+    "find": "_INFRA_EXIT_CODES = frozenset({_EXIT_SIGKILL, _EXIT_SIGTERM})",
+    "replace": "_INFRA_EXIT_CODES: frozenset[int] = frozenset()",
+    "tests": [
+      "tests/ee/sites/test_fault_ladder_build.py"
+    ]
+  },
+  {
+    "label": "an in-sandbox timeout is reported as a build failure, so a slow site is told its code is broken",
+    "file": "ee/pocketpaw_ee/sites/daytona_build.py",
+    "find": "        if code == _EXIT_TIMEOUT:",
+    "replace": "        if False and code == _EXIT_TIMEOUT:",
+    "tests": [
+      "tests/ee/sites/test_fault_ladder_build.py"
+    ]
+  },
+  {
+    "label": "a build that left no proof is blamed on the user, which is the exact mis-report the sentinel design exists to prevent",
+    "file": "ee/pocketpaw_ee/sites/daytona_build.py",
+    "find": "        return BuildClassification(\n            outcome=\"infra_lost\",\n            reason=\"no_sentinel_before_timeout\",\n            retryable=True,\n            blames_user=False,\n        )",
+    "replace": "        return BuildClassification(\n            outcome=\"build_failed\",\n            reason=\"no_sentinel_before_timeout\",\n            retryable=True,\n            blames_user=True,\n        )",
+    "tests": [
+      "tests/ee/sites/test_fault_ladder_build.py"
+    ]
+  },
+  {
+    "label": "a sentinel written by an unknown future version is trusted anyway, so field meanings are guessed and a failed build can read as a success",
+    "file": "ee/pocketpaw_ee/sites/daytona_build.py",
+    "find": "    if parsed.get(\"schema\") != SENTINEL_SCHEMA:",
+    "replace": "    if False:",
+    "tests": [
+      "tests/ee/sites/test_fault_ladder_build.py"
+    ]
+  },
+  {
+    "label": "a missing exit code reads as a success, so a build that never ran deploys an empty site",
+    "file": "ee/pocketpaw_ee/sites/daytona_build.py",
+    "find": "    if install_exit is None or build_exit is None:",
+    "replace": "    if False:",
+    "tests": [
+      "tests/ee/sites/test_fault_ladder_build.py"
+    ]
+  },
+  {
+    "label": "an unconfigured Daytona returns a result instead of raising, so a missing credential is reported to the user as a failed build",
+    "file": "ee/pocketpaw_ee/sites/daytona_runner.py",
+    "find": "        if client is None:\n            raise RuntimeError(\n                \"Daytona is not configured (DAYTONA_API_URL / DAYTONA_API_KEY unset)\"\n            )",
+    "replace": "        if client is None:\n            raise RuntimeError(\"build unavailable\")",
+    "tests": [
+      "tests/ee/sites/test_fault_ladder_build.py"
+    ]
+  },
+  {
+    "label": "a build row with no stamp reads as fresh, so a half-completed enqueue makes the site permanently unpublishable",
+    "file": "ee/pocketpaw_ee/sites/build_state.py",
+    "find": "    if stamp is None:\n        return True",
+    "replace": "    if stamp is None:\n        return False",
+    "tests": [
+      "tests/ee/sites/test_fault_ladder_build.py"
+    ]
+  },
+  {
+    "label": "the staleness window becomes a constant, so a healthy long build gets a second billed sandbox opened on top of it",
+    "file": "ee/pocketpaw_ee/sites/build_state.py",
+    "find": "    return timedelta(seconds=max(0, timeout_seconds)) + STALE_MARGIN",
+    "replace": "    return STALE_MARGIN",
+    "tests": [
+      "tests/ee/sites/test_fault_ladder_build.py"
+    ]
+  },
+  {
+    "label": "a terminal failure keeps blocking new builds, so one bad build wedges the site until someone edits the database",
+    "file": "ee/pocketpaw_ee/sites/build_state.py",
+    "find": "    if status not in IN_FLIGHT_STATUSES:\n        return True",
+    "replace": "    if status == \"none\":\n        return True",
+    "tests": [
+      "tests/ee/sites/test_fault_ladder_build.py"
+    ]
+  },
+  {
+    "label": "a Cloudflare outage is swallowed, so the row flips to deployed and the dashboard claims a deploy that never uploaded",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        await cf.put_worker(script_name=site_id, bundle=bundle, bindings=bindings)",
+    "replace": "        try:\n            await cf.put_worker(script_name=site_id, bundle=bundle, bindings=bindings)\n        except Exception:\n            pass",
+    "tests": [
+      "tests/ee/sites/test_fault_ladder_deploy.py"
+    ]
+  },
+  {
+    "label": "a failed workers deploy is swallowed, so the site's URL is re-stamped for a deploy that never happened",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        url = await deploy_w(site_id, build.project_dir, engine=engine)",
+    "replace": "        try:\n            url = await deploy_w(site_id, build.project_dir, engine=engine)\n        except Exception:\n            url = \"\"",
+    "tests": [
+      "tests/ee/sites/test_fault_ladder_deploy.py"
+    ]
+  },
+  {
+    "label": "a failed thumbnail render fails the whole publish, so a site that is already live and serving reports an error to its owner",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    try:\n        from pocketpaw_ee.sites.screenshot import schedule_site_screenshot\n\n        schedule_site_screenshot(site)\n    except Exception:  # noqa: BLE001 \u2014 never fail a live publish over a screenshot",
+    "replace": "    if True:\n        from pocketpaw_ee.sites.screenshot import schedule_site_screenshot\n\n        schedule_site_screenshot(site)\n    if False:  # noqa: BLE001 \u2014 never fail a live publish over a screenshot",
+    "tests": [
+      "tests/ee/sites/test_fault_ladder_deploy.py"
+    ]
+  },
+  {
+    "label": "the node_modules exclusion is dropped, so a build that copies dependencies into its output ships them to the edge",
+    "file": "ee/pocketpaw_ee/sites/daytona_build.py",
+    "find": "        f\"--exclude={shlex.quote(_EXCLUDED_MEMBER)} .\"",
+    "replace": "        \".\"",
+    "tests": [
+      "tests/ee/sites/test_fault_ladder_build.py"
+    ]
+  },
+  {
+    "label": "the exclusion pattern stops matching what tar actually records, so it silently protects nothing",
+    "file": "ee/pocketpaw_ee/sites/daytona_build.py",
+    "find": "_EXCLUDED_MEMBER = \"./node_modules\"",
+    "replace": "_EXCLUDED_MEMBER = \"./nodemodules\"",
+    "tests": [
+      "tests/ee/sites/test_fault_ladder_build.py"
+    ]
+  },
+  {
+    "label": "the exclusion is widened to a substring, so a site with a legitimately-named node_modules_report.html silently loses that file",
+    "file": "ee/pocketpaw_ee/sites/daytona_build.py",
+    "find": "_EXCLUDED_MEMBER = \"./node_modules\"",
+    "replace": "_EXCLUDED_MEMBER = \"*node_modules*\"",
+    "tests": [
+      "tests/ee/sites/test_fault_ladder_build.py"
+    ]
+  }
+]


### PR DESCRIPTION
The Daytona build lane had a documented fallback ladder and no proof any rung
worked. This injects each fault for real and asserts what actually happens, on the
principle that an untested rung counts as failed.

Stacks on `feat/sites-daytona-build-lane`. Tests and one tar flag only — no wiring,
no new production logic.

## Four rungs proven, three partial

| Rung | Result |
|---|---|
| Verification fails (missing sentinel / empty artifact / node_modules present) | proven, all three |
| Screenshot fails, publish still succeeds | proven |
| Daytona unconfigured | proven at the runner; publish half not provable |
| Every degraded path names its rung | reason coverage proven across all 15 conditions |
| Daytona timeout / 5xx / create failure | classification and teardown proven; retry and terminal `failed` not provable |
| A build row nothing can consume | republishability proven; enqueue failure not provable |
| Cloudflare 5xx | previous deployment survives on both targets; retry does not exist |

Two rungs from the original plan were dropped rather than built: the ripple sidecar
cases, since that lane is out of scope, and the in-browser preview case, which moved
to the artifact-preview slice.

## Why three rungs are only partial

Nothing in production calls this lane yet. `run_build`, `should_enqueue`,
`build_is_stale` and `is_in_flight` have no call sites outside tests.
`Site.build_status`, `build_started_at` and `build_job_id` are declared and written
by nothing. There is no arq job, no enqueue and no worker for site builds, and
`service._deploy_site_doc` still builds through the local `GeneratorClient`.

That is the proving phase working as intended, not a defect — but it means four
things have no boundary to inject a fault into. Each is pinned as a tripwire in
`TestTheWiringGapIsRealAndTemporary` that fails the day the lane is wired and names
the rung then owed.

## A real hole in the artifact tar, and a ten-character fix

The include-list tar cannot reach a `node_modules` sitting beside the output
directory, which is the design working. It packs one nested inside it:
`tar -czf out -C dist .` ships `dist/node_modules/`. Measured against a real tar,
not reasoned about.

Neither engine emits that shape today, so this was latent rather than live. Fixed by
adding `--exclude=./node_modules` to the existing command, which closes it by
construction rather than detecting it after the fact.

**Carry this caveat forward.** The fix was verified against bsdtar 3.8.4, which is
what the dev box has. The sandbox image runs GNU tar, and the two differ where it
matters: bsdtar matches an exclude pattern unanchored, GNU tar anchors a pattern
containing a slash. The hole that was actually measured — top-level
`dist/node_modules` — is closed under both. A deeper `dist/sub/node_modules` is
proven locally only. The test docstring says so rather than implying image coverage,
and the first real sandbox round-trip is what settles it.

## A landmine for whoever wires this

`classification.deployable` is derived from the sentinel alone, so it stays True
when the download afterwards returns zero bytes. Its docstring used to promise "a
verified artifact to deploy", which overpromised in a way that would ship a blank
site over a working one. The docstring is corrected here; the behaviour is left to
the wiring phase.

**Gate a deploy on `BuildRunResult.ok`, never on `classification.deployable`.**

## Wiring contracts

| Contract | Why |
|---|---|
| Gate on `BuildRunResult.ok`, never `classification.deployable` | above |
| Split download failures on `retryable` when verification lands | Fewer bytes than the sentinel's `artifact_bytes` means the transfer failed — retry it. Full size but not readable gzip means the build produced garbage — do not. Collapsing them turns a network blip into a permanently burned publish. Keep "nothing arrived" and "half arrived" as separate reasons. |
| Retry with backoff | Needs an attempt loop. `FaultyDaytonaClient(fail_at=..., fail_times=N)` is already built for it: fail twice, assert the third attempt succeeded and that backoff slept. |
| Terminal `failed` carrying a reason | Needs something writing `build_status="failed"` and a `build_reason` field. A rung name has nowhere to be recorded today. |
| Enqueue failure | Needs an enqueue. The recovery half is already proven against `build_state`. |
| Publish-level unavailable | Needs `publish` consulting Daytona: report unavailable, leave the row untouched. |

A download-verification implementation for the second row already exists, built and
mutation-tested, on `spike/sites-artifact-verification` (`c41229c1`, 190 tests,
27/27 mutations). It was kept out of this branch because it is 170 lines of
production logic and this phase is scoped to test scenarios. Whoever wires the lane
should start from it rather than from this table.

Also worth knowing: a Cloudflare outage surfaces through this lane as a *validation*
error, because `cloudflare_client._unwrap` raises on the first non-2xx and nothing
catches it. The tests count attempts and assert exactly one, so adding a retry forces
someone back to them.

## Reusable injectors

`tests/ee/sites/faults.py` exposes `daytona_unconfigured`, `sandbox_create_fails`,
`sandbox_dies_mid_build`, `FailingCloudflare`, `FailingWorkersDeploy` and
`screenshot_always_fails`, so later work does not have to rediscover the patch
points. `FaultyDaytonaClient` takes `fail_at` for any of seven phases plus
`fail_times`; it defaults to failing every time, because a helper that quietly
healed would make a retry that does not exist look real.

## Two edits outside the slice, both disclosed

- `tests/ee/sites/test_daytona_build.py` asserted `"node_modules" not in cmd` with the
  comment "excluded by construction, not by a filter". That assertion encoded the
  belief the measurement disproved, and `--exclude` fails it on the mention of the
  word. It now asserts the exclusion is present and that `node_modules` appears
  exactly once, so it can only ever be the exclusion and never a packed path.
- Two sentinel fixtures hardcoded `artifact_bytes: 4096` beside a ~169-byte
  artifact. Corrected to compute the real length. A fixture asserting a fiction is
  worth fixing whether or not anything reads it.

## Verification

Run independently against `dcb2de66` in a separate checkout, not the author's:

```
pytest  fault ladder + daytona_build + daytona_runner + build_state
        + deployed_at_and_revert + html_publish                     177 passed

mutate.py  fault_ladder 19/19 · daytona_build 11/11
           daytona_image 5/5 · build_state 8/8
           exit 0 each, run serially, zero unmatched anchors, zero survivors
```

`verify_artifact` appears zero times in `ee/`, `daytona_runner.py` is byte-identical
to the base commit, and the only executable production change is the
`_EXCLUDED_MEMBER` constant and the tar return statement. Everything else in the
`daytona_build.py` diff is comment.
