### PR TITLE
Give the build sandbox an install-time supply-chain floor

### DIFF
--- a/ee/pocketpaw_ee/sites/daytona_runner.py
+++ b/ee/pocketpaw_ee/sites/daytona_runner.py
@@ -7,6 +7,22 @@
 # to blame) is testable without a sandbox, and this part is testable with a fake
 # client.
 #
+# Edited 2026-08-10 (SL-3 — the install-time supply-chain floor): the upload step now
+# writes a ``bunfig.toml`` into the sandbox project (see :data:`SANDBOX_BUNFIG`).
+#
+# WHY IT BELONGS HERE rather than in the generated project or the image: this
+# workspace's install protections live in the DEVELOPER'S HOME DIR (``~/.npmrc``,
+# ``~/.bunfig.toml``) and are in no repo, so a fresh container inherited none of them.
+# The captain's ruling that Daytona is ALWAYS the build host is what turns that from a
+# footnote into the whole exposure — the build box was weaker than the runtime image
+# beside it. Injecting at this boundary means a template change cannot silently drop it,
+# and it keeps a build-host control out of the customer's source tree.
+#
+# NOT DONE, and deliberately not faked: ``--frozen-lockfile``. The generator emits no
+# lockfile — verified, nothing under paw-sites writes one — so the flag would fail every
+# build rather than harden it. Enforcing it needs a vetted lockfile for the allowlisted
+# dependency set, which is its own design and is recorded as owed rather than pretended.
+#
 # THE ORDER OF STEPS IS THE CONTRACT, not an implementation detail:
 #
 #   1. Our clock starts BEFORE ``create_sandbox``. It is the only timing signal that
@@ -125,6 +141,39 @@ SANDBOX_PROJECT_DIR = "/home/daytona/paw-build"
 #: accidentally pick them up.
 SANDBOX_WRAPPER_PATH = "/tmp/paw-build.sh"
 SANDBOX_ARTIFACT_PATH = "/tmp/paw-artifact.tgz"
+
+#: SL-3 — the install-time supply-chain floor, uploaded INTO the sandbox project.
+#:
+#: WHY THIS FILE HAS TO EXIST HERE AT ALL. This workspace's protections live in the
+#: DEVELOPER'S HOME DIR (``~/.npmrc``, ``~/.bunfig.toml``) and are not in any repo, so a
+#: fresh container inherits NONE of them: no release-age floor, no ``ignore-scripts``. A
+#: build box that resolves from the open registry with lifecycle scripts enabled is
+#: strictly weaker than the runtime image beside it, and once Daytona is the ONLY build
+#: host that inversion is the whole exposure rather than a note.
+#:
+#: ``minimumReleaseAge`` is the same 7-day floor the dev machines enforce, expressed in
+#: SECONDS because that is bun's unit — 604800. It is the control that would have caught
+#: a compromised fresh publish of an already-vetted package, which the allowlist cannot:
+#: the allowlist pins WHICH packages and a caret pin still floats the VERSION.
+#:
+#: ``ignore-scripts`` matters more here than on a laptop. A postinstall script in a build
+#: container runs with the sandbox's network and its filesystem, next to the artifact we
+#: are about to deploy. Nothing in the vetted set needs one.
+#:
+#: DELIBERATELY UPLOADED, NOT TEMPLATED INTO THE GENERATED PROJECT. Two reasons: it is a
+#: property of the BUILD HOST, not of the customer's site, so it has no business in their
+#: source tree; and injecting it at this boundary means a template change cannot silently
+#: drop it. It lands in the project dir because that is where bun looks.
+SANDBOX_BUNFIG_REL = "bunfig.toml"
+SANDBOX_BUNFIG = """# Written by pocketpaw's build lane — NOT part of your site's source.
+# Install-time supply-chain floor for this sandbox. See daytona_runner.SANDBOX_BUNFIG.
+[install]
+# 7 days, in seconds. Matches the floor the dev machines enforce via ~/.bunfig.toml.
+minimumReleaseAge = 604800
+# No lifecycle scripts. Nothing in the vetted dependency set needs one, and a
+# postinstall here would run beside the artifact we are about to deploy.
+ignoreScripts = true
+"""
 
 #: Seconds added to the in-sandbox timeout for our own ``execute_command`` budget.
 #: The inner ``timeout(1)`` should always fire first, because that path still runs the
@@ -285,6 +334,31 @@ async def run_build(
             )
             for rel, contents in files.items()
         ]
