### PR TITLE
fix(realtime): call participant events reach the group again

### DIFF
--- a/ee/pocketpaw_ee/cloud/_core/realtime/audience.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/audience.py
@@ -1,3 +1,9 @@
+# audience.py — resolves an Event into the user_ids that should receive it.
+# Updated: 2026-08-11 — call.participant_joined / call.participant_left now
+#   resolve to the call's group members (they previously fell through to [],
+#   so InProcessBus skipped fan-out and the frontend's pre-join "who's in the
+#   call" chip went stale). Removed an unreachable duplicate call.started /
+#   call.ended branch that sat below the live one.
 """Resolves an Event into the list of user_ids that should receive it."""
 
 from __future__ import annotations
@@ -224,7 +230,18 @@ class AudienceResolver:
         # panel needs to light up for the receiver and clear for everyone on
         # end. Notes posting also fans out so peer tabs can scroll to the
         # newly-created meeting-notes message without a manual refetch.
-        if t in {"call.started", "call.ended", "call.notes_posted"}:
+        # participant_joined / participant_left keep the pre-join roster chip
+        # ("who's already in the call") honest for members who haven't joined
+        # yet. The joiner is NOT excluded: their own tab needs the roster too,
+        # and ``identity`` may be a guest id minted by livekit/invites.py
+        # rather than a workspace user_id, so it is not an audience key.
+        if t in {
+            "call.started",
+            "call.ended",
+            "call.notes_posted",
+            "call.participant_joined",
+            "call.participant_left",
+        }:
             if gid := d.get("group_id"):
                 return await self._group(gid)
             return []
@@ -323,14 +340,6 @@ class AudienceResolver:
         # --- Presence -----------------------------------------------------------
         if t in {"presence.online", "presence.offline"}:
             return await self._peers(d["user_id"])
-
-        # --- Calls ---------------------------------------------------------------
-        if t in {"call.started", "call.ended"}:
-            # Fan out to all group members so they see incoming/join notifications
-            gid = d.get("group_id")
-            if not gid:
-                return []
-            return await self._group(gid)
 
         # --- Meetings ----------------------------------------------------------
         if t in {"meeting.scheduled", "meeting.updated", "meeting.cancelled", "meeting.started"}:

--- a/tests/cloud/realtime/test_audience.py
+++ b/tests/cloud/realtime/test_audience.py
@@ -415,3 +415,104 @@ async def test_workspace_job_events_route_to_workspace_members():
             }
         )
         assert set(await r.audience(ev)) == {"a", "b"}, cls.__name__
