### PR TITLE
html sites can be edited from chat, and the contact form stops 403ing the visitor

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/sites.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/sites.py
@@ -71,6 +71,21 @@
 # enqueued (a react publish is async, so there is no synchronous outcome to gate
 # on). Its id rides ``SITES_TOOL_IDS``, so the per-surface allowlist picks it up.
 #
+# Updated 2026-08-13 (HE-10 — the html track gets an EDIT lane): the
+# ``edit_html_file`` tool also registers on this SAME server, completing the set —
+# every engine that can be CREATED from chat can now be CHANGED from chat. It had
+# the same hole RX-3 closed for react, one engine over: ``edit_svelte_component``
+# raises ``pocket.not_svelte_site`` on an html pocket and ``edit_react_component``
+# raises ``pocket.not_react_site``, so no tool on this server would accept "change
+# the phone number in the footer" and the agent's only move was a second
+# ``create_html_site`` — a second pocket at a second url, leaving the site the user
+# was looking at untouched. It writes ONE file of the pocket's html source map as a
+# reviewable DRAFT and does NOT republish; html runs no build and therefore has no
+# smoke gate, so a republish here would push unvalidated markup straight to a live
+# site with nothing in between. Named ``edit_html_file`` rather than
+# ``edit_html_component`` because an html site genuinely has no component model —
+# its source map is the raw {path: contents} tree the edge serves verbatim.
+#
 # Updated 2026-08-07 (RX-2 — the agent can select the react engine): the
 # ``create_react_site`` tool also registers on this SAME server. A react site is a
 # {path: contents} map of hand-written React files; publish runs a Vite SSG build
@@ -145,6 +160,12 @@ CREATE_REACT_SITE_TOOL_ID = f"mcp__{SERVER_NAME}__create_react_site"
 # server (see sites_create.py). It writes ONE file of a react site's source map as a
 # reviewable DRAFT; it does NOT publish and does NOT enqueue a build.
 EDIT_REACT_COMPONENT_TOOL_ID = f"mcp__{SERVER_NAME}__edit_react_component"
+# The targeted html-file edit tool (HE-10) — also registers on this SAME server
+# (see sites_create.py). It writes ONE file of an html site's source map as a
+# reviewable DRAFT; it does NOT publish. Named for a FILE rather than a component
+# because an html site has no component model — its source map is the raw
+# {path: contents} tree the edge serves.
+EDIT_HTML_FILE_TOOL_ID = f"mcp__{SERVER_NAME}__edit_html_file"
 # The READ-ONLY build-status tool (RX-4). It exists because react publishes are
 # ASYNC: ``publish`` returns before the build starts, so without a way to ask again
 # on a later turn the agent learns a build was queued and can never discover it
@@ -161,6 +182,7 @@ SITES_TOOL_IDS = (
     CREATE_HTML_SITE_TOOL_ID,
     CREATE_REACT_SITE_TOOL_ID,
     EDIT_REACT_COMPONENT_TOOL_ID,
+    EDIT_HTML_FILE_TOOL_ID,
     GET_SITE_BUILD_STATUS_TOOL_ID,
 )
 
@@ -493,6 +515,7 @@ def build_sites_manager_server() -> tuple[str, Any] | None:
         make_create_landing_site_tool,
         make_create_react_site_tool,
         make_create_svelte_site_tool,
+        make_edit_html_file_tool,
         make_edit_react_component_tool,
         make_edit_svelte_component_tool,
     )
@@ -522,6 +545,11 @@ def build_sites_manager_server() -> tuple[str, Any] | None:
     # stops the agent answering "shorten the hero headline" with a second
     # create_react_site call and a second site pocket.
     edit_react_component = make_edit_react_component_tool(tool)
+    # The html-track EDIT tool (HE-10) — same server, completing the set: every
+    # engine that can be created from chat can now be CHANGED from chat. Registering
+    # it is what stops the agent answering "change the phone number in the footer"
+    # with a second create_html_site call and a second site pocket.
+    edit_html_file = make_edit_html_file_tool(tool)
 
     server = create_sdk_mcp_server(
         name=SERVER_NAME,
@@ -536,6 +564,7 @@ def build_sites_manager_server() -> tuple[str, Any] | None:
             create_html_site,
             create_react_site,
             edit_react_component,
+            edit_html_file,
         ],
     )
     return SERVER_NAME, server
@@ -547,6 +576,7 @@ __all__ = [
     "CREATE_LANDING_SITE_TOOL_ID",
     "CREATE_REACT_SITE_TOOL_ID",
     "CREATE_SVELTE_SITE_TOOL_ID",
+    "EDIT_HTML_FILE_TOOL_ID",
     "EDIT_REACT_COMPONENT_TOOL_ID",
     "EDIT_SVELTE_COMPONENT_TOOL_ID",
     "GET_SITE_BUILD_STATUS_TOOL_ID",

--- a/ee/pocketpaw_ee/agent/mcp_servers/sites_create.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/sites_create.py
@@ -268,6 +268,14 @@ CREATE_REACT_SITE_TOOL_ID = f"mcp__{SERVER_NAME}__create_react_site"
 # changing the one the user is looking at.
 EDIT_REACT_COMPONENT_TOOL_ID = f"mcp__{SERVER_NAME}__edit_react_component"
 
+# HE-10 — the html-track EDIT tool, and the last engine to get one. Same server
+# again. Its absence had the same shape as RX-3's: ``edit_svelte_component``
+# rejects an html pocket and so does ``edit_react_component``, so "change the phone
+# number in the footer" had no tool that would take it and the agent's only move was
+# a second ``create_html_site`` — a second pocket at a second url. Named for a FILE,
+# not a component, because an html site has no component model to name.
+EDIT_HTML_FILE_TOOL_ID = f"mcp__{SERVER_NAME}__edit_html_file"
+
 SITES_CREATE_TOOL_IDS = (
     CREATE_LANDING_SITE_TOOL_ID,
     CREATE_SVELTE_SITE_TOOL_ID,
@@ -276,6 +284,7 @@ SITES_CREATE_TOOL_IDS = (
     CREATE_HTML_SITE_TOOL_ID,
     CREATE_REACT_SITE_TOOL_ID,
     EDIT_REACT_COMPONENT_TOOL_ID,
+    EDIT_HTML_FILE_TOOL_ID,
 )
 
 
@@ -2195,12 +2204,295 @@ def make_edit_react_component_tool(tool: Any) -> Any:
     return edit_react_component
 
 
+async def _edit_html_file_handler(args: dict) -> dict:
+    """MCP handler for ``sites_manager__edit_html_file`` (HE-10).
+
+    Reads workspace/user identity from the per-stream ContextVars, runs the same
+    plan gate the create handlers run, validates the inputs, and delegates to
+    ``sites_service.edit_html_file`` — which resolves the edit and persists the one
+    file as a reviewable DRAFT.
+
+    Mirrors ``_edit_react_component_handler`` almost line for line, and the places
+    it does NOT are the html-specific ones: the argument is ``file_path`` (an html
+    site has files, not components), and the path guidance names the ``_paw/``
+    namespace rather than react's build shell.
+
+    Like the react handler it does NOT republish, so there is no ``SmokeGateFailed``
+    case to map. The reason differs and is worth keeping straight: react cannot roll
+    back because its build is async, whereas html has no build to gate on AT ALL —
+    which means a republish here would push unvalidated markup straight to a live
+    site. Draft-only is the safer contract, not merely the convenient one.
+
+    Returns ``{ok, status:"draft", is_live:false, pocket_id, file_path, created,
+    message}``; sets ``is_error`` when identity is missing, the plan lacks Sites,
+    the inputs are malformed, or the service rejects the edit (a reserved or
+    escaping path, a wrong-engine pocket, a missing/colliding file, an ambiguous
+    ``old_string``) — each relayed by code so the agent can fix and retry rather
+    than report a change that did not happen.
+    """
+    workspace_id, user_id = _identity()
+    if not workspace_id or not user_id:
+        return _error_response(
+            "edit_html_file requires workspace and user context (call from a "
+            "cloud chat session)."
+        )
+
+    record_tool_call(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        tool_server="pocketpaw_sites",
+        tool_name="_edit_html_file",
+        status="ok",
+        ok=True,
+    )
+
+    pocket_id = args.get("pocket_id")
+    if not isinstance(pocket_id, str) or not pocket_id:
+        return _error_response(
+            "edit_html_file requires a `pocket_id` — the id of the html site "
+            "pocket whose file you are editing."
+        )
+    file_path = args.get("file_path")
+    if not isinstance(file_path, str) or not file_path:
+        return _error_response(
+            "edit_html_file requires a `file_path` — the relative path of the file "
+            "to write (e.g. 'index.html' or 'css/site.css'). It must already exist "
+            "in the site's source map unless you pass `create=true`."
+        )
+    args = coerce_json_object_args(args, ("edits",))
+    edits = args.get("edits")
+    new_source = args.get("new_source")
+    has_edits = edits is not None
+    has_new_source = new_source is not None
+    if has_edits == has_new_source:
+        return _error_response(
+            "edit_html_file requires exactly one of `edits` (a targeted "
+            "search/replace diff — PREFERRED for small changes) or `new_source` "
+            "(the FULL new file contents — for large rewrites and for `create`). "
+            "Provide one, not both and not neither."
+        )
+    if has_new_source and not isinstance(new_source, str):
+        return _error_response(
+            "edit_html_file `new_source` must be the FULL new contents of the file "
+            "as a string (the tool replaces the whole file, not a patch)."
+        )
+    if has_edits:
+        # Validate the diff SHAPE here so a malformed payload gets a clear error
+        # before the service runs. The MATCH-uniqueness contract belongs to the
+        # service's apply_edits (relayed below as a ValidationError).
+        if not isinstance(edits, list) or not edits:
+            return _error_response(
+                "edit_html_file `edits` must be a non-empty list of "
+                "{old_string, new_string} blocks (like the built-in Edit tool)."
+            )
+        for i, block in enumerate(edits):
+            if (
+                not isinstance(block, dict)
+                or not isinstance(block.get("old_string"), str)
+                or not isinstance(block.get("new_string"), str)
+            ):
+                return _error_response(
+                    f"edit_html_file `edits` block {i} must be an object with "
+                    "string `old_string` and `new_string`."
+                )
+    create = bool(args.get("create"))
+    if create and not has_new_source:
+        return _error_response(
+            "edit_html_file `create=true` needs `new_source` — the full contents of "
+            "the new file. There is nothing for `edits` to search against in a file "
+            "that does not exist yet."
+        )
+
+    # Plan gate (Sites = "sites"): an edit mutates a site pocket, so it is gated on
+    # the same feature the create tools are. Without this a workspace that lost the
+    # plan could keep editing a site its own /sites list 403s.
+    if (gate := await _require_sites_plan_or_error(workspace_id)) is not None:
+        return gate
+
+    from pocketpaw_ee.cloud._core.errors import CloudError
+    from pocketpaw_ee.sites import service as sites_service
+
+    try:
+        result = await sites_service.edit_html_file(
+            user_id=user_id,
+            pocket_id=pocket_id,
+            file_path=file_path,
+            new_source=new_source if has_new_source else None,
+            edits=edits if has_edits else None,
+            create=create,
+        )
+    except CloudError as exc:
+        # ValidationError (reserved `_paw/` path / escapes the site dir / not an
+        # html site / already exists / a bad diff) or NotFound (unknown pocket or
+        # file). Relay the code + message so the agent knows WHICH guard rejected it.
+        return _error_response(f"{exc.code}: {exc.message}")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("edit_html_file failed", exc_info=True)
+        return _error_response(f"edit failed: {exc}")
+
+    # The edit is a DRAFT. The chat agent narrates this payload, so — exactly like
+    # both sibling edit tools — it must not contain a completed-state publish claim.
+    return _success_response(
+        {
+            "ok": True,
+            "status": "draft",
+            "is_live": False,
+            "pocket_id": result["pocket_id"],
+            "file_path": result["file_path"],
+            "created": result["created"],
+            "message": (
+                "Saved to the site's draft — it is NOT online yet. Tell the user the "
+                "change is in the draft they can preview under /sites, and offer to "
+                "publish it; only call the publish tool when they ask."
+            ),
+        }
+    )
+
+
+def make_edit_html_file_tool(tool: Any) -> Any:
+    """Build the ``edit_html_file`` SDK tool object using the SDK's ``tool``
+    decorator (passed in by the caller that already imported it).
+
+    Registered on the SAME ``pocketpaw_sites_manager`` server as create + publish +
+    the two sibling edit tools (see ``make_create_landing_site_tool`` for why one
+    server)."""
+
+    @tool(
+        "edit_html_file",
+        (
+            "Change an EXISTING html Paw Site (a raw HTML/CSS/JS site — the kind "
+            "`create_html_site` makes, and the kind a site imported from a URL is). "
+            "Use this WHENEVER the user asks to alter an html site that already "
+            "exists — 'change the phone number in the footer', 'shorten the hero "
+            "headline', 'fix the typo on the about page', 'add a contact page'. "
+            "NEVER call `create_html_site` again for a change: that mints a SECOND "
+            "site pocket at a SECOND url and leaves the one the user is looking at "
+            "untouched. The change is saved to the site's DRAFT — it is NOT "
+            "published and nothing goes live.\n"
+            "Give the change ONE of two ways (exactly one, not both):\n"
+            "  * `edits` — PREFER THIS, and prefer it harder here than on the other "
+            "tracks. A list of search/replace blocks [{old_string, new_string}, "
+            "...], exactly like the built-in Edit tool: each `old_string` is copied "
+            "VERBATIM from the current file and must match EXACTLY ONCE (include "
+            "enough surrounding context to be unique), and `new_string` is what it "
+            "becomes. An html page is ONE flat document with no components, so a "
+            "full rewrite means re-emitting the entire page to change a phone "
+            "number. If you have not read the file this turn, read it first so "
+            "old_string matches.\n"
+            "  * `new_source` — the FULL new file contents as a string (REPLACES "
+            "the whole file). For large rewrites, and the only form `create` "
+            "accepts.\n"
+            "To ADD a page: call this twice — once with `create=true` and "
+            "`new_source` for the new file (e.g. `about.html`), then once with "
+            "`edits` on `index.html` to link to it. `create=true` REQUIRES the path "
+            "to be new; editing an existing file with it is rejected so you cannot "
+            "overwrite a page by accident. Without `create` the path must already "
+            "exist, so a typo is an error and never a stray new file.\n"
+            "PATHS: an html site's files are project-relative and MOST LIVE AT THE "
+            "ROOT — `index.html` is the page the edge serves, alongside things like "
+            "`styles.css`, `about.html`, `img/logo.svg`. This is NOT like the react "
+            "track: do NOT prefix paths with `src/`. The ONLY forbidden paths are "
+            "the generated `_paw/` namespace and anything that climbs out of the "
+            "site with `..`.\n"
+            "KEEP THE FORM PLUMBING. If the file contains a `<form>` posting to a "
+            "`/capture/form` endpoint, leave its `action` and its hidden "
+            "`paw_site_id` / `paw_key` / `paw_redirect` inputs EXACTLY as they are "
+            "unless the user asks to change the form itself — they are what makes "
+            "submissions arrive as leads, and a rewrite that drops them silently "
+            "sends every future enquiry nowhere.\n"
+            "Args: `pocket_id` (the html site pocket), `file_path`, and one of "
+            "`edits` / `new_source`, plus optional `create`. Returns {ok, "
+            "status:'draft', is_live:false, pocket_id, file_path, created, "
+            "message}. Relay the `message`: the change is in the DRAFT the user can "
+            "preview under /sites, and publishing is their call — do NOT tell them "
+            "it is live. ok=false with an error means NOTHING was saved: an "
+            "old_string that matched 0 or >1 times means make it more specific and "
+            "retry; a reserved-path, wrong-engine, already-exists or not-found "
+            "error means relay the reason. Do NOT report a successful edit when "
+            "ok=false."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "pocket_id": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Id of the html site pocket to edit.",
+                },
+                "file_path": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": (
+                        "Relative path of the file to write (e.g. 'index.html', "
+                        "'styles.css', 'about.html'). Files usually sit at the site "
+                        "ROOT — do NOT prefix with 'src/'. Must already exist in the "
+                        "site's source map unless `create` is true. The generated "
+                        "`_paw/` namespace is not writable."
+                    ),
+                },
+                "edits": {
+                    "type": "array",
+                    "description": (
+                        "PREFERRED for small changes: a list of search/replace "
+                        "blocks applied to the file's CURRENT contents. Each "
+                        "`old_string` must match exactly once. Send this INSTEAD of "
+                        "`new_source` so you emit only the diff. Not valid with "
+                        "`create`."
+                    ),
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "old_string": {
+                                "type": "string",
+                                "description": (
+                                    "Exact text to replace, copied verbatim from the "
+                                    "current file; must match exactly once."
+                                ),
+                            },
+                            "new_string": {
+                                "type": "string",
+                                "description": "Replacement text (may be empty to delete).",
+                            },
+                        },
+                        "required": ["old_string", "new_string"],
+                        "additionalProperties": False,
+                    },
+                },
+                "new_source": {
+                    "type": "string",
+                    "description": (
+                        "The FULL new contents of the file as a string (REPLACES the "
+                        "whole file — not a diff). Use for large rewrites, and "
+                        "always with `create`."
+                    ),
+                },
+                "create": {
+                    "type": "boolean",
+                    "description": (
+                        "Create a NEW file at `file_path` instead of editing an "
+                        "existing one. Requires `new_source`, and the path must NOT "
+                        "already exist. Use it to add a page, then edit "
+                        "`index.html` to link to it."
+                    ),
+                },
+            },
+            "required": ["pocket_id", "file_path"],
+            "additionalProperties": False,
+        },
+    )
+    async def edit_html_file(args):  # type: ignore[no-untyped-def]
+        return await _edit_html_file_handler(args)
+
+    return edit_html_file
+
+
 __all__ = [
     "CREATE_DYNAMIC_SITE_TOOL_ID",
     "CREATE_HTML_SITE_TOOL_ID",
     "CREATE_LANDING_SITE_TOOL_ID",
     "CREATE_REACT_SITE_TOOL_ID",
     "CREATE_SVELTE_SITE_TOOL_ID",
+    "EDIT_HTML_FILE_TOOL_ID",
     "EDIT_REACT_COMPONENT_TOOL_ID",
     "EDIT_SVELTE_COMPONENT_TOOL_ID",
     "HTML_REQUIRED_KEYS",
@@ -2216,6 +2508,7 @@ __all__ = [
     "make_create_landing_site_tool",
     "make_create_react_site_tool",
     "make_create_svelte_site_tool",
+    "make_edit_html_file_tool",
     "make_edit_react_component_tool",
     "make_edit_svelte_component_tool",
 ]

--- a/ee/pocketpaw_ee/cloud/leads/domain.py
+++ b/ee/pocketpaw_ee/cloud/leads/domain.py
@@ -21,4 +21,11 @@ class Lead:
     form_type: str
     properties: dict[str, Any] = field(default_factory=dict)
     submitter_ref: str = ""
+    # Flattened off ``LeadSource``, the same way ``submitter_ref`` is. Surfaced
+    # because ``Site.enforce_origin`` defaults OFF: a submission from an
+    # unrecognized host is now accepted rather than 403'd, so the only thing that
+    # keeps that trade honest is the owner being able to SEE where a lead came
+    # from. A signal nobody can read is not a signal.
+    origin: str = ""
+    origin_unrecognized: bool = False
     created_at: datetime | None = None

--- a/ee/pocketpaw_ee/cloud/leads/dto.py
+++ b/ee/pocketpaw_ee/cloud/leads/dto.py
@@ -33,7 +33,13 @@ class LeadOut(BaseModel):
     site_id: str
     form_type: str
     properties: dict[str, Any]
-    created_at: str | None
+    # Where the submission came from, and whether that host was on the site's
+    # allowlist AT CAPTURE TIME. Both are informational — since origin enforcement
+    # is opt-in (``Site.enforce_origin``), an unrecognized origin is an accepted
+    # lead the owner can judge for themselves rather than one we silently refused.
+    origin: str = ""
+    origin_unrecognized: bool = False
+    created_at: str | None = None
 
 
 def lead_to_dto(lead: Lead) -> LeadOut:
@@ -42,6 +48,8 @@ def lead_to_dto(lead: Lead) -> LeadOut:
         site_id=lead.site_id,
         form_type=lead.form_type,
         properties=lead.properties,
+        origin=lead.origin,
+        origin_unrecognized=lead.origin_unrecognized,
         created_at=iso_utc(lead.created_at),
     )
 

