### PR TITLE
feat(sites): the free tier had nothing making it free

### DIFF
--- a/ee/pocketpaw_ee/cloud/billing/site_plans.py
+++ b/ee/pocketpaw_ee/cloud/billing/site_plans.py
@@ -13,6 +13,9 @@
 #     records the intended tier WITHOUT a live charge.
 #   * ``cloudflare_features`` — the set of Cloudflare features a higher tier
 #     resells (BC-10 provisions these on publish). The base tier resells none.
+#   * ``badge_removal`` — whether a site on this tier may ship WITHOUT the
+#     free-tier attribution badge. This is the per-site paid tier's headline
+#     feature, so it lives on the tier rather than on the workspace plan.
 #
 # Read-only by design (mirrors ``billing.plans``): no DB, no writes, no emit.
 # ``list_site_plans`` / ``get_site_plan`` return frozen ``SitePlanTier`` value
@@ -20,6 +23,16 @@
 # never drift.
 #
 # Created 2026-06-24 (integration/billing-credits, BC-9): new module.
+# Updated 2026-08-13 (feat/sites-free-badge): added ``badge_removal`` — the gate
+#   ``sites.badge`` reads to decide whether a publish must stamp the attribution
+#   badge. The base tier does NOT carry it (that is what free means); the paid
+#   tiers do. Sourced from its own constant rather than folded into
+#   ``cloudflare_features``, which is specifically about RESOLD Cloudflare
+#   capability and would be the wrong home for a billing-policy flag.
+#   NOTE for the pricing-spec migration (step 3 of the build order in
+#   docs/design/drafts/2026-08-13-paw-sites-pricing-spec.md): when basic/pro/
+#   business are rekeyed to free/site/staff, this mapping moves with them and is
+#   the ONLY place the badge's plan gate is expressed.
 
 from __future__ import annotations
 
@@ -48,6 +61,16 @@ _SITE_PLAN_CF_FEATURES: dict[str, frozenset[str]] = {
     "business": frozenset({"custom_domain", "analytics", "waf", "edge_cache"}),
 }
 
+# Whether a tier may ship a site WITHOUT the attribution badge. ``basic`` is the
+# free floor and keeps its badge — that is the whole difference between free and
+# paid. Absent/unknown keys resolve False in ``_build``, so a typo means BADGED:
+# fail-closed, matching ``sites.badge``'s posture everywhere else.
+_SITE_PLAN_BADGE_REMOVAL: dict[str, bool] = {
+    "basic": False,
+    "pro": True,
+    "business": True,
+}
+
 # Order the catalog is listed in — the price ladder, cheapest first.
 _SITE_TIER_ORDER: tuple[str, ...] = ("basic", "pro", "business")
 
@@ -63,12 +86,15 @@ class SitePlanTier:
     recurring annual sticker (USD, whole dollars). ``dodo_product_id`` is the
     recurring-product id, or None until config populates it. ``cloudflare_features``
     is the set of Cloudflare features the tier resells (BC-10 provisions them).
+    ``badge_removal`` is whether a site on this tier may ship without the
+    attribution badge — read by ``sites.badge.badge_required``.
     """
 
     key: str
     annual_price_usd: int
     dodo_product_id: str | None
     cloudflare_features: frozenset[str]
+    badge_removal: bool = False
 
 
 def _dodo_product_for(key: str) -> str | None:
@@ -105,6 +131,7 @@ def _build(key: str) -> SitePlanTier:
         annual_price_usd=_SITE_PLAN_ANNUAL_PRICE_USD.get(key, 0),
         dodo_product_id=_dodo_product_for(key),
         cloudflare_features=_SITE_PLAN_CF_FEATURES.get(key, frozenset()),
+        badge_removal=_SITE_PLAN_BADGE_REMOVAL.get(key, False),
     )
 
 

--- a/ee/pocketpaw_ee/cloud/entitlements/domain.py
+++ b/ee/pocketpaw_ee/cloud/entitlements/domain.py
@@ -29,6 +29,13 @@
 #   (``int | None``, None = uncapped) — the workspace S3 STORAGE cap in bytes the
 #   uploads pipeline enforces at upload time. Fail-closed to the Free value
 #   (5 GB) on the fallback path.
+# Updated 2026-08-13 (feat/sites-site-entitlements): added ``SiteEntitlements`` —
+#   the PER-SITE shape, a second scope beside the workspace one. Sites are the
+#   only thing billed per-object (``Site.plan_tier`` + ``subscription_status``),
+#   so "what may this SITE do" cannot be answered by the workspace resolver.
+#   Deliberately a separate frozen class rather than fields bolted onto
+#   ``Entitlements``: they resolve from different sources, on different cadences,
+#   and a caller that wants one almost never wants the other.
 
 from __future__ import annotations
 
@@ -71,3 +78,40 @@ class Entitlements:
     max_call_seconds_per_day: int | None
     max_storage_bytes: int | None
     features: frozenset[str] = field(default_factory=frozenset)
+
+
+@dataclass(frozen=True)
+class SiteEntitlements:
+    """What ONE site is entitled to, resolved from its own per-site plan.
+
+    A second scope beside ``Entitlements``. Sites are the only thing this system
+    bills per-object, so "may THIS site drop its badge" is not answerable from the
+    workspace plan — it depends on ``Site.plan_tier`` and, critically, on whether
+    that site's own subscription is actually paying.
+
+    ``subscription_active`` is the load-bearing field and the reason this class
+    exists. A cancelled per-site subscription sets ``subscription_status`` and
+    LEAVES ``plan_tier`` on the paid key — nothing resets it — so a resolver that
+    reads the tier alone hands a cancelled site every paid capability forever.
+    The same hole is open wider today: with no Dodo product configured, a paid
+    publish records its intended tier with NO live charge and
+    ``subscription_status="none"``. Every paid capability below is therefore
+    gated on the tier granting it AND the subscription being active.
+
+    Only "pending" is worth a note among the inactive states: a pending site is
+    not deployed yet (the charge-first flow deploys on activation), so failing
+    closed on it cannot badge a live paying site.
+
+    Deliberately ABSENT: ``conv_allowance``, ``conv_rate_usd`` and
+    ``white_label``. The first two wait on which meter owns a concierge run, and
+    the third on an org entity that does not exist. A field that always returns
+    0/False reads as implemented, which is worse than its absence.
+    """
+
+    site_id: str
+    workspace_id: str
+    plan_tier: str
+    subscription_active: bool
+    badge_required: bool
+    custom_domain: bool
+    concierge_enabled: bool

--- a/ee/pocketpaw_ee/cloud/entitlements/service.py
+++ b/ee/pocketpaw_ee/cloud/entitlements/service.py
@@ -45,7 +45,8 @@ from __future__ import annotations
 
 from pocketpaw_ee.cloud._core.errors import ValidationError
 from pocketpaw_ee.cloud.billing import plans as plan_catalog
-from pocketpaw_ee.cloud.entitlements.domain import Entitlements
+from pocketpaw_ee.cloud.billing import site_plans as site_plan_catalog
+from pocketpaw_ee.cloud.entitlements.domain import Entitlements, SiteEntitlements
 
 
 async def resolve_entitlements(workspace_id: str) -> Entitlements:
@@ -105,4 +106,64 @@ async def resolve_entitlements(workspace_id: str) -> Entitlements:
         max_call_seconds_per_day=tier.max_call_seconds_per_day,
         max_storage_bytes=tier.max_storage_bytes,
         features=tier.features,
+    )
+
+
+# The per-site subscription states that count as PAYING. Everything else —
+# ``none`` (no subscription, including the paid-tier-recorded-but-never-charged
+# case a missing Dodo product produces), ``pending`` (created, not yet confirmed;
+# such a site is not deployed yet) and ``cancelled`` (which LEAVES ``plan_tier``
+# on the paid key) — resolves to no paid capability.
+_ACTIVE_SITE_SUBSCRIPTION_STATUSES = frozenset({"active"})
+
+
+def resolve_site_entitlements(
+    *,
+    site_id: str,
+    workspace_id: str,
+    plan_tier: str | None,
+    subscription_status: str | None,
+    concierge_enabled: bool,
+) -> SiteEntitlements:
+    """Resolve ONE site to what it may do, from its own per-site plan.
+
+    PURE and synchronous, taking the site's billing fields rather than reading
+    them: ``entitlements`` may not import ``models.site`` (EE cloud rule 2 — only
+    ``sites/service.py`` owns that document), so the caller that owns the doc
+    passes what it owns. That also makes every branch here testable without a
+    database.
+
+    Every paid capability is gated on the tier granting it AND the subscription
+    being active. Reading the tier alone is the bug this function exists to
+    prevent: cancellation never resets ``plan_tier``, and an unconfigured Dodo
+    product records a paid tier with no charge at all.
+
+    Fails closed on every unknown: an absent/unknown tier resolves to the base
+    (badged, no custom domain) rather than raising or substituting a paid tier.
+    """
+    tier = site_plan_catalog.get_site_plan(plan_tier)
+    # ``get_site_plan`` deliberately does not substitute a floor, so an unknown or
+    # missing key lands here as None — the fail-closed default.
+    resolved_key = tier.key if tier is not None else site_plan_catalog.BASE_SITE_PLAN_KEY
+
+    subscription_active = (subscription_status or "none") in _ACTIVE_SITE_SUBSCRIPTION_STATUSES
+
+    # Both paid capabilities collapse to False unless the tier grants them AND the
+    # subscription is paying. Written as an explicit branch rather than
+    # ``paid and tier.x`` so the None-narrowing is visible to the type checker
+    # instead of resting on short-circuit evaluation.
+    badge_removal = False
+    custom_domain = False
+    if tier is not None and subscription_active:
+        badge_removal = tier.badge_removal
+        custom_domain = "custom_domain" in tier.cloudflare_features
+
+    return SiteEntitlements(
+        site_id=site_id,
+        workspace_id=workspace_id,
+        plan_tier=resolved_key,
+        subscription_active=subscription_active,
+        badge_required=not badge_removal,
+        custom_domain=custom_domain,
+        concierge_enabled=bool(concierge_enabled),
     )

--- a/ee/pocketpaw_ee/sites/badge.py
+++ b/ee/pocketpaw_ee/sites/badge.py
@@ -94,15 +94,42 @@ BADGE_MARKER = "data-paw-badge"
 BADGE_OPEN = "<!--paw-badge-->"
 BADGE_CLOSE = "<!--/paw-badge-->"
 
-# Removal patterns. The sentinelled one covers this version onward; the two
-# legacy ones cover the un-sentinelled badge already deployed to live sites.
-# All three match only markup THIS module wrote — a customer's own ``<style>`` or
-# ``<a>`` cannot satisfy them, because each is anchored on our marker.
-_SENTINELLED_RE = re.compile(re.escape(BADGE_OPEN) + ".*?" + re.escape(BADGE_CLOSE), re.DOTALL)
-_LEGACY_STYLE_RE = re.compile(
-    r"<style>(?=[^<]*a\[" + re.escape(BADGE_MARKER) + r"\]).*?</style>", re.DOTALL
+# Removal patterns. The sentinelled one covers this version onward; the two legacy
+# ones cover the un-sentinelled badge already deployed to live sites.
+#
+# EACH IS TEMPERED AND BOUNDED, and the first draft was neither. ``.*?`` between
+# our own delimiters looks safe because "only our markup has our marker" — but the
+# match does not have to START at our markup. A page carrying one stray
+# ``<!--paw-badge-->`` (a customer who pasted it, or an imported page that already
+# had one) matched from THAT open forward to OUR badge's close, and everything
+# between was deleted: a 3,127-byte page came out at 26 bytes, the whole body gone.
+#
+# The tempered group ``(?:(?!<open>)[\s\S])`` cannot cross a second opening
+# delimiter, so a stray open can no longer swallow the region up to our real badge
+# — the match fails there and succeeds on our badge alone, leaving their content
+# untouched. The ``{0,N}`` bound is the backstop: our whole snippet is ~2.9KB, so
+# nothing legitimate approaches this, and a pattern that somehow still ran away
+# would drop a bounded region rather than a page.
+#
+# The customer cannot USE any of this — a stripped page is immediately re-injected,
+# so there is no bypass here, only the risk of destroying their content.
+_MAX_BADGE_SPAN = 16384
+
+
+def _tempered(open_pat: str, close_pat: str, guard: str) -> re.Pattern[str]:
+    """``open … close``, unable to cross another ``guard``, bounded in length."""
+    return re.compile(
+        open_pat + r"(?:(?!" + guard + r")[\s\S]){0," + str(_MAX_BADGE_SPAN) + r"}?" + close_pat
+    )
+
+
+_SENTINELLED_RE = _tempered(re.escape(BADGE_OPEN), re.escape(BADGE_CLOSE), re.escape(BADGE_OPEN))
+_LEGACY_STYLE_RE = _tempered(
+    r"<style>(?=[^<]*a\[" + re.escape(BADGE_MARKER) + r"\])", r"</style>", r"<style[\s>]"
 )
-_LEGACY_ANCHOR_RE = re.compile(r"<a\s+" + re.escape(BADGE_MARKER) + r"=.*?</a>", re.DOTALL)
+# ``="1"`` is the value this module has always emitted, so requiring it is a
+# positive identification rather than "any element wearing our attribute name".
+_LEGACY_ANCHOR_RE = _tempered(r"<a\s+" + re.escape(BADGE_MARKER) + r'="1"', r"</a>", r"<a[\s>]")
 
 # Where the badge points. NOTE: this is the PRODUCT domain, which is open
 # decision #7 in the pricing spec (the sites' own hostname is still unsettled —

--- a/ee/pocketpaw_ee/sites/badge.py
+++ b/ee/pocketpaw_ee/sites/badge.py
@@ -35,6 +35,15 @@
 #     rule in the customer's OWN stylesheet, which we build from. Inline
 #     ``!important`` outranks any author stylesheet, which closes that vector.
 #
+# THE LOCK / LOOK SPLIT. The snippet is a scoped ``<style>`` block plus the
+# anchor. The anchor carries the lock inline; the block carries appearance,
+# ``:hover`` and ``prefers-reduced-motion``, none of which a style attribute can
+# express. Enforcement therefore lives entirely in the part no stylesheet can
+# beat, and the part a customer CAN restyle is the part where restyling is
+# harmless. The mark is an inline SVG (from docs/public/favicon.svg) rather than
+# an ``<img>``: no second request, so a strict CSP or a blocked host cannot leave
+# a broken box where the brand goes.
+#
 # GATED PER SITE, off ``SitePlanTier.badge_removal`` — the site-plan catalog, not
 # the workspace plan. Badge removal is a property of the SITE the customer paid
 # for, and ``Site.plan_tier`` is the only per-site billing axis that exists today.
@@ -45,6 +54,14 @@
 # pricing build order in docs/design/drafts/2026-08-13-paw-sites-pricing-spec.md
 # (see review finding #3 — the badge was specced as the load-bearing free-tier
 # mechanism and had no implementation anywhere).
+# Updated 2026-08-13 (feat/sites-free-badge): styled to the floating-pill genre the
+#   AI-builder badges established (Lovable, Emergent) — dark translucent pill,
+#   backdrop blur, hairline border, brand mark, hover. Our own mark and wording,
+#   not their trade dress. Structurally this added the lock/look split above:
+#   ``build_badge_anchor`` (locked) is now separate from ``build_badge_html``
+#   (look + anchor) so the lock can be asserted against the ELEMENT, not the
+#   snippet — scanning the whole snippet for ``display:`` finds the look block's
+#   copy first and passes while the lock is gone.
 
 from __future__ import annotations
 
@@ -70,36 +87,90 @@ BADGE_TEXT = "Built with PocketPaw"
 
 _HTML_SUFFIXES = (".html", ".htm")
 
-# The properties an author stylesheet would reach for to hide the badge. Inline +
-# ``!important`` beats any author rule, including ``#id .class {display:none}``.
+# THE LOCK. The properties an author stylesheet would reach for to hide the badge,
+# inline and ``!important``. A style-attribute ``!important`` is the strongest
+# author-origin declaration in the cascade — it beats ``#id .cls {display:none
+# !important}`` in the customer's own stylesheet, which is the realistic attack
+# (they never touch our built artifact, but we build FROM their source).
+#
+# ``transform`` is locked, and that is a deliberate cost: it rules out a hover
+# LIFT, because a locked transform cannot be re-enabled for one state. Losing
+# ``transform:scale(0)`` as a hiding vector is worth more than the animation, so
+# the hover below moves colour and shadow instead of position. Do not trade the
+# lock back for the lift.
 _LOCKED_STYLE = (
     "position:fixed!important;"
     "right:16px!important;"
     "bottom:16px!important;"
     "z-index:2147483647!important;"
-    "display:flex!important;"
+    "display:inline-flex!important;"
     "visibility:visible!important;"
     "opacity:1!important;"
     "width:auto!important;"
     "height:auto!important;"
     "max-width:none!important;"
     "max-height:none!important;"
+    "min-width:0!important;"
     "clip-path:none!important;"
     "transform:none!important;"
+    "filter:none!important;"
     "pointer-events:auto!important;"
+    "font-size:12px!important;"
+    "text-indent:0!important;"
 )
 
-# Presentation only — a customer restyling these is welcome to.
-_LOOK_STYLE = (
-    "align-items:center;"
-    "gap:6px;"
-    "padding:6px 10px;"
-    "border-radius:999px;"
-    "background:#111;"
-    "color:#fff;"
-    "font:500 12px/1 system-ui,-apple-system,Segoe UI,sans-serif;"
-    "text-decoration:none;"
-    "box-shadow:0 2px 8px rgba(0,0,0,.24);"
+# THE LOOK. Everything below is presentation and degrades safely: a customer who
+# restyles it still has a visible badge, because the lock above is what keeps it
+# on the page.
+#
+# Why a <style> block at all, when the lock is inline: ``:hover`` and
+# ``prefers-reduced-motion`` cannot be expressed in a style attribute. Splitting
+# them is what buys a badge that looks considered instead of stamped on, without
+# weakening the part that enforces.
+#
+# Scoped to the marker attribute so it cannot touch the customer's own elements,
+# and every declaration is a single rule — no resets, no ``*`` selectors.
+_LOOK_CSS = (
+    "a[data-paw-badge]{"
+    "align-items:center;gap:7px;padding:7px 13px 7px 8px;border-radius:999px;"
+    "background:rgba(15,17,21,.78);"
+    "-webkit-backdrop-filter:blur(14px) saturate(140%);"
+    "backdrop-filter:blur(14px) saturate(140%);"
+    "border:1px solid rgba(255,255,255,.16);"
+    "color:#f4f6f8;"
+    "font-family:ui-sans-serif,system-ui,-apple-system,'Segoe UI',sans-serif;"
+    "font-weight:500;line-height:1;letter-spacing:.01em;text-decoration:none;"
+    "box-shadow:0 1px 2px rgba(0,0,0,.28),0 8px 24px -6px rgba(0,0,0,.45);"
+    "transition:background .18s ease,border-color .18s ease,box-shadow .18s ease;"
+    "}"
+    "a[data-paw-badge]:hover{"
+    "background:rgba(22,25,31,.9);"
+    "border-color:rgba(255,255,255,.3);"
+    "box-shadow:0 1px 2px rgba(0,0,0,.3),0 12px 32px -6px rgba(0,0,0,.55);"
+    "}"
+    "a[data-paw-badge]:focus-visible{"
+    "outline:2px solid #0A84FF;outline-offset:2px;"
+    "}"
+    "a[data-paw-badge] svg{display:block;flex:none;}"
+    "@media(prefers-reduced-motion:reduce){"
+    "a[data-paw-badge]{transition:none;}"
+    "}"
+)
+
+# The paw mark, inlined from docs/public/favicon.svg. Inline because the page is
+# served from the edge with no asset pipeline of ours behind it — an <img src>
+# would be a second request to a host this site does not own, and a CSP or an
+# offline viewer would leave a broken box where the brand goes.
+_MARK_SVG = (
+    '<svg width="17" height="17" viewBox="0 0 32 32" aria-hidden="true" focusable="false">'
+    '<circle cx="16" cy="16" r="15" fill="#0A84FF"/>'
+    '<g transform="translate(4,4)" fill="none" stroke="#fff" stroke-width="2" '
+    'stroke-linecap="round" stroke-linejoin="round">'
+    '<circle cx="11" cy="4" r="2"/><circle cx="3" cy="7" r="2"/>'
+    '<circle cx="19" cy="7" r="2"/><circle cx="7" cy="19" r="2"/>'
+    '<circle cx="15" cy="19" r="2"/>'
+    '<path d="M8 14v.5a2 2 0 0 0 2 2h2a2 2 0 0 0 2-2V14a4 4 0 0 0-6 0z"/>'
+    "</g></svg>"
 )
 
 
@@ -127,14 +198,33 @@ def badge_required(*, badge_removal: bool) -> bool:
     return not badge_removal
 
 
-def build_badge_html() -> str:
-    """The badge markup: a plain anchor, no script, styles inline and locked."""
+def build_badge_anchor() -> str:
+    """Just the anchor — the element that carries the lock.
+
+    Split out from ``build_badge_html`` so the lock can be asserted against the
+    ELEMENT rather than the whole snippet. Searching the snippet for
+    ``display:`` finds whichever copy comes first, and the look block legitimately
+    carries unlocked declarations, so a test scanning the whole string measures
+    the wrong one and passes while the lock is gone.
+    """
+    text = html.escape(BADGE_TEXT)
     return (
         f'<a {BADGE_MARKER}="1" href="{BADGE_HREF}" target="_blank" '
         f'rel="noopener noreferrer nofollow" '
-        f'aria-label="{html.escape(BADGE_TEXT)}" '
-        f'style="{_LOCKED_STYLE}{_LOOK_STYLE}">{html.escape(BADGE_TEXT)}</a>'
+        f'aria-label="{text}" '
+        f'style="{_LOCKED_STYLE}">{_MARK_SVG}<span>{text}</span></a>'
     )
+
+
+def build_badge_html() -> str:
+    """The full badge snippet: the scoped look, then the locked anchor.
+
+    No script, and nothing fetched — the mark is an inline SVG, so the badge is
+    complete the moment the HTML arrives and survives a blocked CDN, a strict CSP
+    and a reader with JavaScript off. Those are the same conditions under which a
+    script-injected badge quietly disappears, which is why this one is markup.
+    """
+    return f"<style>{_LOOK_CSS}</style>{build_badge_anchor()}"
 
 
 def inject_into_html(page: str, badge: str) -> str | None:
@@ -231,6 +321,7 @@ __all__ = [
     "BADGE_TEXT",
     "BadgeInjectionError",
     "badge_required",
+    "build_badge_anchor",
     "build_badge_html",
     "inject_into_html",
     "inject_into_tree",

--- a/ee/pocketpaw_ee/sites/badge.py
+++ b/ee/pocketpaw_ee/sites/badge.py
@@ -67,6 +67,7 @@ from __future__ import annotations
 
 import html
 import logging
+import re
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -76,6 +77,23 @@ logger = logging.getLogger(__name__)
 # contract as ``paw_bar.embed.EMBED_MARKER``, deliberately a different string so
 # the two features can never satisfy each other's check.
 BADGE_MARKER = "data-paw-badge"
+
+# The sentinels wrapping every injected badge. They exist so a LATER version can
+# remove an EARLIER one without knowing anything about the markup between them:
+# the badge is a thing we restyle, and the first version had no way to be
+# replaced, so a republished site kept whatever badge it was first given.
+BADGE_OPEN = "<!--paw-badge-->"
+BADGE_CLOSE = "<!--/paw-badge-->"
+
+# Removal patterns. The sentinelled one covers this version onward; the two
+# legacy ones cover the un-sentinelled badge already deployed to live sites.
+# All three match only markup THIS module wrote — a customer's own ``<style>`` or
+# ``<a>`` cannot satisfy them, because each is anchored on our marker.
+_SENTINELLED_RE = re.compile(re.escape(BADGE_OPEN) + ".*?" + re.escape(BADGE_CLOSE), re.DOTALL)
+_LEGACY_STYLE_RE = re.compile(
+    r"<style>(?=[^<]*a\[" + re.escape(BADGE_MARKER) + r"\]).*?</style>", re.DOTALL
+)
+_LEGACY_ANCHOR_RE = re.compile(r"<a\s+" + re.escape(BADGE_MARKER) + r"=.*?</a>", re.DOTALL)
 
 # Where the badge points. NOTE: this is the PRODUCT domain, which is open
 # decision #7 in the pricing spec (the sites' own hostname is still unsettled —
@@ -224,15 +242,44 @@ def build_badge_html() -> str:
     and a reader with JavaScript off. Those are the same conditions under which a
     script-injected badge quietly disappears, which is why this one is markup.
     """
