### PR TITLE
The sites test suite was reading the operator's own .env

### DIFF
--- a/tests/ee/sites/conftest.py
+++ b/tests/ee/sites/conftest.py
@@ -1,5 +1,23 @@
 # tests/ee/sites/conftest.py
 # Created: 2026-06-18 (feat/sites-dedupe-migration, PERF-2).
+# Updated 2026-08-11 (fix/tests-ignore-operator-env): added the autouse
+#   ``_operator_env_cleared`` fixture. Nothing in this tree isolated the test process
+#   from the developer's own environment: ``config.py`` declares ``env_file=".env"`` and
+#   ``security/url_validators.py`` calls ``load_dotenv(override=False)`` at IMPORT time,
+#   and dotenv searches upward from the CWD — so a gitignored ``.env`` in the checkout
+#   root silently became test input. With one present, ``PAW_CF_DEPLOY_MODE`` alone
+#   flipped 89 tests red (98 failed / 909 passed, against 5 / 1005 on a clean tree) by
+#   sending them down the real Cloudflare Workers path with the operator's live API
+#   token in the environment. CI never catches it (no ``.env`` there — green by
+#   construction), so it only bites locally, where "tests broken" reads as "branch
+#   broken". This deletes the variables that SELECT a code path or SUPPLY a credential
+#   before every test. Delete-only and function-scoped on purpose: a test that wants one
+#   set does so in its own body, after this has run. Deleting alone was NOT enough —
+#   ``pocketpaw.uploads.factory.build_adapter`` calls ``load_dotenv()`` lazily, so it
+#   re-read the file mid-test and put the variables back (a non-overriding load happily
+#   sets a var this fixture has just removed); three test_preview_refresh.py tests were
+#   still reaching the live path. So the fixture also neuters ``load_dotenv`` per test.
+#   test_env_isolation.py proves both legs, so neither can quietly stop working.
 # Updated 2026-08-08 (capture readiness): added the autouse ``_site_pages_are_serving``
 #   fixture. Screenshot capture now polls the site's url before rendering it, so
 #   without this every existing capture test would fire a real request at a hostname
@@ -83,6 +101,83 @@ async def _sites_beanie_settings() -> Any:
     db.list_collection_names = _safe_list_collection_names  # type: ignore[method-assign]
 
     await init_beanie(database=db, document_models=[*ALL_DOCUMENTS, MemoryFactDoc])
