### PR TITLE
The site edit tools could write a site's source but never read it

### DIFF
--- a/ee/pocketpaw_ee/agent/mcp_servers/sites.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/sites.py
@@ -60,6 +60,27 @@
 # ``SITES_TOOL_IDS`` like every other tool here; the /sites allow-list is a hard
 # whitelist that filters an absent id out silently.
 #
+# Updated 2026-08-19 (fix/sites-read-source-tool — the edit lane could write but not
+# read): added an ELEVENTH tool, the READ-ONLY ``read_site_source``. The surface could
+# WRITE a site's source three ways and READ it zero ways, which is not a missing
+# convenience but a hole the three edit tools fall through. Each of them PREFERS its
+# ``edits`` (search/replace) form, whose ``old_string`` must be copied VERBATIM from the
+# current file and match exactly once, and each description duly said "read it first" —
+# naming no tool, because none existed. ``get_pocket`` does carry ``source``, but it
+# lives on the ``pockets`` server and ``sites_allow`` is a hard whitelist
+# (SITES|STOCK|ICON|PALETTE|DESIGN_SYSTEM|ASK), so on /sites it is filtered out with no
+# error; the profile separately drops the file/shell built-ins on the stated assumption
+# that "the source map is a tool ARGUMENT", which holds only while the agent still has
+# the source it just authored in context. So the only REACHABLE edit form was a
+# whole-file ``new_source`` composed from memory — precisely the shape the edit
+# descriptions warn about, which silently drops a ``<form>``'s ``action`` and its hidden
+# ``paw_site_id`` / ``paw_key`` / ``paw_redirect`` inputs and sends every future enquiry
+# nowhere. Two modes keep the fix from causing the problem it prevents: no ``file_path``
+# returns a manifest of paths + byte sizes (a react source map inlined whole would
+# swallow the context the edit needs), and a ``file_path`` returns that one file
+# verbatim. Engine-agnostic, unlike the edit tools — a read is safe everywhere and the
+# agent often does not know the engine until it looks.
+#
 # Updated 2026-08-11 (RX-3 — the react track gets an EDIT lane): the
 # ``edit_react_component`` tool also registers on this SAME server (built via the
 # factory in sites_create.py), so create → publish → edit sit together for react
@@ -172,6 +193,16 @@ EDIT_HTML_FILE_TOOL_ID = f"mcp__{SERVER_NAME}__edit_html_file"
 # finished. Must ride SITES_TOOL_IDS like the rest — the /sites allow-list is a hard
 # whitelist and filters an absent id out with no error.
 GET_SITE_BUILD_STATUS_TOOL_ID = f"mcp__{SERVER_NAME}__get_site_build_status"
+# The READ-ONLY source tool — also registers on this SAME server (see
+# sites_create.py). It closes the hole the three edit tools were written over:
+# each PREFERS an `edits` diff whose ``old_string`` must be copied verbatim from
+# the current file, and each says "read it first", but /sites had no reader. The
+# ``pockets`` server's ``get_pocket`` does carry ``source`` and is filtered out by
+# the hard allowlist; the file/shell built-ins are dropped by the profile on the
+# assumption that "the source map is a tool ARGUMENT" — which holds only while the
+# agent still has the source it just authored in context. Must ride SITES_TOOL_IDS
+# like the rest: an absent id is filtered out with no error at all.
+READ_SITE_SOURCE_TOOL_ID = f"mcp__{SERVER_NAME}__read_site_source"
 
 SITES_TOOL_IDS = (
     PUBLISH_TOOL_ID,
@@ -184,6 +215,7 @@ SITES_TOOL_IDS = (
     EDIT_REACT_COMPONENT_TOOL_ID,
     EDIT_HTML_FILE_TOOL_ID,
     GET_SITE_BUILD_STATUS_TOOL_ID,
+    READ_SITE_SOURCE_TOOL_ID,
 )
 
 
@@ -518,6 +550,7 @@ def build_sites_manager_server() -> tuple[str, Any] | None:
         make_edit_html_file_tool,
         make_edit_react_component_tool,
         make_edit_svelte_component_tool,
+        make_read_site_source_tool,
     )
 
     create_landing_site = make_create_landing_site_tool(tool)
@@ -550,6 +583,11 @@ def build_sites_manager_server() -> tuple[str, Any] | None:
     # it is what stops the agent answering "change the phone number in the footer"
     # with a second create_html_site call and a second site pocket.
     edit_html_file = make_edit_html_file_tool(tool)
+    # The READ tool — same server, so read → edit → publish sit together. It is the
+    # precondition for the `edits` form the three edit tools above prefer: their
+    # `old_string` has to be copied out of the CURRENT file, and this is the only
+    # thing on /sites that can hand the agent that file.
+    read_site_source = make_read_site_source_tool(tool)
 
     server = create_sdk_mcp_server(
         name=SERVER_NAME,
@@ -565,6 +603,7 @@ def build_sites_manager_server() -> tuple[str, Any] | None:
             create_react_site,
             edit_react_component,
             edit_html_file,
+            read_site_source,
         ],
     )
     return SERVER_NAME, server
