### PR TITLE
chore(ci): validate mutation-plan anchors on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,13 @@
 # gate (AT-4): the compiled atlas artifact (src/pocketpaw/atlas/data/
 # atlas.json) must match a fresh compile of authored entries + connector/
 # senses extraction, or the step fails with a diff summary.
+# Updated: 2026-08-10 — new `mutation-anchors` job (#1903). Nineteen mutation
+# plans lived under tests/mutations/ with nothing in this directory running any
+# of them, so a plan whose anchor had rotted applied ZERO mutations while still
+# reading as covered — two were found in that state on the same day. The job
+# runs `mutate.py --validate`, which counts substrings and exits: no mutation
+# applied, no tests run, no dependency install. A full sweep is deliberately
+# NOT here; see the job's own comment for why.
 name: CI
 
 on:
@@ -229,6 +236,46 @@ jobs:
         env:
           POCKETPAW_LLM_PROVIDER: "ollama"
           POCKETPAW_OLLAMA_HOST: "http://localhost:11434"
+
+  mutation-anchors:
+    # ANCHOR VALIDATION ONLY, NOT A SWEEP. `mutate.py --validate` reads each plan, counts
+    # its `find` string in the target file, and exits. It applies no mutation, runs no
+    # test and writes no marker — so this job needs no dependency install and finishes in
+    # seconds.
+    #
+    # WHY IT EXISTS (#1903). A plan's `find` is a substring of source, so any refactor can
+    # invalidate one. mutate.py handles that correctly on its own — it aborts before the
+    # first mutation and names the offender — but nothing ran it, so a rotted plan sat at
+    # ZERO applied mutations while still reading as covered. `fault_ladder.json` (19
+    # entries) and `site_preview_refresh.json` (5) were both found in that state on the
+    # same day, in unrelated subsystems. The tool was never the problem; nobody was
+    # listening.
+    #
+    # A FULL SWEEP IS DELIBERATELY NOT HERE. A sweep applies a mutation and runs a test
+    # subset per entry — minutes of compute across ~194 entries — and requiring that of
+    # every PR is probably the wrong trade. Real mutation signal still comes from running
+    # the plans, which stays a deliberate act. If it should become automatic, the shape is
+    # a scheduled or label-gated job, or one that runs only the plans whose covered files
+    # the PR touched. That is a separate decision, not something to bolt on here.
+    #
+    # NOT IN `deploy-coolify`'s `needs`, on purpose: a stale anchor is a hole in our
+    # verification, not a defect in the code being deployed, so it must not block a
+    # production deploy. It still shows red on the PR, which is where it is actionable.
+    name: Mutation plan anchors
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # setup-python rather than uv: this runs stdlib-only code against JSON and source
+      # text, so there is nothing to resolve or sync. If this step ever needs dependencies,
+      # the validator has started doing more than counting substrings and should be
+      # reviewed rather than fed a `uv sync`.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Validate every mutation plan's anchors
+        run: python scripts/mutate.py --validate
 
   import-linter:
     name: OSS-EE boundary

--- a/scripts/mutate.py
+++ b/scripts/mutate.py
@@ -32,6 +32,22 @@ escaped, so it works in CI.
     uv run python scripts/mutate.py --plan tests/mutations/entity_rows.json
     uv run python scripts/mutate.py --plan <plan> --only "positional"
 
+A PLAN IS ONLY WORTH WHAT ITS LAST RUN PROVED, AND A ROTTED PLAN IS SILENT.
+An anchor is a substring of source, so any refactor can invalidate one. When that
+happens this script does the right thing — it aborts before the first mutation and
+names the offender — but nobody hears it unless somebody runs it, so the plan sits
+at ZERO applied mutations while reading as covered. ``fault_ladder.json`` was found
+in exactly that state, a 245-line plan proving nothing for an unknown period, and
+``site_preview_refresh.json`` beside it. Neither was caught by anything automatic.
+
+    uv run python scripts/mutate.py --validate     # every plan, every anchor
+
+``--validate`` checks that each ``find`` resolves EXACTLY ONCE in its target file and
+stops. It applies nothing, runs no tests and writes no marker, so it costs
+milliseconds and is safe to run anywhere — which is what makes it cheap enough to
+put on every PR (`.github/workflows/ci.yml`, the `mutation-anchors` job) while a full
+sweep stays a deliberate, local act.
+
 RESTORATION IS THE ONE THING IT MUST NEVER GET WRONG. Original bytes are read
 once up front, every apply is wrapped in try/finally, SIGINT is trapped, and a
 final pass restores everything again on the way out. A crashed run that left a
