### PR TITLE
pydantic-ai never delivered its tool arguments

### DIFF
--- a/src/pocketpaw/agents/pydantic_ai.py
+++ b/src/pocketpaw/agents/pydantic_ai.py
@@ -248,11 +248,35 @@ with a pydantic-ai that can place a per-run string ahead of capability
 instructions WITHOUT replacing the ones it resolves per run —
 ``test_capability_instructions_are_still_contributed_at_run_time`` in
 tests/test_prompt_backend_digest.py is the tripwire for that day.
+
+Updated 2026-08-15 (HTN-9, fix/pydantic-ai-tool-args) — **this backend never
+delivered its tool arguments.** Every ``tool_use`` it emitted carried
+``input={}``, so anything rendering a call's arguments ("Searching the web for
+{query}") degraded to the bare tool name. Two independent defects, either
+sufficient on its own:
+
+1. ``_announce_tool`` deduped on ``tool_call_id`` alone, and the early
+   ``PartStartEvent`` signal claims that id first with a placeholder ``{}`` — so
+   the authoritative ``FunctionToolCallEvent`` was returned early and discarded.
+   The dedupe is now qualified by phase.
+2. pydantic-ai types ``ToolCallPart.args`` as ``str | dict | None`` and the
+   STREAMED path — the only one used here — delivers JSON **text**. The metadata
+   builder kept it only ``if isinstance(args, dict)``, coercing every real
+   streamed call to ``{}``. ``_tool_args_as_dict`` decodes it.
+
+Fixing only the dedupe still ships ``{}``, which is why the guard test asserts
+the exact argument dict rather than a mere event count.
+
+One call now emits TWO ``tool_use`` events — provisional then resolved — under
+the ``input_pending`` contract documented on ``AgentEvent`` in ``protocol.py``
+and shared with ``claude_sdk``. A consumer that APPENDS per event must skip
+``input_pending is True``.
 """
 
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import re
 from collections import OrderedDict
@@ -1962,8 +1986,10 @@ class PydanticAIBackend:
         handle = _RunHandle()
         self._active.add(handle)
 
-        # Tool ids already announced, so the early PartStartEvent signal and the
-        # authoritative FunctionToolCallEvent don't double-announce one call.
+        # Tool calls already announced, keyed "<phase>:<call_id>". Phase-qualified
+        # so the early PartStartEvent signal and the authoritative
+        # FunctionToolCallEvent each get through once for one call — see
+        # ``_announce_tool`` for why the id alone was the wrong key.
         announced: set[str] = set()
 
         try:
@@ -2106,8 +2132,10 @@ class PydanticAIBackend:
                 out.append(AgentEvent(type="thinking", content=part.content))
             elif isinstance(part, ToolCallPart):
                 # Early signal so the UI flips from "Thinking..." to
-                # "Using <tool>..." before the args finish streaming.
-                self._announce_tool(part, announced, out, args={})
+                # "Using <tool>..." before the args finish streaming. Flagged
+                # provisional: the args are not final yet, and the resolved
+                # event below is the one that carries them.
+                self._announce_tool(part, announced, out, args={}, pending=True)
 
         elif isinstance(event, PartDeltaEvent):
             delta = event.delta
@@ -2117,7 +2145,8 @@ class PydanticAIBackend:
                 out.append(AgentEvent(type="thinking", content=delta.content_delta))
 
         elif isinstance(event, FunctionToolCallEvent):
-            self._announce_tool(event.part, announced, out, args=event.part.args)
+            # Authoritative: the arguments the tool is actually invoked with.
+            self._announce_tool(event.part, announced, out, args=event.part.args, pending=False)
 
         elif isinstance(event, FunctionToolResultEvent):
             part = event.part
@@ -2139,21 +2168,82 @@ class PydanticAIBackend:
         return out
 
     @staticmethod
-    def _announce_tool(part: Any, announced: set[str], out: list[AgentEvent], *, args: Any) -> None:
-        """Emit a ``tool_use`` for *part* unless its call id was already announced."""
+    def _tool_args_as_dict(args: Any) -> dict:
+        """Normalize ``ToolCallPart.args`` to the dict the ``input`` contract promises.
+
+        pydantic-ai types ``args`` as ``str | dict | None`` and the STREAMED path
+        — the only one this backend uses — delivers the JSON **text**, not the
+        decoded mapping. A plain ``isinstance(args, dict)`` guard therefore
+        discards the arguments of every real streamed call.
+
+        Anything that does not decode to a JSON object becomes ``{}``. Consumers
+        index this (``input["query"]``), so a non-mapping is worse than empty;
+        ``ToolCallPart.args_as_dict()`` is deliberately not used here because it
+        answers malformed input with an ``{"INVALID_JSON": ...}`` sentinel that
+        would reach the UI as if the model had passed an argument by that name.
+        """
+        if isinstance(args, dict):
+            return args
+        if isinstance(args, str):
+            try:
+                decoded = json.loads(args)
+            except (ValueError, TypeError):
+                return {}
+            return decoded if isinstance(decoded, dict) else {}
+        return {}
+
+    @staticmethod
+    def _announce_tool(
+        part: Any,
+        announced: set[str],
+        out: list[AgentEvent],
+        *,
+        args: Any,
+        pending: bool,
+    ) -> None:
+        """Emit a ``tool_use`` for *part*, deduped per call id AND per phase.
+
+        ONE tool call legitimately produces TWO events here, and the difference
+        between them is what ``input_pending`` exists to state:
+
+        * ``pending=True`` — the PROVISIONAL announcement, emitted the moment the
+          name is known so the UI can leave "Thinking...". Its ``input`` is a
+          placeholder and is NOT what the tool will run with.
+        * ``pending=False`` — the RESOLVED event, carrying the final arguments.
+
+        The dedupe is qualified by phase rather than by id alone. Keying on the
+        id alone made the provisional event suppress the resolved one, so
+        ``input`` was permanently ``{}`` on this backend and a caller rendering
+        "Searching the web for {query}" had nothing to interpolate. Keeping the
+        id in the key still stops a repeat of either phase from stacking a
+        duplicate row for one call.
+
+        The canonical statement of this contract lives on ``AgentEvent`` in
+        ``agents/protocol.py``; ``claude_sdk`` announces the same way, and
+        ``deep_agents`` emits once already-resolved (an ABSENT flag reads as
+        resolved, so a single-event backend needs no flag). Consumers that APPEND
+        per event — a log, an activity feed, a pending-call list — must skip
+        ``input_pending is True`` or they record a phantom call carrying no
+        arguments.
+        """
         name = getattr(part, "tool_name", None)
         if not name:
             return
         call_id = getattr(part, "tool_call_id", None)
         if call_id:
-            if call_id in announced:
+            key = f"{'pending' if pending else 'final'}:{call_id}"
+            if key in announced:
                 return
-            announced.add(call_id)
+            announced.add(key)
         out.append(
             AgentEvent(
                 type="tool_use",
                 content=f"Using {name}...",
-                metadata={"name": name, "input": args if isinstance(args, dict) else {}},
+                metadata={
+                    "name": name,
+                    "input": PydanticAIBackend._tool_args_as_dict(args),
+                    "input_pending": pending,
+                },
             )
         )
 

--- a/tests/test_pydantic_ai_backend.py
+++ b/tests/test_pydantic_ai_backend.py
@@ -17,6 +17,15 @@ written after the probe, not before.
 
 Everything here runs against pydantic-ai's ``TestModel`` / ``FunctionModel``, so
 no provider key and no network are required.
+
+Updated 2026-08-15 (HTN-9, fix/pydantic-ai-tool-args) — the tool-announcement
+tests now assert the ``input_pending`` contract and, above all, the ARGUMENTS.
+``test_tool_use_announced_once_per_call_id`` used to assert exactly one
+``tool_use`` per call and passed for the life of the backend while ``input`` was
+unconditionally ``{}`` — counting events proved the dedupe worked and said
+nothing about whether the arguments survived it. Its replacement counts one
+event PER PHASE, and ``test_streamed_tool_call_delivers_its_real_arguments``
+pins the payload the count test could never see.
 """
 
 from __future__ import annotations
