### PR TITLE
The default backend reported every tool call with empty arguments

### DIFF
--- a/src/pocketpaw/agents/claude_sdk.py
+++ b/src/pocketpaw/agents/claude_sdk.py
@@ -1,5 +1,20 @@
 """
 Claude Agent SDK backend for PocketPaw.
+Updated: 2026-08-15 (HTN-4, feat/claude-sdk-tool-args) — a ``tool_use`` event now
+  reaches consumers carrying the tool's REAL arguments. The stream loop announced
+  a tool twice over: once from the partial ``content_block_start`` (name known,
+  arguments not yet streamed, so ``input={}``) and once from the completed
+  ``AssistantMessage`` (the SDK's fully assembled ``input``). The second was
+  suppressed by an ``_announced_tools`` name guard the first had just populated,
+  so on the DEFAULT backend's streamed path every tool call reached consumers
+  with empty arguments — the announcement won and the truth was dropped. The
+  guard is gone (and with it the set, whose only reader it was): both emissions
+  now go out, distinguished by an additive ``metadata["input_pending"]`` — True
+  on the provisional announcement, False on the resolved one. Two events for one
+  streamed call is intended; consumers render a tool status line they REPLACE, so
+  the resolved event upgrades the display. The non-streaming path (no
+  ``_StreamEvent``, hence no ``include_partial_messages``) never ran the first
+  branch, so it still emits exactly one event per call, as it always did.
 Updated: 2026-08-03 (PA-7b, feat/prompt-assembler-channel) — two things, and the
   first is a docstring that had become false. ``_behavior_prefix`` said PA-7
   would delete it once the channel path produced a digest of its own. The channel
@@ -3110,7 +3125,6 @@ class ClaudeSDKBackend(BaseAgentBackend):
 
             # State tracking for StreamEvent deduplication
             _streamed_via_events = False
-            _announced_tools: set[str] = set()
             _event_count = 0
             _saw_result = False  # Track if ResultMessage was consumed
             # The model that actually answered (from AssistantMessage.model) —
@@ -3153,11 +3167,23 @@ class ClaudeSDKBackend(BaseAgentBackend):
                             cb = raw.get("content_block", {})
                             if cb.get("type") == "tool_use":
                                 tool_name = cb.get("name", "unknown")
-                                _announced_tools.add(tool_name)
+                                # PROVISIONAL announcement. ``content_block_start``
+                                # opens the block before a single argument fragment
+                                # has streamed, so the name is known here and the
+                                # input is not. Emit anyway — a prompt "tool
+                                # started" indicator is the whole reason this
+                                # branch exists — and flag ``input_pending`` so a
+                                # consumer can tell the empty ``input`` is a
+                                # placeholder that the AssistantMessage branch
+                                # below supersedes with the real arguments.
                                 yield AgentEvent(
                                     type="tool_use",
                                     content=f"Using {tool_name}...",
-                                    metadata={"name": tool_name, "input": {}},
+                                    metadata={
+                                        "name": tool_name,
+                                        "input": {},
+                                        "input_pending": True,
+                                    },
                                 )
                         elif event_type == "content_block_stop":
                             if getattr(event, "_block_type", None) == "thinking":
@@ -3239,21 +3265,33 @@ class ClaudeSDKBackend(BaseAgentBackend):
                             if text:
                                 yield AgentEvent(type="message", content=text)
 
+                        # RESOLVED emission. The completed message carries the
+                        # SDK's fully assembled ``input``, and this is the only
+                        # place the real arguments exist — the streamed
+                        # announcement above never has them. It is emitted
+                        # UNCONDITIONALLY: it used to be skipped for any tool the
+                        # streaming branch had already named, which on a streamed
+                        # turn is every tool, so consumers only ever saw
+                        # ``input={}``. A streamed call therefore surfaces twice
+                        # (provisional, then resolved) — correct, because consumers
+                        # REPLACE a tool's status line rather than append to it. On
+                        # the non-streaming path (no ``_StreamEvent``, so no
+                        # ``include_partial_messages``) this branch is the only
+                        # emitter and one call still yields exactly one event.
                         tools = self._extract_tool_info(event)
                         for tool in tools:
-                            if tool["name"] not in _announced_tools:
-                                logger.info(f"🔧 Tool: {tool['name']}")
-                                yield AgentEvent(
-                                    type="tool_use",
-                                    content=f"Using {tool['name']}...",
-                                    metadata={
-                                        "name": tool["name"],
-                                        "input": tool["input"],
-                                    },
-                                )
+                            logger.info(f"🔧 Tool: {tool['name']}")
+                            yield AgentEvent(
+                                type="tool_use",
+                                content=f"Using {tool['name']}...",
+                                metadata={
+                                    "name": tool["name"],
+                                    "input": tool["input"],
+                                    "input_pending": False,
+                                },
+                            )
 
                         _streamed_via_events = False
-                        _announced_tools.clear()
                         continue
 
                     # ========== ResultMessage - final result ==========

--- a/src/pocketpaw/agents/loop.py
+++ b/src/pocketpaw/agents/loop.py
@@ -6,6 +6,17 @@ and streams AgentEvent responses back to channels.
 
 PII scanning before memory storage is opt-in via pii_scan_enabled + pii_scan_memory settings.
 
+Updated: 2026-08-15 (HTN-4, feat/claude-sdk-tool-args) — the ``tool_use`` branch
+correlates ONE pending call per real tool call, not one per event. The claude_sdk
+backend now announces a streamed call twice (provisional when the tool block
+opens, then resolved with the assembled arguments), and this branch appended a
+``pending_tool_calls`` entry per EVENT — so every streamed call left a stale entry
+that ``tool_result``'s name-match never popped, and the ``pop(0)`` fallback then
+handed later results an id belonging to an earlier call. It also published two
+``tool_start`` events per call, the first carrying no real arguments. The branch
+now skips the provisional announcement (``metadata["input_pending"] is True``).
+Backends that never set the flag read None and are untouched.
+
 Updated: 2026-08-03 (PA-7b, feat/prompt-assembler-channel) — the channel turn
 carries its prompt's ``stable_digest`` to the backend. ``_process_message_inner``
 calls ``AgentContextBuilder.assemble_system_prompt`` (which returns the digest
@@ -1444,7 +1455,25 @@ class AgentLoop:
                             except Exception:
                                 logger.debug("Failed to evaluate budget state", exc_info=True)
 
-                    elif etype == "tool_use":
+                    # ``input_pending`` marks a PROVISIONAL announcement: the
+                    # backend knows the tool's name but its arguments are still
+                    # streaming (claude_sdk emits one when the tool block opens,
+                    # then a resolved event with the assembled arguments). Only
+                    # the resolved event may be correlated here — this branch
+                    # appends one pending entry per event, so honouring both
+                    # would leak an entry per call and corrupt every later
+                    # ``tool_call_id`` via the ``pop(0)`` fallback below. It is
+                    # skipped rather than merged because the ``tool_start`` this
+                    # publishes is APPENDED by its consumers (the dashboard
+                    # transparency log and the client activity store both render
+                    # ``params`` as a new row), so a provisional row is a junk
+                    # row with no arguments, not a placeholder that gets
+                    # upgraded. The fast-indicator role the provisional event
+                    # exists for is served on the chat ``tool_use`` path, which
+                    # replaces a status line instead of appending. Backends that
+                    # never set the flag (pydantic_ai, deep_agents, ...) read
+                    # None here and behave exactly as before.
+                    elif etype == "tool_use" and meta.get("input_pending") is not True:
                         tool_name = meta.get("name") or meta.get("tool", "unknown")
                         tool_input = meta.get("input") or meta
                         tool_call_seq += 1

--- a/src/pocketpaw/agents/loop.py
+++ b/src/pocketpaw/agents/loop.py
@@ -1475,7 +1475,18 @@ class AgentLoop:
                     # None here and behave exactly as before.
                     elif etype == "tool_use" and meta.get("input_pending") is not True:
                         tool_name = meta.get("name") or meta.get("tool", "unknown")
-                        tool_input = meta.get("input") or meta
+                        # A tool called with NO arguments reports ``input={}``,
+                        # which is falsy — an ``or meta`` fallback here published
+                        # the whole metadata dict as the call's parameters, so the
+                        # transparency log rendered ``{'input': {}, 'name':
+                        # 'get_system_status'}`` where the arguments belong. No
+                        # backend ever put arguments outside ``input`` (opencode
+                        # omits the key entirely and simply has none to give), so
+                        # the fallback never recovered anything real. Absent or
+                        # malformed now reads as "no arguments", which is true.
+                        tool_input = meta.get("input")
+                        if not isinstance(tool_input, dict):
+                            tool_input = {}
                         tool_call_seq += 1
                         tool_call_id = f"{trace_id}:{tool_call_seq}"
                         pending_tool_calls.append({"id": tool_call_id, "name": tool_name})

--- a/src/pocketpaw/agents/protocol.py
+++ b/src/pocketpaw/agents/protocol.py
@@ -1,4 +1,12 @@
-"""Agent Protocol — core event type and legacy agent interface."""
+"""Agent Protocol — core event type and legacy agent interface.
+
+Updated: 2026-08-15 (HTN-4, feat/claude-sdk-tool-args) — documents the
+``tool_use`` metadata contract, in particular ``input_pending``. Backends differ
+in how many ``tool_use`` events they emit per call (claude_sdk emits a
+provisional announcement then a resolved event; deep_agents dedupes internally
+and emits once), and the rule reconciling them lived only in those backends'
+file headers, where no consumer would find it.
+"""
 
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
@@ -21,6 +29,36 @@ class AgentEvent:
           later native ``resume``. Only emitted when a ``SessionHandle`` is threaded.
         - "error": Error message
         - "done": Agent finished processing
+
+    ``tool_use`` metadata:
+        - ``name`` (str): the tool being invoked.
+        - ``input`` (dict): the arguments it was called with.
+        - ``input_pending`` (bool, optional): whether ``input`` is still
+          provisional. See the contract below.
+
+    The ``input_pending`` contract — ONE tool call may produce MORE THAN ONE
+    ``tool_use`` event:
+
+        - ``input_pending=True`` marks a PROVISIONAL announcement. The backend
+          knows the tool's name but its arguments have not finished arriving, so
+          ``input`` is a placeholder (typically ``{}``) and is NOT the arguments
+          the tool will run with. A resolved event for the same call follows.
+        - ``input_pending=False`` — or the key being ABSENT — marks a RESOLVED
+          event: ``input`` is final. Absent means resolved, so a backend that
+          emits one event per call needs no flag and is correct by default.
+
+    Backends may legitimately do either. ``claude_sdk`` announces a streamed call
+    as it opens (the SDK reveals the name before the argument JSON has streamed)
+    and then emits the resolved event, because that announcement is what makes a
+    "tool started" indicator prompt. ``deep_agents`` instead dedupes on
+    ``tool_call_id`` and emits once, already resolved.
+
+    Consumer rule: if you APPEND per event — a log, an activity feed, a pending
+    list keyed per call — you MUST skip events with ``input_pending is True``, or
+    you will record a phantom call carrying no arguments. If you REPLACE per tool
+    (a status line that gets overwritten), you may render both and let the
+    resolved event upgrade the display. Test ``is True`` rather than truthiness
+    so an unflagged backend keeps behaving as resolved.
     """
 
     type: str

