### PR TITLE
fix(sites): the build lane's state never reached the wire (slice 3 flip is blocked — see body)

### DIFF
--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -2,6 +2,20 @@
 # plane. Distinct request and response shapes per the cloud 4-file rules.
 # Created: 2026-05-30 (feat/paw-sites-backend, RFC 12 Task 3.5).
 #
+# Updated 2026-08-10 (SL-3 — the build lane reaches the wire): added
+# ``SiteResponse.build_reason`` and put all three build fields
+# (``build_status`` / ``build_reason`` / ``build_job_id``) on ``SiteStatusResponse``
+# too.
+#
+# SG-9i DECLARED ``build_status`` AND ``build_job_id`` ON ``SiteResponse`` AND NOTHING
+# EVER POPULATED THEM. ``service._to_response`` builds the DTO field by field and never
+# passed either, so every response carried the field DEFAULTS: ``build_status`` was
+# frozen at "none" for every site, no matter what the row said, and there was no
+# ``build_reason`` field at all. The frontend build-status UI reads all three — so it was
+# polling a value that could not change, which looks exactly like a build that never
+# starts. The populating half is in ``service.py``; this file only ever declared the
+# shape, which is why the gap survived a review: both halves looked complete alone.
+#
 # Updated 2026-06-01 (Phase 3 — local fake-deploy): SiteResponse carries ``url``,
 # the deployed site's openable address. LOCAL mode returns the localhost URL the
 # per-site static server serves so the caller (and the cmux smoke) can open the
@@ -223,6 +237,23 @@ class SiteResponse(BaseModel):
     # build still gets it. That matters precisely because a queued build is the case
     # where the user reloads.
     build_job_id: str | None = None
+    # SL-3: WHY the build reached ``build_status`` — a fixed ``"<rung>:<cause>"``
+    # identifier from ``sites/build_job.py`` (e.g. ``build_failed:install_failed``,
+    # ``infra_lost:build_killed_by_signal_137``), read from the persisted
+    # ``Site.build_reason``. None when no build has settled.
+    #
+    # WITHOUT THIS ON THE WIRE, ``build_status="failed"`` IS UNACTIONABLE, which is the
+    # exact failure the field was added to prevent: the row can say a build failed and
+    # nothing can say whether the user's code broke or we lost the container — and those
+    # two need opposite responses from whoever is looking at it.
+    #
+    # SAFE TO SURFACE, and that is a property of the WRITER, not of this field: the
+    # vocabulary is closed on both halves and the build's stderr never enters it (a
+    # build's error text is the user's own code and can carry a token pasted into a
+    # config). A client may split on the colon to group by rung; it must not assume the
+    # set of rungs is closed forever, for the same reason it must not error on an
+    # unrecognised ``build_status``.
+    build_reason: str | None = None
     # SI-4: the persisted import summary for an IMPORTED site — {pages: [{path,
     # title}], asset_count, asset_bytes, forms: [{page, original_action, rewired}],
     # scripts, warnings} (from-url adds status/source_url). None for every
@@ -334,6 +365,20 @@ class SiteStatusResponse(BaseModel):
     # republish updates it), plus POST /sites/{site_id}/preview-refresh on demand,
     # and the value is a different uploads link every capture.
     preview_image_url: str | None = None
