### PR TITLE
Give a finished build somewhere to record its outcome

### DIFF
--- a/ee/pocketpaw_ee/cloud/models/site.py
+++ b/ee/pocketpaw_ee/cloud/models/site.py
@@ -269,6 +269,24 @@ class Site(TimestampedDocument):
     # on reload a transient id is gone, so the client loses its polling handle at the
     # precise moment the wait is longest.
     build_job_id: str | None = None
+    # SL-2: WHY the build reached ``build_status``. The rung name from
+    # ``daytona_build.classify_build`` — ``build_failed`` / ``timed_out`` /
+    # ``infra_lost`` / ``completed_ok`` — plus, for a user-blamed failure, the short
+    # cause the classifier extracted.
+    #
+    # THIS FIELD IS WHAT MAKES A TERMINAL FAILURE HONEST. Without it every
+    # classification the lane computes dies at the boundary: the row can say ``failed``
+    # and nothing can say whether the user's code broke or we lost the container. Those
+    # two need OPPOSITE handling — one is the user's to fix, the other is ours to retry
+    # — so a ``failed`` with no reason is not a smaller error, it is an unactionable
+    # one, and the fallback ("your build failed") is exactly the mis-report the whole
+    # sentinel design exists to prevent.
+    #
+    # SAFE TO SURFACE. It carries a fixed rung name, never raw stderr: a build's error
+    # text is the user's own code and can contain anything, including a token pasted
+    # into a config. The stderr tail stays in logs. Same reasoning as
+    # ``jobs/worker.py``'s ``_safe_failure_message``.
+    build_reason: str | None = None
     # BC-9: per-site annual plan (the Webflow model — each published site has its
     # OWN recurring annual plan on a tier, distinct from the workspace plan).
     # ``plan_tier`` is the site-plan catalog key (basic | pro | business — see

--- a/ee/pocketpaw_ee/sites/build_state.py
+++ b/ee/pocketpaw_ee/sites/build_state.py
@@ -6,6 +6,14 @@
 # where a build got to, and a guard that stops two publishes of the same site racing
 # into two sandboxes.
 #
+# Edited 2026-08-10 (SL-2 — the captain ruled Daytona is ALWAYS the build host, which
+# supersedes the SG-12 verdict's "do not wire it yet"): added :func:`settle`, the
+# missing half of this module. It could say whether to START a build and not what to
+# write when one ENDED, so every classification ``daytona_build.classify_build``
+# computed died at the boundary. The paired field is ``Site.build_reason``, which
+# carries the rung name — a terminal ``failed`` with no reason cannot distinguish "the
+# user's code broke" from "we lost the container", and those need opposite handling.
+#
 # MODELLED ON DP0-4 (``sites/service.py:_provisioning_is_stale``) because that pattern
 # already solved the hard half correctly: status alone is a ONE-WAY DOOR. A job that no
 # worker ever consumed, or that died before writing a terminal status, pins the row in
@@ -147,6 +155,43 @@ def is_in_flight(doc: Any) -> bool:
     return getattr(doc, "build_status", None) in IN_FLIGHT_STATUSES
 
 
+def settle(
+    outcome: str,
+    *,
+    retryable: bool,
+    attempts_left: int,
+) -> BuildStatus | None:
+    """The status one attempt's verdict should leave on the row — or ``None`` to retry.
+
+    SL-2. The missing half of this module: it could already say whether to START a build
+    and never what to write when one ENDS, so every classification the lane computed
+    died at the boundary.
+
+    ``None`` MEANS "STAY IN FLIGHT", and it is the whole reason this returns an optional
+    rather than a status. A retryable outcome with attempts left must NOT be written as
+    ``failed`` even briefly: ``should_enqueue`` treats a terminal status as free to
+    re-publish, so a transient ``failed`` between attempts is an invitation for a second
+    sandbox to start on top of the retry — two bills, two artifacts racing to deploy,
+    the exact case the single-flight guard exists to prevent.
+
+    THE ASYMMETRY IS DELIBERATE AND OPPOSITE TO ``build_is_stale``'s. There, an unknown
+    reads as stale (act) because a stuck guard is worse than a redundant build. Here, an
+    unrecognised outcome reads as ``failed`` (stop) because the alternative is retrying
+    something we cannot classify, forever, at one sandbox per attempt. Both pick the
+    direction whose worst case is bounded; they just point different ways.
+
+    ``attempts_left`` is what the caller has, not what it wishes it had: retry/backoff
+    does not exist in the lane yet, so today every caller passes 0 and a retryable
+    failure settles immediately. That is honest rather than aspirational — when an
+    attempt loop lands it passes a real number and this function needs no change.
+    """
+    if outcome == "completed_ok":
+        return "built"
+    if retryable and attempts_left > 0:
+        return None
+    return "failed"
+
+
 __all__ = [
     "IN_FLIGHT_STATUSES",
     "STALE_MARGIN",
@@ -154,6 +199,7 @@ __all__ = [
     "BuildStatus",
     "build_is_stale",
     "is_in_flight",
+    "settle",
     "should_enqueue",
     "stale_after",
 ]

--- a/tests/ee/sites/test_build_state.py
+++ b/tests/ee/sites/test_build_state.py
@@ -213,3 +213,60 @@ class TestTheWireCarriesTheState:
             "built",
             "failed",
         }
