### PR TITLE
A static svelte publish can queue its build

### DIFF
--- a/ee/pocketpaw_ee/sites/build_job.py
+++ b/ee/pocketpaw_ee/sites/build_job.py
@@ -24,11 +24,23 @@
 # nothing. That is not dead code — a build queued to verify an artifact is a real use of
 # this lane, and it is what the fault-ladder tests drive.
 #
-# WHICH ENGINES ARRIVE HERE IS DECIDED IN ``service.build_runs_async``, not here, and it is
-# react-only today. The reason is the artifact, not the queue: an adapter-cloudflare build
-# (ripple, dynamic svelte) emits pages rendered by a ``_worker.js`` whose imports sit
-# outside the tarred directory, so the artifact cannot serve — which is why ``truth_lane``
-# refuses to preview one. Widen that predicate only together with the artifact.
+# Edited 2026-08-11 (SL-4): STATIC SVELTE NOW ARRIVES HERE TOO, which mattered out of all
+# proportion to its size — svelte is the only engine with a real edit lane
+# (``edit_svelte_component`` + the REPL), so until this the editable engine was the slow one
+# and the fast one could not be edited. Two things had to move for it: the in-sandbox tar
+# packed the NOMINAL per-engine output dir, which for svelte names the dynamic
+# ``.svelte-kit/cloudflare`` a static build never creates (so every static svelte build
+# would have tarred nothing and classified as a failure), and the deploy-side unpack chose
+# its extract dir the same wrong way. Both now read
+# ``engines.static_output_rel_candidates``; see ``_deploy_built_artifact`` for the
+# re-check of the preview-shaped skip list against an adapter-static tree.
+#
+# WHICH SITES ARRIVE HERE IS DECIDED IN ``service.build_runs_async``, not here, and it now
+# reads the SITE rather than the engine name — react plus static svelte. The reason for the
+# exclusions is the artifact, not the queue: an adapter-cloudflare build (ripple, DYNAMIC
+# svelte) emits pages rendered by a ``_worker.js`` whose imports sit outside the tarred
+# directory, so the artifact cannot serve — which is why ``truth_lane`` refuses to preview
+# one. Widen that predicate past those only together with the artifact.
 #
 # ┌───────────────────────────────────────────────────────────────────────────────────┐
 # │ WHY A DEDICATED ARQ FUNCTION AND NOT THE WORKSPACE-JOBS REGISTRY.                  │
@@ -572,14 +584,35 @@ async def _deploy_built_artifact(
     path would mean the deploy got the unproven copy.
 
     Its skip list is written for a PREVIEW (``_worker.js`` and deploy metadata are
-    dropped), which is harmless here only because this path is react-only: react emits no
-    server entry, and ``deploy_workers`` writes its own ``.assetsignore``. Widening
-    ``service.build_runs_async`` past react means revisiting this — an engine whose worker
-    IS the site cannot have it dropped on the way to the edge.
+    dropped), and SL-4 widened this lane to static svelte, so the list was re-checked
+    against what ``adapter-static`` emits rather than assumed still harmless:
 
-    The tree is extracted UNDER the engine's static-output rel, because the deploy targets
-    resolve their source as ``<project_dir>/<static_output_rel>`` while the tar is rooted
-    AT that directory's contents. Extracting flat would deploy an empty dir.
+    * ``_worker.js`` — adapter-static emits NONE, so nothing is dropped. That is the whole
+      reason static svelte can ride this lane at all, and it is why ``build_runs_async``
+      must keep DYNAMIC svelte out: an adapter-cloudflare tree's worker IS the renderer,
+      and this unpack would silently drop it on the way to the edge.
+    * ``_routes.json`` / ``.assetsignore`` — adapter-CLOUDFLARE artifacts, absent from a
+      ``build`` tree. And ``deploy_workers`` writes its own ``.assetsignore`` regardless,
+      so carrying the build's copy would be the thing that broke, not dropping it.
+    * ``_headers`` / ``_redirects`` — Pages-format config. adapter-static does not emit
+      them; it WOULD copy them verbatim if a site authored them into ``static/``. Dropping
+      them is still correct here, because the deploy target is a Worker with an assets
+      binding and consumes neither file — carrying them would upload two files that
+      nothing reads and that ``resolve`` would then have to refuse as pages.
+    * ``_app/`` — svelte's entire JS/CSS payload, matched by NO skip rule. The lists key
+      on exact segment names, and ``_app`` is not one of them.
+
+    So a static svelte artifact loses nothing deployable. The react finding is unchanged:
+    it emits no server entry either.
+
+    The tree is extracted UNDER the FIRST of the engine's ``static_output_rel_candidates``,
+    not under the nominal ``static_output_rel``. The deploy targets resolve their source as
+    ``<project_dir>/<resolve_static_output_rel(...)>`` while the tar is rooted AT that
+    directory's contents, so extracting flat would deploy an empty dir — and for svelte the
+    NOMINAL rel names the dynamic shape (``.svelte-kit/cloudflare``), which is not where a
+    static build's output belongs. The first candidate is the resolver's first probe, so
+    the two agree by construction for every engine: ``dist`` for react,
+    ``.svelte-kit/cloudflare`` for ripple (both unchanged), ``build`` for svelte.
     """
     if not artifact:
         # ``settle`` only reaches ``built`` via ``BuildRunResult.ok``, which requires
@@ -589,13 +622,13 @@ async def _deploy_built_artifact(
 
     from pocketpaw_ee.sites import artifact_preview
     from pocketpaw_ee.sites import service as _service
-    from pocketpaw_ee.sites.engines import static_output_rel
+    from pocketpaw_ee.sites.engines import static_output_rel_candidates
 
     deploy = deployer or _service.deploy_prebuilt_site
     project_dir = tempfile.mkdtemp(prefix="paw-deploy-")
     try:
         unpacked = artifact_preview.unpack_artifact(
-            artifact, Path(project_dir, static_output_rel(engine))
+            artifact, Path(project_dir, static_output_rel_candidates(engine)[0])
         )
         logger.info(
             "sites.build: materialised %d entries (%d bytes) for the deploy of site %s",

--- a/ee/pocketpaw_ee/sites/daytona_build.py
+++ b/ee/pocketpaw_ee/sites/daytona_build.py
@@ -42,7 +42,11 @@ import shlex
 from dataclasses import dataclass
 from typing import Any, Literal
 
-from pocketpaw_ee.sites.engines import normalize_engine, static_output_rel
+from pocketpaw_ee.sites.engines import (
+    normalize_engine,
+    static_output_rel,
+    static_output_rel_candidates,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -436,6 +440,8 @@ def artifact_tar_command(
     engine: str | None,
     project_dir: str,
     dest_path: str,
+    *,
+    output_dir_expr: str | None = None,
 ) -> str:
     """The in-sandbox command that packs ONLY the deployable output.
 
