### PR TITLE
The publish tool said a site was live when it was still queued

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2,6 +2,15 @@
 docs/api-reference.md — Hand-maintained reference for cloud REST endpoints
 that are not covered by the per-endpoint Mintlify pages under docs/api/.
 
+Updated: 2026-08-11 (feat/sites-react-edit-lane, RX-4) — documented the build-lane
+fields now on the `publish` tool response and the new read-only
+`get_site_build_status` tool, in the same MCP section. Both are recorded here
+because the *reason* they exist is not visible from their field lists: `url` and
+`deployed` are individually insufficient to answer "is this site live", and on
+react they actively mislead (a first publish returns `url: ""`, a re-publish
+returns the previous deploy's url). Anyone reading only the field names would
+reasonably use `url` directly, which is the defect.
+
 Updated: 2026-08-11 (feat/sites-react-edit-lane, RX-3) — added the "Sites —
 Agent Editing Tools (in-process MCP)" section documenting `edit_react_component`
 and the per-engine split that decides which editing tool a site gets. This is
@@ -1395,6 +1404,57 @@ Errors (relayed to the agent as `is_error` with the code, so it can fix and retr
 Every write goes through `pockets_service.set_react_source_file`, which emits
 `PocketUpdated` and records a draft `ArtifactVersion` snapshotting the full edited
 source map — so an edit is a reviewable Branch draft a later publish promotes.
+
+### Build state on the `publish` response
+
+`publish` returns `{ok, message, site: {...}}`. The `site` object carries the five
+original keys (`id`, `pocket_id`, `name`, `url`, `deployed`) plus the build lane's
+state:
+
+| Key | Notes |
+|-----|-------|
+| `build_status` | `none` \| `queued` \| `building` \| `built` \| `failed`. Passed through **verbatim** — an unrecognised value is never normalised. |
+| `build_reason` | `"<rung>:<cause>"` explaining how the build settled. `null` until one does. A `failed` status without this is unactionable. |
+| `build_job_id` | Handle for the queued build. Persisted, so it survives a reload. |
+| `build_in_progress` | Derived. `true` while a build is running, **and for any unrecognised `build_status`**. |
+| `is_live` | Derived. The only field to gate "show the user the url" on. |
+
+`is_live` requires a non-empty `url` **and** `deployed` **and** no build in flight,
+because each is individually insufficient. This matters on **react**, the only engine
+where `build_runs_async(engine)` is true:
+
+- On a **first** publish, `_enqueue_static_build` creates the Site doc with `url: ""`
+  and `deployed: false`. That is honest — nothing is serving yet, and the worker flips
+  both when the deploy succeeds — but it means `url` alone is an empty string.
+- On a **re-publish**, `url` and `deployed` deliberately keep the *previous* deploy's
+  values so a rebuild never reports a working site as down. Both say "live" while the
+  url serves the pre-change page.
+- `build_status` alone cannot tell a never-built pocket (`none`) from a finished one.
+
+`build_in_progress` reads an unknown status as in-progress, which is the wire contract
+and the deliberate **opposite** of `build_state.should_enqueue`, which treats an
+unknown status as terminal. Both are correct on their own axis: a redundant build costs
+one sandbox, while a spurious "your site is live" costs the user's trust.
+
+The derivation lives in `sites.service.build_wire_state` and is shared with the status
+tool below, so the two surfaces cannot disagree about whether a site is live.
+
+### `get_site_build_status`
+
+Read-only. Takes `pocket_id` and returns `{ok, message, pocket_id, site_id, name,
+published, url, deployed, build_status, build_reason, build_job_id, build_in_progress,
+is_live}`.
+
+This exists because a react publish is **asynchronous**: the `publish` call returns
+before the build starts, so its response can never report how the build ended. Without
+a later read, `queued` is a dead end — the agent learns a build was enqueued and has no
+way to discover it finished.
+
+A pocket with no Site doc returns `published: false` rather than an error; from the
+caller's side "this was never published" is the useful answer, and it is correct whether
+the pocket has no site or does not exist. The read resolves the canonical Site doc
+through `canonical_site_for_pocket`, which is tenant-scoped on the workspace — that
+filter is the access check, and there is no plan gate because nothing is mutated.
 
 ## Fabric — Transform Mappings (source→Fabric ingest)
 

--- a/ee/pocketpaw_ee/agent/mcp_servers/sites.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/sites.py
@@ -30,6 +30,36 @@
 # automatically. Opt-in — the default marketing brain stays create_landing_site
 # (ripple); the default flip to html is HE-12.
 #
+# Updated 2026-08-11 (RX-4 — the publish response tells the agent whether the site is
+# actually live): ``_publish_handler``'s success body hand-built five keys (id /
+# pocket_id / name / url / deployed) while ``_to_response`` — the wire the FRONTEND
+# polls — also carries ``build_status`` / ``build_reason`` / ``build_job_id``. The
+# agent got none of the three, and react is the one engine where that breaks the happy
+# path, because it is the only engine with ``build_runs_async(engine) is True``:
+#
+#   * FIRST publish — ``_enqueue_static_build`` creates the Site doc with ``url=""``
+#     and ``deployed=False``, honestly (nothing is serving yet; the worker flips both
+#     on success). Meanwhile ``pocketpaw-create-react-site`` STEP 4 tells the agent to
+#     "show the user the returned url". So it showed an empty string, or invented one.
+#   * RE-publish — ``url`` / ``deployed`` deliberately KEEP the previous deploy's
+#     values so a rebuild never reports a working site as down. Right for the
+#     frontend, which reads ``build_status`` beside them; for the agent it meant
+#     reporting the OLD url as though the edit were already live.
+#
+# So the body now carries the three raw fields VERBATIM (never normalised — see
+# ``_to_response``), plus ``build_in_progress`` and ``is_live``, plus a ``message``
+# stating the conclusion in prose. The derivation lives in
+# ``sites.service.build_wire_state`` and is SHARED with the new status tool, because
+# the two surfaces disagreeing about whether a site is live would be worse than either
+# being wrong alone. A boolean is not enough on its own here: the original defect was
+# narration, not data, so the message exists to be relayed.
+#
+# Also added the READ-ONLY ``get_site_build_status`` tool. Without it the queued state
+# is a dead end — an async publish returns before the build starts, so the agent could
+# learn a build was enqueued and never find out how it ended. It rides
+# ``SITES_TOOL_IDS`` like every other tool here; the /sites allow-list is a hard
+# whitelist that filters an absent id out silently.
+#
 # Updated 2026-08-11 (RX-3 — the react track gets an EDIT lane): the
 # ``edit_react_component`` tool also registers on this SAME server (built via the
 # factory in sites_create.py), so create → publish → edit sit together for react
@@ -115,6 +145,12 @@ CREATE_REACT_SITE_TOOL_ID = f"mcp__{SERVER_NAME}__create_react_site"
 # server (see sites_create.py). It writes ONE file of a react site's source map as a
 # reviewable DRAFT; it does NOT publish and does NOT enqueue a build.
 EDIT_REACT_COMPONENT_TOOL_ID = f"mcp__{SERVER_NAME}__edit_react_component"
+# The READ-ONLY build-status tool (RX-4). It exists because react publishes are
+# ASYNC: ``publish`` returns before the build starts, so without a way to ask again
+# on a later turn the agent learns a build was queued and can never discover it
+# finished. Must ride SITES_TOOL_IDS like the rest — the /sites allow-list is a hard
+# whitelist and filters an absent id out with no error.
+GET_SITE_BUILD_STATUS_TOOL_ID = f"mcp__{SERVER_NAME}__get_site_build_status"
 
 SITES_TOOL_IDS = (
     PUBLISH_TOOL_ID,
@@ -125,6 +161,7 @@ SITES_TOOL_IDS = (
     CREATE_HTML_SITE_TOOL_ID,
     CREATE_REACT_SITE_TOOL_ID,
     EDIT_REACT_COMPONENT_TOOL_ID,
+    GET_SITE_BUILD_STATUS_TOOL_ID,
 )
 
 
@@ -212,18 +249,138 @@ async def _publish_handler(args: dict) -> dict:
         logger.warning("sites publish failed", exc_info=True)
         return _error_response(f"publish failed: {exc}")
 
+    # RX-4 — the build lane's state rides the response. Without it this body was five
+    # keys (id / pocket_id / name / url / deployed), and on the react happy path that
+    # is actively misleading in two different ways, because react is the only engine
+    # with ``build_runs_async(engine) is True``:
+    #
+    #   * FIRST publish — ``_enqueue_static_build`` creates the Site doc with
+    #     ``url=""`` and ``deployed=False``, honestly, because nothing is serving yet.
+    #     The agent was handed an empty string while ``pocketpaw-create-react-site``
+    #     STEP 4 tells it to "show the user the returned url", so it showed nothing or
+    #     invented something.
+    #   * RE-publish — ``url`` and ``deployed`` deliberately keep the PREVIOUS
+    #     deploy's values so a rebuild never reports a working site as down. Correct
+    #     for the frontend, which reads ``build_status`` beside them. For an agent
+    #     that could not see ``build_status``, it meant reporting the OLD url as
+    #     though the change were already live.
+    #
+    # ``build_wire_state`` owns the derivation (shared with get_site_build_status, so
+    # the two can never disagree) and passes ``build_status`` through VERBATIM.
+    # ``is_live`` is the field to gate "show the user this url" on; ``message`` says
+    # the same thing in prose, because a boolean the agent does not look at is not a
+    # fix — the prompt-level failure here was narration, not data.
+    state = sites_service.build_wire_state(doc)
+    if state["is_live"]:
+        message = "The site is live. Show the user the `url`."
+    elif state["build_in_progress"]:
+        message = (
+            "The build is not finished, so the site is NOT live yet and `url` is "
+            "either empty or still serving the PREVIOUS version. Do NOT show the "
+            "user a url and do NOT say it is live. Tell them the build is running "
+            "and that you can check again in a moment with "
+            "`get_site_build_status`."
+        )
+    elif state["build_status"] == "failed":
+        message = (
+            "The build FAILED, so the site is not live. Relay `build_reason` to the "
+            "user rather than a url, and offer to fix the page and publish again."
+        )
+    else:
+        message = (
+            "The publish was accepted but nothing is serving yet. Do NOT show a url "
+            "or say the site is live; check `get_site_build_status` before "
+            "reporting one."
+        )
     return _success_response(
         {
             "ok": True,
+            "message": message,
             "site": {
                 "id": str(doc.id),
                 "pocket_id": doc.pocket_id,
                 "name": doc.name,
-                "url": doc.url,
-                "deployed": doc.deployed,
+                **state,
             },
         }
     )
+
+
+async def _get_site_build_status_handler(args: dict) -> dict:
+    """MCP handler for ``sites_manager__get_site_build_status`` (RX-4).
+
+    READ-ONLY. The answer to "is it up yet?" on a turn after the publish, and the
+    reason the queued state a react publish returns is not a dead end: with
+    ``build_runs_async("react") is True`` the publish call returns before the build
+    starts, so without this the agent could learn a build was enqueued and then never
+    discover it finished.
+
+    Delegates to ``sites_service.site_build_status``, which resolves the canonical
+    Site doc tenant-scoped on the workspace and derives the same fields the widened
+    publish response carries (one shared derivation, so the two cannot disagree).
+    A pocket that was never published reports ``published=False`` rather than an
+    error — from the agent's side that is the useful answer.
+    """
+    workspace_id, user_id = _identity()
+    if not workspace_id or not user_id:
+        return _error_response(
+            "get_site_build_status requires workspace and user context (call from a "
+            "cloud chat session)."
+        )
+
+    record_tool_call(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        tool_server="pocketpaw_sites_manager",
+        tool_name="_get_site_build_status",
+        status="ok",
+        ok=True,
+    )
+
+    pocket_id = args.get("pocket_id")
+    if not isinstance(pocket_id, str) or not pocket_id:
+        return _error_response(
+            "get_site_build_status requires a `pocket_id` — the id of the site "
+            "pocket whose build you are checking."
+        )
+
+    from pocketpaw_ee.cloud._core.errors import CloudError
+    from pocketpaw_ee.sites import service as sites_service
+
+    try:
+        state = await sites_service.site_build_status(
+            workspace_id=workspace_id, pocket_id=pocket_id
+        )
+    except CloudError as exc:
+        return _error_response(f"{exc.code}: {exc.message}")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("get_site_build_status failed", exc_info=True)
+        return _error_response(f"could not read the build status: {exc}")
+
+    if not state["published"]:
+        message = (
+            "This site has never been published, so there is no build and nothing "
+            "is live. Offer to publish it."
+        )
+    elif state["is_live"]:
+        message = "The build finished and the site is live. Show the user the `url`."
+    elif state["build_in_progress"]:
+        message = (
+            "The build is still running, so the site is NOT live at this version "
+            "yet. Do NOT show a url as if it were current. Tell the user it is "
+            "still building and offer to check again."
+        )
+    elif state["build_status"] == "failed":
+        message = (
+            "The build FAILED. Relay `build_reason` to the user, not a url, and "
+            "offer to fix the page and publish again."
+        )
+    else:
+        message = (
+            "There is no build in flight and the site is not serving a current "
+            "deploy. Do NOT report it as live."
+        )
+    return _success_response({"ok": True, "message": message, **state})
 
 
 def build_sites_manager_server() -> tuple[str, Any] | None:
@@ -284,6 +441,47 @@ def build_sites_manager_server() -> tuple[str, Any] | None:
     async def publish(args):  # type: ignore[no-untyped-def]
         return await _publish_handler(args)
 
+    @tool(
+        "get_site_build_status",
+        (
+            "Check whether a published Paw Site's build has finished and whether the "
+            "site is LIVE. READ-ONLY — it changes nothing. Call this when the user "
+            "asks 'is it up yet?', 'did it deploy?', 'is my site live?', or when a "
+            "previous `publish` came back with `build_in_progress: true` and you now "
+            "need to know the outcome. This is the ONLY way to find out: a react "
+            "site's build runs asynchronously, so `publish` returns BEFORE the build "
+            "starts and its response can never tell you how the build ended.\n"
+            "Args: `pocket_id` (required — the site pocket). Returns {ok, message, "
+            "pocket_id, site_id, name, published, url, deployed, build_status, "
+            "build_reason, build_job_id, build_in_progress, is_live}.\n"
+            "HOW TO READ IT: gate everything on `is_live`. Show the user the `url` "
+            "ONLY when `is_live` is true. When `build_in_progress` is true the build "
+            "is still running and `url` is either empty or still serving the "
+            "PREVIOUS version — say it is still building, do NOT show a url, and do "
+            "NOT say it is live. When `build_status` is 'failed', relay "
+            "`build_reason` and offer to fix the page and publish again. When "
+            "`published` is false the site has never been published at all. Relay "
+            "the `message` — it already states the correct conclusion. Never invent "
+            "a url, and never report a site as live off `deployed` or a non-empty "
+            "`url` alone: a rebuild deliberately keeps the previous deploy's values "
+            "so a working site is not reported as down mid-build."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "pocket_id": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": ("Id of the site pocket whose build status you are checking."),
+                },
+            },
+            "required": ["pocket_id"],
+            "additionalProperties": False,
+        },
+    )
+    async def get_site_build_status(args):  # type: ignore[no-untyped-def]
+        return await _get_site_build_status_handler(args)
+
     # Register the deterministic landing-site create tool on this SAME server.
     # The SKILL flow is: produce the `content` copy → create_landing_site →
     # publish, so the two hops sit on one allowlisted server. Built here (not as a
@@ -330,6 +528,7 @@ def build_sites_manager_server() -> tuple[str, Any] | None:
         version="1.0.0",
         tools=[
             publish,
+            get_site_build_status,
             create_landing_site,
             create_svelte_site,
             edit_svelte_component,
@@ -350,6 +549,7 @@ __all__ = [
     "CREATE_SVELTE_SITE_TOOL_ID",
     "EDIT_REACT_COMPONENT_TOOL_ID",
     "EDIT_SVELTE_COMPONENT_TOOL_ID",
+    "GET_SITE_BUILD_STATUS_TOOL_ID",
     "PUBLISH_TOOL_ID",
     "SERVER_NAME",
     "SITES_TOOL_IDS",

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,22 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-08-11 (RX-4 — the agent can tell whether a site is actually live): added
+# ``build_wire_state`` (pure) and ``site_build_status`` (a read). ``_to_response``
+# already gave the frontend ``build_status`` / ``build_reason`` / ``build_job_id``, and
+# the frontend polls them next to ``url`` knowing a site can be live and simultaneously
+# mid-rebuild. The chat agent had neither the fields nor that knowledge, and on react —
+# the only engine where ``build_runs_async`` is True — that meant a first publish handed
+# it ``url=""`` and a re-publish handed it the PREVIOUS deploy's url, both reported as
+# success. ``build_wire_state`` derives ``build_in_progress`` and ``is_live`` from the
+# row once, so the publish response and the status tool cannot disagree; the raw status
+# still passes through verbatim. ``build_in_progress`` reads an unknown status as IN
+# PROGRESS, deliberately the OPPOSITE of ``build_state.should_enqueue`` (a redundant
+# build costs one sandbox; a spurious "your site is live" costs trust), and is derived
+# from ``TERMINAL_STATUSES`` so a new state defaults to in-progress here for free.
+# ``site_build_status`` exists because an async publish returns before the build starts:
+# without a later read, "queued" is a dead end.
+#
 # Updated 2026-08-11 (RX-3 — the react track gets an EDIT lane): added
 # ``edit_react_component``, the react peer of ``edit_svelte_component``. Until this
 # existed there was no way to change a react site: this module's edit entry points
@@ -3209,6 +3225,109 @@ async def _canonical_site_doc(workspace_id: str, pocket_id: str) -> _SiteDoc | N
     # Prefer the newest doc that carries a real url (the freshest live build);
     # fall back to the newest doc overall when none has one.
     return next((d for d in docs if d.url), docs[0])
+
+
+def build_wire_state(doc: _SiteDoc | None) -> dict[str, Any]:
+    """The build fields an AGENT-facing tool reports, derived in ONE place (RX-4).
+
+    ``_to_response`` already surfaces ``build_status`` / ``build_reason`` /
+    ``build_job_id`` to the frontend, which polls them alongside ``url`` and knows
+    that a site can be live and simultaneously mid-rebuild. The chat agent has no
+    such knowledge and cannot poll, so it needs the same three fields PLUS the
+    conclusion drawn from them. This function is that conclusion, and it lives here
+    rather than in the two calling handlers because the publish response and the
+    build-status tool disagreeing about whether a site is live is worse than either
+    being wrong on its own.
+
+    The three raw fields pass through VERBATIM, matching ``_to_response``: a
+    ``build_status`` this deploy predates must never be normalised against a known
+    set, because mapping it to "none" would tell a caller nothing is building about
+    a build that is running.
+
+    ``build_in_progress`` reads an unknown status as IN PROGRESS. That is the WIRE
+    direction and it is deliberately the OPPOSITE of ``build_state.should_enqueue``,
+    which treats an unknown status as terminal — both are right on their own axis
+    (see ``build_state``'s header: a redundant build costs one sandbox, while a
+    spurious "your site is live" costs the user's trust). Derived from
+    ``TERMINAL_STATUSES`` rather than from ``IN_FLIGHT_STATUSES`` so a state added
+    to the machine defaults to in-progress here without anyone remembering to
+    update this function.
+
+    ``is_live`` is the only field an agent should gate "show the user this url" on.
+    It requires a real url AND a successful deploy AND no build in flight, because
+    each of the three is individually insufficient:
+
+      * a FIRST async publish creates the Site doc with ``url=""`` and
+        ``deployed=False`` (``_enqueue_static_build`` — honest, nothing is serving
+        yet), so ``url`` alone is an empty string the agent would hand over;
+      * a RE-publish deliberately KEEPS the previous deploy's ``url`` and
+        ``deployed=True`` so a rebuild never reports a working site as down, so
+        those two alone say "live" while serving the pre-change page;
+      * ``build_status`` alone cannot tell a never-built pocket ("none") from a
+        finished one.
+
+    Pure and I/O-free, so it is directly unit-testable, and it takes ``None`` for a
+    pocket with no Site doc at all (never published) rather than making every caller
+    write the same empty shape.
+    """
+    from pocketpaw_ee.sites.build_state import TERMINAL_STATUSES
+
+    if doc is None:
+        return {
+            "url": "",
+            "deployed": False,
+            "build_status": "none",
+            "build_reason": None,
+            "build_job_id": None,
+            "build_in_progress": False,
+            "is_live": False,
+        }
+    status = getattr(doc, "build_status", "none")
+    in_progress = status != "none" and status not in TERMINAL_STATUSES
+    url = doc.url or ""
+    return {
+        "url": url,
+        "deployed": bool(doc.deployed),
+        "build_status": status,
+        "build_reason": getattr(doc, "build_reason", None),
+        "build_job_id": getattr(doc, "build_job_id", None),
+        "build_in_progress": in_progress,
+        "is_live": bool(url) and bool(doc.deployed) and not in_progress,
+    }
+
+
+async def site_build_status(*, workspace_id: str, pocket_id: str) -> dict[str, Any]:
+    """Read a pocket's current build + live state. READ-ONLY (RX-4).
+
+    The answer to "is it up yet?" on a turn AFTER the publish. Without it the queued
+    state a react publish returns is a dead end: the agent learns a build was
+    enqueued and then has no way to ever discover it finished, because
+    ``build_runs_async("react")`` means the publish call returned before the build
+    even started.
+
+    Resolves the ONE canonical Site doc for the pocket through
+    ``canonical_site_for_pocket``, which is tenant-scoped on ``workspace_id`` and
+    dedupe-aware — the same resolution ``pocket_status`` uses, so the two cannot
+    report different sites for one pocket.
+
+    A pocket with no Site doc returns ``published=False`` rather than raising. From
+    the agent's side "this was never published" is the useful answer and is correct
+    whether the pocket has no site or does not exist; the read cannot leak across
+    tenants either way, because the query is filtered on ``workspace``.
+
+    No plan gate: nothing is mutated, and a workspace that has lost the Sites
+    feature reading its own build state changes nothing it could not already see in
+    the /sites UI. The tenancy filter IS the access check here.
+    """
+    doc = await canonical_site_for_pocket(workspace_id, pocket_id)
+    state = build_wire_state(doc)
+    return {
+        "pocket_id": pocket_id,
+        "site_id": str(doc.id) if doc is not None else None,
+        "name": doc.name if doc is not None else "",
+        "published": doc is not None,
+        **state,
+    }
 
 
 async def canonical_site_for_pocket(workspace_id: str, pocket_id: str) -> _SiteDoc | None:

--- a/tests/ee/agent/test_sites_mcp_server/test_build_status_tool.py
+++ b/tests/ee/agent/test_sites_mcp_server/test_build_status_tool.py
@@ -1,0 +1,391 @@
+# tests/ee/agent/test_sites_mcp_server/test_build_status_tool.py
+# Created: 2026-08-11 (feat/sites-react-edit-lane, RX-4) — the AGENT-facing half of the
+# build-visibility fix. Two things under test:
+#
+#   1. ``_publish_handler``'s widened success body. It used to hand-build five keys
+#      (id / pocket_id / name / url / deployed) while ``_to_response`` — the wire the
+#      frontend polls — also carried ``build_status`` / ``build_reason`` /
+#      ``build_job_id``. On react (the only engine with ``build_runs_async`` True) that
+#      meant a first publish handed the agent ``url=""`` while the create skill told it
+#      to "show the user the returned url", and a re-publish handed it the PREVIOUS
+#      deploy's url as though the change were live.
+#   2. The new READ-ONLY ``get_site_build_status`` tool, which is the only way to learn
+#      how an async build ENDED — ``publish`` returns before the build starts.
+#
+# THE NARRATION IS THE FIX, not the data. A boolean the agent does not consult changes
+# nothing, so the assertions below check the ``message`` prose as strictly as the
+# fields: on a queued build it must NOT read as a live site, and it must point at the
+# status tool so the queued state is not a dead end.
+#
+# Registration gets its own tests because id-in-tuple and tool-registered are separate
+# facts and the /sites allow-list is a hard whitelist: an id missing from
+# ``SITES_TOOL_IDS`` is filtered out with NO error, and every handler-level test in this
+# file would still pass.
+"""Tests for the widened publish response and the get_site_build_status tool."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+
+class _Doc:
+    """The Site-doc fields the publish handler reads onto its response."""
+
+    def __init__(self, **kw) -> None:
+        self.id = kw.pop("id", "site_abc")
+        self.pocket_id = kw.pop("pocket_id", "pk1")
+        self.name = kw.pop("name", "Bright Smile")
+        self.url = kw.pop("url", "")
+        self.deployed = kw.pop("deployed", False)
+        for key in ("build_status", "build_reason", "build_job_id"):
+            if key in kw:
+                setattr(self, key, kw[key])
+
+
+def _body(envelope: dict) -> dict:
+    assert not envelope.get("is_error"), envelope
+    return json.loads(envelope["content"][0]["text"])
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+class TestRegistration:
+    def test_status_tool_id_is_on_the_shared_allowlist(self) -> None:
+        """The assertion that catches the whole class of bug: ``sites_allow`` is built
+        from ``SITES_TOOL_IDS`` and is a hard whitelist on /sites, so a tool absent from
+        the tuple never reaches the agent and errors nowhere."""
+        from pocketpaw_ee.agent.mcp_servers.sites import (
+            GET_SITE_BUILD_STATUS_TOOL_ID,
+            SITES_TOOL_IDS,
+        )
+
+        assert (
+            GET_SITE_BUILD_STATUS_TOOL_ID == "mcp__pocketpaw_sites_manager__get_site_build_status"
+        )
+        assert GET_SITE_BUILD_STATUS_TOOL_ID in SITES_TOOL_IDS
+
+    def test_provider_advertises_the_status_tool(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers.sites import GET_SITE_BUILD_STATUS_TOOL_ID
+        from pocketpaw_ee.extensions import CloudSitesMcpProvider
+
+        assert GET_SITE_BUILD_STATUS_TOOL_ID in CloudSitesMcpProvider().tool_ids()
+
+    def test_the_built_server_lists_the_status_tool(self) -> None:
+        """An id in the tuple with no tool behind it whitelists a name that never
+        answers, so the registration is checked separately from the constant."""
+        import asyncio
+
+        from mcp import types
+        from pocketpaw_ee.agent.mcp_servers.sites import build_sites_manager_server
+
+        built = build_sites_manager_server()
+        if built is None:
+            pytest.skip("claude_agent_sdk not installed")
+        _name, server = built
+        handler = server["instance"].request_handlers[types.ListToolsRequest]
+        listed = asyncio.run(handler(types.ListToolsRequest(method="tools/list")))
+        tool = next((t for t in listed.root.tools if t.name == "get_site_build_status"), None)
+        assert tool is not None, sorted(t.name for t in listed.root.tools)
+        assert (tool.inputSchema or {}).get("required") == ["pocket_id"]
+        # The description must gate on is_live, or the agent falls back to reading
+        # ``url``/``deployed`` directly, which is exactly the bug.
+        assert "is_live" in (tool.description or "")
+
+
+# ---------------------------------------------------------------------------
+# The widened publish response
+# ---------------------------------------------------------------------------
+
+
+class TestPublishResponseCarriesBuildState:
+    @pytest.mark.asyncio
+    async def test_a_live_publish_says_live_and_gives_the_url(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import sites as mcp
+
+        doc = _Doc(url="https://bright.paw.test/", deployed=True, build_status="built")
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch("pocketpaw_ee.sites.service.publish_pocket", new=AsyncMock(return_value=doc)),
+        ):
+            body = _body(await mcp._publish_handler({"pocket_id": "pk1"}))
+
+        assert body["site"]["is_live"] is True
+        assert body["site"]["url"] == "https://bright.paw.test/"
+        assert body["site"]["build_status"] == "built"
+        assert "live" in body["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_a_first_async_publish_does_not_read_as_a_live_site(self) -> None:
+        """The reported defect. The row is exactly what ``_enqueue_static_build`` inserts
+        on a first react publish: ``url=""``, ``deployed=False``, ``build_status="queued"``.
+
+        The old five-key body gave the agent an empty url and nothing else, next to a
+        skill instruction to show it. So this asserts BOTH halves of the fix: the fields
+        say not-live, and the prose says so too and points at the status tool.
+
+        THE MUTATION THAT BREAKS THIS: revert the body to the five hand-built keys.
+        """
+        from pocketpaw_ee.agent.mcp_servers import sites as mcp
+
+        doc = _Doc(url="", deployed=False, build_status="queued", build_job_id="job-1")
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch("pocketpaw_ee.sites.service.publish_pocket", new=AsyncMock(return_value=doc)),
+        ):
+            body = _body(await mcp._publish_handler({"pocket_id": "pk1"}))
+
+        site = body["site"]
+        assert site["is_live"] is False
+        assert site["build_in_progress"] is True
+        assert site["build_status"] == "queued"
+        assert site["build_job_id"] == "job-1"
+        assert site["url"] == ""
+
+        message = body["message"].lower()
+        # The prose has to carry the conclusion, because the original defect was
+        # narration rather than data: a boolean the agent does not consult fixes
+        # nothing. Assert what the message TELLS the agent to do, not the absence of
+        # substrings — "is live" legitimately appears inside "do NOT say it is live".
+        assert "not live" in message
+        assert "do not show" in message
+        # It must route the agent to the follow-up read, or "queued" is a dead end.
+        assert "get_site_build_status" in body["message"]
+
+    @pytest.mark.asyncio
+    async def test_a_republish_over_a_live_site_is_not_reported_as_current(self) -> None:
+        """The subtler half: a rebuild deliberately KEEPS the previous deploy's url and
+        ``deployed=True`` so a working site is never reported as down. Both of those say
+        "live" while the url serves the pre-change page, so the response must lean on
+        ``build_status`` and say the change is not live yet."""
+        from pocketpaw_ee.agent.mcp_servers import sites as mcp
+
+        doc = _Doc(url="https://bright.paw.test/", deployed=True, build_status="building")
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch("pocketpaw_ee.sites.service.publish_pocket", new=AsyncMock(return_value=doc)),
+        ):
+            body = _body(await mcp._publish_handler({"pocket_id": "pk1"}))
+
+        assert body["site"]["is_live"] is False
+        assert body["site"]["build_in_progress"] is True
+        # The url is still reported (it is real), but the message forbids showing it as
+        # the current version.
+        assert body["site"]["url"] == "https://bright.paw.test/"
+        assert "previous version" in body["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_a_failed_build_relays_the_reason_not_a_url(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import sites as mcp
+
+        doc = _Doc(url="", deployed=False, build_status="failed", build_reason="build:exit_1")
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch("pocketpaw_ee.sites.service.publish_pocket", new=AsyncMock(return_value=doc)),
+        ):
+            body = _body(await mcp._publish_handler({"pocket_id": "pk1"}))
+
+        assert body["site"]["build_reason"] == "build:exit_1"
+        assert body["site"]["is_live"] is False
+        assert "failed" in body["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_the_original_five_keys_are_still_present(self) -> None:
+        """Widening, not replacing. The frontend-facing shape of this tool is contract
+        for anything already reading it, so the old keys must survive."""
+        from pocketpaw_ee.agent.mcp_servers import sites as mcp
+
+        doc = _Doc(url="https://x/", deployed=True, build_status="built")
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch("pocketpaw_ee.sites.service.publish_pocket", new=AsyncMock(return_value=doc)),
+        ):
+            body = _body(await mcp._publish_handler({"pocket_id": "pk1"}))
+
+        assert set(body["site"]) >= {"id", "pocket_id", "name", "url", "deployed"}
+        assert body["site"]["id"] == "site_abc"
+        assert body["site"]["pocket_id"] == "pk1"
+
+
+# ---------------------------------------------------------------------------
+# get_site_build_status
+# ---------------------------------------------------------------------------
+
+
+class TestStatusHandler:
+    @pytest.mark.asyncio
+    async def test_settled_build_is_reported_live(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import sites as mcp
+
+        state = {
+            "pocket_id": "pk1",
+            "site_id": "site_abc",
+            "name": "Bright Smile",
+            "published": True,
+            "url": "https://bright.paw.test/",
+            "deployed": True,
+            "build_status": "built",
+            "build_reason": None,
+            "build_job_id": "job-9",
+            "build_in_progress": False,
+            "is_live": True,
+        }
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch(
+                "pocketpaw_ee.sites.service.site_build_status",
+                new=AsyncMock(return_value=state),
+            ),
+        ):
+            body = _body(await mcp._get_site_build_status_handler({"pocket_id": "pk1"}))
+
+        assert body["ok"] is True
+        assert body["is_live"] is True
+        assert body["url"] == "https://bright.paw.test/"
+        assert "live" in body["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_in_flight_build_is_not_reported_live(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import sites as mcp
+
+        state = {
+            "pocket_id": "pk1",
+            "site_id": "site_abc",
+            "name": "n",
+            "published": True,
+            "url": "",
+            "deployed": False,
+            "build_status": "building",
+            "build_reason": None,
+            "build_job_id": "job-9",
+            "build_in_progress": True,
+            "is_live": False,
+        }
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch(
+                "pocketpaw_ee.sites.service.site_build_status",
+                new=AsyncMock(return_value=state),
+            ),
+        ):
+            body = _body(await mcp._get_site_build_status_handler({"pocket_id": "pk1"}))
+
+        assert body["is_live"] is False
+        message = body["message"].lower()
+        assert "still building" in message
+        assert "not live" in message
+
+    @pytest.mark.asyncio
+    async def test_never_published_is_answered_not_errored(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import sites as mcp
+
+        state = {
+            "pocket_id": "pk1",
+            "site_id": None,
+            "name": "",
+            "published": False,
+            "url": "",
+            "deployed": False,
+            "build_status": "none",
+            "build_reason": None,
+            "build_job_id": None,
+            "build_in_progress": False,
+            "is_live": False,
+        }
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch(
+                "pocketpaw_ee.sites.service.site_build_status",
+                new=AsyncMock(return_value=state),
+            ),
+        ):
+            body = _body(await mcp._get_site_build_status_handler({"pocket_id": "pk1"}))
+
+        assert body["published"] is False
+        assert "never been published" in body["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_failed_build_relays_the_reason(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import sites as mcp
+
+        state = {
+            "pocket_id": "pk1",
+            "site_id": "s",
+            "name": "n",
+            "published": True,
+            "url": "",
+            "deployed": False,
+            "build_status": "failed",
+            "build_reason": "infra:sandbox_lost",
+            "build_job_id": "job-9",
+            "build_in_progress": False,
+            "is_live": False,
+        }
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch(
+                "pocketpaw_ee.sites.service.site_build_status",
+                new=AsyncMock(return_value=state),
+            ),
+        ):
+            body = _body(await mcp._get_site_build_status_handler({"pocket_id": "pk1"}))
+
+        assert body["build_reason"] == "infra:sandbox_lost"
+        assert "build_reason" in body["message"]
+
+    @pytest.mark.asyncio
+    async def test_missing_identity_is_error(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import sites as mcp
+
+        with patch.object(mcp, "_identity", return_value=(None, None)):
+            out = await mcp._get_site_build_status_handler({"pocket_id": "pk1"})
+        assert out.get("is_error") is True
+        assert "workspace and user context" in out["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_missing_pocket_id_is_error(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import sites as mcp
+
+        with patch.object(mcp, "_identity", return_value=("ws1", "u1")):
+            out = await mcp._get_site_build_status_handler({})
+        assert out.get("is_error") is True
+        assert "`pocket_id`" in out["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_cloud_error_is_relayed_by_code(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import sites as mcp
+        from pocketpaw_ee.cloud._core.errors import Forbidden
+
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch(
+                "pocketpaw_ee.sites.service.site_build_status",
+                new=AsyncMock(side_effect=Forbidden("pocket.access_denied", "nope")),
+            ),
+        ):
+            out = await mcp._get_site_build_status_handler({"pocket_id": "pk1"})
+        assert out.get("is_error") is True
+        assert "pocket.access_denied" in out["content"][0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_unexpected_exception_is_an_error_not_a_success(self) -> None:
+        """A read that blew up must not surface as "nothing is building"."""
+        from pocketpaw_ee.agent.mcp_servers import sites as mcp
+
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch(
+                "pocketpaw_ee.sites.service.site_build_status",
+                new=AsyncMock(side_effect=RuntimeError("mongo went away")),
+            ),
+        ):
+            out = await mcp._get_site_build_status_handler({"pocket_id": "pk1"})
+        assert out.get("is_error") is True
+        assert "could not read the build status" in out["content"][0]["text"]

--- a/tests/ee/agent/test_sites_mcp_server/test_mcp_tool.py
+++ b/tests/ee/agent/test_sites_mcp_server/test_mcp_tool.py
@@ -6,11 +6,16 @@
 # ContextVars + the shared publish_pocket service and inspect the MCP envelope
 # the SDK returns to the agent.
 #
-# Updated: 2026-08-11 (feat/sites-react-edit-lane, RX-3) — the registration test now
-# pins the EIGHTH tool id on this server, ``edit_react_component``. The count
-# assertion did its job here: adding the tool failed this test before anything else,
-# which is exactly the decision point it exists to force (SITES_TOOL_IDS feeds the
-# /sites surface allow-list, so a new id widens what the agent can reach).
+# Updated: 2026-08-11 (feat/sites-react-edit-lane, RX-3 + RX-4) — the registration test
+# now pins the EIGHTH and NINTH tool ids on this server, ``edit_react_component`` and
+# the read-only ``get_site_build_status``. The count assertion did its job both times:
+# each new tool failed this test before anything else, which is exactly the decision
+# point it exists to force (SITES_TOOL_IDS feeds the /sites surface allow-list, so a new
+# id widens what the agent can reach).
+#
+# The publish handler's own response is no longer covered only here — RX-4 widened it
+# with the build-lane fields, and those live in test_build_status_tool.py beside the
+# status tool that shares their derivation.
 """MCP server registration + handler tests for the Paw Sites publish tool."""
 
 from __future__ import annotations
@@ -38,6 +43,7 @@ class TestSitesMcpServerRegistration:
             CREATE_SVELTE_SITE_TOOL_ID,
             EDIT_REACT_COMPONENT_TOOL_ID,
             EDIT_SVELTE_COMPONENT_TOOL_ID,
+            GET_SITE_BUILD_STATUS_TOOL_ID,
             PUBLISH_TOOL_ID,
             SERVER_NAME,
             SITES_TOOL_IDS,
@@ -72,10 +78,17 @@ class TestSitesMcpServerRegistration:
         assert CREATE_HTML_SITE_TOOL_ID in SITES_TOOL_IDS
         assert CREATE_REACT_SITE_TOOL_ID in SITES_TOOL_IDS
         assert EDIT_REACT_COMPONENT_TOOL_ID in SITES_TOOL_IDS
+        # RX-4 — the READ-ONLY build-status tool, the 9th id. It is the only way the
+        # agent can learn how an ASYNC build ended, since publish returns before the
+        # build starts.
+        assert (
+            GET_SITE_BUILD_STATUS_TOOL_ID == "mcp__pocketpaw_sites_manager__get_site_build_status"
+        )
+        assert GET_SITE_BUILD_STATUS_TOOL_ID in SITES_TOOL_IDS
         # The count is deliberate: adding a tool here widens the /sites surface
         # allow-list (SITES_TOOL_IDS feeds it), so a new id must be a decision,
         # not a side effect. Bump it WITH an id assertion above — never alone.
-        assert len(SITES_TOOL_IDS) == 8
+        assert len(SITES_TOOL_IDS) == 9
 
     def test_extension_provider_advertises_tool_id(self) -> None:
         """The entry-point provider's ``tool_ids()`` feeds the claude_sdk

--- a/tests/ee/sites/test_agent_build_visibility.py
+++ b/tests/ee/sites/test_agent_build_visibility.py
@@ -1,0 +1,362 @@
+# tests/ee/sites/test_agent_build_visibility.py — RX-4: what the CHAT AGENT is told
+# about whether a site is actually live.
+# Created: 2026-08-11 (feat/sites-react-edit-lane).
+#
+# THE DEFECT. ``_to_response`` gives the FRONTEND ``build_status`` / ``build_reason`` /
+# ``build_job_id``, and the frontend polls them next to ``url`` knowing the wire contract
+# that a site can be live and simultaneously mid-rebuild. The agent's publish tool
+# hand-built its own five-key body and carried none of the three, so on react — the only
+# engine with ``build_runs_async(engine) is True`` — it was handed values it had no way
+# to interpret:
+#
+#   * FIRST publish: ``url=""`` and ``deployed=False``, while the create skill's STEP 4
+#     tells it to "show the user the returned url".
+#   * RE-publish: the PREVIOUS deploy's ``url`` and ``deployed=True``, so it reported the
+#     old page as though the change were live.
+#
+# So these tests are about a derivation, not a feature: ``build_wire_state`` is the one
+# place ``is_live`` is decided, and ``site_build_status`` is the later read that stops
+# "queued" being a dead end (an async publish returns before the build starts, so
+# without it the agent can never learn how the build ended).
+#
+# TWO PROPERTIES ARE LOAD BEARING:
+#   (a) ``is_live`` requires url AND deployed AND no build in flight. Each of the three
+#       is individually insufficient, and the tests below prove that one at a time
+#       rather than asserting the happy path and trusting the rest.
+#   (b) An UNKNOWN ``build_status`` reads as IN PROGRESS here — deliberately the
+#       opposite of ``build_state.should_enqueue``, which treats unknown as terminal.
+#       Both are right on their own axis; a test pins the direction so a future
+#       "simplification" that unifies them fails loudly.
+#
+# Mutation coverage: tests/mutations/react_edit_lane.json.
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
+from pocketpaw_ee.sites import build_job as bj
+from pocketpaw_ee.sites import build_state as bs
+from pocketpaw_ee.sites import service as sites_service
+
+REACT_SOURCE = {"src/App.tsx": "export default function App() { return <p>hi</p>; }"}
+
+
+class _Row:
+    """The handful of Site fields ``build_wire_state`` reads. A plain object rather
+    than a Beanie doc because the function is pure and must stay directly testable."""
+
+    def __init__(self, **kw: Any) -> None:
+        self.url = kw.get("url", "")
+        self.deployed = kw.get("deployed", False)
+        for key in ("build_status", "build_reason", "build_job_id"):
+            if key in kw:
+                setattr(self, key, kw[key])
+
+
+# ---------------------------------------------------------------------------
+# (a) is_live needs all three, and the raw fields pass through untouched
+# ---------------------------------------------------------------------------
+
+
+class TestIsLive:
+    def test_a_settled_deploy_is_live(self) -> None:
+        state = sites_service.build_wire_state(
+            _Row(url="https://x.paw.test/", deployed=True, build_status="built")
+        )
+        assert state["is_live"] is True
+        assert state["build_in_progress"] is False
+
+    def test_a_first_async_publish_is_not_live_and_carries_no_url(self) -> None:
+        """The exact row ``_enqueue_static_build`` inserts on a first publish. The agent
+        used to receive this as a bare success with ``url=""``.
+
+        THE MUTATION THAT BREAKS THIS: drop ``bool(url)`` from the ``is_live``
+        conjunction. Run: an empty url read as live and this failed.
+        """
+        state = sites_service.build_wire_state(
+            _Row(url="", deployed=False, build_status="queued", build_job_id="job-1")
+        )
+        assert state["is_live"] is False
+        assert state["build_in_progress"] is True
+        assert state["url"] == ""
+        assert state["build_job_id"] == "job-1"
+
+    def test_a_settled_build_with_no_url_is_still_not_live(self) -> None:
+        """The row that makes ``bool(url)`` load bearing on its own: the build has
+        SETTLED (nothing in flight) and ``deployed`` is True, so the only thing standing
+        between the agent and handing the user an empty string is the url check.
+
+        Not hypothetical. ``_canonical_site_doc`` exists partly because rows with a
+        ``deployed`` flag and no persisted url are real — that is the stale-live-link bug
+        it was written to dodge — and a deploy that flipped the flag before persisting
+        the url lands in exactly this shape.
+
+        THE MUTATION THAT BREAKS THIS: drop ``bool(url)`` from the ``is_live``
+        conjunction. Run: the empty url read as live and this failed. (The queued-row
+        test below does NOT catch that mutation — ``not in_progress`` already makes it
+        false there, which is how the escape was found.)
+        """
+        state = sites_service.build_wire_state(_Row(url="", deployed=True, build_status="built"))
+        assert state["build_in_progress"] is False
+        assert state["is_live"] is False
+
+    def test_a_republish_over_a_live_site_is_not_live_at_this_version(self) -> None:
+        """The subtler half. A re-publish KEEPS the previous deploy's url and
+        ``deployed=True`` on purpose, so a rebuild never reports a working site as down.
+        Both of those say "live" while the url serves the PRE-CHANGE page, so
+        ``build_status`` is the only thing that can tell the agent otherwise.
+
+        THE MUTATION THAT BREAKS THIS: drop ``not in_progress`` from ``is_live``. Run:
+        a mid-rebuild site reported live and this failed.
+        """
+        state = sites_service.build_wire_state(
+            _Row(url="https://x.paw.test/", deployed=True, build_status="building")
+        )
+        assert state["is_live"] is False
+        assert state["build_in_progress"] is True
+
+    def test_a_never_built_pocket_is_not_live_and_not_in_progress(self) -> None:
+        """ "none" is terminal AND means nothing was ever built, so it must not read as
+        a build the agent could wait for."""
+        state = sites_service.build_wire_state(_Row(url="", deployed=False))
+        assert state["build_status"] == "none"
+        assert state["build_in_progress"] is False
+        assert state["is_live"] is False
+
+    def test_a_failed_build_is_not_live_and_carries_its_reason(self) -> None:
+        """``build_status="failed"`` with no reason is unactionable — the agent cannot
+        tell "the user's code broke" from "we lost the container"."""
+        state = sites_service.build_wire_state(
+            _Row(url="", deployed=False, build_status="failed", build_reason="build:exit_1")
+        )
+        assert state["is_live"] is False
+        assert state["build_in_progress"] is False
+        assert state["build_reason"] == "build:exit_1"
+
+    def test_no_site_doc_reads_as_nothing_built(self) -> None:
+        """``None`` is a real input (a pocket that was never published), so the function
+        answers it rather than making every caller write the empty shape."""
+        state = sites_service.build_wire_state(None)
+        assert state == {
+            "url": "",
+            "deployed": False,
+            "build_status": "none",
+            "build_reason": None,
+            "build_job_id": None,
+            "build_in_progress": False,
+            "is_live": False,
+        }
+
+    def test_a_pre_sl3_row_with_no_build_fields_does_not_raise(self) -> None:
+        """Read through ``getattr`` defaults like ``_to_response`` does, so a row written
+        before the build fields existed reads as "no build" instead of blowing up."""
+        bare = type("Bare", (), {"url": "https://x/", "deployed": True})()
+        state = sites_service.build_wire_state(bare)
+        assert state["build_status"] == "none"
+        assert state["is_live"] is True
+
+
+# ---------------------------------------------------------------------------
+# (b) the unknown-status direction, and that it is NOT should_enqueue's
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownStatusReadsAsInProgress:
+    def test_an_unrecognised_status_is_in_progress_not_live(self) -> None:
+        """The wire's contract: a client treats an unrecognised status as in-progress, so
+        growing the vocabulary never shows a user a spurious "live". A status this deploy
+        predates must not be mapped to "nothing is building".
+
+        THE MUTATION THAT BREAKS THIS: derive ``build_in_progress`` from
+        ``IN_FLIGHT_STATUSES`` instead of from ``TERMINAL_STATUSES``. Run: the unknown
+        status read as terminal, the site reported live, and this failed.
+        """
+        state = sites_service.build_wire_state(
+            _Row(url="https://x/", deployed=True, build_status="uploading-artifact")
+        )
+        assert state["build_in_progress"] is True
+        assert state["is_live"] is False
+        # And the raw value is passed through VERBATIM, never normalised.
+        assert state["build_status"] == "uploading-artifact"
+
+    def test_the_two_readers_disagree_on_purpose(self) -> None:
+        """The asymmetry stated out loud so nobody "fixes" it into one helper.
+
+        ``should_enqueue`` treats an unknown status as TERMINAL and starts a build (a
+        redundant build costs one sandbox; a stuck guard costs the site every future
+        publish). This function treats the same status as IN PROGRESS (a spurious "your
+        site is live" costs the user's trust). Same input, opposite answers, both right.
+        """
+        row = _Row(url="https://x/", deployed=True, build_status="something-new")
+        assert bs.should_enqueue(row, 600) is True
+        assert sites_service.build_wire_state(row)["build_in_progress"] is True
+
+    def test_every_in_flight_status_reads_as_in_progress(self) -> None:
+        """Derived from the state machine rather than hand-listed, so a new in-flight
+        state is covered here the moment it joins ``IN_FLIGHT_STATUSES``."""
+        for status in sorted(bs.IN_FLIGHT_STATUSES):
+            state = sites_service.build_wire_state(
+                _Row(url="https://x/", deployed=True, build_status=status)
+            )
+            assert state["build_in_progress"] is True, status
+            assert state["is_live"] is False, status
+
+
+# ---------------------------------------------------------------------------
+# site_build_status — the later read that stops "queued" being a dead end
+# ---------------------------------------------------------------------------
+
+
+async def _seed_site(**kw: Any) -> _SiteDoc:
+    doc = _SiteDoc(
+        workspace=kw.pop("workspace", "ws1"),
+        pocket_id=kw.pop("pocket_id", "pk1"),
+        owner="u1",
+        name=kw.pop("name", "Bright Smile"),
+        script_name="s1",
+        deployed=kw.pop("deployed", False),
+        url=kw.pop("url", ""),
+        signed_key="k",
+        **kw,
+    )
+    await doc.insert()
+    return doc
+
+
+@pytest.mark.asyncio
+async def test_status_reads_back_a_settled_build(beanie_test_db):
+    """The turn after the publish: the build finished, so the agent can finally show a
+    url. This is the whole point of the tool."""
+    await _seed_site(
+        pocket_id="pk1",
+        url="https://bright.paw.test/",
+        deployed=True,
+        build_status="built",
+        build_job_id="job-9",
+    )
+
+    out = await sites_service.site_build_status(workspace_id="ws1", pocket_id="pk1")
+
+    assert out["published"] is True
+    assert out["is_live"] is True
+    assert out["build_in_progress"] is False
+    assert out["build_status"] == "built"
+    assert out["url"] == "https://bright.paw.test/"
+    assert out["name"] == "Bright Smile"
+    assert out["site_id"]
+
+
+@pytest.mark.asyncio
+async def test_status_reads_back_an_in_flight_build(beanie_test_db):
+    await _seed_site(pocket_id="pk1", url="", deployed=False, build_status="queued")
+
+    out = await sites_service.site_build_status(workspace_id="ws1", pocket_id="pk1")
+
+    assert out["build_in_progress"] is True
+    assert out["is_live"] is False
+
+
+@pytest.mark.asyncio
+async def test_status_of_a_never_published_pocket_says_so(beanie_test_db):
+    """Not an error. "This was never published" is the useful answer, and it is correct
+    whether the pocket has no site or does not exist."""
+    out = await sites_service.site_build_status(workspace_id="ws1", pocket_id="nope")
+
+    assert out["published"] is False
+    assert out["is_live"] is False
+    assert out["site_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_status_is_tenant_scoped(beanie_test_db):
+    """The tenancy filter IS the access check on this read, so it gets a test rather
+    than a comment. Another workspace's site must read as never-published.
+
+    THE MUTATION THAT BREAKS THIS: drop the ``workspace`` filter from
+    ``_canonical_site_doc``'s query.
+    """
+    await _seed_site(workspace="ws_other", pocket_id="pk1", url="https://x/", deployed=True)
+
+    out = await sites_service.site_build_status(workspace_id="ws1", pocket_id="pk1")
+
+    assert out["published"] is False
+    assert out["is_live"] is False
+
+
+# ---------------------------------------------------------------------------
+# End to end: a real async react publish reports queued, not a bare empty url
+# ---------------------------------------------------------------------------
+
+
+class _FakeGenerator:
+    def __init__(self) -> None:
+        self.build_calls: list[dict[str, Any]] = []
+
+    async def build(self, **kw: Any) -> Any:
+        from pocketpaw_ee.sites.generator_client import BuildResult
+
+        self.build_calls.append(kw)
+        return BuildResult(project_dir="/tmp/site", ripple_version="0.2.0")
+
+
+class _FakePool:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def enqueue_job(self, function: str, *args: Any, _job_id: str | None = None, **kw: Any):
+        self.calls.append({"function": function, "job_id": _job_id})
+        return object()
+
+
+@pytest.mark.asyncio
+async def test_a_real_first_react_publish_reports_queued_not_a_url(
+    beanie_test_db, monkeypatch: pytest.MonkeyPatch
+):
+    """The end-to-end version of the first-publish case, through the REAL async publish
+    path rather than a hand-built row — so the shape this asserts is the shape
+    ``_enqueue_static_build`` actually produces.
+
+    The inline generator must not have run (that is the flip), and the doc the publish
+    returns must derive to "not live, build in progress" rather than to a success with
+    an empty url.
+    """
+    from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
+
+    pocket = _PocketDoc(workspace="ws1", name="P", owner="u1", type="site")
+    await pocket.insert()
+
+    pool = _FakePool()
+
+    async def _get_pool() -> Any:
+        return pool
+
+    monkeypatch.setattr(bj, "_get_pool", _get_pool)
+    gen = _FakeGenerator()
+
+    doc = await sites_service.publish(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=str(pocket.id),
+        theme={},
+        name="x",
+        engine="react",
+        source=REACT_SOURCE,
+        _generator=gen,
+        _local_deploy=lambda site_id, project_dir: f"http://127.0.0.1/{site_id}/",
+    )
+
+    # The build was enqueued, not run inline.
+    assert gen.build_calls == []
+    assert pool.calls, "no build was enqueued"
+
+    state = sites_service.build_wire_state(doc)
+    assert state["is_live"] is False, state
+    assert state["build_in_progress"] is True, state
+    assert state["url"] == ""
+    assert state["build_status"] in bs.IN_FLIGHT_STATUSES
+    # And the later read agrees with what the publish returned — one derivation.
+    later = await sites_service.site_build_status(workspace_id="ws1", pocket_id=str(pocket.id))
+    assert later["is_live"] is False
+    assert later["build_status"] == state["build_status"]

--- a/tests/mutations/react_edit_lane.json
+++ b/tests/mutations/react_edit_lane.json
@@ -195,6 +195,89 @@
     ]
   },
   {
+    "label": "is_live stops requiring a url, so a first async publish (url=\"\") reports the site as live and the agent hands the user an empty string",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        \"is_live\": bool(url) and bool(doc.deployed) and not in_progress,",
+    "replace": "        \"is_live\": bool(doc.deployed) and not in_progress,",
+    "tests": [
+      "tests/ee/sites/test_agent_build_visibility.py::TestIsLive::test_a_settled_build_with_no_url_is_still_not_live"
+    ]
+  },
+  {
+    "label": "is_live ignores the in-flight build, so a re-publish reports the PREVIOUS deploy's url as though the change were already live",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        \"is_live\": bool(url) and bool(doc.deployed) and not in_progress,",
+    "replace": "        \"is_live\": bool(url) and bool(doc.deployed),",
+    "tests": [
+      "tests/ee/sites/test_agent_build_visibility.py::TestIsLive::test_a_republish_over_a_live_site_is_not_live_at_this_version",
+      "tests/ee/agent/test_sites_mcp_server/test_build_status_tool.py::TestPublishResponseCarriesBuildState::test_a_republish_over_a_live_site_is_not_reported_as_current"
+    ]
+  },
+  {
+    "label": "build_in_progress is derived from IN_FLIGHT_STATUSES, so an unknown status reads as terminal and a running build is reported live (the wire contract is the opposite of should_enqueue's)",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    in_progress = status != \"none\" and status not in TERMINAL_STATUSES",
+    "replace": "    in_progress = status in __import__(\"pocketpaw_ee.sites.build_state\", fromlist=[\"x\"]).IN_FLIGHT_STATUSES",
+    "tests": [
+      "tests/ee/sites/test_agent_build_visibility.py::TestUnknownStatusReadsAsInProgress::test_an_unrecognised_status_is_in_progress_not_live"
+    ]
+  },
+  {
+    "label": "build_status is normalised against a known set instead of passing through verbatim, so a status this deploy predates is reported as \"nothing is building\"",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    status = getattr(doc, \"build_status\", \"none\")\n    in_progress =",
+    "replace": "    status = getattr(doc, \"build_status\", \"none\")\n    status = status if status in TERMINAL_STATUSES else \"none\"\n    in_progress =",
+    "tests": [
+      "tests/ee/sites/test_agent_build_visibility.py::TestUnknownStatusReadsAsInProgress::test_an_unrecognised_status_is_in_progress_not_live"
+    ]
+  },
+  {
+    "label": "the publish response goes back to the five hand-built keys, so the agent never sees the build state at all",
+    "file": "ee/pocketpaw_ee/agent/mcp_servers/sites.py",
+    "find": "                \"name\": doc.name,\n                **state,",
+    "replace": "                \"name\": doc.name,\n                \"url\": doc.url,\n                \"deployed\": doc.deployed,",
+    "tests": [
+      "tests/ee/agent/test_sites_mcp_server/test_build_status_tool.py::TestPublishResponseCarriesBuildState::test_a_first_async_publish_does_not_read_as_a_live_site"
+    ]
+  },
+  {
+    "label": "the queued publish message stops naming the status tool, so the agent learns a build is running and can never find out how it ended",
+    "file": "ee/pocketpaw_ee/agent/mcp_servers/sites.py",
+    "find": "            \"and that you can check again in a moment with \"\n            \"`get_site_build_status`.\"",
+    "replace": "            \"and that it should be up shortly.\"",
+    "tests": [
+      "tests/ee/agent/test_sites_mcp_server/test_build_status_tool.py::TestPublishResponseCarriesBuildState::test_a_first_async_publish_does_not_read_as_a_live_site"
+    ]
+  },
+  {
+    "label": "the build-status tool is not registered on the server, so its id is whitelisted but nothing answers a call",
+    "file": "ee/pocketpaw_ee/agent/mcp_servers/sites.py",
+    "find": "            publish,\n            get_site_build_status,",
+    "replace": "            publish,",
+    "tests": [
+      "tests/ee/agent/test_sites_mcp_server/test_build_status_tool.py::TestRegistration::test_the_built_server_lists_the_status_tool"
+    ]
+  },
+  {
+    "label": "the build-status tool id leaves SITES_TOOL_IDS, so the /sites allow-list filters the tool out silently and every handler test still passes",
+    "file": "ee/pocketpaw_ee/agent/mcp_servers/sites.py",
+    "find": "    EDIT_REACT_COMPONENT_TOOL_ID,\n    GET_SITE_BUILD_STATUS_TOOL_ID,\n)",
+    "replace": "    EDIT_REACT_COMPONENT_TOOL_ID,\n)",
+    "tests": [
+      "tests/ee/agent/test_sites_mcp_server/test_build_status_tool.py::TestRegistration::test_status_tool_id_is_on_the_shared_allowlist",
+      "tests/ee/agent/test_sites_mcp_server/test_mcp_tool.py::TestSitesMcpServerRegistration::test_server_name_and_tool_id"
+    ]
+  },
+  {
+    "label": "site_build_status drops the tenancy filter by resolving the doc without the workspace, so one workspace reads another's build state",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    doc = await canonical_site_for_pocket(workspace_id, pocket_id)\n    state = build_wire_state(doc)",
+    "replace": "    doc = await _SiteDoc.find_one({\"pocket_id\": pocket_id})  # global-read: mutation\n    state = build_wire_state(doc)",
+    "tests": [
+      "tests/ee/sites/test_agent_build_visibility.py::test_status_is_tenant_scoped"
+    ]
+  },
+  {
     "label": "the react create step stops naming the edit tool, so a follow-up change goes back to a second create_react_site and a second site pocket",
     "file": "ee/pocketpaw_ee/cloud/surface/handlers/sites.py",
     "find": "            \"`mcp__pocketpaw_sites_manager__edit_react_component` with the SAME \"",


### PR DESCRIPTION
The publish tool told the agent a site was live when it wasn't.

`_publish_handler` hand-built its success body from five keys — `id`, `pocket_id`, `name`, `url`, `deployed`. Meanwhile `_to_response`, the wire the frontend polls, carries `build_status`, `build_reason` and `build_job_id`. The agent's tool response dropped all three, so the frontend could tell a queued build from a live site and the agent could not.

react is the only engine where `build_runs_async` is true, which makes it the only engine where that gap bites — and it bites in both directions:

- **First publish.** `_enqueue_static_build` creates the Site doc with `deployed=False` and `url=""`, deliberately: nothing is serving yet. The agent got an empty url, and the create skill told it to show the user the returned url.
- **Re-publish.** `url` and `deployed` keep the previous deploy's values, so a rebuild never reports a working site as down. Correct for a client that reads `build_status` alongside them. For the agent it meant handing over a link that serves the page from *before* the edit — the mistake that looks most convincing, because the link works.

## What changed

The publish `site` object keeps its five fields and gains `build_status`, `build_reason`, `build_job_id`, `build_in_progress` and `is_live`, plus a top-level `message`.

`is_live` is a single field a prompt can gate on. It is true only when there is a non-empty url **and** `deployed` **and** no build in flight. Each term alone is insufficient — a queued flag by itself does not cover the re-publish case, where both `url` and `deployed` say live. There is a test per term.

`build_status` passes through **verbatim**. `_to_response`'s comment is explicit that it must never be normalised against a hardcoded set, and this path now has a mutation pinning that.

`build_in_progress` reads an unknown status as in-progress, matching the wire contract, and derives from `TERMINAL_STATUSES` so a newly added state defaults correctly without an edit here. That is deliberately the opposite direction from `should_enqueue`, which treats unknown as terminal — a test pins the asymmetry so nobody unifies the two and reintroduces the sandbox leak.

`message` exists because the defect was narration, not data. A boolean the agent never consults fixes nothing while the instruction to show the url is still in the skill. On a queued build the message says the site is not live, forbids showing a url, and names the tool that can resolve it.

## The queued state is no longer a dead end

`get_site_build_status(pocket_id)` is a new read-only tool returning the same fields plus `published`, so "is it up yet?" is answerable on a later turn. Without it the agent could learn a build was queued and then never find out it finished.

Its id rides `SITES_TOOL_IDS`. That tuple builds the per-surface allowlist, and a tool registered on the server but missing from it is filtered out with no error while every direct handler test still passes — so there is a mutation for that too.

Both surfaces share `sites.service.build_wire_state`, so the publish response and the status tool cannot disagree about whether a site is live.

## Mutations

`uv run python scripts/mutate.py --plan tests/mutations/react_edit_lane.json` → **31 of 31 caught.**

Three escaped across two rounds and all three were real test gaps. The most useful: dropping `bool(url)` from `is_live` survived, because the queued row it was aimed at already had a build in flight, so a different term made `is_live` false anyway. The fix was a row where the empty url is the only thing standing in the way — a settled build with `deployed=True` and no persisted url. The test and the code agreed and both were beside the point, which is what the mutation rule exists to catch.

## Tests

31 new (`test_agent_build_visibility.py` 16, `test_build_status_tool.py` 15), and the tool-count tripwire in `test_mcp_tool.py` moved 8 → 9.

`tests/ee/agent/test_sites_mcp_server` 139 passed. A combined run with the async-publish and build-status-wire suites plus `tests/cloud/surface`: 383 passed, 13 failed — the 13 being the pre-existing `SurfacePreamble.lower()` drift on `dev`, unrelated to this change.

`docs/api-reference.md` gains the new fields and the status tool.
