### PR TITLE
Check the artifact bytes, not the sentinel's word for them

### DIFF
--- a/ee/pocketpaw_ee/sites/build_job.py
+++ b/ee/pocketpaw_ee/sites/build_job.py
@@ -217,8 +217,13 @@ RUNG_SCAFFOLD_EMPTY = "scaffold_empty"
 #: sandbox could not be created. Nothing ran, so it is ours and retryable.
 RUNG_SANDBOX_UNAVAILABLE = "sandbox_unavailable"
 #: The classification cleared the build and the download delivered no bytes. Distinct
-#: from ``artifact_empty`` (which the sentinel catches) because this one is a property of
-#: the TRANSFER, so it is worth another attempt.
+#: from the sentinel's ``artifact_empty`` because this one is a property of the TRANSFER,
+#: so it is worth another attempt.
+#:
+#: Updated 2026-08-11: ``run_build`` now verifies the bytes and reports that same
+#: condition as ``infra_lost:artifact_empty``, so this rung is no longer reached from that
+#: path. It remains the guard for any OTHER result carrying ``deployable`` with no bytes —
+#: see :func:`resolve_build_settlement` for why that is kept rather than removed.
 RUNG_ARTIFACT_MISSING = "artifact_missing"
 #: The enqueue itself failed after the row was already stamped ``queued``. Written by the
 #: enqueue helper so the row lands TERMINAL instead of pinned in flight.
@@ -273,11 +278,20 @@ def resolve_build_settlement(result: BuildRunResult, *, attempts_left: int = 0) 
     is not — and a rung that lies about retryability either burns a publish that a second
     attempt would have fixed, or retries something no attempt can fix.
 
-    Truncation — a payload that arrives SHORTER than the sentinel's ``artifact_bytes`` —
-    is NOT distinguished here. That needs the promised size threaded off the sentinel,
-    which is banked on ``spike/sites-artifact-verification`` along with the rest of the
-    four-way artifact classification. Until it lands, a truncated download settles as
-    ``built``; the gap is real, is not new, and is recorded rather than papered over.
+    Updated 2026-08-11: THE ``deployable``-BUT-NOT-``ok`` CASE NO LONGER ARRIVES FROM
+    ``run_build``. That runner verifies the downloaded bytes itself and demotes the
+    classification, so an empty download now reaches here already named
+    ``infra_lost:artifact_empty`` — and a TRUNCATED one, which used to settle as ``built``
+    because nothing compared the promise against what arrived, reaches here as
+    ``infra_lost:artifact_truncated``. Both are more precise than this rung could be, so
+    the first branch handles them.
+
+    THE ``artifact_missing`` BRANCH STAYS ANYWAY, and not as decoration: this function's
+    contract is over a ``BuildRunResult``, not over "a result that came from ``run_build``".
+    A result assembled anywhere else — a future caller, a partial re-implementation, a test
+    — can still carry ``deployable`` with no bytes, and the branch is what stops that being
+    settled as ``built``. Deleting it would make the safe reading depend on an invariant
+    held one module away.
     """
     classification = result.classification
     if result.ok:

--- a/ee/pocketpaw_ee/sites/daytona_build.py
+++ b/ee/pocketpaw_ee/sites/daytona_build.py
@@ -32,13 +32,22 @@
 # WHAT THIS MODULE DELIBERATELY DOES NOT DO: talk to Daytona. The whole point is that
 # the decision procedure is testable without a sandbox, because it is the part that
 # must be right. Wiring lives in the caller.
+#
+# Updated 2026-08-11 (SG-7, fault ladder): added :func:`verify_artifact` and
+# :func:`promised_artifact_bytes`, which read the DOWNLOADED bytes rather than the
+# sentinel's claims about them. See the block above that function for why it earns its
+# place on top of the tar command's own exclusion, and for why its rejections split on
+# ``retryable`` — a truncated transfer is transient, an unreadable full-size artifact is
+# not. Still no Daytona in this module: it is handed bytes, it does not fetch them.
 from __future__ import annotations
 
+import io
 import json
 import logging
 import math
 import os
 import shlex
+import tarfile
 from dataclasses import dataclass
 from typing import Any, Literal
 
@@ -223,13 +232,21 @@ class BuildClassification:
         """True when the CLASSIFICATION cleared the build — not when its bytes were checked.
 
         Corrected 2026-08-10 (SG-7): this used to claim "there is a verified artifact to
-        deploy", which overpromised in a way that matters. It is derived from the sentinel
-        alone, so it stays True when the download afterwards returns zero bytes or a
-        truncated payload — nothing here has seen the artifact.
+        deploy", which overpromised in a way that matters. Read on a classification that
+        came straight out of :func:`classify_build`, it is derived from the sentinel alone,
+        so it stays True when the download afterwards returns zero bytes or a truncated
+        payload — nothing here has seen the artifact.
 
