### PR TITLE
Every tool reads as English

### DIFF
--- a/ee/pocketpaw_ee/cloud/shared/agent_bridge.py
+++ b/ee/pocketpaw_ee/cloud/shared/agent_bridge.py
@@ -44,6 +44,13 @@ so a group/DM agent that delivers a file persists the structured signal too.
 This path has no run-transport SSE stream, so it emits no ``artifact`` event —
 that applies only to the streaming ``run_core`` path.
 
+Updated 2026-08-15 (HTN-2): ``_narrate_tool_use`` takes the running agent and
+resolves that agent's OWN ``ToolRegistry`` (``tool_bridge.narration_registry_for``),
+so a tool's declared phrase is read off the live instance the registry holds
+rather than from a hardcoded name->class map that constructed the tool. Tools
+that declare nothing now derive a phrase from their name, so an unannotated
+tool reaches the wire as "Publishing the site" instead of no narration at all.
+
 Updated 2026-08-15 (HTN-1): the ``tool_use`` branch reads ``event.metadata``
 (name + input) with ``event.content`` as fallback — the precedence ``run_core``
 already uses — and adds an additive ``narration`` field to ``agent.tool_use``
@@ -468,18 +475,40 @@ def _augment_message_with_attachments(content: str, attachments: list[dict] | No
     return f"{content}\n\nAttached files:\n" + "\n".join(lines)
 
 
-def _narrate_tool_use(tool_name: str, tool_input: dict[str, Any]) -> str | None:
+def _narrate_tool_use(
+    tool_name: str, tool_input: dict[str, Any], instance: Any = None
+) -> str | None:
     """Render a plain-language phrase for a tool call, or None.
 
-    Returns None for any tool that declares no ``Narration`` — narration is
+    Returns None for any tool that has no phrasing at all — narration is
     decoration, so it must never raise into, or block, the response stream.
+
+    ``instance`` is the running agent, and it is what makes a tool's OWN
+    declared phrase reachable: ``narration_registry_for`` resolves the live
+    ``ToolRegistry`` backing that agent's bridged tool surface, and the lookup
+    reads the ``Narration`` off the instance the registry already holds. It is
+    never constructed — ``ShellTool.__init__`` calls ``get_settings()``, and on
+    cloud EE substitutes ``DaytonaShellTool`` under the same name, so building a
+    tool to read a property would run real setup on the event loop to phrase a
+    status line, and could phrase the wrong tool's.
+
+    Without a resolvable registry (the Claude SDK backend surfaces its tools
+    over MCP rather than through the bridge) the lookup still answers from the
+    override table or by deriving from the tool name — that is why the cloud
+    path's ``litellm_web_search`` narrates with its query either way, and why
+    the registry is what rescues the builtin ``web_search`` specifically.
     """
     if not tool_name:
         return None
     try:
         from pocketpaw.tools.narration import narration_for_tool, render
 
-        return render(narration_for_tool(tool_name), tool_input)
+        registry = None
+        if instance is not None:
+            from pocketpaw.agents.tool_bridge import narration_registry_for
+
+            registry = narration_registry_for(getattr(instance, "backend", None))
+        return render(narration_for_tool(tool_name, registry), tool_input)
     except Exception:
         logger.debug("Tool narration failed for %s", tool_name, exc_info=True)
         return None
@@ -678,7 +707,7 @@ async def _run_agent_response(
                 }
                 # Purely additive: a tool with no narration emits no field, and
                 # the bridge never invents a fallback phrase.
-                narration = _narrate_tool_use(tool_name, tool_input)
+                narration = _narrate_tool_use(tool_name, tool_input, instance)
                 if narration:
                     payload["narration"] = narration
                 await emit(AgentToolUse(data=payload))

--- a/src/pocketpaw/agents/tool_bridge.py
+++ b/src/pocketpaw/agents/tool_bridge.py
@@ -14,6 +14,16 @@ Backend-aware exclusion:
 - BrowserTool/DesktopTool: always excluded (need special session state)
 
 Changes:
+- 2026-08-15 (HTN-2, feat/narration-registry-lookup): the ToolRegistry each
+  build_*_tools() constructs is no longer dropped at function exit. It is kept
+  on the ToolPolicy it was built under and reachable through
+  narration_registry_for(backend), so a caller holding an agent can resolve
+  that agent's OWN live tool instances — which is what humanized tool narration
+  reads a tool's declared phrase off. Anchored on the policy because its
+  lifetime is already the agent's; a module-level map would leak, since the
+  registry references its policy and would keep its own weak key alive. The
+  four builders now share _build_tool_registry() instead of repeating the same
+  three lines.
 - 2026-07-29 (feat/pydantic-ai-backend): added build_pydantic_ai_tools() plus the
   two signature builders it shares. pydantic-ai derives a tool's JSON schema from
   the wrapper's *signature*, so the wrappers synthesize one instead of emitting
@@ -39,6 +49,66 @@ from pocketpaw.tools.protocol import BaseTool
 from pocketpaw.tools.registry import ToolRegistry
 
 logger = logging.getLogger(__name__)
+
+
+def _build_tool_registry(backend: str, policy: ToolPolicy) -> ToolRegistry:
+    """Build the ToolRegistry for one backend's bridged surface, and retain it.
+
+    The four ``build_*_tools`` functions below all did these three lines
+    themselves and dropped the registry on the floor at function exit. It is
+    now kept on the POLICY, so a caller that has the agent can reach that
+    agent's live tool instances. Humanized tool narration (HTN-2) is the
+    consumer: it reads the ``Narration`` a tool declares off the instance the
+    registry already holds, because CONSTRUCTING a tool to read a property
+    would run ``ShellTool.__init__`` -> ``get_settings()`` on the event loop
+    just to phrase a status line.
+
+    The policy is the anchor for two reasons. Its LIFETIME is already the
+    agent's — the pool builds one policy per agent, the backend holds it, and
+    an evicted ``AgentInstance`` takes both with it — and ``set_tool_policy``
+    swaps the policy while clearing ``_custom_tools``, so a rebuilt surface
+    lands on the new policy instead of serving a stale registry.
+
+    A module-level map would be worse in two distinct ways. It would LEAK: the
+    registry references its policy, so even a weak-keyed entry would keep its
+    own key alive forever, holding every agent's tools for the life of the
+    process. And keyed by tool NAME it would also be ambiguous — EE registers
+    ``DaytonaShellTool`` under the same ``shell`` name as the OSS builtin, so
+    two live agents would disagree and the lookup would have to pick one
+    nondeterministically or refuse to narrate ``shell`` at all.
+    """
+    registry = ToolRegistry(policy=policy)
+    for tool in _instantiate_all_tools(backend=backend):
+        registry.register(tool)
+    policy._bridged_registry = registry
+    return registry
+
+
+def narration_registry_for(backend: Any) -> ToolRegistry | None:
+    """Return the ToolRegistry backing *backend*'s bridged tool surface.
+
+    The seam that lets a caller holding an agent (the cloud agent bridge)
+    resolve that agent's OWN live tools. Returns ``None`` for a backend that
+    never bridged tools through here — the Claude SDK backend surfaces its
+    tools over MCP, so there is no registry to find and narration derives from
+    the tool name instead.
+
+    Duck-typed on the public ``get_tool_policy`` every bridged backend exposes,
+    so no caller has to reach for a private attribute of a backend.
+    """
+    getter = getattr(backend, "get_tool_policy", None)
+    if not callable(getter):
+        return None
+    try:
+        policy = getter()
+        if policy is None:
+            return None
+        registry = getattr(policy, "_bridged_registry", None)
+    except Exception:  # noqa: BLE001 — a status line must never break a run
+        logger.debug("Could not resolve a narration registry for %r", type(backend), exc_info=True)
+        return None
+    return registry if isinstance(registry, ToolRegistry) else None
+
 
 # Tools excluded from ALL backends -- need special session state or desktop access.
 _ALWAYS_EXCLUDED = frozenset({"BrowserTool", "DesktopTool"})
@@ -237,9 +307,7 @@ def build_openai_function_tools(
             deny=settings.tools_deny,
         )
 
-    registry = ToolRegistry(policy=policy)
-    for tool in _instantiate_all_tools(backend=backend):
-        registry.register(tool)
+    registry = _build_tool_registry(backend, policy)
 
     function_tools: list[FunctionTool] = []
     for tool_name in registry.allowed_tool_names:
@@ -365,9 +433,7 @@ def build_adk_function_tools(
             deny=settings.tools_deny,
         )
 
-    registry = ToolRegistry(policy=policy)
-    for tool in _instantiate_all_tools(backend=backend):
-        registry.register(tool)
+    registry = _build_tool_registry(backend, policy)
 
     function_tools: list = []
     for tool_name in registry.allowed_tool_names:
@@ -456,9 +522,7 @@ def build_deep_agents_tools(
             deny=settings.tools_deny,
         )
 
-    registry = ToolRegistry(policy=policy)
-    for tool in _instantiate_all_tools(backend=backend):
-        registry.register(tool)
+    registry = _build_tool_registry(backend, policy)
 
     structured_tools: list = []
     for tool_name in registry.allowed_tool_names:
@@ -510,9 +574,7 @@ def build_pydantic_ai_tools(
             deny=settings.tools_deny,
         )
 
-    registry = ToolRegistry(policy=policy)
-    for tool in _instantiate_all_tools(backend=backend):
-        registry.register(tool)
+    registry = _build_tool_registry(backend, policy)
 
     tools: list = []
     for tool_name in registry.allowed_tool_names:

--- a/src/pocketpaw/tools/narration.py
+++ b/src/pocketpaw/tools/narration.py
@@ -22,6 +22,28 @@
 #     to copy them, so a hostile ``__format__`` can never reach ``.format()``.
 #   - bound sanitizing work before it starts: truncate to a scan limit first so
 #     a multi-MB tool arg can't drive full-size copies on the event loop.
+#
+# Updated: 2026-08-15 (HTN-2) — every tool reads as English, not just the one
+# annotated tool. ``_ANNOTATED_TOOLS`` (the one-entry name -> (module, class)
+# stopgap) is DELETED: it mapped to builtin classes, so MCP and connector tools
+# could never appear in it, and reading a narration through it CONSTRUCTED the
+# tool. ``narration_for_tool`` now resolves in three steps —
+#
+#   1. the ``Narration`` declared on the LIVE instance a ``ToolRegistry``
+#      already holds. Never construct a tool to read a property:
+#      ``ShellTool.__init__`` calls ``get_settings()``, so a registry-wide
+#      version of the old instantiate-to-read pattern would build settings, and
+#      whatever the credential store does on first load, on the event loop just
+#      to phrase a status line.
+#   2. ``_NARRATION_OVERRIDES`` — phrasing for tools that are external and
+#      cannot self-declare (MCP servers, connector surfaces, proxy-side tools).
+#   3. derive-from-name — strip the vendor prefix, find a verb in a small fixed
+#      lexicon, phrase it verb-first. Deterministic string work, no LLM.
+#
+# and returns ``None`` when all three come up empty, so a caller omits the field
+# rather than inventing a phrase. A derived phrase never interpolates arguments:
+# derivation reads the tool's NAME, and a name carries no ``safe_args``
+# allowlist, so there is nothing that would make an argument safe to show.
 
 from __future__ import annotations
 
@@ -31,7 +53,6 @@ import string
 import unicodedata
 from dataclasses import dataclass
 from functools import lru_cache
-from importlib import import_module
 from numbers import Number
 from typing import Any
 
@@ -274,30 +295,247 @@ def render(narration: Narration | None, args: dict | None) -> str | None:
         return bare
 
 
-# Tool name -> (module, class) for the builtin tools that declare a Narration.
-# Kept explicit rather than walking every builtin so a lookup never imports the
-# world (or an optional dependency) just to phrase a status line. HTN-2 replaces
-# this with the real registry lookup plus the derive-from-name fallback.
-_ANNOTATED_TOOLS: dict[str, tuple[str, str]] = {
-    "web_search": ("pocketpaw.tools.builtin.web_search", "WebSearchTool"),
+# Phrasing for tools that cannot declare a ``Narration`` of their own. An MCP
+# server's tools and a connector's hosted actions are defined outside this
+# codebase, so there is no class to annotate — this table is the only place
+# their phrasing can live.
+#
+# This is NOT the deleted ``_ANNOTATED_TOOLS`` under a new name. That map named
+# a module and a class and CONSTRUCTED the tool to read a property off it; this
+# one holds finished ``Narration`` values and imports nothing. A builtin belongs
+# on its own class (``BaseTool.narration``), never here.
+#
+# Keying is by wire name, which is the only identity the bridge has. See the
+# collision caveat in ``narration_for_tool``.
+_NARRATION_OVERRIDES: dict[str, Narration] = {
+    # LiteLLM's proxy exposes web search under this name, with a ``query``
+    # parameter. Derivation alone would read it as the bare "Searching the web"
+    # — correct but incurious — because a derived phrase never interpolates
+    # arguments. Declaring it here is what puts the query back in the sentence.
+    "litellm_web_search": Narration(
+        active="Searching the web for {query}",
+        bare="Searching the web",
+        safe_args=("query",),
+    ),
 }
+
+# Verb -> gerund. Deliberately small and fixed: a derived phrase is a fallback,
+# so it needs to be predictable and wrong-in-a-boring-way rather than clever. A
+# name whose verb is not in here derives nothing and narrates nothing.
+_VERB_LEXICON: dict[str, str] = {
+    "publish": "Publishing",
+    "create": "Creating",
+    "search": "Searching",
+    "invite": "Inviting",
+    "delete": "Deleting",
+    "update": "Updating",
+    "list": "Listing",
+    "send": "Sending",
+    "read": "Reading",
+    "write": "Writing",
+    "run": "Running",
+    "fetch": "Fetching",
+}
+
+# Leading tokens that name the vendor rather than the thing being acted on.
+# Stripped only from the FRONT, so ``pocketpaw_sites_publish`` loses its prefix
+# while a hypothetical ``export_pocketpaw`` keeps its object.
+_VENDOR_PREFIXES = frozenset({"mcp", "pocketpaw", "paw", "litellm", "composio"})
+
+# Object tokens that are a NAME rather than a common noun, mapped to how they
+# are spelled in a sentence. A name takes no article: the article rule that
+# makes ``sites_publish`` read "Publishing the site" would otherwise make
+# ``gmail_search`` read "Searching the gmail".
+#
+# The services here are the ones PocketPaw actually surfaces tools for — see
+# ``_COMPOSIO_OVERLAPPING_TOOL_NAMES`` in ``agents/tool_bridge.py``, which is
+# where these names come from. One missing from this map degrades to the article
+# form, which reads slightly wrong rather than incorrectly.
+_PROPER_NOUNS: dict[str, str] = {
+    "calendar": "Calendar",
+    "discord": "Discord",
+    "docs": "Docs",
+    "drive": "Drive",
+    "github": "GitHub",
+    "gmail": "Gmail",
+    "jira": "Jira",
+    "linear": "Linear",
+    "notion": "Notion",
+    "python": "Python",
+    "reddit": "Reddit",
+    "sheets": "Sheets",
+    "slack": "Slack",
+    "telegram": "Telegram",
+    "youtube": "YouTube",
+}
+
+# Splits a name into words: an acronym run (``HTTP``), a capitalized word
+# (``Fetch``), or a lowercase/digit run. The default backend's own builtins are
+# camelCase — ``WebSearch``, ``TodoWrite``, ``WebFetch`` — so without this they
+# derive nothing at all, being a single unrecognisable token.
+_WORD_RUN = re.compile(r"[A-Z]+(?![a-z])|[A-Z][a-z0-9]*|[a-z0-9]+")
+
+# A tool NAME is externally controlled — a user-added MCP server names its own
+# tools — and a derived phrase embeds it, so the name is validated before any
+# of it reaches a user-visible string. ASCII word characters only: that rejects
+# the bidi overrides and zero-width characters ``_strip_invisibles`` exists to
+# catch, before they ever get near a phrase. Length is capped here so the
+# derived phrase is bounded without a second cap downstream.
+_DERIVABLE_NAME = re.compile(r"^[A-Za-z0-9_]{1,80}$")
+_MAX_NAME_TOKENS = 8
+
+
+def _name_tokens(segment: str) -> list[str]:
+    """Split one name segment into lowercase words.
+
+    Handles both conventions a tool name arrives in: ``sites_publish`` and
+    ``TodoWrite``.
+    """
+    return [word.lower() for word in _WORD_RUN.findall(segment)]
+
+
+def _strip_vendor_prefix(tokens: list[str]) -> list[str]:
+    index = 0
+    while index < len(tokens) and tokens[index] in _VENDOR_PREFIXES:
+        index += 1
+    return tokens[index:]
+
+
+def _singularize(word: str) -> str:
+    """Naive trailing-plural trim — enough for tool names, not for English.
+
+    Tool names are short machine identifiers ("sites", "entries"), so the two
+    common plural forms cover the surface. The ``ss``/``us``/``is``/``os``
+    guard keeps "status", "analysis" and "address" intact.
+    """
+    if len(word) > 3 and word.endswith("ies"):
+        return word[:-3] + "y"
+    if len(word) > 2 and word.endswith("s") and not word.endswith(("ss", "us", "is", "os")):
+        return word[:-1]
+    return word
 
 
 @lru_cache(maxsize=256)
-def narration_for_tool(tool_name: str) -> Narration | None:
-    """Look up the ``Narration`` a builtin tool declares, by tool name.
+def _derive_narration(tool_name: str) -> Narration | None:
+    """Phrase a tool call from the tool's NAME alone.
 
-    Returns ``None`` for any tool that isn't annotated — callers treat that as
-    "no narration", never as a reason to invent one.
+    ``pocketpaw_sites_publish`` -> "Publishing the site". Returns ``None`` when
+    the name carries no verb this can recognise (``shell``), because a phrase
+    invented from a name we cannot read is worse than the raw name: it is a
+    confident sentence about something the agent may not be doing.
+
+    The result carries no placeholders, so it renders identically whatever the
+    call's arguments were.
     """
-    target = _ANNOTATED_TOOLS.get(tool_name)
-    if target is None:
+    if not isinstance(tool_name, str) or not _DERIVABLE_NAME.match(tool_name):
         return None
-    module_path, class_name = target
+
+    # ``mcp__<server>__<tool>`` is how Claude Code namespaces an in-process MCP
+    # tool. The last segment is the tool itself; the segment before it is the
+    # server, which is the only place an object noun lives when the tool
+    # segment is a bare verb (``mcp__pocketpaw_pocket_specialist__create``).
+    segments = [segment for segment in tool_name.split("__") if segment]
+    if not segments:
+        return None
+    tokens = _strip_vendor_prefix(_name_tokens(segments[-1]))
+    if not tokens or len(tokens) > _MAX_NAME_TOKENS:
+        return None
+
+    # Three orders occur in the wild, so the verb is looked for in all of them:
+    #   sites_publish, web_search        verb last, object before it
+    #   create_pocket, send_message      verb first, object after it
+    #   gmail_send, gmail_list_labels    service first, then the verb-first form
+    # The trailing position wins, because a name that ENDS in a verb is using it
+    # as a verb; a name that merely contains one may be using it as a noun
+    # (``search_index_update`` is an update, not a search).
+    if tokens[-1] in _VERB_LEXICON:
+        verb, object_tokens = tokens[-1], tokens[:-1]
+    else:
+        for index, token in enumerate(tokens):
+            if token in _VERB_LEXICON:
+                verb, object_tokens = token, tokens[index + 1 :]
+                break
+        else:
+            return None
+
+    if not object_tokens and len(segments) >= 2:
+        # ``mcp__pocketpaw_pocket_specialist__create`` — the tool segment is a
+        # bare verb, so the server segment is the only noun on offer.
+        object_tokens = _strip_vendor_prefix(_name_tokens(segments[-2]))
+    object_tokens = [token for token in object_tokens if token != "tool"]
+    if len(object_tokens) > _MAX_NAME_TOKENS:
+        return None
+
+    gerund = _VERB_LEXICON[verb]
+    if not object_tokens:
+        # A verb with no object still beats the raw identifier, and inventing
+        # an object would be inventing a fact.
+        phrase = gerund
+    elif len(object_tokens) == 1 and object_tokens[0] in _PROPER_NOUNS:
+        phrase = f"{gerund} {_PROPER_NOUNS[object_tokens[0]]}"
+    else:
+        # "list" is inherently plural — singularizing it gives "Listing the
+        # file" for ``list_files``, which is the one place the trim reads worse
+        # than leaving the name alone.
+        if verb != "list":
+            object_tokens[-1] = _singularize(object_tokens[-1])
+        phrase = f"{gerund} the {' '.join(object_tokens)}"
+
+    return Narration(active=phrase, bare=phrase)
+
+
+def _declared_narration(tool_name: str, registry: Any | None) -> Narration | None:
+    """Read the ``Narration`` off the LIVE instance ``registry`` holds.
+
+    Never constructs anything. The registry already owns instantiated tools
+    (``ToolRegistry.register`` stores the instance), so a lookup is a dict get
+    and an attribute read — no ``__init__`` runs, no settings get built, no
+    credential store gets touched to phrase a status line.
+
+    Every step is guarded because none of it is our code: ``registry`` is
+    duck-typed, ``get`` may be anything callable, and ``narration`` is a
+    property a tool author wrote.
+    """
+    if registry is None:
+        return None
+    getter = getattr(registry, "get", None)
+    if not callable(getter):
+        return None
     try:
-        tool = getattr(import_module(module_path), class_name)()
-        narration = tool.narration
+        tool = getter(tool_name)
+        if tool is None:
+            return None
+        narration = getattr(tool, "narration", None)
     except Exception:
         logger.debug("Narration lookup failed for tool %r", tool_name, exc_info=True)
         return None
     return narration if isinstance(narration, Narration) else None
+
+
+def narration_for_tool(tool_name: str, registry: Any | None = None) -> Narration | None:
+    """Resolve the ``Narration`` for a tool call, by tool name.
+
+    Resolution order, first hit wins:
+
+    1. the narration declared on the live instance in ``registry`` (when the
+       caller has one);
+    2. ``_NARRATION_OVERRIDES``, for external tools that cannot self-declare;
+    3. derive-from-name.
+
+    Returns ``None`` when none of them phrase it. Callers omit the field on
+    ``None`` — they never fall back to a phrase of their own.
+
+    IDENTITY CAVEAT: every step keys on the bare wire name, which is the only
+    identity a caller has at this point. On backends that emit unprefixed MCP
+    tool names (``agents/codex_cli.py``), a user-added MCP server exposing a
+    tool called ``web_search`` would inherit whatever ``web_search`` means
+    here. Resolving that needs the tool's ORIGIN (the server field the caller
+    would have to read alongside the name), not a change in this function.
+    """
+    if not isinstance(tool_name, str) or not tool_name:
+        return None
+    return (
+        _declared_narration(tool_name, registry)
+        or _NARRATION_OVERRIDES.get(tool_name)
+        or _derive_narration(tool_name)
+    )

--- a/src/pocketpaw/tools/narration.py
+++ b/src/pocketpaw/tools/narration.py
@@ -312,6 +312,15 @@ _NARRATION_OVERRIDES: dict[str, Narration] = {
     # parameter. Derivation alone would read it as the bare "Searching the web"
     # — correct but incurious — because a derived phrase never interpolates
     # arguments. Declaring it here is what puts the query back in the sentence.
+    #
+    # This entry does NOT make the registry lookup optional, and the two cover
+    # different tools. With LiteLLM's search interception off, the cloud path
+    # calls the proxy's search tool under THIS name and narrates from this
+    # table, needing no registry. The builtin ``web_search`` — our own
+    # ``WebSearchTool`` via the MCP bridge — is a different row of that table
+    # and declares its own phrase, which is reachable only through the live
+    # registry. Delete the seam and this entry keeps the cloud path speaking
+    # while the builtin quietly drops its query.
     "litellm_web_search": Narration(
         active="Searching the web for {query}",
         bare="Searching the web",
@@ -491,6 +500,13 @@ def _declared_narration(tool_name: str, registry: Any | None) -> Narration | Non
     (``ToolRegistry.register`` stores the instance), so a lookup is a dict get
     and an attribute read — no ``__init__`` runs, no settings get built, no
     credential store gets touched to phrase a status line.
+
+    ``.narration`` IS THE ONLY ATTRIBUTE THIS MAY TOUCH on the tool. Not
+    ``definition``, not ``parameters``, never ``execute``. Narration is a
+    description of a call, so it needs one declaration and nothing else, and a
+    lookup that reaches further turns a status line into a second caller of the
+    tool surface. Widening this is a change to the security boundary, not a
+    convenience.
 
     Every step is guarded because none of it is our code: ``registry`` is
     duck-typed, ``get`` may be anything callable, and ``narration`` is a

--- a/src/pocketpaw/tools/policy.py
+++ b/src/pocketpaw/tools/policy.py
@@ -17,6 +17,13 @@ Updated: 2026-05-21 — Added ``is_mcp_server_explicitly_allowed`` so built-in
   added ``OPT_IN_MCP_SERVERS`` — the single source of truth for which
   in-process servers are opt-in, imported by AgentPool and ClaudeSDKBackend.
 
+Updated: 2026-08-15 (HTN-2) — a policy carries the ``ToolRegistry`` built under
+  it (``_bridged_registry``), so a caller holding an agent can reach that
+  agent's OWN live tool instances. Humanized tool narration reads a tool's
+  declared phrase off the instance the registry holds rather than constructing
+  the tool. The policy is the anchor because its lifetime is already the
+  agent's; see the field's comment for why a module-level map would leak.
+
 Inspired by OpenClaw's tool-policy.ts.
 """
 
@@ -24,6 +31,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Sequence
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -137,6 +145,21 @@ class ToolPolicy:
         # Pre-resolve for fast lookups
         self._allowed_set = self._resolve()
         self._denied_set = self._expand_names(self._deny_raw)
+
+        # The ToolRegistry built under this policy, attached by
+        # ``agents.tool_bridge._build_tool_registry`` and read back through
+        # ``agents.tool_bridge.narration_registry_for``. Declared here so it is
+        # a field of the object rather than an attribute that appears from
+        # another module, and typed loosely because ``ToolRegistry`` imports
+        # this module — naming the type here would be a cycle.
+        #
+        # This is where the registry's LIFETIME comes from: it is exactly this
+        # policy's, which is the agent's. The pool evicts an idle
+        # ``AgentInstance``, the backend and its policy go, and the registry and
+        # its tool instances go with them. Holding it in a module-level map
+        # instead would leak — the registry references this policy, so a
+        # weak-keyed entry would keep its own key alive forever.
+        self._bridged_registry: Any = None
 
     # ------------------------------------------------------------------
     # Public API

--- a/tests/cloud/shared/test_agent_bridge_narration.py
+++ b/tests/cloud/shared/test_agent_bridge_narration.py
@@ -10,9 +10,12 @@
 #   - the interpolated search phrase is asserted against ``litellm_web_search``,
 #     the name the CLOUD path actually emits, which resolves through the
 #     override table;
-#   - the builtin ``web_search`` degrades to the bare phrase here, because this
-#     bridge has no ``ToolRegistry`` handle to read the declaration off. That is
-#     pinned by its own test rather than left to be discovered.
+#   - the builtin ``web_search`` still renders its DECLARED phrase, now read off
+#     the live instance in the agent's own ``ToolRegistry`` (resolved through
+#     ``tool_bridge.narration_registry_for``) instead of off a tool the lookup
+#     constructed. A backend that bridges no tools — the Claude SDK one, whose
+#     tools come over MCP — has no registry to resolve and derives instead;
+#     both paths have a test.
 #
 # The events here use the shape the backends ACTUALLY emit — ``content`` is a
 # prose string ("Using web_search...") and ``metadata`` carries the bare name
@@ -41,12 +44,34 @@ def _tool_use_event(name: str, tool_input: dict):
     )
 
 
