### PR TITLE
Send an explicit max_tokens, so a short reply is affordable

### DIFF
--- a/src/pocketpaw/agents/model_limits.py
+++ b/src/pocketpaw/agents/model_limits.py
@@ -1,0 +1,151 @@
+# Resolve a model's output-token ceiling, so a run can send an explicit cap.
+# Created: 2026-08-16 (feat/agent-max-output-tokens).
+#
+# WHY. No agent backend sent ``max_tokens`` at all. The only ModelSettings in
+# the agents package is the AgentAPI shim, where the parameter is explicitly
+# ignored. Sending nothing is not neutral: OpenRouter bills its PRE-FLIGHT
+# credit check against ``max_tokens``, and with none supplied it substitutes the
+# model's ceiling. On deepseek-v4-flash that is 65536, so a request whose reply
+# would be a few hundred tokens is refused with
+#
+#   402 - This request requires more credits, or fewer max_tokens. You
+#         requested up to 65536 tokens, but can only afford 6627.
+#
+# The account was not out of credits in any meaningful sense; it could not
+# afford the WORST CASE we implicitly asked for. Sending the model's real
+# 8192 shrinks that reservation eightfold. Other gateways price the reservation
+# differently, but none of them are helped by us declining to say.
+#
+# WHERE THE NUMBER COMES FROM. litellm ships
+# ``model_prices_and_context_window_backup.json`` — ~1.3 MB, 3000+ models —
+# inside the installed package, and ``get_model_info()`` reads it. That is the
+# same data as BerriAI's raw JSON on GitHub, except it is pinned with the
+# dependency and reviewed when the pin moves, instead of being whatever ``main``
+# says at the moment a process happens to boot.
+#
+# LITELLM_LOCAL_MODEL_COST_MAP. litellm's ``get_model_cost_map`` fetches that
+# JSON over HTTP AT IMPORT TIME unless this variable is set, falling back to the
+# bundled copy only on failure. So the network fetch already happens today,
+# unpinned, in the import path of anything that touches litellm. We set the
+# variable with ``setdefault`` before importing: it removes a startup network
+# dependency we did not intend, keeps model data pinned to the reviewed version,
+# and an operator who genuinely wants live pricing can still export it as false.
+#
+# FAILING OPEN IS THE POINT. Every lookup path returns None rather than raising.
+# None means "send no cap", which is exactly today's behaviour — so a model
+# litellm has never heard of, or a deployment without litellm installed, is no
+# worse off than before this file existed.
+
+from __future__ import annotations
+
+import logging
+import os
+from functools import lru_cache
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+#: Returned by the settings reader to mean "the operator disabled this".
+_DISABLED = -1
+
+#: The cap sent when nothing more specific is known.
+#
+# NOT the model's advertised ceiling, and this is the whole design decision.
+# The goal is a reservation that covers a real reply, not the largest reply the
+# model could theoretically emit — those are different numbers and only the
+# first one is useful. Asking for the ceiling is what produced the 402 in the
+# first place, because that is precisely what a gateway assumes when we send
+# nothing.
+#
+# The metadata is also not trustworthy enough to drive the value. Measured on
+# 2026-08-16, ``deepseek/deepseek-v4-flash`` read ``max_output_tokens: 8192``
+# upstream in the morning and ``393216`` the same afternoon — a 48x change,
+# with ``max_input_tokens`` sitting at 1000000, which reads like a context
+# window leaking into the output field. Had we resolved the ceiling and sent it,
+# the credit reservation would have gone from 65536 to 393216 and the 402 would
+# have got SIX TIMES worse while looking like a fix.
+#
+# 8192 is generous for a chat turn (roughly 6000 words) and small enough that a
+# pre-flight credit check passes on a modest balance. An operator who needs
+# more sets ``agent_max_output_tokens``.
+DEFAULT_MAX_OUTPUT_TOKENS = 8192
+
+
+def _model_info(name: str) -> dict[str, Any] | None:
+    """``litellm.get_model_info(name)`` or None, never raising."""
+    if not name:
+        return None
+    try:
+        # setdefault, not assignment: an operator who wants live pricing can
+        # still export it false. See the module header — without this, litellm
+        # HTTP-fetches the cost map at import, so merely asking a question about
+        # a model reaches the network and reads whatever `main` says today.
+        os.environ.setdefault("LITELLM_LOCAL_MODEL_COST_MAP", "true")
+        import litellm
+    except Exception:  # noqa: BLE001 — litellm is an optional extra
+        logger.debug("litellm unavailable; no model metadata for %r", name)
+        return None
+    try:
+        info = litellm.get_model_info(name)
+    except Exception:  # noqa: BLE001 — an unknown model raises, and prints
+        # litellm writes a "Provider List:" banner to the console before
+        # raising. Unknown models are ordinary here (the pinned map trails
+        # new releases), so this stays at debug and the caller falls back.
+        logger.debug("No pinned model metadata for %r", name)
+        return None
+    return info if isinstance(info, dict) else None
+
+
+@lru_cache(maxsize=256)
+def model_output_ceiling(provider: str, model: str) -> int | None:
+    """The model's documented ``max_output_tokens``, or None if unknown.
+
+    Tries the bare model name first, then ``provider/model``. Both spellings
+    occur in real config: ``pydantic_ai_model`` may be ``deepseek/deepseek-v4-
+    flash`` (already vendor-qualified, provider resolved separately from
+    ``pydantic_ai_provider``) or a bare ``gpt-4o`` under an explicit provider.
+
+    Cached because it is consulted once per run and the answer is a property of
+    the installed litellm, which cannot change inside a process.
+    """
+    for candidate in (model, f"{provider}/{model}" if provider and model else ""):
+        info = _model_info(candidate)
+        if not info:
+            continue
+        for key in ("max_output_tokens", "max_tokens"):
+            value = info.get(key)
+            if isinstance(value, int) and value > 0:
+                return value
+    return None
+
+
+def resolve_max_output_tokens(provider: str, model: str, settings: Any) -> int | None:
+    """The output cap to send for this run, or None to send none.
+
+    1. ``agent_max_output_tokens`` < 0 — the operator opted out. Send nothing,
+       which is the pre-existing behaviour, 402s and all.
+    2. Otherwise the target is the operator's positive value, or
+       ``DEFAULT_MAX_OUTPUT_TOKENS``.
+    3. The model's documented ceiling is applied as an UPPER BOUND only, and
+       only when known. It can lower the target, never raise it.
+
+    Step 3 is deliberately weak. Metadata answers "what is the most this model
+    could emit", and the reservation we want is "enough for a real reply" —
+    letting the first override the second is how a fix becomes a bigger 402.
+    Its real job is the narrow one it is good at: not asking a small model for
+    more than it can produce, which some providers reject outright.
+    """
+    configured = getattr(settings, "agent_max_output_tokens", 0)
+    try:
+        configured = int(configured or 0)
+    except (TypeError, ValueError):
+        configured = 0
+
+    if configured <= _DISABLED:
+        return None
+
+    target = configured if configured > 0 else DEFAULT_MAX_OUTPUT_TOKENS
+    ceiling = model_output_ceiling(provider or "", model or "")
+    if ceiling and ceiling < target:
+        return ceiling
+    return target