--- a/tests/test_agent_loop_tool_correlation.py
+++ b/tests/test_agent_loop_tool_correlation.py
@@ -1,0 +1,303 @@
+# tests/test_agent_loop_tool_correlation.py
+# Created: 2026-08-15 (HTN-4 follow-up, feat/claude-sdk-tool-args) — pins the
+# correlation contract between the loop's ``tool_start`` and ``tool_result``
+# SystemEvents, now that a streamed claude_sdk call announces itself TWICE.
+#
+# HTN-4 made the claude_sdk backend emit two ``tool_use`` events per streamed
+# call: a provisional one when the tool block opens (``input_pending=True``,
+# arguments not yet streamed) and a resolved one carrying the assembled
+# arguments. The loop appended one ``pending_tool_calls`` entry per EVENT, so
+# each streamed call left a stale entry behind. ``tool_result`` pops the first
+# entry matching by name, so the residue accumulated across a turn and the
+# ``pop(0)`` fallback could hand a later unmatched result an id belonging to an
+# earlier call. It also published two ``tool_start`` events per call, the first
+# with empty ``params`` — and both the dashboard transparency log
+# (frontend/js/features/transparency.js) and the client activity store
+# (client/src/lib/stores/activity.svelte.ts) APPEND those rather than replacing,
+# so the empty one was a visible junk row, not a harmless duplicate.
+#
+# These tests drive ``AgentLoop._process_message`` with a scripted backend event
+# stream and assert on the SystemEvents published to the bus — the correlation is
+# only observable there, since ``pending_tool_calls`` is a local. The harness
+# mirrors ``tests/test_agent_loop.py``.
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from pocketpaw.agents.loop import AgentLoop
+from pocketpaw.agents.protocol import AgentEvent
+from pocketpaw.bus import Channel, InboundMessage
+from pocketpaw.prompt import AssembledPrompt
+
+_STUB_DIGEST = "0123456789abcdef"
+
+_WRITE_ARGS = {"file_path": "/tmp/a.md", "content": "hello"}
+_READ_ARGS = {"file_path": "/tmp/b.md"}
+
+
+# ===========================================================================
+# Event-script helpers — one per shape of backend emission
+# ===========================================================================
+
+
+def _provisional(name: str) -> AgentEvent:
+    """What claude_sdk emits when the tool block opens: name, no arguments."""
+    return AgentEvent(
+        type="tool_use",
+        content=f"Using {name}...",
+        metadata={"name": name, "input": {}, "input_pending": True},
+    )
+
+
+def _resolved(name: str, args: dict) -> AgentEvent:
+    """What claude_sdk emits once the message completes: the real arguments."""
+    return AgentEvent(
+        type="tool_use",
+        content=f"Using {name}...",
+        metadata={"name": name, "input": args, "input_pending": False},
+    )
+
+
+def _unflagged(name: str, args: dict) -> AgentEvent:
+    """What every OTHER backend emits — no ``input_pending`` key at all."""
+    return AgentEvent(
+        type="tool_use",
+        content=f"Using {name}...",
+        metadata={"name": name, "input": args},
+    )
+
+
+def _result(name: str, content: str = "ok") -> AgentEvent:
+    return AgentEvent(type="tool_result", content=content, metadata={"name": name})
+
+
+# ===========================================================================
+# Harness
+# ===========================================================================
+
+
+async def _drive(events: list[AgentEvent]) -> list:
+    """Run one turn whose backend yields ``events``; return the SystemEvents."""
+    bus = MagicMock()
+    bus.consume_inbound = AsyncMock()
+    bus.publish_outbound = AsyncMock()
+    bus.publish_system = AsyncMock()
+
+    memory = MagicMock()
+    memory.add_to_session = AsyncMock()
+    memory.get_session_history = AsyncMock(return_value=[])
+    memory.get_compacted_history = AsyncMock(return_value=[])
+    memory.resolve_session_key = AsyncMock(side_effect=lambda k: k)
+
+    router = MagicMock()
+
+    async def _run(
+        message,
+        *,
+        system_prompt=None,
+        history=None,
+        session_key=None,
+        system_prompt_digest="",
+    ):
+        for ev in events:
+            yield ev
+        yield AgentEvent(type="done", content="")
+
+    router.run = _run
+    router.stop = AsyncMock()
+
+    settings = MagicMock()
+    settings.agent_backend = "claude_agent_sdk"
+    settings.max_concurrent_conversations = 5
+
+    with (
+        patch("pocketpaw.agents.loop.get_message_bus", return_value=bus),
+        patch("pocketpaw.agents.loop.get_memory_manager", return_value=memory),
+        patch("pocketpaw.agents.loop.AgentContextBuilder") as builder_cls,
+        patch("pocketpaw.agents.loop.AgentRouter", return_value=router),
+        patch("pocketpaw.agents.loop.get_settings", return_value=settings),
+        patch("pocketpaw.agents.loop.Settings") as settings_cls,
+    ):
+        builder_cls.return_value.assemble_system_prompt = AsyncMock(
+            return_value=AssembledPrompt(text="System Prompt", stable_digest=_STUB_DIGEST)
+        )
+        settings_cls.load.return_value = settings
+
+        loop = AgentLoop()
+        await loop._process_message(
+            InboundMessage(
+                channel=Channel.CLI,
+                sender_id="user1",
+                chat_id="chat1",
+                content="run a tool",
+            )
+        )
+
+    return [call[0][0] for call in bus.publish_system.call_args_list]
+
+
+def _of_type(system_events, event_type: str) -> list[dict]:
+    return [e.data for e in system_events if e.event_type == event_type]
+
+
+# ===========================================================================
+# 1. One streamed call -> one tool_start, real params, correct correlation
+# ===========================================================================
+
+
+async def test_streamed_call_yields_one_tool_start_with_real_params() -> None:
+    """A streamed call arrives as provisional + resolved. Only the resolved one
+    may become a pending entry, so the turn publishes ONE ``tool_start`` carrying
+    the real arguments, and the result correlates to it."""
+    system_events = await _drive(
+        [
+            _provisional("Write"),
+            _resolved("Write", _WRITE_ARGS),
+            _result("Write"),
+        ]
+    )
+
+    starts = _of_type(system_events, "tool_start")
+    results = _of_type(system_events, "tool_result")
+
+    assert len(starts) == 1, (
+        f"one real call must publish one tool_start, got {len(starts)}: "
+        f"{[s.get('params') for s in starts]}"
+    )
+    assert starts[0]["params"] == _WRITE_ARGS, (
+        "the published tool_start must carry the REAL arguments, not the "
+        f"provisional placeholder — got {starts[0]['params']}"
+    )
+    assert len(results) == 1
+    assert results[0]["tool_call_id"] == starts[0]["tool_call_id"], (
+        "the tool_result must correlate to the tool_start of its own call"
+    )
+    assert results[0]["tool_call_id"], "correlation id must not be empty"
+
+
+# ===========================================================================
+# 2. Multi-tool turn leaves no stale pending entries
+# ===========================================================================
+
+
+async def test_multi_tool_streamed_turn_leaves_no_stale_pending_entries() -> None:
+    """The accumulation test. Two streamed calls to the SAME tool, both resolved
+    by their results, must leave the pending list EMPTY.
+
+    ``pending_tool_calls`` is a local, so residue is probed through the behaviour
+    it drives: a trailing result whose name matches nothing falls back to
+    ``pop(0)``. With an empty list that yields an empty id; with leftovers it
+    yields an id belonging to an earlier call, which is exactly the corruption
+    under test."""
+    system_events = await _drive(
+        [
+            _provisional("Write"),
+            _resolved("Write", _WRITE_ARGS),
+            _result("Write"),
+            _provisional("Write"),
+            _resolved("Write", _READ_ARGS),
+            _result("Write"),
+            # Probe: a result for a call that never started.
+            _result("Ghost"),
+        ]
+    )
+
+    starts = _of_type(system_events, "tool_start")
+    results = _of_type(system_events, "tool_result")
+
+    assert len(starts) == 2, f"two real calls must publish two tool_starts, got {len(starts)}"
+    assert [s["params"] for s in starts] == [_WRITE_ARGS, _READ_ARGS], (
+        "each tool_start must carry its own call's real arguments"
+    )
+
+    assert results[0]["tool_call_id"] == starts[0]["tool_call_id"]
+    assert results[1]["tool_call_id"] == starts[1]["tool_call_id"]
+
+    ghost = results[2]
+    assert ghost["tool_call_id"] == "", (
+        "after both calls are correlated the pending list must be EMPTY, so an "
+        "unmatched result gets no id. A non-empty id here means stale entries "
+        f"accumulated and were handed to the wrong call — got {ghost['tool_call_id']!r}"
+    )
+
+
+# ===========================================================================
+# 3. Out-of-order results still correlate to the right call
+# ===========================================================================
+
+
+async def test_interleaved_results_correlate_to_the_right_call() -> None:
+    """Two different tools started, results arriving in the reverse order: each
+    result must carry the id of ITS OWN start, not the first pending entry."""
+    system_events = await _drive(
+        [
+            _provisional("Read"),
+            _resolved("Read", _READ_ARGS),
+            _provisional("Write"),
+            _resolved("Write", _WRITE_ARGS),
+            _result("Write"),
+            _result("Read"),
+        ]
+    )
+
+    starts = _of_type(system_events, "tool_start")
+    results = _of_type(system_events, "tool_result")
+
+    assert len(starts) == 2, f"expected two tool_starts, got {len(starts)}"
+    ids = {s["name"]: s["tool_call_id"] for s in starts}
+
+    assert results[0]["name"] == "Write"
+    assert results[0]["tool_call_id"] == ids["Write"], (
+        "the Write result must correlate to the Write call even though Read started first"
+    )
+    assert results[1]["name"] == "Read"
+    assert results[1]["tool_call_id"] == ids["Read"]
+
+
+# ===========================================================================
+# 4. Backends that never set the flag are untouched
+# ===========================================================================
+
+
+async def test_backend_without_input_pending_is_unchanged() -> None:
+    """pydantic_ai, deep_agents and friends emit one tool_use per call and never
+    set ``input_pending``, so the loop reads None. Absent must behave exactly as
+    present-and-False: one start, real params, correct correlation."""
+    system_events = await _drive(
+        [
+            _unflagged("Read", _READ_ARGS),
+            _result("Read"),
+            _unflagged("Write", _WRITE_ARGS),
+            _result("Write"),
+            _result("Ghost"),
+        ]
+    )
+
+    starts = _of_type(system_events, "tool_start")
+    results = _of_type(system_events, "tool_result")
+
+    assert len(starts) == 2, f"expected one tool_start per call, got {len(starts)}"
+    assert [s["params"] for s in starts] == [_READ_ARGS, _WRITE_ARGS]
+    assert results[0]["tool_call_id"] == starts[0]["tool_call_id"]
+    assert results[1]["tool_call_id"] == starts[1]["tool_call_id"]
+    assert results[2]["tool_call_id"] == "", "an unflagged backend must leave no residue either"
+
+
+async def test_non_streaming_claude_sdk_path_is_unchanged() -> None:
+    """The non-streaming claude_sdk path emits a single resolved event
+    (``input_pending=False``) and no provisional one. It must correlate exactly
+    as it did before the flag existed."""
+    system_events = await _drive(
+        [
+            _resolved("Write", _WRITE_ARGS),
+            _result("Write"),
+        ]
+    )
+
+    starts = _of_type(system_events, "tool_start")
+    results = _of_type(system_events, "tool_result")
+
+    assert len(starts) == 1
+    assert starts[0]["params"] == _WRITE_ARGS
+    assert results[0]["tool_call_id"] == starts[0]["tool_call_id"]

