### PR TITLE
feat(sites): publish a react site by queueing its build

### DIFF
--- a/ee/pocketpaw_ee/sites/build_job.py
+++ b/ee/pocketpaw_ee/sites/build_job.py
@@ -7,12 +7,28 @@
 # it, ``build_state`` could decide what to write and nothing called it. This is the
 # module that joins them, and it is the FIRST caller ``run_build`` has ever had.
 #
-# WHAT THIS DELIBERATELY DOES NOT DO: change the publish path. ``service.publish`` still
-# builds synchronously through the local generator. Flipping it to enqueue-and-return is
-# a separate slice gated on a frontend that can render a queued build — and shipping the
-# flip before that frontend exists would show every publisher a finished-looking page
-# for a site that has not built yet. So this module is complete and callable, and the
-# only thing that calls it today is its tests.
+# Edited 2026-08-10 (SL-3): THIS MODULE NOW HAS A PRODUCTION CALLER, and it finishes the
+# publish rather than only recording a verdict. ``service._enqueue_static_build`` queues a
+# build for the engines whose artifact can be deployed from this lane, and on a clean
+# build the job materialises the artifact and calls ``service.deploy_prebuilt_site`` — the
+# SAME deploy tail the inline path runs (concierge embed → deploy → canonical upsert →
+# knowledge sync + screenshot). One deploy implementation, two places the build can have
+# happened.
+#
+# THE DEPLOY RUNS BEFORE THE ROW SETTLES. ``built`` must never mean "built but not
+# serving": a client reads that as done. So a deploy failure after a clean build settles
+# as :data:`RUNG_DEPLOY_FAILED` instead — its own rung, because nothing about the user's
+# build was wrong and blaming it would send them to debug a site that compiles.
+#
+# ``deploy_inputs=None`` KEEPS THE SLICE-2 SHAPE REACHABLE: build, classify, record, deploy
+# nothing. That is not dead code — a build queued to verify an artifact is a real use of
+# this lane, and it is what the fault-ladder tests drive.
+#
+# WHICH ENGINES ARRIVE HERE IS DECIDED IN ``service.build_runs_async``, not here, and it is
+# react-only today. The reason is the artifact, not the queue: an adapter-cloudflare build
+# (ripple, dynamic svelte) emits pages rendered by a ``_worker.js`` whose imports sit
+# outside the tarred directory, so the artifact cannot serve — which is why ``truth_lane``
+# refuses to preview one. Widen that predicate only together with the artifact.
 #
 # ┌───────────────────────────────────────────────────────────────────────────────────┐
 # │ WHY A DEDICATED ARQ FUNCTION AND NOT THE WORKSPACE-JOBS REGISTRY.                  │
@@ -207,6 +223,11 @@ RUNG_ARTIFACT_MISSING = "artifact_missing"
 #: The enqueue itself failed after the row was already stamped ``queued``. Written by the
 #: enqueue helper so the row lands TERMINAL instead of pinned in flight.
 RUNG_ENQUEUE_FAILED = "enqueue_failed"
+#: SL-3. The build produced a deployable artifact and the DEPLOY failed. Deliberately its
+#: own rung rather than folded into ``build_failed``: nothing about the user's build was
+#: wrong, so blaming it would send them to debug a site that compiles. Retryable — a
+#: failed wrangler run or an unreachable Cloudflare is worth another publish.
+RUNG_DEPLOY_FAILED = "deploy_failed"
 
 
 @dataclass(frozen=True)