--- a/ee/pocketpaw_ee/cloud/leads/router.py
+++ b/ee/pocketpaw_ee/cloud/leads/router.py
@@ -1,8 +1,42 @@
-# ee/pocketpaw_ee/cloud/leads/router.py — capture ingest (public, origin-pinned,
-# signed-key-gated; the edge Queue drains here) + authed tenant-scoped reads.
+# ee/pocketpaw_ee/cloud/leads/router.py — capture ingest (public, signed-key-gated,
+# origin-ATTRIBUTED; the edge Queue drains here) + authed tenant-scoped reads.
 # The public capture endpoint deliberately has NO auth dependency: it is called
-# by the deployed site's Queue consumer, authenticated by the per-site signed
-# key + origin pin, not a user session.
+# by the deployed site's own pages / Queue consumer, authenticated by the per-site
+# signed key, not a user session.
+#
+# Updated 2026-08-13 (fix/sites-capture-origin-posture): the origin pin STOPPED
+# BEING A GATE by default and became a recorded signal plus a per-site opt-in
+# (``Site.enforce_origin``, default False) — the Formspree/Basin posture. Reported
+# from a live run: a site published to ``*.workers.dev`` submitted its contact form
+# and the VISITOR was shown ``{"detail":"Origin not allowed for this site"}``.
+#
+# The pin was never buying what it looked like it was buying. It guards a
+# credential that is ALREADY PUBLIC on three of the four engines — html, react and
+# static svelte all ship ``paw_key`` as a hidden input in the page source — and
+# ``Origin`` binds browsers only, so any script forges it in one flag. What it did
+# reliably was 403 legitimate submissions whenever the stored allowlist and the
+# serving host disagreed, which has several routine causes (a draft/preview publish
+# that returns before the deploy stamp, an async react build inserted with
+# ``url=""``, apex vs ``www.``, a preview URL, a ``file://`` open sending no Origin
+# at all). Every one fails CLOSED, and on the native-form path the person who sees
+# the failure is the customer's prospect, not the owner — who sees only an absence
+# of leads.
+#
+# Three pieces make the new posture safe, and they ship together:
+#   * ``_effective_origins`` derives the known-host set from the site's own ``url``
+#     and attached ``domains`` instead of trusting the stamped field alone, so a
+#     site's own traffic is never foreign to it — for the flag AND for the opt-in
+#     gate, which would otherwise 403 its own pages.
+#   * ``_redirect_base`` no longer echoes the request Origin unconditionally. That
+#     was safe ONLY because the origin had just been pinned; without the pin it
+#     would be an open redirect. It now prefers an allowlisted origin, falls back to
+#     the site's own url, and never emits a host the caller chose.
+#   * every lead records ``origin`` + ``origin_unrecognized`` (evaluated at capture,
+#     against the derived set) so an owner can judge an unexpected submission
+#     instead of us silently refusing it.
+# The controls that actually work on a public endpoint with a public key are
+# untouched: honeypot, atomic per-(scope, minute) rate limit, injection screen at
+# HIGH, payload cap, constant-time key compare, open-redirect guard.
 #
 # Created 2026-05-30 (feat/paw-sites-backend, RFC 12 Task 3.4): the Sites
 # capture surface. Public POST /sites/{site_id}/capture (site-exists → origin
@@ -67,6 +101,90 @@ def _rate_key(request: Request) -> str:
     return hashlib.sha256(host.encode("utf-8")).hexdigest() if host else ""
 
 
+def _origin_of(request: Request) -> str:
+    """The submitting page's ``Origin`` header, trimmed ("" when absent)."""
+    return (request.headers.get("origin") or "").strip()
+
+
+def _effective_origins(site: _SiteDoc) -> list[str]:
+    """The hosts a submission may legitimately come FROM, derived rather than only
+    read off ``allowed_origins``.
+
+    ``allowed_origins`` is STAMPED at publish (``_with_deployed_host``) and grown by
+    ``add_domain``, which means it is only as good as the write paths that maintain
+    it — and they have gaps. A draft/preview publish returns before the deploy stamp
+    runs, an async (react) build inserts its Site row with ``url=""`` and fills the
+    url in later from the worker, and any row created before the stamping landed
+    still carries just the localhost seed. In every one of those the site's OWN
+    deployed host is missing from its own allowlist, so its own visitors read as
+    foreign.
+
+    That was survivable only while nobody looked at the answer. Now that origin is
+    recorded on each lead, a stale allowlist would mark a site's genuine traffic
+    ``origin_unrecognized`` — a flag that fires on the normal case teaches an owner
+    to ignore it, which is worse than not having it. And for a site that opts INTO
+    enforcement it would be a live 403 on its own pages.
+
+    So the site's canonical ``url`` host and every attached custom ``domains``
+    hostname are folded in here. Both are values WE wrote from a deploy we
+    performed, never caller input, so this widens the set only to hosts the site
+    demonstrably owns.
+    """
+    hosts = list(site.allowed_origins)
+    candidates = [site.url or ""]
+    candidates.extend(d.hostname for d in (site.domains or []) if d.hostname)
+    for candidate in candidates:
+        host = candidate.strip().lower()
+        if "://" in host:
+            host = host.split("://", 1)[1]
+        host = host.split("/", 1)[0].split(":", 1)[0]
+        if host and host not in hosts:
+            hosts.append(host)
+    return hosts
+
+
+def _origin_gate(site: _SiteDoc, origin: str) -> None:
+    """Enforce the origin pin ONLY for a site that opted into it.
+
+    Formspree posture (see ``Site.enforce_origin`` for the full reasoning): by
+    default a submission from an unrecognized host is ACCEPTED and attributed on
+    the Lead rather than 403'd. The pin guards a credential that is already public
+    in the page source on three of the four engines, and ``Origin`` constrains
+    browsers only — so as a gate it mostly turned real submissions into a JSON 403
+    the customer's prospect had to look at.
+
+    A site that flips ``enforce_origin`` gets the old fail-closed behaviour back
+    verbatim, including on an empty allowlist and a missing header.
+    """
+    if site.enforce_origin and not origin_allowed(_effective_origins(site), origin or None):
+        raise HTTPException(403, "Origin not allowed for this site")
+
+
+def _redirect_base(site: _SiteDoc, origin: str) -> str:
+    """Absolute prefix for the native-form 303, chosen so it can NEVER be an
+    attacker-controlled host.
+
+    This used to be the request ``Origin`` unconditionally, which was safe only
+    because the origin had just been pinned. With the pin now opt-in, that would be
+    an open redirect: anyone could POST with ``Origin: https://evil.test`` and be
+    sent there. So the base is resolved in a strict order:
+
+      1. the request Origin, but ONLY when it is on the site's allowlist — the
+         common case, and the one that keeps a visitor on the custom domain they
+         are actually browsing rather than bouncing them to a workers.dev URL;
+      2. the site's own canonical ``url`` — correct whenever the origin is absent,
+         unrecognized, or forged;
+      3. "" — a relative Location, when the site has no url yet (a draft, or an
+         async build whose worker has not filled it in).
+
+    Every branch is a value WE control or have already validated, so an unvalidated
+    origin cannot reach the ``Location`` header under any input.
+    """
+    if origin and origin_allowed(_effective_origins(site), origin):
+        return origin.rstrip("/")
+    return (site.url or "").rstrip("/")
+
+
 @router.post("/sites/{site_id}/capture", response_model=CaptureResponse)
 async def capture_lead(site_id: str, body: CaptureRequest, request: Request) -> CaptureResponse:
     """Public ingest. Order: site exists → origin pinned → signed key → payload
@@ -76,8 +194,8 @@ async def capture_lead(site_id: str, body: CaptureRequest, request: Request) -> 
     if site is None:
         raise HTTPException(404, "Site not found")
 
-    if not origin_allowed(site.allowed_origins, request.headers.get("origin")):
-        raise HTTPException(403, "Origin not allowed for this site")
+    origin = _origin_of(request)
+    _origin_gate(site, origin)
 
     # H1: constant-time compare so the key check can't be probed via timing.
     if not secrets.compare_digest(body.signed_key, site.signed_key):
@@ -95,6 +213,8 @@ async def capture_lead(site_id: str, body: CaptureRequest, request: Request) -> 
         payload=body.payload,
         submitter_ref=body.submitter_ref or "anon",
         rate_key=_rate_key(request),  # server-derived; the real per-IP limiter key
+        origin=origin,
+        known_origins=_effective_origins(site),
     )
     if lead is None:
         return CaptureResponse(ok=False, reason="dropped")
@@ -143,8 +263,8 @@ async def capture_form(request: Request) -> Response:
     if site is None:
         raise HTTPException(404, "Site not found")
 
-    if not origin_allowed(site.allowed_origins, request.headers.get("origin")):
-        raise HTTPException(403, "Origin not allowed for this site")
+    origin = _origin_of(request)
+    _origin_gate(site, origin)
 
     # H1 (same as the JSON path): constant-time compare — no timing side channel.
     if not secrets.compare_digest(key, site.signed_key):
@@ -173,14 +293,16 @@ async def capture_form(request: Request) -> Response:
         # a limiter key). Truncated: paw_page is caller-controlled text.
         submitter_ref=f"form:{page}"[:256] if page else "form",
         rate_key=_rate_key(request),  # server-derived; the real per-IP limiter key
+        origin=origin,
+        known_origins=_effective_origins(site),
     )
 
-    # 303 back to the site. The Location is the VALIDATED Origin (already pinned
-    # against site.allowed_origins above) + the RELATIVE redirect path, so the
-    # browser can only land back on the submitting site. origin_allowed fails
-    # closed on a missing Origin, so it is always present here.
-    origin = (request.headers.get("origin") or "").rstrip("/")
-    return Response(status_code=303, headers={"Location": f"{origin}{redirect}"})
+    # 303 back to the site. The base is resolved by ``_redirect_base`` — an
+    # allowlisted Origin, else the site's own canonical url, else relative — so the
+    # Location is never a host the caller chose. The redirect path itself already
+    # passed ``_safe_relative_redirect`` above.
+    location = f"{_redirect_base(site, origin)}{redirect}"
+    return Response(status_code=303, headers={"Location": location})
 
 
 # Leads is a Sites surface, so its plan gate is the "sites" feature (go+) — the

--- a/ee/pocketpaw_ee/cloud/leads/router.py
+++ b/ee/pocketpaw_ee/cloud/leads/router.py
@@ -225,8 +225,17 @@ def _safe_relative_redirect(path: str) -> bool:
     """Open-redirect guard for the native-form 303: the redirect target must be a
     RELATIVE path on the submitting site. Rejects absolute URLs (no leading "/"),
     protocol-relative ("//host"), backslash tricks, embedded schemes, and CR/LF
-    (header injection). The accepted value is later prefixed with the VALIDATED
-    request Origin, so the browser can only ever land back on the pinned site."""
+    (header injection).
+
+    This carries MORE weight since the origin pin became opt-in (2026-08-13). It
+    used to be the second of two locks — the accepted path was prefixed with an
+    Origin that had already been pinned, so a bad path still could not leave the
+    site. Now ``_redirect_base`` resolves to "" for a site with no canonical url
+    yet (a draft, or an async build whose worker has not reported back), and on
+    that branch THIS FUNCTION IS THE ONLY LOCK: the accepted value becomes the
+    whole ``Location``. The ``//host`` and ``://`` rejections are what stop a
+    protocol-relative or absolute target there, so neither may be relaxed on the
+    grounds that something downstream re-checks the host. Nothing does."""
     if not path.startswith("/") or path.startswith("//"):
         return False
     if "\\" in path or "\r" in path or "\n" in path or "://" in path:

--- a/ee/pocketpaw_ee/cloud/leads/service.py
+++ b/ee/pocketpaw_ee/cloud/leads/service.py
@@ -83,7 +83,11 @@ from pocketpaw.security.injection_scanner import (
     get_injection_scanner,
 )
 from pocketpaw.sites_capture import contact_form
-from pocketpaw.sites_capture.ingest import interpolate_mapping, is_honeypot_tripped
+from pocketpaw.sites_capture.ingest import (
+    interpolate_mapping,
+    is_honeypot_tripped,
+    origin_allowed,
+)
 from pocketpaw.sites_capture.models import SiteEventMapping
 from pocketpaw_ee.cloud.leads.domain import Lead
 from pocketpaw_ee.cloud.models.lead import Lead as _LeadDoc
@@ -103,6 +107,8 @@ def _to_domain(doc: _LeadDoc) -> Lead:
         form_type=doc.form_type,
         properties=doc.properties,
         submitter_ref=doc.source.submitter_ref if doc.source else "",
