### PR TITLE
Preview a site's built artifact, with no runtime in the way

### DIFF
--- a/docs/design/2026-08-10-sites-artifact-preview.md
+++ b/docs/design/2026-08-10-sites-artifact-preview.md
@@ -1,0 +1,180 @@
+<!-- Verdict for SG-10 of the paw-sites greenfield proving program: preview a site's
+     BUILT STATIC ARTIFACT, with no runtime. Written 2026-08-10 alongside
+     ee/pocketpaw_ee/sites/artifact_preview.py. Records what the static path covers,
+     what it does not, why the in-browser Node runtime is parked rather than solved,
+     and the licence trap that must not be repeated. -->
+
+# Previewing a built site artifact
+
+## What changed about the question
+
+SG-10 was originally "preview a site by booting a Node runtime in the browser" — a
+StackBlitz WebContainer session running a dev server for the site project. Two things
+retired that framing before any of it was built.
+
+**The build left the request path.** Every source-engine site now builds in an ephemeral
+Daytona sandbox that deletes itself, and only the static output comes back.
+`daytona_build.artifact_tar_command` packs exactly `static_output_rel(engine)` and
+nothing else, so `node_modules` is excluded by construction rather than by a filter.
+Measured against the live lane on 2026-08-09:
+
+| engine | artifact | entries | wall clock | `node_modules` | `_worker.js` |
+|--------|----------|---------|-----------|----------------|--------------|
+| react  | 61,487 B | 4       | 8.70s     | absent         | absent       |
+| svelte | 33,104 B | 24      | 14.67s    | absent         | present (4,335 B) |
+
+WebContainer answers "run a dev server for a project with dependencies, in the browser".
+Serving an already-built static tree is not that question. It needs no Node at all.
+
+**Choosing static removes constraints instead of adding them.** The in-tab runtime needs
+cross-origin isolation. COEP `require-corp` blocks presigned-S3 images, which is exactly
+what the sites gallery cards render, so turning it on breaks the surface the preview
+lives on. `credentialless` avoids that but is Chromium/Firefox only, so Safari lands back
+on `require-corp` and the same breakage. The static path sets no COOP or COEP header, and
+a test asserts neither appears on a preview response.
+
+## What this path does
+
+`ee/pocketpaw_ee/sites/artifact_preview.py` unpacks a build artifact and answers HTTP
+requests against the unpacked tree. `local_server.py`'s handler grew a second branch:
+`/<site_id>/...` is unchanged plain static serving of a local deploy, and
+`/_preview/<site_id>/...` routes through `artifact_preview.resolve`.
+
+It rides the server that already exists rather than standing up a second one. The
+established in-app preview pattern here is already "a localhost HTTP server, iframed by
+the builder" — `dev_server.py` does that with Vite — so the artifact preview is the same
+shape with the dev server removed.
+
+The module carries no per-engine layout knowledge, and that is not an oversight. The lane
+tars with `-C <static_output_rel(engine)> .`, so react's `dist` and svelte's
+`.svelte-kit/cloudflare` both arrive as a tree whose root is the deployable root. The
+artifact is already engine-normalized at the point it is packed. The engine is still
+consulted, through `engines.py` predicates rather than string compares, for the two things
+it genuinely decides: `static_output_rel(engine) == "."` means the engine runs no build
+and has no artifact to preview (so `html` is refused, mirroring the same guard in
+`artifact_tar_command`), and `emits_server_worker(engine)` says whether a `_worker.js` in
+the artifact is expected.
+
+### The three edge cases, and what was decided
+
+**`_worker.js` is skipped at unpack and refused at resolve.** svelte emits one even with
+no server routes at all; `adapter-cloudflare` emits a Server shell regardless, confirmed
+by deleting `src/routes/api/`, wiping `.svelte-kit` and rebuilding clean. So the preview
+does two things with it. It never writes it to disk, so the file does not sit inside a
+tree that gets served. And it refuses any request for it — including a directory-shaped
+`_worker.js/chunks/0.js`, which is what `adapter-cloudflare` emits for larger apps.
+
+The refusal is a 404 rather than a 403, and that is deliberate. A static preview genuinely
+has no server entry to offer, and a 403 would confirm the file is there. The reason to
+care is not tidiness: on the svelte track that bundle has carried a substituted per-site
+`__CAPTURE_SIGNED_KEY__`, so returning its source would be a secret disclosure. Its
+presence must not break anything else, and it does not — the index and the rest of the
+`_app/` tree serve normally beside it.
+
+`_routes.json` and `.assetsignore` get the same treatment for a weaker reason: they are
+deploy configuration, not site content.
+
+**`/api/submit` is refused visibly, and cannot be faked.** Lead capture is deferred, so
+there is no submit endpoint to serve. A form POST that appeared to succeed would be worse
+than an error, because the message would be lost silently. Any request under `api/`
+returns 501 with a page that says form submissions are not handled in preview and that
+publishing enables them. Any non-GET method returns 405 the same way, which covers the
+form-with-no-action case that posts back to the page itself. Nothing in the module can
+return 2xx for a write, and both refusals are checked before the module looks at whether
+an artifact is even stored — the honest answer to a form POST does not depend on that.
+
+**Two engine shapes, no hardcoded layout.** Covered above. The tests use tarballs shaped
+like both measured artifacts (4 entries and 24 entries with a worker) rather than one,
+because a preview that only ever saw react's shape would pass while being wrong about
+svelte's.
+
+### Publish does not depend on preview
+
+Demonstrated by test rather than asserted here. A local deploy is served, the preview is
+then broken three ways — an unreadable artifact, no artifact, and a resolver that raises
+mid-request — and the deployed site is re-fetched after each one and still answers 200.
+
+Two mechanisms make that true. `safe_store_artifact` swallows every failure and returns
+`None`, the way `screenshot.safe_take_*` does for card images, so a publish tail can call
+it without risk. And the preview branch in the handler catches everything and answers 500
+for that one request, because an exception escaping there would run on the same server
+thread that serves live local deploys.
+
+### The two roots are disjoint on purpose
+
+Deploys live under `sites_home()`, which the server hands out as plain static files.
+Previews live under `previews_home()` (`~/.pocketpaw/site-previews`, or
+`PAW_SITES_PREVIEW_DIR`), which the server never serves directly. If a preview tree sat
+inside `sites_home()`, the static branch would serve it as plain files with none of the
+refusals applied, and the `_worker.js` refusal would have a bypass. Keeping the roots
+disjoint is what makes the refusals structural instead of advisory, and a test asserts the
+containment both ways.
+
+## What this path does not cover
+
+**It is not a cloud-reachable endpoint yet.** The preview is served by the localhost
+static server, which is right for the proving phase and for local development, and is the
+same shape `dev_server.py` already uses. Exposing it through the authed cloud surface is a
+separate decision, and there is a real finding behind that: serving customer-authored HTML
+from the app's own origin means the page runs with the app's origin. The obvious mitigation
+is CSP `sandbox allow-scripts`, which puts the document in an opaque origin — but a
+sandboxed document's site-for-cookies is empty, so `SameSite` cookies stop riding its
+subresource requests and the page's own CSS and JS fail to load. The alternative is an
+unauthenticated preview URL carrying a signed, expiring token, which is a security design
+of its own. Neither should be picked as a side effect of this slice.
+
+Worth recording while adjacent: the session cookie is `HttpOnly` (`cloud/auth/core.py`
+pins `cookie_httponly=True`), so customer JavaScript in a preview cannot read it via
+`document.cookie`. Cookies are not port-scoped, so a localhost preview shares a cookie
+domain with a locally-running app — that is pre-existing on the `dev_server.py` path and
+not introduced here.
+
+**Nothing calls the build lane yet.** `daytona_runner.run_build` returns the artifact as
+in-memory `bytes` on `BuildRunResult.artifact`, and the only caller today is
+`scripts/sg9_daytona_roundtrip.py`. There is no S3 upload and no persistence in the sites
+module. The preview therefore takes artifact bytes as its input and does not assume where
+they came from: `local_server.serve_artifact_preview(site_id, artifact, engine=...)` is the
+one-call wiring point for whichever caller lands first, whether that is the publish tail
+handing over `result.artifact` directly or a later read from object storage.
+
+**No SPA fallback.** A missing asset is a 404, never a rewrite to `index.html`. Rewriting
+would report a broken build as a working page, which is the one failure mode a preview
+whose job is verification must not have. A client-routed project that needs deep-link
+previews would have to opt into a fallback explicitly.
+
+**No directory listings.** A directory with no `index.html` is a 404. A listing would hand
+out the build tree's shape to anyone holding the URL.
+
+## Live-edit preview is parked, not solved
+
+The one case this does not replace is a preview that reflects edits without a rebuild —
+hot module reload against a running dev server. That needs a Node runtime somewhere. Today
+it is `dev_server.py`, a Vite process on the box. Moving it into the browser is what
+WebContainer would be for, and that decision is blocked on a question nobody has asked
+yet.
+
+**The blocker is procurement, not engineering.** A commercial WebContainer plan carries a
+session cap. The case that matters here is sessions booted by tenants' own end visitors
+rather than by our authenticated seats, and that is exactly the kind vendors price
+separately. Until someone asks StackBlitz and gets an answer in writing, in-tab live-edit
+preview stays parked.
+
+**The licence trap, stated plainly so it is not repeated.** `@webcontainer/api` declares
+`"license": "MIT"` in its npm manifest. That covers the client library only. It does not
+cover the hosted runtime, and it is not the commercial terms. It must never be cited as
+permission to ship — not in code, not in a comment, not in a doc, not in a PR body, and
+not in a customer conversation. Reading the manifest as a licence for the service is the
+specific mistake this paragraph exists to prevent.
+
+## Verification
+
+Unit rules in `tests/ee/sites/test_artifact_preview.py`; HTTP behaviour and the
+publish-isolation proof in `tests/ee/sites/test_artifact_preview_server.py`. Mutation plan
+at `tests/mutations/sites_artifact_preview.json`, covering the refusals, both traversal
+guards, the link-member guard, the content-type table, the size ceilings, the disjoint
+roots, and the two failure-containment paths.
+
+One guard is deliberately not mutation-covered. The post-join containment check in
+`resolve` is unreachable while the path parser is correct — every way a joined path can
+leave the root is refused before the join. It stays because "the parser is correct" is an
+assumption, and the check costs one stat.

--- a/docs/design/2026-08-10-sites-artifact-preview.md
+++ b/docs/design/2026-08-10-sites-artifact-preview.md
@@ -2,7 +2,12 @@
      BUILT STATIC ARTIFACT, with no runtime. Written 2026-08-10 alongside
      ee/pocketpaw_ee/sites/artifact_preview.py. Records what the static path covers,
      what it does not, why the in-browser Node runtime is parked rather than solved,
-     and the licence trap that must not be repeated. -->
+     and the licence trap that must not be repeated.
+     Revised 2026-08-10, same day, for two things that landed after the first draft:
+     the captain's ruling that Daytona is a BUILD host only (so dev_server.py stays and
+     the footprint question is unanswered rather than solved), and path traversal, which
+     the original brief omitted and which nothing else in the program covers -- SG-11's
+     checklist does not include it. -->
 
 # Previewing a built site artifact
 
@@ -88,6 +93,45 @@ like both measured artifacts (4 entries and 24 entries with a worker) rather tha
 because a preview that only ever saw react's shape would pass while being wrong about
 svelte's.
 
+### Path traversal, at both ends
+
+A static file server over an extracted archive has two traversal surfaces, not one, and
+both are guarded.
+
+**At extract time.** A member named `../../etc/passwd`, or an absolute path, a drive
+letter, a backslash, or a symlink, escapes when it is written, regardless of how careful
+the request side is. `tarfile` has historically been unsafe by default here, so nothing in
+this module calls `extractall`: members are written one at a time after their names are
+validated, and archive permissions are discarded so nothing can arrive executable. Links
+are refused rather than followed, hardlinks included — a hardlink to a member that *is* in
+the archive extracts to real content, so without a member-type check it would be written
+like any other file.
+
+**At request time.** The path is percent-decoded first (`..%2f..%2f` only looks safe
+before decoding), validated segment by segment, and then — the part that matters —
+resolved and compared against the resolved root. A prefix check on the raw string is
+defeated by encoding and, more importantly, by a symlink, which no amount of string
+inspection can see. Both sides are resolved, because the root itself can sit under a link:
+a temp dir on macOS does (`/tmp` → `/private/tmp`), and comparing a resolved target
+against an unresolved root would refuse every legitimate request there.
+
+Two details worth writing down.
+
+The parser and the containment check return **different reasons** (`unsafe_path` versus
+`escaped_root`) for the same 404. That is not cosmetic. The first version of the traversal
+tests asserted only the status, and a mutation that disabled the parser's `..` check still
+passed, because containment refused the same request afterwards. The suite would have
+shipped a broken parser guard. Asserting the specific reason is what makes each layer
+independently provable.
+
+And the NUL-byte case landed somewhere unexpected. A NUL in a member name **cannot ride a
+tar archive at all** — the format's name field is NUL-terminated, so writing a member
+called `./safe.html\0/../../escaped.txt` and reading the archive back yields
+`./safe.html`; the tail is gone before any of our code sees it. The guard is kept because
+refusing a NUL is a property of a name parser rather than of tar, but it is asserted
+against the parser directly. A test that packed such a tarball would have looked like
+proof and been none.
+
 ### Publish does not depend on preview
 
 Demonstrated by test rather than asserted here. A local deploy is served, the preview is
@@ -145,15 +189,37 @@ previews would have to opt into a fallback explicitly.
 **No directory listings.** A directory with no `index.html` is a 404. A listing would hand
 out the build tree's shape to anyone holding the URL.
 
-## Live-edit preview is parked, not solved
+## Live-edit preview is parked, not solved — and `dev_server.py` stays
 
-The one case this does not replace is a preview that reflects edits without a rebuild —
-hot module reload against a running dev server. That needs a Node runtime somewhere. Today
-it is `dev_server.py`, a Vite process on the box. Moving it into the browser is what
-WebContainer would be for, and that decision is blocked on a question nobody has asked
-yet.
+The one case this does not replace is a preview that reflects edits without a rebuild:
+hot module reload against a running dev server. That needs a Node runtime somewhere, and
+right now the only place it can be is the box.
 
-**The blocker is procurement, not engineering.** A commercial WebContainer plan carries a
+**`dev_server.py` stays. It is not being retired, and nothing here proposes retiring it.**
+The original slice promised a verdict that would gate its retirement; that retirement is
+off the table. Two independent doors closed. Daytona is a **build host only** — the captain
+ruled it cannot host a dev environment, and the ruling is structurally forced rather than a
+preference: a dev server is long-lived by definition, while the Daytona lane makes every
+sandbox ephemeral, strict-timeout and self-deleting in a `finally`. Hosting a dev env there
+means either abandoning the self-delete rule, which reinstates the `auto_stop_interval`
+billing landmine that rule exists to kill, or a dev server that vanishes mid-edit. No
+configuration is both. And WebContainer, the other candidate, is parked on procurement
+(below). With both closed, the on-box Vite process is the only live editing path, and it is
+load-bearing.
+
+**What moved and what did not.** *Viewing* a built site moved off the box — that is what
+this slice did, and it is real. *Editing* did not move at all. Keeping `dev_server.py` is
+the status quo rather than a regression, and edits are already fast: P2a replaced per-edit
+rebuilds with HMR, so a hot reload is milliseconds.
+
+What stays on the box is the **footprint**. Live editing means N long-lived Vite processes
+plus N `node_modules` trees on a 4-CPU / 6G api container, at 100–200 users per tenant.
+Moving that to the client was WebContainer's entire value, so **that question is now
+unanswered, not solved** — and it is a capacity question, not a latency one. Anyone reading
+this as "preview cost left the box" has it right for viewing and wrong for the half that
+actually constrains scaling.
+
+**The WebContainer blocker is procurement, not engineering.** A commercial plan carries a
 session cap. The case that matters here is sessions booted by tenants' own end visitors
 rather than by our authenticated seats, and that is exactly the kind vendors price
 separately. Until someone asks StackBlitz and gets an answer in writing, in-tab live-edit
@@ -166,15 +232,23 @@ permission to ship — not in code, not in a comment, not in a doc, not in a PR 
 not in a customer conversation. Reading the manifest as a licence for the service is the
 specific mistake this paragraph exists to prevent.
 
