### PR TITLE
Bridged tools were handed strings where they declared ints

### DIFF
--- a/src/pocketpaw/agents/tool_bridge.py
+++ b/src/pocketpaw/agents/tool_bridge.py
@@ -618,10 +618,25 @@ def _make_pydantic_ai_tool(tool_cls: Any, tool: Any, settings: Any) -> Any:
       defaulted to the schema's own ``default``. (The LangChain bridge marks all
       parameters required; respecting ``required`` here is deliberate.)
 
-    Explicit nulls are dropped for any parameter whose default is not ``None``.
-    A model is free to send ``"num_results": null`` for an optional argument,
-    and passing that through would override the tool's own ``= 5`` with ``None``
-    — the omitted-argument bug by another route.
+    A ``None`` is dropped for any OPTIONAL parameter rather than forwarded, so
+    ``tool.execute``'s own default applies. Two ways a ``None`` gets here and
+    both are wrong to pass on:
+
+    * the model sends ``"num_results": null`` explicitly;
+    * the model omits an optional argument whose JSON schema declares no
+      ``default``, so the synthesized signature defaults it to ``None`` and
+      pydantic-ai fills that in.
+
+    The second is the wider hole. 26 parameters across 13 tools are in that
+    shape — ``connector_*`` takes ``pocket_id: str = "default"``, ``drive_list``
+    takes ``max_results: int = 20``, ``reddit_search`` takes ``limit: int = 10``
+    — and every one of them was being handed ``None`` instead of its default the
+    moment real arguments started arriving.
+
+    Dropping rather than forwarding is safe in both directions: a tool whose own
+    default IS ``None`` gets ``None`` either way, so the only behaviour that
+    changes is the one that was already broken. Required parameters are never
+    dropped — a missing required argument must still fail loudly.
     """
     import inspect
 
@@ -633,11 +648,10 @@ def _make_pydantic_ai_tool(tool_cls: Any, tool: Any, settings: Any) -> Any:
         params, annotations = _signature_from_model(inspect, schema_cls)
     else:
         params, annotations = _signature_from_json_schema(inspect, defn.parameters or {})
+        params = _borrow_defaults_from_execute(inspect, params, tool)
 
     _drop_when_null = frozenset(
-        p.name
-        for p in params
-        if p.default is not inspect.Parameter.empty and p.default is not None
+        p.name for p in params if p.default is not inspect.Parameter.empty
     )
 
     async def _run(**kwargs: Any) -> str:
@@ -722,6 +736,44 @@ def _python_type_for(prop: Any) -> Any:
         # caller adds for optional properties, so take the first real type.
         declared = next((t for t in declared if t != "null"), None)
     return _JSON_SCHEMA_TYPES.get(declared, str)
+
+
+def _borrow_defaults_from_execute(inspect: Any, params: list, tool: Any) -> list:
+    """Fill an optional parameter's default from ``tool.execute`` when the JSON
+    schema does not declare one.
+
+    Most tools document a default in prose ("Number of results (default: 5)")
+    and encode it only in the Python signature. The schema then has no
+    ``default``, the synthesized parameter falls back to ``None``, and
+    pydantic-ai passes that ``None`` when the model omits the argument — right
+    over the top of the tool's own value.
+
+    26 parameters across 13 tools are in that shape: ``connector_*`` declares
+    ``pocket_id: str = "default"``, ``drive_list`` declares
+    ``max_results: int = 20``, ``reddit_search`` declares ``limit: int = 10``.
+    The numeric ones crash exactly like ``web_search`` did; the string ones are
+    quieter and worse, because ``pocket_id=None`` is a wrong scope rather than an
+    error.
+
+    Borrowing the real default also tells the MODEL the truth: the advertised
+    schema shows ``"default": 20`` instead of a nullable field with no default,
+    so it can omit the argument knowingly. ``_run`` still drops an explicit
+    ``null`` as a second line of defence.
+    """
+    try:
+        execute_params = inspect.signature(tool.execute).parameters
+    except (TypeError, ValueError):  # pragma: no cover - defensive
+        return params
+
+    patched: list = []
+    for p in params:
+        own = execute_params.get(p.name)
+        needs_default = p.default is None and own is not None
+        if needs_default and own.default is not inspect.Parameter.empty and own.default is not None:
+            patched.append(p.replace(default=own.default))
+        else:
+            patched.append(p)
+    return patched
 
 
 def _signature_from_json_schema(inspect: Any, parameters: dict) -> tuple[list, dict]:

--- a/src/pocketpaw/agents/tool_bridge.py
+++ b/src/pocketpaw/agents/tool_bridge.py
@@ -14,6 +14,20 @@ Backend-aware exclusion:
 - BrowserTool/DesktopTool: always excluded (need special session state)
 
 Changes:
+- 2026-08-15 (fix/bridged-tool-arg-types): _signature_from_json_schema now maps
+  each property's JSON-schema ``type`` to the matching Python annotation and
+  keeps the schema's own ``default``, instead of flattening everything to
+  ``str`` / ``str | None = None``. pydantic-ai builds the schema the MODEL sees
+  from this signature, so an ``{"type": "integer", "default": 5}`` property was
+  advertised as a nullable string and execute() received ``"5"`` or ``None``
+  where it annotated ``int = 5``. web_search crashed on
+  ``min(max(num_results, 1), 10)`` ("'>' not supported between instances of
+  'int' and 'NoneType'/'str'"); every bridged tool with a non-string parameter
+  was affected. _make_pydantic_ai_tool also drops an explicit ``null`` for any
+  parameter whose default is not None, so a model sending ``"num_results":
+  null`` no longer overrides the tool's own default. Both halves were masked
+  until the pydantic-ai argument drop was fixed — while the backend delivered
+  ``{}``, no argument ever reached a tool.
 - 2026-08-15 (HTN-2, feat/narration-registry-lookup): the ToolRegistry each
   build_*_tools() constructs is no longer dropped at function exit. It is kept
   on the ToolPolicy it was built under and reachable through
@@ -599,17 +613,36 @@ def _make_pydantic_ai_tool(tool_cls: Any, tool: Any, settings: Any) -> Any:
     * ``args_schema`` present — mirror the Pydantic model's fields with their
       real annotations and defaults, so nested objects (the pocket specialist's
       ``hints``) round-trip as ``$defs`` instead of being flattened to strings.
-    * otherwise — one ``str`` parameter per declared property, optional ones
-      annotated ``str | None`` with a ``None`` default so the model isn't forced
-      to invent a value for every field. (The LangChain bridge marks all
+    * otherwise — one parameter per declared property carrying the PYTHON type
+      its JSON-schema ``type`` names, optional ones annotated ``T | None`` and
+      defaulted to the schema's own ``default``. (The LangChain bridge marks all
       parameters required; respecting ``required`` here is deliberate.)
+
+    Explicit nulls are dropped for any parameter whose default is not ``None``.
+    A model is free to send ``"num_results": null`` for an optional argument,
+    and passing that through would override the tool's own ``= 5`` with ``None``
+    — the omitted-argument bug by another route.
     """
     import inspect
 
     defn = tool.definition
     limit = int(getattr(settings, "pydantic_ai_max_tool_output_chars", 0) or 0)
 