--- a/tests/test_agent_loop_tool_correlation.py
+++ b/tests/test_agent_loop_tool_correlation.py
@@ -301,3 +301,53 @@ async def test_non_streaming_claude_sdk_path_is_unchanged() -> None:
     assert len(starts) == 1
     assert starts[0]["params"] == _WRITE_ARGS
     assert results[0]["tool_call_id"] == starts[0]["tool_call_id"]
+
+
+# ===========================================================================
+# 5. Zero-argument and argument-less calls report no arguments, not the metadata
+# ===========================================================================
+
+
+async def test_zero_argument_call_publishes_empty_params() -> None:
+    """A tool called with no arguments reports ``input={}``, which is falsy. The
+    published ``params`` must be that empty dict — not the metadata dict, which an
+    ``or meta`` fallback used to substitute, putting ``{'input': {}, 'name':
+    'get_system_status'}`` where the arguments belong in the transparency log."""
+    system_events = await _drive(
+        [
+            AgentEvent(
+                type="tool_use",
+                content="Using get_system_status...",
+                metadata={"name": "get_system_status", "input": {}},
+            ),
+            _result("get_system_status"),
+        ]
+    )
+
+    starts = _of_type(system_events, "tool_start")
+
+    assert len(starts) == 1
+    assert starts[0]["params"] == {}, (
+        "a zero-argument call must publish empty params, not the metadata dict — "
+        f"got {starts[0]['params']}"
+    )
+
+
+async def test_backend_omitting_input_publishes_empty_params() -> None:
+    """opencode emits ``metadata={"name": ...}`` with no ``input`` key at all. It
+    has no arguments to give, so the loop must say so rather than pass the
+    metadata dict off as the call's parameters."""
+    system_events = await _drive(
+        [
+            AgentEvent(type="tool_use", content="Using Read...", metadata={"name": "Read"}),
+            _result("Read"),
+        ]
+    )
+
+    starts = _of_type(system_events, "tool_start")
+
+    assert len(starts) == 1
+    assert starts[0]["name"] == "Read"
+    assert starts[0]["params"] == {}, (
+        f"a backend omitting 'input' must publish empty params, got {starts[0]['params']}"
+    )

