### PR TITLE
Let the dashboard frame the Paw Bar in a site preview

### DIFF
--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -1,4 +1,23 @@
 # ee/paw_bar/router.py — HTTP surface for the Paw Bar widget layer.
+# Updated: 2026-08-21 (fix/paw-bar-preview-frame-ancestors) — the bar renders in the
+#   builder's site preview. GET /paw-bar/frame gated the embedder on the Site's
+#   ``allowed_origins`` alone, but the builder previews a site by framing its real
+#   published page, so the bar's iframe sits TWO deep — dashboard → site page → bar —
+#   and ``frame-ancestors`` is matched against EVERY ancestor, not just the immediate
+#   parent. Nothing in the publish path knows the dashboard exists, so no Site
+#   allowlist ever named it and every preview logged "Framing '<backend>' violates
+#   ... frame-ancestors" and showed an empty box. New ``_public_frame_ancestors``
+#   appends the dashboard origin — ``PAWBAR_DASHBOARD_ORIGIN`` or, unset (the state
+#   every deploy we ship is in), the already-declared
+#   ``POCKETPAW_API_CORS_ALLOWED_ORIGINS`` — through the SAME sanitizer, and new
+#   ``_ancestor_sources`` dedupes so a dashboard that is also an allowlist entry
+#   lists once. Deliberately NOT a widening of ``allowed_origins``: that list also
+#   gates chat and lead capture via ``origin_allowed``, so this widens the render
+#   gate and nothing else. Fail-closed still reads the Site's allowlist alone, so a
+#   Site with no embedders stays unrenderable. Neither var set → the header is
+#   byte-identical to before. The session-authed owner preview
+#   (``/paw-bar/admin/site/{id}/preview-frame``) is untouched and still framed by
+#   ``_dashboard_origin`` alone.
 # Updated: 2026-08-16 (fix/paw-bar-role-gates) — the last nine ``require_scope`` gates
 #   in this router become ROLE gates, so the ``require_scope`` import is gone. The
 #   two admin site-settings routes (the concierge kill switch) and the seven widget
@@ -666,6 +685,55 @@ def _sanitize_ancestor(raw: Any) -> str | None:
     return v
 
 
+def _sanitize_dashboard_ancestor(raw: Any) -> str | None:
+    """``_sanitize_ancestor``, but KEEPING an explicit http/https scheme.
+
+    This is the difference between the fix working and not working. A schemeless
+    host-source resolves against the FRAME's OWN scheme (see ``_sanitize_ancestor``),
+    so on an https backend the bare source ``localhost:5173`` means
+    ``https://localhost:5173`` — and a dashboard served over plain http, which is
+    every local dev session pointed at a deployed backend, is refused by a policy
+    that appears to name it. That is exactly the reported failure: the blocked
+    request's header already listed ``localhost:*`` and ``127.0.0.1:*``.
+
+    ``allowed_origins`` cannot carry a scheme (``_normalize_origin_hosts`` reduces it
+    to bare hosts upstream) and shouldn't — a customer's site is https in production
+    and the schemeless form is the https-tight one there. The dashboard origin is
+    different: it is declared BY the operator, complete with the scheme they serve
+    it on, so it is honored as declared. A non-browser scheme (``tauri://localhost``)
+    has no host-source spelling and is dropped rather than guessed at.
+    """
+    if not isinstance(raw, str):
+        return None
+    value = raw.strip().lower()
+    if "://" not in value:
+        return _sanitize_ancestor(value)
+    scheme, _, rest = value.partition("://")
+    if scheme not in ("http", "https"):
+        return None
+    host = _sanitize_ancestor(rest)
+    return f"{scheme}://{host}" if host else None
+
+
+def _ancestor_sources(origins: list[str], sanitize: Any = _sanitize_ancestor) -> list[str]:
+    """Sanitize origins into frame-ancestors host-sources: drop the unusable, collapse
+    repeats (first occurrence wins, order otherwise preserved).
+
+    Dedup earns its keep now that the dashboard origin is appended to the Site's
+    allowlist — in local dev it IS one of the seeded hosts. A repeated source is
+    harmless to a browser but turns the header into a puzzle in a console error,
+    which is the only place anyone ever reads one.
+    """
+    seen: set[str] = set()
+    sources: list[str] = []
+    for origin in origins or []:
+        source = sanitize(origin)
+        if source and source not in seen:
+            seen.add(source)
+            sources.append(source)
+    return sources
+
+
 def _frame_ancestors_csp(allowed_origins: list[str]) -> str | None:
     """Build the ``frame-ancestors`` CSP value from a Site's ``allowed_origins``.
 
@@ -674,10 +742,69 @@ def _frame_ancestors_csp(allowed_origins: list[str]) -> str | None:
     source-less directive. Mirrors ``site_keys.origin_allowed``'s empty=deny model,
     NOT the router's ``_origin_allowed`` empty=allow-all footgun.
     """
