### PR TITLE
Burst the site-build lane: the single-flight guard leaks sandboxes under concurrency

### DIFF
--- a/docs/runbooks/2026-08-11-site-build-burst-harness.md
+++ b/docs/runbooks/2026-08-11-site-build-burst-harness.md
@@ -1,0 +1,126 @@
+# Site-build burst harness — what it proves, what it cannot, and how to run it live
+
+Created 2026-08-11 (D5). Companion to `tests/ee/sites/burst_harness.py` and
+`tests/ee/sites/test_burst_harness.py`.
+
+Every publish is now a Daytona sandbox. That put the site-build lane's single-flight
+guard on the critical path for cost as well as correctness, and until this harness nothing
+measured it under contention. This note exists so a green test run is not mistaken for a
+validated concurrency cap.
+
+## Running it
+
+```
+uv run pytest tests/ee/sites/test_burst_harness.py
+```
+
+Under two seconds, no Redis, no Mongo, no Daytona, no network. Every "sandbox" is a
+recorded arq enqueue and the clock is injected, so a burst that spans an hour of window
+arithmetic finishes in microseconds. If a run of this harness ever asks for
+`DAYTONA_API_KEY`, something has been wired wrong — nothing here is allowed to reach the
+API.
+
+The mutation plan that proves the assertions bite:
+
+```
+uv run python scripts/mutate.py --plan tests/mutations/sites_burst_harness.json
+```
+
+## What it found
+
+**A concurrent burst defeats the single-flight guard.** `enqueue_site_build` gates on a
+READ (`should_enqueue`) and then stamps with a WRITE (`mark_build_queued`), and it awaits
+between the two. Any publish arriving inside that window reads a row with no build in
+flight, passes the gate correctly, and opens its own sandbox. Measured: **8 concurrent
+publishes of one site produce 8 sandboxes.** Two are enough to reproduce it — two clicks
+inside one round trip.
+
+The state machine itself is sound, which is what localises the defect:
+
+| Burst shape | Sandboxes for one site | Reading |
+|---|---|---|
+| Publishes serialised (await each) | 1, second returns `None` | The guard works |
+| Burst arriving after the stamp landed | 0, all refused | `should_enqueue` is correct |
+| 8 concurrent, one shared row object | 8 | The read-write window is open |
+| 8 concurrent, each having loaded its own row | 8 | Same window, across workers |
+| 8 concurrent across 8 different sites | 8 | Correct — the guard is per-site, not global |
+
+So this is missing atomicity at the row, not a bug in `build_state`. The fix is a
+conditional write: stamp `queued` only if the row is still observed non-in-flight
+(Mongo `find_one_and_update` with a status precondition), and have the loser of the race
+get nothing back and return `None`. When that lands, the assertions in
+`TestSingleFlightUnderContention` flip from `sandboxes == BURST` to `sandboxes == 1` and
+`refused == BURST - 1`. Those numbers are asserted exactly so that flip is the fix's
+acceptance test.
+
+The harness leaves the current behaviour pinned rather than fixed, because the fix is a
+change to the write path and belongs in its own reviewed PR.
+
+A second, smaller observation while sizing anything: `STALE_MARGIN` is 10 minutes, so for
+any engine budget well under that the margin dominates the derived window and deriving it
+buys little. Both engines currently resolve to 600s, where the two terms are comparable.
+
+## What this harness cannot tell us
+
+Read this before quoting a green run as evidence for a concurrency cap.
+
+- **It does not measure the cap.** No value for the concurrency cap can be derived from
+  it. The harness exercises the guard's logic against a fake runner; it has no model of
+  how many sandboxes Daytona will actually give us concurrently, or at what point
+  throughput stops improving.
+- **It does not measure real sandbox contention.** Sandbox creation latency under
+  parallel load, Daytona-side queueing, rate limits, and quota rejections are all absent.
+  The fake pool always accepts.
+- **It does not measure queue latency.** Arq queue depth, worker pickup delay and the
+  real distribution of wait time behind a cap are not modelled. The staleness window is
+  exercised against an injected clock, which proves the arithmetic, not the wait.
+- **It does not measure the deploy race.** The harness counts sandboxes; it does not run
+  two artifacts to the deploy step and observe which wins. That the overspend also risks
+  a wrong artifact going live is reasoned, not measured.
+- **It does not exercise multi-worker or multi-process concurrency.** The separate-doc
+  burst is the right shape for it — each publish holds its own snapshot of the row — but
+  it runs in one event loop against a fake. A real two-worker race adds Mongo write
+  ordering and clock skew.
+- **Mongomock is not Mongo.** The one shared-doc burst driven through real Beanie against
+  mongomock returned 1 sandbox rather than 8, because mongomock's write resolves without
+  yielding to the event loop. Beanie applies its local merge *after* awaiting the write
+  (`Document.update` → `merge_models(self, result)`), so against real Mongo that case
+  races too. This is why the harness's own `FakeSite.set` yields before applying: it is
+  the faithful model, and a fake that applied writes synchronously would report a
+  guarantee the lane does not have.
+
+Sizing the cap still needs a live run.
+
+## Running it live (deliberate, spends money)
+
+Not automated, and deliberately not wired to a test marker — a live burst creates real
+Daytona sandboxes and bills for them, and that is the captain's call, not a side effect of
+running a suite. There is no code in the tree that can trigger it.
+
+Preconditions: a staging workspace, `DAYTONA_API_KEY` and `POCKETPAW_REDIS_URL` set for
+staging (never production), at least one arq worker running the site-build queue, and an
+agreed spend ceiling — at N publishes you are buying N sandboxes.
+
+```bash
+# One site, N concurrent publishes. Measures the single-flight guard against real
+# infrastructure and prints the number of sandboxes the burst actually opened.
+POCKETPAW_ENV=staging \
+  uv run python -m pocketpaw_ee.sites.scripts.burst_live \
+    --site-id <staging-site-id> --publishes 8 --report /tmp/burst.json
+```
+
+`pocketpaw_ee.sites.scripts.burst_live` does not exist yet, on purpose — writing it is
+part of whoever runs the live burst, and it should be a thin script that drives the real
+publish endpoint N times and then reads back `build_status` / `build_job_id` plus the
+Daytona sandbox list for the window. Keeping it unwritten means there is no armed path to
+spending money sitting in the repo.
+
+What to record from a live run, since these are the numbers the fake cannot produce:
+
+1. Sandboxes created vs publishes issued (the single-flight result against real writes).
+2. Time from publish to `building` at each concurrency level — where queue wait starts
+   dominating is where the cap belongs.
+3. Any Daytona rate-limit or quota rejection, and which rung classified it.
+4. p50/p95 total build time under load vs the measured ~8.7s solo react build. The gap is
+   what the cap has to be sized against.
+5. Whether any site ended in a terminal status with two artifacts having been produced.

