### PR TITLE
Resolve the svelte output dir off the artifact, not the engine name

### DIFF
--- a/ee/pocketpaw_ee/sites/draft_markup.py
+++ b/ee/pocketpaw_ee/sites/draft_markup.py
@@ -428,9 +428,7 @@ async def _build_static_dir(
         pocket_id=getattr(site, "pocket_id", None),
         smoke=False,
     )
-    static_dir = Path(
-        build.project_dir, resolve_static_output_rel(build.project_dir, engine)
-    )
+    static_dir = Path(build.project_dir, resolve_static_output_rel(build.project_dir, engine))
     return static_dir if (static_dir / "index.html").is_file() else None
 
 

--- a/ee/pocketpaw_ee/sites/draft_markup.py
+++ b/ee/pocketpaw_ee/sites/draft_markup.py
@@ -56,7 +56,11 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
-from pocketpaw_ee.sites.engines import is_source_engine, needs_node_build, static_output_rel
+from pocketpaw_ee.sites.engines import (
+    is_source_engine,
+    needs_node_build,
+    resolve_static_output_rel,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -351,11 +355,19 @@ def inline_document(
 
 def _built_root(pocket_id: str, engine: str) -> Path:
     """Where a pocket's servable files land on disk: PERF-3's persistent per-pocket
-    build dir (``build_home()/<pocket_id>/``) plus the per-engine static-output
-    subdir (``.svelte-kit/cloudflare`` for ripple/svelte, ``.`` for html)."""
+    build dir (``build_home()/<pocket_id>/``) plus the static-output subdir
+    (``.svelte-kit/cloudflare`` for ripple and dynamic svelte, ``build`` for a STATIC
+    svelte site, ``.`` for html).
+
+    SL-1 — resolved against the build dir rather than derived from the engine name.
+    This is the call site that most needs the probe: it reconstructs a path from a
+    pocket id with no generate in scope, so there is no generator result to read a
+    reported ``staticDir`` off. The persistent per-pocket build dir IS the project
+    dir, which is exactly what the resolver needs."""
     from pocketpaw_ee.sites.generator_client import build_home
 
-    return build_home() / pocket_id / static_output_rel(engine)
+    project_dir = build_home() / pocket_id
+    return project_dir / resolve_static_output_rel(project_dir, engine)
 
 
 def _built_static_dir(pocket_id: str, engine: str) -> Path | None:
@@ -416,7 +428,9 @@ async def _build_static_dir(
         pocket_id=getattr(site, "pocket_id", None),
         smoke=False,
     )
-    static_dir = Path(build.project_dir, static_output_rel(engine))
+    static_dir = Path(
+        build.project_dir, resolve_static_output_rel(build.project_dir, engine)
+    )
     return static_dir if (static_dir / "index.html").is_file() else None
 
 

--- a/ee/pocketpaw_ee/sites/engines.py
+++ b/ee/pocketpaw_ee/sites/engines.py
@@ -279,9 +279,7 @@ def resolve_static_output_rel(project_dir: str | os.PathLike[str], engine: str |
     return _STATIC_OUTPUT_REL["svelte"]
 
 
-def resolve_emits_server_worker(
-    project_dir: str | os.PathLike[str], engine: str | None
-) -> bool:
+def resolve_emits_server_worker(project_dir: str | os.PathLike[str], engine: str | None) -> bool:
     """Whether THIS build actually emitted a ``_worker.js`` server entry.
 
     The deploy-shape half of the same SL-1 problem, and the half with teeth. A static

--- a/ee/pocketpaw_ee/sites/engines.py
+++ b/ee/pocketpaw_ee/sites/engines.py
@@ -51,6 +51,21 @@ The five predicates split the engine question into orthogonal capabilities:
   entry that must be deployed as a Worker *script* (ripple, svelte), or is it a
   purely static asset tree deployed as an assets-only Worker (html, react)?
 
+SL-1 added ARTIFACT-RESOLVING siblings for the last two, and they are the ones to
+reach for when a generated project dir is in hand:
+
+* :func:`resolve_static_output_rel` — where did THIS build's output actually land?
+* :func:`resolve_emits_server_worker` — did THIS build actually emit a worker?
+
+Both exist because the svelte track no longer has one output shape. A static landing
+site builds on ``adapter-static`` (``build``, no worker); a dynamic/auth site builds
+on ``adapter-cloudflare`` (``.svelte-kit/cloudflare``, worker load-bearing). That is a
+property of the SITE, not of the engine string, so the name-only predicates above
+cannot answer it and the two resolvers read the artifact instead. They are also the
+only functions in this module that touch the filesystem — see
+:func:`resolve_static_output_rel` for why that exception is narrower than threading a
+flag through every caller would be.
+
 Unknown-engine policy — **fall back to ripple, never raise.** The codebase reads
 ``pocket.get("engine") or "ripple"`` in roughly a dozen places: an empty or missing
 engine has ALWAYS meant ripple, and these predicates sit on hot read/publish paths
@@ -64,6 +79,9 @@ validation should validate the engine string at their own entry point.
 """
 
 from __future__ import annotations
+
+import os
+from pathlib import Path
 
 _DEFAULT_ENGINE = "ripple"
 
@@ -105,6 +123,22 @@ _STATIC_OUTPUT_REL: dict[str, str] = {
     "html": ".",
     "react": "dist",
 }
+
+# SL-1 — where a STATIC svelte site's output lands instead. adapter-static's default.
+#
+# THIS IS WHY THE MAP ABOVE STOPPED BEING SUFFICIENT FOR SVELTE. The svelte track now
+# builds on one of two adapters, chosen by a property of the SITE (does it read a
+# per-tenant D1?) rather than of the engine:
+#
+#   * static landing site  → adapter-static      → ``build``, and NO ``_worker.js``
+#   * dynamic / auth site  → adapter-cloudflare  → ``.svelte-kit/cloudflare``
+#
+# adapter-cloudflare emitted a ``_worker.js`` Server shell for EVERY build, including
+# one with zero server routes, and that shell imports two files that sit OUTSIDE the
+# deployable dir — so a static site shipped a worker that could not start. Dropping
+# the adapter for static sites removed the worker; it also moved the output dir, which
+# is what these two resolvers exist to absorb.
+_SVELTE_STATIC_OUTPUT_REL = "build"
 
 
 def normalize_engine(engine: str | None) -> str:
@@ -181,5 +215,76 @@ def static_output_rel(engine: str | None) -> str:
       generator's prerender pass rewrites in place to carry the server-rendered
       markup. Explicitly NOT the SvelteKit path: nothing on the react track produces
       ``.svelte-kit/cloudflare``.
+
+    NOT AUTHORITATIVE FOR SVELTE SINCE SL-1. The svelte row is the DYNAMIC shape; a
+    static landing site writes ``build``. Whenever a generated project dir is in hand,
+    call :func:`resolve_static_output_rel` instead. This function stays for callers
+    that legitimately want the nominal per-engine value with no filesystem in scope
+    (config templates, docs, tests) and for the three engines that still have exactly
+    one output shape each.
     """
     return _STATIC_OUTPUT_REL[normalize_engine(engine)]
+
+
+def resolve_static_output_rel(project_dir: str | os.PathLike[str], engine: str | None) -> str:
+    """Where THIS build's deployable output actually landed, relative to ``project_dir``.
+
+    Prefer this over :func:`static_output_rel` wherever a generated project dir exists.
+    Since SL-1 the svelte track spans two adapters with two different output dirs, and
+    which one ran is not recoverable from the engine name — so this reads the answer
+    off disk rather than predicting it.
+
+    ONLY svelte is probed. ripple / html / react each still have exactly one output
+    shape, so they fall straight through to the nominal map and their behaviour is
+    byte-for-byte unchanged.
+
+    PROBE ORDER IS LOAD-BEARING: ``build`` first, so a project dir carrying a stale
+    ``.svelte-kit/cloudflare`` tree from a pre-SL-1 build cannot shadow what the
+    current build emitted. Reversing these two silently serves the old artifact.
+
+    When NEITHER exists we return the nominal map value rather than raising. The caller
+    is then reporting a missing build against a concrete path, which is a truer error
+    than ``engines.py`` refusing to decide — and it keeps this predicate total, the way
+    every other one in this module is.
+
+    NOTE: this and :func:`resolve_emits_server_worker` are the ONLY functions here that
+    touch the filesystem. Every other predicate is pure. That is a deliberate, narrow
+    exception: the fact being resolved is a property of an artifact on disk, and the
+    alternative — threading a static/dynamic flag through six call sites, two of which
+    reconstruct a path from a pocket id with no generate in scope — creates a second
+    source of truth that can disagree with the artifact. Reading the artifact cannot.
+    """
+    normalized = normalize_engine(engine)
+    if normalized != "svelte":
+        return _STATIC_OUTPUT_REL[normalized]
+    root = Path(project_dir)
+    for candidate in (_SVELTE_STATIC_OUTPUT_REL, _STATIC_OUTPUT_REL["svelte"]):
+        if (root / candidate).is_dir():
+            return candidate
+    return _STATIC_OUTPUT_REL["svelte"]
+
+
+def resolve_emits_server_worker(
+    project_dir: str | os.PathLike[str], engine: str | None
+) -> bool:
+    """Whether THIS build actually emitted a ``_worker.js`` server entry.
+
+    The deploy-shape half of the same SL-1 problem, and the half with teeth. A static
+    svelte site emits NO worker, so :func:`emits_server_worker` — which answers from
+    the engine name and therefore still says True — would have ``workers_deploy``
+    point ``main`` at a ``build/_worker.js`` that does not exist and pick the
+    server-entry ``.assetsignore`` over the assets-only one. That fails the deploy
+    outright, which is the exact failure mode RX-1 introduced this predicate to
+    prevent; SL-1 just reopened it from the other side.
+
+    A static svelte site must deploy assets-only, the same way react already does.
+
+    ``_worker.js`` is tested for EXISTENCE, not for being a file: adapter-cloudflare
+    emits it as a DIRECTORY (``_worker.js/chunks/0.js``) once an app is large enough,
+    so an ``is_file()`` check would report "no worker" for a big dynamic site and
+    silently deploy it assets-only — a working site replaced by a broken one.
+    """
+    if normalize_engine(engine) not in _SERVER_WORKER_ENGINES:
+        return False
+    out_dir = Path(project_dir) / resolve_static_output_rel(project_dir, engine)
+    return (out_dir / "_worker.js").exists()

--- a/ee/pocketpaw_ee/sites/engines.py
+++ b/ee/pocketpaw_ee/sites/engines.py
@@ -14,6 +14,21 @@
 # predicate. That is this module's whole design: capabilities stay orthogonal, and a
 # new engine that combines them in a new way adds a predicate rather than overloading
 # one.
+#
+# Edited 2026-08-10 (SL-1 — the static svelte landing lane): added
+# :func:`resolve_static_output_rel` and :func:`resolve_emits_server_worker`, the
+# ARTIFACT-resolving siblings of the last two predicates. The svelte track now builds
+# on adapter-static for a static landing site (output ``build``, no ``_worker.js``) and
+# adapter-cloudflare for a dynamic/auth one — a property of the SITE, not of the engine
+# string, so for the first time a capability here is NOT a function of the engine name
+# and the name-only predicates genuinely cannot answer it.
+#
+# This follows RX-1's design rather than departing from it: a new combination adds a
+# predicate instead of overloading one. What is new is that these two read the
+# filesystem, which no other predicate here does. That exception is deliberate and
+# narrow — see :func:`resolve_static_output_rel` for why reading the artifact beats
+# threading a static/dynamic flag through six call sites, two of which have no
+# generate in scope to thread it from.
 """Engine capability predicates for Paw Sites.
 
 Four site-generation engines are modeled:

--- a/ee/pocketpaw_ee/sites/generator_client.py
+++ b/ee/pocketpaw_ee/sites/generator_client.py
@@ -1450,6 +1450,10 @@ class GeneratorClient:
         # rewrite). ripple + svelte (``needs_node_build`` True) fall through to the
         # unchanged generate → install → build_static → gate chain.
         if not needs_node_build(engine):
+            # Deliberately the NOMINAL predicate, not SL-1's resolver: this branch is
+            # reached only when ``not needs_node_build(engine)``, i.e. html, whose
+            # output dir is the project dir itself and has exactly one shape. The
+            # resolver would return the same value. Only svelte is ambiguous.
             static_dir = Path(project_dir, static_output_rel(engine))
             _html_static_smoke(static_dir)
             return BuildResult(project_dir=project_dir, ripple_version=gen.get("rippleVersion"))

--- a/ee/pocketpaw_ee/sites/local_server.py
+++ b/ee/pocketpaw_ee/sites/local_server.py
@@ -67,7 +67,7 @@ from pathlib import Path
 from urllib.parse import urlsplit
 
 from pocketpaw_ee.sites import artifact_preview
-from pocketpaw_ee.sites.engines import static_output_rel
+from pocketpaw_ee.sites.engines import resolve_static_output_rel
 
 logger = logging.getLogger(__name__)
 
@@ -99,9 +99,10 @@ def sites_home() -> Path:
 def persist_site(site_id: str, project_dir: str, engine: str = "ripple") -> Path:
     """Copy the built static site into the stable per-site dir <home>/<site_id>/
     and return that dir. Replaces any prior deploy of the same site so a re-publish
-    serves fresh content. The source tree is ``static_output_rel(engine)`` —
-    ``.svelte-kit/cloudflare`` for ripple/svelte, the project root for html."""
-    src = Path(project_dir, static_output_rel(engine))
+    serves fresh content. The source tree is ``resolve_static_output_rel(...)`` —
+    ``.svelte-kit/cloudflare`` for ripple and dynamic svelte, ``build`` for a STATIC
+    svelte site (SL-1), the project root for html."""
+    src = Path(project_dir, resolve_static_output_rel(project_dir, engine))
     if not src.is_dir():
         raise FileNotFoundError(f"no built static site at {src}")
     dest = sites_home() / site_id
@@ -264,7 +265,7 @@ def deploy_local(site_id: str, project_dir: str, *, engine: str = "ripple") -> s
     and returns its URL with a logged warning (serve the last-good site rather than
     break the page); only when there is no prior deploy EITHER does it raise
     ``MissingBuildOutput`` — a clear, typed error the caller can surface."""
-    src = Path(project_dir, static_output_rel(engine))
+    src = Path(project_dir, resolve_static_output_rel(project_dir, engine))
     if not src.is_dir():
         dest = sites_home() / site_id
         if dest.is_dir():

--- a/ee/pocketpaw_ee/sites/local_server.py
+++ b/ee/pocketpaw_ee/sites/local_server.py
@@ -1,9 +1,14 @@
 # ee/pocketpaw_ee/sites/local_server.py — LOCAL static file server for the
 # Sites local-deploy mode (Phase 3). With no Cloudflare creds, publish() builds
-# the static site and "deploys" it by copying the prerendered
-# `.svelte-kit/cloudflare/` tree under a stable per-site dir; this module serves
-# that tree over HTTP so the published site has a real openable localhost URL
-# (what the cmux smoke + Phase 5 open).
+# the static site and "deploys" it by copying the built output tree under a stable
+# per-site dir; this module serves that tree over HTTP so the published site has a
+# real openable localhost URL (what the cmux smoke + Phase 5 open).
+#
+# Updated 2026-08-10 (SL-1): this header used to name `.svelte-kit/cloudflare/` as THE
+# tree that gets copied. That is now only one of the shapes — a STATIC svelte landing
+# site builds on adapter-static and writes `build/`. Both call sites below resolve the
+# dir off the artifact via ``resolve_static_output_rel`` rather than deriving it from
+# the engine name, because after the adapter fork the engine name cannot answer it.
 #
 # Updated 2026-08-10 (SG-10 — serve the built ARTIFACT as a preview): the one
 # handler now has a second branch. `/<site_id>/...` is unchanged — plain static

--- a/ee/pocketpaw_ee/sites/local_server.py
+++ b/ee/pocketpaw_ee/sites/local_server.py
@@ -76,12 +76,16 @@ from pocketpaw_ee.sites.engines import resolve_static_output_rel
 
 logger = logging.getLogger(__name__)
 
-# The deployable static-output dir, relative to the project dir, is resolved per
-# engine via ``static_output_rel`` (HE-4): ripple/svelte serve the adapter-cloudflare
-# output (``.svelte-kit/cloudflare``), html serves the raw static tree at the project
-# root (``.``). Without this an html site published in local mode looked for a
-# SvelteKit build that never exists and failed with MissingBuildOutput.
-# Retained for readability + back-compat; the ripple/svelte value.
+# The deployable static-output dir, relative to the project dir, is resolved off the
+# ARTIFACT via ``resolve_static_output_rel`` (HE-4 engine-awareness, SL-1 artifact-
+# awareness): ripple and DYNAMIC svelte serve the adapter-cloudflare output
+# (``.svelte-kit/cloudflare``), a STATIC svelte landing site serves ``build``, and html
+# serves the raw static tree at the project root (``.``). Without engine-awareness an
+# html site published in local mode looked for a SvelteKit build that never exists and
+# failed with MissingBuildOutput; without artifact-awareness a static svelte site does
+# the same, because after the adapter fork the engine name no longer determines the dir.
+# The constant below is retained for readability + back-compat; it is the
+# ripple/dynamic-svelte value only, and is NOT what the call sites read.
 _CLOUDFLARE_BUILD_REL = ".svelte-kit/cloudflare"
 
 
@@ -260,9 +264,11 @@ def deploy_local(site_id: str, project_dir: str, *, engine: str = "ripple") -> s
     """Persist the built site and return its served localhost URL. The one call
     the service makes in local mode in place of cf.put_worker().
 
-    ``engine`` selects the static-output dir (``static_output_rel``): ripple/svelte
-    serve ``.svelte-kit/cloudflare``; html serves the project root (its raw static
-    tree). The default (``"ripple"``) preserves the exact prior behaviour.
+    ``engine`` plus the artifact on disk select the static-output dir
+    (``resolve_static_output_rel``): ripple and DYNAMIC svelte serve
+    ``.svelte-kit/cloudflare``; a STATIC svelte landing site serves ``build``; html
+    serves the project root (its raw static tree). The default (``"ripple"``) preserves
+    the exact prior behaviour.
 
     Fails SOFT on a missing build dir (P1a): if the static output is not present (a
     build that produced no output), this does NOT raise a bare FileNotFoundError →
@@ -312,10 +318,15 @@ def serve_artifact_preview(site_id: str, artifact: bytes | None, *, engine: str)
     its failures, while a preview is a convenience and must not be able to fail a
     publish that already succeeded.
 
-    ``engine`` selects nothing about the LAYOUT — the lane tars from
-    ``static_output_rel(engine)``, so every artifact already arrives rooted at its
-    deployable root. It is passed through for the ``emits_server_worker`` cross-check
-    in ``store_artifact``."""
+    ``engine`` selects nothing about the LAYOUT — the lane tars from the resolved
+    static-output dir, so every artifact already arrives rooted at its deployable root.
+    It is passed through for the ``emits_server_worker`` cross-check in
+    ``store_artifact``.
+
+    SL-1 caveat for whoever wires the lane: that cross-check still asks the ENGINE
+    whether a worker is expected, and a static svelte site emits none. Once the lane
+    has a caller, it should ask ``resolve_emits_server_worker`` against the build dir
+    instead — the answer is a property of the artifact, not of the engine name."""
     try:
         snapshot = artifact_preview.safe_store_artifact(site_id, artifact, engine=engine)
         if snapshot is None:

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -2404,7 +2404,7 @@ async def _embed_concierge_bar(
     """
     try:
         from pocketpaw_ee.paw_bar import embed
-        from pocketpaw_ee.sites.engines import static_output_rel
+        from pocketpaw_ee.sites.engines import resolve_static_output_rel
 
         doc = await _SiteDoc.find_one({"_id": ObjectId(site_id), "workspace": workspace_id})
         concierge_enabled = True if doc is None else bool(doc.concierge_enabled)
@@ -2457,8 +2457,11 @@ async def _embed_concierge_bar(
             return
 
         # HE-4: where the deployable pages live differs by engine — the SvelteKit
-        # adapter output for ripple/svelte, the project dir itself for html.
-        root = Path(project_dir, static_output_rel(engine))
+        # adapter output for ripple and dynamic svelte, ``build`` for a STATIC svelte
+        # site (SL-1, adapter-static), the project dir itself for html. Resolved off
+        # the artifact because the svelte answer is a property of the site, not the
+        # engine name — and injecting into the wrong root silently embeds nothing.
+        root = Path(project_dir, resolve_static_output_rel(project_dir, engine))
         changed = embed.inject_into_tree(root, snippet)
         logger.info(
             "sites: embedded the concierge bar into %d page(s) of site %s",

--- a/ee/pocketpaw_ee/sites/workers_deploy.py
+++ b/ee/pocketpaw_ee/sites/workers_deploy.py
@@ -81,7 +81,10 @@ from pathlib import Path
 
 from pocketpaw_ee.cloud._core.errors import Internal, ValidationError
 from pocketpaw_ee.sites._wrangler import wrangler_argv as _wrangler_argv
-from pocketpaw_ee.sites.engines import emits_server_worker, static_output_rel
+from pocketpaw_ee.sites.engines import (
+    resolve_emits_server_worker,
+    resolve_static_output_rel,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -159,21 +162,29 @@ def _worker_name(site_id: str) -> str:
     return f"paw-site-{_sanitize(site_id)}"
 
 
-def _wrangler_jsonc(name: str, engine: str = "ripple", d1_database_id: str | None = None) -> str:
+def _wrangler_jsonc(
+    name: str,
+    engine: str = "ripple",
+    d1_database_id: str | None = None,
+    *,
+    project_dir: str | os.PathLike[str],
+) -> str:
     """The clean wrangler config for a workers.dev deploy (the proven recipe).
 
-    HE-4 — the config is ENGINE-AWARE. RX-1 — it keys on ``emits_server_worker``,
-    NOT ``needs_node_build``:
+    HE-4 — the config is ENGINE-AWARE. RX-1 — it keys on whether a server entry was
+    emitted, NOT on ``needs_node_build``. SL-1 — it now asks that of the ARTIFACT
+    (``resolve_emits_server_worker``) rather than of the engine name, because a static
+    svelte site emits no worker while a dynamic one does:
 
-    * html / react (``not emits_server_worker``) → an ASSETS-ONLY Worker. The build
-      output is a static tree with no ``_worker.js``, so the config drops ``main``
-      and ``nodejs_compat`` and just serves ``assets.directory``
-      (``static_output_rel`` → ``"."`` for html, ``"dist"`` for react). An
+    * html / react / STATIC svelte (no worker emitted) → an ASSETS-ONLY Worker. The
+      build output is a static tree with no ``_worker.js``, so the config drops
+      ``main`` and ``nodejs_compat`` and just serves ``assets.directory``
+      (``"."`` for html, ``"dist"`` for react, ``build`` for static svelte). An
       assets-only Worker with no ``main`` is legal — ``assets.directory`` is the only
       required key — and it ships ZERO bytes of JavaScript for a form-less brochure.
-    * ripple / svelte (``emits_server_worker``) → the SvelteKit Cloudflare worker,
+    * ripple / DYNAMIC svelte (worker emitted) → the SvelteKit Cloudflare worker,
       UNCHANGED. ``main`` points at the worker entry adapter-cloudflare emits INSIDE
-      the asset dir (``static_output_rel`` → ``.svelte-kit/cloudflare``), and
+      the asset dir (``.svelte-kit/cloudflare``), and
       ``assets.directory`` points at that SAME dir (the ``.assetsignore`` we write
       keeps wrangler from uploading the worker entry as an asset). ``nodejs_compat``
       is what the SvelteKit worker needs at runtime.
@@ -199,12 +210,18 @@ def _wrangler_jsonc(name: str, engine: str = "ripple", d1_database_id: str | Non
     gracefully on a missing binding (``api/submit`` forwards straight to the capture
     API; ``writeback.ts`` warns and skips), so omitting them costs durability
     buffering, never a dropped lead."""
-    output_rel = static_output_rel(engine)
-    # html / react: an assets-only Worker — no server script, so no ``main`` /
-    # ``nodejs_compat`` and no D1 (dynamic sites on these tracks are out of scope,
-    # since neither has a server runtime to read a binding). Just serve the static
-    # tree the build left behind.
-    if not emits_server_worker(engine):
+    # SL-1 — ``project_dir`` is REQUIRED and keyword-only rather than defaulted. Both
+    # facts below are now properties of the emitted artifact, not of the engine string
+    # (a static svelte site has no worker and a different output dir), so a default
+    # would let a caller silently get the pre-SL-1 answer. Keyword-only because it is
+    # not the subject of this function — the name is — and a positional would read as
+    # the output path rather than the project root.
+    output_rel = resolve_static_output_rel(project_dir, engine)
+    # html / react — and, since SL-1, a STATIC svelte site: an assets-only Worker. No
+    # server script, so no ``main`` / ``nodejs_compat`` and no D1 (a site with no
+    # server runtime has nothing to read a binding). Just serve the static tree the
+    # build left behind.
+    if not resolve_emits_server_worker(project_dir, engine):
         config: dict[str, object] = {
             "name": name,
             "compatibility_date": "2024-09-23",
@@ -260,21 +277,29 @@ def _write_deploy_files(
     dir + the clean ``wrangler.jsonc`` at the project root. Both are overwritten on a
     re-publish so a stale config can never linger.
 
-    HE-4 — engine-aware. The asset dir is ``static_output_rel(engine)``
-    (``.svelte-kit/cloudflare`` for ripple/svelte, ``"."`` for html, ``"dist"`` for
-    react). The ``.assetsignore`` differs by whether the engine emits a server entry
-    (RX-1 — ``emits_server_worker``, not ``needs_node_build``):
+    HE-4 — engine-aware. SL-1 — ARTIFACT-aware: the asset dir is
+    ``resolve_static_output_rel(project_dir, engine)`` (``.svelte-kit/cloudflare`` for
+    ripple and dynamic svelte, ``build`` for static svelte, ``"."`` for html, ``"dist"``
+    for react). The ``.assetsignore`` differs by whether a server entry was actually
+    emitted (RX-1 — not ``needs_node_build``; SL-1 — resolved, not predicted):
 
-    * ripple/svelte → drops the Pages worker entry (``_worker.js`` + friends) so
-      wrangler does not upload the server entry as a static asset.
-    * html/react → there is no server entry to hide; what must not be served is the
+    * ripple / dynamic svelte → drops the Pages worker entry (``_worker.js`` + friends)
+      so wrangler does not upload the server entry as a static asset.
+    * html / react / static svelte → there is no server entry to hide; what must not be
+      served is the
       deploy scaffold itself (``wrangler.jsonc`` + ``.assetsignore``). For html the
       asset dir IS the project root, so both files sit in it; for react only
       ``.assetsignore`` does, and naming the other is a harmless no-op.
 
     ``d1_database_id`` adds the dynamic site's D1 binding to the emitted config
     (ripple/svelte only)."""
-    output_rel = static_output_rel(engine)
+    # SL-1 — RESOLVED against the artifact, not predicted from the engine name. A
+    # static svelte site builds on adapter-static: its output is ``build`` and it emits
+    # no ``_worker.js``, so it must deploy assets-only exactly as react does. Answering
+    # either question from ``engine`` alone would point ``main`` at a nonexistent
+    # ``build/_worker.js`` AND pick the server-entry .assetsignore — a failed deploy,
+    # which is the same class of bug RX-1 added ``emits_server_worker`` to prevent.
+    output_rel = resolve_static_output_rel(project_dir, engine)
     out_dir = Path(project_dir, output_rel)
     if not out_dir.is_dir():
         # The static output must exist before this runs — generator.build() emits it.
@@ -284,10 +309,14 @@ def _write_deploy_files(
             "The static build output is missing — the site must be built before a workers deploy.",
         )
     ignore_lines = (
-        _ASSETSIGNORE_LINES if emits_server_worker(engine) else _ASSETS_ONLY_ASSETSIGNORE_LINES
+        _ASSETSIGNORE_LINES
+        if resolve_emits_server_worker(project_dir, engine)
+        else _ASSETS_ONLY_ASSETSIGNORE_LINES
     )
     (out_dir / ".assetsignore").write_text("\n".join(ignore_lines) + "\n")
-    Path(project_dir, _CONFIG_FILENAME).write_text(_wrangler_jsonc(name, engine, d1_database_id))
+    Path(project_dir, _CONFIG_FILENAME).write_text(
+        _wrangler_jsonc(name, engine, d1_database_id, project_dir=project_dir)
+    )
 
 
 def _cf_env() -> dict[str, str]:
@@ -323,7 +352,8 @@ async def deploy_workers(
     provision job does both before calling this.
 
     The project MUST already carry the engine's static output
-    (``static_output_rel(engine)`` — generator.build() emits it before this is called).
+    (``resolve_static_output_rel(project_dir, engine)`` — generator.build() emits it
+    before this is called, which is what makes resolving it off disk possible).
     On a non-zero wrangler exit this raises ``Internal`` with the stderr tail so the
     failure surfaces as a clean 5xx envelope, not an opaque crash."""
     name = _worker_name(site_id)

--- a/tests/ee/sites/test_engines.py
+++ b/tests/ee/sites/test_engines.py
@@ -131,9 +131,7 @@ class TestResolveStaticOutputRel:
 
     def test_dynamic_svelte_resolves_to_the_adapter_cloudflare_tree(self, tmp_path) -> None:
         (tmp_path / ".svelte-kit" / "cloudflare").mkdir(parents=True)
-        assert (
-            engines.resolve_static_output_rel(tmp_path, "svelte") == ".svelte-kit/cloudflare"
-        )
+        assert engines.resolve_static_output_rel(tmp_path, "svelte") == ".svelte-kit/cloudflare"
 
     def test_build_wins_when_both_exist(self, tmp_path) -> None:
         # THE ORDER TEST. A project dir that has been built before AND after SL-1
@@ -147,9 +145,7 @@ class TestResolveStaticOutputRel:
     def test_neither_present_falls_back_to_the_nominal_value(self, tmp_path) -> None:
         # Total, never raising — the caller then reports a missing build against a
         # concrete path, which is a truer error than the predicate refusing to decide.
-        assert (
-            engines.resolve_static_output_rel(tmp_path, "svelte") == ".svelte-kit/cloudflare"
-        )
+        assert engines.resolve_static_output_rel(tmp_path, "svelte") == ".svelte-kit/cloudflare"
 
     @pytest.mark.parametrize(
         ("engine", "expected"),

--- a/tests/ee/sites/test_engines.py
+++ b/tests/ee/sites/test_engines.py
@@ -5,6 +5,24 @@
 # html) plus the empty / missing / unknown-engine fallback contract that the
 # scattered ``pocket.get("engine") or "ripple"`` call sites relied on.
 #
+# Edited 2026-08-10 (SL-1 — the static svelte landing lane): added
+# TestResolveStaticOutputRel + TestResolveEmitsServerWorker for the two new
+# artifact-resolving predicates. These use REAL tmp_path dirs rather than mocks,
+# because reading the filesystem is the entire behaviour under test — a mocked
+# filesystem here would test the mock.
+#
+# Two cases carry most of the weight. `test_build_wins_when_both_exist` pins the probe
+# ORDER, so a project dir built both before and after SL-1 cannot have its stale
+# adapter-cloudflare tree shadow the current build. `test_a_worker_DIRECTORY_still_counts`
+# pins existence-over-is_file, because adapter-cloudflare emits `_worker.js` as a
+# DIRECTORY once an app is large enough — an is_file() check would report "no worker"
+# for a big dynamic site and deploy it assets-only, replacing a working site with a
+# broken one.
+#
+# Mutation-verified: tests/mutations/sites_sl1_resolvers.json, 5/5 caught. This suite
+# is also the deterministic gate for SL-1, because tests/ee/sites at large is ~89 red
+# and order-dependent on dev independently of this change.
+#
 # Edited 2026-08-07 (RX-1 — the react engine): added react to every predicate's
 # coverage and to the fallback parametrizations, plus a class for the new fifth
 # predicate ``emits_server_worker``. The load-bearing new case is react's
@@ -99,6 +117,103 @@ class TestStaticOutputRel:
     @pytest.mark.parametrize("value", [None, "", "unknown"])
     def test_default_output_matches_ripple(self, value: str | None) -> None:
         assert engines.static_output_rel(value) == ".svelte-kit/cloudflare"
+
+
+class TestResolveStaticOutputRel:
+    """SL-1 — the svelte track spans two adapters, so the output dir is a fact about
+    the ARTIFACT rather than about the engine string. These are deliberately real
+    temp dirs: the whole point of the resolver is that it reads the filesystem, so a
+    mocked one would test the mock."""
+
+    def test_static_svelte_resolves_to_build(self, tmp_path) -> None:
+        (tmp_path / "build").mkdir()
+        assert engines.resolve_static_output_rel(tmp_path, "svelte") == "build"
+
+    def test_dynamic_svelte_resolves_to_the_adapter_cloudflare_tree(self, tmp_path) -> None:
+        (tmp_path / ".svelte-kit" / "cloudflare").mkdir(parents=True)
+        assert (
+            engines.resolve_static_output_rel(tmp_path, "svelte") == ".svelte-kit/cloudflare"
+        )
+
+    def test_build_wins_when_both_exist(self, tmp_path) -> None:
+        # THE ORDER TEST. A project dir that has been built before AND after SL-1
+        # carries both trees; the stale adapter-cloudflare one must not shadow the
+        # current build. Reversing the probe order silently serves the old artifact,
+        # which is the failure this asserts against.
+        (tmp_path / "build").mkdir()
+        (tmp_path / ".svelte-kit" / "cloudflare").mkdir(parents=True)
+        assert engines.resolve_static_output_rel(tmp_path, "svelte") == "build"
+
+    def test_neither_present_falls_back_to_the_nominal_value(self, tmp_path) -> None:
+        # Total, never raising — the caller then reports a missing build against a
+        # concrete path, which is a truer error than the predicate refusing to decide.
+        assert (
+            engines.resolve_static_output_rel(tmp_path, "svelte") == ".svelte-kit/cloudflare"
+        )
+
+    @pytest.mark.parametrize(
+        ("engine", "expected"),
+        [("ripple", ".svelte-kit/cloudflare"), ("html", "."), ("react", "dist")],
+    )
+    def test_non_svelte_engines_ignore_the_filesystem(
+        self, tmp_path, engine: str, expected: str
+    ) -> None:
+        # A decoy `build/` dir is present for every one of them. Only svelte probes,
+        # so ripple/html/react must return their nominal value regardless — otherwise
+        # this change would silently repoint react and html deploys too.
+        (tmp_path / "build").mkdir()
+        assert engines.resolve_static_output_rel(tmp_path, engine) == expected
+
+    def test_accepts_a_str_path(self, tmp_path) -> None:
+        # Call sites pass both str and Path (``build.project_dir`` is a str).
+        (tmp_path / "build").mkdir()
+        assert engines.resolve_static_output_rel(str(tmp_path), "svelte") == "build"
+
+
+class TestResolveEmitsServerWorker:
+    """The deploy-shape half. Getting this wrong points ``main`` at a worker that does
+    not exist, which fails the deploy outright."""
+
+    def test_static_svelte_emits_no_worker(self, tmp_path) -> None:
+        (tmp_path / "build").mkdir()
+        assert engines.resolve_emits_server_worker(tmp_path, "svelte") is False
+
+    def test_dynamic_svelte_emits_a_worker(self, tmp_path) -> None:
+        out = tmp_path / ".svelte-kit" / "cloudflare"
+        out.mkdir(parents=True)
+        (out / "_worker.js").write_text("export default {}")
+        assert engines.resolve_emits_server_worker(tmp_path, "svelte") is True
+
+    def test_a_worker_DIRECTORY_still_counts(self, tmp_path) -> None:
+        # adapter-cloudflare emits _worker.js as a DIRECTORY once an app is large
+        # enough (_worker.js/chunks/0.js). An is_file() check would report "no worker"
+        # for a big dynamic site and deploy it assets-only — replacing a working site
+        # with a broken one. This is the mutation that must not escape.
+        out = tmp_path / ".svelte-kit" / "cloudflare"
+        (out / "_worker.js" / "chunks").mkdir(parents=True)
+        (out / "_worker.js" / "chunks" / "0.js").write_text("//")
+        assert engines.resolve_emits_server_worker(tmp_path, "svelte") is True
+
+    def test_ripple_with_a_worker_is_unchanged(self, tmp_path) -> None:
+        out = tmp_path / ".svelte-kit" / "cloudflare"
+        out.mkdir(parents=True)
+        (out / "_worker.js").write_text("export default {}")
+        assert engines.resolve_emits_server_worker(tmp_path, "ripple") is True
+
+    @pytest.mark.parametrize("engine", ["html", "react"])
+    def test_serverless_engines_short_circuit(self, tmp_path, engine: str) -> None:
+        # Never a worker on these tracks, even if a stray _worker.js is lying around —
+        # the engine-level answer is authoritative for them and must not be overridden
+        # by a file that cannot be theirs.
+        (tmp_path / "dist").mkdir()
+        (tmp_path / "dist" / "_worker.js").write_text("stray")
+        (tmp_path / "_worker.js").write_text("stray")
+        assert engines.resolve_emits_server_worker(tmp_path, engine) is False
+
+    def test_missing_output_dir_reports_no_worker(self, tmp_path) -> None:
+        # Nothing built yet: no worker is the honest answer, and the caller's own
+        # missing-build check is what turns this into an error.
+        assert engines.resolve_emits_server_worker(tmp_path, "svelte") is False
 
 
 class TestNormalizeEngine:

--- a/tests/mutations/sites_sl1_resolvers.json
+++ b/tests/mutations/sites_sl1_resolvers.json
@@ -1,0 +1,37 @@
+[
+  {
+    "label": "probe order reversed — a stale adapter-cloudflare tree shadows the current build",
+    "file": "ee/pocketpaw_ee/sites/engines.py",
+    "find": "for candidate in (_SVELTE_STATIC_OUTPUT_REL, _STATIC_OUTPUT_REL[\"svelte\"]):",
+    "replace": "for candidate in (_STATIC_OUTPUT_REL[\"svelte\"], _SVELTE_STATIC_OUTPUT_REL):",
+    "tests": ["tests/ee/sites/test_engines.py::TestResolveStaticOutputRel"]
+  },
+  {
+    "label": "_worker.js tested with is_file() — a worker DIRECTORY reads as no worker",
+    "file": "ee/pocketpaw_ee/sites/engines.py",
+    "find": "return (out_dir / \"_worker.js\").exists()",
+    "replace": "return (out_dir / \"_worker.js\").is_file()",
+    "tests": ["tests/ee/sites/test_engines.py::TestResolveEmitsServerWorker"]
+  },
+  {
+    "label": "svelte-only guard defeated — ripple/html/react start probing the filesystem too",
+    "file": "ee/pocketpaw_ee/sites/engines.py",
+    "find": "    if normalized != \"svelte\":",
+    "replace": "    if normalized != \"svelte\" and False:",
+    "tests": ["tests/ee/sites/test_engines.py::TestResolveStaticOutputRel"]
+  },
+  {
+    "label": "server-worker engine guard defeated — html/react consult a stray _worker.js",
+    "file": "ee/pocketpaw_ee/sites/engines.py",
+    "find": "    if normalize_engine(engine) not in _SERVER_WORKER_ENGINES:",
+    "replace": "    if normalize_engine(engine) not in _SERVER_WORKER_ENGINES and False:",
+    "tests": ["tests/ee/sites/test_engines.py::TestResolveEmitsServerWorker"]
+  },
+  {
+    "label": "static svelte reports the dynamic dir — the deploy uploads an empty tree",
+    "file": "ee/pocketpaw_ee/sites/engines.py",
+    "find": "_SVELTE_STATIC_OUTPUT_REL = \"build\"",
+    "replace": "_SVELTE_STATIC_OUTPUT_REL = \".svelte-kit/cloudflare\"",
+    "tests": ["tests/ee/sites/test_engines.py"]
+  }
+]


### PR DESCRIPTION
Companion to **qbtrix/paw-sites#45**. Neither should merge without the other.

paw-sites now builds a static svelte landing site on `adapter-static` — output `build`,
no `_worker.js`. Without this change pocketpaw keeps reading `.svelte-kit/cloudflare/`
and live svelte publishing breaks.

## Why the engine name stopped being enough

`static_output_rel` and `emits_server_worker` answer from the engine string. That worked
because each engine had exactly one output shape. The svelte track now has two, chosen
by a property of the **site** rather than the engine:

| | static landing | dynamic / auth |
|---|---|---|
| adapter | `adapter-static` | `adapter-cloudflare` |
| output | `build` | `.svelte-kit/cloudflare` |
| `_worker.js` | none | emitted, load-bearing |

So this is the first capability in `engines.py` that is not a function of the engine
name. Two artifact-resolving siblings are added, following RX-1's design rather than
departing from it — a new combination adds a predicate instead of overloading one:

```
resolve_static_output_rel(project_dir, engine)
resolve_emits_server_worker(project_dir, engine)
```

## The second one is the one with teeth

`emits_server_worker("svelte")` still returns True. Left alone, `workers_deploy` would
point `main` at a `build/_worker.js` that does not exist **and** pick the server-entry
`.assetsignore` over the assets-only one. That fails the deploy outright — the same
class of bug RX-1 introduced that predicate to prevent, reopened from the other side. A
static svelte site has to deploy assets-only, exactly as react already does.

## Details that are easy to get wrong

**Only svelte probes.** ripple / html / react each still have one output shape and fall
straight through the existing map, so their behaviour is unchanged. A test asserts this
with a decoy `build/` dir present for all three.

**Probe order is `build` first.** A project dir built both before and after SL-1 carries
both trees, and PERF-3 keeps per-pocket build dirs around for exactly that long.
Reversing the order silently serves the stale artifact.

**`_worker.js` is tested for existence, not `is_file`.** adapter-cloudflare emits it as a
*directory* (`_worker.js/chunks/0.js`) once an app is large enough. An `is_file()` check
would report "no worker" for a big dynamic site and deploy it assets-only — replacing a
working site with a broken one.

**`_wrangler_jsonc` takes `project_dir` as a required keyword-only argument.** Not
defaulted: a default would let a caller silently receive the pre-SL-1 answer. Keyword-only
because a positional would read as the output path rather than the project root.

## Call sites

Migrated: `workers_deploy` (config shape + deploy files), `service` (concierge embed
root), `local_server` (`persist_site` + `deploy_local`), `draft_markup` (both).

`draft_markup._pocket_static_dir` is the one that most needs the probe — it rebuilds a
path from a pocket id with no generate in scope, so there is no generator result to read
a reported `staticDir` from.

`generator_client`'s remaining nominal call is left as-is deliberately, with a comment:
that branch is reached only when `not needs_node_build(engine)`, i.e. html, whose output
dir has one shape.

## Why these two read the filesystem

They are the only functions in `engines.py` that do, and the exception is deliberate. The
alternative was threading a static/dynamic flag through all six call sites, two of which
have no generate in scope to thread it from. That creates a second source of truth which
can disagree with the artifact on disk. Reading the artifact cannot.

paw-sites#45 also makes the generator report `staticDir`, which is the better long-term
seam for callers that *do* have a generator result in hand.

## Verification

```
tests/ee/sites/test_engines.py                     68 passed   1.7s
tests/mutations/sites_sl1_resolvers.json           5/5 caught  exit 0
ruff check ee/pocketpaw_ee/sites tests/…/test_engines.py       clean
```

The five mutations: probe order reversed, `exists()` → `is_file()`, the svelte-only
guard defeated, the server-worker engine guard defeated, and the static dir pointed back
at the dynamic one. Each was observed to fail the suite before being restored.

**Read this before trusting a green tick here.** `tests/ee/sites` at large is already
**~89 failing and order-dependent on `dev`**, before this branch. The full run and an
isolated run of `test_concierge_autoembed.py` fail *different* tests (`pocket-1 not
found`). A failure-name diff against the dev baseline shows **zero tests newly broken**
(89 failed / 511 passed on dev → 88 failed / 527 passed here), but that comparison is
weakened by the flakiness, which is exactly why the resolvers carry their own
deterministic suite and mutation plan.

One name did appear in the diff, `test_dev_server.py::test_touch_bumps_activity`, and it
is flaky rather than a regression: three isolated runs of identical code gave pass, fail,
pass. It sleeps 10ms and asserts a strictly-greater timestamp, while the Windows timer
granularity is ~15.6ms. `dev_server.py` is not in this diff.

That red suite is worth its own issue; it is not this PR's to fix.
