### PR TITLE
atlas_describe fabric:<Type> carries a live source-truth aggregate

### DIFF
--- a/src/pocketpaw/agents/sdk_mcp_atlas.py
+++ b/src/pocketpaw/agents/sdk_mcp_atlas.py
@@ -49,6 +49,15 @@
 # role-gated id like an unknown id, and the known-ids error listing excludes
 # them. Belt-and-braces: admin capabilities can never leak from ANY atlas server
 # wiring, provider or not (matches DefaultEntitlementProvider's role hiding).
+#
+# Updated: 2026-08-17 (feat/ast-2-atlas-trust-aggregate, AST-2) — the describe
+# handler awaits ``describe_fabric_id_async`` instead of the sync
+# ``describe_fabric_id``: same registry payload for ``fabric:<type>`` ids, plus
+# the additive ``source_truth`` field (live per-property disputed / stale /
+# aging counts + winner writer mix from the OSS FabricStore) when the
+# introspector exposes the optional ``entity_type_source_truth``. Handlers are
+# already async, so the aiosqlite read runs in the handler's own loop — no sync
+# bridge. Search is untouched (properties-only, FINDING B).
 
 from __future__ import annotations
 
@@ -217,9 +226,12 @@ async def _atlas_describe_handler(
     if introspector is not None:
         # Fail-closed inside: a miss OR a raising introspector returns None,
         # and the id falls through to the normal unknown-id error below.
-        from pocketpaw.atlas.fabric import describe_fabric_id
+        # AST-2: the async sibling ALSO awaits the optional type-level
+        # ``source_truth`` aggregate (only when the introspector exposes it;
+        # any raise leaves the key absent and the schema payload intact).
+        from pocketpaw.atlas.fabric import describe_fabric_id_async
 
-        fabric_payload = describe_fabric_id(introspector, entry_id.strip())
+        fabric_payload = await describe_fabric_id_async(introspector, entry_id.strip())
         if fabric_payload is not None:
             return _text_result(json.dumps(fabric_payload, ensure_ascii=False))
 

--- a/src/pocketpaw/atlas/fabric.py
+++ b/src/pocketpaw/atlas/fabric.py
@@ -45,6 +45,29 @@
 #     ``(?<=[A-Z])(?=[A-Z][a-z])`` so consecutive-capital names split
 #     ("HTTPServer" → "HTTP Server", "APIKey" → "API Key"); "http server" /
 #     "api key" queries now match acronym-named entity types.
+#
+# Updated: 2026-08-17 (feat/ast-2-atlas-trust-aggregate, AST-2) — the describe
+#   view learns source-truth. The registry knows Customer HAS ``arr``; the OSS
+#   ``FabricStore`` (a different DB) knows whether ``arr`` is disputed / stale
+#   and who won. One optional, duck-typed, ASYNC read bridges them at the
+#   TYPE level:
+#   * ``RegistryFabricIntrospector.entity_type_source_truth(name)`` — NOT a
+#     Protocol member (same reasoning as ``list_entity_properties``). Resolves
+#     the type in the store, runs ONE indexed type-scoped
+#     ``list_statement_keys`` (LIMIT cap+1) — an untracked type stops there
+#     with zero further statement reads — then walks tracked keys through
+#     ``get_statements`` + the pure ``resolve()`` (mirroring
+#     ``get_object_provenance``), capped at ``SOURCE_TRUTH_SAMPLE_CAP`` keys
+#     (``sampled=True``). Rolls up per property: objects / disputed / stale /
+#     aging / winner_writer_mix, plus ``mode``, ``tracked``, ``object_count``
+#     and a pointer to ``fabric_query include_provenance=true``.
+#   * ``describe_fabric_id_async`` — the awaitable sibling the async
+#     ``atlas_describe`` handler now calls: sync describe + the aggregate folded
+#     in as the additive ``source_truth`` key. Any raise → key absent, registry
+#     payload intact. ``search_entity_types`` never touches it.
+#   * ``build_workspace_fabric_introspector`` also binds
+#     ``get_fabric_store(workspace_id=...)``; that binding degrades alone (the
+#     registry introspector still returns, only ``source_truth`` goes absent).
 
 from __future__ import annotations
 
@@ -63,6 +86,13 @@ FABRIC_KIND = "fabric"
 # Cap on synthetic fabric cards appended to a search answer. Compiled-entry
 # results keep their own limit; fabric cards are extra, never displacing.
 MAX_FABRIC_RESULTS = 3
+
+# AST-2: hard cap on tracked (object_id, property) keys the type-level
+# source-truth aggregate walks per describe. Above it the roll-up reports
+# ``sampled=True`` and stops — a describe answer is a glance, not an audit;
+# the per-object truth is one fabric_query away (SOURCE_TRUTH_POINTER).
+SOURCE_TRUTH_SAMPLE_CAP = 500
+SOURCE_TRUTH_POINTER = "fabric_query include_provenance=true for the per-object answer"
 
 # Entity-type names are commonly CamelCase ("CustomerAccount"); split on
 # case boundaries before stemming so "customer account" queries match. Two
@@ -110,6 +140,20 @@ class FabricIntrospector(Protocol):
     # ``isinstance`` check for introspectors (including test fakes) that only
     # implement the two required methods — so it stays a documented, duck-typed
     # extension rather than a Protocol member.
+    #
+    # OPTIONAL — a type-level source-truth aggregate for the DETAIL view (AST-2).
+    #
+    # An implementation MAY expose ``async entity_type_source_truth(name) ->
+    # dict | None`` — a live roll-up of the OSS FabricStore's statement
+    # provenance for objects of that type (per property: how many tracked
+    # objects, how many disputed / stale / aging, the winner writer-class mix;
+    # see ``RegistryFabricIntrospector.entity_type_source_truth`` for the exact
+    # shape). ONLY ``describe_fabric_id_async`` consumes it (via ``getattr`` +
+    # ``callable`` + ``await``), folded into the describe payload as the
+    # additive ``source_truth`` key; ``search_entity_types`` NEVER calls it —
+    # search stays properties-only (FINDING B). Any raise → the key is simply
+    # absent and the registry payload still answers. Same non-Protocol
+    # reasoning as ``list_entity_properties`` above.
 
 
 def _fabric_tokens(text: str) -> set[str]:
@@ -271,6 +315,36 @@ def describe_fabric_id(
         return None
 
 
+async def describe_fabric_id_async(
+    introspector: FabricIntrospector,
+    entry_id: str,
+) -> dict[str, Any] | None:
+    """:func:`describe_fabric_id` plus the optional live ``source_truth`` roll-up.
+
+    The async sibling the (already async) ``atlas_describe`` handler awaits.
+    It calls the sync registry describe unchanged, then — ONLY when the
+    introspector exposes the optional, duck-typed ``entity_type_source_truth``
+    (AST-2) — awaits it and folds a dict result in as ``source_truth``.
+    Fail-closed: a missing method, a ``None`` result, or ANY raise leaves the
+    key ABSENT and the registry payload untouched, so a broken FabricStore
+    can never take the schema answer down with it. Sync callers keep using
+    ``describe_fabric_id``.
+    """
+    payload = describe_fabric_id(introspector, entry_id)
+    if payload is None:
+        return None
+    aggregate = getattr(introspector, "entity_type_source_truth", None)
+    if not callable(aggregate):
+        return payload
+    try:
+        source_truth = await aggregate(payload["name"])
+        if isinstance(source_truth, dict):
+            payload["source_truth"] = source_truth
+    except Exception as exc:  # noqa: BLE001 — additive field, never break the tool
+        logger.debug("atlas fabric source-truth aggregate unavailable (%s): %s", entry_id, exc)
+    return payload
+
+
 class RegistryFabricIntrospector:
     """Adapter from the EE ``WorkspaceFabricRegistry`` read surface to
     :class:`FabricIntrospector`.
@@ -280,12 +354,28 @@ class RegistryFabricIntrospector:
     ``list_entity_links``) so tests can wrap a tmp-path store without
     importing ``pocketpaw_ee`` at module scope. The registry is already
     bound to one workspace — this adapter adds no scoping of its own.
+
+    ``source_truth`` (AST-2) is an OPTIONAL OSS ``FabricStore`` (the
+    per-property statement/provenance store — a different DB from the
+    registry) bound to the same workspace; with it,
+    :meth:`entity_type_source_truth` serves the live type-level trust
+    aggregate. ``None`` (the default, and the builder's fallback when the
+    store can't be bound) makes that method answer ``None`` — the describe
+    payload then simply lacks ``source_truth``.
     """
 
-    __slots__ = ("_registry",)
+    __slots__ = ("_registry", "_source_truth", "_workspace_id")
 
-    def __init__(self, registry: Any) -> None:
+    def __init__(
+        self,
+        registry: Any,
+        *,
+        source_truth: Any | None = None,
+        workspace_id: str | None = None,
+    ) -> None:
         self._registry = registry
+        self._source_truth = source_truth
+        self._workspace_id = workspace_id
 
     def list_entity_types(self) -> list[str]:
         return list(self._registry.list_entity_types())
@@ -312,6 +402,85 @@ class RegistryFabricIntrospector:
         """
         return sorted(self._registry.get_entity_properties(name))
 
+    async def entity_type_source_truth(self, name: str) -> dict | None:
+        """Live type-level source-truth roll-up for the describe view (AST-2).
+
+        Optional, duck-typed — NOT a ``FabricIntrospector`` Protocol member
+        (see the OPTIONAL note on the Protocol). ``None`` when no store is
+        bound. Otherwise::
+
+            {mode, tracked, sampled, object_count,
+             properties: {<prop>: {objects, disputed, stale, aging,
+                                   winner_writer_mix: {<writer_class>: n}}},
+             pointer}
+
+        Cost is bounded by the TRACKED set, never the whole fabric: the type
+        name resolves to the store's type row (``get_type_by_name``, a
+        ``fabric_object_types`` read); ONE indexed ``list_statement_keys``
+        query (type-scoped join, ``LIMIT cap+1``) is the only statement read
+        for an untracked type — no keys → ``tracked=False`` and it stops.
+        Tracked keys are walked with ``get_statements`` + the pure
+        ``resolve()`` (mirroring ``FabricStore.get_object_provenance`` —
+        dispute/freshness/winner metadata are never persisted, so they are
+        recomputed here), capped at ``SOURCE_TRUTH_SAMPLE_CAP`` keys
+        (``sampled=True`` beyond it). ``winner_freshness`` is None on the
+        pinned path, so a pinned winner counts as neither stale nor aging.
+        """
+        store = self._source_truth
+        if store is None:
+            return None
+        from datetime import UTC, datetime
+
+        from pocketpaw.config import get_settings
+        from pocketpaw.fabric.resolver import resolve
+        from pocketpaw.fabric.trust import default_trust_rules
+
+        ws = self._workspace_id
+        out: dict[str, Any] = {
+            "mode": get_settings().fabric_source_truth_mode,
+            "tracked": False,
+            "sampled": False,
+            "object_count": 0,
+            "properties": {},
+            "pointer": SOURCE_TRUTH_POINTER,
+        }
+        obj_type = await store.get_type_by_name(name, workspace_id=ws)
+        if obj_type is None:
+            return out
+        keys = await store.list_statement_keys(
+            workspace_id=ws, type_id=obj_type.id, limit=SOURCE_TRUTH_SAMPLE_CAP + 1
+        )
+        if not keys:
+            return out
+        if len(keys) > SOURCE_TRUTH_SAMPLE_CAP:
+            out["sampled"] = True
+            keys = keys[:SOURCE_TRUTH_SAMPLE_CAP]
+        out["tracked"] = True
+        out["object_count"] = len({oid for oid, _prop in keys})
+        now = datetime.now(UTC)
+        rules = default_trust_rules()
+        properties: dict[str, dict[str, Any]] = {}
+        for object_id, prop in keys:
+            stmts = await store.get_statements(object_id, prop, workspace_id=ws)
+            if not stmts:
+                continue
+            resolution = resolve(stmts, rules, object_type=obj_type.name, now=now)
+            entry = properties.setdefault(
+                prop,
+                {"objects": 0, "disputed": 0, "stale": 0, "aging": 0, "winner_writer_mix": {}},
+            )
+            entry["objects"] += 1
+            if resolution.is_disputed:
+                entry["disputed"] += 1
+            if resolution.winner_freshness in ("stale", "aging"):
+                entry[resolution.winner_freshness] += 1
+            winner = resolution.winner_statement
+            if winner is not None:
+                mix = entry["winner_writer_mix"]
+                mix[winner.writer_class] = mix.get(winner.writer_class, 0) + 1
+        out["properties"] = properties
+        return out
+
 
 def build_workspace_fabric_introspector(workspace_id: str) -> FabricIntrospector | None:
     """EE wiring hook: a live introspector bound to *workspace_id*, or None.
@@ -321,6 +490,12 @@ def build_workspace_fabric_introspector(workspace_id: str) -> FabricIntrospector
     state dir) — all DEBUG-logged, all degrade to "no introspector"
     (fail-closed). The returned introspector is constructed PER RUN with the
     run's workspace id — never cached process-globally.