@@ -373,9 +394,11 @@ async def run_site_build(
     engine: str,
     timeout_seconds: int,
     *,
+    deploy_inputs: dict[str, Any] | None = None,
     attempts_left: int = 0,
     _runner: Any = None,
     _client: Any = None,
+    _deployer: Any = None,
 ) -> None:
     """arq job: scaffold, build in an ephemeral sandbox, and record the outcome.
 
@@ -390,9 +413,15 @@ async def run_site_build(
     immediately. It is a parameter rather than a literal so ``settle``'s stay-in-flight
     branch is reachable the day an attempt loop lands, and testable before then.
 
-    ``_runner`` / ``_client`` are the test-injection seams (the convention the rest of
-    ``sites`` uses): a generator runner exposing ``generate``, and a Daytona client.
-    None means the real thing.
+    ``deploy_inputs`` is what the publish captured, carried through so the DEPLOY runs
+    with the inputs of the publish that queued it rather than with whatever the pocket's
+    draft has become since. When it is None the job builds and records the outcome and
+    deploys nothing — the shape slice 2 shipped, still reachable and still tested,
+    because a build whose result is only being verified is a real use of this lane.
+
+    ``_runner`` / ``_client`` / ``_deployer`` are the test-injection seams (the convention
+    the rest of ``sites`` uses): a generator runner exposing ``generate``, a Daytona
+    client, and the deploy callback. None means the real thing.
 
     NEVER RAISES FOR A BUILD OUTCOME — a failed build, a timeout and a lost sandbox are
     all results, and the row is where they get recorded. It DOES re-raise when the sandbox
@@ -493,7 +522,90 @@ async def run_site_build(
 
     settlement = resolve_build_settlement(result, attempts_left=attempts_left)
     _log_outcome(site_id, result, settlement)
+
+    # SL-3: a build that produced a deployable artifact still has to become a LIVE site.
+    # The deploy runs BEFORE the row settles, so ``built`` never means "built but not
+    # serving" — a status a client would reasonably read as done.
+    if settlement.status == "built" and deploy_inputs is not None:
+        try:
+            await _deploy_built_artifact(
+                result.artifact,
+                engine=engine,
+                deploy_inputs=deploy_inputs,
+                deployer=_deployer,
+            )
+        except Exception:
+            # The build worked and the deploy did not, so this is NOT a build failure —
+            # but from the publisher's side nothing went live, and the row is the only
+            # place that can say so. A terminal status is also what keeps the site
+            # republishable; leaving ``built`` on a site that never deployed would read
+            # as success forever.
+            logger.exception("sites.build: deploy failed for site %s after a clean build", site_id)
+            await _record(
+                site,
+                _settlement(
+                    RUNG_DEPLOY_FAILED,
+                    "deploy_raised",
+                    retryable=True,
+                    attempts_left=attempts_left,
+                ),
+            )
+            raise
+
     await _record(site, settlement)
+
+
+async def _deploy_built_artifact(
+    artifact: bytes | None,
+    *,
+    engine: str,
+    deploy_inputs: dict[str, Any],
+    deployer: Any = None,
+) -> None:
+    """Materialise the artifact into a project-dir shape and run the deploy tail.
+
+    THE ARTIFACT IS UNPACKED THROUGH ``artifact_preview.unpack_artifact``, not through a
+    second extractor written here. That function is hardened against the two things a tar
+    from customer content will eventually contain — a member that escapes its root
+    (``../``, absolute, drive-qualified, a symlink) and a zip bomb — and every one of
+    those guards has a mutation proving it fires. Hand-rolling an extractor for the deploy
+    path would mean the deploy got the unproven copy.
+
+    Its skip list is written for a PREVIEW (``_worker.js`` and deploy metadata are
+    dropped), which is harmless here only because this path is react-only: react emits no
+    server entry, and ``deploy_workers`` writes its own ``.assetsignore``. Widening
+    ``service.build_runs_async`` past react means revisiting this — an engine whose worker
+    IS the site cannot have it dropped on the way to the edge.
+
+    The tree is extracted UNDER the engine's static-output rel, because the deploy targets
+    resolve their source as ``<project_dir>/<static_output_rel>`` while the tar is rooted
+    AT that directory's contents. Extracting flat would deploy an empty dir.
+    """
+    if not artifact:
+        # ``settle`` only reaches ``built`` via ``BuildRunResult.ok``, which requires
+        # bytes, so this is unreachable rather than tolerated — and it is checked anyway,
+        # because "deploy whatever arrived" is how an empty deploy happens.
+        raise RuntimeError("refusing to deploy an empty artifact")
+
+    from pocketpaw_ee.sites import artifact_preview
+    from pocketpaw_ee.sites import service as _service
+    from pocketpaw_ee.sites.engines import static_output_rel
+
+    deploy = deployer or _service.deploy_prebuilt_site
+    project_dir = tempfile.mkdtemp(prefix="paw-deploy-")
+    try:
+        unpacked = artifact_preview.unpack_artifact(
+            artifact, Path(project_dir, static_output_rel(engine))
+        )
+        logger.info(
+            "sites.build: materialised %d entries (%d bytes) for the deploy of site %s",
+            unpacked.entries,
+            unpacked.bytes_written,
+            deploy_inputs.get("site_id"),
+        )
+        await deploy(project_dir=project_dir, deploy_inputs=deploy_inputs)
+    finally:
+        shutil.rmtree(project_dir, ignore_errors=True)
 
 
 async def _scaffold(generator_input: dict[str, Any], out_dir: str, *, runner: Any = None) -> str:
@@ -601,6 +713,7 @@ async def enqueue_site_build(
     *,
     engine: str,
     generator_input: dict[str, Any],
+    deploy_inputs: dict[str, Any] | None = None,
     timeout_seconds: int | None = None,
     _pool_override: Any = None,
 ) -> str | None:
@@ -656,6 +769,10 @@ async def enqueue_site_build(
             normalize_engine(engine),
             timeout,
             _job_id=job_id,
+            # Rides as a kwarg so the positional payload stays exactly what slice 2
+            # shipped, and a build queued for verification alone (no deploy) simply omits
+            # it. arq forwards any non-underscore kwarg to the function.
+            deploy_inputs=deploy_inputs,
         )
         if job is None:
             # arq returns None when the id already exists. With a uuid-tailed id that
@@ -685,6 +802,7 @@ __all__ = [
     "OUT_OF_SANDBOX_MARGIN_SECONDS",
     "RUNG_ARTIFACT_MISSING",
     "RUNG_ENGINE_NOT_BUILDABLE",
+    "RUNG_DEPLOY_FAILED",
     "RUNG_ENQUEUE_FAILED",
     "RUNG_SANDBOX_UNAVAILABLE",
     "RUNG_SCAFFOLD_EMPTY",

--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -2,6 +2,20 @@
 # plane. Distinct request and response shapes per the cloud 4-file rules.
 # Created: 2026-05-30 (feat/paw-sites-backend, RFC 12 Task 3.5).
 #
+# Updated 2026-08-10 (SL-3 — the build lane reaches the wire): added
+# ``SiteResponse.build_reason`` and put all three build fields
+# (``build_status`` / ``build_reason`` / ``build_job_id``) on ``SiteStatusResponse``
+# too.
+#
+# SG-9i DECLARED ``build_status`` AND ``build_job_id`` ON ``SiteResponse`` AND NOTHING
+# EVER POPULATED THEM. ``service._to_response`` builds the DTO field by field and never
+# passed either, so every response carried the field DEFAULTS: ``build_status`` was
+# frozen at "none" for every site, no matter what the row said, and there was no
+# ``build_reason`` field at all. The frontend build-status UI reads all three — so it was
+# polling a value that could not change, which looks exactly like a build that never
+# starts. The populating half is in ``service.py``; this file only ever declared the
+# shape, which is why the gap survived a review: both halves looked complete alone.
+#
 # Updated 2026-06-01 (Phase 3 — local fake-deploy): SiteResponse carries ``url``,
 # the deployed site's openable address. LOCAL mode returns the localhost URL the
 # per-site static server serves so the caller (and the cmux smoke) can open the
@@ -223,6 +237,23 @@ class SiteResponse(BaseModel):
     # build still gets it. That matters precisely because a queued build is the case
     # where the user reloads.
     build_job_id: str | None = None
+    # SL-3: WHY the build reached ``build_status`` — a fixed ``"<rung>:<cause>"``
+    # identifier from ``sites/build_job.py`` (e.g. ``build_failed:install_failed``,
+    # ``infra_lost:build_killed_by_signal_137``), read from the persisted
+    # ``Site.build_reason``. None when no build has settled.
+    #
+    # WITHOUT THIS ON THE WIRE, ``build_status="failed"`` IS UNACTIONABLE, which is the
+    # exact failure the field was added to prevent: the row can say a build failed and
+    # nothing can say whether the user's code broke or we lost the container — and those
+    # two need opposite responses from whoever is looking at it.
+    #
+    # SAFE TO SURFACE, and that is a property of the WRITER, not of this field: the
+    # vocabulary is closed on both halves and the build's stderr never enters it (a
+    # build's error text is the user's own code and can carry a token pasted into a
+    # config). A client may split on the colon to group by rung; it must not assume the
+    # set of rungs is closed forever, for the same reason it must not error on an
+    # unrecognised ``build_status``.
+    build_reason: str | None = None
     # SI-4: the persisted import summary for an IMPORTED site — {pages: [{path,
     # title}], asset_count, asset_bytes, forms: [{page, original_action, rewired}],
     # scripts, warnings} (from-url adds status/source_url). None for every
@@ -334,6 +365,20 @@ class SiteStatusResponse(BaseModel):
     # republish updates it), plus POST /sites/{site_id}/preview-refresh on demand,
     # and the value is a different uploads link every capture.
     preview_image_url: str | None = None
+    # ── SL-3: the build lane's state on the BY-POCKET read too ──────────────────
+    # The same three fields ``SiteResponse`` carries (see there for the full write-up
+    # of each). They are duplicated onto this DTO for the same reason ``deployed_at`` /
+    # ``pattern`` / ``engine`` / ``preview_image_url`` already are: this is the read a
+    # builder polls BY POCKET, and it is the only GET keyed on a pocket id, so a client
+    # watching a build it just triggered has nowhere else to look. Without them a badge
+    # would have to fetch the whole gallery list to find one site's build state.
+    #
+    # All three default to the "no build has happened" values, so a pocket with no Site
+    # doc, and every row that predates the fields, reads as "nothing building" rather
+    # than as an error.
+    build_status: str = "none"
+    build_reason: str | None = None
+    build_job_id: str | None = None
 
 
 class SiteVersionResponse(BaseModel):

--- a/ee/pocketpaw_ee/sites/generator_client.py
+++ b/ee/pocketpaw_ee/sites/generator_client.py
@@ -8,6 +8,14 @@
 # behind a _runner so the orchestration is unit-testable without Bun/workerd.
 # Created: 2026-05-30 (feat/paw-sites-backend, Task 2.3).
 #
+# Updated 2026-08-10 (SL-3 — the async publish needs the payload without the build):
+# extracted ``build_generator_input`` out of ``_build_one`` as a module-level function.
+# ``_build_one`` now calls it and passes the result straight through, so every existing
+# payload is byte-identical; the point is that the ASYNC publish path can assemble the
+# same input in the web process while ``generate`` runs in a worker. Two copies of that
+# assembly would drift on the next generator key that lands, and the failure would be
+# silent — a site that builds differently depending on which path published it.
+#
 # Updated 2026-07-30 (fix/sites-d1-svelte-audit): corrected the build-timeout
 # comments. They claimed "a legit build is ~45-60s", which is true for a static site
 # and false for a dynamic one — a measured 1-table dynamic ripple build takes 4m47s,
@@ -891,6 +899,101 @@ def _rewrite_ripple_dep(project_dir: str, source: str) -> None:
         pkg_path.write_text(json.dumps(pkg, indent=2))
 
 
+def build_generator_input(
+    *,
+    engine: str,
+    theme: dict[str, Any],
+    site_id: str,
+    title: str,
+    capture_api_base: str,
+    capture_signed_key: str,
+    ripple_spec: dict[str, Any] | None = None,
+    source: dict[str, Any] | None = None,
+    assets: dict[str, str] | None = None,
+    builder_origin: str | None = None,
+    d1_database_id: str = "",
+    keeps_client_bundle: bool = False,
+) -> dict[str, Any]:
+    """The generator's STAGE-1/2 input payload — the exact dict handed to ``generate``.
+
+    Extracted from ``_build_one`` 2026-08-10 (SL-3) so the ASYNC publish path can build
+    the same payload without a second implementation. That mattered enough to justify a
+    refactor of a well-covered function: the ephemeral build lane runs ``generate`` in a
+    worker, so the payload has to be assembled at enqueue time in the web process. Two
+    copies of this assembly would drift on the next generator key that lands, and the
+    failure would be silent — a site that builds differently depending on which path
+    published it.
+
+    Behaviour-preserving by construction: ``_build_one`` now calls this and passes the
+    result straight through, so every existing payload is byte-identical.
+    """
+    site_config: dict[str, Any] = {
+        "siteId": site_id,
+        "title": title,
+        "captureApiBase": capture_api_base,
+        "captureSignedKey": capture_signed_key,
+        # DP0-1: the per-tenant D1 id the generator threads into the emitted
+        # wrangler.toml ``database_id``. ALWAYS present (default "" for a static
+        # site — the prior empty value), so a caller CAN bind a dynamic site's
+        # data plane by supplying it. The real id comes from the provision job
+        # at the caller in a later task (DP0-3/DP0-4).
+        "d1DatabaseId": d1_database_id,
+    }
+    # SE-2b: only present when the site is being published as editable, so a
+    # non-editable publish's payload is byte-identical to before this change.
+    if builder_origin:
+        site_config["builderOrigin"] = builder_origin
+    # MT-1: only present when the site DECLARES that its own client JS is
+    # load-bearing. The generator then emits ``csr = true`` (the page stays
+    # prerendered) and marks the route manifest, so the hand-written onMount /
+    # ``use:`` action / IntersectionObserver / WebGL code actually runs and the
+    # ripple build's prune step leaves the hydration bundle alone. Omitted when
+    # False so a plain static site's payload is byte-identical to before.
+    if keeps_client_bundle:
+        site_config["keepsClientBundle"] = True
+    input_json: dict[str, Any] = {
+        "engine": engine,
+        "theme": theme,
+        "siteConfig": site_config,
+    }
+    if engine == "svelte":
+        # DSV-5: a DYNAMIC svelte pocket carries its live-data bindings
+        # (objects/sources/actions/auth) as SIBLING keys on the same ``source``
+        # envelope that holds the {path: contents} files. Peel them out: the
+        # file map goes on ``input.source`` (materializeSource writes each key
+        # as a file, so a binding key mixed in would break the build), and the
+        # bindings are spread as FLAT siblings on GenerateInput — the exact
+        # shape DSV-1's parseBindings reads (``input.objects`` / ``input.sources``
+        # / ``input.actions`` / ``input.auth``), NOT nested under ``source``. A
+        # STATIC svelte pocket has no binding keys → ``bindings`` is empty and
+        # ``input.source`` is the unchanged file map (pre-DSV-5 wire bytes).
+        files, bindings = _split_svelte_source(source)
+        input_json["source"] = files
+        input_json.update(bindings)
+    elif is_source_engine(engine):
+        # HE-3/HE-1: html is a source-map engine too — it sends its raw
+        # ``{path: contents}`` static tree on ``input.source`` and OMITS
+        # ``rippleSpec`` (a hand-authored html site has no rippleSpec). Unlike
+        # svelte there is NO binding split: dynamic (live-data) html is a
+        # non-goal, so an html source map carries only files. ripple (not a
+        # source engine) is untouched by this branch and still sends rippleSpec
+        # below, so its wire bytes — and svelte's — are unchanged.
+        input_json["source"] = source or {}
+        # SI-4 CROSS-REPO SEAM: an html IMPORT also carries binary files, which
+        # cannot ride the text-only ``source`` map — they ride ``input.assets``
+        # ({path: base64}). The paw-sites generator's ``assets`` handling
+        # (decode + write each entry verbatim into the emitted static tree) is
+        # being added in a PARALLEL paw-sites slice; this codes to that
+        # contract. Sent ONLY when non-empty, so a plain html publish's payload
+        # stays byte-identical, and a generator predating the key ignores it
+        # (the import report warns that assets then don't deploy).
+        if assets:
+            input_json["assets"] = assets
+    else:
+        input_json["rippleSpec"] = ripple_spec
+    return input_json
+
+
 class _Runner(Protocol):
     async def generate(self, input_json: dict[str, Any], out_dir: str) -> dict[str, Any]: ...
     async def install(self, project_dir: str) -> tuple[bool, str]: ...
@@ -1368,70 +1471,20 @@ class GeneratorClient:
         # §4.2: ``engine`` is always present; the STAGE-2 payload key forks on
         # it. svelte → ``source`` (no rippleSpec); ripple → ``rippleSpec`` (no
         # source). siteConfig + theme ride both tracks unchanged.
-        site_config: dict[str, Any] = {
-            "siteId": site_id,
-            "title": title,
-            "captureApiBase": capture_api_base,
-            "captureSignedKey": capture_signed_key,
-            # DP0-1: the per-tenant D1 id the generator threads into the emitted
-            # wrangler.toml ``database_id``. ALWAYS present (default "" for a static
-            # site — the prior empty value), so a caller CAN bind a dynamic site's
-            # data plane by supplying it. The real id comes from the provision job
-            # at the caller in a later task (DP0-3/DP0-4).
-            "d1DatabaseId": d1_database_id,
-        }
-        # SE-2b: only present when the site is being published as editable, so a
-        # non-editable publish's payload is byte-identical to before this change.
-        if builder_origin:
-            site_config["builderOrigin"] = builder_origin
-        # MT-1: only present when the site DECLARES that its own client JS is
-        # load-bearing. The generator then emits ``csr = true`` (the page stays
-        # prerendered) and marks the route manifest, so the hand-written onMount /
-        # ``use:`` action / IntersectionObserver / WebGL code actually runs and the
-        # ripple build's prune step leaves the hydration bundle alone. Omitted when
-        # False so a plain static site's payload is byte-identical to before.
-        if keeps_client_bundle:
-            site_config["keepsClientBundle"] = True
-        input_json: dict[str, Any] = {
-            "engine": engine,
-            "theme": theme,
-            "siteConfig": site_config,
-        }
-        if engine == "svelte":
-            # DSV-5: a DYNAMIC svelte pocket carries its live-data bindings
-            # (objects/sources/actions/auth) as SIBLING keys on the same ``source``
-            # envelope that holds the {path: contents} files. Peel them out: the
-            # file map goes on ``input.source`` (materializeSource writes each key
-            # as a file, so a binding key mixed in would break the build), and the
-            # bindings are spread as FLAT siblings on GenerateInput — the exact
-            # shape DSV-1's parseBindings reads (``input.objects`` / ``input.sources``
-            # / ``input.actions`` / ``input.auth``), NOT nested under ``source``. A
-            # STATIC svelte pocket has no binding keys → ``bindings`` is empty and
-            # ``input.source`` is the unchanged file map (pre-DSV-5 wire bytes).
-            files, bindings = _split_svelte_source(source)
-            input_json["source"] = files
-            input_json.update(bindings)
-        elif is_source_engine(engine):
-            # HE-3/HE-1: html is a source-map engine too — it sends its raw
-            # ``{path: contents}`` static tree on ``input.source`` and OMITS
-            # ``rippleSpec`` (a hand-authored html site has no rippleSpec). Unlike
-            # svelte there is NO binding split: dynamic (live-data) html is a
-            # non-goal, so an html source map carries only files. ripple (not a
-            # source engine) is untouched by this branch and still sends rippleSpec
-            # below, so its wire bytes — and svelte's — are unchanged.
-            input_json["source"] = source or {}
-            # SI-4 CROSS-REPO SEAM: an html IMPORT also carries binary files, which
-            # cannot ride the text-only ``source`` map — they ride ``input.assets``
-            # ({path: base64}). The paw-sites generator's ``assets`` handling
-            # (decode + write each entry verbatim into the emitted static tree) is
-            # being added in a PARALLEL paw-sites slice; this codes to that
-            # contract. Sent ONLY when non-empty, so a plain html publish's payload
-            # stays byte-identical, and a generator predating the key ignores it
-            # (the import report warns that assets then don't deploy).
-            if assets:
-                input_json["assets"] = assets
-        else:
-            input_json["rippleSpec"] = ripple_spec
+        input_json = build_generator_input(
+            engine=engine,
+            theme=theme,
+            site_id=site_id,
+            title=title,
+            capture_api_base=capture_api_base,
+            capture_signed_key=capture_signed_key,
+            ripple_spec=ripple_spec,
+            source=source,
+            assets=assets,
+            builder_origin=builder_origin,
+            d1_database_id=d1_database_id,
+            keeps_client_bundle=keeps_client_bundle,
+        )
         gen = await self._runner.generate(input_json, out_dir)
         project_dir = gen["projectDir"]
         # HE-3: an html publish's last-mile output IS the authored source (HE-1 makes

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -813,8 +813,8 @@ from pocketpaw_ee.sites.dto import (
     SiteResponse,
     SiteStatusResponse,
 )
-from pocketpaw_ee.sites.engines import content_key, is_source_engine
-from pocketpaw_ee.sites.generator_client import GeneratorClient
+from pocketpaw_ee.sites.engines import content_key, is_source_engine, normalize_engine
+from pocketpaw_ee.sites.generator_client import BuildResult, GeneratorClient
 
 logger = logging.getLogger(__name__)
 
@@ -2157,6 +2157,13 @@ async def _deploy_site_doc(
     # HE-4: the workers deployer is engine-aware (``deploy_workers(site_id,
     # project_dir, *, engine=..., d1_database_id=...)``), so the seam takes kwargs.
     workers_deploy: Callable[..., Any] | None = None,
+    # SL-3: an ALREADY-BUILT project dir. When given, the inline build is SKIPPED and
+    # everything after it (concierge embed → deploy → upsert → sync/screenshot) runs
+    # verbatim. This is how the ephemeral build lane finishes a publish: the worker
+    # built in a sandbox, materialised the artifact, and calls back in here rather than
+    # growing a second copy of the deploy tail. One deploy path, two places the build
+    # can have happened.
+    prebuilt_project_dir: str | None = None,
 ) -> _SiteDoc:
     """Generate, smoke-gate, deploy, and UPSERT the LIVE canonical Site doc.
 
