### PR TITLE
fix(ci): the private-key check in the secret scan never ran

### DIFF
--- a/.github/workflows/pr-quality-gate.yml
+++ b/.github/workflows/pr-quality-gate.yml
@@ -1,4 +1,12 @@
 # PR quality gate — enforces contribution standards and security checks.
+# Updated: 2026-08-10 — Secret scan moved out of inline grep into
+#   scripts/scan_secrets.py. The old bash-array loop fed each pattern to
+#   `grep -qE "$pattern"`; the PEM private-key pattern begins with a hyphen,
+#   so grep parsed it as an option, exited 2, and the enclosing `if` read that
+#   error as "no match" — the private-key check had never run. Also: the step
+#   now fails closed when the base ref will not resolve (it used to swallow a
+#   failed `git diff` and report a clean scan), only added lines are scanned,
+#   and the dangerous-pattern step no longer discards grep's error status.
 # Updated: 2026-03-05 — Fixed duplicate const bug, added security scan, dependency alerts, sensitive file alerts, PR size gate.
 name: PR Quality Gate
 
@@ -325,7 +333,17 @@ jobs:
               continue
             fi
             for pattern in "${PATTERNS[@]}"; do
-              MATCHES=$(grep -nE "$pattern" "$file" 2>/dev/null || true)
+              # -e stops a pattern from being parsed as an option, and the
+              # status is inspected rather than discarded: grep returns 1 for
+              # "no match" but 2+ for a real error, and collapsing the two is
+              # what kept the secrets scan below dead for months. Errors used
+              # to go to /dev/null here, which would have hidden the same bug.
+              GREP_STATUS=0
+              MATCHES=$(grep -nE -e "$pattern" "$file") || GREP_STATUS=$?
+              if [ "$GREP_STATUS" -gt 1 ]; then
+                echo "::error::grep failed with status $GREP_STATUS on pattern: $pattern"
+                exit 1
+              fi
               if [ -n "$MATCHES" ]; then
                 FOUND=1
                 REPORT+="### $file\n"
@@ -365,53 +383,66 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # The pattern list used to live inline here as a bash array fed to
+      # `grep -qE "$pattern"`. The PEM private-key pattern starts with a
+      # hyphen, so grep read it as an option, exited 2, and the enclosing
+      # `if` scored that hard error as "no match" — the check never ran.
+      # Patterns now live in scripts/scan_secrets.py, where they are regex
+      # data rather than argv, and the exit status is explicit:
+      # 0 clean / 1 findings / 2 scanner error. The self-test runs first so a
+      # pattern that goes dead fails the gate instead of passing every PR.
       - name: Check for secrets in diff
         run: |
-          DIFF=$(git diff origin/${{ github.event.pull_request.base.ref }}...HEAD -- . ':!uv.lock' ':!*.lock' ':!src/pocketpaw/security/redact.py' ':!tests/test_redact.py' ':!tests/test_pii.py' ':!tests/test_logging_scrub.py' 2>/dev/null || true)
-          if [ -z "$DIFF" ]; then
-            echo "No diff to scan."
-            exit 0
-          fi
+          python3 scripts/scan_secrets.py --self-test
 
