### PR TITLE
fix(push): every notification kind reaches the OS, driven off the persisted row

### DIFF
--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -936,12 +936,14 @@ def mount_cloud(app: FastAPI) -> None:
 
     register_lead_notification_listeners()
 
-    # Push notifications fan-out (#1393) — v1 product events
-    # (agent.stream_end / instinct.approval.created / meeting.started) →
-    # ``dispatch.notify``, which forks WS-vs-Web-Push so a user with both the
-    # desktop app and a browser tab open is notified exactly once. Same
-    # constraint as the other bus subscribers: register AFTER init_realtime
-    # installed the singleton bus.
+    # Push notifications fan-out (#1393) — ``notification.new`` (every
+    # persisted notification, so the OS surface can't drift from the bell)
+    # plus ``agent.stream_end`` (the one product event that persists no
+    # notification row) → ``dispatch.notify``, which forks WS-vs-Web-Push so a
+    # user with both the desktop app and a browser tab open is notified exactly
+    # once. Must be registered AFTER the notification producers' own bus
+    # subscribers above, and — like every other bus subscriber — after
+    # init_realtime installed the singleton bus.
     from pocketpaw_ee.cloud.push.listeners import register_push_event_listeners
 
     register_push_event_listeners()

--- a/ee/pocketpaw_ee/cloud/__init__.py
+++ b/ee/pocketpaw_ee/cloud/__init__.py
@@ -941,8 +941,7 @@ def mount_cloud(app: FastAPI) -> None:
     # plus ``agent.stream_end`` (the one product event that persists no
     # notification row) → ``dispatch.notify``, which forks WS-vs-Web-Push so a
     # user with both the desktop app and a browser tab open is notified exactly
-    # once. Must be registered AFTER the notification producers' own bus
-    # subscribers above, and — like every other bus subscriber — after
+    # once. Same constraint as every other bus subscriber: register AFTER
     # init_realtime installed the singleton bus.
     from pocketpaw_ee.cloud.push.listeners import register_push_event_listeners
 

--- a/ee/pocketpaw_ee/cloud/instinct_approvals/service.py
+++ b/ee/pocketpaw_ee/cloud/instinct_approvals/service.py
@@ -1,4 +1,15 @@
 # ee/pocketpaw_ee/cloud/instinct_approvals/service.py
+#
+# Updated: 2026-08-11 (fix/notif-push-convergence) — ``create_approval`` now
+# also writes an ``instinct_approval`` NOTIFICATION for ``requested_by``
+# (``_notify_requester``, best-effort). A guardian block previously had no
+# notification row at all: the only signal was a push listener wired straight
+# to ``instinct.approval.created``, so the in-app bell never showed it. Push has
+# converged on ``notification.new``, so the row is what now reaches both the
+# bell and the OS. Side effect worth knowing: notifications also fan OUT to a
+# workspace's configured Slack / generic webhook (notifications/delivery.py), so
+# a tenant with external delivery on will start seeing guardian blocks there.
+#
 # Created: 2026-05-28 (feat/wave-3a-instinct-dispatch) — sole Beanie
 # writer for the ``InstinctApproval`` collection (RFC 03 v2). Module-
 # level ``async def`` API per EE cloud rule 5. Every state-mutating
@@ -35,6 +46,7 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime
 from typing import Any
 
