### PR TITLE
The appearance preview frames the real site, not a picture of it

### DIFF
--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -437,6 +437,7 @@ import re
 import uuid
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime
+from html import escape
 from pathlib import Path
 from typing import Any
 
@@ -901,41 +902,11 @@ def _safe_parent_origin(po: str, allowed_origins: list[str]) -> str:
     return f"{scheme}://{hostport}"
 
 
-def _safe_css_url(value: str) -> str:
-    """A path or https URL safe inside a CSS ``url("...")`` literal, or "".
-
-    We own the quotes, so what must be impossible is terminating the token or
-    starting a new declaration. Anything carrying a quote, a paren, a backslash,
-    whitespace or a semicolon is REFUSED rather than escaped — the values we
-    actually need (an /api/v1/uploads/{id} path) contain none of them, so refusing
-    costs nothing and leaves nothing to get subtly wrong.
-
-    Mirrors ``paw_bar.appearance._safe_image_url``, which guards the same class of
-    literal for the owner's own hero and avatar URLs.
-    """
-    v = (value or "").strip()
-    if not v:
-        return ""
-    if any(c in v for c in "()\"'\\ \n\r\t;"):
-        return ""
-    if v.startswith("/") and not v.startswith("//"):
-        return v
-    if v.lower().startswith("https://"):
-        return v
-    return ""
-
-
-# Dark page background for the OWNER preview frame only (not the public embed), so
-# the transparent glass bar sits on a dark surface matching the dashboard instead of
-# a white canvas. A near-black neutral tuned to the paw-enterprise dark theme.
-_PREVIEW_PAGE_BG = "#0d0e12"
-
-
 def _pawbar_bootstrap_html(
     config: dict[str, Any],
     asset_mount: str,
     page_bg: str = "",
-    backdrop_url: str = "",
+    scene_url: str = "",
 ) -> str:
     """Render the glass frame document: seed ``window.__PAWBAR__`` then load the app.
 
@@ -955,33 +926,40 @@ def _pawbar_bootstrap_html(
     """
     config_json = json.dumps(config).replace("<", "\\u003c")
     v = _asset_version()
-    # The OWNER preview paints the site's own screenshot behind the bar, so the
-    # owner judges their theme against the page it will actually sit on rather
-    # than against a neutral rectangle. A picture, deliberately, not an iframe of
-    # the live site: a framed site can refuse (X-Frame-Options / frame-ancestors)
-    # and would leave a blank box, and it would run the customer's own scripts
-    # inside our preview. The screenshot always renders, and it is already taken.
+    # THE SITE ITSELF, behind the bar (owner preview only). The owner judges a
+    # theme on the page it will actually sit on — scrolling, responding, current
+    # — rather than on a screenshot of it or on a colour we chose. Composed HERE
+    # rather than in the dashboard because this is where the URL already is: the
+    # route has the Site document open.
     #
-    # ``backdrop_url`` is same-origin with this document (both are this API), so
-    # the auth-gated /api/v1/uploads/{id} it points at is fetched with the session
-    # cookie. The dashboard needs a grant flow to read the same file; this frame
-    # does not, because it is not cross-origin with it.
+    # ?pawbar=off keeps the page's OWN embedded bar down. A published site
+    # auto-embeds the public one, and without this the owner sees two — the public
+    # bar on the SAVED look behind the one being edited, and the wrong one is what
+    # responds to the controls.
     #