+**There is no server-side preview fallback, of any kind.** The earlier spec routed
+"in-tab WebContainer when the project qualifies, Daytona VM otherwise". The VM half is
+gone with the ruling, and nothing in this slice reintroduces it: the preview path contains
+no Daytona call and no VM concept. Daytona appears in this subsystem only as the place the
+artifact was *built*, before it arrived.
+
 ## Verification
 
 Unit rules in `tests/ee/sites/test_artifact_preview.py`; HTTP behaviour and the
 publish-isolation proof in `tests/ee/sites/test_artifact_preview_server.py`. Mutation plan
-at `tests/mutations/sites_artifact_preview.json`, covering the refusals, both traversal
-guards, the link-member guard, the content-type table, the size ceilings, the disjoint
-roots, and the two failure-containment paths.
+at `tests/mutations/sites_artifact_preview.json` — 27 mutations, all caught.
 
-One guard is deliberately not mutation-covered. The post-join containment check in
-`resolve` is unreachable while the path parser is correct — every way a joined path can
-leave the root is refused before the join. It stays because "the parser is correct" is an
-assumption, and the check costs one stat.
+Every traversal guard has its own mutation, deliberately one per guard rather than one per
+condition: a combined `if a or b or c` reads as verified when only one of the three is, so
+each refusal is a separate statement that can be removed on its own and watched to break
+exactly one test. That covers the `..`, absolute-path, drive-letter, backslash and NUL
+checks on both the member-name and request-path sides, the link-member refusal, and the
+post-join containment check. The containment check is exercised by a real symlink planted
+inside a preview tree; that test skips only where the OS refuses to create symlinks, which
+is worth knowing because on such a platform its mutation would escape rather than fail.

--- a/ee/pocketpaw_ee/sites/artifact_preview.py
+++ b/ee/pocketpaw_ee/sites/artifact_preview.py
@@ -36,7 +36,7 @@
 # (``static_output_rel`` == "." means it has no build subdir) and whether a
 # ``_worker.js`` in the artifact is expected (``emits_server_worker``).
 #
-# THREE DECISIONS WORTH READING BEFORE CHANGING ANYTHING HERE:
+# FOUR DECISIONS WORTH READING BEFORE CHANGING ANYTHING HERE:
 #
 #   * ``_worker.js`` IS NEITHER EXECUTED NOR SERVED, AND NEVER LANDS ON DISK. svelte
 #     emits one even with no server routes — confirmed by deleting ``src/routes/api/``,
@@ -55,6 +55,20 @@
 #   * NO SPA FALLBACK. A missing asset is a 404, never a rewrite to ``index.html``.
 #     Rewriting would make a broken build look finished, which is the one failure mode
 #     a preview whose job is verification must not have.
+#   * PATH TRAVERSAL IS GUARDED AT BOTH ENDS, because this is a static file server over
+#     an extracted archive and that is two attack surfaces, not one.
+#       - AT EXTRACT TIME (:func:`_normalized_member_path`): a member named
+#         ``../../etc/passwd``, an absolute path, a drive letter, a backslash, a NUL, or
+#         a symlink/hardlink escapes regardless of how careful the request side is.
+#         ``tarfile`` has historically been unsafe by default here, which is why nothing
+#         in this module calls ``extractall`` — members are written one at a time after
+#         their names have been validated, with archive permissions discarded.
+#       - AT REQUEST TIME (:func:`_request_segments` then :func:`_contained`): the path
+#         is percent-decoded and validated, and then — the part that matters — RESOLVED
+#         and checked against the resolved root. A prefix check on the raw string is
+#         defeated by encoding and by symlinks; a check on the real path is not.
+#     Every one of those guards has a mutation in ``tests/mutations`` proving it fires.
+#     A traversal guard nobody has watched break is not a guard.
 #
 # Storage lives at ``previews_home()`` — deliberately NOT under
 # ``local_server.sites_home()``. That server serves its root as plain static files, so
@@ -265,12 +279,23 @@ def _normalized_member_path(name: str) -> tuple[str, ...] | None:
 
     ``tar -C <dir> .`` names every member ``./x/y``, so the leading ``.`` is normal and
     stripped. Everything else here is a refusal: an absolute path, a ``..`` segment, a
-    backslash (a path separator on Windows and a legal filename character on POSIX —
-    treating it as either is a way to be surprised), or a NUL.
+    backslash, a drive letter, or a NUL.
+
+    EACH REFUSAL IS ITS OWN STATEMENT rather than one combined condition, so a mutation
+    can remove exactly one of them and be seen to break exactly one test. A single
+    ``if a or b or c`` guard reads as verified when only one of the three is.
     """
-    if not name or name.startswith("/") or name.startswith("\\"):
+    if not name or name.startswith("/"):
         return None
-    if "\x00" in name or "\\" in name:
+    if "\x00" in name:
+        # A NUL truncates the name for any C-level consumer, so a member called
+        # "index.html\x00/../../evil" can pass a suffix or prefix check and land
+        # somewhere else entirely.
+        return None
+    if "\\" in name:
+        # A path separator on Windows and a legal filename character on POSIX.
+        # Treating it as either means the same artifact writes to two different
+        # places depending on where it is unpacked.
         return None
     if len(name) > 1 and name[1] == ":":  # a Windows drive-qualified path
         return None
@@ -521,18 +546,61 @@ def _request_segments(subpath: str) -> tuple[str, ...] | None:
     ``C:/Windows`` and the join silently leaves the preview root. On POSIX the same
     segment is an ordinary filename, so the check costs nothing and closes a hole that
     exists on the platform this is developed on.
+
+    Refusals are separate statements for the same reason as in
+    :func:`_normalized_member_path`: so each one can be mutated on its own and shown
+    to be load-bearing. Refusing here is not the last line of defence — the caller
+    still resolves and contains (:func:`_contained`) — but it is the layer that sees
+    the request as the client wrote it, before any join has happened.
     """
     decoded = unquote(subpath or "")
-    if "\x00" in decoded or "\\" in decoded:
+    if "\x00" in decoded:
+        # A NUL truncates the path for any C-level consumer, so it can make a
+        # suffix or extension check agree with a different file than the one opened.
+        return None
+    if "\\" in decoded:
         return None
     segments: list[str] = []
     for raw in decoded.split("/"):
         if raw in ("", "."):
             continue
-        if raw == ".." or (len(raw) > 1 and raw[1] == ":"):
+        if raw == "..":
+            return None
+        if len(raw) > 1 and raw[1] == ":":
             return None
         segments.append(raw)
     return tuple(segments)
+
+
+def _contained(root: Path, target: Path) -> Path | None:
+    """``target``'s real path when it is inside ``root``, else ``None``.
+
+    RESOLVE, THEN CONTAIN — in that order, and on the REAL path rather than the string.
+    Sanitising the request and trusting the result is the version of this that fails: a
+    prefix check on the raw string is defeated by percent-encoding (handled a layer up)
+    and by a SYMLINK, which no amount of string inspection can see. Only comparing the
+    resolved path against the resolved root catches a link inside the tree that points
+    out of it. Both sides are resolved because the root itself can sit under a link —
+    a temp dir on macOS does (``/tmp`` → ``/private/tmp``), and comparing a resolved
+    target against an unresolved root would then refuse every legitimate request.
+
+    Returning the path rather than a bool is deliberate: the caller cannot end up
+    holding a path it never contained, and there is no branch where the containment
+    check is skipped but a resolved path exists. An earlier version set ``inside =
+    False`` in an ``except OSError`` and left ``resolved`` unassigned — safe only
+    because that branch happened to return, which is exactly the coupling that breaks
+    when someone adds a branch later. pyright flagged it as possibly-unbound; on a
+    path-resolution routine that reads as a containment bug waiting to happen, not a
+    lint.
+    """
+    try:
+        real_root = root.resolve()
+        real = target.resolve()
+    except OSError:  # pragma: no cover - an unresolvable path is refused, not raised
+        return None
+    if real == real_root or real.is_relative_to(real_root):
+        return real
+    return None
 
 
 def resolve(site_id: str, subpath: str, *, method: str = "GET") -> PreviewResponse:
@@ -599,18 +667,14 @@ def resolve(site_id: str, subpath: str, *, method: str = "GET") -> PreviewRespon
             404, "metadata_refused", "Not found", "There's no such page in this preview."
         )
 
-    target = root.joinpath(*segments) if segments else root
-    try:
-        resolved = target.resolve()
-        inside = resolved == root.resolve() or resolved.is_relative_to(root.resolve())
-    except OSError:  # pragma: no cover - unresolvable path
-        inside = False
-    if not inside:
-        # DEFENCE IN DEPTH, and deliberately unreachable while ``_request_segments`` is
-        # correct — every way a joined path can leave the root (``..``, an anchor, a
-        # separator) is refused up there. It stays because "the parser is correct" is an
-        # assumption, and a containment check after the join costs one stat.
-        return _refusal(404, "unsafe_path", "No preview here", "That path isn't valid.")
+    resolved = _contained(root, root.joinpath(*segments) if segments else root)
+    if resolved is None:
+        # A DISTINCT reason from the parser's ``unsafe_path``, though the client sees the
+        # same 404 and the same page. The two layers refuse for different reasons, and
+        # with one shared reason string a mutation that disabled the parser would still
+        # look caught — the containment check would refuse the same request and the test
+        # would pass. Separate reasons are what make each layer independently provable.
+        return _refusal(404, "escaped_root", "No preview here", "That path isn't valid.")
 
     if resolved.is_dir():
         if not subpath.endswith("/"):