+    schema_cls = getattr(tool, "args_schema", None)
+    if schema_cls is not None:
+        params, annotations = _signature_from_model(inspect, schema_cls)
+    else:
+        params, annotations = _signature_from_json_schema(inspect, defn.parameters or {})
+
+    _drop_when_null = frozenset(
+        p.name
+        for p in params
+        if p.default is not inspect.Parameter.empty and p.default is not None
+    )
+
     async def _run(**kwargs: Any) -> str:
+        if _drop_when_null:
+            kwargs = {k: v for k, v in kwargs.items() if not (v is None and k in _drop_when_null)}
         try:
             result = await tool.execute(**kwargs)
         except Exception as exc:
@@ -631,12 +664,6 @@ def _make_pydantic_ai_tool(tool_cls: Any, tool: Any, settings: Any) -> Any:
     _run.__name__ = defn.name
     _run.__qualname__ = defn.name
     _run.__doc__ = defn.description
-
-    schema_cls = getattr(tool, "args_schema", None)
-    if schema_cls is not None:
-        params, annotations = _signature_from_model(inspect, schema_cls)
-    else:
-        params, annotations = _signature_from_json_schema(inspect, defn.parameters or {})
 
     annotations["return"] = str
     _run.__signature__ = inspect.Signature(parameters=params, return_annotation=str)
@@ -672,30 +699,75 @@ def _signature_from_model(inspect: Any, model: Any) -> tuple[list, dict]:
     return params, annotations
 
 
