### PR TITLE
fix(sites): the refine chat spoke ripple to every engine

### DIFF
--- a/ee/pocketpaw_ee/cloud/surface/handlers/sites.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/sites.py
@@ -136,7 +136,56 @@
 # here, and no site content is read — refine and chat echo the pocket id and
 # never describe the page — so a key built from meta is EXACT, and editing a
 # site correctly leaves it still. The sub-builders keep returning ``str``; only
-# the entry point answers the key.
+# the entry point answers the key. (The refine half of that claim no longer
+# holds — see the next entry.)
+#
+# Changes: 2026-08-11 (fix/sites-refine-preamble-engine-fork) — ``_refine_preamble``
+# FORKS BY ENGINE. It was written for ripple and shipped to all four: on a react,
+# html or svelte site it commanded ``pocket_specialist__edit`` (which mutates a
+# rippleSpec those pockets do not have — their content is a ``source`` map),
+# asserted "renders STATICALLY (no JavaScript runs for the visitor)" (react ships a
+# hydrating client bundle by default), claimed "the site auto-publishes from its
+# source pocket" (nothing auto-publishes — publish is a tool call and a paid-tier
+# checkout), and then listed five SSR rules about ripple WIDGET shapes
+# (``pricing-table``/``tiers``, the ``accordion`` ban, the ``form``/``newsletter``
+# ban) at a page with no widgets at all. Per pocketpaw/CLAUDE.md, "The prompt may
+# not command a tool the agent doesn't have" — and its "naming an existing-but-wrong
+# tool is the same defect" clause is exactly this: the specialist IS reachable here
+# (``pocketpaw_pocket_specialist`` rides ``ALWAYS_ALLOWED_MCP_SERVERS``), so the
+# agent got an edit tool that could not touch its pocket and improvised silently.
+#
+# THE ENGINE IS READ FROM THE POCKET, NOT FROM ``meta``. ``meta.engine`` is a
+# CREATE hint — the /sites gallery's preset picker sets it, and the refine
+# SurfaceMetaProvider (paw-enterprise ``routes/sites/[siteId]/+page.svelte``) stamps
+# only ``site_id`` / ``pocket_id`` / ``focus_node_id`` / ``mode``. Forking refine on
+# ``meta.engine`` would therefore have put EVERY site on the ``or "html"`` default:
+# a regression for ripple and no fix for react. So refine resolves the engine from
+# its source pocket through the canonical ``sites/engines.py::normalize_engine``
+# (the same value publish branches on), which makes this preamble the first on this
+# surface to read live state — hence ``content_key`` for the refine branch, per
+# ``_helpers.content_key``'s own rule. Create and chat still answer ``meta_key``.
+# An unreadable pocket (deleted, cross-tenant, DB error) or an engine this module
+# has no branch for lands on ``_refine_unknown_engine_step``, which names NO edit
+# tool and tells the agent to identify the engine first — the one honest answer,
+# and the reason a fifth engine in ``engines.py`` degrades instead of silently
+# inheriting react's rules.
+#
+# Per-branch, only what is TRUE for that engine: ripple keeps its widget rules and
+# the specialist edit path byte-for-byte (it was always correct there); svelte gets
+# ``edit_svelte_component``, which STAGES A DRAFT PREVIEW rather than publishing
+# (the module header above still says "and republishes" — stale since
+# feat/sites-diff-edit); react gets the react component-edit tool and the prerender
+# contract as ``pocketpaw-create-react-site/SKILL.md`` states it; html gets the
+# truth that it has NO chat edit tool at all — ``create_html_site`` takes no
+# ``pocket_id`` and would mint a SECOND site, and ``edit_svelte_component``'s guard
+# is svelte-only by design ("html has no per-component model — it edits by uid
+# splice (HE-9), not here"), so the branch says so instead of naming something.
+# The publish claim is fixed on every branch and the queued-build wording is gated
+# on ``sites/service.py::build_runs_async`` — react alone today — so svelte starts
+# telling the truth on its own if #1913 flips it. ASK-DON'T-ASSUME and the
+# ``ask-user-questions`` widget survive unchanged on every branch: refine keeps
+# ``ripple_mode="on"`` for all engines (``surface_registry._sites_profile``), so
+# that mechanism is real here even where create would have used ``ask_user`` chips.
 
 # Updated: 2026-08-11 (feat/sites-react-edit-lane, RX-3) — the react track finally
 # has an EDIT tool, and two preambles were telling the agent the wrong thing about
@@ -159,15 +208,42 @@
 # The refine fork reads `meta.engine`, which is documented as the CREATE hint, so it
 # only fires when the per-site chat client stamps it — see
 # `_react_refine_preamble`'s docstring. Absent it, refine behaves exactly as before.
+#
+# Updated: 2026-08-11 (fix/sites-refine-preamble-engine-fork) — RX-3's own caveat
+# above was the whole problem, and it is now closed: `meta.engine` is never stamped
+# on the refine surface, so `_react_refine_preamble` rendered for no one. Rather
+# than send the engine from the client (another repo, and wrong-until-deployed),
+# the engine is resolved SERVER-SIDE off the source pocket and `_refine_preamble`
+# forks on it for all four engines. `_react_refine_preamble` is FOLDED INTO that
+# fork's react branch rather than kept beside it: two react refine preambles, one
+# of them dead, is the drift the fork exists to prevent. Its content carries over
+# — the edit tool, the reserved shell, the dependency list, the prerender rule, the
+# draft framing — with three corrections. It used `mcp__pocketpaw_ask__ask_user`,
+# but refine holds `ripple_mode="on"` on every engine, so the `ask-user-questions`
+# widget is the mechanism this surface actually renders. It named
+# `pocket_specialist__edit` inside its prohibition; the create preamble's react
+# branch forbids "the pocket specialist" by concept without the id, and this now
+# matches that. And it told the agent to relay the publish result, which on react
+# is a QUEUED build whose url is empty on a first publish and the previous deploy
+# on a re-publish — see `_refine_publish_step`. RX-3's create-side change (the
+# react `build_step` naming the edit tool) is untouched.
 
 from __future__ import annotations
 
 import functools
+import logging
 from typing import Any
 
 from pocketpaw_ee.cloud.surface.domain import SurfaceMeta, SurfacePreamble
-from pocketpaw_ee.cloud.surface.handlers._helpers import meta_key
+from pocketpaw_ee.cloud.surface.handlers._helpers import content_key, meta_key
+from pocketpaw_ee.sites.react_paths import (
+    REACT_AUTHORABLE_PREFIXES,
+    REACT_RESERVED_FILES,
+    REACT_RESERVED_PREFIX,
+)
 from pocketpaw_ee.sites_crew.models import DesignBrief
+
+logger = logging.getLogger(__name__)
 
 # --- The concierge block (fix/concierge-tools-for-site-agent) -----------------
 #
@@ -233,6 +309,107 @@ _CONCIERGE_NOTE = (
 )
 
 
+# --- Engine resolution, shared by the create fork and the refine fork ---------
+#
+# ONE tuple and ONE normalizer so the two forks cannot drift: a fifth engine added
+# here has to be given a branch in both, and until it is, both fall back visibly
+# rather than silently instructing the wrong track.
+#
+# The two forks take DIFFERENT defaults, and that is the point of the parameter
+# rather than a wart. Create is choosing an engine for a page that does not exist
+# yet, so an unrecognized hint means "build the default" — html. Refine is
+# describing a page that ALREADY exists, so there is no sensible default: guessing
+# hands the agent the wrong edit tool. Refine passes what the pocket stored and
+# treats anything unrecognized as unknown (see ``_refine_engine``).
+_SITE_ENGINES: tuple[str, ...] = ("html", "svelte", "ripple", "react")
+
+
+def _preamble_engine(raw: str | None, *, default: str) -> str:
+    """Normalize an engine value for a preamble fork. Never raises.
+
+    Mirrors ``sites/engines.py::normalize_engine``'s never-raise policy (an
+    unusable engine string must not break chat) while keeping the create fork's
+    html default, which differs from that module's ripple one.
+    """
+    engine = (raw or default).lower()
+    return engine if engine in _SITE_ENGINES else default
+
+
+async def _refine_engine(pocket_id: str, user_id: str, workspace_id: str) -> str | None:
+    """Resolve which engine authored the site being refined. ``None`` if unknowable.
+
+    Read from the SOURCE POCKET, not from ``meta``: ``meta.engine`` is a create-time
+    hint that the /sites gallery's preset picker sets and the refine surface never
+    stamps at all, so a fork on it would put every refine on the create default.
+    The pocket's own ``engine`` is what publish branches on, so a preamble keyed to
+    it describes the page the user is actually looking at.
+
+    Normalized through the canonical ``sites/engines.py::normalize_engine`` rather
+    than ``_preamble_engine`` so this agrees with the publish path by construction —
+    including its legacy default: a pocket predating the field reads ``"ripple"``,
+    which is exactly the branch such a site has always been given.
+
+    Returns ``None`` on any failure, which the caller renders as an explicit
+    "identify the engine first" instruction. The catch is broad on purpose (the same
+    shape ``handlers/pocket.py::_load_pocket`` uses): NotFound, Forbidden and a
+    dropped connection all mean the same thing here — we cannot say, so we must not
+    claim. A preamble is never worth breaking a chat turn over.
+
+    Tenancy: ``pockets_service.get`` gates by owner / shared_with / visibility, NOT
+    by workspace, so a user in two workspaces could stamp a pocket from B in a chat
+    in A. Rejecting a workspace mismatch keeps the engine (and with it the tool the
+    prompt names) from being read out of the wrong tenant.
+    """
+    try:
+        from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+        pocket = await pockets_service.get(pocket_id, user_id)
+    except Exception:  # noqa: BLE001 — see the docstring: never break a turn
+        logger.debug("sites_handler: engine lookup for %s failed", pocket_id, exc_info=True)
+        return None
+    if pocket.get("workspace") != workspace_id:
+        logger.warning(
+            "sites_handler: workspace mismatch for pocket %s (chat=%s, pocket=%s); "
+            "refusing to read its engine",
+            pocket_id,
+            workspace_id,
+            pocket.get("workspace"),
+        )
+        return None
+    try:
+        from pocketpaw_ee.sites.engines import normalize_engine
+
+        return normalize_engine(pocket.get("engine"))
+    except Exception:  # noqa: BLE001
+        logger.debug("sites_handler: normalize_engine unavailable", exc_info=True)
+        return None
+
+
+def _publish_runs_async(engine: str) -> bool:
+    """Does publishing this engine QUEUE its build instead of running it inline?
+
+    Delegates to ``sites/service.py::build_runs_async`` — the predicate the publish
+    path itself branches on — so this prompt cannot claim a synchronous publish for
+    an engine that has since moved to the queue (static svelte is the live
+    candidate). Hardcoding ``engine == "react"`` here would be a second copy of a
+    fact that is actively moving.
+
+    An import failure answers TRUE, deliberately. The two wordings are not
+    symmetric: telling the agent to report a queued build when the publish was
+    actually inline costs the user one extra click to see a url, while telling it to
+    show a url when the build is still queued makes it announce a change that is not
+    live yet — on a first publish there is no url at all, and on a re-publish the url
+    serves the PREVIOUS page. Degrade toward the claim that cannot be false.
+    """
+    try:
+        from pocketpaw_ee.sites.service import build_runs_async
+
+        return build_runs_async(engine)
+    except Exception:  # noqa: BLE001
+        logger.debug("sites_handler: build_runs_async unavailable", exc_info=True)
+        return True
+
+
 @functools.lru_cache(maxsize=1)
 def _design_taste_system() -> str:
     """Return the ``pocketpaw-design-taste`` SKILL.md body (frontmatter stripped)
@@ -280,13 +457,6 @@ def _design_taste_system() -> str:
 async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> SurfacePreamble:
     """Render the /sites surface preamble.
 
-    The cache key is built from ``meta`` alone, and here that is exact rather
-    than a concession: all three sub-preambles are pure functions of the meta
-    plus a process-cached read of the design-taste SKILL.md. Nothing about the
-    SITE is read — the refine and chat modes echo the ``pocket_id`` and never
-    describe the page's contents — so editing a site does NOT move this key,
-    and should not: the preamble says the same thing before and after.
-
     Modes, keyed on the meta:
 
     * **Create** (no ``pocket_id``) — the /sites gallery / describe-to-create
@@ -298,14 +468,44 @@ async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> 
     * **Refine / Build** (``pocket_id`` present, ``mode`` "build" or unset) —
       the per-site chat at ``/sites/[siteId]``. Refine the EXISTING published
       site by editing its source pocket in place; never rebuild from scratch.
+
+    TWO KEYING RULES, because the modes no longer read the same amount:
+
+    * Create and chat are pure functions of ``meta`` plus a process-cached read
+      of the design-taste SKILL.md. Nothing about the SITE is read — chat echoes
+      the ``pocket_id`` and never describes the page's contents — so ``meta_key``
+      is exact rather than a concession, and editing a site correctly leaves the
+      key still: the preamble says the same thing before and after.
+    * Refine reads the pocket to learn which ENGINE authored the site, because
+      the instructions it renders (which edit tool exists, whether JavaScript
+      runs for the visitor, whether a publish returns a usable url) are different
+      facts per engine and ``meta`` does not carry the engine on this surface. So
+      it answers ``content_key`` — the digest of what was actually rendered,
+      which is the honest key the moment a handler reads live state. It moves
+      when the rendered instructions move and not otherwise: editing the SITE
+      does not shift it (the text describes the track, never the content), while
+      a pocket that became unreadable does, which is correct — that turn's
+      preamble genuinely says something different.
+
+    The sub-builders keep returning ``str``; only the entry point answers the key.
     """
     if meta.pocket_id:
-        text = _chat_preamble(meta) if meta.mode == "chat" else _refine_preamble(meta)
+        if meta.mode == "chat":
+            text = _chat_preamble(meta)
+        else:
+            # The one read on this surface. Its failure mode is a preamble that
+            # says "identify the engine first", never a failed turn.
+            engine = await _refine_engine(meta.pocket_id, user_id, workspace_id)
+            refine_text = _refine_preamble(meta, engine)
+            return SurfacePreamble(
+                text=refine_text,
+                cache_key=content_key("sites", refine_text),
+            )
     else:
         text = _create_preamble(meta)
-    # The five inputs the three sub-preambles read, all off ``meta``. ``mode``
-    # and ``engine`` are in there because they pick which preamble was rendered
-    # at all — toggling Build/Chat on the same site is a different prompt.
+    # The five inputs the two meta-only sub-preambles read, all off ``meta``.
+    # ``mode`` and ``engine`` are in there because they pick which preamble was
+    # rendered at all — toggling Build/Chat on the same site is a different prompt.
     return SurfacePreamble(
         text=text,
         cache_key=meta_key(
@@ -347,16 +547,15 @@ def _create_preamble(meta: SurfaceMeta) -> str:
     is the user's call — not an automatic step off a plain "create a site".
     """
     route = meta.route_path or "/sites"
