### PR TITLE
fix(sites): the html edit tool shipped, the prompt kept saying it hadn't

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2,6 +2,17 @@
 docs/api-reference.md — Hand-maintained reference for cloud REST endpoints
 that are not covered by the per-endpoint Mintlify pages under docs/api/.
 
+Updated: 2026-08-18 (fix/sites-html-refine-names-the-edit-tool) — documented
+`edit_html_file`, the html track's chat edit tool. It shipped in db083bfc without
+reaching this file, so the section below still said html had no edit tool and was
+"edited by uid splice via the leaf-edits route" — that route is the NATIVE
+editor's path, not the agent's, and the two are different entry points. Recorded
+with the same emphasis the react entry gets on the things a field list cannot
+show: why the argument is `file_path` rather than `component_path` (html has no
+component model, and its paths are root-relative), and why this tool does not
+republish for a DIFFERENT reason than react's — html runs no build at all, so
+there is no gate that could catch a bad edit before it went live.
+
 Updated: 2026-08-11 (feat/sites-react-edit-lane, RX-4) — documented the build-lane
 fields now on the `publish` tool response and the new read-only
 `get_site_build_status` tool, in the same MCP section. Both are recorded here
@@ -1738,7 +1749,7 @@ report a destroy as done.
 Editing a Paw Site from chat does not go over HTTP. The chat agent reaches it
 through the in-process MCP server `pocketpaw_sites_manager`
 (`ee/pocketpaw_ee/agent/mcp_servers/sites.py`), whose tools are namespaced
-`mcp__pocketpaw_sites_manager__<tool>`. Two editing tools live there, one per
+`mcp__pocketpaw_sites_manager__<tool>`. Three editing tools live there, one per
 hand-authored engine, and they are **not interchangeable** — each rejects the
 other's pockets.
 
@@ -1746,10 +1757,12 @@ other's pockets.
 |------|--------|-----------|
 | `edit_svelte_component` | `engine: "svelte"` | Builds a draft **preview** (workerd smoke gate; rolls the source back if it fails) |
 | `edit_react_component` | `engine: "react"` | **No.** Persists the draft and stops — no build, no deploy |
+| `edit_html_file` | `engine: "html"` | **No.** Persists the draft and stops — html runs no build, so there is nothing to gate a deploy on |
 
 A ripple or dynamic site is edited through the pocket specialist's rippleSpec
-merge instead; an html site is edited by uid splice via the leaf-edits route
-above.
+merge instead. The leaf-edits REST route above is the *native editor's* html path
+(uid splice) and is a different entry point from `edit_html_file`, which is the
+chat agent's.
 
 ### `edit_react_component`
 
