### PR TITLE
The owner's inbox showed one row for a visitor who asked four questions

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2333,7 +2333,7 @@ the split is the security model:
 | `POST /paw-bar/action` | Run a verb the widget spec declares. `auto` verbs touch only the visitor's own cart or a checkout link; `gated` verbs execute nothing and raise an Instinct proposal for a human. |
 | `GET /paw-bar/cart` | The visitor's own cart. |
 | `POST /paw-bar/decision-contact` | Leave an email so a decision reaches the visitor after they close the page. The address is stored on the decision row only — never in agent context, the KB, or transcripts. |
-| `GET /paw-bar/messages/{widget_id}/{customer_ref}` | Poll for owner and system messages once a human has joined. Returns `role`, `content`, `at` and `bot_paused` — never notes, tags, assignee or contact address. |
+| `GET /paw-bar/messages/{widget_id}/{customer_ref}` | Poll for owner and system messages once a human has joined. Returns `role`, `content`, `at` and `bot_paused` — never notes, tags, assignee or contact address. Pass `conversation_id` to scope the read (and `bot_paused`) to the thread on screen; omitting it answers for the visitor's whole history, which is what a cached widget bundle does. |
 | `GET /paw-bar/articles` | The site's own synced pages, for a self-serve reading list. |
 
 ### Admin — the owner surface
@@ -2342,10 +2342,10 @@ the split is the security model:
 |---|---|
 | `GET /paw-bar/admin/site/{site_id}/overview` | Counts and the bound widget. |
 | `GET/PATCH /paw-bar/admin/site/{site_id}/settings` | The kill switch, greeting, transcript-retention toggle, and `concierge_appearance` — the white-label block (accent, surface mode, radius, blur, font, launcher, hero, motion preset, agent identity) that renders into the widget's `--pawbar-*` custom properties. Sent whole rather than per-field; every value validates into a safe CSS literal, since these become the right-hand side of a custom property in a document the widget serves. |
-| `GET /paw-bar/admin/site/{site_id}/conversations` | The inbox. Supports `?state=open\|needs_human\|snoozed\|closed`, carries per-state `counts`, and each row joins its lifecycle state, unread count, tags and whether an action is pending. |
-| `GET /paw-bar/admin/site/{site_id}/conversations/{customer_ref}` | One conversation's transcript, interleaving visitor, assistant, owner and system turns by timestamp. |
-| `PATCH /paw-bar/admin/site/{site_id}/conversations/{customer_ref}` | Move state, snooze, tag, or append a private note. |
-| `POST /paw-bar/admin/site/{site_id}/conversations/{customer_ref}/reply` | Reply as the owner. Persists the turn, mutes the bot, clears unread, and reopens a closed or snoozed conversation. |
+| `GET /paw-bar/admin/site/{site_id}/conversations` | The inbox. One row per CONVERSATION, not per visitor — a visitor who asked four separate questions is four rows, each carrying its own `conversation_id` and its own last sentence. Supports `?state=open\|needs_human\|snoozed\|closed`, carries per-state `counts`, and each row joins its lifecycle state, unread count, tags and whether an action is pending. |
+| `GET /paw-bar/admin/site/{site_id}/conversations/{customer_ref}` | One conversation's transcript, interleaving visitor, assistant, owner and system turns by timestamp. Pass `conversation_id` to read ONE thread; without it the visitor's whole history is merged into a single transcript. Both sources narrow together — narrowing only the runs would interleave one thread's questions with every reply a human ever sent that visitor. |
+| `PATCH /paw-bar/admin/site/{site_id}/conversations/{customer_ref}` | Move state, snooze, tag, or append a private note. Send `conversation_id` to file the thread you are READING; omit it and the visitor's conversation in progress is filed instead. |
+| `POST /paw-bar/admin/site/{site_id}/conversations/{customer_ref}/reply` | Reply as the owner. Persists the turn, mutes the bot, clears unread, and reopens a closed or snoozed conversation. Send `conversation_id` so the reply lands in the thread being answered — without it an answer to an older question surfaces inside whichever conversation the visitor has open now. A `conversation_id` belonging to another visitor or another site is a 404, never a silent fallback. |
 | `GET /paw-bar/admin/agent/{agent_id}/conversations` | The same inbox scoped to an agent rather than a site — the union across every site that agent serves. |
 | `GET /paw-bar/admin/site/{site_id}/decisions` | Gated actions awaiting a human. |
 | `GET /paw-bar/admin/site/{site_id}/handoffs` | Conversations a visitor asked to escalate. |

--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -1800,6 +1800,11 @@ class ConversationItem(BaseModel):
     """
 
     customer_ref: str
+    # WHICH conversation this row is (2026-08-19). A visitor may hold several, so
+    # ``customer_ref`` names the person and no longer identifies the row. Empty
+    # only for a conversation with no state row and no identified run — the
+    # legacy shape, kept listable rather than dropped.
+    conversation_id: str = ""
     last_message_at: str
     preview: str
     state: str = "open"
@@ -1933,6 +1938,11 @@ class ConversationPatchRequest(BaseModel):
     tags: list[str] | None = None
     note: str | None = None
     bot_paused: bool | None = None
+    # WHICH of the visitor's conversations to file (2026-08-19). Absent means the
+    # one in progress, which is what every pre-identity client sends and what the
+    # store has always written. It is not a patchable FIELD — it is the address —
+    # so it is stripped before the field whitelist ever sees it.
+    conversation_id: str | None = None
 
 
 class ConversationPatchResponse(BaseModel):
@@ -1969,9 +1979,17 @@ class TranscriptMessage(BaseModel):
 
 
 class ConversationReplyRequest(BaseModel):
-    """Body of POST .../conversations/{customer_ref}/reply — the owner's own turn."""
+    """Body of POST .../conversations/{customer_ref}/reply — the owner's own turn.
+
+    ``conversation_id`` names the thread being answered (2026-08-19). Absent means
+    the visitor's active one — the pre-identity behaviour, kept so a cached
+    dashboard bundle keeps working. Sending it is how an owner answers a question
+    from a conversation the visitor has since moved on from without that answer
+    materializing inside the conversation they are typing in right now.
+    """
 
     text: str
+    conversation_id: str | None = None
 
 
 class ConversationReplyResponse(BaseModel):
