### PR TITLE
Contact form: the form and the thing that reads it were never compared

### DIFF
--- a/ee/pocketpaw_ee/cloud/leads/service.py
+++ b/ee/pocketpaw_ee/cloud/leads/service.py
@@ -82,6 +82,7 @@ from pocketpaw.security.injection_scanner import (
     ThreatLevel,
     get_injection_scanner,
 )
+from pocketpaw.sites_capture import contact_form
 from pocketpaw.sites_capture.ingest import interpolate_mapping, is_honeypot_tripped
 from pocketpaw.sites_capture.models import SiteEventMapping
 from pocketpaw_ee.cloud.leads.domain import Lead
@@ -259,6 +260,20 @@ async def capture(
     if not _passes_injection_screen(payload):
         _emit_drop_audit(site=site, form_type=form_type, reason="injection")
         return None
+
+    # CONTACT FORM ONLY — alias normalization + schema validation. Other form
+    # types have no declared schema, so they keep the previous behaviour exactly.
+    if form_type == contact_form.CONTACT_FORM_TYPE:
+        # Non-destructive: adds canonical keys, drops nothing. This is what makes
+        # a lead from an ALREADY-PUBLISHED site land — those Workers POST
+        # ``name=...`` and will until someone republishes them, which nobody does
+        # because the site looks fine. Also what lets an IMPORTED form's
+        # ``your-email`` / ``Phone Number`` reach the mapping at all.
+        payload = contact_form.normalize(payload)
+        reason = contact_form.validate(payload)
+        if reason is not None:
+            _emit_drop_audit(site=site, form_type=form_type, reason=reason)
+            return None
 
     raw_mapping = site.event_mapping.get(form_type)
     if raw_mapping is None:

--- a/ee/pocketpaw_ee/sites/landing_assembler.py
+++ b/ee/pocketpaw_ee/sites/landing_assembler.py
@@ -37,6 +37,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from pocketpaw.sites_capture import contact_form
+
 # Anchor ids the navbar / CTAs / footer link to. The wrapping section/card
 # carries the id because marketing widgets have none of their own.
 _ANCHOR_SERVICES = "services"
@@ -217,61 +219,62 @@ def _cta_band(content: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+# Per-field placeholder overrides from the ``content`` copy object, keyed by
+# canonical field name. Copy is the LLM's to supply; the field set and the POST
+# names are not (see ``_lead_form_card``).
+_PLACEHOLDER_KEYS: dict[str, tuple[str, str]] = {
+    contact_form.FULL_NAME: ("contact", "name_placeholder"),
+    contact_form.EMAIL: ("contact", "email"),
+    contact_form.PHONE: ("contact", "phone"),
+    contact_form.MESSAGE: ("root", "message_placeholder"),
+}
+
+
+def _placeholder(content: dict[str, Any], spec: contact_form.ContactField) -> str:
+    """The copy-supplied placeholder for a field, falling back to the schema's."""
+    where, key = _PLACEHOLDER_KEYS.get(spec.name, ("root", ""))
+    source = content if where == "root" else (content.get(where) or {})
+    return _s(source.get(key) if key else None, spec.placeholder)
+
+
 def _lead_form_card(content: dict[str, Any]) -> dict[str, Any]:
     """The FLAT lead-capture form (SSR rule 1).
 
     Flat ``input`` / ``textarea`` / ``button{type:submit}`` placed directly in a
     ``card`` — NEVER a ``form`` or ``newsletter`` widget (those emit a nested
     ``<form>`` that the browser drops inside the site template's outer form, so
-    the visitor's submit silently captures nothing). Each input carries a real
-    ``name`` so the native POST maps the lead. The default
-    ``name``/``email``/``phone``/``message`` field set matches the Site service's
-    seeded ``event_mapping``, so a lead lands with no manual config.
+    the visitor's submit silently captures nothing).
+
+    Updated 2026-08-13: the fields are now GENERATED from
+    ``sites_capture.contact_form.CONTACT_FIELDS`` — the same declaration the Site
+    service derives its seeded ``event_mapping`` from. They used to be four
+    hand-written literals whose docstring claimed they matched that mapping. They
+    did not: this emitted ``name="name"`` and the mapping read
+    ``{{ payload.full_name }}``, so the visitor's name was projected away and every
+    lead from this path landed with an empty name. Two hand-written lists in two
+    packages will drift; one declaration cannot.
     """
-    contact = content.get("contact") or {}
     title = _s(content.get("form_title"), "Get in touch")
+    fields: list[dict[str, Any]] = []
+    for spec in contact_form.CONTACT_FIELDS:
+        props: dict[str, Any] = {
+            # The POST name IS the canonical field name — that identity is the
+            # whole point of deriving from the schema.
+            "name": spec.name,
+            "label": spec.label,
+            "placeholder": _placeholder(content, spec),
+        }
+        if spec.required:
+            props["required"] = True
+        if not spec.multiline and spec.input_type != "text":
+            props["type"] = spec.input_type
+        fields.append({"type": "textarea" if spec.multiline else "input", "props": props})
+
     return {
         "type": "card",
         "props": {"id": _ANCHOR_BOOK, "title": title},
         "children": [
-            {
-                "type": "input",
-                "props": {
-                    "name": "name",
-                    "label": "Your name",
-                    "placeholder": _s(contact.get("name_placeholder"), "Jane Doe"),
-                    "required": True,
-                },
-            },
-            {
-                "type": "input",
-                "props": {
-                    "name": "email",
-                    "label": "Email",
-                    "type": "email",
-                    "placeholder": _s(contact.get("email"), "you@email.com"),
-                    "required": True,
-                },
-            },
-            {
-                "type": "input",
-                "props": {
-                    "name": "phone",
-                    "label": "Phone",
-                    "type": "tel",
-                    "placeholder": _s(contact.get("phone"), "(555) 010-1234"),
-                },
-            },
-            {
-                "type": "textarea",
-                "props": {
-                    "name": "message",
-                    "label": "How can we help?",
-                    "placeholder": _s(
-                        content.get("message_placeholder"), "Tell us what you need..."
-                    ),
-                },
-            },
+            *fields,
             {
                 "type": "button",
                 "props": {

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -837,6 +837,7 @@ from typing import Any
 from bson import ObjectId
 from bson.errors import InvalidId
 
+from pocketpaw.sites_capture.contact_form import CONTACT_FORM_TYPE, default_event_mapping
 from pocketpaw_ee.cloud._core.errors import (
     CloudError,
     Forbidden,
@@ -1502,24 +1503,22 @@ def _builder_origin() -> str:
 # The default logical form type. The generated /api/submit endpoint sends this
 # constant as ``form_type`` (the static page wraps the whole spec in one form, so
 # there is no per-form id at submit time), so the seeded mapping must key on it.
-_DEFAULT_FORM_TYPE = "lead"
+#
+# Updated 2026-08-13: both this and the mapping below are now DERIVED from
+# ``sites_capture.contact_form``, the single declaration of what a contact form
+# is. They used to be restated here, and the restatement drifted from the form
+# ``landing_assembler`` actually generates — the assembler emitted ``name="name"``
+# while this mapping read ``{{ payload.full_name }}``, so every lead captured
+# through the deterministic landing path stored an empty name and threw away the
+# value the visitor typed. Nothing compared the two files, so nothing caught it.
+# Derivation is the fix: a field rename is now one edit in one tuple.
+_DEFAULT_FORM_TYPE = CONTACT_FORM_TYPE
 
 # Default event mapping seeded at publish so a basic contact lead lands with NO
-# manual Mongo edit. Maps the common lead fields a marketing form collects; the
-# interpolator drops any ``{{ payload.X }}`` whose key is absent from the
-# submission (resolves to None), so a form that only sends {full_name, phone}
-# still produces a Lead — the extra fields simply come back empty.
-_DEFAULT_EVENT_MAPPING: dict[str, Any] = {
-    _DEFAULT_FORM_TYPE: {
-        "creates": "Lead",
-        "fields": {
-            "full_name": "{{ payload.full_name }}",
-            "phone": "{{ payload.phone }}",
-            "email": "{{ payload.email }}",
-            "message": "{{ payload.message }}",
-        },
-    }
-}
+# manual Mongo edit. The interpolator drops any ``{{ payload.X }}`` whose key is
+# absent from the submission (resolves to None), so a form that only sends
+# {full_name, phone} still produces a Lead — the extra fields come back empty.
+_DEFAULT_EVENT_MAPPING: dict[str, Any] = default_event_mapping()
 
 
 def _default_allowed_origins() -> list[str]:

--- a/src/pocketpaw/sites_capture/contact_form.py
+++ b/src/pocketpaw/sites_capture/contact_form.py
@@ -1,0 +1,272 @@
+# src/pocketpaw/sites_capture/contact_form.py — the ONE declaration of what a
+# Paw Site contact form is: its fields, the names they POST under, the older
+# names still arriving from the deployed fleet, and what makes a submission
+# worth storing.
+#
+# Created 2026-08-13. WHY IT EXISTS: the form and the thing that reads the form
+# were declared in two different packages and drifted. ``landing_assembler``
+# generated ``name="name"``; ``_DEFAULT_EVENT_MAPPING`` read
+# ``{{ payload.full_name }}``; nobody compared them, so every lead from the
+# deterministic landing path stored an empty name and discarded the value the
+# visitor actually typed. Both sides now derive from ``CONTACT_FIELDS`` here, so
+# the drift is not a bug that can recur — it is a rename that touches one tuple.
+#
+# This lives in the OSS package (not ee/) because both consumers are on opposite
+# sides of the open-core split: the assembler is EE, the capture service is EE,
+# but ``sites_capture`` is where the shared, dependency-free capture primitives
+# already live (``ingest.py``, ``models.py``) and where both may import from.
+#
+# THE RULE THAT SHAPES THE VALIDATION: a lost lead is the worst failure this
+# subsystem has. That principle is already why the injection screen drops at HIGH
+# rather than MEDIUM (see cloud/leads/service.py). So validation here is strict
+# about SHAPE — sizes, and whether the business can actually reply — and refuses
+# to be a spelling critic. A typo'd email with a good phone number is a customer;
+# a submission with neither is not reachable and is not a lead.
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+# The logical form type for a contact submission. It is the ``event_mapping``
+# key, the ``form_type`` the generated site POSTs, and the default the
+# native-form endpoint assumes. One constant so those three can never disagree.
+CONTACT_FORM_TYPE = "lead"
+
+# What the mapping ``creates`` — the lead's logical record type.
+CONTACT_CREATES = "Lead"
+
+
+@dataclass(frozen=True)
+class ContactField:
+    """One field of the canonical contact form.
+
+    ``name`` is BOTH the input's POST name and the stored property key — keeping
+    them identical is what removes the seam this module exists to close.
+
+    ``aliases`` are other names the same value arrives under. Two sources need
+    them: sites published BEFORE this module existed (their Workers are deployed
+    and will keep POSTing the old names until someone republishes, which nobody
+    will), and IMPORTED sites, whose forms were written by whoever built the
+    original page and use whatever they felt like. Aliases are matched loosely —
+    see ``_key``.
+    """
+
+    name: str
+    label: str
+    input_type: str = "text"
+    required: bool = False
+    max_length: int = 500
+    aliases: tuple[str, ...] = ()
+    # A field a business could reply through. At least one must arrive with a
+    # usable value or the submission is unreachable — see ``validate``.
+    reply_channel: bool = False
+    placeholder: str = ""
+    multiline: bool = False
+
+
+CONTACT_FIELDS: tuple[ContactField, ...] = (
+    ContactField(
+        name="full_name",
+        label="Your name",
+        required=True,
+        max_length=200,
+        # ``name`` is FIRST because it is what the deployed fleet sends.
+        aliases=("name", "yourname", "fullname", "firstname", "contactname"),
+        placeholder="Jane Doe",
+    ),
+    ContactField(
+        name="email",
+        label="Email",
+        input_type="email",
+        required=True,
+        # RFC 5321's maximum reverse-path length. Anything longer is not an
+        # address someone typed.
+        max_length=320,
+        aliases=("emailaddress", "youremail", "mail", "contactemail", "workemail"),
+        reply_channel=True,
+        placeholder="you@email.com",
+    ),
+    ContactField(
+        name="phone",
+        label="Phone",
+        input_type="tel",
+        max_length=50,
+        aliases=(
+            "tel",
+            "telephone",
+            "phonenumber",
+            "mobile",
+            "cell",
+            "yourphone",
+            "contactnumber",
+        ),
+        reply_channel=True,
+        placeholder="(555) 010-1234",
+    ),
+    ContactField(
+        name="message",
+        label="How can we help?",
+        # The one genuinely free-text field, so the only one sized for prose. The
+        # 8KB whole-payload cap in models.py still sits above this.
+        max_length=5000,
+        aliases=("msg", "comments", "comment", "enquiry", "inquiry", "details", "yourmessage"),
+        placeholder="Tell us what you need...",
+        multiline=True,
+    ),
+)
+
+CONTACT_FIELD_NAMES: tuple[str, ...] = tuple(f.name for f in CONTACT_FIELDS)
+
+# Convenience handles so callers reference a field by constant rather than by a
+# string literal that a rename would leave behind.
+FULL_NAME, EMAIL, PHONE, MESSAGE = CONTACT_FIELD_NAMES
+
+
+def _key(raw: str) -> str:
+    """Normalize a submitted field name for alias matching.
+
+    Lowercase and strip everything that is not a letter or digit, so ``Your Name``,
+    ``your-name``, ``your_name`` and ``yourName`` all collapse to one key. Imported
+    forms use every one of those conventions, and matching them exactly would mean
+    enumerating the cross product."""
+    return re.sub(r"[^a-z0-9]", "", raw.lower())
+
+
+def _alias_index() -> dict[str, str]:
+    """``normalized submitted name`` → ``canonical field name``.
+
+    Built once at import. A field's own name maps to itself, so the canonical
+    spelling always resolves without being listed among its own aliases."""
+    index: dict[str, str] = {}
+    for spec in CONTACT_FIELDS:
+        index[_key(spec.name)] = spec.name
+        for alias in spec.aliases:
+            index.setdefault(_key(alias), spec.name)
+    return index
+
+
+_ALIASES = _alias_index()
+
+
+def default_event_mapping() -> dict[str, dict[str, object]]:
+    """The seeded ``event_mapping`` for a freshly published site, derived from
+    ``CONTACT_FIELDS`` rather than restated.
+
+    Shaped as the plain dict the Site document stores (``SiteEventMapping``
+    validates it on read), keyed by ``CONTACT_FORM_TYPE``."""
+    return {
+        CONTACT_FORM_TYPE: {
+            "creates": CONTACT_CREATES,
+            "fields": {f.name: f"{{{{ payload.{f.name} }}}}" for f in CONTACT_FIELDS},
+        }
+    }
+
+
+def normalize(payload: dict[str, object]) -> dict[str, object]:
+    """Resolve aliased field names to their canonical spelling.
+
+    NON-DESTRUCTIVE: returns a copy carrying every original key plus the canonical
+    ones. Nothing downstream loses a key it was relying on — the honeypot field and
+    any extra input on an imported form still read exactly as submitted. (The
+    mapping projection is what decides storage; this only makes sure the canonical
+    lookup finds the value.)
+
+    A canonical key that already arrived with a non-empty value WINS over an alias,
+    so a form sending both ``full_name`` and ``name`` is not at the mercy of dict
+    ordering."""
+    out = dict(payload)
+    for raw, value in payload.items():
+        canonical = _ALIASES.get(_key(str(raw)))
+        if canonical is None or canonical == raw:
+            continue
+        if str(out.get(canonical) or "").strip():
+            continue  # the canonical spelling already carries a real value
+        if str(value or "").strip():
+            out[canonical] = value
+    return out
+
+
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+
+def looks_like_email(value: object) -> bool:
+    """Structural check only — one ``@``, a dot in the domain, no whitespace.
+
+    Deliberately not an RFC-complete validator and deliberately not a
+    deliverability check. The question being asked is "could a human reply to
+    this", not "is this address perfectly formed"; a stricter rule here rejects
+    real customers, which is the expensive direction to be wrong in."""
+    return bool(_EMAIL_RE.match(str(value or "").strip()))
+
+
+def looks_like_phone(value: object) -> bool:
+    """At least 7 digits after stripping formatting — the shortest real subscriber
+    number. Extensions, spaces, dashes, parentheses and ``+`` all survive."""
+    return len(re.sub(r"\D", "", str(value or ""))) >= 7
+
+
+def recognized(payload: dict[str, object]) -> bool:
+    """Did ANY canonical field resolve to a real value?
+
+    False means the submission's field names are ones this schema has never seen —
+    an imported form built by someone else, using names outside the alias table.
+    That is a configuration gap on our side, not a bad submission, and the two are
+    treated very differently in ``validate``."""
+    return any(str(payload.get(spec.name) or "").strip() for spec in CONTACT_FIELDS)
+
+
+def validate(payload: dict[str, object]) -> str | None:
+    """Check a NORMALIZED contact payload. Returns ``None`` when it should be
+    stored, or a short machine-readable reason when it should be dropped.
+
+    Two rules, both about whether this is a lead at all:
+
+    * ``too_long`` — a field exceeded its cap. A 5000-character name is not a
+      name, and the per-field caps are what make the 8KB payload cap meaningful
+      (without them one field could carry the whole budget).
+    * ``no_reply_channel`` — the form was understood and carries no usable email
+      and no usable phone. The business cannot answer it, so it is not a lead.
+
+    Everything else passes. Two deliberate leniencies:
+
+    * A malformed email with a good phone is KEPT — that is a reachable customer
+      with a typo, and rejecting them is the expensive direction to be wrong in.
+    * A payload where NOTHING resolved is KEPT. It is tempting to treat "no
+      recognized fields" as the strongest possible ``no_reply_channel``, but the
+      cause is almost always an imported form whose field names are not in the
+      alias table. Dropping it makes a misconfigured capture look like an absence
+      of visitors — the owner sees silence and concludes nobody is filling the
+      form. Letting it through stores an empty lead and rings the bell, which is
+      an ugly but HONEST signal that submissions are arriving and something needs
+      fixing. Silence is the worse failure."""
+    for spec in CONTACT_FIELDS:
+        if len(str(payload.get(spec.name) or "")) > spec.max_length:
+            return "too_long"
+
+    if not recognized(payload):
+        return None
+
+    reachable = looks_like_email(payload.get(EMAIL)) or looks_like_phone(payload.get(PHONE))
+    if not reachable:
+        return "no_reply_channel"
+    return None
+
+
+__all__ = [
+    "CONTACT_CREATES",
+    "CONTACT_FIELDS",
+    "CONTACT_FIELD_NAMES",
+    "CONTACT_FORM_TYPE",
+    "ContactField",
+    "EMAIL",
+    "FULL_NAME",
+    "MESSAGE",
+    "PHONE",
+    "default_event_mapping",
+    "looks_like_email",
+    "looks_like_phone",
+    "normalize",
+    "recognized",
+    "validate",
+]

--- a/tests/cloud/leads/test_service.py
+++ b/tests/cloud/leads/test_service.py
@@ -41,6 +41,8 @@ from pocketpaw_ee.cloud.leads import service as leads_service
 from pocketpaw_ee.cloud.models.site import Site
 from pocketpaw_ee.cloud.shared.events import event_bus
 
+from pocketpaw.sites_capture import contact_form
+
 
 @pytest.fixture
 def lead_events():
@@ -528,3 +530,116 @@ async def test_dropped_submission_emits_nothing(mongo_db, lead_events):
         submitter_ref="ip_unmapped",
     )
     assert lead_events == []
+
+
+# ---------------------------------------------------------------------------
+# 2026-08-13 — the canonical contact-form schema (sites_capture/contact_form.py).
+# Normalization + validation run ONLY for the contact form type, so everything
+# above this line — all of which uses "AppointmentRequest" — is deliberately
+# untouched by them. That containment is itself pinned below.
+# ---------------------------------------------------------------------------
+
+
+async def _contact_site(**over) -> Site:
+    """A site carrying the REAL seeded contact mapping, like a published one."""
+    site = Site(
+        workspace="ws1",
+        pocket_id="pk1",
+        owner="u1",
+        name=SITE_NAME,
+        script_name=SITE_ID,
+        allowed_origins=["brightsmiledental.com"],
+        signed_key="pp_tok_x",
+        event_mapping=contact_form.default_event_mapping(),
+        **over,
+    )
+    await site.insert()
+    return site
+
+
+@pytest.mark.asyncio
+async def test_a_live_sites_legacy_field_name_still_lands_its_lead(mongo_db):
+    """The fleet published before the schema existed POSTs ``name=``. Those Workers
+    are deployed and nobody republishes a site that looks fine, so the alias is the
+    only thing standing between them and a permanently empty name column."""
+    site = await _contact_site()
+    lead = await leads_service.capture(
+        site=site,
+        form_type=contact_form.CONTACT_FORM_TYPE,
+        payload={"name": "Sam Rivera", "email": "sam@example.com"},
+        submitter_ref="anon",
+        rate_key="rk1",
+    )
+    assert lead is not None
+    assert lead.properties["full_name"] == "Sam Rivera"
+
+
+@pytest.mark.asyncio
+async def test_an_unreachable_submission_is_dropped_with_its_reason(mongo_db, _isolate_audit_log):
+    """No email, no phone — nobody can answer it. Dropped like any other, through
+    the same audit path, and carrying none of the submitted values."""
+    sink = _capture_audit(_isolate_audit_log)
+    site = await _contact_site()
+    secret = "SecretLeadName1234"
+
+    lead = await leads_service.capture(
+        site=site,
+        form_type=contact_form.CONTACT_FORM_TYPE,
+        payload={"full_name": secret, "message": "call me"},
+        submitter_ref="anon",
+        rate_key="rk2",
+    )
+
+    assert lead is None
+    assert await leads_service.count_for_site("ws1", SITE_ID) == 0
+    assert len(sink) == 1
+    assert sink[0]["context"]["reason"] == "no_reply_channel"
+    assert secret not in json.dumps(sink[0], default=str)
+
+
+@pytest.mark.asyncio
+async def test_a_dropped_contact_submission_never_rings_the_workspace(mongo_db, lead_events):
+    """Same rule the other drops follow: nothing stored, nothing emitted."""
+    site = await _contact_site()
+    await leads_service.capture(
+        site=site,
+        form_type=contact_form.CONTACT_FORM_TYPE,
+        payload={"full_name": "Sam", "message": "call me"},
+        submitter_ref="anon",
+        rate_key="rk3",
+    )
+    assert lead_events == []
+
+
+@pytest.mark.asyncio
+async def test_a_form_the_schema_does_not_recognize_is_still_captured(mongo_db):
+    """An imported form using names outside the alias table is OUR gap, not a bad
+    submission. It stores an empty lead and rings the bell — ugly, but an honest
+    signal that submissions are arriving and the mapping needs attention. Dropping
+    it would make a broken capture indistinguishable from having no visitors."""
+    site = await _contact_site()
+    lead = await leads_service.capture(
+        site=site,
+        form_type=contact_form.CONTACT_FORM_TYPE,
+        payload={"how_did_you_hear": "a friend", "budget_range": "10-20k"},
+        submitter_ref="anon",
+        rate_key="rk4",
+    )
+    assert lead is not None
+
+
+@pytest.mark.asyncio
+async def test_a_non_contact_form_type_is_left_entirely_alone(mongo_db):
+    """The schema governs the contact form and nothing else. A site with a custom
+    mapping keeps its own field names and gets no validation — otherwise adding
+    this module would have silently started dropping other people's submissions."""
+    site = await _site()  # "AppointmentRequest", mapping name <- payload.full_name
+    lead = await leads_service.capture(
+        site=site,
+        form_type="AppointmentRequest",
+        payload={"full_name": "Sam"},  # no reply channel at all
+        submitter_ref="anon",
+        rate_key="rk5",
+    )
+    assert lead is not None
+    assert lead.properties == {"name": "Sam"}

--- a/tests/ee/sites/test_contact_form_contract.py
+++ b/tests/ee/sites/test_contact_form_contract.py
@@ -1,0 +1,181 @@
+# tests/ee/sites/test_contact_form_contract.py — the generated contact form and
+# the seeded event mapping are two halves of one contract, and nothing was
+# holding them together.
+#
+# Created 2026-08-13. THE BUG THIS REPRODUCES: ``landing_assembler`` emits the
+# lead form's first input as ``name="name"`` (landing_assembler.py, ``_lead_form_card``)
+# while the event mapping every Site doc is seeded with reads ``{{ payload.full_name }}``
+# (sites/service.py, ``_DEFAULT_EVENT_MAPPING``). Nothing aliases the two. So on
+# every site built through the deterministic landing path, the visitor types their
+# name, the browser POSTs ``name=...``, the interpolator looks up ``payload.full_name``,
+# finds nothing, and stores ``full_name: None``. The lead lands, the bell rings, the
+# owner opens the Leads view — and the one field they most need is empty. The typed
+# value is not recoverable: ``interpolate_mapping`` projects ONLY the mapping's keys,
+# so the submitted ``name`` never reaches storage at all.
+#
+# It is invisible to every existing test because they all hand-build BOTH sides.
+# tests/cloud/leads/test_service.py fixes its own mapping (``{"name": "{{ payload.full_name }}"}``)
+# and then submits ``{"full_name": "Sam"}`` — a payload matched to that fixture, not
+# the one the real form sends. That test passes and proves the interpolator works.
+# It cannot fail on this bug, because the form is not in it.
+#
+# So these tests deliberately import BOTH real artifacts and assert against neither's
+# hand-written copy: the field names come out of ``assemble_landing_spec`` and the
+# mapping comes out of ``_DEFAULT_EVENT_MAPPING``. A test that restated either side
+# would be testing the restatement.
+#
+# What is pinned here:
+#   * the contract — every input the assembler emits is reachable by the seeded
+#     mapping, so a form field can never again be generated with nowhere to land;
+#   * the end-to-end reproduction — a submission whose keys are the GENERATED input
+#     names, run through the real capture pipeline with the real seeded mapping,
+#     arrives with the visitor's values intact;
+#   * the already-published fleet — sites deployed before the fix still POST the old
+#     field names, and their leads must land too (nobody republishes to get a name).
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import pytest
+from pocketpaw_ee.cloud.leads import service as leads_service
+from pocketpaw_ee.cloud.models.site import Site
+from pocketpaw_ee.sites.landing_assembler import assemble_landing_spec
+from pocketpaw_ee.sites.service import _DEFAULT_EVENT_MAPPING, _DEFAULT_FORM_TYPE
+
+# A published Site's ``script_name`` is the deploy script name — a 24-char hex
+# ObjectId. Same convention as tests/cloud/leads/test_service.py.
+SITE_ID = "6d4a1f2b3c8e9a0f1b2c3d4e"
+
+# The copy a create-landing-site call hands the assembler. Deliberately minimal:
+# the form is fixed structure, not copy, so it is emitted whatever the content says.
+CONTENT: dict[str, Any] = {
+    "brand": "Bright Smile Dental",
+    "hero": {"title": "Dentistry that doesn't hurt"},
+}
+
+_PLACEHOLDER = re.compile(r"\{\{\s*payload\.([a-zA-Z0-9_]+)\s*\}\}")
+
+
+def _generated_field_names(spec: dict[str, Any]) -> list[str]:
+    """Every ``name`` the assembled spec puts on a submitting input.
+
+    Walks the real node tree rather than reaching into ``_lead_form_card``, so the
+    test still sees the truth if the form moves or grows a field."""
+    found: list[str] = []
+
+    def walk(node: Any) -> None:
+        if isinstance(node, dict):
+            if node.get("type") in {"input", "textarea", "select"}:
+                field = (node.get("props") or {}).get("name")
+                if field:
+                    found.append(str(field))
+            for child in node.get("children") or []:
+                walk(child)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item)
+
+    walk(spec.get("ui"))
+    return found
+
+
+def _mapped_payload_keys() -> set[str]:
+    """The ``payload.X`` keys the seeded default mapping actually reads."""
+    fields = _DEFAULT_EVENT_MAPPING[_DEFAULT_FORM_TYPE]["fields"]
+    return {m.group(1) for template in fields.values() for m in _PLACEHOLDER.finditer(template)}
+
+
+async def _seeded_site(**over: Any) -> Site:
+    """A Site carrying the REAL seeded mapping — the doc publish() actually writes."""
+    site = Site(
+        workspace="ws1",
+        pocket_id="pk1",
+        owner="u1",
+        name="Bright Smile Dental",
+        script_name=SITE_ID,
+        allowed_origins=["brightsmiledental.com"],
+        signed_key="pp_tok_x",
+        event_mapping=_DEFAULT_EVENT_MAPPING,
+        **over,
+    )
+    await site.insert()
+    return site
+
+
+# --------------------------------------------------------------------------- #
+# THE CONTRACT
+# --------------------------------------------------------------------------- #
+
+
+def test_every_generated_form_field_can_reach_the_seeded_mapping():
+    """THE BUG, at the seam. The assembler and the mapping are edited in different
+    files by different tasks, and nothing has ever compared them.
+
+    Mutation: rename any input in ``_lead_form_card`` without touching
+    ``_DEFAULT_EVENT_MAPPING`` and this fails — which is exactly what happened."""
+    generated = _generated_field_names(assemble_landing_spec(CONTENT))
+    assert generated, "the assembler emitted no named inputs at all"
+
+    unreachable = [f for f in generated if f not in _mapped_payload_keys()]
+    assert not unreachable, (
+        f"the generated form POSTs {unreachable} and the seeded mapping reads "
+        f"{sorted(_mapped_payload_keys())} — those submissions are silently discarded"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_submission_from_the_generated_form_keeps_the_visitors_values(beanie_test_db):
+    """THE BUG, end to end. The payload keys here are not chosen — they are read off
+    the assembled spec, so this is the exact body the visitor's browser sends.
+
+    Before the fix the stored properties came back with ``full_name`` empty and the
+    typed name nowhere in the document."""
+    site = await _seeded_site()
+    typed = {
+        "name": "Sam Rivera",
+        "full_name": "Sam Rivera",
+        "email": "sam@example.com",
+        "phone": "555-0134",
+        "message": "Do you take walk-ins on Saturday?",
+    }
+    # Submit ONLY the fields the real form actually renders.
+    payload = {f: typed[f] for f in _generated_field_names(assemble_landing_spec(CONTENT))}
+
+    lead = await leads_service.capture(
+        site=site,
+        form_type=_DEFAULT_FORM_TYPE,
+        payload=payload,
+        submitter_ref="anon",
+        rate_key="ip_hash_1",
+    )
+
+    assert lead is not None, "a well-formed contact submission was dropped"
+    # The visitor's name is the field an owner needs most; it must survive.
+    assert "Sam Rivera" in lead.properties.values(), (
+        f"the submitted name never reached storage — properties={lead.properties}"
+    )
+    assert lead.properties.get("email") == "sam@example.com"
+    assert lead.properties.get("message") == "Do you take walk-ins on Saturday?"
+
+
+@pytest.mark.asyncio
+async def test_a_site_published_before_the_fix_still_lands_its_leads(beanie_test_db):
+    """The fleet is already deployed. Those Workers POST ``name=...`` and will keep
+    doing so until someone republishes them — which nobody will, because the site
+    looks fine. Whatever the fix is, it has to reach back to them, so the old field
+    name must still resolve."""
+    site = await _seeded_site()
+
+    lead = await leads_service.capture(
+        site=site,
+        form_type=_DEFAULT_FORM_TYPE,
+        payload={"name": "Dana Okoye", "email": "dana@example.com"},
+        submitter_ref="anon",
+        rate_key="ip_hash_2",
+    )
+
+    assert lead is not None
+    assert "Dana Okoye" in lead.properties.values(), (
+        f"a live site's lead still loses its name — properties={lead.properties}"
+    )

--- a/tests/ee/sites/test_landing_assembler.py
+++ b/tests/ee/sites/test_landing_assembler.py
@@ -192,12 +192,29 @@ class TestAssembleLandingSpec:
             )
 
         # Inputs must carry real ``name``s so the native form POST maps fields.
+        #
+        # Updated 2026-08-13: these names come from
+        # ``sites_capture.contact_form.CONTACT_FIELDS`` instead of being spelled out
+        # here. The literals this used to assert — ``{"name", "email"}`` — were
+        # copied from the assembler, so the test agreed with the code and both
+        # disagreed with the event mapping that reads the submission. It passed for
+        # the entire life of the bug where the visitor's name was projected away.
+        # A test that restates the thing it is checking cannot catch a drift; the
+        # cross-module contract is pinned in tests/ee/sites/test_contact_form_contract.py.
+        from pocketpaw.sites_capture import contact_form
+
+        expected_inputs = {f.name for f in contact_form.CONTACT_FIELDS if not f.multiline}
+        expected_textareas = {f.name for f in contact_form.CONTACT_FIELDS if f.multiline}
+
         input_names = {(n.get("props") or {}).get("name") for n in _nodes_of_type(spec, "input")}
-        assert {"name", "email"} <= input_names, f"lead inputs need name+email; got {input_names}"
+        assert expected_inputs <= input_names, (
+            f"lead inputs must POST the canonical names "
+            f"{sorted(expected_inputs)}; got {input_names}"
+        )
         textarea_names = {
             (n.get("props") or {}).get("name") for n in _nodes_of_type(spec, "textarea")
         }
-        assert "message" in textarea_names
+        assert expected_textareas <= textarea_names
 
     def test_pricing_uses_tiers_not_plans(self) -> None:
         from pocketpaw_ee.sites.landing_assembler import assemble_landing_spec

--- a/tests/mutations/contact_form_schema.json
+++ b/tests/mutations/contact_form_schema.json
@@ -1,0 +1,104 @@
+[
+  {
+    "label": "contact form: the assembler's field names drift from the mapping again (the original bug)",
+    "file": "src/pocketpaw/sites_capture/contact_form.py",
+    "find": "        name=\"full_name\",\n        label=\"Your name\",",
+    "replace": "        name=\"contact_full_name\",\n        label=\"Your name\",",
+    "tests": [
+      "tests/ee/sites/test_contact_form_contract.py"
+    ]
+  },
+  {
+    "label": "contact form: the generated form stops deriving its POST names from the schema",
+    "file": "ee/pocketpaw_ee/sites/landing_assembler.py",
+    "find": "            \"name\": spec.name,",
+    "replace": "            \"name\": spec.name.replace(\"full_name\", \"name\"),",
+    "tests": [
+      "tests/ee/sites/test_contact_form_contract.py"
+    ]
+  },
+  {
+    "label": "contact form: the seeded mapping goes back to being restated by hand",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "_DEFAULT_EVENT_MAPPING: dict[str, Any] = default_event_mapping()",
+    "replace": "_DEFAULT_EVENT_MAPPING: dict[str, Any] = {\n    _DEFAULT_FORM_TYPE: {\n        \"creates\": \"Lead\",\n        \"fields\": {\"full_name\": \"{{ payload.full_name }}\"},\n    }\n}",
+    "tests": [
+      "tests/ee/sites/test_contact_form_contract.py"
+    ]
+  },
+  {
+    "label": "contact form: alias normalization is dropped, so the deployed fleet goes dark",
+    "file": "ee/pocketpaw_ee/cloud/leads/service.py",
+    "find": "        payload = contact_form.normalize(payload)",
+    "replace": "        payload = dict(payload)",
+    "tests": [
+      "tests/ee/sites/test_contact_form_contract.py",
+      "tests/cloud/leads/test_service.py"
+    ]
+  },
+  {
+    "label": "contact form: an empty canonical key shadows the alias that has the value",
+    "file": "src/pocketpaw/sites_capture/contact_form.py",
+    "find": "        if str(out.get(canonical) or \"\").strip():\n            continue  # the canonical spelling already carries a real value",
+    "replace": "        if canonical in out:\n            continue",
+    "tests": [
+      "tests/sites_capture/test_contact_form.py"
+    ]
+  },
+  {
+    "label": "contact form: normalization starts dropping unrecognized keys (disables the honeypot)",
+    "file": "src/pocketpaw/sites_capture/contact_form.py",
+    "find": "    out = dict(payload)",
+    "replace": "    out: dict[str, object] = {}",
+    "tests": [
+      "tests/sites_capture/test_contact_form.py"
+    ]
+  },
+  {
+    "label": "contact form: validation stops rejecting a submission nobody can reply to",
+    "file": "src/pocketpaw/sites_capture/contact_form.py",
+    "find": "    if not reachable:\n        return \"no_reply_channel\"",
+    "replace": "    if False:\n        return \"no_reply_channel\"",
+    "tests": [
+      "tests/sites_capture/test_contact_form.py",
+      "tests/cloud/leads/test_service.py"
+    ]
+  },
+  {
+    "label": "contact form: the per-field length cap is removed",
+    "file": "src/pocketpaw/sites_capture/contact_form.py",
+    "find": "        if len(str(payload.get(spec.name) or \"\")) > spec.max_length:\n            return \"too_long\"",
+    "replace": "        if False:\n            return \"too_long\"",
+    "tests": [
+      "tests/sites_capture/test_contact_form.py"
+    ]
+  },
+  {
+    "label": "contact form: an unrecognized imported form is silently dropped instead of captured",
+    "file": "src/pocketpaw/sites_capture/contact_form.py",
+    "find": "    if not recognized(payload):\n        return None",
+    "replace": "    if not recognized(payload):\n        return \"no_reply_channel\"",
+    "tests": [
+      "tests/sites_capture/test_contact_form.py",
+      "tests/cloud/leads/test_service.py"
+    ]
+  },
+  {
+    "label": "contact form: a typo'd email with a good phone starts being rejected",
+    "file": "src/pocketpaw/sites_capture/contact_form.py",
+    "find": "    reachable = looks_like_email(payload.get(EMAIL)) or looks_like_phone(payload.get(PHONE))",
+    "replace": "    reachable = looks_like_email(payload.get(EMAIL))",
+    "tests": [
+      "tests/sites_capture/test_contact_form.py"
+    ]
+  },
+  {
+    "label": "contact form: validation leaks onto form types that never declared this schema",
+    "file": "ee/pocketpaw_ee/cloud/leads/service.py",
+    "find": "    if form_type == contact_form.CONTACT_FORM_TYPE:",
+    "replace": "    if True:",
+    "tests": [
+      "tests/cloud/leads/test_service.py"
+    ]
+  }
+]

--- a/tests/sites_capture/test_contact_form.py
+++ b/tests/sites_capture/test_contact_form.py
@@ -1,0 +1,190 @@
+# tests/sites_capture/test_contact_form.py — the canonical contact-form schema:
+# alias resolution for the field names that actually arrive, and a validation
+# rule tuned so it can never be the reason a real customer is lost.
+#
+# Created 2026-08-13 alongside src/pocketpaw/sites_capture/contact_form.py.
+#
+# The schema exists because the form and the mapping that reads it were declared
+# in two packages and drifted (see tests/ee/sites/test_contact_form_contract.py
+# for that reproduction). These tests cover the module's own two jobs:
+#
+#   * NORMALIZE — the deployed fleet POSTs ``name=``, imported forms POST
+#     whatever their original author typed, and both have to reach the canonical
+#     key. Non-destructive, and a real canonical value always beats an alias.
+#   * VALIDATE — strict about SHAPE (per-field caps, is there any way to reply)
+#     and deliberately lenient about everything else. The asymmetry is the point:
+#     a dropped lead is the worst outcome this subsystem has, so every judgment
+#     call here errs toward keeping the submission.
+#
+# The leniencies are pinned as hard as the rejections, because they are the part
+# a later "let's tighten validation" pass would quietly undo.
+from __future__ import annotations
+
+import pytest
+
+from pocketpaw.sites_capture import contact_form as cf
+
+# --------------------------------------------------------------------------- #
+# Normalization — the names that actually arrive
+# --------------------------------------------------------------------------- #
+
+
+def test_the_deployed_fleets_field_name_resolves_to_the_canonical_one():
+    """``name`` is what every site published before this module POSTs, and those
+    Workers keep POSTing it until someone republishes them — which nobody does,
+    because the site looks fine. If this alias breaks, the fleet goes dark."""
+    out = cf.normalize({"name": "Sam Rivera"})
+    assert out[cf.FULL_NAME] == "Sam Rivera"
+
+
+@pytest.mark.parametrize(
+    ("submitted", "expected"),
+    [
+        ("Your Name", cf.FULL_NAME),
+        ("your-name", cf.FULL_NAME),
+        ("your_name", cf.FULL_NAME),
+        ("FULLNAME", cf.FULL_NAME),
+        ("e-mail", cf.EMAIL),
+        ("Email Address", cf.EMAIL),
+        ("work_email", cf.EMAIL),
+        ("Phone Number", cf.PHONE),
+        ("tel", cf.PHONE),
+        ("mobile", cf.PHONE),
+        ("Comments", cf.MESSAGE),
+        ("your-message", cf.MESSAGE),
+    ],
+)
+def test_imported_forms_spelling_conventions_all_collapse_to_one_key(submitted, expected):
+    """Imported pages were built by whoever built them. Matching these exactly
+    would mean enumerating the cross product of casing, spaces, hyphens and
+    underscores, so the matcher strips to letters and digits instead."""
+    assert cf.normalize({submitted: "value"})[expected] == "value"
+
+
+def test_normalization_keeps_every_original_key():
+    """NON-DESTRUCTIVE by contract. The honeypot check reads a field that is not in
+    this schema at all, and it runs on the same dict — so dropping unknown keys
+    here would disable spam protection from a long way away."""
+    out = cf.normalize({"name": "Sam", "company_website": "spam", "budget": "10k"})
+    assert out["company_website"] == "spam"
+    assert out["budget"] == "10k"
+
+
+def test_a_real_canonical_value_beats_an_alias():
+    """A form can send both. Which one wins must not depend on dict ordering."""
+    out = cf.normalize({"full_name": "Canonical", "name": "Alias"})
+    assert out[cf.FULL_NAME] == "Canonical"
+
+
+def test_an_empty_canonical_value_yields_to_a_filled_alias():
+    """The generated form renders every field, so unfilled ones POST as empty
+    strings. An empty canonical key must not shadow an alias that has the value —
+    that would reintroduce the original bug for any form sending both."""
+    out = cf.normalize({"full_name": "", "name": "Sam"})
+    assert out[cf.FULL_NAME] == "Sam"
+
+
+# --------------------------------------------------------------------------- #
+# Validation — rejections
+# --------------------------------------------------------------------------- #
+
+
+def test_a_contactable_submission_passes():
+    assert cf.validate({cf.FULL_NAME: "Sam", cf.EMAIL: "sam@example.com"}) is None
+
+
+def test_a_submission_nobody_can_reply_to_is_rejected():
+    """No email, no phone. The business cannot answer it, so it is not a lead —
+    and letting it ring the bell trains the owner to ignore the bell."""
+    assert cf.validate({cf.FULL_NAME: "Sam", cf.MESSAGE: "call me"}) == "no_reply_channel"
+
+
+def test_an_oversized_field_is_rejected():
+    """Per-field caps are what make the 8KB payload cap mean anything — without
+    them a single field can carry the entire budget."""
+    assert cf.validate({cf.EMAIL: "a@b.co", cf.MESSAGE: "x" * 5001}) == "too_long"
+
+
+def test_the_cap_is_per_field_not_shared():
+    """A long message must not make a normal name look oversized."""
+    assert cf.validate({cf.EMAIL: "a@b.co", cf.FULL_NAME: "Sam", cf.MESSAGE: "x" * 4999}) is None
+
+
+# --------------------------------------------------------------------------- #
+# Validation — the leniencies, pinned so a later tightening pass has to argue
+# --------------------------------------------------------------------------- #
+
+
+def test_a_typod_email_with_a_good_phone_is_kept():
+    """THE ASYMMETRY. This person is reachable and wants to be contacted; the only
+    thing wrong is a typo. Rejecting them costs a customer to enforce tidiness."""
+    assert cf.validate({cf.FULL_NAME: "Sam", cf.EMAIL: "sam@@", cf.PHONE: "555-0134"}) is None
+
+
+def test_an_unrecognized_form_is_kept_rather_than_silently_dropped():
+    """An imported form whose field names are outside the alias table is OUR
+    configuration gap, not a bad submission.
+
+    Dropping it makes a broken capture look like an absence of visitors — the
+    owner sees silence and concludes nobody fills the form. Storing an empty lead
+    is ugly, but it is an honest signal that submissions ARE arriving and
+    something needs fixing. Silence is the worse failure, so this must not become
+    a rejection."""
+    assert cf.validate({"how_did_you_hear": "a friend", "budget_range": "10-20k"}) is None
+
+
+def test_a_phone_only_submission_is_kept():
+    """Plenty of real contact forms ask for a phone and nothing else."""
+    assert cf.validate({cf.FULL_NAME: "Sam", cf.PHONE: "(555) 010-1234"}) is None
+
+
+def test_a_nameless_but_contactable_submission_is_kept():
+    """``full_name`` is marked required in the GENERATED markup — that is a browser
+    hint on our own form, not a server-side rule. An imported form may not ask for
+    a name at all, and a reachable person is a lead regardless."""
+    assert cf.validate({cf.EMAIL: "sam@example.com"}) is None
+
+
+# --------------------------------------------------------------------------- #
+# The reply-channel predicates
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("value", ["sam@example.com", "a.b+tag@sub.example.co.uk"])
+def test_real_addresses_read_as_email(value):
+    assert cf.looks_like_email(value)
+
+
+@pytest.mark.parametrize("value", ["", "sam", "sam@", "@example.com", "sam@example", "a b@c.com"])
+def test_non_addresses_do_not(value):
+    assert not cf.looks_like_email(value)
+
+
+@pytest.mark.parametrize("value", ["5550134", "(555) 010-1234", "+1 555 010 1234", "555-0134 x22"])
+def test_real_numbers_read_as_phone(value):
+    """Formatting is whatever the visitor typed — only the digit count matters."""
+    assert cf.looks_like_phone(value)
+
+
+@pytest.mark.parametrize("value", ["", "555", "call me", "n/a"])
+def test_too_few_digits_does_not(value):
+    """Seven digits is the shortest real subscriber number."""
+    assert not cf.looks_like_phone(value)
+
+
+# --------------------------------------------------------------------------- #
+# The derived mapping
+# --------------------------------------------------------------------------- #
+
+
+def test_the_seeded_mapping_reads_exactly_the_fields_the_schema_declares():
+    """The mapping is DERIVED, not restated — that is the whole point of the
+    module. If a field is added to CONTACT_FIELDS, the seed must grow with it
+    without anyone remembering to edit a second list."""
+    mapping = cf.default_event_mapping()[cf.CONTACT_FORM_TYPE]
+    fields = mapping["fields"]
+    assert isinstance(fields, dict)
+    assert mapping["creates"] == cf.CONTACT_CREATES
+    assert set(fields) == set(cf.CONTACT_FIELD_NAMES)
+    for name, template in fields.items():
+        assert template == f"{{{{ payload.{name} }}}}"


### PR DESCRIPTION
## The bug

`landing_assembler` generates the lead form's first input as `name="name"`. The event mapping every Site doc is seeded with reads `{{ payload.full_name }}`. Nothing aliased them.

So on every site built through the deterministic landing path: the visitor types their name, the browser POSTs `name=...`, the interpolator looks up `payload.full_name`, finds nothing, and stores `full_name: None`. The owner gets the notification, opens the Leads view, and the field they most need is empty.

The typed value isn't recoverable from the stored lead either — `interpolate_mapping` projects only the mapping's own keys, so `name` never reached storage at all.

## Why nothing caught it

Both existing tests hand-built both sides. `test_landing_assembler` asserted `{"name", "email"} <= input_names` — literals copied from the assembler. `tests/cloud/leads/test_service.py` fixes its own mapping and submits a payload matched to that fixture. Each agreed with itself, and neither ever compared the two files. Both passed for the whole life of the bug.

The new contract test reads the field names off `assemble_landing_spec` and the mapping off `_DEFAULT_EVENT_MAPPING` and compares those. It restates neither.

## The fix

One declaration — `src/pocketpaw/sites_capture/contact_form.py` — that the generated form and the seeded mapping both derive from. A field rename is now one edit in one tuple.

It also adds the schema checking capture never had. `event_mapping` is a projection template, not a schema: no required fields, no formats, no per-field sizes. For the contact form type only:

- **Aliases resolve before mapping.** This is what makes the fix reach the already-published fleet — those Workers still POST `name=` and will until someone republishes, which nobody does because the site looks fine. It also lets imported forms (`your-email`, `Phone Number`, `Comments`) reach the canonical key.
- **Per-field length caps.** Without them one field can carry the entire 8KB payload budget.
- **A submission with no usable email and no usable phone is dropped.** The business can't answer it.

## Where it deliberately stays lenient

A lost lead is the worst failure this subsystem has — it's already why the injection screen drops at HIGH rather than MEDIUM. So:

- A typo'd email with a good phone is **kept**. That's a reachable customer.
- A form whose field names we don't recognize is **kept**, not dropped. That's almost always an imported form outside the alias table — our configuration gap, not a bad submission. Dropping it makes a broken capture look identical to having no visitors; the owner sees silence and concludes nobody fills the form. An empty lead is ugly but honest.

Both leniencies are pinned by tests, because they're what a later "tighten validation" pass would quietly undo.

## Blast radius

Normalization and validation run only when `form_type` is the contact type. Sites with a custom mapping keep their own field names and get no validation — pinned by a test.

## Verification

```
109 passed   tests/sites_capture tests/cloud/leads test_landing_assembler test_contact_form_contract
all 11 mutations caught   tests/mutations/contact_form_schema.json
```

The three tests in `test_contact_form_contract.py` were written first and observed failing:

```
the generated form POSTs ['name'] and the seeded mapping reads
['email', 'full_name', 'message', 'phone'] — those submissions are silently discarded

the submitted name never reached storage —
properties={'full_name': None, 'phone': '555-0134', 'email': 'sam@example.com', ...}
```

## Still open

Two related gaps found while tracing this, both out of scope here:

1. **react and raw-HTML sites capture nothing.** `rewireForms` runs only on the import path, and those tracks have no `/api/submit` route, so the agent-authored `<form>` has no action and submitting reloads the page. Needs a prompt block plus token substitution in the generator.
2. **The per-IP rate limit measures the wrong machine.** The ripple track forwards server-side from the Worker, so `_rate_key` hashes the Cloudflare egress IP, not the visitor's. Per-visitor isolation doesn't exist, and `per_ip_limit_per_min = 10` collapses into a 10-leads/minute ceiling for the whole site.
