### PR TITLE
Mark the flagged atlas primitives with their live rollout mode

### DIFF
--- a/docs/atlas.md
+++ b/docs/atlas.md
@@ -67,6 +67,9 @@ search dropped a 3N sqlite N+1. SECURITY (separate PRs): the role-aware
 provider now re-resolves per turn (a warm shared client had leaked owner
 cards to a member), and the admin path gained an OWNER guard on owner-grants
 + an atomic approve.
+Updated: 2026-08-17 (feat/ast-3-atlas-flag-aware, AST-3) — flag-aware
+`available` + tri-state `mode` for primitive:source-truth / primitive:verify-loop
+in the overlay section; `mode?` on search cards.
 -->
 
 # Atlas — the OS self-model
@@ -242,6 +245,19 @@ the calling workspace's reality:
   listing. No "upgrade to see this" leakage in v1. If
   `connected_connector_names` raises, every connector is annotated
   `available: false` (unavailable, not filtered).
+- **Flag-aware primitives (AST-3)** — `primitive:source-truth` and
+  `primitive:verify-loop` ship behind rollout flags that default off. They are
+  ALWAYS described (discoverable — hiding them would misdirect the agent), but
+  the overlay stamps `available` (flag not `off`) plus a tri-state `mode`
+  (`off` | `shadow` | `enforce`), read from live settings on every pass:
+  source-truth from `fabric_source_truth_mode`
+  (`POCKETPAW_FABRIC_SOURCE_TRUTH_MODE`); verify-loop from the HIGHER of
+  `effective_deep_work_verify_mode()` / `effective_cloud_plan_verify_mode()`
+  (`POCKETPAW_DEEP_WORK_VERIFY_MODE` / `POCKETPAW_CLOUD_PLAN_VERIFY_MODE`).
+  Search cards and describe carry `mode`; an off primitive's describe adds
+  `enable_hint` (the env-flag pointer) instead of the connector `connect_hint`,
+  and it demotes below available entries at equal relevance exactly like an
+  unavailable connector. Discovery hints only — never an enforcement gate.
 - **Re-ranking** — search results get a stable re-sort so an available
   connector ranks above an unavailable one at EQUAL relevance; the store's
   base scoring is untouched (an unavailable-but-more-relevant entry still
@@ -333,7 +349,7 @@ path), so it is ambient on every agent run. Two tools:
 - **Args:** `intent` (string, required) — what the agent is trying to do,
   e.g. `"approve agent actions"` or `"publish a website"`.
 - **Returns:** ranked capability cards as JSON —
-  `{"results": [{id, kind, name, summary, surface?, available?}, ...]}`
+  `{"results": [{id, kind, name, summary, surface?, available?, mode?}, ...]}`
   (top 5). Simple lexical scoring over name / keywords / summary /
   narrative with suffix normalization (see "Search ranking rules"); name
   and keyword hits rank highest. `available` appears on

--- a/ee/pocketpaw_ee/agent/atlas_provider.py
+++ b/ee/pocketpaw_ee/agent/atlas_provider.py
@@ -14,6 +14,14 @@
 #   is a capability-DISCLOSURE leak (a member seeing cards they can't use), not an
 #   enforcement bypass — but a real leak worth fixing. Warm-client sharing is left
 #   untouched (the surgical option).
+# Updated: 2026-08-17 (feat/ast-3-atlas-flag-aware, AST-3) — no code change.
+#   The rollout-flagged primitives (``primitive:source-truth`` /
+#   ``primitive:verify-loop``) get their ``available`` + tri-state ``mode`` from
+#   the CORE overlay's ``_overlay_one`` (provider-independent, read from live
+#   settings per pass), so this provider has parity with the OSS default by
+#   construction — pinned in tests/ee/agent/test_atlas_role_provider.py
+#   (``TestFlagAwareParity``), not duplicated here. The ``capability:fabric.*``
+#   cards stay ``role:member``-gated regardless of mode.
 #
 # The DISCOVERY layer for the workspace-admin tools — NOT the security gate.
 # The RBAC checks INSIDE each admin tool (workspace_admin.py) are the real lock

--- a/src/pocketpaw/agents/sdk_mcp_atlas.py
+++ b/src/pocketpaw/agents/sdk_mcp_atlas.py
@@ -58,6 +58,17 @@
 # introspector exposes the optional ``entity_type_source_truth``. Handlers are
 # already async, so the aiosqlite read runs in the handler's own loop — no sync
 # bridge. Search is untouched (properties-only, FINDING B).
+#
+# Updated: 2026-08-17 (feat/ast-3-atlas-flag-aware, AST-3) — the two
+# rollout-flagged primitives (``primitive:source-truth`` / ``primitive:verify-loop``)
+# now come through the overlay with ``available`` (flag not off) and a tri-state
+# ``mode`` (off | shadow | enforce). Search cards and the describe payload carry
+# ``mode`` whenever the overlay set it; an OFF primitive's describe payload adds
+# ``enable_hint`` (the env-flag pointer from ``overlay.FLAG_ENABLE_HINTS``) —
+# the same shape as an unavailable connector's ``connect_hint``, different
+# pointer — and NEVER the integrations-surface hint. Discovery hints only; the
+# ``provider is None`` global path is unchanged (production always passes a
+# provider — claude_sdk.py builds one per run).
 
 from __future__ import annotations
 
