### PR TITLE
feat(livekit): add max_playout_delay to room creation

### DIFF
--- a/ee/pocketpaw_ee/cloud/livekit/service.py
+++ b/ee/pocketpaw_ee/cloud/livekit/service.py
@@ -764,6 +764,7 @@ async def create_room(
                 name=room_name,
                 empty_timeout=5 * 60,
                 max_participants=50,
+                max_playout_delay=750,
             )
             await lk.room.create_room(req)
             logger.info("Created LiveKit room %s for group %s", room_name, group_id)


### PR DESCRIPTION
## What & why

Sets `max_playout_delay=750` on the `CreateRoomRequest` when a new LiveKit room is created.

This is a jitter-buffer ceiling on the receiving side — it lets WebRTC buffer up to 750ms of audio to ride out lossy-WiFi bursts instead of cutting out mid-sentence. Pairs with the frontend work in [paw-enterprise#791](https://github.com/qbtrix/paw-enterprise/pull/791) (Windows-web voice-break fixes + per-participant volume control).

## Files
- `ee/pocketpaw_ee/cloud/livekit/service.py` — one line added to `create_room`'s `CreateRoomRequest`

## Testing
- 68/68 backend LiveKit tests pass (`test_livekit_service`, `test_call_budget`, `test_service_emits`)