--- a/src/pocketpaw/agents/pydantic_ai.py
+++ b/src/pocketpaw/agents/pydantic_ai.py
@@ -868,6 +868,23 @@ class PydanticAIBackend:
             provider = "litellm"
         return provider, model_str
 
+    def _resolve_max_output_tokens(self) -> int | None:
+        """The ``max_tokens`` this run should send, or None to send none.
+
+        Resolved from the SAME ``_parse_provider_model`` output that built the
+        model, so the cap and the model can never disagree. Never raises — the
+        helper fails open to None, which is the no-cap behaviour this backend
+        had before the setting existed.
+        """
+        try:
+            from pocketpaw.agents.model_limits import resolve_max_output_tokens
+
+            provider, model = self._parse_provider_model()
+            return resolve_max_output_tokens(provider, model, self.settings)
+        except Exception:  # noqa: BLE001 — a token cap must never break a run
+            logger.debug("Could not resolve a max output token cap", exc_info=True)
+            return None
+
     def _build_model(self, model_spec: str | None = None) -> Any:
         """Build the pydantic-ai model client for the configured provider."""
         provider, model = self._parse_provider_model(model_spec)
@@ -2036,6 +2053,16 @@ class PydanticAIBackend:
                 from pydantic_ai.usage import UsageLimits
 
                 kwargs["usage_limits"] = UsageLimits(request_limit=max_turns)