-        A caller must therefore gate a deploy on ``BuildRunResult.ok`` (which also requires
-        bytes to have arrived), never on this flag by itself. Whoever wires this lane owns
-        the download verification; see the SG-7 wiring contracts.
+        Updated 2026-08-11: ``daytona_runner.run_build`` now runs :func:`verify_artifact`
+        over the downloaded bytes and REPLACES this classification with a non-deployable
+        one when they are rejected, so the flag does follow the bytes on the result that
+        runner hands back. That is a property of the runner, not of this property, and the
+        distinction is load-bearing: anything that classifies without downloading (the
+        classifier's own tests, a future caller that only wants the verdict) still gets the
+        sentinel-only reading.
+
+        A caller must therefore still gate a deploy on ``BuildRunResult.ok``, which also
+        requires bytes to have arrived, rather than on this flag by itself.
         """
         return self.outcome == "completed_ok"
 
@@ -475,6 +492,128 @@ def artifact_tar_command(
 
 
 # ---------------------------------------------------------------------------
+# Verifying the artifact BYTES, not the sentinel's claims about them
+# ---------------------------------------------------------------------------
+#
+# WHY THIS EXISTS ALONGSIDE THE TAR COMMAND, which already scopes the archive to the
+# output dir AND excludes :data:`_EXCLUDED_MEMBER`. Two reasons, and neither is "in case
+# the command is wrong in a way we could have reasoned about":
+#
+#   1. THE EXCLUSION IS A FLAG ON A BINARY THIS PROCESS NEVER RUNS. Its behaviour is the
+#      tar implementation's, not ours, and the two implementations in play already
+#      disagreed once: GNU tar (what ``debian_slim`` runs) anchors a pattern containing a
+#      slash, bsdtar does not, so ``--exclude=./node_modules`` passed locally and shipped
+#      a nested ``node_modules`` in CI. That was found by a test, not by a reader, and the
+#      class of bug — "the command still looks correct" — is exactly what a check on the
+#      resulting bytes catches and a check on the command cannot.
+#   2. NOTHING ELSE IN THE LANE LOOKS AT THE TRANSFER. An empty, truncated or corrupt
+#      download is invisible to the sentinel by construction: the sentinel is written
+#      inside the sandbox, before any bytes cross the wire.
+#
+# The include-list plus the exclusion remain the PRIMARY defence and are tested directly,
+# by running the real tar over a real node_modules tree
+# (tests/ee/sites/test_fault_ladder_build.py). This is the backstop, and the only gate in
+# the lane that has read the artifact.
+
+#: A path segment that must never appear in a deployable artifact.
+_FORBIDDEN_SEGMENT = "node_modules"
+
+
+@dataclass(frozen=True)
+class ArtifactRejection:
+    """Why an artifact may not be deployed, and whether trying again could help.
+
+    ``retryable`` is decided HERE rather than by the caller because the answer differs per
+    reason and is not obvious from outside: a truncated download is a transient property
+    of the TRANSFER, while an unreadable full-size artifact is a durable property of what
+    the BUILD produced. Collapsing the two either burns a publish on a network blip or
+    spends a second sandbox re-proving a deterministic failure.
+    """
+
+    reason: str
+    retryable: bool
+
+
+def _readable_size(value: Any) -> int | None:
+    """A positive artifact size, or ``None`` when the value is unusable.
+
+    ``bool`` is rejected for the same reason :func:`_coerce_exit` rejects it: ``True``
+    would otherwise read as a promised size of one byte.
+    """
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    return value if value > 0 else None
+
+
+def promised_artifact_bytes(sentinel: str | bytes | dict[str, Any] | None) -> int | None:
+    """The artifact size the sentinel promised, or ``None`` when it cannot be read.
+
+    Exists so the runner can compare the promise against what actually arrived without
+    re-implementing sentinel parsing or widening :class:`BuildClassification`.
+    """
+    parsed = _parse_sentinel(sentinel)
+    if parsed is None:
+        return None
+    return _readable_size(parsed.get("artifact_bytes"))
+
+
+def verify_artifact(
+    payload: bytes | None, *, expected_bytes: int | None = None
+) -> ArtifactRejection | None:
+    """Check the DOWNLOADED artifact. Returns a rejection, or ``None`` when it is fit.
+
+    The last gate before a deploy, and the only one that reads the artifact itself rather
+    than the sentinel's claims about it. Every rejection must stop the deploy rather than
+    shrink it: a partial deploy and a blank site are worse outcomes than a failed publish,
+    because they overwrite something that was working.
+
+    ``expected_bytes`` is the size the sentinel promised (see
+    :func:`promised_artifact_bytes`). It is what separates a transfer failure from a bad
+    build, and that separation is the whole basis of the ``retryable`` split:
+
+    * ``artifact_empty`` — nothing arrived. RETRYABLE: the build reported a size, so the
+      bytes existed in the sandbox and it is the download that failed.
+    * ``artifact_truncated`` — fewer bytes than promised. RETRYABLE for the same reason,
+      and kept DISTINCT from empty because "nothing arrived" and "half arrived" send an
+      operator to different places.
+    * ``artifact_unreadable`` — the promised size arrived and will not open as a gzip tar.
+      NOT retryable: the transfer did its job, so the content is what is wrong and a
+      second attempt reproduces it.
+    * ``artifact_contains_node_modules`` — the tar command's exclusion leaked. NOT
+      retryable, and never the user's fault.
+
+    When no size was promised, a failure defaults to RETRYABLE. That asymmetry is
+    deliberate and matches ``build_state.build_is_stale``: a redundant build costs one
+    sandbox, whereas calling a transient failure permanent costs the user their publish.
+
+    Reads only the tar INDEX, so cost is bounded by member count, not by artifact size.
+    """
+    promised = _readable_size(expected_bytes)
+    got = len(payload) if payload else 0
+
+    if got == 0:
+        return ArtifactRejection("artifact_empty", retryable=True)
+    if promised is not None and got < promised:
+        return ArtifactRejection("artifact_truncated", retryable=True)
+
+    try:
+        with tarfile.open(fileobj=io.BytesIO(payload or b""), mode="r:gz") as tar:
+            names = tar.getnames()
+    except (tarfile.TarError, OSError, EOFError, ValueError):
+        # A full-size payload that will not open is garbage the build produced. With no
+        # promised size we cannot tell that from a truncated transfer, so take the safe
+        # direction and allow a retry.
+        return ArtifactRejection("artifact_unreadable", retryable=promised is None)
+
+    for name in names:
+        # Normalise the leading "./" the tar command produces before splitting, so a
+        # member recorded as "./node_modules/x" is caught the same as "node_modules/x".
+        if _FORBIDDEN_SEGMENT in name.replace("\\", "/").split("/"):
+            return ArtifactRejection("artifact_contains_node_modules", retryable=False)
+    return None
+
+
+# ---------------------------------------------------------------------------
 # The in-sandbox wrapper
 # ---------------------------------------------------------------------------
 
@@ -610,11 +749,14 @@ __all__ = [
     "STDERR_TAIL_BYTES",
     "TIMEOUT_FLOOR_SECONDS",
     "TIMEOUT_SAFETY_FACTOR",
+    "ArtifactRejection",
     "BuildClassification",
     "BuildOutcome",
     "artifact_tar_command",
     "build_timeout_seconds",
     "build_wrapper_script",
     "classify_build",
+    "promised_artifact_bytes",
     "resolve_build_timeout_seconds",
+    "verify_artifact",
 ]

--- a/ee/pocketpaw_ee/sites/daytona_runner.py
+++ b/ee/pocketpaw_ee/sites/daytona_runner.py
@@ -111,6 +111,13 @@
 # thing that would undo this. If you are reading this because you were about to do it: the
 # primary reason above is live, so re-make the security decision first — do not reason from
 # the retracted claim that the signed key is gone.
+#
+# Updated 2026-08-11 (SG-7, fault ladder): the downloaded artifact now passes through
+# ``daytona_build.verify_artifact`` before the result is assembled, so an empty, truncated,
+# unreadable or ``node_modules``-carrying artifact demotes the classification to a
+# non-deployable ``infra_lost`` and the bytes are dropped, instead of leaving ``deployable``
+# True on a result a caller would deploy. The rejection carries its OWN ``retryable``: a
+# truncated transfer is worth another attempt, a build that produced garbage is not.
 from __future__ import annotations
 
 import logging
@@ -125,6 +132,8 @@ from pocketpaw_ee.sites.daytona_build import (
     artifact_tar_command,
     build_wrapper_script,
     classify_build,
+    promised_artifact_bytes,
+    verify_artifact,
 )
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
@@ -400,6 +409,38 @@ async def run_build(
                     blames_user=False,
                     stderr_tail=classification.stderr_tail,
                 )
+            else:
+                # SG-7: verify the BYTES, not the sentinel's claims about them. Runs here
+                # because it is the first moment the artifact exists locally, and before
+                # the return because ``deployable`` is the flag a caller deploys on —
+                # leaving it True for an empty or node_modules-carrying artifact is how a
+                # blank or 500 MB site ships.
+                #
+                # NEVER ``blames_user``: a leaked exclusion and a failed transfer are both
+                # ours, and telling the user their build is broken would be a lie.
+                # ``retryable`` comes from the rejection rather than being fixed here,
+                # because only the rejection knows whether the transfer or the build is at
+                # fault.
+                rejection = verify_artifact(
+                    artifact, expected_bytes=promised_artifact_bytes(sentinel)
+                )
+                if rejection is not None:
+                    logger.warning(
+                        "daytona_runner: artifact rejected (%s, retryable=%s)",
+                        rejection.reason,
+                        rejection.retryable,
+                    )
+                    classification = BuildClassification(
+                        outcome="infra_lost",
+                        reason=rejection.reason,
+                        retryable=rejection.retryable,
+                        blames_user=False,
+                        stderr_tail=classification.stderr_tail,
+                    )
+                    # Dropped rather than returned alongside the rejection: a caller that
+                    # read the bytes off a result it did not gate on would deploy exactly
+                    # what this check refused.
+                    artifact = None
         t_extracted = time.monotonic()
     finally:
         # Explicit teardown. Swallows its own errors: a delete that fails must not mask

--- a/tests/ee/sites/faults.py
+++ b/tests/ee/sites/faults.py
@@ -56,11 +56,11 @@ def ok_sentinel(**over: Any) -> dict[str, Any]:
         "install_exit": 0,
         "build_exit": 0,
         "artifact_rel": "dist",
-        # Promises what ``FaultyDaytonaClient`` actually hands back, rather than a round
-        # number. A TRUTHFULNESS fix, not scaffolding for a gate: nothing compares the two
-        # today, so a hardcoded 4096 beside a ~170-byte artifact is simply a fiction a
-        # reader would have to discover. It also matters the moment download verification
-        # arrives, since that is precisely the comparison it will make.
+        # The promised size MUST agree with what the fake actually hands back, because
+        # ``verify_artifact`` compares the two (2026-08-11): a sentinel promising 4096 bytes
+        # beside a ~170-byte artifact is a TRUNCATED transfer, so a hardcoded number here
+        # would make every happy-path test in the ladder fail for the wrong reason. It
+        # started as a truthfulness fix while nothing compared them; it is now load-bearing.
         "artifact_bytes": len(clean_artifact()),
         "stderr_tail": "",
     }
@@ -98,6 +98,43 @@ def clean_artifact() -> bytes:
             "./assets/app.js": b"console.log(1)",
         }
     )
+
+
+def artifact_with_node_modules() -> bytes:
+    """A well-formed artifact that nonetheless carries ``node_modules``.
+
+    The shape a leaked exclusion would produce: ``dist/node_modules/`` becomes
+    ``./node_modules/`` once packed with ``-C dist``. It cannot be produced by putting a
+    tree on disk and running the real command — that is what the include-list tests do, and
+    they now pass — so a hand-built tar is the only way to exercise what the byte gate does
+    when the exclusion does NOT hold, which is the case it exists for.
+
+    Deliberately a VALID tar: rejecting garbage is the easy half, and the interesting half
+    is rejecting something that opens cleanly.
+    """
+    return tar_bytes(
+        {
+            "./index.html": b"<!doctype html>",
+            "./node_modules/.bin/vite": b"#!/usr/bin/env node",
+            "./node_modules/react/index.js": b"module.exports = {}",
+        }
+    )
+
+
+def truncated_artifact() -> bytes:
+    """The first 40 bytes of a healthy artifact — a transfer that died part-way."""
+    return clean_artifact()[:40]
+
+
+def garbage_artifact(size: int) -> bytes:
+    """``size`` bytes that are not a tar at all.
+
+    Used with a sentinel promising exactly ``size``, so the FULL promised payload arrives
+    and is still unreadable. That combination is what distinguishes "the build produced
+    garbage" (not retryable) from "the transfer lost bytes" (retryable), and it is the only
+    way to exercise the non-retryable branch.
+    """
+    return b"x" * size
 
 
 # ---------------------------------------------------------------------------
@@ -439,9 +476,11 @@ __all__ = [
     "FailingCloudflare",
     "FailingWorkersDeploy",
     "FaultyDaytonaClient",
+    "artifact_with_node_modules",
     "clean_artifact",
     "cloudflare_error",
     "daytona_unconfigured",
+    "garbage_artifact",
     "ok_sentinel",
     "pack_with_real_tar",
     "sandbox_create_fails",
@@ -449,5 +488,6 @@ __all__ = [
     "screenshot_always_fails",
     "tar_bytes",
     "tar_is_available",
+    "truncated_artifact",
     "write_project_tree",
 ]

--- a/tests/ee/sites/test_async_publish.py
+++ b/tests/ee/sites/test_async_publish.py
@@ -32,7 +32,7 @@ from pocketpaw_ee.sites import build_state as bs
 from pocketpaw_ee.sites import engines as engines_mod
 from pocketpaw_ee.sites import service as sites_service
 
-from tests.ee.sites.faults import FaultyDaytonaClient, clean_artifact, tar_bytes
+from tests.ee.sites.faults import FaultyDaytonaClient, clean_artifact, ok_sentinel, tar_bytes
 
 REACT_SOURCE = {"src/App.tsx": "export default function App() { return <p>hi</p>; }"}
 
@@ -446,7 +446,15 @@ class TestTheWorkerFinishesThePublish:
             600,
             deploy_inputs=_deploy_inputs(str(site.id)),
             _runner=_FakeRunner(),
-            _client=FaultyDaytonaClient(artifact=evil),
+            # The sentinel must promise THIS artifact's length, not the default clean
+            # one's. ``run_build`` compares the promise against what arrived (2026-08-11),
+            # and ``evil`` is a few bytes shorter than ``clean_artifact()`` — so on the
+            # default sentinel it would be rejected as a TRUNCATED transfer and never reach
+            # the extraction this test is about. The escape has to be the reason it fails,
+            # not a byte count that happens to differ.
+            _client=FaultyDaytonaClient(
+                artifact=evil, sentinel=ok_sentinel(artifact_bytes=len(evil))
+            ),
             _deployer=_deploy,
         )
 
@@ -492,8 +500,6 @@ class TestTheWorkerFinishesThePublish:
         async def _deploy(*, project_dir: str, deploy_inputs: dict[str, Any]) -> Any:
             deploys.append(project_dir)
             return None
-
-        from tests.ee.sites.faults import ok_sentinel
 
         await bj.run_site_build(
             {},

--- a/tests/ee/sites/test_build_job.py
+++ b/tests/ee/sites/test_build_job.py
@@ -597,12 +597,19 @@ class TestTheJobRecordsWhatHappened:
         self, beanie_test_db
     ) -> None:
         """The end-to-end form of wiring contract #1: the sandbox reports success and the
-        download delivers nothing."""
+        download delivers nothing.
+
+        The RUNG CHANGED on 2026-08-11 and the property did not. ``run_build`` now verifies
+        the downloaded bytes and demotes the classification itself, so this arrives already
+        named ``infra_lost:artifact_empty`` rather than reaching
+        ``resolve_build_settlement``'s ``artifact_missing`` fallback. Both are terminal,
+        retryable and not the user's fault; the new one is more precise, since it comes from
+        the code that looked at the bytes."""
         site = await _insert_site()
         await _run_job(site, client=FaultyDaytonaClient(artifact=b""))
         fresh = await _reread(site)
         assert fresh.build_status == "failed"
-        assert fresh.build_reason == "artifact_missing:download_delivered_no_bytes"
+        assert fresh.build_reason == "infra_lost:artifact_empty"
 
     async def test_an_unbuildable_engine_is_refused_before_any_sandbox_exists(
         self, beanie_test_db

--- a/tests/ee/sites/test_fault_ladder_build.py
+++ b/tests/ee/sites/test_fault_ladder_build.py
@@ -51,32 +51,33 @@
 # node_modules tree tested the construction instead, and turned up the gap the gate would
 # have masked: ``-C dist .`` packs ``dist/node_modules/``. Draft two recorded that gap as a
 # passing characterisation test, which documented a 500 MB-artifact path without closing it.
-# The resolution is neither: ``--exclude=./node_modules`` on the existing command removes the
+# The resolution is neither: ``--exclude=node_modules`` on the existing command removes the
 # path BY CONSTRUCTION, so there is nothing to detect at runtime and nothing left open.
 #
-# WIRING CONTRACTS THIS TASK OWES THE NEXT ONE, recorded here because the code cannot hold
-# them yet:
+# ── UPDATED 2026-08-11. BOTH WIRING CONTRACTS THIS FILE RECORDED ARE NOW DISCHARGED. ──
+#
+# This header used to carry two contracts "the code cannot hold yet", because the lane had
+# no callers and 170 lines of unreachable gate logic would have been a feature build. It has
+# callers now, so both are code:
 #
 #   1. GATE A DEPLOY ON ``BuildRunResult.ok``, NEVER ON ``classification.deployable``.
-#      ``deployable`` is derived from the sentinel alone and stays True when the download
-#      returns zero bytes — see its docstring. Nothing verifies delivered bytes today.
-#   2. WHEN DOWNLOAD VERIFICATION IS ADDED, SPLIT ITS FAILURES ON ``retryable``. A payload
-#      SHORTER than the sentinel's ``artifact_bytes`` is a property of the TRANSFER and is
-#      worth another attempt; one that arrives at full size and still will not open as a gzip
-#      tar is a property of what the BUILD produced, and retrying only spends a second
-#      sandbox reproducing it. The sentinel already carries ``artifact_bytes``, which is what
-#      makes the two distinguishable. Collapsing them into one non-retryable failure turns a
-#      network blip into a permanently burned publish. Keep "nothing arrived" and "half
-#      arrived" as SEPARATE reasons — they send an operator to different places.
+#      ``build_job.resolve_build_settlement`` does, and says so in its docstring.
+#   2. SPLIT DOWNLOAD-VERIFICATION FAILURES ON ``retryable``. ``daytona_build``'s
+#      ``verify_artifact`` does: four reasons (``artifact_empty`` / ``artifact_truncated`` /
+#      ``artifact_unreadable`` / ``artifact_contains_node_modules``), an
+#      ``ArtifactRejection`` carrying its own ``retryable``, and ``promised_artifact_bytes``
+#      reading the size off the sentinel rather than widening ``BuildClassification``.
+#      ``daytona_runner.run_build`` calls it and demotes the classification, which is what
+#      turned ``test_an_empty_download_is_reported_as_not_ok`` from a characterisation test
+#      into the five real rungs in ``TestF5VerificationFailsSoNothingDeploys``.
 #
-#      This is not just a requirement list: it was BUILT and mutation-tested, then held back
-#      because 170 lines of new production logic in a lane with zero callers is a feature
-#      build, and the gate's correct shape depends on how the wiring ends up consuming it.
-#      The implementation lives on ``spike/sites-artifact-verification`` — a four-way
-#      classification (``artifact_empty`` / ``artifact_truncated`` / ``artifact_unreadable`` /
-#      ``artifact_contains_node_modules``), an ``ArtifactRejection`` carrying its own
-#      ``retryable``, and ``promised_artifact_bytes`` reading the size off the sentinel rather
-#      than widening ``BuildClassification``. Start there rather than from scratch.
+# THE ONE THING THAT DID NOT SURVIVE THE WAIT is worth naming, because it is the argument
+# for building the tests first: the banked gate assumed the tar command had NO exclusion and
+# justified itself as "construction cannot cover this". By the time it landed the command
+# carried ``--exclude=node_modules``, so that justification was gone and the real one is
+# narrower — the exclusion is a flag on a tar binary this process never runs, and GNU and
+# bsdtar already disagreed about it once in CI. Same code, different reason, and only the
+# reason tells you what the gate is allowed to stop protecting.
 
 from __future__ import annotations
 
@@ -96,13 +97,17 @@ from tests.ee.sites.faults import (
     NODE_MODULES_PROJECT,
     DaytonaUnavailable,
     FaultyDaytonaClient,
+    artifact_with_node_modules,
     clean_artifact,
     daytona_unconfigured,
+    garbage_artifact,
     ok_sentinel,
     pack_with_real_tar,
     sandbox_create_fails,
     sandbox_dies_mid_build,
+    tar_bytes,
     tar_is_available,
+    truncated_artifact,
     write_project_tree,
 )
 
@@ -468,35 +473,88 @@ class TestF5VerificationFailsSoNothingDeploys:
         assert got.classification.reason == "artifact_size_unknown"
         assert got.classification.deployable is False
 
-    async def test_an_empty_download_is_reported_as_not_ok(self) -> None:
-        """A CHARACTERISATION test, recording a discrepancy rather than a fix.
+    async def test_an_empty_download_is_not_deployable_and_is_worth_retrying(self) -> None:
+        """WHAT THIS TEST USED TO SAY, because the change is the point. It was a
+        CHARACTERISATION test asserting ``deployable is True`` here — the sentinel promised
+        bytes, the download delivered none, and nothing in the lane had looked at the
+        artifact — with a message telling whoever closed the discrepancy to come and delete
+        the assertion. 2026-08-11 closed it, so this is that deletion.
 
-        The sentinel is the build's claim; the download is the fact. When the sentinel
-        promises bytes and the download delivers none, ``BuildRunResult.ok`` correctly
-        reads False — but ``classification.deployable`` still reads True, and that flag's
-        docstring promises "there is a verified artifact to deploy". So a caller gating on
-        ``deployable`` rather than ``ok`` would deploy nothing over something working.
+        The sentinel is the build's claim; the download is the fact. When they disagree,
+        ``deployable`` — whose contract is "there is a verified artifact to deploy" — must
+        follow the fact.
 
-        Left as-is deliberately: this is the proving phase, no caller exists yet, and
-        adding production code to close it is the wiring phase's call. The contract for
-        whoever wires this lane is "gate on ``.ok``", and this test fails if the
-        discrepancy is closed — at which point the contract can be relaxed.
-
-        UPDATED 2026-08-10 (SL-2 slice 2): the contract now has a live consumer.
-        ``build_job.resolve_build_settlement`` gates on ``.ok`` and gives this exact case
-        its own retryable rung (``artifact_missing``) instead of the classifier's
-        ``completed_ok``. The discrepancy itself is UNCHANGED — ``deployable`` still reads
-        True here — so this test's assertion stands as written, and it is still the thing
-        that would tell you if someone closed it upstream.
+        RETRYABLE, because the sentinel reported a size: the bytes existed in the sandbox,
+        so it is the transfer that failed, and a transfer failure is exactly what another
+        attempt fixes.
         """
         client = FaultyDaytonaClient(artifact=b"")
         got = await dr.run_build(REACT_FILES, engine="react", timeout_seconds=600, client=client)
         assert got.ok is False, "ok must not be True for a zero-byte artifact"
         assert got.artifact_bytes == 0
-        assert got.classification.deployable is True, (
-            "deployable now disagrees with ok — if it was fixed, drop the 'gate on .ok' "
-            "contract from the SG-7 findings"
+        assert got.classification.deployable is False
+        assert got.classification.reason == "artifact_empty"
+        assert got.classification.retryable is True
+        assert got.classification.blames_user is False
+        assert got.artifact is None
+
+    async def test_a_truncated_transfer_is_worth_retrying(self) -> None:
+        """Fewer bytes than the sentinel promised. The rung a single ``retryable=False``
+        would have got wrong: a network blip would become a permanently burned publish.
+
+        Also the case that used to settle as ``built``, since nothing compared the promise
+        against what arrived — a half-transferred site replacing a working one."""
+        client = FaultyDaytonaClient(artifact=truncated_artifact())
+        got = await dr.run_build(REACT_FILES, engine="react", timeout_seconds=600, client=client)
+        assert got.classification.deployable is False
+        assert got.classification.reason == "artifact_truncated"
+        assert got.classification.retryable is True
+        assert got.classification.blames_user is False
+        assert got.artifact is None
+
+    async def test_a_full_size_unreadable_artifact_is_NOT_worth_retrying(self) -> None:
+        """The other side of the split, and the reason the split has to exist. Every
+        promised byte arrived and it still will not open, so the transfer did its job and
+        the content is what is wrong — a second sandbox would reproduce it exactly."""
+        payload = garbage_artifact(512)
+        client = FaultyDaytonaClient(
+            artifact=payload, sentinel=ok_sentinel(artifact_bytes=len(payload))
         )
+        got = await dr.run_build(REACT_FILES, engine="react", timeout_seconds=600, client=client)
+        assert got.classification.reason == "artifact_unreadable"
+        assert got.classification.retryable is False
+        assert got.classification.blames_user is False
+
+    async def test_an_artifact_carrying_node_modules_is_not_deployable(self) -> None:
+        """The 500 MB-on-the-wire failure, caught at the bytes.
+
+        The include-list plus ``--exclude=node_modules`` is what PREVENTS this shape, and
+        the class below proves that with the real tar. This asserts the backstop still
+        works when the prevention does not — which is not hypothetical: the exclusion's
+        behaviour belongs to whichever tar the image ships, and GNU and bsdtar already
+        disagreed about it once."""
+        payload = artifact_with_node_modules()
+        client = FaultyDaytonaClient(
+            artifact=payload, sentinel=ok_sentinel(artifact_bytes=len(payload))
+        )
+        got = await dr.run_build(REACT_FILES, engine="react", timeout_seconds=600, client=client)
+        assert got.classification.deployable is False
+        assert got.classification.reason == "artifact_contains_node_modules"
+        assert got.artifact is None
+        assert got.ok is False
+
+    async def test_a_leaked_node_modules_is_ours_and_not_retried(self) -> None:
+        """Whose bug it is decides what the user is told, and a leaked exclusion is ours —
+        reporting "your build is broken" would send them to debug their own code for our
+        packaging mistake. Not retried either: it is deterministic."""
+        payload = artifact_with_node_modules()
+        client = FaultyDaytonaClient(
+            artifact=payload, sentinel=ok_sentinel(artifact_bytes=len(payload))
+        )
+        got = await dr.run_build(REACT_FILES, engine="react", timeout_seconds=600, client=client)
+        assert got.classification.blames_user is False
+        assert got.classification.outcome == "infra_lost"
+        assert got.classification.retryable is False
 
     async def test_a_download_failure_is_transport_loss_not_a_build_failure(self) -> None:
         """The sentinel proved the artifact existed and was non-empty, so failing to fetch
@@ -516,6 +574,82 @@ class TestF5VerificationFailsSoNothingDeploys:
         assert got.classification.deployable is True
         assert got.ok is True
         assert got.artifact_bytes > 0
+
+
+class TestVerifyArtifactAndTheRetryableSplit:
+    """The gate as a unit. The split is the part worth testing directly: whether a
+    rejection is retryable depends on comparing the promised size against what arrived,
+    and that comparison has three outcomes a runner-level test cannot isolate."""
+
+    def test_no_bytes_is_empty_and_retryable(self) -> None:
+        for payload in (b"", None):
+            got = db.verify_artifact(payload, expected_bytes=4096)
+            assert got is not None
+            assert got.reason == "artifact_empty"
+            assert got.retryable is True
+
+    def test_short_of_the_promise_is_truncated_and_retryable(self) -> None:
+        got = db.verify_artifact(clean_artifact()[:40], expected_bytes=len(clean_artifact()))
+        assert got is not None
+        assert got.reason == "artifact_truncated"
+        assert got.retryable is True
+
+    def test_full_size_garbage_is_unreadable_and_not_retryable(self) -> None:
+        payload = garbage_artifact(300)
+        got = db.verify_artifact(payload, expected_bytes=len(payload))
+        assert got is not None
+        assert got.reason == "artifact_unreadable"
+        assert got.retryable is False
+
+    def test_unreadable_with_no_promised_size_defaults_to_retryable(self) -> None:
+        """With nothing to compare against, "garbage" and "truncated" are the same
+        observation. Retryable is the safe direction: one wasted sandbox against a publish
+        the user can never complete. Same asymmetry ``build_is_stale`` uses."""
+        got = db.verify_artifact(b"not a tar at all")
+        assert got is not None
+        assert got.reason == "artifact_unreadable"
+        assert got.retryable is True
+
+    def test_a_clean_artifact_passes(self) -> None:
+        assert db.verify_artifact(clean_artifact(), expected_bytes=len(clean_artifact())) is None
+
+    def test_a_bigger_than_promised_artifact_is_not_treated_as_truncated(self) -> None:
+        """Only SHORT counts. A payload at or over the promise arrived intact, and treating
+        a size mismatch in that direction as a failure would reject healthy builds."""
+        assert db.verify_artifact(clean_artifact(), expected_bytes=8) is None
+
+    @pytest.mark.parametrize("member", ["node_modules/react/index.js", "./node_modules/a.js"])
+    def test_node_modules_is_caught_whatever_the_prefix(self, member: str) -> None:
+        payload = tar_bytes({"./index.html": b"<!doctype html>", member: b"x"})
+        got = db.verify_artifact(payload, expected_bytes=len(payload))
+        assert got is not None
+        assert got.reason == "artifact_contains_node_modules"
+        assert got.retryable is False
+
+    def test_a_name_that_merely_contains_the_word_is_not_rejected(self) -> None:
+        """Segment-wise, not substring: a legitimate ``node_modules_report.html`` must not
+        fail a healthy build. A substring check would fire on innocent sites, which is how
+        a safety gate gets switched off. The same property the tar command's own exclusion
+        has to hold, checked here for the backstop that could disagree with it."""
+        payload = tar_bytes(
+            {
+                "./index.html": b"<!doctype html>",
+                "./docs/node_modules_report.html": b"<p>size audit</p>",
+            }
+        )
+        assert db.verify_artifact(payload, expected_bytes=len(payload)) is None
+
+    def test_a_promised_size_that_is_nonsense_is_ignored(self) -> None:
+        """``True`` is an int subclass and would otherwise read as a one-byte promise,
+        which would make every real artifact look oversized rather than short."""
+        assert db.verify_artifact(clean_artifact(), expected_bytes=True) is None
+        assert db.promised_artifact_bytes(ok_sentinel(artifact_bytes=True)) is None
+
+    def test_the_promised_size_comes_off_the_sentinel(self) -> None:
+        assert db.promised_artifact_bytes(ok_sentinel(artifact_bytes=1234)) == 1234
+        assert db.promised_artifact_bytes(None) is None
+        assert db.promised_artifact_bytes(b"{not json") is None
+        assert db.promised_artifact_bytes(ok_sentinel(artifact_bytes=0)) is None
 
 
 @pytest.mark.skipif(not tar_is_available(), reason="needs a real tar binary")
@@ -718,13 +852,43 @@ class TestF7EveryDegradedPathNamesItsRung:
         got = await dr.run_build(REACT_FILES, engine="react", timeout_seconds=600, client=client)
         assert got.classification.reason == f"build_killed_by_signal_{EXIT_SIGKILL}"
 
-    async def test_the_runner_only_reason_is_named_too(self) -> None:
-        """One condition exists only in the runner and the classifier never sees it, which
-        makes it the one most likely to ship nameless."""
+    async def test_the_runner_only_reasons_are_named_too(self) -> None:
+        """These conditions exist only in the runner and the classifier never sees them,
+        which makes them the ones most likely to ship nameless. Asserted as a SET so two of
+        them cannot quietly collapse onto one reason — an operator reading a shared reason
+        still cannot tell which happened."""
         download = FaultyDaytonaClient(fail_at="artifact")
         got = await dr.run_build(REACT_FILES, engine="react", timeout_seconds=600, client=download)
+        reasons = {got.classification.reason}
         assert got.classification.reason == "artifact_download_failed"
-        assert got.classification.blames_user is False
+
+        nm = artifact_with_node_modules()
+        garbage = garbage_artifact(300)
+        # Paired explicitly: the first two need the DEFAULT sentinel (which promises a full
+        # clean artifact) so the payload reads as short, while the last two must promise
+        # their own length so the payload reads as complete-but-wrong.
+        cases = [
+            (b"", ok_sentinel()),
+            (truncated_artifact(), ok_sentinel()),
+            (garbage, ok_sentinel(artifact_bytes=len(garbage))),
+            (nm, ok_sentinel(artifact_bytes=len(nm))),
+        ]
+        for payload, sentinel in cases:
+            client = FaultyDaytonaClient(artifact=payload, sentinel=sentinel)
+            res = await dr.run_build(
+                REACT_FILES, engine="react", timeout_seconds=600, client=client
+            )
+            assert res.classification.reason, "a runner rejection shipped with no reason"
+            assert res.classification.blames_user is False
+            reasons.add(res.classification.reason)
+
+        assert reasons == {
+            "artifact_download_failed",
+            "artifact_empty",
+            "artifact_truncated",
+            "artifact_unreadable",
+            "artifact_contains_node_modules",
+        }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/mutations/daytona_build.json
+++ b/tests/mutations/daytona_build.json
@@ -18,10 +18,10 @@
     ]
   },
   {
-    "label": "bool exit codes are coerced instead of rejected, so build_exit=False deploys an unbuilt site",
+    "label": "bool exit codes are coerced instead of rejected, so build_exit=False deploys an unbuilt site [re-anchored 2026-08-11: verify_artifact's _readable_size carries the identical guard line, so the one-line anchor became ambiguous and would have aborted this whole plan]",
     "file": "ee/pocketpaw_ee/sites/daytona_build.py",
-    "find": "    if isinstance(value, bool) or not isinstance(value, int):",
-    "replace": "    if not isinstance(value, int):",
+    "find": "    if isinstance(value, bool) or not isinstance(value, int):\n        return None\n    return value\n",
+    "replace": "    if not isinstance(value, int):\n        return None\n    return value\n",
     "tests": [
       "tests/ee/sites/test_daytona_build.py"
     ]

--- a/tests/mutations/fault_ladder.json
+++ b/tests/mutations/fault_ladder.json
@@ -169,5 +169,122 @@
     "tests": [
       "tests/ee/sites/test_fault_ladder_build.py"
     ]
+  },
+  {
+    "label": "a transfer that delivered nothing is called permanent, so a network blip burns the publish instead of retrying",
+    "file": "ee/pocketpaw_ee/sites/daytona_build.py",
+    "find": "    if got == 0:\n        return ArtifactRejection(\"artifact_empty\", retryable=True)",
+    "replace": "    if got == 0:\n        return ArtifactRejection(\"artifact_empty\", retryable=False)",
+    "tests": [
+      "tests/ee/sites/test_fault_ladder_build.py"
+    ]
+  },
+  {
+    "label": "a half-arrived artifact is called permanent, so a dropped connection costs the user their publish",
+    "file": "ee/pocketpaw_ee/sites/daytona_build.py",
+    "find": "        return ArtifactRejection(\"artifact_truncated\", retryable=True)",
+    "replace": "        return ArtifactRejection(\"artifact_truncated\", retryable=False)",
+    "tests": [
+      "tests/ee/sites/test_fault_ladder_build.py"
+    ]
+  },
+  {
+    "label": "a truncated transfer is misread as a complete one, so half a site is accepted as whole",
+    "file": "ee/pocketpaw_ee/sites/daytona_build.py",
+    "find": "    if promised is not None and got < promised:",
+    "replace": "    if promised is not None and got > promised:",
+    "tests": [
+      "tests/ee/sites/test_fault_ladder_build.py"
+    ]
+  },
+  {
+    "label": "a build that produced garbage is retried, spending a fresh sandbox to reproduce the identical failure",
+    "file": "ee/pocketpaw_ee/sites/daytona_build.py",
+    "find": "        return ArtifactRejection(\"artifact_unreadable\", retryable=promised is None)",
+    "replace": "        return ArtifactRejection(\"artifact_unreadable\", retryable=True)",
+    "tests": [
+      "tests/ee/sites/test_fault_ladder_build.py"
+    ]
+  },
+  {
+    "label": "a leaked node_modules is retried, so every attempt re-packs the same 500 MB artifact and bills for it",
+    "file": "ee/pocketpaw_ee/sites/daytona_build.py",
+    "find": "            return ArtifactRejection(\"artifact_contains_node_modules\", retryable=False)",
+    "replace": "            return ArtifactRejection(\"artifact_contains_node_modules\", retryable=True)",
+    "tests": [
+      "tests/ee/sites/test_fault_ladder_build.py"
+    ]
+  },
+  {
+    "label": "an empty artifact download counts as one byte, so nothing-arrived is misread as a short transfer and the empty rung never fires",
+    "file": "ee/pocketpaw_ee/sites/daytona_build.py",
+    "find": "    got = len(payload) if payload else 0",
+    "replace": "    got = len(payload) if payload else 1",
+    "tests": [
+      "tests/ee/sites/test_fault_ladder_build.py"
+    ]
+  },
+  {
+    "label": "the substring check comes back, so a site with a legitimately-named node_modules_report.html is rejected as if it shipped the dependency tree",
+    "file": "ee/pocketpaw_ee/sites/daytona_build.py",
+    "find": "        if _FORBIDDEN_SEGMENT in name.replace(\"\\\\\", \"/\").split(\"/\"):",
+    "replace": "        if _FORBIDDEN_SEGMENT in name.replace(\"\\\\\", \"/\"):",
+    "tests": [
+      "tests/ee/sites/test_fault_ladder_build.py"
+    ]
+  },
+  {
+    "label": "our own transfer or packaging failure is reported to the user as their build being broken",
+    "file": "ee/pocketpaw_ee/sites/daytona_runner.py",
+    "find": "                        reason=rejection.reason,\n                        retryable=rejection.retryable,\n                        blames_user=False,",
+    "replace": "                        reason=rejection.reason,\n                        retryable=rejection.retryable,\n                        blames_user=True,",
+    "tests": [
+      "tests/ee/sites/test_fault_ladder_build.py"
+    ]
+  },
+  {
+    "label": "the retryable split is discarded at the wiring, so a truncated transfer becomes a permanent failure anyway",
+    "file": "ee/pocketpaw_ee/sites/daytona_runner.py",
+    "find": "                        retryable=rejection.retryable,",
+    "replace": "                        retryable=False,",
+    "tests": [
+      "tests/ee/sites/test_fault_ladder_build.py"
+    ]
+  },
+  {
+    "label": "the artifact is never checked, so whatever the build produced deploys unverified",
+    "file": "ee/pocketpaw_ee/sites/daytona_runner.py",
+    "find": "                rejection = verify_artifact(\n                    artifact, expected_bytes=promised_artifact_bytes(sentinel)\n                )",
+    "replace": "                rejection = None",
+    "tests": [
+      "tests/ee/sites/test_fault_ladder_build.py"
+    ]
+  },
+  {
+    "label": "the promised size never reaches the check, so a truncated transfer is indistinguishable from a bad build",
+    "file": "ee/pocketpaw_ee/sites/daytona_runner.py",
+    "find": "                    artifact, expected_bytes=promised_artifact_bytes(sentinel)",
+    "replace": "                    artifact, expected_bytes=None",
+    "tests": [
+      "tests/ee/sites/test_fault_ladder_build.py"
+    ]
+  },
+  {
+    "label": "a rejected artifact is still handed back, so a caller can deploy bytes the gate refused",
+    "file": "ee/pocketpaw_ee/sites/daytona_runner.py",
+    "find": "                    artifact = None\n        t_extracted = time.monotonic()",
+    "replace": "        t_extracted = time.monotonic()",
+    "tests": [
+      "tests/ee/sites/test_fault_ladder_build.py"
+    ]
+  },
+  {
+    "label": "a boolean promised size is coerced instead of rejected, so artifact_bytes=True reads as a one-byte promise and every real artifact looks oversized rather than short",
+    "file": "ee/pocketpaw_ee/sites/daytona_build.py",
+    "find": "    if isinstance(value, bool) or not isinstance(value, int):\n        return None\n    return value if value > 0 else None",
+    "replace": "    if not isinstance(value, int):\n        return None\n    return value if value > 0 else None",
+    "tests": [
+      "tests/ee/sites/test_fault_ladder_build.py"
+    ]
   }
 ]


