### PR TITLE
The streaming chat surface says what the agent is doing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,28 @@ jobs:
           POCKETPAW_LLM_PROVIDER: "ollama"
           POCKETPAW_OLLAMA_HOST: "http://localhost:11434"
 
+      - name: Run agent plan + narration surface tests
+        # Same addopts escape as the two steps above. These four files are the
+        # ONLY coverage of the plan panel and tool narration, and both features
+        # ship on two independent transports (the group/DM bus and the SSE
+        # stream). Living in the tests/cloud blind spot is how HTN-2 merged
+        # green while breaking an assertion in HTN-5's own sibling file: no lane
+        # ran either one, so "CI is green" said nothing about this surface.
+        #
+        # test_run_core_narration.py in particular compares the two transports
+        # against each other, which is the check that catches a feature wired to
+        # one surface and silently not the other — the bug this step exists for.
+        run: >-
+          uv run pytest
+          tests/cloud/runs/test_run_core_narration.py
+          tests/cloud/runs/test_run_core_plan_surface.py
+          tests/cloud/shared/test_agent_bridge_plan.py
+          tests/cloud/shared/test_agent_bridge_narration.py
+          -o addopts="" -q --tb=short
+        env:
+          POCKETPAW_LLM_PROVIDER: "ollama"
+          POCKETPAW_OLLAMA_HOST: "http://localhost:11434"
+
   mutation-anchors:
     # ANCHOR VALIDATION ONLY, NOT A SWEEP. `mutate.py --validate` reads each plan, counts
     # its `find` string in the target file, and exits. It applies no mutation, runs no