+        origin=doc.source.origin if doc.source else "",
+        origin_unrecognized=bool(doc.source and doc.source.origin_unrecognized),
         created_at=getattr(doc, "createdAt", None),
     )
 
@@ -239,6 +245,8 @@ async def capture(
     payload: dict[str, Any],
     submitter_ref: str,
     rate_key: str = "",
+    origin: str = "",
+    known_origins: list[str] | None = None,
 ) -> Lead | None:
     """Harden + persist one submission as a tenant-scoped Lead. Returns None
     when the submission is dropped (honeypot / rate-limited / injection screen /
@@ -248,7 +256,21 @@ async def capture(
     the client host). ``submitter_ref`` is only an opaque label. An empty
     ``rate_key`` falls back to a fixed sentinel — never to ``submitter_ref`` —
     so a missing client host collapses to one shared bucket rather than handing
-    the caller a fresh bucket per request."""
+    the caller a fresh bucket per request.
+
+    ``origin`` is the submitting page's ``Origin`` header, recorded on the lead for
+    attribution. It is NOT a gate here: the router owns the (opt-in,
+    ``Site.enforce_origin``) enforcement decision, and by default a submission from
+    an unrecognized host is accepted and flagged rather than dropped. Passing it is
+    what lets an owner see that leads are arriving from somewhere they did not
+    expect — the visibility that replaces the old silent 403.
+
+    ``known_origins`` is the set the flag is judged against, and the router passes
+    its DERIVED set (``allowed_origins`` plus the site's own url host and attached
+    custom domains) rather than letting this re-read the stored field. The two must
+    agree: if the gate accepts a host the flag then marks unrecognized, the flag
+    fires on a site's own normal traffic and stops meaning anything. Defaults to the
+    stored field for a caller with nothing better."""
     effective_rate_key = rate_key or "unknown"
     if is_honeypot_tripped(payload, honeypot_field=site.honeypot_field):
         _emit_drop_audit(site=site, form_type=form_type, reason="honeypot")
@@ -292,6 +314,14 @@ async def capture(
             site_id=site.script_name,
             submitter_ref=submitter_ref,
             rate_key=effective_rate_key,
+            origin=origin,
+            # Evaluated NOW, against the allowlist as it stands at capture time, so
+            # the flag keeps meaning "unrecognized when it arrived" even after the
+            # owner later connects the domain it came from.
+            origin_unrecognized=bool(origin)
+            and not origin_allowed(
+                site.allowed_origins if known_origins is None else known_origins, origin
+            ),
         ),
     )
     await doc.insert()

--- a/ee/pocketpaw_ee/cloud/models/lead.py
+++ b/ee/pocketpaw_ee/cloud/models/lead.py
@@ -32,6 +32,20 @@ class LeadSource(BaseModel):
     site_id: str
     submitter_ref: str = ""  # opaque, caller-supplied LABEL (not PII, not the limiter key)
     rate_key: str = ""  # server-derived host hash; the per-IP limiter buckets on this
+    # The submitting page's ``Origin``, as sent ("" when the browser sent none).
+    #
+    # Recorded rather than enforced: since ``Site.enforce_origin`` defaults off, a
+    # submission from an unexpected host is ACCEPTED and attributed instead of
+    # 403'd. That is the trade the default makes — an owner who wants to know where
+    # leads came from can read it here, and one who wants the old hard gate flips
+    # ``enforce_origin``. Server-derived (read off the request headers), never a
+    # body field, so a caller cannot forge the recorded value independently of the
+    # header the browser actually sent.
+    origin: str = ""
+    # True when an origin WAS sent and it is not on the site's allowlist. Precomputed
+    # at capture because the allowlist can change afterwards, and a lead's flag
+    # should mean "unrecognized when it arrived" rather than "unrecognized today".
+    origin_unrecognized: bool = False
 
 
 class Lead(TimestampedDocument):

--- a/ee/pocketpaw_ee/cloud/models/site.py
+++ b/ee/pocketpaw_ee/cloud/models/site.py
@@ -396,6 +396,35 @@ class Site(TimestampedDocument):
     import_report: dict[str, Any] = Field(default_factory=dict)
     # Capture hardening config (mirrors sites_capture.SiteFormConfig fields).
     allowed_origins: list[str] = Field(default_factory=list)
+    # Whether ``allowed_origins`` HARD-GATES lead capture, or is only a signal.
+    #
+    # Default OFF, deliberately, and this is the Formspree/Basin/Getform posture
+    # rather than a relaxation of ours by accident. Two facts make the pin close to
+    # worthless as a gate on the capture path while keeping all of its ability to
+    # break a customer's contact form:
+    #
+    #   * The credential it guards is ALREADY PUBLIC on three of the four engines.
+    #     html / react / static-svelte all ship ``paw_key`` as a hidden input in the
+    #     page source, so "the signed key" is a site IDENTIFIER that anyone can read,
+    #     not a secret the origin pin is protecting.
+    #   * ``Origin`` binds BROWSERS ONLY. Any curl/script forges it in one flag, so
+    #     the pin never stopped a determined spammer — it stopped the honest case.
+    #
+    # What it DID do reliably was 403 real submissions: a site whose doc predates
+    # the deployed-host stamping, an async (react) build whose Site row was inserted
+    # with ``url=""`` before the worker filled it in, an apex/``www.`` mismatch, a
+    # preview URL, a page opened over ``file://`` (Origin: null). Every one of those
+    # fails CLOSED, and on the native-form path the visitor — the customer's actual
+    # prospect — is shown a raw JSON 403 instead of a thank-you page.
+    #
+    # So the controls that survive are the ones that work on a public endpoint with
+    # a public key: the honeypot, the per-(scope, minute) rate limit, the injection
+    # screen, and the payload cap. Origin becomes an ATTRIBUTABLE SIGNAL — recorded
+    # on every lead (``LeadSource.origin``) so an owner can see where submissions
+    # came from — and a per-site opt-in for anyone who wants the strict behaviour
+    # back. Existing rows read the default and are therefore un-gated, which is the
+    # intended migration: they were the ones silently dropping leads.
+    enforce_origin: bool = False
     signed_key: str = ""
     rate_limit_per_min: int = 60
     per_ip_limit_per_min: int = 10

--- a/ee/pocketpaw_ee/cloud/pockets/service.py
+++ b/ee/pocketpaw_ee/cloud/pockets/service.py
@@ -2272,6 +2272,82 @@ async def set_react_source_file(
     return await _resolved_wire_dict(doc, user_id)
 
 
+async def set_html_source_file(
+    pocket_id: str,
+    user_id: str,
+    *,
+    file_path: str,
+    new_source: str,
+    create: bool = False,
+) -> dict:
+    """Write ONE file in an html-engine pocket's ``source`` map and persist it.
+
+    The html peer of ``set_react_source_file``. Until HE-10 the html track had no
+    per-file writer at all: ``set_imported_source`` (below) replaces the WHOLE map
+    and is the crawler's, taking an explicit ``workspace_id`` with no viewer check
+    because it runs in the background off a request. Pointing an agent edit at it
+    would have swapped a site's entire contents to change one headline, and done so
+    without the ``_check_domain_edit_access`` every other authored write runs.
+
+    Access mirrors ``update`` / ``set_react_source_file``: explicit
+    ``(pocket_id, user_id)`` with ``_check_domain_edit_access`` (owner /
+    shared_with / workspace-visible). A missing pocket raises ``NotFound``.
+
+    ``create`` carries the same inverted contract as the react peer, for the same
+    reason — "add an about page" needs a new FILE plus a link from ``index.html``:
+
+      * ``create=False`` (default) — ``file_path`` MUST already exist, else
+        ``NotFound`` (404). A typo'd path is never a silent create.
+      * ``create=True`` — ``file_path`` must NOT already exist, else
+        ``ValidationError`` (422). Silently overwriting a real page is worse than
+        a rejected call the agent can retry.
+
+    A non-html pocket (``engine != "html"`` or no ``source`` map) is a
+    ``ValidationError`` (422, ``pocket.not_html_site``) rather than a write against
+    the wrong content model.
+
+    Returns the resolved wire dict every other write returns. Like the react peer
+    and unlike the svelte one it does NOT return the file's prior contents: that
+    value exists there only so the caller can roll back a failed republish, and
+    this lane has no republish to fail — an html publish runs no build and no
+    smoke gate, so there is no gate to be rejected by. Persisting the draft IS
+    the whole job.
+    """
+    doc = await _fetch_pocket(pocket_id)
+    _check_domain_edit_access(_pocket_to_domain(doc), user_id)
+
+    if getattr(doc, "engine", "ripple") != "html" or not isinstance(doc.source, dict):
+        raise ValidationError(
+            "pocket.not_html_site",
+            "This pocket is not an html Paw Site — it has no raw source map to edit.",
+        )
+    exists = file_path in doc.source
+    if create and exists:
+        raise ValidationError(
+            "pocket.html_file_exists",
+            f"`{file_path}` already exists in this site's source map. Edit it "
+            "without `create` instead of overwriting it.",
+        )
+    if not create and not exists:
+        raise NotFound("site_component", file_path)
+
+    # Reassign a fresh dict so Beanie tracks the change (in-place mutation of a
+    # dict field is not always detected as dirty by the ODM) — same note as
+    # ``set_svelte_source_file``.
+    updated = dict(doc.source)
+    updated[file_path] = new_source
+    doc.source = updated
+    await doc.save()
+    await emit(PocketUpdated(data=await _pocket_event_payload(doc)))
+    # Branch primitive (BP-3): a source-map edit ALSO writes a draft
+    # ArtifactVersion snapshotting the FULL map, so the edit is a reviewable draft
+    # a later publish promotes. The helper is engine-agnostic despite its name (it
+    # snapshots ``doc.source`` whatever engine wrote it) — the same reuse
+    # ``set_react_source_file`` makes.
+    await _record_pocket_svelte_draft_version(doc, author=user_id)
+    return await _resolved_wire_dict(doc, user_id)
+
+
 async def set_imported_source(
     pocket_id: str,
     *,

--- a/ee/pocketpaw_ee/sites/html_paths.py
+++ b/ee/pocketpaw_ee/sites/html_paths.py
@@ -1,0 +1,151 @@
+# html_paths.py — the ONE place the html-track source-map path policy lives.
+#
+# Created: 2026-08-13 (feat/sites-html-edit-lane, HE-10) — the html peer of
+# ``react_paths.py``, written for the same reason that module was extracted: the
+# EDIT lane is a second writer of a source map that until now only ``create``
+# wrote, and a second writer carrying its own copy of the guard is how the guard
+# rots.
+#
+# It is deliberately NOT a copy of ``react_paths``. The two engines have opposite
+# shapes, and copying react's rules onto html would have rejected almost every
+# legitimate html edit:
+#
+#   * react's authored files must live under ``src/`` or ``public/`` — everything
+#     at the project root belongs to a generated build shell. An html site HAS no
+#     build shell: ``html-scaffold.ts`` writes the author's map verbatim into the
+#     servable directory, so ``index.html`` and ``styles.css`` at the ROOT are the
+#     normal case. Porting react's positive rule here would reject the entry
+#     document of every html site.
+#   * react reserves four generator-owned files plus ``src/paw/``. html reserves
+#     exactly ONE namespace, ``_paw/``, and reserves nothing else — there is no
+#     ``package.json`` on this track to protect, because there is no build.
+#
+# So what transfers is the STRUCTURE (normalize first, one verdict function, no
+# dependency on the cloud error hierarchy) and not the rules.
+"""html-track source-map path policy for Paw Sites.
+
+An html-engine pocket's ``source`` is a ``{relative_path: file_contents}`` map of
+raw HTML/CSS/JS that the paw-sites generator materializes **verbatim** into the
+directory the edge serves. There is no framework, no build, and no generated
+shell the author writes on top of — the map IS the site.
+
+That leaves exactly two rules, both mirrored from ``html-scaffold.ts``'s
+``assertWritablePath``, which throws at materialize time:
+
+1. **The path may not escape the project root.** ``../etc/passwd`` and absolute
+   paths are rejected. The generator asserts this too; checking here turns a
+   build-time throw far from the authoring turn into an actionable error.
+
+2. **``_paw/`` belongs to the generator.** The HE-7/HE-8 editing artifacts live
+   there — most importantly ``_paw/edit-manifest.json``, the uid→byteSpan map the
+   native editor drives its write path from. An author who could write under
+   ``_paw/`` could shadow that manifest, and a shadowed manifest does not fail
+   loudly: it points valid uids at wrong byte offsets, so the next native edit
+   splices into the middle of a tag.
+
+Both rules apply to the NORMALIZED path (``posixpath``, not ``os.path`` —
+source-map keys are POSIX-style project-relative paths whatever the host OS is),
+because a guard a trivial spelling defeats is not a guard: ``_paw/./x`` and
+``_paw\\x`` and ``foo/../_paw/x`` all resolve into the reserved namespace.
+"""
+
+from __future__ import annotations
+
+import posixpath
+
+# The namespace the html generator owns. Mirrors ``RESERVED_NAMESPACE`` in
+# paw-sites' html-scaffold.ts, which throws on a collision. Stored WITH the
+# trailing slash so the guard matches the directory and not a sibling that merely
+# shares the prefix — ``_pawprint.html`` is a perfectly ordinary page name and
+# must stay writable.
+HTML_RESERVED_PREFIX = "_paw/"
+
+
+def normalize_html_path(path: str) -> str:
+    """Collapse a source-map key to the path the generator will actually write.
+
+    Backslashes become forward slashes (a Windows-authored key, or an agent that
+    guessed the separator) and ``.``/``..`` segments collapse. The generator
+    normalizes the same way before it throws, so normalizing first is what makes
+    this module agree with it.
+    """
+    return posixpath.normpath(path.replace("\\", "/"))
+
+
+def is_reserved_html_path(path: str) -> bool:
+    """True when ``path`` resolves onto the generator-owned ``_paw/`` namespace.
+
+    Matches the directory itself as well as anything under it, so neither
+    ``_paw`` nor ``_paw/edit-manifest.json`` is writable.
+    """
+    norm = normalize_html_path(path)
+    return norm == HTML_RESERVED_PREFIX.rstrip("/") or norm.startswith(HTML_RESERVED_PREFIX)
+
+
+def escapes_project_root(path: str) -> bool:
+    """True when ``path`` resolves outside the project directory.
+
+    Two ways out, and both are checked on the NORMALIZED path: a ``..`` that
+    survives normalization (``../x``, ``a/../../x``), and an absolute path
+    (``/etc/passwd``). A ``..`` in the middle that normalization absorbs
+    (``a/../b`` → ``b``) is not an escape and is allowed through.
+    """
+    norm = normalize_html_path(path)
+    return norm == ".." or norm.startswith("../") or posixpath.isabs(norm)
+
+
+def html_path_rejection(path: str) -> str | None:
+    """Return why ``path`` may not be written, or ``None`` when it may.
+
+    The single-path verdict the edit lane needs. Checked escape-first: a path that
+    leaves the project is the more fundamental problem, and naming the reserved
+    namespace for ``../_paw/x`` would point the author at the wrong rule.
+
+    Returns a message fragment the caller wraps in its own error, so the error
+    code stays the caller's choice (the sites service raises two distinct codes)
+    and this module keeps no dependency on the cloud error hierarchy — the same
+    contract ``react_paths.react_path_rejection`` holds.
+    """
+    norm = normalize_html_path(path)
+    if escapes_project_root(path):
+        return (
+            f"`{path}` resolves to `{norm}`, which is outside the site directory. "
+            "An html site's files are project-relative — `index.html`, "
+            "`styles.css`, `about/index.html`. A path that climbs out of the "
+            "project with `..`, or an absolute path, is not writable."
+        )
+    if is_reserved_html_path(path):
+        return (
+            f"`{path}` resolves to `{norm}`, which is inside the generator-owned "
+            "`_paw/` namespace. That is where the editing artifacts live — "
+            "`_paw/edit-manifest.json` maps each editable element to a byte range "
+            "in your source, and the visual editor writes through it. Shadowing "
+            "it would point valid elements at wrong offsets. Write your own files "
+            "anywhere else, including the project root."
+        )
+    if not norm or norm == ".":
+        return (
+            f"`{path}` does not name a file. Give the path relative to the site "
+            "root, like `index.html` or `css/site.css`."
+        )
+    return None
+
+
+def reserved_html_keys(source: dict[str, object]) -> list[str]:
+    """Return the source-map keys that collide with the generator-owned namespace.
+
+    The whole-map form, the peer of ``react_paths.reserved_react_keys``. Returns
+    the keys AS THE AUTHOR SPELLED THEM (not normalized) so the error points at
+    something findable in the payload.
+    """
+    return sorted(key for key in source if is_reserved_html_path(key))
+
+
+__all__ = [
+    "HTML_RESERVED_PREFIX",
+    "escapes_project_root",
+    "html_path_rejection",
+    "is_reserved_html_path",
+    "normalize_html_path",
+    "reserved_html_keys",
+]

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -870,6 +870,11 @@ from pocketpaw_ee.sites.dto import (
 )
 from pocketpaw_ee.sites.engines import content_key, is_source_engine, normalize_engine
 from pocketpaw_ee.sites.generator_client import BuildResult, GeneratorClient
+from pocketpaw_ee.sites.html_paths import (
+    html_path_rejection,
+    is_reserved_html_path,
+    normalize_html_path,
+)
 from pocketpaw_ee.sites.react_paths import is_reserved_react_path, react_path_rejection
 
 logger = logging.getLogger(__name__)
@@ -5408,6 +5413,181 @@ async def edit_react_component(
     # native editor's shadow-render, which reads a SvelteKit build; react has no
     # such artifact, so warming one here would build a site nothing reads.
     return {"pocket_id": pocket_id, "component_path": component_path, "created": create}
+
+
+async def edit_html_file(
+    *,
+    user_id: str,
+    pocket_id: str,
+    file_path: str,
+    new_source: str | None = None,
+    edits: list[dict[str, str]] | None = None,
+    create: bool = False,
+    _pockets: Any = None,
+) -> dict[str, Any]:
+    """Write ONE file of an html Paw Site pocket and leave it as a reviewable DRAFT.
+
+    The chat-agent entry point for a targeted html edit (HE-10), and the third and
+    last engine to get one. Before this the html track had NO chat edit path at
+    all: ``edit_svelte_component`` raises ``pocket.not_svelte_site`` on an html
+    pocket and ``edit_react_component`` raises ``pocket.not_react_site``, so the
+    agent's only move on "change the phone number in the footer" was a second
+    ``create_html_site`` — a SECOND site pocket, at a second URL, instead of a
+    change to the one the user is looking at. That is the exact hole RX-3 closed
+    for react, reopened one engine over.
+
+    **This is a FILE edit, not a component edit, and the name says so.** svelte and
+    react both have a component model, so their tools take a ``component_path``. An
+    html site has none: ``html-scaffold.ts`` writes the author's map verbatim into
+    the directory the edge serves, so what exists is files — ``index.html``,
+    ``css/site.css``, ``about/index.html``. Calling the parameter
+    ``component_path`` here would have been consistency bought by lying about the
+    content model.
+
+    The edit is expressed one of two ways (exactly one is required), the same
+    contract both siblings use so the agent's instinct transfers:
+
+      * ``edits`` — a list of ``[{old_string, new_string}, ...]`` search/replace
+        blocks applied to the file's CURRENT contents via the shared
+        :func:`apply_edits`, which requires each ``old_string`` to match exactly
+        once and raises a clear, retry-able ``ValidationError`` otherwise. PREFERRED
+        for small changes: the agent emits only the diff. On this track that saving
+        is at its largest — an html page is one flat document with no component
+        decomposition, so a "full rewrite" means re-emitting the entire site page.
+      * ``new_source`` — the FULL new file contents, used as-is. For large rewrites,
+        and the ONLY form accepted with ``create=True`` (there is nothing to diff
+        against a file that does not exist yet).
+
+    ``create=True`` mints a NEW path instead of editing an existing one — "add an
+    about page" needs ``about.html`` PLUS a link from ``index.html``. It INVERTS the
+    existence check rather than relaxing it (``create=False`` requires the path to
+    exist, ``create=True`` requires it not to), so exactly one of the two mistakes
+    is impossible in each mode.
+
+    **DRAFT-ONLY. This does NOT republish**, matching ``edit_react_component`` and
+    ``apply_leaf_edits`` rather than ``edit_svelte_component``. The svelte tool
+    republishes because it has a workerd smoke gate to catch a broken edit and a
+    rollback to run when the gate fires. html has NEITHER: ``needs_node_build``
+    is False for html, so there is no build, no smoke render, and nothing that can
+    reject an edit before it deploys. A republish here would therefore push
+    unvalidated markup straight to a live customer site with no gate in between —
+    strictly worse than leaving it as a draft the user publishes deliberately. So
+    persisting the edited draft IS the whole job, and publishing stays the user's
+    call. A future reader looking at this and reaching for the missing republish
+    should read this paragraph first.
+
+    The path guard is load-bearing, not hygiene, and it is html's own — see
+    :mod:`pocketpaw_ee.sites.html_paths` for why react's rules could not be reused
+    (an html site's files legitimately live at the project ROOT, which react's
+    ``src/``-or-``public/`` rule would reject outright). Two rejections: a path that
+    escapes the site directory, and the generator-owned ``_paw/`` namespace, where
+    ``_paw/edit-manifest.json`` maps each editable element to a byte range. An
+    author who could shadow that manifest would not break anything loudly — the
+    next NATIVE editor edit would splice at wrong offsets, landing mid-tag.
+
+    Raises, all BEFORE anything is written:
+      * ``ValidationError("site_edit.invalid_args")`` — not exactly one of
+        ``edits`` / ``new_source``;
+      * ``ValidationError("site_edit.create_needs_source")`` — ``create=True``
+        without ``new_source``;
+      * ``ValidationError("site_edit.reserved_path")`` — the ``_paw/`` namespace;
+      * ``ValidationError("site_edit.path_outside_source")`` — escapes the site dir;
+      * ``ValidationError("pocket.not_html_site")`` — not an html site pocket;
+      * ``NotFound("site_component")`` — ``create=False`` and the path is absent;
+      * ``ValidationError("pocket.html_file_exists")`` — ``create=True`` and the
+        path is present;
+      * whatever :func:`apply_edits` raises on a 0-match / ambiguous ``old_string``.
+
+    ``_pockets`` is an injectable seam for the pockets service so the orchestration
+    is unit-testable with no Bun / Cloudflare in sight — there is nothing else to
+    inject, because there is no build.
+
+    Takes NO ``workspace_id``, for the same reason ``edit_react_component`` does
+    not: tenancy is resolved by the pockets service off ``user_id`` (its public
+    ``get`` raises Forbidden itself), and the workspace is only needed to look up
+    the Site doc whose builder origin a REPUBLISH must re-apply — which this lane
+    does not do.
+
+    Returns ``{pocket_id, file_path, created}``.
+    """
+    if _pockets is not None:
+        pockets_service = _pockets
+    else:
+        from pocketpaw_ee.cloud.pockets import service as pockets_service  # type: ignore[no-redef]
+
+    # Exactly one of the two edit shapes (mirrors both siblings).
+    if (edits is None) == (new_source is None):
+        raise ValidationError(
+            "site_edit.invalid_args",
+            "edit_html_file requires exactly one of `edits` (a targeted "
+            "search/replace diff) or `new_source` (a full file rewrite).",
+        )
+    if create and new_source is None:
+        raise ValidationError(
+            "site_edit.create_needs_source",
+            "Creating a new file needs `new_source` — the full contents of the new "
+            "file. There is nothing for `edits` to search against.",
+        )
+
+    # The path guard. FIRST, before the pocket is even read: a call that names an
+    # unwritable path is rejected on the path alone, so no amount of pocket state
+    # can make it land.
+    if (reason := html_path_rejection(file_path)) is not None:
+        code = (
+            "site_edit.reserved_path"
+            if is_reserved_html_path(file_path)
+            else "site_edit.path_outside_source"
+        )
+        raise ValidationError(code, reason)
+
+    # Store under the NORMALIZED key, not the one the agent spelled. The generator
+    # normalizes before it writes (``assertSafeRelPath`` → ``join(outDir, rel)``), so
+    # two keys that normalize to the same path are ONE file on disk. Persisting the
+    # raw spelling would let ``create=True`` on ``./index.html`` pass the
+    # not-already-present check, land a SECOND map entry, and then have both entries
+    # materialize onto ``index.html`` — leaving the live home page decided by dict
+    # iteration order. Normalizing here also makes ``./index.html`` and
+    # ``img\\logo.svg`` resolve to the existing file the author meant, instead of
+    # 404ing on a path that is present under its canonical spelling.
+    file_path = normalize_html_path(file_path)
+
+    # The pockets service's PUBLIC get raises NotFound / Forbidden itself (entity
+    # isolation) — a missing / cross-tenant pocket surfaces as 404 / 403.
+    pocket = await pockets_service.get(pocket_id, user_id)
+    if (pocket.get("engine") or "ripple") != "html" or not isinstance(pocket.get("source"), dict):
+        raise ValidationError(
+            "pocket.not_html_site",
+            "This pocket is not an html Paw Site — it has no raw source map to edit.",
+        )
+    source_map = pocket["source"]
+    # The MISSING-path half of the inversion is enforced here as well as at the
+    # write, because the ``edits`` branch below indexes the map: without it a typo'd
+    # path is a KeyError instead of the NotFound the caller has to relay. The
+    # EXISTING-path half is deliberately NOT duplicated — nothing here reads the
+    # file on the create path, so the check would only be a second copy of a rule
+    # the write chokepoint already owns for every caller. (Same reasoning, and the
+    # same proven-by-mutation result, as ``edit_react_component``.)
+    if not create and file_path not in source_map:
+        raise NotFound("site_component", file_path)
+
+    if edits is not None:
+        # apply_edits raises ValidationError (clear, retry-able) on any match-count
+        # violation, BEFORE anything is persisted.
+        new_source = apply_edits(source_map[file_path], edits)
+
+    assert new_source is not None  # narrowing: the arg checks above guarantee it
+    await pockets_service.set_html_source_file(
+        pocket_id,
+        user_id,
+        file_path=file_path,
+        new_source=new_source,
+        create=create,
+    )
+
+    # NO publish, NO enqueue, NO native pre-warm — see the DRAFT-ONLY paragraph
+    # above. The pre-warm serves the svelte native editor's shadow-render, which
+    # reads a SvelteKit build; html has no such artifact.
+    return {"pocket_id": pocket_id, "file_path": file_path, "created": create}
 
 
 async def _latest_site_for_pocket(workspace_id: str, pocket_id: str) -> _SiteDoc | None:

--- a/src/pocketpaw/bundled_skills/_bundled/skills/pocketpaw-create-paw-site/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/skills/pocketpaw-create-paw-site/SKILL.md
@@ -103,6 +103,45 @@ confirming the message was sent — as another entry in the `source` map.
 No JavaScript: this is a plain native browser POST, so never add an onSubmit
 handler or a `fetch`.
 
+### Changing an html site that already exists
+
+When the user asks for a CHANGE to a site they already have — "shorten the
+headline", "fix the phone number in the footer", "add an about page" — call
+`edit_html_file`, not `create_html_site`. Calling create again mints a SECOND
+site pocket at a SECOND url and leaves the site they are looking at untouched,
+which reads to them as the change silently not working.
+
+```
+edit_html_file(
+  pocket_id = "<the existing site's pocket id>",
+  file_path = "index.html",
+  edits     = [{ "old_string": "555-0100", "new_string": "555-0199" }]
+)
+```
+
+Prefer `edits` (a list of `{old_string, new_string}` blocks, like the built-in
+Edit tool) over `new_source`. Each `old_string` must match the current file
+EXACTLY ONCE, so read the file first and copy the text verbatim; include enough
+surrounding context to be unique. On this track the saving is at its largest —
+an html page is one flat document, so "rewrite the file" means re-emitting the
+whole page to change a phone number.
+
+To ADD a page, call it twice: once with `create=true` and `new_source` for the
+new file, then once with `edits` on `index.html` to link to it.
+
+**Paths are the same ones you authored** — `index.html`, `styles.css`,
+`about.html`, `img/logo.svg`. Do not prefix with `src/`; that is the react
+track. The only unwritable path is the generated `_paw/` namespace.
+
+**Leave the form plumbing alone** unless the user is asking to change the form
+itself. The `action` and the hidden `paw_site_id` / `paw_key` / `paw_redirect`
+inputs are what make a submission arrive as a lead; a rewrite that drops them
+still renders and still submits, and every future enquiry goes nowhere.
+
+The edit is saved to the site's DRAFT — it is not published. Tell the user the
+change is in the draft they can preview under /sites and offer to publish it;
+only call `publish` when they ask.
+
 **Do not reach for this by default.** Unless the user explicitly wants raw
 HTML, use the copy-only `create_landing_site` path below.
 

--- a/tests/cloud/leads/test_router.py
+++ b/tests/cloud/leads/test_router.py
@@ -53,21 +53,198 @@ async def _site(ws="ws1", site_id="site_1") -> Site:
     return site
 
 
-@pytest.mark.asyncio
-async def test_capture_rejects_wrong_origin(mongo_db, capture_app):
-    await _site()
+async def _capture_json(capture_app, *, origin, site_id="site_1"):
+    headers = {"origin": origin} if origin is not None else {}
     async with AsyncClient(transport=ASGITransport(app=capture_app), base_url="http://t") as c:
-        resp = await c.post(
-            "/api/v1/sites/site_1/capture",
+        return await c.post(
+            f"/api/v1/sites/{site_id}/capture",
             json={
                 "form_type": "AppointmentRequest",
                 "payload": {"full_name": "Sam"},
                 "submitter_ref": "ip1",
                 "signed_key": "key_ok",
             },
-            headers={"origin": "https://evil.example.com"},
+            headers=headers,
         )
+
+
+@pytest.mark.asyncio
+async def test_capture_accepts_an_unrecognized_origin_and_flags_it(mongo_db, capture_app):
+    """THE DEFAULT FLIPPED, deliberately. This used to assert 403.
+
+    The origin pin guards a credential that is ALREADY PUBLIC on three of the four
+    engines (``paw_key`` ships as a hidden input in the page source), and ``Origin``
+    constrains browsers only — any script forges it. So as a gate it did not stop a
+    determined spammer; it 403'd real submissions whenever the allowlist and the
+    serving host disagreed (a doc predating deployed-host stamping, an async react
+    build inserted with ``url=""``, apex vs ``www.``, a preview URL, a ``file://``
+    open). Every one of those failed CLOSED, and on the native-form path the
+    customer's own prospect was shown a raw JSON 403.
+
+    So the submission is now ACCEPTED and ATTRIBUTED. The flag is what makes the
+    trade honest — the lead is not silently indistinguishable from an expected one.
+
+    Mutation: restore the unconditional ``origin_allowed`` gate in the router and
+    this fails."""
+    from pocketpaw_ee.cloud.leads import service as leads_service
+
+    site = await _site()
+    resp = await _capture_json(capture_app, origin="https://evil.example.com")
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["ok"] is True
+    leads = await leads_service.list_for_site(site.workspace, "site_1")
+    assert len(leads) == 1
+    assert leads[0].origin == "https://evil.example.com"
+    assert leads[0].origin_unrecognized is True
+
+
+@pytest.mark.asyncio
+async def test_capture_records_a_recognized_origin_without_flagging_it(mongo_db, capture_app):
+    """The other half: an expected origin is recorded too, and NOT flagged — so the
+    flag distinguishes rather than firing on everything."""
+    from pocketpaw_ee.cloud.leads import service as leads_service
+
+    site = await _site()
+    resp = await _capture_json(capture_app, origin="https://brightsmiledental.com")
+
+    assert resp.status_code == 200, resp.text
+    leads = await leads_service.list_for_site(site.workspace, "site_1")
+    assert leads[0].origin == "https://brightsmiledental.com"
+    assert leads[0].origin_unrecognized is False
+
+
+@pytest.mark.asyncio
+async def test_capture_still_403s_when_the_site_opts_into_enforcement(mongo_db, capture_app):
+    """The strict behaviour is not gone, it is OPT-IN. A site that flips
+    ``enforce_origin`` gets the old fail-closed gate back verbatim.
+
+    Mutation: drop the ``site.enforce_origin and`` guard's first operand (making the
+    gate unconditional) and the two tests above fail; delete the guard entirely and
+    this one fails. Both directions are covered."""
+    from pocketpaw_ee.cloud.leads import service as leads_service
+
+    site = await _site()
+    site.enforce_origin = True
+    await site.save()
+
+    resp = await _capture_json(capture_app, origin="https://evil.example.com")
+
     assert resp.status_code == 403
+    assert await leads_service.count_for_site(site.workspace, "site_1") == 0
+
+
+@pytest.mark.asyncio
+async def test_an_enforcing_site_still_fails_closed_on_a_missing_origin(mongo_db, capture_app):
+    """``origin_allowed`` fails closed on an absent header, and opting in must
+    preserve that — otherwise "strict" would be weaker than the old default against
+    the one caller that trivially omits the header."""
+    site = await _site()
+    site.enforce_origin = True
+    await site.save()
+
+    resp = await _capture_json(capture_app, origin=None)
+
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_capture_accepts_a_submission_with_no_origin_header_by_default(mongo_db, capture_app):
+    """A missing Origin is the ``file://`` / stripped-header case. Under the old
+    fail-closed default it was a 403; it is now an accepted, unflagged lead — there
+    is no origin to find unrecognized."""
+    from pocketpaw_ee.cloud.leads import service as leads_service
+
+    site = await _site()
+    resp = await _capture_json(capture_app, origin=None)
+
+    assert resp.status_code == 200, resp.text
+    leads = await leads_service.list_for_site(site.workspace, "site_1")
+    assert leads[0].origin == ""
+    assert leads[0].origin_unrecognized is False
+
+
+@pytest.mark.asyncio
+async def test_a_sites_own_deployed_host_is_never_unrecognized(mongo_db, capture_app):
+    """THE CASE THAT PRODUCED THE ORIGINAL 403 REPORT: a site deployed to
+    ``*.workers.dev`` whose ``allowed_origins`` still carried only the localhost
+    seed, so its own visitors were foreign to it.
+
+    ``allowed_origins`` is stamped by the publish deploy path, and there are real
+    ways to land a Site row that never got the stamp — a draft/preview publish
+    returns before it, an async react build inserts with ``url=""`` and fills the
+    url in later, and rows predating the stamping keep the seed. Deriving the
+    effective set from the site's own ``url`` closes all of them at once.
+
+    Mutation: make ``_effective_origins`` return ``site.allowed_origins`` unchanged
+    and this fails."""
+    from pocketpaw_ee.cloud.leads import service as leads_service
+
+    site = await _site()
+    site.allowed_origins = ["localhost", "127.0.0.1"]  # the un-stamped seed
+    site.url = "https://bright.workers.dev"
+    await site.save()
+
+    resp = await _capture_json(capture_app, origin="https://bright.workers.dev")
+
+    assert resp.status_code == 200, resp.text
+    leads = await leads_service.list_for_site(site.workspace, "site_1")
+    assert leads[0].origin_unrecognized is False, (
+        "a site's own deployed host was recorded as unrecognized"
+    )
+
+
+@pytest.mark.asyncio
+async def test_an_attached_custom_domain_is_never_unrecognized(mongo_db, capture_app):
+    """Same derivation, other source. ``add_domain`` appends to ``allowed_origins``,
+    but a row whose domain was attached by any path that did not is still the site's
+    own domain — and its visitors are its own."""
+    from pocketpaw_ee.cloud.leads import service as leads_service
+    from pocketpaw_ee.cloud.models.site import SiteDomain
+
+    site = await _site()
+    site.allowed_origins = ["localhost"]
+    site.domains = [SiteDomain(hostname="northdental.example", status="live")]
+    await site.save()
+
+    resp = await _capture_json(capture_app, origin="https://northdental.example")
+
+    assert resp.status_code == 200, resp.text
+    leads = await leads_service.list_for_site(site.workspace, "site_1")
+    assert leads[0].origin_unrecognized is False
+
+
+@pytest.mark.asyncio
+async def test_an_enforcing_site_accepts_its_own_deployed_host(mongo_db, capture_app):
+    """The derivation has to reach the GATE too, not just the flag. A site that opts
+    into enforcement while carrying an un-stamped allowlist would otherwise 403 its
+    own pages — the strict mode would be unusable exactly where it is wanted."""
+    site = await _site()
+    site.allowed_origins = ["localhost"]
+    site.url = "https://bright.workers.dev"
+    site.enforce_origin = True
+    await site.save()
+
+    resp = await _capture_json(capture_app, origin="https://bright.workers.dev")
+
+    assert resp.status_code == 200, resp.text
+
+
+@pytest.mark.asyncio
+async def test_the_derivation_does_not_admit_an_unrelated_host(mongo_db, capture_app):
+    """The widening is bounded: only hosts WE wrote (the deploy url, attached
+    domains) join the set, so a third-party origin is still unrecognized."""
+    from pocketpaw_ee.cloud.leads import service as leads_service
+
+    site = await _site()
+    site.url = "https://bright.workers.dev"
+    await site.save()
+
+    resp = await _capture_json(capture_app, origin="https://evil.example.com")
+
+    assert resp.status_code == 200, resp.text
+    leads = await leads_service.list_for_site(site.workspace, "site_1")
+    assert leads[0].origin_unrecognized is True
 
 
 @pytest.mark.asyncio
@@ -274,15 +451,90 @@ async def test_capture_form_non_relative_redirect_is_400(mongo_db, capture_app, 
 
 
 @pytest.mark.asyncio
-async def test_capture_form_wrong_origin_is_403(mongo_db, capture_app):
-    await _form_site()
+async def test_capture_form_accepts_an_unrecognized_origin(mongo_db, capture_app):
+    """The native-form half of the flipped default, and the one that motivated it:
+    here the 403 was rendered TO THE VISITOR as raw JSON. A prospect filling in a
+    contact form saw ``{"detail":"Origin not allowed for this site"}`` instead of a
+    thank-you page, and the site owner saw no lead and no error."""
+    from pocketpaw_ee.cloud.leads import service as leads_service
+
+    site = await _form_site()
     async with AsyncClient(transport=ASGITransport(app=capture_app), base_url="http://t") as c:
         resp = await c.post(
             "/api/v1/capture/form",
             data=_form_fields(),
             headers={"origin": "https://evil.example.com"},
         )
+
+    assert resp.status_code == 303
+    assert await leads_service.count_for_site(site.workspace, "site_form") == 1
+
+
+@pytest.mark.asyncio
+async def test_capture_form_redirects_to_the_site_not_the_claimed_origin(mongo_db, capture_app):
+    """THE OPEN REDIRECT THE FLIPPED DEFAULT WOULD OTHERWISE HAVE OPENED.
+
+    The 303 Location used to be the request Origin verbatim, which was safe ONLY
+    because the origin had just been pinned. With the pin opt-in, echoing it back
+    would let anyone POST with ``Origin: https://evil.example.com`` and have us send
+    the browser there. ``_redirect_base`` therefore falls back to the site's OWN url
+    whenever the origin is not allowlisted.
+
+    Mutation: return ``origin`` unconditionally from ``_redirect_base`` and this
+    fails."""
+    site = await _form_site()
+    site.url = "https://bright.workers.dev"
+    await site.save()
+
+    async with AsyncClient(transport=ASGITransport(app=capture_app), base_url="http://t") as c:
+        resp = await c.post(
+            "/api/v1/capture/form",
+            data=_form_fields(),
+            headers={"origin": "https://evil.example.com"},
+        )
+
+    assert resp.status_code == 303
+    location = resp.headers["location"]
+    assert location == "https://bright.workers.dev/thanks.html", location
+    assert "evil.example.com" not in location
+
+
+@pytest.mark.asyncio
+async def test_capture_form_keeps_the_visitor_on_a_recognized_origin(mongo_db, capture_app):
+    """An allowlisted origin IS used as the base, so a visitor on the custom domain
+    stays there instead of being bounced to the workers.dev url after submitting."""
+    site = await _form_site()
+    site.url = "https://bright.workers.dev"
+    await site.save()
+
+    async with AsyncClient(transport=ASGITransport(app=capture_app), base_url="http://t") as c:
+        resp = await c.post(
+            "/api/v1/capture/form",
+            data=_form_fields(),
+            headers={"origin": "https://brightsmiledental.com"},
+        )
+
+    assert resp.headers["location"] == "https://brightsmiledental.com/thanks.html"
+
+
+@pytest.mark.asyncio
+async def test_capture_form_403s_for_an_enforcing_site(mongo_db, capture_app):
+    """Opt-in strictness works on this path too."""
+    from pocketpaw_ee.cloud.leads import service as leads_service
+
+    site = await _form_site()
+    site.enforce_origin = True
+    await site.save()
+
+    async with AsyncClient(transport=ASGITransport(app=capture_app), base_url="http://t") as c:
+        resp = await c.post(
+            "/api/v1/capture/form",
+            data=_form_fields(),
+            headers={"origin": "https://evil.example.com"},
+        )
+
     assert resp.status_code == 403
+    assert await leads_service.count_for_site(site.workspace, "site_form") == 0
 
 
 @pytest.mark.asyncio

--- a/tests/ee/agent/test_sites_mcp_server/test_edit_html_file.py
+++ b/tests/ee/agent/test_sites_mcp_server/test_edit_html_file.py
@@ -1,0 +1,365 @@
+# tests/ee/agent/test_sites_mcp_server/test_edit_html_file.py
+# Created: 2026-08-13 (feat/sites-html-edit-lane, HE-10) — coverage for the
+# html-track edit tool ``edit_html_file`` on the in-process
+# ``pocketpaw_sites_manager`` server. Modelled on its react sibling
+# (test_edit_react_component.py), with the differences that matter to the agent:
+#
+#   1. Registration — the tool id rides the SAME server allowlist as publish + the
+#      five create tools + the two sibling edit tools, and the extension provider
+#      advertises it. Registration is not a formality here: it is the entire
+#      difference between "the agent can change an html site" and "the agent's only
+#      move is a second create_html_site that mints a SECOND site pocket at a
+#      SECOND url".
+#   2. THE ARGUMENT IS ``file_path``, NOT ``component_path``. An html site has no
+#      component model — ``html-scaffold.ts`` writes the source map verbatim into
+#      the served directory — so the schema names files. A test pins this because
+#      "make it consistent with the siblings" is the obvious refactor and it would
+#      break every call the description teaches.
+#   3. PATH GUIDANCE. react's tool tells the agent to write under ``src/``; doing
+#      that here produces a site whose pages the edge never serves, because an html
+#      site's entry document is ``index.html`` at the ROOT. The description has to
+#      say so explicitly, and a test asserts it does.
+#   4. NARRATION — the success body must not claim the change is published or live.
+#
+# There is deliberately NO SmokeGateFailed case: html runs no build at all, so
+# nothing can fail a smoke gate. The service-level persist + guard behaviour lives
+# in tests/ee/sites/test_html_file_edit.py; this file pins the agent surface.
+"""Tests for the html-track file edit tool (edit_html_file)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+
+@pytest.fixture(autouse=True)
+def _default_sites_plan():
+    """``edit_html_file`` runs the shared Sites plan gate before it touches the
+    service. These tests use synthetic workspace ids with no seeded Workspace doc,
+    so default the plan to one that unlocks Sites ("go"); the denial path has its
+    own test below."""
+    with patch(
+        "pocketpaw_ee.cloud.workspace.service.get_workspace_plan",
+        new=AsyncMock(return_value="go"),
+    ):
+        yield
+
+
+def _ok_result(*, created: bool = False, file_path: str = "index.html") -> dict:
+    """What the service returns on a successful edit."""
+    return {"pocket_id": "pk1", "file_path": file_path, "created": created}
+
+
+def _listed_tool(name: str = "edit_html_file"):
+    """Fetch the tool as the SDK would list it, or skip when the SDK is absent."""
+    import asyncio
+
+    from mcp import types
+    from pocketpaw_ee.agent.mcp_servers.sites import build_sites_manager_server
+
+    built = build_sites_manager_server()
+    if built is None:  # claude_agent_sdk absent — nothing to assert
+        pytest.skip("claude_agent_sdk not installed")
+    _name, server = built
+    handler = server["instance"].request_handlers[types.ListToolsRequest]
+    listed = asyncio.run(handler(types.ListToolsRequest(method="tools/list")))
+    return listed.root.tools
+
+
+# ---------------------------------------------------------------------------
+# Registration — the tool rides the shared sites_manager allowlist
+# ---------------------------------------------------------------------------
+
+
+class TestRegistration:
+    def test_tool_id_on_shared_server_allowlist(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers.sites import EDIT_HTML_FILE_TOOL_ID, SITES_TOOL_IDS
+
+        assert EDIT_HTML_FILE_TOOL_ID == "mcp__pocketpaw_sites_manager__edit_html_file"
+        assert EDIT_HTML_FILE_TOOL_ID in SITES_TOOL_IDS
+
+    def test_provider_advertises_edit_tool_id(self) -> None:
+        """``tool_ids()`` feeds the claude_sdk allowlist loop AND the /sites surface
+        scope. A tool the provider does not advertise is registered on the server
+        and still unreachable from the surface that needs it."""
+        from pocketpaw_ee.agent.mcp_servers.sites import EDIT_HTML_FILE_TOOL_ID
+        from pocketpaw_ee.extensions import CloudSitesMcpProvider
+
+        assert EDIT_HTML_FILE_TOOL_ID in CloudSitesMcpProvider().tool_ids()
+
+    def test_the_built_server_actually_lists_the_tool(self) -> None:
+        """The id constant and the registered tool are two different facts, and only
+        this one proves the SDK will dispatch a call. An id in ``SITES_TOOL_IDS``
+        with no tool behind it allow-lists a name that does not answer.
+
+        Mutation: drop ``edit_html_file`` from the ``tools=[...]`` list in
+        ``build_sites_manager_server`` and this fails while every id assertion above
+        keeps passing."""
+        names = {t.name for t in _listed_tool()}
+        assert "edit_html_file" in names, sorted(names)
+
+    def test_every_engine_that_can_be_created_can_now_be_edited(self) -> None:
+        """The point of HE-10 stated as an invariant. html was the last engine with a
+        create tool and no edit tool; if a future engine repeats that, this fails."""
+        names = {t.name for t in _listed_tool()}
+        assert {"create_html_site", "edit_html_file"} <= names
+        assert {"create_react_site", "edit_react_component"} <= names
+        assert {"create_svelte_site", "edit_svelte_component"} <= names
+
+    def test_the_schema_names_a_file_not_a_component(self) -> None:
+        """An html site has no components. Renaming this to ``component_path`` for
+        symmetry with the siblings would contradict every example in the tool's own
+        description and break the calls it teaches."""
+        tool = next(t for t in _listed_tool() if t.name == "edit_html_file")
+        props = (tool.inputSchema or {}).get("properties") or {}
+        assert set(props) >= {"pocket_id", "file_path", "edits", "new_source", "create"}
+        assert "component_path" not in props
+        assert (tool.inputSchema or {}).get("required") == ["pocket_id", "file_path"]
+
+    def test_the_description_steers_away_from_a_second_create(self) -> None:
+        """The bug this tool exists to fix is behavioural, so the description has to
+        say so: an agent that reaches for ``create_html_site`` on an edit request
+        mints a second site pocket, and nothing in the schema stops it."""
+        tool = next(t for t in _listed_tool() if t.name == "edit_html_file")
+        description = tool.description or ""
+        assert "create_html_site" in description
+        assert "NEVER" in description
+
+    def test_the_description_warns_off_reacts_src_prefix(self) -> None:
+        """The most likely wrong guess on this track, because the agent has just been
+        reading a react tool that requires ``src/``. An html file written to
+        ``src/index.html`` is materialized to a path the edge never serves, and the
+        site simply looks unchanged."""
+        tool = next(t for t in _listed_tool() if t.name == "edit_html_file")
+        description = tool.description or ""
+        assert "index.html" in description
+        assert "src/" in description  # named in order to be ruled out
+
+    def test_the_description_tells_the_agent_to_keep_the_capture_plumbing(self) -> None:
+        """A full-file rewrite is what "change the headline" tempts on a one-document
+        track, and it is exactly the shape that silently drops a form's ``action``
+        and hidden ``paw_*`` inputs. Losing them does not error: the form still
+        renders, still submits, and every future enquiry goes nowhere."""
+        tool = next(t for t in _listed_tool() if t.name == "edit_html_file")
+        description = tool.description or ""
+        assert "paw_site_id" in description
+        assert "paw_key" in description
+
+
+# ---------------------------------------------------------------------------
+# Handler wiring — identity, plan gate, validation, response shape, errors
+# ---------------------------------------------------------------------------
+
+
+class TestEditHandler:
+    @pytest.mark.asyncio
+    async def test_success_returns_pocket_and_file_path(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        fake = AsyncMock(return_value=_ok_result())
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch("pocketpaw_ee.sites.service.edit_html_file", new=fake),
+        ):
+            out = await mcp._edit_html_file_handler(
+                {
+                    "pocket_id": "pk1",
+                    "file_path": "index.html",
+                    "new_source": "<!doctype html><h1>Hi</h1>",
+                }
+            )
+
+        assert not out.get("is_error"), out
+        body = json.loads(out["content"][0]["text"])
+        assert body["ok"] is True
+        assert body["pocket_id"] == "pk1"
+        assert body["file_path"] == "index.html"
+        assert body["created"] is False
+        # The service got the agent identity + the edit inputs.
+        fake.assert_awaited_once()
+        kwargs = fake.await_args.kwargs
+        assert kwargs["user_id"] == "u1"
+        assert kwargs["pocket_id"] == "pk1"
+        assert kwargs["file_path"] == "index.html"
+        assert kwargs["new_source"].startswith("<!doctype")
+        assert kwargs["edits"] is None
+        assert kwargs["create"] is False
+
+    @pytest.mark.asyncio
+    async def test_a_targeted_diff_reaches_the_service_as_edits(self) -> None:
+        """The preferred form. The handler must forward the blocks rather than
+        collapsing them into a rewrite."""
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        fake = AsyncMock(return_value=_ok_result())
+        blocks = [{"old_string": "555-0100", "new_string": "555-0199"}]
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch("pocketpaw_ee.sites.service.edit_html_file", new=fake),
+        ):
+            out = await mcp._edit_html_file_handler(
+                {"pocket_id": "pk1", "file_path": "index.html", "edits": blocks}
+            )
+
+        assert not out.get("is_error"), out
+        kwargs = fake.await_args.kwargs
+        assert kwargs["edits"] == blocks
+        assert kwargs["new_source"] is None
+
+    @pytest.mark.asyncio
+    async def test_the_success_body_does_not_claim_the_change_is_live(self) -> None:
+        """NARRATION. The agent relays this payload verbatim-ish, and an edit is a
+        DRAFT — html publishes are the user's call. A body that said "published"
+        would have the agent tell a user their change is online when the edge is
+        still serving the old page."""
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch(
+                "pocketpaw_ee.sites.service.edit_html_file",
+                new=AsyncMock(return_value=_ok_result()),
+            ),
+        ):
+            out = await mcp._edit_html_file_handler(
+                {"pocket_id": "pk1", "file_path": "index.html", "new_source": "<h1/>"}
+            )
+
+        body = json.loads(out["content"][0]["text"])
+        assert body["status"] == "draft"
+        assert body["is_live"] is False
+        message = body["message"].lower()
+        assert "not" in message and "online" in message
+        assert "published" not in message.replace("publish it", "")
+
+    @pytest.mark.asyncio
+    async def test_missing_identity_is_an_error(self) -> None:
+        """Called outside a cloud chat stream there is no workspace/user, and
+        proceeding would mis-tenant the write."""
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        with patch.object(mcp, "_identity", return_value=(None, None)):
+            out = await mcp._edit_html_file_handler(
+                {"pocket_id": "pk1", "file_path": "index.html", "new_source": "<h1/>"}
+            )
+        assert out["is_error"] is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "args",
+        [
+            {"file_path": "index.html", "new_source": "<h1/>"},  # no pocket_id
+            {"pocket_id": "pk1", "new_source": "<h1/>"},  # no file_path
+            {"pocket_id": "pk1", "file_path": "index.html"},  # neither edit shape
+            {  # both edit shapes
+                "pocket_id": "pk1",
+                "file_path": "index.html",
+                "new_source": "<h1/>",
+                "edits": [{"old_string": "a", "new_string": "b"}],
+            },
+            {"pocket_id": "pk1", "file_path": "index.html", "edits": []},  # empty diff
+            {  # malformed block
+                "pocket_id": "pk1",
+                "file_path": "index.html",
+                "edits": [{"old_string": "a"}],
+            },
+            {  # create without new_source
+                "pocket_id": "pk1",
+                "file_path": "about.html",
+                "edits": [{"old_string": "a", "new_string": "b"}],
+                "create": True,
+            },
+        ],
+    )
+    async def test_malformed_input_is_rejected_before_the_service_runs(self, args) -> None:
+        """Every one of these is the caller's bug, and each gets a clear message the
+        agent can act on rather than a stack trace. Crucially the service is never
+        reached, so a bad call cannot half-write."""
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        fake = AsyncMock()
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch("pocketpaw_ee.sites.service.edit_html_file", new=fake),
+        ):
+            out = await mcp._edit_html_file_handler(args)
+
+        assert out["is_error"] is True, out
+        fake.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_service_rejection_is_relayed_by_code(self) -> None:
+        """The agent has to know WHICH guard fired to fix and retry — a reserved path
+        needs a different correction from an ambiguous old_string."""
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+        from pocketpaw_ee.cloud._core.errors import ValidationError
+
+        err = ValidationError("site_edit.reserved_path", "`_paw/x` is generator-owned.")
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch("pocketpaw_ee.sites.service.edit_html_file", new=AsyncMock(side_effect=err)),
+        ):
+            out = await mcp._edit_html_file_handler(
+                {
+                    "pocket_id": "pk1",
+                    "file_path": "_paw/x",
+                    "new_source": "{}",
+                    "create": True,
+                }
+            )
+
+        assert out["is_error"] is True
+        text = out["content"][0]["text"]
+        assert "site_edit.reserved_path" in text
+        assert "generator-owned" in text
+
+    @pytest.mark.asyncio
+    async def test_a_workspace_without_the_sites_plan_is_gated(self) -> None:
+        """An edit mutates a site pocket, so it is gated on the same feature the
+        create tools are. Without this a workspace that lost the plan could keep
+        editing a site its own /sites list 403s."""
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        fake = AsyncMock()
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch(
+                "pocketpaw_ee.cloud.workspace.service.get_workspace_plan",
+                new=AsyncMock(return_value="free"),
+            ),
+            patch("pocketpaw_ee.sites.service.edit_html_file", new=fake),
+        ):
+            out = await mcp._edit_html_file_handler(
+                {"pocket_id": "pk1", "file_path": "index.html", "new_source": "<h1/>"}
+            )
+
+        assert out["is_error"] is True
+        fake.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_create_is_forwarded(self) -> None:
+        """``create=true`` is how a page gets ADDED, and it has to reach the service
+        for the existence inversion to apply."""
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        fake = AsyncMock(return_value=_ok_result(created=True, file_path="about.html"))
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch("pocketpaw_ee.sites.service.edit_html_file", new=fake),
+        ):
+            out = await mcp._edit_html_file_handler(
+                {
+                    "pocket_id": "pk1",
+                    "file_path": "about.html",
+                    "new_source": "<h1>About</h1>",
+                    "create": True,
+                }
+            )
+
+        assert not out.get("is_error"), out
+        assert fake.await_args.kwargs["create"] is True
+        assert json.loads(out["content"][0]["text"])["created"] is True