@@ -222,13 +231,18 @@ async def test_run_emits_tool_use_and_tool_result_in_order():
     assert "echoed x" in result.content
 
 
-async def test_tool_use_announced_once_per_call_id():
-    """The early PartStartEvent signal and the authoritative
-    FunctionToolCallEvent describe the SAME call — the UI must see one."""
+def _search_backend(tool_call_id: str | None):
+    """A backend whose model streams one ``web_search`` call carrying arguments."""
 
     async def stream_fn(messages: list[ModelMessage], info: AgentInfo):
         if len(messages) == 1:
-            yield {0: DeltaToolCall(name="ping", json_args="{}", tool_call_id="dup-1")}
+            yield {
+                0: DeltaToolCall(
+                    name="web_search",
+                    json_args='{"query": "pocketpaw"}',
+                    tool_call_id=tool_call_id,
+                )
+            }
         else:
             yield "ok"
 
@@ -236,14 +250,118 @@ async def test_tool_use_announced_once_per_call_id():
 
     from pydantic_ai.tools import Tool
 
-    async def ping() -> str:
-        """Ping."""
-        return "pong"
+    async def web_search(query: str) -> str:
+        """Search the web."""
+        return f"results for {query}"
 
-    backend._custom_tools = [Tool(ping, name="ping", description="Ping.")]
+    backend._custom_tools = [Tool(web_search, name="web_search", description="Search the web.")]
+    return backend
 