--- a/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
+++ b/ee/pocketpaw_ee/cloud/chat/runs/run_core.py
@@ -1,6 +1,20 @@
 """Agent-run core — the loop the executor invokes for every chat run.
 
 Changes:
+- 2026-08-15 (HTN-11) — the ``tool_start`` frame carries an additive
+  ``narration``: the tool's plain-language phrase, from the SAME
+  ``shared/tool_narration.py`` the group/DM bridge calls.
+
+  Narration shipped in HTN-1 wired to the bridge alone, so this surface — the
+  main streaming chat — kept sending bare tool names while group/DM read as
+  English. No task in that plan covered this path; HTN-7 is Mission Control's
+  activity ticker, not the chat stream. The asymmetry survived because each
+  surface had its own tests and neither compared against the other, which is
+  why ``test_run_core_narration.py`` asserts the two frames agree rather than
+  only that this one is populated.
+
+  Additive, exactly as on the bridge: a tool with no phrasing emits no field
+  and a client keyed on ``tool`` is unaffected.
 - 2026-08-15 (HTN-5) — ``_drive_agent_loop`` routes a recognized plan tool
   (``write_plan`` today) through ``shared/plan_normalizer.py`` and yields a
   ``plan_updated`` SSE frame INSTEAD of the ``tool_start`` chip, so the plan
@@ -332,6 +346,7 @@ from pocketpaw_ee.cloud.chat.runs.domain import RunSpec
 from pocketpaw_ee.cloud.chat.runs.transport import get_stream_transport
 from pocketpaw_ee.cloud.shared.errors import CloudError
 from pocketpaw_ee.cloud.shared.plan_normalizer import PlanTracker
+from pocketpaw_ee.cloud.shared.tool_narration import narrate_tool_use
 from pocketpaw_ee.cloud.surface import (
     SurfaceKind,
     SurfaceMeta,
@@ -1562,7 +1577,16 @@ async def _drive_agent_loop(
                                 },
                             )
                     else:
-                        yield ("tool_start", {"tool": name, "input": tool_input})
+                        # HTN-11: the same phrase the group/DM bridge sends, from
+                        # the same function, so one tool cannot read as English on
+                        # one surface and as a raw name on the other. Additive:
+                        # a tool with no phrasing emits no field and the client
+                        # keeps rendering ``tool``.
+                        frame: dict[str, Any] = {"tool": name, "input": tool_input}
+                        narration = narrate_tool_use(name, tool_input, instance)
+                        if narration:
+                            frame["narration"] = narration
+                        yield ("tool_start", frame)
             elif etype == "tool_result":
                 meta = getattr(event, "metadata", None) or {}
                 name = ""

--- a/ee/pocketpaw_ee/cloud/shared/agent_bridge.py
+++ b/ee/pocketpaw_ee/cloud/shared/agent_bridge.py
@@ -44,7 +44,13 @@ so a group/DM agent that delivers a file persists the structured signal too.
 This path has no run-transport SSE stream, so it emits no ``artifact`` event —
 that applies only to the streaming ``run_core`` path.
 
-Updated 2026-08-15 (HTN-2): ``_narrate_tool_use`` takes the running agent and
+Updated 2026-08-15 (HTN-11): the phrasing function moved to
+``shared/tool_narration.py`` as ``narrate_tool_use`` and this module imports it.
+It was private here while exactly one surface narrated; the streaming
+``run_core`` path now calls the same function, and a second copy is how the two
+surfaces would drift apart. Same arrangement as ``plan_normalizer``.
+
+Updated 2026-08-15 (HTN-2): ``narrate_tool_use`` takes the running agent and
 resolves that agent's OWN ``ToolRegistry`` (``tool_bridge.narration_registry_for``),
 so a tool's declared phrase is read off the live instance the registry holds
 rather than from a hardcoded name->class map that constructed the tool. Tools
@@ -89,6 +95,7 @@ from pocketpaw_ee.cloud.realtime.events import (
 )
 from pocketpaw_ee.cloud.shared.events import event_bus
 from pocketpaw_ee.cloud.shared.plan_normalizer import PlanTracker
+from pocketpaw_ee.cloud.shared.tool_narration import narrate_tool_use
 
 logger = logging.getLogger(__name__)
 
@@ -475,45 +482,6 @@ def _augment_message_with_attachments(content: str, attachments: list[dict] | No
     return f"{content}\n\nAttached files:\n" + "\n".join(lines)
 
 
-def _narrate_tool_use(
-    tool_name: str, tool_input: dict[str, Any], instance: Any = None
-) -> str | None:
-    """Render a plain-language phrase for a tool call, or None.
-
-    Returns None for any tool that has no phrasing at all — narration is
-    decoration, so it must never raise into, or block, the response stream.
-
-    ``instance`` is the running agent, and it is what makes a tool's OWN
-    declared phrase reachable: ``narration_registry_for`` resolves the live
-    ``ToolRegistry`` backing that agent's bridged tool surface, and the lookup
-    reads the ``Narration`` off the instance the registry already holds. It is
-    never constructed — ``ShellTool.__init__`` calls ``get_settings()``, and on
-    cloud EE substitutes ``DaytonaShellTool`` under the same name, so building a
-    tool to read a property would run real setup on the event loop to phrase a
-    status line, and could phrase the wrong tool's.
-
-    Without a resolvable registry (the Claude SDK backend surfaces its tools
-    over MCP rather than through the bridge) the lookup still answers from the
-    override table or by deriving from the tool name — that is why the cloud
-    path's ``litellm_web_search`` narrates with its query either way, and why
-    the registry is what rescues the builtin ``web_search`` specifically.
-    """
-    if not tool_name:
-        return None
-    try:
-        from pocketpaw.tools.narration import narration_for_tool, render
-
-        registry = None
-        if instance is not None:
-            from pocketpaw.agents.tool_bridge import narration_registry_for
-
-            registry = narration_registry_for(getattr(instance, "backend", None))
-        return render(narration_for_tool(tool_name, registry), tool_input)
-    except Exception:
-        logger.debug("Tool narration failed for %s", tool_name, exc_info=True)
-        return None
-
-
 async def _run_agent_response(
     agent_id: str,
     group_id: str,
@@ -707,7 +675,7 @@ async def _run_agent_response(
                 }
                 # Purely additive: a tool with no narration emits no field, and
                 # the bridge never invents a fallback phrase.
-                narration = _narrate_tool_use(tool_name, tool_input, instance)
+                narration = narrate_tool_use(tool_name, tool_input, instance)
                 if narration:
                     payload["narration"] = narration
                 await emit(AgentToolUse(data=payload))

--- a/ee/pocketpaw_ee/cloud/shared/tool_narration.py
+++ b/ee/pocketpaw_ee/cloud/shared/tool_narration.py
@@ -1,0 +1,69 @@
+# Shared tool-call narration for every cloud surface.
+# Created: 2026-08-15 (HTN-11) — lifted verbatim out of
+# ``agent_bridge._narrate_tool_use`` so the streaming ``run_core`` path can call
+# the SAME function rather than grow a second phrasing implementation.
+#
+# Why this module exists at all: narration shipped in HTN-1 wired to exactly one
+# surface, the group/DM WebSocket bridge. The streaming chat surface yields its
+# own ``tool_start`` frame from ``run_core`` and never learned about the field,
+# so the main chat showed raw tool names while group/DM read as English. The
+# asymmetry was invisible because each path had its own tests and neither
+# compared against the other.
+#
+# This mirrors ``plan_normalizer``: one module, both transports, so a phrasing
+# rule can never be true on one surface and false on the other. A caller that
+# wants the phrase imports ``narrate_tool_use``; nobody re-implements it.
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def narrate_tool_use(tool_name: str, tool_input: Any = None, instance: Any = None) -> str | None:
+    """Render a plain-language phrase for a tool call, or None.
+
+    Returns None for any tool that has no phrasing at all — narration is
+    decoration, so it must never raise into, or block, the response stream.
+
+    ``instance`` is the running agent, and it is what makes a tool's OWN
+    declared phrase reachable: ``narration_registry_for`` resolves the live
+    ``ToolRegistry`` backing that agent's bridged tool surface, and the lookup
+    reads the ``Narration`` off the instance the registry already holds. It is
+    never constructed — ``ShellTool.__init__`` calls ``get_settings()``, and on
+    cloud EE substitutes ``DaytonaShellTool`` under the same name, so building a
+    tool to read a property would run real setup on the event loop to phrase a
+    status line, and could phrase the wrong tool's.
+
+    Without a resolvable registry (the Claude SDK backend surfaces its tools
+    over MCP rather than through the bridge) the lookup still answers from the
+    override table or by deriving from the tool name — that is why the cloud
+    path's ``litellm_web_search`` narrates with its query either way, and why
+    the registry is what rescues the builtin ``web_search`` specifically.
+
+    A non-dict ``tool_input`` is coerced to ``{}`` rather than passed through.
+    Both callers type it ``Any`` (it is whatever the backend put in
+    ``event.metadata["input"]``), and ``render`` is declared against ``dict |
+    None``. Without the coercion a string there raises inside ``render`` and the
+    except below swallows it into ``None`` — no phrase at all. Coerced, the
+    lookup still yields the BARE phrase, which is the documented fallback: an
+    unknown argument means "don't interpolate", not "say nothing".
+    """
+    if not tool_name:
+        return None
+    if not isinstance(tool_input, dict):
+        tool_input = {}
+    try:
+        from pocketpaw.tools.narration import narration_for_tool, render
+
+        registry = None
+        if instance is not None:
+            from pocketpaw.agents.tool_bridge import narration_registry_for
+
+            registry = narration_registry_for(getattr(instance, "backend", None))
+        return render(narration_for_tool(tool_name, registry), tool_input)
+    except Exception:
+        logger.debug("Tool narration failed for %s", tool_name, exc_info=True)
+        return None

--- a/tests/cloud/runs/test_run_core_narration.py
+++ b/tests/cloud/runs/test_run_core_narration.py
@@ -1,0 +1,300 @@
+# tests/cloud/runs/test_run_core_narration.py
+# Created 2026-08-15 (HTN-11) — pins tool narration on the STREAMING chat path.
+#
+# HTN-1 wired narration to the group/DM bridge only, so this surface — the one
+# most users actually watch — kept emitting bare tool names while group/DM read
+# as English. Nothing failed. Each surface had its own tests, both passed, and
+# neither compared against the other.
+#
+# So the load-bearing test here is not "run_core emits a narration". It is
+# ``test_both_surfaces_narrate_the_same_call_identically``, which drives ONE
+# backend event through BOTH paths and asserts the phrases match. A test that
+# only checked this file would have gone green on the day the bug shipped.
+#
+# The backend events use the shape pydantic-ai actually emits: ``content`` is
+# the prose "Using web_search...", ``metadata`` carries the bare name plus the
+# call's argument dict (``agents/pydantic_ai.py::_announce_tool``).
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pocketpaw_ee.cloud.chat.agent_service import ScopeContext, ScopeKind
+from pocketpaw_ee.cloud.chat.runs import run_core
+
+pytestmark = pytest.mark.asyncio
+
+
+def _tool_use_event(name: str, tool_input: dict):
+    return SimpleNamespace(
+        type="tool_use",
+        content=f"Using {name}...",
+        metadata={"name": name, "input": tool_input},
+    )
+
+
+def _done():
+    return SimpleNamespace(type="done", content="")
+
+
+def _scope_ctx() -> ScopeContext:
+    return ScopeContext(
+        kind=ScopeKind.SESSION,
+        scope_id="s1",
+        workspace_id="w1",
+        user_id="u1",
+        members=["u1"],
+        target_agent_id="a1",
+    )
+
+
+def _bridged_backend():
+    """A stand-in for a backend that bridged its tools — pydantic_ai, and the
+    three others that go through ``_build_tool_registry``.
+
+    Built through the PUBLIC builder rather than by hand, because the thing
+    under test is whether ``narration_registry_for`` can reach the live
+    ``ToolRegistry`` the builder retained on the policy. Hand-attaching a
+    registry would assert that a hand-attached registry works.
+
+    Returns ``None`` when pydantic-ai isn't installed, so the caller can pin the
+    no-registry behaviour instead of silently testing it by accident.
+    """
+    from pocketpaw.agents.tool_bridge import build_pydantic_ai_tools
+    from pocketpaw.config import Settings
+    from pocketpaw.tools.policy import ToolPolicy
+
+    policy = ToolPolicy(profile="full")
+    settings = Settings(
+        pydantic_ai_model="litellm:test-model",
+        litellm_api_base="http://localhost:4000",
+        litellm_api_key="sk-test",
+    )
+    if not build_pydantic_ai_tools(settings, backend="pydantic_ai", policy=policy):
+        return None
+    return SimpleNamespace(get_tool_policy=lambda: policy)
+
+
+async def _sse_frames(
+    monkeypatch, backend_events: list[Any], *, backend: Any = None
+) -> list[tuple[str, dict]]:
+    """Drive ``_drive_agent_loop`` and return every yielded SSE frame."""
+
+    class _FakePool:
+        async def get(self, _agent_id):
+            return SimpleNamespace(config={}, agent_name="A", backend=backend)
+
+        def run(self, agent_id, content, session_key, **run_kwargs):
+            async def _gen():
+                for ev in backend_events:
+                    yield ev
+
+            return _gen()
+
+    monkeypatch.setattr(run_core, "get_agent_pool", lambda: _FakePool())
+
+    async def _fake_knowledge(*a, **k):
+        return ""
+
+    monkeypatch.setattr(run_core, "build_knowledge_context", _fake_knowledge)
+    monkeypatch.setattr(run_core, "build_behavior_instructions", lambda ctx, backend_name=None: "")
+    monkeypatch.setattr(run_core, "attach_sse_event_sink", lambda q: None)
+    monkeypatch.setattr(run_core, "attach_agent_identity", lambda **k: None)
+    monkeypatch.setattr(run_core, "detach_sse_event_sink", lambda t: None)
+    monkeypatch.setattr(run_core, "detach_agent_identity", lambda t: None)
+
+    async def _never_cancelled():
+        return False
+
+    out: list[tuple[str, dict]] = []
+    async for ev in run_core._drive_agent_loop(
+        _scope_ctx(),
+        user_content="find the filings",
+        attachments_in=None,
+        mentions_in=None,
+        history=None,
+        is_cancelled=_never_cancelled,
+        emit_stream_start=False,
+    ):
+        out.append(ev)
+    return out
+
+
+async def _bridge_events(backend_events: list, *, backend: Any = None) -> list:
+    """Drive the group/DM bridge over the same events. Mirrors the harness in
+    tests/cloud/shared/test_agent_bridge_plan.py so the two are comparable."""
+    from pocketpaw_ee.cloud.shared import agent_bridge
+
+    instance = SimpleNamespace(agent_name="Test Agent", backend=backend)
+    pool = MagicMock()
+    pool.get = AsyncMock(return_value=instance)
+    pool.observe = AsyncMock()
+
+    async def fake_run(*_args, **_kwargs):
+        for event in backend_events:
+            yield event
+
+    pool.run = fake_run
+
+    from pocketpaw_ee.cloud.models.message import Message as _RealMessage
+
+    to_list_mock = AsyncMock(return_value=[])
+    limit_mock = MagicMock()
+    limit_mock.to_list = to_list_mock
+    sort_mock = MagicMock()
+    sort_mock.limit = MagicMock(return_value=limit_mock)
+    find_mock = MagicMock()
+    find_mock.sort = MagicMock(return_value=sort_mock)
+
+    with (
+        patch("pocketpaw_ee.cloud.shared.agent_bridge.emit", new=AsyncMock()) as m_emit,
+        patch.multiple(
+            _RealMessage,
+            create=True,
+            group=MagicMock(),
+            deleted=MagicMock(),
+            createdAt=MagicMock(),
+        ),
+        patch.object(_RealMessage, "find", MagicMock(return_value=find_mock)),
+        patch("pocketpaw.agents.pool.get_agent_pool", return_value=pool),
+        patch(
+            "pocketpaw_ee.cloud.agents.knowledge.KnowledgeService.search_context",
+            new=AsyncMock(return_value=""),
+        ),
+    ):
+        await agent_bridge._run_agent_response(
+            agent_id="agent-1",
+            group_id="group-1",
+            workspace_id="ws-1",
+            user_message="find the filings",
+            group_members=["user-1"],
+        )
+
+    return [call.args[0] for call in m_emit.await_args_list if call.args]
+
+
+# ---------------------------------------------------------------------------
+# the streaming surface narrates at all
+# ---------------------------------------------------------------------------
+
+
+async def test_the_tool_start_frame_carries_a_narration(monkeypatch):
+    """The headline fix. Before this, ``tool_start`` carried only tool+input and
+    the client had nothing to render but the raw name."""
+    frames = await _sse_frames(
+        monkeypatch, [_tool_use_event("web_search", {"query": "quarterly filings"}), _done()]
+    )
+
+    starts = [data for name, data in frames if name == "tool_start"]
+    assert len(starts) == 1, frames
+    assert starts[0]["narration"], "the streaming surface emitted no narration"
+
+
+async def test_the_narration_interpolates_an_allowlisted_argument(monkeypatch):
+    """``web_search`` allowlists ``query``, so the phrase names the search.
+
+    Asserted on content, not just presence: a bare "Searching the web" would
+    satisfy a truthiness check while losing the whole point of the feature.
+
+    Needs a backend that BRIDGED its tools, which is what makes the tool's
+    declared ``Narration`` reachable (HTN-2 reads it off the live instance the
+    registry holds). That is the configuration this ships on — pydantic_ai,
+    openai_agents, google_adk and deep_agents all go through the bridge.
+    """
+    backend = _bridged_backend()
+    if backend is None:
+        pytest.skip("pydantic-ai not installed; no bridged registry to resolve")
+
+    frames = await _sse_frames(
+        monkeypatch,
+        [_tool_use_event("web_search", {"query": "quarterly filings"}), _done()],
+        backend=backend,
+    )
+
+    narration = next(d for n, d in frames if n == "tool_start")["narration"]
+    assert "quarterly filings" in narration, narration
+
+
+async def test_without_a_bridged_registry_the_phrase_degrades_to_bare(monkeypatch):
+    """The claude_agent_sdk case, pinned rather than left to be discovered.
+
+    That backend surfaces its tools over MCP, so ``narration_registry_for``
+    finds nothing and a declared phrase is unreachable — the lookup falls
+    through to derive-from-name, which never interpolates arguments because a
+    NAME carries no ``safe_args`` allowlist saying which are safe to show.
+
+    So the same search reads "Searching the web" there and "Searching the web
+    for quarterly filings" on a bridged backend. That is a real gap, not a
+    quirk of this fixture, and it is why this asserts the degraded phrase
+    explicitly instead of asserting nothing about it.
+    """
+    frames = await _sse_frames(
+        monkeypatch,
+        [_tool_use_event("web_search", {"query": "quarterly filings"}), _done()],
+        backend=None,
+    )
+
+    narration = next(d for n, d in frames if n == "tool_start")["narration"]
+    assert narration == "Searching the web", narration
+    assert "quarterly filings" not in narration
+
+
+async def test_the_tool_name_still_travels(monkeypatch):
+    """Narration is ADDITIVE. A client keyed on ``tool`` must be unaffected."""
+    frames = await _sse_frames(
+        monkeypatch, [_tool_use_event("web_search", {"query": "q"}), _done()]
+    )
+
+    start = next(d for n, d in frames if n == "tool_start")
+    assert start["tool"] == "web_search"
+    assert start["input"] == {"query": "q"}
+
+
+async def test_a_plan_tool_still_yields_no_tool_start(monkeypatch):
+    """HTN-5's substitution is not disturbed by adding a field to the branch it
+    falls through to."""
+    frames = await _sse_frames(
+        monkeypatch,
+        [
+            _tool_use_event(
+                "write_plan", {"items": [{"content": "Ship it", "status": "in_progress"}]}
+            ),
+            _done(),
+        ],
+    )
+
+    assert [n for n, _ in frames if n == "tool_start"] == []
+    assert [n for n, _ in frames if n == "plan_updated"], frames
+
+
+# ---------------------------------------------------------------------------
+# the two surfaces agree — the test that would have caught the original gap
+# ---------------------------------------------------------------------------
+
+
+async def test_both_surfaces_narrate_the_same_call_identically(monkeypatch):
+    """One backend event, both paths, same phrase.
+
+    This is the regression guard for the ACTUAL failure: narration existing on
+    one surface and silently not the other. Asserting each side independently is
+    what let that ship — both suites were green the whole time.
+    """
+    backend = _bridged_backend()
+    if backend is None:
+        pytest.skip("pydantic-ai not installed; no bridged registry to resolve")
+
+    def _events():
+        return [_tool_use_event("web_search", {"query": "quarterly filings"}), _done()]
+
+    frames = await _sse_frames(monkeypatch, _events(), backend=backend)
+    sse = next(d for n, d in frames if n == "tool_start")["narration"]
+
+    emitted = await _bridge_events(_events(), backend=backend)
+    ws = next(e.data for e in emitted if e.type == "agent.tool_use")["narration"]
+
+    assert sse == ws, f"streaming says {sse!r}, group/DM says {ws!r}"
+    # Pinned against BOTH surfaces degrading together: identical bare phrases
+    # would satisfy the equality above while the feature was broken on each.
+    assert "quarterly filings" in sse, sse

--- a/tests/cloud/shared/test_agent_bridge_plan.py
+++ b/tests/cloud/shared/test_agent_bridge_plan.py
@@ -262,7 +262,32 @@ async def test_an_unreadable_plan_call_falls_back_to_the_tool_chip():
 @pytest.mark.asyncio
 async def test_a_non_plan_tool_is_untouched():
     """Regression guard on HTN-1: ordinary tools still emit their chip and