### PR DESCRIPTION
The build lane trusted a file the sandbox wrote about itself. `artifact_bytes` comes from the sentinel, which is written inside the container before anything crosses the wire, so an empty or half-transferred download still arrived with `classification.deployable` reading True. A caller gating on that flag would replace a working site with a blank one. The four rungs `test_fault_ladder_build.py` recorded as owed to whoever wired this lane are now code, and the header comment that recorded them says so.

## What lands

`daytona_build.verify_artifact` reads the downloaded tar's index and returns one of four rejections, each carrying its own `retryable`:

| reason | retryable | why |
|---|---|---|
| `artifact_empty` | yes | the sentinel promised a size, so the bytes existed in the sandbox and the transfer is what failed |
| `artifact_truncated` | yes | same reason, kept distinct from empty because "nothing arrived" and "half arrived" send an operator to different places |
| `artifact_unreadable` | no | every promised byte arrived and it will not open, so the content is wrong and a second sandbox reproduces it |
| `artifact_contains_node_modules` | no | the tar exclusion leaked; deterministic, and never the user's fault |

`promised_artifact_bytes` reads the size off the sentinel rather than widening `BuildClassification`. `run_build` calls the gate, demotes the classification to a non-deployable `infra_lost`, and drops the bytes so nothing downstream can deploy what the gate refused. Only the tar index is read, so cost is bounded by member count rather than artifact size.