+
+
+@pytest.mark.asyncio
+async def test_call_participant_events_route_to_group_members():
+    # A pre-join tab shows "who's already in the call" from these two events.
+    # Before this branch existed they fell through to [], so InProcessBus
+    # skipped the fan-out entirely and the roster chip went stale.
+    async def group_members(_gid: str) -> list[str]:
+        return ["u1", "u2", "u3"]
+
+    from pocketpaw_ee.cloud._core.realtime.events import (
+        CallParticipantJoined,
+        CallParticipantLeft,
+    )
+
+    r = AudienceResolver(group_members=group_members)
+    for cls in (CallParticipantJoined, CallParticipantLeft):
+        ev = cls(
+            data={
+                "group_id": "g1",
+                "room_name": "group-call-g1",
+                "identity": "u2",
+                "name": "Bob",
+            }
+        )
+        assert set(await r.audience(ev)) == {"u1", "u2", "u3"}, cls.__name__
+
+
+@pytest.mark.asyncio
+async def test_call_participant_events_exclude_non_members():
+    # Membership is DB-resolved, not payload-supplied: a stranger holding a
+    # live socket never learns who is on another group's call.
+    members_by_group = {"g1": ["u-alice", "u-bob"]}
+
+    async def group_members(gid: str) -> list[str]:
+        return list(members_by_group.get(gid, []))
+
+    from pocketpaw_ee.cloud._core.realtime.events import (
+        CallParticipantJoined,
+        CallParticipantLeft,
+    )
+
+    r = AudienceResolver(group_members=group_members)
+    for cls in (CallParticipantJoined, CallParticipantLeft):
+        ev = cls(data={"group_id": "g1", "identity": "u-alice", "name": "Alice"})
+        audience = await r.audience(ev)
+        assert "u-mallory" not in audience, cls.__name__
+        assert set(audience) == {"u-alice", "u-bob"}, cls.__name__
+
+
+@pytest.mark.asyncio
+async def test_call_participant_joined_keeps_the_joiner_in_the_audience():
+    # The joiner's own tab needs the roster too. ``identity`` is also not a
+    # safe audience key — livekit/invites.py mints ``guest-<hex>`` identities
+    # for invite links, which are not workspace user_ids.
+    async def group_members(_gid: str) -> list[str]:
+        return ["u1", "u2"]
+
+    from pocketpaw_ee.cloud._core.realtime.events import CallParticipantJoined
+
+    r = AudienceResolver(group_members=group_members)
+    ev = CallParticipantJoined(
+        data={"group_id": "g1", "identity": "guest-deadbeef", "name": "Guest"}
+    )
+    assert set(await r.audience(ev)) == {"u1", "u2"}
+
+
+@pytest.mark.asyncio
+async def test_call_participant_events_without_group_id_have_no_audience():
+    # Defensive: a malformed event must fall through to [], never to an
+    # unscoped audience. The fetcher raises to prove the guard short-circuits.
+    async def group_members(_gid: str) -> list[str]:
+        raise AssertionError("group_members must not be called without a group_id")
+
+    from pocketpaw_ee.cloud._core.realtime.events import (
+        CallParticipantJoined,
+        CallParticipantLeft,
+    )
+
+    r = AudienceResolver(group_members=group_members)
+    for cls in (CallParticipantJoined, CallParticipantLeft):
+        assert await r.audience(cls(data={"identity": "u1"})) == [], cls.__name__
+
+
+@pytest.mark.asyncio
+async def test_call_lifecycle_events_still_route_to_group_members():
+    # Pin: adding the participant types to the shared call branch (and removing
+    # the unreachable duplicate below it) must not change the lifecycle events.
+    async def group_members(_gid: str) -> list[str]:
+        return ["u1", "u2"]
+
+    from pocketpaw_ee.cloud._core.realtime.events import (
+        CallEnded,
+        CallNotesPosted,
+        CallStarted,
+    )
+
+    r = AudienceResolver(group_members=group_members)
+    for cls in (CallStarted, CallEnded, CallNotesPosted):
+        ev = cls(data={"group_id": "g1"})
+        assert set(await r.audience(ev)) == {"u1", "u2"}, cls.__name__

--- a/tests/cloud/realtime/test_audience_isolation.py
+++ b/tests/cloud/realtime/test_audience_isolation.py
@@ -17,6 +17,11 @@ DB-resolved membership, these tests fail loudly.
 The companion membership checks for *inbound* client → server messages
 (``room.join``, ``typing.*``, ``read.ack``) live in
 ``tests/cloud/chat/test_room_scoped.py``.