-    return f"<style>{_LOOK_CSS}</style>{build_badge_anchor()}"
+    return f"{BADGE_OPEN}<style>{_LOOK_CSS}</style>{build_badge_anchor()}{BADGE_CLOSE}"
+
+
+def strip_badge(page: str) -> str:
+    """Remove any badge this module has ever injected, leaving the page otherwise
+    byte-identical.
+
+    Two patterns, because the badge outlived its first markup:
+      * SENTINELLED — everything between the comment markers. Every badge from
+        this version on is wrapped, so removal never has to understand the markup
+        inside and a future restyle costs nothing here.
+      * LEGACY — the un-sentinelled shapes already deployed: the scoped style
+        block and the anchor. Both are matched on our own marker only, so nothing
+        of the customer's can be caught by them.
+
+    Regex over HTML is normally a bad idea; it is bounded here because this only
+    ever matches markup THIS module wrote, whose shape is known exactly.
+    """
+    page = _SENTINELLED_RE.sub("", page)
+    page = _LEGACY_STYLE_RE.sub("", page)
+    page = _LEGACY_ANCHOR_RE.sub("", page)
+    return page
 
 
 def inject_into_html(page: str, badge: str) -> str | None:
-    """Return ``page`` with ``badge`` before the last ``</body>``, or ``None`` if
-    it is already badged.
+    """Return ``page`` carrying the CURRENT badge, or ``None`` if it already does.
 
-    ``None`` (not the unchanged page) so the caller can tell "nothing to do" from
-    "rewritten" and skip the write — the steady state on every re-publish.
+    REPLACES rather than skips. Skip-if-present is what
+    ``paw_bar.embed.inject_into_html`` does, and it is right there — that snippet
+    never changes. The badge is markup we iterate on, and PERF-3 builds into a
+    STABLE per-pocket working dir, so an already-injected page comes back around
+    on the next publish. Skipping it pinned the first badge a site was ever given,
+    permanently, which is exactly how a restyle reached a republished site and
+    changed nothing.
+
+    Still returns ``None`` when the page already carries this exact badge, so the
+    steady-state re-publish writes nothing and the caller's "changed" count stays
+    honest.
 
     The insertion point is the LAST ``</body>``: a page can mention the string in
     an inline script or a code sample, and the real closing tag is the final one.
