### PR TITLE
A Paw Bar visitor may hold more than one conversation

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2327,7 +2327,9 @@ the split is the security model:
 | `GET /paw-bar/spec/{widget_id}` | The widget's render spec. |
 | `POST /paw-bar/events/{widget_id}` | Ingest a widget event. |
 | `GET /paw-bar/events/{widget_id}/decision/{customer_ref}` | Poll the outcome of a gated action the visitor requested. |
-| `POST /paw-bar/chat` | Stream a concierge reply (SSE). When the owner has taken the conversation over this emits a single `human_replying` frame and dispatches no agent run at all. |
+| `POST /paw-bar/chat` | Stream a concierge reply (SSE). When the owner has taken the conversation over this emits a single `human_replying` frame and dispatches no agent run at all. Takes an optional `conversation_id`; omit it and the turn lands on the visitor's conversation in progress, which is what widget bundles built before that field send. |
+| `GET /paw-bar/conversations` | The visitor's own conversations on this bar, newest first, with a preview and which one is in progress. Scoped to the `customer_ref` the embed key already bound, so there is nothing to enumerate. |
+| `POST /paw-bar/conversations` | Start a fresh conversation. The current one is retired rather than deleted — it stays in the visitor's list and in the owner's inbox — and the next turn starts the agent cold instead of replaying the thread the visitor walked away from. |
 | `POST /paw-bar/action` | Run a verb the widget spec declares. `auto` verbs touch only the visitor's own cart or a checkout link; `gated` verbs execute nothing and raise an Instinct proposal for a human. |
 | `GET /paw-bar/cart` | The visitor's own cart. |
 | `POST /paw-bar/decision-contact` | Leave an email so a decision reaches the visitor after they close the page. The address is stored on the decision row only — never in agent context, the KB, or transcripts. |

--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -2997,7 +2997,12 @@ async def _conversation_counts(widget: PawBarWidget | None, workspace_id: str) -
 
 
 async def _concierge_runs_for_visitor(
-    pocket_id: str, customer_ref: str, workspace_id: str, *, limit: int
+    pocket_id: str,
+    customer_ref: str,
+    workspace_id: str,
+    *,
+    limit: int,
+    session_key: str = "",
 ) -> list[Any]:
     """One visitor's concierge runs on one site, most-recent first.
 
@@ -3013,19 +3018,31 @@ async def _concierge_runs_for_visitor(
       * ``user_id``       — the anonymous customer handle; a sibling VISITOR of
                             the same widget never matches.
 
+    ``session_key`` narrows further, to ONE conversation of that visitor
+    (2026-08-19). It is optional because the two callers want different things:
+    the owner's transcript read wants the visitor's whole history with the site,
+    while the agent's memory rehydration must see only the conversation actually
+    in progress — replaying an abandoned thread into a fresh one is the bug this
+    parameter exists to fix. The key already encodes the conversation id, so this
+    needs no new field on the run doc.
+
     Callers pass ``workspace_id`` / ``pocket_id`` from the authenticated
     authority (the resolved site key or the session's workspace), never from the
     request body. Index-backed and always bounded by ``limit``.
     """
     from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
 
