### PR TITLE
Give pocketpaw's own installs a release-age floor

### DIFF
--- a/ee/pyproject.toml
+++ b/ee/pyproject.toml
@@ -329,6 +329,18 @@ annotation_typing = false
 # ee/pyproject.toml (workspace-local source). See
 # ee/pocketpaw_ee/foresight/substrate/oasis/README-FORK.md for the
 # vendoring rationale and the openai/psutil cap audit.
+[tool.uv]
+# The same install-time supply-chain floor as the root pyproject.toml, repeated
+# here because ee/ carries its OWN uv.lock and therefore resolves on its own
+# whenever `uv lock` runs against this file. Settings do not inherit from the
+# parent directory, so without this line the enterprise layer's resolution is
+# the bare one the root's floor was added to fix.
+#
+# Read the root pyproject.toml's `[tool.uv]` comment before touching this: the
+# value is an absolute DATE, not a rolling duration, and the two must be
+# bumped together or the two locks drift to different floors.
+exclude-newer = "2026-08-10T00:00:00Z"
+
 [tool.uv.sources]
 camel-ai = { git = "https://github.com/qbtrix/camel-ai.git", rev = "76ff78e8c78d0a38277e421ea9aca34904b4dc37" }
 

--- a/ee/uv.lock
+++ b/ee/uv.lock
@@ -7,6 +7,9 @@ resolution-markers = [
     "python_full_version < '3.13'",
 ]
 
+[options]
+exclude-newer = "2026-08-10T00:00:00Z"
+
 [[package]]
 name = "aiofiles"
 version = "24.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -543,6 +543,47 @@ dev = [
 # the Test (OSS-only) CI job relies on).
 ee = ["pocketpaw-ee"]
 
+[tool.uv]
+# Install-time supply-chain floor for this repo's own Python resolution.
+#
+# WHY THIS IS HERE. The workspace policy is a 7-day minimum release age: a
+# version has to sit on the index for a week before we will resolve it, which
+# is the one control that catches a compromised fresh publish of a package we
+# already vetted (an allowlist pins WHICH package, and a ranged pin still
+# floats the VERSION). That policy was documented as living in the developer's
+# home directory — and those files do not exist on any machine we checked.
+# `npm config get min-release-age` returns null; there is no ~/.config/uv/
+# uv.toml and no UV_EXCLUDE_NEWER in the environment. So every `uv lock` /
+# `uv sync` in this repo, including the CI jobs, resolved straight off PyPI
+# with no age gate at all. Enforcement now lives per-repo instead: the Daytona
+# build sandbox got its bun floor (#1897), paw-enterprise got its npm floor
+# (#768), and this is pocketpaw's.
+#
+# THE UNIT IS A DATE, NOT A DURATION — this is the trade-off, and it is the
+# whole reason this block needs a comment. bun's `minimumReleaseAge` is
+# seconds and npm's `min-release-age` is days, so both roll forward on their
+# own. uv's `exclude-newer` is an absolute timestamp: it does not move, so it
+# needs a human to bump it. Keep it roughly ONE DAY behind today when you do.
+# Set it too recent and there is no floor left; set it too far back and it
+# starts refusing releases that have legitimately aged past the window, which
+# also breaks first-party packages on a fast cadence (soul-protocol has hit
+# exactly this). Bumping it is a deliberate act, not a chore to automate away.
+#
+# WHAT IT DOES AND DOES NOT GATE. It applies at RESOLUTION time. `uv sync`
+# against the committed uv.lock still installs what the lock pins — the lock
+# is the record of what was already vetted, and this stops a NEW resolve from
+# reaching for something the index published yesterday. If a bump makes a
+# needed dependency unresolvable, pin the previous satisfying version or raise
+# it with the captain. Do not lower this date to make a resolve pass, and
+# never work around it with a bypass flag.
+#
+# It lives in `[tool.uv]` rather than a `uv.toml` on purpose. This repo
+# already keeps its uv config in pyproject.toml (`[tool.uv.sources]` below,
+# and the same in ee/pyproject.toml), and adding an adjacent uv.toml makes uv
+# ignore the settings fields in `[tool.uv]` entirely — verified on uv 0.10.4,
+# which warns and then drops them. One config home, no split brain.
+exclude-newer = "2026-08-10T00:00:00Z"
+
 [tool.uv.sources]
 pocketpaw-ee = { path = "ee", editable = true }
 # RFC 08 PR 3 — Foresight CAMEL hard-dep promotion.

