### PR TITLE
Static svelte publishes can build in the sandbox instead of blocking the API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -172,3 +172,14 @@
 #                                                # "python:3.12-slim"). Unset or "standard"
 #                                                # uses the pre-built Paw dev image with
 #                                                # Python, Node.js, GCC, Docker, and UV.
+
+# ── Paw Sites build lane ───────────────────────────────────
+# Which engines build in a Daytona sandbox rather than inline in the API process.
+# react has since SL-3 and is not configurable. STATIC svelte is opt-in:
+# PAW_SITES_SVELTE_ASYNC_BUILD=false
+#   Requires DAYTONA_API_URL + DAYTONA_API_KEY — the lane has NO local fallback, so
+#   turning it on without them turns working svelte publishes into failures. Set it on
+#   the web service AND the worker (web decides to enqueue, worker does the build).
+#   Dynamic svelte is never routed to the lane whatever this says: its artifact is
+#   worker-rendered and cannot serve from a tar.
+#   Caveat before enabling — docs/internal/2026-05-resumable-runs-deploy.md.

--- a/docs/internal/2026-05-resumable-runs-deploy.md
+++ b/docs/internal/2026-05-resumable-runs-deploy.md
@@ -130,6 +130,35 @@ Env vars (all also documented in `backend/CLAUDE.md` → Key Conventions):
 | `POCKETPAW_CLOUD_RUN_STREAM_TTL` | `3600` | Redis Stream retention after a run terminates |
 | `POCKETPAW_CLOUD_STREAM_TRANSPORT` | `redis` | Future hook for non-Redis backends |
 | `PAW_SITES_BUILD_TIMEOUT_SEC[_<ENGINE>]` | `600` (floor) | Per-build sandbox budget for the site-build function. Read at worker **import**, so a change takes effect on the worker restart a deploy performs — see below |
+| `PAW_SITES_SVELTE_ASYNC_BUILD` | unset (off) | Routes STATIC svelte publishes to the Daytona build lane instead of building them inline. Read per call, so it takes effect without a restart — but set it on **both** the web service and the worker: the web side decides whether to enqueue, the worker side does the build. See the caveat below before turning it on |
+
+### Turning the svelte lane on (`PAW_SITES_SVELTE_ASYNC_BUILD`)
+
+Off by default. On, a **static** svelte publish stops blocking the API process on
+`bun install` + `bun run build` and goes through the same lane react has used since SL-3.
+A **dynamic** svelte site is never routed there whatever the flag says — its
+adapter-cloudflare artifact is rendered by a `_worker.js` whose imports sit outside the
+tarred directory, so the artifact cannot execute.
+
+**Requires Daytona.** The lane has no local fallback: with `DAYTONA_API_URL` /
+`DAYTONA_API_KEY` unset, `run_build` raises and the publish settles
+`sandbox_unavailable:run_build_raised`. Turning this on where Daytona is not configured
+converts working svelte publishes into failures.
+
+**What you give up, and what you do not.** An inline publish runs `paw-sites`'s
+`runWorkerdSmokeRender`, which makes two checks the sandbox has no paw-sites to make:
+
+- The known-workerd-marker scan — **recovered**. The wrapper greps the whole build log
+  for the same markers and fails the build on a hit, which is stricter than the inline
+  path's own read of a truncated stderr tail.
+- The **resting-visibility guard** — **not recovered**. It judges a clean build by reading
+  the prerendered `index.html` and the emitted CSS to catch a page that is blank at rest,
+  and nothing about an exit code substitutes for it. Until the lane can run that verdict,
+  a site published through it is not checked for the blank-at-rest failure.
+
+That gap is why the flag is off by default rather than a straight flip. Its fix is a
+`paw-sites-gen` subcommand that judges an already-built tree, called by the worker on the
+unpacked artifact.
 
 ### The worker runs three functions, each with its own timeout
 

--- a/ee/pocketpaw_ee/agent/mcp_servers/sites.py
+++ b/ee/pocketpaw_ee/agent/mcp_servers/sites.py
@@ -35,7 +35,12 @@
 # pocket_id / name / url / deployed) while ``_to_response`` — the wire the FRONTEND
 # polls — also carries ``build_status`` / ``build_reason`` / ``build_job_id``. The
 # agent got none of the three, and react is the one engine where that breaks the happy
-# path, because it is the only engine with ``build_runs_async(engine) is True``:
+# path, because it is the only engine with ``build_runs_async(engine) is True``
+# unconditionally. Updated 2026-08-21 (SL-4): STATIC svelte answers True as well once
+# ``PAW_SITES_SVELTE_ASYNC_BUILD`` is on, so everything below now describes two engines
+# rather than one. Nothing here needed changing for that — the keys ride the response for
+# whatever the gate flips, which is why they were added to the response and not to a
+# react branch.
 #
 #   * FIRST publish — ``_enqueue_static_build`` creates the Site doc with ``url=""``
 #     and ``deployed=False``, honestly (nothing is serving yet; the worker flips both
@@ -306,7 +311,9 @@ async def _publish_handler(args: dict) -> dict:
     # RX-4 — the build lane's state rides the response. Without it this body was five
     # keys (id / pocket_id / name / url / deployed), and on the react happy path that
     # is actively misleading in two different ways, because react is the only engine
-    # with ``build_runs_async(engine) is True``:
+    # with ``build_runs_async(engine) is True`` unconditionally — and since SL-4 a STATIC
+    # svelte publish takes the same path whenever the lane is switched on, so read every
+    # "react" below as "any engine the gate flips":
     #
     #   * FIRST publish — ``_enqueue_static_build`` creates the Site doc with
     #     ``url=""`` and ``deployed=False``, honestly, because nothing is serving yet.