-    their narration, and never emit a plan event."""
+    their narration, and never emit a plan event.
+
+    The narration assertion was ``"Searching the web for quarterly filings"``
+    when this was written, because HTN-1 resolved a tool's declared phrase from
+    a static name->class map and CONSTRUCTED the tool to read it. HTN-2 removed
+    that on purpose — ``ShellTool.__init__`` calls ``get_settings()`` and cloud
+    EE substitutes ``DaytonaShellTool`` under the same name, so constructing a
+    tool to phrase a status line ran real setup and could phrase the wrong
+    tool's — and reads the phrase off the live instance in the agent's own
+    ``ToolRegistry`` instead.
+
+    ``instance`` here has no ``backend``, so no registry resolves and the lookup
+    falls through to derive-from-name, which never interpolates arguments: a
+    NAME carries no ``safe_args`` allowlist saying which are safe to show. The
+    bare phrase is the correct outcome for THIS fixture.
+
+    That is not the whole story, and the gap is real rather than an artifact:
+    the claude_agent_sdk backend surfaces its tools over MCP and never
+    populates a registry either, so it loses argument interpolation in
+    production the same way. The four bridged backends (pydantic_ai,
+    openai_agents, google_adk, deep_agents) do resolve one and get the full
+    phrase. Both halves are pinned in
+    ``tests/cloud/runs/test_run_core_narration.py``, which builds a real
+    bridged registry for the good case rather than asserting only the degraded
+    one.
+    """
     emitted = await _emitted(
         [_tool_use_event("web_search", {"query": "quarterly filings"}), _done_event()]
     )
