### PR TITLE
Say what the agent is doing, not which function it called

### DIFF
--- a/docs/design/2026-08-15-claude-sdk-tool-args-recap.html
+++ b/docs/design/2026-08-15-claude-sdk-tool-args-recap.html
@@ -1,0 +1,584 @@
+<!doctype html>
+<!--
+  recap-template.html — paw-visual-recap skill (created 2026-07-03).
+  Changes: initial version. Self-contained diff-recap viewer: ALL CSS/JS inline, zero external
+  requests (no CDN, no fonts, no http(s) references). Renders entirely from window.RECAP_SPEC
+  (contract: recap-spec.schema.json). The RECAP_SPEC placeholder line in the script below is
+  replaced by string substitution — see SKILL.md. Rendered copies are GENERATED artifacts:
+  never hand-edit one; regenerate from the refs (the diff wins on conflict).
+  Sibling of paw-visual-plan/plan-template.html — same mechanism, same visual language.
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Recap</title>
+<style>
+  *{box-sizing:border-box}
+  :root{
+    --bg:#0b0e14;--panel:#11161f;--panel2:#182031;--line:#232c3d;
+    --text:#c8d3e0;--dim:#7f8b9e;--green:#5ac8a8;--amber:#d9a854;
+    --blue:#6ca8d9;--red:#d97c7c;
+    --addbg:rgba(90,200,168,.08);--delbg:rgba(217,124,124,.09);
+    --mono:ui-monospace,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;
+  }
+  html{scroll-behavior:smooth}
+  body{margin:0;background:var(--bg);color:var(--text);font:14px/1.6 var(--mono);-webkit-font-smoothing:antialiased}
+  a{color:var(--blue);text-decoration:none}
+  main,header.mast{max-width:1060px;margin:0 auto;padding:0 24px}
+  header.mast{padding-top:30px;padding-bottom:14px}
+  .kicker{font-size:11px;letter-spacing:.14em;text-transform:uppercase;color:var(--dim)}
+  header.mast h1{margin:6px 0 12px;font-size:26px;line-height:1.2;color:#e8eef5;font-weight:600}
+  .meta-row{display:flex;flex-wrap:wrap;gap:8px}
+  .chip{background:var(--panel);border:1px solid var(--line);border-radius:4px;padding:3px 10px;font-size:12px;color:var(--dim)}
+  .chip b{color:var(--green);font-weight:600;margin-right:4px}
+  .refline{color:var(--dim);font-size:13px;margin:8px 0 0}
+  .refline code{color:#dbe6f1}
+  .refline .arr{color:var(--green);margin:0 6px}
+  ul.commits{list-style:none;margin:10px 0 0;padding:0}
+  ul.commits li{padding:2px 0;font-size:13px}
+  ul.commits .sha{color:var(--amber);margin-right:10px}
+  nav{position:sticky;top:0;z-index:10;background:rgba(11,14,20,.92);backdrop-filter:blur(6px);border-top:1px solid var(--line);border-bottom:1px solid var(--line)}
+  nav .inner{max-width:1060px;margin:0 auto;padding:7px 20px;display:flex;flex-wrap:wrap;gap:2px}
+  nav a{padding:4px 10px;border-radius:4px;color:var(--dim);font-size:11px;letter-spacing:.06em;text-transform:uppercase}
+  nav a:hover{color:var(--text);background:var(--panel2)}
+  main{padding-bottom:90px}
+  section{margin-top:46px;scroll-margin-top:56px}
+  h2{margin:0 0 14px;font-size:13px;text-transform:uppercase;letter-spacing:.14em;color:var(--dim);border-bottom:1px solid var(--line);padding-bottom:8px;font-weight:600}
+  h2 .hash{color:var(--green);margin-right:7px}
+  .prose p{margin:9px 0;max-width:76ch}
+  .prose ul{margin:8px 0;padding-left:22px}
+  .prose li{margin:3px 0}
+  code{background:var(--panel2);border:1px solid var(--line);padding:1px 5px;border-radius:3px;font-size:.92em;color:#dbe6f1}
+  .tag{display:inline-block;font-size:10px;letter-spacing:.1em;text-transform:uppercase;border-radius:3px;padding:1px 7px;border:1px solid;vertical-align:middle}
+  .tag.warn{color:var(--amber);border-color:var(--amber)}
+  /* stats */
+  .stat-row{display:flex;flex-wrap:wrap;gap:14px}
+  .stat{background:var(--panel);border:1px solid var(--line);border-radius:6px;padding:14px 22px;min-width:130px}
+  .stat .n{font-size:26px;font-weight:600;color:#e8eef5;display:block}
+  .stat .n.plus{color:var(--green)}
+  .stat .n.minus{color:var(--red)}
+  .stat .k{font-size:11px;text-transform:uppercase;letter-spacing:.1em;color:var(--dim)}
+  .bar{margin-top:14px;height:8px;border-radius:4px;overflow:hidden;display:flex;background:var(--panel2);border:1px solid var(--line);max-width:420px}
+  .bar .add{background:var(--green)}
+  .bar .del{background:var(--red)}
+  /* key changes accordion */
+  details.kc{border:1px solid var(--line);border-radius:6px;background:var(--panel);margin:0 0 12px}
+  details.kc summary{cursor:pointer;padding:10px 14px;display:flex;flex-wrap:wrap;align-items:baseline;gap:10px}
+  details.kc summary::marker{color:var(--green)}
+  details.kc[open] summary{border-bottom:1px solid var(--line)}
+  .kc-path{color:#e8eef5;font-weight:600;font-size:13px;word-break:break-all}
+  .kc-note{color:var(--dim);font-size:13px;flex:1 1 100%;margin-left:22px}
+  .hunk{margin:12px 14px;border:1px solid var(--line);border-radius:4px;overflow-x:auto}
+  .hunk-h{background:var(--panel2);color:var(--blue);padding:4px 12px;font-size:12px;border-bottom:1px solid var(--line);white-space:pre}
+  .hunk pre{margin:0;padding:6px 0;font:12px/1.5 var(--mono)}
+  .dl{display:block;padding:0 12px;white-space:pre}
+  .dl.add{color:var(--green);background:var(--addbg)}
+  .dl.del{color:var(--red);background:var(--delbg)}
+  .dl.ctx{color:var(--dim)}
+  .dl .m{display:inline-block;width:1.2em;user-select:none;opacity:.8}
+  /* file tree */
+  .dirgrp{margin:0 0 18px}
+  .dirname{color:var(--blue);font-size:12px;letter-spacing:.04em;padding:4px 0;border-bottom:1px dashed var(--line)}
+  table.ft{width:100%;border-collapse:collapse;font-size:13px}
+  table.ft td{padding:6px 10px;border-bottom:1px solid var(--line);vertical-align:baseline}
+  table.ft td.f{width:60%}
+  table.ft td.n{text-align:right;white-space:nowrap}
+  .plus{color:var(--green)}
+  .minus{color:var(--red)}
+  .fflag{font-size:10px;letter-spacing:.1em;text-transform:uppercase;border-radius:3px;padding:1px 7px;border:1px solid}
+  .fflag.new{color:var(--green);border-color:var(--green)}
+  .fflag.modified{color:var(--amber);border-color:var(--amber)}
+  .fflag.deleted{color:var(--red);border-color:var(--red)}
+  .fflag.renamed{color:var(--blue);border-color:var(--blue)}
+  .keymark{color:var(--green);font-size:11px;margin-left:8px}
+  /* api deltas */
+  .delta{background:var(--panel);border:1px solid var(--line);border-radius:6px;padding:12px 16px;margin:0 0 12px}
+  .delta .kind{font-size:10px;letter-spacing:.1em;text-transform:uppercase;color:var(--amber);border:1px solid var(--amber);border-radius:3px;padding:1px 7px}
+  .delta .pair{margin-top:8px;overflow-x:auto}
+  .delta .b,.delta .a{display:block;padding:3px 10px;white-space:pre-wrap;border-radius:3px;font-size:13px}
+  .delta .b{color:var(--red);background:var(--delbg)}
+  .delta .a{color:var(--green);background:var(--addbg);margin-top:3px}
+  .delta .note{margin-top:8px;color:var(--dim);font-size:13px}
+  ul.inf{list-style:none;margin:0;padding:0}
+  ul.inf li{padding:8px 0;border-bottom:1px dashed var(--line);max-width:80ch}
+  ul.inf .tag{margin-right:10px}
+  footer{max-width:1060px;margin:60px auto 0;padding:14px 24px;border-top:1px solid var(--line);color:var(--dim);font-size:11px}
+  @media print{
+    :root{--bg:#fff;--panel:#fff;--panel2:#f2f2f2;--line:#bbb;--text:#111;--dim:#555;--green:#0a7a5c;--amber:#8a6414;--blue:#1c5f96;--red:#a33;--addbg:#eaf6f1;--delbg:#faeceb}
+    nav{display:none}
+    body{font-size:12px}
+    details.kc,.delta,.dirgrp{break-inside:avoid}
+    section{margin-top:26px}
+  }
+</style>
+</head>
+<body>
+<header class="mast" id="mast"></header>
+<nav><div class="inner" id="navlinks"></div></nav>
+<main id="main"></main>
+<footer>generated by paw-visual-recap — the refs are the source of truth; regenerate, don't hand-edit.</footer>
+<script>
+window.RECAP_SPEC = {
+  "meta": {
+    "title": "Default backend's tool arguments (PR #1943)",
+    "date": "2026-08-15",
+    "base": "origin/dev",
+    "head": "origin/feat/claude-sdk-tool-args",
+    "commits": [
+      {
+        "sha": "6e17f792",
+        "subject": "fix(agents): a tool with no arguments reported the metadata dict as its arguments"
+      },
+      {
+        "sha": "121be545",
+        "subject": "docs(agents): write the input_pending contract where consumers will find it"
+      },
+      {
+        "sha": "3782c36f",
+        "subject": "fix(agents): one pending tool call per call, not per event"
+      },
+      {
+        "sha": "901a8e54",
+        "subject": "fix(agents): claude_sdk announced every tool call with empty arguments"
+      }
+    ]
+  },
+  "narrative": "`claude_agent_sdk` is the default backend. On a streamed turn every tool call reached consumers with `input={}`.\n\nThe arguments were never lost in transit. The SDK assembles them and delivers them on the completed `AssistantMessage`; they died two lines later at a name guard, because the streaming branch had already announced that tool. On a streamed turn that is every tool, so the only emission carrying real arguments was always the one discarded. No `input_json_delta` reassembly was needed \u2014 the original plan called for it, and that was wrong.\n\n**Review the two-event contract.** Both emissions now go out, distinguished by an additive `input_pending`. That broke correlation in `loop.py`, which appended one pending entry per event \u2014 caught before the PR and fixed here. Skipping the provisional event matters because both consumers of that `tool_start` *append* rather than replace, so a provisional row was permanent junk, not a placeholder.\n\nTwo existing tests asserted the old suppression and were rewritten rather than deleted. **That is the part most worth a second pair of eyes** \u2014 an assertion being rewritten by the change it was guarding.",
+  "stats": {
+    "files": 6,
+    "adds": 854,
+    "dels": 22
+  },
+  "fileTree": [
+    {
+      "path": "src/pocketpaw/agents/claude_sdk.py",
+      "adds": 52,
+      "dels": 14,
+      "flag": "modified"
+    },
+    {
+      "path": "src/pocketpaw/agents/loop.py",
+      "adds": 42,
+      "dels": 2,
+      "flag": "modified"
+    },
+    {
+      "path": "src/pocketpaw/agents/protocol.py",
+      "adds": 39,
+      "dels": 1,
+      "flag": "modified"
+    },
+    {
+      "path": "tests/test_agent_loop_tool_correlation.py",
+      "adds": 353,
+      "dels": 0,
+      "flag": "new"
+    },
+    {
+      "path": "tests/test_claude_sdk_tool_args.py",
+      "adds": 338,
+      "dels": 0,
+      "flag": "new"
+    },
+    {
+      "path": "tests/test_stream_event.py",
+      "adds": 30,
+      "dels": 5,
+      "flag": "modified"
+    }
+  ],
+  "keyChanges": [
+    {
+      "path": "src/pocketpaw/agents/claude_sdk.py",
+      "annotation": "The whole bug, deleted: `_announced_tools` was suppressing the only emission that ever held real arguments. The set is gone because this guard was its only reader.",
+      "hunks": [
+        {
+          "header": "@@ -3110,7 +3125,6 @@ class ClaudeSDKBackend(BaseAgentBackend):",
+          "lines": [
+            {
+              "t": "ctx",
+              "s": "            # State tracking for StreamEvent deduplication"
+            },
+            {
+              "t": "ctx",
+              "s": "            _streamed_via_events = False"
+            },
+            {
+              "t": "del",
+              "s": "            _announced_tools: set[str] = set()"
+            },
+            {
+              "t": "ctx",
+              "s": "            _event_count = 0"
+            },
+            {
+              "t": "ctx",
+              "s": "            _saw_result = False  # Track if ResultMessage was consumed"
+            }
+          ]
+        },
+        {
+          "header": "@@ -3153,11 +3167,23 @@",
+          "lines": [
+            {
+              "t": "ctx",
+              "s": "                            if cb.get(\"type\") == \"tool_use\":"
+            },
+            {
+              "t": "ctx",
+              "s": "                                tool_name = cb.get(\"name\", \"unknown\")"
+            },
+            {
+              "t": "del",
+              "s": "                                _announced_tools.add(tool_name)"
+            },
+            {
+              "t": "add",
+              "s": "                                # PROVISIONAL announcement. ``content_block_start``"
+            },
+            {
+              "t": "add",
+              "s": "                                # opens the block before a single argument fragment"
+            },
+            {
+              "t": "add",
+              "s": "                                # has streamed, so the name is known here and the"
+            },
+            {
+              "t": "add",
+              "s": "                                # input is not."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "src/pocketpaw/agents/loop.py",
+      "annotation": "The correlation fix. One compound condition; `is not True` fails open so a backend setting something unexpected is still correlated rather than silently dropped.",
+      "hunks": [
+        {
+          "header": "@@ -1444,9 +1455,38 @@ class AgentLoop:",
+          "lines": [
+            {
+              "t": "del",
+              "s": "                    elif etype == \"tool_use\":"
+            },
+            {
+              "t": "add",
+              "s": "                    # ``input_pending`` marks a PROVISIONAL announcement: the"
+            },
+            {
+              "t": "add",
+              "s": "                    # backend knows the tool's name but its arguments are still"
+            },
+            {
+              "t": "add",
+              "s": "                    # streaming. Only the resolved event may be correlated here \u2014"
+            },
+            {
+              "t": "add",
+              "s": "                    # this branch appends one pending entry per event, so honouring"
+            },
+            {
+              "t": "add",
+              "s": "                    # both would leak an entry per call and corrupt every later"
+            },
+            {
+              "t": "add",
+              "s": "                    # ``tool_call_id`` via the ``pop(0)`` fallback below."
+            },
+            {
+              "t": "add",
+              "s": "                    elif etype == \"tool_use\" and meta.get(\"input_pending\") is not True:"
+            }
+          ]
+        },
+        {
+          "header": "@@ -1475,7 +1475,18 @@",
+          "lines": [
+            {
+              "t": "ctx",
+              "s": "                        tool_name = meta.get(\"name\") or meta.get(\"tool\", \"unknown\")"
+            },
+            {
+              "t": "del",
+              "s": "                        tool_input = meta.get(\"input\") or meta"
+            },
+            {
+              "t": "add",
+              "s": "                        # A tool called with NO arguments reports ``input={}``,"
+            },
+            {
+              "t": "add",
+              "s": "                        # which is falsy \u2014 an ``or meta`` fallback here published"
+            },
+            {
+              "t": "add",
+              "s": "                        # the whole metadata dict as the call's parameters."
+            },
+            {
+              "t": "add",
+              "s": "                        tool_input = meta.get(\"input\")"
+            },
+            {
+              "t": "add",
+              "s": "                        if not isinstance(tool_input, dict):"
+            },
+            {
+              "t": "add",
+              "s": "                            tool_input = {}"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "src/pocketpaw/agents/protocol.py",
+      "annotation": "The contract, written where a consumer will actually find it. The last paragraph is the rule that would have prevented the correlation bug.",
+      "hunks": [
+        {
+          "header": "@@ (AgentEvent docstring)",
+          "lines": [
+            {
+              "t": "add",
+              "s": "    The ``input_pending`` contract \u2014 ONE tool call may produce MORE THAN ONE"
+            },
+            {
+              "t": "add",
+              "s": "    ``tool_use`` event:"
+            },
+            {
+              "t": "add",
+              "s": ""
+            },
+            {
+              "t": "add",
+              "s": "        - ``input_pending=True`` marks a PROVISIONAL announcement."
+            },
+            {
+              "t": "add",
+              "s": "        - ``input_pending=False`` \u2014 or the key being ABSENT \u2014 marks a RESOLVED"
+            },
+            {
+              "t": "add",
+              "s": "          event: ``input`` is final."
+            },
+            {
+              "t": "add",
+              "s": ""
+            },
+            {
+              "t": "add",
+              "s": "    Consumer rule: if you APPEND per event \u2014 a log, an activity feed, a pending"
+            },
+            {
+              "t": "add",
+              "s": "    list keyed per call \u2014 you MUST skip events with ``input_pending is True``, or"
+            },
+            {
+              "t": "add",
+              "s": "    you will record a phantom call carrying no arguments."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "tests/test_stream_event.py",
+      "annotation": "The judgment call worth checking: an existing assertion rewritten by the change it guarded. The replacement pins count, ordering and both payload shapes where the original pinned only a count.",
+      "hunks": [
+        {
+          "header": "@@ -200,7 +220,12 @@",
+          "lines": [
+            {
+              "t": "ctx",
+              "s": "        tool_events = [e for e in events if e.type == \"tool_use\"]"
+            },
+            {
+              "t": "del",
+              "s": "        assert len(tool_events) == 1"
+            },
+            {
+              "t": "add",
+              "s": "        assert len(tool_events) == 2"
+            },
+            {
+              "t": "add",
+              "s": "        provisional, resolved = tool_events"
+            },
+            {
+              "t": "add",
+              "s": "        assert provisional.metadata[\"input_pending\"] is True"
+            },
+            {
+              "t": "add",
+              "s": "        assert provisional.metadata[\"input\"] == {}"
+            },
+            {
+              "t": "add",
+              "s": "        assert resolved.metadata[\"input_pending\"] is False"
+            },
+            {
+              "t": "add",
+              "s": "        assert resolved.metadata[\"input\"] == {\"file\": \"foo.py\"}"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "apiDeltas": [
+    {
+      "kind": "schema",
+      "before": "AgentEvent(type=\"tool_use\").metadata -> {name, input}",
+      "after": "AgentEvent(type=\"tool_use\").metadata -> {name, input, input_pending?}",
+      "note": "Additive. Absent means resolved, so deep_agents' single deduped event and claude_sdk's pair are both correct under one rule."
+    },
+    {
+      "kind": "schema",
+      "before": "streamed tool call -> 1 tool_use event, input always {}",
+      "after": "streamed tool call -> 2 tool_use events: provisional {} then resolved real args",
+      "note": "Non-streaming path is unchanged at exactly one event per call."
+    }
+  ],
+  "inferred": [
+    "The claim that no backend carries arguments outside `input` comes from reading all eight backends; opencode omits the key entirely and has no arguments to give.",
+    "The 71-failure full-suite baseline was shown unchanged by reverting the touched files and re-running, so it is attributed to the environment (a missing herdr binary) rather than measured per-cause."
+  ]
+};
+(function(){
+"use strict";
+var S = window.RECAP_SPEC;
+var main = document.getElementById("main");
+if (!S) {
+  main.innerHTML = "<p style='padding:40px 0'>window.RECAP_SPEC is empty — this file was not generated. Run the substitution in the paw-visual-recap SKILL.md.</p>";
+  return;
+}
+function esc(s){return String(s).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;");}
+function inline(t){
+  t = esc(t);
+  t = t.replace(/`([^`]+)`/g,"<code>$1</code>");
+  t = t.replace(/\*\*([^*]+)\*\*/g,"<strong>$1</strong>");
+  t = t.replace(/\*([^*]+)\*/g,"<em>$1</em>");
+  return t;
+}
+function md(s){ /* md-lite: paragraphs, "- " lists, **bold**, *em*, `code` */
+  return String(s).trim().split(/\n\s*\n/).map(function(b){
+    var lines = b.split("\n");
+    var isList = lines.length > 0 && lines.every(function(l){return /^\s*-\s+/.test(l);});
+    if (isList) return "<ul>" + lines.map(function(l){return "<li>"+inline(l.replace(/^\s*-\s+/,""))+"</li>";}).join("") + "</ul>";
+    return "<p>" + inline(b) + "</p>";
+  }).join("");
+}
+function chip(k,v){return '<span class="chip"><b>'+esc(k)+'</b>'+esc(v)+'</span>';}
+
+/* masthead */
+var meta = S.meta || {};
+document.title = (meta.title || "Recap") + " — recap";
+var mast = '<div class="kicker">paw-visual-recap &middot; generated &mdash; regenerate, don\'t hand-edit</div>'
+  + '<h1>'+esc(meta.title || "Untitled recap")+'</h1>'
+  + '<div class="refline"><code>'+esc(meta.base||"?")+'</code><span class="arr">&rarr;</span><code>'+esc(meta.head||"?")+'</code></div>'
+  + '<div class="meta-row" style="margin-top:10px">'
+  + (meta.date ? chip("date", meta.date) : "")
+  + ((meta.commits||[]).length ? chip("commits", String(meta.commits.length)) : "")
+  + (S.stats ? chip("files", String(S.stats.files)) : "")
+  + '</div>'
+  + (meta.prUrl ? '<div class="refline">PR: <a href="'+esc(meta.prUrl)+'">'+esc(meta.prUrl)+'</a></div>' : "");
+if ((meta.commits || []).length) {
+  mast += '<ul class="commits">' + meta.commits.map(function(c){
+    return '<li><span class="sha">'+esc(c.sha)+'</span>'+esc(c.subject)+'</li>';
+  }).join("") + '</ul>';
+}
+document.getElementById("mast").innerHTML = mast;
+
+/* sections — only pushed when the spec has data, so empty blocks disappear */
+var sections = [];
+function section(id, label, html){ sections.push({id:id, label:label, html:html}); }
+
+if (S.narrative) section("narrative", "Narrative", '<div class="prose">'+md(S.narrative)+'</div>');
+
+if (S.stats) {
+  var st = S.stats, tot = (st.adds + st.dels) || 1;
+  section("stats", "Stats",
+    '<div class="stat-row">'
+    + '<div class="stat"><span class="n">'+st.files+'</span><span class="k">files</span></div>'
+    + '<div class="stat"><span class="n plus">+'+st.adds+'</span><span class="k">insertions</span></div>'
+    + '<div class="stat"><span class="n minus">&minus;'+st.dels+'</span><span class="k">deletions</span></div>'
+    + '</div>'
+    + '<div class="bar" title="+'+st.adds+' / -'+st.dels+'">'
+    + '<div class="add" style="width:'+Math.round(100*st.adds/tot)+'%"></div>'
+    + '<div class="del" style="flex:1"></div>'
+    + '</div>');
+}
+
+var keyPaths = {};
+if ((S.keyChanges || []).length) {
+  var kcs = S.keyChanges.map(function(k, i){
+    keyPaths[k.path] = true;
+    var hunks = (k.hunks || []).map(function(h){
+      var body = (h.lines || []).map(function(l){
+        var m = l.t === "add" ? "+" : (l.t === "del" ? "-" : " ");
+        return '<span class="dl '+esc(l.t)+'"><span class="m">'+m+'</span>'+esc(l.s)+'</span>';
+      }).join("");
+      return '<div class="hunk"><div class="hunk-h">'+esc(h.header)+'</div><pre>'+body+'</pre></div>';
+    }).join("");
+    return '<details class="kc"'+(i===0?' open':'')+'>'
+      + '<summary><span class="kc-path">'+esc(k.path)+'</span>'
+      + '<span class="kc-note">'+inline(k.annotation||"")+'</span></summary>'
+      + hunks + '</details>';
+  }).join("");
+  section("keychanges", "Key changes", kcs);
+}
+
+if ((S.fileTree || []).length) {
+  var groups = {}, order = [];
+  S.fileTree.forEach(function(f){
+    var i = f.path.lastIndexOf("/");
+    var dir = i < 0 ? "." : f.path.slice(0, i);
+    if (!groups[dir]) { groups[dir] = []; order.push(dir); }
+    groups[dir].push(f);
+  });
+  var ft = order.map(function(dir){
+    var rows = groups[dir].map(function(f){
+      var base = f.path.slice(dir === "." ? 0 : dir.length + 1);
+      return '<tr><td class="f"><code>'+esc(base)+'</code>'
+        + (keyPaths[f.path] ? '<span class="keymark" title="annotated in key changes">&#9670; key</span>' : '')
+        + '</td>'
+        + '<td class="n"><span class="plus">+'+f.adds+'</span> <span class="minus">&minus;'+f.dels+'</span></td>'
+        + '<td><span class="fflag '+esc(f.flag)+'">'+esc(f.flag)+'</span></td></tr>';
+    }).join("");
+    return '<div class="dirgrp"><div class="dirname">'+esc(dir)+'/</div><table class="ft"><tbody>'+rows+'</tbody></table></div>';
+  }).join("");
+  section("files", "Files", ft);
+}
+
+if ((S.apiDeltas || []).length) {
+  section("apideltas", "API deltas", S.apiDeltas.map(function(d){
+    return '<div class="delta"><span class="kind">'+esc(d.kind)+'</span>'
+      + '<div class="pair"><span class="b">- '+esc(d.before)+'</span><span class="a">+ '+esc(d.after)+'</span></div>'
+      + (d.note ? '<div class="note">'+inline(d.note)+'</div>' : '')
+      + '</div>';
+  }).join(""));
+}
+
+if ((S.inferred || []).length)
+  section("inferred", "Inferred", '<ul class="inf">'+S.inferred.map(function(x){
+    return '<li><span class="tag warn">inferred</span>'+inline(x)+'</li>';
+  }).join("")+'</ul>');
+
+main.innerHTML = sections.map(function(s){
+  return '<section id="'+s.id+'"><h2><span class="hash">#</span>'+s.label+'</h2>'+s.html+'</section>';
+}).join("");
+document.getElementById("navlinks").innerHTML = sections.map(function(s){
+  return '<a href="#'+s.id+'">'+s.label+'</a>';
+}).join("");
+
+/* print-friendly: expand all collapsed key changes before printing */
+window.addEventListener("beforeprint", function(){
+  document.querySelectorAll("details").forEach(function(d){ d.open = true; });
+});
+})();
+</script>
+</body>
+</html>

--- a/docs/design/2026-08-15-humanized-tool-narration-prd.md
+++ b/docs/design/2026-08-15-humanized-tool-narration-prd.md
@@ -154,8 +154,52 @@ drop point. It is two:
 |---|---|---|
 | Backend, claude_agent_sdk **streaming** path | `src/pocketpaw/agents/claude_sdk.py:3154-3161` | on `content_block_start`, emits `metadata={"name": …, "input": {}}` — hardcoded empty — and adds the name to `_announced_tools`. |
 | Backend, claude_agent_sdk **block** path | `src/pocketpaw/agents/claude_sdk.py:3242-3253` | the completed `AssistantMessage` carries **fully-assembled real arguments** (`_extract_tool_info` reads `block.input` off the SDK's `ToolUseBlock`, `:1156-1162`) — but the guard `if tool["name"] not in _announced_tools` at `:3243` **suppresses the emission**, because the streaming path already announced that name. |
-| Backend, pydantic-ai | `src/pocketpaw/agents/pydantic_ai.py:2156` | emits `"input": args` — args present. |
+| Backend, pydantic-ai | `src/pocketpaw/agents/pydantic_ai.py:2156` | emits `"input": args` — **but see the correction below; in practice the args-bearing emission is usually suppressed.** |
 | Bridge (all backends) | `ee/.../cloud/shared/agent_bridge.py:582` | reads only the tool name; discards `metadata["input"]` entirely. |
+
+> **Correction 2026-08-15 (b) — pydantic-ai has the SAME bug, and this PRD said it did not.**
+> `_announce_tool` (`pydantic_ai.py:2142-2158`) dedupes on `tool_call_id`, and `_map_event` calls
+> it twice for one call: first from `PartStartEvent(ToolCallPart)` with `args={}` as an early UI
+> signal (`:2110`), then from `FunctionToolCallEvent` with the authoritative args (`:2120`). The
+> comment at `:1965` states the suppression as the intent. Measured:
+>
+> | `tool_call_id` | events emitted | real args reach a consumer |
+> |---|---|---|
+> | present (the normal case) | 1 | **no** — `input={}` |
+> | absent | 2 | yes |
+>
+> So on pydantic-ai, narration renders `bare` ("Searching the web") and never the interpolated
+> `active` phrase. **The interpolation this whole feature exists for does not happen in production
+> on either major backend** until HTN-4's `input_pending` contract is mirrored here. HTN-1's
+> demonstration of "Searching the web for quarterly filings" holds in its tests, which construct
+> the event directly, and not in a live streamed run.
+
+### Decision 7: provider-side (native) web tools emit no tool event at all
+
+**Discovered 2026-08-15 while answering "what if web search comes from LiteLLM?"**
+
+`pydantic_ai_native_web_tools` (`config.py:714`, default `False`) moves web search and page fetch
+provider-side, registering `WebSearch(local=<our WebSearchTool>)` so the model's own native search
+runs at the provider instead of inside the agent process (`pydantic_ai.py:1592-1626`). Routing
+search through LiteLLM/the provider means turning this on.
+
+pydantic-ai 2.18 represents a provider-executed call as **`NativeToolCallPart`** /
+**`NativeToolReturnPart`**. Measured: these are *siblings* of `ToolCallPart` under
+`BaseToolCallPart`, **not subclasses** (`issubclass(NativeToolCallPart, ToolCallPart)` is `False`).
+`_map_event` tests `isinstance(part, ToolCallPart)` at `:2107` and imports neither native type.
+
+**Consequence:** with native web tools on, a web search produces **no `tool_use` event and no
+`tool_result` event whatsoever**. Not a wrong phrase — nothing. The UI stays on "Thinking…" for the
+entire search, which is the single operation a user most wants narrated. The `web_search`
+annotation and `_ANNOTATED_TOOLS` are irrelevant on that path because no event ever reaches the
+bridge.
+
+**What:** map the native parts in `_map_event` and give them the same `input_pending` treatment.
+Tracked as HTN-9 and HTN-10 in the tasks doc.
+
+**Tradeoff accepted:** this widens the feature past "annotate our own tools". It is not optional
+work — a narration feature that goes silent exactly when the agent reaches the internet is worse
+than the raw tool name it replaced.
 
 > **Corrected 2026-08-15 by the HTN-0 spike.** This decision originally stated that the streaming
 > path discards incrementally-streamed input and that the fix required accumulating

--- a/docs/design/2026-08-15-humanized-tool-narration-prd.md
+++ b/docs/design/2026-08-15-humanized-tool-narration-prd.md
@@ -1,0 +1,232 @@
+<!-- PRD — humanized tool narration + normalized agent plan surface.
+     Created 2026-08-15. Stage ② (to-prd). Next: /to-issues. Status: Draft.
+     Supersedes nothing. Source design: 2026-08-15-humanized-tool-narration.md
+     Both stage-① open questions were resolved from source before writing; see Approach D5/D6. -->
+
+# Humanized tool narration + a normalized agent plan surface
+
+**Source:** brainstorm 2026-08-15 → `docs/design/2026-08-15-humanized-tool-narration.md`
+**Status:** Draft · **Priority:** High · **Size:** L
+**Repos:** pocketpaw (primary), paw-enterprise (render side)
+**Branch:** `feat/humanized-tool-narration` · **Worktree:** `D:/paw-worktrees/humanized-tools`
+
+## Goal
+
+Every surface that shows agent activity says what the agent is actually doing, in words a
+non-developer reads without translation — "Searching the web for *quarterly filings*",
+"Publishing the site", "Inviting *sam@acme.com* to the workspace" — instead of
+`using pocketpaw_sites_publish`. At the same time the agent's ordered plan becomes a live,
+pinned UI component that mutates in place as steps complete, rather than being invisible.
+
+Both are delivered by one server-side layer, so chat, Mission Control's ticker, and every
+channel adapter (Telegram, Discord, Slack, WhatsApp, CLI) inherit it without per-surface work.
+
+## Why now
+
+Users currently read raw snake_case tool identifiers in production chat. The only humanization
+that exists — a 9-entry map at `paw-enterprise/src/lib/core/chat/store.svelte.ts:709` — was
+written for Claude Agent SDK tool names and has been silently wrong for every PocketPaw-native
+tool since a second backend landed. The tool surface is now 48 builtin modules plus ~49 bridged
+MCP tools plus the connector surface, so the gap widens with every release. Separately, the
+pydantic-ai backend already maintains a real ordered plan via the harness `Planning` capability
+and throws all of it away at the UI boundary.
+
+## Non-goals
+
+- **i18n and per-surface phrasing.** The `Narration` object is structured from day one so these
+  are additive later, but nothing is built now.
+- **Pocket-level narration overrides.** Plausible; not v1.
+- **The planner MCP's `todos[]` build brief** (`ee/.../mcp_servers/planner.py:528`). Different
+  lifecycle — a build brief walked by pocket_specialist, not a live agent checklist.
+- **Plan persistence or historical replay.** Plans stay per-run and in-memory, as `PlanState` is.
+- **Restructuring Mission Control or the Instinct decision feed.** This feeds them; it does not
+  redesign them.
+- **Retrofitting narration onto MCP tools' upstream definitions.** External tools are covered by
+  the override registry and the derive-from-name fallback, not by changing their sources.
+
+## Global Constraints
+
+These bind every build chunk and flow verbatim into the stage-③ tasks doc. No task re-litigates them.
+
+1. **Target branch:** all pocketpaw work branches from and targets `dev`. paw-enterprise work
+   targets its own default branch. Never push to `main`.
+2. **Worktree isolation is mandatory.** Any agent running `git checkout -b`, committing, or
+   pushing gets its own worktree. pocketpaw and paw-enterprise are separate repos and get
+   separate worktrees.
+3. **Never merge on green.** Open the PR, report the URL, stop. The captain merges.
+4. **Argument interpolation is a security boundary.** No tool argument is ever rendered into
+   narration unless it is named in that tool's `safe_args` allowlist. This is enforced by test,
+   not by review. Any chunk touching narration rendering is security-relevant.
+5. **Backward compatibility on the wire.** The existing `tool` field in `AgentToolUse.data` stays
+   populated. All new fields are additive so an older client keeps working.
+6. **`topics.gen.ts` is generated.** Never hand-edit; regenerate via
+   `uv run python backend/scripts/gen_topics.py`.
+7. **Glossary bindings:** Pocket = workspace container; Connector = workspace-scoped integration;
+   Ripple = generative UI layer; Instinct = decision pipeline. No LLM-default readings.
+8. **Docs in the same PR** as the behavior they describe.
+9. **`/humanize` every PR title and body** before opening.
+
+## Approach
+
+### Decision 1: narration is authored on the tool, not in a central map
+
+**What:** an optional `Narration` object on `BaseTool`, alongside `trust_level`:
+
+```python
+@dataclass(frozen=True)
+class Narration:
+    active: str                        # "Searching the web for {query}"
+    bare: str                          # "Searching the web"  (args missing/redacted)
+    safe_args: tuple[str, ...] = ()    # allowlist — ONLY these may interpolate
+```
+
+**Why:** which of a tool's arguments are safe to display is knowledge only the tool has, and it is
+a security property of the same class as `trust_level`. `shell`, `pip_install`, and the connector
+tools all accept arguments that can carry credentials, tokens, or PII; rendering them publishes a
+secret to every channel adapter. Once the allowlist must live on the tool, splitting the template
+into a second file buys nothing. Supporting evidence: the central-map design has already been
+tried here and already rotted — `store.svelte.ts:709` is that design, incomplete and silently so,
+because nothing fails when an entry is missing.
+
+**Tradeoff accepted:** touching ~48 modules instead of one file, and losing the ability to read
+the entire product voice in a single file. Decision 3 recovers the review ergonomics.
+
+### Decision 2: a deterministic derive-from-name fallback, so partial rollout still wins
+
+**What:** when a tool declares no narration, fall back in order — (1) override registry for MCP and
+connector tools, (2) derive from the name via a small verb lexicon (`publish`→Publishing,
+`create`→Creating, `search`→Searching, `invite`→Inviting), so `pocketpaw_sites_publish` reads
+"Publishing the site", (3) `using <name>` as last resort.
+
+**Why:** it makes the rollout monotonic. Narration improves before all ~100 tools are annotated, so
+a half-finished migration is a net gain rather than a stranded refactor. This is the specific
+mitigation for the "cross-cutting change goes stale at 60%" failure mode.
+
+**Tradeoff accepted:** derived phrasing is blander than hand-written and occasionally awkward for
+tools whose names do not start with a verb. Acceptable because it is strictly better than the
+status quo and is superseded per-tool as annotations land.
+
+### Decision 3: templates are seeded by a one-time model-drafted pass, reviewed as one diff
+
+**What:** a model drafts `Narration` for all builtin tools in a single pass; a human reviews the
+whole set as one diff and edits for voice before commit.
+
+**Why:** recovers the one real advantage of a central file — reading and unifying the product voice
+in a single sitting — without keeping the central file. No generated line ships unread.
+
+**Tradeoff accepted:** one large review diff. Bounded, and it happens once.
+
+### Decision 4: one normalized plan event, whole-list replacement
+
+**What:** a new `agent.plan_updated` realtime event carrying the full ordered list, with a status
+superset of `pending | in_progress | completed | cancelled`, a per-run monotonic `seq`, and a
+`progress` rollup. One normalizer per source: `write_plan` (pydantic-ai), `write_todos`
+(deep_agents), `TodoWrite` (claude_agent_sdk).
+
+**Why:** three backends emit three incompatible schemas for the same concept, and the default
+backend is not the one being developed against. Normalizing at the bridge means the frontend binds
+to one stable shape and never learns backend names. Whole-list replacement is inherited from
+`write_plan`'s own semantics, which eliminates diffing and partial-update ordering bugs; `seq`
+prevents a stale list from overwriting a fresh one if delivery reorders.
+
+**Tradeoff accepted:** larger payloads than a delta protocol, and a normalizer to maintain per
+backend. Both are cheap next to the class of bugs deltas would introduce.
+
+### Decision 5: narration attaches to `agent.tool_use` — `agent.tool_start` is dead
+
+**Resolved from source, 2026-08-15** (stage-① open question 2). `AgentToolStart` is defined at
+`ee/.../_core/realtime/events.py:352`, is subscribed in `audience.py:194` and accepted by
+`activity/buffer.py:180`, and is **emitted nowhere in the codebase**. The buffer docstring at
+`buffer.py:174` claiming the bus emits it is inaccurate.
+
+**What:** attach narration to `agent.tool_use` only. Leave `AgentToolStart` untouched; do not
+build on it and do not delete it in this work.
+
+**Tradeoff accepted:** a known-dead event stays in the registry. Removing it is unrelated cleanup
+and would widen this PR's blast radius.
+
+### Decision 6: the argument drop happens at TWO layers, and both must be fixed
+
+**Resolved from source, 2026-08-15** (stage-① open question 1). The stage-① design assumed a single
+drop point. It is two:
+
+| Layer | Location | Behavior |
+|---|---|---|
+| Backend, claude_agent_sdk **streaming** path | `src/pocketpaw/agents/claude_sdk.py:3160` | emits `metadata={"name": …, "input": {}}` — **hardcoded empty**. `input_json_delta` is handled nowhere in the file, so incrementally-streamed tool input is discarded at `content_block_start`. |
+| Backend, claude_agent_sdk **block** path | `src/pocketpaw/agents/claude_sdk.py:3251` | emits `"input": tool["input"]` — args present. |
+| Backend, pydantic-ai | `src/pocketpaw/agents/pydantic_ai.py:2156` | emits `"input": args` — args present. |
+| Bridge (all backends) | `ee/.../cloud/shared/agent_bridge.py:582` | reads only the tool name; discards `metadata["input"]` entirely. |
+
+**What:** fix the bridge for all backends (chunk 1) *and* accumulate `input_json_delta` fragments in
+the claude_agent_sdk streaming path, emitting on `content_block_stop` (chunk 5).
+
+**Why this matters more than it looks:** `TodoWrite` on the default backend's streaming path
+currently carries no arguments at all. Without chunk 5, the plan panel renders perfectly against
+pydantic-ai in development and is **blank in production for default-config users**. Chunk 5 is not
+optional polish; it is what makes the feature real for most of the install base.
+
+**Tradeoff accepted:** chunk 5 touches streaming assembly in a 3000-line backend module, the
+riskiest edit in this PRD. It is isolated behind its own chunk and its own tests for that reason.
+
+## Open questions
+
+- [ ] **Does the realtime layer guarantee per-run event ordering?** If yes, `seq` is
+  belt-and-braces; if no, it is load-bearing. Needs a read of the realtime delivery path —
+  research spike, before chunk 6.
+- [ ] **Who owns the product voice for ~100 narration templates?** The seeded pass produces the
+  diff; the reviewer is a human decision and should be named before chunk 4 runs. Needs captain.
+- [ ] **Does retiring `_summarise()`'s field-fishing change what Mission Control operators see?**
+  Needs a look at the live ticker, not an assumption that narration is strictly better there.
+  Before chunk 8.
+- [ ] **Is the claude_agent_sdk streaming path the one chat actually uses**, or is it only hit
+  under a specific config? Determines whether chunk 5 is release-blocking or a follow-up.
+  Needs a live run — before sequencing chunk 5.
+
+## Success metrics
+
+**Quantitative**
+- Zero raw snake_case tool identifiers rendered in chat for the top 20 tools by call volume.
+- 100% of builtin tools declare `Narration`, enforced by a failing test — not a sampled audit.
+- Plan panel populates on both `pydantic_ai` and the default `claude_agent_sdk` backend.
+- No measurable added latency on the tool-call path (narration is a dict lookup and a format call).
+
+**Qualitative**
+- A non-developer watching the chat can describe what the agent just did without asking.
+- The two ad-hoc narration implementations (`statusMap`, `_summarise` field-fishing) are deleted,
+  not merely bypassed.
+
+## Build chunks
+
+Dependency order. Estimates in agent-hours per the workspace's agent-time budgeting rule.
+
+| # | Chunk | Files touched | Est. |
+|---|-------|---------------|------|
+| 1 | **Bridge carries arguments.** Extract `metadata["input"]` alongside the name; add an (initially empty) `narration` field to `AgentToolUse.data`; keep `tool` populated. Tests assert args survive the bridge. | `ee/.../cloud/shared/agent_bridge.py` | 0.5 |
+| 2 | **`Narration` contract + renderer + fallbacks.** Dataclass, render function, `safe_args` enforcement, truncation/newline-stripping, verb lexicon, override registry. Full unit tests. No tool annotations yet — the fallback alone improves every surface. | `src/pocketpaw/tools/protocol.py`, new `src/pocketpaw/tools/narration.py` | 1.5 |
+| 3 | **Frontend consumes narration; delete the map.** Render `data.narration`; remove the 9-entry `statusMap`. | `paw-enterprise/src/lib/core/chat/store.svelte.ts` | 0.5 |
+| 4 | **Annotate builtin tools** (seeded pass, Decision 3) + the mechanical test that every builtin declares `Narration` and references only allowlisted fields. | ~48 modules under `src/pocketpaw/tools/builtin/`, new test | 2.0 |
+| 5 | **claude_agent_sdk streaming arg capture.** Accumulate `input_json_delta`, emit on `content_block_stop`. Unblocks the default backend. Highest-risk chunk; isolated. | `src/pocketpaw/agents/claude_sdk.py` | 1.5 |
+| 6 | **Plan event + normalizers.** `AgentPlanUpdated`, normalizers for the three sources, `seq`, change-hash coalescing, topic regen, audience wiring. | `ee/.../_core/realtime/events.py`, `audience.py`, `agent_bridge.py`, new normalizers, `topics.gen.ts` (generated) | 2.0 |
+| 7 | **Pinned plan panel.** Mutating-in-place component bound to `agent.plan_updated`; narration renders as the sub-line of the `in_progress` item. | paw-enterprise (new component + mount) | 2.0 |
+| 8 | **Activity buffer prefers narration.** Retire `_summarise()` field-fishing; verify the Mission Control ticker does not regress. | `ee/.../cloud/activity/buffer.py` | 0.5 |
+| 9 | **Security audit pass.** `security-auditor` review of the interpolation path against the 7-layer stack. | review only | 0.5 |
+
+**Total: ~11 agent-hours.** Chunks 1→2→3 form the first shippable slice (narration live, fallback
+phrasing, two surfaces improved). Chunks 6→7 form the second (plan panel). Chunk 5 gates the plan
+panel's usefulness on the default backend.
+
+**Suggested PR grouping:** (1+2+3) narration foundation · (4) template annotations · (5) streaming
+args · (6+7) plan surface · (8+9) cleanup and audit. Five PRs, each independently reviewable.
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Credential or PII rendered into narration and broadcast to every channel adapter | Medium | **Critical** | `safe_args` allowlist; mechanical test that templates reference only allowlisted fields; truncation and newline-stripping; dedicated `security-auditor` pass (chunk 9) before merge |
+| Plan panel blank in production while working in dev — default backend's streaming path carries no args | **High** if chunk 5 is skipped | High | Chunk 5 is scoped as release-blocking for the plan feature; verify against a live default-config run, not a unit test |
+| Chunk 5 destabilizes streaming in a 3000-line backend module | Medium | High | Isolated chunk, own PR, own tests; the block path at :3251 is untouched and remains the reference behavior |
+| Event flood — `write_plan` fires at start and end of every step, resending the whole list | High | Medium | Emit only on actual change (hash the item list); coalesce bursts |
+| Out-of-order delivery lets a stale plan overwrite a fresh one | Low | Medium | Per-run monotonic `seq`; frontend ignores lower `seq`. Open question on whether ordering is already guaranteed |
+| Annotation migration stalls at partial coverage | Medium | Low | Derive-from-name fallback (Decision 2) makes partial coverage a net gain; the mechanical test surfaces the gap rather than hiding it |
+| Mission Control ticker regresses when `_summarise` field-fishing retires | Low | Medium | Chunk 8 verifies the live ticker explicitly; open question tracked |
+| `TodoWrite` normalizer written against a guessed payload | Medium | High | Capture a real payload from a live default-backend run before writing the mapper |

--- a/docs/design/2026-08-15-humanized-tool-narration-prd.md
+++ b/docs/design/2026-08-15-humanized-tool-narration-prd.md
@@ -152,21 +152,31 @@ drop point. It is two:
 
 | Layer | Location | Behavior |
 |---|---|---|
-| Backend, claude_agent_sdk **streaming** path | `src/pocketpaw/agents/claude_sdk.py:3160` | emits `metadata={"name": …, "input": {}}` — **hardcoded empty**. `input_json_delta` is handled nowhere in the file, so incrementally-streamed tool input is discarded at `content_block_start`. |
-| Backend, claude_agent_sdk **block** path | `src/pocketpaw/agents/claude_sdk.py:3251` | emits `"input": tool["input"]` — args present. |
+| Backend, claude_agent_sdk **streaming** path | `src/pocketpaw/agents/claude_sdk.py:3154-3161` | on `content_block_start`, emits `metadata={"name": …, "input": {}}` — hardcoded empty — and adds the name to `_announced_tools`. |
+| Backend, claude_agent_sdk **block** path | `src/pocketpaw/agents/claude_sdk.py:3242-3253` | the completed `AssistantMessage` carries **fully-assembled real arguments** (`_extract_tool_info` reads `block.input` off the SDK's `ToolUseBlock`, `:1156-1162`) — but the guard `if tool["name"] not in _announced_tools` at `:3243` **suppresses the emission**, because the streaming path already announced that name. |
 | Backend, pydantic-ai | `src/pocketpaw/agents/pydantic_ai.py:2156` | emits `"input": args` — args present. |
 | Bridge (all backends) | `ee/.../cloud/shared/agent_bridge.py:582` | reads only the tool name; discards `metadata["input"]` entirely. |
 
-**What:** fix the bridge for all backends (chunk 1) *and* accumulate `input_json_delta` fragments in
-the claude_agent_sdk streaming path, emitting on `content_block_stop` (chunk 5).
+> **Corrected 2026-08-15 by the HTN-0 spike.** This decision originally stated that the streaming
+> path discards incrementally-streamed input and that the fix required accumulating
+> `input_json_delta` fragments. **That was wrong.** The SDK assembles the arguments itself and
+> delivers them intact on the `AssistantMessage`; pocketpaw's own dedup guard is what drops them.
+> No JSON-fragment assembly is needed anywhere.
 
-**Why this matters more than it looks:** `TodoWrite` on the default backend's streaming path
-currently carries no arguments at all. Without chunk 5, the plan panel renders perfectly against
-pydantic-ai in development and is **blank in production for default-config users**. Chunk 5 is not
-optional polish; it is what makes the feature real for most of the install base.
+**What:** fix the bridge for all backends (chunk 1) *and* stop the `_announced_tools` guard from
+suppressing the args-bearing `AssistantMessage` emission (chunk 5). The likely minimal shape: the
+streaming path announces the name for a fast indicator without claiming to carry input, and the
+`AssistantMessage` path still emits, upgrading the narration from `bare` to `active` once the real
+arguments land. One extra `tool_use` event per tool call is acceptable — the surfaces render a
+status line that is replaced, not appended, so an upgrade is invisible except as better text.
 
-**Tradeoff accepted:** chunk 5 touches streaming assembly in a 3000-line backend module, the
-riskiest edit in this PRD. It is isolated behind its own chunk and its own tests for that reason.
+**Why this matters more than it looks:** `TodoWrite` on the default backend currently reaches the
+bridge with no arguments. Without chunk 5, the plan panel renders perfectly against pydantic-ai in
+development and is **blank in production for default-config users**. Chunk 5 is not optional
+polish; it is what makes the feature real for most of the install base.
+
+**Tradeoff accepted:** one duplicate `tool_use` event per call on the streaming path. Cheaper than
+the alternative of delaying the activity indicator until the assistant message completes.
 
 ## Open questions
 

--- a/docs/design/2026-08-15-humanized-tool-narration-recap.html
+++ b/docs/design/2026-08-15-humanized-tool-narration-recap.html
@@ -1,0 +1,673 @@
+<!doctype html>
+<!--
+  recap-template.html — paw-visual-recap skill (created 2026-07-03).
+  Changes: initial version. Self-contained diff-recap viewer: ALL CSS/JS inline, zero external
+  requests (no CDN, no fonts, no http(s) references). Renders entirely from window.RECAP_SPEC
+  (contract: recap-spec.schema.json). The RECAP_SPEC placeholder line in the script below is
+  replaced by string substitution — see SKILL.md. Rendered copies are GENERATED artifacts:
+  never hand-edit one; regenerate from the refs (the diff wins on conflict).
+  Sibling of paw-visual-plan/plan-template.html — same mechanism, same visual language.
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Recap</title>
+<style>
+  *{box-sizing:border-box}
+  :root{
+    --bg:#0b0e14;--panel:#11161f;--panel2:#182031;--line:#232c3d;
+    --text:#c8d3e0;--dim:#7f8b9e;--green:#5ac8a8;--amber:#d9a854;
+    --blue:#6ca8d9;--red:#d97c7c;
+    --addbg:rgba(90,200,168,.08);--delbg:rgba(217,124,124,.09);
+    --mono:ui-monospace,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;
+  }
+  html{scroll-behavior:smooth}
+  body{margin:0;background:var(--bg);color:var(--text);font:14px/1.6 var(--mono);-webkit-font-smoothing:antialiased}
+  a{color:var(--blue);text-decoration:none}
+  main,header.mast{max-width:1060px;margin:0 auto;padding:0 24px}
+  header.mast{padding-top:30px;padding-bottom:14px}
+  .kicker{font-size:11px;letter-spacing:.14em;text-transform:uppercase;color:var(--dim)}
+  header.mast h1{margin:6px 0 12px;font-size:26px;line-height:1.2;color:#e8eef5;font-weight:600}
+  .meta-row{display:flex;flex-wrap:wrap;gap:8px}
+  .chip{background:var(--panel);border:1px solid var(--line);border-radius:4px;padding:3px 10px;font-size:12px;color:var(--dim)}
+  .chip b{color:var(--green);font-weight:600;margin-right:4px}
+  .refline{color:var(--dim);font-size:13px;margin:8px 0 0}
+  .refline code{color:#dbe6f1}
+  .refline .arr{color:var(--green);margin:0 6px}
+  ul.commits{list-style:none;margin:10px 0 0;padding:0}
+  ul.commits li{padding:2px 0;font-size:13px}
+  ul.commits .sha{color:var(--amber);margin-right:10px}
+  nav{position:sticky;top:0;z-index:10;background:rgba(11,14,20,.92);backdrop-filter:blur(6px);border-top:1px solid var(--line);border-bottom:1px solid var(--line)}
+  nav .inner{max-width:1060px;margin:0 auto;padding:7px 20px;display:flex;flex-wrap:wrap;gap:2px}
+  nav a{padding:4px 10px;border-radius:4px;color:var(--dim);font-size:11px;letter-spacing:.06em;text-transform:uppercase}
+  nav a:hover{color:var(--text);background:var(--panel2)}
+  main{padding-bottom:90px}
+  section{margin-top:46px;scroll-margin-top:56px}
+  h2{margin:0 0 14px;font-size:13px;text-transform:uppercase;letter-spacing:.14em;color:var(--dim);border-bottom:1px solid var(--line);padding-bottom:8px;font-weight:600}
+  h2 .hash{color:var(--green);margin-right:7px}
+  .prose p{margin:9px 0;max-width:76ch}
+  .prose ul{margin:8px 0;padding-left:22px}
+  .prose li{margin:3px 0}
+  code{background:var(--panel2);border:1px solid var(--line);padding:1px 5px;border-radius:3px;font-size:.92em;color:#dbe6f1}
+  .tag{display:inline-block;font-size:10px;letter-spacing:.1em;text-transform:uppercase;border-radius:3px;padding:1px 7px;border:1px solid;vertical-align:middle}
+  .tag.warn{color:var(--amber);border-color:var(--amber)}
+  /* stats */
+  .stat-row{display:flex;flex-wrap:wrap;gap:14px}
+  .stat{background:var(--panel);border:1px solid var(--line);border-radius:6px;padding:14px 22px;min-width:130px}
+  .stat .n{font-size:26px;font-weight:600;color:#e8eef5;display:block}
+  .stat .n.plus{color:var(--green)}
+  .stat .n.minus{color:var(--red)}
+  .stat .k{font-size:11px;text-transform:uppercase;letter-spacing:.1em;color:var(--dim)}
+  .bar{margin-top:14px;height:8px;border-radius:4px;overflow:hidden;display:flex;background:var(--panel2);border:1px solid var(--line);max-width:420px}
+  .bar .add{background:var(--green)}
+  .bar .del{background:var(--red)}
+  /* key changes accordion */
+  details.kc{border:1px solid var(--line);border-radius:6px;background:var(--panel);margin:0 0 12px}
+  details.kc summary{cursor:pointer;padding:10px 14px;display:flex;flex-wrap:wrap;align-items:baseline;gap:10px}
+  details.kc summary::marker{color:var(--green)}
+  details.kc[open] summary{border-bottom:1px solid var(--line)}
+  .kc-path{color:#e8eef5;font-weight:600;font-size:13px;word-break:break-all}
+  .kc-note{color:var(--dim);font-size:13px;flex:1 1 100%;margin-left:22px}
+  .hunk{margin:12px 14px;border:1px solid var(--line);border-radius:4px;overflow-x:auto}
+  .hunk-h{background:var(--panel2);color:var(--blue);padding:4px 12px;font-size:12px;border-bottom:1px solid var(--line);white-space:pre}
+  .hunk pre{margin:0;padding:6px 0;font:12px/1.5 var(--mono)}
+  .dl{display:block;padding:0 12px;white-space:pre}
+  .dl.add{color:var(--green);background:var(--addbg)}
+  .dl.del{color:var(--red);background:var(--delbg)}
+  .dl.ctx{color:var(--dim)}
+  .dl .m{display:inline-block;width:1.2em;user-select:none;opacity:.8}
+  /* file tree */
+  .dirgrp{margin:0 0 18px}
+  .dirname{color:var(--blue);font-size:12px;letter-spacing:.04em;padding:4px 0;border-bottom:1px dashed var(--line)}
+  table.ft{width:100%;border-collapse:collapse;font-size:13px}
+  table.ft td{padding:6px 10px;border-bottom:1px solid var(--line);vertical-align:baseline}
+  table.ft td.f{width:60%}
+  table.ft td.n{text-align:right;white-space:nowrap}
+  .plus{color:var(--green)}
+  .minus{color:var(--red)}
+  .fflag{font-size:10px;letter-spacing:.1em;text-transform:uppercase;border-radius:3px;padding:1px 7px;border:1px solid}
+  .fflag.new{color:var(--green);border-color:var(--green)}
+  .fflag.modified{color:var(--amber);border-color:var(--amber)}
+  .fflag.deleted{color:var(--red);border-color:var(--red)}
+  .fflag.renamed{color:var(--blue);border-color:var(--blue)}
+  .keymark{color:var(--green);font-size:11px;margin-left:8px}
+  /* api deltas */
+  .delta{background:var(--panel);border:1px solid var(--line);border-radius:6px;padding:12px 16px;margin:0 0 12px}
+  .delta .kind{font-size:10px;letter-spacing:.1em;text-transform:uppercase;color:var(--amber);border:1px solid var(--amber);border-radius:3px;padding:1px 7px}
+  .delta .pair{margin-top:8px;overflow-x:auto}
+  .delta .b,.delta .a{display:block;padding:3px 10px;white-space:pre-wrap;border-radius:3px;font-size:13px}
+  .delta .b{color:var(--red);background:var(--delbg)}
+  .delta .a{color:var(--green);background:var(--addbg);margin-top:3px}
+  .delta .note{margin-top:8px;color:var(--dim);font-size:13px}
+  ul.inf{list-style:none;margin:0;padding:0}
+  ul.inf li{padding:8px 0;border-bottom:1px dashed var(--line);max-width:80ch}
+  ul.inf .tag{margin-right:10px}
+  footer{max-width:1060px;margin:60px auto 0;padding:14px 24px;border-top:1px solid var(--line);color:var(--dim);font-size:11px}
+  @media print{
+    :root{--bg:#fff;--panel:#fff;--panel2:#f2f2f2;--line:#bbb;--text:#111;--dim:#555;--green:#0a7a5c;--amber:#8a6414;--blue:#1c5f96;--red:#a33;--addbg:#eaf6f1;--delbg:#faeceb}
+    nav{display:none}
+    body{font-size:12px}
+    details.kc,.delta,.dirgrp{break-inside:avoid}
+    section{margin-top:26px}
+  }
+</style>
+</head>
+<body>
+<header class="mast" id="mast"></header>
+<nav><div class="inner" id="navlinks"></div></nav>
+<main id="main"></main>
+<footer>generated by paw-visual-recap — the refs are the source of truth; regenerate, don't hand-edit.</footer>
+<script>
+window.RECAP_SPEC = {
+  "meta": {
+    "title": "Humanized tool narration (PR #1942)",
+    "date": "2026-08-15",
+    "base": "origin/dev",
+    "head": "origin/feat/humanized-tool-narration",
+    "commits": [
+      {
+        "sha": "639b0d89",
+        "subject": "docs(design): wave 1 status \u2014 two PRs open, neither merged"
+      },
+      {
+        "sha": "a2ce35d4",
+        "subject": "test(tools): pin the emoji ZWJ cost of stripping the Cf category"
+      },
+      {
+        "sha": "d7538a83",
+        "subject": "test(tools): assert narration falls back, not just that the character vanished"
+      },
+      {
+        "sha": "c537bd0f",
+        "subject": "docs(design): stripping Cf closes two findings and costs emoji ZWJ sequences"
+      },
+      {
+        "sha": "e9857a16",
+        "subject": "fix(tools): close the invisible-character and declaration gaps in narration"
+      },
+      {
+        "sha": "22ef0a65",
+        "subject": "docs(design): security review corrects this plan's threat model in two directions"
+      },
+      {
+        "sha": "1ad93e24",
+        "subject": "docs(design): HTN-2 should delete the stopgap map, not grow it"
+      },
+      {
+        "sha": "1440437f",
+        "subject": "feat(tools): narrate tool calls in plain language server-side"
+      },
+      {
+        "sha": "01c2bf71",
+        "subject": "docs(design): HTN-0 says the SDK arguments were never lost, just suppressed"
+      },
+      {
+        "sha": "227750e3",
+        "subject": "docs(design): task breakdown \u2014 re-cut the PRD's chunks so the first merge is visible"
+      },
+      {
+        "sha": "4bb6b2c0",
+        "subject": "docs(design): PRD \u2014 and the argument drop turns out to be two bugs, not one"
+      },
+      {
+        "sha": "e4c40350",
+        "subject": "docs(design): the tool narration and the agent plan are the same bug"
+      }
+    ]
+  },
+  "narrative": "Users watching an agent work read `using pocketpaw_sites_publish`. The only humanized phrasing that existed was a nine-entry lookup table in the Svelte chat store, keyed to Claude Agent SDK tool names, so every PocketPaw-native tool fell through to `using ${tool}` \u2014 48 builtin modules, ~49 bridged MCP tools, and the whole connector surface.\n\nThis moves phrasing to the server. A tool declares a `Narration` and the bridge renders it once, so every surface reads the same words. `web_search` is annotated as the reference; a tool without a `Narration` emits no field and the bridge invents nothing.\n\n**Review the allowlist first.** Tool arguments are model-authored and routinely carry credentials, so only fields named in `safe_args` may interpolate. A security review returned SOUND_WITH_FINDINGS: the allowlist held against every format-string escape hatch tried against it. Six findings were fixed here, three of them reproduced by running the exploit first and re-run after to confirm closure.\n\n**The bridge change also closed a leak that predates this work.** Reading `event.content` first meant codex_cli's entire shell command went into the `tool` field, unbounded and unsanitized, out to every group member.",
+  "stats": {
+    "files": 9,
+    "adds": 2037,
+    "dels": 15
+  },
+  "fileTree": [
+    {
+      "path": "src/pocketpaw/tools/narration.py",
+      "adds": 303,
+      "dels": 0,
+      "flag": "new"
+    },
+    {
+      "path": "src/pocketpaw/tools/protocol.py",
+      "adds": 14,
+      "dels": 0,
+      "flag": "modified"
+    },
+    {
+      "path": "src/pocketpaw/tools/builtin/web_search.py",
+      "adds": 14,
+      "dels": 0,
+      "flag": "modified"
+    },
+    {
+      "path": "ee/pocketpaw_ee/cloud/shared/agent_bridge.py",
+      "adds": 57,
+      "dels": 15,
+      "flag": "modified"
+    },
+    {
+      "path": "tests/test_tool_narration.py",
+      "adds": 527,
+      "dels": 0,
+      "flag": "new"
+    },
+    {
+      "path": "tests/cloud/shared/test_agent_bridge_narration.py",
+      "adds": 191,
+      "dels": 0,
+      "flag": "new"
+    },
+    {
+      "path": "docs/design/2026-08-15-humanized-tool-narration.md",
+      "adds": 247,
+      "dels": 0,
+      "flag": "new"
+    },
+    {
+      "path": "docs/design/2026-08-15-humanized-tool-narration-prd.md",
+      "adds": 242,
+      "dels": 0,
+      "flag": "new"
+    },
+    {
+      "path": "docs/design/2026-08-15-humanized-tool-narration-tasks.md",
+      "adds": 442,
+      "dels": 0,
+      "flag": "new"
+    }
+  ],
+  "keyChanges": [
+    {
+      "path": "src/pocketpaw/tools/narration.py",
+      "annotation": "The security boundary. `_template_fields` refuses every construct that could escape the allowlist \u2014 attribute access, indexing, positional, conversions, format specs. The review traced each against CPython's own parser and called the rejection list complete.",
+      "hunks": [
+        {
+          "header": "@@ -0,0 +1,303 @@ (new file)",
+          "lines": [
+            {
+              "t": "add",
+              "s": "    fields: list[str] = []"
+            },
+            {
+              "t": "add",
+              "s": "    try:"
+            },
+            {
+              "t": "add",
+              "s": "        parsed = list(_FORMATTER.parse(template))"
+            },
+            {
+              "t": "add",
+              "s": "    except ValueError:"
+            },
+            {
+              "t": "add",
+              "s": "        # Malformed template (unbalanced braces) \u2014 treat as unrenderable."
+            },
+            {
+              "t": "add",
+              "s": "        return None"
+            },
+            {
+              "t": "add",
+              "s": "    for _literal, field_name, format_spec, conversion in parsed:"
+            },
+            {
+              "t": "add",
+              "s": "        if field_name is None:"
+            },
+            {
+              "t": "add",
+              "s": "            continue"
+            },
+            {
+              "t": "add",
+              "s": "        if conversion is not None or format_spec:"
+            },
+            {
+              "t": "add",
+              "s": "            return None"
+            },
+            {
+              "t": "add",
+              "s": "        if not field_name.isidentifier():"
+            },
+            {
+              "t": "add",
+              "s": "            return None"
+            },
+            {
+              "t": "add",
+              "s": "        fields.append(field_name)"
+            },
+            {
+              "t": "add",
+              "s": "    return fields"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "src/pocketpaw/tools/protocol.py",
+      "annotation": "The declaration surface: an optional property on `BaseTool`, sitting beside `trust_level`. Narration lives with the tool because which arguments are safe to display is knowledge only the tool has.",
+      "hunks": [
+        {
+          "header": "@@ -99,6 +103,16 @@ class BaseTool(ABC):",
+          "lines": [
+            {
+              "t": "ctx",
+              "s": "        \"\"\"Required trust level to use this tool.\"\"\""
+            },
+            {
+              "t": "ctx",
+              "s": "        return \"standard\""
+            },
+            {
+              "t": "ctx",
+              "s": ""
+            },
+            {
+              "t": "add",
+              "s": "    @property"
+            },
+            {
+              "t": "add",
+              "s": "    def narration(self) -> Narration | None:"
+            },
+            {
+              "t": "add",
+              "s": "        \"\"\"Plain-language phrasing for a call to this tool."
+            },
+            {
+              "t": "add",
+              "s": ""
+            },
+            {
+              "t": "add",
+              "s": "        Override to give users a readable status line (\"Searching the web for"
+            },
+            {
+              "t": "add",
+              "s": "        quarterly filings\") instead of the bare tool name. ``None`` means the"
+            },
+            {
+              "t": "add",
+              "s": "        tool has no phrasing and callers should not invent one."
+            },
+            {
+              "t": "add",
+              "s": "        \"\"\""
+            },
+            {
+              "t": "add",
+              "s": "        return None"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "src/pocketpaw/tools/builtin/web_search.py",
+      "annotation": "The reference annotation, and the shape every tool in HTN-3 will copy. Note `num_results` is deliberately left out of `safe_args`.",
+      "hunks": [
+        {
+          "header": "@@ -42,6 +46,16 @@ class WebSearchTool(BaseTool):",
+          "lines": [
+            {
+              "t": "ctx",
+              "s": "    def trust_level(self) -> str:"
+            },
+            {
+              "t": "ctx",
+              "s": "        return \"standard\""
+            },
+            {
+              "t": "ctx",
+              "s": ""
+            },
+            {
+              "t": "add",
+              "s": "    @property"
+            },
+            {
+              "t": "add",
+              "s": "    def narration(self) -> Narration | None:"
+            },
+            {
+              "t": "add",
+              "s": "        # ``query`` is the only arg safe to show \u2014 ``num_results`` is noise, and"
+            },
+            {
+              "t": "add",
+              "s": "        # anything not listed here can never reach the rendered phrase."
+            },
+            {
+              "t": "add",
+              "s": "        return Narration("
+            },
+            {
+              "t": "add",
+              "s": "            active=\"Searching the web for {query}\","
+            },
+            {
+              "t": "add",
+              "s": "            bare=\"Searching the web\","
+            },
+            {
+              "t": "add",
+              "s": "            safe_args=(\"query\",),"
+            },
+            {
+              "t": "add",
+              "s": "        )"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "ee/pocketpaw_ee/cloud/shared/agent_bridge.py",
+      "annotation": "Two things at once: arguments now survive the bridge, and the `tool` field stops carrying prose. The deleted lines are the pre-existing leak \u2014 on codex_cli, `event.content` is the full shell command.",
+      "hunks": [
+        {
+          "header": "@@ -580,22 +604,40 @@",
+          "lines": [
+            {
+              "t": "ctx",
+              "s": "            elif event.type == \"tool_use\":"
+            },
+            {
+              "t": "del",
+              "s": "                tool_name = \"\""
+            },
+            {
+              "t": "del",
+              "s": "                if isinstance(event.content, dict):"
+            },
+            {
+              "t": "del",
+              "s": "                    tool_name = event.content.get(\"tool\") or event.content.get(\"name\") or \"\""
+            },
+            {
+              "t": "del",
+              "s": "                elif isinstance(event.content, str):"
+            },
+            {
+              "t": "del",
+              "s": "                    tool_name = event.content"
+            },
+            {
+              "t": "add",
+              "s": "                tool_input: dict[str, Any] = {}"
+            },
+            {
+              "t": "add",
+              "s": "                meta = getattr(event, \"metadata\", None)"
+            },
+            {
+              "t": "add",
+              "s": "                meta = meta if isinstance(meta, dict) else {}"
+            },
+            {
+              "t": "add",
+              "s": "                if meta:"
+            },
+            {
+              "t": "add",
+              "s": "                    tool_name = meta.get(\"name\") or meta.get(\"tool\") or \"\""
+            },
+            {
+              "t": "add",
+              "s": "                    raw_input = meta.get(\"input\")"
+            },
+            {
+              "t": "add",
+              "s": "                    tool_input = raw_input if isinstance(raw_input, dict) else {}"
+            },
+            {
+              "t": "add",
+              "s": "                # Purely additive: a tool with no narration emits no field, and"
+            },
+            {
+              "t": "add",
+              "s": "                # the bridge never invents a fallback phrase."
+            },
+            {
+              "t": "add",
+              "s": "                narration = _narrate_tool_use(tool_name, tool_input)"
+            },
+            {
+              "t": "add",
+              "s": "                if narration:"
+            },
+            {
+              "t": "add",
+              "s": "                    payload[\"narration\"] = narration"
+            },
+            {
+              "t": "add",
+              "s": "                await emit(AgentToolUse(data=payload))"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "apiDeltas": [
+    {
+      "kind": "schema",
+      "before": "agent.tool_use -> {group_id, agent_id, agent_name, tool}",
+      "after": "agent.tool_use -> {group_id, agent_id, agent_name, tool, narration?}",
+      "note": "Additive. `tool` stays populated, so an older client is unaffected. `narration` is absent for any tool that declares none."
+    },
+    {
+      "kind": "schema",
+      "before": "tool field value on codex_cli: \"Running: curl -H 'Authorization: Bearer ...'\"",
+      "after": "tool field value on codex_cli: \"shell\"",
+      "note": "The old value was event.content, which carried the whole command. This is the pre-existing leak the precedence change closes."
+    }
+  ],
+  "inferred": [
+    "Tool counts (48 builtin modules, ~49 bridged MCP tools) are read from the repo layout and the pydantic_ai backend docstring, not measured at runtime.",
+    "The security review was static analysis: Bash was unavailable to the reviewer, so its CPython parser and re.sub claims were reasoned, not executed. Three of its findings were separately reproduced and re-verified by running them.",
+    "'Every surface inherits the phrasing' is the design intent. Verified today: narration reaches one emit scoped to chat-group members, and no channel adapter consumes the field yet."
+  ]
+};
+(function(){
+"use strict";
+var S = window.RECAP_SPEC;
+var main = document.getElementById("main");
+if (!S) {
+  main.innerHTML = "<p style='padding:40px 0'>window.RECAP_SPEC is empty — this file was not generated. Run the substitution in the paw-visual-recap SKILL.md.</p>";
+  return;
+}
+function esc(s){return String(s).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;");}
+function inline(t){
+  t = esc(t);
+  t = t.replace(/`([^`]+)`/g,"<code>$1</code>");
+  t = t.replace(/\*\*([^*]+)\*\*/g,"<strong>$1</strong>");
+  t = t.replace(/\*([^*]+)\*/g,"<em>$1</em>");
+  return t;
+}
+function md(s){ /* md-lite: paragraphs, "- " lists, **bold**, *em*, `code` */
+  return String(s).trim().split(/\n\s*\n/).map(function(b){
+    var lines = b.split("\n");
+    var isList = lines.length > 0 && lines.every(function(l){return /^\s*-\s+/.test(l);});
+    if (isList) return "<ul>" + lines.map(function(l){return "<li>"+inline(l.replace(/^\s*-\s+/,""))+"</li>";}).join("") + "</ul>";
+    return "<p>" + inline(b) + "</p>";
+  }).join("");
+}
+function chip(k,v){return '<span class="chip"><b>'+esc(k)+'</b>'+esc(v)+'</span>';}
+
+/* masthead */
+var meta = S.meta || {};
+document.title = (meta.title || "Recap") + " — recap";
+var mast = '<div class="kicker">paw-visual-recap &middot; generated &mdash; regenerate, don\'t hand-edit</div>'
+  + '<h1>'+esc(meta.title || "Untitled recap")+'</h1>'
+  + '<div class="refline"><code>'+esc(meta.base||"?")+'</code><span class="arr">&rarr;</span><code>'+esc(meta.head||"?")+'</code></div>'
+  + '<div class="meta-row" style="margin-top:10px">'
+  + (meta.date ? chip("date", meta.date) : "")
+  + ((meta.commits||[]).length ? chip("commits", String(meta.commits.length)) : "")
+  + (S.stats ? chip("files", String(S.stats.files)) : "")
+  + '</div>'
+  + (meta.prUrl ? '<div class="refline">PR: <a href="'+esc(meta.prUrl)+'">'+esc(meta.prUrl)+'</a></div>' : "");
+if ((meta.commits || []).length) {
+  mast += '<ul class="commits">' + meta.commits.map(function(c){
+    return '<li><span class="sha">'+esc(c.sha)+'</span>'+esc(c.subject)+'</li>';
+  }).join("") + '</ul>';
+}
+document.getElementById("mast").innerHTML = mast;
+
+/* sections — only pushed when the spec has data, so empty blocks disappear */
+var sections = [];
+function section(id, label, html){ sections.push({id:id, label:label, html:html}); }
+
+if (S.narrative) section("narrative", "Narrative", '<div class="prose">'+md(S.narrative)+'</div>');
+
+if (S.stats) {
+  var st = S.stats, tot = (st.adds + st.dels) || 1;
+  section("stats", "Stats",
+    '<div class="stat-row">'
+    + '<div class="stat"><span class="n">'+st.files+'</span><span class="k">files</span></div>'
+    + '<div class="stat"><span class="n plus">+'+st.adds+'</span><span class="k">insertions</span></div>'
+    + '<div class="stat"><span class="n minus">&minus;'+st.dels+'</span><span class="k">deletions</span></div>'
+    + '</div>'
+    + '<div class="bar" title="+'+st.adds+' / -'+st.dels+'">'
+    + '<div class="add" style="width:'+Math.round(100*st.adds/tot)+'%"></div>'
+    + '<div class="del" style="flex:1"></div>'
+    + '</div>');
+}
+
+var keyPaths = {};
+if ((S.keyChanges || []).length) {
+  var kcs = S.keyChanges.map(function(k, i){
+    keyPaths[k.path] = true;
+    var hunks = (k.hunks || []).map(function(h){
+      var body = (h.lines || []).map(function(l){
+        var m = l.t === "add" ? "+" : (l.t === "del" ? "-" : " ");
+        return '<span class="dl '+esc(l.t)+'"><span class="m">'+m+'</span>'+esc(l.s)+'</span>';
+      }).join("");
+      return '<div class="hunk"><div class="hunk-h">'+esc(h.header)+'</div><pre>'+body+'</pre></div>';
+    }).join("");
+    return '<details class="kc"'+(i===0?' open':'')+'>'
+      + '<summary><span class="kc-path">'+esc(k.path)+'</span>'
+      + '<span class="kc-note">'+inline(k.annotation||"")+'</span></summary>'
+      + hunks + '</details>';
+  }).join("");
+  section("keychanges", "Key changes", kcs);
+}
+
+if ((S.fileTree || []).length) {
+  var groups = {}, order = [];
+  S.fileTree.forEach(function(f){
+    var i = f.path.lastIndexOf("/");
+    var dir = i < 0 ? "." : f.path.slice(0, i);
+    if (!groups[dir]) { groups[dir] = []; order.push(dir); }
+    groups[dir].push(f);
+  });
+  var ft = order.map(function(dir){
+    var rows = groups[dir].map(function(f){
+      var base = f.path.slice(dir === "." ? 0 : dir.length + 1);
+      return '<tr><td class="f"><code>'+esc(base)+'</code>'
+        + (keyPaths[f.path] ? '<span class="keymark" title="annotated in key changes">&#9670; key</span>' : '')
+        + '</td>'
+        + '<td class="n"><span class="plus">+'+f.adds+'</span> <span class="minus">&minus;'+f.dels+'</span></td>'
+        + '<td><span class="fflag '+esc(f.flag)+'">'+esc(f.flag)+'</span></td></tr>';
+    }).join("");
+    return '<div class="dirgrp"><div class="dirname">'+esc(dir)+'/</div><table class="ft"><tbody>'+rows+'</tbody></table></div>';
+  }).join("");
+  section("files", "Files", ft);
+}
+
+if ((S.apiDeltas || []).length) {
+  section("apideltas", "API deltas", S.apiDeltas.map(function(d){
+    return '<div class="delta"><span class="kind">'+esc(d.kind)+'</span>'
+      + '<div class="pair"><span class="b">- '+esc(d.before)+'</span><span class="a">+ '+esc(d.after)+'</span></div>'
+      + (d.note ? '<div class="note">'+inline(d.note)+'</div>' : '')
+      + '</div>';
+  }).join(""));
+}
+
+if ((S.inferred || []).length)
+  section("inferred", "Inferred", '<ul class="inf">'+S.inferred.map(function(x){
+    return '<li><span class="tag warn">inferred</span>'+inline(x)+'</li>';
+  }).join("")+'</ul>');
+
+main.innerHTML = sections.map(function(s){
+  return '<section id="'+s.id+'"><h2><span class="hash">#</span>'+s.label+'</h2>'+s.html+'</section>';
+}).join("");
+document.getElementById("navlinks").innerHTML = sections.map(function(s){
+  return '<a href="#'+s.id+'">'+s.label+'</a>';
+}).join("");
+
+/* print-friendly: expand all collapsed key changes before printing */
+window.addEventListener("beforeprint", function(){
+  document.querySelectorAll("details").forEach(function(d){ d.open = true; });
+});
+})();
+</script>
+</body>
+</html>

--- a/docs/design/2026-08-15-humanized-tool-narration-tasks.md
+++ b/docs/design/2026-08-15-humanized-tool-narration-tasks.md
@@ -5,6 +5,22 @@
 
 # Humanized tool narration — Tasks (local, not filed)
 
+## Status — wave 1 closed 2026-08-15
+
+| Task | Status | PR | Evidence |
+|---|---|---|---|
+| HTN-0 | done | — | Rescoped HTN-4; findings inline below |
+| HTN-1 | **PR open, awaiting captain** | [#1942](https://github.com/pocketpaw/pocketpaw/pull/1942) | 46 narration tests, 160 in sweep; security SOUND_WITH_FINDINGS, 6 fixed |
+| HTN-4 | **PR open, awaiting captain** | [#1943](https://github.com/pocketpaw/pocketpaw/pull/1943) | 131 passed; correlation regression caught and fixed before PR |
+| HTN-2 | ready | — | Carries inherited design + security notes below |
+| HTN-3 | blocked on HTN-2 | — | See sequencing note |
+| HTN-5 | ready | — | Unblocked by HTN-1 |
+| HTN-6 | **blocked — needs captain** | — | Live `TodoWrite` payload capture; see HTN-0 finding 3 |
+| HTN-7 | ready | — | Unblocked by HTN-1 |
+| HTN-8 | first pass done | — | Re-audit when HTN-2/3 widen the surface |
+
+**Neither PR is merged.** Per the never-merge-on-green gate, both wait on captain review.
+
 Vertical slices from the PRD's 9 build chunks. The PRD's chunks were layered
 (bridge → contract → frontend); they are re-cut here by shippable outcome, so the first
 merge puts a real humanized phrase on a real screen instead of landing plumbing nobody can see.

--- a/docs/design/2026-08-15-humanized-tool-narration-tasks.md
+++ b/docs/design/2026-08-15-humanized-tool-narration-tasks.md
@@ -47,7 +47,21 @@ vertical: the unit of *value* is the visible phrase, not the layer.
 
 ---
 
-## HTN-0 — Resolve the two sequencing unknowns · ~0.5 agent-hrs
+## HTN-0 — Resolve the two sequencing unknowns · ~0.5 agent-hrs · **DONE (partial)**
+
+> **Findings, 2026-08-15.**
+> 1. **Streaming vs block path — ANSWERED.** Both fire. `claude_agent_sdk` delivers fully
+>    assembled real arguments on the `AssistantMessage` (`_extract_tool_info` → `block.input`,
+>    `claude_sdk.py:1156-1162`); pocketpaw suppresses that emission with the `_announced_tools`
+>    guard at `:3243`. The arguments were never lost, so HTN-4 needs no `input_json_delta`
+>    accumulation and is rescoped from ~1.5h/high-risk to ~0.5h/low-risk.
+> 2. **Event ordering — DOWNGRADED to informational, not blocking.** The answer does not change
+>    what gets built: `seq` is cheap and ships either way. It determines only whether `seq` is
+>    load-bearing or belt-and-braces. HTN-5 proceeds without it.
+> 3. **Live `TodoWrite` payload — STILL OPEN, needs the captain.** `TodoWrite` is a CLI-side
+>    builtin bundled inside `claude_agent_sdk/_bundled/claude.exe`, so its shape is not readable
+>    from source and requires a live default-backend run to capture. **HTN-6 is blocked on this**
+>    and must not be written against an inferred payload.
 
 **Slice:** the answers that decide whether HTN-4 is release-blocking and whether `seq` is
 load-bearing. Cheap to run, expensive to guess wrong.
@@ -162,32 +176,38 @@ test asserting the derived phrasing for a sample of unannotated tools; `statusMa
 
 ---
 
-## HTN-4 — Narration works on the default backend · ~1.5 agent-hrs
+## HTN-4 — Narration works on the default backend · ~0.5 agent-hrs
 
-**Slice:** `claude_agent_sdk` — the shipped default — carries tool arguments through its streaming
-path, so narration and the plan panel are not pydantic-ai-only features.
+> **Rescoped 2026-08-15 by HTN-0, from ~1.5h and "highest-risk" down to ~0.5h and low-risk.** The
+> arguments are not lost and never needed reassembling — see below.
+
+**Slice:** `claude_agent_sdk` — the shipped default — delivers tool arguments to the bridge, so
+narration and the plan panel are not pydantic-ai-only features.
 
 **Do:**
-- `src/pocketpaw/agents/claude_sdk.py`: accumulate `input_json_delta` fragments (currently handled
-  nowhere in the file) and emit the `tool_use` event on `content_block_stop` with the assembled
-  input, replacing the hardcoded `"input": {}` at `:3160`.
-- Leave the block path at `:3251` untouched — it already passes real args and is the reference
-  behavior to match.
-- Tests: a streaming fixture with a multi-fragment tool input asserting the assembled args match
-  the block path's output for the same call.
+- `src/pocketpaw/agents/claude_sdk.py`: the completed `AssistantMessage` already carries fully
+  assembled real arguments (`_extract_tool_info` → `block.input`, `:1156-1162`). They are dropped
+  by the guard `if tool["name"] not in _announced_tools` at `:3243`, because the streaming path at
+  `:3156` already added the name while emitting `"input": {}`.
+- Let the args-bearing emission through. Likely minimal shape: the streaming path announces the
+  name for a fast indicator without suppressing the later event; the `AssistantMessage` path emits
+  with real arguments, upgrading narration from `bare` to `active`.
+- **Do not** implement `input_json_delta` accumulation. The SDK assembles the input itself; that
+  work is unnecessary.
+- Tests: assert a streamed tool call produces a `tool_use` event carrying real `input`, and that
+  narration upgrades from `bare` to `active` across the pair.
 
-**Done when:** a streamed default-backend turn emits `tool_use` with populated `input`, and the
-streaming and block paths produce identical metadata for an equivalent call.
+**Done when:** a streamed default-backend tool call reaches the bridge with populated `input`, with
+a test covering the announce-then-upgrade sequence.
 
 **Interfaces:**
-- exposes: populated `metadata["input"]` on the streaming path (consumed by HTN-6, and by HTN-1's
+- exposes: populated `metadata["input"]` on the default backend (consumed by HTN-6, and by HTN-1's
   bridge rendering for default-backend users)
 - consumes: nothing new
 
-**Deps:** HTN-0 (which confirms whether this path is actually live, and therefore whether this
-task is release-blocking or a follow-up).
-**PRs:** 1 — pocketpaw. **Highest-risk task in the set:** streaming assembly in a 3000-line module.
-Keep it alone in its PR.
+**Deps:** HTN-0 (done).
+**PRs:** 1 — pocketpaw. Still keep it alone in its PR: it changes event cardinality on the default
+backend's hot path, so it deserves an isolated diff even though it is small.
 
 ---
 

--- a/docs/design/2026-08-15-humanized-tool-narration-tasks.md
+++ b/docs/design/2026-08-15-humanized-tool-narration-tasks.md
@@ -129,7 +129,33 @@ asserts the emitted `AgentToolUse.data.narration` equals `"Searching the web for
 **Slice:** every tool that declares nothing still reads like English.
 `pocketpaw_sites_publish` → "Publishing the site", not `using pocketpaw_sites_publish`.
 
+> **Inherited from HTN-1, 2026-08-15 — read before starting.**
+> HTN-1 shipped `_ANNOTATED_TOOLS` in `narration.py`: a hardcoded `tool name → (module, class)`
+> map with exactly one entry. **It is a stopgap to DELETE, not an extension point to grow.** It
+> maps to builtin *classes*, so MCP and connector tools — precisely what this task must cover —
+> can never appear in it by construction.
+>
+> HTN-1 read `src/pocketpaw/tools/registry.py` in full and rejected it for three concrete
+> reasons, so do not re-derive them: (1) `ToolRegistry` is instance-based (`__init__(self,
+> policy=None)`) with no module-level singleton — `get_tool_registry` / `_global_registry` /
+> `create_default_registry` all return zero hits across `src/`; (2) the bridge has no registry
+> handle to reach — `_run_agent_response` only receives `instance` from `pool.get(agent_id)`, and
+> `pool.py` exposes no tool registry; (3) registries are populated per-caller (e.g.
+> `tools/cli.py:102` constructs and registers `WebSearchTool()` itself), and `builtin/__init__.py`
+> uses lazy `__getattr__` over `_LAZY_IMPORTS` *specifically because* optional dependencies are
+> missing in some installs — so walking every builtin to find narrations would import the world
+> and can raise `ImportError`, just to phrase a status line.
+>
+> **The real fix is threading the agent's actual `ToolRegistry` through to the bridge.** That is
+> this task's central design problem, not the verb lexicon.
+>
+> **Sequencing: HTN-2 MUST land before HTN-3.** Until the registry lookup replaces
+> `_ANNOTATED_TOOLS`, every tool HTN-3 annotates is dead code unless someone also hand-adds a line
+> to that map. The dependency order below already reflects this; this note records why.
+
 **Do:**
+- Replace `_ANNOTATED_TOOLS` with a real lookup that reaches the agent's `ToolRegistry`, per the
+  note above. Delete the stopgap map in the same change.
 - Derive-from-name fallback in `narration.py`: strip vendor prefix, verb-first via a small
   deterministic lexicon (`publish`→Publishing, `create`→Creating, `search`→Searching,
   `invite`→Inviting, `delete`→Deleting, `update`→Updating, `list`→Listing, `send`→Sending).

--- a/docs/design/2026-08-15-humanized-tool-narration-tasks.md
+++ b/docs/design/2026-08-15-humanized-tool-narration-tasks.md
@@ -21,6 +21,33 @@
 
 **Neither PR is merged.** Per the never-merge-on-green gate, both wait on captain review.
 
+### ⚠ Merge order is load-bearing: #1943 before HTN-9
+
+HTN-9 makes pydantic-ai emit the provisional + resolved pair, same as HTN-4 did for claude_sdk.
+`loop.py`'s skip of provisional events ships in **#1943 (HTN-4)**. Merge HTN-9 first and `dev` gets
+duplicate `pending_tool_calls` entries on the pydantic-ai path — stale residue across a turn and
+corrupted `tool_call_id` correlation via the `pop(0)` fallback — until #1943 lands.
+
+**Merge #1943 before, or in the same batch as, HTN-9.** HTN-9's branch is off `origin/dev` and
+deliberately does not touch `loop.py`, to avoid conflicting with #1943.
+
+### HTN-9 found a second defect this plan never diagnosed
+
+The plan (and my brief) said the bug was the `tool_call_id` dedupe. That was only half.
+`ToolCallPart.args` is typed `str | dict[str, Any] | None` (`pydantic_ai/messages.py:1942`), and
+the streamed path delivers **JSON text**, not a dict. The metadata builder kept the value only
+`if isinstance(args, dict)`, coercing every real streamed call to `{}`. **Fixing the dedupe alone
+would still have shipped `{}`** — a green task and a broken feature.
+
+Two things worth carrying forward:
+- The decoder must not fall back to `args_as_dict()`, whose documented behavior on malformed JSON
+  is to return `{'INVALID_JSON': '<raw args>'}` (`messages.py:1991-2003`) — that would hand the UI a
+  fabricated argument *named* `INVALID_JSON` as though the model had passed it. Non-object payloads
+  become `{}` instead.
+- The replaced test counted one `tool_use` per call and passed for the life of the backend while
+  `input` was unconditionally `{}`. It proved the dedupe worked and said nothing about whether the
+  arguments survived it. **Assert the argument dict, not the event count.**
+
 Vertical slices from the PRD's 9 build chunks. The PRD's chunks were layered
 (bridge → contract → frontend); they are re-cut here by shippable outcome, so the first
 merge puts a real humanized phrase on a real screen instead of landing plumbing nobody can see.

--- a/docs/design/2026-08-15-humanized-tool-narration-tasks.md
+++ b/docs/design/2026-08-15-humanized-tool-narration-tasks.md
@@ -406,7 +406,15 @@ Recorded here rather than quietly absorbed.
 **First broadly useful outcome:** + HTN-2 (~4h) — every tool reads as English, no annotations needed.
 
 **Out of scope (deferred, from the PRD's non-goals):**
-- i18n and per-surface phrasing — `Narration` is structured so these are additive later
+- i18n and per-surface phrasing — `Narration` is structured so these are additive later.
+  **Known consequence to revisit when i18n lands (measured 2026-08-15):** the security fix strips
+  the whole Unicode `Cf` category to close the bidi-override and zero-width-padding findings, and
+  U+200D ZERO WIDTH JOINER is `Cf`. So a ZWJ emoji sequence degrades to its components
+  (👩‍💻 renders as 👩 💻), and ZWJ/ZWNJ conjunct control in Indic and Arabic scripts is stripped
+  too. Ordinary non-ASCII is unaffected — Japanese, Devanagari and accented Latin all verified
+  intact. This is the right trade for an 80-char status line whose arguments are model-authored,
+  and narrowing the class to re-admit U+200D would reopen the zero-width padding bypass. Flagged
+  so i18n work treats it as a known decision rather than a bug to "fix"
 - Pocket-level narration overrides
 - The planner MCP's `todos[]` build brief (`ee/.../mcp_servers/planner.py:528`) — different lifecycle
 - Plan persistence and historical replay — plans stay per-run and in-memory

--- a/docs/design/2026-08-15-humanized-tool-narration-tasks.md
+++ b/docs/design/2026-08-15-humanized-tool-narration-tasks.md
@@ -412,7 +412,66 @@ or a channel adapter.
 
 ---
 
-**Total:** ~12.5 agent-hours across 8 tasks and 11 PRs.
+---
+
+## HTN-9 — pydantic-ai must stop suppressing its own arguments · ~0.5 agent-hrs
+
+**Slice:** the interpolated phrase actually appears on pydantic-ai, instead of degrading to `bare`.
+
+**Why this exists:** HTN-4 fixed exactly this bug in `claude_sdk` and the PRD asserted pydantic-ai
+was unaffected. That was wrong, measured 2026-08-15. `_announce_tool`
+(`agents/pydantic_ai.py:2142-2158`) dedupes on `tool_call_id`; `_map_event` calls it first from
+`PartStartEvent(ToolCallPart)` with `args={}` (`:2110`) and then from `FunctionToolCallEvent` with
+the authoritative args (`:2120`). With a `tool_call_id` present — the normal case — exactly one
+event is emitted and it carries `input={}`. Real arguments never reach a consumer.
+
+**Do:**
+- Adopt the contract HTN-4 already documented on `AgentEvent`: emit the early signal with
+  `input_pending=True`, emit the authoritative one with `input_pending=False`, and stop letting the
+  first suppress the second. The contract and the consumer rule are already written in
+  `agents/protocol.py`; this is the second backend adopting them rather than a new design.
+- `loop.py` already skips provisional events, so correlation needs no further change. Verify that.
+
+**Done when:** a streamed pydantic-ai tool call with a `tool_call_id` yields a resolved event whose
+`input` holds the real arguments, and `web_search` narrates as "Searching the web for {query}"
+rather than "Searching the web".
+
+**Interfaces:** consumes the `input_pending` contract from HTN-4. Exposes nothing new.
+**Deps:** HTN-4 (merged or not — the contract is what matters). **PRs:** 1 — pocketpaw.
+
+---
+
+## HTN-10 — provider-side web tools currently narrate nothing at all · ~1.5 agent-hrs
+
+**Slice:** a web search that runs at the provider (the LiteLLM path) produces a status line.
+
+**Why this exists:** `pydantic_ai_native_web_tools` (`config.py:714`, default `False`) registers
+`WebSearch(local=<our WebSearchTool>)` so the model's native search runs provider-side
+(`pydantic_ai.py:1592-1626`). pydantic-ai 2.18 surfaces those calls as `NativeToolCallPart` /
+`NativeToolReturnPart`, which are **siblings** of `ToolCallPart` under `BaseToolCallPart`, not
+subclasses — verified, `issubclass(NativeToolCallPart, ToolCallPart)` is `False`. `_map_event`
+tests `isinstance(part, ToolCallPart)` at `:2107` and imports neither native type, so a
+provider-side search emits **no `tool_use` and no `tool_result` at all**. The UI holds on
+"Thinking…" for the whole search.
+
+**Do:**
+- Handle `NativeToolCallPart` / `NativeToolReturnPart` in `_map_event`, mapping them to `tool_use`
+  and `tool_result` with the same `input_pending` discipline as HTN-9.
+- Check what the native part actually names the tool. If the provider's name differs from our
+  `web_search`, narration lookup must reconcile the two — this interacts directly with HTN-2's
+  identity work, so do them in that order or share the resolution.
+- Decide and document whether a provider-executed call should be visually distinguishable from a
+  locally executed one. They have different privacy properties: the query leaves for the provider.
+
+**Done when:** with `pydantic_ai_native_web_tools=True`, a search emits a narrated `tool_use`, and a
+test pins that native parts are not silently dropped.
+
+**Interfaces:** consumes HTN-9's contract adoption and HTN-2's identity resolution.
+**Deps:** HTN-9, and HTN-2 if the provider's tool name differs. **PRs:** 1 — pocketpaw.
+
+---
+
+**Total:** ~14.5 agent-hours across 10 tasks and 13 PRs (was ~12.5/8/11 before HTN-9 and HTN-10).
 
 This exceeds the PRD's ~11-hour estimate by ~1.5h: the HTN-0 spike is new (the PRD carried those
 questions as open rather than costed), and the cross-repo tasks each carry a second PR's overhead.

--- a/docs/design/2026-08-15-humanized-tool-narration-tasks.md
+++ b/docs/design/2026-08-15-humanized-tool-narration-tasks.md
@@ -274,6 +274,36 @@ test asserting the derived phrasing for a sample of unannotated tools; `statusMa
 
 ## HTN-3 — The builtin surface speaks in the product's voice · ~2 agent-hrs
 
+> **⚠ Re-price this task before running it. Measured 2026-08-15, after HTN-2's seam landed.**
+>
+> HTN-2 anchors the live `ToolRegistry` on the agent's `ToolPolicy`, reachable via
+> `tool_bridge.narration_registry_for(backend)`. That works for the **four** backends whose tools
+> go through the bridge — `build_openai_function_tools`, `build_adk_function_tools`,
+> `build_deep_agents_tools`, `build_pydantic_ai_tools` (`tool_bridge.py:310, 436, 525, 577`).
+>
+> **`claude_agent_sdk` — the shipped default (`config.py:409`) — is NOT one of them.** It never
+> references `tool_bridge`; it surfaces tools over MCP via `build_inprocess_mcp_toolsets`
+> (`tool_bridge.py:816`), which does not build or retain a registry. So on the default backend
+> there is no registry to resolve, and a tool's **declared** `Narration` is unreachable.
+>
+> **What that means for this task:** hand-authoring ~100 `Narration` declarations buys hand-written
+> phrasing on pydantic-ai, openai_agents, google_adk and deep_agents — and buys **nothing** for
+> default-config users, who fall through to the override table and derive-from-name. Derive-from-name
+> is decent ("Publishing the site", not `using pocketpaw_sites_publish`), so the floor is fine; the
+> question is whether ~2 agent-hours of hand-written product voice is worth it while the default
+> backend cannot see it.
+>
+> **Cheaper orderings to consider first:**
+> - Extend the seam to `build_inprocess_mcp_toolsets` so the default backend resolves a registry
+>   too. Probably small, since the pattern now exists — this is the highest-leverage follow-up in
+>   the whole plan and should be scoped before HTN-3.
+> - Or grow the **override table** for the top tools by call volume, which reaches every backend
+>   including the default, and defer per-tool declarations until the seam covers MCP.
+>
+> This does not invalidate HTN-2 — the seam is what rescues the builtin `web_search` on bridged
+> backends, and the security argument for `safe_args` living on the tool is unchanged. It re-prices
+> HTN-3 only.
+
 **Slice:** hand-quality phrasing across all builtin tools, replacing derived phrasing tool by tool.
 
 **Do:**

--- a/docs/design/2026-08-15-humanized-tool-narration-tasks.md
+++ b/docs/design/2026-08-15-humanized-tool-narration-tasks.md
@@ -1,0 +1,320 @@
+<!-- Local task breakdown — humanized tool narration + normalized agent plan surface.
+     Created 2026-08-15. Stage ③ (kept LOCAL, not filed in any repo).
+     Source: docs/design/2026-08-15-humanized-tool-narration-prd.md
+     Vertical slices, dependency-ordered. Next: /paw-execute. -->
+
+# Humanized tool narration — Tasks (local, not filed)
+
+Vertical slices from the PRD's 9 build chunks. The PRD's chunks were layered
+(bridge → contract → frontend); they are re-cut here by shippable outcome, so the first
+merge puts a real humanized phrase on a real screen instead of landing plumbing nobody can see.
+
+**Global Constraints** (verbatim from the PRD — no task re-litigates these):
+
+1. **Target branch:** all pocketpaw work branches from and targets `dev`. paw-enterprise work
+   targets its own default branch. Never push to `main`.
+2. **Worktree isolation is mandatory.** Any agent running `git checkout -b`, committing, or
+   pushing gets its own worktree. pocketpaw and paw-enterprise are separate repos and get
+   separate worktrees.
+3. **Never merge on green.** Open the PR, report the URL, stop. The captain merges.
+4. **Argument interpolation is a security boundary.** No tool argument is ever rendered into
+   narration unless it is named in that tool's `safe_args` allowlist. This is enforced by test,
+   not by review. Any chunk touching narration rendering is security-relevant.
+5. **Backward compatibility on the wire.** The existing `tool` field in `AgentToolUse.data` stays
+   populated. All new fields are additive so an older client keeps working.
+6. **`topics.gen.ts` is generated.** Never hand-edit; regenerate via
+   `uv run python backend/scripts/gen_topics.py`.
+7. **Glossary bindings:** Pocket = workspace container; Connector = workspace-scoped integration;
+   Ripple = generative UI layer; Instinct = decision pipeline. No LLM-default readings.
+8. **Docs in the same PR** as the behavior they describe.
+9. **`/humanize` every PR title and body** before opening.
+
+**Critical path:** HTN-0 → HTN-1 → HTN-5 → HTN-6.
+
+```
+HTN-0 ─▶ HTN-1 ─┬─▶ HTN-2 ─▶ HTN-3 ─▶ HTN-8
+                │
+                ├─▶ HTN-5 ─▶ HTN-6
+                │             ▲
+                ├─▶ HTN-7     │
+                │             │
+                └─▶ HTN-4 ────┘
+```
+
+**Cross-repo note:** HTN-1 and HTN-5 each span pocketpaw and paw-enterprise, so each ships **two
+PRs** — backend first, frontend second, sequenced not stacked (separate repos). The slice is still
+vertical: the unit of *value* is the visible phrase, not the layer.
+
+---
+
+## HTN-0 — Resolve the two sequencing unknowns · ~0.5 agent-hrs
+
+**Slice:** the answers that decide whether HTN-4 is release-blocking and whether `seq` is
+load-bearing. Cheap to run, expensive to guess wrong.
+
+**Do:**
+- Run a real chat turn on the default config and capture which `claude_sdk.py` path emits the
+  `tool_use` event — the streaming path (`:3160`, `"input": {}`) or the block path (`:3251`,
+  real args). This decides whether HTN-4 blocks the release or is a follow-up.
+- Capture a live `TodoWrite` payload from that same run — HTN-6's normalizer must be written
+  against a real payload, not an inferred one.
+- Read the realtime delivery path and record whether per-run event ordering is guaranteed. If it
+  is, `seq` in HTN-5 is belt-and-braces; if not, it is load-bearing.
+
+**Done when:** a short findings note is appended to the PRD's Open questions section with the
+captured `TodoWrite` payload pasted verbatim, and each of the three questions is marked resolved
+with its answer. No code changes.
+
+**Interfaces:**
+- exposes: the real `TodoWrite` wire payload (consumed by HTN-6); a yes/no on ordering guarantees
+  (consumed by HTN-5); a yes/no on whether the streaming path is live (re-prioritizes HTN-4)
+- consumes: nothing
+
+**Deps:** none.
+
+---
+
+## HTN-1 — One tool narrates, end to end · ~2.5 agent-hrs
+
+**Slice:** a real `web_search` call renders as **"Searching the web for *quarterly filings*"** in
+chat. The whole path proven on one tool before it is widened to a hundred.
+
+**Do:**
+- `src/pocketpaw/tools/narration.py` (new): the `Narration` frozen dataclass
+  (`active` / `bare` / `safe_args`) and `render(narration, args) -> str`. Rendering rules:
+  only `safe_args` fields interpolate; a missing/empty/redacted safe arg falls back to `bare`;
+  values are newline-stripped and truncated to 80 chars.
+- `src/pocketpaw/tools/protocol.py`: optional `narration` property on `BaseTool`, default `None`,
+  alongside `trust_level`.
+- Annotate **one** tool — `web_search` — as the reference implementation.
+- `ee/.../cloud/shared/agent_bridge.py:582`: extract `metadata["input"]` alongside the tool name,
+  render narration server-side, add a `narration` field to `AgentToolUse.data`. Keep `tool`
+  populated (Global Constraint 5).
+- `paw-enterprise/src/lib/core/chat/store.svelte.ts:706`: render `data.narration` when present,
+  falling through to the existing behavior when absent. **Do not delete the `statusMap` yet** —
+  it is the fallback until HTN-2 lands.
+- Tests: renderer unit tests including the redaction and truncation paths; a bridge test asserting
+  args survive and `narration` is populated.
+
+**Done when:** a live `web_search` turn shows the interpolated phrase in chat, and a bridge test
+asserts the emitted `AgentToolUse.data.narration` equals `"Searching the web for quarterly filings"`.
+
+**Interfaces:**
+- exposes: `Narration` dataclass and `render()` (consumed by HTN-2, HTN-3); `BaseTool.narration`
+  property (consumed by HTN-3); `AgentToolUse.data.narration` wire field (consumed by HTN-7);
+  tool arguments surviving the bridge (consumed by HTN-5)
+- consumes: `AgentEvent.metadata["input"]` as already emitted by `pydantic_ai.py:2156`
+
+**Deps:** HTN-0.
+**PRs:** 2 — pocketpaw (backend), then paw-enterprise (render).
+
+---
+
+## HTN-2 — The unannotated tail stops showing raw identifiers · ~1 agent-hr
+
+**Slice:** every tool that declares nothing still reads like English.
+`pocketpaw_sites_publish` → "Publishing the site", not `using pocketpaw_sites_publish`.
+
+**Do:**
+- Derive-from-name fallback in `narration.py`: strip vendor prefix, verb-first via a small
+  deterministic lexicon (`publish`→Publishing, `create`→Creating, `search`→Searching,
+  `invite`→Inviting, `delete`→Deleting, `update`→Updating, `list`→Listing, `send`→Sending).
+  No LLM at runtime.
+- Override registry for MCP and connector tools, which cannot self-declare.
+- Fallback order: declared `Narration` → override registry → derive-from-name → `using <name>`.
+- **Delete the 9-entry `statusMap`** at `store.svelte.ts:709` — the server now covers every case
+  it did, and more.
+- Tests: a table test over representative real tool names from the MCP and connector surfaces.
+
+**Done when:** no tool in the top-20-by-call-volume renders a raw snake_case identifier, with a
+test asserting the derived phrasing for a sample of unannotated tools; `statusMap` is gone.
+
+**Interfaces:**
+- exposes: the complete fallback chain (relied on by HTN-3 as the baseline it improves on)
+- consumes: `render()` and the `Narration` contract from HTN-1
+
+**Deps:** HTN-1.
+**PRs:** 2 — pocketpaw (fallback), paw-enterprise (`statusMap` deletion).
+
+---
+
+## HTN-3 — The builtin surface speaks in the product's voice · ~2 agent-hrs
+
+**Slice:** hand-quality phrasing across all builtin tools, replacing derived phrasing tool by tool.
+
+**Do:**
+- Run the seeded pass: a model drafts `Narration` for every builtin tool across the ~48 modules
+  under `src/pocketpaw/tools/builtin/`, including a proposed `safe_args` per tool.
+- **A human reviews the entire diff for voice and for allowlist correctness before commit.** The
+  allowlist review is the security-relevant half and cannot be skimmed — see Global Constraint 4.
+- Mechanical test: every builtin tool declares `Narration`, and every template references only
+  fields named in that tool's `safe_args`. A template referencing a non-allowlisted field fails
+  the suite rather than leaking at runtime.
+
+**Done when:** the test passes with zero exemptions, and the reviewer has signed off on the diff.
+
+**Interfaces:**
+- exposes: annotated tools (no new contract); the mechanical test (guards HTN-8)
+- consumes: `BaseTool.narration` from HTN-1; the fallback chain from HTN-2 as the pre-existing baseline
+
+**Deps:** HTN-1, HTN-2.
+**PRs:** 1 — pocketpaw. Large but mechanical diff; review is the real cost.
+
+---
+
+## HTN-4 — Narration works on the default backend · ~1.5 agent-hrs
+
+**Slice:** `claude_agent_sdk` — the shipped default — carries tool arguments through its streaming
+path, so narration and the plan panel are not pydantic-ai-only features.
+
+**Do:**
+- `src/pocketpaw/agents/claude_sdk.py`: accumulate `input_json_delta` fragments (currently handled
+  nowhere in the file) and emit the `tool_use` event on `content_block_stop` with the assembled
+  input, replacing the hardcoded `"input": {}` at `:3160`.
+- Leave the block path at `:3251` untouched — it already passes real args and is the reference
+  behavior to match.
+- Tests: a streaming fixture with a multi-fragment tool input asserting the assembled args match
+  the block path's output for the same call.
+
+**Done when:** a streamed default-backend turn emits `tool_use` with populated `input`, and the
+streaming and block paths produce identical metadata for an equivalent call.
+
+**Interfaces:**
+- exposes: populated `metadata["input"]` on the streaming path (consumed by HTN-6, and by HTN-1's
+  bridge rendering for default-backend users)
+- consumes: nothing new
+
+**Deps:** HTN-0 (which confirms whether this path is actually live, and therefore whether this
+task is release-blocking or a follow-up).
+**PRs:** 1 — pocketpaw. **Highest-risk task in the set:** streaming assembly in a 3000-line module.
+Keep it alone in its PR.
+
+---
+
+## HTN-5 — The plan appears and mutates in place · ~3 agent-hrs
+
+**Slice:** on pydantic-ai, the agent's `write_plan` output renders as a pinned panel that updates
+as steps complete, with the current narration line as the sub-line of the `in_progress` item.
+
+**Do:**
+- `ee/.../cloud/_core/realtime/events.py`: add `AgentPlanUpdated` (`agent.plan_updated`) near
+  `AgentToolUse` (`:382`).
+- Regenerate topics: `uv run python backend/scripts/gen_topics.py` (Global Constraint 6).
+- `ee/.../cloud/_core/realtime/audience.py:194`: broadcast the new topic.
+- Normalizer for `write_plan` → the canonical shape: `{group_id, agent_id, run_id, seq, items:
+  [{id, content, status}], progress: {completed, total}}`, status enum
+  `pending|in_progress|completed|cancelled`.
+- Bridge: route plan tools to the normalizer and emit `agent.plan_updated`; emit only on actual
+  change (hash the item list) to absorb `write_plan` firing at both the start and end of each step.
+- Per-run monotonic `seq`; the frontend ignores any event with a lower `seq` than the one it holds.
+- paw-enterprise: the pinned panel. **Replaces state wholesale, never merges** — whole-list
+  replacement is inherited from `write_plan`'s own semantics. Not chat messages: a plan re-printed
+  per update is what makes transcripts unreadable.
+
+**Done when:** a multi-step pydantic-ai turn shows the plan populating and ticking through
+`in_progress` → `completed` in place, with no duplicate panels and no flicker on repeated
+identical `write_plan` calls.
+
+**Interfaces:**
+- exposes: the `agent.plan_updated` event contract and the normalizer registry (consumed by HTN-6);
+  the panel component (extended by HTN-6 only in that it gains more sources)
+- consumes: tool arguments surviving the bridge (HTN-1); the ordering answer from HTN-0
+
+**Deps:** HTN-1, HTN-0.
+**PRs:** 2 — pocketpaw (event + normalizer), then paw-enterprise (panel).
+
+---
+
+## HTN-6 — The plan works on every backend · ~1 agent-hr
+
+**Slice:** the panel populates for default-config users and deep_agents users, not just pydantic-ai.
+
+**Do:**
+- Normalizer for `TodoWrite` (claude_agent_sdk) written against the **payload captured in HTN-0**,
+  not an inferred shape.
+- Normalizer for `write_todos` (deep_agents) — three states; `cancelled` simply never emitted.
+- Tests: one fixture per backend asserting all three normalize to a byte-identical canonical event
+  for an equivalent plan.
+
+**Done when:** the same three-step plan produces the same canonical event from all three backends,
+and the panel is verified live on the default backend.
+
+**Interfaces:**
+- exposes: full backend coverage of the plan surface
+- consumes: the normalizer registry and event contract from HTN-5; the captured payload from HTN-0;
+  populated streaming args from HTN-4
+
+**Deps:** HTN-5, HTN-4, HTN-0.
+**PRs:** 1 — pocketpaw.
+
+---
+
+## HTN-7 — Mission Control's ticker uses the same narration · ~0.5 agent-hrs
+
+**Slice:** the second ad-hoc narration implementation is retired, so operators and end users see
+one consistent phrasing.
+
+**Do:**
+- `ee/.../cloud/activity/buffer.py::_summarise()`: prefer the `narration` field; retire the
+  field-fishing chain (`summary` → `message` → `tool` → `tool_name` → `thought` → `name`).
+- **Verify the live ticker rather than assuming narration is strictly better there** — operator
+  phrasing needs are not identical to end-user phrasing needs.
+- While in the file: correct the `:174` docstring, which claims the bus emits `agent.tool_start`.
+  It is emitted nowhere (confirmed 2026-08-15).
+
+**Done when:** the ticker renders narration for tool events, and a before/after comparison on a
+real run shows no operator-facing regression.
+
+**Interfaces:**
+- exposes: nothing new
+- consumes: `AgentToolUse.data.narration` from HTN-1
+
+**Deps:** HTN-1.
+**PRs:** 1 — pocketpaw.
+
+---
+
+## HTN-8 — Security audit of the interpolation path · ~0.5 agent-hrs
+
+**Slice:** independent confirmation that no argument path can leak a credential into a transcript
+or a channel adapter.
+
+**Do:**
+- `security-auditor` review of the full path against the 7-layer stack: `safe_args` enforcement,
+  the truncation and newline-stripping rules, the derive-from-name fallback (which must never
+  interpolate anything), and the override registry.
+- Adversarial cases specifically: `shell`, `pip_install`, and the connector tools — the three
+  families whose arguments most plausibly carry secrets.
+
+**Done when:** the auditor signs off, or files findings that are fixed and re-reviewed.
+**This task gates merge of the narration feature** (Global Constraint 4).
+
+**Interfaces:**
+- exposes: sign-off
+- consumes: the complete annotated surface from HTN-3
+
+**Deps:** HTN-3.
+**PRs:** review only — findings, if any, land as fixes on the relevant task's branch.
+
+---
+
+**Total:** ~12.5 agent-hours across 8 tasks and 11 PRs.
+
+This exceeds the PRD's ~11-hour estimate by ~1.5h: the HTN-0 spike is new (the PRD carried those
+questions as open rather than costed), and the cross-repo tasks each carry a second PR's overhead.
+Recorded here rather than quietly absorbed.
+
+**First shippable outcome:** HTN-0 → HTN-1 (~3h) puts a real humanized phrase on a real screen.
+**First broadly useful outcome:** + HTN-2 (~4h) — every tool reads as English, no annotations needed.
+
+**Out of scope (deferred, from the PRD's non-goals):**
+- i18n and per-surface phrasing — `Narration` is structured so these are additive later
+- Pocket-level narration overrides
+- The planner MCP's `todos[]` build brief (`ee/.../mcp_servers/planner.py:528`) — different lifecycle
+- Plan persistence and historical replay — plans stay per-run and in-memory
+- Restructuring Mission Control or the Instinct decision feed
+- Deleting the dead `AgentToolStart` event — unrelated cleanup, would widen blast radius
+
+**Build location:** pocketpaw → `dev` (worktree `D:/paw-worktrees/humanized-tools`, branch
+`feat/humanized-tool-narration`). paw-enterprise → its own default branch, **separate worktree
+required** per Global Constraint 2.

--- a/docs/design/2026-08-15-humanized-tool-narration-tasks.md
+++ b/docs/design/2026-08-15-humanized-tool-narration-tasks.md
@@ -149,6 +149,34 @@ asserts the emitted `AgentToolUse.data.narration` equals `"Searching the web for
 > **The real fix is threading the agent's actual `ToolRegistry` through to the bridge.** That is
 > this task's central design problem, not the verb lexicon.
 >
+> **From the HTN-1 security review, 2026-08-15 — three things this task inherits:**
+>
+> - **Read the narration off the live instance; never construct a tool to read a property.**
+>   The registry already stores live instances (`tools/registry.py:47,52,61-63`), so use
+>   `registry.get(name).narration`. HTN-1's `narration_for_tool` instantiates the class, which is
+>   harmless for `WebSearchTool` but does not generalize: `ShellTool.__init__` calls
+>   `get_settings()` (`tools/builtin/shell.py:22`), so a registry-wide version of that pattern
+>   would construct settings — and whatever the credential store does on first load — on the event
+>   loop, purely to phrase a status line.
+>
+> - **[MEDIUM] Narration must key on resolved tool IDENTITY, not the bare wire name.** Today the
+>   lookup is a process-global name→class map with no namespace or ownership check, and
+>   `registry.py:52` (`self._tools[tool.name] = tool`) overwrites silently on collision. On the
+>   codex_cli backend the MCP branch (`agents/codex_cli.py:523-532`) emits the RAW unprefixed MCP
+>   tool name while keeping `server` in a field the bridge never reads — so a user-added MCP server
+>   exposing `web_search(query)` inherits the builtin's phrase, and every group member's ticker
+>   asserts in the product's own voice that the agent is searching the web. Misattribution is the
+>   core failure mode for a feature whose entire job is to say what the agent is doing. (On the
+>   default `claude_sdk` backend MCP tools carry `mcp__<server>__<tool>` names, so there it
+>   requires overriding a builtin name in the registry instead.) At minimum, refuse to narrate a
+>   name that is not the builtin registry's own entry.
+>
+> - **Truncate before sanitizing, once large-arg tools are annotated.** HTN-1 sanitizes the full
+>   untruncated value before capping at 80 chars. Negligible for `web_search.query`; it becomes
+>   multi-MB copies per `tool_use` event on the response stream's own task the moment this task or
+>   HTN-3 annotates `shell`'s command, a file write's content, or a connector payload. (A fix is
+>   landing in HTN-1; verify it survived before annotating anything large.)
+>
 > **Sequencing: HTN-2 MUST land before HTN-3.** Until the registry lookup replaces
 > `_ANNOTATED_TOOLS`, every tool HTN-3 annotates is dead code unless someone also hand-adds a line
 > to that map. The dependency order below already reflects this; this note records why.
@@ -321,6 +349,30 @@ real run shows no operator-facing regression.
 ---
 
 ## HTN-8 — Security audit of the interpolation path · ~0.5 agent-hrs
+
+> **A first pass already ran against HTN-1 on 2026-08-15 — verdict SOUND_WITH_FINDINGS.** The
+> allowlist held against every format-string escape hatch (`{q.__class__}`, `{q[0]}`, `{0}`,
+> `{q!r}`, `{q:>99999999}`, nested specs, malformed and doubled braces); `_template_fields` was
+> judged complete against CPython's own parser, and ANSI/terminal escape injection is genuinely
+> blocked (both the 7-bit `\x1b[` and 8-bit `\x9b` introducers fall inside the stripped ranges).
+> Findings 1-6 were fixed in HTN-1; the tool-identity MEDIUM moved to HTN-2 above.
+>
+> **Two corrections to this plan's stated threat model, from that review:**
+> 1. **Narration does NOT currently reach any channel adapter or the CLI.** It rides one emit, and
+>    `agent.tool_use` scopes its audience to chat-group members only
+>    (`_core/realtime/audience.py:192-202`). The wider blast radius this plan assumed is the design
+>    *intent*, not the current wiring — it becomes true only when a surface actually consumes the
+>    field. Re-audit at that point, not before.
+> 2. **HTN-1 incidentally closed a real pre-existing leak.** The old bridge read `event.content`
+>    first, and on codex_cli that is `f"Running: {item.command}"` — so the ENTIRE shell command was
+>    written to the `tool` field, unbounded and unsanitized, and emitted to every group member
+>    (`agents/codex_cli.py:497-506`, and the same shape at `:511-512` / `:535-536` for file paths
+>    and search queries). Those are the arguments that carry `Authorization: Bearer …` and
+>    `export …_KEY=`. That field is now just `"shell"`.
+>
+> **What this task still owes:** re-audit once HTN-2/HTN-3 widen the surface from one tool to ~100
+> and from builtins to MCP/connector tools, and close the layer-5 gap — nothing on this path emits
+> an `AuditEvent`, though narration is the first place tool ARGUMENTS become user-visible.
 
 **Slice:** independent confirmation that no argument path can leak a credential into a transcript
 or a channel adapter.

--- a/docs/design/2026-08-15-humanized-tool-narration-tasks.md
+++ b/docs/design/2026-08-15-humanized-tool-narration-tasks.md
@@ -21,7 +21,18 @@
 
 **Neither PR is merged.** Per the never-merge-on-green gate, both wait on captain review.
 
-### ⚠ Merge order is load-bearing: #1943 before HTN-9
+### ⚠ Merge order for the whole wave: #1943 → #1945 → HTN-5
+
+Two independent constraints chain into one order:
+1. **#1943 before #1945** — see below.
+2. **#1945 before HTN-5 (the plan surface)** — pydantic-ai suppresses tool arguments until #1945
+   lands, so `write_plan` reaches the bridge with `input={}` and the plan surface is **inert**.
+   It is not broken; it has nothing to normalize. HTN-5 ships a fail-open fallback (an
+   unrecognized plan call falls through to the ordinary tool chip) precisely so this window
+   degrades to today's behavior rather than to a silent surface. **Do not verify the plan panel
+   live before #1945 merges — it will look broken and will not be.**
+
+### ⚠ #1943 before HTN-9 (#1945)
 
 HTN-9 makes pydantic-ai emit the provisional + resolved pair, same as HTN-4 did for claude_sdk.
 `loop.py`'s skip of provisional events ships in **#1943 (HTN-4)**. Merge HTN-9 first and `dev` gets
@@ -65,8 +76,20 @@ merge puts a real humanized phrase on a real screen instead of landing plumbing 
    not by review. Any chunk touching narration rendering is security-relevant.
 5. **Backward compatibility on the wire.** The existing `tool` field in `AgentToolUse.data` stays
    populated. All new fields are additive so an older client keeps working.
-6. **`topics.gen.ts` is generated.** Never hand-edit; regenerate via
-   `uv run python backend/scripts/gen_topics.py`.
+6. **`topics.gen.ts` is generated — but the generator is LOSSY. Do not run it bare.**
+   ⚠ **Corrected 2026-08-15.** This constraint originally said "regenerate via
+   `uv run python backend/scripts/gen_topics.py`". Following that instruction **deletes 10 live
+   topics.** Measured by running the script redirected to scratch and diffing against the
+   committed file: it adds the one wanted line and removes `belt_plan`, five `mandate.*` topics
+   and four `meeting.*` topics.
+   **Cause:** `EVENT_REGISTRY` is populated by class-definition side effects, and the classes
+   behind those topics live in `ee/pocketpaw_ee/cloud/mandates/events.py` and
+   `.../meetings/events.py`, which `scripts/gen_topics.py` never imports. So it regenerates from a
+   registry missing a third of its sources. **Pre-existing, unrelated to this work, and worth its
+   own fix.**
+   **Until the generator's imports are fixed:** hand-add the single topic line in sort position and
+   say so in the PR body. A one-line manual edit is strictly safer than a lossy regeneration.
+   If you do run it, run it redirected to scratch and diff before writing anything.
 7. **Glossary bindings:** Pocket = workspace container; Connector = workspace-scoped integration;
    Ripple = generative UI layer; Instinct = decision pipeline. No LLM-default readings.
 8. **Docs in the same PR** as the behavior they describe.

--- a/docs/design/2026-08-15-humanized-tool-narration-tasks.md
+++ b/docs/design/2026-08-15-humanized-tool-narration-tasks.md
@@ -466,6 +466,38 @@ provider-side search emits **no `tool_use` and no `tool_result` at all**. The UI
 **Done when:** with `pydantic_ai_native_web_tools=True`, a search emits a narrated `tool_use`, and a
 test pins that native parts are not silently dropped.
 
+> **There is a THIRD path, and on it narration is impossible from our side.** Checked against the
+> LiteLLM docs 2026-08-15, prompted by the captain running Parallel (parallel.ai) as a LiteLLM
+> search provider.
+>
+> LiteLLM's `websearch_interception` callback resolves web search **inside the proxy**: it detects
+> the model's `litellm_web_search` tool call, executes it against the configured provider
+> (`search_provider: parallel_ai`), makes a follow-up request carrying the results, and returns
+> only the final answer. Its own docs describe the outcome as "One API call from user → Complete
+> answer with search results" — the client never sees the intermediate tool call.
+>
+> So with interception enabled, **no `tool_use` event exists for pocketpaw to narrate**. This is
+> not a mapping bug like HTN-10's native parts; the event genuinely never crosses the wire. HTN-9
+> and HTN-10 cannot fix it, and neither can annotating any tool.
+>
+> **Which path you are on is a config question,** decided by whether `callbacks:
+> ["websearch_interception"]` is set in the LiteLLM config:
+>
+> | LiteLLM config | Tool name pocketpaw sees | Narratable? |
+> |---|---|---|
+> | `websearch_interception` ON | *(nothing — resolved in-proxy)* | **No.** Turn interception off, or surface the search from LiteLLM another way |
+> | Interception OFF, search tool exposed to the model | `litellm_web_search` | Yes, but **not** under the name `web_search` |
+> | Neither; our own `WebSearchTool` via the MCP bridge | `web_search` | Yes — the path HTN-1 annotated |
+>
+> **Two concrete consequences for HTN-2 and HTN-3:**
+> 1. The name is `litellm_web_search`, not `web_search`. HTN-1's `_ANNOTATED_TOOLS` misses it
+>    entirely. HTN-2's derive-from-name fallback should strip a `litellm_` vendor prefix (it
+>    already plans to strip vendor prefixes), which yields "Searching the web" — correct but not
+>    interpolated. Interpolating the query needs an override entry with `safe_args=("query",)`,
+>    since the parameter is `query` per LiteLLM's tool schema.
+> 2. A proxy-executed search has different privacy properties from a local one: the query goes to
+>    Parallel. Worth deciding whether the phrasing should say so rather than implying we searched.
+
 **Interfaces:** consumes HTN-9's contract adoption and HTN-2's identity resolution.
 **Deps:** HTN-9, and HTN-2 if the provider's tool name differs. **PRs:** 1 — pocketpaw.
 

--- a/docs/design/2026-08-15-humanized-tool-narration.md
+++ b/docs/design/2026-08-15-humanized-tool-narration.md
@@ -1,0 +1,247 @@
+<!-- design draft — humanized tool narration + normalized agent plan surface.
+     Created 2026-08-15. Stage ① (paw-brainstorm). Next: /to-prd. Status: DRAFT.
+     Covers two threads that share one root cause: the agent bridge discards tool
+     arguments, so neither narration-with-context nor plan rendering is possible today. -->
+
+# Design: humanized tool narration + a normalized agent plan surface
+
+**Date:** 2026-08-15 · **Size:** L · **Stage:** ① brainstorm → next: `/to-prd`
+**Repos:** pocketpaw (primary), paw-enterprise (render side)
+**Branch:** `feat/humanized-tool-narration` · **Worktree:** `D:/paw-worktrees/humanized-tools`
+
+## Problem
+
+Three user-visible symptoms, one root cause.
+
+1. **Users read raw tool identifiers.** The chat surface renders `using pocketpaw_sites_publish`,
+   `using create_pocket`, `using web_search`. The only humanization that exists is a hardcoded
+   9-entry `statusMap` at `paw-enterprise/src/lib/core/chat/store.svelte.ts:709`, keyed on
+   *Claude Agent SDK* tool names (`WebSearch`, `Read`, `Bash`, `Glob`, …). Every PocketPaw-native
+   tool — 48 builtin modules, ~49 bridged MCP tools, the whole connector surface — misses the map
+   and falls through to `using ${tool}`.
+
+2. **The agent's plan is invisible.** The pydantic-ai backend enables the harness `Planning`
+   capability (`src/pocketpaw/agents/pydantic_ai.py:1286`), so the model maintains a real ordered
+   plan via `write_plan`. None of it reaches the UI.
+
+3. **Narration is implemented twice, ad hoc, and neither implementation is right.** Besides the
+   frontend `statusMap`, `ee/pocketpaw_ee/cloud/activity/buffer.py::_summarise()` independently
+   fishes a display string out of the event payload (`summary` → `message` → `tool` → `tool_name`
+   → `thought` → `name`, else the raw event type) to feed Mission Control's ticker. The two do not
+   know about each other and both degrade to raw tool names in the common case.
+
+**Root cause.** `ee/pocketpaw_ee/cloud/shared/agent_bridge.py:582` extracts only the tool *name*
+from the `tool_use` event and **drops the arguments**. Everything downstream is therefore forced
+to author display text from a bare identifier, per surface, after the fact.
+
+- For thread 1 this is why "Searching the web" can never become "Searching the web **for X**".
+- For thread 2 it is fatal: `write_plan`'s entire payload *is* its arguments, so the frontend
+  receives `{"tool": "write_plan"}` and nothing else. No component can render the plan today
+  regardless of how it is written.
+
+Fixing that one seam unblocks both threads. That is why they are one project, not two.
+
+## Orientation findings
+
+**Glossary terms used in their paw meanings:** Pocket (workspace container, not clothing),
+Connector (workspace-scoped data integration), Ripple (generative UI layer), Instinct (decision
+pipeline). No glossary term is used in its LLM-default sense here.
+
+**Prior art in-repo — four plan/todo mechanisms, three incompatible schemas:**
+
+| Source | Where | Shape | States |
+|---|---|---|---|
+| `write_plan` | `pydantic_ai_harness.planning`, enabled at `agents/pydantic_ai.py:1286` | `items: [{content, status}]` | pending, in_progress, completed, **cancelled** |
+| `write_todos` / `read_todos` | `agents/deep_agents.py:533` (langchain `TodoListMiddleware`) | `[{content, status}]` | pending, in_progress, completed |
+| `TodoWrite` | native to `claude_agent_sdk` — the **default** backend (`config.py:409`) | not referenced anywhere in pocketpaw source; passes through untouched | unverified |
+| planner MCP `todos[]` | `ee/.../agent/mcp_servers/planner.py:528` | `{id, label, description, success_criteria[], preconditions[], depends_on[], tags[], estimated_minutes}` | n/a — build brief |
+
+The first three are the same concept with three schemas. The fourth is a different lifecycle
+(a build brief walked by pocket_specialist on "build it") and is a **non-goal** here.
+
+`write_plan` uses **whole-plan replacement** — the model resends the entire ordered list on every
+call, no indices, no deltas. That semantic is a gift: it maps directly onto a mutating pinned
+panel with no diffing and no ordering logic. State lives in a per-run in-memory `PlanState`.
+
+**Event plumbing.** `AgentEvent(type="tool_use")` in `src/pocketpaw/agents/protocol.py` is the
+universal seam — all backends emit it, so one server-side narration layer covers every backend
+*and* every channel adapter (Telegram, Discord, Slack, WhatsApp, CLI), which the current
+frontend-only implementation cannot. `agent.tool_start` and `agent.tool_result` already exist in
+`_core/realtime/events.py` and in the generated topic list; the chat store subscribes to neither.
+
+**Charter alignment.** Two universal principles from
+`docs/roadmap/future-upgrades/engineering-patterns/workspace-charter.md` apply directly:
+mechanical enforcement (a test that fails when a tool lacks narration) beats human review, and one
+canonical reference beats phased propagation. The existing 9-entry `statusMap` is a worked example
+of the failure mode this design exists to prevent.
+
+**External research:** not run. The decision drivers here are all internal (existing schemas, the
+bridge seam, the security property below); no external prior art would change the shape. Flagged
+so a later reader knows it was a deliberate skip, not an oversight.
+
+## Approach (chosen)
+
+**Narrate server-side at the bridge, from tool-declared templates, and normalize every backend's
+plan tool into one canonical event.**
+
+### Why tool-declared over a central registry
+
+A central map was considered and rejected. The deciding argument is not maintainability, it is
+security: **which of a tool's arguments are safe to display is knowledge only the tool has.**
+`shell`, `pip_install`, and the connector tools all accept arguments that can carry credentials,
+tokens, or PII. Rendering `Running curl -H 'Authorization: Bearer sk-…'` into a chat transcript
+publishes a secret to every channel adapter. That allowlist is the same class of knowledge as
+`trust_level`, which already lives on `BaseTool`. Once it must live on the tool, splitting the
+template into a second file buys nothing.
+
+Supporting argument: the central-registry approach has already been tried in this codebase and has
+already rotted. `store.svelte.ts:709` *is* that design at small scale — written for one backend,
+silently wrong for every other since the day a second backend landed, and nothing fails when it is
+incomplete. It just prints the raw name forever.
+
+**Rejected — central registry only:** simpler and reviewable in one pass, but drifts silently and
+cannot hold the security allowlist correctly.
+
+**Rejected — LLM narration on the hot path:** per-call tokens, latency, nondeterministic phrasing,
+and it can confidently describe a tool it has misread. Retained only as a **build-time** seeding
+pass (below).
+
+**Adopted as the authoring mechanism:** a one-time model-drafted pass proposes templates for all
+~100 tools, reviewed by a human as a single diff and committed. This recovers the one real benefit
+of a central file — reading the whole product voice top-to-bottom and making it consistent in one
+sitting — without keeping the central file. No generated line ships unread.
+
+## Design
+
+### Contract 1 — `Narration` (authoring, colocated with the tool)
+
+```python
+@dataclass(frozen=True)
+class Narration:
+    active: str                        # "Searching the web for {query}"
+    bare: str                          # "Searching the web"  (args missing/redacted)
+    safe_args: tuple[str, ...] = ()    # allowlist — ONLY these may interpolate
+```
+
+Exposed as an optional property on `BaseTool` (default `None`), alongside `trust_level`.
+
+**Rendering rules** (one function, server-side):
+
+- Only fields listed in `safe_args` are interpolated. A template referencing a field outside
+  `safe_args` is a **test failure**, not a runtime leak — the check is mechanical.
+- A missing, empty, or redacted safe arg falls back to `bare`.
+- Interpolated values are newline-stripped and truncated (80 chars) before rendering.
+
+**Fallback chain** when a tool declares no narration:
+
+1. Override registry — for MCP and connector tools, which are external and cannot self-declare.
+2. **Derive from name** — strip the vendor prefix, verb-first via a small deterministic lexicon
+   (`publish`→Publishing, `create`→Creating, `search`→Searching, `invite`→Inviting, …), so
+   `pocketpaw_sites_publish` reads *"Publishing the site"* rather than
+   *"using pocketpaw_sites_publish"*. No LLM at runtime.
+3. `using <name>` — the current behavior, as the last resort.
+
+Step 2 is what makes the rollout safe: narration improves **before** all ~100 tools are annotated,
+so a half-finished migration is still a net gain and cannot strand.
+
+`Narration` ships as a structured object from day one even though only three fields are populated,
+so i18n, per-surface phrasing, and Pocket-level overrides become additive fields later rather than
+a breaking change across 48 modules.
+
+### Contract 2 — normalized plan event
+
+New realtime event `agent.plan_updated`:
+
+```json
+{
+  "group_id": "…", "agent_id": "…", "run_id": "…", "seq": 7,
+  "items": [
+    {"id": "1", "content": "Add the database migration", "status": "completed"},
+    {"id": "2", "content": "Wire the endpoint",          "status": "in_progress"}
+  ],
+  "progress": {"completed": 1, "total": 2}
+}
+```
+
+Status enum is the **superset**: `pending | in_progress | completed | cancelled`. Sources with
+three states simply never emit `cancelled`.
+
+One normalizer per source, all producing this shape:
+
+- `write_plan` (pydantic-ai) — direct field map, all four states.
+- `write_todos` (deep_agents) — direct map, three states.
+- `TodoWrite` (claude_agent_sdk) — **wire shape unverified**; see Open questions.
+
+**Whole-list replacement semantics**, inherited from `write_plan`: the frontend *replaces* its
+state, never merges. No diffing, no partial-update ordering bugs. `seq` is a per-run monotonic
+counter so an out-of-order delivery cannot let a stale plan overwrite a fresh one.
+
+### Contract 3 — bridge changes
+
+At `ee/pocketpaw_ee/cloud/shared/agent_bridge.py:582`:
+
+- Extract tool **arguments** alongside the name.
+- If the tool is registered as a plan tool → run its normalizer and emit `agent.plan_updated`.
+- Otherwise → render narration server-side and add a `narration` field to `AgentToolUse.data`.
+- Keep the existing `tool` field populated for backward compatibility.
+
+## Integration points
+
+| Change | File |
+|---|---|
+| Add `AgentPlanUpdated` event | `ee/pocketpaw_ee/cloud/_core/realtime/events.py` (near `AgentToolUse`, :382) |
+| Regenerate topic list | `uv run python backend/scripts/gen_topics.py` → `paw-enterprise/src/lib/core/shared/topics.gen.ts` (generated — do not hand-edit) |
+| Broadcast the new topic | `ee/pocketpaw_ee/cloud/_core/realtime/audience.py:194` |
+| Prefer `narration`, retire field-fishing | `ee/pocketpaw_ee/cloud/activity/buffer.py::_summarise()` |
+| Consume `narration`; **delete** the 9-entry map | `paw-enterprise/src/lib/core/chat/store.svelte.ts:706-720` |
+| New pinned plan panel | paw-enterprise (new component, bound to `agent.plan_updated`) |
+| Channel adapters | no change — narration is server-side, so they inherit it |
+
+The plan panel is a **pinned panel that mutates in place**, not chat messages. A plan re-printed
+on every update is what makes agent transcripts unreadable. The thread-1 narration line renders as
+the sub-line of the currently `in_progress` item: thread 1 answers "what is it doing right now",
+thread 2 answers "where does that sit in the plan". One event contract underneath both, so the two
+indicators cannot disagree on screen.
+
+## Risks & reversal cost
+
+1. **Credential/PII leak through narration.** The central risk. Mitigated by the `safe_args`
+   allowlist plus a mechanical test that every template references only allowlisted fields, and by
+   truncation. **Requires a `security-auditor` pass before merge** — this touches the 7-layer stack.
+2. **Default-backend coverage.** `claude_agent_sdk` is the shipped default and its `TodoWrite`
+   payload is unverified in this codebase. If the normalizer is wrong, the panel is blank for most
+   users while working perfectly in dev on pydantic-ai. Verify against a real payload first.
+3. **Event flood.** `write_plan` is called at the start *and* end of every step, and it resends the
+   whole list each time. Mitigate by emitting only on actual change (hash the item list) and
+   coalescing bursts.
+4. **Ordering.** Whole-list replacement plus out-of-order delivery would let a stale plan overwrite
+   a fresh one. `seq` addresses this, but whether the realtime layer already guarantees per-run
+   ordering is unconfirmed.
+5. **Mission Control regression.** Retiring `_summarise()`'s fallback changes what operators see in
+   the ticker. Check the ticker explicitly rather than assuming narration is strictly better there.
+
+**Reversal cost.** LOW for the bridge and event work — all fields are additive and `tool` stays
+populated, so an old client keeps working. MEDIUM for `BaseTool.narration` across 48 modules,
+though it is optional and additive, so a partial state is valid and revert is per-tool rather than
+all-or-nothing.
+
+## Open questions
+
+1. **What does `claude_agent_sdk` actually put on the wire for `TodoWrite`?** Blocks the
+   default-backend normalizer. Must be captured from a live run, not inferred.
+2. **Does the bridge emit `agent.tool_use`, `agent.tool_start`, or both** for a pydantic-ai run?
+   Both exist in the bus vocabulary and the activity buffer accepts all three; narration must
+   attach to whichever actually fires, or it will be silently absent.
+3. **Does the realtime layer guarantee per-run event ordering?** If yes, `seq` is belt-and-braces;
+   if no, it is load-bearing.
+4. **Who owns the product voice for ~100 templates?** The seeding pass produces the diff; the
+   review pass is a human decision and should be named before the pass runs.
+
+## Non-goals
+
+- i18n and per-surface phrasing (structured `Narration` keeps the door open; not built now).
+- Pocket-level narration overrides.
+- The planner MCP's `todos[]` build brief — different lifecycle, not this surface.
+- Plan persistence or historical replay. Plans stay per-run and in-memory, as `PlanState` is today.
+- Replacing the Instinct decision feed or Mission Control's ticker. This feeds them; it does not
+  restructure them.

--- a/ee/pocketpaw_ee/cloud/shared/agent_bridge.py
+++ b/ee/pocketpaw_ee/cloud/shared/agent_bridge.py
@@ -43,6 +43,13 @@ delivered-artifact collector around ``pool.run`` and drains it into a
 so a group/DM agent that delivers a file persists the structured signal too.
 This path has no run-transport SSE stream, so it emits no ``artifact`` event —
 that applies only to the streaming ``run_core`` path.
+
+Updated 2026-08-15 (HTN-1): the ``tool_use`` branch reads ``event.metadata``
+(name + input) with ``event.content`` as fallback — the precedence ``run_core``
+already uses — and adds an additive ``narration`` field to ``agent.tool_use``
+carrying the tool's plain-language phrase ("Searching the web for quarterly
+filings"). ``tool`` still carries the tool name, so clients keyed on it are
+unaffected; a tool with no ``Narration`` emits no ``narration`` field.
 """
 
 from __future__ import annotations
@@ -449,6 +456,23 @@ def _augment_message_with_attachments(content: str, attachments: list[dict] | No
     return f"{content}\n\nAttached files:\n" + "\n".join(lines)
 
 
+def _narrate_tool_use(tool_name: str, tool_input: dict[str, Any]) -> str | None:
+    """Render a plain-language phrase for a tool call, or None.
+
+    Returns None for any tool that declares no ``Narration`` — narration is
+    decoration, so it must never raise into, or block, the response stream.
+    """
+    if not tool_name:
+        return None
+    try:
+        from pocketpaw.tools.narration import narration_for_tool, render
+
+        return render(narration_for_tool(tool_name), tool_input)
+    except Exception:
+        logger.debug("Tool narration failed for %s", tool_name, exc_info=True)
+        return None
+
+
 async def _run_agent_response(
     agent_id: str,
     group_id: str,
@@ -580,22 +604,40 @@ async def _run_agent_response(
                         )
                     )
             elif event.type == "tool_use":
-                # Notify clients which tool the agent is using
+                # Notify clients which tool the agent is using, and — when the
+                # tool declares a Narration — what it is doing in plain language.
+                #
+                # Precedence matches the SSE path (``chat/runs/run_core.py``):
+                # ``metadata`` first because every backend puts the bare tool
+                # name and the call's args there, while ``content`` carries a
+                # prose string ("Using web_search..."). Reading content first
+                # gave clients that prose as the ``tool`` value, which no
+                # name-keyed client could match.
                 tool_name = ""
-                if isinstance(event.content, dict):
-                    tool_name = event.content.get("tool") or event.content.get("name") or ""
-                elif isinstance(event.content, str):
-                    tool_name = event.content
-                await emit(
-                    AgentToolUse(
-                        data={
-                            "group_id": group_id,
-                            "agent_id": agent_id,
-                            "agent_name": instance.agent_name,
-                            "tool": tool_name,
-                        },
-                    )
-                )
+                tool_input: dict[str, Any] = {}
+                meta = getattr(event, "metadata", None)
+                meta = meta if isinstance(meta, dict) else {}
+                if meta:
+                    tool_name = meta.get("name") or meta.get("tool") or ""
+                    raw_input = meta.get("input")
+                    tool_input = raw_input if isinstance(raw_input, dict) else {}
+                if not tool_name:
+                    if isinstance(event.content, dict):
+                        tool_name = event.content.get("tool") or event.content.get("name") or ""
+                    elif isinstance(event.content, str):
+                        tool_name = event.content
+                payload: dict[str, Any] = {
+                    "group_id": group_id,
+                    "agent_id": agent_id,
+                    "agent_name": instance.agent_name,
+                    "tool": tool_name,
+                }
+                # Purely additive: a tool with no narration emits no field, and
+                # the bridge never invents a fallback phrase.
+                narration = _narrate_tool_use(tool_name, tool_input)
+                if narration:
+                    payload["narration"] = narration
+                await emit(AgentToolUse(data=payload))
             elif event.type == "thinking":
                 await emit(
                     AgentToolUse(

--- a/src/pocketpaw/tools/builtin/web_search.py
+++ b/src/pocketpaw/tools/builtin/web_search.py
@@ -7,6 +7,9 @@
 #   to a LiteLLM gateway gets web search with no second vendor key and no
 #   second egress path. Whatever the operator registered there (parallel_ai,
 #   tinyfish, …) is reachable by name.
+# 2026-08-15 (HTN-1): declares a ``narration`` — the reference implementation
+#   for humanized tool narration, so a search reads as "Searching the web for
+#   quarterly filings" instead of the bare tool name.
 
 import logging
 from typing import Any
@@ -14,6 +17,7 @@ from typing import Any
 import httpx
 
 from pocketpaw.config import get_settings
+from pocketpaw.tools.narration import Narration
 from pocketpaw.tools.protocol import BaseTool
 
 logger = logging.getLogger(__name__)
@@ -41,6 +45,16 @@ class WebSearchTool(BaseTool):
     @property
     def trust_level(self) -> str:
         return "standard"
+
+    @property
+    def narration(self) -> Narration | None:
+        # ``query`` is the only arg safe to show — ``num_results`` is noise, and
+        # anything not listed here can never reach the rendered phrase.
+        return Narration(
+            active="Searching the web for {query}",
+            bare="Searching the web",
+            safe_args=("query",),
+        )
 
     @property
     def parameters(self) -> dict[str, Any]:

--- a/src/pocketpaw/tools/narration.py
+++ b/src/pocketpaw/tools/narration.py
@@ -1,0 +1,176 @@
+# Humanized tool narration — turns a tool call into a plain-language phrase.
+# Created: 2026-08-15 (HTN-1) — surfaces render "using pocketpaw_sites_publish"
+# today because every consumer only ever sees the bare tool NAME. A tool now
+# declares a ``Narration`` (see ``BaseTool.narration``) and the server renders
+# it once, so chat, Mission Control, and every channel adapter inherit the same
+# phrasing instead of each keeping its own hardcoded name->phrase map.
+#
+# The rendering rules here are security boundaries, not style choices: tool
+# arguments are model-authored and frequently carry secrets (api keys, tokens,
+# file contents), so ONLY fields a tool explicitly allowlists in ``safe_args``
+# may ever reach a user-visible string, and only after sanitizing.
+
+from __future__ import annotations
+
+import logging
+import re
+import string
+from dataclasses import dataclass
+from functools import lru_cache
+from importlib import import_module
+from numbers import Number
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Interpolated values are truncated to this many characters (ellipsis included)
+# so a pasted essay in a tool arg can't blow out a status line.
+_MAX_VALUE_LEN = 80
+_ELLIPSIS = "…"
+
+# C0/C1 control characters plus the Unicode line/paragraph separators. Stripped
+# before substitution so an arg can't inject newlines into a status line (or a
+# terminal escape sequence into a channel adapter that writes to a TTY).
+_CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f-\x9f\u2028\u2029]")
+_WHITESPACE_RUN = re.compile(r"\s+")
+
+_FORMATTER = string.Formatter()
+
+
+@dataclass(frozen=True)
+class Narration:
+    """Plain-language phrasing for a tool call.
+
+    ``active`` may interpolate arguments, but ONLY those named in
+    ``safe_args``. ``bare`` carries no arguments at all and is the fallback
+    whenever ``active`` cannot be rendered safely, so it must stand on its own
+    as a complete phrase.
+    """
+
+    active: str  # "Searching the web for {query}"
+    bare: str  # "Searching the web"
+    safe_args: tuple[str, ...] = ()  # allowlist — ONLY these may interpolate
+
+
+def _template_fields(template: str) -> list[str] | None:
+    """Return the plain field names in ``template``.
+
+    Returns ``None`` when the template uses any construct we refuse to render:
+    positional (``{0}``), attribute/index access (``{q.__class__}``,
+    ``{q[0]}``), conversions (``{q!r}``) or format specs (``{q:>999999}``).
+    Those are either escape hatches out of the allowlist or a way to make
+    formatting expensive, and a narration never needs them.
+    """
+    fields: list[str] = []
+    try:
+        parsed = list(_FORMATTER.parse(template))
+    except ValueError:
+        # Malformed template (unbalanced braces) — treat as unrenderable.
+        return None
+    for _literal, field_name, format_spec, conversion in parsed:
+        if field_name is None:
+            continue
+        if conversion is not None or format_spec:
+            return None
+        if not field_name.isidentifier():
+            return None
+        fields.append(field_name)
+    return fields
+
+
+def _sanitize(value: Any) -> str | None:
+    """Coerce an allowlisted arg to a short, single-line string.
+
+    Returns ``None`` when the value is unusable (wrong type, or empty once
+    stripped), which the caller turns into a ``bare`` fallback.
+    """
+    # ``bool`` is an ``int`` subclass, so it would sail through the Number
+    # check and interpolate as "True" — never what a phrase wants.
+    if isinstance(value, bool) or not isinstance(value, str | Number):
+        return None
+    text = value if isinstance(value, str) else str(value)
+    text = _CONTROL_CHARS.sub(" ", text)
+    text = _WHITESPACE_RUN.sub(" ", text).strip()
+    if not text:
+        return None
+    if len(text) > _MAX_VALUE_LEN:
+        text = text[: _MAX_VALUE_LEN - len(_ELLIPSIS)].rstrip() + _ELLIPSIS
+    return text
+
+
+def render(narration: Narration | None, args: dict | None) -> str | None:
+    """Render ``narration`` against a tool call's arguments.
+
+    Returns the active phrase when every field it names is allowlisted and
+    present, the bare phrase when it isn't, and ``None`` when there is no
+    narration to render at all (an unannotated tool).
+    """
+    if narration is None:
+        return None
+
+    bare = (narration.bare or "").strip() or None
+    template = narration.active or ""
+    fields = _template_fields(template)
+    if fields is None:
+        return bare
+    if not fields:
+        # No placeholders — ``active`` is already a literal phrase.
+        return template.strip() or bare
+
+    # A template naming a field outside ``safe_args`` is a programming error.
+    # Fall back rather than interpolate: the whole point of the allowlist is
+    # that an un-vetted field never reaches a user-visible string.
+    allowed = set(narration.safe_args)
+    unlisted = [name for name in fields if name not in allowed]
+    if unlisted:
+        logger.warning(
+            "Narration template %r names non-allowlisted field(s) %s — falling back to bare phrase",
+            template,
+            sorted(set(unlisted)),
+        )
+        return bare
+
+    source = args if isinstance(args, dict) else {}
+    values: dict[str, str] = {}
+    for name in fields:
+        clean = _sanitize(source.get(name))
+        if clean is None:
+            return bare
+        values[name] = clean
+
+    try:
+        return template.format(**values).strip() or bare
+    except (IndexError, KeyError, ValueError):
+        # Every field was validated above, so this is belt-and-braces: a
+        # narration must never be able to break the call it describes.
+        logger.debug("Narration template %r failed to format", template, exc_info=True)
+        return bare
+
+
+# Tool name -> (module, class) for the builtin tools that declare a Narration.
+# Kept explicit rather than walking every builtin so a lookup never imports the
+# world (or an optional dependency) just to phrase a status line. HTN-2 replaces
+# this with the real registry lookup plus the derive-from-name fallback.
+_ANNOTATED_TOOLS: dict[str, tuple[str, str]] = {
+    "web_search": ("pocketpaw.tools.builtin.web_search", "WebSearchTool"),
+}
+
+
+@lru_cache(maxsize=256)
+def narration_for_tool(tool_name: str) -> Narration | None:
+    """Look up the ``Narration`` a builtin tool declares, by tool name.
+
+    Returns ``None`` for any tool that isn't annotated — callers treat that as
+    "no narration", never as a reason to invent one.
+    """
+    target = _ANNOTATED_TOOLS.get(tool_name)
+    if target is None:
+        return None
+    module_path, class_name = target
+    try:
+        tool = getattr(import_module(module_path), class_name)()
+        narration = tool.narration
+    except Exception:
+        logger.debug("Narration lookup failed for tool %r", tool_name, exc_info=True)
+        return None
+    return narration if isinstance(narration, Narration) else None

--- a/src/pocketpaw/tools/narration.py
+++ b/src/pocketpaw/tools/narration.py
@@ -9,12 +9,26 @@
 # arguments are model-authored and frequently carry secrets (api keys, tokens,
 # file contents), so ONLY fields a tool explicitly allowlists in ``safe_args``
 # may ever reach a user-visible string, and only after sanitizing.
+#
+# Updated: 2026-08-15 (HTN-1 security review) —
+#   - strip the whole Cf (format) category, not just C0/C1 controls. Bidi
+#     overrides (U+202A-202E) let attacker text visually cross the trusted
+#     prefix, and zero-width characters (U+200B) are NOT White_Space, so a
+#     zero-width-only value slipped past the empty->bare check.
+#   - ``Narration`` validates itself in ``__post_init__``: ``safe_args=("query")``
+#     (a missing comma) is a ``str``, which ``set()`` explodes into a
+#     per-character allowlist that fails OPEN for single-character fields.
+#   - normalize ``str`` subclasses explicitly rather than relying on ``re.sub``
+#     to copy them, so a hostile ``__format__`` can never reach ``.format()``.
+#   - bound sanitizing work before it starts: truncate to a scan limit first so
+#     a multi-MB tool arg can't drive full-size copies on the event loop.
 
 from __future__ import annotations
 
 import logging
 import re
 import string
+import unicodedata
 from dataclasses import dataclass
 from functools import lru_cache
 from importlib import import_module
@@ -28,11 +42,28 @@ logger = logging.getLogger(__name__)
 _MAX_VALUE_LEN = 80
 _ELLIPSIS = "…"
 
-# C0/C1 control characters plus the Unicode line/paragraph separators. Stripped
-# before substitution so an arg can't inject newlines into a status line (or a
-# terminal escape sequence into a channel adapter that writes to a TTY).
-_CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f-\x9f\u2028\u2029]")
+# Unicode categories replaced with a space before substitution:
+#   Cc — C0/C1 controls: newlines into a status line, terminal escape sequences
+#        into a channel adapter that writes to a TTY.
+#   Cf — format characters. Two distinct attacks live here, which is why the
+#        whole category goes rather than a hand-picked list. Bidirectional
+#        overrides (U+202A-202E, U+2066-2069) make a renderer reorder the run
+#        so attacker text visually crosses the trusted "Searching the web for"
+#        prefix. Zero-width characters (U+200B, U+FEFF, U+00AD) are invisible
+#        but are NOT White_Space, so ``\s`` and ``str.strip()`` both leave them
+#        alone and a zero-width-only value would sail past the empty check and
+#        put a phrase with a blank slot on the wire.
+#   Zl/Zp — line and paragraph separators.
+# Zs (NBSP, ideographic space) is deliberately absent: those ARE White_Space,
+# so the whitespace collapse below already folds them.
+_STRIPPED_CATEGORIES = frozenset({"Cc", "Cf", "Zl", "Zp"})
 _WHITESPACE_RUN = re.compile(r"\s+")
+
+# Sanitizing walks the value character by character and allocates copies, so it
+# is bounded before it starts rather than after. The slack over _MAX_VALUE_LEN
+# absorbs characters that sanitizing removes, so the real cap below still has
+# material to work with.
+_SANITIZE_SCAN_LIMIT = _MAX_VALUE_LEN * 4
 
 _FORMATTER = string.Formatter()
 
@@ -45,11 +76,68 @@ class Narration:
     ``safe_args``. ``bare`` carries no arguments at all and is the fallback
     whenever ``active`` cannot be rendered safely, so it must stand on its own
     as a complete phrase.
+
+    OUTPUT CONTRACT — the rendered phrase is PLAIN TEXT. It is sanitized
+    (control and format characters removed, length capped) but it is NOT
+    escaped for any markup language, and it embeds tool arguments, which are
+    model-authored. Consumers must render it as text: assign it to
+    ``textContent``, never to ``innerHTML``, and never interpolate it into a
+    markdown or HTML template. A channel adapter sending it to Telegram or
+    Slack with a ``parse_mode`` set must escape it for that mode first, or an
+    argument containing ``<``, ``_`` or ``*`` will mangle the message or make
+    the send fail outright.
+
+    Validated on construction: a template that names a field outside
+    ``safe_args`` is a declaration error and raises here rather than silently
+    degrading to ``bare`` at first render.
     """
 
     active: str  # "Searching the web for {query}"
     bare: str  # "Searching the web"
     safe_args: tuple[str, ...] = ()  # allowlist — ONLY these may interpolate
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.active, str) or not isinstance(self.bare, str):
+            raise TypeError("Narration.active and Narration.bare must both be str")
+
+        # ``safe_args=("query")`` — a missing trailing comma, the easy typo in
+        # a one-element tuple — is a plain str, and ``set()`` would turn it into
+        # the per-character allowlist {'q','u','e','r','y'}. That fails closed
+        # for realistic field names but fails OPEN for any single-character
+        # field, so reject the type outright instead of trusting the shape.
+        if isinstance(self.safe_args, str) or not isinstance(self.safe_args, tuple | list):
+            raise TypeError(
+                f"Narration.safe_args must be a tuple of field names, got "
+                f"{type(self.safe_args).__name__!r}. A one-element tuple needs "
+                f'its trailing comma: safe_args=("query",)'
+            )
+        if not all(isinstance(name, str) for name in self.safe_args):
+            raise TypeError("Narration.safe_args entries must all be str")
+        # Normalize list -> tuple so the declared type holds and the frozen
+        # dataclass stays hashable.
+        object.__setattr__(self, "safe_args", tuple(self.safe_args))
+
+        fields = _template_fields(self.active)
+        if fields is None:
+            raise ValueError(
+                f"Narration.active is not a renderable template: {self.active!r}. "
+                "Positional fields, attribute/index access, conversions and "
+                "format specs are all rejected."
+            )
+        unlisted = sorted({name for name in fields if name not in set(self.safe_args)})
+        if unlisted:
+            raise ValueError(
+                f"Narration.active names field(s) {unlisted} that are not in "
+                f"safe_args={tuple(self.safe_args)!r}. Add them to safe_args only "
+                "if they are safe to show a user; otherwise remove them from the phrase."
+            )
+        # ``bare`` is the fallback that must always be renderable on its own, so
+        # it may not carry placeholders — they would reach the wire as literal
+        # braces at exactly the moment interpolation has already failed.
+        if _template_fields(self.bare):
+            raise ValueError(
+                f"Narration.bare must be a complete phrase with no placeholders, got {self.bare!r}"
+            )
 
 
 def _template_fields(template: str) -> list[str] | None:
@@ -78,6 +166,17 @@ def _template_fields(template: str) -> list[str] | None:
     return fields
 
 
+def _strip_invisibles(text: str) -> str:
+    """Replace control and format characters with a space.
+
+    Replaced rather than deleted so words either side of a stripped character
+    don't get silently glued together.
+    """
+    if not any(unicodedata.category(ch) in _STRIPPED_CATEGORIES for ch in text):
+        return text
+    return "".join(" " if unicodedata.category(ch) in _STRIPPED_CATEGORIES else ch for ch in text)
+
+
 def _sanitize(value: Any) -> str | None:
     """Coerce an allowlisted arg to a short, single-line string.
 
@@ -88,9 +187,28 @@ def _sanitize(value: Any) -> str | None:
     # check and interpolate as "True" — never what a phrase wants.
     if isinstance(value, bool) or not isinstance(value, str | Number):
         return None
-    text = value if isinstance(value, str) else str(value)
-    text = _CONTROL_CHARS.sub(" ", text)
+
+    raw = value if isinstance(value, str) else str(value)
+
+    # Bound the work BEFORE the character walk and the copies it makes. A tool
+    # arg can be large by design (a shell command, a file's contents, a
+    # connector payload), and this runs on the response stream's own task.
+    if len(raw) > _SANITIZE_SCAN_LIMIT:
+        raw = raw[:_SANITIZE_SCAN_LIMIT]
+
+    # Normalize a ``str`` SUBCLASS down to an exact ``str``, explicitly. A
+    # subclass can override ``__format__`` (and ``__str__``), and ``.format()``
+    # calls ``__format__`` on its arguments — so a subclass reaching that call
+    # runs model-influenced code. This used to be closed only as a side effect
+    # of ``re.sub()`` copying its input, which a refactor that skipped the
+    # regex would have silently reopened. ``str.__str__`` is the base
+    # implementation, so a subclass override cannot intercept it.
+    text = raw if type(raw) is str else str.__str__(raw)
+
+    text = _strip_invisibles(text)
     text = _WHITESPACE_RUN.sub(" ", text).strip()
+    # Must come after stripping: a value of only zero-width characters is
+    # visually empty but is not White_Space, so this is what catches it.
     if not text:
         return None
     if len(text) > _MAX_VALUE_LEN:
@@ -120,7 +238,12 @@ def render(narration: Narration | None, args: dict | None) -> str | None:
     # A template naming a field outside ``safe_args`` is a programming error.
     # Fall back rather than interpolate: the whole point of the allowlist is
     # that an un-vetted field never reaches a user-visible string.
-    allowed = set(narration.safe_args)
+    #
+    # ``__post_init__`` rejects a str ``safe_args``, but it is not the only way
+    # an instance can exist: ``copy.deepcopy`` and unpickling both rebuild a
+    # dataclass without running it. Re-check here so the character-exploded
+    # allowlist can never fail open, whatever route the instance took.
+    allowed = set() if isinstance(narration.safe_args, str) else set(narration.safe_args)
     unlisted = [name for name in fields if name not in allowed]
     if unlisted:
         logger.warning(
@@ -131,19 +254,23 @@ def render(narration: Narration | None, args: dict | None) -> str | None:
         return bare
 
     source = args if isinstance(args, dict) else {}
-    values: dict[str, str] = {}
-    for name in fields:
-        clean = _sanitize(source.get(name))
-        if clean is None:
-            return bare
-        values[name] = clean
-
+    # The guard covers sanitizing as well as formatting. ``_sanitize`` calls
+    # ``str(value)`` on a model-supplied object, and ``dict.get`` runs
+    # ``__hash__`` / ``__eq__`` — any of which can raise from code we don't
+    # control. Callers must be able to trust the docstring's promise that a
+    # narration cannot break the call it describes; the design routes channel
+    # adapters at ``render`` directly, and those have no blanket catch of their
+    # own the way the agent bridge does.
     try:
+        values: dict[str, str] = {}
+        for name in fields:
+            clean = _sanitize(source.get(name))
+            if clean is None:
+                return bare
+            values[name] = clean
         return template.format(**values).strip() or bare
-    except (IndexError, KeyError, ValueError):
-        # Every field was validated above, so this is belt-and-braces: a
-        # narration must never be able to break the call it describes.
-        logger.debug("Narration template %r failed to format", template, exc_info=True)
+    except Exception:
+        logger.debug("Narration template %r failed to render", template, exc_info=True)
         return bare
 
 

--- a/src/pocketpaw/tools/protocol.py
+++ b/src/pocketpaw/tools/protocol.py
@@ -2,12 +2,16 @@
 # Created: 2026-02-02
 # Updated: 2026-05-21 (#1160) — BaseTool._success / _error now pass results
 # through cap_tool_output() so a noisy tool blob can't flood agent context.
+# Updated: 2026-08-15 (HTN-1) — BaseTool grows an optional ``narration``
+# property so a tool can declare how its call reads in plain language. Defaults
+# to None; see ``pocketpaw.tools.narration``.
 
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Protocol
 
+from pocketpaw.tools.narration import Narration
 from pocketpaw.tools.output_budget import cap_tool_output
 
 
@@ -98,6 +102,16 @@ class BaseTool(ABC):
     def trust_level(self) -> str:
         """Required trust level to use this tool."""
         return "standard"
+
+    @property
+    def narration(self) -> Narration | None:
+        """Plain-language phrasing for a call to this tool.
+
+        Override to give users a readable status line ("Searching the web for
+        quarterly filings") instead of the bare tool name. ``None`` means the
+        tool has no phrasing and callers should not invent one.
+        """
+        return None
 
     @property
     def parameters(self) -> dict[str, Any]:

--- a/tests/cloud/shared/test_agent_bridge_narration.py
+++ b/tests/cloud/shared/test_agent_bridge_narration.py
@@ -1,0 +1,191 @@
+# Bridge-level tests for humanized tool narration (HTN-1).
+# Created: 2026-08-15 — proves a real ``tool_use`` event reaches the wire as
+# "Searching the web for quarterly filings" instead of a bare tool name.
+#
+# The events here use the shape the backends ACTUALLY emit — ``content`` is a
+# prose string ("Using web_search...") and ``metadata`` carries the bare name
+# plus the call's input (see ``agents/claude_sdk.py`` and ``agents/pydantic_ai.py``).
+# Handing the bridge a tidier hand-built event would test the function rather
+# than the surface, and would certify a payload no backend ever produces.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _done_event():
+    return SimpleNamespace(type="done", content="", metadata={})
+
+
+def _tool_use_event(name: str, tool_input: dict):
+    """A ``tool_use`` event shaped exactly like the SDK backends emit one."""
+    return SimpleNamespace(
+        type="tool_use",
+        content=f"Using {name}...",
+        metadata={"name": name, "input": tool_input},
+    )
+
+
+async def _emitted_tool_use(events: list) -> list[dict]:
+    """Drive ``_run_agent_response`` over ``events`` and return the payloads of
+    every ``agent.tool_use`` it emitted."""
+    from pocketpaw_ee.cloud.shared import agent_bridge
+
+    instance = SimpleNamespace(agent_name="Test Agent")
+    pool = MagicMock()
+    pool.get = AsyncMock(return_value=instance)
+    pool.observe = AsyncMock()
+
+    async def fake_run(*_args, **_kwargs):
+        for event in events:
+            yield event
+
+    pool.run = fake_run
+
+    from pocketpaw_ee.cloud.models.message import Message as _RealMessage
+
+    # Beanie isn't initialized in unit tests; stub the history query so the
+    # bridge never reaches a real database. The run yields no text, so the
+    # bridge short-circuits before the persistence branch.
+    to_list_mock = AsyncMock(return_value=[])
+    limit_mock = MagicMock()
+    limit_mock.to_list = to_list_mock
+    sort_mock = MagicMock()
+    sort_mock.limit = MagicMock(return_value=limit_mock)
+    find_mock = MagicMock()
+    find_mock.sort = MagicMock(return_value=sort_mock)
+
+    with (
+        patch("pocketpaw_ee.cloud.shared.agent_bridge.emit", new=AsyncMock()) as m_emit,
+        patch.multiple(
+            _RealMessage,
+            create=True,
+            group=MagicMock(),
+            deleted=MagicMock(),
+            createdAt=MagicMock(),
+        ),
+        patch.object(_RealMessage, "find", MagicMock(return_value=find_mock)),
+        patch("pocketpaw.agents.pool.get_agent_pool", return_value=pool),
+        patch(
+            "pocketpaw_ee.cloud.agents.knowledge.KnowledgeService.search_context",
+            new=AsyncMock(return_value=""),
+        ),
+    ):
+        await agent_bridge._run_agent_response(
+            agent_id="agent-1",
+            group_id="group-1",
+            workspace_id="ws-1",
+            user_message="what were the quarterly filings?",
+            group_members=["user-1"],
+        )
+
+    return [
+        call.args[0].data
+        for call in m_emit.await_args_list
+        if call.args and call.args[0].type == "agent.tool_use"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_web_search_tool_use_carries_a_humanized_narration():
+    """HTN-1's headline behaviour: a real web_search call reaches the wire with
+    a plain-language phrase, and the tool name still rides alongside it."""
+    payloads = await _emitted_tool_use(
+        [
+            _tool_use_event("web_search", {"query": "quarterly filings"}),
+            _done_event(),
+        ]
+    )
+
+    assert len(payloads) == 1, f"expected one agent.tool_use emit, got {payloads}"
+    payload = payloads[0]
+
+    assert payload["narration"] == "Searching the web for quarterly filings"
+    # Additive only — clients keyed on ``tool`` keep working untouched.
+    assert payload["tool"] == "web_search"
+    assert payload["agent_id"] == "agent-1"
+    assert payload["group_id"] == "group-1"
+
+
+@pytest.mark.asyncio
+async def test_unannotated_tool_emits_no_narration_field():
+    """HTN-2 owns the derive-from-name fallback. Until then an unannotated tool
+    stays silent — the bridge must not invent a phrase of its own."""
+    payloads = await _emitted_tool_use(
+        [
+            _tool_use_event("pocketpaw_sites_publish", {"pocket_id": "p1"}),
+            _done_event(),
+        ]
+    )
+
+    assert len(payloads) == 1
+    payload = payloads[0]
+
+    assert payload["tool"] == "pocketpaw_sites_publish"
+    assert payload.get("narration") is None
+
+
+@pytest.mark.asyncio
+async def test_missing_query_degrades_to_the_bare_phrase():
+    """A tool call whose args don't carry the allowlisted field still narrates
+    — just without interpolation."""
+    payloads = await _emitted_tool_use(
+        [
+            _tool_use_event("web_search", {}),
+            _done_event(),
+        ]
+    )
+
+    assert payloads[0]["narration"] == "Searching the web"
+    assert payloads[0]["tool"] == "web_search"
+
+
+@pytest.mark.asyncio
+async def test_secrets_in_tool_input_never_reach_the_wire():
+    """The bridge hands the whole input dict to the renderer, so this is the
+    end-to-end proof that only allowlisted fields survive the trip."""
+    payloads = await _emitted_tool_use(
+        [
+            _tool_use_event(
+                "web_search",
+                {"query": "quarterly filings", "api_key": "sk-live-SUPERSECRET"},
+            ),
+            _done_event(),
+        ]
+    )
+
+    assert payloads[0]["narration"] == "Searching the web for quarterly filings"
+    assert "SUPERSECRET" not in str(payloads[0])
+
+
+@pytest.mark.asyncio
+async def test_event_without_metadata_still_reports_a_tool():
+    """Backwards compatibility: an event carrying only ``content`` (no
+    metadata) keeps falling back to the old content-based extraction."""
+    payloads = await _emitted_tool_use(
+        [
+            SimpleNamespace(type="tool_use", content={"tool": "shell"}, metadata={}),
+            _done_event(),
+        ]
+    )
+
+    assert payloads[0]["tool"] == "shell"
+    assert payloads[0].get("narration") is None
+
+
+@pytest.mark.asyncio
+async def test_thinking_event_is_unchanged():
+    """The thinking branch shares the AgentToolUse wire type and must not have
+    grown a narration field."""
+    payloads = await _emitted_tool_use(
+        [
+            SimpleNamespace(type="thinking", content="pondering", metadata={}),
+            _done_event(),
+        ]
+    )
+
+    assert payloads[0]["tool"] == "thinking"
+    assert "narration" not in payloads[0]

--- a/tests/test_tool_narration.py
+++ b/tests/test_tool_narration.py
@@ -1,0 +1,191 @@
+# Tests for humanized tool narration (HTN-1).
+# Created: 2026-08-15 — locks the rendering contract in
+# ``pocketpaw.tools.narration``. Most of these are security tests, not
+# formatting tests: tool args are model-authored and routinely carry secrets,
+# so the allowlist and the sanitizer are the things that must not regress.
+
+from __future__ import annotations
+
+from pocketpaw.tools.narration import Narration, narration_for_tool, render
+
+SEARCH = Narration(
+    active="Searching the web for {query}",
+    bare="Searching the web",
+    safe_args=("query",),
+)
+
+
+def test_interpolates_an_allowlisted_arg():
+    """The happy path: an allowlisted arg lands in the active phrase."""
+    assert (
+        render(SEARCH, {"query": "quarterly filings"}) == "Searching the web for quarterly filings"
+    )
+
+
+def test_no_narration_renders_nothing():
+    """An unannotated tool produces no narration — never an invented one."""
+    assert render(None, {"query": "anything"}) is None
+
+
+def test_missing_safe_arg_falls_back_to_bare():
+    assert render(SEARCH, {}) == "Searching the web"
+    assert render(SEARCH, None) == "Searching the web"
+
+
+def test_empty_safe_arg_falls_back_to_bare():
+    """Empty / whitespace-only args would render "Searching the web for "."""
+    assert render(SEARCH, {"query": ""}) == "Searching the web"
+    assert render(SEARCH, {"query": "   "}) == "Searching the web"
+
+
+def test_non_scalar_safe_arg_falls_back_to_bare():
+    """Only strings and numbers interpolate — never a dict/list/None repr."""
+    for bad in ({"nested": 1}, ["a", "b"], None, object()):
+        assert render(SEARCH, {"query": bad}) == "Searching the web"
+
+
+def test_bool_safe_arg_falls_back_to_bare():
+    """``bool`` is an ``int`` subclass — it must not slip through as "True"."""
+    assert render(SEARCH, {"query": True}) == "Searching the web"
+
+
+def test_numeric_safe_arg_interpolates():
+    narration = Narration(active="Reading page {page}", bare="Reading", safe_args=("page",))
+    assert render(narration, {"page": 42}) == "Reading page 42"
+
+
+def test_non_allowlisted_field_never_reaches_output():
+    """THE security test: a template may name a field, but only ``safe_args``
+    decides what can be interpolated. A tool author who writes ``{api_key}``
+    into a phrase must get the bare fallback, not a leaked credential."""
+    leaky = Narration(
+        active="Searching {query} with {api_key}",
+        bare="Searching the web",
+        safe_args=("query",),
+    )
+    result = render(leaky, {"query": "filings", "api_key": "sk-live-SUPERSECRET"})
+
+    assert result == "Searching the web"
+    assert "SUPERSECRET" not in result
+    assert "api_key" not in result
+
+
+def test_args_dict_is_never_rendered_wholesale():
+    """No "render whatever args exist" fallback — unreferenced args stay out."""
+    result = render(SEARCH, {"query": "filings", "password": "hunter2", "num_results": 5})
+
+    assert result == "Searching the web for filings"
+    assert "hunter2" not in result
+    assert "num_results" not in result
+
+
+def test_newlines_and_control_chars_are_stripped():
+    """An arg must not be able to inject newlines or escape sequences into a
+    status line that channel adapters write straight to a terminal."""
+    result = render(SEARCH, {"query": "line one\nline two\r\tand\x1b[31m more"})
+
+    assert "\n" not in result
+    assert "\r" not in result
+    assert "\t" not in result
+    assert "\x1b" not in result
+    # Control chars collapse to a single space rather than vanishing, so words
+    # either side of one don't get silently glued together.
+    assert result == "Searching the web for line one line two and [31m more"
+
+
+def test_long_values_are_truncated_to_80_chars():
+    """A pasted essay in a tool arg can't blow out the status line."""
+    result = render(SEARCH, {"query": "x" * 500})
+
+    prefix = "Searching the web for "
+    assert result.startswith(prefix)
+    value = result[len(prefix) :]
+    assert len(value) == 80, f"interpolated value was {len(value)} chars: {value!r}"
+    assert value.endswith("…")
+
+
+def test_value_just_under_the_cap_is_untouched():
+    """Off-by-one guard: exactly 80 chars must not gain an ellipsis."""
+    result = render(SEARCH, {"query": "y" * 80})
+
+    assert result == "Searching the web for " + "y" * 80
+    assert "…" not in result
+
+
+def test_template_without_placeholders_renders_as_is():
+    narration = Narration(active="Thinking it over", bare="Thinking")
+    assert render(narration, {"anything": "ignored"}) == "Thinking it over"
+
+
+def test_format_escape_hatches_fall_back_to_bare():
+    """Attribute/index access, conversions and format specs are all routes
+    around the allowlist (or ways to make formatting expensive). Each must
+    fall back rather than render."""
+    hatches = [
+        "Searching {query.__class__}",
+        "Searching {query[0]}",
+        "Searching {query!r}",
+        "Searching {query:>999999}",
+        "Searching {0}",
+        "Searching {query",  # malformed
+    ]
+    for template in hatches:
+        narration = Narration(active=template, bare="Searching the web", safe_args=("query",))
+        assert render(narration, {"query": "filings"}) == "Searching the web", (
+            f"template {template!r} was rendered instead of falling back"
+        )
+
+
+def test_unrenderable_active_with_no_bare_yields_none():
+    """Nothing safe to say means say nothing — not an empty string."""
+    narration = Narration(active="Searching for {secret}", bare="", safe_args=())
+    assert render(narration, {"secret": "x"}) is None
+
+
+def test_web_search_declares_the_reference_narration():
+    """The one annotated tool (HTN-1's reference implementation)."""
+    from pocketpaw.tools.builtin.web_search import WebSearchTool
+
+    narration = WebSearchTool().narration
+
+    assert narration is not None
+    assert narration.safe_args == ("query",)
+    # The allowlisted arg must be a real parameter of the tool, or the phrase
+    # silently degrades to bare forever.
+    assert "query" in WebSearchTool().parameters["properties"]
+    assert render(narration, {"query": "quarterly filings"}) == (
+        "Searching the web for quarterly filings"
+    )
+
+
+def test_narration_lookup_by_tool_name():
+    assert narration_for_tool("web_search") is not None
+    assert render(narration_for_tool("web_search"), {"query": "filings"}) == (
+        "Searching the web for filings"
+    )
+
+
+def test_unannotated_tool_has_no_narration():
+    """HTN-1 annotates exactly one tool; everything else stays silent until
+    HTN-2 lands the derive-from-name fallback."""
+    assert narration_for_tool("shell") is None
+    assert narration_for_tool("pocketpaw_sites_publish") is None
+    assert render(narration_for_tool("shell"), {"command": "ls"}) is None
+
+
+def test_base_tool_defaults_to_no_narration():
+    from pocketpaw.tools.protocol import BaseTool
+
+    class _Bare(BaseTool):
+        @property
+        def name(self) -> str:
+            return "bare_tool"
+
+        @property
+        def description(self) -> str:
+            return "does nothing"
+
+        async def execute(self, **params):
+            return ""
+
+    assert _Bare().narration is None

--- a/tests/test_tool_narration.py
+++ b/tests/test_tool_narration.py
@@ -221,6 +221,35 @@ def test_no_invisible_characters_survive():
         assert letter in result, f"visible text was lost: {result!r}"
 
 
+def test_emoji_zwj_sequences_split_a_known_accepted_cost():
+    """Stripping the whole Cf category takes U+200D with it, so a multi-person
+    emoji splits into its components: the phrase stays readable but the glyph
+    is no longer joined.
+
+    This is deliberate, and pinned here so it does not get "fixed" by exempting
+    U+200D. Doing that would reopen the zero-width padding bypass for that
+    character — a ZWJ-only value would once again be invisible content that
+    sails past the empty check. Cosmetic degradation in a status line is the
+    cheaper side of that trade.
+    """
+    zwj = "\u200d"
+    woman_technologist = "\U0001f469" + zwj + "\U0001f4bb"
+
+    result = render(SEARCH, {"query": woman_technologist})
+
+    assert result == "Searching the web for \U0001f469 \U0001f4bb"
+    assert zwj not in result
+
+    # Plain emoji, variation selectors and skin-tone modifiers are NOT Cf and
+    # must come through untouched.
+    assert render(SEARCH, {"query": "\U0001f600 recipes"}) == (
+        "Searching the web for \U0001f600 recipes"
+    )
+    assert render(SEARCH, {"query": "\U0001f44d\U0001f3fd"}) == (
+        "Searching the web for \U0001f44d\U0001f3fd"
+    )
+
+
 def test_ordinary_unicode_text_is_preserved():
     """Stripping targets invisibles, not non-ASCII — a real query in Hindi or
     Japanese must still render."""

--- a/tests/test_tool_narration.py
+++ b/tests/test_tool_narration.py
@@ -162,7 +162,12 @@ def test_every_bidi_control_is_stripped():
     """The whole embedding/override/isolate family, not just RLO."""
     for ch in _BIDI_CONTROLS:
         result = render(SEARCH, {"query": f"before{ch}after"})
-        assert ch not in result, f"U+{ord(ch):04X} survived sanitizing"
+        # Assert the whole phrase, not just the character's absence: a broken
+        # implementation that dropped the value entirely would also satisfy
+        # "the control is gone", and that is not the behavior we want here.
+        assert result == "Searching the web for before after", (
+            f"U+{ord(ch):04X} was not stripped cleanly: {result!r}"
+        )
 
 
 def test_zero_width_only_value_falls_back_to_bare():
@@ -179,6 +184,30 @@ def test_each_zero_width_character_alone_falls_back_to_bare():
         )
 
 
+def test_zero_width_padding_never_reaches_the_truncation_cap():
+    """The original bug produced 79 invisible characters plus an ellipsis — the
+    cap fired on content with no visible width at all. The empty check runs
+    against the STRIPPED text, so padding can never get that far, however long
+    it is: past the 80-char cap, and past the sanitize scan limit."""
+    from pocketpaw.tools.narration import _SANITIZE_SCAN_LIMIT
+
+    zwsp = _ZERO_WIDTH[0]
+    for count in (90, _SANITIZE_SCAN_LIMIT + 500, 5_000):
+        assert render(SEARCH, {"query": zwsp * count}) == "Searching the web", (
+            f"{count} zero-width characters did not fall back to bare"
+        )
+
+
+def test_zero_width_padding_around_real_text_is_removed():
+    """Padding must be stripped without taking the real value with it, and
+    without eating into the cap."""
+    zwsp = _ZERO_WIDTH[0]
+    result = render(SEARCH, {"query": zwsp * 200 + "visible" + zwsp * 200})
+
+    assert result == "Searching the web for visible"
+    assert zwsp not in result
+
+
 def test_no_invisible_characters_survive():
     """Blanket guard over the categories the sanitizer promises to remove."""
     hostile = "a\u200bb\u202ec\ufeffd\x00e\u00adf\u2028g"
@@ -186,6 +215,10 @@ def test_no_invisible_characters_survive():
 
     leaked = [ch for ch in result if unicodedata.category(ch) in _INVISIBLE_CATEGORIES]
     assert not leaked, f"invisible characters survived: {[hex(ord(c)) for c in leaked]}"
+    # ...and the visible letters between them are still there, so this can't be
+    # satisfied by an implementation that simply threw the value away.
+    for letter in "abcdefg":
+        assert letter in result, f"visible text was lost: {result!r}"
 
 
 def test_ordinary_unicode_text_is_preserved():

--- a/tests/test_tool_narration.py
+++ b/tests/test_tool_narration.py
@@ -3,8 +3,22 @@
 # ``pocketpaw.tools.narration``. Most of these are security tests, not
 # formatting tests: tool args are model-authored and routinely carry secrets,
 # so the allowlist and the sanitizer are the things that must not regress.
+# Updated: 2026-08-15 (security review) — added coverage for the Cf category
+# (bidi overrides, zero-width characters), declaration-time validation of
+# ``safe_args``, ``str``-subclass normalization, and the bounded sanitize path.
+# Invalid declarations now raise, so the tests that prove ``render`` still
+# fails closed build their Narration through ``_unvalidated``.
+#
+# Invisible characters are written as \uXXXX escapes, never as literals: a
+# literal is unreviewable in a diff, and an editor or tool that rewrites the
+# file can silently mangle it (one became a NUL byte while this file was being
+# written, which broke collection outright).
 
 from __future__ import annotations
+
+import unicodedata
+
+import pytest
 
 from pocketpaw.tools.narration import Narration, narration_for_tool, render
 
@@ -13,6 +27,46 @@ SEARCH = Narration(
     bare="Searching the web",
     safe_args=("query",),
 )
+
+# Categories the sanitizer promises to remove.
+_INVISIBLE_CATEGORIES = {"Cc", "Cf", "Zl", "Zp"}
+
+# Bidi embeddings, overrides and isolates.
+_BIDI_CONTROLS = (
+    "\u202a",  # LRE
+    "\u202b",  # RLE
+    "\u202c",  # PDF
+    "\u202d",  # LRO
+    "\u202e",  # RLO
+    "\u2066",  # LRI
+    "\u2067",  # RLI
+    "\u2068",  # FSI
+    "\u2069",  # PDI
+)
+
+# Invisible but not White_Space.
+_ZERO_WIDTH = (
+    "\u200b",  # ZERO WIDTH SPACE
+    "\u200c",  # ZERO WIDTH NON-JOINER
+    "\u200d",  # ZERO WIDTH JOINER
+    "\ufeff",  # ZERO WIDTH NO-BREAK SPACE / BOM
+    "\u00ad",  # SOFT HYPHEN
+    "\u2060",  # WORD JOINER
+)
+
+
+def _unvalidated(active: str, bare: str, safe_args) -> Narration:
+    """Build a Narration bypassing ``__post_init__``.
+
+    Declaration-time validation is the first line of defense; ``render`` failing
+    closed is the second. These must be tested independently, or a regression
+    that removes the second one goes unnoticed behind the first.
+    """
+    narration = object.__new__(Narration)
+    object.__setattr__(narration, "active", active)
+    object.__setattr__(narration, "bare", bare)
+    object.__setattr__(narration, "safe_args", safe_args)
+    return narration
 
 
 def test_interpolates_an_allowlisted_arg():
@@ -56,13 +110,10 @@ def test_numeric_safe_arg_interpolates():
 
 def test_non_allowlisted_field_never_reaches_output():
     """THE security test: a template may name a field, but only ``safe_args``
-    decides what can be interpolated. A tool author who writes ``{api_key}``
-    into a phrase must get the bare fallback, not a leaked credential."""
-    leaky = Narration(
-        active="Searching {query} with {api_key}",
-        bare="Searching the web",
-        safe_args=("query",),
-    )
+    decides what can be interpolated. Declaration-time validation now rejects
+    this shape outright, so build it unvalidated to prove ``render`` ALSO
+    refuses — the leak must be closed at both layers."""
+    leaky = _unvalidated("Searching {query} with {api_key}", "Searching the web", ("query",))
     result = render(leaky, {"query": "filings", "api_key": "sk-live-SUPERSECRET"})
 
     assert result == "Searching the web"
@@ -93,6 +144,69 @@ def test_newlines_and_control_chars_are_stripped():
     assert result == "Searching the web for line one line two and [31m more"
 
 
+# --- Cf category: bidi overrides and zero-width characters -------------------
+
+
+def test_bidi_override_is_stripped():
+    """A right-to-left override makes a bidi-aware renderer reorder the run, so
+    attacker text can visually cross the trusted "Searching the web for" prefix.
+    Reachable by ordinary indirect prompt injection: a poisoned page leads the
+    agent to search with a bidi-laden query."""
+    result = render(SEARCH, {"query": "\u202egnihton gnitteled"})
+
+    assert "\u202e" not in result
+    assert result == "Searching the web for gnihton gnitteled"
+
+
+def test_every_bidi_control_is_stripped():
+    """The whole embedding/override/isolate family, not just RLO."""
+    for ch in _BIDI_CONTROLS:
+        result = render(SEARCH, {"query": f"before{ch}after"})
+        assert ch not in result, f"U+{ord(ch):04X} survived sanitizing"
+
+
+def test_zero_width_only_value_falls_back_to_bare():
+    """U+200B is category Cf, not White_Space — ``\\s`` and ``str.strip()`` both
+    leave it alone, so before this was stripped the empty->bare check never
+    fired and the wire carried a phrase with a blank slot."""
+    assert render(SEARCH, {"query": "\u200b" * 90}) == "Searching the web"
+
+
+def test_each_zero_width_character_alone_falls_back_to_bare():
+    for ch in _ZERO_WIDTH:
+        assert render(SEARCH, {"query": ch * 10}) == "Searching the web", (
+            f"U+{ord(ch):04X} alone did not fall back to bare"
+        )
+
+
+def test_no_invisible_characters_survive():
+    """Blanket guard over the categories the sanitizer promises to remove."""
+    hostile = "a\u200bb\u202ec\ufeffd\x00e\u00adf\u2028g"
+    result = render(SEARCH, {"query": hostile})
+
+    leaked = [ch for ch in result if unicodedata.category(ch) in _INVISIBLE_CATEGORIES]
+    assert not leaked, f"invisible characters survived: {[hex(ord(c)) for c in leaked]}"
+
+
+def test_ordinary_unicode_text_is_preserved():
+    """Stripping targets invisibles, not non-ASCII — a real query in Hindi or
+    Japanese must still render."""
+    assert render(SEARCH, {"query": "तिमाही रिपोर्ट"}) == "Searching the web for तिमाही रिपोर्ट"
+    assert render(SEARCH, {"query": "四半期報告"}) == "Searching the web for 四半期報告"
+
+
+def test_non_breaking_space_is_folded_not_stripped():
+    """NBSP is category Zs and IS White_Space, so the whitespace collapse folds
+    it to a plain space — it must not reach the wire as a literal U+00A0."""
+    result = render(SEARCH, {"query": "quarterly\u00a0filings"})
+
+    assert result == "Searching the web for quarterly filings"
+    assert "\u00a0" not in result
+
+
+# --- Truncation and bounded work --------------------------------------------
+
+
 def test_long_values_are_truncated_to_80_chars():
     """A pasted essay in a tool arg can't blow out the status line."""
     result = render(SEARCH, {"query": "x" * 500})
@@ -112,34 +226,194 @@ def test_value_just_under_the_cap_is_untouched():
     assert "…" not in result
 
 
-def test_template_without_placeholders_renders_as_is():
-    narration = Narration(active="Thinking it over", bare="Thinking")
-    assert render(narration, {"anything": "ignored"}) == "Thinking it over"
+def test_sanitizing_is_bounded_before_the_cap():
+    """Sanitizing truncates to a scan limit BEFORE walking the value, so work is
+    bounded by the limit rather than by the caller's input size.
+
+    The observable consequence: content past the scan limit cannot influence the
+    result. Here the whole scanned window is whitespace, so the value sanitizes
+    to empty and falls back to bare — if sanitizing still walked the full string
+    it would find "hello" and render it.
+    """
+    from pocketpaw.tools.narration import _SANITIZE_SCAN_LIMIT
+
+    padded = " " * (_SANITIZE_SCAN_LIMIT + 80) + "hello"
+    assert render(SEARCH, {"query": padded}) == "Searching the web"
 
 
-def test_format_escape_hatches_fall_back_to_bare():
-    """Attribute/index access, conversions and format specs are all routes
-    around the allowlist (or ways to make formatting expensive). Each must
-    fall back rather than render."""
-    hatches = [
+def test_very_large_value_renders_capped():
+    """A multi-MB argument must still produce a capped one-line phrase."""
+    result = render(SEARCH, {"query": "z" * 5_000_000})
+
+    prefix = "Searching the web for "
+    assert result.startswith(prefix)
+    assert len(result[len(prefix) :]) == 80
+
+
+# --- Hostile objects ---------------------------------------------------------
+
+
+def test_hostile_str_subclass_never_reaches_format():
+    """``.format()`` calls ``__format__`` on its arguments, so a ``str``
+    subclass reaching it runs model-influenced code. Sanitizing normalizes to an
+    exact ``str`` explicitly; this used to hold only as a side effect of
+    ``re.sub`` copying its input.
+
+    Asserting the fully interpolated phrase matters: if normalization regressed,
+    the override would raise and ``render``'s guard would quietly return ``bare``,
+    so a weaker assertion would still pass.
+    """
+
+    class _Hostile(str):
+        def __format__(self, spec):  # pragma: no cover - must never run
+            raise AssertionError("__format__ override ran")
+
+        def __str__(self):  # pragma: no cover - must never run
+            raise AssertionError("__str__ override ran")
+
+    assert render(SEARCH, {"query": _Hostile("filings")}) == "Searching the web for filings"
+
+
+def test_hostile_number_that_raises_falls_back_to_bare():
+    """``_sanitize`` calls ``str(value)`` on a Number, which can raise from code
+    we don't control. Channel adapters call ``render`` directly and have no
+    blanket catch of their own, so the guard has to cover sanitizing too."""
+
+    class _HostileNumber(int):
+        def __str__(self):
+            raise RuntimeError("boom")
+
+    assert render(SEARCH, {"query": _HostileNumber(5)}) == "Searching the web"
+
+
+def test_hostile_args_mapping_falls_back_to_bare():
+    """Even the lookup can raise — ``args`` is a dict handed in by a caller."""
+
+    class _HostileDict(dict):
+        def get(self, *_args, **_kwargs):
+            raise RuntimeError("boom")
+
+    assert render(SEARCH, _HostileDict()) == "Searching the web"
+
+
+# --- Declaration-time validation --------------------------------------------
+
+
+def test_safe_args_missing_comma_is_rejected():
+    """``safe_args=("query")`` is a str, and ``set()`` explodes it into the
+    per-character allowlist {'q','u','e','r','y'}. HTN-3 hand-authors ~100 of
+    these declarations, which makes this typo close to certain."""
+    with pytest.raises(TypeError, match="trailing comma"):
+        Narration(
+            active="Searching the web for {query}",
+            bare="Searching the web",
+            safe_args=("query"),  # noqa: UP034 - the typo under test
+        )
+
+
+def test_single_character_safe_args_typo_fails_closed():
+    """The fail-OPEN case that motivated the check: with a str ``safe_args``,
+    a single-character field name lands inside the exploded character set and
+    would have been allowlisted by accident."""
+    with pytest.raises(TypeError):
+        Narration(active="Reading page {q}", bare="Reading", safe_args=("q"))  # noqa: UP034
+
+
+def test_str_safe_args_also_fails_closed_at_render():
+    """Second layer for the same typo. ``__post_init__`` rejects a str
+    ``safe_args``, but ``copy.deepcopy`` and unpickling both rebuild a dataclass
+    without running it, so ``render`` must not explode the str into a
+    per-character allowlist either."""
+    single_char = _unvalidated("Reading page {q}", "Reading", "q")
+
+    assert render(single_char, {"q": "secret-value"}) == "Reading"
+
+    multi_char = _unvalidated("Searching the web for {query}", "Searching the web", "query")
+    assert render(multi_char, {"query": "filings"}) == "Searching the web"
+
+
+def test_safe_args_rejects_non_string_entries():
+    with pytest.raises(TypeError):
+        Narration(active="Reading page {page}", bare="Reading", safe_args=(1,))
+
+
+def test_safe_args_accepts_a_list_and_normalizes_to_tuple():
+    narration = Narration(active="Reading page {page}", bare="Reading", safe_args=["page"])
+
+    assert narration.safe_args == ("page",)
+    assert render(narration, {"page": 3}) == "Reading page 3"
+
+
+def test_active_naming_an_unlisted_field_is_rejected_at_declaration():
+    """The leak now fails at declaration rather than degrading silently at first
+    render, where nobody is watching."""
+    with pytest.raises(ValueError, match="api_key"):
+        Narration(
+            active="Searching {query} with {api_key}",
+            bare="Searching the web",
+            safe_args=("query",),
+        )
+
+
+def test_escape_hatch_templates_are_rejected_at_declaration():
+    """Attribute/index access, conversions, format specs and positional fields
+    are all routes around the allowlist (or ways to make formatting expensive)."""
+    for template in (
         "Searching {query.__class__}",
         "Searching {query[0]}",
         "Searching {query!r}",
         "Searching {query:>999999}",
         "Searching {0}",
         "Searching {query",  # malformed
-    ]
-    for template in hatches:
-        narration = Narration(active=template, bare="Searching the web", safe_args=("query",))
+    ):
+        with pytest.raises(ValueError):
+            Narration(active=template, bare="Searching the web", safe_args=("query",))
+
+
+def test_escape_hatch_templates_also_fail_closed_at_render():
+    """Second layer: if such a declaration ever reaches ``render`` anyway, it
+    falls back rather than rendering."""
+    for template in (
+        "Searching {query.__class__}",
+        "Searching {query[0]}",
+        "Searching {query!r}",
+        "Searching {query:>999999}",
+        "Searching {0}",
+        "Searching {query",
+    ):
+        narration = _unvalidated(template, "Searching the web", ("query",))
         assert render(narration, {"query": "filings"}) == "Searching the web", (
             f"template {template!r} was rendered instead of falling back"
         )
 
 
+def test_bare_with_a_placeholder_is_rejected():
+    """``bare`` is the fallback that must always stand alone — a placeholder
+    there reaches the wire as literal braces at exactly the moment
+    interpolation has already failed."""
+    with pytest.raises(ValueError, match="no placeholders"):
+        Narration(active="Searching for {query}", bare="Searching {query}", safe_args=("query",))
+
+
+def test_non_string_active_or_bare_is_rejected():
+    with pytest.raises(TypeError):
+        Narration(active=None, bare="Searching the web")
+    with pytest.raises(TypeError):
+        Narration(active="Searching the web", bare=None)
+
+
+def test_template_without_placeholders_renders_as_is():
+    narration = Narration(active="Thinking it over", bare="Thinking")
+    assert render(narration, {"anything": "ignored"}) == "Thinking it over"
+
+
 def test_unrenderable_active_with_no_bare_yields_none():
     """Nothing safe to say means say nothing — not an empty string."""
-    narration = Narration(active="Searching for {secret}", bare="", safe_args=())
+    narration = _unvalidated("Searching for {secret}", "", ())
     assert render(narration, {"secret": "x"}) is None
+
+
+# --- Tool wiring -------------------------------------------------------------
 
 
 def test_web_search_declares_the_reference_narration():


### PR DESCRIPTION
Users watching an agent work currently read `using pocketpaw_sites_publish`. The only humanized phrasing that existed was a nine-entry lookup table in the Svelte chat store, keyed to Claude Agent SDK tool names, so every PocketPaw-native tool fell through to `using ${tool}`. That is 48 builtin modules, roughly 49 bridged MCP tools, and the whole connector surface.

This moves the phrasing to the server. A tool declares a `Narration` and the bridge renders it once, so chat, Mission Control and any future channel adapter read the same words instead of each keeping a table of its own.

```python
narration = Narration(
    active="Searching the web for {query}",
    bare="Searching the web",
    safe_args=("query",),
)
```

`web_search` is annotated as the reference implementation. A tool without a `Narration` emits no field, and the bridge never invents one.

## Why there is an allowlist

Tool arguments are model-authored and routinely carry credentials. `shell` takes arbitrary commands, `pip_install` takes package specs, and the connector tools carry whatever the integration needs. Only fields named in `safe_args` can be interpolated. A template naming anything else falls back to the bare phrase rather than leaking it, and values are stripped of control characters and capped at 80 characters before substitution. Nothing renders whatever arguments happen to be present.

## It closes a leak that was already there

The bridge used to read `event.content` first. On the codex_cli backend that string is `f"Running: {item.command}"`, so the entire shell command went into the `tool` field, unbounded and unsanitized, out to every member of the group. Edited file paths and search queries had the same shape. That field is now `shell`.

## Security review

Verdict was SOUND_WITH_FINDINGS. The allowlist held against every format-string escape hatch thrown at it, including `{q.__class__}`, `{q[0]}`, `{0}`, `{q!r}` and `{q:>99999999}`.

Six findings are fixed here. Two were confirmed by running them first: a right-to-left override survived into the rendered phrase and could visually rewrite it, and ninety zero-width spaces defeated the empty-value check, because those characters are category `Cf` rather than whitespace. A third was rated low and turned out to be a real bypass once executed. `safe_args=("query")` without the trailing comma is a string, `set()` turns it into a per-character allowlist, and a single-character field then interpolates without ever having been allowlisted. Malformed declarations now raise at construction instead.

Stripping the `Cf` category costs emoji ZWJ sequences, so a woman-technologist renders as a woman and a laptop. Ordinary non-ASCII is unaffected, checked against Japanese, Devanagari and accented Latin. It is recorded in the design doc against the deferred i18n work.

## Left for the next task

Narration binds to the bare tool name with no ownership check. An MCP tool named `web_search` would inherit the builtin's phrase and tell everyone in the group that the agent is searching the web. Misattribution is the whole failure mode for a feature whose only job is saying what the agent is doing, so it is worth fixing properly: the answer is keying on registry identity, which is the next task's central design problem rather than a patch here. `_ANNOTATED_TOOLS` is a one-entry stopgap for the same reason, and should be deleted rather than grown.

## Tests

46 on the narration path, 160 across the surrounding sweep. One pre-existing failure in `test_agent_bridge_emits.py`, which reads a hardcoded `D:/paw/backend/...` path that has not existed since the ee namespace rename. It fails the same way on `dev`.

The branch also carries the design, PRD and task docs for this work, including the two corrections that came out of building it: the SDK arguments were never lost in transit, and narration does not currently reach any channel adapter.