@@ -2212,6 +2219,27 @@ async def _deploy_site_doc(
             builder_origin=builder_origin,
         )
 
+    # SL-3: fork to the EPHEMERAL BUILD LANE for the engines whose artifact can
+    # actually be deployed from it. A prebuilt dir means the worker already ran this
+    # build and is calling back in to finish the publish, so it must NOT re-fork.
+    if prebuilt_project_dir is None and build_runs_async(engine):
+        return await _enqueue_static_build(
+            workspace_id=workspace_id,
+            user_id=user_id,
+            pocket_id=pocket_id,
+            site_id=site_id,
+            signed_key=signed_key,
+            site_name=site_name,
+            ripple_spec=ripple_spec,
+            theme=theme,
+            engine=engine,
+            source=source,
+            assets=assets,
+            pattern=pattern,
+            builder_origin=builder_origin,
+            keeps_client_bundle=keeps_client_bundle,
+        )
+
     gen = generator or GeneratorClient()
     # DEP-3: map a generator/install/smoke failure (missing toolchain, non-zero
     # build, SSR fail-gate) to a clean CloudError (sites.generator_failed → 5xx)
@@ -2222,28 +2250,36 @@ async def _deploy_site_doc(
     # non-import publish's build call (and every injected fake's expected kwargs)
     # stays byte-identical to before the assets seam existed.
     _asset_kwargs: dict[str, Any] = {"assets": assets} if assets else {}
-    build = await _build_or_cloud_error(
-        gen,
-        ripple_spec=ripple_spec,
-        theme=theme,
-        site_id=site_id,
-        title=site_name,
-        capture_api_base=_capture_base(),
-        capture_signed_key=signed_key,
-        engine=engine,
-        source=source,
-        builder_origin=builder_origin,
-        keeps_client_bundle=keeps_client_bundle,
-        **_asset_kwargs,
-        # PERF-3: build into the STABLE per-pocket working dir so node_modules
-        # persists and `bun install` is cached across builds, cutting the dominant
-        # per-edit cost.
-        pocket_id=pocket_id,
-        # A live deploy keeps the SSR fail-gate (smoke=True) so the gate + the
-        # rollback in edit_svelte_component are unchanged — a broken edit never
-        # reaches the live deploy.
-        smoke=True,
-    )
+    if prebuilt_project_dir is not None:
+        # SL-3: the worker already built this site in a sandbox and materialised the
+        # artifact on disk. Skip the build and reuse everything below it verbatim —
+        # ``BuildResult`` carries only what the tail reads (``project_dir``), and the
+        # SSR smoke gate does not apply because this artifact came back from a build
+        # that already ran the engine's own gate inside the sandbox.
+        build = BuildResult(project_dir=prebuilt_project_dir, ripple_version=None)
+    else:
+        build = await _build_or_cloud_error(
+            gen,
+            ripple_spec=ripple_spec,
+            theme=theme,
+            site_id=site_id,
+            title=site_name,
+            capture_api_base=_capture_base(),
+            capture_signed_key=signed_key,
+            engine=engine,
+            source=source,
+            builder_origin=builder_origin,
+            keeps_client_bundle=keeps_client_bundle,
+            **_asset_kwargs,
+            # PERF-3: build into the STABLE per-pocket working dir so node_modules
+            # persists and `bun install` is cached across builds, cutting the dominant
+            # per-edit cost.
+            pocket_id=pocket_id,
+            # A live deploy keeps the SSR fail-gate (smoke=True) so the gate + the
+            # rollback in edit_svelte_component are unchanged — a broken edit never
+            # reaches the live deploy.
+            smoke=True,
+        )
 
     # Grow the concierge onto the built pages BEFORE they deploy, so the artifact
     # that goes live already carries the bar. This is a LIVE-publish-only step: a
@@ -2875,6 +2911,200 @@ async def _provision_dynamic_site(
     )
     doc._provision_job_id = result.get("job_id")
     return doc
+
+
+# ---------------------------------------------------------------------------
+# SL-3 — the async static publish.
+# ---------------------------------------------------------------------------
+
+
+def build_runs_async(engine: str | None) -> bool:
+    """Does publishing this engine ENQUEUE its build instead of running it inline?
+
+    True for exactly the engines whose ephemeral-lane artifact can actually be
+    DEPLOYED, which today is react alone. This is a narrow answer to a broad-sounding
+    question, and the narrowness is the whole content of the predicate:
+
+    * ``html`` runs no build at all (``needs_node_build`` is False), so there is
+      nothing to enqueue. Flipping it would add a queue wait to the one engine that
+      never needed one.
+    * ``ripple`` and DYNAMIC ``svelte`` build on adapter-cloudflare, whose output's
+      pages are rendered by a ``_worker.js`` whose imports sit OUTSIDE the tarred
+      directory. The artifact therefore cannot serve — which is not a guess: it is why
+      ``truth_lane`` refuses to even PREVIEW one (``REASON_WORKER_RENDERED``). Queueing
+      those builds would replace a working publish with one nothing can deploy.
+    * STATIC ``svelte`` (adapter-static) IS self-sufficient, and is still excluded,
+      because which adapter ran is a property of the built SITE and is not knowable at
+      enqueue time — only after the build. A gate has to decide before it spends the
+      queue, so svelte stays inline until the artifact question is settled for the
+      whole track.
+    * ``react`` emits a prerendered, assets-only ``dist`` with no server entry, so the
+      tar is the whole deployable site.
+
+    Widen this ONLY together with the artifact: the moment an adapter-cloudflare
+    artifact can serve, ripple and svelte belong here too, and this predicate is the
+    one place that changes.
+    """
+    return normalize_engine(engine) == "react"
+
+
+async def _enqueue_static_build(
+    *,
+    workspace_id: str,
+    user_id: str,
+    pocket_id: str,
+    site_id: str,
+    signed_key: str,
+    site_name: str,
+    ripple_spec: dict[str, Any] | None,
+    theme: dict[str, Any],
+    engine: str,
+    source: dict[str, str] | None,
+    assets: dict[str, str] | None,
+    pattern: str | None,
+    builder_origin: str | None,
+    keeps_client_bundle: bool,
+) -> _SiteDoc:
+    """Enqueue a static site's build and return immediately (SL-3).
+
+    The async half of ``_deploy_site_doc``. It ensures the ONE canonical Site doc for
+    ``(workspace, pocket_id)`` exists, stamps the build lifecycle onto it, and hands the
+    build to the ephemeral lane. The worker calls back into
+    :func:`deploy_prebuilt_site` when the artifact is ready, so the deploy, the upsert
+    and the post-deploy scheduling all still happen exactly once, in one place.
+
+    A RE-PUBLISH DOES NOT TAKE THE LIVE SITE DOWN, and that is the important difference
+    from ``_provision_dynamic_site``, which sets ``deployed=False`` / ``url=""`` while
+    its job runs. Here the previous deploy is still serving the moment a rebuild is
+    queued, so clearing those fields would report a working site as not-live for the
+    length of a build. ``build_status`` carries the in-flight state instead — the wire
+    contract the frontend already codes to ("a site can be live and simultaneously
+    mid-rebuild").
+
+    Returns the doc carrying ``build_status`` / ``build_started_at`` / ``build_job_id``,
+    which ``_to_response`` surfaces so the client has something to poll. On a
+    single-flight no-op (a build is genuinely already in flight) the doc comes back
+    unchanged, still carrying the in-flight build's own job id — the caller is watching
+    the right build, just not a new one.
+    """
+    # Lazy import: keeps the sites service free of an eager arq/Redis dependency at
+    # module load, and breaks the cycle (``build_job`` imports this module).
+    from pocketpaw_ee.sites import build_job
+    from pocketpaw_ee.sites.generator_client import build_generator_input
+
+    oid = ObjectId(site_id)
+    doc = await _SiteDoc.find_one({"_id": oid, "workspace": workspace_id})
+    if doc is None:
+        doc = _SiteDoc(
+            id=oid,
+            workspace=workspace_id,
+            pocket_id=pocket_id,
+            owner=user_id,
+            name=site_name,
+            script_name=site_id,
+            # A first publish has nothing serving yet, so this is honest rather than
+            # pessimistic: the worker flips both when the deploy succeeds.
+            deployed=False,
+            url="",
+            signed_key=signed_key,
+            builder_origin=builder_origin or "",
+            allowed_origins=_default_allowed_origins(),
+            event_mapping=_DEFAULT_EVENT_MAPPING,
+        )
+        await doc.insert()
+    else:
+        # Refresh only the identity fields a re-publish legitimately changes. NOT
+        # ``deployed`` / ``url`` (the prior deploy is still live), NOT
+        # ``allowed_origins`` / ``domains`` / ``signed_key`` (a connected domain and the
+        # capture key must survive a rebuild).
+        doc.pocket_id = pocket_id
+        doc.owner = user_id
+        doc.name = site_name
+        doc.script_name = site_id
+        await doc.save()
+
+    generator_input = build_generator_input(
+        engine=engine,
+        theme=theme,
+        site_id=site_id,
+        title=site_name,
+        capture_api_base=_capture_base(),
+        capture_signed_key=signed_key,
+        ripple_spec=ripple_spec,
+        source=source,
+        assets=assets,
+        builder_origin=builder_origin,
+        keeps_client_bundle=keeps_client_bundle,
+    )
+    # The inputs the worker hands back to ``deploy_prebuilt_site`` so the deploy tail
+    # runs with exactly what this publish captured, not with whatever the pocket's
+    # draft has become by the time the build finishes.
+    deploy_inputs = {
+        "workspace_id": workspace_id,
+        "user_id": user_id,
+        "pocket_id": pocket_id,
+        "site_id": site_id,
+        "signed_key": signed_key,
+        "site_name": site_name,
+        "engine": engine,
+        "pattern": pattern,
+        "builder_origin": builder_origin,
+    }
+
+    # An enqueue failure PROPAGATES. The helper rolls the row to a terminal status
+    # first, so the site stays republishable, and the raise becomes the 5xx the user
+    # sees. Returning success for a build that was never queued is the one outcome
+    # worse than a failed publish: the row would read in-progress forever and the UI
+    # would poll a job that does not exist.
+    job_id = await build_job.enqueue_site_build(
+        doc,
+        engine=engine,
+        generator_input=generator_input,
+        deploy_inputs=deploy_inputs,
+    )
+    logger.info(
+        "sites: queued the build for site %s (pocket %s, engine %s) as job %s",
+        site_id,
+        pocket_id,
+        engine,
+        job_id,
+    )
+    # Re-read so the response carries what the enqueue just wrote (the helper stamps
+    # through a targeted ``set``, so the in-memory doc this function holds is stale).
+    fresh = await _SiteDoc.find_one({"_id": oid, "workspace": workspace_id})
+    return fresh if fresh is not None else doc
+
+
+async def deploy_prebuilt_site(
+    *,
+    project_dir: str,
+    deploy_inputs: dict[str, Any],
+    _local_deploy: Callable[[str, str], str] | None = None,
+    _workers_deploy: Callable[..., Any] | None = None,
+) -> _SiteDoc:
+    """Finish a publish whose build already happened elsewhere (SL-3).
+
+    The seam the build worker calls once it has materialised the artifact. It runs
+    ``_deploy_site_doc``'s tail — concierge embed → deploy → canonical upsert →
+    knowledge sync + screenshot — against the prebuilt tree, so there is exactly ONE
+    implementation of "what happens after a site is built" and the async path cannot
+    drift from the inline one.
+
+    ``deploy_inputs`` is the dict ``_enqueue_static_build`` put in the job payload, so
+    the deploy uses what the PUBLISH captured. The worker passes no injection seams, so
+    ``PAW_CF_DEPLOY_MODE`` selects the target exactly as it does inline (local mode still
+    serves from ``local_server.deploy_local``); the two underscore-prefixed parameters
+    exist only so a test can drive this seam without a real deploy target, mirroring
+    ``publish``'s own ``_local_deploy`` / ``_workers_deploy``.
+    """
+    return await _deploy_site_doc(
+        ripple_spec=None,
+        theme={},
+        prebuilt_project_dir=project_dir,
+        local_deploy=_local_deploy,
+        workers_deploy=_workers_deploy,
+        **deploy_inputs,
+    )
 
 
 async def _load(workspace_id: str, site_id: str) -> _SiteDoc:

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,31 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-08-10 (SL-3 — the build lane reaches the wire): ``_to_response`` and
+# ``pocket_status`` now populate ``build_status`` / ``build_reason`` / ``build_job_id``
+# from the Site row. They were declared on the DTOs by SG-9i and never passed here, so
+# every response carried the defaults — ``build_status`` frozen at "none" regardless of
+# the row — and the shipped build-status UI was polling a field that could not change.
+# Read via ``getattr`` defaults like every other field, so a pre-SG-9i row reads as "no
+# build" instead of raising, and a pocket with no Site doc reads "none" rather than null
+# (a draft that was never published has no build, which is not the same as a failed one).
+#
+# ``build_status`` is passed through VERBATIM, never normalised against a known set: the
+# wire's contract is that a client treats an unrecognised status as IN-PROGRESS, and
+# folding an unknown value into "none" here would break that from the server side.
+#
+# THE PUBLISH PATH IS UNCHANGED BY SL-3. ``_deploy_site_doc`` still builds and deploys
+# inline for a static site. Flipping it to enqueue-and-return is blocked on a
+# prerequisite that does not exist yet: the ephemeral lane's artifact is a tar of the
+# static output only, ``sites/build_job.py`` never persists it, and no deploy target
+# accepts one — ``local_server.deploy_local`` and ``workers_deploy.deploy_workers`` both
+# want a project DIR, and the wfp path wants a worker bundle read out of one. Worse, for
+# ripple and dynamic svelte the artifact cannot serve at all: its pages come from a
+# ``_worker.js`` whose imports sit OUTSIDE the tarred directory, which is precisely why
+# ``truth_lane`` refuses to even preview one (``REASON_WORKER_RENDERED``). Flipping today
+# would take those sites from "publishes and works" to "queues a build nothing can
+# deploy".
+#
 # Updated 2026-08-10 (SL-2 slice 2 — the ephemeral-build lane gets a job): added the
 # four seams the site-build arq job (``sites/build_job.py``) writes its lifecycle
 # through — ``load_build_site``, ``mark_build_queued``, ``mark_build_running``,
@@ -1618,6 +1643,23 @@ def _to_response(doc: _SiteDoc, pattern: str = "", engine: str = "") -> SiteResp
         # None until a capture lands (empty string on the doc, and every pre-SC-1
         # row via the getattr default, read as None on the wire).
         preview_image_url=getattr(doc, "preview_image_url", "") or None,
+        # SL-3: the build lane's state, straight off the persisted row. These three
+        # were declared on the DTO by SG-9i and never populated here, so every
+        # response carried the DEFAULTS — ``build_status`` frozen at "none" no matter
+        # what the row said. A client polling a build therefore watched a field that
+        # could not change, which is indistinguishable from a build that never starts.
+        #
+        # Read with ``getattr`` defaults like every field above, so a pre-SG-9i row
+        # reads as "no build" rather than raising.
+        #
+        # ``build_status`` is passed through VERBATIM — never normalised against a
+        # known set. The wire's contract is that a client treats an unrecognised status
+        # as in-progress, and mapping an unknown value to "none" here would break that
+        # from the server side: it would tell a client "nothing is building" about a
+        # build that is running under a status this deploy predates.
+        build_status=getattr(doc, "build_status", "none"),
+        build_reason=getattr(doc, "build_reason", None),
+        build_job_id=getattr(doc, "build_job_id", None),
     )
 
 