@@ -240,12 +287,18 @@ def inject_into_html(page: str, badge: str) -> str | None:
     the badge appended rather than skipped — an unbadged page is the one outcome
     this module does not accept.
     """
-    if BADGE_MARKER in page:
-        return None
-    idx = page.lower().rfind("</body>")
+    stripped = strip_badge(page)
+    idx = stripped.lower().rfind("</body>")
     if idx == -1:
-        return f"{page}\n{badge}\n"
-    return f"{page[:idx]}{badge}\n{page[idx:]}"
+        updated = f"{stripped}{badge}"
+    else:
+        updated = f"{stripped[:idx]}{badge}{stripped[idx:]}"
+    # No surrounding whitespace, and that is load-bearing rather than tidy:
+    # ``strip_badge`` removes exactly the sentinelled block, so any newline added
+    # around it would survive the strip and make the round-trip differ from the
+    # original by one character — which reads as "changed" on every single
+    # re-publish and rewrites every page forever.
+    return None if updated == page else updated
 
 
 def inject_into_tree(root: Path) -> list[Path]:

--- a/ee/pocketpaw_ee/sites/badge.py
+++ b/ee/pocketpaw_ee/sites/badge.py
@@ -62,6 +62,15 @@
 #   (look + anchor) so the lock can be asserted against the ELEMENT, not the
 #   snippet — scanning the whole snippet for ``display:`` finds the look block's
 #   copy first and passes while the lock is gone.
+# Updated 2026-08-15 (feat/sites-free-badge, review): closed a bypass this module
+#   shipped with. The lock covered the ANCHOR only, so ``a[data-paw-badge] span
+#   {display:none}`` — two ordinary lines, no ``!important`` needed — left a
+#   visible empty pill carrying no mark and no wording. The mark and the text now
+#   carry their own inline locks (``_CHILD_LOCK``), and a ``_GUARD_CSS`` rule
+#   neutralises the pseudo-element overlay, which is the one vector with no
+#   element to lock. Also replaced the raise on an undecodable page with a
+#   byte-preserving latin-1 round-trip: refusing it made an imported non-UTF-8
+#   site permanently unpublishable, which is worse than what it prevented.
 
 from __future__ import annotations
 
@@ -137,6 +146,55 @@ _LOCKED_STYLE = (
     "text-indent:0!important;"
 )
 
+# THE CHILD LOCK, and the reason it exists is a bug this module shipped with.
+#
+# Locking the anchor alone is not enough, and the gap was invisible because every
+# locked property still reported "visible". The mark and the text are separate
+# elements INSIDE the anchor, and an element with no inline style is styleable by
+# any author rule — it does not even need ``!important``:
+#
+#     a[data-paw-badge] span { display:none }
+#     a[data-paw-badge] svg  { display:none }
+#
+# Two ordinary lines left the anchor fixed, opaque, at max z-index, and carrying
+# nothing: an empty pill. Enforcement that only defends the container is not
+# enforcement, so the children now carry the same treatment.
+_CHILD_LOCK = (
+    "visibility:visible!important;"
+    "opacity:1!important;"
+    "position:static!important;"
+    "transform:none!important;"
+    "filter:none!important;"
+    "clip-path:none!important;"
+    "max-width:none!important;"
+    "max-height:none!important;"
+)
+
+# ``color`` and ``font-size`` are hiding vectors on TEXT specifically —
+# ``color:transparent`` and ``font-size:0`` each erase the wording while leaving a
+# perfectly "visible" element behind. ``letter-spacing`` collapses it the same way.
+_SPAN_LOCK = _CHILD_LOCK + (
+    "display:inline!important;"
+    "font-size:12px!important;"
+    "line-height:1!important;"
+    "color:#f4f6f8!important;"
+    "letter-spacing:.01em!important;"
+    "text-indent:0!important;"
+    "white-space:nowrap!important;"
+)
+
+# ``max-width`` is in the common set for a reason the mark makes obvious: a locked
+# ``width:17px`` is still beaten by ``max-width:0``, so locking one without the
+# other locks nothing. ``flex:none`` stops a flex parent shrinking it to zero.
+_MARK_LOCK = _CHILD_LOCK + (
+    "display:block!important;"
+    "width:17px!important;"
+    "height:17px!important;"
+    "min-width:17px!important;"
+    "min-height:17px!important;"
+    "flex:none!important;"
+)
+
 # THE LOOK. Everything below is presentation and degrades safely: a customer who
 # restyles it still has a visible badge, because the lock above is what keeps it
 # on the page.
@@ -169,10 +227,29 @@ _LOOK_CSS = (
     "a[data-paw-badge]:focus-visible{"
     "outline:2px solid #0A84FF;outline-offset:2px;"
     "}"
-    "a[data-paw-badge] svg{display:block;flex:none;}"
     "@media(prefers-reduced-motion:reduce){"
     "a[data-paw-badge]{transition:none;}"
     "}"
+)
+
+# THE GUARD. One vector that CANNOT be locked inline, because it has no element to
+# put a style attribute on: a pseudo-element painted over the badge —
+# ``a[data-paw-badge]::after{content:"";position:absolute;inset:0;background:#fff}``
+# — covers it as cheaply as the child bypass did.
+#
+# So this rule lives in the stylesheet by necessity, not by preference, and it is
+# the ONE place ``!important`` is allowed outside the element lock. It is emitted
+# LAST in the document, so it beats an author rule of equal specificity on order.
+#
+# It is NOT airtight, and that is worth stating plainly rather than discovering
+# later: a higher-specificity author rule (``body a[data-paw-badge]::after``) with
+# ``!important`` still wins. Neither this nor any CSS can stop a customer script
+# appending an overlay at runtime. The badge raises the cost of removal; it does
+# not make removal impossible, and nothing rendered inside a page the customer
+# controls ever could.
+_GUARD_CSS = (
+    "a[data-paw-badge]::before,a[data-paw-badge]::after"
+    "{content:none!important;display:none!important;}"
 )
 
 # The paw mark, inlined from docs/public/favicon.svg. Inline because the page is
@@ -180,7 +257,8 @@ _LOOK_CSS = (
 # would be a second request to a host this site does not own, and a CSP or an
 # offline viewer would leave a broken box where the brand goes.
 _MARK_SVG = (
-    '<svg width="17" height="17" viewBox="0 0 32 32" aria-hidden="true" focusable="false">'
+    '<svg width="17" height="17" viewBox="0 0 32 32" aria-hidden="true" '
+    f'focusable="false" style="{_MARK_LOCK}">'
     '<circle cx="16" cy="16" r="15" fill="#0A84FF"/>'
     '<g transform="translate(4,4)" fill="none" stroke="#fff" stroke-width="2" '
     'stroke-linecap="round" stroke-linejoin="round">'
@@ -224,13 +302,18 @@ def build_badge_anchor() -> str:
     ``display:`` finds whichever copy comes first, and the look block legitimately
     carries unlocked declarations, so a test scanning the whole string measures
     the wrong one and passes while the lock is gone.
+
+    EVERY element here carries a lock — anchor, mark and text. The children are
+    not decoration inside a locked box: they are the badge, and an unlocked child
+    is a two-line bypass (see ``_CHILD_LOCK``).
     """
     text = html.escape(BADGE_TEXT)
     return (
         f'<a {BADGE_MARKER}="1" href="{BADGE_HREF}" target="_blank" '
         f'rel="noopener noreferrer nofollow" '
         f'aria-label="{text}" '
-        f'style="{_LOCKED_STYLE}">{_MARK_SVG}<span>{text}</span></a>'
+        f'style="{_LOCKED_STYLE}">{_MARK_SVG}'
+        f'<span style="{_SPAN_LOCK}">{text}</span></a>'
     )
 
 
@@ -242,7 +325,7 @@ def build_badge_html() -> str:
     and a reader with JavaScript off. Those are the same conditions under which a
     script-injected badge quietly disappears, which is why this one is markup.
     """
-    return f"{BADGE_OPEN}<style>{_LOOK_CSS}</style>{build_badge_anchor()}{BADGE_CLOSE}"
+    return f"{BADGE_OPEN}<style>{_LOOK_CSS}{_GUARD_CSS}</style>{build_badge_anchor()}{BADGE_CLOSE}"
 
 
 def strip_badge(page: str) -> str:
@@ -308,10 +391,14 @@ def inject_into_tree(root: Path) -> list[Path]:
     ``paw_bar.embed.inject_into_tree`` (that one logs and skips, because a bar is
     worth less than a deploy):
 
-      * an unreadable, undecodable or unwritable page RAISES — that page exists,
-        the deploy will upload it, and it would go out unbadged. This is the whole
-        enforcement, and it is exactly the class of failure a customer's own
-        content can provoke (a page that will not decode as UTF-8).
+      * an unreadable or unwritable page RAISES — that page exists, the deploy
+        will upload it, and it would go out unbadged. This is the whole
+        enforcement.
+
+    An UNDECODABLE page does not raise, and used to. It is badged through a
+    byte-preserving latin-1 round-trip instead — see the read block below. A
+    non-UTF-8 page is an ordinary imported one, not an attack, and raising made
+    that site permanently unpublishable with no override.
 
     ...but NOT on an empty root, and the distinction is deliberate rather than a
     softening. ``root`` here is ``project_dir / resolve_static_output_rel(...)`` —
@@ -346,15 +433,42 @@ def inject_into_tree(root: Path) -> list[Path]:
             continue
         seen_pages += 1
         try:
-            page = path.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError) as exc:
+            raw = path.read_bytes()
+        except OSError as exc:
             raise BadgeInjectionError(f"unreadable page {path} — refusing to deploy") from exc
+
+        # UTF-8 first, latin-1 as a BYTE-PRESERVING fallback rather than a raise.
+        #
+        # The raise was the wrong tool here. A page that will not decode as UTF-8 is
+        # not an attack — it is an ordinary imported page (sites/import crawls real
+        # sites, which are full of windows-1252) — and refusing it meant that site
+        # could never publish again, with no operator override anywhere. A
+        # permanent, un-overridable publish failure is a worse outcome than the one
+        # it was protecting against.
+        #
+        # latin-1 round-trips ANY byte sequence exactly (every byte maps to one
+        # code point and back), and the badge is pure ASCII, so writing back in the
+        # same codec reproduces the original bytes with ASCII spliced in. That is
+        # safe for every ASCII-compatible encoding — utf-8, latin-1, windows-1252,
+        # the whole ISO-8859 family. ``test_the_badge_is_pure_ascii`` pins the
+        # assumption the fallback rests on; if the badge ever gains a non-ASCII
+        # character, this silently corrupts a latin-1 page and that test is what
+        # stops it.
+        try:
+            page, codec = raw.decode("utf-8"), "utf-8"
+        except UnicodeDecodeError:
+            page, codec = raw.decode("latin-1"), "latin-1"
+            logger.info(
+                "sites badge: %s is not UTF-8 — badging it byte-preserving as latin-1",
+                path,
+            )
+
         updated = inject_into_html(page, badge)
         if updated is None:
             continue
         try:
-            path.write_text(updated, encoding="utf-8")
-        except OSError as exc:
+            path.write_bytes(updated.encode(codec))
+        except (OSError, UnicodeEncodeError) as exc:
             raise BadgeInjectionError(f"unwritable page {path} — refusing to deploy") from exc
         changed.append(path)
 

--- a/ee/pocketpaw_ee/sites/badge.py
+++ b/ee/pocketpaw_ee/sites/badge.py
@@ -1,0 +1,237 @@
+# ee/pocketpaw_ee/sites/badge.py — the FREE-TIER ATTRIBUTION BADGE: the
+# server-rendered "Built with PocketPaw" mark every un-upgraded site carries.
+#
+# This is the enforcement half of the free tier. Removing the badge is what the
+# paid per-site plan sells, so the badge is not decoration — it is the only thing
+# separating free from paid, and it is treated as a gate, not a garnish.
+#
+# SHAPE MIRRORS ``paw_bar/embed.py`` DELIBERATELY: both inject into the built
+# static tree between the build and the deploy, so the artifact that lands is
+# already correct — no second deploy, no post-publish patch. Read that module
+# first; this one is its sibling.
+#
+# ...AND INVERTS ITS FAILURE POSTURE, WHICH IS THE WHOLE POINT. The concierge bar
+# is failure-SOFT on purpose ("a site going live matters more than its bar"). The
+# badge is failure-CLOSED on every page that will actually ship: an unwritable
+# file or a page that will not decode raises ``BadgeInjectionError`` and the
+# publish aborts before deploy. A badge that fails open is not an enforcement
+# mechanism — the exploit is simply to make injection fail and walk away with a
+# free unbadged site.
+#
+# The ONE case that is not fatal is an empty/missing output root, and that is
+# reasoned rather than lenient: this module resolves its root through the same
+# ``resolve_static_output_rel`` that ``sites.local_server`` and the Cloudflare
+# deploy resolve their UPLOAD source from. No tree means the deploy ships nothing
+# from that root either, so there is no state where the badge finds nothing and a
+# real page still goes live. See ``inject_into_tree`` — and do not restore a raise
+# there without re-checking that the deploy still reads the same root.
+#
+# SERVER-RENDERED, NOT CSS-HIDEABLE (the spec's words). Two consequences:
+#   * the badge is raw HTML in the document, never a ``<script>`` that draws it —
+#     a JS-blocked visitor still sees it, and there is no loader to 404.
+#   * every property that could hide it (``display``/``visibility``/``opacity``/
+#     ``position``/``z-index``/size) is inline AND ``!important``. The realistic
+#     attack is not editing our artifact (customers never touch it) — it is a
+#     rule in the customer's OWN stylesheet, which we build from. Inline
+#     ``!important`` outranks any author stylesheet, which closes that vector.
+#
+# GATED PER SITE, off ``SitePlanTier.badge_removal`` — the site-plan catalog, not
+# the workspace plan. Badge removal is a property of the SITE the customer paid
+# for, and ``Site.plan_tier`` is the only per-site billing axis that exists today.
+# When per-site entitlements land, ``badge_required`` is the one function that
+# changes.
+#
+# Created 2026-08-13 (feat/sites-free-badge): new module. Implements step 1 of the
+# pricing build order in docs/design/drafts/2026-08-13-paw-sites-pricing-spec.md
+# (see review finding #3 — the badge was specced as the load-bearing free-tier
+# mechanism and had no implementation anywhere).
+
+from __future__ import annotations
+
+import html
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# The attribute stamped on the injected badge. Presence of this string in a page
+# means "already badged" — the idempotence check on every re-publish. Same
+# contract as ``paw_bar.embed.EMBED_MARKER``, deliberately a different string so
+# the two features can never satisfy each other's check.
+BADGE_MARKER = "data-paw-badge"
+
+# Where the badge points. NOTE: this is the PRODUCT domain, which is open
+# decision #7 in the pricing spec (the sites' own hostname is still unsettled —
+# ``*.workers.dev`` today, ``sites.rohitk06.in`` on the proven custom-domain
+# lane). This constant is the single place it changes.
+BADGE_HREF = "https://pocketpaw.dev"
+
+BADGE_TEXT = "Built with PocketPaw"
+
+_HTML_SUFFIXES = (".html", ".htm")
+
+# The properties an author stylesheet would reach for to hide the badge. Inline +
+# ``!important`` beats any author rule, including ``#id .class {display:none}``.
+_LOCKED_STYLE = (
+    "position:fixed!important;"
+    "right:16px!important;"
+    "bottom:16px!important;"
+    "z-index:2147483647!important;"
+    "display:flex!important;"
+    "visibility:visible!important;"
+    "opacity:1!important;"
+    "width:auto!important;"
+    "height:auto!important;"
+    "max-width:none!important;"
+    "max-height:none!important;"
+    "clip-path:none!important;"
+    "transform:none!important;"
+    "pointer-events:auto!important;"
+)
+
+# Presentation only — a customer restyling these is welcome to.
+_LOOK_STYLE = (
+    "align-items:center;"
+    "gap:6px;"
+    "padding:6px 10px;"
+    "border-radius:999px;"
+    "background:#111;"
+    "color:#fff;"
+    "font:500 12px/1 system-ui,-apple-system,Segoe UI,sans-serif;"
+    "text-decoration:none;"
+    "box-shadow:0 2px 8px rgba(0,0,0,.24);"
+)
+
+
+class BadgeInjectionError(RuntimeError):
+    """A page that should have been badged was not.
+
+    Raised — never swallowed — so ``publish_pocket`` aborts before deploy. See the
+    failure-posture note at the top of this module: silently continuing here hands
+    out an unbadged free site, which is the exact outcome the badge exists to
+    prevent.
+    """
+
+
+def badge_required(*, badge_removal: bool) -> bool:
+    """Whether this site must carry the badge.
+
+    One line today, and deliberately its own function: this is the single
+    chokepoint every caller asks, so when per-site entitlements arrive (step 2 of
+    the build order) the plumbing changes here and nowhere else.
+
+    ``badge_removal`` comes off the site's ``SitePlanTier``. It defaults to False
+    everywhere it is resolved, so an unknown/absent/misspelled tier means BADGED —
+    fail-closed on the gate as well as on the injection.
+    """
+    return not badge_removal
+
+
+def build_badge_html() -> str:
+    """The badge markup: a plain anchor, no script, styles inline and locked."""
+    return (
+        f'<a {BADGE_MARKER}="1" href="{BADGE_HREF}" target="_blank" '
+        f'rel="noopener noreferrer nofollow" '
+        f'aria-label="{html.escape(BADGE_TEXT)}" '
+        f'style="{_LOCKED_STYLE}{_LOOK_STYLE}">{html.escape(BADGE_TEXT)}</a>'
+    )
+
+
+def inject_into_html(page: str, badge: str) -> str | None:
+    """Return ``page`` with ``badge`` before the last ``</body>``, or ``None`` if
+    it is already badged.
+
+    ``None`` (not the unchanged page) so the caller can tell "nothing to do" from
+    "rewritten" and skip the write — the steady state on every re-publish.
+
+    The insertion point is the LAST ``</body>``: a page can mention the string in
+    an inline script or a code sample, and the real closing tag is the final one.
+    A page with no ``</body>`` at all (a fragment, a hand-written partial) gets
+    the badge appended rather than skipped — an unbadged page is the one outcome
+    this module does not accept.
+    """
+    if BADGE_MARKER in page:
+        return None
+    idx = page.lower().rfind("</body>")
+    if idx == -1:
+        return f"{page}\n{badge}\n"
+    return f"{page[:idx]}{badge}\n{page[idx:]}"
+
+
+def inject_into_tree(root: Path) -> list[Path]:
+    """Badge every HTML page under ``root``; return the pages rewritten.
+
+    FAILURE-CLOSED ON EVERY PAGE THAT WILL SHIP, which is what separates this from
+    ``paw_bar.embed.inject_into_tree`` (that one logs and skips, because a bar is
+    worth less than a deploy):
+
+      * an unreadable, undecodable or unwritable page RAISES — that page exists,
+        the deploy will upload it, and it would go out unbadged. This is the whole
+        enforcement, and it is exactly the class of failure a customer's own
+        content can provoke (a page that will not decode as UTF-8).
+
+    ...but NOT on an empty root, and the distinction is deliberate rather than a
+    softening. ``root`` here is ``project_dir / resolve_static_output_rel(...)`` —
+    the SAME path ``sites.local_server`` and the Cloudflare deploy resolve their
+    upload source from. So if there is no tree, or a tree with no HTML in it, the
+    deploy has nothing to ship from that root either: there is no state where the
+    badge finds nothing and a real page still goes live. Raising there would not
+    protect a single site; it would only turn every stubbed-build test into a
+    publish failure. It logs at WARNING and returns instead.
+
+    Do not "restore" the raise without first checking that the deploy still reads
+    this same root — the argument above is the only thing making it safe.
+
+    An already-badged page is skipped SILENTLY and counts as a success: that is
+    the steady state on re-publish, and logging it would bury real failures under
+    a line per page per deploy.
+    """
+    if not root.is_dir():
+        logger.warning(
+            "sites badge: no built static tree at %s — nothing to badge (the deploy "
+            "reads this same root, so nothing ships from it either)",
+            root,
+        )
+        return []
+
+    badge = build_badge_html()
+    changed: list[Path] = []
+    seen_pages = 0
+
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or path.suffix.lower() not in _HTML_SUFFIXES:
+            continue
+        seen_pages += 1
+        try:
+            page = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            raise BadgeInjectionError(f"unreadable page {path} — refusing to deploy") from exc
+        updated = inject_into_html(page, badge)
+        if updated is None:
+            continue
+        try:
+            path.write_text(updated, encoding="utf-8")
+        except OSError as exc:
+            raise BadgeInjectionError(f"unwritable page {path} — refusing to deploy") from exc
+        changed.append(path)
+
+    if seen_pages == 0:
+        logger.warning(
+            "sites badge: no HTML pages under %s — nothing to badge (same root the "
+            "deploy uploads from, so nothing ships from it either)",
+            root,
+        )
+
+    return changed
+
+
+__all__ = [
+    "BADGE_HREF",
+    "BADGE_MARKER",
+    "BADGE_TEXT",
+    "BadgeInjectionError",
+    "badge_required",
+    "build_badge_html",
+    "inject_into_html",
+    "inject_into_tree",
+]

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -2718,28 +2718,40 @@ async def _stamp_free_badge(
     unbadged site. ``BadgeInjectionError`` therefore propagates and the publish
     aborts before deploy — a site that cannot be badged does not ship.
 
-    The tier is read off the site's EXISTING doc, defaulting to the base (badged)
-    tier when there is none. A FIRST publish reaches here BEFORE the Site doc is
-    inserted, exactly as the concierge embed above documents, so "no doc" must
-    mean "free" rather than "skip" — the opposite default would ship every
-    brand-new site unbadged, which is the bug this whole module exists to prevent.
+    The site's billing fields are read off its EXISTING doc and resolved by
+    ``entitlements.resolve_site_entitlements``, which is where the "may this site
+    drop its badge" rule lives — NOT here, and not off ``plan_tier`` alone. A paid
+    tier whose subscription is cancelled, pending, or was never charged at all
+    keeps its ``plan_tier``, so reading the tier by itself hands those sites a
+    free badge removal.
+
+    A FIRST publish reaches here BEFORE the Site doc is inserted, exactly as the
+    concierge embed above documents, so "no doc" must mean "free" rather than
+    "skip" — the opposite default would ship every brand-new site unbadged, which
+    is the bug this whole module exists to prevent.
     """