--- a/tests/test_claude_sdk_tool_args.py
+++ b/tests/test_claude_sdk_tool_args.py
@@ -1,0 +1,338 @@
+# tests/test_claude_sdk_tool_args.py
+# Created: 2026-08-15 (HTN-4, feat/claude-sdk-tool-args) — pins the contract that a
+# ``tool_use`` event from the DEFAULT agent backend carries the tool's REAL
+# arguments.
+#
+# The bug this locks down: ``run``'s stream loop announces a tool from the partial
+# ``content_block_start`` (name known, arguments not yet streamed, so ``input={}``)
+# and again from the completed ``AssistantMessage`` (the SDK's fully assembled
+# ``input``). An ``_announced_tools`` name guard suppressed the SECOND one — the
+# only emission that ever had the arguments — so on a streamed turn every consumer
+# saw ``input={}``. ``include_partial_messages`` is on whenever ``StreamEvent``
+# imports, which is every ordinary run, so this was the normal case and not an edge.
+#
+# Live ``claude`` model calls are BLOCKED in CI, so these tests SPY on the boundary
+# (a faked SDK message stream through the warm client) rather than making a real
+# call — the seam under test is claude_sdk's own event-emission logic, which is
+# exercised for real. The fakes and patch scaffolding mirror
+# ``test_claude_sdk_session_handle.py``.
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from pocketpaw.agents.claude_sdk import ClaudeAgentSDK, ClaudeSDKBackend
+from pocketpaw.agents.model_router import ModelSelection, TaskComplexity
+
+_LLM_CLIENT = "pocketpaw.llm.client.resolve_llm_client"
+_MODEL_ROUTER = "pocketpaw.agents.model_router.ModelRouter"
+
+# The arguments a consumer needs and used to be denied.
+_WRITE_ARGS = {"file_path": "/tmp/notes.md", "content": "hello"}
+
+
+# ===========================================================================
+# Fakes — SDK message/block stand-ins. Each is a distinct real class so the
+# loop's ``isinstance`` dispatch picks exactly one branch per event.
+# ===========================================================================
+
+
+def _make_settings(**overrides):
+    defaults = {
+        "agent_backend": "claude_agent_sdk",
+        "tool_profile": "full",
+        "tools_allow": [],
+        "tools_deny": [],
+        "smart_routing_enabled": False,
+        "claude_sdk_provider": "anthropic",
+        "claude_sdk_model": None,
+        "claude_sdk_max_turns": None,
+        "sdk_load_bundled_skills": False,
+        "anthropic_api_key": "sk-test-key",
+    }
+    defaults.update(overrides)
+    mock = MagicMock()
+    for k, v in defaults.items():
+        setattr(mock, k, v)
+    return mock
+
+
+class _Options:
+    """Real options stand-in so ``_client_cache_key`` / dispatch can read it."""
+
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+        self.model = kwargs.get("model", "")
+        self.allowed_tools = kwargs.get("allowed_tools", [])
+        self.system_prompt = kwargs.get("system_prompt", "")
+        self.plugins = kwargs.get("plugins", [])
+        self.resume = kwargs.get("resume", None)
+
+
+class _FakeStreamEvent:
+    """Stand-in for the SDK's partial-message StreamEvent (``.event`` is the raw
+    Anthropic streaming event dict)."""
+
+    def __init__(self, event: dict):
+        self.event = event
+
+
+class _FakeToolUseBlock:
+    """Stand-in for ``ToolUseBlock`` — carries the ASSEMBLED arguments."""
+
+    # ``input`` shadows the builtin deliberately — it is the SDK's field name,
+    # and ``_extract_tool_info`` reads it by that name off the real block.
+    def __init__(self, name: str, input: dict):
+        self.name = name
+        self.input = input
+
+
+class _FakeAssistantMessage:
+    def __init__(self, content: list, model: str = "claude-sonnet-4-5-20250929"):
+        self.content = content
+        self.model = model
+
+
+class _FakeResultMsg:
+    def __init__(self):
+        self.is_error = False
+        self.result = "ok"
+        self.total_cost_usd = None
+        self.usage = {}
+
+
+def _tool_block_start(name: str) -> _FakeStreamEvent:
+    """The partial event that opens a tool block: name only, no arguments yet."""
+    return _FakeStreamEvent(
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "tool_use", "id": "toolu_01", "name": name, "input": {}},
+        }
+    )
+
+
+def _text_delta(text: str) -> _FakeStreamEvent:
+    return _FakeStreamEvent({"type": "content_block_delta", "delta": {"text": text}})
+
+
+class _FakeClient:
+    """Warm persistent client whose ``receive_messages()`` replays a scripted
+    message list — the stream the real SDK would produce."""
+
+    def __init__(self, script: list, options=None, **_kw):
+        self._script = script
+        self.options = options
+
+    async def connect(self, prompt=None):
+        pass
+
+    async def query(self, prompt, session_id="default"):
+        pass
+
+    async def receive_messages(self):
+        for msg in self._script:
+            yield msg
+
+    async def disconnect(self):
+        pass
+
+    async def interrupt(self):
+        pass
+
+
+def _make_sdk(script: list, *, streaming: bool):
+    """Build an SDK wired to replay ``script``. ``streaming=False`` models a
+    runtime whose SDK has no ``StreamEvent`` — no ``include_partial_messages``,
+    so only the AssistantMessage branch ever runs."""
+    with patch.object(ClaudeSDKBackend, "_initialize"):
+        sdk = ClaudeAgentSDK(_make_settings())
+    sdk._sdk_available = True
+    sdk._cli_available = True
+
+    sdk._ClaudeAgentOptions = lambda **kwargs: _Options(**kwargs)
+    sdk._ClaudeSDKClient = lambda **kwargs: _FakeClient(list(script), **kwargs)
+    sdk._HookMatcher = MagicMock()
+    sdk._ResultMessage = _FakeResultMsg
+    sdk._AssistantMessage = _FakeAssistantMessage
+    sdk._ToolUseBlock = _FakeToolUseBlock
+    sdk._StreamEvent = _FakeStreamEvent if streaming else None
+    sdk._SystemMessage = None
+    sdk._UserMessage = None
+    sdk._ToolResultBlock = None
+    sdk._TextBlock = None
+    return sdk
+
+
+async def _drive_run(sdk, message="do the thing"):
+    """Run a full turn under the LLM / router / MCP patches ``run()`` needs."""
+
+    async def _go():
+        return [ev async for ev in sdk.run(message, system_prompt="identity", session_key="s1")]
+
+    selection = ModelSelection(
+        complexity=TaskComplexity.MODERATE,
+        model="claude-sonnet-4-5-20250929",
+        reason="test",
+    )
+    with patch(_LLM_CLIENT) as mock_resolve:
+        mock_llm = MagicMock()
+        mock_llm.is_ollama = False
+        mock_llm.is_openai_compatible = False
+        mock_llm.is_gemini = False
+        mock_llm.is_litellm = False
+        mock_llm.is_openrouter = False
+        mock_llm.to_sdk_env.return_value = {"ANTHROPIC_API_KEY": "sk-test"}
+        mock_resolve.return_value = mock_llm
+        with patch(_MODEL_ROUTER) as MockRouter:
+            MockRouter.return_value.classify.return_value = selection
+            with patch.object(ClaudeSDKBackend, "_get_mcp_servers", return_value={}):
+                return await _go()
+
+
+def _tool_events(events):
+    return [e for e in events if e.type == "tool_use"]
+
+
+# ===========================================================================
+# 1. Streamed turn — the real arguments reach the consumer
+# ===========================================================================
+
+
+async def test_streamed_tool_call_surfaces_real_arguments() -> None:
+    """On the streamed path the assembled ``input`` must reach consumers. This is
+    the regression: the AssistantMessage emission carrying it was suppressed
+    because the partial announcement had already claimed the tool's name."""
+    sdk = _make_sdk(
+        [
+            _text_delta("Saving that for you."),
+            _tool_block_start("Write"),
+            _FakeAssistantMessage([_FakeToolUseBlock("Write", _WRITE_ARGS)]),
+            _FakeResultMsg(),
+        ],
+        streaming=True,
+    )
+
+    tools = _tool_events(await _drive_run(sdk))
+
+    assert any(t.metadata.get("input") == _WRITE_ARGS for t in tools), (
+        "a streamed tool call must surface a tool_use event carrying the REAL "
+        f"arguments — got {[t.metadata.get('input') for t in tools]}"
+    )
+    # Two events for one call is the intended shape: prompt announcement first,
+    # resolved arguments second (consumers REPLACE the tool's status line).
+    assert len(tools) == 2, f"expected a provisional + a resolved event, got {len(tools)}"
+    provisional, resolved = tools
+    assert provisional.metadata["name"] == "Write"
+    assert provisional.metadata["input"] == {}
+    assert provisional.metadata["input_pending"] is True, (
+        "the announcement must flag that its empty input is a placeholder"
+    )
+    assert resolved.metadata["name"] == "Write"
+    assert resolved.metadata["input"] == _WRITE_ARGS
+    assert resolved.metadata["input_pending"] is False, (
+        "the resolved emission must flag its input as final"
+    )
+
+
+async def test_streamed_announcement_still_precedes_the_model_reply() -> None:
+    """The announcement's whole purpose is a PROMPT 'tool started' indicator, so
+    it must still be emitted as the block opens — not deferred until the message
+    completes."""
+    sdk = _make_sdk(
+        [
+            _tool_block_start("Write"),
+            _text_delta("done"),
+            _FakeAssistantMessage([_FakeToolUseBlock("Write", _WRITE_ARGS)]),
+            _FakeResultMsg(),
+        ],
+        streaming=True,
+    )
+
+    events = await _drive_run(sdk)
+    types = [e.type for e in events]
+    first_tool = types.index("tool_use")
+    first_text = types.index("message")
+
+    assert first_tool < first_text, (
+        "the provisional announcement must be emitted when the tool block opens, "
+        "ahead of the text streamed after it"
+    )
+    assert events[first_tool].metadata["input_pending"] is True
+
+
+async def test_repeated_tool_name_resolves_each_call_separately() -> None:
+    """Two calls to the SAME tool in one message must each surface their own
+    arguments. The old guard was keyed on the tool NAME, so it collapsed repeats —
+    the second call's arguments could never have been distinguished."""
+    first_args = {"file_path": "/tmp/a.md"}
+    second_args = {"file_path": "/tmp/b.md"}
+    sdk = _make_sdk(
+        [
+            _tool_block_start("Read"),
+            _tool_block_start("Read"),
+            _FakeAssistantMessage(
+                [
+                    _FakeToolUseBlock("Read", first_args),
+                    _FakeToolUseBlock("Read", second_args),
+                ]
+            ),
+            _FakeResultMsg(),
+        ],
+        streaming=True,
+    )
+
+    resolved = [t for t in _tool_events(await _drive_run(sdk)) if not t.metadata["input_pending"]]
+
+    assert [t.metadata["input"] for t in resolved] == [first_args, second_args], (
+        "each tool call must resolve to its own arguments, not be deduplicated by name"
+    )
+
+
+# ===========================================================================
+# 2. Non-streaming path — unchanged: exactly one event per call, with real args
+# ===========================================================================
+
+
+async def test_non_streaming_path_emits_exactly_one_tool_use_per_call() -> None:
+    """Without ``StreamEvent`` the SDK gets no ``include_partial_messages``, so the
+    AssistantMessage branch is the ONLY emitter. That path already carried real
+    arguments and must not regress into zero or two events."""
+    sdk = _make_sdk(
+        [
+            _FakeAssistantMessage([_FakeToolUseBlock("Write", _WRITE_ARGS)]),
+            _FakeResultMsg(),
+        ],
+        streaming=False,
+    )
+
+    tools = _tool_events(await _drive_run(sdk))
+
+    assert len(tools) == 1, f"the non-streaming path must emit ONE tool_use, got {len(tools)}"
+    assert tools[0].metadata["name"] == "Write"
+    assert tools[0].metadata["input"] == _WRITE_ARGS
+    assert tools[0].metadata["input_pending"] is False
+
+
+async def test_non_streaming_path_emits_one_event_per_call_for_repeats() -> None:
+    """Two calls to the same tool, no streaming: two events, each with its own
+    arguments — one per call, never collapsed and never duplicated."""
+    first_args = {"file_path": "/tmp/a.md"}
+    second_args = {"file_path": "/tmp/b.md"}
+    sdk = _make_sdk(
+        [
+            _FakeAssistantMessage(
+                [
+                    _FakeToolUseBlock("Read", first_args),
+                    _FakeToolUseBlock("Read", second_args),
+                ]
+            ),
+            _FakeResultMsg(),
+        ],
+        streaming=False,
+    )
+
+    tools = _tool_events(await _drive_run(sdk))
+
+    assert [t.metadata["input"] for t in tools] == [first_args, second_args]
+    assert all(t.metadata["input_pending"] is False for t in tools)