+#: JSON-schema ``type`` -> the Python annotation pydantic-ai should advertise.
+#: Anything unlisted (``null``, a ``$ref``, a missing ``type``) falls back to
+#: ``str``, which is what every property used to get.
+_JSON_SCHEMA_TYPES: dict[str, Any] = {
+    "string": str,
+    "integer": int,
+    "number": float,
+    "boolean": bool,
+    "array": list,
+    "object": dict,
+}
+
+
+def _python_type_for(prop: Any) -> Any:
+    """Map one JSON-schema property to a Python annotation."""
+    if not isinstance(prop, dict):
+        return str
+    declared = prop.get("type")
+    if isinstance(declared, list):
+        # ``["integer", "null"]`` — nullability is carried by the ``| None`` the
+        # caller adds for optional properties, so take the first real type.
+        declared = next((t for t in declared if t != "null"), None)
+    return _JSON_SCHEMA_TYPES.get(declared, str)
+
+
 def _signature_from_json_schema(inspect: Any, parameters: dict) -> tuple[list, dict]:
-    """Build ``str``-typed signature params from a tool's JSON-schema properties.
+    """Build signature params from a tool's JSON-schema properties.
+
+    Each property carries the Python type its ``type`` names, because
+    pydantic-ai turns this signature into the schema the MODEL is shown. Every
+    property used to be annotated ``str`` regardless of what it declared, so a
+    tool declaring ``num_results: {"type": "integer"}`` advertised a string and
+    ``execute()`` was handed ``"5"`` where it annotated ``int``. ``web_search``
+    died on ``min(max(num_results, 1), 10)``; every bridged tool with a
+    non-string parameter had the same defect.
 
     Honours the schema's ``required`` list: optional properties become