+
+The file also carries the positive half of that contract for the LiveKit
+call-participant events: ``if audience:`` in ``publish`` means an unresolved
+event is silently delivered to nobody, so those two pins assert on the
+``send_to_user`` calls rather than on the resolver's return value.
 """
 
 from __future__ import annotations
@@ -27,6 +32,8 @@ import pytest
 from pocketpaw_ee.cloud._core.realtime.audience import AudienceResolver
 from pocketpaw_ee.cloud._core.realtime.bus import InProcessBus
 from pocketpaw_ee.cloud._core.realtime.events import (
+    CallParticipantJoined,
+    CallParticipantLeft,
     MessageNew,
     WorkspaceUpdated,
 )
@@ -443,3 +450,72 @@ async def test_cookie_path_still_works(monkeypatch):
     mgr.connect.assert_awaited_once()
     assert mgr.connect.await_args.args[1] == "cookie-user"
     ws.close.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_call_participant_joined_reaches_every_group_member():
+    """End-to-end pin: emit -> resolver -> ConnectionManager.send_to_user.
+
+    This is the regression that matters. The resolver had no branch for
+    ``call.participant_joined``, so it returned ``[]``, and ``InProcessBus``
+    guards its fan-out with ``if audience:`` — the event was published and
+    delivered to nobody. Asserting on the resolver alone would not have
+    caught the skipped fan-out, so assert on the socket calls.
+    """
+    members_by_group = {"g1": ["u-alice", "u-bob"]}
+
+    async def group_members(gid: str) -> list[str]:
+        return list(members_by_group.get(gid, []))
+
+    resolver = AudienceResolver(group_members=group_members)
+    conn = AsyncMock()
+    bus = InProcessBus(resolver=resolver, conn_manager=conn)
+
+    await bus.publish(
+        CallParticipantJoined(
+            data={
+                "group_id": "g1",
+                "room_name": "group-call-g1",
+                "identity": "u-alice",
+                "name": "Alice",
+            }
+        )
+    )
+
+    assert conn.send_to_user.await_count == 2, "fan-out was skipped (audience resolved to [])"
+    recipients = {call.args[0] for call in conn.send_to_user.await_args_list}
+    assert recipients == {"u-alice", "u-bob"}
+    assert "u-mallory" not in recipients
+
+    payload = conn.send_to_user.await_args.args[1]
+    assert payload.type == "call.participant_joined"
+    assert payload.data["identity"] == "u-alice"
+
+
+@pytest.mark.asyncio
+async def test_call_participant_left_reaches_every_group_member():
+    """Same pin for the leave half — the roster chip clears on both edges."""
+    members_by_group = {"g1": ["u-alice", "u-bob"]}
+
+    async def group_members(gid: str) -> list[str]:
+        return list(members_by_group.get(gid, []))
+
+    resolver = AudienceResolver(group_members=group_members)
+    conn = AsyncMock()
+    bus = InProcessBus(resolver=resolver, conn_manager=conn)
+
+    await bus.publish(
+        CallParticipantLeft(
+            data={
+                "group_id": "g1",
+                "room_name": "group-call-g1",
+                "identity": "u-bob",
+                "name": "Bob",
+            }
+        )
+    )
+
+    assert conn.send_to_user.await_count == 2, "fan-out was skipped (audience resolved to [])"
+    recipients = {call.args[0] for call in conn.send_to_user.await_args_list}
+    assert recipients == {"u-alice", "u-bob"}
+    assert conn.send_to_user.await_args.args[1].type == "call.participant_left"

--- a/tests/mutations/call_participant_audience.json
+++ b/tests/mutations/call_participant_audience.json
@@ -1,0 +1,50 @@
+[
+  {
+    "label": "participant events fall back out of the call branch (the original dead-event bug)",
+    "file": "ee/pocketpaw_ee/cloud/_core/realtime/audience.py",
+    "find": "            \"call.notes_posted\",\n            \"call.participant_joined\",\n            \"call.participant_left\",\n        }:",
+    "replace": "            \"call.notes_posted\",\n        }:",
+    "tests": [
+      "tests/cloud/realtime/test_audience.py::test_call_participant_events_route_to_group_members",
+      "tests/cloud/realtime/test_audience_isolation.py::test_call_participant_joined_reaches_every_group_member",
+      "tests/cloud/realtime/test_audience_isolation.py::test_call_participant_left_reaches_every_group_member"
+    ]
+  },
+  {
+    "label": "only the joined half is wired (leave regresses to [])",
+    "file": "ee/pocketpaw_ee/cloud/_core/realtime/audience.py",
+    "find": "            \"call.participant_left\",\n        }:",
+    "replace": "        }:",
+    "tests": [
+      "tests/cloud/realtime/test_audience_isolation.py::test_call_participant_left_reaches_every_group_member"
+    ]
+  },
+  {
+    "label": "audience keyed off the payload identity instead of DB-resolved membership",
+    "file": "ee/pocketpaw_ee/cloud/_core/realtime/audience.py",
+    "find": "            \"call.participant_left\",\n        }:\n            if gid := d.get(\"group_id\"):\n                return await self._group(gid)",
+    "replace": "            \"call.participant_left\",\n        }:\n            if d.get(\"identity\"):\n                return [d[\"identity\"]]\n            if gid := d.get(\"group_id\"):\n                return await self._group(gid)",
+    "tests": [
+      "tests/cloud/realtime/test_audience.py::test_call_participant_events_exclude_non_members",
+      "tests/cloud/realtime/test_audience.py::test_call_participant_joined_keeps_the_joiner_in_the_audience"
+    ]
+  },
+  {
+    "label": "missing group_id no longer short-circuits (unscoped member lookup)",
+    "file": "ee/pocketpaw_ee/cloud/_core/realtime/audience.py",
+    "find": "            \"call.participant_left\",\n        }:\n            if gid := d.get(\"group_id\"):\n                return await self._group(gid)\n            return []",
+    "replace": "            \"call.participant_left\",\n        }:\n            return await self._group(d.get(\"group_id\", \"\"))",
+    "tests": [
+      "tests/cloud/realtime/test_audience.py::test_call_participant_events_without_group_id_have_no_audience"
+    ]
+  },
+  {
+    "label": "call lifecycle events lose their audience (pin against collateral damage)",
+    "file": "ee/pocketpaw_ee/cloud/_core/realtime/audience.py",
+    "find": "        if t in {\n            \"call.started\",\n            \"call.ended\",",
+    "replace": "        if t in {\n            \"call.__started\",\n            \"call.__ended\",",
+    "tests": [
+      "tests/cloud/realtime/test_audience.py::test_call_lifecycle_events_still_route_to_group_members"
+    ]
+  }
+]


### PR DESCRIPTION
## Problem

`call.participant_joined` and `call.participant_left` were emitted (livekit/router.py on join via /token and on leave, plus invites.py for guest joins) and registered in the event registry, but the realtime audience resolver had no branch for them. So `_core/realtime/bus.py`'s `if audience:` fan-out saw an empty list and delivered them to nobody. The frontend handler that updates the "who's in the call" roster chip was dead code.

## Change

`_core/realtime/audience.py` — add both types to the existing call branch (alongside `call.started` / `call.ended` / `call.notes_posted`), resolving to the members of the call's group. A missing `group_id` short-circuits to an empty audience without raising.

The joiner is deliberately not excluded from the audience: their own tab needs the roster update, and for guest joins the `identity` is a `guest-<hex>` token, not a workspace user id, so it can't safely key an exclusion anyway.

Also removed an unreachable duplicate `call.started` / `call.ended` branch that sat below the live one (the live branch returns on every path for those types). No behavior change from the removal.

## Tests

96 passed across `tests/cloud/realtime/` and `tests/cloud/livekit/`. The audience tests pin both types to group members, exclude a non-member, prove the missing-group short-circuit with a raising fetcher, and pin that `call.started/ended/notes_posted` still route unchanged. A bus-level test builds a real InProcessBus and asserts publish → resolver → ConnectionManager reaches every member (a resolver-return-value test alone can't catch a skipped fan-out). 5/5 mutations caught.

## Pairs with

pocketpaw fix/call-leave-membership-guard — the leave endpoint that emits one of these events was missing its group-membership guard; that PR closes it. Merge them together. The frontend chime/toast half is a separate paw-enterprise PR in the same wave.