+    predicates = [
+        ChatRunDoc.workspace == workspace_id,
+        ChatRunDoc.context_type == _CONCIERGE_CONTEXT_TYPE,
+        ChatRunDoc.scope_id == pocket_id,
+        ChatRunDoc.user_id == customer_ref,
+    ]
+    if session_key:
+        predicates.append(ChatRunDoc.session_key == session_key)
+
     return (
-        await ChatRunDoc.find(
-            ChatRunDoc.workspace == workspace_id,
-            ChatRunDoc.context_type == _CONCIERGE_CONTEXT_TYPE,
-            ChatRunDoc.scope_id == pocket_id,
-            ChatRunDoc.user_id == customer_ref,
-        )
+        await ChatRunDoc.find(*predicates)
         .sort(-ChatRunDoc.createdAt)  # type: ignore[operator]
         .limit(limit)
         .to_list()
@@ -3033,9 +3050,9 @@ async def _concierge_runs_for_visitor(
 
 
 async def _load_concierge_history(
-    pocket_id: str, customer_ref: str, workspace_id: str
+    pocket_id: str, customer_ref: str, workspace_id: str, session_key: str = ""
 ) -> list[dict[str, str]]:
-    """Rehydrate one visitor's prior turns as ``RunSpec.history``.
+    """Rehydrate this CONVERSATION's prior turns as ``RunSpec.history``.
 
     The concierge visitor is anonymous and has no ``Message`` rows, so the authed
     surfaces' ``load_history_for_scope`` has nothing to read and every turn was
@@ -3057,6 +3074,13 @@ async def _load_concierge_history(
     writes this turn's doc, so the visitor's message rides in ``RunSpec.content``
     exactly once.
 
+    ``session_key`` scopes the replay to ONE conversation (2026-08-19). Before it,
+    the read was per-VISITOR, so a visitor who started over still had their
+    abandoned thread replayed into the agent — the loudest half of the reported
+    "every session is one session" bug, because it is the half the visitor could
+    actually feel. Passing "" restores the old visitor-wide behaviour and is what
+    a caller with no conversation in hand gets.
+
     Failure-soft: any read error degrades to no memory and logs. A visitor's chat
     must not 500 because the run collection hiccuped.
     """
@@ -3067,7 +3091,11 @@ async def _load_concierge_history(
 
     try:
         runs = await _concierge_runs_for_visitor(
-            pocket_id, customer_ref, workspace_id, limit=_HISTORY_TURN_CAP
+            pocket_id,
+            customer_ref,
+            workspace_id,
+            limit=_HISTORY_TURN_CAP,
+            session_key=session_key,
         )
 
         history: list[dict[str, str]] = []
@@ -3596,6 +3624,18 @@ class ConciergeChatRequest(BaseModel):
     # NEVER an authenticated principal.
     customer_ref: str
     message: str
+    # Which of this visitor's conversations the turn belongs to (2026-08-19).
+    #
+    # OPTIONAL on purpose, and it must stay optional: widget bundles cached on
+    # visitors' devices predate the field, and a required one would 422 every one
+    # of them the moment this deploys. Absent means "the conversation in
+    # progress", which the store resolves-or-creates — exactly the behaviour
+    # before conversations had identities.
+    #
+    # An id belonging to another visitor or another tenant does not resolve, and
+    # the turn falls back to the caller's own active conversation rather than
+    # erroring: the value is client-supplied, so it is a hint, never an authority.
+    conversation_id: str = ""
 
 
 def _sse(event: str, data: dict[str, Any], *, entry_id: str | None = None) -> bytes:
@@ -3868,6 +3908,30 @@ async def concierge_chat(body: ConciergeChatRequest, request: Request) -> Stream
     except Exception:
         logger.warning("conversation state upsert failed (non-fatal)", exc_info=True)
 
+    # Which conversation is this turn part of (2026-08-19)? The body's id is a
+    # client-supplied HINT and is verified against this visitor's own rows before
+    # it is honoured — a caller naming a stranger's (or another tenant's)
+    # conversation gets their own active one instead of a refusal, because the
+    # only thing a refusal would tell them is that the id was real.
+    #
+    # Everything downstream keys off ``conversation_key``: the run's session_key,
+    # the history replay, and the ledger's conversation id. It is derived HERE,
+    # once, so those three can never drift apart again.
+    if body.conversation_id and conversation is not None:
+        try:
+            named = await store.get_conversation_by_id(
+                body.conversation_id, workspace_id=ctx.workspace_id
+            )
+            if (
+                named is not None
+                and named.widget_id == body.widget_id
+                and named.customer_ref == body.customer_ref
+            ):
+                conversation = named
+        except Exception:
+            logger.warning("conversation id lookup failed (non-fatal)", exc_info=True)
+    conversation_key = conversation.id if conversation is not None else body.customer_ref
+
     # Owner notification #1 of 3 (slice 3): a NEW conversation started. Not every
     # turn — a bar that pinged on each message would train the owner to ignore the
     # badge, which costs them the two escalations that actually need them. Awaited
@@ -3983,11 +4047,20 @@ async def concierge_chat(body: ConciergeChatRequest, request: Request) -> Stream
     stored_user_text = (
         body.message[:_STORED_USER_TEXT_CHARS] if site.concierge_store_transcripts else ""
     )
-    # ``history`` is THIS visitor's prior turns on THIS site (see
+    # The agent session this turn belongs to. It carries ``conversation_key`` —
+    # the conversation's own id — where it used to carry ``customer_ref``
+    # (2026-08-19). That one substitution is the identity fix at the run layer:
+    # with the visitor's handle in this slot, every conversation they ever had
+    # was ONE agent session, which is precisely what "multiple sessions are
+    # treated as a single session" described. Built here rather than inline in
+    # the RunSpec because the history read below must scope to the same value.
+    session_key = f"cloud:concierge:{ctx.pocket_id}:{conversation_key}:{widget.agent_id}"
+    # ``history`` is THIS CONVERSATION's prior turns (see
     # ``_load_concierge_history``). Read BEFORE ``create_run`` below writes this
     # turn's doc, so the current message rides in ``content`` and appears exactly
-    # once. Scoped to (workspace, concierge, pocket, customer_ref) — a sibling
-    # visitor's, a sibling site's, and another tenant's turns can never appear.
+    # once. Scoped to (workspace, concierge, pocket, customer_ref, session) — a
+    # sibling visitor's, a sibling site's, another tenant's, and now this
+    # visitor's OWN earlier conversations can never appear.
     #
     # Gated on the SAME retention toggle as the write: an owner who turned
     # transcript storage off gets no memory, because there is nothing stored to
@@ -3995,7 +4068,12 @@ async def concierge_chat(body: ConciergeChatRequest, request: Request) -> Stream
     # conversation with the questions missing. That degradation is the owner's
     # privacy choice working, not a bug to route around.
     prior_history = (
-        await _load_concierge_history(ctx.pocket_id or "", body.customer_ref, ctx.workspace_id)
+        await _load_concierge_history(
+            ctx.pocket_id or "",
+            body.customer_ref,
+            ctx.workspace_id,
+            session_key=session_key,
+        )
         if site.concierge_store_transcripts
         else []
     )
@@ -4004,7 +4082,7 @@ async def concierge_chat(body: ConciergeChatRequest, request: Request) -> Stream
         workspace_id=ctx.workspace_id,
         context_type="concierge",
         scope_id=ctx.pocket_id or "",
-        session_key=f"cloud:concierge:{ctx.pocket_id}:{body.customer_ref}:{widget.agent_id}",
+        session_key=session_key,
         group=None,
         user_id=body.customer_ref,
         agent_id=widget.agent_id,
@@ -4245,6 +4323,172 @@ async def get_cart(
         logger.debug("cart-read marker record failed (non-fatal)", exc_info=True)
     cart = await store.get_cart(w, customer_ref)
     return JSONResponse(cart_wire(widget, customer_ref, cart))
+
+
+# ---------------------------------------------------------------------------
+# Public conversation endpoints (2026-08-19) — the visitor's own Messages list
+#
+# The visitor half of the conversation-identity fix. Before it, a visitor had
+# exactly one conversation per widget forever, so there was nothing to list and
+# no way to start another; the widget's "New conversation" wiped its own
+# localStorage and the backend never heard about it.
+#
+# Same armor class as chat and the cart, through the shared
+# ``_front_gate_for_key`` (404 unknown widget → 429 rate limit → 401 bad key →
+# 403 origin/binding). Both endpoints are strictly visitor-scoped: the caller can
+# only ever read or write conversations belonging to the ``customer_ref`` the
+# gate already bound, so there is no id to enumerate and nothing to reach across.
+# ---------------------------------------------------------------------------
+
+
+class VisitorConversationItem(BaseModel):
+    """One row of the widget's Messages list."""
+
+    id: str
+    state: str = "open"
+    # The last thing said, from the visitor's point of view. "" for a conversation
+    # opened but never used — the widget renders its own empty-state copy rather
+    # than a blank row.
+    preview: str = ""
+    last_message_at: str = ""
+    # Is this the conversation in progress? The widget resumes into it and sends
+    # turns against it by default.
+    active: bool = False
+
+
+class VisitorConversationsResponse(BaseModel):
+    conversations: list[VisitorConversationItem] = Field(default_factory=list)
+
+
+class OpenConversationRequest(BaseModel):
+    key: str
+    w: str
+    customer_ref: str
+
+
+async def _visitor_conversation_previews(
+    widget: PawBarWidget, pocket_id: str, customer_ref: str, workspace_id: str
+) -> dict[str, tuple[str, str]]:
+    """Map ``conversation_id -> (preview, last_message_at)`` in ONE query.
+
+    The conversation rows carry lifecycle state but deliberately no messages, so
+    the preview comes from the run docs. Rather than a query per conversation
+    (which would be N round-trips for a list of N), this reads the visitor's
+    recent runs once, bounded by ``_CONVERSATION_SCAN_CAP``, and buckets them by
+    the conversation encoded in each run's ``session_key``. Runs arrive
+    newest-first, so the FIRST run seen for a conversation is its latest.
+
+    A conversation whose only turns are the owner's own replies (those live in
+    ``paw_bar_owner_messages``, never as run docs — the metering sweeper bills
+    runs, and an owner reply shaped as one would charge the owner for typing)
+    resolves to no preview here and renders from its state instead.
+
+    Failure-soft: the list is worth showing without previews.
+    """
+    out: dict[str, tuple[str, str]] = {}
+    if not pocket_id:
+        return out
+    try:
+        runs = await _concierge_runs_for_visitor(
+            pocket_id, customer_ref, workspace_id, limit=_CONVERSATION_SCAN_CAP
+        )
+    except Exception:
+        logger.warning("visitor conversation previews failed (non-fatal)", exc_info=True)
+        return out
+
+    prefix = f"cloud:concierge:{pocket_id}:"
+    suffix = f":{widget.agent_id}"
+    for run in runs:
+        key = getattr(run, "session_key", "") or ""
+        if not key.startswith(prefix) or not key.endswith(suffix):
+            continue
+        conversation_id = key[len(prefix) : len(key) - len(suffix)]
+        if not conversation_id or conversation_id in out:
+            continue  # newest-first, so the first hit is the latest turn
+        text = (run.partial_text or "") or (getattr(run, "user_text", "") or "")
+        when = getattr(run, "createdAt", None)
+        out[conversation_id] = (
+            text[:_CONVERSATION_PREVIEW_CHARS],
+            when.isoformat() if when else "",
+        )
+    return out
+
+
+@router.get("/paw-bar/conversations", response_model=VisitorConversationsResponse)
+async def list_visitor_conversations(
+    request: Request,
+    w: str,
+    key: str,
+    customer_ref: str,
+) -> VisitorConversationsResponse:
+    """This visitor's own conversations on this bar, newest first.
+
+    What the widget's Messages tab reads. Scoped twice over — the store filters to
+    one (widget, visitor) pair and the front gate has already bound that visitor
+    to the resolved key — so a sibling visitor's or a sibling site's conversations
+    can never appear in the answer.
+    """
+    origin = request.headers.get("origin")
+    widget, ctx, _site = await _front_gate_for_key(
+        widget_id=w,
+        signed_key=key,
+        customer_ref=customer_ref,
+        origin=origin,
+        request=request,
+    )
+    store = _store()
+    rows = await store.list_conversations_for_visitor(
+        widget.id, customer_ref, workspace_id=ctx.workspace_id
+    )
+    previews = await _visitor_conversation_previews(
+        widget, ctx.pocket_id or "", customer_ref, ctx.workspace_id
+    )
+    conversations = []
+    for row in rows:
+        preview, last_at = previews.get(row.id, ("", ""))
+        conversations.append(
+            VisitorConversationItem(
+                id=row.id,
+                state=row.state.value,
+                preview=preview,
+                last_message_at=last_at or (row.last_visitor_at or ""),
+                active=row.active,
+            )
+        )
+    return VisitorConversationsResponse(conversations=conversations)
+
+
+@router.post("/paw-bar/conversations", response_model=VisitorConversationItem)
+async def open_visitor_conversation(
+    body: OpenConversationRequest, request: Request
+) -> VisitorConversationItem:
+    """Start a fresh conversation for this visitor and return it.
+
+    The backend half of the widget's "New conversation". The visitor's current
+    conversation is RETIRED rather than deleted — it stays in their Messages list
+    and in the owner's inbox — and the new one becomes active, so the next turn
+    lands on it and the agent starts cold instead of replaying the thread the
+    visitor just walked away from.
+    """
+    origin = request.headers.get("origin")
+    widget, ctx, _site = await _front_gate_for_key(
+        widget_id=body.w,
+        signed_key=body.key,
+        customer_ref=body.customer_ref,
+        origin=origin,
+        request=request,
+    )
+    store = _store()
+    conversation = await store.open_conversation(
+        widget.id, body.customer_ref, workspace_id=ctx.workspace_id
+    )
+    return VisitorConversationItem(
+        id=conversation.id,
+        state=conversation.state.value,
+        preview="",
+        last_message_at="",
+        active=True,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/pocketpaw/paw_bar/models.py
+++ b/src/pocketpaw/paw_bar/models.py
@@ -593,6 +593,13 @@ class Conversation(BaseModel):
     # uses it to say when the bot hands itself back.
     bot_paused_at: str = ""
     unread_for_owner: int = 0
+    # 2026-08-19 (conversation identity): is this the visitor's conversation IN
+    # PROGRESS? A visitor may own several — starting over retires the current one
+    # (``active = False``) and opens a fresh one — and a partial unique index
+    # keeps at most one active per (widget, visitor), so a chat turn that names no
+    # conversation still resolves to exactly one row. Defaults True because every
+    # row written before this existed was that visitor's only conversation.
+    active: bool = True
     created_at: datetime = Field(default_factory=datetime.now)
     updated_at: datetime = Field(default_factory=datetime.now)
 

--- a/src/pocketpaw/paw_bar/store.py
+++ b/src/pocketpaw/paw_bar/store.py
@@ -233,13 +233,27 @@ CREATE TABLE IF NOT EXISTS paw_bar_carts (
     PRIMARY KEY (widget_id, customer_ref)
 );
 
--- Owner inbox (slice 1): the conversation STATE row. One per
--- (widget_id, customer_ref) — the same identity as the concierge run stream's
--- session_key — holding lifecycle + operator metadata ONLY. No messages: the
--- transcript stays derived from the run docs, so there is one source of truth
--- for what was said and one for how the owner is handling it. Created lazily on
--- the visitor's first turn (or the owner's first read), so no backfill is needed
--- and a legacy conversation with no row still lists with defaults.
+-- Owner inbox (slice 1): the conversation STATE row, holding lifecycle +
+-- operator metadata ONLY. No messages: the transcript stays derived from the run
+-- docs, so there is one source of truth for what was said and one for how the
+-- owner is handling it. Created lazily on the visitor's first turn (or the
+-- owner's first read), so no backfill is needed and a legacy conversation with
+-- no row still lists with defaults.
+--
+-- 2026-08-19 (conversation identity): ``id`` is the identity. It always was the
+-- primary key, but nothing READ it as identity — every caller keyed on the
+-- (widget_id, customer_ref) pair, and a UNIQUE over that pair sat here enforcing
+-- exactly one conversation per visitor per widget, forever. That was the
+-- reported "multiple sessions collapse into one" bug at its root: a visitor who
+-- started over had no way to say so, so their abandoned thread kept being
+-- replayed into the agent and the owner's inbox showed one endless conversation.
+--
+-- The pair UNIQUE is replaced by ``active`` plus a PARTIAL unique index over
+-- (widget_id, customer_ref) WHERE active = 1. That keeps the invariant worth
+-- keeping — a visitor has at most ONE conversation in progress, so a turn that
+-- names no conversation still resolves deterministically — while letting any
+-- number of finished ones accumulate as history. The partial index is also a
+-- valid ON CONFLICT target, so the visitor-turn upsert stays a single statement.
 CREATE TABLE IF NOT EXISTS paw_bar_conversations (
     id TEXT PRIMARY KEY,
     widget_id TEXT NOT NULL,
@@ -256,9 +270,9 @@ CREATE TABLE IF NOT EXISTS paw_bar_conversations (
     last_owner_at TEXT DEFAULT '',
     bot_paused_at TEXT DEFAULT '',
     unread_for_owner INTEGER DEFAULT 0,
+    active INTEGER DEFAULT 1,
     created_at TEXT DEFAULT (datetime('now')),
-    updated_at TEXT DEFAULT (datetime('now')),
-    UNIQUE (widget_id, customer_ref)
+    updated_at TEXT DEFAULT (datetime('now'))
 );
 
 -- Owner inbox (slice 2): the thread lines that have NO run doc. A concierge turn
@@ -295,6 +309,15 @@ CREATE INDEX IF NOT EXISTS idx_pp_spec_revisions_widget
     ON paw_bar_spec_revisions(widget_id, revision DESC);
 CREATE INDEX IF NOT EXISTS idx_pp_conversations_state
     ON paw_bar_conversations(widget_id, state, updated_at DESC);
+-- At most ONE conversation in progress per visitor per widget. This is what the
+-- visitor-turn upsert conflicts against, and what lets a chat request that names
+-- no conversation still resolve to exactly one row. Finished conversations carry
+-- active = 0 and are unconstrained, so history accumulates freely.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_pp_conversations_active
+    ON paw_bar_conversations(widget_id, customer_ref) WHERE active = 1;
+-- The Messages tab's read: this visitor's conversations, newest first.
+CREATE INDEX IF NOT EXISTS idx_pp_conversations_visitor
+    ON paw_bar_conversations(widget_id, customer_ref, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_pp_owner_messages_thread
     ON paw_bar_owner_messages(widget_id, customer_ref, created_at);
 """
@@ -303,6 +326,10 @@ CREATE INDEX IF NOT EXISTS idx_pp_owner_messages_thread
 # use when adding it to an already-deployed table. Keep in lockstep with the
 # CREATE TABLE above (the primary key + the UNIQUE constraint can't be ALTERed in
 # and are therefore not listed — a table that old is recreated, not migrated).
+# How many of a visitor's own conversations the Messages tab may read at once.
+# The cap lives here rather than on the endpoint so no caller can lift it.
+_VISITOR_CONVERSATIONS_CAP = 50
+
 _CONVERSATION_COLUMNS: dict[str, str] = {
     "workspace_id": "TEXT DEFAULT ''",
     "state": "TEXT DEFAULT 'open'",
@@ -316,6 +343,10 @@ _CONVERSATION_COLUMNS: dict[str, str] = {
     "last_owner_at": "TEXT DEFAULT ''",
     "bot_paused_at": "TEXT DEFAULT ''",
     "unread_for_owner": "INTEGER DEFAULT 0",
+    # 2026-08-19 (conversation identity). Defaults to 1 so every row a deployed
+    # DB already holds becomes that visitor's ACTIVE conversation — a visitor
+    # mid-thread when this ships keeps their thread instead of losing it.
+    "active": "INTEGER DEFAULT 1",
     "created_at": "TEXT",
     "updated_at": "TEXT",
 }
@@ -514,6 +545,11 @@ class PawBarStore:
             for name, decl in _CONVERSATION_COLUMNS.items():
                 if name not in cols:
                     await db.execute(f"ALTER TABLE paw_bar_conversations ADD COLUMN {name} {decl}")
+            # 2026-08-19 (conversation identity): shed the legacy
+            # UNIQUE (widget_id, customer_ref). Runs AFTER the ALTER loop above so
+            # the old table already carries ``active`` and the copy can name every
+            # column. See the method for why this needs a rebuild at all.
+            await PawBarStore._drop_legacy_conversation_pair_unique(db)
         # paw_bar_owner_messages (owner inbox, slice 2) — same reasoning as the
         # conversations block above: new table today, ALTER path ready for the
         # first column that post-dates a deployed one.
@@ -522,6 +558,89 @@ class PawBarStore:
             for name, decl in _OWNER_MESSAGE_COLUMNS.items():
                 if name not in cols:
                     await db.execute(f"ALTER TABLE paw_bar_owner_messages ADD COLUMN {name} {decl}")
+
+    @staticmethod
+    async def _drop_legacy_conversation_pair_unique(db: aiosqlite.Connection) -> None:
+        """Rebuild ``paw_bar_conversations`` without ``UNIQUE (widget_id, customer_ref)``.
+
+        SQLite cannot ALTER a table constraint away, and that constraint is the
+        whole bug: while it stands, a visitor's second conversation collides with
+        their first and the backend keeps treating every session as one. The
+        documented remedy is a table rebuild, so that is what this does — guarded
+        so it runs exactly once per deployed DB and never on a fresh one.
+
+        Detection is precise rather than name-based: an inline table UNIQUE shows
+        up in ``PRAGMA index_list`` as an AUTO index (``origin='u'``) that is
+        unique and NOT partial. The replacement index is partial, so it can never
+        be mistaken for the thing being dropped and a re-run is a no-op.
+
+        No foreign keys reference this table, which is what keeps the rebuild
+        simple: create, copy, drop, rename. The caller runs inside
+        ``_ensure_schema`` before ``executescript``, so SCHEMA_SQL then recreates
+        every index (including the partial unique) against the new table.
+        """
+
+        async def _legacy_pair_index() -> str | None:
+            async with db.execute("PRAGMA index_list(paw_bar_conversations)") as cur:
+                indexes = await cur.fetchall()
+            for row in indexes:
+                # (seq, name, unique, origin, partial)
+                name, unique, origin, partial = row[1], row[2], row[3], row[4]
+                if not unique or partial or origin != "u":
+                    continue
+                async with db.execute(f"PRAGMA index_info({name})") as cur:
+                    columns = [r[2] for r in await cur.fetchall()]
+                if set(columns) == {"widget_id", "customer_ref"}:
+                    return str(name)
+            return None
+
+        if await _legacy_pair_index() is None:
+            return
+
+        # Column list is fixed and matches SCHEMA_SQL's CREATE TABLE. Named
+        # explicitly (never SELECT *) so the copy is order-independent — a
+        # deployed table's ALTER-added columns sit in a different physical order
+        # than a fresh one's.
+        columns = (
+            "id, widget_id, customer_ref, workspace_id, state, bot_paused,"
+            " snooze_until, assignee, tags, notes, contact_email, last_visitor_at,"
+            " last_owner_at, bot_paused_at, unread_for_owner, active, created_at, updated_at"
+        )
+        await db.execute(
+            "CREATE TABLE paw_bar_conversations_rebuild ("
+            " id TEXT PRIMARY KEY,"
+            " widget_id TEXT NOT NULL,"
+            " customer_ref TEXT NOT NULL,"
+            " workspace_id TEXT DEFAULT '',"
+            " state TEXT DEFAULT 'open',"
+            " bot_paused INTEGER DEFAULT 0,"
+            " snooze_until TEXT DEFAULT '',"
+            " assignee TEXT DEFAULT '',"
+            " tags TEXT DEFAULT '[]',"
+            " notes TEXT DEFAULT '[]',"
+            " contact_email TEXT DEFAULT '',"
+            " last_visitor_at TEXT DEFAULT '',"
+            " last_owner_at TEXT DEFAULT '',"
+            " bot_paused_at TEXT DEFAULT '',"
+            " unread_for_owner INTEGER DEFAULT 0,"
+            " active INTEGER DEFAULT 1,"
+            " created_at TEXT DEFAULT (datetime('now')),"
+            " updated_at TEXT DEFAULT (datetime('now'))"
+            ")"
+        )
+        # Every legacy row was that visitor's only conversation, so it becomes
+        # their ACTIVE one (COALESCE guards a NULL from the ALTER-added column).
+        await db.execute(
+            f"INSERT INTO paw_bar_conversations_rebuild ({columns})"
+            f" SELECT id, widget_id, customer_ref, workspace_id, state, bot_paused,"
+            f" snooze_until, assignee, tags, notes, contact_email, last_visitor_at,"
+            f" last_owner_at, bot_paused_at, unread_for_owner, COALESCE(active, 1),"
+            f" created_at, updated_at FROM paw_bar_conversations"
+        )
+        await db.execute("DROP TABLE paw_bar_conversations")
+        await db.execute(
+            "ALTER TABLE paw_bar_conversations_rebuild RENAME TO paw_bar_conversations"
+        )
 
     def _conn(self) -> aiosqlite.Connection:
         return aiosqlite.connect(self._db_path)
@@ -1125,9 +1244,12 @@ class PawBarStore:
             await db.execute(
                 "INSERT INTO paw_bar_conversations"
                 " (id, widget_id, customer_ref, workspace_id, state, last_visitor_at,"
-                " unread_for_owner, created_at, updated_at)"
-                " VALUES (?, ?, ?, ?, 'open', ?, 1, ?, ?)"
-                " ON CONFLICT (widget_id, customer_ref) DO UPDATE SET"
+                " unread_for_owner, active, created_at, updated_at)"
+                " VALUES (?, ?, ?, ?, 'open', ?, 1, 1, ?, ?)"
+                # Conflict target is the PARTIAL unique index, so the turn lands on
+                # the visitor's conversation IN PROGRESS and never on a finished
+                # one — that is what keeps "start over" from reopening the past.
+                " ON CONFLICT (widget_id, customer_ref) WHERE active = 1 DO UPDATE SET"
                 "   last_visitor_at = excluded.last_visitor_at,"
                 "   unread_for_owner = paw_bar_conversations.unread_for_owner + 1,"
                 "   state = CASE WHEN paw_bar_conversations.state IN ('closed', 'snoozed')"
@@ -1166,9 +1288,10 @@ class PawBarStore:
         async with self._conn() as db:
             await db.execute(
                 "INSERT INTO paw_bar_conversations"
-                " (id, widget_id, customer_ref, workspace_id, state, created_at, updated_at)"
-                " VALUES (?, ?, ?, ?, 'open', ?, ?)"
-                " ON CONFLICT (widget_id, customer_ref) DO NOTHING",
+                " (id, widget_id, customer_ref, workspace_id, state, active,"
+                " created_at, updated_at)"
+                " VALUES (?, ?, ?, ?, 'open', 1, ?, ?)"
+                " ON CONFLICT (widget_id, customer_ref) WHERE active = 1 DO NOTHING",
                 (_gen_conversation_id(), widget_id, customer_ref, workspace_id, now, now),
             )
             await db.commit()
@@ -1187,8 +1310,14 @@ class PawBarStore:
         ``None`` is a normal answer, not an error: a conversation that predates
         this table (or one whose visitor never sent a turn after it shipped) simply
         has no row, and every caller renders it with the model defaults.
+
+        Since 2026-08-19 a visitor may own several conversations, so "the"
+        conversation means the one IN PROGRESS. Every existing caller wants that
+        one — the takeover mute, the owner's queue row, the unread counter — and a
+        finished conversation is reached by id through
+        :meth:`get_conversation_by_id` instead.
         """
-        conditions = "widget_id = ? AND customer_ref = ?"
+        conditions = "widget_id = ? AND customer_ref = ? AND active = 1"
         params: list[Any] = [widget_id, customer_ref]
         ws_cond, ws_params = _conversation_workspace_scope(workspace_id)
         if ws_cond:
@@ -1201,6 +1330,105 @@ class PawBarStore:
             async with db.execute(sql, bound) as cur:
                 row = await cur.fetchone()
                 return self._row_to_conversation(row) if row else None
+
+    async def open_conversation(
+        self, widget_id: str, customer_ref: str, workspace_id: str = ""
+    ) -> Conversation:
+        """Start a NEW conversation for this visitor and return it.
+
+        The visitor said "start over". Before 2026-08-19 they had no way to: the
+        widget's "New conversation" only wiped its own localStorage, the backend
+        never heard about it, and the abandoned thread kept being replayed into
+        the agent while the owner's inbox showed one conversation that never
+        ended. This is the missing half of that gesture.
+
+        The current conversation is RETIRED (``active = 0``), not deleted — it is
+        the visitor's history and the owner's record, and the Messages tab lists
+        it. Retire-then-insert runs as one transaction so the partial unique index
+        can never see two active rows, and so a failure leaves the visitor with
+        their existing conversation rather than none.
+        """
+        await self._ensure_schema()
+        now = datetime.now().isoformat()
+        row_id = _gen_conversation_id()
+        async with self._conn() as db:
+            await db.execute("BEGIN IMMEDIATE")
+            await db.execute(
+                "UPDATE paw_bar_conversations SET active = 0, updated_at = ?"
+                " WHERE widget_id = ? AND customer_ref = ? AND active = 1",
+                (now, widget_id, customer_ref),
+            )
+            await db.execute(
+                "INSERT INTO paw_bar_conversations"
+                " (id, widget_id, customer_ref, workspace_id, state, active,"
+                " created_at, updated_at)"
+                " VALUES (?, ?, ?, ?, 'open', 1, ?, ?)",
+                (row_id, widget_id, customer_ref, workspace_id, now, now),
+            )
+            await db.commit()
+        conversation = await self.get_conversation_by_id(row_id)
+        # Just written, so a None here means the DB vanished underneath us. Hand
+        # back an unsaved value object rather than raising: a bookkeeping read
+        # must never break the visitor's chat.
+        return conversation or Conversation(
+            id=row_id, widget_id=widget_id, customer_ref=customer_ref, workspace_id=workspace_id
+        )
+
+    async def get_conversation_by_id(
+        self, conversation_id: str, workspace_id: str | None = None
+    ) -> Conversation | None:
+        """One conversation BY ITS OWN ID, active or retired.
+
+        The identity read the pair-keyed lookups could never express. ``None``
+        covers absent, malformed, and cross-tenant alike, so a caller holding a
+        conversation id from another workspace learns nothing from the shape of
+        the answer.
+        """
+        if not conversation_id:
+            return None
+        conditions = "id = ?"
+        params: list[Any] = [conversation_id]
+        ws_cond, ws_params = _conversation_workspace_scope(workspace_id)
+        if ws_cond:
+            conditions += f" AND {ws_cond}"
+            params.extend(ws_params)
+        sql, bound = self._conversation_select(conditions, params, order="LIMIT 1")
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(sql, bound) as cur:
+                row = await cur.fetchone()
+                return self._row_to_conversation(row) if row else None
+
+    async def list_conversations_for_visitor(
+        self,
+        widget_id: str,
+        customer_ref: str,
+        workspace_id: str | None = None,
+        limit: int = _VISITOR_CONVERSATIONS_CAP,
+    ) -> list[Conversation]:
+        """This visitor's own conversations, newest first — the Messages tab's read.
+
+        Scoped to one (widget, visitor) pair, so a sibling visitor's or a sibling
+        site's conversations can never appear. Capped: a visitor with a long
+        history gets their recent conversations, not an unbounded list, and the
+        cap is the store's rather than the caller's so no endpoint can lift it.
+        """
+        conditions = "widget_id = ? AND customer_ref = ?"
+        params: list[Any] = [widget_id, customer_ref]
+        ws_cond, ws_params = _conversation_workspace_scope(workspace_id)
+        if ws_cond:
+            conditions += f" AND {ws_cond}"
+            params.extend(ws_params)
+        bounded = max(1, min(int(limit or _VISITOR_CONVERSATIONS_CAP), _VISITOR_CONVERSATIONS_CAP))
+        sql, bound = self._conversation_select(
+            conditions, params, order=f"ORDER BY created_at DESC, id DESC LIMIT {bounded}"
+        )
+        await self._ensure_schema()
+        async with self._conn() as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(sql, bound) as cur:
+                return [self._row_to_conversation(r) for r in await cur.fetchall()]
 
     async def list_conversations(
         self,
@@ -1314,9 +1542,13 @@ class PawBarStore:
             return existing
         assignments.append("updated_at = ?")
         values.append(datetime.now().isoformat())
+        # ``active = 1`` is load-bearing since a visitor may own several
+        # conversations (2026-08-19): without it, one owner action — closing,
+        # snoozing, tagging, adding a note — would rewrite that visitor's ENTIRE
+        # history in one statement.
         sql = (
             f"UPDATE paw_bar_conversations SET {', '.join(assignments)}"
-            " WHERE widget_id = ? AND customer_ref = ?"
+            " WHERE widget_id = ? AND customer_ref = ? AND active = 1"
         )
         values.extend([widget_id, customer_ref])
         ws_cond, ws_params = _conversation_workspace_scope(workspace_id)
@@ -1381,7 +1613,10 @@ class PawBarStore:
         cutoff = _bot_pause_cutoff(now)
         if not cutoff:
             return None
-        conditions = "widget_id = ? AND customer_ref = ? AND bot_paused = 1"
+        # Scoped to the conversation IN PROGRESS: a retired one's mute is history,
+        # and resuming the bot on it would post a hand-back message into a thread
+        # nobody is reading (2026-08-19).
+        conditions = "widget_id = ? AND customer_ref = ? AND active = 1 AND bot_paused = 1"
         params: list[Any] = [now, widget_id, customer_ref]
         ws_cond, ws_params = _conversation_workspace_scope(workspace_id)
         if ws_cond:
@@ -1672,6 +1907,10 @@ class PawBarStore:
             last_owner_at=row["last_owner_at"] or "",
             bot_paused_at=(row["bot_paused_at"] or "") if "bot_paused_at" in keys else "",
             unread_for_owner=row["unread_for_owner"] or 0,
+            # A row read from a DB whose ALTER hasn't run yet has no column; it
+            # predates multi-conversation support and is therefore the visitor's
+            # one and only, which is exactly what active means.
+            active=bool(row["active"]) if "active" in keys else True,
             created_at=datetime.fromisoformat(row["created_at"]),
             updated_at=datetime.fromisoformat(row["updated_at"]),
         )

--- a/tests/cloud/test_paw_bar_concierge_chat.py
+++ b/tests/cloud/test_paw_bar_concierge_chat.py
@@ -613,7 +613,7 @@ async def test_chat_rate_limit_is_429(concierge_client):
 
 
 async def _dispatch(
-    client, store, monkeypatch, *, site_kw=None, real_create_run=False, **payload_ov
+    client, store, monkeypatch, *, site_kw=None, real_create_run=False, widget_id=None, **payload_ov
 ):
     """Run one chat request through the endpoint and return the dispatched RunSpec.
 
@@ -621,11 +621,18 @@ async def _dispatch(
     ``real_create_run=True`` to let the REAL one write this turn's run doc — that is
     what makes the "current message isn't replayed into history" test meaningful,
     since the doc it writes is exactly the row a mis-ordered read would pick up.
+
+    ``widget_id`` pins the widget's id so a test can open the visitor's
+    conversation BEFORE dispatching and seed run docs against that conversation's
+    session key (see ``_memory_conversation``). Without it the id is minted here
+    and a memory test has nothing to seed against.
     """
     from pocketpaw_ee.cloud.chat.runs.memory_stream import InMemoryStreamTransport
 
     await _site(**(site_kw or {}))
-    widget = await store.create_widget(_widget(agent_id="agent-xyz"))
+    widget = await store.create_widget(
+        _widget(agent_id="agent-xyz", **({"id": widget_id} if widget_id else {}))
+    )
 
     transport = InMemoryStreamTransport()
     fake_exec = _FakeExecutor(transport)
@@ -786,20 +793,46 @@ async def _mk_run(*, minutes_ago: int = 0, **ov):
     return doc
 
 
+# The widget these memory tests pin, so the visitor's conversation can be opened
+# before the dispatch and seeded against (2026-08-19, conversation identity).
+_MEMORY_WIDGET = "w-memory"
+
+
+async def _memory_conversation(store, *, customer_ref="cust-1"):
+    """Open this visitor's conversation and return ``(id, session_key)``.
+
+    Memory is scoped to a CONVERSATION rather than to a visitor, so a seeded run
+    doc only replays when it carries that conversation's session key. Opening the
+    row here (before ``_dispatch``) is what makes the key knowable at seed time;
+    the dispatch then resolves the same row as the visitor's active one.
+    """
+    conversation = await store.open_conversation(_MEMORY_WIDGET, customer_ref, "ws-1")
+    return conversation.id, f"cloud:concierge:pocket-1:{conversation.id}:agent-xyz"
+
+
 @pytest.mark.asyncio
 async def test_chat_rehydrates_this_visitors_prior_turns(concierge_client, monkeypatch):
     """The defect this closes: prior turns come back, oldest-first, in the
     {"role","content"} shape ``load_history_for_scope`` returns for authed
     surfaces — so the agent can answer "what is my name" from what it was told."""
     client, store = concierge_client
+    _, key = await _memory_conversation(store)
     await _mk_run(
         minutes_ago=10,
+        session_key=key,
         user_text="My name is Priya.",
         partial_text="Nice to meet you, Priya.",
     )
-    await _mk_run(minutes_ago=5, user_text="I have 12 clients.", partial_text="Twelve, noted.")
+    await _mk_run(
+        minutes_ago=5,
+        session_key=key,
+        user_text="I have 12 clients.",
+        partial_text="Twelve, noted.",
+    )
 
-    spec = await _dispatch(client, store, monkeypatch, message="What is my name?")
+    spec = await _dispatch(
+        client, store, monkeypatch, widget_id=_MEMORY_WIDGET, message="What is my name?"
+    )
 
     assert spec.history == [
         {"role": "user", "content": "My name is Priya."},
@@ -815,16 +848,22 @@ async def test_chat_history_never_carries_a_sibling_visitors_turns(concierge_cli
     agent — only the customer handle separates them. One visitor's words must
     never be replayed into another's run."""
     client, store = concierge_client
-    await _mk_run(minutes_ago=5, user_text="I am cust-1.", partial_text="Hello, cust-1.")
+    _, key = await _memory_conversation(store)
+    _, sibling_key = await _memory_conversation(store, customer_ref="cust-2")
+    await _mk_run(
+        minutes_ago=5, session_key=key, user_text="I am cust-1.", partial_text="Hello, cust-1."
+    )
     await _mk_run(
         minutes_ago=4,
         user_id="cust-2",
-        session_key="cloud:concierge:pocket-1:cust-2:agent-xyz",
+        session_key=sibling_key,
         user_text="My order number is 99887 and my name is Bob.",
         partial_text="Thanks Bob, order 99887 ships Tuesday.",
     )
 
-    spec = await _dispatch(client, store, monkeypatch, message="Where is my order?")
+    spec = await _dispatch(
+        client, store, monkeypatch, widget_id=_MEMORY_WIDGET, message="Where is my order?"
+    )
 
     assert spec.history == [
         {"role": "user", "content": "I am cust-1."},
@@ -902,11 +941,14 @@ async def test_chat_history_is_bounded_by_the_turn_cap(concierge_client, monkeyp
     from pocketpaw_ee.paw_bar.router import _HISTORY_TURN_CAP
 
     client, store = concierge_client
+    _, key = await _memory_conversation(store)
     seeded = _HISTORY_TURN_CAP + 3
     for i in range(seeded):
-        await _mk_run(minutes_ago=seeded - i, user_text=f"q{i}", partial_text=f"a{i}")
+        await _mk_run(
+            minutes_ago=seeded - i, session_key=key, user_text=f"q{i}", partial_text=f"a{i}"
+        )
 
-    spec = await _dispatch(client, store, monkeypatch, message="and now?")
+    spec = await _dispatch(client, store, monkeypatch, widget_id=_MEMORY_WIDGET, message="and now?")
 
     assert len(spec.history) == _HISTORY_TURN_CAP * 2
     # The OLDEST three were dropped; the surviving stretch ends at the newest.
@@ -930,14 +972,16 @@ async def test_chat_history_is_bounded_by_the_character_budget(concierge_client,
     # bound here, not the turn cap.
     assert 0 < fits < seeded <= _HISTORY_TURN_CAP
 
+    _, key = await _memory_conversation(store)
     for i in range(seeded):
         await _mk_run(
             minutes_ago=seeded - i,
+            session_key=key,
             user_text=f"{i}" + "x" * (line - 1),
             partial_text=f"{i}" + "y" * (line - 1),
         )
 
-    spec = await _dispatch(client, store, monkeypatch, message="and now?")
+    spec = await _dispatch(client, store, monkeypatch, widget_id=_MEMORY_WIDGET, message="and now?")
 
     assert sum(len(m["content"]) for m in spec.history) <= _HISTORY_TOTAL_CHARS
     assert len(spec.history) == fits * 2  # whole exchanges only
@@ -955,13 +999,15 @@ async def test_chat_history_clips_one_long_line_instead_of_evicting_the_turn(
     from pocketpaw_ee.paw_bar.router import _HISTORY_MESSAGE_CHARS
 
     client, store = concierge_client
+    _, key = await _memory_conversation(store)
     await _mk_run(
         minutes_ago=5,
+        session_key=key,
         user_text="Tell me everything.",
         partial_text="z" * (_HISTORY_MESSAGE_CHARS + 500),
     )
 
-    spec = await _dispatch(client, store, monkeypatch, message="and now?")
+    spec = await _dispatch(client, store, monkeypatch, widget_id=_MEMORY_WIDGET, message="and now?")
 
     assert [m["role"] for m in spec.history] == ["user", "assistant"]
     assert len(spec.history[1]["content"]) == _HISTORY_MESSAGE_CHARS
@@ -994,10 +1040,20 @@ async def test_chat_does_not_replay_the_current_message_into_history(concierge_c
     would pick the visitor's own message straight back up — this is the test that
     pins the ordering."""
     client, store = concierge_client
-    await _mk_run(minutes_ago=5, user_text="My name is Priya.", partial_text="Hello, Priya.")
+    _, key = await _memory_conversation(store)
+    await _mk_run(
+        minutes_ago=5, session_key=key, user_text="My name is Priya.", partial_text="Hello, Priya."
+    )
 
     message = "What is my name?"
-    spec = await _dispatch(client, store, monkeypatch, real_create_run=True, message=message)
+    spec = await _dispatch(
+        client,
+        store,
+        monkeypatch,
+        widget_id=_MEMORY_WIDGET,
+        real_create_run=True,
+        message=message,
+    )
 
     occurrences = [spec.content, *(m["content"] for m in spec.history)].count(message)
     assert occurrences == 1
@@ -1007,8 +1063,9 @@ async def test_chat_does_not_replay_the_current_message_into_history(concierge_c
     ]
 
     # And the doc create_run wrote IS visible to the next turn's read — the
-    # exclusion above is ordering, not a blind spot.
+    # exclusion above is ordering, not a blind spot. Read on the SAME session key
+    # the dispatch used, since memory is conversation-scoped.
     from pocketpaw_ee.paw_bar.router import _load_concierge_history
 
-    next_turn = await _load_concierge_history("pocket-1", "cust-1", "ws-1")
+    next_turn = await _load_concierge_history("pocket-1", "cust-1", "ws-1", session_key=key)
     assert {"role": "user", "content": message} in next_turn

--- a/tests/cloud/test_paw_bar_conversation_identity.py
+++ b/tests/cloud/test_paw_bar_conversation_identity.py
@@ -1,0 +1,571 @@
+# tests/cloud/test_paw_bar_conversation_identity.py — a Paw Bar visitor may hold
+# MORE THAN ONE conversation.
+#
+# Created 2026-08-19 as the reproduction for the reported bug: "multiple sessions
+# from paw-bar are treated as a single session by the backend." They were. The
+# Paw Bar had no conversation identity at all — every read, write, run
+# ``session_key`` and ledger id was keyed on the pair ``(widget_id,
+# customer_ref)``:
+#
+#   * ``store.py`` put ``UNIQUE (widget_id, customer_ref)`` on
+#     ``paw_bar_conversations``, so one browser could only ever own ONE row per
+#     widget, for the life of that browser's localStorage.
+#   * ``router.py`` built ``session_key=f"cloud:concierge:{pocket}:{ref}:{agent}"``
+#     — no conversation component, so every turn a visitor ever sent shared one
+#     agent session.
+#   * ``ledger.conversation_id()`` DERIVED its id as ``f"{widget}:{ref}"`` rather
+#     than reporting a real one.
+#   * ``Conversation.id`` (``ppc_…``) existed on the model and was vestigial:
+#     nothing read it as identity.
+#
+# The visible harm is the third layer, not the first: because
+# ``_load_concierge_history`` scoped its replay to the VISITOR, a visitor who
+# started over still had their abandoned thread replayed into the agent's
+# context, and the owner's inbox showed one endless conversation instead of the
+# several the visitor actually had.
+#
+# Layers here:
+#   * Store: ``open_conversation`` mints a genuinely new row; the visitor's turns
+#     land on the ACTIVE one; ``list_conversations_for_visitor`` returns them
+#     newest-first; a legacy row (pre-``id``-as-identity) keeps working and
+#     becomes that visitor's first conversation.
+#   * Router: ``session_key`` carries the conversation, not the visitor; history
+#     is scoped to the conversation so a fresh one starts cold; a request that
+#     omits ``conversation_id`` still works (cached widget bundles in the wild).
+#
+# All of these FAIL before the identity fix and pass after it.
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from pocketpaw.paw_bar.models import PawBarSpec, PawBarWidget
+from pocketpaw.paw_bar.store import PawBarStore
+
+_VALID_KEY = "site_key_" + "a" * 24
+_ORIGIN = "https://brewco.com"
+_REF = "cust-0001"
+
+
+# --------------------------------------------------------------------------- #
+# Builders
+# --------------------------------------------------------------------------- #
+
+
+def _widget(**ov) -> PawBarWidget:
+    d = dict(
+        pocket_id="pocket-1",
+        owner="user:maya",
+        name="Brew & Co",
+        spec=PawBarSpec(widget_id="w-1", pocket_id="pocket-1"),
+        allowed_domains=["brewco.com"],
+        agent_id="agent-xyz",
+        workspace_id="ws-1",
+        rate_limit_per_min=60,
+        per_customer_limit_per_min=30,
+    )
+    d.update(ov)
+    return PawBarWidget(**d)
+
+
+async def _site(**ov):
+    from pocketpaw_ee.cloud.models.site import Site
+
+    d = dict(
+        workspace="ws-1",
+        pocket_id="pocket-1",
+        owner="user:maya",
+        script_name="",
+        signed_key=_VALID_KEY,
+        allowed_origins=["brewco.com"],
+    )
+    d.update(ov)
+    s = Site(**d)
+    await s.insert()
+    return s
+
+
+class _FakeExecutor:
+    """Captures every submitted spec; writes a canned reply so the SSE tail ends."""
+
+    def __init__(self, transport) -> None:
+        self.transport = transport
+        self.submitted: list = []
+
+    async def submit(self, spec) -> None:
+        self.submitted.append(spec)
+        await self.transport.append_event(
+            spec.run_id, "chunk", {"content": "We open at 8am!", "type": "text"}
+        )
+        await self.transport.append_event(
+            spec.run_id, "stream_end", {"assistant_message_id": "m1", "cancelled": False}
+        )
+
+
+@pytest_asyncio.fixture
+async def store(tmp_path):
+    return PawBarStore(tmp_path / "identity.db")
+
+
+@pytest_asyncio.fixture
+async def chat(tmp_path, mongo_db, store, monkeypatch):
+    """A public client for POST /paw-bar/chat backed by a tmp store + Beanie.
+
+    Yields ``(client, store, executor, widget)``. Unlike the sibling suite's
+    helper this keeps ONE widget across turns — the whole point here is what
+    happens on a visitor's SECOND conversation with the SAME bar.
+    """
+    from unittest.mock import patch
+
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.cloud.chat.runs.memory_stream import InMemoryStreamTransport
+    from pocketpaw_ee.paw_bar.router import router
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(router)
+
+    transport = InMemoryStreamTransport()
+    executor = _FakeExecutor(transport)
+    monkeypatch.setattr(
+        "pocketpaw_ee.cloud.chat.runs.transport.get_stream_transport", lambda: transport
+    )
+    monkeypatch.setattr("pocketpaw_ee.cloud.chat.runs.executor.get_executor", lambda: executor)
+
+    async def _fake_create_run(spec):
+        return SimpleNamespace(run_id=spec.run_id)
+
+    monkeypatch.setattr("pocketpaw_ee.cloud.chat.runs.service.create_run", _fake_create_run)
+
+    await _site()
+    widget = await store.create_widget(_widget())
+
+    with patch("pocketpaw_ee.paw_bar.router._store", return_value=store):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            yield c, store, executor, widget
+
+
+async def _seed_run(*, session_key: str, user_text: str, partial_text: str) -> Any:
+    """Insert one completed concierge turn — the row conversation memory reads back.
+
+    Written directly rather than dispatched: the ``chat`` fixture stubs
+    ``create_run``, so a turn sent through the endpoint leaves no doc behind and a
+    history assertion against it would be measuring an empty collection.
+    """
+    from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
+
+    doc = ChatRunDoc(
+        run_id=uuid.uuid4().hex,
+        workspace="ws-1",
+        context_type="concierge",
+        scope_id="pocket-1",
+        session_key=session_key,
+        user_id=_REF,
+        agent_id="agent-xyz",
+        client_message_id=uuid.uuid4().hex,
+        user_message_id="",
+        status="completed",
+        user_text=user_text,
+        partial_text=partial_text,
+    )
+    await doc.insert()
+    return doc
+
+
+async def _say(client, widget_id: str, message: str, **ov) -> Any:
+    payload = dict(
+        widget_id=widget_id,
+        signed_key=_VALID_KEY,
+        customer_ref=_REF,
+        message=message,
+    )
+    payload.update(ov)
+    res = await client.post("/paw-bar/chat", json=payload, headers={"Origin": _ORIGIN})
+    assert res.status_code == 200, res.text
+    return res
+
+
+# --------------------------------------------------------------------------- #
+# Layer 1 — the store: a visitor may own more than one conversation
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_opening_a_conversation_mints_a_genuinely_new_row(store):
+    """The reported bug, at its root.
+
+    ``UNIQUE (widget_id, customer_ref)`` meant a visitor's second conversation
+    overwrote their first. Starting over must mint a NEW row with its own id,
+    leaving the old one intact and readable.
+    """
+    first = await store.open_conversation("w-1", _REF, workspace_id="ws-1")
+    second = await store.open_conversation("w-1", _REF, workspace_id="ws-1")
+
+    assert first.id != second.id, "starting over must mint a new conversation, not reuse the old"
+    # Both survive — the first is history, not a row that got clobbered.
+    assert await store.get_conversation_by_id(first.id) is not None
+    assert await store.get_conversation_by_id(second.id) is not None
+
+
+@pytest.mark.asyncio
+async def test_visitor_turns_land_on_the_active_conversation(store):
+    """Two turns inside ONE conversation still share one row — the fix must not
+    swing the other way and mint a conversation per message.
+
+    A RETIRED conversation is present on purpose: with only one row in the table
+    every read returns it and this passes even unscoped. The retired row is what
+    makes "the active one" a claim with teeth.
+    """
+    retired = await store.open_conversation("w-1", _REF, workspace_id="ws-1")
+    current = await store.open_conversation("w-1", _REF, workspace_id="ws-1")
+
+    a = await store.upsert_conversation_on_visitor_turn("w-1", _REF, "ws-1")
+    b = await store.upsert_conversation_on_visitor_turn("w-1", _REF, "ws-1")
+
+    assert a.id == b.id == current.id
+    assert b.unread_for_owner == 2
+    # The finished conversation saw neither turn.
+    assert (await store.get_conversation_by_id(retired.id)).unread_for_owner == 0
+
+
+@pytest.mark.asyncio
+async def test_a_retired_conversation_is_not_the_one_in_progress(store):
+    """ "The conversation in progress" must mean exactly that.
+
+    Every other read is masked by the fact that the newest conversation is also
+    the active one, so an unscoped lookup accidentally agrees. The state that
+    separates them is a visitor whose only conversation has been retired — what a
+    close path or a TTL sweep leaves behind — and there the answer must be "none
+    in progress", not the finished one. The takeover mute reads this: a retired
+    row's stale ``bot_paused`` would silence the bot in a conversation nobody is
+    holding.
+    """
+    import aiosqlite
+
+    retired = await store.open_conversation("w-1", _REF, workspace_id="ws-1")
+    async with aiosqlite.connect(store._db_path) as db:
+        await db.execute("UPDATE paw_bar_conversations SET active = 0 WHERE id = ?", (retired.id,))
+        await db.commit()
+
+    assert await store.get_conversation("w-1", _REF, workspace_id="ws-1") is None
+    # It is still the visitor's history, and still reachable by its own id.
+    assert (await store.get_conversation_by_id(retired.id)) is not None
+
+
+@pytest.mark.asyncio
+async def test_visitor_conversations_list_newest_first(store):
+    """What the Messages tab reads. Newest-first is the order every messenger in
+    this class uses, and the order the list is indexed for."""
+    first = await store.open_conversation("w-1", _REF, workspace_id="ws-1")
+    second = await store.open_conversation("w-1", _REF, workspace_id="ws-1")
+
+    rows = await store.list_conversations_for_visitor("w-1", _REF, workspace_id="ws-1")
+
+    assert [r.id for r in rows] == [second.id, first.id]
+    # A sibling visitor's conversations are never in this list.
+    await store.open_conversation("w-1", "cust-other", workspace_id="ws-1")
+    rows = await store.list_conversations_for_visitor("w-1", _REF, workspace_id="ws-1")
+    assert [r.id for r in rows] == [second.id, first.id]
+
+
+@pytest.mark.asyncio
+async def test_legacy_row_becomes_the_visitors_first_conversation(store):
+    """Migration is free: a row written before this change already carries a
+    ``ppc_…`` id, so it simply becomes that visitor's first conversation. A
+    visitor mid-thread when the fix deploys must not lose it."""
+    legacy = await store.upsert_conversation_on_visitor_turn("w-1", _REF, "ws-1")
+
+    rows = await store.list_conversations_for_visitor("w-1", _REF, workspace_id="ws-1")
+    assert [r.id for r in rows] == [legacy.id]
+
+    # And the next turn still lands on it rather than starting a stranger.
+    again = await store.upsert_conversation_on_visitor_turn("w-1", _REF, "ws-1")
+    assert again.id == legacy.id
+
+
+@pytest.mark.asyncio
+async def test_owner_actions_touch_only_the_conversation_in_progress(store):
+    """The blast-radius guard.
+
+    ``update_conversation`` is keyed by (widget, visitor), which addressed exactly
+    one row while a visitor could only have one. Now that they can have many, the
+    same statement would close, snooze, tag or annotate a visitor's ENTIRE history
+    at once unless it is scoped to the active row.
+    """
+    from pocketpaw.paw_bar.models import ConversationState
+
+    retired = await store.open_conversation("w-1", _REF, workspace_id="ws-1")
+    current = await store.open_conversation("w-1", _REF, workspace_id="ws-1")
+
+    await store.update_conversation(
+        "w-1", _REF, workspace_id="ws-1", state=ConversationState.CLOSED.value
+    )
+
+    assert (await store.get_conversation_by_id(current.id)).state is ConversationState.CLOSED
+    # The finished conversation is untouched — it is the visitor's record.
+    assert (await store.get_conversation_by_id(retired.id)).state is ConversationState.OPEN
+
+
+# --------------------------------------------------------------------------- #
+# Layer 1b — the migration: a DEPLOYED db sheds the old pair UNIQUE
+#
+# The riskiest code in this change. SQLite cannot ALTER a constraint away, so a
+# deployed paw_bar.db needs a table REBUILD, and every test above runs against a
+# fresh schema that never exercises it. These build the old table by hand.
+# --------------------------------------------------------------------------- #
+
+
+_LEGACY_CONVERSATIONS_SQL = """
+CREATE TABLE paw_bar_conversations (
+    id TEXT PRIMARY KEY,
+    widget_id TEXT NOT NULL,
+    customer_ref TEXT NOT NULL,
+    workspace_id TEXT DEFAULT '',
+    state TEXT DEFAULT 'open',
+    bot_paused INTEGER DEFAULT 0,
+    snooze_until TEXT DEFAULT '',
+    assignee TEXT DEFAULT '',
+    tags TEXT DEFAULT '[]',
+    notes TEXT DEFAULT '[]',
+    contact_email TEXT DEFAULT '',
+    last_visitor_at TEXT DEFAULT '',
+    last_owner_at TEXT DEFAULT '',
+    bot_paused_at TEXT DEFAULT '',
+    unread_for_owner INTEGER DEFAULT 0,
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now')),
+    UNIQUE (widget_id, customer_ref)
+);
+"""
+
+
+@pytest.mark.asyncio
+async def test_legacy_db_sheds_the_pair_unique_and_keeps_its_row(tmp_path):
+    """A deployed DB carrying the old ``UNIQUE (widget_id, customer_ref)`` must
+    end up able to hold a visitor's SECOND conversation, without losing the row
+    it already had."""
+    import aiosqlite
+
+    db_path = tmp_path / "legacy.db"
+    async with aiosqlite.connect(db_path) as db:
+        await db.executescript(_LEGACY_CONVERSATIONS_SQL)
+        await db.execute(
+            "INSERT INTO paw_bar_conversations"
+            " (id, widget_id, customer_ref, workspace_id, state, unread_for_owner,"
+            " created_at, updated_at)"
+            " VALUES ('ppc_legacy', 'w-1', ?, 'ws-1', 'needs_human', 3, ?, ?)",
+            (_REF, "2026-08-01T00:00:00", "2026-08-01T00:00:00"),
+        )
+        await db.commit()
+
+    st = PawBarStore(db_path)
+
+    # The pre-existing row survived the rebuild INTACT — id, state and counters.
+    legacy = await st.get_conversation_by_id("ppc_legacy")
+    assert legacy is not None
+    assert legacy.state.value == "needs_human"
+    assert legacy.unread_for_owner == 3
+    assert legacy.active is True
+
+    # And the constraint that caused the bug is gone: a second one now fits.
+    second = await st.open_conversation("w-1", _REF, workspace_id="ws-1")
+    rows = await st.list_conversations_for_visitor("w-1", _REF, workspace_id="ws-1")
+    assert {r.id for r in rows} == {"ppc_legacy", second.id}
+    assert [r.active for r in rows] == [True, False]
+
+
+@pytest.mark.asyncio
+async def test_the_rebuild_is_idempotent(tmp_path):
+    """A second open of the same DB must not rebuild again (and must not lose
+    anything if it somehow did). Guards the detection predicate: the REPLACEMENT
+    index is unique too, so a name-based or unique-only check would loop."""
+    import aiosqlite
+
+    db_path = tmp_path / "twice.db"
+    async with aiosqlite.connect(db_path) as db:
+        await db.executescript(_LEGACY_CONVERSATIONS_SQL)
+        await db.commit()
+
+    first = await PawBarStore(db_path).open_conversation("w-1", _REF, workspace_id="ws-1")
+    # A brand-new store object over the same file re-runs _ensure_schema.
+    second = await PawBarStore(db_path).open_conversation("w-1", _REF, workspace_id="ws-1")
+
+    rows = await PawBarStore(db_path).list_conversations_for_visitor(
+        "w-1", _REF, workspace_id="ws-1"
+    )
+    assert {r.id for r in rows} == {first.id, second.id}
+
+
+@pytest.mark.asyncio
+async def test_the_active_invariant_survives_the_rebuild(tmp_path):
+    """The partial unique index must be REAL after a rebuild, not just intended:
+    two active conversations for one visitor is the state that would let the
+    original bug back in through a different door."""
+    import aiosqlite
+
+    db_path = tmp_path / "invariant.db"
+    async with aiosqlite.connect(db_path) as db:
+        await db.executescript(_LEGACY_CONVERSATIONS_SQL)
+        await db.commit()
+
+    st = PawBarStore(db_path)
+    await st.open_conversation("w-1", _REF, workspace_id="ws-1")
+
+    with pytest.raises(aiosqlite.IntegrityError):
+        async with aiosqlite.connect(db_path) as db:
+            await db.execute(
+                "INSERT INTO paw_bar_conversations"
+                " (id, widget_id, customer_ref, workspace_id, state, active,"
+                " created_at, updated_at)"
+                " VALUES ('ppc_second_active', 'w-1', ?, 'ws-1', 'open', 1, ?, ?)",
+                (_REF, "2026-08-19T00:00:00", "2026-08-19T00:00:00"),
+            )
+            await db.commit()
+
+
+# --------------------------------------------------------------------------- #
+# Layer 2 — the router: the agent session follows the CONVERSATION
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_session_key_is_scoped_to_the_conversation_not_the_visitor(chat):
+    """The bug as the agent experienced it.
+
+    ``session_key`` was ``cloud:concierge:{pocket}:{customer_ref}:{agent}`` — no
+    conversation component — so every conversation a visitor ever had was one
+    agent session. Two conversations must produce two keys.
+    """
+    client, store, executor, widget = chat
+
+    await _say(client, widget.id, "What time do you open?")
+    first_key = executor.submitted[-1].session_key
+
+    opened = await store.open_conversation(widget.id, _REF, workspace_id="ws-1")
+    await _say(client, widget.id, "Different question", conversation_id=opened.id)
+    second_key = executor.submitted[-1].session_key
+
+    assert first_key != second_key, "a new conversation must be a new agent session"
+    assert opened.id in second_key
+
+
+@pytest.mark.asyncio
+async def test_a_fresh_conversation_starts_cold(chat):
+    """The visible harm. ``_load_concierge_history`` replayed by VISITOR, so a
+    visitor who started over still had the abandoned thread in the agent's
+    context. A fresh conversation must carry none of it.
+
+    The abandoned turn is seeded as a real run doc rather than sent through the
+    endpoint: the fixture stubs ``create_run``, so a dispatched turn writes
+    nothing and this would pass against an empty collection no matter how the
+    history read is scoped.
+    """
+    client, store, executor, widget = chat
+
+    abandoned = await store.open_conversation(widget.id, _REF, workspace_id="ws-1")
+    await _seed_run(
+        session_key=f"cloud:concierge:pocket-1:{abandoned.id}:agent-xyz",
+        user_text="My order number is 4417",
+        partial_text="Order 4417 ships Tuesday.",
+    )
+
+    # Prove the seed IS readable on its own conversation, so the assertion below
+    # is isolation working rather than an empty collection.
+    await _say(client, widget.id, "Any update?", conversation_id=abandoned.id)
+    assert "4417" in str(executor.submitted[-1].history)
+
+    opened = await store.open_conversation(widget.id, _REF, workspace_id="ws-1")
+    await _say(client, widget.id, "Do you ship overseas?", conversation_id=opened.id)
+
+    replayed = " ".join(m.get("content", "") for m in (executor.submitted[-1].history or []))
+    assert "4417" not in replayed, "the abandoned conversation leaked into the new one"
+
+
+@pytest.mark.asyncio
+async def test_visitor_can_list_and_open_conversations(chat):
+    """The Messages tab's contract end to end: send a turn, start over, and the
+    visitor sees BOTH conversations with the new one active."""
+    client, store, executor, widget = chat
+
+    await _say(client, widget.id, "First question")
+
+    res = await client.post(
+        "/paw-bar/conversations",
+        json={"key": _VALID_KEY, "w": widget.id, "customer_ref": _REF},
+        headers={"Origin": _ORIGIN},
+    )
+    assert res.status_code == 200, res.text
+    opened = res.json()
+    assert opened["active"] is True
+
+    res = await client.get(
+        "/paw-bar/conversations",
+        params={"w": widget.id, "key": _VALID_KEY, "customer_ref": _REF},
+        headers={"Origin": _ORIGIN},
+    )
+    assert res.status_code == 200, res.text
+    rows = res.json()["conversations"]
+
+    assert len(rows) == 2
+    assert rows[0]["id"] == opened["id"]
+    # Exactly one conversation is in progress, and it is the new one.
+    assert [r["active"] for r in rows] == [True, False]
+
+
+@pytest.mark.asyncio
+async def test_visitor_conversations_never_leak_across_visitors(chat):
+    """A sibling visitor of the SAME bar shares the widget, the site and the
+    agent — only the handle separates them. Their conversations must not be
+    listable by each other."""
+    client, store, executor, widget = chat
+
+    stranger = "cust-stranger-9"
+    await store.open_conversation(widget.id, stranger, workspace_id="ws-1")
+    mine = await store.open_conversation(widget.id, _REF, workspace_id="ws-1")
+
+    res = await client.get(
+        "/paw-bar/conversations",
+        params={"w": widget.id, "key": _VALID_KEY, "customer_ref": _REF},
+        headers={"Origin": _ORIGIN},
+    )
+    assert res.status_code == 200, res.text
+    ids = [r["id"] for r in res.json()["conversations"]]
+
+    assert ids == [mine.id]
+
+
+@pytest.mark.asyncio
+async def test_a_stranger_conversation_id_falls_back_to_your_own(chat):
+    """``conversation_id`` is a client-supplied HINT, never an authority. Naming
+    someone else's conversation must not attach your turn to their thread — and
+    must not confirm the id was real either."""
+    client, store, executor, widget = chat
+
+    stranger = await store.open_conversation(widget.id, "cust-stranger-9", workspace_id="ws-1")
+    await _say(client, widget.id, "Whose thread is this?", conversation_id=stranger.id)
+
+    assert stranger.id not in executor.submitted[-1].session_key
+
+
+@pytest.mark.asyncio
+async def test_chat_without_a_conversation_id_still_works(chat):
+    """Compat. Widget bundles cached in the wild send no ``conversation_id``;
+    they must resolve-or-create the visitor's active conversation rather than
+    422. This is what lets the backend ship before the widget does."""
+    client, store, executor, widget = chat
+
+    await _say(client, widget.id, "First, from an old bundle")
+    await _say(client, widget.id, "Second, from an old bundle")
+
+    # Both turns landed on ONE conversation, and that conversation is real.
+    keys = {s.session_key for s in executor.submitted}
+    assert len(keys) == 1
+    rows = await store.list_conversations_for_visitor(widget.id, _REF, workspace_id="ws-1")
+    assert len(rows) == 1

--- a/tests/mutations/paw_bar_conversation_identity.json
+++ b/tests/mutations/paw_bar_conversation_identity.json
@@ -1,0 +1,108 @@
+[
+  {
+    "label": "the session key reverts to the visitor handle — every conversation is one agent session again (the original bug)",
+    "file": "ee/pocketpaw_ee/paw_bar/router.py",
+    "find": "    session_key = f\"cloud:concierge:{ctx.pocket_id}:{conversation_key}:{widget.agent_id}\"",
+    "replace": "    session_key = f\"cloud:concierge:{ctx.pocket_id}:{body.customer_ref}:{widget.agent_id}\"",
+    "tests": [
+      "tests/cloud/test_paw_bar_conversation_identity.py::test_session_key_is_scoped_to_the_conversation_not_the_visitor",
+      "tests/cloud/test_paw_bar_conversation_identity.py::test_a_fresh_conversation_starts_cold"
+    ]
+  },
+  {
+    "label": "history stops scoping to the conversation — an abandoned thread replays into a fresh one",
+    "file": "ee/pocketpaw_ee/paw_bar/router.py",
+    "find": "    if session_key:\n        predicates.append(ChatRunDoc.session_key == session_key)",
+    "replace": "    pass",
+    "tests": [
+      "tests/cloud/test_paw_bar_conversation_identity.py::test_a_fresh_conversation_starts_cold"
+    ]
+  },
+  {
+    "label": "the client-supplied conversation id is trusted without checking whose it is",
+    "file": "ee/pocketpaw_ee/paw_bar/router.py",
+    "find": "            if (\n                named is not None\n                and named.widget_id == body.widget_id\n                and named.customer_ref == body.customer_ref\n            ):\n                conversation = named",
+    "replace": "            if named is not None:\n                conversation = named",
+    "tests": [
+      "tests/cloud/test_paw_bar_conversation_identity.py::test_a_stranger_conversation_id_falls_back_to_your_own"
+    ]
+  },
+  {
+    "label": "opening a conversation stops retiring the previous one — two actives, and the upsert picks arbitrarily",
+    "file": "src/pocketpaw/paw_bar/store.py",
+    "find": "            await db.execute(\n                \"UPDATE paw_bar_conversations SET active = 0, updated_at = ?\"\n                \" WHERE widget_id = ? AND customer_ref = ? AND active = 1\",\n                (now, widget_id, customer_ref),\n            )",
+    "replace": "            pass",
+    "tests": [
+      "tests/cloud/test_paw_bar_conversation_identity.py::test_opening_a_conversation_mints_a_genuinely_new_row",
+      "tests/cloud/test_paw_bar_conversation_identity.py::test_visitor_conversations_list_newest_first"
+    ]
+  },
+  {
+    "label": "an owner action loses its active scope — closing one conversation closes the visitor's whole history",
+    "file": "src/pocketpaw/paw_bar/store.py",
+    "find": "            \" WHERE widget_id = ? AND customer_ref = ? AND active = 1\"\n        )\n        values.extend([widget_id, customer_ref])",
+    "replace": "            \" WHERE widget_id = ? AND customer_ref = ?\"\n        )\n        values.extend([widget_id, customer_ref])",
+    "tests": [
+      "tests/cloud/test_paw_bar_conversation_identity.py::test_owner_actions_touch_only_the_conversation_in_progress"
+    ]
+  },
+  {
+    "label": "the visitor turn lands on any conversation, not the one in progress",
+    "file": "src/pocketpaw/paw_bar/store.py",
+    "find": "        conditions = \"widget_id = ? AND customer_ref = ? AND active = 1\"\n        params: list[Any] = [widget_id, customer_ref]\n        ws_cond, ws_params = _conversation_workspace_scope(workspace_id)\n        if ws_cond:\n            conditions += f\" AND {ws_cond}\"\n            params.extend(ws_params)\n        sql, bound = self._conversation_select(conditions, params, order=\"LIMIT 1\")",
+    "replace": "        conditions = \"widget_id = ? AND customer_ref = ?\"\n        params: list[Any] = [widget_id, customer_ref]\n        ws_cond, ws_params = _conversation_workspace_scope(workspace_id)\n        if ws_cond:\n            conditions += f\" AND {ws_cond}\"\n            params.extend(ws_params)\n        sql, bound = self._conversation_select(conditions, params, order=\"LIMIT 1\")",
+    "tests": [
+      "tests/cloud/test_paw_bar_conversation_identity.py::test_visitor_turns_land_on_the_active_conversation",
+      "tests/cloud/test_paw_bar_conversation_identity.py::test_owner_actions_touch_only_the_conversation_in_progress",
+      "tests/cloud/test_paw_bar_conversation_identity.py::test_a_retired_conversation_is_not_the_one_in_progress"
+    ]
+  },
+  {
+    "label": "the visitor list stops filtering by visitor — a stranger's conversations become listable",
+    "file": "src/pocketpaw/paw_bar/store.py",
+    "find": "        conditions = \"widget_id = ? AND customer_ref = ?\"\n        params: list[Any] = [widget_id, customer_ref]\n        ws_cond, ws_params = _conversation_workspace_scope(workspace_id)\n        if ws_cond:\n            conditions += f\" AND {ws_cond}\"\n            params.extend(ws_params)\n        bounded = max(1, min(int(limit or _VISITOR_CONVERSATIONS_CAP), _VISITOR_CONVERSATIONS_CAP))",
+    "replace": "        conditions = \"widget_id = ?\"\n        params: list[Any] = [widget_id]\n        ws_cond, ws_params = _conversation_workspace_scope(workspace_id)\n        if ws_cond:\n            conditions += f\" AND {ws_cond}\"\n            params.extend(ws_params)\n        bounded = max(1, min(int(limit or _VISITOR_CONVERSATIONS_CAP), _VISITOR_CONVERSATIONS_CAP))",
+    "tests": [
+      "tests/cloud/test_paw_bar_conversation_identity.py::test_visitor_conversations_list_newest_first",
+      "tests/cloud/test_paw_bar_conversation_identity.py::test_visitor_conversations_never_leak_across_visitors"
+    ]
+  },
+  {
+    "label": "the legacy pair UNIQUE is never dropped — a deployed DB still cannot hold a second conversation",
+    "file": "src/pocketpaw/paw_bar/store.py",
+    "find": "            await PawBarStore._drop_legacy_conversation_pair_unique(db)",
+    "replace": "            pass",
+    "tests": [
+      "tests/cloud/test_paw_bar_conversation_identity.py::test_legacy_db_sheds_the_pair_unique_and_keeps_its_row",
+      "tests/cloud/test_paw_bar_conversation_identity.py::test_the_rebuild_is_idempotent"
+    ]
+  },
+  {
+    "label": "the rebuild drops the rows it was meant to carry across",
+    "file": "src/pocketpaw/paw_bar/store.py",
+    "find": "        await db.execute(\n            f\"INSERT INTO paw_bar_conversations_rebuild ({columns})\"",
+    "replace": "        await db.execute(\n            f\"INSERT INTO paw_bar_conversations_rebuild ({columns}) SELECT NULL WHERE 0 --\"\n            f\" ignored: (\"",
+    "tests": [
+      "tests/cloud/test_paw_bar_conversation_identity.py::test_legacy_db_sheds_the_pair_unique_and_keeps_its_row"
+    ]
+  },
+  {
+    "label": "the partial unique index loses its WHERE — a retired conversation now collides with the active one",
+    "file": "src/pocketpaw/paw_bar/store.py",
+    "find": "CREATE UNIQUE INDEX IF NOT EXISTS idx_pp_conversations_active\n    ON paw_bar_conversations(widget_id, customer_ref) WHERE active = 1;",
+    "replace": "CREATE UNIQUE INDEX IF NOT EXISTS idx_pp_conversations_active\n    ON paw_bar_conversations(widget_id, customer_ref);",
+    "tests": [
+      "tests/cloud/test_paw_bar_conversation_identity.py::test_opening_a_conversation_mints_a_genuinely_new_row",
+      "tests/cloud/test_paw_bar_conversation_identity.py::test_visitor_conversations_list_newest_first"
+    ]
+  },
+  {
+    "label": "the active invariant is dropped entirely — two conversations in progress at once",
+    "file": "src/pocketpaw/paw_bar/store.py",
+    "find": "CREATE UNIQUE INDEX IF NOT EXISTS idx_pp_conversations_active\n    ON paw_bar_conversations(widget_id, customer_ref) WHERE active = 1;",
+    "replace": "CREATE INDEX IF NOT EXISTS idx_pp_conversations_active\n    ON paw_bar_conversations(widget_id, customer_ref) WHERE active = 1;",
+    "tests": [
+      "tests/cloud/test_paw_bar_conversation_identity.py::test_the_active_invariant_survives_the_rebuild"
+    ]
+  }
+]


### PR DESCRIPTION
Reported as "multiple sessions from the bar are treated as a single session." They were. The cause is that the Paw Bar had no conversation identity at all — every read, write, run `session_key` and ledger id keyed on the pair `(widget_id, customer_ref)`.

## What was actually wrong

| Where | What it did |
|---|---|
| `store.py` | `UNIQUE (widget_id, customer_ref)` on `paw_bar_conversations` — a browser could own exactly one row per widget, permanently |
| `router.py` | `session_key = cloud:concierge:{pocket}:{customer_ref}:{agent}` — no conversation component, so every turn a visitor ever sent shared one agent session |
| `ledger.py` | `conversation_id()` derived `"{widget}:{ref}"` rather than reporting a real id |
| `models.py` | `Conversation.id` (`ppc_…`) existed and was vestigial — nothing read it as identity |

The half a visitor could feel was the history replay. `_load_concierge_history` scoped to the **visitor**, so someone who hit "New conversation" — which only ever cleared the widget's own localStorage, the backend never heard about it — still had the abandoned thread fed back into the agent. The owner's inbox showed one thread that never ended.

## The fix

`Conversation.id` becomes the identity. The pair `UNIQUE` gives way to an `active` column plus a **partial** unique index over `(widget_id, customer_ref) WHERE active = 1`. That keeps the invariant worth keeping — at most one conversation in progress, so a turn that names none still resolves to exactly one row — while letting finished ones accumulate as history. The partial index is also a valid `ON CONFLICT` target, so the visitor-turn upsert stays a single statement.

Two endpoints back the widget's Messages list: `GET /paw-bar/conversations` and `POST /paw-bar/conversations`, both behind the same front gate as chat and both scoped to the visitor the embed key already bound, so there is no id to enumerate.

## Compatibility

`conversation_id` on the chat body is optional and must stay that way. Bundles cached on visitors' devices predate the field, and a required one would `422` every one of them the moment this deploys; absent means "the conversation in progress". An id belonging to another visitor or tenant resolves to the caller's own conversation rather than an error — the only thing an error would confirm is that the id was real.

Migration is free for the data and not free for the schema: existing rows already carry a `ppc_…` id and become that visitor's first conversation, but SQLite cannot `ALTER` a constraint away, so a deployed database rebuilds the table once. The rebuild is guarded on the legacy auto-index actually being present (detected by shape, not by name — the replacement index is unique too), so it runs once and a re-run is a no-op.

## Also caught on the way through

`update_conversation` and the idle bot-resume were keyed by the pair alone, which addressed exactly one row while a visitor could only have one. Left as they were, a single owner action — close, snooze, tag, note — would have rewritten that visitor's entire history in one statement.

## Verification

- 15 new tests in `tests/cloud/test_paw_bar_conversation_identity.py`, including three that build the **old** table by hand and prove the rebuild carries rows across, is idempotent, and leaves a real enforced invariant behind.
- All 11 mutations in `tests/mutations/paw_bar_conversation_identity.json` are caught. Two escaped on the first run and both were tests passing for the wrong reason: the history test dispatched through a stubbed `create_run` and so measured an empty collection, and the active-scope test had only one conversation in the table, where an unscoped read agrees by accident. Both are fixed.
- `tests/cloud/ -k "paw_bar or concierge"`: 546 passed, 12 failed — the same 12 that fail on `dev` before this branch (preamble/provisioning/escape-hatch/widget-js, none of them touched here). Baseline was measured by stashing, not assumed.

Six history tests in `test_paw_bar_concierge_chat.py` changed with the contract: they hardcoded the old `session_key` shape, and memory is now conversation-scoped, so they open the conversation up front and seed against its key.

## Follow-up, not in here

The widget still mints one `pawbar.customer_ref` per browser with **no widget namespace**, while the transcript key beside it is namespaced. The iframe origin is shared across every site this backend serves, so one browser hands the same anonymous handle to every tenant's bar. That is a `paw-bar` repo change and ships with the Messages tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
