### PR TITLE
fix(security): guard the call leave endpoint like its siblings

### DIFF
--- a/ee/pocketpaw_ee/cloud/livekit/router.py
+++ b/ee/pocketpaw_ee/cloud/livekit/router.py
@@ -3,6 +3,7 @@
 Endpoints:
 - ``POST /api/v1/livekit/rooms`` — create/get a call room for a group
 - ``POST /api/v1/livekit/token`` — generate participant access token
+- ``POST /api/v1/livekit/rooms/{group_id}/leave`` — announce a participant left
 - ``DELETE /api/v1/livekit/rooms/{group_id}`` — end a call
 - ``GET /api/v1/livekit/rooms/{group_id}`` — get room status
 - ``POST /api/v1/livekit/rooms/{group_id}/recording/start`` — start recording (owner only)
@@ -17,7 +18,14 @@ Endpoints:
 All routes require an active enterprise license, user authentication,
 and group membership, EXCEPT the public invite validate/join endpoints
 which allow external guests without a Pocketpaw account. Recording endpoints
-additionally require workspace ownership."""
+additionally require workspace ownership.
+
+``/rooms/{group_id}/leave`` was the one exception to that guarantee until
+2026-08-11 — it emitted ``CallParticipantLeft`` to the group's members with
+no license and no membership check, so any authenticated user could inject a
+fabricated participant-left event into any group in any workspace. It now
+carries the same guard as its siblings; see
+``tests/cloud/livekit/test_leave_route_guard.py``."""
 
 from __future__ import annotations
 
@@ -301,6 +309,16 @@ async def leave_call(
     user=Depends(current_user),
 ):
     """Notify that a participant left a call without ending it."""