@@ -1803,6 +1816,68 @@ Errors (relayed to the agent as `is_error` with the code, so it can fix and retr
 Every write goes through `pockets_service.set_react_source_file`, which emits
 `PocketUpdated` and records a draft `ArtifactVersion` snapshotting the full edited
 source map — so an edit is a reviewable Branch draft a later publish promotes.
+
+### `edit_html_file`
+
+Write ONE file of an html site's `source` map as a reviewable draft.
+
+| Arg | Type | Notes |
+|-----|------|-------|
+| `pocket_id` | string | Required. The html site pocket. |
+| `file_path` | string | Required. Project-relative and usually at the site **root** — `index.html`, `styles.css`, `about.html`, `img/logo.svg`. Must already exist unless `create` is true. |
+| `edits` | array | A list of `{old_string, new_string}` blocks applied to the file's current contents. Each `old_string` must match **exactly once**. Exactly one of `edits` / `new_source`. |
+| `new_source` | string | The full new file contents (replaces the whole file). Required with `create`. |
+| `create` | boolean | Default `false`. Create a NEW file at `file_path`; the path must **not** already exist. |
+
+Returns `{ok: true, status: "draft", is_live: false, pocket_id, file_path,
+created, message}`. To **add a page**, call it twice: once with `create: true` for
+e.g. `about.html`, then again with `edits` on `index.html` to link to it.
+
+**The argument is `file_path`, not `component_path`, and the difference is not
+cosmetic.** svelte and react have a component model; html does not — the scaffold
+writes the author's map verbatim into the directory the edge serves, so what
+exists is files. Paths are **root-relative with no `src/` prefix**; passing react's
+`src/components/Hero.tsx` shape here creates a file nothing serves.
+
+**It does not publish**, for a different reason than react's. React defers because
+its build is async and there is no synchronous outcome to roll back from. Html has
+no build *at all* (`needs_node_build` is false), so there is no smoke render and
+nothing that could reject a bad edit before it deployed — a republish here would
+push unvalidated markup straight to a live customer site. Draft-only is the safer
+contract, not merely the convenient one.
+
+**Write scope**: only two rejections, because an html site's files legitimately
+live at the project root and react's `src/`-or-`public/` rule would reject the
+whole track. Paths are normalized (backslashes, `.`/`..`) before the check.
+
+| Rejected | Why |
+|----------|-----|
+| the `_paw/` namespace | Generator-owned. `_paw/edit-manifest.json` maps each editable element to a byte range; shadowing it makes the next **native** editor edit splice at wrong offsets and land mid-tag — silently. |
+| anything escaping the site directory | `..` and absolute paths. |
+
+Errors (relayed to the agent as `is_error` with the code, so it can fix and retry):
+
+| Code | When |
+|------|------|
+| `site_edit.invalid_args` | Not exactly one of `edits` / `new_source`. |
+| `site_edit.create_needs_source` | `create` without `new_source`. |
+| `site_edit.reserved_path` | The resolved path is in `_paw/`. |
+| `site_edit.path_outside_source` | The resolved path escapes the site directory. |
+| `site_edit.no_match` / `site_edit.ambiguous_match` | An `old_string` matched 0 or >1 times. Make it more specific and retry. |
+| `pocket.not_html_site` | The pocket is not an html Paw Site. |
+| `pocket.html_file_exists` | `create` on a path that already exists. |
+| `site_component.not_found` | `create` is false and the path is not in the source map. |
+| `plan.feature_denied` | The workspace's plan lacks the `sites` feature. |
+
+Every write goes through `pockets_service.set_html_source_file`, which emits
+`PocketUpdated` and records a draft `ArtifactVersion` — the same chokepoint
+contract the react tool uses.
+
+**Keep the form plumbing.** If a file contains a `<form>` posting to
+`/capture/form`, its `action` and the hidden `paw_site_id` / `paw_key` /
+`paw_redirect` inputs are what deliver leads. A rewrite that drops them leaves a
+form that still looks right and captures nothing, with no visible change to the
+page.
 
 ### Build state on the `publish` response
 

--- a/ee/pocketpaw_ee/cloud/surface/handlers/sites.py
+++ b/ee/pocketpaw_ee/cloud/surface/handlers/sites.py
@@ -139,6 +139,26 @@
 # the entry point answers the key. (The refine half of that claim no longer
 # holds — see the next entry.)
 #
+# Changes: 2026-08-18 (fix/sites-html-refine-names-the-edit-tool) — the html
+# branches stopped denying a tool that exists. ``edit_html_file`` shipped in
+# db083bfc ("html sites could be made and published, never changed") wired all the
+# way through: service → MCP tool → ``sites_manager`` server → ``SITES_TOOL_IDS``
+# → the /sites allow-list. That commit never touched THIS file, so the refine
+# preamble kept the pre-HE-10 text telling the agent an html site "has no edit tool
+# yet" and to hand back a code block instead. The agent obeyed the prompt over its
+# own tool list — the reported symptom was it answering an edit request with
+# "editing an html site's files from chat is not wired up yet" while holding the
+# tool that does it. Four sites carried the stale claim and all four are fixed:
+# ``_refine_preamble``'s html branch (now names the tool, its ``file_path``
+# argument and its root-relative paths, mirroring the react branch),
+# ``_refine_unknown_engine_step`` (listed html as the engine with no edit tool),
+# the ``publish_step`` gate (html was excluded because no write could land — it
+# now gets the same publish step, rendered synchronous since ``build_runs_async``
+# is react-only), and ``_create_preamble``'s html branch (had no "changes go
+# through the edit tool" clause, so a follow-up change in the create conversation
+# re-created the site). Guarded by a NEW inverse test: every REGISTERED edit tool
+# must be named by its engine's refine branch — the existing gate only checked
+# that named tools exist, which is why a real tool going unnamed shipped clean.
 # Changes: 2026-08-11 (fix/sites-refine-preamble-engine-fork) — ``_refine_preamble``
 # FORKS BY ENGINE. It was written for ripple and shipped to all four: on a react,
 # html or svelte site it commanded ``pocket_specialist__edit`` (which mutates a
@@ -689,7 +709,19 @@ def _create_preamble(meta: SurfaceMeta) -> str:
             "live-data / dynamic app (dashboards, per-user data) → "
             "`mcp__pocketpaw_sites_manager__create_dynamic_site`. A described "
             "business, a desire for a 'nice' or 'modern' site, or the design "
-            "direction the user picked is NOT such a request — stay on HTML."
+            "direction the user picked is NOT such a request — stay on HTML.\n"
+            "CHANGES GO THROUGH THE EDIT TOOL. Once the site exists, ANY further "
+            "change the user asks for in this conversation — 'change the phone "
+            "number in the footer', 'shorten the hero headline', 'add an about "
+            "page' — is `mcp__pocketpaw_sites_manager__edit_html_file` with the "
+            "SAME pocket_id, NOT a second `create_html_site` call. Calling create "
+            "again mints a SECOND site and leaves the one the user is looking at "
+            "unchanged. Send a targeted `edits` diff for a small change (an html "
+            "page is one flat document, so a rewrite re-emits the whole page to "
+            "change a line); to add a page, call it with `create=true` for the new "
+            "file and then again with `edits` on `index.html` to link to it. The "
+            "edit saves to the DRAFT — it does not publish, so keep offering the "
+            "Preview rather than announcing a live change."
         )
 
     # ASK MECHANISM — used ONLY when the agent genuinely needs a real-world FACT