+        # SL-3 — the supply-chain floor. OURS WINS, and the conflict is resolved HERE
+        # rather than by upload ordering.
+        #
+        # ``bulk_upload`` hands the whole list to the Daytona SDK in ONE batch call, so
+        # which write survives for a duplicate destination is the SDK's business and is
+        # not specified by anything we control. Relying on "later overwrites earlier"
+        # would be a guess dressed as a guarantee, so the caller's copy is dropped
+        # explicitly instead — deterministic, and visible in the log when it happens.
+        #
+        # Ours wins because this is a FLOOR: a control the built project can override is
+        # not one. The trade is that a legitimate project-level bun setting would be
+        # discarded, which is why the drop is logged at WARNING rather than passed over in
+        # silence. No generated project emits a bunfig.toml today, so this is a guard
+        # against a future template or a hostile source map, not a live collision.
+        bunfig_dst = f"{SANDBOX_PROJECT_DIR}/{SANDBOX_BUNFIG_REL}"
+        displaced = [u for u in uploads if u[1] == bunfig_dst]
+        if displaced:
+            logger.warning(
+                "sites: dropped a project-supplied %s in favour of the lane's "
+                "supply-chain floor (sandbox %s)",
+                SANDBOX_BUNFIG_REL,
+                sandbox_id,
+            )
+            uploads = [u for u in uploads if u[1] != bunfig_dst]
+        uploads.append((SANDBOX_BUNFIG.encode(), bunfig_dst))
         uploads.append((wrapper.encode(), SANDBOX_WRAPPER_PATH))
         await client.bulk_upload(sandbox_id, uploads)
         t_uploaded = time.monotonic()

--- a/tests/ee/sites/test_daytona_runner.py
+++ b/tests/ee/sites/test_daytona_runner.py
@@ -281,3 +281,80 @@ class TestFailsBeforeSpendingMoney:
         with pytest.raises(ValueError, match="project root"):
             await dr.run_build(REACT_FILES, engine="html", timeout_seconds=600, client=c)
         assert c.calls == []