+    # ── SL-3: the build lane's state on the BY-POCKET read too ──────────────────
+    # The same three fields ``SiteResponse`` carries (see there for the full write-up
+    # of each). They are duplicated onto this DTO for the same reason ``deployed_at`` /
+    # ``pattern`` / ``engine`` / ``preview_image_url`` already are: this is the read a
+    # builder polls BY POCKET, and it is the only GET keyed on a pocket id, so a client
+    # watching a build it just triggered has nowhere else to look. Without them a badge
+    # would have to fetch the whole gallery list to find one site's build state.
+    #
+    # All three default to the "no build has happened" values, so a pocket with no Site
+    # doc, and every row that predates the fields, reads as "nothing building" rather
+    # than as an error.
+    build_status: str = "none"
+    build_reason: str | None = None
+    build_job_id: str | None = None
 
 
 class SiteVersionResponse(BaseModel):

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,31 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-08-10 (SL-3 — the build lane reaches the wire): ``_to_response`` and
+# ``pocket_status`` now populate ``build_status`` / ``build_reason`` / ``build_job_id``
+# from the Site row. They were declared on the DTOs by SG-9i and never passed here, so
+# every response carried the defaults — ``build_status`` frozen at "none" regardless of
+# the row — and the shipped build-status UI was polling a field that could not change.
+# Read via ``getattr`` defaults like every other field, so a pre-SG-9i row reads as "no
+# build" instead of raising, and a pocket with no Site doc reads "none" rather than null
+# (a draft that was never published has no build, which is not the same as a failed one).
+#
+# ``build_status`` is passed through VERBATIM, never normalised against a known set: the
+# wire's contract is that a client treats an unrecognised status as IN-PROGRESS, and
+# folding an unknown value into "none" here would break that from the server side.
+#
+# THE PUBLISH PATH IS UNCHANGED BY SL-3. ``_deploy_site_doc`` still builds and deploys
+# inline for a static site. Flipping it to enqueue-and-return is blocked on a
+# prerequisite that does not exist yet: the ephemeral lane's artifact is a tar of the
+# static output only, ``sites/build_job.py`` never persists it, and no deploy target
+# accepts one — ``local_server.deploy_local`` and ``workers_deploy.deploy_workers`` both
+# want a project DIR, and the wfp path wants a worker bundle read out of one. Worse, for
+# ripple and dynamic svelte the artifact cannot serve at all: its pages come from a
+# ``_worker.js`` whose imports sit OUTSIDE the tarred directory, which is precisely why
+# ``truth_lane`` refuses to even preview one (``REASON_WORKER_RENDERED``). Flipping today
+# would take those sites from "publishes and works" to "queues a build nothing can
+# deploy".
+#
 # Updated 2026-08-10 (SL-2 slice 2 — the ephemeral-build lane gets a job): added the
 # four seams the site-build arq job (``sites/build_job.py``) writes its lifecycle
 # through — ``load_build_site``, ``mark_build_queued``, ``mark_build_running``,
@@ -1618,6 +1643,23 @@ def _to_response(doc: _SiteDoc, pattern: str = "", engine: str = "") -> SiteResp
         # None until a capture lands (empty string on the doc, and every pre-SC-1
         # row via the getattr default, read as None on the wire).
         preview_image_url=getattr(doc, "preview_image_url", "") or None,
+        # SL-3: the build lane's state, straight off the persisted row. These three
+        # were declared on the DTO by SG-9i and never populated here, so every
+        # response carried the DEFAULTS — ``build_status`` frozen at "none" no matter
+        # what the row said. A client polling a build therefore watched a field that
+        # could not change, which is indistinguishable from a build that never starts.
+        #
+        # Read with ``getattr`` defaults like every field above, so a pre-SG-9i row
+        # reads as "no build" rather than raising.
+        #
+        # ``build_status`` is passed through VERBATIM — never normalised against a
+        # known set. The wire's contract is that a client treats an unrecognised status
+        # as in-progress, and mapping an unknown value to "none" here would break that
+        # from the server side: it would tell a client "nothing is building" about a
+        # build that is running under a status this deploy predates.
+        build_status=getattr(doc, "build_status", "none"),
+        build_reason=getattr(doc, "build_reason", None),
+        build_job_id=getattr(doc, "build_job_id", None),
     )
 
 
@@ -4968,6 +5010,17 @@ async def pocket_status(*, workspace_id: str, pocket_id: str) -> SiteStatusRespo
         preview_image_url=(getattr(doc, "preview_image_url", "") or None)
         if doc is not None
         else None,
+        # SL-3: the build lane's state on the read a builder polls BY POCKET. This is
+        # the only GET keyed on a pocket id, so a client watching a build it just
+        # triggered has nowhere else to look — without these it would have to fetch the
+        # whole gallery list to find one site's build state.
+        #
+        # A pocket with NO Site doc reads the "no build" defaults rather than null: a
+        # draft that has never been published has not got a failed build, it has got no
+        # build, and those must not look the same to a badge.
+        build_status=getattr(doc, "build_status", "none") if doc is not None else "none",
+        build_reason=getattr(doc, "build_reason", None) if doc is not None else None,
+        build_job_id=getattr(doc, "build_job_id", None) if doc is not None else None,
     )
 
 