--- a/tests/ee/agent/test_sites_mcp_server/test_mcp_tool.py
+++ b/tests/ee/agent/test_sites_mcp_server/test_mcp_tool.py
@@ -41,6 +41,7 @@ class TestSitesMcpServerRegistration:
             CREATE_LANDING_SITE_TOOL_ID,
             CREATE_REACT_SITE_TOOL_ID,
             CREATE_SVELTE_SITE_TOOL_ID,
+            EDIT_HTML_FILE_TOOL_ID,
             EDIT_REACT_COMPONENT_TOOL_ID,
             EDIT_SVELTE_COMPONENT_TOOL_ID,
             GET_SITE_BUILD_STATUS_TOOL_ID,
@@ -70,6 +71,12 @@ class TestSitesMcpServerRegistration:
         # Its absence was the whole react-edit hole: with only the svelte edit tool
         # registered, a react site could be created and published but never changed.
         assert EDIT_REACT_COMPONENT_TOOL_ID == "mcp__pocketpaw_sites_manager__edit_react_component"
+        # HE-10 — the html-track EDIT tool, the THIRD edit tool and the one that
+        # completes the set: every engine with a create tool now has an edit tool.
+        # Named for a FILE because an html site has no component model. Its absence
+        # was the react hole one engine over — an html site could be created,
+        # imported and published but never changed.
+        assert EDIT_HTML_FILE_TOOL_ID == "mcp__pocketpaw_sites_manager__edit_html_file"
         assert PUBLISH_TOOL_ID in SITES_TOOL_IDS
         assert CREATE_LANDING_SITE_TOOL_ID in SITES_TOOL_IDS
         assert CREATE_SVELTE_SITE_TOOL_ID in SITES_TOOL_IDS