-async def _emitted_tool_use(events: list) -> list[dict]:
+def _bridged_backend():
+    """A backend whose bridged tool surface is reachable, as a real one is.
+
+    Mirrors production: ``tool_bridge`` builds the registry under the agent's
+    ToolPolicy and keeps it there, and every bridged backend exposes
+    ``get_tool_policy``. Building it through the real helper means this carries
+    the live ``WebSearchTool`` instance, not a stub of one — the point of the
+    seam is that the phrase is read off the instance the agent actually holds.
+    """
+    from pocketpaw.agents.tool_bridge import _build_tool_registry
+    from pocketpaw.tools.policy import ToolPolicy
+
+    policy = ToolPolicy(profile="full")
+    _build_tool_registry("pydantic_ai", policy)
+    return SimpleNamespace(get_tool_policy=lambda: policy)
+
+
+async def _emitted_tool_use(events: list, backend=None) -> list[dict]:
     """Drive ``_run_agent_response`` over ``events`` and return the payloads of
-    every ``agent.tool_use`` it emitted."""
+    every ``agent.tool_use`` it emitted.
+
+    ``backend`` rides on the agent instance the pool hands back, which is how
+    the narration lookup reaches the agent's own tool registry. Defaults to
+    None — a backend that bridges no tools, like the Claude SDK one.
+    """
     from pocketpaw_ee.cloud.shared import agent_bridge
 
-    instance = SimpleNamespace(agent_name="Test Agent")
+    instance = SimpleNamespace(agent_name="Test Agent", backend=backend)
     pool = MagicMock()
     pool.get = AsyncMock(return_value=instance)
     pool.observe = AsyncMock()
@@ -131,20 +156,32 @@ async def test_search_tool_use_carries_a_humanized_narration():
 
 
 @pytest.mark.asyncio
-async def test_builtin_web_search_degrades_to_the_bare_phrase_here():
-    """KNOWN GAP, pinned deliberately rather than left to be discovered.
+async def test_builtin_web_search_renders_its_declared_phrase_through_the_registry():
+    """THE no-regression test at the bridge.
 
-    ``WebSearchTool`` DECLARES the interpolated phrase, and the lookup renders
-    it whenever a caller passes the ``ToolRegistry`` holding that tool (see
-    ``test_narration_lookup_reads_the_declaration_off_a_live_registry``). This
-    bridge has no registry handle to pass — every ``ToolRegistry`` in the
-    process is built inside ``agents/tool_bridge.py`` and discarded there — so
-    the lookup falls through to derive-from-name and the query is dropped.
-
-    Restoring the interpolation is a seam, not a phrasing change: it needs the
-    agent's registry threaded to this function. Until then this asserts what
-    actually happens, so the gap stays visible in the suite.
+    ``WebSearchTool`` declares the interpolated phrase. Before HTN-2 the bridge
+    reached it through a name -> (module, class) map that INSTANTIATED the tool;
+    that map is gone, so this now resolves the agent's own ``ToolRegistry`` and
+    reads the declaration off the live instance. If the seam breaks, this drops
+    to the derived "Searching the web" — the silent downgrade of the one tool
+    that already worked.
     """