With no promised size to compare against, a failure defaults to retryable. One wasted sandbox is cheaper than a publish the user can never complete — the same asymmetry `build_state.build_is_stale` already uses.

## Why it earns its place on top of the tar exclusion

`artifact_tar_command` already scopes the archive to the output dir and passes `--exclude=node_modules`, so the obvious objection is that this is redundant. It isn't, for two reasons that are in the code as a comment:

1. **The exclusion is a flag on a binary this process never runs.** Its behaviour belongs to whichever tar the image ships, and the two in play already disagreed: GNU tar anchors a pattern containing a slash, bsdtar doesn't, so `--exclude=./node_modules` passed locally and shipped a nested `node_modules` in CI. That class of bug — the command still looks correct — is what a check on the resulting bytes catches and a check on the command cannot.
2. **Nothing else in the lane looks at the transfer.** Empty, truncated and corrupt downloads are invisible to the sentinel by construction.

The include-list stays the primary defence and is still tested by running the real tar over a real `node_modules` tree. This is the backstop, and the only gate in the lane that has read the artifact.

## One thing worth reading

This was built and mutation-tested weeks ago, then held back because 170 lines of production logic in a lane with no callers is a feature build. Reapplying it verbatim would have shipped a lie: the banked version justified itself as "the include-list excludes node_modules by construction, and construction cannot cover the nested case" — but the explicit `--exclude` landed in the meantime and does cover it. Same code, and the reasoning is rewritten rather than reapplied, because only the reason tells you what the gate is allowed to stop protecting.

