### PR TITLE
feat(sites): give the react track a way to edit a site, and tell the agent when it is live

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2,6 +2,17 @@
 docs/api-reference.md — Hand-maintained reference for cloud REST endpoints
 that are not covered by the per-endpoint Mintlify pages under docs/api/.
 
+Updated: 2026-08-11 (feat/sites-react-edit-lane, RX-3) — added the "Sites —
+Agent Editing Tools (in-process MCP)" section documenting `edit_react_component`
+and the per-engine split that decides which editing tool a site gets. This is
+the first MCP tool documented in this file, which is otherwise REST-only, and it
+belongs here for a specific reason: the react edit lane has no REST route at all
+(it is chat-only), so a reader who checks the reference for "how do I change a
+react site" would otherwise find the svelte native-editing endpoints above and
+reasonably conclude nothing exists. The section also records WHY this tool does
+not publish, because the missing republish looks like an omission next to
+`edit_svelte_component` and is not one.
+
 Created: 2026-05-21 (RFC 04 alpha) — documents the per-pocket backend
 binding + read-only source-run endpoints. The rest of the cloud pockets
 API is described in the auto-generated wiki article
@@ -1313,6 +1324,77 @@ Errors:
 | 404 | `pocket.not_found` | Unknown pocket id. |
 | 403 | `pocket.access_denied` | The caller lacks access to the pocket. |
 | 500 | `sites.generator_failed` | The arm build failed (missing toolchain, non-zero build, or smoke-gate failure). |
+
+## Sites — Agent Editing Tools (in-process MCP)
+
+Editing a Paw Site from chat does not go over HTTP. The chat agent reaches it
+through the in-process MCP server `pocketpaw_sites_manager`
+(`ee/pocketpaw_ee/agent/mcp_servers/sites.py`), whose tools are namespaced
+`mcp__pocketpaw_sites_manager__<tool>`. Two editing tools live there, one per
+hand-authored engine, and they are **not interchangeable** — each rejects the
+other's pockets.
+
+| Tool | Engine | Publishes? |
+|------|--------|-----------|
+| `edit_svelte_component` | `engine: "svelte"` | Builds a draft **preview** (workerd smoke gate; rolls the source back if it fails) |
+| `edit_react_component` | `engine: "react"` | **No.** Persists the draft and stops — no build, no deploy |
+
+A ripple or dynamic site is edited through the pocket specialist's rippleSpec
+merge instead; an html site is edited by uid splice via the leaf-edits route
+above.
+
+### `edit_react_component`
+
+Write ONE file of a react site's `source` map as a reviewable draft.
+
+| Arg | Type | Notes |
+|-----|------|-------|
+| `pocket_id` | string | Required. The react site pocket. |
+| `component_path` | string | Required. Project-relative, e.g. `src/components/Hero.tsx`. Must already exist unless `create` is true. |
+| `edits` | array | A list of `{old_string, new_string}` blocks applied to the file's current contents. Each `old_string` must match **exactly once**. Exactly one of `edits` / `new_source`. |
+| `new_source` | string | The full new file contents (replaces the whole file). Required with `create`. |
+| `create` | boolean | Default `false`. Create a NEW file at `component_path`; the path must **not** already exist. |
+
+Returns `{ok: true, status: "draft", is_live: false, pocket_id, component_path,
+created, message}`. To **add a section**, call it twice: once with `create: true`
+for `src/components/<Name>.tsx`, then again with `edits` on `src/App.tsx` to
+import and render it.
+
+**It does not publish and does not enqueue a build**, and that is a deliberate
+divergence from the svelte tool rather than an omission. `build_runs_async("react")`
+is true: a react publish enqueues a Daytona build and returns before any build
+outcome exists, so there is no synchronous result to gate on and nothing to roll
+back from — a rollback fired on enqueue-success would revert a good edit.
+Persisting the draft is the whole job (the same shape the leaf-edits route
+documents). Publishing stays an explicit `publish` call the user asks for.
+
+**Write scope is enforced, not advisory.** The generator owns the build shell, so
+`index.html`, `package.json`, `vite.config.ts`, `paw-prerender.mjs` and everything
+under `src/paw/` are rejected, and the resolved path must land under `src/` or
+`public/`. Paths are normalized (backslashes, `.`/`..`) before the check, so
+`./package.json` and `src/paw/../paw/entry.tsx` are rejected too. This is the same
+policy `create_react_site` applies, shared through
+`ee/pocketpaw_ee/sites/react_paths.py` — an edit that could write `package.json`
+would be writing the dependency manifest, which is where the supply-chain
+release-age floor is enforced.
+
+Errors (relayed to the agent as `is_error` with the code, so it can fix and retry):
+
+| Code | When |
+|------|------|
+| `site_edit.invalid_args` | Not exactly one of `edits` / `new_source`. |
+| `site_edit.create_needs_source` | `create` without `new_source`. |
+| `site_edit.reserved_path` | The resolved path is generator-owned. |
+| `site_edit.path_outside_source` | The resolved path is outside `src/` and `public/`. |
+| `site_edit.no_match` / `site_edit.ambiguous_match` | An `old_string` matched 0 or >1 times. Make it more specific and retry. |
+| `pocket.not_react_site` | The pocket is not a react Paw Site. |
+| `pocket.react_component_exists` | `create` on a path that already exists. |
+| `site_component.not_found` | `create` is false and the path is not in the source map. |
+| `plan.feature_denied` | The workspace's plan lacks the `sites` feature. |
+
+Every write goes through `pockets_service.set_react_source_file`, which emits
+`PocketUpdated` and records a draft `ArtifactVersion` snapshotting the full edited
+source map — so an edit is a reviewable Branch draft a later publish promotes.
 
 ## Fabric — Transform Mappings (source→Fabric ingest)
 

--- a/ee/pocketpaw_ee/agent/mcp_servers/sites.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/sites.py
@@ -30,6 +30,17 @@
 # automatically. Opt-in — the default marketing brain stays create_landing_site
 # (ripple); the default flip to html is HE-12.
 #
+# Updated 2026-08-11 (RX-3 — the react track gets an EDIT lane): the
+# ``edit_react_component`` tool also registers on this SAME server (built via the
+# factory in sites_create.py), so create → publish → edit sit together for react
+# exactly as they do for svelte. Before it, ``edit_svelte_component`` was the ONLY
+# edit tool on the server: a react site could be created and published but never
+# changed, so the agent answered "shorten the hero headline" by calling
+# ``create_react_site`` again and minting a SECOND site pocket. It writes ONE file
+# of the pocket's react source map as a reviewable DRAFT — no republish, no build
+# enqueued (a react publish is async, so there is no synchronous outcome to gate
+# on). Its id rides ``SITES_TOOL_IDS``, so the per-surface allowlist picks it up.
+#
 # Updated 2026-08-07 (RX-2 — the agent can select the react engine): the
 # ``create_react_site`` tool also registers on this SAME server. A react site is a
 # {path: contents} map of hand-written React files; publish runs a Vite SSG build
@@ -100,6 +111,10 @@ CREATE_HTML_SITE_TOOL_ID = f"mcp__{SERVER_NAME}__create_html_site"
 # sites_create.py). A react site is a {path: contents} map of hand-written React
 # files; publish runs a Vite SSG build that prerenders it to a static dist/.
 CREATE_REACT_SITE_TOOL_ID = f"mcp__{SERVER_NAME}__create_react_site"
+# The targeted react-component edit tool (RX-3) — also registers on this SAME
+# server (see sites_create.py). It writes ONE file of a react site's source map as a
+# reviewable DRAFT; it does NOT publish and does NOT enqueue a build.
+EDIT_REACT_COMPONENT_TOOL_ID = f"mcp__{SERVER_NAME}__edit_react_component"
 
 SITES_TOOL_IDS = (
     PUBLISH_TOOL_ID,
@@ -109,6 +124,7 @@ SITES_TOOL_IDS = (
     CREATE_DYNAMIC_SITE_TOOL_ID,
     CREATE_HTML_SITE_TOOL_ID,
     CREATE_REACT_SITE_TOOL_ID,
+    EDIT_REACT_COMPONENT_TOOL_ID,
 )
 
 
@@ -279,6 +295,7 @@ def build_sites_manager_server() -> tuple[str, Any] | None:
         make_create_landing_site_tool,
         make_create_react_site_tool,
         make_create_svelte_site_tool,
+        make_edit_react_component_tool,
         make_edit_svelte_component_tool,
     )
 
@@ -302,6 +319,11 @@ def build_sites_manager_server() -> tuple[str, Any] | None:
     # html: the tool steers the agent to it only on an explicit React request or a
     # genuine interactivity need.
     create_react_site = make_create_react_site_tool(tool)
+    # The react-track EDIT tool (RX-3) — same server, so create → publish → edit
+    # sit together for react exactly as they do for svelte. Registering it is what
+    # stops the agent answering "shorten the hero headline" with a second
+    # create_react_site call and a second site pocket.
+    edit_react_component = make_edit_react_component_tool(tool)
 
     server = create_sdk_mcp_server(
         name=SERVER_NAME,
@@ -314,6 +336,7 @@ def build_sites_manager_server() -> tuple[str, Any] | None:
             create_dynamic_site,
             create_html_site,
             create_react_site,
+            edit_react_component,
         ],
     )
     return SERVER_NAME, server