+    await require_license()
+
+    # Verify the caller is a member of the target group. This runs OUTSIDE the
+    # try below on purpose: the emit's blanket ``except`` must never swallow a
+    # 403/404 raised here. ``CallParticipantLeft`` fans out to the group's
+    # members, so an unguarded handler let any authenticated user push a
+    # fabricated "X left the call" into a group they don't belong to.
+    group = await _get_group_domain_or_404(group_id)
+    _require_domain_group_member(group, str(user.id))
+
     gid = group_id
     try:
         await emit(

--- a/tests/cloud/livekit/test_leave_route_guard.py
+++ b/tests/cloud/livekit/test_leave_route_guard.py
@@ -1,0 +1,120 @@
+"""HTTP contract tests for POST /livekit/rooms/{group_id}/leave (R-7).
+
+New file. ``leave_call`` shipped with NO license check and NO group-membership
+check while every sibling route (``generate_token``, ``get_room_info``,
+``end_call``) gated on ``require_license`` + ``_require_domain_group_member``.
+Since ``CallParticipantLeft`` fans out to the group's DB-resolved members, an
+unguarded handler let any authenticated user push a fabricated "X left the
+call" into a group they have no relationship with — injection across tenants.
+
+These tests mount the livekit router on a bare FastAPI app (the shared
+``cloud_app_client`` fixture mounts the chat agent router and overrides
+``current_user_id``, the wrong dependency for this router) and exercise the
+route over httpx against an isolated mongomock-motor DB.
+
+``require_license`` is called INLINE in the handler bodies, not wired as a
+``Depends`` — so ``app.dependency_overrides`` cannot reach it and the tests
+patch the router module's imported name instead.
+
+The assertions that matter are the emit-suppression ones: a 403 alone does not
+prove the guard runs BEFORE the ``try``/``except Exception: pass`` around the
+emit. Mutation that must break these: move the three guard calls inside the
+try block, or delete ``_require_domain_group_member`` from ``leave_call``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from fastapi import HTTPException
+from httpx import ASGITransport, AsyncClient
+from pocketpaw_ee.cloud._core.realtime.events import CallParticipantLeft
+from pocketpaw_ee.cloud.models.group import Group as _GroupDoc
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+@pytest_asyncio.fixture
+async def client(mongo_db) -> AsyncClient:  # noqa: ARG001 — fixture wires Beanie
+    from fastapi import FastAPI
+    from pocketpaw_ee.cloud._core.deps import current_user
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.cloud.livekit.router import router as livekit_router
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(livekit_router)
+    # The handler reads both ``.id`` and ``.full_name`` off the user.
+    app.dependency_overrides[current_user] = lambda: SimpleNamespace(id="u1", full_name="User One")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as c:
+        yield c
+
+
+@pytest_asyncio.fixture
+async def licensed():
+    """Neutralize the inline ``require_license()`` call in the router module."""
+    with patch(
+        "pocketpaw_ee.cloud.livekit.router.require_license",
+        new_callable=AsyncMock,
+        return_value=None,
+    ) as m:
+        yield m
+
+
+async def _make_group(members: list[str]) -> str:
+    doc = _GroupDoc(workspace="w-other", name="Private", owner=members[0] if members else "u9")
+    doc.members = list(members)
+    await doc.insert()
+    return str(doc.id)
+
+
+async def test_leave_rejects_non_member(client, licensed, recording_bus) -> None:
+    """A user outside the group cannot inject a participant-left event."""
+    gid = await _make_group(["u2", "u3"])
+
+    resp = await client.post(f"/livekit/rooms/{gid}/leave")
+
+    assert resp.status_code == 403
+    assert not [e for e in recording_bus.events if isinstance(e, CallParticipantLeft)]
+
+
+async def test_leave_rejects_unknown_group(client, licensed, recording_bus) -> None:
+    """A guessed / non-existent group id 404s instead of emitting."""
+    resp = await client.post("/livekit/rooms/507f1f77bcf86cd799439011/leave")
+
+    assert resp.status_code == 404
+    assert not [e for e in recording_bus.events if isinstance(e, CallParticipantLeft)]
+
+
+async def test_leave_allows_member(client, licensed, recording_bus) -> None:
+    """A real member still gets the normal 200 + the fan-out event."""
+    gid = await _make_group(["u1", "u2"])
+
+    resp = await client.post(f"/livekit/rooms/{gid}/leave")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+    left = [e for e in recording_bus.events if isinstance(e, CallParticipantLeft)]
+    assert len(left) == 1
+    assert left[0].data["group_id"] == gid
+    assert left[0].data["identity"] == "u1"
+    assert left[0].data["name"] == "User One"
+
+
+async def test_leave_requires_license(client, recording_bus) -> None:
+    """No license: same 403 the siblings return, and nothing is emitted."""
+    gid = await _make_group(["u1"])
+
+    with patch(
+        "pocketpaw_ee.cloud.livekit.router.require_license",
+        new_callable=AsyncMock,
+        side_effect=HTTPException(status_code=403, detail="Enterprise license required."),
+    ):
+        resp = await client.post(f"/livekit/rooms/{gid}/leave")
+
+    assert resp.status_code == 403
+    assert not [e for e in recording_bus.events if isinstance(e, CallParticipantLeft)]

--- a/tests/mutations/livekit_leave_guard.json
+++ b/tests/mutations/livekit_leave_guard.json
@@ -12,5 +12,19 @@
     "find": "    \"\"\"Notify that a participant left a call without ending it.\"\"\"\n    await require_license()",
     "replace": "    \"\"\"Notify that a participant left a call without ending it.\"\"\"",
     "tests": ["tests/cloud/livekit/test_leave_route_guard.py::test_leave_requires_license"]
+  },
+  {
+    "label": "move the leave guards inside the try (the except swallows the 403)",
+    "file": "ee/pocketpaw_ee/cloud/livekit/router.py",
+    "find": "    group = await _get_group_domain_or_404(group_id)\n    _require_domain_group_member(group, str(user.id))\n\n    gid = group_id\n    try:\n        await emit(",
+    "replace": "    gid = group_id\n    try:\n        group = await _get_group_domain_or_404(group_id)\n        _require_domain_group_member(group, str(user.id))\n        await emit(",
+    "tests": ["tests/cloud/livekit/test_leave_route_guard.py"]
+  },
+  {
+    "label": "emit before the guard runs (status stays 403, event still leaks)",
+    "file": "ee/pocketpaw_ee/cloud/livekit/router.py",
+    "find": "    group = await _get_group_domain_or_404(group_id)\n    _require_domain_group_member(group, str(user.id))\n\n    gid = group_id\n    try:\n        await emit(\n            CallParticipantLeft(\n                data={\n                    \"group_id\": gid,\n                    \"room_name\": livekit_service.room_name_for_group(gid),\n                    \"identity\": str(user.id),\n                    \"name\": user.full_name or str(user.id),\n                }\n            )\n        )\n    except Exception:\n        pass",
+    "replace": "    gid = group_id\n    try:\n        await emit(\n            CallParticipantLeft(\n                data={\n                    \"group_id\": gid,\n                    \"room_name\": livekit_service.room_name_for_group(gid),\n                    \"identity\": str(user.id),\n                    \"name\": user.full_name or str(user.id),\n                }\n            )\n        )\n    except Exception:\n        pass\n    group = await _get_group_domain_or_404(group_id)\n    _require_domain_group_member(group, str(user.id))",
+    "tests": ["tests/cloud/livekit/test_leave_route_guard.py"]
   }
 ]

--- a/tests/mutations/livekit_leave_guard.json
+++ b/tests/mutations/livekit_leave_guard.json
@@ -1,0 +1,16 @@
+[
+  {
+    "label": "drop the membership check from leave_call",
+    "file": "ee/pocketpaw_ee/cloud/livekit/router.py",
+    "find": "    group = await _get_group_domain_or_404(group_id)\n    _require_domain_group_member(group, str(user.id))\n\n    gid = group_id",
+    "replace": "    gid = group_id",
+    "tests": ["tests/cloud/livekit/test_leave_route_guard.py"]
+  },
+  {
+    "label": "drop the license check from leave_call",
+    "file": "ee/pocketpaw_ee/cloud/livekit/router.py",
+    "find": "    \"\"\"Notify that a participant left a call without ending it.\"\"\"\n    await require_license()",
+    "replace": "    \"\"\"Notify that a participant left a call without ending it.\"\"\"",
+    "tests": ["tests/cloud/livekit/test_leave_route_guard.py::test_leave_requires_license"]
+  }
+]


### PR DESCRIPTION
## Problem

`POST /livekit/rooms/{group_id}/leave` emitted `CallParticipantLeft` with only `Depends(current_user)` — no group-membership check and no license check, unlike every other non-public route in the file (the token endpoint and `end_call` both do `require_license()` → `_get_group_domain_or_404` → `_require_domain_group_member`). This was latent while the event went nowhere; the paired audience-wiring PR (#1928) makes `CallParticipantLeft` fan out to a group's members, so an unguarded handler lets any authenticated user POST an arbitrary group id and push a fabricated "X left the call" into a group they don't belong to. No data leaks out (the audience is resolved from DB membership), but it's spoofed-roster injection plus leaking the caller's own id into a foreign group.

## Change

`livekit/router.py` — `leave_call` now runs the same three guards as its siblings, placed **outside/before** the `try/except Exception: pass` around the emit so a 403/404 propagates to the client instead of being swallowed. No new imports (all three helpers were already imported). One endpoint touched; nothing else.

`workspace_id` is deliberately not added — like its siblings, membership is the whole gate; the workspace dep only resolves the caller's own active workspace and never compares against the target resource.

## Tests

8 passed in `tests/cloud/livekit/`. A non-member gets 403 **and** emits no `CallParticipantLeft`; a member gets 200 and exactly one event; the no-license path is covered. The security-carrying assertions are the emit-suppression ones, not the status codes — a 403 alone wouldn't prove the guard runs before the try. The mutation plan (4/4 caught) includes the two subtle ordering mutants: guards moved inside the try (status flips to 200) and emit moved before the guard (status stays 403 but the event still leaks) — the latter is killed only by the emit-suppression assertion, which is what proves it earns its place.

## Pairs with

pocketpaw #1928 (audience wiring). Merge together.