@@ -271,4 +296,4 @@ async def test_a_non_plan_tool_is_untouched():
     tool_uses = [e.data for e in emitted if e.type == "agent.tool_use"]
     assert len(tool_uses) == 1
     assert tool_uses[0]["tool"] == "web_search"
-    assert tool_uses[0]["narration"] == "Searching the web for quarterly filings"
+    assert tool_uses[0]["narration"] == "Searching the web"


### PR DESCRIPTION
Humanized tool status reached the group/DM bridge and stopped there. The main chat — the surface most people actually watch — kept showing raw tool names.

## What was missing

Two paths emit a tool call. `agent_bridge.py` sends `agent.tool_use` over the bus for group/DM, and it got `narration` in HTN-1. `run_core.py` yields its own `tool_start` frame for the streaming chat, and the word `narration` appeared in that file zero times. The frontend matches: `onAgentToolUse` renders the phrase, while `ChatSession` builds its step label from the bare tool name.

So no frontend change could have shown it. The field never crossed the wire.

**No task in the narration plan covered this path.** HTN-7 is Mission Control's activity ticker, not the chat stream. The *plan* surface was specified for both transports and tested on both. Narration was specified for one, and the asymmetry survived because each surface had its own tests, both passed, and neither compared against the other.

## The change

The phrasing function moves to `shared/tool_narration.py` and both paths call it — the same arrangement `plan_normalizer.py` already has for the plan surface. Keeping a second copy is how the two would drift apart again.