+    payloads = await _emitted_tool_use(
+        [
+            _tool_use_event("web_search", {"query": "quarterly filings"}),
+            _done_event(),
+        ],
+        backend=_bridged_backend(),
+    )
+
+    assert payloads[0]["tool"] == "web_search"
+    assert payloads[0]["narration"] == "Searching the web for quarterly filings"
+
+
+@pytest.mark.asyncio
+async def test_a_backend_that_bridges_no_tools_still_narrates_by_derivation():
+    """The Claude SDK backend surfaces its tools over MCP, so there is no
+    registry to resolve. The chain must still answer — from the tool name."""
     payloads = await _emitted_tool_use(
         [
             _tool_use_event("web_search", {"query": "quarterly filings"}),
@@ -152,7 +189,6 @@ async def test_builtin_web_search_degrades_to_the_bare_phrase_here():
         ]
     )
 
-    assert payloads[0]["tool"] == "web_search"
     assert payloads[0]["narration"] == "Searching the web"
 
 

--- a/tests/cloud/shared/test_agent_bridge_narration.py
+++ b/tests/cloud/shared/test_agent_bridge_narration.py
@@ -2,6 +2,18 @@
 # Created: 2026-08-15 — proves a real ``tool_use`` event reaches the wire as
 # "Searching the web for quarterly filings" instead of a bare tool name.
 #
