### PR TITLE
A new site draft now reaches a gallery that is already open

### DIFF
--- a/ee/pocketpaw_ee/cloud/_core/realtime/audience.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/audience.py
@@ -340,15 +340,18 @@ class AudienceResolver:
                 return []
             return await self._group(gid)
 
-        # --- Sites (published site lifecycle) -----------------------------------
-        # Workspace-scoped: the /sites gallery is a per-workspace view, and a
-        # publish lands asynchronously relative to the chat turn that started it
-        # (the agent creates + publishes server-side). Fan out to every workspace
-        # member so an open gallery flips the new site to Live on its own — no
-        # poll, no manual refresh. Payload carries {workspace_id, site_id,
-        # pocket_id, owner, plan_tier}; the client keys the gallery row off
-        # site_id / pocket_id.
-        if t == "site.published":
+        # --- Sites (site lifecycle: draft created, then published) ---------------
+        # Workspace-scoped: the /sites gallery is a per-workspace view, and BOTH
+        # halves of the lifecycle land asynchronously relative to the chat turn that
+        # started them (the agent creates, then publishes, server-side). Fan out to
+        # every workspace member so an open gallery gains the new card
+        # (``site.created``) and flips it to Live (``site.published``) on its own —
+        # no poll, no manual refresh. The per-run ``pocket_created`` SSE cannot do
+        # this job: it reaches only the tab that owns that chat stream, so a create
+        # from a second tab / a teammate / an import is invisible without the bus.
+        # Payloads carry {workspace_id, site_id, pocket_id, owner, ...}; the client
+        # keys the gallery row off site_id / pocket_id.
+        if t in {"site.created", "site.published"}:
             if wid := d.get("workspace_id"):
                 return await self._workspace(wid)
             return []

--- a/ee/pocketpaw_ee/cloud/_core/realtime/events.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/events.py
@@ -532,6 +532,27 @@ class SitePublished(Event):
     EVENT_TYPE: ClassVar[str] = "site.published"
 
 
+# Sites — a DRAFT site was created (fix/sites-draft-realtime). Emitted by
+# ``sites.service.create_draft_site`` after the Site doc is inserted, on the FRESH
+# mint only (the mint is idempotent — a repeat create, or one against an
+# already-live doc, returns the existing doc and emits nothing). data:
+# {workspace_id, site_id, pocket_id, owner, deployed} — ``deployed`` is always
+# False here, and rides along so a listener can tell a draft from a publish
+# without a second read.
+#
+# WHY A SECOND SITE EVENT. ``site.published`` used to be the only one, so the
+# /sites gallery had no way to hear that a draft had appeared: draft-first create
+# (pocketpaw#1744) mints the Site doc long before any publish, and the only other
+# signal is the ``pocket_created`` SSE, which is per-RUN and therefore reaches
+# just the one tab that started the create. Every other open gallery — a second
+# tab, a teammate, the /chat surface, a zip/url import — showed the new draft only
+# after a manual Refresh. This is the draft half of the pair, routed to the same
+# workspace audience for the same reason.
+@dataclass
+class SiteCreated(Event):
+    EVENT_TYPE: ClassVar[str] = "site.created"
+
+
 # Tasks (Mission Control work-item primitive)
 @dataclass
 class TaskProposed(Event):

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1741,6 +1741,31 @@ async def require_sites_plan(workspace_id: str) -> None:
         )
 
 