@@ -459,6 +465,19 @@ def artifact_tar_command(
     (``html``): tarring ``.`` would sweep in ``node_modules`` and defeat the whole
     design. html needs no build and so never reaches this lane; a caller that gets
     here with it has a routing bug and should hear about it loudly.
+
+    ``output_dir_expr`` (SL-4) overrides the ``-C`` argument with an ALREADY-SHELL-SAFE
+    expression, for the one caller that cannot know the dir when the command is rendered:
+    :func:`build_wrapper_script` resolves svelte's two possible output dirs at RUNTIME, in
+    the sandbox, after the build. It is interpolated verbatim, so a caller passing
+    anything but a quoted literal or a quoted shell expansion is passing a shell-injection
+    hole; ``project_dir`` is still used for the engine guard either way.
+
+    WITHOUT the override this stays a SINGLE ``tar`` invocation containing no shell
+    constructs, and that is a contract, not an accident: ``tests/ee/sites/faults.py``'s
+    ``pack_with_real_tar`` runs the rendered command through ``shlex.split`` +
+    ``subprocess.run`` with NO shell, so the include-list is exercised by the real tar
+    binary. A probe loop rendered in here would silently stop being testable that way.
     """
     rel = static_output_rel(engine)
     if rel == ".":
@@ -467,9 +486,10 @@ def artifact_tar_command(
             "project root, so an include-list cannot exclude node_modules; this "
             "lane is for engines whose build writes a subdirectory"
         )
-    output_dir = f"{project_dir.rstrip('/')}/{rel}"
+    if output_dir_expr is None:
+        output_dir_expr = shlex.quote(f"{project_dir.rstrip('/')}/{rel}")
     return (
-        f"tar -czf {shlex.quote(dest_path)} -C {shlex.quote(output_dir)} "
+        f"tar -czf {shlex.quote(dest_path)} -C {output_dir_expr} "
         f"--exclude={shlex.quote(_EXCLUDED_MEMBER)} ."
     )
 
@@ -553,7 +573,31 @@ def build_wrapper_script(
     abort the script at the first failing step, which is precisely when the evidence
     matters. Every command's status is captured explicitly instead.
     """
-    tar_cmd = artifact_tar_command(engine, project_dir, artifact_path)
+    candidates = static_output_rel_candidates(engine)
+    # SL-4: an engine with ONE output shape renders byte-for-byte the script it always
+    # did — no probe, and the tar's ``-C`` is the literal quoted path. Only svelte has
+    # two, and only svelte pays for the resolution.
+    if len(candidates) > 1:
+        probe = "\n".join(
+            (
+                "# SL-4: which adapter ran is a property of the built SITE, so resolve the",
+                "# output dir off the ARTIFACT rather than predicting it from the engine",
+                "# name. This is the shell twin of engines.resolve_static_output_rel and",
+                "# the PROBE ORDER IS THE SAME ORDER, from the same list: build first, so a",
+                "# project dir carrying a stale adapter-cloudflare tree cannot shadow what",
+                "# this build actually emitted. Runs AFTER the build, because before it",
+                "# neither candidate exists yet.",
+                f"for CAND in {' '.join(shlex.quote(c) for c in candidates)}; do",
+                '  if [ -d "$PROJECT/$CAND" ]; then ARTIFACT_REL="$CAND"; break; fi',
+                "done",
+            )
+        )
+        tar_cmd = artifact_tar_command(
+            engine, project_dir, artifact_path, output_dir_expr='"$PROJECT/$ARTIFACT_REL"'
+        )
+    else:
+        probe = ""
+        tar_cmd = artifact_tar_command(engine, project_dir, artifact_path)
     result_path = f"{project_dir.rstrip('/')}/{BUILD_RESULT_FILENAME}"
     writer = _SENTINEL_WRITER.replace("TAIL_BYTES", str(STDERR_TAIL_BYTES))
 
@@ -566,6 +610,10 @@ RESULT={shlex.quote(result_path)}
 STDERR_LOG=/tmp/paw-build-stderr.log
 ARTIFACT={shlex.quote(artifact_path)}
 ENGINE={shlex.quote(normalize_engine(engine))}
+# The NOMINAL output dir, and for svelte only a pre-build fallback: the probe below
+# re-resolves it off the artifact once the build has run. Set here so a failure
+# BEFORE the build still writes a sentinel under ``set -u`` rather than dying in the
+# trap, which would turn a plain build failure into an unexplained infra loss.
 ARTIFACT_REL={shlex.quote(static_output_rel(engine))}
 STARTED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
@@ -595,6 +643,7 @@ if [ "$BUILD_EXIT" -ne 0 ]; then
   exit "$BUILD_EXIT"
 fi
 
+{probe}
 {tar_cmd} >>"$STDERR_LOG" 2>&1
 if [ -f "$ARTIFACT" ]; then
   ARTIFACT_BYTES=$(wc -c < "$ARTIFACT" | tr -d '[:space:]')

--- a/ee/pocketpaw_ee/sites/engines.py
+++ b/ee/pocketpaw_ee/sites/engines.py
@@ -38,6 +38,17 @@
 # narrow — see :func:`resolve_static_output_rel` for why reading the artifact beats
 # threading a static/dynamic flag through six call sites, two of which have no
 # generate in scope to thread it from.
+#
+# Edited 2026-08-11 (SL-4 — static svelte joined the ephemeral build lane): added
+# :func:`static_output_rel_candidates`, and :func:`resolve_static_output_rel` now reads
+# its probe order from it instead of carrying its own copy. SL-1 left the probe order in
+# one function, which was correct while every caller that needed it had a project dir to
+# probe. The async build lane has two callers that do NOT: the in-sandbox tar (rendered
+# before the build it packs, so it has to resolve at runtime IN the sandbox) and the
+# deploy-side unpack (which chooses the dir name it extracts INTO). Both previously used
+# the nominal :func:`static_output_rel`, whose svelte row names the DYNAMIC shape — so the
+# tar would have packed a directory a static build never creates, and every static svelte
+# publish through that lane would have failed with an empty artifact.
 """Engine capability predicates for Paw Sites.
 
 Four site-generation engines are modeled:
@@ -282,6 +293,35 @@ def static_output_rel(engine: str | None) -> str:
     return _STATIC_OUTPUT_REL[normalize_engine(engine)]
 
 
+def static_output_rel_candidates(engine: str | None) -> tuple[str, ...]:
+    """Every dir this engine's build might write its deployable output to, in
+    :func:`resolve_static_output_rel`'s PROBE ORDER.
+
+    One entry for ripple / html / react — each has exactly one output shape. TWO for
+    svelte (``build`` then ``.svelte-kit/cloudflare``), because the track spans two
+    adapters chosen by a property of the SITE.
+
+    ADDED 2026-08-11 (SL-4 — static svelte joined the async build lane) for the callers
+    that must agree with :func:`resolve_static_output_rel` while holding NO filesystem
+    it can probe. There are two, and they sit on either side of the ephemeral lane:
+
+    * the in-sandbox tar, which must pick the output dir AFTER the build has run, in a
+      bash script rendered before it — so it renders this list as a shell probe and
+      resolves at runtime, on the sandbox's disk;
+    * the deploy-side unpack, which extracts the tar under a dir name the resolver will
+      then find, so it uses the FIRST candidate.
+
+    Both previously used the nominal :func:`static_output_rel`, which for svelte names
+    the DYNAMIC shape — the tar would have packed a directory a static build never
+    creates. Naming the order once is what keeps those two and the resolver from
+    drifting; the probe order itself is load-bearing (see the resolver).
+    """
+    normalized = normalize_engine(engine)
+    if normalized == "svelte":
+        return (_SVELTE_STATIC_OUTPUT_REL, _STATIC_OUTPUT_REL["svelte"])
+    return (_STATIC_OUTPUT_REL[normalized],)
+
+
 def resolve_static_output_rel(project_dir: str | os.PathLike[str], engine: str | None) -> str:
     """Where THIS build's deployable output actually landed, relative to ``project_dir``.
 
@@ -314,7 +354,7 @@ def resolve_static_output_rel(project_dir: str | os.PathLike[str], engine: str |
     if normalized != "svelte":
         return _STATIC_OUTPUT_REL[normalized]
     root = Path(project_dir)
-    for candidate in (_SVELTE_STATIC_OUTPUT_REL, _STATIC_OUTPUT_REL["svelte"]):
+    for candidate in static_output_rel_candidates(normalized):
         if (root / candidate).is_dir():
             return candidate
     return _STATIC_OUTPUT_REL["svelte"]

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -2219,10 +2219,19 @@ async def _deploy_site_doc(
             builder_origin=builder_origin,
         )
 
-    # SL-3: fork to the EPHEMERAL BUILD LANE for the engines whose artifact can
-    # actually be deployed from it. A prebuilt dir means the worker already ran this
-    # build and is calling back in to finish the publish, so it must NOT re-fork.
-    if prebuilt_project_dir is None and build_runs_async(engine):
+    # SL-3: fork to the EPHEMERAL BUILD LANE for the sites whose artifact can actually be
+    # deployed from it. A prebuilt dir means the worker already ran this build and is
+    # calling back in to finish the publish, so it must NOT re-fork.
+    #
+    # SL-4: the predicate reads the SITE, not just the engine name, so it also flips
+    # static svelte. It is safe to pass ``pattern`` / ``ripple_spec`` a second time here
+    # even though the dynamic fork above has already consumed them: this call is reached
+    # only when ``_is_dynamic`` was False, so the predicate re-deriving the same answer is
+    # a check that agrees rather than a second source of truth. Asking again is what keeps
+    # the predicate correct for a caller that has NOT forked first.
+    if prebuilt_project_dir is None and build_runs_async(
+        engine, pattern=pattern, ripple_spec=ripple_spec
+    ):
         return await _enqueue_static_build(
             workspace_id=workspace_id,
             user_id=user_id,
@@ -2918,12 +2927,17 @@ async def _provision_dynamic_site(
 # ---------------------------------------------------------------------------
 
 
-def build_runs_async(engine: str | None) -> bool:
-    """Does publishing this engine ENQUEUE its build instead of running it inline?
+def build_runs_async(
+    engine: str | None,
+    *,
+    pattern: str | None,
+    ripple_spec: dict[str, Any] | None,
+) -> bool:
+    """Does publishing this site ENQUEUE its build instead of running it inline?
 
-    True for exactly the engines whose ephemeral-lane artifact can actually be
-    DEPLOYED, which today is react alone. This is a narrow answer to a broad-sounding
-    question, and the narrowness is the whole content of the predicate:
+    True for exactly the sites whose ephemeral-lane artifact can actually be DEPLOYED.
+    This is a narrow answer to a broad-sounding question, and the narrowness is the whole
+    content of the predicate:
 
     * ``html`` runs no build at all (``needs_node_build`` is False), so there is
       nothing to enqueue. Flipping it would add a queue wait to the one engine that
@@ -2933,19 +2947,36 @@ def build_runs_async(engine: str | None) -> bool:
       directory. The artifact therefore cannot serve — which is not a guess: it is why
       ``truth_lane`` refuses to even PREVIEW one (``REASON_WORKER_RENDERED``). Queueing
       those builds would replace a working publish with one nothing can deploy.
-    * STATIC ``svelte`` (adapter-static) IS self-sufficient, and is still excluded,
-      because which adapter ran is a property of the built SITE and is not knowable at
-      enqueue time — only after the build. A gate has to decide before it spends the
-      queue, so svelte stays inline until the artifact question is settled for the
-      whole track.
+    * STATIC ``svelte`` (adapter-static) emits ``build`` with NO server entry, so like
+      react its tar IS the whole deployable site. **This is why the predicate takes a
+      site and not just an engine name.**
     * ``react`` emits a prerendered, assets-only ``dist`` with no server entry, so the
       tar is the whole deployable site.
 
-    Widen this ONLY together with the artifact: the moment an adapter-cloudflare
-    artifact can serve, ripple and svelte belong here too, and this predicate is the
-    one place that changes.
+    A SITE, NOT AN ENGINE — corrected 2026-08-11 (SL-4). This docstring used to exclude
+    static svelte on the grounds that "which adapter ran is a property of the built SITE
+    and is not knowable at enqueue time". That was wrong, and the code sitting above it
+    already proved it wrong: ``_deploy_site_doc`` forks on ``_is_dynamic(pattern,
+    ripple_spec)`` BEFORE any build, from data the caller already holds. The adapter is
+    not knowable from the engine STRING, which is a different claim — and the fix is to
+    stop asking the string. Static svelte matters more than its size: svelte is the only
+    engine with a real edit lane (``edit_svelte_component`` + the REPL), so before this
+    the engine you could edit was the slow one and the fast one could not be edited.
+
+    ``pattern`` / ``ripple_spec`` are REQUIRED keyword arguments with no defaults, which
+    is deliberate and mirrors SL-1's ``deploy_workers(project_dir=...)``. A default would
+    mean "assume static", and assuming static about a DYNAMIC svelte site queues a build
+    whose artifact nothing can deploy — a working publish traded for a broken one. There
+    is no safe default, so there is no default.
+
+    Widen the adapter-cloudflare exclusions ONLY together with the artifact: the moment
+    such an artifact can serve, ripple and dynamic svelte belong here too, and this
+    predicate is the one place that changes.
     """
-    return normalize_engine(engine) == "react"
+    normalized = normalize_engine(engine)
+    if normalized == "react":
+        return True
+    return normalized == "svelte" and not _is_dynamic(pattern, ripple_spec)
 
 
 async def _enqueue_static_build(

--- a/tests/ee/sites/test_async_publish.py
+++ b/tests/ee/sites/test_async_publish.py
@@ -13,12 +13,22 @@
 #      request returns before the site is up, so every path out of the job has to leave the
 #      row saying something true — and `built` must never mean "built but not serving".
 #
-# WHY REACT AND ONLY REACT flips today: an adapter-cloudflare artifact (ripple, dynamic
-# svelte) has pages rendered by a `_worker.js` whose imports sit outside the tarred
-# directory, so the artifact cannot serve. That is the same fact `truth_lane` refuses to
-# preview on. react emits a prerendered assets-only `dist`, so its tar IS the whole site.
+# WHICH SITES FLIP, and why it is a property of the SITE rather than of the engine name:
+# an adapter-cloudflare artifact (ripple, DYNAMIC svelte) has pages rendered by a
+# `_worker.js` whose imports sit outside the tarred directory, so the artifact cannot
+# serve. That is the same fact `truth_lane` refuses to preview on. react emits a
+# prerendered assets-only `dist`, so its tar IS the whole site.
 #
-# Mutations in tests/mutations/sl3_publish_flip.json, run and caught.
+# Edited 2026-08-11 (SL-4): STATIC svelte flips too, so the file now drives ONE engine down
+# BOTH lanes — see TestTheSvelteTrackForksOnTheSite. SL-3 excluded it on the stated grounds
+# that "which adapter ran is not knowable at enqueue time"; the dynamic fork sitting three
+# lines above the async fork already disproved that, so the tests that encoded it are gone
+# and the dynamic-svelte exclusion is now asserted on its real reason. The
+# dynamic-stays-out half is the regression guarantee and is the more important of the two:
+# queueing one trades a publish that works for one nothing can deploy.
+#
+# Mutations in tests/mutations/sl3_publish_flip.json and sl4_svelte_async.json, run and
+# caught.
 
 from __future__ import annotations
 
@@ -105,32 +115,72 @@ async def _publish(*, engine: str, pocket_id: str, gen: _FakeGenerator, **over: 
 # ---------------------------------------------------------------------------
 
 
+def _flips(engine: str | None, *, pattern: str | None = None, spec: Any = None) -> bool:
+    return sites_service.build_runs_async(engine, pattern=pattern, ripple_spec=spec)
+
+
 class TestOnlyTheDeployableEngineFlips:
     def test_react_builds_asynchronously(self) -> None:
-        assert sites_service.build_runs_async("react") is True
+        assert _flips("react") is True
 
-    @pytest.mark.parametrize("engine", ["ripple", "svelte", "html"])
+    def test_static_svelte_builds_asynchronously(self) -> None:
+        """SL-4. adapter-static emits ``build`` with no server entry, so a static svelte
+        tar IS the whole deployable site — the same property that qualified react."""
+        assert _flips("svelte", pattern="landing") is True
+
+    @pytest.mark.parametrize("engine", ["ripple", "html"])
     def test_every_other_engine_stays_inline(self, engine: str) -> None:
-        """Not an arbitrary allowlist. html runs no build at all; ripple and dynamic
-        svelte produce an artifact that cannot serve; static svelte is self-sufficient but
-        indistinguishable from the dynamic shape until AFTER the build, and a gate has to
-        decide before it spends the queue."""
-        assert sites_service.build_runs_async(engine) is False
+        """Not an arbitrary allowlist. html runs no build at all; ripple builds on
+        adapter-cloudflare and produces an artifact that cannot serve."""
+        assert _flips(engine) is False
 
     def test_an_unknown_engine_stays_inline(self) -> None:
         """Unknown normalises to ripple everywhere in this codebase, and ripple is inline.
         The fallback must not flip a site whose engine we failed to recognise."""
         for value in (None, "", "nope"):
-            assert sites_service.build_runs_async(value) is False
+            assert _flips(value) is False
 
     def test_no_flipped_engine_needs_a_worker_to_serve_its_pages(self) -> None:
         """The property behind the allowlist, checked against engines.py rather than
         restated. An engine whose output is worker-rendered cannot be deployed from a tar
-        of its static dir, so it must not be in the async set."""
+        of its static dir, so it must not be in the async set.
+
+        ``expects_server_worker`` is TRI-STATE and svelte's answer is ``None`` — either
+        shape is legitimate from the name alone — so the assertion is "not True" rather
+        than "is False". Narrowing it back to ``is False`` would fail on the very site this
+        slice added, and would be asserting the engine name can answer a question SL-1
+        established it cannot."""
         for engine in ("ripple", "svelte", "html", "react"):
-            if sites_service.build_runs_async(engine):
-                assert engines_mod.expects_server_worker(engine) is False, engine
+            if _flips(engine, pattern="landing"):
+                assert engines_mod.expects_server_worker(engine) is not True, engine
                 assert engines_mod.needs_node_build(engine) is True, engine
+
+
+class TestDynamicSvelteStaysInline:
+    """THE REGRESSION GUARANTEE OF SL-4, and the half that matters more than the flip.
+
+    A dynamic svelte site builds on adapter-cloudflare, whose pages are rendered by a
+    ``_worker.js`` importing two files from OUTSIDE the tarred directory — the same fact
+    ``truth_lane`` refuses to preview one on. Queueing it would trade a publish that works
+    for one nothing can deploy, and the deploy-side unpack would silently DROP the worker
+    on the way to the edge. So every route by which a site can be dynamic must keep it out.
+    """
+
+    def test_the_stamped_pattern_keeps_it_inline(self) -> None:
+        assert _flips("svelte", pattern="dynamic") is False
+
+    @pytest.mark.parametrize("key", ["sources", "actions", "auth"])
+    def test_an_unstamped_spec_carrying_live_bindings_keeps_it_inline(self, key: str) -> None:
+        """The safety net, not a formality: a pocket can carry dynamic bindings without
+        having been stamped, and ``_is_dynamic`` is authoritative on both routes."""
+        assert _flips("svelte", spec={key: [{"name": "x"}]}) is False
+
+    def test_the_predicate_has_no_default_for_the_site(self) -> None:
+        """``pattern`` / ``ripple_spec`` are REQUIRED keyword args. A default would mean
+        "assume static", and assuming static about a dynamic svelte site is exactly the
+        broken publish above — so there is deliberately no default to get wrong."""
+        with pytest.raises(TypeError):
+            sites_service.build_runs_async("svelte")  # type: ignore[call-arg]
 
 
 # ---------------------------------------------------------------------------
@@ -312,6 +362,126 @@ class TestAReactPublishEnqueues:
 
 
 # ---------------------------------------------------------------------------
+# SL-4 — the svelte track, BOTH WAYS through one publish
+# ---------------------------------------------------------------------------
+
+
+SVELTE_SOURCE = {"src/routes/+page.svelte": "<h1>hi</h1>"}
+
+
+def _svelte_static_artifact() -> bytes:
+    """An adapter-STATIC ``build`` tree, as the include-list tar would pack it.
+
+    Shaped from what adapter-static actually emits — a prerendered ``index.html`` per
+    route, ``_app/immutable`` for the JS/CSS payload, and whatever the project's
+    ``static/`` dir held — and deliberately NOT carrying a ``_worker.js`` or a
+    ``_routes.json``, because that is the whole difference from the dynamic shape and the
+    reason this tree can be deployed from a tar at all.
+    """
+    return tar_bytes(
+        {
+            "./index.html": b"<!doctype html><title>hi</title>",
+            "./about/index.html": b"<!doctype html><title>about</title>",
+            "./favicon.png": b"\x89PNG\r\n\x1a\n",
+            "./_app/immutable/e.js": b"export const x=1",
+            "./_app/immutable/assets/style.css": b"body{margin:0}",
+            "./_app/version.json": b'{"version":"1"}',
+        }
+    )
+
+
+class TestTheSvelteTrackForksOnTheSite:
+    """One engine, two publishes, two different lanes — driven end-to-end through
+    ``publish`` rather than through the predicate, because the predicate agreeing with
+    itself is not the property that matters. What matters is which lane a real publish
+    lands in, and the two tests below are deliberately symmetric so a change that flattens
+    the fork fails one of them.
+    """
+
+    async def test_a_static_svelte_publish_enqueues_and_returns(
+        self, beanie_test_db, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pool = _install_pool(monkeypatch, _FakePool())
+        pocket_id = await _seed_pocket()
+        gen = _FakeGenerator()
+
+        doc = await _publish(engine="svelte", pocket_id=pocket_id, gen=gen, source=SVELTE_SOURCE)
+
+        assert gen.build_calls == [], "the request still ran a build"
+        assert len(pool.calls) == 1
+        assert doc.build_status == "queued"
+        assert doc.build_job_id
+        # The engine reaches the worker as the normalised positional payload, which is
+        # how the lane knows to probe for adapter-static's ``build`` instead of the
+        # dynamic output dir.
+        assert pool.calls[0]["args"][3] == "svelte"
+
+    async def test_a_dynamic_svelte_publish_never_enters_the_build_lane(
+        self, beanie_test_db, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """THE ONE THAT MATTERS MOST. Its artifact's pages come from a ``_worker.js`` whose
+        imports sit outside the tar, and the deploy-side unpack DROPS that worker — so
+        enqueueing it would replace a working publish with one nothing can deploy. It keeps
+        the durable provision job (which owns standing up its D1) and never queues a build.
+        """
+        dispatched: list[dict[str, Any]] = []
+
+        async def _dispatch(**kw: Any) -> dict[str, Any]:
+            dispatched.append(kw)
+            return {"job_id": "job-1"}
+
+        from pocketpaw_ee.cloud.jobs import service as jobs_service
+
+        monkeypatch.setattr(jobs_service, "dispatch_job", _dispatch)
+        pool = _install_pool(monkeypatch, _FakePool())
+        pocket_id = await _seed_pocket(pattern="dynamic")
+        gen = _FakeGenerator()
+
+        await _publish(
+            engine="svelte",
+            pocket_id=pocket_id,
+            gen=gen,
+            source=SVELTE_SOURCE,
+            pattern="dynamic",
+        )
+
+        assert pool.calls == [], "a dynamic svelte publish queued a build"
+        assert len(dispatched) == 1
+        assert dispatched[0]["job_name"] == "provision_site"
+        assert gen.build_calls == []
+
+    async def test_an_unstamped_dynamic_svelte_publish_also_stays_out(
+        self, beanie_test_db, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Same guarantee via the OTHER route into ``_is_dynamic``: a spec carrying live
+        bindings that was never stamped ``pattern="dynamic"``. Checked through publish
+        because the stamp is what a caller controls and the spec is what a pocket can drift
+        into."""
+        dispatched: list[dict[str, Any]] = []
+
+        async def _dispatch(**kw: Any) -> dict[str, Any]:
+            dispatched.append(kw)
+            return {"job_id": "job-1"}
+
+        from pocketpaw_ee.cloud.jobs import service as jobs_service
+
+        monkeypatch.setattr(jobs_service, "dispatch_job", _dispatch)
+        pool = _install_pool(monkeypatch, _FakePool())
+        pocket_id = await _seed_pocket()
+
+        await _publish(
+            engine="svelte",
+            pocket_id=pocket_id,
+            gen=_FakeGenerator(),
+            source=SVELTE_SOURCE,
+            ripple_spec={"actions": [{"name": "signup"}]},
+        )
+
+        assert pool.calls == [], "an unstamped dynamic svelte publish queued a build"
+        assert len(dispatched) == 1
+
+
+# ---------------------------------------------------------------------------
 # The worker finishes the publish
 # ---------------------------------------------------------------------------
 
@@ -414,6 +584,76 @@ class TestTheWorkerFinishesThePublish:
 
         assert captured["index"] is True
         assert captured["nested"] is True
+
+    async def test_a_static_svelte_artifact_lands_where_the_resolver_looks(
+        self, beanie_test_db
+    ) -> None:
+        """SL-4, and the failure it prevents is a BLANK site replacing a working one.
+
+        The nominal ``static_output_rel("svelte")`` is the DYNAMIC shape
+        (``.svelte-kit/cloudflare``), which a static build never produces. Extracting there
+        and then letting ``resolve_static_output_rel`` probe would happen to agree — but it
+        would agree on a lie about which adapter ran, and the honest dir is what the deploy
+        target must find. So the extract uses the first PROBE CANDIDATE, and this asserts
+        the resolver then lands on the tree that was actually written."""
+        from pathlib import Path
+
+        from pocketpaw_ee.sites.engines import resolve_static_output_rel
+
+        site = await self._site()
+        captured: dict[str, Any] = {}
+
+        async def _deploy(*, project_dir: str, deploy_inputs: dict[str, Any]) -> Any:
+            captured["rel"] = resolve_static_output_rel(project_dir, "svelte")
+            captured["index"] = Path(project_dir, "build", "index.html").is_file()
+            captured["app"] = Path(project_dir, "build", "_app", "immutable", "e.js").is_file()
+            return None
+
+        await bj.run_site_build(
+            {},
+            "ws1",
+            str(site.id),
+            {"engine": "svelte", "siteConfig": {}},
+            "svelte",
+            600,
+            deploy_inputs=_deploy_inputs(str(site.id)),
+            _runner=_FakeRunner(),
+            _client=FaultyDaytonaClient(artifact=_svelte_static_artifact()),
+            _deployer=_deploy,
+        )
+
+        assert captured["rel"] == "build", "the deploy resolved a dir the unpack never wrote"
+        assert captured["index"] is True
+        assert captured["app"] is True, "svelte's whole JS payload was dropped"
+
+    async def test_the_preview_shaped_skip_list_drops_nothing_a_static_svelte_site_needs(
+        self, beanie_test_db
+    ) -> None:
+        """The trap SL-3 flagged for exactly this moment. ``unpack_artifact``'s skip list is
+        written for a PREVIEW and was safe only because the lane was react-only, so it is
+        re-checked here against an adapter-static tree rather than assumed still safe.
+
+        The finding: nothing deployable is dropped. adapter-static emits no ``_worker.js``
+        and none of adapter-cloudflare's deploy metadata, and ``_app`` — where svelte's
+        entire JS/CSS payload lives — matches no skip rule, because the lists key on exact
+        segment names and ``_app`` is not one of them."""
+        from pathlib import Path
+
+        from pocketpaw_ee.sites import artifact_preview
+
+        with tempfile.TemporaryDirectory() as dest:
+            unpacked = artifact_preview.unpack_artifact(_svelte_static_artifact(), Path(dest))
+            assert unpacked.server_entries == ()
+            assert unpacked.metadata_entries == ()
+            assert unpacked.rejected == ()
+            for rel in (
+                "index.html",
+                "about/index.html",
+                "favicon.png",
+                "_app/immutable/e.js",
+                "_app/immutable/assets/style.css",
+            ):
+                assert Path(dest, rel).is_file(), rel
 
     async def test_a_hostile_member_is_refused_rather_than_written(self, beanie_test_db) -> None:
         """The artifact is customer content, so the deploy path unpacks through the SAME

--- a/tests/ee/sites/test_daytona_build.py
+++ b/tests/ee/sites/test_daytona_build.py
@@ -24,6 +24,7 @@ import json
 
 import pytest
 from pocketpaw_ee.sites import daytona_build as db
+from pocketpaw_ee.sites import engines
 
 
 def _sentinel(**overrides: object) -> dict[str, object]:
@@ -278,6 +279,26 @@ class TestArtifactIncludeList:
         cmd = db.artifact_tar_command("svelte", "/home/daytona/proj", "/tmp/a.tgz")
         assert "/home/daytona/proj/.svelte-kit/cloudflare" in cmd
 
+    def test_an_override_replaces_the_output_dir_and_nothing_else(self) -> None:
+        """SL-4's seam for the wrapper, which resolves svelte's two output dirs at runtime.
+        The override must reach ``-C`` verbatim and must not disturb the include-list — a
+        change that dropped the exclusion here would ship node_modules to the edge."""
+        cmd = db.artifact_tar_command(
+            "svelte", "/home/daytona/proj", "/tmp/a.tgz", output_dir_expr='"$PROJECT/$REL"'
+        )
+        assert '-C "$PROJECT/$REL"' in cmd
+        assert "/home/daytona/proj/.svelte-kit/cloudflare" not in cmd
+        assert "--exclude=node_modules" in cmd
+
+    def test_the_default_command_stays_free_of_shell_constructs(self) -> None:
+        """A contract, not a style note: ``faults.pack_with_real_tar`` runs this through
+        ``shlex.split`` + ``subprocess.run`` with NO shell, which is what makes the
+        include-list testable against the real tar binary. Rendering a probe loop in here
+        would break that silently — the test would still pass, against nothing."""
+        cmd = db.artifact_tar_command("svelte", "/home/daytona/proj", "/tmp/a.tgz")
+        for construct in ("$", ";", "&&", "|", "\n", "`"):
+            assert construct not in cmd, construct
+
     def test_html_is_refused_because_its_output_is_the_project_root(self) -> None:
         """Tarring ``.`` would sweep in node_modules and defeat the include-list. html
         needs no build so never reaches this lane; a caller that gets here is buggy and
@@ -353,6 +374,56 @@ class TestWrapperScript:
         )
         assert "bun install --frozen-lockfile" in script
         assert "bun run build:prod" in script
+
+
+class TestTheSvelteOutputDirIsResolvedInTheSandbox:
+    """SL-4. The script is rendered BEFORE the build it packs, and which of svelte's two
+    adapters ran is only visible afterwards — on the sandbox's disk. So the script probes
+    there instead of predicting here. Without this the tar packed
+    ``.svelte-kit/cloudflare``, which a static build never creates, and every static svelte
+    publish through this lane would have produced zero bytes and classified as a failure.
+    """
+
+    def _svelte(self) -> str:
+        return db.build_wrapper_script(
+            "svelte", "/home/daytona/p", timeout_seconds=600, artifact_path="/tmp/a.tgz"
+        )
+
+    def test_the_probe_order_matches_the_resolvers(self) -> None:
+        """Load-bearing, and it is the reason both read one list: ``build`` must be tried
+        FIRST so a stale adapter-cloudflare tree left by a pre-SL-1 build cannot shadow what
+        this build emitted. Reversed, the lane silently ships the old artifact."""
+        candidates = engines.static_output_rel_candidates("svelte")
+        assert candidates == ("build", ".svelte-kit/cloudflare")
+        assert f"for CAND in {' '.join(candidates)}; do" in self._svelte()
+
+    def test_the_tar_reads_the_resolved_dir_and_not_the_nominal_one(self) -> None:
+        script = self._svelte()
+        assert '-C "$PROJECT/$ARTIFACT_REL"' in script
+        assert "-C '/home/daytona/p/.svelte-kit/cloudflare'" not in script
+
+    def test_the_probe_runs_after_the_build_and_before_the_tar(self) -> None:
+        """Before the build neither candidate exists, so a probe hoisted above it always
+        falls through to the nominal dynamic dir — the bug this fixes, reintroduced."""
+        script = self._svelte()
+        assert script.index("bun run build") < script.index("for CAND in")
+        assert script.index("for CAND in") < script.index("tar -czf")
+
+    def test_the_sentinel_reports_the_dir_that_was_actually_packed(self) -> None:
+        """``artifact_rel`` in the sentinel is the record of where the bytes came from. It
+        reads ``$ARTIFACT_REL``, so resolving that variable is what keeps the record honest
+        rather than a restatement of the guess."""
+        assert '"$ARTIFACT_REL"' in self._svelte()
+
+    def test_a_single_shape_engine_renders_no_probe(self) -> None:
+        """react and ripple have exactly one output dir each, so they pay nothing for
+        svelte's ambiguity and their script is unchanged."""
+        for engine, nominal in (("react", "dist"), ("ripple", ".svelte-kit/cloudflare")):
+            script = db.build_wrapper_script(
+                engine, "/home/daytona/p", timeout_seconds=600, artifact_path="/tmp/a.tgz"
+            )
+            assert "for CAND in" not in script, engine
+            assert f"-C /home/daytona/p/{nominal} " in script, engine
 
 
 class TestResolveBuildTimeout:

--- a/tests/mutations/fault_ladder.json
+++ b/tests/mutations/fault_ladder.json
@@ -2,8 +2,8 @@
   {
     "label": "the artifact is packed from the project root, so node_modules ships to the edge and a 30 KB site becomes a 500 MB upload",
     "file": "ee/pocketpaw_ee/sites/daytona_build.py",
-    "find": "    output_dir = f\"{project_dir.rstrip('/')}/{rel}\"",
-    "replace": "    output_dir = project_dir.rstrip('/')",
+    "find": "        output_dir_expr = shlex.quote(f\"{project_dir.rstrip('/')}/{rel}\")",
+    "replace": "        output_dir_expr = shlex.quote(project_dir.rstrip(\"/\"))",
     "tests": [
       "tests/ee/sites/test_fault_ladder_build.py"
     ]
@@ -11,7 +11,7 @@
   {
     "label": "the include-list becomes an exclude-list that forgets node_modules, which is the regression that silently ships the whole dependency tree",
     "file": "ee/pocketpaw_ee/sites/daytona_build.py",
-    "find": "    return (\n        f\"tar -czf {shlex.quote(dest_path)} -C {shlex.quote(output_dir)} \"\n        f\"--exclude={shlex.quote(_EXCLUDED_MEMBER)} .\"\n    )",
+    "find": "    return (\n        f\"tar -czf {shlex.quote(dest_path)} -C {output_dir_expr} \"\n        f\"--exclude={shlex.quote(_EXCLUDED_MEMBER)} .\"\n    )",
     "replace": "    return (\n        f\"tar -czf {shlex.quote(dest_path)} --exclude=.git \"\n        f\"-C {shlex.quote(project_dir.rstrip('/'))} .\"\n    )",
     "tests": [
       "tests/ee/sites/test_fault_ladder_build.py"

--- a/tests/mutations/sites_sl1_resolvers.json
+++ b/tests/mutations/sites_sl1_resolvers.json
@@ -2,36 +2,47 @@
   {
     "label": "probe order reversed — a stale adapter-cloudflare tree shadows the current build",
     "file": "ee/pocketpaw_ee/sites/engines.py",
-    "find": "for candidate in (_SVELTE_STATIC_OUTPUT_REL, _STATIC_OUTPUT_REL[\"svelte\"]):",
-    "replace": "for candidate in (_STATIC_OUTPUT_REL[\"svelte\"], _SVELTE_STATIC_OUTPUT_REL):",
-    "tests": ["tests/ee/sites/test_engines.py::TestResolveStaticOutputRel"]
+    "find": "        return (_SVELTE_STATIC_OUTPUT_REL, _STATIC_OUTPUT_REL[\"svelte\"])",
+    "replace": "        return (_STATIC_OUTPUT_REL[\"svelte\"], _SVELTE_STATIC_OUTPUT_REL)",
+    "tests": [
+      "tests/ee/sites/test_engines.py::TestResolveStaticOutputRel",
+      "tests/ee/sites/test_daytona_build.py::TestTheSvelteOutputDirIsResolvedInTheSandbox::test_the_probe_order_matches_the_resolvers"
+    ]
   },
   {
     "label": "_worker.js tested with is_file() — a worker DIRECTORY reads as no worker",
     "file": "ee/pocketpaw_ee/sites/engines.py",
     "find": "return (out_dir / \"_worker.js\").exists()",
     "replace": "return (out_dir / \"_worker.js\").is_file()",
-    "tests": ["tests/ee/sites/test_engines.py::TestResolveEmitsServerWorker"]
+    "tests": [
+      "tests/ee/sites/test_engines.py::TestResolveEmitsServerWorker"
+    ]
   },
   {
     "label": "svelte-only guard defeated — ripple/html/react start probing the filesystem too",
     "file": "ee/pocketpaw_ee/sites/engines.py",
     "find": "    if normalized != \"svelte\":",
     "replace": "    if normalized != \"svelte\" and False:",
-    "tests": ["tests/ee/sites/test_engines.py::TestResolveStaticOutputRel"]
+    "tests": [
+      "tests/ee/sites/test_engines.py::TestResolveStaticOutputRel"
+    ]
   },
   {
     "label": "server-worker engine guard defeated — html/react consult a stray _worker.js",
     "file": "ee/pocketpaw_ee/sites/engines.py",
     "find": "    if normalize_engine(engine) not in _SERVER_WORKER_ENGINES:",
     "replace": "    if normalize_engine(engine) not in _SERVER_WORKER_ENGINES and False:",
-    "tests": ["tests/ee/sites/test_engines.py::TestResolveEmitsServerWorker"]
+    "tests": [
+      "tests/ee/sites/test_engines.py::TestResolveEmitsServerWorker"
+    ]
   },
   {
     "label": "static svelte reports the dynamic dir — the deploy uploads an empty tree",
     "file": "ee/pocketpaw_ee/sites/engines.py",
     "find": "_SVELTE_STATIC_OUTPUT_REL = \"build\"",
     "replace": "_SVELTE_STATIC_OUTPUT_REL = \".svelte-kit/cloudflare\"",
-    "tests": ["tests/ee/sites/test_engines.py"]
+    "tests": [
+      "tests/ee/sites/test_engines.py"
+    ]
   }
 ]

--- a/tests/mutations/sl3_publish_flip.json
+++ b/tests/mutations/sl3_publish_flip.json
@@ -2,7 +2,7 @@
   {
     "label": "SL-3: every engine flips to async, so a ripple or dynamic-svelte publish queues a build whose artifact cannot serve (its pages come from a _worker.js whose imports sit outside the tar) — the site stops publishing",
     "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "    return normalize_engine(engine) == \"react\"",
+    "find": "    normalized = normalize_engine(engine)\n    if normalized == \"react\":\n        return True\n    return normalized == \"svelte\" and not _is_dynamic(pattern, ripple_spec)",
     "replace": "    return True",
     "tests": [
       "tests/ee/sites/test_async_publish.py::TestOnlyTheDeployableEngineFlips",
@@ -12,8 +12,8 @@
   {
     "label": "SL-3: no engine flips, so the whole slice is inert — publish still blocks on an inline build and the queued-build UI has nothing to show",
     "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "def build_runs_async(engine: str | None) -> bool:",
-    "replace": "def build_runs_async(engine: str | None) -> bool:\n    return False",
+    "find": "def build_runs_async(\n    engine: str | None,\n    *,\n    pattern: str | None,\n    ripple_spec: dict[str, Any] | None,\n) -> bool:",
+    "replace": "def build_runs_async(\n    engine: str | None,\n    *,\n    pattern: str | None,\n    ripple_spec: dict[str, Any] | None,\n) -> bool:\n    return False",
     "tests": [
       "tests/ee/sites/test_async_publish.py::TestAReactPublishEnqueues",
       "tests/ee/sites/test_async_publish.py::TestOnlyTheDeployableEngineFlips::test_react_builds_asynchronously"
@@ -22,8 +22,8 @@
   {
     "label": "SL-3: the async fork stops excluding a worker callback, so the worker's deploy re-enters the fork and enqueues ANOTHER build — a publish that queues itself forever and never goes live",
     "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "    if prebuilt_project_dir is None and build_runs_async(engine):",
-    "replace": "    if build_runs_async(engine):",
+    "find": "    if prebuilt_project_dir is None and build_runs_async(\n        engine, pattern=pattern, ripple_spec=ripple_spec\n    ):",
+    "replace": "    if build_runs_async(engine, pattern=pattern, ripple_spec=ripple_spec):",
     "tests": [
       "tests/ee/sites/test_async_publish.py::TestTheDeploySeamRunsTheInlineTail"
     ]
@@ -86,7 +86,7 @@
   {
     "label": "SL-3: the artifact is extracted FLAT instead of under the engine's static-output dir, so the deploy target resolves an empty directory and a blank site replaces a working one",
     "file": "ee/pocketpaw_ee/sites/build_job.py",
-    "find": "            artifact, Path(project_dir, static_output_rel(engine))",
+    "find": "            artifact, Path(project_dir, static_output_rel_candidates(engine)[0])",
     "replace": "            artifact, Path(project_dir)",
     "tests": [
       "tests/ee/sites/test_async_publish.py::TestTheWorkerFinishesThePublish::test_the_deploy_receives_the_artifact_under_the_engines_output_dir"

--- a/tests/mutations/sl4_svelte_async.json
+++ b/tests/mutations/sl4_svelte_async.json
@@ -20,10 +20,10 @@
     ]
   },
   {
-    "label": "SL-4: the fork stops passing the site to the predicate and lets it default, so a dynamic svelte publish is treated as static — this is why the parameters have no defaults, and the mutation proves the call site cannot regress silently",
+    "label": "SL-4: the publish's DYNAMIC fork is removed, so a dynamic svelte site falls through to the async fork. Before SL-4 that only cost it the provision job and it still built inline; now it is QUEUED, and the artifact the lane produces has its _worker.js dropped at unpack — a site that cannot serve is pushed to the edge",
     "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "    if prebuilt_project_dir is None and build_runs_async(\n        engine, pattern=pattern, ripple_spec=ripple_spec\n    ):",
-    "replace": "    if prebuilt_project_dir is None and build_runs_async(\n        engine, pattern=None, ripple_spec=None\n    ):",
+    "find": "    if _is_dynamic(pattern, ripple_spec):\n        return await _provision_dynamic_site(",
+    "replace": "    if False:\n        return await _provision_dynamic_site(",
     "tests": [
       "tests/ee/sites/test_async_publish.py::TestTheSvelteTrackForksOnTheSite::test_a_dynamic_svelte_publish_never_enters_the_build_lane",
       "tests/ee/sites/test_async_publish.py::TestTheSvelteTrackForksOnTheSite::test_an_unstamped_dynamic_svelte_publish_also_stays_out"

--- a/tests/mutations/sl4_svelte_async.json
+++ b/tests/mutations/sl4_svelte_async.json
@@ -1,0 +1,69 @@
+[
+  {
+    "label": "SL-4: the predicate answers from the engine name alone again, so EVERY svelte site queues its build — including a dynamic one, whose artifact's pages come from a _worker.js the deploy-side unpack then drops. A working publish is replaced by one nothing can deploy",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    return normalized == \"svelte\" and not _is_dynamic(pattern, ripple_spec)",
+    "replace": "    return normalized == \"svelte\"",
+    "tests": [
+      "tests/ee/sites/test_async_publish.py::TestDynamicSvelteStaysInline",
+      "tests/ee/sites/test_async_publish.py::TestTheSvelteTrackForksOnTheSite::test_a_dynamic_svelte_publish_never_enters_the_build_lane"
+    ]
+  },
+  {
+    "label": "SL-4: the dynamic check is INVERTED, so static svelte blocks the request for the whole build while dynamic svelte queues one that cannot deploy — both lanes wrong at once, and the flip appears to work because something still enqueues",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    return normalized == \"svelte\" and not _is_dynamic(pattern, ripple_spec)",
+    "replace": "    return normalized == \"svelte\" and _is_dynamic(pattern, ripple_spec)",
+    "tests": [
+      "tests/ee/sites/test_async_publish.py::TestOnlyTheDeployableEngineFlips::test_static_svelte_builds_asynchronously",
+      "tests/ee/sites/test_async_publish.py::TestTheSvelteTrackForksOnTheSite::test_a_static_svelte_publish_enqueues_and_returns"
+    ]
+  },
+  {
+    "label": "SL-4: the fork stops passing the site to the predicate and lets it default, so a dynamic svelte publish is treated as static — this is why the parameters have no defaults, and the mutation proves the call site cannot regress silently",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if prebuilt_project_dir is None and build_runs_async(\n        engine, pattern=pattern, ripple_spec=ripple_spec\n    ):",
+    "replace": "    if prebuilt_project_dir is None and build_runs_async(\n        engine, pattern=None, ripple_spec=None\n    ):",
+    "tests": [
+      "tests/ee/sites/test_async_publish.py::TestTheSvelteTrackForksOnTheSite::test_a_dynamic_svelte_publish_never_enters_the_build_lane",
+      "tests/ee/sites/test_async_publish.py::TestTheSvelteTrackForksOnTheSite::test_an_unstamped_dynamic_svelte_publish_also_stays_out"
+    ]
+  },
+  {
+    "label": "SL-4: the in-sandbox tar goes back to the NOMINAL per-engine output dir, which for svelte names the dynamic .svelte-kit/cloudflare a static build never creates — so every static svelte build tars nothing, comes back at zero bytes, and is reported to the user as a build failure",
+    "file": "ee/pocketpaw_ee/sites/daytona_build.py",
+    "find": "        tar_cmd = artifact_tar_command(\n            engine, project_dir, artifact_path, output_dir_expr='\"$PROJECT/$ARTIFACT_REL\"'\n        )",
+    "replace": "        tar_cmd = artifact_tar_command(engine, project_dir, artifact_path)",
+    "tests": [
+      "tests/ee/sites/test_daytona_build.py::TestTheSvelteOutputDirIsResolvedInTheSandbox::test_the_tar_reads_the_resolved_dir_and_not_the_nominal_one"
+    ]
+  },
+  {
+    "label": "SL-4: the output-dir probe is hoisted ABOVE the build, where neither candidate exists yet, so it always falls through to the nominal dynamic dir and the resolution is inert — the original bug with a probe in front of it",
+    "file": "ee/pocketpaw_ee/sites/daytona_build.py",
+    "find": "timeout {timeout_seconds}s {build_command} >>\"$STDERR_LOG\" 2>&1",
+    "replace": "{probe}\ntimeout {timeout_seconds}s {build_command} >>\"$STDERR_LOG\" 2>&1",
+    "tests": [
+      "tests/ee/sites/test_daytona_build.py::TestTheSvelteOutputDirIsResolvedInTheSandbox::test_the_probe_runs_after_the_build_and_before_the_tar"
+    ]
+  },
+  {
+    "label": "SL-4: the deploy-side unpack goes back to the nominal rel, so a static svelte artifact is extracted into .svelte-kit/cloudflare while the deploy target resolves build — the deploy finds an empty directory and a blank site replaces a working one",
+    "file": "ee/pocketpaw_ee/sites/build_job.py",
+    "find": "            artifact, Path(project_dir, static_output_rel_candidates(engine)[0])",
+    "replace": "            artifact, Path(project_dir, static_output_rel_candidates(engine)[-1])",
+    "tests": [
+      "tests/ee/sites/test_async_publish.py::TestTheWorkerFinishesThePublish::test_a_static_svelte_artifact_lands_where_the_resolver_looks"
+    ]
+  },
+  {
+    "label": "SL-4: the preview's server-entry skip list grows _app, so unpack drops svelte's ENTIRE JS and CSS payload and the site deploys as unstyled, non-hydrating markup — a deploy that looks like it worked",
+    "file": "ee/pocketpaw_ee/sites/artifact_preview.py",
+    "find": "_SERVER_ENTRY_NAMES: frozenset[str] = frozenset({\"_worker.js\"})",
+    "replace": "_SERVER_ENTRY_NAMES: frozenset[str] = frozenset({\"_worker.js\", \"_app\"})",
+    "tests": [
+      "tests/ee/sites/test_async_publish.py::TestTheWorkerFinishesThePublish::test_the_preview_shaped_skip_list_drops_nothing_a_static_svelte_site_needs",
+      "tests/ee/sites/test_async_publish.py::TestTheWorkerFinishesThePublish::test_a_static_svelte_artifact_lands_where_the_resolver_looks"
+    ]
+  }
+]


### PR DESCRIPTION
## Read this first: seven tests are red and the reason is a decision, not a bug

`tests/ee/sites` is **12 failed / 1015 passed** against a 5-failed baseline (the four
Windows wedged-child ones in `test_generator_client_timeout.py`, #1899, plus flaky
`test_dev_server`). The seven extra failures are all one root cause and they are worth a
ruling before this merges:

```
test_builder_origin.py::test_edit_component_preserves_stored_builder_origin
test_builder_origin.py::test_edit_component_on_non_editable_site_stays_non_editable
test_builder_origin.py::test_make_site_editable_republishes_with_origin
test_edit_draft_not_publish.py::test_chat_create_publish_still_goes_live
test_native_artifact.py::test_publish_prewarms_then_native_artifact_hits
test_native_artifact.py::test_publish_prewarm_uses_prewarm_origin_over_env
test_native_artifact.py::test_publish_no_prewarm_origin_keeps_env_fallback
test_smoke_at_publish.py::test_live_publish_runs_smoke
```

Every one publishes a `pattern="landing"` svelte pocket — genuinely static, so it takes the
new lane and dies on `POCKETPAW_REDIS_URL is not set`. They are not incidental users of the
svelte engine. They assert the **synchronous** publish contract:

- `test_chat_create_publish_still_goes_live` — a publish returns with `deployed=True` and the
  draft already promoted to `published`. Async returns before either happens; both are
  deferred to the worker, not lost.
- `test_live_publish_runs_smoke` — the inline SSR fail-gate runs in the request. The sandbox
  build still fails a broken site, so nothing broken deploys, but the user now sees a queued
  build settling `build_failed` instead of a synchronous `SmokeGateFailed`.
- the three `publish_prewarm` ones — **the real loss.** PERF-3 has a svelte publish build into
  the stable per-pocket dir, leaving `node_modules` and a built tree that the edit lane's
  `get_native_artifact` reuses. An ephemeral sandbox deletes itself, so nothing local is
  warmed and the first edit after a publish pays a cold build. Publish got fast; the first
  edit got slower.
- the three `test_builder_origin` ones — the edit lane's own republish. `edit_svelte_component`
  rolls back on a smoke failure precisely because "a broken edit never reaches the live
  deploy" (service.py says so at the `smoke=True` call). With an async publish that gate
  moves into the worker.

#1908 already made all of this true for react and shipped. The svelte tests are simply the
first place the contract is actually asserted. **I did not rewrite them to expect `queued`** —
that would convert a product decision into a test-maintenance diff and hide the prewarm
regression. Two ways forward, and the choice is the captain's:

1. accept the deferred-live / deferred-promotion semantics for svelte as they already are for
   react, update these seven, and open a follow-up for the edit lane's warm dir; or
2. narrow the flip so the edit-lane republish stays inline and only a fresh publish queues.

Everything below is complete and green on its own terms.

## What changed

`build_runs_async` decides whether a publish queues its build or blocks the request running
it inline. It took an engine name and returned True for react alone. It now takes the site:

```python
def build_runs_async(
    engine: str | None,
    *,
    pattern: str | None,
    ripple_spec: dict[str, Any] | None,
) -> bool
```

True for react and for **static svelte** (`not _is_dynamic(pattern, ripple_spec)`).

Both new parameters are required keyword arguments with no defaults. A default would mean
"assume static", and assuming static about a dynamic svelte site queues a build whose artifact
nothing can deploy. There is no safe default, so there is no default — the same reasoning SL-1
used for `deploy_workers(project_dir=...)`.

## Why this one mattered more than its size

react has the whole async publish pipeline and **no edit lane at all** — `react-scaffold.ts`
says so outright. svelte has the real edit lane (`edit_svelte_component` plus the REPL) and a
publish that blocks the request for the entire build. The engine you could edit was the slow
one and the fast one could not be edited.

## The reason #1908 gave for excluding svelte does not hold

Its docstring excluded static svelte because "which adapter ran is a property of the built
SITE and is not knowable at enqueue time". The code three lines above the gate disproves it:
`_deploy_site_doc` forks on `_is_dynamic(pattern, ripple_spec)` before any build, from data
the caller already holds, and `service.py`'s own header says the publish path forks on
`_is_dynamic` before any build.

What is genuinely unknowable is the adapter from the engine *string* — a different claim. The
fix is to stop asking the string. The docstring now carries the real reason static svelte is
included and keeps the other exclusions.

## Dynamic svelte and ripple stay inline

An adapter-cloudflare build's pages are rendered by a `_worker.js` importing two files from
outside the tarred directory, so the artifact cannot serve. Not a guess — it is the same fact
`truth_lane` refuses to preview one on, and the deploy-side unpack would drop that worker on
the way to the edge. html runs no build, so there is nothing to enqueue.

## Two things had to move before a static svelte build could survive the lane

Neither is cosmetic; the first would have failed every static svelte publish.

**The in-sandbox tar packed the wrong directory.** `artifact_tar_command` used the nominal
`static_output_rel(engine)`, whose svelte row names `.svelte-kit/cloudflare` — the *dynamic*
shape. adapter-static writes `build`. The tar would have targeted a directory that does not
exist, come back at zero bytes, and classified as a build failure reported to the user.

The wrapper script now resolves the output dir at runtime *in the sandbox*, after the build,
probing candidates in order — the shell twin of `resolve_static_output_rel`. That is the choice
`engines.py` already made for this fact: read the artifact rather than thread a static/dynamic
flag through call sites that can disagree with it. In the sandbox the artifact is on disk. The
sentinel's `artifact_rel` reads the resolved value, so the record of where the bytes came from
stays honest.

`artifact_tar_command` gained an `output_dir_expr` override for that one caller and without it
stays a single `tar` invocation with no shell constructs — a contract, because
`faults.pack_with_real_tar` runs the rendered command through `shlex.split` with no shell, and
a probe loop in there would silently stop being tested against the real tar binary.

The probe order now lives in `engines.static_output_rel_candidates`, which
`resolve_static_output_rel` reads instead of keeping its own copy. `build` first is
load-bearing: reversed, a stale adapter-cloudflare tree shadows what the current build emitted.
Engines with one output shape render byte-identical scripts and pay nothing.

**The deploy-side unpack chose its extract dir the same wrong way.** It now extracts under the
first probe candidate, so the deploy-side resolver lands on the tree that was actually written
— `dist` for react and `.svelte-kit/cloudflare` for ripple exactly as before, `build` for
svelte.

## The skip list, which #1908 flagged for exactly this moment

`unpack_artifact`'s skip list is preview-shaped and was safe only because the lane was
react-only. Re-checked against what adapter-static emits: **nothing deployable is dropped.**

- `_worker.js` — adapter-static emits none. That is the whole difference from the dynamic shape
  and the reason this tree can be deployed from a tar at all.
- `_routes.json` / `.assetsignore` — adapter-cloudflare artifacts, absent from a `build` tree.
  `deploy_workers` writes its own `.assetsignore` regardless, so carrying the build's copy is
  what would break, not dropping it.
- `_headers` / `_redirects` — Pages-format config. adapter-static does not emit them; it would
  copy them verbatim if a site authored them into `static/`. Dropping them is still correct:
  the deploy target is a Worker with an assets binding and reads neither file.
- `_app/` — svelte's entire JS and CSS payload, matched by no skip rule, because the lists key
  on exact segment names and `_app` is not one of them. There is a test and a mutation on this
  one specifically, since it is the drop that would deploy unstyled non-hydrating markup and
  look like it worked.

## Verification

- `tests/ee/sites`: 12 failed / 1015 passed / 4 skipped in 69s. Baseline 5 failed; the seven
  extra are the section at the top.
- Both ways through one publish, in `TestTheSvelteTrackForksOnTheSite`:
  `test_a_static_svelte_publish_enqueues_and_returns` and
  `test_a_dynamic_svelte_publish_never_enters_the_build_lane`, plus
  `test_an_unstamped_dynamic_svelte_publish_also_stays_out` for the other route into
  `_is_dynamic`. The dynamic half is the regression guarantee and matters more.
- `tests/mutations/sl4_svelte_async.json` — 7 mutations, **all caught**. One escaped on the
  first sweep: making the call site default the site away is harmless, because the dynamic fork
  returns before the predicate is reached. The premise was wrong, not the suite, so it was
  replaced with the mutation that does have a harm — removing the dynamic fork, which before
  this slice only cost a dynamic site its provision job and now gets it queued.
- Four existing plans had anchors in code this PR touched. Repointed at the current code with
  their harms intact rather than left silently inert, and re-run whole: `sl3_publish_flip`
  11/11, `fault_ladder` 19/19, `sites_sl1_resolvers` 5/5. The SL-1 probe-order mutation now
  also names the sandbox test it breaks.
- `python scripts/mutate.py --validate`: 282 anchors across 25 plans.
- `uv run ruff check .` and `ruff format --check .` clean repo-wide.