+
+    AST-2: the same call also binds the workspace's OSS ``FabricStore``
+    (``get_fabric_store(workspace_id=...)``) as the introspector's optional
+    ``source_truth`` store. That binding degrades INDEPENDENTLY: if it fails
+    the registry introspector is still returned (schema answers keep
+    working) and only the ``source_truth`` describe field goes absent.
     """
     if not isinstance(workspace_id, str) or not workspace_id.strip():
         return None
@@ -330,9 +505,17 @@ def build_workspace_fabric_introspector(workspace_id: str) -> FabricIntrospector
         logger.debug("pocketpaw_ee.fabric not importable; atlas fabric introspection off")
         return None
     try:
+        ws = workspace_id.strip()
         store = WorkspaceFabricStore()
-        registry = WorkspaceFabricRegistry(store=store, workspace_id=workspace_id.strip())
-        return RegistryFabricIntrospector(registry)
+        registry = WorkspaceFabricRegistry(store=store, workspace_id=ws)
+        source_truth = None
+        try:
+            from pocketpaw.stores import get_fabric_store
+
+            source_truth = get_fabric_store(workspace_id=ws)
+        except Exception as exc:  # noqa: BLE001 — additive field degrades alone
+            logger.debug("atlas fabric source-truth store unavailable: %s", exc)
+        return RegistryFabricIntrospector(registry, source_truth=source_truth, workspace_id=ws)
     except Exception as exc:  # noqa: BLE001 — infra failure degrades, never crashes
         logger.debug("atlas fabric introspector construction failed: %s", exc)
         return None
@@ -342,9 +525,12 @@ __all__ = [
     "FABRIC_ID_PREFIX",
     "FABRIC_KIND",
     "MAX_FABRIC_RESULTS",
+    "SOURCE_TRUTH_POINTER",
+    "SOURCE_TRUTH_SAMPLE_CAP",
     "FabricIntrospector",
     "RegistryFabricIntrospector",
     "build_workspace_fabric_introspector",
     "describe_fabric_id",
+    "describe_fabric_id_async",
     "search_entity_types",
 ]

--- a/src/pocketpaw/fabric/store.py
+++ b/src/pocketpaw/fabric/store.py
@@ -1,5 +1,11 @@
 # Fabric store — async SQLite operations for the ontology layer.
 # Created: 2026-03-28 — CRUD for object types, objects, and links.
+# Updated: 2026-08-17 (AST-2 — atlas type-level trust aggregate) —
+#   ``list_statement_keys`` gains two optional kwargs: ``type_id`` narrows the
+#   DISTINCT (object_id, property) walk to objects of ONE type via an indexed
+#   join (idx_statements_object ↔ idx_objects_type — still tracked-set cost,
+#   never a full-fabric scan) and ``limit`` caps the rows. Read-only,
+#   additive; existing keyword callers are byte-identical.
 # Updated: 2026-07-11 (FST-7 — freshness) — the merge-site statement pass now
 #   threads an aware-UTC ``now`` into resolve() (within-family staleness
 #   demotion live in shadow AND enforce); the divergence line gained a
@@ -2796,6 +2802,8 @@ class FabricStore:
         *,
         workspace_id: str | None = None,
         object_id: str | None = None,
+        type_id: str | None = None,
+        limit: int | None = None,
     ) -> list[tuple[str, str]]:
         """DISTINCT ``(object_id, property)`` pairs that HAVE statements (FST-6).
 