--- a/ee/pocketpaw_ee/sites/artifact_preview.py
+++ b/ee/pocketpaw_ee/sites/artifact_preview.py
@@ -1,0 +1,677 @@
+# ee/pocketpaw_ee/sites/artifact_preview.py — preview a site's BUILT STATIC
+# ARTIFACT. Unpacks the tarball the ephemeral build lane produces and answers
+# HTTP requests against it. No Node runtime, no dev server, no cross-origin
+# isolation.
+#
+# Created 2026-08-10 (SG-10, re-aimed). The slice originally booted an in-tab Node
+# runtime (StackBlitz WebContainer) to run a dev server for the site project. Two
+# things retired that premise:
+#
+#   1. THE BUILD LEFT THE REQUEST PATH. Every source-engine site now builds in an
+#      ephemeral Daytona sandbox that deletes itself, and only the STATIC OUTPUT
+#      comes back — ``daytona_build.artifact_tar_command`` packs exactly
+#      ``static_output_rel(engine)`` and nothing else. Measured 2026-08-09: react
+#      61,487 bytes / 4 entries in 8.70s, svelte 33,104 bytes / 24 entries in
+#      14.67s, neither containing ``node_modules``. Serving an already-built static
+#      tree needs no Node at all, so the in-browser runtime solves a problem this
+#      lane no longer has.
+#   2. THE LICENCE QUESTION IS PROCUREMENT, NOT ENGINEERING. Nobody has asked
+#      StackBlitz whether a licence covers sessions booted by tenants' own end
+#      visitors. Note that ``@webcontainer/api`` declaring ``"license": "MIT"`` in
+#      its npm manifest covers the CLIENT LIBRARY ONLY — not the hosted runtime and
+#      not the commercial terms. It is not permission and must never be cited as
+#      such.
+#
+# Choosing static REMOVES constraints. The in-tab runtime needs cross-origin
+# isolation, and COEP ``require-corp`` blocks presigned-S3 images — exactly what the
+# sites gallery cards render. ``credentialless`` dodges that but is Chromium/Firefox
+# only, so Safari still breaks. This path sets no COOP/COEP header at all.
+#
+# THE ARTIFACT IS ALREADY ENGINE-NORMALIZED, and that is the whole reason this module
+# carries no per-engine layout knowledge. The lane packs with
+# ``tar -C <static_output_rel(engine)> .``, so react's ``dist`` and svelte's
+# ``.svelte-kit/cloudflare`` both arrive as a tree whose ROOT is the deployable root.
+# The engine is still consulted — via ``engines`` predicates, never a string compare —
+# for two things it genuinely decides: whether the engine belongs in this lane at all
+# (``static_output_rel`` == "." means it has no build subdir) and whether a
+# ``_worker.js`` in the artifact is expected (``emits_server_worker``).
+#
+# THREE DECISIONS WORTH READING BEFORE CHANGING ANYTHING HERE:
+#
+#   * ``_worker.js`` IS NEITHER EXECUTED NOR SERVED, AND NEVER LANDS ON DISK. svelte
+#     emits one even with no server routes — confirmed by deleting ``src/routes/api/``,
+#     wiping ``.svelte-kit`` and rebuilding clean; ``adapter-cloudflare`` emits a Server
+#     shell regardless. It is skipped at unpack AND refused at resolve (404, not 403 —
+#     a static preview genuinely has no server entry to offer, and 403 would advertise
+#     the file). The refusal is not tidiness: on the svelte track that bundle
+#     historically carried a substituted per-site ``__CAPTURE_SIGNED_KEY__``, so
+#     returning its SOURCE would be a secret disclosure. Its presence must not break
+#     the rest of the preview, and it does not — everything beside it still serves.
+#   * ``/api/*`` IS REFUSED VISIBLY, NEVER FAKED. Lead capture is deferred, so no
+#     ``/api/submit`` exists to serve. A form POST that appeared to succeed would be
+#     worse than an error, so any request under ``api/`` gets 501 and a page that says
+#     so, and any non-GET method gets 405 the same way. Nothing in this module can
+#     return 2xx for a write.
+#   * NO SPA FALLBACK. A missing asset is a 404, never a rewrite to ``index.html``.
+#     Rewriting would make a broken build look finished, which is the one failure mode
+#     a preview whose job is verification must not have.
+#
+# Storage lives at ``previews_home()`` — deliberately NOT under
+# ``local_server.sites_home()``. That server serves its root as plain static files, so
+# a preview tree inside it would be reachable without passing these guards, and the
+# ``_worker.js`` refusal would have a bypass. Keeping the roots disjoint is what makes
+# the refusals structural rather than advisory.
+from __future__ import annotations
+
+import io
+import logging
+import mimetypes
+import os
+import re
+import shutil
+import tarfile
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from urllib.parse import unquote
+
+from pocketpaw_ee.sites.engines import emits_server_worker, normalize_engine, static_output_rel
+
+logger = logging.getLogger(__name__)
+
+#: URL path segment the preview tree is mounted under on the local static server.
+#: A distinct prefix (rather than a bare ``/<site_id>/``) is what lets one handler
+#: route preview requests through :func:`resolve` while leaving the deploy trees on
+#: plain static serving.
+PREVIEW_URL_PREFIX = "_preview"
+
+#: A site id is a URL path segment here, so it is validated rather than trusted.
+#: Real ids are Mongo ObjectIds / uuids; this rejects separators, dots and anything
+#: that could climb out of ``previews_home()``.
+_SAFE_SITE_ID = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+
+#: Members skipped at unpack and refused at resolve. ``_worker.js`` arrives as a FILE
+#: on the measured svelte artifact (4,335 bytes) but ``adapter-cloudflare`` emits a
+#: DIRECTORY of chunks for larger apps, so the match is per path SEGMENT and takes the
+#: whole subtree with it.
+_SERVER_ENTRY_NAMES: frozenset[str] = frozenset({"_worker.js"})
+
+#: Deploy configuration that rides along in the artifact and is not site content.
+#: ``_routes.json`` and ``.assetsignore`` are what adapter-cloudflare emits; the
+#: Pages-style ``_headers`` / ``_redirects`` are here because they are the same kind of
+#: thing and would be equally wrong to serve as a page.
+_DEPLOY_METADATA_NAMES: frozenset[str] = frozenset(
+    {"_routes.json", ".assetsignore", "_headers", "_redirects"}
+)
+
+#: Zip-bomb ceilings. The measured artifacts are 4 and 24 entries at tens of KB, so
+#: these are orders of magnitude clear of anything real; they exist because the tarball
+#: is built from customer content and a preview must not be a way to fill the disk.
+MAX_ENTRIES = 20_000
+MAX_TOTAL_BYTES = 128 * 1024 * 1024
+
+#: Content types resolved from an EXPLICIT table before falling back to
+#: ``mimetypes``, because the stdlib reads the Windows registry and has been observed
+#: returning ``text/plain`` for ``.js`` there. A preview that serves the site's
+#: JavaScript as ``text/plain`` renders a page that never hydrates — and the captain's
+#: standing rule is that JS is load-bearing for sites, so getting this wrong silently
+#: breaks the thing the preview exists to check.
+_CONTENT_TYPES: dict[str, str] = {
+    ".html": "text/html; charset=utf-8",
+    ".htm": "text/html; charset=utf-8",
+    ".js": "text/javascript; charset=utf-8",
+    ".mjs": "text/javascript; charset=utf-8",
+    ".css": "text/css; charset=utf-8",
+    ".json": "application/json; charset=utf-8",
+    ".map": "application/json; charset=utf-8",
+    ".webmanifest": "application/manifest+json",
+    ".txt": "text/plain; charset=utf-8",
+    ".xml": "application/xml; charset=utf-8",
+    ".svg": "image/svg+xml",
+    ".ico": "image/x-icon",
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".avif": "image/avif",
+    ".woff": "font/woff",
+    ".woff2": "font/woff2",
+    ".ttf": "font/ttf",
+    ".otf": "font/otf",
+    ".wasm": "application/wasm",
+    ".mp4": "video/mp4",
+    ".webm": "video/webm",
+}
+
+_OCTET_STREAM = "application/octet-stream"
+
+
+class ArtifactRejected(ValueError):
+    """The artifact cannot be turned into a preview. Base of the refusals below."""
+
+
+class ArtifactUnreadable(ArtifactRejected):
+    """The bytes are not a readable gzipped tar (truncated download, wrong file)."""
+
+
+class ArtifactTooLarge(ArtifactRejected):
+    """The artifact exceeds :data:`MAX_ENTRIES` or :data:`MAX_TOTAL_BYTES`."""
+
+
+class BadSiteId(ArtifactRejected):
+    """The site id is not a safe single path segment."""
+
+
+@dataclass(frozen=True)
+class UnpackedArtifact:
+    """What came out of one artifact, including what was deliberately left out.
+
+    The skip lists are RETURNED rather than only logged: ``server_entries`` is the
+    evidence that svelte's server shell was seen and dropped, and ``rejected`` is the
+    evidence a hostile member was refused. A preview that silently discarded either
+    would leave nothing to check.
+    """
+
+    entries: int
+    bytes_written: int
+    server_entries: tuple[str, ...] = ()
+    metadata_entries: tuple[str, ...] = ()
+    rejected: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class PreviewSnapshot:
+    """A stored preview: where it is on disk, and what it is mounted at."""
+
+    site_id: str
+    engine: str
+    root: Path
+    url_path: str
+    unpacked: UnpackedArtifact
+
+
+@dataclass(frozen=True)
+class PreviewResponse:
+    """One resolved request. Deliberately a value, not a write to a socket, so every
+    rule below is unit-testable without an HTTP server in the way."""
+
+    status: int
+    reason: str
+    content_type: str = "text/html; charset=utf-8"
+    body: bytes = b""
+    #: Set only on 301. The subpath to redirect to, RELATIVE to the site's mount
+    #: point — the caller composes the absolute URL because only it knows the prefix.
+    location: str | None = None
+    headers: tuple[tuple[str, str], ...] = field(default_factory=tuple)
+
+    @property
+    def ok(self) -> bool:
+        return 200 <= self.status < 300
+
+
+def previews_home() -> Path:
+    """Root of the unpacked preview trees.
+
+    ``~/.pocketpaw/site-previews`` by default; override with ``PAW_SITES_PREVIEW_DIR``
+    (tests point it at a temp dir so a run never writes the real home).
+
+    A SIBLING of ``local_server.sites_home()``, never a child. That server hands its
+    whole root out as static files, so a preview stored inside it would be reachable
+    without passing :func:`resolve` — and the ``_worker.js`` refusal would have a
+    bypass. Disjoint roots are what make the guards structural.
+    """
+    raw = os.environ.get("PAW_SITES_PREVIEW_DIR")
+    base = Path(raw) if raw else Path.home() / ".pocketpaw" / "site-previews"
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+
+def _check_site_id(site_id: str) -> str:
+    if not isinstance(site_id, str) or not _SAFE_SITE_ID.match(site_id):
+        raise BadSiteId(f"unsafe site id for a preview path: {site_id!r}")
+    return site_id
+
+
+def preview_root(site_id: str) -> Path:
+    """Where this site's unpacked artifact lives. Does not create it."""
+    return previews_home() / _check_site_id(site_id)
+
+
+def has_preview(site_id: str) -> bool:
+    """True when an unpacked artifact is on disk for this site."""
+    try:
+        return preview_root(site_id).is_dir()
+    except BadSiteId:
+        return False
+
+
+def discard_preview(site_id: str) -> bool:
+    """Remove a site's preview tree. True when something was removed."""
+    root = preview_root(site_id)
+    if not root.is_dir():
+        return False
+    shutil.rmtree(root, ignore_errors=True)
+    return not root.exists()
+
+
+# ---------------------------------------------------------------------------
+# Unpacking
+# ---------------------------------------------------------------------------
+
+
+def _normalized_member_path(name: str) -> tuple[str, ...] | None:
+    """Split a tar member name into safe segments, or ``None`` when it is not safe.
+
+    ``tar -C <dir> .`` names every member ``./x/y``, so the leading ``.`` is normal and
+    stripped. Everything else here is a refusal: an absolute path, a ``..`` segment, a
+    backslash (a path separator on Windows and a legal filename character on POSIX —
+    treating it as either is a way to be surprised), or a NUL.
+    """
+    if not name or name.startswith("/") or name.startswith("\\"):
+        return None
+    if "\x00" in name or "\\" in name:
+        return None
+    if len(name) > 1 and name[1] == ":":  # a Windows drive-qualified path
+        return None
+    segments: list[str] = []
+    for raw in name.split("/"):
+        if raw in ("", "."):
+            continue
+        if raw == "..":
+            return None
+        segments.append(raw)
+    return tuple(segments)
+
+
+def unpack_artifact(artifact: bytes, dest: Path) -> UnpackedArtifact:
+    """Extract a build artifact into ``dest``, dropping what must not be served.
+
+    Members are written ONE AT A TIME from ``extractfile`` rather than through
+    ``extractall``: this path has to distinguish three outcomes per member (write,
+    security-skip, policy-skip) and report all three, which a bulk extract cannot.
+    Permissions from the archive are never applied, so no member can arrive
+    executable or setuid.
+
+    Skips, all recorded on the result:
+      * ``_worker.js`` (and its whole subtree) — see the module header. Not written at
+        all, so the server bundle never sits inside a served tree.
+      * deploy configuration (``_routes.json``, ``.assetsignore``, ...) — not content.
+      * anything unsafe: absolute paths, ``..``, symlinks, hardlinks, devices, fifos.
+        Links are refused rather than followed because a link is how a tarball reaches
+        outside the directory it is extracted into.
+
+    Raises :class:`ArtifactUnreadable` when the bytes are not a gzipped tar, and
+    :class:`ArtifactTooLarge` past either ceiling — a bomb stops extraction rather
+    than being skipped, because the harm is the writing itself.
+    """
+    dest.mkdir(parents=True, exist_ok=True)
+    entries = 0
+    written = 0
+    server: list[str] = []
+    metadata: list[str] = []
+    rejected: list[str] = []
+
+    try:
+        tar = tarfile.open(fileobj=io.BytesIO(artifact), mode="r:gz")
+    except (tarfile.TarError, OSError, EOFError) as exc:
+        raise ArtifactUnreadable(f"artifact is not a readable gzipped tar: {exc}") from exc
+
+    with tar:
+        for member in tar:
+            segments = _normalized_member_path(member.name)
+            if segments is None:
+                rejected.append(member.name)
+                continue
+            if not segments:  # the archive's own "." root entry
+                continue
+            if not (member.isfile() or member.isdir()):
+                # symlink / hardlink / device / fifo — the escape hatches.
+                rejected.append(member.name)
+                continue
+            if any(seg in _SERVER_ENTRY_NAMES for seg in segments):
+                server.append("/".join(segments))
+                continue
+            if any(seg in _DEPLOY_METADATA_NAMES for seg in segments):
+                metadata.append("/".join(segments))
+                continue
+
+            target = dest.joinpath(*segments)
+            if member.isdir():
+                target.mkdir(parents=True, exist_ok=True)
+                continue
+
+            entries += 1
+            if entries > MAX_ENTRIES:
+                raise ArtifactTooLarge(f"artifact has more than {MAX_ENTRIES} entries")
+            written += max(0, member.size)
+            if written > MAX_TOTAL_BYTES:
+                raise ArtifactTooLarge(f"artifact unpacks to more than {MAX_TOTAL_BYTES} bytes")
+            source = tar.extractfile(member)
+            if source is None:  # pragma: no cover - isfile() implies a payload
+                rejected.append(member.name)
+                entries -= 1
+                continue
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with target.open("wb") as fh:
+                shutil.copyfileobj(source, fh)
+
+    return UnpackedArtifact(
+        entries=entries,
+        bytes_written=written,
+        server_entries=tuple(server),
+        metadata_entries=tuple(metadata),
+        rejected=tuple(rejected),
+    )
+
+
+def store_artifact(site_id: str, artifact: bytes, *, engine: str) -> PreviewSnapshot:
+    """Unpack ``artifact`` as this site's preview, replacing any previous one.
+
+    Refuses an engine whose static output is the project ROOT (``html``, whose
+    ``static_output_rel`` is ``"."``), mirroring the guard in
+    ``daytona_build.artifact_tar_command``: such an engine runs no build, so it never
+    produces an artifact, and one arriving here means a routing bug that should be
+    loud rather than previewed.
+
+    Cross-checks the artifact against ``emits_server_worker(engine)`` and WARNS on a
+    mismatch — a react artifact carrying a server entry, or a svelte one missing it,
+    means the build lane changed shape underneath us. It is a warning and not a
+    refusal because either way the static tree is still previewable, and a preview
+    that refused to open would hide the discrepancy instead of surfacing it.
+
+    Unpacks into a temporary sibling and swaps it in, so a failure part-way through
+    leaves the PREVIOUS preview intact rather than a half-written tree serving a
+    mixture of two builds.
+    """
+    site_id = _check_site_id(site_id)
+    engine = normalize_engine(engine)
+    if static_output_rel(engine) == ".":
+        raise ArtifactRejected(
+            f"engine {engine!r} emits its static output at the project root and runs no "
+            "build, so it produces no artifact to preview"
+        )
+
+    root = previews_home() / site_id
+    incoming = root.parent / f".{site_id}.incoming-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+    try:
+        unpacked = unpack_artifact(artifact, incoming)
+        # rmtree-then-rename: os.replace cannot clobber an existing directory on
+        # Windows. The gap where neither exists is bounded by a local rename and the
+        # publish path holds a per-site single-flight, so two stores cannot race here.
+        if root.exists():
+            shutil.rmtree(root)
+        incoming.replace(root)
+    except BaseException:
+        shutil.rmtree(incoming, ignore_errors=True)
+        raise
+
+    if unpacked.server_entries and not emits_server_worker(engine):
+        logger.warning(
+            "sites.artifact_preview: %s artifact for site %s carried a server entry (%s) "
+            "even though this engine emits none — the build lane may have changed shape",
+            engine,
+            site_id,
+            ", ".join(unpacked.server_entries),
+        )
+    elif emits_server_worker(engine) and not unpacked.server_entries:
+        logger.warning(
+            "sites.artifact_preview: %s artifact for site %s carried NO server entry, "
+            "though this engine always emits one — the artifact may be incomplete",
+            engine,
+            site_id,
+        )
+    if unpacked.rejected:
+        logger.warning(
+            "sites.artifact_preview: refused %d unsafe member(s) from site %s's artifact: %s",
+            len(unpacked.rejected),
+            site_id,
+            ", ".join(unpacked.rejected[:5]),
+        )
+
+    return PreviewSnapshot(
+        site_id=site_id,
+        engine=engine,
+        root=root,
+        url_path=f"/{PREVIEW_URL_PREFIX}/{site_id}/",
+        unpacked=unpacked,
+    )
+
+
+def safe_store_artifact(
+    site_id: str, artifact: bytes | None, *, engine: str
+) -> PreviewSnapshot | None:
+    """:func:`store_artifact` that never raises — returns ``None`` on any failure.
+
+    The form a PUBLISH path may call. A publish that succeeded must not be reported as
+    failed because a preview could not be unpacked, so this swallows everything the
+    way ``screenshot.safe_take_*`` does for card images. The strict form stays
+    available for a caller that is asking for a preview and is entitled to the error.
+    """
+    if not artifact:
+        return None
+    try:
+        return store_artifact(site_id, artifact, engine=engine)
+    except Exception:  # noqa: BLE001 — a preview must never cost anybody a publish
+        logger.warning(
+            "sites.artifact_preview: could not store a preview for site %s", site_id, exc_info=True
+        )
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Resolving requests
+# ---------------------------------------------------------------------------
+
+_STANDARD_HEADERS: tuple[tuple[str, str], ...] = (
+    # A preview is re-stored on every rebuild, so a cached copy is a preview of the
+    # PREVIOUS build — the exact confusion the feature exists to remove.
+    ("Cache-Control", "no-store"),
+    ("X-Content-Type-Options", "nosniff"),
+)
+
+
+def _page(title: str, detail: str) -> bytes:
+    """A minimal explanatory page. Plain and self-contained: a refusal has to be
+    readable inside an iframe with no styling of ours available."""
+    return (
+        '<!doctype html><html lang="en"><meta charset="utf-8">'
+        f"<title>{title}</title>"
+        '<body style="font:14px/1.6 system-ui,sans-serif;padding:2rem;max-width:34rem">'
+        f'<h1 style="font-size:1.1rem;margin:0 0 .5rem">{title}</h1>'
+        f'<p style="margin:0;color:#444">{detail}</p>'
+        "</body></html>"
+    ).encode()
+
+
+def _refusal(status: int, reason: str, title: str, detail: str) -> PreviewResponse:
+    return PreviewResponse(
+        status=status,
+        reason=reason,
+        content_type="text/html; charset=utf-8",
+        body=_page(title, detail),
+        headers=_STANDARD_HEADERS + (("X-Paw-Preview", reason),),
+    )
+
+
+def content_type_for(name: str) -> str:
+    """Content type for a filename, explicit table first.
+
+    ``mimetypes`` is consulted only for extensions the table does not name. It is not
+    consulted FIRST because on Windows it reads the registry, where ``.js`` has been
+    observed mapping to ``text/plain`` — served that way the browser refuses to
+    execute the bundle and the previewed page never hydrates.
+    """
+    suffix = Path(name).suffix.lower()
+    explicit = _CONTENT_TYPES.get(suffix)
+    if explicit:
+        return explicit
+    guessed, _ = mimetypes.guess_type(name)
+    return guessed or _OCTET_STREAM
+
+
+def _request_segments(subpath: str) -> tuple[str, ...] | None:
+    """Segments of a request subpath, or ``None`` when it is not safe.
+
+    Percent-decodes FIRST: ``..%2f..%2fsecret`` is a traversal attempt that only looks
+    safe before decoding, and this is the layer that has to see through it.
+
+    A DRIVE-QUALIFIED segment is refused, which is not a theoretical case: pathlib
+    treats ``C:`` as an anchor, so ``root.joinpath("C:", "Windows")`` returns
+    ``C:/Windows`` and the join silently leaves the preview root. On POSIX the same
+    segment is an ordinary filename, so the check costs nothing and closes a hole that
+    exists on the platform this is developed on.
+    """
+    decoded = unquote(subpath or "")
+    if "\x00" in decoded or "\\" in decoded:
+        return None
+    segments: list[str] = []
+    for raw in decoded.split("/"):
+        if raw in ("", "."):
+            continue
+        if raw == ".." or (len(raw) > 1 and raw[1] == ":"):
+            return None
+        segments.append(raw)
+    return tuple(segments)
+
+
+def resolve(site_id: str, subpath: str, *, method: str = "GET") -> PreviewResponse:
+    """Answer one preview request. Pure enough to test: reads disk, writes nothing.
+
+    ``subpath`` is the URL path AFTER the site's mount point — ``""``, ``"/"``,
+    ``"/assets/app.js"``. The distinction between ``""`` and ``"/"`` is load-bearing:
+    a page served without a trailing slash resolves its own ``./assets/...`` links one
+    level too high and loads with no CSS or JS, so ``""`` is a 301 rather than the
+    index.
+
+    The order of the checks is deliberate. Policy (no backend, no writes) is answered
+    before existence, so a form POST gets the same honest refusal whether or not an
+    artifact happens to be stored; and the refusals are answered before any disk read,
+    so a refused path never touches the filesystem.
+    """
+    try:
+        site_id = _check_site_id(site_id)
+    except BadSiteId:
+        return _refusal(404, "bad_site_id", "No preview here", "That preview address isn't valid.")
+
+    segments = _request_segments(subpath)
+    if segments is None:
+        return _refusal(404, "unsafe_path", "No preview here", "That path isn't valid.")
+
+    if segments and segments[0] == "api":
+        # Lead capture is deferred, so there is no backend behind a preview. Saying so
+        # is the point: a POST that returned somebody's own page with a 200 would read
+        # as a successful submission and lose the message.
+        return _refusal(
+            501,
+            "backend_not_served",
+            "Not available in preview",
+            "This preview serves the built pages only — form submissions and other "
+            "API calls aren't handled here. Publish the site to enable them.",
+        )
+
+    if method.upper() not in ("GET", "HEAD"):
+        return _refusal(
+            405,
+            "method_not_allowed",
+            "Not available in preview",
+            "A preview serves pages; it can't accept submissions. Publish the site to enable them.",
+        )
+
+    root = preview_root(site_id)
+    if not root.is_dir():
+        return _refusal(
+            404,
+            "no_preview",
+            "Nothing built yet",
+            "No build has been previewed for this site yet.",
+        )
+
+    if any(seg in _SERVER_ENTRY_NAMES for seg in segments):
+        # 404, not 403: a static preview HAS no server entry to serve, and this
+        # bundle has carried a per-site signed key in the past — its source must
+        # never come back over the wire, and a 403 would confirm it is there.
+        return _refusal(
+            404, "server_entry_refused", "Not found", "There's no such page in this preview."
+        )
+    if any(seg in _DEPLOY_METADATA_NAMES or seg.startswith(".") for seg in segments):
+        return _refusal(
+            404, "metadata_refused", "Not found", "There's no such page in this preview."
+        )
+
+    target = root.joinpath(*segments) if segments else root
+    try:
+        resolved = target.resolve()
+        inside = resolved == root.resolve() or resolved.is_relative_to(root.resolve())
+    except OSError:  # pragma: no cover - unresolvable path
+        inside = False
+    if not inside:
+        # DEFENCE IN DEPTH, and deliberately unreachable while ``_request_segments`` is
+        # correct — every way a joined path can leave the root (``..``, an anchor, a
+        # separator) is refused up there. It stays because "the parser is correct" is an
+        # assumption, and a containment check after the join costs one stat.
+        return _refusal(404, "unsafe_path", "No preview here", "That path isn't valid.")
+
+    if resolved.is_dir():
+        if not subpath.endswith("/"):
+            return PreviewResponse(
+                status=301,
+                reason="redirect_slash",
+                location=(subpath or "") + "/",
+                headers=_STANDARD_HEADERS + (("X-Paw-Preview", "redirect_slash"),),
+            )
+        index = resolved / "index.html"
+        if not index.is_file():
+            # Never a directory listing. A preview that enumerated the build tree
+            # would hand out the artifact's shape to anyone holding the URL.
+            return _refusal(
+                404, "not_found", "Not found", "There's no page at this address in this preview."
+            )
+        resolved = index
+
+    if not resolved.is_file():
+        # Deliberately NOT rewritten to index.html. An SPA fallback would report a
+        # missing asset as a working page, which is the one thing a verification
+        # preview must not do.
+        return _refusal(
+            404, "not_found", "Not found", "There's no page at this address in this preview."
+        )
+
+    try:
+        body = resolved.read_bytes()
+    except OSError as exc:
+        logger.warning("sites.artifact_preview: could not read %s (%s)", resolved, exc)
+        return _refusal(
+            404, "not_found", "Not found", "There's no page at this address in this preview."
+        )
+
+    return PreviewResponse(
+        status=200,
+        reason="ok",
+        content_type=content_type_for(resolved.name),
+        body=body,
+        headers=_STANDARD_HEADERS + (("X-Paw-Preview", "ok"),),
+    )
+
+
+__all__ = [
+    "MAX_ENTRIES",
+    "MAX_TOTAL_BYTES",
+    "PREVIEW_URL_PREFIX",
+    "ArtifactRejected",
+    "ArtifactTooLarge",
+    "ArtifactUnreadable",
+    "BadSiteId",
+    "PreviewResponse",
+    "PreviewSnapshot",
+    "UnpackedArtifact",
+    "content_type_for",
+    "discard_preview",
+    "has_preview",
+    "preview_root",
+    "previews_home",
+    "resolve",
+    "safe_store_artifact",
+    "store_artifact",
+    "unpack_artifact",
+]