@@ -78,7 +85,8 @@ class TestSitesMcpServerRegistration:
         assert CREATE_HTML_SITE_TOOL_ID in SITES_TOOL_IDS
         assert CREATE_REACT_SITE_TOOL_ID in SITES_TOOL_IDS
         assert EDIT_REACT_COMPONENT_TOOL_ID in SITES_TOOL_IDS
-        # RX-4 — the READ-ONLY build-status tool, the 9th id. It is the only way the
+        assert EDIT_HTML_FILE_TOOL_ID in SITES_TOOL_IDS
+        # RX-4 — the READ-ONLY build-status tool. It is the only way the
         # agent can learn how an ASYNC build ended, since publish returns before the
         # build starts.
         assert (
@@ -88,7 +96,7 @@ class TestSitesMcpServerRegistration:
         # The count is deliberate: adding a tool here widens the /sites surface
         # allow-list (SITES_TOOL_IDS feeds it), so a new id must be a decision,
         # not a side effect. Bump it WITH an id assertion above — never alone.
-        assert len(SITES_TOOL_IDS) == 9
+        assert len(SITES_TOOL_IDS) == 10
 
     def test_extension_provider_advertises_tool_id(self) -> None:
         """The entry-point provider's ``tool_ids()`` feeds the claude_sdk

--- a/tests/ee/sites/test_html_file_edit.py
+++ b/tests/ee/sites/test_html_file_edit.py
@@ -1,0 +1,639 @@
+# tests/ee/sites/test_html_file_edit.py — the html-track EDIT lane
+# (sites_service.edit_html_file). Created: 2026-08-13 (feat/sites-html-edit-lane,
+# HE-10).
+#
+# WHAT WAS MISSING, and it is the RX-3 hole one engine over. ``create_html_site``
+# shipped in HE-6 and the URL importer (SI-5) mints html pockets too, so html sites
+# existed in quantity — and NOTHING could change one from chat. Both existing edit
+# entry points reject an html pocket by design (``edit_svelte_component`` raises
+# ``pocket.not_svelte_site``, ``edit_react_component`` raises
+# ``pocket.not_react_site``), and the only html-engine writer in the pockets service
+# was ``set_imported_source``, which replaces the WHOLE map and takes a
+# ``workspace_id`` with no viewer check because the crawler calls it off-request.
+# So "change the phone number in the footer" had no tool that would take it, and the
+# agent's only available move was a second ``create_html_site`` — a SECOND pocket at
+# a SECOND url, leaving the site the user was looking at untouched.
+#
+# These use the shared ``beanie_test_db`` fixture (an in-memory Mongo) so the pockets
+# service persists a REAL html Pocket doc and the guards run against real state.
+# There is no generator, no Cloudflare and no bundle reader to inject, because there
+# is no build — html is the one engine where ``needs_node_build`` is False.
+#
+# THREE PROPERTIES ARE LOAD BEARING and get their own sections:
+#   (a) DRAFT-ONLY — the edit must not publish. The REASON is not react's and the
+#       distinction matters: react cannot roll back because its build is async,
+#       whereas html has no build to gate on AT ALL, so a republish here would push
+#       unvalidated markup straight to a live customer site with nothing in between.
+#       Asserted by spying on the publish seam AND by the observable that no Site doc
+#       exists afterwards.
+#   (b) THE PATH GUARD, WHICH IS HTML'S OWN. The temptation was to reuse
+#       ``react_paths``; doing so would have rejected ``index.html`` — every html
+#       site's entry document — because react requires ``src/`` or ``public/``. So
+#       the positive rule is ABSENT here on purpose, and there is a test that fails
+#       if someone "restores" it. What IS reserved is ``_paw/``, where
+#       ``_paw/edit-manifest.json`` maps each editable element to a byte range; an
+#       author who could shadow it would not break anything loudly, they would make
+#       the NEXT native-editor edit splice at wrong offsets.
+#   (c) THE CREATE/EXISTS INVERSION — ``create=False`` demands the path exist (a typo
+#       is never a silent create); ``create=True`` demands it not.
+#
+# Mutation coverage: tests/mutations/html_edit_lane.json.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import NotFound, ValidationError
+from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
+from pocketpaw_ee.cloud.pockets import service as pockets_service
+from pocketpaw_ee.sites import service as sites_service
+
+_INDEX_V1 = (
+    "<!doctype html>\n"
+    '<html lang="en">\n'
+    "<head><title>Bright Smile Dental</title>\n"
+    '<link rel="stylesheet" href="styles.css"></head>\n'
+    "<body>\n"
+    "  <h1>Bright Smile Dental</h1>\n"
+    "  <p>Gentle care in the heart of town.</p>\n"
+    '  <a href="tel:5550100">555-0100</a>\n'
+    "</body>\n"
+    "</html>\n"
+)
+_STYLES = ":root{--brand:#0A84FF}\nbody{font-family:system-ui}\n"
+_HTML_SOURCE = {
+    "index.html": _INDEX_V1,
+    "styles.css": _STYLES,
+    "img/logo.svg": "<svg/>",
+}
+
+
+async def _make_html_pocket(workspace_id: str, user_id: str) -> str:
+    """Persist a real html-engine Pocket via the pockets service and return its id.
+
+    Mirrors how ``create_html_site`` lands one: type='site', pattern='landing',
+    engine='html', source=<map>, ripple_spec=None, trusted=True."""
+    _view, pocket_id, err = await pockets_service.agent_create(
+        workspace_id=workspace_id,
+        owner_id=user_id,
+        name="Bright Smile",
+        type_="site",
+        pattern="landing",
+        ripple_spec=None,
+        engine="html",
+        source=dict(_HTML_SOURCE),
+        trusted=True,
+    )
+    assert err is None, err
+    assert pocket_id is not None
+    return pocket_id
+
+
+async def _source_of(pocket_id: str, user_id: str = "u1") -> dict:
+    wire = await pockets_service.get(pocket_id, user_id)
+    return wire["source"]
+
+
+# ---------------------------------------------------------------------------
+# The happy paths — a targeted diff and a full rewrite
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_targeted_edits_are_applied_and_persisted(beanie_test_db):
+    """The dominant case, and the one the whole lane exists for: the agent sends
+    only the diff and the file changes.
+
+    THE MUTATION THAT BREAKS THIS: make the persist a no-op (drop the
+    ``set_html_source_file`` call) — the re-read still carries the old number."""
+    pocket_id = await _make_html_pocket("ws1", "u1")
+
+    out = await sites_service.edit_html_file(
+        user_id="u1",
+        pocket_id=pocket_id,
+        file_path="index.html",
+        edits=[{"old_string": "555-0100", "new_string": "555-0199"}],
+    )
+
+    assert out == {"pocket_id": pocket_id, "file_path": "index.html", "created": False}
+    source = await _source_of(pocket_id)
+    assert "555-0199" in source["index.html"]
+    assert "555-0100" not in source["index.html"]
+    # Only the targeted file moved — the rest of the map came through verbatim.
+    assert source["styles.css"] == _STYLES
+    assert source["img/logo.svg"] == "<svg/>"
+
+
+@pytest.mark.asyncio
+async def test_editing_a_root_level_file_is_allowed(beanie_test_db):
+    """THE TEST THAT FAILS IF SOMEONE PORTS REACT'S POSITIVE PATH RULE HERE.
+
+    ``react_path_rejection`` requires a path to resolve under ``src/`` or
+    ``public/``, because on that track everything at the project root belongs to a
+    generated build shell. An html site has NO build shell — ``html-scaffold.ts``
+    writes the author's map verbatim into the directory the edge serves — so its
+    files legitimately live at the root, starting with the ``index.html`` the edge
+    serves as the entry document. Reusing react's module here would have rejected
+    the single most-edited file on the track.
+
+    Mutation: swap ``html_path_rejection`` for ``react_path_rejection`` in
+    ``edit_html_file`` and this fails on every file in the fixture."""
+    pocket_id = await _make_html_pocket("ws1", "u1")
+
+    for path in ("index.html", "styles.css"):
+        await sites_service.edit_html_file(
+            user_id="u1",
+            pocket_id=pocket_id,
+            file_path=path,
+            new_source=f"/* {path} */",
+        )
+
+    source = await _source_of(pocket_id)
+    assert source["index.html"] == "/* index.html */"
+    assert source["styles.css"] == "/* styles.css */"
+
+
+@pytest.mark.asyncio
+async def test_new_source_replaces_the_whole_file(beanie_test_db):
+    """The large-rewrite form: ``new_source`` is used as-is, not merged."""
+    pocket_id = await _make_html_pocket("ws1", "u1")
+    rewritten = "<!doctype html>\n<html><body><h1>New</h1></body></html>\n"
+
+    await sites_service.edit_html_file(
+        user_id="u1",
+        pocket_id=pocket_id,
+        file_path="index.html",
+        new_source=rewritten,
+    )
+
+    assert (await _source_of(pocket_id))["index.html"] == rewritten
+
+
+@pytest.mark.asyncio
+async def test_a_second_edit_stacks_on_the_first(beanie_test_db):
+    """Consecutive edits compose — the second reads what the first persisted, so a
+    multi-turn conversation converges instead of each turn undoing the last."""
+    pocket_id = await _make_html_pocket("ws1", "u1")
+
+    await sites_service.edit_html_file(
+        user_id="u1",
+        pocket_id=pocket_id,
+        file_path="index.html",
+        edits=[{"old_string": "555-0100", "new_string": "555-0199"}],
+    )
+    await sites_service.edit_html_file(
+        user_id="u1",
+        pocket_id=pocket_id,
+        file_path="index.html",
+        edits=[{"old_string": "Gentle care", "new_string": "Expert care"}],
+    )
+
+    index = (await _source_of(pocket_id))["index.html"]
+    assert "555-0199" in index and "Expert care" in index
+
+
+# ---------------------------------------------------------------------------
+# (a) DRAFT-ONLY — no publish, and nothing goes live
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_edit_does_not_publish(beanie_test_db, monkeypatch):
+    """An html publish runs NO build and NO smoke gate, so there is nothing that
+    could reject a broken edit before it reached the edge. Republishing from here
+    would therefore push unvalidated markup straight to a live customer site — the
+    opposite of the svelte lane, where the smoke gate is exactly what makes an
+    automatic republish safe.
+
+    Mutation: add a ``publish_pocket`` call to ``edit_html_file`` and this fails."""
+    pocket_id = await _make_html_pocket("ws1", "u1")
+    calls: list = []
+    monkeypatch.setattr(
+        sites_service,
+        "publish_pocket",
+        lambda *a, **k: calls.append(k) or (_ for _ in ()).throw(AssertionError("published")),
+    )
+
+    await sites_service.edit_html_file(
+        user_id="u1",
+        pocket_id=pocket_id,
+        file_path="index.html",
+        edits=[{"old_string": "555-0100", "new_string": "555-0199"}],
+    )
+
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_no_site_doc_is_created_by_an_edit(beanie_test_db):
+    """The observable half of the same contract, independent of any seam: a Site doc
+    is what makes a site exist at a url, and an edit must not mint one."""
+    pocket_id = await _make_html_pocket("ws1", "u1")
+
+    await sites_service.edit_html_file(
+        user_id="u1",
+        pocket_id=pocket_id,
+        file_path="index.html",
+        new_source="<html></html>",
+    )
+
+    assert await _SiteDoc.find({"pocket_id": pocket_id}).count() == 0
+
+
+# ---------------------------------------------------------------------------
+# (b) THE PATH GUARD — the generator's namespace, and escapes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "path",
+    [
+        "_paw/edit-manifest.json",
+        "_paw",
+        "_paw/nested/deep.json",
+        # Every spelling the normalizer is supposed to collapse. A guard a trivial
+        # path spelling defeats is not a guard.
+        "./_paw/edit-manifest.json",
+        "_paw/./edit-manifest.json",
+        "img/../_paw/edit-manifest.json",
+        "_paw\\edit-manifest.json",
+    ],
+)
+async def test_the_generator_namespace_is_not_writable(beanie_test_db, path):
+    """``_paw/edit-manifest.json`` maps each editable element to a byte range in the
+    author's source, and the native visual editor writes THROUGH it. Shadowing it
+    does not fail loudly — it points valid uids at wrong offsets, so the next native
+    edit splices into the middle of a tag.
+
+    ``create=True`` is used because that is the dangerous direction: it is the only
+    mode that can mint a path that does not exist yet."""
+    pocket_id = await _make_html_pocket("ws1", "u1")
+
+    with pytest.raises(ValidationError) as exc:
+        await sites_service.edit_html_file(
+            user_id="u1",
+            pocket_id=pocket_id,
+            file_path=path,
+            new_source="{}",
+            create=True,
+        )
+    assert exc.value.code == "site_edit.reserved_path"
+    # Nothing was written under any spelling of the reserved path.
+    assert not any(k.startswith("_paw") for k in await _source_of(pocket_id))
+
+
+@pytest.mark.asyncio
+async def test_a_file_merely_sharing_the_prefix_is_writable(beanie_test_db):
+    """``_pawprint.html`` is an ordinary page name. Reserving the NAMESPACE means
+    matching the directory, not any sibling whose name starts with the same
+    characters — which is why the constant carries its trailing slash.
+
+    Mutation: drop the trailing slash from ``HTML_RESERVED_PREFIX`` and this fails."""
+    pocket_id = await _make_html_pocket("ws1", "u1")
+
+    await sites_service.edit_html_file(
+        user_id="u1",
+        pocket_id=pocket_id,
+        file_path="_pawprint.html",
+        new_source="<h1>Our work</h1>",
+        create=True,
+    )
+
+    assert (await _source_of(pocket_id))["_pawprint.html"] == "<h1>Our work</h1>"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "path",
+    ["../secrets.env", "../../etc/passwd", "/etc/passwd", "img/../../out.html"],
+)
+async def test_a_path_that_escapes_the_site_is_rejected(beanie_test_db, path):
+    """The generator asserts this too (``assertSafeRelPath``), but a build-time throw
+    lands far from the authoring turn. Rejecting here names the problem while the
+    agent can still act on it."""
+    pocket_id = await _make_html_pocket("ws1", "u1")
+
+    with pytest.raises(ValidationError) as exc:
+        await sites_service.edit_html_file(
+            user_id="u1",
+            pocket_id=pocket_id,
+            file_path=path,
+            new_source="x",
+            create=True,
+        )
+    assert exc.value.code == "site_edit.path_outside_source"
+
+
+@pytest.mark.asyncio
+async def test_a_path_with_an_absorbed_dotdot_is_allowed(beanie_test_db):
+    """``img/../logo.svg`` normalizes to ``logo.svg`` and never leaves the project,
+    so it is not an escape. The guard rejects paths that RESOLVE outside, not paths
+    that merely contain ``..`` — over-rejecting here would fail legitimate edits."""
+    pocket_id = await _make_html_pocket("ws1", "u1")
+
+    await sites_service.edit_html_file(
+        user_id="u1",
+        pocket_id=pocket_id,
+        file_path="img/../logo.svg",
+        new_source="<svg id='new'/>",
+        create=True,
+    )
+
+    assert "logo.svg" in await _source_of(pocket_id)
+
+
+# ---------------------------------------------------------------------------
+# (c) THE CREATE/EXISTS INVERSION
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_typo_is_not_a_silent_create(beanie_test_db):
+    """Without ``create`` the path must already exist. The alternative — writing a
+    new file at the misspelled path — leaves the real page unchanged while the tool
+    reports success, so the user is told a change landed that nobody can see."""
+    pocket_id = await _make_html_pocket("ws1", "u1")
+
+    with pytest.raises(NotFound):
+        await sites_service.edit_html_file(
+            user_id="u1",
+            pocket_id=pocket_id,
+            file_path="indx.html",
+            new_source="<h1>oops</h1>",
+        )
+    assert "indx.html" not in await _source_of(pocket_id)
+
+
+@pytest.mark.asyncio
+async def test_a_diff_against_a_missing_file_is_a_404_not_a_crash(beanie_test_db):
+    """WHY THE SITES-SERVICE EXISTENCE CHECK EARNS ITS KEEP even though the pockets
+    service also refuses a missing path.
+
+    On the ``new_source`` path the two are indistinguishable — the chokepoint raises
+    the same NotFound a moment later, which is exactly what a mutation proved by
+    ESCAPING when this file only covered that path. The ``edits`` path is different:
+    it INDEXES ``source_map[file_path]`` to compute the new source, so without the
+    local check a typo'd path raises KeyError — a 500 the agent cannot act on —
+    before the chokepoint is ever reached.
+
+    Mutation: delete the ``if not create and file_path not in source_map`` guard in
+    ``edit_html_file`` and this fails with KeyError instead of NotFound."""
+    pocket_id = await _make_html_pocket("ws1", "u1")
+
+    with pytest.raises(NotFound):
+        await sites_service.edit_html_file(
+            user_id="u1",
+            pocket_id=pocket_id,
+            file_path="indx.html",
+            edits=[{"old_string": "555-0100", "new_string": "555-0199"}],
+        )
+
+
+@pytest.mark.asyncio
+async def test_the_pockets_service_refuses_a_non_html_pocket_directly(beanie_test_db):
+    """The write chokepoint carries its OWN engine gate, and this calls it directly
+    because that is the only way to see it.
+
+    Routed through ``edit_html_file`` the sites-service gate rejects first, so a
+    mutation removing the chokepoint's gate ESCAPED — the test could not tell the
+    two layers apart. ``set_html_source_file`` is a public service function
+    (entity isolation: it is where EVERY html source write lands, not only this
+    lane's), so a future caller reaching it without the sites-service preamble must
+    still be refused rather than writing raw html into a react pocket's map."""
+    _view, pocket_id, err = await pockets_service.agent_create(
+        workspace_id="ws1",
+        owner_id="u1",
+        name="React site",
+        type_="site",
+        pattern="landing",
+        ripple_spec=None,
+        engine="react",
+        source={"src/App.tsx": "export default () => <main/>;"},
+        trusted=True,
+    )
+    assert err is None, err
+
+    with pytest.raises(ValidationError) as exc:
+        await pockets_service.set_html_source_file(
+            pocket_id,
+            "u1",
+            file_path="index.html",
+            new_source="<h1>x</h1>",
+            create=True,
+        )
+    assert exc.value.code == "pocket.not_html_site"
+
+
+@pytest.mark.asyncio
+async def test_create_mints_a_new_page(beanie_test_db):
+    """The affirmative case ``create`` exists for: "add an about page" needs a new
+    FILE, then an edit to ``index.html`` to link to it."""
+    pocket_id = await _make_html_pocket("ws1", "u1")
+
+    out = await sites_service.edit_html_file(
+        user_id="u1",
+        pocket_id=pocket_id,
+        file_path="about.html",
+        new_source="<!doctype html><h1>About us</h1>",
+        create=True,
+    )
+
+    assert out["created"] is True
+    source = await _source_of(pocket_id)
+    assert source["about.html"] == "<!doctype html><h1>About us</h1>"
+    # The rest of the site is untouched by an add.
+    assert source["index.html"] == _INDEX_V1
+
+
+@pytest.mark.asyncio
+async def test_create_refuses_to_overwrite_an_existing_page(beanie_test_db):
+    """The inversion's other half. Silently replacing the live home page with what
+    the agent thought was a new file is worse than a rejected call it can retry."""
+    pocket_id = await _make_html_pocket("ws1", "u1")
+
+    with pytest.raises(ValidationError) as exc:
+        await sites_service.edit_html_file(
+            user_id="u1",
+            pocket_id=pocket_id,
+            file_path="index.html",
+            new_source="<h1>clobbered</h1>",
+            create=True,
+        )
+    assert exc.value.code == "pocket.html_file_exists"
+    assert (await _source_of(pocket_id))["index.html"] == _INDEX_V1
+
+
+@pytest.mark.asyncio
+async def test_create_without_new_source_is_rejected(beanie_test_db):
+    """There is nothing for ``edits`` to search against in a file that does not
+    exist, so this is caught at the argument level rather than raising a KeyError
+    deeper in."""
+    pocket_id = await _make_html_pocket("ws1", "u1")
+
+    with pytest.raises(ValidationError) as exc:
+        await sites_service.edit_html_file(
+            user_id="u1",
+            pocket_id=pocket_id,
+            file_path="about.html",
+            edits=[{"old_string": "a", "new_string": "b"}],
+            create=True,
+        )
+    assert exc.value.code == "site_edit.create_needs_source"
+
+
+# ---------------------------------------------------------------------------
+# Engine gating and argument shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_react_pocket_is_rejected(beanie_test_db):
+    """The mirror of the rejections that created this hole. Each engine's edit tool
+    accepts only its own content model — writing raw html into a react source map
+    would persist a file the Vite build cannot compile."""
+    _view, pocket_id, err = await pockets_service.agent_create(
+        workspace_id="ws1",
+        owner_id="u1",
+        name="React site",
+        type_="site",
+        pattern="landing",
+        ripple_spec=None,
+        engine="react",
+        source={"src/App.tsx": "export default () => <main/>;"},
+        trusted=True,
+    )
+    assert err is None, err
+
+    with pytest.raises(ValidationError) as exc:
+        await sites_service.edit_html_file(
+            user_id="u1",
+            pocket_id=pocket_id,
+            file_path="index.html",
+            new_source="<h1>x</h1>",
+        )
+    assert exc.value.code == "pocket.not_html_site"
+
+
+@pytest.mark.asyncio
+async def test_a_ripple_pocket_is_rejected(beanie_test_db):
+    """A ripple pocket's content is a rippleSpec, not a source map — it has no
+    ``source`` key to index, so the guard has to fire before the read."""
+    _view, pocket_id, err = await pockets_service.agent_create(
+        workspace_id="ws1",
+        owner_id="u1",
+        name="Ripple site",
+        type_="site",
+        pattern="landing",
+        ripple_spec={"type": "container", "children": []},
+        trusted=True,
+    )
+    assert err is None, err
+
+    with pytest.raises(ValidationError) as exc:
+        await sites_service.edit_html_file(
+            user_id="u1",
+            pocket_id=pocket_id,
+            file_path="index.html",
+            new_source="<h1>x</h1>",
+        )
+    assert exc.value.code == "pocket.not_html_site"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},  # neither
+        {"new_source": "<h1/>", "edits": [{"old_string": "a", "new_string": "b"}]},  # both
+    ],
+)
+async def test_exactly_one_edit_shape_is_required(beanie_test_db, kwargs):
+    """Neither is a no-op call; both is ambiguous about which wins. Both are the
+    caller's bug and are rejected before anything is read or written."""
+    pocket_id = await _make_html_pocket("ws1", "u1")
+
+    with pytest.raises(ValidationError) as exc:
+        await sites_service.edit_html_file(
+            user_id="u1", pocket_id=pocket_id, file_path="index.html", **kwargs
+        )
+    assert exc.value.code == "site_edit.invalid_args"
+
+
+@pytest.mark.asyncio
+async def test_an_ambiguous_old_string_is_rejected_and_nothing_is_written(beanie_test_db):
+    """``apply_edits`` requires a unique match, and this pins that the rejection
+    happens BEFORE the persist. "Bright Smile Dental" appears in both the <title>
+    and the <h1>, so a replace-first implementation would change both and report
+    success — the agent would never learn it had edited the wrong one too."""
+    pocket_id = await _make_html_pocket("ws1", "u1")
+
+    with pytest.raises(ValidationError) as exc:
+        await sites_service.edit_html_file(
+            user_id="u1",
+            pocket_id=pocket_id,
+            file_path="index.html",
+            edits=[{"old_string": "Bright Smile Dental", "new_string": "Bright Smile"}],
+        )
+    assert exc.value.code == "site_edit.ambiguous_match"
+    assert (await _source_of(pocket_id))["index.html"] == _INDEX_V1
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_pocket_is_not_found(beanie_test_db):
+    """Resolved by the pockets service's public ``get``, which owns the tenancy
+    check — this lane never queries a Pocket doc itself."""
+    with pytest.raises(NotFound):
+        await sites_service.edit_html_file(
+            user_id="u1",
+            pocket_id="6d4a1f2b3c8e9a0f1b2c3d4e",
+            file_path="index.html",
+            new_source="<h1>x</h1>",
+        )
+
+
+# ---------------------------------------------------------------------------
+# The lead-capture plumbing an edit must not quietly drop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_an_edit_elsewhere_leaves_the_capture_form_intact(beanie_test_db):
+    """A targeted diff cannot touch what it does not name, and on this track that is
+    load bearing: an html site's contact form carries its ``action`` plus hidden
+    ``paw_site_id`` / ``paw_key`` / ``paw_redirect`` inputs, and those are the whole
+    reason a submission arrives as a lead. Dropping them fails silently — the form
+    still renders, still submits, and every enquiry goes nowhere.
+
+    This is why the tool description tells the agent to prefer ``edits`` and to
+    leave the form plumbing alone: a full-file rewrite is the shape that loses it,
+    and on a one-document track a rewrite is what "change the headline" tempts."""
+    form = (
+        '<form method="POST" action="https://api.test/api/v1/capture/form">'
+        '<input type="hidden" name="paw_site_id" value="site123">'
+        '<input type="hidden" name="paw_key" value="k_abc">'
+        '<input type="hidden" name="paw_redirect" value="/thank-you">'
+        '<input name="full_name"><button>Send</button></form>'
+    )
+    _view, pocket_id, err = await pockets_service.agent_create(
+        workspace_id="ws1",
+        owner_id="u1",
+        name="With form",
+        type_="site",
+        pattern="landing",
+        ripple_spec=None,
+        engine="html",
+        source={"index.html": f"<body><h1>Old headline</h1>{form}</body>"},
+        trusted=True,
+    )
+    assert err is None, err
+
+    await sites_service.edit_html_file(
+        user_id="u1",
+        pocket_id=pocket_id,
+        file_path="index.html",
+        edits=[{"old_string": "Old headline", "new_string": "New headline"}],
+    )
+
+    index = (await _source_of(pocket_id))["index.html"]
+    assert "New headline" in index
+    assert form in index, "the targeted edit disturbed the capture form"