@@ -56,6 +68,8 @@ from pocketpaw_ee.cloud.instinct_approvals.dto import (
     approval_to_wire_dict,
 )
 from pocketpaw_ee.cloud.models.instinct_approval import InstinctApproval as _ApprovalDoc
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Private mapping helper — Beanie doc → domain
@@ -130,7 +144,47 @@ async def create_approval(
     domain = _to_domain(doc)
     wire = approval_to_wire_dict(domain)
     await emit(InstinctApprovalCreated(data=dict(wire)))
+    await _notify_requester(domain)
     return wire
+
+
+async def _notify_requester(approval: InstinctApproval) -> None:
+    """Write the bell/OS notification for a guardian block. Never raises.
+
+    Before 2026-08-11 the ONLY signal a blocked user got was a push listener
+    subscribed straight to ``instinct.approval.created`` — no notification row
+    existed, so the in-app bell never showed the block at all. Push has since
+    converged on ``notification.new`` (push/listeners.py), so persisting the
+    row is what now reaches BOTH surfaces. Title and body are carried over
+    verbatim from that retired listener.
+
+    Late import mirrors the other cross-module fan-out callers
+    (meetings/bridges/notifications.py, leads/bridges/notifications.py): it
+    avoids a circular import and tolerates the service being unavailable in
+    unit-test contexts. Best-effort by design — a notification failure must
+    not roll back the approval row the gate depends on.
+    """
+    try:
+        from pocketpaw_ee.cloud.notifications import service as notifications_service
+        from pocketpaw_ee.cloud.notifications.domain import NotificationSource
+
+        await notifications_service.create(
+            workspace_id=approval.workspace_id,
+            recipient=approval.requested_by,
+            kind="instinct_approval",
+            title="Action needs approval",
+            body=f"{approval.action_name or 'An action'} was held for your review.",
+            source=NotificationSource(
+                type="instinct_approval",
+                id=approval.id,
+                pocket_id=approval.pocket_id,
+                room_id=None,
+            ),
+        )
+    except Exception:
+        logger.exception(
+            "Failed to create instinct_approval notification for approval=%s", approval.id
+        )
 
 
 async def auto_approve(

--- a/ee/pocketpaw_ee/cloud/push/__init__.py
+++ b/ee/pocketpaw_ee/cloud/push/__init__.py
@@ -8,7 +8,8 @@
 # router.py (thin HTTP boundary). Two extra modules carry the #1393 wiring:
 # dispatch.py (``notify`` — the WS/Web-Push transport fork that never
 # double-notifies a user with both the desktop app and a browser tab open)
-# and listeners.py (the v1 product events — agent.stream_end /
-# instinct.approval.created / meeting.started — subscribed to the realtime
-# bus and routed through ``notify``). Neither writes Beanie directly, so the
+# and listeners.py (``notification.new`` — every persisted notification —
+# plus ``agent.stream_end``, the one product event with no notification row,
+# subscribed to the realtime bus and routed through ``notify``). Neither
+# writes Beanie directly, so the
 # "Push — Beanie writes only from service.py" contract still holds.

--- a/ee/pocketpaw_ee/cloud/push/coalesce.py
+++ b/ee/pocketpaw_ee/cloud/push/coalesce.py
@@ -5,7 +5,7 @@
 # limit with 429s). The OS already collapses same-``tag`` notifications on the
 # view side; this bounds the SEND side.
 #
-# Semantics — LEADING-EDGE throttle, keyed by (workspace_id, user_id, group_id):
+# Semantics — LEADING-EDGE throttle, keyed by (workspace_id, user_id, scope):
 #   - First submit for an idle key   → emit IMMEDIATELY (zero added latency),
 #                                        then open a cooldown window.
 #   - Submits during the cooldown     → suppressed; the latest emit is remembered.
@@ -25,6 +25,14 @@
 # coalescing entirely — every submit emits immediately (pre-throttle behaviour).
 # Named ``CLOUD_*`` to match the sibling ``CLOUD_PUSH_CONTACT`` — this cloud
 # layer reads its own knobs from ``os.environ`` directly.
+#
+# Updated 2026-08-11 (fix/notif-push-convergence): the third key component is
+# now a SCOPE, not strictly a group id. Push converged on the persisted
+# notification (push/listeners.py), and most kinds — an invite, a captured
+# lead, a task assignment — have no room to key on. The caller passes
+# ``source_room_id or kind``, so a room-less burst of one kind still coalesces
+# per recipient instead of firing one Web Push per row. Nothing in this module
+# changed: the key was always an opaque 3-tuple. Env knob semantics unchanged.
 #
 # Updated 2026-07-02: the leading edge now fires DETACHED (a background task,
 # like the trailing flush) instead of being awaited inline. ``submit`` is
@@ -52,7 +60,8 @@ logger = logging.getLogger(__name__)
 _ENV_SECONDS = "CLOUD_PUSH_COALESCE_SECONDS"
 _DEFAULT_SECONDS = 5.0
 
-# A key is (workspace_id, user_id, group_id). ``_tasks`` holds the open cooldown
+# A key is (workspace_id, user_id, scope) — scope being the room a notification
+# belongs to, or its kind when it has no room. ``_tasks`` holds the open cooldown
 # window for a key; ``_pending`` holds the latest suppressed emit awaiting the
 # next flush. Both are cleared when a window closes.
 _Key = tuple[str, str, str]

--- a/ee/pocketpaw_ee/cloud/push/listeners.py
+++ b/ee/pocketpaw_ee/cloud/push/listeners.py
@@ -76,10 +76,19 @@ logger = logging.getLogger(__name__)
 # The push body is replaced with the generic string here so the lock screen
 # never shows it. ``message`` is absent on purpose — it gets the unread-count
 # body instead (see ``_push_body``), preserving the pre-convergence UX.
+#
+# BODIES ONLY. Titles pass through untouched, deliberately: a title is a short
+# entitlement-scoped label ("You were mentioned in #ops", "New lead") that the
+# producer already writes content-free, and it is the same string the bell and
+# the old per-event handlers already showed. Bodies are where free-form user
+# content lands, so bodies are what get scrubbed.
+#
+# ``lead_captured`` is deliberately NOT here: leads/bridges writes "Someone
+# submitted the {form_type} form on {site_label}." — no visitor data — so an
+# override would only make the push less useful.
 _GENERIC_BODIES: dict[str, str] = {
     "mention": "You were mentioned.",
     "reaction": "Someone reacted to your message.",
-    "lead_captured": "A new lead came in.",
     "paw_bar_conversation_new": "A new conversation started.",
     "paw_bar_needs_human": "A conversation needs you.",
     "paw_bar_visitor_reply": "A visitor replied.",
@@ -165,8 +174,8 @@ def _target_url(data: dict[str, Any]) -> str | None:
 
     Mirrors the frontend resolver ``paw-enterprise/src/lib/core/notifications/
     target.ts`` (``targetUrl``) — that file is the source of truth; this is the
-    subset that is unambiguous from the wire DTO alone. Two deliberate
-    departures, both to avoid shipping a link that lands nowhere:
+    subset that is unambiguous from the wire DTO alone. Every arm below matches
+    it except two, both departing to avoid shipping a link that lands nowhere:
 
       * ``paw_bar_conversation`` — the frontend splits the compound
         ``<widget_id>:<customer_ref>`` id to reopen the exact conversation. We
@@ -203,6 +212,12 @@ def _target_url(data: dict[str, Any]) -> str | None:
         return f"/meetings?id={source_id}"
     if source_type == "meeting_started":
         return f"/chat/{nav_target}?join=meeting-{source_id}"
+    if source_type == "lead":
+        # The lead lives on its SITE's leads view (the source's room_id is the
+        # site id); ``id`` stays the lead so the panel can identify the row.
+        # Without this arm the default below builds /chat/<site_id> — a room
+        # that cannot exist.
+        return f"/sites/{nav_target}?view=leads"
     # Same default arm as the frontend: unknown source types resolve to the
     # chat room, which is where every other current backend kind lives.
     return f"/chat/{nav_target}"
@@ -243,12 +258,18 @@ async def on_notification_new(event: Event) -> None:
     resolution, so push cannot drift from the bell.
 
     Each send is routed through the leading-edge coalescer (push/coalesce.py)
-    keyed on ``(workspace, user, source_room_id or kind)``: a burst in one
-    conversation — or a burst of one room-less kind — collapses to a leading
-    push plus at most one trailing flush per window. Kinds that persist two
-    rows for a single user action (a mention writes both ``message`` and
-    ``mention``) share a room, so they share a key and collapse; the OS then
-    folds them into one toast via the shared ``tag``.
+    keyed on ``(workspace, user, source_room_id or kind)``, so a burst in one
+    conversation — or a burst of one room-less kind — is throttled to a leading
+    push plus at most one trailing flush per window.
+
+    What that means for a mention, precisely: one @mention writes TWO rows
+    (``message`` for every member, ``mention`` for the target), so the target
+    gets TWO sends, not one. The first fires immediately on the leading edge;
+    the second is suppressed and flushed when the cooldown window elapses
+    (~``CLOUD_PUSH_COALESCE_SECONDS`` later). What the shared key buys is that
+    they are two rather than N, and both carry the same ``tag``, so the OS
+    REPLACES the first toast instead of stacking a second one. The user sees
+    one notification that updates; the transport still made two sends.
     """
     data = event.data or {}
     user_id = data.get("user_id")

--- a/ee/pocketpaw_ee/cloud/push/listeners.py
+++ b/ee/pocketpaw_ee/cloud/push/listeners.py
@@ -49,11 +49,12 @@
 #
 # LOCK-SCREEN PRIVACY. A push body lands on a lock screen, so it must never
 # carry user-authored text. Several kinds persist exactly that — ``message`` /
-# ``mention`` / ``reaction`` store ``content[:200]``, the concierge kinds store
-# a visitor's words, ``lead_captured`` stores lead fields. Those bodies are
-# REPLACED here with a generic one (see ``_GENERIC_BODIES`` and
-# ``_push_body``); ``message`` keeps the pre-convergence "N new messages" count
-# UX. Only kinds whose persisted body is already generic pass through verbatim.
+# ``mention`` / ``reaction`` store ``content[:200]`` and the concierge kinds
+# store a visitor's words. Those bodies are REPLACED here with a generic one
+# (see ``_GENERIC_BODIES`` and ``_push_body``); ``message`` keeps the
+# pre-convergence "N new messages" count UX. Kinds whose persisted body is
+# already generic (``lead_captured`` included — it stores no visitor data)
+# pass through verbatim.
 #
 # Each handler is best-effort: a failure to resolve recipients or dispatch is
 # logged and swallowed so one bad event can't break the bus fan-out (the bus

--- a/ee/pocketpaw_ee/cloud/push/listeners.py
+++ b/ee/pocketpaw_ee/cloud/push/listeners.py
@@ -1,35 +1,59 @@
-# Product events → notification dispatch (pocketpaw#1393).
-# Created: 2026-06-09 (feat/push-wire-events) — subscribes the v1 notification
-# event set to the realtime in-process bus and routes each to ``notify(...)``
-# (push/dispatch.py), which forks WS-vs-Web-Push so a user is never
-# double-notified. Mirrors the meeting-notifications bridge pattern
-# (meetings/bridges/notifications.py): one handler per event type, each
-# resolving recipients + a small {title, body, url?} payload, registered from
-# ``mount_cloud`` after ``init_realtime`` installs the singleton bus.
+# Persisted notifications → push dispatch (pocketpaw#1393).
+# Created: 2026-06-09 (feat/push-wire-events) — subscribed a hand-picked set of
+# product events to the realtime in-process bus and routed each to
+# ``notify(...)`` (push/dispatch.py), which forks WS-vs-Web-Push so a user is
+# never double-notified.
 #
-# Updated: 2026-07-02 (feat/push-user-message-notifications) — wired
-# ``message.sent`` → ``on_new_message`` so a human-to-human message notifies the
-# group's OTHER human members. The body is generic-with-a-count ("N new
-# messages") — the message text never reaches the OS notification surface
-# (lock-screen privacy). Only the human ``message_add`` path emits
-# ``message.sent``; agent replies ride ``agent.stream_end`` (on_agent_complete),
-# so there is no double-notify.
+# Updated: 2026-07-02 (feat/push-user-message-notifications) — added a
+# ``message.sent`` handler so human-to-human messages notified the group's
+# other members, throttled through push/coalesce.py.
 #
-# v1 events wired (those with a real emission point + a resolvable recipient):
-#   - agent.stream_end           → agent-complete. Recipients = the group's
-#                                  human members (resolved off the group the
-#                                  payload names; the payload itself carries
-#                                  no workspace_id, so we read it from the
-#                                  group domain).
-#   - instinct.approval.created  → guardian-block. The Instinct/guardian layer
-#                                  gated an action into the approval queue;
-#                                  recipient = ``requested_by`` (the user whose
-#                                  action was blocked), workspace = the event's
-#                                  ``workspace_id``.
-#   - meeting.started            → meeting-start. Recipients = creator
-#                                  (recall) or every group member (livekit),
-#                                  matching the existing meeting bridge's
-#                                  recipient logic.
+# Updated: 2026-08-11 (fix/notif-push-convergence) — CONVERGED on the persisted
+# notification. The old design wired FOUR product events by hand while
+# ``notifications/service.create`` produces a dozen kinds, so invites,
+# pocket-shares, task assignments, captured leads, meeting reminders and every
+# concierge kind reached the in-app bell but NEVER reached the OS. Each handler
+# also re-resolved its own recipients, so push drifted from the bell by
+# construction. Now ONE handler subscribes to ``notification.new`` — the event
+# ``service.create`` emits for every persisted notification — and the recipient,
+# workspace and title come straight off the wire DTO. Bell and OS can no longer
+# disagree: if a row was written, a push was attempted.
+#
+# Events wired today:
+#   - notification.new  → on_notification_new. THE convergence handler. One
+#                         push per persisted notification, recipient = the
+#                         DTO's ``user_id``, workspace = its ``workspace_id``.
+#   - agent.stream_end  → on_agent_complete. KEPT deliberately. Agent replies
+#                         are the one product event with NO notification row:
+#                         ``chat/message_service.create_agent_message`` persists
+#                         the message but never calls
+#                         ``notifications_service.create``. Retiring this
+#                         handler would silently drop agent-reply push. It
+#                         cannot double-fire — no row means no
+#                         ``notification.new`` for the same reply.
+#
+# Retired here (their flows persist a notification, so ``notification.new``
+# now carries them):
+#   - message.sent               → ``message_service.add_message`` creates a
+#                                  ``message`` row for EVERY non-self member,
+#                                  not only mentions, so the old per-message
+#                                  fan-out is fully covered.
+#   - meeting.started            → ``meetings/bridges/notifications.py`` creates
+#                                  a ``meeting_started`` row with byte-identical
+#                                  recipient logic (creator for recall, group
+#                                  members for livekit).
+#   - instinct.approval.created  → ``instinct_approvals/service.create_approval``
+#                                  now writes an ``instinct_approval`` row
+#                                  (added in the same change), so the guardian
+#                                  block rides the converged path.
+#
+# LOCK-SCREEN PRIVACY. A push body lands on a lock screen, so it must never
+# carry user-authored text. Several kinds persist exactly that — ``message`` /
+# ``mention`` / ``reaction`` store ``content[:200]``, the concierge kinds store
+# a visitor's words, ``lead_captured`` stores lead fields. Those bodies are
+# REPLACED here with a generic one (see ``_GENERIC_BODIES`` and
+# ``_push_body``); ``message`` keeps the pre-convergence "N new messages" count
+# UX. Only kinds whose persisted body is already generic pass through verbatim.
 #
 # Each handler is best-effort: a failure to resolve recipients or dispatch is
 # logged and swallowed so one bad event can't break the bus fan-out (the bus
@@ -42,10 +66,24 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from pocketpaw_ee.cloud._core.realtime.events import Event
+from pocketpaw_ee.cloud._core.realtime.events import Event, NotificationNew
 from pocketpaw_ee.cloud.push import coalesce, dispatch
 
 logger = logging.getLogger(__name__)
+
+
+# Kinds whose PERSISTED body carries user-authored or otherwise sensitive text.
+# The push body is replaced with the generic string here so the lock screen
+# never shows it. ``message`` is absent on purpose — it gets the unread-count
+# body instead (see ``_push_body``), preserving the pre-convergence UX.
+_GENERIC_BODIES: dict[str, str] = {
+    "mention": "You were mentioned.",
+    "reaction": "Someone reacted to your message.",
+    "lead_captured": "A new lead came in.",
+    "paw_bar_conversation_new": "A new conversation started.",
+    "paw_bar_needs_human": "A conversation needs you.",
+    "paw_bar_visitor_reply": "A visitor replied.",
+}
 
 
 # ---------------------------------------------------------------------------
@@ -118,12 +156,133 @@ def _count_body(count: int) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Handlers — one per event type
+# Payload builders — kind → {title, body, url?, tag?}
 # ---------------------------------------------------------------------------
 
 
+def _target_url(data: dict[str, Any]) -> str | None:
+    """Deep link for a persisted notification, or None when it has none.
+
+    Mirrors the frontend resolver ``paw-enterprise/src/lib/core/notifications/
+    target.ts`` (``targetUrl``) — that file is the source of truth; this is the
+    subset that is unambiguous from the wire DTO alone. Two deliberate
+    departures, both to avoid shipping a link that lands nowhere:
+
+      * ``paw_bar_conversation`` — the frontend splits the compound
+        ``<widget_id>:<customer_ref>`` id to reopen the exact conversation. We
+        stop at the agent's conversations tab rather than duplicate that
+        parsing, and fall back to ``/agents`` with no bound agent. (The
+        frontend's old DEFAULT arm sent this to ``/chat/<widget>:<ref>``, a room
+        that cannot exist — found live 2026-07-31.)
+      * ``instinct_approval`` — omitted. The approvals tray is a global overlay
+        opened via ``approvalsStore.openTray()``, not a route, so there is no
+        URL to point at. The pre-convergence handler sent ``/?view=approvals``,
+        which nothing in the frontend reads.
+    """
+    source_type = data.get("source_type")
+    source_id = data.get("source_id")
+    if not (source_type and source_id):
+        return None
+
+    room_id = data.get("source_room_id")
+    pocket_id = data.get("source_pocket_id")
+    nav_target = room_id or source_id
+
+    if source_type == "instinct_approval":
+        return None
+    if source_type == "paw_bar_conversation":
+        agent_id = data.get("source_agent_id")
+        return f"/agents/{agent_id}?tab=conversations" if agent_id else "/agents"
+    if source_type in ("message", "mention"):
+        return f"/pockets/{pocket_id}/chat" if pocket_id else f"/chat/{nav_target}"
+    if source_type == "invite":
+        return f"/invite/{source_id}"
+    if source_type == "pocket_shared":
+        return f"/pockets/{source_id}"
+    if source_type == "meeting":
+        return f"/meetings?id={source_id}"
+    if source_type == "meeting_started":
+        return f"/chat/{nav_target}?join=meeting-{source_id}"
+    # Same default arm as the frontend: unknown source types resolve to the
+    # chat room, which is where every other current backend kind lives.
+    return f"/chat/{nav_target}"
+
+
+async def _push_body(data: dict[str, Any]) -> str:
+    """The body that may cross a lock screen. Never user-authored text.
+
+    ``message`` recomputes the unread count at send time so a coalesced
+    trailing flush carries a current total (the pre-convergence behaviour).
+    Every other content-bearing kind gets its generic replacement; the rest
+    pass through the persisted body, which is already generic at create time.
+    """
+    kind = data.get("kind") or ""
+    if kind == "message":
+        room_id = data.get("source_room_id")
+        user_id = data.get("user_id") or ""
+        count = await _unread_count(user_id, room_id) if room_id else 1
+        return _count_body(count)
+    generic = _GENERIC_BODIES.get(kind)
+    if generic is not None:
+        return generic
+    return data.get("body") or ""
+
+
+# ---------------------------------------------------------------------------
+# Handlers
+# ---------------------------------------------------------------------------
+
+
+async def on_notification_new(event: Event) -> None:
+    """notification.new → push the persisted notification to its recipient.
+
+    THE convergence handler: one push per persisted notification, for every
+    kind ``notifications/service.create`` writes. The payload is built entirely
+    from the wire DTO the event carries (``id, user_id, workspace_id, kind,
+    title, body, source_*, read, created_at``) — no second recipient
+    resolution, so push cannot drift from the bell.
+
+    Each send is routed through the leading-edge coalescer (push/coalesce.py)
+    keyed on ``(workspace, user, source_room_id or kind)``: a burst in one
+    conversation — or a burst of one room-less kind — collapses to a leading
+    push plus at most one trailing flush per window. Kinds that persist two
+    rows for a single user action (a mention writes both ``message`` and
+    ``mention``) share a room, so they share a key and collapse; the OS then
+    folds them into one toast via the shared ``tag``.
+    """
+    data = event.data or {}
+    user_id = data.get("user_id")
+    workspace_id = data.get("workspace_id")
+    if not (user_id and workspace_id):
+        return
+
+    kind = data.get("kind") or ""
+    title = data.get("title") or "Notification"
+    url = _target_url(data)
+    # Collapse key for the OS: same conversation (or, room-less, same kind)
+    # replaces the earlier toast instead of stacking.
+    tag = data.get("source_room_id") or kind or None
+
+    async def _emit() -> None:
+        payload: dict[str, Any] = {"title": title, "body": await _push_body(data)}
+        if url:
+            payload["url"] = url
+        if tag:
+            payload["tag"] = tag
+        await _dispatch(workspace_id, user_id, payload)
+
+    await coalesce.submit((workspace_id, user_id, tag or "notification"), _emit)
+
+
 async def on_agent_complete(event: Event) -> None:
-    """agent.stream_end → notify the group's human members the agent replied."""
+    """agent.stream_end → notify the group's human members the agent replied.
+
+    Not covered by ``on_notification_new``: ``create_agent_message`` persists
+    the agent's message but writes NO notification row, so there is no
+    ``notification.new`` for an agent reply — and therefore no double-fire
+    either. If a future change starts persisting a row for agent replies, this
+    handler must be retired in the same commit.
+    """
     data = event.data or {}
     group_id = data.get("group_id")
     if not group_id:
@@ -147,121 +306,13 @@ async def on_agent_complete(event: Event) -> None:
         await _dispatch(workspace_id, recipient, payload)
 
 
-async def on_guardian_block(event: Event) -> None:
-    """instinct.approval.created → notify the user whose action was gated."""
-    data = event.data or {}
-    workspace_id = data.get("workspace_id")
-    recipient = data.get("requested_by")
-    if not (workspace_id and recipient):
-        return
-
-    action_name = data.get("action_name") or "An action"
-    payload = {
-        "title": "Action needs approval",
-        "body": f"{action_name} was held for your review.",
-        "url": "/?view=approvals",
-    }
-    await _dispatch(workspace_id, recipient, payload)
-
-
-async def on_meeting_started(event: Event) -> None:
-    """meeting.started → notify the meeting's recipients it has begun."""
-    data = event.data or {}
-    workspace_id = data.get("workspace_id")
-    meeting_id = data.get("meeting_id")
-    if not (workspace_id and meeting_id):
-        return
-
-    source = data.get("source", "recall")
-    group_id = data.get("group_id")
-    if source == "livekit" and group_id:
-        recipients = await _group_member_ids(group_id)
-    else:
-        creator = data.get("created_by") or data.get("organizer_user_id")
-        recipients = [creator] if creator else []
-
-    if not recipients:
-        return
-
-    payload = {
-        "title": "Meeting started",
-        "body": "A meeting has started.",
-        "url": f"/?join=meeting-{meeting_id}",
-    }
-    for recipient in recipients:
-        await _dispatch(workspace_id, recipient, payload)
-
-
-async def on_new_message(event: Event) -> None:
-    """message.sent → notify a group's OTHER human members of a new message.
-
-    Generic-with-a-count: the title names the sender, the body is only the
-    unread count ("N new messages") — the message text never reaches the OS
-    notification surface. The sender is excluded (no self-ping), and the
-    WS-vs-Web-Push dedupe in ``dispatch.notify`` means only members with no
-    live connection actually receive a Web Push.
-
-    Only the human ``message_add`` path emits ``message.sent``; the
-    ``senderType != "user"`` guard is defensive belt-and-braces so an
-    agent-authored message can never double-fire alongside
-    ``on_agent_complete`` (agent.stream_end).
-
-    ``message.sent`` carries the wire dict (camelCase ``senderName`` /
-    ``senderType``) plus ``group_id`` + ``sender_id`` but NO ``workspace_id``,
-    so the workspace is resolved from the group — mirroring on_agent_complete.
-
-    Each send is routed through the leading-edge coalescer (push/coalesce.py):
-    the first message pings instantly, a burst within the cooldown collapses to
-    one trailing send. The emit closure recomputes the unread count at send
-    time, so both the leading and any trailing push carry a current count.
-    """
-    data = event.data or {}
-    group_id = data.get("group_id")
-    if not group_id:
-        return
-    if data.get("senderType") not in (None, "user"):
-        return
-
-    workspace_id = await _group_workspace_id(group_id)
-    if not workspace_id:
-        return
-
-    sender_id = data.get("sender_id")
-    recipients = [uid for uid in await _group_member_ids(group_id) if uid != sender_id]
-    if not recipients:
-        return
-
-    title = data.get("senderName") or "New message"
-    url = f"/?join={group_id}"
-    for recipient in recipients:
-        # ``recipient`` is bound as a default arg so the closure captures THIS
-        # iteration's value (the other captured names are constant per call).
-        # The count is recomputed inside so a coalesced trailing send reflects
-        # the accumulated unread total. ``tag`` is the group id so the OS
-        # collapses a conversation's notifications into one updating toast.
-        async def _emit(recipient: str = recipient) -> None:
-            count = await _unread_count(recipient, group_id)
-            await _dispatch(
-                workspace_id,
-                recipient,
-                {
-                    "title": title,
-                    "body": _count_body(count),
-                    "url": url,
-                    "tag": group_id,
-                },
-            )
-
-        await coalesce.submit((workspace_id, recipient, group_id), _emit)
-
-
 # ---------------------------------------------------------------------------
 # Registration — called from mount_cloud() after init_realtime.
 # ---------------------------------------------------------------------------
 
 
 def register_push_event_listeners() -> None:
-    """Wire the v1 product events → notification dispatch. Idempotent-safe.
+    """Wire persisted notifications + agent replies → push. Idempotent-safe.
 
     Subscribes on the realtime in-process bus (the same bus the WS fan-out
     rides), so handlers fire whether or not any client is currently
@@ -270,17 +321,13 @@ def register_push_event_listeners() -> None:
     from pocketpaw_ee.cloud._core.realtime.bus import get_bus
 
     bus = get_bus()
+    bus.subscribe(NotificationNew.EVENT_TYPE, on_notification_new)
     bus.subscribe("agent.stream_end", on_agent_complete)
-    bus.subscribe("instinct.approval.created", on_guardian_block)
-    bus.subscribe("meeting.started", on_meeting_started)
-    bus.subscribe("message.sent", on_new_message)
-    logger.info("registered v1 product events → push notification dispatch")
+    logger.info("registered notification.new + agent.stream_end → push dispatch")
 
 
 __all__ = [
     "on_agent_complete",
-    "on_guardian_block",
-    "on_meeting_started",
-    "on_new_message",
+    "on_notification_new",
     "register_push_event_listeners",
 ]

--- a/tests/cloud/push/test_listeners.py
+++ b/tests/cloud/push/test_listeners.py
@@ -10,10 +10,13 @@
 #     the coverage hole the convergence closes (invites, leads, tasks,
 #     concierge kinds never reached the OS before);
 #   * lock-screen privacy — the persisted body of a content-bearing kind
-#     (message / mention / reaction / concierge / lead) NEVER crosses into the
-#     push payload, and ``message`` keeps its "N new messages" count body;
-#   * no double-fire — a mention writes two rows for one user action, and the
-#     coalescer collapses them to one immediate push;
+#     (message / mention / reaction / concierge) NEVER crosses into the
+#     push payload, ``message`` keeps its "N new messages" count body, and
+#     ``lead_captured`` (already content-free) passes through verbatim;
+#   * no double-fire — a mention writes two rows for one user action on ONE
+#     coalesce key: the first sends immediately, the second flushes when the
+#     window elapses under the same replacing ``tag`` (two sends, one visible
+#     notification that updates);
 #   * the retired subscriptions are actually gone from ``register``;
 #   * the coalesce key falls back to the KIND for room-less notifications, so
 #     a burst of invites doesn't fan out one Web Push per row;

--- a/tests/cloud/push/test_listeners.py
+++ b/tests/cloud/push/test_listeners.py
@@ -149,12 +149,13 @@ async def test_noop_without_recipient_or_workspace(notify_calls) -> None:
 
 @pytest.mark.parametrize(
     "kind",
-    ["message", "mention", "reaction", "lead_captured"]
+    ["message", "mention", "reaction"]
     + ["paw_bar_conversation_new", "paw_bar_needs_human", "paw_bar_visitor_reply"],
 )
 async def test_content_bearing_body_never_leaks(notify_calls, _unread, kind) -> None:
-    # These kinds persist user-authored text in ``body`` (message content,
-    # a visitor's words, lead fields). A push body lands on a lock screen.
+    # These kinds persist user-authored text in ``body`` (message content, a
+    # visitor's words). A push body lands on a lock screen. ``lead_captured``
+    # is absent on purpose — its persisted body is already content-free.
     secret = "wire me $10k to account 12345"
     await listeners.on_notification_new(
         NotificationNew(data=_dto(kind=kind, title="Something", body=secret, source_room_id="g1"))
@@ -194,6 +195,19 @@ async def test_message_body_singular_without_room(notify_calls, monkeypatch) -> 
     assert payload["body"] == "1 new message"
 
 
+async def test_lead_captured_body_passes_through(notify_calls) -> None:
+    # leads/bridges writes "Someone submitted the {form_type} form on
+    # {site_label}." — no visitor data — so overriding it would be a pure UX
+    # downgrade. Guards against someone "hardening" it back into the map.
+    body = "Someone submitted the contact form on Acme Dental."
+    await listeners.on_notification_new(
+        NotificationNew(data=_dto(kind="lead_captured", body=body, source_type="lead"))
+    )
+
+    _, _, payload = notify_calls[0]
+    assert payload["body"] == body
+
+
 async def test_generic_kind_body_passes_through(notify_calls) -> None:
     # ``task_assigned`` persists a generic body ("Assigned by <id>") — nothing
     # user-authored — so it is NOT rewritten.
@@ -222,6 +236,9 @@ async def test_generic_kind_body_passes_through(notify_calls) -> None:
         ("meeting_started", {"source_room_id": "g1"}, "/chat/g1?join=meeting-s1"),
         ("paw_bar_conversation", {"source_agent_id": "a1"}, "/agents/a1?tab=conversations"),
         ("paw_bar_conversation", {}, "/agents"),
+        # A lead's room_id is its SITE — without the arm the default builds
+        # /chat/<site_id>, a room that cannot exist.
+        ("lead", {"source_room_id": "site1"}, "/sites/site1?view=leads"),
         ("meeting_reminder", {"source_room_id": "g1"}, "/chat/g1"),
     ],
 )
@@ -252,12 +269,23 @@ async def test_payload_omits_url_when_there_is_none(notify_calls) -> None:
 # ---------------------------------------------------------------------------
 
 
-async def test_mention_flow_pushes_once_per_recipient(notify_calls, _unread, monkeypatch) -> None:
+async def test_mention_flow_sends_twice_under_one_replacing_tag(
+    notify_calls, _unread, monkeypatch
+) -> None:
     """One @mention writes TWO notification rows (kind ``message`` for every
-    member, kind ``mention`` for the mentioned user), so the same user action
-    emits two ``notification.new`` events. Both share the room, so both share a
-    coalesce key and collapse to a single immediate push."""
-    monkeypatch.setenv("CLOUD_PUSH_COALESCE_SECONDS", "5")
+    member, kind ``mention`` for the target), so the same user action emits two
+    ``notification.new`` events for the target.
+
+    The honest behaviour, asserted end to end rather than only at the leading
+    edge: the first send fires IMMEDIATELY, the second is suppressed and
+    flushed when the cooldown window elapses — TWO sends, not one. What the
+    shared coalesce key buys is that they are two rather than N, and both carry
+    the same ``tag``, so the OS replaces the first toast instead of stacking a
+    second. Mutation that breaks it: key the coalescer on the KIND first rather
+    than the room, which splits the two rows onto different keys — both then
+    fire on their own leading edge and the "once immediately" assertion goes to
+    two."""
+    monkeypatch.setenv("CLOUD_PUSH_COALESCE_SECONDS", "0.05")
 
     await listeners.on_notification_new(
         NotificationNew(data=_dto(id="n1", kind="message", source_room_id="g1"))
@@ -268,8 +296,14 @@ async def test_mention_flow_pushes_once_per_recipient(notify_calls, _unread, mon
     # The leading emit is detached (a background task) — let it run.
     await asyncio.sleep(0)
     await asyncio.sleep(0)
+    assert len(notify_calls) == 1, "leading edge fires immediately, once"
 
-    assert len(notify_calls) == 1
+    # Advance past the cooldown: the suppressed mention row flushes.
+    await asyncio.sleep(0.2)
+
+    assert len(notify_calls) == 2, "the second row flushes after the window"
+    assert {p["tag"] for _, _, p in notify_calls} == {"g1"}, "one replacing toast"
+    assert {uid for _, uid, _ in notify_calls} == {"alice"}
     await listeners.coalesce.aclose()
 
 

--- a/tests/cloud/push/test_listeners.py
+++ b/tests/cloud/push/test_listeners.py
@@ -1,23 +1,35 @@
-# Tests for the product-event → notification dispatch listeners (pocketpaw#1393).
-# Created: 2026-06-09 (feat/push-wire-events) — proves each v1 handler resolves
-# the right recipients + payload and routes through ``dispatch.notify``:
-#   - on_agent_complete: resolves the group's workspace + members and notifies
-#     every human member (agent.stream_end carries no workspace_id);
-#   - on_guardian_block: notifies ``requested_by`` in the event's workspace;
-#   - on_meeting_started: notifies the creator (recall) or group members
-#     (livekit), mirroring the meeting bridge.
+# Tests for the persisted-notification → push dispatch listener (pocketpaw#1393).
+# Created: 2026-06-09 (feat/push-wire-events) — covered the four hand-wired
+# product-event handlers (agent.stream_end / instinct.approval.created /
+# meeting.started / message.sent).
+#
+# Updated: 2026-08-11 (fix/notif-push-convergence) — rewritten around
+# ``on_notification_new``, the single handler push now converges on. What the
+# suite pins:
+#   * EVERY kind ``notifications/service.create`` writes reaches dispatch —
+#     the coverage hole the convergence closes (invites, leads, tasks,
+#     concierge kinds never reached the OS before);
+#   * lock-screen privacy — the persisted body of a content-bearing kind
+#     (message / mention / reaction / concierge / lead) NEVER crosses into the
+#     push payload, and ``message`` keeps its "N new messages" count body;
+#   * no double-fire — a mention writes two rows for one user action, and the
+#     coalescer collapses them to one immediate push;
+#   * the retired subscriptions are actually gone from ``register``;
+#   * the coalesce key falls back to the KIND for room-less notifications, so
+#     a burst of invites doesn't fan out one Web Push per row;
+#   * ``on_agent_complete`` survives — agent replies persist no notification
+#     row, so retiring it would have silently dropped their push.
 # ``dispatch.notify`` is patched to record calls — no WS, no Web Push, no DB.
-# group_service lookups are patched so no Mongo is needed.
 
 from __future__ import annotations
+
+import asyncio
 
 import pytest
 from pocketpaw_ee.cloud._core.realtime.events import (
     AgentStreamEnd,
-    InstinctApprovalCreated,
-    MessageSent,
+    NotificationNew,
 )
-from pocketpaw_ee.cloud.meetings.events import MeetingStarted
 from pocketpaw_ee.cloud.push import listeners
 
 
@@ -34,18 +46,266 @@ def notify_calls(monkeypatch):
 
 @pytest.fixture(autouse=True)
 def _no_coalesce(monkeypatch):
-    """Run on_new_message with the coalescer OFF (pass-through) so these tests
+    """Run the handler with the coalescer OFF (pass-through) so these tests
     assert the recipient/payload logic directly. The leading-edge throttle has
-    its own dedicated suite in test_coalesce.py. ``reset()`` clears any window
-    state so a lingering task can't leak into the next test."""
+    its own dedicated suite in test_coalesce.py; the two tests below that DO
+    exercise it re-enable it locally. ``reset()`` clears any window state so a
+    lingering task can't leak into the next test."""
     monkeypatch.setenv("CLOUD_PUSH_COALESCE_SECONDS", "0")
     listeners.coalesce.reset()
     yield
     listeners.coalesce.reset()
 
 
+def _dto(**overrides) -> dict:
+    """The wire DTO ``notification.new`` carries (notifications/dto.py)."""
+    data: dict = {
+        "id": "n1",
+        "user_id": "alice",
+        "workspace_id": "w1",
+        "kind": "invite",
+        "title": "You were invited",
+        "body": "",
+        "source_id": "inv1",
+        "source_type": "invite",
+        "source_pocket_id": None,
+        "source_room_id": None,
+        "source_agent_id": None,
+        "read": False,
+        "created_at": "2026-08-11T00:00:00Z",
+    }
+    data.update(overrides)
+    return data
+
+
 # ---------------------------------------------------------------------------
-# agent-complete (agent.stream_end)
+# Coverage — every persisted kind reaches dispatch
+# ---------------------------------------------------------------------------
+
+# One representative row per kind ``notifications/service.create`` writes today.
+# Kinds that used to have NO push at all are the point of the convergence.
+ALL_KINDS: list[tuple[str, str | None]] = [
+    ("message", "message"),
+    ("mention", "message"),
+    ("reaction", "message"),
+    ("group_invite", "message"),
+    ("invite", "invite"),
+    ("task_assigned", None),
+    ("lead_captured", "lead"),
+    ("meeting_scheduled", "meeting_scheduled"),
+    ("meeting_started", "meeting_started"),
+    ("meeting_cancelled", "meeting_cancelled"),
+    ("meeting_reminder", "meeting_reminder"),
+    ("meeting_recording_ready", "meeting_recording_ready"),
+    ("meeting_transcript_ready", "meeting_transcript_ready"),
+    ("instinct_approval", "instinct_approval"),
+    ("paw_bar_conversation_new", "paw_bar_conversation"),
+    ("paw_bar_needs_human", "paw_bar_conversation"),
+    ("paw_bar_visitor_reply", "paw_bar_conversation"),
+]
+
+
+@pytest.fixture
+def _unread(monkeypatch):
+    async def fake_count(user_id, group_id):
+        return 3
+
+    monkeypatch.setattr(listeners, "_unread_count", fake_count)
+
+
+async def test_every_kind_reaches_dispatch(notify_calls, _unread) -> None:
+    for index, (kind, source_type) in enumerate(ALL_KINDS):
+        await listeners.on_notification_new(
+            NotificationNew(
+                data=_dto(
+                    id=f"n{index}",
+                    kind=kind,
+                    title=f"{kind} happened",
+                    source_type=source_type,
+                    source_id=f"s{index}" if source_type else None,
+                    source_room_id="g1" if kind in ("message", "mention", "reaction") else None,
+                )
+            )
+        )
+
+    # N notifications of distinct kinds → N dispatches, one per row.
+    assert len(notify_calls) == len(ALL_KINDS)
+    assert {uid for _, uid, _ in notify_calls} == {"alice"}
+    assert all(ws == "w1" for ws, _, _ in notify_calls)
+    assert all(p["title"].endswith("happened") for _, _, p in notify_calls)
+
+
+async def test_noop_without_recipient_or_workspace(notify_calls) -> None:
+    await listeners.on_notification_new(NotificationNew(data=_dto(user_id=None)))
+    await listeners.on_notification_new(NotificationNew(data=_dto(workspace_id=None)))
+    await listeners.on_notification_new(NotificationNew(data={}))
+    assert notify_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Lock-screen privacy — the persisted body must not cross into the push
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "kind",
+    ["message", "mention", "reaction", "lead_captured"]
+    + ["paw_bar_conversation_new", "paw_bar_needs_human", "paw_bar_visitor_reply"],
+)
+async def test_content_bearing_body_never_leaks(notify_calls, _unread, kind) -> None:
+    # These kinds persist user-authored text in ``body`` (message content,
+    # a visitor's words, lead fields). A push body lands on a lock screen.
+    secret = "wire me $10k to account 12345"
+    await listeners.on_notification_new(
+        NotificationNew(data=_dto(kind=kind, title="Something", body=secret, source_room_id="g1"))
+    )
+
+    assert len(notify_calls) == 1
+    _, _, payload = notify_calls[0]
+    assert secret not in payload["body"]
+    assert secret not in payload["title"]
+    assert payload["body"]  # still says something useful
+
+
+async def test_message_body_is_the_unread_count(notify_calls, _unread) -> None:
+    await listeners.on_notification_new(
+        NotificationNew(
+            data=_dto(kind="message", title="Alice", body="hello there", source_room_id="g1")
+        )
+    )
+
+    _, _, payload = notify_calls[0]
+    assert payload["body"] == "3 new messages"
+    # Collapse per conversation so a later message updates the same toast.
+    assert payload["tag"] == "g1"
+
+
+async def test_message_body_singular_without_room(notify_calls, monkeypatch) -> None:
+    async def boom(*_a, **_k):
+        raise AssertionError("no room → no unread lookup")
+
+    monkeypatch.setattr(listeners, "_unread_count", boom)
+
+    await listeners.on_notification_new(
+        NotificationNew(data=_dto(kind="message", body="secret", source_room_id=None))
+    )
+
+    _, _, payload = notify_calls[0]
+    assert payload["body"] == "1 new message"
+
+
+async def test_generic_kind_body_passes_through(notify_calls) -> None:
+    # ``task_assigned`` persists a generic body ("Assigned by <id>") — nothing
+    # user-authored — so it is NOT rewritten.
+    await listeners.on_notification_new(
+        NotificationNew(data=_dto(kind="task_assigned", body="Assigned by u9", source_type=None))
+    )
+
+    _, _, payload = notify_calls[0]
+    assert payload["body"] == "Assigned by u9"
+
+
+# ---------------------------------------------------------------------------
+# Deep links — mirrors paw-enterprise src/lib/core/notifications/target.ts
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("source_type", "extra", "expected"),
+    [
+        ("message", {"source_room_id": "g1"}, "/chat/g1"),
+        ("mention", {"source_room_id": "g1"}, "/chat/g1"),
+        ("message", {"source_pocket_id": "p1"}, "/pockets/p1/chat"),
+        ("invite", {}, "/invite/s1"),
+        ("pocket_shared", {}, "/pockets/s1"),
+        ("meeting", {}, "/meetings?id=s1"),
+        ("meeting_started", {"source_room_id": "g1"}, "/chat/g1?join=meeting-s1"),
+        ("paw_bar_conversation", {"source_agent_id": "a1"}, "/agents/a1?tab=conversations"),
+        ("paw_bar_conversation", {}, "/agents"),
+        ("meeting_reminder", {"source_room_id": "g1"}, "/chat/g1"),
+    ],
+)
+def test_target_url(source_type, extra, expected) -> None:
+    assert listeners._target_url(_dto(source_type=source_type, source_id="s1", **extra)) == expected
+
+
+def test_target_url_omitted_when_ambiguous() -> None:
+    # No source at all → no link.
+    assert listeners._target_url(_dto(source_type=None, source_id=None)) is None
+    # The approvals tray is a global overlay, not a route — a ``/chat/<id>``
+    # default arm would land on a room that cannot exist.
+    assert listeners._target_url(_dto(source_type="instinct_approval", source_id="a1")) is None
+
+
+async def test_payload_omits_url_when_there_is_none(notify_calls) -> None:
+    await listeners.on_notification_new(
+        NotificationNew(data=_dto(kind="instinct_approval", source_type="instinct_approval"))
+    )
+
+    _, _, payload = notify_calls[0]
+    assert "url" not in payload
+    assert payload["tag"] == "instinct_approval"
+
+
+# ---------------------------------------------------------------------------
+# No double-fire — the coalescer collapses a mention's two rows
+# ---------------------------------------------------------------------------
+
+
+async def test_mention_flow_pushes_once_per_recipient(notify_calls, _unread, monkeypatch) -> None:
+    """One @mention writes TWO notification rows (kind ``message`` for every
+    member, kind ``mention`` for the mentioned user), so the same user action
+    emits two ``notification.new`` events. Both share the room, so both share a
+    coalesce key and collapse to a single immediate push."""
+    monkeypatch.setenv("CLOUD_PUSH_COALESCE_SECONDS", "5")
+
+    await listeners.on_notification_new(
+        NotificationNew(data=_dto(id="n1", kind="message", source_room_id="g1"))
+    )
+    await listeners.on_notification_new(
+        NotificationNew(data=_dto(id="n2", kind="mention", source_room_id="g1"))
+    )
+    # The leading emit is detached (a background task) — let it run.
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert len(notify_calls) == 1
+    await listeners.coalesce.aclose()
+
+
+async def test_coalesce_key_falls_back_to_kind_without_a_room(notify_calls, monkeypatch) -> None:
+    """Room-less kinds (invites, tasks, leads) used to have no coalesce scope at
+    all. Keyed on the kind, a burst for one recipient collapses instead of
+    firing one Web Push per row."""
+    monkeypatch.setenv("CLOUD_PUSH_COALESCE_SECONDS", "5")
+
+    await listeners.on_notification_new(NotificationNew(data=_dto(id="n1", kind="invite")))
+    await listeners.on_notification_new(NotificationNew(data=_dto(id="n2", kind="invite")))
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert len(notify_calls) == 1
+    await listeners.coalesce.aclose()
+
+
+async def test_different_kinds_without_a_room_do_not_collapse(notify_calls, monkeypatch) -> None:
+    """The fallback scopes per KIND, so an invite and a task assignment for the
+    same user are still two separate pushes."""
+    monkeypatch.setenv("CLOUD_PUSH_COALESCE_SECONDS", "5")
+
+    await listeners.on_notification_new(NotificationNew(data=_dto(id="n1", kind="invite")))
+    await listeners.on_notification_new(
+        NotificationNew(data=_dto(id="n2", kind="task_assigned", source_type=None))
+    )
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert len(notify_calls) == 2
+    await listeners.coalesce.aclose()
+
+
+# ---------------------------------------------------------------------------
+# agent-complete (agent.stream_end) — KEPT: agent replies persist no row
 # ---------------------------------------------------------------------------
 
 