-    engine = (meta.engine or "html").lower()
     # RX-2 adds "react". Every engine named here MUST have a create tool the
     # /sites agent can actually reach — the build step below names one, and a
     # preamble that commands an absent tool does not error, it makes the model
     # improvise (pocketpaw/CLAUDE.md, "The prompt may not command a tool the agent
     # doesn't have"). react's tool is ``create_react_site``, registered on the
     # sites_manager server and carried into the surface allow-list by
-    # ``SITES_TOOL_IDS``. An unknown engine still falls back to html.
-    if engine not in ("html", "svelte", "ripple", "react"):
-        engine = "html"
+    # ``SITES_TOOL_IDS``. An unknown engine still falls back to html — shared with
+    # the refine fork via ``_preamble_engine`` so the two engine lists are one list.
+    engine = _preamble_engine(meta.engine, default="html")
     engine_attr = f' engine="{engine}"'
 
     if engine == "svelte":
@@ -619,110 +818,355 @@ def _create_preamble(meta: SurfaceMeta) -> str:
     )
 
 
-def _react_refine_preamble(meta: SurfaceMeta) -> str:
-    """The /sites/[siteId] refine preamble for a REACT site (RX-3).
+# The rules that transfer to EVERY engine, because they are properties of a
+# marketing landing page and not of a rendering track. The five numbered rules the
+# ripple branch keeps are the ones that do NOT transfer: they name widget types
+# (``pricing-table``'s ``tiers``, the ``accordion`` ban, the ``form`` /
+# ``newsletter`` ban) and a react/html/svelte page has no widgets to name.
+_REFINE_SHARED_RULES = (
+    "PRESERVE the landing funnel (nav → hero → services → proof → pricing → "
+    "call-to-action → lead form → footer): a refine changes a section, it does not "
+    "reorder or drop the funnel, and it does not turn the page into a dashboard.\n"
+    "REAL COPY ONLY. Never invent a testimonial, a statistic, a price, an address, "
+    "or a phone number to fill a section you are editing — ask, or keep what is "
+    "there.\n"
+    "Every CTA stays an anchor `href` (or `tel:` / `mailto:`), never a click "
+    "handler that needs JavaScript to navigate.\n"
+    "The lead form stays a FLAT native `<form>` — real `name=` on every "
+    '`input`/`textarea` and a `button type="submit"`. Never nest a form inside a '
+    "form, and never replace it with a widget that does.\n"
+)
 
-    Its own function rather than a branch inside ``_refine_preamble`` because
-    almost nothing in that preamble is true here. That one tells the agent to
-    apply the change via ``mcp__pocketpaw_pocket_specialist__edit`` and then
-    enumerates five rules about ripple WIDGETS (``pricing-table`` uses ``tiers``,
-    never the ``accordion`` widget, Tier-0 animation names). A react site has no
-    rippleSpec at all, so on this engine every one of those is either inert or
-    actively wrong: the specialist edit path would try to merge a spec the pocket
-    does not have. Per pocketpaw/CLAUDE.md, naming an existing-but-WRONG tool is
-    the same defect as naming an absent one — the model does not error, it
-    improvises.
 
-    The prerender rule replaces the SSR widget rules, because it is the react
-    spelling of the same hazard: ``useEffect`` does not run at prerender time, so
-    a resting state set only in an effect bakes as the initial value.
+def _react_write_scope() -> str:
+    """The paths a react edit may and may not write — rendered from the constants
+    the tool ENFORCES, not retyped as prose beside them.
 