@@ -2805,21 +2813,35 @@ class FabricStore:
         not the whole fabric. ``workspace_id`` applies the standard W4a read
         scope (own rows + legacy NULL); ``object_id`` narrows to one object.
         Ordered by ``(object_id, property)`` for a deterministic walk.
+
+        ``type_id`` (AST-2) narrows to objects OF ONE TYPE — an indexed join
+        of ``fabric_statements.object_id`` (idx_statements_object) to
+        ``fabric_objects.type_id`` (idx_objects_type), so a type-level read
+        still visits only tracked keys, never the whole fabric. ``limit`` caps
+        the row count (the atlas trust aggregate passes cap+1 to detect
+        sampling in the same single query).
         """
         conditions: list[str] = []
         params: list[Any] = []
         if object_id is not None:
-            conditions.append("object_id = ?")
+            conditions.append("s.object_id = ?")
             params.append(object_id)
-        ws_cond, ws_params = _workspace_scope(workspace_id)
+        if type_id is not None:
+            conditions.append("o.type_id = ?")
+            params.append(type_id)
+        ws_cond, ws_params = _workspace_scope(workspace_id, column="s.workspace_id")
         if ws_cond:
             conditions.append(ws_cond)
             params.extend(ws_params)
+        join = " JOIN fabric_objects o ON o.id = s.object_id" if type_id is not None else ""
         where = f" WHERE {' AND '.join(conditions)}" if conditions else ""
         sql = (
-            "SELECT DISTINCT object_id, property FROM fabric_statements"
-            f"{where} ORDER BY object_id, property"
+            "SELECT DISTINCT s.object_id, s.property FROM fabric_statements s"
+            f"{join}{where} ORDER BY s.object_id, s.property"
         )
+        if limit is not None:
+            sql += " LIMIT ?"
+            params.append(int(limit))
         await self._ensure_schema()
         async with self._conn() as db:
             async with db.execute(sql, params) as cur:

--- a/tests/atlas/test_fabric_introspection.py
+++ b/tests/atlas/test_fabric_introspection.py
@@ -12,8 +12,21 @@
 # construction against a tmp-path WorkspaceFabricStore is import-guarded
 # (pytest.importorskip) so the test runs where pocketpaw_ee is installed
 # (or via PYTHONPATH=ee) and skips cleanly elsewhere.
+#
+# Updated: 2026-08-17 (feat/ast-2-atlas-trust-aggregate, AST-2) — the
+# TestSourceTruthAggregate section: describe on a TRACKED type (a real OSS
+# FabricStore in tmp_path with two competing ``arr`` statements) carries the
+# additive ``source_truth`` roll-up (properties.arr.disputed == 1, winner mix,
+# tracked=True); an UNTRACKED type answers tracked=False with ZERO
+# get_statements reads and at most one keys lookup (spy proxy); a missing /
+# raising source-truth store leaves the key ABSENT and the registry payload
+# intact (helper, handler and builder levels); search NEVER calls the
+# aggregate; >500 tracked keys → sampled=True (with a rough timing print);
+# and the store's type-scoped ``list_statement_keys`` is pinned directly.
 
 import json
+import time
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
@@ -24,9 +37,13 @@ from pocketpaw.agents.sdk_mcp_atlas import (
 from pocketpaw.atlas.fabric import (
     FABRIC_ID_PREFIX,
     FABRIC_KIND,
+    SOURCE_TRUTH_POINTER,
+    SOURCE_TRUTH_SAMPLE_CAP,
     FabricIntrospector,
+    RegistryFabricIntrospector,
     build_workspace_fabric_introspector,
     describe_fabric_id,
+    describe_fabric_id_async,
     search_entity_types,
 )
 
@@ -307,8 +324,6 @@ class TestEeAdapterReadPath:
         pytest.importorskip("pocketpaw_ee")
         from pocketpaw_ee.fabric import WorkspaceFabricRegistry, WorkspaceFabricStore
 
-        from pocketpaw.atlas.fabric import RegistryFabricIntrospector
-
         store = WorkspaceFabricStore(tmp_path / "fabric_registry.db")
         store.register_entity_type("ws-1", "Customer")
         store.register_property("ws-1", "Customer", "email")
@@ -422,8 +437,6 @@ class TestEeAdapter:
         # Another workspace's ontology must be invisible.
         store.register_entity_type("ws-2", "Secret")
 
-        from pocketpaw.atlas.fabric import RegistryFabricIntrospector
-
         adapter = RegistryFabricIntrospector(
             WorkspaceFabricRegistry(store=store, workspace_id="ws-1")
         )
@@ -442,3 +455,426 @@ class TestEeAdapter:
         assert cards and cards[0]["id"] == "fabric:Customer"
         payload = describe_fabric_id(adapter, "fabric:Customer")
         assert payload is not None and payload["properties"] == ["churn_risk", "email"]
+
+
+# ---------------------------------------------------------------------------
+# AST-2 — the type-level source-truth aggregate on describe
+# ---------------------------------------------------------------------------
+
+
+class _DictRegistry:
+    """Registry-shaped fake for RegistryFabricIntrospector (no pocketpaw_ee)."""
+
+    def __init__(self, schema: dict | None = None) -> None:
+        self._schema = _SCHEMA if schema is None else schema
+
+    def list_entity_types(self):
+        return sorted(self._schema)
+
+    def entity_type_exists(self, name):
+        return name in self._schema
+
+    def get_entity_properties(self, name):
+        return set(self._schema.get(name, {}).get("properties", []))
+
+    def list_entity_links(self, name):
+        return list(self._schema.get(name, {}).get("links", []))
+
+
+class _CountingStore:
+    """Transparent proxy over a real FabricStore that counts the statement
+    reads the aggregate may issue (the type-scoped keys lookup and the
+    per-key get_statements walk)."""
+
+    def __init__(self, store) -> None:
+        self._store = store
+        self.calls = {"list_statement_keys": 0, "get_statements": 0}
+
+    def __getattr__(self, name):
+        return getattr(self._store, name)
+
+    async def list_statement_keys(self, **kwargs):
+        self.calls["list_statement_keys"] += 1
+        return await self._store.list_statement_keys(**kwargs)
+
+    async def get_statements(self, *args, **kwargs):
+        self.calls["get_statements"] += 1
+        return await self._store.get_statements(*args, **kwargs)
+
+
+async def _fresh_store(tmp_path, monkeypatch):
+    """A FabricStore in 'off' mode (create_object writes NO statements, so
+    only the statements the test appends explicitly are tracked)."""
+    from pocketpaw.fabric.store import FabricStore
+
+    monkeypatch.setattr("pocketpaw.fabric.store._source_truth_mode", lambda: "off")
+    return FabricStore(tmp_path / "fabric.db")
+
+
+async def _seed_disputed_customer(store):
+    """One Customer whose ``arr`` has two competing OPEN statements from two
+    writer classes (connector 120 vs inferred 150) — cross-tier, materially
+    different, both open-validity → the resolver reports a dispute with the
+    connector as winner. Returns the store's type + object."""
+    obj_type = await store.define_type(name="Customer", properties=[])
+    obj = await store.create_object(obj_type.id, {"name": "Acme", "arr": 120})
+    crm = await store.upsert_source("connector_run", connector="crm", run_id="r1")
+    agent = await store.upsert_source("agent_session", session_id="s1")
+    await store.append_statement(obj.id, "arr", 120, crm.id, "connector")
+    await store.append_statement(obj.id, "arr", 150, agent.id, "inferred")
+    return obj_type, obj
+
+
+class TestSourceTruthAggregate:
+    @pytest.mark.asyncio
+    async def test_tracked_type_reports_dispute_and_winner_mix(self, tmp_path, monkeypatch):
+        store = await _fresh_store(tmp_path, monkeypatch)
+        await _seed_disputed_customer(store)
+        adapter = RegistryFabricIntrospector(_DictRegistry(), source_truth=store)
+
+        payload = await describe_fabric_id_async(adapter, "fabric:Customer")
+
+        assert payload is not None
+        # The registry payload is untouched by the additive field.
+        assert payload["properties"] == ["churn_risk", "email", "plan"]
+        st = payload["source_truth"]
+        assert st["tracked"] is True
+        assert st["sampled"] is False
+        assert st["object_count"] == 1
+        assert st["mode"] in ("off", "shadow", "enforce")
+        assert st["pointer"] == SOURCE_TRUTH_POINTER
+        # Only the TRACKED property appears; "name" (untracked) is absent.
+        assert set(st["properties"]) == {"arr"}
+        arr = st["properties"]["arr"]
+        assert arr["objects"] == 1
+        assert arr["disputed"] == 1  # open connector vs inferred rival, different values
+        assert arr["stale"] == 0 and arr["aging"] == 0  # both observed moments ago
+        assert arr["winner_writer_mix"] == {"connector": 1}  # ladder: connector > inferred
+
+    @pytest.mark.asyncio
+    async def test_stale_winner_counted(self, tmp_path, monkeypatch):
+        """A lone connector value observed long ago is the (stale) winner —
+        the aggregate counts it under ``stale`` and it is not disputed."""
+        store = await _fresh_store(tmp_path, monkeypatch)
+        obj_type = await store.define_type(name="Customer", properties=[])
+        obj = await store.create_object(obj_type.id, {"arr": 1})
+        crm = await store.upsert_source("connector_run", connector="crm", run_id="r1")
+        long_ago = datetime.now(UTC) - timedelta(days=400)
+        await store.append_statement(obj.id, "arr", 1, crm.id, "connector", observed_at=long_ago)
+        adapter = RegistryFabricIntrospector(_DictRegistry(), source_truth=store)
+
+        st = (await describe_fabric_id_async(adapter, "fabric:Customer"))["source_truth"]
+
+        assert st["properties"]["arr"] == {
+            "objects": 1,
+            "disputed": 0,
+            "stale": 1,
+            "aging": 0,
+            "winner_writer_mix": {"connector": 1},
+        }
+
+    @pytest.mark.asyncio
+    async def test_untracked_type_zero_statement_reads(self, tmp_path, monkeypatch):
+        """Type exists in the store but has NO statements: exactly one keys
+        lookup (the indexed existence check) and ZERO get_statements."""
+        store = await _fresh_store(tmp_path, monkeypatch)
+        obj_type = await store.define_type(name="Competitor", properties=[])
+        await store.create_object(obj_type.id, {"pricing_page": "x"})
+        spy = _CountingStore(store)
+        adapter = RegistryFabricIntrospector(_DictRegistry(), source_truth=spy)
+
+        payload = await describe_fabric_id_async(adapter, "fabric:Competitor")
+
+        st = payload["source_truth"]
+        assert st == {
+            "mode": st["mode"],
+            "tracked": False,
+            "sampled": False,
+            "object_count": 0,
+            "properties": {},
+            "pointer": SOURCE_TRUTH_POINTER,
+        }
+        assert spy.calls == {"list_statement_keys": 1, "get_statements": 0}, spy.calls
+
+    @pytest.mark.asyncio
+    async def test_type_unknown_to_store_zero_reads_at_all(self, tmp_path, monkeypatch):
+        """Registry knows the type, the statement store never saw it: no
+        statement read of any kind."""
+        store = await _fresh_store(tmp_path, monkeypatch)
+        spy = _CountingStore(store)
+        adapter = RegistryFabricIntrospector(_DictRegistry(), source_truth=spy)
+
+        st = (await describe_fabric_id_async(adapter, "fabric:Customer"))["source_truth"]
+
+        assert st["tracked"] is False
+        assert spy.calls == {"list_statement_keys": 0, "get_statements": 0}, spy.calls
+
+    @pytest.mark.asyncio
+    async def test_other_types_statements_do_not_leak_in(self, tmp_path, monkeypatch):
+        """Competitor's tracked keys never count toward Customer's roll-up
+        (the keys walk is type-scoped, not a full-fabric scan)."""
+        store = await _fresh_store(tmp_path, monkeypatch)
+        await _seed_disputed_customer(store)
+        comp = await store.define_type(name="Competitor", properties=[])
+        rival = await store.create_object(comp.id, {"pricing_page": "x"})
+        src = await store.upsert_source("document", document_uri="doc://1")
+        await store.append_statement(rival.id, "pricing_page", "y", src.id, "agent")
+        spy = _CountingStore(store)
+        adapter = RegistryFabricIntrospector(_DictRegistry(), source_truth=spy)
+
+        st = (await describe_fabric_id_async(adapter, "fabric:Customer"))["source_truth"]
+
+        assert set(st["properties"]) == {"arr"}
+        assert st["object_count"] == 1
+        # One keys lookup + one get_statements per tracked Customer key.
+        assert spy.calls == {"list_statement_keys": 1, "get_statements": 1}, spy.calls
+
+    @pytest.mark.asyncio
+    async def test_no_store_bound_field_absent(self):
+        adapter = RegistryFabricIntrospector(_DictRegistry())
+        payload = await describe_fabric_id_async(adapter, "fabric:Customer")
+        assert payload is not None
+        assert "source_truth" not in payload
+        assert payload["properties"] == ["churn_risk", "email", "plan"]
+
+    @pytest.mark.asyncio
+    async def test_raising_store_field_absent_payload_intact(self):
+        class BrokenStore:
+            async def get_type_by_name(self, *a, **k):
+                raise RuntimeError("fabric.db missing")
+
+        adapter = RegistryFabricIntrospector(_DictRegistry(), source_truth=BrokenStore())
+        payload = await describe_fabric_id_async(adapter, "fabric:Customer")
+        assert payload is not None
+        assert "source_truth" not in payload
+        assert payload["properties"] == ["churn_risk", "email", "plan"]
+
+    @pytest.mark.asyncio
+    async def test_plain_introspector_without_method_unchanged(self):
+        """An introspector lacking the optional method (the two-method fake)
+        answers exactly as before — no source_truth, no error."""
+        payload = await describe_fabric_id_async(FakeIntrospector(), "fabric:Customer")
+        assert payload == describe_fabric_id(FakeIntrospector(), "fabric:Customer")
+        assert "source_truth" not in payload
+
+    @pytest.mark.asyncio
+    async def test_search_never_calls_the_aggregate(self):
+        calls = {"aggregate": 0}
+
+        class Introspector(FakeIntrospector):
+            async def entity_type_source_truth(self, name):
+                calls["aggregate"] += 1
+                return {"tracked": True}
+
+        introspector = Introspector()
+        assert search_entity_types(introspector, "customer churn")
+        out = await _atlas_search_handler({"intent": "customer churn"}, introspector=introspector)
+        assert not out.get("is_error")
+        assert calls["aggregate"] == 0, "search must stay properties-only (FINDING B)"
+
+    @pytest.mark.asyncio
+    async def test_handler_merges_source_truth_for_fabric_id(self):
+        canned = {
+            "mode": "shadow",
+            "tracked": True,
+            "sampled": False,
+            "object_count": 41,
+            "properties": {"arr": {"objects": 41, "disputed": 3, "stale": 12, "aging": 0}},
+            "pointer": SOURCE_TRUTH_POINTER,
+        }
+
+        class Introspector(FakeIntrospector):
+            async def entity_type_source_truth(self, name):
+                assert name == "Customer"
+                return canned
+
+        out = await _atlas_describe_handler({"id": "fabric:Customer"}, introspector=Introspector())
+        assert not out.get("is_error")
+        payload = json.loads(_text_of(out))
+        assert payload["source_truth"] == canned
+        assert payload["properties"] == ["churn_risk", "email", "plan"]
+
+        # The two-method fake still answers without the field.
+        plain = json.loads(
+            _text_of(
+                await _atlas_describe_handler(
+                    {"id": "fabric:Customer"}, introspector=FakeIntrospector()
+                )
+            )
+        )
+        assert "source_truth" not in plain
+
+    @pytest.mark.asyncio
+    async def test_sample_cap_marks_sampled(self, tmp_path, monkeypatch, capsys):
+        """More tracked keys than the cap → sampled=True, walk stops at the
+        cap. Seeds cap+10 keys and prints the aggregate's wall-clock so the
+        per-describe cost of a saturated type is known."""
+        import sqlite3
+
+        store = await _fresh_store(tmp_path, monkeypatch)
+        obj_type = await store.define_type(name="Customer", properties=[])
+        src = await store.upsert_source("connector_run", connector="crm", run_id="r1")
+        objects = 51
+        props_per_object = 10  # 51 * 10 = 510 keys > cap (500)
+        obj_ids = []
+        for i in range(objects):
+            obj = await store.create_object(obj_type.id, {"idx": i})
+            obj_ids.append(obj.id)
+        # Bulk-seed statements straight into the tmp DB (the store's schema is
+        # already ensured) — this is fixture speed, not the read under test.
+        now = datetime.now(UTC).isoformat()
+        rows = [
+            (
+                f"st-{i}-{p}",
+                oid,
+                f"p{p}",
+                json.dumps(i),
+                src.id,
+                "connector",
+                now,
+                now,
+                now,
+                None,
+                "normal",
+                None,
+                0,
+                None,
+            )
+            for i, oid in enumerate(obj_ids)
+            for p in range(props_per_object)
+        ]
+        with sqlite3.connect(tmp_path / "fabric.db") as db:
+            db.executemany(
+                "INSERT INTO fabric_statements (id, object_id, property, value, "
+                "source_ref_id, writer_class, observed_at, recorded_at, valid_from, "
+                "valid_to, rank, rank_reason, pinned, workspace_id) "
+                "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                rows,
+            )
+        spy = _CountingStore(store)
+        adapter = RegistryFabricIntrospector(_DictRegistry(), source_truth=spy)
+
+        t0 = time.perf_counter()
+        st = (await describe_fabric_id_async(adapter, "fabric:Customer"))["source_truth"]
+        elapsed = time.perf_counter() - t0
+        print(
+            f"\n[AST-2 sample-cap] {objects * props_per_object} tracked keys → "
+            f"walked {SOURCE_TRUTH_SAMPLE_CAP} in {elapsed:.2f}s"
+        )
+
+        assert st["tracked"] is True
+        assert st["sampled"] is True
+        assert sum(p["objects"] for p in st["properties"].values()) == SOURCE_TRUTH_SAMPLE_CAP
+        assert spy.calls["list_statement_keys"] == 1
+        assert spy.calls["get_statements"] == SOURCE_TRUTH_SAMPLE_CAP
+
+
+class TestStoreTypeScopedKeys:
+    """The store read helper behind the aggregate: ``list_statement_keys``
+    with ``type_id`` / ``limit`` (additive kwargs)."""
+
+    @pytest.mark.asyncio
+    async def test_type_id_scopes_and_limit_caps(self, tmp_path, monkeypatch):
+        store = await _fresh_store(tmp_path, monkeypatch)
+        cust_type, cust = await _seed_disputed_customer(store)
+        comp = await store.define_type(name="Competitor", properties=[])
+        rival = await store.create_object(comp.id, {"pricing_page": "x"})
+        src = await store.upsert_source("document", document_uri="doc://1")
+        await store.append_statement(rival.id, "pricing_page", "y", src.id, "agent")
+        await store.append_statement(rival.id, "hq", "Berlin", src.id, "agent")
+
+        # Unscoped (existing behavior): every tracked key.
+        assert len(await store.list_statement_keys()) == 3
+        # Type-scoped: only that type's keys.
+        assert await store.list_statement_keys(type_id=cust_type.id) == [(cust.id, "arr")]
+        comp_keys = await store.list_statement_keys(type_id=comp.id)
+        assert comp_keys == [(rival.id, "hq"), (rival.id, "pricing_page")]
+        # limit caps the walk.
+        assert await store.list_statement_keys(type_id=comp.id, limit=1) == [(rival.id, "hq")]
+        # Unknown type → nothing.
+        assert await store.list_statement_keys(type_id="nope") == []
+
+    @pytest.mark.asyncio
+    async def test_type_scoped_query_uses_indexes(self, tmp_path, monkeypatch):
+        """EXPLAIN QUERY PLAN: the type-scoped walk is an indexed SEARCH on
+        both sides (idx_objects_type → idx_statements_object[_property]) —
+        never a full table SCAN on either."""
+        import sqlite3
+
+        store = await _fresh_store(tmp_path, monkeypatch)
+        await _seed_disputed_customer(store)
+        with sqlite3.connect(tmp_path / "fabric.db") as db:
+            plan = db.execute(
+                "EXPLAIN QUERY PLAN SELECT DISTINCT s.object_id, s.property "
+                "FROM fabric_statements s JOIN fabric_objects o ON o.id = s.object_id "
+                "WHERE o.type_id = ? ORDER BY s.object_id, s.property LIMIT ?",
+                ("t", 501),
+            ).fetchall()
+        text = " | ".join(str(r[3]) for r in plan)
+        assert "SCAN" not in text, text
+        assert "idx_objects_type" in text, text
+        assert "idx_statements_object" in text, text
+
+
+class TestBuilderBindsSourceTruth:
+    def test_builder_degrades_source_truth_alone(self, tmp_path, monkeypatch):
+        """get_fabric_store raising must NOT null the introspector: the registry
+        payload still answers and only source_truth is absent."""
+        pytest.importorskip("pocketpaw_ee")
+        import pocketpaw_ee.fabric as ee_fabric
+
+        registry_store = ee_fabric.WorkspaceFabricStore(tmp_path / "fabric_registry.db")
+        registry_store.register_entity_type("ws-1", "Customer")
+        registry_store.register_property("ws-1", "Customer", "email")
+        monkeypatch.setattr(ee_fabric, "WorkspaceFabricStore", lambda: registry_store)
+
+        def boom(**_kw):
+            raise RuntimeError("fabric.db unavailable")
+
+        monkeypatch.setattr("pocketpaw.stores.get_fabric_store", boom)
+
+        introspector = build_workspace_fabric_introspector("ws-1")
+        assert introspector is not None
+        payload = describe_fabric_id(introspector, "fabric:Customer")
+        assert payload is not None and payload["properties"] == ["email"]
+
+        import asyncio
+
+        async_payload = asyncio.run(describe_fabric_id_async(introspector, "fabric:Customer"))
+        assert async_payload is not None
+        assert "source_truth" not in async_payload
+
+    def test_builder_binds_workspace_store(self, tmp_path, monkeypatch):
+        """Happy path: the builder hands the introspector the workspace's
+        FabricStore, and describe carries source_truth."""
+        pytest.importorskip("pocketpaw_ee")
+        import pocketpaw_ee.fabric as ee_fabric
+
+        registry_store = ee_fabric.WorkspaceFabricStore(tmp_path / "fabric_registry.db")
+        registry_store.register_entity_type("ws-1", "Customer")
+        monkeypatch.setattr(ee_fabric, "WorkspaceFabricStore", lambda: registry_store)
+
+        from pocketpaw.fabric.store import FabricStore
+
+        monkeypatch.setattr("pocketpaw.fabric.store._source_truth_mode", lambda: "off")
+        fabric_store = FabricStore(tmp_path / "fabric.db")
+        seen = {}
+
+        def fake_get_fabric_store(*, workspace_id=None):
+            seen["workspace_id"] = workspace_id
+            return fabric_store
+
+        monkeypatch.setattr("pocketpaw.stores.get_fabric_store", fake_get_fabric_store)
+
+        introspector = build_workspace_fabric_introspector("ws-1")
+        assert introspector is not None
+        assert seen == {"workspace_id": "ws-1"}
+
+        import asyncio
+
+        async def _run():
+            await _seed_disputed_customer(fabric_store)
+            return await describe_fabric_id_async(introspector, "fabric:Customer")
+
+        payload = asyncio.run(_run())
+        assert payload["source_truth"]["properties"]["arr"]["disputed"] == 1


