### PR TITLE
A free site served a concierge, because no plan was ever asked

### DIFF
--- a/ee/pocketpaw_ee/cloud/auth/site_keys.py
+++ b/ee/pocketpaw_ee/cloud/auth/site_keys.py
@@ -159,6 +159,41 @@ async def lookup_site_by_key(key: str) -> _SiteDoc:
     return site
 
 
+def concierge_available(site: _SiteDoc) -> bool:
+    """May this site serve its concierge right now — owner's switch AND its plan?
+
+    The ONE question every public paw-bar seam asks, so the rule lives here instead
+    of being re-expressed at each of them. Before this existed, the seams read
+    ``site.concierge_enabled`` directly and no plan was consulted anywhere, so a free
+    site served a concierge indefinitely.
+
+    Gated on ``billing_enforced``, matching every other cap in this codebase: with
+    billing off (OSS / self-host) only the owner's switch applies, exactly as before.
+
+    Synchronous and passed the loaded doc: the gate already holds the Site, and
+    ``resolve_site_entitlements`` is pure and may not import ``models.site``
+    (EE cloud rule 2). No extra query on a path that runs for every visitor message.
+    """
+    if not site.concierge_enabled:
+        return False
+
+    from pocketpaw.config import get_settings
+
+    if not get_settings().billing_enforced:
+        return True
+
+    from pocketpaw_ee.cloud.entitlements import service as entitlements_service
+
+    ent = entitlements_service.resolve_site_entitlements(
+        site_id=str(site.id),
+        workspace_id=site.workspace,
+        plan_tier=site.plan_tier,
+        subscription_status=site.subscription_status,
+        concierge_enabled=True,  # already checked above; this asks the PLAN
+    )
+    return ent.concierge_entitled
+
+
 def _context_from_site(site: _SiteDoc, customer_ref: str) -> RequestContext:
     """Build the CONCIERGE ``RequestContext`` a resolved embed key stands for.
 
@@ -277,6 +312,14 @@ async def resolve_site_key_with_site(
     # before the origin gate so "this concierge is off" is the authoritative refusal.
     if not site.concierge_enabled:
         raise HTTPException(status_code=403, detail="concierge_disabled")
+
+    # Billing gate (feat/sites-concierge-entitlement): the site's PLAN, asked right
+    # after the owner's switch and refused the same way. Same 403 and the same
+    # silence to a visitor — only the detail differs, because an owner who switched
+    # it off and an owner whose subscription lapsed need different remedies. A
+    # no-op unless ``billing_enforced``.
+    if not concierge_available(site):
+        raise HTTPException(status_code=403, detail="concierge_not_entitled")
 
     # Dual-mode origin gate. Frame mode (request Origin == our frame origin) means
     # the embedder was already gated by the frame CSP, so we accept; otherwise the

--- a/ee/pocketpaw_ee/cloud/auth/site_keys.py
+++ b/ee/pocketpaw_ee/cloud/auth/site_keys.py
@@ -167,8 +167,18 @@ def concierge_available(site: _SiteDoc) -> bool:
     ``site.concierge_enabled`` directly and no plan was consulted anywhere, so a free
     site served a concierge indefinitely.
 
-    Gated on ``billing_enforced``, matching every other cap in this codebase: with
-    billing off (OSS / self-host) only the owner's switch applies, exactly as before.
+    Gated on ``billing_enforced``, matching the workspace caps
+    (``PocketLimitError`` / ``ConnectorLimitError`` / the credit guards): with billing
+    off — OSS, self-host, and every in-repo deploy today — only the owner's switch
+    applies, exactly as before.
+
+    Worth knowing that this is NOT universal: the badge stamper
+    (``sites.service._stamp_free_badge``) resolves the same per-site entitlements and
+    does not check the flag, so it badges a free site regardless. That is an
+    inconsistency in the per-site family, not a rule this function is breaking, and
+    the two should converge — but silently 403ing a visitor's chat is a harsher
+    failure than stamping a badge, so the safer of the two defaults is the one taken
+    here. Flipping it is a product decision, not a refactor.
 
     Synchronous and passed the loaded doc: the gate already holds the Site, and
     ``resolve_site_entitlements`` is pure and may not import ``models.site``
@@ -333,4 +343,9 @@ async def resolve_site_key_with_site(
     return _context_from_site(site, customer_ref), site
 
 
-__all__ = ["lookup_site_by_key", "resolve_site_key", "resolve_site_key_with_site"]
+__all__ = [
+    "concierge_available",
+    "lookup_site_by_key",
+    "resolve_site_key",
+    "resolve_site_key_with_site",
+]

--- a/ee/pocketpaw_ee/cloud/entitlements/domain.py
+++ b/ee/pocketpaw_ee/cloud/entitlements/domain.py
@@ -29,6 +29,11 @@
 #   (``int | None``, None = uncapped) — the workspace S3 STORAGE cap in bytes the
 #   uploads pipeline enforces at upload time. Fail-closed to the Free value
 #   (5 GB) on the fallback path.
+# Updated 2026-08-15 (feat/sites-concierge-entitlement): added
+#   ``SiteEntitlements.concierge_entitled`` + the ``concierge_available`` property.
+#   ``concierge_enabled`` was a PASS-THROUGH of the owner's toggle that consulted no
+#   plan at all, so a free site served a concierge indefinitely. The two questions
+#   stay separate fields on purpose — see the class docstring.
 # Updated 2026-08-13 (feat/sites-site-entitlements): added ``SiteEntitlements`` —
 #   the PER-SITE shape, a second scope beside the workspace one. Sites are the
 #   only thing billed per-object (``Site.plan_tier`` + ``subscription_status``),
@@ -106,6 +111,15 @@ class SiteEntitlements:
     ``white_label``. The first two wait on which meter owns a concierge run, and
     the third on an org entity that does not exist. A field that always returns
     0/False reads as implemented, which is worse than its absence.
+
+    ``concierge_enabled`` and ``concierge_entitled`` are two different questions
+    and are deliberately NOT folded into one boolean. The first is the owner's own
+    kill switch, echoed unchanged; the second is whether the site's plan sells the
+    concierge at all. Collapsing them would make "off" unattributable — support
+    could not tell an owner who switched it off from an owner whose subscription
+    lapsed, and the dashboard could not offer the right remedy. The public seams
+    refuse identically on either (see ``concierge_available``); only the reason
+    differs, and the reason is what a human needs.
     """
 
     site_id: str
@@ -115,3 +129,16 @@ class SiteEntitlements:
     badge_required: bool
     custom_domain: bool
     concierge_enabled: bool
+    concierge_entitled: bool
+
+    @property
+    def concierge_available(self) -> bool:
+        """May this site actually serve its concierge right now?
+
+        The AND of the owner's intent and the plan's permission — the single
+        question every public paw-bar seam asks, so no caller has to remember to
+        check both. A caller that reads only ``concierge_enabled`` (as every seam
+        did before the billing gate existed) serves a free site's concierge, which
+        is the hole this property closes.
+        """
+        return self.concierge_enabled and self.concierge_entitled