+
+
+class TestSettle:
+    """SL-2 — what one attempt's verdict writes to the row.
+
+    The load-bearing case is ``None``, not the happy path: a retryable failure with
+    attempts left must stay IN FLIGHT, because ``should_enqueue`` reads any terminal
+    status as free to re-publish. Writing ``failed`` between attempts invites a second
+    sandbox on top of the retry.
+    """
+
+    def test_success_settles_as_built(self) -> None:
+        assert bs.settle("completed_ok", retryable=False, attempts_left=0) == "built"
+
+    def test_a_user_build_failure_settles_as_failed(self) -> None:
+        assert bs.settle("build_failed", retryable=False, attempts_left=0) == "failed"
+
+    def test_a_retryable_failure_with_attempts_left_stays_in_flight(self) -> None:
+        # None, NOT "failed" — see the class docstring for why a transient terminal
+        # status is worse than staying in flight.
+        assert bs.settle("infra_lost", retryable=True, attempts_left=2) is None
+        assert bs.settle("timed_out", retryable=True, attempts_left=1) is None
+
+    def test_a_retryable_failure_with_no_attempts_left_settles_as_failed(self) -> None:
+        # Today's real path: no attempt loop exists, so every caller passes 0.
+        assert bs.settle("infra_lost", retryable=True, attempts_left=0) == "failed"
+        assert bs.settle("timed_out", retryable=True, attempts_left=0) == "failed"
+
+    def test_success_settles_even_with_attempts_left(self) -> None:
+        """A success must never be held open by a retry budget it does not need."""
+        assert bs.settle("completed_ok", retryable=True, attempts_left=5) == "built"
+
+    def test_an_unrecognised_outcome_settles_as_failed_rather_than_retrying(self) -> None:
+        """The opposite asymmetry to ``build_is_stale``, and deliberately so: an
+        unknown status there reads as stale (act), because a stuck guard costs every
+        future publish. Here an unknown outcome stops, because retrying something we
+        cannot classify costs one sandbox per attempt without bound."""
+        assert bs.settle("who_knows", retryable=False, attempts_left=0) == "failed"
+        assert bs.settle("", retryable=False, attempts_left=3) == "failed"
+
+    def test_every_settled_status_is_terminal(self) -> None:
+        """The invariant tying this to the rest of the module: settle must never leave a
+        row in an IN_FLIGHT status, or the build is finished and the guard still blocks."""
+        for outcome in ("completed_ok", "build_failed", "timed_out", "infra_lost", "??"):
+            for retryable in (True, False):
+                got = bs.settle(outcome, retryable=retryable, attempts_left=0)
+                assert got is not None
+                assert got in bs.TERMINAL_STATUSES, (outcome, retryable, got)
+
+    def test_the_reason_field_exists_to_carry_the_rung(self) -> None:
+        """``settle`` names the status; the rung name rides ``build_reason``. Without
+        that field a terminal failure cannot say whether the user's code broke or we
+        lost the container — the two need opposite handling."""
+        from pocketpaw_ee.cloud.models.site import Site
+
+        assert "build_reason" in Site.model_fields
+        assert Site.model_fields["build_reason"].default is None

--- a/tests/mutations/build_state.json
+++ b/tests/mutations/build_state.json
@@ -4,55 +4,98 @@
     "file": "ee/pocketpaw_ee/sites/build_state.py",
     "find": "    if stamp is None:\n        return True",
     "replace": "    if stamp is None:\n        return False",