--- a/ee/pocketpaw_ee/sites/local_server.py
+++ b/ee/pocketpaw_ee/sites/local_server.py
@@ -5,6 +5,29 @@
 # that tree over HTTP so the published site has a real openable localhost URL
 # (what the cmux smoke + Phase 5 open).
 #
+# Updated 2026-08-10 (SG-10 — serve the built ARTIFACT as a preview): the one
+# handler now has a second branch. `/<site_id>/...` is unchanged — plain static
+# serving of a local DEPLOY. `/_preview/<site_id>/...` routes through
+# `artifact_preview.resolve`, which answers from a tree unpacked out of the
+# ephemeral build lane's artifact tarball.
+#
+# ONE SERVER, TWO BRANCHES, on purpose. The established in-app preview pattern in
+# this codebase is already "a localhost HTTP server, iframed by the builder"
+# (`dev_server.py` does exactly that with Vite), so the artifact preview rides the
+# server that exists rather than standing up a second one. It needs no Node, no dev
+# server and no COOP/COEP: the artifact is already built.
+#
+# THE TWO ROOTS ARE DISJOINT, and that is load-bearing. Deploys live under
+# `sites_home()`, which this server hands out as plain static files; previews live
+# under `artifact_preview.previews_home()`, which it never serves directly. If a
+# preview tree sat inside `sites_home()`, the static branch would serve it without
+# passing `resolve`'s guards and the `_worker.js` refusal would have a bypass.
+#
+# A FAILING PREVIEW CANNOT TAKE A DEPLOY WITH IT. The preview branch catches
+# everything and answers 500 for that ONE request; the static branch and the server
+# thread are untouched, and `serve_artifact_preview` swallows a store failure and
+# returns None so a publish tail can call it safely.
+#
 # Updated 2026-06-19 (fix/sites-preview-fresh-build, P1a — fail soft on a missing
 # build dir): ``deploy_local`` no longer lets a missing ``.svelte-kit/cloudflare/``
 # escape as a bare FileNotFoundError → 500. If the build dir is absent but a PRIOR
@@ -41,7 +64,9 @@ import threading
 from functools import partial
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+from urllib.parse import urlsplit
 
+from pocketpaw_ee.sites import artifact_preview
 from pocketpaw_ee.sites.engines import static_output_rel
 
 logger = logging.getLogger(__name__)
@@ -93,10 +118,111 @@ _lock = threading.Lock()
 
 
 class _QuietHandler(SimpleHTTPRequestHandler):
-    """SimpleHTTPRequestHandler that doesn't spam stderr with a line per GET."""
+    """SimpleHTTPRequestHandler that doesn't spam stderr with a line per GET, plus the
+    `/_preview/<site_id>/...` branch that serves an unpacked build artifact.
+
+    The preview branch answers the request itself rather than going through
+    ``translate_path``, so it never resolves inside ``sites_home()`` — the preview
+    tree lives outside the served root by design (see the module header)."""
 
     def log_message(self, *args: object) -> None:  # noqa: D401 - silence access log
         pass
+
+    # --- the preview branch ------------------------------------------------
+
+    def _preview_target(self) -> tuple[str, str] | None:
+        """``(site_id, subpath)`` when this request is for a preview, else ``None``.
+
+        ``subpath`` keeps its leading slash — and keeps the difference between ``""``
+        (``/_preview/<id>``) and ``"/"`` (``/_preview/<id>/``), which is what lets
+        ``resolve`` redirect the first to the second. Without that redirect the page
+        loads and its relative asset URLs resolve one level too high, so it renders
+        with no CSS and no JS.
+        """
+        raw = urlsplit(self.path).path
+        prefix = f"/{artifact_preview.PREVIEW_URL_PREFIX}"
+        if raw != prefix and not raw.startswith(prefix + "/"):
+            return None
+        rest = raw[len(prefix) :].lstrip("/")
+        site_id, separator, tail = rest.partition("/")
+        # The separator, not the tail, is what distinguishes `/_preview/<id>` from
+        # `/_preview/<id>/` — both leave `tail` empty.
+        return site_id, (f"/{tail}" if separator else "")
+
+    def _serve_preview(self, site_id: str, subpath: str) -> None:
+        """Write one resolved preview response.
+
+        Catches EVERYTHING. A preview is a best-effort read of a tree built from
+        customer content; an exception escaping here would surface as a broken
+        connection on this request and, worse, put a traceback between the server
+        thread and every OTHER site it is serving — including live local deploys.
+        """
+        try:
+            result = artifact_preview.resolve(site_id, subpath, method=self.command)
+        except Exception:  # noqa: BLE001 — contain it to this one request
+            logger.warning(
+                "sites.artifact_preview: resolve failed for site %s (%s)",
+                site_id,
+                subpath,
+                exc_info=True,
+            )
+            self.send_error(500, "preview could not be served")
+            return
+
+        self.send_response(result.status)
+        if result.location is not None:
+            mount = f"/{artifact_preview.PREVIEW_URL_PREFIX}/{site_id}"
+            self.send_header("Location", f"{mount}{result.location}")
+        for name, value in result.headers:
+            self.send_header(name, value)
+        if result.body:
+            self.send_header("Content-Type", result.content_type)
+            self.send_header("Content-Length", str(len(result.body)))
+        else:
+            self.send_header("Content-Length", "0")
+        self.end_headers()
+        if result.body and self.command != "HEAD":
+            self.wfile.write(result.body)
+
+    def do_GET(self) -> None:
+        target = self._preview_target()
+        if target is None:
+            super().do_GET()
+            return
+        self._serve_preview(*target)
+
+    def do_HEAD(self) -> None:
+        target = self._preview_target()
+        if target is None:
+            super().do_HEAD()
+            return
+        self._serve_preview(*target)
+
+    def do_POST(self) -> None:
+        """A POST is only ever answered for a preview path, and only ever refused.
+
+        A site's form posts to ``/api/submit``, which this deployment does not serve
+        (lead capture is deferred). Letting the request fall through to static serving
+        would return the page itself with a 200 — indistinguishable from a successful
+        submission, and the message would be silently lost. ``resolve`` answers 501
+        with a page that says so. Any other path keeps the stock 501, which is what
+        this server already did for every POST."""
+        # Drain the body before answering. The server speaks HTTP/1.0 and closes after
+        # each response, so an unread body would be discarded anyway — but on Windows
+        # closing a socket with unread data can reach the client as a reset instead of
+        # the 501 page it needs to see.
+        try:
+            length = int(self.headers.get("Content-Length") or 0)
+        except ValueError:
+            length = 0
+        if length > 0:
+            self.rfile.read(min(length, 1024 * 1024))
+
+        target = self._preview_target()
+        if target is None:
+            self.send_error(501, f"Unsupported method ({self.command})")
+            return
+        self._serve_preview(*target)
 
 
 def ensure_server() -> str:
@@ -157,11 +283,52 @@ def deploy_local(site_id: str, project_dir: str, *, engine: str = "ripple") -> s
     return local_url_for(site_id)
 
 
+# --- the artifact preview -------------------------------------------------
+
+
+def preview_url_for(site_id: str) -> str:
+    """The localhost URL a site's unpacked build artifact is previewed at.
+
+    Trailing slash on purpose: the page's own asset links are relative (``./_app/...``,
+    ``./assets/...``) and resolve one level too high without it, so the preview would
+    open with no CSS and no JS. ``resolve`` also redirects the slashless form, but the
+    URL we hand out should not need the redirect."""
+    return f"{ensure_server()}/{artifact_preview.PREVIEW_URL_PREFIX}/{site_id}/"
+
+
+def serve_artifact_preview(site_id: str, artifact: bytes | None, *, engine: str) -> str | None:
+    """Store a build artifact as this site's preview and return its URL, or ``None``.
+
+    The artifact-lane peer of :func:`deploy_local`, and the one call a publish tail
+    would make. NEVER RAISES — a preview that could not be unpacked, or a server that
+    could not start, returns ``None`` and is logged. That is the whole difference
+    between the two functions: ``deploy_local`` is the publish itself and must report
+    its failures, while a preview is a convenience and must not be able to fail a
+    publish that already succeeded.
+
+    ``engine`` selects nothing about the LAYOUT — the lane tars from
+    ``static_output_rel(engine)``, so every artifact already arrives rooted at its
+    deployable root. It is passed through for the ``emits_server_worker`` cross-check
+    in ``store_artifact``."""
+    try:
+        snapshot = artifact_preview.safe_store_artifact(site_id, artifact, engine=engine)
+        if snapshot is None:
+            return None
+        return preview_url_for(site_id)
+    except Exception:  # noqa: BLE001 — ensure_server() is the remaining raiser
+        logger.warning(
+            "sites: could not serve an artifact preview for site %s", site_id, exc_info=True
+        )
+        return None
+
+
 __all__ = [
     "sites_home",
     "persist_site",
     "ensure_server",
     "local_url_for",
     "deploy_local",
+    "preview_url_for",
+    "serve_artifact_preview",
     "MissingBuildOutput",
 ]

--- a/tests/ee/sites/test_artifact_preview.py
+++ b/tests/ee/sites/test_artifact_preview.py
@@ -453,24 +453,52 @@ def test_containment_resolves_both_sides(tmp_path):
     assert ap._contained(linked_root, tmp_path / "elsewhere.txt") is None
 
 
-def test_a_drive_qualified_request_path_cannot_read_outside_the_root(_preview_home):
+def test_a_drive_qualified_request_path_is_refused_at_the_parser():
     """pathlib treats ``C:`` as an anchor, so joining it onto the root RESETS the path
-    and the read lands wherever the segment points. Refused at the parser."""
+    and the read lands wherever the segment points. Refused at the parser.
+
+    LITERALS ONLY, and that is the fix for a portability bug rather than a style choice.
+    This case used to be checked with ``"/" + secret.as_posix()`` for a real file in a
+    tmp dir, which is drive-qualified on Windows and NOT on POSIX — there it becomes
+    ``//tmp/...``, whose segments are all benign names, so the parser correctly declines
+    to flag it and a later layer refuses it instead. The assertion then failed on Linux
+    reading ``not_found`` where it wanted ``unsafe_path``. A drive anchor is a
+    platform-independent property of the STRING, so it is tested with strings.
+    """
     ap.store_artifact("eve5", _tar(_REACT_ARTIFACT), engine="react")
+
+    for path in ("/C:/Windows/win.ini", "/c:", "/D:/x", "/c:/"):
+        got = ap.resolve("eve5", path)
+        assert got.status == 404, path
+        # Refused by the parser, not merely contained after the join — same reason as
+        # in the `..` case above. Asserting the specific reason is what makes each
+        # layer independently provable (see the module header).
+        assert got.reason == "unsafe_path", path
+
+
+def test_an_absolute_path_to_a_real_file_outside_the_root_cannot_read_it(_preview_home):
+    """The security property, checked against a file that genuinely exists outside.
+
+    Kept SEPARATE from the drive-anchor case above because WHICH layer refuses this is
+    legitimately platform-dependent: on Windows the string is drive-qualified and the
+    parser rejects it; on POSIX every segment is a benign name, the join lands inside
+    the root, and it is refused as missing. Both are correct refusals, so this asserts
+    the property that must hold on every platform — status 404 and NOT ONE BYTE of the
+    outside file — and deliberately does not pin the reason.
+
+    Pinning it here is what broke on Linux, and loosening it in the shared loop would
+    have weakened the drive-anchor assertion too. Splitting keeps both strict about the
+    thing each can actually promise.
+    """
+    ap.store_artifact("eve6", _tar(_REACT_ARTIFACT), engine="react")
     secret = _preview_home.parent / "outside.txt"
     secret.write_bytes(b"tenant secret")
 
-    for path in (
-        "/" + secret.as_posix(),
-        "/C:/Windows/win.ini",
-        "/c:",
-    ):
-        got = ap.resolve("eve5", path)
-        assert got.status == 404, path
-        assert b"tenant secret" not in got.body, path
-        # Refused by the parser, not merely contained after the join — same reason as
-        # in the `..` case above.
-        assert got.reason == "unsafe_path", path
+    got = ap.resolve("eve6", "/" + secret.as_posix())
+    assert got.status == 404
+    assert b"tenant secret" not in got.body
+    # Refused, by whichever guard owns it on this platform — never served.
+    assert got.reason in {"unsafe_path", "escaped_root", "not_found"}
 
 
 def test_an_unsafe_site_id_cannot_climb_out_of_the_preview_root():

--- a/tests/ee/sites/test_artifact_preview.py
+++ b/tests/ee/sites/test_artifact_preview.py
@@ -175,10 +175,15 @@ def test_worker_source_is_refused_even_when_it_is_on_disk():
     other way must still not hand back the server bundle's source."""
     snap = ap.store_artifact("svelte5", _tar(_REACT_ARTIFACT), engine="svelte")
     # The canary must be SECRET-SHAPED (so the assertion means something) without
