### PR TITLE
The served loader was two commits behind the app it has to talk to

### DIFF
--- a/ee/pocketpaw_ee/paw_bar/static/paw-bar.js
+++ b/ee/pocketpaw_ee/paw_bar/static/paw-bar.js
@@ -3,7 +3,7 @@
 //
 // GENERATED, DO NOT EDIT BY HAND. Produced by `bun run build:loader` in the
 // paw-bar repo (loader/dist/loader.readable.js) and copied here verbatim.
-// Source: qbtrix/paw-bar loader/src/loader.ts @ 99e2a47
+// Source: qbtrix/paw-bar loader/src/loader.ts @ e8c1d81
 //
 // It used to be hand-transcribed TypeScript with the annotations stripped by
 // hand. That drifts silently: this copy predated a whole session of loader
@@ -30,7 +30,7 @@
   var FRAME_PATH = "/paw-bar/frame";
   var POS_KEY = "__pawbar_pos_v2";
   var DRAG_MIN_PX = 4;
-  var BAR_MAX_W = 720;
+  var BAR_W = 384;
   var DEFAULT_BAR_H = 96;
   var DEFAULT_CHIP = { w: 240, h: 72 };
   var MIN_H = 48;
@@ -64,7 +64,7 @@
     }
     win[LOADED_FLAG] = true;
     const parentOrigin = resolveParentOrigin(win);
-    const src = endpoint + FRAME_PATH + "?key=" + encodeURIComponent(siteKey) + "&w=" + encodeURIComponent(widgetId) + "&po=" + encodeURIComponent(parentOrigin);
+    const src = endpoint + FRAME_PATH + "?key=" + encodeURIComponent(siteKey) + "&w=" + encodeURIComponent(widgetId) + "&po=" + encodeURIComponent(parentOrigin) + "&s=" + hostScheme(win);
     const iframe = doc.createElement("iframe");
     iframe.title = "Site concierge";
     iframe.setAttribute("allow", "clipboard-write");
@@ -77,7 +77,7 @@
     let anchor = readAnchor(win);
     let dragFrom = null;
     const size = {
-      bar: { w: BAR_MAX_W, h: DEFAULT_BAR_H },
+      bar: { w: BAR_W, h: DEFAULT_BAR_H },
       chip: { w: DEFAULT_CHIP.w, h: DEFAULT_CHIP.h },
       panel: { w: PANEL_W, h: PANEL_MAX_H }
     };
@@ -89,8 +89,8 @@
     function dockBox() {
       const vw = win.innerWidth || 0;
       const vh = win.innerHeight || 0;
-      const maxW = vw ? vw - VIEWPORT_MARGIN : BAR_MAX_W;
-      const wantW = view === "bar" ? Math.min(size.bar.w, BAR_MAX_W) : size[view].w;
+      const maxW = vw ? vw - VIEWPORT_MARGIN : BAR_W;
+      const wantW = view === "bar" ? BAR_W : size[view].w;
       const w = Math.min(wantW, maxW);
       const wantH = view === "panel" ? PANEL_MAX_H : size[view].h;
       const h = vh ? clamp(wantH, MIN_H, vh - VIEWPORT_MARGIN) : Math.max(MIN_H, wantH);
@@ -123,9 +123,26 @@
     }
     (doc.body || doc.documentElement).appendChild(iframe);
     applyDock();