-    "tests": ["tests/ee/sites/test_build_state.py"]
+    "tests": [
+      "tests/ee/sites/test_build_state.py"
+    ]
   },
   {
     "label": "the staleness window becomes a constant again, so a healthy long build gets a second sandbox enqueued on top of it",
     "file": "ee/pocketpaw_ee/sites/build_state.py",
     "find": "    return timedelta(seconds=max(0, timeout_seconds)) + STALE_MARGIN",
     "replace": "    return STALE_MARGIN",
-    "tests": ["tests/ee/sites/test_build_state.py"]
+    "tests": [
+      "tests/ee/sites/test_build_state.py"
+    ]
   },
   {
     "label": "a non-positive timeout yields a zero window, so every in-flight build reads as stale and the guard stops guarding",
     "file": "ee/pocketpaw_ee/sites/build_state.py",
     "find": "    return timedelta(seconds=max(0, timeout_seconds)) + STALE_MARGIN",
     "replace": "    return timedelta(seconds=timeout_seconds)",
-    "tests": ["tests/ee/sites/test_build_state.py"]
+    "tests": [
+      "tests/ee/sites/test_build_state.py"
+    ]
   },
   {
     "label": "queued stops counting as in-flight, so a publish waiting behind the cap enqueues a second build and spends twice",
     "file": "ee/pocketpaw_ee/sites/build_state.py",
     "find": "IN_FLIGHT_STATUSES: frozenset[str] = frozenset({\"queued\", \"building\"})",
     "replace": "IN_FLIGHT_STATUSES: frozenset[str] = frozenset({\"building\"})",
-    "tests": ["tests/ee/sites/test_build_state.py"]
+    "tests": [
+      "tests/ee/sites/test_build_state.py"
+    ]
   },
   {
     "label": "a terminal 'failed' status blocks a new build, so one bad build wedges the site until someone edits the database",
     "file": "ee/pocketpaw_ee/sites/build_state.py",
     "find": "    if status not in IN_FLIGHT_STATUSES:\n        return True",
     "replace": "    if status in TERMINAL_STATUSES and status != \"failed\":\n        return True",
-    "tests": ["tests/ee/sites/test_build_state.py"]
+    "tests": [
+      "tests/ee/sites/test_build_state.py"
+    ]
   },
   {
     "label": "a naive datetime is rejected as unreadable, so every row from an older writer looks stale and the guard silently stops blocking",
     "file": "ee/pocketpaw_ee/sites/build_state.py",
     "find": "    if value.tzinfo is None:\n        return value.replace(tzinfo=UTC)",
     "replace": "    if value.tzinfo is None:\n        return None",
-    "tests": ["tests/ee/sites/test_build_state.py"]
+    "tests": [
+      "tests/ee/sites/test_build_state.py"
+    ]
   },
   {
-    "label": "is_in_flight is aliased to the spend decision, so a stale row renders as idle to a viewer while a build may still be running",
+    "label": "is_in_flight is aliased to the spend decision, so a stale row renders as idle to a viewer while a build may still be running [anchor de-coupled from __all__ 2026-08-10: it pinned to the last function before __all__, and inserting settle() between them broke it]",
     "file": "ee/pocketpaw_ee/sites/build_state.py",
-    "find": "    return getattr(doc, \"build_status\", None) in IN_FLIGHT_STATUSES\n\n\n__all__",
-    "replace": "    return not should_enqueue(doc, 600)\n\n\n__all__",
-    "tests": ["tests/ee/sites/test_build_state.py"]
+    "find": "    return getattr(doc, \"build_status\", None) in IN_FLIGHT_STATUSES",
+    "replace": "    return not should_enqueue(doc, 600)",
+    "tests": [
+      "tests/ee/sites/test_build_state.py"
+    ]
   },
   {
     "label": "build_job_id becomes transient like DP0-4's, so a client that reloads during a queued build loses its polling handle",
     "file": "ee/pocketpaw_ee/cloud/models/site.py",
     "find": "    build_job_id: str | None = None",
     "replace": "    _build_job_id: str | None = PrivateAttr(default=None)",
-    "tests": ["tests/ee/sites/test_build_state.py"]
+    "tests": [
+      "tests/ee/sites/test_build_state.py"
+    ]
+  },
+  {
+    "label": "SL-2: a SUCCESSFUL build settles as failed, so a working site reports broken",
+    "file": "ee/pocketpaw_ee/sites/build_state.py",
+    "find": "    if outcome == \"completed_ok\":\n        return \"built\"",
+    "replace": "    if outcome == \"completed_ok\":\n        return \"failed\"",
+    "tests": [
+      "tests/ee/sites/test_build_state.py::TestSettle"
+    ]
+  },
+  {
+    "label": "SL-2: the attempts-left guard is dropped, so a retryable failure NEVER settles and the row is stuck in flight forever \u2014 permanently unpublishable with no error to see",
+    "file": "ee/pocketpaw_ee/sites/build_state.py",
+    "find": "    if retryable and attempts_left > 0:\n        return None",
+    "replace": "    if retryable:\n        return None",
+    "tests": [
+      "tests/ee/sites/test_build_state.py::TestSettle"
+    ]
+  },
+  {
+    "label": "SL-2: a retryable failure settles immediately even with attempts left, so a transient infra loss becomes terminal and the retry budget is dead code",
+    "file": "ee/pocketpaw_ee/sites/build_state.py",
+    "find": "    if retryable and attempts_left > 0:\n        return None\n    return \"failed\"",
+    "replace": "    if retryable and attempts_left > 0:\n        pass\n    return \"failed\"",
+    "tests": [
+      "tests/ee/sites/test_build_state.py::TestSettle"
+    ]
   }
 ]