+
+
+class TestTheSupplyChainFloorReachesTheSandbox:
+    """SL-3. The workspace's install protections live in the DEVELOPER'S HOME DIR
+    (``~/.npmrc``, ``~/.bunfig.toml``) and are in no repo, so a fresh container inherits
+    none of them. Once Daytona is the only build host, that makes the build box weaker
+    than the runtime image beside it — these tests are what stop the floor being dropped
+    by a refactor nobody connects to supply chain.
+    """
+
+    async def test_a_bunfig_is_uploaded_into_the_project_dir(self) -> None:
+        c = FakeClient(sentinel=_ok_sentinel())
+        await dr.run_build(REACT_FILES, engine="react", timeout_seconds=600, client=c)
+        dests = [dest for _, dest in c.uploaded]
+        assert f"{dr.SANDBOX_PROJECT_DIR}/{dr.SANDBOX_BUNFIG_REL}" in dests
+
+    async def test_the_floor_carries_the_seven_day_release_age_and_no_scripts(self) -> None:
+        """The two controls, asserted on the BYTES that actually get uploaded rather
+        than on the constant, so a broken encode or a wrong destination still fails."""
+        c = FakeClient(sentinel=_ok_sentinel())
+        await dr.run_build(REACT_FILES, engine="react", timeout_seconds=600, client=c)
+        dst = f"{dr.SANDBOX_PROJECT_DIR}/{dr.SANDBOX_BUNFIG_REL}"
+        body = next(src for src, dest in c.uploaded if dest == dst)
+        text = body.decode() if isinstance(body, bytes) else body
+        # 604800 = 7 days in seconds, bun's unit. The number is asserted literally: a
+        # plausible-looking wrong value (a day, or minutes) is the failure mode here.
+        assert "minimumReleaseAge = 604800" in text
+        assert "ignoreScripts = true" in text
+        assert "[install]" in text
+
+    async def test_a_project_supplied_bunfig_is_dropped_so_the_floor_wins(self) -> None:
+        """A floor a built project can override is not a floor.
+
+        Resolved in our own code, NOT by upload ordering: bulk_upload hands the whole
+        list to the SDK in one batch, so which write survives a duplicate destination is
+        not ours to guarantee. Asserting exactly ONE bunfig destination is what proves
+        the resolution happened here.
+        """
+        hostile = dict(REACT_FILES)
+        hostile["bunfig.toml"] = "[install]\nminimumReleaseAge = 0\nignoreScripts = false\n"
+        c = FakeClient(sentinel=_ok_sentinel())
+        await dr.run_build(hostile, engine="react", timeout_seconds=600, client=c)
+
+        dst = f"{dr.SANDBOX_PROJECT_DIR}/{dr.SANDBOX_BUNFIG_REL}"
+        matching = [src for src, dest in c.uploaded if dest == dst]
+        assert len(matching) == 1, "the project's bunfig must be dropped, not merely lost a race"
+        text = matching[0].decode() if isinstance(matching[0], bytes) else matching[0]
+        assert "minimumReleaseAge = 604800" in text
+        assert "minimumReleaseAge = 0" not in text
+        assert "ignoreScripts = false" not in text
+
+    async def test_dropping_a_project_bunfig_is_logged_not_silent(self, caplog) -> None:
+        """The trade this makes is discarding a possibly-legitimate project setting, so
+        it must be visible. A silent override is the version of this that wastes an
+        afternoon when someone's bun config appears not to apply."""
+        import logging
+
+        hostile = dict(REACT_FILES)
+        hostile["bunfig.toml"] = "[install]\nminimumReleaseAge = 0\n"
+        c = FakeClient(sentinel=_ok_sentinel())
+        with caplog.at_level(logging.WARNING):
+            await dr.run_build(hostile, engine="react", timeout_seconds=600, client=c)
+        # getMessage(), not .message: the latter only exists once a formatter has run,
+        # so reading it here raises rather than failing the assertion it looks like.
+        assert any("bunfig.toml" in r.getMessage() for r in caplog.records)
+
+    async def test_the_floor_does_not_displace_the_project_or_the_wrapper(self) -> None:
+        """Adding an upload must not cost an existing one."""
+        c = FakeClient(sentinel=_ok_sentinel())
+        await dr.run_build(REACT_FILES, engine="react", timeout_seconds=600, client=c)
+        dests = [dest for _, dest in c.uploaded]
+        assert dr.SANDBOX_WRAPPER_PATH in dests
+        for rel in REACT_FILES:
+            assert f"{dr.SANDBOX_PROJECT_DIR}/{rel}" in dests
+        # No duplicate destinations at all — a batch upload with two writes to one path
+        # is ambiguous by construction.
+        assert len(dests) == len(set(dests))

--- a/tests/mutations/sites_supply_chain_floor.json
+++ b/tests/mutations/sites_supply_chain_floor.json
@@ -1,0 +1,37 @@
+[
+  {
+    "label": "SL-3: the release-age floor is removed, so a compromised fresh publish of an already-vetted package installs in the build container",
+    "file": "ee/pocketpaw_ee/sites/daytona_runner.py",
+    "find": "minimumReleaseAge = 604800",
+    "replace": "minimumReleaseAge = 0",
+    "tests": ["tests/ee/sites/test_daytona_runner.py::TestTheSupplyChainFloorReachesTheSandbox"]
+  },
+  {
+    "label": "SL-3: lifecycle scripts are re-enabled, so a postinstall runs with the sandbox's network and filesystem next to the artifact about to be deployed",
+    "file": "ee/pocketpaw_ee/sites/daytona_runner.py",
+    "find": "ignoreScripts = true",
+    "replace": "ignoreScripts = false",
+    "tests": ["tests/ee/sites/test_daytona_runner.py::TestTheSupplyChainFloorReachesTheSandbox"]
+  },
+  {
+    "label": "SL-3: a project-supplied bunfig is no longer dropped, so the floor's survival depends on the SDK's unspecified duplicate-destination ordering — a guess dressed as a guarantee",
+    "file": "ee/pocketpaw_ee/sites/daytona_runner.py",
+    "find": "            uploads = [u for u in uploads if u[1] != bunfig_dst]",
+    "replace": "            pass",
+    "tests": ["tests/ee/sites/test_daytona_runner.py::TestTheSupplyChainFloorReachesTheSandbox"]
+  },
+  {
+    "label": "SL-3: the floor is never uploaded at all, so the container installs with no release-age gate and scripts enabled",
+    "file": "ee/pocketpaw_ee/sites/daytona_runner.py",
+    "find": "        uploads.append((SANDBOX_BUNFIG.encode(), bunfig_dst))",
+    "replace": "        pass",
+    "tests": ["tests/ee/sites/test_daytona_runner.py::TestTheSupplyChainFloorReachesTheSandbox"]
+  },
+  {
+    "label": "SL-3: the drop happens silently, so someone whose project bun config appears not to apply has nothing in the log to explain it",
+    "file": "ee/pocketpaw_ee/sites/daytona_runner.py",
+    "find": "            logger.warning(\n                \"sites: dropped a project-supplied %s in favour of the lane's \"\n                \"supply-chain floor (sandbox %s)\",\n                SANDBOX_BUNFIG_REL,\n                sandbox_id,\n            )",
+    "replace": "            pass",
+    "tests": ["tests/ee/sites/test_daytona_runner.py::TestTheSupplyChainFloorReachesTheSandbox"]
+  }
+]


