### PR TITLE
feat(knowledge): paginate /knowledge/articles + UnifiedPage for /files

### DIFF
--- a/ee/pocketpaw_ee/cloud/files/router.py
+++ b/ee/pocketpaw_ee/cloud/files/router.py
@@ -51,6 +51,7 @@ async def list_files(
     source: Literal["chat", "local", "drive"] | None = Query(None),
     pocket_id: str | None = Query(None),
     limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
     user_id: str = Depends(current_user_id),
     current_workspace: str = Depends(current_workspace_id),
 ) -> JSONResponse:
@@ -58,6 +59,16 @@ async def list_files(
 
     ``workspace_id`` is accepted for explicitness but must match the
     caller's current workspace — cross-workspace listing is rejected.
+
+    Pagination is offset-based: ``limit`` bounds each page (default 100,
+    max 500) and ``offset`` skips that many rows into the sorted, deduped
+    listing. The response carries ``total`` (rows matching the query,
+    independent of the page) and ``has_more`` so clients can render a
+    "load more" affordance. Offset pages are sliced after the merge +
+    dedupe + newest-first sort, so pages are stable while the set is
+    unchanged. Fetching is capped at 500 rows per source, so ``offset``
+    beyond ~500 cannot page further (the FE stops offering "load more"
+    when a page comes back empty).
 
     Stage 3.E: when ``pocket_id`` is set, the caller must be a pocket
     member (owner / team / shared / workspace-visible). Non-members get
@@ -87,8 +98,8 @@ async def list_files(
                 content={"detail": "files.pocket_forbidden"},
             )
 
-    files, warnings = await _SVC.list_unified(
-        current_workspace, source=source, limit=limit, pocket_id=pocket_id
+    page = await _SVC.list_unified(
+        current_workspace, source=source, limit=limit, offset=offset, pocket_id=pocket_id
     )
 
     return JSONResponse(
@@ -107,9 +118,13 @@ async def list_files(
                     "created": f.created.isoformat() if f.created else None,
                     "chat_id": f.chat_id,
                 }
-                for f in files
+                for f in page.files
             ],
-            "warnings": warnings,
+            "warnings": page.warnings,
+            "total": page.total,
+            "has_more": page.has_more,
+            "offset": offset,
+            "limit": limit,
         }
     )
 

--- a/ee/pocketpaw_ee/cloud/files/service.py
+++ b/ee/pocketpaw_ee/cloud/files/service.py
@@ -13,6 +13,15 @@ optional ``pocket_id``. When set, the chat-uploads slice is filtered to
 that pocket only. When ``None`` (the default), the listing returns
 workspace-only rows — the workspace Files panel never sees pocket files,
 which is the privacy contract for pocket-scoped uploads.
+
+2026-08-13 (Files pagination): ``list_unified`` now returns a
+``UnifiedPage`` (files + warnings + total + has_more) and accepts an
+``offset`` for offset-based paging. ``total`` comes from a cheap count
+query on the dominant chat-uploads source so ``has_more`` is accurate
+even when the fetch is capped at the mongo 500-row limit. Each source is
+fetched with ``offset + limit`` rows so slicing the merged, deduped set
+at ``[offset:offset+limit]`` stays correct within that cap. Callers that
+only need the flat list keep working via ``page.files``.
 """
 
 from __future__ import annotations
@@ -42,6 +51,20 @@ class UnifiedFile:
     url: str | None  # None for local fs (FE uses Tauri for those)
     created: datetime | None
     chat_id: str | None = None
+
+
+@dataclass
+class UnifiedPage:
+    """One page of the unified Files listing plus pagination metadata.
+
+    ``total`` is the number of rows matching the query (independent of the
+    per-source fetch cap), so ``has_more`` stays correct on a full page.
+    """
+
+    files: list[UnifiedFile]
+    warnings: list[str]
+    total: int
+    has_more: bool
 
 
 def _dedupe(files: list[UnifiedFile]) -> list[UnifiedFile]:
@@ -113,18 +136,35 @@ class UnifiedFilesService:
         )
         return []
 
+    async def _count_chat_uploads(self, workspace_id: str, pocket_id: str | None) -> int:
+        """Count live chat uploads under the same scope ``list_chat_uploads``
+        lists. Mirrors its tri-state ``pocket_id`` handling so ``total`` and
+        ``has_more`` describe exactly the rows that can be paged through."""
+        if pocket_id:
+            return await self._uploads.count_by_workspace(workspace_id, pocket_id=pocket_id)
+        return await self._uploads.count_by_workspace(workspace_id, pocket_id=LIST_WORKSPACE_ONLY)
+
     async def list_unified(
         self,
         workspace_id: str,
         *,
         source: FileSource | None,
         limit: int,
+        offset: int = 0,
         pocket_id: str | None = None,
-    ) -> tuple[list[UnifiedFile], list[str]]:
-        """Return (files, warnings).
+    ) -> UnifiedPage:
+        """Return a ``UnifiedPage`` for the given offset/limit window.
 
         ``source`` is optional — omit for "everything we can reach". When
         a specific source is requested, only that source is queried.
+
+        Pagination: each source is fetched with ``offset + limit`` rows
+        (capped at the mongo 500-row fetch limit), then the merged,
+        deduped set is sliced at ``[offset : offset + limit]``. ``total``
+        is the real matching count from a cheap count query so ``has_more``
+        is accurate even when the fetch is capped. Sources that can't be
+        paged (local files enumerated client-side, the stubbed Drive
+        branch) report ``total=0`` / ``has_more=False``.
 
         Stage 3.E: when ``pocket_id`` is set, the chat slice is filtered
         to that pocket. When ``None`` (the default), the chat slice
@@ -132,7 +172,8 @@ class UnifiedFilesService:
         workspace Files panel. The Drive branch is workspace-level for
         now (a Drive-per-pocket connector is Phase 4 territory).
         """