-    ``str | None = None`` so the model may omit them.
+    ``T | None`` so the model may omit them, defaulted to the schema's own
+    ``default`` rather than to ``None``. The default matters as much as the
+    type — ``num_results`` declares ``"default": 5``, and passing ``None`` for
+    an omitted argument OVERRODE the tool's own ``= 5`` instead of leaving it
+    alone.
+
+    Both halves were invisible while the pydantic-ai backend delivered ``{}``
+    for every tool call: no argument arrived, so the tool's Python defaults
+    always applied and the annotations were never exercised.
     """
     props = parameters.get("properties", {}) or {}
     required = set(parameters.get("required", []) or [])
     params: list = []
     annotations: dict = {}
-    for name in props:
+    for name, prop in props.items():
+        declared = _python_type_for(prop)
         if name in required:
-            params.append(inspect.Parameter(name, inspect.Parameter.KEYWORD_ONLY, annotation=str))
-            annotations[name] = str
+            params.append(
+                inspect.Parameter(name, inspect.Parameter.KEYWORD_ONLY, annotation=declared)
+            )
+            annotations[name] = declared
         else:
+            optional = declared | None
             params.append(
                 inspect.Parameter(
                     name,
                     inspect.Parameter.KEYWORD_ONLY,
-                    annotation=str | None,
-                    default=None,
+                    annotation=optional,
+                    default=prop.get("default") if isinstance(prop, dict) else None,
                 )
             )
-            annotations[name] = str | None
+            annotations[name] = optional
     return params, annotations
 
 

--- a/src/pocketpaw/agents/tool_bridge.py
+++ b/src/pocketpaw/agents/tool_bridge.py
@@ -23,11 +23,18 @@ Changes:
   where it annotated ``int = 5``. web_search crashed on
   ``min(max(num_results, 1), 10)`` ("'>' not supported between instances of
   'int' and 'NoneType'/'str'"); every bridged tool with a non-string parameter
-  was affected. _make_pydantic_ai_tool also drops an explicit ``null`` for any
-  parameter whose default is not None, so a model sending ``"num_results":
-  null`` no longer overrides the tool's own default. Both halves were masked
-  until the pydantic-ai argument drop was fixed — while the backend delivered
-  ``{}``, no argument ever reached a tool.
+  was affected. Where the schema declares no ``default`` at all,
+  _borrow_defaults_from_execute takes it from ``tool.execute`` instead of
+  falling back to None — 26 parameters across 13 tools document their default
+  only in the Python signature (``connector_*`` has ``pocket_id: str =
+  "default"``, ``drive_list`` has ``max_results: int = 20``), and every one was
+  handed None the moment real arguments started arriving. The numeric ones
+  crash like web_search did; the string ones are quieter and worse, because
+  ``pocket_id=None`` is a wrong scope rather than an error. _run additionally
+  drops an explicit ``null`` for any OPTIONAL parameter, so a model sending
+  ``"num_results": null`` gets the tool's default rather than None. All of it
+  was masked until the pydantic-ai argument drop was fixed — while the backend
+  delivered ``{}``, no argument ever reached a tool.
 - 2026-08-15 (HTN-2, feat/narration-registry-lookup): the ToolRegistry each
   build_*_tools() constructs is no longer dropped at function exit. It is kept
   on the ToolPolicy it was built under and reachable through
@@ -650,9 +657,7 @@ def _make_pydantic_ai_tool(tool_cls: Any, tool: Any, settings: Any) -> Any:
         params, annotations = _signature_from_json_schema(inspect, defn.parameters or {})
         params = _borrow_defaults_from_execute(inspect, params, tool)
 
-    _drop_when_null = frozenset(
-        p.name for p in params if p.default is not inspect.Parameter.empty
-    )
+    _drop_when_null = frozenset(p.name for p in params if p.default is not inspect.Parameter.empty)
 
     async def _run(**kwargs: Any) -> str:
         if _drop_when_null:

--- a/tests/test_tool_bridge_arg_types.py
+++ b/tests/test_tool_bridge_arg_types.py
@@ -128,3 +128,62 @@ async def test_web_search_survives_the_argument_the_model_actually_sends(supplie
 
     assert "not supported between instances" not in result, result
     assert not result.startswith("Error executing web_search"), result
+
+
+def test_no_optional_argument_reaches_a_tool_as_none():
+    """The wider half of the bug, swept across the whole bridged surface.
+
+    ``web_search`` is where this crashed loudly. It is not where it was rare:
+    26 parameters across 13 tools declare no JSON-schema ``default`` while their
+    ``execute()`` declares a real one — ``connector_*`` has
+    ``pocket_id: str = "default"``, ``drive_list`` has ``max_results: int = 20``.
+    The synthesized signature defaulted those to ``None``, pydantic-ai filled the
+    ``None`` in when the model omitted the argument, and it overrode the tool's
+    own default.
+
+    The integer ones crash the same way ``web_search`` did. The string ones are
+    worse: ``pocket_id=None`` instead of ``"default"`` is a silently wrong scope,
+    not an error anyone sees.
+
+    Asserted over EVERY bridged tool rather than a sample, because the failure is
+    per-parameter and a sample is how 25 of the 26 stay hidden.
+    """
+    import inspect
+
+    from pocketpaw.agents.tool_bridge import _instantiate_all_tools, build_pydantic_ai_tools
+
+    wrappers = {t.name: t for t in build_pydantic_ai_tools(_settings(), backend="pydantic_ai")}
+    if not wrappers:
+        pytest.skip("pydantic-ai not installed; nothing bridged")
+
+    offenders: list[str] = []
+    for tool in _instantiate_all_tools("pydantic_ai"):
+        wrapper = wrappers.get(getattr(tool, "name", ""))
+        if wrapper is None:
+            continue
+        try:
+            spec = tool.definition.parameters or {}
+            execute_sig = inspect.signature(tool.execute)
+            bridged_sig = inspect.signature(wrapper.function)
+        except (TypeError, ValueError):  # pragma: no cover - defensive
+            continue
+
+        required = set(spec.get("required", []) or [])
+        for pname in (spec.get("properties", {}) or {}):
+            if pname in required:
+                continue
+            own = execute_sig.parameters.get(pname)
+            bridged = bridged_sig.parameters.get(pname)
+            if own is None or bridged is None:
+                continue
+            if own.default is inspect.Parameter.empty or own.default is None:
+                continue
+            # The tool has a real default. Omitting the argument must NOT
+            # deliver None over the top of it.
+            if bridged.default is None:
+                offenders.append(f"{tool.name}.{pname} (execute default {own.default!r})")
+
+    assert not offenders, (
+        f"{len(offenders)} optional argument(s) would arrive as None and override "
+        f"the tool's own default: {offenders[:8]}"
+    )

--- a/tests/test_tool_bridge_arg_types.py
+++ b/tests/test_tool_bridge_arg_types.py
@@ -1,0 +1,128 @@
+# Bridged tools must receive their arguments in the TYPE their schema declares.
+# Created: 2026-08-15 — regression tests for the pydantic-ai bridge flattening
+# every parameter to ``str``/``str | None``.
+#
+# ``_signature_from_json_schema`` built one ``str`` parameter per declared
+# property regardless of the schema's ``type``, and defaulted every optional one
+# to ``None``. pydantic-ai derives the tool schema it advertises from that
+# signature, so a tool declaring ``num_results: {"type": "integer", "default": 5}``
+# was offered to the model as a nullable STRING. ``execute()`` then received
+# ``None`` (omitted) or ``"5"`` (provided) where it had annotated ``int = 5``.
+#
+# It surfaced as ``web_search`` dying on ``min(max(num_results, 1), 10)`` with
+# "'>' not supported between instances of 'int' and 'NoneType'" and the ``str``
+# variant. That line is not the bug — it is just the first place a wrong type
+# gets compared. Every bridged tool with a non-string parameter had it.
+#
+# The bug was INVISIBLE until the pydantic-ai argument drop was fixed: while the
+# backend delivered ``{}`` for every call, optional arguments never arrived and
+# the tool's own Python defaults always applied.
+#
+# These tests exercise the real bridge output (``build_pydantic_ai_tools``), not
+# a hand-built signature — a hand-built one would test the helper rather than
+# the surface the model actually calls.
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from pocketpaw.config import Settings
+
+
+def _settings(**overrides) -> Settings:
+    base = {
+        "pydantic_ai_model": "litellm:test-model",
+        "litellm_api_base": "http://localhost:4000",
+        "litellm_api_key": "sk-test",
+    }
+    base.update(overrides)
+    return Settings(**base)
+
+
+def _bridged(name: str):
+    from pocketpaw.agents.tool_bridge import build_pydantic_ai_tools
+
+    for tool in build_pydantic_ai_tools(_settings(), backend="pydantic_ai"):
+        if tool.name == name:
+            return tool
+    pytest.skip(f"{name} is not bridged in this configuration")
+
+
+def test_an_integer_property_is_not_advertised_as_a_string():
+    """The declared ``type`` reaches the signature pydantic-ai reads.
+
+    Asserted on the annotation rather than on a call, because this is what
+    pydantic-ai turns into the JSON schema the MODEL sees. Get it wrong and the
+    model is actively instructed to send "5".
+    """
+    sig = inspect.signature(_bridged("web_search").function)
+    annotation = sig.parameters["num_results"].annotation
+
+    assert annotation is not str, "an integer property was advertised as a string"
+    assert str not in getattr(annotation, "__args__", (annotation,)), (
+        f"num_results advertised as {annotation!r}; the schema declares an integer"
+    )
+
+
+def test_an_optional_property_keeps_its_schema_default():
+    """``num_results`` declares ``"default": 5``.
+
+    Defaulting it to ``None`` instead is the omitted-argument half of the bug:
+    the model leaves it out, the bridge passes ``num_results=None`` explicitly,
+    and that OVERRIDES the tool's own ``= 5``. The tool never sees its default.
+    """
+    sig = inspect.signature(_bridged("web_search").function)
+    assert sig.parameters["num_results"].default == 5
+
+
+def test_the_schema_the_model_is_shown_declares_an_integer():
+    """The end of the chain: what pydantic-ai actually advertises.
+
+    The signature is an implementation detail; THIS is the artifact that tells
+    the model what to send. It read ``{"type": "string"}`` with a null default,
+    which is why models sent ``"5"`` — they were asked for a string.
+    """
+    props = _bridged("web_search").function_schema.json_schema["properties"]
+    num = props["num_results"]
+    types = {opt.get("type") for opt in num.get("anyOf", [num])}
+
+    assert "integer" in types, num
+    assert "string" not in types, num
+    assert num.get("default") == 5, num
+
+
+@pytest.mark.parametrize(
+    "supplied",
+    [
+        pytest.param({}, id="model-omitted-it"),
+        pytest.param({"num_results": None}, id="model-sent-null"),
+        pytest.param({"num_results": "5"}, id="model-sent-a-string"),
+        pytest.param({"num_results": 5}, id="model-sent-an-int"),
+    ],
+)
+async def test_web_search_survives_the_argument_the_model_actually_sends(supplied):
+    """The crashing variants from the 2026-08-15 report, plus the good cases.
+
+    Routed through ``function_schema.validator`` because that is the layer
+    pydantic-ai puts in front of the tool: it coerces ``"5"`` to ``5`` against
+    the advertised schema. Calling ``.function`` directly would BYPASS it and
+    test a path production never takes.
+
+    No network: with no provider key configured the tool returns its "not
+    configured" string, and that return happens AFTER
+    ``min(max(num_results, 1), 10)`` — so reaching it at all is the proof the
+    clamp no longer explodes.
+
+    ``_run`` swallows exceptions into ``"Error executing <tool>: ..."``, so a
+    regression here is a wrong STRING rather than a raised error — assert on the
+    message, or this passes while the tool is broken.
+    """
+    tool = _bridged("web_search")
+    kwargs = tool.function_schema.validator.validate_python({"query": "quarterly filings", **supplied})
+
+    result = await tool.function(**kwargs)
+
+    assert "not supported between instances" not in result, result
+    assert not result.startswith("Error executing web_search"), result

--- a/tests/test_tool_bridge_arg_types.py
+++ b/tests/test_tool_bridge_arg_types.py
@@ -120,7 +120,9 @@ async def test_web_search_survives_the_argument_the_model_actually_sends(supplie
     message, or this passes while the tool is broken.
     """
     tool = _bridged("web_search")