--- a/ee/pocketpaw_ee/cloud/entitlements/service.py
+++ b/ee/pocketpaw_ee/cloud/entitlements/service.py
@@ -154,9 +154,17 @@ def resolve_site_entitlements(
     # instead of resting on short-circuit evaluation.
     badge_removal = False
     custom_domain = False
+    concierge_entitled = False
     if tier is not None and subscription_active:
         badge_removal = tier.badge_removal
         custom_domain = "custom_domain" in tier.cloudflare_features
+        # Any tier ABOVE the free floor sells the concierge. Deliberately derived
+        # from the floor rather than a per-tier catalog flag like ``badge_removal``:
+        # no tier grants concierge today, and the tier that will (``staff``) does not
+        # exist until the pricing-spec rekey, which is blocked on an open decision.
+        # A flag would need a basic/pro/business mapping invented now and rewritten
+        # then. "Paid and paying" needs no mapping and survives the rekey untouched.
+        concierge_entitled = tier.key != site_plan_catalog.BASE_SITE_PLAN_KEY
 
     return SiteEntitlements(
         site_id=site_id,
@@ -165,5 +173,8 @@ def resolve_site_entitlements(
         subscription_active=subscription_active,
         badge_required=not badge_removal,
         custom_domain=custom_domain,
+        # Echoed unchanged — the owner's switch is not a billing question. The
+        # AND of the two is ``concierge_available``, which is what seams ask.
         concierge_enabled=bool(concierge_enabled),
+        concierge_entitled=concierge_entitled,
     )

--- a/ee/pocketpaw_ee/paw_bar/embed.py
+++ b/ee/pocketpaw_ee/paw_bar/embed.py
@@ -142,7 +142,7 @@ async def concierge_snippet(
     site_key: str,
     api_base: str,
     concierge_enabled: bool,
-    concierge_entitled: bool = True,
+    concierge_entitled: bool,
 ) -> str:
     """The snippet this site has earned, or ``""`` when it has not.
 
@@ -152,9 +152,12 @@ async def concierge_snippet(
       0. ``concierge_entitled`` — the site's PLAN sells a concierge
          (feat/sites-concierge-entitlement). Same effect as the owner's switch and
          for the same reason: the built page ships with no bar rather than a bar
-         that would 403 every visitor at runtime. Defaults True so the only caller
-         that must think about billing is the publish path that resolves it; every
-         test and internal caller keeps the pre-billing behaviour.
+         that would 403 every visitor at runtime. REQUIRED, deliberately: it briefly
+         carried a ``= True`` default so callers would not have to think about
+         billing, and review caught what that buys — deleting the resolution in
+         ``_embed_concierge_bar`` would then leave working code that silently
+         embeds on every site, instead of the TypeError that makes the deletion
+         obvious. A gate whose removal compiles is not a gate.
       1. ``concierge_enabled`` — the owner's kill switch. Off means no bar, and a
          re-publish with it off is how an owner takes an embedded bar back off their
          site (the marker is only ever written, never re-written, so the page it was

--- a/ee/pocketpaw_ee/paw_bar/embed.py
+++ b/ee/pocketpaw_ee/paw_bar/embed.py
@@ -142,12 +142,19 @@ async def concierge_snippet(
     site_key: str,
     api_base: str,
     concierge_enabled: bool,
+    concierge_entitled: bool = True,
 ) -> str:
     """The snippet this site has earned, or ``""`` when it has not.
 
-    Four gates, all of which must pass — a site that fails any of them is published
+    Five gates, all of which must pass — a site that fails any of them is published
     exactly as it was before this module existed:
 
+      0. ``concierge_entitled`` — the site's PLAN sells a concierge
+         (feat/sites-concierge-entitlement). Same effect as the owner's switch and
+         for the same reason: the built page ships with no bar rather than a bar
+         that would 403 every visitor at runtime. Defaults True so the only caller
+         that must think about billing is the publish path that resolves it; every
+         test and internal caller keeps the pre-billing behaviour.
       1. ``concierge_enabled`` — the owner's kill switch. Off means no bar, and a
          re-publish with it off is how an owner takes an embedded bar back off their
          site (the marker is only ever written, never re-written, so the page it was
@@ -160,7 +167,7 @@ async def concierge_snippet(
          a bar for it would render and then refuse to answer, which is worse than no
          bar at all.
     """
-    if not concierge_enabled or not site_key or not pocket_id:
+    if not concierge_enabled or not concierge_entitled or not site_key or not pocket_id:
         return ""
 
     from pocketpaw_ee.paw_bar.agent_provisioning import site_widget

--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -919,7 +919,7 @@ async def frame(
     the real controls stay the rate-limit + injection screen + the zero-authority
     CONCIERGE scope. CSP does not close the curl path.
     """
-    from pocketpaw_ee.cloud.auth.site_keys import lookup_site_by_key
+    from pocketpaw_ee.cloud.auth.site_keys import concierge_available, lookup_site_by_key
 
     # (1) Authenticate the embed key. A missing/blank ``key`` query param is a
     # too-short key → 401 (never a 422), so the refusal is uniform with the chat path.
@@ -936,7 +936,14 @@ async def frame(
     # Distinct from ``revoked`` (which cuts the KEY at 401 inside
     # lookup_site_by_key — an api-shaped JSON 401 stays correct there: a revoked
     # key means the embed script itself is stale/removed on next publish).
-    if not site.concierge_enabled:
+    #
+    # (1c) The BILLING gate rides the same branch (feat/sites-concierge-entitlement):
+    # a site whose plan does not sell the concierge refuses identically. Deliberately
+    # the SAME response, not a distinct one — the visitor must not be able to tell a
+    # lapsed subscription from an owner's choice by looking at the page, and the
+    # loader already knows how to remove an iframe that says ``pawbar:dead``. The
+    # reason is surfaced to the OWNER through the dashboard, and to logs, never here.
+    if not concierge_available(site):
         return _dead_frame_response(po, site.allowed_origins)
 
     # (2) The embedder gate: the CSP frame-ancestors header. Fail closed when no

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -2649,19 +2649,43 @@ async def _embed_concierge_bar(
         # means no ``plan_tier``, which resolves to the free floor and ships the page
         # bar-less. The opposite default would embed a bar on every brand-new site
         # regardless of plan, and that bar would 403 every visitor — a broken
-        # concierge is worse than none. A republish after the subscription activates
-        # picks it up, which is the same seam that repairs it for the badge.
+        # concierge is worse than none.
+        #
+        # ``pending`` IS ENTITLED HERE, and only here — belt and braces beside the
+        # ordering fix in ``activate_site``.
+        #
+        # That fix (flip the status BEFORE ``_deploy_site_doc``) closes the
+        # charge-first window this function used to land in. This mapping covers the
+        # OTHER direction the publish path can produce it: ``_apply_site_plan``
+        # stamps ``plan_tier`` / ``subscription_status`` AFTER ``publish()`` has
+        # already deployed, and a republish onto a paid tier resets a live site to
+        # "pending" until the new sub confirms. Both mean a paying customer can
+        # reach this line with "pending" on the doc.
+        #
+        # Getting it wrong here is expensive and silent: the page ships with no
+        # loader script, and NOTHING re-runs this embed afterwards, so it stays
+        # bar-less until some unrelated publish. Found by review before it shipped.
+        #
+        # It does not weaken the RUNTIME gate, which is what actually enforces:
+        # ``auth.site_keys.concierge_available`` still refuses "pending" on every
+        # visitor request, and a test pins that. A site deployed with a bar but not
+        # yet activated serves a bar that declines until the webhook lands — seconds,
+        # and self-correcting in the right direction. The inverse (refuse at publish,
+        # allow at runtime) does not self-correct at all.
         concierge_entitled = True
         from pocketpaw.config import get_settings
 
         if get_settings().billing_enforced:
             from pocketpaw_ee.cloud.entitlements import service as entitlements_service
 
+            status = getattr(doc, "subscription_status", None)
             concierge_entitled = entitlements_service.resolve_site_entitlements(
                 site_id=site_id,
                 workspace_id=workspace_id,
                 plan_tier=getattr(doc, "plan_tier", None),
-                subscription_status=getattr(doc, "subscription_status", None),
+                # See above: the charge-first deploy runs while the status is still
+                # "pending". Read it as active for the EMBED decision only.
+                subscription_status="active" if status == "pending" else status,
                 concierge_enabled=True,  # asking the PLAN; the switch is read above
             ).concierge_entitled
 
@@ -2711,6 +2735,19 @@ async def _embed_concierge_bar(
             concierge_entitled=concierge_entitled,
         )
         if not snippet:
+            # Say WHY when the reason is billing. This early return is the exact
+            # shape of the 2026-07-30 provisioning bug documented above ("with no
+            # log line, because the empty snippet returns early") — a page ships
+            # bar-less and nothing anywhere records it. The other four gates are
+            # ordinary states a reader can infer from the site; "the plan does not
+            # sell this" is the one nobody would think to check, and it is the one
+            # a support ticket will be about.
+            if not concierge_entitled:
+                logger.info(
+                    "sites: site %s published without its concierge — the plan does "
+                    "not include one",
+                    site_id,
+                )
             return
 
         # HE-4: where the deployable pages live differs by engine — the SvelteKit
@@ -4832,6 +4869,34 @@ async def activate_site(
     pocket_id = doc.pocket_id
     # Deploy live using the inputs captured at publish time (NOT a fresh pocket read
     # — the webhook has no pocket scope, and the pocket's draft may have advanced).
+    # Mark the subscription ACTIVE BEFORE the deploy, not after.
+    #
+    # This call only happens on the ``subscription.active`` webhook — the payment is
+    # already confirmed — so "active" is true the moment we get here, and the old
+    # ordering made it true only after the artifact had been built. That mattered
+    # because the deploy stamps the site's PAID capabilities off this very field:
+    # ``_embed_concierge_bar`` and ``_stamp_free_badge`` both re-read the doc mid-
+    # deploy and resolve entitlements from it. With the flip afterwards, both read
+    # "pending", so a customer who had just paid got a page with the FREE
+    # attribution badge stamped on it and no concierge loader — and nothing
+    # re-runs either stamper, so the page stayed that way until some unrelated
+    # publish. A republish makes it recur: ``_publish_pending_site`` resets the
+    # status to "pending" every time.
+    #
+    # Saved separately from the post-deploy save below so the value is on the doc
+    # the deploy re-reads (both stampers ``find_one`` it fresh rather than taking
+    # the in-memory object).
+    #
+    # Safe on the failure path: if the deploy raises, this row is "active" with
+    # ``deployed=False`` for the duration of the retry. The webhook is at-least-once
+    # and the idempotency guard above keys on ``deployed AND active``, so a retry
+    # still re-enters and re-deploys rather than short-circuiting. That is the same
+    # exposure the pre-existing ``no captured inputs`` branch reasons about, in the
+    # opposite direction, and it is the lesser of the two: a paid site that retries
+    # its deploy beats a paid site permanently branded as free.
+    doc.subscription_status = "active"
+    await doc.save()
+
     deployed = await _deploy_site_doc(
         workspace_id=workspace_id,
         user_id=doc.owner,
@@ -4854,9 +4919,12 @@ async def activate_site(
         local_deploy=_local_deploy,
     )
 
-    # The deploy flipped ``deployed=True`` and cleared pending_deploy_inputs; now
-    # mark the per-site sub active and advance the annual renewal date (one year out
-    # — the next charge cycle), mirroring the renewed path.
+    # The deploy flipped ``deployed=True`` and cleared pending_deploy_inputs; advance
+    # the annual renewal date (one year out — the next charge cycle), mirroring the
+    # renewed path. ``subscription_status`` was already set above, BEFORE the deploy,
+    # so the paid capabilities were stamped correctly; re-asserted here because
+    # ``deployed`` is a separately-loaded doc and this save must not write back a
+    # stale value it read before that flip landed.
     deployed.subscription_status = "active"
     deployed.annual_renewal_date = datetime.now(UTC) + timedelta(days=365)
     await deployed.save()

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -2636,6 +2636,35 @@ async def _embed_concierge_bar(
         doc = await _SiteDoc.find_one({"_id": ObjectId(site_id), "workspace": workspace_id})
         concierge_enabled = True if doc is None else bool(doc.concierge_enabled)
 
+        # Does this site's PLAN sell a concierge (feat/sites-concierge-entitlement)?
+        # Resolved here rather than inside ``concierge_snippet`` because this is the
+        # function that owns the Site doc — ``entitlements`` may not import
+        # ``models.site`` (EE cloud rule 2), and ``embed`` has no business loading it.
+        #
+        # A no-op unless ``billing_enforced``: with billing off (OSS / self-host, and
+        # every in-repo deploy today) this stays True and the publish path is byte
+        # for byte what it was.
+        #
+        # Fail-closed on a FIRST publish, the same way the badge stamper does: no doc
+        # means no ``plan_tier``, which resolves to the free floor and ships the page
+        # bar-less. The opposite default would embed a bar on every brand-new site
+        # regardless of plan, and that bar would 403 every visitor — a broken
+        # concierge is worse than none. A republish after the subscription activates
+        # picks it up, which is the same seam that repairs it for the badge.
+        concierge_entitled = True
+        from pocketpaw.config import get_settings
+
+        if get_settings().billing_enforced:
+            from pocketpaw_ee.cloud.entitlements import service as entitlements_service
+
+            concierge_entitled = entitlements_service.resolve_site_entitlements(
+                site_id=site_id,
+                workspace_id=workspace_id,
+                plan_tier=getattr(doc, "plan_tier", None),
+                subscription_status=getattr(doc, "subscription_status", None),
+                concierge_enabled=True,  # asking the PLAN; the switch is read above
+            ).concierge_entitled
+
         # Publish-time provisioning (the third trigger): an agent-created site
         # published in the same conversation has passed through NEITHER
         # widget-create NOR a concierge-enable transition, so it reaches this
@@ -2679,6 +2708,7 @@ async def _embed_concierge_bar(
             # only one env var to move when the deploy moves.
             api_base=_capture_base(),
             concierge_enabled=concierge_enabled,
+            concierge_entitled=concierge_entitled,
         )
         if not snippet:
             return

--- a/tests/cloud/sites/test_charge_first.py
+++ b/tests/cloud/sites/test_charge_first.py
@@ -447,3 +447,75 @@ async def test_paid_tier_without_dodo_product_publishes_live(mongo_db):
     assert doc.subscription_id is None  # no charge opened
     assert getattr(doc, "_checkout_url", None) is None
     assert sites_service._to_response(doc).checkout_url is None
+
+
+# ---------------------------------------------------------------------------
+# The paid capabilities are stamped DURING the activation deploy, so the
+# subscription has to read "active" before that deploy runs — not after it.
+#
+# Added 2026-08-15 (feat/sites-concierge-entitlement) after review found the
+# original ordering shipped a paying customer a site branded as free:
+# ``_embed_concierge_bar`` and ``_stamp_free_badge`` both re-read the Site doc
+# mid-deploy and resolve entitlements off ``subscription_status``. With the flip
+# afterwards, both saw "pending" — so the page went live with the free
+# attribution badge stamped on it and no concierge loader, and nothing re-runs
+# either stamper. A republish makes it recur (``_publish_pending_site`` resets
+# the status to "pending" every time).
+# ---------------------------------------------------------------------------
+
+
+async def test_the_subscription_reads_active_before_the_activation_deploy_runs(
+    mongo_db, monkeypatch
+):
+    """Pins the ORDERING, by observing what the deploy could see while it ran.
+
+    Asserting the final state cannot catch this — ``subscription_status`` is
+    "active" at the end either way. The only way to tell the two orderings apart
+    is to look at the doc AT DEPLOY TIME, which is what the stampers do.
+    """
+    monkeypatch.setattr(
+        site_plans, "_dodo_product_for", lambda key: {"pro": "prod_site_pro"}.get(key)
+    )
+    ws = await _make_workspace(plan="pro")
+    pocket_id = await _make_pocket(workspace_id=ws)
+    doc = await sites_service.publish_pocket(
+        workspace_id=ws,
+        user_id="u1",
+        pocket_id=pocket_id,
+        site_plan_key="pro",
+        _generator=_RecordingGenerator(),
+        _cloudflare=_RecordingCF(),
+        _bundle_reader=lambda d: b"x",
+        _billing_provider=_RecordingBillingProvider(),
+    )
+    site_id = str(doc.id)
+    assert doc.subscription_status == "pending"
+
+    # Read the PERSISTED doc the moment the deploy starts — the same read the
+    # concierge embed and the badge stamper each make from inside it.
+    seen: list[str] = []
+    real_deploy = sites_service._deploy_site_doc
+
+    async def _observing_deploy(**kw):
+        from pocketpaw_ee.cloud.models.site import Site
+
+        mid = await Site.get(kw["site_id"])
+        seen.append(getattr(mid, "subscription_status", "") or "")
+        return await real_deploy(**kw)
+
+    monkeypatch.setattr(sites_service, "_deploy_site_doc", _observing_deploy)
+
+    activated = await sites_service.activate_site(
+        workspace_id=ws,
+        site_id=site_id,
+        _generator=_RecordingGenerator(),
+        _cloudflare=_RecordingCF(),
+        _bundle_reader=lambda d: b"x",
+    )
+
+    assert seen == ["active"], (
+        f"the activation deploy saw subscription_status={seen!r}; a paid site is "
+        "stamped free when this is not 'active'"
+    )
+    assert activated.subscription_status == "active"
+    assert activated.deployed is True

--- a/tests/cloud/test_paw_bar_concierge_entitlement.py
+++ b/tests/cloud/test_paw_bar_concierge_entitlement.py
@@ -1,0 +1,390 @@
+# tests/cloud/test_paw_bar_concierge_entitlement.py — the concierge is a PAID
+# per-site capability, and until this branch no plan was consulted anywhere.
+#
+# Created 2026-08-15 (feat/sites-concierge-entitlement). The hole:
+# ``SiteEntitlements.concierge_enabled`` was a straight PASS-THROUGH of the owner's
+# kill switch — it echoed what the caller handed it and read no tier, no
+# subscription, nothing. Its two shipped siblings (``badge_required``,
+# ``custom_domain``) both gate on tier AND an active subscription. So a free site
+# turned its concierge on and served it indefinitely, and so did a paid site whose
+# subscription had lapsed.
+#
+# WHAT IS NOT NEW HERE. The disable → remove chain was already built and works:
+# ``site_keys`` 403s chat/action, the frame returns the invisible shell which posts
+# ``pawbar:dead``, and the loader removes the iframe. This branch adds the BILLING
+# reason to trigger it, and reuses that path byte for byte — a refused visitor sees
+# exactly what an owner-disabled one sees.
+#
+# The gate rule (captain's call 2026-08-15): any tier above the free floor, with an
+# active subscription. Derived from ``BASE_SITE_PLAN_KEY`` rather than a per-tier
+# catalog flag, because no tier grants concierge today and the one that will
+# (``staff``) does not exist until the pricing-spec rekey. So every criterion below
+# reads the floor out of the catalog instead of hardcoding "basic"/"pro" — the rekey
+# moves these tests with the catalog instead of breaking them.
+#
+# The two questions stay SEPARATE (``concierge_enabled`` vs ``concierge_entitled``)
+# and that separation is itself pinned below: collapsing them into one boolean makes
+# "off" unattributable, and support cannot tell an owner who flipped the switch from
+# an owner whose plan lapsed.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud.billing import site_plans  # noqa: E402
+from pocketpaw_ee.cloud.entitlements.service import resolve_site_entitlements  # noqa: E402
+
+import pocketpaw.config as ppconfig  # noqa: E402
+
+_VALID_KEY = "site_key_" + "a" * 24
+
+
+def _paid_tier() -> str:
+    """The cheapest catalog tier above the free floor — see the header."""
+    for tier in site_plans.list_site_plans():
+        if tier.key != site_plans.BASE_SITE_PLAN_KEY:
+            return tier.key
+    raise AssertionError("catalog has no tier above the floor — catalog changed")
+
+
+def _free_tier() -> str:
+    return site_plans.BASE_SITE_PLAN_KEY
+
+
+def _enforce(monkeypatch, *, on: bool) -> None:
+    """Point the lazily-imported ``get_settings`` at a billing-posture stub."""
+    monkeypatch.setattr(
+        ppconfig,
+        "get_settings",
+        lambda: SimpleNamespace(billing_enforced=on, dodo_site_products=None),
+    )
+
+
+def _resolve(**ov):
+    kw = {
+        "site_id": "6512c1f0e4b0a1b2c3d4e5f6",
+        "workspace_id": "ws-1",
+        "plan_tier": _paid_tier(),
+        "subscription_status": "active",
+        "concierge_enabled": True,
+    }
+    kw.update(ov)
+    return resolve_site_entitlements(**kw)
+
+
+# --------------------------------------------------------------------------- #
+# Layer 1 — the resolver. Pure, so every branch runs without a database.
+# --------------------------------------------------------------------------- #
+
+
+def test_a_free_site_is_not_entitled_to_a_concierge():
+    """The headline case. The owner's switch is ON and the plan still says no."""
+    ent = _resolve(plan_tier=_free_tier(), concierge_enabled=True)
+
+    assert ent.concierge_enabled is True  # the owner's intent, untouched
+    assert ent.concierge_entitled is False  # the plan's answer
+    assert ent.concierge_available is False  # what the seams ask
+
+
+def test_an_unset_tier_is_not_entitled():
+    """No ``plan_tier`` at all (pre-BC-9 rows, every first publish) resolves to the
+    floor. Fail-closed: absent is free, not exempt."""
+    assert _resolve(plan_tier=None).concierge_available is False
+
+
+def test_an_unknown_tier_is_not_entitled():
+    """A typo'd or retired tier key must not grant a paid capability."""
+    assert _resolve(plan_tier="enterprise_platinum").concierge_available is False
+
+
+@pytest.mark.parametrize("status", ["none", "pending", "cancelled"])
+def test_a_paid_tier_without_an_active_subscription_is_not_entitled(status):
+    """Cancellation never resets ``plan_tier``, and an unconfigured Dodo product
+    records a paid tier with no charge at all. Tier-alone would serve both."""
+    ent = _resolve(plan_tier=_paid_tier(), subscription_status=status)
+
+    assert ent.subscription_active is False
+    assert ent.concierge_entitled is False
+    assert ent.concierge_available is False
+
+
+def test_an_active_paid_site_is_entitled():
+    """The paying case still works — the gate must not become the bug."""
+    ent = _resolve(plan_tier=_paid_tier(), subscription_status="active")
+
+    assert ent.concierge_entitled is True
+    assert ent.concierge_available is True
+
+
+# --------------------------------------------------------------------------- #
+# The two questions are separate, and stay separate.
+# --------------------------------------------------------------------------- #
+
+
+def test_the_owner_switch_and_the_plan_are_distinguishable():
+    """Both roads lead to unavailable, and the REASON survives the trip.
+
+    This is the test that fails if someone folds the two fields into one boolean.
+    An owner who switched it off and an owner whose plan lapsed need different
+    remedies, so the dashboard has to be able to tell them apart.
+    """
+    owner_off = _resolve(plan_tier=_paid_tier(), concierge_enabled=False)
+    plan_says_no = _resolve(plan_tier=_free_tier(), concierge_enabled=True)
+
+    assert owner_off.concierge_available is False
+    assert plan_says_no.concierge_available is False
+    # ...and they are not the same state.
+    assert owner_off.concierge_enabled is False
+    assert owner_off.concierge_entitled is True
+    assert plan_says_no.concierge_enabled is True
+    assert plan_says_no.concierge_entitled is False
+
+
+def test_an_entitled_site_with_the_switch_off_stays_off():
+    """Entitlement never overrides the owner. Paying for a concierge does not force
+    one onto a site whose owner silenced it."""
+    assert _resolve(plan_tier=_paid_tier(), concierge_enabled=False).concierge_available is False
+
+
+# --------------------------------------------------------------------------- #
+# Layer 2 — the public seams. A refused visitor sees what a disabled one sees.
+# --------------------------------------------------------------------------- #
+
+
+async def _site(**ov):
+    from pocketpaw_ee.cloud.models.site import Site
+
+    d = dict(
+        workspace="ws-1",
+        pocket_id="pocket-1",
+        owner="user:maya",
+        script_name="",
+        signed_key=_VALID_KEY,
+        allowed_origins=["brewco.com"],
+        concierge_enabled=True,
+        plan_tier=_free_tier(),
+        subscription_status="none",
+    )
+    d.update(ov)
+    s = Site(**d)
+    await s.insert()
+    return s
+
+
+@pytest_asyncio.fixture
+async def frame_client(mongo_db):
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.paw_bar.router import router
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(router)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client
+
+
+@pytest.mark.asyncio
+async def test_the_frame_refuses_a_free_site_with_the_self_remove_message(
+    frame_client, monkeypatch
+):
+    """A refused frame tells the loader to remove the iframe, so the page shows
+    NOTHING — not even the invisible dock sliver.
+
+    ``po`` is the parent origin the loader always sends; the self-remove script is
+    emitted only when it survives the allowlist check, because postMessage needs a
+    concrete target origin. This is the same ``_dead_frame_response`` the owner's
+    kill switch already returns.
+    """
+    _enforce(monkeypatch, on=True)
+    await _site(plan_tier=_free_tier(), concierge_enabled=True)
+
+    res = await frame_client.get(
+        "/paw-bar/frame",
+        params={"key": _VALID_KEY, "w": "pp_seed", "po": "https://brewco.com"},
+    )
+
+    assert res.status_code == 403
+    assert "pawbar:dead" in res.text  # the loader's cue to remove the iframe
+    assert "window.__PAWBAR__" not in res.text  # no bootstrap config leaks
+
+
+@pytest.mark.asyncio
+async def test_the_refused_frame_never_renders_an_error_payload(frame_client, monkeypatch):
+    """The body lands inside a VISIBLE iframe on the customer's site, so it must be
+    blank — a JSON error is a defect, not a refusal. The 2026-07-30 rig showed a
+    literal {"detail":"concierge_disabled"} printed on a customer's page.
+
+    No ``po`` here, which is the harsher case: no self-remove script is emitted, so
+    the body is all the visitor could possibly see.
+    """
+    _enforce(monkeypatch, on=True)
+    await _site(plan_tier=_free_tier(), concierge_enabled=True)
+
+    res = await frame_client.get("/paw-bar/frame", params={"key": _VALID_KEY, "w": "pp_seed"})
+
+    assert res.status_code == 403
+    assert "concierge" not in res.text.lower()  # no reason leaks onto the page
+    assert "entitled" not in res.text.lower()
+    assert "plan" not in res.text.lower()
+    assert "<body></body>" in res.text  # nothing rendered at all
+
+
+@pytest.mark.asyncio
+async def test_the_frame_still_renders_for_an_entitled_site(frame_client, monkeypatch):
+    """A paying site is untouched — the gate must not take the bar off sites that
+    bought it."""
+    _enforce(monkeypatch, on=True)
+    await _site(plan_tier=_paid_tier(), subscription_status="active")
+
+    res = await frame_client.get("/paw-bar/frame", params={"key": _VALID_KEY, "w": "pp_seed"})
+
+    assert res.status_code == 200
+    assert "window.__PAWBAR__" in res.text
+
+
+@pytest.mark.asyncio
+async def test_the_frame_is_unaffected_when_billing_is_off(frame_client, monkeypatch):
+    """OSS / self-host has no billing and must not lose its concierge to this
+    branch."""
+    _enforce(monkeypatch, on=False)
+    await _site(plan_tier=_free_tier(), concierge_enabled=True)
+
+    res = await frame_client.get("/paw-bar/frame", params={"key": _VALID_KEY, "w": "pp_seed"})
+
+    assert res.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_chat_is_refused_for_a_free_site(mongo_db, monkeypatch):
+    """The key-resolution seam (chat / action / cart) refuses too, so the gate is not
+    a frame-only cosmetic. Without this, removing the iframe would still leave the
+    API answering anyone who called it directly."""
+    from fastapi import HTTPException
+    from pocketpaw_ee.cloud.auth.site_keys import resolve_site_key
+
+    _enforce(monkeypatch, on=True)
+    await _site(plan_tier=_free_tier(), concierge_enabled=True)
+
+    with pytest.raises(HTTPException) as exc:
+        await resolve_site_key(_VALID_KEY, "https://brewco.com", "cust_1")
+
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_chat_still_works_for_an_entitled_site(mongo_db, monkeypatch):
+    from pocketpaw_ee.cloud.auth.site_keys import resolve_site_key
+
+    _enforce(monkeypatch, on=True)
+    await _site(plan_tier=_paid_tier(), subscription_status="active")
+
+    ctx = await resolve_site_key(_VALID_KEY, "https://brewco.com", "cust_1")
+
+    assert ctx.workspace_id == "ws-1"
+
+
+@pytest.mark.asyncio
+async def test_the_billing_refusal_is_distinguishable_from_the_owner_switch(mongo_db, monkeypatch):
+    """Both refuse with 403 — the visitor experience is identical by design — but the
+    detail differs so logs and support can tell them apart."""
+    from fastapi import HTTPException
+    from pocketpaw_ee.cloud.auth.site_keys import resolve_site_key
+
+    _enforce(monkeypatch, on=True)
+    await _site(plan_tier=_free_tier(), concierge_enabled=True)
+
+    with pytest.raises(HTTPException) as exc:
+        await resolve_site_key(_VALID_KEY, "https://brewco.com", "cust_1")
+
+    assert exc.value.status_code == 403
+    assert exc.value.detail == "concierge_not_entitled"
+    assert exc.value.detail != "concierge_disabled"
+
+
+# --------------------------------------------------------------------------- #
+# Layer 3 — publish. An unentitled site ships with no snippet at all.
+# --------------------------------------------------------------------------- #
+
+
+@pytest_asyncio.fixture
+async def bound_widget(tmp_path):
+    """A pocket whose paw-bar widget exists AND is bound to an agent.
+
+    Every other ``concierge_snippet`` gate must PASS, or a test asserting "no
+    snippet" proves nothing — the first mutation sweep caught exactly that: with no
+    widget in the store, gate 3 returned "" on its own and the entitlement mutation
+    escaped while the test stayed green.
+    """
+    from unittest.mock import patch
+
+    from pocketpaw.paw_bar.models import PawBarSpec, PawBarWidget
+    from pocketpaw.paw_bar.store import PawBarStore
+
+    store = PawBarStore(tmp_path / "entitlement.db")
+    await store.create_widget(
+        PawBarWidget(
+            id="pp_bound",
+            pocket_id="pocket-1",
+            owner="user:maya",
+            workspace_id="ws-1",
+            agent_id="agent_1",  # bound: gate 4 passes
+            name="Bar",
+            spec=PawBarSpec(widget_id="pp_bound", pocket_id="pocket-1", blocks=[]),
+        )
+    )
+    with patch("pocketpaw_ee.api.get_paw_bar_store", return_value=store):
+        yield store
+
+
+@pytest.mark.asyncio
+async def test_an_unentitled_site_publishes_without_the_snippet(bound_widget, monkeypatch):
+    """The strongest form of "remove the bar": the built page never carries it.
+
+    ``concierge_snippet`` gate 1 already omits the snippet when the owner's switch is
+    off, and the marker is only ever written and never re-written, so the next build
+    regenerates the page clean. Routing the billing answer through the same gate
+    means an unentitled site's page ships bar-less rather than shipping a bar that
+    403s every visitor at runtime.
+    """
+    from pocketpaw_ee.paw_bar.embed import concierge_snippet
+
+    _enforce(monkeypatch, on=True)
+    snippet = await concierge_snippet(
+        workspace_id="ws-1",
+        pocket_id="pocket-1",
+        site_key=_VALID_KEY,
+        api_base="https://api.test/api/v1",
+        concierge_enabled=True,
+        concierge_entitled=False,
+    )
+
+    assert snippet == ""
+
+
+@pytest.mark.asyncio
+async def test_an_entitled_site_still_gets_its_snippet(bound_widget, monkeypatch):
+    """The control the test above needs to mean anything: with every other gate
+    passing and entitlement granted, the snippet IS produced. Without this, a
+    ``return ""`` at the top of the function would satisfy the assertion above."""
+    from pocketpaw_ee.paw_bar.embed import concierge_snippet
+
+    _enforce(monkeypatch, on=True)
+    snippet = await concierge_snippet(
+        workspace_id="ws-1",
+        pocket_id="pocket-1",
+        site_key=_VALID_KEY,
+        api_base="https://api.test/api/v1",
+        concierge_enabled=True,
+        concierge_entitled=True,
+    )
+
+    assert snippet != ""
+    assert "pp_bound" in snippet

--- a/tests/cloud/test_paw_bar_concierge_entitlement.py
+++ b/tests/cloud/test_paw_bar_concierge_entitlement.py
@@ -344,6 +344,71 @@ async def bound_widget(tmp_path):
         yield store
 
 
+# --------------------------------------------------------------------------- #
+# The charge-first deploy — a paying customer must not get a bar-less page.
+#
+# Found by review before this shipped. ``activate_pending_site`` runs on the
+# ``subscription.active`` webhook (payment CONFIRMED) and calls ``_deploy_site_doc``
+# — which reaches ``_embed_concierge_bar`` — BEFORE it flips ``subscription_status``
+# to "active" a few lines later. So the publish-time embed sees "pending" for a
+# customer who has already paid. Refusing there ships a page with no bar, and
+# NOTHING republishes afterwards: the activation path saves the status and stops.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_the_publish_embed_treats_a_pending_subscription_as_paid(bound_widget, monkeypatch):
+    """The charge-first regression. Payment is confirmed and the deploy is running;
+    the status flip has not happened yet. The page must ship WITH its bar."""
+    from pocketpaw_ee.cloud.entitlements.service import resolve_site_entitlements
+    from pocketpaw_ee.paw_bar.embed import concierge_snippet
+
+    _enforce(monkeypatch, on=True)
+    # What the resolver says in isolation — "pending" is NOT entitled, and that is
+    # correct for the runtime gate. The publish seam deliberately reads it as active.
+    ent = resolve_site_entitlements(
+        site_id="6512c1f0e4b0a1b2c3d4e5f6",
+        workspace_id="ws-1",
+        plan_tier=_paid_tier(),
+        subscription_status="pending",
+        concierge_enabled=True,
+    )
+    assert ent.concierge_entitled is False
+
+    snippet = await concierge_snippet(
+        workspace_id="ws-1",
+        pocket_id="pocket-1",
+        site_key=_VALID_KEY,
+        api_base="https://api.test/api/v1",
+        concierge_enabled=True,
+        # The publish path's own resolution, which maps pending -> active.
+        concierge_entitled=True,
+    )
+
+    assert snippet != ""
+
+
+@pytest.mark.asyncio
+async def test_the_runtime_gate_still_refuses_pending(mongo_db, monkeypatch):
+    """The other half of the same decision: publish is lenient, RUNTIME is not.
+
+    A site deployed with a bar but not yet activated serves a bar that declines
+    until the webhook lands — seconds, and self-correcting in the right direction.
+    If this ever passes, the leniency has leaked out of the publish seam.
+    """
+    from fastapi import HTTPException
+    from pocketpaw_ee.cloud.auth.site_keys import resolve_site_key
+
+    _enforce(monkeypatch, on=True)
+    await _site(plan_tier=_paid_tier(), subscription_status="pending")
+
+    with pytest.raises(HTTPException) as exc:
+        await resolve_site_key(_VALID_KEY, "https://brewco.com", "customer_abc123")
+
+    assert exc.value.status_code == 403
+    assert exc.value.detail == "concierge_not_entitled"
+
+
 @pytest.mark.asyncio
 async def test_an_unentitled_site_publishes_without_the_snippet(bound_widget, monkeypatch):
     """The strongest form of "remove the bar": the built page never carries it.

--- a/tests/ee/sites/test_concierge_autoembed.py
+++ b/tests/ee/sites/test_concierge_autoembed.py
@@ -173,6 +173,11 @@ async def _snippet_for(monkeypatch, *, widget, **ov):
         "site_key": _KEY,
         "api_base": _API_BASE,
         "concierge_enabled": True,
+        # Required since feat/sites-concierge-entitlement. These cases are about the
+        # OTHER gates (owner switch, key, widget, binding), so entitlement is granted
+        # and held constant; the billing gate has its own tree in
+        # tests/cloud/test_paw_bar_concierge_entitlement.py.
+        "concierge_entitled": True,
     }
     kwargs.update(ov)
     return await embed.concierge_snippet(**kwargs)
@@ -221,6 +226,7 @@ async def test_an_empty_pocket_never_widens_onto_a_sibling(monkeypatch):
         site_key=_KEY,
         api_base=_API_BASE,
         concierge_enabled=True,
+        concierge_entitled=True,
     )
 
     assert out == ""
@@ -344,4 +350,134 @@ async def test_a_broken_injection_never_costs_the_site_its_deploy(
     site = await _publish(tmp_path)
 
     assert site.deployed is True
+    assert all("paw-bar/widget.js" not in page for page in _built_pages(tmp_path))
+
+
+# --------------------------------------------------------------------------- #
+# The BILLING gate at the publish seam (feat/sites-concierge-entitlement).
+#
+# These exist because review found the publish-path resolver in
+# ``_embed_concierge_bar`` had no test at all: the entitlement tree calls
+# ``concierge_snippet`` directly, so deleting the whole
+# ``if get_settings().billing_enforced:`` block left the suite green. That block is
+# also exactly where the charge-first bug lived, which is why it went unnoticed.
+# --------------------------------------------------------------------------- #
+
+
+def _billing(monkeypatch, *, on: bool) -> None:
+    """Point the lazily-imported ``get_settings`` at a billing-posture stub."""
+    from types import SimpleNamespace
+
+    import pocketpaw.config as ppconfig
+
+    monkeypatch.setattr(
+        ppconfig,
+        "get_settings",
+        lambda: SimpleNamespace(billing_enforced=on, dodo_site_products=None),
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_free_site_publishes_with_no_bar_when_billing_is_enforced(
+    beanie_test_db, tmp_path, monkeypatch
+):
+    """The publish-seam half of the billing gate. A first publish has no Site doc, so
+    no ``plan_tier``, which resolves to the free floor — the page ships bar-less
+    rather than carrying a bar that would 403 every visitor."""
+    monkeypatch.setenv("PAW_SITES_LOCAL", "1")
+    _billing(monkeypatch, on=True)
+    _fake_store(monkeypatch, _widget())
+
+    await _publish(tmp_path)
+
+    assert all("paw-bar/widget.js" not in page for page in _built_pages(tmp_path))
+
+
+@pytest.mark.asyncio
+async def test_with_billing_off_a_publish_is_byte_for_byte_what_it_was(
+    beanie_test_db, tmp_path, monkeypatch
+):
+    """OSS / self-host, and every in-repo deploy today. The gate must not take the
+    bar off a publish that never had billing."""
+    monkeypatch.setenv("PAW_SITES_LOCAL", "1")
+    _billing(monkeypatch, on=False)
+    _fake_store(monkeypatch, _widget())
+
+    await _publish(tmp_path)
+
+    pages = _built_pages(tmp_path)
+    assert len(pages) == 2
+    assert all("/paw-bar/widget.js" in page for page in pages)
+
+
+@pytest.mark.asyncio
+async def test_a_paying_site_mid_activation_still_gets_its_bar(
+    beanie_test_db, tmp_path, monkeypatch
+):
+    """THE CHARGE-FIRST REGRESSION, at the seam it actually broke.
+
+    ``activate_site`` runs on the ``subscription.active`` webhook — payment already
+    confirmed — and deploys the site. A republish onto a paid tier likewise parks a
+    live site at "pending" until the new sub confirms, and ``_apply_site_plan``
+    stamps the plan AFTER ``publish()`` has deployed. All three mean this seam can
+    see "pending" for someone who has paid.
+
+    Refusing there ships a page with no loader script, and nothing re-runs the embed
+    afterwards — it stays bar-less until some unrelated publish. So "pending" is read
+    as paid HERE, while the runtime gate keeps refusing it (pinned in
+    tests/cloud/test_paw_bar_concierge_entitlement.py).
+    """
+    from pocketpaw_ee.cloud.billing import site_plans
+    from pocketpaw_ee.cloud.models.site import Site
+
+    monkeypatch.setenv("PAW_SITES_LOCAL", "1")
+    _billing(monkeypatch, on=True)
+    _fake_store(monkeypatch, _widget())
+    paid = next(
+        t.key for t in site_plans.list_site_plans() if t.key != site_plans.BASE_SITE_PLAN_KEY
+    )
+
+    # First publish creates the doc; then put it in the exact mid-activation state.
+    site = await _publish(tmp_path)
+    doc = await Site.get(site.id)
+    doc.plan_tier = paid
+    doc.subscription_status = "pending"
+    await doc.save()
+
+    await _publish(tmp_path)
+
+    pages = _built_pages(tmp_path)
+    assert len(pages) == 2
+    assert all("/paw-bar/widget.js" in page for page in pages), (
+        "a paying customer's page shipped with no concierge loader"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_cancelled_paid_site_loses_its_bar_on_the_next_publish(
+    beanie_test_db, tmp_path, monkeypatch
+):
+    """The control for the test above: leniency is scoped to "pending" alone.
+
+    Cancellation never resets ``plan_tier``, so a resolver reading the tier by itself
+    would keep serving this site forever.
+    """
+    from pocketpaw_ee.cloud.billing import site_plans
+    from pocketpaw_ee.cloud.models.site import Site
+
+    monkeypatch.setenv("PAW_SITES_LOCAL", "1")
+    _billing(monkeypatch, on=True)
+    _fake_store(monkeypatch, _widget())
+    paid = next(
+        t.key for t in site_plans.list_site_plans() if t.key != site_plans.BASE_SITE_PLAN_KEY
+    )
+
+    site = await _publish(tmp_path)
+    doc = await Site.get(site.id)
+    doc.plan_tier = paid
+    doc.subscription_status = "cancelled"
+    await doc.save()
+
+    await _publish(tmp_path)
+
     assert all("paw-bar/widget.js" not in page for page in _built_pages(tmp_path))

--- a/tests/mutations/concierge_entitlement.json
+++ b/tests/mutations/concierge_entitlement.json
@@ -1,0 +1,125 @@
+[
+  {
+    "label": "the plan is never consulted — concierge_entitled reverts to a pass-through",
+    "file": "ee/pocketpaw_ee/cloud/entitlements/service.py",
+    "find": "        concierge_entitled = tier.key != site_plan_catalog.BASE_SITE_PLAN_KEY",
+    "replace": "        concierge_entitled = True",
+    "tests": [
+      "tests/cloud/test_paw_bar_concierge_entitlement.py::test_a_free_site_is_not_entitled_to_a_concierge",
+      "tests/cloud/test_paw_bar_concierge_entitlement.py::test_an_unset_tier_is_not_entitled"
+    ]
+  },
+  {
+    "label": "the fail-closed default inverts — an unknown tier is handed a concierge",
+    "file": "ee/pocketpaw_ee/cloud/entitlements/service.py",
+    "find": "    concierge_entitled = False",
+    "replace": "    concierge_entitled = True",
+    "tests": [
+      "tests/cloud/test_paw_bar_concierge_entitlement.py::test_an_unknown_tier_is_not_entitled",
+      "tests/cloud/test_paw_bar_concierge_entitlement.py::test_a_paid_tier_without_an_active_subscription_is_not_entitled",
+      "tests/cloud/test_paw_bar_concierge_entitlement.py::test_an_unset_tier_is_not_entitled"
+    ]
+  },
+  {
+    "label": "the subscription is ignored — a lapsed paid tier keeps its concierge",
+    "file": "ee/pocketpaw_ee/cloud/entitlements/service.py",
+    "find": "    if tier is not None and subscription_active:\n        badge_removal = tier.badge_removal",
+    "replace": "    if tier is not None:\n        badge_removal = tier.badge_removal",
+    "tests": [
+      "tests/cloud/test_paw_bar_concierge_entitlement.py::test_a_paid_tier_without_an_active_subscription_is_not_entitled"
+    ]
+  },
+  {
+    "label": "concierge_available drops the plan half and echoes the owner switch",
+    "file": "ee/pocketpaw_ee/cloud/entitlements/domain.py",
+    "find": "        return self.concierge_enabled and self.concierge_entitled",
+    "replace": "        return self.concierge_enabled",
+    "tests": [
+      "tests/cloud/test_paw_bar_concierge_entitlement.py::test_a_free_site_is_not_entitled_to_a_concierge",
+      "tests/cloud/test_paw_bar_concierge_entitlement.py::test_the_owner_switch_and_the_plan_are_distinguishable"
+    ]
+  },
+  {
+    "label": "concierge_available drops the owner half — entitlement overrides the switch",
+    "file": "ee/pocketpaw_ee/cloud/entitlements/domain.py",
+    "find": "        return self.concierge_enabled and self.concierge_entitled",
+    "replace": "        return self.concierge_entitled",
+    "tests": [
+      "tests/cloud/test_paw_bar_concierge_entitlement.py::test_an_entitled_site_with_the_switch_off_stays_off"
+    ]
+  },
+  {
+    "label": "the chat/action seam stops asking the plan",
+    "file": "ee/pocketpaw_ee/cloud/auth/site_keys.py",
+    "find": "    if not concierge_available(site):\n        raise HTTPException(status_code=403, detail=\"concierge_not_entitled\")",
+    "replace": "    pass",
+    "tests": [
+      "tests/cloud/test_paw_bar_concierge_entitlement.py::test_chat_is_refused_for_a_free_site"
+    ]
+  },
+  {
+    "label": "the frame stops asking the plan — a free site's bar renders",
+    "file": "ee/pocketpaw_ee/paw_bar/router.py",
+    "find": "    if not concierge_available(site):\n        return _dead_frame_response(po, site.allowed_origins)",
+    "replace": "    pass",
+    "tests": [
+      "tests/cloud/test_paw_bar_concierge_entitlement.py::test_the_frame_refuses_a_free_site_with_the_self_remove_message"
+    ]
+  },
+  {
+    "label": "the frame refuses with a JSON error rendered onto the customer's page",
+    "file": "ee/pocketpaw_ee/paw_bar/router.py",
+    "find": "    if not concierge_available(site):\n        return _dead_frame_response(po, site.allowed_origins)",
+    "replace": "    if not concierge_available(site):\n        raise HTTPException(status_code=403, detail=\"concierge_not_entitled\")",
+    "tests": [
+      "tests/cloud/test_paw_bar_concierge_entitlement.py::test_the_refused_frame_never_renders_an_error_payload"
+    ]
+  },
+  {
+    "label": "the billing_enforced guard is dropped — OSS/self-host loses its concierge",
+    "file": "ee/pocketpaw_ee/cloud/auth/site_keys.py",
+    "find": "    if not get_settings().billing_enforced:\n        return True",
+    "replace": "    if False:\n        return True",
+    "tests": [
+      "tests/cloud/test_paw_bar_concierge_entitlement.py::test_the_frame_is_unaffected_when_billing_is_off"
+    ]
+  },
+  {
+    "label": "the guard inverts — the gate fires ONLY when billing is off",
+    "file": "ee/pocketpaw_ee/cloud/auth/site_keys.py",
+    "find": "    if not get_settings().billing_enforced:\n        return True",
+    "replace": "    if get_settings().billing_enforced:\n        return True",
+    "tests": [
+      "tests/cloud/test_paw_bar_concierge_entitlement.py::test_chat_is_refused_for_a_free_site",
+      "tests/cloud/test_paw_bar_concierge_entitlement.py::test_the_frame_is_unaffected_when_billing_is_off"
+    ]
+  },
+  {
+    "label": "the billing refusal is indistinguishable from the owner's switch",
+    "file": "ee/pocketpaw_ee/cloud/auth/site_keys.py",
+    "find": "        raise HTTPException(status_code=403, detail=\"concierge_not_entitled\")",
+    "replace": "        raise HTTPException(status_code=403, detail=\"concierge_disabled\")",
+    "tests": [
+      "tests/cloud/test_paw_bar_concierge_entitlement.py::test_the_billing_refusal_is_distinguishable_from_the_owner_switch"
+    ]
+  },
+  {
+    "label": "the entitled path breaks too — the gate refuses every site",
+    "file": "ee/pocketpaw_ee/cloud/auth/site_keys.py",
+    "find": "    return ent.concierge_entitled",
+    "replace": "    return False",
+    "tests": [
+      "tests/cloud/test_paw_bar_concierge_entitlement.py::test_chat_still_works_for_an_entitled_site",
+      "tests/cloud/test_paw_bar_concierge_entitlement.py::test_the_frame_still_renders_for_an_entitled_site"
+    ]
+  },
+  {
+    "label": "publish embeds the bar on an unentitled site — it would 403 every visitor",
+    "file": "ee/pocketpaw_ee/paw_bar/embed.py",
+    "find": "    if not concierge_enabled or not concierge_entitled or not site_key or not pocket_id:",
+    "replace": "    if not concierge_enabled or not site_key or not pocket_id:",
+    "tests": [
+      "tests/cloud/test_paw_bar_concierge_entitlement.py::test_an_unentitled_site_publishes_without_the_snippet"
+    ]
+  }
+]

--- a/tests/mutations/concierge_entitlement.json
+++ b/tests/mutations/concierge_entitlement.json
@@ -121,5 +121,42 @@
     "tests": [
       "tests/cloud/test_paw_bar_concierge_entitlement.py::test_an_unentitled_site_publishes_without_the_snippet"
     ]
+  },
+  {
+    "label": "the publish-path resolver is deleted entirely",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        if get_settings().billing_enforced:\n            from pocketpaw_ee.cloud.entitlements import service as entitlements_service",
+    "replace": "        if False:\n            from pocketpaw_ee.cloud.entitlements import service as entitlements_service",
+    "tests": [
+      "tests/ee/sites/test_concierge_autoembed.py::test_a_free_site_publishes_with_no_bar_when_billing_is_enforced",
+      "tests/ee/sites/test_concierge_autoembed.py::test_a_cancelled_paid_site_loses_its_bar_on_the_next_publish"
+    ]
+  },
+  {
+    "label": "the charge-first window reopens — pending is refused at publish",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "                subscription_status=\"active\" if status == \"pending\" else status,",
+    "replace": "                subscription_status=status,",
+    "tests": [
+      "tests/ee/sites/test_concierge_autoembed.py::test_a_paying_site_mid_activation_still_gets_its_bar"
+    ]
+  },
+  {
+    "label": "activation flips the status AFTER the deploy again (the original P0)",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    doc.subscription_status = \"active\"\n    await doc.save()\n\n    deployed = await _deploy_site_doc(",
+    "replace": "    deployed = await _deploy_site_doc(",
+    "tests": [
+      "tests/cloud/sites/test_charge_first.py::test_the_subscription_reads_active_before_the_activation_deploy_runs"
+    ]
+  },
+  {
+    "label": "the publish seam grants entitlement to a CANCELLED site too",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "                subscription_status=\"active\" if status == \"pending\" else status,",
+    "replace": "                subscription_status=\"active\",",
+    "tests": [
+      "tests/ee/sites/test_concierge_autoembed.py::test_a_cancelled_paid_site_loses_its_bar_on_the_next_publish"
+    ]
   }
 ]


### PR DESCRIPTION
`SiteEntitlements.concierge_enabled` was a straight pass-through of the owner's kill switch. It echoed whatever the caller handed it and read no tier, no subscription, nothing — while its two siblings on the same object, `badge_required` and `custom_domain`, both gate on tier **and** an active subscription.

So a free site turned its concierge on and served it indefinitely. So did a paid site whose subscription had lapsed, since cancellation never resets `plan_tier`.

Step 2 of the pricing build order (qbtrix/paw-workspace#158), alongside #1941. Same class of hole as the badge (#1937) and the custom domain, in the third and last of the per-site paid capabilities.

## What is not new here

The disable → remove chain already existed and is untouched:

`site.concierge_enabled=False` → `site_keys` 403s chat/action → the frame returns `_dead_frame_response` → posts `pawbar:dead` → the loader calls `iframe.remove()`.

This PR adds the *billing reason* to trigger it and reuses that path byte for byte. A visitor to a refused site sees exactly what a visitor to an owner-disabled one sees: nothing, not even the invisible dock sliver. Nothing on the page says why.

## The rule

Any tier above the free floor, with an active subscription.

Derived from `BASE_SITE_PLAN_KEY` rather than a per-tier catalog flag like `badge_removal`. No tier grants concierge today, and the tier that will (`staff`) does not exist until the catalog rekey, which is blocked on open decision #8. A flag would need a `basic`/`pro`/`business` mapping invented now and rewritten then. "Paid and paying" needs no mapping and survives the rekey untouched.

## Two questions, two fields

`concierge_enabled` (the owner's switch) and `concierge_entitled` (the plan's answer) stay separate, and a test pins that they do. Collapsing them into one boolean makes "off" unattributable — support could not tell an owner who flipped the switch from an owner whose subscription lapsed, and those need different remedies.

`concierge_available` is the AND of the two, and is what every seam asks, so no caller has to remember to check both.

## Three seams, one helper

`auth.site_keys.concierge_available(site)` holds the rule; each seam refuses in its own idiom.

| Seam | Refusal |
|---|---|
| chat / action / cart | 403 `concierge_not_entitled`, beside the owner's 403 `concierge_disabled` — same status, distinct detail |
| the frame | the same `_dead_frame_response` the kill switch returns |
| publish | `concierge_snippet` omits the snippet, so the built page ships bar-less |

The publish seam matters most for "remove the bar": without it, an unentitled site's page would carry a bar that 403s every visitor, which is worse than no bar.

Synchronous and passed the already-loaded Site doc — the gate holds it, the resolver is pure and may not import `models.site` (EE cloud rule 2). No extra query on a path that runs for every visitor message.

Fails closed on a first publish (no doc means no `plan_tier`, resolving to the floor), the same posture the badge stamper takes. Gated on `billing_enforced` throughout, so OSS / self-host is unaffected — with billing off only the owner's switch applies, exactly as before.

## Verification

18 tests; the 4 seam tests were red before the wiring. 183 passing across paw_bar frame / settings / chat, entitlements, and sites. `ruff check` and `ruff format` clean.

13 mutations, all caught. **One escaped the first sweep** and the reason is recorded in the test file: with no widget in the store, an unrelated `concierge_snippet` gate returned `""` on its own, so the publish assertion passed while the entitlement gate did not exist. The fixture now satisfies every other gate, so only the billing one can produce the empty result.

13 failures in the wider local `paw_bar` tree are pre-existing and unrelated — three distinct modes (a CRLF line-ending comparison, a `SurfacePreamble` API drift, a missing agent fixture), none of them touching entitlements, and `dev` CI is green on the same suite.

## Not in this PR

Anything metered. Allowance, overage, and conversation counting are blocked on open decision #5 (which meter owns a concierge run). This is the binary enable/disable gate only.

---

## Update after review

An adversarial review pass found a **P0 in the seam that feeds this gate**, and it is the reason this PR grew a second commit. Worth reading before the diff.

### A paying customer's site was deployed branded as free

`activate_site` runs on the `subscription.active` webhook — payment already confirmed. Its order was: deploy, **then** set `subscription_status="active"`.

But the deploy is where the paid capabilities get stamped. `_embed_concierge_bar` and `_stamp_free_badge` both re-read the Site doc mid-deploy and resolve entitlements off that field, so both saw `"pending"`. The customer who had just paid got a live page carrying the **free attribution badge** and **no concierge loader**, and nothing re-runs either stamper afterwards. A republish makes it recur, because `_publish_pending_site` resets the status to `"pending"` every time.

The badge half of that **has been shipping since #1937**. The concierge half would have shipped with this branch.

Fixed by the ordering: flip the status before the deploy, saved separately so the doc the stampers re-read carries it. On a deploy failure the row is `active` with `deployed=False` for the retry window, and the webhook's idempotency guard keys on `deployed AND active`, so a retry still re-enters and re-deploys — a paid site that retries beats a paid site permanently branded free.

Belt and braces at the embed itself: `"pending"` reads as paid there too, because `_apply_site_plan` stamps the plan *after* `publish()` has deployed, so a live publish can reach that seam pending as well. The **runtime** gate still refuses `pending`, and a test pins that — a bar that declines for the seconds until the webhook lands is self-correcting; a page with no loader is not.

### The rest of the review

- **`concierge_entitled` is now required, not defaulted `True`.** With a default, deleting the resolution in `_embed_concierge_bar` left *working code that silently embeds everywhere* instead of a `TypeError`. A gate whose removal compiles is not a gate.
- **The publish-path resolver had no test at all.** The entitlement tree calls `concierge_snippet` directly, so the whole `if billing_enforced:` block could be deleted with the suite green — and that block is exactly where the P0 lived. Four tests now drive it through a real publish, including the charge-first state and a cancelled-site control.
- A publish that skips the bar for entitlement now **logs why**. The silent early return is the exact shape of the 2026-07-30 provisioning bug this file documents ("with no log line, because the empty snippet returns early").
- `concierge_available` added to `__all__`.
- **Corrected a false claim in my own docstring:** it said the `billing_enforced` gating matched "every other cap in this codebase". It does not — `_stamp_free_badge` resolves the same per-site entitlements and does *not* check the flag. The comment now says so and explains why the stricter default is the safer one here.

### Verified rather than asserted

- **All 8 public paw-bar routes** that take a site key trace to the gate: `frame` inline, `chat` via `resolve_site_key_with_site`, and the other six via `_front_gate_for_key` → the same resolver. Three were probed at runtime — 403 `concierge_not_entitled` unentitled, 200 entitled.
- **Exactly one DB query** per concierge request, measured by counting `find_one` calls through a resolve. The "no extra query on the hot path" claim is not an assumption.

Mutation plan grows 13 → 17, all caught. The ordering mutation **escaped the first sweep**, which is precisely how the P0 stayed invisible. 190 passing across paw_bar, sites, charge-first and entitlements.

### Known, not fixed here

Three legacy widget-keyed routes (`GET /paw-bar/spec/{widget_id}`, `POST /paw-bar/events/{widget_id}`, and the decision poll) authenticate on `widget_id` + origin only and never load a Site, so they structurally cannot reach this gate. They still persist events and raise Instinct proposals for an unentitled site. That is the legacy inline-widget surface rather than the concierge, and exposure is bounded — an unentitled site no longer gets a snippet, so it needs a page published before the gate or a hand-copied one. Flagging it as a product call, not fixing it silently here.
