### PR TITLE
Declare who owns each UI-exposed setting

### DIFF
--- a/src/pocketpaw/config_tiers.py
+++ b/src/pocketpaw/config_tiers.py
@@ -1,0 +1,229 @@
+# Field ownership registry for Settings — declares which tier owns each
+# UI-exposed setting.
+#
+# Changes:
+#   - 2026-08-16: Initial implementation. Declaration only: this module maps
+#     field name -> owning tier and names the tenant-secret fields that stay
+#     blocked. It builds no storage, no endpoints, and no resolver — nothing
+#     reads TIER_OF yet, so shipping it changes zero runtime behaviour.
+
+"""Who owns each ``Settings`` field.
+
+``Settings`` is a process-global Pydantic model persisted to a single
+``~/.pocketpaw/config.json``. The paw-enterprise frontend exposes 55 of its
+fields across settings pages grouped under ACCOUNT and WORKSPACE headings, but
+every one of them writes that same global file via ``PUT /api/v1/settings``. On
+a shared deployment one user changing their theme changes it for everyone, and
+"workspace" settings are not per-workspace at all.
+
+The eventual fix is a three-tier resolver
+(``user.preferences[f] ?? workspace.settings[f] ?? Settings.f``). This module is
+step one of that work and only step one: it records *who owns what*, so the
+storage, endpoints, and resolver that follow have one place to agree on.
+
+The three tiers
+---------------
+
+``Tier.USER``
+    Belongs to the signed-in human and follows them across workspaces — theme,
+    avatar, notification and sound toggles.
+
+``Tier.WORKSPACE``
+    Belongs to the tenant: memory and embedding choices, voice and search
+    providers, PII and injection scan policy, compaction tuning.
+
+``Tier.PLATFORM``
+    Belongs to the operator's box: filesystem paths, auth and rate limits,
+    process behaviour, and the platform's own third-party credentials. A tenant
+    must never set these.
+
+Completeness is enforced over the UI-EXPOSED set, not all 326 fields
+------------------------------------------------------------------
+
+``TIER_OF`` deliberately holds 55 entries, not one per ``Settings`` field. The
+55 are exactly the fields the frontend renders (each one carries a
+``fieldKey="..."`` in ``paw-enterprise/src/routes/settings/``), and those are the
+only fields a tenant can reach today. Classifying the other ~271 would be
+speculation about surfaces that do not exist. The test suite enforces the
+correspondence in both directions, so a new settings control added to the
+frontend fails CI until its owner is declared here.
+
+Why an unlisted field defaults to PLATFORM
+------------------------------------------
+
+``tier_of()`` returns ``Tier.PLATFORM`` for anything absent from ``TIER_OF``.
+That is the safe default, and it is chosen rather than inherited: PLATFORM means
+"only the operator's own config file sets this", which is precisely today's
+behaviour for every field. A missing entry therefore preserves the status quo
+and can never accidentally hand a tenant write access to something it should not
+have. The failure mode of forgetting a field is "a tenant cannot customise it
+yet" — inconvenient, and visible. The opposite default would fail silently and
+in the dangerous direction.
+
+The ``default_workspace_dir`` trap
+----------------------------------
+
+``default_workspace_dir`` renders on the *preferences* page, sitting among the
+theme and notification controls that are genuinely per-user. It is not a
+preference. It is the agent's working directory on the server's filesystem, so
+it is PLATFORM. Page grouping in the frontend reflects where a control was
+convenient to put, not who owns it — classify by what the field *does*.
+``vectordb_path`` and ``media_download_dir`` are server paths for the same
+reason.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class Tier(StrEnum):
+    """The owner of a settings field."""
+
+    USER = "user"
+    WORKSPACE = "workspace"
+    PLATFORM = "platform"
+
+
+# ---------------------------------------------------------------------------
+# USER — follows the signed-in human across workspaces
+# ---------------------------------------------------------------------------
+
+_USER_FIELDS: frozenset[str] = frozenset(
+    {
+        "theme_preference",
+        "user_avatar_emoji",
+        "notifications_enabled",
+        "sound_enabled",
+        "tool_notifications_enabled",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# PLATFORM — the operator's box. Filesystem paths, auth and rate limits,
+# process behaviour, and the platform's own third-party credentials.
+# ---------------------------------------------------------------------------
+
+_PLATFORM_FIELDS: frozenset[str] = frozenset(
+    {
+        # Server filesystem paths. default_workspace_dir renders on the
+        # preferences page — see the module docstring's trap note.
+        "default_workspace_dir",
+        "media_download_dir",
+        "media_max_file_size_mb",
+        # Auth and rate limiting.
+        "session_token_ttl_hours",
+        "api_rate_limit_per_key",
+        # Process behaviour.
+        "health_check_on_startup",
+        "self_audit_enabled",
+        "self_audit_schedule",
+        "a2a_enabled",
+        "a2a_agent_name",
+        "a2a_task_timeout",
+        # The platform's own third-party credentials, billed to the operator.
+        "google_oauth_client_id",
+        "google_oauth_client_secret",
+        "spotify_client_id",
+        "spotify_client_secret",
+        "google_api_key",
+        # OCR runs against a platform credential or a locally installed
+        # tesseract binary, so the choice is the operator's.
+        "ocr_provider",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# WORKSPACE — the tenant's own choices
+# ---------------------------------------------------------------------------
+
+_WORKSPACE_FIELDS: frozenset[str] = frozenset(
+    {
+        # Memory and embedding.
+        "memory_backend",
+        "memory_use_inference",
+        "vectordb_path",
+        "file_auto_learn",
+        "file_vector_enabled",
+        "vector_store",
+        "embedding_provider",
+        "embedding_model",
+        "mem0_llm_provider",
+        "mem0_llm_model",
+        "mem0_embedder_provider",
+        "mem0_embedder_model",
+        "mem0_auto_learn",
+        # Compaction tuning.
+        "compaction_recent_window",
+        "compaction_char_budget",
+        "compaction_llm_summarize",
+        # Voice.
+        "tts_provider",
+        "tts_voice",
+        "voice_reply_enabled",
+        "stt_provider",
+        "stt_model",
+        "sarvam_tts_language",
+        "elevenlabs_api_key",
+        "sarvam_api_key",
+        # Search and image generation.
+        "web_search_provider",
+        "tavily_api_key",
+        "brave_search_api_key",
+        "image_model",
+        # PII and injection scan policy.
+        "pii_default_action",
+        "pii_scan_memory",
+        "pii_scan_audit",
+        "injection_scan_llm",
+        "injection_scan_llm_model",
+    }
+)
+
+
+TIER_OF: dict[str, Tier] = {
+    **{field: Tier.USER for field in _USER_FIELDS},
+    **{field: Tier.WORKSPACE for field in _WORKSPACE_FIELDS},
+    **{field: Tier.PLATFORM for field in _PLATFORM_FIELDS},
+}
+
+
+# ---------------------------------------------------------------------------
+# Tenant secrets — classified, but not yet offered
+# ---------------------------------------------------------------------------
+
+# These four are in ``pocketpaw.credentials.SECRET_FIELDS`` and are classified
+# WORKSPACE above, which is the correct long-term ownership: they are the
+# tenant's own API keys, billed to the tenant, and a tenant should be able to
+# bring its own.
+#
+# They must NOT be offered at the tenant tier until encryption at rest is
+# settled. Today's secret storage encrypts with a key derived from machine
+# identity into the operator's own ~/.pocketpaw/secrets.enc — a threat model
+# that assumes one operator holding their own keys. Per-tenant secrets in a
+# shared database are a different threat model: many mutually-untrusting
+# tenants, keys that must stay unreadable to each other and to a database
+# backup. That work does not exist yet.
+#
+# The entries stay in the WORKSPACE mapping on purpose. The intent is recorded
+# so the eventual resolver does not have to rediscover it; the exposure is
+# blocked separately. Deleting them here would silently promote them.
+TENANT_SECRETS_BLOCKED: frozenset[str] = frozenset(
+    {
+        "elevenlabs_api_key",
+        "sarvam_api_key",
+        "tavily_api_key",
+        "brave_search_api_key",
+    }
+)
+
+
+def tier_of(field: str) -> Tier:
+    """Return the tier that owns ``field``.
+
+    Anything not explicitly classified is PLATFORM — the safe default, which
+    preserves today's behaviour. See the module docstring for why.
+    """
+    return TIER_OF.get(field, Tier.PLATFORM)

--- a/tests/test_config_tiers.py
+++ b/tests/test_config_tiers.py
@@ -1,0 +1,178 @@
+# Tests for the Settings field ownership registry (config_tiers.py).
+#
+# Changes:
+#   - 2026-08-16: Initial implementation. Covers the four drift risks: a field
+#     renamed in config.py, a miscount from a field landing in two tiers, the
+#     unlisted-field default, and a new frontend control shipped without an
+#     owner. The last of those reads the sibling paw-enterprise repo and skips
+#     when it is absent, so CI without it stays green.
+
+"""Tests for the three-tier field ownership registry."""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+from pocketpaw.config import Settings
+from pocketpaw.config_tiers import TENANT_SECRETS_BLOCKED, TIER_OF, Tier, tier_of
+from pocketpaw.credentials import SECRET_FIELDS
+
+
+def _fields_in(tier: Tier) -> set[str]:
+    """The registry's own view of a tier — derived from the exported mapping.
+
+    Deliberately not the private per-tier frozensets that build ``TIER_OF``:
+    the mapping is what the resolver will read, so it is what gets asserted.
+    """
+    return {field for field, owner in TIER_OF.items() if owner is tier}
+
+
+class TestRegistryIntegrity:
+    """The registry must describe fields that actually exist."""
+
+    def test_every_registered_field_exists_on_settings(self):
+        """Catches typos, and catches a field renamed in config.py later."""
+        unknown = sorted(set(TIER_OF) - set(Settings.model_fields))
+        assert unknown == [], f"registered but not a Settings field: {unknown}"
+
+    def test_registry_has_55_entries(self):
+        """The UI-exposed set. Not one entry per Settings field — see the docstring."""
+        assert len(TIER_OF) == 55
+
+    def test_per_tier_counts(self):
+        """A field landing in two tiers would silently shift these."""
+        assert len(_fields_in(Tier.USER)) == 5
+        assert len(_fields_in(Tier.WORKSPACE)) == 33
+        assert len(_fields_in(Tier.PLATFORM)) == 17
+
+    def test_tiers_partition_the_registry(self):
+        """Every entry is one of the three tiers, and they sum to the whole."""
+        total = sum(len(_fields_in(tier)) for tier in Tier)
+        assert total == len(TIER_OF)
+
+
+class TestTierOf:
+    """The lookup helper, including its safe default."""
+
+    def test_unlisted_field_defaults_to_platform(self):
+        """The safe default: unclassified means operator-only, i.e. today's behaviour."""
+        assert "anthropic_api_key" not in TIER_OF
+        assert tier_of("anthropic_api_key") is Tier.PLATFORM
+
+    def test_field_that_does_not_exist_at_all_is_platform(self):
+        """Fails closed rather than raising."""
+        assert tier_of("no_such_field_anywhere") is Tier.PLATFORM
+
+    def test_known_user_field(self):
+        assert tier_of("theme_preference") is Tier.USER
+
+    def test_known_workspace_field(self):
+        assert tier_of("memory_backend") is Tier.WORKSPACE
+
+    def test_known_platform_field(self):
+        assert tier_of("api_rate_limit_per_key") is Tier.PLATFORM
+
+    def test_default_workspace_dir_is_platform_not_user(self):
+        """The trap: it renders on the preferences page but is a server path."""
+        assert tier_of("default_workspace_dir") is Tier.PLATFORM
+
+
+class TestTenantSecretsBlocked:
+    """Secret-bearing WORKSPACE fields stay classified but unexposed."""
+
+    def test_blocked_secrets_are_classified_workspace(self):
+        assert TENANT_SECRETS_BLOCKED <= _fields_in(Tier.WORKSPACE)
+
+    def test_blocked_secrets_are_real_secrets(self):
+        assert TENANT_SECRETS_BLOCKED <= SECRET_FIELDS
+
+    def test_every_workspace_secret_is_blocked(self):
+        """No WORKSPACE field may carry a secret without being on the blocklist.
+
+        Without this, adding the next tenant-supplied API key to the WORKSPACE
+        tier would quietly expose it at a tier that has no encryption at rest.
+        """
+        workspace_secrets = _fields_in(Tier.WORKSPACE) & SECRET_FIELDS
+        assert workspace_secrets == set(TENANT_SECRETS_BLOCKED)
+
+    def test_no_user_tier_secrets(self):
+        """Nothing at the USER tier may carry a secret."""
+        assert _fields_in(Tier.USER) & SECRET_FIELDS == set()
+
+
+# ---------------------------------------------------------------------------
+# Completeness gate against the frontend
+# ---------------------------------------------------------------------------
+
+_FIELD_KEY_RE = re.compile(r'fieldKey="([a-zA-Z0-9_]+)"')
+
+
+_SETTINGS_ROUTES = Path("src") / "routes" / "settings"
+
+
+def _paw_enterprise_settings_dir() -> Path | None:
+    """Locate the sibling paw-enterprise settings routes, or None if absent.
+
+    paw-enterprise is a separate repo checked out beside pocketpaw. It is not
+    present in every checkout or CI environment, so this gate skips rather than
+    fails when it is missing.
+
+    ``PAW_ENTERPRISE_DIR`` overrides the search and should point at the repo
+    root. Without it, every ancestor of this file is checked for a
+    ``paw-enterprise`` sibling — the plain checkout has one two levels up, and a
+    git worktree of pocketpaw sits at a different depth.
+    """
+    override = os.environ.get("PAW_ENTERPRISE_DIR")
+    if override:
+        candidate = Path(override) / _SETTINGS_ROUTES
+        return candidate if candidate.is_dir() else None
+
+    for ancestor in Path(__file__).resolve().parents:
+        candidate = ancestor / "paw-enterprise" / _SETTINGS_ROUTES
+        if candidate.is_dir():
+            return candidate
+    return None
+
+
+def _ui_field_keys(settings_dir: Path) -> set[str]:
+    keys: set[str] = set()
+    for path in settings_dir.rglob("*.svelte"):
+        keys.update(_FIELD_KEY_RE.findall(path.read_text(encoding="utf-8")))
+    return keys
+
+
+class TestFrontendCompleteness:
+    """Every field the frontend exposes must have a declared owner."""
+
+    def test_every_ui_field_key_is_classified(self):
+        settings_dir = _paw_enterprise_settings_dir()
+        if settings_dir is None:
+            pytest.skip(
+                "sibling repo paw-enterprise not checked out beside pocketpaw; "
+                "the frontend completeness gate needs its src/routes/settings/"
+            )
+
+        ui_keys = _ui_field_keys(settings_dir)
+        assert ui_keys, f"no fieldKey= attributes found under {settings_dir} — regex drift?"
+
+        unclassified = sorted(ui_keys - set(TIER_OF))
+        assert unclassified == [], (
+            f"settings controls exposed by the frontend with no declared owner: "
+            f"{unclassified}. Add each to TIER_OF in src/pocketpaw/config_tiers.py."
+        )
+
+    def test_registry_does_not_outrun_the_ui(self):
+        """The other direction: a stale entry for a control the UI dropped."""
+        settings_dir = _paw_enterprise_settings_dir()
+        if settings_dir is None:
+            pytest.skip("sibling repo paw-enterprise not checked out beside pocketpaw")
+
+        stale = sorted(set(TIER_OF) - _ui_field_keys(settings_dir))
+        assert stale == [], (
+            f"registered but no longer exposed by the frontend: {stale}. "
+            f"Either the control was removed or its fieldKey was renamed."
+        )