-          FOUND=0
-          # Common secret patterns
-          PATTERNS=(
-            'AKIA[0-9A-Z]{16}'                           # AWS Access Key
-            'sk-[a-zA-Z0-9]{20,}'                        # OpenAI/Anthropic API key
-            'ghp_[a-zA-Z0-9]{36}'                        # GitHub PAT
-            'gho_[a-zA-Z0-9]{36}'                        # GitHub OAuth
-            'xoxb-[0-9]+-[a-zA-Z0-9]+'                   # Slack bot token
-            'xoxp-[0-9]+-[a-zA-Z0-9]+'                   # Slack user token
-            'sk_live_[a-zA-Z0-9]+'                        # Stripe secret key
-            '-----BEGIN .*PRIVATE KEY-----'                 # Private keys
-          )
-
-          for pattern in "${PATTERNS[@]}"; do
-            if echo "$DIFF" | grep -qE "$pattern"; then
-              FOUND=1
-              echo "::error::Potential secret detected matching pattern: $pattern"
-            fi
-          done
-
-          if [ "$FOUND" -eq 1 ]; then
-            gh pr comment ${{ github.event.pull_request.number }} \
-              --body "<!-- security-scan-secrets -->
-          ## Security scan: potential secrets detected
-
-          This PR diff appears to contain secrets or API keys. Please remove them immediately and rotate any exposed credentials.
-
-          If these are false positives (e.g., placeholder patterns in tests), a maintainer will verify." \
-              --edit-last 2>/dev/null || \
-            gh pr comment ${{ github.event.pull_request.number }} \
-              --body "<!-- security-scan-secrets -->
-          ## Security scan: potential secrets detected
-
-          This PR diff appears to contain secrets or API keys. Please remove them immediately and rotate any exposed credentials.
-
-          If these are false positives (e.g., placeholder patterns in tests), a maintainer will verify."
+          BASE="origin/${{ github.event.pull_request.base.ref }}"
+          if ! git rev-parse --verify --quiet "$BASE^{commit}" >/dev/null; then
+            echo "::error::Cannot resolve $BASE, so the secret scan cannot run. Failing closed."
             exit 1
           fi
 