--- a/tests/test_stream_event.py
+++ b/tests/test_stream_event.py
@@ -1,5 +1,15 @@
 # Tests for StreamEvent token-by-token streaming integration
 # Created: 2026-02-06
+# Updated: 2026-08-15 (HTN-4, feat/claude-sdk-tool-args) — the two tool_use tests
+# now pin the TWO-event contract for a streamed call. They previously asserted
+# that the AssistantMessage emission was suppressed once the streaming branch had
+# announced the tool by name; that suppression was the bug, because the
+# AssistantMessage is the only place the assembled arguments exist, so every
+# streamed tool call reached consumers with ``input={}``. ``test_no_duplicate_
+# tool_use`` was renamed to ``test_streamed_tool_use_resolves_to_real_args``
+# since it now guarantees the opposite of what its name promised. Nothing else in
+# this file changed — the text-dedup tests still assert single emission, which is
+# untouched.
 # Updated: 2026-08-03 (PA-7b, feat/prompt-assembler-channel) — the stub builder
 # returns an ``AssembledPrompt`` from ``assemble_system_prompt`` and the fake
 # router declares ``system_prompt_digest``, because ``AgentLoop`` now carries the
@@ -163,9 +173,11 @@ class TestStreamEventHandling:
 
         events = await _collect(sdk)
         tool_events = [e for e in events if e.type == "tool_use"]