-        per_source = max(1, min(limit, 500))
+        # Fetch enough rows per source to satisfy the requested window.
+        per_source = max(1, min(offset + limit, 500))
         warnings: list[str] = []
         merged: list[UnifiedFile] = []
 
@@ -167,4 +208,11 @@ class UnifiedFilesService:
         merged.sort(key=lambda f: f.created or datetime.min, reverse=True)
         merged = _dedupe(merged)
 
-        return merged[:limit], warnings
+        total = 0
+        if source in (None, "chat"):
+            total = await self._count_chat_uploads(workspace_id, pocket_id)
+
+        page = merged[offset : offset + limit]
+        has_more = offset + len(page) < total
+
+        return UnifiedPage(files=page, warnings=warnings, total=total, has_more=has_more)

--- a/ee/pocketpaw_ee/cloud/kb/knowledge_router.py
+++ b/ee/pocketpaw_ee/cloud/kb/knowledge_router.py
@@ -315,6 +315,18 @@ async def list_workspace_articles(
     agent_id: str | None = Query(
         None, description="Filter by agent; 'workspace' for workspace-only"
     ),
+    limit: int | None = Query(
+        None,
+        ge=1,
+        le=500,
+        description="Max rows to return. Omit for the legacy one-shot "
+        "full listing (backward compatible).",
+    ),
+    offset: int = Query(
+        0,
+        ge=0,
+        description="Offset into the newest-first listing (with `limit`).",
+    ),
     active_workspace_id: str = Depends(current_workspace_id),
     user_id: str = Depends(current_user_id),
 ) -> dict:
@@ -325,6 +337,10 @@ async def list_workspace_articles(
        if set (prevents accidental cross-tenant reads).
     - ``agent_id`` — optional filter. ``"workspace"`` means workspace-only,
       otherwise restricts to one agent's KB.
+    - ``limit`` / ``offset`` — optional offset pagination for the unified
+      Files panel. The merge itself still fans out across every scope; only
+      the response window is sliced. When ``limit`` is omitted the endpoint
+      keeps returning every article (existing consumers unchanged).
     """
     if workspace_id_q is not None and workspace_id_q != active_workspace_id:
         raise Forbidden(
@@ -336,7 +352,14 @@ async def list_workspace_articles(
     if agent_id is not None and agent_id != "workspace" and agent_id not in agent_ids:
         # Unknown agent or an agent outside this workspace — surface as empty
         # rather than leaking existence of agents in other workspaces.
-        return {"articles": [], "total": 0, "agent_ids": agent_ids}
+        return {
+            "articles": [],
+            "total": 0,
+            "has_more": False,
+            "offset": offset,
+            "limit": limit,
+            "agent_ids": agent_ids,
+        }
 
     articles = await aggregate_workspace_articles(
         workspace_id=active_workspace_id,
@@ -347,9 +370,16 @@ async def list_workspace_articles(
         agent_filter=agent_id,
     )
 
+    total = len(articles)
+    page = articles[offset : offset + limit] if limit is not None else articles
+    has_more = offset + len(page) < total
+
     return {
-        "articles": [a.to_dict() for a in articles],
-        "total": len(articles),
+        "articles": [a.to_dict() for a in page],
+        "total": total,
+        "has_more": has_more,
+        "offset": offset,
+        "limit": limit,
         "agent_ids": agent_ids,
     }
 

--- a/ee/pocketpaw_ee/cloud/surface/handlers/files.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/files.py
@@ -51,7 +51,8 @@ async def build_preamble(workspace_id: str, user_id: str, meta: SurfaceMeta) -> 
         from pocketpaw_ee.cloud.files.service import UnifiedFilesService
 
         svc = UnifiedFilesService()
-        files, _warnings = await svc.list_unified(workspace_id, source=None, limit=LIST_LIMIT)
+        page = await svc.list_unified(workspace_id, source=None, limit=LIST_LIMIT)
+        files = page.files
     except Exception:
         logger.debug("files_handler: list_unified failed", exc_info=True)
         return SurfacePreamble(

--- a/ee/pocketpaw_ee/cloud/uploads/mongo_store.py
+++ b/ee/pocketpaw_ee/cloud/uploads/mongo_store.py
@@ -358,6 +358,33 @@ class MongoFileStore:
         docs = await FileUpload.find(query).sort([("createdAt", -1)]).limit(capped).to_list()
         return [r for r in (self._to_record(d) for d in docs) if r is not None]
 
+    async def count_by_workspace(
+        self,
+        workspace: str,
+        *,
+        pocket_id: str | None | _Sentinel = None,
+    ) -> int:
+        """Count live (non-deleted) file records in a workspace.
+
+        Mirrors ``list_by_workspace``'s tri-state ``pocket_id`` so the
+        count always describes exactly the rows a matching list call would
+        return:
+        - ``None`` (default): no pocket filter applied.
+        - A string id: rows scoped to that pocket.
+        - ``LIST_WORKSPACE_ONLY`` sentinel: rows with ``pocket_id IS None``
+          (workspace-scoped uploads only — what the workspace Files panel
+          surfaces).
+        """
+        query: dict = {
+            "workspace": workspace,
+            "deleted_at": None,
+        }
+        if pocket_id is LIST_WORKSPACE_ONLY:
+            query["pocket_id"] = None
+        elif isinstance(pocket_id, str):
+            query["pocket_id"] = pocket_id
+        return await FileUpload.find(query).count()
+
     async def iter_by_pocket(
         self,
         workspace: str,

--- a/tests/cloud/files/test_router_pocket_filter.py
+++ b/tests/cloud/files/test_router_pocket_filter.py
@@ -150,3 +150,37 @@ async def test_acl_lookup_failure_treated_as_denial(monkeypatch, beanie_files_db
         headers={"x-user": "u1", "x-workspace": "w1"},
     )
     assert r.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_files_offset_pagination(monkeypatch, beanie_files_db):
+    """GET /files returns total + has_more and honours offset/limit."""
+    for i in range(5):
+        await _seed("w1", name=f"f{i}.pdf")
+
+    async def is_member(**_kwargs):
+        return False
+
+    client = _build_app(monkeypatch, member_check=is_member)
+
+    first = client.get(
+        "/api/v1/files?source=chat&limit=2&offset=0",
+        headers={"x-user": "u1", "x-workspace": "w1"},
+    )
+    assert first.status_code == 200, first.text
+    body = first.json()
+    assert len(body["files"]) == 2
+    assert body["total"] == 5
+    assert body["has_more"] is True
+    assert body["offset"] == 0
+    assert body["limit"] == 2
+
+    last = client.get(
+        "/api/v1/files?source=chat&limit=2&offset=4",
+        headers={"x-user": "u1", "x-workspace": "w1"},
+    )
+    assert last.status_code == 200, last.text
+    last_body = last.json()
+    assert len(last_body["files"]) == 1
+    assert last_body["total"] == 5
+    assert last_body["has_more"] is False

--- a/tests/cloud/files/test_unified_list.py
+++ b/tests/cloud/files/test_unified_list.py
@@ -92,13 +92,13 @@ async def test_unified_list_includes_chat_and_drive_warning(beanie_files_db):
     await _seed_upload("w1", name="chat-attachment.pdf")
 
     svc = UnifiedFilesService()
-    files, warnings = await svc.list_unified("w1", source=None, limit=50)
+    page = await svc.list_unified("w1", source=None, limit=50)
 
-    assert [f.source for f in files] == ["chat"]
-    assert [f.filename for f in files] == ["chat-attachment.pdf"]
+    assert [f.source for f in page.files] == ["chat"]
+    assert [f.filename for f in page.files] == ["chat-attachment.pdf"]
     # Drive branch is stubbed — the service flags it so the FE can
     # render a "connect Drive" nudge without guessing.
-    assert any("drive.not_connected" in w for w in warnings)
+    assert any("drive.not_connected" in w for w in page.warnings)
 
 
 @pytest.mark.asyncio
@@ -106,19 +106,19 @@ async def test_unified_list_chat_only_has_no_drive_warning(beanie_files_db):
     await _seed_upload("w1", name="a.pdf")
 
     svc = UnifiedFilesService()
-    files, warnings = await svc.list_unified("w1", source="chat", limit=50)
+    page = await svc.list_unified("w1", source="chat", limit=50)
 
-    assert len(files) == 1
-    assert warnings == []
+    assert len(page.files) == 1
+    assert page.warnings == []
 
 
 @pytest.mark.asyncio
 async def test_unified_list_local_source_warns_client_only(beanie_files_db):
     svc = UnifiedFilesService()
-    files, warnings = await svc.list_unified("w1", source="local", limit=50)
+    page = await svc.list_unified("w1", source="local", limit=50)
 
-    assert files == []
-    assert any("local.client_only" in w for w in warnings)
+    assert page.files == []
+    assert any("local.client_only" in w for w in page.warnings)
 
 
 def test_dedupe_keeps_first_occurrence():
@@ -145,5 +145,47 @@ async def test_unified_list_respects_limit_cap(beanie_files_db):
         await _seed_upload("w1", name=f"f{i}.pdf")
 
     svc = UnifiedFilesService()
-    files, _ = await svc.list_unified("w1", source="chat", limit=3)
-    assert len(files) == 3
+    page = await svc.list_unified("w1", source="chat", limit=3)
+    assert len(page.files) == 3
+
+
+@pytest.mark.asyncio
+async def test_unified_list_offset_pagination(beanie_files_db):
+    """Offset paging walks the newest-first merged set and reports an
+    accurate total + has_more (total comes from a count, not the page)."""
+    for i in range(5):
+        await _seed_upload("w1", name=f"f{i}.pdf")
+
+    svc = UnifiedFilesService()
+
+    first = await svc.list_unified("w1", source="chat", limit=2, offset=0)
+    assert len(first.files) == 2
+    assert first.total == 5
+    assert first.has_more is True
+
+    second = await svc.list_unified("w1", source="chat", limit=2, offset=2)
+    assert len(second.files) == 2
+    assert second.total == 5
+    assert second.has_more is True
+
+    last = await svc.list_unified("w1", source="chat", limit=2, offset=4)
+    assert len(last.files) == 1
+    assert last.total == 5
+    assert last.has_more is False
+
+    # Pages don't overlap and cover every row exactly once (newest first).
+    names = [f.filename for f in first.files + second.files + last.files]
+    assert sorted(names) == [f"f{i}.pdf" for i in range(5)]
+
+
+@pytest.mark.asyncio
+async def test_unified_list_has_more_false_on_short_page(beanie_files_db):
+    """A page short of ``limit`` on the last batch never claims more rows."""
+    for i in range(3):
+        await _seed_upload("w1", name=f"f{i}.pdf")
+
+    svc = UnifiedFilesService()
+    page = await svc.list_unified("w1", source="chat", limit=10, offset=0)
+    assert len(page.files) == 3
+    assert page.total == 3
+    assert page.has_more is False

--- a/tests/cloud/test_knowledge_router.py
+++ b/tests/cloud/test_knowledge_router.py
@@ -88,6 +88,42 @@ def test_list_workspace_articles_unions_scopes(client: TestClient) -> None:
     assert set(body["agent_ids"]) == {"agent-1", "agent-2"}
 
 
+def test_list_workspace_articles_paginated(client: TestClient) -> None:
+    """limit/offset slice the newest-first stream and report has_more.
+
+    Seed order (newest first after the aggregator sort): ws-doc-2
+    (2026-04-19), ws-doc-1 (2026-04-18), a1-doc (2026-04-17), a2-doc
+    (2026-04-16). Page of 2 → first page has_more=True, second page False.
+    """
+    first = client.get("/api/v1/knowledge/articles?limit=2&offset=0")
+    assert first.status_code == 200, first.text
+    body = first.json()
+    assert [a["id"] for a in body["articles"]] == ["ws-doc-2", "ws-doc-1"]
+    assert body["total"] == 4
+    assert body["has_more"] is True
+    assert body["offset"] == 0
+    assert body["limit"] == 2
+
+    second = client.get("/api/v1/knowledge/articles?limit=2&offset=2")
+    assert second.status_code == 200, second.text
+    second_body = second.json()
+    assert [a["id"] for a in second_body["articles"]] == ["a1-doc", "a2-doc"]
+    assert second_body["total"] == 4
+    assert second_body["has_more"] is False
+
+
+def test_list_workspace_articles_without_limit_is_unchanged(client: TestClient) -> None:
+    """Omit limit/offset → the legacy one-shot full listing, plus has_more
+    False so the frontend knows there's nothing left to page."""
+    response = client.get("/api/v1/knowledge/articles")
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert len(body["articles"]) == 4
+    assert body["has_more"] is False
+    assert body["limit"] is None
+    assert body["offset"] == 0
+
+
 def test_filter_by_workspace_keyword(client: TestClient) -> None:
     response = client.get("/api/v1/knowledge/articles?agent_id=workspace")
     assert response.status_code == 200

--- a/tests/cloud/uploads/test_pocket_isolation.py
+++ b/tests/cloud/uploads/test_pocket_isolation.py
@@ -46,9 +46,9 @@ async def test_pocket_a_listing_returns_only_pocket_a_files(beanie_upload_db):
     await _seed("w1", name="b-secret.pdf", pocket_id="B")
 
     svc = UnifiedFilesService()
-    files, _warnings = await svc.list_unified("w1", source="chat", limit=50, pocket_id="A")
+    page = await svc.list_unified("w1", source="chat", limit=50, pocket_id="A")
 
-    assert [f.filename for f in files] == ["a-secret.pdf"]
+    assert [f.filename for f in page.files] == ["a-secret.pdf"]
 
 
 @pytest.mark.asyncio
@@ -57,9 +57,9 @@ async def test_pocket_b_listing_returns_only_pocket_b_files(beanie_upload_db):
     await _seed("w1", name="b-secret.pdf", pocket_id="B")
 
     svc = UnifiedFilesService()
-    files, _warnings = await svc.list_unified("w1", source="chat", limit=50, pocket_id="B")
+    page = await svc.list_unified("w1", source="chat", limit=50, pocket_id="B")
 
-    assert [f.filename for f in files] == ["b-secret.pdf"]
+    assert [f.filename for f in page.files] == ["b-secret.pdf"]
 
 
 @pytest.mark.asyncio
@@ -75,9 +75,9 @@ async def test_workspace_listing_excludes_all_pocket_files(beanie_upload_db):
     await _seed("w1", name="b-secret.pdf", pocket_id="B")
 
     svc = UnifiedFilesService()
-    files, _warnings = await svc.list_unified("w1", source="chat", limit=50, pocket_id=None)
+    page = await svc.list_unified("w1", source="chat", limit=50, pocket_id=None)
 
-    assert [f.filename for f in files] == ["ws-doc.pdf"]
+    assert [f.filename for f in page.files] == ["ws-doc.pdf"]
 
 
 @pytest.mark.asyncio
@@ -90,9 +90,9 @@ async def test_cross_workspace_isolation_holds_within_pocket_filter(
     await _seed("w2", name="w2-pa.pdf", pocket_id="P")
 
     svc = UnifiedFilesService()
-    files, _ = await svc.list_unified("w1", source="chat", limit=50, pocket_id="P")
+    page = await svc.list_unified("w1", source="chat", limit=50, pocket_id="P")
 
-    assert [f.filename for f in files] == ["w1-pa.pdf"]
+    assert [f.filename for f in page.files] == ["w1-pa.pdf"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What & why

Backend half of `/files` scroll-pagination (frontend: qbtrix/paw-enterprise#786). Paged 25-at-a-time loading needs the API to slice and report `has_more`.

## Changes

- **`GET /knowledge/articles`** accepts `limit` (1–500) + `offset`, slices the newest-first aggregation, and returns `has_more`/`offset`/`limit`. Unknown-agent early-return now includes the same fields. Omitting `limit` preserves the legacy one-shot full listing (verified unchanged).
- **`GET /files`** returns a `UnifiedPage` (`total`/`has_more`/`offset`/`limit`) for all sources so the frontend can page 25 at a time.

## Tests

- `test_list_workspace_articles_paginated` — page slicing + `has_more` flip
- `test_list_workspace_articles_without_limit_is_unchanged` — legacy contract intact
- Offset pagination tests for the unified `/files` listing; pocket-filter + isolation tests updated for `UnifiedPage`
- 98 passed; `ruff check` clean