-          echo "No secrets detected in diff."
+          git diff "$BASE...HEAD" -- . \
+            ':!uv.lock' ':!*.lock' \
+            ':!src/pocketpaw/security/redact.py' \
+            ':!tests/test_redact.py' \
+            ':!tests/test_pii.py' \
+            ':!tests/test_logging_scrub.py' \
+            > pr.diff
+          echo "Scanning $(wc -l < pr.diff) diff lines for secrets."
+
+          SCAN_STATUS=0
+          python3 scripts/scan_secrets.py --report findings.txt < pr.diff || SCAN_STATUS=$?
+
+          if [ "$SCAN_STATUS" -eq 0 ]; then
+            echo "No secrets detected in diff."
+            exit 0
+          fi
+          if [ "$SCAN_STATUS" -ne 1 ]; then
+            echo "::error::Secret scanner exited $SCAN_STATUS (scanner error, not a clean result)."
+            exit 1
+          fi
+
+          COMMENT_BODY=$(cat <<'COMMENT_EOF'
+          <!-- security-scan-secrets -->
+          ## Security scan: potential secrets detected
+
+          This PR diff appears to contain secrets or API keys. Remove them and rotate any exposed credential. Force-pushing is not enough on its own; treat the value as compromised.
+
+          Matches below list the location and the credential shape only, never the value.
+
+          COMMENT_EOF
+          )
+          COMMENT_BODY+=$'\n```\n'
+          COMMENT_BODY+=$(cat findings.txt)
+          COMMENT_BODY+=$'\n```\n'
+          COMMENT_BODY+=$'\nIf these are false positives (for example a placeholder in a test), a maintainer will verify.'
+
+          gh pr comment ${{ github.event.pull_request.number }} \
+            --body "$COMMENT_BODY" \
+            --edit-last 2>/dev/null || \
+          gh pr comment ${{ github.event.pull_request.number }} \
+            --body "$COMMENT_BODY"
+
+          exit 1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/scan_secrets.py
+++ b/scripts/scan_secrets.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Secret scanner for the PR quality gate.
+
+Added 2026-08-10. Replaces the inline `grep -qE` loop that used to live in
+`.github/workflows/pr-quality-gate.yml` ("Check for secrets in diff").
+
+Why this is a script and not shell
+----------------------------------
+The old step looped a bash array of patterns through `grep -qE "$pattern"`.
+One pattern began with a hyphen (`-----BEGIN .*PRIVATE KEY-----`), so grep
+parsed it as an option bundle, printed "unknown option", and exited 2. The
+surrounding `if` treats any non-zero status as "no match", so a hard scanner
+error was indistinguishable from a clean result: the private-key check never
+ran. Here the patterns are data handed to `re`, never argv, so that entire
+failure mode is gone, and the exit status is explicit:
+
+    0  clean
+    1  findings (the caller should fail the PR)
+    2  scanner error (bad usage, unreadable input) — never mistake for clean
+
+Why the patterns look the way they do
+-------------------------------------
+Every pattern is written with quantifiers and character classes instead of
+literal `.*` runs, so this file never matches its own pattern table. The old
+PEM pattern did match itself, which means even a correctly-quoted version of
+the old step would have failed the gate on the workflow file that defined it.
+Positive samples for --self-test are assembled from fragments at runtime for
+the same reason: no realistic secret shape is ever stored at rest in this
+repo. This scanner has twice been tripped by material that only *described*
+a secret; describe the shape, never reproduce it.
+
+Findings report the pattern label and the file:line, never the matched text —
+CI logs are readable by anyone who can see the run, so echoing the match back
+would publish the secret the scan just caught.
+
+Usage
+-----
+    git diff <base>...HEAD | python3 scripts/scan_secrets.py
+    python3 scripts/scan_secrets.py --all-lines < some_file
+    python3 scripts/scan_secrets.py --self-test
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+
+# A bare hyphen kept in its own constant. Building PEM material from this
+# means no five-hyphen run — and therefore no PEM header — exists as a
+# literal anywhere in this file.
+_H = "-"
+
+EXIT_CLEAN = 0
+EXIT_FINDINGS = 1
+EXIT_ERROR = 2
+
+
+@dataclass(frozen=True)
+class Pattern:
+    """One secret shape, plus a runtime-built sample that must match it."""
+
+    label: str
+    regex: re.Pattern[str]
+    sample: Callable[[], str]
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: str
+    lineno: int
+    label: str
+
+    def render(self) -> str:
+        return f"{self.path}:{self.lineno}: {self.label}"
+
+
+PATTERNS: tuple[Pattern, ...] = (
+    Pattern(
+        # AWS long-term (AKIA) and STS session (ASIA) key IDs. Both are the
+        # 4-char prefix plus 16 uppercase-alnum characters.
+        label="AWS access key ID",
+        regex=re.compile(r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b"),
+        sample=lambda: "AKIA" + "IOSFODNN7EXAMPLE",
+    ),
+    Pattern(
+        # Anthropic keys are sk-ant-api03-<base64ish>, so they contain
+        # hyphens and underscores. The previous character class stopped at
+        # the first hyphen and could not match an Anthropic key at all —
+        # the one vendor key shape this repo is most likely to leak.
+        label="Anthropic API key",
+        regex=re.compile(r"\bsk" + _H + r"ant" + _H + r"[A-Za-z0-9_" + _H + r"]{20,}"),
+        sample=lambda: "sk" + _H + "ant" + _H + "api03" + _H + "A" * 80,
+    ),
+    Pattern(
+        # OpenAI keys: sk-<48 base62> and the newer sk-proj-<...>. The \b
+        # prefix stops this firing on ordinary prose like
+        # "disk-usagemonitoring..." which the unanchored version matched.
+        label="OpenAI API key",
+        regex=re.compile(r"\bsk" + _H + r"(?:proj" + _H + r")?[A-Za-z0-9]{20,}"),
+        sample=lambda: "sk" + _H + "T3BlbkFJ" + "A" * 40,
+    ),
+    Pattern(
+        # GitHub tokens share one shape across prefixes: ghp_ (classic PAT),
+        # gho_ (OAuth), ghu_ (user-to-server), ghs_ (server-to-server, i.e.
+        # GITHUB_TOKEN), ghr_ (refresh). The old list covered only ghp_ and
+        # gho_, so an Actions token pasted into a file sailed through.
+        label="GitHub token",
+        regex=re.compile(r"\bgh[pousr]_[A-Za-z0-9]{36}\b"),
+        sample=lambda: "ghp" + "_" + "A" * 36,
+    ),
+    Pattern(
+        label="GitHub fine-grained PAT",
+        regex=re.compile(r"\bgithub_pat_[A-Za-z0-9_]{40,}"),
+        sample=lambda: "github" + "_pat_" + "A" * 60,
+    ),
+    Pattern(
+        # Slack bot / user / app-level tokens.
+        label="Slack token",
+        regex=re.compile(r"\bxox[baprs]" + _H + r"[0-9A-Za-z" + _H + r"]{10,}"),
+        sample=lambda: "xox" + "b" + _H + "1234567890" + _H + "abcdefghijkl",
+    ),
+    Pattern(
+        # Stripe live secret and restricted keys. Requires 16+ trailing
+        # characters: real keys are ~24, and the shorter form was matching
+        # prose that merely names the prefix while explaining it — a false
+        # positive this repo has already been burned by twice.
+        label="Stripe live key",
+        regex=re.compile(r"\b[sr]k_live_[A-Za-z0-9]{16,}"),
+        sample=lambda: "s" + "k_live_" + "A" * 24,
+    ),
+    Pattern(
+        # PEM private key header, in the quantifier form that does not match
+        # its own definition. Covers RSA / EC / DSA / OPENSSH / ENCRYPTED
+        # and the bare "BEGIN PRIVATE KEY".
+        label="PEM private key",
+        regex=re.compile(_H + r"{5}BEGIN [A-Z0-9 ]*PRIVATE KEY" + _H + r"{5}"),
+        sample=lambda: _H * 5 + "BEGIN RSA PRIVATE KEY" + _H * 5,
+    ),
+    Pattern(
+        label="Google API key",
+        regex=re.compile(r"\bAIza[0-9A-Za-z_" + _H + r"]{35}\b"),
+        sample=lambda: "AIza" + "A" * 35,
+    ),
+)
+
+
+_HUNK = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@")
+
+
+def iter_scannable(text: str, *, all_lines: bool) -> list[tuple[str, int, str]]:
+    """Yield (path, lineno, content) for each line the scan should inspect.
+
+    In the default (diff) mode only added lines are inspected. Context and
+    removed lines describe code that is already committed: flagging those
+    would fail every unrelated PR that happens to touch a file near a
+    pre-existing match, and would fail a PR whose whole purpose is to
+    *remove* a leaked credential.
+
+    ``lineno`` is the line number in the post-change file, tracked from the
+    hunk header, so a finding points at where the credential actually landed.
+    """
+    out: list[tuple[str, int, str]] = []
+    path = "(stdin)"
+    lineno = 0
+    for raw in text.splitlines():
+        if all_lines:
+            lineno += 1
+            out.append((path, lineno, raw))
+            continue
+        if raw.startswith("+++ "):
+            # "+++ b/src/foo.py" — the file header, not content.
+            path = raw[4:].removeprefix("b/")
+            lineno = 0
+            continue
+        if raw.startswith(("--- ", "diff ", "index ")):
+            continue
+        hunk = _HUNK.match(raw)
+        if hunk:
+            lineno = int(hunk.group(1)) - 1
+            continue
+        if raw.startswith("+"):
+            lineno += 1
+            out.append((path, lineno, raw[1:]))
+        elif raw.startswith(" ") or raw == "":
+            # A context line still advances the post-change file position.
+            lineno += 1
+    return out
+
+
+def scan(text: str, *, all_lines: bool = False) -> list[Finding]:
+    findings: list[Finding] = []
+    for path, lineno, content in iter_scannable(text, all_lines=all_lines):
+        for pattern in PATTERNS:
+            if pattern.regex.search(content):
+                findings.append(Finding(path=path, lineno=lineno, label=pattern.label))
+    return findings
+
+
+def self_test() -> list[str]:
+    """Prove every pattern is alive. Returns a list of failure messages.
+
+    This runs in CI immediately before the real scan, so a pattern that goes
+    dead fails the gate loudly instead of silently passing every PR — which
+    is exactly how the PEM check stayed broken.
+    """
+    failures: list[str] = []
+    source = _read_own_source()
+
+    for pattern in PATTERNS:
+        sample = pattern.sample()
+
+        # 1. The pattern matches its own sample.
+        if not pattern.regex.search(sample):
+            failures.append(f"{pattern.label}: pattern does not match its own sample")
+
+        # 2. The sample survives a realistic diff round trip.
+        diff = f"+++ b/planted.txt\n+{sample}\n"
+        if not any(f.label == pattern.label for f in scan(diff)):
+            failures.append(f"{pattern.label}: not detected in a unified diff")
+
+        # 3. The pattern does not match this file, so committing the pattern
+        #    table never trips the scanner.
+        if pattern.regex.search(source):
+            failures.append(f"{pattern.label}: matches this scanner's own source")
+
+    # 4. Ordinary text stays clean.
+    benign = (
+        "+++ b/notes.md\n"
+        "+Rotate the disk-usagemonitoringservice credentials quarterly.\n"
+        "+See docs for how the sk_live prefix identifies a Stripe key.\n"
+    )
+    if scan(benign):
+        failures.append(f"benign text produced findings: {[f.label for f in scan(benign)]}")
+
+    # 5. Removed and context lines are not scanned.
+    removal = "+++ b/leak.py\n-" + _H * 5 + "BEGIN RSA PRIVATE KEY" + _H * 5 + "\n"
+    if scan(removal):
+        failures.append("a removed line produced a finding")
+
+    return failures
+
+
+def _read_own_source() -> str:
+    try:
+        with open(__file__, encoding="utf-8") as fh:
+            return fh.read()
+    except OSError:  # pragma: no cover - only if the script is run from a zip
+        return ""
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Scan a diff (or text) for committed secrets.")
+    parser.add_argument(
+        "--all-lines",
+        action="store_true",
+        help="Scan every input line instead of only a unified diff's added lines.",
+    )
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="Verify every pattern still matches a generated sample, then exit.",
+    )
+    parser.add_argument(
+        "--report",
+        metavar="PATH",
+        help=(
+            "Write the plain findings list (one 'path:line: label' per line) to PATH, "
+            "for a caller that wants to quote it in a PR comment. Never contains the "
+            "matched text."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        failures = self_test()
+        if failures:
+            for failure in failures:
+                print(f"::error::secret-scan self-test: {failure}")
+            print(f"Self-test FAILED ({len(failures)} problem(s)).")
+            return EXIT_ERROR
+        print(f"Self-test passed: {len(PATTERNS)} patterns alive.")
+        return EXIT_CLEAN
+
+    try:
+        text = sys.stdin.read()
+    except (OSError, UnicodeDecodeError) as exc:
+        print(f"::error::secret scan could not read stdin: {exc}")
+        return EXIT_ERROR
+
+    findings = scan(text, all_lines=args.all_lines)
+    report = "\n".join(f.render() for f in findings)
+
+    if args.report:
+        try:
+            with open(args.report, "w", encoding="utf-8") as fh:
+                fh.write(report + ("\n" if report else ""))
+        except OSError as exc:
+            print(f"::error::secret scan could not write {args.report}: {exc}")
+            return EXIT_ERROR
+
+    if not findings:
+        print("No secrets detected.")
+        return EXIT_CLEAN
+
+    print(report)
+    print(f"::error::Secret scan failed: {len(findings)} potential secret(s) in this diff.")
+    return EXIT_FINDINGS
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_scan_secrets.py
+++ b/tests/test_scan_secrets.py
@@ -1,0 +1,218 @@
+"""Tests for scripts/scan_secrets.py, the PR quality gate's secret scanner.
+
+Added 2026-08-10 alongside the scanner. These exist because the check they
+guard was dead in CI for months without anyone noticing: the PEM private-key
+pattern began with a hyphen, grep parsed it as an option, and the resulting
+exit status 2 was read by the calling `if` as "nothing found". A scan that
+cannot fail is indistinguishable from a scan that passes, so the regression
+has to be caught mechanically.
+
+Every secret-shaped string used here is assembled from fragments at call
+time. Nothing in this file, at rest, matches a pattern the scanner looks for
+- that is deliberate. The scanner has twice been tripped by test fixtures and
+by comments that quoted a realistic credential while explaining it. Describe
+the shape; never write one down.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "scan_secrets.py"
+
+# A lone hyphen, so no five-hyphen run (and therefore no PEM header) is ever
+# a literal in this file.
+H = "-"
+
+
+def _load() -> ModuleType:
+    """Import the script by path. `scripts/` is not a package, so there is no
+    import path to it; registering in sys.modules first is required because
+    the module's frozen dataclasses resolve their annotations through it."""
+    spec = importlib.util.spec_from_file_location("scan_secrets", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["scan_secrets"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+scan_secrets = _load()
+
+
+def _pem_header(kind: str = "RSA") -> str:
+    """A PEM header built at runtime. Header only, no key material."""
+    return f"{H * 5}BEGIN {kind} PRIVATE KEY{H * 5}"
+
+
+def _diff(path: str, *added: str) -> str:
+    body = "".join(f"+{line}\n" for line in added)
+    return f"diff --git a/{path} b/{path}\n--- a/{path}\n+++ b/{path}\n@@ -0,0 +1 @@\n{body}"
+
+
+# ---------------------------------------------------------------------------
+# The regression this PR fixes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("kind", ["RSA", "EC", "DSA", "OPENSSH", "ENCRYPTED", ""])
+def test_pem_private_key_is_detected(kind: str) -> None:
+    """The check that never ran. Every PEM flavour must be caught."""
+    findings = scan_secrets.scan(_diff("deploy/id_key", _pem_header(kind).replace("  ", " ")))
+    assert [f.label for f in findings] == ["PEM private key"]
+
+
+def test_pem_pattern_does_not_match_its_own_definition() -> None:
+    """Guards the trap that kept the old pattern unfixable.
+
+    The previous pattern (`-----BEGIN .*PRIVATE KEY-----`) matched its own
+    text, so a correctly-quoted version of the old step would have failed the
+    gate on the very workflow file that declared it. Any future pattern must
+    stay inert against the scanner's own source.
+    """
+    source = SCRIPT.read_text(encoding="utf-8")
+    matching = [p.label for p in scan_secrets.PATTERNS if p.regex.search(source)]
+    assert matching == []
+
+
+def test_scanner_source_and_this_test_file_are_clean_at_rest() -> None:
+    """Neither file may trip the scan when it lands in a PR diff."""
+    for path in (SCRIPT, Path(__file__).resolve()):
+        as_diff = _diff(path.name, *path.read_text(encoding="utf-8").splitlines())
+        assert scan_secrets.scan(as_diff) == []
+
+
+# ---------------------------------------------------------------------------
+# Every pattern is alive
+# ---------------------------------------------------------------------------
+
+
+def test_self_test_reports_no_failures() -> None:
+    assert scan_secrets.self_test() == []
+
+
+@pytest.mark.parametrize("pattern", scan_secrets.PATTERNS, ids=lambda p: p.label)
+def test_each_pattern_detects_its_own_sample(pattern: object) -> None:
+    sample = pattern.sample()  # type: ignore[attr-defined]
+    label = pattern.label  # type: ignore[attr-defined]
+    findings = scan_secrets.scan(_diff("planted.txt", sample))
+    assert label in [f.label for f in findings]
+
+
+def test_anthropic_key_shape_is_detected() -> None:
+    """The shape this repo is most likely to leak, and the one the old
+    character class could not match because it stopped at the first hyphen."""
+    key = "sk" + H + "ant" + H + "api03" + H + ("A" * 95)
+    findings = scan_secrets.scan(_diff("src/config.py", f'ANTHROPIC_API_KEY = "{key}"'))
+    assert "Anthropic API key" in [f.label for f in findings]
+
+
+def test_github_actions_token_shape_is_detected() -> None:
+    """ghs_ was absent from the old list; only ghp_ and gho_ were covered."""
+    token = "gh" + "s_" + ("A" * 36)
+    findings = scan_secrets.scan(_diff("ci/env.sh", f"export TOKEN={token}"))
+    assert "GitHub token" in [f.label for f in findings]
+
+
+# ---------------------------------------------------------------------------
+# False positives the repo has already been burned by
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "Rotate the disk" + H + "usagemonitoringcredentials every quarter.",
+        "The sk_live prefix marks a Stripe key; the test prefix is different.",
+        "See docs/security.md for how we handle PEM material.",
+        "REDACT_PATTERNS covers AWS, Slack and GitHub token prefixes.",
+    ],
+)
+def test_prose_about_secrets_does_not_trip_the_scan(line: str) -> None:
+    assert scan_secrets.scan(_diff("docs/security.md", line)) == []
+
+
+def test_removed_lines_are_not_scanned() -> None:
+    """A PR whose purpose is to delete a leaked key must not be blocked."""
+    removal = f"+++ b/leak.py\n-{_pem_header()}\n"
+    assert scan_secrets.scan(removal) == []
+
+
+def test_context_lines_are_not_scanned() -> None:
+    """Pre-existing matches near an unrelated edit must not fail every PR."""
+    diff = f"+++ b/leak.py\n@@ -1,3 +1,3 @@\n {_pem_header()}\n+x = 1\n"
+    assert scan_secrets.scan(diff) == []
+
+
+# ---------------------------------------------------------------------------
+# Finding location
+# ---------------------------------------------------------------------------
+
+
+def test_finding_reports_the_post_change_file_line() -> None:
+    """The line number comes from the hunk header, so it points at the real
+    location in the file rather than at an offset within the diff."""
+    diff = (
+        "diff --git a/deploy/keys.py b/deploy/keys.py\n"
+        "--- a/deploy/keys.py\n"
+        "+++ b/deploy/keys.py\n"
+        "@@ -40,3 +40,4 @@ def load():\n"
+        "     pass\n"
+        "-old = 1\n"
+        f"+KEY = '{_pem_header()}'\n"
+        "     return None\n"
+    )
+    findings = scan_secrets.scan(diff)
+    assert [f.render() for f in findings] == ["deploy/keys.py:41: PEM private key"]
+
+
+# ---------------------------------------------------------------------------
+# Exit status contract - the part CI depends on
+# ---------------------------------------------------------------------------
+
+
+def _run(stdin: str, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        input=stdin,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_exit_status_1_on_findings() -> None:
+    result = _run(_diff("deploy/id_key", _pem_header()))
+    assert result.returncode == scan_secrets.EXIT_FINDINGS
+    assert "PEM private key" in result.stdout
+
+
+def test_exit_status_0_on_clean_diff() -> None:
+    result = _run(_diff("src/foo.py", "def hello():", "    return 1"))
+    assert result.returncode == scan_secrets.EXIT_CLEAN
+
+
+def test_self_test_flag_exits_zero() -> None:
+    result = _run("", "--self-test")
+    assert result.returncode == scan_secrets.EXIT_CLEAN
+    assert "patterns alive" in result.stdout
+
+
+def test_findings_never_echo_the_matched_text() -> None:
+    """CI logs are widely readable; printing the match publishes the secret."""
+    key = "AKIA" + ("Q" * 16)
+    result = _run(_diff("src/config.py", f"AWS_KEY = {key}"))
+    assert result.returncode == scan_secrets.EXIT_FINDINGS
+    assert key not in result.stdout
+    assert "AWS access key ID" in result.stdout
+
+
+def test_all_lines_mode_scans_plain_text() -> None:
+    result = _run(_pem_header() + "\n", "--all-lines")
+    assert result.returncode == scan_secrets.EXIT_FINDINGS


### PR DESCRIPTION
## The bug

The `security-scan` job's "Check for secrets in diff" step looped a bash array of patterns through `grep -qE "$pattern"`. One of those patterns was `-----BEGIN .*PRIVATE KEY-----`. It starts with a hyphen, so grep never saw it as a pattern:

```
$ echo "$DIFF" | grep -qE "$pattern"
grep: unknown option -- ---BEGIN .*PRIVATE KEY-----
Usage: grep [OPTION]... PATTERN [FILE]...
EXIT=2
```

The step wrapped that in `if echo "$DIFF" | grep -qE "$pattern"; then`. An `if` scores any non-zero status as false, so grep's hard error was indistinguishable from a clean result. The private-key check has never run.

Reproduced end to end against a scratch repo whose branch commits a `deploy/keys/id_rsa` file with a real PEM header. Running the old step body verbatim:

```
OLD STEP EXIT=0
grep: unknown option -- ---BEGIN .*PRIVATE KEY-----
No secrets detected in diff.
```

The same case against the step in this PR:

```
EXIT=1
Self-test passed: 9 patterns alive.
deploy/keys/id_rsa:1: PEM private key
::error::Secret scan failed: 1 potential secret(s) in this diff.
```

## Why this was not a one-character fix

The obvious repair is `grep -qE -- "$pattern"`. That would have failed the gate on its own workflow file, because `-----BEGIN .*PRIVATE KEY-----` matches its own definition: after the literal `-----BEGIN `, the `.*` happily consumes the characters `.*` and then `PRIVATE KEY-----` lines up. So the first person to quote it correctly would have got a red CI on the file that declares it, and probably reverted.

Patterns now live in `scripts/scan_secrets.py` as regex data handed to `re`, never as argv, so the option-parsing failure mode is gone by construction rather than patched. They are written with quantifiers and character classes instead of literal `.*` runs, so the pattern table stays inert against itself. Exit status is explicit: 0 clean, 1 findings, 2 scanner error.

## Rest of the audit

Same class of bug, a failure that reads as a pass:

- `DIFF=$(git diff ... || true)` swallowed a failing `git diff`, leaving `DIFF` empty, which took the `if [ -z "$DIFF" ]` branch and exited 0 with "No diff to scan." The base ref is now resolved up front and the step fails closed when it cannot be. Verified: an unresolvable base gives `EXIT=1` where it used to give 0.
- The sibling "Scan for dangerous code patterns" step sent grep's stderr to `/dev/null` and discarded its status with `|| true`, so a malformed pattern there would have died the same silent death. It now passes patterns via `-e` and treats status 2 or higher as a job failure. Verified: an invalid regex in that array produces `::error::grep failed with status 2 on pattern: ...` and fails the step, and `-e` makes a hyphen-leading pattern match as a pattern rather than error out.
- The dangerous-pattern step remains warn-only for actual matches. That is deliberate and documented in the step, so it is unchanged.

Pattern accuracy, checked one at a time:

- `sk-[a-zA-Z0-9]{20,}` was labelled "OpenAI/Anthropic" but cannot match an Anthropic key. The class stops at the first hyphen of `sk-ant-api03-`, so it never reaches 20 characters. The vendor key shape this repo is most likely to leak was not covered. Split into separate Anthropic and OpenAI patterns.
- That same pattern was unanchored, so it matched ordinary prose containing `disk-` followed by a long word. Both replacements are word-anchored.
- GitHub coverage was `ghp_` and `gho_`. `ghu_`, `ghs_` and `ghr_` share the identical shape, and fine-grained PATs were missing entirely.
- `sk_live_[a-zA-Z0-9]+` matched the prefix plus a single character, which is how text describing the prefix while explaining it tripped the scan. Now requires a realistic length.
- Added AWS STS session keys (`ASIA`) next to the existing long-term `AKIA`, and Google API keys.

Two behaviour changes worth calling out for review:

- The scan reads added lines only. Context and removed lines describe code that is already committed, so scanning them failed any PR that merely touched a file near a pre-existing match, and blocked a PR whose whole purpose was to delete a leaked key. Line numbers now come from the hunk header, so a finding points at the real location in the file.
- Findings report file, line and credential shape, never the matched text. The old step echoed the pattern into the log, and CI logs are readable by anyone who can see the run.

## How a regression gets caught

Two layers, both mechanical.

`scripts/scan_secrets.py --self-test` builds a positive sample for every pattern at runtime, asserts each one matches its sample, asserts each one survives a diff round trip, and asserts none of them match the scanner's own source. CI runs it immediately before the real scan, so a pattern that goes dead fails the gate on the spot instead of passing every PR for months.

`tests/test_scan_secrets.py` covers the same ground from pytest, plus the exit-status contract (0/1/2), every PEM flavour, the Anthropic and Actions-token shapes that were missing, the prose cases that have caused false positives here before, and the assertion that neither the scanner nor the test file matches a pattern when it lands in a diff. 32 tests.

## The fixture trap

This scanner has been tripped twice by test material and by comments that quoted a credential while explaining it. Nothing in either new file matches a pattern at rest: hyphens for PEM material come from a `_H = "-"` constant so no five-hyphen run exists as a literal, and every secret-shaped string is assembled from fragments at call time. Confirmed by running the new scanner over this PR's own diff:

```
$ git diff --cached origin/dev -- . ':!uv.lock' ':!*.lock' | python3 scripts/scan_secrets.py
No secrets detected.
EXIT=0
```

The scanner is stdlib-only and runs under bare `python3`, so the job needs no `uv sync` or `setup-python` step.

## Verification

```
uv run pytest tests/test_scan_secrets.py -q     -> 32 passed
uv run ruff check .                             -> All checks passed
uv run ruff format --check .                    -> 2686 files already formatted
```

Both workflow steps were extracted from the YAML and executed under `bash -e` (the GitHub default shell) against a scratch git repo, with `gh` stubbed: planted key fails with a comment, clean branch passes, unresolvable base fails closed.

No separate issue filed for the scan bug since the fix is complete here.