-    # matching a real credential pattern. It used to read `paw_sk_live_deadbeef`, which
-    # tripped the pr-quality-gate secret scan on `sk_live_[a-zA-Z0-9]+` and failed CI on
-    # a test whose entire point is that the string is NOT served. Renamed rather than
+    # matching a real credential pattern. It previously embedded a Stripe-secret-shaped
+    # literal, which tripped the pr-quality-gate secret scan and failed CI on a test
+    # whose entire point is that the string is NOT served. Renamed rather than
     # allow-listed: a scanner exemption on a sites test would outlive the reason for it.
+    #
+    # AND DO NOT QUOTE THE OLD VALUE HERE. The first attempt at this comment spelled it
+    # out to explain the fix, which re-introduced the very literal the rename removed and
+    # failed the scan again — the scanner reads the diff, and a comment is diff too.
+    # Describe the shape, never reproduce it.
     (snap.root / "_worker.js").write_bytes(b"const KEY='paw_canary_notacredential_deadbeef'")
 
     got = ap.resolve("svelte5", "/_worker.js")

--- a/tests/ee/sites/test_artifact_preview.py
+++ b/tests/ee/sites/test_artifact_preview.py
@@ -13,11 +13,19 @@
 # Three things here are security assertions rather than behaviour checks, and should be
 # read as such: `_worker.js` never lands on disk and never comes back over the wire (it
 # has carried a per-site signed key), a tarball member cannot write outside the preview
-# root, and a request path cannot read outside it — including percent-encoded.
+# root, and a request path cannot read outside it.
+#
+# Updated 2026-08-10: path traversal covered end to end after the lead flagged it as
+# missing from the brief. Both surfaces, since a static server over an extracted archive
+# has two: MEMBER names at extract time (`..`, absolute, drive letter, backslash, NUL,
+# symlink, hardlink) and REQUEST paths at read time (the same, plus percent-encoded
+# forms, plus a symlink planted inside the tree — the case no string check can see, and
+# the reason containment runs on the RESOLVED path).
 
 from __future__ import annotations
 
 import io
+import os
 import tarfile
 
 import pytest
@@ -277,6 +285,53 @@ def test_a_backslash_member_is_refused():
     assert snap.unpacked.rejected == ("..\\..\\escaped.txt",)
 
 
+def test_a_nul_byte_member_name_is_refused():
+    """Asserted against the name parser directly, and here is why that is the honest
+    place for it: the tar format's name field is NUL-TERMINATED, so an embedded NUL
+    cannot ride an archive at all. Verified — writing a member called
+    ``./safe.html\\x00/../../escaped.txt`` and reading the archive back yields
+    ``./safe.html``; the tail is gone before any of our code sees it.
+
+    So this guard is unreachable through a tarball, and a test that packed one would
+    prove nothing while looking like it proved something. It is kept because
+    ``_normalized_member_path`` is a name parser and refusing a NUL is a property of the
+    parser, not of tar — a NUL truncates the name for any C-level consumer, which is how
+    a name passes a suffix check and opens a different file."""
+    assert ap._normalized_member_path("./safe.html\x00/../../escaped.txt") is None
+    assert ap._normalized_member_path("./a\x00b") is None
+    assert ap._normalized_member_path("./safe.html") == ("safe.html",)
+
+
+def test_a_drive_qualified_member_name_is_refused():
+    """Asserted at the parser rather than by packing one, deliberately: with the guard
+    removed, ``C:/evil.txt`` joins to an ANCHORED path and the unpacker would attempt a
+    real write to the drive root. A test that has to succeed at writing outside the
+    sandbox to prove a guard works is a test that damages the machine when the guard
+    breaks."""
+    assert ap._normalized_member_path("C:/evil.txt") is None
+    assert ap._normalized_member_path("d:/evil.txt") is None
+    assert ap._normalized_member_path("./assets/app.js") == ("assets", "app.js")
+
+
+def test_a_nul_truncated_member_still_cannot_escape(_preview_home):
+    """The consequence of the truncation above: what actually lands is the truncated
+    name, which must still be a safe single segment inside the root."""
+    snap = ap.store_artifact(
+        "eve6",
+        _tar(
+            {
+                "./index.html": b"<title>x</title>ok",
+                "./safe.html\x00/../../escaped.txt": b"pwned",
+            }
+        ),
+        engine="react",
+    )
+
+    assert (snap.root / "safe.html").read_bytes() == b"pwned"
+    assert not (_preview_home.parent / "escaped.txt").exists()
+    assert not (_preview_home / "escaped.txt").exists()
+
+
 def test_too_many_entries_is_refused_and_leaves_no_partial_tree(monkeypatch, _preview_home):
     monkeypatch.setattr(ap, "MAX_ENTRIES", 2)
 
@@ -313,6 +368,79 @@ def test_percent_encoded_traversal_cannot_read_outside_the_root(_preview_home):
         got = ap.resolve("eve4", path)
         assert got.status == 404, path
         assert b"tenant secret" not in got.body, path
+        # `unsafe_path`, so the PARSER refused it. Asserting only the 404 was not
+        # enough: with the parser's `..` check disabled, the post-join containment
+        # check refuses the same request with `escaped_root` and a status-only
+        # assertion still passes. That is a mutation this suite would have shipped.
+        assert got.reason == "unsafe_path", path
+
+
+def test_a_nul_byte_in_a_request_path_is_refused(_preview_home):
+    """A NUL can make an extension or suffix check agree with a different file than the
+    one that ends up opened."""
+    ap.store_artifact("eve7", _tar(_REACT_ARTIFACT), engine="react")
+    (_preview_home / "secret.txt").write_bytes(b"tenant secret")
+
+    for path in ("/index.html\x00.png", "/\x00../secret.txt", "/index.html%00.png"):
+        got = ap.resolve("eve7", path)
+        assert got.status == 404, path
+        assert got.reason == "unsafe_path", path
+        assert b"tenant secret" not in got.body, path
+
+
+def test_a_backslash_in_a_request_path_is_refused():
+    ap.store_artifact("eve8", _tar(_REACT_ARTIFACT), engine="react")
+
+    for path in ("\\index.html", "/..\\..\\secret.txt", "/%5c..%5csecret.txt"):
+        got = ap.resolve("eve8", path)
+        assert got.status == 404, path
+        assert got.reason == "unsafe_path", path
+
+
+def test_a_symlink_inside_the_tree_cannot_read_outside_it(tmp_path, _preview_home):
+    """The case a string check cannot see. Every segment here is innocent — no ``..``,
+    no encoding, no separator — and the path still leaves the root, because one segment
+    on disk is a link. Only comparing the RESOLVED path against the resolved root
+    refuses it.
+
+    A link cannot arrive via an artifact (link members are refused at unpack), so this
+    plants one directly. That is the point: the containment check is what holds when the
+    tree contains something the unpacker did not put there.
+    """
+    snap = ap.store_artifact("eve9", _tar(_REACT_ARTIFACT), engine="react")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.txt").write_bytes(b"tenant secret")
+    try:
+        os.symlink(outside, snap.root / "shared", target_is_directory=True)
+    except (OSError, NotImplementedError) as exc:  # pragma: no cover - platform-gated
+        pytest.skip(f"cannot create a symlink on this platform: {exc}")
+
+    got = ap.resolve("eve9", "/shared/secret.txt")
+    assert got.status == 404
+    # `escaped_root`, not `unsafe_path` — this refusal came from containment after the
+    # join, which is the only layer that can see a link. Asserting the specific reason is
+    # what stops a broken parser guard from looking verified because this check caught it.
+    assert got.reason == "escaped_root"
+    assert b"tenant secret" not in got.body
+
+
+def test_containment_resolves_both_sides(tmp_path):
+    """A root that itself sits under a link must still contain its own children —
+    otherwise the guard refuses every legitimate request on a platform whose temp dir
+    is a link (macOS: /tmp -> /private/tmp)."""
+    real_root = tmp_path / "real"
+    (real_root / "assets").mkdir(parents=True)
+    (real_root / "assets" / "app.js").write_bytes(b"x")
+    try:
+        os.symlink(real_root, tmp_path / "via-link", target_is_directory=True)
+    except (OSError, NotImplementedError) as exc:  # pragma: no cover - platform-gated
+        pytest.skip(f"cannot create a symlink on this platform: {exc}")
+
+    linked_root = tmp_path / "via-link"
+    assert ap._contained(linked_root, linked_root / "assets" / "app.js") is not None
+    assert ap._contained(linked_root, linked_root) is not None
+    assert ap._contained(linked_root, tmp_path / "elsewhere.txt") is None
 
 
 def test_a_drive_qualified_request_path_cannot_read_outside_the_root(_preview_home):
