### PR TITLE
chore(ci): give inactive PRs three months before the stale bot closes them

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,5 +1,15 @@
 # Stale — auto-close abandoned PRs and issues.
 # Created: 2026-02-26
+# Updated: 2026-07-28 — the PR window was eating live work. Three changes:
+#   1. `needs-work` added to exempt-pr-labels. It's this repo's review-queue
+#      label, so nearly every open PR carries it while it waits on captain
+#      review — the one state the bot must never treat as abandonment.
+#      It wasn't exempt, and the bot closed 25 unmerged PRs on that path.
+#   2. `security` added to exempt-pr-labels. Issues already had it; PRs
+#      didn't, so a security fix could age out silently.
+#   3. days-before-pr-stale 14 -> 45. Review here is batched and captain-gated,
+#      so a PR sitting three weeks is normal, not dead. 45 + 7 still reaps
+#      genuinely abandoned work within two months.
 name: Stale
 
 on:
@@ -18,11 +28,11 @@ jobs:
       - uses: actions/stale@v9
         with:
           # PRs
-          days-before-pr-stale: 14
+          days-before-pr-stale: 45
           days-before-pr-close: 7
           stale-pr-label: 'stale'
           stale-pr-message: >
-            This PR has been inactive for 14 days. It will be closed in 7 days
+            This PR has been inactive for 45 days. It will be closed in 7 days
             if there's no further activity. If you're still working on this,
             push an update or leave a comment.
           close-pr-message: >
@@ -41,5 +51,5 @@ jobs:
 
           # Don't stale these
           exempt-issue-labels: 'pinned,good first issue,roadmap,security'
-          exempt-pr-labels: 'pinned,work-in-progress'
+          exempt-pr-labels: 'pinned,work-in-progress,needs-work,security'
           exempt-all-assignees: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,6 +10,11 @@
 #   3. days-before-pr-stale 14 -> 45. Review here is batched and captain-gated,
 #      so a PR sitting three weeks is normal, not dead. 45 + 7 still reaps
 #      genuinely abandoned work within two months.
+# Updated: 2026-09-08 — this file never reached main; the live scheduled run
+#   was still on 14 + 7 and closing real PRs (four went on the 2026-09-07 run).
+#   Widen the PR window to 75 + 15, so nothing closes under three months of
+#   inactivity, and keep the needs-work / security exemptions. Issue windows
+#   left as-is. Merge this to main to make the scheduled run use it.
 name: Stale
 
 on:
@@ -28,11 +33,11 @@ jobs:
       - uses: actions/stale@v9
         with:
           # PRs
-          days-before-pr-stale: 45
-          days-before-pr-close: 7
+          days-before-pr-stale: 75
+          days-before-pr-close: 15
           stale-pr-label: 'stale'
           stale-pr-message: >
-            This PR has been inactive for 45 days. It will be closed in 7 days
+            This PR has been inactive for 75 days. It will be closed in 15 days
             if there's no further activity. If you're still working on this,
             push an update or leave a comment.
           close-pr-message: >


### PR DESCRIPTION
The stale workflow on `main` is still the old 14-day version. The longer window (with the needs-work / security exemptions) was committed on a branch months ago but never merged, so the scheduled Monday run keeps running 14 + 7. On the 2026-09-07 run it closed #1868, #1869, #1870, #1871 and marked four more stale before hitting the 30-operation-per-run cap.

This lands the config on `main` and widens the PR window past three months:

- `days-before-pr-stale`: 14 → 75
- `days-before-pr-close`: 7 → 15

A PR now sits inactive for 75 days before it goes stale, then gets a 15-day warning before close. Nothing auto-closes under three months. The `needs-work` and `security` PR exemptions carry over, so anything in the captain review queue is skipped entirely. Issue windows are unchanged (30 + 14).

Once this merges, the next Monday run reads the new numbers. Already-stale PRs that carry `needs-work` become exempt and are left alone. Two external PRs that were stale-labeled but well under the window (#1564, #1906) had the label removed by hand so they don't get closed before this merges.