### PR DESCRIPTION
The SG-12 verdict's own "fix this first", now urgent because the captain ruled **Daytona
is always the build host**.

## The gap, verified not assumed

This workspace's install protections live in the **developer's home directory** —
`~/.npmrc`, `~/.bunfig.toml` — and are in **no repo**. I checked: neither file exists here.

So a fresh Daytona container inherited **none** of them. No release-age floor, no
`ignore-scripts`. The build box was strictly weaker than the runtime image sitting beside
it, and once every publish is a sandbox that inversion is the whole exposure rather than a
footnote.

## What lands

The upload step now writes a `bunfig.toml` into the sandbox project, carrying two controls:

| control | why |
|---|---|
| `minimumReleaseAge = 604800` | The same 7-day floor the dev machines enforce, in bun's unit. **This is the control the allowlist cannot provide:** the allowlist pins *which* packages, and a caret pin still floats the *version* — so a compromised fresh publish of an already-vetted package would install without it. |
| `ignoreScripts = true` | A postinstall in a build container runs with the sandbox's network and filesystem, beside the artifact we are about to deploy. Nothing in the vetted set needs one. |

**Injected at the upload boundary, not templated into the generated project.** Two
reasons: it is a property of the *build host*, not of the customer's site, so it has no
business in their source tree; and injecting here means a template change cannot silently
drop it.

## Ours wins, and the conflict is resolved in our code

`bulk_upload` hands the whole list to the Daytona SDK in **one batch call**, so which
write survives a duplicate destination is not specified by anything we control. Relying on
"later overwrites earlier" would have been a guess dressed as a guarantee — I wrote that
comment first, then checked, and it was wrong.

So a project-supplied `bunfig.toml` is dropped **explicitly**, and the test asserts there
is exactly **one** bunfig destination in the upload list, which is what proves the
resolution happened here rather than in the SDK.

Ours wins because this is a *floor*: a control the built project can override is not one.
The trade is that a legitimate project-level bun setting would be discarded, so the drop
is logged at WARNING — a silent override is how someone loses an afternoon to a bun config
that appears not to apply. No generated project emits one today, so this guards a future
template or a hostile source map, not a live collision.

## Not done, and deliberately not faked

**`--frozen-lockfile`.** The generator emits **no lockfile** — nothing under paw-sites
writes one — so the flag would fail every build rather than harden it. Enforcing it needs a
vetted lockfile for the allowlisted dependency set, which is its own design. Recorded as
owed rather than pretended.

**The image's floating base and its unpinned `curl | bash` installs.** Those live in
`cloud/daytona/image.py` and are a separate change.

## Verification

```
tests/ee/sites/test_daytona_runner.py              24 passed
tests/mutations/sites_supply_chain_floor.json      5/5 caught, exit 0
ruff check / ruff format --check                   clean
```

Two things about how the assertions are written. They read the **bytes that actually get
uploaded**, not the constant, so a broken encode or a wrong destination still fails. And
the release-age number is asserted **literally**, because a plausible-looking wrong value —
a day, or minutes instead of seconds — is the real failure mode here, not a missing line.

The five mutations cover both controls being weakened, the floor not being uploaded at all,
the explicit drop being removed (which would hand the guarantee back to the SDK), and the
warning going silent.

## Adjacent, worth deciding together

This and **SR-5 (registry mirror / warm image)** are the same problem seen twice. A warm
image is how you stop paying a full `bun install` per build *and* how you stop resolving
from the open registry inside the container. Always-Daytona removed PERF-3's install-skip,
so SR-5's premise — which I had marked weakened by measurement — is restored, and it is now
the main lever on per-build cost. Flagging rather than widening this PR's scope.