--- a/ee/pocketpaw_ee/sites/build_job.py
+++ b/ee/pocketpaw_ee/sites/build_job.py
@@ -468,6 +468,13 @@ async def run_site_build(
 
     await sites_service.mark_build_running(site)
 
+    # SL-4 — decided ONCE, from the payload, and used by both the tar's include-list and
+    # the deploy's unpack. Deriving it twice is how the two end up disagreeing, and a
+    # disagreement here unpacks an artifact into a directory the deployer does not read.
+    from pocketpaw_ee.sites.generator_client import expected_static_output_rel
+
+    artifact_rel = expected_static_output_rel(engine, generator_input)
+
     work_dir = tempfile.mkdtemp(prefix=f"paw-build-{site_id}-")
     try:
         try:
@@ -515,6 +522,7 @@ async def run_site_build(
                 engine=normalize_engine(engine),
                 timeout_seconds=timeout_seconds,
                 client=_client,
+                artifact_rel=artifact_rel,
             )
         except Exception:
             # Nothing ran: Daytona unconfigured, or the sandbox could not be created.
@@ -547,6 +555,7 @@ async def run_site_build(
                 engine=engine,
                 deploy_inputs=deploy_inputs,
                 deployer=_deployer,
+                output_rel=artifact_rel,
             )
         except Exception:
             # The build worked and the deploy did not, so this is NOT a build failure —
@@ -575,6 +584,7 @@ async def _deploy_built_artifact(
     engine: str,
     deploy_inputs: dict[str, Any],
     deployer: Any = None,
+    output_rel: str | None = None,
 ) -> None:
     """Materialise the artifact into a project-dir shape and run the deploy tail.
 
@@ -585,15 +595,35 @@ async def _deploy_built_artifact(
     those guards has a mutation proving it fires. Hand-rolling an extractor for the deploy
     path would mean the deploy got the unproven copy.
 
-    Its skip list is written for a PREVIEW (``_worker.js`` and deploy metadata are
-    dropped), which is harmless here only because this path is react-only: react emits no
-    server entry, and ``deploy_workers`` writes its own ``.assetsignore``. Widening
-    ``service.build_runs_async`` past react means revisiting this — an engine whose worker
-    IS the site cannot have it dropped on the way to the edge.
-
     The tree is extracted UNDER the engine's static-output rel, because the deploy targets
     resolve their source as ``<project_dir>/<static_output_rel>`` while the tar is rooted
     AT that directory's contents. Extracting flat would deploy an empty dir.
+
+    ``output_rel`` IS THE SAME PREDICTION THE TAR USED (SL-4), passed down rather than
+    recomputed. svelte has two output dirs and the deploy targets probe for them in a
+    fixed order (``engines.resolve_static_output_rel``), so extracting an adapter-static
+    tree under the nominal ``.svelte-kit/cloudflare`` would still be FOUND — by accident,
+    because the probe falls through to it — while reporting the wrong adapter to anything
+    that asks. Threading the one value the tar was built from keeps the pack and the
+    unpack unable to disagree. ``None`` keeps the nominal value, so react is unchanged.
+
+    ── THE SERVER-ENTRY REFUSAL (the obligation this docstring used to only record) ─────
+
+    ``unpack_artifact``'s skip list DROPS ``_worker.js``. That list is written for a
+    PREVIEW, where a worker is noise the preview server cannot run anyway — and it was
+    harmless here only while this path was react-only, since react emits no server entry.
+    Widening the gate past react is exactly the event the previous version of this
+    docstring warned about, so the warning is now a check.
+
+    An artifact carrying a server entry is REFUSED rather than unpacked, because for an
+    engine whose worker IS the site, silently dropping it deploys a shell that cannot
+    start — a working site replaced by a broken one, with every status reporting success.
+    Refusing settles the row as a deploy failure instead, which is recoverable and true.
+
+    It should be unreachable: ``service.build_runs_async`` keeps dynamic svelte and ripple
+    out of this lane precisely because their artifacts are worker-rendered. "Unreachable"
+    is the reason to check it, not a reason to skip it — the gate reads a prediction, and
+    this reads what actually arrived.
     """
     if not artifact:
         # ``settle`` only reaches ``built`` via ``BuildRunResult.ok``, which requires
@@ -605,21 +635,57 @@ async def _deploy_built_artifact(
     from pocketpaw_ee.sites import service as _service
     from pocketpaw_ee.sites.engines import static_output_rel
 
+    _refuse_server_entry(artifact, engine=engine, site_id=deploy_inputs.get("site_id"))
+
+    rel = output_rel or static_output_rel(engine)
     deploy = deployer or _service.deploy_prebuilt_site
     project_dir = tempfile.mkdtemp(prefix="paw-deploy-")
     try:
-        unpacked = artifact_preview.unpack_artifact(
-            artifact, Path(project_dir, static_output_rel(engine))
-        )
+        unpacked = artifact_preview.unpack_artifact(artifact, Path(project_dir, rel))
         logger.info(
-            "sites.build: materialised %d entries (%d bytes) for the deploy of site %s",
+            "sites.build: materialised %d entries (%d bytes) under %s for the deploy of site %s",
             unpacked.entries,
             unpacked.bytes_written,
+            rel,
             deploy_inputs.get("site_id"),
         )
         await deploy(project_dir=project_dir, deploy_inputs=deploy_inputs)
     finally:
         shutil.rmtree(project_dir, ignore_errors=True)
+
+
+def _refuse_server_entry(artifact: bytes, *, engine: str, site_id: Any) -> None:
+    """Raise when the artifact carries a ``_worker.js`` the unpack would silently drop.
+
+    Reads the tar's MEMBER NAMES only — no extraction, no decompression of contents beyond
+    what the index needs — so this cannot itself become the zip-bomb surface
+    ``unpack_artifact`` is hardened against.
+
+    ``_worker.js`` is matched as a path COMPONENT rather than a filename, because
+    adapter-cloudflare emits it as a DIRECTORY (``_worker.js/chunks/0.js``) once an app is
+    large enough. ``engines.resolve_emits_server_worker`` had to learn the same thing from
+    the other side; a check keyed on a file would report "no worker" for exactly the
+    biggest, most broken-if-dropped sites.
+
+    An UNREADABLE archive is not this function's failure to report: ``verify_artifact``
+    already rejects one upstream with a reason of its own, so re-raising here would
+    relabel a known condition. Pass and let the unpack speak.
+    """
+    import tarfile
+    from io import BytesIO
+
+    try:
+        with tarfile.open(fileobj=BytesIO(artifact), mode="r:gz") as tar:
+            names = tar.getnames()
+    except Exception:  # noqa: BLE001 — see the docstring; not our condition to report
+        return
+    for name in names:
+        if any(part == "_worker.js" for part in name.replace("\\", "/").split("/")):
+            raise RuntimeError(
+                f"refusing to deploy a {normalize_engine(engine)} artifact carrying a "
+                f"server entry ({name}) — the unpack would drop it and deploy a shell "
+                f"that cannot start (site {site_id})"
+            )
 
 
 async def _scaffold(generator_input: dict[str, Any], out_dir: str, *, runner: Any = None) -> str:

--- a/ee/pocketpaw_ee/sites/daytona_build.py
+++ b/ee/pocketpaw_ee/sites/daytona_build.py
@@ -732,9 +732,7 @@ def _render_marker_scan(markers: tuple[str, ...]) -> str:
     """
     if not markers:
         return "# no SSR markers configured for this engine\n"
-    tests = " || ".join(
-        f'grep -qF -- {shlex.quote(marker)} "$STDERR_LOG"' for marker in markers
-    )
+    tests = " || ".join(f'grep -qF -- {shlex.quote(marker)} "$STDERR_LOG"' for marker in markers)
     return (
         f"if {tests}; then\n"
         '  echo "paw: build log carries a known SSR failure marker" >>"$STDERR_LOG"\n'

--- a/ee/pocketpaw_ee/sites/daytona_build.py
+++ b/ee/pocketpaw_ee/sites/daytona_build.py
@@ -51,7 +51,11 @@ import tarfile
 from dataclasses import dataclass
 from typing import Any, Literal
 
-from pocketpaw_ee.sites.engines import normalize_engine, static_output_rel
+from pocketpaw_ee.sites.engines import (
+    candidate_static_output_rels,
+    normalize_engine,
+    static_output_rel,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -453,6 +457,8 @@ def artifact_tar_command(
     engine: str | None,
     project_dir: str,
     dest_path: str,
+    *,
+    output_rel: str | None = None,
 ) -> str:
     """The in-sandbox command that packs ONLY the deployable output.
 
@@ -476,8 +482,35 @@ def artifact_tar_command(
     (``html``): tarring ``.`` would sweep in ``node_modules`` and defeat the whole
     design. html needs no build and so never reaches this lane; a caller that gets
     here with it has a routing bug and should hear about it loudly.
+
+    ``output_rel`` NAMES WHICH OUTPUT DIR THIS BUILD WILL WRITE, for the one engine that
+    has more than one (SL-4). svelte builds on adapter-static (``build``) or
+    adapter-cloudflare (``.svelte-kit/cloudflare``) depending on the site's bindings, and
+    the include-list is rendered into the wrapper BEFORE the build runs, so it cannot read
+    the answer off disk the way ``engines.resolve_static_output_rel`` does. The caller
+    predicts it with ``generator_client.expected_static_output_rel`` — the same helper the
+    unpack uses — and passes it here. ``None`` keeps the nominal per-engine value, so every
+    pre-SL-4 call renders a byte-identical command.
+
+    An ``output_rel`` the engine cannot emit is REFUSED rather than honoured. An
+    include-list aimed at a directory that will never exist packs nothing, and an empty
+    artifact is indistinguishable from a build that produced nothing — so the caller's
+    mistake would arrive disguised as the user's. ``engines.candidate_static_output_rels``
+    owns the per-engine set, so this validates against the same list the resolver probes.
+
+    NOTE THIS IS STILL ONE ``shlex``-SPLITTABLE COMMAND, with no shell conditional in it.
+    An earlier draft probed for the directory in bash so the tar could self-correct; that
+    would have broken ``tests/ee/sites/faults.py::pack_with_real_tar``, which runs the
+    command through ``shlex.split`` WITHOUT a shell precisely so the test does not depend
+    on which bash a Windows Python resolves. Predicting the directory keeps the command a
+    plain argv, and a wrong prediction still fails the designed way: loudly and empty.
     """
-    rel = static_output_rel(engine)
+    rel = static_output_rel(engine) if output_rel is None else output_rel
+    if output_rel is not None and output_rel not in candidate_static_output_rels(engine):
+        raise ValueError(
+            f"engine {normalize_engine(engine)!r} cannot emit its static output at "
+            f"{output_rel!r}; expected one of {candidate_static_output_rels(engine)}"
+        )
     if rel == ".":
         raise ValueError(
             f"engine {normalize_engine(engine)!r} emits its static output at the "
@@ -665,6 +698,52 @@ PYEOF
 """
 
 
+#: Build-log substrings that mean the render FAILED even though the build may have exited
+#: zero. Mirrors ``paw-sites/src/smoke.ts::KNOWN_WORKERD_FAILURES`` and the copy
+#: ``generator_client._WORKERD_SSR_MARKERS`` already keeps for the inline path — a third
+#: copy, and worth it, because this one has to reach the INSIDE of a sandbox that has no
+#: paw-sites in it.
+#:
+#: WHY THE LANE NEEDS ITS OWN. An inline publish runs ``runWorkerdSmokeRender``, which
+#: fails the verdict on any of these markers. The lane runs bare ``bun install`` +
+#: ``bun run build``, so without this a site that prerendered a marker onto a zero exit
+#: would deploy. That is not theoretical for the svelte track: ``window is not defined``
+#: from a top-level import of a browser-only library is the classic Paw Site failure.
+#:
+#: The wrapper greps the WHOLE log rather than the sentinel's tail, which makes this
+#: STRICTER than reading ``stderr_tail`` Python-side would be: a marker printed early in a
+#: long ``bun install`` scrolls out of a tail and would be missed.
+WORKERD_SSR_MARKERS: tuple[str, ...] = (
+    "window is not defined",
+    "document is not defined",
+    "No such module",
+)
+
+
+def _render_marker_scan(markers: tuple[str, ...]) -> str:
+    """The bash that fails a zero-exit build whose log carries an SSR failure marker.
+
+    ``grep -F`` — FIXED strings, never patterns. A marker is prose ("window is not
+    defined"), and letting it be read as a regex would make a future marker containing a
+    ``.`` or a ``*`` match things it does not mean.
+
+    Renders to a no-op when ``markers`` is empty, so a caller can switch the scan off
+    without the script growing an empty ``if`` that always fires.
+    """
+    if not markers:
+        return "# no SSR markers configured for this engine\n"
+    tests = " || ".join(
+        f'grep -qF -- {shlex.quote(marker)} "$STDERR_LOG"' for marker in markers
+    )
+    return (
+        f"if {tests}; then\n"
+        '  echo "paw: build log carries a known SSR failure marker" >>"$STDERR_LOG"\n'
+        "  BUILD_EXIT=1\n"
+        '  exit "$BUILD_EXIT"\n'
+        "fi\n"
+    )
+
+
 def build_wrapper_script(
     engine: str | None,
     project_dir: str,
@@ -673,6 +752,8 @@ def build_wrapper_script(
     artifact_path: str,
     install_command: str = "bun install",
     build_command: str = "bun run build",
+    artifact_rel: str | None = None,
+    ssr_markers: tuple[str, ...] = WORKERD_SSR_MARKERS,
 ) -> str:
     """Render the bash wrapper the sandbox runs.
 
@@ -691,8 +772,16 @@ def build_wrapper_script(
     reaching the sentinel write with the real exit codes in hand, and ``-e`` would
     abort the script at the first failing step, which is precisely when the evidence
     matters. Every command's status is captured explicitly instead.
+
+    ``artifact_rel`` (SL-4) names which of the engine's output dirs this build will write,
+    for the one engine that has two. It reaches BOTH the tar's include-list and the
+    sentinel's ``artifact_rel`` field, which is the point: the sentinel is evidence, and
+    evidence claiming ``.svelte-kit/cloudflare`` for a build that wrote ``build`` sends
+    whoever reads it to look in the wrong place. ``None`` keeps the nominal per-engine
+    value and renders a byte-identical script.
     """
-    tar_cmd = artifact_tar_command(engine, project_dir, artifact_path)
+    tar_cmd = artifact_tar_command(engine, project_dir, artifact_path, output_rel=artifact_rel)
+    marker_scan = _render_marker_scan(ssr_markers)
     result_path = f"{project_dir.rstrip('/')}/{BUILD_RESULT_FILENAME}"
     writer = _SENTINEL_WRITER.replace("TAIL_BYTES", str(STDERR_TAIL_BYTES))
 
@@ -705,7 +794,7 @@ RESULT={shlex.quote(result_path)}
 STDERR_LOG=/tmp/paw-build-stderr.log
 ARTIFACT={shlex.quote(artifact_path)}
 ENGINE={shlex.quote(normalize_engine(engine))}
-ARTIFACT_REL={shlex.quote(static_output_rel(engine))}
+ARTIFACT_REL={shlex.quote(artifact_rel or static_output_rel(engine))}
 STARTED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
 # -1 distinguishes "never ran" from "ran and returned 0". A step that never ran
@@ -734,6 +823,13 @@ if [ "$BUILD_EXIT" -ne 0 ]; then
   exit "$BUILD_EXIT"
 fi
 
+# A CLEAN EXIT IS NOT A CLEAN RENDER. SvelteKit's prerender pass reports an SSR throw in
+# the log and can still exit zero, so the marker scan runs on a build that "succeeded".
+# Rewriting BUILD_EXIT rather than inventing a new sentinel field is deliberate: the
+# outcome IS a build failure, it belongs to the user, and classify_build already routes a
+# non-zero build exit to ``build_failed`` with the stderr tail attached — which is exactly
+# where the marker the user has to act on already is.
+{marker_scan}
 {tar_cmd} >>"$STDERR_LOG" 2>&1
 if [ -f "$ARTIFACT" ]; then
   ARTIFACT_BYTES=$(wc -c < "$ARTIFACT" | tr -d '[:space:]')
@@ -754,6 +850,7 @@ __all__ = [
     "BuildOutcome",
     "artifact_tar_command",
     "build_timeout_seconds",
+    "WORKERD_SSR_MARKERS",
     "build_wrapper_script",
     "classify_build",
     "promised_artifact_bytes",

--- a/ee/pocketpaw_ee/sites/daytona_runner.py
+++ b/ee/pocketpaw_ee/sites/daytona_runner.py
@@ -274,6 +274,7 @@ async def run_build(
     disk_gb: int = 10,
     install_command: str = "bun install",
     build_command: str = "bun run build",
+    artifact_rel: str | None = None,
 ) -> BuildRunResult:
     """Build ``files`` in a fresh Daytona sandbox and return the verdict + artifact.
 
@@ -284,6 +285,12 @@ async def run_build(
     ``timeout_seconds`` is a parameter and deliberately has no default: the value comes
     from ``daytona_build.build_timeout_seconds`` over measured p95s, and baking a guess
     in here would quietly become the real policy.
+
+    ``artifact_rel`` (SL-4) names which output dir this build will write, for the one
+    engine whose builds have two shapes. It is threaded straight through to the wrapper's
+    include-list and sentinel; ``None`` keeps the nominal per-engine value. The caller
+    predicts it — this module does not, because the prediction reads the pocket's bindings
+    and this module is deliberately ignorant of everything but files and a sandbox.
 
     Never raises for a build outcome — a failed build, a timeout and a lost sandbox are
     all *results*, and the caller needs the classification to decide between reporting
@@ -306,10 +313,18 @@ async def run_build(
         artifact_path=SANDBOX_ARTIFACT_PATH,
         install_command=install_command,
         build_command=build_command,
+        artifact_rel=artifact_rel,
     )
     # Rendered here rather than inside the wrapper so an engine whose output is the
     # project root fails BEFORE a sandbox is created and billed.
-    artifact_tar_command(engine, SANDBOX_PROJECT_DIR, SANDBOX_ARTIFACT_PATH)
+    #
+    # ``artifact_rel`` is passed (SL-4) rather than left to default. Validating the NOMINAL
+    # rel while the wrapper packs an OVERRIDDEN one would make this pre-flight check the
+    # one place in the lane that disagrees with what actually runs — it would clear an
+    # override the tar then refuses, which is the opposite of what a pre-flight is for.
+    artifact_tar_command(
+        engine, SANDBOX_PROJECT_DIR, SANDBOX_ARTIFACT_PATH, output_rel=artifact_rel
+    )
 
     name = sandbox_name or f"paw-build-{int(time.time() * 1000)}"
     idle_minutes = _lifecycle_minutes(timeout_seconds)

--- a/ee/pocketpaw_ee/sites/engines.py
+++ b/ee/pocketpaw_ee/sites/engines.py
@@ -282,6 +282,28 @@ def static_output_rel(engine: str | None) -> str:
     return _STATIC_OUTPUT_REL[normalize_engine(engine)]
 
 
+def candidate_static_output_rels(engine: str | None) -> tuple[str, ...]:
+    """Every output dir a build of ``engine`` could legitimately write, in PROBE ORDER.
+
+    One place owns the fact that svelte has two output shapes and which one wins a tie.
+    :func:`resolve_static_output_rel` probes this list on disk; the ephemeral build lane
+    validates a caller's override against it before rendering an include-list aimed at a
+    directory the engine never writes.
+
+    PROBE ORDER IS LOAD-BEARING, and for the same reason it was load-bearing when it
+    lived inline in the resolver: ``build`` comes FIRST so a project dir carrying a stale
+    ``.svelte-kit/cloudflare`` tree from a pre-SL-1 build cannot shadow what the current
+    build emitted. Reversing these two silently serves the old artifact.
+
+    Every other engine has exactly one shape, so its tuple has one element and callers
+    that only ever handled one value keep working unchanged.
+    """
+    normalized = normalize_engine(engine)
+    if normalized == "svelte":
+        return (_SVELTE_STATIC_OUTPUT_REL, _STATIC_OUTPUT_REL["svelte"])
+    return (_STATIC_OUTPUT_REL[normalized],)
+
+
 def resolve_static_output_rel(project_dir: str | os.PathLike[str], engine: str | None) -> str:
     """Where THIS build's deployable output actually landed, relative to ``project_dir``.
 
@@ -314,7 +336,8 @@ def resolve_static_output_rel(project_dir: str | os.PathLike[str], engine: str |
     if normalized != "svelte":
         return _STATIC_OUTPUT_REL[normalized]
     root = Path(project_dir)
-    for candidate in (_SVELTE_STATIC_OUTPUT_REL, _STATIC_OUTPUT_REL["svelte"]):
+    candidates = candidate_static_output_rels(normalized)
+    for candidate in candidates:
         if (root / candidate).is_dir():
             return candidate
     return _STATIC_OUTPUT_REL["svelte"]

--- a/ee/pocketpaw_ee/sites/generator_client.py
+++ b/ee/pocketpaw_ee/sites/generator_client.py
@@ -308,7 +308,13 @@ from pathlib import Path
 from typing import Any, Protocol
 from urllib.parse import unquote
 
-from pocketpaw_ee.sites.engines import is_source_engine, needs_node_build, static_output_rel
+from pocketpaw_ee.sites.engines import (
+    candidate_static_output_rels,
+    is_source_engine,
+    needs_node_build,
+    normalize_engine,
+    static_output_rel,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -491,6 +497,84 @@ def _split_svelte_source(
     files = {k: v for k, v in src.items() if k not in _SVELTE_BINDING_KEYS}
     bindings = {k: src[k] for k in _SVELTE_BINDING_KEYS if k in src}
     return files, bindings
+
+
+def svelte_source_is_dynamic(source: dict[str, Any] | None) -> bool:
+    """Would the generator build this svelte source on adapter-CLOUDFLARE (SL-4)?
+
+    The Python mirror of ``paw-sites/src/bindings.ts::parseBindings``, whose
+    ``isDynamic`` (``sources.length > 0 || actions.length > 0 || auth``) is the ONE flag
+    that picks the adapter — and therefore the output dir, and therefore whether the
+    artifact is a self-contained tree or a worker shell that cannot execute outside its
+    build.
+
+    A SECOND IMPLEMENTATION OF A RULE THAT ALREADY EXISTS IN TYPESCRIPT, and that is worth
+    naming rather than hiding. It earns its place because the answer is needed BEFORE the
+    generator runs: ``service.build_runs_async`` has to decide whether to spend a queue
+    slot, and the only thing that knows the answer today is a build that has not happened.
+
+    THE DISAGREEMENT IS DESIGNED TO BE LOUD. If this and ``parseBindings`` ever diverge,
+    the lane's include-list points at a directory the build did not write, so the artifact
+    is EMPTY and ``classify_build`` refuses it before anything deploys — the same
+    fail-closed shape ``artifact_tar_command`` was built around. It cannot ship the wrong
+    site; it can only fail a publish that should have succeeded.
+
+    MIRRORED EXACTLY, including the parts that look like details:
+
+    * ``sources`` is filtered to ``kind == "data"`` first, because ``parseBindings`` does.
+      Counting every entry would hold static sites out of the lane forever, which is the
+      failure mode that looks like nothing happening.
+    * LENGTH, not presence. An envelope carrying ``sources: []`` is static; a classifier
+      keying on the key existing would call it dynamic.
+    * ``auth`` must be exactly ``True`` (``spec.auth === true``), not merely truthy.
+
+    Accepts either shape the payload takes on its way through the publish: the bindings
+    NESTED in the ``source`` envelope (how a pocket persists them) and spread FLAT as
+    siblings (how ``build_generator_input`` hands them to the generator, via
+    :func:`_split_svelte_source`). Both are read, so a caller holding either one classifies
+    the same and the tar cannot end up aimed at the wrong directory.
+    """
+    if not isinstance(source, dict):
+        return False
+    if source.get("auth") is True:
+        return True
+    raw_sources = source.get("sources")
+    if isinstance(raw_sources, list):
+        for entry in raw_sources:
+            if isinstance(entry, dict) and entry.get("kind") == "data":
+                return True
+    raw_actions = source.get("actions")
+    return isinstance(raw_actions, list) and len(raw_actions) > 0
+
+
+def expected_static_output_rel(engine: str | None, generator_input: dict[str, Any]) -> str:
+    """Which output dir THIS build will write, decided from the payload (SL-4).
+
+    The predict-ahead sibling of ``engines.resolve_static_output_rel``, which answers the
+    same question by reading a finished build off disk. The ephemeral lane needs the answer
+    before the build exists — the include-list that packs the artifact is rendered into the
+    wrapper script, and the unpack that feeds the deploy has to land the tree where the
+    deployer will look for it. ONE helper for both, so the tar and the unpack cannot drift
+    apart; a mismatch between them deploys an empty directory.
+
+    Only svelte can answer anything but its nominal value. Every other engine has exactly
+    one output shape, so this returns ``static_output_rel(engine)`` unchanged for them and
+    their behaviour is byte-for-byte what it was before this function existed.
+
+    Reads the bindings from BOTH shapes the payload takes: nested under ``source`` (how a
+    pocket persists them) and flat at the top level (how ``build_generator_input`` spreads
+    them for the generator).
+    """
+    if normalize_engine(engine) != "svelte":
+        return static_output_rel(engine)
+    nested = generator_input.get("source")
+    if svelte_source_is_dynamic(nested if isinstance(nested, dict) else None):
+        return static_output_rel("svelte")
+    if svelte_source_is_dynamic(generator_input):
+        return static_output_rel("svelte")
+    # The FIRST candidate is adapter-static's ``build`` — read from engines.py rather
+    # than restated here, so the probe order and the prediction can never disagree.
+    return candidate_static_output_rels("svelte")[0]
 
 
 def reap_build_workerd(project_dir: str) -> int:

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -881,7 +881,11 @@ from pocketpaw_ee.sites.dto import (
     SiteStatusResponse,
 )
 from pocketpaw_ee.sites.engines import content_key, is_source_engine, normalize_engine
-from pocketpaw_ee.sites.generator_client import BuildResult, GeneratorClient
+from pocketpaw_ee.sites.generator_client import (
+    BuildResult,
+    GeneratorClient,
+    svelte_source_is_dynamic,
+)
 from pocketpaw_ee.sites.html_paths import (
     html_path_rejection,
     is_reserved_html_path,
@@ -2346,7 +2350,7 @@ async def _deploy_site_doc(
     # SL-3: fork to the EPHEMERAL BUILD LANE for the engines whose artifact can
     # actually be deployed from it. A prebuilt dir means the worker already ran this
     # build and is calling back in to finish the publish, so it must NOT re-fork.
-    if prebuilt_project_dir is None and build_runs_async(engine):
+    if prebuilt_project_dir is None and build_runs_async(engine, source=source, pattern=pattern):
         return await _enqueue_static_build(
             workspace_id=workspace_id,
             user_id=user_id,
@@ -3194,34 +3198,122 @@ async def _provision_dynamic_site(
 # ---------------------------------------------------------------------------
 
 
-def build_runs_async(engine: str | None) -> bool:
-    """Does publishing this engine ENQUEUE its build instead of running it inline?
+def build_runs_async(
+    engine: str | None,
+    *,
+    source: dict[str, Any] | None = None,
+    pattern: str | None = None,
+) -> bool:
+    """Does publishing this site ENQUEUE its build instead of running it inline?
 
-    True for exactly the engines whose ephemeral-lane artifact can actually be
-    DEPLOYED, which today is react alone. This is a narrow answer to a broad-sounding
-    question, and the narrowness is the whole content of the predicate:
+    True for the engines whose ephemeral-lane artifact can actually be DEPLOYED. That is
+    react, and — since SL-4 — a STATIC svelte site. The predicate is about the ARTIFACT,
+    not about the queue, and every line below follows from that:
 
-    * ``html`` runs no build at all (``needs_node_build`` is False), so there is
-      nothing to enqueue. Flipping it would add a queue wait to the one engine that
-      never needed one.
-    * ``ripple`` and DYNAMIC ``svelte`` build on adapter-cloudflare, whose output's
-      pages are rendered by a ``_worker.js`` whose imports sit OUTSIDE the tarred
-      directory. The artifact therefore cannot serve — which is not a guess: it is why
-      ``truth_lane`` refuses to even PREVIEW one (``REASON_WORKER_RENDERED``). Queueing
-      those builds would replace a working publish with one nothing can deploy.
-    * STATIC ``svelte`` (adapter-static) IS self-sufficient, and is still excluded,
-      because which adapter ran is a property of the built SITE and is not knowable at
-      enqueue time — only after the build. A gate has to decide before it spends the
-      queue, so svelte stays inline until the artifact question is settled for the
-      whole track.
-    * ``react`` emits a prerendered, assets-only ``dist`` with no server entry, so the
-      tar is the whole deployable site.
+    * ``html`` runs no build at all (``needs_node_build`` is False), so there is nothing
+      to enqueue. Flipping it would add a queue wait to the one engine that never needed
+      one.
+    * ``ripple`` builds on adapter-cloudflare unconditionally. Its pages are rendered by a
+      ``_worker.js`` whose imports sit OUTSIDE the tarred directory, so the artifact
+      cannot serve — which is not a guess: it is why ``truth_lane`` refuses to even
+      PREVIEW one (``REASON_WORKER_RENDERED``). Queueing it would replace a working
+      publish with one nothing can deploy.
+    * ``react`` emits a prerendered, assets-only ``dist`` with no server entry, so the tar
+      is the whole deployable site.
+    * ``svelte`` DEPENDS ON THE SITE, and reading that dependency is the whole of SL-4.
 
-    Widen this ONLY together with the artifact: the moment an adapter-cloudflare
-    artifact can serve, ripple and svelte belong here too, and this predicate is the
-    one place that changes.
+    ── WHAT CHANGED FOR SVELTE, AND WHY THE OLD REASON NO LONGER HOLDS ──────────────────
+
+    This docstring used to say static svelte was excluded "because which adapter ran is a
+    property of the built SITE and is not knowable at enqueue time — only after the
+    build". That premise was wrong, and it was wrong in a checkable way. The adapter is
+    picked by ``paw-sites/src/index.ts`` from ``parseBindings(...).isDynamic``, computed
+    from ``objects``/``sources``/``actions``/``auth`` — which ride the publish as sibling
+    keys on the ``source`` envelope (``generator_client._SVELTE_BINDING_KEYS``) and are in
+    this function's hand before a queue slot is spent. Nothing has to be built to know.
+
+    So the fork is:
+
+      * static svelte  → adapter-static     → ``build``, self-contained, NO worker → QUEUE
+      * dynamic svelte → adapter-cloudflare → worker-rendered, cannot serve       → INLINE
+
+    THE DYNAMIC ANSWER IS THE LOAD-BEARING ONE. ``_deploy_site_doc`` forks a dynamic site
+    to ``_provision_dynamic_site`` before it ever reaches here, but that fork calls
+    ``_is_dynamic``, which reads the ``ripple_spec`` — and a svelte pocket carries its
+    bindings on the ``source`` envelope instead, so for svelte that fork sees only the
+    ``pattern == "dynamic"`` stamp. An unstamped dynamic svelte pocket therefore arrives
+    here looking static to every check that came before, and a gate keying on the engine
+    name alone would queue it and deploy a worker shell that cannot start. Both signals
+    are read for that reason, not for symmetry.
+
+    ``source`` DEFAULTING TO None ANSWERS "QUEUED" FOR SVELTE, deliberately. The caller
+    that has no source in scope is ``cloud/surface/handlers/sites.py::_publish_runs_async``,
+    which documents why it degrades that way: telling the agent a build is queued when the
+    publish was inline costs one extra click, while telling it a url is live when the build
+    is still queued announces a page that does not exist yet — on a first publish there is
+    no url at all, and on a re-publish the url still serves the PREVIOUS page. The publish
+    path itself always holds the source and never relies on this default.
+
+    Widen this further ONLY together with the artifact: the moment an adapter-cloudflare
+    artifact can serve, ripple and dynamic svelte belong here too, and this predicate is
+    the one place that changes.
     """
-    return normalize_engine(engine) == "react"
+    normalized = normalize_engine(engine)
+    if normalized == "react":
+        return True
+    if normalized != "svelte":
+        return False
+    if not svelte_async_build_enabled():
+        return False
+    if pattern == "dynamic":
+        return False
+    if source is None:
+        return True
+    return not svelte_source_is_dynamic(source)
+
+
+def svelte_async_build_enabled() -> bool:
+    """Is the static svelte track routed to the ephemeral build lane? (SL-4)
+
+    ``PAW_SITES_SVELTE_ASYNC_BUILD``, DEFAULT OFF. Read per call rather than cached at
+    import so an operator can flip it without a redeploy, and so a test can set it with
+    ``monkeypatch.setenv`` and get the behaviour it asked for.
+
+    ── WHY THIS SHIPS BEHIND A FLAG AND react DID NOT ──────────────────────────────────
+
+    Not caution for its own sake. Moving a svelte publish into the lane DROPS TWO
+    PUBLISH-TIME CHECKS that an inline publish runs, because ``paw-sites``'s
+    ``runWorkerdSmokeRender`` is what performs them and it does not exist inside the
+    sandbox:
+
+      1. The known-workerd-marker scan. RECOVERED — the wrapper now greps the full build
+         log for the same markers ``generator_client._WORKERD_SSR_MARKERS`` carries and
+         fails the build on a hit, so this one is not lost. It is better than the inline
+         check on one axis: the wrapper reads the WHOLE log, while the sentinel only ever
+         carries a tail.
+      2. The RESTING-VISIBILITY guard (``checkRestingVisibility`` /
+         ``judgeRestingVisibility``) — the check that a marketing page is not blank at
+         rest. NOT recovered. It judges a CLEAN build by reading the prerendered
+         ``index.html`` and the emitted CSS, so nothing about a non-zero exit code
+         substitutes for it, and porting it to Python would make a third implementation of
+         a rule that already exists twice.
+
+    react never had either check, so the lane cost it nothing. svelte has both today, and
+    a default-on flip would have removed one of them from every marketing site the product
+    publishes without anything failing to say so.
+
+    THE FLAG IS THEREFORE A STAGING DEVICE, NOT A PERMANENT SWITCH. Turning it on is safe
+    and useful right now — the offload is real and the lane's own gates (build exit,
+    artifact verification, the server-entry refusal) all apply. Making it the DEFAULT is
+    blocked on giving the lane a resting-visibility verdict, whose clean shape is a
+    ``paw-sites-gen`` subcommand that judges an already-built tree, invoked by the worker
+    on the unpacked artifact. That is a paw-sites change plus a vendor refresh, so it is
+    its own PR in its own repo rather than a silent gap here.
+    """
+    import os
+
+    raw = os.environ.get("PAW_SITES_SVELTE_ASYNC_BUILD", "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
 
 
 async def _enqueue_static_build(

--- a/tests/ee/sites/test_async_publish.py
+++ b/tests/ee/sites/test_async_publish.py
@@ -112,9 +112,15 @@ class TestOnlyTheDeployableEngineFlips:
     @pytest.mark.parametrize("engine", ["ripple", "svelte", "html"])
     def test_every_other_engine_stays_inline(self, engine: str) -> None:
         """Not an arbitrary allowlist. html runs no build at all; ripple and dynamic
-        svelte produce an artifact that cannot serve; static svelte is self-sufficient but
-        indistinguishable from the dynamic shape until AFTER the build, and a gate has to
-        decide before it spends the queue."""
+        svelte produce an artifact that cannot serve.
+
+        CORRECTED 2026-08-21 (SL-4): this docstring used to add that static svelte was
+        "indistinguishable from the dynamic shape until AFTER the build". That was wrong —
+        the adapter is picked from ``parseBindings(...).isDynamic``, whose inputs ride the
+        publish on the ``source`` envelope — and the correction is what let the static
+        svelte track into the lane. svelte is still asserted INLINE here because the flip
+        ships behind ``PAW_SITES_SVELTE_ASYNC_BUILD``, default off; the flipped behaviour
+        lives in ``test_svelte_async_build.py``, which turns the flag on."""
         assert sites_service.build_runs_async(engine) is False
 
     def test_an_unknown_engine_stays_inline(self) -> None:

--- a/tests/ee/sites/test_svelte_async_build.py
+++ b/tests/ee/sites/test_svelte_async_build.py
@@ -1,0 +1,600 @@
+# tests/ee/sites/test_svelte_async_build.py — the STATIC svelte track joins the
+# ephemeral build lane.
+#
+# Created 2026-08-21. Until now ``service.build_runs_async`` answered ``engine ==
+# "react"`` and its docstring gave the reason svelte was held back: a static svelte site
+# (adapter-static) IS self-sufficient, but "which adapter ran is a property of the built
+# SITE and is not knowable at enqueue time — only after the build". That premise is what
+# these tests retire. It IS knowable: the svelte track's static/dynamic fork is decided by
+# ``paw-sites/src/bindings.ts::parseBindings`` from ``objects``/``sources``/``actions``/
+# ``auth``, which ride the publish as sibling keys on the ``source`` envelope
+# (``generator_client._SVELTE_BINDING_KEYS``) and are therefore in the caller's hand
+# BEFORE the queue is spent.
+#
+# THE THREE THINGS THAT HAD TO MOVE TOGETHER, one class each below:
+#
+#   1. THE GATE reads the bindings, not just the engine string. A dynamic svelte site
+#      must NOT enter the lane: adapter-cloudflare's ``_worker.js`` imports
+#      ``./../output/server/index.js``, which sits OUTSIDE the tarred directory, so its
+#      artifact cannot execute (canary-verified 2026-08-10, and the reason ``truth_lane``
+#      refuses to even preview one).
+#   2. THE TAR targets the adapter that actually ran. The wrapper baked
+#      ``static_output_rel("svelte")`` == ``.svelte-kit/cloudflare``; adapter-static writes
+#      ``build``. Left alone, every static svelte build would tar a directory that does
+#      not exist and settle as ``artifact_empty``.
+#   3. THE UNPACK puts the tree where the deployer will look for it, using the SAME
+#      resolved rel the tar used — one helper, so the two cannot drift.
+#
+# WHY A DISAGREEMENT IS SAFE RATHER THAN SILENT: if our classifier and the generator's
+# ever disagree, the tar's include-list points at a directory the build did not write, so
+# the artifact is EMPTY and the lane fails loudly before anything deploys. That is
+# ``artifact_tar_command``'s stated design ("a wrong include-list ships NOTHING, LOUDLY")
+# doing its job, not a hole.
+"""The static svelte track's entry into the ephemeral build lane."""
+
+from __future__ import annotations
+
+import tarfile
+from io import BytesIO
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pocketpaw_ee.sites import daytona_build as db
+from pocketpaw_ee.sites import engines as engines_mod
+from pocketpaw_ee.sites import generator_client as gen_mod
+from pocketpaw_ee.sites import service as sites_service
+
+from tests.ee.sites.faults import tar_is_available, write_project_tree
+
+# A minimal svelte source envelope. The file map is what materializeSource writes; the
+# binding keys (absent here) are what decides the adapter.
+_STATIC_SOURCE: dict[str, Any] = {
+    "src/routes/+page.svelte": "<h1>hi</h1>",
+    "src/routes/+layout.ts": "export const prerender = true;",
+}
+
+
+# ---------------------------------------------------------------------------
+# 1. The gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def svelte_lane_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Turn the staging flag on for the tests that describe the flipped behaviour.
+
+    A fixture rather than a module-level env write, so a test that does NOT ask for it
+    observes the shipped default — which is how ``TestTheFlagIsTheDefaultOff`` below can
+    assert the default at all."""
+    monkeypatch.setenv("PAW_SITES_SVELTE_ASYNC_BUILD", "1")
+
+
+class TestTheFlagIsTheDefaultOff:
+    """The shipped default. Every svelte publish still builds inline until an operator
+    turns the lane on, which is what keeps the six suites that encode the inline
+    contract — the publish-time smoke gate, the native-artifact pre-warm, the
+    builder-origin editability — passing untouched."""
+
+    def test_svelte_is_inline_until_the_flag_is_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("PAW_SITES_SVELTE_ASYNC_BUILD", raising=False)
+        assert sites_service.svelte_async_build_enabled() is False
+        assert sites_service.build_runs_async("svelte", source=_STATIC_SOURCE) is False
+
+    @pytest.mark.parametrize("raw", ["1", "true", "TRUE", "yes", "on"])
+    def test_the_truthy_spellings_all_work(self, monkeypatch: pytest.MonkeyPatch, raw: str) -> None:
+        monkeypatch.setenv("PAW_SITES_SVELTE_ASYNC_BUILD", raw)
+        assert sites_service.svelte_async_build_enabled() is True
+
+    @pytest.mark.parametrize("raw", ["", "0", "false", "off", "no", "maybe"])
+    def test_anything_else_stays_off(self, monkeypatch: pytest.MonkeyPatch, raw: str) -> None:
+        """Fail CLOSED on a value nobody defined. A flag that reads ``"maybe"`` as on
+        turns a typo into a production routing change."""
+        monkeypatch.setenv("PAW_SITES_SVELTE_ASYNC_BUILD", raw)
+        assert sites_service.svelte_async_build_enabled() is False
+
+    def test_react_does_not_read_the_flag(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """react has been in the lane since SL-3 and the flag is about svelte only.
+        Gating react on it would silently un-ship a shipped path."""
+        monkeypatch.delenv("PAW_SITES_SVELTE_ASYNC_BUILD", raising=False)
+        assert sites_service.build_runs_async("react") is True
+
+
+@pytest.mark.usefixtures("svelte_lane_on")
+class TestTheGateReadsTheBindingsNotJustTheEngine:
+    def test_a_static_svelte_site_now_builds_asynchronously(self) -> None:
+        """The point of the change. A hand-written landing site carries no binding keys,
+        so the generator picks adapter-static and the artifact is a self-contained tree."""
+        assert sites_service.build_runs_async("svelte", source=_STATIC_SOURCE) is True
+
+    def test_react_is_unchanged(self) -> None:
+        assert sites_service.build_runs_async("react") is True
+
+    @pytest.mark.parametrize("engine", ["ripple", "html"])
+    def test_the_engines_that_did_not_flip_stay_inline(self, engine: str) -> None:
+        """html runs no build at all; ripple is adapter-cloudflare unconditionally, so its
+        artifact is worker-rendered and cannot serve from a tar."""
+        assert sites_service.build_runs_async(engine) is False
+
+    def test_an_unknown_engine_stays_inline(self) -> None:
+        """Unknown normalises to ripple everywhere in this codebase, and ripple is inline.
+        The fallback must not flip a site whose engine we failed to recognise."""
+        for value in (None, "", "nope"):
+            assert sites_service.build_runs_async(value) is False
+
+    @pytest.mark.parametrize(
+        ("key", "value"),
+        [
+            ("sources", [{"name": "posts", "object": "post", "kind": "data"}]),
+            ("actions", [{"name": "addPost", "object": "post"}]),
+            ("auth", True),
+        ],
+    )
+    def test_a_dynamic_svelte_site_is_refused(self, key: str, value: Any) -> None:
+        """THE regression this gate exists to prevent. A dynamic site builds on
+        adapter-cloudflare, whose ``_worker.js`` imports a file outside the tarred dir —
+        so queueing it would replace a working publish with one nothing can deploy.
+
+        Mutation: drop the binding check and this ships a broken site to the edge."""
+        source = dict(_STATIC_SOURCE, **{key: value})
+        assert sites_service.build_runs_async("svelte", source=source) is False
+
+    def test_the_dynamic_stamp_alone_is_enough(self) -> None:
+        """``pattern == "dynamic"`` is authoritative wherever it is set (the
+        create-dynamic-site tool stamps it), and it is checked even when the envelope
+        carries no binding keys at all — belt to ``_is_dynamic``'s braces."""
+        assert (
+            sites_service.build_runs_async("svelte", source=_STATIC_SOURCE, pattern="dynamic")
+            is False
+        )
+
+    def test_a_non_data_source_does_not_make_a_site_dynamic(self) -> None:
+        """Mirrors ``parseBindings``, which filters ``sources`` to ``kind === 'data'``
+        before counting them. A classifier that counted every entry would hold back
+        static sites forever, which is the failure that looks like nothing happening."""
+        source = dict(_STATIC_SOURCE, sources=[{"name": "x", "object": "y", "kind": "static"}])
+        assert sites_service.build_runs_async("svelte", source=source) is True
+
+    @pytest.mark.parametrize("truthy", ["yes", "true", 1, ["x"], {"on": True}])
+    def test_auth_must_be_exactly_true_not_merely_truthy(self, truthy: Any) -> None:
+        """``parseBindings`` reads ``spec.auth === true``. A Python mirror using a plain
+        truthiness check diverges the moment a pocket stores the string ``"yes"`` — and it
+        diverges in the direction that silently holds a static site out of the lane, which
+        is indistinguishable from the feature not working.
+
+        Mutation: ``source.get("auth")`` instead of ``source.get("auth") is True``."""
+        source = dict(_STATIC_SOURCE, auth=truthy)
+        assert gen_mod.svelte_source_is_dynamic(source) is False
+        assert sites_service.build_runs_async("svelte", source=source) is True
+
+    def test_empty_binding_keys_are_not_dynamic(self) -> None:
+        """An envelope that carries the keys with nothing in them is a static site. The
+        generator counts LENGTH, not presence, and so must this."""
+        source = dict(_STATIC_SOURCE, objects=[], sources=[], actions=[], auth=False)
+        assert sites_service.build_runs_async("svelte", source=source) is True
+
+    def test_svelte_with_no_source_in_scope_answers_queued(self) -> None:
+        """``cloud/surface/handlers/sites.py::_publish_runs_async`` holds a pocket engine
+        and no source, and documents that it degrades toward the claim that cannot be
+        false: announcing a queued build costs a click, announcing a url that is not live
+        yet is a lie. The default matches that policy deliberately."""
+        assert sites_service.build_runs_async("svelte") is True
+
+    def test_every_flipped_engine_can_serve_without_a_worker(self) -> None:
+        """The property behind the gate, checked against engines.py rather than restated.
+        svelte answers ``None`` (either adapter is legitimate), which is exactly why the
+        gate needs the bindings and the engine name is not enough."""
+        assert engines_mod.expects_server_worker("react") is False
+        assert engines_mod.expects_server_worker("svelte") is None
+        assert engines_mod.expects_server_worker("ripple") is True
+
+
+# ---------------------------------------------------------------------------
+# 2. The tar
+# ---------------------------------------------------------------------------
+
+
+class TestTheTarTargetsTheAdapterThatActuallyRan:
+    def test_the_expected_rel_follows_the_bindings(self) -> None:
+        static = gen_mod.expected_static_output_rel("svelte", {"source": _STATIC_SOURCE})
+        dynamic = gen_mod.expected_static_output_rel(
+            "svelte", {"source": _STATIC_SOURCE, "auth": True}
+        )
+        assert static == "build"
+        assert dynamic == ".svelte-kit/cloudflare"
+
+    def test_a_non_svelte_engine_keeps_its_single_output_shape(self) -> None:
+        assert gen_mod.expected_static_output_rel("react", {}) == "dist"
+        assert gen_mod.expected_static_output_rel("ripple", {}) == ".svelte-kit/cloudflare"
+
+    def test_the_bindings_are_read_as_flat_siblings_too(self) -> None:
+        """``build_generator_input`` peels the binding keys OUT of the envelope and spreads
+        them as flat siblings on the generator input (``_split_svelte_source``), so by the
+        time the lane holds the payload the keys are at the top level, not under
+        ``source``. Both shapes must classify the same or the tar aims at the wrong dir."""
+        nested = gen_mod.expected_static_output_rel(
+            "svelte", {"source": {**_STATIC_SOURCE, "auth": True}}
+        )
+        flat = gen_mod.expected_static_output_rel(
+            "svelte", {"source": _STATIC_SOURCE, "auth": True}
+        )
+        assert nested == flat == ".svelte-kit/cloudflare"
+
+    def test_the_tar_packs_the_static_output_when_told_to(self) -> None:
+        cmd = db.artifact_tar_command(
+            "svelte", "/home/daytona/proj", "/tmp/a.tgz", output_rel="build"
+        )
+        assert "/home/daytona/proj/build" in cmd
+        assert ".svelte-kit" not in cmd
+
+    def test_the_default_is_unchanged_for_every_engine(self) -> None:
+        """The regression guarantee. Callers that pass no override must render the exact
+        command they rendered before this parameter existed."""
+        assert db.artifact_tar_command("react", "/p", "/tmp/a.tgz") == db.artifact_tar_command(
+            "react", "/p", "/tmp/a.tgz", output_rel=None
+        )
+        assert "/p/.svelte-kit/cloudflare" in db.artifact_tar_command("svelte", "/p", "/tmp/a.tgz")
+
+    def test_an_override_the_engine_cannot_emit_is_refused(self) -> None:
+        """An include-list aimed at a directory this engine never writes packs nothing,
+        and an empty artifact is indistinguishable from a build that produced nothing. Fail
+        where the caller can still be blamed for it."""
+        with pytest.raises(ValueError, match="cannot emit"):
+            db.artifact_tar_command("react", "/p", "/tmp/a.tgz", output_rel="build")
+
+    def test_the_project_root_is_still_refused(self) -> None:
+        """html's output IS the project dir, so an include-list cannot exclude
+        node_modules. Unchanged — and it must stay unreachable through the override."""
+        with pytest.raises(ValueError, match="project root"):
+            db.artifact_tar_command("html", "/p", "/tmp/a.tgz")
+
+    def test_the_wrapper_records_the_rel_it_actually_tarred(self) -> None:
+        """The sentinel's ``artifact_rel`` is evidence, and evidence that says
+        ``.svelte-kit/cloudflare`` for a build that wrote ``build`` is worse than none."""
+        script = db.build_wrapper_script(
+            "svelte",
+            "/p",
+            timeout_seconds=600,
+            artifact_path="/tmp/a.tgz",
+            artifact_rel="build",
+        )
+        # ``shlex.quote`` leaves a bare word unquoted, so this is the literal rendering.
+        assert "\nARTIFACT_REL=build\n" in script
+        assert "/p/build" in script
+        assert ".svelte-kit" not in script
+
+    @pytest.mark.skipif(not tar_is_available(), reason="needs a real tar binary")
+    def test_a_real_tar_packs_build_and_leaves_a_stale_adapter_tree_behind(
+        self, tmp_path: Path
+    ) -> None:
+        """Run the real binary over a tree carrying BOTH output dirs — the shape a project
+        dir has when a pre-SL-1 adapter-cloudflare build left one behind. Packing the stale
+        one serves the old site forever, silently, which no unit assertion on the command
+        string would catch."""
+        import shlex
+        import subprocess
+
+        project = write_project_tree(
+            tmp_path / "proj",
+            {
+                "build/index.html": b"<h1>the current build</h1>",
+                "build/_app/immutable/entry.js": b"//js",
+                ".svelte-kit/cloudflare/index.html": b"<h1>stale</h1>",
+                "node_modules/left-pad/index.js": b"//dep",
+            },
+        )
+        dest = str(tmp_path / "out.tgz").replace("\\", "/")
+        command = db.artifact_tar_command("svelte", project, dest, output_rel="build")
+        proc = subprocess.run(shlex.split(command), capture_output=True, text=True)
+        if proc.returncode != 0:
+            raise RuntimeError(f"tar failed ({proc.returncode}): {proc.stderr.strip()}")
+        with tarfile.open(dest) as tar:
+            names = sorted(tar.getnames())
+        assert "./index.html" in names
+        assert not any("stale" in n or ".svelte-kit" in n for n in names)
+        assert not any("node_modules" in n for n in names)
+
+
+# ---------------------------------------------------------------------------
+# 2b. The gate the sandbox would otherwise have lost
+# ---------------------------------------------------------------------------
+
+
+class TestTheWrapperKeepsTheSsrMarkerScan:
+    """An inline svelte publish fails on a known workerd marker even when the build exits
+    ZERO (``paw-sites/src/smoke.ts::interpretBuildOutput`` checks the markers BEFORE it
+    checks the exit code). The lane runs bare ``bun install`` + ``bun run build`` and has
+    no paw-sites in the sandbox, so without this the check is simply gone — and
+    ``window is not defined`` from a top-level browser-only import is the classic Paw Site
+    failure, not an exotic one."""
+
+    def test_the_scan_runs_after_a_clean_build(self) -> None:
+        script = db.build_wrapper_script(
+            "svelte", "/p", timeout_seconds=600, artifact_path="/tmp/a.tgz", artifact_rel="build"
+        )
+        for marker in db.WORKERD_SSR_MARKERS:
+            assert f"grep -qF -- '{marker}'" in script
+        # AFTER the build, BEFORE the tar: a marker must not be discovered on a log that
+        # does not exist yet, and must stop the artifact from being packed at all.
+        assert script.index("bun run build") < script.index("grep -qF")
+        assert script.index("grep -qF") < script.index("tar -czf")
+
+    def test_a_hit_becomes_a_build_failure_the_user_owns(self) -> None:
+        """``BUILD_EXIT=1`` rather than a new sentinel field, so ``classify_build`` routes
+        it to ``build_failed`` with ``blames_user`` — which is true, and which puts the
+        marker in the stderr tail the user is shown."""
+        script = db.build_wrapper_script(
+            "svelte", "/p", timeout_seconds=600, artifact_path="/tmp/a.tgz", artifact_rel="build"
+        )
+        scan = script[script.index("grep -qF") : script.index("tar -czf")]
+        assert "BUILD_EXIT=1" in scan
+
+    def test_markers_are_matched_as_fixed_strings(self) -> None:
+        """``-F``. A marker is prose, and one containing a ``.`` read as a regex matches
+        text it does not mean — a false build failure on a site that is fine."""
+        script = db.build_wrapper_script(
+            "react", "/p", timeout_seconds=600, artifact_path="/tmp/a.tgz"
+        )
+        assert "grep -q " not in script
+        assert script.count("grep -qF -- ") == len(db.WORKERD_SSR_MARKERS)
+
+    def test_the_markers_match_the_inline_paths_list(self) -> None:
+        """Two copies of one rule, so they are asserted equal rather than trusted. The
+        inline publish reads ``generator_client._WORKERD_SSR_MARKERS``; a marker added to
+        one list and not the other means the lane and the inline path disagree about what
+        a broken render looks like."""
+        assert set(db.WORKERD_SSR_MARKERS) == set(gen_mod._WORKERD_SSR_MARKERS)
+
+    def test_an_empty_marker_set_renders_no_conditional(self) -> None:
+        """Mutation: an empty tuple must not render a bare ``if ; then``, which is a
+        syntax error that would fail every build in the lane."""
+        script = db.build_wrapper_script(
+            "react", "/p", timeout_seconds=600, artifact_path="/tmp/a.tgz", ssr_markers=()
+        )
+        assert "grep -qF" not in script
+        assert "if ; then" not in script
+
+    @pytest.mark.skipif(not tar_is_available(), reason="needs a POSIX shell")
+    def test_the_rendered_scan_is_valid_bash(self) -> None:
+        """``bash -n`` over the whole script. The scan is generated shell embedded in
+        generated shell, and a quoting mistake in it does not fail a unit assertion — it
+        fails every build in the lane, at runtime, as an unexplained exit 2."""
+        import shutil
+        import subprocess
+
+        bash = shutil.which("bash") or ""
+        if not bash:
+            pytest.skip("no bash on PATH")
+        script = db.build_wrapper_script(
+            "svelte", "/p", timeout_seconds=600, artifact_path="/tmp/a.tgz", artifact_rel="build"
+        )
+        proc = subprocess.run([bash, "-n"], input=script, capture_output=True, text=True)
+        assert proc.returncode == 0, proc.stderr
+
+
+# ---------------------------------------------------------------------------
+# 3. The unpack
+# ---------------------------------------------------------------------------
+
+
+def _tar_bytes(members: dict[str, bytes]) -> bytes:
+    """A gzipped tar rooted AT the output dir's contents, the shape the sandbox sends."""
+    buf = BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        for name, data in members.items():
+            info = tarfile.TarInfo(f"./{name}")
+            info.size = len(data)
+            tar.addfile(info, BytesIO(data))
+    return buf.getvalue()
+
+
+class TestTheDeployUnpacksWhereTheDeployerWillLook:
+    @pytest.mark.asyncio
+    async def test_a_static_svelte_artifact_lands_under_build(self) -> None:
+        """``deploy_prebuilt_site`` resolves its source as
+        ``<project_dir>/resolve_static_output_rel(...)``, which probes ``build`` FIRST.
+        Extracting under the nominal ``.svelte-kit/cloudflare`` would still be found by
+        that probe today — but only by accident, and the accident inverts the moment a
+        dynamic artifact reaches the same code. Put the tree where it belongs."""
+        from pocketpaw_ee.sites import build_job
+
+        seen: dict[str, Any] = {}
+
+        async def _fake_deploy(*, project_dir: str, deploy_inputs: dict[str, Any]) -> None:
+            root = Path(project_dir)
+            seen["rel"] = engines_mod.resolve_static_output_rel(root, "svelte")
+            seen["index"] = (root / "build" / "index.html").read_bytes()
+
+        await build_job._deploy_built_artifact(
+            _tar_bytes({"index.html": b"<h1>live</h1>"}),
+            engine="svelte",
+            deploy_inputs={"site_id": "s1"},
+            deployer=_fake_deploy,
+            output_rel="build",
+        )
+        assert seen["rel"] == "build"
+        assert seen["index"] == b"<h1>live</h1>"
+
+    @pytest.mark.asyncio
+    async def test_react_is_unchanged(self) -> None:
+        from pocketpaw_ee.sites import build_job
+
+        seen: dict[str, Any] = {}
+
+        async def _fake_deploy(*, project_dir: str, deploy_inputs: dict[str, Any]) -> None:
+            seen["index"] = (Path(project_dir) / "dist" / "index.html").read_bytes()
+
+        await build_job._deploy_built_artifact(
+            _tar_bytes({"index.html": b"<h1>react</h1>"}),
+            engine="react",
+            deploy_inputs={"site_id": "s1"},
+            deployer=_fake_deploy,
+        )
+        assert seen["index"] == b"<h1>react</h1>"
+
+    @pytest.mark.asyncio
+    async def test_an_artifact_carrying_a_server_entry_is_refused(self) -> None:
+        """``unpack_artifact``'s skip list DROPS ``_worker.js`` — written for a preview,
+        where a worker is noise. On the way to the edge it is the site. Dropping it
+        silently deploys a shell that cannot start, so the lane refuses the artifact
+        instead. This discharges the obligation ``_deploy_built_artifact``'s own docstring
+        recorded against widening the gate past react."""
+        from pocketpaw_ee.sites import build_job
+
+        async def _never(*, project_dir: str, deploy_inputs: dict[str, Any]) -> None:
+            raise AssertionError("the deploy must not be reached")
+
+        with pytest.raises(RuntimeError, match="server entry"):
+            await build_job._deploy_built_artifact(
+                _tar_bytes({"index.html": b"<h1>x</h1>", "_worker.js": b"export default {}"}),
+                engine="svelte",
+                deploy_inputs={"site_id": "s1"},
+                deployer=_never,
+                output_rel="build",
+            )
+
+    @pytest.mark.asyncio
+    async def test_a_chunked_worker_directory_is_refused_too(self) -> None:
+        """adapter-cloudflare emits ``_worker.js`` as a DIRECTORY once an app is large
+        enough (``_worker.js/chunks/0.js``). ``engines.resolve_emits_server_worker`` had to
+        learn the same thing, and for the same reason: a check keyed on a FILE reports "no
+        worker" for exactly the biggest sites — the ones most broken by dropping it.
+
+        Mutation: match ``name == "_worker.js"`` instead of a path component and this
+        artifact sails through, which is the failure that only shows up in production."""
+        from pocketpaw_ee.sites import build_job
+
+        async def _never(*, project_dir: str, deploy_inputs: dict[str, Any]) -> None:
+            raise AssertionError("the deploy must not be reached")
+
+        with pytest.raises(RuntimeError, match="server entry"):
+            await build_job._deploy_built_artifact(
+                _tar_bytes({"index.html": b"<h1>x</h1>", "_worker.js/chunks/0.js": b"//c"}),
+                engine="svelte",
+                deploy_inputs={"site_id": "s1"},
+                deployer=_never,
+                output_rel="build",
+            )
+
+    @pytest.mark.asyncio
+    async def test_an_unreadable_archive_is_left_to_the_unpack_to_report(self) -> None:
+        """``verify_artifact`` already rejects a corrupt archive upstream with a reason of
+        its own. Re-raising here would relabel a known condition as a server-entry problem
+        and send whoever reads the row to look for a worker that was never there."""
+        from pocketpaw_ee.sites import build_job
+
+        with pytest.raises(Exception) as caught:
+            await build_job._deploy_built_artifact(
+                b"not a tar at all",
+                engine="svelte",
+                deploy_inputs={"site_id": "s1"},
+                deployer=None,
+                output_rel="build",
+            )
+        assert "server entry" not in str(caught.value)
+
+
+# ---------------------------------------------------------------------------
+# 4. The whole job, end to end
+# ---------------------------------------------------------------------------
+
+
+class TestTheJobWiresThePredictionToBothEnds:
+    """The direct-call tests above hand ``_deploy_built_artifact`` an ``output_rel``, so
+    none of them proves ``run_site_build`` PASSES one. That is the seam where the tar and
+    the unpack can silently stop agreeing, and where the harm is worst: the artifact lands
+    somewhere the deploy target does not read, and a blank site replaces a working one.
+
+    Mutation: ``output_rel=None`` at the job's deploy call, which every other test here
+    survives."""
+
+    async def _site(self):
+        from pocketpaw_ee.cloud.models.site import Site
+
+        doc = Site(workspace="ws1", pocket_id="pk1", owner="u1", name="x", build_status="queued")
+        await doc.insert()
+        return doc
+
+    async def test_a_static_svelte_build_deploys_from_build_not_the_adapter_dir(
+        self, beanie_test_db
+    ) -> None:
+        from pocketpaw_ee.sites import build_job as bj
+
+        from tests.ee.sites.faults import FaultyDaytonaClient, clean_artifact
+        from tests.ee.sites.test_async_publish import _deploy_inputs, _FakeRunner
+
+        site = await self._site()
+        captured: dict[str, Any] = {}
+
+        async def _deploy(*, project_dir: str, deploy_inputs: dict[str, Any]) -> Any:
+            root = Path(project_dir)
+            captured["under_build"] = (root / "build" / "index.html").is_file()
+            captured["under_adapter"] = (root / ".svelte-kit" / "cloudflare").exists()
+            captured["resolved"] = engines_mod.resolve_static_output_rel(root, "svelte")
+            return None
+
+        await bj.run_site_build(
+            {},
+            "ws1",
+            str(site.id),
+            {"engine": "svelte", "siteConfig": {}, "source": dict(_STATIC_SOURCE)},
+            "svelte",
+            600,
+            deploy_inputs=_deploy_inputs(str(site.id)),
+            _runner=_FakeRunner(),
+            _client=FaultyDaytonaClient(artifact=clean_artifact()),
+            _deployer=_deploy,
+        )
+
+        assert captured["under_build"] is True, "the artifact must land under adapter-static's dir"
+        assert captured["under_adapter"] is False, "nothing may be written to the dynamic dir"
+        assert captured["resolved"] == "build"
+
+    async def test_the_sandbox_is_told_to_tar_the_same_directory(self, beanie_test_db) -> None:
+        """The other end of the same prediction. What the sandbox EXECUTES has to pack
+        ``build``; predicting ``build`` for the unpack while packing
+        ``.svelte-kit/cloudflare`` produces an empty artifact rather than a wrong one —
+        loud, but still a publish that cannot succeed."""
+        from pocketpaw_ee.sites import build_job as bj
+
+        from tests.ee.sites.faults import FaultyDaytonaClient, clean_artifact
+        from tests.ee.sites.test_async_publish import _deploy_inputs, _FakeRunner
+
+        class _RecordingClient(FaultyDaytonaClient):
+            """``FaultyDaytonaClient`` records that exec HAPPENED, not what it ran. The
+            wrapper script is the whole contract with the sandbox, so this keeps it."""
+
+            def __init__(self, **kwargs: Any) -> None:
+                super().__init__(**kwargs)
+                self.commands: list[str] = []
+
+            async def execute_command(self, sandbox_id, command, timeout=30):  # type: ignore[no-untyped-def]
+                self.commands.append(str(command))
+                return await super().execute_command(sandbox_id, command, timeout)
+
+        site = await self._site()
+        client = _RecordingClient(artifact=clean_artifact())
+
+        async def _deploy(*, project_dir: str, deploy_inputs: dict[str, Any]) -> Any:
+            return None
+
+        await bj.run_site_build(
+            {},
+            "ws1",
+            str(site.id),
+            {"engine": "svelte", "siteConfig": {}, "source": dict(_STATIC_SOURCE)},
+            "svelte",
+            600,
+            deploy_inputs=_deploy_inputs(str(site.id)),
+            _runner=_FakeRunner(),
+            _client=client,
+            _deployer=_deploy,
+        )
+
+        uploaded = "".join(
+            contents.decode("utf-8", "replace") if isinstance(contents, bytes) else str(contents)
+            for contents, _path in client.uploaded
+        )
+        haystack = " ".join(client.commands) + uploaded
+        assert "/build" in haystack, "the sandbox must be told to tar adapter-static's dir"
+        assert ".svelte-kit/cloudflare" not in haystack

--- a/tests/mutations/fault_ladder.json
+++ b/tests/mutations/fault_ladder.json
@@ -20,8 +20,8 @@
   {
     "label": "an engine whose output is the project root is packed anyway, so an html site's node_modules is uploaded with it",
     "file": "ee/pocketpaw_ee/sites/daytona_build.py",
-    "find": "    rel = static_output_rel(engine)\n    if rel == \".\":",
-    "replace": "    rel = static_output_rel(engine)\n    if False:",
+    "find": "    if rel == \".\":\n        raise ValueError(",
+    "replace": "    if False:\n        raise ValueError(",
     "tests": [
       "tests/ee/sites/test_fault_ladder_build.py"
     ]

--- a/tests/mutations/sites_sl1_resolvers.json
+++ b/tests/mutations/sites_sl1_resolvers.json
@@ -2,36 +2,46 @@
   {
     "label": "probe order reversed — a stale adapter-cloudflare tree shadows the current build",
     "file": "ee/pocketpaw_ee/sites/engines.py",
-    "find": "for candidate in (_SVELTE_STATIC_OUTPUT_REL, _STATIC_OUTPUT_REL[\"svelte\"]):",
-    "replace": "for candidate in (_STATIC_OUTPUT_REL[\"svelte\"], _SVELTE_STATIC_OUTPUT_REL):",
-    "tests": ["tests/ee/sites/test_engines.py::TestResolveStaticOutputRel"]
+    "find": "        return (_SVELTE_STATIC_OUTPUT_REL, _STATIC_OUTPUT_REL[\"svelte\"])",
+    "replace": "        return (_STATIC_OUTPUT_REL[\"svelte\"], _SVELTE_STATIC_OUTPUT_REL)",
+    "tests": [
+      "tests/ee/sites/test_engines.py::TestResolveStaticOutputRel"
+    ]
   },
   {
     "label": "_worker.js tested with is_file() — a worker DIRECTORY reads as no worker",
     "file": "ee/pocketpaw_ee/sites/engines.py",
     "find": "return (out_dir / \"_worker.js\").exists()",
     "replace": "return (out_dir / \"_worker.js\").is_file()",
-    "tests": ["tests/ee/sites/test_engines.py::TestResolveEmitsServerWorker"]
+    "tests": [
+      "tests/ee/sites/test_engines.py::TestResolveEmitsServerWorker"
+    ]
   },
   {
     "label": "svelte-only guard defeated — ripple/html/react start probing the filesystem too",
     "file": "ee/pocketpaw_ee/sites/engines.py",
     "find": "    if normalized != \"svelte\":",
     "replace": "    if normalized != \"svelte\" and False:",
-    "tests": ["tests/ee/sites/test_engines.py::TestResolveStaticOutputRel"]
+    "tests": [
+      "tests/ee/sites/test_engines.py::TestResolveStaticOutputRel"
+    ]
   },
   {
     "label": "server-worker engine guard defeated — html/react consult a stray _worker.js",
     "file": "ee/pocketpaw_ee/sites/engines.py",
     "find": "    if normalize_engine(engine) not in _SERVER_WORKER_ENGINES:",
     "replace": "    if normalize_engine(engine) not in _SERVER_WORKER_ENGINES and False:",
-    "tests": ["tests/ee/sites/test_engines.py::TestResolveEmitsServerWorker"]
+    "tests": [
+      "tests/ee/sites/test_engines.py::TestResolveEmitsServerWorker"
+    ]
   },
   {
     "label": "static svelte reports the dynamic dir — the deploy uploads an empty tree",
     "file": "ee/pocketpaw_ee/sites/engines.py",
     "find": "_SVELTE_STATIC_OUTPUT_REL = \"build\"",
     "replace": "_SVELTE_STATIC_OUTPUT_REL = \".svelte-kit/cloudflare\"",
-    "tests": ["tests/ee/sites/test_engines.py"]
+    "tests": [
+      "tests/ee/sites/test_engines.py"
+    ]
   }
 ]

--- a/tests/mutations/sl3_publish_flip.json
+++ b/tests/mutations/sl3_publish_flip.json
@@ -2,8 +2,8 @@
   {
     "label": "SL-3: every engine flips to async, so a ripple or dynamic-svelte publish queues a build whose artifact cannot serve (its pages come from a _worker.js whose imports sit outside the tar) — the site stops publishing",
     "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "    return normalize_engine(engine) == \"react\"",
-    "replace": "    return True",
+    "find": "    normalized = normalize_engine(engine)\n    if normalized == \"react\":\n        return True",
+    "replace": "    normalized = normalize_engine(engine)\n    return True",
     "tests": [
       "tests/ee/sites/test_async_publish.py::TestOnlyTheDeployableEngineFlips",
       "tests/ee/sites/test_async_publish.py::TestTheInlinePathIsUnchanged"
@@ -12,8 +12,8 @@
   {
     "label": "SL-3: no engine flips, so the whole slice is inert — publish still blocks on an inline build and the queued-build UI has nothing to show",
     "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "def build_runs_async(engine: str | None) -> bool:",
-    "replace": "def build_runs_async(engine: str | None) -> bool:\n    return False",
+    "find": "    normalized = normalize_engine(engine)\n    if normalized == \"react\":",
+    "replace": "    return False\n    normalized = normalize_engine(engine)\n    if normalized == \"react\":",
     "tests": [
       "tests/ee/sites/test_async_publish.py::TestAReactPublishEnqueues",
       "tests/ee/sites/test_async_publish.py::TestOnlyTheDeployableEngineFlips::test_react_builds_asynchronously"
@@ -22,8 +22,8 @@
   {
     "label": "SL-3: the async fork stops excluding a worker callback, so the worker's deploy re-enters the fork and enqueues ANOTHER build — a publish that queues itself forever and never goes live",
     "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "    if prebuilt_project_dir is None and build_runs_async(engine):",
-    "replace": "    if build_runs_async(engine):",
+    "find": "    if prebuilt_project_dir is None and build_runs_async(engine, source=source, pattern=pattern):",
+    "replace": "    if build_runs_async(engine, source=source, pattern=pattern):",
     "tests": [
       "tests/ee/sites/test_async_publish.py::TestTheDeploySeamRunsTheInlineTail"
     ]
@@ -86,8 +86,8 @@
   {
     "label": "SL-3: the artifact is extracted FLAT instead of under the engine's static-output dir, so the deploy target resolves an empty directory and a blank site replaces a working one",
     "file": "ee/pocketpaw_ee/sites/build_job.py",
-    "find": "            artifact, Path(project_dir, static_output_rel(engine))",
-    "replace": "            artifact, Path(project_dir)",
+    "find": "        unpacked = artifact_preview.unpack_artifact(artifact, Path(project_dir, rel))",
+    "replace": "        unpacked = artifact_preview.unpack_artifact(artifact, Path(project_dir))",
     "tests": [
       "tests/ee/sites/test_async_publish.py::TestTheWorkerFinishesThePublish::test_the_deploy_receives_the_artifact_under_the_engines_output_dir"
     ]

--- a/tests/mutations/sl4_svelte_lane.json
+++ b/tests/mutations/sl4_svelte_lane.json
@@ -1,0 +1,131 @@
+[
+  {
+    "label": "SL-4: the staging flag defaults ON, so every svelte publish moves to the lane the moment this merges — dropping the resting-visibility gate from every marketing site without anything failing to say so",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if not svelte_async_build_enabled():\n        return False\n",
+    "replace": "",
+    "tests": [
+      "tests/ee/sites/test_svelte_async_build.py::TestTheFlagIsTheDefaultOff",
+      "tests/ee/sites/test_smoke_at_publish.py::test_live_publish_runs_smoke"
+    ]
+  },
+  {
+    "label": "SL-4: the flag reads any non-empty value as on, so a typo (PAW_SITES_SVELTE_ASYNC_BUILD=maybe) becomes a production routing change",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    return raw in {\"1\", \"true\", \"yes\", \"on\"}",
+    "replace": "    return bool(raw)",
+    "tests": [
+      "tests/ee/sites/test_svelte_async_build.py::TestTheFlagIsTheDefaultOff::test_anything_else_stays_off"
+    ]
+  },
+  {
+    "label": "SL-4: the gate stops reading the bindings, so a DYNAMIC svelte site enters the lane and deploys an adapter-cloudflare artifact whose _worker.js imports a file outside the tar — a worker shell that cannot start replaces a working site",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    return not svelte_source_is_dynamic(source)",
+    "replace": "    return True",
+    "tests": [
+      "tests/ee/sites/test_svelte_async_build.py::TestTheGateReadsTheBindingsNotJustTheEngine::test_a_dynamic_svelte_site_is_refused"
+    ]
+  },
+  {
+    "label": "SL-4: the gate ignores the pattern=='dynamic' stamp, so a stamped dynamic svelte pocket whose bindings live somewhere the envelope does not show still enters the lane",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if pattern == \"dynamic\":\n        return False\n",
+    "replace": "",
+    "tests": [
+      "tests/ee/sites/test_svelte_async_build.py::TestTheGateReadsTheBindingsNotJustTheEngine::test_the_dynamic_stamp_alone_is_enough"
+    ]
+  },
+  {
+    "label": "SL-4: the classifier counts every source instead of only kind=='data', diverging from parseBindings — static sites are held out of the lane forever, which looks exactly like the feature never shipping",
+    "file": "ee/pocketpaw_ee/sites/generator_client.py",
+    "find": "            if isinstance(entry, dict) and entry.get(\"kind\") == \"data\":",
+    "replace": "            if isinstance(entry, dict):",
+    "tests": [
+      "tests/ee/sites/test_svelte_async_build.py::TestTheGateReadsTheBindingsNotJustTheEngine::test_a_non_data_source_does_not_make_a_site_dynamic"
+    ]
+  },
+  {
+    "label": "SL-4: auth is read as truthy rather than exactly True, diverging from parseBindings' `spec.auth === true`",
+    "file": "ee/pocketpaw_ee/sites/generator_client.py",
+    "find": "    if source.get(\"auth\") is True:",
+    "replace": "    if source.get(\"auth\"):",
+    "tests": [
+      "tests/ee/sites/test_generator_client_svelte.py",
+      "tests/ee/sites/test_svelte_async_build.py"
+    ]
+  },
+  {
+    "label": "SL-4: the predicted output dir falls back to the nominal per-engine value, so a static svelte build tars .svelte-kit/cloudflare — a directory adapter-static never writes — and every publish settles artifact_empty",
+    "file": "ee/pocketpaw_ee/sites/generator_client.py",
+    "find": "    return candidate_static_output_rels(\"svelte\")[0]",
+    "replace": "    return static_output_rel(\"svelte\")",
+    "tests": [
+      "tests/ee/sites/test_svelte_async_build.py::TestTheTarTargetsTheAdapterThatActuallyRan"
+    ]
+  },
+  {
+    "label": "SL-4: an output_rel the engine cannot emit is honoured instead of refused, so a caller's mistake packs nothing and arrives disguised as the user's build producing nothing",
+    "file": "ee/pocketpaw_ee/sites/daytona_build.py",
+    "find": "    if output_rel is not None and output_rel not in candidate_static_output_rels(engine):",
+    "replace": "    if False:",
+    "tests": [
+      "tests/ee/sites/test_svelte_async_build.py::TestTheTarTargetsTheAdapterThatActuallyRan::test_an_override_the_engine_cannot_emit_is_refused"
+    ]
+  },
+  {
+    "label": "SL-4: the wrapper drops the SSR marker scan, so a svelte build that prerenders 'window is not defined' onto a ZERO exit code deploys — the check an inline publish makes and the sandbox has no paw-sites to make",
+    "file": "ee/pocketpaw_ee/sites/daytona_build.py",
+    "find": "    marker_scan = _render_marker_scan(ssr_markers)",
+    "replace": "    marker_scan = _render_marker_scan(())",
+    "tests": [
+      "tests/ee/sites/test_svelte_async_build.py::TestTheWrapperKeepsTheSsrMarkerScan"
+    ]
+  },
+  {
+    "label": "SL-4: markers are matched as regexes rather than fixed strings, so a marker containing a '.' matches text it does not mean and fails a build that is fine",
+    "file": "ee/pocketpaw_ee/sites/daytona_build.py",
+    "find": "        f'grep -qF -- {shlex.quote(marker)} \"$STDERR_LOG\"' for marker in markers",
+    "replace": "        f'grep -q -- {shlex.quote(marker)} \"$STDERR_LOG\"' for marker in markers",
+    "tests": [
+      "tests/ee/sites/test_svelte_async_build.py::TestTheWrapperKeepsTheSsrMarkerScan::test_markers_are_matched_as_fixed_strings"
+    ]
+  },
+  {
+    "label": "SL-4: a marker hit no longer fails the build, so the scan runs, logs, and lets the broken render deploy anyway",
+    "file": "ee/pocketpaw_ee/sites/daytona_build.py",
+    "find": "        \"  BUILD_EXIT=1\\n\"",
+    "replace": "        \"  BUILD_EXIT=0\\n\"",
+    "tests": [
+      "tests/ee/sites/test_svelte_async_build.py::TestTheWrapperKeepsTheSsrMarkerScan::test_a_hit_becomes_a_build_failure_the_user_owns"
+    ]
+  },
+  {
+    "label": "SL-4: the deploy stops refusing an artifact that carries a server entry, so unpack_artifact's preview-shaped skip list silently DROPS the _worker.js and deploys a shell that cannot start",
+    "file": "ee/pocketpaw_ee/sites/build_job.py",
+    "find": "    _refuse_server_entry(artifact, engine=engine, site_id=deploy_inputs.get(\"site_id\"))",
+    "replace": "    pass",
+    "tests": [
+      "tests/ee/sites/test_svelte_async_build.py::TestTheDeployUnpacksWhereTheDeployerWillLook"
+    ]
+  },
+  {
+    "label": "SL-4: the server-entry check matches a FILE named _worker.js instead of a path component, so adapter-cloudflare's chunked _worker.js/ DIRECTORY escapes — the shape only the biggest sites emit, and the ones most broken by dropping it",
+    "file": "ee/pocketpaw_ee/sites/build_job.py",
+    "find": "        if any(part == \"_worker.js\" for part in name.replace(\"\\\\\", \"/\").split(\"/\")):",
+    "replace": "        if name.replace(\"\\\\\", \"/\").split(\"/\")[-1] == \"_worker.js\":",
+    "tests": [
+      "tests/ee/sites/test_svelte_async_build.py::TestTheDeployUnpacksWhereTheDeployerWillLook::test_a_chunked_worker_directory_is_refused_too"
+    ]
+  },
+  {
+    "label": "SL-4: the tar and the unpack derive the output dir independently, so a change to one leaves the artifact extracted into a directory the deploy target does not read — a blank site replacing a working one",
+    "file": "ee/pocketpaw_ee/sites/build_job.py",
+    "find": "                output_rel=artifact_rel,",
+    "replace": "                output_rel=None,",
+    "tests": [
+      "tests/ee/sites/test_async_publish.py::TestTheWorkerFinishesThePublish",
+      "tests/ee/sites/test_svelte_async_build.py::TestTheJobWiresThePredictionToBothEnds"
+    ]
+  }
+]

--- a/tests/mutations/sl4_svelte_lane.json
+++ b/tests/mutations/sl4_svelte_lane.json
@@ -85,8 +85,8 @@
   {
     "label": "SL-4: markers are matched as regexes rather than fixed strings, so a marker containing a '.' matches text it does not mean and fails a build that is fine",
     "file": "ee/pocketpaw_ee/sites/daytona_build.py",
-    "find": "        f'grep -qF -- {shlex.quote(marker)} \"$STDERR_LOG\"' for marker in markers",
-    "replace": "        f'grep -q -- {shlex.quote(marker)} \"$STDERR_LOG\"' for marker in markers",
+    "find": "join(f'grep -qF -- {shlex.quote(marker)} \"$STDERR_LOG\"' for marker in markers)",
+    "replace": "join(f'grep -q -- {shlex.quote(marker)} \"$STDERR_LOG\"' for marker in markers)",
     "tests": [
       "tests/ee/sites/test_svelte_async_build.py::TestTheWrapperKeepsTheSsrMarkerScan::test_markers_are_matched_as_fixed_strings"
     ]


### PR DESCRIPTION
A static svelte publish blocks the API process for the whole of `bun install` + `bun run build`. react stopped doing that in SL-3, when it moved to the ephemeral Daytona lane. This lets svelte do the same.

## Why svelte was held back, and why that reason was wrong

`build_runs_async` answered `engine == "react"`, and its docstring explained the exclusion:

> STATIC svelte (adapter-static) IS self-sufficient, and is still excluded, because which adapter ran is a property of the built SITE and is not knowable at enqueue time — only after the build.

That premise does not hold. The adapter is picked in `paw-sites/src/index.ts` from `parseBindings(...).isDynamic`, computed from `objects` / `sources` / `actions` / `auth`. Those ride the publish as sibling keys on the `source` envelope, so they are in the caller's hand before a queue slot is spent. Nothing has to be built to know which adapter will run.

So the fork is decidable up front:

| | adapter | output | worker | lane |
|---|---|---|---|---|
| static svelte | adapter-static | `build` | none | queue |
| dynamic svelte | adapter-cloudflare | `.svelte-kit/cloudflare` | renders every page | inline |

Dynamic stays inline for the reason it always has. Its `_worker.js` imports `./../output/server/index.js`, which sits outside the tarred directory, so the artifact cannot execute. That was verified by a canary build, and it is why `truth_lane` refuses to even preview one.

## Three things had to move together

The gate now reads the bindings. Reading the engine name alone is not enough, and the dynamic answer is the load-bearing one. `_deploy_site_doc` forks dynamic sites away before `build_runs_async` is ever called, but that fork uses `_is_dynamic`, which reads the `ripple_spec`. A svelte pocket carries its bindings on the `source` envelope instead, so for svelte that fork only sees the `pattern == "dynamic"` stamp. An unstamped dynamic svelte pocket arrives at the gate looking static to everything upstream. That is why both signals are read.

The tar now targets the adapter that actually ran. The wrapper baked `static_output_rel("svelte")` = `.svelte-kit/cloudflare`, but adapter-static writes `build`. Left alone, every static svelte build would have packed a directory that does not exist and settled `artifact_empty`. The include-list is rendered before the build runs, so it cannot read the answer off disk. The caller predicts it with `expected_static_output_rel` and passes it down.

The unpack uses that same prediction. One helper feeds both the tar and the extract, so they cannot drift into extracting a tree the deploy target does not read.

Two smaller things came with it. `artifact_tar_command` refuses an `output_rel` the engine cannot emit, because an include-list aimed at a directory that will never exist packs nothing, and the caller's mistake would otherwise arrive disguised as the user's build producing nothing. And `_deploy_built_artifact` refuses an artifact carrying a `_worker.js`. That discharges the obligation its own docstring recorded against exactly this widening: `unpack_artifact`'s skip list drops the server entry, which is right for a preview and wrong on the way to the edge.

## What the lane gives up, and what it does not

An inline publish runs `paw-sites`'s `runWorkerdSmokeRender`. The sandbox has no paw-sites in it, so two checks were at risk.

The known-workerd-marker scan is recovered. The wrapper greps the whole build log for the same markers and fails the build on a hit, which is stricter than the inline path, since that one only ever sees a truncated stderr tail. `window is not defined` from a top-level browser-only import is the classic Paw Site failure, not an exotic one, and it can land on a zero exit code.

The resting-visibility guard is not recovered. It judges a clean build by reading the prerendered `index.html` and the emitted CSS to catch a page that is blank at rest. No exit code substitutes for it, and porting it to Python would be a third implementation of a rule that already exists twice.

That gap is why this ships behind `PAW_SITES_SVELTE_ASYNC_BUILD`, default off, rather than as a straight flip. Turning it on is safe and useful now, since the offload is real and the lane's own gates all apply. But a default-on flip would have quietly removed a check from every marketing site the product publishes. Making it the default is blocked on giving the lane a resting-visibility verdict, whose clean shape is a `paw-sites-gen` subcommand that judges an already-built tree, called by the worker on the unpacked artifact. That is a paw-sites change plus a vendor refresh, so it belongs in its own PR in its own repo.

The lane has no local fallback. With `DAYTONA_API_URL` / `DAYTONA_API_KEY` unset, `run_build` raises and the publish settles `sandbox_unavailable:run_build_raised`. Set the flag on the web service and the worker both: web decides whether to enqueue, worker does the build.

## Testing

- 53 new tests in `tests/ee/sites/test_svelte_async_build.py` covering the flag, the gate, the tar target, the marker scan, the unpack, and the job wiring end to end.
- A new mutation plan, `tests/mutations/sl4_svelte_lane.json`, with 14 mutations. The first run had 2 escape, which found two real holes: nothing distinguished a truthy `auth` from `auth is True`, and nothing proved `run_site_build` actually passes the predicted rel to the deploy. Both are now covered.
- Three existing plans had anchors pointing at code this PR moved. Repaired and re-run: `sl3_publish_flip` (11 caught), `fault_ladder` (32 caught), `sites_sl1_resolvers` (5 caught).
- `tests/ee/sites/`, `tests/cloud/surface/test_sites_handler.py` and `tests/ee/agent/test_sites_mcp_server/` are green.
- With the flag off, behaviour is byte-for-byte what it was, which is what keeps the six suites encoding the inline contract passing untouched.
