### PR TITLE
feat(sites): move the previewability gate to the disk boundary

### DIFF
--- a/ee/pocketpaw_ee/sites/artifact_preview.py
+++ b/ee/pocketpaw_ee/sites/artifact_preview.py
@@ -23,18 +23,32 @@
 #      such.
 #
 # Updated 2026-08-10 (SG-10 wiring — this module now has a caller). ``truth_lane.py``
-# is it, and it sits IN FRONT of everything here: it refuses an artifact whose pages are
-# rendered by a ``_worker.js`` we cannot execute, so such an artifact is never stored and
-# never served. Nothing in this module changed shape as a result — the guards, the skip
-# and the refusals are the same — except ``store_artifact``/``safe_store_artifact``,
-# which grew an optional ``expect_server_worker``. That exists because the
+# is it. It owns the REASONS a build is refused, the discard-on-refusal, the project-dir
+# probe and the exposure seam; this module owns tar-reading and disk. ``store_artifact``
+# also grew an optional ``expect_server_worker``, because the
 # ``emits_server_worker(engine)`` cross-check below asks the ENGINE NAME a question the
 # name stopped being able to answer at SL-1: engine ``"svelte"`` now covers a static
 # landing build with no worker and a dynamic one with a load-bearing worker, so the
 # check warned "the artifact may be incomplete" on every healthy static svelte preview.
 # A caller that resolved the answer off the artifact passes it in; ``None`` keeps the old
-# behaviour for every other caller. No signal is lost — the missing-worker case
-# ``truth_lane`` suppresses here, it refuses outright, which is louder than a log line.
+# behaviour for every other caller.
+#
+# Updated 2026-08-10 (the gate moved TO THE DISK BOUNDARY). The previewability check
+# first shipped one layer up, in ``truth_lane`` only. That left ``store_artifact`` and
+# ``safe_store_artifact`` as un-gated public functions with inviting names: a future
+# caller wiring either of them would have stored and served a worker-rendered tree with
+# nothing to suggest a gate had been skipped. So the check is HERE now, in the one
+# function every path to disk goes through — a check anywhere else is bypassable by
+# picking a different caller. ``scan_artifact`` and ``ArtifactShape`` moved in with it,
+# which is where they belonged anyway: reading a tarball is this module's job, and the
+# rule now has a single definition (``ArtifactShape.is_server_rendered``) that both the
+# refusal and ``truth_lane``'s naming of it read.
+#
+# ``store_unvouched_artifact`` is the ONE deliberate way past the gate, and the tests
+# that need a tree containing what ``resolve`` refuses are its only caller. Its name is
+# the control, and the name is CHECKED — a test scans every module under ``src/`` and
+# ``ee/`` and fails if any of them mentions it. See that function for why the seam is
+# kept rather than the coverage deleted.
 #
 # Choosing static REMOVES constraints. The in-tab runtime needs cross-origin
 # isolation, and COEP ``require-corp`` blocks presigned-S3 images — exactly what the
@@ -138,6 +152,17 @@ _DEPLOY_METADATA_NAMES: frozenset[str] = frozenset(
     {"_routes.json", ".assetsignore", "_headers", "_redirects"}
 )
 
+#: ``adapter-cloudflare``'s routing table. Deploy configuration when the question is what
+#: to SERVE (hence its membership in the set above, which is skipped at unpack), and
+#: EVIDENCE when the question is what the build expected to render it — see
+#: :attr:`ArtifactShape.declares_absent_renderer`. Both readings are legitimate; naming it
+#: once keeps them from drifting apart.
+ROUTING_TABLE_NAME = "_routes.json"
+
+#: The document a preview opens at. An artifact without one at its ROOT has nothing to
+#: show, and saying so beats opening the preview onto its own 404 page.
+ENTRY_DOCUMENT_NAME = "index.html"
+
 #: Zip-bomb ceilings. The measured artifacts are 4 and 24 entries at tens of KB, so
 #: these are orders of magnitude clear of anything real; they exist because the tarball
 #: is built from customer content and a preview must not be a way to fill the disk.
@@ -195,6 +220,16 @@ class ArtifactTooLarge(ArtifactRejected):
 
 class BadSiteId(ArtifactRejected):
     """The site id is not a safe single path segment."""
+
+
+class ArtifactNotPreviewable(ArtifactRejected):
+    """The artifact's pages are rendered by a server entry this module cannot execute.
+
+    Raised by :func:`store_artifact` before anything is written. Its own subclass rather
+    than a bare :class:`ArtifactRejected` because the caller acts on it differently: an
+    ``ArtifactTooLarge`` is a fault to log, while this is a NORMAL, expected outcome for
+    a whole track of sites and the surface above has a specific thing to say about it.
+    """
 
 
 @dataclass(frozen=True)
@@ -410,6 +445,93 @@ def unpack_artifact(artifact: bytes, dest: Path) -> UnpackedArtifact:
     )
 
 