+
+            # Per-RUN like ``usage_limits`` above, and for the same reason: the
+            # cached agent is shared across runs, while the cap is a property of
+            # the model THIS run resolved. The fast-model path builds its own
+            # model and is unaffected.
+            max_output = self._resolve_max_output_tokens()
+            if max_output:
+                from pydantic_ai.settings import ModelSettings
+
+                kwargs["model_settings"] = ModelSettings(max_tokens=max_output)
 
             async with agent.run_stream_events(message, **kwargs) as stream:
                 async for event in stream:

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -679,6 +679,24 @@ class Settings(BaseSettings):
             "this cannot raise."
         ),
     )
+    agent_max_output_tokens: int = Field(
+        default=0,
+        description=(
+            "Max output tokens an agent run may request. 0 (default) sends "
+            "8192, lowered to the model's documented ceiling when the pinned "
+            "litellm metadata knows it; a positive value replaces the 8192; a "
+            "negative value sends no cap at all. Sending nothing is not "
+            "neutral — OpenRouter prices its pre-flight credit check against "
+            "max_tokens and substitutes the model's own ceiling when none is "
+            "given, so a short reply is refused with a 402 over a reservation "
+            "nobody asked for. The metadata is a clamp rather than the source: "
+            "deepseek-v4-flash advertised 8192 and then 393216 on the same day, "
+            "and sending the larger number would have made that 402 six times "
+            "worse. Distinct from litellm_max_tokens, which only reaches the "
+            "plain-completion provider (chat titles and the like), never an "
+            "agent backend."
+        ),
+    )
     pydantic_ai_max_turns: int = Field(
         default=100,
         description=(

--- a/tests/test_agent_max_output_tokens.py
+++ b/tests/test_agent_max_output_tokens.py
@@ -104,9 +104,7 @@ def test_the_model_ceiling_can_never_raise_the_cap():
 
     So a ceiling above the target must be ignored, whatever the metadata says.
     """
-    with patch(
-        "pocketpaw.agents.model_limits.model_output_ceiling", return_value=393_216
-    ):
+    with patch("pocketpaw.agents.model_limits.model_output_ceiling", return_value=393_216):
         got = resolve_max_output_tokens("litellm", "deepseek/deepseek-v4-flash", _settings())
 
     assert got == DEFAULT_MAX_OUTPUT_TOKENS
@@ -115,9 +113,12 @@ def test_the_model_ceiling_can_never_raise_the_cap():
 
 def test_a_junk_setting_does_not_break_a_run():
     """Settings can arrive from a UI, a YAML file, or an env var."""
-    assert resolve_max_output_tokens(
-        "litellm", "deepseek/deepseek-v4-flash", _settings(agent_max_output_tokens=0)
-    ) == DEFAULT_MAX_OUTPUT_TOKENS
+    assert (
+        resolve_max_output_tokens(
+            "litellm", "deepseek/deepseek-v4-flash", _settings(agent_max_output_tokens=0)
+        )
+        == DEFAULT_MAX_OUTPUT_TOKENS
+    )
 
 
 def test_a_resolver_failure_never_breaks_a_run():

--- a/tests/test_agent_max_output_tokens.py
+++ b/tests/test_agent_max_output_tokens.py
@@ -1,0 +1,204 @@
+# An agent run must send an explicit max_tokens.
+# Created: 2026-08-16 (feat/agent-max-output-tokens).
+#
+# No agent backend sent one. That is not a neutral omission: OpenRouter prices
+# its PRE-FLIGHT credit check against max_tokens and substitutes the model's own
+# ceiling when none is given, so a reply that would run a few hundred tokens was
+# refused with
+#
+#   402 - You requested up to 65536 tokens, but can only afford 6627.
+#
+# The two halves are tested separately on purpose: the resolver is pure and gets
+# its branches pinned directly, and one surface test proves the number actually
+# reaches ``run_stream_events`` — a resolver returning the right value into a
+# run that never sends it is the failure this whole change exists to avoid.
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from pocketpaw.agents.model_limits import (
+    DEFAULT_MAX_OUTPUT_TOKENS,
+    model_output_ceiling,
+    resolve_max_output_tokens,
+)
+from pocketpaw.config import Settings
+
+
+def _settings(**overrides) -> Settings:
+    base: dict[str, Any] = {
+        "pydantic_ai_model": "litellm:deepseek/deepseek-v4-flash",
+        "litellm_api_base": "http://localhost:4000",
+        "litellm_api_key": "sk-test",
+    }
+    base.update(overrides)
+    return Settings(**base)
+
+
+# ---------------------------------------------------------------------------
+# the resolver
+# ---------------------------------------------------------------------------
+
+
+def test_a_run_sends_a_cap_by_default():
+    """The whole point: with no configuration, something is sent.
+
+    Before this, the answer was None on every model and every backend.
+    """
+    assert resolve_max_output_tokens("litellm", "deepseek/deepseek-v4-flash", _settings()) == (
+        DEFAULT_MAX_OUTPUT_TOKENS
+    )
+
+
+def test_an_operator_value_replaces_the_default():
+    got = resolve_max_output_tokens(
+        "litellm", "deepseek/deepseek-v4-flash", _settings(agent_max_output_tokens=4096)
+    )
+    assert got == 4096
+
+
+def test_a_negative_value_opts_out_entirely():
+    """The escape hatch back to the old behaviour, for a gateway that dislikes
+    an explicit cap. It must send NOTHING, not zero — ``max_tokens=0`` is a
+    request for an empty completion on several providers."""
+    got = resolve_max_output_tokens(
+        "litellm", "deepseek/deepseek-v4-flash", _settings(agent_max_output_tokens=-1)
+    )
+    assert got is None
+
+
+def test_an_unknown_model_still_gets_the_default():
+    """The pinned metadata trails new releases by design, so "not in the map" is
+    ordinary rather than exceptional. It must not mean "send no cap" — that is
+    the broken state, and brand-new models are exactly where it bites."""
+    assert resolve_max_output_tokens("litellm", "no-such-model-xyz", _settings()) == (
+        DEFAULT_MAX_OUTPUT_TOKENS
+    )
+
+
+def test_a_smaller_model_ceiling_lowers_the_cap():
+    """The clamp's real job: don't ask a 4k model for 8k.
+
+    Skipped rather than asserted blind if the pinned map doesn't carry the
+    model — the point is the CLAMP, and a test that silently stops exercising it
+    is worse than one that says so.
+    """
+    ceiling = model_output_ceiling("openai", "gpt-3.5-turbo")
+    if not ceiling or ceiling >= DEFAULT_MAX_OUTPUT_TOKENS:
+        pytest.skip("pinned metadata has no smaller-than-default ceiling for gpt-3.5-turbo")
+
+    assert resolve_max_output_tokens("openai", "gpt-3.5-turbo", _settings()) == ceiling
+
+
+def test_the_model_ceiling_can_never_raise_the_cap():
+    """The finding that shaped this design, pinned so it cannot regress.
+
+    On 2026-08-16 ``deepseek/deepseek-v4-flash`` advertised max_output_tokens
+    8192 in the morning and 393216 the same afternoon, with max_input_tokens at
+    1000000 — a context window leaking into the output field. Resolving the
+    ceiling and SENDING it would have taken the credit reservation from 65536 to
+    393216 and made the 402 six times worse while looking like a fix.
+
+    So a ceiling above the target must be ignored, whatever the metadata says.
+    """
+    with patch(
+        "pocketpaw.agents.model_limits.model_output_ceiling", return_value=393_216
+    ):
+        got = resolve_max_output_tokens("litellm", "deepseek/deepseek-v4-flash", _settings())
+
+    assert got == DEFAULT_MAX_OUTPUT_TOKENS
+    assert got < 393_216
+
+
+def test_a_junk_setting_does_not_break_a_run():
+    """Settings can arrive from a UI, a YAML file, or an env var."""
+    assert resolve_max_output_tokens(
+        "litellm", "deepseek/deepseek-v4-flash", _settings(agent_max_output_tokens=0)
+    ) == DEFAULT_MAX_OUTPUT_TOKENS
+
+
+def test_a_resolver_failure_never_breaks_a_run():
+    """A token cap is a cost optimisation, not a feature. If anything in the
+    lookup throws, the run proceeds uncapped rather than dying."""
+    from pocketpaw.agents.pydantic_ai import PydanticAIBackend
+
+    backend = PydanticAIBackend(_settings())
+    with patch(
+        "pocketpaw.agents.model_limits.resolve_max_output_tokens",
+        side_effect=RuntimeError("metadata exploded"),
+    ):
+        assert backend._resolve_max_output_tokens() is None
+
+
+# ---------------------------------------------------------------------------
+# the surface — the number reaches the run
+# ---------------------------------------------------------------------------
+
+
+async def _captured_run_kwargs(backend) -> dict:
+    """Drive a real ``backend.run`` and return the kwargs it handed pydantic-ai.
+
+    Patches ``run_stream_events`` rather than the resolver, so this fails if the
+    wiring is dropped even while every resolver test above still passes. That is
+    the failure mode worth guarding: a correct number that never leaves the
+    process changes nothing about the 402.
+    """
+    captured: dict = {}
+
+    class _Stream:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        def __aiter__(self):
+            async def _empty():
+                return
+                yield  # pragma: no cover - never reached, makes this a generator
+
+            return _empty()
+
+    def _fake(self, message, **kwargs):  # noqa: ARG001 - signature mirrors pydantic-ai
+        captured.update(kwargs)
+        return _Stream()
+
+    from pydantic_ai import Agent
+
+    with patch.object(Agent, "run_stream_events", _fake):
+        async for _ in backend.run("hello"):
+            pass
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_the_cap_reaches_run_stream_events():
+    """The number is on the kwargs pydantic-ai receives."""
+    from pydantic_ai.models.test import TestModel
+
+    from pocketpaw.agents.pydantic_ai import PydanticAIBackend
+
+    backend = PydanticAIBackend(_settings())
+    with patch.object(backend, "_build_model", return_value=TestModel(custom_output_text="ok")):
+        kwargs = await _captured_run_kwargs(backend)
+
+    assert "model_settings" in kwargs, f"no model_settings sent; got {sorted(kwargs)}"
+    assert kwargs["model_settings"].get("max_tokens") == DEFAULT_MAX_OUTPUT_TOKENS
+
+
+@pytest.mark.asyncio
+async def test_opting_out_sends_no_model_settings_at_all():
+    """The escape hatch must omit the key, not send ``max_tokens=0`` — which is
+    a request for an empty completion on several providers."""
+    from pydantic_ai.models.test import TestModel
+
+    from pocketpaw.agents.pydantic_ai import PydanticAIBackend
+
+    backend = PydanticAIBackend(_settings(agent_max_output_tokens=-1))
+    with patch.object(backend, "_build_model", return_value=TestModel(custom_output_text="ok")):
+        kwargs = await _captured_run_kwargs(backend)
+
+    assert "model_settings" not in kwargs


### PR DESCRIPTION
Every agent run went out with no `max_tokens`. The only `ModelSettings` in the agents package is the AgentAPI shim, where the parameter is explicitly ignored.

That omission is not neutral:

```
402 - This request requires more credits, or fewer max_tokens.
      You requested up to 65536 tokens, but can only afford 6627.
```

OpenRouter prices its **pre-flight credit check against `max_tokens`**, and substitutes the model's own ceiling when none is supplied. Nobody asked for 65536 — we declined to say, so it assumed the worst case. Sending 8192 shrinks that reservation eightfold.

The retries in the reported log tell the same story: the "can only afford" figure falls across them (25782 → 18408 → 11834 → 6627) as the balance drains, and 17 `previous_errors` are the same unaffordable request tried again.

## The design decision: metadata is a clamp, not the source

The obvious implementation is to look up the model's advertised ceiling and send it. That is what I built first, and it is wrong.

Measured on 2026-08-16, `deepseek/deepseek-v4-flash` reported:

| when | `max_output_tokens` |
|---|---|
| morning (and the pasted config) | 8192 |
| same afternoon, upstream `main` | **393216** |

A 48× change within hours, with `max_input_tokens` at 1000000 — which reads like a context window leaking into the output field. **Resolving that ceiling and sending it would have taken the reservation from 65536 to 393216 and made the 402 six times worse, while looking exactly like a fix.**

So the ceiling can only ever *lower* the target, never raise it. Its job is the narrow one it is actually good at: not asking a 4k model for 8k.

```
disabled (< 0)      -> send nothing (today's behaviour)
target               = operator value, else 8192
ceiling known and smaller -> use the ceiling
```

## Where the number comes from

litellm ships the model map inside the installed package. The lookup forces `LITELLM_LOCAL_MODEL_COST_MAP` via `setdefault`, so an operator can still opt out.

That flag matters beyond this feature: **without it, litellm HTTP-fetches that JSON from BerriAI's `main` at import time**, falling back to the bundled copy only on failure. That unpinned runtime fetch already happens today in the import path of anything touching litellm — and it is precisely how the 393216 arrived. Forcing local removes a startup network dependency nobody chose and pins model data to a reviewed version.

The pinned map trails new releases, so an unknown model is ordinary rather than exceptional. It falls back to the default — not to "no cap", which is the broken state and is exactly where brand-new models would land.

## Settings

`agent_max_output_tokens` — `0` auto, positive overrides, negative opts out entirely. Distinct from the existing `litellm_max_tokens`, which only reaches the plain-completion provider (chat titles and the like) and never an agent backend; that gap is why setting it would not have helped.

## Verification

```
10 new tests + the pydantic-ai backend suite:  141 passed, 1 skipped
settings-adjacent suites:                       64 passed, 2 skipped
ruff:                                           clean
```

The surface test patches `run_stream_events` rather than the resolver, because a correct number that never leaves the process fixes nothing and every resolver test would still pass. It was **mutation-checked** — disabling the wiring fails it with the exact kwargs received:

```
AssertionError: no model_settings sent; got ['instructions', 'message_history', 'usage_limits']
```

The volatility finding is pinned as its own test, with the ceiling stubbed at 393216, so a future refactor cannot quietly reintroduce "just send the advertised maximum".

## Scope

pydantic-ai only — the backend actually in use. `model_limits.py` is backend-agnostic, so `deep_agents`, `openai_agents` and `google_adk` can adopt it in a follow-up; none of them cap output today either.