@@ -992,10 +1024,10 @@ def _refine_unknown_engine_step(pocket_id: str) -> str:
 
     The read fails on a deleted pocket, a cross-workspace stamp, or a dropped
     connection — and a fifth engine in ``sites/engines.py`` with no branch here
-    lands in the same place. Every engine's edit path is a DIFFERENT tool and three
-    of the four reject a pocket from another track, so guessing is the one move
-    guaranteed to be wrong roughly three times in four. Name no tool; make the
-    agent look first.
+    lands in the same place. Every engine's edit path is a DIFFERENT tool and each
+    one rejects a pocket from another track, so guessing is the one move guaranteed
+    to be wrong roughly three times in four. Name no single tool; make the agent
+    look first.
     """
     return (
         "WHICH ENGINE AUTHORED THIS SITE COULD NOT BE DETERMINED, so do not assume "
@@ -1009,9 +1041,8 @@ def _refine_unknown_engine_step(pocket_id: str) -> str:
         "pockets carry a `source` map ({path: file contents}) instead, and the "
         "specialist CANNOT edit those — svelte uses "
         "`mcp__pocketpaw_sites_manager__edit_svelte_component`, react uses "
-        "`mcp__pocketpaw_sites_manager__edit_react_component`, and html has no "
-        "edit tool at all yet (say so plainly rather than reaching for a create "
-        "tool).\n"
+        "`mcp__pocketpaw_sites_manager__edit_react_component`, and html uses "
+        "`mcp__pocketpaw_sites_manager__edit_html_file`.\n"
         "If the read fails too, tell the user you could not load their site rather "
         "than attempting an edit blind.\n"
     )
@@ -1025,8 +1056,8 @@ def _refine_preamble(meta: SurfaceMeta, engine: str | None = None) -> str:
 
     * **which tool can edit the page at all** — ripple's content is a ``rippleSpec``
       the pocket specialist merges into; svelte, react and html carry a ``source``
-      map instead, which that tool cannot touch. Each source engine has (or lacks)
-      its own file-level edit tool;
+      map instead, which that tool cannot touch. Each source engine has its own
+      file-level edit tool, and they do not take the same arguments;
     * **whether JavaScript runs for the visitor** — a react site ships a hydrating
       client bundle by default (``sites_keep_client_bundle_default``), so "no
       JavaScript runs" is false there, while the prerender contract that DOES bind
@@ -1174,50 +1205,75 @@ def _refine_preamble(meta: SurfaceMeta, engine: str | None = None) -> str:
             " The page is a hand-authored static HTML/CSS bundle served straight "
             "from the edge — the files in the source map ARE the page."
         )
-        # THE HONEST BRANCH. html is the DEFAULT create engine and has no
-        # chat-reachable edit tool: ``create_html_site`` takes no ``pocket_id`` (it
-        # mints a new pocket, so calling it here would leave the user with a second,
-        # unrelated site), ``edit_svelte_component``'s service guard is svelte-only
-        # by design, and the uid-splice path behind the native editor
-        # (``sites/service.py::apply_leaf_edits``) is a REST route and svelte-gated
-        # too. Naming any of them would be the exact defect this fork fixes, so the
-        # branch states the gap instead. Being useful inside a real limit beats
-        # improvising outside it.
+        # THE BRANCH THAT WENT STALE. Written when html genuinely had no
+        # chat-reachable edit tool, it told the agent to hand the user a code block
+        # and say editing "is not wired up yet". ``edit_html_file`` shipped in
+        # db083bfc (service → MCP tool → ``sites_manager`` registration →
+        # ``SITES_TOOL_IDS``) and that commit never touched this file, so the prompt
+        # kept denying a capability the agent was already holding.
+        #
+        # That is the MIRROR of the defect pocketpaw/CLAUDE.md names under "The
+        # prompt may not command a tool the agent doesn't have", and it fails the
+        # same silent way: a prompt may not DENY a tool the agent DOES have. The
+        # model trusts the preamble over its own tool list, so the user is told the
+        # product cannot do something it can — and nothing errors.
+        #
+        # The argument names are read off ``edit_html_file``'s own schema rather
+        # than copied from the react branch: an html site has FILES, so the argument
+        # is ``file_path``, and its paths are root-relative with no ``src/`` prefix.
         edit_step = (
-            "YOU CANNOT WRITE THIS SITE'S FILES FROM THIS CHAT. An html site has "
-            "no edit tool yet — that is a real gap in the product, not something "
-            "to work around:\n"
-            "- the pocket specialist edits a rippleSpec. This pocket has a "
-            "`source` map instead, so it has nothing to merge into — do NOT call "
-            "it and do NOT draft a rippleSpec.\n"
-            "- the create tools take no pocket id: each one creates a NEW pocket "
-            "and a SECOND site, leaving the one the user is looking at untouched. "
-            "Do NOT call a create tool to 'apply' a change.\n"
-            "WHAT TO DO INSTEAD, in one turn: call "
-            f"`mcp__pocketpaw_pocket__get_pocket` with pocket_id `{pocket_id}` to "
-            "read the current files from its `source` map, work out exactly what "
-            "the change is, and give the user the finished replacement markup for "
-            "the file that changes (in a code block, with the file's path) plus a "
-            "one-line description of where it goes. Then say plainly that editing "
-            "an html site's files from chat is not wired up yet, so you cannot "
-            "apply it for them. Do not imply you saved, published, or previewed "
-            "anything — nothing was written.\n"
+            "Treat the user's message as an edit to ONE file. This site's content "
+            "is a `source` map ({path: file contents}), NOT a rippleSpec — there is "
+            "no widget spec here, so do NOT call the pocket specialist and do NOT "
+            "draft a rippleSpec.\n"
+            "Call `mcp__pocketpaw_sites_manager__edit_html_file` with pocket_id "
+            f"`{pocket_id}`, the `file_path` to write, and EXACTLY ONE of `edits` "
+            "(a list of {old_string, new_string} blocks — PREFER THIS, and prefer "
+            "it harder here than on the component tracks: an html page is ONE flat "
+            "document, so a whole-file rewrite means re-emitting the entire page to "
+            "change a phone number. Each old_string must match the current file "
+            "verbatim and exactly once) or `new_source` (the whole new file, for a "
+            "large rewrite). Read the file before you diff it. To ADD a page, call "
+            "it twice: once with `create=true` and `new_source` for the new file "
+            "(e.g. 'about.html'), then once with `edits` on `index.html` to link to "
+            "it. NEVER call `create_html_site` again to apply a change — it takes "
+            "no pocket id, so it mints a SECOND site pocket at a SECOND url and "
+            "leaves the one the user is looking at untouched.\n"
+            "PATHS ARE ROOT-RELATIVE: `index.html` is the page the edge serves, "
+            "alongside `styles.css`, `about.html`, `img/logo.svg`. Do NOT prefix "
+            "them with `src/` — that is the react track. The generated `_paw/` "
+            "namespace and any path climbing out with `..` are rejected.\n"
+            "THE EDIT IS SAVED TO THE DRAFT, NOT PUBLISHED. The tool returns "
+            '`status:"draft"` / `is_live:false`; nothing is built and nothing goes '
+            "live, and the user previews it under /sites. Relay the tool's own "
+            "`message` and do not tell them it is live. On `ok:false` NOTHING was "
+            "saved — relay the reason (a reserved path, the wrong engine, a file "
+            "that already exists or does not exist, an old_string that matched 0 or "
+            "more than 1 time) rather than reporting a change that did not "
+            "happen.\n"
         )
         rules = _REFINE_SHARED_RULES + (
-            "Whatever markup you hand back keeps the page working with no "
-            "JavaScript: the full resting state lives in the HTML, never rendered "
-            "only by a script.\n"
+            "Whatever markup you write keeps the page working with no JavaScript: "
+            "the full resting state lives in the HTML, never rendered only by a "
+            "script.\n"
         )
     else:
         render_truth = ""
         edit_step = _refine_unknown_engine_step(pocket_id)
         rules = _REFINE_SHARED_RULES
 
-    # html has nothing to publish FROM chat (no write landed), and the unknown
-    # branch has not established which engine it would be publishing — naming a
-    # publish flow in either would invite the agent to publish the LAST build as
-    # if it carried the change the user just asked for.
-    publish_step = "" if engine in (None, "html") else _refine_publish_step(engine, pocket_id)
+    # html was excluded here only because no write could land on it. Now that
+    # ``edit_html_file`` stages a draft exactly as svelte and react do, it earns the
+    # same publish step they get — leaving it out would strand the user with a
+    # saved change and no way to take it live. Its build is INLINE
+    # (``build_runs_async`` is react-only), so ``_refine_publish_step`` renders the
+    # synchronous wording for it.
+    #
+    # The UNKNOWN branch still gets nothing, for the reason it always did: it has
+    # not established which engine it would be publishing, so naming a publish flow
+    # there invites the agent to publish the LAST build as if it carried the change
+    # the user just asked for.
+    publish_step = "" if engine is None else _refine_publish_step(engine, pocket_id)
 
     return (
         f'<surface kind="sites" route="{route}" pocket="{pocket_id}"'

--- a/tests/cloud/surface/test_sites_handler.py
+++ b/tests/cloud/surface/test_sites_handler.py
@@ -104,6 +104,19 @@
 # concierge (provisioning is live-publish-only) and must not name a configuration
 # tool that does not exist (catalog/actions are owner-authored only).
 
+# Updated: 2026-08-18 (fix/sites-html-refine-names-the-edit-tool) — the html
+# refine branch was denying a tool that exists. ``edit_html_file`` shipped in
+# db083bfc without touching the handler, so the preamble kept telling the agent an
+# html site had no edit tool and the agent relayed that to users. Three tests here
+# changed: ``test_html_refine_admits_it_has_no_edit_tool`` became
+# ``test_html_refine_routes_the_edit_to_the_html_edit_tool`` (it had been
+# certifying the stale prompt as correct on every run), and two new ones pin the
+# publish step html now earns and the unknown-engine fallback that listed html as
+# uneditable. The gate that should have caught this gained its missing direction:
+# ``test_every_registered_edit_tool_is_named_by_its_refine_branch`` fails when a
+# REGISTERED tool goes unnamed, where the existing gate only failed when a NAMED
+# tool was unregistered.
+
 from __future__ import annotations
 
 import pytest
@@ -1339,6 +1352,7 @@ async def test_ripple_refine_keeps_the_rippleSpec_merge(mongo_db: object) -> Non
 
 REACT_TOOL = "mcp__pocketpaw_sites_manager__edit_react_component"
 SVELTE_TOOL = "mcp__pocketpaw_sites_manager__edit_svelte_component"
+HTML_TOOL = "mcp__pocketpaw_sites_manager__edit_html_file"
 RIPPLE_TOOL = "mcp__pocketpaw_pocket_specialist__edit"
 SOURCE_MAP_ENGINES = ("svelte", "react", "html")
 ALL_REFINE_ENGINES = ("ripple", "svelte", "react", "html", None)
@@ -1735,30 +1749,81 @@ async def test_svelte_refine_names_its_own_tool_and_calls_the_edit_a_draft() -> 
     assert "new_source" in preamble
 
 
-async def test_html_refine_admits_it_has_no_edit_tool() -> None:
-    """html is the DEFAULT create engine and has NO chat-reachable edit tool:
-    ``create_html_site`` takes no pocket id (it mints a second site),
-    ``edit_svelte_component``'s guard is svelte-only by design, and the uid-splice
-    path behind the native editor is a svelte-gated REST route. So the branch says
-    so — the one thing it must not do is name a tool to fill the gap.
+async def test_html_refine_routes_the_edit_to_the_html_edit_tool() -> None:
+    """html refine applies the change with ``edit_html_file``.
 
-    THE MUTATION THAT BREAKS THIS: point the html branch's edit step at
-    ``mcp__pocketpaw_sites_manager__create_html_site``. Run: a create tool was named
-    as the apply path and this failed. (Applied 2026-08-11.)
+    This test used to assert the OPPOSITE — that the branch admits it has no edit
+    tool — and it was correct when written. ``edit_html_file`` shipped in db083bfc
+    without touching the handler, so the assertion outlived the gap it described
+    and certified the stale prompt as correct on every run. Rewritten rather than
+    deleted: the html branch still has rules the other engines do not, and they are
+    pinned below.
+
+    THE MUTATION THAT BREAKS THIS: point the html branch's edit step back at
+    ``mcp__pocketpaw_pocket__get_pocket`` + "hand the user the markup". Run: the
+    branch stopped naming a write tool and this failed.
     """
     preamble = sites_handler._refine_preamble(_refine_meta(), "html")
     lower = preamble.lower()
 
