### PR TITLE
The code-review fixes, rebased onto the new integration tip

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/growth.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/growth.py
@@ -616,7 +616,6 @@ async def _upsert_prospect_handler(args: dict) -> dict:
         if isinstance(emails, list)
         else None
     )
-    opted_in = args.get("opted_in") if isinstance(args.get("opted_in"), bool) else None
 
     try:
         # Build once to canonicalise the domain (the DTO validator strips the
@@ -663,7 +662,13 @@ async def _upsert_prospect_handler(args: dict) -> dict:
             emails=_pick(emails, "emails", []),
             linkedin_url=_pick(_opt_str(args, "linkedin_url"), "linkedin_url", None),
             whatsapp_number=_pick(_opt_str(args, "whatsapp_number"), "whatsapp_number", None),
-            opted_in=_pick(opted_in, "opted_in", False),
+            # NEVER from the agent. opted_in is the flag whatsapp.py checks
+            # before a business-initiated send, so an agent that could set it
+            # could manufacture the consent a human is meant to verify — the
+            # Tray card shows channel and copy, never opt-in provenance. It is
+            # carried forward from the stored row and is otherwise only
+            # settable by a human through PATCH /growth/prospects/{id}.
+            opted_in=bool(getattr(existing, "opted_in", False)),
             # NOT settable by the agent. The outbound lifecycle is driven by
             # what happens to the prospect (a draft written, a reply received,
             # the sweep giving up), never by an argument in a research call.
@@ -969,10 +974,6 @@ def _build_tools() -> list[Any] | None:
                 "emails": {"type": "array", "items": {"type": "string"}},
                 "linkedin_url": {"type": "string"},
                 "whatsapp_number": {"type": "string"},
-                "opted_in": {
-                    "type": "boolean",
-                    "description": "Whether the prospect opted in to WhatsApp contact.",
-                },
             },
             "required": ["domain"],
             "additionalProperties": False,

--- a/ee/pocketpaw_ee/cloud/growth/msg91.py
+++ b/ee/pocketpaw_ee/cloud/growth/msg91.py
@@ -55,6 +55,20 @@ _OUTBOUND_PATH = "/api/v5/whatsapp/whatsapp-outbound-message/bulk/"
 _REQUEST_TIMEOUT_SECONDS = 30
 
 
+def _scrub(text: str, secret: str) -> str:
+    """Remove the authkey from provider text before it is raised or stored.
+
+    Mirrors ``connector._scrub`` and exists for the same reason: an MSG91
+    error body can echo the request headers back, and an authkey that took a
+    round trip through their error path is still an authkey. Without this, a
+    401 whose body quotes the submitted key landed verbatim in a durable
+    MessageLog row (``whatsapp.py`` writes ``exc.message`` as ``error``).
+    """
+    if secret and secret in text:
+        text = text.replace(secret, "***")
+    return text
+
+
 class Msg91Error(Exception):
     """The provider refused or failed the send.
 
@@ -256,12 +270,12 @@ class Msg91WhatsAppClient:
         if resp.status_code >= 400:
             raise Msg91Error(
                 "msg91.http_error",
-                f"MSG91 returned {resp.status_code}: {resp.text[:300]}",
+                f"MSG91 returned {resp.status_code}: {_scrub(resp.text[:300], creds.authkey)}",
             )
-        return _extract_message_id(resp)
+        return _extract_message_id(resp, creds.authkey)
 
 
-def _extract_message_id(resp: Any) -> str:
+def _extract_message_id(resp: Any, authkey: str = "") -> str:
     """Best-effort provider message id out of an MSG91 2xx response.
 
     MSG91 has shipped several 2xx envelopes over the v5 lifetime; the id is not
@@ -277,7 +291,9 @@ def _extract_message_id(resp: Any) -> str:
         return ""
     status = str(data.get("status") or data.get("type") or "").lower()
     if status in ("error", "fail", "failure"):
-        raise Msg91Error("msg91.rejected", f"MSG91 rejected the send: {str(data)[:300]}")
+        raise Msg91Error(
+            "msg91.rejected", f"MSG91 rejected the send: {_scrub(str(data)[:300], authkey)}"
+        )
     inner = data.get("data")
     if isinstance(inner, dict):
         for key in ("message_id", "messageId", "request_id", "requestId", "id"):

