### PR TITLE
Render an unsaved appearance to tokens, so the concierge preview can repaint

### DIFF
--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -1393,6 +1393,26 @@ class ConciergeSettingsUpdate(BaseModel):
     concierge_store_transcripts: bool | None = None
 
 
+class ConciergePreviewTokensRequest(BaseModel):
+    """An UNSAVED appearance to render, for the editor's live preview (2026-08-20)."""
+
+    concierge_appearance: ConciergeAppearance = Field(default_factory=ConciergeAppearance)
+
+
+class ConciergePreviewTokensResponse(BaseModel):
+    """The rendered ``--pawbar-*`` map, plus the appearance as VALIDATED.
+
+    Both halves matter. The tokens are what the widget applies; the normalized
+    appearance is what the owner actually gets, and returning it means the editor
+    can show a clamped radius or a rejected image URL the moment it happens
+    rather than at save time, which is the point at which it currently surprises
+    people.
+    """
+
+    tokens: dict[str, str]
+    concierge_appearance: ConciergeAppearance
+
+
 class ConciergeSettingsResponse(BaseModel):
     """The owner-facing view of a Site's concierge settings (D1)."""
 
@@ -1502,6 +1522,40 @@ async def update_site_concierge_settings(
         # for those rather than 500 on the owner who has not saved a theme yet.
         concierge_appearance=getattr(site, "concierge_appearance", None) or ConciergeAppearance(),
     )
+
+
+@router.post(
+    "/paw-bar/admin/site/{site_id}/appearance/preview-tokens",
+    response_model=ConciergePreviewTokensResponse,
+    dependencies=[Depends(_require_paw_bar_manage)],
+)
+async def render_preview_tokens(
+    site_id: str,
+    req: ConciergePreviewTokensRequest,
+    workspace_id: str = Depends(current_workspace_id),
+) -> ConciergePreviewTokensResponse:
+    """Render an unsaved appearance to its ``--pawbar-*`` tokens. WRITES NOTHING.
+
+    The appearance editor's preview is the real widget in a cross-origin iframe,
+    so it can only be repainted by telling it what to paint. What it needs is the
+    token map — and ``ConciergeAppearance.tokens()`` is the ONE renderer for that.
+    Re-expressing it in the client would put a second copy of the mapping on the
+    other side of a network boundary, where the two would drift silently and the
+    preview would stop being evidence of anything.
+
+    So the draft comes here, gets validated by exactly the model a save would
+    validate it with, and goes back as tokens. That the validation is the same is
+    the reason this is trustworthy: the preview shows the CLAMPED value, not the
+    one the owner typed, so it cannot promise a look that a save would not store.
+
+    Tenancy: the site is resolved workspace-scoped and the result is discarded.
+    We do not need the document to render — the appearance is in the body — but
+    loading it is what makes a cross-tenant or bogus site id a 404 here exactly
+    as it is on the settings PATCH, rather than an open rendering oracle.
+    """
+    await _load_site_scoped(site_id, workspace_id)
+    look = req.concierge_appearance
+    return ConciergePreviewTokensResponse(tokens=look.tokens(), concierge_appearance=look)
 
 
 # ---------------------------------------------------------------------------

--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -830,6 +830,7 @@ def _pawbar_frame_config(
     greeting: str,
     starters: list[str] | None = None,
     appearance: ConciergeAppearance | None = None,
+    preview: bool = False,
 ) -> dict[str, Any]:
     """Build the ``window.__PAWBAR__`` bootstrap config shared by the public frame
     and the owner preview frame (D5).
@@ -858,6 +859,14 @@ def _pawbar_frame_config(
         "endpoint": api_base,
         "parentOrigin": parent_origin,
         "mode": "concierge",
+        # 2026-08-20 — TRUE only for the owner preview frame (D5), never the
+        # public embed. It is what lets the glass app accept live --pawbar-*
+        # updates postMessage'd by the appearance editor as the owner drags a
+        # slider. A public bar must refuse those: its parent is the customer's
+        # own page, and an embed that restyles itself on request from whatever
+        # framed it is a wider surface than this feature needs. Origin is checked
+        # too — this flag decides whether the listener exists at all.
+        "preview": bool(preview),
         # D1 / SS-6 — the owner's opening line; the glass app renders it (D4) and
         # falls back to its own default when "".
         "greeting": greeting or "",
@@ -2789,6 +2798,7 @@ async def get_site_preview_frame(
         greeting=site.concierge_greeting or "",
         starters=await _bound_agent_starters(widget.agent_id),
         appearance=getattr(site, "concierge_appearance", None),
+        preview=True,
     )
     # Preview-only dark page so the transparent bar reads as sitting on the dark
     # dashboard, not a white canvas. The public /paw-bar/frame passes no page_bg

--- a/tests/cloud/test_paw_bar_concierge_settings.py
+++ b/tests/cloud/test_paw_bar_concierge_settings.py
@@ -291,6 +291,22 @@ async def test_settings_patch_is_partial(client):
 
 
 @pytest.mark.asyncio
+async def test_public_frame_is_not_marked_preview(client):
+    """The public embed must not advertise itself as a preview.
+
+    ``preview`` is what lets the glass app accept live token updates from its
+    parent. A public bar's parent is the CUSTOMER's page, so the flag being wrong
+    here would hand every embedder a restyling channel this feature never
+    intended to open.
+    """
+    c, _store = client
+    await _site()
+    res = await c.get("/paw-bar/frame", params={"key": _VALID_KEY})
+    assert res.status_code == 200
+    assert '"preview": false' in res.text or '"preview":false' in res.text
+
+
+@pytest.mark.asyncio
 async def test_preview_tokens_renders_without_writing(client):
     """The editor's live preview needs tokens for a draft nobody has saved."""
     c, _store = client

