### PR TITLE
A visitor can read back their own conversation

### DIFF
--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -4634,6 +4634,18 @@ class VisitorConversationsResponse(BaseModel):
     conversations: list[VisitorConversationItem] = Field(default_factory=list)
 
 
+class VisitorTranscriptResponse(BaseModel):
+    """One of THIS visitor's conversations, oldest-first (2026-08-21).
+
+    The widget's own history. Same messages the owner drill-in renders, through
+    the same loader — a visitor and the site owner reading one thread must not
+    be reading two different reconstructions of it.
+    """
+
+    conversation_id: str
+    messages: list[TranscriptMessage] = Field(default_factory=list)
+
+
 class OpenConversationRequest(BaseModel):
     key: str
     w: str
@@ -4763,6 +4775,69 @@ async def open_visitor_conversation(
         last_message_at="",
         active=True,
     )
+
+
+@router.get(
+    "/paw-bar/conversations/{conversation_id}/messages",
+    response_model=VisitorTranscriptResponse,
+)
+async def get_visitor_conversation_messages(
+    conversation_id: str,
+    request: Request,
+    w: str,
+    key: str,
+    customer_ref: str,
+) -> VisitorTranscriptResponse:
+    """This visitor's own messages in one conversation, oldest-first.
+
+    WHY THIS EXISTS. The widget had no way to ask. Its thread lived only in the
+    frame's localStorage, so anything that lost that storage lost the history
+    outright — and plenty does: the bar is a third-party iframe, which Safari
+    blocks storage for and Chrome/Firefox partition per top-level site, and the
+    stored row carries a 7-day TTL besides. The server had every message the
+    whole time (it is what the owner's inbox reads); nothing could fetch them.
+
+    So a visitor who chatted, navigated, and came back saw an empty panel with
+    their conversation id still in localStorage pointing at turns nobody could
+    load. This is the read that was missing. localStorage becomes a cache for
+    the first paint rather than the record.
+
+    Scoped twice, like the list beside it: the front gate binds this visitor to
+    the resolved key, and the conversation is checked against the ones the store
+    holds for that (widget, visitor) pair. A conversation id belonging to another
+    visitor or another site 404s rather than returning an empty thread — the
+    loader would answer empty anyway (it filters on customer_ref), but a 404 says
+    the honest thing instead of implying the conversation exists and is silent.
+    """
+    origin = request.headers.get("origin")
+    widget, ctx, _site = await _front_gate_for_key(
+        widget_id=w,
+        signed_key=key,
+        customer_ref=customer_ref,
+        origin=origin,
+        request=request,
+    )
+    if not conversation_id:
+        raise HTTPException(status_code=404, detail="conversation_not_found")
+
+    store = _store()
+    rows = await store.list_conversations_for_visitor(
+        widget.id, customer_ref, workspace_id=ctx.workspace_id
+    )
+    if conversation_id not in {row.id for row in rows}:
+        raise HTTPException(status_code=404, detail="conversation_not_found")
+
+    messages = await _load_transcript(
+        ctx.pocket_id or "",
+        customer_ref,
+        ctx.workspace_id,
+        widget=widget,
+        conversation_id=conversation_id,
+    )
+    # None means the ref has nothing stored at all; for a conversation the store
+    # DOES know about, that is an empty thread rather than a missing one — a bot
+    # muted the whole time, or a site with transcripts off and no owner replies.
+    return VisitorTranscriptResponse(conversation_id=conversation_id, messages=messages or [])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cloud/test_paw_bar_conversation_identity.py
+++ b/tests/cloud/test_paw_bar_conversation_identity.py
@@ -520,6 +520,106 @@ async def test_visitor_can_list_and_open_conversations(chat):
 
 
 @pytest.mark.asyncio
