### PR TITLE
The agent's plan reaches the UI

### DIFF
--- a/ee/pocketpaw_ee/cloud/_core/realtime/audience.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/audience.py
@@ -1,4 +1,6 @@
 # audience.py — resolves an Event into the user_ids that should receive it.
+# Updated: 2026-08-15 (HTN-5) — agent.plan_updated joins the agent runtime
+#   stream branch, scoped to the group's members like agent.tool_use.
 # Updated: 2026-08-11 — call.participant_joined / call.participant_left now
 #   resolve to the call's group members (they previously fell through to [],
 #   so InProcessBus skipped fan-out and the frontend's pre-join "who's in the
@@ -198,6 +200,9 @@ class AudienceResolver:
             "agent.stream_end",
             "agent.stream_start",
             "agent.tool_use",
+            # HTN-5: the plan panel is chat furniture, so it is scoped exactly
+            # like the tool chips it replaces — group members, never a broadcast.
+            "agent.plan_updated",
         }:
             return await self._group(d["group_id"])
 

--- a/ee/pocketpaw_ee/cloud/_core/realtime/events.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/events.py
@@ -51,6 +51,10 @@
 #   ``WebSandboxStatusChanged`` (type="websandbox.status_changed") for the Web
 #   Cursor sandbox registry. Emitted by ``websandbox.service`` on every
 #   state-mutating call per cloud rule 9.
+# Updated: 2026-08-15 (HTN-5, feat/agent-plan-surface) — added
+#   ``AgentPlanUpdated`` (type="agent.plan_updated") for the agent plan panel.
+#   Emitted by ``shared/agent_bridge.py`` when a backend's plan tool call
+#   normalizes to a plan that actually changed.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -381,6 +385,22 @@ class AgentStreamEnd(Event):
 @dataclass
 class AgentToolUse(Event):
     EVENT_TYPE: ClassVar[str] = "agent.tool_use"
+
+
+@dataclass
+class AgentPlanUpdated(Event):
+    # HTN-5: the agent's ordered plan, normalized out of whichever plan tool the
+    # backend exposes (``write_plan`` today; ``write_todos`` / ``TodoWrite`` in
+    # HTN-6). Payload: ``{group_id, agent_id, agent_name, run_id, seq,
+    # items: [{id, content, status}], progress: {completed, total}}`` with
+    # status in ``pending|in_progress|completed|cancelled``.
+    #
+    # WHOLE-LIST REPLACEMENT: every emit carries the complete ordered plan, so
+    # a receiver replaces its state and never merges — inherited from
+    # ``write_plan``, which overwrites its own state on each call. ``seq`` is a
+    # per-run monotonic counter so a reordered delivery cannot let a stale plan
+    # overwrite a fresh one.
+    EVENT_TYPE: ClassVar[str] = "agent.plan_updated"
 
 
 # Agents (entity CRUD — distinct from agent.* runtime stream events above)

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -1,6 +1,30 @@
 """Agent-run core — the loop the executor invokes for every chat run.
 
 Changes:
+- 2026-08-15 (HTN-5) — ``_drive_agent_loop`` routes a recognized plan tool
+  (``write_plan`` today) through ``shared/plan_normalizer.py`` and yields a
+  ``plan_updated`` SSE frame INSTEAD of the ``tool_start`` chip, so the plan
+  panel renders on the streaming chat surface and not only on the group/DM
+  bridge. Same normalizer, same ``PlanTracker``, same fail-open rule as the
+  bridge: a plan call whose arguments don't normalize falls through to the
+  ordinary chip.
+
+  **Why a frame here and a bus event there.** The bridge emits
+  ``agent.plan_updated`` through ``emit()``, which the AudienceResolver scopes
+  by ``data["group_id"]``. This function has NO group identity — ``RunSpec.group``
+  is nullable and never reaches it, and ``ScopeContext`` carries no group — so a
+  bus emit would raise ``KeyError('group_id')`` inside the resolver, get
+  swallowed by ``emit``'s except, and be delivered to nobody. On this surface the
+  audience is the one client streaming the run, which is exactly what the SSE
+  transport already addresses. ``execute_run`` forwards every yielded frame via
+  ``transport.append_event`` with no name whitelist, so the frame needs no
+  registration.
+
+  ``_new_run_id()`` was hoisted to ``stream_run_id`` for this: it used to be
+  minted inline inside the ``emit_stream_start`` block, so it did not exist when
+  that flag was false and nothing else could reference it. Same value on the
+  wire; now the plan frames carry the same ``run_id`` the client already has
+  from ``stream_start``.
 - 2026-08-07 (fix/code-delegate-pooled-context) — ``_drive_agent_loop`` now
   PUBLISHES its side-channel queue under the run's ``session_mongo_id``
   (``register_stream_sink``, beside the existing ``attach_sse_event_sink``)
@@ -307,6 +331,7 @@ from pocketpaw_ee.cloud.chat.runs import service as run_service
 from pocketpaw_ee.cloud.chat.runs.domain import RunSpec
 from pocketpaw_ee.cloud.chat.runs.transport import get_stream_transport
 from pocketpaw_ee.cloud.shared.errors import CloudError
+from pocketpaw_ee.cloud.shared.plan_normalizer import PlanTracker
 from pocketpaw_ee.cloud.surface import (
     SurfaceKind,
     SurfaceMeta,
@@ -1163,9 +1188,18 @@ async def _drive_agent_loop(
     )
     behavior_instructions = build_behavior_instructions(ctx, backend_name=backend_name)
 
+    # HTN-5: one id for the whole invocation. It was previously minted inline in
+    # the ``stream_start`` payload, so it existed only when ``emit_stream_start``
+    # was true and nothing else could refer to it. Hoisting it changes no wire
+    # value — ``stream_start`` still carries exactly this — but gives the plan
+    # frames below a ``run_id`` the client already holds, matching the group/DM
+    # bridge where ``run_id`` equals the id on ``agent.stream_start``.
+    stream_run_id = _new_run_id()
+    plan_tracker = PlanTracker(run_id=stream_run_id)
+
     if emit_stream_start:
         stream_start_payload: dict[str, Any] = {
-            "run_id": _new_run_id(),
+            "run_id": stream_run_id,
             "agent_id": ctx.target_agent_id,
             "agent_name": getattr(instance, "agent_name", ""),
             "scope": ctx.kind.value,
@@ -1507,7 +1541,28 @@ async def _drive_agent_loop(
                         },
                     )
                 else:
-                    yield ("tool_start", {"tool": name, "input": tool_input})
+                    # HTN-5: a plan tool is not a tool chip. Same normalizer and
+                    # same per-run tracker as the group/DM bridge — only the
+                    # transport differs, because this surface has no group to
+                    # fan out to (see the module docstring) and the client
+                    # streaming the run IS the audience. Same fail-open rule:
+                    # arguments that don't normalize fall through to the chip.
+                    observation = plan_tracker.observe(name, tool_input)
+                    if observation.recognized:
+                        # ``payload is None`` means the plan didn't change; the
+                        # tool fires at the start and end of every step, and
+                        # emitting nothing is what keeps the panel from flickering.
+                        if observation.payload is not None:
+                            yield (
+                                "plan_updated",
+                                {
+                                    "agent_id": ctx.target_agent_id,
+                                    "agent_name": getattr(instance, "agent_name", ""),
+                                    **observation.payload,
+                                },
+                            )
+                    else:
+                        yield ("tool_start", {"tool": name, "input": tool_input})
             elif etype == "tool_result":
                 meta = getattr(event, "metadata", None) or {}
                 name = ""

--- a/ee/pocketpaw_ee/cloud/shared/agent_bridge.py
+++ b/ee/pocketpaw_ee/cloud/shared/agent_bridge.py
@@ -50,6 +50,16 @@ already uses — and adds an additive ``narration`` field to ``agent.tool_use``
 carrying the tool's plain-language phrase ("Searching the web for quarterly
 filings"). ``tool`` still carries the tool name, so clients keyed on it are
 unaffected; a tool with no ``Narration`` emits no ``narration`` field.
+
+Updated 2026-08-15 (HTN-5): the ``tool_use`` branch routes a recognized plan tool
+(``write_plan`` today) through ``shared/plan_normalizer.py`` and emits
+``agent.plan_updated`` INSTEAD of ``agent.tool_use`` — the panel is the narration,
+so "Using write_plan..." alongside it is bookkeeping noise. The substitution is
+fail-open: a plan call whose arguments cannot be read falls back to the ordinary
+``agent.tool_use``, so the surface degrades to today's behaviour rather than
+going silent. A per-run ``PlanTracker`` supplies the monotonic ``seq`` and
+suppresses re-emits of an unchanged plan (``write_plan`` fires at both the start
+and the end of every step and resends the whole list each time).
 """
 
 from __future__ import annotations