@@ -325,6 +348,7 @@ __all__ = [
     "CREATE_LANDING_SITE_TOOL_ID",
     "CREATE_REACT_SITE_TOOL_ID",
     "CREATE_SVELTE_SITE_TOOL_ID",
+    "EDIT_REACT_COMPONENT_TOOL_ID",
     "EDIT_SVELTE_COMPONENT_TOOL_ID",
     "PUBLISH_TOOL_ID",
     "SERVER_NAME",

--- a/ee/pocketpaw_ee/agent/mcp_servers/sites_create.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/sites_create.py
@@ -1,6 +1,32 @@
 # sites_create.py — in-process MCP server exposing the DETERMINISTIC Paw Site
 # create action. Created: 2026-06-04 (feat/sites-deterministic-fastpath).
 #
+# Updated: 2026-08-11 (RX-3 — the react track gets an EDIT lane) — added a SEVENTH
+# tool ``edit_react_component`` plus its handler, mirroring
+# ``make_edit_svelte_component_tool``'s shape (identity → record_tool_call →
+# input validation → plan gate → service → draft-framed success body). It closes a
+# hole this file was half of: ``edit_svelte_component`` was the ONLY edit tool
+# registered, so on a react site the agent's only move for "shorten the hero
+# headline" was to call ``create_react_site`` again, minting a SECOND site pocket.
+# Three things about it differ from the svelte edit tool, all deliberate:
+#   * DRAFT-ONLY, with no ``SmokeGateFailed`` branch to map. Nothing is built, so
+#     nothing can fail a smoke gate — and a react publish enqueues its build and
+#     returns before any outcome exists, so there would be nothing to roll back to
+#     anyway. The success body says draft and publishing stays the user's call.
+#   * A ``create`` flag, because ``set_react_source_file`` (like its svelte peer)
+#     refuses a path that is not already in the map, and "add a testimonials
+#     section" needs a NEW file plus an ``src/App.tsx`` edit. It requires
+#     ``new_source`` and requires the path to be ABSENT, so it cannot overwrite a
+#     real component.
+#   * It runs ``_require_sites_plan_or_error``. ``edit_svelte_component`` does not,
+#     which is an asymmetry in that tool rather than a precedent for this one.
+# The reserved-path guard is the load-bearing part: without the same normalization
+# create uses, ``edit_react_component(component_path="package.json", create=true)``
+# writes the dependency manifest, defeating the generator's dependency allowlist
+# and with it the supply-chain release-age floor. So the policy moved OUT of this
+# file into ``pocketpaw_ee.sites.react_paths`` and both writers call it — the
+# constants below are now re-exports.
+#
 # Updated: 2026-08-07 (RX-2 — the agent can select the react engine) — added a
 # FIFTH create tool ``create_react_site`` for the Paw Sites "react track" (the
 # engine RX-1 registered). It mirrors ``create_html_site`` (the agent IS the
@@ -197,10 +223,10 @@ from __future__ import annotations
 
 import json
 import logging
-import posixpath
 from typing import Any
 
 from pocketpaw.agents.mcp_arg_coercion import coerce_json_object_args
+from pocketpaw_ee.sites import react_paths
 
 from ._audit import record_tool_call
 
@@ -236,6 +262,12 @@ CREATE_HTML_SITE_TOOL_ID = f"mcp__{SERVER_NAME}__create_html_site"
 # prerendered static output assets-only, with no server entry.
 CREATE_REACT_SITE_TOOL_ID = f"mcp__{SERVER_NAME}__create_react_site"
 
+# RX-3 — the react-track EDIT tool. Same server again. Without it the agent's only
+# response to "shorten the hero headline" on a react site was to call
+# ``create_react_site`` a second time, which mints a SECOND site pocket instead of
+# changing the one the user is looking at.
+EDIT_REACT_COMPONENT_TOOL_ID = f"mcp__{SERVER_NAME}__edit_react_component"
+
 SITES_CREATE_TOOL_IDS = (
     CREATE_LANDING_SITE_TOOL_ID,
     CREATE_SVELTE_SITE_TOOL_ID,
@@ -243,6 +275,7 @@ SITES_CREATE_TOOL_IDS = (
     CREATE_DYNAMIC_SITE_TOOL_ID,
     CREATE_HTML_SITE_TOOL_ID,
     CREATE_REACT_SITE_TOOL_ID,
+    EDIT_REACT_COMPONENT_TOOL_ID,
 )
 
 
@@ -359,9 +392,16 @@ REACT_REQUIRED_KEYS = ("src/App.tsx",)
 # Reserving them is not tidiness: an author who could overwrite ``index.html`` or
 # ``paw-prerender.mjs`` could remove the prerender outlet or the pass that fills
 # it, turning the site back into a shell that is blank with JavaScript disabled —
-# exactly what this engine exists to refuse to ship.
-REACT_RESERVED_FILES = ("index.html", "package.json", "vite.config.ts", "paw-prerender.mjs")
-REACT_RESERVED_PREFIX = "src/paw/"
+# exactly what this engine exists to refuse to ship. And an author who could
+# overwrite ``package.json`` would be writing the dependency manifest, which is
+# where the supply-chain release-age floor is enforced.
+#
+# RX-3: the policy itself now lives in ``pocketpaw_ee.sites.react_paths`` because
+# the EDIT lane is a second writer of the same map and two copies of a guard drift.
+# These names are re-exported here (and stay in ``__all__``) so every importer of
+# the create-time spelling keeps working.
+REACT_RESERVED_FILES = react_paths.REACT_RESERVED_FILES
+REACT_RESERVED_PREFIX = react_paths.REACT_RESERVED_PREFIX
 
 
 def _missing_react_keys(source: dict[str, Any]) -> list[str]:
@@ -376,17 +416,11 @@ def _missing_react_keys(source: dict[str, Any]) -> list[str]:
 def _reserved_react_keys(source: dict[str, Any]) -> list[str]:
     """Return the source-map keys that collide with a generator-owned path.
 
-    Normalizes backslashes and ``.``/``..`` segments so ``./index.html`` and
-    ``src\\paw\\x.tsx`` cannot slip past the check — the generator normalizes the
-    same way before it throws, and a guard that a trivial path spelling defeats is
-    not a guard. ``posixpath.normpath`` (not ``os.path``) because source-map keys
-    are always POSIX-style project-relative paths regardless of the host OS."""
-    hits: list[str] = []
-    for key in source:
-        norm = posixpath.normpath(key.replace("\\", "/"))
-        if norm in REACT_RESERVED_FILES or norm.startswith(REACT_RESERVED_PREFIX):
-            hits.append(key)
-    return sorted(hits)
+    A thin alias for ``react_paths.reserved_react_keys`` (RX-3), which normalizes
+    backslashes and ``.``/``..`` segments so ``./index.html`` and
+    ``src\\paw\\x.tsx`` cannot slip past the check. Kept under this name because
+    the create handler and its tests call it."""
+    return react_paths.reserved_react_keys(source)
 
 
 # ── Dynamic-track spec surface (RFC 12 A2) ──────────────────────────────────
@@ -1891,12 +1925,283 @@ def make_edit_svelte_component_tool(tool: Any) -> Any:
     return edit_svelte_component
 
 
+async def _edit_react_component_handler(args: dict) -> dict:
+    """MCP handler for ``sites_manager__edit_react_component`` (RX-3).
+
+    Reads workspace/user identity from the per-stream ContextVars, runs the same
+    plan gate the create handlers run, validates the inputs, and delegates to
+    ``sites_service.edit_react_component`` — which resolves the edit and persists
+    the one file as a reviewable DRAFT.
+
+    It does NOT republish and does NOT enqueue a build, so unlike the svelte edit
+    handler there is no ``SmokeGateFailed`` case to map: nothing is built, so
+    nothing can fail a smoke gate, and there would be nothing to roll back if it
+    could (a react publish enqueues its build and returns before any outcome
+    exists). The success body says draft, and publishing stays the user's call.
+
+    Returns ``{ok, status:"draft", is_live:false, pocket_id, component_path,
+    created, message}``; sets ``is_error`` when identity is missing, the plan lacks
+    Sites, the inputs are malformed, or the service rejects the edit (a reserved
+    path, a wrong-engine pocket, a missing/colliding component, an ambiguous
+    ``old_string``) — each relayed by code so the agent can fix and retry rather
+    than report a change that did not happen.
+    """
+    workspace_id, user_id = _identity()
+    if not workspace_id or not user_id:
+        return _error_response(
+            "edit_react_component requires workspace and user context (call from a "
+            "cloud chat session)."
+        )
+
+    record_tool_call(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        tool_server="pocketpaw_sites",
+        tool_name="_edit_react_component",
+        status="ok",
+        ok=True,
+    )
+
+    pocket_id = args.get("pocket_id")
+    if not isinstance(pocket_id, str) or not pocket_id:
+        return _error_response(
+            "edit_react_component requires a `pocket_id` — the id of the react site "
+            "pocket whose component you are editing."
+        )
+    component_path = args.get("component_path")
+    if not isinstance(component_path, str) or not component_path:
+        return _error_response(
+            "edit_react_component requires a `component_path` — the relative path of "
+            "the file to write (e.g. 'src/components/Hero.tsx'). It must already "
+            "exist in the site's source map unless you pass `create=true`."
+        )
+    args = coerce_json_object_args(args, ("edits",))
+    edits = args.get("edits")
+    new_source = args.get("new_source")
+    has_edits = edits is not None
+    has_new_source = new_source is not None
+    if has_edits == has_new_source:
+        return _error_response(
+            "edit_react_component requires exactly one of `edits` (a targeted "
+            "search/replace diff — PREFERRED for small changes) or `new_source` "
+            "(the FULL new file contents — for large rewrites and for `create`). "
+            "Provide one, not both and not neither."
+        )
+    if has_new_source and not isinstance(new_source, str):
+        return _error_response(
+            "edit_react_component `new_source` must be the FULL new contents of the "
+            "file as a string (the tool replaces the whole file, not a patch)."
+        )
+    if has_edits:
+        # Validate the diff SHAPE here so a malformed payload gets a clear error
+        # before the service runs. The MATCH-uniqueness contract belongs to the
+        # service's apply_edits (relayed below as a ValidationError).
+        if not isinstance(edits, list) or not edits:
+            return _error_response(
+                "edit_react_component `edits` must be a non-empty list of "
+                "{old_string, new_string} blocks (like the built-in Edit tool)."
+            )
+        for i, block in enumerate(edits):
+            if (
+                not isinstance(block, dict)
+                or not isinstance(block.get("old_string"), str)
+                or not isinstance(block.get("new_string"), str)
+            ):
+                return _error_response(
+                    f"edit_react_component `edits` block {i} must be an object with "
+                    "string `old_string` and `new_string`."
+                )
+    create = bool(args.get("create"))
+    if create and not has_new_source:
+        return _error_response(
+            "edit_react_component `create=true` needs `new_source` — the full "
+            "contents of the new file. There is nothing for `edits` to search "
+            "against in a file that does not exist yet."
+        )
+
+    # Plan gate (Sites = "sites"): an edit mutates a site pocket, so it is gated on
+    # the same feature the create tools are. Without this a workspace that lost the
+    # plan could keep editing a site its own /sites list 403s.
+    if (gate := await _require_sites_plan_or_error(workspace_id)) is not None:
+        return gate
+
+    from pocketpaw_ee.cloud._core.errors import CloudError
+    from pocketpaw_ee.sites import service as sites_service
+
+    try:
+        result = await sites_service.edit_react_component(
+            user_id=user_id,
+            pocket_id=pocket_id,
+            component_path=component_path,
+            new_source=new_source if has_new_source else None,
+            edits=edits if has_edits else None,
+            create=create,
+        )
+    except CloudError as exc:
+        # ValidationError (reserved path / outside src+public / not a react site /
+        # already exists / a bad diff) or NotFound (unknown pocket or component).
+        # Relay the code + message so the agent knows WHICH guard rejected it.
+        return _error_response(f"{exc.code}: {exc.message}")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("edit_react_component failed", exc_info=True)
+        return _error_response(f"edit failed: {exc}")
+
+    # The edit is a DRAFT. The chat agent narrates this payload, so — exactly like
+    # the svelte edit tool — it must not contain a completed-state publish claim.
+    return _success_response(
+        {
+            "ok": True,
+            "status": "draft",
+            "is_live": False,
+            "pocket_id": result["pocket_id"],
+            "component_path": result["component_path"],
+            "created": result["created"],
+            "message": (
+                "Saved to the site's draft — it is NOT online yet, and no build was "
+                "started. Tell the user the change is in the draft they can preview "
+                "under /sites, and offer to publish it; only call the publish tool "
+                "when they ask."
+            ),
+        }
+    )
+
+
+def make_edit_react_component_tool(tool: Any) -> Any:
+    """Build the ``edit_react_component`` SDK tool object using the SDK's ``tool``
+    decorator (passed in by the caller that already imported it).
+
+    Registered on the SAME ``pocketpaw_sites_manager`` server as create + publish +
+    ``edit_svelte_component`` (see ``make_create_landing_site_tool`` for why one
+    server)."""
+
+    @tool(
+        "edit_react_component",
+        (
+            "Change an EXISTING react Paw Site. Use this WHENEVER the user asks to "
+            "alter a react site that already exists — 'shorten the hero headline', "
+            "'make the pricing cards darker', 'fix the typo in the FAQ', 'add a "
+            "testimonials section'. NEVER call `create_react_site` again for a "
+            "change: that mints a SECOND site pocket and leaves the one the user is "
+            "looking at untouched. The change is saved to the site's DRAFT — it is "
+            "NOT published, nothing is built, and nothing goes live.\n"
+            "Give the change ONE of two ways (exactly one, not both):\n"
+            "  * `edits` — PREFER THIS for small/targeted changes. A list of "
+            "search/replace blocks [{old_string, new_string}, ...], exactly like "
+            "the built-in Edit tool: each `old_string` is copied VERBATIM from the "
+            "current file and must match EXACTLY ONCE (include enough surrounding "
+            "context to be unique), and `new_string` is what it becomes. You send "
+            "ONLY the change, not the whole file — far fewer tokens and faster. If "
+            "you have not read the file this turn, read it first so old_string "
+            "matches.\n"
+            "  * `new_source` — the FULL new file contents as a string (REPLACES "
+            "the whole file). For large rewrites, and the only form `create` "
+            "accepts.\n"
+            "To ADD a section: call this twice — once with `create=true` and "
+            "`new_source` for the new `src/components/<Name>.tsx`, then once with "
+            "`edits` on `src/App.tsx` to import and render it. `create=true` "
+            "REQUIRES the path to be new; editing an existing file with it is "
+            "rejected so you cannot overwrite a component by accident. Without "
+            "`create` the path must already exist, so a typo is an error and never "
+            "a stray new file.\n"
+            "You may only write under `src/` (outside `src/paw/`) and `public/`. "
+            "`index.html`, `package.json`, `vite.config.ts`, `paw-prerender.mjs` "
+            "and `src/paw/` are GENERATED and rejected — they carry the prerender "
+            "contract and the dependency list, and there is no way to add a "
+            "dependency. PRERENDER RULE (same as create_react_site): every "
+            "component must render its resting/final state in its RETURNED MARKUP, "
+            "because `useEffect` does not run at prerender time.\n"
+            "Args: `pocket_id` (the react site pocket), `component_path`, and one "
+            "of `edits` / `new_source`, plus optional `create`. Returns {ok, "
+            "status:'draft', is_live:false, pocket_id, component_path, created, "
+            "message}. Relay the `message`: the change is in the DRAFT the user can "
+            "preview under /sites, and publishing is their call — do NOT tell them "
+            "it is live. ok=false with an error means NOTHING was saved: an "
+            "old_string that matched 0 or >1 times means make it more specific and "
+            "retry; a reserved-path, wrong-engine, already-exists or not-found "
+            "error means relay the reason. Do NOT report a successful edit when "
+            "ok=false."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "pocket_id": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Id of the react site pocket to edit.",
+                },
+                "component_path": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": (
+                        "Relative path of the file to write (e.g. "
+                        "'src/components/Hero.tsx'). Must already exist in the "
+                        "site's source map unless `create` is true. Only `src/` "
+                        "(outside `src/paw/`) and `public/` may be written."
+                    ),
+                },
+                "edits": {
+                    "type": "array",
+                    "description": (
+                        "PREFERRED for small changes: a list of search/replace "
+                        "blocks applied to the file's CURRENT contents. Each "
+                        "`old_string` must match exactly once. Send this INSTEAD of "
+                        "`new_source` so you emit only the diff. Not valid with "
+                        "`create`."
+                    ),
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "old_string": {
+                                "type": "string",
+                                "description": (
+                                    "Exact text to replace, copied verbatim from the "
+                                    "current file; must match exactly once."
+                                ),
+                            },
+                            "new_string": {
+                                "type": "string",
+                                "description": "Replacement text (may be empty to delete).",
+                            },
+                        },
+                        "required": ["old_string", "new_string"],
+                        "additionalProperties": False,
+                    },
+                },
+                "new_source": {
+                    "type": "string",
+                    "description": (
+                        "The FULL new contents of the file as a string (REPLACES the "
+                        "whole file — not a diff). Use for large rewrites, and "
+                        "always with `create`."
+                    ),
+                },
+                "create": {
+                    "type": "boolean",
+                    "description": (
+                        "Create a NEW file at `component_path` instead of editing an "
+                        "existing one. Requires `new_source`, and the path must NOT "
+                        "already exist. Use it to add a section, then edit "
+                        "`src/App.tsx` to render it."
+                    ),
+                },
+            },
+            "required": ["pocket_id", "component_path"],
+            "additionalProperties": False,
+        },
+    )
+    async def edit_react_component(args):  # type: ignore[no-untyped-def]
+        return await _edit_react_component_handler(args)
+
+    return edit_react_component
+
+
 __all__ = [
     "CREATE_DYNAMIC_SITE_TOOL_ID",
     "CREATE_HTML_SITE_TOOL_ID",
     "CREATE_LANDING_SITE_TOOL_ID",
     "CREATE_REACT_SITE_TOOL_ID",
     "CREATE_SVELTE_SITE_TOOL_ID",
+    "EDIT_REACT_COMPONENT_TOOL_ID",
     "EDIT_SVELTE_COMPONENT_TOOL_ID",
     "HTML_REQUIRED_KEYS",
     "REACT_REQUIRED_KEYS",
@@ -1911,5 +2216,6 @@ __all__ = [
     "make_create_landing_site_tool",
     "make_create_react_site_tool",
     "make_create_svelte_site_tool",
+    "make_edit_react_component_tool",
     "make_edit_svelte_component_tool",
 ]

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -229,6 +229,20 @@ run-tool route can read the allowlist off the credential row.
 ``get_pocket_backend_for_executor`` APPENDS ``allowed_tools`` as the 9th tuple
 element (back-compatible — every existing positional destructure uses ``*_``).
 
+Changes: 2026-08-11 (feat/sites-react-edit-lane, RX-3) — added
+``set_react_source_file``, the react peer of ``set_svelte_source_file`` and the
+only place a react ``source`` map is written after create. Until this existed the
+react track had NO edit path at all — ``set_svelte_source_file`` rejects a react
+pocket with ``pocket.not_svelte_site``, so the chat agent's only response to
+"shorten the hero headline" was a second ``create_react_site``, which minted a
+SECOND site pocket. It mirrors the svelte peer on access
+(``_check_domain_edit_access``), the fresh-dict reassignment for ODM dirty
+tracking, ``emit(PocketUpdated(...))`` and the best-effort draft
+``ArtifactVersion`` snapshot, and diverges in exactly two ways: a ``create`` flag
+(a new component FILE is needed to add a section, and it INVERTS the path check
+rather than relaxing it — ``create=False`` demands the path exist, ``create=True``
+demands it not), and it returns only the wire dict, because the react lane has no
+republish to roll back from.
 Changes: 2026-06-17 (feat/sites-svelte-component-edit, SE-2) — added
 ``set_svelte_source_file``: rewrite ONE file in a svelte-engine pocket's
 ``source`` map (the {path: contents} hand-written SvelteKit files) and persist
@@ -2179,6 +2193,83 @@ async def set_svelte_source_file(
     # versioning is an additive history layer, never a gate on the edit.
     await _record_pocket_svelte_draft_version(doc, author=user_id)
     return await _resolved_wire_dict(doc, user_id), previous_source
+
+
+async def set_react_source_file(
+    pocket_id: str,
+    user_id: str,
+    *,
+    component_path: str,
+    new_source: str,
+    create: bool = False,
+) -> dict:
+    """Write ONE file in a react-engine pocket's ``source`` map and persist it.
+
+    The react peer of ``set_svelte_source_file``, and the only place a react
+    ``source`` map is written after create — the Pocket Beanie write stays inside
+    the pockets service (entity isolation: the sites service resolves the edit and
+    orchestrates, but never touches the Pocket model).
+
+    Access mirrors ``update`` / ``set_svelte_source_file``: explicit
+    ``(pocket_id, user_id)`` with ``_check_domain_edit_access`` (owner /
+    shared_with / workspace-visible). A missing pocket raises ``NotFound``.
+
+    ``create`` is the one place this DIVERGES from the svelte peer, and it exists
+    because "add a testimonials section" needs a new component FILE plus an edit to
+    ``src/App.tsx`` — with an existence-only contract the agent could not add a
+    section at all. It flips the path check rather than relaxing it, so exactly one
+    of the two mistakes is impossible in each mode:
+
+      * ``create=False`` (default) — ``component_path`` MUST already exist, else
+        ``NotFound`` (404) on the component. A typo'd path is never a silent create.
+      * ``create=True`` — ``component_path`` must NOT already exist, else
+        ``ValidationError`` (422). Silently overwriting a real component the agent
+        thought it was adding is worse than a rejected call it can retry.
+
+    A non-react pocket (``engine != "react"`` or no ``source`` map) is a
+    ``ValidationError`` (422, ``pocket.not_react_site``) rather than a write against
+    the wrong content model.
+
+    Returns the resolved wire dict every other write returns. Unlike the svelte peer
+    it does NOT also return the file's prior contents: that value exists there only
+    so the caller can roll back a failed republish, and the react edit lane has no
+    republish to fail (``build_runs_async("react")`` is True — a react publish
+    enqueues a Daytona build and returns before any outcome exists). Persisting the
+    draft IS the whole job.
+    """
+    doc = await _fetch_pocket(pocket_id)
+    _check_domain_edit_access(_pocket_to_domain(doc), user_id)
+
+    if getattr(doc, "engine", "ripple") != "react" or not isinstance(doc.source, dict):
+        raise ValidationError(
+            "pocket.not_react_site",
+            "This pocket is not a react Paw Site — it has no component source map to edit.",
+        )
+    exists = component_path in doc.source
+    if create and exists:
+        raise ValidationError(
+            "pocket.react_component_exists",
+            f"`{component_path}` already exists in this site's source map. Edit it "
+            "without `create` instead of overwriting it.",
+        )
+    if not create and not exists:
+        raise NotFound("site_component", component_path)
+
+    # Reassign a fresh dict so Beanie tracks the change (in-place mutation of a
+    # dict field is not always detected as dirty by the ODM) — same note as
+    # ``set_svelte_source_file``.
+    updated = dict(doc.source)
+    updated[component_path] = new_source
+    doc.source = updated
+    await doc.save()
+    await emit(PocketUpdated(data=await _pocket_event_payload(doc)))
+    # Branch primitive (BP-3): a source-map edit ALSO writes a draft
+    # ArtifactVersion snapshotting the FULL map, so the edit is a reviewable draft
+    # a later publish promotes. The helper is engine-agnostic (it snapshots
+    # ``doc.source`` whatever engine wrote it); same best-effort contract — an
+    # additive history layer, never a gate on the edit.
+    await _record_pocket_svelte_draft_version(doc, author=user_id)
+    return await _resolved_wire_dict(doc, user_id)
 
 
 async def set_imported_source(
@@ -5742,6 +5833,7 @@ __all__ = [
     "set_pocket_backend",
     "set_pocket_connector_permissions",
     "set_pocket_write_policy",
+    "set_react_source_file",
     "set_svelte_source_file",
     "unassign_project_on_pockets",
     "update",

--- a/ee/pocketpaw_ee/cloud/surface/handlers/sites.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/sites.py
@@ -138,6 +138,28 @@
 # site correctly leaves it still. The sub-builders keep returning ``str``; only
 # the entry point answers the key.
 
+# Updated: 2026-08-11 (feat/sites-react-edit-lane, RX-3) — the react track finally
+# has an EDIT tool, and two preambles were telling the agent the wrong thing about
+# changing a react site:
+#   * `_create_preamble`'s react `build_step` now says that any change after the
+#     create goes through `mcp__pocketpaw_sites_manager__edit_react_component` with
+#     the same pocket_id, NOT a second `create_react_site`. That is the reported
+#     bug: with no edit tool registered, a follow-up "shorten the hero headline"
+#     had one available move, and it minted a SECOND site pocket while the site the
+#     user was looking at stayed unchanged.
+#   * `_refine_preamble` now routes a react site to the new
+#     `_react_refine_preamble`. The existing refine preamble names
+#     `mcp__pocketpaw_pocket_specialist__edit` and then enumerates five rules about
+#     ripple WIDGETS; a react pocket has no rippleSpec, so on that engine the
+#     instruction is not merely useless, it points at a merge with nothing to merge
+#     into. Per pocketpaw/CLAUDE.md, naming an existing-but-WRONG tool is the same
+#     defect as naming an absent one. The react preamble replaces the widget rules
+#     with the prerender rule (the same hazard in React spelling) and the
+#     src/+public/ write scope the tool actually enforces.
+# The refine fork reads `meta.engine`, which is documented as the CREATE hint, so it
+# only fires when the per-site chat client stamps it — see
+# `_react_refine_preamble`'s docstring. Absent it, refine behaves exactly as before.
+
 from __future__ import annotations
 
 import functools
@@ -395,7 +417,19 @@ def _create_preamble(meta: SurfaceMeta) -> str:
             "rippleSpec and NO widget catalog on this track — do not draft a "
             "rippleSpec or call the pocket specialist, and there is no "
             "`/api/submit` route (no server runtime), so a lead form is a native "
-            "`<form>` with flat named fields."
+            "`<form>` with flat named fields.\n"
+            "CHANGES GO THROUGH THE EDIT TOOL. Once the site exists, ANY further "
+            "change the user asks for in this conversation — 'shorten the hero "
+            "headline', 'darker pricing cards', 'add a testimonials section' — is "
+            "`mcp__pocketpaw_sites_manager__edit_react_component` with the SAME "
+            "pocket_id, NOT a second `create_react_site` call. Calling create again "
+            "mints a SECOND site and leaves the one the user is looking at "
+            "unchanged. Send a targeted `edits` diff for a small change; to add a "
+            "section, call it with `create=true` for the new "
+            "`src/components/<Name>.tsx` and then again with `edits` on "
+            "`src/App.tsx` to render it. The edit saves to the DRAFT — it does not "
+            "publish, so keep offering the Preview rather than announcing a live "
+            "change."
         )
     elif engine == "ripple":
         engine_note = " The page is rendered STATICALLY (no JavaScript runs for the visitor)."
@@ -585,13 +619,106 @@ def _create_preamble(meta: SurfaceMeta) -> str:
     )
 
 
+def _react_refine_preamble(meta: SurfaceMeta) -> str:
+    """The /sites/[siteId] refine preamble for a REACT site (RX-3).
+
+    Its own function rather than a branch inside ``_refine_preamble`` because
+    almost nothing in that preamble is true here. That one tells the agent to
+    apply the change via ``mcp__pocketpaw_pocket_specialist__edit`` and then
+    enumerates five rules about ripple WIDGETS (``pricing-table`` uses ``tiers``,
+    never the ``accordion`` widget, Tier-0 animation names). A react site has no
+    rippleSpec at all, so on this engine every one of those is either inert or
+    actively wrong: the specialist edit path would try to merge a spec the pocket
+    does not have. Per pocketpaw/CLAUDE.md, naming an existing-but-WRONG tool is
+    the same defect as naming an absent one — the model does not error, it
+    improvises.
+
+    The prerender rule replaces the SSR widget rules, because it is the react
+    spelling of the same hazard: ``useEffect`` does not run at prerender time, so
+    a resting state set only in an effect bakes as the initial value.
+
+    REACHABILITY CAVEAT, worth knowing before trusting this in production:
+    ``SurfaceMeta.engine`` is documented as the /sites CREATE hint (the engine
+    toggle), and ``resolve_profile`` deliberately ignores it once ``pocket_id`` is
+    set. So this branch only renders when the per-site chat client actually stamps
+    ``engine="react"`` on the surface meta. When it does not, refine falls through
+    to the ripple preamble below exactly as it does today — no regression, but the
+    react-correct instructions do not arrive either. Sending the engine from the
+    /sites/[siteId] client is the follow-up that finishes this.
+    """
+    route = meta.route_path or "/sites"
+    pocket_id = meta.pocket_id or ""
+    return (
+        f'<surface kind="sites" route="{route}" pocket="{pocket_id}" '
+        'engine="react" mode="refine" />\n'
+        "<sites-orientation>\n"
+        f"The user is REFINING an EXISTING React Paw Site (source pocket "
+        f"`{pocket_id}`) — a real standalone marketing website whose pages are "
+        "hand-written React components PRERENDERED to static HTML at build time. "
+        "They are on its per-site chat asking for a CHANGE to that page. Do NOT "
+        "rebuild the site from scratch, do NOT create a new site or a new pocket, "
+        "and do NOT treat it as an in-app dashboard pocket. Talk about it as a "
+        "'site' or 'page' — never a 'pocket'.\n"
+        "</sites-orientation>\n"
+        "<sites-procedure>\n"
+        "ASK, DON'T ASSUME: if the requested edit is ambiguous, or applying it "
+        "needs a real fact you don't have (new copy, a price, a section's "
+        "content, or which of several interpretations the user means), call "
+        "`mcp__pocketpaw_ask__ask_user` with a one-line question and 3–5 short "
+        "options (include a 'you decide' option) instead of guessing — and NEVER "
+        "fabricate real-world facts (testimonials, stats, prices, addresses, "
+        "contact details).\n"
+        "APPLY THE CHANGE with "
+        "`mcp__pocketpaw_sites_manager__edit_react_component`, passing pocket_id "
+        f"`{pocket_id}`. That is the ONLY way to change this site. Do NOT call "
+        "`create_react_site` (it mints a SECOND site and leaves this one "
+        "untouched), and do NOT call `mcp__pocketpaw_pocket_specialist__edit` or "
+        "any rippleSpec merge — a React site has no rippleSpec, so there is "
+        "nothing for those to edit.\n"
+        "Send a targeted `edits` diff — a list of {old_string, new_string} blocks "
+        "where each old_string is copied VERBATIM from the current file and "
+        "matches exactly once — rather than the whole file, and read the file "
+        "first if you have not this turn. To ADD a section, call the tool twice: "
+        "once with `create=true` and `new_source` for the new "
+        "`src/components/<Name>.tsx`, then once with `edits` on `src/App.tsx` to "
+        "import and render it.\n"
+        "YOU MAY ONLY WRITE under `src/` (outside `src/paw/`) and `public/`. "
+        "`index.html`, `package.json`, `vite.config.ts`, `paw-prerender.mjs` and "
+        "`src/paw/` are GENERATED and will be rejected — they carry the prerender "
+        "contract and the dependency list. The project has react, react-dom and "
+        "vite and NOTHING else: no router, no CSS framework, no state or "
+        "animation library, and no way to add a dependency, so build the change "
+        "with what is there.\n"
+        "PRERENDER RULE: every component must render its resting/final state in "
+        "its RETURNED MARKUP. `useEffect` does not run at prerender time, so a "
+        "count-up initialized to 0 bakes '0' — initialize it to the final value. "
+        "Keep any motion CSS-only unless the site already ships client "
+        "JavaScript.\n"
+        "THE EDIT IS A DRAFT. It does NOT publish and does NOT start a build, so "
+        "never tell the user the change is live. Point them at the in-app Preview "
+        "under /sites and offer to publish; call "
+        "`mcp__pocketpaw_sites_manager__publish` only when they ask to go live, "
+        "and then relay the real result — no phantom URLs. Keep talking 'site' / "
+        "'page', never 'pocket'.\n"
+        "</sites-procedure>\n"
+        f"{_CONCIERGE_NOTE}"
+    )
+
+
 def _refine_preamble(meta: SurfaceMeta) -> str:
     """The /sites/[siteId] refine preamble — edit an EXISTING published site.
 
     Landing-aware: mirrors the create-paw-site brain's structure + 5 SSR rules
     so an edit can't reintroduce a static-site trap. Carries the source
     ``pocket_id`` so the agent edits the right pocket in place.
+
+    RX-3: a react site routes to ``_react_refine_preamble`` instead, because this
+    preamble's edit instruction (``mcp__pocketpaw_pocket_specialist__edit``) and
+    its five ripple-widget rules are all about a rippleSpec a react pocket does
+    not have. See that function for the ``meta.engine`` reachability caveat.
     """
+    if (meta.engine or "").lower() == "react":
+        return _react_refine_preamble(meta)
     route = meta.route_path or "/sites"
     pocket_id = meta.pocket_id or ""
     return (
@@ -862,4 +989,10 @@ def _chat_preamble(meta: SurfaceMeta) -> str:
     )
 
 
-__all__ = ["build_preamble", "_create_preamble", "_frontend_preamble", "_chat_preamble"]
+__all__ = [
+    "build_preamble",
+    "_create_preamble",
+    "_frontend_preamble",
+    "_chat_preamble",
+    "_react_refine_preamble",
+]

--- a/ee/pocketpaw_ee/sites/react_paths.py
+++ b/ee/pocketpaw_ee/sites/react_paths.py
@@ -1,0 +1,151 @@
+# react_paths.py — the ONE place the react-track source-map path policy lives.
+#
+# Created: 2026-08-11 (feat/sites-react-edit-lane, RX-3) — extracted from
+# ``agent/mcp_servers/sites_create.py``, which owned ``REACT_RESERVED_FILES`` /
+# ``REACT_RESERVED_PREFIX`` / ``_reserved_react_keys`` because create was the only
+# writer of a react ``source`` map. ``edit_react_component`` is the second writer,
+# and a second writer with its own copy of the guard is how the guard rots: an edit
+# that could write ``package.json`` would defeat the generator's dependency
+# allowlist and, with it, the supply-chain release-age floor the manifest is what
+# enforces. So the normalization + the reserved set moved HERE and both writers call
+# it. ``sites_create`` re-exports the two constants and ``_reserved_react_keys``
+# under their old names, so nothing that imported them from there had to change.
+#
+# What is NEW here (create never needed it) is :func:`react_path_rejection` — the
+# single-path verdict an edit needs. Create validates a whole map and only had to
+# answer "which keys collide"; an edit names ONE path and has to answer "may this
+# path be written at all", which is the reserved question PLUS a positive one:
+# the resolved path must land under ``src/`` or ``public/``. Create got that second
+# half for free (its required ``src/App.tsx`` key and the generator's own scaffold
+# meant a stray root file was merely inert), but an edit with ``create=True`` can
+# mint an arbitrary path, so "not reserved" is not the same as "allowed".
+"""React-track source-map path policy for Paw Sites.
+
+A react-engine pocket's ``source`` is a ``{relative_path: file_contents}`` map that
+the paw-sites generator materializes ON TOP of a build shell it owns. Two rules
+govern which paths an author (create OR edit) may write:
+
+1. **Reserved paths are the generator's.** ``index.html``, ``package.json``,
+   ``vite.config.ts``, ``paw-prerender.mjs`` and everything under ``src/paw/``
+   carry the prerender contract. paw-sites' ``react-scaffold.ts`` throws on a
+   collision; checking here turns a build-time throw far from the authoring turn
+   into an actionable error. It is not tidiness: an author who could overwrite
+   ``paw-prerender.mjs`` could remove the pass that fills the prerender outlet,
+   turning the site back into a shell that is blank with JavaScript disabled — and
+   an author who could overwrite ``package.json`` would be writing the dependency
+   manifest, which is where the supply-chain release-age floor is enforced.
+
+2. **Authored files live under ``src/`` or ``public/``.** Everything else at the
+   project root belongs to the shell, so a path outside those two prefixes is
+   rejected rather than silently written somewhere the build ignores.
+
+Both rules are applied to the NORMALIZED path: backslashes become forward slashes
+and ``.``/``..`` segments collapse (``posixpath``, not ``os.path`` — source-map keys
+are POSIX-style project-relative paths regardless of the host OS). A guard a
+trivial path spelling defeats is not a guard, and ``./package.json`` /
+``src\\paw\\entry.tsx`` / ``src/paw/../paw/entry.tsx`` are trivial spellings.
+"""
+
+from __future__ import annotations
+
+import posixpath
+from typing import Any
+
+# Paths the generator owns and no source map may write. Mirrors ``RESERVED_FILES``
+# + ``RESERVED_NAMESPACE`` in paw-sites' react-scaffold.ts, which throws on a
+# collision.
+REACT_RESERVED_FILES: tuple[str, ...] = (
+    "index.html",
+    "package.json",
+    "vite.config.ts",
+    "paw-prerender.mjs",
+)
+REACT_RESERVED_PREFIX = "src/paw/"
+
+# The two directories an author may write into. Anything else — a root-level file,
+# a path that escapes the project with ``..``, an absolute path — is not authorable.
+REACT_AUTHORABLE_PREFIXES: tuple[str, ...] = ("src/", "public/")
+
+
+def normalize_react_path(path: str) -> str:
+    """Collapse a source-map key to the path the generator will actually write.
+
+    Backslashes become forward slashes (a Windows-authored key, or an agent that
+    guessed the separator) and ``.``/``..`` segments collapse. The generator
+    normalizes the same way before it throws, so normalizing first is what makes
+    the guards below agree with it.
+    """
+    return posixpath.normpath(path.replace("\\", "/"))
+
+
+def is_reserved_react_path(path: str) -> bool:
+    """True when ``path`` resolves onto a generator-owned file or namespace."""
+    norm = normalize_react_path(path)
+    return norm in REACT_RESERVED_FILES or norm.startswith(REACT_RESERVED_PREFIX)
+
+
+def is_authorable_react_path(path: str) -> bool:
+    """True when ``path`` resolves inside ``src/`` or ``public/``.
+
+    Note this is about the RESOLVED path: ``src/../package.json`` normalizes to
+    ``package.json`` and is not authorable, which is the point.
+    """
+    norm = normalize_react_path(path)
+    return any(norm.startswith(prefix) for prefix in REACT_AUTHORABLE_PREFIXES)
+
+
+def reserved_react_keys(source: dict[str, Any]) -> list[str]:
+    """Return the source-map keys that collide with a generator-owned path.
+
+    The whole-map form, used by ``create_react_site`` to name every offending key
+    at once instead of failing on the first. Returns the keys AS THE AUTHOR SPELLED
+    THEM (not normalized) so the error message points at something findable in the
+    payload.
+    """
+    return sorted(key for key in source if is_reserved_react_path(key))
+
+
+def react_path_rejection(path: str) -> str | None:
+    """Return why ``path`` may not be written, or ``None`` when it may.
+
+    The single-path form, used by the edit lane. Two rejections, checked in this
+    order because the reserved one is the more specific and more useful message:
+
+      * a generator-owned path (rule 1) — names the shell and the reason;
+      * anything outside ``src/`` / ``public/`` (rule 2) — catches root-level
+        files, ``..`` escapes and absolute paths in one check.
+
+    Returns a message fragment the caller wraps in its own error, so the error
+    code is the caller's choice (the sites service raises two distinct codes) and
+    this module stays free of any dependency on the cloud error hierarchy.
+    """
+    norm = normalize_react_path(path)
+    if norm in REACT_RESERVED_FILES or norm.startswith(REACT_RESERVED_PREFIX):
+        return (
+            f"`{path}` resolves to `{norm}`, which the generator owns. The build "
+            "shell (index.html, package.json, vite.config.ts, paw-prerender.mjs) "
+            "and the `src/paw/` namespace carry the prerender contract that keeps "
+            "the page from shipping blank without JavaScript, and package.json is "
+            "where the dependency allowlist lives. Edit under `src/` (outside "
+            "`src/paw/`) or `public/`."
+        )
+    if not any(norm.startswith(prefix) for prefix in REACT_AUTHORABLE_PREFIXES):
+        return (
+            f"`{path}` resolves to `{norm}`, which is outside the authored source "
+            "tree. A react site's own files live under `src/` or `public/`; "
+            "everything else at the project root belongs to the generated build "
+            "shell."
+        )
+    return None
+
+
+__all__ = [
+    "REACT_AUTHORABLE_PREFIXES",
+    "REACT_RESERVED_FILES",
+    "REACT_RESERVED_PREFIX",
+    "is_authorable_react_path",
+    "is_reserved_react_path",
+    "normalize_react_path",
+    "react_path_rejection",
+    "reserved_react_keys",
+]

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,28 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-08-11 (RX-3 — the react track gets an EDIT lane): added
+# ``edit_react_component``, the react peer of ``edit_svelte_component``. Until this
+# existed there was no way to change a react site: this module's edit entry points
+# are svelte-gated, so the chat agent's only response to "shorten the hero
+# headline" was a second ``create_react_site``, which mints a SECOND site pocket.
+# Two contracts differ from the svelte peer on purpose, and both are argued in the
+# function's own docstring so a reader who only opens that one does not have to
+# guess:
+#   * DRAFT-ONLY — it does NOT republish and does NOT enqueue a build. It cannot:
+#     ``build_runs_async("react")`` is True, so a react publish enqueues a Daytona
+#     build and returns before any outcome exists. There is nothing synchronous to
+#     roll back from, and a rollback fired on enqueue-success would revert a good
+#     edit. Persisting the draft IS the job (the shape ``apply_leaf_edits`` already
+#     documents). Publishing stays the user's call.
+#   * A ``create`` flag for a NEW component file, because "add a testimonials
+#     section" needs one plus an ``src/App.tsx`` edit. It INVERTS the existence
+#     check rather than relaxing it.
+# The path guard is shared with create through the new
+# ``sites/react_paths.py`` — an edit that could write ``package.json`` would be a
+# way around the generator's dependency allowlist, and with it the supply-chain
+# release-age floor that manifest is what enforces.
+#
 # Updated 2026-08-10 (SL-3 — the build lane reaches the wire): ``_to_response`` and
 # ``pocket_status`` now populate ``build_status`` / ``build_reason`` / ``build_job_id``
 # from the Site row. They were declared on the DTOs by SG-9i and never passed here, so
@@ -816,6 +838,7 @@ from pocketpaw_ee.sites.dto import (
 )
 from pocketpaw_ee.sites.engines import content_key, is_source_engine, normalize_engine
 from pocketpaw_ee.sites.generator_client import BuildResult, GeneratorClient
+from pocketpaw_ee.sites.react_paths import is_reserved_react_path, react_path_rejection
 
 logger = logging.getLogger(__name__)
 
@@ -4668,6 +4691,162 @@ async def edit_svelte_component(
         _generator=_generator,
     )
     return doc
+
+
+async def edit_react_component(
+    *,
+    user_id: str,
+    pocket_id: str,
+    component_path: str,
+    new_source: str | None = None,
+    edits: list[dict[str, str]] | None = None,
+    create: bool = False,
+    _pockets: Any = None,
+) -> dict[str, Any]:
+    """Write ONE file of a react Paw Site pocket and leave it as a reviewable DRAFT.
+
+    The chat-agent entry point for a targeted react edit (RX-3). Before this
+    existed the react track had no edit path: ``edit_svelte_component`` rejects a
+    react pocket, so the agent's only move on "shorten the hero headline" was a
+    second ``create_react_site`` — a SECOND site pocket instead of a change to the
+    one the user is looking at.
+
+    The edit is expressed one of two ways (exactly one is required), the same
+    contract ``edit_svelte_component`` uses so the agent's instinct transfers:
+
+      * ``edits`` — a list of ``[{old_string, new_string}, ...]`` search/replace
+        blocks applied to the file's CURRENT contents via the shared
+        :func:`apply_edits`, which requires each ``old_string`` to match exactly
+        once and raises a clear, retry-able ``ValidationError`` otherwise. PREFERRED
+        for small changes: the agent emits only the diff.
+      * ``new_source`` — the FULL new file contents, used as-is. For large rewrites,
+        and the ONLY form accepted with ``create=True`` (there is nothing to diff
+        against a file that does not exist yet).
+
+    ``create=True`` mints a NEW path instead of editing an existing one. It exists
+    because "add a testimonials section" needs a new component file PLUS an edit to
+    ``src/App.tsx``, and without it the agent cannot add a section at all. It
+    INVERTS the existence check rather than relaxing it — ``create=False`` requires
+    the path to exist (a typo is never a silent create), ``create=True`` requires it
+    NOT to (an accidental overwrite of a real component is worse than a rejected
+    call).
+
+    **DRAFT-ONLY. This does NOT republish and does NOT enqueue a build**, and that
+    is a deliberate departure from ``edit_svelte_component``, which republishes and
+    rolls the source back when the workerd smoke gate rejects the edit. That
+    contract cannot transfer: ``build_runs_async("react")`` is True, so a react
+    publish ENQUEUES a Daytona build and returns before any build outcome exists —
+    there is nothing synchronous to roll back from, and a rollback fired on an
+    enqueue-success would revert a good edit. So persisting the edited draft IS the
+    whole job, the same shape ``apply_leaf_edits`` already documents. Publishing
+    stays the user's call (what ``pocketpaw-create-react-site`` STEP 4 promises).
+    A future reader looking at this and reaching for the missing republish should
+    read this paragraph first.
+
+    The path guard is load-bearing, not hygiene. ``create_react_site`` refuses
+    generator-owned paths, and an edit that did not would be a way around that
+    allowlist: ``edit_react_component(component_path="package.json", create=True)``
+    writes the dependency manifest, defeating the generator's dependency allowlist
+    and with it the supply-chain release-age floor the manifest is what enforces.
+    Both guards call the SAME
+    :func:`pocketpaw_ee.sites.react_paths.react_path_rejection` — normalized, so
+    ``./package.json`` and ``src/paw/../paw/entry.tsx`` cannot spell their way past
+    it — and it also requires the resolved path to land under ``src/`` or
+    ``public/``.
+
+    Raises, all BEFORE anything is written:
+      * ``ValidationError("site_edit.invalid_args")`` — not exactly one of
+        ``edits`` / ``new_source``;
+      * ``ValidationError("site_edit.create_needs_source")`` — ``create=True``
+        without ``new_source``;
+      * ``ValidationError("site_edit.reserved_path")`` — a generator-owned path;
+      * ``ValidationError("site_edit.path_outside_source")`` — outside
+        ``src/`` / ``public/``;
+      * ``ValidationError("pocket.not_react_site")`` — not a react site pocket;
+      * ``NotFound("site_component")`` — ``create=False`` and the path is absent;
+      * ``ValidationError("pocket.react_component_exists")`` — ``create=True`` and
+        the path is present;
+      * whatever :func:`apply_edits` raises on a 0-match / ambiguous ``old_string``.
+
+    ``_pockets`` is an injectable seam for the pockets service so the orchestration
+    is unit-testable with no Bun / workerd / Cloudflare in sight — there is nothing
+    else to inject, because there is no build.
+
+    Takes NO ``workspace_id``, unlike its siblings: tenancy is resolved by the
+    pockets service off ``user_id`` (its public ``get`` raises Forbidden itself), and
+    ``edit_svelte_component`` only needs the workspace to look up the Site doc whose
+    builder origin its republish must re-apply — a republish this lane does not do.
+
+    Returns ``{pocket_id, component_path, created}``.
+    """
+    if _pockets is not None:
+        pockets_service = _pockets
+    else:
+        from pocketpaw_ee.cloud.pockets import service as pockets_service  # type: ignore[no-redef]
+
+    # Exactly one of the two edit shapes (mirrors edit_svelte_component).
+    if (edits is None) == (new_source is None):
+        raise ValidationError(
+            "site_edit.invalid_args",
+            "edit_react_component requires exactly one of `edits` (a targeted "
+            "search/replace diff) or `new_source` (a full file rewrite).",
+        )
+    if create and new_source is None:
+        raise ValidationError(
+            "site_edit.create_needs_source",
+            "Creating a new component needs `new_source` — the full contents of the "
+            "new file. There is nothing for `edits` to search against.",
+        )
+
+    # The reserved-path guard. FIRST, before the pocket is even read: a call that
+    # names a generator-owned path is rejected on the path alone, so no amount of
+    # pocket state can make it land.
+    if (reason := react_path_rejection(component_path)) is not None:
+        code = (
+            "site_edit.reserved_path"
+            if is_reserved_react_path(component_path)
+            else "site_edit.path_outside_source"
+        )
+        raise ValidationError(code, reason)
+
+    # The pockets service's PUBLIC get raises NotFound / Forbidden itself (entity
+    # isolation) — a missing / cross-tenant pocket surfaces as 404 / 403.
+    pocket = await pockets_service.get(pocket_id, user_id)
+    if (pocket.get("engine") or "ripple") != "react" or not isinstance(pocket.get("source"), dict):
+        raise ValidationError(
+            "pocket.not_react_site",
+            "This pocket is not a react Paw Site — it has no component source map to edit.",
+        )
+    source_map = pocket["source"]
+    # The MISSING-path half of the inversion is enforced here as well as at the write,
+    # because the ``edits`` branch below indexes the map: without it a typo'd path is a
+    # KeyError instead of the NotFound the caller has to relay. The EXISTING-path half
+    # (``create`` onto a live component) is deliberately NOT duplicated — nothing here
+    # reads the file on the create path, so the check would only be a second copy of a
+    # rule the write chokepoint already owns for every caller. Proven rather than
+    # assumed: with the duplicate present, the mutation that deleted it ESCAPED, because
+    # the chokepoint caught the write anyway.
+    if not create and component_path not in source_map:
+        raise NotFound("site_component", component_path)
+
+    if edits is not None:
+        # apply_edits raises ValidationError (clear, retry-able) on any match-count
+        # violation, BEFORE anything is persisted.
+        new_source = apply_edits(source_map[component_path], edits)
+
+    assert new_source is not None  # narrowing: the arg checks above guarantee it
+    await pockets_service.set_react_source_file(
+        pocket_id,
+        user_id,
+        component_path=component_path,
+        new_source=new_source,
+        create=create,
+    )
+
+    # NO publish, NO enqueue, NO native pre-warm. The pre-warm serves the svelte
+    # native editor's shadow-render, which reads a SvelteKit build; react has no
+    # such artifact, so warming one here would build a site nothing reads.
+    return {"pocket_id": pocket_id, "component_path": component_path, "created": create}
 
 
 async def _latest_site_for_pocket(workspace_id: str, pocket_id: str) -> _SiteDoc | None:

--- a/scripts/mutate.py
+++ b/scripts/mutate.py
@@ -361,9 +361,23 @@ def validate_plans(plans: list[Path], *, force: bool = False) -> int:
     texts: dict[Path, str | None] = {}
 
     def _text(path: Path) -> str | None:
+        """The file as the SWEEP will see it — ``read_bytes().decode()``, not
+        ``read_text()``.
+
+        The difference is line endings, and it is not cosmetic. ``read_text``
+        opens in universal-newlines mode, so a CRLF file arrives with ``\\n``;
+        the sweep reads ``read_bytes()`` (it must, to restore byte-for-byte) and
+        decodes, so CRLF stays CRLF. A multi-line anchor into a CRLF file
+        therefore matched here and then aborted the sweep with "anchor not
+        found" — validation passing a plan the sweep refuses to run, which is
+        exactly the disagreement :func:`anchor_problem`'s single definition
+        exists to prevent. Found 2026-08-11 on
+        ``ee/pocketpaw_ee/cloud/surface/handlers/sites.py``, which is CRLF in
+        the repo; the CI ``mutation-anchors`` job would have stayed green while
+        every local sweep touching that file died on arrival."""
         if path not in texts:
             try:
-                texts[path] = path.read_text(encoding="utf-8")
+                texts[path] = path.read_bytes().decode("utf-8")
             except OSError:
                 texts[path] = None
         return texts[path]

--- a/tests/cloud/surface/test_sites_handler.py
+++ b/tests/cloud/surface/test_sites_handler.py
@@ -1,6 +1,15 @@
 # tests/cloud/surface/test_sites_handler.py — Sites surface handler.
 #
 # Created: 2026-06-03 — Guards the /sites surface preamble.
+# Updated: 2026-08-11 (feat/sites-react-edit-lane, RX-3) — four tests at the BOTTOM
+# of this file pin the two preambles that route to the new react edit tool: the
+# react create step now says a follow-up change is
+# `edit_react_component`, NOT a second `create_react_site` (the re-create is what
+# minted a SECOND site pocket), and a react refine routes to
+# `_react_refine_preamble` instead of the rippleSpec merge path a react pocket has
+# nothing to merge into. The fourth test pins that ripple/svelte/no-engine refine is
+# byte-for-byte unchanged, so the fork cannot leak into the engine it was not
+# written for.
 # Updated: 2026-06-03 (pm) — Bundled skills now load on the SDK backend (local
 # plugin via the SDK `plugins=` option), so the preamble PREFERS the
 # `pocketpaw-create-site` skill and keeps the raw MCP tools only as a fallback.
@@ -1091,3 +1100,128 @@ async def test_concierge_awareness_does_not_depend_on_the_mcp_tool_id_import() -
         assert "concierge" in preamble.lower()
     finally:
         registry._MCP_TOOL_IDS_CACHE = original
+
+
+# ---------------------------------------------------------------------------
+# RX-3 — the react EDIT lane reaches the preambles that route to it
+# ---------------------------------------------------------------------------
+
+
+async def test_react_create_step_routes_follow_up_changes_to_the_edit_tool() -> None:
+    """The reported bug in prompt form: with no edit tool named, a follow-up
+    "shorten the hero headline" left the agent one available move — a second
+    ``create_react_site`` — which mints a SECOND site pocket and leaves the site the
+    user is looking at unchanged. The react build step now names the edit tool and
+    forbids the re-create.
+
+    THE MUTATION THAT BREAKS THIS: delete the CHANGES-GO-THROUGH-THE-EDIT-TOOL
+    paragraph from the react ``build_step``.
+    """
+    preamble = (
+        await sites_handler.build_preamble(
+            WORKSPACE, USER, SurfaceMeta(route_path="/sites", engine="react")
+        )
+    ).text
+
+    assert "mcp__pocketpaw_sites_manager__edit_react_component" in preamble
+    lower = preamble.lower()
+    # It says the re-create is wrong, and says WHY (a second site).
+    assert "second `create_react_site`" in preamble or "second create_react_site" in lower
+    assert "second site" in lower
+    # And it teaches the two-call add-a-section shape the tool actually needs.
+    assert "create=true" in lower
+    assert "src/app.tsx" in lower
+
+
+async def test_react_refine_names_the_edit_tool_and_not_the_ripple_merge() -> None:
+    """A react site's refine chat must route to ``edit_react_component``.
+
+    The default refine preamble names ``mcp__pocketpaw_pocket_specialist__edit``,
+    which merges a rippleSpec — and a react pocket has no rippleSpec, so that is an
+    instruction with nothing to act on. Per pocketpaw/CLAUDE.md, naming an
+    existing-but-WRONG tool is the same defect as naming an absent one: the model
+    does not error, it improvises.
+
+    THE MUTATION THAT BREAKS THIS: drop the ``engine == "react"`` fork from
+    ``_refine_preamble`` so react falls through to the ripple preamble.
+    """
+    preamble = (
+        await sites_handler.build_preamble(
+            WORKSPACE,
+            USER,
+            SurfaceMeta(
+                route_path="/sites/site-abc",
+                pocket_id=REFINE_POCKET,
+                site_id="site-abc",
+                engine="react",
+            ),
+        )
+    ).text
+
+    assert "mcp__pocketpaw_sites_manager__edit_react_component" in preamble
+    # The pocket the agent must edit is named, so it cannot address the wrong one.
+    assert REFINE_POCKET in preamble
+    # The ripple merge path is named ONLY as a prohibition — naming it at all is
+    # deliberate (the agent has the tool, so silence would leave it as a plausible
+    # move), but it must never read as the instruction.
+    assert "do NOT call `mcp__pocketpaw_pocket_specialist__edit`" in preamble
+    # The ripple WIDGET vocabulary is absent: those rules are about a spec this
+    # engine does not have, and carrying them would teach a react author to look
+    # for widgets that are not there.
+    assert "pricing-table" not in preamble
+    assert "accordion" not in preamble
+    # Re-creating is explicitly refused.
+    assert "create_react_site" in preamble
+
+
+async def test_react_refine_carries_the_prerender_and_write_scope_rules() -> None:
+    """The two rules that replace the ripple widget rules on this engine.
+
+    The prerender rule is the same hazard in React spelling (``useEffect`` does not
+    run at prerender time, so a resting state set only in an effect bakes as the
+    initial value), and the write scope is what the tool actually enforces — an edit
+    naming a reserved path is rejected, so the preamble must not let the agent
+    discover that by trial."""
+    preamble = (
+        await sites_handler.build_preamble(
+            WORKSPACE,
+            USER,
+            SurfaceMeta(
+                route_path="/sites/site-abc",
+                pocket_id=REFINE_POCKET,
+                site_id="site-abc",
+                engine="react",
+            ),
+        )
+    ).text
+    lower = preamble.lower()
+
+    assert "prerender" in lower
+    assert "useeffect" in lower
+    # The write scope + the reserved shell, spelled out.
+    assert "src/" in preamble and "public/" in preamble
+    assert "package.json" in preamble
+    assert "src/paw/" in preamble
+    # And that the edit is a DRAFT, so the agent does not announce a live change.
+    assert "draft" in lower
+    assert "does not publish" in lower
+
+
+async def test_non_react_refine_is_unchanged() -> None:
+    """The fork must not disturb the engine it was not written for: a refine with no
+    engine hint, or a ripple one, still gets the rippleSpec merge preamble."""
+    for engine in (None, "ripple", "svelte"):
+        preamble = (
+            await sites_handler.build_preamble(
+                WORKSPACE,
+                USER,
+                SurfaceMeta(
+                    route_path="/sites/site-abc",
+                    pocket_id=REFINE_POCKET,
+                    site_id="site-abc",
+                    engine=engine,
+                ),
+            )
+        ).text
+        assert "mcp__pocketpaw_pocket_specialist__edit" in preamble, engine
+        assert "edit_react_component" not in preamble, engine

--- a/tests/ee/agent/test_sites_mcp_server/test_edit_react_component.py
+++ b/tests/ee/agent/test_sites_mcp_server/test_edit_react_component.py
@@ -1,0 +1,514 @@
+# tests/ee/agent/test_sites_mcp_server/test_edit_react_component.py
+# Created: 2026-08-11 (feat/sites-react-edit-lane, RX-3) — coverage for the
+# react-track edit tool ``edit_react_component`` on the in-process
+# ``pocketpaw_sites_manager`` server. Modelled on its svelte sibling
+# (test_edit_svelte_component.py), with the differences that matter to the agent:
+#
+#   1. Registration — the tool id rides the SAME server allowlist as publish +
+#      the five create tools + edit_svelte_component, and the extension provider
+#      advertises it. Registration is not a formality here: it is the entire
+#      difference between "the agent can change a react site" and "the agent's only
+#      move is a second create_react_site that mints a SECOND site pocket".
+#   2. Handler wiring — identity gating, the Sites plan gate, input validation
+#      (including the `create` rules the svelte tool has no equivalent of), the
+#      success-body shape, and error MAPPING by code so the agent relays WHICH
+#      guard rejected the call.
+#   3. NARRATION — the success body must not claim the change is published or live.
+#      An edit is a draft; the agent reads this payload and tells the user.
+#
+# There is deliberately NO SmokeGateFailed case: react edits do not build, so
+# nothing can fail a smoke gate. The service-level persist + guard behaviour lives
+# in tests/ee/sites/test_react_component_edit.py; this file pins the agent surface.
+"""Tests for the react-track component edit tool (edit_react_component)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+
+@pytest.fixture(autouse=True)
+def _default_sites_plan():
+    """``edit_react_component`` runs the shared Sites plan gate
+    (sites.service.require_sites_plan) before it touches the service. These tests
+    use synthetic workspace ids with no seeded Workspace doc, so default the plan to
+    one that unlocks Sites ("go"); the denial path has its own test below."""
+    with patch(
+        "pocketpaw_ee.cloud.workspace.service.get_workspace_plan",
+        new=AsyncMock(return_value="go"),
+    ):
+        yield
+
+
+def _ok_result(*, created: bool = False) -> dict:
+    """What the service returns on a successful edit."""
+    return {
+        "pocket_id": "pk1",
+        "component_path": "src/components/Hero.tsx",
+        "created": created,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Registration — the tool rides the shared sites_manager allowlist
+# ---------------------------------------------------------------------------
+
+
+class TestRegistration:
+    def test_tool_id_on_shared_server_allowlist(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers.sites import (
+            EDIT_REACT_COMPONENT_TOOL_ID,
+            SITES_TOOL_IDS,
+        )
+
+        assert EDIT_REACT_COMPONENT_TOOL_ID == "mcp__pocketpaw_sites_manager__edit_react_component"
+        assert EDIT_REACT_COMPONENT_TOOL_ID in SITES_TOOL_IDS
+
+    def test_provider_advertises_edit_tool_id(self) -> None:
+        """``tool_ids()`` feeds the claude_sdk allowlist loop AND the /sites surface
+        scope. A tool the provider does not advertise is registered on the server
+        and still unreachable from the surface that needs it."""
+        from pocketpaw_ee.agent.mcp_servers.sites import EDIT_REACT_COMPONENT_TOOL_ID
+        from pocketpaw_ee.extensions import CloudSitesMcpProvider
+
+        assert EDIT_REACT_COMPONENT_TOOL_ID in CloudSitesMcpProvider().tool_ids()
+
+    def test_the_built_server_actually_lists_the_tool(self) -> None:
+        """The id constant and the registered tool are two different facts, and only
+        this one proves the SDK will dispatch a call. An id in ``SITES_TOOL_IDS``
+        with no tool behind it allow-lists a name that does not answer."""
+        import asyncio
+
+        from mcp import types
+        from pocketpaw_ee.agent.mcp_servers.sites import build_sites_manager_server
+
+        built = build_sites_manager_server()
+        if built is None:  # claude_agent_sdk absent — nothing to assert
+            pytest.skip("claude_agent_sdk not installed")
+        _name, server = built
+        handler = server["instance"].request_handlers[types.ListToolsRequest]
+        listed = asyncio.run(handler(types.ListToolsRequest(method="tools/list")))
+        names = {t.name for t in listed.root.tools}
+        assert "edit_react_component" in names, sorted(names)
+
+    def test_the_schema_declares_the_create_flag(self) -> None:
+        """``create`` is the argument the svelte edit tool has no equivalent of, and
+        the only way to ADD a section. If it drops off the schema the agent cannot
+        pass it and "add a testimonials section" silently becomes impossible."""
+        import asyncio
+
+        from mcp import types
+        from pocketpaw_ee.agent.mcp_servers.sites import build_sites_manager_server
+
+        built = build_sites_manager_server()
+        if built is None:
+            pytest.skip("claude_agent_sdk not installed")
+        _name, server = built
+        handler = server["instance"].request_handlers[types.ListToolsRequest]
+        listed = asyncio.run(handler(types.ListToolsRequest(method="tools/list")))
+        tool = next(t for t in listed.root.tools if t.name == "edit_react_component")
+        props = (tool.inputSchema or {}).get("properties") or {}
+        assert set(props) >= {"pocket_id", "component_path", "edits", "new_source", "create"}
+        assert (tool.inputSchema or {}).get("required") == ["pocket_id", "component_path"]
+
+    def test_the_description_steers_away_from_a_second_create(self) -> None:
+        """The bug this tool exists to fix is behavioural, so the description has to
+        say so: an agent that reaches for ``create_react_site`` on an edit request
+        mints a second site pocket, and nothing in the schema stops it."""
+        import asyncio
+
+        from mcp import types
+        from pocketpaw_ee.agent.mcp_servers.sites import build_sites_manager_server
+
+        built = build_sites_manager_server()
+        if built is None:
+            pytest.skip("claude_agent_sdk not installed")
+        _name, server = built
+        handler = server["instance"].request_handlers[types.ListToolsRequest]
+        listed = asyncio.run(handler(types.ListToolsRequest(method="tools/list")))
+        tool = next(t for t in listed.root.tools if t.name == "edit_react_component")
+        description = tool.description or ""
+        assert "create_react_site" in description
+        assert "NEVER" in description
+
+
+# ---------------------------------------------------------------------------
+# Handler wiring — identity, plan gate, validation, response shape, errors
+# ---------------------------------------------------------------------------
+
+
+class TestEditHandler:
+    @pytest.mark.asyncio
+    async def test_success_returns_pocket_and_component_path(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        fake = AsyncMock(return_value=_ok_result())
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch("pocketpaw_ee.sites.service.edit_react_component", new=fake),
+        ):
+            out = await mcp._edit_react_component_handler(
+                {
+                    "pocket_id": "pk1",
+                    "component_path": "src/components/Hero.tsx",
+                    "new_source": "export default function Hero() { return <section/>; }",
+                }
+            )
+
+        assert not out.get("is_error"), out
+        body = json.loads(out["content"][0]["text"])
+        assert body["ok"] is True
+        assert body["pocket_id"] == "pk1"
+        assert body["component_path"] == "src/components/Hero.tsx"
+        assert body["created"] is False
+        # The service got the agent identity + the edit inputs.
+        fake.assert_awaited_once()
+        kwargs = fake.await_args.kwargs
+        assert kwargs["user_id"] == "u1"
+        assert kwargs["pocket_id"] == "pk1"
+        assert kwargs["new_source"].startswith("export default")
+        assert kwargs["edits"] is None
+        assert kwargs["create"] is False
+
+    @pytest.mark.asyncio
+    async def test_success_payload_says_draft_and_never_claims_it_is_live(self) -> None:
+        """The agent narrates this payload verbatim-ish, so a publish claim in it is
+        a lie told to the user. A react edit stages a draft: nothing is built,
+        nothing is deployed, and publishing is a separate call the user asks for."""
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch(
+                "pocketpaw_ee.sites.service.edit_react_component",
+                new=AsyncMock(return_value=_ok_result()),
+            ),
+        ):
+            out = await mcp._edit_react_component_handler(
+                {
+                    "pocket_id": "pk1",
+                    "component_path": "src/components/Hero.tsx",
+                    "new_source": "x",
+                }
+            )
+
+        assert not out.get("is_error"), out
+        body = json.loads(out["content"][0]["text"])
+        assert body["status"] == "draft"
+        assert body["is_live"] is False
+        message = (body.get("message") or "").lower()
+        assert "draft" in message
+
+        text = out["content"][0]["text"].lower()
+        # No completed-state publish claim. "publish" survives as an instruction
+        # ("offer to publish it"), but never as something that already happened.
+        assert "published" not in text
+        assert "republished" not in text
+        assert "live at" not in text
+        assert "now live" not in text
+        # ``is_live`` is a JSON key with an underscore, so the bare phrase must be
+        # absent.
+        assert "is live" not in text
+
+    @pytest.mark.asyncio
+    async def test_edits_input_forwarded_to_service(self) -> None:
+        """The targeted-diff form: the handler forwards the blocks and does NOT
+        require ``new_source``."""
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        fake = AsyncMock(return_value=_ok_result())
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch("pocketpaw_ee.sites.service.edit_react_component", new=fake),
+        ):
+            out = await mcp._edit_react_component_handler(
+                {
+                    "pocket_id": "pk1",
+                    "component_path": "src/components/Hero.tsx",
+                    "edits": [{"old_string": "Bright", "new_string": "Brighter"}],
+                }
+            )
+
+        assert not out.get("is_error"), out
+        kwargs = fake.await_args.kwargs
+        assert kwargs["edits"] == [{"old_string": "Bright", "new_string": "Brighter"}]
+        assert kwargs.get("new_source") is None
+
+    @pytest.mark.asyncio
+    async def test_edits_arriving_as_a_json_string_are_coerced(self) -> None:
+        """Some backends hand a structured argument through as a JSON STRING.
+        ``coerce_json_object_args`` is what stops that reading as "no edits given",
+        which would surface as the exactly-one error on a call that supplied one."""
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        fake = AsyncMock(return_value=_ok_result())
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch("pocketpaw_ee.sites.service.edit_react_component", new=fake),
+        ):
+            out = await mcp._edit_react_component_handler(
+                {
+                    "pocket_id": "pk1",
+                    "component_path": "src/components/Hero.tsx",
+                    "edits": json.dumps([{"old_string": "a", "new_string": "b"}]),
+                }
+            )
+
+        assert not out.get("is_error"), out
+        assert fake.await_args.kwargs["edits"] == [{"old_string": "a", "new_string": "b"}]
+
+    @pytest.mark.asyncio
+    async def test_create_is_forwarded_with_new_source(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        fake = AsyncMock(return_value=_ok_result(created=True))
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch("pocketpaw_ee.sites.service.edit_react_component", new=fake),
+        ):
+            out = await mcp._edit_react_component_handler(
+                {
+                    "pocket_id": "pk1",
+                    "component_path": "src/components/Testimonials.tsx",
+                    "new_source": "export default function Testimonials() { return <section/>; }",
+                    "create": True,
+                }
+            )
+
+        assert not out.get("is_error"), out
+        assert json.loads(out["content"][0]["text"])["created"] is True
+        assert fake.await_args.kwargs["create"] is True
+
+    @pytest.mark.asyncio
+    async def test_create_without_new_source_is_error(self) -> None:
+        """Rejected at the surface, before the service: there is nothing for
+        ``edits`` to search against in a file that does not exist yet."""
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        fake = AsyncMock(return_value=_ok_result())
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch("pocketpaw_ee.sites.service.edit_react_component", new=fake),
+        ):
+            out = await mcp._edit_react_component_handler(
+                {
+                    "pocket_id": "pk1",
+                    "component_path": "src/components/New.tsx",
+                    "edits": [{"old_string": "a", "new_string": "b"}],
+                    "create": True,
+                }
+            )
+        assert out.get("is_error") is True
+        assert "`new_source`" in out["content"][0]["text"]
+        fake.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_neither_edits_nor_new_source_is_error(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        with patch.object(mcp, "_identity", return_value=("ws1", "u1")):
+            out = await mcp._edit_react_component_handler(
+                {"pocket_id": "pk1", "component_path": "src/components/Hero.tsx"}
+            )
+        assert out.get("is_error") is True
+        text = out["content"][0]["text"]
+        assert "edits" in text and "new_source" in text
+
+    @pytest.mark.asyncio
+    async def test_both_edits_and_new_source_is_error(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        with patch.object(mcp, "_identity", return_value=("ws1", "u1")):
+            out = await mcp._edit_react_component_handler(
+                {
+                    "pocket_id": "pk1",
+                    "component_path": "src/components/Hero.tsx",
+                    "new_source": "whole file",
+                    "edits": [{"old_string": "a", "new_string": "b"}],
+                }
+            )
+        assert out.get("is_error") is True
+        assert "not both" in out["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_malformed_edits_is_error(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        with patch.object(mcp, "_identity", return_value=("ws1", "u1")):
+            out = await mcp._edit_react_component_handler(
+                {
+                    "pocket_id": "pk1",
+                    "component_path": "src/components/Hero.tsx",
+                    "edits": [{"old_string": "only-old"}],
+                }
+            )
+        assert out.get("is_error") is True
+        assert "`edits`" in out["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_non_string_new_source_is_error(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        with patch.object(mcp, "_identity", return_value=("ws1", "u1")):
+            out = await mcp._edit_react_component_handler(
+                {
+                    "pocket_id": "pk1",
+                    "component_path": "src/components/Hero.tsx",
+                    "new_source": {"not": "a string"},
+                }
+            )
+        assert out.get("is_error") is True
+        assert "`new_source`" in out["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_missing_component_path_is_error(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        with patch.object(mcp, "_identity", return_value=("ws1", "u1")):
+            out = await mcp._edit_react_component_handler({"pocket_id": "pk1", "new_source": "x"})
+        assert out.get("is_error") is True
+        assert "`component_path`" in out["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_missing_pocket_id_is_error(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        with patch.object(mcp, "_identity", return_value=("ws1", "u1")):
+            out = await mcp._edit_react_component_handler(
+                {"component_path": "src/components/Hero.tsx", "new_source": "x"}
+            )
+        assert out.get("is_error") is True
+        assert "`pocket_id`" in out["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_missing_identity_is_error(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        with patch.object(mcp, "_identity", return_value=(None, None)):
+            out = await mcp._edit_react_component_handler(
+                {
+                    "pocket_id": "pk1",
+                    "component_path": "src/components/Hero.tsx",
+                    "new_source": "x",
+                }
+            )
+        assert out.get("is_error") is True
+        assert "workspace and user context" in out["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_plan_gate_denies_a_workspace_without_sites(self) -> None:
+        """An edit mutates a site pocket, so it is gated on the same "sites" feature
+        the create tools are. Without the gate a workspace that lost the plan could
+        keep editing a site its own /sites list 403s.
+
+        THE MUTATION THAT BREAKS THIS: delete the ``_require_sites_plan_or_error``
+        call from the handler. Run: the service was reached on a free plan.
+        """
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        fake = AsyncMock(return_value=_ok_result())
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch(
+                "pocketpaw_ee.cloud.workspace.service.get_workspace_plan",
+                new=AsyncMock(return_value="free"),
+            ),
+            patch("pocketpaw_ee.sites.service.edit_react_component", new=fake),
+        ):
+            out = await mcp._edit_react_component_handler(
+                {
+                    "pocket_id": "pk1",
+                    "component_path": "src/components/Hero.tsx",
+                    "new_source": "x",
+                }
+            )
+        assert out.get("is_error") is True
+        assert "plan.feature_denied" in out["content"][0]["text"]
+        fake.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "code,message",
+        [
+            ("site_edit.reserved_path", "`package.json` resolves to a generator-owned path"),
+            ("site_edit.path_outside_source", "`README.md` is outside the source tree"),
+            ("pocket.not_react_site", "This pocket is not a react Paw Site"),
+            ("pocket.react_component_exists", "already exists in this site's source map"),
+            ("site_edit.ambiguous_match", "old_string matches 3 times"),
+        ],
+    )
+    async def test_validation_errors_are_relayed_by_code(self, code: str, message: str) -> None:
+        """Every guard's rejection reaches the agent BY CODE, so it can tell a
+        retry-able diff problem from a refused path from a wrong-engine pocket. A
+        generic "edit failed" would make all five look like the same transient
+        failure and invite a blind retry."""
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+        from pocketpaw_ee.cloud._core.errors import ValidationError
+
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch(
+                "pocketpaw_ee.sites.service.edit_react_component",
+                new=AsyncMock(side_effect=ValidationError(code, message)),
+            ),
+        ):
+            out = await mcp._edit_react_component_handler(
+                {
+                    "pocket_id": "pk1",
+                    "component_path": "src/components/Hero.tsx",
+                    "new_source": "x",
+                }
+            )
+        assert out.get("is_error") is True
+        text = out["content"][0]["text"]
+        assert code in text
+        assert message in text
+
+    @pytest.mark.asyncio
+    async def test_not_found_is_relayed_by_code(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+        from pocketpaw_ee.cloud._core.errors import NotFound
+
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch(
+                "pocketpaw_ee.sites.service.edit_react_component",
+                new=AsyncMock(side_effect=NotFound("site_component", "src/components/X.tsx")),
+            ),
+        ):
+            out = await mcp._edit_react_component_handler(
+                {
+                    "pocket_id": "pk1",
+                    "component_path": "src/components/X.tsx",
+                    "new_source": "x",
+                }
+            )
+        assert out.get("is_error") is True
+        assert "site_component.not_found" in out["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_unexpected_exception_is_an_error_not_a_success(self) -> None:
+        """A non-CloudError must not fall through as a successful edit — the agent
+        would tell the user a change landed that did not."""
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch(
+                "pocketpaw_ee.sites.service.edit_react_component",
+                new=AsyncMock(side_effect=RuntimeError("mongo went away")),
+            ),
+        ):
+            out = await mcp._edit_react_component_handler(
+                {
+                    "pocket_id": "pk1",
+                    "component_path": "src/components/Hero.tsx",
+                    "new_source": "x",
+                }
+            )
+        assert out.get("is_error") is True
+        assert "edit failed" in out["content"][0]["text"]

--- a/tests/ee/agent/test_sites_mcp_server/test_mcp_tool.py
+++ b/tests/ee/agent/test_sites_mcp_server/test_mcp_tool.py
@@ -5,6 +5,12 @@
 # allowlist publication) plus per-handler tests that mock the identity
 # ContextVars + the shared publish_pocket service and inspect the MCP envelope
 # the SDK returns to the agent.
+#
+# Updated: 2026-08-11 (feat/sites-react-edit-lane, RX-3) — the registration test now
+# pins the EIGHTH tool id on this server, ``edit_react_component``. The count
+# assertion did its job here: adding the tool failed this test before anything else,
+# which is exactly the decision point it exists to force (SITES_TOOL_IDS feeds the
+# /sites surface allow-list, so a new id widens what the agent can reach).
 """MCP server registration + handler tests for the Paw Sites publish tool."""
 
 from __future__ import annotations
@@ -30,6 +36,7 @@ class TestSitesMcpServerRegistration:
             CREATE_LANDING_SITE_TOOL_ID,
             CREATE_REACT_SITE_TOOL_ID,
             CREATE_SVELTE_SITE_TOOL_ID,
+            EDIT_REACT_COMPONENT_TOOL_ID,
             EDIT_SVELTE_COMPONENT_TOOL_ID,
             PUBLISH_TOOL_ID,
             SERVER_NAME,
@@ -53,6 +60,10 @@ class TestSitesMcpServerRegistration:
         assert CREATE_HTML_SITE_TOOL_ID == "mcp__pocketpaw_sites_manager__create_html_site"
         # RX-2 — the react-track create tool, the 5th create tool on this server.
         assert CREATE_REACT_SITE_TOOL_ID == "mcp__pocketpaw_sites_manager__create_react_site"
+        # RX-3 — the react-track EDIT tool, the SECOND edit tool on this server.
+        # Its absence was the whole react-edit hole: with only the svelte edit tool
+        # registered, a react site could be created and published but never changed.
+        assert EDIT_REACT_COMPONENT_TOOL_ID == "mcp__pocketpaw_sites_manager__edit_react_component"
         assert PUBLISH_TOOL_ID in SITES_TOOL_IDS
         assert CREATE_LANDING_SITE_TOOL_ID in SITES_TOOL_IDS
         assert CREATE_SVELTE_SITE_TOOL_ID in SITES_TOOL_IDS
@@ -60,10 +71,11 @@ class TestSitesMcpServerRegistration:
         assert CREATE_DYNAMIC_SITE_TOOL_ID in SITES_TOOL_IDS
         assert CREATE_HTML_SITE_TOOL_ID in SITES_TOOL_IDS
         assert CREATE_REACT_SITE_TOOL_ID in SITES_TOOL_IDS
+        assert EDIT_REACT_COMPONENT_TOOL_ID in SITES_TOOL_IDS
         # The count is deliberate: adding a tool here widens the /sites surface
         # allow-list (SITES_TOOL_IDS feeds it), so a new id must be a decision,
         # not a side effect. Bump it WITH an id assertion above — never alone.
-        assert len(SITES_TOOL_IDS) == 7
+        assert len(SITES_TOOL_IDS) == 8
 
     def test_extension_provider_advertises_tool_id(self) -> None:
         """The entry-point provider's ``tool_ids()`` feeds the claude_sdk

--- a/tests/ee/sites/test_react_component_edit.py
+++ b/tests/ee/sites/test_react_component_edit.py
@@ -1,0 +1,629 @@
+# tests/ee/sites/test_react_component_edit.py — the react-track EDIT lane
+# (sites_service.edit_react_component). Created: 2026-08-11 (feat/sites-react-edit-lane,
+# RX-3).
+#
+# WHAT WAS MISSING. ``create_react_site`` shipped in RX-2 and worked; nothing could
+# change a react site afterwards. The only edit entry point was svelte-gated at three
+# layers, so the chat agent's only available move on "shorten the hero headline" was to
+# call ``create_react_site`` a second time — minting a SECOND site pocket and leaving
+# the one the user was looking at untouched. These tests pin the lane that closes it.
+#
+# They use the shared ``beanie_test_db`` fixture (an in-memory Mongo) so the pockets
+# service persists a REAL react Pocket doc and the guards run against real state. There
+# is no generator, no Cloudflare and no bundle reader to inject, because there is no
+# build: the whole contract is "resolve the edit and persist the draft".
+#
+# THREE PROPERTIES ARE LOAD BEARING and get their own sections below:
+#   (a) DRAFT-ONLY — the edit must not publish and must not enqueue a build. Asserted
+#       both by spying on the publish/enqueue seams AND by the observable that no Site
+#       doc exists afterwards. This is NOT a copy of the svelte contract: svelte
+#       republishes and rolls back on a smoke failure, which react cannot do because
+#       ``build_runs_async("react")`` is True and a react publish returns before any
+#       build outcome exists.
+#   (b) THE RESERVED-PATH GUARD — an edit must not be a way around the create tool's
+#       allowlist. ``create=True`` on ``package.json`` would write the dependency
+#       manifest, defeating the generator's dependency allowlist and with it the
+#       supply-chain release-age floor that manifest is what enforces. Every spelling
+#       the normalizer is supposed to collapse is tested, because a guard a trivial
+#       path spelling defeats is not a guard.
+#   (c) THE CREATE/EXISTS INVERSION — ``create=False`` demands the path exist (a typo
+#       is never a silent create); ``create=True`` demands it not (an accidental
+#       overwrite of a real component is worse than a rejected call).
+#
+# Mutation coverage: tests/mutations/react_edit_lane.json.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import NotFound, ValidationError
+from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
+from pocketpaw_ee.cloud.pockets import service as pockets_service
+from pocketpaw_ee.sites import service as sites_service
+
+_HERO_V1 = (
+    "export default function Hero() {\n"
+    "  return (\n"
+    "    <section className='hero'>\n"
+    "      <h1>Bright Smile Dental</h1>\n"
+    "      <p>Gentle care in the heart of town.</p>\n"
+    "    </section>\n"
+    "  );\n"
+    "}\n"
+)
+_APP = (
+    "import Hero from './components/Hero';\n\n"
+    "export default function App() {\n"
+    "  return (\n    <main>\n      <Hero />\n    </main>\n  );\n}\n"
+)
+_REACT_SOURCE = {
+    "src/App.tsx": _APP,
+    "src/components/Hero.tsx": _HERO_V1,
+    "src/index.css": ":root{--brand:#0A84FF}",
+    "public/favicon.svg": "<svg/>",
+}
+
+
+async def _make_react_pocket(workspace_id: str, user_id: str) -> str:
+    """Persist a real react-engine Pocket via the pockets service and return its id.
+
+    Mirrors how ``create_react_site`` lands one: type='site', pattern='landing',
+    engine='react', source=<map>, trusted=True."""
+    _view, pocket_id, err = await pockets_service.agent_create(
+        workspace_id=workspace_id,
+        owner_id=user_id,
+        name="Bright Smile",
+        type_="site",
+        pattern="landing",
+        ripple_spec=None,
+        engine="react",
+        source=dict(_REACT_SOURCE),
+        trusted=True,
+    )
+    assert err is None, err
+    assert pocket_id is not None
+    return pocket_id
+
+
+async def _source_of(pocket_id: str, user_id: str = "u1") -> dict:
+    wire = await pockets_service.get(pocket_id, user_id)
+    return wire["source"]
+
+
+# ---------------------------------------------------------------------------
+# The happy paths — a targeted diff and a full rewrite
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_targeted_edits_are_applied_and_persisted(beanie_test_db):
+    """The dominant case: the agent sends only the diff and the file changes.
+
+    THE MUTATION THAT BREAKS THIS: make the persist a no-op (drop the
+    ``set_react_source_file`` call). Run: the re-read still had the old headline.
+    """
+    pocket_id = await _make_react_pocket("ws1", "u1")
+
+    out = await sites_service.edit_react_component(
+        user_id="u1",
+        pocket_id=pocket_id,
+        component_path="src/components/Hero.tsx",
+        edits=[{"old_string": "Bright Smile Dental", "new_string": "Bright Smile"}],
+    )
+
+    assert out == {
+        "pocket_id": pocket_id,
+        "component_path": "src/components/Hero.tsx",
+        "created": False,
+    }
+    source = await _source_of(pocket_id)
+    assert "<h1>Bright Smile</h1>" in source["src/components/Hero.tsx"]
+    # Only the targeted file moved — the rest of the map came through verbatim.
+    assert source["src/App.tsx"] == _APP
+    assert source["src/index.css"] == ":root{--brand:#0A84FF}"
+
+
+@pytest.mark.asyncio
+async def test_new_source_replaces_the_whole_file(beanie_test_db):
+    """The large-rewrite form: ``new_source`` is used as-is, not merged."""
+    pocket_id = await _make_react_pocket("ws1", "u1")
+    rewritten = "export default function Hero() {\n  return <section>New</section>;\n}\n"
+
+    await sites_service.edit_react_component(
+        user_id="u1",
+        pocket_id=pocket_id,
+        component_path="src/components/Hero.tsx",
+        new_source=rewritten,
+    )
+
+    source = await _source_of(pocket_id)
+    assert source["src/components/Hero.tsx"] == rewritten
+
+
+@pytest.mark.asyncio
+async def test_edit_writes_a_reviewable_draft_version(beanie_test_db):
+    """The edit leaves a Branch draft snapshotting the FULL edited map, so a later
+    publish has something to promote. This is what makes "draft-only" a draft rather
+    than an unreviewable in-place mutation."""
+    pocket_id = await _make_react_pocket("ws1", "u1")
+
+    await sites_service.edit_react_component(
+        user_id="u1",
+        pocket_id=pocket_id,
+        component_path="src/components/Hero.tsx",
+        edits=[{"old_string": "Gentle care", "new_string": "Gentle, unhurried care"}],
+    )
+
+    from pocketpaw_ee.versions import service as versions
+
+    draft = await versions.get_draft(scope_type="pocket", scope_id=pocket_id)
+    assert draft is not None
+    assert "Gentle, unhurried care" in draft.content["src/components/Hero.tsx"]
+    # The snapshot is the whole map, not just the edited file.
+    assert draft.content["src/App.tsx"] == _APP
+
+
+# ---------------------------------------------------------------------------
+# (a) DRAFT-ONLY — no publish, no build enqueued
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_edit_does_not_publish_and_does_not_enqueue_a_build(beanie_test_db, monkeypatch):
+    """The contract that separates this lane from ``edit_svelte_component``.
+
+    A react publish ENQUEUES a Daytona build and returns before any outcome exists,
+    so there is nothing synchronous to roll back from and a republish here would
+    spend a sandbox on every keystroke-sized edit. Persisting the draft is the whole
+    job.
+
+    Asserted two ways on purpose: spies prove the seams were never called, and the
+    empty Site collection proves it at the level of observable state — a publish, by
+    any route, upserts a Site doc.
+
+    THE MUTATION THAT BREAKS THIS: append a ``publish_pocket(...)`` call to
+    ``edit_react_component``. Run: the spy fired and this failed.
+    """
+    pocket_id = await _make_react_pocket("ws1", "u1")
+
+    called: list[str] = []
+
+    async def _no_publish(**_kw):
+        called.append("publish_pocket")
+        raise AssertionError("edit_react_component must not publish")
+
+    async def _no_enqueue(**_kw):
+        called.append("_enqueue_static_build")
+        raise AssertionError("edit_react_component must not enqueue a build")
+
+    def _no_prewarm(**_kw):
+        called.append("_schedule_native_prewarm")
+        raise AssertionError("edit_react_component must not pre-warm a svelte artifact")
+
+    monkeypatch.setattr(sites_service, "publish_pocket", _no_publish)
+    monkeypatch.setattr(sites_service, "_enqueue_static_build", _no_enqueue)
+    monkeypatch.setattr(sites_service, "_schedule_native_prewarm", _no_prewarm)
+
+    await sites_service.edit_react_component(
+        user_id="u1",
+        pocket_id=pocket_id,
+        component_path="src/components/Hero.tsx",
+        new_source="export default function Hero() { return <section/>; }\n",
+    )
+
+    assert called == []
+    # No Site doc was minted or touched — a publish (live or preview) upserts one.
+    assert await _SiteDoc.find_all().to_list() == []
+
+
+# ---------------------------------------------------------------------------
+# (b) The reserved-path guard
+# ---------------------------------------------------------------------------
+
+# Every spelling the normalizer must collapse. The plain names are the four files
+# the generator owns; the rest are the evasions — a leading ``./``, Windows
+# separators, and a ``..`` round trip through the reserved namespace. If any of
+# these lands, the create tool's allowlist has a back door.
+_RESERVED_SPELLINGS = [
+    "package.json",
+    "./package.json",
+    "index.html",
+    "vite.config.ts",
+    "paw-prerender.mjs",
+    "src/paw/entry.tsx",
+    "src\\paw\\entry.tsx",
+    "src/paw/../paw/entry.tsx",
+    "src/components/../paw/entry-client.tsx",
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", _RESERVED_SPELLINGS)
+async def test_every_reserved_path_spelling_is_rejected(beanie_test_db, path: str):
+    """An edit may not write a generator-owned path, however it is spelled.
+
+    ``package.json`` is the one that matters most: it is the dependency manifest, so
+    writing it defeats the generator's dependency allowlist and with it the
+    supply-chain release-age floor. The others carry the prerender contract — remove
+    ``paw-prerender.mjs`` and the page ships blank without JavaScript, which is the
+    thing this engine exists to refuse.
+
+    ``create=True`` is used deliberately: it is the STRONGER attack (an
+    existence-checked edit would also have to guess a path already in the map), so
+    proving it fails proves the weaker one does.
+
+    THE MUTATION THAT BREAKS THIS: drop the ``react_path_rejection`` call from
+    ``edit_react_component``. Run: the write landed and this failed.
+    """
+    pocket_id = await _make_react_pocket("ws1", "u1")
+
+    with pytest.raises(ValidationError) as exc:
+        await sites_service.edit_react_component(
+            user_id="u1",
+            pocket_id=pocket_id,
+            component_path=path,
+            new_source='{"dependencies": {"evil": "*"}}',
+            create=True,
+        )
+    assert exc.value.code == "site_edit.reserved_path", exc.value.code
+    # Nothing was written under any spelling of the key.
+    source = await _source_of(pocket_id)
+    assert set(source) == set(_REACT_SOURCE)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "path",
+    [
+        "README.md",
+        "styles.css",
+        "../../etc/passwd",
+        "/etc/passwd",
+        "src/../secrets.env",
+        "lib/components/Hero.tsx",
+    ],
+)
+async def test_path_outside_src_and_public_is_rejected(beanie_test_db, path: str):
+    """The positive half of the policy: authored files live under ``src/`` or
+    ``public/``. Everything else at the project root belongs to the generated shell,
+    and a ``..`` escape or an absolute path is not a project path at all.
+
+    THE MUTATION THAT BREAKS THIS: widen ``REACT_AUTHORABLE_PREFIXES`` to ``("",)``.
+    Run: every path became authorable and this failed.
+    """
+    pocket_id = await _make_react_pocket("ws1", "u1")
+
+    with pytest.raises(ValidationError) as exc:
+        await sites_service.edit_react_component(
+            user_id="u1",
+            pocket_id=pocket_id,
+            component_path=path,
+            new_source="nope",
+            create=True,
+        )
+    assert exc.value.code == "site_edit.path_outside_source", exc.value.code
+    assert set(await _source_of(pocket_id)) == set(_REACT_SOURCE)
+
+
+@pytest.mark.asyncio
+async def test_the_guard_runs_before_the_pocket_is_read(beanie_test_db):
+    """A reserved path is rejected on the path ALONE — no pocket state can make it
+    land. Proven with a pocket id that does not exist: a guard that ran after the
+    read would raise NotFound instead."""
+    with pytest.raises(ValidationError) as exc:
+        await sites_service.edit_react_component(
+            user_id="u1",
+            pocket_id="0123456789abcdef01234567",
+            component_path="package.json",
+            new_source="{}",
+            create=True,
+        )
+    assert exc.value.code == "site_edit.reserved_path"
+
+
+# ---------------------------------------------------------------------------
+# (c) The create/exists inversion
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_adds_a_new_component_file(beanie_test_db):
+    """The reason ``create`` exists: "add a testimonials section" needs a NEW file
+    plus an ``src/App.tsx`` edit, and the write chokepoint refuses any path not
+    already in the map. Without this the agent cannot add a section at all."""
+    pocket_id = await _make_react_pocket("ws1", "u1")
+    testimonials = "export default function Testimonials() { return <section/>; }\n"
+
+    out = await sites_service.edit_react_component(
+        user_id="u1",
+        pocket_id=pocket_id,
+        component_path="src/components/Testimonials.tsx",
+        new_source=testimonials,
+        create=True,
+    )
+
+    assert out["created"] is True
+    source = await _source_of(pocket_id)
+    assert source["src/components/Testimonials.tsx"] == testimonials
+    # The rest of the map is intact — a create is additive.
+    assert source["src/components/Hero.tsx"] == _HERO_V1
+
+
+@pytest.mark.asyncio
+async def test_missing_path_is_not_found_when_create_is_false(beanie_test_db):
+    """A typo must never be a silent create. This is the default mode, so it is the
+    one a mistyped path actually hits.
+
+    THE MUTATION THAT BREAKS THIS: make ``create`` default to True. Run: the typo'd
+    path was created and no NotFound was raised.
+    """
+    pocket_id = await _make_react_pocket("ws1", "u1")
+
+    with pytest.raises(NotFound):
+        await sites_service.edit_react_component(
+            user_id="u1",
+            pocket_id=pocket_id,
+            component_path="src/components/Heroo.tsx",
+            new_source="export default function Heroo() { return null; }\n",
+        )
+    assert "src/components/Heroo.tsx" not in await _source_of(pocket_id)
+
+
+@pytest.mark.asyncio
+async def test_missing_path_with_edits_is_not_found_not_a_key_error(beanie_test_db):
+    """The ``edits`` branch INDEXES the source map to read the current contents, so
+    the existence check has to run in the sites service and not only at the write
+    chokepoint. Without it a typo'd path is a bare ``KeyError`` that the MCP handler
+    can only report as "edit failed: 'src/...'" — the agent cannot tell a missing
+    component from a broken backend, so it cannot fix the path and retry.
+
+    This is the test the ``new_source`` case does NOT cover: with a full rewrite the
+    chokepoint's own NotFound arrives first, so the sites-service check looks
+    redundant right up until the diff path needs it.
+
+    THE MUTATION THAT BREAKS THIS: neuter the ``not create and component_path not in
+    source_map`` check in ``edit_react_component``. Run: a KeyError surfaced instead
+    of NotFound and this failed.
+    """
+    pocket_id = await _make_react_pocket("ws1", "u1")
+
+    with pytest.raises(NotFound):
+        await sites_service.edit_react_component(
+            user_id="u1",
+            pocket_id=pocket_id,
+            component_path="src/components/Heroo.tsx",
+            edits=[{"old_string": "Bright", "new_string": "Brighter"}],
+        )
+
+
+@pytest.mark.asyncio
+async def test_existing_path_is_rejected_when_create_is_true(beanie_test_db):
+    """``create`` INVERTS the existence check rather than relaxing it: an accidental
+    overwrite of a real component is worse than a rejected call the agent can retry
+    without the flag.
+
+    THE MUTATION THAT BREAKS THIS: drop the ``create and exists`` branch. Run: the
+    existing Hero was silently overwritten and no error was raised.
+    """
+    pocket_id = await _make_react_pocket("ws1", "u1")
+
+    with pytest.raises(ValidationError) as exc:
+        await sites_service.edit_react_component(
+            user_id="u1",
+            pocket_id=pocket_id,
+            component_path="src/components/Hero.tsx",
+            new_source="clobbered",
+            create=True,
+        )
+    assert exc.value.code == "pocket.react_component_exists"
+    assert (await _source_of(pocket_id))["src/components/Hero.tsx"] == _HERO_V1
+
+
+@pytest.mark.asyncio
+async def test_create_without_new_source_is_rejected(beanie_test_db):
+    """There is nothing for ``edits`` to search against in a file that does not
+    exist yet, so ``create`` requires the full contents."""
+    pocket_id = await _make_react_pocket("ws1", "u1")
+
+    with pytest.raises(ValidationError) as exc:
+        await sites_service.edit_react_component(
+            user_id="u1",
+            pocket_id=pocket_id,
+            component_path="src/components/New.tsx",
+            edits=[{"old_string": "a", "new_string": "b"}],
+            create=True,
+        )
+    assert exc.value.code == "site_edit.create_needs_source"
+
+
+# ---------------------------------------------------------------------------
+# Argument + engine guards
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_both_edits_and_new_source_is_rejected(beanie_test_db):
+    """Exactly one edit shape. Accepting both would leave which one wins to
+    whichever branch happened to run last."""
+    pocket_id = await _make_react_pocket("ws1", "u1")
+
+    with pytest.raises(ValidationError) as exc:
+        await sites_service.edit_react_component(
+            user_id="u1",
+            pocket_id=pocket_id,
+            component_path="src/components/Hero.tsx",
+            new_source="whole file",
+            edits=[{"old_string": "Bright", "new_string": "Brighter"}],
+        )
+    assert exc.value.code == "site_edit.invalid_args"
+    assert (await _source_of(pocket_id))["src/components/Hero.tsx"] == _HERO_V1
+
+
+@pytest.mark.asyncio
+async def test_neither_edits_nor_new_source_is_rejected(beanie_test_db):
+    """A call with no change in it is a bug in the caller, not an empty success."""
+    pocket_id = await _make_react_pocket("ws1", "u1")
+
+    with pytest.raises(ValidationError) as exc:
+        await sites_service.edit_react_component(
+            user_id="u1",
+            pocket_id=pocket_id,
+            component_path="src/components/Hero.tsx",
+        )
+    assert exc.value.code == "site_edit.invalid_args"
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_old_string_is_rejected_and_nothing_is_written(beanie_test_db):
+    """The uniqueness contract comes from the SHARED ``apply_edits`` (there is
+    deliberately no second copy of that logic), and it fires BEFORE the persist —
+    an ambiguous diff leaves the file byte-identical rather than replacing an
+    arbitrary one of the matches."""
+    pocket_id = await _make_react_pocket("ws1", "u1")
+
+    with pytest.raises(ValidationError) as exc:
+        await sites_service.edit_react_component(
+            user_id="u1",
+            pocket_id=pocket_id,
+            # "section" appears in both the opening and closing tag.
+            component_path="src/components/Hero.tsx",
+            edits=[{"old_string": "section", "new_string": "div"}],
+        )
+    assert exc.value.code == "site_edit.ambiguous_match"
+    assert (await _source_of(pocket_id))["src/components/Hero.tsx"] == _HERO_V1
+
+
+@pytest.mark.asyncio
+async def test_svelte_pocket_is_rejected(beanie_test_db):
+    """The react edit lane must not touch a svelte site's source map — the engines
+    have different content models and different publish contracts (svelte
+    republishes synchronously; react cannot)."""
+    _view, pocket_id, err = await pockets_service.agent_create(
+        workspace_id="ws1",
+        owner_id="u1",
+        name="Svelte Site",
+        type_="site",
+        pattern="landing",
+        ripple_spec=None,
+        engine="svelte",
+        source={"src/routes/+page.svelte": "<h1>hi</h1>"},
+        trusted=True,
+    )
+    assert err is None, err
+
+    with pytest.raises(ValidationError) as exc:
+        await sites_service.edit_react_component(
+            user_id="u1",
+            pocket_id=pocket_id,
+            component_path="src/routes/+page.svelte",
+            new_source="<h1>changed</h1>",
+        )
+    assert exc.value.code == "pocket.not_react_site"
+
+
+@pytest.mark.asyncio
+async def test_ripple_pocket_is_rejected(beanie_test_db):
+    """A ripple pocket has no source map at all — the guard must reject it rather
+    than dereference ``None``."""
+    _view, pocket_id, err = await pockets_service.agent_create(
+        workspace_id="ws1",
+        owner_id="u1",
+        name="Ripple Site",
+        type_="site",
+        pattern="landing",
+        ripple_spec={"version": 1, "ui": {"type": "text", "props": {"text": "hi"}}},
+        trusted=True,
+    )
+    assert err is None, err
+
+    with pytest.raises(ValidationError) as exc:
+        await sites_service.edit_react_component(
+            user_id="u1",
+            pocket_id=pocket_id,
+            component_path="src/App.tsx",
+            new_source="export default function App() { return null; }\n",
+        )
+    assert exc.value.code == "pocket.not_react_site"
+
+
+@pytest.mark.asyncio
+async def test_missing_pocket_raises_not_found(beanie_test_db):
+    """A missing pocket id raises NotFound (the pockets service's public ``get``
+    owns that), mapped by the MCP handler to an is_error."""
+    with pytest.raises(NotFound):
+        await sites_service.edit_react_component(
+            user_id="u1",
+            pocket_id="0123456789abcdef01234567",
+            component_path="src/components/Hero.tsx",
+            new_source="export default function Hero() { return null; }\n",
+        )
+
+
+# ---------------------------------------------------------------------------
+# The write chokepoint enforces the same rules for every caller
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pockets_service_rejects_a_non_react_pocket(beanie_test_db):
+    """``set_react_source_file`` is the chokepoint, so it owns the guards for ANY
+    caller — not just for the one orchestration path above."""
+    _view, pocket_id, err = await pockets_service.agent_create(
+        workspace_id="ws1",
+        owner_id="u1",
+        name="Svelte Site",
+        type_="site",
+        pattern="landing",
+        ripple_spec=None,
+        engine="svelte",
+        source={"src/routes/+page.svelte": "<h1>hi</h1>"},
+        trusted=True,
+    )
+    assert err is None, err
+
+    with pytest.raises(ValidationError) as exc:
+        await pockets_service.set_react_source_file(
+            pocket_id,
+            "u1",
+            component_path="src/routes/+page.svelte",
+            new_source="<h1>no</h1>",
+        )
+    assert exc.value.code == "pocket.not_react_site"
+
+
+@pytest.mark.asyncio
+async def test_pockets_service_enforces_the_create_inversion(beanie_test_db):
+    """Both halves of the inversion, at the chokepoint rather than the orchestration
+    layer, so a future second caller inherits them."""
+    pocket_id = await _make_react_pocket("ws1", "u1")
+
+    with pytest.raises(NotFound):
+        await pockets_service.set_react_source_file(
+            pocket_id, "u1", component_path="src/components/Nope.tsx", new_source="x"
+        )
+    with pytest.raises(ValidationError) as exc:
+        await pockets_service.set_react_source_file(
+            pocket_id,
+            "u1",
+            component_path="src/components/Hero.tsx",
+            new_source="x",
+            create=True,
+        )
+    assert exc.value.code == "pocket.react_component_exists"
+
+
+@pytest.mark.asyncio
+async def test_pockets_service_emits_pocket_updated(beanie_test_db, _recording_bus_for_sites):
+    """Cloud rule 9 — a state-mutating service function emits. A silent source
+    mutation desyncs the search index, soul memory and ripple invalidation."""
+    pocket_id = await _make_react_pocket("ws1", "u1")
+    _recording_bus_for_sites.events.clear()
+
+    await pockets_service.set_react_source_file(
+        pocket_id,
+        "u1",
+        component_path="src/components/Hero.tsx",
+        new_source="export default function Hero() { return <section/>; }\n",
+    )
+
+    kinds = [type(e).__name__ for e in _recording_bus_for_sites.events]
+    assert "PocketUpdated" in kinds, kinds

--- a/tests/mutations/react_authoring.json
+++ b/tests/mutations/react_authoring.json
@@ -55,16 +55,16 @@
   },
   {
     "label": "the reserved-path guard stops normalizing, so ./index.html overwrites the prerender template",
-    "file": "ee/pocketpaw_ee/agent/mcp_servers/sites_create.py",
-    "find": "        norm = posixpath.normpath(key.replace(\"\\\\\", \"/\"))",
-    "replace": "        norm = key",
+    "file": "ee/pocketpaw_ee/sites/react_paths.py",
+    "find": "    return posixpath.normpath(path.replace(\"\\\\\", \"/\"))",
+    "replace": "    return path",
     "tests": [
       "tests/ee/agent/test_sites_mcp_server/test_create_react_site.py::TestReservedPathRejection"
     ]
   },
   {
     "label": "the reserved guard matches by prefix, locking the author out of src/pawprint.ts",
-    "file": "ee/pocketpaw_ee/agent/mcp_servers/sites_create.py",
+    "file": "ee/pocketpaw_ee/sites/react_paths.py",
     "find": "REACT_RESERVED_PREFIX = \"src/paw/\"",
     "replace": "REACT_RESERVED_PREFIX = \"src/paw\"",
     "tests": [

--- a/tests/mutations/react_edit_lane.json
+++ b/tests/mutations/react_edit_lane.json
@@ -1,0 +1,206 @@
+[
+  {
+    "label": "the reserved-path guard is gone: an edit can write package.json, defeating the dependency allowlist and the supply-chain release-age floor",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if (reason := react_path_rejection(component_path)) is not None:",
+    "replace": "    if False and (reason := react_path_rejection(component_path)) is not None:",
+    "tests": [
+      "tests/ee/sites/test_react_component_edit.py::test_every_reserved_path_spelling_is_rejected",
+      "tests/ee/sites/test_react_component_edit.py::test_path_outside_src_and_public_is_rejected"
+    ]
+  },
+  {
+    "label": "the reserved set is empty, so only the outside-src check remains and src/paw/ becomes writable",
+    "file": "ee/pocketpaw_ee/sites/react_paths.py",
+    "find": "REACT_RESERVED_PREFIX = \"src/paw/\"",
+    "replace": "REACT_RESERVED_PREFIX = \"zzz-never-matches/\"",
+    "tests": [
+      "tests/ee/sites/test_react_component_edit.py::test_every_reserved_path_spelling_is_rejected"
+    ]
+  },
+  {
+    "label": "the path is checked as authored instead of normalized, so ./package.json and src\\\\paw\\\\entry.tsx spell their way past the guard",
+    "file": "ee/pocketpaw_ee/sites/react_paths.py",
+    "find": "    return posixpath.normpath(path.replace(\"\\\\\", \"/\"))",
+    "replace": "    return path",
+    "tests": [
+      "tests/ee/sites/test_react_component_edit.py::test_every_reserved_path_spelling_is_rejected"
+    ]
+  },
+  {
+    "label": "every path becomes authorable, so a ..-escape or a root-level file is written",
+    "file": "ee/pocketpaw_ee/sites/react_paths.py",
+    "find": "REACT_AUTHORABLE_PREFIXES: tuple[str, ...] = (\"src/\", \"public/\")",
+    "replace": "REACT_AUTHORABLE_PREFIXES: tuple[str, ...] = (\"\",)",
+    "tests": [
+      "tests/ee/sites/test_react_component_edit.py::test_path_outside_src_and_public_is_rejected"
+    ]
+  },
+  {
+    "label": "the guard runs AFTER the pocket read, so pocket state (a 404) decides the error instead of the path alone",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        raise ValidationError(code, reason)\n\n    # The pockets service's PUBLIC get raises NotFound / Forbidden itself (entity\n    # isolation) — a missing / cross-tenant pocket surfaces as 404 / 403.\n    pocket = await pockets_service.get(pocket_id, user_id)\n    if (pocket.get(\"engine\") or \"ripple\") != \"react\"",
+    "replace": "        pass\n\n    # The pockets service's PUBLIC get raises NotFound / Forbidden itself (entity\n    # isolation) — a missing / cross-tenant pocket surfaces as 404 / 403.\n    pocket = await pockets_service.get(pocket_id, user_id)\n    if (pocket.get(\"engine\") or \"ripple\") != \"react\"",
+    "tests": [
+      "tests/ee/sites/test_react_component_edit.py::test_the_guard_runs_before_the_pocket_is_read",
+      "tests/ee/sites/test_react_component_edit.py::test_every_reserved_path_spelling_is_rejected"
+    ]
+  },
+  {
+    "label": "create defaults to True, so a typo'd component_path is a silent new file instead of a 404",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    edits: list[dict[str, str]] | None = None,\n    create: bool = False,\n    _pockets: Any = None,",
+    "replace": "    edits: list[dict[str, str]] | None = None,\n    create: bool = True,\n    _pockets: Any = None,",
+    "tests": [
+      "tests/ee/sites/test_react_component_edit.py::test_missing_path_is_not_found_when_create_is_false"
+    ]
+  },
+  {
+    "label": "the write chokepoint stops refusing create onto an existing path, so a create silently overwrites a real component",
+    "file": "ee/pocketpaw_ee/cloud/pockets/service.py",
+    "find": "    exists = component_path in doc.source\n    if create and exists:",
+    "replace": "    exists = component_path in doc.source\n    if False and create and exists:",
+    "tests": [
+      "tests/ee/sites/test_react_component_edit.py::test_pockets_service_enforces_the_create_inversion",
+      "tests/ee/sites/test_react_component_edit.py::test_existing_path_is_rejected_when_create_is_true"
+    ]
+  },
+  {
+    "label": "the write chokepoint stops requiring an existing path, so a non-create write to a typo'd path is a silent new file",
+    "file": "ee/pocketpaw_ee/cloud/pockets/service.py",
+    "find": "    if not create and not exists:\n        raise NotFound(\"site_component\", component_path)\n\n    # Reassign a fresh dict so Beanie tracks the change (in-place mutation of a\n    # dict field is not always detected as dirty by the ODM) — same note as\n    # ``set_svelte_source_file``.",
+    "replace": "    # Reassign a fresh dict so Beanie tracks the change (in-place mutation of a\n    # dict field is not always detected as dirty by the ODM) — same note as\n    # ``set_svelte_source_file``.",
+    "tests": [
+      "tests/ee/sites/test_react_component_edit.py::test_pockets_service_enforces_the_create_inversion"
+    ]
+  },
+  {
+    "label": "the sites service stops requiring an existing path, so an `edits` call on a typo'd path is a KeyError instead of a relayable NotFound",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if not create and component_path not in source_map:\n        raise NotFound(\"site_component\", component_path)",
+    "replace": "    if False:\n        raise NotFound(\"site_component\", component_path)",
+    "tests": [
+      "tests/ee/sites/test_react_component_edit.py::test_missing_path_with_edits_is_not_found_not_a_key_error"
+    ]
+  },
+  {
+    "label": "the write chokepoint accepts a non-react pocket, so a react edit can clobber a svelte site's source map",
+    "file": "ee/pocketpaw_ee/cloud/pockets/service.py",
+    "find": "    if getattr(doc, \"engine\", \"ripple\") != \"react\" or not isinstance(doc.source, dict):",
+    "replace": "    if False and not isinstance(doc.source, dict):",
+    "tests": [
+      "tests/ee/sites/test_react_component_edit.py::test_pockets_service_rejects_a_non_react_pocket"
+    ]
+  },
+  {
+    "label": "the sites service accepts any engine, so an edit runs against a rippleSpec pocket with no source map",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if (pocket.get(\"engine\") or \"ripple\") != \"react\" or not isinstance(pocket.get(\"source\"), dict):",
+    "replace": "    if False and not isinstance(pocket.get(\"source\"), dict):",
+    "tests": [
+      "tests/ee/sites/test_react_component_edit.py::test_svelte_pocket_is_rejected",
+      "tests/ee/sites/test_react_component_edit.py::test_ripple_pocket_is_rejected"
+    ]
+  },
+  {
+    "label": "the exactly-one-edit-shape check is dropped, so a call with both or neither is accepted",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if (edits is None) == (new_source is None):\n        raise ValidationError(\n            \"site_edit.invalid_args\",\n            \"edit_react_component requires exactly one of `edits` (a targeted \"",
+    "replace": "    if False:\n        raise ValidationError(\n            \"site_edit.invalid_args\",\n            \"edit_react_component requires exactly one of `edits` (a targeted \"",
+    "tests": [
+      "tests/ee/sites/test_react_component_edit.py::test_both_edits_and_new_source_is_rejected",
+      "tests/ee/sites/test_react_component_edit.py::test_neither_edits_nor_new_source_is_rejected"
+    ]
+  },
+  {
+    "label": "create stops requiring new_source, so an edits-only create writes nothing meaningful",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if create and new_source is None:\n        raise ValidationError(\n            \"site_edit.create_needs_source\",",
+    "replace": "    if False:\n        raise ValidationError(\n            \"site_edit.create_needs_source\",",
+    "tests": [
+      "tests/ee/sites/test_react_component_edit.py::test_create_without_new_source_is_rejected"
+    ]
+  },
+  {
+    "label": "the edit republishes, which for react enqueues a Daytona build on every keystroke-sized change",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    # NO publish, NO enqueue, NO native pre-warm. The pre-warm serves the svelte",
+    "replace": "    await publish_pocket(workspace_id=\"\", user_id=user_id, pocket_id=pocket_id)\n    # NO publish, NO enqueue, NO native pre-warm. The pre-warm serves the svelte",
+    "tests": [
+      "tests/ee/sites/test_react_component_edit.py::test_edit_does_not_publish_and_does_not_enqueue_a_build"
+    ]
+  },
+  {
+    "label": "the draft ArtifactVersion is never written, so there is no reviewable draft for a later publish to promote",
+    "file": "ee/pocketpaw_ee/cloud/pockets/service.py",
+    "find": "    await _record_pocket_svelte_draft_version(doc, author=user_id)\n    return await _resolved_wire_dict(doc, user_id)\n\n\nasync def set_imported_source(",
+    "replace": "    return await _resolved_wire_dict(doc, user_id)\n\n\nasync def set_imported_source(",
+    "tests": [
+      "tests/ee/sites/test_react_component_edit.py::test_edit_writes_a_reviewable_draft_version"
+    ]
+  },
+  {
+    "label": "the write stops emitting PocketUpdated, so the search index / soul memory / ripple invalidation desync (cloud rule 9)",
+    "file": "ee/pocketpaw_ee/cloud/pockets/service.py",
+    "find": "    await doc.save()\n    await emit(PocketUpdated(data=await _pocket_event_payload(doc)))\n    # Branch primitive (BP-3): a source-map edit ALSO writes a draft",
+    "replace": "    await doc.save()\n    # Branch primitive (BP-3): a source-map edit ALSO writes a draft",
+    "tests": [
+      "tests/ee/sites/test_react_component_edit.py::test_pockets_service_emits_pocket_updated"
+    ]
+  },
+  {
+    "label": "the MCP handler skips the Sites plan gate, so a workspace without the plan keeps editing a site its own /sites list 403s",
+    "file": "ee/pocketpaw_ee/agent/mcp_servers/sites_create.py",
+    "find": "    if (gate := await _require_sites_plan_or_error(workspace_id)) is not None:\n        return gate\n\n    from pocketpaw_ee.cloud._core.errors import CloudError\n    from pocketpaw_ee.sites import service as sites_service\n\n    try:\n        result = await sites_service.edit_react_component(",
+    "replace": "    from pocketpaw_ee.cloud._core.errors import CloudError\n    from pocketpaw_ee.sites import service as sites_service\n\n    try:\n        result = await sites_service.edit_react_component(",
+    "tests": [
+      "tests/ee/agent/test_sites_mcp_server/test_edit_react_component.py::TestEditHandler::test_plan_gate_denies_a_workspace_without_sites"
+    ]
+  },
+  {
+    "label": "the edit tool is not registered on the sites_manager server, so the id is allow-listed but nothing answers a call",
+    "file": "ee/pocketpaw_ee/agent/mcp_servers/sites.py",
+    "find": "            create_react_site,\n            edit_react_component,",
+    "replace": "            create_react_site,",
+    "tests": [
+      "tests/ee/agent/test_sites_mcp_server/test_edit_react_component.py::TestRegistration::test_the_built_server_actually_lists_the_tool"
+    ]
+  },
+  {
+    "label": "the create flag leaves the tool schema, so the agent cannot pass it and adding a section becomes impossible",
+    "file": "ee/pocketpaw_ee/agent/mcp_servers/sites_create.py",
+    "find": "                \"create\": {\n                    \"type\": \"boolean\",",
+    "replace": "                \"create_DROPPED\": {\n                    \"type\": \"boolean\",",
+    "tests": [
+      "tests/ee/agent/test_sites_mcp_server/test_edit_react_component.py::TestRegistration::test_the_schema_declares_the_create_flag"
+    ]
+  },
+  {
+    "label": "the success body claims the change is published, so the agent tells the user a draft edit went live",
+    "file": "ee/pocketpaw_ee/agent/mcp_servers/sites_create.py",
+    "find": "                \"Saved to the site's draft — it is NOT online yet, and no build was \"",
+    "replace": "                \"Published — the change is live at the site's url. Also a draft. \"",
+    "tests": [
+      "tests/ee/agent/test_sites_mcp_server/test_edit_react_component.py::TestEditHandler::test_success_payload_says_draft_and_never_claims_it_is_live"
+    ]
+  },
+  {
+    "label": "the react refine preamble is dropped, so a react site's chat is told to merge a rippleSpec it does not have",
+    "file": "ee/pocketpaw_ee/cloud/surface/handlers/sites.py",
+    "find": "    if (meta.engine or \"\").lower() == \"react\":",
+    "replace": "    if False:",
+    "tests": [
+      "tests/cloud/surface/test_sites_handler.py::test_react_refine_names_the_edit_tool_and_not_the_ripple_merge",
+      "tests/cloud/surface/test_sites_handler.py::test_react_refine_carries_the_prerender_and_write_scope_rules"
+    ]
+  },
+  {
+    "label": "the react create step stops naming the edit tool, so a follow-up change goes back to a second create_react_site and a second site pocket",
+    "file": "ee/pocketpaw_ee/cloud/surface/handlers/sites.py",
+    "find": "            \"`mcp__pocketpaw_sites_manager__edit_react_component` with the SAME \"",
+    "replace": "            \"`create_react_site` again with the SAME \"",
+    "tests": [
+      "tests/cloud/surface/test_sites_handler.py::test_react_create_step_routes_follow_up_changes_to_the_edit_tool"
+    ]
+  }
+]


### PR DESCRIPTION
> **Two things a reviewer merging on a green tick should know.**
>
> **1. `_react_refine_preamble` is INERT on this branch. React refine is NOT fixed by this PR.** The function exists and is tested, but the fork that reaches it reads `meta.engine`, and the /sites/[siteId] client never stamps `engine` on a refine — `resolve_profile` ignores it once `pocket_id` is set. So a react site's refine chat still gets the ripple preamble today. Do not read the presence of `_react_refine_preamble` as "react refine is handled"; the stacked PR on `fix/sites-refine-preamble-engine-fork` is what makes it reachable, and that one also rewrites the engine-blind preamble properly. A test here pins that ripple/svelte/no-engine refine is byte-for-byte unchanged, so this is inert rather than half-live.
>
> **2. `edit_react_component` requires the `sites` plan; `edit_svelte_component` does not.** That asymmetry is deliberate, not an oversight. The plan gate on the sites MCP surface is create-only today — `_edit_svelte_component_handler` has never called it. Gating an edit on a paid surface is the defensible direction, so the react tool calls `_require_sites_plan_or_error` and svelte keeps its existing behaviour. **Do not "fix" this by removing the react gate.** The follow-up is to add the gate to the svelte edit tool, which is a behaviour change on a shipped path and belongs in its own PR.

## The gap

`create_react_site` shipped in RX-2 and works. Nothing could change a react site afterwards, because every edit path was svelte-gated at three layers:

- `agent/mcp_servers/sites_create.py` registered only `make_edit_svelte_component_tool`
- `sites/service.py` checks `engine != "svelte"` and raises
- `cloud/pockets/service.py`'s `set_svelte_source_file` raises `pocket.not_svelte_site` on a react pocket. That file contained the string "react" zero times.

So when a user said "shorten the hero headline", the agent had exactly one available move: call `create_react_site` again. That mints a second site pocket and leaves the site they are looking at untouched.

## What this adds

`edit_react_component(pocket_id, component_path, edits | new_source, create=False)` on the existing `pocketpaw_sites_manager` server, plus the write chokepoint under it and the two preambles that route to it.

| Layer | Added |
|---|---|
| `cloud/pockets/service.py` | `set_react_source_file`, the Beanie write, with `_check_domain_edit_access`, fresh-dict reassignment, `emit(PocketUpdated)`, and the best-effort draft `ArtifactVersion` |
| `sites/service.py` | `edit_react_component`: resolve the edit, persist. No build to inject. |
| `sites/react_paths.py` | new, the shared path policy (below) |
| `agent/mcp_servers/sites_create.py` + `sites.py` | the handler, the tool factory, registration |
| `cloud/surface/handlers/sites.py` | the two preambles |

`edits` reuses the existing `apply_edits` rather than growing a second copy of the match-uniqueness rule.

## Three decisions worth reviewing

It does not publish, and does not enqueue a build. `edit_svelte_component` republishes and rolls the source back if the workerd smoke gate rejects the edit. That contract cannot transfer: `build_runs_async("react")` is True, so a react publish enqueues a Daytona build and returns before any build outcome exists. There is nothing synchronous to roll back from, and a rollback fired on enqueue-success would revert a good edit. Persisting the draft is the whole job, the shape `apply_leaf_edits` already documents. Publishing stays the user's call, which is also what `pocketpaw-create-react-site` STEP 4 promises. I said this in the docstring, the module header and the api-reference, because the missing republish reads as an omission and a future reader would otherwise "fix" it.

`create=True` inverts the existence check rather than relaxing it. It exists because "add a testimonials section" needs a new component file plus an `src/App.tsx` edit, and the write chokepoint refuses any path not already in the map, so without it the agent cannot add a section at all. `create=False` requires the path to exist, so a typo is never a silent create. `create=True` requires it not to, because an accidental overwrite of a real component is worse than a rejected call the agent can retry.

The path guard is load-bearing, and it moved. Without the same normalization create uses, `edit_react_component(component_path="package.json", create=True)` writes the dependency manifest, defeating the generator's dependency allowlist and with it the supply-chain release-age floor that manifest is what enforces. So `REACT_RESERVED_FILES`, `REACT_RESERVED_PREFIX` and the normalizer moved out of `sites_create.py` into `sites/react_paths.py`, and both writers call one copy. `sites_create` re-exports the old names, so nothing that imported them changed. The edit form adds the positive half create never needed: the resolved path must land under `src/` or `public/`. Two distinct codes, `site_edit.reserved_path` and `site_edit.path_outside_source`.

## The preambles were telling the agent the wrong thing

The react create step now says a follow-up change goes through the edit tool with the same `pocket_id`, not a second `create_react_site`.

A react refine chat now routes to a new `_react_refine_preamble`. The existing `_refine_preamble` names `mcp__pocketpaw_pocket_specialist__edit` and then enumerates five rules about ripple *widgets* (`pricing-table` uses `tiers`, never `accordion`, Tier-0 animation names). A react pocket has no rippleSpec, so on that engine every one of those is inert or actively wrong, and the specialist edit path would try to merge a spec that does not exist. Per `CLAUDE.md`, naming an existing-but-wrong tool is the same defect as naming an absent one: the model does not error, it improvises. The react preamble replaces the widget rules with the prerender rule, which is the same hazard in React spelling, and the write scope the tool actually enforces.

One caveat, stated plainly. That fork reads `meta.engine`, which is documented as the /sites *create* hint and which `resolve_profile` deliberately ignores once `pocket_id` is set. The /sites/[siteId] client does not stamp it today, so the react refine branch is inert until paw-enterprise sends it. Absent the hint, refine behaves exactly as before, and a test pins that ripple/svelte/no-engine refine is unchanged. The create-step fix has no such dependency and covers the reported flow, since the follow-up change lands in the same chat session as the create.

`tests/cloud/surface/test_entity_id_contract.py` does not trip: `pocket` is already in `_KNOWN_ADDRESSABLE_KINDS`, and `component_path` is not a `<kind>_id`. No allow-list entry was added.

## Second defect: publish never told the agent whether the site was live

`_publish_handler` hand-built a five-key body (`id`, `pocket_id`, `name`, `url`, `deployed`) while `_to_response`, the wire the frontend polls, also carries `build_status`, `build_reason` and `build_job_id`. The agent got none of the three, and react is the one engine where that breaks the happy path, since it is the only engine with `build_runs_async(engine)` True:

- **First publish.** `_enqueue_static_build` creates the Site doc with `url: ""` and `deployed: false`. That is honest, because nothing is serving yet and the worker flips both on success. But `pocketpaw-create-react-site` STEP 4 tells the agent to show the user the returned url, so it showed an empty string or invented one.
- **Re-publish.** `url` and `deployed` deliberately keep the *previous* deploy's values so a rebuild never reports a working site as down. Right for the frontend, which reads `build_status` beside them. For an agent that could not see `build_status`, it meant reporting the old url as though the change were live.

The body now carries the three raw fields verbatim, never normalised, plus `build_in_progress`, `is_live`, and a `message`.

`is_live` requires a non-empty `url` **and** `deployed` **and** no build in flight, because each term is individually insufficient. The tests prove that one term at a time rather than asserting the happy path and trusting the rest.

`build_in_progress` reads an unknown status as in progress. That is the wire contract and the deliberate opposite of `build_state.should_enqueue`, which treats unknown as terminal: a redundant build costs one sandbox, a spurious "your site is live" costs trust. It derives from `TERMINAL_STATUSES`, so a state added to the machine defaults to in-progress here for free. One test pins the asymmetry out loud so nobody unifies the two readers.

The `message` exists because the original defect was narration, not data. A boolean the agent does not consult fixes nothing, so the payload states the conclusion in prose and, on a queued build, names the tool to check next.

## New tool: get_site_build_status

Read-only. Without it the queued state is a dead end: an async publish returns before the build starts, so the agent could learn a build was enqueued and never discover how it ended.

It resolves the canonical Site doc through `canonical_site_for_pocket`, which is tenant-scoped on the workspace. That filter is the access check, and there is no plan gate because nothing is mutated. A pocket with no Site doc answers `published: false` rather than raising, since from the caller's side "never published" is the useful answer and is correct whether the pocket has no site or does not exist.

Both surfaces share one derivation, `sites.service.build_wire_state`, because the publish response and the status tool disagreeing about whether a site is live would be worse than either being wrong alone.

**Final key names**, since two agents are writing docs against them: `build_status`, `build_reason`, `build_job_id`, `build_in_progress`, `is_live`. Tool id `mcp__pocketpaw_sites_manager__get_site_build_status`, one required param `pocket_id`.

Both new tool ids ride `SITES_TOOL_IDS`. That was called out as a merge-blocker and it is a real one: `sites_allow` is built from that tuple and is a hard whitelist on /sites, so an absent id is filtered out with no error while every handler-level test still passes. There is a test per tool asserting the id is in the tuple *and* that the built server actually lists the tool, because those are two different facts.

## Tests

New: `tests/ee/sites/test_react_component_edit.py` (34), `tests/ee/agent/test_sites_mcp_server/test_edit_react_component.py` (26), `tests/ee/sites/test_agent_build_visibility.py` (16), `tests/ee/agent/test_sites_mcp_server/test_build_status_tool.py` (15), four in `test_sites_handler.py`. `test_mcp_tool.py`'s deliberate tool-count tripwire went 7 to 8 to 9, each time with an id assertion, which is exactly the decision it exists to force.

Covered: targeted `edits`; `new_source` rewrite; both and neither rejected; ambiguous `old_string`; svelte and ripple pockets rejected; missing path rejected when `create=False`, and separately on the `edits` branch where it would otherwise be a `KeyError`; existing path rejected when `create=True`; every reserved-path spelling (`package.json`, `./package.json`, `index.html`, `vite.config.ts`, `paw-prerender.mjs`, `src/paw/entry.tsx`, `src\paw\entry.tsx`, `src/paw/../paw/entry.tsx`); paths outside `src/` and `public/` including `..` escapes and absolute paths; the guard running before the pocket is read; the plan gate; and that the edit neither publishes nor enqueues, asserted both by spies on the seams and by the Site collection still being empty.

## Mutations

`tests/mutations/react_edit_lane.json`, 31 mutations, all caught.

Three escaped across the two rounds, and all three were real test gaps rather than curiosities:

1. Deleting the sites-service `create and exists` check escaped, because the write chokepoint caught the write anyway. The mutation's harm claim was false. Fixed by removing the duplicate, so that rule has one owner, and repointing the mutation at the chokepoint.
2. Removing the sites-service missing-path check escaped, because the only test used `new_source`, where the chokepoint's `NotFound` arrives first. The check is load-bearing only on the `edits` branch, which indexes the map. Added the test for that case.
3. Dropping `bool(url)` from `is_live` escaped, because the queued row it was pointed at already had a build in flight, so another term made `is_live` false anyway. Added the row where the empty url is the only thing standing in the way: a settled build with `deployed: true` and no persisted url, which is a shape `_canonical_site_doc` exists partly to handle.

This work also surfaced a latent bug in `scripts/mutate.py`, fixed here. `--validate` read files with `read_text` (universal newlines) while the sweep reads `read_bytes().decode()`, so a multi-line anchor into a CRLF file passed validation and then aborted the sweep with "anchor not found". `cloud/surface/handlers/sites.py` is CRLF in this repo, so the CI `mutation-anchors` job would have stayed green while every local sweep touching that file died on arrival. `--validate` now reads what the sweep reads.

Extracting `_reserved_react_keys` rotted two anchors in `tests/mutations/react_authoring.json`. Both were repointed at the new module and that whole plan was re-run: 11 of 11 caught.

## Not fixed here

`tests/cloud/surface` has 13 failures on `origin/dev` (`test_home_handler.py` x1, `test_sites_handler.py` x12), all the same drift: the tests call `preamble.lower()` on the `SurfacePreamble` that PA-2 made `build_preamble` return. Unrelated to this change, and left alone rather than folded into an already-large diff.