--- a/tests/mutations/supply_chain_floor_python.json
+++ b/tests/mutations/supply_chain_floor_python.json
@@ -1,0 +1,23 @@
+[
+  {
+    "label": "D2: the OSS core's release-age floor is pushed into the future, so uv resolves anything the index published today and a compromised fresh publish of an already-vetted package installs",
+    "file": "pyproject.toml",
+    "find": "exclude-newer = \"2026-08-10T00:00:00Z\"",
+    "replace": "exclude-newer = \"2099-01-01T00:00:00Z\"",
+    "tests": ["tests/test_supply_chain_floor.py::TestThePythonSupplyChainFloor"]
+  },
+  {
+    "label": "D2: the enterprise layer's floor is pushed into the future, so ee/uv.lock — which resolves independently of the root — loses its gate while the root still looks protected",
+    "file": "ee/pyproject.toml",
+    "find": "exclude-newer = \"2026-08-10T00:00:00Z\"",
+    "replace": "exclude-newer = \"2099-01-01T00:00:00Z\"",
+    "tests": ["tests/test_supply_chain_floor.py::TestThePythonSupplyChainFloor"]
+  },
+  {
+    "label": "D2: the cutoff uv actually resolved under is erased from the lock, so the declared floor governs nothing that `uv sync` installs",
+    "file": "uv.lock",
+    "find": "[options]\nexclude-newer = \"2026-08-10T00:00:00Z\"",
+    "replace": "[options]",
+    "tests": ["tests/test_supply_chain_floor.py::TestThePythonSupplyChainFloor"]
+  }
+]