-    from pocketpaw_ee.cloud.billing import site_plans as site_plan_catalog
+    from pocketpaw_ee.cloud.entitlements import service as entitlements_service
     from pocketpaw_ee.sites import badge
     from pocketpaw_ee.sites.engines import resolve_static_output_rel
 
     doc = await _SiteDoc.find_one({"_id": ObjectId(site_id), "workspace": workspace_id})
-    tier_key = getattr(doc, "plan_tier", None) if doc is not None else None
-    tier = site_plan_catalog.get_site_plan(tier_key)
-    # ``get_site_plan`` returns None for an unknown/missing key and deliberately
-    # does NOT substitute a floor, so the fail-closed default lands here.
-    badge_removal = bool(tier.badge_removal) if tier is not None else False
+    # ``getattr`` carries the no-doc case on its own: a first publish has no Site
+    # row yet, and ``getattr(None, "plan_tier", None)`` is already the fail-closed
+    # answer. The defaults here ARE the first-publish contract — an absent tier and
+    # an absent subscription resolve to free-and-badged.
+    ent = entitlements_service.resolve_site_entitlements(
+        site_id=site_id,
+        workspace_id=workspace_id,
+        plan_tier=getattr(doc, "plan_tier", None),
+        subscription_status=getattr(doc, "subscription_status", None),
+        concierge_enabled=bool(getattr(doc, "concierge_enabled", True)),
+    )
 
-    if not badge.badge_required(badge_removal=badge_removal):
+    if not ent.badge_required:
         logger.info(
-            "sites: site %s is on tier %s — badge not required",
+            "sites: site %s is on paid tier %s with an active subscription — badge not required",
             site_id,
-            tier_key,
+            ent.plan_tier,
         )
         return
 

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -2405,6 +2405,20 @@ async def _deploy_site_doc(
         site_name=site_name,
     )
 
+    # Stamp the free-tier attribution badge onto the same built tree, also before
+    # the deploy. Ordered AFTER the concierge so the bar is present when the badge
+    # walks the pages (both are idempotent, so the order only decides which one
+    # logs the rewrite — but a fixed order keeps re-publishes byte-stable).
+    #
+    # NOT failure-soft, unlike the concierge above: this raises and the publish
+    # aborts rather than deploying an unbadged free site. See ``_stamp_free_badge``.
+    await _stamp_free_badge(
+        workspace_id=workspace_id,
+        site_id=site_id,
+        project_dir=build.project_dir,
+        engine=engine,
+    )
+
     # DS-2: a DYNAMIC site (pattern == "dynamic", or a spec carrying live
     # bindings) is backed by a per-tenant Cloudflare D1, so its deployed Worker
     # needs a D1 binding to reach that DB. Resolve the site's D1 id BEFORE deploy:
@@ -2682,6 +2696,60 @@ async def _embed_concierge_bar(
             site_id,
             exc_info=True,
         )
+
+
+async def _stamp_free_badge(
+    *,
+    workspace_id: str,
+    site_id: str,
+    project_dir: str,
+    engine: str,
+) -> None:
+    """Stamp the attribution badge onto the built pages, before they deploy.
+
+    The sibling of ``_embed_concierge_bar`` — same seam (between build and deploy,
+    so the artifact that lands is already right), same output-root resolution —
+    with the OPPOSITE failure posture, which is the entire point.
+
+    ``_embed_concierge_bar`` swallows everything because a site going live matters
+    more than its bar. This one swallows NOTHING. The badge is what the paid
+    per-site tier sells the removal of, so a badge that fails open is not an
+    enforcement mechanism: the exploit is to make injection fail and keep the free
+    unbadged site. ``BadgeInjectionError`` therefore propagates and the publish
+    aborts before deploy — a site that cannot be badged does not ship.
+
+    The tier is read off the site's EXISTING doc, defaulting to the base (badged)
+    tier when there is none. A FIRST publish reaches here BEFORE the Site doc is
+    inserted, exactly as the concierge embed above documents, so "no doc" must
+    mean "free" rather than "skip" — the opposite default would ship every
+    brand-new site unbadged, which is the bug this whole module exists to prevent.
+    """
+    from pocketpaw_ee.cloud.billing import site_plans as site_plan_catalog
+    from pocketpaw_ee.sites import badge
+    from pocketpaw_ee.sites.engines import resolve_static_output_rel
+
+    doc = await _SiteDoc.find_one({"_id": ObjectId(site_id), "workspace": workspace_id})
+    tier_key = getattr(doc, "plan_tier", None) if doc is not None else None
+    tier = site_plan_catalog.get_site_plan(tier_key)
+    # ``get_site_plan`` returns None for an unknown/missing key and deliberately
+    # does NOT substitute a floor, so the fail-closed default lands here.
+    badge_removal = bool(tier.badge_removal) if tier is not None else False
+
+    if not badge.badge_required(badge_removal=badge_removal):
+        logger.info(
+            "sites: site %s is on tier %s — badge not required",
+            site_id,
+            tier_key,
+        )
+        return
+
+    root = Path(project_dir, resolve_static_output_rel(project_dir, engine))
+    changed = badge.inject_into_tree(root)
+    logger.info(
+        "sites: stamped the attribution badge onto %d page(s) of site %s",
+        len(changed),
+        site_id,
+    )
 
 
 def _with_deployed_host(allowed_origins: list[str], url: str) -> list[str]:

--- a/tests/cloud/entitlements/test_site_entitlements.py
+++ b/tests/cloud/entitlements/test_site_entitlements.py
@@ -1,0 +1,143 @@
+# tests/cloud/entitlements/test_site_entitlements.py — a site's paid capabilities
+# need a subscription that is actually paying.
+# Created 2026-08-13 (feat/sites-site-entitlements). The hole this pins shut: a
+# per-site plan records ``plan_tier`` and NOTHING ever resets it. Cancellation
+# sets ``subscription_status="cancelled"`` and leaves the tier on the paid key,
+# and — wider — an unconfigured Dodo product lets a paid publish record its tier
+# with no live charge at all (``subscription_status="none"``). Any resolver that
+# reads the tier alone therefore hands a free badge removal and a free custom
+# domain to sites that have never paid, permanently.
+#
+# The resolver is pure, so every branch is exercised without a database: it takes
+# the site's billing fields because ``entitlements`` may not import ``models.site``
+# (EE cloud rule 2).
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.billing import site_plans as site_plan_catalog
+from pocketpaw_ee.cloud.entitlements.service import resolve_site_entitlements
+
+_SITE = "6512c1f0e4b0a1b2c3d4e5f6"
+_WS = "ws_1"
+
+
+def _resolve(**ov):
+    kw = {
+        "site_id": _SITE,
+        "workspace_id": _WS,
+        "plan_tier": "pro",
+        "subscription_status": "active",
+        "concierge_enabled": True,
+    }
+    kw.update(ov)
+    return resolve_site_entitlements(**kw)
+
+
+# --------------------------------------------------------------------------- #
+# The paying case
+# --------------------------------------------------------------------------- #
+
+
+def test_an_active_paid_site_drops_the_badge_and_gets_its_domain():
+    ent = _resolve(plan_tier="pro", subscription_status="active")
+
+    assert ent.subscription_active is True
+    assert ent.badge_required is False
+    assert ent.custom_domain is True
+    assert ent.plan_tier == "pro"
+
+
+def test_business_is_paid_too():
+    ent = _resolve(plan_tier="business", subscription_status="active")
+
+    assert ent.badge_required is False
+    assert ent.custom_domain is True
+
+
+# --------------------------------------------------------------------------- #
+# The hole: a paid TIER without a paying SUBSCRIPTION
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("status", ["cancelled", "none", "pending", "", None, "garbage"])
+def test_a_paid_tier_without_an_active_subscription_is_badged(status):
+    """The whole reason this resolver exists. ``plan_tier`` stays "pro" through
+    cancellation — nothing resets it — so gating on the tier alone means a
+    cancelled site never sees a badge again."""
+    ent = _resolve(plan_tier="pro", subscription_status=status)
+
+    assert ent.subscription_active is False
+    assert ent.badge_required is True
+    assert ent.custom_domain is False
+
+
+def test_a_tier_recorded_but_never_charged_is_badged():
+    """Today's live case, not a hypothetical: no Dodo product is configured, so a
+    paid publish records the intended tier and takes no money —
+    ``subscription_status`` stays "none"."""
+    ent = _resolve(plan_tier="business", subscription_status="none")
+
+    assert ent.badge_required is True
+    assert ent.custom_domain is False
+
+
+def test_the_tier_is_still_reported_when_it_is_not_being_paid_for():
+    """Report what the row says, gate on whether it is paid. Blanking the tier
+    would lose the information a reconcile/dunning view needs."""
+    ent = _resolve(plan_tier="pro", subscription_status="cancelled")
+
+    assert ent.plan_tier == "pro"
+    assert ent.subscription_active is False
+
+
+# --------------------------------------------------------------------------- #
+# Fail-closed on the base and the unknown
+# --------------------------------------------------------------------------- #
+
+
+def test_the_base_tier_is_badged_even_when_active():
+    ent = _resolve(plan_tier="basic", subscription_status="active")
+
+    assert ent.badge_required is True
+    assert ent.custom_domain is False
+
+
+@pytest.mark.parametrize("tier", [None, "", "stduio", "site", "staff"])
+def test_an_unknown_or_absent_tier_falls_to_the_base(tier):
+    """Includes the plan ids the pricing spec proposes but the catalog does not
+    carry yet — until they are added, they must resolve to badged, not to a
+    silent upgrade."""
+    ent = _resolve(plan_tier=tier, subscription_status="active")
+
+    assert ent.plan_tier == site_plan_catalog.BASE_SITE_PLAN_KEY
+    assert ent.badge_required is True
+    assert ent.custom_domain is False
+
+
+# --------------------------------------------------------------------------- #
+# Passthrough + scope
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("enabled", [True, False])
+def test_concierge_passes_through_untouched(enabled):
+    """The owner's kill switch is not a billing decision — it is carried, not
+    re-decided, so a paid site can still turn its own concierge off."""
+    assert _resolve(concierge_enabled=enabled).concierge_enabled is enabled
+
+
+def test_the_scope_travels_with_the_answer():
+    ent = _resolve()
+
+    assert ent.site_id == _SITE
+    assert ent.workspace_id == _WS
+
+
+def test_the_blocked_flags_are_absent_rather_than_stubbed():
+    """conv_allowance / conv_rate_usd / white_label wait on decisions that are
+    still open. A field that always returned 0/False would read as implemented."""
+    ent = _resolve()
+
+    for absent in ("conv_allowance", "conv_rate_usd", "white_label"):
+        assert not hasattr(ent, absent)

--- a/tests/ee/sites/test_free_badge.py
+++ b/tests/ee/sites/test_free_badge.py
@@ -23,6 +23,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -218,10 +219,72 @@ def test_every_hiding_vector_is_locked_important(prop):
 def test_the_lock_lives_on_the_element_not_the_stylesheet():
     """The <style> block is beatable by a later author rule; the style attribute is
     not. If a locked property ever migrates into the block, enforcement silently
-    becomes a suggestion."""
-    style_block = badge.build_badge_html().split("</style>")[0]
+    becomes a suggestion.
 
-    assert "!important" not in style_block
+    The GUARD rule is the one sanctioned exception — a pseudo-element has no
+    element to carry a style attribute, so it can only be defended from the
+    stylesheet."""
+    assert "!important" not in badge._LOOK_CSS
+    assert "!important" in badge._GUARD_CSS
+
+
+# --------------------------------------------------------------------------- #
+# Layer 2b — the CHILD lock (the bypass this module shipped with)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "prop",
+    ["display", "visibility", "opacity", "font-size", "color", "position", "transform"],
+)
+def test_the_text_is_locked_too(prop):
+    """Two ordinary lines used to defeat the whole feature:
+
+        a[data-paw-badge] span { display:none }
+
+    The anchor stayed fixed, opaque and at max z-index — an empty pill carrying
+    nothing. A child with no inline style is styleable by ANY author rule, without
+    even needing !important, so locking only the container locked nothing."""
+    span = badge.build_badge_anchor().split("<span")[1]
+
+    assert f"{prop}:" in span
+    start = span.index(f"{prop}:")
+    assert "!important" in span[start : start + 40]
+
+
+@pytest.mark.parametrize(
+    "prop", ["display", "visibility", "opacity", "width", "height", "max-width"]
+)
+def test_the_mark_is_locked_too(prop):
+    """``max-width`` earns its place: a locked ``width:17px`` is still beaten by
+    ``max-width:0``, so locking one without the other locks nothing."""
+    svg = badge.build_badge_anchor().split("<svg")[1].split(">")[0]
+
+    assert f"{prop}:" in svg
+    start = svg.index(f"{prop}:")
+    assert "!important" in svg[start : start + 40]
+
+
+def test_no_element_in_the_badge_is_left_unlocked():
+    """The general form of the bug, so a future child element cannot repeat it."""
+    anchor = badge.build_badge_anchor()
+
+    for tag in re.finditer(r"<(a|svg|span)\b([^>]*)>", anchor):
+        assert "style=" in tag.group(2), f"<{tag.group(1)}> ships with no inline lock"
+        assert "!important" in tag.group(2)
+
+
+def test_a_pseudo_element_overlay_is_neutralised():
+    """The one vector with no element to lock — ::after painted over the badge.
+
+    Asserted against the EMITTED snippet, not against ``_GUARD_CSS``: a constant
+    can be perfectly correct and simply not reach the page, which is exactly what
+    the "guard is dropped" mutation does."""
+    out = badge.build_badge_html()
+
+    assert "::before" in out
+    assert "::after" in out
+    assert "content:none!important" in out
 
 
 def test_the_hover_moves_colour_not_position():
@@ -272,10 +335,41 @@ def test_a_tree_with_no_html_is_survivable(tmp_path):
     assert badge.inject_into_tree(tmp_path) == []
 
 
-def test_an_undecodable_page_raises_rather_than_being_skipped(tmp_path):
-    """The skip-and-continue that is correct for the concierge bar is the exploit
-    here: one unreadable file and that page ships unbadged."""
-    (tmp_path / "index.html").write_bytes(b"<body>\xff\xfe not utf-8 </body>")
+def test_the_badge_is_pure_ascii():
+    """The invariant the latin-1 fallback rests on. If the badge ever gains a
+    non-ASCII character — a curly quote in the wording, an en dash in the CSS —
+    writing it back into a latin-1 page corrupts that page. This test is what
+    stops that, so it is not cosmetic."""
+    badge.build_badge_html().encode("ascii")  # raises if anything is non-ASCII
+
+
+def test_a_non_utf8_page_is_badged_byte_preserving(tmp_path):
+    """This used to RAISE, which made an imported windows-1252 site permanently
+    unpublishable with no operator override — worse than what it prevented.
+    sites/import crawls real sites, so non-UTF-8 pages are ordinary, not hostile."""
+    original = "<html><body><p>caf\xe9 r\xe9sum\xe9</p></body></html>".encode("latin-1")
+    (tmp_path / "index.html").write_bytes(original)
+
+    changed = badge.inject_into_tree(tmp_path)
+
+    assert len(changed) == 1
+    out = (tmp_path / "index.html").read_bytes()
+    # the badge landed...
+    assert badge.BADGE_MARKER.encode() in out
+    # ...and every original byte survived it
+    assert b"caf\xe9 r\xe9sum\xe9" in out
+    assert out.decode("latin-1").startswith("<html><body><p>")
+
+
+def test_an_unreadable_page_still_raises(tmp_path, monkeypatch):
+    """Undecodable is survivable; UNREADABLE is not. A page we cannot open at all
+    would ship unbadged, which is the thing this module exists to prevent."""
+    (tmp_path / "index.html").write_text("<body>x</body>", encoding="utf-8")
+
+    def _boom(self, *a, **kw):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(Path, "read_bytes", _boom)
 
     with pytest.raises(badge.BadgeInjectionError):
         badge.inject_into_tree(tmp_path)
@@ -287,17 +381,26 @@ def test_an_unwritable_page_raises_rather_than_being_skipped(tmp_path, monkeypat
     def _boom(self, *a, **kw):
         raise OSError("read-only file system")
 
-    monkeypatch.setattr(Path, "write_text", _boom)
+    monkeypatch.setattr(Path, "write_bytes", _boom)
 
     with pytest.raises(badge.BadgeInjectionError):
         badge.inject_into_tree(tmp_path)
 
 
-def test_one_bad_page_stops_the_whole_publish(tmp_path):
+def test_one_bad_page_stops_the_whole_publish(tmp_path, monkeypatch):
     """Not "the good pages ship badged and the bad one slips through" — the publish
     aborts, so the site does not go live half-enforced."""
     (tmp_path / "a.html").write_text("<body>a</body>", encoding="utf-8")
-    (tmp_path / "b.html").write_bytes(b"\xff\xfe")
+    (tmp_path / "b.html").write_text("<body>b</body>", encoding="utf-8")
+
+    real = Path.write_bytes
+
+    def _boom_on_b(self, data, *a, **kw):
+        if self.name == "b.html":
+            raise OSError("read-only file system")
+        return real(self, data, *a, **kw)
+
+    monkeypatch.setattr(Path, "write_bytes", _boom_on_b)
 
     with pytest.raises(badge.BadgeInjectionError):
         badge.inject_into_tree(tmp_path)
@@ -441,7 +544,12 @@ async def test_an_unbadgeable_page_aborts_the_publish(tmp_path, monkeypatch):
     """The enforcement, end to end: the stamper does NOT swallow, so publish_pocket
     raises and the site never reaches the deploy."""
     _site_doc_returning(monkeypatch, None)
-    (tmp_path / "index.html").write_bytes(b"<body>\xff\xfe</body>")
+    (tmp_path / "index.html").write_text("<body>home</body>", encoding="utf-8")
+
+    def _unwritable(self, *a, **kw):
+        raise OSError("read-only file system")
+
+    monkeypatch.setattr(Path, "write_bytes", _unwritable)
 
     with pytest.raises(badge.BadgeInjectionError):
         await sites_service._stamp_free_badge(

--- a/tests/ee/sites/test_free_badge.py
+++ b/tests/ee/sites/test_free_badge.py
@@ -58,8 +58,10 @@ def test_the_last_closing_body_wins():
     out = badge.inject_into_html(page, badge.build_badge_html())
 
     assert out is not None
-    assert out.count(badge.BADGE_MARKER) == 1
-    assert out.index(badge.BADGE_MARKER) > out.lower().index("</body>")
+    # Count ANCHORS, not markers — the marker is also the look block's selector,
+    # so it legitimately appears several times in one injection.
+    assert out.count(f"<a {badge.BADGE_MARKER}") == 1
+    assert out.index(f"<a {badge.BADGE_MARKER}") > out.lower().index("</body>")
 
 
 def test_a_page_without_a_body_tag_still_gets_a_badge():
@@ -113,23 +115,77 @@ def test_the_badge_is_markup_not_a_script():
     there is no loader that can 404 the enforcement away."""
     out = badge.build_badge_html()
 
-    assert out.lstrip().startswith("<a ")
     assert "<script" not in out.lower()
+    assert "<a " in out
+
+
+def test_nothing_in_the_badge_is_fetched():
+    """A strict CSP or a blocked host must not leave a hole where the brand goes,
+    so the mark is an inline SVG and there is no src/href to an asset."""
+    out = badge.build_badge_html()
+
+    assert "<svg" in out
+    assert "<img" not in out.lower()
+    assert 'src="' not in out
+    assert "@import" not in out
+    # The only URL in the snippet is the badge's own link target.
+    assert out.count("http") == 1
 
 
 @pytest.mark.parametrize(
     "prop",
-    ["display", "visibility", "opacity", "position", "z-index", "width", "height"],
+    [
+        "display",
+        "visibility",
+        "opacity",
+        "position",
+        "z-index",
+        "width",
+        "height",
+        "transform",
+        "filter",
+        "clip-path",
+        "pointer-events",
+    ],
 )
 def test_every_hiding_vector_is_locked_important(prop):
     """The realistic attack is not editing our artifact — customers never touch it.
-    It is a rule in the customer's OWN stylesheet, which we build from. Inline
-    !important outranks any author rule, including #id .class {display:none}."""
-    out = badge.build_badge_html()
+    It is a rule in the customer's OWN stylesheet, which we build from. A
+    style-attribute !important is the strongest author-origin declaration, so it
+    outranks even #id .class {display:none !important}.
 