-    sources = [s for s in (_sanitize_ancestor(o) for o in (allowed_origins or [])) if s]
+    sources = _ancestor_sources(allowed_origins)
     if not sources:
         return None
     return "frame-ancestors " + " ".join(sources)
+
+
+def _dashboard_preview_ancestors() -> list[str]:
+    """Origins allowed to frame the PUBLIC bar because they are our own dashboard.
+
+    The builder previews a site by framing its real published page, so the bar's
+    iframe sits TWO deep — dashboard → site page → bar — and ``frame-ancestors`` is
+    matched against EVERY ancestor, not just the immediate parent. Nothing in the
+    publish path knows the dashboard exists (``_default_allowed_origins`` seeds the
+    local hosts, ``_with_deployed_host`` adds the site's own), so no Site allowlist
+    ever named it and the bar was refused in every preview.
+
+    Two sources, in order:
+      1. ``PAWBAR_DASHBOARD_ORIGIN`` — explicit, comma-separated. The SAME var the
+         session-authed owner preview reads (``_dashboard_origin``), minus its
+         ``localhost:5173`` default: unset must mean unset here, or every public
+         customer bar would name a visitor's own machine as a permitted embedder.
+      2. ``POCKETPAW_API_CORS_ALLOWED_ORIGINS`` — the origins the operator has
+         ALREADY declared as first-party browsers for this API, i.e. the
+         paw-enterprise frontend. Falling back to it is what makes a correctly
+         configured deploy work with no new variable, and that matters because no
+         deploy we ship sets PAWBAR_DASHBOARD_ORIGIN — which is how this broke.
+
+    The env is read raw rather than through ``Settings.load()``: load() re-reads
+    config.json and the credential store on every call, and this is a public,
+    per-request path. That means parsing the list here, so both the JSON shape
+    pydantic writes and the CSV operators write are accepted — every entry lands in
+    ``_sanitize_ancestor`` regardless, so a malformed one is dropped, never injected.
+    Never the request's own Origin/Referer, never a wildcard.
+    """
+    raw = os.environ.get("PAWBAR_DASHBOARD_ORIGIN", "").strip()
+    if not raw:
+        raw = os.environ.get("POCKETPAW_API_CORS_ALLOWED_ORIGINS", "").strip()
+    if not raw:
+        return []
+    parts = raw.strip("[]").split(",")
+    return [p.strip().strip('"').strip("'") for p in parts if p.strip()]
+
+
+def _public_frame_ancestors(allowed_origins: list[str]) -> str | None:
+    """``frame-ancestors`` for the PUBLIC visitor frame: the Site's allowlist, plus
+    our own dashboard so an owner can actually see the bar in the builder preview.
+
+    Fail-closed is still decided on the SITE's allowlist ALONE — a Site with no
+    embedders stays unrenderable, and a declared dashboard origin never revives it
+    (the owner preview has its own session-authed endpoint for that). The dashboard
+    entry is only ever ADDITIVE, on top of a policy that already had one source.
+
+    Deliberately NOT done by widening ``Site.allowed_origins``: that list also gates
+    chat and lead capture through ``site_keys.origin_allowed``, so writing the
+    dashboard into it would hand the dashboard origin authority it has no need for.
+    This widens the render gate and nothing else.
+    """
+    site_sources = _ancestor_sources(allowed_origins)
+    if not site_sources:
+        return None
+    dashboard = _ancestor_sources(_dashboard_preview_ancestors(), _sanitize_dashboard_ancestor)
+    extra = [s for s in dashboard if s not in site_sources]
+    return "frame-ancestors " + " ".join([*site_sources, *extra])
 
 
 def _configured_frame_origin(request: Request) -> str:
