### PR TITLE
Make the queued stamp a claim, so one publish means one sandbox

### DIFF
--- a/docs/runbooks/2026-08-11-site-build-burst-harness.md
+++ b/docs/runbooks/2026-08-11-site-build-burst-harness.md
@@ -26,35 +26,40 @@ The mutation plan that proves the assertions bite:
 uv run python scripts/mutate.py --plan tests/mutations/sites_burst_harness.json
 ```
 
-## What it found
+## What it found, and what the fix was
 
-**A concurrent burst defeats the single-flight guard.** `enqueue_site_build` gates on a
-READ (`should_enqueue`) and then stamps with a WRITE (`mark_build_queued`), and it awaits
-between the two. Any publish arriving inside that window reads a row with no build in
-flight, passes the gate correctly, and opens its own sandbox. Measured: **8 concurrent
-publishes of one site produce 8 sandboxes.** Two are enough to reproduce it — two clicks
-inside one round trip.
+**A concurrent burst defeated the single-flight guard.** `enqueue_site_build` gated on a
+READ (`should_enqueue`) and then stamped with a WRITE (`mark_build_queued`), awaiting
+between the two. Any publish arriving inside that window read a row with no build in
+flight, passed the gate correctly, and opened its own sandbox. Measured: **8 concurrent
+publishes of one site produced 8 sandboxes.** Two were enough — two clicks inside one round
+trip.
 
-The state machine itself is sound, which is what localises the defect:
+The state machine itself was sound, which is what localised the defect:
 
-| Burst shape | Sandboxes for one site | Reading |
-|---|---|---|
-| Publishes serialised (await each) | 1, second returns `None` | The guard works |
-| Burst arriving after the stamp landed | 0, all refused | `should_enqueue` is correct |
-| 8 concurrent, one shared row object | 8 | The read-write window is open |
-| 8 concurrent, each having loaded its own row | 8 | Same window, across workers |
-| 8 concurrent across 8 different sites | 8 | Correct — the guard is per-site, not global |
+| Burst shape | Before | After | Reading |
+|---|---|---|---|
+| Publishes serialised (await each) | 1 | 1 | The rule was never wrong |
+| Burst arriving after the stamp landed | 0, all refused | 0, all refused | `should_enqueue` is correct |
+| 8 concurrent, one shared row object | 8 | 1 | The read-write window is closed |
+| 8 concurrent, each having loaded its own row | 8 | 1 | Closed across workers too |
+| 8 concurrent across 8 different sites | 8 | 8 | Correct — the guard is per-site, not global |
 
-So this is missing atomicity at the row, not a bug in `build_state`. The fix is a
-conditional write: stamp `queued` only if the row is still observed non-in-flight
-(Mongo `find_one_and_update` with a status precondition), and have the loser of the race
-get nothing back and return `None`. When that lands, the assertions in
-`TestSingleFlightUnderContention` flip from `sandboxes == BURST` to `sandboxes == 1` and
-`refused == BURST - 1`. Those numbers are asserted exactly so that flip is the fix's
-acceptance test.
+The fix (`fix/atomic-queued-stamp`) moves the decision into the write.
+`service.claim_build_queued` stamps `queued` through `find_one_and_update` with
+`build_state.claim_precondition` as its filter, so the database picks one winner; the losers
+write nothing and return `None`, which is the same answer a refused publish gave before.
+There is no `should_enqueue` pre-check in front of it any more — one gate, and it is the
+conditional write.
 
-The harness leaves the current behaviour pinned rather than fixed, because the fix is a
-change to the write path and belongs in its own reviewed PR.
+**The precondition has to encode staleness, not just status.** A filter of "status is not
+queued or building" would refuse a STALE in-flight row, which is the one case the window
+deliberately lets through, and that is how a site becomes permanently unpublishable. So it
+is a disjunction mirroring `should_enqueue`'s branches: status not in flight, OR the stamp
+is not a date (missing, null, or garbage — which reads as stale), OR the stamp is older
+than the row's derived window. `TestTheClaimPreconditionMatchesTheGuard` asserts the filter
+and `should_enqueue` reach the same verdict on every state, because the rule now lives in
+two languages and drift in the strict direction is the expensive one.
 
 A second, smaller observation while sizing anything: `STALE_MARGIN` is 10 minutes, so for
 any engine budget well under that the margin dominates the derived window and deriving it
@@ -87,7 +92,14 @@ Read this before quoting a green run as evidence for a concurrency cap.
   (`Document.update` → `merge_models(self, result)`), so against real Mongo that case
   races too. This is why the harness's own `FakeSite.set` yields before applying: it is
   the faithful model, and a fake that applied writes synchronously would report a
-  guarantee the lane does not have.
+  guarantee the lane does not have. The corollary matters for reviewing the fix: a green
+  mongomock run proves nothing about atomicity, so the flipped assertions are verified on
+  the yielding fake and mongomock is used only where its lack of yielding is irrelevant —
+  asserting what the precondition MEANS to a query engine.
+- **It does not prove Mongo's atomicity, it assumes it.** `FakeCollection` reproduces the
+  one guarantee the fix rests on (a single-document update matches and applies without
+  yielding). That guarantee is Mongo's to keep; the harness verifies the lane depends on
+  nothing more than it.
 
 Sizing the cap still needs a live run.
 

--- a/ee/pocketpaw_ee/sites/build_job.py
+++ b/ee/pocketpaw_ee/sites/build_job.py
@@ -151,7 +151,7 @@ from arq import create_pool
 from arq.connections import ArqRedis, RedisSettings
 
 from pocketpaw_ee.sites import service as sites_service
-from pocketpaw_ee.sites.build_state import BuildStatus, settle, should_enqueue
+from pocketpaw_ee.sites.build_state import BuildStatus, settle
 from pocketpaw_ee.sites.daytona_build import resolve_build_timeout_seconds
 from pocketpaw_ee.sites.daytona_runner import (
     EXEC_TIMEOUT_SLACK_SECONDS,
@@ -740,17 +740,22 @@ async def enqueue_site_build(
 
     Order, and why each step is where it is:
 
-      1. GATE on ``should_enqueue``. A build genuinely in flight must not get a second
-         sandbox; a stale one must not block forever. Both live in ``build_state``.
-      2. STAMP ``queued`` + the clock + the job id, in ONE write, BEFORE the enqueue.
-         Before, because a worker that claimed the job first would write a terminal
-         status and then have this stamp land on top of it, pinning a finished build in
-         ``queued`` forever. One write, because the job id is minted here rather than
-         read back off the enqueue, so there is no second write to race with the job.
-      3. ENQUEUE. On ANY failure — a dead Redis, or arq refusing the id — roll the row to
+      1. CLAIM the slot: stamp ``queued`` + the clock + the job id in ONE CONDITIONAL
+         write, BEFORE the enqueue. Conditional because the gate and the stamp used to be
+         two steps — read ``should_enqueue``, then write — and every publish arriving
+         between them read the same pre-stamp row, passed the gate correctly, and opened
+         its own sandbox: 8 concurrent publishes of one site produced 8 sandboxes. The
+         precondition (``build_state.claim_precondition``) puts the decision inside the
+         write so the database picks one winner; the losers return ``None`` having written
+         nothing. Before the enqueue, because a worker that claimed the job first would
+         write a terminal status and then have this stamp land on top of it, pinning a
+         finished build in ``queued`` forever. One write, because the job id is minted here
+         rather than read back off the enqueue, so there is no second write to race with
+         the job.
+      2. ENQUEUE. On ANY failure — a dead Redis, or arq refusing the id — roll the row to
          a terminal status and re-raise. Skipping the rollback is what pins a row in
-         ``queued`` behind an enqueue that never happened, and ``should_enqueue`` would
-         then no-op every publish of this site until the staleness window lapsed.
+         ``queued`` behind an enqueue that never happened, and the claim would then refuse
+         every publish of this site until the staleness window lapsed.
 
     ``timeout_seconds`` defaults to the engine's resolved budget and is passed on to the
     job, so the window the guard measures and the budget the sandbox is held to are one
@@ -762,16 +767,19 @@ async def enqueue_site_build(
         timeout_seconds if timeout_seconds is not None else resolve_build_timeout_seconds(engine)
     )
 
-    if not should_enqueue(site, timeout):
+    # The claim IS the gate. There is deliberately no ``should_enqueue`` pre-check in
+    # front of it: a second reader of the same rule would be free but would also invite
+    # the next reader of this code to believe the read is what protects the site, which is
+    # the belief that cost 8 sandboxes. One gate, and it is the conditional write.
+    job_id = _mint_job_id(site_id)
+    claimed = await sites_service.claim_build_queued(site, job_id=job_id, timeout_seconds=timeout)
+    if not claimed:
         logger.info(
             "sites.build: site %s already has a build in flight (%s) — not enqueueing",
             site_id,
             getattr(site, "build_status", None),
         )
         return None
-
-    job_id = _mint_job_id(site_id)
-    await sites_service.mark_build_queued(site, job_id=job_id)
 
     try:
         pool = _pool_override or await _get_pool()

--- a/ee/pocketpaw_ee/sites/build_state.py
+++ b/ee/pocketpaw_ee/sites/build_state.py
@@ -14,6 +14,16 @@
 # carries the rung name — a terminal ``failed`` with no reason cannot distinguish "the
 # user's code broke" from "we lost the container", and those need opposite handling.
 #
+# Edited 2026-08-11 (fix/atomic-queued-stamp): added :func:`claim_precondition`, because
+# ``should_enqueue`` could answer the single-flight question but could not ENFORCE its
+# answer. Every caller read it and then stamped in a second step, and a burst harness
+# (tests/ee/sites/test_burst_harness.py) measured what that costs: 8 concurrent publishes
+# of one site opened 8 sandboxes, because each read the same pre-stamp row and each passed
+# the gate correctly. The logic here was never wrong — the write was not conditional. The
+# new function is the same rule expressed as a precondition on the stamping write, so the
+# database picks one winner and the losers write nothing. Any future guard added here has
+# to be expressible BOTH ways or the two halves drift apart.
+#
 # MODELLED ON DP0-4 (``sites/service.py:_provisioning_is_stale``) because that pattern
 # already solved the hard half correctly: status alone is a ONE-WAY DOOR. A job that no
 # worker ever consumed, or that died before writing a terminal status, pins the row in
@@ -144,6 +154,48 @@ def should_enqueue(doc: Any, timeout_seconds: int, *, now: datetime | None = Non
     return build_is_stale(doc, timeout_seconds, now=now)
 
 
+def claim_precondition(timeout_seconds: int, *, now: datetime | None = None) -> dict[str, Any]:
+    """The Mongo filter that lets a publish CLAIM the build slot, as a query fragment.
+
+    Added 2026-08-11: ``should_enqueue`` answers the question correctly but cannot enforce
+    the answer, because a caller reads it and then writes in a second step. Between those
+    two, every concurrent publish sees the same pre-stamp row, passes the gate, and opens
+    its own sandbox — measured at 8 sandboxes for 8 concurrent publishes of one site. This
+    is the same rule expressed as a PRECONDITION on the stamping write, so the database
+    decides the winner and the losers write nothing.
+
+    IT MUST ENCODE ``should_enqueue`` EXACTLY, STALENESS INCLUDED. A simpler precondition
+    of "status is not queued or building" would refuse a STALE in-flight row — the one
+    case ``should_enqueue`` deliberately lets through — and that is how a site becomes
+    permanently unpublishable, the failure this module's window exists to prevent. So the
+    filter is a disjunction of the four ways a row is claimable, mirroring the branches of
+    ``should_enqueue`` and ``build_is_stale`` in order:
+
+      1. the status is not in flight (terminal, or unrecognised — which reads as terminal
+         here, deliberately, for the reason in the module header);
+      2. the stamp is missing or not a date, i.e. unreadable, which reads as STALE;
+      3. the stamp is older than the row's own derived window.
+
+    ``$not: {$type: "date"}`` covers a null stamp, an absent field, and a garbage value
+    (a string from an older writer, say) in one clause, which keeps the asymmetric call
+    intact: an unusable stamp is claimable rather than blocking. Getting that backwards
+    trades one redundant idempotent build for a site that can never publish again.
+
+    The caller must pass the SAME ``now`` it stamps with, or the window it tests against
+    is not the window it writes.
+    """
+    reference = now or datetime.now(UTC)
+    if reference.tzinfo is None:  # pragma: no cover - defensive
+        reference = reference.replace(tzinfo=UTC)
+    return {
+        "$or": [
+            {"build_status": {"$nin": sorted(IN_FLIGHT_STATUSES)}},
+            {"build_started_at": {"$not": {"$type": "date"}}},
+            {"build_started_at": {"$lt": reference - stale_after(timeout_seconds)}},
+        ]
+    }
+
+
 def is_in_flight(doc: Any) -> bool:
     """True when the row CLAIMS a build is running, ignoring staleness.
 
@@ -198,6 +250,7 @@ __all__ = [
     "TERMINAL_STATUSES",
     "BuildStatus",
     "build_is_stale",
+    "claim_precondition",
     "is_in_flight",
     "settle",
     "should_enqueue",

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -28,7 +28,7 @@
 #
 # Updated 2026-08-10 (SL-2 slice 2 — the ephemeral-build lane gets a job): added the
 # four seams the site-build arq job (``sites/build_job.py``) writes its lifecycle
-# through — ``load_build_site``, ``mark_build_queued``, ``mark_build_running``,
+# through — ``load_build_site``, ``claim_build_queued``, ``mark_build_running``,
 # ``record_build_outcome`` — at the bottom of the DP0-3 seam block, which they are
 # modelled on. This module stays the sole owner of Site writes; the build lane never
 # touches the Beanie doc.
@@ -799,6 +799,7 @@ from pocketpaw_ee.cloud._core.errors import (
 )
 from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
 from pocketpaw_ee.cloud.models.site import SiteDomain as _SiteDomainDoc
+from pocketpaw_ee.sites.build_state import claim_precondition
 from pocketpaw_ee.sites.domain import HostnameStatus
 from pocketpaw_ee.sites.dto import (
     AuditFinding,
@@ -3409,23 +3410,60 @@ async def load_build_site(workspace_id: str, site_id: str) -> _SiteDoc | None:
     return await _SiteDoc.find_one({"_id": oid, "workspace": workspace_id})
 
 
-async def mark_build_queued(site: _SiteDoc, *, job_id: str) -> None:
-    """Stamp a site as having a build ENQUEUED: status, clock, and polling handle.
+async def claim_build_queued(
+    site: _SiteDoc,
+    *,
+    job_id: str,
+    timeout_seconds: int,
+    now: datetime | None = None,
+) -> bool:
+    """CLAIM the build slot for ``site`` and stamp it ``queued``. False means lost.
 
-    One write, all four fields. ``build_started_at`` is what bounds the single-flight
-    guard — without it the row reads as stale immediately and a second publish opens a
-    second sandbox. ``build_job_id`` is persisted (not a transient PrivateAttr like
-    DP0-4's) because a queued build is exactly when a user reloads. ``build_reason`` is
-    cleared so a new attempt never shows the previous attempt's rung.
+    One write, all four fields, CONDITIONAL on the row still being claimable.
+    ``build_started_at`` is what bounds the single-flight guard — without it the row reads
+    as stale immediately and a second publish opens a second sandbox. ``build_job_id`` is
+    persisted (not a transient PrivateAttr like DP0-4's) because a queued build is exactly
+    when a user reloads. ``build_reason`` is cleared so a new attempt never shows the
+    previous attempt's rung.
+
+    Rewritten 2026-08-11 from ``mark_build_queued``, which wrote unconditionally. Reading
+    ``should_enqueue`` and then stamping is two steps with an await between them, and every
+    publish arriving inside that window read the same pre-stamp row, passed the gate
+    correctly, and opened its own sandbox: 8 concurrent publishes of one site produced 8
+    sandboxes. The precondition moves the decision into the write, so the DATABASE picks
+    one winner. Unlike the other three build seams this is the one write that must NOT be
+    a blind ``set``.
+
+    THE PRECONDITION IS ``build_state.claim_precondition`` AND NOT A LOCAL REPHRASING.
+    It has to permit exactly what ``should_enqueue`` permits, staleness included: a
+    precondition that refused a stale in-flight row would recreate the one-way door and
+    leave the site permanently unpublishable. The same ``now`` is used for the window test
+    and the stamp, so the row is never tested against a window it was not written with.
+
+    Returns True when this caller owns the build and False when another publish claimed it
+    first. False is not an error — it is the same "a build is already in flight" answer the
+    caller returned before, and it is the losing publish's cue to write nothing at all.
     """
-    await site.set(
-        {
-            "build_status": "queued",
-            "build_started_at": datetime.now(UTC),
-            "build_job_id": job_id,
-            "build_reason": None,
-        }
+    stamp = now or datetime.now(UTC)
+    values: dict[str, Any] = {
+        "build_status": "queued",
+        "build_started_at": stamp,
+        "build_job_id": job_id,
+        "build_reason": None,
+    }
+    collection = type(site).get_pymongo_collection()
+    won = await collection.find_one_and_update(
+        {"_id": site.id, **claim_precondition(timeout_seconds, now=stamp)},
+        {"$set": values},
     )
+    if won is None:
+        return False
+    # The write went to the DB, so the in-memory doc is now behind it. Every later step
+    # of the enqueue reads this object (the log line, the rollback), and a caller that
+    # won the claim but still saw a stale local row would report the pre-claim status.
+    for field, value in values.items():
+        setattr(site, field, value)
+    return True
 
 
 async def mark_build_running(site: _SiteDoc) -> None:

--- a/tests/ee/sites/burst_harness.py
+++ b/tests/ee/sites/burst_harness.py
@@ -15,23 +15,30 @@
 # take ``now=`` — so a burst is a loop over an injected clock rather than a wait. That is
 # deliberate on both sides: a harness that takes minutes is a harness nobody runs.
 #
-# THE TWO CONCURRENCY MODELS, and why both are here. The guard is a READ-then-WRITE, not
-# a compare-and-swap, so what it guarantees depends entirely on whether the stamp lands
-# before a sibling reads:
+# THE TWO CONCURRENCY MODELS, and why both are here. What a guard guarantees depends on
+# whether a sibling can read the row before the stamp lands:
 #
 #   * SHARED-DOC (``burst_on_one_doc``) — N publishes racing on ONE in-memory row, which
-#     is what a single process re-entering publish looks like. The stamp is visible to
-#     every later reader as soon as it lands.
+#     is what a single process re-entering publish looks like.
 #   * SEPARATE-DOC (``burst_on_reloaded_docs``) — N publishes that each LOAD their own
 #     copy of the row first, which is what N concurrent HTTP requests actually look like.
 #     Each reader has its own snapshot, so a stamp written by one is invisible to a
 #     sibling that read before it.
 #
 # The second is the honest model of production and the harder case. Keeping both is the
-# point: the difference between them is the size of the guard's race window, and a
-# harness that only ran the friendly model would report a guarantee the lane does not
-# have. See docs/runbooks/2026-08-11-site-build-burst-harness.md for what this can and
-# cannot tell us.
+# point: an in-process lock would satisfy the first and leave the second racing across
+# workers, and only a decision taken AT THE ROW satisfies both.
+#
+# Edited 2026-08-11 (fix/atomic-queued-stamp): added ``_ROWS`` + ``FakeCollection``, so the
+# fake can stand in for the collection and not only the document. The lane's gate is now a
+# CONDITIONAL WRITE (``service.claim_build_queued`` on ``build_state.claim_precondition``)
+# rather than a read followed by a write, and a conditional write cannot be exercised
+# against a fake that only models a doc. ``FakeCollection.find_one_and_update`` reproduces
+# the one property the fix rests on and nothing more: it yields before it runs, and once
+# running it matches and applies without yielding again.
+#
+# See docs/runbooks/2026-08-11-site-build-burst-harness.md for what this can and cannot
+# tell us.
 
 from __future__ import annotations
 
@@ -99,17 +106,34 @@ class YieldingPool(RecordingPool):
 # ---------------------------------------------------------------------------
 
 
+_ROWS: dict[str, FakeSite] = {}
+"""The stand-in for the sites collection: one canonical row per id.
+
+The registry is what makes the fake capable of modelling a conditional write at all. A
+publish holds its own ``FakeSite`` (its own snapshot, as a request does), but the CLAIM is
+decided against the one row registered here — which is exactly the split between a local
+copy and the database that lets a read-then-write guard lose a race."""
+
+
 @dataclass
 class FakeSite:
-    """A Site-shaped row whose writes yield to the loop, like a DB round trip does.
+    """A Site-shaped row whose blind writes yield to the loop, like a DB round trip does.
 
     ``set`` is the load-bearing detail. A fake that applied a write synchronously would
     make every burst pass, because no sibling could ever observe the pre-write state —
-    the harness would be measuring its own fake instead of the guard. Yielding first
-    reproduces the real gap between a gate's read and its stamp.
+    the harness would be measuring its own fake instead of the lane. Yielding first
+    reproduces the real gap between a read and a write. Mongomock does NOT do this: its
+    write resolves without yielding, which is why the burst against real Beanie + mongomock
+    reported one sandbox while the lane was opening eight.
 
-    Every write is appended to ``transitions``, which is what lets a test assert that
-    ``queued`` and ``building`` stayed DISTINGUISHABLE under load rather than merely
+    ``get_pymongo_collection`` is the other half, added 2026-08-11 with the atomic claim: the
+    conditional write goes through the collection, not the doc, so the fake has to stand in
+    for the collection too. Its ``find_one_and_update`` yields FIRST and then matches and
+    applies WITHOUT yielding, which is the one property a single-document Mongo update
+    guarantees and the one the fix depends on.
+
+    Every status write is appended to ``transitions``, which is what lets a test assert
+    that ``queued`` and ``building`` stayed DISTINGUISHABLE under load rather than merely
     that the row ended up somewhere plausible.
     """
 
@@ -120,11 +144,22 @@ class FakeSite:
     build_job_id: str | None = None
     build_reason: str | None = None
     transitions: list[tuple[str, str | None]] = field(default_factory=list)
+    register: bool = True
+
+    def __post_init__(self) -> None:
+        # A freshly constructed row is the canonical one for its id — a new test starts
+        # from a clean row. A snapshot passes register=False so it does not displace the
+        # row its siblings are racing against.
+        if self.register:
+            _ROWS[self.id] = self
 
     async def set(self, values: dict[str, Any]) -> None:
         await asyncio.sleep(0)  # a real write is a round trip; a sibling may run here
+        row = _ROWS.get(self.id, self)
         for key, value in values.items():
             setattr(self, key, value)
+            if row is not self:
+                setattr(row, key, value)
         if "build_status" in values:
             self.transitions.append((values["build_status"], values.get("build_reason")))
 
@@ -142,7 +177,85 @@ class FakeSite:
             build_job_id=self.build_job_id,
             build_reason=self.build_reason,
             transitions=self.transitions,  # shared on purpose: one row, one history
+            register=False,
         )
+
+    @classmethod
+    def get_pymongo_collection(cls) -> FakeCollection:
+        return FakeCollection()
+
+
+class FakeCollection:
+    """The sites collection, in memory, supporting exactly one operation.
+
+    Deliberately minimal. It exists so the atomic claim can be exercised without Mongo,
+    and it implements the two properties the fix rests on and nothing else: the update
+    yields before it runs (a real one is a round trip), and once running it matches the
+    precondition and applies the change as ONE indivisible step.
+    """
+
+    async def find_one_and_update(
+        self, filter_: dict[str, Any], update: dict[str, Any]
+    ) -> dict[str, Any] | None:
+        await asyncio.sleep(0)
+        # --- no await past this point: this is the atomic section ---
+        row = _ROWS.get(str(filter_.get("_id")))
+        if row is None or not _matches(row, filter_):
+            return None
+        values = update["$set"]
+        for key, value in values.items():
+            setattr(row, key, value)
+        if "build_status" in values:
+            row.transitions.append((values["build_status"], values.get("build_reason")))
+        return {"_id": row.id, **values}
+
+
+def _matches(row: FakeSite, filter_: dict[str, Any]) -> bool:
+    """Evaluate the claim precondition against a row.
+
+    Interprets the real filter dict rather than re-deciding the rule in Python, so a
+    precondition that says the wrong thing fails the burst tests too. Supports only the
+    operators ``claim_precondition`` emits — anything else raises, so a filter that grows
+    an operator this cannot evaluate fails loudly instead of matching everything.
+    """
+    for key, condition in filter_.items():
+        if key == "_id":
+            continue
+        if key == "$or":
+            if not any(_matches(row, clause) for clause in condition):
+                return False
+            continue
+        value = getattr(row, key, None)
+        if not _field_matches(value, condition):
+            return False
+    return True
+
+
+def _field_matches(value: Any, condition: Any) -> bool:
+    if not isinstance(condition, dict):
+        return bool(value == condition)
+    for op, operand in condition.items():
+        if op == "$nin":
+            if value in operand:
+                return False
+        elif op == "$lt":
+            if not isinstance(value, datetime):
+                return False
+            # BSON stores every date as UTC, so Mongo never sees a naive/aware mismatch.
+            # The fake holds Python objects and would raise on the comparison, so it
+            # normalises the same way ``_read_stamp`` does.
+            stamp = value if value.tzinfo else value.replace(tzinfo=UTC)
+            if not stamp < operand:
+                return False
+        elif op == "$not":
+            if _field_matches(value, operand):
+                return False
+        elif op == "$type":
+            if operand != "date" or not isinstance(value, datetime):
+                return False
+        else:  # pragma: no cover - a new operator must be taught to the fake
+            raise AssertionError(f"the fake collection cannot evaluate {op!r}")
+    return True
 
 
 def aged_site(status: str, *, age_seconds: float | None, **kwargs: Any) -> FakeSite:

--- a/tests/ee/sites/test_burst_harness.py
+++ b/tests/ee/sites/test_burst_harness.py
@@ -7,14 +7,23 @@
 # "sandbox" is a recorded enqueue.
 #
 # WHAT THIS FOUND, and it is the reason the file exists rather than a footnote:
-# ``enqueue_site_build`` gates with a READ (``should_enqueue``) and then stamps with a
+# ``enqueue_site_build`` gated with a READ (``should_enqueue``) and then stamped with a
 # WRITE (``mark_build_queued``), with an await in between and no compare-and-swap. Every
-# publish that arrives inside that window reads the pre-stamp row, passes the gate, and
-# opens its own sandbox. At N=8 that is EIGHT sandboxes for one site. The guard's own
-# logic is correct — a burst that arrives after the stamp lands is refused in full — so
-# the defect is the missing atomicity at the row, not the state machine.
-# ``TestSingleFlightUnderContention`` pins that behaviour deliberately; see its docstring
-# and docs/runbooks/2026-08-11-site-build-burst-harness.md.
+# publish arriving inside that window read the pre-stamp row, passed the gate, and opened
+# its own sandbox. At N=8 that was EIGHT sandboxes for one site. The guard's own logic was
+# never wrong — a burst arriving after the stamp lands is refused in full — so the defect
+# was missing atomicity at the row, not the state machine.
+#
+# Edited 2026-08-11 (fix/atomic-queued-stamp): the assertions in
+# ``TestSingleFlightUnderContention`` are FLIPPED from the pinned defect numbers to the
+# fixed ones (one sandbox, N-1 refusals), which is what they were written to be the
+# acceptance test for. ``claim_build_queued`` now stamps conditionally on
+# ``build_state.claim_precondition``, so the database picks one winner.
+# ``TestTheClaimPreconditionMatchesTheGuard`` is new and guards the thing the fix newly
+# risks: the same rule now lives in two languages, and if the Mongo filter and
+# ``should_enqueue`` ever disagree about a stale row, a site stops being publishable.
+#
+# See docs/runbooks/2026-08-11-site-build-burst-harness.md.
 #
 # THE HARNESS MEASURES LOGIC, NOT INFRASTRUCTURE. It cannot tell us real sandbox
 # contention, real queue latency, or the right value for the concurrency cap. Those need
@@ -29,6 +38,7 @@ from datetime import UTC, datetime, timedelta
 import pytest
 from pocketpaw_ee.sites import build_job as bj
 from pocketpaw_ee.sites import build_state as bs
+from pocketpaw_ee.sites import service as sites_service
 
 from tests.ee.sites.burst_harness import (
     BUILD_TIMEOUT,
@@ -96,61 +106,89 @@ class TestTheGuardHoldsWhenPublishesAreSerialised:
 
 
 class TestSingleFlightUnderContention:
-    """N concurrent publishes of ONE site. The guarantee this lane needs is exactly one
-    in-flight build; two sandboxes for one site is two bills and two artifacts racing to
-    deploy.
+    """N concurrent publishes of ONE site must produce exactly one in-flight build. Two
+    sandboxes for one site is two bills and two artifacts racing to deploy.
 
-    THESE TESTS PIN THE CURRENT BEHAVIOUR, WHICH DOES NOT MEET THAT GUARANTEE. They are
-    characterisation tests, not an endorsement. ``enqueue_site_build`` reads the row to
-    gate and then writes the row to stamp, and between those two steps it awaits; a
-    sibling publish that reads inside that window sees a row with no build in flight and
-    is correct to enqueue, by the guard's own rules. Serialising the publishes fixes it
-    (see the class above), which is what identifies the gap as atomicity rather than
-    logic.
+    THESE ARE THE ACCEPTANCE TESTS FOR THE ATOMIC CLAIM, and they were written first, in
+    #1910, asserting the numbers the lane actually produced: ``sandboxes == BURST``. The
+    gate was a read (``should_enqueue``) followed by a write (``mark_build_queued``) with
+    an await between them, so every publish inside that window read the same pre-stamp row
+    and each one was correct, by the guard's own rules, to open a sandbox. Eight publishes,
+    eight sandboxes.
 
-    WHEN THE FIX LANDS — a conditional write that only stamps a row still observed
-    terminal (Mongo's ``find_one_and_update`` with a status precondition), so the loser
-    of the race gets nothing back and returns ``None`` — the assertions here flip to
-    ``sandboxes == 1`` and ``refused == BURST - 1``. That flip is the fix's acceptance
-    test, and it is why the numbers are asserted exactly rather than loosely.
+    ``claim_build_queued`` moves the decision INTO the write —
+    ``build_state.claim_precondition`` as a filter on ``find_one_and_update`` — so the
+    database picks one winner and the losers write nothing and return ``None``. The numbers
+    below are the flipped ones.
+
+    THE FAKE'S YIELD BEHAVIOUR IS WHAT MAKES THIS MEANINGFUL. Mongomock resolves a write
+    without yielding to the event loop, so a burst driven through real Beanie against
+    mongomock reported one sandbox while the lane was opening eight — the old
+    infrastructure could not see this bug. ``FakeSite.set`` yields before applying and
+    ``FakeCollection.find_one_and_update`` yields before matching and then does not yield
+    again, which is the one guarantee a single-document Mongo update gives.
     """
 
-    async def test_concurrent_publishes_each_open_their_own_sandbox_today(self) -> None:
+    async def test_a_concurrent_burst_opens_exactly_one_sandbox(self) -> None:
         site = FakeSite()
         report = await burst_on_one_doc(site, BURST, pool=YieldingPool())
         assert report.errors == []
-        # The guarantee: == 1. The reality: one per publish.
-        assert report.sandboxes == BURST, (
+        assert report.sandboxes == 1, (
             f"{BURST} concurrent publishes of one site opened {report.sandboxes} sandboxes; "
-            "the single-flight guard needs 1"
+            "single-flight means 1"
         )
-        assert report.refused == 0
+        assert report.refused == BURST - 1
+        assert len(report.job_ids) == 1
 
-    async def test_separate_requests_each_holding_their_own_row_copy_also_race(self) -> None:
-        """The production shape. Two HTTP publishes each load the site before gating, so
-        neither can see the other's stamp however the loop interleaves afterwards. This
-        is the model the fix has to satisfy — an in-process lock would pass the shared-doc
-        case above and still leave this one racing across workers."""
+    async def test_separate_requests_each_holding_their_own_row_copy_still_get_one(self) -> None:
+        """The production shape, and the one an in-process lock would not fix. Each publish
+        loads the site before it claims, so no local copy can see a sibling's stamp — the
+        decision has to happen at the row, which is where the precondition puts it."""
         site = FakeSite()
         report = await burst_on_reloaded_docs(site, BURST, pool=YieldingPool())
         assert report.errors == []
-        assert report.sandboxes == BURST
-        assert report.refused == 0
+        assert report.sandboxes == 1
+        assert report.refused == BURST - 1
 
-    async def test_even_two_concurrent_publishes_are_enough(self) -> None:
-        """The failure does not need load. Two clicks on a publish button inside one
-        round trip reproduce it, which is why this is a correctness bug and not a
-        capacity note."""
+    async def test_two_concurrent_publishes_get_one_sandbox(self) -> None:
+        """Two clicks inside one round trip was enough to reproduce the leak, so it is
+        also the smallest case that has to hold."""
         report = await burst_on_one_doc(FakeSite(), 2, pool=YieldingPool())
-        assert report.sandboxes == 2
+        assert report.sandboxes == 1
+        assert report.refused == 1
 
-    async def test_every_racing_publish_mints_a_distinct_job_id(self) -> None:
-        """Not a nice-to-have: arq refuses a duplicate id by returning ``None``, and the
-        lane reads that as a failed enqueue and rolls the row to ``failed``. A stable
-        per-site id would therefore convert this race into a publish that reports broken
-        rather than one that overspends — a worse failure, and a silent one."""
-        report = await burst_on_one_doc(FakeSite(), BURST, pool=YieldingPool())
-        assert len(set(report.job_ids)) == len(report.job_ids)
+    async def test_the_losing_publish_returns_none_rather_than_raising(self) -> None:
+        """The contract upstream already relies on: ``None`` means "a build is already in
+        flight", not "something went wrong". A loser that raised, or that rolled the row to
+        ``failed``, would turn a race the user cannot see into an error they can."""
+        site = FakeSite()
+        report = await burst_on_one_doc(site, BURST, pool=YieldingPool())
+        assert report.errors == []
+        assert report.refused == BURST - 1
+        assert site.build_status == "queued"
+        assert site.build_reason is None
+
+    async def test_the_losers_write_nothing_at_all(self) -> None:
+        """One claim, one status write. If a loser wrote too, the row would carry a second
+        ``queued`` stamp — which moves the staleness window forward on a build it does not
+        own and hides a genuinely stuck build for another full window."""
+        site = FakeSite()
+        await burst_on_one_doc(site, BURST, pool=YieldingPool())
+        assert site.transitions == [("queued", None)]
+
+    async def test_each_rebuild_mints_a_fresh_job_id(self) -> None:
+        """Still load-bearing after the fix, for a reason unrelated to the race: arq
+        refuses a duplicate id by returning ``None`` and keeps a finished job's RESULT for
+        an hour, so a stable per-site id would silently refuse every rebuild for an hour
+        after a build finished — a single-flight guard enforced in the wrong layer, and
+        invisible because the refusal is a ``None`` rather than an error."""
+        pool = YieldingPool()
+        site = FakeSite()
+        first = await burst_on_one_doc(site, 1, pool=pool)
+        site.build_status = "built"  # the first build finished; a rebuild is legitimate
+        second = await burst_on_one_doc(site, 1, pool=pool)
+        assert first.job_ids != second.job_ids
+        assert len(set(pool.job_ids)) == 2
 
 
 class TestTheGuardIsPerSiteNotGlobal:
@@ -230,7 +268,11 @@ class TestTheStalenessWindowUnderBurst:
         window = bs.stale_after(BUILD_TIMEOUT).total_seconds()
         site = aged_site("building", age_seconds=window + 120)
         report = await burst_on_one_doc(site, BURST, pool=YieldingPool())
-        assert report.sandboxes >= 1, "a dead row must not block publishes forever"
+        assert report.sandboxes == 1, (
+            "a dead row must not block publishes forever, and unsticking it must not "
+            "hand out a sandbox per publish either"
+        )
+        assert report.refused == BURST - 1
 
 
 # ---------------------------------------------------------------------------
@@ -252,7 +294,9 @@ class TestQueuedAndBuildingStayDistinguishable:
         assert {status for status, _ in site.transitions} == {"queued"}
         await sites_service.mark_build_running(site)
         assert [status for status, _ in site.transitions][-1] == "building"
-        assert [s for s, _ in site.transitions].count("queued") == 3
+        assert [s for s, _ in site.transitions].count("queued") == 1, (
+            "three concurrent publishes, one claim, one stamp"
+        )
 
     async def test_a_worker_pickup_moves_the_clock_forward_not_just_the_status(self) -> None:
         """``mark_build_running`` RE-stamps ``build_started_at`` on purpose: the stamp
@@ -325,9 +369,12 @@ class TestAnUnusableStampReadsAsStale:
         assert bs.should_enqueue(site, BUILD_TIMEOUT) is True
 
     async def test_a_stampless_in_flight_row_never_wedges_the_site(self) -> None:
+        """The precondition has to permit this row, or the asymmetric call is reversed and
+        a row that never got a stamp becomes permanently unpublishable. It also must not
+        permit it more than once."""
         site = FakeSite(build_status="queued", build_started_at=None)
         report = await burst_on_one_doc(site, BURST, pool=YieldingPool())
-        assert report.sandboxes >= 1
+        assert report.sandboxes == 1
 
     def test_an_unknown_status_reads_as_terminal_and_lets_a_publish_through(self) -> None:
         """The reader/writer deploy-ordering constraint in the module header, from the
@@ -398,6 +445,143 @@ class TestARetryStaysInFlightAndWritesNothing:
 # ---------------------------------------------------------------------------
 
 
+class TestTheClaimPreconditionMatchesTheGuard:
+    """The precondition has to permit EXACTLY what ``should_enqueue`` permits.
+
+    Two halves of one rule live in two languages now — Python for the read, a Mongo filter
+    for the write — and the failure mode of drift is asymmetric and nasty. A precondition
+    that is too STRICT (the obvious "status not in queued/building") refuses a stale
+    in-flight row, which is the one case the window exists to let through, and the site
+    becomes permanently unpublishable with no error to see. Too LOOSE and the leak is back.
+
+    Driven against mongomock ON PURPOSE, and this is the one place that is the right tool:
+    these assert what the filter MEANS to a Mongo query engine, where mongomock's lack of
+    yielding is irrelevant. Atomicity is verified separately, on the yielding fake — a
+    mongomock burst cannot see a race at all.
+    """
+
+    async def _claimable(self, beanie_db: object, **fields: object) -> bool:
+        from pocketpaw_ee.cloud.models.site import Site
+
+        doc = Site(workspace="ws1", pocket_id="pk1", owner="u1", name="S", **fields)  # type: ignore[arg-type]
+        await doc.insert()
+        found = await Site.get_pymongo_collection().find_one(
+            {"_id": doc.id, **bs.claim_precondition(BUILD_TIMEOUT)}
+        )
+        return found is not None
+
+    @pytest.mark.parametrize("status", ["none", "built", "failed"])
+    async def test_a_terminal_row_is_claimable(self, beanie_test_db, status: str) -> None:
+        assert await self._claimable(
+            beanie_test_db, build_status=status, build_started_at=datetime.now(UTC)
+        )
+
+    async def test_an_unknown_status_is_claimable(self, beanie_test_db) -> None:
+        """Matches ``should_enqueue``'s reading of an unrecognised status as terminal. The
+        cost of this choice is the deploy-ordering constraint in ``build_state``'s header:
+        a new in-flight state must reach every reader before any writer emits it."""
+        assert await self._claimable(
+            beanie_test_db, build_status="provisioning", build_started_at=datetime.now(UTC)
+        )
+
+    @pytest.mark.parametrize("status", ["queued", "building"])
+    async def test_a_fresh_in_flight_row_is_not_claimable(
+        self, beanie_test_db, status: str
+    ) -> None:
+        """The leak, closed. This is the row a second publish used to stamp over."""
+        assert not await self._claimable(
+            beanie_test_db, build_status=status, build_started_at=datetime.now(UTC)
+        )
+
+    @pytest.mark.parametrize("status", ["queued", "building"])
+    async def test_a_stale_in_flight_row_is_claimable(self, beanie_test_db, status: str) -> None:
+        """The case a naive status-only precondition would have refused, turning an
+        overspend bug into an unpublishable site — the worse direction."""
+        age = timedelta(seconds=bs.stale_after(BUILD_TIMEOUT).total_seconds() + 60)
+        assert await self._claimable(
+            beanie_test_db, build_status=status, build_started_at=datetime.now(UTC) - age
+        )
+
+    async def test_an_in_flight_row_at_its_exact_window_is_not_claimable(
+        self, beanie_test_db
+    ) -> None:
+        """Same strict boundary as ``build_is_stale``: at the window it is still in
+        flight. If the two disagreed by a tick, the read and the write would disagree
+        about whether a live build exists."""
+        at_edge = datetime.now(UTC) - bs.stale_after(BUILD_TIMEOUT)
+        assert not await self._claimable(
+            beanie_test_db, build_status="building", build_started_at=at_edge + timedelta(seconds=5)
+        )
+
+    async def test_an_in_flight_row_with_no_stamp_is_claimable(self, beanie_test_db) -> None:
+        """The asymmetric call, preserved through the filter: one redundant idempotent
+        build beats a site that can never publish again."""
+        assert await self._claimable(beanie_test_db, build_status="building", build_started_at=None)
+
+    async def test_the_claim_tests_the_window_against_the_clock_it_stamps_with(
+        self, beanie_test_db
+    ) -> None:
+        """One clock decides the window and writes the stamp. If the precondition used
+        wall-clock while the stamp used the caller's ``now``, the row would be judged
+        against a window it was not written with — and a row that is live on the caller's
+        clock could be claimed anyway."""
+        from pocketpaw_ee.cloud.models.site import Site
+
+        # Anchored to real now rather than a fixed date. A hard-coded date can land in the
+        # future relative to wall-clock UTC, and then the broken form of this code
+        # (wall-clock for the window, the caller's clock for the stamp) accidentally agrees
+        # with the correct form and the test proves nothing.
+        started = datetime.now(UTC) - timedelta(hours=2)
+        doc = Site(
+            workspace="ws1",
+            pocket_id="pk1",
+            owner="u1",
+            name="S",
+            build_status="building",
+            build_started_at=started,
+        )
+        await doc.insert()
+        # Five minutes after the build started: inside its window, so still in flight —
+        # even though wall-clock is far past it.
+        won = await sites_service.claim_build_queued(
+            doc,
+            job_id="job-1",
+            timeout_seconds=BUILD_TIMEOUT,
+            now=started + timedelta(minutes=5),
+        )
+        assert won is False
+        assert (await Site.get(doc.id)).build_status == "building"
+
+    async def test_the_precondition_agrees_with_should_enqueue_on_every_case(
+        self, beanie_test_db
+    ) -> None:
+        """The property that matters more than any single case: for the same row, the read
+        and the write must reach the same verdict. Anything else and the two halves of the
+        rule have drifted."""
+        window = bs.stale_after(BUILD_TIMEOUT).total_seconds()
+        cases = [
+            ("none", 1),
+            ("built", 1),
+            ("failed", 1),
+            ("queued", 5),
+            ("building", 5),
+            ("queued", window + 60),
+            ("building", window + 60),
+            ("building", None),
+            ("provisioning", 5),
+        ]
+        for status, age in cases:
+            claimable = await self._claimable(
+                beanie_test_db,
+                build_status=status,
+                build_started_at=None
+                if age is None
+                else datetime.now(UTC) - timedelta(seconds=age),
+            )
+            expected = bs.should_enqueue(aged_site(status, age_seconds=age), BUILD_TIMEOUT)
+            assert claimable is expected, (status, age, claimable, expected)
+
+
 class TestTheHarnessSpendsNothing:
     """A burst harness that could reach real infrastructure is a harness nobody dares
     run, and spending sandboxes is the captain's call, not a side effect of the suite."""
@@ -407,7 +591,7 @@ class TestTheHarnessSpendsNothing:
         reads ``POCKETPAW_REDIS_URL`` and opens a connection — is never reached."""
         pool = RecordingPool()
         await burst_on_one_doc(FakeSite(), 3, pool=pool)
-        assert pool.sandboxes == 3
+        assert pool.sandboxes == 1
         assert all(call["function"] == bj.ARQ_FUNCTION_NAME for call in pool.calls)
 
     def test_the_recorded_enqueue_count_is_the_cost_meter(self) -> None:

--- a/tests/mutations/sites_burst_harness.json
+++ b/tests/mutations/sites_burst_harness.json
@@ -1,14 +1,5 @@
 [
   {
-    "label": "D5: the single-flight gate is removed from the enqueue, so every publish of a site opens its own sandbox unconditionally — the guard stops guarding and nothing else in the lane notices",
-    "file": "ee/pocketpaw_ee/sites/build_job.py",
-    "find": "    if not should_enqueue(site, timeout):",
-    "replace": "    if False:",
-    "tests": [
-      "tests/ee/sites/test_burst_harness.py::TestTheGuardHoldsWhenPublishesAreSerialised"
-    ]
-  },
-  {
     "label": "D5: the job id becomes deterministic per site, so arq refuses the second concurrent enqueue and the lane rolls the row to failed — a race that overspends turns into a publish that reports broken",
     "file": "ee/pocketpaw_ee/sites/build_job.py",
     "find": "    return f\"site-build-{site_id}-{uuid.uuid4().hex}\"",
@@ -47,10 +38,55 @@
   {
     "label": "D5: the queued stamp is dropped from the enqueue write, so the row reads as stale the instant it is written and the very next publish opens a second sandbox",
     "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "            \"build_status\": \"queued\",\n            \"build_started_at\": datetime.now(UTC),",
-    "replace": "            \"build_status\": \"queued\",",
+    "find": "        \"build_status\": \"queued\",\n        \"build_started_at\": stamp,",
+    "replace": "        \"build_status\": \"queued\",",
     "tests": [
       "tests/ee/sites/test_burst_harness.py::TestTheGuardHoldsWhenPublishesAreSerialised"
+    ]
+  },
+  {
+    "label": "D5/atomic: the precondition is dropped from the queued claim, so the stamping write is unconditional again and every concurrent publish of one site opens its own sandbox — the exact leak this fix closes, measured at 8 sandboxes for 8 publishes",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        {\"_id\": site.id, **claim_precondition(timeout_seconds, now=stamp)},",
+    "replace": "        {\"_id\": site.id},",
+    "tests": [
+      "tests/ee/sites/test_burst_harness.py::TestSingleFlightUnderContention"
+    ]
+  },
+  {
+    "label": "D5/atomic: the claim ignores the write's outcome and always reports a win, so every loser of the race enqueues anyway and the precondition becomes decoration",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if won is None:\n        return False",
+    "replace": "    if won is None:\n        pass",
+    "tests": [
+      "tests/ee/sites/test_burst_harness.py::TestSingleFlightUnderContention"
+    ]
+  },
+  {
+    "label": "D5/atomic: the precondition drops its staleness clauses and gates on status alone, so a STALE in-flight row can never be claimed and the site is permanently unpublishable with no error to see — the worse direction of the same bug",
+    "file": "ee/pocketpaw_ee/sites/build_state.py",
+    "find": "            {\"build_started_at\": {\"$not\": {\"$type\": \"date\"}}},\n            {\"build_started_at\": {\"$lt\": reference - stale_after(timeout_seconds)}},",
+    "replace": "",
+    "tests": [
+      "tests/ee/sites/test_burst_harness.py::TestTheClaimPreconditionMatchesTheGuard"
+    ]
+  },
+  {
+    "label": "D5/atomic: the precondition treats an unreadable stamp as blocking rather than stale, so a row written by an older writer (or with no stamp at all) can never be claimed again",
+    "file": "ee/pocketpaw_ee/sites/build_state.py",
+    "find": "            {\"build_started_at\": {\"$not\": {\"$type\": \"date\"}}},",
+    "replace": "            {\"build_started_at\": {\"$type\": \"date\"}},",
+    "tests": [
+      "tests/ee/sites/test_burst_harness.py::TestTheClaimPreconditionMatchesTheGuard"
+    ]
+  },
+  {
+    "label": "D5/atomic: the claim tests the window against a different clock than it stamps with, so the row is judged against a window it was not written with",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "claim_precondition(timeout_seconds, now=stamp)",
+    "replace": "claim_precondition(timeout_seconds)",
+    "tests": [
+      "tests/ee/sites/test_burst_harness.py::TestTheClaimPreconditionMatchesTheGuard"
     ]
   }
 ]

--- a/tests/mutations/sl2_build_job.json
+++ b/tests/mutations/sl2_build_job.json
@@ -47,10 +47,10 @@
     ]
   },
   {
-    "label": "the row is never stamped queued, so single-flight is off (a second publish opens a second sandbox and two artifacts race to deploy) and a client that reloads has no job id to poll",
+    "label": "the row is never stamped queued, so single-flight is off (a second publish opens a second sandbox and two artifacts race to deploy) and a client that reloads has no job id to poll [anchor repointed 2026-08-11: mark_build_queued became the conditional claim_build_queued]",
     "file": "ee/pocketpaw_ee/sites/build_job.py",
-    "find": "    job_id = _mint_job_id(site_id)\n    await sites_service.mark_build_queued(site, job_id=job_id)",
-    "replace": "    job_id = _mint_job_id(site_id)",
+    "find": "    job_id = _mint_job_id(site_id)\n    claimed = await sites_service.claim_build_queued(site, job_id=job_id, timeout_seconds=timeout)",
+    "replace": "    job_id = _mint_job_id(site_id)\n    claimed = True",
     "tests": [
       "tests/ee/sites/test_build_job.py::TestEnqueueingABuild"
     ]
@@ -75,9 +75,9 @@
     ]
   },
   {
-    "label": "the single-flight gate is dropped, so two publishes of one site open two sandboxes — two bills, and two artifacts racing to be the one that deploys",
+    "label": "the single-flight gate is dropped, so two publishes of one site open two sandboxes — two bills, and two artifacts racing to be the one that deploys [anchor repointed 2026-08-11: the gate moved into the conditional write, so the caller's branch is now the claim's result]",
     "file": "ee/pocketpaw_ee/sites/build_job.py",
-    "find": "    if not should_enqueue(site, timeout):",
+    "find": "    if not claimed:",
     "replace": "    if False:",
     "tests": [
       "tests/ee/sites/test_build_job.py::TestEnqueueingABuild::test_a_live_build_is_not_enqueued_twice"
@@ -194,10 +194,10 @@
     ]
   },
   {
-    "label": "a new attempt no longer clears the previous rung, so a queued build displays the last attempt's failure reason — a row that lies to whoever is watching it",
+    "label": "a new attempt no longer clears the previous rung, so a queued build displays the last attempt's failure reason — a row that lies to whoever is watching it [anchor re-indented 2026-08-11: the values dict moved out of the set() call into the claim]",
     "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "            \"build_job_id\": job_id,\n            \"build_reason\": None,",
-    "replace": "            \"build_job_id\": job_id,",
+    "find": "        \"build_job_id\": job_id,\n        \"build_reason\": None,",
+    "replace": "        \"build_job_id\": job_id,",
     "tests": [
       "tests/ee/sites/test_build_job.py::TestEnqueueingABuild::test_a_new_attempt_clears_the_previous_rung"
     ]


### PR DESCRIPTION
Closes the leak #1910 measured. The single-flight guard read the row and then wrote it, awaiting in between, so every publish arriving inside that window read the same pre-stamp row, passed the gate correctly by the guard's own rules, and opened its own sandbox. Eight concurrent publishes of one site produced eight sandboxes.

## The fix

`should_enqueue` was never wrong — it could not enforce its answer. So the answer moves into the write. `service.claim_build_queued` stamps `queued` through `find_one_and_update` with `build_state.claim_precondition` as the filter, and the database picks one winner. The losers write nothing and return `None`, which is the same answer a refused publish already gave, so nothing upstream changes.

The `should_enqueue` pre-check in front of it is gone. A second reader of the same rule would be free, but it would also invite the next reader of that code to believe the read is what protects the site — and that belief is what cost eight sandboxes. One gate, and it is the conditional write.

| Burst shape | Before | After |
|---|---|---|
| 8 concurrent, one shared row | 8 sandboxes | 1 sandbox, 7 refused |
| 8 concurrent, each having loaded its own row | 8 sandboxes | 1 sandbox, 7 refused |
| 2 concurrent | 2 sandboxes | 1 sandbox, 1 refused |
| Burst on a stale (dead) row | unblocked | 1 sandbox, 7 refused |
| 8 concurrent across 8 sites | 8 sandboxes | 8 sandboxes (unchanged, correct) |

## How the precondition expresses staleness

This was the part worth getting right rather than approximating. A filter of `status not in ("queued","building")` would refuse a **stale** in-flight row — the one case `should_enqueue` deliberately lets through — and that is how a site becomes permanently unpublishable, which is the worse direction. So the precondition is a disjunction mirroring `should_enqueue`'s branches:

```
{"$or": [
  {"build_status": {"$nin": ["building", "queued"]}},          # terminal, or unrecognised
  {"build_started_at": {"$not": {"$type": "date"}}},           # missing/null/garbage -> stale
  {"build_started_at": {"$lt": now - stale_after(timeout)}},   # past its own window
]}
```

No second step is needed — the stale case fits in the filter. Three details:

- `$not: {$type: "date"}` covers a null stamp, an absent field, and a garbage value from an older writer in one clause, so the asymmetric call survives intact: an unusable stamp stays claimable. One redundant idempotent build beats a site that can never publish again.
- `$nin` on the in-flight set (not `$in` on the terminal set) keeps `should_enqueue`'s reading of an *unrecognised* status as terminal, so the deploy-ordering constraint in `build_state`'s header is unchanged: a new in-flight state still has to reach every reader before any writer emits it.
- `$lt` is strict, matching `build_is_stale`'s `>`. At exactly the window the build is still in flight, in both halves.

One clock feeds the window test and the stamp (`claim_precondition(timeout, now=stamp)`), so a row is never judged against a window it was not written with.

The rule now lives in two languages, which is what this newly risks. `TestTheClaimPreconditionMatchesTheGuard` asserts the filter and `should_enqueue` reach the same verdict on every state, with the states enumerated rather than sampled.

## Verification, and where each half is verified

This PR **carries #1910's harness** (cherry-picked) with the assertions flipped from the pinned defect numbers to `sandboxes == 1` / `refused == BURST - 1`, which is what they were written to be the acceptance test for.

Atomicity is verified on the **yielding fake, not mongomock**. Mongomock resolves a write without yielding to the event loop, so a mongomock burst cannot see this class of bug at all — that is why the bug survived a 1000-test suite. `FakeSite` now stands in for the collection as well as the document, because a conditional write cannot be exercised against a fake that only models a doc; `FakeCollection.find_one_and_update` yields before it runs and then matches and applies without yielding, which is the one property a single-document Mongo update guarantees and the only one this fix leans on.

Mongomock is used in exactly one place, where its lack of yielding is irrelevant: asserting what the precondition **means** to a query engine. That half caught a real bug during development — `get_motor_collection()` does not exist in this Beanie version (the codebase uses `get_pymongo_collection()`), which would have been a production `AttributeError` on every publish.

- `tests/ee/sites/test_burst_harness.py`: 47 passed in 1.9s.
- `tests/ee/sites/test_build_job.py`: 63 passed — the existing enqueue tests pass unchanged through the new claim.
- `tests/ee/sites` full: 4 failed, 1053 passed, 4 skipped. The 4 are the known `test_generator_client_timeout.py` set (#1899); flaky `test_dev_server.py::test_touch_bumps_activity` passed. No new failures.
- `scripts/mutate.py --plan tests/mutations/sites_burst_harness.json`: **10 mutations, all caught**, including the one that deletes the precondition (which reproduces the 8-sandbox leak), the one that drops only the staleness clauses (which reproduces the unpublishable-site failure), and the one that ignores the write's outcome.
- `scripts/mutate.py --validate`: 285 anchors across 25 plans, each resolving exactly once.
- `ruff check .` and `ruff format --check .` clean repo-wide.
- No live infrastructure. No Daytona, no Redis, no network.

## Merge order

**#1910 should merge first.** It documents the bug and carries the runbook, which stands on its own as the record of what was measured and what the harness cannot tell us; this PR then rebases to a small diff. Superseding #1910 would fold the finding into the fix and lose the independently reviewed measurement — worth keeping given the finding is what made the fix possible. The overlap is mechanical: the four files #1910 adds, three of which this PR then edits.

## Two housekeeping notes

- I repointed three anchors in `tests/mutations/sl2_build_job.json` that the rename broke (`mark_build_queued` → `claim_build_queued`, and the gate branch moving from `should_enqueue` to the claim's result). Each label's described harm is preserved and the repoint is noted inline. Without this the plan aborts before its first mutation and reads as covering while proving nothing.
- #1910's two new test files landed with CRLF line endings while the repo's Python is LF. I matched them here so this PR's diff shows content only rather than a whole-file rewrite; normalising them is a one-line follow-up better done in #1910 at the source.

## What this still does not tell us

Unchanged from #1910, and worth repeating because a green run here is easy to over-read: this does not measure the concurrency cap, real sandbox contention, real queue latency, or the deploy race. It also does not prove Mongo's atomicity — it assumes it, and verifies the lane depends on nothing more. Sizing the cap still needs a live burst, which spends money and is the captain's call.