-    assert f"{prop}:" in out
-    start = out.index(f"{prop}:")
-    assert "!important" in out[start : start + 40]
+    Asserted against the ANCHOR, not the whole snippet: the look block carries
+    unlocked declarations by design, and scanning the snippet finds whichever copy
+    comes first — which passes while the lock is gone."""
+    anchor = badge.build_badge_anchor()
+
+    assert f"{prop}:" in anchor
+    start = anchor.index(f"{prop}:")
+    assert "!important" in anchor[start : start + 40]
+
+
+def test_the_lock_lives_on_the_element_not_the_stylesheet():
+    """The <style> block is beatable by a later author rule; the style attribute is
+    not. If a locked property ever migrates into the block, enforcement silently
+    becomes a suggestion."""
+    style_block = badge.build_badge_html().split("</style>")[0]
+
+    assert "!important" not in style_block
+
+
+def test_the_hover_moves_colour_not_position():
+    """``transform`` is locked, so a hover LIFT cannot work — a locked transform
+    can't be re-enabled for one state. The lock is worth more than the animation;
+    this pins the trade rather than leaving a dead rule that looks like a bug."""
+    out = badge.build_badge_html()
+    hover = out.split(":hover{")[1].split("}")[0]
+
+    assert "transform" not in hover
+    assert "background" in hover
+
+
+def test_motion_is_optional():
+    assert "prefers-reduced-motion" in badge.build_badge_html()
 
 
 def test_the_badge_links_out_and_names_itself():
@@ -139,6 +195,9 @@ def test_the_badge_links_out_and_names_itself():
     assert badge.BADGE_TEXT in out
     assert 'rel="noopener noreferrer nofollow"' in out
     assert "aria-label=" in out
+    # The mark is decorative — the accessible name comes from the label + text,
+    # so a screen reader announces the badge once, not once per shape in the paw.
+    assert 'aria-hidden="true"' in out
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/ee/sites/test_free_badge.py
+++ b/tests/ee/sites/test_free_badge.py
@@ -246,8 +246,14 @@ def _site_doc_returning(monkeypatch, doc):
 
 
 class _Doc:
-    def __init__(self, plan_tier):
+    """A Site row's billing fields. ``subscription_status`` is required here on
+    purpose: a fixture carrying only ``plan_tier`` models a site that never paid,
+    and pretending that is a paid site is how the cancelled-site hole hides."""
+
+    def __init__(self, plan_tier, subscription_status="active", concierge_enabled=True):
         self.plan_tier = plan_tier
+        self.subscription_status = subscription_status
+        self.concierge_enabled = concierge_enabled
 
 
 @pytest.mark.asyncio
@@ -285,8 +291,8 @@ async def test_a_basic_tier_site_is_badged(tmp_path, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_a_paid_site_ships_clean(tmp_path, monkeypatch):
-    """What the customer actually bought."""
-    _site_doc_returning(monkeypatch, _Doc("pro"))
+    """What the customer actually bought — a paid tier WITH a paying subscription."""
+    _site_doc_returning(monkeypatch, _Doc("pro", subscription_status="active"))
     (tmp_path / "index.html").write_text("<body>home</body>", encoding="utf-8")
 
     await sites_service._stamp_free_badge(
@@ -297,6 +303,27 @@ async def test_a_paid_site_ships_clean(tmp_path, monkeypatch):
     )
 
     assert badge.BADGE_MARKER not in (tmp_path / "index.html").read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", ["cancelled", "none", "pending"])
+async def test_a_paid_tier_that_stopped_paying_gets_its_badge_back(tmp_path, monkeypatch, status):
+    """Cancellation sets subscription_status and LEAVES plan_tier on "pro" —
+    nothing resets it — so gating the stamp on the tier alone meant a cancelled
+    site never saw a badge again. "none" is the same hole and is the LIVE state
+    today, because no Dodo product is configured and a paid publish records its
+    tier without taking money."""
+    _site_doc_returning(monkeypatch, _Doc("pro", subscription_status=status))
+    (tmp_path / "index.html").write_text("<body>home</body>", encoding="utf-8")
+
+    await sites_service._stamp_free_badge(
+        workspace_id="w1",
+        site_id="6512c1f0e4b0a1b2c3d4e5f6",
+        project_dir=str(tmp_path),
+        engine="html",
+    )
+
+    assert badge.BADGE_MARKER in (tmp_path / "index.html").read_text(encoding="utf-8")
 
 
 @pytest.mark.asyncio

--- a/tests/ee/sites/test_free_badge.py
+++ b/tests/ee/sites/test_free_badge.py
@@ -1,0 +1,315 @@
+# tests/ee/sites/test_free_badge.py — a free site cannot ship without its badge.
+# Created 2026-08-13 (feat/sites-free-badge). What this pins shut: the badge is the
+# ONLY difference between the free tier and the paid per-site tier, so every way it
+# could quietly not happen is a way to get the paid product for nothing. Four
+# layers, matching where it can break:
+#   * Pure injection (no I/O): the badge lands before </body>, a page with no
+#     </body> still gets one, a second pass is a no-op, every page in a tree gets
+#     one.
+#   * The lock: it is server-rendered markup rather than a script, and every
+#     property an author stylesheet would use to hide it is inline + !important.
+#     A badge that a customer's own CSS can hide is not an enforcement mechanism.
+#   * FAILURE-CLOSED on every page that ships: an unreadable/undecodable page and
+#     an unwritable page each RAISE, and one bad page aborts the whole publish.
+#     This is the inversion from ``_embed_concierge_bar`` (which logs and
+#     continues) and it is the heart of the feature — if injection could fail
+#     soft, the exploit is to make it fail. An EMPTY root is the one survivable
+#     case, because the deploy resolves its upload source from that same root, so
+#     nothing ships from it either; those two tests pin the reasoning so nobody
+#     "restores" a raise that would protect no site.
+#   * The gate: basic is badged, pro/business are not, and an unknown or missing
+#     tier is BADGED (fail-closed on the gate too, so a typo can't buy a free
+#     removal).
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pocketpaw_ee.cloud.billing import site_plans as site_plan_catalog
+from pocketpaw_ee.sites import badge
+from pocketpaw_ee.sites import service as sites_service
+
+# --------------------------------------------------------------------------- #
+# Layer 1 — injection (pure)
+# --------------------------------------------------------------------------- #
+
+
+def test_the_badge_lands_before_the_closing_body():
+    page = "<!doctype html><html><body><h1>Atlas AC</h1></body></html>"
+
+    out = badge.inject_into_html(page, badge.build_badge_html())
+
+    assert out is not None
+    assert out.index("<a ") < out.index("</body>")
+    assert out.endswith("</body></html>")
+
+
+def test_the_last_closing_body_wins():
+    """A page can mention the string in a code sample; the real closing tag is the
+    final one. Injecting at the FIRST match buries the badge inside the sample,
+    where a <code> block renders it as text rather than a badge.
+
+    The assertion has to be "after the first </body>", not "before the last one" —
+    the latter is true even when the badge lands in the sample, which is how the
+    ``rfind``->``find`` mutation escaped this test's first version."""
+    page = "<html><body><code></body></code><p>real content</p></body></html>"
+
+    out = badge.inject_into_html(page, badge.build_badge_html())
+
+    assert out is not None
+    assert out.count(badge.BADGE_MARKER) == 1
+    assert out.index(badge.BADGE_MARKER) > out.lower().index("</body>")
+
+
+def test_a_page_without_a_body_tag_still_gets_a_badge():
+    """Fragments and hand-written partials have no </body>. Appending beats
+    skipping — an unbadged page is the one outcome this module does not accept."""
+    out = badge.inject_into_html("<h1>Atlas AC</h1>", badge.build_badge_html())
+
+    assert out is not None
+    assert badge.BADGE_MARKER in out
+
+
+def test_rebadging_is_a_no_op():
+    """The steady state on every re-publish. Returning None (not the unchanged
+    page) is what lets the caller skip the write."""
+    once = badge.inject_into_html("<body>hi</body>", badge.build_badge_html())
+    assert once is not None
+
+    assert badge.inject_into_html(once, badge.build_badge_html()) is None
+
+
+def test_every_page_in_the_tree_gets_a_badge(tmp_path):
+    (tmp_path / "index.html").write_text("<body>home</body>", encoding="utf-8")
+    (tmp_path / "about.html").write_text("<body>about</body>", encoding="utf-8")
+    nested = tmp_path / "blog"
+    nested.mkdir()
+    (nested / "post.html").write_text("<body>post</body>", encoding="utf-8")
+    (tmp_path / "styles.css").write_text("body{color:red}", encoding="utf-8")
+
+    changed = badge.inject_into_tree(tmp_path)
+
+    assert len(changed) == 3
+    for name in ("index.html", "about.html", "blog/post.html"):
+        assert badge.BADGE_MARKER in (tmp_path / name).read_text(encoding="utf-8")
+    assert badge.BADGE_MARKER not in (tmp_path / "styles.css").read_text(encoding="utf-8")
+
+
+def test_a_second_publish_rewrites_nothing_but_still_succeeds(tmp_path):
+    (tmp_path / "index.html").write_text("<body>home</body>", encoding="utf-8")
+    badge.inject_into_tree(tmp_path)
+
+    assert badge.inject_into_tree(tmp_path) == []
+
+
+# --------------------------------------------------------------------------- #
+# Layer 2 — the lock (server-rendered, not CSS-hideable)
+# --------------------------------------------------------------------------- #
+
+
+def test_the_badge_is_markup_not_a_script():
+    """Server-rendered is the spec's word. A JS-blocked visitor still sees it, and
+    there is no loader that can 404 the enforcement away."""
+    out = badge.build_badge_html()
+
+    assert out.lstrip().startswith("<a ")
+    assert "<script" not in out.lower()
+
+
+@pytest.mark.parametrize(
+    "prop",
+    ["display", "visibility", "opacity", "position", "z-index", "width", "height"],
+)
+def test_every_hiding_vector_is_locked_important(prop):
+    """The realistic attack is not editing our artifact — customers never touch it.
+    It is a rule in the customer's OWN stylesheet, which we build from. Inline
+    !important outranks any author rule, including #id .class {display:none}."""
+    out = badge.build_badge_html()
+
+    assert f"{prop}:" in out
+    start = out.index(f"{prop}:")
+    assert "!important" in out[start : start + 40]
+
+
+def test_the_badge_links_out_and_names_itself():
+    out = badge.build_badge_html()
+
+    assert badge.BADGE_HREF in out
+    assert badge.BADGE_TEXT in out
+    assert 'rel="noopener noreferrer nofollow"' in out
+    assert "aria-label=" in out
+
+
+# --------------------------------------------------------------------------- #
+# Layer 3 — failure-closed (the inversion from the concierge bar)
+# --------------------------------------------------------------------------- #
+
+
+def test_a_missing_build_tree_is_survivable(tmp_path):
+    """The deliberate exception to fail-closed, and the reasoning is load-bearing:
+    this root is the SAME path the deploy resolves its upload source from, so no
+    tree means nothing ships from it either. Raising here would protect no site
+    and would turn every stubbed-build publish test into a failure."""
+    assert badge.inject_into_tree(tmp_path / "nope") == []
+
+
+def test_a_tree_with_no_html_is_survivable(tmp_path):
+    """Same argument: no HTML at the root the deploy uploads from means no page
+    goes live, badged or otherwise."""
+    (tmp_path / "styles.css").write_text("body{}", encoding="utf-8")
+
+    assert badge.inject_into_tree(tmp_path) == []
+
+
+def test_an_undecodable_page_raises_rather_than_being_skipped(tmp_path):
+    """The skip-and-continue that is correct for the concierge bar is the exploit
+    here: one unreadable file and that page ships unbadged."""
+    (tmp_path / "index.html").write_bytes(b"<body>\xff\xfe not utf-8 </body>")
+
+    with pytest.raises(badge.BadgeInjectionError):
+        badge.inject_into_tree(tmp_path)
+
+
+def test_an_unwritable_page_raises_rather_than_being_skipped(tmp_path, monkeypatch):
+    (tmp_path / "index.html").write_text("<body>home</body>", encoding="utf-8")
+
+    def _boom(self, *a, **kw):
+        raise OSError("read-only file system")
+
+    monkeypatch.setattr(Path, "write_text", _boom)
+
+    with pytest.raises(badge.BadgeInjectionError):
+        badge.inject_into_tree(tmp_path)
+
+
+def test_one_bad_page_stops_the_whole_publish(tmp_path):
+    """Not "the good pages ship badged and the bad one slips through" — the publish
+    aborts, so the site does not go live half-enforced."""
+    (tmp_path / "a.html").write_text("<body>a</body>", encoding="utf-8")
+    (tmp_path / "b.html").write_bytes(b"\xff\xfe")
+
+    with pytest.raises(badge.BadgeInjectionError):
+        badge.inject_into_tree(tmp_path)
+
+
+# --------------------------------------------------------------------------- #
+# Layer 4 — the gate (which tiers must carry it)
+# --------------------------------------------------------------------------- #
+
+
+def test_the_base_tier_is_badged():
+    """This is what free means, and it is the only thing the paid tier sells."""
+    tier = site_plan_catalog.get_site_plan(site_plan_catalog.BASE_SITE_PLAN_KEY)
+
+    assert tier is not None
+    assert tier.badge_removal is False
+    assert badge.badge_required(badge_removal=tier.badge_removal) is True
+
+
+@pytest.mark.parametrize("key", ["pro", "business"])
+def test_the_paid_tiers_may_drop_the_badge(key):
+    tier = site_plan_catalog.get_site_plan(key)
+
+    assert tier is not None
+    assert tier.badge_removal is True
+    assert badge.badge_required(badge_removal=tier.badge_removal) is False
+
+
+def test_an_unknown_tier_is_badged():
+    """``get_site_plan`` deliberately does not substitute a floor, so the caller's
+    fail-closed default is what a typo lands on. A misspelled tier must not buy a
+    free badge removal."""
+    assert site_plan_catalog.get_site_plan("stduio") is None
+    assert badge.badge_required(badge_removal=False) is True
+
+
+def test_a_site_with_no_tier_at_all_is_badged():
+    """A FIRST publish reaches the stamper before its Site doc exists, so "no tier"
+    is the single most common case on the path — and it must mean free."""
+    assert site_plan_catalog.get_site_plan(None) is None
+    assert badge.badge_required(badge_removal=False) is True
+
+
+# --------------------------------------------------------------------------- #
+# Layer 5 — the publish path (gate + injection wired together)
+# --------------------------------------------------------------------------- #
+
+
+def _site_doc_returning(monkeypatch, doc):
+    """Point ``_stamp_free_badge``'s tier lookup at ``doc`` without a database."""
+
+    async def _find_one(*_a, **_kw):
+        return doc
+
+    monkeypatch.setattr(sites_service._SiteDoc, "find_one", _find_one)
+
+
+class _Doc:
+    def __init__(self, plan_tier):
+        self.plan_tier = plan_tier
+
+
+@pytest.mark.asyncio
+async def test_a_first_publish_badges_before_it_deploys(tmp_path, monkeypatch):
+    """The case the whole feature turns on: a brand-new site reaches the stamper
+    BEFORE its Site doc is inserted, so the tier lookup finds nothing. That must
+    resolve to free-and-badged, not to skip."""
+    _site_doc_returning(monkeypatch, None)
+    (tmp_path / "index.html").write_text("<body>home</body>", encoding="utf-8")
+
+    await sites_service._stamp_free_badge(
+        workspace_id="w1",
+        site_id="6512c1f0e4b0a1b2c3d4e5f6",
+        project_dir=str(tmp_path),
+        engine="html",
+    )
+
+    assert badge.BADGE_MARKER in (tmp_path / "index.html").read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_a_basic_tier_site_is_badged(tmp_path, monkeypatch):
+    _site_doc_returning(monkeypatch, _Doc("basic"))
+    (tmp_path / "index.html").write_text("<body>home</body>", encoding="utf-8")
+
+    await sites_service._stamp_free_badge(
+        workspace_id="w1",
+        site_id="6512c1f0e4b0a1b2c3d4e5f6",
+        project_dir=str(tmp_path),
+        engine="html",
+    )
+
+    assert badge.BADGE_MARKER in (tmp_path / "index.html").read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_a_paid_site_ships_clean(tmp_path, monkeypatch):
+    """What the customer actually bought."""
+    _site_doc_returning(monkeypatch, _Doc("pro"))
+    (tmp_path / "index.html").write_text("<body>home</body>", encoding="utf-8")
+
+    await sites_service._stamp_free_badge(
+        workspace_id="w1",
+        site_id="6512c1f0e4b0a1b2c3d4e5f6",
+        project_dir=str(tmp_path),
+        engine="html",
+    )
+
+    assert badge.BADGE_MARKER not in (tmp_path / "index.html").read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_an_unbadgeable_page_aborts_the_publish(tmp_path, monkeypatch):
+    """The enforcement, end to end: the stamper does NOT swallow, so publish_pocket
+    raises and the site never reaches the deploy."""
+    _site_doc_returning(monkeypatch, None)
+    (tmp_path / "index.html").write_bytes(b"<body>\xff\xfe</body>")
+
+    with pytest.raises(badge.BadgeInjectionError):
+        await sites_service._stamp_free_badge(
+            workspace_id="w1",
+            site_id="6512c1f0e4b0a1b2c3d4e5f6",
+            project_dir=str(tmp_path),
+            engine="html",
+        )