-    events = await _collect(backend, "ping it")
-    assert sum(1 for e in events if e.type == "tool_use") == 1
+
+async def test_streamed_tool_call_delivers_its_real_arguments():
+    """The resolved ``tool_use`` must carry the arguments the tool RAN with.
+
+    Two separate defects used to swallow them, and either one alone is enough to
+    strand a consumer on ``{}`` — which is why this asserts the exact dict and
+    not merely a non-empty one:
+
+    1. ``_announce_tool`` deduped on ``tool_call_id``, so the authoritative
+       ``FunctionToolCallEvent`` returned early behind the early
+       ``PartStartEvent`` signal that had already claimed the id with ``{}``.
+    2. pydantic-ai delivers streamed ``ToolCallPart.args`` as a JSON **string**,
+       and the metadata builder kept it only ``if isinstance(args, dict)`` —
+       so the string was coerced to ``{}`` even once the dedupe let it through.
+
+    A feature rendering "Searching the web for {query}" degrades to a bare
+    "Searching the web" on this backend whenever either regresses.
+    """
+    events = await _collect(_search_backend("c1"), "search for pocketpaw")
+
+    resolved = [
+        e for e in events if e.type == "tool_use" and e.metadata.get("input_pending") is not True
+    ]
+    assert len(resolved) == 1, "exactly one resolved announcement per call"
+    assert resolved[0].metadata["name"] == "web_search"
+    assert resolved[0].metadata["input"] == {"query": "pocketpaw"}
+
+
+async def test_provisional_announcement_still_fires_early():
+    """The early signal is what flips the UI off "Thinking..." — keep it.
+
+    It is flagged ``input_pending=True`` so an appending consumer can skip it;
+    its ``input`` is a placeholder and NOT what the tool runs with.
+    """
+    events = await _collect(_search_backend("c1"), "search for pocketpaw")
+    tool_uses = [e for e in events if e.type == "tool_use"]
+
+    assert tool_uses[0].metadata["input_pending"] is True
+    assert tool_uses[0].metadata["name"] == "web_search"
+    assert tool_uses[0].metadata["input"] == {}
+
+    # Provisional first, resolved after — never the reverse.
+    flags = [e.metadata.get("input_pending") for e in tool_uses]
+    assert flags == [True, False]
+
+    # And the early signal must beat the tool's result to the consumer.
+    kinds = [e.type for e in events]
+    assert kinds.index("tool_use") < kinds.index("tool_result")
+
+
+async def test_tool_use_announced_once_per_call_id_per_phase():
+    """One call yields one PROVISIONAL and one RESOLVED event — never more.
+
+    The dedupe is phase-qualified rather than removed: a repeat of either phase
+    for the same id is still suppressed, so the id remains the thing that stops
+    a UI from stacking duplicate rows for one call.
+    """
+    events = await _collect(_search_backend("dup-1"), "search for pocketpaw")
+    tool_uses = [e for e in events if e.type == "tool_use"]
+
+    assert sum(1 for e in tool_uses if e.metadata.get("input_pending") is True) == 1
+    assert sum(1 for e in tool_uses if e.metadata.get("input_pending") is False) == 1
+
+
+def test_announce_tool_without_call_id_resolves_arguments():
+    """The no-``tool_call_id`` path must not be made worse by the phase key.
+
+    It is exercised directly because it is unreachable from the streaming path:
+    pydantic-ai MINTS an id (``pyd_ai_<hex>``) when the model delta omits one, so
+    a run-level test would silently cover the id path twice. Without an id there
+    is nothing to dedupe on, so both phases emit — and the resolved one must
+    still carry decoded arguments.
+    """
+    backend = PydanticAIBackend(_settings())
+    announced: set[str] = set()
+    out: list = []
+    part = SimpleNamespace(tool_name="web_search", tool_call_id=None)
+
+    backend._announce_tool(part, announced, out, args={}, pending=True)
+    backend._announce_tool(part, announced, out, args='{"query": "pocketpaw"}', pending=False)
+
+    assert [e.metadata["input_pending"] for e in out] == [True, False]
+    assert out[0].metadata["input"] == {}
+    assert out[1].metadata["input"] == {"query": "pocketpaw"}
+
+
+@pytest.mark.parametrize(
+    ("args", "expected"),
+    [
+        ('{"query": "x"}', {"query": "x"}),  # streamed calls arrive as JSON text
+        ({"query": "x"}, {"query": "x"}),  # non-streamed calls arrive decoded
+        (None, {}),  # a no-argument tool
+        ("not json", {}),  # never propagate junk as arguments
+        ("[1, 2]", {}),  # valid JSON, wrong shape
+        (123, {}),
+    ],
+)
+def test_announce_tool_normalizes_arguments(args, expected):
+    """``input`` is always a dict, whatever the provider streamed."""
+    backend = PydanticAIBackend(_settings())
+    out: list = []
+    backend._announce_tool(
+        SimpleNamespace(tool_name="t", tool_call_id="c1"), set(), out, args=args, pending=False
+    )
+    assert out[0].metadata["input"] == expected
 
 
 async def test_history_is_threaded_into_the_model():