--- a/tests/mutations/capture_origin_posture.json
+++ b/tests/mutations/capture_origin_posture.json
@@ -1,0 +1,93 @@
+[
+  {
+    "label": "the origin pin becomes an unconditional gate again (JSON path)",
+    "file": "ee/pocketpaw_ee/cloud/leads/router.py",
+    "find": "    if site.enforce_origin and not origin_allowed(_effective_origins(site), origin or None):",
+    "replace": "    if not origin_allowed(_effective_origins(site), origin or None):",
+    "tests": ["tests/cloud/leads/test_router.py"]
+  },
+  {
+    "label": "the opt-in gate is removed entirely (enforce_origin does nothing)",
+    "file": "ee/pocketpaw_ee/cloud/leads/router.py",
+    "find": "    if site.enforce_origin and not origin_allowed(_effective_origins(site), origin or None):\n        raise HTTPException(403, \"Origin not allowed for this site\")",
+    "replace": "    return",
+    "tests": ["tests/cloud/leads/test_router.py"]
+  },
+  {
+    "label": "the 303 echoes the caller's claimed Origin (open redirect)",
+    "file": "ee/pocketpaw_ee/cloud/leads/router.py",
+    "find": "    if origin and origin_allowed(_effective_origins(site), origin):\n        return origin.rstrip(\"/\")\n    return (site.url or \"\").rstrip(\"/\")",
+    "replace": "    return origin.rstrip(\"/\")",
+    "tests": ["tests/cloud/leads/test_router.py"]
+  },
+  {
+    "label": "the 303 always uses the site url (a custom-domain visitor is bounced away)",
+    "file": "ee/pocketpaw_ee/cloud/leads/router.py",
+    "find": "    if origin and origin_allowed(_effective_origins(site), origin):\n        return origin.rstrip(\"/\")\n    return (site.url or \"\").rstrip(\"/\")",
+    "replace": "    return (site.url or \"\").rstrip(\"/\")",
+    "tests": ["tests/cloud/leads/test_router.py"]
+  },
+  {
+    "label": "the known-host set is not derived (a site's own deployed host reads as foreign)",
+    "file": "ee/pocketpaw_ee/cloud/leads/router.py",
+    "find": "    hosts = list(site.allowed_origins)\n    candidates = [site.url or \"\"]\n    candidates.extend(d.hostname for d in (site.domains or []) if d.hostname)",
+    "replace": "    hosts = list(site.allowed_origins)\n    candidates: list[str] = []",
+    "tests": ["tests/cloud/leads/test_router.py"]
+  },
+  {
+    "label": "attached custom domains are dropped from the derived set",
+    "file": "ee/pocketpaw_ee/cloud/leads/router.py",
+    "find": "    candidates.extend(d.hostname for d in (site.domains or []) if d.hostname)",
+    "replace": "    pass",
+    "tests": ["tests/cloud/leads/test_router.py"]
+  },
+  {
+    "label": "the origin is never recorded on the lead",
+    "file": "ee/pocketpaw_ee/cloud/leads/service.py",
+    "find": "            origin=origin,",
+    "replace": "            origin=\"\",",
+    "tests": ["tests/cloud/leads/test_router.py"]
+  },
+  {
+    "label": "every submission is flagged unrecognized (the flag stops discriminating)",
+    "file": "ee/pocketpaw_ee/cloud/leads/service.py",
+    "find": "            origin_unrecognized=bool(origin)\n            and not origin_allowed(\n                site.allowed_origins if known_origins is None else known_origins, origin\n            ),",
+    "replace": "            origin_unrecognized=bool(origin),",
+    "tests": ["tests/cloud/leads/test_router.py"]
+  },
+  {
+    "label": "nothing is ever flagged unrecognized",
+    "file": "ee/pocketpaw_ee/cloud/leads/service.py",
+    "find": "            origin_unrecognized=bool(origin)\n            and not origin_allowed(\n                site.allowed_origins if known_origins is None else known_origins, origin\n            ),",
+    "replace": "            origin_unrecognized=False,",
+    "tests": ["tests/cloud/leads/test_router.py"]
+  },
+  {
+    "label": "the flag is judged against the stale stored field, not the derived set",
+    "file": "ee/pocketpaw_ee/cloud/leads/service.py",
+    "find": "                site.allowed_origins if known_origins is None else known_origins, origin",
+    "replace": "                site.allowed_origins, origin",
+    "tests": ["tests/cloud/leads/test_router.py"]
+  },
+  {
+    "label": "the origin header is never read (attribution is always empty)",
+    "file": "ee/pocketpaw_ee/cloud/leads/router.py",
+    "find": "    return (request.headers.get(\"origin\") or \"\").strip()",
+    "replace": "    return \"\"",
+    "tests": ["tests/cloud/leads/test_router.py"]
+  },
+  {
+    "label": "an enforcing site stops failing closed on a missing Origin",
+    "file": "ee/pocketpaw_ee/cloud/leads/router.py",
+    "find": "    if site.enforce_origin and not origin_allowed(_effective_origins(site), origin or None):",
+    "replace": "    if site.enforce_origin and origin and not origin_allowed(_effective_origins(site), origin):",
+    "tests": ["tests/cloud/leads/test_router.py"]
+  },
+  {
+    "label": "enforce_origin defaults ON (the old fail-closed default returns)",
+    "file": "ee/pocketpaw_ee/cloud/models/site.py",
+    "find": "    enforce_origin: bool = False",
+    "replace": "    enforce_origin: bool = True",
+    "tests": ["tests/cloud/leads/test_router.py"]
+  }
+]