--- a/tests/ee/sites/test_free_badge.py
+++ b/tests/ee/sites/test_free_badge.py
@@ -119,6 +119,90 @@ def test_replacing_leaves_the_page_otherwise_intact():
     assert "backdrop-filter" not in swapped
 
 
+def test_a_stray_open_sentinel_does_not_swallow_the_page():
+    """The strip patterns' worst case, and it was live: a page carrying ONE stray
+    ``<!--paw-badge-->`` matched from THAT open forward to our badge's close and
+    deleted everything between. A 3,127-byte page came out at 26 bytes.
+
+    The match does not have to start at our markup — that is the assumption
+    "only our markup has our marker" quietly makes and does not earn."""
+    page = (
+        "<html><body>"
+        + badge.BADGE_OPEN
+        + "<h1>customer content</h1>"
+        + "x" * 200
+        + badge.build_badge_html()
+        + "</body></html>"
+    )
+
+    out = badge.strip_badge(page)
+
+    assert "customer content" in out
+    assert "x" * 200 in out
+    assert badge.BADGE_MARKER not in out  # our real badge still went
+
+
+def test_a_fake_anchor_does_not_swallow_the_page():
+    """Same shape on the legacy anchor: an element wearing our marker with no
+    nearby ``</a>`` used to match forward to some distant one."""
+    page = (
+        '<body><a data-paw-badge="1">x</a>'
+        "<h1>customer content</h1>"
+        '<a href="/y">their link</a>' + badge.build_badge_html() + "</body>"
+    )
+
+    out = badge.strip_badge(page)
+
+    assert "customer content" in out
+    assert "their link" in out
+
+
+def test_a_customer_style_block_survives():
+    page = "<body>" + badge.build_badge_html() + "<style>body{color:red}</style><p>copy</p></body>"
+
+    out = badge.strip_badge(page)
+
+    assert "body{color:red}" in out
+    assert "<p>copy</p>" in out
+    assert badge.BADGE_MARKER not in out
+
+
+def test_the_strip_span_is_bounded():
+    """The backstop. Even a correctly-delimited region cannot remove an unbounded
+    amount of a page — a runaway drops a bounded region, never the document.
+
+    The size here is a FIXED 200KB, deliberately not ``_MAX_BADGE_SPAN + n``: a
+    test that scales with the constant it guards moves with the mutation and
+    reports "bounded" for any bound at all, which is exactly how the first
+    version of this passed while the bound was raised to ten million."""
+    huge = badge.BADGE_OPEN + ("y" * 200_000) + badge.BADGE_CLOSE
+    page = f"<body>{huge}<p>after</p></body>"
+
+    out = badge.strip_badge(page)
+
+    assert "y" * 100 in out, "a region larger than the bound must be left alone"
+    assert "<p>after</p>" in out
+
+
+def test_an_element_wearing_our_attribute_with_another_value_survives():
+    """The legacy anchor requires ``="1"`` — the value this module has always
+    emitted — so it is a positive identification of OUR markup rather than
+    "anything carrying our attribute name"."""
+    page = '<body><a data-paw-badge="mine" href="/x">customer link</a><p>copy</p></body>'
+
+    out = badge.strip_badge(page)
+
+    assert "customer link" in out
+    assert "<p>copy</p>" in out
+
+
+def test_our_own_badge_is_still_fully_stripped():
+    """The hardening must not cost the thing the patterns exist for."""
+    page = "<body><p>hi</p>" + badge.build_badge_html() + "</body>"
+
+    assert badge.strip_badge(page) == "<body><p>hi</p></body>"
+
+
 def test_a_stale_badge_is_replaced_across_a_whole_tree(tmp_path):
     """The republish path, not just one page."""
     old = '<a data-paw-badge="1" style="background:#111;">Built with PocketPaw</a>'

--- a/tests/ee/sites/test_free_badge.py
+++ b/tests/ee/sites/test_free_badge.py
@@ -73,13 +73,64 @@ def test_a_page_without_a_body_tag_still_gets_a_badge():
     assert badge.BADGE_MARKER in out
 
 
-def test_rebadging_is_a_no_op():
+def test_rebadging_with_the_SAME_badge_is_a_no_op():
     """The steady state on every re-publish. Returning None (not the unchanged
     page) is what lets the caller skip the write."""
     once = badge.inject_into_html("<body>hi</body>", badge.build_badge_html())
     assert once is not None
 
     assert badge.inject_into_html(once, badge.build_badge_html()) is None
+
+
+def test_an_OUTDATED_badge_is_replaced_not_kept():
+    """The stale-badge bug, reported live: a site republished after the badge was
+    restyled kept the badge it was first given.
+
+    Skip-if-present is correct for the concierge bar, whose snippet never
+    changes. The badge is markup we iterate on, and PERF-3 builds into a STABLE
+    per-pocket working dir, so an already-injected page comes back around on the
+    next publish. Skipping it pins the first badge a site ever got, forever."""
+    old = (
+        '<a data-paw-badge="1" href="https://pocketpaw.dev" '
+        'style="background:#111;">Built with PocketPaw</a>'
+    )
+    page = f"<html><body><h1>site</h1>{old}</body></html>"
+
+    out = badge.inject_into_html(page, badge.build_badge_html())
+
+    assert out is not None, "an outdated badge must be replaced, not skipped"
+    assert "background:#111" not in out
+    assert out.count(f"<a {badge.BADGE_MARKER}") == 1
+    assert "backdrop-filter" in out
+
+
+def test_replacing_leaves_the_page_otherwise_intact():
+    page = "<html><body><h1>site</h1><p>copy</p></body></html>"
+    first = badge.inject_into_html(page, badge.build_badge_html())
+    assert first is not None
+
+    # A second pass with a DIFFERENT badge must swap only the badge.
+    swapped = badge.inject_into_html(first, "<a data-paw-badge='1'>v2</a>")
+
+    assert swapped is not None
+    assert "<h1>site</h1><p>copy</p>" in swapped
+    assert swapped.count("<h1>") == 1
+    assert "backdrop-filter" not in swapped
+
+
+def test_a_stale_badge_is_replaced_across_a_whole_tree(tmp_path):
+    """The republish path, not just one page."""
+    old = '<a data-paw-badge="1" style="background:#111;">Built with PocketPaw</a>'
+    for name in ("index.html", "about.html"):
+        (tmp_path / name).write_text(f"<body>x{old}</body>", encoding="utf-8")
+
+    changed = badge.inject_into_tree(tmp_path)
+
+    assert len(changed) == 2
+    for name in ("index.html", "about.html"):
+        page = (tmp_path / name).read_text(encoding="utf-8")
+        assert "background:#111" not in page
+        assert page.count(f"<a {badge.BADGE_MARKER}") == 1
 
 
 def test_every_page_in_the_tree_gets_a_badge(tmp_path):