Additive on both sides: a tool with no phrasing emits no field, and a client keyed on `tool` is unaffected.

One hardening at the shared seam: a non-dict `tool_input` is coerced to `{}` rather than passed through. Both callers type it `Any`, and `render` is declared against `dict | None` — a string there used to raise inside `render` and get swallowed into "no phrase at all". Coerced, the lookup still yields the bare phrase, which is the documented fallback.

## The test that matters

`test_both_surfaces_narrate_the_same_call_identically` drives one backend event through **both** paths and asserts the phrases match. A test that only checked `run_core` would have gone green on the day this bug shipped, which is the whole point.

It also asserts the phrase still contains the query, because two surfaces degrading together would satisfy the equality while the feature was broken on each.

## tests/cloud does not run in CI

This is the more important half.

`addopts` in `pyproject.toml` is `--ignore=tests/cloud --ignore=tests/e2e`, so **no lane runs `tests/cloud`**. Two individual files have an explicit `-o addopts=""` escape; everything else is invisible.

That includes every test for the plan panel and tool narration. It is how #1948 merged green while breaking an assertion in #1946's own sibling file — nothing ran either one. Adding tests to a directory no lane runs is not adding coverage, so this adds a step for the four files covering this surface, following the pattern the cockpit and agent-activity steps already established.