+    yield
+
+
+# The ambient variables an operator's own ``.env`` leaks into the test process. Each one
+# either SELECTS a code path (``PAW_CF_DEPLOY_MODE`` picks the real Workers deploy over
+# the local one), SUPPLIES a credential that path would then use for real, or overrides a
+# default the tests assert against (``PAW_CF_SITES_DOMAIN``, ``PAW_CF_WRANGLER_CMD``).
+# The whole family is listed rather than only the variables observed failing: CI runs
+# with none of them set, so anything green there is green with all of them absent, which
+# makes deleting the rest free and stops the same leak reappearing through a sibling
+# variable. Kept module-level so test_env_isolation.py asserts against this exact list
+# instead of a copy that can drift.
+OPERATOR_ENV_VARS: tuple[str, ...] = (
+    "PAW_CF_DEPLOY_MODE",
+    "PAW_CF_ZONE_ID",
+    "PAW_CF_ACCOUNT_ID",
+    "PAW_CF_API_TOKEN",
+    "PAW_CF_WORKERS_SUBDOMAIN",
+    "PAW_CF_DISPATCH_NAMESPACE",
+    "PAW_CF_SITES_DOMAIN",
+    "PAW_CF_WRANGLER_CMD",
+    "PAW_CF_MIGRATE_TIMEOUT_SEC",
+    "DAYTONA_API_KEY",
+    "DAYTONA_API_URL",
+)
+
+
+@pytest.fixture(autouse=True)
+def _operator_env_cleared(monkeypatch):
+    """Remove the operator's own Cloudflare / Daytona environment from every sites test
+    (fix/tests-ignore-operator-env).
+
+    ``config.py`` sets ``env_file=".env"`` and ``security/url_validators.py`` calls
+    ``load_dotenv(override=False)`` at import time, which searches UPWARD from the CWD.
+    So a gitignored ``.env`` in the checkout root is test input, and the suite's result
+    depends on who is running it: with one present ``PAW_CF_DEPLOY_MODE`` alone took the
+    tree from 5 failures to 98, because the deploy tests took the real Workers path with
+    a live API token sitting in the environment. The observed failures died early on a
+    missing build output, but nothing structural was stopping a less-mocked test from
+    reaching Cloudflare for real.
+
+    Deleting, not setting, is the point: it makes each test's behaviour a property of
+    the code under test rather than of the machine. Function-scoped so a test that WANTS
+    one of these sets it in its own body, after this fixture has already run —
+    test_service.py, test_fault_ladder_deploy.py and test_workers_deploy.py all do
+    exactly that, and are unaffected.
+
+    DELETING IS NOT ENOUGH ON ITS OWN, which is the part worth remembering. Some call
+    sites load the file LAZILY, inside the function, so they re-read it DURING the test —
+    ``pocketpaw.uploads.factory.build_adapter`` is the one that bit here (its own comment
+    reasons that ``load_dotenv`` "won't override vars already in env", which is true and
+    beside the point: this fixture has just made the var ABSENT, so a non-overriding load
+    is free to set it again). Three of test_preview_refresh.py's tests store a screenshot,
+    reach ``build_adapter``, and were still taking the live Workers path with the
+    variables deleted. So the second leg neuters ``load_dotenv`` for the duration of each
+    test: the ambient file is not test input, whenever it is read from."""
+    for name in OPERATOR_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+    def _refuse_to_load_dotenv(*_args: Any, **_kwargs: Any) -> bool:
+        """Stand in for ``dotenv.load_dotenv``. Returns False, its "loaded nothing"
+        value, so a caller that checks the result sees an empty file rather than an
+        error."""
+        return False
+
+    try:
+        import dotenv
+        import dotenv.main
+    except Exception:  # pragma: no cover — dotenv is only an indirect dep
+        pass
+    else:
+        # Both spellings: callers use ``from dotenv import load_dotenv`` today, and the
+        # lazy import resolves the attribute at CALL time, so patching the module object
+        # is what catches them. ``dotenv.main`` is patched too so a future
+        # ``from dotenv.main import load_dotenv`` cannot quietly reopen the hole.
+        monkeypatch.setattr(dotenv, "load_dotenv", _refuse_to_load_dotenv)
+        monkeypatch.setattr(dotenv.main, "load_dotenv", _refuse_to_load_dotenv)
     yield
 
 