--- a/tests/mutations/free_badge.json
+++ b/tests/mutations/free_badge.json
@@ -184,6 +184,34 @@
     ]
   },
   {
+    "label": "the strip patterns lose their temper, so a stray sentinel eats the page",
+    "file": "ee/pocketpaw_ee/sites/badge.py",
+    "find": "        open_pat + r\"(?:(?!\" + guard + r\")[\\s\\S]){0,\" + str(_MAX_BADGE_SPAN) + r\"}?\" + close_pat",
+    "replace": "        open_pat + r\"[\\s\\S]{0,\" + str(_MAX_BADGE_SPAN) + r\"}?\" + close_pat",
+    "tests": [
+      "tests/ee/sites/test_free_badge.py::test_a_stray_open_sentinel_does_not_swallow_the_page",
+      "tests/ee/sites/test_free_badge.py::test_a_fake_anchor_does_not_swallow_the_page"
+    ]
+  },
+  {
+    "label": "the strip span loses its bound",
+    "file": "ee/pocketpaw_ee/sites/badge.py",
+    "find": "_MAX_BADGE_SPAN = 16384",
+    "replace": "_MAX_BADGE_SPAN = 10000000",
+    "tests": [
+      "tests/ee/sites/test_free_badge.py::test_the_strip_span_is_bounded"
+    ]
+  },
+  {
+    "label": "the legacy anchor stops requiring our attribute VALUE",
+    "file": "ee/pocketpaw_ee/sites/badge.py",
+    "find": "_LEGACY_ANCHOR_RE = _tempered(r\"<a\\s+\" + re.escape(BADGE_MARKER) + r'=\"1\"', r\"</a>\", r\"<a[\\s>]\")",
+    "replace": "_LEGACY_ANCHOR_RE = _tempered(r\"<a\\s+\" + re.escape(BADGE_MARKER) + r'=', r\"</a>\", r\"<zzz[\\s>]\")",
+    "tests": [
+      "tests/ee/sites/test_free_badge.py::test_an_element_wearing_our_attribute_with_another_value_survives"
+    ]
+  },
+  {
     "label": "the stamper stops walking the tree, so no page is ever badged",
     "file": "ee/pocketpaw_ee/sites/badge.py",
     "find": "        seen_pages += 1",

--- a/tests/mutations/free_badge.json
+++ b/tests/mutations/free_badge.json
@@ -62,8 +62,8 @@
   {
     "label": "the badge lands at the FIRST </body>, so a code sample can swallow it",
     "file": "ee/pocketpaw_ee/sites/badge.py",
-    "find": "    idx = page.lower().rfind(\"</body>\")",
-    "replace": "    idx = page.lower().find(\"</body>\")",
+    "find": "    idx = stripped.lower().rfind(\"</body>\")",
+    "replace": "    idx = stripped.lower().find(\"</body>\")",
     "tests": [
       "tests/ee/sites/test_free_badge.py::test_the_last_closing_body_wins"
     ]
@@ -114,6 +114,26 @@
     "replace": "    \"background:rgba(15,17,21,.78)!important;\"",
     "tests": [
       "tests/ee/sites/test_free_badge.py::test_the_lock_lives_on_the_element_not_the_stylesheet"
+    ]
+  },
+  {
+    "label": "an already-badged page is skipped again, pinning the first badge forever",
+    "file": "ee/pocketpaw_ee/sites/badge.py",
+    "find": "    page = _SENTINELLED_RE.sub(\"\", page)",
+    "replace": "    return page",
+    "tests": [
+      "tests/ee/sites/test_free_badge.py::test_an_OUTDATED_badge_is_replaced_not_kept",
+      "tests/ee/sites/test_free_badge.py::test_a_stale_badge_is_replaced_across_a_whole_tree"
+    ]
+  },
+  {
+    "label": "one stray newline makes every re-publish rewrite every page",
+    "file": "ee/pocketpaw_ee/sites/badge.py",
+    "find": "        updated = f\"{stripped[:idx]}{badge}{stripped[idx:]}\"",
+    "replace": "        updated = f\"{stripped[:idx]}{badge}\\n{stripped[idx:]}\"",
+    "tests": [
+      "tests/ee/sites/test_free_badge.py::test_rebadging_with_the_SAME_badge_is_a_no_op",
+      "tests/ee/sites/test_free_badge.py::test_a_second_publish_rewrites_nothing_but_still_succeeds"
     ]
   },
   {

--- a/tests/mutations/free_badge.json
+++ b/tests/mutations/free_badge.json
@@ -101,8 +101,8 @@
   {
     "label": "the brand mark becomes a fetched asset a CSP can block",
     "file": "ee/pocketpaw_ee/sites/badge.py",
-    "find": "    '<svg width=\"17\" height=\"17\" viewBox=\"0 0 32 32\" aria-hidden=\"true\" focusable=\"false\">'",
-    "replace": "    '<img src=\"https://pocketpaw.dev/favicon.svg\" width=\"17\" height=\"17\" alt=\"\"><svg viewBox=\"0 0 32 32\" aria-hidden=\"true\">'",
+    "find": "    '<svg width=\"17\" height=\"17\" viewBox=\"0 0 32 32\" aria-hidden=\"true\" '",
+    "replace": "    '<img src=\"https://pocketpaw.dev/favicon.svg\" width=\"17\" height=\"17\" alt=\"\"><svg viewBox=\"0 0 32 32\" aria-hidden=\"true\" '",
     "tests": [
       "tests/ee/sites/test_free_badge.py::test_nothing_in_the_badge_is_fetched"
     ]
@@ -134,6 +134,53 @@
     "tests": [
       "tests/ee/sites/test_free_badge.py::test_rebadging_with_the_SAME_badge_is_a_no_op",
       "tests/ee/sites/test_free_badge.py::test_a_second_publish_rewrites_nothing_but_still_succeeds"
+    ]
+  },
+  {
+    "label": "the TEXT loses its lock, so two lines of author css empty the badge",
+    "file": "ee/pocketpaw_ee/sites/badge.py",
+    "find": "        f'<span style=\"{_SPAN_LOCK}\">{text}</span></a>'",
+    "replace": "        f'<span>{text}</span></a>'",
+    "tests": [
+      "tests/ee/sites/test_free_badge.py::test_the_text_is_locked_too",
+      "tests/ee/sites/test_free_badge.py::test_no_element_in_the_badge_is_left_unlocked"
+    ]
+  },
+  {
+    "label": "the MARK loses its lock",
+    "file": "ee/pocketpaw_ee/sites/badge.py",
+    "find": "    f'focusable=\"false\" style=\"{_MARK_LOCK}\">'",
+    "replace": "    'focusable=\"false\">'",
+    "tests": [
+      "tests/ee/sites/test_free_badge.py::test_the_mark_is_locked_too",
+      "tests/ee/sites/test_free_badge.py::test_no_element_in_the_badge_is_left_unlocked"
+    ]
+  },
+  {
+    "label": "the pseudo-element guard is dropped, so ::after can cover the badge",
+    "file": "ee/pocketpaw_ee/sites/badge.py",
+    "find": "    return f\"{BADGE_OPEN}<style>{_LOOK_CSS}{_GUARD_CSS}</style>{build_badge_anchor()}{BADGE_CLOSE}\"",
+    "replace": "    return f\"{BADGE_OPEN}<style>{_LOOK_CSS}</style>{build_badge_anchor()}{BADGE_CLOSE}\"",
+    "tests": [
+      "tests/ee/sites/test_free_badge.py::test_a_pseudo_element_overlay_is_neutralised"
+    ]
+  },
+  {
+    "label": "a non-UTF-8 page goes back to bricking the publish",
+    "file": "ee/pocketpaw_ee/sites/badge.py",
+    "find": "            page, codec = raw.decode(\"latin-1\"), \"latin-1\"",
+    "replace": "            raise BadgeInjectionError(f\"undecodable page {path} — refusing to deploy\")",
+    "tests": [
+      "tests/ee/sites/test_free_badge.py::test_a_non_utf8_page_is_badged_byte_preserving"
+    ]
+  },
+  {
+    "label": "the badge gains a non-ASCII character the latin-1 write would corrupt",
+    "file": "ee/pocketpaw_ee/sites/badge.py",
+    "find": "BADGE_TEXT = \"Built with PocketPaw\"",
+    "replace": "BADGE_TEXT = \"Built with PocketPaw\\u2019s\"",
+    "tests": [
+      "tests/ee/sites/test_free_badge.py::test_the_badge_is_pure_ascii"
     ]
   },
   {

--- a/tests/mutations/free_badge.json
+++ b/tests/mutations/free_badge.json
@@ -40,10 +40,21 @@
     ]
   },
   {
-    "label": "a first publish (no Site doc yet) defaults to UNbadged",
+    "label": "the resolver's fail-closed default flips to UNbadged",
+    "file": "ee/pocketpaw_ee/cloud/entitlements/service.py",
+    "find": "    badge_removal = False",
+    "replace": "    badge_removal = True",
+    "tests": [
+      "tests/ee/sites/test_free_badge.py::test_a_first_publish_badges_before_it_deploys",
+      "tests/cloud/entitlements/test_site_entitlements.py::test_the_base_tier_is_badged_even_when_active",
+      "tests/cloud/entitlements/test_site_entitlements.py::test_an_unknown_or_absent_tier_falls_to_the_base"
+    ]
+  },
+  {
+    "label": "a first publish (no Site row yet) is read as a paid ACTIVE site",
     "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "    badge_removal = bool(tier.badge_removal) if tier is not None else False",
-    "replace": "    badge_removal = bool(tier.badge_removal) if tier is not None else True",
+    "find": "        plan_tier=getattr(doc, \"plan_tier\", None),\n        subscription_status=getattr(doc, \"subscription_status\", None),",
+    "replace": "        plan_tier=getattr(doc, \"plan_tier\", \"pro\"),\n        subscription_status=getattr(doc, \"subscription_status\", \"active\"),",
     "tests": [
       "tests/ee/sites/test_free_badge.py::test_a_first_publish_badges_before_it_deploys"
     ]
@@ -64,6 +75,27 @@
     "replace": "    \"display:flex;\"",
     "tests": [
       "tests/ee/sites/test_free_badge.py::test_every_hiding_vector_is_locked_important"
+    ]
+  },
+  {
+    "label": "a cancelled subscription counts as paying",
+    "file": "ee/pocketpaw_ee/cloud/entitlements/service.py",
+    "find": "_ACTIVE_SITE_SUBSCRIPTION_STATUSES = frozenset({\"active\"})",
+    "replace": "_ACTIVE_SITE_SUBSCRIPTION_STATUSES = frozenset({\"active\", \"cancelled\", \"none\"})",
+    "tests": [
+      "tests/cloud/entitlements/test_site_entitlements.py::test_a_paid_tier_without_an_active_subscription_is_badged",
+      "tests/cloud/entitlements/test_site_entitlements.py::test_a_tier_recorded_but_never_charged_is_badged",
+      "tests/ee/sites/test_free_badge.py::test_a_paid_tier_that_stopped_paying_gets_its_badge_back"
+    ]
+  },
+  {
+    "label": "paid capability stops requiring a paying subscription (the tier alone wins)",
+    "file": "ee/pocketpaw_ee/cloud/entitlements/service.py",
+    "find": "    if tier is not None and subscription_active:",
+    "replace": "    if tier is not None:",
+    "tests": [
+      "tests/cloud/entitlements/test_site_entitlements.py::test_a_paid_tier_without_an_active_subscription_is_badged",
+      "tests/ee/sites/test_free_badge.py::test_a_paid_tier_that_stopped_paying_gets_its_badge_back"
     ]
   },
   {

--- a/tests/mutations/free_badge.json
+++ b/tests/mutations/free_badge.json
@@ -1,0 +1,79 @@
+[
+  {
+    "label": "the gate stops requiring the badge at all",
+    "file": "ee/pocketpaw_ee/sites/badge.py",
+    "find": "    return not badge_removal",
+    "replace": "    return False",
+    "tests": [
+      "tests/ee/sites/test_free_badge.py::test_the_base_tier_is_badged",
+      "tests/ee/sites/test_free_badge.py::test_an_unknown_tier_is_badged"
+    ]
+  },
+  {
+    "label": "the free tier is handed badge removal",
+    "file": "ee/pocketpaw_ee/cloud/billing/site_plans.py",
+    "find": "    \"basic\": False,",
+    "replace": "    \"basic\": True,",
+    "tests": [
+      "tests/ee/sites/test_free_badge.py::test_the_base_tier_is_badged",
+      "tests/ee/sites/test_free_badge.py::test_a_basic_tier_site_is_badged"
+    ]
+  },
+  {
+    "label": "an undecodable page is skipped instead of aborting the publish",
+    "file": "ee/pocketpaw_ee/sites/badge.py",
+    "find": "            raise BadgeInjectionError(f\"unreadable page {path} — refusing to deploy\") from exc",
+    "replace": "            continue",
+    "tests": [
+      "tests/ee/sites/test_free_badge.py::test_an_undecodable_page_raises_rather_than_being_skipped",
+      "tests/ee/sites/test_free_badge.py::test_one_bad_page_stops_the_whole_publish",
+      "tests/ee/sites/test_free_badge.py::test_an_unbadgeable_page_aborts_the_publish"
+    ]
+  },
+  {
+    "label": "an unwritable page is skipped instead of aborting the publish",
+    "file": "ee/pocketpaw_ee/sites/badge.py",
+    "find": "            raise BadgeInjectionError(f\"unwritable page {path} — refusing to deploy\") from exc",
+    "replace": "            continue",
+    "tests": [
+      "tests/ee/sites/test_free_badge.py::test_an_unwritable_page_raises_rather_than_being_skipped"
+    ]
+  },
+  {
+    "label": "a first publish (no Site doc yet) defaults to UNbadged",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    badge_removal = bool(tier.badge_removal) if tier is not None else False",
+    "replace": "    badge_removal = bool(tier.badge_removal) if tier is not None else True",
+    "tests": [
+      "tests/ee/sites/test_free_badge.py::test_a_first_publish_badges_before_it_deploys"
+    ]
+  },
+  {
+    "label": "the badge lands at the FIRST </body>, so a code sample can swallow it",
+    "file": "ee/pocketpaw_ee/sites/badge.py",
+    "find": "    idx = page.lower().rfind(\"</body>\")",
+    "replace": "    idx = page.lower().find(\"</body>\")",
+    "tests": [
+      "tests/ee/sites/test_free_badge.py::test_the_last_closing_body_wins"
+    ]
+  },
+  {
+    "label": "the display lock loses its !important, so author CSS can hide the badge",
+    "file": "ee/pocketpaw_ee/sites/badge.py",
+    "find": "    \"display:flex!important;\"",
+    "replace": "    \"display:flex;\"",
+    "tests": [
+      "tests/ee/sites/test_free_badge.py::test_every_hiding_vector_is_locked_important"
+    ]
+  },
+  {
+    "label": "the stamper stops walking the tree, so no page is ever badged",
+    "file": "ee/pocketpaw_ee/sites/badge.py",
+    "find": "        seen_pages += 1",
+    "replace": "        seen_pages += 1\n        continue",
+    "tests": [
+      "tests/ee/sites/test_free_badge.py::test_every_page_in_the_tree_gets_a_badge",
+      "tests/ee/sites/test_free_badge.py::test_a_first_publish_badges_before_it_deploys"
+    ]
+  }
+]

--- a/tests/mutations/free_badge.json
+++ b/tests/mutations/free_badge.json
@@ -71,8 +71,8 @@
   {
     "label": "the display lock loses its !important, so author CSS can hide the badge",
     "file": "ee/pocketpaw_ee/sites/badge.py",
-    "find": "    \"display:flex!important;\"",
-    "replace": "    \"display:flex;\"",
+    "find": "    \"display:inline-flex!important;\"",
+    "replace": "    \"display:inline-flex;\"",
     "tests": [
       "tests/ee/sites/test_free_badge.py::test_every_hiding_vector_is_locked_important"
     ]
@@ -96,6 +96,24 @@
     "tests": [
       "tests/cloud/entitlements/test_site_entitlements.py::test_a_paid_tier_without_an_active_subscription_is_badged",
       "tests/ee/sites/test_free_badge.py::test_a_paid_tier_that_stopped_paying_gets_its_badge_back"
+    ]
+  },
+  {
+    "label": "the brand mark becomes a fetched asset a CSP can block",
+    "file": "ee/pocketpaw_ee/sites/badge.py",
+    "find": "    '<svg width=\"17\" height=\"17\" viewBox=\"0 0 32 32\" aria-hidden=\"true\" focusable=\"false\">'",
+    "replace": "    '<img src=\"https://pocketpaw.dev/favicon.svg\" width=\"17\" height=\"17\" alt=\"\"><svg viewBox=\"0 0 32 32\" aria-hidden=\"true\">'",
+    "tests": [
+      "tests/ee/sites/test_free_badge.py::test_nothing_in_the_badge_is_fetched"
+    ]
+  },
+  {
+    "label": "a lock-strength declaration migrates into the beatable stylesheet",
+    "file": "ee/pocketpaw_ee/sites/badge.py",
+    "find": "    \"background:rgba(15,17,21,.78);\"",
+    "replace": "    \"background:rgba(15,17,21,.78)!important;\"",
+    "tests": [
+      "tests/ee/sites/test_free_badge.py::test_the_lock_lives_on_the_element_not_the_stylesheet"
     ]
   },
   {


### PR DESCRIPTION
Removing the attribution badge is what the paid per-site tier sells, and there was no badge. Not built, not designed. Every `badge` in the tree is the gallery's capability chip, which is a different thing. So the ladder had a paid step that handed the customer what they already had.

Step 1 of the pricing build order in `docs/design/drafts/2026-08-13-paw-sites-pricing-spec.md` (workspace repo), which reviews the captain's pricing spec — finding #3 is this gap.

## How it works

Stamps onto the built pages between the build and the deploy, the same seam `_embed_concierge_bar` uses, so the artifact that lands is already right and there is no second deploy.

It **inverts that function's failure posture**, which is the point. The concierge bar swallows everything because a site going live matters more than its bar. This swallows nothing: an unreadable or unwritable page raises `BadgeInjectionError` and the publish aborts. A badge that fails open is not enforcement, because the exploit is simply to make injection fail.

One case is deliberately survivable: an empty output root. It resolves through the same `resolve_static_output_rel` the deploy reads its upload source from, so no tree means nothing ships from that root either. Raising there would protect no site and would turn every stubbed-build publish test into a failure. The reasoning is in the module and pinned by two tests, because it is the one place a future reader would reasonably "restore" a raise.

Server-rendered rather than a script, and every property that could hide it is inline and `!important`. The real attack is a rule in the customer's own stylesheet, which we build from, not our artifact, which they never touch.

## The gate

New `badge_removal` flag on `SitePlanTier`. `basic` keeps its badge; `pro` and `business` drop it. A first publish reaches the stamper before its `Site` doc exists, so an absent tier resolves to badged — the opposite default would ship every new site clean.

When `basic`/`pro`/`business` are rekeyed to the new plan ids, that mapping is the only place the badge's plan gate lives.

## Verification

29 tests. 1260 passing across `tests/ee/sites/` and `tests/cloud/sites/`, no regressions. `ruff check` and `ruff format` clean.

Eight mutations in `tests/mutations/free_badge.json`, all caught. The first sweep had one escape worth recording: `rfind`→`find` walked through `test_the_last_closing_body_wins`, because asserting the badge sits before the *last* `</body>` is true even when it lands inside a `<code>` sample. The assertion now pins it after the first.

## Not in this PR

Republish-on-plan-transition. A downgrade that flips `badge_required` has to rebuild a deployed static artifact, and that needs the plan catalog that step 3 introduces. Filed as a follow-up rather than half-built here.
