### PR TITLE
React and html sites had a contact form that posted nowhere

### DIFF
--- a/ee/pocketpaw_ee/cloud/surface/handlers/sites.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/sites.py
@@ -579,7 +579,8 @@ def _create_preamble(meta: SurfaceMeta) -> str:
             "this track — do not draft a rippleSpec or call the pocket "
             "specialist. If the skill is unavailable, author the source map "
             "yourself and call `mcp__pocketpaw_sites_manager__create_svelte_site` "
-            "(then STOP at the draft — publish only on explicit request)."
+            "(then STOP at the draft — publish only on explicit request).\n"
+            + native_form_contract()
         )
     elif engine == "react":
         engine_note = (

--- a/ee/pocketpaw_ee/cloud/surface/handlers/sites.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/sites.py
@@ -234,6 +234,7 @@ import functools
 import logging
 from typing import Any
 
+from pocketpaw.sites_capture import contact_form
 from pocketpaw_ee.cloud.surface.domain import SurfaceMeta, SurfacePreamble
 from pocketpaw_ee.cloud.surface.handlers._helpers import content_key, meta_key
 from pocketpaw_ee.sites.react_paths import (
@@ -617,7 +618,8 @@ def _create_preamble(meta: SurfaceMeta) -> str:
             "rippleSpec or call the pocket specialist, and there is no "
             "`/api/submit` route (no server runtime), so a lead form is a native "
             "`<form>` with flat named fields.\n"
-            "CHANGES GO THROUGH THE EDIT TOOL. Once the site exists, ANY further "
+            + native_form_contract()
+            + "CHANGES GO THROUGH THE EDIT TOOL. Once the site exists, ANY further "
             "change the user asks for in this conversation — 'shorten the hero "
             "headline', 'darker pricing cards', 'add a testimonials section' — is "
             "`mcp__pocketpaw_sites_manager__edit_react_component` with the SAME "
@@ -638,8 +640,7 @@ def _create_preamble(meta: SurfaceMeta) -> str:
             'and stamps the source pocket `type="site"` + `pattern="landing"`. '
             "THEME the page with the chosen design system's tokens + your asset "
             "URLs. The lead-capture form must be FLAT native "
-            '`input`/`textarea`/`button{type:"submit"}` widgets with real field '
-            "names (name, email, phone, message) — NEVER the `form` or "
+            '`input`/`textarea`/`button{type:"submit"}` widgets — NEVER the `form` or '
             "`newsletter` widget, which nests an invalid `<form>` on a static "
             "site and captures zero leads. If the skill is unavailable, fall back "
             "to `mcp__pocketpaw_pocket_specialist__create` (build the "
@@ -669,11 +670,12 @@ def _create_preamble(meta: SurfaceMeta) -> str:
             "explicit request per the DRAFT-FIRST step. There is NO rippleSpec and NO widget "
             "catalog on this track — do not draft a rippleSpec or call the pocket "
             "specialist; the HTML files ARE the page. The lead-capture form must "
-            "be a real `<form>` with FLAT named `input`/`textarea` fields (name, "
-            'email, phone, message) and a `button type="submit"`. `index.html` '
+            "be a real `<form>` with FLAT named `input`/`textarea` fields and a "
+            '`button type="submit"`. `index.html` '
             "MUST contain the full resting state in markup (never rendered only "
             "by JS), since the visitor is served static HTML.\n"
-            "DO NOT switch engines. You MUST use "
+            + native_form_contract()
+            + "DO NOT switch engines. You MUST use "
             "`mcp__pocketpaw_sites_manager__create_html_site` — do NOT call "
             "`create_svelte_site`, `create_landing_site`, or the "
             "`pocketpaw-create-svelte-site` / `pocketpaw-create-paw-site` skills, "
@@ -835,7 +837,59 @@ _REFINE_SHARED_RULES = (
     "The lead form stays a FLAT native `<form>` — real `name=` on every "
     '`input`/`textarea` and a `button type="submit"`. Never nest a form inside a '
     "form, and never replace it with a widget that does.\n"
+    # A refine rewrites whole sections, and the form's plumbing does not look like
+    # copy — the action and the three hidden inputs are the first thing a rewrite
+    # drops as noise. Losing them costs every subsequent lead on the site, silently
+    # and with no visible change to the page, so the rule has to be stated where
+    # refines read it and not only where creates do.
+    "PRESERVE the form's PLUMBING exactly as it is: the `action`, the `method`, "
+    "and every hidden `paw_*` input (including any `__TOKEN__` placeholder value — "
+    "those are resolved at publish and are NOT stale placeholders to clean up). "
+    "They are what deliver the lead; a form that keeps its fields but loses its "
+    "action still looks right and captures nothing.\n"
 )
+
+
+def native_form_contract() -> str:
+    """Where a lead form posts on the tracks that have NO server route.
+
+    react and raw-html sites have no ``/api/submit`` (nothing runs server-side), and
+    the generator's ``rewireForms`` fires only on the IMPORT path. The prompt used to
+    stop at "a lead form is a native ``<form>`` with flat named fields" — correct as
+    far as it went, and it never said where the form posts. A ``<form>`` with no
+    action posts to itself, so the visitor pressed Send, the page reloaded, and the
+    lead was gone. No error, no log, a site that looks perfect.
+
+    The agent has neither the site id nor the signed key while authoring (on a create
+    the site does not exist yet, and the key is minted at publish), so it writes
+    PLACEHOLDERS. ``build_generator_input`` resolves them on the way to the generator,
+    for public deploys only. Same three tokens the svelte templates already use.
+
+    Field names render from ``contact_form.CONTACT_FIELDS``, never spelled out here.
+    A prompt is one more hand-written field list, and a hand-written field list
+    drifting from the mapping that reads it is the exact bug the schema was created
+    to end — writing them out again would reintroduce it one layer up.
+    """
+    fields = ", ".join(f"`{name}`" for name in contact_form.CONTACT_FIELD_NAMES)
+    return (
+        "LEAD FORM — WHERE IT POSTS. This track has no server route, so a `<form>` "
+        "with no `action` submits to the page itself and the lead is LOST SILENTLY. "
+        "Every contact form you write MUST carry, verbatim:\n"
+        '  `<form method="POST" action="__CAPTURE_API_BASE__/capture/form">`\n'
+        "and these three hidden inputs inside it:\n"
+        '  `<input type="hidden" name="paw_site_id" value="__SITE_ID__">`\n'
+        '  `<input type="hidden" name="paw_key" value="__CAPTURE_SIGNED_KEY__">`\n'
+        '  `<input type="hidden" name="paw_redirect" value="/thank-you">`\n'
+        "The three `__TOKENS__` are placeholders — write them EXACTLY as shown and "
+        "never invent a value for them; publish substitutes the real site id, "
+        "capture URL and signed key. `paw_redirect` MUST be a relative path on this "
+        "site (an absolute URL is rejected with a 400), so author the page it names — "
+        "a small `/thank-you` route or `thank-you.html` confirming the message was "
+        "sent. Name the visible inputs " + fields + " — those are the names the lead "
+        "pipeline maps, and a field named anything else is stored empty. Mark the "
+        "name and email inputs `required`. No JavaScript: this is a plain native "
+        "browser POST, so never attach an onSubmit handler or a fetch call.\n"
+    )
 
 
 def _react_write_scope() -> str:

--- a/ee/pocketpaw_ee/sites/generator_client.py
+++ b/ee/pocketpaw_ee/sites/generator_client.py
@@ -899,6 +899,41 @@ def _rewrite_ripple_dep(project_dir: str, source: str) -> None:
         pkg_path.write_text(json.dumps(pkg, indent=2))
 
 
+def _resolve_capture_tokens(
+    source: dict[str, Any],
+    *,
+    site_id: str,
+    capture_api_base: str,
+    capture_signed_key: str,
+) -> dict[str, Any]:
+    """Replace the capture placeholders in every text entry of a source map.
+
+    The same three tokens ``scaffoldProject`` substitutes into the svelte templates,
+    so a site author (human or agent) writes one convention on every engine. Returns
+    a NEW map — the caller's dict is the stored pocket source and must not be mutated.
+
+    Only ``str`` values are touched. A svelte source envelope carries live-data
+    binding keys alongside its files (see ``_split_svelte_source``), and those are
+    dicts/lists that must ride through untouched.
+
+    Idempotent, and a no-op on source with no tokens — which is every ripple and
+    almost every svelte site, so this cannot change their emitted bytes."""
+    resolved = {
+        "__CAPTURE_API_BASE__": capture_api_base,
+        "__SITE_ID__": site_id,
+        "__CAPTURE_SIGNED_KEY__": capture_signed_key,
+    }
+    out: dict[str, Any] = {}
+    for path, contents in source.items():
+        if not isinstance(contents, str):
+            out[path] = contents
+            continue
+        for token, value in resolved.items():
+            contents = contents.replace(token, value)
+        out[path] = contents
+    return out
+
+
 def build_generator_input(
     *,
     engine: str,
@@ -951,6 +986,45 @@ def build_generator_input(
     # False so a plain static site's payload is byte-identical to before.
     if keeps_client_bundle:
         site_config["keepsClientBundle"] = True
+    # 2026-08-13 — resolve the capture tokens in AUTHORED source, public deploys only.
+    #
+    # The react and html tracks have no server route: there is no ``/api/submit`` to
+    # forward a lead, and ``rewireForms`` runs only on the IMPORT path. So a
+    # hand-authored ``<form>`` on those tracks posted to nothing and every submission
+    # was lost on page reload. The authoring prompt now tells the agent to write the
+    # native-form contract with ``__CAPTURE_API_BASE__`` / ``__SITE_ID__`` /
+    # ``__CAPTURE_SIGNED_KEY__`` placeholders — the same token convention
+    # ``scaffoldProject`` already substitutes into the svelte templates — and this is
+    # where they become real values.
+    #
+    # It happens HERE, not in the generator, for one reason: the prompt that emits the
+    # tokens and the code that resolves them then ship in the same commit. Split across
+    # repos, a prompt live before its substitution puts a literal
+    # ``__CAPTURE_API_BASE__`` in the action of every react/html site published in
+    # between.
+    #
+    # GATED ON A PUBLIC DEPLOY (``not builder_origin``), and that gate is load-bearing
+    # rather than tidiness: the html edit lane records ``byteSpan`` offsets in its edit
+    # manifest, computed over the bytes the generator was handed. Substitution changes
+    # lengths (a real signed key is roughly twice its placeholder), so arming a build
+    # with substituted source and later splicing edits into the STORED placeholder
+    # source would land every edit after the form at the wrong offset and quietly
+    # corrupt the page. Armed builds therefore keep the placeholders — the form does
+    # not submit inside the builder preview, which is also the better behaviour (an
+    # edit session cannot mint live leads).
+    #
+    # The pocket keeps the placeholders either way: ``apply_leaf_edits`` has its own
+    # subprocess path and never sees a substituted map, so stored source is never
+    # rewritten with a real key. That is what keeps ``rotate_signed_key`` meaningful —
+    # the next publish substitutes the new key with nothing to migrate.
+    if source and not builder_origin:
+        source = _resolve_capture_tokens(
+            source,
+            site_id=site_id,
+            capture_api_base=capture_api_base,
+            capture_signed_key=capture_signed_key,
+        )
+
     input_json: dict[str, Any] = {
         "engine": engine,
         "theme": theme,

--- a/ee/pocketpaw_ee/sites/generator_client.py
+++ b/ee/pocketpaw_ee/sites/generator_client.py
@@ -899,6 +899,50 @@ def _rewrite_ripple_dep(project_dir: str, source: str) -> None:
         pkg_path.write_text(json.dumps(pkg, indent=2))
 
 
+# A `<form … action="/api/submit" …>` opening tag, in any attribute order and with
+# either quote style. ``[^>]*`` cannot cross the tag boundary, so this matches one
+# opening tag and never runs past it — the same shape paw-sites' ``rewireForms``
+# uses on arbitrary imported HTML, applied here to markup we generated ourselves.
+_LEGACY_SUBMIT_FORM = re.compile(
+    r"(<form\b[^>]*\baction=)([\"'])/api/submit\2([^>]*>)", re.IGNORECASE
+)
+
+# The hidden inputs a direct capture POST needs, in TOKEN form — ``_resolve_capture_tokens``
+# runs after this and turns them into real values, so there is exactly one place in this
+# module that knows the site id and the signed key.
+_CAPTURE_HIDDEN_FIELDS = (
+    '<input type="hidden" name="paw_site_id" value="__SITE_ID__">'
+    '<input type="hidden" name="paw_key" value="__CAPTURE_SIGNED_KEY__">'
+    '<input type="hidden" name="paw_redirect" value="/thank-you">'
+)
+
+
+def _rewire_legacy_submit_forms(contents: str) -> str:
+    """Repoint a form still aimed at the removed ``/api/submit`` route.
+
+    The svelte skill taught ``<form method="POST" action="/api/submit">`` for as long
+    as that route existed, so it is baked into the stored source of every svelte pocket
+    authored before this change. The route is gone — a STATIC svelte site never even
+    served it (``svelte-scaffold.ts`` deletes ``src/routes/api`` because adapter-static
+    cannot prerender a POST handler, which is why those sites have been losing every
+    lead), and deleting it for the dynamic sites too is what leaves one capture path
+    across all four engines instead of one per engine.
+
+    Rewriting rather than leaving them to break is the same call the alias table in
+    ``sites_capture.contact_form`` makes: the fleet is already published, nobody
+    republishes a site that looks fine, and a form that 404s looks exactly like a site
+    nobody is filling in.
+
+    Emits PLACEHOLDERS, never values — the caller resolves them immediately after.
+    Idempotent: the rewritten action is no longer ``/api/submit``, so a second pass
+    matches nothing, and source authored against the new contract is untouched."""
+    return _LEGACY_SUBMIT_FORM.sub(
+        lambda m: f'{m.group(1)}"__CAPTURE_API_BASE__/capture/form"{m.group(3)}'
+        + _CAPTURE_HIDDEN_FIELDS,
+        contents,
+    )
+
+
 def _resolve_capture_tokens(
     source: dict[str, Any],
     *,
@@ -916,8 +960,12 @@ def _resolve_capture_tokens(
     binding keys alongside its files (see ``_split_svelte_source``), and those are
     dicts/lists that must ride through untouched.
 
-    Idempotent, and a no-op on source with no tokens — which is every ripple and
-    almost every svelte site, so this cannot change their emitted bytes."""
+    Runs ``_rewire_legacy_submit_forms`` FIRST, so a form still pointing at the removed
+    ``/api/submit`` route is repointed into tokens and then resolved by the same pass —
+    one place that knows the real values, rather than two.
+
+    Idempotent, and a no-op on source with no tokens and no legacy form — which is every
+    ripple site, so this cannot change their emitted bytes."""
     resolved = {
         "__CAPTURE_API_BASE__": capture_api_base,
         "__SITE_ID__": site_id,
@@ -928,6 +976,7 @@ def _resolve_capture_tokens(
         if not isinstance(contents, str):
             out[path] = contents
             continue
+        contents = _rewire_legacy_submit_forms(contents)
         for token, value in resolved.items():
             contents = contents.replace(token, value)
         out[path] = contents

--- a/src/pocketpaw/bundled_skills/_bundled/skills/pocketpaw-create-paw-site/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/skills/pocketpaw-create-paw-site/SKILL.md
@@ -66,6 +66,43 @@ never "TBD"/"Lorem ipsum"). It returns `{ ok, pocket_id, pocket }`; hand
 `pocket_id` to `publish` exactly like the copy path (STEP 3). If `ok` is
 false, relay the error.
 
+### The lead form on this track
+
+There is no `/api/submit` here — an html site deploys as a static asset tree
+with no server route — so a `<form>` with no `action` posts to the page itself
+and the lead is lost with no error. Author the form exactly like this:
+
+```html
+<form method="POST" action="__CAPTURE_API_BASE__/capture/form">
+  <input type="hidden" name="paw_site_id" value="__SITE_ID__">
+  <input type="hidden" name="paw_key" value="__CAPTURE_SIGNED_KEY__">
+  <input type="hidden" name="paw_redirect" value="/thank-you.html">
+
+  <label>Your name<input name="full_name" required></label>
+  <label>Email<input type="email" name="email" required></label>
+  <label>Phone<input type="tel" name="phone"></label>
+  <label>How can we help?<textarea name="message"></textarea></label>
+
+  <button type="submit">Send</button>
+</form>
+```
+
+**Write the three `__TOKENS__` exactly as shown** — they are placeholders that
+publish substitutes with the real capture URL, site id and signed key. You have
+none of those values while authoring, so never invent one or leave `action`
+empty.
+
+**The visible field names are fixed**: `full_name`, `email`, `phone`, `message`.
+A field named anything else is stored empty, and the business never sees what
+the visitor typed.
+
+**`paw_redirect` must be a relative path on this site** (an absolute URL is
+rejected with a 400), so include the page it names — a small `thank-you.html`
+confirming the message was sent — as another entry in the `source` map.
+
+No JavaScript: this is a plain native browser POST, so never add an onSubmit
+handler or a `fetch`.
+
 **Do not reach for this by default.** Unless the user explicitly wants raw
 HTML, use the copy-only `create_landing_site` path below.
 

--- a/src/pocketpaw/bundled_skills/_bundled/skills/pocketpaw-create-react-site/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/skills/pocketpaw-create-react-site/SKILL.md
@@ -209,12 +209,38 @@ The React track deploys as a **purely static asset tree** — there is no server
 route, so the SvelteKit skeleton's `/api/submit` endpoint does not exist here.
 This matches the html track.
 
-Author the form as a real `<form>` with FLAT named fields
-(`name`, `email`, `phone`, `message`) and a `<button type="submit">`, and post
-it natively. Do **not** wire an `onSubmit` handler that fetches — a static page
-should capture the lead whether or not JavaScript ran. If you have no capture
-endpoint to target, prefer a `mailto:` form action or a plain `tel:` / `mailto:`
-CTA over a form that silently drops submissions, and say so in your summary.
+There **is** a capture endpoint, and it is the shared one. Post to it natively:
+
+```jsx
+<form method="POST" action="__CAPTURE_API_BASE__/capture/form">
+  <input type="hidden" name="paw_site_id" value="__SITE_ID__" />
+  <input type="hidden" name="paw_key" value="__CAPTURE_SIGNED_KEY__" />
+  <input type="hidden" name="paw_redirect" value="/thank-you" />
+
+  <label>Your name<input name="full_name" required /></label>
+  <label>Email<input type="email" name="email" required /></label>
+  <label>Phone<input type="tel" name="phone" /></label>
+  <label>How can we help?<textarea name="message" /></label>
+
+  <button type="submit">Send</button>
+</form>
+```
+
+**Write the three `__TOKENS__` exactly as shown.** They are placeholders —
+publish substitutes the real capture URL, site id and signed key. You do not
+have those values while authoring (on a create the site does not exist yet, and
+the key is minted at publish), so never invent one or leave the action empty.
+
+**The visible field names are fixed**: `full_name`, `email`, `phone`, `message`.
+They are the names the lead pipeline maps; a field named anything else is stored
+empty and the business never sees what the visitor typed.
+
+**`paw_redirect` must be a relative path on this site** — an absolute URL is
+rejected with a 400 — so author the page it points at (a small `thank-you`
+route or `thank-you.html` confirming the message was sent).
+
+Do **not** wire an `onSubmit` handler that fetches. A static page should capture
+the lead whether or not JavaScript ran, and this is a plain native browser POST.
 
 ### What the project has (and what it does not)
 

--- a/src/pocketpaw/bundled_skills/_bundled/skills/pocketpaw-create-svelte-site/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/skills/pocketpaw-create-svelte-site/SKILL.md
@@ -176,12 +176,56 @@ Conversion essentials the page should carry:
   is an **anchor** (`href="#book"` / `#pricing`) — not an `on:click`
   button (a dead button on a static page).
 - A **pricing** section with real tiers and a highlighted recommended tier.
-- A **lead form** so the published site captures leads out of the box. Use
-  plain `<input>` / `<textarea>` / `<button type="submit">` with real
-  `name`s, POSTing to the skeleton's `/api/submit` endpoint (e.g.
-  `<form method="POST" action="/api/submit">`). The skeleton provides
-  `api/submit` → Lead; it is track-agnostic and already wired.
+- A **lead form** so the published site captures leads out of the box — see
+  "Lead capture" below. It posts natively to the shared capture endpoint.
+  There is **no** `/api/submit` route on this track any more; see below for
+  why, and do not author one.
 - Every CTA is an anchor (`#book`, `tel:`, `mailto:`).
+
+### Lead capture (there is no `/api/submit` on this track)
+
+Earlier versions of this skill told you to POST to a generated `/api/submit`
+route. **That route no longer exists**, and on a static site it never really
+did: `adapter-static` cannot prerender a POST handler, so the scaffold deleted
+`src/routes/api` and every lead those sites collected went to a 404. The form
+now posts straight to the shared capture API, which is the same endpoint the
+html and react tracks use — one capture path for every engine.
+
+```svelte
+<form method="POST" action="__CAPTURE_API_BASE__/capture/form">
+  <input type="hidden" name="paw_site_id" value="__SITE_ID__" />
+  <input type="hidden" name="paw_key" value="__CAPTURE_SIGNED_KEY__" />
+  <input type="hidden" name="paw_redirect" value="/thank-you" />
+
+  <label>Your name<input name="full_name" required /></label>
+  <label>Email<input type="email" name="email" required /></label>
+  <label>Phone<input type="tel" name="phone" /></label>
+  <label>How can we help?<textarea name="message"></textarea></label>
+
+  <button type="submit">Send</button>
+</form>
+```
+
+**Write the three `__TOKENS__` exactly as shown.** They are placeholders that
+publish substitutes with the real capture URL, site id and signed key. You do
+not have those values while authoring, so never invent one or leave `action`
+empty.
+
+**The visible field names are fixed**: `full_name`, `email`, `phone`,
+`message`. A field named anything else is stored empty and the business never
+sees what the visitor typed.
+
+**`paw_redirect` must be a relative path on this site** — an absolute URL is
+rejected with a 400 — so add the route it names to your source map:
+
+```
+src/routes/thank-you/+page.svelte    a short confirmation: "Thanks — we got your request."
+src/routes/thank-you/+page.ts        export const prerender = true;
+```
+
+No `use:enhance`, no `on:submit`, no `fetch`. This is a plain native browser
+POST so the lead is captured whether or not JavaScript ran — which on a
+prerendered page is the whole point.
 
 ### Sourcing photography (real images, not placeholders)
 
@@ -217,9 +261,10 @@ strings. The generator writes these files onto the paw-sites skeleton and
 prerenders.
 
 **The skeleton provides** everything infrastructural — `package.json`,
-`svelte.config.js`, `vite.config`, the adapter, `app.html`, and the
-`api/submit` lead endpoint. **You provide only** the route + component +
-style files. **Required keys:**
+`svelte.config.js`, `vite.config`, the adapter, and `app.html`. It does
+**not** provide a lead endpoint: the form posts straight to the shared
+capture API (see "Lead capture"). **You provide only** the route +
+component + style files. **Required keys:**
 
 ```
 src/routes/+page.svelte      the composition root — imports + renders the sections in order
@@ -484,7 +529,9 @@ D1 + wires the read/write layer. Done.
    (imports `app.css`), `+page.ts` (prerender), `app.css`, and the
    `src/lib/components/*.svelte` sections — every import resolvable.
 4. **It converts + captures.** CTAs are anchors, there's a real priced
-   pricing section, and a flat lead form POSTing to `/api/submit`.
+   pricing section, and a flat lead form posting to
+   `__CAPTURE_API_BASE__/capture/form` with its three hidden `paw_*`
+   inputs and a `thank-you` route for `paw_redirect` to land on.
 5. **You stopped at the draft (or published only if asked).** By default the
    user got a pointer to the in-app Preview under /sites and an offer to
    publish — not an auto-publish. If they explicitly asked to go live, they got

--- a/tests/cloud/surface/test_sites_handler.py
+++ b/tests/cloud/surface/test_sites_handler.py
@@ -118,6 +118,8 @@ from pocketpaw_ee.sites_crew.models import (
     Section,
 )
 
+from pocketpaw.sites_capture import contact_form
+
 pytestmark = pytest.mark.asyncio
 
 WORKSPACE = "ws-surface-sites"
@@ -219,23 +221,50 @@ async def test_create_ripple_engine_uses_pocket_specialist_fallback() -> None:
     assert "fall back" in preamble.lower() or "fallback" in preamble.lower()
 
 
+async def _preamble_for(engine: str | None) -> str:
+    return (
+        await sites_handler.build_preamble(
+            WORKSPACE, USER, SurfaceMeta(route_path="/sites", engine=engine)
+        )
+    ).text
+
+
 async def test_sites_handler_specifies_flat_lead_capture_form() -> None:
-    """Every create carries the flat-native lead-form rule so the published
-    static site captures leads: named fields (email) built FLAT, never a nested
-    form widget. Checked on both the html default and the ripple track."""
-    for engine in (None, "ripple"):
-        preamble = (
-            await sites_handler.build_preamble(
-                WORKSPACE, USER, SurfaceMeta(route_path="/sites", engine=engine)
-            )
-        ).text
-        lower = preamble.lower()
-        # A lead-capture form is part of the marketing/landing build.
+    """Every create carries the flat-native lead-form rule so the published static
+    site captures leads: fields built FLAT, never a nested form widget."""
+    for engine in (None, "ripple", "react"):
+        lower = (await _preamble_for(engine)).lower()
         assert "form" in lower
-        # At least one concrete, named field so leads are actually captured.
-        assert "email" in lower
-        # The flat-native rule.
         assert "flat" in lower
+
+
+async def test_the_tracks_that_author_their_own_form_are_told_where_it_posts() -> None:
+    """html and react have no server route, so the form's ACTION is the whole
+    difference between a captured lead and a page reload that loses it. This used
+    to be missing entirely — the prompt said "a native `<form>` with flat named
+    fields" and never said where it posts.
+
+    Asserted per-track rather than over a merged blob: a rule that reaches only one
+    of the two authoring tracks is the same silent loss on the other."""
+    for engine in (None, "react"):  # None == the html default
+        preamble = await _preamble_for(engine)
+        assert "__CAPTURE_API_BASE__/capture/form" in preamble, f"{engine}: no capture action"
+        assert "__CAPTURE_SIGNED_KEY__" in preamble, f"{engine}: no signed key field"
+        for field in contact_form.CONTACT_FIELD_NAMES:
+            assert field in preamble, f"{engine}: never told to emit {field!r}"
+
+
+async def test_the_ripple_track_is_not_told_to_author_a_form() -> None:
+    """On ripple the form is COMPOSED BY CODE — ``assemble_landing_spec`` builds it
+    from ``contact_form.CONTACT_FIELDS`` and the skill supplies copy only. Handing
+    that track the native-form contract would tell the agent to write markup it has
+    no way to write, and naming the fields would imply it chooses them.
+
+    This is the "the prompt may not command something the agent cannot do" rule
+    applied to markup rather than to a tool."""
+    preamble = await _preamble_for("ripple")
+    assert "__CAPTURE_API_BASE__" not in preamble
+    assert "paw_site_id" not in preamble
 
 
 # --- Refine mode (meta carries a pocket_id — the per-site /sites/[siteId] chat) ---

--- a/tests/cloud/surface/test_sites_handler.py
+++ b/tests/cloud/surface/test_sites_handler.py
@@ -244,9 +244,14 @@ async def test_the_tracks_that_author_their_own_form_are_told_where_it_posts() -
     to be missing entirely — the prompt said "a native `<form>` with flat named
     fields" and never said where it posts.
 
+    svelte is in this list too, and it is the one that was quietly worst: the skill
+    taught `action="/api/submit"` while `svelte-scaffold.ts` DELETES `src/routes/api`
+    for a static site (adapter-static cannot prerender a POST handler), so those
+    forms 404'd and the owner read it as nobody filling the form in.
+
     Asserted per-track rather than over a merged blob: a rule that reaches only one
-    of the two authoring tracks is the same silent loss on the other."""
-    for engine in (None, "react"):  # None == the html default
+    of the three authoring tracks is the same silent loss on the others."""
+    for engine in (None, "react", "svelte"):  # None == the html default
         preamble = await _preamble_for(engine)
         assert "__CAPTURE_API_BASE__/capture/form" in preamble, f"{engine}: no capture action"
         assert "__CAPTURE_SIGNED_KEY__" in preamble, f"{engine}: no signed key field"

--- a/tests/ee/sites/test_static_form_capture.py
+++ b/tests/ee/sites/test_static_form_capture.py
@@ -1,0 +1,193 @@
+# tests/ee/sites/test_static_form_capture.py — a hand-authored contact form on a
+# track with no server route had nowhere to post, and the failure was silent.
+#
+# Created 2026-08-13. THE BUG THIS COVERS: the react and raw-html tracks have no
+# ``/api/submit`` endpoint (no server runtime), and ``rewireForms`` runs ONLY on
+# the import path — ``src/cli.ts`` says so in as many words: "the ONLY caller of
+# rewireForms in the deployed backend path". So on those two tracks the authoring
+# prompt asked for "a native ``<form>`` with flat named fields" and never said
+# where it posts. A ``<form>`` with no action posts to itself: the visitor fills
+# it in, presses send, the page reloads, and the lead is gone. Nothing errors,
+# nothing is logged, and the site looks completely fine.
+#
+# THE FIX has two halves that must ship together. The prompt tells the agent to
+# author the full native-form contract using the ``__CAPTURE_API_BASE__`` /
+# ``__SITE_ID__`` / ``__CAPTURE_SIGNED_KEY__`` placeholders (the same tokens
+# ``scaffoldProject`` already substitutes into the svelte templates), and
+# ``build_generator_input`` resolves them on the way to the generator. Splitting
+# those across repos would mean a window where the prompt is live and the
+# substitution is not, publishing literal ``__CAPTURE_API_BASE__`` into the action
+# of every react/html site — so they are one commit, and this file pins both ends.
+#
+# What is pinned here:
+#   * a public deploy resolves all three tokens, on both source-map tracks;
+#   * an ARMED (editable) build does NOT — see the byteSpan note on that test,
+#     which is the subtle one and the reason the gate exists at all;
+#   * the caller's map is never mutated, so the POCKET keeps placeholders and a
+#     rotated signed key is picked up by the next publish with nothing to migrate;
+#   * non-string entries survive (a dynamic svelte envelope carries binding keys
+#     alongside its files);
+#   * the prompt actually names the endpoint and the canonical field names, rather
+#     than the two drifting the way the assembler and the mapping did.
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.sites.generator_client import build_generator_input  # noqa: E402
+
+from pocketpaw.sites_capture import contact_form  # noqa: E402
+
+SITE_ID = "6d4a1f2b3c8e9a0f1b2c3d4e"
+CAPTURE_BASE = "https://api.pocketpaw.test/api/v1"
+SIGNED_KEY = "site_key_bTdSb2hpdEs4d2FoYQ"
+
+# The form an authoring agent is now told to write. Tokens, not values — the agent
+# has neither at authoring time (on a create the site does not exist yet and the
+# key is minted at publish).
+AUTHORED_FORM = (
+    '<form method="POST" action="__CAPTURE_API_BASE__/capture/form">'
+    '<input type="hidden" name="paw_site_id" value="__SITE_ID__">'
+    '<input type="hidden" name="paw_key" value="__CAPTURE_SIGNED_KEY__">'
+    '<input type="hidden" name="paw_redirect" value="/thank-you">'
+    '<input name="full_name" required><input type="email" name="email" required>'
+    '<button type="submit">Send</button></form>'
+)
+
+
+def _input(engine: str, source: dict, **over):
+    return build_generator_input(
+        engine=engine,
+        theme={},
+        site_id=SITE_ID,
+        title="Bright Smile Dental",
+        capture_api_base=CAPTURE_BASE,
+        capture_signed_key=SIGNED_KEY,
+        source=source,
+        **over,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# A public deploy resolves the tokens
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(("engine", "path"), [("html", "index.html"), ("react", "src/App.tsx")])
+def test_a_published_form_posts_to_a_real_address(engine, path):
+    """THE FIX. Before it, whatever the agent wrote in ``action`` was whatever the
+    agent guessed, and on these tracks that was nothing at all."""
+    out = _input(engine, {path: AUTHORED_FORM})
+    emitted = out["source"][path]
+
+    assert f'action="{CAPTURE_BASE}/capture/form"' in emitted
+    assert f'value="{SITE_ID}"' in emitted
+    assert f'value="{SIGNED_KEY}"' in emitted
+    # No token may survive into the deployed page.
+    for token in ("__CAPTURE_API_BASE__", "__SITE_ID__", "__CAPTURE_SIGNED_KEY__"):
+        assert token not in emitted, f"{token} shipped to the live site"
+
+
+def test_source_with_no_tokens_is_passed_through_unchanged():
+    """Ripple and virtually every svelte site carry no tokens. Substitution must be
+    incapable of changing their emitted bytes."""
+    untouched = {"src/routes/+page.svelte": "<h1>Brew and Co</h1>"}
+    assert _input("svelte", untouched)["source"] == untouched
+
+
+def test_resolution_is_idempotent():
+    """A republish re-runs this over source that already looks resolved (it does
+    not — the pocket keeps tokens — but the property costs nothing and a future
+    caching layer could hand us a resolved map)."""
+    once = _input("html", {"index.html": AUTHORED_FORM})["source"]["index.html"]
+    twice = _input("html", {"index.html": once})["source"]["index.html"]
+    assert once == twice
+
+
+# --------------------------------------------------------------------------- #
+# An ARMED build must NOT resolve them — the subtle one
+# --------------------------------------------------------------------------- #
+
+
+def test_an_editable_build_keeps_the_placeholders():
+    """THE OFFSET TRAP. The html edit lane records ``byteSpan`` offsets in its edit
+    manifest, computed over the bytes the generator was handed. A real signed key is
+    about twice the length of its placeholder, so arming a build with SUBSTITUTED
+    source and later splicing an edit into the STORED (placeholder) source would put
+    every span after the form out by the difference — edits landing mid-tag, silently.
+
+    Keeping armed builds on placeholders makes the two byte-identical. The form does
+    not submit inside the builder preview, which is the right behaviour anyway: an
+    edit session should not be able to mint live leads.
+
+    Mutation: drop ``and not builder_origin`` from the condition in
+    ``build_generator_input`` and this fails."""
+    out = _input("html", {"index.html": AUTHORED_FORM}, builder_origin="http://localhost:8888")
+    emitted = out["source"]["index.html"]
+
+    assert "__CAPTURE_API_BASE__" in emitted
+    assert "__CAPTURE_SIGNED_KEY__" in emitted
+    assert SIGNED_KEY not in emitted
+
+
+# --------------------------------------------------------------------------- #
+# The stored pocket keeps its placeholders
+# --------------------------------------------------------------------------- #
+
+
+def test_the_callers_source_map_is_never_mutated():
+    """The map handed in IS the stored pocket source. Mutating it would bake a real
+    signed key into the pocket, and ``rotate_signed_key`` would then leave every
+    published page authenticating with the leaked key it was rotated away from."""
+    stored = {"index.html": AUTHORED_FORM}
+    _input("html", stored)
+    assert stored == {"index.html": AUTHORED_FORM}
+
+
+def test_non_string_entries_ride_through_untouched():
+    """A DYNAMIC svelte pocket carries live-data binding keys on the same envelope
+    as its files (see ``_split_svelte_source``). Those are dicts and lists; running
+    a string replace over them would raise."""
+    out = _input(
+        "svelte",
+        {
+            "src/routes/+page.svelte": "<h1>__SITE_ID__</h1>",
+            "objects": [{"name": "Booking", "fields": []}],
+            "auth": {"mode": "none"},
+        },
+    )
+    assert out["source"]["src/routes/+page.svelte"] == f"<h1>{SITE_ID}</h1>"
+    assert out["objects"] == [{"name": "Booking", "fields": []}]
+
+
+# --------------------------------------------------------------------------- #
+# The prompt half — the tokens are worthless if nothing tells the agent to write them
+# --------------------------------------------------------------------------- #
+
+
+def test_the_static_track_prompt_teaches_the_whole_native_form_contract():
+    """The substitution above only ever runs on source an agent actually authored
+    that way. This asserts the instruction exists and is complete — endpoint, both
+    credential fields, and the relative-redirect rule the endpoint 400s without."""
+    from pocketpaw_ee.cloud.surface.handlers.sites import native_form_contract
+
+    block = native_form_contract()
+
+    assert "__CAPTURE_API_BASE__/capture/form" in block
+    assert "paw_site_id" in block and "__SITE_ID__" in block
+    assert "paw_key" in block and "__CAPTURE_SIGNED_KEY__" in block
+    # The open-redirect guard 400s an absolute path, so the agent has to know.
+    assert "paw_redirect" in block
+    assert "relative" in block.lower()
+
+
+def test_the_prompt_names_the_canonical_field_names_rather_than_its_own():
+    """The whole reason the contact schema exists is that a hand-written field list
+    drifted from the mapping that reads it. A prompt is another hand-written field
+    list, so it renders from the same declaration."""
+    from pocketpaw_ee.cloud.surface.handlers.sites import native_form_contract
+
+    block = native_form_contract()
+    for field in contact_form.CONTACT_FIELD_NAMES:
+        assert field in block, f"the prompt never tells the agent to emit {field!r}"

--- a/tests/ee/sites/test_static_form_capture.py
+++ b/tests/ee/sites/test_static_form_capture.py
@@ -191,3 +191,84 @@ def test_the_prompt_names_the_canonical_field_names_rather_than_its_own():
     block = native_form_contract()
     for field in contact_form.CONTACT_FIELD_NAMES:
         assert field in block, f"the prompt never tells the agent to emit {field!r}"
+
+
+# --------------------------------------------------------------------------- #
+# The svelte track — and the /api/submit route it used to depend on
+# --------------------------------------------------------------------------- #
+#
+# The skill taught `<form method="POST" action="/api/submit">` for as long as that
+# route existed, so it is in the stored source of every svelte pocket authored
+# before this change. On a STATIC svelte site the route was never actually served:
+# svelte-scaffold.ts deletes src/routes/api because adapter-static cannot prerender
+# a POST handler, so those forms have been 404ing and losing every lead. Removing
+# the route for the dynamic sites too is what leaves ONE capture path across all
+# four engines — but it can only be removed if the already-published fleet is
+# carried across, which is what the rewrite below does.
+
+LEGACY_FORM = (
+    '<form method="POST" action="/api/submit">'
+    '<input name="full_name" required><button type="submit">Send</button></form>'
+)
+
+
+def test_a_form_still_aimed_at_the_removed_route_is_repointed():
+    """The fleet does not republish itself and nobody edits a site that looks fine,
+    so deleting the route without this would turn every existing svelte site's form
+    into a 404 the owner reads as "nobody is filling it in"."""
+    emitted = _input("svelte", {"src/routes/+page.svelte": LEGACY_FORM})["source"][
+        "src/routes/+page.svelte"
+    ]
+
+    assert f'action="{CAPTURE_BASE}/capture/form"' in emitted
+    assert "/api/submit" not in emitted
+
+
+def test_the_repointed_form_gains_the_credentials_the_endpoint_requires():
+    """Repointing the action alone would 401 — /capture/form gates on the per-site
+    signed key and needs the site id to resolve the tenant. The rewrite injects both
+    (plus the redirect) as hidden inputs inside the form it just repointed."""
+    emitted = _input("svelte", {"src/routes/+page.svelte": LEGACY_FORM})["source"][
+        "src/routes/+page.svelte"
+    ]
+
+    assert f'name="paw_site_id" value="{SITE_ID}"' in emitted
+    assert f'name="paw_key" value="{SIGNED_KEY}"' in emitted
+    assert 'name="paw_redirect"' in emitted
+    # Inside the form, not after it — a hidden input outside the form is not sent.
+    assert emitted.index("paw_site_id") < emitted.index("</form>")
+
+
+def test_the_rewrite_is_idempotent():
+    """A republish runs this again over source that was already rewritten in a
+    previous publish's payload (and over freshly authored source, which already
+    carries the new contract). Neither may accumulate a second set of hidden
+    inputs."""
+    once = _input("svelte", {"p.svelte": LEGACY_FORM})["source"]["p.svelte"]
+    twice = _input("svelte", {"p.svelte": once})["source"]["p.svelte"]
+    assert once == twice
+    assert once.count("paw_site_id") == 1
+
+
+def test_a_form_authored_against_the_new_contract_is_left_alone():
+    """Source written to the CURRENT skill has no legacy action, so the rewrite must
+    not touch it — it only resolves the tokens."""
+    emitted = _input("svelte", {"p.svelte": AUTHORED_FORM})["source"]["p.svelte"]
+    assert emitted.count("paw_site_id") == 1
+    assert emitted.count("<form") == 1
+
+
+def test_an_unrelated_form_is_not_hijacked():
+    """A search box or a newsletter form on the same page posts somewhere else, and
+    rewriting it would both break it and start minting leads from it."""
+    other = '<form method="GET" action="/search"><input name="q"></form>'
+    assert _input("svelte", {"p.svelte": other})["source"]["p.svelte"] == other
+
+
+def test_the_svelte_prompt_carries_the_capture_contract():
+    """The svelte create branch had no form guidance at all — the skill owned it, and
+    the skill was pointing at the route that no longer exists."""
+    from pocketpaw_ee.cloud.surface.handlers.sites import native_form_contract
+
+    block = native_form_contract()
+    assert "__CAPTURE_API_BASE__/capture/form" in block

--- a/tests/mutations/static_form_capture.json
+++ b/tests/mutations/static_form_capture.json
@@ -1,0 +1,94 @@
+[
+  {
+    "label": "static capture: a public deploy stops resolving the tokens (form action ships a literal __CAPTURE_API_BASE__)",
+    "file": "ee/pocketpaw_ee/sites/generator_client.py",
+    "find": "    if source and not builder_origin:\n        source = _resolve_capture_tokens(",
+    "replace": "    if False:\n        source = _resolve_capture_tokens(",
+    "tests": [
+      "tests/ee/sites/test_static_form_capture.py"
+    ]
+  },
+  {
+    "label": "static capture: an ARMED build gets substituted source, shifting every html edit byteSpan",
+    "file": "ee/pocketpaw_ee/sites/generator_client.py",
+    "find": "    if source and not builder_origin:",
+    "replace": "    if source:",
+    "tests": [
+      "tests/ee/sites/test_static_form_capture.py"
+    ]
+  },
+  {
+    "label": "static capture: the substitution mutates the caller's map, baking a real signed key into the stored pocket",
+    "file": "ee/pocketpaw_ee/sites/generator_client.py",
+    "find": "    out: dict[str, Any] = {}\n    for path, contents in source.items():",
+    "replace": "    out: dict[str, Any] = source\n    for path, contents in list(source.items()):",
+    "tests": [
+      "tests/ee/sites/test_static_form_capture.py"
+    ]
+  },
+  {
+    "label": "static capture: a non-string source entry is run through the string replace (dynamic svelte bindings)",
+    "file": "ee/pocketpaw_ee/sites/generator_client.py",
+    "find": "        if not isinstance(contents, str):\n            out[path] = contents\n            continue",
+    "replace": "        contents = str(contents)",
+    "tests": [
+      "tests/ee/sites/test_static_form_capture.py"
+    ]
+  },
+  {
+    "label": "static capture: the signed-key token stops being resolved (form 401s on every submit)",
+    "file": "ee/pocketpaw_ee/sites/generator_client.py",
+    "find": "        \"__CAPTURE_SIGNED_KEY__\": capture_signed_key,",
+    "replace": "",
+    "tests": [
+      "tests/ee/sites/test_static_form_capture.py"
+    ]
+  },
+  {
+    "label": "static capture: the prompt stops naming the capture endpoint (form posts to the page itself)",
+    "file": "ee/pocketpaw_ee/cloud/surface/handlers/sites.py",
+    "find": "action=\"__CAPTURE_API_BASE__/capture/form\"",
+    "replace": "action=\"\"",
+    "tests": [
+      "tests/ee/sites/test_static_form_capture.py",
+      "tests/cloud/surface/test_sites_handler.py"
+    ]
+  },
+  {
+    "label": "static capture: the prompt spells its own field names instead of rendering the schema's",
+    "file": "ee/pocketpaw_ee/cloud/surface/handlers/sites.py",
+    "find": "    fields = \", \".join(f\"`{name}`\" for name in contact_form.CONTACT_FIELD_NAMES)",
+    "replace": "    fields = \"`name`, `email`, `phone`, `message`\"",
+    "tests": [
+      "tests/ee/sites/test_static_form_capture.py",
+      "tests/cloud/surface/test_sites_handler.py"
+    ]
+  },
+  {
+    "label": "static capture: the react track loses the contract while html keeps it",
+    "file": "ee/pocketpaw_ee/cloud/surface/handlers/sites.py",
+    "find": "            \"`<form>` with flat named fields.\\n\"\r\n            + native_form_contract()\r\n            + \"CHANGES GO THROUGH THE EDIT TOOL.",
+    "replace": "            \"`<form>` with flat named fields.\\n\"\r\n            + \"CHANGES GO THROUGH THE EDIT TOOL.",
+    "tests": [
+      "tests/cloud/surface/test_sites_handler.py"
+    ]
+  },
+  {
+    "label": "static capture: the ripple track is handed markup instructions it cannot act on",
+    "file": "ee/pocketpaw_ee/cloud/surface/handlers/sites.py",
+    "find": "            \"URLs. The lead-capture form must be FLAT native \"\r\n            '`input`/`textarea`/`button{type:\"submit\"}` widgets — NEVER the `form` or '",
+    "replace": "            \"URLs. \" + native_form_contract() + \"The lead-capture form must be FLAT native \"\r\n            '`input`/`textarea`/`button{type:\"submit\"}` widgets — NEVER the `form` or '",
+    "tests": [
+      "tests/cloud/surface/test_sites_handler.py"
+    ]
+  },
+  {
+    "label": "static capture: a refine is no longer told to preserve the form's plumbing",
+    "file": "ee/pocketpaw_ee/cloud/surface/handlers/sites.py",
+    "find": "    \"PRESERVE the form's PLUMBING exactly as it is: the `action`, the `method`, \"",
+    "replace": "    \"\" \"",
+    "tests": [
+      "tests/cloud/surface/test_sites_handler.py"
+    ]
+  }
+]

--- a/tests/mutations/static_form_capture.json
+++ b/tests/mutations/static_form_capture.json
@@ -90,5 +90,41 @@
     "tests": [
       "tests/cloud/surface/test_sites_handler.py"
     ]
+  },
+  {
+    "label": "static capture: a form still aimed at the removed /api/submit route is left to 404",
+    "file": "ee/pocketpaw_ee/sites/generator_client.py",
+    "find": "        contents = _rewire_legacy_submit_forms(contents)",
+    "replace": "        contents = contents",
+    "tests": [
+      "tests/ee/sites/test_static_form_capture.py"
+    ]
+  },
+  {
+    "label": "static capture: the repointed form loses the credentials the endpoint gates on",
+    "file": "ee/pocketpaw_ee/sites/generator_client.py",
+    "find": "        + _CAPTURE_HIDDEN_FIELDS,",
+    "replace": "        ,",
+    "tests": [
+      "tests/ee/sites/test_static_form_capture.py"
+    ]
+  },
+  {
+    "label": "static capture: the rewrite hijacks every form, not just the legacy capture one",
+    "file": "ee/pocketpaw_ee/sites/generator_client.py",
+    "find": "/api/submit\\2([^>]*>)\"",
+    "replace": "[^\"']*\\2([^>]*>)\"",
+    "tests": [
+      "tests/ee/sites/test_static_form_capture.py"
+    ]
+  },
+  {
+    "label": "static capture: the svelte track loses the contract",
+    "file": "ee/pocketpaw_ee/cloud/surface/handlers/sites.py",
+    "find": "            + native_form_contract()\r\n        )",
+    "replace": "        )",
+    "tests": [
+      "tests/cloud/surface/test_sites_handler.py"
+    ]
   }
 ]


### PR DESCRIPTION
**Stacked on #1933** — targets `fix/sites-contact-form-schema`, because the prompt renders its field names from the contact schema that PR introduces. Merge #1933 first (with `--rebase`, per the stacked-PR rule), then this retargets to `dev`.

## The bug

The react and raw-html tracks have no server route — no `/api/submit` — and the generator's `rewireForms` fires only on the import path. `paw-sites/src/cli.ts` says so in as many words: *"the ONLY caller of rewireForms in the deployed backend path"*.

The authoring prompt asked for "a native `<form>` with flat named fields" and never said where it posts. A `<form>` with no action posts to itself. The visitor fills it in, presses Send, the page reloads, and the lead is gone. No error, no log, and a site that looks completely fine.

The react skill had already noticed and routed around it, which shows how long this has been true:

> If you have no capture endpoint to target, prefer a `mailto:` form action or a plain `tel:` / `mailto:` CTA over a form that silently drops submissions.

There is an endpoint — the shared, origin-pinned, signed-key-gated `/capture/form` the imported track already posts to.

## Both halves, one commit

**The prompt** (`native_form_contract()`) teaches the whole contract: the action, the three hidden `paw_*` inputs, and the rule that `paw_redirect` must be relative — the endpoint 400s otherwise, so the agent has to know to author the thank-you page it names. Field names render from `contact_form.CONTACT_FIELD_NAMES`, never spelled out: a prompt is one more hand-written field list, and a hand-written field list drifting from the mapping that reads it is exactly the bug #1933 fixes. Writing them again would reintroduce it one layer up.

**The substitution** (`build_generator_input`) resolves `__CAPTURE_API_BASE__` / `__SITE_ID__` / `__CAPTURE_SIGNED_KEY__` — the same tokens `scaffoldProject` already substitutes into the svelte templates. The agent has none of those values while authoring (on a create the site doesn't exist yet; the key is minted at publish), so it writes placeholders.

## Two design calls worth reviewing

**Substitution is in pocketpaw, not paw-sites.** The obvious home is the react/html materializers next to the existing `scaffoldProject` substitution. But `paw-sites` ships as a separate binary resolved via `PAW_SITES_GEN_CMD`, so a prompt live before its substitution would publish a literal `__CAPTURE_API_BASE__` into the action of every react/html site in the gap. Putting it at `build_generator_input` — the single chokepoint both publish paths funnel through — means the prompt and the resolver ship together. It also keeps paw-sites' documented "byte-identical, no transform" invariant for html intact.

**It's gated on a public deploy, and that gate is load-bearing.** The html edit lane records `byteSpan` offsets computed over the bytes the generator was handed. A real signed key is roughly twice its placeholder, so arming a build with substituted source and later splicing an edit into the stored (placeholder) source would land every span after the form out by the difference — edits landing mid-tag, silently. Armed builds keep placeholders, which also means an edit session can't mint live leads.

The pocket keeps placeholders either way: `apply_leaf_edits` has its own subprocess path and never sees a substituted map. That's what keeps `rotate_signed_key` meaningful — the next publish substitutes the new key with nothing to migrate.

## Ripple is deliberately excluded

Its form is composed by code from the same schema (`assemble_landing_spec`), so the skill supplies copy only. Handing that track the native-form contract would tell the agent to write markup it has no way to write — the "prompt may not command something the agent can't do" rule applied to markup rather than a tool. Pinned by a test, and one of the mutations injects the contract into the ripple branch to prove the pin holds.

## Refine

`_REFINE_SHARED_RULES` now says to preserve the form's plumbing. A refine rewrites whole sections, and the action plus three hidden inputs don't look like copy — they're the first thing a rewrite drops as noise. Losing them costs every subsequent lead, with no visible change to the page.

## Also updated

Both bundled skills (`pocketpaw-create-react-site`, the raw-HTML track of `pocketpaw-create-paw-site`) now carry the same contract. They're a second prompt surface reaching the same agent; leaving them saying `mailto:` would have them contradicting the handler.

## Verification

```
1472 passed   tests/ee/sites tests/cloud/surface tests/sites_capture tests/cloud/leads
              tests/test_prompt_names_only_real_tools.py
 178 passed   tests/atlas
all 10 mutations caught   tests/mutations/static_form_capture.json
```

One mutation escaped on the first run — it removed the block's warning sentence but left the endpoint, so the tests correctly didn't care. Retargeted at the `action=` attribute, which is the thing that actually matters.

## Not covered

Whether the deployed backend's `paw-sites-gen` binary matters here: it doesn't for this change (substitution is entirely upstream of the generator), but the react/html **publish smoke** has not been run against a real deploy. Worth one live publish on each track before this is trusted end-to-end.