-    assert "cannot write this site's files from this chat" in lower
-    # No write tool is named — including the create tool that would look like one.
-    assert "create_html_site" not in preamble
+    assert HTML_TOOL in preamble
+    # The html argument is `file_path` — react's `component_path` is a different
+    # tool's schema and a wrong-argument call is rejected.
+    assert "`file_path`" in preamble
+    assert "component_path" not in preamble
+    # Root-relative paths: the `src/` prefix belongs to the react track.
+    assert "root-relative" in lower
+    # The wrong tools stay unnamed: create mints a SECOND site, and the specialist
+    # merges a rippleSpec this pocket does not have.
     assert "pocket_specialist__edit" not in preamble
     assert SVELTE_TOOL not in preamble
     assert REACT_TOOL not in preamble
-    # It still does the useful half: read the current source and hand back markup.
-    assert "mcp__pocketpaw_pocket__get_pocket" in preamble
-    # And it must not offer to publish a change it never applied.
-    assert "mcp__pocketpaw_sites_manager__publish" not in preamble
+    # `create_html_site` IS named, but only as the thing never to call for a change.
+    assert "NEVER call `create_html_site` again to apply a change" in preamble
+    # The edit stages a draft, so the branch must not report it live.
+    assert "not published" in lower
+    assert "is_live:false" in preamble
+
+
+async def test_html_refine_can_offer_to_publish_the_change() -> None:
+    """A saved html edit is publishable, so the branch must say how.
+
+    While html had no edit tool the publish step was deliberately withheld: naming
+    one would have invited the agent to publish the LAST build as if it carried a
+    change it never applied. That reasoning expires with the gap — withholding it
+    now strands the user with a saved draft and no route to live.
+
+    THE MUTATION THAT BREAKS THIS: restore ``engine in (None, "html")`` on the
+    ``publish_step`` gate. Run: html saved a change it could not take live and this
+    failed.
+    """
+    preamble = sites_handler._refine_preamble(_refine_meta(), "html")
+
+    assert "mcp__pocketpaw_sites_manager__publish" in preamble
+    # Publishing stays the user's call — an edit must not auto-publish.
+    assert "the user's call" in preamble.lower()
+    # html builds INLINE (`build_runs_async` is react-only), so it must NOT carry
+    # react's queued-build paragraph or the status tool that only async needs.
+    assert "get_site_build_status" not in preamble
+    assert "asynchronous" not in preamble.lower()
+
+
+async def test_the_unknown_engine_step_no_longer_calls_html_uneditable() -> None:
+    """The engine-lookup fallback listed html as the engine with no edit tool.
+
+    It is reached whenever the pocket read fails, so its stale half sent every
+    unresolvable html site down the same dead end the html branch did.
+
+    THE MUTATION THAT BREAKS THIS: put "html has no edit tool at all yet" back.
+    Run: the fallback denied a registered tool and this failed.
+    """
+    step = sites_handler._refine_unknown_engine_step("pkt-1")
+
+    assert HTML_TOOL in step
+    assert "no edit tool" not in step.lower()
+    # It still names the other three, and still makes the agent look first.
+    assert SVELTE_TOOL in step and REACT_TOOL in step and RIPPLE_TOOL in step
+    assert "mcp__pocketpaw_pocket__get_pocket" in step
 
 
 async def test_ripple_refine_is_unchanged_apart_from_the_publish_claim() -> None:
@@ -1848,3 +1913,71 @@ async def test_every_tool_a_refine_branch_names_is_a_registered_tool() -> None:
         "a refine branch names tools that no MCP server registers — the agent "
         f"cannot call these and will improvise instead of erroring: {sorted(unresolved)}"
     )
+
+
+# --- HE-10 follow-through (fix/sites-html-refine-names-the-edit-tool) ---------
+#
+# THE REPORTED BUG: on an html site's refine chat the agent answered an edit
+# request with "editing an html site's files from chat is not wired up yet" and
+# handed back a code block instead of applying the change.
+#
+# It was never a missing tool. ``edit_html_file`` shipped in db083bfc wired all
+# the way through — service, MCP tool, ``sites_manager`` registration,
+# ``SITES_TOOL_IDS``, the /sites allow-list — but that commit never touched
+# ``handlers/sites.py``. Compare 34582e73, which shipped the react edit tool AND
+# +137 lines of this handler in the same commit. So the prompt kept the pre-HE-10
+# text and the agent believed the prompt over its own tool list.
+#
+# It shipped clean because the gate below ran one way only:
+# ``test_every_tool_a_refine_branch_names_is_a_registered_tool`` catches a
+# preamble naming a tool that does not exist, and nothing caught a tool that
+# exists and no preamble names.
+#
+# The tests above pin the fixed branch. The one below is the missing direction of
+# the gate, and it is the one that would have caught this on the day it landed.
+
+
+async def test_every_registered_edit_tool_is_named_by_its_refine_branch() -> None:
+    """The INVERSE gate: a registered edit tool no preamble names is unreachable.
+
+    The failure has no error to notice — the agent simply reports the capability
+    as missing, which is indistinguishable from the product genuinely lacking it.
+    Derived from the MCP tool schemas, never a hand-kept list, so a fourth edit
+    tool joins this gate by being registered rather than by being remembered.
+
+    THE MUTATION THAT BREAKS THIS: drop ``edit_html_file`` from the html refine
+    branch. Run: a registered tool went unnamed and this failed.
+    """
+    registered = await _registered_mcp_tool_ids()
+    assert registered, "no MCP tools enumerated — the derivation broke, not the prompt"
+
+    for engine, tool_id in (
+        ("svelte", SVELTE_TOOL),
+        ("react", REACT_TOOL),
+        ("html", HTML_TOOL),
+    ):
+        text = sites_handler._refine_preamble(_refine_meta(), engine)
+        assert tool_id in registered, f"{tool_id} is not registered — fix the server"
+        assert tool_id in text, (
+            f"{tool_id} is a REGISTERED tool that the {engine} refine branch never "
+            "names, so the agent cannot reach it and will tell the user the "
+            "capability does not exist"
+        )
+
+
+async def test_html_create_routes_follow_up_changes_to_the_edit_tool() -> None:
+    """The create side had the same hole: html got no "changes go through the edit
+    tool" clause, so a follow-up change in the SAME conversation re-created the
+    site. react has carried this clause since RX-3; html now does too.
+
+    THE MUTATION THAT BREAKS THIS: delete the clause from the html build step.
+    Run: the create branch let a follow-up change mint a second site and this
+    failed.
+    """
+    preamble = await _preamble_for(None)  # no engine hint == the html default
+
+    assert HTML_TOOL in preamble
+    assert "CHANGES GO THROUGH THE EDIT TOOL" in preamble
+    assert "SAME pocket_id" in preamble
+    # Create is still the FIRST thing named — this is a create preamble.
+    assert preamble.index("create_html_site") < preamble.index("edit_html_file")