--- a/tests/ee/sites/burst_harness.py
+++ b/tests/ee/sites/burst_harness.py
@@ -1,0 +1,323 @@
+# tests/ee/sites/burst_harness.py — the site-build lane's burst / concurrency harness.
+#
+# Created 2026-08-11 (D5). The captain's ruling made EVERY publish a Daytona sandbox, so
+# the single-flight guard in ``sites/build_state.py`` moved onto the critical path for
+# both cost and correctness — and nothing measured it under contention. This module is
+# the fake lane that lets a burst be measured without spending a sandbox.
+#
+# WHY A FAKE LANE RATHER THAN A LIVE BURST. A live burst spends real sandboxes and real
+# money, and it is the captain's call to make deliberately, not a side effect of running
+# the test suite. Everything here is in-process: the "sandbox" is a recorded enqueue, the
+# clock is injected, and no code path in this file can reach the Daytona API or Redis. A
+# harness that needs ``DAYTONA_API_KEY`` to run is the wrong harness.
+#
+# WHAT MAKES THIS CHEAP. ``build_state`` is pure — no Beanie, no I/O, and its functions
+# take ``now=`` — so a burst is a loop over an injected clock rather than a wait. That is
+# deliberate on both sides: a harness that takes minutes is a harness nobody runs.
+#
+# THE TWO CONCURRENCY MODELS, and why both are here. The guard is a READ-then-WRITE, not
+# a compare-and-swap, so what it guarantees depends entirely on whether the stamp lands
+# before a sibling reads:
+#
+#   * SHARED-DOC (``burst_on_one_doc``) — N publishes racing on ONE in-memory row, which
+#     is what a single process re-entering publish looks like. The stamp is visible to
+#     every later reader as soon as it lands.
+#   * SEPARATE-DOC (``burst_on_reloaded_docs``) — N publishes that each LOAD their own
+#     copy of the row first, which is what N concurrent HTTP requests actually look like.
+#     Each reader has its own snapshot, so a stamp written by one is invisible to a
+#     sibling that read before it.
+#
+# The second is the honest model of production and the harder case. Keeping both is the
+# point: the difference between them is the size of the guard's race window, and a
+# harness that only ran the friendly model would report a guarantee the lane does not
+# have. See docs/runbooks/2026-08-11-site-build-burst-harness.md for what this can and
+# cannot tell us.
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+BUILD_TIMEOUT = 600
+"""The engine budget both engines currently resolve to (``daytona_build``'s floor).
+Hard-coded rather than resolved so a burst's arithmetic stays readable, and so an env
+var on the machine running the tests cannot move the window under the assertions."""
+
+
+# ---------------------------------------------------------------------------
+# The fake build runner
+# ---------------------------------------------------------------------------
+
+
+class RecordingPool:
+    """An arq pool that RECORDS an enqueue instead of performing one.
+
+    Each recorded call is one sandbox that a real lane would have created, so
+    ``len(pool.calls)`` is the harness's cost meter: the number this reports for a burst
+    of N publishes of one site is the number of Daytona bills that burst would produce.
+    Two is the failure the single-flight guard exists to prevent.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def enqueue_job(
+        self, function: str, *args: Any, _job_id: str | None = None, **kwargs: Any
+    ) -> object:
+        self.calls.append({"function": function, "args": args, "job_id": _job_id, "kwargs": kwargs})
+        return object()
+
+    @property
+    def sandboxes(self) -> int:
+        """How many sandboxes this burst would have opened."""
+        return len(self.calls)
+
+    @property
+    def job_ids(self) -> list[str | None]:
+        return [call["job_id"] for call in self.calls]
+
+
+class YieldingPool(RecordingPool):
+    """A pool that hands control back to the loop BEFORE recording.
+
+    Widens the interleaving window on purpose. A real ``enqueue_job`` is a Redis round
+    trip, so the loop is free to run a sibling publish mid-enqueue; a fake that records
+    synchronously hides any ordering bug that window exposes.
+    """
+
+    async def enqueue_job(
+        self, function: str, *args: Any, _job_id: str | None = None, **kwargs: Any
+    ) -> object:
+        await asyncio.sleep(0)
+        return await super().enqueue_job(function, *args, _job_id=_job_id, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# The fake row
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeSite:
+    """A Site-shaped row whose writes yield to the loop, like a DB round trip does.
+
+    ``set`` is the load-bearing detail. A fake that applied a write synchronously would
+    make every burst pass, because no sibling could ever observe the pre-write state —
+    the harness would be measuring its own fake instead of the guard. Yielding first
+    reproduces the real gap between a gate's read and its stamp.
+
+    Every write is appended to ``transitions``, which is what lets a test assert that
+    ``queued`` and ``building`` stayed DISTINGUISHABLE under load rather than merely
+    that the row ended up somewhere plausible.
+    """
+
+    workspace: str = "ws-burst"
+    id: str = "site-burst"
+    build_status: str = "none"
+    build_started_at: datetime | None = None
+    build_job_id: str | None = None
+    build_reason: str | None = None
+    transitions: list[tuple[str, str | None]] = field(default_factory=list)
+
+    async def set(self, values: dict[str, Any]) -> None:
+        await asyncio.sleep(0)  # a real write is a round trip; a sibling may run here
+        for key, value in values.items():
+            setattr(self, key, value)
+        if "build_status" in values:
+            self.transitions.append((values["build_status"], values.get("build_reason")))
+
+    def snapshot(self) -> FakeSite:
+        """An independent copy of the row as it reads RIGHT NOW.
+
+        This is what "each request loads its own doc" means: a snapshot taken before a
+        sibling's stamp lands never sees that stamp, however the loop interleaves after.
+        """
+        return FakeSite(
+            workspace=self.workspace,
+            id=self.id,
+            build_status=self.build_status,
+            build_started_at=self.build_started_at,
+            build_job_id=self.build_job_id,
+            build_reason=self.build_reason,
+            transitions=self.transitions,  # shared on purpose: one row, one history
+        )
+
+
+def aged_site(status: str, *, age_seconds: float | None, **kwargs: Any) -> FakeSite:
+    """A row in ``status`` whose stamp is ``age_seconds`` old (``None`` = no stamp)."""
+    stamp = None if age_seconds is None else datetime.now(UTC) - timedelta(seconds=age_seconds)
+    return FakeSite(build_status=status, build_started_at=stamp, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# The clock
+# ---------------------------------------------------------------------------
+
+
+class Clock:
+    """An injected clock. The guard's functions all take ``now=``, so a burst that spans
+    an hour of window arithmetic runs in microseconds and lands on exact boundaries —
+    which a sleeping harness cannot do, and which is where the interesting bugs are."""
+
+    def __init__(self, start: datetime | None = None) -> None:
+        self.now = start or datetime(2026, 8, 11, 12, 0, 0, tzinfo=UTC)
+
+    def advance(self, **delta: float) -> datetime:
+        self.now = self.now + timedelta(**delta)
+        return self.now
+
+    def ago(self, **delta: float) -> datetime:
+        return self.now - timedelta(**delta)
+
+
+# ---------------------------------------------------------------------------
+# The burst drivers
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BurstReport:
+    """What one burst of N publishes did.
+
+    ``sandboxes`` is the cost line and the assertion that matters: for N publishes of one
+    site it must be 1. ``refused`` counts the publishes the guard turned away — a
+    ``None`` return from ``enqueue_site_build``, which is the lane's "a build is already
+    in flight" answer, not an error.
+    """
+
+    results: list[Any]
+    sandboxes: int
+    transitions: list[tuple[str, str | None]]
+
+    @property
+    def job_ids(self) -> list[str]:
+        return [r for r in self.results if isinstance(r, str)]
+
+    @property
+    def refused(self) -> int:
+        return sum(1 for r in self.results if r is None)
+
+    @property
+    def errors(self) -> list[BaseException]:
+        return [r for r in self.results if isinstance(r, BaseException)]
+
+
+async def _gather(coros: list[Any]) -> list[Any]:
+    return list(await asyncio.gather(*coros, return_exceptions=True))
+
+
+async def burst_on_one_doc(
+    site: FakeSite,
+    n: int,
+    *,
+    pool: RecordingPool | None = None,
+    engine: str = "react",
+) -> BurstReport:
+    """N concurrent publishes racing on ONE row object.
+
+    The friendly model: a stamp is visible to every reader that has not yet gated. This
+    is a single process re-entering publish, not two HTTP requests.
+    """
+    from pocketpaw_ee.sites import build_job
+
+    pool = pool or RecordingPool()
+    results = await _gather(
+        [
+            build_job.enqueue_site_build(
+                site,
+                engine=engine,
+                generator_input=_input(),
+                timeout_seconds=BUILD_TIMEOUT,
+                _pool_override=pool,
+            )
+            for _ in range(n)
+        ]
+    )
+    return BurstReport(results=results, sandboxes=pool.sandboxes, transitions=site.transitions)
+
+
+async def burst_on_reloaded_docs(
+    site: FakeSite,
+    n: int,
+    *,
+    pool: RecordingPool | None = None,
+    engine: str = "react",
+) -> BurstReport:
+    """N concurrent publishes that each LOAD their own copy of the row first.
+
+    The production model: N HTTP requests, each with its own snapshot of the row. Every
+    snapshot is taken before any stamp lands, which is exactly the window a read-then-
+    write guard leaves open and a compare-and-swap would close.
+    """
+    from pocketpaw_ee.sites import build_job
+
+    pool = pool or RecordingPool()
+    snapshots = [site.snapshot() for _ in range(n)]
+    results = await _gather(
+        [
+            build_job.enqueue_site_build(
+                snap,
+                engine=engine,
+                generator_input=_input(),
+                timeout_seconds=BUILD_TIMEOUT,
+                _pool_override=pool,
+            )
+            for snap in snapshots
+        ]
+    )
+    return BurstReport(results=results, sandboxes=pool.sandboxes, transitions=site.transitions)
+
+
+async def burst_on_distinct_sites(
+    n: int,
+    *,
+    pool: RecordingPool | None = None,
+    engine: str = "react",
+) -> BurstReport:
+    """N concurrent publishes of N DIFFERENT sites.
+
+    The control case, and the one that must NOT be throttled: the guard is per-site, so
+    N distinct sites are N legitimate builds. A guard that collapsed them would be a
+    global lock wearing a single-flight costume, and it would serialise every customer
+    behind whoever published first.
+    """
+    from pocketpaw_ee.sites import build_job
+
+    pool = pool or RecordingPool()
+    sites = [FakeSite(id=f"site-{i}") for i in range(n)]
+    results = await _gather(
+        [
+            build_job.enqueue_site_build(
+                s,
+                engine=engine,
+                generator_input=_input(),
+                timeout_seconds=BUILD_TIMEOUT,
+                _pool_override=pool,
+            )
+            for s in sites
+        ]
+    )
+    transitions = [t for s in sites for t in s.transitions]
+    return BurstReport(results=results, sandboxes=pool.sandboxes, transitions=transitions)
+
+
+def _input() -> dict[str, Any]:
+    """The smallest generator payload the enqueue will accept. Scrubbed by the lane on
+    the way in, so nothing here needs to be realistic."""
+    return {"siteId": "site-burst", "spec": {"sections": []}}
+
+
+__all__ = [
+    "BUILD_TIMEOUT",
+    "BurstReport",
+    "Clock",
+    "FakeSite",
+    "RecordingPool",
+    "YieldingPool",
+    "aged_site",
+    "burst_on_distinct_sites",
+    "burst_on_one_doc",
+    "burst_on_reloaded_docs",
+]

--- a/tests/ee/sites/test_burst_harness.py
+++ b/tests/ee/sites/test_burst_harness.py
@@ -1,0 +1,417 @@
+# tests/ee/sites/test_burst_harness.py — the site-build lane under a burst.
+#
+# Created 2026-08-11 (D5). Every publish is now a Daytona sandbox, which puts the
+# single-flight guard on the critical path for MONEY as well as correctness, and nothing
+# measured it under contention. These run the guard against a faked lane
+# (``burst_harness.py``): no Daytona, no Redis, no sandbox, an injected clock, and every
+# "sandbox" is a recorded enqueue.
+#
+# WHAT THIS FOUND, and it is the reason the file exists rather than a footnote:
+# ``enqueue_site_build`` gates with a READ (``should_enqueue``) and then stamps with a
+# WRITE (``mark_build_queued``), with an await in between and no compare-and-swap. Every
+# publish that arrives inside that window reads the pre-stamp row, passes the gate, and
+# opens its own sandbox. At N=8 that is EIGHT sandboxes for one site. The guard's own
+# logic is correct — a burst that arrives after the stamp lands is refused in full — so
+# the defect is the missing atomicity at the row, not the state machine.
+# ``TestSingleFlightUnderContention`` pins that behaviour deliberately; see its docstring
+# and docs/runbooks/2026-08-11-site-build-burst-harness.md.
+#
+# THE HARNESS MEASURES LOGIC, NOT INFRASTRUCTURE. It cannot tell us real sandbox
+# contention, real queue latency, or the right value for the concurrency cap. Those need
+# a live burst, which spends real money and is the captain's call to make deliberately.
+# A green run here does NOT mean the cap is validated.
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from pocketpaw_ee.sites import build_job as bj
+from pocketpaw_ee.sites import build_state as bs
+
+from tests.ee.sites.burst_harness import (
+    BUILD_TIMEOUT,
+    Clock,
+    FakeSite,
+    RecordingPool,
+    YieldingPool,
+    aged_site,
+    burst_on_distinct_sites,
+    burst_on_one_doc,
+    burst_on_reloaded_docs,
+)
+
+BURST = 8
+"""Enough concurrency to interleave every ordering that matters, small enough that a
+failure prints a readable report. The lane's failure mode does not need N=100 to show
+up — it shows up at 2."""
+
+
+# ---------------------------------------------------------------------------
+# The guard works. Establish that before measuring where it stops working.
+# ---------------------------------------------------------------------------
+
+
+class TestTheGuardHoldsWhenPublishesAreSerialised:
+    """The baseline, and the harness's own calibration. If these failed, a later red
+    result would be the harness lying rather than the lane racing."""
+
+    async def test_a_second_sequential_publish_is_refused(self) -> None:
+        site = FakeSite()
+        pool = RecordingPool()
+        first = await bj.enqueue_site_build(
+            site,
+            engine="react",
+            generator_input={"siteId": "x"},
+            timeout_seconds=BUILD_TIMEOUT,
+            _pool_override=pool,
+        )
+        second = await bj.enqueue_site_build(
+            site,
+            engine="react",
+            generator_input={"siteId": "x"},
+            timeout_seconds=BUILD_TIMEOUT,
+            _pool_override=pool,
+        )
+        assert isinstance(first, str)
+        assert second is None, "the guard's answer for 'already in flight' is None"
+        assert pool.sandboxes == 1, "one publish, one sandbox, one bill"
+
+    async def test_a_burst_arriving_after_the_stamp_is_refused_in_full(self) -> None:
+        """The load-bearing proof that the STATE MACHINE is right. Once the row carries
+        its ``queued`` stamp, N concurrent publishes all read it and all decline — no
+        sandbox, no bill. Whatever goes wrong under contention is therefore the missing
+        atomicity at the row, not ``should_enqueue``'s logic."""
+        site = aged_site("queued", age_seconds=5)
+        report = await burst_on_one_doc(site, BURST, pool=YieldingPool())
+        assert report.sandboxes == 0
+        assert report.refused == BURST
+        assert report.errors == []
+
+
+# ---------------------------------------------------------------------------
+# The finding
+# ---------------------------------------------------------------------------
+
+
+class TestSingleFlightUnderContention:
+    """N concurrent publishes of ONE site. The guarantee this lane needs is exactly one
+    in-flight build; two sandboxes for one site is two bills and two artifacts racing to
+    deploy.
+
+    THESE TESTS PIN THE CURRENT BEHAVIOUR, WHICH DOES NOT MEET THAT GUARANTEE. They are
+    characterisation tests, not an endorsement. ``enqueue_site_build`` reads the row to
+    gate and then writes the row to stamp, and between those two steps it awaits; a
+    sibling publish that reads inside that window sees a row with no build in flight and
+    is correct to enqueue, by the guard's own rules. Serialising the publishes fixes it
+    (see the class above), which is what identifies the gap as atomicity rather than
+    logic.
+
+    WHEN THE FIX LANDS — a conditional write that only stamps a row still observed
+    terminal (Mongo's ``find_one_and_update`` with a status precondition), so the loser
+    of the race gets nothing back and returns ``None`` — the assertions here flip to
+    ``sandboxes == 1`` and ``refused == BURST - 1``. That flip is the fix's acceptance
+    test, and it is why the numbers are asserted exactly rather than loosely.
+    """
+
+    async def test_concurrent_publishes_each_open_their_own_sandbox_today(self) -> None:
+        site = FakeSite()
+        report = await burst_on_one_doc(site, BURST, pool=YieldingPool())
+        assert report.errors == []
+        # The guarantee: == 1. The reality: one per publish.
+        assert report.sandboxes == BURST, (
+            f"{BURST} concurrent publishes of one site opened {report.sandboxes} sandboxes; "
+            "the single-flight guard needs 1"
+        )
+        assert report.refused == 0
+
+    async def test_separate_requests_each_holding_their_own_row_copy_also_race(self) -> None:
+        """The production shape. Two HTTP publishes each load the site before gating, so
+        neither can see the other's stamp however the loop interleaves afterwards. This
+        is the model the fix has to satisfy — an in-process lock would pass the shared-doc
+        case above and still leave this one racing across workers."""
+        site = FakeSite()
+        report = await burst_on_reloaded_docs(site, BURST, pool=YieldingPool())
+        assert report.errors == []
+        assert report.sandboxes == BURST
+        assert report.refused == 0
+
+    async def test_even_two_concurrent_publishes_are_enough(self) -> None:
+        """The failure does not need load. Two clicks on a publish button inside one
+        round trip reproduce it, which is why this is a correctness bug and not a
+        capacity note."""
+        report = await burst_on_one_doc(FakeSite(), 2, pool=YieldingPool())
+        assert report.sandboxes == 2
+
+    async def test_every_racing_publish_mints_a_distinct_job_id(self) -> None:
+        """Not a nice-to-have: arq refuses a duplicate id by returning ``None``, and the
+        lane reads that as a failed enqueue and rolls the row to ``failed``. A stable
+        per-site id would therefore convert this race into a publish that reports broken
+        rather than one that overspends — a worse failure, and a silent one."""
+        report = await burst_on_one_doc(FakeSite(), BURST, pool=YieldingPool())
+        assert len(set(report.job_ids)) == len(report.job_ids)
+
+
+class TestTheGuardIsPerSiteNotGlobal:
+    async def test_distinct_sites_are_not_throttled_by_each_other(self) -> None:
+        """The control case. A guard that collapsed distinct sites would be a global lock
+        wearing a single-flight costume, serialising every customer behind whoever
+        published first — so this must stay N-for-N even after the race above is fixed."""
+        report = await burst_on_distinct_sites(BURST)
+        assert report.sandboxes == BURST
+        assert report.refused == 0
+        assert len(set(report.job_ids)) == BURST
+
+
+# ---------------------------------------------------------------------------
+# The staleness window, at both edges, on an injected clock
+# ---------------------------------------------------------------------------
+
+
+class TestTheStalenessWindowUnderBurst:
+    """The window is derived from the build's OWN timeout plus ``STALE_MARGIN``, not a
+    constant, and a burst is where a wrong window costs the most: every publish in it
+    makes the same wrong call at once.
+
+    Both edges matter and they fail in opposite directions — too generous pins a dead row
+    (the site becomes unpublishable), too tight re-enqueues onto a healthy long build
+    (two sandboxes). The clock is injected, so these land on the exact boundary second
+    instead of sleeping toward it."""
+
+    def test_a_healthy_long_build_is_never_re_enqueued_by_a_burst(self) -> None:
+        clock = Clock()
+        site = FakeSite(build_status="building", build_started_at=clock.ago(seconds=590))
+        for _ in range(BURST):
+            assert bs.should_enqueue(site, BUILD_TIMEOUT, now=clock.now) is False
+
+    def test_a_dead_row_past_its_window_is_re_enqueued(self) -> None:
+        """The one-way-door fix. Without it a build that died without writing a terminal
+        status pins the row and every later publish is a silent no-op."""
+        clock = Clock()
+        window = bs.stale_after(BUILD_TIMEOUT).total_seconds()
+        site = FakeSite(build_status="building", build_started_at=clock.ago(seconds=window + 1))
+        assert bs.should_enqueue(site, BUILD_TIMEOUT, now=clock.now) is True
+
+    def test_the_boundary_is_strictly_past_the_window_not_at_it(self) -> None:
+        """Exactly at the window is still in flight. A harness that only tested "well
+        past" and "well inside" would miss an off-by-one that unsticks live builds one
+        second early — cheap to write, and the exact reason the clock is injected."""
+        clock = Clock()
+        window = bs.stale_after(BUILD_TIMEOUT)
+        at_the_edge = FakeSite(build_status="building", build_started_at=clock.now - window)
+        one_past = FakeSite(
+            build_status="building",
+            build_started_at=clock.now - window - timedelta(seconds=1),
+        )
+        assert bs.build_is_stale(at_the_edge, BUILD_TIMEOUT, now=clock.now) is False
+        assert bs.build_is_stale(one_past, BUILD_TIMEOUT, now=clock.now) is True
+
+    @pytest.mark.parametrize("timeout", [60, 600, 3600])
+    def test_a_longer_budget_buys_a_longer_window(self, timeout: int) -> None:
+        """The whole point of deriving instead of hard-coding: one build age reads as
+        stale under its own budget and healthy under a larger one.
+
+        Worth knowing while sizing the cap: ``STALE_MARGIN`` is 10 minutes, so for any
+        engine budget below that the margin DOMINATES the window and deriving buys
+        little. Both engines currently resolve to 600s, where the two terms are
+        comparable; a much shorter budget would make the window effectively constant
+        again, which is the thing deriving it was meant to avoid."""
+        clock = Clock()
+        age = bs.stale_after(timeout).total_seconds() + 60
+        site = FakeSite(build_status="building", build_started_at=clock.ago(seconds=age))
+        assert bs.should_enqueue(site, timeout, now=clock.now) is True
+        assert bs.should_enqueue(site, timeout + 3600, now=clock.now) is False
+
+    async def test_a_burst_on_a_stale_row_is_no_longer_blocked_by_it(self) -> None:
+        """End to end through the enqueue: a wedged row must not survive as a permanent
+        block. The overspend from the race above applies here too — but a stuck site that
+        can never publish again is the failure this direction is biased against."""
+        window = bs.stale_after(BUILD_TIMEOUT).total_seconds()
+        site = aged_site("building", age_seconds=window + 120)
+        report = await burst_on_one_doc(site, BURST, pool=YieldingPool())
+        assert report.sandboxes >= 1, "a dead row must not block publishes forever"
+
+
+# ---------------------------------------------------------------------------
+# queued vs building
+# ---------------------------------------------------------------------------
+
+
+class TestQueuedAndBuildingStayDistinguishable:
+    """Collapsing these loses the only signal separating "waiting behind the cap" from
+    "stuck", which is what turns a crash into a support ticket. Under load is exactly
+    when that distinction is load-bearing, because under load is when queueing is
+    normal."""
+
+    async def test_a_burst_stamps_queued_and_a_worker_pickup_stamps_building(self) -> None:
+        from pocketpaw_ee.sites import service as sites_service
+
+        site = FakeSite()
+        await burst_on_one_doc(site, 3, pool=YieldingPool())
+        assert {status for status, _ in site.transitions} == {"queued"}
+        await sites_service.mark_build_running(site)
+        assert [status for status, _ in site.transitions][-1] == "building"
+        assert [s for s, _ in site.transitions].count("queued") == 3
+
+    async def test_a_worker_pickup_moves_the_clock_forward_not_just_the_status(self) -> None:
+        """``mark_build_running`` RE-stamps ``build_started_at`` on purpose: the stamp
+        means "when the current attempt started", and carrying the enqueue's clock over
+        would spend the staleness window on queue wait. Under a cap that is most of the
+        window, so a build that waited would be declared stale while still running and
+        re-enqueued on top of itself — the expensive direction.
+
+        Driven through the seam rather than asserted on a hand-built row, so dropping the
+        re-stamp from the write actually fails something."""
+        from pocketpaw_ee.sites import service as sites_service
+
+        queued_an_hour_ago = datetime.now(UTC) - timedelta(hours=1)
+        site = FakeSite(build_status="queued", build_started_at=queued_an_hour_ago)
+        await sites_service.mark_build_running(site)
+        assert site.build_status == "building"
+        assert site.build_started_at is not None
+        assert site.build_started_at > queued_an_hour_ago + timedelta(minutes=59), (
+            "the queue wait was charged to the build's window instead of being re-stamped"
+        )
+
+    def test_both_are_in_flight_but_they_are_not_the_same_state(self) -> None:
+        queued = aged_site("queued", age_seconds=1)
+        building = aged_site("building", age_seconds=1)
+        assert bs.is_in_flight(queued) and bs.is_in_flight(building)
+        assert queued.build_status != building.build_status
+        assert bs.IN_FLIGHT_STATUSES == {"queued", "building"}
+
+    def test_a_worker_pickup_re_stamps_the_clock_so_queue_wait_is_not_charged(self) -> None:
+        """The reason ``mark_build_running`` re-stamps rather than leaving the enqueue's
+        clock: under a cap, queue wait can be most of the window, and a build that waited
+        would be declared stale while still running — then re-enqueued on top of itself,
+        which is the expensive direction."""
+        clock = Clock()
+        waited = bs.stale_after(BUILD_TIMEOUT).total_seconds() - 30
+        queued_long_ago = FakeSite(
+            build_status="queued", build_started_at=clock.ago(seconds=waited)
+        )
+        assert bs.should_enqueue(queued_long_ago, BUILD_TIMEOUT, now=clock.now) is False
+        # 60s later the enqueue stamp has lapsed; a re-stamp at pickup is what saves it.
+        later = clock.advance(seconds=60)
+        assert bs.should_enqueue(queued_long_ago, BUILD_TIMEOUT, now=later) is True
+        restamped = FakeSite(build_status="building", build_started_at=later)
+        assert bs.should_enqueue(restamped, BUILD_TIMEOUT, now=later) is False
+
+    def test_a_queued_build_is_visible_to_a_viewer_not_silently_absent(self) -> None:
+        """What makes a cap safe to turn on: a publish waiting behind it has to be
+        visibly waiting. ``is_in_flight`` is the UI's read and is deliberately not
+        ``not should_enqueue`` — a stale row still renders as in-progress."""
+        stale = aged_site("queued", age_seconds=99_999)
+        assert bs.is_in_flight(stale) is True
+        assert bs.should_enqueue(stale, BUILD_TIMEOUT) is True
+
+
+# ---------------------------------------------------------------------------
+# The asymmetric-failure call
+# ---------------------------------------------------------------------------
+
+
+class TestAnUnusableStampReadsAsStale:
+    """Deliberately asymmetric, and biased toward spending: a redundant enqueue costs one
+    idempotent build, a stuck guard costs the site EVERY future publish. Under a burst
+    the redundancy is multiplied, which is the price of the bias and is still the right
+    side to be wrong on."""
+
+    @pytest.mark.parametrize("stamp", [None, "2026-08-11", 0, object(), float("nan")])
+    def test_an_unreadable_stamp_does_not_block_a_publish(self, stamp: object) -> None:
+        site = FakeSite(build_status="building", build_started_at=stamp)  # type: ignore[arg-type]
+        assert bs.build_is_stale(site, BUILD_TIMEOUT) is True
+        assert bs.should_enqueue(site, BUILD_TIMEOUT) is True
+
+    async def test_a_stampless_in_flight_row_never_wedges_the_site(self) -> None:
+        site = FakeSite(build_status="queued", build_started_at=None)
+        report = await burst_on_one_doc(site, BURST, pool=YieldingPool())
+        assert report.sandboxes >= 1
+
+    def test_an_unknown_status_reads_as_terminal_and_lets_a_publish_through(self) -> None:
+        """The reader/writer deploy-ordering constraint in the module header, from the
+        guard's side: an unrecognised status is far likelier to be drift or a bad write
+        than a live build, and blocking on it recreates the one-way door. The cost is
+        that a NEW in-flight state must reach every reader before any writer emits it."""
+        assert bs.should_enqueue(aged_site("provisioning", age_seconds=1), BUILD_TIMEOUT) is True
+        assert bs.is_in_flight(aged_site("provisioning", age_seconds=1)) is False
+
+
+# ---------------------------------------------------------------------------
+# settle: None means stay in flight, and nothing may be written
+# ---------------------------------------------------------------------------
+
+
+class TestARetryStaysInFlightAndWritesNothing:
+    """``settle`` returning ``None`` is a NO-WRITE instruction, not a status. Writing
+    ``failed`` between attempts is read by ``should_enqueue`` as "free to re-publish",
+    which invites a second sandbox on top of the retry — the same overspend the guard
+    exists to prevent, arriving through the settle path instead of the enqueue path.
+
+    These drive ``build_job._record`` rather than ``settle`` alone, because the bug this
+    guards is at the boundary: ``settle`` can return the right thing and the row still
+    get written if ``_record`` does not honour it."""
+
+    async def test_a_retryable_failure_with_attempts_left_writes_no_status(self) -> None:
+        site = aged_site("building", age_seconds=10)
+        settlement = bj.BuildSettlement(status=None, reason="sandbox_unavailable:create_failed")
+        await bj._record(site, settlement)
+        assert site.transitions == [], "a retry must not write a status, even briefly"
+        assert site.build_status == "building"
+        assert bs.should_enqueue(site, BUILD_TIMEOUT) is False, (
+            "the row must still block a second publish while the retry is pending"
+        )
+
+    async def test_a_terminal_settlement_is_written_once_with_its_rung(self) -> None:
+        site = aged_site("building", age_seconds=10)
+        await bj._record(site, bj.BuildSettlement(status="failed", reason="scaffold_failed:exit_1"))
+        assert site.transitions == [("failed", "scaffold_failed:exit_1")]
+        assert bs.should_enqueue(site, BUILD_TIMEOUT) is True, "a terminal row never blocks"
+
+    async def test_concurrent_settlements_of_one_build_write_at_most_one_status(self) -> None:
+        """A retry racing its own timeout is a real shape: two settlements for one build.
+        The ``None`` one must contribute nothing, so the row carries exactly the terminal
+        verdict and not a queue of them."""
+        site = aged_site("building", age_seconds=10)
+        await asyncio.gather(
+            bj._record(site, bj.BuildSettlement(status=None, reason="infra_lost:retrying")),
+            bj._record(site, bj.BuildSettlement(status="built", reason="completed_ok:verified")),
+        )
+        assert site.transitions == [("built", "completed_ok:verified")]
+
+    def test_settle_never_leaves_a_row_in_an_in_flight_status(self) -> None:
+        """The invariant that ties settle back to the guard: a finished build whose status
+        is still ``queued`` or ``building`` blocks every publish until the window lapses."""
+        for outcome in ("completed_ok", "build_failed", "timed_out", "infra_lost", "??"):
+            for retryable in (True, False):
+                got = bs.settle(outcome, retryable=retryable, attempts_left=0)
+                assert got in bs.TERMINAL_STATUSES, (outcome, retryable, got)
+
+    def test_a_retry_budget_holds_the_row_open_rather_than_terminating_it(self) -> None:
+        assert bs.settle("infra_lost", retryable=True, attempts_left=1) is None
+        assert bs.settle("infra_lost", retryable=True, attempts_left=0) == "failed"
+
+
+# ---------------------------------------------------------------------------
+# The harness itself
+# ---------------------------------------------------------------------------
+
+
+class TestTheHarnessSpendsNothing:
+    """A burst harness that could reach real infrastructure is a harness nobody dares
+    run, and spending sandboxes is the captain's call, not a side effect of the suite."""
+
+    async def test_no_burst_path_touches_redis_or_daytona(self) -> None:
+        """Every driver takes a pool override, so ``_get_pool`` — the only code that
+        reads ``POCKETPAW_REDIS_URL`` and opens a connection — is never reached."""
+        pool = RecordingPool()
+        await burst_on_one_doc(FakeSite(), 3, pool=pool)
+        assert pool.sandboxes == 3
+        assert all(call["function"] == bj.ARQ_FUNCTION_NAME for call in pool.calls)
+
+    def test_the_recorded_enqueue_count_is_the_cost_meter(self) -> None:
+        """The number these tests assert on is a sandbox count, which is a bill. Keeping
+        that mapping explicit is what makes a red result legible as money."""
+        pool = RecordingPool()
+        assert pool.sandboxes == 0