@@ -1058,8 +1185,10 @@ async def frame(
 
     # (2) The embedder gate: the CSP frame-ancestors header. Fail closed when no
     # allowlisted origin survives sanitization — refuse to render (same
-    # invisible-shell shape: this body also lands in a visible iframe).
-    csp = _frame_ancestors_csp(site.allowed_origins)
+    # invisible-shell shape: this body also lands in a visible iframe). The Site's
+    # allowlist plus OUR dashboard, which frames the site's real page in the builder
+    # preview and so becomes a second ancestor the browser matches too.
+    csp = _public_frame_ancestors(site.allowed_origins)
     if csp is None:
         return _dead_frame_response(po, site.allowed_origins)
 

--- a/tests/cloud/test_paw_bar_frame.py
+++ b/tests/cloud/test_paw_bar_frame.py
@@ -3,6 +3,16 @@
 # Created 2026-07-15: covers GET /paw-bar/frame (the iframe document + the CSP
 # frame-ancestors embedder gate) and the CSP/parent-origin helper functions.
 # Three layers:
+# Updated 2026-08-21 (dashboard preview ancestor): the builder frames a site's real
+#   published page, so the bar's iframe sits TWO deep — dashboard → site page → bar —
+#   and frame-ancestors is matched against EVERY ancestor. No Site allowlist named the
+#   dashboard, so the bar was refused in every preview with
+#   "Framing '<backend>' violates ... frame-ancestors". New coverage: the dashboard
+#   origin is admitted alongside the allowlist, sourced from PAWBAR_DASHBOARD_ORIGIN or
+#   (unset — the shipped state) the declared CORS origins; it is sanitized like any
+#   allowlist entry; it never revives an empty allowlist; and with neither source set
+#   the header is byte-identical to before. An autouse fixture clears both vars so the
+#   exact-header assertions stay hermetic.
 # Updated 2026-07-30 (frame-ancestors port fix): the expected header now carries a
 #   ``:*`` port on every portless entry. A CSP host-source with no port matches only
 #   the scheme's DEFAULT port, so a site served on any other port could not be framed
@@ -34,6 +44,14 @@ from pocketpaw.paw_bar.store import PawBarStore
 
 _VALID_KEY = "site_key_" + "a" * 24
 _FRAME_ORIGIN = "https://frame.pocketpaw.test"
+
+
+@pytest.fixture(autouse=True)
+def _no_dashboard_origin(monkeypatch):
+    """Every test here states its own dashboard config. Clearing both sources keeps
+    the exact-header assertions hermetic on a machine that happens to export one."""
+    monkeypatch.delenv("PAWBAR_DASHBOARD_ORIGIN", raising=False)
+    monkeypatch.delenv("POCKETPAW_API_CORS_ALLOWED_ORIGINS", raising=False)
 
 
 # --------------------------------------------------------------------------- #
@@ -74,6 +92,84 @@ def test_frame_ancestors_sanitizes_header_injection():
     assert csp == "frame-ancestors brewco.com:* ok.example.com:*"
     assert ";" not in csp
     assert "\n" not in csp
+
+
+def test_ancestor_sources_dedupes_repeats():
+    """The dashboard origin is appended to the Site's allowlist, and in local dev it
+    IS one of the seeded hosts — so the same source can arrive twice. A repeat is
+    harmless to a browser but makes the header a puzzle to read; it collapses to one,
+    first occurrence wins, order otherwise preserved."""
+    from pocketpaw_ee.paw_bar.router import _ancestor_sources
+
+    assert _ancestor_sources(["localhost", "brewco.com", "localhost", "https://localhost/"]) == [
+        "localhost:*",
+        "brewco.com:*",
+    ]
+
+
+def test_public_frame_ancestors_appends_configured_dashboard_origin(monkeypatch):
+    monkeypatch.setenv("PAWBAR_DASHBOARD_ORIGIN", "https://app.example.com")
+    from pocketpaw_ee.paw_bar.router import _public_frame_ancestors
+
+    assert (
+        _public_frame_ancestors(["brewco.com"])
+        == "frame-ancestors brewco.com:* https://app.example.com:*"
+    )
+
+
+def test_public_frame_ancestors_still_fails_closed_on_empty_allowlist(monkeypatch):
+    """A declared dashboard origin must NOT resurrect a Site that has no embedders.
+    Fail-closed is decided on the Site's own allowlist alone; the dashboard entry is
+    additive on top of a policy that already had at least one source."""
+    monkeypatch.setenv("PAWBAR_DASHBOARD_ORIGIN", "https://app.example.com")
+    from pocketpaw_ee.paw_bar.router import _public_frame_ancestors
+
+    assert _public_frame_ancestors([]) is None
+    assert _public_frame_ancestors(["", "   "]) is None
+
+
+def test_dashboard_ancestor_keeps_an_explicit_scheme():
+    """The reported header ALREADY listed ``localhost:*`` and the bar was blocked
+    anyway — because a schemeless host-source resolves against the FRAME's scheme, so
+    against an https backend it means ``https://localhost``. A dashboard on plain
+    http (every local session pointed at a deployed backend) needs the scheme kept,
+    or appending it changes nothing."""
+    from pocketpaw_ee.paw_bar.router import _sanitize_dashboard_ancestor
+
+    assert _sanitize_dashboard_ancestor("http://localhost:5173") == "http://localhost:5173"
+    assert _sanitize_dashboard_ancestor("https://app.example.com") == "https://app.example.com:*"
+    # No scheme declared → the allowlist's schemeless form, unchanged.
+    assert _sanitize_dashboard_ancestor("app.example.com") == "app.example.com:*"
+    # No host-source spelling for a non-browser scheme → dropped, never guessed at.
+    assert _sanitize_dashboard_ancestor("tauri://localhost") is None
+    # Header injection is refused here exactly as it is for allowed_origins.
+    assert _sanitize_dashboard_ancestor("https://evil.example; default-src *") is None
+    assert _sanitize_dashboard_ancestor("https://bad\nhost") is None
+
+
+def test_dashboard_preview_ancestors_prefers_the_explicit_var(monkeypatch):
+    from pocketpaw_ee.paw_bar.router import _dashboard_preview_ancestors
+
+    monkeypatch.setenv("PAWBAR_DASHBOARD_ORIGIN", "https://app.example.com")
+    monkeypatch.setenv("POCKETPAW_API_CORS_ALLOWED_ORIGINS", '["https://ignored.example"]')
+    assert _dashboard_preview_ancestors() == ["https://app.example.com"]
+
+
+def test_dashboard_preview_ancestors_reads_cors_origins_in_either_shape(monkeypatch):
+    """``api_cors_allowed_origins`` is a pydantic list, so the env form is JSON — but
+    operators write CSV (``.env.example`` even documents CSV for a sibling var). Read
+    the raw env permissively rather than re-implementing pydantic's parsing: both
+    shapes reach the same sanitizer, and anything malformed is dropped there."""
+    from pocketpaw_ee.paw_bar.router import _dashboard_preview_ancestors
+
+    monkeypatch.setenv("POCKETPAW_API_CORS_ALLOWED_ORIGINS", '["https://a.example"]')
+    assert _dashboard_preview_ancestors() == ["https://a.example"]
+
+    monkeypatch.setenv("POCKETPAW_API_CORS_ALLOWED_ORIGINS", "https://a.example,https://b.example")
+    assert _dashboard_preview_ancestors() == ["https://a.example", "https://b.example"]
+
+    monkeypatch.setenv("POCKETPAW_API_CORS_ALLOWED_ORIGINS", "  ")
+    assert _dashboard_preview_ancestors() == []
 
 
 def test_safe_parent_origin_only_echoes_allowlisted():
@@ -146,6 +242,93 @@ async def test_frame_valid_key_renders_with_csp(frame_client):
     assert '"siteKey": "site_key_' in body  # world-visible embed key, by design
     assert "/pawbar-app/pawbar.js" in body
     assert "/pawbar-app/pawbar.css" in body
+
+
+@pytest.mark.asyncio
+async def test_frame_admits_the_dashboard_as_an_ancestor(frame_client, monkeypatch):
+    """The reported bug. The builder previews a site by framing its real published
+    page, so the bar's iframe sits TWO deep — dashboard → site page → bar — and
+    frame-ancestors is matched against EVERY ancestor, not just the immediate parent.
+    Nothing in the publish path knows the dashboard exists, so no Site allowlist ever
+    named it and the bar was refused in every preview."""
+    monkeypatch.setenv("PAWBAR_DASHBOARD_ORIGIN", "https://app.example.com")
+    await _site(allowed_origins=["brewco.com"])
+    res = await frame_client.get("/paw-bar/frame", params={"key": _VALID_KEY})
+
+    assert res.status_code == 200
+    assert (
+        res.headers["content-security-policy"]
+        == "frame-ancestors brewco.com:* https://app.example.com:*"
+    )
+
+
+@pytest.mark.asyncio
+async def test_frame_admits_an_http_dashboard_against_an_https_frame(frame_client, monkeypatch):
+    """The reported case, end to end: a local dashboard driving a DEPLOYED https
+    backend. The Site allowlist already seeds ``localhost``, and the bar was still
+    blocked, because that bare source reads as https against an https frame. The
+    dashboard entry carries the scheme, so the header now says what it means."""
+    monkeypatch.setenv("PAWBAR_DASHBOARD_ORIGIN", "http://localhost:5173")
+    await _site(allowed_origins=["localhost", "127.0.0.1", "site.pawsites.workers.dev"])
+    res = await frame_client.get("/paw-bar/frame", params={"key": _VALID_KEY})
+
+    assert res.status_code == 200
+    assert res.headers["content-security-policy"] == (
+        "frame-ancestors localhost:* 127.0.0.1:* site.pawsites.workers.dev:* http://localhost:5173"
+    )
+
+
+@pytest.mark.asyncio
+async def test_frame_falls_back_to_the_declared_cors_origins(frame_client, monkeypatch):
+    """No deploy we ship sets PAWBAR_DASHBOARD_ORIGIN — which is exactly how this
+    broke. The operator has already declared where the frontend lives, as the API's
+    CORS origins, so an unset var reads those instead of staying silently broken."""
+    monkeypatch.setenv("POCKETPAW_API_CORS_ALLOWED_ORIGINS", '["https://app.example.com"]')
+    await _site(allowed_origins=["brewco.com"])
+    res = await frame_client.get("/paw-bar/frame", params={"key": _VALID_KEY})
+
+    assert (
+        res.headers["content-security-policy"]
+        == "frame-ancestors brewco.com:* https://app.example.com:*"
+    )
+
+
+@pytest.mark.asyncio
+async def test_frame_ancestors_unchanged_when_no_dashboard_is_configured(frame_client):
+    """Neither source set (the autouse fixture clears both) → the header is EXACTLY
+    the Site's allowlist. In particular the ``localhost:5173`` default that
+    ``_dashboard_origin`` applies to the session-authed OWNER preview must not leak
+    into the public frame, where it would name every visitor's own machine as a
+    permitted embedder of a customer's bar."""
+    await _site(allowed_origins=["brewco.com"])
+    res = await frame_client.get("/paw-bar/frame", params={"key": _VALID_KEY})
+
+    assert res.headers["content-security-policy"] == "frame-ancestors brewco.com:*"
+
+
+@pytest.mark.asyncio
+async def test_frame_sanitizes_the_dashboard_origin(frame_client, monkeypatch):
+    """The var is operator-controlled data flowing into a response HEADER, so it goes
+    through the SAME sanitizer allowed_origins does: an unusable value is dropped and
+    the Site's own policy still renders — never a split header, never a 403."""
+    monkeypatch.setenv("PAWBAR_DASHBOARD_ORIGIN", "https://app.example.com; default-src *")
+    await _site(allowed_origins=["brewco.com"])
+    res = await frame_client.get("/paw-bar/frame", params={"key": _VALID_KEY})
+
+    assert res.status_code == 200
+    assert res.headers["content-security-policy"] == "frame-ancestors brewco.com:*"
+
+
+@pytest.mark.asyncio
+async def test_frame_dashboard_origin_does_not_revive_an_empty_allowlist(frame_client, monkeypatch):
+    """Fail-closed is decided on the SITE's allowlist alone. A Site with no embedders
+    stays unrenderable even when a dashboard origin is declared — the owner preview
+    has its own session-authed endpoint for that."""
+    monkeypatch.setenv("PAWBAR_DASHBOARD_ORIGIN", "https://app.example.com")
+    await _site(allowed_origins=[])
+    res = await frame_client.get("/paw-bar/frame", params={"key": _VALID_KEY})
+
+    assert res.status_code == 403
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Opening a site in the builder logs this and leaves an empty box where the bar should be:

```
Framing 'https://backend.hzd.interacly.com/' violates the following Content Security
Policy directive: "frame-ancestors localhost:* 127.0.0.1:*
paw-site-289e48b1be86c7071f2fda8c.pawsites.workers.dev:*". The request has been blocked.
```

## Why

The preview frames the site's real published page, so the bar's iframe sits two deep:

```
dashboard                 <- not on any allowlist
  site page               <- paw-site-....workers.dev
    bar                   <- backend, writes the policy
```

`frame-ancestors` is matched against every ancestor, not just the immediate parent. The
header is built from `Site.allowed_origins`, which `_default_allowed_origins` seeds with
the local hosts and `_with_deployed_host` tops up with the site's own host at deploy.
Nothing in that path knows the dashboard exists, so the grandparent was never named and
the browser refused the frame. The bar works fine on the live site, where the site page
is the only ancestor — which is why this only ever showed up in the builder.

## What changed

`_public_frame_ancestors` appends the dashboard origin to the Site's allowlist, from
`PAWBAR_DASHBOARD_ORIGIN` or, when that is unset, the CORS origins already declared for
the frontend. The fallback is the interesting half: no deploy we ship sets
`PAWBAR_DASHBOARD_ORIGIN`, which is how this shipped broken and how the owner-preview
endpoint is quietly still defaulting to `localhost:5173` in production.

The dashboard entry keeps its scheme, and that detail is the whole fix. A schemeless
host-source resolves against the frame's own scheme, so against an https backend a bare
`localhost:5173` reads as `https://localhost:5173`. That is why the header in the report
already lists `localhost:*` and a local dashboard was refused anyway — appending the
origin without its scheme would have changed nothing. `allowed_origins` stays schemeless:
it is normalized to bare hosts upstream, and the https-tight reading is the correct one
for a customer's site.

Deliberately not done by widening `allowed_origins`. That list also gates chat and lead
capture through `origin_allowed`, so writing the dashboard into it would hand the
dashboard authority it has no use for. This widens the render gate and nothing else.

Unchanged: fail-closed still reads the Site's allowlist alone, so a site with no
embedders stays unrenderable even with a dashboard origin declared. With neither variable
set the header is byte-identical to before. The session-authed owner preview
(`/paw-bar/admin/site/{id}/preview-frame`) is untouched.

## Deploying

Nothing to set if `POCKETPAW_API_CORS_ALLOWED_ORIGINS` already carries the frontend
origin. Otherwise set `PAWBAR_DASHBOARD_ORIGIN` to the dashboard's origin — the page you
have open, not the backend.

## Tests

31 in `tests/cloud/test_paw_bar_frame.py`, 120 across the paw-bar cloud suites. Both
halves were mutation-checked: reverting the call site fails 3 tests, dropping the scheme
from the dashboard entry fails 4.

## Noticed on the way

`deploy/coolify/.env.example` documents `POCKETPAW_CLOUD_ALLOWED_ORIGINS` as "Public
hostname your browser hits (paw-enterprise frontend)". Nothing reads it — the live
setting is `api_cors_allowed_origins` (`POCKETPAW_API_CORS_ALLOWED_ORIGINS`). Left alone
here; worth a follow-up before it misleads someone else.