@@ -330,6 +458,9 @@ def test_a_drive_qualified_request_path_cannot_read_outside_the_root(_preview_ho
         got = ap.resolve("eve5", path)
         assert got.status == 404, path
         assert b"tenant secret" not in got.body, path
+        # Refused by the parser, not merely contained after the join — same reason as
+        # in the `..` case above.
+        assert got.reason == "unsafe_path", path
 
 
 def test_an_unsafe_site_id_cannot_climb_out_of_the_preview_root():

--- a/tests/ee/sites/test_artifact_preview.py
+++ b/tests/ee/sites/test_artifact_preview.py
@@ -1,0 +1,471 @@
+# tests/ee/sites/test_artifact_preview.py — the rules of the static artifact preview:
+# what gets unpacked, what is refused, and what a request resolves to.
+#
+# Created 2026-08-10 (SG-10, re-aimed). These are the unit half; the HTTP half and the
+# publish-isolation proof live in test_artifact_preview_server.py.
+#
+# The tarballs here are shaped like the ones MEASURED off the live Daytona lane on
+# 2026-08-09 — react's 4-entry `dist` and svelte's 24-entry `.svelte-kit/cloudflare`
+# WITH a `_worker.js` — because the two engines produce genuinely different trees and a
+# preview that only ever saw one of them would pass while being wrong about the other.
+# Member names carry the `./` prefix real `tar -C <dir> .` emits.
+#
+# Three things here are security assertions rather than behaviour checks, and should be
+# read as such: `_worker.js` never lands on disk and never comes back over the wire (it
+# has carried a per-site signed key), a tarball member cannot write outside the preview
+# root, and a request path cannot read outside it — including percent-encoded.
+
+from __future__ import annotations
+
+import io
+import tarfile
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.sites import artifact_preview as ap  # noqa: E402
+
+# The 4-entry react `dist` shape (measured: 61,487 bytes, no node_modules, no worker).
+_REACT_ARTIFACT = {
+    "./index.html": b"<!doctype html><title>Acme</title><div id=root>hello react</div>",
+    "./assets/index-a1b2c3.js": b"console.log('react bundle')",
+    "./assets/index-d4e5f6.css": b"body{color:#111}",
+    "./vite.svg": b"<svg xmlns='http://www.w3.org/2000/svg'></svg>",
+}
+
+# The svelte `.svelte-kit/cloudflare` shape (measured: 24 entries, 33,104 bytes,
+# `_worker.js` at 4,335 bytes even with `src/routes/api/` deleted).
+_SVELTE_ARTIFACT = {
+    "./index.html": b"<!doctype html><title>Acme</title><body>hello svelte</body>",
+    "./_worker.js": b"export default {fetch(){}} // SIGNED_KEY_WOULD_BE_HERE",
+    "./_routes.json": b'{"include":["/*"]}',
+    "./.assetsignore": b"_worker.js\n",
+    "./_app/version.json": b'{"version":"1"}',
+    "./_app/immutable/entry/start.abc.js": b"export const start = 1",
+    "./_app/immutable/assets/_layout.def.css": b".x{}",
+}
+
+
+def _tar(
+    members: dict[str, bytes],
+    *,
+    links: dict[str, str] | None = None,
+    hardlinks: dict[str, str] | None = None,
+) -> bytes:
+    """Pack ``members`` (names used VERBATIM) into gzipped tar bytes.
+
+    Names are verbatim so a test can post a hostile one — ``../escape.txt``,
+    ``/etc/shadow`` — which is the whole point of the rejection tests. ``links`` adds
+    symlink members and ``hardlinks`` adds hardlink members; both are the shapes a
+    tarball uses to reach a file the extraction directory does not contain.
+    """
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        root = tarfile.TarInfo("./")
+        root.type = tarfile.DIRTYPE
+        tar.addfile(root)
+        for name, payload in members.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            tar.addfile(info, io.BytesIO(payload))
+        for kind, entries in ((tarfile.SYMTYPE, links), (tarfile.LNKTYPE, hardlinks)):
+            for name, target in (entries or {}).items():
+                info = tarfile.TarInfo(name)
+                info.type = kind
+                info.linkname = target
+                tar.addfile(info)
+    return buf.getvalue()
+
+
+@pytest.fixture(autouse=True)
+def _preview_home(tmp_path, monkeypatch):
+    """Point the preview root at a temp dir so no test writes the real ~/.pocketpaw."""
+    monkeypatch.setenv("PAW_SITES_PREVIEW_DIR", str(tmp_path / "site-previews"))
+    return tmp_path / "site-previews"
+
+
+# --- the two engine shapes -------------------------------------------------
+
+
+def test_react_artifact_previews_from_its_own_root():
+    snap = ap.store_artifact("react1", _tar(_REACT_ARTIFACT), engine="react")
+
+    assert snap.unpacked.entries == 4
+    assert snap.url_path == "/_preview/react1/"
+
+    index = ap.resolve("react1", "/")
+    assert index.status == 200
+    assert b"hello react" in index.body
+    assert index.content_type == "text/html; charset=utf-8"
+
+    js = ap.resolve("react1", "/assets/index-a1b2c3.js")
+    assert js.status == 200
+    assert js.body == b"console.log('react bundle')"
+    assert js.content_type == "text/javascript; charset=utf-8"
+
+
+def test_svelte_artifact_previews_and_its_deeper_tree_resolves():
+    """The engines emit 4 vs 24 entries; nothing here knows which. The lane tars from
+    ``static_output_rel(engine)``, so both arrive rooted at their deployable root."""
+    ap.store_artifact("svelte1", _tar(_SVELTE_ARTIFACT), engine="svelte")
+
+    index = ap.resolve("svelte1", "/")
+    assert index.status == 200
+    assert b"hello svelte" in index.body
+
+    nested = ap.resolve("svelte1", "/_app/immutable/entry/start.abc.js")
+    assert nested.status == 200
+    assert nested.content_type == "text/javascript; charset=utf-8"
+
+
+# --- _worker.js ------------------------------------------------------------
+
+
+def test_worker_entry_is_never_written_and_never_served(_preview_home):
+    snap = ap.store_artifact("svelte2", _tar(_SVELTE_ARTIFACT), engine="svelte")
+
+    assert snap.unpacked.server_entries == ("_worker.js",)
+    assert not (snap.root / "_worker.js").exists()
+
+    refused = ap.resolve("svelte2", "/_worker.js")
+    assert refused.status == 404
+    assert refused.reason == "server_entry_refused"
+    assert b"SIGNED_KEY_WOULD_BE_HERE" not in refused.body
+
+
+def test_the_worker_does_not_break_the_rest_of_the_preview():
+    """The stated risk: its presence must neither be executed nor 404 everything else."""
+    ap.store_artifact("svelte3", _tar(_SVELTE_ARTIFACT), engine="svelte")
+
+    assert ap.resolve("svelte3", "/").status == 200
+    assert ap.resolve("svelte3", "/_app/version.json").status == 200
+
+
+def test_a_worker_directory_is_refused_wholesale():
+    """adapter-cloudflare emits `_worker.js` as a DIRECTORY of chunks for larger apps,
+    so matching the leaf filename alone would let the chunks through."""
+    snap = ap.store_artifact(
+        "svelte4",
+        _tar(
+            {
+                "./index.html": b"<title>x</title>ok",
+                "./_worker.js/index.js": b"// server shell",
+                "./_worker.js/chunks/0.js": b"// chunk",
+            }
+        ),
+        engine="svelte",
+    )
+
+    assert not (snap.root / "_worker.js").exists()
+    assert sorted(snap.unpacked.server_entries) == ["_worker.js/chunks/0.js", "_worker.js/index.js"]
+    assert ap.resolve("svelte4", "/_worker.js/index.js").reason == "server_entry_refused"
+
+
+def test_worker_source_is_refused_even_when_it_is_on_disk():
+    """Defence in depth: the unpack skip is the primary guard, but a tree unpacked some
+    other way must still not hand back the server bundle's source."""
+    snap = ap.store_artifact("svelte5", _tar(_REACT_ARTIFACT), engine="svelte")
+    (snap.root / "_worker.js").write_bytes(b"const KEY='paw_sk_live_deadbeef'")
+
+    got = ap.resolve("svelte5", "/_worker.js")
+    assert got.status == 404
+    assert b"paw_sk_live_deadbeef" not in got.body
+
+
+def test_deploy_metadata_is_not_served_as_content():
+    snap = ap.store_artifact("svelte6", _tar(_SVELTE_ARTIFACT), engine="svelte")
+
+    assert sorted(snap.unpacked.metadata_entries) == [".assetsignore", "_routes.json"]
+    assert ap.resolve("svelte6", "/_routes.json").reason == "metadata_refused"
+    assert ap.resolve("svelte6", "/.assetsignore").reason == "metadata_refused"
+
+
+# --- no backend ------------------------------------------------------------
+
+
+def test_api_submit_is_refused_visibly_not_faked():
+    ap.store_artifact("form1", _tar(_REACT_ARTIFACT), engine="react")
+
+    posted = ap.resolve("form1", "/api/submit", method="POST")
+    assert posted.status == 501
+    assert posted.reason == "backend_not_served"
+    assert not posted.ok
+    assert b"form submissions" in posted.body
+    # A redirect would read as a successful submission in the browser's address bar.
+    assert posted.location is None
+
+    # GET of the same path is refused identically — no "endpoint exists" signal.
+    assert ap.resolve("form1", "/api/submit").status == 501
+
+
+def test_a_post_to_the_page_itself_is_refused():
+    """A form with no `action` posts to the current URL, so refusing only `/api/*`
+    would leave that case returning the page with a 200."""
+    ap.store_artifact("form2", _tar(_REACT_ARTIFACT), engine="react")
+
+    got = ap.resolve("form2", "/", method="POST")
+    assert got.status == 405
+    assert got.reason == "method_not_allowed"
+    assert b"hello react" not in got.body
+
+
+def test_the_backend_refusal_does_not_depend_on_a_stored_artifact():
+    """Policy before existence: the honest answer to a form POST is the same whether or
+    not a build happens to be stored."""
+    got = ap.resolve("never-built", "/api/submit", method="POST")
+    assert got.status == 501
+    assert got.reason == "backend_not_served"
+
+
+# --- hostile tarballs ------------------------------------------------------
+
+
+def test_traversal_members_are_refused_and_write_nothing_outside_the_root(_preview_home):
+    outside = _preview_home.parent / "escaped.txt"
+    snap = ap.store_artifact(
+        "eve1",
+        _tar(
+            {
+                "./index.html": b"<title>x</title>ok",
+                "../escaped.txt": b"pwned",
+                "../../escaped-deeper.txt": b"pwned",
+                "/tmp/absolute.txt": b"pwned",
+            }
+        ),
+        engine="react",
+    )
+
+    assert len(snap.unpacked.rejected) == 3
+    assert not outside.exists()
+    assert not (_preview_home.parent / "escaped-deeper.txt").exists()
+    # The safe member still landed: a hostile entry does not cost the whole preview.
+    assert ap.resolve("eve1", "/").status == 200
+
+
+def test_link_members_are_refused(_preview_home):
+    """A link is how a tarball reaches a file the extraction directory does not contain,
+    so links are refused rather than followed — symlinks AND hardlinks. The hardlink
+    matters on its own: a hardlink to a member that IS in the archive extracts to real
+    content, so without the member-type guard it would be written like any other file.
+    """
+    snap = ap.store_artifact(
+        "eve2",
+        _tar(
+            {"./index.html": b"<title>x</title>ok"},
+            links={"./secrets": "/etc/passwd", "./up": "../.."},
+            hardlinks={"./copy.html": "./index.html"},
+        ),
+        engine="react",
+    )
+
+    assert sorted(snap.unpacked.rejected) == ["./copy.html", "./secrets", "./up"]
+    assert not (snap.root / "secrets").exists()
+    assert not (snap.root / "up").exists()
+    assert not (snap.root / "copy.html").exists()
+    assert snap.unpacked.entries == 1
+
+
+def test_a_backslash_member_is_refused():
+    """A backslash is a separator on Windows and a legal filename character on POSIX;
+    accepting it means the same artifact writes to two different places."""
+    snap = ap.store_artifact(
+        "eve3",
+        _tar({"./index.html": b"<title>x</title>ok", "..\\..\\escaped.txt": b"pwned"}),
+        engine="react",
+    )
+    assert snap.unpacked.rejected == ("..\\..\\escaped.txt",)
+
+
+def test_too_many_entries_is_refused_and_leaves_no_partial_tree(monkeypatch, _preview_home):
+    monkeypatch.setattr(ap, "MAX_ENTRIES", 2)
+
+    with pytest.raises(ap.ArtifactTooLarge):
+        ap.store_artifact("bomb1", _tar(_REACT_ARTIFACT), engine="react")
+
+    assert not (_preview_home / "bomb1").exists()
+    assert list(_preview_home.glob("*")) == []
+
+
+def test_too_many_bytes_is_refused(monkeypatch, _preview_home):
+    monkeypatch.setattr(ap, "MAX_TOTAL_BYTES", 16)
+
+    with pytest.raises(ap.ArtifactTooLarge):
+        ap.store_artifact("bomb2", _tar(_REACT_ARTIFACT), engine="react")
+
+    assert not (_preview_home / "bomb2").exists()
+
+
+def test_bytes_that_are_not_a_tarball_are_refused(_preview_home):
+    with pytest.raises(ap.ArtifactUnreadable):
+        ap.store_artifact("junk1", b"this is not a gzipped tar", engine="react")
+    assert not (_preview_home / "junk1").exists()
+
+
+# --- hostile request paths -------------------------------------------------
+
+
+def test_percent_encoded_traversal_cannot_read_outside_the_root(_preview_home):
+    ap.store_artifact("eve4", _tar(_REACT_ARTIFACT), engine="react")
+    (_preview_home / "secret.txt").write_bytes(b"tenant secret")
+
+    for path in ("/../secret.txt", "/..%2fsecret.txt", "/%2e%2e/secret.txt", "/a/../../secret.txt"):
+        got = ap.resolve("eve4", path)
+        assert got.status == 404, path
+        assert b"tenant secret" not in got.body, path
+
+
+def test_a_drive_qualified_request_path_cannot_read_outside_the_root(_preview_home):
+    """pathlib treats ``C:`` as an anchor, so joining it onto the root RESETS the path
+    and the read lands wherever the segment points. Refused at the parser."""
+    ap.store_artifact("eve5", _tar(_REACT_ARTIFACT), engine="react")
+    secret = _preview_home.parent / "outside.txt"
+    secret.write_bytes(b"tenant secret")
+
+    for path in (
+        "/" + secret.as_posix(),
+        "/C:/Windows/win.ini",
+        "/c:",
+    ):
+        got = ap.resolve("eve5", path)
+        assert got.status == 404, path
+        assert b"tenant secret" not in got.body, path
+
+
+def test_an_unsafe_site_id_cannot_climb_out_of_the_preview_root():
+    for site_id in ("..", "../..", "a/b", "", "a\\b", "site id"):
+        got = ap.resolve(site_id, "/")
+        assert got.status == 404
+        assert got.reason == "bad_site_id"
+
+
+def test_a_directory_is_never_listed():
+    """A listing would hand the build tree's shape to anyone holding the preview URL."""
+    ap.store_artifact("dir1", _tar(_REACT_ARTIFACT), engine="react")
+
+    got = ap.resolve("dir1", "/assets/")
+    assert got.status == 404
+    assert b"index-a1b2c3.js" not in got.body
+
+
+def test_a_missing_asset_is_a_404_and_not_the_index():
+    """No SPA fallback: rewriting a missing asset to index.html would report a broken
+    build as a working page."""
+    ap.store_artifact("miss1", _tar(_REACT_ARTIFACT), engine="react")
+
+    got = ap.resolve("miss1", "/assets/index-deleted.js")
+    assert got.status == 404
+    assert got.reason == "not_found"
+    assert b"hello react" not in got.body
+
+
+def test_a_site_with_no_stored_build_says_so():
+    got = ap.resolve("nothing1", "/")
+    assert got.status == 404
+    assert got.reason == "no_preview"
+
+
+# --- serving details that break a page silently ---------------------------
+
+
+def test_the_slashless_url_redirects_rather_than_serving_the_index():
+    """Served at `/_preview/<id>` the page's own `./assets/x.js` resolves to
+    `/_preview/assets/x.js` — it renders with no CSS and no JS and looks 'plain'."""
+    ap.store_artifact("slash1", _tar(_REACT_ARTIFACT), engine="react")
+
+    got = ap.resolve("slash1", "")
+    assert got.status == 301
+    assert got.location == "/"
+
+    nested = ap.resolve("slash1", "/assets")
+    assert nested.status == 301
+    assert nested.location == "/assets/"
+
+
+def test_javascript_is_typed_executably_even_when_mimetypes_says_text_plain(monkeypatch):
+    """The stdlib reads the Windows registry, where `.js` has been observed mapping to
+    text/plain. Served that way the browser refuses to run the bundle and the previewed
+    page never hydrates — with every other signal saying the preview worked."""
+    monkeypatch.setattr(ap.mimetypes, "guess_type", lambda *_a, **_k: ("text/plain", None))
+
+    assert ap.content_type_for("index-a1b2c3.js") == "text/javascript; charset=utf-8"
+    assert ap.content_type_for("app.mjs") == "text/javascript; charset=utf-8"
+    assert ap.content_type_for("style.css") == "text/css; charset=utf-8"
+    assert ap.content_type_for("font.woff2") == "font/woff2"
+    # Not in the table → the stdlib still gets its say.
+    assert ap.content_type_for("weird.zzz") == "text/plain"
+
+
+def test_a_preview_is_never_cached():
+    ap.store_artifact("cache1", _tar(_REACT_ARTIFACT), engine="react")
+
+    got = ap.resolve("cache1", "/")
+    assert ("Cache-Control", "no-store") in got.headers
+    assert ("X-Content-Type-Options", "nosniff") in got.headers
+
+
+def test_restoring_replaces_the_previous_build_completely():
+    ap.store_artifact("re1", _tar(_REACT_ARTIFACT), engine="react")
+    assert ap.resolve("re1", "/assets/index-a1b2c3.js").status == 200
+
+    ap.store_artifact(
+        "re1",
+        _tar({"./index.html": b"<title>x</title>second build"}),
+        engine="react",
+    )
+
+    assert b"second build" in ap.resolve("re1", "/").body
+    # A leftover file from the previous build would serve a mixture of two builds.
+    assert ap.resolve("re1", "/assets/index-a1b2c3.js").status == 404
+
+
+# --- engine capability, via the predicates --------------------------------
+
+
+def test_an_engine_with_no_build_subdir_is_refused(_preview_home):
+    """`html` runs no build, so it produces no artifact. Mirrors the same guard in
+    `daytona_build.artifact_tar_command` — an artifact arriving for it is a routing
+    bug and should be loud rather than previewed."""
+    with pytest.raises(ap.ArtifactRejected):
+        ap.store_artifact("html1", _tar(_REACT_ARTIFACT), engine="html")
+    assert not (_preview_home / "html1").exists()
+
+
+def test_an_unexpected_server_entry_is_reported(caplog):
+    """react emits no server entry. One turning up means the lane changed shape, which
+    is worth saying out loud — but not worth refusing to preview over."""
+    with caplog.at_level("WARNING"):
+        snap = ap.store_artifact("mix1", _tar(_SVELTE_ARTIFACT), engine="react")
+
+    assert snap.unpacked.server_entries == ("_worker.js",)
+    assert "even though this engine emits none" in caplog.text
+    assert ap.resolve("mix1", "/").status == 200
+
+
+def test_a_missing_server_entry_is_reported_for_svelte(caplog):
+    with caplog.at_level("WARNING"):
+        ap.store_artifact("mix2", _tar(_REACT_ARTIFACT), engine="svelte")
+
+    assert "carried NO server entry" in caplog.text
+
+
+# --- the publish-safe wrapper ---------------------------------------------
+
+
+def test_safe_store_never_raises(caplog, _preview_home):
+    with caplog.at_level("WARNING"):
+        assert ap.safe_store_artifact("safe1", b"not a tarball", engine="react") is None
+        assert ap.safe_store_artifact("safe1", None, engine="react") is None
+        assert ap.safe_store_artifact("../escape", b"x", engine="react") is None
+
+    assert not (_preview_home / "safe1").exists()
+    assert ap.safe_store_artifact("safe2", _tar(_REACT_ARTIFACT), engine="react") is not None
+
+
+def test_has_preview_and_discard():
+    assert ap.has_preview("life1") is False
+    ap.store_artifact("life1", _tar(_REACT_ARTIFACT), engine="react")
+    assert ap.has_preview("life1") is True
+    assert ap.discard_preview("life1") is True
+    assert ap.has_preview("life1") is False
+    assert ap.has_preview("../escape") is False

--- a/tests/ee/sites/test_artifact_preview.py
+++ b/tests/ee/sites/test_artifact_preview.py
@@ -174,11 +174,16 @@ def test_worker_source_is_refused_even_when_it_is_on_disk():
     """Defence in depth: the unpack skip is the primary guard, but a tree unpacked some
     other way must still not hand back the server bundle's source."""
     snap = ap.store_artifact("svelte5", _tar(_REACT_ARTIFACT), engine="svelte")
-    (snap.root / "_worker.js").write_bytes(b"const KEY='paw_sk_live_deadbeef'")
+    # The canary must be SECRET-SHAPED (so the assertion means something) without
+    # matching a real credential pattern. It used to read `paw_sk_live_deadbeef`, which
+    # tripped the pr-quality-gate secret scan on `sk_live_[a-zA-Z0-9]+` and failed CI on
+    # a test whose entire point is that the string is NOT served. Renamed rather than
+    # allow-listed: a scanner exemption on a sites test would outlive the reason for it.
+    (snap.root / "_worker.js").write_bytes(b"const KEY='paw_canary_notacredential_deadbeef'")
 
     got = ap.resolve("svelte5", "/_worker.js")
     assert got.status == 404
-    assert b"paw_sk_live_deadbeef" not in got.body
+    assert b"paw_canary_notacredential_deadbeef" not in got.body
 
 
 def test_deploy_metadata_is_not_served_as_content():

--- a/tests/ee/sites/test_artifact_preview_server.py
+++ b/tests/ee/sites/test_artifact_preview_server.py
@@ -1,0 +1,225 @@
+# tests/ee/sites/test_artifact_preview_server.py — the artifact preview over real HTTP,
+# and the proof that a publish does not depend on it.
+#
+# Created 2026-08-10 (SG-10, re-aimed). test_artifact_preview.py covers the rules; this
+# file covers the two things only a running server can show:
+#
+#   1. A BUILT ARTIFACT IS ACTUALLY PREVIEWABLE with no Node runtime, no dev server and
+#      no cross-origin isolation — the page and its bundle come back over HTTP from an
+#      unpacked tarball, and the refusals hold on the wire (not just in a return value).
+#   2. PUBLISH IS UNAFFECTED WHEN PREVIEW FAILS, demonstrated rather than asserted in
+#      prose. A local deploy is served, the preview is then broken three different ways
+#      (unreadable artifact, a resolver that raises, no artifact at all), and the
+#      deployed site is re-fetched after each one and still answers 200.
+#
+# The deploy and preview roots being disjoint is checked here too: it is what stops the
+# static branch serving a preview tree without passing `resolve`'s guards, which would
+# give the `_worker.js` refusal a bypass.
+
+from __future__ import annotations
+
+import io
+import tarfile
+import urllib.error
+import urllib.request
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.sites import artifact_preview as ap  # noqa: E402
+
+_ARTIFACT = {
+    "./index.html": b"<!doctype html><title>Acme</title><script src=./assets/app.js></script>ok",
+    "./assets/app.js": b"console.log('bundle')",
+    "./_worker.js": b"export default {fetch(){}} // SIGNED_KEY_WOULD_BE_HERE",
+}
+
+
+def _tar(members: dict[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        for name, payload in members.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            tar.addfile(info, io.BytesIO(payload))
+    return buf.getvalue()
+
+
+def _get(url: str, *, method: str = "GET", data: bytes | None = None):
+    """Fetch ``url`` and return ``(status, body, headers)``, treating an HTTP error as a
+    result rather than an exception — every refusal here is a status code we assert on."""
+    req = urllib.request.Request(url, data=data, method=method)  # noqa: S310 - localhost
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310 - localhost
+            return resp.status, resp.read(), dict(resp.headers)
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read(), dict(exc.headers)
+
+
+@pytest.fixture
+def server(tmp_path, monkeypatch):
+    """A freshly-rooted local static server, torn down afterwards.
+
+    The server is a process singleton whose served root is captured when it starts, so
+    a test that only set the env var would be served by whatever root a previous test
+    started with. Resetting the singleton is what makes the roots in this file real."""
+    monkeypatch.setenv("PAW_SITES_LOCAL_DIR", str(tmp_path / "sites"))
+    monkeypatch.setenv("PAW_SITES_PREVIEW_DIR", str(tmp_path / "site-previews"))
+
+    from pocketpaw_ee.sites import local_server
+
+    previous = local_server._server
+    local_server._server = None
+    try:
+        yield local_server
+    finally:
+        started = local_server._server
+        if started is not None:
+            started.shutdown()
+            started.server_close()
+        local_server._server = previous
+
+
+def _react_project(tmp_path):
+    """A built react project dir: `dist/index.html`, what `deploy_local` copies."""
+    dist = tmp_path / "project" / "dist"
+    dist.mkdir(parents=True)
+    (dist / "index.html").write_bytes(b"<!doctype html><title>Live</title>the deployed site")
+    return tmp_path / "project"
+
+
+# --- the preview, over the wire -------------------------------------------
+
+
+def test_a_built_artifact_is_previewable_over_http(server):
+    url = server.serve_artifact_preview("site1", _tar(_ARTIFACT), engine="svelte")
+    assert url is not None and url.endswith("/_preview/site1/")
+
+    status, body, headers = _get(url)
+    assert status == 200
+    assert b"<title>Acme</title>" in body
+    assert headers["Cache-Control"] == "no-store"
+    # No cross-origin isolation is needed for this path, and none is claimed.
+    assert "Cross-Origin-Embedder-Policy" not in headers
+    assert "Cross-Origin-Opener-Policy" not in headers
+
+    status, body, headers = _get(url + "assets/app.js")
+    assert status == 200
+    assert body == b"console.log('bundle')"
+    assert headers["Content-Type"] == "text/javascript; charset=utf-8"
+
+
+def test_the_slashless_preview_url_still_lands_on_the_page(server):
+    server.serve_artifact_preview("site2", _tar(_ARTIFACT), engine="svelte")
+    base = server.ensure_server()
+
+    status, body, _ = _get(f"{base}/_preview/site2")
+    assert status == 200
+    assert b"<title>Acme</title>" in body
+
+
+def test_the_worker_is_not_reachable_over_http(server):
+    url = server.serve_artifact_preview("site3", _tar(_ARTIFACT), engine="svelte")
+
+    status, body, _ = _get(url + "_worker.js")
+    assert status == 404
+    assert b"SIGNED_KEY_WOULD_BE_HERE" not in body
+
+
+def test_a_form_post_in_preview_is_refused_visibly(server):
+    url = server.serve_artifact_preview("site4", _tar(_ARTIFACT), engine="svelte")
+
+    status, body, _ = _get(url + "api/submit", method="POST", data=b"email=a%40b.test")
+    assert status == 501
+    assert b"form submissions" in body
+
+    # And a form with no action, which posts to the page itself.
+    status, body, _ = _get(url, method="POST", data=b"email=a%40b.test")
+    assert status == 405
+    assert b"the deployed site" not in body
+
+
+def test_head_returns_the_headers_without_the_body(server):
+    url = server.serve_artifact_preview("site5", _tar(_ARTIFACT), engine="svelte")
+
+    status, body, headers = _get(url, method="HEAD")
+    assert status == 200
+    assert body == b""
+    assert headers["Content-Type"] == "text/html; charset=utf-8"
+
+
+def test_an_unbuilt_site_previews_as_a_404(server):
+    base = server.ensure_server()
+    status, _, _ = _get(f"{base}/_preview/never-built/")
+    assert status == 404
+
+
+# --- publish is unaffected when preview fails -----------------------------
+
+
+def test_a_deploy_keeps_serving_when_the_artifact_cannot_be_unpacked(server, tmp_path):
+    site_url = server.deploy_local("site6", str(_react_project(tmp_path)), engine="react")
+    assert _get(site_url)[1] == b"<!doctype html><title>Live</title>the deployed site"
+
+    # An unreadable artifact: the failure a truncated download or a wrong file gives.
+    assert server.serve_artifact_preview("site6", b"not a gzipped tar", engine="react") is None
+    assert server.serve_artifact_preview("site6", None, engine="react") is None
+
+    status, body, _ = _get(site_url)
+    assert status == 200
+    assert body == b"<!doctype html><title>Live</title>the deployed site"
+    assert not (ap.previews_home() / "site6").exists()
+
+
+def test_a_deploy_keeps_serving_when_the_resolver_itself_raises(server, tmp_path, monkeypatch):
+    """The harder half. A store failure is caught by design; an exception thrown while
+    ANSWERING a preview request runs on the same server thread that serves live local
+    deploys, so it has to be contained to the one request."""
+    site_url = server.deploy_local("site7", str(_react_project(tmp_path)), engine="react")
+    preview_url = server.serve_artifact_preview("site7", _tar(_ARTIFACT), engine="react")
+    assert _get(preview_url)[0] == 200
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("preview resolution exploded")
+
+    working = ap.resolve
+    monkeypatch.setattr(ap, "resolve", _boom)
+
+    assert _get(preview_url)[0] == 500
+    status, body, _ = _get(site_url)
+    assert status == 200
+    assert body == b"<!doctype html><title>Live</title>the deployed site"
+
+    # And the server is still alive for the next preview once the fault clears.
+    # Restored by hand rather than with monkeypatch.undo(), which would also revert the
+    # PAW_SITES_PREVIEW_DIR the `server` fixture set on the same shared MonkeyPatch and
+    # point the preview root back at the real home.
+    monkeypatch.setattr(ap, "resolve", working)
+    assert _get(preview_url)[0] == 200
+
+
+def test_the_preview_root_is_outside_the_served_deploy_root(server, tmp_path):
+    """If a preview tree sat under `sites_home()` the static branch would serve it as
+    plain files — `_worker.js` included — without passing any of `resolve`'s guards."""
+    server.serve_artifact_preview("site8", _tar(_ARTIFACT), engine="svelte")
+
+    sites_root = server.sites_home().resolve()
+    previews_root = ap.previews_home().resolve()
+    assert not previews_root.is_relative_to(sites_root)
+    assert not (sites_root / "site8").exists()
+
+    # The static branch has no route to the preview tree.
+    base = server.ensure_server()
+    assert _get(f"{base}/site8/")[0] == 404
+    assert _get(f"{base}/site8/index.html")[0] == 404
+
+
+def test_a_preview_does_not_disturb_a_prior_deploy_of_the_same_site(server, tmp_path):
+    """Same site id on both branches. The two roots must not alias, or a preview of a
+    new build would overwrite the live local deploy of the old one."""
+    site_url = server.deploy_local("site9", str(_react_project(tmp_path)), engine="react")
+    server.serve_artifact_preview("site9", _tar(_ARTIFACT), engine="svelte")
+
+    assert _get(site_url)[1] == b"<!doctype html><title>Live</title>the deployed site"
+    assert b"<title>Acme</title>" in _get(server.preview_url_for("site9"))[1]

--- a/tests/mutations/sites_artifact_preview.json
+++ b/tests/mutations/sites_artifact_preview.json
@@ -1,0 +1,188 @@
+[
+  {
+    "label": "svelte's server bundle is written into the preview tree, so the file that has carried a per-site signed key sits inside a directory we serve",
+    "file": "ee/pocketpaw_ee/sites/artifact_preview.py",
+    "find": "            if any(seg in _SERVER_ENTRY_NAMES for seg in segments):\n                server.append(\"/\".join(segments))",
+    "replace": "            if False:\n                server.append(\"/\".join(segments))",
+    "tests": [
+      "tests/ee/sites/test_artifact_preview.py"
+    ]
+  },
+  {
+    "label": "a request for _worker.js is answered from disk, handing the server bundle's source to anyone who can open the preview",
+    "file": "ee/pocketpaw_ee/sites/artifact_preview.py",
+    "find": "    if any(seg in _SERVER_ENTRY_NAMES for seg in segments):\n        # 404, not 403",
+    "replace": "    if False:\n        # 404, not 403",
+    "tests": [
+      "tests/ee/sites/test_artifact_preview.py",
+      "tests/ee/sites/test_artifact_preview_server.py"
+    ]
+  },
+  {
+    "label": "a form POST to /api/submit falls through to the static tree, so a visitor's message is silently dropped by a response that looks like success",
+    "file": "ee/pocketpaw_ee/sites/artifact_preview.py",
+    "find": "    if segments and segments[0] == \"api\":",
+    "replace": "    if False:",
+    "tests": [
+      "tests/ee/sites/test_artifact_preview.py",
+      "tests/ee/sites/test_artifact_preview_server.py"
+    ]
+  },
+  {
+    "label": "a form with no action posts to the page itself and gets the page back with a 200, which reads as a submission that worked",
+    "file": "ee/pocketpaw_ee/sites/artifact_preview.py",
+    "find": "    if method.upper() not in (\"GET\", \"HEAD\"):",
+    "replace": "    if False:",
+    "tests": [
+      "tests/ee/sites/test_artifact_preview.py",
+      "tests/ee/sites/test_artifact_preview_server.py"
+    ]
+  },
+  {
+    "label": "an absolute path inside a build artifact is extracted, so a hostile or broken build writes files outside the preview root",
+    "file": "ee/pocketpaw_ee/sites/artifact_preview.py",
+    "find": "    if not name or name.startswith(\"/\") or name.startswith(\"\\\\\"):",
+    "replace": "    if not name:",
+    "tests": [
+      "tests/ee/sites/test_artifact_preview.py"
+    ]
+  },
+  {
+    "label": "a '..' member in a build artifact is extracted, so the artifact overwrites files above the preview root",
+    "file": "ee/pocketpaw_ee/sites/artifact_preview.py",
+    "find": "    for raw in name.split(\"/\"):\n        if raw in (\"\", \".\"):\n            continue\n        if raw == \"..\":",
+    "replace": "    for raw in name.split(\"/\"):\n        if raw in (\"\", \".\"):\n            continue\n        if False:",
+    "tests": [
+      "tests/ee/sites/test_artifact_preview.py"
+    ]
+  },
+  {
+    "label": "link members are extracted instead of refused, so a tarball reaches a file the extraction directory never contained",
+    "file": "ee/pocketpaw_ee/sites/artifact_preview.py",
+    "find": "            if not (member.isfile() or member.isdir()):",
+    "replace": "            if False:",
+    "tests": [
+      "tests/ee/sites/test_artifact_preview.py"
+    ]
+  },
+  {
+    "label": "a crafted preview URL reads outside the preview root, so one tenant's URL fetches another site's files",
+    "file": "ee/pocketpaw_ee/sites/artifact_preview.py",
+    "find": "    for raw in decoded.split(\"/\"):\n        if raw in (\"\", \".\"):\n            continue\n        if raw == \"..\" or (len(raw) > 1 and raw[1] == \":\"):",
+    "replace": "    for raw in decoded.split(\"/\"):\n        if raw in (\"\", \".\"):\n            continue\n        if False:",
+    "tests": [
+      "tests/ee/sites/test_artifact_preview.py"
+    ]
+  },
+  {
+    "label": "any site id is accepted as a path segment, so a preview URL walks out of the previews directory",
+    "file": "ee/pocketpaw_ee/sites/artifact_preview.py",
+    "find": "_SAFE_SITE_ID = re.compile(r\"^[A-Za-z0-9_-]{1,64}$\")",
+    "replace": "_SAFE_SITE_ID = re.compile(r\"^.*$\")",
+    "tests": [
+      "tests/ee/sites/test_artifact_preview.py"
+    ]
+  },
+  {
+    "label": "the site's JavaScript is typed from the Windows registry, which serves it as text/plain, so the browser refuses to run it and the previewed page never hydrates",
+    "file": "ee/pocketpaw_ee/sites/artifact_preview.py",
+    "find": "    explicit = _CONTENT_TYPES.get(suffix)",
+    "replace": "    explicit = None",
+    "tests": [
+      "tests/ee/sites/test_artifact_preview.py"
+    ]
+  },
+  {
+    "label": "the preview is cacheable, so after a rebuild the customer keeps being shown the previous build and reports the edit as lost",
+    "file": "ee/pocketpaw_ee/sites/artifact_preview.py",
+    "find": "    (\"Cache-Control\", \"no-store\"),",
+    "replace": "    (\"Cache-Control\", \"public, max-age=3600\"),",
+    "tests": [
+      "tests/ee/sites/test_artifact_preview.py",
+      "tests/ee/sites/test_artifact_preview_server.py"
+    ]
+  },
+  {
+    "label": "the entry ceiling is gone, so an artifact with a million files fills the disk the tenant box runs on",
+    "file": "ee/pocketpaw_ee/sites/artifact_preview.py",
+    "find": "            if entries > MAX_ENTRIES:",
+    "replace": "            if False:",
+    "tests": [
+      "tests/ee/sites/test_artifact_preview.py"
+    ]
+  },
+  {
+    "label": "the size ceiling is gone, so a compression bomb in a build artifact fills the disk",
+    "file": "ee/pocketpaw_ee/sites/artifact_preview.py",
+    "find": "            if written > MAX_TOTAL_BYTES:",
+    "replace": "            if False:",
+    "tests": [
+      "tests/ee/sites/test_artifact_preview.py"
+    ]
+  },
+  {
+    "label": "an engine that runs no build is previewed anyway, hiding a routing bug behind a preview built from the wrong tree",
+    "file": "ee/pocketpaw_ee/sites/artifact_preview.py",
+    "find": "    if static_output_rel(engine) == \".\":",
+    "replace": "    if False:",
+    "tests": [
+      "tests/ee/sites/test_artifact_preview.py"
+    ]
+  },
+  {
+    "label": "a refused artifact is unpacked over the live preview, so a rejected build replaces a good preview with a half-written tree",
+    "file": "ee/pocketpaw_ee/sites/artifact_preview.py",
+    "find": "    incoming = root.parent / f\".{site_id}.incoming-{os.getpid()}-{uuid.uuid4().hex[:8]}\"",
+    "replace": "    incoming = root",
+    "tests": [
+      "tests/ee/sites/test_artifact_preview.py"
+    ]
+  },
+  {
+    "label": "a preview that cannot be stored raises into the caller, so a publish that already succeeded is reported to the customer as failed",
+    "file": "ee/pocketpaw_ee/sites/artifact_preview.py",
+    "find": "    except Exception:  # noqa: BLE001 — a preview must never cost anybody a publish",
+    "replace": "    except SystemExit:  # mutated: the swallow is gone",
+    "tests": [
+      "tests/ee/sites/test_artifact_preview.py",
+      "tests/ee/sites/test_artifact_preview_server.py"
+    ]
+  },
+  {
+    "label": "deploy metadata is served as site content, so _routes.json and .assetsignore are readable at a public preview URL",
+    "file": "ee/pocketpaw_ee/sites/artifact_preview.py",
+    "find": "    if any(seg in _DEPLOY_METADATA_NAMES or seg.startswith(\".\") for seg in segments):",
+    "replace": "    if False:",
+    "tests": [
+      "tests/ee/sites/test_artifact_preview.py"
+    ]
+  },
+  {
+    "label": "the slashless preview URL serves the page instead of redirecting, so it opens with no CSS and no JS and the customer reads a working build as broken",
+    "file": "ee/pocketpaw_ee/sites/artifact_preview.py",
+    "find": "        if not subpath.endswith(\"/\"):",
+    "replace": "        if False:",
+    "tests": [
+      "tests/ee/sites/test_artifact_preview.py",
+      "tests/ee/sites/test_artifact_preview_server.py"
+    ]
+  },
+  {
+    "label": "preview trees land inside the deploy root, so the plain static branch serves them without any of the refusals, _worker.js included",
+    "file": "ee/pocketpaw_ee/sites/artifact_preview.py",
+    "find": "    raw = os.environ.get(\"PAW_SITES_PREVIEW_DIR\")",
+    "replace": "    raw = os.environ.get(\"PAW_SITES_LOCAL_DIR\")",
+    "tests": [
+      "tests/ee/sites/test_artifact_preview_server.py"
+    ]
+  },
+  {
+    "label": "an error while answering a preview escapes onto the server thread, so one bad preview interrupts the live local deploys the same server is serving",
+    "file": "ee/pocketpaw_ee/sites/local_server.py",
+    "find": "        except Exception:  # noqa: BLE001 — contain it to this one request",
+    "replace": "        except SystemExit:  # mutated: containment removed",
+    "tests": [
+      "tests/ee/sites/test_artifact_preview_server.py"
+    ]
+  }
+]

--- a/tests/mutations/sites_artifact_preview.json
+++ b/tests/mutations/sites_artifact_preview.json
@@ -41,8 +41,62 @@
   {
     "label": "an absolute path inside a build artifact is extracted, so a hostile or broken build writes files outside the preview root",
     "file": "ee/pocketpaw_ee/sites/artifact_preview.py",
-    "find": "    if not name or name.startswith(\"/\") or name.startswith(\"\\\\\"):",
+    "find": "    if not name or name.startswith(\"/\"):",
     "replace": "    if not name:",
+    "tests": [
+      "tests/ee/sites/test_artifact_preview.py"
+    ]
+  },
+  {
+    "label": "a NUL in a member name is accepted, so a name that passes a suffix check opens a different file than the one checked",
+    "file": "ee/pocketpaw_ee/sites/artifact_preview.py",
+    "find": "    if \"\\x00\" in name:",
+    "replace": "    if False:",
+    "tests": [
+      "tests/ee/sites/test_artifact_preview.py"
+    ]
+  },
+  {
+    "label": "a backslash in a member name is accepted, so the same artifact writes to two different places depending on the host OS",
+    "file": "ee/pocketpaw_ee/sites/artifact_preview.py",
+    "find": "    if \"\\\\\" in name:",
+    "replace": "    if False:",
+    "tests": [
+      "tests/ee/sites/test_artifact_preview.py"
+    ]
+  },
+  {
+    "label": "a drive-qualified member name is accepted, so extraction writes to the drive root instead of the preview directory",
+    "file": "ee/pocketpaw_ee/sites/artifact_preview.py",
+    "find": "    if len(name) > 1 and name[1] == \":\":  # a Windows drive-qualified path",
+    "replace": "    if False:  # a Windows drive-qualified path",
+    "tests": [
+      "tests/ee/sites/test_artifact_preview.py"
+    ]
+  },
+  {
+    "label": "a NUL in a request path is accepted, so an extension check agrees with a different file than the one served",
+    "file": "ee/pocketpaw_ee/sites/artifact_preview.py",
+    "find": "    if \"\\x00\" in decoded:",
+    "replace": "    if False:",
+    "tests": [
+      "tests/ee/sites/test_artifact_preview.py"
+    ]
+  },
+  {
+    "label": "a backslash in a request path is accepted, so a Windows-separator traversal reaches the containment check instead of being refused as written",
+    "file": "ee/pocketpaw_ee/sites/artifact_preview.py",
+    "find": "    if \"\\\\\" in decoded:",
+    "replace": "    if False:",
+    "tests": [
+      "tests/ee/sites/test_artifact_preview.py"
+    ]
+  },
+  {
+    "label": "the post-join containment check trusts the path, so a symlink inside the preview tree reads any file the process can open",
+    "file": "ee/pocketpaw_ee/sites/artifact_preview.py",
+    "find": "    if real == real_root or real.is_relative_to(real_root):",
+    "replace": "    if True:",
     "tests": [
       "tests/ee/sites/test_artifact_preview.py"
     ]
@@ -68,7 +122,7 @@
   {
     "label": "a crafted preview URL reads outside the preview root, so one tenant's URL fetches another site's files",
     "file": "ee/pocketpaw_ee/sites/artifact_preview.py",
-    "find": "    for raw in decoded.split(\"/\"):\n        if raw in (\"\", \".\"):\n            continue\n        if raw == \"..\" or (len(raw) > 1 and raw[1] == \":\"):",
+    "find": "    for raw in decoded.split(\"/\"):\n        if raw in (\"\", \".\"):\n            continue\n        if raw == \"..\":",
     "replace": "    for raw in decoded.split(\"/\"):\n        if raw in (\"\", \".\"):\n            continue\n        if False:",
     "tests": [
       "tests/ee/sites/test_artifact_preview.py"
@@ -183,6 +237,15 @@
     "replace": "        except SystemExit:  # mutated: containment removed",
     "tests": [
       "tests/ee/sites/test_artifact_preview_server.py"
+    ]
+  },
+  {
+    "label": "a drive-qualified request segment is accepted, so joining it anchors the path at the drive root and the read leaves the preview entirely",
+    "file": "ee/pocketpaw_ee/sites/artifact_preview.py",
+    "find": "        if len(raw) > 1 and raw[1] == \":\":\n            return None",
+    "replace": "        if False:\n            return None",
+    "tests": [
+      "tests/ee/sites/test_artifact_preview.py"
     ]
   }
 ]


### PR DESCRIPTION
Previews a site's built artifact over HTTP with no Node runtime involved. Stacks on
`feat/sites-daytona-build-lane`.

## Why the shape changed

This slice was originally "boot a Node runtime in the browser" — a WebContainer
session running a dev server for the site project. Two things retired that before
anything was built.

**The build left the request path.** Source-engine sites now build in an ephemeral
Daytona sandbox and only the static output comes back. Measured against the live lane:

| engine | artifact | entries | wall clock | `node_modules` | `_worker.js` |
|--------|----------|---------|-----------|----------------|--------------|
| react  | 61,487 B | 4       | 8.70s     | absent         | absent       |
| svelte | 33,104 B | 24      | 14.67s    | absent         | present (4,335 B) |

WebContainer answers "run a dev server for a project with dependencies, in the
browser". Serving an already-built tree is not that question.

**Static removes constraints rather than adding them.** The in-tab runtime needs
cross-origin isolation. COEP `require-corp` blocks presigned-S3 images, which is
exactly what the sites gallery cards render, so enabling it breaks the surface the
preview lives on. `credentialless` avoids that but is Chromium/Firefox only, so
Safari lands back on `require-corp` and the same breakage. This path sets no COOP or
COEP header at all, and a test asserts neither appears on a preview response.

## How it works

`artifact_preview.py` unpacks an artifact and answers requests against the unpacked
tree. `local_server.py` gained a second branch: `/<site_id>/...` is unchanged static
serving of a local deploy, `/_preview/<site_id>/...` routes through
`artifact_preview.resolve`. It rides the server that already exists rather than
standing up a second one — the same shape `dev_server.py` uses, with the dev server
removed.

The module holds no per-engine layout knowledge, and that is deliberate rather than an
omission: the lane tars with `-C <static_output_rel(engine)> .`, so react's `dist` and
svelte's `.svelte-kit/cloudflare` both arrive as a tree whose root is the deployable
root. The artifact is already engine-normalised when it is packed. The engine is still
consulted through `engines.py` predicates for the two things it genuinely decides —
whether the engine runs a build at all (`html` is refused), and whether a `_worker.js`
is expected.

## The three edge cases

**`_worker.js` is skipped at unpack and refused at resolve.** svelte emits one even
with zero server routes; `adapter-cloudflare` emits a Server shell regardless,
confirmed by deleting `src/routes/api/`, wiping `.svelte-kit` and rebuilding clean. So
it is never written to disk, and any request for it is refused — including the
directory-shaped `_worker.js/chunks/0.js` that adapter-cloudflare emits for larger
apps.

The refusal is **404, not 403**. A static preview genuinely has no server entry to
offer, and a 403 confirms the file is there. That matters because on the svelte track
this bundle has carried a substituted per-site `__CAPTURE_SIGNED_KEY__`, so serving its
source would be a secret disclosure. `_routes.json` and `.assetsignore` get the same
treatment for the weaker reason that they are deploy configuration, not site content.

**`/api/submit` is refused visibly and cannot be faked.** Lead capture is deferred, so
there is no endpoint to serve, and a POST that appeared to succeed would lose the
message silently. Anything under `api/` returns 501 explaining that publishing enables
submissions; any non-GET returns 405, which also covers a form with no action posting
back to its own page. Both refusals are answered before the module checks whether an
artifact is even stored, so the honest answer does not depend on that.

**Both engine shapes are tested**, using tarballs shaped like each measured artifact
rather than one, because a preview that only ever saw react's 4-entry shape would pass
while being wrong about svelte's 24-entry one.

## Path traversal, guarded at both ends

The brief omitted this and nothing else in the program covers it — the security slice's
checklist does not include traversal.

**At extract time.** A member named `../../etc/passwd`, an absolute path, a drive
letter, a backslash or a symlink escapes when written, no matter how careful the
request side is. `tarfile` has historically been unsafe by default here, so nothing
calls `extractall`: members are written one at a time after their names are validated,
archive permissions are discarded so nothing arrives executable, and link members are
refused rather than followed — hardlinks included, since a hardlink to a member that
*is* in the archive extracts to real content and would otherwise be written like any
other file.

**At request time.** The path is percent-decoded first (`..%2f..%2f` only looks safe
before decoding), validated segment by segment, then resolved and compared against the
resolved root. A prefix check on the raw string is defeated by encoding and, more
importantly, by a symlink, which no string inspection can see. Both sides are resolved
because the root itself can sit under a link — a temp dir on macOS does (`/tmp` →
`/private/tmp`), and comparing a resolved target against an unresolved root would
refuse every legitimate request there.

Two findings from building it that are worth more than the guards:

**Asserting only the status code hid a broken guard.** The parser and the containment
check return different reasons (`unsafe_path` vs `escaped_root`) for the same 404. The
first version of the tests asserted status alone, and a mutation disabling the parser's
`..` check still passed — because containment refused the same request afterwards. The
suite would have shipped a broken parser guard while looking green. Asserting the
specific reason is what makes each layer independently provable.

**A NUL byte cannot ride a tar archive at all.** The format's name field is
NUL-terminated, so a member written as `./safe.html\0/../../escaped.txt` reads back as
`./safe.html` — the tail is gone before any of this code sees it. The guard is kept,
because refusing a NUL is a property of a name parser rather than of tar, but it is
asserted against the parser directly. A test that packed such a tarball would have
looked like proof and been none.

## Publish does not depend on preview

Demonstrated by test, not asserted. A local deploy is served, the preview is then
broken three ways — unreadable artifact, no artifact, and a resolver that raises
mid-request — and the deployed site is re-fetched after each and still answers 200.

Two mechanisms make that hold. `safe_store_artifact` swallows every failure and returns
`None`, the way `screenshot.safe_take_*` does for card images, so a publish tail can
call it without risk. And the preview branch catches everything and answers 500 for
that one request, because an exception escaping there would run on the same server
thread that serves live local deploys.

## The two roots are disjoint on purpose

Deploys live under `sites_home()`, which the server hands out as plain static files.
Previews live under `previews_home()` (`~/.pocketpaw/site-previews`, or
`PAW_SITES_PREVIEW_DIR`), which the server never serves directly. A preview tree inside
`sites_home()` would be served by the static branch with none of the refusals applied,
giving the `_worker.js` refusal a bypass. Disjoint roots are what make the refusals
structural rather than advisory, and a test asserts containment both ways.

## What this does not cover

**Not a cloud-reachable endpoint.** It is served by the localhost static server, which
is right for this phase and matches `dev_server.py`'s existing shape. Exposing it
through the authed cloud surface is a separate decision, and there is a real finding
behind that: serving customer-authored HTML from the app's own origin means the page
runs with the app's origin. The obvious mitigation, CSP `sandbox allow-scripts`, puts
the document in an opaque origin — but a sandboxed document's site-for-cookies is
empty, so `SameSite` cookies stop riding its subresource requests and the page's own CSS
and JS fail to load. The alternative is an unauthenticated preview URL carrying a
signed, expiring token, which is a security design of its own. Neither should be picked
as a side effect of this slice.

Adjacent and worth recording: the session cookie is `HttpOnly`, so customer JavaScript
in a preview cannot read it. Cookies are not port-scoped, so a localhost preview shares
a cookie domain with a locally running app — pre-existing on the `dev_server.py` path,
not introduced here.

**Nothing calls the build lane yet.** `run_build` returns the artifact as in-memory
bytes and its only caller is a round-trip script. There is no S3 upload and no
persistence in the sites module. So the preview takes artifact bytes as input and
assumes nothing about their origin:
`local_server.serve_artifact_preview(site_id, artifact, engine=...)` is the one-call
wiring point for whichever caller lands first.

**No SPA fallback.** A missing asset is a 404, never a rewrite to `index.html`.
Rewriting would report a broken build as a working page, which is the one failure mode
a preview whose job is verification must not have.

**No directory listings.** A directory without `index.html` is a 404; a listing would
hand out the build tree's shape to anyone holding the URL.

## Live-edit preview is parked, and `dev_server.py` stays

The one case this does not replace is a preview reflecting edits without a rebuild.
That needs a Node runtime somewhere, and both candidate homes are closed.

Daytona is a **build host only** — a dev server is long-lived by definition while every
sandbox in this lane is ephemeral, strict-timeout and self-deleting, so hosting one
there means either giving back the self-delete rule that killed the
`auto_stop_interval` billing landmine, or a dev server that vanishes mid-edit. No
configuration is both. WebContainer is parked on procurement.

So **`dev_server.py` stays and is load-bearing.** The original slice promised a verdict
gating its retirement; that retirement is off the table.

*Viewing* a built site moved off the box, which is what this slice delivered. *Editing*
did not move at all. That is the status quo rather than a regression — edits are already
fast, since HMR replaced per-edit rebuilds. What stays on the box is the **footprint**:
N long-lived Vite processes plus N `node_modules` trees on a 4-CPU/6G api container at
100–200 users per tenant. Moving that to the client was WebContainer's entire value, so
that question is **unanswered rather than solved**, and it is a capacity question, not a
latency one.

**The WebContainer blocker is procurement.** A commercial plan carries a session cap,
and the case here is sessions booted by tenants' own end visitors rather than our
authenticated seats — exactly what vendors price separately.

**The licence trap, stated so it is not repeated.** `@webcontainer/api` declares
`"license": "MIT"` in its npm manifest. That covers the client library only. It is not
the hosted runtime and not the commercial terms, and it must never be cited as
permission to ship — not in code, a comment, a doc, a PR, or a customer conversation.

**No server-side preview fallback of any kind.** The earlier spec routed "in-tab
WebContainer when the project qualifies, Daytona VM otherwise". The VM half is gone and
nothing here reintroduces it: the preview path contains no Daytona call and no VM
concept.

## Verification

Run independently in a separate checkout, not the author's:

```
pytest  test_artifact_preview + test_artifact_preview_server
        + test_engines + test_html_publish                      116 passed

mutate.py  tests/mutations/sites_artifact_preview.json      27/27 caught
           exit 0, zero unmatched anchors, zero survivors
```

Every traversal guard has its own mutation, one per guard rather than one per
condition — a combined `if a or b or c` reads as verified when only one branch is. That
covers `..`, absolute paths, drive letters, backslashes and NUL on both the member-name
and request-path sides, the link-member refusal, and the post-join containment check.
Containment is exercised with a real symlink planted inside a preview tree; that test
skips where the OS refuses symlink creation, which is worth knowing because its mutation
would escape rather than fail there.