@@ -82,194 +342,35 @@ async def test_agent_complete_noop_when_workspace_unresolved(notify_calls, monke
 
 
 # ---------------------------------------------------------------------------
-# guardian-block (instinct.approval.created)
+# Registration — the retired subscriptions must be gone
 # ---------------------------------------------------------------------------
 
 
-async def test_guardian_block_notifies_requester(notify_calls) -> None:
-    event = InstinctApprovalCreated(
-        data={
-            "workspace_id": "w1",
-            "requested_by": "carol",
-            "action_name": "send_email",
-        }
-    )
-    await listeners.on_guardian_block(event)
-
-    assert len(notify_calls) == 1
-    ws, uid, payload = notify_calls[0]
-    assert ws == "w1"
-    assert uid == "carol"
-    assert "send_email" in payload["body"]
+RETIRED_EVENTS = ("instinct.approval.created", "meeting.started", "message.sent")
 
 
-async def test_guardian_block_noop_without_recipient(notify_calls) -> None:
-    await listeners.on_guardian_block(InstinctApprovalCreated(data={"workspace_id": "w1"}))
-    assert notify_calls == []
+def test_register_subscribes_only_the_converged_events(monkeypatch) -> None:
+    subscribed: list[tuple[str, object]] = []
+
+    class _FakeBus:
+        def subscribe(self, event_type, handler):
+            subscribed.append((event_type, handler))
+
+    from pocketpaw_ee.cloud._core.realtime import bus as bus_module
+
+    monkeypatch.setattr(bus_module, "get_bus", lambda: _FakeBus())
+    listeners.register_push_event_listeners()
+
+    types = [t for t, _ in subscribed]
+    assert types == ["notification.new", "agent.stream_end"]
+    # Each retired event's flow now persists a notification row (or, for
+    # instinct approvals, does as of this change), so a subscription here
+    # would double-fire against ``notification.new``.
+    for retired in RETIRED_EVENTS:
+        assert retired not in types
+    assert dict(subscribed)["notification.new"] is listeners.on_notification_new
 
 
-# ---------------------------------------------------------------------------
-# meeting-start (meeting.started)
-# ---------------------------------------------------------------------------
-
-
-async def test_meeting_started_notifies_creator_for_recall(notify_calls) -> None:
-    event = MeetingStarted(
-        data={
-            "workspace_id": "w1",
-            "meeting_id": "m1",
-            "source": "recall",
-            "created_by": "dave",
-        }
-    )
-    await listeners.on_meeting_started(event)
-
-    assert len(notify_calls) == 1
-    ws, uid, payload = notify_calls[0]
-    assert (ws, uid) == ("w1", "dave")
-    assert "meeting-m1" in payload["url"]
-
-
-async def test_meeting_started_notifies_group_for_livekit(notify_calls, monkeypatch) -> None:
-    async def fake_members(group_id):
-        return ["eve", "frank"]
-
-    monkeypatch.setattr(listeners, "_group_member_ids", fake_members)
-
-    event = MeetingStarted(
-        data={
-            "workspace_id": "w1",
-            "meeting_id": "m2",
-            "source": "livekit",
-            "group_id": "g9",
-        }
-    )
-    await listeners.on_meeting_started(event)
-
-    assert {uid for _, uid, _ in notify_calls} == {"eve", "frank"}
-
-
-async def test_meeting_started_noop_without_meeting(notify_calls) -> None:
-    await listeners.on_meeting_started(MeetingStarted(data={"workspace_id": "w1"}))
-    assert notify_calls == []
-
-
-# ---------------------------------------------------------------------------
-# new-message (message.sent) — user↔user notifications
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture
-def new_message_env(monkeypatch):
-    """Patch the group + unread lookups so on_new_message needs no Mongo."""
-
-    async def fake_ws_id(group_id):
-        return "w-msg"
-
-    async def fake_members(group_id):
-        return ["alice", "bob", "carol"]
-
-    async def fake_count(user_id, group_id):
-        return 3
-
-    monkeypatch.setattr(listeners, "_group_workspace_id", fake_ws_id)
-    monkeypatch.setattr(listeners, "_group_member_ids", fake_members)
-    monkeypatch.setattr(listeners, "_unread_count", fake_count)
-
-
-async def test_new_message_notifies_other_members_with_count(notify_calls, new_message_env) -> None:
-    event = MessageSent(
-        data={
-            "group_id": "g1",
-            "sender_id": "alice",
-            "senderName": "Alice",
-            "senderType": "user",
-        }
-    )
-    await listeners.on_new_message(event)
-
-    # Alice is the sender → excluded; only bob + carol are notified.
-    assert {uid for _, uid, _ in notify_calls} == {"bob", "carol"}
-    assert all(ws == "w-msg" for ws, _, _ in notify_calls)
-    # Title names the sender; body carries ONLY the count (no message text).
-    assert all(p["title"] == "Alice" for _, _, p in notify_calls)
-    assert all(p["body"] == "3 new messages" for _, _, p in notify_calls)
-    # Collapse per-conversation so a later message updates the same toast.
-    assert all(p["tag"] == "g1" for _, _, p in notify_calls)
-
-
-async def test_new_message_body_never_leaks_content(notify_calls, new_message_env) -> None:
-    secret = "wire me $10k to account 12345"
-    event = MessageSent(
-        data={
-            "group_id": "g1",
-            "sender_id": "alice",
-            "senderName": "Alice",
-            "senderType": "user",
-            "content": secret,
-        }
-    )
-    await listeners.on_new_message(event)
-
-    assert notify_calls  # sanity: it did notify
-    for _, _, payload in notify_calls:
-        assert secret not in payload["body"]
-        assert secret not in payload["title"]
-
-
-async def test_new_message_singular_count_body(notify_calls, monkeypatch) -> None:
-    async def fake_ws_id(group_id):
-        return "w"
-
-    async def fake_members(group_id):
-        return ["a", "b"]
-
-    async def fake_count(user_id, group_id):
-        return 1
-
-    monkeypatch.setattr(listeners, "_group_workspace_id", fake_ws_id)
-    monkeypatch.setattr(listeners, "_group_member_ids", fake_members)
-    monkeypatch.setattr(listeners, "_unread_count", fake_count)
-
-    event = MessageSent(
-        data={"group_id": "g", "sender_id": "a", "senderName": "A", "senderType": "user"}
-    )
-    await listeners.on_new_message(event)
-
-    assert notify_calls
-    assert all(p["body"] == "1 new message" for _, _, p in notify_calls)
-
-
-async def test_new_message_skips_agent_authored(notify_calls, monkeypatch) -> None:
-    # An agent-authored message.sent (senderType != "user") must not fire here;
-    # agent replies are covered by on_agent_complete (agent.stream_end).
-    async def boom(*_a, **_k):
-        raise AssertionError("agent-authored message must not resolve recipients")
-
-    monkeypatch.setattr(listeners, "_group_workspace_id", boom)
-
-    await listeners.on_new_message(
-        MessageSent(data={"group_id": "g", "sender_id": "bot", "senderType": "agent"})
-    )
-    assert notify_calls == []
-
-
-async def test_new_message_noop_without_group(notify_calls) -> None:
-    await listeners.on_new_message(MessageSent(data={"sender_id": "a", "senderType": "user"}))
-    assert notify_calls == []
-
-
-async def test_new_message_noop_when_sender_is_only_member(notify_calls, monkeypatch) -> None:
-    async def fake_ws_id(group_id):
-        return "w"
-
-    async def fake_members(group_id):
-        return ["solo"]
-
-    monkeypatch.setattr(listeners, "_group_workspace_id", fake_ws_id)
-    monkeypatch.setattr(listeners, "_group_member_ids", fake_members)
-
-    await listeners.on_new_message(
-        MessageSent(data={"group_id": "g", "sender_id": "solo", "senderType": "user"})
-    )
-    assert notify_calls == []
+def test_retired_handlers_no_longer_exist() -> None:
+    for name in ("on_guardian_block", "on_meeting_started", "on_new_message"):
+        assert not hasattr(listeners, name), f"{name} should have been retired"

--- a/tests/cloud/test_instinct_approvals_service.py
+++ b/tests/cloud/test_instinct_approvals_service.py
@@ -229,3 +229,57 @@ async def test_auto_approve_requires_workspace_and_user() -> None:
         await approvals_service.auto_approve(
             "w1", "", _create_body(), trust_score=0.95, triager_reasoning="r"
         )
+
+
+# ---------------------------------------------------------------------------
+# Guardian-block notification (fix/notif-push-convergence, 2026-08-11)
+#
+# ``create_approval`` used to emit ``instinct.approval.created`` and nothing
+# else — a push listener subscribed to that event directly, so a blocked user
+# got an OS ping but the in-app bell never showed the block. Push has since
+# converged on ``notification.new``, so the row below is what reaches BOTH.
+# ---------------------------------------------------------------------------
+
+
+async def test_create_writes_a_notification_for_the_requester() -> None:
+    from pocketpaw_ee.cloud.notifications import service as notifications_service
+
+    out = await approvals_service.create_approval("w1", "u1", _create_body())
+
+    notes = await notifications_service.list_for_user("u1")
+    assert len(notes) == 1
+    note = notes[0]
+    assert note.kind == "instinct_approval"
+    assert note.workspace_id == "w1"
+    assert note.recipient_id == "u1"
+    assert "do_thing" in note.body
+    assert note.source is not None
+    assert (note.source.type, note.source.id) == ("instinct_approval", out["id"])
+
+
+async def test_create_emits_notification_new_so_push_rides_it(recording_bus) -> None:
+    from pocketpaw_ee.cloud._core.realtime.events import NotificationNew
+
+    out = await approvals_service.create_approval("w1", "u1", _create_body())
+
+    new = [e for e in recording_bus.events if isinstance(e, NotificationNew)]
+    assert len(new) == 1
+    # The push handler reads recipient + workspace straight off this payload.
+    assert new[0].data["user_id"] == "u1"
+    assert new[0].data["workspace_id"] == "w1"
+    assert new[0].data["kind"] == "instinct_approval"
+    assert new[0].data["source_id"] == out["id"]
+
+
+async def test_notification_failure_does_not_break_approval_creation(monkeypatch) -> None:
+    # The gate depends on the approval row; a dead notification path must not
+    # take it down with it.
+    from pocketpaw_ee.cloud.notifications import service as notifications_service
+
+    async def boom(**_kwargs):
+        raise RuntimeError("notifications down")
+
+    monkeypatch.setattr(notifications_service, "create", boom)
+
+    out = await approvals_service.create_approval("w1", "u1", _create_body())
+    assert out["status"] == "pending"

--- a/tests/mutations/push_convergence.json
+++ b/tests/mutations/push_convergence.json
@@ -1,0 +1,74 @@
+[
+  {
+    "label": "privacy: stop rewriting content-bearing bodies (persisted text reaches the lock screen)",
+    "file": "ee/pocketpaw_ee/cloud/push/listeners.py",
+    "find": "    generic = _GENERIC_BODIES.get(kind)\n    if generic is not None:\n        return generic\n    return data.get(\"body\") or \"\"",
+    "replace": "    return data.get(\"body\") or \"\"",
+    "tests": [
+      "tests/cloud/push/test_listeners.py"
+    ]
+  },
+  {
+    "label": "privacy: message body carries the persisted content instead of the unread count",
+    "file": "ee/pocketpaw_ee/cloud/push/listeners.py",
+    "find": "        count = await _unread_count(user_id, room_id) if room_id else 1\n        return _count_body(count)",
+    "replace": "        return data.get(\"body\") or \"\"",
+    "tests": [
+      "tests/cloud/push/test_listeners.py"
+    ]
+  },
+  {
+    "label": "convergence: re-subscribe a retired event (double-fires against notification.new)",
+    "file": "ee/pocketpaw_ee/cloud/push/listeners.py",
+    "find": "    bus.subscribe(\"agent.stream_end\", on_agent_complete)",
+    "replace": "    bus.subscribe(\"agent.stream_end\", on_agent_complete)\n    bus.subscribe(\"message.sent\", on_agent_complete)",
+    "tests": [
+      "tests/cloud/push/test_listeners.py"
+    ]
+  },
+  {
+    "label": "convergence: drop the notification.new subscription (every kind loses push)",
+    "file": "ee/pocketpaw_ee/cloud/push/listeners.py",
+    "find": "    bus.subscribe(NotificationNew.EVENT_TYPE, on_notification_new)\n",
+    "replace": "",
+    "tests": [
+      "tests/cloud/push/test_listeners.py"
+    ]
+  },
+  {
+    "label": "coalesce: drop the kind fallback so room-less kinds share one key",
+    "file": "ee/pocketpaw_ee/cloud/push/listeners.py",
+    "find": "    await coalesce.submit((workspace_id, user_id, tag or \"notification\"), _emit)",
+    "replace": "    await coalesce.submit((workspace_id, user_id, \"notification\"), _emit)",
+    "tests": [
+      "tests/cloud/push/test_listeners.py"
+    ]
+  },
+  {
+    "label": "deep link: let instinct_approval fall through to the dead /chat/<id> default",
+    "file": "ee/pocketpaw_ee/cloud/push/listeners.py",
+    "find": "    if source_type == \"instinct_approval\":\n        return None\n",
+    "replace": "",
+    "tests": [
+      "tests/cloud/push/test_listeners.py"
+    ]
+  },
+  {
+    "label": "guardian block: stop persisting the notification (bell + OS both go dark again)",
+    "file": "ee/pocketpaw_ee/cloud/instinct_approvals/service.py",
+    "find": "    await _notify_requester(domain)\n",
+    "replace": "",
+    "tests": [
+      "tests/cloud/test_instinct_approvals_service.py"
+    ]
+  },
+  {
+    "label": "guardian block: notify the wrong recipient",
+    "file": "ee/pocketpaw_ee/cloud/instinct_approvals/service.py",
+    "find": "            recipient=approval.requested_by,",
+    "replace": "            recipient=\"someone-else\",",
+    "tests": [
+      "tests/cloud/test_instinct_approvals_service.py"
+    ]
+  }
+]

--- a/tests/mutations/push_convergence.json
+++ b/tests/mutations/push_convergence.json
@@ -45,6 +45,33 @@
     ]
   },
   {
+    "label": "coalesce: key on the kind before the room, splitting a mention's two rows",
+    "file": "ee/pocketpaw_ee/cloud/push/listeners.py",
+    "find": "    tag = data.get(\"source_room_id\") or kind or None",
+    "replace": "    tag = kind or data.get(\"source_room_id\") or None",
+    "tests": [
+      "tests/cloud/push/test_listeners.py"
+    ]
+  },
+  {
+    "label": "deep link: drop the lead arm (bell lands on /chat/<site_id>, a dead room)",
+    "file": "ee/pocketpaw_ee/cloud/push/listeners.py",
+    "find": "        return f\"/sites/{nav_target}?view=leads\"",
+    "replace": "        return f\"/chat/{nav_target}\"",
+    "tests": [
+      "tests/cloud/push/test_listeners.py"
+    ]
+  },
+  {
+    "label": "privacy: over-scrub lead_captured, whose persisted body is already content-free",
+    "file": "ee/pocketpaw_ee/cloud/push/listeners.py",
+    "find": "    \"mention\": \"You were mentioned.\",",
+    "replace": "    \"mention\": \"You were mentioned.\",\n    \"lead_captured\": \"A new lead came in.\",",
+    "tests": [
+      "tests/cloud/push/test_listeners.py"
+    ]
+  },
+  {
     "label": "deep link: let instinct_approval fall through to the dead /chat/<id> default",
     "file": "ee/pocketpaw_ee/cloud/push/listeners.py",
     "find": "    if source_type == \"instinct_approval\":\n        return None\n",


### PR DESCRIPTION
## Problem

Push notifications were wired to 4 hand-picked product events (`agent.stream_end`, `instinct.approval.created`, `meeting.started`, `message.sent`) while `notifications/service.create` produces ~12 kinds. Invites, `pocket_shared`, tasks, leads, and the concierge kinds never reached the OS when the user was away. Each handler also re-resolved recipients on its own, so the push side could drift from the bell.

## Changes

- One handler on `notification.new` (the event every persisted notification emits) now drives push: recipient, workspace, kind, and title come straight off the wire DTO. Any kind the bell sees, push sees. Routed through the existing coalescer and WS-vs-push dispatch, so dedupe semantics are unchanged.
- Retired the `message.sent`, `meeting.started`, and `instinct.approval.created` handlers. The first two were already covered by persisted rows (recipient logic verified byte-equivalent); the third had no row at all, so `instinct_approvals/service.py` now persists an `instinct_approval` notification for the requester. Guardian blocks show up in the bell, and ride the workspace's Slack/webhook delivery config as a side effect.
- Kept `agent.stream_end`: agent replies persist no notification row, so retiring it would have dropped their push entirely, and no row means nothing to double-fire against.
- Lock-screen privacy: content-bearing bodies (message/mention/reaction content, concierge visitor text) are replaced with generic ones before hitting the push payload; `message` keeps its "N new messages" count. `lead_captured` passes through, its persisted body carries no visitor data. Titles pass through deliberately (short, entitlement-scoped labels, same exposure as the bell).
- Deep links mirror the FE resolver, including the `lead` arm (`/sites/<site>?view=leads`). `instinct_approval` omits its URL: the approvals tray is an overlay, not a route. The matching FE change (bell resolver arm so guardian blocks don't dead-link to `/chat/<approval_id>`) rides the attentive-path PR in paw-enterprise this same wave.
- Coalesce key falls back to the kind for room-less notifications, so burst-y kinds still collapse.
- Honest coalescing note: a mention writes two rows (message + mention) on one key. The first pushes immediately, the second flushes when the window elapses under the same replacing `tag` — two sends, one visible notification that updates.

## Tests

85 passed in `tests/cloud/push/`; 153 passed across push + notifications + instinct approvals (the 6 failures are pre-existing on base c9c6751, verified by stash-diff: 5 auth-fixture 401s, 1 unrelated double-notify). 11/11 mutations caught in `tests/mutations/push_convergence.json`, including "coalesce keyed kind-before-room", "lead arm dropped", and "privacy override re-added for a safe kind". import-linter (both configs), ruff, and mypy clean.

## Related

- Pairs with pocketpaw#1924 (zombie-socket liveness + dispatch fallback) — independent, no ordering constraint.
- FE half of the guardian-block deep link ships in the paw-enterprise attentive-path PR.