@@ -4968,6 +5010,17 @@ async def pocket_status(*, workspace_id: str, pocket_id: str) -> SiteStatusRespo
         preview_image_url=(getattr(doc, "preview_image_url", "") or None)
         if doc is not None
         else None,
+        # SL-3: the build lane's state on the read a builder polls BY POCKET. This is
+        # the only GET keyed on a pocket id, so a client watching a build it just
+        # triggered has nowhere else to look — without these it would have to fetch the
+        # whole gallery list to find one site's build state.
+        #
+        # A pocket with NO Site doc reads the "no build" defaults rather than null: a
+        # draft that has never been published has not got a failed build, it has got no
+        # build, and those must not look the same to a badge.
+        build_status=getattr(doc, "build_status", "none") if doc is not None else "none",
+        build_reason=getattr(doc, "build_reason", None) if doc is not None else None,
+        build_job_id=getattr(doc, "build_job_id", None) if doc is not None else None,
     )
 
 

--- a/tests/ee/sites/test_async_publish.py
+++ b/tests/ee/sites/test_async_publish.py
@@ -1,0 +1,621 @@
+# tests/ee/sites/test_async_publish.py — SL-3: the static publish path enqueues its build
+# instead of running it inline, and the worker finishes the publish.
+#
+# Created 2026-08-10 (SL-3).
+#
+# THE TWO FAILURES THIS SUITE EXISTS FOR, and they pull in opposite directions:
+#
+#   1. A SITE THAT STOPS PUBLISHING. The flip moves the build off the request, so every
+#      engine that is NOT flipped must still build and deploy inline, byte-for-byte. Most
+#      of this file is that regression guarantee, because the change is worthless if it
+#      quietly breaks ripple.
+#   2. A PUBLISH THAT REPORTS SUCCESS AND NEVER GOES LIVE. Async publishing means the
+#      request returns before the site is up, so every path out of the job has to leave the
+#      row saying something true — and `built` must never mean "built but not serving".
+#
+# WHY REACT AND ONLY REACT flips today: an adapter-cloudflare artifact (ripple, dynamic
+# svelte) has pages rendered by a `_worker.js` whose imports sit outside the tarred
+# directory, so the artifact cannot serve. That is the same fact `truth_lane` refuses to
+# preview on. react emits a prerendered assets-only `dist`, so its tar IS the whole site.
+#
+# Mutations in tests/mutations/sl3_publish_flip.json, run and caught.
+
+from __future__ import annotations
+
+import tempfile
+from typing import Any
+
+import pytest
+from pocketpaw_ee.cloud.models.site import Site
+from pocketpaw_ee.sites import build_job as bj
+from pocketpaw_ee.sites import build_state as bs
+from pocketpaw_ee.sites import engines as engines_mod
+from pocketpaw_ee.sites import service as sites_service
+
+from tests.ee.sites.faults import FaultyDaytonaClient, clean_artifact, tar_bytes
+
+REACT_SOURCE = {"src/App.tsx": "export default function App() { return <p>hi</p>; }"}
+
+
+class _FakeGenerator:
+    """Records whether the INLINE build ran. The whole flip is about that call."""
+
+    def __init__(self) -> None:
+        self.build_calls: list[dict[str, Any]] = []
+
+    async def build(self, **kw: Any) -> Any:
+        from pocketpaw_ee.sites.generator_client import BuildResult
+
+        self.build_calls.append(kw)
+        return BuildResult(project_dir="/tmp/site", ripple_version="0.2.0")
+
+
+class _FakePool:
+    def __init__(self, *, error: BaseException | None = None) -> None:
+        self.error = error
+        self.calls: list[dict[str, Any]] = []
+
+    async def enqueue_job(self, function: str, *args: Any, _job_id: str | None = None, **kw: Any):
+        self.calls.append({"function": function, "args": args, "job_id": _job_id, "kwargs": kw})
+        if self.error is not None:
+            raise self.error
+        return object()
+
+
+def _install_pool(monkeypatch: pytest.MonkeyPatch, pool: _FakePool) -> _FakePool:
+    """Give the REAL enqueue helper a pool, so the row stamping under test is the
+    production one rather than a stub of it."""
+
+    async def _get_pool() -> Any:
+        return pool
+
+    monkeypatch.setattr(bj, "_get_pool", _get_pool)
+    return pool
+
+
+async def _seed_pocket(*, workspace_id: str = "ws1", pattern: str | None = None) -> str:
+    from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
+
+    doc = _PocketDoc(workspace=workspace_id, name="P", owner="u1", type="site", pattern=pattern)
+    await doc.insert()
+    return str(doc.id)
+
+
+async def _publish(*, engine: str, pocket_id: str, gen: _FakeGenerator, **over: Any) -> Any:
+    kwargs: dict[str, Any] = {
+        "workspace_id": "ws1",
+        "user_id": "u1",
+        "pocket_id": pocket_id,
+        "theme": {},
+        "name": "x",
+        "engine": engine,
+        "_generator": gen,
+        "_local_deploy": lambda site_id, project_dir: f"http://127.0.0.1/{site_id}/",
+    }
+    if engine == "ripple":
+        kwargs["ripple_spec"] = {"type": "container"}
+    else:
+        kwargs["source"] = REACT_SOURCE
+    kwargs.update(over)
+    return await sites_service.publish(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Which engines flip
+# ---------------------------------------------------------------------------
+
+
+class TestOnlyTheDeployableEngineFlips:
+    def test_react_builds_asynchronously(self) -> None:
+        assert sites_service.build_runs_async("react") is True
+
+    @pytest.mark.parametrize("engine", ["ripple", "svelte", "html"])
+    def test_every_other_engine_stays_inline(self, engine: str) -> None:
+        """Not an arbitrary allowlist. html runs no build at all; ripple and dynamic
+        svelte produce an artifact that cannot serve; static svelte is self-sufficient but
+        indistinguishable from the dynamic shape until AFTER the build, and a gate has to
+        decide before it spends the queue."""
+        assert sites_service.build_runs_async(engine) is False
+
+    def test_an_unknown_engine_stays_inline(self) -> None:
+        """Unknown normalises to ripple everywhere in this codebase, and ripple is inline.
+        The fallback must not flip a site whose engine we failed to recognise."""
+        for value in (None, "", "nope"):
+            assert sites_service.build_runs_async(value) is False
+
+    def test_no_flipped_engine_needs_a_worker_to_serve_its_pages(self) -> None:
+        """The property behind the allowlist, checked against engines.py rather than
+        restated. An engine whose output is worker-rendered cannot be deployed from a tar
+        of its static dir, so it must not be in the async set."""
+        for engine in ("ripple", "svelte", "html", "react"):
+            if sites_service.build_runs_async(engine):
+                assert engines_mod.expects_server_worker(engine) is False, engine
+                assert engines_mod.needs_node_build(engine) is True, engine
+
+
+# ---------------------------------------------------------------------------
+# The engines that did NOT flip must be untouched
+# ---------------------------------------------------------------------------
+
+
+class TestTheInlinePathIsUnchanged:
+    """The regression guarantee. This is the half that matters most: a flip that breaks
+    ripple has cost more than it bought."""
+
+    async def test_a_ripple_publish_still_builds_inline(self, beanie_test_db) -> None:
+        pocket_id = await _seed_pocket()
+        gen = _FakeGenerator()
+        doc = await _publish(engine="ripple", pocket_id=pocket_id, gen=gen)
+        assert len(gen.build_calls) == 1
+        assert doc.deployed is True
+        assert doc.build_status == "none"
+
+    async def test_a_ripple_publish_does_not_enqueue(
+        self, beanie_test_db, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pool = _install_pool(monkeypatch, _FakePool())
+        pocket_id = await _seed_pocket()
+        await _publish(engine="ripple", pocket_id=pocket_id, gen=_FakeGenerator())
+        assert pool.calls == []
+
+    async def test_a_ripple_publish_still_reaches_the_local_deploy(self, beanie_test_db) -> None:
+        """Local mode is the path the smoke tests use; the flip must not disturb it."""
+        pocket_id = await _seed_pocket()
+        deployed: list[str] = []
+        await _publish(
+            engine="ripple",
+            pocket_id=pocket_id,
+            gen=_FakeGenerator(),
+            _local_deploy=lambda site_id, project_dir: (
+                deployed.append(site_id) or f"http://127.0.0.1/{site_id}/"
+            ),
+        )
+        assert len(deployed) == 1
+
+    async def test_a_dynamic_publish_still_goes_to_the_provision_job(
+        self, beanie_test_db, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The dynamic fork is checked BEFORE the async fork, so a dynamic site keeps its
+        own durable job and never enters the build lane."""
+        dispatched: list[dict[str, Any]] = []
+
+        async def _dispatch(**kw: Any) -> dict[str, Any]:
+            dispatched.append(kw)
+            return {"job_id": "job-1"}
+
+        from pocketpaw_ee.cloud.jobs import service as jobs_service
+
+        monkeypatch.setattr(jobs_service, "dispatch_job", _dispatch)
+        pool = _install_pool(monkeypatch, _FakePool())
+        pocket_id = await _seed_pocket(pattern="dynamic")
+        gen = _FakeGenerator()
+
+        await _publish(engine="ripple", pocket_id=pocket_id, gen=gen, pattern="dynamic")
+
+        assert len(dispatched) == 1
+        assert dispatched[0]["job_name"] == "provision_site"
+        assert pool.calls == []
+        assert gen.build_calls == []
+
+
+# ---------------------------------------------------------------------------
+# The flip
+# ---------------------------------------------------------------------------
+
+
+class TestAReactPublishEnqueues:
+    async def test_it_does_not_build_inline(
+        self, beanie_test_db, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _install_pool(monkeypatch, _FakePool())
+        pocket_id = await _seed_pocket()
+        gen = _FakeGenerator()
+        await _publish(engine="react", pocket_id=pocket_id, gen=gen)
+        assert gen.build_calls == [], "the request still ran a build"
+
+    async def test_the_response_carries_something_to_poll(
+        self, beanie_test_db, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without these the client has nothing to watch and the user sees a publish that
+        appears to do nothing — the regression the whole two-repo sequence exists to
+        prevent."""
+        _install_pool(monkeypatch, _FakePool())
+        pocket_id = await _seed_pocket()
+        doc = await _publish(engine="react", pocket_id=pocket_id, gen=_FakeGenerator())
+        assert doc.build_status == "queued"
+        assert doc.build_job_id
+        assert doc.build_started_at is not None
+        wire = sites_service._to_response(doc)
+        assert wire.build_status == "queued"
+        assert wire.build_job_id == doc.build_job_id
+
+    async def test_a_first_publish_is_honestly_not_deployed_yet(
+        self, beanie_test_db, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _install_pool(monkeypatch, _FakePool())
+        pocket_id = await _seed_pocket()
+        doc = await _publish(engine="react", pocket_id=pocket_id, gen=_FakeGenerator())
+        assert doc.deployed is False
+        assert doc.url == ""
+
+    async def test_a_rebuild_leaves_the_live_site_serving(
+        self, beanie_test_db, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The difference from the dynamic provision path, and it is deliberate: that one
+        clears ``deployed``/``url`` while its job runs. Here the PREVIOUS deploy is still
+        serving the moment a rebuild is queued, so clearing them would report a working
+        site as not-live for the length of a build. The frontend already codes to this —
+        "a site can be live and simultaneously mid-rebuild"."""
+        _install_pool(monkeypatch, _FakePool())
+        pocket_id = await _seed_pocket()
+        site_id = str(sites_service._live_object_id("ws1", pocket_id))
+        live = Site(
+            id=sites_service._live_object_id("ws1", pocket_id),
+            workspace="ws1",
+            pocket_id=pocket_id,
+            owner="u1",
+            name="x",
+            script_name=site_id,
+            deployed=True,
+            url="https://live.example",
+        )
+        await live.insert()
+
+        doc = await _publish(engine="react", pocket_id=pocket_id, gen=_FakeGenerator())
+
+        assert doc.deployed is True
+        assert doc.url == "https://live.example"
+        assert doc.build_status == "queued"
+
+    async def test_the_payload_carries_the_deploy_inputs(
+        self, beanie_test_db, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The worker deploys with what the PUBLISH captured, not with whatever the
+        pocket's draft has become by the time the build finishes."""
+        pool = _install_pool(monkeypatch, _FakePool())
+        pocket_id = await _seed_pocket()
+        await _publish(engine="react", pocket_id=pocket_id, gen=_FakeGenerator())
+        inputs = pool.calls[0]["kwargs"]["deploy_inputs"]
+        assert inputs["engine"] == "react"
+        assert inputs["pocket_id"] == pocket_id
+        assert inputs["workspace_id"] == "ws1"
+        assert inputs["site_id"] == pool.calls[0]["args"][1]
+
+    async def test_a_second_publish_does_not_open_a_second_sandbox(
+        self, beanie_test_db, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pool = _install_pool(monkeypatch, _FakePool())
+        pocket_id = await _seed_pocket()
+        await _publish(engine="react", pocket_id=pocket_id, gen=_FakeGenerator())
+        await _publish(engine="react", pocket_id=pocket_id, gen=_FakeGenerator())
+        assert len(pool.calls) == 1, "single-flight let a second build through"
+
+    async def test_a_failed_enqueue_surfaces_and_leaves_the_site_republishable(
+        self, beanie_test_db, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """THE JUDGEMENT CALL. Returning success for a build that was never queued is the
+        worst outcome: the row would read in-progress forever and the UI would poll a job
+        that does not exist. So the enqueue failure propagates — the caller turns it into
+        the 5xx the user sees — and the row lands terminal so the next publish can run."""
+        _install_pool(monkeypatch, _FakePool(error=RuntimeError("redis is down")))
+        pocket_id = await _seed_pocket()
+
+        with pytest.raises(RuntimeError, match="redis is down"):
+            await _publish(engine="react", pocket_id=pocket_id, gen=_FakeGenerator())
+
+        doc = await Site.find_one({"pocket_id": pocket_id, "workspace": "ws1"})
+        assert doc is not None
+        assert doc.build_status == "failed"
+        assert doc.build_reason == "enqueue_failed:pool_or_enqueue_raised"
+        assert bs.should_enqueue(doc, 600) is True
+        assert bs.is_in_flight(doc) is False
+
+
+# ---------------------------------------------------------------------------
+# The worker finishes the publish
+# ---------------------------------------------------------------------------
+
+
+class _FakeRunner:
+    def __init__(self, tree: dict[str, bytes] | None = None) -> None:
+        self.tree = tree or {"package.json": b"{}", "src/App.tsx": b"x"}
+
+    async def generate(self, input_json: dict[str, Any], out_dir: str) -> dict[str, Any]:
+        from pathlib import Path
+
+        project = Path(out_dir, "project")
+        for rel, contents in self.tree.items():
+            target = project / rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(contents)
+        return {"projectDir": str(project)}
+
+
+def _deploy_inputs(site_id: str) -> dict[str, Any]:
+    return {
+        "workspace_id": "ws1",
+        "user_id": "u1",
+        "pocket_id": "pk1",
+        "site_id": site_id,
+        "signed_key": "k",
+        "site_name": "x",
+        "engine": "react",
+        "pattern": None,
+        "builder_origin": None,
+    }
+
+
+class TestTheWorkerFinishesThePublish:
+    async def _site(self) -> Site:
+        doc = Site(workspace="ws1", pocket_id="pk1", owner="u1", name="x", build_status="queued")
+        await doc.insert()
+        return doc
+
+    async def test_a_clean_build_is_deployed_before_the_row_says_built(
+        self, beanie_test_db
+    ) -> None:
+        """Ordering, not decoration: ``built`` must never mean "built but not serving",
+        because a client reads that as done."""
+        site = await self._site()
+        seen: list[str] = []
+
+        async def _deploy(*, project_dir: str, deploy_inputs: dict[str, Any]) -> Any:
+            fresh = await Site.get(site.id)
+            seen.append(fresh.build_status if fresh else "?")
+            return fresh
+
+        await bj.run_site_build(
+            {},
+            "ws1",
+            str(site.id),
+            {"engine": "react", "siteConfig": {}},
+            "react",
+            600,
+            deploy_inputs=_deploy_inputs(str(site.id)),
+            _runner=_FakeRunner(),
+            _client=FaultyDaytonaClient(artifact=clean_artifact()),
+            _deployer=_deploy,
+        )
+
+        assert seen == ["building"], "the deploy ran after the row already said built"
+        fresh = await Site.get(site.id)
+        assert fresh is not None
+        assert fresh.build_status == "built"
+
+    async def test_the_deploy_receives_the_artifact_under_the_engines_output_dir(
+        self, beanie_test_db
+    ) -> None:
+        """The deploy targets resolve their source as ``<project_dir>/<static_output_rel>``
+        while the tar is rooted AT that directory's contents. Extracting flat would deploy
+        an empty directory and the site would go live blank."""
+        from pathlib import Path
+
+        site = await self._site()
+        captured: dict[str, Any] = {}
+
+        async def _deploy(*, project_dir: str, deploy_inputs: dict[str, Any]) -> Any:
+            captured["dir"] = project_dir
+            captured["index"] = Path(project_dir, "dist", "index.html").is_file()
+            captured["nested"] = Path(project_dir, "dist", "assets", "app.js").is_file()
+            return None
+
+        await bj.run_site_build(
+            {},
+            "ws1",
+            str(site.id),
+            {"engine": "react", "siteConfig": {}},
+            "react",
+            600,
+            deploy_inputs=_deploy_inputs(str(site.id)),
+            _runner=_FakeRunner(),
+            _client=FaultyDaytonaClient(artifact=clean_artifact()),
+            _deployer=_deploy,
+        )
+
+        assert captured["index"] is True
+        assert captured["nested"] is True
+
+    async def test_a_hostile_member_is_refused_rather_than_written(self, beanie_test_db) -> None:
+        """The artifact is customer content, so the deploy path unpacks through the SAME
+        hardened extractor the preview uses instead of a second one written here. A member
+        that escapes its root must not land on the deploy host."""
+        from pathlib import Path
+
+        site = await self._site()
+        escaped = Path("/tmp/paw-escape-canary.txt")
+        if escaped.exists():
+            escaped.unlink()
+        evil = tar_bytes(
+            {
+                "./index.html": b"<p>ok</p>",
+                "../../../../tmp/paw-escape-canary.txt": b"escaped",
+            }
+        )
+        captured: dict[str, Any] = {}
+
+        async def _deploy(*, project_dir: str, deploy_inputs: dict[str, Any]) -> Any:
+            captured["index"] = Path(project_dir, "dist", "index.html").is_file()
+            return None
+
+        await bj.run_site_build(
+            {},
+            "ws1",
+            str(site.id),
+            {"engine": "react", "siteConfig": {}},
+            "react",
+            600,
+            deploy_inputs=_deploy_inputs(str(site.id)),
+            _runner=_FakeRunner(),
+            _client=FaultyDaytonaClient(artifact=evil),
+            _deployer=_deploy,
+        )
+
+        assert escaped.exists() is False, "a tar member escaped the deploy root"
+        # Not vacuous: the innocent member still arrived.
+        assert captured["index"] is True
+
+    async def test_a_deploy_failure_after_a_clean_build_is_its_own_rung(
+        self, beanie_test_db
+    ) -> None:
+        """Nothing about the user's build was wrong, so ``build_failed`` would send them to
+        debug a site that compiles. It is still terminal, because the site did not go live
+        and the row must stay republishable."""
+        site = await self._site()
+
+        async def _deploy(*, project_dir: str, deploy_inputs: dict[str, Any]) -> Any:
+            raise RuntimeError("wrangler exploded")
+
+        with pytest.raises(RuntimeError, match="wrangler exploded"):
+            await bj.run_site_build(
+                {},
+                "ws1",
+                str(site.id),
+                {"engine": "react", "siteConfig": {}},
+                "react",
+                600,
+                deploy_inputs=_deploy_inputs(str(site.id)),
+                _runner=_FakeRunner(),
+                _client=FaultyDaytonaClient(artifact=clean_artifact()),
+                _deployer=_deploy,
+            )
+
+        fresh = await Site.get(site.id)
+        assert fresh is not None
+        assert fresh.build_status == "failed"
+        assert fresh.build_reason == "deploy_failed:deploy_raised"
+        assert bs.should_enqueue(fresh, 600) is True
+
+    async def test_a_failed_build_never_reaches_the_deploy(self, beanie_test_db) -> None:
+        site = await self._site()
+        deploys: list[str] = []
+
+        async def _deploy(*, project_dir: str, deploy_inputs: dict[str, Any]) -> Any:
+            deploys.append(project_dir)
+            return None
+
+        from tests.ee.sites.faults import ok_sentinel
+
+        await bj.run_site_build(
+            {},
+            "ws1",
+            str(site.id),
+            {"engine": "react", "siteConfig": {}},
+            "react",
+            600,
+            deploy_inputs=_deploy_inputs(str(site.id)),
+            _runner=_FakeRunner(),
+            _client=FaultyDaytonaClient(sentinel=ok_sentinel(build_exit=1)),
+            _deployer=_deploy,
+        )
+
+        assert deploys == []
+        fresh = await Site.get(site.id)
+        assert fresh is not None
+        assert fresh.build_status == "failed"
+
+    async def test_a_build_with_no_deploy_inputs_still_records_its_verdict(
+        self, beanie_test_db
+    ) -> None:
+        """The slice-2 shape, still reachable: a build queued to VERIFY an artifact
+        deploys nothing and is not a broken publish."""
+        site = await self._site()
+        deploys: list[str] = []
+
+        async def _deploy(*, project_dir: str, deploy_inputs: dict[str, Any]) -> Any:
+            deploys.append(project_dir)
+            return None
+
+        await bj.run_site_build(
+            {},
+            "ws1",
+            str(site.id),
+            {"engine": "react", "siteConfig": {}},
+            "react",
+            600,
+            _runner=_FakeRunner(),
+            _client=FaultyDaytonaClient(artifact=clean_artifact()),
+            _deployer=_deploy,
+        )
+
+        assert deploys == []
+        fresh = await Site.get(site.id)
+        assert fresh is not None
+        assert fresh.build_status == "built"
+
+
+class TestTheDeploySeamRunsTheInlineTail:
+    """``deploy_prebuilt_site`` is where the two paths converge, and nothing above tests it
+    (the worker tests inject a fake deployer to isolate the job). This drives the real seam,
+    which is what proves the async path deploys through the SAME code the inline path does
+    rather than a second implementation that can drift.
+    """
+
+    async def test_it_deploys_the_prebuilt_tree_without_rebuilding(self, beanie_test_db) -> None:
+        from pathlib import Path
+
+        pocket_id = await _seed_pocket()
+        site_id = str(sites_service._live_object_id("ws1", pocket_id))
+        project = Path(tempfile.mkdtemp(prefix="paw-seam-"))
+        (project / "dist").mkdir()
+        (project / "dist" / "index.html").write_text("<p>hi</p>", encoding="utf-8")
+
+        deployed: list[tuple[str, str]] = []
+
+        def _local_deploy(sid: str, project_dir: str) -> str:
+            deployed.append((sid, project_dir))
+            return f"http://127.0.0.1/{sid}/"
+
+        # The real generator would need bun on PATH; if the seam rebuilt, this would raise
+        # rather than silently pass, which is the point of NOT injecting a fake generator.
+        doc = await sites_service.deploy_prebuilt_site(
+            project_dir=str(project),
+            deploy_inputs={
+                "workspace_id": "ws1",
+                "user_id": "u1",
+                "pocket_id": pocket_id,
+                "site_id": site_id,
+                "signed_key": "k",
+                "site_name": "x",
+                "engine": "react",
+                "pattern": None,
+                "builder_origin": None,
+            },
+            _local_deploy=_local_deploy,
+        )
+
+        assert len(deployed) == 1, "the prebuilt tree never reached a deploy target"
+        assert deployed[0][1] == str(project)
+        assert doc.deployed is True
+        assert doc.url.endswith(f"/{site_id}/")
+
+    async def test_the_seam_does_not_re_enter_the_async_fork(self, beanie_test_db) -> None:
+        """The worker calls back in with a prebuilt dir for an engine whose publishes are
+        async. Without the ``prebuilt_project_dir is None`` guard on the fork, that callback
+        would enqueue ANOTHER build — a publish that queues itself forever."""
+        from pathlib import Path
+
+        pocket_id = await _seed_pocket()
+        site_id = str(sites_service._live_object_id("ws1", pocket_id))
+        project = Path(tempfile.mkdtemp(prefix="paw-seam2-"))
+        (project / "dist").mkdir()
+        (project / "dist" / "index.html").write_text("<p>hi</p>", encoding="utf-8")
+
+        doc = await sites_service.deploy_prebuilt_site(
+            project_dir=str(project),
+            deploy_inputs={
+                "workspace_id": "ws1",
+                "user_id": "u1",
+                "pocket_id": pocket_id,
+                "site_id": site_id,
+                "signed_key": "k",
+                "site_name": "x",
+                "engine": "react",
+                "pattern": None,
+                "builder_origin": None,
+            },
+            _local_deploy=lambda sid, d: f"http://127.0.0.1/{sid}/",
+        )
+
+        # A re-enqueue would have left the row queued instead of deployed.
+        assert doc.build_status != "queued"
+        assert doc.deployed is True

--- a/tests/ee/sites/test_build_status_on_the_wire.py
+++ b/tests/ee/sites/test_build_status_on_the_wire.py
@@ -1,0 +1,190 @@
+# tests/ee/sites/test_build_status_on_the_wire.py — the build lane's state as a CLIENT
+# sees it: ``SiteResponse`` (publish + the gallery list) and ``SiteStatusResponse`` (the
+# by-pocket status read).
+#
+# Created 2026-08-10 (SL-3).
+#
+# WHY THIS FILE EXISTS. SG-9i declared ``build_status`` and ``build_job_id`` on
+# ``SiteResponse``, and nothing ever populated them: ``_to_response`` builds the DTO field
+# by field, so every response carried the DEFAULTS — ``build_status`` frozen at "none" for
+# every site no matter what the row said — and ``build_reason`` was not a field at all.
+# Both halves reviewed clean alone. The DTO looked complete because the fields were there;
+# the service looked complete because it passed every field it knew about.
+#
+# The shipped build-status UI reads all three, so the effect was a client polling a value
+# that CANNOT CHANGE. That is indistinguishable, from the outside, from a build that never
+# starts — which is the one regression this whole sequence exists to prevent.
+#
+# THE PROPERTY THESE PIN is deliberately not "the field exists". A field can exist and be
+# hard-coded. Each test drives a DIFFERENT value onto the row and asserts the wire carries
+# THAT value, because the failure mode being guarded is a constant, not an absence.
+#
+# Mutations in tests/mutations/sl3_build_status_wire.json, run and caught.
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pocketpaw_ee.cloud.models.site import Site
+from pocketpaw_ee.sites import service as sites_service
+from pocketpaw_ee.sites.dto import SiteResponse, SiteStatusResponse
+
+#: A settled failure as ``build_job`` writes it: the rung, then the cause, both from
+#: closed sets. The shape a client splits on to decide whether to blame the user's code.
+FAILED_REASON = "build_failed:install_failed"
+
+#: An infrastructure loss, which settles to the SAME status as the failure above. The pair
+#: is what proves the status alone cannot carry the distinction.
+INFRA_REASON = "infra_lost:no_sentinel_before_timeout"
+
+
+def _doc(**overrides: Any) -> Site:
+    base: dict[str, Any] = {"workspace": "ws1", "pocket_id": "pk1", "owner": "u1", "name": "S"}
+    base.update(overrides)
+    return Site(**base)
+
+
+class TestTheBuildStateReachesSiteResponse:
+    """``POST /sites/publish`` and ``GET /sites`` both answer with this DTO."""
+
+    def test_a_queued_build_is_visible_with_its_polling_handle(self) -> None:
+        got = sites_service._to_response(
+            _doc(build_status="queued", build_job_id="site-build-abc123")
+        )
+        assert got.build_status == "queued"
+        assert got.build_job_id == "site-build-abc123"
+
+    def test_a_building_row_is_visible(self) -> None:
+        assert sites_service._to_response(_doc(build_status="building")).build_status == "building"
+
+    def test_a_finished_build_is_visible(self) -> None:
+        assert sites_service._to_response(_doc(build_status="built")).build_status == "built"
+
+    def test_a_failure_carries_the_rung_that_explains_it(self) -> None:
+        """The reason is the whole point of the field. ``failed`` with nothing else is
+        unactionable: it cannot say whether the user's code broke or we lost the
+        container, and those need opposite responses."""
+        got = sites_service._to_response(_doc(build_status="failed", build_reason=FAILED_REASON))
+        assert got.build_status == "failed"
+        assert got.build_reason == FAILED_REASON
+
+    def test_the_two_kinds_of_failure_are_distinguishable_on_the_wire(self) -> None:
+        """Both settle as ``failed``, so the STATUS is identical and only the rung
+        separates them. If the reason did not reach the client, a user would be told their
+        site is broken when we lost the sandbox."""
+        theirs = sites_service._to_response(_doc(build_status="failed", build_reason=FAILED_REASON))
+        ours = sites_service._to_response(_doc(build_status="failed", build_reason=INFRA_REASON))
+        assert theirs.build_status == ours.build_status == "failed"
+        assert theirs.build_reason != ours.build_reason
+        assert theirs.build_reason.split(":")[0] == "build_failed"
+        assert ours.build_reason.split(":")[0] == "infra_lost"
+
+    def test_a_site_that_never_built_reads_as_no_build(self) -> None:
+        got = sites_service._to_response(_doc())
+        assert got.build_status == "none"
+        assert got.build_reason is None
+        assert got.build_job_id is None
+
+    def test_an_unrecognised_status_is_passed_through_verbatim(self) -> None:
+        """The wire's contract is that a CLIENT treats an unknown status as in-progress,
+        and that only works if the server does not flatten it first. Normalising here
+        would report "nothing is building" about a build running under a status this
+        deploy predates — the rolling-deploy hazard ``build_state``'s header describes,
+        seen from the read side."""
+        got = sites_service._to_response(_doc(build_status="uploading"))
+        assert got.build_status == "uploading"
+
+    def test_a_row_predating_the_fields_does_not_break_the_read(self) -> None:
+        """Every other field here is read with a ``getattr`` default for this reason: the
+        gallery is a hot read and a pre-SG-9i row must not turn it into a 500."""
+
+        class _Ancient:
+            id = "64b7f9c2e4b0a1d2c3e4f5a6"
+            pocket_id = "pk1"
+            name = "old"
+            script_name = "s"
+            deployed = True
+            signed_key = "k"
+            url = "https://example.test"
+
+        got = sites_service._to_response(_Ancient())  # type: ignore[arg-type]
+        assert got.build_status == "none"
+        assert got.build_reason is None
+        assert got.build_job_id is None
+
+
+class TestTheDtoDeclaresTheContract:
+    def test_site_response_carries_all_three_fields(self) -> None:
+        for field in ("build_status", "build_reason", "build_job_id"):
+            assert field in SiteResponse.model_fields, field
+
+    def test_site_status_response_carries_all_three_too(self) -> None:
+        """The by-pocket read is the only GET keyed on a pocket id, so a builder watching
+        a build it just triggered has nowhere else to poll."""
+        for field in ("build_status", "build_reason", "build_job_id"):
+            assert field in SiteStatusResponse.model_fields, field
+
+    @pytest.mark.parametrize("model", [SiteResponse, SiteStatusResponse])
+    def test_the_defaults_mean_no_build_rather_than_an_error(self, model: Any) -> None:
+        assert model.model_fields["build_status"].default == "none"
+        assert model.model_fields["build_reason"].default is None
+        assert model.model_fields["build_job_id"].default is None
+
+    def test_the_reason_survives_serialisation(self) -> None:
+        """A field that exists on the model and is dropped by the dump is not on the
+        wire. This is the boundary a client actually reads."""
+        dumped = sites_service._to_response(
+            _doc(build_status="failed", build_reason=FAILED_REASON)
+        ).model_dump()
+        assert dumped["build_status"] == "failed"
+        assert dumped["build_reason"] == FAILED_REASON
+
+
+class TestTheBuildStateReachesTheByPocketStatus:
+    """``GET /sites/by-pocket/{pocket_id}/status`` — what a build badge polls."""
+
+    async def _status(self, monkeypatch: pytest.MonkeyPatch, doc: Site | None) -> Any:
+        async def _canonical(_ws: str, _pk: str) -> Any:
+            return doc
+
+        async def _patterns(_ws: str, _ids: list[str]) -> dict[str, str]:
+            return {}
+
+        async def _engines(_ws: str, _ids: list[str]) -> dict[str, str]:
+            return {}
+
+        from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+        monkeypatch.setattr(sites_service, "_canonical_site_doc", _canonical)
+        monkeypatch.setattr(pockets_service, "patterns_for_pockets", _patterns)
+        monkeypatch.setattr(pockets_service, "engines_for_pockets", _engines)
+        return await sites_service.pocket_status(workspace_id="ws1", pocket_id="pk1")
+
+    async def test_a_build_in_flight_is_visible_by_pocket(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        got = await self._status(
+            monkeypatch, _doc(build_status="building", build_job_id="site-build-xyz")
+        )
+        assert got.build_status == "building"
+        assert got.build_job_id == "site-build-xyz"
+
+    async def test_a_failure_and_its_rung_are_visible_by_pocket(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        got = await self._status(
+            monkeypatch, _doc(build_status="failed", build_reason=INFRA_REASON)
+        )
+        assert got.build_status == "failed"
+        assert got.build_reason == INFRA_REASON
+
+    async def test_a_pocket_with_no_site_reads_as_no_build_not_as_null(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A draft that was never published has NO build. That must not look the same as a
+        build that failed, and it must not look like an error either."""
+        got = await self._status(monkeypatch, None)
+        assert got.build_status == "none"
+        assert got.build_reason is None
+        assert got.build_job_id is None

--- a/tests/ee/sites/test_fault_ladder_build.py
+++ b/tests/ee/sites/test_fault_ladder_build.py
@@ -837,6 +837,137 @@ class TestF2AndF7TheRecordedRowNamesItsRung:
 
 
 # ---------------------------------------------------------------------------
+# F1 + F3 at the PUBLISH boundary — what the third pin demanded when it fired
+# ---------------------------------------------------------------------------
+
+
+class TestF1AndF3AtThePublishBoundary:
+    """The publish half of F1 and F3, provable now that publish reaches the lane (SL-3).
+
+    F1 above proves ``run_build`` refuses loudly when Daytona is unconfigured. The pin that
+    fired asked for the PUBLISH half of that rung, and answering it honestly means saying
+    that the flip CHANGED it: Daytona is no longer touched inside the request, so an
+    unconfigured sandbox can no longer fail a publish. The failure moves to the row, which
+    is the whole point of ``build_reason`` — and the property that still has to hold is that
+    it lands there rather than nowhere, and that the site stays republishable.
+    """
+
+    async def test_an_unconfigured_daytona_no_longer_fails_the_publish_itself(
+        self, beanie_test_db, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The publish is ACCEPTED and the sandbox failure surfaces later on the row.
+
+        This is a deliberate behaviour change, not a regression: a queue exists precisely so
+        the request does not depend on the build host being up. What must not happen is a
+        publish that reports success and leaves nothing to look at — hence the queued status
+        and the job id on the way out.
+        """
+        from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
+        from pocketpaw_ee.sites import build_job, service
+
+        daytona_unconfigured(monkeypatch)
+
+        pool_calls: list[tuple] = []
+
+        class _Pool:
+            async def enqueue_job(self, function, *args, _job_id=None, **kw):
+                pool_calls.append((function, _job_id))
+                return object()
+
+        async def _get_pool():
+            return _Pool()
+
+        monkeypatch.setattr(build_job, "_get_pool", _get_pool)
+
+        pocket = _PocketDoc(workspace="ws-f1", name="P", owner="u1", type="site")
+        await pocket.insert()
+
+        doc = await service.publish(
+            workspace_id="ws-f1",
+            user_id="u1",
+            pocket_id=str(pocket.id),
+            theme={},
+            name="x",
+            engine="react",
+            source={"src/App.tsx": "x"},
+        )
+
+        assert doc.build_status == "queued"
+        assert doc.build_job_id
+        assert pool_calls, "the publish did not reach the queue"
+
+    async def test_the_worker_records_the_unavailable_sandbox_on_the_row(
+        self, beanie_test_db, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """F1's rung, at the place a user can now see it. ``sandbox_unavailable`` must not
+        read as the user's build being broken, and the row must not be left mid-flight."""
+        from pocketpaw_ee.cloud.models.site import Site
+        from pocketpaw_ee.sites import build_job
+
+        daytona_unconfigured(monkeypatch)
+
+        site = Site(workspace="ws-f1b", pocket_id="pk", owner="u1", build_status="queued")
+        await site.insert()
+
+        class _Runner:
+            async def generate(self, input_json, out_dir):
+                from pathlib import Path as _P
+
+                project = _P(out_dir, "project")
+                project.mkdir(parents=True, exist_ok=True)
+                (project / "package.json").write_bytes(b"{}")
+                return {"projectDir": str(project)}
+
+        with pytest.raises(RuntimeError, match="not configured"):
+            await build_job.run_site_build(
+                {}, "ws-f1b", str(site.id), {"engine": "react"}, "react", 600, _runner=_Runner()
+            )
+
+        fresh = await Site.get(site.id)
+        assert fresh is not None
+        assert fresh.build_reason == "sandbox_unavailable:run_build_raised"
+        assert bs.should_enqueue(fresh, 600) is True
+
+    async def test_a_publish_whose_enqueue_fails_returns_an_error_the_user_can_see(
+        self, beanie_test_db, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The other half the pin named. A publish that swallowed a failed enqueue would
+        leave the row reading in-progress forever with nothing coming to consume it — F3's
+        harm, arriving through the front door instead of the worker."""
+        from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
+        from pocketpaw_ee.cloud.models.site import Site
+        from pocketpaw_ee.sites import build_job, service
+
+        class _DeadPool:
+            async def enqueue_job(self, *_a, **_kw):
+                raise RuntimeError("redis is down")
+
+        async def _get_pool():
+            return _DeadPool()
+
+        monkeypatch.setattr(build_job, "_get_pool", _get_pool)
+
+        pocket = _PocketDoc(workspace="ws-f3p", name="P", owner="u1", type="site")
+        await pocket.insert()
+
+        with pytest.raises(RuntimeError, match="redis is down"):
+            await service.publish(
+                workspace_id="ws-f3p",
+                user_id="u1",
+                pocket_id=str(pocket.id),
+                theme={},
+                name="x",
+                engine="react",
+                source={"src/App.tsx": "x"},
+            )
+
+        doc = await Site.find_one({"pocket_id": str(pocket.id), "workspace": "ws-f3p"})
+        assert doc is not None
+        assert bs.should_enqueue(doc, 600) is True
+        assert bs.is_in_flight(doc) is False
+
+
+# ---------------------------------------------------------------------------
 # The gap — pinned so it cannot close silently
 # ---------------------------------------------------------------------------
 
@@ -849,43 +980,23 @@ class TestTheWiringGapIsRealAndTemporary:
     becomes injectable and must be proven for real. Deleting a failing test here instead of
     proving its rung is the one wrong response.
 
-    UPDATED 2026-08-10 (SL-2 slice 2). Two of these fired and were replaced by the proofs
-    they demanded, not removed: the lifecycle fields ARE written now and there IS an
-    enqueue, so see ``TestF2AndF7TheRecordedRowNamesItsRung`` and
-    ``TestF3AnUnconsumableBuildRow``'s last test. The two below are still true statements
-    about this branch and stay armed.
+    UPDATED 2026-08-10, twice. SL-2 slice 2 fired two of these — the lifecycle fields ARE
+    written and there IS an enqueue — and they became
+    ``TestF2AndF7TheRecordedRowNamesItsRung`` and ``TestF3AnUnconsumableBuildRow``'s last
+    test. SL-3 fired the third: publish now reaches the lane, and its proofs are in
+    ``TestF1AndF3AtThePublishBoundary``.
+
+    ONE PIN IS LEFT, and it is still a true statement about this branch: nothing retries.
+    Every enqueue passes ``attempts_left=0``, so ``settle``'s stay-in-flight branch is
+    reachable only by a forced test. When a retry loop lands, this fires and F2's
+    backoff half becomes provable.
     """
 
-    def test_publish_does_not_consult_the_daytona_lane_yet(self) -> None:
-        """When this fails: F1's publish half is now provable — a publish with Daytona
-        unconfigured must report unavailable and leave the site's row untouched.
-
-        FOUR markers now, not one. SL-2 slice 2 built the job and the enqueue helper and
-        deliberately did NOT call either from publish, so "does publish reach the lane" can
-        no longer be answered by looking for the runner alone: a publish that flips to
-        async will call ``enqueue_site_build`` and may never name ``daytona_runner`` at all.
-        The two import forms are matched as well, because a wiring could route through a
-        local alias and name neither.
-
-        Deliberately matched on IMPORT FORMS rather than on the bare module name: this
-        module's own header refers to ``sites/build_job.py`` in prose (it documents which
-        module writes through its seams), and a marker that a comment can trip is a marker
-        that gets deleted rather than investigated.
-        """
-        from pocketpaw_ee.sites import service
-
-        source = Path(service.__file__).read_text(encoding="utf-8")
-        for marker in (
-            "daytona_runner",
-            "enqueue_site_build",
-            "import build_job",
-            "build_job import",
-        ):
-            assert marker not in source, (
-                f"publish now reaches the build lane ({marker!r}) — prove F1's publish "
-                "half (unavailable + site unchanged) and that a publish whose enqueue "
-                "fails still returns an error the user can see"
-            )
+    # ``test_publish_does_not_consult_the_daytona_lane_yet`` FIRED on 2026-08-10 (SL-3) and
+    # was replaced by the two proofs its failure message demanded, in
+    # ``TestF1AndF3AtThePublishBoundary`` below. Publish now reaches the lane for the
+    # engines whose artifact can be deployed from it, so the statement the pin made is no
+    # longer true and re-asserting it would only pin the wiring shut.
 
     def test_the_lane_still_classifies_one_attempt_at_a_time(self) -> None:
         """When this fails: F2's retry-with-backoff becomes provable. ``FaultyDaytonaClient``

--- a/tests/mutations/sl3_build_status_wire.json
+++ b/tests/mutations/sl3_build_status_wire.json
@@ -1,0 +1,75 @@
+[
+  {
+    "label": "SL-3: the publish/gallery response stops carrying build_status, so it reverts to the DTO default and every client polls a value frozen at 'none' — indistinguishable from a build that never starts, which is the bug this slice fixed",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        build_status=getattr(doc, \"build_status\", \"none\"),",
+    "replace": "",
+    "tests": [
+      "tests/ee/sites/test_build_status_on_the_wire.py::TestTheBuildStateReachesSiteResponse"
+    ]
+  },
+  {
+    "label": "SL-3: the response stops carrying build_reason, so a terminal 'failed' reaches the user with no rung — they cannot tell whether their code broke or we lost the container, and those need opposite responses",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        build_reason=getattr(doc, \"build_reason\", None),",
+    "replace": "",
+    "tests": [
+      "tests/ee/sites/test_build_status_on_the_wire.py::TestTheBuildStateReachesSiteResponse::test_a_failure_carries_the_rung_that_explains_it",
+      "tests/ee/sites/test_build_status_on_the_wire.py::TestTheBuildStateReachesSiteResponse::test_the_two_kinds_of_failure_are_distinguishable_on_the_wire"
+    ]
+  },
+  {
+    "label": "SL-3: the response stops carrying build_job_id, so a client that reloads during a queued build loses its polling handle at the moment the wait is longest — the exact reason the field is persisted rather than transient",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        build_job_id=getattr(doc, \"build_job_id\", None),",
+    "replace": "",
+    "tests": [
+      "tests/ee/sites/test_build_status_on_the_wire.py::TestTheBuildStateReachesSiteResponse::test_a_queued_build_is_visible_with_its_polling_handle"
+    ]
+  },
+  {
+    "label": "SL-3: the server normalises an unrecognised build_status to 'none', breaking the wire contract that a client treats an unknown status as IN-PROGRESS — it would report 'nothing is building' about a live build running under a status this deploy predates",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        build_status=getattr(doc, \"build_status\", \"none\"),\n        build_reason=getattr(doc, \"build_reason\", None),",
+    "replace": "        build_status=getattr(doc, \"build_status\", \"none\")\n        if getattr(doc, \"build_status\", \"none\") in {\"none\", \"queued\", \"building\", \"built\", \"failed\"}\n        else \"none\",\n        build_reason=getattr(doc, \"build_reason\", None),",
+    "tests": [
+      "tests/ee/sites/test_build_status_on_the_wire.py::TestTheBuildStateReachesSiteResponse::test_an_unrecognised_status_is_passed_through_verbatim"
+    ]
+  },
+  {
+    "label": "SL-3: the by-pocket status read stops carrying build_status, so the one GET keyed on a pocket id cannot answer 'is this building' and a badge has to fetch the whole gallery to find out",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        build_status=getattr(doc, \"build_status\", \"none\") if doc is not None else \"none\",",
+    "replace": "",
+    "tests": [
+      "tests/ee/sites/test_build_status_on_the_wire.py::TestTheBuildStateReachesTheByPocketStatus"
+    ]
+  },
+  {
+    "label": "SL-3: the by-pocket read stops carrying build_reason, so a badge can show that a build failed and never why",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        build_reason=getattr(doc, \"build_reason\", None) if doc is not None else None,",
+    "replace": "",
+    "tests": [
+      "tests/ee/sites/test_build_status_on_the_wire.py::TestTheBuildStateReachesTheByPocketStatus::test_a_failure_and_its_rung_are_visible_by_pocket"
+    ]
+  },
+  {
+    "label": "SL-3: a pocket with no Site doc reports build_status None instead of 'none', so a draft that was never published is indistinguishable from a row whose status is missing — a badge then has to guess between 'no build' and 'broken read'",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        build_status=getattr(doc, \"build_status\", \"none\") if doc is not None else \"none\",\n        build_reason=getattr(doc, \"build_reason\", None) if doc is not None else None,",
+    "replace": "        build_status=getattr(doc, \"build_status\", \"none\") if doc is not None else None,\n        build_reason=getattr(doc, \"build_reason\", None) if doc is not None else None,",
+    "tests": [
+      "tests/ee/sites/test_build_status_on_the_wire.py::TestTheBuildStateReachesTheByPocketStatus::test_a_pocket_with_no_site_reads_as_no_build_not_as_null"
+    ]
+  },
+  {
+    "label": "SL-3: build_reason is dropped from SiteResponse, so the field a client reads to explain a failure does not exist on the wire at all",
+    "file": "ee/pocketpaw_ee/sites/dto.py",
+    "find": "    build_reason: str | None = None\n    # SI-4: the persisted import summary for an IMPORTED site — {pages: [{path,",
+    "replace": "    # SI-4: the persisted import summary for an IMPORTED site — {pages: [{path,",
+    "tests": [
+      "tests/ee/sites/test_build_status_on_the_wire.py::TestTheDtoDeclaresTheContract"
+    ]
+  }
+]

--- a/tests/mutations/sl3_publish_flip.json
+++ b/tests/mutations/sl3_publish_flip.json
@@ -1,0 +1,104 @@
+[
+  {
+    "label": "SL-3: every engine flips to async, so a ripple or dynamic-svelte publish queues a build whose artifact cannot serve (its pages come from a _worker.js whose imports sit outside the tar) — the site stops publishing",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    return normalize_engine(engine) == \"react\"",
+    "replace": "    return True",
+    "tests": [
+      "tests/ee/sites/test_async_publish.py::TestOnlyTheDeployableEngineFlips",
+      "tests/ee/sites/test_async_publish.py::TestTheInlinePathIsUnchanged"
+    ]
+  },
+  {
+    "label": "SL-3: no engine flips, so the whole slice is inert — publish still blocks on an inline build and the queued-build UI has nothing to show",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "def build_runs_async(engine: str | None) -> bool:",
+    "replace": "def build_runs_async(engine: str | None) -> bool:\n    return False",
+    "tests": [
+      "tests/ee/sites/test_async_publish.py::TestAReactPublishEnqueues",
+      "tests/ee/sites/test_async_publish.py::TestOnlyTheDeployableEngineFlips::test_react_builds_asynchronously"
+    ]
+  },
+  {
+    "label": "SL-3: the async fork stops excluding a worker callback, so the worker's deploy re-enters the fork and enqueues ANOTHER build — a publish that queues itself forever and never goes live",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if prebuilt_project_dir is None and build_runs_async(engine):",
+    "replace": "    if build_runs_async(engine):",
+    "tests": [
+      "tests/ee/sites/test_async_publish.py::TestTheDeploySeamRunsTheInlineTail"
+    ]
+  },
+  {
+    "label": "SL-3: the deploy seam drops the prebuilt dir, so the worker's callback REBUILDS the site inline in the worker instead of deploying the artifact it just paid a sandbox for",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        prebuilt_project_dir=project_dir,\n        local_deploy=_local_deploy,",
+    "replace": "        local_deploy=_local_deploy,",
+    "tests": [
+      "tests/ee/sites/test_async_publish.py::TestTheDeploySeamRunsTheInlineTail::test_it_deploys_the_prebuilt_tree_without_rebuilding"
+    ]
+  },
+  {
+    "label": "SL-3: a re-publish clears deployed/url while the rebuild runs, so a working site reports itself not-live for the length of a build — a rebuild made to look like an outage",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        doc.pocket_id = pocket_id\n        doc.owner = user_id\n        doc.name = site_name\n        doc.script_name = site_id\n        await doc.save()",
+    "replace": "        doc.pocket_id = pocket_id\n        doc.owner = user_id\n        doc.name = site_name\n        doc.script_name = site_id\n        doc.deployed = False\n        doc.url = \"\"\n        await doc.save()",
+    "tests": [
+      "tests/ee/sites/test_async_publish.py::TestAReactPublishEnqueues::test_a_rebuild_leaves_the_live_site_serving"
+    ]
+  },
+  {
+    "label": "SL-3: publish swallows a failed enqueue and returns success, so the row reads in-progress forever and the UI polls a job that was never queued — the worst outcome of the whole slice",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    job_id = await build_job.enqueue_site_build(\n        doc,\n        engine=engine,\n        generator_input=generator_input,\n        deploy_inputs=deploy_inputs,\n    )",
+    "replace": "    job_id = None\n    try:\n        job_id = await build_job.enqueue_site_build(\n            doc,\n            engine=engine,\n            generator_input=generator_input,\n            deploy_inputs=deploy_inputs,\n        )\n    except Exception:\n        pass",
+    "tests": [
+      "tests/ee/sites/test_async_publish.py::TestAReactPublishEnqueues::test_a_failed_enqueue_surfaces_and_leaves_the_site_republishable",
+      "tests/ee/sites/test_fault_ladder_build.py::TestF1AndF3AtThePublishBoundary::test_a_publish_whose_enqueue_fails_returns_an_error_the_user_can_see"
+    ]
+  },
+  {
+    "label": "SL-3: the deploy inputs are dropped from the job payload, so the worker builds and records a verdict and NEVER deploys — every react publish stops at 'built' and the site never goes live",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        generator_input=generator_input,\n        deploy_inputs=deploy_inputs,\n    )",
+    "replace": "        generator_input=generator_input,\n    )",
+    "tests": [
+      "tests/ee/sites/test_async_publish.py::TestAReactPublishEnqueues::test_the_payload_carries_the_deploy_inputs"
+    ]
+  },
+  {
+    "label": "SL-3: the row settles 'built' BEFORE the deploy runs, so a client sees a finished build while the site is not yet serving — and a deploy that then fails leaves 'built' standing on a site that never went live",
+    "file": "ee/pocketpaw_ee/sites/build_job.py",
+    "find": "    if settlement.status == \"built\" and deploy_inputs is not None:",
+    "replace": "    await _record(site, settlement)\n    if settlement.status == \"built\" and deploy_inputs is not None:",
+    "tests": [
+      "tests/ee/sites/test_async_publish.py::TestTheWorkerFinishesThePublish::test_a_clean_build_is_deployed_before_the_row_says_built"
+    ]
+  },
+  {
+    "label": "SL-3: a deploy failure after a clean build is swallowed, so the row settles 'built' for a site nothing deployed — publish reports success forever and nobody learns the deploy died",
+    "file": "ee/pocketpaw_ee/sites/build_job.py",
+    "find": "            await _record(\n                site,\n                _settlement(\n                    RUNG_DEPLOY_FAILED,\n                    \"deploy_raised\",\n                    retryable=True,\n                    attempts_left=attempts_left,\n                ),\n            )\n            raise",
+    "replace": "            pass",
+    "tests": [
+      "tests/ee/sites/test_async_publish.py::TestTheWorkerFinishesThePublish::test_a_deploy_failure_after_a_clean_build_is_its_own_rung"
+    ]
+  },
+  {
+    "label": "SL-3: the artifact is extracted FLAT instead of under the engine's static-output dir, so the deploy target resolves an empty directory and a blank site replaces a working one",
+    "file": "ee/pocketpaw_ee/sites/build_job.py",
+    "find": "            artifact, Path(project_dir, static_output_rel(engine))",
+    "replace": "            artifact, Path(project_dir)",
+    "tests": [
+      "tests/ee/sites/test_async_publish.py::TestTheWorkerFinishesThePublish::test_the_deploy_receives_the_artifact_under_the_engines_output_dir"
+    ]
+  },
+  {
+    "label": "SL-3: a failed build still reaches the deploy, so a site that did not compile is pushed to the edge on the strength of whatever bytes came back",
+    "file": "ee/pocketpaw_ee/sites/build_job.py",
+    "find": "    if settlement.status == \"built\" and deploy_inputs is not None:\n        try:",
+    "replace": "    if deploy_inputs is not None:\n        try:",
+    "tests": [
+      "tests/ee/sites/test_async_publish.py::TestTheWorkerFinishesThePublish::test_a_failed_build_never_reaches_the_deploy"
+    ]
+  }
+]


### PR DESCRIPTION
**Stacked on #1907** (`feat/sl3-async-publish`), which must merge first — this needs the build fields it put on the wire, or the queued state it creates has nothing to poll.

The static publish path now enqueues its build instead of running it inline. **For react only**, and that is the load-bearing decision in the PR.

## Why react only

I could not flip ripple or svelte without breaking publishing, and the evidence is code that is already on dev:

- **ripple and dynamic svelte** build on adapter-cloudflare, whose output's pages are rendered by a `_worker.js` whose two imports sit **outside** the tarred directory. The artifact cannot serve. That is the same fact `truth_lane` was built on — it refuses to even *preview* such an artifact (`REASON_WORKER_RENDERED`). Queueing those builds replaces a working publish with one nothing can deploy.
- **html** runs no build at all (`needs_node_build` is False), so there is nothing to enqueue. Flipping it would add a queue wait to the one engine that never needed one.
- **static svelte** *is* self-sufficient (adapter-static, no worker) and still stays inline, because which adapter ran is a property of the built **site**, not of the engine name — it is unknowable at enqueue time, and a gate has to decide before it spends the queue.
- **react** emits a prerendered, assets-only `dist` with no server entry, so its tar is the whole deployable site.

`service.build_runs_async` is the single place that widens the moment the artifact question is settled for the SvelteKit track. Until then this slice de-risks the entire async path in production on the one engine where it is safe.

## The worker finishes the publish

A queued build that ends at `build_status="built"` with the site still not live would be a publish that silently does nothing, so the job now completes the publish: on a clean build it materialises the artifact and calls `service.deploy_prebuilt_site`, which runs `_deploy_site_doc`'s **own** tail — concierge embed → deploy → canonical upsert → knowledge sync + screenshot — against the prebuilt tree.

That is why `_deploy_site_doc` gained a `prebuilt_project_dir` parameter instead of the tail being copied into the job. One deploy implementation, two places the build can have happened; the async path cannot drift from the inline one, and `PAW_CF_DEPLOY_MODE` still selects the target, so **local mode is untouched** and the localhost smoke path behaves exactly as before.

## Decisions a reviewer should challenge if they disagree

**The deploy runs before the row settles.** `built` must never mean "built but not serving" — a client reads that as done. A deploy failure after a clean build settles as `deploy_failed:deploy_raised`: its own rung, because nothing about the user's build was wrong and `build_failed` would send them to debug a site that compiles. Retryable, and terminal, so the site stays republishable.

**A rebuild does not take the live site down.** Unlike the dynamic provision path — which clears `deployed`/`url` while its job runs — a re-publish leaves both alone. The previous deploy is still serving the moment a rebuild is queued, so clearing them would report a working site as not-live for the length of a build. `build_status` carries the in-flight state instead, which is the contract the frontend already codes to ("a site can be live and simultaneously mid-rebuild").

**The artifact is unpacked through `artifact_preview.unpack_artifact`, not a second extractor.** That function is hardened against the two things a tar built from customer content will eventually contain — a member that escapes its root and a zip bomb — and every one of those guards has a mutation proving it fires. A deploy-path copy would be the unproven one. Its skip list is preview-shaped (`_worker.js`, deploy metadata), which is harmless *only* because this path is react-only; widening `build_runs_async` means revisiting it, and the docstring says so.

**`generator_client.build_generator_input` is extracted from `_build_one`.** The enqueue has to assemble the generator payload in the web process while `generate` runs in the worker. Two copies of that assembly would drift on the next generator key that lands, and the failure would be silent — a site that builds differently depending on which path published it. Behaviour-preserving: `_build_one` now calls it and passes the result straight through, and the 42 generator-client tests pass unchanged.

## The judgement call you asked for

**An enqueue failure propagates.** The helper rolls the row to a terminal `enqueue_failed:pool_or_enqueue_raised` first, so the site stays republishable, and then the exception re-raises and becomes the 5xx the user sees.

Returning success for a build that was never queued is the worst available outcome: the row would read in-progress forever, the UI would poll a job that does not exist, and the only signal of the failure would be a log line nobody is reading. A visible failed publish is strictly better than an invisible stuck one — the user can press publish again, and the terminal row means the guard lets them.

Tested from both ends: `test_a_failed_enqueue_surfaces_and_leaves_the_site_republishable` (through `publish`) and the ladder's `test_a_publish_whose_enqueue_fails_returns_an_error_the_user_can_see`. A mutation that wraps the enqueue in `try/except pass` is caught by both.

## The tripwire that fired

`test_publish_does_not_consult_the_daytona_lane_yet` was armed for exactly this commit and fired. Its message demanded two proofs, and both are now in `TestF1AndF3AtThePublishBoundary`:

- **F1's publish half**, answered honestly rather than preserved: an unconfigured Daytona no longer fails the publish, because the flip moved the build host out of the request. The publish is accepted as `queued` and the sandbox failure lands on the row as `sandbox_unavailable:run_build_raised` — which is the entire point of `build_reason`. What must not happen is a publish that reports success and leaves nothing to look at, so the queued status and the job id are asserted on the way out.
- **F3 at the front door**: a publish whose enqueue fails raises and leaves a row that is neither in-flight nor pinned.

The pin was retired with a comment recording why the statement it made is no longer true, not deleted quietly. One pin is left and still true: nothing retries.

## Verification

- **28 new tests** — 25 in `test_async_publish.py`, 3 in the ladder. Most of the file is the regression guarantee for the engines that did *not* flip: ripple still builds inline, still reaches the local deploy, still does not enqueue; a dynamic publish still goes to `provision_site` and never enters the build lane.
- `tests/ee/sites`: **1006 passed, 4 failed, 4 skipped** — the four are `test_generator_client_timeout.py`'s Windows wedged-child failures (#1899) and nothing else. 63s.
- Mutations: `sl3_publish_flip.json` **11/11 caught**, `sl2_build_job.json` re-run **24/24**. The 11 include every-engine-flips, no-engine-flips, the worker callback re-entering the fork, the prebuilt dir dropped (a rebuild in the worker), a rebuild clearing `deployed`/`url`, a swallowed enqueue failure, the deploy inputs dropped from the payload, settling before deploying, a swallowed deploy failure, a flat extraction, and a failed build reaching the deploy.
- `python scripts/mutate.py --validate`: 275 anchors across 24 plans, each resolving once.
- `uv run ruff check .` + `uv run ruff format --check .`: clean repo-wide (2693 files).
- Secret scan over the diff against all eight patterns (AWS key id, `sk-`, `ghp_`/`gho_`, `xoxb-`/`xoxp-`, `sk_live_`, PEM header checked by hand since CI's grep eats a leading hyphen): zero matches.

## Not done

The SvelteKit track. Making an adapter-cloudflare artifact self-sufficient is the prerequisite for flipping ripple and svelte, and it is one predicate away once that lands.
