### PR TITLE
Second review pass: my own fixes had three regressions

### DIFF
--- a/ee/pocketpaw_ee/cloud/growth/msg91.py
+++ b/ee/pocketpaw_ee/cloud/growth/msg91.py
@@ -69,6 +69,12 @@ def _scrub(text: str, secret: str) -> str:
     return text
 
 
+# ORDER MATTERS AT EVERY CALL SITE: scrub the WHOLE body, then truncate. Slicing
+# first can cut a key in half across the boundary, so ``secret in text`` misses
+# and the prefix survives into a durable MessageLog row — which is precisely the
+# leak this function exists to stop.
+
+
 class Msg91Error(Exception):
     """The provider refused or failed the send.
 
@@ -270,7 +276,7 @@ class Msg91WhatsAppClient:
         if resp.status_code >= 400:
             raise Msg91Error(
                 "msg91.http_error",
-                f"MSG91 returned {resp.status_code}: {_scrub(resp.text[:300], creds.authkey)}",
+                f"MSG91 returned {resp.status_code}: {_scrub(resp.text, creds.authkey)[:300]}",
             )
         return _extract_message_id(resp, creds.authkey)
 
@@ -292,7 +298,7 @@ def _extract_message_id(resp: Any, authkey: str = "") -> str:
     status = str(data.get("status") or data.get("type") or "").lower()
     if status in ("error", "fail", "failure"):
         raise Msg91Error(
-            "msg91.rejected", f"MSG91 rejected the send: {_scrub(str(data)[:300], authkey)}"
+            "msg91.rejected", f"MSG91 rejected the send: {_scrub(str(data), authkey)[:300]}"
         )
     inner = data.get("data")
     if isinstance(inner, dict):

--- a/ee/pocketpaw_ee/cloud/growth/researcher.py
+++ b/ee/pocketpaw_ee/cloud/growth/researcher.py
@@ -224,6 +224,26 @@ def _extract_json(text: str) -> dict[str, Any] | None:
 
     if not objects:
         return None
+
+    def _answer_score(obj: dict[str, Any]) -> int:
+        """How much this object looks like the actual research.
+
+        POSITION IS NOT A SIGNAL, in either direction. Taking the first
+        `companies` object let a restated template beat the answer; taking the
+        last let a trailing recap beat it, AND let a nested `companies` key
+        inside a company entry beat its own parent. Both were reproduced. So
+        the tiebreak is content: the real answer is the one whose `companies`
+        is the longest list of dicts that actually carry a domain.
+        """
+        rows = obj.get("companies")
+        if not isinstance(rows, list):
+            return -1
+        return sum(1 for r in rows if isinstance(r, dict) and str(r.get("domain") or "").strip())
+
+    scored = [(o, _answer_score(o)) for o in objects]
+    best = max(scored, key=lambda pair: pair[1])
+    if best[1] >= 0:
+        return best[0]
     # The LAST qualifying object wins, not the first.
     #
     # This is the fix for a reproduced bug, so it is worth being explicit about
@@ -236,10 +256,7 @@ def _extract_json(text: str) -> dict[str, Any] | None:
     # JSON, and this picks the last candidate, so a preamble cannot shadow the
     # answer even if one reappears. Two independent guards, because the thing
     # they protect is the one guarantee this module claims to be structural.
-    for obj in reversed(objects):
-        if "companies" in obj:
-            return obj
-    return objects[-1]
+    return objects[0]
 
 
 def _evidence_from(raw: Any) -> EmailEvidence | None:
@@ -269,7 +286,14 @@ def _evidence_from(raw: Any) -> EmailEvidence | None:
     # addresses on adjacent lines of a contact page) passes every guard and is
     # stored as ONE address, which the dispatch path then hands to the provider
     # as a recipient. Exactly one @, no whitespace, something on each side.
-    if any(ch.isspace() for ch in address) or address.count("@") != 1:
+    # ``str.isspace()`` is False for ZWSP, BOM and the direction marks
+    # (Unicode category Cf) and for NUL — all of which a WebFetch extraction
+    # can carry out of real HTML. Category-check instead of trusting isspace.
+    import unicodedata
+
+    if any(ch.isspace() or unicodedata.category(ch) in ("Cf", "Cc") for ch in address):
+        return None
+    if address.count("@") != 1:
         return None
     if len(address) > 254:  # RFC 5321 ceiling; anything longer is not an address
         return None

--- a/ee/pocketpaw_ee/cloud/growth/researcher.py
+++ b/ee/pocketpaw_ee/cloud/growth/researcher.py
@@ -233,29 +233,39 @@ def _extract_json(text: str) -> dict[str, Any] | None:
         last let a trailing recap beat it, AND let a nested `companies` key
         inside a company entry beat its own parent. Both were reproduced. So
         the tiebreak is content: the real answer is the one whose `companies`
-        is the longest list of dicts that actually carry a domain.
+        is the longest list of dicts that actually carry a domain, weighted by
+        how much each row actually says.
+
+        HONEST LIMIT: two candidates of identical shape and richness cannot be
+        told apart by content, and this falls back to the first. The real
+        protection against an echoed template is that the prompt no longer
+        contains parseable JSON to echo — this scoring is defence in depth,
+        not a proof.
         """
         rows = obj.get("companies")
         if not isinstance(rows, list):
             return -1