+    let overlayOpen = false;
+    function watchHostPointer(on) {
+      overlayOpen = on;
+    }
+    doc.addEventListener(
+      "pointerdown",
+      (ev) => {
+        if (overlayOpen && ev.target !== iframe) postToFrame({ type: "pawbar:host-pointerdown" });
+      },
+      true
+    );
     function postToFrame(msg) {
       const target = iframe.contentWindow;
       if (target) target.postMessage(msg, frameOrigin);
+    }
+    const schemeQuery = win.matchMedia && win.matchMedia("(prefers-color-scheme: dark)");
+    if (schemeQuery && schemeQuery.addEventListener) {
+      schemeQuery.addEventListener("change", () => {
+        postToFrame({ type: "pawbar:scheme", s: hostScheme(win) });
+      });
     }
     win.addEventListener("message", (ev) => {
       if (ev.origin !== frameOrigin) return;
@@ -139,8 +156,8 @@
           const h = Number(data.h);
           if (Number.isFinite(h)) size[view].h = h;
           const w = Number(data.w);
-          if (Number.isFinite(w) && w > 0) size[view].w = w;
-          applyDock(true);
+          if (view !== "bar" && Number.isFinite(w) && w > 0) size[view].w = w;
+          applyDock(false);
           break;
         }
         case "pawbar:view": {
@@ -156,6 +173,7 @@
           break;
         }
         case "pawbar:dead":
+          watchHostPointer(false);
           iframe.remove();
           break;
         case "pawbar:open":
@@ -166,6 +184,9 @@
         case "pawbar:expand":
           expanded = data.on === true;
           applyDock(true);
+          break;
+        case "pawbar:overlay":
+          watchHostPointer(data.on === true);
           break;
         case "pawbar:close":
           view = dockView;
@@ -227,6 +248,26 @@
   function lastScriptWith(dataAttr, doc) {
     const list = doc.querySelectorAll("script[" + dataAttr + "]");
     return list.length ? list[list.length - 1] : null;
+  }
+  function hostScheme(win) {
+    const doc = win.document;
+    try {
+      const declared = win.getComputedStyle(doc.documentElement).colorScheme || "";
+      const dark = declared.indexOf("dark") >= 0;
+      const light = declared.indexOf("light") >= 0;
+      if (dark !== light) return dark ? "d" : "l";
+      const roots = [doc.body, doc.documentElement];
+      for (let i = 0; i < roots.length; i++) {
+        const el = roots[i];
+        if (!el) continue;
+        const parts = win.getComputedStyle(el).backgroundColor.match(/[\d.]+/g);
+        if (!parts || parts.length < 3 || parts.length > 3 && +parts[3] < 0.5) continue;
+        const lum = (0.2126 * +parts[0] + 0.7152 * +parts[1] + 0.0722 * +parts[2]) / 255;
+        return lum < 0.5 ? "d" : "l";
+      }
+    } catch {
+    }
+    return win.matchMedia && win.matchMedia("(prefers-color-scheme: dark)").matches ? "d" : "l";
   }
   function originOf(url) {
     try {

--- a/tests/cloud/test_paw_bar_widget_js.py
+++ b/tests/cloud/test_paw_bar_widget_js.py
@@ -70,7 +70,10 @@ async def test_env_override_wins(widget_client, tmp_path, monkeypatch):
     """PAW_BAR_WIDGET_JS is the seam for serving a freshly built bundle without a
     redeploy."""
     custom = tmp_path / "built-widget.js"
-    custom.write_text("/* a newer build */\n", encoding="utf-8")
+    # write_bytes, not write_text: text mode translates "\n" to "\r\n" on Windows,
+    # so the route served CRLF and this assertion failed on a Windows dev box while
+    # passing in Linux CI. The route copies bytes; the fixture must write bytes.
+    custom.write_bytes(b"/* a newer build */\n")
     monkeypatch.setenv("PAW_BAR_WIDGET_JS", str(custom))
 
     res = await widget_client.get("/paw-bar/widget.js")
@@ -159,6 +162,47 @@ def test_the_vendored_loader_docks_a_column_rather_than_covering_the_page():
     # The opt-in big reading surface, and the box animation, both reached here.
     assert "pawbar:expand" in code
     assert "BOX_MS" in code
+
+
+def test_the_vendored_loader_speaks_the_frame_protocol_the_app_expects():
+    """The loader and the glass app are two halves of one protocol shipped from two
+    places, and only this half lives in this repo. The app is built in paw-bar and
+    dropped into ``PAWBAR_APP_DIR``; nothing here can see its version. So when the
+    loader falls behind, the app keeps sending messages into a copy with no case for
+    them and the failures are all silent and all cosmetic-looking.
+
+    That is not hypothetical. The vendored copy sat two loader commits behind while
+    the app had already moved, and every symptom was a half of this protocol going
+    unanswered:
+
+      * ``scheme.ts`` reads the ``s`` query param off its own iframe URL. Only the
+        loader can know the HOST page's colour scheme — the iframe's own
+        ``prefers-color-scheme`` is the visitor's OS, not the site's. Without ``s``
+        a light site got a dark widget bolted to it.
+      * the app posts ``pawbar:overlay`` whenever a menu opens, expecting
+        ``pawbar:host-pointerdown`` back when the visitor clicks the page outside
+        the frame. An old loader ignores the first and never sends the second, so
+        popovers stay open forever.
+
+    Asserting on the wire vocabulary rather than diffing against a sibling checkout,
+    which is not present on a CI box. This is the same reasoning as the dock test
+    above, applied to the messages instead of the geometry.
+    """
+    from pocketpaw_ee.paw_bar.router import paw_bar_widget_file
+
+    source = paw_bar_widget_file().read_text(encoding="utf-8")
+    code = chr(10).join(ln for ln in source.splitlines() if not ln.lstrip().startswith("//"))
+
+    # The host's scheme rides the frame URL, and it is DERIVED from the host page
+    # rather than read off the iframe's own media query.
+    assert '"&s=" + hostScheme(win)' in code
+
+    # ...and it stays live: a host that changes theme after load tells the frame.
+    assert "pawbar:scheme" in code
+
+    # The overlay handshake, both directions.
+    assert "pawbar:overlay" in code, "app announces menus; loader must have a case"
+    assert "pawbar:host-pointerdown" in code, "loader must report host clicks back"
 
 
 def test_the_vendored_loader_is_generated_not_hand_edited():


### PR DESCRIPTION
The vendored loader was pinned at paw-bar `99e2a47`. Two loader commits landed after it, through PRs #6 and #7 in that repo:

- `3e6e32f` — the docked bar could not grow, and a repeated citation crashed
- `e8c1d81` — the widget follows the site it is bolted to

Nothing here noticed, because nothing here can. The glass app is built in paw-bar and dropped into `PAWBAR_APP_DIR` at deploy time, so this repo has no view of the version it is being asked to speak to. The app moved. This half did not.

## What that actually cost

Not "an older bar" — a protocol with one side deaf:

- `scheme.ts` reads the `s` query param off its own iframe URL, because only the loader can see the **host** page's colour scheme (the iframe's own `prefers-color-scheme` is the visitor's OS, not the site's). The old loader never appended it, so a light site got a dark widget bolted onto it.
- The app posts `pawbar:overlay` when a menu opens and waits for `pawbar:host-pointerdown` when the visitor clicks outside the frame. The old loader had a case for neither, so popovers never closed.
- The bar rendered at `BAR_MAX_W = 720` where the source had moved to `BAR_W = 384` — roughly twice its intended width.

## What changed

Refreshed from `loader/dist/loader.readable.js` at `e8c1d81`, byte-for-byte below the header.

Added a test that pins the wire vocabulary rather than the geometry. It cannot diff against paw-bar (not present on a CI box), so it asserts the messages the app actually sends and expects back. **It fails against the copy this PR replaces** — I checked, because a guard nobody has watched fail is not a guard. It will not catch every future drift, but it catches this one, which had already shipped twice.

Also fixed `test_env_override_wins`, which wrote its fixture with `write_text`: on Windows that translates `\n` to `\r\n`, so the route served CRLF and the assertion failed locally while passing in Linux CI.

## Checks

- `tests/cloud/test_paw_bar_widget_js.py` — 12 passed
- `test_paw_bar_frame.py` + `test_paw_bar_concierge_entitlement.py` — 39 passed
- Full `-k "paw_bar or pawbar"` sweep compared against pristine `dev`: **zero new failures**, one fixed. The 11 that remain are pre-existing preamble/provisioning failures on my Windows box, unrelated to the loader.

The deploy-side half of this — the app bundle that could never update — is a separate PR on the workspace repo.