@@ -100,6 +116,11 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 #: must never be committable); the reader-facing signal is the pytest report-header
 #: banner in ``tests/conftest.py``, which fires on the path a reader actually takes.
 MARKER_PATH = REPO_ROOT / ".mutation-sweep-active"
+
+#: Where the plans live. ``--validate`` reads every ``*.json`` here by default, including
+#: ``_restore_fixture.json`` — that one drives ``test_mutate_sweep_marker.py``, so its
+#: anchor rotting would break a test rather than a sweep, which is no less worth catching.
+PLANS_DIR = REPO_ROOT / "tests" / "mutations"
 
 
 def _write_marker(plan: Path, current: str | None) -> None:
@@ -251,6 +272,141 @@ class Mutation:
         self.find: str = raw["find"]
         self.replace: str = raw["replace"]
         self.tests: list[str] = list(raw["tests"])
+
+
+def _rel(path: Path) -> str:
+    """``path`` relative to the repo root when it is inside it, else the path itself.
+
+    ``relative_to`` RAISES for a path outside the root, and a plan legitimately can be:
+    ``--plan`` accepts an absolute path and the tests point it at a tmp dir. An
+    unguarded call turned a validation run into a ValueError traceback with no output at
+    all — found by the tests in ``tests/test_mutate_validate.py``, which is the whole
+    reason a reporting path needs them too.
+    """
+    try:
+        return path.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def anchor_problem(mutation: Mutation, text: str) -> str | None:
+    """Why ``mutation``'s anchor is unusable against ``text``, or ``None`` if it is fine.
+
+    THE ONE DEFINITION of "is this anchor usable", read by both the sweep's upfront
+    validation and :func:`validate_plans`. The two want different POLICIES — a sweep must
+    stop at the first offender because proceeding half-configured is worse than not
+    starting, while validation must report every offender in one pass so a fix is one
+    round trip — but they must never disagree about what an offender IS. A second copy of
+    this rule would let the validator pass a plan the sweep then refuses to run.
+    """
+    found = text.count(mutation.find)
+    if found == 0:
+        return "anchor not found"
+    if found > 1:
+        # ASCII: this string is printed, and cp1252 turns an em-dash into a replacement
+        # character right next to the count the reader came for.
+        return f"anchor appears {found} times - make it unique"
+    return None
+
+
+def _refuse_validation_during_a_sweep(*, force: bool) -> None:
+    """Refuse to validate while a sweep marker exists.
+
+    A DIFFERENT reason from :func:`_refuse_on_existing_marker`'s, so it gets its own
+    message rather than borrowing that one: nothing here writes, so there is no mutation
+    to bake in. The problem is that a sweep has a file mutated RIGHT NOW, which means the
+    anchor it replaced currently reads as "not found" — validation would report a healthy
+    plan as rotted, which is the same mid-sweep false alarm the marker exists to prevent,
+    arriving from a new direction.
+    """
+    if not MARKER_PATH.exists() or force:
+        return
+    try:
+        age = marker_age(MARKER_PATH.read_text(encoding="utf-8"))
+    except OSError:  # pragma: no cover - unreadable marker is still a marker
+        age = None
+    note = f"{int(age.total_seconds() // 60)}m old" if age is not None else "undatable"
+    raise SystemExit(
+        f"REFUSING TO VALIDATE: {MARKER_PATH.name} exists ({note}).\n"
+        "  A sweep has a file mutated right now, so the anchor it replaced would read as\n"
+        "  missing and this pass would report a healthy plan as rotted.\n"
+        "  Wait for the sweep to finish, or pass --force if the tree is verified clean.\n"
+    )
+
+
+def validate_plans(plans: list[Path], *, force: bool = False) -> int:
+    """``--validate``: check every anchor in every plan resolves EXACTLY ONCE.
+
+    Applies no mutation, runs no test, writes no marker, touches no file. That is the
+    whole point: an anchor is a substring of source, so any refactor can invalidate one,
+    and a plan whose anchor has rotted goes QUIET rather than red — it aborts before its
+    first mutation and reports nothing unless somebody runs it. ``fault_ladder.json`` sat
+    at zero applied mutations for an unknown period while reading as covered.
+
+    Reports EVERY offender rather than the first, because the fix is per-anchor and a
+    fail-fast pass would need one CI round trip per rotted entry.
+
+    Deliberately NOT a sweep. A sweep applies a mutation and runs a test subset per entry,
+    which is minutes of compute and the wrong thing to ask of every PR; this is a few
+    milliseconds of string counting and catches the whole failure mode both real incidents
+    hit. Real mutation signal still comes from running the plans.
+
+    There is deliberately no ``--only``-style filter here: a filtered validation in CI
+    would look like a gate while leaving most plans unchecked.
+    """
+    _refuse_validation_during_a_sweep(force=force)
+    if not plans:
+        raise SystemExit(f"no mutation plans found under {_rel(PLANS_DIR)}")
+
+    texts: dict[Path, str | None] = {}
+
+    def _text(path: Path) -> str | None:
+        if path not in texts:
+            try:
+                texts[path] = path.read_text(encoding="utf-8")
+            except OSError:
+                texts[path] = None
+        return texts[path]
+
+    checked = 0
+    problems: list[tuple[str, str, str, str]] = []
+    for plan in sorted(plans):
+        rel_plan = _rel(plan)
+        for m in _load_plan(plan):
+            checked += 1
+            text = _text(m.file)
+            rel_file = _rel(m.file)
+            if text is None:
+                problems.append((rel_plan, m.label, rel_file, "no such file"))
+                continue
+            problem = anchor_problem(m, text)
+            if problem:
+                problems.append((rel_plan, m.label, rel_file, problem))
+
+    # ASCII only in what this prints. The message is read in a CI log and on a Windows
+    # console, and cp1252 renders a stray em-dash as a replacement character right where
+    # the reader is looking for a count.
+    if not problems:
+        plural = "plan" if len(plans) == 1 else "plans"
+        print(f"OK: {checked} anchors across {len(plans)} {plural} each resolve exactly once.")
+        return 0
+
+    current = ""
+    for rel_plan, label, rel_file, problem in problems:
+        if rel_plan != current:
+            print(f"\n{rel_plan}")
+            current = rel_plan
+        print(f"  {problem}")
+        print(f"    label: {label}")
+        print(f"    file : {rel_file}")
+    print(
+        f"\nFAIL: {len(problems)} of {checked} anchors do not resolve exactly once, across "
+        f"{len({p[0] for p in problems})} plan(s).\n"
+        "A plan with a bad anchor applies NO mutations: it aborts before the first one, so\n"
+        "it reads as covered while proving nothing. Repoint the anchor at the code as it is\n"
+        "now, keeping the harm the label describes, then re-run that whole plan."
+    )
+    return 1
 
 
 def _load_plan(path: Path) -> list[Mutation]:
@@ -431,14 +587,33 @@ def main() -> int:
         action="store_true",
         help="undo what a hard-killed sweep left behind, then clear the marker",
     )
+    parser.add_argument(
+        "--validate",
+        action="store_true",
+        help=(
+            "check every anchor in every plan resolves exactly once, then stop. "
+            "Applies nothing, runs no tests. With --plan, checks that plan alone"
+        ),
+    )
     args = parser.parse_args()
 
-    # --restore reads the plan path out of the marker, so it needs no --plan. Checked
-    # here rather than with argparse groups so the error names the actual requirement.
+    # --restore reads the plan path out of the marker, and --validate defaults to every
+    # plan, so neither needs --plan. Checked here rather than with argparse groups so the
+    # error names the actual requirement.
     if args.restore:
         return restore_from_marker()
+    if args.validate:
+        # --plan narrows it for local use; the default is EVERY plan, because a
+        # validation that covered one plan would look like a gate and check almost
+        # nothing.
+        plans = (
+            [args.plan if args.plan.is_absolute() else REPO_ROOT / args.plan]
+            if args.plan is not None
+            else sorted(PLANS_DIR.glob("*.json"))
+        )
+        return validate_plans(plans, force=args.force)
     if args.plan is None:
-        parser.error("--plan is required (or use --restore)")
+        parser.error("--plan is required (or use --validate / --restore)")
 
     mutations = _load_plan(args.plan if args.plan.is_absolute() else REPO_ROOT / args.plan)
     if args.only:
@@ -468,14 +643,15 @@ def main() -> int:
         if not m.file.exists():
             raise SystemExit(f"{m.label}: no such file {m.file}")
         originals.setdefault(m.file, m.file.read_bytes())
-        text = originals[m.file].decode("utf-8")
-        found = text.count(m.find)
-        if found == 0:
-            raise SystemExit(f"{m.label}: anchor not found in {m.file.relative_to(REPO_ROOT)}")
-        if found > 1:
+        # Same rule ``--validate`` applies, from the same function — see
+        # :func:`anchor_problem`. The POLICY differs and that is deliberate: a sweep stops
+        # at the first offender, because starting half-configured is worse than not
+        # starting, while validation reports them all.
+        problem = anchor_problem(m, originals[m.file].decode("utf-8"))
+        if problem:
             raise SystemExit(
-                f"{m.label}: anchor appears {found} times in "
-                f"{m.file.relative_to(REPO_ROOT)} — make it unique"
+                f"{m.label}: {problem} in {m.file.relative_to(REPO_ROOT)}\n"
+                "  Run `python scripts/mutate.py --validate` to see every rotted anchor."
             )
 
     def _restore_all(*_signal_args: object) -> None:

--- a/tests/mutations/fault_ladder.json
+++ b/tests/mutations/fault_ladder.json
@@ -137,8 +137,8 @@
   {
     "label": "a failed thumbnail render fails the whole publish, so a site that is already live and serving reports an error to its owner",
     "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "    try:\n        from pocketpaw_ee.sites.screenshot import schedule_site_screenshot\n\n        schedule_site_screenshot(site)\n    except Exception:  # noqa: BLE001 \u2014 never fail a live publish over a screenshot",
-    "replace": "    if True:\n        from pocketpaw_ee.sites.screenshot import schedule_site_screenshot\n\n        schedule_site_screenshot(site)\n    if False:  # noqa: BLE001 \u2014 never fail a live publish over a screenshot",
+    "find": "    try:\n        from pocketpaw_ee.sites.screenshot import schedule_site_screenshot\n\n        schedule_site_screenshot(site)\n    except Exception:  # noqa: BLE001 — never fail a live publish over a screenshot",
+    "replace": "    if True:\n        from pocketpaw_ee.sites.screenshot import schedule_site_screenshot\n\n        schedule_site_screenshot(site)\n    if False:  # noqa: BLE001 — never fail a live publish over a screenshot",
     "tests": [
       "tests/ee/sites/test_fault_ladder_deploy.py"
     ]
@@ -155,8 +155,8 @@
   {
     "label": "the exclusion pattern stops matching what tar actually records, so it silently protects nothing",
     "file": "ee/pocketpaw_ee/sites/daytona_build.py",
-    "find": "_EXCLUDED_MEMBER = \"./node_modules\"",
-    "replace": "_EXCLUDED_MEMBER = \"./nodemodules\"",
+    "find": "_EXCLUDED_MEMBER = \"node_modules\"",
+    "replace": "_EXCLUDED_MEMBER = \"nodemodules\"",
     "tests": [
       "tests/ee/sites/test_fault_ladder_build.py"
     ]
@@ -164,7 +164,7 @@
   {
     "label": "the exclusion is widened to a substring, so a site with a legitimately-named node_modules_report.html silently loses that file",
     "file": "ee/pocketpaw_ee/sites/daytona_build.py",
-    "find": "_EXCLUDED_MEMBER = \"./node_modules\"",
+    "find": "_EXCLUDED_MEMBER = \"node_modules\"",
     "replace": "_EXCLUDED_MEMBER = \"*node_modules*\"",
     "tests": [
       "tests/ee/sites/test_fault_ladder_build.py"

--- a/tests/mutations/site_preview_refresh.json
+++ b/tests/mutations/site_preview_refresh.json
@@ -20,8 +20,8 @@
   {
     "label": "preview refresh: the manual path swallows the failure it was asked to report",
     "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "    from pocketpaw_ee.sites.screenshot import take_draft_screenshot, take_site_screenshot",
-    "replace": "    from pocketpaw_ee.sites.screenshot import (\n        safe_take_draft_screenshot as take_draft_screenshot,\n    )\n    from pocketpaw_ee.sites.screenshot import (\n        safe_take_site_screenshot as take_site_screenshot,\n    )",
+    "find": "        image_url = await take_site_screenshot(site, ready_delays=())",
+    "replace": "        from pocketpaw_ee.sites.screenshot import safe_take_site_screenshot\n\n        image_url = await safe_take_site_screenshot(site)",
     "tests": [
       "tests/ee/sites/test_preview_refresh.py"
     ]
@@ -38,8 +38,8 @@
   {
     "label": "preview refresh: a cross-tenant site id is photographed instead of 404ing",
     "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "    site = await _load(workspace_id, site_id)\n\n    if (getattr(site, \"url\", \"\") or \"\").strip():\n        image_url = await take_site_screenshot(site)",
-    "replace": "    from bson import ObjectId as _Oid\n\n    site = await _SiteDoc.find_one({\"_id\": _Oid(site_id)})\n    if site is None:\n        raise NotFound(\"site\", site_id)\n\n    if (getattr(site, \"url\", \"\") or \"\").strip():\n        image_url = await take_site_screenshot(site)",
+    "find": "    site = await _load(workspace_id, site_id)\n\n    url = (getattr(site, \"url\", \"\") or \"\").strip()",
+    "replace": "    site = await _SiteDoc.find_one({\"_id\": ObjectId(site_id)})\n    if site is None:\n        raise NotFound(\"site\", site_id)\n\n    url = (getattr(site, \"url\", \"\") or \"\").strip()",
     "tests": [
       "tests/ee/sites/test_preview_refresh.py"
     ]

--- a/tests/test_mutate_validate.py
+++ b/tests/test_mutate_validate.py
@@ -1,0 +1,170 @@
+# tests/test_mutate_validate.py — `scripts/mutate.py --validate`, the anchor-rot check.
+#
+# Created 2026-08-10 (#1903). Nineteen mutation plans (194 anchors) lived under
+# tests/mutations/ with nothing in .github/workflows/ running any of them. The issue says
+# twenty; that count included a plan still on an unmerged branch. That is not a gap in the
+# tool —
+# mutate.py validates every anchor upfront and aborts before applying anything, naming
+# the offender — it is a gap in listening. A plan whose anchor has rotted sits at ZERO
+# applied mutations while reading as covered, and nothing says so until somebody runs it.
+# Two plans were found in exactly that state on the same day (fault_ladder.json,
+# site_preview_refresh.json), in unrelated subsystems.
+#
+# So the check itself needs tests, for the same reason every guard in this repo does: a
+# validator nobody has watched fail is not a validator. The three that matter are the two
+# failure modes (an anchor matching zero times, and one matching more than once) and the
+# healthy case, because a validator that passed everything would also pass the real plans
+# and look identical to a working one.
+#
+# THE LAST TEST IS THE ONE THAT WOULD HAVE CAUGHT #1903 ITSELF: it runs --validate over
+# the repo's REAL plans. It is the same command CI runs, so a rotted anchor fails here
+# too, on the machine of whoever rotted it.
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MUTATE = REPO_ROOT / "scripts" / "mutate.py"
+MARKER = REPO_ROOT / ".mutation-sweep-active"
+
+#: A real repo file with a stable, unique anchor, borrowed from
+#: test_mutate_sweep_marker.py's choice for the same reason: plans resolve ``file``
+#: against the repo root, so the target has to exist.
+_TARGET = "ee/pocketpaw_ee/sites/build_state.py"
+_UNIQUE_ANCHOR = 'IN_FLIGHT_STATUSES: frozenset[str] = frozenset({"queued", "building"})'
+
+#: Appears more than once in the same file, which is the second failure mode. Asserted
+#: below rather than assumed, so this test cannot quietly stop testing anything if the
+#: file changes.
+_REPEATED_ANCHOR = "        return True"
+
+
+def _validate(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(MUTATE), "--validate", *args],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        encoding="utf-8",
+    )
+
+
+def _plan(tmp_path: Path, find: str, *, label: str = "a planted anchor") -> Path:
+    plan = tmp_path / "plan.json"
+    plan.write_text(
+        json.dumps(
+            [
+                {
+                    "label": label,
+                    "file": _TARGET,
+                    "find": find,
+                    "replace": "# mutated",
+                    "tests": ["tests/ee/sites/test_build_state.py"],
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return plan
+
+
+class TestTheValidatorFires:
+    """Both failure modes, demonstrated. A guard nobody has watched break is not a guard."""
+
+    def test_an_anchor_that_matches_nothing_fails(self, tmp_path: Path) -> None:
+        plan = _plan(
+            tmp_path, "def a_function_that_was_renamed_or_deleted(", label="a rotted anchor"
+        )
+
+        result = _validate("--plan", str(plan))
+
+        assert result.returncode != 0
+        assert "anchor not found" in result.stdout
+        # The label and the file, because "a plan failed" is not actionable and the label
+        # is what says which guarantee stopped being proven.
+        assert "a rotted anchor" in result.stdout
+        assert _TARGET in result.stdout
+
+    def test_an_anchor_that_matches_twice_fails(self, tmp_path: Path) -> None:
+        """The near-miss from #1902: a refactor gave a second function a line that had
+        been unique to one. Replacing the wrong one produces a meaningless result that
+        still looks like a pass, which is why more-than-once is refused rather than
+        guessed at."""
+        occurrences = (REPO_ROOT / _TARGET).read_text(encoding="utf-8").count(_REPEATED_ANCHOR)
+        assert occurrences > 1, "the fixture anchor is no longer repeated - pick another"
+
+        result = _validate("--plan", str(_plan(tmp_path, _REPEATED_ANCHOR)))
+
+        assert result.returncode != 0
+        assert f"anchor appears {occurrences} times" in result.stdout
+
+    def test_a_good_anchor_passes(self, tmp_path: Path) -> None:
+        result = _validate("--plan", str(_plan(tmp_path, _UNIQUE_ANCHOR)))
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "OK:" in result.stdout
+
+    def test_it_applies_nothing_and_leaves_no_marker(self, tmp_path: Path) -> None:
+        """Validation is read-only: no mutation applied, no sweep marker written. If it
+        wrote one, a validation crash would strand a marker claiming a sweep is running,
+        and a marker nobody believes is worse than none."""
+        before = (REPO_ROOT / _TARGET).read_bytes()
+        marker_existed = MARKER.exists()
+
+        assert _validate("--plan", str(_plan(tmp_path, _UNIQUE_ANCHOR))).returncode == 0
+
+        assert (REPO_ROOT / _TARGET).read_bytes() == before
+        assert MARKER.exists() is marker_existed
+
+    def test_it_reports_every_offender_not_just_the_first(self, tmp_path: Path) -> None:
+        """A sweep stops at the first bad anchor, because starting half-configured is
+        worse than not starting. Validation must not: the fix is per-anchor, and
+        fail-fast would cost one CI round trip per rotted entry."""
+        plan = tmp_path / "plan.json"
+        plan.write_text(
+            json.dumps(
+                [
+                    {
+                        "label": f"rotted anchor {n}",
+                        "file": _TARGET,
+                        "find": f"def a_function_never_written_{n}(",
+                        "replace": "# mutated",
+                        "tests": ["tests/ee/sites/test_build_state.py"],
+                    }
+                    for n in range(3)
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        result = _validate("--plan", str(plan))
+
+        assert result.returncode != 0
+        for n in range(3):
+            assert f"rotted anchor {n}" in result.stdout
+        assert "3 of 3 anchors" in result.stdout
+
+
+class TestTheRepoOwnPlansValidate:
+    def test_every_checked_in_plan_resolves_exactly_once(self) -> None:
+        """The test that would have caught #1903. Same command CI runs, over the real
+        plans, so an anchor rotted by a refactor fails on the machine that rotted it."""
+        result = _validate()
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "OK:" in result.stdout
+
+    def test_it_covers_every_plan_on_disk_not_a_hand_kept_list(self) -> None:
+        """A validator that walked a list would silently stop covering a plan the day
+        somebody added one without updating the list, which is the same class of rot it
+        exists to catch."""
+        plans = sorted((REPO_ROOT / "tests" / "mutations").glob("*.json"))
+        expected = sum(len(json.loads(plan.read_text(encoding="utf-8"))) for plan in plans)
+
+        result = _validate()
+
+        assert f"{expected} anchors across {len(plans)} plans" in result.stdout


### PR DESCRIPTION
Closes #1903.

Nineteen mutation plans hold 194 anchors, and nothing ran any of them. `mutate.py` was
never the problem — it validates every anchor upfront and aborts before applying
anything, naming the offender. Nobody was listening, so a plan whose anchor had rotted
applied *zero* mutations while still reading as covered.

## Two dead plans on dev, not one

The issue names `fault_ladder.json`. Validating all nineteen found a second:

| plan | entries | broken anchors | why it rotted |
|---|---|---|---|
| `fault_ladder.json` | 19 | 2 | anchored on `_EXCLUDED_MEMBER = "./node_modules"`. That was **fixed** to a bare unanchored `"node_modules"` because GNU tar leaves nested `./sub/node_modules/` in the archive with the `./` form |
| `site_preview_refresh.json` | 5 | 2 | one anchored on a screenshot import that grew a readiness gate (`_READY_DELAYS_MANUAL`, `wait_until_serving`); the other on a branch that gained a `url` variable |

Four anchors, two plans, **24 entries applying nothing**. Both were fixed by repointing
the anchor at the code as it is now, keeping the harm each label describes. No plan was
restructured.

One of the repoints is worth calling out, because the naive fix would have been wrong.
`site_preview_refresh.json` #2 wanted the manual refresh to swallow a failure it is
supposed to report, and did it by aliasing `safe_take_site_screenshot` over the imported
name. That no longer works: the call site is now
`take_site_screenshot(site, ready_delays=())` and the `safe_` variant has no
`ready_delays` parameter, so the mutation would die on a `TypeError` — "caught", but by a
crash rather than by the thing the label names. `mutate.py`'s own docstring warns about
exactly this failure. So the anchor moved to the **call**, which is also precisely the
mutation `test_the_deploy_path_swallows_the_failure_the_manual_path_reports` describes in
its docstring.

**Note for whoever merges second:** #1901 fixes the same two `fault_ladder.json` anchors.
Expect a small conflict in that JSON and resolve it trivially — both branches repoint to
the same current literal.

## The flag

```
python scripts/mutate.py --validate                          # every plan (the CI form)
python scripts/mutate.py --validate --plan tests/mutations/x.json   # one plan, locally
```

- Checks each `find` resolves **exactly once** in its target file.
- Applies no mutation, runs no test, writes no marker, touches no file.
- Exits non-zero listing **every** offender with its `label`, its file, and whether it
  matched zero times or more than once.
- Defaults to all of `tests/mutations/*.json`. There is deliberately **no `--only` filter**
  — a filtered validation in CI would look like a gate while checking almost nothing.

Output:

```
OK: 194 anchors across 19 plans each resolve exactly once.
```

```
tests/mutations/build_state.json
  anchor not found
    label: a missing build stamp reads as FRESH instead of stale, ...
    file : ee/pocketpaw_ee/sites/build_state.py

FAIL: 1 of 194 anchors do not resolve exactly once, across 1 plan(s).
```

Three design points, since each was a decision rather than a default:

1. **`anchor_problem()` is the single definition of what an offender is**, read by both
   `--validate` and the sweep's upfront check. The *policies* differ deliberately — a sweep
   stops at the first offender because starting half-configured is worse than not starting,
   while validation reports them all so a fix is one round trip — but they must never
   disagree about what counts. A second copy of the rule would let the validator pass a
   plan the sweep then refuses to run. This is the "expose rather than duplicate" the issue
   asked for; the sweep's inline check is now four lines calling it.
2. **It refuses to run while a sweep marker exists** (`--force` overrides). A sweep has a
   file mutated right now, so the anchor it replaced currently reads as "not found" —
   validation would report a healthy plan as rotted. That is the same mid-sweep false alarm
   the marker exists to prevent, arriving from a new direction. It gets its own message
   rather than reusing `_refuse_on_existing_marker`'s, because that one warns about baking a
   mutation in via restore and nothing here writes.
3. **Printed output is ASCII.** cp1252 renders a stray em-dash as a replacement character
   right next to the count the reader came for. Comments and docstrings keep theirs.

## The CI job

`mutation-anchors` in `.github/workflows/ci.yml` — not `pr-quality-gate.yml`, to stay clear
of #1898. Three steps: checkout, `setup-python@v5` at 3.12, `python scripts/mutate.py
--validate`. **No `uv sync`, no venv** — the validator is stdlib-only against JSON and
source text, verified by running it under a bare `python` exactly as CI will. Seconds, not
minutes.

Two things it deliberately is not:

- **Not a full sweep.** A sweep applies a mutation and runs a test subset per entry —
  minutes of compute across 194 entries — and requiring that of every PR is probably the
  wrong trade. Real mutation signal still comes from running the plans, which stays a
  deliberate act. If it should become automatic, the shape is a scheduled or label-gated
  job, or one that runs only the plans whose covered files the PR touched. That is a
  separate decision and I have not made it here.
- **Not in `deploy-coolify`'s `needs`.** A stale anchor is a hole in our verification, not a
  defect in the code being deployed, so it must not block a production deploy. It still goes
  red on the PR, which is where it is actionable.

## How I proved the validator fires

Manually first, then as tests so the proof is repeatable rather than a one-off.
`tests/test_mutate_validate.py`, 7 tests:

- a planted zero-match anchor fails, and the output names the label and the file
- a planted multi-match anchor fails, with the occurrence count asserted against a live
  count of the fixture so the test cannot quietly stop testing anything
- a good anchor passes
- nothing is applied and no marker is left (target bytes compared before and after)
- three rotted anchors in one plan produce three reports, not one
- **the repo's real plans validate** — the same command CI runs, so an anchor rotted by a
  refactor fails on the machine that rotted it. This is the test that would have caught
  \#1903.
- the validator covers every plan on disk rather than a hand-kept list, computed dynamically

Writing those found a real bug in my own code: `plan.relative_to(REPO_ROOT)` raises for a
plan outside the repo, and `--plan` accepts absolute paths, so a validation run against a
tmp-dir plan died with a `ValueError` traceback and no output at all. Fixed with a `_rel()`
helper that falls back to the path as given.

## Verified

- `--validate` on dev **before** the anchor fixes: **4 of 194 anchors** bad, across 2 plans.
  **After: `OK: 194 anchors across 19 plans each resolve exactly once`,** exit 0.
- `tests/mutations/site_preview_refresh.json`: **5/5 caught.** Run twice — once after the
  repoint, once after the `mutate.py` refactor.
- `tests/mutations/fault_ladder.json`: **19/19 caught.** Also run twice, same reason.
- `tests/test_mutate_validate.py` + `tests/test_mutate_sweep_marker.py`: **29 passed.** The
  marker file asserts on the `anchor not found` string, which the refactor preserves.
- `tests/ee/sites`: **4 failed / 818 passed / 4 skipped** — the dev baseline exactly, same
  four `test_generator_client_timeout.py` names (issue #1899, Windows-only). No production
  code changed, so this is a control rather than a result.
- `uv run ruff check .` and `uv run ruff format --check .`: clean, repo-wide (2685 files).
- `ci.yml` parsed with `yaml.safe_load` to confirm the job registers and
  `deploy-coolify.needs` is unchanged.
- No sweep marker left behind after any run. Line endings checked on every edited file
  after scripted edits, LF throughout.

One correction to the issue's own numbers: it says twenty plans. There are **nineteen** on
dev — the twentieth is `sites_truth_lane.json`, still on the unmerged #1900/#1902 stack.
The finding is unaffected.

## One thing worth deciding separately

The issue raises whether a plan whose covered file a PR touches should have to *run* in
that PR. That is the targeted middle ground between this and a full sweep, and it is
cheap to compute — every entry already names its `file`. I have not built it, because it
changes what a PR is required to do rather than just closing a blind spot, and that is
your call.
