### PR TITLE
fix(ci): dev has been red for days, and one of the reasons was invisible

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/sites_create.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/sites_create.py
@@ -2233,8 +2233,7 @@ async def _edit_html_file_handler(args: dict) -> dict:
     workspace_id, user_id = _identity()
     if not workspace_id or not user_id:
         return _error_response(
-            "edit_html_file requires workspace and user context (call from a "
-            "cloud chat session)."
+            "edit_html_file requires workspace and user context (call from a cloud chat session)."
         )
 
     record_tool_call(

--- a/ee/pocketpaw_ee/sites/generator_client.py
+++ b/ee/pocketpaw_ee/sites/generator_client.py
@@ -937,8 +937,9 @@ def _rewire_legacy_submit_forms(contents: str) -> str:
     Idempotent: the rewritten action is no longer ``/api/submit``, so a second pass
     matches nothing, and source authored against the new contract is untouched."""
     return _LEGACY_SUBMIT_FORM.sub(
-        lambda m: f'{m.group(1)}"__CAPTURE_API_BASE__/capture/form"{m.group(3)}'
-        + _CAPTURE_HIDDEN_FIELDS,
+        lambda m: (
+            f'{m.group(1)}"__CAPTURE_API_BASE__/capture/form"{m.group(3)}' + _CAPTURE_HIDDEN_FIELDS
+        ),
         contents,
     )
 

--- a/tests/mutations/react_edit_lane.json
+++ b/tests/mutations/react_edit_lane.json
@@ -49,8 +49,8 @@
   {
     "label": "create defaults to True, so a typo'd component_path is a silent new file instead of a 404",
     "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "    edits: list[dict[str, str]] | None = None,\n    create: bool = False,\n    _pockets: Any = None,",
-    "replace": "    edits: list[dict[str, str]] | None = None,\n    create: bool = True,\n    _pockets: Any = None,",
+    "find": "    component_path: str,\n    new_source: str | None = None,\n    edits: list[dict[str, str]] | None = None,\n    create: bool = False,\n    _pockets: Any = None,",
+    "replace": "    component_path: str,\n    new_source: str | None = None,\n    edits: list[dict[str, str]] | None = None,\n    create: bool = True,\n    _pockets: Any = None,",
     "tests": [
       "tests/ee/sites/test_react_component_edit.py::test_missing_path_is_not_found_when_create_is_false"
     ]
@@ -115,8 +115,8 @@
   {
     "label": "create stops requiring new_source, so an edits-only create writes nothing meaningful",
     "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "    if create and new_source is None:\n        raise ValidationError(\n            \"site_edit.create_needs_source\",",
-    "replace": "    if False:\n        raise ValidationError(\n            \"site_edit.create_needs_source\",",
+    "find": "    if create and new_source is None:\n        raise ValidationError(\n            \"site_edit.create_needs_source\",\n            \"Creating a new component needs `new_source` — the full contents of the \"",
+    "replace": "    if False:\n        raise ValidationError(\n            \"site_edit.create_needs_source\",\n            \"Creating a new component needs `new_source` — the full contents of the \"",
     "tests": [
       "tests/ee/sites/test_react_component_edit.py::test_create_without_new_source_is_rejected"
     ]
@@ -133,8 +133,8 @@
   {
     "label": "the draft ArtifactVersion is never written, so there is no reviewable draft for a later publish to promote",
     "file": "ee/pocketpaw_ee/cloud/pockets/service.py",
-    "find": "    await _record_pocket_svelte_draft_version(doc, author=user_id)\n    return await _resolved_wire_dict(doc, user_id)\n\n\nasync def set_imported_source(",
-    "replace": "    return await _resolved_wire_dict(doc, user_id)\n\n\nasync def set_imported_source(",
+    "find": "    # ``doc.source`` whatever engine wrote it); same best-effort contract — an\n    # additive history layer, never a gate on the edit.\n    await _record_pocket_svelte_draft_version(doc, author=user_id)\n    return await _resolved_wire_dict(doc, user_id)",
+    "replace": "    # ``doc.source`` whatever engine wrote it); same best-effort contract — an\n    # additive history layer, never a gate on the edit.\n    return await _resolved_wire_dict(doc, user_id)",
     "tests": [
       "tests/ee/sites/test_react_component_edit.py::test_edit_writes_a_reviewable_draft_version"
     ]
@@ -142,8 +142,8 @@
   {
     "label": "the write stops emitting PocketUpdated, so the search index / soul memory / ripple invalidation desync (cloud rule 9)",
     "file": "ee/pocketpaw_ee/cloud/pockets/service.py",
-    "find": "    await doc.save()\n    await emit(PocketUpdated(data=await _pocket_event_payload(doc)))\n    # Branch primitive (BP-3): a source-map edit ALSO writes a draft",
-    "replace": "    await doc.save()\n    # Branch primitive (BP-3): a source-map edit ALSO writes a draft",
+    "find": "    updated[component_path] = new_source\n    doc.source = updated\n    await doc.save()\n    await emit(PocketUpdated(data=await _pocket_event_payload(doc)))\n    # Branch primitive (BP-3): a source-map edit ALSO writes a draft",
+    "replace": "    updated[component_path] = new_source\n    doc.source = updated\n    await doc.save()\n    # Branch primitive (BP-3): a source-map edit ALSO writes a draft",
     "tests": [
       "tests/ee/sites/test_react_component_edit.py::test_pockets_service_emits_pocket_updated"
     ]
@@ -169,8 +169,8 @@
   {
     "label": "the create flag leaves the tool schema, so the agent cannot pass it and adding a section becomes impossible",
     "file": "ee/pocketpaw_ee/agent/mcp_servers/sites_create.py",
-    "find": "                \"create\": {\n                    \"type\": \"boolean\",",
-    "replace": "                \"create_DROPPED\": {\n                    \"type\": \"boolean\",",
+    "find": "                \"create\": {\n                    \"type\": \"boolean\",\n                    \"description\": (\n                        \"Create a NEW file at `component_path` instead of editing an \"",
+    "replace": "                \"create_DROPPED\": {\n                    \"type\": \"boolean\",\n                    \"description\": (\n                        \"Create a NEW file at `component_path` instead of editing an \"",
     "tests": [
       "tests/ee/agent/test_sites_mcp_server/test_edit_react_component.py::TestRegistration::test_the_schema_declares_the_create_flag"
     ]
@@ -261,8 +261,8 @@
   {
     "label": "the build-status tool id leaves SITES_TOOL_IDS, so the /sites allow-list filters the tool out silently and every handler test still passes",
     "file": "ee/pocketpaw_ee/agent/mcp_servers/sites.py",
-    "find": "    EDIT_REACT_COMPONENT_TOOL_ID,\n    GET_SITE_BUILD_STATUS_TOOL_ID,\n)",
-    "replace": "    EDIT_REACT_COMPONENT_TOOL_ID,\n)",
+    "find": "    EDIT_REACT_COMPONENT_TOOL_ID,\n    EDIT_HTML_FILE_TOOL_ID,\n    GET_SITE_BUILD_STATUS_TOOL_ID,\n)",
+    "replace": "    EDIT_REACT_COMPONENT_TOOL_ID,\n    EDIT_HTML_FILE_TOOL_ID,\n)",
     "tests": [
       "tests/ee/agent/test_sites_mcp_server/test_build_status_tool.py::TestRegistration::test_status_tool_id_is_on_the_shared_allowlist",
       "tests/ee/agent/test_sites_mcp_server/test_mcp_tool.py::TestSitesMcpServerRegistration::test_server_name_and_tool_id"

--- a/tests/mutations/static_form_capture.json
+++ b/tests/mutations/static_form_capture.json
@@ -103,8 +103,8 @@
   {
     "label": "static capture: the repointed form loses the credentials the endpoint gates on",
     "file": "ee/pocketpaw_ee/sites/generator_client.py",
-    "find": "        + _CAPTURE_HIDDEN_FIELDS,",
-    "replace": "        ,",
+    "find": "            f'{m.group(1)}\"__CAPTURE_API_BASE__/capture/form\"{m.group(3)}' + _CAPTURE_HIDDEN_FIELDS",
+    "replace": "            f'{m.group(1)}\"__CAPTURE_API_BASE__/capture/form\"{m.group(3)}'",
     "tests": [
       "tests/ee/sites/test_static_form_capture.py"
     ]


### PR DESCRIPTION
Two unrelated breakages, both already on `dev`, neither from the PR that surfaced them (#1937). Lint and the mutation-anchor job have been failing since before that branch existed.

## The mechanical half

`sites_create.py` and `generator_client.py` fail `ruff format --check`, which fails Lint. Reformatted. The ASTs are identical before and after, so nothing moved — that's checked, not assumed.

## The half worth reading

`react_edit_lane.json` had five anchors that no longer resolve, all collateral from the html edit lane. `edit_html_file` copied `edit_react_component`'s shape, so four anchors that used to be unique now match twice, and a fifth broke when `EDIT_HTML_FILE_TOOL_ID` was inserted into the id list. Each is repointed onto react-specific context — `component_path` vs `file_path`, "a new component" vs "a new file" — keeping the harm its label describes.

Then the part that actually matters.

**A plan with a bad anchor applies no mutations at all.** It aborts before the first one. So `react_edit_lane` has not run since the html lane landed — it has been reporting itself as covered while proving nothing.

Running it once the anchors resolved turned up a **sixth mutation that escaped**, and its anchor was the dangerous kind: still unique, so `--validate` was perfectly happy, but it ended at `async def set_imported_source(` and `set_html_source_file` had been inserted directly above that. The anchor silently moved from the react setter to the html one, and the react test it was paired with never noticed the difference. Repointed at the react block; all 31 catch now.

That failure mode is worth knowing about generally: an anchor that ends at a neighbouring `def` will follow that neighbour when someone inserts a function above it, and stays unique the whole time.

## One more, caused by fixing the first

Reformatting `generator_client.py` rotted an anchor in `static_form_capture.json` — the formatter folded the exact line the anchor matched into the lambda above it. Repointed; that plan's 14 all catch.

## Verification

- `ruff check .` and `ruff format --check .` clean
- 488 anchors across 40 plans, each resolving exactly once
- `tests/test_mutate_validate.py` green (this was the second CI failure)
- **both touched plans re-run in full**, not just re-validated — 31/31 and 14/14 caught

Local `pytest` on the OSS-only scope shows 58 failures, but those are pre-existing and Windows-only; Ubuntu CI reports 2, and both are the ones fixed here. My `.py` changes are provably inert (identical ASTs) and the other two files are JSON plans that only `scripts/mutate.py` reads.