-    # Re-sanitized rather than trusted: it comes off a stored document field, and
-    # what we are building here is a CSS literal.
-    safe_backdrop = _safe_css_url(backdrop_url)
-    if page_bg and safe_backdrop:
-        preview_style = (
-            "<style>html,body{"
-            f"background-color:{page_bg};"
-            f'background-image:url("{safe_backdrop}");'
-            "background-size:cover;background-position:top center;"
-            "background-repeat:no-repeat;color-scheme:dark}</style>\n"
-        )
-    elif page_bg:
-        preview_style = f"<style>html,body{{background:{page_bg};color-scheme:dark}}</style>\n"
-    else:
-        preview_style = ""
+    # Sandboxed. It is the owner's own page, but still a whole third-party
+    # document running inside our frame: allow-scripts so it renders as it really
+    # does, and deliberately NOT allow-same-origin beside it, which would hand it
+    # this document.
+    scene_html = (
+        f'<iframe class="pawbar-scene" src="{escape(scene_url, quote=True)}" '
+        f'title="Your site" '
+        f'sandbox="allow-scripts allow-popups allow-forms"></iframe>'
+        if scene_url
+        else ""
+    )
+    # The scene fills the document and the bar app draws over it. Fixed rather
+    # than absolute so the bar stays put while the framed page scrolls under it,
+    # which is how it behaves on a real page.
+    scene_style = (
+        "<style>html,body{margin:0;height:100%}iframe.pawbar-scene{position:fixed;inset:0;width:100%;height:100%;border:0}</style>"
+        + chr(10)
+        if scene_url
+        else ""
+    )
+    preview_style = (
+        f"<style>html,body{{background:{page_bg};color-scheme:dark}}</style>\n" if page_bg else ""
+    )
     return (
         "<!doctype html>\n"
         '<html lang="en">\n'
@@ -990,9 +968,11 @@ def _pawbar_bootstrap_html(
         '<meta name="viewport" content="width=device-width, initial-scale=1">\n'
         "<title>Paw Bar</title>\n"
         f'<link rel="stylesheet" href="{asset_mount}/pawbar.css?v={v}">\n'
+        f"{scene_style}"
         f"{preview_style}"
         "</head>\n"
         "<body>\n"
+        f"{scene_html}"
         '<div id="pawbar-root"></div>\n'
         f"<script>window.__PAWBAR__ = {config_json};</script>\n"
         f'<script src="{asset_mount}/pawbar.js?v={v}"></script>\n'
@@ -2983,18 +2963,18 @@ async def get_site_preview_frame(
         preview=True,
     )
     # Preview-only dark page so the transparent bar reads as sitting on the dark
-    # dashboard, not a white canvas. The public /paw-bar/frame passes no page_bg
-    # (stays transparent over the customer's real site).
-    # The site's own screenshot goes behind the bar, so the owner judges their
-    # theme against the page it will sit on. Same field the gallery card renders
-    # and Match my site reads; empty until a capture has run, which falls back to
-    # the flat dark surface below.
-    html = _pawbar_bootstrap_html(
-        config,
-        PAWBAR_APP_MOUNT,
-        page_bg=_PREVIEW_PAGE_BG,
-        backdrop_url=getattr(site, "preview_image_url", "") or "",
-    )
+    # TRANSPARENT, exactly like the public embed. The dashboard composes the
+    # preview now: it frames the site's own published page and lays this frame
+    # over it, so the bar sits on the real page rather than on a colour we chose
+    # for it. A page background here would paint over that site.
+    # The site's own published URL, straight off the document this route already
+    # loaded. "" when the site has never deployed, or deployed with no dispatch
+    # domain configured — there is genuinely nothing to frame then, and the bar
+    # previews on a plain surface rather than in an empty white box.
+    scene = getattr(site, "url", "") or ""
+    if scene:
+        scene += ("&" if "?" in scene else "?") + "pawbar=off"
+    html = _pawbar_bootstrap_html(config, PAWBAR_APP_MOUNT, scene_url=scene)
     return HTMLResponse(
         content=html,
         headers={"Content-Security-Policy": csp, "Cache-Control": "no-store"},

--- a/tests/cloud/test_paw_bar_concierge_settings.py
+++ b/tests/cloud/test_paw_bar_concierge_settings.py
@@ -291,24 +291,49 @@ async def test_settings_patch_is_partial(client):
 
 
 @pytest.mark.asyncio
-async def test_preview_frame_paints_the_site_behind_the_bar(client):
-    """The owner judges a theme against the page it will sit on, not a rectangle."""
+async def test_the_preview_frames_the_site_itself(client):
+    """The owner judges a theme on the page it will sit on.
+
+    Not a screenshot of it — that was the earlier attempt and it was wrong: a
+    picture does not scroll, does not respond, and goes stale between captures.
+    The published page is frameable (we publish it; the generated worker sets no
+    X-Frame-Options), so it is framed.
+    """
     c, store = client
-    site = await _site(preview_image_url="/api/v1/uploads/shot123")
+    site = await _site(url="https://s1.paw-sites.test")
     await store.create_widget(_widget())
 
     res = await c.get(f"/paw-bar/admin/site/{site.id}/preview-frame")
 
     assert res.status_code == 200, res.text
-    assert 'background-image:url("/api/v1/uploads/shot123")' in res.text
-    # Same-origin with this document, so the auth-gated upload is fetched with the
-    # session cookie — no grant flow, unlike the dashboard's cross-origin read.
-    assert "background-size:cover" in res.text
+    assert 'class="pawbar-scene"' in res.text
+    assert "https://s1.paw-sites.test" in res.text
+    # The page auto-embeds the PUBLIC bar. Without this the owner sees two, and
+    # the one that answers the controls is the one behind.
+    assert "pawbar=off" in res.text
 
 
 @pytest.mark.asyncio
-async def test_preview_frame_without_a_capture_keeps_the_flat_surface(client):
-    """A site whose screenshot has not run yet must not render a broken image."""
+async def test_the_framed_site_is_sandboxed_away_from_the_frame(client):
+    """It is the owner's own page, and still a whole third-party document running
+    inside ours. allow-scripts WITH allow-same-origin would hand it this
+    document — and this document holds the site key and takes live token updates.
+    """
+    c, store = client
+    site = await _site(url="https://s1.paw-sites.test")
+    await store.create_widget(_widget())
+
+    res = await c.get(f"/paw-bar/admin/site/{site.id}/preview-frame")
+
+    assert "sandbox=" in res.text
+    assert "allow-scripts" in res.text
+    assert "allow-same-origin" not in res.text
+
+
+@pytest.mark.asyncio
+async def test_an_undeployed_site_previews_without_a_scene(client):
+    """Never deployed, or deployed with no dispatch domain configured. There is
+    nothing to frame, and an empty frame would read as a broken editor."""
     c, store = client
     site = await _site()
     await store.create_widget(_widget())
@@ -316,29 +341,31 @@ async def test_preview_frame_without_a_capture_keeps_the_flat_surface(client):
     res = await c.get(f"/paw-bar/admin/site/{site.id}/preview-frame")
 
     assert res.status_code == 200
-    assert "background-image" not in res.text
-    from pocketpaw_ee.paw_bar.router import _PREVIEW_PAGE_BG
-
-    assert _PREVIEW_PAGE_BG in res.text
+    assert "pawbar-scene" not in res.text
+    # The bar is still previewable; that is the point of the pane.
+    assert 'id="pawbar-root"' in res.text
 
 
 @pytest.mark.asyncio
-async def test_a_backdrop_that_could_break_out_of_the_css_is_refused(client):
-    """The URL lands inside a url("...") literal we construct.
+async def test_the_owner_preview_frame_is_transparent(client):
+    """It composites over the site, so it must not paint a page of its own.
 
-    It comes off a stored document field, so it is sanitized rather than trusted:
-    a value carrying a quote could close the literal and start a new declaration.
-    Refused outright — the site falls back to the flat surface.
+    The dashboard frames the site's published page and lays this frame on top, so
+    the bar is judged on the page it will actually sit on. Any background here
+    paints over that — which is what the earlier screenshot-backdrop attempt did,
+    and why it is gone.
     """
     c, store = client
-    site = await _site(preview_image_url='/a"); background:url(https://evil.test/x')
+    site = await _site()
     await store.create_widget(_widget())
 
     res = await c.get(f"/paw-bar/admin/site/{site.id}/preview-frame")
 
-    assert res.status_code == 200
-    assert "evil.test" not in res.text
-    assert "background-image" not in res.text
+    assert res.status_code == 200, res.text
+    assert "background" not in res.text
+    # Still the OWNER frame, though: the preview flag is what lets it take live
+    # token updates from the appearance editor.
+    assert '"preview": true' in res.text or '"preview":true' in res.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Reverts #1979 and replaces it with the thing it was standing in for. Pairs with qbtrix/paw-bar#10.

## #1979 was the wrong answer

It painted the site's stored **screenshot** behind the bar. A picture of a site is not a site: it doesn't scroll, doesn't respond, and goes stale between captures — which is why it needed a Refresh button at all. That button was the smell, and I built around it instead of listening to it.

The reason I didn't frame the real page was a CSP / `X-Frame-Options` risk **that doesn't apply to us**. We publish these sites, and the generated worker sets no frame headers at all — they're frameable today. I reasoned from a generic constraint about framing third-party pages instead of checking our own product.

## What it does now

The preview frame renders the site's own published page behind the bar, and the bar draws over it.

Composed **here rather than in the dashboard** because this is where the URL already is: the route has the Site document open and `site.url` is on it. Threading it out to the client and back would be plumbing for nothing.

`?pawbar=off` keeps the page's own embedded bar down. A published site auto-embeds the public one, so without it the owner sees **two** bars — the public one on the *saved* look behind the one being edited, and the wrong one is what responds to the controls. The loader's opt-out for that is paw-bar#10.

## The scene is sandboxed

It's the owner's own page, and it's still a whole third-party document running inside our frame — a frame that holds the site key and accepts live token updates. `allow-scripts` so the page renders as it really does; **`allow-same-origin` deliberately not granted beside it**, which together would hand that document straight back to this one.

## The page background goes too

Wrong twice over: it would paint over the site, and it only existed because this frame used to *be* the whole preview pane and needed not to look like a white box on dark chrome. The frame is now exactly what the public embed is — transparent, on someone else's page. `_PREVIEW_PAGE_BG` is deleted.

The preview **flag** stays. Different thing: it's what lets this frame take live `--pawbar-*` updates from the editor, and the public embed still must not.

## Checks

Six tests: the site is framed, its own bar is suppressed, the sandbox withholds `allow-same-origin`, the frame paints no background, an undeployed site previews on a plain surface, and the preview flag survives.

`test_paw_bar_concierge_settings.py` + `test_paw_bar_frame.py` + `test_paw_bar_appearance.py` — 88 passed. The one failure (`test_frame_valid_key_renders_with_csp`) is local-env: my `.env` supplies a dashboard origin that lands in `frame-ancestors`. It's unrelated to this diff.

Also restores a line-length fix the revert undid — #1979's `ruff format` pass had reflowed an unrelated helper, and reverting the commit reverted that too.

**Note:** needs paw-bar#10 merged and the vendored loader refreshed before `?pawbar=off` actually suppresses anything.