-    REACHABILITY CAVEAT, worth knowing before trusting this in production:
-    ``SurfaceMeta.engine`` is documented as the /sites CREATE hint (the engine
-    toggle), and ``resolve_profile`` deliberately ignores it once ``pocket_id`` is
-    set. So this branch only renders when the per-site chat client actually stamps
-    ``engine="react"`` on the surface meta. When it does not, refine falls through
-    to the ripple preamble below exactly as it does today — no regression, but the
-    react-correct instructions do not arrive either. Sending the engine from the
-    /sites/[siteId] client is the follow-up that finishes this.
+    ``sites/react_paths.py`` is the shared module ``edit_react_component`` and
+    ``create_react_site`` both check against, so reading it here means the day a
+    fifth reserved file is added, this instruction gains it in the same commit
+    instead of drifting into a stale list the agent trusts. A prompt that lists four
+    reserved paths when the tool rejects five does not fail loudly: the agent writes
+    the fifth, gets ``site_edit.reserved_path`` back, and spends a turn discovering
+    what the prompt was supposed to have told it.
+
+    The normalization note is not decoration — the tool collapses ``.``/``..`` and
+    backslashes BEFORE it checks, so ``./package.json`` is rejected too and an agent
+    that reads the list as a literal string match would think it found a loophole.
     """
-    route = meta.route_path or "/sites"
-    pocket_id = meta.pocket_id or ""
+    reserved = ", ".join(f"`{path}`" for path in REACT_RESERVED_FILES)
+    authorable = " and ".join(f"`{prefix}`" for prefix in REACT_AUTHORABLE_PREFIXES)
     return (
-        f'<surface kind="sites" route="{route}" pocket="{pocket_id}" '
-        'engine="react" mode="refine" />\n'
-        "<sites-orientation>\n"
-        f"The user is REFINING an EXISTING React Paw Site (source pocket "
-        f"`{pocket_id}`) — a real standalone marketing website whose pages are "
-        "hand-written React components PRERENDERED to static HTML at build time. "
-        "They are on its per-site chat asking for a CHANGE to that page. Do NOT "
-        "rebuild the site from scratch, do NOT create a new site or a new pocket, "
-        "and do NOT treat it as an in-app dashboard pocket. Talk about it as a "
-        "'site' or 'page' — never a 'pocket'.\n"
-        "</sites-orientation>\n"
-        "<sites-procedure>\n"
-        "ASK, DON'T ASSUME: if the requested edit is ambiguous, or applying it "
-        "needs a real fact you don't have (new copy, a price, a section's "
-        "content, or which of several interpretations the user means), call "
-        "`mcp__pocketpaw_ask__ask_user` with a one-line question and 3–5 short "
-        "options (include a 'you decide' option) instead of guessing — and NEVER "
-        "fabricate real-world facts (testimonials, stats, prices, addresses, "
-        "contact details).\n"
-        "APPLY THE CHANGE with "
-        "`mcp__pocketpaw_sites_manager__edit_react_component`, passing pocket_id "
-        f"`{pocket_id}`. That is the ONLY way to change this site. Do NOT call "
-        "`create_react_site` (it mints a SECOND site and leaves this one "
-        "untouched), and do NOT call `mcp__pocketpaw_pocket_specialist__edit` or "
-        "any rippleSpec merge — a React site has no rippleSpec, so there is "
-        "nothing for those to edit.\n"
-        "Send a targeted `edits` diff — a list of {old_string, new_string} blocks "
-        "where each old_string is copied VERBATIM from the current file and "
-        "matches exactly once — rather than the whole file, and read the file "
-        "first if you have not this turn. To ADD a section, call the tool twice: "
-        "once with `create=true` and `new_source` for the new "
-        "`src/components/<Name>.tsx`, then once with `edits` on `src/App.tsx` to "
-        "import and render it.\n"
-        "YOU MAY ONLY WRITE under `src/` (outside `src/paw/`) and `public/`. "
-        "`index.html`, `package.json`, `vite.config.ts`, `paw-prerender.mjs` and "
-        "`src/paw/` are GENERATED and will be rejected — they carry the prerender "
-        "contract and the dependency list. The project has react, react-dom and "
-        "vite and NOTHING else: no router, no CSS framework, no state or "
-        "animation library, and no way to add a dependency, so build the change "
-        "with what is there.\n"
-        "PRERENDER RULE: every component must render its resting/final state in "
-        "its RETURNED MARKUP. `useEffect` does not run at prerender time, so a "
-        "count-up initialized to 0 bakes '0' — initialize it to the final value. "
-        "Keep any motion CSS-only unless the site already ships client "
-        "JavaScript.\n"
-        "THE EDIT IS A DRAFT. It does NOT publish and does NOT start a build, so "
-        "never tell the user the change is live. Point them at the in-app Preview "
-        "under /sites and offer to publish; call "
-        "`mcp__pocketpaw_sites_manager__publish` only when they ask to go live, "
-        "and then relay the real result — no phantom URLs. Keep talking 'site' / "
-        "'page', never 'pocket'.\n"
-        "</sites-procedure>\n"
-        f"{_CONCIERGE_NOTE}"
+        f"YOU MAY ONLY WRITE under {authorable}, and never under "
+        f"`{REACT_RESERVED_PREFIX}`. {reserved} and everything under "
+        f"`{REACT_RESERVED_PREFIX}` are GENERATED and will be rejected — they carry "
+        "the prerender contract and the dependency list. Paths are normalized "
+        "before that check, so a `./` prefix or a `..` segment does not get around "
+        "it. The project has react, react-dom and vite and NOTHING else: no router, "
+        "no CSS framework, no state or animation library, and no way to add a "
+        "dependency — so build the change with what is there, and if it genuinely "
+        "needs a new package, say so instead of importing one.\n"
     )
 
 
-def _refine_preamble(meta: SurfaceMeta) -> str:
+def _refine_publish_step(engine: str | None, pocket_id: str) -> str:
+    """The publish instruction for a refine turn. Honest per engine.
+
+    Three claims in the old text were wrong at once, and each was wrong in the
+    direction that makes the agent announce something that did not happen: that the
+    site "auto-publishes from its source pocket" (nothing auto-publishes — publish
+    is a tool call, and on a paid tier it can open a checkout), that an edit is
+    followed by a re-publish at all (the svelte and react edit tools stage a DRAFT
+    and deliberately do not build), and that the agent should "show the live `url`"
+    (on an ASYNC engine that url is empty on a first publish and points at the
+    PREVIOUS deploy on a re-publish, so it serves the pre-change page).
+
+    ``_publish_runs_async`` decides the last part, so the wording follows the
+    publish path instead of restating it.
+
+    THE GATE IS ``is_live``, WHICH IS WHY THIS NAMES A FIELD AT ALL (#1920). The
+    publish response carries ``build_status`` / ``build_reason`` / ``build_job_id`` /
+    ``build_in_progress`` / ``is_live`` beside the original five keys, and ``is_live``
+    is the only one that answers the question the agent is about to answer out loud:
+    it is true only when there is a non-empty ``url`` AND ``deployed`` AND no build
+    in flight. ``deployed`` and a non-empty ``url`` each look like that answer and
+    are not — a rebuild deliberately keeps the previous deploy's values so a working
+    site is not reported as down mid-build, which is exactly the state where they
+    lie. The statuses are deliberately NOT enumerated here: the wire contract treats
+    an unrecognized ``build_status`` as in-progress, so a closed list in the prompt
+    would go stale in the unsafe direction.
+    """
+    common = (
+        "PUBLISHING IS A SEPARATE STEP AND THE USER'S CALL. Nothing you do here "
+        "goes live on its own: the published page keeps serving its last build "
+        "until someone publishes, and publishing deploys to the public edge (on a "
+        "paid tier it can open a checkout). Do NOT publish off a plain edit "
+        "request. Tell the user their change is saved and offer to take it live.\n"
+        "When they DO ask ('publish', 'make it live', 'ship it'), call "
+        f"`mcp__pocketpaw_sites_manager__publish` with pocket_id `{pocket_id}` and "
+        "relay the REAL result — the real error text on a failure. Never claim a "
+        "publish that did not happen.\n"
+        "GATE 'IT IS LIVE' ON THE `is_live` FIELD AND ON NOTHING ELSE. Show the "
+        "`url` only when `is_live` is true. Never report a site as live off "
+        "`deployed` or a non-empty `url` alone — a rebuild keeps the PREVIOUS "
+        "deploy's url and `deployed:true` on purpose, so both are set while the "
+        "page the user just changed is not live. The response also carries a "
+        "`message` that already states the correct conclusion: relay it.\n"
+    )
+    if not _publish_runs_async(engine or ""):
+        return common + ("Never invent or guess a url — show only what the tool returned.\n")
+    return common + (
+        "THE BUILD IS ASYNCHRONOUS ON THIS ENGINE, so publish returns BEFORE the "
+        "build starts and its response can never tell you how the build ended. On a "
+        "FIRST publish the site is created with no url at all (empty) and "
+        "`deployed` false; on a RE-publish the url is the PREVIOUS deploy, which "
+        "keeps serving the OLD page for as long as the rebuild takes. Report it as "
+        "a build that has STARTED, not as a live page.\n"
+        "TO LEARN THE OUTCOME, call "
+        "`mcp__pocketpaw_sites_manager__get_site_build_status` with pocket_id "
+        f"`{pocket_id}` — that is the ONLY way, and it is the follow-up whenever a "
+        "publish came back with `build_in_progress` true. While it is still true, "
+        "say the site is still building and show no url. If the build FAILED, relay "
+        "`build_reason` instead of a url and offer to fix the page and publish "
+        "again. Only once `is_live` is true is the url the thing to show.\n"
+    )
+
+
+def _refine_unknown_engine_step(pocket_id: str) -> str:
+    """What to say when we could not read which engine authored the site.
+
+    The read fails on a deleted pocket, a cross-workspace stamp, or a dropped
+    connection — and a fifth engine in ``sites/engines.py`` with no branch here
+    lands in the same place. Every engine's edit path is a DIFFERENT tool and three
+    of the four reject a pocket from another track, so guessing is the one move
+    guaranteed to be wrong roughly three times in four. Name no tool; make the
+    agent look first.
+    """
+    return (
+        "WHICH ENGINE AUTHORED THIS SITE COULD NOT BE DETERMINED, so do not assume "
+        "one. The edit path is a different tool per engine and each rejects a site "
+        "from another track, so a guess is a failed tool call at best and a "
+        "confident wrong answer at worst.\n"
+        f"FIRST call `mcp__pocketpaw_pocket__get_pocket` with pocket_id "
+        f"`{pocket_id}` and read its `engine`. A `ripple` pocket carries a "
+        "`rippleSpec` (a widget tree) and is edited with "
+        "`mcp__pocketpaw_pocket_specialist__edit`. `svelte`, `react` and `html` "
+        "pockets carry a `source` map ({path: file contents}) instead, and the "
+        "specialist CANNOT edit those — svelte uses "
+        "`mcp__pocketpaw_sites_manager__edit_svelte_component`, react uses "
+        "`mcp__pocketpaw_sites_manager__edit_react_component`, and html has no "
+        "edit tool at all yet (say so plainly rather than reaching for a create "
+        "tool).\n"
+        "If the read fails too, tell the user you could not load their site rather "
+        "than attempting an edit blind.\n"
+    )
+
+
+def _refine_preamble(meta: SurfaceMeta, engine: str | None = None) -> str:
     """The /sites/[siteId] refine preamble — edit an EXISTING published site.
 
-    Landing-aware: mirrors the create-paw-site brain's structure + 5 SSR rules
-    so an edit can't reintroduce a static-site trap. Carries the source
-    ``pocket_id`` so the agent edits the right pocket in place.
+    IT FORKS BY ENGINE because every load-bearing instruction in it is a different
+    fact per engine, not a different phrasing of one fact:
 
-    RX-3: a react site routes to ``_react_refine_preamble`` instead, because this
-    preamble's edit instruction (``mcp__pocketpaw_pocket_specialist__edit``) and
-    its five ripple-widget rules are all about a rippleSpec a react pocket does
-    not have. See that function for the ``meta.engine`` reachability caveat.
+    * **which tool can edit the page at all** — ripple's content is a ``rippleSpec``
+      the pocket specialist merges into; svelte, react and html carry a ``source``
+      map instead, which that tool cannot touch. Each source engine has (or lacks)
+      its own file-level edit tool;
+    * **whether JavaScript runs for the visitor** — a react site ships a hydrating
+      client bundle by default (``sites_keep_client_bundle_default``), so "no
+      JavaScript runs" is false there, while the prerender contract that DOES bind
+      react has no analogue on a ripple widget page;
+    * **whether a publish hands back a url worth showing** — see
+      ``_refine_publish_step``.
+
+    Written for ripple and shipped to all four, it asserted the ripple answer to all
+    three on every site. ``engine`` is resolved by ``_refine_engine`` from the
+    SOURCE POCKET (``meta`` does not carry it on this surface); ``None`` means it
+    could not be read and routes to ``_refine_unknown_engine_step``.
+
+    The ripple branch is deliberately unchanged apart from the publish claim: it was
+    correct there, and this is a fix for the other three engines rather than a
+    rewrite of working behaviour. What is shared across all branches is the
+    ASK-DON'T-ASSUME gate, the ``ask-user-questions`` mechanism (refine keeps
+    ``ripple_mode="on"`` on every engine, so that widget is real here), the funnel /
+    real-copy / anchor-CTA / flat-form rules, and the source ``pocket_id`` — which
+    every branch still threads into the tool call it names.
     """
-    if (meta.engine or "").lower() == "react":
-        return _react_refine_preamble(meta)
     route = meta.route_path or "/sites"
     pocket_id = meta.pocket_id or ""
+    engine_attr = f' engine="{engine}"' if engine else ' engine="unknown"'
+
+    if engine == "ripple":
+        render_truth = (
+            " The page renders STATICALLY (no JavaScript runs for the visitor), so "
+            "every change must still work as plain HTML."
+        )
+        edit_step = (
+            "Treat the user's message as an edit to APPLY to the existing site. "
+            f"Apply the change to pocket `{pocket_id}` via "
+            "`mcp__pocketpaw_pocket_specialist__edit` (the merge/edit path — it "
+            "mutates the existing spec in place). NEVER use the create path and "
+            "NEVER rebuild the page from scratch; a refine is a targeted edit on "
+            "top of the current landing spec.\n"
+        )
+        # The five rules are ripple's and stay ripple's: each names a widget type,
+        # and the other three engines have no widgets. Byte-identical to the text
+        # that shipped before the fork.
+        rules = (
+            "PRESERVE the landing structure (nav → hero → services → proof → "
+            "pricing → flat lead form → footer) and keep the 5 static-site (SSR) "
+            "rules intact while you edit:\n"
+            "1. Lead capture stays FLAT native `input`/`textarea`/"
+            '`button{type:"submit"}` with real field names (name, email, phone, '
+            "message) — NEVER the `form` or `newsletter` widget, which nests an "
+            "invalid `<form>` inside the site template's outer POST form and "
+            "captures zero leads.\n"
+            "2. `pricing-table` uses `tiers` (never `plans`/`columns`).\n"
+            "3. An FAQ is `heading` + `text` pairs — NEVER the `accordion` widget "
+            "(its panels only open with JS, so on a static site the answers never "
+            "expand).\n"
+            "4. Every CTA is an anchor `href` (or `tel:` / `mailto:`) — never an "
+            "`on_click` handler, which is a dead button with no client JS.\n"
+            "5. `hero` is the marketing Hero widget — never the dashboard "
+            "`hero+grid` (a page-header plus a KPI `stat` grid); no metric grid, "
+            "no charts. This is marketing, not analytics.\n"
+            "Any animation stays Tier-0 (CSS-only, static-safe) — `aurora`, "
+            "`marquee`, `border-beam`, `shimmer`, `text-effect`; never `reveal`, "
+            "`parallax`, or `spotlight` (they need client JS and hide content on a "
+            "static page).\n"
+        )
+    elif engine == "svelte":
+        render_truth = (
+            " The page is hand-written SvelteKit components PRERENDERED to static "
+            "HTML, so a section must look finished in the markup it returns — "
+            "never set the resting state only in `onMount`."
+        )
+        edit_step = (
+            "Treat the user's message as an edit to ONE component file. This "
+            "site's content is a `source` map ({path: file contents}), NOT a "
+            "rippleSpec — there is no widget spec here, so do NOT call the pocket "
+            "specialist and do NOT draft a rippleSpec.\n"
+            "Call `mcp__pocketpaw_sites_manager__edit_svelte_component` with "
+            f"pocket_id `{pocket_id}`, the `component_path` of the file to change "
+            "(it must already exist in the source map, e.g. "
+            "'src/lib/components/Hero.svelte'), and EXACTLY ONE of `edits` (a "
+            "list of {old_string, new_string} blocks — prefer this for anything "
+            "targeted; each old_string must match the current file verbatim and "
+            "exactly once) or `new_source` (the whole new file, for a large "
+            "rewrite). Read the file before you diff it. NEVER call a create tool "
+            "to apply a change — that mints a second site and leaves this one "
+            "untouched.\n"
+            "THE EDIT IS A DRAFT PREVIEW, NOT A DEPLOY. The tool returns "
+            '`status:"draft"`, `is_live:false` and a `preview_url` that previews '
+            "the edit — it is not the live site and the live page is unchanged. "
+            "Relay the tool's own `message`, and never tell the user the change is "
+            "published or live. On `ok:false` nothing was staged: an old_string "
+            "that matched 0 or more than 1 time needs more context, and a "
+            "smoke-test failure means fix the component and retry.\n"
+        )
+        rules = _REFINE_SHARED_RULES
+    elif engine == "react":  # RX-3's `_react_refine_preamble`, folded in here
+        # The tool id and its argument names are read off ``edit_react_component``'s
+        # own schema (RX-3), not guessed.
+        render_truth = (
+            " The page is hand-written React components PRERENDERED to static HTML "
+            "at build time, and it ALSO ships a client bundle by default — so it "
+            "is not a no-JavaScript page, and it is not a page you may leave blank "
+            "until JavaScript runs."
+        )
+        edit_step = (
+            "Treat the user's message as an edit to ONE component file. This "
+            "site's content is a `source` map ({path: file contents}), NOT a "
+            "rippleSpec — there is no widget spec here, so do NOT call the pocket "
+            "specialist and do NOT draft a rippleSpec.\n"
+            "Call `mcp__pocketpaw_sites_manager__edit_react_component` with "
+            f"pocket_id `{pocket_id}`, the `component_path` to write (e.g. "
+            "'src/components/Hero.tsx'), and EXACTLY ONE of `edits` (a list of "
+            "{old_string, new_string} blocks — prefer this for anything targeted; "
+            "each old_string must match the current file verbatim and exactly "
+            "once) or `new_source` (the whole new file). Read the file before you "
+            "diff it. To ADD a section, call it twice: once with `create=true` and "
+            "`new_source` for the new `src/components/<Name>.tsx`, then once with "
+            "`edits` on `src/App.tsx` to import and render it. NEVER call "
+            "`create_react_site` again for a change — that mints a SECOND site "
+            "pocket and leaves the one the user is looking at untouched.\n"
+            f"{_react_write_scope()}"
+            "THE EDIT IS SAVED TO THE DRAFT, NOT PUBLISHED. The tool returns "
+            '`status:"draft"` / `is_live:false`, nothing is built and nothing '
+            "goes live; the user previews it under /sites. Relay the tool's own "
+            "`message` and do not tell them it is live. On `ok:false` NOTHING was "
+            "saved — relay the reason (a reserved path, the wrong engine, an "
+            "old_string that matched 0 or more than 1 time) rather than reporting "
+            "a successful edit.\n"
+        )
+        rules = _REFINE_SHARED_RULES + (
+            "THE PRERENDER RULE governs every component you touch: at build time "
+            "`<App />` is rendered to HTML by `react-dom/server`, before any "
+            "browser JavaScript runs. `useEffect` does NOT run at prerender time, "
+            "and `window` / `document` do not exist during that render. So every "
+            "component must render its resting/final state in its RETURNED MARKUP "
+            "— a count-up initialized to 0 bakes '0', so initialize it to the "
+            "final value; an accordion's open panel is the `useState` initial "
+            "value; a scroll-reveal keeps its content in the markup and only adds "
+            "a class. Touch `window`/`document` inside `useEffect` (or behind a "
+            "`typeof window !== 'undefined'` check), never in a component body or "
+            "at module top level. If your edit would leave a section looking "
+            "unfinished with JavaScript disabled, move the final state into the "
+            "returned markup.\n"
+        )
+    elif engine == "html":
+        render_truth = (
+            " The page is a hand-authored static HTML/CSS bundle served straight "
+            "from the edge — the files in the source map ARE the page."
+        )
+        # THE HONEST BRANCH. html is the DEFAULT create engine and has no
+        # chat-reachable edit tool: ``create_html_site`` takes no ``pocket_id`` (it
+        # mints a new pocket, so calling it here would leave the user with a second,
+        # unrelated site), ``edit_svelte_component``'s service guard is svelte-only
+        # by design, and the uid-splice path behind the native editor
+        # (``sites/service.py::apply_leaf_edits``) is a REST route and svelte-gated
+        # too. Naming any of them would be the exact defect this fork fixes, so the
+        # branch states the gap instead. Being useful inside a real limit beats
+        # improvising outside it.
+        edit_step = (
+            "YOU CANNOT WRITE THIS SITE'S FILES FROM THIS CHAT. An html site has "
+            "no edit tool yet — that is a real gap in the product, not something "
+            "to work around:\n"
+            "- the pocket specialist edits a rippleSpec. This pocket has a "
+            "`source` map instead, so it has nothing to merge into — do NOT call "
+            "it and do NOT draft a rippleSpec.\n"
+            "- the create tools take no pocket id: each one creates a NEW pocket "
+            "and a SECOND site, leaving the one the user is looking at untouched. "
+            "Do NOT call a create tool to 'apply' a change.\n"
+            "WHAT TO DO INSTEAD, in one turn: call "
+            f"`mcp__pocketpaw_pocket__get_pocket` with pocket_id `{pocket_id}` to "
+            "read the current files from its `source` map, work out exactly what "
+            "the change is, and give the user the finished replacement markup for "
+            "the file that changes (in a code block, with the file's path) plus a "
+            "one-line description of where it goes. Then say plainly that editing "
+            "an html site's files from chat is not wired up yet, so you cannot "
+            "apply it for them. Do not imply you saved, published, or previewed "
+            "anything — nothing was written.\n"
+        )
+        rules = _REFINE_SHARED_RULES + (
+            "Whatever markup you hand back keeps the page working with no "
+            "JavaScript: the full resting state lives in the HTML, never rendered "
+            "only by a script.\n"
+        )
+    else:
+        render_truth = ""
+        edit_step = _refine_unknown_engine_step(pocket_id)
+        rules = _REFINE_SHARED_RULES
+
+    # html has nothing to publish FROM chat (no write landed), and the unknown
+    # branch has not established which engine it would be publishing — naming a
+    # publish flow in either would invite the agent to publish the LAST build as
+    # if it carried the change the user just asked for.
+    publish_step = "" if engine in (None, "html") else _refine_publish_step(engine, pocket_id)
+
     return (
-        f'<surface kind="sites" route="{route}" pocket="{pocket_id}" mode="refine" />\n'
+        f'<surface kind="sites" route="{route}" pocket="{pocket_id}"'
+        f'{engine_attr} mode="refine" />\n'
         "<sites-orientation>\n"
         f"The user is REFINING an EXISTING published Paw Site (source pocket "
         f"`{pocket_id}`) — a live standalone marketing website already deployed "
@@ -732,9 +1176,7 @@ def _refine_preamble(meta: SurfaceMeta) -> str:
         "dashboard pocket. It is a real marketing landing page that reads top to "
         "bottom as a conversion funnel: nav, hero, services, social proof, "
         "pricing, a call-to-action, a flat lead-capture form, footer. Talk about "
-        "it as a 'site' or 'page' — never a 'pocket'. The page renders STATICALLY "
-        "(no JavaScript runs for the visitor), so every change must still work as "
-        "plain HTML.\n"
+        f"it as a 'site' or 'page' — never a 'pocket'.{render_truth}\n"
         "</sites-orientation>\n"
         "<sites-procedure>\n"
         "ASK, DON'T ASSUME: if the requested edit is ambiguous, or applying it "
@@ -743,36 +1185,11 @@ def _refine_preamble(meta: SurfaceMeta) -> str:
         "ASK with an `ask-user-questions` ripple widget (include a 'you decide' "
         "option) instead of guessing — and NEVER fabricate real-world facts "
         "(testimonials, stats, prices, addresses, contact details).\n"
-        "Treat the user's message as an edit to APPLY to the existing site, then "
-        f"re-publish. Apply the change to pocket `{pocket_id}` via "
-        "`mcp__pocketpaw_pocket_specialist__edit` (the merge/edit path — it "
-        "mutates the existing spec in place). NEVER use the create path and NEVER "
-        "rebuild the page from scratch; a refine is a targeted edit on top of the "
-        "current landing spec. After the edit lands it can be re-published (the "
-        "site auto-publishes from its source pocket); relay any publish error — "
-        "never claim a phantom publish — and show the live `url`.\n"
-        "PRESERVE the landing structure (nav → hero → services → proof → pricing "
-        "→ flat lead form → footer) and keep the 5 static-site (SSR) rules intact "
-        "while you edit:\n"
-        "1. Lead capture stays FLAT native `input`/`textarea`/"
-        '`button{type:"submit"}` with real field names (name, email, phone, '
-        "message) — NEVER the `form` or `newsletter` widget, which nests an "
-        "invalid `<form>` inside the site template's outer POST form and captures "
-        "zero leads.\n"
-        "2. `pricing-table` uses `tiers` (never `plans`/`columns`).\n"
-        "3. An FAQ is `heading` + `text` pairs — NEVER the `accordion` widget "
-        "(its panels only open with JS, so on a static site the answers never "
-        "expand).\n"
-        "4. Every CTA is an anchor `href` (or `tel:` / `mailto:`) — never an "
-        "`on_click` handler, which is a dead button with no client JS.\n"
-        "5. `hero` is the marketing Hero widget — never the dashboard "
-        "`hero+grid` (a page-header plus a KPI `stat` grid); no metric grid, no "
-        "charts. This is marketing, not analytics.\n"
-        "Any animation stays Tier-0 (CSS-only, static-safe) — `aurora`, "
-        "`marquee`, `border-beam`, `shimmer`, `text-effect`; never `reveal`, "
-        "`parallax`, or `spotlight` (they need client JS and hide content on a "
-        'static page). Keep `type="site"` + `pattern="landing"` on the pocket. '
-        "Keep talking 'site' / 'page', never 'pocket'.\n"
+        f"{edit_step}"
+        f"{rules}"
+        f"{publish_step}"
+        'Keep `type="site"` + `pattern="landing"` on the pocket. Keep talking '
+        "'site' / 'page', never 'pocket'.\n"
         "</sites-procedure>\n"
         f"{_CONCIERGE_NOTE}"
     )
@@ -994,5 +1411,5 @@ __all__ = [
     "_create_preamble",
     "_frontend_preamble",
     "_chat_preamble",
-    "_react_refine_preamble",
+    "_refine_preamble",
 ]

--- a/tests/cloud/surface/test_home_handler.py
+++ b/tests/cloud/surface/test_home_handler.py
@@ -12,6 +12,27 @@
 #   3. An empty workspace (no widgets pinned yet) still produces a
 #      usable preamble naming surface=home — the home dashboard is
 #      always present, even before the user adds anything.
+#
+# Updated: 2026-08-11 (fix/sites-refine-preamble-engine-fork) — repaired guarantee
+# 3, which had been RED on dev. ``ensure_home_pocket`` stopped provisioning an
+# empty pocket when built-in home widgets moved to the DB
+# (``feat(pockets): built-in home widgets from DB``): it now auto-seeds every
+# ``auto_seed=True`` builtin, so a fresh user has "Intent of the Day" pinned and the
+# ``count="0"`` assertion was measuring that change rather than the handler. The
+# empty branch is still reachable — unpin what was seeded — so the test unpins
+# instead of dropping the assertion, and a second test covers the grid a real new
+# user gets, which nothing had asserted.
+#
+# That second test also records a LIVE DEFECT it would otherwise have papered over:
+# every pinned row renders ``id=?`` because ``format_widget_line`` reads
+# ``widget.id`` while the wire dict carries ``_id``
+# (``pockets/dto.py::_widget_to_wire``) and ``_AttrDict`` answers a missing key with
+# ``None``. That is pocketpaw/CLAUDE.md's "Prompt rows must carry the id the tools
+# take" reintroduced by a key-name mismatch — invisible to the AST gate, since the
+# row does go through ``entity_line``, and invisible to the cap test, whose fixture
+# is built from objects that DO have ``.id``. It affects the pocket surface too. Not
+# fixed here (this PR owns the sites preamble); filed as its own task so the fix
+# lands with the handler.
 
 from __future__ import annotations
 
@@ -115,9 +136,23 @@ async def test_home_handler_marks_broken_spec_widget() -> None:
 
 
 async def test_home_handler_empty_workspace_returns_minimal_preamble() -> None:
-    """An empty workspace gets a usable preamble naming surface=home."""
+    """A home grid with nothing pinned gets a usable preamble naming surface=home.
+
+    ``ensure_home_pocket`` no longer provisions an EMPTY pocket: since
+    ``feat(pockets): built-in home widgets from DB`` it auto-seeds every
+    ``auto_seed=True`` builtin, which today is "Intent of the Day"
+    (``tests/cloud/test_home_pocket.py`` pins that as intended). The empty branch
+    is still reachable — a user can unpin what was seeded — so this test now
+    UNPINS it rather than asserting a zero that provisioning stopped producing.
+    Without that the assertion was measuring the seeding change, not the handler.
+    """
     user_id = await _seed_user("owner-empty@surface.test")
-    # No widgets seeded — ensure_home_pocket provisions an empty pocket.
+    pocket, _ = await pockets_service.ensure_home_pocket(WORKSPACE, user_id)
+    # ``_id``, not ``id`` — the widget wire dict is the legacy shape
+    # (``dto._widget_to_wire``). That mismatch is also why these rows render
+    # ``id=?``; see test_home_handler_lists_the_auto_seeded_builtin.
+    for widget in pocket["widgets"]:
+        await pockets_service.remove_widget(pocket["_id"], widget["_id"], user_id)
 
     preamble = (await home_handler.build_preamble(WORKSPACE, user_id, SurfaceMeta())).text
 
@@ -125,3 +160,37 @@ async def test_home_handler_empty_workspace_returns_minimal_preamble() -> None:
     # The pinned-widgets block exists with count=0 and an empty marker.
     assert '<pinned-widgets count="0"' in preamble
     assert "empty" in preamble.lower()
+
+
+async def test_home_handler_lists_the_auto_seeded_builtin() -> None:
+    """The state a real new user is actually in: one auto-seeded builtin pinned.
+
+    Added with the test above, because that one was the only coverage of a freshly
+    provisioned home grid and it had to stop describing one to keep testing the
+    empty block. Nothing asserted what the handler renders for the grid every new
+    user gets.
+
+    IT ALSO RECORDS A LIVE DEFECT rather than asserting the row is addressable,
+    because it is not: ``format_widget_line`` reads ``widget.id`` while the wire
+    dict this handler passes it carries the id under ``_id``
+    (``pockets/dto.py::_widget_to_wire``), and ``_AttrDict.__getattr__`` returns
+    ``None`` for a missing key — so every pinned row on the home AND pocket
+    surfaces renders ``id=?`` even though ``update_widget`` requires
+    ``widget_id``. That is the bug pocketpaw/CLAUDE.md's "Prompt rows must carry
+    the id the tools take" exists for, reintroduced by a key-name mismatch instead
+    of a hand-rolled row — which is why the AST gate cannot see it (the row does go
+    through ``entity_line``) and why the cap fixture, built from objects with a real
+    ``.id``, measures rows production never renders. Left as an assertion of what
+    ships, with its own task, so the fix lands with the handler and not here.
+    """
+    user_id = await _seed_user("owner-seeded@surface.test")
+    pocket, created = await pockets_service.ensure_home_pocket(WORKSPACE, user_id)
+    assert created is True
+
+    preamble = (await home_handler.build_preamble(WORKSPACE, user_id, SurfaceMeta())).text
+
+    assert '<surface kind="home"' in preamble
+    assert f'<pinned-widgets count="{len(pocket["widgets"])}"' in preamble
+    for widget in pocket["widgets"]:
+        assert widget["name"] in preamble
+    assert "id=?" in preamble

--- a/tests/cloud/surface/test_sites_handler.py
+++ b/tests/cloud/surface/test_sites_handler.py
@@ -1017,8 +1017,7 @@ async def test_every_sites_mode_knows_the_concierge_exists(label: str, meta: Sur
     precisely because no mode carried it, so this is parametrized across all
     five dispatched (engine, mode) combinations rather than spot-checking one.
     """