-        return sum(1 for r in rows if isinstance(r, dict) and str(r.get("domain") or "").strip())
+        score = 0
+        for r in rows:
+            if not isinstance(r, dict) or not str(r.get("domain") or "").strip():
+                continue
+            # A real finding is RICHER than an echoed shape: it carries the
+            # brief and the pages that were read. Counting rows alone ties a
+            # one-row echo against a one-row answer.
+            score += 1
+            score += sum(
+                1
+                for field in ("company", "name", "research_brief")
+                if str(r.get(field) or "").strip()
+            )
+            urls = r.get("source_urls")
+            score += len(urls) if isinstance(urls, list) else 0
+        return score
 
     scored = [(o, _answer_score(o)) for o in objects]
     best = max(scored, key=lambda pair: pair[1])
     if best[1] >= 0:
         return best[0]
-    # The LAST qualifying object wins, not the first.
-    #
-    # This is the fix for a reproduced bug, so it is worth being explicit about
-    # why. The prompt used to carry a fully-valid JSON example — complete with
-    # an "observed" email on example.com — and this loop took the FIRST object
-    # with a ``companies`` key. A model that restated the shape before
-    # answering therefore had its own template parsed as the research: the real
-    # findings were discarded and a fabricated prospect was filed carrying an
-    # address nobody had ever seen. The prompt no longer contains parseable
-    # JSON, and this picks the last candidate, so a preamble cannot shadow the
-    # answer even if one reappears. Two independent guards, because the thing
-    # they protect is the one guarantee this module claims to be structural.
     return objects[0]
 
 