--- a/tests/test_config_tiers.py
+++ b/tests/test_config_tiers.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import os
 import re
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -123,15 +124,45 @@ def _paw_enterprise_settings_dir() -> Path | None:
 
     ``PAW_ENTERPRISE_DIR`` overrides the search and should point at the repo
     root. Without it, every ancestor of this file is checked for a
-    ``paw-enterprise`` sibling — the plain checkout has one two levels up, and a
-    git worktree of pocketpaw sits at a different depth.
+    ``paw-enterprise`` sibling.
+
+    The ancestor walk alone is not enough, and the reason is worth stating: a
+    git worktree of pocketpaw lives OUTSIDE the workspace (``D:/paw-worktrees/
+    settings-field-tiers``), so no ancestor of it holds a ``paw-enterprise``
+    sibling and the walk returns None. The gate then skips — silently, and
+    exactly in the setup an implementer working on a feature branch uses. A
+    completeness gate that no-ops in the common case is decoration.
+
+    So the worktree case is resolved explicitly: ask git for the main
+    checkout's path (``git rev-parse --path-format=absolute --git-common-dir``
+    points at ``<main>/.git`` even from a linked worktree) and look for the
+    sibling beside that.
     """
     override = os.environ.get("PAW_ENTERPRISE_DIR")
     if override:
         candidate = Path(override) / _SETTINGS_ROUTES
         return candidate if candidate.is_dir() else None
 
-    for ancestor in Path(__file__).resolve().parents:
+    here = Path(__file__).resolve()
+    roots = list(here.parents)
+
+    # A linked worktree's ancestors don't include the workspace, so resolve the
+    # main checkout via git and search from there too.
+    try:
+        common = subprocess.run(
+            ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            cwd=here.parent,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        if common.returncode == 0 and common.stdout.strip():
+            roots.extend(Path(common.stdout.strip()).resolve().parents)
+    except (OSError, subprocess.SubprocessError):  # pragma: no cover - git absent
+        pass
+
+    for ancestor in roots:
         candidate = ancestor / "paw-enterprise" / _SETTINGS_ROUTES
         if candidate.is_dir():
             return candidate


### PR DESCRIPTION
## Why

`Settings` is a process-global Pydantic model persisted to a single `~/.pocketpaw/config.json`. The paw-enterprise frontend exposes 55 of its fields across pages grouped under **ACCOUNT** and **WORKSPACE** headings — but every one of them writes that same global file via `PUT /api/v1/settings`.

So on a shared deployment, one user changing their theme changes it for everyone, and "workspace" settings are not per-workspace at all. `WorkspaceSettings`, the real per-tenant model, holds three fields; `User` has no preferences field.

Nobody has hit this because `require_scope("settings:write")` is currently unsatisfiable for cloud tenants, so those pages 403 on every save. The permission bug has been containing a data-ownership bug.

## What this is

Step one, and only step one: a registry that records **who owns what**. No storage, no endpoints, no resolver — nothing reads `TIER_OF` yet, so this changes zero runtime behaviour.

- **USER (5)** — follows the human across workspaces: theme, avatar, notification and sound toggles.
- **WORKSPACE (33)** — the tenant's own: memory and embedding choices, voice and search providers, PII and injection scan policy, compaction tuning.
- **PLATFORM (17)** — the operator's box: filesystem paths, auth and rate limits, process behaviour, and the platform's own third-party credentials.

Anything unlisted resolves to PLATFORM. That default is chosen rather than inherited: PLATFORM means "only the operator's config file sets this", which is exactly today's behaviour for every field. Forgetting a field means a tenant cannot customise it yet — inconvenient and visible. The opposite default would fail silently in the dangerous direction.

## Two things worth reading

**`default_workspace_dir` is the trap.** It renders on the *preferences* page, among genuinely per-user controls, and it is the agent's working directory on the server's filesystem. PLATFORM. Page grouping reflects where a control was convenient to put, not who owns it — classify by what the field does. `vectordb_path` and `media_download_dir` are server paths for the same reason.

**Four tenant secrets are classified but blocked.** `elevenlabs_api_key`, `sarvam_api_key`, `tavily_api_key` and `brave_search_api_key` are correctly WORKSPACE — they are the tenant's own keys, billed to the tenant. But today's secret storage encrypts against machine identity into the operator's own `secrets.enc`, a threat model that assumes one operator holding their own keys. Per-tenant secrets in a shared database are a different problem, and that work does not exist yet. `TENANT_SECRETS_BLOCKED` names them so the eventual resolver does not have to rediscover the intent; deleting them from the mapping would silently promote them later.

## Verification

`16 passed`. The frontend completeness gate scans `paw-enterprise/src/routes/settings/` for `fieldKey="..."` and fails if any exposed field lacks an owner, so a new settings control breaks CI until someone declares its tier.

That gate initially skipped inside a git worktree — those live outside the workspace, so the ancestor walk never finds the sibling repo, which is precisely the setup a feature branch uses. It now resolves the main checkout via `git rev-parse --git-common-dir`. Confirmed by deleting a field from the registry: three tests fail, including the frontend check.