Turning that step on made the broken assertion visible, and it is corrected here rather than worked around. `test_a_non_plan_tool_is_untouched` expected `"Searching the web for quarterly filings"` from a fixture whose instance has no `backend`. HTN-1 could satisfy that by constructing the tool to read its declaration; HTN-2 deliberately stopped doing that, because `ShellTool.__init__` calls `get_settings()` and cloud EE substitutes `DaytonaShellTool` under the same name. With no registry the lookup derives from the name, and a derived phrase never interpolates arguments — a NAME carries no `safe_args` allowlist. The bare phrase is correct for that fixture.

**The underlying gap is real and stays open.** `claude_agent_sdk` — the default backend — surfaces its tools over MCP and populates no registry either, so it loses argument interpolation in production exactly the same way. The four bridged backends (`pydantic_ai`, `openai_agents`, `google_adk`, `deep_agents`) resolve one and get the full phrase. Both halves are now pinned explicitly, in `test_run_core_narration.py`, which builds a real bridged registry through the public builder for the good case instead of asserting only the degraded one. Closing it means giving the SDK path a registry, which is its own change.

## Verification

```
new file:                    6 passed
the four files the CI step runs:   35 passed
```

Wider run on the touched modules is `330 passed, 3 failed` — all three fail identically on unmodified `dev` (checked, not assumed): two unrelated, and the third is the assertion this PR corrects.

## Still not covered

Only `web_search` declares a `Narration` — 1 of 93 builtin tool classes. Every other tool gets a derived phrase, which reads as English ("Publishing the site") but never names its arguments. Annotating the rest is HTN-3 and is not in here.