### PR DESCRIPTION
## What

The atlas Fabric introspector describes entity *types* from the ontology registry — it knows `Customer` has a property `arr` but nothing about whether `arr` is disputed, stale, or inferred. Source-truth attaches to object *instances*, in a different database. This adds one bounded, type-level read that bridges them. Stacked on #1958 (AST-2).

## Change

`atlas_describe fabric:<Type>` now carries an additive `source_truth` roll-up: per property, how many tracked objects, how many disputed / stale / aging, and the winner writer-class mix, plus `mode` / `tracked` / `sampled` / `object_count` and a pointer to `fabric_query include_provenance=true` for the per-object answer. It points at the shipped instance-level read instead of duplicating it.

Mechanics:
- A new optional, **async**, duck-typed `RegistryFabricIntrospector.entity_type_source_truth` — documented in the same "optional, not a Protocol member" block as `list_entity_properties` (adding it to the Protocol would break `isinstance` for two-method fakes).
- `build_workspace_fabric_introspector` binds the OSS `get_fabric_store(workspace_id=)` in an inner try, so a store failure degrades alone.
- Only the new `describe_fabric_id_async` consumes it (`getattr` + `callable` + `await`, from the already-async handler). The sync `describe_fabric_id` is unchanged. Search never calls it — search stays properties-only.
- `FabricStore.list_statement_keys` gained additive `type_id` / `limit` kwargs: an indexed `fabric_objects(type_id) ⋈ fabric_statements(object_id)` join. Existing callers are byte-identical.

The winner cache stores only the value, so `is_disputed` / freshness / winner writer-class are computed by running the pure resolver per tracked key — cost bounded by the tracked-key set, never a full-fabric scan. Cap 500 keys → `sampled=true`. Untracked type = one indexed lookup, zero statement reads.

## Verified

- `pytest tests/atlas` → 202 passed (baseline 187 + 15 new); the #1645 N+1 regression test still green.
- Zero-read proof (spy over a real store): untracked → `{list_statement_keys: 1, get_statements: 0}`.
- Tracked demo: two competing statements on `arr` → `properties.arr.disputed == 1`, `winner_writer_mix == {connector: 1}`.
- Sample cap: 510 tracked keys → walked 500 in 0.28s, `sampled` true.
- `EXPLAIN QUERY PLAN` pinned: `SEARCH ... USING INDEX idx_objects_type` / `USING COVERING INDEX idx_statements_object_property`, no SCAN.
- Store-binding failure → registry payload intact, `source_truth` absent.
- `atlas build --check` unchanged; both import-linter configs green; ruff clean.