### PR TITLE
feat(sites): wire the artifact truth lane behind a previewability gate

### DIFF
--- a/ee/pocketpaw_ee/sites/artifact_preview.py
+++ b/ee/pocketpaw_ee/sites/artifact_preview.py
@@ -22,6 +22,20 @@
 #      not the commercial terms. It is not permission and must never be cited as
 #      such.
 #
+# Updated 2026-08-10 (SG-10 wiring — this module now has a caller). ``truth_lane.py``
+# is it, and it sits IN FRONT of everything here: it refuses an artifact whose pages are
+# rendered by a ``_worker.js`` we cannot execute, so such an artifact is never stored and
+# never served. Nothing in this module changed shape as a result — the guards, the skip
+# and the refusals are the same — except ``store_artifact``/``safe_store_artifact``,
+# which grew an optional ``expect_server_worker``. That exists because the
+# ``emits_server_worker(engine)`` cross-check below asks the ENGINE NAME a question the
+# name stopped being able to answer at SL-1: engine ``"svelte"`` now covers a static
+# landing build with no worker and a dynamic one with a load-bearing worker, so the
+# check warned "the artifact may be incomplete" on every healthy static svelte preview.
+# A caller that resolved the answer off the artifact passes it in; ``None`` keeps the old
+# behaviour for every other caller. No signal is lost — the missing-worker case
+# ``truth_lane`` suppresses here, it refuses outright, which is louder than a log line.
+#
 # Choosing static REMOVES constraints. The in-tab runtime needs cross-origin
 # isolation, and COEP ``require-corp`` blocks presigned-S3 images — exactly what the
 # sites gallery cards render. ``credentialless`` dodges that but is Chromium/Firefox
@@ -390,7 +404,13 @@ def unpack_artifact(artifact: bytes, dest: Path) -> UnpackedArtifact:
     )
 
 
-def store_artifact(site_id: str, artifact: bytes, *, engine: str) -> PreviewSnapshot:
+def store_artifact(
+    site_id: str,
+    artifact: bytes,
+    *,
+    engine: str,
+    expect_server_worker: bool | None = None,
+) -> PreviewSnapshot:
     """Unpack ``artifact`` as this site's preview, replacing any previous one.
 
     Refuses an engine whose static output is the project ROOT (``html``, whose
@@ -404,6 +424,14 @@ def store_artifact(site_id: str, artifact: bytes, *, engine: str) -> PreviewSnap
     means the build lane changed shape underneath us. It is a warning and not a
     refusal because either way the static tree is still previewable, and a preview
     that refused to open would hide the discrepancy instead of surfacing it.
+
+    ``expect_server_worker`` OVERRIDES that engine-name expectation, and exists because
+    since SL-1 the engine name cannot answer it: engine ``"svelte"`` spans a static
+    landing build (``adapter-static``, no worker) and a dynamic one
+    (``adapter-cloudflare``, worker), so the name-only predicate warns "the artifact may
+    be incomplete" on every healthy static svelte preview. A caller that has resolved
+    the answer off the artifact passes it here. ``None`` keeps the historical
+    engine-name behaviour, so every existing call site is unchanged.
 
     Unpacks into a temporary sibling and swaps it in, so a failure part-way through
     leaves the PREVIOUS preview intact rather than a half-written tree serving a
@@ -431,7 +459,10 @@ def store_artifact(site_id: str, artifact: bytes, *, engine: str) -> PreviewSnap
         shutil.rmtree(incoming, ignore_errors=True)
         raise
 
-    if unpacked.server_entries and not emits_server_worker(engine):
+    expected_worker = (
+        emits_server_worker(engine) if expect_server_worker is None else expect_server_worker
+    )
+    if unpacked.server_entries and not expected_worker:
         logger.warning(
             "sites.artifact_preview: %s artifact for site %s carried a server entry (%s) "
             "even though this engine emits none — the build lane may have changed shape",
@@ -439,7 +470,7 @@ def store_artifact(site_id: str, artifact: bytes, *, engine: str) -> PreviewSnap
             site_id,
             ", ".join(unpacked.server_entries),
         )
-    elif emits_server_worker(engine) and not unpacked.server_entries:
+    elif expected_worker and not unpacked.server_entries:
         logger.warning(
             "sites.artifact_preview: %s artifact for site %s carried NO server entry, "
             "though this engine always emits one — the artifact may be incomplete",
@@ -464,7 +495,11 @@ def store_artifact(site_id: str, artifact: bytes, *, engine: str) -> PreviewSnap
 
 
 def safe_store_artifact(
-    site_id: str, artifact: bytes | None, *, engine: str
+    site_id: str,
+    artifact: bytes | None,
+    *,
+    engine: str,
+    expect_server_worker: bool | None = None,
 ) -> PreviewSnapshot | None:
     """:func:`store_artifact` that never raises — returns ``None`` on any failure.
 