+# Updated: 2026-08-15 (HTN-2) — the narration lookup no longer instantiates a
+# tool from a one-entry name -> class map, so what the bridge emits changed in
+# three ways:
+#   - an unannotated tool now derives a phrase ("Publishing the site") where it
+#     previously emitted no narration field at all;
+#   - the interpolated search phrase is asserted against ``litellm_web_search``,
+#     the name the CLOUD path actually emits, which resolves through the
+#     override table;
+#   - the builtin ``web_search`` degrades to the bare phrase here, because this
+#     bridge has no ``ToolRegistry`` handle to read the declaration off. That is
+#     pinned by its own test rather than left to be discovered.
+#
 # The events here use the shape the backends ACTUALLY emit — ``content`` is a
 # prose string ("Using web_search...") and ``metadata`` carries the bare name
 # plus the call's input (see ``agents/claude_sdk.py`` and ``agents/pydantic_ai.py``).
@@ -90,12 +102,20 @@ async def _emitted_tool_use(events: list) -> list[dict]:
 
 
 @pytest.mark.asyncio
-async def test_web_search_tool_use_carries_a_humanized_narration():
-    """HTN-1's headline behaviour: a real web_search call reaches the wire with
-    a plain-language phrase, and the tool name still rides alongside it."""
+async def test_search_tool_use_carries_a_humanized_narration():
+    """The headline behaviour: a real search call reaches the wire with an
+    interpolated plain-language phrase, and the tool name rides alongside it.
+
+    The name is ``litellm_web_search`` rather than ``web_search`` because that
+    is what the CLOUD path — the only consumer of this bridge — actually emits:
+    with LiteLLM's search interception off, the model calls the proxy's search
+    tool under that name (see the LiteLLM finding in
+    ``docs/design/2026-08-15-humanized-tool-narration-tasks.md``). It resolves
+    through the narration override table, which needs no registry handle.
+    """
     payloads = await _emitted_tool_use(
         [
-            _tool_use_event("web_search", {"query": "quarterly filings"}),
+            _tool_use_event("litellm_web_search", {"query": "quarterly filings"}),
             _done_event(),
         ]
     )