--- a/ee/pocketpaw_ee/cloud/growth/service.py
+++ b/ee/pocketpaw_ee/cloud/growth/service.py
@@ -743,22 +743,41 @@ async def upsert_by_domain(
         # no-event: growth has no realtime subscriber in v1.
         return _to_response(_to_domain(doc))
 
-    # Fields a re-import may OVERWRITE. Everything omitted from this tuple is
-    # deliberate, not forgotten.
-    for field in ("name", "company", "tier", "research_brief", "whatsapp_number"):
+    # Descriptive fields a re-import may OVERWRITE. Everything omitted from
+    # this tuple is deliberate, not forgotten.
+    for field in ("name", "company", "tier", "research_brief"):
         setattr(doc, field, getattr(body, field))
 
-    # ``status`` and ``opted_in`` are LIFECYCLE, not import data, and the DTO
-    # defaults them to "new" / False. Overwriting them meant re-uploading last
-    # month's CSV to the bulk route — the one whose docstring calls a re-run
-    # safe — revived every prospect the sweep had retired to ``dead`` and every
-    # one that had ``replied``, then the sweep re-entered the sequence on
-    # people it had deliberately given up on, including anyone marked dead for
-    # asking not to be contacted. A re-import must never resurrect.
-    if body.status != "new":
-        doc.status = body.status
-    if body.opted_in:
-        doc.opted_in = True
+    # LIFECYCLE IS NOT IMPORT DATA. ``status`` and ``opted_in`` are never
+    # written here at all — an import describes who someone is, it does not
+    # decide where they sit in a sequence or whether they consented. Both move
+    # only through PATCH (an explicit human act) or the gate.
+    #
+    # A first attempt at this let a non-default status through
+    # (``if body.status != "new"``), which protected only a sheet with no
+    # status column — and an operator's working sheet is exactly the one that
+    # carries a stale ``in_sequence``. Re-uploading it lifted rows back out of
+    # the terminal set and the follow-up sweep re-entered the sequence on
+    # people it had retired, including anyone marked dead for asking not to be
+    # contacted.
+
+    # THE NUMBER AND THE CONSENT MOVE TOGETHER, and this is the one that
+    # actually reaches a stranger. Consent is given by a PERSON on a NUMBER,
+    # never by a domain: if a re-import points the row at a different number,
+    # whatever opt-in was recorded belonged to whoever held the old one.
+    #
+    # An earlier version of this fix overwrote ``whatsapp_number``
+    # unconditionally while making ``opted_in`` sticky-True — so a sheet
+    # carrying a new SDR's mobile and no opt-in column inherited the founder's
+    # consent, cleared the dispatch guard, and put a business-initiated
+    # template in front of someone who never agreed to it. The blanket
+    # overwrite it replaced did NOT have that hole, because it reset
+    # ``opted_in`` on the same import. A fix must not be more dangerous than
+    # the bug.
+    incoming_number = body.whatsapp_number
+    if incoming_number is not None and incoming_number != doc.whatsapp_number:
+        doc.whatsapp_number = incoming_number
+        doc.opted_in = False
 
     # ``emails`` / ``linkedin_url`` are set-only for the same reason
     # ``project_id`` is below: a row that says nothing about them must not

--- a/ee/pocketpaw_ee/cloud/growth/worker.py
+++ b/ee/pocketpaw_ee/cloud/growth/worker.py
@@ -77,6 +77,9 @@ logger = logging.getLogger(__name__)
 # after the first two or three ICPs — see the note on ``job_timeout`` below.
 _DEFAULT_JOB_TIMEOUT_SECONDS = 1800
 
+# One template/email POST. Unchanged from arq's default on purpose.
+_DISPATCH_TIMEOUT_SECONDS = 300
+
 
 async def dispatch(ctx: dict[str, Any], draft_id: str, channel: str) -> None:
     """Dispatch an APPROVED outbound draft.
@@ -151,17 +154,25 @@ def _redis_settings() -> RedisSettings:
     return RedisSettings.from_dsn(url)
 
 
-def _job_timeout_seconds() -> int:
+def _job_timeout_seconds() -> int | None:
     """Per-job ceiling for the growth queue, in seconds.
 
     Default 30 minutes: the discovery sweep works ICPs sequentially and each
     one is a real agent run. Override with ``GROWTH_JOB_TIMEOUT_SECONDS`` when
     a deployment runs more hunts than that comfortably fits.
     """
+    # ``0`` DISABLES the ceiling, matching this package's own convention
+    # (``discovery.py``'s monthly max, and the agent-jail knobs in CLAUDE.md).
+    # An earlier version ran it through ``max(int(raw), 60)``, so an operator
+    # setting 0 to mean "no limit" got 60s — a 30x TIGHTENING, and one whose
+    # cancellations are invisible because CancelledError is a BaseException.
     raw = os.environ.get("GROWTH_JOB_TIMEOUT_SECONDS", "").strip()
     if raw:
         try:
-            return max(int(raw), 60)
+            parsed = int(raw)
+            if parsed <= 0:
+                return None
+            return max(parsed, 60)
         except ValueError:
             logger.warning(
                 "growth worker: GROWTH_JOB_TIMEOUT_SECONDS=%r is not an integer — using %d",
@@ -181,7 +192,12 @@ class WorkerSettings:
     # ``func(..., name=...)`` pins the job's wire name to the explicit dotted
     # constant so the executor's ``enqueue_job(GROWTH_DISPATCH_JOB_NAME, ...)``
     # always matches, independent of the Python function's name.
-    functions = [func(dispatch, name=GROWTH_DISPATCH_JOB_NAME)]
+    # The dispatch job keeps arq's 300s. The long ``job_timeout`` below exists
+    # for the discovery sweep, which works ICPs sequentially; applying it here
+    # too would let ten hung provider sockets hold every worker slot for half
+    # an hour with human-approved outbound queued behind them, and max_tries=1
+    # means no recovery.
+    functions = [func(dispatch, name=GROWTH_DISPATCH_JOB_NAME, timeout=_DISPATCH_TIMEOUT_SECONDS)]
     # G-7 — one daily tick at 13:00 UTC (business hours across US/EU, and well
     # clear of the midnight batch traffic every other scheduler piles onto).
     # ``unique=True`` (arq's default, explicit here because it is the property

--- a/tests/cloud/growth/test_researcher.py
+++ b/tests/cloud/growth/test_researcher.py
@@ -266,7 +266,19 @@ class TestTheReviewFindings:
                 }
             ]
         )
-        answer = _response([{"domain": "realclinic.co.uk"}])
+        # A real finding carries the brief and the pages it was read from; an
+        # echoed shape does not. That difference is the signal — see
+        # _answer_score's honest-limit note for what it cannot separate.
+        answer = _response(
+            [
+                {
+                    "domain": "realclinic.co.uk",
+                    "company": "Real Clinic",
+                    "research_brief": "two-chair practice, phone-only bookings",
+                    "source_urls": ["https://realclinic.co.uk/contact"],
+                }
+            ]
+        )
         result = parse_research_response(f"Shape:{preamble}\nResults:{answer}", max_results=5)
         assert [c.domain for c in result.companies] == ["realclinic.co.uk"]
         # Mutation: "extractor takes the FIRST companies object again".

--- a/tests/cloud/growth/test_upsert_lifecycle.py
+++ b/tests/cloud/growth/test_upsert_lifecycle.py
@@ -1,0 +1,120 @@
+# tests/cloud/growth/test_upsert_lifecycle.py — what a re-import may and may
+# not change.
+# Created 2026-08-17 (fix/growth-review-findings, second review pass).
+#
+# These exist because the first attempt at "a re-import must never resurrect"
+# shipped with NO test and was wrong in two ways a review caught:
+#
+#   * ``whatsapp_number`` was still overwritten unconditionally while
+#     ``opted_in`` had become sticky-True, so a sheet carrying a new number and
+#     no opt-in column INHERITED the previous person's consent — and the
+#     WhatsApp dispatch guard reads exactly that flag. The blanket overwrite it
+#     replaced did NOT have that hole, because it reset ``opted_in`` on the
+#     same import. A fix must not be more dangerous than the bug it fixes.
+#   * the status guard was ``if body.status != "new"``, which protected only a
+#     sheet with NO status column — and an operator's working sheet is exactly
+#     the one carrying a stale ``in_sequence``.
+#
+# Both are lifecycle, and lifecycle is not import data.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.growth import service as growth_service
+from pocketpaw_ee.cloud.growth.dto import CreateProspectRequest
+
+WS = "ws-upsert-lifecycle"
+
+
+def _req(**over: object) -> CreateProspectRequest:
+    base: dict[str, object] = {
+        "name": "Priya",
+        "company": "Northwind",
+        "domain": "northwind.example",
+        "source": "manual",
+    }
+    base.update(over)
+    return CreateProspectRequest.model_validate(base)
+
+
+class TestConsentNeverTransfers:
+    """Consent is given by a PERSON on a NUMBER, never by a domain."""
+
+    @pytest.mark.asyncio
+    async def test_a_new_number_drops_the_old_consent(self, mongo_db) -> None:
+        """Mutation: "consent survives a number change on re-import".
+
+        The founder consented on their mobile. A later sheet points the row at
+        an SDR's number with no opt-in column. If the flag survived, a
+        business-initiated template would reach someone who never agreed — and
+        the Tray card shows channel and copy, never opt-in provenance, so no
+        human review catches it.
+        """
+        created = await growth_service.upsert_by_domain(
+            WS, _req(whatsapp_number="+911111111111", opted_in=True)
+        )
+        assert created.opted_in is True
+
+        moved = await growth_service.upsert_by_domain(WS, _req(whatsapp_number="+919999999999"))
+        assert moved.id == created.id
+        assert moved.whatsapp_number == "+919999999999"
+        assert moved.opted_in is False, "consent must not follow the row to a new number"
+
+    @pytest.mark.asyncio
+    async def test_the_same_number_keeps_its_consent(self, mongo_db) -> None:
+        """An enrichment pass repeating the number changes nothing about it."""
+        await growth_service.upsert_by_domain(
+            WS, _req(domain="same.example", whatsapp_number="+911111111111", opted_in=True)
+        )
+        again = await growth_service.upsert_by_domain(
+            WS, _req(domain="same.example", whatsapp_number="+911111111111", company="Renamed")
+        )
+        assert again.opted_in is True
+        assert again.company == "Renamed"
+
+    @pytest.mark.asyncio
+    async def test_an_omitted_number_clears_neither_it_nor_the_consent(self, mongo_db) -> None:
+        """An email-only enrichment sheet must not blank the WhatsApp channel —
+        which would read as a data-entry error rather than an import side
+        effect."""
+        await growth_service.upsert_by_domain(
+            WS, _req(domain="keep.example", whatsapp_number="+911111111111", opted_in=True)
+        )
+        enriched = await growth_service.upsert_by_domain(
+            WS, _req(domain="keep.example", emails=["a@keep.example"])
+        )
+        assert enriched.whatsapp_number == "+911111111111"
+        assert enriched.opted_in is True
+
+
+class TestAReImportNeverResurrects:
+    """Mutation: "a re-import can write status again (resurrects the dead)"."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("stale_status", ["new", "in_sequence", "qualified", "drafted"])
+    async def test_no_status_a_sheet_can_carry_revives_the_dead(
+        self, mongo_db, stale_status: str
+    ) -> None:
+        """``in_sequence`` is the case that matters: it is what a live campaign
+        sheet actually contains, and the first fix let it straight through."""
+        domain = f"dead-{stale_status}.example"
+        created = await growth_service.upsert_by_domain(WS, _req(domain=domain))
+        await growth_service.mark_prospect_dead(WS, created.id)
+
+        again = await growth_service.upsert_by_domain(WS, _req(domain=domain, status=stale_status))
+        assert again.status == "dead", (
+            "a re-import must not lift a prospect out of a terminal state"
+        )
+
+    @pytest.mark.asyncio
+    async def test_descriptive_fields_still_update(self, mongo_db) -> None:
+        """The point is to freeze LIFECYCLE, not to freeze the row — an import
+        that corrects a company name must still land."""
+        created = await growth_service.upsert_by_domain(WS, _req(domain="desc.example"))
+        again = await growth_service.upsert_by_domain(
+            WS,
+            _req(domain="desc.example", company="Northwind Dental Ltd", tier="a"),
+        )
+        assert again.id == created.id
+        assert again.company == "Northwind Dental Ltd"
+        assert again.tier == "a"

--- a/tests/mutations/growth_review_gates.json
+++ b/tests/mutations/growth_review_gates.json
@@ -1,15 +1,8 @@
 [
   {
-    "label": "extractor takes the FIRST companies object again (the template-echo bug)",
-    "file": "ee/pocketpaw_ee/cloud/growth/researcher.py",
-    "find": "    for obj in reversed(objects):",
-    "replace": "    for obj in objects:",
-    "tests": "tests/cloud/growth/test_researcher.py::TestTheReviewFindings::test_a_preamble_object_cannot_shadow_the_answer"
-  },
-  {
     "label": "email shape check removed \u2014 a two-line address becomes storable",
     "file": "ee/pocketpaw_ee/cloud/growth/researcher.py",
-    "find": "    if any(ch.isspace() for ch in address) or address.count(\"@\") != 1:\n        return None",
+    "find": "    if address.count(\"@\") != 1:\n        return None",
     "replace": "    if False:\n        return None",
     "tests": "tests/cloud/growth/test_researcher.py::TestTheReviewFindings::test_a_malformed_address_is_never_storable"
   },
@@ -67,6 +60,41 @@
     "file": "ee/pocketpaw_ee/cloud/growth/researcher.py",
     "find": "    if any(ch in address for ch in '<>\"\\\\,;:()[]'):\n        return None",
     "replace": "    if False:\n        return None",
+    "tests": "tests/cloud/growth/test_researcher.py::TestTheReviewFindings::test_a_malformed_address_is_never_storable"
+  },
+  {
+    "label": "answer picked by position again (first) \u2014 a leading echo wins",
+    "file": "ee/pocketpaw_ee/cloud/growth/researcher.py",
+    "find": "    scored = [(o, _answer_score(o)) for o in objects]\n    best = max(scored, key=lambda pair: pair[1])",
+    "replace": "    scored = [(o, _answer_score(o)) for o in objects]\n    best = (objects[0], _answer_score(objects[0]))",
+    "tests": "tests/cloud/growth/test_researcher.py::TestTheReviewFindings"
+  },
+  {
+    "label": "answer picked by position again (last) \u2014 a trailing recap wins",
+    "file": "ee/pocketpaw_ee/cloud/growth/researcher.py",
+    "find": "    best = max(scored, key=lambda pair: pair[1])",
+    "replace": "    best = (objects[-1], _answer_score(objects[-1]))",
+    "tests": "tests/cloud/growth/test_researcher.py::TestTheReviewFindings"
+  },
+  {
+    "label": "consent survives a number change on re-import",
+    "file": "ee/pocketpaw_ee/cloud/growth/service.py",
+    "find": "        doc.whatsapp_number = incoming_number\n        doc.opted_in = False",
+    "replace": "        doc.whatsapp_number = incoming_number",
+    "tests": "tests/cloud/growth/test_upsert_lifecycle.py"
+  },
+  {
+    "label": "a re-import can write status again (resurrects the dead)",
+    "file": "ee/pocketpaw_ee/cloud/growth/service.py",
+    "find": "    for field in (\"name\", \"company\", \"tier\", \"research_brief\"):",
+    "replace": "    doc.status = body.status\n    for field in (\"name\", \"company\", \"tier\", \"research_brief\"):",
+    "tests": "tests/cloud/growth/test_upsert_lifecycle.py"
+  },
+  {
+    "label": "zero-width characters allowed back into an address",
+    "file": "ee/pocketpaw_ee/cloud/growth/researcher.py",
+    "find": "    if any(ch.isspace() or unicodedata.category(ch) in (\"Cf\", \"Cc\") for ch in address):",
+    "replace": "    if any(ch.isspace() for ch in address):",
     "tests": "tests/cloud/growth/test_researcher.py::TestTheReviewFindings::test_a_malformed_address_is_never_storable"
   }
 ]


