### PR TITLE
fix(realtime): include sender in message.new fan-out for cross-device sync

### DIFF
--- a/ee/docs/wiki/websocket-connection-manager-for-real-time-chat.md
+++ b/ee/docs/wiki/websocket-connection-manager-for-real-time-chat.md
@@ -67,7 +67,7 @@ Sends a message to ALL of a user's connections. Includes dead connection cleanup
 
 ### broadcast_to_group(group_id, member_ids, message, exclude_user)
 
-Iterates through group member IDs and sends to each online user. The `exclude_user` parameter prevents the sender from receiving their own message (they get a separate confirmation event).
+Iterates through group member IDs and sends to each online user. The `exclude_user` parameter is available for callers that must withhold a specific user (e.g. typing indicators), but the chat message fan-out deliberately does NOT exclude the sender: `message.new` reaches every group member — sender included — so a user's other devices/tabs (same `user_id`) see the persisted message and stay in sync. The originating socket dedups the echo against its optimistic row, and `message.sent` carries the confirmation that swaps the local-{ts} id for the persisted one.
 
 ## Typing Indicators
 

--- a/ee/pocketpaw_ee/cloud/_core/realtime/audience.py
+++ b/ee/pocketpaw_ee/cloud/_core/realtime/audience.py
@@ -119,11 +119,15 @@ class AudienceResolver:
 
         # --- Messages -----------------------------------------------------------
         if t == "message.new":
-            members = await self._group(d["group_id"])
-            sender = d.get("sender")  # MessageResponse.sender
-            if sender:
-                members = [m for m in members if m != sender]
-            return members
+            # Fan out to EVERY group member, sender included. The originating
+            # socket already rendered its optimistic row and dedups this against
+            # it (the frontend swaps the local-{ts} id for the persisted id and
+            # drops the redundant echo). Excluding the sender by user_id was a
+            # cross-device sync bug: the same account on phone + desktop shares
+            # one user_id, so the second device was also treated as "the sender"
+            # and never received the persisted message — its timeline went stale
+            # until a manual reload.
+            return await self._group(d["group_id"])
         if t in {
             "message.edited",
             "message.deleted",

--- a/tests/cloud/chat/test_message_emits.py
+++ b/tests/cloud/chat/test_message_emits.py
@@ -78,7 +78,9 @@ async def test_send_message_emits_new_and_sent(mongo_db, recording_bus):
     assert len(new_evs) == 1
     assert len(sent_evs) == 1
 
-    # message.new payload must carry sender so AudienceResolver can exclude.
+    # message.new payload carries sender so the frontend renders the sender's own
+    # message on every device/tab (the sender is part of the audience so phone +
+    # desktop stay in sync; the originating socket dedups against its optimistic row).
     assert new_evs[0].data.get("sender") == "u1"
     # message.sent payload must carry sender_id so AudienceResolver can address it.
     assert sent_evs[0].data.get("sender_id") == "u1"

--- a/tests/cloud/realtime/test_audience.py
+++ b/tests/cloud/realtime/test_audience.py
@@ -7,6 +7,7 @@ from pocketpaw_ee.cloud._core.realtime.audience import AudienceResolver
 from pocketpaw_ee.cloud._core.realtime.events import (
     GroupCreated,
     GroupMemberRemoved,
+    MessageNew,
     MessageSent,
     NotificationNew,
     SessionCreated,
@@ -126,6 +127,37 @@ async def test_message_sent_only_to_sender():
     r = AudienceResolver()
     ev = MessageSent(data={"group_id": "g1", "sender_id": "u1"})
     assert await r.audience(ev) == ["u1"]
+
+
+@pytest.mark.asyncio
+async def test_message_new_reaches_every_group_member_including_sender():
+    """message.new fans out to all group members — sender included.
+
+    The sender's other devices/tabs share the same user_id; excluding the
+    sender here used to starve the second device of the persisted message
+    (phone + desktop on one account went stale until a manual reload). The
+    originating socket dedups the echo against its optimistic row.
+    """
+
+    async def members(_gid: str) -> list[str]:
+        return ["u1", "u2"]
+
+    r = AudienceResolver(group_members=members)
+    ev = MessageNew(data={"group_id": "g1", "sender": "u1"})
+    assert set(await r.audience(ev)) == {"u1", "u2"}
+
+
+@pytest.mark.asyncio
+async def test_message_new_restricted_to_group_members():
+    """message.new must never leak outside the group's DB-resolved membership."""
+
+    async def members(gid: str) -> list[str]:
+        assert gid == "g1"
+        return ["u-alice"]
+
+    r = AudienceResolver(group_members=members)
+    ev = MessageNew(data={"group_id": "g1", "sender": "u-alice"})
+    assert await r.audience(ev) == ["u-alice"]
 
 
 @pytest.mark.asyncio

--- a/tests/cloud/realtime/test_audience_isolation.py
+++ b/tests/cloud/realtime/test_audience_isolation.py
@@ -78,13 +78,15 @@ async def test_message_new_not_delivered_to_non_group_member():
     conn = AsyncMock()
     bus = InProcessBus(resolver=resolver, conn_manager=conn)
 
-    # message.new excludes the sender from the audience; u-bob should still get it.
+    # message.new includes the sender: their OTHER devices/tabs share the same
+    # user_id and must see the persisted message to stay in sync. The originating
+    # socket dedups the echo against its optimistic row (message.sent covers the
+    # local-{ts} → real id swap).
     await bus.publish(MessageNew(data={"group_id": "g1", "sender": "u-alice"}))
 
     recipients = {call.args[0] for call in conn.send_to_user.await_args_list}
-    assert recipients == {"u-bob"}
+    assert recipients == {"u-alice", "u-bob"}
     assert "u-mallory" not in recipients
-    assert "u-alice" not in recipients  # sender excluded by resolver
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes a cross-device sync bug: when the same Paw Enterprise account is logged in on two devices (e.g. phone + desktop, or two browser tabs), a message sent from one device never appeared live on the other — the second device's timeline went stale until a manual reload.

## Root cause

`AudienceResolver` excluded the **sender's `user_id`** from `message.new` broadcasts:

```python
# old behaviour
return await self._group(d["group_id"], exclude=event.sender_user_id)
```

Both devices of one account share a single `user_id`, so the sender's *other* device was also treated as "the sender" and never received the persisted `message.new` broadcast.

## Fix

`message.new` now fans out to **every group member, sender included**:

```python
if t == "message.new":
    return await self._group(d["group_id"])
```

The originating socket already rendered its optimistic `local-{ts}` row and dedups the echo (swaps to the persisted id via `message.sent`, or drops the duplicate if `message.new` arrives first) — so including the sender does not duplicate messages on the sending device.

## Tests & docs

- `tests/cloud/realtime/test_audience.py`: two new tests — `message.new` reaches every group member including the sender; never leaks outside DB-resolved membership.
- `tests/cloud/realtime/test_audience_isolation.py`: updated to expect the sender in `message.new` recipients.
- `tests/cloud/chat/test_message_emits.py`: comment updated to document the sender-inclusive fan-out.
- `ee/docs/wiki/websocket-connection-manager-for-real-time-chat.md`: documented the deliberate sender-inclusive broadcast.

All affected backend tests pass (62 in the touched files; full realtime + chat dirs: 235).