@@ -581,6 +620,7 @@ __all__ = [
     "EDIT_SVELTE_COMPONENT_TOOL_ID",
     "GET_SITE_BUILD_STATUS_TOOL_ID",
     "PUBLISH_TOOL_ID",
+    "READ_SITE_SOURCE_TOOL_ID",
     "SERVER_NAME",
     "SITES_TOOL_IDS",
     "build_sites_manager_server",

--- a/ee/pocketpaw_ee/agent/mcp_servers/sites_create.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/sites_create.py
@@ -1,6 +1,18 @@
 # sites_create.py — in-process MCP server exposing the DETERMINISTIC Paw Site
 # create action. Created: 2026-06-04 (feat/sites-deterministic-fastpath).
 #
+# Updated: 2026-08-19 (fix/sites-read-source-tool — the edit lane could write but not
+# read) — added ``read_site_source`` + ``_read_site_source_handler``, the READ half the
+# three edit tools in this file were written against and never had. Each of them prefers
+# an ``edits`` diff whose ``old_string`` must be copied VERBATIM from the current file,
+# and each told the agent to "read it first" while naming no tool that could: /sites
+# filters out ``get_pocket`` (wrong server, hard whitelist) and drops the file/shell
+# built-ins. So the only reachable form was a blind ``new_source`` rewrite — the shape
+# that silently drops a capture form's hidden ``paw_*`` inputs. All three descriptions
+# now name ``read_site_source`` and spell out the read → copy → ``edits`` flow, because
+# a description is the only prompt real estate this surface has. Two modes (manifest vs
+# one file) keep a react source map from flooding the context the edit itself needs.
+#
 # Updated: 2026-08-11 (RX-3 — the react track gets an EDIT lane) — added a SEVENTH
 # tool ``edit_react_component`` plus its handler, mirroring
 # ``make_edit_svelte_component_tool``'s shape (identity → record_tool_call →
@@ -1842,8 +1854,11 @@ def make_edit_svelte_component_tool(tool: Any) -> Any:
             "current file and must match EXACTLY ONCE (include enough surrounding "
             "context to be unique), and `new_string` is what it becomes. You send "
             "ONLY the change, not the whole file — far fewer tokens and faster. If "
-            "you have not read the file this turn, read it first so old_string "
-            "matches.\n"
+            "you have not read the file this turn, call `read_site_source` "
+            "(pocket_id + file_path) FIRST and copy old_string out of what it "
+            "returns — a remembered or guessed old_string does not match, and "
+            "rewriting the file instead silently drops whatever you did not carry "
+            "over.\n"
             "  * `new_source` — the FULL new file contents as a string (REPLACES "
             "the whole file, not a patch). Reserve this for LARGE rewrites where "
             "most of the file changes; for a small tweak use `edits`.\n"
@@ -2100,8 +2115,11 @@ def make_edit_react_component_tool(tool: Any) -> Any:
             "current file and must match EXACTLY ONCE (include enough surrounding "
             "context to be unique), and `new_string` is what it becomes. You send "
             "ONLY the change, not the whole file — far fewer tokens and faster. If "
-            "you have not read the file this turn, read it first so old_string "
-            "matches.\n"
+            "you have not read the file this turn, call `read_site_source` "
+            "(pocket_id + file_path) FIRST and copy old_string out of what it "
+            "returns — a remembered or guessed old_string does not match, and "
+            "rewriting the file instead silently drops whatever you did not carry "
+            "over.\n"
             "  * `new_source` — the FULL new file contents as a string (REPLACES "
             "the whole file). For large rewrites, and the only form `create` "
             "accepts.\n"
@@ -2202,6 +2220,95 @@ def make_edit_react_component_tool(tool: Any) -> Any:
         return await _edit_react_component_handler(args)
 
     return edit_react_component
+
+
+async def _read_site_source_handler(args: dict) -> dict:
+    """MCP handler for ``sites_manager__read_site_source``.
+
+    The READ half of the edit lane. The three ``edit_*`` tools all prefer their
+    ``edits`` (search/replace) form and all tell the agent to read the file first
+    — and until this tool existed nothing on /sites could, because the surface's
+    allowlist excludes the ``pockets`` server and its profile drops the file/shell
+    built-ins. The agent's only reachable move was a full-file ``new_source``
+    rewrite composed from memory, which is how a site loses its capture-form
+    plumbing without a single error being raised.
+
+    Two modes, mirroring the built-in Read instinct the edit descriptions invoke:
+    no ``file_path`` returns the cheap MANIFEST (paths + byte sizes, no contents —
+    a react source map would otherwise flood the context), and a ``file_path``
+    returns that one file VERBATIM so an ``old_string`` copied out of it matches.
+
+    Plan-gated like its edit siblings: reading is a step of the edit flow, so a
+    workspace whose plan no longer unlocks Sites should not keep using it.
+
+    Returns ``{ok, pocket_id, engine, ...}``; sets ``is_error`` when identity is
+    missing, the plan lacks Sites, ``pocket_id`` is absent, or the service rejects
+    the read (a ripple pocket with no source map, an unknown file) — each relayed
+    by code so the agent can correct itself rather than guess again.
+    """
+    workspace_id, user_id = _identity()
+    if not workspace_id or not user_id:
+        return _error_response(
+            "read_site_source requires workspace and user context (call from a cloud chat session)."
+        )
+
+    record_tool_call(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        tool_server="pocketpaw_sites",
+        tool_name="_read_site_source",
+        status="ok",
+        ok=True,
+    )
+
+    pocket_id = args.get("pocket_id")
+    if not isinstance(pocket_id, str) or not pocket_id:
+        return _error_response(
+            "read_site_source requires a `pocket_id` — the id of the site pocket "
+            "whose source you are reading."
+        )
+    file_path = args.get("file_path")
+    if file_path is not None and (not isinstance(file_path, str) or not file_path):
+        return _error_response(
+            "read_site_source `file_path` must be a non-empty string (the relative "
+            "path of one file). Omit it entirely to list the site's files instead."
+        )
+
+    if (gate := await _require_sites_plan_or_error(workspace_id)) is not None:
+        return gate
+
+    from pocketpaw_ee.cloud._core.errors import CloudError
+    from pocketpaw_ee.sites import service as sites_service
+
+    try:
+        result = await sites_service.read_site_source(
+            user_id=user_id,
+            pocket_id=pocket_id,
+            file_path=file_path,
+        )
+    except CloudError as exc:
+        # ValidationError (a ripple pocket has no source map) or NotFound (unknown
+        # pocket or file). Relay code + message so the agent knows WHICH guard hit.
+        return _error_response(f"{exc.code}: {exc.message}")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("read_site_source failed", exc_info=True)
+        return _error_response(f"read failed: {exc}")
+
+    body: dict[str, Any] = {"ok": True, **result}
+    body["message"] = (
+        (
+            "These are the site's files. Read the one you need with `file_path` "
+            "before you edit it, then copy `old_string` out of what comes back."
+        )
+        if file_path is None
+        else (
+            "This is the file's CURRENT content. Copy `old_string` from it "
+            "VERBATIM for the matching edit tool's `edits`, and prefer that over "
+            "`new_source` — a full rewrite drops anything you did not carry over, "
+            "including the capture form's hidden paw_* inputs."
+        )
+    )
+    return _success_response(body)
 
 
 async def _edit_html_file_handler(args: dict) -> dict:
@@ -2348,6 +2455,75 @@ async def _edit_html_file_handler(args: dict) -> dict:
     )
 
 
