### PR TITLE
Put badge removal and the concierge on the site-plan wire

### DIFF
--- a/ee/pocketpaw_ee/cloud/billing/site_plans.py
+++ b/ee/pocketpaw_ee/cloud/billing/site_plans.py
@@ -23,6 +23,12 @@
 # never drift.
 #
 # Created 2026-06-24 (integration/billing-credits, BC-9): new module.
+# Updated 2026-08-19 (feat/site-plan-catalog-inclusions): added the
+#   ``sells_concierge`` property — the catalog-level "does this tier sell the
+#   concierge", lifted out of ``resolve_site_entitlements`` where it lived as an
+#   inline ``tier.key != BASE_SITE_PLAN_KEY``. Two callers now need the same
+#   answer (the resolver, and the plan-catalog DTO the buyer-facing plan cards
+#   read), and one rule expressed twice is one rule that drifts.
 # Updated 2026-08-13 (feat/sites-free-badge): added ``badge_removal`` — the gate
 #   ``sites.badge`` reads to decide whether a publish must stamp the attribution
 #   badge. The base tier does NOT carry it (that is what free means); the paid
@@ -87,7 +93,8 @@ class SitePlanTier:
     recurring-product id, or None until config populates it. ``cloudflare_features``
     is the set of Cloudflare features the tier resells (BC-10 provisions them).
     ``badge_removal`` is whether a site on this tier may ship without the
-    attribution badge — read by ``sites.badge.badge_required``.
+    attribution badge — read by ``sites.badge.badge_required``. ``sells_concierge``
+    is derived, not stored (see the property).
     """
 
     key: str
@@ -95,6 +102,24 @@ class SitePlanTier:
     dodo_product_id: str | None
     cloudflare_features: frozenset[str]
     badge_removal: bool = False
+
+    @property
+    def sells_concierge(self) -> bool:
+        """Does this tier sell the visitor concierge at all?
+
+        Derived from the floor rather than a per-tier catalog dict like
+        ``badge_removal``: no tier grants concierge today and the tier that will
+        (``staff``) does not exist until the pricing-spec rekey, which is blocked
+        on an open decision. A dict would need a basic/pro/business mapping
+        invented now and rewritten then; "any tier above the floor" needs no
+        mapping and survives the rekey untouched.
+
+        This is the CATALOG question — "does this tier sell it" — and on its own
+        entitles nobody. ``resolve_site_entitlements`` ANDs it with an active
+        subscription to answer "may THIS site serve one", which is the question
+        every public seam asks.
+        """
+        return self.key != BASE_SITE_PLAN_KEY
 
 
 def _dodo_product_for(key: str) -> str | None:

--- a/ee/pocketpaw_ee/cloud/entitlements/dto.py
+++ b/ee/pocketpaw_ee/cloud/entitlements/dto.py
@@ -29,6 +29,13 @@
 #   ``max_storage_bytes`` (the workspace S3 storage cap in bytes; ``None`` ==
 #   uncapped Enterprise) so the plan cards can render the storage limit and the
 #   Settings storage page can show used vs cap.
+# Updated 2026-08-19 (feat/site-plan-catalog-inclusions): ``SitePlanTierResponse``
+#   now also carries ``badge_removal`` and ``sells_concierge``. Both existed
+#   server-side and neither reached the wire, so the buyer-facing plan cards could
+#   only list ``cloudflare_features`` — they showed nothing about the attribution
+#   badge or the concierge, which are the two capabilities the paid tiers are
+#   actually sold on. A card that cannot name what a tier includes cannot name what
+#   it omits either, which is the half buyers ask about.
 
 from __future__ import annotations
 
@@ -132,12 +139,21 @@ class SitePlanTierResponse(BaseModel):
     ``cloudflare_features`` is the SORTED list of Cloudflare features the tier
     resells (deterministic JSON; BC-10 provisions these when a domain is added).
     ``dodo_product_id`` is None until config populates it.
+
+    ``badge_removal`` and ``sells_concierge`` are what the tier SELLS, not what any
+    particular site has: they say a tier may drop the attribution badge and may run
+    a visitor concierge. A site gets neither until its own subscription is active —
+    that AND lives in ``resolve_site_entitlements``, and it is why these two must
+    never be read as a per-site entitlement. They are here so a plan CARD can say
+    what each tier includes and, by their absence, what it does not.
     """
 
     key: str
     annual_price_usd: int
     dodo_product_id: str | None = None
     cloudflare_features: list[str] = Field(default_factory=list)
