### PR TITLE
A free site could attach a custom domain and keep it

### DIFF
--- a/ee/pocketpaw_ee/cloud/_core/errors.py
+++ b/ee/pocketpaw_ee/cloud/_core/errors.py
@@ -31,6 +31,13 @@ Changed 2026-07-08 (feat/billing-smb-caps): added ``PocketLimitError`` (402,
 ``SeatLimitError``. Same 402 money-adjacent family; distinct codes so the UI can
 prompt a plan upgrade. Both enforce at create/enable time only (never retroactive)
 and only when ``billing_enforced`` is on.
+
+Changed 2026-08-15 (fix/sites-custom-domain-entitlement): added
+``CustomDomainNotEntitled`` (402, ``billing.custom_domain_not_entitled``) — the
+domain-attach sibling of the two above, and the first of this family keyed to a
+PER-SITE plan rather than the workspace one. Not a count limit: it reports a
+capability the site's tier does not resell, or a paid tier whose subscription is
+not paying. Attach-time only, gated on ``billing_enforced``.
 """
 
 from __future__ import annotations
@@ -145,6 +152,41 @@ class ConnectorLimitError(CloudError):
 
     def __init__(self, limit: int) -> None:
         super().__init__(402, "billing.connector_limit", f"Connector limit of {limit} reached")
+
+
+class CustomDomainNotEntitled(CloudError):
+    """A site tried to attach a custom domain its per-site plan does not grant (402).
+
+    Sibling of ``PocketLimitError`` / ``ConnectorLimitError`` for the domain-attach
+    seam, and the same money-adjacent 402 family, with a distinct
+    ``billing.custom_domain_not_entitled`` code so the UI prompts a per-SITE plan
+    upgrade rather than a workspace one.
+
+    The distinction from its siblings is that this is not a COUNT limit: there is no
+    ceiling to report, only a capability the site's tier either resells or does not.
+    Two different failures land here and the message separates them, because the
+    remedies differ — a free site upgrades its plan, while a paid site whose
+    subscription lapsed fixes its billing and keeps the tier it already chose.
+
+    Enforced at ATTACH time only — never retroactive. A downgrade does not rip a
+    live domain off a deployed site, and re-adding an already-connected domain
+    (the only self-service repair for a missing Worker route) stays reachable. The
+    spec's period-end detach is a different lane. Gated on ``billing_enforced``,
+    so OSS / self-host never sees it.
+    """
+
+    def __init__(self, *, plan_tier: str, subscription_active: bool) -> None:
+        if subscription_active:
+            detail = (
+                f"the {plan_tier} plan does not include a custom domain — "
+                "upgrade this site's plan to connect one"
+            )
+        else:
+            detail = (
+                f"this site is on {plan_tier} without an active subscription — "
+                "renew it to connect a custom domain"
+            )
+        super().__init__(402, "billing.custom_domain_not_entitled", f"Custom domain: {detail}")
 
 
 class CallLimitError(CloudError):

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -4586,9 +4586,31 @@ async def _apply_site_plan(
     # Resolve the tier; fall back to the base tier for a None / unknown key so a
     # publish is never blocked by a bad tier string (the entitlement gate is the
     # one that matters and already ran).
-    tier = site_plans.get_site_plan(site_plan_key) or site_plans.get_site_plan(
-        site_plans.BASE_SITE_PLAN_KEY
-    )
+    #
+    # ...but NEVER let that fallback DOWNGRADE a site that already holds a tier.
+    # ``site_plan_key`` is an optional client-supplied field, so an ordinary
+    # republish that simply omits it used to rewrite a paying site's ``plan_tier``
+    # to the base key and its ``subscription_status`` to "none". Nothing restores
+    # either — only the ``subscription.active`` webhook writes "active", and no path
+    # rewrites the tier — so the site silently lost every paid capability for good.
+    # That was survivable while nothing read the fields; the custom-domain gate on
+    # ``add_domain`` reads them, which turns it into a permanent 402 telling a
+    # paying customer to upgrade a plan they already bought.
+    #
+    # An EXPLICIT key still wins in both directions: a real downgrade is a request
+    # carrying the target tier, not the absence of one. Only the None/unknown case
+    # is treated as "leave it as it is".
+    tier = site_plans.get_site_plan(site_plan_key)
+    if tier is None:
+        existing_tier = site_plans.get_site_plan(getattr(doc, "plan_tier", None))
+        tier = existing_tier or site_plans.get_site_plan(site_plans.BASE_SITE_PLAN_KEY)
+        if existing_tier is not None:
+            logger.info(
+                "sites: publish for site %s carried no site_plan_key — keeping its "
+                "existing tier %s rather than resetting to the base",
+                str(doc.id),
+                existing_tier.key,
+            )
     plan_key = tier.key if tier is not None else site_plans.BASE_SITE_PLAN_KEY
 
     site_id = str(doc.id)
@@ -4623,11 +4645,24 @@ async def _apply_site_plan(
 
     # Stamp the per-site plan on the (already persisted) canonical Site doc.
     doc.plan_tier = plan_key
-    doc.subscription_id = subscription_id
     # A live sub starts pending until Dodo posts a verified subscription.active;
     # an unconfigured (no-charge) tier has no live sub to activate, so it stays
     # "none". The per-site webhook advances "pending" → "active".
-    doc.subscription_status = "pending" if subscription_id else "none"
+    #
+    # The ACTIVE case is carved out, for the same reason the tier fallback above is:
+    # a republish of a site that is already paying opened no new subscription
+    # (``subscription_id`` is None on this pass because no fresh checkout was made),
+    # and writing "none" over "active" silently strips every paid capability from a
+    # customer who is still being charged. Nothing restores it — only the webhook
+    # writes "active", and it has already fired for this subscription. Keep what the
+    # site has; a genuine cancellation arrives as a webhook, never as the absence of
+    # a checkout during an unrelated republish.
+    if subscription_id:
+        doc.subscription_id = subscription_id
+        doc.subscription_status = "pending"
+    elif doc.subscription_status != "active":
+        doc.subscription_id = subscription_id
+        doc.subscription_status = "none"
     await doc.save()
 
     await emit(

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -840,6 +840,7 @@ from bson.errors import InvalidId
 from pocketpaw.sites_capture.contact_form import CONTACT_FORM_TYPE, default_event_mapping
 from pocketpaw_ee.cloud._core.errors import (
     CloudError,
+    CustomDomainNotEntitled,
     Forbidden,
     Internal,
     NotFound,
@@ -3896,6 +3897,54 @@ def _route_target(site: Any) -> str:
     return worker_name(str(site.id))
 
 
+def _assert_entitled_to_custom_domain(site: Any) -> None:
+    """Refuse the attach unless this site's own plan grants a custom domain.
+
+    Delegates the RULE to ``entitlements.resolve_site_entitlements`` rather than
+    reading ``plan_tier`` here, for the reason that resolver exists: cancellation
+    never resets the tier, and an unconfigured Dodo product records a paid tier with
+    no charge, so tier-alone hands a free custom domain to sites that have never
+    paid. That resolver had exactly one caller (the badge stamper); this is the
+    second, and both paid per-site capabilities now answer to the same function.
+
+    Gated on ``billing_enforced``, matching every other cap in this codebase: OSS /
+    self-host has no billing and must not acquire a paywall. The lazy ``get_settings``
+    import mirrors the connector cap — it keeps the billing posture off this module's
+    import path.
+
+    Synchronous and passed the loaded doc, because the resolver is pure and
+    ``entitlements`` may not import ``models.site`` (EE cloud rule 2): the caller
+    that owns the document passes what it owns.
+    """
+    from pocketpaw.config import get_settings
+
+    if not get_settings().billing_enforced:
+        return
+
+    from pocketpaw_ee.cloud.entitlements import service as entitlements_service
+
+    ent = entitlements_service.resolve_site_entitlements(
+        site_id=str(site.id),
+        workspace_id=site.workspace,
+        plan_tier=site.plan_tier,
+        subscription_status=site.subscription_status,
+        concierge_enabled=bool(getattr(site, "concierge_enabled", True)),
+    )
+    if ent.custom_domain:
+        return
+
+    logger.info(
+        "sites: refused a custom domain for site %s — tier %s, subscription active: %s",
+        site.id,
+        ent.plan_tier,
+        ent.subscription_active,
+    )
+    raise CustomDomainNotEntitled(
+        plan_tier=ent.plan_tier,
+        subscription_active=ent.subscription_active,
+    )
+
+
 async def add_domain(
     *,
     workspace_id: str,
@@ -3974,6 +4023,27 @@ async def add_domain(
             "Publish the site before connecting a domain — a custom domain has to "
             "point at a published site, and this one hasn't been published yet.",
         )
+
+    # A custom domain is a PAID per-site capability, so ask whether this site is
+    # entitled to one BEFORE anything is created. Until 2026-08-15 nothing asked:
+    # the tier was resolved just below, but only to pass ``cloudflare_features`` to
+    # provisioning (BC-10 resale), and no branch anywhere read whether the tier
+    # granted the domain itself. The endpoint's only gate was RBAC, which is
+    # permission rather than billing, so a base-tier site attached a custom domain
+    # and kept it — as did a paid site whose subscription was cancelled or, with no
+    # Dodo product configured, never charged at all.
+    #
+    # Placed HERE, and the position is the contract:
+    #   * AFTER the already-connected branch above returns, so this is never
+    #     retroactive. A site that loses its entitlement keeps a live domain, and
+    #     the re-Add route repair — the only self-service fix for a domain that
+    #     silently serves the fallback origin — stays reachable. Detaching on
+    #     downgrade happens at period end, which is not this seam.
+    #   * BEFORE ``create_custom_hostname``. Refusing afterwards would leave a
+    #     hostname on the shared zone with no Site row pointing at it: invisible to
+    #     the product, and it makes the customer's next legitimate attach fail on a
+    #     1406 duplicate they can neither see nor clear.
+    _assert_entitled_to_custom_domain(site)
 
     # Resolve the site's tier → its cloudflare_features and provision them on the
     # custom hostname. A base-tier (or unknown) site resolves to an empty set, so

--- a/tests/cloud/sites/test_custom_domain_entitlement.py
+++ b/tests/cloud/sites/test_custom_domain_entitlement.py
@@ -1,0 +1,382 @@
+# tests/cloud/sites/test_custom_domain_entitlement.py — a custom domain is a PAID
+# per-site capability, and until this branch nothing checked whether the site was
+# entitled to one.
+#
+# Created 2026-08-15 (fix/sites-custom-domain-entitlement). The hole: ``add_domain``
+# already resolved the site's plan — but only to pass ``cloudflare_features`` to
+# Cloudflare (BC-10 resale). No branch anywhere asked "may this site have a custom
+# domain at all". The only gate on the endpoint was RBAC (``fabric.write``), which
+# is permission, not billing. So a basic-tier site attached a custom domain and
+# kept it, and so did a paid site whose subscription was cancelled or never
+# charged.
+#
+# ``resolve_site_entitlements`` has answered this since 2026-08-13 and had exactly
+# ONE caller (the badge stamper). This tree pins the second one.
+#
+# Deliberately tier-key agnostic: every criterion reads the tier that grants
+# ``custom_domain`` out of the catalog rather than hardcoding "pro", so the
+# pricing-spec rekey (basic/pro/business → free/site/staff) moves these tests with
+# the catalog instead of breaking them.
+#
+# Two postures inherited from the siblings this gate copies (``PocketLimitError``,
+# ``ConnectorLimitError``) and pinned here because both are easy to "fix" wrongly
+# later:
+#   * ATTACH-TIME ONLY, never retroactive — a downgrade does not rip a live domain
+#     off a deployed site mid-flight, and the re-Add route REPAIR stays reachable.
+#     The spec's downgrade rules detach at period end; that is a different lane.
+#   * Gated on ``billing_enforced`` — OSS / self-host has no billing and must not
+#     acquire a paywall from this branch.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud._core.errors import CloudError  # noqa: E402
+from pocketpaw_ee.cloud.billing import site_plans  # noqa: E402
+from pocketpaw_ee.cloud.models.site import Site, SiteDomain  # noqa: E402
+from pocketpaw_ee.sites import service as sites_service  # noqa: E402
+from pocketpaw_ee.sites.domain import CustomHostname, HostnameStatus  # noqa: E402
+
+import pocketpaw.config as ppconfig  # noqa: E402
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+# --------------------------------------------------------------------------- #
+# Catalog-derived tier keys — see the header on why these are not literals.
+# --------------------------------------------------------------------------- #
+
+
+def _a_tier_granting_custom_domain() -> str:
+    """The cheapest catalog tier that resells ``custom_domain``."""
+    for tier in site_plans.list_site_plans():
+        if "custom_domain" in tier.cloudflare_features:
+            return tier.key
+    raise AssertionError("no site plan tier resells custom_domain — catalog changed")
+
+
+def _the_free_tier() -> str:
+    """The base/floor tier. It resells nothing, which is what free means."""
+    return site_plans.BASE_SITE_PLAN_KEY
+
+
+# --------------------------------------------------------------------------- #
+# Test doubles.
+# --------------------------------------------------------------------------- #
+
+
+class _RecordingCF:
+    """Stand-in CloudflareClient that records calls and never touches the network.
+
+    Records ``create_custom_hostname`` AND ``create_worker_route`` because one
+    criterion here is specifically that a refused attach reaches NEITHER — a gate
+    that raises after Cloudflare has already accepted the hostname leaves an orphan
+    on the zone that nothing in the product can see or clear.
+    """
+
+    def __init__(self) -> None:
+        self.create_calls: list[dict] = []
+        self.route_calls: list[dict] = []
+        self.delete_calls: list[str] = []
+
+    async def create_custom_hostname(
+        self, hostname: str, *, features: set[str] | None = None
+    ) -> CustomHostname:
+        self.create_calls.append({"hostname": hostname, "features": features})
+        return CustomHostname(
+            id="ch_test",
+            hostname=hostname,
+            status=HostnameStatus.PENDING,
+            cname_target="zone_1.cdn.cloudflare.net",
+        )
+
+    async def create_worker_route(self, *, pattern: str, script: str) -> str:
+        self.route_calls.append({"pattern": pattern, "script": script})
+        return "route_test"
+
+    async def delete_custom_hostname(self, hostname_id: str) -> None:
+        self.delete_calls.append(hostname_id)
+
+
+def _enforce(monkeypatch, *, on: bool) -> None:
+    """Point the config's ``get_settings`` at a flag stub carrying the billing
+    posture. Lazily imported inside the gate, same as the connector/pocket caps."""
+    monkeypatch.setattr(
+        ppconfig,
+        "get_settings",
+        lambda: SimpleNamespace(billing_enforced=on, dodo_site_products=None),
+    )
+
+
+async def _seed_site(
+    *,
+    workspace_id: str,
+    plan_tier: str | None,
+    subscription_status: str = "none",
+    deployed: bool = True,
+) -> str:
+    """Insert a real Site doc and return its id string.
+
+    ``deployed=True`` by default: an unpublished site is refused by a DIFFERENT
+    guard (``sites.domain_needs_publish``), and a test that tripped that one while
+    believing it proved the entitlement gate would pass for the wrong reason.
+    """
+    doc = Site(
+        workspace=workspace_id,
+        pocket_id="pk_1",
+        owner="u1",
+        name="My Site",
+        plan_tier=plan_tier,
+        subscription_status=subscription_status,
+        deployed=deployed,
+    )
+    await doc.insert()
+    return str(doc.id)
+
+
+# --------------------------------------------------------------------------- #
+# The bug: a site with no paid entitlement attached a custom domain.
+# --------------------------------------------------------------------------- #
+
+
+async def test_a_free_site_cannot_attach_a_custom_domain(monkeypatch):
+    """The headline case. A base-tier site resells no custom_domain, so the attach
+    is refused with a 402 the UI can turn into an upgrade prompt."""
+    _enforce(monkeypatch, on=True)
+    ws = "ws_free_domain"
+    site_id = await _seed_site(workspace_id=ws, plan_tier=_the_free_tier())
+    cf = _RecordingCF()
+
+    with pytest.raises(CloudError) as exc:
+        await sites_service.add_domain(
+            workspace_id=ws,
+            site_id=site_id,
+            hostname="www.freeloader.com",
+            _cloudflare=cf,
+        )
+
+    assert exc.value.status_code == 402
+    assert exc.value.code == "billing.custom_domain_not_entitled"
+
+
+async def test_an_unset_tier_cannot_attach_a_custom_domain(monkeypatch):
+    """A site with no ``plan_tier`` at all (pre-BC-9 rows, and every first publish)
+    resolves to the floor. Fail-closed: absent is free, not exempt."""
+    _enforce(monkeypatch, on=True)
+    ws = "ws_untiered_domain"
+    site_id = await _seed_site(workspace_id=ws, plan_tier=None)
+    cf = _RecordingCF()
+
+    with pytest.raises(CloudError) as exc:
+        await sites_service.add_domain(
+            workspace_id=ws,
+            site_id=site_id,
+            hostname="www.untiered.com",
+            _cloudflare=cf,
+        )
+
+    assert exc.value.status_code == 402
+
+
+async def test_a_refused_attach_never_reaches_cloudflare(monkeypatch):
+    """The gate runs BEFORE any Cloudflare call.
+
+    Raising after ``create_custom_hostname`` succeeds would leave a hostname on the
+    shared zone with no Site row pointing at it — invisible to the product, and it
+    makes the customer's next legitimate attach fail on a 1406 duplicate they
+    cannot see or clear.
+    """
+    _enforce(monkeypatch, on=True)
+    ws = "ws_no_cf_call"
+    site_id = await _seed_site(workspace_id=ws, plan_tier=_the_free_tier())
+    cf = _RecordingCF()
+
+    with pytest.raises(CloudError):
+        await sites_service.add_domain(
+            workspace_id=ws,
+            site_id=site_id,
+            hostname="www.nocall.com",
+            _cloudflare=cf,
+        )
+
+    assert cf.create_calls == []
+    assert cf.route_calls == []
+
+
+async def test_a_refused_attach_writes_nothing_to_the_site(monkeypatch):
+    """No half-state: the refused hostname is not on ``domains``, and — the easier
+    one to miss — not on ``allowed_origins`` either, which is what authorizes a
+    host to POST captures at the site."""
+    _enforce(monkeypatch, on=True)
+    ws = "ws_no_write"
+    site_id = await _seed_site(workspace_id=ws, plan_tier=_the_free_tier())
+    cf = _RecordingCF()
+
+    with pytest.raises(CloudError):
+        await sites_service.add_domain(
+            workspace_id=ws,
+            site_id=site_id,
+            hostname="www.nowrite.com",
+            _cloudflare=cf,
+        )
+
+    doc = await Site.get(site_id)
+    assert doc.domains == []
+    assert "www.nowrite.com" not in doc.allowed_origins
+
+
+# --------------------------------------------------------------------------- #
+# The wider half of the hole: a paid TIER without a paying SUBSCRIPTION.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("status", ["none", "pending", "cancelled"])
+async def test_a_paid_tier_without_an_active_subscription_is_refused(monkeypatch, status):
+    """Cancellation never resets ``plan_tier``, and an unconfigured Dodo product
+    records a paid tier with no charge at all. Reading the tier alone therefore
+    hands a free custom domain to sites that have never paid — permanently. The
+    resolver gates on tier AND subscription; this proves the attach seam does too.
+    """
+    _enforce(monkeypatch, on=True)
+    ws = f"ws_paid_{status}"
+    site_id = await _seed_site(
+        workspace_id=ws,
+        plan_tier=_a_tier_granting_custom_domain(),
+        subscription_status=status,
+    )
+    cf = _RecordingCF()
+
+    with pytest.raises(CloudError) as exc:
+        await sites_service.add_domain(
+            workspace_id=ws,
+            site_id=site_id,
+            hostname=f"www.{status}.com",
+            _cloudflare=cf,
+        )
+
+    assert exc.value.status_code == 402
+    assert cf.create_calls == []
+
+
+# --------------------------------------------------------------------------- #
+# The paying case still works — the gate must not become the bug.
+# --------------------------------------------------------------------------- #
+
+
+async def test_an_active_paid_site_attaches_normally(monkeypatch):
+    """A tier that resells custom_domain, on an active subscription, is unaffected:
+    Cloudflare is called and the domain lands on the site."""
+    _enforce(monkeypatch, on=True)
+    ws = "ws_paid_active"
+    tier = _a_tier_granting_custom_domain()
+    site_id = await _seed_site(workspace_id=ws, plan_tier=tier, subscription_status="active")
+    cf = _RecordingCF()
+
+    res = await sites_service.add_domain(
+        workspace_id=ws,
+        site_id=site_id,
+        hostname="www.paying.com",
+        _cloudflare=cf,
+    )
+
+    assert res.hostname == "www.paying.com"
+    assert len(cf.create_calls) == 1
+    doc = await Site.get(site_id)
+    assert [d.hostname for d in doc.domains] == ["www.paying.com"]
+
+
+async def test_the_resold_feature_set_still_rides_along(monkeypatch):
+    """The BC-10 resale contract is untouched by the gate — an entitled attach still
+    passes its tier's ``cloudflare_features`` through to provisioning."""
+    _enforce(monkeypatch, on=True)
+    ws = "ws_features_intact"
+    tier = _a_tier_granting_custom_domain()
+    site_id = await _seed_site(workspace_id=ws, plan_tier=tier, subscription_status="active")
+    cf = _RecordingCF()
+
+    await sites_service.add_domain(
+        workspace_id=ws,
+        site_id=site_id,
+        hostname="www.features.com",
+        _cloudflare=cf,
+    )
+
+    assert cf.create_calls[0]["features"] == set(site_plans.get_site_plan(tier).cloudflare_features)
+
+
+# --------------------------------------------------------------------------- #
+# Never retroactive — the posture inherited from the pocket/connector caps.
+# --------------------------------------------------------------------------- #
+
+
+async def test_an_already_connected_domain_still_repairs_its_route(monkeypatch):
+    """A site that LOST its entitlement keeps its live domain, and the re-Add route
+    repair stays reachable.
+
+    Pressing Add again is the only self-service fix for a domain connected before
+    the routing lane shipped (those have no route and silently serve the fallback
+    origin while Cloudflare reports them active). If the gate ran before the repair,
+    a downgraded site would be stuck serving a broken domain with no way out — and
+    detaching on downgrade is a period-end job, not this seam's.
+    """
+    _enforce(monkeypatch, on=True)
+    ws = "ws_repair"
+    site_id = await _seed_site(workspace_id=ws, plan_tier=_the_free_tier())
+    doc = await Site.get(site_id)
+    # ``_route_target`` asks the SITE what was deployed, never the environment what
+    # is configured — and this tree's conftest clears the operator's PAW_CF_* env,
+    # so the pre-field fallback resolves to "". Stamping the target is what gives
+    # this site a route-addressable Worker, and therefore a route to repair.
+    doc.deploy_target = "workers"
+    doc.domains.append(
+        SiteDomain(
+            hostname="www.legacy.com",
+            cf_hostname_id="ch_legacy",
+            cname_target="zone_1.cdn.cloudflare.net",
+            status="active",
+            cf_route_id="",  # the missing route this call exists to repair
+        )
+    )
+    await doc.save()
+    cf = _RecordingCF()
+
+    res = await sites_service.add_domain(
+        workspace_id=ws,
+        site_id=site_id,
+        hostname="www.legacy.com",
+        _cloudflare=cf,
+    )
+
+    assert res.hostname == "www.legacy.com"
+    assert len(cf.route_calls) == 1
+    refreshed = await Site.get(site_id)
+    assert refreshed.domains[0].cf_route_id == "route_test"
+
+
+# --------------------------------------------------------------------------- #
+# OSS / self-host — billing off means no paywall.
+# --------------------------------------------------------------------------- #
+
+
+async def test_with_billing_off_the_gate_never_fires(monkeypatch):
+    """With ``billing_enforced`` off, a free site attaches a custom domain exactly
+    as it did before this branch. Self-host has no billing and must not inherit a
+    paywall from it."""
+    _enforce(monkeypatch, on=False)
+    ws = "ws_oss"
+    site_id = await _seed_site(workspace_id=ws, plan_tier=_the_free_tier())
+    cf = _RecordingCF()
+
+    res = await sites_service.add_domain(
+        workspace_id=ws,
+        site_id=site_id,
+        hostname="www.selfhost.com",
+        _cloudflare=cf,
+    )
+
+    assert res.hostname == "www.selfhost.com"
+    assert len(cf.create_calls) == 1

--- a/tests/cloud/sites/test_custom_domain_entitlement.py
+++ b/tests/cloud/sites/test_custom_domain_entitlement.py
@@ -380,3 +380,98 @@ async def test_with_billing_off_the_gate_never_fires(monkeypatch):
 
     assert res.hostname == "www.selfhost.com"
     assert len(cf.create_calls) == 1
+
+
+# --------------------------------------------------------------------------- #
+# The gate is only as correct as the fields it reads, and the publish path used
+# to rewrite both of them on every republish.
+#
+# Added 2026-08-15 after review. ``site_plan_key`` is an optional client-supplied
+# field, so an ordinary republish that omits it reset ``plan_tier`` to the base key
+# and ``subscription_status`` to "none". Nothing restores either — only the
+# ``subscription.active`` webhook writes "active", and no path rewrites the tier.
+# Harmless while nothing read the fields; this branch makes ``add_domain`` read
+# them, which turns the loss into a permanent 402 telling a paying customer to
+# upgrade a plan they already bought.
+# --------------------------------------------------------------------------- #
+
+
+async def test_a_republish_without_a_plan_key_keeps_the_paid_tier(monkeypatch):
+    """The tier survives a republish that simply does not mention it."""
+    from pocketpaw_ee.sites import service as svc
+
+    _enforce(monkeypatch, on=True)
+    ws = "ws_keep_tier"
+    tier = _a_tier_granting_custom_domain()
+    site_id = await _seed_site(workspace_id=ws, plan_tier=tier, subscription_status="active")
+    doc = await Site.get(site_id)
+
+    await svc._apply_site_plan(
+        doc=doc,
+        workspace_id=ws,
+        pocket_id="pk_1",
+        user_id="u1",
+        site_plan_key=None,  # the republish says nothing about the plan
+        provider=None,
+    )
+
+    refreshed = await Site.get(site_id)
+    assert refreshed.plan_tier == tier
+    assert refreshed.subscription_status == "active"
+
+
+async def test_a_republish_leaves_a_paying_site_able_to_attach_a_domain(monkeypatch):
+    """The whole point, end to end: republish, then attach. Before the fix this
+    402'd with "upgrade this site's plan" at a customer who was still paying."""
+    from pocketpaw_ee.sites import service as svc
+
+    _enforce(monkeypatch, on=True)
+    ws = "ws_republish_domain"
+    tier = _a_tier_granting_custom_domain()
+    site_id = await _seed_site(workspace_id=ws, plan_tier=tier, subscription_status="active")
+    doc = await Site.get(site_id)
+    await svc._apply_site_plan(
+        doc=doc,
+        workspace_id=ws,
+        pocket_id="pk_1",
+        user_id="u1",
+        site_plan_key=None,
+        provider=None,
+    )
+    cf = _RecordingCF()
+
+    res = await sites_service.add_domain(
+        workspace_id=ws,
+        site_id=site_id,
+        hostname="www.stillpaying.com",
+        _cloudflare=cf,
+    )
+
+    assert res.hostname == "www.stillpaying.com"
+
+
+async def test_an_explicit_tier_still_wins(monkeypatch):
+    """The fix must not make downgrades impossible. A real plan change carries the
+    target tier; only the ABSENCE of one is read as "leave it alone"."""
+    from pocketpaw_ee.sites import service as svc
+
+    _enforce(monkeypatch, on=True)
+    ws = "ws_explicit_downgrade"
+    site_id = await _seed_site(
+        workspace_id=ws,
+        plan_tier=_a_tier_granting_custom_domain(),
+        subscription_status="active",
+    )
+    doc = await Site.get(site_id)
+
+    await svc._apply_site_plan(
+        doc=doc,
+        workspace_id=ws,
+        pocket_id="pk_1",
+        user_id="u1",
+        site_plan_key=_the_free_tier(),  # an explicit move to the floor
+        provider=None,
+    )
+
+    refreshed = await Site.get(site_id)
+    assert refreshed.plan_tier == _the_free_tier()

--- a/tests/mutations/custom_domain_entitlement.json
+++ b/tests/mutations/custom_domain_entitlement.json
@@ -94,5 +94,34 @@
       "tests/cloud/sites/test_custom_domain_entitlement.py::test_an_active_paid_site_attaches_normally",
       "tests/cloud/sites/test_custom_domain_entitlement.py::test_the_resold_feature_set_still_rides_along"
     ]
