### PR TITLE
docs: fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,11 +456,11 @@ bun run tauri build            # Production build
 
 ## Star History
 
-<a href="https://star-history.com/#pocketpaw/pocketpaw&Date">
+<a href="https://star-history.dera.page/#pocketpaw/pocketpaw&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=pocketpaw/pocketpaw&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=pocketpaw/pocketpaw&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=pocketpaw/pocketpaw&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=pocketpaw/pocketpaw&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=pocketpaw/pocketpaw&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=pocketpaw/pocketpaw&type=Date" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart embedded in the README is broken: the upstream star-history.com service stopped working properly due to GitHub stargazer API restrictions, so the image no longer renders.

This PR updates the chart to use a working alternative hosting of the same star-history project. The wrapping link now points to a hash-based URL on the new host, and the chart images use the matching /svg endpoint with the existing parameters and themes preserved.