+    badge_removal: bool = False
+    sells_concierge: bool = False
 
 
 class SitePlanCatalogResponse(BaseModel):
@@ -153,4 +169,6 @@ def site_plan_tier_to_dto(tier: SitePlanTier) -> SitePlanTierResponse:
         annual_price_usd=tier.annual_price_usd,
         dodo_product_id=tier.dodo_product_id,
         cloudflare_features=sorted(tier.cloudflare_features),
+        badge_removal=tier.badge_removal,
+        sells_concierge=tier.sells_concierge,
     )

--- a/ee/pocketpaw_ee/cloud/entitlements/service.py
+++ b/ee/pocketpaw_ee/cloud/entitlements/service.py
@@ -40,6 +40,11 @@
 # Updated 2026-08-08 (feat/billing-storage-caps): also added
 #   ``max_storage_bytes`` — the workspace S3 storage cap (Free = 5 GB) surfaced
 #   to the uploads gate and the /storage/usage read; fail-closed to 5 GB.
+# Updated 2026-08-20 (feat/site-plan-catalog-inclusions): ``concierge_entitled``
+#   now reads ``tier.sells_concierge`` off the catalog row instead of re-deriving
+#   "above the free floor" here — the plan-catalog DTO needs the same answer for
+#   the buyer-facing plan cards, and two copies of one rule drift. The AND with an
+#   active subscription stays here; that is this resolver's job, not the catalog's.
 
 from __future__ import annotations
 