@@ -105,15 +125,44 @@ async def test_web_search_tool_use_carries_a_humanized_narration():
 
     assert payload["narration"] == "Searching the web for quarterly filings"
     # Additive only — clients keyed on ``tool`` keep working untouched.
-    assert payload["tool"] == "web_search"
+    assert payload["tool"] == "litellm_web_search"
     assert payload["agent_id"] == "agent-1"
     assert payload["group_id"] == "group-1"
 
 
 @pytest.mark.asyncio
-async def test_unannotated_tool_emits_no_narration_field():
-    """HTN-2 owns the derive-from-name fallback. Until then an unannotated tool
-    stays silent — the bridge must not invent a phrase of its own."""
+async def test_builtin_web_search_degrades_to_the_bare_phrase_here():
+    """KNOWN GAP, pinned deliberately rather than left to be discovered.
+
+    ``WebSearchTool`` DECLARES the interpolated phrase, and the lookup renders
+    it whenever a caller passes the ``ToolRegistry`` holding that tool (see
+    ``test_narration_lookup_reads_the_declaration_off_a_live_registry``). This
+    bridge has no registry handle to pass — every ``ToolRegistry`` in the
+    process is built inside ``agents/tool_bridge.py`` and discarded there — so
+    the lookup falls through to derive-from-name and the query is dropped.
+
+    Restoring the interpolation is a seam, not a phrasing change: it needs the
+    agent's registry threaded to this function. Until then this asserts what
+    actually happens, so the gap stays visible in the suite.
+    """
+    payloads = await _emitted_tool_use(
+        [
+            _tool_use_event("web_search", {"query": "quarterly filings"}),
+            _done_event(),
+        ]
+    )
+
+    assert payloads[0]["tool"] == "web_search"
+    assert payloads[0]["narration"] == "Searching the web"
+
+
+@pytest.mark.asyncio
+async def test_unannotated_tool_emits_a_derived_narration():
+    """HTN-2: a tool that declares nothing still reaches the wire as English.
+
+    This is the case the whole feature is named for — the surface used to
+    render "using pocketpaw_sites_publish".
+    """
     payloads = await _emitted_tool_use(
         [
             _tool_use_event("pocketpaw_sites_publish", {"pocket_id": "p1"}),
@@ -125,7 +174,10 @@ async def test_unannotated_tool_emits_no_narration_field():
     payload = payloads[0]
 
     assert payload["tool"] == "pocketpaw_sites_publish"
-    assert payload.get("narration") is None
+    assert payload["narration"] == "Publishing the site"
+    # A derived phrase is built from the NAME, so no argument rides along with
+    # it — the name carries no ``safe_args`` allowlist that could vet one.
+    assert "p1" not in payload["narration"]
 
 
 @pytest.mark.asyncio
@@ -144,21 +196,28 @@ async def test_missing_query_degrades_to_the_bare_phrase():
 
 
 @pytest.mark.asyncio
-async def test_secrets_in_tool_input_never_reach_the_wire():
+@pytest.mark.parametrize("tool_name", ["litellm_web_search", "web_search"])
+async def test_secrets_in_tool_input_never_reach_the_wire(tool_name):
     """The bridge hands the whole input dict to the renderer, so this is the
-    end-to-end proof that only allowlisted fields survive the trip."""
+    end-to-end proof that only allowlisted fields survive the trip.
+
+    Run against both search paths — the interpolating one (override) and the
+    derived one — because the allowlist has to hold on whichever branch of the
+    lookup answers, not just the one that happens to interpolate.
+    """
     payloads = await _emitted_tool_use(
         [
             _tool_use_event(
-                "web_search",
+                tool_name,
                 {"query": "quarterly filings", "api_key": "sk-live-SUPERSECRET"},
             ),
             _done_event(),
         ]
     )
 
-    assert payloads[0]["narration"] == "Searching the web for quarterly filings"
     assert "SUPERSECRET" not in str(payloads[0])
+    assert "api_key" not in str(payloads[0])
+    assert payloads[0]["narration"].startswith("Searching the web")
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_bridge_narration_registry.py
+++ b/tests/test_tool_bridge_narration_registry.py
@@ -93,6 +93,61 @@ def test_two_agents_resolve_their_own_registries():
     assert tool_bridge.narration_registry_for(_FakeBackend(policy_b)) is registry_b
 
 
+class _DeclaringShell:
+    """A tool named ``shell`` that declares its own phrase."""
+
+    def __init__(self, phrase: str):
+        self._phrase = phrase
+
+    name = "shell"
+
+    @property
+    def narration(self):
+        from pocketpaw.tools.narration import Narration
+
+        return Narration(active=self._phrase, bare=self._phrase)
+
+
+def test_an_ee_substituted_tool_narrates_from_its_own_declaration():
+    """The case that decided the seam's shape.
+
+    On cloud, EE registers ``DaytonaShellTool`` under the SAME ``shell`` name as
+    the OSS ``ShellTool`` and it wins by last-writer-wins registration
+    (``extensions.py:1297``, ``daytona/tools.py:763``). Two agents can be live in
+    one process with different instances behind that one name. A process-global
+    name index would have to pick one nondeterministically, or refuse to narrate
+    ``shell`` at all; resolving through the agent's OWN registry makes both
+    answers correct at once.
+
+    Neither shell tool declares a ``Narration`` yet — HTN-3 writes those — so
+    this uses two declaring stand-ins registered exactly the way EE substitutes,
+    which pins the property now instead of waiting on annotations to exist.
+    """
+    oss_policy = ToolPolicy(profile="full")
+    oss_registry = tool_bridge._build_tool_registry("pydantic_ai", oss_policy)
+    oss_registry.register(_DeclaringShell("Running a shell command"))
+
+    cloud_policy = ToolPolicy(profile="full")
+    cloud_registry = tool_bridge._build_tool_registry("pydantic_ai", cloud_policy)
+    cloud_registry.register(_DeclaringShell("Running a command in the sandbox"))
+
+    oss_backend = _FakeBackend(oss_policy)
+    cloud_backend = _FakeBackend(cloud_policy)
+
+    oss_phrase = render(
+        narration_for_tool("shell", tool_bridge.narration_registry_for(oss_backend)), {}
+    )
+    cloud_phrase = render(
+        narration_for_tool("shell", tool_bridge.narration_registry_for(cloud_backend)), {}
+    )
+
+    assert oss_phrase == "Running a shell command"
+    assert cloud_phrase == "Running a command in the sandbox"
+    assert oss_phrase != cloud_phrase, (
+        "both agents resolved the same instance — the lookup is not per-agent"
+    )
+
+
 def test_the_retained_registry_is_released_with_its_policy():
     """Lifetime — the reason this hangs off the policy and not a module map.
 

--- a/tests/test_tool_bridge_narration_registry.py
+++ b/tests/test_tool_bridge_narration_registry.py
@@ -1,0 +1,148 @@
+# Tests for the narration registry seam in ``agents/tool_bridge.py`` (HTN-2).
+# Created: 2026-08-15 — every ToolRegistry the bridge builds used to be dropped
+# at function exit, so a caller holding an agent had no way to reach that
+# agent's live tool instances and a tool's declared ``Narration`` was
+# unreadable in production. These tests pin the seam that fixes it: the
+# registry is retained under the agent's own ToolPolicy, resolved through the
+# public ``narration_registry_for``, and released when the policy dies.
+#
+# The lifetime test is the load-bearing one. This process serves every tenant,
+# so a retention that outlived the agent would be a leak, and a retention keyed
+# process-wide by tool NAME would be ambiguous — EE registers DaytonaShellTool
+# under the same ``shell`` name as the OSS builtin.
+
+from __future__ import annotations
+
+import gc
+import weakref
+
+import pytest
+
+from pocketpaw.agents import tool_bridge
+from pocketpaw.tools.narration import narration_for_tool, render
+from pocketpaw.tools.policy import ToolPolicy
+
+
+class _FakeBackend:
+    """Stands in for a bridged backend.
+
+    Every backend that bridges tools through ``tool_bridge`` (pydantic_ai,
+    deep_agents, openai_agents, google_adk) exposes this exact public method,
+    which is why the seam duck-types on it instead of reaching for ``_policy``.
+    """
+
+    def __init__(self, policy: ToolPolicy):
+        self._policy = policy
+
+    def get_tool_policy(self) -> ToolPolicy:
+        return self._policy
+
+
+@pytest.fixture
+def bridged_backend():
+    policy = ToolPolicy(profile="full")
+    registry = tool_bridge._build_tool_registry("pydantic_ai", policy)
+    return _FakeBackend(policy), registry
+
+
+def test_the_agents_registry_is_reachable_from_its_backend(bridged_backend):
+    backend, registry = bridged_backend
+
+    assert tool_bridge.narration_registry_for(backend) is registry
+    assert registry.has("web_search"), "the bridged surface should carry the builtin tools"
+
+
+def test_web_search_still_renders_its_declared_phrase(bridged_backend):
+    """THE no-regression test.
+
+    Before HTN-2 this phrase came from a one-entry name -> (module, class) map
+    that INSTANTIATED ``WebSearchTool`` to read the property off it. Deleting
+    that map without this seam would have silently downgraded the one tool that
+    already worked, from the interpolated phrase to a bare one.
+    """
+    backend, _ = bridged_backend
+    registry = tool_bridge.narration_registry_for(backend)
+
+    assert render(narration_for_tool("web_search", registry), {"query": "quarterly filings"}) == (
+        "Searching the web for quarterly filings"
+    )
+
+
+def test_an_unannotated_tool_in_the_registry_still_derives(bridged_backend):
+    """The registry answering does not disable the rest of the chain — a tool
+    the registry holds that declares nothing falls through to derivation."""
+    backend, _ = bridged_backend
+    registry = tool_bridge.narration_registry_for(backend)
+
+    assert registry.has("write_file")
+    assert render(narration_for_tool("write_file", registry), {}) == "Writing the file"
+
+
+def test_two_agents_resolve_their_own_registries():
+    """Why this is keyed per policy rather than by tool name process-wide: on a
+    cloud process two agents are live at once, and EE registers
+    ``DaytonaShellTool`` under the same name as the OSS ``ShellTool``. Each
+    agent must resolve ITS instance — a shared name index would have to pick
+    one nondeterministically or refuse to narrate ``shell`` at all."""
+    policy_a, policy_b = ToolPolicy(profile="full"), ToolPolicy(profile="full")
+    registry_a = tool_bridge._build_tool_registry("pydantic_ai", policy_a)
+    registry_b = tool_bridge._build_tool_registry("deep_agents", policy_b)
+
+    assert registry_a is not registry_b
+    assert tool_bridge.narration_registry_for(_FakeBackend(policy_a)) is registry_a
+    assert tool_bridge.narration_registry_for(_FakeBackend(policy_b)) is registry_b
+
+
+def test_the_retained_registry_is_released_with_its_policy():
+    """Lifetime — the reason this hangs off the policy and not a module map.
+
+    Retention is bounded by the agent's own lifecycle: the pool evicts an idle
+    AgentInstance, the backend and its policy go with it, and the registry and
+    its ~76 tool instances go too.
+
+    The first draft of this seam used a module-level ``WeakKeyDictionary``
+    keyed by policy, and THIS test is what caught that it leaks: the registry
+    holds a reference back to its policy, so the entry's value keeps its own
+    weak key alive and nothing is ever collected. Keep this test pointed at
+    collection, not at a container's length, or that bug comes back invisible.
+    """
+    policy = ToolPolicy(profile="full")
+    registry_ref = weakref.ref(tool_bridge._build_tool_registry("pydantic_ai", policy))
+    assert registry_ref() is not None
+
+    del policy
+    gc.collect()
+
+    assert registry_ref() is None, "the registry outlived the policy that anchors it"
+
+
+@pytest.mark.parametrize(
+    ("label", "backend"),
+    [
+        ("no backend at all", None),
+        ("a backend that never bridged tools", object()),
+        (
+            "a policy getter returning None",
+            type("_B", (), {"get_tool_policy": lambda self: None})(),
+        ),
+        (
+            "a policy getter that raises",
+            type(
+                "_B",
+                (),
+                {"get_tool_policy": lambda self: (_ for _ in ()).throw(RuntimeError("no"))},
+            )(),
+        ),
+    ],
+)
+def test_a_backend_without_a_bridged_registry_resolves_nothing(label, backend):
+    """The Claude SDK backend surfaces its tools over MCP rather than through
+    this bridge, so there is genuinely no registry to find. That must resolve to
+    None quietly — narration then derives from the tool name."""
+    assert tool_bridge.narration_registry_for(backend) is None, label
+
+
+def test_an_unretained_policy_resolves_nothing():
+    """A policy that never built a surface has no registry — and asking must not
+    invent one."""
+    assert tool_bridge.narration_registry_for(_FakeBackend(ToolPolicy(profile="full"))) is None

--- a/tests/test_tool_narration.py
+++ b/tests/test_tool_narration.py
@@ -13,6 +13,18 @@
 # literal is unreviewable in a diff, and an editor or tool that rewrites the
 # file can silently mangle it (one became a NUL byte while this file was being
 # written, which broke collection outright).
+#
+# Updated: 2026-08-15 (HTN-2) — coverage for the lookup chain that replaced the
+# ``_ANNOTATED_TOOLS`` stopgap: declared-on-the-live-instance, then the override
+# table, then derive-from-name, then nothing. Three of these are security tests
+# rather than phrasing tests:
+#   - the lookup must never CONSTRUCT a tool to read its narration (a registry
+#     entry whose ``__init__`` raises and records that it ran);
+#   - a derived phrase must be argument-blind, since a NAME carries no
+#     ``safe_args`` allowlist that could make an argument safe to show;
+#   - a tool name is externally controlled — a user-added MCP server names its
+#     own tools — and a derived phrase embeds it, so the hostile-name table
+#     covers the same attacks the argument sanitizer already defends against.
 
 from __future__ import annotations
 
@@ -494,18 +506,37 @@ def test_web_search_declares_the_reference_narration():
     )
 
 
-def test_narration_lookup_by_tool_name():
-    assert narration_for_tool("web_search") is not None
-    assert render(narration_for_tool("web_search"), {"query": "filings"}) == (
+def test_narration_lookup_reads_the_declaration_off_a_live_registry():
+    """The declared phrase is read off the instance the registry already holds.
+
+    HTN-1 looked this up through a name -> (module, class) map and CONSTRUCTED
+    the tool. HTN-2 deletes that map: the registry owns live instances, so a
+    lookup is a dict get and an attribute read.
+    """
+    from pocketpaw.tools.builtin.web_search import WebSearchTool
+    from pocketpaw.tools.registry import ToolRegistry
+
+    registry = ToolRegistry()
+    registry.register(WebSearchTool())
+
+    assert render(narration_for_tool("web_search", registry), {"query": "filings"}) == (
         "Searching the web for filings"
     )
 
 
-def test_unannotated_tool_has_no_narration():
-    """HTN-1 annotates exactly one tool; everything else stays silent until
-    HTN-2 lands the derive-from-name fallback."""
+def test_unannotated_tool_derives_a_phrase_instead_of_a_raw_identifier():
+    """HTN-2's headline behaviour: a tool that declares nothing still reads as
+    English, and the raw snake_case identifier never reaches a user."""
+    assert render(narration_for_tool("pocketpaw_sites_publish"), {"pocket_id": "p1"}) == (
+        "Publishing the site"
+    )
+
+
+def test_a_name_with_no_recognisable_verb_narrates_nothing():
+    """The chain ends at None, never at an invented phrase. ``shell`` carries
+    no verb this can read, so the caller omits the field and the surface keeps
+    whatever fallback it already had."""
     assert narration_for_tool("shell") is None
-    assert narration_for_tool("pocketpaw_sites_publish") is None
     assert render(narration_for_tool("shell"), {"command": "ls"}) is None
 
 
@@ -525,3 +556,247 @@ def test_base_tool_defaults_to_no_narration():
             return ""
 
     assert _Bare().narration is None
+
+
+# ---------------------------------------------------------------------------
+# HTN-2 — the lookup chain: declared (live instance) -> override -> derived.
+# ---------------------------------------------------------------------------
+
+
+class _FakeRegistry:
+    """Duck-typed stand-in for ``ToolRegistry``.
+
+    The lookup only ever calls ``.get(name)``, so a test can hand it something
+    that is deliberately NOT a tool instance — which is how the
+    never-construct proof below works.
+    """
+
+    def __init__(self, entries: dict):
+        self._entries = entries
+
+    def get(self, name: str):
+        return self._entries.get(name)
+
+
+def test_the_stopgap_annotated_tools_map_is_deleted():
+    """HTN-1's ``_ANNOTATED_TOOLS`` was a name -> (module, class) map with one
+    entry. It could not describe an MCP or connector tool by construction, and
+    reading through it instantiated the tool. Growing it was the wrong fix, so
+    the regression guard is that the symbol is gone entirely."""
+    from pocketpaw.tools import narration as narration_module
+
+    assert not hasattr(narration_module, "_ANNOTATED_TOOLS")
+
+
+def test_narration_lookup_never_constructs_a_tool():
+    """The security constraint this whole task is built around.
+
+    ``ShellTool.__init__`` calls ``get_settings()``, so a lookup that
+    instantiated a tool to read a property would build settings — and whatever
+    the credential store does on first load — on the event loop, just to phrase
+    a status line. The registry entry here is a CLASS whose ``__init__`` raises
+    and records that it ran: if anything calls it, the list below is not empty.
+    """
+    constructed: list[str] = []
+
+    class _Exploding:
+        name = "pocketpaw_sites_publish"
+
+        def __init__(self):
+            constructed.append("boom")
+            raise RuntimeError("a narration lookup must never run this")
+
+        @property
+        def narration(self):  # pragma: no cover - only reachable via an instance
+            return None
+
+    registry = _FakeRegistry({"pocketpaw_sites_publish": _Exploding})
+
+    # Falls through to derivation rather than raising or constructing.
+    assert render(narration_for_tool("pocketpaw_sites_publish", registry), {}) == (
+        "Publishing the site"
+    )
+    assert constructed == [], "the lookup constructed a tool to read its narration"
+
+
+def test_a_narration_property_that_raises_falls_through_to_derivation():
+    """``narration`` is a property a tool author wrote, so it can raise. A
+    broken declaration must not take the status line down with it."""
+
+    class _Broken:
+        name = "pocketpaw_sites_publish"
+
+        @property
+        def narration(self):
+            raise RuntimeError("bad declaration")
+
+    registry = _FakeRegistry({"pocketpaw_sites_publish": _Broken()})
+
+    assert render(narration_for_tool("pocketpaw_sites_publish", registry), {}) == (
+        "Publishing the site"
+    )
+
+
+def test_a_registry_that_misbehaves_is_survivable():
+    """``registry`` is duck-typed — a caller can hand over anything."""
+
+    class _Hostile:
+        def get(self, name):
+            raise RuntimeError("no")
+
+    assert render(narration_for_tool("pocketpaw_sites_publish", _Hostile()), {}) == (
+        "Publishing the site"
+    )
+    assert narration_for_tool("pocketpaw_sites_publish", object()) is not None
+    assert narration_for_tool("shell", object()) is None
+
+
+def test_declaration_beats_the_override_table():
+    """Resolution order: a tool that declares its own phrasing owns it, even
+    when the name is also in the override table."""
+
+    class _Declared:
+        name = "litellm_web_search"
+        narration = Narration(active="Consulting the archive", bare="Consulting the archive")
+
+    registry = _FakeRegistry({"litellm_web_search": _Declared()})
+
+    assert render(narration_for_tool("litellm_web_search", registry), {"query": "x"}) == (
+        "Consulting the archive"
+    )
+
+
+def test_the_override_table_beats_derivation():
+    """``litellm_web_search`` derives to the bare "Searching the web" on its
+    name alone — a derived phrase never interpolates arguments, because a name
+    carries no ``safe_args`` allowlist. The override is what puts the query
+    back in the sentence."""
+    assert render(narration_for_tool("litellm_web_search"), {"query": "quarterly filings"}) == (
+        "Searching the web for quarterly filings"
+    )
+
+
+def test_the_override_still_honours_the_safe_args_allowlist():
+    """An override is a declaration like any other, so the allowlist governs it
+    too — this is the ONE entry that interpolates, so it is the one that has to
+    be proven not to leak."""
+    rendered = render(
+        narration_for_tool("litellm_web_search"),
+        {"query": "quarterly filings", "api_key": "sk-live-SUPERSECRET"},
+    )
+
+    assert rendered == "Searching the web for quarterly filings"
+    assert "SUPERSECRET" not in rendered
+
+
+def test_the_override_falls_back_to_bare_without_the_query():
+    assert render(narration_for_tool("litellm_web_search"), {}) == "Searching the web"
+
+
+# Real names from the surfaces this task exists to cover. The MCP names are the
+# ``mcp__<server>__<tool>`` form Claude Code emits (``agents/sdk_mcp_atlas.py``,
+# ``agents/claude_sdk.py:494``); the connector names are lifted verbatim from
+# ``_COMPOSIO_OVERLAPPING_TOOL_NAMES`` in ``agents/tool_bridge.py``; the
+# camelCase ones are the default backend's own builtins.
+@pytest.mark.parametrize(
+    ("tool_name", "expected"),
+    [
+        # The PRD's worked example.
+        ("pocketpaw_sites_publish", "Publishing the site"),
+        # MCP surface — namespaced, and a bare-verb tool segment borrows its
+        # object noun from the server segment.
+        ("mcp__pocketpaw_pocket_specialist__create", "Creating the pocket specialist"),
+        ("mcp__pocketpaw_widgets__list_widgets", "Listing the widgets"),
+        # Connector surface — a service name takes no article.
+        ("gmail_search", "Searching Gmail"),
+        ("gmail_list_labels", "Listing the labels"),
+        ("gmail_create_label", "Creating the label"),
+        ("docs_read", "Reading Docs"),
+        ("drive_list", "Listing Drive"),
+        ("reddit_search", "Searching Reddit"),
+        # Verb in the middle: the service prefix is dropped, not narrated.
+        ("github_create_issue", "Creating the issue"),
+        # Default-backend builtins are camelCase.
+        ("WebSearch", "Searching the web"),
+        ("TodoWrite", "Writing the todo"),
+        ("Read", "Reading"),
+        # Plurals are trimmed for the article form, except after "list".
+        ("delete_entries", "Deleting the entry"),
+        ("list_files", "Listing the files"),
+        # "status" is not a plural.
+        ("update_status", "Updating the status"),
+        ("run_python", "Running Python"),
+    ],
+)
+def test_derived_phrasing_for_real_tool_names(tool_name, expected):
+    assert render(narration_for_tool(tool_name), {}) == expected
+
+
+@pytest.mark.parametrize(
+    "tool_name",
+    [
+        "shell",  # no verb in the lexicon
+        "bash",
+        "NotebookEdit",  # "edit" is deliberately not in the lexicon
+        "gmail_trash",
+        "",
+        "___",
+    ],
+)
+def test_names_that_narrate_nothing(tool_name):
+    """Nothing is invented. The caller omits the field and the surface keeps
+    whatever fallback it already had."""
+    assert narration_for_tool(tool_name) is None
+
+
+def test_derivation_never_interpolates_arguments():
+    """A derived phrase is built from the NAME. The name carries no
+    ``safe_args`` allowlist, so nothing could make an argument safe to show —
+    a derived narration must be argument-blind."""
+    rendered = render(
+        narration_for_tool("pocketpaw_sites_publish"),
+        {"pocket_id": "p1", "api_key": "sk-live-SUPERSECRET", "query": "quarterly filings"},
+    )
+
+    assert rendered == "Publishing the site"
+    assert "SUPERSECRET" not in rendered
+    assert "quarterly" not in rendered
+
+
+# Invisible characters are \uXXXX escapes, never literals — see this file's
+# header. A tool NAME is externally controlled (a user-added MCP server names
+# its own tools) and a derived phrase embeds it, so every attack the renderer
+# defends against for ARGUMENTS applies to the name too.
+@pytest.mark.parametrize(
+    ("label", "tool_name"),
+    [
+        ("bidi override", "sites_\u202epublish"),
+        ("zero width", "sites\u200b_publish"),
+        ("newline", "sites_publish\nfake"),
+        ("ansi escape", "sites_publish\u001b[31m"),
+        ("brace injection", "sites_{query}_publish"),
+        ("non-ascii", "sites_pubÍish"),
+        ("overlong", "a_" * 200 + "publish"),
+    ],
+)
+def test_a_hostile_tool_name_derives_nothing(label, tool_name):
+    """The name is validated before any of it reaches a phrase. Rejecting
+    outright beats sanitizing: a name we cannot read is a name we cannot
+    describe honestly."""
+    assert narration_for_tool(tool_name) is None, label
+
+
+def test_a_derived_phrase_carries_no_placeholders():
+    """Derivation builds a template ``render`` will call ``.format()`` on, so a
+    brace reaching it would either raise or interpolate. The name gate is what
+    makes that impossible; this pins the property itself."""
+    for tool_name in ("pocketpaw_sites_publish", "gmail_search", "TodoWrite"):
+        narration = narration_for_tool(tool_name)
+        assert "{" not in narration.active and "}" not in narration.active
+        assert narration.safe_args == ()
+        assert narration.active == narration.bare
+
+
+def test_lookup_ignores_a_non_string_name():
+    assert narration_for_tool(None) is None
+    assert narration_for_tool(123) is None


### PR DESCRIPTION
> **Stacked on #1942** (`feat/humanized-tool-narration`). Review that first.

#1942 taught one tool to narrate itself. This makes every tool readable, and gives a tool's own declaration a way to reach the wire.

Three layers, tried in order:

1. **Declared** — the `Narration` a tool defines, read off the live instance the agent's own registry holds.
2. **Override table** — for MCP and connector tools, which cannot self-declare. Seeded with `litellm_web_search`, since LiteLLM's proxy exposes web search under that name with a `query` parameter.
3. **Derived from the name** — vendor prefix stripped, verb-first through a small deterministic lexicon. `pocketpaw_sites_publish` reads "Publishing the site" instead of `using pocketpaw_sites_publish`. No LLM at runtime.

Anything unresolved returns `None` and the bridge emits no narration field. It never invents a phrase.

## Reaching the registry, and why it lives on the policy

The obvious approach — a hardcoded `name -> (module, class)` map — is deleted here, and a test guards its absence. It cannot work: `extensions.py:1297` and `cloud/daytona/tools.py:763` register `DaytonaShellTool` under the same `shell` name as the OSS builtin, last-writer-wins. A class map narrates the wrong class on cloud. Reading off the live instance is the only correct source.

But every `ToolRegistry` was built inside `tool_bridge.py` and dropped at function exit. So the registry is now retained — **on the `ToolPolicy` it was built under**, reachable through a public `narration_registry_for(backend)` that duck-types on the `get_tool_policy()` every bridged backend already exposes. No backend file needed editing and nothing reaches into a backend's privates.

The policy is the anchor because its lifetime is already the agent's: the pool builds one policy per agent, the backend holds it, the `AgentInstance` holds the backend, and eviction takes the whole chain. `set_tool_policy` swaps the policy while clearing `_custom_tools`, so a rebuilt surface lands on the new policy rather than serving a stale registry.

**A module-level `WeakKeyDictionary` was tried first and leaks.** `ToolRegistry` holds `self._policy`, so the entry's *value* keeps its own weak key alive — every agent's tools would persist for the life of a process that serves every tenant. The lifetime test caught it. That test now asserts the registry is genuinely collected through a `weakref` rather than that a container shrank, so the leak cannot return invisibly.

Incremental memory is small: the wrappers in `_custom_tools` already close over the same instances. The real addition is tools the registry holds that a backend filtered out of its wrapper list — a few dozen small objects per live agent.

## Never construct a tool to read a property

`ShellTool.__init__` calls `get_settings()`. Constructing a tool to read its narration would run real setup on the event loop to phrase a status line, and on cloud could phrase the wrong tool's. Reading off the live instance removes the possibility entirely — there is no longer a code path that *could* construct one. A test registers a class whose `__init__` records and raises, then asserts the lookup falls through to derivation with the recorder empty.

The lookup touches `.narration` and nothing else. Never `definition`, never `execute`. That is written into the docstring as a security boundary, not a convenience.

## Verification

```
narration + registry + bridge + policy + tool_bridge:   162 passed
wider tools and cloud sweep:                            1 failed, 227 passed
agent-backend slice:                                     85 passed
```

The single failure is pre-existing: `test_agent_bridge_emits.py` hardcodes `Path("D:/paw/backend/ee/cloud/shared/agent_bridge.py")`, a layout that has not existed since the ee namespace rename. It fails identically on `dev`.

`web_search` is proven not to regress through the **real** registry path, not an injected stub — the test builds through `_build_tool_registry("pydantic_ai", policy)`, the same function the four builders call, and a companion test proves it end-to-end at the bridge with the interpolated phrase on the emitted payload.

The EE substitution case has its own test: two agents each get a declaring tool registered under `shell` the way EE substitutes, and each narrates from its own declaration. That case is the entire reason this is per-agent rather than a process-global lookup, and it had no coverage until it was asked for.

## Known limits, all deliberate

- **Identity is name-keyed.** On codex_cli, an MCP server exposing `web_search` inherits the builtin's phrase. Fixing it needs the `server` field read inside the `tool_use` block, which this PR does not own. Documented as the follow-up.
- **Bridged backends only.** `claude_agent_sdk` surfaces tools over MCP and never touches `tool_bridge`, so declared narration is unreachable there and it falls to the override table and derivation. Extending the seam to `build_inprocess_mcp_toolsets` is the highest-leverage follow-up in this plan and should be scoped before anyone hand-authors ~100 declarations.
- **`policy._bridged_registry` is a private attribute set from another module.** Declared as a field in `ToolPolicy.__init__` and documented on both sides so it is a field rather than a surprise. A public accessor pair was a larger surface than this task warranted; worth revisiting if the seam gains a second consumer.
- **The frontend half is not here.** Deleting the 9-entry `statusMap` at `store.svelte.ts:709` lives in paw-enterprise.

## For whoever edits these files next

`narration.py` and `test_tool_narration.py` are committed **CRLF** while their neighbours are LF. Editors normalize on save and turn a 200-line change into an 844-line whole-file diff that will collide with any sibling branch in the same file. Check `git diff --stat` before committing there.