-        # Should only get ONE tool_use (from StreamEvent), not a duplicate from AssistantMessage
-        assert len(tool_events) == 1
+        # The announcement fires as the block opens, before any argument has
+        # streamed — that promptness is the reason this emission exists.
         assert tool_events[0].metadata["name"] == "Bash"
+        assert tool_events[0].metadata["input_pending"] is True
+        assert tool_events[0].metadata["input"] == {}
 
     async def test_no_duplicate_text(self):
         """When StreamEvent deltas sent, AssistantMessage text is skipped."""
@@ -183,8 +195,16 @@ class TestStreamEventHandling:
         assert len(messages) == 1
         assert messages[0].content == "Hi"
 
-    async def test_no_duplicate_tool_use(self):
-        """When StreamEvent announced tool, AssistantMessage tool_use is skipped."""
+    async def test_streamed_tool_use_resolves_to_real_args(self):
+        """A streamed tool call surfaces TWICE: the provisional announcement, then
+        the AssistantMessage carrying the assembled arguments.
+
+        This test used to assert the opposite — that the AssistantMessage emission
+        was skipped once the announcement had named the tool. That guard was the
+        HTN-4 bug: the suppressed emission is the only one that ever holds the
+        arguments, so on the default backend every consumer saw ``input={}``. The
+        pair is intended; consumers key off ``input_pending`` (loop.py correlates
+        only the resolved one; chat surfaces replace their status line)."""
         sdk = _make_sdk()
 
         async def fake_query(**kw):
