### PR TITLE
Put a site's creation time on the wire

### DIFF
--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -203,6 +203,18 @@ class SiteResponse(BaseModel):
     # P2b: ISO-8601 timestamp of the most recent successful live deploy, or None
     # before the first deploy (a preview-only / never-deployed pocket reads None).
     deployed_at: str | None = None
+    # ISO-8601 timestamp of when the Site row was created — the doc's ``createdAt``,
+    # which every TimestampedDocument has carried since day one. This only surfaces
+    # it.
+    #
+    # It exists because ``deployed_at`` above is None for every DRAFT, and
+    # draft-first create means most of a real workspace is drafts. The gallery
+    # orders by "most recent", so with only ``deployed_at`` on the wire the entire
+    # draft population had NO ordering key and fell through to alphabetical — a site
+    # created a minute ago rendered under "About". None only for a doc that somehow
+    # predates the base model's field, so the client still degrades to name order
+    # rather than crashing.
+    created_at: str | None = None
     # DS-1a: the source pocket's authoring pattern ("dynamic" | "landing" | ...),
     # resolved from Pocket.pattern (it lives on the pocket, not the Site). "" when
     # the pocket has no pattern or could not be resolved. Lets the frontend badge

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1684,6 +1684,7 @@ async def _promote_pocket_draft_to_published(
 
 def _to_response(doc: _SiteDoc, pattern: str = "", engine: str = "") -> SiteResponse:
     deployed_at = getattr(doc, "deployed_at", None)
+    created_at = getattr(doc, "createdAt", None)
     return SiteResponse(
         id=str(doc.id),
         pocket_id=doc.pocket_id,
@@ -1698,6 +1699,13 @@ def _to_response(doc: _SiteDoc, pattern: str = "", engine: str = "") -> SiteResp
         # P2b: ISO string of the last successful live deploy, or None before the
         # first deploy (pre-P2b rows read null via the getattr default).
         deployed_at=deployed_at.isoformat() if deployed_at is not None else None,
+        # When the row was made. The gallery orders by "most recent", and
+        # ``deployed_at`` above is None for every draft — so without this the whole
+        # draft half of a workspace had no ordering key and sorted alphabetically,
+        # which put a site created a minute ago below one created last month. Read
+        # via getattr for the same reason deployed_at is: a doc that predates the
+        # field reads None rather than raising.
+        created_at=created_at.isoformat() if created_at is not None else None,
         # DS-1a: the source pocket's authoring pattern ("dynamic" | "landing" |
         # ...), resolved by the caller from Pocket.pattern (it lives on the pocket,
         # not the Site). "" when unset / unresolved so the gallery is empty-safe.

--- a/tests/ee/sites/test_created_at_on_the_wire.py
+++ b/tests/ee/sites/test_created_at_on_the_wire.py
@@ -1,0 +1,140 @@
+# tests/ee/sites/test_created_at_on_the_wire.py — feat/sites-created-at: the /sites
+# gallery orders by "most recent", and until now the only timestamp on the wire was
+# ``deployed_at``.
+#
+# Created: 2026-08-21 (feat/sites-created-at).
+#
+# THE BUG. ``deployed_at`` is None for every DRAFT, and draft-first create
+# (pocketpaw#1744) means most of a real workspace is drafts. The gallery's sort
+# therefore had NO ordering key for the entire draft population and fell through to
+# its alphabetical tiebreak — so a site created a minute ago rendered below one
+# created last month, under "About". The data was never missing: ``Site`` extends
+# ``TimestampedDocument``, which has stamped ``createdAt`` on insert since day one.
+# It simply was not surfaced.
+#
+# What these pin:
+#   * a freshly minted DRAFT carries ``created_at`` on SiteResponse even though it
+#     has no ``deployed_at`` — the case the whole change exists for;
+#   * it is an ISO-8601 string, not a datetime, matching every other timestamp on
+#     these DTOs (the frontend does Date.parse on it);
+#   * publishing does not disturb it — a site's creation time is not its deploy
+#     time, and the two must be independently readable;
+#   * a doc that somehow carries no ``createdAt`` reads None rather than raising,
+#     so an old row degrades to name order instead of blanking the gallery.
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pocketpaw_ee.sites import service as sites_service
+
+pytestmark = pytest.mark.asyncio
+
+
+class _FakeGenerator:
+    async def build(self, **kw):
+        from pocketpaw_ee.sites.generator_client import BuildResult
+
+        self.built = kw
+        return BuildResult(project_dir="/tmp/site", ripple_version="0.2.0")
+
+
+async def _publish_local(pocket_id: str, *, name: str):
+    """Publish through the LIVE path in LOCAL deploy mode. PAW_CF_DEPLOY_MODE is
+    pinned by the caller's monkeypatch (the workspace .env leaks ``workers`` into the
+    test env, which would send publish down the workers.dev branch and hit the
+    network); the injected ``_local_deploy`` seam means no build tree is needed.
+    Copied from test_draft_first_visibility.py, which publishes the same way."""
+    wire = {"name": name, "engine": "ripple", "rippleSpec": {"type": "container"}}
+    with patch(
+        "pocketpaw_ee.cloud.pockets.service.get",
+        new=AsyncMock(return_value=wire),
+    ):
+        return await sites_service.publish_pocket(
+            workspace_id="ws1",
+            user_id="u1",
+            pocket_id=pocket_id,
+            _generator=_FakeGenerator(),
+            _bundle_reader=lambda d: b"unused-in-local-mode",
+            _local_deploy=lambda sid, pd: f"http://127.0.0.1:9999/{sid}/",
+        )
+
+
+async def test_a_draft_carries_created_at_with_no_deployed_at(beanie_test_db):
+    """THE CASE THIS EXISTS FOR. A draft has never deployed, so ``deployed_at`` is
+    None — and before this change that left the gallery with nothing to order it by.
+    ``created_at`` is present from the moment the row is minted."""
+    await sites_service.create_draft_site(
+        workspace_id="ws1", user_id="u1", pocket_id="pk_draft", name="Minimal Test"
+    )
+
+    cards = await sites_service.list_for_workspace("ws1")
+    assert len(cards) == 1
+    card = cards[0]
+
+    assert card.deployed is False
+    assert card.deployed_at is None, "a draft has not deployed — this must stay None"
+    assert card.created_at is not None, (
+        "a draft must carry created_at, or the gallery has no key to order it by"
+    )
+
+
+async def test_created_at_is_an_iso_string_not_a_datetime(beanie_test_db):
+    """The wire shape. Every other timestamp on these DTOs is an ISO-8601 string and
+    the frontend runs Date.parse over it; a datetime would serialize differently and
+    a naive client would read NaN."""
+    await sites_service.create_draft_site(
+        workspace_id="ws1", user_id="u1", pocket_id="pk_iso", name="Bright Smile"
+    )
+
+    card = (await sites_service.list_for_workspace("ws1"))[0]
+    assert isinstance(card.created_at, str)
+    # Round-trips: the string parses back to the same instant.
+    assert isinstance(datetime.fromisoformat(card.created_at), datetime)
+
+
+async def test_publishing_does_not_move_created_at(beanie_test_db, monkeypatch):
+    """A site's creation time is not its deploy time. Publish upserts the SAME doc
+    (the one-doc invariant), so ``created_at`` must survive it unchanged while
+    ``deployed_at`` appears alongside — the gallery reads deploy first and falls back
+    to creation, and it can only do that if both are readable."""
+    monkeypatch.delenv("PAW_CF_ACCOUNT_ID", raising=False)
+    monkeypatch.delenv("PAW_SITES_LOCAL", raising=False)
+    monkeypatch.setenv("PAW_CF_DEPLOY_MODE", "local")
+
+    await sites_service.create_draft_site(
+        workspace_id="ws1", user_id="u1", pocket_id="pk_pub", name="Bright Smile"
+    )
+    before = (await sites_service.list_for_workspace("ws1"))[0].created_at
+    assert before is not None
+
+    await _publish_local("pk_pub", name="Bright Smile")
+
+    card = (await sites_service.list_for_workspace("ws1"))[0]
+    assert card.deployed is True
+    assert card.created_at == before, "publish must not restamp the creation time"
+    assert card.deployed_at is not None, "and it must stamp the deploy time"
+
+
+async def test_a_doc_without_created_at_reads_none_rather_than_raising(beanie_test_db):
+    """Degrade, do not crash. ``_to_response`` reads the field via getattr for the
+    same reason ``deployed_at`` does: a row written before the field existed must
+    render as "no date" — which the gallery answers with name order — rather than
+    taking the whole list down with an AttributeError."""
+    from pocketpaw_ee.cloud.models.site import Site as _SiteDoc
+
+    doc = _SiteDoc(
+        workspace="ws1",
+        pocket_id="pk_old",
+        owner="u1",
+        name="Legacy",
+        script_name="legacy",
+        deployed=False,
+        signed_key="k",
+    )
+    # Stand in for a row that predates TimestampedDocument's field.
+    object.__setattr__(doc, "createdAt", None)
+
+    response = sites_service._to_response(doc)
+    assert response.created_at is None


### PR DESCRIPTION
The Site doc has carried `createdAt` since it was first written. Every `TimestampedDocument` does. It was never on `SiteResponse`, so the gallery had exactly one timestamp to order by: `deployed_at`.

That is null for every draft, and draft-first create means most of a real workspace is drafts. So the entire draft half of the list had no ordering key and fell through to the alphabetical tiebreak. A site created a minute ago sorted under "About". Surfacing the field the database already had is the whole change.

Read through `getattr` for the same reason `deployed_at` is: a row that somehow predates the field renders as no date, which the gallery answers with name order, rather than taking the list down with an `AttributeError`.

## Who wants it

qbtrix/paw-enterprise#814, which regroups the /sites gallery into Drafts and Published sections. Grouping alone would have left the same bug inside the Drafts section, where every member has a null deploy stamp. The frontend field is optional, so the gallery degrades to the current name order against a backend that does not send it yet, and the two can merge in either order.

## Tests

`tests/ee/sites/test_created_at_on_the_wire.py` covers a draft carrying `created_at` with no `deployed_at` (the case this exists for), the ISO string shape, publish leaving the creation time alone while stamping the deploy time, and a doc with no `createdAt` reading None rather than raising.

`tests/ee/sites` and `tests/ee/agent` are green (1980 tests).