--- a/tests/mutations/html_edit_lane.json
+++ b/tests/mutations/html_edit_lane.json
@@ -96,5 +96,26 @@
     "find": "    return {\"pocket_id\": pocket_id, \"file_path\": file_path, \"created\": create}",
     "replace": "    await publish_pocket(workspace_id=\"\", user_id=user_id, pocket_id=pocket_id, name=\"\")\n    return {\"pocket_id\": pocket_id, \"file_path\": file_path, \"created\": create}",
     "tests": ["tests/ee/sites/test_html_file_edit.py"]
+  },
+  {
+    "label": "the html refine branch is dropped, so an html site's chat falls back to the engine-unknown routing table instead of naming its own edit tool",
+    "file": "ee/pocketpaw_ee/cloud/surface/handlers/sites.py",
+    "find": "    elif engine == \"html\":",
+    "replace": "    elif False:  # html refine branch dropped",
+    "tests": ["tests/cloud/surface/test_sites_handler.py::test_html_refine_routes_the_edit_to_the_html_edit_tool", "tests/cloud/surface/test_sites_handler.py::test_html_refine_can_offer_to_publish_the_change"]
+  },
+  {
+    "label": "the html create step stops naming the edit tool, so a follow-up change in the same conversation goes back to a second create_html_site and a second site pocket",
+    "file": "ee/pocketpaw_ee/cloud/surface/handlers/sites.py",
+    "find": "            \"page' \u2014 is `mcp__pocketpaw_sites_manager__edit_html_file` with the \"",
+    "replace": "            \"page' \u2014 is `create_html_site` again with the \"",
+    "tests": ["tests/cloud/surface/test_sites_handler.py::test_html_create_routes_follow_up_changes_to_the_edit_tool"]
+  },
+  {
+    "label": "the publish step is withheld from html again, so a saved html edit has no route to live and the agent cannot tell the user how to publish it",
+    "file": "ee/pocketpaw_ee/cloud/surface/handlers/sites.py",
+    "find": "    publish_step = \"\" if engine is None else _refine_publish_step(engine, pocket_id)",
+    "replace": "    publish_step = \"\" if engine in (None, \"html\") else _refine_publish_step(engine, pocket_id)",
+    "tests": ["tests/cloud/surface/test_sites_handler.py::test_html_refine_can_offer_to_publish_the_change"]
   }
 ]