@@ -2243,20 +2261,18 @@ async def patch_site_conversation(
         raise HTTPException(404, "conversation_not_found")
 
     store = _store()
-    conversation = await store.get_conversation(widget.id, customer_ref, workspace_id=workspace_id)
-    if conversation is None:
-        # No row yet — only mint one if this ref actually HAS a conversation here.
-        runs = await _concierge_runs_for_visitor(
-            site.pocket_id, customer_ref, workspace_id, limit=1
-        )
-        if not runs:
-            raise HTTPException(404, "conversation_not_found")
-        conversation = await store.ensure_conversation(widget.id, customer_ref, workspace_id)
+    conversation = await _resolve_owner_conversation(
+        store, site, widget, customer_ref, workspace_id, req.conversation_id or ""
+    )
 
     if fields:
         before = conversation
         updated = await store.update_conversation(
-            widget.id, customer_ref, workspace_id=workspace_id, **fields
+            widget.id,
+            customer_ref,
+            workspace_id=workspace_id,
+            conversation_id=conversation.id,
+            **fields,
         )
         conversation = updated or conversation
         # AL-2 — record whichever ledger beats this patch actually crossed
@@ -2342,19 +2358,18 @@ async def post_site_conversation_reply(
         raise HTTPException(404, "conversation_not_found")
 
     store = _store()
-    conversation = await store.get_conversation(widget.id, customer_ref, workspace_id=workspace_id)
-    if conversation is None:
-        runs = await _concierge_runs_for_visitor(
-            site.pocket_id, customer_ref, workspace_id, limit=1
-        )
-        if not runs:
-            raise HTTPException(404, "conversation_not_found")
-        conversation = await store.ensure_conversation(widget.id, customer_ref, workspace_id)
+    conversation = await _resolve_owner_conversation(
+        store, site, widget, customer_ref, workspace_id, req.conversation_id or ""
+    )
 
     message = await store.add_owner_message(
         widget.id,
         customer_ref,
         text,
+        # The line is said IN a conversation (2026-08-19). Without this it was
+        # said to the VISITOR, and surfaced in every thread they owned — including
+        # ones they started after it was written.
+        conversation_id=conversation.id,
         role=OwnerMessageRole.OWNER,
         author=getattr(user, "id", "") or "",
         workspace_id=workspace_id,
@@ -2372,7 +2387,11 @@ async def post_site_conversation_reply(
         fields["snooze_until"] = ""
     before = conversation
     updated = await store.update_conversation(
-        widget.id, customer_ref, workspace_id=workspace_id, **fields
+        widget.id,
+        customer_ref,
+        workspace_id=workspace_id,
+        conversation_id=conversation.id,
+        **fields,
     )
     conversation = updated or conversation
     # AL-2 — typing IS taking over, so this is where ``paw.conversation.takeover``
@@ -2498,6 +2517,9 @@ async def get_agent_conversations(
 async def get_site_conversation_transcript(
     site_id: str,
     customer_ref: str,
+    conversation_id: str = Query(
+        "", description="Read ONE conversation, not the visitor's whole history"
+    ),
     workspace_id: str = Depends(current_workspace_id),
 ) -> ConversationTranscriptResponse:
     """One visitor's concierge transcript on a site, oldest-first (D2 drill-in).
@@ -2523,7 +2545,13 @@ async def get_site_conversation_transcript(
     # No concierge widget on this site → no conversation exists to read.
     if widget is None:
         raise HTTPException(404, "conversation_not_found")
-    messages = await _load_transcript(site.pocket_id, customer_ref, workspace_id, widget=widget)
+    messages = await _load_transcript(
+        site.pocket_id,
+        customer_ref,
+        workspace_id,
+        widget=widget,
+        conversation_id=conversation_id,
+    )
     if messages is None:
         # No concierge run for this (pocket, customer_ref) — the ref has no
         # conversation on this site's widget.
@@ -2721,6 +2749,51 @@ async def get_site_preview_frame(
 # --- D2 aggregation data-source helpers -------------------------------------
 
 
+async def _resolve_owner_conversation(
+    store: Any,
+    site: Any,
+    widget: Any,
+    customer_ref: str,
+    workspace_id: str,
+    conversation_id: str = "",
+) -> Any:
+    """The conversation an owner's write addresses. Raises 404 if there isn't one.
+
+    ONE resolver for the PATCH and the reply (2026-08-19), because they were
+    resolving separately and both resolved to the visitor's ACTIVE row — so an
+    owner acting on the thread they were reading silently acted on a different
+    one the moment the visitor started a new conversation.
+
+    With ``conversation_id`` the named row must belong to this widget AND this
+    visitor; a mismatch is a 404 rather than a silent fallback. The fallback is
+    right on the VISITOR path (telling an anonymous caller that an id was real is
+    the only thing a refusal there would leak), and wrong here: this caller is
+    authenticated and already workspace-scoped, so answering their explicit
+    address with a different conversation's data is a correctness bug, not
+    defence.
+
+    Without it, the visitor's conversation in progress — the pre-identity
+    behaviour, kept so a cached dashboard bundle keeps working. LAZY ROW
+    CREATION is preserved on that path only: a conversation that predates the
+    state table is minted on first touch rather than 404ing the owner's first
+    snooze.
+    """
+    if conversation_id:
+        named = await store.get_conversation_by_id(conversation_id, workspace_id=workspace_id)
+        if named is None or named.widget_id != widget.id or named.customer_ref != customer_ref:
+            raise HTTPException(404, "conversation_not_found")
+        return named
+    conversation = await store.get_conversation(widget.id, customer_ref, workspace_id=workspace_id)
+    if conversation is None:
+        runs = await _concierge_runs_for_visitor(
+            site.pocket_id, customer_ref, workspace_id, limit=1
+        )
+        if not runs:
+            raise HTTPException(404, "conversation_not_found")
+        conversation = await store.ensure_conversation(widget.id, customer_ref, workspace_id)
+    return conversation
+
+
 def _validated_conversation_fields(req: ConversationPatchRequest, author: str) -> dict[str, Any]:
     """Turn a validated PATCH body into the store's keyword fields.
 
@@ -2841,17 +2914,49 @@ def _display_name(contact_email: str, customer_ref: str) -> str:
     return f"visitor-{customer_ref[:_DISPLAY_REF_CHARS]}" if customer_ref else "visitor"
 
 
+def _conversation_of_run(run: Any, pocket_id: str, widget: PawBarWidget | None) -> str:
+    """The conversation token encoded in a run's ``session_key``.
+
+    The key is ``cloud:concierge:{pocket}:{conversation}:{agent}``. Before
+    conversation identity the middle slot held the VISITOR's handle, so this
+    returns whatever is there and the caller decides what it is by looking for a
+    matching conversation row — a token that resolves to no row is a legacy run,
+    not an error. Parsed by stripping the known prefix and the last segment
+    rather than splitting on ``:``, because a pocket id is not guaranteed to be
+    colon-free and a naive split would mis-slice it.
+
+    Returns ``""`` for a key this function does not recognize, which groups that
+    run under its visitor exactly as the pre-identity code did.
+    """
+    key = getattr(run, "session_key", "") or ""
+    prefix = f"cloud:concierge:{pocket_id}:"
+    if not pocket_id or not key.startswith(prefix):
+        return ""
+    rest = key[len(prefix) :]
+    agent_id = getattr(widget, "agent_id", "") if widget is not None else ""
+    if agent_id and rest.endswith(f":{agent_id}"):
+        return rest[: -len(agent_id) - 1]
+    head, _, _tail = rest.rpartition(":")
+    return head
+
+
 async def _conversation_side_data(
     widget: PawBarWidget | None, workspace_id: str, refs: list[str]
 ) -> tuple[dict[str, Any], set[str], dict[str, str]]:
     """Load the per-visitor extras a conversation list row needs.
 
-    Returns ``(state rows by ref, refs with a pending action, contact email by
-    ref)``. Two bounded store reads for the WHOLE page, never one per row:
+    Returns ``(state rows by CONVERSATION ID, refs with a pending action, contact
+    email by ref)``. Two bounded store reads for the WHOLE page, never one per
+    row:
 
       * the ``paw_bar_conversations`` rows for exactly the refs on this page, and
       * this widget's decision rows, which answer both "is something waiting on
         the owner" and "did this visitor ever leave an email".
+
+    The state map is keyed by conversation id (2026-08-19). It was keyed by
+    ``customer_ref``, which silently kept ONE row per visitor — the same collapse
+    the list itself was making, one layer down, so fixing only the list would
+    have joined every one of a visitor's conversations to the same state.
 
     The email is READ from the decision row rather than copied onto the
     conversation row — it stays in the one place the PII invariant names, and this
@@ -2863,9 +2968,16 @@ async def _conversation_side_data(
         return states, set(), {}
     try:
         rows = await _store().list_conversations(
-            widget.id, workspace_id=workspace_id, limit=len(refs), customer_refs=refs
+            widget.id,
+            workspace_id=workspace_id,
+            # A visitor may hold several conversations, so the page's row budget
+            # is no longer one-per-ref. Bounded by the same scan cap the run
+            # window uses rather than by len(refs), which would truncate a busy
+            # visitor's threads out of their own state join.
+            limit=_CONVERSATION_SCAN_CAP,
+            customer_refs=refs,
         )
-        states = {row.customer_ref: row for row in rows}
+        states = {row.id: row for row in rows}
     except Exception:  # noqa: BLE001 — queue metadata is additive, never fatal
         logger.warning("conversation state read failed for widget %s", widget.id, exc_info=True)
     pending, emails = await _decision_side_data(widget, refs)
@@ -2966,15 +3078,53 @@ async def _list_conversations(
         logger.warning("conversations read failed for pocket %s", pocket_id, exc_info=True)
         return ConversationsResponse(items=[], cursor=None, unsupported=False)
 
-    # Dedupe the scanned window first (most-recent run per customer wins), THEN
-    # join and filter, THEN cut to `limit` — cutting first would hide a matching
-    # conversation behind a page of non-matching ones.
-    candidates: list[tuple[str, str, str]] = []
-    seen: set[str] = set()
+    # Dedupe the scanned window first (most-recent run per CONVERSATION wins),
+    # THEN join and filter, THEN cut to `limit` — cutting first would hide a
+    # matching conversation behind a page of non-matching ones.
+    #
+    # 2026-08-19: the dedupe key is the conversation, not the visitor. It was
+    # ``run.user_id``, which was right exactly while a visitor could hold one
+    # conversation; once they could hold several it silently discarded all but
+    # their most recent, and the owner's inbox showed one row for a person who
+    # had asked four separate questions. The other three were not collapsed
+    # behind a disclosure — they were absent, with no way to reach them.
+    parsed: list[tuple[str, str, Any]] = []  # (customer_ref, conversation token, run)
+    refs: list[str] = []
     for run in runs:
-        if run.user_id in seen:
+        if run.user_id not in refs:
+            refs.append(run.user_id)
+        parsed.append((run.user_id, _conversation_of_run(run, pocket_id, widget), run))
+
+    states, pending, emails = await _conversation_side_data(widget, workspace_id, refs)
+
+    # A token is a real conversation id only if a row confirms it. Anything else
+    # is a run from before conversations had identity, whose session_key carries
+    # the visitor's handle in that slot — those keep the old behaviour and group
+    # per visitor, resolving to that visitor's conversation in progress.
+    active_by_ref = {
+        row.customer_ref: row for row in states.values() if getattr(row, "active", True)
+    }
+
+    candidates: list[tuple[str, str, str, str]] = []  # ref, conversation_id, when, preview
+    seen: set[str] = set()
+    for ref, token, run in parsed:
+        if states.get(token) is not None:
+            conversation_id = token
+        else:
+            legacy = active_by_ref.get(ref)
+            conversation_id = legacy.id if legacy is not None else ""
+        # Group by the CONVERSATION we resolved to, falling back to the visitor
+        # only when there is no conversation to name. Grouping by the raw token
+        # instead splits one thread in two on the shape this deploy creates: a
+        # visitor mid-conversation at the migration has runs of both spellings —
+        # older ones carrying their handle in the session_key's conversation
+        # slot, newer ones carrying the real id — and both resolve HERE to the
+        # same row. Two rows, one id, and a client keying its list on the id has
+        # duplicate keys.
+        group = conversation_id or ref
+        if group in seen:
             continue
-        seen.add(run.user_id)
+        seen.add(group)
         when = run.ended_at or run.createdAt
         # Prefer the agent's reply as the row preview (unchanged). Fall back to the
         # visitor's own question when there is no reply — a run that failed or was
@@ -2982,16 +3132,17 @@ async def _list_conversations(
         # question at least says what the visitor wanted.
         preview = (run.partial_text or "") or (getattr(run, "user_text", "") or "")
         candidates.append(
-            (run.user_id, when.isoformat() if when else "", preview[:_CONVERSATION_PREVIEW_CHARS])
+            (
+                ref,
+                conversation_id,
+                when.isoformat() if when else "",
+                preview[:_CONVERSATION_PREVIEW_CHARS],
+            )
         )
 
-    states, pending, emails = await _conversation_side_data(
-        widget, workspace_id, [ref for ref, _, _ in candidates]
-    )
-
     items: list[ConversationItem] = []
-    for ref, last_message_at, preview in candidates:
-        row = states.get(ref)
+    for ref, conversation_id, last_message_at, preview in candidates:
+        row = states.get(conversation_id)
         row_state = row.state.value if row is not None else "open"
         if state and row_state != state:
             continue
@@ -2999,6 +3150,7 @@ async def _list_conversations(
         items.append(
             ConversationItem(
                 customer_ref=ref,
+                conversation_id=conversation_id,
                 last_message_at=last_message_at,
                 preview=preview,
                 state=row_state,
@@ -3200,6 +3352,7 @@ async def _load_transcript(
     customer_ref: str,
     workspace_id: str,
     widget: PawBarWidget | None = None,
+    conversation_id: str = "",
 ) -> list[TranscriptMessage] | None:
     """Build one visitor's full conversation, oldest-first (D2 drill-in + slice 2).
 
@@ -3225,9 +3378,23 @@ async def _load_transcript(
 
     Returns ``None`` only when the ref has NOTHING here (the caller 404s) —
     distinct from an empty list, which means rows exist but none carried text.
+
+    ``conversation_id`` narrows BOTH sources to one thread (2026-08-19). Narrowing
+    only one would be worse than narrowing neither: the owner would read one
+    conversation's questions interleaved with every reply a human ever sent that
+    visitor, and the timestamps would make it look like a coherent exchange.
     """
+    session_key = (
+        f"cloud:concierge:{pocket_id}:{conversation_id}:{getattr(widget, 'agent_id', '')}"
+        if conversation_id and widget is not None
+        else ""
+    )
     runs = await _concierge_runs_for_visitor(
-        pocket_id, customer_ref, workspace_id, limit=_TRANSCRIPT_CAP
+        pocket_id,
+        customer_ref,
+        workspace_id,
+        limit=_TRANSCRIPT_CAP,
+        session_key=session_key,
     )
 
     messages: list[TranscriptMessage] = []
@@ -3264,6 +3431,7 @@ async def _load_transcript(
                 customer_ref,
                 workspace_id=workspace_id,
                 limit=_TRANSCRIPT_CAP,
+                conversation_id=conversation_id or None,
             )
         except Exception:  # noqa: BLE001 — the run-derived half must still render
             logger.warning("owner message read failed for widget %s", widget.id, exc_info=True)
@@ -4673,6 +4841,7 @@ async def get_visitor_messages(
     request: Request,
     signed_key: str = Query("", description="The public Site.signed_key"),
     after: str = Query("", description="Only messages stamped strictly later"),
+    conversation_id: str = Query("", description="Only lines said in this conversation"),
 ) -> VisitorMessagesResponse:
     """Poll for owner/system messages on this visitor's thread.
 
@@ -4711,9 +4880,26 @@ async def get_visitor_messages(
     store = _store()
     try:
         await store.auto_resume_bot_if_idle(widget.id, customer_ref, ctx.workspace_id)
-        conversation = await store.get_conversation(
-            widget.id, customer_ref, workspace_id=ctx.workspace_id
-        )
+        # ``bot_paused`` belongs to the conversation on screen, not to the
+        # visitor's most recent one — otherwise a visitor reading an old thread a
+        # human had taken over is told the assistant is muted in the thread they
+        # are actually typing into. A named conversation must still be THEIRS;
+        # a stranger's id reads as no conversation rather than as its state.
+        conversation = None
+        if conversation_id:
+            named = await store.get_conversation_by_id(
+                conversation_id, workspace_id=ctx.workspace_id
+            )
+            if (
+                named is not None
+                and named.widget_id == widget.id
+                and named.customer_ref == customer_ref
+            ):
+                conversation = named
+        else:
+            conversation = await store.get_conversation(
+                widget.id, customer_ref, workspace_id=ctx.workspace_id
+            )
         messages = await store.list_owner_messages(
             widget.id,
             customer_ref,
@@ -4721,6 +4907,11 @@ async def get_visitor_messages(
             after=_normalized_after(after),
             roles=_PUBLIC_MESSAGE_ROLES,
             limit=_OWNER_POLL_CAP,
+            # Scoped to the thread on screen (2026-08-19). Omitted by a cached
+            # widget bundle, which then keeps the pre-identity behaviour of
+            # receiving every owner line on the visitor's whole thread — degraded
+            # but never silent, which is the right way round for a poll.
+            conversation_id=conversation_id or None,
         )
     except Exception:  # noqa: BLE001 — a poll that 500s stalls the visitor's thread
         logger.warning("visitor message poll failed for widget %s", widget.id, exc_info=True)

--- a/src/pocketpaw/paw_bar/models.py
+++ b/src/pocketpaw/paw_bar/models.py
@@ -654,6 +654,11 @@ class OwnerMessage(BaseModel):
     id: str = Field(default_factory=_gen_owner_message_id)
     widget_id: str
     customer_ref: str
+    #: The conversation this line was said in (2026-08-19). Empty only for lines
+    #: written before the column existed and never backfilled — see the store's
+    #: migration. It is what stops an owner's reply appearing in a thread it does
+    #: not belong to.
+    conversation_id: str = ""
     workspace_id: str = ""
     role: OwnerMessageRole = OwnerMessageRole.OWNER
     content: str = ""

--- a/src/pocketpaw/paw_bar/store.py
+++ b/src/pocketpaw/paw_bar/store.py
@@ -281,12 +281,24 @@ CREATE TABLE IF NOT EXISTS paw_bar_conversations (
 -- that arrived while the bot was muted (no run was dispatched, by design). Kept
 -- out of the run collection deliberately: the metering sweeper bills every
 -- unbilled terminal run, so an owner reply shaped as one would charge the owner
--- for typing. Same (widget_id, customer_ref) identity as the conversation row,
--- so the transcript reader merges the two sources on one key.
+-- for typing.
+--
+-- 2026-08-19 (owner-side conversation identity): a line carries the
+-- ``conversation_id`` it was said IN. It used to carry only (widget, visitor),
+-- which was correct exactly while a visitor could hold one conversation. Once
+-- they could hold several, an owner's reply had nowhere to say WHICH — so it was
+-- appended to the visitor and surfaced in every thread they owned, including
+-- ones started after it was written. An owner answering yesterday's question in
+-- front of today's is the failure this column removes.
+--
+-- Empty means "said before this column existed". Deployed rows are backfilled to
+-- the visitor's active conversation on migration (there was only one, which is
+-- the whole premise), so an empty value should not survive a migrated DB.
 CREATE TABLE IF NOT EXISTS paw_bar_owner_messages (
     id TEXT PRIMARY KEY,
     widget_id TEXT NOT NULL,
     customer_ref TEXT NOT NULL,
+    conversation_id TEXT DEFAULT '',
     workspace_id TEXT DEFAULT '',
     role TEXT DEFAULT 'owner',
     content TEXT DEFAULT '',
@@ -320,6 +332,9 @@ CREATE INDEX IF NOT EXISTS idx_pp_conversations_visitor
     ON paw_bar_conversations(widget_id, customer_ref, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_pp_owner_messages_thread
     ON paw_bar_owner_messages(widget_id, customer_ref, created_at);
+-- The visitor's poll, scoped to the conversation on screen (2026-08-19).
+CREATE INDEX IF NOT EXISTS idx_pp_owner_messages_conversation
+    ON paw_bar_owner_messages(conversation_id, created_at);
 """
 
 # The paw_bar_conversations columns, with the exact declaration each ALTER must
@@ -354,6 +369,9 @@ _CONVERSATION_COLUMNS: dict[str, str] = {
 # The paw_bar_owner_messages columns, same contract as the conversation map above:
 # keep in lockstep with the CREATE TABLE, primary key excluded.
 _OWNER_MESSAGE_COLUMNS: dict[str, str] = {
+    # 2026-08-19 (owner-side conversation identity). The first column here to
+    # post-date a deployed table, so this is the ALTER path's first real use.
+    "conversation_id": "TEXT DEFAULT ''",
     "workspace_id": "TEXT DEFAULT ''",
     "role": "TEXT DEFAULT 'owner'",
     "content": "TEXT DEFAULT ''",
@@ -555,9 +573,36 @@ class PawBarStore:
         # first column that post-dates a deployed one.
         if "paw_bar_owner_messages" in existing:
             cols = await _columns("paw_bar_owner_messages")
-            for name, decl in _OWNER_MESSAGE_COLUMNS.items():
-                if name not in cols:
-                    await db.execute(f"ALTER TABLE paw_bar_owner_messages ADD COLUMN {name} {decl}")
+            added = [name for name in _OWNER_MESSAGE_COLUMNS if name not in cols]
+            for name in added:
+                await db.execute(
+                    f"ALTER TABLE paw_bar_owner_messages ADD COLUMN"
+                    f" {name} {_OWNER_MESSAGE_COLUMNS[name]}"
+                )
+            # 2026-08-19 (owner-side conversation identity): backfill the lines a
+            # deployed DB already holds. Every one was written while a visitor
+            # could hold exactly ONE conversation, so the thread it was said in is
+            # unambiguous — it is that visitor's active row. Done once, at the
+            # moment the column appears, rather than left empty and papered over
+            # by a fallback in every reader: a nullable "means the old thing" is
+            # how the pair-keyed bug survived this long.
+            if "conversation_id" in added and "paw_bar_conversations" in existing:
+                await db.execute(
+                    "UPDATE paw_bar_owner_messages SET conversation_id = ("
+                    "  SELECT c.id FROM paw_bar_conversations c"
+                    "   WHERE c.widget_id = paw_bar_owner_messages.widget_id"
+                    "     AND c.customer_ref = paw_bar_owner_messages.customer_ref"
+                    "     AND c.active = 1"
+                    "   LIMIT 1"
+                    ") WHERE conversation_id = '' OR conversation_id IS NULL"
+                )
+                # A line whose visitor has no conversation row at all (the thread
+                # predates the conversations table) keeps '' rather than NULL, so
+                # every reader compares against one empty value, not two.
+                await db.execute(
+                    "UPDATE paw_bar_owner_messages SET conversation_id = ''"
+                    " WHERE conversation_id IS NULL"
+                )
 
     @staticmethod
     async def _drop_legacy_conversation_pair_unique(db: aiosqlite.Connection) -> None:
@@ -1479,6 +1524,8 @@ class PawBarStore:
         widget_id: str,
         customer_ref: str,
         workspace_id: str | None = None,
+        *,
+        conversation_id: str = "",
         **fields: Any,
     ) -> Conversation | None:
         """Patch a conversation's operator fields. Returns ``None`` if it has no row.
@@ -1492,8 +1539,28 @@ class PawBarStore:
 
         The lookup and the UPDATE are both workspace-scoped, so a cross-tenant
         (widget, customer) pair writes nothing and reads back ``None``.
+
+        ``conversation_id`` targets ONE conversation, active or retired
+        (2026-08-19). Without it the write lands on the visitor's active row,
+        which is right for a visitor-driven touch and wrong for an owner: an
+        owner filing or taking over the thread they are READING must reach that
+        thread, not whichever one the visitor has since moved on to. The named
+        row is checked against ``(widget_id, customer_ref)`` before anything is
+        written, so an id belonging to another visitor or another site addresses
+        nothing rather than being taken on trust.
         """
-        existing = await self.get_conversation(widget_id, customer_ref, workspace_id=workspace_id)
+        if conversation_id:
+            existing = await self.get_conversation_by_id(conversation_id, workspace_id=workspace_id)
+            if (
+                existing is None
+                or existing.widget_id != widget_id
+                or existing.customer_ref != customer_ref
+            ):
+                return None
+        else:
+            existing = await self.get_conversation(
+                widget_id, customer_ref, workspace_id=workspace_id
+            )
         if existing is None:
             return None
         allowed = {
@@ -1542,15 +1609,22 @@ class PawBarStore:
             return existing
         assignments.append("updated_at = ?")
         values.append(datetime.now().isoformat())
-        # ``active = 1`` is load-bearing since a visitor may own several
+        # Address ONE row, always. With an explicit id that is the row the caller
+        # named (already proven to belong to this visitor and widget above);
+        # without one it is the visitor's active conversation. ``active = 1`` is
+        # load-bearing in that second form since a visitor may own several
         # conversations (2026-08-19): without it, one owner action — closing,
         # snoozing, tagging, adding a note — would rewrite that visitor's ENTIRE
         # history in one statement.
-        sql = (
-            f"UPDATE paw_bar_conversations SET {', '.join(assignments)}"
-            " WHERE widget_id = ? AND customer_ref = ? AND active = 1"
-        )
-        values.extend([widget_id, customer_ref])
+        if conversation_id:
+            sql = f"UPDATE paw_bar_conversations SET {', '.join(assignments)} WHERE id = ?"
+            values.append(existing.id)
+        else:
+            sql = (
+                f"UPDATE paw_bar_conversations SET {', '.join(assignments)}"
+                " WHERE widget_id = ? AND customer_ref = ? AND active = 1"
+            )
+            values.extend([widget_id, customer_ref])
         ws_cond, ws_params = _conversation_workspace_scope(workspace_id)
         if ws_cond:
             sql += f" AND {ws_cond}"
@@ -1559,6 +1633,11 @@ class PawBarStore:
         async with self._conn() as db:
             await db.execute(sql, values)
             await db.commit()
+        # Read back the row that was WRITTEN. Reading the active one here would
+        # hand a caller who patched a retired conversation somebody else's state
+        # and report it as the result of their own edit.
+        if conversation_id:
+            return await self.get_conversation_by_id(existing.id, workspace_id=workspace_id)
         return await self.get_conversation(widget_id, customer_ref, workspace_id=workspace_id)
 
     async def conversation_counts(
@@ -1658,6 +1737,7 @@ class PawBarStore:
         customer_ref: str,
         content: str,
         *,
+        conversation_id: str = "",
         role: OwnerMessageRole | str = OwnerMessageRole.OWNER,
         author: str = "",
         workspace_id: str = "",
@@ -1669,12 +1749,18 @@ class PawBarStore:
         read it; a line that could be edited afterwards is not a transcript.
         ``role`` is normalized through :class:`OwnerMessageRole`, so an unknown
         value raises here rather than becoming a row no reader can classify.
+
+        ``conversation_id`` names the thread the line was said in (2026-08-19).
+        It is optional so the pre-identity callers keep compiling, but every
+        caller in this codebase passes it — an empty value now means only
+        "written before the column existed".
         """
         await self._ensure_schema()
         message = OwnerMessage(
             id=_gen_owner_message_id(),
             widget_id=widget_id,
             customer_ref=customer_ref,
+            conversation_id=conversation_id,
             workspace_id=workspace_id,
             role=OwnerMessageRole(role),
             content=content,
@@ -1684,12 +1770,14 @@ class PawBarStore:
         async with self._conn() as db:
             await db.execute(
                 "INSERT INTO paw_bar_owner_messages"
-                " (id, widget_id, customer_ref, workspace_id, role, content, author, created_at)"
-                " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                " (id, widget_id, customer_ref, conversation_id, workspace_id,"
+                "  role, content, author, created_at)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     message.id,
                     message.widget_id,
                     message.customer_ref,
+                    message.conversation_id,
                     message.workspace_id,
                     message.role.value,
                     message.content,
@@ -1708,6 +1796,7 @@ class PawBarStore:
         after: str = "",
         roles: list[str] | None = None,
         limit: int = 50,
+        conversation_id: str | None = None,
     ) -> list[OwnerMessage]:
         """One thread's out-of-band lines, OLDEST-first.
 
@@ -1722,9 +1811,20 @@ class PawBarStore:
         The cap keeps the LATEST ``limit`` lines: a long-running thread's newest
         messages are the ones a poll is missing. They are then reversed so the
         result reads oldest-first like every other transcript in this codebase.
+
+        ``conversation_id`` narrows to ONE thread (2026-08-19). It is STRICT: a
+        line said in another conversation never comes back, and neither does an
+        unmigrated line carrying no conversation. Both were tempting to include —
+        "show the owner everything" — and both are the bug this column exists to
+        remove, which is a reply appearing in a conversation it was not said in.
+        Omit the argument to read the visitor's whole thread, which is what the
+        owner's per-visitor history view still wants.
         """
         conditions = "widget_id = ? AND customer_ref = ?"
         params: list[Any] = [widget_id, customer_ref]
+        if conversation_id is not None:
+            conditions += " AND conversation_id = ?"
+            params.append(conversation_id)
         ws_cond, ws_params = _conversation_workspace_scope(workspace_id)
         if ws_cond:
             conditions += f" AND {ws_cond}"
@@ -1930,6 +2030,7 @@ class PawBarStore:
             id=row["id"],
             widget_id=row["widget_id"],
             customer_ref=row["customer_ref"],
+            conversation_id=row["conversation_id"] or "",
             workspace_id=row["workspace_id"] or "",
             role=role,
             content=row["content"] or "",

--- a/tests/cloud/test_paw_bar_owner_conversation_identity.py
+++ b/tests/cloud/test_paw_bar_owner_conversation_identity.py
@@ -1,0 +1,420 @@
+# tests/cloud/test_paw_bar_owner_conversation_identity.py — the OWNER half of
+# conversation identity.
+#
+# Created 2026-08-19 as the reproduction for the second half of the reported
+# session bug. The VISITOR half shipped (see
+# test_paw_bar_conversation_identity.py): a visitor may now hold several
+# conversations, each with its own id, its own ``session_key`` and its own
+# history replay. The owner half never moved. Every owner-facing seam still keys
+# on ``customer_ref`` — the VISITOR — so the product disagrees with itself about
+# what a conversation is:
+#
+#   * ``_list_conversations`` dedupes the run scan by ``run.user_id``, keeping
+#     "the most-recent run per customer". A visitor with four conversations is
+#     ONE row in the owner's inbox, showing only their latest sentence. The other
+#     three are unreachable — not filtered, not collapsed behind a disclosure:
+#     absent.
+#   * ``paw_bar_owner_messages`` has no ``conversation_id`` column, so an owner's
+#     reply cannot be addressed to a conversation even in principle. It is
+#     appended to the visitor.
+#   * ``POST …/conversations/{customer_ref}/reply`` and
+#     ``PATCH …/conversations/{customer_ref}`` both resolve through
+#     ``get_conversation(widget, ref)``, which returns the ACTIVE row. An owner
+#     answering the question a visitor asked yesterday writes into whatever the
+#     visitor happens to be saying today.
+#   * ``GET /paw-bar/messages/{widget}/{ref}`` serves every owner line the
+#     visitor has ever been sent, into whichever conversation is on screen.
+#
+# The last two are the ones that hurt: taking over a conversation mutes the bot
+# for that visitor EVERYWHERE, and a reply meant for one thread surfaces in
+# another. That is a support tool answering the wrong customer question in front
+# of the customer.
+#
+# Every test here fails before the owner-side fix and passes after it.
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from beanie import PydanticObjectId
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from pocketpaw.paw_bar.models import PawBarBlock, PawBarSpec, PawBarWidget
+from pocketpaw.paw_bar.store import PawBarStore
+
+_KEY = "site_key_" + "a" * 24
+_ORIGIN = "https://brewco.com"
+_REF = "cust-0001"
+_USER_ID = PydanticObjectId()
+
+
+# --------------------------------------------------------------------------- #
+# Builders — same shapes as test_paw_bar_conversations.py
+# --------------------------------------------------------------------------- #
+
+
+async def _site(**ov: Any):
+    from pocketpaw_ee.cloud.models.site import Site
+
+    d = dict(
+        workspace="ws-1",
+        pocket_id="pocket-1",
+        owner="user:maya",
+        name="Brew & Co",
+        script_name="",
+        signed_key=_KEY,
+        allowed_origins=["brewco.com"],
+    )
+    d.update(ov)
+    s = Site(**d)
+    await s.insert()
+    return s
+
+
+def _widget(**ov: Any) -> PawBarWidget:
+    d = dict(
+        pocket_id="pocket-1",
+        owner="user:maya",
+        name="Brew & Co",
+        spec=PawBarSpec(
+            widget_id="pp_seed",
+            pocket_id="pocket-1",
+            blocks=[PawBarBlock(type="text", content="Hi")],
+        ),
+        allowed_domains=["brewco.com"],
+        agent_id="agent-xyz",
+        workspace_id="ws-1",
+    )
+    d.update(ov)
+    return PawBarWidget(**d)
+
+
+def _skey(conversation_id: str) -> str:
+    """The run session_key the chat endpoint builds for a conversation."""
+    return f"cloud:concierge:pocket-1:{conversation_id}:agent-xyz"
+
+
+async def _mk_run(**ov: Any):
+    from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
+
+    d = dict(
+        run_id=uuid.uuid4().hex,
+        workspace="ws-1",
+        context_type="concierge",
+        scope_id="pocket-1",
+        session_key=_skey(_REF),
+        user_id=_REF,
+        agent_id="agent-xyz",
+        client_message_id=uuid.uuid4().hex,
+        user_message_id="",
+        status="completed",
+        partial_text="We open at 8.",
+    )
+    d.update(ov)
+    doc = ChatRunDoc(**d)
+    await doc.insert()
+    return doc
+
+
+def _fake_user(role: str, workspace_id: str = "ws-1") -> SimpleNamespace:
+    return SimpleNamespace(
+        id=_USER_ID,
+        active_workspace=workspace_id,
+        workspaces=[SimpleNamespace(workspace=workspace_id, role=role)],
+    )
+
+
+@pytest_asyncio.fixture
+async def store(tmp_path):
+    return PawBarStore(tmp_path / "owner-conv.db")
+
+
+@pytest_asyncio.fixture
+async def client(mongo_db, store, monkeypatch):
+    """ADMIN client — the owner's inbox."""
+    from pocketpaw_ee.cloud._core.deps import current_workspace_id
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.cloud.auth import current_active_user
+    from pocketpaw_ee.paw_bar.router import router
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(router)
+    app.dependency_overrides[current_active_user] = lambda: _fake_user("admin")
+    app.dependency_overrides[current_workspace_id] = lambda: "ws-1"
+    monkeypatch.setattr("pocketpaw_ee.paw_bar.router._store", lambda: store)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        yield c, store
+
+
+@pytest_asyncio.fixture
+async def public(mongo_db, store, monkeypatch):
+    """PUBLIC client — the visitor's own poll."""
+    from pocketpaw_ee.cloud._core.http import add_error_handler
+    from pocketpaw_ee.paw_bar.router import router
+
+    app = FastAPI()
+    add_error_handler(app)
+    app.include_router(router)
+    monkeypatch.setattr("pocketpaw_ee.paw_bar.router._store", lambda: store)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        yield c, store
+
+
+async def _two_threads(store):
+    """One visitor, two conversations. Store-only — no run docs, so this is
+    usable without Beanie.
+
+    ``retired`` is the older one the visitor has moved on from; ``current`` is
+    the one in progress. The owner must be able to address either.
+    """
+    widget = await store.create_widget(_widget())
+    retired = await store.open_conversation(widget.id, _REF, workspace_id="ws-1")
+    current = await store.open_conversation(widget.id, _REF, workspace_id="ws-1")
+    return widget, retired, current
+
+
+async def _two_conversations(store):
+    """``_two_threads`` plus a concierge turn in each, so the run-backed inbox
+    read has something to list. Needs Beanie (the ``mongo_db`` fixture)."""
+    widget, retired, current = await _two_threads(store)
+    await _mk_run(session_key=_skey(retired.id), partial_text="We open at 8.")
+    await _mk_run(session_key=_skey(current.id), partial_text="Yes, we ship to Berlin.")
+    return widget, retired, current
+
+
+# --------------------------------------------------------------------------- #
+# Layer 1 — the store: an owner line belongs to a CONVERSATION
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_an_owner_reply_belongs_to_one_conversation(store):
+    """``paw_bar_owner_messages`` has no conversation column, so today an owner
+    reply is addressed to the visitor and appears in every thread they own."""
+    widget, retired, current = await _two_threads(store)
+
+    await store.add_owner_message(
+        widget.id,
+        _REF,
+        "Sorry for the wait — 8am, yes.",
+        conversation_id=retired.id,
+        workspace_id="ws-1",
+    )
+
+    in_retired = await store.list_owner_messages(
+        widget.id, _REF, workspace_id="ws-1", conversation_id=retired.id
+    )
+    assert [m.content for m in in_retired] == ["Sorry for the wait — 8am, yes."]
+    # The conversation the visitor is actually looking at must not show it.
+    in_current = await store.list_owner_messages(
+        widget.id, _REF, workspace_id="ws-1", conversation_id=current.id
+    )
+    assert in_current == []
+
+
+@pytest.mark.asyncio
+async def test_a_legacy_owner_line_still_reads_on_the_visitors_thread(store):
+    """Backfill-free: lines written before the column existed carry no
+    conversation, and must stay readable rather than vanishing from history."""
+    widget, _retired, _current = await _two_threads(store)
+    await store.add_owner_message(widget.id, _REF, "From before", workspace_id="ws-1")
+
+    unscoped = await store.list_owner_messages(widget.id, _REF, workspace_id="ws-1")
+    assert [m.content for m in unscoped] == ["From before"]
+
+
+# --------------------------------------------------------------------------- #
+# Layer 2 — the inbox lists CONVERSATIONS
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_the_inbox_lists_each_conversation_not_each_visitor(client):
+    """The reported bug, at the owner's screen: a visitor's several
+    conversations are deduped into one row keyed on their handle."""
+    c, store = client
+    site = await _site()
+    _w, retired, current = await _two_conversations(store)
+
+    body = (await c.get(f"/paw-bar/admin/site/{site.id}/conversations")).json()
+
+    assert len(body["items"]) == 2
+    assert {i["conversation_id"] for i in body["items"]} == {retired.id, current.id}
+    # Each row shows its OWN last sentence, not the visitor's latest overall.
+    previews = {i["conversation_id"]: i["preview"] for i in body["items"]}
+    assert previews[retired.id] == "We open at 8."
+    assert previews[current.id] == "Yes, we ship to Berlin."
+    # The visitor is still named on every row — one person, several threads.
+    assert {i["customer_ref"] for i in body["items"]} == {_REF}
+
+
+@pytest.mark.asyncio
+async def test_a_conversation_spanning_the_migration_is_ONE_row(client):
+    """The common shape on the day this deploys, not an exotic edge.
+
+    A visitor mid-thread when conversation identity shipped has runs of BOTH
+    spellings on the SAME conversation: the older ones carry their handle in the
+    session_key's conversation slot, the newer ones carry the real id. Grouped by
+    those raw tokens they are two rows — and both resolve to the same
+    conversation, so the pair share an id. The owner sees the thread twice, and
+    a client keying its list on conversation_id has duplicate keys.
+    """
+    c, store = client
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    conversation = await store.open_conversation(widget.id, _REF, workspace_id="ws-1")
+    # Pre-identity: the visitor's handle sat in the conversation slot.
+    await _mk_run(session_key=_skey(_REF), partial_text="We open at 8.")
+    # Post-identity: the same thread, now carrying its real id.
+    await _mk_run(session_key=_skey(conversation.id), partial_text="Yes, we ship to Berlin.")
+
+    body = (await c.get(f"/paw-bar/admin/site/{site.id}/conversations")).json()
+
+    assert len(body["items"]) == 1
+    assert body["items"][0]["conversation_id"] == conversation.id
+    # Newest-first, so the row shows the latest thing said in it.
+    assert body["items"][0]["preview"] == "Yes, we ship to Berlin."
+
+
+# --------------------------------------------------------------------------- #
+# Layer 3 — intervening addresses ONE conversation
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_an_owner_reply_lands_on_the_conversation_it_names(client):
+    """Answering yesterday's question must not appear inside today's thread."""
+    c, store = client
+    site = await _site()
+    widget, retired, current = await _two_threads(store)
+
+    res = await c.post(
+        f"/paw-bar/admin/site/{site.id}/conversations/{_REF}/reply",
+        json={"text": "Sorry for the wait — 8am, yes.", "conversation_id": retired.id},
+    )
+
+    assert res.status_code == 200
+    # The echoed row identifies itself by ``id`` — it always did; nothing ever
+    # read it as identity. The LIST row is the one that needed a new field, since
+    # it has no id of its own and ``customer_ref`` names the person, not the row.
+    assert res.json()["conversation"]["id"] == retired.id
+    # BOTH halves, deliberately. Asserting only that the reply is absent from the
+    # wrong thread passes when it is stored with NO conversation at all — which
+    # is precisely the pre-fix behaviour, and is how this test first escaped its
+    # own mutation (drop the reply's ``conversation_id=`` and watch it).
+    in_retired = await store.list_owner_messages(
+        widget.id, _REF, workspace_id="ws-1", conversation_id=retired.id
+    )
+    assert [m.content for m in in_retired] == ["Sorry for the wait — 8am, yes."]
+    in_current = await store.list_owner_messages(
+        widget.id, _REF, workspace_id="ws-1", conversation_id=current.id
+    )
+    assert in_current == []
+
+
+@pytest.mark.asyncio
+async def test_taking_over_one_conversation_leaves_the_others_bot_live(client):
+    """Muting the assistant is per-conversation. Today ``bot_paused`` is written
+    to the visitor's active row, so taking over ANY thread silences the bot on
+    the one the visitor is currently typing into."""
+    c, store = client
+    site = await _site()
+    _w, retired, current = await _two_conversations(store)
+
+    res = await c.patch(
+        f"/paw-bar/admin/site/{site.id}/conversations/{_REF}",
+        json={"bot_paused": True, "conversation_id": retired.id},
+    )
+
+    assert res.status_code == 200
+    assert (await store.get_conversation_by_id(retired.id)).bot_paused is True
+    assert (await store.get_conversation_by_id(current.id)).bot_paused is False
+
+
+@pytest.mark.asyncio
+async def test_the_transcript_reads_one_conversation_not_the_visitors_history(client):
+    """The drill-in the owner actually reads before replying.
+
+    Both sources have to narrow together. Narrowing only the runs would be worse
+    than narrowing neither: one conversation's questions would render interleaved
+    with every reply a human ever sent that visitor, and the timestamps would
+    make it look like a coherent exchange.
+    """
+    c, store = client
+    site = await _site()
+    widget, retired, current = await _two_conversations(store)
+    await store.add_owner_message(
+        widget.id, _REF, "About your 8am question", conversation_id=retired.id, workspace_id="ws-1"
+    )
+    await store.add_owner_message(
+        widget.id, _REF, "About Berlin", conversation_id=current.id, workspace_id="ws-1"
+    )
+
+    res = await c.get(
+        f"/paw-bar/admin/site/{site.id}/conversations/{_REF}",
+        params={"conversation_id": current.id},
+    )
+
+    assert res.status_code == 200
+    contents = [m["content"] for m in res.json()["messages"]]
+    assert "Yes, we ship to Berlin." in contents
+    assert "About Berlin" in contents
+    # Neither half of the other conversation crosses over.
+    assert "We open at 8." not in contents
+    assert "About your 8am question" not in contents
+
+
+@pytest.mark.asyncio
+async def test_an_owner_cannot_address_another_visitors_conversation(client):
+    """``conversation_id`` is an address the client supplies, so it is checked
+    against the visitor in the path rather than trusted. Otherwise the owner's
+    own inbox becomes a way to write into any conversation on the site by id."""
+    c, store = client
+    site = await _site()
+    widget = await store.create_widget(_widget())
+    mine = await store.open_conversation(widget.id, _REF, workspace_id="ws-1")
+    theirs = await store.open_conversation(widget.id, "cust-0002", workspace_id="ws-1")
+
+    res = await c.patch(
+        f"/paw-bar/admin/site/{site.id}/conversations/{_REF}",
+        json={"state": "closed", "conversation_id": theirs.id},
+    )
+
+    assert res.status_code == 404
+    assert (await store.get_conversation_by_id(theirs.id)).state.value == "open"
+    assert (await store.get_conversation_by_id(mine.id)).state.value == "open"
+
+
+# --------------------------------------------------------------------------- #
+# Layer 4 — the visitor's poll is scoped to the conversation on screen
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_the_visitor_poll_only_returns_this_conversations_lines(public):
+    """The delivery seam. Without it the owner-side fix is invisible: the widget
+    would still drop every owner line into whichever thread is open."""
+    c, store = public
+    await _site()
+    widget, retired, current = await _two_threads(store)
+    await store.add_owner_message(
+        widget.id, _REF, "About your 8am question", conversation_id=retired.id, workspace_id="ws-1"
+    )
+    await store.add_owner_message(
+        widget.id, _REF, "About Berlin", conversation_id=current.id, workspace_id="ws-1"
+    )
+
+    res = await c.get(
+        f"/paw-bar/messages/{widget.id}/{_REF}",
+        params={"signed_key": _KEY, "conversation_id": current.id},
+        headers={"Origin": _ORIGIN},
+    )
+
+    assert res.status_code == 200
+    assert [m["content"] for m in res.json()["messages"]] == ["About Berlin"]

--- a/tests/mutations/paw_bar_conversation_identity.json
+++ b/tests/mutations/paw_bar_conversation_identity.json
@@ -40,8 +40,8 @@
   {
     "label": "an owner action loses its active scope — closing one conversation closes the visitor's whole history",
     "file": "src/pocketpaw/paw_bar/store.py",
-    "find": "            \" WHERE widget_id = ? AND customer_ref = ? AND active = 1\"\n        )\n        values.extend([widget_id, customer_ref])",
-    "replace": "            \" WHERE widget_id = ? AND customer_ref = ?\"\n        )\n        values.extend([widget_id, customer_ref])",
+    "find": "                \" WHERE widget_id = ? AND customer_ref = ? AND active = 1\"\n            )\n            values.extend([widget_id, customer_ref])",
+    "replace": "                \" WHERE widget_id = ? AND customer_ref = ?\"\n            )\n            values.extend([widget_id, customer_ref])",
     "tests": [
       "tests/cloud/test_paw_bar_conversation_identity.py::test_owner_actions_touch_only_the_conversation_in_progress"
     ]

--- a/tests/mutations/paw_bar_owner_conversation_identity.json
+++ b/tests/mutations/paw_bar_owner_conversation_identity.json
@@ -1,0 +1,102 @@
+[
+  {
+    "label": "the inbox dedupes by visitor again — a visitor's several conversations collapse to one row",
+    "file": "ee/pocketpaw_ee/paw_bar/router.py",
+    "find": "        group = conversation_id or ref",
+    "replace": "        group = ref",
+    "tests": [
+      "tests/cloud/test_paw_bar_owner_conversation_identity.py::test_the_inbox_lists_each_conversation_not_each_visitor"
+    ]
+  },
+  {
+    "label": "the state join is keyed by visitor again — every conversation reads one row's state",
+    "file": "ee/pocketpaw_ee/paw_bar/router.py",
+    "find": "        states = {row.id: row for row in rows}",
+    "replace": "        states = {row.customer_ref: row for row in rows}",
+    "tests": [
+      "tests/cloud/test_paw_bar_owner_conversation_identity.py::test_the_inbox_lists_each_conversation_not_each_visitor"
+    ]
+  },
+  {
+    "label": "an owner reply is addressed to the visitor again — it surfaces in every thread they own",
+    "file": "ee/pocketpaw_ee/paw_bar/router.py",
+    "find": "        conversation_id=conversation.id,\n        role=OwnerMessageRole.OWNER,",
+    "replace": "        role=OwnerMessageRole.OWNER,",
+    "tests": [
+      "tests/cloud/test_paw_bar_owner_conversation_identity.py::test_an_owner_reply_lands_on_the_conversation_it_names"
+    ]
+  },
+  {
+    "label": "the owner's write resolves to the active row — taking over one thread mutes another",
+    "file": "src/pocketpaw/paw_bar/store.py",
+    "find": "        if conversation_id:\n            existing = await self.get_conversation_by_id(",
+    "replace": "        if False:\n            existing = await self.get_conversation_by_id(",
+    "tests": [
+      "tests/cloud/test_paw_bar_owner_conversation_identity.py::test_taking_over_one_conversation_leaves_the_others_bot_live"
+    ]
+  },
+  {
+    "label": "the UPDATE targets the active row rather than the named one",
+    "file": "src/pocketpaw/paw_bar/store.py",
+    "find": "        if conversation_id:\n            sql = f\"UPDATE paw_bar_conversations SET {', '.join(assignments)} WHERE id = ?\"\n            values.append(existing.id)",
+    "replace": "        if False:\n            sql = f\"UPDATE paw_bar_conversations SET {', '.join(assignments)} WHERE id = ?\"\n            values.append(existing.id)",
+    "tests": [
+      "tests/cloud/test_paw_bar_owner_conversation_identity.py::test_taking_over_one_conversation_leaves_the_others_bot_live"
+    ]
+  },
+  {
+    "label": "the owner-line read ignores the conversation — every thread shows every reply",
+    "file": "src/pocketpaw/paw_bar/store.py",
+    "find": "        if conversation_id is not None:\n            conditions += \" AND conversation_id = ?\"\n            params.append(conversation_id)",
+    "replace": "        if False:\n            conditions += \" AND conversation_id = ?\"\n            params.append(conversation_id)",
+    "tests": [
+      "tests/cloud/test_paw_bar_owner_conversation_identity.py::test_an_owner_reply_belongs_to_one_conversation",
+      "tests/cloud/test_paw_bar_owner_conversation_identity.py::test_the_visitor_poll_only_returns_this_conversations_lines"
+    ]
+  },
+  {
+    "label": "the visitor's poll stops naming its conversation — owner lines land in the wrong thread",
+    "file": "ee/pocketpaw_ee/paw_bar/router.py",
+    "find": "            # but never silent, which is the right way round for a poll.\n            conversation_id=conversation_id or None,",
+    "replace": "            # but never silent, which is the right way round for a poll.\n            conversation_id=None,",
+    "tests": [
+      "tests/cloud/test_paw_bar_owner_conversation_identity.py::test_the_visitor_poll_only_returns_this_conversations_lines"
+    ]
+  },
+  {
+    "label": "a named conversation is taken on trust — another visitor's thread is writable",
+    "file": "ee/pocketpaw_ee/paw_bar/router.py",
+    "find": "        if named is None or named.widget_id != widget.id or named.customer_ref != customer_ref:\n            raise HTTPException(404, \"conversation_not_found\")\n        return named",
+    "replace": "        if named is None:\n            raise HTTPException(404, \"conversation_not_found\")\n        return named",
+    "tests": [
+      "tests/cloud/test_paw_bar_owner_conversation_identity.py::test_an_owner_cannot_address_another_visitors_conversation"
+    ]
+  },
+  {
+    "label": "the transcript's runs stop scoping — one thread's questions merge with another's",
+    "file": "ee/pocketpaw_ee/paw_bar/router.py",
+    "find": "        limit=_TRANSCRIPT_CAP,\n        session_key=session_key,\n    )",
+    "replace": "        limit=_TRANSCRIPT_CAP,\n        session_key=\"\",\n    )",
+    "tests": [
+      "tests/cloud/test_paw_bar_owner_conversation_identity.py::test_the_transcript_reads_one_conversation_not_the_visitors_history"
+    ]
+  },
+  {
+    "label": "the transcript's owner lines stop scoping — every reply shows in every thread",
+    "file": "ee/pocketpaw_ee/paw_bar/router.py",
+    "find": "                limit=_TRANSCRIPT_CAP,\n                conversation_id=conversation_id or None,",
+    "replace": "                limit=_TRANSCRIPT_CAP,\n                conversation_id=None,",
+    "tests": [
+      "tests/cloud/test_paw_bar_owner_conversation_identity.py::test_the_transcript_reads_one_conversation_not_the_visitors_history"
+    ]
+  },
+  {
+    "label": "one conversation splits in two across the migration — same id, duplicate keys",
+    "file": "ee/pocketpaw_ee/paw_bar/router.py",
+    "find": "        group = conversation_id or ref",
+    "replace": "        group = token",
+    "tests": [
+      "tests/cloud/test_paw_bar_owner_conversation_identity.py::test_a_conversation_spanning_the_migration_is_ONE_row"
+    ]
+  }
+]


### PR DESCRIPTION
Conversation identity shipped on the visitor's side a while back and stopped there. A visitor can now hold several conversations, each with its own id, its own run `session_key` and its own history replay. None of the owner-facing code moved with it — every seam still keys on `customer_ref`, the person — so the two halves of the product disagree about what a conversation is.

## What that costs

| Seam | Behaviour today |
|---|---|
| `GET …/conversations` | Dedupes the run scan by `run.user_id`. Four separate questions render as **one** row showing the latest sentence. |
| `POST …/conversations/{ref}/reply` | Resolves to the visitor's **active** row. Answering yesterday's question writes into whatever they're saying today. |
| `PATCH …/conversations/{ref}` | Same. Taking one thread over mutes the assistant in the thread they're typing in. |
| `GET /paw-bar/messages/{widget}/{ref}` | Serves every owner line the visitor has ever been sent, into whichever thread is on screen. |

The missing three conversations aren't collapsed behind a disclosure — they're absent, with nothing to click. And `paw_bar_owner_messages` had no conversation column, so a reply couldn't be addressed to a thread even in principle.

## The fix

Carry the id the rest of the system already had. Owner lines store the conversation they were said in; the inbox groups runs by the conversation encoded in `session_key` and joins state by id; the reply, the patch and the visitor's poll all take a `conversation_id`.

Deployed owner lines are **backfilled** on migration to the visitor's active conversation — there was exactly one when they were written, which is the whole premise — rather than left empty behind a reader fallback. A nullable "means the old thing" is how the pair-keyed bug survived this long.

Compatible in both directions: a client that sends no `conversation_id` gets the old resolve-to-active behaviour, so cached dashboard and widget bundles keep working, and a legacy run whose `session_key` carries the visitor handle still groups per visitor and still lists.

One thing worth calling out — **a client-supplied id is an address, not a credential.** It's checked against the `(widget, visitor)` in the path before anything is written, and a mismatch is a 404. The silent fallback is right on the *visitor* path, where a refusal would confirm an id was real; it's wrong here, where the caller is already authenticated and workspace-scoped.

## Verification

- 7 new tests in `tests/cloud/test_paw_bar_owner_conversation_identity.py` — **run red first**, the headline one failing `assert 1 == 2` on the inbox
- 8 mutations in `tests/mutations/paw_bar_owner_conversation_identity.json`, **each observed to break its test**
- One escaped on the first run, and it was a hole in my test rather than in the code: it asserted the reply was *absent* from the wrong thread but never that it *reached* the right one, so storing it with no conversation at all passed. Fixed, re-run, all 8 caught.
- `--validate` repo-wide: 581 anchors across 48 plans resolve. My edit rotted one anchor in the sibling `paw_bar_conversation_identity` plan; it's repointed and that plan's 11 mutations were re-run and all still catch.
- Full `-k paw_bar` suite: 572 passed. The 12 failures are pre-existing — verified by stashing this diff and getting the identical list on a clean tree.
- `ruff check .` clean.

Docs updated in `docs/api-reference.md` for all four routes.

## Not in this PR

The `/chat` sites section that reads this — the owner surface for browsing sessions and stepping in — is next, and needs this merged first since it's the thing that makes more than one row exist.