--- a/ee/pocketpaw_ee/cloud/entitlements/service.py
+++ b/ee/pocketpaw_ee/cloud/entitlements/service.py
@@ -158,13 +158,12 @@ def resolve_site_entitlements(
     if tier is not None and subscription_active:
         badge_removal = tier.badge_removal
         custom_domain = "custom_domain" in tier.cloudflare_features
-        # Any tier ABOVE the free floor sells the concierge. Deliberately derived
-        # from the floor rather than a per-tier catalog flag like ``badge_removal``:
-        # no tier grants concierge today, and the tier that will (``staff``) does not
-        # exist until the pricing-spec rekey, which is blocked on an open decision.
-        # A flag would need a basic/pro/business mapping invented now and rewritten
-        # then. "Paid and paying" needs no mapping and survives the rekey untouched.
-        concierge_entitled = tier.key != site_plan_catalog.BASE_SITE_PLAN_KEY
+        # Any tier ABOVE the free floor sells the concierge. The rule itself now
+        # lives on the catalog row (``SitePlanTier.sells_concierge``) because the
+        # plan-catalog DTO needs the same answer for the buyer-facing plan cards;
+        # read it, do not re-express it. What stays HERE is the AND with an active
+        # subscription, which is this resolver's whole job.
+        concierge_entitled = tier.sells_concierge
 
     return SiteEntitlements(
         site_id=site_id,

--- a/tests/cloud/billing/test_site_plan_inclusions.py
+++ b/tests/cloud/billing/test_site_plan_inclusions.py
@@ -1,0 +1,114 @@
+# tests/cloud/billing/test_site_plan_inclusions.py — the plan CARD must be able to
+# say what a tier includes, and what it leaves out.
+#
+# Created 2026-08-19 (feat/site-plan-catalog-inclusions). What this pins: two
+# capabilities the paid tiers are actually sold on — dropping the attribution
+# badge, and running a visitor concierge — existed server-side and reached no
+# client. ``GET /billing/site-plans`` shipped ``cloudflare_features`` only, so the
+# buyer-facing cards rendered a Cloudflare feature list and said nothing about
+# either. The free tier's card listed NOTHING at all, which is the worst case: the
+# one tier whose omissions are the entire product.
+#
+# Two properties are asserted, not one:
+#   * the catalog's ``sells_concierge`` is derived from the FLOOR, so the rekey in
+#     step 3 of the pricing spec (basic/pro/business -> free/site/staff) does not
+#     have to rewrite it;
+#   * the DTO mirrors the catalog row EXACTLY for every tier, so a tier added to
+#     the catalog cannot reach the wire with these two silently False.
+#
+# The second is the one worth having. A hand-written "pro is True" assertion
+# passes just as well against a mapper that hardcodes the answer.
+
+from __future__ import annotations
+
+from pocketpaw_ee.cloud.billing import site_plans as catalog
+from pocketpaw_ee.cloud.entitlements.dto import site_plan_tier_to_dto
+from pocketpaw_ee.cloud.entitlements.service import resolve_site_entitlements
+
+# --------------------------------------------------------------------------- #
+# sells_concierge — derived from the floor, not a per-tier mapping
+# --------------------------------------------------------------------------- #
+
+
+def test_base_tier_does_not_sell_the_concierge():
+    base = catalog.get_site_plan(catalog.BASE_SITE_PLAN_KEY)
+    assert base is not None
+    assert base.sells_concierge is False
+
+
+def test_every_tier_above_the_floor_sells_the_concierge():
+    paid = [t for t in catalog.list_site_plans() if t.key != catalog.BASE_SITE_PLAN_KEY]
+    assert paid, "catalog has no paid tier — this test would assert nothing"
+    assert all(t.sells_concierge for t in paid)
+
+
+def test_the_rule_follows_the_floor_rather_than_the_tier_name(monkeypatch):
+    """Rekeying the floor moves the answer with it — no basic/pro/business mapping.
+
+    This is the property that makes the pricing-spec rekey cheap: point
+    ``BASE_SITE_PLAN_KEY`` at another tier and that tier stops selling the
+    concierge, with nothing else edited. A per-tier dict would fail here.
+    """
+    monkeypatch.setattr(catalog, "BASE_SITE_PLAN_KEY", "pro")
+    assert catalog.get_site_plan("pro").sells_concierge is False
+    assert catalog.get_site_plan("basic").sells_concierge is True
+
+
+def test_the_resolver_reads_the_catalog_rule_rather_than_its_own(monkeypatch):
+    """``resolve_site_entitlements`` must not re-express the floor comparison.
+
+    One rule written twice is one rule that drifts. Overriding the property is
+    what makes this discriminating: moving ``BASE_SITE_PLAN_KEY`` instead would
+    pass against the old inline ``tier.key != BASE_SITE_PLAN_KEY`` too, since that
+    reads the same global. Only a resolver that actually calls ``sells_concierge``
+    follows the property here.
+
+    Breaks on: restoring the inline comparison in ``resolve_site_entitlements``.
+    """
+    monkeypatch.setattr(catalog.SitePlanTier, "sells_concierge", property(lambda _self: False))
+    ent = resolve_site_entitlements(
+        site_id="6512c1f0e4b0a1b2c3d4e5f6",
+        workspace_id="ws_1",
+        plan_tier="pro",
+        subscription_status="active",
+        concierge_enabled=True,
+    )
+    assert ent.concierge_entitled is False
+
+
+# --------------------------------------------------------------------------- #
+# The wire — the whole point of the change
+# --------------------------------------------------------------------------- #
+
+
+def test_the_dto_mirrors_every_catalog_row():
+    """No tier reaches the wire with these two silently False.
+
+    Written as a sweep over the catalog rather than three hand-written rows: a
+    mapper that hardcodes ``badge_removal=False`` passes a per-tier assertion for
+    the free tier and fails here.
+    """
+    for tier in catalog.list_site_plans():
+        dto = site_plan_tier_to_dto(tier)
+        assert dto.badge_removal is tier.badge_removal, tier.key
+        assert dto.sells_concierge is tier.sells_concierge, tier.key
+
+
+def test_the_free_tier_card_can_say_what_it_omits():
+    """The free tier's row carries three explicit Falses, not an empty payload.
+
+    Its card is the one that has to render "badge shown", "no concierge", "no
+    custom domain" — omissions are only renderable if they arrive as False rather
+    than as absent keys.
+    """
+    dto = site_plan_tier_to_dto(catalog.get_site_plan(catalog.BASE_SITE_PLAN_KEY))
+    assert dto.badge_removal is False
+    assert dto.sells_concierge is False
+    assert dto.cloudflare_features == []
+
+
+def test_a_paid_tier_card_carries_both_paid_capabilities():
+    dto = site_plan_tier_to_dto(catalog.get_site_plan("pro"))
+    assert dto.badge_removal is True
+    assert dto.sells_concierge is True
+    assert "custom_domain" in dto.cloudflare_features

--- a/tests/mutations/concierge_entitlement.json
+++ b/tests/mutations/concierge_entitlement.json
@@ -2,7 +2,7 @@
   {
     "label": "the plan is never consulted — concierge_entitled reverts to a pass-through",
     "file": "ee/pocketpaw_ee/cloud/entitlements/service.py",
-    "find": "        concierge_entitled = tier.key != site_plan_catalog.BASE_SITE_PLAN_KEY",
+    "find": "        concierge_entitled = tier.sells_concierge",
     "replace": "        concierge_entitled = True",
     "tests": [
       "tests/cloud/test_paw_bar_concierge_entitlement.py::test_a_free_site_is_not_entitled_to_a_concierge",


### PR DESCRIPTION
The site-plan catalog has always known two things it never told anyone: whether a
tier may drop the attribution badge, and whether it sells the visitor concierge.
`GET /billing/site-plans` shipped the key, the annual price, and the Cloudflare
feature list. That is why the buyer-facing plan cards could only ever list
Cloudflare features, and why the free tier's card rendered nothing at all.

`badge_removal` was already a catalog field and simply wasn't mapped into the
DTO. The concierge was worse: it lived as an inline `tier.key !=
BASE_SITE_PLAN_KEY` inside `resolve_site_entitlements`, so there was nothing for
a second caller to read. It moves up to `SitePlanTier.sells_concierge` and the
resolver now reads it rather than re-expressing it. Two places needed the same
answer, and a rule written twice drifts.

It stays derived from the floor rather than a per-tier dict, for the reason the
original comment gave: no tier grants concierge today, the tier that will
(`staff`) doesn't exist until the pricing-spec rekey, and any basic/pro/business
mapping invented now gets rewritten then.

## What this does not change

Neither field entitles anything by itself. They describe what a tier sells. A
site gets the capability only while its own subscription is active, and that AND
stays exactly where it was in `resolve_site_entitlements`. The DTO docstring says
so, because reading these as per-site entitlement is the obvious way to misuse
them.

## Tests

The DTO test sweeps the catalog instead of asserting per tier, so a mapper that
hardcodes `False` fails. Both gates were checked by mutation: hardcoding
`badge_removal=False` breaks the mirror test, and restoring the inline comparison
breaks the resolver test.

`tests/cloud/{billing,entitlements,sites}` pass, 220 of them. The two reds in
`test_plans.py` are pre-existing on `dev` and unrelated (I confirmed by stashing).

The frontend that consumes this is qbtrix/paw-enterprise#feat/site-plan-card-inclusions.