### PR TITLE
The deep-link table now catches the flip it existed for

### DIFF
--- a/tests/cloud/push/test_deeplink_contract.py
+++ b/tests/cloud/push/test_deeplink_contract.py
@@ -9,6 +9,14 @@
 # row here, change it there. Known deliberate divergences: FE
 # paw_bar_conversation appends &conversation=<ref>; FE enumerates several
 # kinds that here fall to the /chat default.
+#
+# Updated 2026-08-20 (test/deeplink-contract-followups): review fixes — added
+# the pocket-AND-room precedence row and the ``alert`` → None row, absorbed
+# test_listeners.py's older duplicate table into this one, and wired the
+# mutation plan (tests/mutations/deeplink_contract.json; run via
+# ``uv run python scripts/mutate.py --plan tests/mutations/deeplink_contract.json``).
+# Mutations proven to break this table: flipping the pocket-vs-room precedence,
+# deleting the ``lead`` arm, deleting the ``alert`` arm.
 
 from __future__ import annotations
 
@@ -59,6 +67,24 @@ GOLDEN = [
         "message without pocket or room falls back to the source id",
         {"source_type": "message", "source_id": "msg-1"},
         "/chat/msg-1",
+    ),
+    (
+        # Pins the precedence, not just each branch alone: with BOTH set the
+        # pocket must win. Flipping the ``if pocket_id`` order passes every
+        # single-field row silently — this row is the one that trips.
+        "message with both pocket and room prefers the pocket chat",
+        {
+            "source_type": "message",
+            "source_id": "msg-1",
+            "source_pocket_id": "pocket-3",
+            "source_room_id": "room-5",
+        },
+        "/pockets/pocket-3/chat",
+    ),
+    (
+        "alert has no route (no alerts page; a dead /chat link would be worse)",
+        {"source_type": "alert", "source_id": "budget_exhausted"},
+        None,
     ),
     (
         "mention inside a pocket goes to the pocket chat",
@@ -139,4 +165,7 @@ GOLDEN = [
     ids=[row[0] for row in GOLDEN],
 )
 def test_target_url_golden(data: dict, expected: str | None) -> None:
+    """Breaks under tests/mutations/deeplink_contract.json — flipped
+    pocket-vs-room precedence, a deleted ``lead``/``alert`` arm, or a
+    paw_bar arm that drops its agent binding (all 4 observed caught)."""
     assert _target_url(data) == expected

--- a/tests/cloud/push/test_listeners.py
+++ b/tests/cloud/push/test_listeners.py
@@ -23,6 +23,10 @@
 #   * ``on_agent_complete`` survives — agent replies persist no notification
 #     row, so retiring it would have silently dropped their push.
 # ``dispatch.notify`` is patched to record calls — no WS, no Web Push, no DB.
+#
+# Updated: 2026-08-20 (test/deeplink-contract-followups) — the deep-link
+# parametrize moved to test_deeplink_contract.py (golden contract table);
+# this file keeps the dispatch/coalesce/privacy pins only.
 
 from __future__ import annotations
 
@@ -223,38 +227,12 @@ async def test_generic_kind_body_passes_through(notify_calls) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Deep links — mirrors paw-enterprise src/lib/core/notifications/target.ts
+# Deep links live in test_deeplink_contract.py — the golden table in that file
+# is the single backend pin for ``_target_url`` (and the twin of the
+# paw-enterprise table). The parametrized copy that used to sit here was a
+# second hand-kept duplicate of the same contract; it drifted-by-omission
+# (no pocket-vs-room precedence row) and is absorbed there (2026-08-20).
 # ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    ("source_type", "extra", "expected"),
-    [
-        ("message", {"source_room_id": "g1"}, "/chat/g1"),
-        ("mention", {"source_room_id": "g1"}, "/chat/g1"),
-        ("message", {"source_pocket_id": "p1"}, "/pockets/p1/chat"),
-        ("invite", {}, "/invite/s1"),
-        ("pocket_shared", {}, "/pockets/s1"),
-        ("meeting", {}, "/meetings?id=s1"),
-        ("meeting_started", {"source_room_id": "g1"}, "/chat/g1?join=meeting-s1"),
-        ("paw_bar_conversation", {"source_agent_id": "a1"}, "/agents/a1?tab=conversations"),
-        ("paw_bar_conversation", {}, "/agents"),
-        # A lead's room_id is its SITE — without the arm the default builds
-        # /chat/<site_id>, a room that cannot exist.
-        ("lead", {"source_room_id": "site1"}, "/sites/site1?view=leads"),
-        ("meeting_reminder", {"source_room_id": "g1"}, "/chat/g1"),
-    ],
-)
-def test_target_url(source_type, extra, expected) -> None:
-    assert listeners._target_url(_dto(source_type=source_type, source_id="s1", **extra)) == expected
-
-
-def test_target_url_omitted_when_ambiguous() -> None:
-    # No source at all → no link.
-    assert listeners._target_url(_dto(source_type=None, source_id=None)) is None
-    # The approvals tray is a global overlay, not a route — a ``/chat/<id>``
-    # default arm would land on a room that cannot exist.
-    assert listeners._target_url(_dto(source_type="instinct_approval", source_id="a1")) is None
 
 
 async def test_payload_omits_url_when_there_is_none(notify_calls) -> None:

--- a/tests/mutations/deeplink_contract.json
+++ b/tests/mutations/deeplink_contract.json
@@ -1,0 +1,38 @@
+[
+ {
+  "label": "resolver: flip pocket-vs-room precedence to room-first",
+  "file": "ee/pocketpaw_ee/cloud/push/listeners.py",
+  "find": "        return f\"/pockets/{pocket_id}/chat\" if pocket_id else f\"/chat/{nav_target}\"",
+  "replace": "        return f\"/chat/{nav_target}\" if room_id else f\"/pockets/{pocket_id}/chat\"",
+  "tests": [
+   "tests/cloud/push/test_deeplink_contract.py"
+  ]
+ },
+ {
+  "label": "resolver: delete the lead arm (falls to the /chat default)",
+  "file": "ee/pocketpaw_ee/cloud/push/listeners.py",
+  "find": "    if source_type == \"lead\":",
+  "replace": "    if source_type == \"lead_disabled_by_mutation\":",
+  "tests": [
+   "tests/cloud/push/test_deeplink_contract.py"
+  ]
+ },
+ {
+  "label": "resolver: delete the alert arm (falls to the /chat default)",
+  "file": "ee/pocketpaw_ee/cloud/push/listeners.py",
+  "find": "    if source_type == \"alert\":",
+  "replace": "    if source_type == \"alert_disabled_by_mutation\":",
+  "tests": [
+   "tests/cloud/push/test_deeplink_contract.py"
+  ]
+ },
+ {
+  "label": "resolver: paw_bar loses its agent binding (always the bare list)",
+  "file": "ee/pocketpaw_ee/cloud/push/listeners.py",
+  "find": "        return f\"/agents/{agent_id}?tab=conversations\" if agent_id else \"/agents\"",
+  "replace": "        return \"/agents\"",
+  "tests": [
+   "tests/cloud/push/test_deeplink_contract.py"
+  ]
+ }
+]


### PR DESCRIPTION
Follow-up to #1975 from the review pass — three gaps, all confirmed against the merged code.

The table pinned each branch of the message arm alone, never both fields together. Flipping the pocket-vs-room precedence passed every row in both test files silently — the exact drift the contract was written to catch. There's a row for it now, plus one pinning the alert arm that landed with #1872.

test_listeners.py carried an older copy of the same table (it had even drifted the same way — no precedence row). Its deep-link block is absorbed into the contract file; the dispatch, coalesce, and privacy pins stay where they were.

Per the mutation-gate rule this repo runs on: tests/mutations/deeplink_contract.json holds 4 mutations (precedence flip, deleted lead arm, deleted alert arm, paw_bar losing its agent binding). Ran the sweep — all 4 caught. tests/cloud/push/ green locally: 96 passed, then 18/18 on the contract file after the docstring pass.