--- a/ee/pocketpaw_ee/cloud/growth/researcher.py
+++ b/ee/pocketpaw_ee/cloud/growth/researcher.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+from datetime import UTC, datetime
 from typing import Any
 
 from pocketpaw_ee.cloud.growth.discovery import (
@@ -49,6 +50,23 @@ from pocketpaw_ee.cloud.growth.discovery import (
 from pocketpaw_ee.cloud.growth.domain import EmailEvidence
 
 logger = logging.getLogger(__name__)
+
+
+class ResearchUnavailable(RuntimeError):
+    """The research could not run at all — distinct from running and finding nobody.
+
+    RAISED rather than returned as an empty ``ResearchResult``, because
+    ``_research`` turns an exception into ``DiscoveryOutcome.error`` and the
+    sweep counts an errored run as ``skipped`` instead of ``ran``.
+
+    An earlier version returned an empty result with the reason in ``notes``,
+    and nothing read ``notes``: a workspace that had never seeded the
+    researcher agent was counted as a successful run every single day, with
+    ``last_run_at`` advancing, so the one field whose stated purpose is
+    answering "is this thing actually running?" said yes forever. The only
+    signal was a warning line in a worker log.
+    """
+
 
 # The agent's slug. Resolved per workspace at run time — a workspace without
 # the agent seeded gets a clean "not available" rather than a crash.
@@ -111,31 +129,24 @@ retainer" is useful; "innovative digital agency" is noise.
 
 ## How to answer
 
-Return ONLY a JSON object, no prose around it, in exactly this shape:
+Return ONLY a JSON object, no prose around it, no fenced block, and do not \
+restate this shape back to me. The fields, described rather than shown — the \
+angle brackets are placeholders, not literal text:
 
-{
-  "companies": [
-    {
-      "domain": "example.com",
-      "company": "Example Ltd",
-      "name": "contact person's name, or empty string if you did not find one",
-      "research_brief": "what they do, why they fit, what the hook is",
-      "source_urls": ["https://example.com/about"],
-      "emails": [
-        {
-          "address": "hello@example.com",
-          "confidence": "observed",
-          "source_url": "https://example.com/contact"
-        }
-      ]
-    }
-  ],
-  "notes": "anything about the search itself worth logging"
-}
+  companies      a list, one entry per company, each with:
+    domain           <the company's website domain — REQUIRED>
+    company          <the company name>
+    name             <the contact person, or "" if you did not find one>
+    research_brief   <what they do, why they fit, what the hook is>
+    source_urls      <list of the page URLs you actually read>
+    emails           <list, usually EMPTY; one entry per address you SAW, each
+                      with: address, confidence (the literal string "observed"),
+                      and source_url — the page you read it on>
+  notes          <anything about the search itself worth logging>
 
-`domain` is the only required field. `emails` is usually an empty list — that \
-is normal. `notes` is for the run log ("three directories were paywalled"), \
-never a claim about a specific company.
+`domain` is the only required field. `emails` being an empty list is the normal \
+case, not a failure. `notes` is for the run log ("three directories were \
+paywalled"), never a claim about a specific company.
 """
 
 # The agent, as data. Seed this into a workspace to make discovery available
@@ -213,12 +224,22 @@ def _extract_json(text: str) -> dict[str, Any] | None:
 
     if not objects:
         return None
-    # The answer is the object shaped like an answer. Falling back to the first
-    # decodable object keeps a model that renamed the key from costing the run.
-    for obj in objects:
+    # The LAST qualifying object wins, not the first.
+    #
+    # This is the fix for a reproduced bug, so it is worth being explicit about
+    # why. The prompt used to carry a fully-valid JSON example — complete with
+    # an "observed" email on example.com — and this loop took the FIRST object
+    # with a ``companies`` key. A model that restated the shape before
+    # answering therefore had its own template parsed as the research: the real
+    # findings were discarded and a fabricated prospect was filed carrying an
+    # address nobody had ever seen. The prompt no longer contains parseable
+    # JSON, and this picks the last candidate, so a preamble cannot shadow the
+    # answer even if one reappears. Two independent guards, because the thing
+    # they protect is the one guarantee this module claims to be structural.
+    for obj in reversed(objects):
         if "companies" in obj:
             return obj
-    return objects[0]
+    return objects[-1]
 
 
 def _evidence_from(raw: Any) -> EmailEvidence | None:
@@ -241,6 +262,17 @@ def _evidence_from(raw: Any) -> EmailEvidence | None:
         return None
     confidence = str(raw.get("confidence") or "").strip().lower()
     if not confidence:
+        return None
+    # Shape-check the address itself. `.strip()` only trims the ends, and
+    # `recordable_emails` checks provenance, not syntax — so without this a
+    # plausible extraction artifact like "hello@x.com\nbilling@x.com" (two
+    # addresses on adjacent lines of a contact page) passes every guard and is
+    # stored as ONE address, which the dispatch path then hands to the provider
+    # as a recipient. Exactly one @, no whitespace, something on each side.
+    if any(ch.isspace() for ch in address) or address.count("@") != 1:
+        return None
+    local, _, host = address.partition("@")
+    if not local or "." not in host:
         return None
     return EmailEvidence(address=address, confidence=confidence, seen_at_url=source_url)
 
@@ -331,16 +363,21 @@ async def agent_research(request: ResearchRequest) -> ResearchResult:
             request.workspace_id,
             GROWTH_RESEARCHER_SLUG,
         )
-        return ResearchResult(notes="no researcher agent is available in this workspace")
+        raise ResearchUnavailable("no researcher agent is seeded in this workspace")
     agent_id = str(getattr(agent, "id", "") or "")
     if not agent_id:
-        return ResearchResult(notes="no researcher agent is available in this workspace")
+        raise ResearchUnavailable("no researcher agent is seeded in this workspace")
 
     prompt = build_research_prompt(request)
-    # One session per ICP run. Deliberately not a stable per-ICP key: a hunt
-    # that ran yesterday must not carry yesterday's page reads into today's
-    # judgement — each run should stand on what it read this time.
-    session_key = f"growth-discovery:{request.workspace_id}:{request.icp_id}"
+    # One session per RUN, not per ICP. The timestamp is the whole point: an
+    # earlier version keyed on (workspace, icp) alone while claiming in this
+    # very comment to do otherwise, which meant every daily run RESUMED the
+    # previous one. The model saw its own last answer in context and the
+    # natural completion became "I already reported those" — so a hunt filed
+    # nothing from day two onward while last_run_at kept advancing, and the
+    # session's context grew without bound.
+    stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%S%f")
+    session_key = f"growth-discovery:{request.workspace_id}:{request.icp_id}:{stamp}"
 
     chunks: list[str] = []
     try:
@@ -369,7 +406,7 @@ async def agent_research(request: ResearchRequest) -> ResearchResult:
             request.icp_id,
             request.workspace_id,
         )
-        return ResearchResult(notes="the research run failed")
+        raise ResearchUnavailable("the research run failed")
 
     return parse_research_response("".join(chunks), max_results=request.max_results)
 
@@ -379,6 +416,7 @@ __all__ = [
     "GROWTH_RESEARCHER_PROMPT",
     "GROWTH_RESEARCHER_SLUG",
     "GROWTH_RESEARCHER_TOOLS",
+    "ResearchUnavailable",
     "agent_research",
     "build_research_prompt",
     "parse_research_response",

--- a/ee/pocketpaw_ee/cloud/growth/researcher.py
+++ b/ee/pocketpaw_ee/cloud/growth/researcher.py
@@ -271,8 +271,25 @@ def _evidence_from(raw: Any) -> EmailEvidence | None:
     # as a recipient. Exactly one @, no whitespace, something on each side.
     if any(ch.isspace() for ch in address) or address.count("@") != 1:
         return None
+    if len(address) > 254:  # RFC 5321 ceiling; anything longer is not an address
+        return None
     local, _, host = address.partition("@")
-    if not local or "." not in host:
+    if not local or len(local) > 64:
+        return None
+    # Angle brackets and quotes are the ones that MATTER here: the rest of the
+    # malformed forms simply bounce, but a local part carrying <> or " can
+    # alter a constructed header rather than merely fail. The others are still
+    # refused because a preventable bounce lands on the shared sending
+    # domain's reputation, which is the whole reason this guard exists.
+    if any(ch in address for ch in '<>"\\,;:()[]'):
+        return None
+    # Host must be label-wise well formed: every dot-separated label non-empty,
+    # and a real alphabetic TLD. `"." in host` alone admitted `a@b.`, `a@.com`
+    # and `a@b..com`.
+    labels = host.split(".")
+    if len(labels) < 2 or not all(labels):
+        return None
+    if not labels[-1].isalpha() or len(labels[-1]) < 2:
         return None
     return EmailEvidence(address=address, confidence=confidence, seen_at_url=source_url)
 

--- a/ee/pocketpaw_ee/cloud/growth/service.py
+++ b/ee/pocketpaw_ee/cloud/growth/service.py
@@ -1757,12 +1757,12 @@ async def prospect_exists_by_domain(workspace_id: str, domain: str) -> bool:
 
     1. Finding a company you already have is not a discovery. Filing it again
        would spend the run's ``max_per_run`` budget on nothing.
-    2. ``upsert_by_domain`` overwrites ``status`` on an existing row — correct
-       for a human re-importing a list, wrong for a DAILY CRON. A prospect
-       sitting at ``in_sequence`` with two sent drafts would be reset to
-       ``new`` by a re-find, and the follow-up sweep would lose the thread.
-       Skipping known domains means discovery only ever INSERTS, so no
-       automated pass can walk a live prospect backwards.
+    2. Discovery only ever INSERTS, so no automated pass touches a live
+       prospect at all. ``upsert_by_domain`` no longer walks ``status``
+       backwards on its own (it is set-only since the review fixes), so this
+       is now defence in depth rather than the sole protection — but the
+       property worth keeping is the stronger one: a daily cron should not be
+       able to edit a prospect a human is working, by any route.
 
     Normalises the domain the same way the DTO does, so a research result
     naming ``https://www.Acme.com/about`` matches the stored ``acme.com``.

--- a/ee/pocketpaw_ee/cloud/growth/service.py
+++ b/ee/pocketpaw_ee/cloud/growth/service.py
@@ -743,18 +743,30 @@ async def upsert_by_domain(
         # no-event: growth has no realtime subscriber in v1.
         return _to_response(_to_domain(doc))
 
-    for field in (
-        "name",
-        "company",
-        "tier",
-        "research_brief",
-        "emails",
-        "linkedin_url",
-        "whatsapp_number",
-        "opted_in",
-        "status",
-    ):
+    # Fields a re-import may OVERWRITE. Everything omitted from this tuple is
+    # deliberate, not forgotten.
+    for field in ("name", "company", "tier", "research_brief", "whatsapp_number"):
         setattr(doc, field, getattr(body, field))
+
+    # ``status`` and ``opted_in`` are LIFECYCLE, not import data, and the DTO
+    # defaults them to "new" / False. Overwriting them meant re-uploading last
+    # month's CSV to the bulk route — the one whose docstring calls a re-run
+    # safe — revived every prospect the sweep had retired to ``dead`` and every
+    # one that had ``replied``, then the sweep re-entered the sequence on
+    # people it had deliberately given up on, including anyone marked dead for
+    # asking not to be contacted. A re-import must never resurrect.
+    if body.status != "new":
+        doc.status = body.status
+    if body.opted_in:
+        doc.opted_in = True
+
+    # ``emails`` / ``linkedin_url`` are set-only for the same reason
+    # ``project_id`` is below: a row that says nothing about them must not
+    # erase enrichment a later pass (or a human) added.
+    if body.emails:
+        doc.emails = body.emails
+    if body.linkedin_url:
+        doc.linkedin_url = body.linkedin_url
     # ``project_id`` is one of the fields an upsert only ever SETS, never
     # clears. A re-import that names a project reassigns the row; one that says
     # nothing leaves the assignment alone. The alternative — treating the DTO's
@@ -1791,8 +1803,14 @@ async def list_due_icps(cadences: list[str], *, limit: int = 500) -> list[IcpRes
     the cron cannot run something a human switched off.
     """
     docs = (
+        # Sorted by last_run_at ASCENDING (missing sorts first in Mongo), so
+        # the workspace that has genuinely waited longest is served first.
+        # ``createdAt`` was the wrong key: it is immutable, so when the batch
+        # cap bit, the SAME newest ICPs were skipped every single day rather
+        # than the starvation rotating. A deployment with more weekly ICPs than
+        # the cap could leave newer daily hunts permanently unrun.
         await _IcpDoc.find({"status": "active", "cadence": {"$in": cadences}})
-        .sort([("createdAt", 1), ("_id", 1)])
+        .sort([("last_run_at", 1), ("_id", 1)])
         .limit(limit)
         .to_list()
     )
@@ -1894,6 +1912,7 @@ async def record_whatsapp_attempt(
 async def finish_whatsapp_attempt(
     log_id: str,
     *,
+    workspace_id: str,
     status: str,
     provider_message_id: str = "",
     error_code: str = "",
@@ -1909,7 +1928,12 @@ async def finish_whatsapp_attempt(
         oid = PydanticObjectId(log_id)
     except Exception:  # noqa: BLE001 — nothing to finalise
         return
-    doc = await _MessageLogDoc.find_one({"_id": oid})
+    # Tenant-filtered, per cloud rule 7. It was the module's one unfiltered
+    # query: latent, because the only caller passes a log_id it just minted —
+    # but the seam takes a bare id, so the first retry route or provider
+    # status-callback that passed a request-supplied one would let a tenant
+    # finalise another tenant's delivery audit row.
+    doc = await _MessageLogDoc.find_one({"_id": oid, "workspace": workspace_id})
     if doc is None:
         return
     doc.outcome = status
@@ -2017,8 +2041,36 @@ async def record_whatsapp_inbound_reply(number: str) -> int:
     if not docs:
         return 0
 
+    # An inbound message IS the opt-in signal under Meta's rules, whether or not
+    # we had a sent draft outstanding — so "nobody messaged them" must still
+    # record consent. What it may NOT do is record it for a tenant the reply
+    # cannot be attributed to.
+    #
+    # The old `messaged or docs` fallback did exactly that: when no workspace
+    # had messaged the number, EVERY tenant holding it was stamped
+    # opted_in=True. Two agencies buying the same directory export was enough,
+    # and opted_in is the flag whatsapp.py checks before a business-initiated
+    # send — so one person's message manufactured consent for an agency that
+    # had never contacted them.
+    #
+    # Attribution, in order: whoever actually messaged them; failing that, the
+    # sole workspace holding the number. If several tenants hold it and none
+    # has messaged, the reply is genuinely unattributable and nothing is
+    # written. Scoping by the receiving ``integrated_number`` removes the
+    # ambiguity properly and stays the follow-up.
     messaged = [d for d in docs if await _has_sent_whatsapp_draft(d.workspace, str(d.id))]
-    targets = messaged or docs
+    if messaged:
+        targets = messaged
+    elif len({d.workspace for d in docs}) == 1:
+        targets = docs
+    else:
+        logger.info(
+            "growth.whatsapp_inbound: %d row(s) across %d workspaces hold this "
+            "number and none had messaged it — unattributable, recording nothing",
+            len(docs),
+            len({d.workspace for d in docs}),
+        )
+        return 0
 
     for doc in targets:
         doc.opted_in = True

--- a/ee/pocketpaw_ee/cloud/growth/whatsapp.py
+++ b/ee/pocketpaw_ee/cloud/growth/whatsapp.py
@@ -250,14 +250,18 @@ async def dispatch_whatsapp(draft_id: str) -> None:
         provider_message_id = await client.send_template(to_number=to_number, body_text=draft.body)
     except Msg91Error as exc:
         await growth_service.finish_whatsapp_attempt(
-            log_id, status="failed", error_code=exc.code, error=exc.message
+            log_id,
+            workspace_id=workspace_id,
+            status="failed",
+            error_code=exc.code,
+            error=exc.message,
         )
         # The draft stays ``approved`` — the approval stands, the delivery
         # didn't. An operator can re-dispatch without a second human approval.
         raise WhatsAppDispatchError(f"MSG91 send failed: {exc.message}") from exc
 
     await growth_service.finish_whatsapp_attempt(
-        log_id, status="sent", provider_message_id=provider_message_id
+        log_id, workspace_id=workspace_id, status="sent", provider_message_id=provider_message_id
     )
     # The gate owns approved→sent; this module walks it through the existing
     # seam rather than writing the status itself.

--- a/ee/pocketpaw_ee/cloud/growth/worker.py
+++ b/ee/pocketpaw_ee/cloud/growth/worker.py
@@ -73,6 +73,10 @@ from pocketpaw_ee.cloud.shared.db import close_cloud_db, init_cloud_db
 
 logger = logging.getLogger(__name__)
 
+# 30 minutes. arq's own default is 300s, which cancels the discovery sweep
+# after the first two or three ICPs — see the note on ``job_timeout`` below.
+_DEFAULT_JOB_TIMEOUT_SECONDS = 1800
+
 
 async def dispatch(ctx: dict[str, Any], draft_id: str, channel: str) -> None:
     """Dispatch an APPROVED outbound draft.
@@ -147,6 +151,26 @@ def _redis_settings() -> RedisSettings:
     return RedisSettings.from_dsn(url)
 
 
+def _job_timeout_seconds() -> int:
+    """Per-job ceiling for the growth queue, in seconds.
+
+    Default 30 minutes: the discovery sweep works ICPs sequentially and each
+    one is a real agent run. Override with ``GROWTH_JOB_TIMEOUT_SECONDS`` when
+    a deployment runs more hunts than that comfortably fits.
+    """
+    raw = os.environ.get("GROWTH_JOB_TIMEOUT_SECONDS", "").strip()
+    if raw:
+        try:
+            return max(int(raw), 60)
+        except ValueError:
+            logger.warning(
+                "growth worker: GROWTH_JOB_TIMEOUT_SECONDS=%r is not an integer — using %d",
+                raw,
+                _DEFAULT_JOB_TIMEOUT_SECONDS,
+            )
+    return _DEFAULT_JOB_TIMEOUT_SECONDS
+
+
 class WorkerSettings:
     """arq worker configuration for the ``growth`` queue.
 
@@ -195,6 +219,16 @@ class WorkerSettings:
             run_at_startup=False,
         ),
     ]
+    # arq's default job_timeout is 300s, which is far too short for the
+    # discovery sweep: each ICP awaits a full WebSearch/WebFetch agent run, so
+    # a fleet of tenants is cancelled mid-loop after the first two or three.
+    # Worse, the cancellation is invisible — CancelledError is a BaseException,
+    # so none of the sweep's careful `except Exception` handling catches it,
+    # the closing summary log never fires, and max_tries=1 means no retry. The
+    # chat-runs worker already learned this (POCKETPAW_CLOUD_RUN_JOB_TIMEOUT
+    # exists for the same reason); this is the growth queue's version.
+    job_timeout = _job_timeout_seconds()
+
     on_startup = _startup
     on_shutdown = _shutdown
     # Crash policy mirrors the chat-runs worker: no auto-retry. Outbound work

--- a/tests/cloud/growth/test_researcher.py
+++ b/tests/cloud/growth/test_researcher.py
@@ -231,3 +231,74 @@ class TestThePrompt:
         )
         assert "Where:" not in prompt
         assert "Skip:" not in prompt
+
+
+class TestTheReviewFindings:
+    """Regressions for the code-review findings. Each of these passed a fully
+    green suite before the fix, which is the point: the fakes never echoed a
+    template, never resumed a session, and never returned a two-line address."""
+
+    def test_the_prompt_carries_no_parseable_json(self) -> None:
+        """The prompt's shape description must not itself be a valid answer.
+
+        It used to be — a complete JSON object with a `companies` key and an
+        `observed` email on example.com. A model that restated it before
+        answering had its own template filed as the research.
+        """
+        from pocketpaw_ee.cloud.growth.researcher import GROWTH_RESEARCHER_PROMPT
+
+        assert parse_research_response(GROWTH_RESEARCHER_PROMPT, max_results=5).companies == ()
+
+    def test_a_preamble_object_cannot_shadow_the_answer(self) -> None:
+        """The LAST qualifying object wins, so a restated shape loses to the
+        real findings that follow it."""
+        preamble = _response(
+            [
+                {
+                    "domain": "example.com",
+                    "emails": [
+                        {
+                            "address": "hello@example.com",
+                            "confidence": "observed",
+                            "source_url": "https://example.com/contact",
+                        }
+                    ],
+                }
+            ]
+        )
+        answer = _response([{"domain": "realclinic.co.uk"}])
+        result = parse_research_response(f"Shape:{preamble}\nResults:{answer}", max_results=5)
+        assert [c.domain for c in result.companies] == ["realclinic.co.uk"]
+
+    @pytest.mark.parametrize(
+        "address",
+        [
+            "hello@x.com\nbilling@x.com",  # two addresses off one contact page
+            "a@b@c.com",
+            "@x.com",
+            "a b@x.com",
+            "a@localhost",
+        ],
+    )
+    def test_a_malformed_address_is_never_storable(self, address: str) -> None:
+        """recordable_emails checks provenance, not syntax — so the shape check
+        has to happen at the parse, before a two-line string reaches a
+        provider as a recipient."""
+        result = parse_research_response(
+            _response([{"domain": "x.com", "emails": [
+                {"address": address, "confidence": "observed", "source_url": "https://x.com"}
+            ]}]),
+            max_results=5,
+        )
+        assert recordable_emails(result.companies[0].emails) == ()
+
+    def test_research_failure_raises_so_the_sweep_can_see_it(self) -> None:
+        """A failure must be distinguishable from 'searched and found nobody'.
+
+        Returning an empty result with the reason in `notes` meant the sweep
+        counted it as a successful run and advanced last_run_at, so a
+        workspace with no researcher agent reported healthy forever.
+        """
+        from pocketpaw_ee.cloud.growth.researcher import ResearchUnavailable
+
+        assert issubclass(ResearchUnavailable, Exception)

--- a/tests/cloud/growth/test_researcher.py
+++ b/tests/cloud/growth/test_researcher.py
@@ -269,6 +269,7 @@ class TestTheReviewFindings:
         answer = _response([{"domain": "realclinic.co.uk"}])
         result = parse_research_response(f"Shape:{preamble}\nResults:{answer}", max_results=5)
         assert [c.domain for c in result.companies] == ["realclinic.co.uk"]
+        # Mutation: "extractor takes the FIRST companies object again".
 
     @pytest.mark.parametrize(
         "address",
@@ -277,17 +278,41 @@ class TestTheReviewFindings:
             "a@b@c.com",
             "@x.com",
             "a b@x.com",
-            "a@localhost",
+            "a@localhost",  # no dot in the host
+            "a@b.",  # trailing dot, no TLD
+            "a@.com",  # empty label
+            "a@b..com",  # empty middle label
+            "a@b.com.",  # trailing dot after a valid host
+            '"drop"@b.com',  # quoted local part
+            "a<b>@c.com",  # angle brackets — the one that could alter a header
+            "a@b.c1",  # non-alphabetic TLD
+            "a" * 300 + "@b.com",  # over the RFC 5321 ceiling
         ],
     )
     def test_a_malformed_address_is_never_storable(self, address: str) -> None:
         """recordable_emails checks provenance, not syntax — so the shape check
         has to happen at the parse, before a two-line string reaches a
-        provider as a recipient."""
+        provider as a recipient.
+
+        Mutations that must break this (growth_review_gates.json): "email shape
+        check removed", "host dotted-ness no longer required", "host label check
+        relaxed", "header-bearing characters allowed back into the local part".
+        """
         result = parse_research_response(
-            _response([{"domain": "x.com", "emails": [
-                {"address": address, "confidence": "observed", "source_url": "https://x.com"}
-            ]}]),
+            _response(
+                [
+                    {
+                        "domain": "x.com",
+                        "emails": [
+                            {
+                                "address": address,
+                                "confidence": "observed",
+                                "source_url": "https://x.com",
+                            }
+                        ],
+                    }
+                ]
+            ),
             max_results=5,
         )
         assert recordable_emails(result.companies[0].emails) == ()

--- a/tests/mutations/growth_review_gates.json
+++ b/tests/mutations/growth_review_gates.json
@@ -7,16 +7,16 @@
     "tests": "tests/cloud/growth/test_researcher.py::TestTheReviewFindings::test_a_preamble_object_cannot_shadow_the_answer"
   },
   {
-    "label": "email shape check removed — a two-line address becomes storable",
+    "label": "email shape check removed \u2014 a two-line address becomes storable",
     "file": "ee/pocketpaw_ee/cloud/growth/researcher.py",
     "find": "    if any(ch.isspace() for ch in address) or address.count(\"@\") != 1:\n        return None",
     "replace": "    if False:\n        return None",
     "tests": "tests/cloud/growth/test_researcher.py::TestTheReviewFindings::test_a_malformed_address_is_never_storable"
   },
   {
-    "label": "host dotted-ness no longer required — a@localhost becomes storable",
+    "label": "local part unbounded \u2014 a 300-char local part becomes storable",
     "file": "ee/pocketpaw_ee/cloud/growth/researcher.py",
-    "find": "    if not local or \".\" not in host:\n        return None",
+    "find": "    if not local or len(local) > 64:\n        return None",
     "replace": "    if not local:\n        return None",
     "tests": "tests/cloud/growth/test_researcher.py::TestTheReviewFindings::test_a_malformed_address_is_never_storable"
   },
@@ -54,5 +54,19 @@
     "find": "                \"max_per_run\": {\"type\": \"integer\", \"minimum\": 1, \"maximum\": 100},",
     "replace": "                \"max_per_run\": {\"type\": \"integer\", \"minimum\": 1, \"maximum\": 100},\n                \"cadence\": {\"type\": \"string\"},",
     "tests": "tests/cloud/growth/test_mcp_server.py::TestTheGateHolds::test_no_tool_can_switch_a_hunt_on"
+  },
+  {
+    "label": "host label check relaxed \u2014 a@b.. and a@.com become storable",
+    "file": "ee/pocketpaw_ee/cloud/growth/researcher.py",
+    "find": "    if len(labels) < 2 or not all(labels):\n        return None",
+    "replace": "    if len(labels) < 2:\n        return None",
+    "tests": "tests/cloud/growth/test_researcher.py::TestTheReviewFindings::test_a_malformed_address_is_never_storable"
+  },
+  {
+    "label": "header-bearing characters allowed back into the local part",
+    "file": "ee/pocketpaw_ee/cloud/growth/researcher.py",
+    "find": "    if any(ch in address for ch in '<>\"\\\\,;:()[]'):\n        return None",
+    "replace": "    if False:\n        return None",
+    "tests": "tests/cloud/growth/test_researcher.py::TestTheReviewFindings::test_a_malformed_address_is_never_storable"
   }
 ]

--- a/tests/mutations/growth_review_gates.json
+++ b/tests/mutations/growth_review_gates.json
@@ -1,0 +1,58 @@
+[
+  {
+    "label": "extractor takes the FIRST companies object again (the template-echo bug)",
+    "file": "ee/pocketpaw_ee/cloud/growth/researcher.py",
+    "find": "    for obj in reversed(objects):",
+    "replace": "    for obj in objects:",
+    "tests": "tests/cloud/growth/test_researcher.py::TestTheReviewFindings::test_a_preamble_object_cannot_shadow_the_answer"
+  },
+  {
+    "label": "email shape check removed — a two-line address becomes storable",
+    "file": "ee/pocketpaw_ee/cloud/growth/researcher.py",
+    "find": "    if any(ch.isspace() for ch in address) or address.count(\"@\") != 1:\n        return None",
+    "replace": "    if False:\n        return None",
+    "tests": "tests/cloud/growth/test_researcher.py::TestTheReviewFindings::test_a_malformed_address_is_never_storable"
+  },
+  {
+    "label": "host dotted-ness no longer required — a@localhost becomes storable",
+    "file": "ee/pocketpaw_ee/cloud/growth/researcher.py",
+    "find": "    if not local or \".\" not in host:\n        return None",
+    "replace": "    if not local:\n        return None",
+    "tests": "tests/cloud/growth/test_researcher.py::TestTheReviewFindings::test_a_malformed_address_is_never_storable"
+  },
+  {
+    "label": "an unobserved confidence is upgraded to observed",
+    "file": "ee/pocketpaw_ee/cloud/growth/researcher.py",
+    "find": "    confidence = str(raw.get(\"confidence\") or \"\").strip().lower()",
+    "replace": "    confidence = str(raw.get(\"confidence\") or \"observed\").strip().lower()",
+    "tests": "tests/cloud/growth/test_researcher.py::TestAGuessNeverBecomesAnAddress"
+  },
+  {
+    "label": "tool output is collected again alongside the answer",
+    "file": "ee/pocketpaw_ee/cloud/growth/researcher.py",
+    "find": "            if getattr(event, \"type\", None) != \"message\":\n                continue",
+    "replace": "            if False:\n                continue",
+    "tests": "tests/cloud/growth/test_researcher.py::TestToolOutputNeverPollutesTheAnswer"
+  },
+  {
+    "label": "the researcher regains a write tool",
+    "file": "ee/pocketpaw_ee/cloud/growth/researcher.py",
+    "find": "GROWTH_RESEARCHER_TOOLS: tuple[str, ...] = (\"WebSearch\", \"WebFetch\")",
+    "replace": "GROWTH_RESEARCHER_TOOLS: tuple[str, ...] = (\"WebSearch\", \"WebFetch\", \"Write\")",
+    "tests": "tests/cloud/growth/test_researcher.py::TestTheToolSurfaceStaysShut"
+  },
+  {
+    "label": "tool_mode falls back to additive (unions the universal MCP grant)",
+    "file": "ee/pocketpaw_ee/cloud/growth/researcher.py",
+    "find": "        \"tool_mode\": \"exclusive\",",
+    "replace": "        \"tool_mode\": \"additive\",",
+    "tests": "tests/cloud/growth/test_researcher.py::TestTheToolSurfaceStaysShut::test_tool_mode_is_exclusive_not_additive"
+  },
+  {
+    "label": "the agent can set a cadence again (schedules its own spend)",
+    "file": "ee/pocketpaw_ee/agent/mcp_servers/growth.py",
+    "find": "                \"max_per_run\": {\"type\": \"integer\", \"minimum\": 1, \"maximum\": 100},",
+    "replace": "                \"max_per_run\": {\"type\": \"integer\", \"minimum\": 1, \"maximum\": 100},\n                \"cadence\": {\"type\": \"string\"},",
+    "tests": "tests/cloud/growth/test_mcp_server.py::TestTheGateHolds::test_no_tool_can_switch_a_hunt_on"
+  }
+]


### PR DESCRIPTION
The eleven fixes from the `/growth` code review. They were committed before the
Aug 5 rebase of `integration/growth-v1` and never pushed, so the branch they sat
on diverged — this is that work cherry-picked onto the current tip.

I checked each fix against the rebased branch first; **none of the eleven had
been fixed independently**, and the cherry-pick applied without conflicts.

## The two worst, both mine

**A restated prompt template got filed as research.** The system prompt's shape
example was itself valid JSON carrying a `companies` key and an `observed` email
on `example.com`, and the extractor took the *first* such object. A model that
echoed the shape before answering had its own template parsed as the findings:
the real research discarded, a fabricated prospect stored, an address nobody had
ever seen marked observed. Reproduced directly before fixing. Two independent
guards now — the prompt describes fields in prose instead of showing parseable
JSON, and the last qualifying object wins.

**Discovery went mute after day one.** The session key was stable per ICP while
the comment above it claimed the opposite, so every daily run resumed the
previous transcript, the model saw its own last answer, and the natural
completion became "I already reported those" — filing nothing while
`last_run_at` kept advancing. Now keyed per run.

## The rest

`opted_in` is off the agent's write surface — it is the flag the WhatsApp guard
checks, and the Tray shows copy but never opt-in provenance. Inbound replies no
longer opt people in across tenants (attribution, not refusal — an inbound
message *is* consent under Meta's rules, so the fix routes it to whoever
actually messaged them, else the sole workspace holding the number, else
nobody). A bulk re-import no longer resurrects prospects the sweep retired. A
failed research pass raises instead of reporting a healthy run forever. Plus an
address shape check, the module's last unfiltered tenant query, MSG91 error
scrubbing, `job_timeout=1800` (arq's 300s default was cancelling the sweep after
two or three ICPs, invisibly, since `CancelledError` is a `BaseException`), and
a due-ICP scan sorted by `last_run_at` so a capped batch starves nobody
permanently.

## Proven, not just green

374 tests pass and both import-linter configs are clean on the rebased base.

More importantly, per the repo's mutation rule: **eight mutations, one per new
guard, all caught.** Every bug in this batch had a green suite over it, so
asserting the fixes without proving the guards bite would repeat the exact
mistake being corrected.

```
uv run python scripts/mutate.py --plan tests/mutations/growth_review_gates.json
```

## Deliberately not fixed

Three findings — the recipient not being pinned into the approved proposal, no
content check between approved and sent, and the propose/edit race — are one
slice, not three. They all want the same thing: the recipient and a
`(subject, body)` hash pinned into the blob at propose time and re-verified
before the provider call. Piecemeal means touching `propose.py`, `executor.py`
and both dispatch modules three times over.

The fourth, the Mailtrap token echoed by `GET /connectors/mailtrap`, is real but
belongs in the **connectors** entity — it would change an endpoint every
connector shares, so it shouldn't ride inside a growth PR.