### PR TITLE
Fix: skip tests gracefully when optional deps aren't installed

### DIFF
--- a/tests/test_browser/test_driver.py
+++ b/tests/test_browser/test_driver.py
@@ -11,6 +11,11 @@ import pytest
 from pocketpaw.browser.driver import BrowserDriver
 from pocketpaw.browser.snapshot import RefMap
 
+# BrowserDriver requires the optional `playwright` extra (pip install
+# 'pocketpaw[browser]'); skip this whole module instead of failing every
+# test with ImportError when it's not installed (#715).
+playwright = pytest.importorskip("playwright")
+
 
 class TestBrowserDriverInit:
     """Tests for BrowserDriver initialization."""

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -177,6 +177,10 @@ class TestContextHub:
     @pytest.mark.asyncio
     async def test_gather_system_status(self, hub):
         """Test gathering system status context."""
+        # gather() degrades gracefully without psutil (returns an "error"
+        # key instead of the metrics below); this test exercises the full
+        # metrics path, so it needs psutil itself (#715).
+        pytest.importorskip("psutil")
         context = await hub.gather(["system_status"])
 
         assert "system_status" in context

--- a/tests/test_sarvam.py
+++ b/tests/test_sarvam.py
@@ -3,6 +3,14 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
+# These tests patch sarvamai.SarvamAI directly, which requires the optional
+# `sarvamai` extra (pip install 'pocketpaw[sarvam]') to even be importable;
+# skip the module instead of failing every test with ModuleNotFoundError
+# when it's not installed (#715).
+sarvamai = pytest.importorskip("sarvamai")
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -11,6 +11,10 @@ class TestStatusTool:
 
     def test_get_system_status_returns_string(self):
         """Status should return a formatted string."""
+        # get_system_status() degrades gracefully without psutil (returns a
+        # "(limited)" message instead of CPU/RAM/Disk figures); this test
+        # exercises the full-stats path, so it needs psutil itself (#715).
+        pytest.importorskip("psutil")
         from pocketpaw.tools import status
 
         result = status.get_system_status()
@@ -23,6 +27,7 @@ class TestStatusTool:
 
     def test_get_system_status_contains_percentages(self):
         """Status should contain percentage values."""
+        pytest.importorskip("psutil")
         from pocketpaw.tools import status
 
         result = status.get_system_status()


### PR DESCRIPTION
## Bug

As described in #715, several test suites fail with `ImportError`/`ModuleNotFoundError` instead of skipping when optional extras (`playwright`, `psutil`, `sarvamai`) aren't installed, breaking the whole test run for anyone who only did a core install.

Reproduced locally (core install, no extras): `python -m pytest tests/test_browser/test_driver.py tests/test_sarvam.py tests/test_daemon.py tests/test_tools.py -q` -> **39 failed**.

## Fix

Follows the project's own existing convention in `tests/test_vectordb.py` (`chromadb = pytest.importorskip("chromadb")`):

- **`tests/test_browser/test_driver.py`**: `BrowserDriver.__init__` calls `require_extra("playwright", "browser")` as soon as playwright is missing, so every test in this file needs it. Added a module-level `playwright = pytest.importorskip("playwright")`.
- **`tests/test_sarvam.py`**: tests patch `sarvamai.SarvamAI` directly via `unittest.mock.patch("sarvamai.SarvamAI", ...)`, which requires the module to be importable. Added a module-level `sarvamai = pytest.importorskip("sarvamai")` (plus the `import pytest` the file was missing).
- **`tests/test_daemon.py`** (`test_gather_system_status`) and **`tests/test_tools.py`** (`test_get_system_status_returns_string`, `test_get_system_status_contains_percentages`): the application code already degrades gracefully without `psutil` (`ContextHub.gather()` and `status.get_system_status()` both return a `(limited)`/`error` message instead of crashing), so these files shouldn't be skipped wholesale -- only the three specific tests that assert on the full-stats path actually need `psutil` itself. Added a function-level `pytest.importorskip("psutil")` to just those three tests.

## Scope note

While reproducing this I found two more pre-existing, unrelated collection failures on current `main` (`tests/connectors/test_drive.py` needs `soul_protocol.engine.retrieval`, `tests/ee/test_fabric_journal.py` needs `aiosqlite`) and one pre-existing unrelated test failure (`tests/test_tools.py::TestFetchTool::test_handle_path_directory`, asserting a `"keyboard"` key that isn't in the actual result). None of these are about the three extras named in #715, so I left them out of this PR to keep it focused -- happy to file separate issues for them if useful.

## Testing

- Before: `pytest tests/test_browser/test_driver.py tests/test_sarvam.py tests/test_daemon.py tests/test_tools.py -q` (core install, no extras) -> 39 failed, 69 passed.
- After: same command -> 1 failed (the pre-existing, unrelated `test_handle_path_directory`), 42 passed, 5 skipped -- all playwright/sarvamai/psutil tests now skip cleanly instead of failing.
- `ruff check` / `ruff format --check` on all 4 changed files: clean.

Closes #715