### PR DESCRIPTION
> **Merge order matters. Land #1943 before this, or in the same batch.**
> This makes pydantic-ai emit a provisional/resolved pair, and the `loop.py` change that stops consumers appending one pending entry per *event* ships in #1943. Merged first on its own, this regresses tool-call correlation on `dev`. Details at the bottom.

Every `tool_use` this backend emitted carried `input={}`. A caller rendering "Searching the web for {query}" had nothing to interpolate and fell back to the bare tool name, so the interpolated phrase existed only in tests.

There were two independent defects, either one sufficient on its own.

## The dedupe

`_announce_tool` deduped on `tool_call_id` alone. `_map_event` calls it twice for one call: an early `PartStartEvent(ToolCallPart)` announcement so the UI can flip off "Thinking…" before arguments finish streaming, then the authoritative `FunctionToolCallEvent`. The early one claimed the id with a placeholder `{}`, so the authoritative one hit the early return and its arguments were discarded. The dedupe is now keyed by phase as well as id, which still stops a repeat of either phase stacking a duplicate row for one call.

## The one that was easy to miss

pydantic-ai types `ToolCallPart.args` as `str | dict | None`, and the streamed path — the only one this backend uses — delivers JSON *text*. The metadata builder kept the value only `if isinstance(args, dict)`, so every real streamed call was coerced to `{}` regardless of what the dedupe did.

Fixing the dedupe alone still ships `{}`. That is worth stating plainly because the original diagnosis stopped at the dedupe, and a fix limited to it would have produced a green task and a feature still broken in production. It was caught by measuring the raw value rather than trusting a synthetic fixture: `('str', '{"query": "pocketpaw"}')`.

`_tool_args_as_dict` decodes it. It deliberately does **not** use pydantic-ai's `args_as_dict()`, whose documented behavior on malformed JSON is to return `{'INVALID_JSON': '<raw args>'}` — that would put a fabricated argument *named* `INVALID_JSON` in front of the user as though the model had passed it. Non-object payloads become `{}` instead.

## Two events per call now

One call emits a provisional event then a resolved one, under the `input_pending` contract shared with claude_sdk: `True` means provisional with a resolved event to follow, `False` or absent means final. Consumers that append per event must skip provisional ones; consumers that replace a status line may render both and let the resolved event upgrade the display.

## The test that was replaced

`test_tool_use_announced_once_per_call_id` asserted one `tool_use` per call. It passed for the entire life of this backend while `input` was unconditionally `{}` — it proved the dedupe worked and never looked at the arguments. It is now `..._per_phase`, and the guard test asserts the exact argument dict rather than counting events.

## Verification

Red first, then green, by path rather than a `-k` slice:

- new tests against the pre-fix state: `10 failed, 121 passed, 1 skipped`
- after the fix: `147 passed, 1 skipped` across both pydantic-ai test files
- blast radius across every suite referencing this backend: `202 passed, 1 skipped`, plus `44 passed, 6 skipped`

Both defects were mutation-checked independently, so neither test passes by coincidence: reverting the dedupe fails 3, and reverting the args decoding while keeping the dedupe also fails 3. The same guard test fails under both, which is what proves the dedupe fix alone is insufficient.

A full-suite run did not finish inside the working window and no full-suite pass is being claimed here. What was run is listed above.

## Why merge order matters

`loop.py` appends one `pending_tool_calls` entry per `tool_use` event and pops by name on `tool_result`. Replaying the real fixed event stream through `origin/dev`'s copy of that loop, with two tool calls:

```
real tool calls made         : 2
tool_start events published  : 4
pending_tool_calls LEFT OVER : 2
```

The leftovers then corrupt later `tool_call_id`s through the `pop(0)` fallback, and the provisional events publish the whole metadata dict as `params` because `meta.get("input") or meta` treats an empty `input` as falsy. #1943 fixes both. This branch deliberately does not touch `loop.py`, to avoid conflicting with it.

One cleanup for whoever merges second: #1943's `loop.py` header lists `pydantic_ai` among the backends that never set the flag. That stops being true once this lands.