--- a/tests/mutations/html_edit_lane.json
+++ b/tests/mutations/html_edit_lane.json
@@ -1,0 +1,100 @@
+[
+  {
+    "label": "the persist is a no-op (the edit never reaches the pocket)",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    await pockets_service.set_html_source_file(\n        pocket_id,\n        user_id,\n        file_path=file_path,\n        new_source=new_source,\n        create=create,\n    )",
+    "replace": "    _ = (pockets_service, new_source, create)",
+    "tests": ["tests/ee/sites/test_html_file_edit.py"]
+  },
+  {
+    "label": "the path guard is skipped entirely",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if (reason := html_path_rejection(file_path)) is not None:",
+    "replace": "    if False and (reason := html_path_rejection(file_path)) is not None:",
+    "tests": ["tests/ee/sites/test_html_file_edit.py"]
+  },
+  {
+    "label": "the reserved namespace loses its trailing slash (prefix-matches siblings)",
+    "file": "ee/pocketpaw_ee/sites/html_paths.py",
+    "find": "HTML_RESERVED_PREFIX = \"_paw/\"",
+    "replace": "HTML_RESERVED_PREFIX = \"_paw\"",
+    "tests": ["tests/ee/sites/test_html_file_edit.py"]
+  },
+  {
+    "label": "the path is not normalized before matching (a trivial spelling escapes)",
+    "file": "ee/pocketpaw_ee/sites/html_paths.py",
+    "find": "    return posixpath.normpath(path.replace(\"\\\\\", \"/\"))",
+    "replace": "    return path",
+    "tests": ["tests/ee/sites/test_html_file_edit.py"]
+  },
+  {
+    "label": "escape detection drops the leading-.. check",
+    "file": "ee/pocketpaw_ee/sites/html_paths.py",
+    "find": "    return norm == \"..\" or norm.startswith(\"../\") or posixpath.isabs(norm)",
+    "replace": "    return posixpath.isabs(norm)",
+    "tests": ["tests/ee/sites/test_html_file_edit.py"]
+  },
+  {
+    "label": "escape detection drops the absolute-path check",
+    "file": "ee/pocketpaw_ee/sites/html_paths.py",
+    "find": "    return norm == \"..\" or norm.startswith(\"../\") or posixpath.isabs(norm)",
+    "replace": "    return norm == \"..\" or norm.startswith(\"../\")",
+    "tests": ["tests/ee/sites/test_html_file_edit.py"]
+  },
+  {
+    "label": "the write uses the raw path, so ./index.html shadows index.html",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    file_path = normalize_html_path(file_path)",
+    "replace": "    file_path = file_path",
+    "tests": ["tests/ee/sites/test_html_file_edit.py"]
+  },
+  {
+    "label": "create no longer requires new_source",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if create and new_source is None:\n        raise ValidationError(\n            \"site_edit.create_needs_source\",\n            \"Creating a new file needs `new_source` — the full contents of the new \"\n            \"file. There is nothing for `edits` to search against.\",\n        )",
+    "replace": "    pass",
+    "tests": ["tests/ee/sites/test_html_file_edit.py"]
+  },
+  {
+    "label": "a diff against a missing file crashes with KeyError instead of 404",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if not create and file_path not in source_map:\n        raise NotFound(\"site_component\", file_path)",
+    "replace": "    pass",
+    "tests": ["tests/ee/sites/test_html_file_edit.py"]
+  },
+  {
+    "label": "the engine gate accepts any source-map pocket",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if (pocket.get(\"engine\") or \"ripple\") != \"html\" or not isinstance(pocket.get(\"source\"), dict):\n        raise ValidationError(\n            \"pocket.not_html_site\",",
+    "replace": "    if not isinstance(pocket.get(\"source\"), dict):\n        raise ValidationError(\n            \"pocket.not_html_site\",",
+    "tests": ["tests/ee/sites/test_html_file_edit.py"]
+  },
+  {
+    "label": "the exactly-one-edit-shape check is dropped",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if (edits is None) == (new_source is None):\n        raise ValidationError(\n            \"site_edit.invalid_args\",\n            \"edit_html_file requires exactly one of `edits` (a targeted \"\n            \"search/replace diff) or `new_source` (a full file rewrite).\",\n        )",
+    "replace": "    pass",
+    "tests": ["tests/ee/sites/test_html_file_edit.py"]
+  },
+  {
+    "label": "create overwrites an existing file at the pockets-service chokepoint",
+    "file": "ee/pocketpaw_ee/cloud/pockets/service.py",
+    "find": "    if create and exists:\n        raise ValidationError(\n            \"pocket.html_file_exists\",",
+    "replace": "    if False and exists:\n        raise ValidationError(\n            \"pocket.html_file_exists\",",
+    "tests": ["tests/ee/sites/test_html_file_edit.py"]
+  },
+  {
+    "label": "the pockets-service engine gate accepts a non-html pocket",
+    "file": "ee/pocketpaw_ee/cloud/pockets/service.py",
+    "find": "    if getattr(doc, \"engine\", \"ripple\") != \"html\" or not isinstance(doc.source, dict):\n        raise ValidationError(\n            \"pocket.not_html_site\",",
+    "replace": "    if not isinstance(doc.source, dict):\n        raise ValidationError(\n            \"pocket.not_html_site\",",
+    "tests": ["tests/ee/sites/test_html_file_edit.py"]
+  },
+  {
+    "label": "the edit republishes (pushes unvalidated markup live)",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    return {\"pocket_id\": pocket_id, \"file_path\": file_path, \"created\": create}",
+    "replace": "    await publish_pocket(workspace_id=\"\", user_id=user_id, pocket_id=pocket_id, name=\"\")\n    return {\"pocket_id\": pocket_id, \"file_path\": file_path, \"created\": create}",
+    "tests": ["tests/ee/sites/test_html_file_edit.py"]
+  }
+]


### PR DESCRIPTION
Stacked on #1934. Two changes that came out of the same live run.

## 1. The html track had no edit path

`edit_svelte_component` rejects an html pocket by design, and so does `edit_react_component`. The only html-engine writer in the pockets service was `set_imported_source`, which replaces the whole source map and skips the viewer check because the crawler calls it off a request. So "change the phone number in the footer" had no tool that would accept it, and the agent's only move was a second `create_html_site` — a second pocket at a second url, with the site the user was looking at untouched.

That is the hole RX-3 closed for react. This closes it the same way, with two things deliberately not copied.

**The path policy is html's own** (`sites/html_paths.py`). react requires an authored path to resolve under `src/` or `public/`, because everything at its project root belongs to a generated build shell. An html site has no shell — `html-scaffold.ts` writes the map verbatim into the directory the edge serves — so its files legitimately live at the root, starting with `index.html`. Reusing react's module would have rejected the most-edited file on the track. What *is* reserved is `_paw/`, where `_paw/edit-manifest.json` maps each editable element to a byte range; shadowing it fails quietly, by making the next visual-editor edit splice at the wrong offset.

**The tool is `edit_html_file`, not `edit_html_component`**, because an html site has no component model to name.

**Draft-only**, like the react lane but for a different reason: react cannot roll back because its build is async, whereas html has no build to gate on at all. A republish here would push unvalidated markup straight to a live site with nothing in between.

One bug found by its own tests: the write stored the raw path, so `create=true` on `./index.html` passed the not-already-present check, landed a second map entry, and both would materialize onto `index.html` — leaving the live home page decided by dict iteration order. It stores the normalized path now.

## 2. The contact form 403'd the visitor

A site published to workers.dev submitted its form and the visitor was shown `{"detail":"Origin not allowed for this site"}`. The owner saw no lead and no error.

The pin was not buying much. It guards a credential that is already public on three of the four engines — html, react and static svelte all ship `paw_key` as a hidden input in the page source — and `Origin` binds browsers only, so any script forges it. What it did reliably was fail closed on real submissions whenever the stored allowlist and the serving host disagreed: a draft publish that returns before the deploy stamp runs, an async react build inserted with `url=""`, apex vs `www.`, a preview URL, a `file://` open that sends no Origin.

Origin is now a recorded signal plus a per-site opt-in (`enforce_origin`, default off) — the posture Formspree and Basin ship. Honeypot, rate limit, injection screen, payload cap, constant-time key compare and the open-redirect guard are untouched.

Two things had to ship with it:

- **The 303 no longer echoes the request Origin.** That was safe only because the origin had just been pinned; without the pin it is an open redirect anyone can drive with a header. It prefers an allowlisted origin (so a custom-domain visitor stays on their domain) and otherwise falls back to the site's own url — never a host the caller chose.
- **The known-host set is derived**, folding in the site's own url host and attached domains, both values we wrote from a deploy we performed. Without it a stale allowlist marks a site's own traffic unrecognized, and a flag that fires on the normal case is one people learn to ignore — and for a site that opts into enforcement it would be a live 403 on its own pages.

## Testing

- `tests/ee/sites/test_html_file_edit.py` — 32 tests
- `tests/ee/agent/test_sites_mcp_server/test_edit_html_file.py` — 22 tests
- `tests/cloud/leads/test_router.py` — rewritten where it pinned the old fail-closed default, plus the derivation and open-redirect cases

Mutation plans, both fully caught: `html_edit_lane.json` (14), `capture_origin_posture.json` (13). Two escaped on the first html run — one showed the sites-service existence check is only observable on the `edits` path (a KeyError where a 404 belongs), the other that the chokepoint's engine gate needed testing directly rather than through a caller that rejects first. Both now have tests.

`tests/ee` (1824), `tests/cloud/{leads,sites,surface}`, `tests/sites_capture`, `tests/atlas` green. Ruff and import-linter clean.

## Not done

The `enforce_origin` flag has no UI — it is settable on the model only. Worth a Sites settings toggle if anyone wants strict mode without a shell.