+def make_read_site_source_tool(tool: Any) -> Any:
+    """Build the ``read_site_source`` SDK tool object.
+
+    Registered on the SAME ``pocketpaw_sites_manager`` server as create + publish +
+    the three edit tools, so read → edit → publish sit on one allowlisted server
+    (see ``make_create_landing_site_tool`` for why one server)."""
+
+    @tool(
+        "read_site_source",
+        (
+            "READ the current source of an EXISTING Paw Site. READ-ONLY — it "
+            "changes nothing and never publishes. Works on every source-bearing "
+            "engine (html, react, svelte); only a ripple site has no source map.\n"
+            "CALL THIS BEFORE EVERY EDIT. The edit tools "
+            "(`edit_html_file` / `edit_react_component` / "
+            "`edit_svelte_component`) take an `edits` list whose `old_string` must "
+            "be copied VERBATIM from the file and match EXACTLY ONCE — you cannot "
+            "write one for a file you have not read this turn. Guessing instead, or "
+            "falling back to a whole-file `new_source` written from memory, is how a "
+            "site silently loses content the user never asked you to touch — most "
+            "damagingly a `<form>`'s `action` and its hidden `paw_site_id` / "
+            "`paw_key` / `paw_redirect` inputs, after which the page still renders, "
+            "still submits, and every future enquiry goes nowhere.\n"
+            "TWO MODES:\n"
+            "  * NO `file_path` — the MANIFEST: every file's path and byte size, no "
+            "contents. Start here when you do not know what the site contains; it is "
+            "cheap and it tells you the real paths (html sites keep `index.html` at "
+            "the ROOT, react sites live under `src/`).\n"
+            "  * WITH `file_path` — that ONE file's exact current contents. Read only "
+            "the files you intend to change; a whole react site at once wastes the "
+            "context you need for the edit itself.\n"
+            "Args: `pocket_id` (required — the site pocket) and optional `file_path`. "
+            "Returns {ok, pocket_id, engine, ...}: the manifest carries {files:[{path, "
+            "bytes}], file_count, bindings}, a single read carries {file_path, bytes, "
+            "contents}. `bindings` names a DYNAMIC svelte site's live-data keys "
+            "(objects / sources / actions / auth) — they are configuration, NOT files, "
+            "so never pass one as a `file_path`. ok=false means nothing was read: "
+            "`pocket.no_source_map` means it is a ripple site (use the pocket tools), "
+            "and a not-found names the paths that DO exist — use one of them rather "
+            "than guessing again."
+        ),
+        {
+            "type": "object",
+            "properties": {
+                "pocket_id": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Id of the site pocket whose source you are reading.",
+                },
+                "file_path": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": (
+                        "Optional. The relative path of ONE file to read in full "
+                        "(e.g. 'index.html', 'src/App.tsx'). OMIT it to list the "
+                        "site's files with their sizes and no contents."
+                    ),
+                },
+            },
+            "required": ["pocket_id"],
+            "additionalProperties": False,
+        },
+    )
+    async def read_site_source(args):  # type: ignore[no-untyped-def]
+        return await _read_site_source_handler(args)
+
+    return read_site_source
+
+
 def make_edit_html_file_tool(tool: Any) -> Any:
     """Build the ``edit_html_file`` SDK tool object using the SDK's ``tool``
     decorator (passed in by the caller that already imported it).
@@ -2376,8 +2552,11 @@ def make_edit_html_file_tool(tool: Any) -> Any:
             "enough surrounding context to be unique), and `new_string` is what it "
             "becomes. An html page is ONE flat document with no components, so a "
             "full rewrite means re-emitting the entire page to change a phone "
-            "number. If you have not read the file this turn, read it first so "
-            "old_string matches.\n"
+            "number. If you have not read the file this turn, call "
+            "`read_site_source` (pocket_id + file_path) FIRST and copy old_string "
+            "out of what it returns — a remembered or guessed old_string does not "
+            "match, and rewriting the page instead is what drops the capture "
+            "form.\n"
             "  * `new_source` — the FULL new file contents as a string (REPLACES "
             "the whole file). For large rewrites, and the only form `create` "
             "accepts.\n"
@@ -2510,4 +2689,5 @@ __all__ = [
     "make_edit_html_file_tool",
     "make_edit_react_component_tool",
     "make_edit_svelte_component_tool",
+    "make_read_site_source_tool",
 ]

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,17 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-08-19 (fix/sites-read-source-tool): added ``read_site_source`` — the
+# READ primitive beside ``apply_edits``. The three ``edit_*`` functions below all
+# resolve an agent-authored diff against the CURRENT file, and nothing on the /sites
+# surface could hand the agent that file: ``get_pocket`` carries ``source`` but sits
+# on a server the /sites allowlist excludes, and the profile drops the file/shell
+# built-ins. The reachable fallback was a whole-file rewrite from memory, which is how
+# a site loses its capture-form plumbing with no error raised. Two modes — a manifest
+# (paths + byte sizes, no contents, ``_paw/`` filtered) and one file verbatim — so the
+# read cannot itself flood the context the edit needs. Engine-agnostic on purpose:
+# only a pocket with no source map at all (ripple) is rejected.
+#
 # Updated 2026-08-12 (sites Settings consolidation): added ``get_site_client`` /
 # ``update_site_client`` / ``record_site_invoice`` — the owner's record of who a
 # site is FOR and what they have billed them. Two decisions worth knowing before
@@ -5147,6 +5158,112 @@ def apply_edits(source: str, edits: list[dict[str, str]]) -> str:
             )
         result = result.replace(old, new, 1)
     return result
+
+
+# The svelte ``source`` envelope keeps a dynamic site's live-data bindings as
+# SIBLING keys beside the file map. Reused here (rather than importing the
+# generator client) so a read never drags the generator's import graph in.
+_SOURCE_BINDING_KEYS = ("objects", "sources", "actions", "auth")
+
+
+async def read_site_source(
+    *,
+    user_id: str,
+    pocket_id: str,
+    file_path: str | None = None,
+) -> dict[str, Any]:
+    """Read an existing Paw Site's source map — the READ half of the edit lane.
+
+    This is the counterpart the three ``edit_*`` tools were written against and
+    that did not exist. Each of them PREFERS its ``edits`` (search/replace) form,
+    whose ``old_string`` must be copied VERBATIM from the current file and match
+    exactly once; their descriptions duly say "read it first". On /sites there was
+    nothing to read with: ``sites_allow`` is a hard whitelist that excludes the
+    ``pockets`` server (so ``get_pocket``, which does carry ``source``, is filtered
+    out), and the profile drops the file/shell built-ins on the stated assumption
+    that "the source map is a tool ARGUMENT" — true when the agent authored the
+    site in the same context, false for every later turn and every imported site.
+    The only reachable edit form was therefore a blind full-file ``new_source``
+    rewrite, which is precisely the shape that silently drops a ``<form>``'s
+    ``action`` and its hidden ``paw_*`` inputs and sends future leads nowhere.
+
+    TWO MODES, because a react site's whole source map would flood the context
+    window that has to hold it:
+
+      * ``file_path=None`` → the MANIFEST: ``{files: [{path, bytes}, ...],
+        file_count, bindings}``. Paths and sizes only, NO contents.
+      * ``file_path="index.html"`` → that ONE file's contents, byte-for-byte.
+
+    Engine-agnostic on purpose: unlike the edit tools (each pinned to its own
+    engine) a read is safe everywhere, and the agent frequently does not know the
+    engine until it looks. Only a pocket with no source map at all — a ripple site
+    — is rejected, and by code so the agent stops rather than retries.
+
+    The generated ``_paw/`` namespace is filtered out of the manifest: the edit
+    tools reject it on the path alone, so listing it only invites a call that
+    cannot succeed. Reading one by explicit path is still allowed — seeing the
+    generated manifest is occasionally useful and never destructive.
+
+    Raises ``ValidationError("pocket.no_source_map")`` for a ripple pocket and
+    ``NotFound`` for an unknown ``file_path``. Tenancy is the pockets service's
+    public ``get``, which raises NotFound / Forbidden for a missing or
+    cross-tenant pocket, so this adds no isolation rules of its own.
+    """
+    from pocketpaw_ee.cloud.pockets import service as pockets_service
+
+    pocket = await pockets_service.get(pocket_id, user_id)
+    source = pocket.get("source")
+    engine = pocket.get("engine") or "ripple"
+    if not isinstance(source, dict) or not source:
+        raise ValidationError(
+            "pocket.no_source_map",
+            f"This pocket has no raw source map to read (engine={engine!r}). Only "
+            "html, react and svelte Paw Sites keep one; a ripple site is authored "
+            "as a rippleSpec, so read it with the pocket tools instead.",
+        )
+
+    # Files are the str-valued entries. A dynamic svelte envelope's bindings
+    # (objects/sources/actions/auth) are list/bool siblings on the SAME dict — the
+    # agent must not be handed `objects` as though it were a component to edit.
+    files = {k: v for k, v in source.items() if k not in _SOURCE_BINDING_KEYS}
+    bindings = [k for k in _SOURCE_BINDING_KEYS if k in source]
+
+    if file_path is None:
+        listed = sorted(k for k in files if not is_reserved_html_path(k))
+        return {
+            "pocket_id": pocket_id,
+            "engine": engine,
+            # The react edit skill's orientation step reads engine + source +
+            # keeps_client_bundle off ONE call. It used to name get_pocket, which
+            # /sites filters out, so the manifest carries the third field too and
+            # the step stops depending on an unreachable tool.
+            "keeps_client_bundle": pocket.get("keeps_client_bundle"),
+            "files": [{"path": k, "bytes": len(str(files[k]).encode("utf-8"))} for k in listed],
+            "file_count": len(listed),
+            "bindings": bindings,
+        }
+
+    # Single-file read. Try the path as spelled first, then normalized, so
+    # './index.html' and 'img\\logo.svg' resolve to the file the agent meant —
+    # the same courtesy the html edit path extends on write.
+    key = file_path if file_path in files else normalize_html_path(file_path)
+    if key not in files:
+        # Name what DOES exist: a typo must not read as "the file is empty", and a
+        # blind retry is just another guess.
+        available = ", ".join(sorted(k for k in files if not is_reserved_html_path(k))[:40])
+        raise NotFound(
+            "site_file",
+            f"{file_path} (this site's files are: {available})",
+        )
+
+    contents = str(files[key])
+    return {
+        "pocket_id": pocket_id,
+        "engine": engine,
+        "file_path": key,
+        "bytes": len(contents.encode("utf-8")),
+        "contents": contents,
+    }
 
 
 async def apply_leaf_edits(

--- a/src/pocketpaw/bundled_skills/_bundled/skills/pocketpaw-edit-react-site/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/skills/pocketpaw-edit-react-site/SKILL.md
@@ -64,23 +64,36 @@ nothing else.
 You cannot write a correct diff against a file you have not read, and
 `old_string` has to match the file **verbatim** — including indentation.
 
+Two calls. First the manifest, to see what the site actually contains:
+
 ```
-mcp__pocketpaw_pocket__get_pocket(pocket_id = <the site pocket's id>)
+read_site_source(pocket_id = <the site pocket's id>)
 ```
 
-Read three things off the returned pocket:
+Read three things off it:
 
 - **`engine`** — must be `"react"`. If it is `"svelte"`, `"ripple"`, `"html"`
   or `"dynamic"`, you are on the wrong skill; see the bottom of this file.
-- **`source`** — the `{path: contents}` map. Find the file that owns the
-  section the user named (`src/components/Hero.tsx` for the hero) and read its
-  current contents. This is where `old_string` comes from.
+- **`files`** — each file's path and byte size (no contents; a whole react
+  source map would swallow the context you need for the edit). Find the file
+  that owns the section the user named — `src/components/Hero.tsx` for the hero.
 - **`keeps_client_bundle`** — needed only if your edit introduces the page's
   first client behaviour; see the interactivity section below.
+
+Then read that one file in full — this is where `old_string` comes from:
+
+```
+read_site_source(pocket_id = <id>, file_path = "src/components/Hero.tsx")
+```
 
 If the user named a section but you cannot tell which file owns it, read
 `src/App.tsx` — it is the composition root and imports every section in
 order, so it is the site's table of contents.
+
+**Do not reach for `get_pocket` here.** It is not on the /sites allow-list, so
+the call does not reach a tool — and skipping the read to write `old_string`
+from memory does not fail loudly, it fails as a zero-match error or, worse, as
+a `new_source` rewrite that quietly drops whatever you did not carry over.
 
 ## STEP 2 — Choose the edit shape
 
@@ -386,8 +399,9 @@ Never fall back to another engine's tool, and never fall back to
 ## Related tools (via MCP)
 
 - `mcp__pocketpaw_sites_manager__edit_react_component` — the edit itself (STEP 3)
-- `mcp__pocketpaw_pocket__get_pocket` — read the current `source`, `engine` and
-  `keeps_client_bundle` (STEP 1)
+- `mcp__pocketpaw_sites_manager__read_site_source` — read the current `source`,
+  `engine` and `keeps_client_bundle` (STEP 1). The /sites counterpart of
+  `get_pocket`, which is NOT on this surface's allow-list
 - `mcp__pocketpaw_sites_manager__publish` — deploy, on explicit request (STEP 4)
 - `mcp__pocketpaw_sites_manager__edit_svelte_component` — the svelte-track sibling
 - `mcp__pocketpaw_stock__search_stock_images` — real photography for a new section

--- a/tests/ee/agent/test_sites_mcp_server/test_mcp_tool.py
+++ b/tests/ee/agent/test_sites_mcp_server/test_mcp_tool.py
@@ -46,6 +46,7 @@ class TestSitesMcpServerRegistration:
             EDIT_SVELTE_COMPONENT_TOOL_ID,
             GET_SITE_BUILD_STATUS_TOOL_ID,
             PUBLISH_TOOL_ID,
+            READ_SITE_SOURCE_TOOL_ID,
             SERVER_NAME,
             SITES_TOOL_IDS,
         )
@@ -93,10 +94,20 @@ class TestSitesMcpServerRegistration:
             GET_SITE_BUILD_STATUS_TOOL_ID == "mcp__pocketpaw_sites_manager__get_site_build_status"
         )
         assert GET_SITE_BUILD_STATUS_TOOL_ID in SITES_TOOL_IDS
+        # The READ-ONLY source tool — the counterpart the three edit tools above
+        # were written against. Each PREFERS an `edits` diff whose `old_string`
+        # must be copied VERBATIM from the current file, and each says "read it
+        # first"; until this shipped /sites had no reader, because the allowlist
+        # excludes the `pockets` server (whose `get_pocket` does carry `source`)
+        # and the profile drops the file/shell built-ins. The reachable edit form
+        # was therefore a blind whole-file rewrite — the shape that silently drops
+        # a capture form's hidden paw_* inputs.
+        assert READ_SITE_SOURCE_TOOL_ID == "mcp__pocketpaw_sites_manager__read_site_source"
+        assert READ_SITE_SOURCE_TOOL_ID in SITES_TOOL_IDS
         # The count is deliberate: adding a tool here widens the /sites surface
         # allow-list (SITES_TOOL_IDS feeds it), so a new id must be a decision,
         # not a side effect. Bump it WITH an id assertion above — never alone.
-        assert len(SITES_TOOL_IDS) == 10
+        assert len(SITES_TOOL_IDS) == 11
 
     def test_extension_provider_advertises_tool_id(self) -> None:
         """The entry-point provider's ``tool_ids()`` feeds the claude_sdk