--- a/tests/ee/sites/test_env_isolation.py
+++ b/tests/ee/sites/test_env_isolation.py
@@ -1,0 +1,112 @@
+# tests/ee/sites/test_env_isolation.py
+# Created: 2026-08-11 (fix/tests-ignore-operator-env) — proves the autouse
+# ``_operator_env_cleared`` fixture in this directory's conftest actually removes the
+# operator's ambient Cloudflare / Daytona environment, and that its list still covers
+# every ``PAW_CF_*`` variable the sites source reads.
+#
+# WHY THIS FILE EXISTS. The guard it covers is invisible when it works: with no ``.env``
+# in the checkout there is nothing to delete, so a broken or deleted fixture leaves the
+# suite green on CI and green in a worktree, and only misbehaves on the one machine that
+# has real credentials on disk — the machine least likely to suspect the harness. So the
+# module-scoped fixture below PLANTS the variables first (module scope instantiates
+# before the function-scoped conftest fixture, so the guard sees them and has something
+# to remove), which makes the assertion real everywhere instead of vacuous.
+#
+# The planted values are deliberately self-describing non-secrets. Do not swap them for
+# realistic-looking tokens: the repo's own secret scanner has been tripped by test
+# canaries before, and a placeholder that names itself is also a better error message.
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+from tests.ee.sites.conftest import OPERATOR_ENV_VARS
+
+# Shapes, not secrets. Only PAW_CF_DEPLOY_MODE needs a real-looking value, because it is
+# the one variable whose CONTENT selects a code path ("workers" = the live Cloudflare
+# deploy); the rest only need to be present to prove they get removed.
+_PLANTED: dict[str, str] = {
+    name: ("workers" if name == "PAW_CF_DEPLOY_MODE" else f"planted-by-{__name__}-not-a-credential")
+    for name in OPERATOR_ENV_VARS
+}
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _simulate_operator_env():
+    """Stand in for the operator's gitignored ``.env`` being loaded into the process.
+
+    Module-scoped on purpose: pytest instantiates higher-scoped fixtures first, so these
+    are already in ``os.environ`` when the function-scoped ``_operator_env_cleared``
+    runs. ``monkeypatch`` is function-scoped and therefore unavailable here, so this
+    saves and restores ``os.environ`` by hand — including the case where the developer
+    running it genuinely has one of these set."""
+    saved = {name: os.environ.get(name) for name in _PLANTED}
+    os.environ.update(_PLANTED)
+    yield
+    for name, previous in saved.items():
+        if previous is None:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = previous
+
+
+def test_operator_env_is_absent_inside_a_test() -> None:
+    """The planted environment does not reach the test body."""
+    leaked = {name: os.environ[name] for name in OPERATOR_ENV_VARS if name in os.environ}
+    assert leaked == {}, (
+        f"the sites suite is reading ambient configuration: {sorted(leaked)}. "
+        "The autouse _operator_env_cleared fixture in tests/ee/sites/conftest.py is "
+        "meant to delete these before every test."
+    )
+
+
+def test_deploy_mode_default_is_not_the_live_path() -> None:
+    """The specific failure this guards: an ambient ``PAW_CF_DEPLOY_MODE=workers``
+    silently routing tests down the real Cloudflare deploy with a live token present."""
+    assert os.environ.get("PAW_CF_DEPLOY_MODE") is None
+
+
+def test_a_mid_test_dotenv_load_cannot_put_them_back(tmp_path: Path) -> None:
+    """The second leg of the guard: deleting the variables is not enough on its own.
+
+    ``pocketpaw.uploads.factory.build_adapter`` imports and calls ``load_dotenv`` INSIDE
+    the function, so it re-reads the file during the test — and because the fixture has
+    made the variable absent, a non-overriding load is free to set it again. That is not
+    hypothetical: it is how three test_preview_refresh.py tests kept reaching the live
+    Cloudflare path after the delete was in place. This calls ``load_dotenv`` the same
+    lazy way, pointed at a real file on disk, and asserts nothing lands in the
+    environment."""
+    env_file = tmp_path / ".env"
+    env_file.write_text("PAW_CF_DEPLOY_MODE=workers\n", encoding="utf-8")
+
+    from dotenv import load_dotenv
+
+    load_dotenv(str(env_file), override=True)
+
+    assert os.environ.get("PAW_CF_DEPLOY_MODE") is None, (
+        "a mid-test load_dotenv reached os.environ — the _operator_env_cleared fixture "
+        "is meant to neuter dotenv.load_dotenv for the duration of each test."
+    )
+
+
+def test_cleared_list_covers_every_paw_cf_variable_in_the_sites_source() -> None:
+    """Catch a NEW ``PAW_CF_*`` variable added to sites without being added to the
+    cleared list — otherwise the leak returns quietly through the new name."""
+    from pocketpaw_ee import sites
+
+    source_root = Path(sites.__file__).parent
+    referenced: set[str] = set()
+    for path in source_root.rglob("*.py"):
+        referenced.update(re.findall(r"\bPAW_CF_[A-Z0-9_]+\b", path.read_text(encoding="utf-8")))
+
+    assert referenced, f"found no PAW_CF_* references under {source_root} — bad glob?"
+    missing = referenced - set(OPERATOR_ENV_VARS)
+    assert not missing, (
+        f"these PAW_CF_* variables are read by the sites source but are not cleared "
+        f"before tests: {sorted(missing)}. Add them to OPERATOR_ENV_VARS in "
+        "tests/ee/sites/conftest.py."
+    )


### PR DESCRIPTION
`config.py` declares `env_file=".env"` and `security/url_validators.py` calls `load_dotenv(override=False)` at import time. dotenv searches upward from the CWD, and nothing in the test tree isolated against it — no `monkeypatch.delenv`, no `clear=True`, in any conftest. So a gitignored `.env` in the checkout root was test input.