--- a/tests/mutations/sites_refine_engine_fork.json
+++ b/tests/mutations/sites_refine_engine_fork.json
@@ -20,10 +20,10 @@
   {
     "label": "the html branch names a create tool as its apply path — the agent mints a SECOND site and reports the edit done",
     "file": "ee/pocketpaw_ee/cloud/surface/handlers/sites.py",
-    "find": "            \"- the create tools take no pocket id: each one creates a NEW pocket \"",
-    "replace": "            \"- apply the change with `mcp__pocketpaw_sites_manager__create_html_site` \"",
+    "find": "            \"Call `mcp__pocketpaw_sites_manager__edit_html_file` with pocket_id \"",
+    "replace": "            \"Call `mcp__pocketpaw_sites_manager__create_html_site` with pocket_id \"",
     "tests": [
-      "tests/cloud/surface/test_sites_handler.py::test_html_refine_admits_it_has_no_edit_tool"
+      "tests/cloud/surface/test_sites_handler.py::test_html_refine_routes_the_edit_to_the_html_edit_tool"
     ]
   },
   {


### PR DESCRIPTION
Reported as "editing html sites isn't working — the agent says it doesn't have an edit html tool wired up." The agent was right about what it read and wrong about what it had.

## What happened

`edit_html_file` landed in db083bfc wired end to end: service, MCP tool, registration on the `sites_manager` server, `SITES_TOOL_IDS`, the /sites allow-list. That commit never touched `handlers/sites.py`, so the refine preamble kept the text written before the tool existed:

> YOU CANNOT WRITE THIS SITE'S FILES FROM THIS CHAT. An html site has no edit tool yet — that is a real gap in the product [...] say plainly that editing an html site's files from chat is not wired up yet

The agent obeyed the preamble over its own tool list and relayed that to users, verbatim. Nothing errored.

Compare 34582e73, which shipped the react edit tool and +137 lines of this handler in the same commit. That is the step html missed.

## What changed

Four places carried the stale claim:

| Where | Was | Now |
|---|---|---|
| `_refine_preamble` html branch | "you cannot write this site's files" | names the tool, its `file_path` argument, and its root-relative paths, the way the react branch does |
| `_refine_unknown_engine_step` | listed html as the engine with no edit tool | names `edit_html_file` alongside the other three |
| the `publish_step` gate | skipped html, since no write could land on it | html gets it; its build is inline (`build_runs_async` is react-only), so the synchronous wording |
| `_create_preamble` html branch | no "changes go through the edit tool" clause | a follow-up change in the same conversation no longer re-creates the site at a second url |

The argument names are read off `edit_html_file`'s own schema rather than copied from react's: an html site has files, so it takes `file_path`, and its paths sit at the root with no `src/` prefix.

## Why it shipped clean

The gate ran one way only. `test_every_tool_a_refine_branch_names_is_a_registered_tool` fails when a preamble names a tool that does not exist. Nothing failed when a tool existed and no preamble named it — and that failure has no error to notice, since the agent just reports the capability as missing.

`test_every_registered_edit_tool_is_named_by_its_refine_branch` is that missing direction, derived from the MCP tool schemas rather than a hand-kept list, so a fourth edit tool joins the gate by being registered rather than by being remembered.

`test_html_refine_admits_it_has_no_edit_tool` was rewritten, not deleted. It was correct when written, and had been certifying the stale prompt as correct on every run since the tool landed.

## Verification

- 1652 passed, 4 skipped across `tests/cloud/surface/`, `tests/ee/agent/test_sites_mcp_server/`, `tests/ee/sites/`
- `html_edit_lane.json` gained the three preamble mutations the react lane already had — all 17 caught
- `sites_refine_engine_fork.json` — 14/14 caught; one anchor pointed at text this removes and is repointed at the same harm
- `mutate.py --validate` — 540 anchors across 44 plans each resolve exactly once
- ruff check and format clean

Docs: api-reference now documents the tool, including why the argument is `file_path` and why this one does not republish for a different reason than react's — html runs no build at all, so nothing could catch a bad edit before it went live.