+async def test_a_visitor_can_read_back_their_own_conversation(chat):
+    """The read the widget never had.
+
+    Its thread lived only in the frame's localStorage, so anything that lost that
+    storage lost the history — and plenty does: the bar is a third-party iframe
+    (Safari blocks its storage, Chrome and Firefox partition it per top-level
+    site) and the stored row carries a 7-day TTL. The server had every message the
+    whole time; nothing could ask for it.
+    """
+    client, store, executor, widget = chat
+    from pocketpaw_ee.cloud.models.chat_run import ChatRunDoc
+
+    conversation = await store.open_conversation(widget.id, _REF, workspace_id="ws-1")
+    await ChatRunDoc(
+        run_id=uuid.uuid4().hex,
+        workspace="ws-1",
+        context_type="concierge",
+        scope_id="pocket-1",
+        session_key=f"cloud:concierge:pocket-1:{conversation.id}:agent-xyz",
+        user_id=_REF,
+        agent_id="agent-xyz",
+        client_message_id=uuid.uuid4().hex,
+        user_message_id="",
+        status="completed",
+        user_text="Do you deliver on Sundays?",
+        partial_text="We do, until 4pm.",
+    ).insert()
+
+    res = await client.get(
+        f"/paw-bar/conversations/{conversation.id}/messages",
+        params={"w": widget.id, "key": _VALID_KEY, "customer_ref": _REF},
+        headers={"Origin": _ORIGIN},
+    )
+
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["conversation_id"] == conversation.id
+    spoken = " ".join(m["content"] for m in body["messages"])
+    # BOTH halves: the visitor's own question and the reply. A thread that comes
+    # back assistant-only reads as the bar talking to itself.
+    assert "Do you deliver on Sundays?" in spoken
+    assert "We do, until 4pm." in spoken
+
+
+@pytest.mark.asyncio
+async def test_a_visitor_cannot_read_another_visitors_conversation(chat):
+    """Two visitors of the same bar share the widget, the site and the agent —
+    only the handle separates them. A conversation id is guessable in a way a
+    handle is not, so the id alone must never be enough to read a thread."""
+    client, store, executor, widget = chat
+
+    stranger = "cust-stranger-9"
+    theirs = await store.open_conversation(widget.id, stranger, workspace_id="ws-1")
+
+    res = await client.get(
+        f"/paw-bar/conversations/{theirs.id}/messages",
+        params={"w": widget.id, "key": _VALID_KEY, "customer_ref": _REF},
+        headers={"Origin": _ORIGIN},
+    )
+
+    # 404, not an empty 200: the loader filters on customer_ref so it would answer
+    # empty anyway, but that would imply the conversation exists and is silent.
+    assert res.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_conversation_id_is_a_404(chat):
+    client, store, executor, widget = chat
+
+    res = await client.get(
+        "/paw-bar/conversations/ppc-does-not-exist/messages",
+        params={"w": widget.id, "key": _VALID_KEY, "customer_ref": _REF},
+        headers={"Origin": _ORIGIN},
+    )
+
+    assert res.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_a_known_but_empty_conversation_reads_as_empty_not_missing(chat):
+    """A conversation the store knows about with nothing said in it yet.
+
+    Distinct from a missing one, and the widget needs the difference: empty means
+    "show the greeting", 404 means "this pointer is stale, stop trusting it".
+    """
+    client, store, executor, widget = chat
+
+    opened = await store.open_conversation(widget.id, _REF, workspace_id="ws-1")
+
+    res = await client.get(
+        f"/paw-bar/conversations/{opened.id}/messages",
+        params={"w": widget.id, "key": _VALID_KEY, "customer_ref": _REF},
+        headers={"Origin": _ORIGIN},
+    )
+
+    assert res.status_code == 200, res.text
+    assert res.json()["messages"] == []
+
+
+@pytest.mark.asyncio
 async def test_visitor_conversations_never_leak_across_visitors(chat):
     """A sibling visitor of the SAME bar shares the widget, the site and the
     agent — only the handle separates them. Their conversations must not be


### PR DESCRIPTION
Backend half of fixing lost chat history. Pairs with qbtrix/paw-bar#9.

## The bug

The widget had no way to ask for its own messages. Its thread lived **only** in the frame's localStorage, so anything that lost that storage lost the history outright — and plenty does. The bar is a third-party iframe: Safari blocks its storage entirely, Chrome and Firefox partition it per top-level site, and the stored row carries a 7-day TTL besides.

The server had every message the whole time. It's what the owner's inbox reads. Nothing could fetch them.

The reported failure looked exactly like that: a visitor chats, navigates, comes back, and the panel is empty while localStorage still holds `pawbar.active.v1.<widget>` pointing at a conversation whose turns nobody can load. **The pointer outlives the thread it points at**, because the pointer has no TTL and the transcript does.

## What this adds

`GET /paw-bar/conversations/{id}/messages`, through `_load_transcript` — the same loader the owner drill-in uses, so a visitor and the site owner reading one thread are not reading two different reconstructions of it.

## Scoped twice

The front gate binds the visitor to the resolved key, and the conversation is then checked against the ones the store holds for that `(widget, visitor)` pair.

That second check is **not** redundant: a conversation id is guessable in a way an anonymous handle is not, so the id alone must never be enough to read a thread. I disabled it to confirm — two tests fail.

## 404, not an empty 200

For a foreign or unknown id. The loader filters on `customer_ref` so it would answer empty anyway, but empty *implies the conversation exists and has nothing in it* — and the widget needs that distinction: empty means show the greeting, 404 means this pointer is stale, stop trusting it.

## Checks

Four tests: a visitor reads back **both halves** of their own exchange (a thread that returns assistant-only reads as the bar talking to itself), a sibling visitor's conversation 404s, an unknown id 404s, and a known-but-silent conversation reads as empty rather than missing.

`test_paw_bar_conversation_identity.py` + `test_paw_bar_conversations.py` + `test_paw_bar_owner_conversation_identity.py` — 74 passed. ruff check + format clean.