+  },
+  {
+    "label": "a republish without a plan key silently downgrades the tier to the floor",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    tier = site_plans.get_site_plan(site_plan_key)\n    if tier is None:\n        existing_tier = site_plans.get_site_plan(getattr(doc, \"plan_tier\", None))",
+    "replace": "    tier = site_plans.get_site_plan(site_plan_key)\n    if tier is None:\n        existing_tier = None",
+    "tests": [
+      "tests/cloud/sites/test_custom_domain_entitlement.py::test_a_republish_without_a_plan_key_keeps_the_paid_tier",
+      "tests/cloud/sites/test_custom_domain_entitlement.py::test_a_republish_leaves_a_paying_site_able_to_attach_a_domain"
+    ]
+  },
+  {
+    "label": "a republish writes 'none' over an ACTIVE subscription",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    elif doc.subscription_status != \"active\":",
+    "replace": "    else:",
+    "tests": [
+      "tests/cloud/sites/test_custom_domain_entitlement.py::test_a_republish_without_a_plan_key_keeps_the_paid_tier",
+      "tests/cloud/sites/test_custom_domain_entitlement.py::test_a_republish_leaves_a_paying_site_able_to_attach_a_domain"
+    ]
+  },
+  {
+    "label": "the keep-tier fallback swallows an EXPLICIT downgrade too",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    tier = site_plans.get_site_plan(site_plan_key)\n    if tier is None:",
+    "replace": "    tier = None\n    if tier is None:",
+    "tests": [
+      "tests/cloud/sites/test_custom_domain_entitlement.py::test_an_explicit_tier_still_wins"
+    ]
   }
 ]

--- a/tests/mutations/custom_domain_entitlement.json
+++ b/tests/mutations/custom_domain_entitlement.json
@@ -1,0 +1,98 @@
+[
+  {
+    "label": "the gate is deleted outright",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    _assert_entitled_to_custom_domain(site)",
+    "replace": "    pass",
+    "tests": [
+      "tests/cloud/sites/test_custom_domain_entitlement.py::test_a_free_site_cannot_attach_a_custom_domain",
+      "tests/cloud/sites/test_custom_domain_entitlement.py::test_an_unset_tier_cannot_attach_a_custom_domain"
+    ]
+  },
+  {
+    "label": "the gate reads the TIER alone, ignoring whether the subscription pays",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if ent.custom_domain:\n        return",
+    "replace": "    if \"custom_domain\" in (site_plans.get_site_plan(site.plan_tier).cloudflare_features if site_plans.get_site_plan(site.plan_tier) else set()):\n        return",
+    "tests": [
+      "tests/cloud/sites/test_custom_domain_entitlement.py::test_a_paid_tier_without_an_active_subscription_is_refused"
+    ]
+  },
+  {
+    "label": "the fail-closed default inverts — an unknown tier is handed a domain",
+    "file": "ee/pocketpaw_ee/cloud/entitlements/service.py",
+    "find": "    custom_domain = False",
+    "replace": "    custom_domain = True",
+    "tests": [
+      "tests/cloud/sites/test_custom_domain_entitlement.py::test_an_unset_tier_cannot_attach_a_custom_domain",
+      "tests/cloud/sites/test_custom_domain_entitlement.py::test_a_free_site_cannot_attach_a_custom_domain",
+      "tests/cloud/entitlements/test_site_entitlements.py::test_an_unknown_or_absent_tier_falls_to_the_base"
+    ]
+  },
+  {
+    "label": "the gate runs AFTER Cloudflare has already created the hostname",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    _assert_entitled_to_custom_domain(site)\n\n    # Resolve the site's tier",
+    "replace": "\n    # Resolve the site's tier",
+    "tests": [
+      "tests/cloud/sites/test_custom_domain_entitlement.py::test_a_refused_attach_never_reaches_cloudflare"
+    ]
+  },
+  {
+    "label": "a refused attach still writes the hostname onto allowed_origins",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    _assert_entitled_to_custom_domain(site)",
+    "replace": "    site.allowed_origins.append(hostname)\n    await site.set({\"allowed_origins\": list(site.allowed_origins)})\n    _assert_entitled_to_custom_domain(site)",
+    "tests": [
+      "tests/cloud/sites/test_custom_domain_entitlement.py::test_a_refused_attach_writes_nothing_to_the_site"
+    ]
+  },
+  {
+    "label": "the gate becomes retroactive — it runs before the already-connected repair",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    hostname = _normalize_hostname(hostname)\n    existing = next(",
+    "replace": "    _assert_entitled_to_custom_domain(site)\n    hostname = _normalize_hostname(hostname)\n    existing = next(",
+    "tests": [
+      "tests/cloud/sites/test_custom_domain_entitlement.py::test_an_already_connected_domain_still_repairs_its_route"
+    ]
+  },
+  {
+    "label": "the billing_enforced guard is dropped — OSS/self-host inherits the paywall",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if not get_settings().billing_enforced:\n        return\n\n    from pocketpaw_ee.cloud.entitlements import service as entitlements_service",
+    "replace": "    from pocketpaw_ee.cloud.entitlements import service as entitlements_service",
+    "tests": [
+      "tests/cloud/sites/test_custom_domain_entitlement.py::test_with_billing_off_the_gate_never_fires"
+    ]
+  },
+  {
+    "label": "the guard inverts — the gate fires ONLY when billing is off",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if not get_settings().billing_enforced:\n        return",
+    "replace": "    if get_settings().billing_enforced:\n        return",
+    "tests": [
+      "tests/cloud/sites/test_custom_domain_entitlement.py::test_a_free_site_cannot_attach_a_custom_domain",
+      "tests/cloud/sites/test_custom_domain_entitlement.py::test_with_billing_off_the_gate_never_fires"
+    ]
+  },
+  {
+    "label": "the refusal degrades to a 4xx the UI cannot tell from a validation error",
+    "file": "ee/pocketpaw_ee/cloud/_core/errors.py",
+    "find": "        super().__init__(402, \"billing.custom_domain_not_entitled\", f\"Custom domain: {detail}\")",
+    "replace": "        super().__init__(422, \"sites.custom_domain_not_entitled\", f\"Custom domain: {detail}\")",
+    "tests": [
+      "tests/cloud/sites/test_custom_domain_entitlement.py::test_a_free_site_cannot_attach_a_custom_domain",
+      "tests/cloud/sites/test_custom_domain_entitlement.py::test_a_paid_tier_without_an_active_subscription_is_refused"
+    ]
+  },
+  {
+    "label": "the entitled path is broken too — the gate refuses everyone",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if ent.custom_domain:\n        return",
+    "replace": "    if False:\n        return",
+    "tests": [
+      "tests/cloud/sites/test_custom_domain_entitlement.py::test_an_active_paid_site_attaches_normally",
+      "tests/cloud/sites/test_custom_domain_entitlement.py::test_the_resold_feature_set_still_rides_along"
+    ]
+  }
+]


### PR DESCRIPTION
The custom domain is what the paid per-site tier sells, and nothing checked whether the site was entitled to one.

`add_domain` resolved the site's plan already — but only to pass `cloudflare_features` to provisioning (BC-10 resale). No branch anywhere asked whether the tier granted the domain itself. The only gate on the endpoint was RBAC (`fabric.write`), which is permission, not billing.

So a base-tier site attached a custom domain and kept it. So did a paid site whose subscription was cancelled — cancellation never resets `plan_tier`. So did one that was never charged at all: with no Dodo product configured, a paid publish records its intended tier and takes no money.

Step 2 of the pricing build order in `docs/design/drafts/2026-08-13-paw-sites-pricing-spec.md` (workspace repo, qbtrix/paw-workspace#158). Same class of bug #1937 fixed for the badge, in the sibling capability.

## How it works

`resolve_site_entitlements` has answered this since #1937 and had exactly one caller, the badge stamper. This is the second, so both paid per-site capabilities resolve through the same function instead of one of them reading `plan_tier` directly. That resolver gates on the tier granting the capability **and** the subscription actually paying, which is the half a tier-only check misses.

Two positions in `add_domain`, and each one is the contract:

**After the already-connected branch returns**, so the gate is never retroactive. A site that loses its entitlement keeps its live domain, and the re-Add route repair stays reachable — that repair is the only self-service fix for a domain connected before the routing lane shipped, which silently serves the fallback origin while Cloudflare reports it active. Detaching on downgrade happens at period end and is filed as #1940.

**Before `create_custom_hostname`.** Refusing afterwards would leave a hostname on the shared zone with no `Site` row pointing at it: invisible to the product, and it makes the customer's next legitimate attach fail on a 1406 duplicate they can neither see nor clear.

## The error

New `CustomDomainNotEntitled` (402), joining `PocketLimitError` and `ConnectorLimitError` in the money-adjacent family, with a distinct code so the UI prompts a **per-site** upgrade rather than a workspace one. It is not a count limit like its siblings — there is no ceiling to report, only a capability the tier does or does not resell. Its message separates the two failures because the remedies differ: a free site upgrades its plan, a lapsed one fixes its billing and keeps the tier it already chose.

Gated on `billing_enforced`, matching every other cap here. Self-host has no billing and does not inherit a paywall from this branch.

## Verification

11 tests, 7 of them red before the fix (all "DID NOT RAISE" — the bug reproduced). 120 passing across `tests/cloud/sites/` and `tests/cloud/entitlements/`, plus `test_domain_routing.py`, `test_router.py` and `test_free_badge.py` green. `ruff check` and `ruff format` clean.

10 mutations in `tests/mutations/custom_domain_entitlement.json`, all caught — including the two that matter most for a gate like this: moving it after the Cloudflare call, and moving it before the repair branch so it becomes retroactive.

Tests read the entitled tier out of the catalog rather than hardcoding `"pro"`, so the pricing-spec rekey (`basic`/`pro`/`business` → `free`/`site`/`staff`) moves them with the catalog instead of breaking them.

Two failures in `tests/cloud/workspace/test_domains.py` are pre-existing on `dev` — confirmed by running them against the unmodified tree. They cover workspace email domains, not site domains.

## Not in this PR

Concierge enforcement — that is #1944, its sibling in step 2 of the build order. Anything *metered* (allowance, overage, conversation counting) stays blocked on open decision #5, which meter owns a concierge run.

---

## Update after review

An adversarial review pass found a real defect in the seam that feeds this gate, plus runtime probing of the whole surface. Second commit on the branch.

**A republish stripped the plan off a site that was still paying.** `site_plan_key` is an optional, client-supplied field. A republish that simply omitted it reset `plan_tier` to the base key and wrote `"none"` over `"active"`. Nothing restores either — only the `subscription.active` webhook writes `"active"`, and no path rewrites the tier.

That has been latent since BC-9 and was harmless while nothing read those fields. This PR makes `add_domain` read them, which turns it into a permanent 402 telling a paying customer to upgrade a plan they already bought. So the gate is correct and its inputs were not.

Both writes now decline to downgrade: an absent or unknown tier keeps whatever the site holds, and an `active` subscription survives a republish that opened no new checkout. An explicit key still wins in both directions — a real downgrade carries the target tier, it is not the absence of one, and a test pins that so the fix cannot overcorrect into "downgrades are impossible".

**Also checked, and clean:**

- `add_domain` is the only caller of `create_custom_hostname` in `ee/`, and the only writers of `Site.domains` are the three branches in this function. No job, sweeper, admin route, MCP tool, or import path bypasses the gate.
- 402 maps correctly through `cloud_error_handler`, and the message interpolates only catalog constants — no site id, workspace id, hostname, or exception text reaches the customer.
- `billing_enforced` defaulting to False does not make any test vacuous: `_enforce` patches the lazily-imported `get_settings`, so all 7 raising tests genuinely fail without the gate.
- The client-controlled-tier hole is closed. A caller can POST `site_plan_key: "pro"`, but that records `subscription_status` as `"none"` or `"pending"` — neither is active, so the gate refuses. Routing through `resolve_site_entitlements` rather than reading `plan_tier` is what makes a self-declared tier worthless.

Mutation plan grows 10 → 13, all caught. 123 passing across sites and entitlements.

**Adjacent, not fixed here:** a tier upgrade bought through Dodo's portal rather than a republish never updates `plan_tier` (the `plan_changed` webhook is a no-op on the Site doc), so the gate would refuse it. Pre-existing gap in the webhook, worth its own issue.