### PR DESCRIPTION
First slice of wiring the async publish path, on the captain's ruling that **Daytona is
always the build host** — which supersedes the SG-12 verdict's "do not wire it yet" and
turns that verdict's four blockers into real work.

This is blocker 4: nothing wrote `build_status`, and there was no `build_reason` field, so
every classification `classify_build` computed died at the boundary.

## What's here

Two pieces, both **independent of the publish path**. Nothing calls them yet, and that is
deliberate — it keeps the first slice reviewable and keeps the live publish path untouched.

**`Site.build_reason`** — why the row reached its status. The rung name from
`classify_build`: `completed_ok` / `build_failed` / `timed_out` / `infra_lost`.

A terminal `failed` with no reason is not a smaller error, it is an unactionable one. "The
user's code broke" and "we lost the container" need **opposite** handling — one is theirs
to fix, the other is ours to retry — and without this field the row cannot tell them
apart, so the fallback becomes "your build failed", which is the exact mis-report the
whole sentinel design exists to prevent.

It carries a **fixed rung name, never raw stderr**. A build's error text is the user's own
code and can contain anything, including a token pasted into a config. The stderr tail
stays in logs. Same reasoning as `jobs/worker.py`'s `_safe_failure_message`.

**`build_state.settle(outcome, *, retryable, attempts_left)`** — what one attempt's
verdict writes to the row, or `None` to retry. The module could already say whether to
START a build and never what to write when one ENDED.

## Three decisions worth reviewing

**`None` means "stay in flight", which is why this returns an optional rather than a
status.** `should_enqueue` reads *any* terminal status as free to re-publish, so writing
`failed` between attempts is an invitation for a second sandbox to start on top of the
retry — two bills, two artifacts racing to deploy, precisely what the single-flight guard
exists to prevent.

**An unrecognised outcome settles as `failed`** — the *opposite* asymmetry to
`build_is_stale`, where an unknown reads as stale, i.e. act. Both pick the direction whose
worst case is bounded: a stuck guard costs the site every future publish, while retrying
something we cannot classify costs one sandbox per attempt without bound. They point
different ways for the same reason.

**`attempts_left` is what the caller has, not what it wishes it had.** No retry/backoff
loop exists in the lane yet, so today every caller passes `0` and a retryable failure
settles immediately. That is honest rather than aspirational — when an attempt loop lands
it passes a real number and this function needs no change.

## Verification

```
tests/ee/sites/test_build_state.py              41 passed
tests/mutations/build_state.json                11/11 caught, exit 0
ruff check / ruff format --check                clean
```

The invariant test is the one to read: `settle` must never leave a row in an `IN_FLIGHT`
status, or the build is finished and the guard still blocks.

## A mutation this change broke, and the trap behind it

One of those 11 was broken **by this commit** and is fixed here. The `is_in_flight`
mutation anchored on `...IN_FLIGHT_STATUSES\n\n\n__all__` — using the trailing `__all__`
to pin itself to the last function in the module. Adding `settle()` between them broke the
anchor.

`mutate.py` **aborts the whole plan on one unmatched `find`**, so a single stale anchor
silently disables every other mutation in the file, including the new ones. It exits 1 and
says so, but a caller that pipes through `tail` or joins with `;` will not see it.

Re-anchored on the bare line after checking it is unique. Worth knowing before anyone else
appends a function to a module that has a mutation plan.

## What this does NOT do

No arq job, no enqueue, no change to `publish`. The next slice is the job itself, and the
seam is now identified: `_runner.generate(input_json, out_dir)` is a pure scaffold step
(no install, no build), so the job generates, reads that dir into the
`{relative_path: contents}` map `run_build` takes, and settles the row from the result.

`BuildRunResult.ok` already implements the wiring contract correctly — `deployable AND
artifact_bytes > 0`, never `classification.deployable` alone — so that landmine is
already disarmed.

Still open from the verdict, and unaffected by this: the sandbox supply-chain posture
(the verdict's own "fix first"), stripping the signed key at the seam for ripple and
dynamic svelte, and closing the verification hole — whose fix is already written and
banked on `spike/sites-artifact-verification` (`c41229c1`).