@@ -64,12 +74,14 @@ from typing import Any
 from pocketpaw_ee.cloud.realtime.emit import emit
 from pocketpaw_ee.cloud.realtime.events import (
     AgentError,
+    AgentPlanUpdated,
     AgentStreamChunk,
     AgentStreamEnd,
     AgentStreamStart,
     AgentToolUse,
 )
 from pocketpaw_ee.cloud.shared.events import event_bus
+from pocketpaw_ee.cloud.shared.plan_normalizer import PlanTracker
 
 logger = logging.getLogger(__name__)
 
@@ -564,6 +576,12 @@ async def _run_agent_response(
     # text, so a coalesced chunk is a lossless UX compromise.
     full_text = ""
     saw_error_event = False
+    # HTN-5: per-run plan state (monotonic ``seq`` + change fingerprint). It
+    # lives on this stack and dies with the run, so there is no registry to
+    # leak. ``temp_msg_id`` is the bridge's only per-run identity and already
+    # rides ``agent.stream_start`` as ``message_id``, so reusing it as
+    # ``run_id`` gives the panel a join key it already holds.
+    plan_tracker = PlanTracker(run_id=temp_msg_id)
     error_summary = ""
     last_emit_ts = 0.0
     STREAM_CHUNK_THROTTLE_S = 0.2
@@ -626,6 +644,32 @@ async def _run_agent_response(
                         tool_name = event.content.get("tool") or event.content.get("name") or ""
                     elif isinstance(event.content, str):
                         tool_name = event.content
+                # HTN-5: a plan tool is not a tool chip. ``write_plan`` restates
+                # the agent's whole ordered plan; rendering that as "Using
+                # write_plan..." next to a live plan panel is noise, so a
+                # recognized plan call emits ``agent.plan_updated`` INSTEAD of
+                # ``agent.tool_use``. The swap only happens when the arguments
+                # actually normalize — an unreadable plan call reports itself
+                # unrecognized and falls through to the ordinary chip below, so
+                # the surface never goes silent.
+                observation = plan_tracker.observe(tool_name, tool_input)
+                if observation.recognized:
+                    # ``payload is None`` means the plan did not change (the
+                    # tool fires at both the start and the end of each step);
+                    # emitting nothing is what keeps the panel from flickering.
+                    if observation.payload is not None:
+                        await emit(
+                            AgentPlanUpdated(
+                                data={
+                                    "group_id": group_id,
+                                    "agent_id": agent_id,
+                                    "agent_name": instance.agent_name,
+                                    **observation.payload,
+                                },
+                            )
+                        )
+                    continue
+
                 payload: dict[str, Any] = {
                     "group_id": group_id,
                     "agent_id": agent_id,

--- a/ee/pocketpaw_ee/cloud/shared/plan_normalizer.py
+++ b/ee/pocketpaw_ee/cloud/shared/plan_normalizer.py
@@ -1,0 +1,260 @@
+# plan_normalizer.py — turns a backend's plan-tool call into the canonical
+# ``agent.plan_updated`` payload (HTN-5).
+# Created: 2026-08-15 (HTN-5) — ships ONE normalizer, ``write_plan`` from
+#   pydantic-ai-harness, verified against the installed
+#   ``pydantic_ai_harness/planning/_toolset.py`` rather than inferred. The
+#   registry exists so ``write_todos`` (deep_agents) and ``TodoWrite``
+#   (claude_agent_sdk) arrive in HTN-6 as a ``register_plan_normalizer`` call
+#   instead of a refactor. ``TodoWrite``'s payload is a CLI-side builtin
+#   compiled into ``claude_agent_sdk/_bundled/claude.exe`` and has NOT been
+#   captured live, so no normalizer is guessed for it here — a guessed shape
+#   would give the default backend's users a panel that is silently blank.
+"""Normalize plan-tool arguments into the canonical plan wire shape.
+
+Three agent backends express the same concept with incompatible schemas, so the
+bridge must not learn any of them. It asks this module two questions — "is this
+a plan tool?" and "what changed?" — and emits whatever comes back.
+
+**Whole-list replacement.** ``write_plan`` overwrites its ``PlanState`` outright
+on every call: the model resends the entire ordered list, with no indices and no
+deltas. The wire contract inherits that, so a receiver REPLACES its state and
+never merges. There is deliberately no diffing anywhere in this module, and
+adding some later would break the contract rather than extend it.
+
+**Item ids are positional.** ``write_plan`` carries no ids. Under whole-list
+replacement the index *is* the identity, so ``id`` is synthesised as ``"1"``,
+``"2"``, … — stable within one event, not across events. Do not key animations
+or persistence off it.
+
+**Status is the superset.** ``pending | in_progress | completed | cancelled``.
+Backends with three states simply never emit ``cancelled``; anything outside the
+four falls back to ``pending`` so a receiver can switch exhaustively.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+#: The superset every source normalizes into. ``cancelled`` comes from
+#: ``write_plan``'s ``TaskStatus``; the three-state sources never emit it.
+PLAN_STATUSES = frozenset({"pending", "in_progress", "completed", "cancelled"})
+DEFAULT_STATUS = "pending"
+
+#: Bounds on what reaches a WebSocket broadcast. The plan is model-authored
+#: free text, so neither the item count nor the per-item length is trustworthy.
+MAX_ITEMS = 100
+MAX_CONTENT_CHARS = 500
+
+
+@dataclass(frozen=True)
+class PlanItem:
+    """One canonical plan step: what the wire carries, nothing more."""
+
+    id: str
+    content: str
+    status: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {"id": self.id, "content": self.content, "status": self.status}
+
+
+#: A normalizer takes one tool call's argument dict and returns the ordered
+#: plan. It returns ``[]`` — never raises — when the arguments are unusable.
+PlanNormalizer = Callable[[dict[str, Any]], list[PlanItem]]
+
+_REGISTRY: dict[str, PlanNormalizer] = {}
+
+
+def register_plan_normalizer(tool_name: str, normalizer: PlanNormalizer) -> None:
+    """Register *normalizer* as the reader for *tool_name*'s arguments."""
+    _REGISTRY[tool_name] = normalizer
+
+
+def is_plan_tool(tool_name: str) -> bool:
+    """True when *tool_name* has a registered normalizer."""
+    return bool(tool_name) and tool_name in _REGISTRY
+
+
+def plan_tools() -> frozenset[str]:
+    """Every currently-registered plan tool name."""
+    return frozenset(_REGISTRY)
+
+
+def normalize_plan(tool_name: str, tool_input: Any) -> list[PlanItem]:
+    """Normalize one plan-tool call, or return ``[]``.
+
+    Never raises: a malformed plan must not take down the response stream, and
+    an empty result routes the caller to its ordinary tool signal instead.
+    """
+    normalizer = _REGISTRY.get(tool_name)
+    if normalizer is None:
+        return []
+    try:
+        return normalizer(tool_input if isinstance(tool_input, dict) else {})
+    except Exception:
+        logger.debug("Plan normalization failed for %s", tool_name, exc_info=True)
+        return []
+
+
+def _items_from_content_status_list(raw: Any) -> list[PlanItem]:
+    """Shape an ordered ``[{content, status}, ...]`` list into canonical items.
+
+    Shared rather than inlined because ``write_todos`` (deep_agents) uses the
+    same shape — HTN-6 reuses this verbatim and only registers a different key.
+    """
+    if isinstance(raw, str):
+        # Defensive: a backend that hands tool arguments through un-decoded
+        # gives us the JSON text rather than the list.
+        try:
+            raw = json.loads(raw)
+        except (TypeError, ValueError):
+            return []
+    if not isinstance(raw, list):
+        return []
+
+    items: list[PlanItem] = []
+    for entry in raw[:MAX_ITEMS]:
+        if isinstance(entry, dict):
+            content = entry.get("content")
+            status = entry.get("status", DEFAULT_STATUS)
+        elif isinstance(entry, str):
+            content, status = entry, DEFAULT_STATUS
+        else:
+            continue
+
+        # Collapse whitespace: a plan step renders as one line in a panel, and
+        # a newline in model-authored text would otherwise break the row.
+        content = " ".join(str(content or "").split())[:MAX_CONTENT_CHARS]
+        if not content:
+            # Nothing renderable. Dropping it keeps ids contiguous and keeps
+            # ``total`` honest about what the panel can actually show.
+            continue
+
+        # ``status`` may arrive as a ``TaskStatus`` enum member if a backend
+        # validated the arguments before announcing the call.
+        status = getattr(status, "value", status)
+        status = str(status or DEFAULT_STATUS).strip().lower()
+        if status not in PLAN_STATUSES:
+            logger.debug("Unknown plan status %r; treating as %s", status, DEFAULT_STATUS)
+            status = DEFAULT_STATUS
+
+        items.append(PlanItem(id=str(len(items) + 1), content=content, status=status))
+    return items
+
+
+def _normalize_write_plan(tool_input: dict[str, Any]) -> list[PlanItem]:
+    """``write_plan(items: list[PlanItem])`` — pydantic-ai-harness planning.
+
+    Read off ``pydantic_ai_harness/planning/_toolset.py``: one argument,
+    ``items``, an ordered list of ``{content, status}`` where ``status`` is the
+    four-value ``TaskStatus``. The tool assigns ``self._state.items = list(items)``
+    — the overwrite that the whole-list-replacement contract inherits.
+    """
+    return _items_from_content_status_list(tool_input.get("items"))
+
+
+register_plan_normalizer("write_plan", _normalize_write_plan)
+
+
+def plan_progress(items: list[PlanItem]) -> dict[str, int]:
+    """``{completed, total}`` for *items*.
+
+    ``cancelled`` counts toward ``total`` but not ``completed``, matching the
+    harness's own ``render_plan`` summary so the panel and the string the model
+    reads back cannot disagree.
+    """
+    return {
+        "completed": sum(1 for item in items if item.status == "completed"),
+        "total": len(items),
+    }
+
+
+def plan_fingerprint(items: list[PlanItem]) -> str:
+    """A stable hash of the plan, used to emit only on actual change."""
+    payload = json.dumps([item.as_dict() for item in items], sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class PlanObservation:
+    """What the caller should do with one observed tool call.
+
+    ``recognized`` false means "this was not a usable plan call" — the caller
+    should fall back to its ordinary tool signal. ``recognized`` true with a
+    ``payload`` of ``None`` means "a plan call that changed nothing" — the
+    caller should emit nothing at all.
+    """
+
+    recognized: bool
+    payload: dict[str, Any] | None
+
+
+UNRECOGNIZED = PlanObservation(recognized=False, payload=None)
+
+
+class PlanTracker:
+    """Per-run plan state: the monotonic ``seq`` and the change fingerprint.
+
+    One instance per agent run, held on the stack of the run and discarded with
+    it, so there is no registry to leak and no cross-run bleed.
+
+    It exists for two reasons:
+
+    * **``write_plan`` fires twice per step** — the tool's own docstring tells
+      the model to call it "when you start and when you finish a step" — and
+      resends the whole list each time. Without the fingerprint the channel
+      floods and the panel flickers through identical renders.
+    * **``seq`` lets a receiver drop a stale plan.** Whether the realtime layer
+      guarantees per-run ordering is unconfirmed; a receiver that ignores any
+      ``seq`` below the one it holds is correct either way.
+    """
+
+    __slots__ = ("_run_id", "_seq", "_fingerprint")
+
+    def __init__(self, run_id: str) -> None:
+        self._run_id = run_id
+        self._seq = 0
+        self._fingerprint = ""
+
+    @property
+    def seq(self) -> int:
+        """The ``seq`` of the last emitted update (0 before the first)."""
+        return self._seq
+
+    def observe(self, tool_name: str, tool_input: Any) -> PlanObservation:
+        """Fold one tool call into the run's plan state."""
+        if not is_plan_tool(tool_name):
+            return UNRECOGNIZED
+
+        items = normalize_plan(tool_name, tool_input)
+        if not items:
+            # A registered plan tool whose arguments we could not read. Today
+            # that is the common case on pydantic-ai: the backend announces the
+            # call from ``PartStartEvent`` with ``input={}`` before the
+            # arguments finish streaming (HTN-9 fixes that). Reporting it as
+            # unrecognized keeps the caller on its ordinary tool signal, so the
+            # surface degrades to today's behaviour instead of going silent.
+            return UNRECOGNIZED
+
+        fingerprint = plan_fingerprint(items)
+        if fingerprint == self._fingerprint:
+            return PlanObservation(recognized=True, payload=None)
+
+        self._fingerprint = fingerprint
+        self._seq += 1
+        return PlanObservation(
+            recognized=True,
+            payload={
+                "run_id": self._run_id,
+                "seq": self._seq,
+                "items": [item.as_dict() for item in items],
+                "progress": plan_progress(items),
+            },
+        )

--- a/tests/cloud/runs/test_run_core_plan_surface.py
+++ b/tests/cloud/runs/test_run_core_plan_surface.py
@@ -141,6 +141,51 @@ async def test_write_plan_yields_a_plan_frame_with_the_whole_plan(monkeypatch):
     assert plans[0]["run_id"], "the panel needs a per-run key to scope itself to"
 
 
+async def test_the_frame_carries_the_agent_identity(monkeypatch):
+    """``agent_id`` lets the panel key plan state by room AND agent instead of
+    by room alone. Without it, a room where two agents plan concurrently shares
+    one entry and the later event wins.
+
+    Pinned on its own because the panel's reconciler depends on it: it is the
+    field that keeps per-agent keying a frontend change rather than a change to
+    a shipped wire contract.
+    """
+    out = await _drive_and_collect(
+        monkeypatch,
+        [_write_plan_event(*THREE_STEP), SimpleNamespace(type="done", content="")],
+    )
+    plans = [data for name, data in out if name == "plan_updated"]
+
+    assert plans[0]["agent_id"] == "a1", "must be ctx.target_agent_id, not the pool's arg"
+    assert plans[0]["agent_name"] == "A"
+
+
+async def test_frame_keys_match_the_ws_event_apart_from_group_id(monkeypatch):
+    """Cross-channel parity, pinned so it cannot drift into two shapes.
+
+    The panel runs ONE reconciler over both channels, so the payloads have to
+    stay identical. The mirror of this assertion is in
+    ``tests/cloud/shared/test_agent_bridge_plan.py`` — the only difference is
+    ``group_id``, which the WS event carries and this path structurally cannot
+    (``_drive_agent_loop`` has no group identity; see the run_core docstring).
+    If either side gains or loses a field, one of the two tests fails.
+    """
+    out = await _drive_and_collect(
+        monkeypatch,
+        [_write_plan_event(*THREE_STEP), SimpleNamespace(type="done", content="")],
+    )
+    plans = [data for name, data in out if name == "plan_updated"]
+
+    assert set(plans[0]) == {
+        "agent_id",
+        "agent_name",
+        "run_id",
+        "seq",
+        "items",
+        "progress",
+    }
+
+
 async def test_a_plan_tool_does_not_also_yield_a_tool_chip(monkeypatch):
     """Same call as the bridge makes: the panel is the narration, so the
     "write_plan" chip would be noise beside it."""

--- a/tests/cloud/runs/test_run_core_plan_surface.py
+++ b/tests/cloud/runs/test_run_core_plan_surface.py
@@ -1,0 +1,360 @@
+# tests/cloud/runs/test_run_core_plan_surface.py
+# Created 2026-08-15 (HTN-5) — pins the plan surface on the STREAMING chat path.
+# The group/DM bridge is covered by tests/cloud/shared/test_agent_bridge_plan.py;
+# this file covers the other call site, which most users actually watch.
+#
+# Two levels, deliberately:
+#   * _drive_agent_loop yields a ("plan_updated", payload) frame instead of the
+#     ("tool_start", ...) chip, with the payload contents asserted.
+#   * execute_run writes that frame to the real SSE transport — proof it reaches
+#     a client, not just that the generator produced a tuple. `append_event` has
+#     no name whitelist, and this is what pins that.
+#
+# The backend events use the shape pydantic-ai actually emits: ``content`` is
+# the prose "Using write_plan...", ``metadata`` carries the bare name plus the
+# call's argument dict (``agents/pydantic_ai.py::_announce_tool``).
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import fakeredis.aioredis
+import pytest
+from pocketpaw_ee.cloud.chat.agent_service import ScopeContext, ScopeKind
+from pocketpaw_ee.cloud.chat.runs import run_core
+from pocketpaw_ee.cloud.chat.runs.domain import RunSpec
+from pocketpaw_ee.cloud.chat.runs.redis_stream import RedisStreamTransport
+
+pytestmark = pytest.mark.asyncio
+
+
+THREE_STEP = (
+    ("Add the database migration", "completed"),
+    ("Wire the endpoint", "in_progress"),
+    ("Backfill the existing rows", "pending"),
+)
+
+
+def _write_plan_event(*pairs: tuple[str, str]):
+    """A ``write_plan`` call carrying the whole ordered plan, as the tool does."""
+    return SimpleNamespace(
+        type="tool_use",
+        content="Using write_plan...",
+        metadata={
+            "name": "write_plan",
+            "input": {
+                "items": [{"content": content, "status": status} for content, status in pairs]
+            },
+        },
+    )
+
+
+def _tool_use_event(name: str, tool_input: dict):
+    return SimpleNamespace(
+        type="tool_use",
+        content=f"Using {name}...",
+        metadata={"name": name, "input": tool_input},
+    )
+
+
+def _scope_ctx() -> ScopeContext:
+    return ScopeContext(
+        kind=ScopeKind.SESSION,
+        scope_id="s1",
+        workspace_id="w1",
+        user_id="u1",
+        members=["u1"],
+        target_agent_id="a1",
+    )
+
+
+async def _drive_and_collect(
+    monkeypatch, backend_events: list[Any], *, emit_stream_start: bool = False
+) -> list[tuple[str, dict]]:
+    """Drive _drive_agent_loop against a fake pool yielding ``backend_events``."""
+
+    class _FakePool:
+        async def get(self, _agent_id):
+            return SimpleNamespace(config={}, agent_name="A")
+
+        def run(self, agent_id, content, session_key, **run_kwargs):
+            async def _gen():
+                for ev in backend_events:
+                    yield ev
+
+            return _gen()
+
+    monkeypatch.setattr(run_core, "get_agent_pool", lambda: _FakePool())
+
+    async def _fake_knowledge(*a, **k):
+        return ""
+
+    monkeypatch.setattr(run_core, "build_knowledge_context", _fake_knowledge)
+    monkeypatch.setattr(run_core, "build_behavior_instructions", lambda ctx, backend_name=None: "")
+    monkeypatch.setattr(run_core, "attach_sse_event_sink", lambda q: None)
+    monkeypatch.setattr(run_core, "attach_agent_identity", lambda **k: None)
+    monkeypatch.setattr(run_core, "detach_sse_event_sink", lambda t: None)
+    monkeypatch.setattr(run_core, "detach_agent_identity", lambda t: None)
+
+    async def _never_cancelled():
+        return False
+
+    out: list[tuple[str, dict]] = []
+    gen = run_core._drive_agent_loop(
+        _scope_ctx(),
+        user_content="ship the plan surface",
+        attachments_in=None,
+        mentions_in=None,
+        history=None,
+        is_cancelled=_never_cancelled,
+        emit_stream_start=emit_stream_start,
+    )
+    async for ev in gen:
+        out.append(ev)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# _drive_agent_loop yields the plan frame
+# ---------------------------------------------------------------------------
+
+
+async def test_write_plan_yields_a_plan_frame_with_the_whole_plan(monkeypatch):
+    """The headline behaviour on the streaming surface: the ordered plan, its
+    progress, and a seq — asserted by contents, not by frame count."""
+    out = await _drive_and_collect(
+        monkeypatch,
+        [_write_plan_event(*THREE_STEP), SimpleNamespace(type="done", content="")],
+    )
+
+    plans = [data for name, data in out if name == "plan_updated"]
+    assert len(plans) == 1, f"expected one plan_updated frame, got {out}"
+
+    assert plans[0]["items"] == [
+        {"id": "1", "content": "Add the database migration", "status": "completed"},
+        {"id": "2", "content": "Wire the endpoint", "status": "in_progress"},
+        {"id": "3", "content": "Backfill the existing rows", "status": "pending"},
+    ]
+    assert plans[0]["progress"] == {"completed": 1, "total": 3}
+    assert plans[0]["seq"] == 1
+    assert plans[0]["agent_id"] == "a1"
+    assert plans[0]["run_id"], "the panel needs a per-run key to scope itself to"
+
+
+async def test_a_plan_tool_does_not_also_yield_a_tool_chip(monkeypatch):
+    """Same call as the bridge makes: the panel is the narration, so the
+    "write_plan" chip would be noise beside it."""
+    out = await _drive_and_collect(
+        monkeypatch,
+        [_write_plan_event(*THREE_STEP), SimpleNamespace(type="done", content="")],
+    )
+    names = [name for name, _ in out]
+
+    assert "tool_start" not in names, f"plan call also yielded a tool chip: {out}"
+    plans = [data for name, data in out if name == "plan_updated"]
+    assert [item["content"] for item in plans[0]["items"]] == [
+        "Add the database migration",
+        "Wire the endpoint",
+        "Backfill the existing rows",
+    ]
+
+
+async def test_two_identical_write_plan_calls_yield_one_frame(monkeypatch):
+    """``write_plan`` fires at the start AND the end of every step and resends
+    the whole list; without coalescing the panel flickers."""
+    out = await _drive_and_collect(
+        monkeypatch,
+        [
+            _write_plan_event(*THREE_STEP),
+            _write_plan_event(*THREE_STEP),
+            SimpleNamespace(type="done", content=""),
+        ],
+    )
+
+    plans = [data for name, data in out if name == "plan_updated"]
+    assert len(plans) == 1, f"expected coalescing to one frame, got {len(plans)}"
+    # A count alone would pass if the surviving frame carried a degenerate plan.
+    assert plans[0]["items"] == [
+        {"id": "1", "content": "Add the database migration", "status": "completed"},
+        {"id": "2", "content": "Wire the endpoint", "status": "in_progress"},
+        {"id": "3", "content": "Backfill the existing rows", "status": "pending"},
+    ]
+    assert plans[0]["progress"] == {"completed": 1, "total": 3}
+
+
+async def test_seq_increases_across_genuine_updates(monkeypatch):
+    out = await _drive_and_collect(
+        monkeypatch,
+        [
+            _write_plan_event(("Wire the endpoint", "pending")),
+            _write_plan_event(("Wire the endpoint", "in_progress")),
+            # An identical repeat in the middle must not burn a seq.
+            _write_plan_event(("Wire the endpoint", "in_progress")),
+            _write_plan_event(("Wire the endpoint", "completed")),
+            SimpleNamespace(type="done", content=""),
+        ],
+    )
+
+    plans = [data for name, data in out if name == "plan_updated"]
+    assert [p["seq"] for p in plans] == [1, 2, 3]
+    assert [p["items"] for p in plans] == [
+        [{"id": "1", "content": "Wire the endpoint", "status": "pending"}],
+        [{"id": "1", "content": "Wire the endpoint", "status": "in_progress"}],
+        [{"id": "1", "content": "Wire the endpoint", "status": "completed"}],
+    ]
+    assert [p["progress"] for p in plans] == [
+        {"completed": 0, "total": 1},
+        {"completed": 0, "total": 1},
+        {"completed": 1, "total": 1},
+    ]
+
+
+async def test_cancelled_survives_to_the_frame(monkeypatch):
+    out = await _drive_and_collect(
+        monkeypatch,
+        [
+            _write_plan_event(("Add the migration", "completed"), ("Wire it up", "cancelled")),
+            SimpleNamespace(type="done", content=""),
+        ],
+    )
+
+    plans = [data for name, data in out if name == "plan_updated"]
+    assert [item["status"] for item in plans[0]["items"]] == ["completed", "cancelled"]
+    assert plans[0]["progress"] == {"completed": 1, "total": 2}
+
+
+async def test_an_unreadable_plan_call_falls_back_to_the_tool_chip(monkeypatch):
+    """Fail-open, and it matters more here: pydantic-ai currently announces the
+    call with ``input={}`` before the args finish streaming (HTN-9)."""
+    out = await _drive_and_collect(
+        monkeypatch,
+        [_tool_use_event("write_plan", {}), SimpleNamespace(type="done", content="")],
+    )
+    names = [name for name, _ in out]
+
+    assert "plan_updated" not in names
+    chips = [data for name, data in out if name == "tool_start"]
+    assert [c["tool"] for c in chips] == ["write_plan"]
+
+
+async def test_a_non_plan_tool_still_yields_its_chip(monkeypatch):
+    """Regression guard: ordinary tools are untouched by the substitution."""
+    out = await _drive_and_collect(
+        monkeypatch,
+        [
+            _tool_use_event("web_search", {"query": "quarterly filings"}),
+            SimpleNamespace(type="done", content=""),
+        ],
+    )
+
+    assert [name for name, _ in out if name == "plan_updated"] == []
+    chips = [data for name, data in out if name == "tool_start"]
+    assert len(chips) == 1
+    assert chips[0]["tool"] == "web_search"
+    assert chips[0]["input"] == {"query": "quarterly filings"}
+
+
+async def test_plan_run_id_matches_the_stream_start_frame(monkeypatch):
+    """``run_id`` is the id the client already received on ``stream_start``, so
+    the panel can attach itself without a second key — the same property the
+    group/DM bridge has. This is why ``_new_run_id()`` was hoisted."""
+    out = await _drive_and_collect(
+        monkeypatch,
+        [_write_plan_event(*THREE_STEP), SimpleNamespace(type="done", content="")],
+        emit_stream_start=True,
+    )
+
+    starts = [data for name, data in out if name == "stream_start"]
+    plans = [data for name, data in out if name == "plan_updated"]
+
+    assert starts[0]["run_id"], "stream_start must still carry a run_id"
+    assert plans[0]["run_id"] == starts[0]["run_id"]
+
+
+# ---------------------------------------------------------------------------
+# execute_run writes the frame to the real SSE transport
+# ---------------------------------------------------------------------------
+
+
+def _spec() -> RunSpec:
+    return RunSpec(
+        run_id="r1",
+        workspace_id="w1",
+        context_type="session",
+        scope_id="s1",
+        session_key="session:s1",
+        group=None,
+        user_id="u1",
+        agent_id="a1",
+        client_message_id="c1",
+        user_message_id="m1",
+        content="ship it",
+        history=[],
+        intent=None,
+    )
+
+
+async def _noop(*a, **k):
+    return None
+
+
+async def fake_resolve_scope_context(**_):
+    class _Ctx:
+        kind = type("K", (), {"value": "session"})()
+        scope_id = "s1"
+        workspace_id = "w1"
+        user_id = "u1"
+        target_agent_id = "a1"
+        members = ["u1"]
+        session_id = None
+        intent = None
+
+    return _Ctx()
+
+
+async def test_plan_frame_reaches_the_sse_stream(monkeypatch):
+    """The end-to-end proof: a ``plan_updated`` frame is written to the live
+    stream a client reads. ``append_event`` takes any frame name, and this is
+    what pins that the plan actually arrives rather than being dropped."""
+    redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    transport = RedisStreamTransport(redis)
+
+    async def _persist_stub(spec, ctx, full_text, attachments, usage=None):
+        return "assistant-msg-1"
+
+    async def fake_agent_events(spec, ctx):
+        yield (
+            "plan_updated",
+            {
+                "agent_id": "a1",
+                "agent_name": "A",
+                "run_id": "stream-run-1",
+                "seq": 1,
+                "items": [
+                    {"id": "1", "content": "Add the database migration", "status": "completed"},
+                    {"id": "2", "content": "Wire the endpoint", "status": "in_progress"},
+                ],
+                "progress": {"completed": 1, "total": 2},
+            },
+        )
+        yield ("chunk", {"content": "done", "type": "text"})
+
+    monkeypatch.setattr(run_core, "_iter_agent_events", fake_agent_events)
+    monkeypatch.setattr(run_core, "get_stream_transport", lambda: transport)
+    monkeypatch.setattr(run_core, "_mark_running", _noop)
+    monkeypatch.setattr(run_core, "_persist_and_complete", _persist_stub)
+    monkeypatch.setattr(run_core, "_broadcast_agent_typing", _noop)
+    monkeypatch.setattr(run_core, "resolve_scope_context", fake_resolve_scope_context)
+
+    await run_core.execute_run(_spec())
+
+    events = [e async for e in transport.read_events("r1", after="0", block_ms=10)]
+    plans = [e for e in events if e.event == "plan_updated"]
+
+    assert len(plans) == 1, f"plan frame did not reach the stream: {[e.event for e in events]}"
+    assert plans[0].data["items"] == [
+        {"id": "1", "content": "Add the database migration", "status": "completed"},
+        {"id": "2", "content": "Wire the endpoint", "status": "in_progress"},
+    ]
+    assert plans[0].data["progress"] == {"completed": 1, "total": 2}
+    assert plans[0].data["seq"] == 1

--- a/tests/cloud/shared/test_agent_bridge_plan.py
+++ b/tests/cloud/shared/test_agent_bridge_plan.py
@@ -130,8 +130,17 @@ async def test_a_plan_tool_does_not_also_emit_a_tool_chip():
     emitted = await _emitted([_write_plan_event(*THREE_STEP), _done_event()])
     types = [e.type for e in emitted]
 
-    assert "agent.plan_updated" in types
     assert "agent.tool_use" not in types, f"plan call also emitted a tool chip: {types}"
+    # Assert the plan event is real, not merely present — a substitution that
+    # suppressed the chip and emitted an empty plan would satisfy the negative
+    # assertion above on its own.
+    plans = [e.data for e in emitted if e.type == "agent.plan_updated"]
+    assert len(plans) == 1
+    assert [item["content"] for item in plans[0]["items"]] == [
+        "Add the database migration",
+        "Wire the endpoint",
+        "Backfill the existing rows",
+    ]
 
 
 @pytest.mark.asyncio
@@ -144,6 +153,15 @@ async def test_two_identical_write_plan_calls_emit_one_event():
     )
 
     assert len(payloads) == 1, f"expected coalescing to one event, got {len(payloads)}"
+    # A count alone would also pass if the surviving event carried a wrong or
+    # degenerate plan, so pin its contents: the point is that the ONE event
+    # that got through is the full plan, not merely that one event got through.
+    assert payloads[0]["items"] == [
+        {"id": "1", "content": "Add the database migration", "status": "completed"},
+        {"id": "2", "content": "Wire the endpoint", "status": "in_progress"},
+        {"id": "3", "content": "Backfill the existing rows", "status": "pending"},
+    ]
+    assert payloads[0]["progress"] == {"completed": 1, "total": 3}
 
 
 @pytest.mark.asyncio
@@ -162,6 +180,17 @@ async def test_seq_increases_across_genuine_updates_in_a_run():
 
     assert [p["seq"] for p in payloads] == [1, 2, 3]
     assert [p["items"][0]["status"] for p in payloads] == ["pending", "in_progress", "completed"]
+    # The content must survive every update, not just the status field.
+    assert [p["items"] for p in payloads] == [
+        [{"id": "1", "content": "Wire the endpoint", "status": "pending"}],
+        [{"id": "1", "content": "Wire the endpoint", "status": "in_progress"}],
+        [{"id": "1", "content": "Wire the endpoint", "status": "completed"}],
+    ]
+    assert [p["progress"] for p in payloads] == [
+        {"completed": 0, "total": 1},
+        {"completed": 0, "total": 1},
+        {"completed": 1, "total": 1},
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/cloud/shared/test_agent_bridge_plan.py
+++ b/tests/cloud/shared/test_agent_bridge_plan.py
@@ -1,0 +1,221 @@
+# Bridge-level tests for the agent plan surface (HTN-5).
+# Created: 2026-08-15 — proves a real ``write_plan`` call reaches the wire as
+# one ``agent.plan_updated`` carrying the whole ordered plan, and that a plan
+# tool no longer shows up as a bare ``agent.tool_use`` chip.
+#
+# The events here use the shape pydantic-ai ACTUALLY emits (``content`` is the
+# prose "Using write_plan...", ``metadata`` carries the bare name plus the
+# call's argument dict — see ``agents/pydantic_ai.py::_announce_tool``). Handing
+# the bridge a tidier hand-built event would test the function rather than the
+# surface.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _done_event():
+    return SimpleNamespace(type="done", content="", metadata={})
+
+
+def _tool_use_event(name: str, tool_input: dict):
+    return SimpleNamespace(
+        type="tool_use",
+        content=f"Using {name}...",
+        metadata={"name": name, "input": tool_input},
+    )
+
+
+def _write_plan_event(*pairs: tuple[str, str]):
+    """A ``write_plan`` call carrying the whole ordered plan, as the tool does."""
+    return _tool_use_event(
+        "write_plan",
+        {"items": [{"content": content, "status": status} for content, status in pairs]},
+    )
+
+
+THREE_STEP = (
+    ("Add the database migration", "completed"),
+    ("Wire the endpoint", "in_progress"),
+    ("Backfill the existing rows", "pending"),
+)
+
+
+async def _emitted(events: list) -> list:
+    """Drive ``_run_agent_response`` over ``events`` and return every emitted
+    event object (type + data), in order."""
+    from pocketpaw_ee.cloud.shared import agent_bridge
+
+    instance = SimpleNamespace(agent_name="Test Agent")
+    pool = MagicMock()
+    pool.get = AsyncMock(return_value=instance)
+    pool.observe = AsyncMock()
+
+    async def fake_run(*_args, **_kwargs):
+        for event in events:
+            yield event
+
+    pool.run = fake_run
+
+    from pocketpaw_ee.cloud.models.message import Message as _RealMessage
+
+    # Beanie isn't initialized in unit tests; stub the history query so the
+    # bridge never reaches a real database. The run yields no text, so the
+    # bridge short-circuits before the persistence branch.
+    to_list_mock = AsyncMock(return_value=[])
+    limit_mock = MagicMock()
+    limit_mock.to_list = to_list_mock
+    sort_mock = MagicMock()
+    sort_mock.limit = MagicMock(return_value=limit_mock)
+    find_mock = MagicMock()
+    find_mock.sort = MagicMock(return_value=sort_mock)
+
+    with (
+        patch("pocketpaw_ee.cloud.shared.agent_bridge.emit", new=AsyncMock()) as m_emit,
+        patch.multiple(
+            _RealMessage,
+            create=True,
+            group=MagicMock(),
+            deleted=MagicMock(),
+            createdAt=MagicMock(),
+        ),
+        patch.object(_RealMessage, "find", MagicMock(return_value=find_mock)),
+        patch("pocketpaw.agents.pool.get_agent_pool", return_value=pool),
+        patch(
+            "pocketpaw_ee.cloud.agents.knowledge.KnowledgeService.search_context",
+            new=AsyncMock(return_value=""),
+        ),
+    ):
+        await agent_bridge._run_agent_response(
+            agent_id="agent-1",
+            group_id="group-1",
+            workspace_id="ws-1",
+            user_message="ship the plan surface",
+            group_members=["user-1"],
+        )
+
+    return [call.args[0] for call in m_emit.await_args_list if call.args]
+
+
+async def _of_type(events: list, wire_type: str) -> list[dict]:
+    return [e.data for e in await _emitted(events) if e.type == wire_type]
+
+
+@pytest.mark.asyncio
+async def test_a_write_plan_call_emits_one_plan_event_with_the_whole_plan():
+    """HTN-5's headline behaviour: the ordered plan, its progress, and a seq."""
+    payloads = await _of_type([_write_plan_event(*THREE_STEP), _done_event()], "agent.plan_updated")
+
+    assert len(payloads) == 1, f"expected one agent.plan_updated, got {payloads}"
+    payload = payloads[0]
+
+    assert payload["items"] == [
+        {"id": "1", "content": "Add the database migration", "status": "completed"},
+        {"id": "2", "content": "Wire the endpoint", "status": "in_progress"},
+        {"id": "3", "content": "Backfill the existing rows", "status": "pending"},
+    ]
+    assert payload["progress"] == {"completed": 1, "total": 3}
+    assert payload["seq"] == 1
+    assert payload["group_id"] == "group-1"
+    assert payload["agent_id"] == "agent-1"
+    assert payload["run_id"], "the panel needs a per-run key to scope itself to"
+
+
+@pytest.mark.asyncio
+async def test_a_plan_tool_does_not_also_emit_a_tool_chip():
+    """The panel IS the narration; "Using write_plan..." next to it is noise."""
+    emitted = await _emitted([_write_plan_event(*THREE_STEP), _done_event()])
+    types = [e.type for e in emitted]
+
+    assert "agent.plan_updated" in types
+    assert "agent.tool_use" not in types, f"plan call also emitted a tool chip: {types}"
+
+
+@pytest.mark.asyncio
+async def test_two_identical_write_plan_calls_emit_one_event():
+    """``write_plan`` fires at the start AND the end of every step and resends
+    the whole list, so without change-coalescing the panel flickers."""
+    payloads = await _of_type(
+        [_write_plan_event(*THREE_STEP), _write_plan_event(*THREE_STEP), _done_event()],
+        "agent.plan_updated",
+    )
+
+    assert len(payloads) == 1, f"expected coalescing to one event, got {len(payloads)}"
+
+
+@pytest.mark.asyncio
+async def test_seq_increases_across_genuine_updates_in_a_run():
+    payloads = await _of_type(
+        [
+            _write_plan_event(("Wire the endpoint", "pending")),
+            _write_plan_event(("Wire the endpoint", "in_progress")),
+            # An identical repeat in the middle must not burn a seq.
+            _write_plan_event(("Wire the endpoint", "in_progress")),
+            _write_plan_event(("Wire the endpoint", "completed")),
+            _done_event(),
+        ],
+        "agent.plan_updated",
+    )
+
+    assert [p["seq"] for p in payloads] == [1, 2, 3]
+    assert [p["items"][0]["status"] for p in payloads] == ["pending", "in_progress", "completed"]
+
+
+@pytest.mark.asyncio
+async def test_cancelled_survives_the_trip_to_the_wire():
+    payloads = await _of_type(
+        [
+            _write_plan_event(
+                ("Add the migration", "completed"), ("Wire the endpoint", "cancelled")
+            ),
+            _done_event(),
+        ],
+        "agent.plan_updated",
+    )
+
+    assert [item["status"] for item in payloads[0]["items"]] == ["completed", "cancelled"]
+    assert payloads[0]["progress"] == {"completed": 1, "total": 2}
+
+
+@pytest.mark.asyncio
+async def test_run_id_matches_the_streaming_message_id():
+    """``run_id`` is the bridge's per-run identity, which is the same id
+    ``agent.stream_start`` already published as ``message_id`` — so the panel
+    can attach itself to the streaming message without a second key."""
+    emitted = await _emitted([_write_plan_event(*THREE_STEP), _done_event()])
+
+    starts = [e.data for e in emitted if e.type == "agent.stream_start"]
+    plans = [e.data for e in emitted if e.type == "agent.plan_updated"]
+
+    assert plans[0]["run_id"] == starts[0]["message_id"]
+
+
+@pytest.mark.asyncio
+async def test_an_unreadable_plan_call_falls_back_to_the_tool_chip():
+    """Fail-open. pydantic-ai currently announces the call with ``input={}``
+    before the args finish streaming (HTN-9), so suppressing the chip on an
+    empty plan would leave the surface silent instead of degraded."""
+    emitted = await _emitted([_tool_use_event("write_plan", {}), _done_event()])
+    types = [e.type for e in emitted]
+
+    assert "agent.plan_updated" not in types
+    tool_uses = [e.data for e in emitted if e.type == "agent.tool_use"]
+    assert [p["tool"] for p in tool_uses] == ["write_plan"]
+
+
+@pytest.mark.asyncio
+async def test_a_non_plan_tool_is_untouched():
+    """Regression guard on HTN-1: ordinary tools still emit their chip and
+    their narration, and never emit a plan event."""
+    emitted = await _emitted(
+        [_tool_use_event("web_search", {"query": "quarterly filings"}), _done_event()]
+    )
+
+    assert [e.type for e in emitted if e.type == "agent.plan_updated"] == []
+    tool_uses = [e.data for e in emitted if e.type == "agent.tool_use"]
+    assert len(tool_uses) == 1
+    assert tool_uses[0]["tool"] == "web_search"
+    assert tool_uses[0]["narration"] == "Searching the web for quarterly filings"

--- a/tests/cloud/shared/test_agent_bridge_plan.py
+++ b/tests/cloud/shared/test_agent_bridge_plan.py
@@ -125,6 +125,30 @@ async def test_a_write_plan_call_emits_one_plan_event_with_the_whole_plan():
 
 
 @pytest.mark.asyncio
+async def test_event_keys_match_the_sse_frame_apart_from_group_id():
+    """Cross-channel parity, pinned so it cannot drift into two shapes.
+
+    The panel runs ONE reconciler over both channels, so the payloads have to
+    stay identical. The mirror of this assertion is in
+    ``tests/cloud/runs/test_run_core_plan_surface.py`` — the only difference is
+    ``group_id``, which this path carries and the streaming chat path
+    structurally cannot. If either side gains or loses a field, one of the two
+    tests fails.
+    """
+    payloads = await _of_type([_write_plan_event(*THREE_STEP), _done_event()], "agent.plan_updated")
+
+    assert set(payloads[0]) == {
+        "group_id",
+        "agent_id",
+        "agent_name",
+        "run_id",
+        "seq",
+        "items",
+        "progress",
+    }
+
+
+@pytest.mark.asyncio
 async def test_a_plan_tool_does_not_also_emit_a_tool_chip():
     """The panel IS the narration; "Using write_plan..." next to it is noise."""
     emitted = await _emitted([_write_plan_event(*THREE_STEP), _done_event()])

--- a/tests/cloud/shared/test_plan_normalizer.py
+++ b/tests/cloud/shared/test_plan_normalizer.py
@@ -1,0 +1,248 @@
+# Unit tests for the plan normalizer + per-run PlanTracker (HTN-5).
+# Created: 2026-08-15 — covers the canonical shape, the four-state enum
+# round-trip, the change-hash coalescing that keeps the panel from flickering,
+# and the monotonic ``seq``.
+#
+# The ``write_plan`` fixtures use the shape the tool ACTUALLY receives — the
+# argument dict pydantic-ai puts on ``AgentEvent.metadata["input"]``, i.e.
+# ``{"items": [{"content": ..., "status": ...}]}`` with status as the raw JSON
+# string the model emits. See ``pydantic_ai_harness/planning/_toolset.py``.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.shared.plan_normalizer import (
+    MAX_CONTENT_CHARS,
+    MAX_ITEMS,
+    PlanTracker,
+    is_plan_tool,
+    normalize_plan,
+    plan_progress,
+    plan_tools,
+)
+
+
+def _write_plan_args(*pairs: tuple[str, str]) -> dict:
+    return {"items": [{"content": content, "status": status} for content, status in pairs]}
+
+
+THREE_STEP = _write_plan_args(
+    ("Add the database migration", "completed"),
+    ("Wire the endpoint", "in_progress"),
+    ("Backfill the existing rows", "pending"),
+)
+
+
+# --- registry ---------------------------------------------------------------
+
+
+def test_only_write_plan_is_registered():
+    """HTN-6 owns the other two. A guessed ``TodoWrite`` normalizer would give
+    the default backend's users a panel that is silently blank."""
+    assert plan_tools() == frozenset({"write_plan"})
+    assert is_plan_tool("write_plan")
+    assert not is_plan_tool("TodoWrite")
+    assert not is_plan_tool("write_todos")
+    assert not is_plan_tool("")
+
+
+def test_unregistered_tool_normalizes_to_nothing():
+    assert normalize_plan("web_search", {"query": "x"}) == []
+
+
+# --- canonical shape --------------------------------------------------------
+
+
+def test_write_plan_normalizes_to_the_canonical_items():
+    items = normalize_plan("write_plan", THREE_STEP)
+
+    assert [item.as_dict() for item in items] == [
+        {"id": "1", "content": "Add the database migration", "status": "completed"},
+        {"id": "2", "content": "Wire the endpoint", "status": "in_progress"},
+        {"id": "3", "content": "Backfill the existing rows", "status": "pending"},
+    ]
+
+
+def test_progress_counts_completed_against_the_whole_list():
+    items = normalize_plan("write_plan", THREE_STEP)
+    assert plan_progress(items) == {"completed": 1, "total": 3}
+
+
+def test_the_four_state_enum_round_trips_including_cancelled():
+    """``cancelled`` is the state only ``write_plan`` has; it must survive
+    unmangled and must NOT count as completed."""
+    items = normalize_plan(
+        "write_plan",
+        _write_plan_args(
+            ("one", "pending"),
+            ("two", "in_progress"),
+            ("three", "completed"),
+            ("four", "cancelled"),
+        ),
+    )
+
+    assert [item.status for item in items] == [
+        "pending",
+        "in_progress",
+        "completed",
+        "cancelled",
+    ]
+    # cancelled sits in the denominator but not the numerator, matching the
+    # harness's own render_plan summary.
+    assert plan_progress(items) == {"completed": 1, "total": 4}
+
+
+def test_enum_valued_status_is_accepted():
+    """A backend that validated the args before announcing hands us the real
+    ``TaskStatus`` member rather than its string."""
+    from enum import Enum
+
+    # Declared exactly as the harness declares it — ``StrEnum`` would be the
+    # modern spelling but would stop mirroring the class we actually receive.
+    class TaskStatus(str, Enum):  # noqa: UP042
+        in_progress = "in_progress"
+
+    items = normalize_plan(
+        "write_plan", {"items": [{"content": "x", "status": TaskStatus.in_progress}]}
+    )
+    assert items[0].status == "in_progress"
+
+
+# --- defensive shaping ------------------------------------------------------
+
+
+def test_missing_status_defaults_to_pending():
+    items = normalize_plan("write_plan", {"items": [{"content": "no status here"}]})
+    assert items[0].status == "pending"
+
+
+def test_unknown_status_falls_back_to_pending():
+    """The frontend switches exhaustively on the four states, so an unknown
+    value must never reach the wire."""
+    items = normalize_plan("write_plan", {"items": [{"content": "x", "status": "blocked"}]})
+    assert items[0].status == "pending"
+
+
+def test_newlines_are_collapsed_into_one_renderable_line():
+    items = normalize_plan("write_plan", {"items": [{"content": "step one\n\n  and more"}]})
+    assert items[0].content == "step one and more"
+
+
+def test_contentless_entries_are_dropped_and_ids_stay_contiguous():
+    items = normalize_plan(
+        "write_plan",
+        {
+            "items": [
+                {"content": "real"},
+                {"status": "pending"},
+                {"content": "   "},
+                {"content": "also real"},
+            ]
+        },
+    )
+    assert [(item.id, item.content) for item in items] == [("1", "real"), ("2", "also real")]
+
+
+def test_oversized_plans_are_bounded():
+    long_content = "x" * (MAX_CONTENT_CHARS + 50)
+    items = normalize_plan(
+        "write_plan",
+        {"items": [{"content": long_content} for _ in range(MAX_ITEMS + 10)]},
+    )
+    assert len(items) == MAX_ITEMS
+    assert len(items[0].content) == MAX_CONTENT_CHARS
+
+
+def test_a_json_string_items_argument_still_decodes():
+    """Belt and braces for a backend that passes tool args through un-decoded."""
+    items = normalize_plan("write_plan", {"items": '[{"content": "one", "status": "completed"}]'})
+    assert [item.as_dict() for item in items] == [
+        {"id": "1", "content": "one", "status": "completed"}
+    ]
+
+
+@pytest.mark.parametrize("args", [{}, {"items": None}, {"items": []}, {"items": "not json"}, None])
+def test_unusable_arguments_normalize_to_nothing_without_raising(args):
+    assert normalize_plan("write_plan", args) == []
+
+
+# --- PlanTracker ------------------------------------------------------------
+
+
+def test_tracker_emits_the_full_contract_on_first_observation():
+    tracker = PlanTracker(run_id="run-1")
+    observation = tracker.observe("write_plan", THREE_STEP)
+
+    assert observation.recognized
+    assert observation.payload == {
+        "run_id": "run-1",
+        "seq": 1,
+        "items": [
+            {"id": "1", "content": "Add the database migration", "status": "completed"},
+            {"id": "2", "content": "Wire the endpoint", "status": "in_progress"},
+            {"id": "3", "content": "Backfill the existing rows", "status": "pending"},
+        ],
+        "progress": {"completed": 1, "total": 3},
+    }
+
+
+def test_an_identical_repeat_is_recognized_but_emits_nothing():
+    """``write_plan`` fires at the start AND the end of every step, resending
+    the whole list. Without this the channel floods and the panel flickers."""
+    tracker = PlanTracker(run_id="run-1")
+
+    first = tracker.observe("write_plan", THREE_STEP)
+    second = tracker.observe("write_plan", THREE_STEP)
+
+    assert first.payload is not None
+    assert second.recognized, "still a plan call — the caller must not fall back to a tool chip"
+    assert second.payload is None
+    assert tracker.seq == 1, "a suppressed repeat must not burn a seq"
+
+
+def test_seq_increases_across_genuine_updates():
+    tracker = PlanTracker(run_id="run-1")
+
+    seqs = []
+    for status in ("pending", "in_progress", "completed"):
+        observation = tracker.observe("write_plan", _write_plan_args(("Wire the endpoint", status)))
+        assert observation.payload is not None
+        seqs.append(observation.payload["seq"])
+
+    assert seqs == [1, 2, 3]
+
+
+def test_a_repeat_between_two_changes_does_not_break_monotonicity():
+    tracker = PlanTracker(run_id="run-1")
+    plan_a = _write_plan_args(("one", "pending"))
+    plan_b = _write_plan_args(("one", "completed"))
+
+    assert tracker.observe("write_plan", plan_a).payload["seq"] == 1
+    assert tracker.observe("write_plan", plan_a).payload is None
+    assert tracker.observe("write_plan", plan_b).payload["seq"] == 2
+
+
+def test_a_non_plan_tool_is_unrecognized():
+    tracker = PlanTracker(run_id="run-1")
+    observation = tracker.observe("web_search", {"query": "quarterly filings"})
+
+    assert not observation.recognized
+    assert observation.payload is None
+
+
+def test_an_unreadable_plan_call_is_unrecognized_so_the_caller_can_fall_back():
+    """pydantic-ai announces the call from ``PartStartEvent`` with ``input={}``
+    before the arguments finish streaming (HTN-9). Reporting that as
+    unrecognized is what keeps the tool chip as the fallback."""
+    tracker = PlanTracker(run_id="run-1")
+    observation = tracker.observe("write_plan", {})
+
+    assert not observation.recognized
+    assert observation.payload is None
+    assert tracker.seq == 0
+
+
+def test_trackers_do_not_share_state_across_runs():
+    plan = THREE_STEP
+    assert PlanTracker(run_id="run-1").observe("write_plan", plan).payload["seq"] == 1
+    assert PlanTracker(run_id="run-2").observe("write_plan", plan).payload["seq"] == 1


### PR DESCRIPTION
> **Stacked on #1942** (`feat/humanized-tool-narration`). Review that one first.
> **Inert until #1945 merges** — see the last section. It is not broken; it has nothing to normalize yet.

The pydantic-ai backend already runs a real planning loop: the model maintains an ordered plan through a `write_plan` tool, revising it as it works. None of that reached the UI. This puts it on the wire so a panel can render it, on both surfaces a user might be watching from.

A `write_plan` call normalizes to:

```json
{
  "group_id": "…", "agent_id": "…", "agent_name": "…", "run_id": "…", "seq": 7,
  "items": [{"id": "1", "content": "Add the migration", "status": "completed"}],
  "progress": {"completed": 1, "total": 2}
}
```

Whole-list replacement, inherited from `write_plan`'s own semantics — the model resends the entire ordered list every call, so the renderer replaces rather than merges and there is no diffing to get wrong. `seq` is per-run monotonic so a reordered delivery cannot let a stale plan overwrite a fresh one. Emission is coalesced on a fingerprint, because `write_plan` fires at the start and end of every step and would otherwise flood the channel.

## Two transports, one normalizer

| Surface | Channel | Name |
|---|---|---|
| Group / DM | WS bus event | `agent.plan_updated` |
| Streaming chat | SSE frame | `plan_updated` |

The payloads are byte-identical so one render function serves both. Only the transport differs at the call site — the normalizer, the tracker, the status enum, the coalescing and the seq are a single module.

The split is not a compromise. `_drive_agent_loop` on the streaming path has **no group identity**: `RunSpec.group` never reaches it and `ScopeContext` carries none. The audience resolver scopes `agent.plan_updated` by `data["group_id"]`, so a bus emit from there raises `KeyError` inside the resolver, gets swallowed by `emit`'s bare `except`, and is delivered to nobody — while still passing any test that merely asserted `emit` was called. The SSE frame is the correct audience on that surface: the client streaming the run *is* the audience, and it is the transport the existing tool chips already use. There is an end-to-end test driving `execute_run` against a real `RedisStreamTransport` rather than trusting a reading of the forwarding code.

## Substitution, not addition — and fail-open

A recognized plan call emits the plan event and **not** the ordinary tool chip. Rendering "Using write_plan…" beside a live plan panel is bookkeeping noise; the panel already says everything the chip would.

The substitution is deliberately fail-open: if the arguments do not normalize into at least one item, the call reports itself unrecognized and falls through to the ordinary chip. That is not defensive habit, it is the live path today — see below — so the surface degrades to current behavior rather than to silence.

## Only `write_plan` is registered

Verified against the installed `pydantic_ai_harness/planning/_toolset.py`, not inferred. `write_todos` (deep_agents) and `TodoWrite` (claude_agent_sdk) are a `register_plan_normalizer(...)` call away, and the `[{content, status}]` shaper is already factored out because `write_todos` shares that shape.

**No `TodoWrite` normalizer was guessed.** Its payload lives inside a compiled binary (`claude_agent_sdk/_bundled/claude.exe`) and needs a live capture. Writing one against an inferred shape is how you get a panel that works in development and is blank for most users, which is the specific failure this design exists to avoid.

## Verification

```
plan tests:            41 passed
wider cloud sweep:     3 failed, 456 passed
```

All three failures are pre-existing and were each confirmed by reverting the changed files to base and re-running, not by assumption. `test_execute_run_threads_surface_meta_into_ctx` is in a file this PR changes, so it was checked independently on the base branch, where it fails identically.

Assertions are on payload contents, not event counts. Mutation-checked rather than assumed: blanking item content so it stops deriving from tool arguments fails 4 of the SSE tests and 4 of the bridge tests; defeating the coalescing fingerprint fails 2; decoupling the plan `run_id` from `stream_start`'s fails the equality test.

Three of the original bridge tests asserted an event fired without inspecting it, and two of those still passed under the content mutation. They now assert the surviving event carries all its items and the right progress. That class of test — one that counts events and never looks at the payload — is exactly what let a sibling bug survive for the life of a backend.

## `topics.gen.ts`

The WS event needs its topic line; the SSE frame needs nothing. The line is added by hand in the panel PR **on purpose**: `scripts/gen_topics.py`, run as documented, also deletes ten live topics (`belt_plan`, five `mandate.*`, four `meeting.*`), because `EVENT_REGISTRY` fills by class-definition side effect and the generator never imports the modules those classes live in. Pre-existing and unrelated; being fixed separately. Do not run the script to "correct" the manual edit.

## Why it is inert until #1945

pydantic-ai currently announces a tool call with `input={}` — the arguments are suppressed before the bridge ever sees them. So `write_plan` arrives with nothing to normalize and the fail-open path yields today's tool chip. #1945 fixes that. Merge order for the wave: **#1943 → #1945 → this**. Do not judge the panel by a live run before #1945 lands; it will look broken and will not be.
