### PR TITLE
fix(cloud): stop zombie sockets from eating notifications

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/router.py
+++ b/ee/pocketpaw_ee/cloud/chat/router.py
@@ -6,8 +6,9 @@ The WebSocket endpoint at ``/ws/cloud`` authenticates via JWT query param.
 Updated 2026-08-11 (fix/notif-liveness-dispatch): the receive loop stamps each
 socket's liveness window via ``manager.touch`` on every inbound frame, so a
 socket that is genuinely talking to us can never be mistaken for a zombie by
-``is_online``. See chat/ws.py's module docstring for what that verdict now
-drives.
+``is_online``. The ping branch additionally calls ``manager.mark_ping_capable``
+— only clients that prove they heartbeat are held to a staleness deadline. See
+chat/ws.py's module docstring for what that verdict drives.
 
 Updated 2026-04-19 (Task 19, Cluster A sub-PR 4): presence events are now
 emitted on WS connect and disconnect. PresenceOnline fires immediately when
@@ -691,6 +692,11 @@ async def websocket_endpoint(websocket: WebSocket, token: str | None = Query(Non
                 # closing edge proxies (e.g. Cloudflare drops idle WebSockets
                 # after ~100s). Reply pong and skip the message-handling path.
                 if isinstance(data, dict) and data.get("type") == "ping":
+                    # A ping proves this client speaks the heartbeat, which is
+                    # what lets is_online hold it to a staleness deadline.
+                    # Clients that never ping stay on legacy liveness rather
+                    # than being churned offline for going quiet.
+                    manager.mark_ping_capable(websocket)
                     await websocket.send_json({"type": "pong"})
                     continue
                 msg = WsInbound.model_validate(_normalize_ws_inbound(data))

--- a/ee/pocketpaw_ee/cloud/chat/router.py
+++ b/ee/pocketpaw_ee/cloud/chat/router.py
@@ -3,6 +3,12 @@
 REST routes live under ``/chat`` and require an enterprise license.
 The WebSocket endpoint at ``/ws/cloud`` authenticates via JWT query param.
 
+Updated 2026-08-11 (fix/notif-liveness-dispatch): the receive loop stamps each
+socket's liveness window via ``manager.touch`` on every inbound frame, so a
+socket that is genuinely talking to us can never be mistaken for a zombie by
+``is_online``. See chat/ws.py's module docstring for what that verdict now
+drives.
+
 Updated 2026-04-19 (Task 19, Cluster A sub-PR 4): presence events are now
 emitted on WS connect and disconnect. PresenceOnline fires immediately when
 a user's first socket accepts; PresenceOffline fires after the existing
@@ -674,6 +680,11 @@ async def websocket_endpoint(websocket: WebSocket, token: str | None = Query(Non
     try:
         while True:
             raw = await websocket.receive_text()
+            # Any inbound frame is proof the socket is alive — refresh its
+            # liveness window before parsing, so even a malformed frame counts
+            # (the client is clearly still there). Notification dispatch reads
+            # this to choose WS over Web Push; see ws.py's module docstring.
+            manager.touch(websocket)
             try:
                 data = json.loads(raw)
                 # Heartbeat: clients ping to keep the socket warm through idle-

--- a/ee/pocketpaw_ee/cloud/chat/ws.py
+++ b/ee/pocketpaw_ee/cloud/chat/ws.py
@@ -53,10 +53,13 @@ logger = logging.getLogger(__name__)
 
 TYPING_TIMEOUT_SECONDS = 5
 PRESENCE_GRACE_SECONDS = 30
-# A ping-capable socket silent this long is presumed dead. Sized at two missed
-# 30s client pings, so a single dropped heartbeat never flips a healthy client
-# offline. Sockets that don't ping are exempt entirely (see _is_fresh).
-LIVENESS_STALE_SECONDS = 60
+# A ping-capable socket silent this long is presumed dead. The client pings
+# every 30s foregrounded, but Chrome's intensive throttling slows hidden tabs'
+# timers to ~1/min after 5 minutes — so size for two missed pings at the
+# THROTTLED cadence, or backgrounded tabs (exactly where push matters) would
+# sit on the boundary and flap close(1001)/reconnect. Costs only slower zombie
+# detection. Sockets that don't ping are exempt entirely (see _is_fresh).
+LIVENESS_STALE_SECONDS = 150
 
 
 class ConnectionManager:

--- a/ee/pocketpaw_ee/cloud/chat/ws.py
+++ b/ee/pocketpaw_ee/cloud/chat/ws.py
@@ -8,12 +8,27 @@ Handles:
 - Message routing to group members
 - Typing indicators with auto-expiry (5s)
 - Presence tracking with grace period (30s before marking offline)
+- Per-socket liveness (see below)
+
+Updated: 2026-08-11 (fix/notif-liveness-dispatch) — ``is_online`` used to mean
+"a socket object is present in the dict", which a half-open socket (laptop
+asleep, NAT timeout) satisfies indefinitely: the TCP close never arrives, so
+the registry keeps a socket nobody is listening on. Notification dispatch
+reads that verdict to pick WS over Web Push, so a zombie socket silently ate
+the notification. Liveness is now traffic-based: every socket carries a
+last-activity stamp, refreshed on any inbound frame (``touch``, called from
+the router's receive loop) and on any successful outbound send. A socket with
+no traffic in EITHER direction for ``LIVENESS_STALE_SECONDS`` is presumed
+zombie — excluded from the verdict and closed best-effort, which wakes the
+router's receive loop so the normal disconnect/presence path runs.
 """
 
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
+import time
 
 from fastapi import WebSocket
 
@@ -23,6 +38,11 @@ logger = logging.getLogger(__name__)
 
 TYPING_TIMEOUT_SECONDS = 5
 PRESENCE_GRACE_SECONDS = 30
+# A socket with no traffic in either direction for this long is presumed dead.
+# Comfortably above the ~30s cadence of ordinary workspace chatter (presence
+# deltas, chat fan-out, client pings) so an idle-but-healthy socket in an
+# active workspace stays fresh on outbound traffic alone.
+LIVENESS_STALE_SECONDS = 60
 
 
 class ConnectionManager:
@@ -39,6 +59,9 @@ class ConnectionManager:
         self._typing_timers: dict[tuple[str, str], asyncio.Task] = {}
         # Current room per socket (at most one): ws -> group_id
         self._ws_to_room: dict[WebSocket, str] = {}
+        # ws -> monotonic timestamp of the last traffic in EITHER direction
+        # (inbound frame received, or outbound send the socket accepted).
+        self._ws_last_seen: dict[WebSocket, float] = {}
 
     async def connect(self, websocket: WebSocket, user_id: str) -> None:
         """Register an authenticated WebSocket connection."""
@@ -46,6 +69,7 @@ class ConnectionManager:
             self.active_connections[user_id] = set()
         self.active_connections[user_id].add(websocket)
         self._ws_to_user[websocket] = user_id
+        self.touch(websocket)
 
         # Cancel any pending offline task
         task = self._offline_tasks.pop(user_id, None)
@@ -67,6 +91,7 @@ class ConnectionManager:
         """
         # Always clear any room association, regardless of user mapping.
         self._ws_to_room.pop(websocket, None)
+        self._ws_last_seen.pop(websocket, None)
 
         user_id = self._ws_to_user.pop(websocket, None)
         if not user_id:
@@ -86,22 +111,96 @@ class ConnectionManager:
         """Return the set of active WebSocket connections for a user."""
         return self.active_connections.get(user_id, set())
 
-    def is_online(self, user_id: str) -> bool:
-        """Check whether a user has at least one active connection."""
-        return bool(self.active_connections.get(user_id))
+    # ------------------------------------------------------------------
+    # Liveness
+    # ------------------------------------------------------------------
 
-    async def send_to_user(self, user_id: str, message: WsOutbound) -> None:
-        """Send a message to all of a user's connections."""
+    def touch(self, websocket: WebSocket) -> None:
+        """Record traffic on a socket, refreshing its liveness window.
+
+        Called by the router's receive loop on EVERY inbound frame (including
+        the client's ``ping`` heartbeat) and internally on every outbound send
+        the socket accepted. Untracked sockets are ignored — a socket that has
+        already been disconnected must not resurrect itself here.
+        """
+        if websocket in self._ws_to_user:
+            self._ws_last_seen[websocket] = time.monotonic()
+
+    def _is_fresh(self, websocket: WebSocket, *, now: float) -> bool:
+        """True when the socket has seen traffic inside the liveness window."""
+        last_seen = self._ws_last_seen.get(websocket)
+        if last_seen is None:
+            # Tracked but never stamped — treat as stale rather than trusting it.
+            return False
+        return (now - last_seen) < LIVENESS_STALE_SECONDS
+
+    def _close_stale(self, websocket: WebSocket) -> None:
+        """Best-effort close of a presumed-zombie socket. Never raises.
+
+        Deliberately does NOT unregister the socket: closing it wakes the
+        router's ``receive_text()`` loop, which runs the normal ``disconnect``
+        path and the presence grace timer with it. Unregistering here instead
+        would swallow the ``presence.offline`` broadcast.
+        """
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return  # No loop (sync context) — the next send will prune it.
+
+        async def _close() -> None:
+            with contextlib.suppress(Exception):
+                await websocket.close(code=1001, reason="Stale connection")
+
+        with contextlib.suppress(Exception):
+            loop.create_task(_close())
+
+    def is_online(self, user_id: str) -> bool:
+        """Check whether a user has at least one LIVE connection.
+
+        "Live" means traffic inside ``LIVENESS_STALE_SECONDS``, not merely a
+        socket object in the registry — see the module docstring. Sockets past
+        the window are closed best-effort on the way through, so the verdict
+        and the cleanup converge without a separate sweeper.
+        """
+        conns = self.active_connections.get(user_id)
+        if not conns:
+            return False
+
+        now = time.monotonic()
+        live = False
+        for ws in list(conns):
+            if self._is_fresh(ws, now=now):
+                live = True
+            else:
+                self._close_stale(ws)
+        return live
+
+    async def send_to_user(self, user_id: str, message: WsOutbound) -> int:
+        """Send a message to all of a user's connections.
+
+        Returns the number of sockets that ACCEPTED the frame. Zero means the
+        user looked connected but nothing was delivered (every socket was dead
+        and got pruned) — the signal ``push.dispatch.notify`` uses to fall back
+        to Web Push instead of dropping the notification.
+        """
         data = message.model_dump(mode="json")
+        delivered = 0
         dead: list[WebSocket] = []
         for ws in self.get_user_connections(user_id):
             try:
                 await ws.send_json(data)
             except Exception:
                 dead.append(ws)
+            else:
+                delivered += 1
+                # A send the socket accepted is proof of life for the liveness
+                # window — idle-but-healthy clients that never send anything
+                # inbound stay online on outbound traffic alone.
+                self.touch(ws)
         # Clean up dead connections
         for ws in dead:
             await self.disconnect(ws)
+        return delivered
 
     async def broadcast_to_group(
         self,
@@ -156,6 +255,8 @@ class ConnectionManager:
                 await ws.send_json(data)
             except Exception:
                 dead.append(ws)
+            else:
+                self.touch(ws)
         for ws in dead:
             await self.disconnect(ws)
 

--- a/ee/pocketpaw_ee/cloud/chat/ws.py
+++ b/ee/pocketpaw_ee/cloud/chat/ws.py
@@ -15,12 +15,27 @@ Updated: 2026-08-11 (fix/notif-liveness-dispatch) — ``is_online`` used to mean
 asleep, NAT timeout) satisfies indefinitely: the TCP close never arrives, so
 the registry keeps a socket nobody is listening on. Notification dispatch
 reads that verdict to pick WS over Web Push, so a zombie socket silently ate
-the notification. Liveness is now traffic-based: every socket carries a
-last-activity stamp, refreshed on any inbound frame (``touch``, called from
-the router's receive loop) and on any successful outbound send. A socket with
-no traffic in EITHER direction for ``LIVENESS_STALE_SECONDS`` is presumed
-zombie — excluded from the verdict and closed best-effort, which wakes the
-router's receive loop so the normal disconnect/presence path runs.
+the notification.
+
+Liveness is now **capability-gated**, because the honest signal is only
+available from clients that ping:
+
+- A socket that has sent a ``ping`` frame is marked ping-capable
+  (``mark_ping_capable``, called from the router's ping branch — capability is
+  proved by behaviour, not assumed). For these, liveness is INBOUND traffic
+  inside ``LIVENESS_STALE_SECONDS``. Outbound sends are deliberately excluded:
+  a write to a half-open socket succeeds for minutes because the kernel
+  buffers it, so counting outbound would let workspace fan-out resurrect a
+  zombie forever. Past the window the socket is dropped from the verdict and
+  closed best-effort, which wakes the receive loop so the normal
+  disconnect/presence path runs.
+- Every other socket (older FE bundles that never ping) keeps the legacy
+  "live while registered" verdict. They send nothing for long stretches while
+  perfectly alive, so applying staleness would churn them into a
+  close/reconnect loop. Their safety net is unchanged: the dispatch
+  zero-accept fallback in ``push/dispatch.py``. That also removes any
+  deployment-ordering constraint against the FE ping rollout — this can ship
+  first, and each client tightens itself the moment it starts pinging.
 """
 
 from __future__ import annotations
@@ -38,10 +53,9 @@ logger = logging.getLogger(__name__)
 
 TYPING_TIMEOUT_SECONDS = 5
 PRESENCE_GRACE_SECONDS = 30
-# A socket with no traffic in either direction for this long is presumed dead.
-# Comfortably above the ~30s cadence of ordinary workspace chatter (presence
-# deltas, chat fan-out, client pings) so an idle-but-healthy socket in an
-# active workspace stays fresh on outbound traffic alone.
+# A ping-capable socket silent this long is presumed dead. Sized at two missed
+# 30s client pings, so a single dropped heartbeat never flips a healthy client
+# offline. Sockets that don't ping are exempt entirely (see _is_fresh).
 LIVENESS_STALE_SECONDS = 60
 
 
@@ -59,9 +73,21 @@ class ConnectionManager:
         self._typing_timers: dict[tuple[str, str], asyncio.Task] = {}
         # Current room per socket (at most one): ws -> group_id
         self._ws_to_room: dict[WebSocket, str] = {}
-        # ws -> monotonic timestamp of the last traffic in EITHER direction
-        # (inbound frame received, or outbound send the socket accepted).
-        self._ws_last_seen: dict[WebSocket, float] = {}
+        # ws -> monotonic timestamp of the last INBOUND frame. This is the only
+        # input to the freshness verdict; see _is_fresh for why outbound is not.
+        self._ws_last_inbound: dict[WebSocket, float] = {}
+        # ws -> monotonic timestamp of the last outbound send the socket
+        # accepted. Diagnostics only — deliberately NOT part of freshness.
+        self._ws_last_outbound: dict[WebSocket, float] = {}
+        # Sockets that have proved they speak the ping heartbeat. Only these
+        # are subject to staleness; everything else keeps legacy semantics.
+        self._ping_capable: set[WebSocket] = set()
+        # Sockets with a close already in flight, so repeated is_online calls
+        # don't pile up duplicate close tasks for the same socket.
+        self._closing: set[WebSocket] = set()
+        # Strong refs to in-flight close tasks — a bare create_task result is
+        # only weakly held by the loop and can be GC'd mid-await.
+        self._close_tasks: set[asyncio.Task] = set()
 
     async def connect(self, websocket: WebSocket, user_id: str) -> None:
         """Register an authenticated WebSocket connection."""
@@ -91,7 +117,10 @@ class ConnectionManager:
         """
         # Always clear any room association, regardless of user mapping.
         self._ws_to_room.pop(websocket, None)
-        self._ws_last_seen.pop(websocket, None)
+        self._ws_last_inbound.pop(websocket, None)
+        self._ws_last_outbound.pop(websocket, None)
+        self._ping_capable.discard(websocket)
+        self._closing.discard(websocket)
 
         user_id = self._ws_to_user.pop(websocket, None)
         if not user_id:
@@ -115,24 +144,61 @@ class ConnectionManager:
     # Liveness
     # ------------------------------------------------------------------
 
-    def touch(self, websocket: WebSocket) -> None:
-        """Record traffic on a socket, refreshing its liveness window.
+    def mark_ping_capable(self, websocket: WebSocket) -> None:
+        """Record that this socket speaks the ping heartbeat.
 
-        Called by the router's receive loop on EVERY inbound frame (including
-        the client's ``ping`` heartbeat) and internally on every outbound send
-        the socket accepted. Untracked sockets are ignored — a socket that has
+        Called from the router's ``ping`` branch, so capability is proved by
+        observed behaviour rather than assumed from a version string. Only
+        capable sockets are subject to staleness — see :meth:`_is_fresh`.
+        Idempotent; untracked sockets are ignored.
+        """
+        if websocket in self._ws_to_user:
+            self._ping_capable.add(websocket)
+
+    def touch(self, websocket: WebSocket) -> None:
+        """Record an INBOUND frame, refreshing the socket's liveness window.
+
+        Called by the router's receive loop on every inbound frame (the ping
+        heartbeat included). Untracked sockets are ignored — a socket that has
         already been disconnected must not resurrect itself here.
         """
         if websocket in self._ws_to_user:
-            self._ws_last_seen[websocket] = time.monotonic()
+            self._ws_last_inbound[websocket] = time.monotonic()
+
+    def _mark_outbound(self, websocket: WebSocket) -> None:
+        """Record an outbound send the socket accepted. Diagnostics only.
+
+        Explicitly NOT an input to :meth:`_is_fresh` — see the note there on
+        why a successful write proves nothing about a half-open socket.
+        """
+        if websocket in self._ws_to_user:
+            self._ws_last_outbound[websocket] = time.monotonic()
 
     def _is_fresh(self, websocket: WebSocket, *, now: float) -> bool:
-        """True when the socket has seen traffic inside the liveness window."""
-        last_seen = self._ws_last_seen.get(websocket)
-        if last_seen is None:
-            # Tracked but never stamped — treat as stale rather than trusting it.
+        """True when the socket should be treated as live.
+
+        Two regimes, keyed on whether the client has proved it pings:
+
+        - **Ping-capable** — freshness is INBOUND traffic only. Outbound sends
+          are not evidence: ``send_json`` to a half-open socket succeeds for
+          minutes (the kernel just buffers the write), so counting them would
+          let workspace fan-out resurrect a zombie forever in a busy workspace,
+          which is the exact bug this liveness work exists to kill.
+        - **Not ping-capable** — legacy semantics: live while registered. Old
+          FE bundles send nothing for long stretches while perfectly alive, so
+          staleness would churn them into a close/reconnect loop. Their safety
+          net stays the dispatch zero-accept fallback, exactly as before this
+          change — no regression, and no ordering constraint against the FE
+          ping rollout.
+        """
+        if websocket not in self._ping_capable:
+            return True
+
+        last_inbound = self._ws_last_inbound.get(websocket)
+        if last_inbound is None:
+            # Capable but never stamped — treat as stale rather than trusting it.
             return False
-        return (now - last_seen) < LIVENESS_STALE_SECONDS
+        return (now - last_inbound) < LIVENESS_STALE_SECONDS
 
     def _close_stale(self, websocket: WebSocket) -> None:
         """Best-effort close of a presumed-zombie socket. Never raises.
@@ -142,6 +208,9 @@ class ConnectionManager:
         path and the presence grace timer with it. Unregistering here instead
         would swallow the ``presence.offline`` broadcast.
         """
+        if websocket in self._closing:
+            return  # A close is already in flight for this socket.
+
         try:
             loop = asyncio.get_running_loop()
         except RuntimeError:
@@ -151,16 +220,25 @@ class ConnectionManager:
             with contextlib.suppress(Exception):
                 await websocket.close(code=1001, reason="Stale connection")
 
-        with contextlib.suppress(Exception):
-            loop.create_task(_close())
+        try:
+            task = loop.create_task(_close())
+        except Exception:
+            return
+        # Hold a strong ref until the task finishes: the event loop only keeps
+        # a weak one, so an unreferenced task can be collected mid-close.
+        self._closing.add(websocket)
+        self._close_tasks.add(task)
+        task.add_done_callback(self._close_tasks.discard)
+        task.add_done_callback(lambda _t: self._closing.discard(websocket))
 
     def is_online(self, user_id: str) -> bool:
         """Check whether a user has at least one LIVE connection.
 
-        "Live" means traffic inside ``LIVENESS_STALE_SECONDS``, not merely a
-        socket object in the registry — see the module docstring. Sockets past
-        the window are closed best-effort on the way through, so the verdict
-        and the cleanup converge without a separate sweeper.
+        For a ping-capable client "live" means an inbound frame inside
+        ``LIVENESS_STALE_SECONDS``, not merely a socket object in the registry
+        — see :meth:`_is_fresh` and the module docstring. Stale sockets are
+        closed best-effort on the way through, so the verdict and the cleanup
+        converge without a separate sweeper.
         """
         conns = self.active_connections.get(user_id)
         if not conns:
@@ -186,17 +264,18 @@ class ConnectionManager:
         data = message.model_dump(mode="json")
         delivered = 0
         dead: list[WebSocket] = []
-        for ws in self.get_user_connections(user_id):
+        # Iterate a COPY: a concurrent _close_stale → disconnect mutates the
+        # live set, and the resulting "set changed size during iteration" fires
+        # at the for statement — outside the per-send try — so it would escape
+        # to notify() and be mistaken for a WS failure, skipping the fallback.
+        for ws in list(self.get_user_connections(user_id)):
             try:
                 await ws.send_json(data)
             except Exception:
                 dead.append(ws)
             else:
                 delivered += 1
-                # A send the socket accepted is proof of life for the liveness
-                # window — idle-but-healthy clients that never send anything
-                # inbound stay online on outbound traffic alone.
-                self.touch(ws)
+                self._mark_outbound(ws)
         # Clean up dead connections
         for ws in dead:
             await self.disconnect(ws)
@@ -256,7 +335,7 @@ class ConnectionManager:
             except Exception:
                 dead.append(ws)
             else:
-                self.touch(ws)
+                self._mark_outbound(ws)
         for ws in dead:
             await self.disconnect(ws)
 

--- a/ee/pocketpaw_ee/cloud/models/notification.py
+++ b/ee/pocketpaw_ee/cloud/models/notification.py
@@ -52,7 +52,13 @@ class Notification(TimestampedDocument):
     class Settings:
         name = "notifications"
         indexes = [
-            # The bell's list query: this recipient's unread, newest first.
+            # The bell's DEFAULT list query (list_for_user with unread=False):
+            # filters recipient only, sorts newest first. The three-key index
+            # below cannot serve this — skipping a middle key leaves ``read``
+            # as a gap, so the sort can't ride the index.
+            IndexModel([("recipient", 1), ("createdAt", -1)]),
+            # The unread variant: recipient + read, newest first. Its
+            # (recipient, read) prefix also serves count_unread.
             # Sorts on ``createdAt`` — TimestampedDocument's camelCase field,
             # NOT ``created_at``, which does not exist on this document.
             IndexModel([("recipient", 1), ("read", 1), ("createdAt", -1)]),

--- a/ee/pocketpaw_ee/cloud/models/notification.py
+++ b/ee/pocketpaw_ee/cloud/models/notification.py
@@ -1,4 +1,13 @@
-"""Notification document."""
+"""Notification document.
+
+Updated: 2026-08-11 (fix/notif-liveness-dispatch) — the inbox index named
+``created_at``, a field this document does not have: timestamps come from
+``TimestampedDocument`` as camelCase ``createdAt`` (no alias), so the sort key
+pointed at nothing and the bell's newest-first query fell back to a collection
+scan. Fixed to ``createdAt``, and a TTL index added so notification rows age
+out at 90 days like their five sibling collections instead of accumulating
+forever.
+"""
 
 from __future__ import annotations
 
@@ -6,6 +15,7 @@ from datetime import datetime
 
 from beanie import Indexed
 from pydantic import BaseModel
+from pymongo import IndexModel
 
 from pocketpaw_ee.cloud.models.base import TimestampedDocument
 
@@ -33,10 +43,20 @@ class Notification(TimestampedDocument):
     body: str = ""
     source: NotificationSource | None = None
     read: bool = False
+    # DEAD FIELD — nothing writes it. The sole writer (notifications/service.py
+    # ``create``) never sets it, so it is None on every row and can back no TTL.
+    # Expiry runs off ``createdAt`` below. Kept for now so existing documents
+    # deserialize; removal is deferred to a dedicated cleanup.
     expires_at: datetime | None = None
 
     class Settings:
         name = "notifications"
         indexes = [
-            [("recipient", 1), ("read", 1), ("created_at", -1)],
+            # The bell's list query: this recipient's unread, newest first.
+            # Sorts on ``createdAt`` — TimestampedDocument's camelCase field,
+            # NOT ``created_at``, which does not exist on this document.
+            IndexModel([("recipient", 1), ("read", 1), ("createdAt", -1)]),
+            # Mongo auto-deletes notifications older than 90 days. Nobody reads
+            # a three-month-old bell item, and the collection is append-heavy.
+            IndexModel([("createdAt", 1)], expireAfterSeconds=86400 * 90),
         ]

--- a/ee/pocketpaw_ee/cloud/push/dispatch.py
+++ b/ee/pocketpaw_ee/cloud/push/dispatch.py
@@ -155,8 +155,7 @@ async def notify(
         # fall through to Web Push. Double-notify is not a risk here: zero
         # sockets received the WS event.
         logger.info(
-            "ws notification reached no sockets, falling back to web push "
-            "for workspace=%s user=%s",
+            "ws notification reached no sockets, falling back to web push for workspace=%s user=%s",
             workspace_id,
             user_id,
         )

--- a/ee/pocketpaw_ee/cloud/push/dispatch.py
+++ b/ee/pocketpaw_ee/cloud/push/dispatch.py
@@ -18,6 +18,15 @@
 # ``service.send_to_user`` which prunes dead rows as before). The liveness
 # check and the chosen transport are surfaced on a returned ``NotifyResult``
 # so the fork is observable and unit-testable without real sockets.
+#
+# Updated: 2026-08-11 (fix/notif-liveness-dispatch) — the dedupe used to trust
+# the liveness verdict absolutely, so a half-open socket (laptop asleep, NAT
+# timeout) took the WS leg into a dead pipe and the notification was lost: WS
+# delivered nothing, Web Push was skipped by the dedupe. The WS leg now reports
+# how many sockets ACCEPTED the frame; zero means "looked live, reached nobody"
+# and falls through to Web Push in the same call, recorded as the
+# ``ws_fallback_push`` transport. ``is_online`` itself got stricter upstream
+# (traffic-based liveness in chat/ws.py) — this is the safety net beneath it.
 
 from __future__ import annotations
 
@@ -42,11 +51,17 @@ WS_NOTIFICATION_TYPE = "notification.push"
 class NotifyResult:
     """Outcome of a single :func:`notify` dispatch.
 
-    ``transport`` is the leg actually taken — ``"ws"`` when the user had a
-    live WebSocket connection (Web Push was skipped) or ``"push"`` when it
-    fell back to Web Push. ``ws_delivered`` is True only on the WS leg.
-    ``send`` carries the Web Push fan-out summary on the push leg (None on
-    the WS leg, since Web Push never ran).
+    ``transport`` is the leg actually taken:
+
+    - ``"ws"`` — the user had a live socket that accepted the frame; Web Push
+      was skipped (the dedupe).
+    - ``"push"`` — no live connection, so Web Push carried it.
+    - ``"ws_fallback_push"`` — the user LOOKED live but the frame reached zero
+      sockets (half-open / zombie), so Web Push carried it after all.
+
+    ``ws_delivered`` is True only when the WS leg actually landed. ``send``
+    carries the Web Push fan-out summary on both push legs (None on the WS
+    leg, since Web Push never ran).
     """
 
     transport: str = "push"
@@ -75,8 +90,13 @@ def _is_user_live(user_id: str) -> bool:
     return manager.is_online(user_id)
 
 
-async def _send_over_ws(user_id: str, payload: PushPayload) -> None:
-    """Push a lightweight notification event to a user's live sockets."""
+async def _send_over_ws(user_id: str, payload: PushPayload) -> int:
+    """Push a lightweight notification event to a user's live sockets.
+
+    Returns the number of sockets that accepted the frame — 0 means the send
+    reached nobody, which the caller treats as "not delivered" and falls back
+    to Web Push.
+    """
     from pocketpaw_ee.cloud.chat.schemas import WsOutbound
     from pocketpaw_ee.cloud.chat.ws import manager
 
@@ -84,7 +104,7 @@ async def _send_over_ws(user_id: str, payload: PushPayload) -> None:
         type=WS_NOTIFICATION_TYPE,
         data=payload.model_dump(exclude_none=True),
     )
-    await manager.send_to_user(user_id, message)
+    return await manager.send_to_user(user_id, message)
 
 
 # ---------------------------------------------------------------------------
@@ -115,7 +135,7 @@ async def notify(
     if _is_user_live(user_id):
         # Live desktop/browser client → WS only, skip Web Push (the dedupe).
         try:
-            await _send_over_ws(user_id, payload)
+            delivered = await _send_over_ws(user_id, payload)
         except Exception:
             # A WS failure must not silently drop the notification, but the
             # send_to_user fan-out is a separate path with its own pruning;
@@ -126,7 +146,22 @@ async def notify(
                 user_id,
             )
             return NotifyResult(transport="ws", ws_delivered=False)
-        return NotifyResult(transport="ws", ws_delivered=True)
+
+        if delivered:
+            return NotifyResult(transport="ws", ws_delivered=True)
+
+        # Looked live, reached nobody — every socket was half-open and got
+        # pruned mid-send. The dedupe would drop the notification entirely, so
+        # fall through to Web Push. Double-notify is not a risk here: zero
+        # sockets received the WS event.
+        logger.info(
+            "ws notification reached no sockets, falling back to web push "
+            "for workspace=%s user=%s",
+            workspace_id,
+            user_id,
+        )
+        result = await push_service.send_to_user(workspace_id, user_id, payload)
+        return NotifyResult(transport="ws_fallback_push", ws_delivered=False, send=result)
 
     # No live connection → Web Push fallback.
     result = await push_service.send_to_user(workspace_id, user_id, payload)

--- a/tests/cloud/notifications/test_model_indexes.py
+++ b/tests/cloud/notifications/test_model_indexes.py
@@ -1,0 +1,71 @@
+# Index-shape contract for the Notification document.
+# Created: 2026-08-11 (fix/notif-liveness-dispatch) — the inbox index was
+# declared on ``created_at``, which this document does not have: timestamps
+# come from TimestampedDocument as camelCase ``createdAt`` with no alias, so
+# the sort key named a nonexistent field and the bell's newest-first query got
+# no index for its sort. The mismatch was invisible — Mongo happily builds an
+# index on a missing field and the query just scans. These assertions pin the
+# field name against the actual model attribute (not a hardcoded string on both
+# sides) and pin the TTL that stops the collection growing forever.
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.models.notification import Notification
+from pymongo import IndexModel
+
+TTL_SECONDS = 86400 * 90
+
+
+def _index_keys(index: IndexModel) -> list[tuple[str, int]]:
+    return list(index.document["key"].items())
+
+
+def _indexes() -> list[IndexModel]:
+    return list(Notification.Settings.indexes)
+
+
+def test_timestamp_field_is_camel_case_on_the_document() -> None:
+    # The premise of the whole fix: the field is createdAt, not created_at.
+    # If a future refactor adds a snake_case alias, this fails first and the
+    # index assertions below become the thing to revisit.
+    assert "createdAt" in Notification.model_fields
+    assert "created_at" not in Notification.model_fields
+
+
+def test_inbox_index_sorts_on_the_real_timestamp_field() -> None:
+    inbox = [
+        idx
+        for idx in _indexes()
+        if [k for k, _ in _index_keys(idx)] == ["recipient", "read", "createdAt"]
+    ]
+    assert len(inbox) == 1, "the recipient/read/createdAt inbox index is missing"
+
+    keys = _index_keys(inbox[0])
+    assert keys[-1] == ("createdAt", -1), "newest-first sort must be descending"
+
+
+def test_no_index_names_a_nonexistent_field() -> None:
+    # Catches the original bug shape generally: every indexed key must be a
+    # real field on the document.
+    fields = set(Notification.model_fields)
+    for idx in _indexes():
+        for key, _direction in _index_keys(idx):
+            root = key.split(".")[0]
+            assert root in fields, f"index key {key!r} is not a field on Notification"
+
+
+def test_ttl_index_expires_rows_at_ninety_days() -> None:
+    ttl = [idx for idx in _indexes() if "expireAfterSeconds" in idx.document]
+    assert len(ttl) == 1, "notifications must have exactly one TTL index"
+
+    doc = ttl[0].document
+    assert doc["expireAfterSeconds"] == TTL_SECONDS
+    # TTL must hang off createdAt: expires_at is a dead field nothing writes,
+    # so a TTL on it would never expire anything.
+    assert _index_keys(ttl[0]) == [("createdAt", 1)]
+
+
+def test_expires_at_is_still_declared_but_unwritten() -> None:
+    # Documented dead field — kept so existing rows deserialize. If something
+    # starts writing it, revisit whether the TTL should move onto it.
+    assert Notification.model_fields["expires_at"].default is None

--- a/tests/cloud/notifications/test_model_indexes.py
+++ b/tests/cloud/notifications/test_model_indexes.py
@@ -44,6 +44,19 @@ def test_inbox_index_sorts_on_the_real_timestamp_field() -> None:
     assert keys[-1] == ("createdAt", -1), "newest-first sort must be descending"
 
 
+def test_default_list_query_has_a_recipient_only_index() -> None:
+    # list_for_user's DEFAULT query (unread=False) filters recipient alone and
+    # sorts createdAt. The three-key index cannot serve it — skipping the
+    # middle `read` key leaves a gap, so the sort can't ride the index and
+    # Mongo falls back to an in-memory sort. The bell's most common query is
+    # exactly this one, so it needs its own index.
+    default_query = [
+        idx for idx in _indexes() if [k for k, _ in _index_keys(idx)] == ["recipient", "createdAt"]
+    ]
+    assert len(default_query) == 1, "the recipient/createdAt index is missing"
+    assert _index_keys(default_query[0])[-1] == ("createdAt", -1)
+
+
 def test_no_index_names_a_nonexistent_field() -> None:
     # Catches the original bug shape generally: every indexed key must be a
     # real field on the document.

--- a/tests/cloud/push/test_dispatch.py
+++ b/tests/cloud/push/test_dispatch.py
@@ -211,3 +211,138 @@ async def test_liveness_seam_reflects_connection_manager(monkeypatch) -> None:
         assert sent["data"]["title"] == "Hi"
     finally:
         await manager.disconnect(ws)
+
+
+# ---------------------------------------------------------------------------
+# Real-seam integration — a REAL ConnectionManager drives both legs.
+#
+# The zombie test above fakes both seams, so it pins notify()'s branching but
+# proves nothing about the manager it actually talks to. These swap in a real
+# ConnectionManager (the lazy `from ...chat.ws import manager` inside each seam
+# resolves the module attribute at call time, so patching it injects a real
+# instance) and assert the notification survives every zombie shape.
+# ---------------------------------------------------------------------------
+
+
+def _real_manager(monkeypatch):
+    from pocketpaw_ee.cloud.chat import ws as ws_module
+
+    manager = ws_module.ConnectionManager()
+    monkeypatch.setattr(ws_module, "manager", manager)
+    return manager
+
+
+async def test_real_seam_legacy_zombie_falls_back_to_push(monkeypatch) -> None:
+    # A non-ping-capable (old FE bundle) socket: is_online says live because
+    # legacy semantics trust the registry, but the write fails, so the WS leg
+    # reaches zero sockets. This is the safety net that keeps old clients from
+    # regressing — driven end to end through the real manager.
+    from unittest.mock import AsyncMock
+
+    manager = _real_manager(monkeypatch)
+
+    dead_socket = AsyncMock()
+    dead_socket.send_json.side_effect = RuntimeError("broken pipe")
+    await manager.connect(dead_socket, "u1")
+
+    push_calls: list = []
+
+    async def fake_send(workspace_id, user_id, payload):
+        push_calls.append(user_id)
+        return SendResult(sent=1)
+
+    monkeypatch.setattr(dispatch.push_service, "send_to_user", fake_send)
+
+    assert manager.is_online("u1") is True  # legacy verdict: registered == live
+
+    result = await dispatch.notify("w1", "u1", _PAYLOAD)
+
+    assert result.transport == "ws_fallback_push"
+    assert push_calls == ["u1"]
+
+
+async def test_real_seam_ping_capable_zombie_falls_back_to_push(monkeypatch) -> None:
+    # A ping-capable client that is still inside its window (so is_online says
+    # live) but whose socket has actually died — the moment the TCP stack gives
+    # up mid-send. Zero accepted → Web Push carries it.
+    from unittest.mock import AsyncMock
+
+    manager = _real_manager(monkeypatch)
+
+    dead_socket = AsyncMock()
+    dead_socket.send_json.side_effect = RuntimeError("broken pipe")
+    await manager.connect(dead_socket, "u1")
+    manager.mark_ping_capable(dead_socket)  # fresh: connect stamped inbound
+
+    push_calls: list = []
+
+    async def fake_send(workspace_id, user_id, payload):
+        push_calls.append(user_id)
+        return SendResult(sent=1)
+
+    monkeypatch.setattr(dispatch.push_service, "send_to_user", fake_send)
+
+    result = await dispatch.notify("w1", "u1", _PAYLOAD)
+
+    assert result.transport == "ws_fallback_push"
+    assert push_calls == ["u1"]
+
+
+async def test_real_seam_stale_ping_capable_socket_takes_the_push_leg(monkeypatch) -> None:
+    # The stale-inbound zombie. Note the transport is 'push', NOT
+    # 'ws_fallback_push': is_online correctly rules the socket dead BEFORE the
+    # WS leg is attempted, so there is no failed WS attempt to fall back from.
+    # What matters for the bug is identical — the notification is delivered,
+    # not dropped.
+    import time
+    from unittest.mock import AsyncMock
+
+    from pocketpaw_ee.cloud.chat.ws import LIVENESS_STALE_SECONDS
+
+    manager = _real_manager(monkeypatch)
+
+    zombie = AsyncMock()
+    await manager.connect(zombie, "u1")
+    manager.mark_ping_capable(zombie)
+    manager._ws_last_inbound[zombie] = time.monotonic() - (LIVENESS_STALE_SECONDS + 1)
+
+    push_calls: list = []
+
+    async def fake_send(workspace_id, user_id, payload):
+        push_calls.append(user_id)
+        return SendResult(sent=1)
+
+    monkeypatch.setattr(dispatch.push_service, "send_to_user", fake_send)
+
+    result = await dispatch.notify("w1", "u1", _PAYLOAD)
+
+    assert result.transport == "push"
+    assert push_calls == ["u1"]
+    # The WS event never went into the dead pipe.
+    assert zombie.send_json.await_count == 0
+
+
+async def test_real_seam_healthy_socket_still_takes_the_ws_leg(monkeypatch) -> None:
+    # The dedupe must survive all of the above: a live client gets WS only.
+    from unittest.mock import AsyncMock
+
+    manager = _real_manager(monkeypatch)
+
+    healthy = AsyncMock()
+    await manager.connect(healthy, "u1")
+    manager.mark_ping_capable(healthy)
+
+    push_calls: list = []
+
+    async def fake_send(workspace_id, user_id, payload):
+        push_calls.append(user_id)
+        return SendResult()
+
+    monkeypatch.setattr(dispatch.push_service, "send_to_user", fake_send)
+
+    result = await dispatch.notify("w1", "u1", _PAYLOAD)
+
+    assert result.transport == "ws"
+    assert result.ws_delivered is True
+    assert push_calls == []
+    assert healthy.send_json.await_count == 1

--- a/tests/cloud/push/test_dispatch.py
+++ b/tests/cloud/push/test_dispatch.py
@@ -10,6 +10,11 @@
 # network. The liveness check and the WS send are patched via the module's
 # injectable seams (``_is_user_live`` / ``_send_over_ws``); one integration
 # test drives the real ConnectionManager singleton to prove the seam matches.
+# Updated: 2026-08-11 (fix/notif-liveness-dispatch) — ``_send_over_ws`` now
+# returns the number of sockets that actually accepted the frame, so the
+# zombie case (user "has" a socket, delivery reaches ZERO of them) falls back
+# to Web Push instead of dropping the notification. The seam fakes therefore
+# return a count, and a new test pins ``transport == "ws_fallback_push"``.
 
 from __future__ import annotations
 
@@ -29,8 +34,9 @@ async def test_live_user_delivers_ws_and_skips_web_push(monkeypatch) -> None:
 
     ws_sent: list[tuple[str, PushPayload]] = []
 
-    async def fake_ws(user_id: str, payload: PushPayload) -> None:
+    async def fake_ws(user_id: str, payload: PushPayload) -> int:
         ws_sent.append((user_id, payload))
+        return 1  # one socket accepted the frame
 
     monkeypatch.setattr(dispatch, "_send_over_ws", fake_ws)
 
@@ -96,6 +102,7 @@ async def test_dispatch_validates_dict_payload(monkeypatch) -> None:
 
     async def fake_ws(user_id, payload):
         captured["payload"] = payload
+        return 1
 
     monkeypatch.setattr(dispatch, "_send_over_ws", fake_ws)
 
@@ -128,6 +135,45 @@ async def test_ws_failure_does_not_double_send_over_push(monkeypatch) -> None:
     assert result.transport == "ws"
     assert result.ws_delivered is False
     assert push_calls == []  # Web Push was NOT used as a fallback.
+
+
+# ---------------------------------------------------------------------------
+# Zombie socket — "live" by the registry, but the frame reaches nobody.
+# ---------------------------------------------------------------------------
+
+
+async def test_zombie_socket_falls_back_to_web_push(monkeypatch) -> None:
+    # The half-open socket case: the connection registry still holds a socket
+    # for the user (laptop asleep, NAT timeout — the TCP close never arrived),
+    # so the liveness check says live, but the send reaches ZERO sockets. Before
+    # the fix the notification was dropped on the floor: WS leg taken, Web Push
+    # skipped by the dedupe, nothing delivered. Now the zero-delivery signal
+    # falls the dispatch through to Web Push in the same call.
+    monkeypatch.setattr(dispatch, "_is_user_live", lambda uid: True)
+
+    async def dead_ws(user_id, payload):
+        return 0  # every socket was dead and got pruned mid-send
+
+    monkeypatch.setattr(dispatch, "_send_over_ws", dead_ws)
+
+    push_calls: list = []
+
+    async def fake_send(workspace_id, user_id, payload):
+        push_calls.append((workspace_id, user_id, payload))
+        return SendResult(sent=1, pruned=1)
+
+    monkeypatch.setattr(dispatch.push_service, "send_to_user", fake_send)
+
+    result = await dispatch.notify("w1", "zombie", _PAYLOAD)
+
+    assert result.transport == "ws_fallback_push"
+    assert result.ws_delivered is False
+    # The Web Push leg actually ran, with the same payload.
+    assert len(push_calls) == 1
+    assert push_calls[0][1] == "zombie"
+    assert push_calls[0][2].title == "Hi"
+    assert result.send is not None
+    assert result.send.sent == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cloud/test_ws.py
+++ b/tests/cloud/test_ws.py
@@ -1,13 +1,19 @@
-"""Tests for the WebSocket connection manager."""
+"""Tests for the WebSocket connection manager.
+
+Updated: 2026-08-11 (fix/notif-liveness-dispatch) — added the liveness block at
+the bottom: ``is_online`` now means "traffic seen inside the window", and
+``send_to_user`` reports how many sockets accepted the frame.
+"""
 
 from __future__ import annotations
 
 import asyncio
+import time
 from unittest.mock import AsyncMock
 
 import pytest
 from pocketpaw_ee.cloud.chat.schemas import WsOutbound
-from pocketpaw_ee.cloud.chat.ws import ConnectionManager
+from pocketpaw_ee.cloud.chat.ws import LIVENESS_STALE_SECONDS, ConnectionManager
 
 
 @pytest.fixture
@@ -180,3 +186,114 @@ async def test_connect_cancels_pending_offline_task(cm):
     await asyncio.sleep(0)
     assert task.cancelled()
     assert "u1" not in cm._offline_tasks
+
+
+# ---------------------------------------------------------------------------
+# Liveness — is_online means "traffic seen recently", not "socket in the dict"
+# (fix/notif-liveness-dispatch, 2026-08-11). A half-open socket used to report
+# online forever, so notification dispatch took the WS leg into a dead pipe and
+# skipped Web Push. These pin the traffic-based verdict in both directions.
+# ---------------------------------------------------------------------------
+
+
+def _backdate(cm, ws, seconds: float) -> None:
+    """Age a socket's last-activity stamp by ``seconds``."""
+    cm._ws_last_seen[ws] = time.monotonic() - seconds
+
+
+async def test_is_online_false_for_stale_socket(cm):
+    # The zombie: registered, never closed, silent past the liveness window.
+    ws = AsyncMock()
+    await cm.connect(ws, "u1")
+    assert cm.is_online("u1")
+
+    _backdate(cm, ws, LIVENESS_STALE_SECONDS + 1)
+
+    assert not cm.is_online("u1")
+
+
+async def test_stale_socket_is_closed_best_effort(cm):
+    # The verdict and the cleanup converge: checking liveness closes the zombie,
+    # which wakes the router's receive loop into the normal disconnect path.
+    ws = AsyncMock()
+    await cm.connect(ws, "u1")
+    _backdate(cm, ws, LIVENESS_STALE_SECONDS + 1)
+
+    assert not cm.is_online("u1")
+    await asyncio.sleep(0)  # let the fire-and-forget close task run
+
+    assert ws.close.await_count == 1
+    # The socket is NOT unregistered here — disconnect() owns that, so the
+    # presence.offline grace broadcast still fires through the usual path.
+    assert ws in cm.get_user_connections("u1")
+
+
+async def test_inbound_touch_keeps_socket_live(cm):
+    # What the router calls on every inbound frame (ping included).
+    ws = AsyncMock()
+    await cm.connect(ws, "u1")
+    _backdate(cm, ws, LIVENESS_STALE_SECONDS + 1)
+    assert not cm.is_online("u1")
+
+    cm.touch(ws)
+
+    assert cm.is_online("u1")
+
+
+async def test_successful_send_keeps_idle_socket_live(cm):
+    # Backward-compat clause: today's clients send nothing for long stretches
+    # while idle-but-alive, so an outbound send the socket ACCEPTED counts as
+    # proof of life. Without this, every quiet client would look like a zombie.
+    ws = AsyncMock()
+    await cm.connect(ws, "u1")
+    _backdate(cm, ws, LIVENESS_STALE_SECONDS + 1)
+    assert not cm.is_online("u1")
+
+    delivered = await cm.send_to_user("u1", WsOutbound(type="test", data={}))
+
+    assert delivered == 1
+    assert cm.is_online("u1")
+
+
+async def test_only_live_socket_makes_user_online(cm):
+    # Multi-device: one zombie tab, one live desktop → still online.
+    zombie = AsyncMock()
+    live = AsyncMock()
+    await cm.connect(zombie, "u1")
+    await cm.connect(live, "u1")
+    _backdate(cm, zombie, LIVENESS_STALE_SECONDS + 1)
+
+    assert cm.is_online("u1")
+
+
+async def test_send_to_user_returns_delivery_count(cm):
+    # The signal dispatch.notify reads: zero delivered means "looked live,
+    # reached nobody" and must fall back to Web Push.
+    dead = AsyncMock()
+    dead.send_json.side_effect = RuntimeError("socket closed")
+    await cm.connect(dead, "u1")
+
+    delivered = await cm.send_to_user("u1", WsOutbound(type="test", data={}))
+
+    assert delivered == 0
+    # The dead socket was pruned by the send itself.
+    assert cm.get_user_connections("u1") == set()
+
+
+async def test_send_to_user_counts_only_accepted_sockets(cm):
+    ok = AsyncMock()
+    dead = AsyncMock()
+    dead.send_json.side_effect = RuntimeError("socket closed")
+    await cm.connect(ok, "u1")
+    await cm.connect(dead, "u1")
+
+    delivered = await cm.send_to_user("u1", WsOutbound(type="test", data={}))
+
+    assert delivered == 1
+
+
+def test_touch_ignores_unknown_socket(cm):
+    # A socket already disconnected must not resurrect itself into the registry.
+    ws = AsyncMock()
+    cm.touch(ws)
+    assert ws not in cm._ws_last_seen

--- a/tests/cloud/test_ws.py
+++ b/tests/cloud/test_ws.py
@@ -1,8 +1,10 @@
 """Tests for the WebSocket connection manager.
 
 Updated: 2026-08-11 (fix/notif-liveness-dispatch) — added the liveness block at
-the bottom: ``is_online`` now means "traffic seen inside the window", and
-``send_to_user`` reports how many sockets accepted the frame.
+the bottom. ``is_online`` is now capability-gated: a socket that has proved it
+pings is held to an INBOUND-traffic deadline, everything else keeps the legacy
+"live while registered" verdict. ``send_to_user`` reports how many sockets
+accepted the frame.
 """
 
 from __future__ import annotations
@@ -189,25 +191,42 @@ async def test_connect_cancels_pending_offline_task(cm):
 
 
 # ---------------------------------------------------------------------------
-# Liveness — is_online means "traffic seen recently", not "socket in the dict"
-# (fix/notif-liveness-dispatch, 2026-08-11). A half-open socket used to report
-# online forever, so notification dispatch took the WS leg into a dead pipe and
-# skipped Web Push. These pin the traffic-based verdict in both directions.
+# Liveness (fix/notif-liveness-dispatch, 2026-08-11)
+#
+# is_online used to mean "a socket object is in the dict", which a half-open
+# socket satisfies forever — so dispatch took the WS leg into a dead pipe and
+# skipped Web Push. The verdict is now capability-gated:
+#   - ping-capable socket  → live iff an INBOUND frame arrived inside the
+#     window. Outbound sends do NOT count: a write to a half-open socket
+#     succeeds for minutes, so counting them would resurrect zombies forever.
+#   - everything else      → legacy "live while registered", no churn.
 # ---------------------------------------------------------------------------
 
 
-def _backdate(cm, ws, seconds: float) -> None:
-    """Age a socket's last-activity stamp by ``seconds``."""
-    cm._ws_last_seen[ws] = time.monotonic() - seconds
+def _backdate_inbound(cm, ws, seconds: float) -> None:
+    """Age a socket's last-INBOUND stamp by ``seconds``."""
+    cm._ws_last_inbound[ws] = time.monotonic() - seconds
 
 
-async def test_is_online_false_for_stale_socket(cm):
-    # The zombie: registered, never closed, silent past the liveness window.
+async def _stale_ping_capable(cm, user_id: str = "u1"):
+    """A registered, ping-capable socket that has gone silent — the zombie."""
+    ws = AsyncMock()
+    await cm.connect(ws, user_id)
+    cm.mark_ping_capable(ws)
+    _backdate_inbound(cm, ws, LIVENESS_STALE_SECONDS + 1)
+    return ws
+
+
+# --- ping-capable sockets are held to the deadline -------------------------
+
+
+async def test_is_online_false_for_stale_ping_capable_socket(cm):
     ws = AsyncMock()
     await cm.connect(ws, "u1")
+    cm.mark_ping_capable(ws)
     assert cm.is_online("u1")
 
-    _backdate(cm, ws, LIVENESS_STALE_SECONDS + 1)
+    _backdate_inbound(cm, ws, LIVENESS_STALE_SECONDS + 1)
 
     assert not cm.is_online("u1")
 
@@ -215,9 +234,7 @@ async def test_is_online_false_for_stale_socket(cm):
 async def test_stale_socket_is_closed_best_effort(cm):
     # The verdict and the cleanup converge: checking liveness closes the zombie,
     # which wakes the router's receive loop into the normal disconnect path.
-    ws = AsyncMock()
-    await cm.connect(ws, "u1")
-    _backdate(cm, ws, LIVENESS_STALE_SECONDS + 1)
+    ws = await _stale_ping_capable(cm)
 
     assert not cm.is_online("u1")
     await asyncio.sleep(0)  # let the fire-and-forget close task run
@@ -228,11 +245,36 @@ async def test_stale_socket_is_closed_best_effort(cm):
     assert ws in cm.get_user_connections("u1")
 
 
+async def test_repeated_is_online_does_not_spawn_duplicate_closes(cm):
+    # is_online runs on every presence snapshot; without the in-flight guard
+    # each call would queue another close task for the same socket.
+    ws = await _stale_ping_capable(cm)
+
+    for _ in range(5):
+        assert not cm.is_online("u1")
+
+    assert len(cm._close_tasks) == 1
+    await asyncio.sleep(0)
+    assert ws.close.await_count == 1
+
+
+async def test_close_task_is_strongly_referenced_until_done(cm):
+    # A bare create_task result is only weakly held by the loop, so an
+    # unreferenced task can be collected mid-close. The manager holds a ref
+    # while it runs and drops it afterwards.
+    await _stale_ping_capable(cm)
+
+    assert not cm.is_online("u1")
+    assert len(cm._close_tasks) == 1  # held while in flight
+
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    assert cm._close_tasks == set()  # released once done
+
+
 async def test_inbound_touch_keeps_socket_live(cm):
     # What the router calls on every inbound frame (ping included).
-    ws = AsyncMock()
-    await cm.connect(ws, "u1")
-    _backdate(cm, ws, LIVENESS_STALE_SECONDS + 1)
+    ws = await _stale_ping_capable(cm)
     assert not cm.is_online("u1")
 
     cm.touch(ws)
@@ -240,19 +282,85 @@ async def test_inbound_touch_keeps_socket_live(cm):
     assert cm.is_online("u1")
 
 
-async def test_successful_send_keeps_idle_socket_live(cm):
-    # Backward-compat clause: today's clients send nothing for long stretches
-    # while idle-but-alive, so an outbound send the socket ACCEPTED counts as
-    # proof of life. Without this, every quiet client would look like a zombie.
-    ws = AsyncMock()
-    await cm.connect(ws, "u1")
-    _backdate(cm, ws, LIVENESS_STALE_SECONDS + 1)
-    assert not cm.is_online("u1")
+async def test_outbound_send_does_not_resurrect_a_zombie(cm):
+    # THE busy-workspace bug: send_json to a half-open socket succeeds (the
+    # kernel buffers the write), so if outbound counted as proof of life,
+    # ordinary workspace fan-out would keep a dead socket "fresh" forever and
+    # the notification would keep going into the void.
+    await _stale_ping_capable(cm)
 
     delivered = await cm.send_to_user("u1", WsOutbound(type="test", data={}))
 
-    assert delivered == 1
+    assert delivered == 1  # the write "succeeded"...
+    assert not cm.is_online("u1")  # ...and proved nothing.
+
+
+async def test_outbound_stamp_is_recorded_for_diagnostics(cm):
+    # Outbound bookkeeping is kept (useful when debugging a stuck socket) —
+    # it just isn't wired into the verdict.
+    ws = AsyncMock()
+    await cm.connect(ws, "u1")
+
+    await cm.send_to_user("u1", WsOutbound(type="test", data={}))
+
+    assert ws in cm._ws_last_outbound
+
+
+# --- non-ping-capable sockets keep legacy semantics -------------------------
+
+
+async def test_legacy_socket_stays_online_while_registered(cm):
+    # Old FE bundles send nothing for long stretches while perfectly alive.
+    # Applying staleness to them would churn every quiet client into a
+    # close/reconnect loop, so they keep the pre-change verdict.
+    ws = AsyncMock()
+    await cm.connect(ws, "u1")
+    _backdate_inbound(cm, ws, LIVENESS_STALE_SECONDS * 100)
+
     assert cm.is_online("u1")
+
+
+async def test_legacy_socket_is_never_closed_by_a_liveness_check(cm):
+    ws = AsyncMock()
+    await cm.connect(ws, "u1")
+    _backdate_inbound(cm, ws, LIVENESS_STALE_SECONDS * 100)
+
+    cm.is_online("u1")
+    await asyncio.sleep(0)
+
+    assert ws.close.await_count == 0
+
+
+async def test_ping_marks_capability_and_is_idempotent(cm):
+    ws = AsyncMock()
+    await cm.connect(ws, "u1")
+
+    cm.mark_ping_capable(ws)
+    cm.mark_ping_capable(ws)
+
+    assert cm._ping_capable == {ws}
+
+
+def test_mark_ping_capable_ignores_unknown_socket(cm):
+    ws = AsyncMock()
+    cm.mark_ping_capable(ws)
+    assert cm._ping_capable == set()
+
+
+async def test_capability_is_cleared_on_disconnect(cm):
+    # Otherwise a reconnecting socket object could inherit a stale capability.
+    ws = AsyncMock()
+    await cm.connect(ws, "u1")
+    cm.mark_ping_capable(ws)
+
+    await cm.disconnect(ws)
+
+    assert cm._ping_capable == set()
+    assert ws not in cm._ws_last_inbound
+    assert ws not in cm._ws_last_outbound
+
+
+# --- multi-device + delivery counting --------------------------------------
 
 
 async def test_only_live_socket_makes_user_online(cm):
@@ -261,7 +369,9 @@ async def test_only_live_socket_makes_user_online(cm):
     live = AsyncMock()
     await cm.connect(zombie, "u1")
     await cm.connect(live, "u1")
-    _backdate(cm, zombie, LIVENESS_STALE_SECONDS + 1)
+    cm.mark_ping_capable(zombie)
+    cm.mark_ping_capable(live)
+    _backdate_inbound(cm, zombie, LIVENESS_STALE_SECONDS + 1)
 
     assert cm.is_online("u1")
 
@@ -292,8 +402,29 @@ async def test_send_to_user_counts_only_accepted_sockets(cm):
     assert delivered == 1
 
 
+async def test_send_to_user_survives_concurrent_disconnect(cm):
+    # send_to_user must iterate a COPY of the live set. A concurrent
+    # _close_stale -> disconnect mutates it, and "set changed size during
+    # iteration" fires at the `for` — outside the per-send try — so it would
+    # escape to notify(), look like a WS failure, and skip the push fallback.
+    ws1 = AsyncMock()
+    ws2 = AsyncMock()
+    await cm.connect(ws1, "u1")
+    await cm.connect(ws2, "u1")
+
+    async def disconnect_sibling(_data):
+        # Mutate the set mid-iteration, exactly as a concurrent prune would.
+        await cm.disconnect(ws2)
+
+    ws1.send_json.side_effect = disconnect_sibling
+
+    delivered = await cm.send_to_user("u1", WsOutbound(type="test", data={}))
+
+    assert delivered >= 1  # no RuntimeError escaped
+
+
 def test_touch_ignores_unknown_socket(cm):
     # A socket already disconnected must not resurrect itself into the registry.
     ws = AsyncMock()
     cm.touch(ws)
-    assert ws not in cm._ws_last_seen
+    assert ws not in cm._ws_last_inbound

--- a/tests/mutations/notif_liveness.json
+++ b/tests/mutations/notif_liveness.json
@@ -1,0 +1,51 @@
+[
+  {
+    "label": "is_online reverts to socket-present (the original zombie bug)",
+    "file": "ee/pocketpaw_ee/cloud/chat/ws.py",
+    "find": "            if self._is_fresh(ws, now=now):\n                live = True",
+    "replace": "            if True:\n                live = True",
+    "tests": ["tests/cloud/test_ws.py::test_is_online_false_for_stale_socket"]
+  },
+  {
+    "label": "stale socket is never closed",
+    "file": "ee/pocketpaw_ee/cloud/chat/ws.py",
+    "find": "            else:\n                self._close_stale(ws)",
+    "replace": "            else:\n                pass",
+    "tests": ["tests/cloud/test_ws.py::test_stale_socket_is_closed_best_effort"]
+  },
+  {
+    "label": "outbound send stops counting as proof of life",
+    "file": "ee/pocketpaw_ee/cloud/chat/ws.py",
+    "find": "                delivered += 1\n                # A send the socket accepted is proof of life for the liveness\n                # window — idle-but-healthy clients that never send anything\n                # inbound stay online on outbound traffic alone.\n                self.touch(ws)",
+    "replace": "                delivered += 1",
+    "tests": ["tests/cloud/test_ws.py::test_successful_send_keeps_idle_socket_live"]
+  },
+  {
+    "label": "send_to_user reports delivery it never made",
+    "file": "ee/pocketpaw_ee/cloud/chat/ws.py",
+    "find": "        delivered = 0\n        dead: list[WebSocket] = []",
+    "replace": "        delivered = 1\n        dead: list[WebSocket] = []",
+    "tests": ["tests/cloud/test_ws.py::test_send_to_user_returns_delivery_count"]
+  },
+  {
+    "label": "zombie dispatch drops the notification again (no push fallback)",
+    "file": "ee/pocketpaw_ee/cloud/push/dispatch.py",
+    "find": "        if delivered:\n            return NotifyResult(transport=\"ws\", ws_delivered=True)",
+    "replace": "        if True:\n            return NotifyResult(transport=\"ws\", ws_delivered=True)",
+    "tests": ["tests/cloud/push/test_dispatch.py::test_zombie_socket_falls_back_to_web_push"]
+  },
+  {
+    "label": "inbox index points at the nonexistent created_at again",
+    "file": "ee/pocketpaw_ee/cloud/models/notification.py",
+    "find": "IndexModel([(\"recipient\", 1), (\"read\", 1), (\"createdAt\", -1)])",
+    "replace": "IndexModel([(\"recipient\", 1), (\"read\", 1), (\"created_at\", -1)])",
+    "tests": ["tests/cloud/notifications/test_model_indexes.py"]
+  },
+  {
+    "label": "TTL hangs off the dead expires_at field, expiring nothing",
+    "file": "ee/pocketpaw_ee/cloud/models/notification.py",
+    "find": "IndexModel([(\"createdAt\", 1)], expireAfterSeconds=86400 * 90)",
+    "replace": "IndexModel([(\"expires_at\", 1)], expireAfterSeconds=86400 * 90)",
+    "tests": ["tests/cloud/notifications/test_model_indexes.py::test_ttl_index_expires_rows_at_ninety_days"]
+  }
+]

--- a/tests/mutations/notif_liveness.json
+++ b/tests/mutations/notif_liveness.json
@@ -4,7 +4,7 @@
     "file": "ee/pocketpaw_ee/cloud/chat/ws.py",
     "find": "            if self._is_fresh(ws, now=now):\n                live = True",
     "replace": "            if True:\n                live = True",
-    "tests": ["tests/cloud/test_ws.py::test_is_online_false_for_stale_socket"]
+    "tests": ["tests/cloud/test_ws.py::test_is_online_false_for_stale_ping_capable_socket"]
   },
   {
     "label": "stale socket is never closed",
@@ -14,11 +14,49 @@
     "tests": ["tests/cloud/test_ws.py::test_stale_socket_is_closed_best_effort"]
   },
   {
-    "label": "outbound send stops counting as proof of life",
+    "label": "outbound success resurrects zombies (busy-workspace regression)",
     "file": "ee/pocketpaw_ee/cloud/chat/ws.py",
-    "find": "                delivered += 1\n                # A send the socket accepted is proof of life for the liveness\n                # window — idle-but-healthy clients that never send anything\n                # inbound stay online on outbound traffic alone.\n                self.touch(ws)",
-    "replace": "                delivered += 1",
-    "tests": ["tests/cloud/test_ws.py::test_successful_send_keeps_idle_socket_live"]
+    "find": "        last_inbound = self._ws_last_inbound.get(websocket)",
+    "replace": "        last_inbound = max(self._ws_last_inbound.get(websocket, 0), self._ws_last_outbound.get(websocket, 0)) or None",
+    "tests": ["tests/cloud/test_ws.py::test_outbound_send_does_not_resurrect_a_zombie"]
+  },
+  {
+    "label": "staleness applied to non-ping-capable sockets (old-bundle churn)",
+    "file": "ee/pocketpaw_ee/cloud/chat/ws.py",
+    "find": "        if websocket not in self._ping_capable:\n            return True",
+    "replace": "        if websocket not in self._ping_capable:\n            pass",
+    "tests": [
+      "tests/cloud/test_ws.py::test_legacy_socket_stays_online_while_registered",
+      "tests/cloud/test_ws.py::test_legacy_socket_is_never_closed_by_a_liveness_check"
+    ]
+  },
+  {
+    "label": "ping frames no longer mark capability",
+    "file": "ee/pocketpaw_ee/cloud/chat/ws.py",
+    "find": "        if websocket in self._ws_to_user:\n            self._ping_capable.add(websocket)",
+    "replace": "        if False:\n            self._ping_capable.add(websocket)",
+    "tests": ["tests/cloud/test_ws.py::test_ping_marks_capability_and_is_idempotent"]
+  },
+  {
+    "label": "duplicate close tasks pile up (no in-flight guard)",
+    "file": "ee/pocketpaw_ee/cloud/chat/ws.py",
+    "find": "        if websocket in self._closing:\n            return  # A close is already in flight for this socket.",
+    "replace": "        if False:\n            return",
+    "tests": ["tests/cloud/test_ws.py::test_repeated_is_online_does_not_spawn_duplicate_closes"]
+  },
+  {
+    "label": "close task left unreferenced (GC can collect it mid-flight)",
+    "file": "ee/pocketpaw_ee/cloud/chat/ws.py",
+    "find": "        self._close_tasks.add(task)",
+    "replace": "        pass",
+    "tests": ["tests/cloud/test_ws.py::test_close_task_is_strongly_referenced_until_done"]
+  },
+  {
+    "label": "send_to_user iterates the live set (concurrent-mutation RuntimeError)",
+    "file": "ee/pocketpaw_ee/cloud/chat/ws.py",
+    "find": "        for ws in list(self.get_user_connections(user_id)):",
+    "replace": "        for ws in self.get_user_connections(user_id):",
+    "tests": ["tests/cloud/test_ws.py::test_send_to_user_survives_concurrent_disconnect"]
   },
   {
     "label": "send_to_user reports delivery it never made",
@@ -28,11 +66,22 @@
     "tests": ["tests/cloud/test_ws.py::test_send_to_user_returns_delivery_count"]
   },
   {
+    "label": "capability survives disconnect (stale marker on a reused socket)",
+    "file": "ee/pocketpaw_ee/cloud/chat/ws.py",
+    "find": "        self._ping_capable.discard(websocket)\n        self._closing.discard(websocket)",
+    "replace": "        self._closing.discard(websocket)",
+    "tests": ["tests/cloud/test_ws.py::test_capability_is_cleared_on_disconnect"]
+  },
+  {
     "label": "zombie dispatch drops the notification again (no push fallback)",
     "file": "ee/pocketpaw_ee/cloud/push/dispatch.py",
     "find": "        if delivered:\n            return NotifyResult(transport=\"ws\", ws_delivered=True)",
     "replace": "        if True:\n            return NotifyResult(transport=\"ws\", ws_delivered=True)",
-    "tests": ["tests/cloud/push/test_dispatch.py::test_zombie_socket_falls_back_to_web_push"]
+    "tests": [
+      "tests/cloud/push/test_dispatch.py::test_zombie_socket_falls_back_to_web_push",
+      "tests/cloud/push/test_dispatch.py::test_real_seam_legacy_zombie_falls_back_to_push",
+      "tests/cloud/push/test_dispatch.py::test_real_seam_ping_capable_zombie_falls_back_to_push"
+    ]
   },
   {
     "label": "inbox index points at the nonexistent created_at again",
@@ -40,6 +89,13 @@
     "find": "IndexModel([(\"recipient\", 1), (\"read\", 1), (\"createdAt\", -1)])",
     "replace": "IndexModel([(\"recipient\", 1), (\"read\", 1), (\"created_at\", -1)])",
     "tests": ["tests/cloud/notifications/test_model_indexes.py"]
+  },
+  {
+    "label": "recipient-only index dropped (default bell query unindexed)",
+    "file": "ee/pocketpaw_ee/cloud/models/notification.py",
+    "find": "            IndexModel([(\"recipient\", 1), (\"createdAt\", -1)]),",
+    "replace": "",
+    "tests": ["tests/cloud/notifications/test_model_indexes.py::test_default_list_query_has_a_recipient_only_index"]
   },
   {
     "label": "TTL hangs off the dead expires_at field, expiring nothing",


### PR DESCRIPTION
## Problem

`ConnectionManager.is_online()` answered "does this user have a socket in the dict" — nothing checked whether the socket was alive. After a laptop sleep or NAT timeout, the socket stays half-open: the server keeps "delivering" WS events into a dead pipe and skips Web Push, so the notification is silently lost. On top of that, the notifications collection declared its compound index on `created_at` while the actual Beanie field is `createdAt`, and nothing ever expired old rows.

## Changes

**Liveness (chat/ws.py, chat/router.py)**
- Each socket records its last inbound frame time; the existing ping branch now also marks the socket "ping-capable".
- A ping-capable socket that goes silent for 150s (two missed pings at Chrome's throttled background-tab cadence) is presumed dead: `is_online` returns false and the socket is closed best-effort (close only, no unregister, so the normal disconnect path still emits `presence.offline`).
- Sockets that never ping (older FE bundles) keep today's live-while-registered semantics. No churn, no deploy-order coupling with the frontend ping PR (paw-enterprise#771); the strict path activates per client as it starts pinging.
- Outbound send success is tracked for diagnostics but deliberately excluded from the liveness verdict: writes to a half-open socket "succeed" into the kernel buffer, which is exactly how a zombie stays hidden in a busy workspace.
- `send_to_user` iterates a copy of the connection set (a concurrent stale-close could mutate it mid-iteration and take down the whole send) and returns how many sockets accepted the frame.

**Dispatch (push/dispatch.py)**
- If the WS leg reaches zero sockets, `notify()` now falls back to Web Push in the same call (`transport="ws_fallback_push"`). The user gets the notification instead of nothing.

**Model (models/notification.py)**
- Compound index fixed to the real field name `createdAt`.
- New `(recipient, createdAt desc)` index for the default bell query (filter on recipient only; the 3-key index can't serve that sort with `read` skipped).
- 90-day TTL on `createdAt`. `expires_at` was already dead (nothing ever set it); it stays in place, marked as such.

## Deploy notes

- The old mis-named index `recipient_1_read_1_created_at_-1` is not auto-dropped (Beanie runs with `allow_index_dropping=False`). Drop it manually after deploy: `db.notifications.dropIndex("recipient_1_read_1_created_at_-1")`.
- The TTL index does a one-time bulk delete of every notification older than 90 days when Mongo first builds it.
- Residual, by design: clients that never ping keep the old exposure (a true half-open socket in a busy workspace can still swallow the WS leg). This self-heals as soon as the frontend ping change ships and each client reconnects.

## Tests

160 passed in the targeted suites (test_ws, push, notifications); the 6 failures are pre-existing on base c9c6751 (5 auth-fixture 401s in test_router_golden, 1 double-notify in test_derived) — verified identical with the diff stashed. 14/14 mutations caught in `tests/mutations/notif_liveness.json`, including "outbound send resurrects the zombie" and "staleness applied to legacy sockets" mutants. Four integration tests drive dispatch through a real ConnectionManager: legacy zombie → fallback push, capable+fresh dead pipe → fallback push, stale capable → direct push (no WS attempt), healthy → WS only. ruff format/check, mypy, and both import-linter configs clean.