@@ -472,11 +507,18 @@ def safe_store_artifact(
     failed because a preview could not be unpacked, so this swallows everything the
     way ``screenshot.safe_take_*`` does for card images. The strict form stays
     available for a caller that is asking for a preview and is entitled to the error.
+
+    NOT THE TRUTH LANE. This stores whatever unpacks; it asks no question about whether
+    the artifact can be RENDERED faithfully, so a worker-rendered artifact stores its
+    static leftovers here and serves them. ``truth_lane.open_preview`` is the gated
+    entry point, and it is the one a preview surface should call.
     """
     if not artifact:
         return None
     try:
-        return store_artifact(site_id, artifact, engine=engine)
+        return store_artifact(
+            site_id, artifact, engine=engine, expect_server_worker=expect_server_worker
+        )
     except Exception:  # noqa: BLE001 — a preview must never cost anybody a publish
         logger.warning(
             "sites.artifact_preview: could not store a preview for site %s", site_id, exc_info=True

--- a/ee/pocketpaw_ee/sites/local_server.py
+++ b/ee/pocketpaw_ee/sites/local_server.py
@@ -16,6 +16,15 @@
 # `artifact_preview.resolve`, which answers from a tree unpacked out of the
 # ephemeral build lane's artifact tarball.
 #
+# Updated 2026-08-10 (SG-10 wiring): the preview branch now has a gated caller in front
+# of it — `truth_lane.open_preview`, which refuses an artifact whose pages are rendered by
+# a `_worker.js` this server cannot execute, so such a tree is never stored. Nothing in
+# this file's request handling changed. `serve_artifact_preview` is deliberately still
+# UNGATED (see its docstring): `resolve`'s own `_worker.js` refusal has to stay reachable
+# over real HTTP, which means something must be able to store a worker-bearing tree.
+# `truth_lane` also reaches back here for the loopback base URL, which is why its import
+# of this module is inside a function.
+#
 # ONE SERVER, TWO BRANCHES, on purpose. The established in-app preview pattern in
 # this codebase is already "a localhost HTTP server, iframed by the builder"
 # (`dev_server.py` does exactly that with Vite), so the artifact preview rides the
@@ -311,22 +320,39 @@ def preview_url_for(site_id: str) -> str:
 def serve_artifact_preview(site_id: str, artifact: bytes | None, *, engine: str) -> str | None:
     """Store a build artifact as this site's preview and return its URL, or ``None``.
 
-    The artifact-lane peer of :func:`deploy_local`, and the one call a publish tail
-    would make. NEVER RAISES — a preview that could not be unpacked, or a server that
-    could not start, returns ``None`` and is logged. That is the whole difference
-    between the two functions: ``deploy_local`` is the publish itself and must report
-    its failures, while a preview is a convenience and must not be able to fail a
-    publish that already succeeded.
+    The artifact-lane peer of :func:`deploy_local`. NEVER RAISES — a preview that could
+    not be unpacked, or a server that could not start, returns ``None`` and is logged.
+    That is the whole difference between the two functions: ``deploy_local`` is the
+    publish itself and must report its failures, while a preview is a convenience and
+    must not be able to fail a publish that already succeeded.
 
     ``engine`` selects nothing about the LAYOUT — the lane tars from the resolved
     static-output dir, so every artifact already arrives rooted at its deployable root.
     It is passed through for the ``emits_server_worker`` cross-check in
     ``store_artifact``.
 
-    SL-1 caveat for whoever wires the lane: that cross-check still asks the ENGINE
-    whether a worker is expected, and a static svelte site emits none. Once the lane
-    has a caller, it should ask ``resolve_emits_server_worker`` against the build dir
-    instead — the answer is a property of the artifact, not of the engine name."""
+    ┌─────────────────────────────────────────────────────────────────────────────────┐
+    │ NOT THE TRUTH LANE. ``truth_lane.open_preview`` is the wired entry point (SG-10  │
+    │ wiring) and it is the one a preview surface must call.                            │
+    └─────────────────────────────────────────────────────────────────────────────────┘
+
+    This function stores whatever unpacks and hands back an address. It asks no question
+    about whether the artifact can be RENDERED faithfully, so an ``adapter-cloudflare``
+    artifact — whose pages come from a ``_worker.js`` nothing here can execute — stores
+    its static leftovers and serves them as though they were the site. That is the
+    failure mode a verification preview must not have, and it is why the gate lives in
+    ``truth_lane`` rather than being assumed here.
+
+    It is kept UNGATED on purpose rather than delegating: ``resolve``'s own ``_worker.js``
+    refusal is the last line of defence and has to stay reachable over real HTTP, which
+    means something has to be able to store a worker-bearing tree. That is this function,
+    and ``tests/ee/sites/test_artifact_preview_server.py`` is what exercises it.
+    ``tests/ee/sites/test_truth_lane.py::test_the_gate_refuses_what_the_ungated_store_serves``
+    pins the difference between the two so it cannot drift into a surprise.
+
+    The SL-1 caveat this docstring used to carry is discharged in ``truth_lane``: the
+    previewability question there is resolved off the ARTIFACT
+    (``resolve_emits_server_worker`` / a tar scan), never from the engine name."""
     try:
         snapshot = artifact_preview.safe_store_artifact(site_id, artifact, engine=engine)
         if snapshot is None:

--- a/ee/pocketpaw_ee/sites/truth_lane.py
+++ b/ee/pocketpaw_ee/sites/truth_lane.py
@@ -1,0 +1,677 @@
+# ee/pocketpaw_ee/sites/truth_lane.py — the TRUTH LANE. Gates a build artifact for
+# previewability, stores the previewable ones through ``artifact_preview``, and refuses
+# the rest BY NAME. No HTTP surface of its own; no engine-name guessing.
+#
+# Created 2026-08-10 (SG-10 wiring). ``artifact_preview.py`` shipped complete and
+# UNWIRED — a correct, guarded, mutation-tested static server for exactly the tree the
+# ephemeral build lane emits, with no caller anywhere in the product. This module is
+# that caller, and it exists because "store the artifact and serve it" is not
+# sufficient: on one of our four engine shapes the artifact the lane tars CANNOT RUN,
+# and storing it anyway produces the one failure mode a verification preview must not
+# have.
+#
+# WHAT "TRUTH LANE" MEANS, AND WHY IT CONSTRAINS EVERY BRANCH BELOW. The edit lane
+# renders an APPROXIMATION of an edit in the browser (an in-tab svelte compile is not a
+# Vite build). This lane renders the real built artifact, so it is the only surface
+# permitted to assert the site is correct. An assertion surface that is sometimes wrong
+# is worse than none at all — the user stops being able to tell which lane to believe.
+# So every path here resolves to "faithful" or "refused, with a reason". There is no
+# "close enough" branch, and adding one would remove this module's reason to exist.
+#
+# ┌───────────────────────────────────────────────────────────────────────────────────┐
+# │ THE FACT THIS MODULE IS BUILT AROUND: A WORKER-BEARING ARTIFACT CANNOT EXECUTE     │
+# │ HERE, SO IT IS REFUSED RATHER THAN PARTIALLY SERVED.                               │
+# └───────────────────────────────────────────────────────────────────────────────────┘
+#
+# ``adapter-cloudflare`` emits a ``_worker.js`` that is the RENDERER, and the artifact
+# ships a ``_routes.json`` handing it ``/*`` minus the immutable assets. Two independent
+# reasons that tree cannot be previewed by a static file server:
+#
+#   1. WE CANNOT RUN IT. This lane serves files; it has no workerd, no Node, no D1
+#      binding and no ``hooks.server.ts`` gate. Whatever the worker would have rendered
+#      is simply absent.
+#   2. IT IS NOT EVEN COMPLETE. Measured 2026-08-09 (proving record §8 item 14): the
+#      emitted worker imports ``../output/server/index.js`` and
+#      ``../cloudflare-tmp/manifest.js``, and BOTH sit outside the directory the lane
+#      tars. The artifact ships a routing table pointing at a worker that cannot start.
+#
+# The static files beside that worker still unpack cleanly, and THAT is the trap. Serve
+# them and the customer is shown a page their site never serves — an empty shell, or a
+# prerendered fallback — and reads it as their site being broken when it is our
+# packaging that is. So worker presence is a REFUSAL, not a warning.
+#
+# The refusal is deliberately coarser than the diagnosis. We do not parse the worker to
+# see whether its imports happen to resolve: we cannot execute it either way, so the
+# question decides nothing — and the worker bundle has historically carried a
+# substituted per-site signed key, which makes reading its bytes to answer a moot
+# question a bad trade on its own.
+#
+# RESOLVED OFF THE ARTIFACT, NEVER OFF THE ENGINE NAME. Since SL-1 the svelte track
+# spans two adapters: a static landing site builds on ``adapter-static`` (output
+# ``build``, no worker, self-contained, previewable) and a dynamic/auth site on
+# ``adapter-cloudflare`` (output ``.svelte-kit/cloudflare``, worker load-bearing, not
+# previewable). Both are engine ``"svelte"``. So the gate reads the artifact —
+# :func:`assess_artifact` scans tar member names, :func:`assess_project` calls
+# ``engines.resolve_emits_server_worker`` — and ``engines.emits_server_worker`` is never
+# consulted here. A name-based gate would refuse every static svelte landing site and
+# admit every dynamic one, i.e. be wrong in both directions at once.
+#
+# WHY THE GATE RUNS BEFORE THE STORE, NOT AFTER. ``store_artifact`` unpacks into a
+# hidden sibling and swaps it in, so gating on its RESULT would leave a window where a
+# refused artifact is live at the preview address. Scanning names first costs one cheap
+# tar pass and keeps the refusal structural: a refused artifact never lands. The result
+# is still cross-checked against the scan afterwards (:data:`REASON_GATE_DISAGREED`) —
+# two readings of the same bytes that disagree mean one of them is wrong, and the safe
+# response to not knowing which is to serve neither.
+#
+# A REFUSAL ALSO DISCARDS ANY PREVIOUS PREVIEW, which is the non-obvious half. Leaving
+# the last good tree in place would keep answering 200 at the same address for a build
+# that was refused — the truth lane asserting correctness about the wrong build. That is
+# the same confusion ``artifact_preview``'s ``Cache-Control: no-store`` exists to
+# prevent, one level up, so it gets the same answer.
+#
+# THE EXPOSURE SEAM IS A SEAM ON PURPOSE — see :func:`preview_base_url`. Which origin
+# serves preview content to a browser is an OPEN CAPTAIN DECISION (research doc §8
+# item 3), and the proving record's §9f warns explicitly that it must not be settled as
+# a byproduct of a preview slice. So the default is loopback, which needs no decision,
+# and every mode that would settle the question refuses with a message naming what has
+# to be decided. Choosing later is one environment variable, not a rewrite.
+from __future__ import annotations
+
+import io
+import logging
+import os
+import tarfile
+from dataclasses import dataclass
+from pathlib import Path
+
+from pocketpaw_ee.sites import artifact_preview
+
+# ``_SERVER_ENTRY_NAMES`` is IMPORTED rather than mirrored, private name and all. A local
+# copy plus a drift test is the other option and it is strictly worse here: the two sets
+# have to agree by construction, because a name this gate does not recognise as a server
+# entry is a name ``unpack_artifact`` would happily write into a served tree.
+from pocketpaw_ee.sites.artifact_preview import (
+    _SERVER_ENTRY_NAMES as SERVER_ENTRY_NAMES,
+)
+from pocketpaw_ee.sites.artifact_preview import (
+    ArtifactRejected,
+    PreviewSnapshot,
+    UnpackedArtifact,
+)
+from pocketpaw_ee.sites.engines import (
+    normalize_engine,
+    resolve_emits_server_worker,
+    resolve_static_output_rel,
+    static_output_rel,
+)
+
+logger = logging.getLogger(__name__)
+
+#: ``adapter-cloudflare``'s routing table. Its presence means the build expected a
+#: worker to answer requests. Skipped at unpack by ``artifact_preview`` (it is deploy
+#: configuration, not content) — this module reads it as EVIDENCE, which is a different
+#: job from deciding whether to serve it.
+ROUTING_TABLE_NAME = "_routes.json"
+
+#: The document a preview opens at. An artifact without one has nothing to show, and
+#: saying so beats opening the preview onto its own 404 page.
+ENTRY_DOCUMENT_NAME = "index.html"
+
+# ---------------------------------------------------------------------------
+# Refusal reasons
+# ---------------------------------------------------------------------------
+#
+# Named constants rather than inline strings so a caller can branch on the reason and a
+# test can assert one without pinning prose. Each is a DISTINCT reason, for the same
+# rationale ``artifact_preview.resolve`` gives for keeping ``unsafe_path`` and
+# ``escaped_root`` apart: with one shared string, a mutation that disabled one check
+# would still look caught because a different check refused the same input.
+
+#: The build produced no artifact at all (nothing to preview, and not an error).
+REASON_NO_ARTIFACT = "no_artifact"
+
+#: The engine runs no build, so it never produces an artifact. Mirrors the refusals in
+#: ``artifact_preview.store_artifact`` and ``daytona_build.artifact_tar_command``.
+REASON_ENGINE_RUNS_NO_BUILD = "engine_runs_no_build"
+
+#: The bytes are not a readable gzipped tar.
+REASON_ARTIFACT_UNREADABLE = "artifact_unreadable"
+
+#: The artifact's pages are rendered by a worker this lane cannot execute. THE reason
+#: this module exists; see the header.
+REASON_SERVER_RENDERED = "server_rendered_artifact"
+
+#: The artifact carries a routing table naming a renderer the artifact does not contain.
+#: Proving record §8 item 14's incompleteness, seen from the other side.
+REASON_INCOMPLETE_ARTIFACT = "incomplete_artifact"
+
+#: The artifact has no root ``index.html``.
+REASON_NO_ENTRY_DOCUMENT = "no_entry_document"
+
+#: ``store_artifact`` refused the artifact (too large, unsafe, bad site id). A fact about
+#: the artifact, and a typed, expected outcome.
+REASON_ARTIFACT_REJECTED = "artifact_rejected"
+
+#: Storing broke in a way nothing anticipated (a full disk, a permission error). A fact
+#: about US, deliberately not folded into :data:`REASON_ARTIFACT_REJECTED`: telling a
+#: customer their build output was rejected when our disk filled up sends them to debug
+#: their site.
+REASON_STORE_FAILED = "store_failed"
+
+#: The pre-store scan and the unpack disagreed about whether a server entry is present.
+REASON_GATE_DISAGREED = "gate_disagreed"
+
+#: Faithful, stored, serveable.
+REASON_OK = "ok"
+
+# ---------------------------------------------------------------------------
+# The exposure seam
+# ---------------------------------------------------------------------------
+
+#: Which origin serves preview CONTENT to a browser.
+EXPOSURE_ENV = "PAW_SITES_PREVIEW_EXPOSURE"
+
+#: Base URL for :data:`EXPOSURE_PREVIEW_ORIGIN`, e.g. ``https://preview.example.net``.
+PREVIEW_ORIGIN_ENV = "PAW_SITES_PREVIEW_ORIGIN"
+
+#: The loopback server this repo already runs (``local_server``). The DEFAULT, and the
+#: only mode that decides nothing: 127.0.0.1 is not reachable off the box, so there is
+#: no token to design, no cookie mechanic to reason about, and no customer JavaScript
+#: executing on an origin that holds a session.
+EXPOSURE_LOOPBACK = "loopback"
+
+#: A dedicated origin that serves nothing else. Config is a base URL and nothing more,
+#: so the mechanism is here — but turning it on is a hosting change and therefore the
+#: captain's call, which is why it is not the default.
+EXPOSURE_PREVIEW_ORIGIN = "preview-origin"
+
+#: The app's own origin. REFUSED until decided: customer-authored JavaScript would run
+#: somewhere that holds the session cookie, and the obvious mitigation does not work —
+#: a CSP ``sandbox`` on the document empties its site-for-cookies, so the page's own
+#: same-origin CSS and JS stop loading and a working build renders as a broken one.
+EXPOSURE_APP_ORIGIN = "app-origin"
+
+#: A signed, expiring URL. REFUSED until decided: it is a security design in its own
+#: right (what is signed, lifetime, revocation, who may mint one), and the standing hard
+#: gate is that no per-site signed key may ever reach a client bundle or view-source.
+EXPOSURE_SIGNED_URL = "signed-url"
+
+_KNOWN_EXPOSURES = frozenset(
+    {EXPOSURE_LOOPBACK, EXPOSURE_PREVIEW_ORIGIN, EXPOSURE_APP_ORIGIN, EXPOSURE_SIGNED_URL}
+)
+
+
+class PreviewExposureNotConfigured(RuntimeError):
+    """The configured exposure cannot serve a preview address yet.
+
+    Raised rather than quietly degraded to loopback. Falling back would hand back a
+    127.0.0.1 URL to an operator who asked for a public one — a preview that silently
+    works only on the API box, discovered by whoever opens the link. Worse, it would let
+    the origin question be answered by a default instead of by a decision.
+    """
+
+
+def preview_exposure() -> str:
+    """The configured exposure mode.
+
+    An unrecognised value falls back to :data:`EXPOSURE_LOOPBACK` with a warning rather
+    than raising: a typo in deploy config should cost the preview its reach, not the
+    publish it hangs off. Every mode that could leak content refuses explicitly below,
+    so the safe direction for an unknown string is the mode that exposes nothing.
+    """
+    raw = (os.environ.get(EXPOSURE_ENV) or "").strip().lower()
+    if not raw:
+        return EXPOSURE_LOOPBACK
+    if raw not in _KNOWN_EXPOSURES:
+        logger.warning(
+            "sites.truth_lane: unknown %s=%r — falling back to %r",
+            EXPOSURE_ENV,
+            raw,
+            EXPOSURE_LOOPBACK,
+        )
+        return EXPOSURE_LOOPBACK
+    return raw
+
+
+def preview_base_url() -> str:
+    """Base URL the preview tree is reachable at, without the site's mount path.
+
+    THIS IS THE SEAM the origin decision lands on, and it is one function on purpose:
+    picking an exposure is a config change plus, for the two refused modes, the design
+    each of them needs. Nothing else in the sites code has to move.
+
+    Raises :class:`PreviewExposureNotConfigured` for a mode whose design is still the
+    captain's — see the module header and research doc §8 item 3.
+    """
+    mode = preview_exposure()
+    if mode == EXPOSURE_LOOPBACK:
+        # Imported here, not at module scope: ``local_server`` imports this module, so a
+        # top-level import would be a cycle. It is also the only thing this module wants
+        # from that server, and only in this one branch.
+        from pocketpaw_ee.sites import local_server
+
+        return local_server.ensure_server()
+    if mode == EXPOSURE_PREVIEW_ORIGIN:
+        origin = (os.environ.get(PREVIEW_ORIGIN_ENV) or "").strip().rstrip("/")
+        if not origin:
+            raise PreviewExposureNotConfigured(
+                f"{EXPOSURE_ENV}={EXPOSURE_PREVIEW_ORIGIN!r} needs {PREVIEW_ORIGIN_ENV} "
+                "set to the base URL of the origin that serves previews"
+            )
+        return origin
+    if mode == EXPOSURE_APP_ORIGIN:
+        raise PreviewExposureNotConfigured(
+            "serving previews from the app's own origin is an open decision: customer "
+            "JavaScript would execute where the session cookie lives, and a CSP sandbox "
+            "on the document breaks the page's own same-origin assets. Pick an exposure "
+            "deliberately before enabling this."
+        )
+    raise PreviewExposureNotConfigured(
+        "signed expiring preview URLs are an open decision: what is signed, how long it "
+        "lives, how it is revoked, and who may mint one. No per-site signed key may "
+        "reach a client bundle or view-source. Design it before enabling this."
+    )
+
+
+def preview_address(site_id: str) -> str | None:
+    """Full preview URL for a site, or ``None`` when the exposure cannot serve one.
+
+    The soft form :func:`open_preview` uses. A missing address is not a failure of the
+    build or of the artifact, so it must not read as one — the verdict stays whatever
+    the artifact earned and the caller sees a stored preview with nowhere to serve it
+    from yet.
+    """
+    try:
+        base = preview_base_url()
+    except PreviewExposureNotConfigured as exc:
+        logger.warning("sites.truth_lane: no preview address for site %s (%s)", site_id, exc)
+        return None
+    except Exception:  # noqa: BLE001 - ensure_server() binds a socket and may fail
+        logger.warning(
+            "sites.truth_lane: could not resolve a preview address for site %s",
+            site_id,
+            exc_info=True,
+        )
+        return None
+    return f"{base}/{artifact_preview.PREVIEW_URL_PREFIX}/{site_id}/"
+
+
+# ---------------------------------------------------------------------------
+# The gate
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ArtifactShape:
+    """What a NAME-LEVEL scan of an artifact found. Nothing is extracted or read.
+
+    Names only, deliberately. The gate's questions ("is there a renderer we cannot
+    run", "is there an entry document") are all answerable from the member list, and
+    the one file whose contents might tempt a reader — the worker bundle, which has
+    carried a substituted per-site signed key — is therefore never opened.
+    """
+
+    entries: int
+    server_entries: tuple[str, ...]
+    routing_tables: tuple[str, ...]
+    has_entry_document: bool
+
+    @property
+    def is_server_rendered(self) -> bool:
+        return bool(self.server_entries)
+
+    @property
+    def declares_absent_renderer(self) -> bool:
+        """A routing table with no worker beside it: the artifact names a renderer it
+        does not contain. Distinct from :attr:`is_server_rendered` because the harm is
+        different — that one is a tree we cannot run, this one is a tree that is not all
+        there — and because a single combined check would report both as one cause."""
+        return bool(self.routing_tables) and not self.server_entries
+
+
+@dataclass(frozen=True)
+class TruthLaneVerdict:
+    """Whether an artifact can be previewed faithfully, and why not when it cannot."""
+
+    previewable: bool
+    reason: str
+    detail: str
+    shape: ArtifactShape | None = None
+
+
+@dataclass(frozen=True)
+class TruthLanePreview:
+    """The outcome of opening the truth lane on one artifact.
+
+    ``verdict`` and ``url`` are INDEPENDENT facts and are kept apart on purpose: the
+    verdict is about the artifact, the address is about where previews are exposed. An
+    unconfigured exposure must not read as a broken build, and a refused build must not
+    read as a missing config.
+    """
+
+    site_id: str
+    engine: str
+    verdict: TruthLaneVerdict
+    exposure: str
+    url: str | None = None
+    mount_path: str | None = None
+    unpacked: UnpackedArtifact | None = None
+
+    @property
+    def ok(self) -> bool:
+        """Serveable: a faithful artifact AND an address to reach it at."""
+        return self.verdict.previewable and self.url is not None
+
+
+def _segments(name: str) -> tuple[str, ...]:
+    """Member name split into path segments, ``.`` and empties dropped.
+
+    ``tar -C <dir> .`` names members ``./x/y``. Backslash is treated as a separator too:
+    a member named ``_app\\_worker.js`` is a single filename on POSIX and a path on
+    Windows, and a gate that read it as a filename would not see the worker at all.
+    ``unpack_artifact`` REFUSES such a member outright, which is the right answer there;
+    here the job is to notice it, so it is split rather than dropped.
+    """
+    return tuple(part for part in name.replace("\\", "/").split("/") if part not in ("", "."))
+
+
+def scan_artifact(artifact: bytes) -> ArtifactShape:
+    """Name-level scan of an artifact tarball.
+
+    Raises :class:`artifact_preview.ArtifactUnreadable` when the bytes are not a
+    readable gzipped tar, so the caller reports the same cause ``unpack_artifact``
+    would.
+    """
+    try:
+        tar = tarfile.open(fileobj=io.BytesIO(artifact), mode="r:gz")
+    except (tarfile.TarError, OSError, EOFError) as exc:
+        raise artifact_preview.ArtifactUnreadable(
+            f"artifact is not a readable gzipped tar: {exc}"
+        ) from exc
+
+    entries = 0
+    server: list[str] = []
+    routes: list[str] = []
+    entry_document = False
+    with tar:
+        for member in tar:
+            segments = _segments(member.name)
+            if not segments:
+                continue
+            entries += 1
+            if any(seg in SERVER_ENTRY_NAMES for seg in segments):
+                server.append("/".join(segments))
+            if segments[-1] == ROUTING_TABLE_NAME:
+                routes.append("/".join(segments))
+            if segments == (ENTRY_DOCUMENT_NAME,):
+                entry_document = True
+    return ArtifactShape(
+        entries=entries,
+        server_entries=tuple(server),
+        routing_tables=tuple(routes),
+        has_entry_document=entry_document,
+    )
+
+
+_SERVER_RENDERED_DETAIL = (
+    "This build's pages are produced by a Cloudflare Worker, which a preview cannot "
+    "run — it serves files, and it has no database binding or sign-in gate. The static "
+    "files packaged beside that worker are not the pages your visitors would see, so "
+    "showing them would misrepresent the site. Publish it to see the real thing."
+)
+
+_INCOMPLETE_DETAIL = (
+    "This build's package includes a routing table that hands requests to a server "
+    "entry the package does not contain, so it is not complete enough to preview. This "
+    "is a packaging problem on our side, not a problem with your site."
+)
+
+
+def _refuse(reason: str, detail: str, shape: ArtifactShape | None = None) -> TruthLaneVerdict:
+    return TruthLaneVerdict(previewable=False, reason=reason, detail=detail, shape=shape)
+
+
+def assess_shape(shape: ArtifactShape, *, engine: str) -> TruthLaneVerdict:
+    """Verdict for an already-scanned artifact.
+
+    Split out from :func:`assess_artifact` so the rules are testable without packing a
+    tarball, and so the ORDER of the refusals is visible in one place. That order
+    matters: the renderer questions come before the entry-document one, because a
+    worker-rendered artifact may legitimately have no ``index.html`` at all and
+    reporting that as the cause would send someone looking at the wrong thing.
+    """
+    if shape.is_server_rendered:
+        return _refuse(REASON_SERVER_RENDERED, _SERVER_RENDERED_DETAIL, shape)
+    if shape.declares_absent_renderer:
+        return _refuse(REASON_INCOMPLETE_ARTIFACT, _INCOMPLETE_DETAIL, shape)
+    if not shape.has_entry_document:
+        return _refuse(
+            REASON_NO_ENTRY_DOCUMENT,
+            "This build produced no home page, so there is nothing to open. The build "
+            "may have written its output somewhere the packaging step did not look.",
+            shape,
+        )
+    return TruthLaneVerdict(
+        previewable=True,
+        reason=REASON_OK,
+        detail=f"{engine} build packaged {shape.entries} files and renders as static pages.",
+        shape=shape,
+    )
+
+
+def assess_artifact(artifact: bytes | None, *, engine: str) -> TruthLaneVerdict:
+    """Can this artifact be previewed faithfully?
+
+    Reads the ARTIFACT, never the engine name — see the module header. The engine is
+    consulted for exactly one thing, the same thing ``artifact_preview.store_artifact``
+    consults it for: whether the engine belongs in this lane at all (an engine whose
+    static output is the project root runs no build, so an artifact arriving for it is a
+    routing bug and should be loud).
+    """
+    normalized = normalize_engine(engine)
+    if static_output_rel(normalized) == ".":
+        return _refuse(
+            REASON_ENGINE_RUNS_NO_BUILD,
+            f"Sites on the {normalized} engine run no build step, so there is no build "
+            "to preview. The published pages are the authored files.",
+        )
+    if not artifact:
+        return _refuse(
+            REASON_NO_ARTIFACT,
+            "No build output has come back for this site yet, so there is nothing to preview.",
+        )
+    try:
+        shape = scan_artifact(artifact)
+    except ArtifactRejected as exc:
+        logger.warning(
+            "sites.truth_lane: artifact for a %s site is unreadable (%s)", normalized, exc
+        )
+        return _refuse(
+            REASON_ARTIFACT_UNREADABLE,
+            "The build output could not be read, so it cannot be previewed. The download "
+            "may have been truncated; building again should produce a readable one.",
+        )
+    return assess_shape(shape, engine=normalized)
+
+
+def assess_project(project_dir: str | os.PathLike[str], engine: str) -> TruthLaneVerdict:
+    """Verdict for a build that is still a PROJECT DIR rather than a tarball.
+
+    The pre-tar half of the same question, for a locally-built site. It resolves both
+    facts off disk — ``resolve_static_output_rel`` for where this build's output landed,
+    ``resolve_emits_server_worker`` for whether it emitted a renderer — because since
+    SL-1 the engine name answers neither for svelte. Kept in step with
+    :func:`assess_shape` by returning the same reasons; the shape is ``None`` because
+    there is no tarball to have scanned.
+    """
+    normalized = normalize_engine(engine)
+    if static_output_rel(normalized) == ".":
+        return _refuse(
+            REASON_ENGINE_RUNS_NO_BUILD,
+            f"Sites on the {normalized} engine run no build step, so there is no build "
+            "to preview. The published pages are the authored files.",
+        )
+    if resolve_emits_server_worker(project_dir, normalized):
+        return _refuse(REASON_SERVER_RENDERED, _SERVER_RENDERED_DETAIL)
+    out_dir = Path(project_dir) / resolve_static_output_rel(project_dir, normalized)
+    if (out_dir / ROUTING_TABLE_NAME).exists():
+        return _refuse(REASON_INCOMPLETE_ARTIFACT, _INCOMPLETE_DETAIL)
+    if not (out_dir / ENTRY_DOCUMENT_NAME).is_file():
+        return _refuse(
+            REASON_NO_ENTRY_DOCUMENT,
+            "This build produced no home page, so there is nothing to open. The build "
+            "may have written its output somewhere the packaging step did not look.",
+        )
+    return TruthLaneVerdict(
+        previewable=True,
+        reason=REASON_OK,
+        detail=f"{normalized} build at {out_dir.name} renders as static pages.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Opening the lane
+# ---------------------------------------------------------------------------
+
+
+def _refused(site_id: str, engine: str, verdict: TruthLaneVerdict) -> TruthLanePreview:
+    """Record a refusal AND drop any preview already stored for this site.
+
+    The discard is the load-bearing half. A previous build's tree left in place keeps
+    answering 200 at the same address, so the surface whose whole job is to say "this
+    build is correct" would be saying it about a different build. Refusing loudly while
+    still serving the old tree is not a refusal.
+    """
+    if artifact_preview.discard_preview(site_id):
+        logger.info(
+            "sites.truth_lane: discarded site %s's previous preview — this build is refused (%s)",
+            site_id,
+            verdict.reason,
+        )
+    return TruthLanePreview(
+        site_id=site_id,
+        engine=engine,
+        verdict=verdict,
+        exposure=preview_exposure(),
+    )
+
+
+def open_preview(site_id: str, artifact: bytes | None, *, engine: str) -> TruthLanePreview:
+    """Gate an artifact, store it when it is faithful, and return where to reach it.
+
+    THE WIRED ENTRY POINT of the truth lane — one call for a build lane's tail or a
+    per-site preview action to make. Never raises: every outcome is a
+    :class:`TruthLanePreview`, because this hangs off a build that may already have
+    succeeded and a preview must never be able to fail one.
+
+    Storing goes through ``artifact_preview.store_artifact`` unchanged, so the unpack
+    guards, the ``_worker.js`` skip and the size ceilings all still apply. What this
+    adds in front of them is the previewability question they do not ask.
+    """
+    normalized = normalize_engine(engine)
+    verdict = assess_artifact(artifact, engine=normalized)
+    # ``artifact is None`` is already covered by the verdict (REASON_NO_ARTIFACT); it is
+    # repeated here to narrow the type for the checker rather than to assert a fact.
+    if not verdict.previewable or artifact is None:
+        return _refused(site_id, normalized, verdict)
+
+    try:
+        snapshot: PreviewSnapshot = artifact_preview.store_artifact(
+            site_id, artifact, engine=normalized, expect_server_worker=False
+        )
+    except ArtifactRejected as exc:
+        # The store REFUSED the artifact — a typed, expected outcome (too large, unsafe
+        # member, bad site id). Reported separately from the clause below because they
+        # are different facts: this one says something about the artifact, that one says
+        # something broke on our side. One shared reason would also make the two clauses
+        # indistinguishable, and a mutation removing either would still look caught.
+        logger.warning("sites.truth_lane: store refused site %s's artifact (%s)", site_id, exc)
+        return _refused(
+            site_id,
+            normalized,
+            _refuse(
+                REASON_ARTIFACT_REJECTED,
+                "The build output could not be unpacked for preview.",
+                verdict.shape,
+            ),
+        )
+    except Exception:  # noqa: BLE001 - a preview must never cost anybody a build
+        logger.warning(
+            "sites.truth_lane: could not store site %s's preview", site_id, exc_info=True
+        )
+        return _refused(
+            site_id,
+            normalized,
+            _refuse(
+                REASON_STORE_FAILED,
+                "The preview could not be prepared. The site itself is unaffected.",
+                verdict.shape,
+            ),
+        )
+
+    if snapshot.unpacked.server_entries:
+        # The scan said no server entry and the unpack found one. One of the two
+        # readings of these bytes is wrong and nothing here can tell which, so serve
+        # neither: the stored tree is dropped and the build is refused.
+        logger.error(
+            "sites.truth_lane: site %s's artifact scanned clean but unpacked a server "
+            "entry (%s) — refusing rather than serving a tree we cannot vouch for",
+            site_id,
+            ", ".join(snapshot.unpacked.server_entries),
+        )
+        return _refused(
+            site_id,
+            normalized,
+            _refuse(
+                REASON_GATE_DISAGREED,
+                "The build output could not be checked consistently, so it is not being "
+                "previewed. This is a packaging problem on our side.",
+                verdict.shape,
+            ),
+        )
+
+    return TruthLanePreview(
+        site_id=site_id,
+        engine=normalized,
+        verdict=verdict,
+        exposure=preview_exposure(),
+        url=preview_address(site_id),
+        mount_path=snapshot.url_path,
+        unpacked=snapshot.unpacked,
+    )
+
+
+__all__ = [
+    "ENTRY_DOCUMENT_NAME",
+    "EXPOSURE_APP_ORIGIN",
+    "EXPOSURE_ENV",
+    "EXPOSURE_LOOPBACK",
+    "EXPOSURE_PREVIEW_ORIGIN",
+    "EXPOSURE_SIGNED_URL",
+    "PREVIEW_ORIGIN_ENV",
+    "REASON_ARTIFACT_REJECTED",
+    "REASON_ARTIFACT_UNREADABLE",
+    "REASON_ENGINE_RUNS_NO_BUILD",
+    "REASON_GATE_DISAGREED",
+    "REASON_INCOMPLETE_ARTIFACT",
+    "REASON_NO_ARTIFACT",
+    "REASON_NO_ENTRY_DOCUMENT",
+    "REASON_OK",
+    "REASON_SERVER_RENDERED",
+    "REASON_STORE_FAILED",
+    "ROUTING_TABLE_NAME",
+    "SERVER_ENTRY_NAMES",
+    "ArtifactShape",
+    "PreviewExposureNotConfigured",
+    "TruthLanePreview",
+    "TruthLaneVerdict",
+    "assess_artifact",
+    "assess_project",
+    "assess_shape",
+    "open_preview",
+    "preview_address",
+    "preview_base_url",
+    "preview_exposure",
+    "scan_artifact",
+]

--- a/tests/ee/sites/test_truth_lane.py
+++ b/tests/ee/sites/test_truth_lane.py
@@ -1,0 +1,695 @@
+# tests/ee/sites/test_truth_lane.py — the rules of the truth lane: which artifacts it
+# will vouch for, which it refuses and with what reason, and what it leaves on disk.
+#
+# Created 2026-08-10 (SG-10 wiring). test_artifact_preview.py covers the static server's
+# own rules and test_artifact_preview_server.py covers them over real HTTP. This file
+# covers the question neither of them asks: SHOULD this artifact be served at all.
+#
+# The artifacts here are shaped like the ones MEASURED off the live Daytona lane on
+# 2026-08-09, because the whole point is that the three shapes differ and two of them are
+# engine ``"svelte"``:
+#
+#   * react ``dist``                     — 4 entries, self-contained, no worker.
+#   * static svelte ``build``            — adapter-static, no worker, self-contained.
+#   * dynamic svelte ``.svelte-kit/cloudflare`` — 24 entries INCLUDING a ``_worker.js``
+#     whose two imports sit outside the tarred directory (proving record §8 item 14), and
+#     a ``_routes.json`` handing that worker ``/*``. Not runnable, and therefore refused.
+#
+# THE LOAD-BEARING TEST IN THIS FILE IS ``test_the_engine_name_decides_nothing``: the two
+# svelte shapes carry the SAME engine string and get OPPOSITE answers. A gate that read
+# the engine name would refuse every static landing site and admit every dynamic one, so
+# that test is what separates "resolves off the artifact" from a comment claiming it does.
+#
+# The security assertions here are about what a refusal leaves behind. A refused artifact
+# must leave nothing on disk (so its worker bundle, which has carried a substituted
+# per-site signed key, never sits inside a served tree) and must not leave a PREVIOUS
+# build's tree answering at the same address (so the surface whose job is to say "this
+# build is correct" is never saying it about a different build).
+
+from __future__ import annotations
+
+import io
+import tarfile
+import urllib.error
+import urllib.request
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.sites import artifact_preview as ap  # noqa: E402
+from pocketpaw_ee.sites import truth_lane as tl  # noqa: E402
+
+#: A canary in the worker bundle. The standing hard gate is that no per-site signed key
+#: may ever appear in a client bundle or in view-source, and the worker is the file that
+#: has historically carried one, so the tests below look for these bytes specifically
+#: rather than for "a file called _worker.js".
+_CANARY = b"pp_tok_CANARY_TRUTHLANE"
+
+# react's Vite `dist` (measured 61,487 bytes / 4 entries, no node_modules, no worker).
+_REACT_DIST = {
+    "./index.html": b"<!doctype html><title>Acme</title><script src=./assets/app.js></script>ok",
+    "./assets/app.js": b"console.log('react bundle')",
+    "./assets/app.css": b"body{color:#111}",
+    "./vite.svg": b"<svg xmlns='http://www.w3.org/2000/svg'></svg>",
+}
+
+# A STATIC svelte landing site: adapter-static's `build`. No worker, no routing table.
+_SVELTE_STATIC_BUILD = {
+    "./index.html": b"<!doctype html><title>Acme</title><body>hello landing</body>",
+    "./_app/version.json": b'{"version":"1"}',
+    "./_app/immutable/entry/start.abc.js": b"export const start = 1",
+    "./_app/immutable/assets/_layout.def.css": b".x{}",
+}
+
+# A DYNAMIC / auth svelte site: adapter-cloudflare's `.svelte-kit/cloudflare`. The worker
+# is the renderer, `_routes.json` says so, and the worker's imports are not in the tar.
+_SVELTE_DYNAMIC_CLOUDFLARE = {
+    "./index.html": b"<!doctype html><title>Acme</title><body></body>",
+    "./404.html": b"<!doctype html><title>Not found</title>",
+    "./_worker.js": (
+        b'import { Server } from "./../output/server/index.js";\n'
+        b'import { manifest } from "./../cloudflare-tmp/manifest.js";\n'
+        b'const KEY = "' + _CANARY + b'";\n'
+    ),
+    "./_routes.json": b'{"version":1,"include":["/*"],"exclude":["/_app/immutable/*"]}',
+    "./.assetsignore": b"_worker.js\n",
+    "./_app/immutable/entry/start.abc.js": b"export const start = 1",
+}
+
+
+def _tar(members: dict[str, bytes], *, dirs: tuple[str, ...] = ()) -> bytes:
+    """Pack ``members`` (names used VERBATIM) into gzipped tar bytes.
+
+    ``dirs`` adds DIRECTORY members, which is not a detail: adapter-cloudflare emits
+    ``_worker.js`` as a directory of chunks once an app is large enough, so a gate that
+    only recognised a worker FILE would wave the biggest dynamic sites straight through.
+    """
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        for name in dirs:
+            info = tarfile.TarInfo(name)
+            info.type = tarfile.DIRTYPE
+            tar.addfile(info)
+        for name, payload in members.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            tar.addfile(info, io.BytesIO(payload))
+    return buf.getvalue()
+
+
+@pytest.fixture(autouse=True)
+def previews(tmp_path, monkeypatch):
+    """Isolate the preview root and the exposure config for every test in this file.
+
+    The exposure defaults to a fixed ``preview-origin`` base URL rather than the real
+    default (loopback), so a unit test never binds a socket and the URL it asserts on is
+    deterministic. ``test_the_default_exposure_is_loopback`` covers the real default.
+    """
+    monkeypatch.setenv("PAW_SITES_PREVIEW_DIR", str(tmp_path / "site-previews"))
+    monkeypatch.setenv("PAW_SITES_LOCAL_DIR", str(tmp_path / "sites"))
+    monkeypatch.setenv(tl.EXPOSURE_ENV, tl.EXPOSURE_PREVIEW_ORIGIN)
+    monkeypatch.setenv(tl.PREVIEW_ORIGIN_ENV, "https://preview.test")
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# What the lane will vouch for
+# ---------------------------------------------------------------------------
+
+
+def test_a_react_dist_artifact_is_previewable():
+    result = tl.open_preview("react1", _tar(_REACT_DIST), engine="react")
+
+    assert result.ok
+    assert result.verdict.reason == tl.REASON_OK
+    assert result.url == "https://preview.test/_preview/react1/"
+    assert result.mount_path == "/_preview/react1/"
+    assert ap.has_preview("react1")
+
+
+def test_a_static_svelte_landing_artifact_is_previewable():
+    result = tl.open_preview("svstatic1", _tar(_SVELTE_STATIC_BUILD), engine="svelte")
+
+    assert result.ok
+    assert result.verdict.reason == tl.REASON_OK
+    assert ap.resolve("svstatic1", "/").status == 200
+
+
+def test_a_previewable_artifact_serves_its_own_bundle():
+    tl.open_preview("react2", _tar(_REACT_DIST), engine="react")
+
+    asset = ap.resolve("react2", "/assets/app.js")
+    assert asset.status == 200
+    # Load-bearing: served as text/plain the browser refuses to execute it and the page
+    # never hydrates, so a "successful" preview would show an unfinished site.
+    assert asset.content_type.startswith("text/javascript")
+
+
+# ---------------------------------------------------------------------------
+# The refusal that is the reason this module exists
+# ---------------------------------------------------------------------------
+
+
+def test_a_dynamic_svelte_artifact_is_refused_rather_than_partially_served():
+    result = tl.open_preview("svdyn1", _tar(_SVELTE_DYNAMIC_CLOUDFLARE), engine="svelte")
+
+    assert not result.ok
+    assert result.verdict.previewable is False
+    assert result.verdict.reason == tl.REASON_SERVER_RENDERED
+    assert result.url is None
+    # The static files beside the worker unpack perfectly well. The point is that they
+    # are NOT stored: half of a worker-rendered site is not the site.
+    assert not ap.has_preview("svdyn1")
+    assert ap.resolve("svdyn1", "/").status == 404
+    assert ap.resolve("svdyn1", "/").reason == "no_preview"
+
+
+def test_the_refusal_says_why_in_words_a_customer_can_act_on():
+    result = tl.open_preview("svdyn2", _tar(_SVELTE_DYNAMIC_CLOUDFLARE), engine="svelte")
+
+    detail = result.verdict.detail.lower()
+    assert "worker" in detail
+    assert "publish" in detail
+    # It must not blame the customer's site for our packaging, and it must not imply the
+    # preview is merely unavailable right now.
+    assert "your site is broken" not in detail
+
+
+def test_the_engine_name_decides_nothing():
+    """The load-bearing test: one engine string, two shapes, opposite answers.
+
+    Since SL-1 a svelte site builds on adapter-static (no worker) or adapter-cloudflare
+    (worker), and only the artifact says which. A gate keyed on ``engine == "svelte"``
+    would be wrong in both directions at once.
+    """
+    static = tl.assess_artifact(_tar(_SVELTE_STATIC_BUILD), engine="svelte")
+    dynamic = tl.assess_artifact(_tar(_SVELTE_DYNAMIC_CLOUDFLARE), engine="svelte")
+
+    assert static.previewable is True
+    assert dynamic.previewable is False
+    assert dynamic.reason == tl.REASON_SERVER_RENDERED
+
+
+def test_a_worker_emitted_as_a_directory_is_still_a_worker():
+    """adapter-cloudflare emits ``_worker.js/chunks/0.js`` once an app is large enough.
+    A gate that only matched a worker FILE would admit exactly the biggest sites."""
+    members = dict(_SVELTE_STATIC_BUILD)
+    members["./_worker.js/chunks/0.js"] = b"export const chunk = 1"
+
+    verdict = tl.assess_artifact(_tar(members, dirs=("./_worker.js",)), engine="svelte")
+
+    assert verdict.reason == tl.REASON_SERVER_RENDERED
+
+
+def test_a_backslash_separated_worker_member_is_seen():
+    """``_app\\_worker.js`` is one filename on POSIX and a path on Windows. ``unpack``
+    refuses such a member outright; the GATE has to notice it either way, or the same
+    artifact would be refused on one host and admitted on the other."""
+    members = dict(_SVELTE_STATIC_BUILD)
+    members["./_app\\_worker.js"] = b"export default {}"
+
+    verdict = tl.assess_artifact(_tar(members), engine="svelte")
+
+    assert verdict.reason == tl.REASON_SERVER_RENDERED
+
+
+def test_a_routing_table_with_no_worker_is_refused_as_incomplete():
+    """§8 item 14's incompleteness from the other side: the artifact ships a routing
+    table naming a renderer it does not contain."""
+    members = dict(_SVELTE_STATIC_BUILD)
+    members["./_routes.json"] = b'{"version":1,"include":["/*"],"exclude":[]}'
+
+    result = tl.open_preview("svdyn3", _tar(members), engine="svelte")
+
+    assert result.verdict.reason == tl.REASON_INCOMPLETE_ARTIFACT
+    assert not ap.has_preview("svdyn3")
+
+
+def test_the_two_renderer_refusals_are_distinct_reasons():
+    """A worker-rendered artifact and an incomplete one are different problems — one is
+    ours to fix by deploying, the other is ours to fix by packaging — so they must not
+    collapse into one reason. With a single shared string, a mutation disabling either
+    check would still look caught."""
+    assert tl.REASON_SERVER_RENDERED != tl.REASON_INCOMPLETE_ARTIFACT
+
+
+def test_an_artifact_with_no_home_page_is_refused():
+    members = {"./assets/app.js": b"console.log(1)"}
+
+    result = tl.open_preview("nohome1", _tar(members), engine="react")
+
+    assert result.verdict.reason == tl.REASON_NO_ENTRY_DOCUMENT
+    assert not ap.has_preview("nohome1")
+
+
+def test_a_nested_index_is_not_the_entry_document():
+    """A preview opens at the root. ``docs/index.html`` is not a home page, and treating
+    it as one would open the preview onto a 404 while reporting success."""
+    members = {"./docs/index.html": b"<!doctype html>nested"}
+
+    assert tl.assess_artifact(_tar(members), engine="react").reason == tl.REASON_NO_ENTRY_DOCUMENT
+
+
+def test_a_worker_rendered_artifact_reports_the_renderer_not_the_missing_page():
+    """Order of refusals. A worker-rendered artifact may legitimately have no root
+    ``index.html``; reporting THAT would send someone to look at the wrong thing."""
+    members = {
+        "./_worker.js": b"export default {}",
+        "./_routes.json": b'{"include":["/*"]}',
+    }
+
+    assert tl.assess_artifact(_tar(members), engine="svelte").reason == tl.REASON_SERVER_RENDERED
+
+
+def test_an_engine_that_runs_no_build_is_refused():
+    """html emits its static output at the project root and runs no build, so an artifact
+    arriving for it is a routing bug. Mirrors the refusals in ``store_artifact`` and
+    ``daytona_build.artifact_tar_command``."""
+    result = tl.open_preview("html1", _tar(_REACT_DIST), engine="html")
+
+    assert result.verdict.reason == tl.REASON_ENGINE_RUNS_NO_BUILD
+    assert not ap.has_preview("html1")
+
+
+def test_unreadable_bytes_and_no_bytes_refuse_differently():
+    assert tl.assess_artifact(b"not a gzipped tar", engine="react").reason == (
+        tl.REASON_ARTIFACT_UNREADABLE
+    )
+    assert tl.assess_artifact(None, engine="react").reason == tl.REASON_NO_ARTIFACT
+    assert tl.assess_artifact(b"", engine="react").reason == tl.REASON_NO_ARTIFACT
+
+
+def test_open_preview_never_raises_on_any_of_them():
+    """It hangs off a build that may already have succeeded, so every outcome is a value."""
+    for artifact in (None, b"", b"junk", _tar(_SVELTE_DYNAMIC_CLOUDFLARE)):
+        result = tl.open_preview("total1", artifact, engine="svelte")
+        assert result.ok is False
+
+
+def test_a_store_that_fails_is_a_refusal_not_an_exception(monkeypatch):
+    """The store is the last thing that can fail, and it must fail the same way as
+    everything else here: a build that already succeeded must never be reported as failed
+    because its preview could not be unpacked."""
+
+    def refusing_store(*args, **kwargs):
+        raise ap.ArtifactTooLarge("mutated: too big")
+
+    monkeypatch.setattr(ap, "store_artifact", refusing_store)
+
+    result = tl.open_preview("storefail1", _tar(_REACT_DIST), engine="react")
+
+    assert result.verdict.reason == tl.REASON_ARTIFACT_REJECTED
+    assert result.ok is False
+
+
+def test_a_store_that_breaks_unexpectedly_reports_a_different_cause(monkeypatch):
+    """An unforeseen failure is a fact about US, not about the artifact. Reporting it as
+    "your build output was rejected" sends the customer to debug their own site."""
+
+    def exploding_store(*args, **kwargs):
+        raise MemoryError("mutated: something unforeseen")
+
+    monkeypatch.setattr(ap, "store_artifact", exploding_store)
+
+    result = tl.open_preview("storefail2", _tar(_REACT_DIST), engine="react")
+
+    assert result.ok is False
+    assert result.verdict.reason == tl.REASON_STORE_FAILED
+    assert result.verdict.reason != tl.REASON_ARTIFACT_REJECTED
+
+
+# ---------------------------------------------------------------------------
+# What a refusal leaves behind
+# ---------------------------------------------------------------------------
+
+
+def test_a_refusal_discards_the_previous_preview():
+    """The half of the refusal that is easy to miss. A previous build's tree left in
+    place keeps answering 200 at the same address, so the surface whose whole job is to
+    say "this build is correct" would be saying it about a different build."""
+    assert tl.open_preview("stale1", _tar(_SVELTE_STATIC_BUILD), engine="svelte").ok
+    assert ap.resolve("stale1", "/").status == 200
+
+    refused = tl.open_preview("stale1", _tar(_SVELTE_DYNAMIC_CLOUDFLARE), engine="svelte")
+
+    assert refused.verdict.reason == tl.REASON_SERVER_RENDERED
+    assert not ap.has_preview("stale1")
+    assert ap.resolve("stale1", "/").status == 404
+
+
+def test_a_refused_artifact_leaves_no_bytes_of_its_worker_on_disk(previews):
+    """The standing hard gate, checked rather than asserted in prose: the file that has
+    carried a substituted per-site signed key must not land inside a served tree."""
+    tl.open_preview("key1", _tar(_SVELTE_DYNAMIC_CLOUDFLARE), engine="svelte")
+
+    root = previews / "site-previews"
+    found = [path for path in root.rglob("*") if path.is_file() and _CANARY in path.read_bytes()]
+    assert found == []
+
+
+def test_the_gate_and_the_unpack_must_agree(monkeypatch):
+    """Two readings of the same bytes that disagree mean one of them is wrong, and
+    nothing here can tell which — so serve neither."""
+    real_scan = tl.scan_artifact
+
+    def lying_scan(artifact: bytes) -> tl.ArtifactShape:
+        shape = real_scan(artifact)
+        return tl.ArtifactShape(
+            entries=shape.entries,
+            server_entries=(),
+            routing_tables=(),
+            has_entry_document=True,
+        )
+
+    monkeypatch.setattr(tl, "scan_artifact", lying_scan)
+
+    result = tl.open_preview("disagree1", _tar(_SVELTE_DYNAMIC_CLOUDFLARE), engine="svelte")
+
+    assert result.verdict.reason == tl.REASON_GATE_DISAGREED
+    assert not ap.has_preview("disagree1")
+
+
+# ---------------------------------------------------------------------------
+# No false success survives the wiring
+# ---------------------------------------------------------------------------
+
+
+def test_a_missing_asset_is_still_a_404_after_the_gate_admits_the_build():
+    """The property ``artifact_preview``'s header commits to, checked THROUGH the truth
+    lane rather than beside it: a missing asset must not be rewritten to index.html. An
+    SPA fallback here would make a broken build look finished, which is the one failure
+    mode a verification preview must not have."""
+    tl.open_preview("nofb1", _tar(_REACT_DIST), engine="react")
+
+    missing = ap.resolve("nofb1", "/assets/does-not-exist.js")
+
+    assert missing.status == 404
+    assert missing.reason == "not_found"
+    assert b"<div id=root>" not in missing.body
+    assert b"react bundle" not in missing.body
+
+
+def test_a_missing_page_is_a_404_not_the_home_page():
+    tl.open_preview("nofb2", _tar(_REACT_DIST), engine="react")
+
+    missing = ap.resolve("nofb2", "/pricing/")
+
+    assert missing.status == 404
+    assert b"<title>Acme</title>" not in missing.body
+
+
+def test_the_gate_refuses_what_the_ungated_store_serves(previews, monkeypatch):
+    """Pins the difference ``local_server.serve_artifact_preview``'s docstring names.
+
+    The ungated store exists so ``resolve``'s own ``_worker.js`` refusal stays reachable
+    over HTTP, which needs something able to store a worker-bearing tree. That is a
+    deliberate seam, not an oversight, and this is what keeps it from drifting into a
+    surprise: the same artifact, stored by one path and refused by the other.
+    """
+    artifact = _tar(_SVELTE_DYNAMIC_CLOUDFLARE)
+
+    assert ap.safe_store_artifact("both1", artifact, engine="svelte") is not None
+    assert ap.has_preview("both1")
+
+    assert tl.open_preview("both2", artifact, engine="svelte").ok is False
+    assert not ap.has_preview("both2")
+
+
+# ---------------------------------------------------------------------------
+# The project-dir half (a build that has not been tarred)
+# ---------------------------------------------------------------------------
+
+
+def _static_svelte_project(root):
+    build = root / "project" / "build"
+    build.mkdir(parents=True)
+    (build / "index.html").write_bytes(b"<!doctype html>landing")
+    return root / "project"
+
+
+def _dynamic_svelte_project(root):
+    out = root / "project" / ".svelte-kit" / "cloudflare"
+    out.mkdir(parents=True)
+    (out / "index.html").write_bytes(b"<!doctype html>shell")
+    (out / "_worker.js").write_bytes(b"export default {}")
+    (out / "_routes.json").write_bytes(b'{"include":["/*"]}')
+    return root / "project"
+
+
+def test_a_static_svelte_project_dir_is_previewable(previews):
+    verdict = tl.assess_project(_static_svelte_project(previews), "svelte")
+
+    assert verdict.previewable is True
+    assert verdict.reason == tl.REASON_OK
+
+
+def test_a_dynamic_svelte_project_dir_is_refused(previews):
+    verdict = tl.assess_project(_dynamic_svelte_project(previews), "svelte")
+
+    assert verdict.reason == tl.REASON_SERVER_RENDERED
+
+
+def test_the_project_probe_resolves_the_output_dir_off_disk(previews):
+    """A stale ``.svelte-kit/cloudflare`` from a pre-SL-1 build must not shadow what this
+    build emitted — ``resolve_static_output_rel`` probes ``build`` first, and this is the
+    case where getting that order wrong silently refuses a good static site."""
+    project = _static_svelte_project(previews)
+    stale = project / ".svelte-kit" / "cloudflare"
+    stale.mkdir(parents=True)
+    (stale / "_worker.js").write_bytes(b"export default {} // stale")
+
+    assert tl.assess_project(project, "svelte").previewable is True
+
+
+def test_a_project_with_a_worker_directory_is_refused(previews):
+    project = _static_svelte_project(previews)
+    (project / "build" / "_worker.js").mkdir()
+
+    assert tl.assess_project(project, "svelte").reason == tl.REASON_SERVER_RENDERED
+
+
+def test_a_project_with_no_home_page_is_refused(previews):
+    project = previews / "empty"
+    (project / "dist").mkdir(parents=True)
+
+    assert tl.assess_project(project, "react").reason == tl.REASON_NO_ENTRY_DOCUMENT
+
+
+def test_an_html_project_runs_no_build(previews):
+    assert tl.assess_project(previews, "html").reason == tl.REASON_ENGINE_RUNS_NO_BUILD
+
+
+# ---------------------------------------------------------------------------
+# The exposure seam
+# ---------------------------------------------------------------------------
+
+
+def test_the_default_exposure_is_loopback(monkeypatch):
+    """The default decides nothing: 127.0.0.1 is not reachable off the box, so there is
+    no token to design and no customer JavaScript running where a session cookie lives."""
+    monkeypatch.delenv(tl.EXPOSURE_ENV, raising=False)
+
+    assert tl.preview_exposure() == tl.EXPOSURE_LOOPBACK
+
+
+def test_an_unknown_exposure_falls_back_to_the_one_that_exposes_nothing(monkeypatch):
+    monkeypatch.setenv(tl.EXPOSURE_ENV, "publik")
+
+    assert tl.preview_exposure() == tl.EXPOSURE_LOOPBACK
+
+
+def test_the_app_origin_exposure_refuses_until_it_is_decided(monkeypatch):
+    monkeypatch.setenv(tl.EXPOSURE_ENV, tl.EXPOSURE_APP_ORIGIN)
+
+    with pytest.raises(tl.PreviewExposureNotConfigured) as caught:
+        tl.preview_base_url()
+
+    # The message has to name the mechanic, not just refuse. Whoever reads it needs to
+    # know that adding a sandbox attribute is not the fix — it empties the document's
+    # site-for-cookies and the page's own same-origin assets stop loading.
+    assert "cookie" in str(caught.value)
+
+
+def test_the_signed_url_exposure_refuses_until_it_is_decided(monkeypatch):
+    monkeypatch.setenv(tl.EXPOSURE_ENV, tl.EXPOSURE_SIGNED_URL)
+
+    with pytest.raises(tl.PreviewExposureNotConfigured) as caught:
+        tl.preview_base_url()
+
+    assert "revoked" in str(caught.value)
+
+
+def test_a_preview_origin_with_no_base_url_refuses_rather_than_degrading(monkeypatch):
+    """Degrading to loopback would hand a 127.0.0.1 URL to an operator who asked for a
+    public one — a preview that silently works only on the API box."""
+    monkeypatch.setenv(tl.EXPOSURE_ENV, tl.EXPOSURE_PREVIEW_ORIGIN)
+    monkeypatch.delenv(tl.PREVIEW_ORIGIN_ENV, raising=False)
+
+    with pytest.raises(tl.PreviewExposureNotConfigured):
+        tl.preview_base_url()
+
+
+def test_a_configured_preview_origin_is_used_and_its_trailing_slash_dropped(monkeypatch):
+    monkeypatch.setenv(tl.PREVIEW_ORIGIN_ENV, "https://preview.example.net/")
+
+    assert tl.preview_base_url() == "https://preview.example.net"
+    assert tl.preview_address("s1") == "https://preview.example.net/_preview/s1/"
+
+
+def test_an_unconfigured_exposure_does_not_read_as_a_broken_build(monkeypatch, caplog):
+    """The verdict is about the artifact; the address is about where previews are
+    exposed. Conflating them would report a perfectly good build as unpreviewable
+    because nobody has picked an origin yet."""
+    monkeypatch.setenv(tl.EXPOSURE_ENV, tl.EXPOSURE_APP_ORIGIN)
+
+    with caplog.at_level("WARNING"):
+        result = tl.open_preview("noaddr1", _tar(_REACT_DIST), engine="react")
+
+    # An undecided exposure and a socket that would not bind both end with no address, and
+    # they are logged DIFFERENTLY on purpose: this one has to say what needs deciding,
+    # because an operator reading "could not resolve a preview address" plus a traceback
+    # goes looking for a fault instead of making a decision.
+    assert "cookie" in caplog.text
+    assert "could not resolve a preview address" not in caplog.text
+
+    assert result.verdict.previewable is True
+    assert result.verdict.reason == tl.REASON_OK
+    assert result.url is None
+    assert result.ok is False
+    # Stored, so flipping the exposure needs no rebuild.
+    assert ap.has_preview("noaddr1")
+    assert ap.resolve("noaddr1", "/").status == 200
+
+
+# ---------------------------------------------------------------------------
+# Over real HTTP, on the one exposure that needs no decision
+# ---------------------------------------------------------------------------
+
+
+def _get(url: str):
+    req = urllib.request.Request(url, method="GET")  # noqa: S310 - localhost
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310 - localhost
+            return resp.status, resp.read()
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read()
+
+
+@pytest.fixture
+def loopback(monkeypatch):
+    """The real default exposure, with the process-singleton server reset.
+
+    The served root is captured when the server starts, so a test that only set the env
+    var would be served by whatever root a previous test started with."""
+    monkeypatch.setenv(tl.EXPOSURE_ENV, tl.EXPOSURE_LOOPBACK)
+    monkeypatch.delenv(tl.PREVIEW_ORIGIN_ENV, raising=False)
+
+    from pocketpaw_ee.sites import local_server
+
+    previous = local_server._server
+    local_server._server = None
+    try:
+        yield local_server
+    finally:
+        started = local_server._server
+        if started is not None:
+            started.shutdown()
+            started.server_close()
+        local_server._server = previous
+
+
+def test_a_gated_preview_serves_the_real_page_over_http(loopback):
+    result = tl.open_preview("http1", _tar(_REACT_DIST), engine="react")
+
+    assert result.ok
+    assert result.url is not None
+    assert result.url.startswith("http://127.0.0.1:")
+
+    status, body = _get(result.url)
+    assert status == 200
+    assert b"<title>Acme</title>" in body
+
+    status, body = _get(result.url + "assets/app.js")
+    assert status == 200
+    assert b"react bundle" in body
+
+
+def test_a_refused_build_answers_404_at_the_preview_address(loopback):
+    refused = tl.open_preview("http2", _tar(_SVELTE_DYNAMIC_CLOUDFLARE), engine="svelte")
+    assert refused.url is None
+
+    # The address a caller would have been handed had it been previewable. Nothing is
+    # there, and nothing renders — the refusal is a fact about the filesystem, not a
+    # flag some later reader has to remember to check.
+    address = f"{loopback.ensure_server()}/_preview/http2/"
+    status, body = _get(address)
+
+    assert status == 404
+    assert _CANARY not in body
+    assert b"hello landing" not in body
+
+
+def test_the_worker_is_unreachable_even_for_an_artifact_the_lane_admits(loopback):
+    """A static svelte build has no worker, so there is nothing to leak — but the request
+    must still refuse rather than 404 by accident of the file being absent. The refusal
+    is what holds when a future build shape puts one back."""
+    result = tl.open_preview("http3", _tar(_SVELTE_STATIC_BUILD), engine="svelte")
+    assert result.url is not None
+
+    status, body = _get(result.url + "_worker.js")
+
+    assert status == 404
+    assert _CANARY not in body
+
+
+def test_a_missing_asset_over_http_does_not_render_the_home_page(loopback):
+    result = tl.open_preview("http4", _tar(_REACT_DIST), engine="react")
+    assert result.url is not None
+
+    status, body = _get(result.url + "assets/missing.js")
+
+    assert status == 404
+    assert b"react bundle" not in body
+    assert b"<title>Acme</title>" not in body
+
+
+# ---------------------------------------------------------------------------
+# The gate's own vocabulary stays in step with the server's
+# ---------------------------------------------------------------------------
+
+
+def test_a_healthy_static_svelte_preview_logs_no_incompleteness_warning(caplog):
+    """``store_artifact``'s cross-check asks the engine name whether a worker was
+    expected, and since SL-1 the name cannot answer it for svelte — so unless the truth
+    lane passes its own resolved answer, every healthy static landing preview warns that
+    the artifact may be incomplete. A warning that fires on the happy path stops carrying
+    information, which is worse than not having it."""
+    with caplog.at_level("WARNING"):
+        assert tl.open_preview("quiet1", _tar(_SVELTE_STATIC_BUILD), engine="svelte").ok
+
+    assert "may be incomplete" not in caplog.text
+
+
+def test_a_react_artifact_carrying_a_worker_still_warns(caplog):
+    """The other direction of the same cross-check has to keep working: an artifact whose
+    shape contradicts its engine is evidence the build lane changed underneath us. The
+    truth lane refuses it, and the warning is what says why the shape was unexpected."""
+    with caplog.at_level("WARNING"):
+        result = ap.store_artifact("shape1", _tar(_SVELTE_DYNAMIC_CLOUDFLARE), engine="react")
+
+    assert result.unpacked.server_entries
+    assert "emits none" in caplog.text
+
+
+def test_the_gate_reads_the_same_server_entry_names_the_unpack_skips():
+    """Imported, not mirrored. A name the gate does not recognise as a server entry is a
+    name ``unpack_artifact`` would write into a served tree, so these cannot drift."""
+    assert tl.SERVER_ENTRY_NAMES is ap._SERVER_ENTRY_NAMES
+
+
+def test_the_routing_table_the_gate_reads_is_one_the_unpack_never_serves():
+    """``_routes.json`` is evidence for the gate and deploy configuration for the server.
+    Both are true; if it ever stopped being skipped at unpack it would be served as site
+    content, which is a different bug this pins the boundary of."""
+    assert tl.ROUTING_TABLE_NAME in ap._DEPLOY_METADATA_NAMES

--- a/tests/mutations/sites_truth_lane.json
+++ b/tests/mutations/sites_truth_lane.json
@@ -1,0 +1,170 @@
+[
+  {
+    "label": "the worker refusal is gone, so a dynamic svelte site's static leftovers are served as though they were the site and the customer reads our packaging failure as their site being broken",
+    "file": "ee/pocketpaw_ee/sites/truth_lane.py",
+    "find": "    if shape.is_server_rendered:\n        return _refuse(REASON_SERVER_RENDERED, _SERVER_RENDERED_DETAIL, shape)",
+    "replace": "    if False:\n        return _refuse(REASON_SERVER_RENDERED, _SERVER_RENDERED_DETAIL, shape)",
+    "tests": ["tests/ee/sites/test_truth_lane.py"]
+  },
+  {
+    "label": "an artifact carrying a worker reports itself as renderer-free, so the one fact the gate exists to notice is invisible to it",
+    "file": "ee/pocketpaw_ee/sites/truth_lane.py",
+    "find": "    def is_server_rendered(self) -> bool:\n        return bool(self.server_entries)",
+    "replace": "    def is_server_rendered(self) -> bool:\n        return False",
+    "tests": ["tests/ee/sites/test_truth_lane.py"]
+  },
+  {
+    "label": "the scan stops recording worker members, so the gate sees a clean artifact and only the post-store cross-check stands between a worker-rendered tree and being served",
+    "file": "ee/pocketpaw_ee/sites/truth_lane.py",
+    "find": "            if any(seg in SERVER_ENTRY_NAMES for seg in segments):\n                server.append(\"/\".join(segments))",
+    "replace": "            if False:\n                server.append(\"/\".join(segments))",
+    "tests": ["tests/ee/sites/test_truth_lane.py"]
+  },
+  {
+    "label": "a worker member written with a backslash separator is not seen as a worker, so the same artifact is refused on one host and served on the other",
+    "file": "ee/pocketpaw_ee/sites/truth_lane.py",
+    "find": "    return tuple(part for part in name.replace(\"\\\\\", \"/\").split(\"/\") if part not in (\"\", \".\"))",
+    "replace": "    return tuple(part for part in name.split(\"/\") if part not in (\"\", \".\"))",
+    "tests": ["tests/ee/sites/test_truth_lane.py"]
+  },
+  {
+    "label": "the routing table is no longer recorded, so an artifact that names a renderer it does not contain passes the gate as if it were complete",
+    "file": "ee/pocketpaw_ee/sites/truth_lane.py",
+    "find": "            if segments[-1] == ROUTING_TABLE_NAME:\n                routes.append(\"/\".join(segments))",
+    "replace": "            if False:\n                routes.append(\"/\".join(segments))",
+    "tests": ["tests/ee/sites/test_truth_lane.py"]
+  },
+  {
+    "label": "the incomplete-artifact refusal is gone, so a build whose server entry got stripped somewhere in packaging is previewed as a finished static site",
+    "file": "ee/pocketpaw_ee/sites/truth_lane.py",
+    "find": "    if shape.declares_absent_renderer:\n        return _refuse(REASON_INCOMPLETE_ARTIFACT, _INCOMPLETE_DETAIL, shape)",
+    "replace": "    if False:\n        return _refuse(REASON_INCOMPLETE_ARTIFACT, _INCOMPLETE_DETAIL, shape)",
+    "tests": ["tests/ee/sites/test_truth_lane.py"]
+  },
+  {
+    "label": "incompleteness stops requiring a routing table, so every self-contained static build is refused as incomplete and no site can be previewed at all",
+    "file": "ee/pocketpaw_ee/sites/truth_lane.py",
+    "find": "        return bool(self.routing_tables) and not self.server_entries",
+    "replace": "        return bool(self.routing_tables) or not self.server_entries",
+    "tests": ["tests/ee/sites/test_truth_lane.py"]
+  },
+  {
+    "label": "an index.html anywhere in the tree counts as the home page, so a build with only docs/index.html is admitted and the preview opens onto its own 404",
+    "file": "ee/pocketpaw_ee/sites/truth_lane.py",
+    "find": "            if segments == (ENTRY_DOCUMENT_NAME,):\n                entry_document = True",
+    "replace": "            if segments[-1] == ENTRY_DOCUMENT_NAME:\n                entry_document = True",
+    "tests": ["tests/ee/sites/test_truth_lane.py"]
+  },
+  {
+    "label": "a refusal leaves the previous build's preview in place, so the one surface allowed to say a build is correct keeps saying it about a different build",
+    "file": "ee/pocketpaw_ee/sites/truth_lane.py",
+    "find": "    if artifact_preview.discard_preview(site_id):",
+    "replace": "    if False:",
+    "tests": ["tests/ee/sites/test_truth_lane.py"]
+  },
+  {
+    "label": "the gate and the unpack are no longer cross-checked, so a worker the name scan missed is served from the stored tree with nothing left to notice it",
+    "file": "ee/pocketpaw_ee/sites/truth_lane.py",
+    "find": "    if snapshot.unpacked.server_entries:",
+    "replace": "    if False:",
+    "tests": ["tests/ee/sites/test_truth_lane.py"]
+  },
+  {
+    "label": "the project probe guesses the output dir from the engine name, so a static svelte landing build is reported as producing no home page — the exact failure SL-1's resolvers exist to prevent",
+    "file": "ee/pocketpaw_ee/sites/truth_lane.py",
+    "find": "    out_dir = Path(project_dir) / resolve_static_output_rel(project_dir, normalized)",
+    "replace": "    out_dir = Path(project_dir) / static_output_rel(normalized)",
+    "tests": ["tests/ee/sites/test_truth_lane.py"]
+  },
+  {
+    "label": "a project dir is no longer probed for a worker, so a locally-built dynamic site is previewed from the shell adapter-cloudflare left behind",
+    "file": "ee/pocketpaw_ee/sites/truth_lane.py",
+    "find": "    if resolve_emits_server_worker(project_dir, normalized):",
+    "replace": "    if False:",
+    "tests": ["tests/ee/sites/test_truth_lane.py"]
+  },
+  {
+    "label": "unreadable build output raises out of the gate instead of refusing, so a truncated download is reported to the customer as a failed build",
+    "file": "ee/pocketpaw_ee/sites/truth_lane.py",
+    "find": "        shape = scan_artifact(artifact)\n    except ArtifactRejected as exc:",
+    "replace": "        shape = scan_artifact(artifact)\n    except SystemExit as exc:",
+    "tests": ["tests/ee/sites/test_truth_lane.py"]
+  },
+  {
+    "label": "a build with no artifact is scanned anyway, so 'nothing was built yet' surfaces as a type error out of the preview call",
+    "file": "ee/pocketpaw_ee/sites/truth_lane.py",
+    "find": "    if not artifact:\n        return _refuse(\n            REASON_NO_ARTIFACT,",
+    "replace": "    if False:\n        return _refuse(\n            REASON_NO_ARTIFACT,",
+    "tests": ["tests/ee/sites/test_truth_lane.py"]
+  },
+  {
+    "label": "an engine that runs no build is assessed as if it produced an artifact, hiding a routing bug behind a preview of whatever tree arrived",
+    "file": "ee/pocketpaw_ee/sites/truth_lane.py",
+    "find": "    routing bug and should be loud).\n    \"\"\"\n    normalized = normalize_engine(engine)\n    if static_output_rel(normalized) == \".\":",
+    "replace": "    routing bug and should be loud).\n    \"\"\"\n    normalized = normalize_engine(engine)\n    if False:",
+    "tests": ["tests/ee/sites/test_truth_lane.py"]
+  },
+  {
+    "label": "a store refusal escapes into the build lane, so a build that already succeeded is reported as failed because its preview could not be unpacked",
+    "file": "ee/pocketpaw_ee/sites/truth_lane.py",
+    "find": "    except ArtifactRejected as exc:\n        # The store REFUSED the artifact",
+    "replace": "    except SystemExit as exc:\n        # The store REFUSED the artifact",
+    "tests": ["tests/ee/sites/test_truth_lane.py"]
+  },
+  {
+    "label": "an unforeseen failure while storing escapes into the build lane, so one bad preview costs a publish that had already worked",
+    "file": "ee/pocketpaw_ee/sites/truth_lane.py",
+    "find": "    except Exception:  # noqa: BLE001 - a preview must never cost anybody a build",
+    "replace": "    except SystemExit:  # mutated: the swallow is gone",
+    "tests": ["tests/ee/sites/test_truth_lane.py"]
+  },
+  {
+    "label": "the default exposure becomes the app's own origin, so customer JavaScript runs where the session cookie lives before anybody decided that it should",
+    "file": "ee/pocketpaw_ee/sites/truth_lane.py",
+    "find": "    if not raw:\n        return EXPOSURE_LOOPBACK",
+    "replace": "    if not raw:\n        return EXPOSURE_APP_ORIGIN",
+    "tests": ["tests/ee/sites/test_truth_lane.py"]
+  },
+  {
+    "label": "a typo in the exposure config is passed through as a mode, so previews stop resolving an address for a setting the operator believes is the default",
+    "file": "ee/pocketpaw_ee/sites/truth_lane.py",
+    "find": "    if raw not in _KNOWN_EXPOSURES:",
+    "replace": "    if False:",
+    "tests": ["tests/ee/sites/test_truth_lane.py"]
+  },
+  {
+    "label": "every exposure resolves to loopback, so an operator who configured a public preview origin silently gets a 127.0.0.1 URL that only works on the API box",
+    "file": "ee/pocketpaw_ee/sites/truth_lane.py",
+    "find": "    if mode == EXPOSURE_LOOPBACK:",
+    "replace": "    if True:",
+    "tests": ["tests/ee/sites/test_truth_lane.py"]
+  },
+  {
+    "label": "an unset preview origin yields an empty base URL, so every preview link is a bare path that resolves against whichever page opened it",
+    "file": "ee/pocketpaw_ee/sites/truth_lane.py",
+    "find": "        if not origin:\n            raise PreviewExposureNotConfigured(",
+    "replace": "        if False:\n            raise PreviewExposureNotConfigured(",
+    "tests": ["tests/ee/sites/test_truth_lane.py"]
+  },
+  {
+    "label": "an undecided exposure raises out of the preview call, so a build that succeeded is reported as failed because nobody has picked an origin yet",
+    "file": "ee/pocketpaw_ee/sites/truth_lane.py",
+    "find": "    except PreviewExposureNotConfigured as exc:",
+    "replace": "    except SystemExit as exc:",
+    "tests": ["tests/ee/sites/test_truth_lane.py"]
+  },
+  {
+    "label": "the app-origin refusal stops naming the cookie mechanic, so whoever hits it adds a sandbox attribute and breaks the page's own assets instead",
+    "file": "ee/pocketpaw_ee/sites/truth_lane.py",
+    "find": "            \"JavaScript would execute where the session cookie lives, and a CSP sandbox \"",
+    "replace": "            \"JavaScript would run somewhere it should not. \"",
+    "tests": ["tests/ee/sites/test_truth_lane.py"]
+  },
+  {
+    "label": "the caller's resolved worker expectation is ignored, so every healthy static svelte preview logs that the artifact may be incomplete and the warning stops meaning anything",
+    "file": "ee/pocketpaw_ee/sites/artifact_preview.py",
+    "find": "    expected_worker = (\n        emits_server_worker(engine) if expect_server_worker is None else expect_server_worker\n    )",
+    "replace": "    expected_worker = emits_server_worker(engine)",
+    "tests": ["tests/ee/sites/test_truth_lane.py"]
+  }
+]


### PR DESCRIPTION
`artifact_preview.py` landed complete, guarded and mutation-tested, with no caller
anywhere. This adds the caller — and the check that has to sit in front of it, because
storing an artifact and serving it is not sufficient for one of the shapes the build lane
produces.

## The problem this exists to prevent

`adapter-cloudflare` emits a `_worker.js` that is the *renderer*, and the artifact ships a
`_routes.json` handing that worker `/*` minus the immutable assets. This lane serves
files: no workerd, no Node, no D1 binding, no `hooks.server.ts` gate. On top of that the
emitted worker imports `../output/server/index.js` and `../cloudflare-tmp/manifest.js`,
and both sit outside the directory the lane tars — so the artifact is not even complete
(proving record section 8 item 14).

The static files beside that worker unpack perfectly well, and that is the trap. Serve
them and the customer is shown a page their site never serves and reads it as their site
being broken, when it is our packaging that is. So worker presence is a refusal, not a
warning.

## What was added

**`ee/pocketpaw_ee/sites/truth_lane.py`** (new). `open_preview(site_id, artifact, engine=)`
gates first and stores second, and never raises — it hangs off a build that may already
have succeeded.

- **The gate runs before the store.** `store_artifact` unpacks into a hidden sibling and
  swaps it in, so gating on its *result* would leave a window where a refused artifact is
  live at the preview address. A name-level tar scan costs one cheap pass and keeps the
  refusal structural: a refused artifact never lands. The unpack result is still
  cross-checked against the scan afterwards — two readings of the same bytes that disagree
  mean one of them is wrong, and the safe response to not knowing which is to serve
  neither.
- **A refusal discards any previous preview.** Leaving the last good tree in place keeps
  answering 200 at the same address, so the surface whose job is to say "this build is
  correct" would be saying it about a different build.
- **Named reasons, not booleans.** `server_rendered_artifact`, `incomplete_artifact`,
  `no_entry_document`, `engine_runs_no_build`, `artifact_unreadable`, `no_artifact`,
  `artifact_rejected`, `store_failed`, `gate_disagreed`. Each is distinct for the reason
  `resolve` keeps `unsafe_path` and `escaped_root` apart: with one shared string, a
  mutation disabling either check still looks caught.
- **`assess_project`** answers the same question for a build that is still a project dir.

**`artifact_preview.py`** — one change: `store_artifact` / `safe_store_artifact` grew an
optional `expect_server_worker`. The existing cross-check asks the *engine name* whether a
worker was expected, and since SL-1 the name cannot answer that for svelte, so it warned
"the artifact may be incomplete" on every healthy static landing preview. `None` keeps the
historical behaviour, so every existing call site is byte-identical. No signal is lost:
the case now suppressed there is refused outright, which is louder than a log line.

**`local_server.py`** — header plus one docstring. No behaviour change.

## Resolved off the artifact, never off the engine name

Since SL-1 a svelte site builds static (`adapter-static` to `build`, no worker,
self-contained) or dynamic (`adapter-cloudflare` to `.svelte-kit/cloudflare`, worker
load-bearing) under the *same* engine string. A name-keyed gate would refuse every static
landing site and admit every dynamic one. So the gate reads tar member names for an
artifact and calls `resolve_emits_server_worker` / `resolve_static_output_rel` for a
project dir. `emits_server_worker` is never consulted.
`test_the_engine_name_decides_nothing` is what separates that from a comment claiming it.

## What the user would see on the dynamic track

`open_preview` returns `previewable=False`, `reason="server_rendered_artifact"`, `url=None`,
and nothing is stored. A GET at the address the preview *would* have had answers 404
`no_preview` — the refusal is a fact about the filesystem, not a flag a later reader has to
remember to check. The detail text says the pages come from a Cloudflare Worker the preview
cannot run, that the files packaged beside it are not what visitors would see, and to
publish the site to see the real thing. It does not blame the customer's site for our
packaging.

## No-false-success, preserved end to end

No catch-all route, no SPA fallback, no friendly 200 error page. Checked *through* the
truth lane rather than beside it: a missing asset stays a 404 whose body contains neither
the bundle nor the home page, over the return value and over real HTTP.

## Security

- **No per-site signed key in a client bundle or in view-source.** Checked, not asserted:
  the dynamic fixture's worker carries a `pp_tok_` canary, and after a refusal the test
  walks every file under the preview root and asserts those bytes appear in none of them.
  Nothing is stored at all, so the worker never sits inside a served tree. A second test
  confirms a request for `_worker.js` stays a 404 even for an artifact the lane admits.
- **Preview content cannot reach app-origin privileges or cookies.** Nothing here serves
  customer content from the app origin. The default exposure is loopback; `app-origin`
  refuses.
- **Path traversal** is untouched — `truth_lane` performs no path joins from request input
  and stores through `store_artifact` unchanged, so both existing guards and all 27 of
  their mutations still apply (re-run, all caught). The two path assertions I did add are
  literals-only name checks (a backslash-separated member, a nested `index.html`), not
  resolution behaviour, so nothing pins a platform-specific `reason`.

## The decision I deliberately left open

**Which origin serves preview content to a browser.** Research doc section 8 item 3, and
section 9f warns explicitly it must not be settled as a byproduct of a preview slice.
`preview_base_url()` is the seam, and it is the only place that has to change:

| `PAW_SITES_PREVIEW_EXPOSURE` | state |
|---|---|
| `loopback` (default) | works. Decides nothing — 127.0.0.1 is not reachable off the box, so no token to design and no customer JS where a session cookie lives |
| `preview-origin` | mechanism present; needs `PAW_SITES_PREVIEW_ORIGIN`. Turning it on is a hosting change, hence not the default |
| `app-origin` | refuses, naming the cookie mechanic — a CSP sandbox empties the document's site-for-cookies and the page's own same-origin assets stop loading, so "add the sandbox attribute" is not the fix |
| `signed-url` | refuses, naming what needs designing: what is signed, lifetime, revocation, who may mint one |

The refusals are why the choice cannot be made by accident. An unknown value falls back to
loopback (the mode that exposes nothing); a `preview-origin` with no base URL refuses
rather than silently degrading to a 127.0.0.1 URL that only works on the API box. An
undecided exposure yields `url=None` with a `previewable=True` verdict, so a good build is
never reported as broken because nobody has picked an origin.

## Also deliberately not done

- **No frontend.** The button is a follow-up; `paw-enterprise` was not touched.
- **No router endpoint.** One that served content would *be* the app-origin decision; one
  that returned metadata would need artifact persistence that does not exist yet (the arq
  build-job slice). The wired surface is `open_preview` plus the loopback server, proven
  over real HTTP.
- **`serve_artifact_preview` is left ungated.** It has no production caller, and it is what
  keeps `resolve`'s own `_worker.js` refusal reachable over HTTP — that test file's fixtures
  are worker-bearing by design, so something must be able to store such a tree. A test pins
  the difference (`test_the_gate_refuses_what_the_ungated_store_serves`) so it cannot drift
  into a surprise. Folding it behind the gate is a follow-up that has to rework
  `test_artifact_preview_server.py`.

## Verified

Measured on the base commit `ba86fcf` and again on the head, on Windows.

- `tests/ee/sites`: baseline **4 failed / 818 passed / 4 skipped** to head **4 failed / 863
  passed / 4 skipped**. Failure *names* diffed, not counts: identical, all four in
  `test_generator_client_timeout.py`, all pre-existing. Plus 45 tests.
- `tests/ee/sites/test_truth_lane.py` alone: **45 passed**.
- `tests/mutations/sites_truth_lane.json` (new, 24 mutations): **all 24 caught**. Two
  escaped on the first run because a following `except Exception` clause absorbed the
  mutated case; both were real design defects — a store refusal and an unforeseen store
  failure reported the same cause, and an undecided exposure was logged the same way as a
  socket that would not bind. Split into `artifact_rejected` / `store_failed` and given
  distinct log messages, then re-run. Every anchor verified unique before each run, and the
  whole plan re-run after the last edit.
- `tests/mutations/sites_artifact_preview.json` (pre-existing, 27): re-run because I edited
  that file. **all 27 caught.**
- `uv run ruff check .` and `uv run ruff format --check .`: both clean, repo-wide (2686
  files).
- `lint-imports` (root) 1 kept / 0 broken; `lint-imports --config ee/pyproject.toml` 34
  kept / 0 broken.
- No new dependencies.