--- a/tests/mutations/sites_burst_harness.json
+++ b/tests/mutations/sites_burst_harness.json
@@ -1,0 +1,56 @@
+[
+  {
+    "label": "D5: the single-flight gate is removed from the enqueue, so every publish of a site opens its own sandbox unconditionally — the guard stops guarding and nothing else in the lane notices",
+    "file": "ee/pocketpaw_ee/sites/build_job.py",
+    "find": "    if not should_enqueue(site, timeout):",
+    "replace": "    if False:",
+    "tests": [
+      "tests/ee/sites/test_burst_harness.py::TestTheGuardHoldsWhenPublishesAreSerialised"
+    ]
+  },
+  {
+    "label": "D5: the job id becomes deterministic per site, so arq refuses the second concurrent enqueue and the lane rolls the row to failed — a race that overspends turns into a publish that reports broken",
+    "file": "ee/pocketpaw_ee/sites/build_job.py",
+    "find": "    return f\"site-build-{site_id}-{uuid.uuid4().hex}\"",
+    "replace": "    return f\"site-build-{site_id}\"",
+    "tests": [
+      "tests/ee/sites/test_burst_harness.py::TestSingleFlightUnderContention"
+    ]
+  },
+  {
+    "label": "D5: the staleness boundary is inclusive, so a build at exactly its window is declared dead and re-enqueued on top of itself one tick early",
+    "file": "ee/pocketpaw_ee/sites/build_state.py",
+    "find": "    return reference - stamp > stale_after(timeout_seconds)",
+    "replace": "    return reference - stamp >= stale_after(timeout_seconds)",
+    "tests": [
+      "tests/ee/sites/test_burst_harness.py::TestTheStalenessWindowUnderBurst"
+    ]
+  },
+  {
+    "label": "D5: a stay-in-flight settlement writes a status anyway, so a retryable failure lands 'failed' between attempts — should_enqueue reads that as free to re-publish and a second sandbox starts on top of the retry",
+    "file": "ee/pocketpaw_ee/sites/build_job.py",
+    "find": "            settlement.reason,\n        )\n        return\n    await sites_service.record_build_outcome(",
+    "replace": "            settlement.reason,\n        )\n    await sites_service.record_build_outcome(",
+    "tests": [
+      "tests/ee/sites/test_burst_harness.py::TestARetryStaysInFlightAndWritesNothing"
+    ]
+  },
+  {
+    "label": "D5: a worker pickup stops re-stamping the clock, so the staleness window is spent on queue wait and a build that waited behind the cap is declared stale while still running",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    await site.set({\"build_status\": \"building\", \"build_started_at\": datetime.now(UTC)})",
+    "replace": "    await site.set({\"build_status\": \"building\"})",
+    "tests": [
+      "tests/ee/sites/test_burst_harness.py::TestQueuedAndBuildingStayDistinguishable"
+    ]
+  },
+  {
+    "label": "D5: the queued stamp is dropped from the enqueue write, so the row reads as stale the instant it is written and the very next publish opens a second sandbox",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "            \"build_status\": \"queued\",\n            \"build_started_at\": datetime.now(UTC),",
+    "replace": "            \"build_status\": \"queued\",",
+    "tests": [
+      "tests/ee/sites/test_burst_harness.py::TestTheGuardHoldsWhenPublishesAreSerialised"
+    ]
+  }
+]


### PR DESCRIPTION
Every publish is a Daytona sandbox now, so the single-flight guard moved onto the critical path for cost as well as correctness. Nothing measured it under contention. This adds the harness that does — against a faked lane, not live infrastructure.

## What it found

**Eight concurrent publishes of one site open eight sandboxes.** `enqueue_site_build` gates on a read (`should_enqueue`) and stamps with a write (`mark_build_queued`), and it awaits between the two. Any publish arriving inside that window reads a row with no build in flight, passes the gate correctly by the guard's own rules, and buys its own sandbox. Two publishes reproduce it — two clicks inside one round trip.

The state machine is not the problem, which is what localises the defect:

| Burst shape | Sandboxes for one site | Reading |
|---|---|---|
| Publishes serialised | 1, second returns `None` | The guard works |
| Burst arriving after the stamp landed | 0, all refused | `should_enqueue` is correct |
| 8 concurrent, one shared row | 8 | The read-write window is open |
| 8 concurrent, each having loaded its own row | 8 | Same window, across workers |
| 8 concurrent across 8 sites | 8 | Correct — the guard is per-site, not global |

So this is missing atomicity at the row, not a bug in `build_state`. The fix is a conditional write — stamp `queued` only if the row is still observed non-in-flight (`find_one_and_update` with a status precondition), loser of the race gets nothing back and returns `None`. This PR does not make that change: it touches the write path and deserves its own review. Instead the assertions pin the current numbers exactly, so flipping them to `sandboxes == 1` / `refused == BURST - 1` is that fix's acceptance test. The class docstring says so, and the tests are named to make clear they characterise a defect rather than bless it.

## No live burst

Nothing here can reach Daytona, Redis, or the network. Every "sandbox" is a recorded arq enqueue, the clock is injected rather than slept on, and the drivers all take a pool override so `_get_pool` — the only code that reads `POCKETPAW_REDIS_URL` — is never reached. There is one test asserting exactly that. 33 tests, under two seconds; a harness that takes minutes is a harness nobody runs.

A deliberate live-run procedure is documented in the runbook, including the five numbers worth recording. The script it names does not exist on purpose — keeping it unwritten means there is no armed path to spending sandboxes sitting in the repo.

## Also covered

- Both staleness edges including the exact boundary second — at the window is still in flight, one second past is stale. The existing suite tested "well inside" and "well past" but not the boundary.
- `queued` and `building` stay distinguishable through a worker pickup, and that pickup re-stamps the clock so queue wait is not charged to the build's window.
- A missing or unreadable stamp reads as stale, including through a burst — the asymmetric call, biased toward one redundant build over a site that can never publish again.
- A stay-in-flight settlement (`settle` returning `None`) writes nothing at all, driven through `_record` rather than `settle` alone, because the bug lives at the boundary.
- Distinct sites are not throttled by each other. A guard that collapsed them would be a global lock wearing a single-flight costume.

## What the harness cannot tell us

Stated plainly because a green run here is easy to misread as a validated cap:

- **It does not measure the cap.** No cap value can be derived from it.
- **No real sandbox contention** — creation latency under load, Daytona-side queueing, rate limits, quota rejections. The fake pool always accepts.
- **No real queue latency** — arq depth, worker pickup delay, the real distribution of wait behind a cap.
- **No deploy race** — it counts sandboxes; it does not run two artifacts to deploy and see which wins.
- **No multi-process concurrency.** The separate-doc burst is the right shape but runs in one event loop against a fake.
- **Mongomock is not Mongo.** Driven through real Beanie against mongomock, the shared-doc burst returns 1 rather than 8, because mongomock's write resolves without yielding. Beanie merges its local state *after* awaiting the write, so against real Mongo that case races too. That is why the harness's own fake yields before applying — a fake that applied writes synchronously would report a guarantee the lane does not have.

Sizing the cap still needs a live run. It is the captain's call because it spends money.

One more thing worth knowing while sizing anything: `STALE_MARGIN` is 10 minutes, so for any engine budget well under that the margin dominates the derived window and deriving it buys little. Both engines currently resolve to 600s, where the two terms are comparable.

## Verification

- `tests/ee/sites`: 4 failed, 1039 passed, 4 skipped. The 4 are the known `test_generator_client_timeout.py` set (#1899); the flaky `test_dev_server.py::test_touch_bumps_activity` passed this run. No new failures.
- `tests/ee/sites/test_burst_harness.py`: 33 passed in 1.7s.
- `scripts/mutate.py --plan tests/mutations/sites_burst_harness.json`: 6 mutations, all caught.
- `scripts/mutate.py --validate`: 281 anchors across 25 plans, each resolving exactly once.
- `ruff check .` and `ruff format --check .` clean repo-wide.

Tests and docs only — no production code changed.