-    preamble = await sites_handler.build_preamble(WORKSPACE, USER, meta)
-    lower = preamble.lower()
+    lower = (await sites_handler.build_preamble(WORKSPACE, USER, meta)).text.lower()
 
     assert "concierge" in lower, f"{label}: preamble never mentions the concierge"
     # Named as the thing the visitor actually sees on the page.
@@ -1037,8 +1036,7 @@ async def test_concierge_block_never_promises_a_configuration_tool(
     declares them — so the preamble has to route the user to the dashboard
     instead of naming a tool that would hard-error.
     """
-    preamble = await sites_handler.build_preamble(WORKSPACE, USER, meta)
-    lower = preamble.lower()
+    lower = (await sites_handler.build_preamble(WORKSPACE, USER, meta)).text.lower()
 
     # No fabricated tool ids for concierge configuration.
     for phantom in (
@@ -1064,8 +1062,7 @@ async def test_create_ties_the_concierge_to_publish_not_to_the_draft() -> None:
     """
     for engine in (None, "svelte", "ripple"):
         meta = SurfaceMeta(route_path="/sites", engine=engine)
-        preamble = await sites_handler.build_preamble(WORKSPACE, USER, meta)
-        lower = preamble.lower()
+        lower = (await sites_handler.build_preamble(WORKSPACE, USER, meta)).text.lower()
         # The concierge arrives WITH the publish, not with the draft.
         assert "publish" in lower
         concierge_at = lower.index("concierge")
@@ -1097,7 +1094,7 @@ async def test_concierge_awareness_does_not_depend_on_the_mcp_tool_id_import() -
         preamble = await sites_handler.build_preamble(
             WORKSPACE, USER, SurfaceMeta(route_path="/sites")
         )
-        assert "concierge" in preamble.lower()
+        assert "concierge" in preamble.text.lower()
     finally:
         registry._MCP_TOOL_IDS_CACHE = original
 

--- a/tests/cloud/surface/test_sites_handler.py
+++ b/tests/cloud/surface/test_sites_handler.py
@@ -243,6 +243,22 @@ async def test_sites_handler_specifies_flat_lead_capture_form() -> None:
 REFINE_POCKET = "pkt-existing-site-123"
 
 
+def _refine_meta(pocket_id: str = REFINE_POCKET, **kwargs: str) -> SurfaceMeta:
+    """The meta the live refine surface sends: site_id + pocket_id, NO engine.
+
+    Spelled out in one helper because the missing ``engine`` is load-bearing rather
+    than incidental — the refine SurfaceMetaProvider in paw-enterprise
+    (``routes/sites/[siteId]/+page.svelte``) stamps ``site_id`` / ``pocket_id`` /
+    ``focus_node_id`` / ``mode`` and nothing else. A test that passed
+    ``engine="react"`` here would be testing a wire shape that does not exist and
+    would have reported the engine fork working while every real refine turn got
+    the fallback.
+    """
+    return SurfaceMeta(
+        route_path="/sites/site-abc", pocket_id=pocket_id, site_id="site-abc", **kwargs
+    )
+
+
 async def test_sites_handler_refine_mode_orients_to_existing_site() -> None:
     """When the meta carries a pocket_id, the surface is the per-site refine
     chat: the agent must REFINE the EXISTING published site, not create a new
@@ -272,15 +288,14 @@ async def test_sites_handler_refine_mode_orients_to_existing_site() -> None:
 
 
 async def test_sites_handler_refine_mode_uses_edit_path() -> None:
-    """Refine applies the change via the merge/edit path on the existing pocket,
-    not the create path — so the published site is updated in place."""
-    preamble = (
-        await sites_handler.build_preamble(
-            WORKSPACE,
-            USER,
-            SurfaceMeta(route_path="/sites/site-abc", pocket_id=REFINE_POCKET, site_id="site-abc"),
-        )
-    ).text
+    """A RIPPLE refine applies the change via the merge/edit path on the existing
+    pocket, not the create path — so the source spec is updated in place.
+
+    Pinned on the ripple branch EXPLICITLY since the engine fork. The specialist
+    merges a rippleSpec, and ripple is the only engine whose pocket has one; the
+    other three branches must NOT name it (see the engine-fork section below).
+    """
+    preamble = sites_handler._refine_preamble(_refine_meta(), "ripple")
 
     # The edit/merge tool, not a fresh create.
     assert "mcp__pocketpaw_pocket_specialist__edit" in preamble
@@ -289,15 +304,14 @@ async def test_sites_handler_refine_mode_uses_edit_path() -> None:
 
 
 async def test_sites_handler_refine_mode_is_landing_aware() -> None:
-    """The refine preamble carries the same landing structure + 5 SSR rules as
-    the create brain, so an edit can't introduce a static-site trap."""
-    preamble = (
-        await sites_handler.build_preamble(
-            WORKSPACE,
-            USER,
-            SurfaceMeta(route_path="/sites/site-abc", pocket_id=REFINE_POCKET, site_id="site-abc"),
-        )
-    ).text
+    """The RIPPLE refine preamble carries the same landing structure + 5 SSR rules
+    as the create brain, so an edit can't introduce a static-site trap.
+
+    These five rules are the ripple branch's and only the ripple branch's: each one
+    names a WIDGET type, and a react/html/svelte page is markup with no widgets in
+    it (test_source_map_refine_drops_the_ripple_widget_rules).
+    """
+    preamble = sites_handler._refine_preamble(_refine_meta(), "ripple")
 
     lower = preamble.lower()
     # Preserve the landing/conversion structure.
@@ -861,11 +875,17 @@ async def test_build_preamble_unchanged_for_create_path() -> None:
 
 async def test_build_preamble_unchanged_for_refine_path() -> None:
     """A refine meta (with pocket_id) still returns exactly `_refine_preamble`'s
-    output — the additive brief helper does not touch the refine dispatch."""
-    meta = SurfaceMeta(route_path="/sites/site-abc", pocket_id=REFINE_POCKET, site_id="site-abc")
+    output — the additive brief helper does not touch the refine dispatch.
+
+    With no pocket seeded the engine lookup finds nothing, so the live dispatch
+    renders the unknown-engine branch; comparing against ``_refine_preamble(meta,
+    None)`` states that outright instead of relying on the default argument
+    happening to match.
+    """
+    meta = _refine_meta()
     live = (await sites_handler.build_preamble(WORKSPACE, USER, meta)).text
 
-    assert live == sites_handler._refine_preamble(meta)
+    assert live == sites_handler._refine_preamble(meta, None)
     assert 'mode="frontend"' not in live
 
 
@@ -937,9 +957,11 @@ async def test_sites_handler_build_mode_identical_to_refine() -> None:
 
     # The toggle's Build side is exactly the refine preamble; unset defaults to it.
     assert build == unset
-    # And it is the mutate-and-republish refine preamble (regression guard).
-    assert "mcp__pocketpaw_pocket_specialist__edit" in build
+    # And it is the refine preamble, not the chat one (regression guard). The edit
+    # TOOL it names is engine-dependent since the fork, so the mode tag is what
+    # this test can assert without re-pinning ripple's tool on every engine.
     assert 'mode="refine"' in build
+    assert 'mode="chat"' not in build
 
 
 async def test_sites_handler_chat_mode_ignored_without_pocket_id() -> None:
@@ -983,6 +1005,31 @@ async def test_mode_threads_through_meta_from_request() -> None:
 # `src/pocketpaw/bundled_skills/`. Nothing in the code path ever stated a
 # concierge exists, so whether the agent mentioned one was decided purely by
 # model sampling — which is exactly what "sometimes" looks like from outside.
+#
+# Updated: 2026-08-11 (fix/sites-refine-preamble-engine-fork) — the REFINE branch
+# forks by engine, so its tests do too. Three things changed shape here:
+#   1. The engine comes from the POCKET, not from `meta`, so the tests that prove
+#      the fork seed a real site pocket and go through `build_preamble`. A test that
+#      passed `engine=` into `_refine_preamble` would have passed against an
+#      implementation that reads `meta.engine` — which the live surface never sends,
+#      so every real refine turn would have taken the fallback. `_refine_meta()`
+#      exists to keep that wire shape (site_id + pocket_id + mode, no engine) in one
+#      place.
+#   2. `test_sites_handler_refine_mode_uses_edit_path` and
+#      `..._is_landing_aware` are now pinned to RIPPLE explicitly. They were
+#      written when there was one branch; the tool and the five widget rules they
+#      assert belong to that engine alone.
+#   3. `test_sites_handler_build_mode_identical_to_refine` no longer asserts the
+#      specialist's tool id, because which edit tool a Build-mode turn names depends
+#      on the site's engine. It pins what it was really about: the Build side of the
+#      toggle is byte-identical to unset.
+# The new section at the bottom pins the per-engine content (react must not command
+# the ripple edit path, must not claim the page runs without JavaScript, must not
+# promise a live url off an async publish, and must carry the prerender contract;
+# html must admit it has no edit tool; ripple must be unchanged), the shared half on
+# every branch including unknown, the content-keyed cache, and — derived from the MCP
+# tool schemas — that every tool id these branches name is one the agent can call.
+# Mutations: tests/mutations/sites_refine_engine_fork.json (11, all caught).
 #
 # These tests make the awareness DETERMINISTIC: every live /sites mode, on every
 # engine, must carry the concierge block. They also pin the two honest LIMITS of
@@ -1130,7 +1177,7 @@ async def test_react_create_step_routes_follow_up_changes_to_the_edit_tool() -> 
     assert "src/app.tsx" in lower
 
 
-async def test_react_refine_names_the_edit_tool_and_not_the_ripple_merge() -> None:
+async def test_react_refine_names_the_edit_tool_and_not_the_ripple_merge(mongo_db: object) -> None:
     """A react site's refine chat must route to ``edit_react_component``.
 
     The default refine preamble names ``mcp__pocketpaw_pocket_specialist__edit``,
@@ -1139,57 +1186,57 @@ async def test_react_refine_names_the_edit_tool_and_not_the_ripple_merge() -> No
     existing-but-WRONG tool is the same defect as naming an absent one: the model
     does not error, it improvises.
 
-    THE MUTATION THAT BREAKS THIS: drop the ``engine == "react"`` fork from
-    ``_refine_preamble`` so react falls through to the ripple preamble.
+    RETARGETED 2026-08-11 (fix/sites-refine-preamble-engine-fork). This test used to
+    pass ``engine="react"`` in the meta and reach ``_react_refine_preamble`` through
+    the RX-3 fork. The refine surface never sends ``engine`` — the
+    SurfaceMetaProvider in paw-enterprise stamps site_id / pocket_id /
+    focus_node_id / mode — so that fork rendered for nobody and this test was the
+    only thing exercising it. It now goes through the branch a real turn takes: the
+    engine resolved from the pocket. The prohibition assertion changed with it: the
+    branch forbids "the pocket specialist" by concept rather than by tool id, which
+    is how ``_create_preamble``'s react branch already words it, so the id must be
+    ABSENT here rather than present-as-a-prohibition.
+
+    THE MUTATION THAT BREAKS THIS: point the react branch's edit step at
+    ``mcp__pocketpaw_pocket_specialist__edit``. Run: caught. (Applied 2026-08-11.)
     """
+    user_id, pocket_id = await _seed_site_pocket("react")
+
     preamble = (
-        await sites_handler.build_preamble(
-            WORKSPACE,
-            USER,
-            SurfaceMeta(
-                route_path="/sites/site-abc",
-                pocket_id=REFINE_POCKET,
-                site_id="site-abc",
-                engine="react",
-            ),
-        )
+        await sites_handler.build_preamble(WORKSPACE, user_id, _refine_meta(pocket_id))
     ).text
 
     assert "mcp__pocketpaw_sites_manager__edit_react_component" in preamble
     # The pocket the agent must edit is named, so it cannot address the wrong one.
-    assert REFINE_POCKET in preamble
-    # The ripple merge path is named ONLY as a prohibition — naming it at all is
-    # deliberate (the agent has the tool, so silence would leave it as a plausible
-    # move), but it must never read as the instruction.
-    assert "do NOT call `mcp__pocketpaw_pocket_specialist__edit`" in preamble
+    assert pocket_id in preamble
+    # The rippleSpec merge is refused — by concept, without handing the model the
+    # tool id it would otherwise pattern-match.
+    assert "do NOT call the pocket specialist" in preamble
+    assert "pocket_specialist__edit" not in preamble
     # The ripple WIDGET vocabulary is absent: those rules are about a spec this
     # engine does not have, and carrying them would teach a react author to look
     # for widgets that are not there.
     assert "pricing-table" not in preamble
-    assert "accordion" not in preamble
     # Re-creating is explicitly refused.
     assert "create_react_site" in preamble
 
 
-async def test_react_refine_carries_the_prerender_and_write_scope_rules() -> None:
+async def test_react_refine_carries_the_prerender_and_write_scope_rules(mongo_db: object) -> None:
     """The two rules that replace the ripple widget rules on this engine.
 
     The prerender rule is the same hazard in React spelling (``useEffect`` does not
     run at prerender time, so a resting state set only in an effect bakes as the
     initial value), and the write scope is what the tool actually enforces — an edit
     naming a reserved path is rejected, so the preamble must not let the agent
-    discover that by trial."""
+    discover that by trial.
+
+    RETARGETED 2026-08-11: same reason as the test above — through the pocket, not
+    through a meta hint the surface does not send.
+    """
+    user_id, pocket_id = await _seed_site_pocket("react")
+
     preamble = (
-        await sites_handler.build_preamble(
-            WORKSPACE,
-            USER,
-            SurfaceMeta(
-                route_path="/sites/site-abc",
-                pocket_id=REFINE_POCKET,
-                site_id="site-abc",
-                engine="react",
-            ),
-        )
+        await sites_handler.build_preamble(WORKSPACE, user_id, _refine_meta(pocket_id))
     ).text
     lower = preamble.lower()
 
@@ -1199,26 +1246,571 @@ async def test_react_refine_carries_the_prerender_and_write_scope_rules() -> Non
     assert "src/" in preamble and "public/" in preamble
     assert "package.json" in preamble
     assert "src/paw/" in preamble
+    # The dependency list, so the agent does not author an import it cannot install.
+    assert "no way to add a dependency" in lower
     # And that the edit is a DRAFT, so the agent does not announce a live change.
     assert "draft" in lower
-    assert "does not publish" in lower
+    assert "nothing is built and nothing goes live" in lower
 
 
-async def test_non_react_refine_is_unchanged() -> None:
-    """The fork must not disturb the engine it was not written for: a refine with no
-    engine hint, or a ripple one, still gets the rippleSpec merge preamble."""
-    for engine in (None, "ripple", "svelte"):
-        preamble = (
-            await sites_handler.build_preamble(
-                WORKSPACE,
-                USER,
-                SurfaceMeta(
-                    route_path="/sites/site-abc",
-                    pocket_id=REFINE_POCKET,
-                    site_id="site-abc",
-                    engine=engine,
-                ),
-            )
-        ).text
-        assert "mcp__pocketpaw_pocket_specialist__edit" in preamble, engine
-        assert "edit_react_component" not in preamble, engine
+async def test_ripple_refine_keeps_the_rippleSpec_merge(mongo_db: object) -> None:
+    """The fork must not disturb the engine it was not written for.
+
+    REPLACES ``test_non_react_refine_is_unchanged``, which asserted that None,
+    "ripple" AND "svelte" all get the rippleSpec merge preamble. That was true only
+    because the RX-3 fork keyed on a meta field the surface never sends: a svelte
+    site has a ``source`` map and its own ``edit_svelte_component``, so handing it
+    the specialist was the same defect as handing it to react. Ripple is the engine
+    that genuinely keeps the merge path, and it is asserted through the pocket.
+    """
+    user_id, pocket_id = await _seed_site_pocket("ripple")
+
+    preamble = (
+        await sites_handler.build_preamble(WORKSPACE, user_id, _refine_meta(pocket_id))
+    ).text
+
+    assert "mcp__pocketpaw_pocket_specialist__edit" in preamble
+    assert "edit_react_component" not in preamble
+    assert "edit_svelte_component" not in preamble
+
+
+# --- The refine engine fork (fix/sites-refine-preamble-engine-fork) -----------
+#
+# THE BUG: `_refine_preamble` was written for ripple and shipped to all four
+# engines. On a react / html / svelte site it commanded
+# `pocket_specialist__edit` — which merges a rippleSpec those pockets do not have
+# (their content is a `source` map) — told the agent the page renders with no
+# JavaScript (react ships a hydrating client bundle by default), claimed the site
+# "auto-publishes from its source pocket", and then listed five SSR rules about
+# ripple WIDGET shapes at a page with no widgets in it.
+#
+# It was invisible for the reason pocketpaw/CLAUDE.md gives under "The prompt may
+# not command a tool the agent doesn't have": the agent does not raise on an
+# unsatisfiable instruction, it improvises, and the improvisation reads like a
+# normal reply. The specialist IS reachable here (`pocketpaw_pocket_specialist`
+# rides `ALWAYS_ALLOWED_MCP_SERVERS`), so this is that rule's "naming an
+# existing-but-wrong tool is the same defect" clause rather than a missing tool.
+#
+# TWO KINDS OF TEST BELOW, and the split matters:
+#
+#   1. RESOLUTION — that the branch is chosen from the POCKET. These seed a real
+#      pocket through the pockets service and go through `build_preamble`, because
+#      the whole defect is reachable only via the live path: `meta.engine` is a
+#      create hint the refine surface never stamps, so a fork on it would have put
+#      every refine on the `or "html"` default while every unit test that passed
+#      an engine directly reported success.
+#   2. CONTENT — what each branch may and may not say. These call
+#      `_refine_preamble(meta, engine)` directly, so an engine's rules can be
+#      pinned without a DB round trip per assertion.
+
+REACT_TOOL = "mcp__pocketpaw_sites_manager__edit_react_component"
+SVELTE_TOOL = "mcp__pocketpaw_sites_manager__edit_svelte_component"
+RIPPLE_TOOL = "mcp__pocketpaw_pocket_specialist__edit"
+SOURCE_MAP_ENGINES = ("svelte", "react", "html")
+ALL_REFINE_ENGINES = ("ripple", "svelte", "react", "html", None)
+
+
+async def _seed_site_pocket(engine: str, *, workspace: str = WORKSPACE) -> tuple[str, str]:
+    """Seed a real site pocket on ``engine``; return ``(user_id, pocket_id)``."""
+    from pocketpaw_ee.cloud.models.user import User as _UserDoc
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+    from pocketpaw_ee.cloud.pockets.dto import CreatePocketRequest
+
+    user = _UserDoc(
+        email=f"owner-{engine}-{workspace}@sites.test",
+        hashed_password="x",
+        is_active=True,
+        is_verified=True,
+        full_name="Site Owner",
+        active_workspace=workspace,
+    )
+    await user.insert()
+    user_id = str(user.id)
+    source = None if engine == "ripple" else {"src/App.tsx": "export default () => null;"}
+    pocket = await pockets_service.create(
+        workspace,
+        user_id,
+        CreatePocketRequest(
+            name=f"{engine} site",
+            type="site",
+            pattern="landing",
+            engine=engine,
+            source=source,
+        ),
+    )
+    return user_id, pocket["_id"]
+
+
+async def _registered_mcp_tool_ids() -> set[str]:
+    """Every ``mcp__<server>__<tool>`` id the agent layer actually registers.
+
+    Walks the ``agent/mcp_servers`` package's ``build_*`` factories AND the pocket
+    specialist, whose server is built in ``agent/pocket_specialist/mcp_tool.py`` —
+    outside the package, and the one the refine ripple branch names. Two return
+    shapes exist (``(name, server)`` from the package, a bare server dict from the
+    specialist) so both are normalized here.
+
+    A builder that raises is SKIPPED rather than failed on: this helper answers
+    "which ids are real", and a server that cannot be built in a test process
+    (missing SDK, missing credentials) cannot answer either way. The caller
+    asserts the derivation found something, so a wholesale failure still shows up.
+    """
+    import importlib
+    import pkgutil
+
+    import pocketpaw_ee.agent.mcp_servers as servers_pkg
+    from mcp import types
+
+    module_names = [
+        f"{servers_pkg.__name__}.{m.name}"
+        for m in pkgutil.iter_modules(servers_pkg.__path__)
+        if not m.name.startswith("_")
+    ]
+    module_names.append("pocketpaw_ee.agent.pocket_specialist.mcp_tool")
+
+    registered: set[str] = set()
+    for module_name in module_names:
+        try:
+            module = importlib.import_module(module_name)
+        except Exception:  # pragma: no cover — see the docstring
+            continue
+        for attr in dir(module):
+            if not attr.startswith("build_"):
+                continue
+            builder = getattr(module, attr)
+            if not callable(builder):
+                continue
+            try:
+                built = builder()
+                if not built:
+                    continue
+                if isinstance(built, tuple):
+                    server_name, server = built
+                else:
+                    server, server_name = built, built.get("name")
+                handler = server["instance"].request_handlers[types.ListToolsRequest]
+                listed = await handler(types.ListToolsRequest(method="tools/list"))
+            except Exception:  # pragma: no cover
+                continue
+            registered |= {f"mcp__{server_name}__{tool.name}" for tool in listed.root.tools}
+    return registered
+
+
+@pytest.mark.parametrize("engine,expected_tool", [("react", REACT_TOOL), ("ripple", RIPPLE_TOOL)])
+async def test_refine_reads_the_engine_off_the_pocket(
+    mongo_db: object, engine: str, expected_tool: str
+) -> None:
+    """THE TEST THE FIX EXISTS FOR: the branch comes from the pocket's engine.
+
+    The meta carries NO engine, exactly as the live refine surface sends it, so
+    this fails on any implementation that forks on ``meta.engine`` — which is what
+    the obvious fix would have done, and it would have handed a react site the html
+    branch while looking correct.
+
+    THE MUTATION THAT BREAKS THIS: make ``build_preamble`` pass ``meta.engine``
+    instead of the resolved engine. Run: react got the unknown branch, the react
+    edit tool was absent and this failed. (Applied 2026-08-11.)
+    """
+    user_id, pocket_id = await _seed_site_pocket(engine)
+
+    preamble = (
+        await sites_handler.build_preamble(WORKSPACE, user_id, _refine_meta(pocket_id))
+    ).text
+
+    assert f'engine="{engine}"' in preamble
+    assert expected_tool in preamble
+
+
+async def test_refine_ignores_a_stale_create_engine_hint(mongo_db: object) -> None:
+    """The POCKET wins over ``meta.engine``, which is a create-time preset hint.
+
+    ``surface_registry._sites_profile`` already states the precedence ("a pocket_id
+    present means refine even if engine=svelte"), and it has to hold here too: a
+    hint left over from the gallery's preset picker must never pick the edit tool
+    for a site that was authored on another track.
+    """
+    user_id, pocket_id = await _seed_site_pocket("ripple")
+
+    preamble = (
+        await sites_handler.build_preamble(
+            WORKSPACE, user_id, _refine_meta(pocket_id, engine="react")
+        )
+    ).text
+
+    assert 'engine="ripple"' in preamble
+    assert RIPPLE_TOOL in preamble
+    assert REACT_TOOL not in preamble
+
+
+async def test_refine_on_an_unreadable_pocket_commands_no_edit_tool(mongo_db: object) -> None:
+    """A pocket we cannot read yields "identify the engine first", not a guess.
+
+    Every engine's edit path rejects a pocket from another track, so on an unknown
+    engine the honest move is to make the agent look. The branch may LIST the
+    per-engine tools (it is a routing table the agent resolves after reading the
+    pocket) but must not hand it one as the tool to call now, and must not offer a
+    publish for a change it has not established it can make.
+    """
+    user_id, _ = await _seed_site_pocket("ripple")
+
+    preamble = (
+        await sites_handler.build_preamble(
+            WORKSPACE, user_id, _refine_meta("ffffffffffffffffffffffff")
+        )
+    ).text
+    lower = preamble.lower()
+
+    assert 'engine="unknown"' in preamble
+    assert "could not be determined" in lower
+    # It routes through the pocket READ first.
+    assert "mcp__pocketpaw_pocket__get_pocket" in preamble
+    assert "mcp__pocketpaw_sites_manager__publish" not in preamble
+
+
+async def test_refine_does_not_read_an_engine_from_another_workspace(mongo_db: object) -> None:
+    """Tenancy: ``pockets_service.get`` gates by owner / shared_with / visibility and
+    NOT by workspace, so a user in two workspaces could stamp a pocket from B in a
+    chat in A. The engine — and with it the tool the prompt names — must not be read
+    across that line.
+
+    THE MUTATION THAT BREAKS THIS: drop the ``pocket.get("workspace") !=
+    workspace_id`` guard in ``_refine_engine``. Run: the react branch rendered
+    inside workspace A and this failed. (Applied 2026-08-11.)
+    """
+    user_id, pocket_id = await _seed_site_pocket("react", workspace="ws-other-tenant")
+
+    preamble = (
+        await sites_handler.build_preamble(WORKSPACE, user_id, _refine_meta(pocket_id))
+    ).text
+
+    # Not react's branch: the engine was refused, not read. (The unknown branch's
+    # routing table still LISTS every engine's tool, which is the point of it —
+    # what must not appear is react's branch, i.e. its engine tag and its rules.)
+    assert 'engine="react"' not in preamble
+    assert 'engine="unknown"' in preamble
+    assert "could not be determined" in preamble.lower()
+    assert "react-dom/server" not in preamble
+
+
+async def test_react_refine_does_not_command_the_ripple_edit_path() -> None:
+    """A react pocket has a ``source`` map and no rippleSpec, so the specialist's
+    merge path has nothing to act on. The branch names react's own tool instead.
+
+    THE MUTATION THAT BREAKS THIS: point the react branch's edit step at
+    ``mcp__pocketpaw_pocket_specialist__edit``. Run: the forbidden id was present
+    and this failed. (Applied 2026-08-11.)
+    """
+    preamble = sites_handler._refine_preamble(_refine_meta(), "react")
+
+    assert "pocket_specialist__edit" not in preamble
+    assert REACT_TOOL in preamble
+    # And it says why, so the agent does not reach for the specialist off its own
+    # prior about how pockets are edited.
+    assert "do NOT call the pocket specialist" in preamble
+    assert "NOT a rippleSpec" in preamble
+
+
+async def test_react_refine_never_says_the_page_runs_without_javascript() -> None:
+    """React sites ship their client bundle by default
+    (``sites_keep_client_bundle_default``), so the ripple branch's "no JavaScript
+    runs for the visitor" is simply false here — and it is the kind of false that
+    makes an agent refuse a menu toggle the site can actually run."""
+    preamble = sites_handler._refine_preamble(_refine_meta(), "react")
+    lower = preamble.lower()
+
+    assert "no javascript runs for the visitor" not in lower
+    assert "renders statically" not in lower
+    # It states the real shape: prerendered AND hydrating.
+    assert "prerendered" in lower
+    assert "client bundle" in lower
+
+
+async def test_react_refine_does_not_promise_a_live_url_on_publish() -> None:
+    """A react publish QUEUES a build (``sites/service.py::build_runs_async``), so
+    the response is not a finished deploy: ``_enqueue_static_build`` creates the Site
+    doc with ``deployed=False`` / ``url=""`` on a first publish, and a re-publish
+    keeps the PREVIOUS deploy's url serving the pre-change page while the rebuild
+    runs. "Show the live url" is wrong in both directions.
+
+    THE MUTATION THAT BREAKS THIS: make ``_publish_runs_async`` return False. Run:
+    the react branch lost the queued-build paragraph and the status tool, and this
+    failed. (Applied 2026-08-11.)
+    """
+    preamble = sites_handler._refine_preamble(_refine_meta(), "react")
+    lower = preamble.lower()
+
+    assert "asynchronous" in lower
+    assert "returns BEFORE the build starts" in preamble
+    # #1920 shipped the read-only status tool, so the branch names it rather than
+    # gesturing at the app. It is the ONLY way to learn how a react build ended.
+    assert "mcp__pocketpaw_sites_manager__get_site_build_status" in preamble
+    assert "build_reason" in preamble
+    # The gate is `is_live` and not `deployed` / a non-empty url, either of which is
+    # set while a rebuild serves the PREVIOUS page. Asserted as the operative
+    # INSTRUCTION rather than as the presence of the field name: the first version of
+    # this test asserted `` `is_live` `` appeared somewhere and "never report a site
+    # as live off `deployed`", and a mutation that rewrote the gate's opening
+    # sentence escaped both — the surviving body still contained each fragment.
+    assert "`url` only when `is_live` is true" in preamble
+    assert "never report a site as live off `deployed`" in lower
+    # And the inversion the mutation introduced, named directly.
+    assert "whenever `deployed` is true" not in preamble
+
+
+async def test_react_refine_carries_the_prerender_contract() -> None:
+    """The rule that actually binds a react edit, stated as
+    ``pocketpaw-create-react-site/SKILL.md`` states it: ``<App />`` is rendered by
+    ``react-dom/server`` at build time, ``useEffect`` does not run then, and
+    ``window``/``document`` do not exist during that render — so a component must
+    return its resting state in markup."""
+    preamble = sites_handler._refine_preamble(_refine_meta(), "react")
+
+    assert "react-dom/server" in preamble
+    assert "`useEffect` does NOT run at prerender time" in preamble
+    assert "RETURNED MARKUP" in preamble
+
+
+async def test_react_refine_states_the_write_scope_the_tool_enforces() -> None:
+    """The reserved paths come from the module the TOOL checks, not from prose.
+
+    ``sites/react_paths.py`` is shared by ``edit_react_component`` and
+    ``create_react_site``, so deriving the expectation from those constants means a
+    fifth reserved file cannot land with the prompt still listing four. A prompt that
+    under-lists does not fail loudly — the agent writes the file, gets
+    ``site_edit.reserved_path``, and burns a turn learning what it should have been
+    told.
+
+    THE MUTATION THAT BREAKS THIS: hardcode ``_react_write_scope``'s list back into
+    prose, dropping ``paw-prerender.mjs``. Run: the derived expectation still wanted
+    it and this failed. (Applied 2026-08-11.)
+    """
+    from pocketpaw_ee.sites.react_paths import (
+        REACT_AUTHORABLE_PREFIXES,
+        REACT_RESERVED_FILES,
+        REACT_RESERVED_PREFIX,
+    )
+
+    preamble = sites_handler._refine_preamble(_refine_meta(), "react")
+
+    for reserved in REACT_RESERVED_FILES:
+        assert f"`{reserved}`" in preamble, f"reserved path {reserved!r} not stated"
+    assert f"`{REACT_RESERVED_PREFIX}`" in preamble
+    for authorable in REACT_AUTHORABLE_PREFIXES:
+        assert f"`{authorable}`" in preamble, f"authorable prefix {authorable!r} not stated"
+    # Normalization happens before the check, so a literal-string reading of the list
+    # is a loophole the agent must not think it has.
+    assert "normalized" in preamble
+
+
+@pytest.mark.parametrize("engine", SOURCE_MAP_ENGINES)
+async def test_source_map_refine_drops_the_ripple_widget_rules(engine: str) -> None:
+    """The five SSR rules name widget types, and a source-map page has no widgets.
+
+    Shipping them to react/html/svelte was not merely useless: "pricing-table uses
+    tiers" and "never the accordion widget" describe a widget catalog the agent
+    cannot use here, so following them means inventing something.
+
+    THE MUTATION THAT BREAKS THIS: append "Keep the 5 static-site (SSR) rules:
+    `pricing-table` uses `tiers`" to ``_REFINE_SHARED_RULES``. Run: the ripple rules
+    reached all three source-map branches and this failed on each. (Applied
+    2026-08-11.)
+    """
+    preamble = sites_handler._refine_preamble(_refine_meta(), engine)
+
+    # Matched on the RULE, not on the bare word: react's prerender rule legitimately
+    # mentions an accordion's open panel as a `useState` initial value, and a test
+    # that banned the word would have forced that guidance out to keep itself green.
+    for widget_rule in (
+        "`pricing-table` uses `tiers`",
+        "NEVER the `accordion` widget",
+        "NEVER the `form` or `newsletter` widget",
+        "`hero+grid`",
+        "`on_click` handler",
+        "5 static-site (SSR) rules",
+    ):
+        assert widget_rule not in preamble, (
+            f"{engine}: ripple widget rule {widget_rule!r} leaked onto a source-map engine"
+        )
+
+
+@pytest.mark.parametrize("engine", ALL_REFINE_ENGINES)
+async def test_every_refine_branch_keeps_what_transfers(engine: str | None) -> None:
+    """The engine-independent half, pinned on every branch including unknown.
+
+    A fork is a place for four copies of an instruction to drift, so the shared
+    rules are asserted across all of them rather than spot-checked on the one that
+    was edited last.
+
+    THE MUTATION THAT BREAKS THIS: drop ``f"{rules}"`` from ``_refine_preamble``'s
+    return. Run: every branch lost the anchor-CTA rule and this failed on all five.
+    (Applied 2026-08-11.)
+    """
+    preamble = sites_handler._refine_preamble(_refine_meta(), engine)
+    lower = preamble.lower()
+
+    # The source pocket is still threaded through every branch — a refine that
+    # cannot name its pocket cannot act on it.
+    assert REFINE_POCKET in preamble
+    assert 'mode="refine"' in preamble
+    # ASK-DON'T-ASSUME and its mechanism (refine keeps ripple_mode="on" on every
+    # engine, so the widget is real here).
+    assert "ask, don't assume" in lower
+    assert "ask-user-questions" in preamble
+    assert "fabricate" in lower
+    # The funnel, real copy, anchor CTAs, and the flat lead form.
+    assert "hero" in lower
+    assert "pricing" in lower
+    assert "footer" in lower
+    assert "href" in lower
+    assert "flat" in lower
+    # Never reframed as a create or a dashboard pocket.
+    assert "do NOT create a new site or a new pocket" in preamble
+    assert "dashboard pocket" in lower
+    # And the concierge block, on every branch.
+    assert "concierge" in lower
+
+
+async def test_svelte_refine_names_its_own_tool_and_calls_the_edit_a_draft() -> None:
+    """``edit_svelte_component`` STAGES A DRAFT PREVIEW — it returns
+    ``status:"draft"`` / ``is_live:false`` and the user clicks Submit for review.
+    (The mcp server's module header still says "and republishes"; that has been
+    stale since feat/sites-diff-edit.) An agent told the edit republished would
+    announce a change that is not live.
+
+    THE MUTATION THAT BREAKS THIS: retitle the block "THE EDIT REPUBLISHES THE
+    SITE". Run: it ESCAPED the first time — ``"draft" in lower`` still held because
+    the surviving payload mentions ``status:"draft"`` — which is why the assertions
+    below are separate and "republish" is banned outright. Re-run: caught.
+    (Applied 2026-08-11.)
+    """
+    preamble = sites_handler._refine_preamble(_refine_meta(), "svelte")
+    lower = preamble.lower()
+
+    assert SVELTE_TOOL in preamble
+    assert "pocket_specialist__edit" not in preamble
+    assert "draft" in lower
+    # Both halves asserted separately, and "republish" banned outright. An `or`
+    # across these let a mutation that retitled the block "THE EDIT REPUBLISHES THE
+    # SITE" escape: the surviving `status:"draft"` mention kept the test green while
+    # the heading — the sentence the agent actually acts on — said the opposite.
+    assert "not a deploy" in lower
+    assert "is not the live site" in lower
+    assert "republish" not in lower
+    # Both edit shapes, so the agent prefers the diff over a whole-file rewrite.
+    assert "old_string" in preamble
+    assert "new_source" in preamble
+
+
+async def test_html_refine_admits_it_has_no_edit_tool() -> None:
+    """html is the DEFAULT create engine and has NO chat-reachable edit tool:
+    ``create_html_site`` takes no pocket id (it mints a second site),
+    ``edit_svelte_component``'s guard is svelte-only by design, and the uid-splice
+    path behind the native editor is a svelte-gated REST route. So the branch says
+    so — the one thing it must not do is name a tool to fill the gap.
+
+    THE MUTATION THAT BREAKS THIS: point the html branch's edit step at
+    ``mcp__pocketpaw_sites_manager__create_html_site``. Run: a create tool was named
+    as the apply path and this failed. (Applied 2026-08-11.)
+    """
+    preamble = sites_handler._refine_preamble(_refine_meta(), "html")
+    lower = preamble.lower()
+
+    assert "cannot write this site's files from this chat" in lower
+    # No write tool is named — including the create tool that would look like one.
+    assert "create_html_site" not in preamble
+    assert "pocket_specialist__edit" not in preamble
+    assert SVELTE_TOOL not in preamble
+    assert REACT_TOOL not in preamble
+    # It still does the useful half: read the current source and hand back markup.
+    assert "mcp__pocketpaw_pocket__get_pocket" in preamble
+    # And it must not offer to publish a change it never applied.
+    assert "mcp__pocketpaw_sites_manager__publish" not in preamble
+
+
+async def test_ripple_refine_is_unchanged_apart_from_the_publish_claim() -> None:
+    """The ripple branch was always correct, so the fork must not have rewritten it.
+
+    Pins the five widget rules and the Tier-0 animation list that only apply here,
+    plus the one thing that DID change: the old text said the site "auto-publishes
+    from its source pocket", which was never true — publish is a tool call and on a
+    paid tier it can open a checkout.
+
+    THE MUTATION THAT BREAKS THIS: delete rule 2 (``pricing-table`` uses ``tiers``)
+    from the ripple branch. Run: the fork had quietly rewritten the one engine that
+    was already correct and this failed. (Applied 2026-08-11.)
+    """
+    preamble = sites_handler._refine_preamble(_refine_meta(), "ripple")
+    lower = preamble.lower()
+
+    assert RIPPLE_TOOL in preamble
+    assert "tiers" in lower
+    assert "accordion" in lower
+    assert "tier-0" in lower
+    assert "hero+grid" in lower
+    # The corrected publish claim.
+    assert "auto-publish" not in lower
+    assert "the user's call" in lower
+    # ripple publishes INLINE, so its response is already conclusive: no queued-build
+    # paragraph and no status tool. That absence is what makes the
+    # `_publish_runs_async` mutation catchable in both directions.
+    assert "get_site_build_status" not in preamble
+    assert "asynchronous" not in lower
+    # It still gates on `is_live` — that field is on every publish response, and
+    # `deployed` alone lies during a rebuild on any engine that grows one.
+    assert "`url` only when `is_live` is true" in preamble
+
+
+async def test_refine_cache_key_is_the_rendered_digest() -> None:
+    """Refine reads the pocket, so ``meta_key`` can no longer describe it: two sites
+    on different engines render different instructions from the same meta shape.
+    ``content_key`` moves exactly when the rendered text moves.
+
+    THE MUTATION THAT BREAKS THIS: key refine on ``meta_key("sites",
+    meta.pocket_id)``. Run: the key stopped tracking the rendered text and this
+    failed. (Applied 2026-08-11.)
+    """
+    from pocketpaw_ee.cloud.surface.handlers._helpers import content_key
+
+    rendered = await sites_handler.build_preamble(WORKSPACE, USER, _refine_meta())
+
+    assert rendered.cache_key == content_key("sites", rendered.text)
+    # A create meta still answers the meta key (it reads nothing about the site).
+    create = await sites_handler.build_preamble(WORKSPACE, USER, SurfaceMeta(route_path="/sites"))
+    assert create.cache_key.startswith("sites:/sites")
+
+
+async def test_every_tool_a_refine_branch_names_is_a_registered_tool() -> None:
+    """The gate pocketpaw/CLAUDE.md asks for, applied to this surface.
+
+    ``tests/test_prompt_names_only_real_tools.py`` does this for the inline ripple
+    prompt and says outright that it covers nothing else. The refine fork now names
+    a different tool per engine, which is exactly the shape that drifts: a tool
+    moves servers or gets renamed, and the prompt keeps commanding the old id while
+    the agent improvises instead of erroring.
+
+    Derived from the MCP tool schemas, never a hand-kept list.
+    """
+    import re
+
+    registered = await _registered_mcp_tool_ids()
+    assert registered, "no MCP tools enumerated — the derivation broke, not the prompt"
+    # The derivation has to reach the specialist's server, which lives OUTSIDE the
+    # mcp_servers package. Asserted rather than assumed: without it the ripple
+    # branch's tool would read as unregistered and the check would fail on the one
+    # branch that was never broken.
+    assert RIPPLE_TOOL in registered, "the enumeration missed the pocket specialist"
+
+    named: set[str] = set()
+    for engine in ALL_REFINE_ENGINES:
+        text = sites_handler._refine_preamble(_refine_meta(), engine)
+        named |= set(re.findall(r"mcp__[a-z0-9_]+__[a-z0-9_]+", text))
+
+    unresolved = named - registered
+    # ``edit_react_component`` lands with feat/sites-react-edit-lane, which this
+    # branch depends on and must merge after. The exemption is self-clearing: it
+    # only tolerates ABSENCE, so the branch that registers the tool turns this into
+    # an ordinary pass with nothing to remove.
+    assert unresolved <= {REACT_TOOL}, (
+        "a refine branch names tools that no MCP server registers — the agent "
+        f"cannot call these and will improvise instead of erroring: {sorted(unresolved)}"
+    )

--- a/tests/mutations/react_authoring.json
+++ b/tests/mutations/react_authoring.json
@@ -1,9 +1,9 @@
 [
   {
-    "label": "the react engine stops being selectable (create falls back to html and the skill is unreachable)",
+    "label": "the react engine stops being selectable (create falls back to html, the skill is unreachable, and a react refine loses its own branch)",
     "file": "ee/pocketpaw_ee/cloud/surface/handlers/sites.py",
-    "find": "    if engine not in (\"html\", \"svelte\", \"ripple\", \"react\"):",
-    "replace": "    if engine not in (\"html\", \"svelte\", \"ripple\"):",
+    "find": "_SITE_ENGINES: tuple[str, ...] = (\"html\", \"svelte\", \"ripple\", \"react\")",
+    "replace": "_SITE_ENGINES: tuple[str, ...] = (\"html\", \"svelte\", \"ripple\")",
     "tests": [
       "tests/cloud/surface/test_sites_handler.py::test_create_mode_engine_react_prefers_create_react_site_skill"
     ]

--- a/tests/mutations/react_edit_lane.json
+++ b/tests/mutations/react_edit_lane.json
@@ -185,10 +185,10 @@
     ]
   },
   {
-    "label": "the react refine preamble is dropped, so a react site's chat is told to merge a rippleSpec it does not have",
+    "label": "the react refine branch is dropped, so a react site's chat cannot name its edit tool and falls back to the engine-unknown routing table",
     "file": "ee/pocketpaw_ee/cloud/surface/handlers/sites.py",
-    "find": "    if (meta.engine or \"\").lower() == \"react\":",
-    "replace": "    if False:",
+    "find": "    elif engine == \"react\":  # RX-3's `_react_refine_preamble`, folded in here",
+    "replace": "    elif False:  # RX-3's `_react_refine_preamble`, folded in here",
     "tests": [
       "tests/cloud/surface/test_sites_handler.py::test_react_refine_names_the_edit_tool_and_not_the_ripple_merge",
       "tests/cloud/surface/test_sites_handler.py::test_react_refine_carries_the_prerender_and_write_scope_rules"

--- a/tests/mutations/sites_refine_engine_fork.json
+++ b/tests/mutations/sites_refine_engine_fork.json
@@ -1,0 +1,129 @@
+[
+  {
+    "label": "the refine fork reads meta.engine instead of the pocket — every refine gets the create default, so a react site is handed html's branch while the fork looks implemented",
+    "file": "ee/pocketpaw_ee/cloud/surface/handlers/sites.py",
+    "find": "            engine = await _refine_engine(meta.pocket_id, user_id, workspace_id)",
+    "replace": "            engine = meta.engine",
+    "tests": [
+      "tests/cloud/surface/test_sites_handler.py::test_refine_reads_the_engine_off_the_pocket"
+    ]
+  },
+  {
+    "label": "the react branch points at the ripple specialist again — the tool merges a rippleSpec a react pocket does not have",
+    "file": "ee/pocketpaw_ee/cloud/surface/handlers/sites.py",
+    "find": "            \"Call `mcp__pocketpaw_sites_manager__edit_react_component` with \"",
+    "replace": "            \"Call `mcp__pocketpaw_pocket_specialist__edit` with \"",
+    "tests": [
+      "tests/cloud/surface/test_sites_handler.py::test_react_refine_does_not_command_the_ripple_edit_path"
+    ]
+  },
+  {
+    "label": "the html branch names a create tool as its apply path — the agent mints a SECOND site and reports the edit done",
+    "file": "ee/pocketpaw_ee/cloud/surface/handlers/sites.py",
+    "find": "            \"- the create tools take no pocket id: each one creates a NEW pocket \"",
+    "replace": "            \"- apply the change with `mcp__pocketpaw_sites_manager__create_html_site` \"",
+    "tests": [
+      "tests/cloud/surface/test_sites_handler.py::test_html_refine_admits_it_has_no_edit_tool"
+    ]
+  },
+  {
+    "label": "publish is described as synchronous on every engine — react's queued build gets reported as a live url (empty on a first publish, the PREVIOUS deploy on a re-publish)",
+    "file": "ee/pocketpaw_ee/cloud/surface/handlers/sites.py",
+    "find": "        return build_runs_async(engine)",
+    "replace": "        return False",
+    "tests": [
+      "tests/cloud/surface/test_sites_handler.py::test_react_refine_does_not_promise_a_live_url_on_publish"
+    ]
+  },
+  {
+    "label": "the engine lookup's tenancy guard is dropped — a pocket stamped from another workspace picks the edit tool for this chat",
+    "file": "ee/pocketpaw_ee/cloud/surface/handlers/sites.py",
+    "find": "    if pocket.get(\"workspace\") != workspace_id:",
+    "replace": "    if False:",
+    "tests": [
+      "tests/cloud/surface/test_sites_handler.py::test_refine_does_not_read_an_engine_from_another_workspace"
+    ]
+  },
+  {
+    "label": "an unreadable pocket guesses ripple instead of admitting it cannot tell — the agent is handed an edit tool that will reject the pocket",
+    "file": "ee/pocketpaw_ee/cloud/surface/handlers/sites.py",
+    "find": "            engine = await _refine_engine(meta.pocket_id, user_id, workspace_id)",
+    "replace": "            engine = await _refine_engine(meta.pocket_id, user_id, workspace_id) or \"ripple\"",
+    "tests": [
+      "tests/cloud/surface/test_sites_handler.py::test_refine_on_an_unreadable_pocket_commands_no_edit_tool"
+    ]
+  },
+  {
+    "label": "the per-engine rules block is dropped from the render — every branch loses the funnel, real-copy, anchor-CTA and flat-form rules",
+    "file": "ee/pocketpaw_ee/cloud/surface/handlers/sites.py",
+    "find": "        f\"{rules}\"",
+    "replace": "        \"\"",
+    "tests": [
+      "tests/cloud/surface/test_sites_handler.py::test_every_refine_branch_keeps_what_transfers"
+    ]
+  },
+  {
+    "label": "the ripple branch loses a widget rule — the fork silently rewrote the one engine that was already correct",
+    "file": "ee/pocketpaw_ee/cloud/surface/handlers/sites.py",
+    "find": "            \"2. `pricing-table` uses `tiers` (never `plans`/`columns`).\\n\"",
+    "replace": "            \"\"",
+    "tests": [
+      "tests/cloud/surface/test_sites_handler.py::test_ripple_refine_is_unchanged_apart_from_the_publish_claim"
+    ]
+  },
+  {
+    "label": "refine answers a meta key again — two engines' instructions hash alike, so a cache keyed on it serves one site's prompt for another's engine",
+    "file": "ee/pocketpaw_ee/cloud/surface/handlers/sites.py",
+    "find": "                cache_key=content_key(\"sites\", refine_text),",
+    "replace": "                cache_key=meta_key(\"sites\", meta.pocket_id),",
+    "tests": [
+      "tests/cloud/surface/test_sites_handler.py::test_refine_cache_key_is_the_rendered_digest"
+    ]
+  },
+  {
+    "label": "the svelte branch calls its staged draft a publish — the agent tells the user a change is live that nothing has built",
+    "file": "ee/pocketpaw_ee/cloud/surface/handlers/sites.py",
+    "find": "            \"THE EDIT IS A DRAFT PREVIEW, NOT A DEPLOY. The tool returns \"",
+    "replace": "            \"THE EDIT REPUBLISHES THE SITE. The tool returns \"",
+    "tests": [
+      "tests/cloud/surface/test_sites_handler.py::test_svelte_refine_names_its_own_tool_and_calls_the_edit_a_draft"
+    ]
+  },
+  {
+    "label": "a source-map branch inherits the ripple widget rules again (the original bug: five rules about widget shapes on a page with no widgets)",
+    "file": "ee/pocketpaw_ee/cloud/surface/handlers/sites.py",
+    "find": "    \"form, and never replace it with a widget that does.\\n\"",
+    "replace": "    \"form. Keep the 5 static-site (SSR) rules: `pricing-table` uses `tiers`.\\n\"",
+    "tests": [
+      "tests/cloud/surface/test_sites_handler.py::test_source_map_refine_drops_the_ripple_widget_rules"
+    ]
+  },
+  {
+    "label": "the publish step gates 'it is live' on `deployed` instead of `is_live` — a rebuild keeps the previous deploy's true `deployed`, so the agent calls the pre-change page live",
+    "file": "ee/pocketpaw_ee/cloud/surface/handlers/sites.py",
+    "find": "        \"`url` only when `is_live` is true. Never report a site as live off \"",
+    "replace": "        \"`url` whenever `deployed` is true. A rebuild keeps \"",
+    "tests": [
+      "tests/cloud/surface/test_sites_handler.py::test_react_refine_does_not_promise_a_live_url_on_publish",
+      "tests/cloud/surface/test_sites_handler.py::test_ripple_refine_is_unchanged_apart_from_the_publish_claim"
+    ]
+  },
+  {
+    "label": "the async branch stops naming the build-status tool, so nothing can ever tell the agent how a react build ended",
+    "file": "ee/pocketpaw_ee/cloud/surface/handlers/sites.py",
+    "find": "        \"`mcp__pocketpaw_sites_manager__get_site_build_status` with pocket_id \"",
+    "replace": "        \"the site's build status in the app with pocket_id \"",
+    "tests": [
+      "tests/cloud/surface/test_sites_handler.py::test_react_refine_does_not_promise_a_live_url_on_publish"
+    ]
+  },
+  {
+    "label": "the write scope is retyped as prose instead of read from react_paths.py, dropping paw-prerender.mjs — the agent writes it, the tool rejects it, and the prompt never said so",
+    "file": "ee/pocketpaw_ee/cloud/surface/handlers/sites.py",
+    "find": "    reserved = \", \".join(f\"`{path}`\" for path in REACT_RESERVED_FILES)",
+    "replace": "    reserved = \"`index.html`, `package.json`, `vite.config.ts`\"",
+    "tests": [
+      "tests/cloud/surface/test_sites_handler.py::test_react_refine_states_the_write_scope_the_tool_enforces"
+    ]
+  }
+]


### PR DESCRIPTION
Rebased onto `dev` (now at #1920), so nothing here depends on an unmerged branch. **Three commits, deliberately splittable:**

| commit | what | drop it? |
|---|---|---|
| `f19b8fe1` | the 12 concierge tests that never adapted to `SurfacePreamble` | no — the gate is dead without it |
| `85a21c65` | the refine engine fork (the actual fix) | no |
| `71e08728` | the home-grid assertion that stopped being true | **yes, cleanly** — `git rebase --onto HEAD~1 HEAD`. See the last section. |

## The defect

`_refine_preamble` is the system prompt for the per-site chat at `/sites/[siteId]` — the surface where a user asks for a change to a site that already exists. It was written for ripple and shipped to all four engines. On a react, html or svelte site it was wrong four ways, and every one of them was silent.

**It commanded `mcp__pocketpaw_pocket_specialist__edit`.** That tool merges a rippleSpec, and only a ripple pocket has one; the other three carry a `source` map. The tool *is* reachable here (`pocketpaw_pocket_specialist` rides `ALWAYS_ALLOWED_MCP_SERVERS`), so this is the "naming an existing-but-wrong tool is the same defect" half of CLAUDE.md's rule, and it fails the way that rule describes: the model does not raise, it improvises, and the improvisation reads like a normal reply.

**It asserted the page "renders STATICALLY (no JavaScript runs for the visitor)".** React sites ship a hydrating client bundle by default (`sites_keep_client_bundle_default`), so that reads as a ban on interactivity the site can actually run.

**It said "the site auto-publishes from its source pocket".** Nothing auto-publishes. Publishing is a tool call that deploys to the public edge and on a paid tier can open a checkout — which is why every create tool stops at a draft.

**Then five SSR rules about ripple widget shapes** — `pricing-table` uses `tiers`, never the `accordion` widget, never `form`/`newsletter` — to an agent editing markup that has no widgets in it. Following them means inventing a catalog that isn't there.

## The engine comes from the pocket, not from `meta`

This is the part that decides whether the fix does anything, and it is where the obvious implementation quietly fails.

`meta.engine` is a **create-time** hint set by the /sites gallery's preset picker. The refine surface never sends it: `paw-enterprise/src/routes/sites/[siteId]/+page.svelte:1693` stamps `site_id`, `pocket_id`, `focus_node_id`, `mode`. The backend agrees in its own words — `SurfaceMeta.engine`'s comment reads *"Does not affect the refine branch (keyed on `pocket_id`), which wins over engine"* — and `surface_registry._sites_profile` says it again.

So mirroring `_create_preamble`'s `(meta.engine or "html").lower()` would have put **every** refine turn on the html default: a regression for ripple, no fix for react, and a green suite either way. #1917 shipped exactly that shape and its own docstring records the consequence.

Refine now resolves the engine off its **source pocket** through `sites/engines.py::normalize_engine` — the same value publish branches on, and its legacy `ripple` default is exactly the branch a pre-field pocket has always had — with the workspace-mismatch guard `handlers/pocket.py::_load_pocket` already uses. Refine therefore reads live state, so it answers `content_key` instead of `meta_key`, per that helper's own rule. Create and chat are untouched. A failed read logs the pocket id at WARNING/DEBUG and renders a branch labelled `engine="unknown"` whose first words are "could not be determined", so a degrade cannot be misread in a transcript as the agent being vague.

The alternative was a one-line stamp in paw-enterprise. Not taken: cross-repo coupling for a value the backend can derive, and wrong-until-deployed in the meantime.

## Per branch, only what is true for that engine

| engine | edit path | what replaced the static claim | publish |
|---|---|---|---|
| **ripple** | `pocket_specialist__edit`, unchanged, with its five widget rules and the Tier-0 list | unchanged — it was always right here | inline; gate on `is_live` |
| **svelte** | `edit_svelte_component`, both edit shapes, and that the edit is a **draft preview**, not live | prerendered; a section must look finished in returned markup, never set only in `onMount` | inline; gate on `is_live` |
| **react** | `edit_react_component`, write scope, `create=true` for a new section | prerendered by `react-dom/server` **and** hydrating, plus the full prerender contract as `pocketpaw-create-react-site/SKILL.md` states it | **queued** — `get_site_build_status` |
| **html** | none, stated plainly | the files in the source map are the page | n/a — nothing was written |
| **unknown** | none; read the pocket first | — | n/a |

**On svelte, the precise claim is live-versus-preview, not build-versus-no-build.** `edit_svelte_component` does call `publish_pocket`, so a real build, the workerd smoke gate and the source rollback all run; what it does not do is go live. It returns `status:"draft"` / `is_live:false` with a `preview_url` and tells the user to click Submit for review. (The mcp server's module header still says "and republishes", which is misleading rather than merely stale — not touched here, it is another agent's file.)

**html has no chat edit tool, and the branch says so rather than papering over it.** `create_html_site` takes no `pocket_id` and mints a new pocket, so calling it to "apply" an edit leaves the user with a second, orphaned site. `edit_svelte_component`'s service guard is svelte-only by design ("html has no per-component model — it edits by uid splice (HE-9), not here"), and that uid-splice path (`apply_leaf_edits`) is a REST route for the native editor and svelte-gated too. So the branch does the useful half — read the current source with `get_pocket`, work out the change, hand back the finished replacement markup with its path — and says plainly that applying it from chat is not wired up. html is the **default** create engine, so this is the most common site type; filed as its own task.

**The write scope is rendered from `ee/pocketpaw_ee/sites/react_paths.py`**, not retyped beside it — `REACT_RESERVED_FILES`, `REACT_RESERVED_PREFIX`, `REACT_AUTHORABLE_PREFIXES`, the same constants `edit_react_component` checks against. A fifth reserved file therefore lands in this instruction in the same commit instead of drifting into a stale list. The prompt also states that paths are normalized before the check, so `./` and `..` are not loopholes an agent thinks it found.

**Publishing gates on `is_live` (#1920) on every branch.** That field is true only when there is a non-empty `url` **and** `deployed` **and** no build in flight. `deployed` and a non-empty `url` each look like the answer and are not: a rebuild deliberately keeps the previous deploy's values so a working site is not reported as down mid-build, which is precisely the state where they lie. The response's `message` already states the conclusion, so the prompt says relay it. Statuses are deliberately **not** enumerated — the wire contract treats an unrecognized `build_status` as in-progress, so a closed list would go stale in the unsafe direction. On an async engine the branch adds that publish returns *before* the build starts and names `get_site_build_status` as the only way to learn the outcome, with `build_reason` relayed on a failure. Which engines are async comes from `build_runs_async`, not a hardcoded `react`, so static svelte corrects itself if #1913 flips.

**Unchanged on every branch:** ASK-DON'T-ASSUME and the `ask-user-questions` widget (refine keeps `ripple_mode="on"` on all engines, so that mechanism is real here), the funnel, real-copy-only, anchor CTAs, the flat native lead form, the concierge block, and the `pocket_id` threaded into whatever tool the branch names.

## Superseding #1917's gate, not reverting it

#1917 added `_react_refine_preamble` to this same function, gated on `(meta.engine or "").lower() == "react"`, and documented the caveat itself: *"this branch only renders when the per-site chat client actually stamps `engine="react"` ... Sending the engine from the /sites/[siteId] client is the follow-up that finishes this."* This is that follow-up, done from the backend instead. Its branch is **folded into** the fork rather than left beside it — two react refine preambles with one of them dead is the drift a fork exists to prevent, and the failure mode is sharp: the moment anyone adds the client stamp, the inert gate starts firing and competes with the pocket-resolved one.

Everything load-bearing carries over: the tool with `pocket_id` / `component_path`, `edits` preferred over a whole-file rewrite, the two-call `create=true` shape, the reserved shell, the dependency list, the prerender rule, the draft framing. Three changes:

1. **Ask mechanism** — it called `mcp__pocketpaw_ask__ask_user`; refine holds `ripple_mode="on"` on every engine, so this surface renders the `ask-user-questions` widget. The chips are the create-side mechanism where ripple is off.
2. **Prohibition wording** — it named `pocket_specialist__edit` inside "do NOT call". Defensible (the agent *has* the tool, so silence leaves it a plausible move), but `_create_preamble`'s react branch forbids "the pocket specialist" by concept without the id, and matching that keeps one style. The prohibition is still there and still asserted; only the id is gone. Flagged as a judgment call, not a correction — say the word and it goes back.
3. **Publish** — "relay the real result" is true in general and insufficient for react, where the build is queued.

Its create-side change is untouched. Its two refine tests are retargeted through a seeded pocket: as written they passed against a branch no real turn reaches, which is the same trap the fork's own tests are shaped around. `test_non_react_refine_is_unchanged` is replaced by `test_ripple_refine_keeps_the_rippleSpec_merge` — it asserted that a **svelte** refine also gets the rippleSpec merge, true only because the fork it tested never fired.

## Tests

`tests/cloud/surface`, same 166 → 190 collected files, run to a log rather than through a pipe:

| tree | result |
|---|---|
| `origin/dev` (`8aac4378`) | **13 failed / 153 passed** |
| after `f19b8fe1` (the 12) | **1 failed / 165 passed** |
| branch tip | **0 failed / 190 passed** |

`diff` of the sorted `FAILED` lines, baseline vs tip: 13 removed, **0 added**. Also green: `lint-imports` 34/34 contracts (this PR adds a module-level `cloud → sites` import, which the existing `worker.py` / `provision_site.py` imports already establish), `ruff check`, `ruff format --check`, and `test_entity_id_contract` 9/9.

The fork's resolution tests seed a real site pocket through the pockets service and go through `build_preamble`, because a test that passes an engine into `_refine_preamble` directly also passes against the `meta.engine` implementation that never fires. `_refine_meta()` keeps the real wire shape in one place so that cannot drift back. One new check derives every registered MCP tool id from the server schemas — reaching the pocket specialist, whose server is built outside the `mcp_servers` package, and asserting that it did — and requires these branches to name nothing else. That is the gate `tests/test_prompt_names_only_real_tools.py` provides for the inline ripple prompt and states outright it does not provide here.

**Mutations: `tests/mutations/sites_refine_engine_fork.json`, 14, all caught.** Two escaped first, and both were faults in the tests rather than curiosities:

- retitling svelte's draft block "THE EDIT REPUBLISHES THE SITE" survived because the payload still mentions `status:"draft"` and an `or` across two assertions kept it green;
- rewriting the `is_live` gate's opening sentence survived because every asserted fragment was still alive further down. That test now pins the operative instruction (`"url only when is_live is true"`) instead of the presence of a field name.

`react_edit_lane.json`'s refine anchor pointed at the dispatch line this removes, and `react_authoring.json`'s first anchor at the engine-list line it replaces — both were rotting `--validate` (and CI's `mutation-anchors` job). Repointed, keeping the harm each label describes, and both plans re-run: **react_edit_lane 22/22, react_authoring 11/11**. `--validate` is clean across all 28 plans / 346 anchors.

## The third commit, and the ruling behind it

The 13th baseline failure was `test_home_handler_empty_workspace_returns_minimal_preamble`. Asked which of two readings the code supports, the answer is **intended provisioning, stale fixture**, and the evidence is a passing test with its own explanation: `tests/cloud/test_home_pocket.py` asserts `len(pocket["widgets"]) == 1` and `widgets[0]["name"] == "Intent of the Day"` under the comment *"Only `auto_seed=True` widgets (currently just Intent of the Day) are pre-pinned on first provision."*

What the auto-seed did leave behind is **five** stale assertions that count widgets as if a fresh grid were empty — this one plus four in `test_home_pocket.py` itself (`test_native_widget_round_trips_through_add_widget`, `test_chart_widget_round_trips_through_add_widget` and their agent twins) which add one widget and assert `len == 1`, now getting 2. Those four are outside `tests/cloud/surface` and are untouched here; they are the better evidence that this was an incomplete migration rather than a behaviour question.

The fix keeps the coverage rather than moving the number: the point of the test is the **empty branch** (`<pinned-widgets count="0">` and its "(empty)" marker), that state is still reachable by unpinning, so the test unpins and asserts exactly what it always did. Changing the expectation to `count="1"` would have deleted the only coverage of that branch while looking like a fix. A second test covers the state a real new user is in, which nothing asserted.

That second test also **records a live defect** rather than tiptoeing around it: every pinned row renders `id=?`, because `format_widget_line` reads `widget.id` while the wire dict carries `_id` (`pockets/dto.py::_widget_to_wire`) and `_AttrDict` answers a missing key with `None`. `update_widget` requires `widget_id`, so the home **and** pocket surfaces both name widgets the agent cannot address — CLAUDE.md's "Prompt rows must carry the id the tools take" reintroduced by a key-name mismatch. Neither existing gate can see it: the AST scan passes because the row does go through `entity_line`, and the cap test passes because its fixture is built from objects that have a real `.id`. Filed as its own task; the assertion here states what ships so the fix has something to flip.

If you would rather see the red: `git rebase --onto HEAD~1 HEAD` drops that commit and nothing else moves.

## Found, not fixed

- **`mutate.py --validate` and the sweep disagree about multi-line anchors.** `validate_plans` reads via `read_text` (universal newlines) while the sweep reads `read_bytes().decode("utf-8")`, so on a CRLF file an anchor containing `\n` validates and then fails to apply — the sweep aborts having applied nothing. `anchor_problem`'s docstring says the two "must never disagree about what an offender IS". Worked around by keeping every anchor single-line.
- **`git stash` is not worktree-safe here** — the stash stack is per-repo, so a `pop` from one worktree can take a sibling agent's entry. Hit while verifying a baseline; the pop conflicted, git kept the entry, and `reset --hard` restored the tree. Nothing lost, but the baseline verification below uses `git checkout <ref> -- .` instead.
- `agent/mcp_servers/sites.py`'s module header on `edit_svelte_component` ("and republishes"); `_frontend_preamble` carries the same two false claims but is unwired into the live dispatch and pinned byte-for-byte by its tests; the ripple branch's static claim is imprecise for a `pattern="dynamic"` site (pre-existing, left byte-for-byte deliberately).