--- a/tests/ee/sites/test_build_status_on_the_wire.py
+++ b/tests/ee/sites/test_build_status_on_the_wire.py
@@ -1,0 +1,190 @@
+# tests/ee/sites/test_build_status_on_the_wire.py — the build lane's state as a CLIENT
+# sees it: ``SiteResponse`` (publish + the gallery list) and ``SiteStatusResponse`` (the
+# by-pocket status read).
+#
+# Created 2026-08-10 (SL-3).
+#
+# WHY THIS FILE EXISTS. SG-9i declared ``build_status`` and ``build_job_id`` on
+# ``SiteResponse``, and nothing ever populated them: ``_to_response`` builds the DTO field
+# by field, so every response carried the DEFAULTS — ``build_status`` frozen at "none" for
+# every site no matter what the row said — and ``build_reason`` was not a field at all.
+# Both halves reviewed clean alone. The DTO looked complete because the fields were there;
+# the service looked complete because it passed every field it knew about.
+#
+# The shipped build-status UI reads all three, so the effect was a client polling a value
+# that CANNOT CHANGE. That is indistinguishable, from the outside, from a build that never
+# starts — which is the one regression this whole sequence exists to prevent.
+#
+# THE PROPERTY THESE PIN is deliberately not "the field exists". A field can exist and be
+# hard-coded. Each test drives a DIFFERENT value onto the row and asserts the wire carries
+# THAT value, because the failure mode being guarded is a constant, not an absence.
+#
+# Mutations in tests/mutations/sl3_build_status_wire.json, run and caught.
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pocketpaw_ee.cloud.models.site import Site
+from pocketpaw_ee.sites import service as sites_service
+from pocketpaw_ee.sites.dto import SiteResponse, SiteStatusResponse
+
+#: A settled failure as ``build_job`` writes it: the rung, then the cause, both from
+#: closed sets. The shape a client splits on to decide whether to blame the user's code.
+FAILED_REASON = "build_failed:install_failed"
+
+#: An infrastructure loss, which settles to the SAME status as the failure above. The pair
+#: is what proves the status alone cannot carry the distinction.
+INFRA_REASON = "infra_lost:no_sentinel_before_timeout"
+
+
+def _doc(**overrides: Any) -> Site:
+    base: dict[str, Any] = {"workspace": "ws1", "pocket_id": "pk1", "owner": "u1", "name": "S"}
+    base.update(overrides)
+    return Site(**base)
+
+
+class TestTheBuildStateReachesSiteResponse:
+    """``POST /sites/publish`` and ``GET /sites`` both answer with this DTO."""
+
+    def test_a_queued_build_is_visible_with_its_polling_handle(self) -> None:
+        got = sites_service._to_response(
+            _doc(build_status="queued", build_job_id="site-build-abc123")
+        )
+        assert got.build_status == "queued"
+        assert got.build_job_id == "site-build-abc123"
+
+    def test_a_building_row_is_visible(self) -> None:
+        assert sites_service._to_response(_doc(build_status="building")).build_status == "building"
+
+    def test_a_finished_build_is_visible(self) -> None:
+        assert sites_service._to_response(_doc(build_status="built")).build_status == "built"
+
+    def test_a_failure_carries_the_rung_that_explains_it(self) -> None:
+        """The reason is the whole point of the field. ``failed`` with nothing else is
+        unactionable: it cannot say whether the user's code broke or we lost the
+        container, and those need opposite responses."""
+        got = sites_service._to_response(_doc(build_status="failed", build_reason=FAILED_REASON))
+        assert got.build_status == "failed"
+        assert got.build_reason == FAILED_REASON
+
+    def test_the_two_kinds_of_failure_are_distinguishable_on_the_wire(self) -> None:
+        """Both settle as ``failed``, so the STATUS is identical and only the rung
+        separates them. If the reason did not reach the client, a user would be told their
+        site is broken when we lost the sandbox."""
+        theirs = sites_service._to_response(_doc(build_status="failed", build_reason=FAILED_REASON))
+        ours = sites_service._to_response(_doc(build_status="failed", build_reason=INFRA_REASON))
+        assert theirs.build_status == ours.build_status == "failed"
+        assert theirs.build_reason != ours.build_reason
+        assert theirs.build_reason.split(":")[0] == "build_failed"
+        assert ours.build_reason.split(":")[0] == "infra_lost"
+
+    def test_a_site_that_never_built_reads_as_no_build(self) -> None:
+        got = sites_service._to_response(_doc())
+        assert got.build_status == "none"
+        assert got.build_reason is None
+        assert got.build_job_id is None
+
+    def test_an_unrecognised_status_is_passed_through_verbatim(self) -> None:
+        """The wire's contract is that a CLIENT treats an unknown status as in-progress,
+        and that only works if the server does not flatten it first. Normalising here
+        would report "nothing is building" about a build running under a status this
+        deploy predates — the rolling-deploy hazard ``build_state``'s header describes,
+        seen from the read side."""
+        got = sites_service._to_response(_doc(build_status="uploading"))
+        assert got.build_status == "uploading"
+
+    def test_a_row_predating_the_fields_does_not_break_the_read(self) -> None:
+        """Every other field here is read with a ``getattr`` default for this reason: the
+        gallery is a hot read and a pre-SG-9i row must not turn it into a 500."""
+
+        class _Ancient:
+            id = "64b7f9c2e4b0a1d2c3e4f5a6"
+            pocket_id = "pk1"
+            name = "old"
+            script_name = "s"
+            deployed = True
+            signed_key = "k"
+            url = "https://example.test"
+
+        got = sites_service._to_response(_Ancient())  # type: ignore[arg-type]
+        assert got.build_status == "none"
+        assert got.build_reason is None
+        assert got.build_job_id is None
+
+
+class TestTheDtoDeclaresTheContract:
+    def test_site_response_carries_all_three_fields(self) -> None:
+        for field in ("build_status", "build_reason", "build_job_id"):
+            assert field in SiteResponse.model_fields, field
+
+    def test_site_status_response_carries_all_three_too(self) -> None:
+        """The by-pocket read is the only GET keyed on a pocket id, so a builder watching
+        a build it just triggered has nowhere else to poll."""
+        for field in ("build_status", "build_reason", "build_job_id"):
+            assert field in SiteStatusResponse.model_fields, field
+
+    @pytest.mark.parametrize("model", [SiteResponse, SiteStatusResponse])
+    def test_the_defaults_mean_no_build_rather_than_an_error(self, model: Any) -> None:
+        assert model.model_fields["build_status"].default == "none"
+        assert model.model_fields["build_reason"].default is None
+        assert model.model_fields["build_job_id"].default is None
+
+    def test_the_reason_survives_serialisation(self) -> None:
+        """A field that exists on the model and is dropped by the dump is not on the
+        wire. This is the boundary a client actually reads."""
+        dumped = sites_service._to_response(
+            _doc(build_status="failed", build_reason=FAILED_REASON)
+        ).model_dump()
+        assert dumped["build_status"] == "failed"
+        assert dumped["build_reason"] == FAILED_REASON
+
+
+class TestTheBuildStateReachesTheByPocketStatus:
+    """``GET /sites/by-pocket/{pocket_id}/status`` — what a build badge polls."""
+
+    async def _status(self, monkeypatch: pytest.MonkeyPatch, doc: Site | None) -> Any:
+        async def _canonical(_ws: str, _pk: str) -> Any:
+            return doc
+
+        async def _patterns(_ws: str, _ids: list[str]) -> dict[str, str]:
+            return {}
+
+        async def _engines(_ws: str, _ids: list[str]) -> dict[str, str]:
+            return {}
+
+        from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+        monkeypatch.setattr(sites_service, "_canonical_site_doc", _canonical)
+        monkeypatch.setattr(pockets_service, "patterns_for_pockets", _patterns)
+        monkeypatch.setattr(pockets_service, "engines_for_pockets", _engines)
+        return await sites_service.pocket_status(workspace_id="ws1", pocket_id="pk1")
+
+    async def test_a_build_in_flight_is_visible_by_pocket(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        got = await self._status(
+            monkeypatch, _doc(build_status="building", build_job_id="site-build-xyz")
+        )
+        assert got.build_status == "building"
+        assert got.build_job_id == "site-build-xyz"
+
+    async def test_a_failure_and_its_rung_are_visible_by_pocket(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        got = await self._status(
+            monkeypatch, _doc(build_status="failed", build_reason=INFRA_REASON)
+        )
+        assert got.build_status == "failed"
+        assert got.build_reason == INFRA_REASON
+
+    async def test_a_pocket_with_no_site_reads_as_no_build_not_as_null(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A draft that was never published has NO build. That must not look the same as a
+        build that failed, and it must not look like an error either."""
+        got = await self._status(monkeypatch, None)
+        assert got.build_status == "none"
+        assert got.build_reason is None
+        assert got.build_job_id is None

--- a/tests/mutations/sl3_build_status_wire.json
+++ b/tests/mutations/sl3_build_status_wire.json
@@ -1,0 +1,75 @@
+[
+  {
+    "label": "SL-3: the publish/gallery response stops carrying build_status, so it reverts to the DTO default and every client polls a value frozen at 'none' — indistinguishable from a build that never starts, which is the bug this slice fixed",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        build_status=getattr(doc, \"build_status\", \"none\"),",
+    "replace": "",
+    "tests": [
+      "tests/ee/sites/test_build_status_on_the_wire.py::TestTheBuildStateReachesSiteResponse"
+    ]
+  },
+  {
+    "label": "SL-3: the response stops carrying build_reason, so a terminal 'failed' reaches the user with no rung — they cannot tell whether their code broke or we lost the container, and those need opposite responses",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        build_reason=getattr(doc, \"build_reason\", None),",
+    "replace": "",
+    "tests": [
+      "tests/ee/sites/test_build_status_on_the_wire.py::TestTheBuildStateReachesSiteResponse::test_a_failure_carries_the_rung_that_explains_it",
+      "tests/ee/sites/test_build_status_on_the_wire.py::TestTheBuildStateReachesSiteResponse::test_the_two_kinds_of_failure_are_distinguishable_on_the_wire"
+    ]
+  },
+  {
+    "label": "SL-3: the response stops carrying build_job_id, so a client that reloads during a queued build loses its polling handle at the moment the wait is longest — the exact reason the field is persisted rather than transient",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        build_job_id=getattr(doc, \"build_job_id\", None),",
+    "replace": "",
+    "tests": [
+      "tests/ee/sites/test_build_status_on_the_wire.py::TestTheBuildStateReachesSiteResponse::test_a_queued_build_is_visible_with_its_polling_handle"
+    ]
+  },
+  {
+    "label": "SL-3: the server normalises an unrecognised build_status to 'none', breaking the wire contract that a client treats an unknown status as IN-PROGRESS — it would report 'nothing is building' about a live build running under a status this deploy predates",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        build_status=getattr(doc, \"build_status\", \"none\"),\n        build_reason=getattr(doc, \"build_reason\", None),",
+    "replace": "        build_status=getattr(doc, \"build_status\", \"none\")\n        if getattr(doc, \"build_status\", \"none\") in {\"none\", \"queued\", \"building\", \"built\", \"failed\"}\n        else \"none\",\n        build_reason=getattr(doc, \"build_reason\", None),",
+    "tests": [
+      "tests/ee/sites/test_build_status_on_the_wire.py::TestTheBuildStateReachesSiteResponse::test_an_unrecognised_status_is_passed_through_verbatim"
+    ]
+  },
+  {
+    "label": "SL-3: the by-pocket status read stops carrying build_status, so the one GET keyed on a pocket id cannot answer 'is this building' and a badge has to fetch the whole gallery to find out",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        build_status=getattr(doc, \"build_status\", \"none\") if doc is not None else \"none\",",
+    "replace": "",
+    "tests": [
+      "tests/ee/sites/test_build_status_on_the_wire.py::TestTheBuildStateReachesTheByPocketStatus"
+    ]
+  },
+  {
+    "label": "SL-3: the by-pocket read stops carrying build_reason, so a badge can show that a build failed and never why",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        build_reason=getattr(doc, \"build_reason\", None) if doc is not None else None,",
+    "replace": "",
+    "tests": [
+      "tests/ee/sites/test_build_status_on_the_wire.py::TestTheBuildStateReachesTheByPocketStatus::test_a_failure_and_its_rung_are_visible_by_pocket"
+    ]
+  },
+  {
+    "label": "SL-3: a pocket with no Site doc reports build_status None instead of 'none', so a draft that was never published is indistinguishable from a row whose status is missing — a badge then has to guess between 'no build' and 'broken read'",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        build_status=getattr(doc, \"build_status\", \"none\") if doc is not None else \"none\",\n        build_reason=getattr(doc, \"build_reason\", None) if doc is not None else None,",
+    "replace": "        build_status=getattr(doc, \"build_status\", \"none\") if doc is not None else None,\n        build_reason=getattr(doc, \"build_reason\", None) if doc is not None else None,",
+    "tests": [
+      "tests/ee/sites/test_build_status_on_the_wire.py::TestTheBuildStateReachesTheByPocketStatus::test_a_pocket_with_no_site_reads_as_no_build_not_as_null"
+    ]
+  },
+  {
+    "label": "SL-3: build_reason is dropped from SiteResponse, so the field a client reads to explain a failure does not exist on the wire at all",
+    "file": "ee/pocketpaw_ee/sites/dto.py",
+    "find": "    build_reason: str | None = None\n    # SI-4: the persisted import summary for an IMPORTED site — {pages: [{path,",
+    "replace": "    # SI-4: the persisted import summary for an IMPORTED site — {pages: [{path,",
+    "tests": [
+      "tests/ee/sites/test_build_status_on_the_wire.py::TestTheDtoDeclaresTheContract"
+    ]
+  }
+]


### PR DESCRIPTION
**This PR does not flip the publish path.** Read the next section before reviewing the diff — I think the flip is blocked on a prerequisite nobody has built, and I would rather be told I am wrong than land an outage. What is here is the part of slice 3 that is unblocked, complete, and needed either way: the build lane's state actually reaching the client.

## Why the flip is not here

Flipping `_deploy_site_doc`'s static path to enqueue-and-return means the build stops happening inline. Everything after the build in that function needs the build's output on local disk: `_embed_concierge_bar` writes into the built pages, then one of three deploy targets runs, then the doc upsert stamps `url` / `deployed` / `deployed_at`. So the deploy has to move to wherever the build now happens — the worker.

The worker cannot deploy today, for two independent reasons:

1. **`build_job.py` never persists the artifact.** `run_build` returns the bytes, the job uses them for `artifact_bytes`, logs the verdict, and returns. Nothing writes them anywhere. A queued build would therefore end at `build_status="built"` with the site never going live — `deployed` still False, `url` still "".

2. **No deploy target accepts what the lane produces, and for the main engines the artifact cannot serve at all.** `local_server.deploy_local` and `workers_deploy.deploy_workers` both take a project *dir* (the latter writes `wrangler.jsonc` into it and shells out to wrangler there); the wfp path reads a worker bundle out of one. The artifact is `tar -C <static_output_rel> .` — the static output only. A synthesized project dir could satisfy the local/assets-only shapes, but not ripple or dynamic svelte: their pages come from a `_worker.js` whose two imports sit **outside** the tarred directory. That is not my inference — it is the finding the truth lane merged last week is built on, and its response was to refuse to even *preview* such an artifact (`truth_lane.REASON_WORKER_RENDERED`, "The artifact's pages are rendered by a worker this lane cannot execute. THE reason this module exists").

So flipping today takes every ripple and dynamic-svelte site from "publishes and works" to "queues a build nothing can deploy", while the one surface that would show the result already refuses to display it. html is moot (`needs_node_build` is False — it runs no build, so there is nothing to enqueue, confirmed as you said).

**The decision I need from you**, because the three routes are materially different work and I do not want to guess:

- **(a) Make the artifact deployable** — include the server bundle's real dependencies in the tar so `_worker.js` can execute, then teach the job to unpack into a project-dir shape and deploy. Fixes the root cause; touches `artifact_tar_command`, which has its own mutation plan and a measured history.
- **(b) Deploy from inside the sandbox** — the sandbox has the whole built project, and wrangler could run there. Avoids the artifact-shape problem entirely; needs CF credentials to reach the sandbox, which is a security decision, not an engineering one.
- **(c) Flip only the engines whose artifact is self-sufficient** (react, and static svelte) and leave ripple/dynamic svelte synchronous. Smallest change, but it still needs a deploy step plus the concierge embed and the doc upsert moved into the worker, and it leaves two publish paths to maintain.

My recommendation is (a) then the flip, because (c) pays most of the flip's cost while leaving the harder half of the estate on the old path, and (b) puts deploy credentials in a third-party sandbox.

## What is in this PR

`build_status` and `build_job_id` were declared on `SiteResponse` by SG-9i and **never populated**. `_to_response` builds the DTO field by field and passed neither, so every response carried the defaults — `build_status` frozen at "none" for every site, whatever the row said — and `build_reason` was not a field at all.

The frontend that shipped in #767 reads all three. So on `dev` right now it is polling a value that cannot change, which from the outside is indistinguishable from a build that never starts. That is the regression this sequence exists to prevent, and it is live independently of any flip.

- `SiteResponse` gains `build_reason`; `_to_response` populates all three off the row.
- `SiteStatusResponse` gains all three, and `pocket_status` populates them. `GET /sites/by-pocket/{pocket_id}/status` is the only GET keyed on a pocket id, so it is the only thing a builder watching a build it just triggered can poll — otherwise a badge has to fetch the whole gallery list to find one site.

Two decisions rather than plumbing:

**`build_status` is passed through verbatim, never normalised against a known set.** The wire's contract is that a *client* treats an unrecognised status as in-progress; folding an unknown value into "none" server-side breaks that from the other end — it would report "nothing is building" about a live build running under a status this deploy predates. That is the read-side face of the deploy-ordering hazard `build_state.py`'s header describes, and it is why one mutation in the plan adds exactly that normalisation and has to be caught.

**A pocket with no Site doc reads "none", not null.** A draft that was never published has no build. That must not look like a failed build, and must not look like a broken read.

Every field is read with a `getattr` default, like the rest of `_to_response`, so a pre-SG-9i row cannot turn a hot gallery read into a 500.

## The judgement call you asked for, already answered in slice 2

Whether publish returns before or after the enqueue is confirmed, and what happens when Redis is down, is settled in `enqueue_site_build` and unchanged here:

- The row is stamped `queued` **before** the enqueue, because a worker that claimed the job first would write a terminal status and have a late stamp land on top of it, pinning a *finished* build in `queued` forever. The job id is minted locally and passed as arq's `_job_id`, so that stamp is one write with nothing to race.
- If the enqueue fails — pool construction, a dead Redis, or arq refusing the id — the row is rolled to a terminal `failed` with `enqueue_failed:pool_or_enqueue_raised` and **the exception re-raises**. So publish cannot return success for a build that was never queued: the caller turns the raise into a 5xx the user sees, and the row is immediately republishable rather than sitting in a state the UI reports as in-progress forever.
- Both paths are tested (`test_a_failed_enqueue_does_not_pin_the_row_in_queued`, `test_an_arq_refusal_is_treated_as_a_failed_enqueue`, `test_an_unset_redis_url_refuses_and_frees_the_row`) and mutation-covered.

When the flip does land, that ordering is what it should keep: enqueue *inside* the request, surface the failure, and never stamp anything a worker cannot undo.

## Verification

- 16 new tests. Each drives a *different* value onto the row and asserts the wire carries that value, because the failure mode being guarded is a hard-coded constant, not an absent field.
- `tests/ee/sites`: **979 passed, 4 failed, 4 skipped** — the four are the `test_generator_client_timeout.py` Windows child-reap failures (#1899) and nothing else. That is your 963 baseline plus these 16.
- `tests/mutations/sl3_build_status_wire.json`: **8/8 caught** — each field dropped from each of the two readers, the unknown-status normalisation, the null-vs-"none" case, and the DTO field removed.
- `python scripts/mutate.py --validate`: 264 anchors across 23 plans each resolve exactly once.
- `uv run ruff check .` and `uv run ruff format --check .`: clean repo-wide (2692 files).
- Secret scan run over my own diff against all eight patterns (AWS key id, `sk-`, `ghp_`/`gho_`, `xoxb-`/`xoxp-`, `sk_live_`, and the PEM header checked by hand since CI's grep eats a leading hyphen): zero matches.

## Not touched

`_deploy_site_doc`, `_provision_dynamic_site`, and every deploy target. The dynamic path already enqueues its provision job with its own single-flight, as you said — I confirmed it at the fork on line 2162 and left it alone. Local mode is untouched, so the localhost path the smoke tests use behaves exactly as before.