@@ -200,7 +220,12 @@ class TestStreamEventHandling:
 
         events = await _collect(sdk)
         tool_events = [e for e in events if e.type == "tool_use"]
-        assert len(tool_events) == 1
+        assert len(tool_events) == 2
+        provisional, resolved = tool_events
+        assert provisional.metadata["input_pending"] is True
+        assert provisional.metadata["input"] == {}
+        assert resolved.metadata["input_pending"] is False
+        assert resolved.metadata["input"] == {"file": "foo.py"}
 
     async def test_fallback_without_stream_event(self):
         """With _StreamEvent = None, AssistantMessage text yields normally."""


### PR DESCRIPTION
`claude_agent_sdk` is the default backend. On a streamed turn, every tool call reached consumers with `input={}`, so anything downstream that wanted to know what a tool was actually called with got nothing.

The arguments were never lost in transit. The SDK assembles them itself and hands them over on the completed `AssistantMessage`, where `_extract_tool_info` reads `block.input` off the `ToolUseBlock`. They died two lines later, at a name guard: the streaming branch announces a tool as its block opens, adds the name to `_announced_tools`, and the `AssistantMessage` branch then skips any tool already in that set. On a streamed turn that is every tool, so the only emission carrying real arguments was always the one thrown away.

So this is not a matter of reassembling `input_json_delta` fragments. The guard is gone, and with it the set, whose only reader it was.