--- a/tests/test_supply_chain_floor.py
+++ b/tests/test_supply_chain_floor.py
@@ -1,0 +1,136 @@
+"""The Python install-time supply-chain floor, asserted on the files that enforce it.
+
+Added with the floor itself: `[tool.uv] exclude-newer` in pyproject.toml (root and
+ee/). The workspace policy is a 7-day minimum release age, and it was documented as
+living in the developer's home directory — where none of those config files actually
+exist. Per-repo enforcement replaced that fiction; this test is what keeps pocketpaw's
+half of it from being deleted or quietly neutered later.
+
+What is worth asserting here is not that a line of TOML is present — that is a
+tautology — but the two properties that can rot independently of it:
+
+  * the declared floor and the LOCKED distributions agree. A lock regenerated
+    without the floor, or hand-edited, admits a distribution published after the
+    cutoff while pyproject.toml still claims a floor. That is the failure that looks
+    fine in review.
+  * no adjacent uv.toml exists. Verified on uv 0.10.4: an adjacent uv.toml makes uv
+    ignore the settings fields in `[tool.uv]` and merely warn, so someone adding one
+    for an unrelated reason silently removes this floor.
+
+Mutation coverage: tests/mutations/supply_chain_floor_python.json.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+#: (pyproject, lockfile) for every independently-resolved Python project in the repo.
+#: ee/ carries its own uv.lock, so it resolves on its own and needs its own floor —
+#: uv settings do not inherit from the parent directory.
+PROJECTS = [
+    (REPO_ROOT / "pyproject.toml", REPO_ROOT / "uv.lock"),
+    (REPO_ROOT / "ee" / "pyproject.toml", REPO_ROOT / "ee" / "uv.lock"),
+]
+
+
+def _declared_floor(pyproject: Path) -> str:
+    data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    uv = data.get("tool", {}).get("uv", {})
+    floor = uv.get("exclude-newer")
+    assert floor, (
+        f"{pyproject.relative_to(REPO_ROOT).as_posix()} declares no "
+        "[tool.uv] exclude-newer, so this project resolves off the index with no "
+        "release-age floor at all"
+    )
+    return str(floor)
+
+
+def _locked_floor(lockfile: Path) -> str | None:
+    data = tomllib.loads(lockfile.read_text(encoding="utf-8"))
+    return data.get("options", {}).get("exclude-newer")
+
+
+def _locked_upload_times(lockfile: Path) -> list[tuple[str, str, str]]:
+    """(upload_time, package, version) for every distribution the lock pins.
+
+    Read out of the lock rather than off the network: this asserts what a `uv sync`
+    would actually install, which is the thing the floor exists to constrain.
+    """
+    data = tomllib.loads(lockfile.read_text(encoding="utf-8"))
+    out: list[tuple[str, str, str]] = []
+    for pkg in data.get("package", []):
+        name = pkg.get("name", "?")
+        version = pkg.get("version", "?")
+        dists = [pkg.get("sdist")] + list(pkg.get("wheels", []))
+        for dist in dists:
+            if isinstance(dist, dict) and dist.get("upload-time"):
+                out.append((str(dist["upload-time"]), name, str(version)))
+    return out
+
+
+class TestThePythonSupplyChainFloor:
+    @pytest.mark.parametrize(
+        ("pyproject", "lockfile"),
+        PROJECTS,
+        ids=lambda p: p.parent.name if p.name == "pyproject.toml" else p.parent.name,
+    )
+    def test_the_lock_was_resolved_under_the_declared_floor(
+        self, pyproject: Path, lockfile: Path
+    ) -> None:
+        """uv stamps the cutoff it resolved under into the lock's [options]. A mismatch
+        means the lock predates the current floor, and `uv sync` installs from the lock
+        — so the declared floor would be governing nothing that actually gets installed.
+        Re-resolve with `uv lock` when this fails; do not edit the lock by hand.
+        """
+        declared = _declared_floor(pyproject)
+        locked = _locked_floor(lockfile)
+        rel = lockfile.relative_to(REPO_ROOT).as_posix()
+        assert locked == declared, (
+            f"{rel} records exclude-newer={locked!r} but "
+            f"{pyproject.relative_to(REPO_ROOT).as_posix()} declares {declared!r}. "
+            "Run `uv lock` in that project directory."
+        )
+
+    @pytest.mark.parametrize(("pyproject", "lockfile"), PROJECTS, ids=lambda p: p.parent.name)
+    def test_no_locked_distribution_is_newer_than_the_floor(
+        self, pyproject: Path, lockfile: Path
+    ) -> None:
+        """The floor's actual promise, checked against the pins rather than the config.
+
+        Compared as ISO-8601 strings, which sort correctly and identically here because
+        both sides are UTC `Z` timestamps — no timezone parsing to get subtly wrong.
+        """
+        declared = _declared_floor(pyproject)
+        rel = lockfile.relative_to(REPO_ROOT).as_posix()
+        newer = [(t, n, v) for t, n, v in _locked_upload_times(lockfile) if t > declared]
+        assert not newer, (
+            f"{rel} pins {len(newer)} distribution(s) published after the "
+            f"{declared} floor: "
+            + ", ".join(f"{n} {v} ({t})" for t, n, v in sorted(newer, reverse=True)[:5])
+        )
+
+    def test_the_two_projects_declare_the_same_floor(self) -> None:
+        """Bumping one and forgetting the other leaves the OSS core and the enterprise
+        layer resolving against different cutoffs — the kind of drift nobody notices
+        until the two locks disagree about a shared transitive dependency."""
+        floors = {p.relative_to(REPO_ROOT).as_posix(): _declared_floor(p) for p, _ in PROJECTS}
+        assert len(set(floors.values())) == 1, f"floors disagree: {floors}"
+
+    @pytest.mark.parametrize(("pyproject", "lockfile"), PROJECTS, ids=lambda p: p.parent.name)
+    def test_no_adjacent_uv_toml_suppresses_the_floor(
+        self, pyproject: Path, lockfile: Path
+    ) -> None:
+        """An adjacent uv.toml wins over `[tool.uv]` and uv only warns about it, so this
+        is a silent-removal path that leaves the pyproject.toml declaration in place and
+        looking authoritative. If a uv.toml is ever genuinely needed, move the floor into
+        it rather than deleting this assertion."""
+        stray = pyproject.parent / "uv.toml"
+        assert not stray.exists(), (
+            f"{stray.relative_to(REPO_ROOT).as_posix()} exists; uv ignores the settings "
+            "in [tool.uv] when it does, which silently drops exclude-newer"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,9 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 
+[options]
+exclude-newer = "2026-08-10T00:00:00Z"
+
 [[package]]
 name = "aiofile"
 version = "3.11.1"


### PR DESCRIPTION
## The gap

The workspace policy is a 7-day minimum release age, and `.claude/CLAUDE.md` says it is enforced for every package manager through home-directory config. Those files are not there:

```
~/.config/uv/uv.toml   ·  $APPDATA/uv/uv.toml  ·  ~/.npmrc  ·  ~/.bunfig.toml     none exist
npm config get min-release-age  →  null      (effective value, so definitive)
UV_EXCLUDE_NEWER                →  unset    (and no uv.toml anywhere in the workspace)
```

So every `uv lock` and `uv sync` in this repo — including the CI jobs, which run `uv sync` from the root — resolved straight off PyPI with no age gate. A release-age floor is the control that catches a compromised fresh publish of a package we have already vetted; an allowlist cannot, because it pins *which* package while a ranged pin still floats the *version*.

Per-repo enforcement already covers the Daytona build sandbox (#1897, bun inside the container) and paw-enterprise (qbtrix/paw-enterprise#768). This is pocketpaw's half.

## What changed

`exclude-newer = "2026-08-10T00:00:00Z"` in `[tool.uv]`, in **two** places:

- the root `pyproject.toml`
- `ee/pyproject.toml` — it carries its own `uv.lock`, so it resolves independently, and uv settings do not inherit from the parent directory. Without both, `uv lock` against `ee/` is exactly the bare resolution this PR exists to fix.

It lives in `[tool.uv]` rather than a new `uv.toml` because an adjacent `uv.toml` takes precedence over the settings fields in `[tool.uv]` and uv only *warns* about it. Checked on uv 0.10.4:

```
warning: Found both a `uv.toml` file and a `[tool.uv]` section in an adjacent
`pyproject.toml`. The following fields from `[tool.uv]` will be ignored ...
```

That is a silent way to lose the floor months from now, and this repo already keeps its uv config in `pyproject.toml`. One config home instead of two.

## The resolution was run, not assumed

`exclude-newer` can refuse a currently-pinned dependency outright, so a from-scratch resolve is the honest test. uv makes that automatic here — it discards a lock resolved under a different cutoff:

```
Ignoring existing lockfile due to addition of global exclude newer 2026-08-10T00:00:00Z
Resolved 383 packages          (root)
Resolved 231 packages          (ee/)
```

**Neither resolve moved a single version.** The entire diff in both lockfiles is the block recording the cutoff:

```
+[options]
+exclude-newer = "2026-08-10T00:00:00Z"
```

Nothing in the dependency set was too fresh — the newest `upload-time` anywhere in the root lock is 2026-07-29 — so no version had to be pinned back and there is nothing here for the captain to decide. A fresh `uv sync --dev` off the regenerated lock built a clean venv and installed all 235 packages, and `uv sync --dev --all-extras --group ee` then resolved and installed the enterprise layer on top of it with no complaint. CI's own `uv sync` is green on this branch.

## The trade-off, which is the reason for the long comment

uv's unit is an absolute **date**, not a duration. bun's `minimumReleaseAge` (seconds) and npm's `min-release-age` (days) roll forward on their own; this one does not, so it needs a human to bump it and stay roughly a day behind today. Set it too recent and there is no floor left; set it too far back and it refuses releases that have legitimately aged past the window, which is how soul-protocol has been broken before. The comment in the root `pyproject.toml` spells this out, along with the rule that a failing resolve gets the previous satisfying version pinned or gets raised with the captain — never a lowered date and never a bypass flag.

## Tests

`tests/test_supply_chain_floor.py` deliberately does not assert that a line of TOML is present, which would be a tautology. It asserts the four things that can rot on their own:

- each lock's recorded cutoff matches its `pyproject.toml`. A lock regenerated without the floor, or hand-edited, admits a newer distribution while the config still claims protection — the failure that looks fine in review
- no locked distribution has an `upload-time` newer than the floor, read out of the lock, because that is what `uv sync` actually installs
- the two projects declare the same date, so bumping one and forgetting the other does not go unnoticed
- no adjacent `uv.toml` exists to suppress the setting

`tests/mutations/supply_chain_floor_python.json` pushes each floor into the future and strips the cutoff from the lock. All 3 caught. `python scripts/mutate.py --validate` passes across all 25 plans (278 anchors), and `ruff check` / `ruff format --check` are clean repo-wide.

## Not in this PR

`.claude/CLAUDE.md` lives in paw-workspace, not here. Its Supply Chain Security section has been corrected to describe per-repo enforcement and to drop the machine-wide claim, and that edit is sitting uncommitted for the captain to review directly.