### PR DESCRIPTION
Two reviewers reported after #1957 merged. Both found defects **in the fixes
themselves**, and one is worse than the bug it replaced. This is the repair.

## Consent could transfer to a different person

Making `opted_in` sticky-True while `whatsapp_number` stayed an unconditional
overwrite meant a sheet carrying a new SDR's mobile and no opt-in column
**inherited the founder's consent**, cleared the dispatch guard, and would have
put a business-initiated WhatsApp template in front of someone who never
agreed. The Tray card shows channel and copy, never opt-in provenance, so no
human review catches it.

The blanket overwrite it replaced did **not** have that hole — it reset
`opted_in` on the same import. A fix must not be more dangerous than the bug.
The number and the consent now move together: a changed number drops the flag.

## The resurrection guard only blocked the literal default

`if body.status != "new"` protected a sheet with *no* status column. An
operator's working sheet is exactly the one carrying a stale `in_sequence`,
which lifted rows back out of the terminal set and let the sweep re-enter the
sequence on people it had retired — including anyone marked dead for asking not
to be contacted. Lifecycle is now never written by an import at all.

## "Last wins" was a mirror of the bug it fixed

Taking the *first* object with a `companies` key let a restated template beat
the answer. Taking the *last* let a trailing recap beat it — and let a nested
`companies` key inside a company entry beat its own parent. Both reproduced.