For the same reason, several hunks off that branch were dropped rather than applied: it predates `_EXCLUDED_MEMBER`, the corrected `deployable` docstring, `build_job`, and the publish flip, and reapplying it would have reverted all four.

## Knock-ons

Both are narrower rungs, not behaviour changes:

- `resolve_build_settlement` no longer sees the deployable-but-empty case from `run_build` — it now arrives already named `infra_lost:artifact_empty`, which is more precise because it comes from the code that looked at the bytes. The `artifact_missing` fallback is kept, and the docstring says why: this function's contract is over a `BuildRunResult`, not over "a result that came from `run_build`", and deleting the branch would make the safe reading depend on an invariant held a module away.
- The path-traversal test in `test_async_publish.py` now has its sentinel promise its own artifact's length. Its hostile tar is 160 bytes against the clean fixture's 169, so on the default sentinel it would be rejected as truncated and never reach the extractor the test is about. The escape has to be why it fails, not a byte count that happens to differ.

## Verification

- `tests/ee/sites`: **4 failed, 1039 passed, 4 skipped** in 86s. The 4 are `test_generator_client_timeout.py` (#1899, Windows wedged-child) and match the pre-existing baseline; the flaky `test_dev_server.py::test_touch_bumps_activity` passed this run.
- `python scripts/mutate.py --validate`: 288 anchors across 24 plans each resolve exactly once.
- `tests/mutations/fault_ladder.json`: **all 32 mutations caught**, including all 13 new ones. `tests/mutations/daytona_build.json`: all 11 caught.
- `ruff check .` and `ruff format --check .` clean repo-wide; `scripts/scan_secrets.py` reports nothing.

One pre-existing anchor needed re-pointing: `_readable_size` carries the same `isinstance(value, bool)` guard line as `_coerce_exit`, which made `daytona_build.json`'s one-line anchor ambiguous — and an ambiguous anchor aborts the whole plan before the first mutation, so it reads as covered while proving nothing. Both are now anchored on three lines including the return, and `_readable_size` got its own mutation so its guard is guarded too.