+async def _emit_site_created(doc: _SiteDoc) -> None:
+    """Publish ``SiteCreated`` for a freshly minted DRAFT Site doc.
+
+    Deliberately UNGUARDED — the caller owns the try/except, so patching this in a
+    test exercises that guard rather than replacing it. Lazy imports keep the sites
+    service free of a hard cloud-realtime dependency, matching ``publish_pocket``.
+    """
+    from pocketpaw_ee.cloud._core.realtime.emit import emit
+    from pocketpaw_ee.cloud._core.realtime.events import SiteCreated
+
+    await emit(
+        SiteCreated(
+            data={
+                "workspace_id": doc.workspace,
+                "site_id": str(doc.id),
+                "pocket_id": doc.pocket_id,
+                "owner": doc.owner,
+                # Always False on a fresh draft. Sent anyway so a listener can tell a
+                # draft from a publish off the payload alone, with no second read.
+                "deployed": False,
+            }
+        )
+    )
+
+
 async def create_draft_site(
     *,
     workspace_id: str,
@@ -1776,6 +1801,17 @@ async def create_draft_site(
     publish. ``publish`` reuses a stored non-empty ``signed_key``, so minting one here is
     what keeps the built key and the doc in sync (the same invariant
     ``test_republish_reuses_signed_key`` pins for a re-publish).
+
+    REALTIME (fix/sites-draft-realtime): a FRESH mint emits ``SiteCreated`` so an
+    already-open gallery gains the card on its own. This used to carry a
+    ``# no-event`` opt-out reasoning that nothing downstream keys on a draft doc —
+    true of the search index and soul memory, but the gallery is a listener too, and
+    it was left with no signal at all. The per-run ``pocket_created`` SSE does not
+    cover this: it reaches only the tab that owns that chat stream, so a draft
+    created from /chat, a second tab, a teammate's session, or a zip/url import was
+    invisible until someone pressed Refresh. The emit sits AFTER the idempotent early
+    return above, so it fires once per real insert — a repeat create, or one against
+    an already-live doc, stays silent.
     """
     oid = _live_object_id(workspace_id, pocket_id)
     # Idempotent + dedupe-safe: never mint a second doc for a pocket, and never reset
@@ -1805,10 +1841,22 @@ async def create_draft_site(
         allowed_origins=_default_allowed_origins(),
         event_mapping=_DEFAULT_EVENT_MAPPING,
     )
-    # no-event: a DRAFT is not a published/deployed mutation — nothing downstream
-    # (search index, soul memory, ripple invalidation) keys on a draft Site doc;
-    # publish emits SitePublished when the site actually goes live.
     await doc.insert()
+    # The gallery IS a downstream listener, and a draft is the moment its card
+    # appears — so this emits, where it used to carry a ``# no-event`` opt-out.
+    # Guarded like every other post-insert side effect below: the Site doc is the
+    # primary contract, and a realtime failure must never cost the user the site
+    # they just asked for. ``emit`` already swallows publish errors; this also
+    # catches the "no bus initialised" AssertionError, so a create that runs outside
+    # a booted cloud (a script, a test tree without the bus fixture) still succeeds.
+    try:
+        await _emit_site_created(doc)
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "create_draft_site: site.created emit failed (non-fatal) for pocket %s",
+            pocket_id,
+            exc_info=True,
+        )
     # SC-2: this is the moment the draft becomes a card in the gallery, so it is the
     # moment to try to give that card a picture. A draft has no url, so the capture
     # shoots its MARKUP instead. Only on a fresh mint — the idempotent early return

--- a/tests/cloud/realtime/test_audience.py
+++ b/tests/cloud/realtime/test_audience.py
@@ -390,6 +390,46 @@ async def test_site_published_without_workspace_id_has_no_audience():
 
 
 @pytest.mark.asyncio
+async def test_site_created_routes_to_workspace_members():
+    # A DRAFT is created async relative to the chat turn exactly like a publish, and
+    # it is just as much a change to what the gallery shows — a new card. It fans out
+    # to the whole workspace for the same reason: only the one tab that ran the create
+    # hears the per-run ``pocket_created`` SSE, so everyone else (a second tab, a
+    # teammate, an import) needs the bus or sees nothing until a manual refresh.
+    async def ws_members(_wid: str) -> list[str]:
+        return ["a", "b", "c"]
+
+    from pocketpaw_ee.cloud._core.realtime.events import SiteCreated
+
+    r = AudienceResolver(workspace_members=ws_members)
+    ev = SiteCreated(
+        data={
+            "workspace_id": "w1",
+            "site_id": "s1",
+            "pocket_id": "pkt1",
+            "owner": "a",
+            "deployed": False,
+        }
+    )
+    assert set(await r.audience(ev)) == {"a", "b", "c"}
+
+
+@pytest.mark.asyncio
+async def test_site_created_without_workspace_id_has_no_audience():
+    # Same defensive guard the publish event carries: no workspace_id → no fan-out,
+    # never an unscoped audience. The fetcher raises to prove the guard short-circuits
+    # before any member lookup.
+    async def ws_members(_wid: str) -> list[str]:
+        raise AssertionError("workspace_members must not be called without a workspace_id")
+
+    from pocketpaw_ee.cloud._core.realtime.events import SiteCreated
+
+    r = AudienceResolver(workspace_members=ws_members)
+    ev = SiteCreated(data={"site_id": "s1", "pocket_id": "pkt1"})
+    assert await r.audience(ev) == []
+
+
+@pytest.mark.asyncio
 async def test_workspace_job_events_route_to_workspace_members():
     # A dynamic site's provisioning job finishes in the ARQ worker, long after
     # publish — the terminal update fans out to the workspace so the gallery can

--- a/tests/ee/sites/test_draft_first_visibility.py
+++ b/tests/ee/sites/test_draft_first_visibility.py
@@ -18,6 +18,14 @@
 #     the built ``captureSignedKey`` matches the persisted doc (lead capture works on
 #     the first publish) — the create-side twin of ``test_republish_reuses_signed_key``.
 #   * BILLING-SAFE: a draft carries no subscription and opens no checkout.
+#
+# Updated: 2026-08-11 (fix/sites-draft-realtime) — added the realtime block at the
+# bottom. Listable was only half of visible: the mint emitted NOTHING (an explicit
+# ``# no-event`` opt-out) and ``site.published`` was the only site event that
+# existed, so a gallery that was already open never learned a draft had appeared.
+# The new tests pin the ``site.created`` emit, its idempotence on the wire, its
+# silence over an already-live doc, and that a failed push never costs the user the
+# site. See the block comment there for the full failure.
 
 from __future__ import annotations
 
@@ -251,3 +259,113 @@ async def test_draft_carries_no_billing(beanie_test_db):
 
     cards = await sites_service.list_for_workspace("ws1")
     assert cards[0].checkout_url is None
+
+
+# ---------------------------------------------------------------------------
+# Realtime: a draft must REACH an already-open gallery (fix/sites-draft-realtime)
+# ---------------------------------------------------------------------------
+# The draft-first fix above made a draft LISTABLE. It did not make it ARRIVE: the
+# mint carried a ``# no-event`` opt-out, and ``site.published`` was the only site
+# event in the catalog — so a gallery that was already open learned nothing when a
+# draft appeared and showed it only after a manual Refresh or an F5. The bounded
+# create poll covers the ONE tab that ran the create (it is armed by the per-run
+# ``pocket_created`` SSE, so it is per-stream by construction); a draft created from
+# the main chat, a second tab, a teammate's session, or an import reached nobody.
+#
+# These pin the emit itself. The workspace fan-out is pinned next to the publish
+# routing in tests/cloud/realtime/test_audience.py.
+
+
+def _site_created(bus) -> list:
+    """The ``site.created`` events the recording bus saw, newest last."""
+    return [e for e in bus.events if e.type == "site.created"]
+
+
+async def test_create_draft_site_emits_site_created(beanie_test_db, _recording_bus_for_sites):
+    """THE BUG: minting a draft emitted nothing, so an open gallery never heard about
+    it. A fresh mint must emit ``site.created`` carrying the ids the client keys the
+    gallery row off (``site_id`` / ``pocket_id``) plus the ``workspace_id`` the
+    audience resolver fans out on.
+
+    Mutation that must break this: delete the ``emit(SiteCreated(...))`` call in
+    ``create_draft_site`` (i.e. restore the ``# no-event`` opt-out)."""
+    doc = await sites_service.create_draft_site(
+        workspace_id="ws1", user_id="u1", pocket_id="pk_evt", name="Fresh Draft"
+    )
+
+    events = _site_created(_recording_bus_for_sites)
+    assert len(events) == 1, "a fresh draft mint must emit exactly one site.created"
+    data = events[0].data
+    assert data["workspace_id"] == "ws1"
+    assert data["site_id"] == str(doc.id)
+    assert data["pocket_id"] == "pk_evt"
+    assert data["owner"] == "u1"
+    # ``deployed`` rides along so a client can tell this apart from a publish without
+    # a second read — a draft is never live.
+    assert data["deployed"] is False
+
+
+async def test_repeat_create_draft_does_not_re_emit(beanie_test_db, _recording_bus_for_sites):
+    """IDEMPOTENT ON THE WIRE, not just in Mongo. The mint already returns the existing
+    doc untouched on a repeat create (``test_create_draft_is_idempotent``); the event
+    must follow it. Emitting per CALL rather than per INSERT would push a duplicate
+    "new site" at every open gallery each time a create tool retried.
+
+    Mutation that must break this: move the emit ABOVE the idempotent early return."""
+    await sites_service.create_draft_site(
+        workspace_id="ws1", user_id="u1", pocket_id="pk_evt_once", name="Once"
+    )
+    await sites_service.create_draft_site(
+        workspace_id="ws1", user_id="u1", pocket_id="pk_evt_once", name="Twice"
+    )
+
+    assert len(_site_created(_recording_bus_for_sites)) == 1
+
+
+async def test_create_draft_over_live_doc_does_not_emit(
+    beanie_test_db, monkeypatch, _recording_bus_for_sites
+):
+    """A stray re-create against an ALREADY-LIVE site must stay silent. The doc is
+    returned unchanged (``test_create_draft_never_clobbers_a_live_doc``), so an event
+    here would tell every open gallery a live site had just been created — the same
+    early return covers both, and this pins that it does."""
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+    monkeypatch.delenv("PAW_SITES_LOCAL", raising=False)
+    monkeypatch.setenv("PAW_CF_DEPLOY_MODE", "local")
+
+    await sites_service.create_draft_site(
+        workspace_id="ws1", user_id="u1", pocket_id="pk_evt_live", name="Live One"
+    )
+    await _publish_local("pk_evt_live", name="Live One")
+    before = len(_site_created(_recording_bus_for_sites))
+
+    await sites_service.create_draft_site(
+        workspace_id="ws1", user_id="u1", pocket_id="pk_evt_live", name="Live One"
+    )
+
+    assert len(_site_created(_recording_bus_for_sites)) == before
+
+
+async def test_emit_failure_does_not_fail_the_create(
+    beanie_test_db, monkeypatch, _recording_bus_for_sites
+):
+    """The draft doc is the primary contract; the push is a courtesy. A realtime
+    failure must not lose the site the user just asked for — the same discipline the
+    thumbnail capture and the ``pocket_created`` push already follow.
+
+    Mutation that must break this: drop the try/except around the emit."""
+
+    async def _boom(_event):
+        raise RuntimeError("bus is down")
+
+    # raising=True (the default) on purpose: if the helper is renamed away, this test
+    # must fail loudly rather than pass against an attribute monkeypatch invented.
+    monkeypatch.setattr(sites_service, "_emit_site_created", _boom)
+
+    doc = await sites_service.create_draft_site(
+        workspace_id="ws1", user_id="u1", pocket_id="pk_evt_boom", name="Still Mine"
+    )
+
+    assert doc.deployed is False
+    docs = await _SiteDoc.find({"workspace": "ws1", "pocket_id": "pk_evt_boom"}).to_list()
+    assert len(docs) == 1

--- a/tests/mutations/sites_draft_realtime.json
+++ b/tests/mutations/sites_draft_realtime.json
@@ -1,0 +1,57 @@
+[
+  {
+    "label": "draft realtime: the mint goes back to emitting nothing, so an open gallery never hears about the draft",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    try:\n        await _emit_site_created(doc)\n    except Exception:  # noqa: BLE001\n        logger.warning(\n            \"create_draft_site: site.created emit failed (non-fatal) for pocket %s\",\n            pocket_id,\n            exc_info=True,\n        )",
+    "replace": "    pass",
+    "tests": [
+      "tests/ee/sites/test_draft_first_visibility.py"
+    ]
+  },
+  {
+    "label": "draft realtime: the emit moves above the idempotent return, so a retried create pushes a duplicate card",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    existing = await _SiteDoc.find_one({\"_id\": oid, \"workspace\": workspace_id})\n    if existing is not None:\n        return existing",
+    "replace": "    existing = await _SiteDoc.find_one({\"_id\": oid, \"workspace\": workspace_id})\n    if existing is not None:\n        await _emit_site_created(existing)\n        return existing",
+    "tests": [
+      "tests/ee/sites/test_draft_first_visibility.py"
+    ]
+  },
+  {
+    "label": "draft realtime: a bus failure escapes and costs the user the site they just created",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    try:\n        await _emit_site_created(doc)\n    except Exception:  # noqa: BLE001",
+    "replace": "    await _emit_site_created(doc)\n    if False:",
+    "tests": [
+      "tests/ee/sites/test_draft_first_visibility.py"
+    ]
+  },
+  {
+    "label": "draft realtime: the event carries no workspace_id, so the audience resolver fans it out to nobody",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "                \"workspace_id\": doc.workspace,\n                \"site_id\": str(doc.id),",
+    "replace": "                \"site_id\": str(doc.id),",
+    "tests": [
+      "tests/ee/sites/test_draft_first_visibility.py"
+    ]
+  },
+  {
+    "label": "draft realtime: site.created loses its audience branch, so the push reaches no workspace member",
+    "file": "ee/pocketpaw_ee/cloud/_core/realtime/audience.py",
+    "find": "        if t in {\"site.created\", \"site.published\"}:",
+    "replace": "        if t in {\"site.published\"}:",
+    "tests": [
+      "tests/cloud/realtime/test_audience.py",
+      "tests/cloud/realtime/test_audience_coverage.py"
+    ]
+  },
+  {
+    "label": "draft realtime: site.created routes to the creator alone instead of the whole workspace",
+    "file": "ee/pocketpaw_ee/cloud/_core/realtime/audience.py",
+    "find": "        if t in {\"site.created\", \"site.published\"}:\n            if wid := d.get(\"workspace_id\"):\n                return await self._workspace(wid)\n            return []",
+    "replace": "        if t in {\"site.created\", \"site.published\"}:\n            if owner := d.get(\"owner\"):\n                return [owner]\n            return []",
+    "tests": [
+      "tests/cloud/realtime/test_audience.py"
+    ]
+  }
+]


### PR DESCRIPTION
## What was wrong

Create a site draft, and a `/sites` gallery that was already open showed nothing. The card appeared when you pressed Refresh or reloaded the page, and not before.

Nothing told the gallery. `create_draft_site` carried an explicit opt-out:

```python
# no-event: a DRAFT is not a published/deployed mutation — nothing downstream
# (search index, soul memory, ripple invalidation) keys on a draft Site doc;
# publish emits SitePublished when the site actually goes live.
```

That held for the three listeners it names. The gallery is a fourth, and it wasn't on the list. `site.published` was the only `site.*` event in the catalog, so the draft half of the lifecycle had no signal at all.

The one thing that did cover it is `pocket_created`, and it only covers one tab. It's a per-run SSE pushed onto the chat stream, so it reaches whoever owns that run and nobody else. It arms the `/sites` create poll, which is bounded to ~14s, gated on `createdThisSession`, and pushed best-effort with the failure swallowed. Everything outside that one stream — a create from `/chat`, a second tab, a teammate's session, a zip or url import — got nothing.

The other two refresh paths don't reach it either. `pollBuildStatus` keys off `anyBuildInFlight(sites)`, so it can only converge a row already in the list; it can't discover one. And `onSiteImported` is an explicit reload in the importing tab only.

## What changed

`SiteCreated` (`site.created`), emitted from `create_draft_site` and routed to the whole workspace next to `site.published` — same audience, same reason.

Three things about the emit worth reviewing:

- **It sits after the idempotent early return.** The mint already returns an existing doc untouched on a repeat create, or one against an already-live doc. The event follows that: emitting per call rather than per insert would push a duplicate "new site" at every open gallery each time a create tool retried, and would announce a live site as newly created.
- **It's wrapped.** The Site doc is the primary contract. A bus failure must not cost someone the site they just asked for — the same discipline the thumbnail capture and the `pocket_created` push already follow. The `except` also covers the "no bus initialised" `AssertionError`, so a create outside a booted cloud still succeeds.
- **The payload carries `deployed: False`** so a listener can tell a draft from a publish without a second read.

Import inherits all of it — `import_service` mints through the same function.

## Tests

Written before the fix, and confirmed failing against it.

- `tests/ee/sites/test_draft_first_visibility.py` — the emit, its idempotence on the wire, its silence over a live doc, and that a failed push never loses the site.
- `tests/cloud/realtime/test_audience.py` — workspace fan-out, and no fan-out without a `workspace_id`.
- `test_audience_coverage.py` picks up the new event automatically.

`tests/mutations/sites_draft_realtime.json` has six mutations covering both files. All six were run and caught:

```
all 6 mutations caught
```

## Local suite

`tests/ee/sites/`, `tests/ee/agent/test_sites_mcp_server/`, `tests/cloud/sites/`: **22 failed, 1308 passed**. The same 22 fail on this branch's merge base with the changes stashed (1304 passed there — the difference is the four new tests). They're the `.env` leak `tests/ee/sites/conftest.py` documents, in the one tree that lacks the isolation fixture, plus the generator-timeout tests. Neither is touched here.

## Needs the frontend PR

The listener half is qbtrix/paw-enterprise#776. Merging this alone is harmless — the event fires and nothing subscribes to it yet.

One thing that PR explains rather than fixes: `test_topics_gen_is_committed_state` regenerates `topics.gen.ts` into the sibling `paw-enterprise` checkout and diffs it. It's sensitive to which branch that sibling sits on, and the generator writes CRLF on Windows, so it rewrites the whole file locally. Worth a look separately.