--- a/tests/ee/agent/test_sites_mcp_server/test_read_site_source.py
+++ b/tests/ee/agent/test_sites_mcp_server/test_read_site_source.py
@@ -1,0 +1,403 @@
+# tests/ee/agent/test_sites_mcp_server/test_read_site_source.py
+# Created: 2026-08-19 (fix/sites-read-source-tool) — coverage for the READ tool
+# ``read_site_source`` on the in-process ``pocketpaw_sites_manager`` server.
+#
+# WHY THIS TOOL EXISTS. The /sites agent could WRITE a site's source three ways
+# (edit_svelte_component / edit_react_component / edit_html_file) and READ it
+# ZERO ways. That is not a missing convenience, it is a hole the edit tools fall
+# through:
+#
+#   1. Every edit tool PREFERS its ``edits`` (search/replace) form, whose
+#      ``old_string`` must be "copied VERBATIM from the current file" and match
+#      exactly once. Their own descriptions instruct "read it first" — and named
+#      no tool that could, because none existed.
+#   2. ``get_pocket`` DOES return ``pocket["source"]`` (``source`` is not in
+#      ``_AGENT_INVISIBLE_FIELDS``), but it lives on the ``pockets`` server, and
+#      ``sites_allow`` is a HARD whitelist of SITES|STOCK|ICON|PALETTE|
+#      DESIGN_SYSTEM|ASK. So on /sites it is silently filtered out.
+#   3. The /sites profile also drops the file/shell built-ins by design
+#      ("the source map / copy is a tool ARGUMENT" — surface_registry.py). True
+#      on CREATE, where the agent authored the source in-context. False on EDIT
+#      of any site it did not author THIS turn.
+#
+# So the only reachable edit form was ``new_source`` — a full-file rewrite
+# composed blind. That is the data-loss path the edit descriptions themselves
+# warn about: it silently drops a ``<form>``'s ``action`` and its hidden
+# ``paw_site_id`` / ``paw_key`` / ``paw_redirect`` inputs, and every future
+# enquiry goes nowhere with no error anywhere.
+#
+# The REGRESSION test that actually pins the bug is
+# ``TestReachableFromTheSitesSurface`` — an id absent from the allowlist is
+# filtered with NO error, so registration alone proves nothing.
+"""Tests for the site source READ tool (read_site_source)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+
+@pytest.fixture(autouse=True)
+def _default_sites_plan():
+    """``read_site_source`` runs the shared Sites plan gate, like its edit
+    siblings. These tests use synthetic workspace ids with no seeded Workspace
+    doc, so default the plan to one that unlocks Sites ("go")."""
+    with patch(
+        "pocketpaw_ee.cloud.workspace.service.get_workspace_plan",
+        new=AsyncMock(return_value="go"),
+    ):
+        yield
+
+
+def _listed_tool(name: str = "read_site_source"):
+    """Fetch the tool as the SDK would list it, or skip when the SDK is absent."""
+    import asyncio
+
+    from mcp import types
+    from pocketpaw_ee.agent.mcp_servers.sites import build_sites_manager_server
+
+    built = build_sites_manager_server()
+    if built is None:  # claude_agent_sdk absent — nothing to assert
+        pytest.skip("claude_agent_sdk not installed")
+    _name, server = built
+    handler = server["instance"].request_handlers[types.ListToolsRequest]
+    listed = asyncio.run(handler(types.ListToolsRequest(method="tools/list")))
+    return listed.root.tools
+
+
+def _body(out: dict) -> dict:
+    """Decode the JSON body a success response carries."""
+    return json.loads(out["content"][0]["text"])
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+class TestRegistration:
+    def test_tool_id_on_shared_server_allowlist(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers.sites import READ_SITE_SOURCE_TOOL_ID, SITES_TOOL_IDS
+
+        assert READ_SITE_SOURCE_TOOL_ID == "mcp__pocketpaw_sites_manager__read_site_source"
+        assert READ_SITE_SOURCE_TOOL_ID in SITES_TOOL_IDS
+
+    def test_provider_advertises_read_tool_id(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers.sites import READ_SITE_SOURCE_TOOL_ID
+        from pocketpaw_ee.extensions import CloudSitesMcpProvider
+
+        assert READ_SITE_SOURCE_TOOL_ID in CloudSitesMcpProvider().tool_ids()
+
+    def test_the_built_server_actually_lists_the_tool(self) -> None:
+        """An id in ``SITES_TOOL_IDS`` with no tool behind it allow-lists a name
+        that does not answer."""
+        names = {t.name for t in _listed_tool()}
+        assert "read_site_source" in names, sorted(names)
+
+    def test_only_pocket_id_is_required(self) -> None:
+        """Manifest mode is the no-``file_path`` call. If ``file_path`` were
+        required the agent could not discover WHICH files exist, and would have
+        to guess a path before it could read one."""
+        tool = next(t for t in _listed_tool() if t.name == "read_site_source")
+        props = (tool.inputSchema or {}).get("properties") or {}
+        assert set(props) >= {"pocket_id", "file_path"}
+        assert (tool.inputSchema or {}).get("required") == ["pocket_id"]
+
+
+# ---------------------------------------------------------------------------
+# THE REGRESSION TEST — reachability, not merely registration
+# ---------------------------------------------------------------------------
+
+
+class TestReachableFromTheSitesSurface:
+    """``sites_allow`` is a hard whitelist: an id missing from it is filtered out
+    with no error and the tool is silently unreachable on the surface that needs
+    it. Registration tests above cannot catch that. These can."""
+
+    def test_read_tool_is_allowed_in_every_sites_mode(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers.sites import READ_SITE_SOURCE_TOOL_ID
+        from pocketpaw_ee.cloud.surface import SurfaceKind, SurfaceMeta, resolve_profile
+
+        for meta in (
+            SurfaceMeta(),  # ripple-create
+            SurfaceMeta(engine="svelte"),  # svelte-create
+            SurfaceMeta(engine="html"),
+            SurfaceMeta(engine="react"),
+            SurfaceMeta(pocket_id="pkt_1"),  # refine an existing site
+        ):
+            allow = resolve_profile(SurfaceKind.SITES, meta).allow_mcp_tool_ids
+            assert allow is not None
+            assert READ_SITE_SOURCE_TOOL_ID in allow, f"unreachable for meta={meta}"
+
+    def test_every_edit_tool_has_a_reachable_way_to_read_first(self) -> None:
+        """The invariant the bug violated, stated directly: a surface that can
+        WRITE a site's source must be able to READ it. Without this the only
+        usable edit form is a blind full-file rewrite."""
+        from pocketpaw_ee.agent.mcp_servers.sites import (
+            EDIT_HTML_FILE_TOOL_ID,
+            EDIT_REACT_COMPONENT_TOOL_ID,
+            EDIT_SVELTE_COMPONENT_TOOL_ID,
+            READ_SITE_SOURCE_TOOL_ID,
+        )
+        from pocketpaw_ee.cloud.surface import SurfaceKind, SurfaceMeta, resolve_profile
+
+        allow = resolve_profile(
+            SurfaceKind.SITES, SurfaceMeta(pocket_id="pkt_1")
+        ).allow_mcp_tool_ids
+        assert allow is not None
+        writers = {
+            EDIT_HTML_FILE_TOOL_ID,
+            EDIT_REACT_COMPONENT_TOOL_ID,
+            EDIT_SVELTE_COMPONENT_TOOL_ID,
+        } & set(allow)
+        assert writers, "no edit tools on /sites — this test is asserting nothing"
+        assert READ_SITE_SOURCE_TOOL_ID in allow
+
+
+# ---------------------------------------------------------------------------
+# The edit tools must NAME the read tool
+# ---------------------------------------------------------------------------
+
+
+class TestEditDescriptionsPointAtTheReadTool:
+    """A tool description is the only prompt real estate this surface has. All
+    three edit tools tell the agent to read the file first; before this fix none
+    of them could name a tool that does it."""
+
+    @pytest.mark.parametrize(
+        "edit_tool",
+        ["edit_html_file", "edit_react_component", "edit_svelte_component"],
+    )
+    def test_edit_description_names_the_read_tool(self, edit_tool: str) -> None:
+        tool = next(t for t in _listed_tool() if t.name == edit_tool)
+        assert "read_site_source" in (tool.description or "")
+
+
+# ---------------------------------------------------------------------------
+# Handler wiring
+# ---------------------------------------------------------------------------
+
+
+class TestReadHandler:
+    @pytest.mark.asyncio
+    async def test_manifest_mode_lists_paths_and_sizes_without_contents(self) -> None:
+        """No ``file_path`` → the cheap manifest. Contents are deliberately NOT
+        included: a react site's full source map would flood the context window,
+        which is the reason allow-listing ``get_pocket`` was not the fix."""
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        fake = AsyncMock(
+            return_value={
+                "pocket_id": "pk1",
+                "engine": "html",
+                "files": [
+                    {"path": "index.html", "bytes": 42},
+                    {"path": "styles.css", "bytes": 7},
+                ],
+                "file_count": 2,
+                "bindings": [],
+            }
+        )
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch("pocketpaw_ee.sites.service.read_site_source", new=fake),
+        ):
+            out = await mcp._read_site_source_handler({"pocket_id": "pk1"})
+
+        assert not out.get("is_error"), out
+        body = _body(out)
+        assert body["ok"] is True
+        assert body["file_count"] == 2
+        assert [f["path"] for f in body["files"]] == ["index.html", "styles.css"]
+        assert "contents" not in json.dumps(body)
+
+    @pytest.mark.asyncio
+    async def test_single_file_mode_returns_verbatim_contents(self) -> None:
+        """The whole point: the returned text must be byte-identical to what is
+        stored, or an ``old_string`` copied from it will not match."""
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        source = '<!doctype html>\n<h1 class="a">Hi</h1>\n<!-- \t tricky "quotes" -->\n'
+        fake = AsyncMock(
+            return_value={
+                "pocket_id": "pk1",
+                "engine": "html",
+                "file_path": "index.html",
+                "bytes": len(source.encode("utf-8")),
+                "contents": source,
+            }
+        )
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch("pocketpaw_ee.sites.service.read_site_source", new=fake),
+        ):
+            out = await mcp._read_site_source_handler(
+                {"pocket_id": "pk1", "file_path": "index.html"}
+            )
+
+        assert not out.get("is_error"), out
+        body = _body(out)
+        assert body["contents"] == source
+
+    @pytest.mark.asyncio
+    async def test_missing_identity_is_an_error(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        with patch.object(mcp, "_identity", return_value=(None, None)):
+            out = await mcp._read_site_source_handler({"pocket_id": "pk1"})
+        assert out.get("is_error") is True
+
+    @pytest.mark.asyncio
+    async def test_missing_pocket_id_is_an_error(self) -> None:
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+
+        with patch.object(mcp, "_identity", return_value=("ws1", "u1")):
+            out = await mcp._read_site_source_handler({})
+        assert out.get("is_error") is True
+
+    @pytest.mark.asyncio
+    async def test_service_error_is_relayed_by_code(self) -> None:
+        """A ripple pocket has no source map. The agent must learn WHICH guard
+        rejected it so it stops trying to read files off a ripple site."""
+        from pocketpaw_ee.agent.mcp_servers import sites_create as mcp
+        from pocketpaw_ee.cloud._core.errors import ValidationError
+
+        fake = AsyncMock(
+            side_effect=ValidationError(
+                "pocket.no_source_map",
+                "This pocket is a ripple Paw Site — it has no raw source map.",
+            )
+        )
+        with (
+            patch.object(mcp, "_identity", return_value=("ws1", "u1")),
+            patch("pocketpaw_ee.sites.service.read_site_source", new=fake),
+        ):
+            out = await mcp._read_site_source_handler({"pocket_id": "pk1"})
+
+        assert out.get("is_error") is True
+        assert "pocket.no_source_map" in out["content"][0]["text"]
+
+
+# ---------------------------------------------------------------------------
+# Service behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestReadService:
+    @pytest.mark.asyncio
+    async def test_manifest_excludes_the_generated_paw_namespace(self) -> None:
+        """``_paw/`` is generated and unwritable by the edit tools. Listing it
+        invites the agent to try an edit that is rejected on the path alone."""
+        from pocketpaw_ee.sites import service as sites_service
+
+        pocket = {
+            "engine": "html",
+            "source": {"index.html": "<h1>Hi</h1>", "_paw/generated.js": "// gen"},
+        }
+        with patch(
+            "pocketpaw_ee.cloud.pockets.service.get",
+            new=AsyncMock(return_value=pocket),
+        ):
+            out = await sites_service.read_site_source(user_id="u1", pocket_id="pk1")
+
+        assert [f["path"] for f in out["files"]] == ["index.html"]
+
+    @pytest.mark.asyncio
+    async def test_the_manifest_carries_no_file_contents(self) -> None:
+        """The handler test above proves the RESPONSE shape against a fake; this
+        proves the SERVICE never puts contents in the manifest at all. Without it
+        a manifest that inlined every file would ship — and the flood it causes
+        is the reason allow-listing ``get_pocket`` was rejected as the fix.
+
+        Mutation: add ``"contents": str(files[k])`` to the manifest rows and this
+        fails while every handler-level assertion keeps passing."""
+        from pocketpaw_ee.sites import service as sites_service
+
+        secret = "THE-FILE-BODY-SHOULD-NOT-APPEAR"
+        pocket = {"engine": "html", "source": {"index.html": secret}}
+        with patch(
+            "pocketpaw_ee.cloud.pockets.service.get",
+            new=AsyncMock(return_value=pocket),
+        ):
+            out = await sites_service.read_site_source(user_id="u1", pocket_id="pk1")
+
+        assert secret not in json.dumps(out)
+        assert out["files"] == [{"path": "index.html", "bytes": len(secret)}]
+
+    @pytest.mark.asyncio
+    async def test_dynamic_svelte_bindings_are_not_listed_as_files(self) -> None:
+        """A dynamic svelte pocket keeps ``objects``/``sources``/``actions``/
+        ``auth`` as SIBLING keys on the same dict as the files. Listing them as
+        files would have the agent try to read ``objects`` as a component."""
+        from pocketpaw_ee.sites import service as sites_service
+
+        pocket = {
+            "engine": "svelte",
+            "source": {
+                "src/routes/+page.svelte": "<h1>Hi</h1>",
+                "objects": [{"name": "lead"}],
+                "auth": True,
+            },
+        }
+        with patch(
+            "pocketpaw_ee.cloud.pockets.service.get",
+            new=AsyncMock(return_value=pocket),
+        ):
+            out = await sites_service.read_site_source(user_id="u1", pocket_id="pk1")
+
+        assert [f["path"] for f in out["files"]] == ["src/routes/+page.svelte"]
+        assert set(out["bindings"]) == {"objects", "auth"}
+
+    @pytest.mark.asyncio
+    async def test_reading_one_file_returns_it_verbatim(self) -> None:
+        from pocketpaw_ee.sites import service as sites_service
+
+        source = '<h1 class="hero">A</h1>\n\t<p>B</p>\n'
+        pocket = {"engine": "html", "source": {"index.html": source}}
+        with patch(
+            "pocketpaw_ee.cloud.pockets.service.get",
+            new=AsyncMock(return_value=pocket),
+        ):
+            out = await sites_service.read_site_source(
+                user_id="u1", pocket_id="pk1", file_path="index.html"
+            )
+
+        assert out["contents"] == source
+        assert out["bytes"] == len(source.encode("utf-8"))
+
+    @pytest.mark.asyncio
+    async def test_a_ripple_pocket_is_rejected_not_a_keyerror(self) -> None:
+        from pocketpaw_ee.cloud._core.errors import ValidationError
+        from pocketpaw_ee.sites import service as sites_service
+
+        pocket = {"engine": "ripple", "source": None}
+        with patch(
+            "pocketpaw_ee.cloud.pockets.service.get",
+            new=AsyncMock(return_value=pocket),
+        ):
+            with pytest.raises(ValidationError) as exc:
+                await sites_service.read_site_source(user_id="u1", pocket_id="pk1")
+
+        assert exc.value.code == "pocket.no_source_map"
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_file_is_not_found_and_names_what_exists(self) -> None:
+        """A typo'd path must not read as "the file is empty". The error names
+        the real paths so the agent's retry is informed rather than another
+        guess."""
+        from pocketpaw_ee.cloud._core.errors import NotFound
+        from pocketpaw_ee.sites import service as sites_service
+
+        pocket = {"engine": "html", "source": {"index.html": "<h1>Hi</h1>"}}
+        with patch(
+            "pocketpaw_ee.cloud.pockets.service.get",
+            new=AsyncMock(return_value=pocket),
+        ):
+            with pytest.raises(NotFound):
+                await sites_service.read_site_source(
+                    user_id="u1", pocket_id="pk1", file_path="about.html"
+                )

--- a/tests/mutations/react_edit_lane.json
+++ b/tests/mutations/react_edit_lane.json
@@ -261,8 +261,8 @@
   {
     "label": "the build-status tool id leaves SITES_TOOL_IDS, so the /sites allow-list filters the tool out silently and every handler test still passes",
     "file": "ee/pocketpaw_ee/agent/mcp_servers/sites.py",
-    "find": "    EDIT_REACT_COMPONENT_TOOL_ID,\n    EDIT_HTML_FILE_TOOL_ID,\n    GET_SITE_BUILD_STATUS_TOOL_ID,\n)",
-    "replace": "    EDIT_REACT_COMPONENT_TOOL_ID,\n    EDIT_HTML_FILE_TOOL_ID,\n)",
+    "find": "    EDIT_HTML_FILE_TOOL_ID,\n    GET_SITE_BUILD_STATUS_TOOL_ID,\n",
+    "replace": "    EDIT_HTML_FILE_TOOL_ID,\n",
     "tests": [
       "tests/ee/agent/test_sites_mcp_server/test_build_status_tool.py::TestRegistration::test_status_tool_id_is_on_the_shared_allowlist",
       "tests/ee/agent/test_sites_mcp_server/test_mcp_tool.py::TestSitesMcpServerRegistration::test_server_name_and_tool_id"

--- a/tests/mutations/site_read_lane.json
+++ b/tests/mutations/site_read_lane.json
@@ -1,0 +1,65 @@
+[
+  {
+    "label": "the read tool is dropped from SITES_TOOL_IDS, so the /sites allow-list filters it out silently and the edit lane is blind again",
+    "file": "ee/pocketpaw_ee/agent/mcp_servers/sites.py",
+    "find": "    GET_SITE_BUILD_STATUS_TOOL_ID,\n    READ_SITE_SOURCE_TOOL_ID,\n)",
+    "replace": "    GET_SITE_BUILD_STATUS_TOOL_ID,\n)",
+    "tests": ["tests/ee/agent/test_sites_mcp_server/test_read_site_source.py::TestReachableFromTheSitesSurface"]
+  },
+  {
+    "label": "the tool is registered but not handed to the server, so the allow-listed name does not answer",
+    "file": "ee/pocketpaw_ee/agent/mcp_servers/sites.py",
+    "find": "            edit_html_file,\n            read_site_source,",
+    "replace": "            edit_html_file,",
+    "tests": ["tests/ee/agent/test_sites_mcp_server/test_read_site_source.py::TestRegistration::test_the_built_server_actually_lists_the_tool"]
+  },
+  {
+    "label": "file_path becomes required, so the agent cannot list the site and must guess a path before it can read one",
+    "file": "ee/pocketpaw_ee/agent/mcp_servers/sites_create.py",
+    "find": "            \"required\": [\"pocket_id\"],\n            \"additionalProperties\": False,\n        },\n    )\n    async def read_site_source(args):",
+    "replace": "            \"required\": [\"pocket_id\", \"file_path\"],\n            \"additionalProperties\": False,\n        },\n    )\n    async def read_site_source(args):",
+    "tests": ["tests/ee/agent/test_sites_mcp_server/test_read_site_source.py::TestRegistration::test_only_pocket_id_is_required"]
+  },
+  {
+    "label": "the manifest ships every file's contents, flooding the context the edit itself needs",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "            \"files\": [{\"path\": k, \"bytes\": len(str(files[k]).encode(\"utf-8\"))} for k in listed],",
+    "replace": "            \"files\": [{\"path\": k, \"bytes\": len(str(files[k]).encode(\"utf-8\")), \"contents\": str(files[k])} for k in listed],",
+    "tests": ["tests/ee/agent/test_sites_mcp_server/test_read_site_source.py::TestReadService::test_the_manifest_carries_no_file_contents"]
+  },
+  {
+    "label": "a dynamic svelte site's live-data bindings are listed as files, so the agent tries to read `objects` as a component",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    files = {k: v for k, v in source.items() if k not in _SOURCE_BINDING_KEYS}",
+    "replace": "    files = dict(source)",
+    "tests": ["tests/ee/agent/test_sites_mcp_server/test_read_site_source.py::TestReadService::test_dynamic_svelte_bindings_are_not_listed_as_files"]
+  },
+  {
+    "label": "the generated _paw/ namespace is listed, inviting an edit that the path guard rejects outright",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        listed = sorted(k for k in files if not is_reserved_html_path(k))",
+    "replace": "        listed = sorted(files)",
+    "tests": ["tests/ee/agent/test_sites_mcp_server/test_read_site_source.py::TestReadService::test_manifest_excludes_the_generated_paw_namespace"]
+  },
+  {
+    "label": "a ripple pocket falls through the no-source-map guard and dies on an attribute error instead of a relayable code",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if not isinstance(source, dict) or not source:\n        raise ValidationError(\n            \"pocket.no_source_map\",",
+    "replace": "    if False:\n        raise ValidationError(\n            \"pocket.no_source_map\",",
+    "tests": ["tests/ee/agent/test_sites_mcp_server/test_read_site_source.py::TestReadService::test_a_ripple_pocket_is_rejected_not_a_keyerror"]
+  },
+  {
+    "label": "the unknown-path guard is skipped, so a typo dies on a raw KeyError instead of the relayable 404 that names what exists",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if key not in files:\n        # Name what DOES exist:",
+    "replace": "    if False:\n        # Name what DOES exist:",
+    "tests": ["tests/ee/agent/test_sites_mcp_server/test_read_site_source.py::TestReadService::test_an_unknown_file_is_not_found_and_names_what_exists"]
+  },
+  {
+    "label": "the html edit tool stops naming the read tool, so its 'read it first' instruction names nothing the agent can call",
+    "file": "ee/pocketpaw_ee/agent/mcp_servers/sites_create.py",
+    "find": "\"`read_site_source` (pocket_id + file_path) FIRST and copy old_string \"",
+    "replace": "\"the current file FIRST and copy old_string \"",
+    "tests": ["tests/ee/agent/test_sites_mcp_server/test_read_site_source.py::TestEditDescriptionsPointAtTheReadTool::test_edit_description_names_the_read_tool[edit_html_file]"]
+  }
+]


### PR DESCRIPTION
## What was wrong

The /sites agent had three ways to write a site's source and none to read it.

That sounds like a missing convenience. It's the hole the edit tools fall through:

1. `edit_html_file`, `edit_react_component` and `edit_svelte_component` all **prefer** their `edits` (search/replace) form, and each `old_string` must be copied verbatim from the current file and match exactly once. All three descriptions say "read it first" — and named no tool, because there wasn't one.
2. `get_pocket` does return `pocket["source"]` (`source` isn't in `_AGENT_INVISIBLE_FIELDS`), but it lives on the `pockets` server, and `sites_allow` is a hard whitelist of SITES | STOCK | ICON | PALETTE | DESIGN_SYSTEM | ASK. On /sites it's filtered out, silently.
3. The profile also drops the file/shell built-ins, on the reasoning written into `surface_registry.py`: "the source map / copy is a tool ARGUMENT". That's true on create, where the agent authored the source in the same context. It's false on every later turn, and on every site imported from a URL.

So the only reachable edit form was `new_source` — a whole-file rewrite composed from memory. That's the case the edit tool descriptions already warn about: it drops a `<form>`'s `action` and its hidden `paw_site_id` / `paw_key` / `paw_redirect` inputs. The page still renders, still submits, and every enquiry after that goes nowhere. Nothing errors.

The shipped `pocketpaw-edit-react-site` skill made this concrete — its STEP 1 was literally `mcp__pocketpaw_pocket__get_pocket(...)`, a call that doesn't reach a tool on the surface the skill runs on.

## What changed

**`read_site_source`**, an eleventh tool on `pocketpaw_sites_manager`, in two modes — because returning a react source map whole would eat the context the edit needs:

- no `file_path` → a manifest: each file's path and byte size, no contents, `_paw/` filtered out (the edit tools reject those paths anyway, so listing them only invites a call that can't succeed)
- with `file_path` → that one file, byte for byte, so an `old_string` copied out of it matches

It's engine-agnostic, unlike the edit tools — a read is safe everywhere and the agent often can't tell the engine until it looks. Only a pocket with no source map at all (ripple) is refused, by code, so the agent stops instead of retrying. A dynamic svelte envelope's `objects` / `sources` / `actions` / `auth` are reported as `bindings`, not files, so they're never mistaken for something editable.

All three edit descriptions now name it and spell out the read → copy → `edits` flow. The react edit skill's STEP 1 uses it, and the manifest carries `keeps_client_bundle` so that step resolves from one reachable call instead of the one that was being filtered.

## Tests

**Reachability is the regression test, not registration.** An id missing from the allowlist is filtered with no error, so a registration assertion proves nothing about whether the agent can call the thing. `TestReachableFromTheSitesSurface` resolves the id through `resolve_profile` for every /sites mode, and asserts the invariant directly: a surface that can write a site's source must be able to read it.

`tests/mutations/site_read_lane.json` covers the lane — **all 9 mutations caught**, including dropping the id from `SITES_TOOL_IDS` (which is exactly the silent-filter failure) and inlining contents into the manifest.

Two of those mutations escaped on the first run and found real gaps: the manifest assertion was only checking a mocked service, and one anchor left the tool name intact in an adjacent string fragment. Both fixed.

## Notes

- `tests/cloud/test_surface_profile.py` has 2 failures on `dev` right now, unrelated to this: they expect a skill named `create-svelte-site` where the profile returns `pocketpaw-create-svelte-site`. Verified pre-existing by stashing this branch's changes. Left alone rather than widening scope.
- `tests/ee/sites/test_dev_server.py::test_touch_bumps_activity` is a timing flake on Windows (passes alone and on re-run); no dev-server code is touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