## Two events per streamed call, on purpose

The provisional announcement is kept because it is what makes a "tool started" indicator prompt: the SDK knows the name well before the argument JSON has finished streaming. Both emissions now go out, told apart by an additive `metadata["input_pending"]`, true on the announcement and false on the resolved event. A backend that never sets the key reads as resolved and is untouched, as is the non-streaming path, which still emits exactly once.

`deep_agents` already solved the same two-phase problem the other way, deduping on `tool_call_id` and emitting once. Both shapes are valid under the same rule, but that rule was worth writing down rather than leaving in a file header, so the `AgentEvent` docstring now carries the contract and the consumer rule that follows from it: if you append per event, skip provisional ones; if you replace per tool, render both and let the resolved event upgrade the display.

## The regression this caused, and the one it uncovered

Emitting twice broke correlation in `loop.py`, which appended a `pending_tool_calls` entry per event. Every streamed call left a second entry that the name match on `tool_result` never popped, the residue built up across a turn, and the `pop(0)` fallback then handed later results an id belonging to an earlier call. The branch now correlates only the resolved event.

Skipping the provisional event rather than merging it matters because both consumers of that `tool_start` append rather than replace. The dashboard transparency log and the client activity store each render `params` as a new row, so a provisional row was permanent junk, not a placeholder waiting to be upgraded.

That work turned up a separate bug in the same line. `meta.get("input") or meta` treats empty input as falsy, so any tool called with no arguments published the whole metadata dict as its parameters, and the transparency log rendered `{'input': {}, 'name': 'get_system_status'}` where the arguments belong. It predates this change and is fixed here as its own commit.

## Two existing tests changed

`test_tool_use_start_yields_tool_use` and `test_no_duplicate_tool_use` both asserted that a streamed call yields exactly one `tool_use` event. That assertion was the bug, so both were updated to the two-event contract rather than deleted, and the second was renamed to `test_streamed_tool_use_resolves_to_real_args` because it now guarantees the opposite of what its name promised. The replacements pin the count, the ordering and both payload shapes, where the originals only pinned a count.

They are worth a look in review. An existing assertion being rewritten by the change it was guarding deserves a second pair of eyes.

## Tests

131 passed across the touched modules and their consumers. The new correlation tests were run red against the pre-fix commit first: three failed, including `expected two tool_starts, got 4`. The two that passed before and after are the regression guards for the unflagged and non-streaming paths.

A full non-EE sweep shows 71 failures on this branch and the same 71 with the changed files reverted, so none belong to this work. They are environmental, mostly a missing `herdr` binary.
