### PR TITLE
Gate the paw-bar admin routes on workspace role

### DIFF
--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -1,4 +1,23 @@
 # ee/paw_bar/router.py — HTTP surface for the Paw Bar widget layer.
+# Updated: 2026-08-16 (fix/paw-bar-role-gates) — the last nine ``require_scope`` gates
+#   in this router become ROLE gates, so the ``require_scope`` import is gone. The
+#   two admin site-settings routes (the concierge kill switch) and the seven widget
+#   CRUD routes now take ``_require_paw_bar_read`` on the two GETs and
+#   ``_require_paw_bar_manage`` on every mutation — the same pair the D2 reads and
+#   the knowledge endpoints already used, so the whole admin surface of this router
+#   is finally gated one way. ``_require_paw_bar_manage`` moved up beside its read
+#   sibling because widget CRUD is now its first caller.
+#   ``require_scope("admin")`` is an OSS SINGLE-TENANT primitive: it accepts
+#   ``request.state.full_access`` (master token / session cookie / localhost, and in
+#   cloud only an ``is_superuser`` platform admin), a file-backed ``pp_`` API key, or
+#   a ``ppat_`` OAuth token. A CLOUD workspace admin presents none of those, so
+#   PATCH /paw-bar/admin/site/{site_id}/settings answered its intended caller with
+#   403 "Missing required scope: admin" — the kill switch was unreachable for the
+#   owner it belongs to. The same line failed the opposite way on self-hosted: a
+#   session cookie sets ``full_access``, so ANY signed-in dashboard user, member
+#   role included, could rotate a widget's token or delete it. One swap closes both.
+#   No new actions: ``paw_bar.read`` / ``paw_bar.manage`` already sit at ADMIN in
+#   guards/actions.py.
 # Updated: 2026-08-01 (AL-2, paw-bar emitters) — three conversation write paths
 #   now record their agent-ledger beats through ``paw_bar/ledger.py`` (fail-soft,
 #   never raises, ~4 lines each):
@@ -406,7 +425,6 @@ from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse, JSONResponse, Response, StreamingResponse
 from pydantic import BaseModel, Field
 