-    kwargs = tool.function_schema.validator.validate_python({"query": "quarterly filings", **supplied})
+    kwargs = tool.function_schema.validator.validate_python(
+        {"query": "quarterly filings", **supplied}
+    )
 
     result = await tool.function(**kwargs)
 

--- a/tests/test_tool_bridge_arg_types.py
+++ b/tests/test_tool_bridge_arg_types.py
@@ -169,7 +169,7 @@ def test_no_optional_argument_reaches_a_tool_as_none():
             continue
 
         required = set(spec.get("required", []) or [])
-        for pname in (spec.get("properties", {}) or {}):
+        for pname in spec.get("properties", {}) or {}:
             if pname in required:
                 continue
             own = execute_sig.parameters.get(pname)


### PR DESCRIPTION
Every `web_search` call on the pydantic-ai backend fails:

```
Pydantic AI tool web_search execution error:
  '>' not supported between instances of 'int' and 'NoneType'
  '>' not supported between instances of 'int' and 'str'
```

The line it dies on is `min(max(num_results, 1), 10)`. That line is not the bug. It is the first place a wrong type gets compared.

## What was wrong

`_signature_from_json_schema` built one `str` parameter per declared property — or `str | None = None` for optional ones — and ignored both the property's `type` and its `default`.

pydantic-ai derives the schema it shows the **model** from that signature. So `web_search`, which declares:

```json
"num_results": {"type": "integer", "default": 5}
```

was advertised to the model as a nullable **string**. Models were being asked for `"5"` and were obliging. And when a model omitted the argument, the bridge passed `num_results=None` explicitly, which overrode the tool's own `= 5` — the tool never saw its default.

Two halves, both fixed here: map each property to the Python type its schema names, and keep the schema's `default`. The advertised schema goes from `{"type": "string"}` to:

```json
"num_results": {"anyOf": [{"type": "integer"}, {"type": "null"}], "default": 5}
```

`_make_pydantic_ai_tool` also drops an explicit `null` for any parameter whose default is not `None`. A model is free to send `"num_results": null`, and passing that through is the omitted-argument bug by another route.

## Scope

This hit **every bridged tool with a non-string parameter**, not only the three that happen to clamp. `web_search` and `instinct_corrections` crash outright; `weather` survives `"5"` because it calls `int()` first, and still dies on `None`.

Only the pydantic-ai path flattened types. `build_openai_function_tools` and `build_adk_function_tools` pass `defn.parameters` through as raw schema, so the declared integer already survives there. Nothing in those paths changes.

The fix is at the bridge rather than in the tools. Scattering `int()` coercion across 93 tools would treat the symptom and leave the schema still lying to the model about what to send.

## Why it appeared now

It was invisible until #1945 fixed the pydantic-ai argument drop. While the backend delivered `{}` for every tool call, no argument ever reached a tool, so the Python defaults always applied and the annotations were never exercised. Fixing the drop is what let real arguments through to find this.

## Verification

Tests reproduce both reported variants first, then pass:

```
before:  4 failed, 1 passed
after:   7 passed
```

The regression run is `176 passed, 8 failed` — those 8 are `test_code_mode_bridge.py` failing on `asyncio.start_unix_server`, which does not exist on Windows. Identical 8 failures on unmodified `dev`, checked rather than assumed.

The argument tests route through `function_schema.validator`, the layer pydantic-ai puts in front of the tool, because that is what coerces `"5"` to `5`. An earlier draft called `.function` directly, bypassed the validator, and failed on a path production never takes — worth knowing if you touch these.