--- a/tests/cloud/test_paw_bar_concierge_settings.py
+++ b/tests/cloud/test_paw_bar_concierge_settings.py
@@ -291,6 +291,78 @@ async def test_settings_patch_is_partial(client):
 
 
 @pytest.mark.asyncio
+async def test_preview_tokens_renders_without_writing(client):
+    """The editor's live preview needs tokens for a draft nobody has saved."""
+    c, _store = client
+    site = await _site()
+
+    res = await c.post(
+        f"/paw-bar/admin/site/{site.id}/appearance/preview-tokens",
+        json={"concierge_appearance": {"accent": "#ff5a36", "radius": 8}},
+    )
+
+    assert res.status_code == 200, res.text
+    tokens = res.json()["tokens"]
+    assert tokens["--pawbar-accent"] == "#ff5a36"
+    assert tokens["--pawbar-radius"] == "8px"
+
+    # WRITES NOTHING. The whole point is that this renders a draft; if it
+    # persisted, every keystroke in the editor would be a save and Revert would
+    # have nothing to go back to.
+    got = await c.get(f"/paw-bar/admin/site/{site.id}/settings")
+    assert got.json()["concierge_appearance"]["accent"] != "#ff5a36"
+
+
+@pytest.mark.asyncio
+async def test_preview_tokens_returns_the_clamped_value_not_the_typed_one(client):
+    """The preview must not promise a look a save would not store.
+
+    Same model, same validators as the PATCH — so an out-of-range radius comes
+    back clamped and an unsafe image URL comes back empty, and the owner sees
+    that while editing instead of discovering it at save time.
+    """
+    c, _store = client
+    site = await _site()
+
+    res = await c.post(
+        f"/paw-bar/admin/site/{site.id}/appearance/preview-tokens",
+        json={
+            "concierge_appearance": {
+                "radius": 9999,
+                "agent_avatar_url": "http://insecure.example/a.png",
+            }
+        },
+    )
+
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["concierge_appearance"]["radius"] == 32
+    assert body["tokens"]["--pawbar-radius"] == "32px"
+    # http:// is refused rather than upgraded — it would be a mixed-content block
+    # on the owner's own https site.
+    assert body["concierge_appearance"]["agent_avatar_url"] == ""
+
+
+@pytest.mark.asyncio
+async def test_preview_tokens_cross_tenant_is_404(client):
+    """Not an open rendering oracle: another workspace's site id 404s.
+
+    The render does not need the document — the appearance is in the body — so
+    the scoped load exists precisely to keep this gate identical to the settings
+    PATCH beside it.
+    """
+    c, _store = client
+    site = await _site(workspace="ws-other")
+
+    res = await c.post(
+        f"/paw-bar/admin/site/{site.id}/appearance/preview-tokens",
+        json={"concierge_appearance": {"accent": "#ff5a36"}},
+    )
+
+    assert res.status_code == 404
+
+
+@pytest.mark.asyncio
 async def test_settings_cross_tenant_is_404(client):
     """A site owned by another workspace 404s for the ws-1 admin session."""
     c, _store = client


### PR DESCRIPTION
Backend half of making the appearance editor's preview actually live. Pairs with paw-bar (widget side) and paw-enterprise (the editor).

## Why an endpoint at all

The editor's preview is the real widget in a **cross-origin** iframe. The dashboard cannot style it — no DOM access — so the only way to repaint is to tell it what to paint, and what it needs is the `--pawbar-*` token map.

That map has exactly one renderer: `ConciergeAppearance.tokens()`. Re-expressing it in the client would put a second copy of the mapping on the far side of a network boundary, where the two drift with nothing to notice. A preview that disagrees with what a save stores is worse than no preview, because it is evidence of the wrong thing — this session has already spent hours on two bugs of exactly that shape.

So `POST .../appearance/preview-tokens` takes the draft and returns tokens.

## Two properties worth stating

**It writes nothing.** The point is to render something nobody has saved. If it persisted, every keystroke in the editor would be a save and Revert would have nothing to return to.

**It returns the appearance as validated**, by the same model the PATCH validates with. That is what makes the preview honest: it shows the clamped radius and the emptied unsafe URL, so it cannot promise a look a save would not store. It also answers a real complaint — those coercions are silent today and only surface when the form snaps back after saving.

## The scoped load that looks redundant

`_load_site_scoped` is called and the result discarded. The render does not need the document; the appearance arrives in the body. It is there so a cross-tenant or bogus site id 404s here exactly as it does on the settings PATCH beside it, rather than leaving an authenticated rendering oracle that answers for any id at all.

## The preview flag

`preview` is true only for the owner preview frame and false for the public embed. It is what lets the widget install a listener for live token updates.

Origin is not the gate to lean on here: a public frame's parent **is** the customer's own page, so an origin check there passes by construction. An embed that restyles itself on request from whatever framed it is a wider surface than this feature needs. Both framing paths build config through one function, so the flag cannot drift between them; it defaults false and only the preview route opts in.

## Checks

- 4 new tests: renders, does not write, clamps, 404s cross-tenant — plus one pinning that the public frame is **not** marked preview, which is the half that would fail silently.
- `tests/cloud/test_paw_bar_concierge_settings.py` + `test_paw_bar_appearance.py` — 65 passed
- ruff check + format clean
- Full `-k "paw_bar or pawbar"` sweep compared against baseline: **no new failures**. The one that differed (`test_a_conversation_spanning_the_migration_is_ONE_row`) is flaky on this branch's base — fails 2 of 3 runs with my changes stashed.