-from pocketpaw.api.deps import require_scope
 from pocketpaw.paw_bar.models import (
     MAX_PAYLOAD_BYTES,
     ConversationState,
@@ -432,6 +450,12 @@ logger = logging.getLogger(__name__)
 # path-sourced dep would read an attacker-suppliable query param), the SAME
 # workspace the reads scope their data to.
 _require_paw_bar_read = require_action("paw_bar.read", workspace_dep=current_workspace_id)
+
+# The write half of the same pair (ADMIN, same session-workspace binding). Declared
+# here beside its read sibling because the widget CRUD routes — the first routes in
+# the file — now gate on it; it used to sit next to the knowledge-sync routes that
+# introduced it, several hundred lines below its first use.
+_require_paw_bar_manage = require_action("paw_bar.manage", workspace_dep=current_workspace_id)
 
 router = APIRouter(tags=["PawBar"])
 
@@ -1065,12 +1089,22 @@ class EventsListResponse(BaseModel):
 # Auth model (W0b): these routes are mounted under /api/v1, which the
 # dashboard AuthMiddleware treats as auth-OPTIONAL — it populates request.state
 # but does NOT 401. So management routes MUST gate themselves at the route
-# level. require_scope("admin") is fail-closed: it accepts a full-access
-# dashboard session (master/session-cookie/localhost) or an admin-scoped
-# API-key / OAuth token, and 403s everyone else (including unauthenticated
-# callers). The per-widget access_token (X-Paw-Bar-Token) is a SECOND factor
-# on read/mutate of a specific widget — it is not a substitute for being a
-# signed-in dashboard user, which is why create/list need this guard.
+# level. They gate on the caller's WORKSPACE ROLE — ``_require_paw_bar_manage``
+# (``paw_bar.manage``, ADMIN) for every mutation, ``_require_paw_bar_read``
+# (``paw_bar.read``, ADMIN) for the list — bound to the SESSION's active
+# workspace, the same one every handler below scopes its store calls to.
+# The per-widget access_token (X-Paw-Bar-Token) is a SECOND factor on
+# read/mutate of a specific widget — it is not a substitute for being a
+# signed-in workspace admin, which is why create/list need this guard.
+#
+# These used to gate on ``require_scope("admin")``, which is an OSS
+# SINGLE-TENANT primitive: it admits a full-access dashboard session, an
+# admin-scoped file-backed API key, or a ppat_ OAuth token. A cloud workspace
+# admin holds NONE of those, so the gate was unsatisfiable for the caller it
+# was meant for (403 on their own site's settings); on self-hosted it was the
+# opposite problem — any signed-in dashboard session sets ``full_access``, so
+# it admitted members too. The role gate fixes both directions at once, and
+# matches what the D2 reads below already did.
 # ---------------------------------------------------------------------------
 
 
@@ -1078,7 +1112,7 @@ class EventsListResponse(BaseModel):
     "/paw-bar/widgets",
     response_model=PawBarWidget,
     status_code=201,
-    dependencies=[Depends(require_scope("admin"))],
+    dependencies=[Depends(_require_paw_bar_manage)],
 )
 async def create_widget(
     req: CreateWidgetRequest,
@@ -1115,7 +1149,7 @@ async def create_widget(
 @router.get(
     "/paw-bar/widgets",
     response_model=WidgetListResponse,
-    dependencies=[Depends(require_scope("admin"))],
+    dependencies=[Depends(_require_paw_bar_read)],
 )
 async def list_widgets(
     pocket_id: str | None = Query(None),
@@ -1150,7 +1184,7 @@ async def get_widget(
 @router.patch(
     "/paw-bar/widgets/{widget_id}/spec",
     response_model=PawBarWidgetPublic,
-    dependencies=[Depends(require_scope("admin"))],
+    dependencies=[Depends(_require_paw_bar_manage)],
 )
 async def update_spec(
     widget_id: str,
@@ -1173,7 +1207,7 @@ async def update_spec(
 @router.patch(
     "/paw-bar/widgets/{widget_id}",
     response_model=PawBarWidgetPublic,
-    dependencies=[Depends(require_scope("admin"))],
+    dependencies=[Depends(_require_paw_bar_manage)],
 )
 async def update_widget(
     widget_id: str,
@@ -1210,7 +1244,7 @@ async def update_widget(
 @router.post(
     "/paw-bar/widgets/{widget_id}/spec/rollback",
     response_model=PawBarWidgetPublic,
-    dependencies=[Depends(require_scope("admin"))],
+    dependencies=[Depends(_require_paw_bar_manage)],
 )
 async def rollback_spec(
     widget_id: str,
@@ -1238,7 +1272,7 @@ async def rollback_spec(
 @router.post(
     "/paw-bar/widgets/{widget_id}/rotate-token",
     response_model=PawBarWidget,
-    dependencies=[Depends(require_scope("admin"))],
+    dependencies=[Depends(_require_paw_bar_manage)],
 )
 async def rotate_token(
     widget_id: str,
@@ -1263,7 +1297,7 @@ async def rotate_token(
 @router.delete(
     "/paw-bar/widgets/{widget_id}",
     status_code=204,
-    dependencies=[Depends(require_scope("admin"))],
+    dependencies=[Depends(_require_paw_bar_manage)],
 )
 async def delete_widget(
     widget_id: str,
@@ -1298,9 +1332,10 @@ async def list_events(
 #
 # The kill switch + greeting live on the SITE doc (not the widget), so the owner
 # read/update is keyed on ``site_id``, not a widget id. Auth mirrors the widget
-# admin CRUD above: ``require_scope("admin")`` (a signed-in dashboard session) +
-# the caller's ACTIVE workspace via ``current_workspace_id``. The lookup is
-# workspace-scoped, so another tenant's site id resolves to 404 and never leaks or
+# admin CRUD above: the caller's WORKSPACE ROLE must clear ``paw_bar.read`` on the
+# GET and ``paw_bar.manage`` on the PATCH (both ADMIN), bound to their ACTIVE
+# workspace via ``current_workspace_id``. The lookup is workspace-scoped, so
+# another tenant's site id resolves to 404 and never leaks or
 # mutates. Reads/writes touch ONLY the concierge fields (the kill switch, the
 # greeting, and the transcript-retention toggle) — the site's publish / billing /
 # capture config is out of scope here. Co-located with the paw-bar
@@ -1362,7 +1397,7 @@ async def _load_site_scoped(site_id: str, workspace_id: str) -> Any:
 @router.get(
     "/paw-bar/admin/site/{site_id}/settings",
     response_model=ConciergeSettingsResponse,
-    dependencies=[Depends(require_scope("admin"))],
+    dependencies=[Depends(_require_paw_bar_read)],
 )
 async def get_site_concierge_settings(
     site_id: str,
@@ -1382,7 +1417,7 @@ async def get_site_concierge_settings(
 @router.patch(
     "/paw-bar/admin/site/{site_id}/settings",
     response_model=ConciergeSettingsResponse,
-    dependencies=[Depends(require_scope("admin"))],
+    dependencies=[Depends(_require_paw_bar_manage)],
 )
 async def update_site_concierge_settings(
     site_id: str,
@@ -1441,7 +1476,8 @@ async def update_site_concierge_settings(
 # ADMIN). The sync is a mutation that spends compute, so it does not ride the read.
 # ---------------------------------------------------------------------------
 
-_require_paw_bar_manage = require_action("paw_bar.manage", workspace_dep=current_workspace_id)
+# ``_require_paw_bar_manage`` is now declared beside ``_require_paw_bar_read`` near
+# the top of the file — the widget CRUD routes above use it too.
 
 
 class ConciergeKnowledgeResponse(BaseModel):

--- a/tests/cloud/conftest.py
+++ b/tests/cloud/conftest.py
@@ -18,6 +18,12 @@ Also exposes:
 - ``cloud_app_client`` — a FastAPI app with the enterprise chat routers
   mounted and auth/license dependencies overridden, used by HTTP-layer
   tests so they don't need a real JWT.
+- ``override_workspace_role`` — pins a caller ROLE + workspace on a bare test
+  app so ``require_action(...)`` guards run their real role check. Added
+  2026-08-16 when the paw-bar admin routes moved off ``require_scope("admin")``
+  onto the role gate: those router-level tests mount the router with no auth
+  stack, so ``current_active_user`` has nothing to resolve and every admin
+  route answers 401 until the dep is overridden.
 """
 
 from __future__ import annotations
@@ -207,6 +213,53 @@ def _fixed_workspace() -> str:
 
 def _no_op_license() -> None:
     return None
+
+
+def fake_workspace_user(role: str = "admin", workspace_id: str = "w1", user_id: str = "u1") -> Any:
+    """User stand-in shaped like ``ee.cloud.models.user.User`` — only the fields
+    the RBAC chain reads (``id``, ``active_workspace``, ``workspaces``).
+
+    ``role`` is the caller's WorkspaceRole in ``workspace_id`` (member | admin |
+    owner), which is what ``check_workspace_action`` compares against the ACTIONS
+    matrix. Nothing here is faked past the identity: the guard itself runs for real.
+    """
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        id=user_id,
+        active_workspace=workspace_id,
+        workspaces=[SimpleNamespace(workspace=workspace_id, role=role)],
+    )
+
+
+def override_workspace_role(
+    app: FastAPI,
+    role: str = "admin",
+    workspace_id: str = "w1",
+    user_id: str = "u1",
+) -> None:
+    """Pin a caller ROLE + active workspace on a bare test app.
+
+    Router-level tests mount a single router on a plain ``FastAPI()`` with no auth
+    stack, so ``current_active_user`` (fastapi-users) finds no session and any
+    ``require_action`` guard 401s before its role check ever runs. Overriding both
+    deps here lets the guard execute for real against the given role — pass
+    ``role="member"`` to assert a 403, ``role="admin"``/``"owner"`` to assert
+    success.
+
+    Also installs ``add_error_handler``: a denied guard raises the cloud-native
+    ``Forbidden`` (a CloudError), which without the handler escapes as an
+    unhandled exception instead of the 403 envelope production returns. The call
+    is idempotent, so an app that already registered it is unaffected.
+    """
+    from pocketpaw_ee.cloud._core.deps import current_workspace_id
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.cloud.auth import current_active_user
+
+    add_error_handler(app)
+    user = fake_workspace_user(role=role, workspace_id=workspace_id, user_id=user_id)
+    app.dependency_overrides[current_active_user] = lambda: user
+    app.dependency_overrides[current_workspace_id] = lambda: workspace_id
 
 
 @pytest_asyncio.fixture

--- a/tests/cloud/test_paw_bar_actions.py
+++ b/tests/cloud/test_paw_bar_actions.py
@@ -489,15 +489,17 @@ class TestActionEndpoint:
 
 @pytest.fixture
 def admin_client(tmp_path, monkeypatch):
-    """TestClient with the admin CRUD routes' workspace dep pinned (like the
-    decision-loop test), backed by a tmp store."""
-    from pocketpaw_ee.cloud._core.deps import current_workspace_id
+    """TestClient with the admin CRUD routes' workspace + ROLE deps pinned (like
+    the decision-loop test), backed by a tmp store. The role is ADMIN because
+    those routes gate on ``paw_bar.read`` / ``paw_bar.manage``."""
     from pocketpaw_ee.paw_bar.router import router
+
+    from tests.cloud.conftest import override_workspace_role
 
     pp_store = PawBarStore(tmp_path / "admin.db")
     app = FastAPI()
     app.include_router(router)
-    app.dependency_overrides[current_workspace_id] = lambda: "ws-1"
+    override_workspace_role(app, role="admin", workspace_id="ws-1")
     monkeypatch.setattr("pocketpaw_ee.paw_bar.router._store", lambda *a, **k: pp_store)
     return TestClient(app), pp_store
 

--- a/tests/cloud/test_paw_bar_agent_provisioning.py
+++ b/tests/cloud/test_paw_bar_agent_provisioning.py
@@ -134,14 +134,17 @@ async def client(tmp_path, mongo_db):
     the SAME tmp store. Yields ``(client, store)``."""
     from unittest.mock import patch
 
-    from pocketpaw_ee.cloud._core.deps import current_workspace_id
     from pocketpaw_ee.cloud._core.http import add_error_handler
     from pocketpaw_ee.paw_bar.router import router
+
+    from tests.cloud.conftest import override_workspace_role
 
     app = FastAPI()
     add_error_handler(app)
     app.include_router(router)
-    app.dependency_overrides[current_workspace_id] = lambda: _WS
+    # The admin routes gate on the caller's workspace ROLE since
+    # fix/paw-bar-role-gates, so pin an ADMIN alongside the workspace.
+    override_workspace_role(app, role="admin", workspace_id=_WS)
 
     store = PawBarStore(tmp_path / "provisioning.db")
     with patch("pocketpaw_ee.api.get_paw_bar_store", return_value=store):

--- a/tests/cloud/test_paw_bar_concierge_settings.py
+++ b/tests/cloud/test_paw_bar_concierge_settings.py
@@ -13,6 +13,16 @@
 # Updated 2026-07-26 (concierge transcripts): a fifth layer covers the
 #   transcript-retention toggle — exposed on GET, writable via PATCH, defaults on,
 #   and fully independent of the kill switch in both directions.
+# Updated 2026-08-16 (fix/paw-bar-role-gates): the two admin settings routes moved
+#   off ``require_scope("admin")`` onto the ``paw_bar.read`` / ``paw_bar.manage``
+#   ROLE gate, so the app fixture now pins the caller's workspace ROLE (admin) and
+#   a sixth layer covers the gate itself: admin/owner can PATCH the kill switch
+#   (the reported bug — a cloud workspace admin used to get 403 "Missing required
+#   scope: admin", because the scope gate only accepts a full-access dashboard
+#   session / pp_ API key / ppat_ token and a workspace admin holds none of them),
+#   a member is refused on both the PATCH and the GET with nothing written, and a
+#   widget DELETE shows the same split even when the caller holds the per-widget
+#   owner token.
 
 from __future__ import annotations
 
@@ -72,24 +82,33 @@ def _widget(**ov: Any) -> PawBarWidget:
     return PawBarWidget(**d)
 
 
+def _build_app(role: str = "admin") -> FastAPI:
+    """Mount the paw_bar router with the caller's workspace ROLE pinned to ws-1.
+
+    The two admin settings routes gate on ``paw_bar.read`` (GET) /
+    ``paw_bar.manage`` (PATCH), so the role stand-in is what decides 200 vs 403;
+    the public frame/chat/action routes on the same router ignore it entirely.
+    """
+    from pocketpaw_ee.paw_bar.router import router
+
+    from tests.cloud.conftest import override_workspace_role
+
+    app = FastAPI()
+    app.include_router(router)
+    override_workspace_role(app, role=role, workspace_id="ws-1")
+    return app
+
+
 @pytest_asyncio.fixture
 async def client(tmp_path, mongo_db):
     """One public+admin app client for every D1 endpoint, backed by a tmp paw_bar
-    store (widget) + Beanie (Site). ``current_workspace_id`` is pinned to ws-1 for
-    the admin settings routes; the public frame/chat/action routes ignore it.
-    Yields ``(client, store)``.
+    store (widget) + Beanie (Site). The caller is a ws-1 ADMIN, so the admin
+    settings routes clear their role gate; the public frame/chat/action routes
+    ignore both the role and the workspace. Yields ``(client, store)``.
     """
     from unittest.mock import patch
 
-    from pocketpaw_ee.cloud._core.deps import current_workspace_id
-    from pocketpaw_ee.cloud._core.http import add_error_handler
-    from pocketpaw_ee.paw_bar.router import router
-
-    app = FastAPI()
-    add_error_handler(app)
-    app.include_router(router)
-    app.dependency_overrides[current_workspace_id] = lambda: "ws-1"
-
+    app = _build_app(role="admin")
     store = PawBarStore(tmp_path / "settings.db")
     with patch("pocketpaw_ee.paw_bar.router._store", return_value=store):
         transport = ASGITransport(app=app)
@@ -349,6 +368,139 @@ async def test_settings_patch_can_turn_transcript_retention_off(client):
     assert res.json()["concierge_store_transcripts"] is False
     got = await c.get(f"/paw-bar/admin/site/{site.id}/settings")
     assert got.json()["concierge_store_transcripts"] is False
+
+
+# --------------------------------------------------------------------------- #
+# Layer 6 — the settings routes are ROLE-gated (fix/paw-bar-role-gates)
+#
+# The reported bug: PATCH /paw-bar/admin/site/{id}/settings answered a workspace
+# ADMIN with 403 "Missing required scope: admin". The route gated on
+# ``require_scope("admin")``, an OSS single-tenant primitive that only accepts
+# request.state.full_access / a pp_ API key / a ppat_ OAuth token — a cloud
+# workspace admin presents none of the three, so the site kill switch was
+# unreachable for the person who owns it. These pin the fix from both sides:
+# the intended caller gets in, and the caller the old gate wrongly admitted on
+# self-hosted (any signed-in session, member included) does not.
+# --------------------------------------------------------------------------- #
+
+
+@pytest_asyncio.fixture
+async def member_client(tmp_path, mongo_db):
+    """Same app, but the caller's ws-1 role is MEMBER (below the ADMIN the
+    paw_bar actions require). Yields ``(client, store)``."""
+    from unittest.mock import patch
+
+    app = _build_app(role="member")
+    store = PawBarStore(tmp_path / "settings_member.db")
+    with patch("pocketpaw_ee.paw_bar.router._store", return_value=store):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://t") as c:
+            yield c, store
+
+
+@pytest.mark.enforce_scope
+@pytest.mark.parametrize("role", ["admin", "owner"])
+@pytest.mark.asyncio
+async def test_admin_role_can_patch_the_kill_switch(role, tmp_path, mongo_db):
+    """THE REPORTED BUG. A workspace admin PATCHes their own site's concierge
+    settings and the write lands — no 403, no scope check.
+
+    ``enforce_scope`` matters here even though this route no longer calls
+    ``require_scope``: it turns OFF the root conftest's ``_TESTING_FULL_ACCESS``
+    bypass, which makes ``require_scope`` a no-op that admits every caller. With
+    the bypass on, this test would pass against the OLD gate too and prove
+    nothing — which is exactly how the bug reached production with the settings
+    surface fully covered. The role gate never reads that flag, so the marker is
+    inert against the fixed code and lethal against a regression to the old one.
+    """
+    from unittest.mock import patch
+
+    site = await _site()
+    app = _build_app(role=role)
+    store = PawBarStore(tmp_path / f"settings_{role}.db")
+    with patch("pocketpaw_ee.paw_bar.router._store", return_value=store):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://t") as c:
+            res = await c.patch(
+                f"/paw-bar/admin/site/{site.id}/settings",
+                json={"concierge_enabled": False},
+            )
+            assert res.status_code == 200, f"{role}: {res.status_code} {res.text}"
+            assert res.json()["concierge_enabled"] is False
+
+    # The switch actually moved on the stored doc, not just in the response.
+    await site.sync()
+    assert site.concierge_enabled is False
+
+
+@pytest.mark.asyncio
+async def test_member_role_cannot_patch_the_kill_switch(member_client, mongo_db):
+    """A MEMBER is refused (403) on the same PATCH, and the site is untouched.
+
+    Under ``require_scope("admin")`` on a self-hosted deploy this succeeded: the
+    session cookie sets ``full_access``, which the scope gate accepts outright.
+    """
+    c, _store = member_client
+    site = await _site()
+    res = await c.patch(
+        f"/paw-bar/admin/site/{site.id}/settings",
+        json={"concierge_enabled": False},
+    )
+    assert res.status_code == 403, res.text
+    assert "workspace.insufficient_role" in res.text
+
+    await site.sync()
+    assert site.concierge_enabled is True  # nothing was written
+
+
+@pytest.mark.asyncio
+async def test_admin_role_can_read_the_settings(client):
+    """The GET takes ``paw_bar.read`` — an admin sees the toggle state."""
+    c, _store = client
+    site = await _site(concierge_greeting="Back at 9am")
+    res = await c.get(f"/paw-bar/admin/site/{site.id}/settings")
+    assert res.status_code == 200, res.text
+    assert res.json()["concierge_greeting"] == "Back at 9am"
+
+
+@pytest.mark.asyncio
+async def test_member_role_cannot_read_the_settings(member_client, mongo_db):
+    """A MEMBER is refused (403) on the GET too — the reads and writes on this
+    surface are both ADMIN, so a member learns nothing about the site's config."""
+    c, _store = member_client
+    site = await _site(concierge_greeting="Back at 9am")
+    res = await c.get(f"/paw-bar/admin/site/{site.id}/settings")
+    assert res.status_code == 403, res.text
+    assert "Back at 9am" not in res.text
+
+
+@pytest.mark.asyncio
+async def test_member_role_cannot_delete_a_widget(member_client, mongo_db):
+    """A widget MUTATION refuses a member as well — the role gate covers the
+    whole admin surface of this router, not just the site settings."""
+    c, store = member_client
+    widget = await store.create_widget(_widget())
+    res = await c.delete(
+        f"/paw-bar/widgets/{widget.id}",
+        headers={"X-Paw-Bar-Token": widget.access_token},
+    )
+    assert res.status_code == 403, res.text
+    # The role gate runs BEFORE the handler, so the row is still there even
+    # though the caller held the correct per-widget owner token.
+    assert await store.get_widget(widget.id) is not None
+
+
+@pytest.mark.asyncio
+async def test_admin_role_can_delete_a_widget(client):
+    """The same DELETE succeeds for an admin holding the owner token (204)."""
+    c, store = client
+    widget = await store.create_widget(_widget())
+    res = await c.delete(
+        f"/paw-bar/widgets/{widget.id}",
+        headers={"X-Paw-Bar-Token": widget.access_token},
+    )
+    assert res.status_code == 204, res.text
+    assert await store.get_widget(widget.id) is None
 
 
 @pytest.mark.asyncio

--- a/tests/cloud/test_paw_bar_decision_loop.py
+++ b/tests/cloud/test_paw_bar_decision_loop.py
@@ -94,9 +94,12 @@ def client(stores, monkeypatch):
     app.include_router(router)
     # W4a — the admin CRUD routes resolve the caller's workspace via the cloud
     # session dep; pin it for the bare test app (same as tests/cloud/conftest.py).
-    from pocketpaw_ee.cloud._core.deps import current_workspace_id
+    # Since fix/paw-bar-role-gates those routes also gate on the caller's
+    # workspace ROLE (paw_bar.read / paw_bar.manage, both ADMIN), so the role is
+    # pinned too — otherwise every widget create here 401s.
+    from tests.cloud.conftest import override_workspace_role
 
-    app.dependency_overrides[current_workspace_id] = lambda: "w-test"
+    override_workspace_role(app, role="admin", workspace_id="w-test")
     monkeypatch.setattr("pocketpaw_ee.paw_bar.router._store", lambda *a, **k: pp_store)
     return TestClient(app)
 

--- a/tests/cloud/test_paw_bar_ingest.py
+++ b/tests/cloud/test_paw_bar_ingest.py
@@ -17,6 +17,15 @@
 # current_workspace_id dep via _override_workspace (the admin CRUD routes
 # thread it); added workspace-stamp-on-create + spec rollback endpoint tests
 # (round-trip, 409 when no revision, owner-token required).
+# Updated: 2026-08-16 (fix/paw-bar-role-gates) — widget CRUD moved off
+# require_scope("admin") onto the paw_bar.read / paw_bar.manage ROLE gate, so
+# _override_workspace now pins the caller's ROLE as well as their workspace and
+# TestWidgetManagementAuth was rewritten around it: unauthenticated is 401 (no
+# session), a signed-in MEMBER is 403 (the case the old scope gate wrongly let
+# through on self-hosted, where a session cookie sets full_access), and
+# admin/owner succeed. The request.state auth markers (full_access, an
+# admin-scoped api_key) and the enforce_scope marker are gone from this file —
+# the role gate never reads request.state, so they proved nothing about it.
 
 from __future__ import annotations
 
@@ -66,17 +75,19 @@ def _widget_payload(**overrides: Any) -> dict[str, Any]:
     return payload
 
 
-def _override_workspace(app: FastAPI, workspace_id: str = "w-test") -> None:
-    """Pin current_workspace_id for a bare test app (W4a).
+def _override_workspace(app: FastAPI, workspace_id: str = "w-test", role: str = "admin") -> None:
+    """Pin the caller's active workspace AND workspace ROLE for a bare test app.
 
     The admin CRUD routes resolve the caller's active workspace through the
-    cloud session dep; these router-level tests mount the router on a bare
-    FastAPI app with no auth stack, so the dep is overridden the same way
-    tests/cloud/conftest.py does for other cloud routers.
+    cloud session dep and their role through ``require_action``; these
+    router-level tests mount the router on a bare FastAPI app with no auth
+    stack, so both deps are overridden the same way tests/cloud/conftest.py
+    does for other cloud routers. Default ``admin`` clears ``paw_bar.read`` /
+    ``paw_bar.manage``; the guard itself still runs for real.
     """
-    from pocketpaw_ee.cloud._core.deps import current_workspace_id
+    from tests.cloud.conftest import override_workspace_role
 
-    app.dependency_overrides[current_workspace_id] = lambda: workspace_id
+    override_workspace_role(app, role=role, workspace_id=workspace_id)
 
 
 @pytest.fixture
@@ -478,42 +489,53 @@ class TestInterpolate:
 # W0b — widget-management auth + access_token non-leak
 # ---------------------------------------------------------------------------
 #
-# These tests opt OUT of the root conftest's _TESTING_FULL_ACCESS bypass
-# (via the `enforce_scope` marker) so require_scope("admin") behaves exactly
-# as it does in production: fail-closed for an unauthenticated caller, open
-# only when an explicit auth marker (full_access / admin-scoped api_key) is on
-# request.state.
+# Rewritten 2026-08-16 (fix/paw-bar-role-gates). These routes used to gate on
+# ``require_scope("admin")``, so this block used to opt out of the root
+# conftest's _TESTING_FULL_ACCESS bypass (the ``enforce_scope`` marker) and
+# stamp ``full_access`` / an admin-scoped api_key onto request.state. Both are
+# now irrelevant: the gate is ``require_action("paw_bar.read"/".manage")``,
+# which reads the caller's WORKSPACE ROLE and never looks at request.state, so
+# the bypass flag cannot reach it either way. Fail-closed now has two shapes,
+# and the tests below pin both:
+#   * no session at all  -> 401 from ``current_active_user`` (fastapi-users)
+#   * signed in as member -> 403 from the role guard
+# The role gate is also STRICTER than what it replaced: an admin-scoped OSS API
+# key / ppat_ OAuth token used to clear ``require_scope("admin")`` and no longer
+# opens these routes. That matches the eight sibling routes in this router that
+# already gated on the same actions.
 
 
-def _build_authed_app(store: PawBarStore, **state_kwargs):
-    """Mount the paw_bar router behind a middleware that stamps the given
-    auth markers onto request.state — the same markers dashboard_auth sets in
-    production. With no kwargs the caller is effectively unauthenticated.
+def _build_authed_app(store: PawBarStore, *, role: str | None = "admin"):
+    """Mount the paw_bar router on a bare app with the caller's ROLE pinned.
+
+    ``role=None`` leaves the auth deps unresolved — i.e. an unauthenticated
+    caller, which is what the fail-closed tests want. ``current_workspace_id``
+    is pinned in every case so a 401/403 is attributable to the role gate and
+    never to a missing workspace.
     """
     app = FastAPI()
-
-    @app.middleware("http")
-    async def _inject(request, call_next):
-        for key, value in state_kwargs.items():
-            setattr(request.state, key, value)
-        return await call_next(request)
-
     app.include_router(router)
-    _override_workspace(app)
+    if role is None:
+        from pocketpaw_ee.cloud._core.deps import current_workspace_id
+
+        app.dependency_overrides[current_workspace_id] = lambda: "w-test"
+    else:
+        _override_workspace(app, role=role)
     return app
-
-
-class _AdminApiKey:
-    """Stand-in for an api-key record with admin scope (matches require_scope)."""
-
-    def __init__(self) -> None:
-        self.scopes = ["admin"]
 
 
 @pytest.fixture
 def unauth_client(tmp_path: Path):
     store = PawBarStore(tmp_path / "paw_bar_unauth.db")
-    app = _build_authed_app(store)  # no auth markers → unauthenticated
+    app = _build_authed_app(store, role=None)  # no session → unauthenticated
+    with patch("pocketpaw_ee.paw_bar.router._store", return_value=store):
+        yield TestClient(app), store
+
+
+@pytest.fixture
+def member_client(tmp_path: Path):
+    store = PawBarStore(tmp_path / "paw_bar_member.db")
+    app = _build_authed_app(store, role="member")
     with patch("pocketpaw_ee.paw_bar.router._store", return_value=store):
         yield TestClient(app), store
 
@@ -521,55 +543,69 @@ def unauth_client(tmp_path: Path):
 @pytest.fixture
 def admin_client(tmp_path: Path):
     store = PawBarStore(tmp_path / "paw_bar_admin.db")
-    app = _build_authed_app(store, full_access=True)
+    app = _build_authed_app(store, role="admin")
     with patch("pocketpaw_ee.paw_bar.router._store", return_value=store):
         yield TestClient(app), store
 
 
-@pytest.mark.enforce_scope
 class TestWidgetManagementAuth:
-    """Widget create / list / update / delete require an authenticated caller."""
+    """Widget create / list / update / delete require an ADMIN workspace role."""
 
-    def test_unauthenticated_list_is_forbidden(self, unauth_client) -> None:
+    def test_unauthenticated_list_is_refused(self, unauth_client) -> None:
         client, _ = unauth_client
         res = client.get("/paw-bar/widgets")
-        assert res.status_code == 403
+        assert res.status_code == 401
 
-    def test_unauthenticated_create_is_forbidden(self, unauth_client) -> None:
+    def test_unauthenticated_create_is_refused(self, unauth_client) -> None:
         client, _ = unauth_client
         res = client.post("/paw-bar/widgets", json=_widget_payload())
-        assert res.status_code == 403
+        assert res.status_code == 401
 
-    def test_unauthenticated_update_is_forbidden(self, unauth_client) -> None:
+    def test_unauthenticated_update_is_refused(self, unauth_client) -> None:
         client, _ = unauth_client
         res = client.patch(
             "/paw-bar/widgets/pp_anything/spec",
             json=_spec().model_dump(),
         )
-        assert res.status_code == 403
+        assert res.status_code == 401
 
-    def test_unauthenticated_delete_is_forbidden(self, unauth_client) -> None:
+    def test_unauthenticated_delete_is_refused(self, unauth_client) -> None:
         client, _ = unauth_client
         res = client.delete("/paw-bar/widgets/pp_anything")
-        assert res.status_code == 403
+        assert res.status_code == 401
 
-    def test_full_access_caller_can_create_and_list(self, admin_client) -> None:
-        client, _ = admin_client
-        created = client.post("/paw-bar/widgets", json=_widget_payload())
-        assert created.status_code == 201
-        listed = client.get("/paw-bar/widgets")
-        assert listed.status_code == 200
-        assert listed.json()["total"] == 1
+    def test_member_role_is_forbidden_on_every_management_route(self, member_client) -> None:
+        """A signed-in MEMBER clears authentication and still fails the role gate.
 
-    def test_admin_scoped_api_key_can_list(self, tmp_path: Path) -> None:
-        store = PawBarStore(tmp_path / "paw_bar_apikey.db")
-        app = _build_authed_app(store, api_key=_AdminApiKey())
+        This is the half ``require_scope("admin")`` got wrong on self-hosted: a
+        session cookie sets ``full_access``, so every one of these calls used to
+        succeed for a member.
+        """
+        client, _ = member_client
+        assert client.get("/paw-bar/widgets").status_code == 403
+        assert client.post("/paw-bar/widgets", json=_widget_payload()).status_code == 403
+        assert (
+            client.patch("/paw-bar/widgets/pp_anything/spec", json=_spec().model_dump()).status_code
+            == 403
+        )
+        assert client.patch("/paw-bar/widgets/pp_anything", json={}).status_code == 403
+        assert client.post("/paw-bar/widgets/pp_anything/spec/rollback").status_code == 403
+        assert client.post("/paw-bar/widgets/pp_anything/rotate-token").status_code == 403
+        assert client.delete("/paw-bar/widgets/pp_anything").status_code == 403
+
+    @pytest.mark.parametrize("role", ["admin", "owner"])
+    def test_admin_and_owner_can_create_and_list(self, tmp_path: Path, role: str) -> None:
+        store = PawBarStore(tmp_path / f"paw_bar_{role}.db")
+        app = _build_authed_app(store, role=role)
         with patch("pocketpaw_ee.paw_bar.router._store", return_value=store):
             client = TestClient(app)
-            assert client.get("/paw-bar/widgets").status_code == 200
+            created = client.post("/paw-bar/widgets", json=_widget_payload())
+            assert created.status_code == 201, created.text
+            listed = client.get("/paw-bar/widgets")
+            assert listed.status_code == 200
+            assert listed.json()["total"] == 1
 
 
-@pytest.mark.enforce_scope
 class TestNoTokenLeak:
     """No list/read response may carry the per-widget access_token (W0b)."""
 


### PR DESCRIPTION
## The bug

`PATCH /paw-bar/admin/site/{site_id}/settings` — the site concierge on/off switch — answered a workspace **admin** with `403 "Missing required scope: admin"`. The person who owns the site could not turn its concierge off.

## Why

Nine routes here gated on `require_scope("admin")`, an OSS single-tenant primitive. It accepts exactly three credentials: `request.state.full_access`, a file-backed `pp_` API key, or a `ppat_` OAuth token. A cloud workspace admin presents none of them — `full_access` is reserved for `is_superuser` platform admins by the W4b escalation fix, and cloud keys are `paw_`-prefixed and live in Mongo, so `dashboard_auth.py` never resolves them. The gate was unsatisfiable for its intended caller.

The same line failed the other way on self-hosted: a dashboard session cookie sets `full_access`, so any signed-in user — member role included — could rotate a widget token or delete a widget.

## The change

Both directions close with one swap. The two GETs take `_require_paw_bar_read`, the seven mutations take `_require_paw_bar_manage` — the `paw_bar.read` / `paw_bar.manage` pair that the D2 reads and the knowledge endpoints in this same router already use, both already ADMIN in `guards/actions.py`. No new actions, no matrix change. `_require_paw_bar_manage` moves up beside its read sibling because widget CRUD is now its first caller.

The file already documented this as the intended direction — `_require_paw_bar_read`'s comment says it "replaces the coarse `require_scope("admin")`". The migration was started and left half-done; this finishes it.

## Worth knowing before merge

**This is stricter than what it replaced.** An admin-scoped OSS API key or `ppat_` token no longer opens these routes; only workspace role does. That matches the eight sibling routes already gated this way, and this router only ever mounts via `mount_cloud()` — but if anything automates paw-bar with an API key today, it will need a session instead.

**The existing tests could not have caught this.** `tests/conftest.py:93` sets `_TESTING_FULL_ACCESS = True` for the whole suite, which makes `require_scope` a no-op that admits everyone. That is how this shipped with the settings surface fully covered. The new tests carry the `enforce_scope` marker to opt out.

## Verification

Reverting just the settings PATCH back to the scope gate fails three of the new tests, one with the exact reported 403:

```
FAILED test_admin_role_can_patch_the_kill_switch[admin]
FAILED test_admin_role_can_patch_the_kill_switch[owner]
FAILED test_member_role_cannot_patch_the_kill_switch
3 failed, 21 passed
```

Restored: `24 passed`. Across the five touched test files, the failure set is identical at base and on this branch — 9 pre-existing preamble failures, zero new.

Six test files pinned a workspace but not a role; they now pin both, via a shared `override_workspace_role` helper in `tests/cloud/conftest.py`. It overrides identity only — the RBAC guard still runs for real.

Part of a wider audit of `require_scope` reachability. The remaining gates are process-global platform surfaces where superuser-only is correct; they are not touched here.