Measured on identical trees:

| tree | result |
|---|---|
| checkout with `.env` present | 98 failed / 909 passed |
| `PAW_CF_DEPLOY_MODE` cleared | 9 failed / 1001 passed |
| clean worktree, no `.env` | 5 failed / 1005 passed |

Two harms. CI cannot catch it: there is no `.env` on a runner, so it is green by construction, and the failures land only on the machine that has real credentials on disk — where "the tests are broken" reads as "the branch is broken". And those tests executed the real Cloudflare code path with a live API token in the environment. The ones observed died early on a missing build output, but nothing structural was stopping a less-mocked test from reaching Cloudflare for real.

## What this changes

An autouse, function-scoped fixture in `tests/ee/sites/conftest.py` deletes the `PAW_CF_*` family and `DAYTONA_API_KEY` / `DAYTONA_API_URL` before every test in the tree.

Deleting rather than forcing values is deliberate: it makes each test's result a property of the code under test instead of the machine running it. Function scope means a test that wants one of these set still sets it in its own body, after the fixture has run — `test_service.py`, `test_fault_ladder_deploy.py` and `test_workers_deploy.py` all do exactly that and are unaffected.

The list covers the whole family rather than only the variables observed failing. CI runs with none of them set, so anything green there is green with all of them absent, which makes the rest free to delete and stops the same leak returning through a sibling variable such as `PAW_CF_SITES_DOMAIN`.

**Deleting alone was not enough**, which is the part worth carrying forward. `pocketpaw.uploads.factory.build_adapter` imports and calls `load_dotenv()` inside the function, so it re-read the file mid-test and put the variables back. Its own comment reasons that the load "won't override vars already in env" — true, and beside the point, because the fixture has just made the var absent, so a non-overriding load is free to set it again. Three `test_preview_refresh.py` tests store a screenshot, reach `build_adapter`, and were still taking the live Workers path with the delete in place. The fixture therefore also neuters `dotenv.load_dotenv` per test.

## Proof, both directions

`tests/ee/sites` returns **4 failed / 1010 passed / 4 skipped** both with a hostile `.env` planted at the worktree root and with none present. Identical numbers is the property being bought. The planted file set `PAW_CF_DEPLOY_MODE=workers` plus fake `PAW_CF_ACCOUNT_ID` / `PAW_CF_API_TOKEN` / `PAW_CF_ZONE_ID` / `PAW_CF_WORKERS_SUBDOMAIN` / `DAYTONA_API_KEY`; it has been deleted, and the worktree is confirmed clean of it.

The 4 failures are the known `test_generator_client_timeout.py` Windows child-reap failures (#1899) and nothing else. `test_dev_server.py::test_touch_bumps_activity`, the other baseline failure, passed on these runs — it is the flaky 10ms-sleep-versus-15.6ms-timer one.

`test_env_isolation.py` proves the guard rather than assuming it. Its module-scoped fixture plants the variables first, since higher scopes instantiate before function-scoped ones, so the assertions are real on a clean tree and in CI instead of passing vacuously against an environment that was already empty. It covers both legs, and a third test walks the sites source for `PAW_CF_*` references and fails if one is missing from the cleared list, so a new credential variable cannot quietly reopen the hole. Planted values are self-describing non-secrets by design.

Checked in the failing direction too: with the delete loop neutered, the guard fails and names all eleven leaked variables.

## Follow-up, deliberately not in this PR

The root cause is global. The same `.env` reaches every suite in the repo — `tests/test_pydantic_ai_backend.py` already carries comments about having been bitten by it — and the real fix is one isolation fixture at the root conftest plus a decision about whether `url_validators` should be calling `load_dotenv` at import time at all. This PR fixes the tree that was measured rather than widening blind. Also worth a look in that pass: `cloud/websandbox/browserpod.py` reads credentials with `dotenv_values`, which bypasses `os.environ` entirely and so would not be caught by a delete-based guard. Nothing under `sites` reaches it today.

Ruff check and format clean repo-wide; `mutate.py --validate` reports 275 anchors across 24 plans.