Position was never the signal. Selection is content-based now, weighted by how
much each row actually says, and the docstring states the honest limit instead
of overclaiming a second time: two candidates of identical shape cannot be told
apart by content. The real guard is that the prompt no longer contains
parseable JSON to echo.

## Also

Zero-width and BOM characters passed the address check, because `str.isspace()`
is False for category Cf. The arq timeout was worker-wide, so the 6× bump also
applied to approved sends and could hold every slot for half an hour behind a
hung socket — scoped to the sweep now, dispatch keeps 300s.
`GROWTH_JOB_TIMEOUT_SECONDS=0` meant 60s rather than "disabled", inverting this
package's own convention. And `_scrub` truncated before scrubbing, so a key
straddling 300 characters leaked its prefix into a durable row.

## The procedural finding, which was the sharpest

**None of the four semantic changes in #1957 had a test or a mutation.** Under
this repo's own rule they shipped ungated, which is how three of them survived.

Now: 14 mutations, all caught, plus `test_upsert_lifecycle.py` covering consent
transfer and resurrection directly. 422 tests, import-linter clean.

One process note worth recording: I pushed the first commit of this branch with
a red test, because the verify chain used `;` between pytest and `git commit`
so the commit was never gated on the suite. Fixed, and every gate here ran
under `set -e`.