@@ -153,7 +164,7 @@ async def _atlas_search_handler(
         from pocketpaw.atlas.overlay import entry_role_requirement
 
         overlaid = [
-            (entry, None)
+            (entry, None, None)
             for entry in store.search(intent, limit=5)
             if entry_role_requirement(entry) is None
         ]
@@ -163,7 +174,8 @@ async def _atlas_search_handler(
         # WA-3: resolve the caller's role (async) before the sync grant filter.
         await _prime_provider(provider)
         overlaid = [
-            (o.entry, o.available) for o in AtlasOverlay.search(store, intent, provider, limit=5)
+            (o.entry, o.available, o.mode)
+            for o in AtlasOverlay.search(store, intent, provider, limit=5)
         ]
 
     fabric_cards: list[dict[str, Any]] = []
@@ -177,7 +189,7 @@ async def _atlas_search_handler(
         return _text_result(f"No atlas entries matched intent: {intent!r}. Try broader wording.")
 
     cards: list[dict[str, Any]] = []
-    for entry, available in overlaid:
+    for entry, available, mode in overlaid:
         card: dict[str, Any] = {
             "id": entry.id,
             "kind": entry.kind,
@@ -188,6 +200,10 @@ async def _atlas_search_handler(
             card["surface"] = entry.surface
         if available is not None:
             card["available"] = available
+        if mode is not None:
+            # AST-3: rollout-flagged primitive — its tri-state mode is a
+            # discovery hint (off | shadow | enforce), not a grant.
+            card["mode"] = mode
         cards.append(card)
     # Fabric cards ride AFTER every compiled-entry card (AT-7): live
     # ontology hits are additive context, never displacing OS answers.
@@ -269,7 +285,19 @@ async def _atlas_describe_handler(
         )
 
     payload = overlaid.entry.model_dump(mode="json", by_alias=True)
-    if overlaid.available is not None:
+    if overlaid.mode is not None:
+        # AST-3: rollout-flagged primitive — always described (discoverable),
+        # honestly marked live or not for THIS deployment. Off → the env-flag
+        # pointer, never the connector's integrations-surface hint.
+        from pocketpaw.atlas.overlay import FLAG_ENABLE_HINTS
+
+        payload["available"] = overlaid.available
+        payload["mode"] = overlaid.mode
+        if overlaid.available is False:
+            payload["enable_hint"] = FLAG_ENABLE_HINTS.get(
+                overlaid.entry.id, "Off in this deployment (see docs/atlas.md)."
+            )
+    elif overlaid.available is not None:
         payload["available"] = overlaid.available
         if overlaid.available is False:
             # Route the lookup through the overlay: a provider that filters

--- a/src/pocketpaw/atlas/overlay.py
+++ b/src/pocketpaw/atlas/overlay.py
@@ -43,6 +43,24 @@
 #   ``ws:<workspace_id>`` scope instead. Nothing is entitlement-gated in
 #   OSS — ``is_granted`` is always True, so OS-level entries (primitives,
 #   surfaces, senses) are never filtered by default.
+#
+# Updated: 2026-08-17 (feat/ast-3-atlas-flag-aware, AST-3) — flag-aware
+# ``available`` for the two rollout-flagged primitives. ``primitive:source-truth``
+# and ``primitive:verify-loop`` ship behind flags that default OFF; atlas must
+# stay DISCOVERABLE (always describe them — hiding them recreates the known
+# misdirection bug) and HONEST (say whether they are live for THIS deployment).
+# ``_overlay_one`` now stamps ``available = (mode != "off")`` plus an additive
+# tri-state ``OverlaidEntry.mode`` ("off" | "shadow" | "enforce") on exactly
+# those two ids, read from live settings once per overlay pass (``_flag_modes``,
+# never cached at import): source-truth reads ``fabric_source_truth_mode``;
+# verify-loop reads the HIGHER of ``effective_deep_work_verify_mode()`` /
+# ``effective_cloud_plan_verify_mode()`` (enforce > shadow > off). Because it is
+# stamped in ``_overlay_one`` (provider-independent), every provider — the OSS
+# default and the EE role-aware one — gets identical mode/availability for free.
+# ``available`` stays a bool so the EXISTING equal-score demotion re-sort in
+# ``search`` applies unchanged. ``FLAG_ENABLE_HINTS`` carries the "how to enable"
+# pointer describe renders when off. DISCOVERY HINTS ONLY — never an
+# enforcement gate (``is_granted`` is untouched by the flags).
 
 from __future__ import annotations
 
@@ -73,6 +91,31 @@ ROLE_REQUIRE_PREFIX = "role:"
 # ``pocketpaw_ee.guards.rbac._ROLE_LEVELS`` (owner > admin > member) so the EE
 # provider and this core module agree without an EE import at core scope.
 ROLE_LEVELS: dict[str, int] = {"member": 1, "admin": 2, "owner": 3}
+
+# Rollout-flagged primitives (AST-3): always DESCRIBED (discoverable), but
+# their ``available`` + tri-state ``mode`` come from the deployment's rollout
+# flags, read from live settings once per overlay pass (see ``_flag_modes``).
+FLAGGED_PRIMITIVE_IDS: tuple[str, ...] = ("primitive:source-truth", "primitive:verify-loop")
+
+# The one-line "how to enable" pointer describe renders when a flagged
+# primitive is off — same shape as the unavailable-connector ``connect_hint``,
+# different pointer (env flag instead of the integrations surface).
+FLAG_ENABLE_HINTS: dict[str, str] = {
+    "primitive:source-truth": (
+        "Source-truth is off in this deployment — set "
+        "POCKETPAW_FABRIC_SOURCE_TRUTH_MODE=shadow|enforce to enable it "
+        "(see docs/atlas.md)."
+    ),
+    "primitive:verify-loop": (
+        "The verify loop is off in this deployment — set deep_work_verify_mode "
+        "and/or cloud_plan_verify_mode (POCKETPAW_DEEP_WORK_VERIFY_MODE / "
+        "POCKETPAW_CLOUD_PLAN_VERIFY_MODE) to shadow|enforce to enable it "
+        "(see docs/atlas.md)."
+    ),
+}
+
+# Tri-state ordering for the verify-loop mode fold (enforce > shadow > off).
+_MODE_RANK: dict[str, int] = {"off": 0, "shadow": 1, "enforce": 2}
 
 
 def entry_role_requirement(entry: AtlasEntry) -> str | None:
@@ -117,14 +160,22 @@ class EntitlementProvider(Protocol):
 class OverlaidEntry:
     """A store entry viewed through one context's overlay.
 
-    ``available`` is a connector-only annotation: True/False for
-    ``kind="connector"`` entries (connected in this context or not), None
-    for every other kind. The wrapped ``entry`` is the shared store's
-    object — treat it as read-only.
+    ``available`` is True/False for ``kind="connector"`` entries (connected
+    in this context or not) and for the rollout-flagged primitives in
+    ``FLAGGED_PRIMITIVE_IDS`` (flag not ``"off"`` for this deployment), None
+    for everything else. ``mode`` is the flagged primitives' tri-state
+    rollout mode (``"off"`` | ``"shadow"`` | ``"enforce"``), None for every
+    other entry.
+
+    Both are DISCOVERY HINTS ONLY (ranking + describe wording) — never an
+    enforcement gate. Nothing may authorize on them; grants come from
+    ``EntitlementProvider.is_granted`` alone. The wrapped ``entry`` is the
+    shared store's object — treat it as read-only.
     """
 
     entry: AtlasEntry
     available: bool | None = None
+    mode: str | None = None
 
 
 def _connector_name(entry: AtlasEntry) -> str:
@@ -156,10 +207,45 @@ def _is_granted(provider: EntitlementProvider, entry: AtlasEntry) -> bool:
         return False
 
 
-def _overlay_one(entry: AtlasEntry, connected: set[str] | None) -> OverlaidEntry:
+def _flag_modes() -> dict[str, str]:
+    """Resolve the rollout mode of each flagged primitive from LIVE settings.
+
+    Called once per overlay pass (never at import) so a mid-session flag flip
+    — or a monkeypatched setting — is reflected on the next atlas call.
+    ``primitive:verify-loop`` folds its two flags to the HIGHER one
+    (enforce > shadow > off): the loop is live if EITHER terminal runs it, and
+    the strongest position is the honest headline. Fail-closed: a settings
+    failure reports ``"off"`` for both — the entry is still described, just
+    marked not live.
+    """
+    try:
+        from pocketpaw.config import get_settings
+
+        settings = get_settings()
+        verify_modes = (
+            settings.effective_deep_work_verify_mode(),
+            settings.effective_cloud_plan_verify_mode(),
+        )
+        return {
+            "primitive:source-truth": settings.fabric_source_truth_mode,
+            "primitive:verify-loop": max(verify_modes, key=lambda m: _MODE_RANK.get(m, 0)),
+        }
+    except Exception as exc:  # noqa: BLE001 — fail closed to "off", never break the tool
+        logger.warning("atlas overlay: rollout-flag resolution failed: %s", exc)
+        return dict.fromkeys(FLAGGED_PRIMITIVE_IDS, "off")
+
+
+def _overlay_one(
+    entry: AtlasEntry, connected: set[str] | None, modes: dict[str, str]
+) -> OverlaidEntry:
     if entry.kind == "connector":
         available = connected is not None and _connector_name(entry) in connected
         return OverlaidEntry(entry=entry, available=available)
+    mode = modes.get(entry.id)
+    if mode is not None:
+        # Flag-aware primitive (AST-3): a discovery hint, never a grant —
+        # the entry is always returned, only marked live or not.
+        return OverlaidEntry(entry=entry, available=mode != "off", mode=mode)
     return OverlaidEntry(entry=entry, available=None)
 
 
@@ -179,7 +265,12 @@ class AtlasOverlay:
         is wanted on scored results.
         """
         connected = _connected_names(provider)
-        return [_overlay_one(entry, connected) for entry in entries if _is_granted(provider, entry)]
+        modes = _flag_modes()
+        return [
+            _overlay_one(entry, connected, modes)
+            for entry in entries
+            if _is_granted(provider, entry)
+        ]
 
     @staticmethod
     def search(
@@ -198,11 +289,12 @@ class AtlasOverlay:
         if limit <= 0:
             return []
         connected = _connected_names(provider)
+        modes = _flag_modes()
         ranked: list[tuple[float, int, OverlaidEntry]] = []
         for score, entry in store.search_scored(query):
             if not _is_granted(provider, entry):
                 continue
-            overlaid = _overlay_one(entry, connected)
+            overlaid = _overlay_one(entry, connected, modes)
             demoted = 1 if overlaid.available is False else 0
             ranked.append((score, demoted, overlaid))
         # Stable sort: score desc, then available-before-unavailable; ties
@@ -222,7 +314,7 @@ class AtlasOverlay:
         entry = store.describe(entry_id)
         if entry is None or not _is_granted(provider, entry):
             return None
-        return _overlay_one(entry, _connected_names(provider))
+        return _overlay_one(entry, _connected_names(provider), _flag_modes())
 
     @staticmethod
     def visible_ids(store: AtlasStore, provider: EntitlementProvider) -> list[str]:
@@ -320,6 +412,8 @@ def build_role_aware_provider(scope_key: str) -> EntitlementProvider | None:
 
 __all__ = [
     "DEFAULT_SCOPE_KEY",
+    "FLAG_ENABLE_HINTS",
+    "FLAGGED_PRIMITIVE_IDS",
     "ROLE_LEVELS",
     "ROLE_REQUIRE_PREFIX",
     "AtlasOverlay",

--- a/tests/atlas/test_compile.py
+++ b/tests/atlas/test_compile.py
@@ -28,12 +28,19 @@
 # Updated: 2026-08-17 (feat/ast-1-atlas-primitives, AST-1) — primitive count
 # assertion bumped 10 → 12 for the new authored primitive:source-truth and
 # primitive:verify-loop entries.
+# Updated: 2026-08-17 (feat/ast-3-atlas-flag-aware, AST-3) — TestFactualClaimGuard
+# gains a LIVENESS guard: the two rollout-flagged primitives default OFF, so a
+# describe payload must never read as live source-truth / verification when the
+# mode is off — the rendered text has to carry ``mode: off`` + the enable
+# pointer, and the ``available``/``mode`` overlay hints must be present.
 
 import json
 import logging
 import os
 import re
 from pathlib import Path
+
+import pytest
 
 from pocketpaw.atlas.compile import (
     AUTHORED_FILES,
@@ -150,6 +157,44 @@ class TestFactualClaimGuard:
             "widgets') — approximations drift silently past the fidelity-only "
             "check. Use a verified exact count or an open-ended '150+':\n" + "\n".join(offenders)
         )
+
+    # AST-3: the rollout-flagged primitives default OFF. Their authored prose
+    # describes what the subsystem DOES; only the overlay can say whether it is
+    # live for THIS deployment. When the flag is off, the rendered describe must
+    # carry the mode + enable pointer so the payload cannot be read as "live
+    # source-truth / verification is running here" — the same misdirection
+    # class as a false route claim, at the deployment level.
+    _FLAGGED = {
+        "primitive:source-truth": "POCKETPAW_FABRIC_SOURCE_TRUTH_MODE",
+        "primitive:verify-loop": "deep_work_verify_mode",
+    }
+
+    @pytest.mark.asyncio
+    async def test_off_flagged_primitive_describe_declares_mode_and_enable_pointer(
+        self, monkeypatch
+    ):
+        from pocketpaw.agents.sdk_mcp_atlas import _atlas_describe_handler
+        from pocketpaw.atlas.overlay import DefaultEntitlementProvider
+        from pocketpaw.config import get_settings
+
+        settings = get_settings()
+        for name in ("fabric_source_truth_mode", "deep_work_verify_mode", "cloud_plan_verify_mode"):
+            monkeypatch.setattr(settings, name, "off")
+        for name in ("deep_work_verify_loop_enabled", "cloud_plan_verify_loop_enabled"):
+            monkeypatch.setattr(settings, name, False)
+
+        provider = DefaultEntitlementProvider(registry=type("R", (), {"status": lambda *_: []})())
+        for entry_id, pointer in self._FLAGGED.items():
+            out = await _atlas_describe_handler({"id": entry_id}, provider)
+            assert not out.get("is_error"), f"{entry_id} must stay DESCRIBABLE when off"
+            text = out["content"][0]["text"]
+            payload = json.loads(text)
+            assert payload["available"] is False, entry_id
+            assert payload["mode"] == "off", entry_id
+            # Rendered text carries the honesty markers an agent will read.
+            assert '"mode": "off"' in text, f"{entry_id}: describe must declare mode off"
+            assert pointer in text, f"{entry_id}: describe must say how to enable it"
+            assert "docs/atlas.md" in payload["enable_hint"], entry_id
 
 
 class TestConnectorExtraction:

--- a/tests/atlas/test_overlay.py
+++ b/tests/atlas/test_overlay.py
@@ -21,6 +21,11 @@
 # non-role entry, proving OSS never leaks admin capabilities; and
 # ``build_role_aware_provider`` returns None for a non-``ws:`` scope so the
 # fail-closed default stays in place.
+# Updated: 2026-08-17 (feat/ast-3-atlas-flag-aware, AST-3) — the "available on
+# connectors only" card invariant now exempts the two rollout-flagged primitives
+# (``FLAGGED_PRIMITIVE_IDS``), which legitimately carry ``available`` + ``mode``
+# from the deployment flags; the flag behaviour itself is pinned in
+# test_overlay_flags.py.
 
 import json
 
@@ -33,6 +38,7 @@ from pocketpaw.agents.sdk_mcp_atlas import (
 from pocketpaw.atlas.model import AtlasEntry, AtlasModel
 from pocketpaw.atlas.overlay import (
     DEFAULT_SCOPE_KEY,
+    FLAGGED_PRIMITIVE_IDS,
     ROLE_LEVELS,
     AtlasOverlay,
     DefaultEntitlementProvider,
@@ -417,7 +423,7 @@ class TestMcpHandlersWithProvider:
         for card in cards:
             if card["kind"] == "connector":
                 assert card["available"] is (card["id"] == "connector:stripe")
-            else:
+            elif card["id"] not in FLAGGED_PRIMITIVE_IDS:  # AST-3: flag-aware
                 assert "available" not in card
 
     @pytest.mark.asyncio

--- a/tests/atlas/test_overlay_flags.py
+++ b/tests/atlas/test_overlay_flags.py
@@ -1,0 +1,309 @@
+# tests/atlas/test_overlay_flags.py — flag-aware ``available`` (tri-state
+# ``mode``) for the rollout-flagged primitives (AST-3). Created: 2026-08-17
+# (feat/ast-3-atlas-flag-aware). Proves, on a synthetic store and through the
+# real MCP handlers: ``primitive:source-truth`` reads
+# ``settings.fabric_source_truth_mode`` and ``primitive:verify-loop`` reads the
+# HIGHER of ``effective_deep_work_verify_mode()`` /
+# ``effective_cloud_plan_verify_mode()`` (enforce > shadow > off) — per overlay
+# pass, so a monkeypatched setting is seen immediately; ``off`` → ``available
+# False`` + ``mode "off"`` and the existing equal-score demotion re-sort ranks
+# the entry below an available primitive; ``shadow`` / ``enforce`` → ``available
+# True`` with the mode surfaced; every other entry stays ``available None`` /
+# ``mode None``; ``available``/``mode`` are DISCOVERY HINTS ONLY — ``is_granted``
+# and describe/visible_ids never filter on them (the primitives stay
+# describable at every mode); a settings failure fails closed to ``off``
+# (still described); describe renders ``mode`` + an ``enable_hint`` (env-var
+# pointer, NOT the connector ``connect_hint``) when off and no hint when live;
+# search cards carry ``mode`` for the two primitives.
+
+import json
+
+import pytest
+
+from pocketpaw.agents.sdk_mcp_atlas import (
+    _atlas_describe_handler,
+    _atlas_search_handler,
+)
+from pocketpaw.atlas.model import AtlasEntry, AtlasModel
+from pocketpaw.atlas.overlay import (
+    FLAG_ENABLE_HINTS,
+    FLAGGED_PRIMITIVE_IDS,
+    AtlasOverlay,
+    DefaultEntitlementProvider,
+    OverlaidEntry,
+)
+from pocketpaw.atlas.store import AtlasStore
+from pocketpaw.config import get_settings
+
+SOURCE_TRUTH = "primitive:source-truth"
+VERIFY_LOOP = "primitive:verify-loop"
+
+
+# ── fixtures ────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def flags(monkeypatch):
+    """Pin EVERY flag input on the live settings object (never rely on the
+    machine's ambient config.json — the legacy verify bools alone would flip
+    the effective mode to ``enforce``). Returns a setter for per-test flips."""
+
+    def _set(
+        *,
+        fabric: str = "off",
+        deep_work: str = "off",
+        cloud_plan: str = "off",
+        deep_work_legacy: bool = False,
+        cloud_plan_legacy: bool = False,
+    ) -> None:
+        settings = get_settings()
+        monkeypatch.setattr(settings, "fabric_source_truth_mode", fabric)
+        monkeypatch.setattr(settings, "deep_work_verify_mode", deep_work)
+        monkeypatch.setattr(settings, "cloud_plan_verify_mode", cloud_plan)
+        monkeypatch.setattr(settings, "deep_work_verify_loop_enabled", deep_work_legacy)
+        monkeypatch.setattr(settings, "cloud_plan_verify_loop_enabled", cloud_plan_legacy)
+
+    _set()
+    return _set
+
+
+def _entry(entry_id: str, kind: str, name: str, **kw) -> AtlasEntry:
+    return AtlasEntry(
+        id=entry_id,
+        kind=kind,
+        name=name,
+        summary=kw.pop("summary", f"{name} summary"),
+        narrative=kw.pop("narrative", f"{name} narrative"),
+        **kw,
+    )
+
+
+def _synthetic_store() -> AtlasStore:
+    """The two flagged primitives + an always-on primitive sharing their
+    keywords (equal-score demotion case), a surface, and a connector. Seed
+    order puts the flagged primitives FIRST so a re-sort is provably the
+    overlay's doing, not seed order."""
+    return AtlasStore(
+        AtlasModel(
+            entries=[
+                _entry(SOURCE_TRUTH, "primitive", "Source-truth", keywords=["provenance"]),
+                _entry(VERIFY_LOOP, "primitive", "Verify loop", keywords=["verdict"]),
+                _entry(
+                    "primitive:pocket", "primitive", "Pocket", keywords=["provenance", "verdict"]
+                ),
+                _entry("surface:integrations", "surface", "Integrations", surface="/x/int"),
+                _entry("connector:alpha_crm", "connector", "Alpha CRM", keywords=["crm"]),
+            ]
+        )
+    )
+
+
+class FakeProvider:
+    def __init__(self, connected=frozenset()):
+        self._connected = set(connected)
+
+    def connected_connector_names(self):
+        return set(self._connected)
+
+    def is_granted(self, entry):
+        return True
+
+
+def _by_id(store: AtlasStore, provider) -> dict[str, OverlaidEntry]:
+    return {o.entry.id: o for o in AtlasOverlay.apply(store.entries, provider)}
+
+
+def _text_of(result: dict) -> str:
+    return next(c for c in result["content"] if c["type"] == "text")["text"]
+
+
+# ── the flag → available/mode mapping ───────────────────────────────────
+
+
+class TestSourceTruthMode:
+    def test_off_is_unavailable_with_mode_off(self, flags):
+        by_id = _by_id(_synthetic_store(), FakeProvider())
+        assert by_id[SOURCE_TRUTH].available is False
+        assert by_id[SOURCE_TRUTH].mode == "off"
+
+    @pytest.mark.parametrize("mode", ["shadow", "enforce"])
+    def test_live_modes_are_available_and_surface_the_mode(self, flags, mode):
+        flags(fabric=mode)
+        by_id = _by_id(_synthetic_store(), FakeProvider())
+        assert by_id[SOURCE_TRUTH].available is True
+        assert by_id[SOURCE_TRUTH].mode == mode
+
+    def test_setting_is_read_per_overlay_pass(self, flags):
+        store = _synthetic_store()
+        assert _by_id(store, FakeProvider())[SOURCE_TRUTH].mode == "off"
+        flags(fabric="shadow")  # flipped mid-session — no import-time cache
+        assert _by_id(store, FakeProvider())[SOURCE_TRUTH].mode == "shadow"
+
+
+class TestVerifyLoopMode:
+    def test_both_off_is_unavailable(self, flags):
+        by_id = _by_id(_synthetic_store(), FakeProvider())
+        assert by_id[VERIFY_LOOP].available is False
+        assert by_id[VERIFY_LOOP].mode == "off"
+
+    def test_deep_work_shadow_alone_is_available_in_shadow(self, flags):
+        flags(deep_work="shadow")
+        o = _by_id(_synthetic_store(), FakeProvider())[VERIFY_LOOP]
+        assert o.available is True
+        assert o.mode == "shadow"
+
+    def test_mode_is_the_higher_of_the_two_flags(self, flags):
+        flags(deep_work="shadow", cloud_plan="enforce")
+        assert _by_id(_synthetic_store(), FakeProvider())[VERIFY_LOOP].mode == "enforce"
+        flags(deep_work="enforce", cloud_plan="off")
+        assert _by_id(_synthetic_store(), FakeProvider())[VERIFY_LOOP].mode == "enforce"
+
+    def test_legacy_bool_resolves_through_the_effective_reader(self, flags):
+        # effective_*_verify_mode() maps the legacy bool to enforce — the
+        # overlay must go through the resolver, not the raw mode field.
+        flags(cloud_plan_legacy=True)
+        assert _by_id(_synthetic_store(), FakeProvider())[VERIFY_LOOP].mode == "enforce"
+
+
+class TestEverythingElseUnchanged:
+    def test_non_flagged_entries_carry_no_mode(self, flags):
+        flags(fabric="enforce", deep_work="enforce")
+        by_id = _by_id(_synthetic_store(), FakeProvider(connected={"alpha_crm"}))
+        assert by_id["primitive:pocket"].available is None
+        assert by_id["primitive:pocket"].mode is None
+        assert by_id["surface:integrations"].mode is None
+        # Connectors keep the connector-only annotation, no mode.
+        assert by_id["connector:alpha_crm"].available is True
+        assert by_id["connector:alpha_crm"].mode is None
+
+    def test_mode_lives_on_the_wrapper_not_the_entry(self, flags):
+        store = _synthetic_store()
+        before = [e.model_dump() for e in store.entries]
+        AtlasOverlay.apply(store.entries, FakeProvider())
+        assert [e.model_dump() for e in store.entries] == before
+
+    def test_settings_failure_fails_closed_to_off_but_still_describes(self, flags, monkeypatch):
+        def _boom():
+            raise RuntimeError("settings unavailable")
+
+        monkeypatch.setattr("pocketpaw.config.get_settings", _boom)
+        store = _synthetic_store()
+        o = AtlasOverlay.describe(store, SOURCE_TRUTH, FakeProvider())
+        assert o is not None, "a settings failure must never HIDE the primitive"
+        assert o.available is False
+        assert o.mode == "off"
+
+
+# ── ranking: off demotes at equal score, unchanged sort logic ────────────
+
+
+class TestFlagDemotion:
+    def test_off_primitive_ranks_below_available_primitive_at_equal_score(self, flags):
+        store = _synthetic_store()
+        # Base order for "provenance": source-truth before pocket (seed order,
+        # equal keyword score).
+        base = [e.id for e in store.search("provenance", limit=10)]
+        assert base.index(SOURCE_TRUTH) < base.index("primitive:pocket")
+
+        ids = [o.entry.id for o in AtlasOverlay.search(store, "provenance", FakeProvider())]
+        assert ids.index("primitive:pocket") < ids.index(SOURCE_TRUTH)
+        assert SOURCE_TRUTH in ids, "demoted, NEVER hidden"
+
+    def test_live_primitive_keeps_seed_order(self, flags):
+        flags(fabric="shadow")
+        store = _synthetic_store()
+        ids = [o.entry.id for o in AtlasOverlay.search(store, "provenance", FakeProvider())]
+        assert ids.index(SOURCE_TRUTH) < ids.index("primitive:pocket")
+
+    def test_verify_loop_demotes_the_same_way(self, flags):
+        store = _synthetic_store()
+        ids = [o.entry.id for o in AtlasOverlay.search(store, "verdict", FakeProvider())]
+        assert ids.index("primitive:pocket") < ids.index(VERIFY_LOOP)
+        flags(deep_work="shadow")
+        ids = [o.entry.id for o in AtlasOverlay.search(store, "verdict", FakeProvider())]
+        assert ids.index(VERIFY_LOOP) < ids.index("primitive:pocket")
+
+
+# ── discovery hints only: never an enforcement gate ─────────────────────
+
+
+class TestDiscoveryOnly:
+    @pytest.mark.parametrize("fabric", ["off", "shadow", "enforce"])
+    def test_default_provider_grants_regardless_of_mode(self, flags, fabric):
+        flags(fabric=fabric)
+        provider = DefaultEntitlementProvider()
+        store = _synthetic_store()
+        for entry_id in FLAGGED_PRIMITIVE_IDS:
+            assert provider.is_granted(store.describe(entry_id)) is True
+
+    def test_off_primitives_are_still_described_and_listed(self, flags):
+        store = _synthetic_store()
+        provider = FakeProvider()
+        for entry_id in FLAGGED_PRIMITIVE_IDS:
+            assert AtlasOverlay.describe(store, entry_id, provider) is not None
+            assert entry_id in AtlasOverlay.visible_ids(store, provider)
+
+    def test_flagged_ids_and_hints_are_paired(self):
+        assert set(FLAGGED_PRIMITIVE_IDS) == {SOURCE_TRUTH, VERIFY_LOOP}
+        assert set(FLAG_ENABLE_HINTS) == set(FLAGGED_PRIMITIVE_IDS)
+        assert "POCKETPAW_FABRIC_SOURCE_TRUTH_MODE" in FLAG_ENABLE_HINTS[SOURCE_TRUTH]
+        assert "deep_work_verify_mode" in FLAG_ENABLE_HINTS[VERIFY_LOOP]
+        assert "cloud_plan_verify_mode" in FLAG_ENABLE_HINTS[VERIFY_LOOP]
+
+
+# ── describe / search rendering through the real MCP handlers ───────────
+
+
+class TestDescribeRendering:
+    @pytest.mark.asyncio
+    async def test_describe_source_truth_off_shows_mode_and_enable_pointer(self, flags):
+        out = await _atlas_describe_handler({"id": SOURCE_TRUTH}, FakeProvider())
+        assert not out.get("is_error")
+        payload = json.loads(_text_of(out))
+        assert payload["available"] is False
+        assert payload["mode"] == "off"
+        assert "POCKETPAW_FABRIC_SOURCE_TRUTH_MODE=shadow|enforce" in payload["enable_hint"]
+        assert "docs/atlas.md" in payload["enable_hint"]
+        # The connector pointer must NOT leak onto a primitive.
+        assert "connect_hint" not in payload
+
+    @pytest.mark.asyncio
+    async def test_describe_source_truth_shadow_reads_live(self, flags):
+        flags(fabric="shadow")
+        payload = json.loads(
+            _text_of(await _atlas_describe_handler({"id": SOURCE_TRUTH}, FakeProvider()))
+        )
+        assert payload["available"] is True
+        assert payload["mode"] == "shadow"
+        assert "enable_hint" not in payload
+
+    @pytest.mark.asyncio
+    async def test_describe_verify_loop_off_then_enforce(self, flags):
+        payload = json.loads(
+            _text_of(await _atlas_describe_handler({"id": VERIFY_LOOP}, FakeProvider()))
+        )
+        assert payload["available"] is False and payload["mode"] == "off"
+        assert "deep_work_verify_mode" in payload["enable_hint"]
+        flags(cloud_plan="enforce")
+        payload = json.loads(
+            _text_of(await _atlas_describe_handler({"id": VERIFY_LOOP}, FakeProvider()))
+        )
+        assert payload["available"] is True and payload["mode"] == "enforce"
+        assert "enable_hint" not in payload
+
+    @pytest.mark.asyncio
+    async def test_describe_other_primitive_untouched(self, flags):
+        payload = json.loads(
+            _text_of(await _atlas_describe_handler({"id": "primitive:instinct"}, FakeProvider()))
+        )
+        assert "available" not in payload
+        assert "mode" not in payload
+
+    @pytest.mark.asyncio
+    async def test_search_cards_carry_mode_for_flagged_primitives(self, flags):
+        flags(fabric="enforce")
+        out = await _atlas_search_handler({"intent": "is this disputed"}, FakeProvider())
+        cards = {c["id"]: c for c in json.loads(_text_of(out))["results"]}
+        assert cards[SOURCE_TRUTH]["available"] is True
+        assert cards[SOURCE_TRUTH]["mode"] == "enforce"
+        assert all("mode" not in c for i, c in cards.items() if i not in FLAGGED_PRIMITIVE_IDS)

--- a/tests/ee/agent/test_atlas_role_provider.py
+++ b/tests/ee/agent/test_atlas_role_provider.py
@@ -23,6 +23,13 @@
 # ``resolve_workspace_role`` reads (``.workspace`` / ``.role``). ``prime()`` is
 # awaited exactly as the sdk_mcp_atlas handler awaits it before the sync grant
 # filter.
+# Updated: 2026-08-17 (feat/ast-3-atlas-flag-aware, AST-3) — ``TestFlagAwareParity``:
+# the role-aware provider produces the SAME ``available`` / ``mode`` for the two
+# rollout-flagged primitives as the OSS default (the stamp lives in the shared
+# core overlay, so parity is structural, proven here rather than duplicated);
+# ``is_granted`` for those primitives is unaffected by the flags (discovery
+# hints only); the ``capability:fabric.*`` cards stay ``role:member``-gated
+# regardless of mode.
 
 from __future__ import annotations
 
@@ -38,8 +45,12 @@ from pocketpaw_ee.cloud.chat.agent_service import (  # noqa: E402
 )
 
 from pocketpaw.atlas.model import AtlasEntry, AtlasModel  # noqa: E402
-from pocketpaw.atlas.overlay import AtlasOverlay  # noqa: E402
-from pocketpaw.atlas.store import AtlasStore  # noqa: E402
+from pocketpaw.atlas.overlay import (  # noqa: E402
+    FLAGGED_PRIMITIVE_IDS,
+    AtlasOverlay,
+    DefaultEntitlementProvider,
+)
+from pocketpaw.atlas.store import AtlasStore, get_atlas_store  # noqa: E402
 
 WS = "w1"
 SCOPE = f"ws:{WS}"
@@ -363,3 +374,72 @@ class TestConstructionAndDelegation:
         )
         # No prime needed — a role-blind entry delegates to the default (grant).
         assert provider.is_granted(primitive) is True
+
+
+# ── AST-3: flag-aware availability parity with the OSS default ──────────────
+
+
+class TestFlagAwareParity:
+    """The rollout-flagged primitives' ``available`` / ``mode`` are stamped in the
+    shared core overlay (``_overlay_one``), so the role-aware provider gets them
+    identically to the OSS default — no EE duplication. Pinned per mode."""
+
+    @pytest.fixture
+    def _flags(self, monkeypatch):
+        from pocketpaw.config import get_settings
+
+        def _set(*, fabric="off", deep_work="off", cloud_plan="off"):
+            settings = get_settings()
+            monkeypatch.setattr(settings, "fabric_source_truth_mode", fabric)
+            monkeypatch.setattr(settings, "deep_work_verify_mode", deep_work)
+            monkeypatch.setattr(settings, "cloud_plan_verify_mode", cloud_plan)
+            monkeypatch.setattr(settings, "deep_work_verify_loop_enabled", False)
+            monkeypatch.setattr(settings, "cloud_plan_verify_loop_enabled", False)
+
+        _set()
+        return _set
+
+    @staticmethod
+    def _flagged(provider) -> dict[str, tuple[bool | None, str | None]]:
+        store = get_atlas_store()
+        entries = [store.describe(i) for i in FLAGGED_PRIMITIVE_IDS]
+        return {o.entry.id: (o.available, o.mode) for o in AtlasOverlay.apply(entries, provider)}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("fabric", "deep_work", "cloud_plan"),
+        [("off", "off", "off"), ("shadow", "shadow", "off"), ("enforce", "off", "enforce")],
+    )
+    async def test_same_available_and_mode_as_default(
+        self, _flags, _patch_user, fabric, deep_work, cloud_plan
+    ):
+        _flags(fabric=fabric, deep_work=deep_work, cloud_plan=cloud_plan)
+        _patch_user("member")
+        with _identity():
+            role_aware = await _primed(RoleAwareEntitlementProvider(scope_key=SCOPE))
+            via_role = self._flagged(role_aware)
+        via_default = self._flagged(DefaultEntitlementProvider(scope_key=SCOPE))
+        assert via_role == via_default
+        assert via_role["primitive:source-truth"] == (fabric != "off", fabric)
+        expected_verify = "enforce" if "enforce" in (deep_work, cloud_plan) else deep_work
+        assert via_role["primitive:verify-loop"] == (expected_verify != "off", expected_verify)
+
+    @pytest.mark.asyncio
+    async def test_flags_never_touch_is_granted(self, _flags, _patch_user):
+        """Discovery hints only: the flagged primitives are granted at EVERY
+        mode, and the role:member fabric capability cards keep their role gate
+        (granted to a member, hidden when the role is unresolved) at every mode."""
+        store = get_atlas_store()
+        flagged = [store.describe(i) for i in FLAGGED_PRIMITIVE_IDS]
+        fabric_caps = [e for e in store.entries if e.id.startswith("capability:fabric.")]
+        assert fabric_caps and all("role:member" in e.requires for e in fabric_caps)
+        for mode in ("off", "shadow", "enforce"):
+            _flags(fabric=mode, deep_work=mode)
+            _patch_user("member")
+            with _identity():
+                member = await _primed(RoleAwareEntitlementProvider(scope_key=SCOPE))
+                assert all(member.is_granted(e) is True for e in flagged), mode
+                assert all(member.is_granted(e) is True for e in fabric_caps), mode
+            unresolved = RoleAwareEntitlementProvider(scope_key=SCOPE)  # never primed
+            assert all(unresolved.is_granted(e) is True for e in flagged), mode
+            assert all(unresolved.is_granted(e) is False for e in fabric_caps), mode


### PR DESCRIPTION
## What

Both new primitives ship behind rollout flags that default off (`fabric_source_truth_mode`; `deep_work_verify_mode` / `cloud_plan_verify_mode`). atlas has to stay discoverable *and* honest: always describe them (the agent must know the OS has them), but say whether they're live for this OS config. Hiding them when off would recreate a known misdirection bug; ignoring the flag would claim capability that isn't there. Stacked on #1959 (AST-3).

## Change

The overlay now stamps flag-driven `available` plus an additive tri-state `OverlaidEntry.mode` (`off | shadow | enforce`) on exactly `primitive:source-truth` (from `fabric_source_truth_mode`) and `primitive:verify-loop` (the higher of the two verify modes). Flags are read from live settings once per overlay pass in the provider-independent `_overlay_one`, so the EE role-aware provider has parity by construction (pinned by test, not duplicated).

- Sort logic is untouched — an off primitive demotes through the existing `available is False` re-sort but is never hidden.
- Describe and search cards carry `mode`; an off primitive's describe adds an `enable_hint` (the env flag to set, plus `docs/atlas.md`) instead of the connector `connect_hint`.
- `is_granted` is unaffected by the flags. `available` / `mode` are discovery hints only, never an enforcement gate — stated in a comment and asserted by test.
- `TestFactualClaimGuard` gained a liveness guard: a describe cannot assert live source-truth or verification when the mode is off.

## Verified

- `pytest tests/atlas tests/ee/agent/test_atlas_role_provider.py` → 246 passed (25 new overlay-flag tests, 4 new EE parity tests).
- Live env demo, real handlers: default → `available False, mode off, enable_hint set`; `POCKETPAW_FABRIC_SOURCE_TRUTH_MODE=shadow` → `available True, mode shadow, no hint`; `POCKETPAW_DEEP_WORK_VERIFY_MODE=enforce` → verify-loop `available True, mode enforce`.
- `git diff overlay.py | grep 'demoted|sort'` → no changed lines.
- `atlas build --check` unchanged; both import-linter configs green; ruff clean.