+# ---------------------------------------------------------------------------
+# Reading an artifact's SHAPE without extracting it
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ArtifactShape:
+    """What a NAME-LEVEL scan of an artifact tarball found. Nothing is extracted.
+
+    Names only, deliberately. Every question the gate below asks is answerable from the
+    member list, and the one file whose contents might tempt a reader — the worker
+    bundle, which has carried a substituted per-site signed key — is therefore never
+    opened.
+    """
+
+    entries: int
+    server_entries: tuple[str, ...]
+    routing_tables: tuple[str, ...]
+    has_entry_document: bool
+
+    @property
+    def is_server_rendered(self) -> bool:
+        """THE gate. A worker in the artifact means the worker is the renderer, and this
+        module cannot execute one. Read by :func:`store_artifact` to refuse and by
+        ``truth_lane`` to name the refusal, so the rule has one definition."""
+        return bool(self.server_entries)
+
+    @property
+    def declares_absent_renderer(self) -> bool:
+        """A routing table with no worker beside it: the artifact names a renderer it
+        does not contain. Distinct from :attr:`is_server_rendered` because the harm is
+        different — that one is a tree we cannot run, this one is a tree that is not all
+        there — and because a single combined check would report both as one cause."""
+        return bool(self.routing_tables) and not self.server_entries
+
+
+def _member_segments(name: str) -> tuple[str, ...]:
+    """A member name split into path segments, ``.`` and empties dropped.
+
+    Distinct from :func:`_normalized_member_path`, which REFUSES a hostile name because
+    it is about to write it. This one only has to SEE the name, so it normalizes instead
+    of refusing: a member called ``_app\\_worker.js`` is one filename on POSIX and a path
+    on Windows, and a scan that read it as a filename would not notice the worker at all.
+    """
+    return tuple(part for part in name.replace("\\", "/").split("/") if part not in ("", "."))
+
+
+def scan_artifact(artifact: bytes) -> ArtifactShape:
+    """Name-level scan of an artifact tarball. Reads no member's contents.
+
+    Raises :class:`ArtifactUnreadable` for bytes that are not a readable gzipped tar, so
+    a caller reports the same cause :func:`unpack_artifact` would.
+    """
+    try:
+        tar = tarfile.open(fileobj=io.BytesIO(artifact), mode="r:gz")
+    except (tarfile.TarError, OSError, EOFError) as exc:
+        raise ArtifactUnreadable(f"artifact is not a readable gzipped tar: {exc}") from exc
+
+    entries = 0
+    server: list[str] = []
+    routes: list[str] = []
+    entry_document = False
+    with tar:
+        for member in tar:
+            segments = _member_segments(member.name)
+            if not segments:
+                continue
+            entries += 1
+            if any(seg in _SERVER_ENTRY_NAMES for seg in segments):
+                server.append("/".join(segments))
+            if segments[-1] == ROUTING_TABLE_NAME:
+                routes.append("/".join(segments))
+            if segments == (ENTRY_DOCUMENT_NAME,):
+                entry_document = True
+    return ArtifactShape(
+        entries=entries,
+        server_entries=tuple(server),
+        routing_tables=tuple(routes),
+        has_entry_document=entry_document,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Storing
+# ---------------------------------------------------------------------------
+
+
 def store_artifact(
     site_id: str,
     artifact: bytes,
@@ -418,6 +540,18 @@ def store_artifact(
     expect_server_worker: bool | None = None,
 ) -> PreviewSnapshot:
     """Unpack ``artifact`` as this site's preview, replacing any previous one.
+
+    THE GATED DOOR TO DISK, and the reason it is gated here rather than only in the
+    surface above: every path that puts a preview tree on disk goes through this
+    function, so a check anywhere else can be bypassed by picking a different caller.
+    :class:`ArtifactNotPreviewable` is raised — before anything is written — for an
+    artifact whose pages come from a ``_worker.js`` this module cannot execute. Serving
+    the static files packaged beside such a worker would show a page the site never
+    serves, which is the one failure mode a verification preview must not have.
+
+    :func:`store_unvouched_artifact` is the deliberate, explicitly-named way past this,
+    and it exists for exactly one caller: the tests that have to construct a tree
+    containing the thing :func:`resolve` refuses.
 
     Refuses an engine whose static output is the project ROOT (``html``, whose
     ``static_output_rel`` is ``"."``), mirroring the guard in
@@ -449,6 +583,44 @@ def store_artifact(
     Unpacks into a temporary sibling and swaps it in, so a failure part-way through
     leaves the PREVIOUS preview intact rather than a half-written tree serving a
     mixture of two builds.
+    """
+    shape = scan_artifact(artifact)
+    if shape.is_server_rendered:
+        raise ArtifactNotPreviewable(
+            "this artifact's pages are rendered by a server entry "
+            f"({', '.join(shape.server_entries)}) that a static preview cannot execute, "
+            "so the files packaged beside it are not the pages the site serves"
+        )
+    return store_unvouched_artifact(
+        site_id, artifact, engine=engine, expect_server_worker=expect_server_worker
+    )
+
+
+def store_unvouched_artifact(
+    site_id: str,
+    artifact: bytes,
+    *,
+    engine: str,
+    expect_server_worker: bool | None = None,
+) -> PreviewSnapshot:
+    """UNSAFE. Store an artifact WITHOUT asking whether it can be previewed faithfully.
+
+    ┌─────────────────────────────────────────────────────────────────────────────────┐
+    │ NEVER CALL THIS FROM A PRODUCTION PATH. Use :func:`store_artifact`.              │
+    └─────────────────────────────────────────────────────────────────────────────────┘
+
+    It exists for one reason. :func:`resolve` refuses ``_worker.js`` — the file that has
+    historically carried a substituted per-site signed key — and that refusal has to stay
+    under test, over real HTTP, which needs a stored tree that CONTAINS a worker. Once
+    :func:`store_artifact` refuses such an artifact before it lands, no gated path can
+    build one, and the refusal would quietly become unreachable and stop being tested.
+    Deleting that coverage to close the hole would trade a proven guard for an unproven
+    one, so the seam is kept and named instead.
+
+    THE NAME IS THE CONTROL, and it is checked rather than trusted:
+    ``tests/ee/sites/test_truth_lane.py::test_no_production_module_stores_an_unvouched_artifact``
+    scans every module under ``src/`` and ``ee/`` and fails if any of them mentions this
+    function. A reviewer does not have to notice the call — CI does.
     """
     site_id = _check_site_id(site_id)
     engine = normalize_engine(engine)
@@ -529,10 +701,13 @@ def safe_store_artifact(
     way ``screenshot.safe_take_*`` does for card images. The strict form stays
     available for a caller that is asking for a preview and is entitled to the error.
 
-    NOT THE TRUTH LANE. This stores whatever unpacks; it asks no question about whether
-    the artifact can be RENDERED faithfully, so a worker-rendered artifact stores its
-    static leftovers here and serves them. ``truth_lane.open_preview`` is the gated
-    entry point, and it is the one a preview surface should call.
+    GATED, because it delegates to :func:`store_artifact`: a worker-rendered artifact
+    returns ``None`` here rather than storing its static leftovers. That needed no change
+    to this function's contract — ``None`` has always meant "no preview" — which is why
+    the gate could go in at the door instead of at each caller.
+
+    A caller that wants the REASON rather than just ``None`` should call
+    ``truth_lane.open_preview``; this signature cannot carry one.
     """
     if not artifact:
         return None
@@ -782,10 +957,14 @@ def resolve(site_id: str, subpath: str, *, method: str = "GET") -> PreviewRespon
 
 
 __all__ = [
+    "ENTRY_DOCUMENT_NAME",
     "MAX_ENTRIES",
     "MAX_TOTAL_BYTES",
     "PREVIEW_URL_PREFIX",
+    "ROUTING_TABLE_NAME",
+    "ArtifactNotPreviewable",
     "ArtifactRejected",
+    "ArtifactShape",
     "ArtifactTooLarge",
     "ArtifactUnreadable",
     "BadSiteId",
@@ -799,6 +978,8 @@ __all__ = [
     "previews_home",
     "resolve",
     "safe_store_artifact",
+    "scan_artifact",
     "store_artifact",
+    "store_unvouched_artifact",
     "unpack_artifact",
 ]

--- a/ee/pocketpaw_ee/sites/local_server.py
+++ b/ee/pocketpaw_ee/sites/local_server.py
@@ -19,11 +19,18 @@
 # Updated 2026-08-10 (SG-10 wiring): the preview branch now has a gated caller in front
 # of it — `truth_lane.open_preview`, which refuses an artifact whose pages are rendered by
 # a `_worker.js` this server cannot execute, so such a tree is never stored. Nothing in
-# this file's request handling changed. `serve_artifact_preview` is deliberately still
-# UNGATED (see its docstring): `resolve`'s own `_worker.js` refusal has to stay reachable
-# over real HTTP, which means something must be able to store a worker-bearing tree.
-# `truth_lane` also reaches back here for the loopback base URL, which is why its import
-# of this module is inside a function.
+# this file's request handling changed.
+#
+# Updated 2026-08-10 (`serve_artifact_preview` is gated too). It shipped ungated for one
+# turn, on the reasoning that `resolve`'s own `_worker.js` refusal has to stay reachable
+# over real HTTP and therefore something must be able to store a worker-bearing tree. That
+# reasoning was right about the requirement and wrong about which function should satisfy
+# it: this one is the obvious front door, and an ungated front door acquires a caller.
+# `artifact_preview.store_unvouched_artifact` satisfies the requirement instead, under a
+# name that says what it is and with a test asserting no production module calls it.
+#
+# `truth_lane` reaches back here for the loopback base URL, which is why its import of
+# this module — and this module's import of it — are both inside functions.
 #
 # ONE SERVER, TWO BRANCHES, on purpose. The established in-app preview pattern in
 # this codebase is already "a localhost HTTP server, iframed by the builder"
@@ -320,34 +327,28 @@ def preview_url_for(site_id: str) -> str:
 def serve_artifact_preview(site_id: str, artifact: bytes | None, *, engine: str) -> str | None:
     """Store a build artifact as this site's preview and return its URL, or ``None``.
 
-    The artifact-lane peer of :func:`deploy_local`. NEVER RAISES — a preview that could
-    not be unpacked, or a server that could not start, returns ``None`` and is logged.
-    That is the whole difference between the two functions: ``deploy_local`` is the
-    publish itself and must report its failures, while a preview is a convenience and
-    must not be able to fail a publish that already succeeded.
+    The artifact-lane peer of :func:`deploy_local`. NEVER RAISES — an artifact that
+    cannot be previewed faithfully, one that could not be unpacked, or a server that
+    could not start, all return ``None`` and are logged. That is the whole difference
+    between the two functions: ``deploy_local`` is the publish itself and must report its
+    failures, while a preview is a convenience and must not be able to fail a publish
+    that already succeeded.
 
     ``engine`` selects nothing about the LAYOUT — the lane tars from the resolved
     static-output dir, so every artifact already arrives rooted at its deployable root.
     It is passed through for the server-entry cross-check in ``store_artifact``.
 
-    ┌─────────────────────────────────────────────────────────────────────────────────┐
-    │ NOT THE TRUTH LANE. ``truth_lane.open_preview`` is the wired entry point (SG-10  │
-    │ wiring) and it is the one a preview surface must call.                            │
-    └─────────────────────────────────────────────────────────────────────────────────┘
+    GATED, via ``truth_lane.open_preview``. It used to store whatever unpacked, which
+    meant an ``adapter-cloudflare`` artifact — whose pages come from a ``_worker.js``
+    nothing here can execute — had its static leftovers served as though they were the
+    site. That is the failure mode a verification preview must not have. The function had
+    no production caller when the gate landed, and closing it then rather than later is
+    the point: whoever eventually wires the obvious-looking "serve an artifact preview"
+    front door has no reason to suspect a gate exists elsewhere that they are skipping.
 
-    This function stores whatever unpacks and hands back an address. It asks no question
-    about whether the artifact can be RENDERED faithfully, so an ``adapter-cloudflare``
-    artifact — whose pages come from a ``_worker.js`` nothing here can execute — stores
-    its static leftovers and serves them as though they were the site. That is the
-    failure mode a verification preview must not have, and it is why the gate lives in
-    ``truth_lane`` rather than being assumed here.
-
-    It is kept UNGATED on purpose rather than delegating: ``resolve``'s own ``_worker.js``
-    refusal is the last line of defence and has to stay reachable over real HTTP, which
-    means something has to be able to store a worker-bearing tree. That is this function,
-    and ``tests/ee/sites/test_artifact_preview_server.py`` is what exercises it.
-    ``tests/ee/sites/test_truth_lane.py::test_the_gate_refuses_what_the_ungated_store_serves``
-    pins the difference between the two so it cannot drift into a surprise.
+    A caller that wants the REASON for a refusal should call ``truth_lane.open_preview``
+    directly — this signature returns ``str | None`` and cannot carry one. ``None`` has
+    always meant "no preview", which is why gating changed no contract here.
 
     SL-1's caveat here said the server-entry cross-check should ask
     ``resolve_emits_server_worker`` against the build dir once the lane had a caller. IT
@@ -356,19 +357,20 @@ def serve_artifact_preview(site_id: str, artifact: bytes | None, *, engine: str)
     sandbox that deletes itself, so no local process ever holds the built project dir to
     resolve against. All that comes back is the artifact.
 
-    So the two halves answer it from different evidence, and both are resolved off the
-    ARTIFACT rather than from an engine name. ``truth_lane`` scans the tar's member names.
-    ``store_artifact`` asks ``engines.expects_server_worker``, a tri-state returning
-    ``None`` for svelte because the name genuinely cannot say which adapter ran — "either
-    shape is legitimate" being the honest answer rather than a warning on every healthy
-    static build. The ``resolve_*`` form stays right for the LOCAL builder path, which
-    does hold a project dir (see ``workers_deploy``)."""
+    So the two halves answer it from different evidence, and neither consults an engine
+    name. ``truth_lane`` scans the tar's member names to decide previewability.
+    ``store_artifact`` asks ``engines.expects_server_worker`` for its cross-check, a
+    tri-state returning ``None`` for svelte because the name genuinely cannot say which
+    adapter ran — "either shape is legitimate" being the honest answer rather than a
+    warning on every healthy static build. The ``resolve_*`` form stays right for the
+    LOCAL builder path, which does hold a project dir (see ``workers_deploy``)."""
+    # Imported inside the function: ``truth_lane`` reaches back here for the loopback base
+    # URL, so a module-level import would close the cycle.
+    from pocketpaw_ee.sites import truth_lane
+
     try:
-        snapshot = artifact_preview.safe_store_artifact(site_id, artifact, engine=engine)
-        if snapshot is None:
-            return None
-        return preview_url_for(site_id)
-    except Exception:  # noqa: BLE001 — ensure_server() is the remaining raiser
+        return truth_lane.open_preview(site_id, artifact, engine=engine).url
+    except Exception:  # noqa: BLE001 — open_preview is total, so this is belt-and-braces
         logger.warning(
             "sites: could not serve an artifact preview for site %s", site_id, exc_info=True
         )

--- a/ee/pocketpaw_ee/sites/truth_lane.py
+++ b/ee/pocketpaw_ee/sites/truth_lane.py
@@ -64,6 +64,17 @@
 # two readings of the same bytes that disagree mean one of them is wrong, and the safe
 # response to not knowing which is to serve neither.
 #
+# WHERE THE GATE ACTUALLY LIVES, since 2026-08-10, AND WHY IT IS IN TWO PLACES.
+# ``artifact_preview.store_artifact`` ENFORCES it, because that is the one function every
+# path to disk goes through and a check anywhere else is bypassable by picking a different
+# caller. This module EXPLAINS it: the enforcement can only raise, and a preview surface
+# needs a reason it can show and a decision about what to do with the previous preview.
+# So the scan here is not redundant with the door — it produces the reason, the detail, and
+# the two questions the door does not ask (an absent renderer, a missing entry document) —
+# and the door is what makes the rule impossible to route around. Neither half is
+# sufficient alone, and the rule itself has ONE definition either way:
+# ``ArtifactShape.is_server_rendered``.
+#
 # A REFUSAL ALSO DISCARDS ANY PREVIOUS PREVIEW, which is the non-obvious half. Leaving
 # the last good tree in place would keep answering 200 at the same address for a build
 # that was refused — the truth lane asserting correctness about the wrong build. That is
@@ -78,10 +89,8 @@
 # to be decided. Choosing later is one environment variable, not a rewrite.
 from __future__ import annotations
 
-import io
 import logging
 import os
-import tarfile
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -89,15 +98,25 @@ from pocketpaw_ee.sites import artifact_preview
 
 # ``_SERVER_ENTRY_NAMES`` is IMPORTED rather than mirrored, private name and all. A local
 # copy plus a drift test is the other option and it is strictly worse here: the two sets
-# have to agree by construction, because a name this gate does not recognise as a server
+# have to agree by construction, because a name this module does not recognise as a server
 # entry is a name ``unpack_artifact`` would happily write into a served tree.
 from pocketpaw_ee.sites.artifact_preview import (
     _SERVER_ENTRY_NAMES as SERVER_ENTRY_NAMES,
 )
+
+# ``ArtifactShape`` / ``scan_artifact`` / the two member names live in
+# ``artifact_preview`` because reading a tarball is that module's job and because
+# ``store_artifact`` needs the same shape to refuse on. Re-exported here so this module
+# still reads as the one place the previewability VOCABULARY is defined.
 from pocketpaw_ee.sites.artifact_preview import (
+    ENTRY_DOCUMENT_NAME,
+    ROUTING_TABLE_NAME,
+    ArtifactNotPreviewable,
     ArtifactRejected,
+    ArtifactShape,
     PreviewSnapshot,
     UnpackedArtifact,
+    scan_artifact,
 )
 from pocketpaw_ee.sites.engines import (
     normalize_engine,
@@ -107,16 +126,6 @@ from pocketpaw_ee.sites.engines import (
 )
 
 logger = logging.getLogger(__name__)
-
-#: ``adapter-cloudflare``'s routing table. Its presence means the build expected a
-#: worker to answer requests. Skipped at unpack by ``artifact_preview`` (it is deploy
-#: configuration, not content) — this module reads it as EVIDENCE, which is a different
-#: job from deciding whether to serve it.
-ROUTING_TABLE_NAME = "_routes.json"
-
-#: The document a preview opens at. An artifact without one has nothing to show, and
-#: saying so beats opening the preview onto its own 404 page.
-ENTRY_DOCUMENT_NAME = "index.html"
 
 # ---------------------------------------------------------------------------
 # Refusal reasons
@@ -303,34 +312,6 @@ def preview_address(site_id: str) -> str | None:
 
 
 @dataclass(frozen=True)
-class ArtifactShape:
-    """What a NAME-LEVEL scan of an artifact found. Nothing is extracted or read.
-
-    Names only, deliberately. The gate's questions ("is there a renderer we cannot
-    run", "is there an entry document") are all answerable from the member list, and
-    the one file whose contents might tempt a reader — the worker bundle, which has
-    carried a substituted per-site signed key — is therefore never opened.
-    """
-
-    entries: int
-    server_entries: tuple[str, ...]
-    routing_tables: tuple[str, ...]
-    has_entry_document: bool
-
-    @property
-    def is_server_rendered(self) -> bool:
-        return bool(self.server_entries)
-
-    @property
-    def declares_absent_renderer(self) -> bool:
-        """A routing table with no worker beside it: the artifact names a renderer it
-        does not contain. Distinct from :attr:`is_server_rendered` because the harm is
-        different — that one is a tree we cannot run, this one is a tree that is not all
-        there — and because a single combined check would report both as one cause."""
-        return bool(self.routing_tables) and not self.server_entries
-
-
-@dataclass(frozen=True)
 class TruthLaneVerdict:
     """Whether an artifact can be previewed faithfully, and why not when it cannot."""
 
@@ -364,61 +345,16 @@ class TruthLanePreview:
         return self.verdict.previewable and self.url is not None
 
 
-def _segments(name: str) -> tuple[str, ...]:
-    """Member name split into path segments, ``.`` and empties dropped.
-
-    ``tar -C <dir> .`` names members ``./x/y``. Backslash is treated as a separator too:
-    a member named ``_app\\_worker.js`` is a single filename on POSIX and a path on
-    Windows, and a gate that read it as a filename would not see the worker at all.
-    ``unpack_artifact`` REFUSES such a member outright, which is the right answer there;
-    here the job is to notice it, so it is split rather than dropped.
-    """
-    return tuple(part for part in name.replace("\\", "/").split("/") if part not in ("", "."))
-
-
-def scan_artifact(artifact: bytes) -> ArtifactShape:
-    """Name-level scan of an artifact tarball.
-
-    Raises :class:`artifact_preview.ArtifactUnreadable` when the bytes are not a
-    readable gzipped tar, so the caller reports the same cause ``unpack_artifact``
-    would.
-    """
-    try:
-        tar = tarfile.open(fileobj=io.BytesIO(artifact), mode="r:gz")
-    except (tarfile.TarError, OSError, EOFError) as exc:
-        raise artifact_preview.ArtifactUnreadable(
-            f"artifact is not a readable gzipped tar: {exc}"
-        ) from exc
-
-    entries = 0
-    server: list[str] = []
-    routes: list[str] = []
-    entry_document = False
-    with tar:
-        for member in tar:
-            segments = _segments(member.name)
-            if not segments:
-                continue
-            entries += 1
-            if any(seg in SERVER_ENTRY_NAMES for seg in segments):
-                server.append("/".join(segments))
-            if segments[-1] == ROUTING_TABLE_NAME:
-                routes.append("/".join(segments))
-            if segments == (ENTRY_DOCUMENT_NAME,):
-                entry_document = True
-    return ArtifactShape(
-        entries=entries,
-        server_entries=tuple(server),
-        routing_tables=tuple(routes),
-        has_entry_document=entry_document,
-    )
-
-
 _SERVER_RENDERED_DETAIL = (
     "This build's pages are produced by a Cloudflare Worker, which a preview cannot "
     "run — it serves files, and it has no database binding or sign-in gate. The static "
     "files packaged beside that worker are not the pages your visitors would see, so "
     "showing them would misrepresent the site. Publish it to see the real thing."
+)
+
+_DISAGREED_DETAIL = (
+    "The build output could not be checked consistently, so it is not being previewed. "
+    "This is a packaging problem on our side."
 )
 
 _INCOMPLETE_DETAIL = (
@@ -580,6 +516,19 @@ def open_preview(site_id: str, artifact: bytes | None, *, engine: str) -> TruthL
         snapshot: PreviewSnapshot = artifact_preview.store_artifact(
             site_id, artifact, engine=normalized, expect_server_worker=False
         )
+    except ArtifactNotPreviewable as exc:
+        # THE DOOR refused what THIS module's scan admitted. Both read the same bytes with
+        # the same scan, so they can only disagree if one of them has been broken — which
+        # makes this the same fact as the post-store cross-check below, and it gets the
+        # same reason. Listed before ``ArtifactRejected`` because it is a subclass of it.
+        logger.error(
+            "sites.truth_lane: site %s's artifact passed this module's scan and was then "
+            "refused at the door (%s) — refusing rather than serving a tree we cannot "
+            "vouch for",
+            site_id,
+            exc,
+        )
+        return _refused(site_id, normalized, _refuse(REASON_GATE_DISAGREED, _DISAGREED_DETAIL))
     except ArtifactRejected as exc:
         # The store REFUSED the artifact — a typed, expected outcome (too large, unsafe
         # member, bad site id). Reported separately from the clause below because they
@@ -621,14 +570,7 @@ def open_preview(site_id: str, artifact: bytes | None, *, engine: str) -> TruthL
             ", ".join(snapshot.unpacked.server_entries),
         )
         return _refused(
-            site_id,
-            normalized,
-            _refuse(
-                REASON_GATE_DISAGREED,
-                "The build output could not be checked consistently, so it is not being "
-                "previewed. This is a packaging problem on our side.",
-                verdict.shape,
-            ),
+            site_id, normalized, _refuse(REASON_GATE_DISAGREED, _DISAGREED_DETAIL, verdict.shape)
         )
 
     return TruthLanePreview(
@@ -662,6 +604,7 @@ __all__ = [
     "REASON_STORE_FAILED",
     "ROUTING_TABLE_NAME",
     "SERVER_ENTRY_NAMES",
+    "ArtifactNotPreviewable",
     "ArtifactShape",
     "PreviewExposureNotConfigured",
     "TruthLanePreview",

--- a/tests/ee/sites/test_artifact_preview.py
+++ b/tests/ee/sites/test_artifact_preview.py
@@ -651,11 +651,27 @@ def test_a_static_svelte_artifact_is_not_reported_as_incomplete(caplog):
 
 
 def test_a_dynamic_svelte_artifact_is_not_reported_either(caplog):
-    """The same engine with the OTHER adapter's output. Both shapes are legitimate, so
-    neither may warn — and a check that warned on this one would fire on every dynamic
-    site instead of every static one."""
+    """The same engine with the OTHER adapter's output. Both shapes are legitimate to
+    BUILD, so neither may warn — a check that warned on this one would fire on every
+    dynamic site instead of every static one.
+
+    Two separate properties are at play and this pins both, because they pull in
+    opposite directions and it would be easy to mistake one for the other:
+
+    * the GATE refuses this artifact outright, since its pages come from a ``_worker.js``
+      nothing here can execute;
+    * the server-entry CROSS-CHECK still says nothing about it, because the engine name
+      cannot tell which adapter ran and "svelte carried a worker" is not an anomaly.
+
+    A refusal is not a warning, and the absence of the warning has to be observable on a
+    tree that actually reached disk — hence the seam, which exists for precisely this:
+    a test needing to construct the tree ``resolve`` refuses.
+    """
+    with pytest.raises(ap.ArtifactNotPreviewable):
+        ap.store_artifact("svelte-dyn-gated", _tar(_SVELTE_ARTIFACT), engine="svelte")
+
     with caplog.at_level("WARNING"):
-        snap = ap.store_artifact("svelte-dyn1", _tar(_SVELTE_ARTIFACT), engine="svelte")
+        snap = ap.store_unvouched_artifact("svelte-dyn1", _tar(_SVELTE_ARTIFACT), engine="svelte")
 
     assert snap.unpacked.server_entries == ("_worker.js",)
     assert "even though this engine emits none" not in caplog.text

--- a/tests/ee/sites/test_artifact_preview.py
+++ b/tests/ee/sites/test_artifact_preview.py
@@ -15,6 +15,15 @@
 # has carried a per-site signed key), a tarball member cannot write outside the preview
 # root, and a request path cannot read outside it.
 #
+# Updated 2026-08-10 (`store_artifact` is gated): the six calls here that store a
+# WORKER-BEARING artifact now go through `store_unvouched_artifact`, the explicitly-named
+# seam past the gate. That is not a workaround — those six are precisely the tests of the
+# un-vouched primitive's behaviour (the worker is skipped at unpack, its whole subtree
+# goes with it, deploy metadata is skipped, the shape mismatch is logged), and they need a
+# tree containing the thing being skipped. Every assertion is unchanged; only the door
+# they come in through moved. `store_artifact` refusing such an artifact outright is
+# asserted separately, in test_truth_lane.py.
+#
 # Updated 2026-08-10: path traversal covered end to end after the lead flagged it as
 # missing from the brief. Both surfaces, since a static server over an extracted archive
 # has two: MEMBER names at extract time (`..`, absolute, drive letter, backslash, NUL,
@@ -116,7 +125,7 @@ def test_react_artifact_previews_from_its_own_root():
 def test_svelte_artifact_previews_and_its_deeper_tree_resolves():
     """The engines emit 4 vs 24 entries; nothing here knows which. The lane tars from
     ``static_output_rel(engine)``, so both arrive rooted at their deployable root."""
-    ap.store_artifact("svelte1", _tar(_SVELTE_ARTIFACT), engine="svelte")
+    ap.store_unvouched_artifact("svelte1", _tar(_SVELTE_ARTIFACT), engine="svelte")
 
     index = ap.resolve("svelte1", "/")
     assert index.status == 200
@@ -131,7 +140,7 @@ def test_svelte_artifact_previews_and_its_deeper_tree_resolves():
 
 
 def test_worker_entry_is_never_written_and_never_served(_preview_home):
-    snap = ap.store_artifact("svelte2", _tar(_SVELTE_ARTIFACT), engine="svelte")
+    snap = ap.store_unvouched_artifact("svelte2", _tar(_SVELTE_ARTIFACT), engine="svelte")
 
     assert snap.unpacked.server_entries == ("_worker.js",)
     assert not (snap.root / "_worker.js").exists()
@@ -144,7 +153,7 @@ def test_worker_entry_is_never_written_and_never_served(_preview_home):
 
 def test_the_worker_does_not_break_the_rest_of_the_preview():
     """The stated risk: its presence must neither be executed nor 404 everything else."""
-    ap.store_artifact("svelte3", _tar(_SVELTE_ARTIFACT), engine="svelte")
+    ap.store_unvouched_artifact("svelte3", _tar(_SVELTE_ARTIFACT), engine="svelte")
 
     assert ap.resolve("svelte3", "/").status == 200
     assert ap.resolve("svelte3", "/_app/version.json").status == 200
@@ -153,7 +162,7 @@ def test_the_worker_does_not_break_the_rest_of_the_preview():
 def test_a_worker_directory_is_refused_wholesale():
     """adapter-cloudflare emits `_worker.js` as a DIRECTORY of chunks for larger apps,
     so matching the leaf filename alone would let the chunks through."""
-    snap = ap.store_artifact(
+    snap = ap.store_unvouched_artifact(
         "svelte4",
         _tar(
             {
@@ -192,7 +201,7 @@ def test_worker_source_is_refused_even_when_it_is_on_disk():
 
 
 def test_deploy_metadata_is_not_served_as_content():
-    snap = ap.store_artifact("svelte6", _tar(_SVELTE_ARTIFACT), engine="svelte")
+    snap = ap.store_unvouched_artifact("svelte6", _tar(_SVELTE_ARTIFACT), engine="svelte")
 
     assert sorted(snap.unpacked.metadata_entries) == [".assetsignore", "_routes.json"]
     assert ap.resolve("svelte6", "/_routes.json").reason == "metadata_refused"
@@ -604,7 +613,7 @@ def test_an_unexpected_server_entry_is_reported(caplog):
     """react emits no server entry. One turning up means the lane changed shape, which
     is worth saying out loud — but not worth refusing to preview over."""
     with caplog.at_level("WARNING"):
-        snap = ap.store_artifact("mix1", _tar(_SVELTE_ARTIFACT), engine="react")
+        snap = ap.store_unvouched_artifact("mix1", _tar(_SVELTE_ARTIFACT), engine="react")
 
     assert snap.unpacked.server_entries == ("_worker.js",)
     assert "even though this engine emits none" in caplog.text

--- a/tests/ee/sites/test_artifact_preview_server.py
+++ b/tests/ee/sites/test_artifact_preview_server.py
@@ -15,6 +15,15 @@
 # The deploy and preview roots being disjoint is checked here too: it is what stops the
 # static branch serving a preview tree without passing `resolve`'s guards, which would
 # give the `_worker.js` refusal a bypass.
+#
+# Updated 2026-08-10 (`serve_artifact_preview` is gated). The fixture used to be a single
+# worker-bearing tree, because `resolve`'s `_worker.js` refusal needs one to refuse. Now
+# that the front door refuses a worker-bearing artifact, that fixture is SPLIT rather than
+# weakened: `_ARTIFACT` (no worker) goes through the front door and every assertion below
+# is unchanged, and `_ARTIFACT_WITH_WORKER` goes through
+# `artifact_preview.store_unvouched_artifact` in the one test that needs the file present.
+# Both refusals stay under test, and the gate itself gained one — the front door turning a
+# worker-bearing artifact away is now asserted here rather than only in the unit file.
 
 from __future__ import annotations
 
@@ -29,9 +38,19 @@ pytest.importorskip("pocketpaw_ee")
 
 from pocketpaw_ee.sites import artifact_preview as ap  # noqa: E402
 
+#: A previewable artifact: self-contained, no server entry. What `serve_artifact_preview`
+#: is allowed to store now that it is gated (SG-10 wiring).
 _ARTIFACT = {
     "./index.html": b"<!doctype html><title>Acme</title><script src=./assets/app.js></script>ok",
     "./assets/app.js": b"console.log('bundle')",
+}
+
+#: The same tree WITH the server entry. `serve_artifact_preview` refuses this now, so a
+#: test that needs it on disk — `resolve`'s `_worker.js` refusal needs the file to be in
+#: the artifact to be refusing anything — goes through
+#: `artifact_preview.store_unvouched_artifact`, the explicitly-named seam past the gate.
+_ARTIFACT_WITH_WORKER = {
+    **_ARTIFACT,
     "./_worker.js": b"export default {fetch(){}} // SIGNED_KEY_WOULD_BE_HERE",
 }
 
@@ -120,11 +139,37 @@ def test_the_slashless_preview_url_still_lands_on_the_page(server):
 
 
 def test_the_worker_is_not_reachable_over_http(server):
-    url = server.serve_artifact_preview("site3", _tar(_ARTIFACT), engine="svelte")
+    """`resolve`'s `_worker.js` refusal, over the wire, against a tree that actually
+    contains one. The gated front door refuses such an artifact before it lands (see the
+    test below), so this goes through the named seam past the gate — otherwise the last
+    line of defence would have nothing left to defend against and would stop being tested.
+    """
+    ap.store_unvouched_artifact("site3", _tar(_ARTIFACT_WITH_WORKER), engine="svelte")
+    url = server.preview_url_for("site3")
 
     status, body, _ = _get(url + "_worker.js")
     assert status == 404
     assert b"SIGNED_KEY_WOULD_BE_HERE" not in body
+
+    # And the rest of the tree still serves, which is what makes the refusal a refusal of
+    # one file rather than of the preview.
+    assert _get(url)[0] == 200
+
+
+def test_the_front_door_refuses_a_worker_bearing_artifact(server):
+    """The hole this closes. `serve_artifact_preview` is the obvious-looking entry point;
+    before it was gated it stored the static leftovers of a worker-rendered build and
+    handed back a URL, so the page a customer opened was one their site never serves."""
+    assert server.serve_artifact_preview(
+        "site10", _tar(_ARTIFACT_WITH_WORKER), engine="svelte"
+    ) is (None)
+    assert not ap.has_preview("site10")
+
+    base = server.ensure_server()
+    status, body, _ = _get(f"{base}/_preview/site10/")
+    assert status == 404
+    assert b"SIGNED_KEY_WOULD_BE_HERE" not in body
+    assert b"<title>Acme</title>" not in body
 
 
 def test_a_form_post_in_preview_is_refused_visibly(server):

--- a/tests/ee/sites/test_truth_lane.py
+++ b/tests/ee/sites/test_truth_lane.py
@@ -348,26 +348,45 @@ def test_a_refused_artifact_leaves_no_bytes_of_its_worker_on_disk(previews):
     assert found == []
 
 
-def test_the_gate_and_the_unpack_must_agree(monkeypatch):
-    """Two readings of the same bytes that disagree mean one of them is wrong, and
-    nothing here can tell which — so serve neither."""
-    real_scan = tl.scan_artifact
+def _lying_scan(real):
+    """A scan that reports every artifact as a clean, self-contained static tree."""
 
-    def lying_scan(artifact: bytes) -> tl.ArtifactShape:
-        shape = real_scan(artifact)
-        return tl.ArtifactShape(
+    def scan(artifact: bytes) -> ap.ArtifactShape:
+        shape = real(artifact)
+        return ap.ArtifactShape(
             entries=shape.entries,
             server_entries=(),
             routing_tables=(),
             has_entry_document=True,
         )
 
-    monkeypatch.setattr(tl, "scan_artifact", lying_scan)
+    return scan
+
+
+def test_a_reason_layer_that_disagrees_with_the_door_refuses(monkeypatch):
+    """Two readings of the same bytes that disagree mean one of them is wrong, and nothing
+    here can tell which — so serve neither. This is the DOOR catching it: only the
+    reason-layer scan is broken, and ``store_artifact`` refuses on its own reading."""
+    monkeypatch.setattr(tl, "scan_artifact", _lying_scan(tl.scan_artifact))
 
     result = tl.open_preview("disagree1", _tar(_SVELTE_DYNAMIC_CLOUDFLARE), engine="svelte")
 
     assert result.verdict.reason == tl.REASON_GATE_DISAGREED
     assert not ap.has_preview("disagree1")
+
+
+def test_a_scan_that_disagrees_with_the_unpack_refuses(monkeypatch):
+    """And this is the POST-STORE cross-check catching it, which is the layer that
+    survives when the scan itself is what is broken. ``_member_segments`` and
+    ``_normalized_member_path`` are genuinely different readers of the same names, so this
+    is not a tautology: with the scan blinded, the unpack is what still sees the worker."""
+    monkeypatch.setattr(ap, "scan_artifact", _lying_scan(ap.scan_artifact))
+    monkeypatch.setattr(tl, "scan_artifact", ap.scan_artifact)
+
+    result = tl.open_preview("disagree2", _tar(_SVELTE_DYNAMIC_CLOUDFLARE), engine="svelte")
+
+    assert result.verdict.reason == tl.REASON_GATE_DISAGREED
+    assert not ap.has_preview("disagree2")
 
 
 # ---------------------------------------------------------------------------
@@ -399,17 +418,179 @@ def test_a_missing_page_is_a_404_not_the_home_page():
     assert b"<title>Acme</title>" not in missing.body
 
 
-def test_the_gate_refuses_what_the_ungated_store_serves(previews, monkeypatch):
-    """Pins the difference ``local_server.serve_artifact_preview``'s docstring names.
+# ---------------------------------------------------------------------------
+# The gate is at the DISK BOUNDARY, so no call path routes around it
+# ---------------------------------------------------------------------------
 
-    The ungated store exists so ``resolve``'s own ``_worker.js`` refusal stays reachable
-    over HTTP, which needs something able to store a worker-bearing tree. That is a
-    deliberate seam, not an oversight, and this is what keeps it from drifting into a
-    surprise: the same artifact, stored by one path and refused by the other.
+
+def test_the_store_itself_refuses_a_worker_bearing_artifact():
+    """The gate is enforced in ``store_artifact`` — the one function every path to disk
+    goes through — rather than only in the surface above, because a check anywhere else is
+    bypassable by picking a different caller."""
+    with pytest.raises(ap.ArtifactNotPreviewable):
+        ap.store_artifact("door1", _tar(_SVELTE_DYNAMIC_CLOUDFLARE), engine="svelte")
+
+    assert not ap.has_preview("door1")
+
+
+def test_the_store_refuses_before_it_writes_anything(previews):
+    """A refusal that unpacked first and cleaned up afterwards would leave a window where
+    the tree is live at the preview address, and would touch the disk on every hostile
+    artifact. Nothing is written at all — not even the hidden incoming sibling."""
+    root = previews / "site-previews"
+    with pytest.raises(ap.ArtifactNotPreviewable):
+        ap.store_artifact("door2", _tar(_SVELTE_DYNAMIC_CLOUDFLARE), engine="svelte")
+
+    # Stronger than "no tree for door2": the refusal happens before ``previews_home()`` is
+    # consulted, so it does not even create the previews root.
+    assert not root.exists() or list(root.iterdir()) == []
+
+
+def test_the_refusal_is_a_kind_of_artifact_rejected():
+    """So a caller that already handles ``ArtifactRejected`` — ``safe_store_artifact``, and
+    ``truth_lane``'s store clause — cannot miss it by not knowing the new name."""
+    assert issubclass(ap.ArtifactNotPreviewable, ap.ArtifactRejected)
+
+
+def test_the_swallowing_store_inherits_the_gate():
+    """``safe_store_artifact`` has an inviting name and swallows everything, so an ungated
+    version of it is exactly the footgun a future caller reaches for. It returns ``None``,
+    which is what it has always returned for "no preview", so gating changed no contract."""
+    assert (
+        ap.safe_store_artifact("safe1", _tar(_SVELTE_DYNAMIC_CLOUDFLARE), engine="svelte") is None
+    )
+    assert not ap.has_preview("safe1")
+
+    assert ap.safe_store_artifact("safe2", _tar(_REACT_DIST), engine="react") is not None
+
+
+def test_the_front_door_inherits_the_gate(loopback):
+    """``local_server.serve_artifact_preview`` is the obvious-looking entry point, and the
+    one whose ungated version this change closed."""
+    from pocketpaw_ee.sites import local_server
+
+    assert (
+        local_server.serve_artifact_preview(
+            "front1", _tar(_SVELTE_DYNAMIC_CLOUDFLARE), engine="svelte"
+        )
+        is None
+    )
+    assert not ap.has_preview("front1")
+
+    assert local_server.serve_artifact_preview("front2", _tar(_REACT_DIST), engine="react")
+    assert ap.has_preview("front2")
+
+
+def test_the_named_seam_is_the_only_way_past_the_gate():
+    """The seam exists so ``resolve``'s own ``_worker.js`` refusal keeps something to
+    refuse. Deleting it to close the hole would trade a proven guard for an unproven one,
+    so it is kept — and named so that using it is a visible act at the call site."""
+    snapshot = ap.store_unvouched_artifact(
+        "seam1", _tar(_SVELTE_DYNAMIC_CLOUDFLARE), engine="svelte"
+    )
+
+    assert snapshot.unpacked.server_entries == ("_worker.js",)
+    assert ap.has_preview("seam1")
+    # Still not SERVED — the seam gets a tree onto disk, it does not weaken `resolve`.
+    assert ap.resolve("seam1", "/_worker.js").reason == "server_entry_refused"
+
+
+def test_no_production_module_stores_an_unvouched_artifact():
+    """THE CONTROL ON THE SEAM, and the reason its name is load-bearing rather than
+    decorative. A comment saying "never call this from production" is enforced by whoever
+    happens to read it; this is enforced by CI. Scans every module under ``src/`` and
+    ``ee/`` — the shipped code — and fails if any of them names the function.
+
+    ``artifact_preview`` itself is excluded because that is where it is defined.
+
+    The scan is AST-based, not a substring search. Prose ABOUT the seam is exactly what a
+    module should carry — ``local_server``'s header explains why its own front door is
+    gated and names the seam while doing so — and a grep would fail on the documentation
+    that makes the design legible. The AST sees calls, imports and attribute access and
+    never sees a comment or a docstring, which is the distinction that matters.
     """
+    import ast
+    from pathlib import Path
+
+    import pocketpaw_ee
+
+    import pocketpaw
+
+    symbol = "store_unvouched_artifact"
+    definer = Path(ap.__file__).resolve()
+    roots = [Path(pocketpaw.__file__).parent, Path(pocketpaw_ee.__file__).parent]
+
+    def references(path: Path) -> bool:
+        try:
+            tree = ast.parse(path.read_text("utf-8"))
+        except (SyntaxError, UnicodeDecodeError):  # pragma: no cover - vendored forks
+            return False
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute) and node.attr == symbol:
+                return True
+            if isinstance(node, ast.Name) and node.id == symbol:
+                return True
+            if isinstance(node, ast.ImportFrom) and any(a.name == symbol for a in node.names):
+                return True
+        return False
+
+    offenders = sorted(
+        str(path)
+        for root in roots
+        for path in root.rglob("*.py")
+        if path.resolve() != definer and references(path)
+    )
+
+    assert offenders == [], (
+        f"{symbol} bypasses the previewability gate and must never be reachable from "
+        f"production. Referenced by: {offenders}"
+    )
+
+
+def test_the_guard_on_the_seam_would_actually_fire(tmp_path):
+    """A guard nobody has watched fail is not a guard. Proves the scan above detects a
+    real call — otherwise a typo in the symbol name would leave it passing forever while
+    checking nothing."""
+    import ast
+
+    module = tmp_path / "offender.py"
+    module.write_text(
+        "from pocketpaw_ee.sites import artifact_preview\n"
+        "def wire(site_id, artifact):\n"
+        "    return artifact_preview.store_unvouched_artifact(\n"
+        "        site_id, artifact, engine='svelte'\n"
+        "    )\n",
+        encoding="utf-8",
+    )
+
+    tree = ast.parse(module.read_text("utf-8"))
+    hits = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Attribute) and node.attr == "store_unvouched_artifact"
+    ]
+    assert len(hits) == 1
+
+    # And prose about it does not count, which is the whole reason the scan is AST-based.
+    commented = tmp_path / "documented.py"
+    commented.write_text(
+        "# never call store_unvouched_artifact from here\nx = 1\n", encoding="utf-8"
+    )
+    prose_tree = ast.parse(commented.read_text("utf-8"))
+    assert not [
+        node
+        for node in ast.walk(prose_tree)
+        if isinstance(node, ast.Attribute) and node.attr == "store_unvouched_artifact"
+    ]
+
+
+def test_the_gate_and_the_seam_disagree_by_design(previews):
+    """Pins the two paths against each other, so the difference stays deliberate rather
+    than becoming a surprise: the same artifact, refused by the door and stored by the
+    seam."""
     artifact = _tar(_SVELTE_DYNAMIC_CLOUDFLARE)
 
-    assert ap.safe_store_artifact("both1", artifact, engine="svelte") is not None
+    assert ap.store_unvouched_artifact("both1", artifact, engine="svelte") is not None
     assert ap.has_preview("both1")
 
     assert tl.open_preview("both2", artifact, engine="svelte").ok is False
@@ -676,7 +857,13 @@ def test_a_react_artifact_carrying_a_worker_still_warns(caplog):
     shape contradicts its engine is evidence the build lane changed underneath us. The
     truth lane refuses it, and the warning is what says why the shape was unexpected."""
     with caplog.at_level("WARNING"):
-        result = ap.store_artifact("shape1", _tar(_SVELTE_DYNAMIC_CLOUDFLARE), engine="react")
+        # Through the seam: the gated door refuses a worker-bearing artifact outright, so
+        # the shape-mismatch WARNING is only reachable on the un-vouched path now. That is
+        # the right place for it — the mismatch is evidence for whoever is looking at a
+        # tree that exists, and on the gated path there is no tree to look at.
+        result = ap.store_unvouched_artifact(
+            "shape1", _tar(_SVELTE_DYNAMIC_CLOUDFLARE), engine="react"
+        )
 
     assert result.unpacked.server_entries
     assert "emits none" in caplog.text

--- a/tests/mutations/sites_artifact_preview.json
+++ b/tests/mutations/sites_artifact_preview.json
@@ -2,8 +2,8 @@
   {
     "label": "svelte's server bundle is written into the preview tree, so the file that has carried a per-site signed key sits inside a directory we serve",
     "file": "ee/pocketpaw_ee/sites/artifact_preview.py",
-    "find": "            if any(seg in _SERVER_ENTRY_NAMES for seg in segments):\n                server.append(\"/\".join(segments))",
-    "replace": "            if False:\n                server.append(\"/\".join(segments))",
+    "find": "            if any(seg in _SERVER_ENTRY_NAMES for seg in segments):\n                server.append(\"/\".join(segments))\n                continue",
+    "replace": "            if False:\n                server.append(\"/\".join(segments))\n                continue",
     "tests": [
       "tests/ee/sites/test_artifact_preview.py"
     ]

--- a/tests/mutations/sites_truth_lane.json
+++ b/tests/mutations/sites_truth_lane.json
@@ -10,25 +10,27 @@
   },
   {
     "label": "an artifact carrying a worker reports itself as renderer-free, so the one fact the gate exists to notice is invisible to it",
-    "file": "ee/pocketpaw_ee/sites/truth_lane.py",
-    "find": "    def is_server_rendered(self) -> bool:\n        return bool(self.server_entries)",
-    "replace": "    def is_server_rendered(self) -> bool:\n        return False",
+    "file": "ee/pocketpaw_ee/sites/artifact_preview.py",
+    "find": "    def is_server_rendered(self) -> bool:\n        \"\"\"THE gate.",
+    "replace": "    def is_server_rendered(self) -> bool:\n        return False  # mutated\n        \"\"\"THE gate.",
     "tests": [
-      "tests/ee/sites/test_truth_lane.py"
+      "tests/ee/sites/test_truth_lane.py",
+      "tests/ee/sites/test_artifact_preview.py"
     ]
   },
   {
     "label": "the scan stops recording worker members, so the gate sees a clean artifact and only the post-store cross-check stands between a worker-rendered tree and being served",
-    "file": "ee/pocketpaw_ee/sites/truth_lane.py",
-    "find": "            if any(seg in SERVER_ENTRY_NAMES for seg in segments):\n                server.append(\"/\".join(segments))",
-    "replace": "            if False:\n                server.append(\"/\".join(segments))",
+    "file": "ee/pocketpaw_ee/sites/artifact_preview.py",
+    "find": "            if any(seg in _SERVER_ENTRY_NAMES for seg in segments):\n                server.append(\"/\".join(segments))\n            if segments[-1] == ROUTING_TABLE_NAME:",
+    "replace": "            if False:\n                server.append(\"/\".join(segments))\n            if segments[-1] == ROUTING_TABLE_NAME:",
     "tests": [
-      "tests/ee/sites/test_truth_lane.py"
+      "tests/ee/sites/test_truth_lane.py",
+      "tests/ee/sites/test_artifact_preview.py"
     ]
   },
   {
     "label": "a worker member written with a backslash separator is not seen as a worker, so the same artifact is refused on one host and served on the other",
-    "file": "ee/pocketpaw_ee/sites/truth_lane.py",
+    "file": "ee/pocketpaw_ee/sites/artifact_preview.py",
     "find": "    return tuple(part for part in name.replace(\"\\\\\", \"/\").split(\"/\") if part not in (\"\", \".\"))",
     "replace": "    return tuple(part for part in name.split(\"/\") if part not in (\"\", \".\"))",
     "tests": [
@@ -37,7 +39,7 @@
   },
   {
     "label": "the routing table is no longer recorded, so an artifact that names a renderer it does not contain passes the gate as if it were complete",
-    "file": "ee/pocketpaw_ee/sites/truth_lane.py",
+    "file": "ee/pocketpaw_ee/sites/artifact_preview.py",
     "find": "            if segments[-1] == ROUTING_TABLE_NAME:\n                routes.append(\"/\".join(segments))",
     "replace": "            if False:\n                routes.append(\"/\".join(segments))",
     "tests": [
@@ -55,7 +57,7 @@
   },
   {
     "label": "incompleteness stops requiring a routing table, so every self-contained static build is refused as incomplete and no site can be previewed at all",
-    "file": "ee/pocketpaw_ee/sites/truth_lane.py",
+    "file": "ee/pocketpaw_ee/sites/artifact_preview.py",
     "find": "        return bool(self.routing_tables) and not self.server_entries",
     "replace": "        return bool(self.routing_tables) or not self.server_entries",
     "tests": [
@@ -64,7 +66,7 @@
   },
   {
     "label": "an index.html anywhere in the tree counts as the home page, so a build with only docs/index.html is admitted and the preview opens onto its own 404",
-    "file": "ee/pocketpaw_ee/sites/truth_lane.py",
+    "file": "ee/pocketpaw_ee/sites/artifact_preview.py",
     "find": "            if segments == (ENTRY_DOCUMENT_NAME,):\n                entry_document = True",
     "replace": "            if segments[-1] == ENTRY_DOCUMENT_NAME:\n                entry_document = True",
     "tests": [
@@ -207,10 +209,39 @@
     ]
   },
   {
-    "label": "the caller's resolved worker expectation is discarded, so the one track the engine name cannot judge (static vs dynamic svelte) loses its cross-check entirely and a static artifact carrying a server entry is never flagged",
+    "label": "the caller's resolved worker expectation is ignored, so every healthy static svelte preview logs that the artifact may be incomplete and the warning stops meaning anything",
     "file": "ee/pocketpaw_ee/sites/artifact_preview.py",
-    "find": "    expected = (\n        expects_server_worker(engine) if expect_server_worker is None else expect_server_worker\n    )",
-    "replace": "    expected = expects_server_worker(engine)",
+    "find": "    expected_worker = (\n        emits_server_worker(engine) if expect_server_worker is None else expect_server_worker\n    )",
+    "replace": "    expected_worker = emits_server_worker(engine)",
+    "tests": [
+      "tests/ee/sites/test_truth_lane.py"
+    ]
+  },
+  {
+    "label": "the gate at the disk boundary is gone, so every ungated caller of the store — present or future — puts a worker-rendered tree on disk and serves it as the site",
+    "file": "ee/pocketpaw_ee/sites/artifact_preview.py",
+    "find": "    shape = scan_artifact(artifact)\n    if shape.is_server_rendered:",
+    "replace": "    shape = scan_artifact(artifact)\n    if False:",
+    "tests": [
+      "tests/ee/sites/test_truth_lane.py",
+      "tests/ee/sites/test_artifact_preview_server.py"
+    ]
+  },
+  {
+    "label": "the front door goes back to storing whatever unpacks, which is the hole this change closed: the obvious-looking entry point serves a worker-rendered build's leftovers as the customer's site",
+    "file": "ee/pocketpaw_ee/sites/local_server.py",
+    "find": "        return truth_lane.open_preview(site_id, artifact, engine=engine).url",
+    "replace": "        artifact_preview.store_unvouched_artifact(site_id, artifact or b\"\", engine=engine)\n        return preview_url_for(site_id)",
+    "tests": [
+      "tests/ee/sites/test_truth_lane.py",
+      "tests/ee/sites/test_artifact_preview_server.py"
+    ]
+  },
+  {
+    "label": "the previewability refusal stops being a kind of ArtifactRejected, so every caller that already handles a rejected artifact silently stops handling this one",
+    "file": "ee/pocketpaw_ee/sites/artifact_preview.py",
+    "find": "class ArtifactNotPreviewable(ArtifactRejected):",
+    "replace": "class ArtifactNotPreviewable(ValueError):",
     "tests": [
       "tests/ee/sites/test_truth_lane.py"
     ]

--- a/tests/mutations/sites_truth_lane.json
+++ b/tests/mutations/sites_truth_lane.json
@@ -209,10 +209,10 @@
     ]
   },
   {
-    "label": "the caller's resolved worker expectation is ignored, so every healthy static svelte preview logs that the artifact may be incomplete and the warning stops meaning anything",
+    "label": "the caller's resolved worker expectation is discarded, so the one track the engine name cannot judge (static vs dynamic svelte) loses its cross-check entirely and a static artifact carrying a server entry is never flagged",
     "file": "ee/pocketpaw_ee/sites/artifact_preview.py",
-    "find": "    expected_worker = (\n        emits_server_worker(engine) if expect_server_worker is None else expect_server_worker\n    )",
-    "replace": "    expected_worker = emits_server_worker(engine)",
+    "find": "    expected = (\n        expects_server_worker(engine) if expect_server_worker is None else expect_server_worker\n    )",
+    "replace": "    expected = expects_server_worker(engine)",
     "tests": [
       "tests/ee/sites/test_truth_lane.py"
     ]


### PR DESCRIPTION
## Stacked on #1900 — merge that one first

Base is `feat/sites-truth-lane`, not `dev`. This is a deliberate second stack level: it
does the follow-up #1900's own body flagged as deferred. Merge order is #1900, then this.
Per the stacked-PR rule, #1900 wants `--rebase` rather than `--squash` while this one is
open.

## What was wrong

`serve_artifact_preview` could store and serve a tree the truth lane would refuse. It had
no production caller, which is the reason to close it now rather than later: it is the
obvious-looking front door, and whoever eventually wires it has no reason to suspect a
gate exists somewhere else that they are skipping. #1900 pinned the discrepancy with a
test and documented it. That was honest, but a pin is not a fix.

## Why the gate moved instead of just delegating

Gating `serve_artifact_preview` alone is five lines, and it would have left the same hole
one level down. `store_artifact` and `safe_store_artifact` were also ungated public
functions with inviting names — `safe_store_artifact` in particular swallows every error
and reads like the safe choice. The lead's argument applies to them verbatim.

So the check went into `store_artifact`: the one function every path to disk goes through.
A check anywhere above it is bypassable by picking a different caller; a check there is
not. `scan_artifact` and `ArtifactShape` moved into `artifact_preview` with it, which is
where they belonged anyway — reading a tarball is that module's job, and it already refuses
the html engine, `_worker.js` at unpack and at resolve, `/api/*`, and non-GET methods.
Refusing an artifact it cannot honestly serve at all is the same policy one step out.

The rule now has exactly one definition, `ArtifactShape.is_server_rendered`. The refusal
reads it, and so does the truth lane when it names the refusal.

Concretely:

| path | before | after |
|---|---|---|
| `truth_lane.open_preview` | gated | gated (unchanged) |
| `local_server.serve_artifact_preview` | **ungated** | gated, via `open_preview` |
| `artifact_preview.safe_store_artifact` | **ungated** | gated, via `store_artifact` |
| `artifact_preview.store_artifact` | **ungated** | **gated — raises `ArtifactNotPreviewable` before writing** |
| `artifact_preview.store_unvouched_artifact` | did not exist | the one named bypass |

`truth_lane` now enforces nothing and explains everything: the reasons, the detail text,
the discard-on-refusal, the project-dir probe, the exposure seam. `artifact_preview`
enforces. Its own pre-store scan is not redundant with the door — it produces the reason
and answers the two questions the door does not ask (an absent renderer, a missing entry
document) — and the door is what makes the rule impossible to route around. Neither half
is sufficient alone.

## The seam, and why it cannot be reached from production

`resolve`'s `_worker.js` refusal is the last line of defence, and it needs a stored tree
that actually contains a worker or it has nothing left to refuse. Once the gated door
turns such an artifact away, no gated path can build one. Deleting that coverage to close
the hole would trade a proven guard for an unproven one, so the seam is kept:

```
artifact_preview.store_unvouched_artifact(site_id, artifact, *, engine, ...)
```

Three things make it safe rather than merely discouraged:

1. **The name is at the call site.** "Unvouched" is not a flag buried in a keyword
   argument; a reader of the calling line sees it.
2. **The name is checked, by CI, not by a reviewer.**
   `test_no_production_module_stores_an_unvouched_artifact` walks every `.py` under
   `src/` and `ee/` and fails if any of them references the symbol.
3. **The check is AST-based, not a grep.** Prose *about* the seam is exactly what a module
   should carry — `local_server`'s header explains why its own front door is gated and
   names the seam while doing so — and a substring search would fail on the documentation
   that makes the design legible. The AST sees calls, imports and attribute access, and
   never sees a comment or a docstring. `test_the_guard_on_the_seam_would_actually_fire`
   proves both halves: it detects a real call in a synthetic module, and ignores a comment
   mentioning the name.

Point 2 is not theory. One of the new mutations reverts the front door to
`store_unvouched_artifact`, and the guard test is one of the things that fails. The
control has been observed firing.

The seam does not weaken `resolve`: a tree stored through it still gets `_worker.js`
refused with `server_entry_refused`, which is asserted.

## What happened to the 13 assertions

None were deleted, and none were weakened.

Only **one** of them actually needed the worker present —
`test_the_worker_is_not_reachable_over_http`. So the fixture was split rather than the
tests rewritten:

- `_ARTIFACT` (no worker) goes through the gated front door. All twelve other assertions
  are byte-identical, and they now additionally prove the gate *admits* a good artifact
  and serves it over HTTP.
- `_ARTIFACT_WITH_WORKER` goes through the seam in that one test, which gained an
  assertion: the rest of the tree still serves, so the refusal is a refusal of one file
  rather than of the preview.
- One test was **added** there: `test_the_front_door_refuses_a_worker_bearing_artifact`,
  which is the hole itself, asserted over real HTTP — `None` returned, nothing on disk,
  404 at the address, and neither the canary nor the page title in the body.

In `test_artifact_preview.py`, six calls moved onto the seam. Those six are precisely the
tests of the un-vouched primitive's behaviour — the worker is skipped at unpack, its whole
subtree goes with it, deploy metadata is skipped, a shape mismatch is logged — and they
need a tree containing the thing being skipped. Every assertion is unchanged; only the
door they come in through moved.

## One thing that got better on its own

The post-store cross-check (`gate_disagreed`) was only reachable one way before. It now
has two distinct paths, and both are tested: the **door** catching a broken reason-layer
scan, and the **post-store unpack** catching a broken scan. That second one is not a
tautology — `_member_segments` and `_normalized_member_path` are genuinely different
readers of the same member names, so with the scan blinded the unpack is what still sees
the worker.

## Verified

Base commit for the comparison is `d4554e8` (#1900's head); the dev baseline is `ba86fcf`.
Windows.

- `tests/ee/sites`: **4 failed / 873 passed / 4 skipped**. Failure *names* diffed against
  the `ba86fcf` baseline: **identical**. All four are
  `test_generator_client_timeout.py` failing `assert not _pid_alive(proc.pid)` — the
  wedged-child-not-reaped-on-Windows issue recorded in #1899, green on Linux CI. +10 tests
  over #1900's 863.
- The three directly affected files together: **104 passed**.
- `tests/mutations/sites_truth_lane.json` — now **27 mutations, all 27 caught**. Six
  anchors were repointed at `artifact_preview.py` because the rules they mutate moved
  there; same harms, same catchers. Three added: the disk-boundary gate removed, the front
  door reverted to the un-vouched store, and `ArtifactNotPreviewable` losing its
  `ArtifactRejected` base.
- `tests/mutations/sites_artifact_preview.json` — **27 mutations, all 27 caught**. One
  anchor needed disambiguating: `scan_artifact` now contains a line that was previously
  unique to `unpack_artifact`, so it matched twice and would have aborted the whole plan.
- Every anchor in both plans verified unique before each run, and both plans re-run after
  the last edit.
- `uv run ruff check .` and `uv run ruff format --check .`: clean, repo-wide (2686 files).
- `lint-imports` 1 kept / 0 broken; `lint-imports --config ee/pyproject.toml` 34 kept / 0
  broken.
- No new dependencies. `paw-enterprise` untouched.

One incidental fix worth naming: a scripted edit to `test_artifact_preview.py` rewrote the
whole file to CRLF, which showed up as a 1289-line diff. Normalized back to LF, so that
file's diff is now the header note plus the six call-site swaps.

## Still deliberately not done

- **No frontend.** Unchanged from #1900.
- **The origin decision is still the captain's.** `preview_base_url()` is untouched by this
  PR; default loopback, `app-origin` and `signed-url` still refuse until decided.
