### PR TITLE
Free includes a custom domain on one site

### DIFF
--- a/ee/pocketpaw_ee/cloud/_core/errors.py
+++ b/ee/pocketpaw_ee/cloud/_core/errors.py
@@ -163,7 +163,12 @@ class CustomDomainNotEntitled(CloudError):
     upgrade rather than a workspace one.
 
     The distinction from its siblings is that this is not a COUNT limit: there is no
-    ceiling to report, only a capability the site's tier either resells or does not.
+    ceiling to report, only a capability the site's tier either grants or does not.
+    ``CustomDomainLimitError`` below is the count sibling, and since 2026-08-21 it
+    is the one that normally fires — the free floor grants one domained site, so a
+    tier granting NONE only exists if the catalog is edited to say so, or if a
+    resolve lands on a tier whose allowance is 0. The class stays because that is
+    exactly the fail-closed case worth having a distinct code for.
     Two different failures land here and the message separates them, because the
     remedies differ — a free site upgrades its plan, while a paid site whose
     subscription lapsed fixes its billing and keeps the tier it already chose.
@@ -187,6 +192,43 @@ class CustomDomainNotEntitled(CloudError):
                 "renew it to connect a custom domain"
             )
         super().__init__(402, "billing.custom_domain_not_entitled", f"Custom domain: {detail}")
+
+
+class CustomDomainLimitError(CloudError):
+    """Workspace hit its plan's cap on how many SITES may carry a custom domain (402).
+
+    The COUNT sibling of ``CustomDomainNotEntitled``, and a separate class because
+    the remedies differ: that one means "this site's subscription is not paying",
+    this one means "you have used the allowance, upgrade a site to add another".
+    A UI that collapses them tells a paying customer to renew a subscription that
+    never lapsed.
+
+    **The unit is the SITE, not the hostname.** A workspace on the free floor gets
+    one site carrying custom domains; apex and ``www`` both sit on that site and
+    spend one allowance between them. ``scope="site"`` reports the OTHER cap — how
+    many hostnames one floor-tier site may carry — which exists only because the
+    site-unit cap leaves that number unbounded.
+
+    Enforced at ATTACH time only, never retroactive: an existing domain is never
+    detached, and re-adding an already-connected hostname (the only self-service
+    repair for a missing Worker route) never reaches this check. Gated on
+    ``billing_enforced``, so OSS / self-host never sees it.
+    """
+
+    def __init__(self, *, limit: int, scope: str = "workspace") -> None:
+        if scope == "site":
+            detail = (
+                f"this site already has {limit} custom hostnames, which is the limit "
+                "on the free plan — upgrade it to connect more"
+            )
+        else:
+            noun = "site" if limit == 1 else "sites"
+            detail = (
+                f"custom domains are included on {limit} {noun} on your plan, and "
+                f"{'that one is' if limit == 1 else 'those are'} already in use — "
+                "upgrade a site's plan to connect another"
+            )
+        super().__init__(402, "billing.custom_domain_limit", f"Custom domain: {detail}")
 
 
 class CallLimitError(CloudError):

--- a/ee/pocketpaw_ee/cloud/billing/site_plans.py
+++ b/ee/pocketpaw_ee/cloud/billing/site_plans.py
@@ -39,6 +39,17 @@
 #   docs/design/drafts/2026-08-13-paw-sites-pricing-spec.md): when basic/pro/
 #   business are rekeyed to free/site/staff, this mapping moves with them and is
 #   the ONLY place the badge's plan gate is expressed.
+# Updated 2026-08-21 (feat/site-free-custom-domain, PW-1): added
+#   ``max_domained_sites`` — HOW MANY SITES in a workspace may carry a custom
+#   domain on this tier (None = uncapped). The floor now carries 1 rather than 0,
+#   which is the captain's rule of 2026-08-21: "only 1 site is allowed to have a
+#   custom domain in free". THE UNIT IS THE SITE, NOT THE HOSTNAME — apex and
+#   ``www`` on one site cost one, not two — which is why the field is not called
+#   ``max_custom_domains``. Custom-domain entitlement now reads this field rather
+#   than ``"custom_domain" in cloudflare_features``, so ``cloudflare_features``
+#   goes back to meaning only what its name says: RESOLD Cloudflare capability
+#   that BC-10 provisions. Also added ``_FREE_MAX_HOSTNAMES_PER_SITE`` — see its
+#   own comment for why a site-unit cap needs a hostname-unit companion.
 
 from __future__ import annotations
 
@@ -50,7 +61,7 @@ from dataclasses import dataclass
 # but the SHAPE (a growing ladder, base resells nothing) is the contract.
 #
 #   basic    — $0/yr    — the included tier; no resold Cloudflare features.
-#   pro      — $120/yr  — adds a custom domain + analytics.
+#   pro      — $120/yr  — adds analytics + uncapped custom domains.
 #   business — $480/yr  — adds the WAF + edge cache controls on top of pro.
 # ---------------------------------------------------------------------------
 _SITE_PLAN_ANNUAL_PRICE_USD: dict[str, int] = {
@@ -77,6 +88,38 @@ _SITE_PLAN_BADGE_REMOVAL: dict[str, bool] = {
     "business": True,
 }
 
+# How many SITES in a workspace may carry a custom domain on this tier.
+# ``None`` means uncapped.
+#
+# THE UNIT IS THE SITE, NOT THE HOSTNAME. A site pointing both ``acme.com`` and
+# ``www.acme.com`` at itself spends ONE of these, not two — which is the pair
+# almost every customer wants and the reason this is not named
+# ``max_custom_domains``. A reader who takes the name literally counts
+# ``SiteDomain`` rows, and ``SiteDomain`` is one row per hostname.
+#
+# The floor carries 1, not 0: "only 1 site is allowed to have a custom domain in
+# free" (captain, 2026-08-21). That 1 is a FLOOR GRANT — it needs no subscription,
+# unlike every other capability on this catalog — so the resolver reads it off the
+# base tier whether or not the site is paying. Unknown keys resolve to 0 in
+# ``_build``: fail-closed, matching ``badge_removal``.
+_SITE_PLAN_MAX_DOMAINED_SITES: dict[str, int | None] = {
+    "basic": 1,
+    "pro": None,
+    "business": None,
+}
+
+# How many HOSTNAMES one FLOOR-tier site may carry. The companion cap to
+# ``max_domained_sites``, and it exists because that field caps sites: without
+# this, a free workspace can point fifty hostnames at its one allowed site, each
+# one costing a Cloudflare custom hostname and a Worker route at $0 revenue. Two
+# is apex + ``www``.
+#
+# Deliberately a single named constant with a single comparison — this is a
+# recommendation the build made, not a rule the captain handed down, so raising it
+# or deleting it is a one-line change and nothing else moves. Paid tiers are not
+# subject to it.
+_FREE_MAX_HOSTNAMES_PER_SITE = 2
+
 # Order the catalog is listed in — the price ladder, cheapest first.
 _SITE_TIER_ORDER: tuple[str, ...] = ("basic", "pro", "business")
 
@@ -94,7 +137,9 @@ class SitePlanTier:
     is the set of Cloudflare features the tier resells (BC-10 provisions them).
     ``badge_removal`` is whether a site on this tier may ship without the
     attribution badge — read by ``sites.badge.badge_required``. ``sells_concierge``
-    is derived, not stored (see the property).
+    is derived, not stored (see the property). ``max_domained_sites`` is how many
+    SITES in the workspace may carry a custom domain on this tier (None =
+    uncapped) — the site, not the hostname, so apex + ``www`` on one site spend one.
     """
 
     key: str
@@ -102,6 +147,7 @@ class SitePlanTier:
     dodo_product_id: str | None
     cloudflare_features: frozenset[str]
     badge_removal: bool = False
+    max_domained_sites: int | None = 0
 
     @property
     def sells_concierge(self) -> bool:
@@ -157,7 +203,22 @@ def _build(key: str) -> SitePlanTier:
         dodo_product_id=_dodo_product_for(key),
         cloudflare_features=_SITE_PLAN_CF_FEATURES.get(key, frozenset()),
         badge_removal=_SITE_PLAN_BADGE_REMOVAL.get(key, False),
+        # ``.get(key, 0)`` and not ``.get(key)``: a missing key must mean NO
+        # domains, while a present key mapped to None means UNCAPPED. Collapsing
+        # the two would hand an unknown tier the uncapped answer.
+        max_domained_sites=_SITE_PLAN_MAX_DOMAINED_SITES.get(key, 0),
     )
+
+
+def free_max_hostnames_per_site() -> int:
+    """How many hostnames one FLOOR-tier site may carry.
+
+    A function rather than a bare constant import so the one seam that enforces it
+    (``sites.service.add_domain``) reads it through the catalog's public surface,
+    the same way it reads every other plan rule. See the constant's comment for why
+    a site-unit cap needs a hostname-unit companion at all.
+    """
+    return _FREE_MAX_HOSTNAMES_PER_SITE
 
 
 def list_site_plans() -> list[SitePlanTier]:
@@ -185,6 +246,7 @@ def get_site_plan(key: str | None) -> SitePlanTier | None:
 __all__ = [
     "BASE_SITE_PLAN_KEY",
     "SitePlanTier",
+    "free_max_hostnames_per_site",
     "get_site_plan",
     "list_site_plans",
 ]

--- a/ee/pocketpaw_ee/cloud/entitlements/domain.py
+++ b/ee/pocketpaw_ee/cloud/entitlements/domain.py
@@ -34,6 +34,14 @@
 #   ``concierge_enabled`` was a PASS-THROUGH of the owner's toggle that consulted no
 #   plan at all, so a free site served a concierge indefinitely. The two questions
 #   stay separate fields on purpose — see the class docstring.
+# Updated 2026-08-21 (feat/site-free-custom-domain, PW-1): added
+#   ``SiteEntitlements.max_domained_sites`` (``int | None``, None = uncapped) — how
+#   many SITES in the workspace may carry a custom domain, counted in SITES rather
+#   than hostnames so apex + ``www`` on one site spend one. Unlike every other
+#   field here it is a FLOOR GRANT: the base tier's 1 resolves with no subscription
+#   at all, because free now includes a custom domain. ``custom_domain`` stays, now
+#   derived as ``max_domained_sites != 0`` — it answers "may this site have one at
+#   all", which is a different question from "has the workspace room for another".
 # Updated 2026-08-13 (feat/sites-site-entitlements): added ``SiteEntitlements`` —
 #   the PER-SITE shape, a second scope beside the workspace one. Sites are the
 #   only thing billed per-object (``Site.plan_tier`` + ``subscription_status``),
@@ -107,6 +115,20 @@ class SiteEntitlements:
     not deployed yet (the charge-first flow deploys on activation), so failing
     closed on it cannot badge a live paying site.
 
+    ``max_domained_sites`` is the odd one out and worth reading twice. Every other
+    capability here is a PAID grant, gated on an active subscription. This one is a
+    FLOOR grant: the base tier confers 1 with no subscription, because free now
+    includes a custom domain. An active paid subscription replaces the floor with
+    the tier's own value (None = uncapped). A LAPSED paid site therefore falls back
+    to the floor's 1 rather than to 0 — it keeps what free would have given it.
+    The unit is the SITE: how many hostnames sit on one site is a separate cap,
+    enforced at the attach seam, not here.
+
+    ``custom_domain`` is derived from it (``!= 0``) rather than stored separately.
+    It answers "may this site have a custom domain at all"; whether the WORKSPACE
+    has room for another is a count the resolver cannot answer, because counting
+    needs the site collection and ``entitlements`` may not import ``models.site``.
+
     Deliberately ABSENT: ``conv_allowance``, ``conv_rate_usd`` and
     ``white_label``. The first two wait on which meter owns a concierge run, and
     the third on an org entity that does not exist. A field that always returns
@@ -128,6 +150,7 @@ class SiteEntitlements:
     subscription_active: bool
     badge_required: bool
     custom_domain: bool
+    max_domained_sites: int | None
     concierge_enabled: bool
     concierge_entitled: bool
 

--- a/ee/pocketpaw_ee/cloud/entitlements/service.py
+++ b/ee/pocketpaw_ee/cloud/entitlements/service.py
@@ -40,6 +40,16 @@
 # Updated 2026-08-08 (feat/billing-storage-caps): also added
 #   ``max_storage_bytes`` — the workspace S3 storage cap (Free = 5 GB) surfaced
 #   to the uploads gate and the /storage/usage read; fail-closed to 5 GB.
+# Updated 2026-08-21 (feat/site-free-custom-domain, PW-1): ``resolve_site_entitlements``
+#   no longer has ONE branch. It has two, and the split is the point of the change:
+#   PAID grants (badge removal, concierge, an UNCAPPED domain allowance) still need
+#   an active subscription, while the FLOOR grant (``max_domained_sites``) resolves
+#   off the base tier whether or not anyone is paying — because free now includes a
+#   custom domain, and a catalog edit alone could never have delivered one. Under
+#   the old single branch every $0 tier fell through to the all-False defaults, so a
+#   floor capability was structurally unexpressible. Also extracted the
+#   active-subscription test to ``_subscription_is_active`` now that two branches
+#   ask it.
 # Updated 2026-08-20 (feat/site-plan-catalog-inclusions): ``concierge_entitled``
 #   now reads ``tier.sells_concierge`` off the catalog row instead of re-deriving
 #   "above the free floor" here — the plan-catalog DTO needs the same answer for
@@ -122,6 +132,46 @@ async def resolve_entitlements(workspace_id: str) -> Entitlements:
 _ACTIVE_SITE_SUBSCRIPTION_STATUSES = frozenset({"active"})
 
 
+def _subscription_is_active(subscription_status: str | None) -> bool:
+    """Is this site's per-site subscription actually paying?
+
+    Extracted from ``resolve_site_entitlements``'s single branch when that branch
+    became two (floor grants vs paid grants) and both needed the same answer. A
+    None / empty status normalizes to "none" — absent is not paying.
+    """
+    return (subscription_status or "none") in _ACTIVE_SITE_SUBSCRIPTION_STATUSES
+
+
+def site_domain_allowance(*, plan_tier: str | None, subscription_status: str | None) -> int | None:
+    """How many SITES may carry a custom domain, from THIS site's own plan.
+
+    ``None`` means uncapped. Public because the ATTACH seam needs it per row: to
+    decide whether a workspace has room for one more domained site it has to ask,
+    of every site already holding a domain, whether that site is riding the free
+    floor or paying for its own uncapped allowance. Only a site on the floor spends
+    the workspace's floor allowance.
+
+    Split out of ``resolve_site_entitlements`` rather than re-derived there, so the
+    floor-vs-paid rule is written once. ``sites.service`` calling this is not a
+    layering break: it is a pure function of two strings, which is the same reason
+    ``resolve_site_entitlements`` takes the site's billing fields instead of
+    reading them (EE cloud rule 2).
+    """
+    # The floor first — it applies to an unknown tier, an absent tier, and a paid
+    # tier whose subscription has lapsed, all of which must land on the same
+    # answer. Free includes one domained site, so this is a grant, not a denial.
+    floor = site_plan_catalog.get_site_plan(site_plan_catalog.BASE_SITE_PLAN_KEY)
+    allowance = floor.max_domained_sites if floor is not None else 0
+
+    # A paying tier's own allowance REPLACES the floor — normally upward
+    # (None = uncapped). Not ``max(...)``: None is not a number, and a tier that
+    # deliberately sells fewer domained sites than free should be able to.
+    tier = site_plan_catalog.get_site_plan(plan_tier)
+    if tier is not None and _subscription_is_active(subscription_status):
+        allowance = tier.max_domained_sites
+    return allowance
+
+
 def resolve_site_entitlements(
     *,
     site_id: str,
@@ -138,31 +188,46 @@ def resolve_site_entitlements(
     passes what it owns. That also makes every branch here testable without a
     database.
 
-    Every paid capability is gated on the tier granting it AND the subscription
-    being active. Reading the tier alone is the bug this function exists to
-    prevent: cancellation never resets ``plan_tier``, and an unconfigured Dodo
-    product records a paid tier with no charge at all.
+    PAID capabilities are gated on the tier granting it AND the subscription being
+    active. Reading the tier alone is the bug this function exists to prevent:
+    cancellation never resets ``plan_tier``, and an unconfigured Dodo product
+    records a paid tier with no charge at all.
+
+    FLOOR capabilities are the exception, and ``max_domained_sites`` is the first
+    of them. Free includes one domained site, so that allowance has to resolve with
+    no subscription — the base tier confers it, and an active paid subscription
+    only ever REPLACES it. Before this split there was one branch and every $0 tier
+    fell straight through it to all-False, which made a floor capability impossible
+    to express in the catalog at all.
 
     Fails closed on every unknown: an absent/unknown tier resolves to the base
-    (badged, no custom domain) rather than raising or substituting a paid tier.
+    (badged, and the base tier's own domain allowance) rather than raising or
+    substituting a paid tier.
     """
     tier = site_plan_catalog.get_site_plan(plan_tier)
     # ``get_site_plan`` deliberately does not substitute a floor, so an unknown or
     # missing key lands here as None — the fail-closed default.
     resolved_key = tier.key if tier is not None else site_plan_catalog.BASE_SITE_PLAN_KEY
 
-    subscription_active = (subscription_status or "none") in _ACTIVE_SITE_SUBSCRIPTION_STATUSES
+    subscription_active = _subscription_is_active(subscription_status)
 
-    # Both paid capabilities collapse to False unless the tier grants them AND the
-    # subscription is paying. Written as an explicit branch rather than
-    # ``paid and tier.x`` so the None-narrowing is visible to the type checker
-    # instead of resting on short-circuit evaluation.
+    # --- FLOOR grants: what the base tier confers with nobody paying -------- #
+    # The rule lives in ``site_domain_allowance`` because the attach seam asks it
+    # per row too, and one rule written twice is one rule that drifts. A lapsed
+    # paid site lands on free's one domained site rather than on zero — losing a
+    # subscription must not leave a customer worse off than never having had one.
+    max_domained_sites = site_domain_allowance(
+        plan_tier=plan_tier, subscription_status=subscription_status
+    )
+
+    # --- PAID grants: the tier AND an active subscription ------------------- #
+    # Written as an explicit branch rather than ``paid and tier.x`` so the
+    # None-narrowing is visible to the type checker instead of resting on
+    # short-circuit evaluation.
     badge_removal = False
-    custom_domain = False
     concierge_entitled = False
     if tier is not None and subscription_active:
         badge_removal = tier.badge_removal
-        custom_domain = "custom_domain" in tier.cloudflare_features
         # Any tier ABOVE the free floor sells the concierge. The rule itself now
         # lives on the catalog row (``SitePlanTier.sells_concierge``) because the
         # plan-catalog DTO needs the same answer for the buyer-facing plan cards;
@@ -176,7 +241,14 @@ def resolve_site_entitlements(
         plan_tier=resolved_key,
         subscription_active=subscription_active,
         badge_required=not badge_removal,
-        custom_domain=custom_domain,
+        # "May this site have a custom domain at all" — derived, never stored
+        # twice. Read off the allowance rather than ``cloudflare_features``, which
+        # goes back to meaning only RESOLD Cloudflare capability (BC-10). Whether
+        # the WORKSPACE has room for one more is a COUNT, and counting needs the
+        # site collection this module may not import (EE cloud rule 2), so it lives
+        # at the attach seam in ``sites.service``.
+        custom_domain=max_domained_sites != 0,
+        max_domained_sites=max_domained_sites,
         # Echoed unchanged — the owner's switch is not a billing question. The
         # AND of the two is ``concierge_available``, which is what seams ask.
         concierge_enabled=bool(concierge_enabled),

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1,6 +1,18 @@
 # ee/pocketpaw_ee/sites/service.py — Sites control-plane orchestration. Sole
 # owner of Site writes.
 #
+# Updated 2026-08-21 (feat/site-free-custom-domain, PW-1): the free floor now
+# includes a custom domain, so ``add_domain`` gained a COUNT gate beside the
+# existing capability gate. ``_domain_cap_exceeded`` answers "does this workspace
+# have room for another site carrying a custom domain", and the unit is the SITE:
+# apex and ``www`` both live on one site and spend one allowance between them.
+# Three counting rules carry the whole behaviour and each one is load-bearing —
+# see that function. ``_hostname_cap_exceeded`` is its companion, capping how many
+# hostnames a single floor site may carry, which the site-unit rule otherwise
+# leaves unbounded. Both sit AFTER the already-connected early return, so neither
+# is retroactive and neither can block the re-Add route repair, and both are gated
+# on ``billing_enforced`` so self-host reads nothing extra.
+#
 # Updated 2026-08-19 (fix/sites-read-source-tool): added ``read_site_source`` — the
 # READ primitive beside ``apply_edits``. The three ``edit_*`` functions below all
 # resolve an agent-authored diff against the CURRENT file, and nothing on the /sites
@@ -847,10 +859,12 @@ from typing import Any
 
 from bson import ObjectId
 from bson.errors import InvalidId
+from pydantic import BaseModel
 
 from pocketpaw.sites_capture.contact_form import CONTACT_FORM_TYPE, default_event_mapping
 from pocketpaw_ee.cloud._core.errors import (
     CloudError,
+    CustomDomainLimitError,
     CustomDomainNotEntitled,
     Forbidden,
     Internal,
@@ -4123,6 +4137,122 @@ def _assert_entitled_to_custom_domain(site: Any) -> None:
     )
 
 
+class _DomainedSiteProjection(BaseModel):
+    """The two billing fields of a site that already holds a custom domain.
+
+    Sites carry generated source, and the census below reads every domained site
+    in the workspace on the attach path — pulling whole documents to look at two
+    strings would drag entire built sites across the wire and discard them. The
+    query filters on ``domains.0`` existing, so the projection does not need the
+    domain rows themselves: presence is the whole question.
+    """
+
+    plan_tier: str | None = None
+    subscription_status: str = "none"
+
+
+async def _domain_cap_exceeded(workspace_id: str, site: Any) -> tuple[bool, int, int | None]:
+    """Would attaching a domain here exceed the workspace cap? -> (exceeded, count, limit).
+
+    The cap counts SITES, not hostnames: "only 1 site is allowed to have a custom
+    domain in free" (captain, 2026-08-21). Getting the unit wrong is the easiest
+    mistake this function can make, because ``SiteDomain`` is one row per hostname,
+    so anything that counts rows refuses apex + ``www`` — the pair almost every
+    customer wants.
+
+    Three rules, all load-bearing:
+
+    1. **Count sites holding at least one domain**, not domains. The query does it
+       with ``domains.0 exists`` rather than loading the arrays.
+    2. **Count floor sites only.** A site paying for its own uncapped allowance
+       does not spend the workspace's floor one. Without this, a workspace whose
+       paid site has a domain could never give its free site the one free includes.
+       The floor-vs-paid question is asked through
+       ``entitlements.site_domain_allowance`` so the rule is not written twice.
+    3. **Exclude the site being attached to.** It is already inside the allowance
+       if it holds a domain, so its second hostname is free; and if it holds none
+       it contributes nothing to the count anyway. Excluding it unconditionally is
+       therefore the same answer as excluding it conditionally, with one less
+       branch to get wrong.
+
+    Archived sites are excluded (``archived: {"$ne": True}``, matching the gallery
+    read): they are dedupe tombstones of a live site, so counting them would charge
+    a workspace twice for one site it can only see once.
+
+    GATED on ``billing_enforced``: OSS / self-host gets ``(False, 0, None)`` with
+    no DB read at all. Returns the tuple rather than raising, mirroring
+    ``pockets.service._pocket_cap_exceeded``.
+    """
+    from pocketpaw.config import get_settings
+
+    if not get_settings().billing_enforced:
+        return (False, 0, None)
+
+    from pocketpaw_ee.cloud.entitlements import service as entitlements_service
+
+    limit = entitlements_service.site_domain_allowance(
+        plan_tier=site.plan_tier, subscription_status=site.subscription_status
+    )
+    if limit is None:
+        return (False, 0, None)
+
+    cursor = _SiteDoc.find(
+        {
+            "workspace": workspace_id,
+            "archived": {"$ne": True},
+            "_id": {"$ne": site.id},
+            "domains.0": {"$exists": True},
+        }
+    ).project(_DomainedSiteProjection)
+    count = 0
+    async for row in cursor:
+        if (
+            entitlements_service.site_domain_allowance(
+                plan_tier=row.plan_tier, subscription_status=row.subscription_status
+            )
+            is not None
+        ):
+            count += 1
+    return (count >= limit, count, limit)
+
+
+def _hostname_cap_exceeded(site: Any) -> tuple[bool, int, int | None]:
+    """Would this be one hostname too many ON THIS SITE? -> (exceeded, count, limit).
+
+    The companion to ``_domain_cap_exceeded``, and it exists because that one caps
+    SITES: on its own it lets a free workspace point fifty hostnames at its one
+    allowed site, each costing a Cloudflare custom hostname and a Worker route at
+    $0 revenue. The limit is apex + ``www``.
+
+    Applies only to a site riding a CAPPED allowance, which today is exactly the
+    free floor — every paid tier is uncapped, so a paying site is never subject to
+    it. Synchronous and reads no database: everything it needs is on the loaded doc.
+
+    This cap is a judgement the build made rather than a rule handed down, so it is
+    one constant and one comparison — raising it or removing it changes nothing
+    else. Gated on ``billing_enforced`` like every other cap here.
+    """
+    from pocketpaw.config import get_settings
+
+    if not get_settings().billing_enforced:
+        return (False, 0, None)
+
+    from pocketpaw_ee.cloud.billing import site_plans as _site_plans
+    from pocketpaw_ee.cloud.entitlements import service as entitlements_service
+
+    if (
+        entitlements_service.site_domain_allowance(
+            plan_tier=site.plan_tier, subscription_status=site.subscription_status
+        )
+        is None
+    ):
+        return (False, 0, None)
+
+    limit = _site_plans.free_max_hostnames_per_site()
+    count = len(site.domains)
+    return (count >= limit, count, limit)
+
+
 async def add_domain(
     *,
     workspace_id: str,
@@ -4222,6 +4352,41 @@ async def add_domain(
     #     the product, and it makes the customer's next legitimate attach fail on a
     #     1406 duplicate they can neither see nor clear.
     _assert_entitled_to_custom_domain(site)
+
+    # Then the COUNT. The capability gate above asks whether this site may have a
+    # custom domain at all; this asks whether the workspace has room for another
+    # site carrying one — a different question, a different remedy, and a different
+    # 402 code, so the UI can say "renew your subscription" and "you've used your
+    # free domain" as the distinct things they are.
+    #
+    # Same position and the same reasons: after the already-connected return (never
+    # retroactive, and the re-Add route repair stays reachable), before
+    # ``create_custom_hostname`` (a refusal after Cloudflare accepts the hostname
+    # strands it on the shared zone, invisible to the product and blocking the
+    # customer's next legitimate attach with a 1406 they cannot clear).
+    exceeded, _count, limit = await _domain_cap_exceeded(workspace_id, site)
+    if exceeded:
+        logger.info(
+            "sites: refused a custom domain for site %s — workspace %s already has "
+            "%s site(s) with a custom domain, limit %s",
+            site.id,
+            workspace_id,
+            _count,
+            limit,
+        )
+        raise CustomDomainLimitError(limit=limit)  # type: ignore[arg-type]  # int when exceeded
+
+    # And the per-site hostname cap, which only a floor site can trip.
+    host_exceeded, _hosts, host_limit = _hostname_cap_exceeded(site)
+    if host_exceeded:
+        logger.info(
+            "sites: refused a custom domain for site %s — it already carries %s "
+            "hostnames, limit %s on the free floor",
+            site.id,
+            _hosts,
+            host_limit,
+        )
+        raise CustomDomainLimitError(limit=host_limit, scope="site")  # type: ignore[arg-type]
 
     # Resolve the site's tier → its cloudflare_features and provision them on the
     # custom hostname. A base-tier (or unknown) site resolves to an empty set, so

--- a/tests/cloud/billing/test_site_plan_domain_quota.py
+++ b/tests/cloud/billing/test_site_plan_domain_quota.py
@@ -1,0 +1,90 @@
+# tests/cloud/billing/test_site_plan_domain_quota.py — the catalog half of "free
+# includes a custom domain".
+#
+# Created 2026-08-21 (feat/site-free-custom-domain, PW-1). The rule is the
+# captain's, 2026-08-21: "only 1 site is allowed to have a custom domain in free".
+# The seam that enforces it is tested in tests/cloud/sites/test_custom_domain_cap.py;
+# what is pinned HERE is the declaration it reads — the ladder's shape, and the two
+# ways a careless edit to it goes wrong quietly.
+#
+# 1. THE UNIT IS THE SITE. ``max_domained_sites`` counts sites, not hostnames, and
+#    the field is not called ``max_custom_domains`` for exactly that reason:
+#    ``SiteDomain`` is one row per hostname, so a reader who takes a hostname-shaped
+#    name literally writes a hostname-shaped count and refuses apex + www.
+# 2. MISSING IS NOT UNCAPPED. ``None`` in the map means uncapped, so an absent key
+#    must resolve to 0 rather than to None. ``.get(key)`` and ``.get(key, 0)`` look
+#    equally reasonable and mean opposite things.
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud.billing import site_plans  # noqa: E402
+
+
+def test_the_floor_includes_one_domained_site():
+    """The captain's rule, at the catalog."""
+    floor = site_plans.get_site_plan(site_plans.BASE_SITE_PLAN_KEY)
+
+    assert floor is not None
+    assert floor.max_domained_sites == 1
+
+
+def test_the_floor_still_resells_no_cloudflare_features():
+    """A custom domain on free is OUR allowance, not a resold Cloudflare feature.
+
+    ``cloudflare_features`` drives what BC-10 provisions on the custom hostname, and
+    the floor resells nothing — that is what free means. The entitlement question
+    moved off this set entirely, which is the point: it now says only what its name
+    says.
+    """
+    floor = site_plans.get_site_plan(site_plans.BASE_SITE_PLAN_KEY)
+
+    assert floor is not None
+    assert floor.cloudflare_features == frozenset()
+
+
+def test_every_paid_tier_is_uncapped():
+    """What a paid tier sells is the absence of a ceiling, not the capability."""
+    paid = [t for t in site_plans.list_site_plans() if t.key != site_plans.BASE_SITE_PLAN_KEY]
+
+    assert paid, "catalog has no tier above the floor — the ladder changed"
+    assert all(t.max_domained_sites is None for t in paid)
+
+
+def test_an_unknown_key_gets_no_domains_at_all():
+    """Fail-closed, and the branch that is one character from being wrong.
+
+    ``None`` means uncapped in this map, so a missing key must come back as 0.
+    ``_build`` is only reached through ``get_site_plan`` with known keys, which is
+    exactly why the defensive default needs its own test — nothing else exercises
+    it, and getting it wrong hands an unknown tier the most generous answer.
+    """
+    assert site_plans._build("no-such-tier").max_domained_sites == 0
+
+
+def test_the_ladder_never_narrows_as_it_climbs():
+    """A more expensive tier may not allow FEWER domained sites than a cheaper one.
+
+    Cheap to assert, and it catches the rekey mistake nobody notices in review: the
+    five tier-keyed maps in this module are edited together, and one of them being
+    left in the old order produces a ladder that silently sells less for more.
+    """
+    ladder = site_plans.list_site_plans()
+    # None sorts as "uncapped" — treat it as larger than any integer.
+    values = [
+        float("inf") if t.max_domained_sites is None else t.max_domained_sites for t in ladder
+    ]
+
+    assert values == sorted(values), f"domain allowance narrows going up the ladder: {values}"
+
+
+def test_the_hostname_companion_cap_leaves_room_for_apex_and_www():
+    """The site-unit rule is only humane if one site may hold both spellings.
+
+    A cap of 1 here would enforce the site rule and still refuse ``www``, which is
+    the failure the site-unit rule exists to avoid — so the floor is 2, not 1.
+    """
+    assert site_plans.free_max_hostnames_per_site() >= 2

--- a/tests/cloud/entitlements/test_site_entitlements.py
+++ b/tests/cloud/entitlements/test_site_entitlements.py
@@ -11,6 +11,19 @@
 # The resolver is pure, so every branch is exercised without a database: it takes
 # the site's billing fields because ``entitlements`` may not import ``models.site``
 # (EE cloud rule 2).
+#
+# Updated 2026-08-21 (feat/site-free-custom-domain, PW-1). Several assertions here
+# INVERTED, and the inversion is the change, not a regression: free now includes a
+# custom domain ("only 1 site is allowed to have a custom domain in free" —
+# captain, 2026-08-21), so a site resolving to the floor gets ``custom_domain
+# True`` and ``max_domained_sites == 1`` where it used to get False and nothing.
+# Badge removal, the concierge, and the UNCAPPED allowance are untouched: those are
+# still paid grants and still need an active subscription, which is why the
+# badge half of every one of these tests still reads exactly as it did.
+#
+# ``custom_domain`` answers "may this site have one at all" and is now True almost
+# everywhere. The question with teeth moved to the attach seam, which counts SITES
+# already holding a domain — see tests/cloud/sites/test_custom_domain_entitlement.py.
 
 from __future__ import annotations
 
@@ -55,6 +68,12 @@ def test_business_is_paid_too():
     assert ent.custom_domain is True
 
 
+def test_what_a_paying_site_actually_buys_is_an_UNCAPPED_allowance():
+    """Free includes a custom domain, so the paid tiers no longer sell the
+    capability — they sell the absence of a ceiling on it. None means uncapped."""
+    assert _resolve(plan_tier="pro", subscription_status="active").max_domained_sites is None
+
+
 # --------------------------------------------------------------------------- #
 # The hole: a paid TIER without a paying SUBSCRIPTION
 # --------------------------------------------------------------------------- #
@@ -69,7 +88,23 @@ def test_a_paid_tier_without_an_active_subscription_is_badged(status):
 
     assert ent.subscription_active is False
     assert ent.badge_required is True
-    assert ent.custom_domain is False
+
+
+@pytest.mark.parametrize("status", ["cancelled", "none", "pending", "", None, "garbage"])
+def test_a_lapsed_paid_site_falls_to_the_FLOOR_allowance_not_to_zero(status):
+    """It keeps what free would have given it, and no more.
+
+    Worth its own test because "fail closed" reads like it should mean zero here,
+    and zero would be wrong: a customer who once paid must not end up worse off
+    than one who never did. What lapsing actually costs is the UNCAPPED allowance —
+    the site drops from None to the floor's 1.
+    """
+    floor = site_plan_catalog.get_site_plan(site_plan_catalog.BASE_SITE_PLAN_KEY)
+
+    ent = _resolve(plan_tier="pro", subscription_status=status)
+
+    assert ent.max_domained_sites == floor.max_domained_sites
+    assert ent.custom_domain is True
 
 
 def test_a_tier_recorded_but_never_charged_is_badged():
@@ -79,7 +114,6 @@ def test_a_tier_recorded_but_never_charged_is_badged():
     ent = _resolve(plan_tier="business", subscription_status="none")
 
     assert ent.badge_required is True
-    assert ent.custom_domain is False
 
 
 def test_the_tier_is_still_reported_when_it_is_not_being_paid_for():
@@ -100,7 +134,41 @@ def test_the_base_tier_is_badged_even_when_active():
     ent = _resolve(plan_tier="basic", subscription_status="active")
 
     assert ent.badge_required is True
-    assert ent.custom_domain is False
+
+
+def test_the_floor_grants_its_domain_with_no_subscription_at_all():
+    """The captain's rule, at the resolver.
+
+    This is the case the old single-branch resolver could not express: every
+    capability sat behind ``tier is not None and subscription_active``, so a $0
+    tier fell through to all-False and a catalog edit granting free a domain would
+    have granted nothing. Splitting floor grants out of paid grants is what makes
+    the catalog value reachable.
+    """
+    ent = _resolve(plan_tier=site_plan_catalog.BASE_SITE_PLAN_KEY, subscription_status="none")
+
+    assert ent.subscription_active is False
+    assert ent.max_domained_sites == 1
+    assert ent.custom_domain is True
+
+
+def test_the_allowance_the_resolver_reports_is_the_one_in_the_catalog():
+    """Pinned against the catalog, not the literal 1, so the rekey moves this test
+    with the ladder instead of breaking it."""
+    floor = site_plan_catalog.get_site_plan(site_plan_catalog.BASE_SITE_PLAN_KEY)
+
+    ent = _resolve(plan_tier=site_plan_catalog.BASE_SITE_PLAN_KEY, subscription_status="none")
+
+    assert ent.max_domained_sites == floor.max_domained_sites
+
+
+def test_a_free_site_still_carries_its_badge_and_still_has_no_concierge():
+    """The floor grant is one capability, not a general amnesty. Free getting a
+    custom domain must not leak badge removal or the concierge along with it."""
+    ent = _resolve(plan_tier=site_plan_catalog.BASE_SITE_PLAN_KEY, subscription_status="none")
+
+    assert ent.badge_required is True
+    assert ent.concierge_entitled is False
 
 
 @pytest.mark.parametrize("tier", [None, "", "stduio", "site", "staff"])
@@ -112,7 +180,9 @@ def test_an_unknown_or_absent_tier_falls_to_the_base(tier):
 
     assert ent.plan_tier == site_plan_catalog.BASE_SITE_PLAN_KEY
     assert ent.badge_required is True
-    assert ent.custom_domain is False
+    # Fail-closed on the ALLOWANCE too: an unknown tier gets the floor's, never the
+    # uncapped one. "active" here is a red herring — there is no tier to activate.
+    assert ent.max_domained_sites == 1
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/cloud/sites/test_custom_domain_cap.py
+++ b/tests/cloud/sites/test_custom_domain_cap.py
@@ -1,0 +1,433 @@
+# tests/cloud/sites/test_custom_domain_cap.py — free includes a custom domain on
+# ONE site, and this tree is the count that enforces the word "one".
+#
+# Created 2026-08-21 (feat/site-free-custom-domain, PW-1). The rule: "only 1 site
+# is allowed to have a custom domain in free" (captain, 2026-08-21). Its sibling
+# tree, test_custom_domain_entitlement.py, covers the CAPABILITY gate — may this
+# site have a domain at all. This one covers the COUNT — has the workspace room
+# for another site that has one. Different question, different 402 code, different
+# remedy, so they are deliberately not one file.
+#
+# THE UNIT IS THE SITE, NOT THE HOSTNAME, and that is the single thing most worth
+# pinning here. ``SiteDomain`` is one row per hostname, so a count that reads rows
+# refuses apex + ``www`` — the pair almost every customer wants — while looking
+# completely correct. The first test in the file is that pair, on purpose: it is
+# the case an earlier draft of this design got wrong.
+#
+# Three counting rules, one test each, plus the guard that keeps the site-unit rule
+# from being free-for-all:
+#   1. sites holding >= 1 domain, not hostnames  -> the apex + www test
+#   2. FLOOR sites only                          -> the mixed-workspace test
+#   3. the target site excluded from its own cap -> the apex + www test again
+#   + a per-site hostname cap, since (1) leaves hostname count unbounded
+#
+# Every tier key is read off the catalog, never written as a literal, so the
+# pricing-spec rekey (basic/pro/business -> free/site/staff) moves this tree with
+# the ladder instead of breaking it.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("pocketpaw_ee")
+
+from pocketpaw_ee.cloud._core.errors import CloudError  # noqa: E402
+from pocketpaw_ee.cloud.billing import site_plans  # noqa: E402
+from pocketpaw_ee.cloud.models.site import Site  # noqa: E402
+from pocketpaw_ee.sites import service as sites_service  # noqa: E402
+from pocketpaw_ee.sites.domain import CustomHostname, HostnameStatus  # noqa: E402
+
+import pocketpaw.config as ppconfig  # noqa: E402
+
+pytestmark = pytest.mark.usefixtures("mongo_db")
+
+
+def _the_free_tier() -> str:
+    return site_plans.BASE_SITE_PLAN_KEY
+
+
+def _an_uncapped_tier() -> str:
+    """The cheapest catalog tier with no ceiling on domained sites."""
+    for tier in site_plans.list_site_plans():
+        if tier.max_domained_sites is None:
+            return tier.key
+    raise AssertionError("no site plan tier has an uncapped domain allowance — catalog changed")
+
+
+def _the_free_site_limit() -> int:
+    """How many domained sites the floor allows, read from the catalog."""
+    floor = site_plans.get_site_plan(site_plans.BASE_SITE_PLAN_KEY)
+    assert floor is not None and floor.max_domained_sites is not None
+    return floor.max_domained_sites
+
+
+class _RecordingCF:
+    """Stand-in CloudflareClient that records calls and never touches the network."""
+
+    def __init__(self) -> None:
+        self.create_calls: list[dict] = []
+        self.route_calls: list[dict] = []
+        self.delete_calls: list[str] = []
+
+    async def create_custom_hostname(
+        self, hostname: str, *, features: set[str] | None = None
+    ) -> CustomHostname:
+        self.create_calls.append({"hostname": hostname, "features": features})
+        return CustomHostname(
+            id=f"ch_{len(self.create_calls)}",
+            hostname=hostname,
+            status=HostnameStatus.PENDING,
+            cname_target="zone_1.cdn.cloudflare.net",
+        )
+
+    async def create_worker_route(self, *, pattern: str, script: str) -> str:
+        self.route_calls.append({"pattern": pattern, "script": script})
+        return f"route_{len(self.route_calls)}"
+
+    async def delete_custom_hostname(self, hostname_id: str) -> None:
+        self.delete_calls.append(hostname_id)
+
+
+def _enforce(monkeypatch, *, on: bool) -> None:
+    monkeypatch.setattr(
+        ppconfig,
+        "get_settings",
+        lambda: SimpleNamespace(billing_enforced=on, dodo_site_products=None),
+    )
+
+
+async def _seed_site(
+    *,
+    workspace_id: str,
+    pocket_id: str,
+    plan_tier: str | None = None,
+    subscription_status: str = "none",
+    archived: bool = False,
+) -> str:
+    """Insert a real Site doc and return its id.
+
+    ``deployed=True`` throughout: an unpublished site is refused by a DIFFERENT
+    guard (``sites.domain_needs_publish``), and a test that tripped that one while
+    believing it proved the cap would pass for the wrong reason.
+    """
+    doc = Site(
+        workspace=workspace_id,
+        pocket_id=pocket_id,
+        owner="u1",
+        name=f"Site {pocket_id}",
+        plan_tier=plan_tier,
+        subscription_status=subscription_status,
+        deployed=True,
+        archived=archived,
+    )
+    await doc.insert()
+    return str(doc.id)
+
+
+async def _attach(ws: str, site_id: str, hostname: str, cf: _RecordingCF | None = None):
+    return await sites_service.add_domain(
+        workspace_id=ws,
+        site_id=site_id,
+        hostname=hostname,
+        _cloudflare=cf or _RecordingCF(),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Rule 1 + rule 3 — the unit is the SITE, and a site is not counted against
+# itself. This is the test the whole design turns on.
+# --------------------------------------------------------------------------- #
+
+
+async def test_apex_and_www_both_land_on_one_free_site(monkeypatch):
+    """The pair every customer wants, and the case a hostname-counting cap refuses.
+
+    ``acme.com`` and ``www.acme.com`` are two ``SiteDomain`` rows on ONE site. Under
+    a cap of one they must both succeed, because the cap counts sites. If this ever
+    fails with ``billing.custom_domain_limit``, the count has drifted back to rows.
+    """
+    _enforce(monkeypatch, on=True)
+    ws = "ws_apex_www"
+    site_id = await _seed_site(workspace_id=ws, pocket_id="pk_1", plan_tier=_the_free_tier())
+
+    await _attach(ws, site_id, "acme.com")
+    await _attach(ws, site_id, "www.acme.com")
+
+    doc = await Site.get(site_id)
+    assert [d.hostname for d in doc.domains] == ["acme.com", "www.acme.com"]
+
+
+# --------------------------------------------------------------------------- #
+# The cap itself — the SECOND site is where free stops.
+# --------------------------------------------------------------------------- #
+
+
+async def test_a_second_free_site_is_refused(monkeypatch):
+    """One site's worth of custom domain, and the second site asking is told so."""
+    _enforce(monkeypatch, on=True)
+    ws = "ws_second_site"
+    first = await _seed_site(workspace_id=ws, pocket_id="pk_1", plan_tier=_the_free_tier())
+    await _attach(ws, first, "www.first.com")
+    second = await _seed_site(workspace_id=ws, pocket_id="pk_2", plan_tier=_the_free_tier())
+
+    with pytest.raises(CloudError) as exc:
+        await _attach(ws, second, "www.second.com")
+
+    assert exc.value.status_code == 402
+    assert exc.value.code == "billing.custom_domain_limit"
+    assert str(_the_free_site_limit()) in exc.value.message
+
+
+async def test_the_refusal_precedes_every_cloudflare_call(monkeypatch):
+    """A refusal after ``create_custom_hostname`` strands a hostname on the shared
+    zone: invisible to the product, and it makes the customer's next legitimate
+    attach fail on a 1406 duplicate they can neither see nor clear."""
+    _enforce(monkeypatch, on=True)
+    ws = "ws_cap_no_cf"
+    first = await _seed_site(workspace_id=ws, pocket_id="pk_1", plan_tier=_the_free_tier())
+    await _attach(ws, first, "www.first.com")
+    second = await _seed_site(workspace_id=ws, pocket_id="pk_2", plan_tier=_the_free_tier())
+    cf = _RecordingCF()
+
+    with pytest.raises(CloudError):
+        await _attach(ws, second, "www.second.com", cf)
+
+    assert cf.create_calls == []
+    assert cf.route_calls == []
+
+
+async def test_a_refused_second_site_keeps_a_clean_document(monkeypatch):
+    """No half-state on the refused site: nothing on ``domains``, and nothing on
+    ``allowed_origins`` either — that list is what authorizes a host to POST
+    captures at the site, so a stray entry there is a real capture hole."""
+    _enforce(monkeypatch, on=True)
+    ws = "ws_cap_clean"
+    first = await _seed_site(workspace_id=ws, pocket_id="pk_1", plan_tier=_the_free_tier())
+    await _attach(ws, first, "www.first.com")
+    second = await _seed_site(workspace_id=ws, pocket_id="pk_2", plan_tier=_the_free_tier())
+
+    with pytest.raises(CloudError):
+        await _attach(ws, second, "www.second.com")
+
+    doc = await Site.get(second)
+    assert doc.domains == []
+    assert doc.allowed_origins == []
+
+
+# --------------------------------------------------------------------------- #
+# Rule 2 — count FLOOR sites only. A paying site does not eat the free allowance.
+# --------------------------------------------------------------------------- #
+
+
+async def test_a_paid_sites_domain_does_not_consume_the_free_allowance(monkeypatch):
+    """The mixed workspace, and the rule easiest to leave out.
+
+    Site B pays for an uncapped allowance and holds a domain; site C is on the
+    floor and holds none. C's first attach must succeed — its allowance is one and
+    nothing on the floor has spent it. A census that counted every domained site
+    would refuse C, which means buying a plan for one site would silently take the
+    free domain away from every other site in the workspace.
+    """
+    _enforce(monkeypatch, on=True)
+    ws = "ws_mixed"
+    paid = await _seed_site(
+        workspace_id=ws,
+        pocket_id="pk_paid",
+        plan_tier=_an_uncapped_tier(),
+        subscription_status="active",
+    )
+    await _attach(ws, paid, "www.paid.com")
+    free_site = await _seed_site(workspace_id=ws, pocket_id="pk_free", plan_tier=_the_free_tier())
+
+    res = await _attach(ws, free_site, "www.free.com")
+
+    assert res.hostname == "www.free.com"
+
+
+async def test_an_uncapped_site_is_never_refused_however_many_siblings_have_domains(monkeypatch):
+    """The paid tier's actual product: no ceiling. Two free-floor sites elsewhere
+    in the workspace do not stand between a paying site and its domain."""
+    _enforce(monkeypatch, on=True)
+    ws = "ws_uncapped"
+    other = await _seed_site(workspace_id=ws, pocket_id="pk_other", plan_tier=_the_free_tier())
+    await _attach(ws, other, "www.other.com")
+    paid = await _seed_site(
+        workspace_id=ws,
+        pocket_id="pk_paid",
+        plan_tier=_an_uncapped_tier(),
+        subscription_status="active",
+    )
+
+    res = await _attach(ws, paid, "www.paid.com")
+
+    assert res.hostname == "www.paid.com"
+
+
+async def test_another_workspaces_domains_are_invisible(monkeypatch):
+    """Tenancy. The census is scoped to one workspace, so a busy neighbour cannot
+    spend this workspace's allowance."""
+    _enforce(monkeypatch, on=True)
+    neighbour = await _seed_site(
+        workspace_id="ws_neighbour", pocket_id="pk_1", plan_tier=_the_free_tier()
+    )
+    await _attach("ws_neighbour", neighbour, "www.neighbour.com")
+    mine = await _seed_site(workspace_id="ws_mine", pocket_id="pk_1", plan_tier=_the_free_tier())
+
+    res = await _attach("ws_mine", mine, "www.mine.com")
+
+    assert res.hostname == "www.mine.com"
+
+
+async def test_an_archived_duplicate_does_not_spend_the_allowance(monkeypatch):
+    """Archived sites are dedupe tombstones (PERF-2), not sites a user can see.
+
+    Counting one would charge a workspace twice for a single site it only has one
+    card for, and the user would have no way to find the row consuming their
+    domain. Matches the gallery read's ``archived: {"$ne": True}``.
+    """
+    _enforce(monkeypatch, on=True)
+    ws = "ws_archived"
+    ghost = await _seed_site(
+        workspace_id=ws, pocket_id="pk_1", plan_tier=_the_free_tier(), archived=True
+    )
+    # Attach while it is still visible, then tombstone it — the order a dedupe run
+    # actually produces.
+    doc = await Site.get(ghost)
+    doc.archived = False
+    await doc.save()
+    await _attach(ws, ghost, "www.ghost.com")
+    doc = await Site.get(ghost)
+    doc.archived = True
+    await doc.save()
+
+    live = await _seed_site(workspace_id=ws, pocket_id="pk_2", plan_tier=_the_free_tier())
+    res = await _attach(ws, live, "www.live.com")
+
+    assert res.hostname == "www.live.com"
+
+
+# --------------------------------------------------------------------------- #
+# Never retroactive — the posture the capability gate already had, re-pinned for
+# the count because the count is the newer and easier one to place wrongly.
+# --------------------------------------------------------------------------- #
+
+
+async def test_re_adding_a_connected_hostname_is_never_refused_for_quota(monkeypatch):
+    """Pressing Add on a hostname the site already has must stay a no-op that
+    returns the stored row, even when the workspace is over its cap.
+
+    It is the only self-service repair for a domain connected before the routing
+    lane shipped — those have no Worker route and silently serve the fallback
+    origin while Cloudflare reports them active. Placing the count gate above the
+    already-connected branch would make a workspace at its cap unable to fix them.
+    """
+    _enforce(monkeypatch, on=True)
+    ws = "ws_repair_over_cap"
+    site_id = await _seed_site(workspace_id=ws, pocket_id="pk_1", plan_tier=_the_free_tier())
+    await _attach(ws, site_id, "www.legacy.com")
+    # Strip the route and stamp a deploy target, reproducing a pre-routing domain.
+    doc = await Site.get(site_id)
+    doc.deploy_target = "workers"
+    doc.domains[0].cf_route_id = ""
+    await doc.save()
+    # ...and put the workspace over its cap from a second site, so a quota check
+    # placed above the repair would fire.
+    over = await _seed_site(workspace_id=ws, pocket_id="pk_2", plan_tier=_the_free_tier())
+    over_doc = await Site.get(over)
+    over_doc.domains = (await Site.get(site_id)).domains
+    await over_doc.save()
+    cf = _RecordingCF()
+
+    res = await sites_service.add_domain(
+        workspace_id=ws, site_id=site_id, hostname="www.legacy.com", _cloudflare=cf
+    )
+
+    assert res.hostname == "www.legacy.com"
+    assert len(cf.route_calls) == 1
+    assert cf.create_calls == []
+
+
+# --------------------------------------------------------------------------- #
+# The per-site hostname guard. A recommendation this build made, not a rule the
+# captain handed down — one constant, one comparison, deletable in a line.
+# --------------------------------------------------------------------------- #
+
+
+async def test_a_free_site_may_carry_apex_plus_www_and_no_more(monkeypatch):
+    """The site-unit cap leaves hostname count unbounded, so a free workspace could
+    otherwise point fifty domains at its one allowed site, each costing a Cloudflare
+    custom hostname and a Worker route at $0 revenue. Two is apex + www."""
+    _enforce(monkeypatch, on=True)
+    ws = "ws_hostname_guard"
+    site_id = await _seed_site(workspace_id=ws, pocket_id="pk_1", plan_tier=_the_free_tier())
+    for i in range(site_plans.free_max_hostnames_per_site()):
+        await _attach(ws, site_id, f"host{i}.acme.com")
+
+    with pytest.raises(CloudError) as exc:
+        await _attach(ws, site_id, "onemore.acme.com")
+
+    assert exc.value.status_code == 402
+    assert exc.value.code == "billing.custom_domain_limit"
+
+
+async def test_the_hostname_guard_does_not_apply_to_a_paying_site(monkeypatch):
+    """A paid site's product is an uncapped allowance, and that includes hostnames."""
+    _enforce(monkeypatch, on=True)
+    ws = "ws_hostname_paid"
+    site_id = await _seed_site(
+        workspace_id=ws,
+        pocket_id="pk_1",
+        plan_tier=_an_uncapped_tier(),
+        subscription_status="active",
+    )
+    for i in range(site_plans.free_max_hostnames_per_site() + 2):
+        await _attach(ws, site_id, f"host{i}.acme.com")
+
+    doc = await Site.get(site_id)
+    assert len(doc.domains) == site_plans.free_max_hostnames_per_site() + 2
+
+
+# --------------------------------------------------------------------------- #
+# OSS / self-host — billing off means no paywall AND no extra read.
+# --------------------------------------------------------------------------- #
+
+
+async def test_with_billing_off_a_second_site_attaches_freely(monkeypatch):
+    """Self-host has no billing and must not inherit a cap from this branch."""
+    _enforce(monkeypatch, on=False)
+    ws = "ws_oss_cap"
+    first = await _seed_site(workspace_id=ws, pocket_id="pk_1", plan_tier=_the_free_tier())
+    await _attach(ws, first, "www.first.com")
+    second = await _seed_site(workspace_id=ws, pocket_id="pk_2", plan_tier=_the_free_tier())
+
+    res = await _attach(ws, second, "www.second.com")
+
+    assert res.hostname == "www.second.com"
+
+
+async def test_with_billing_off_the_census_query_never_runs(monkeypatch):
+    """Not just "no error raised" — no DB read either.
+
+    The census scans every domained site in the workspace. On a self-host install
+    that read buys nothing and would still cost a round trip on every attach, so
+    the flag check comes first. ``_load`` uses ``find_one``; the census is the only
+    caller of ``find`` on this path, which is what makes the assertion specific.
+    """
+    _enforce(monkeypatch, on=False)
+    ws = "ws_oss_noread"
+    site_id = await _seed_site(workspace_id=ws, pocket_id="pk_1", plan_tier=_the_free_tier())
+
+    finds: list[object] = []
+    original = sites_service._SiteDoc.find
+
+    def _spy(*args, **kwargs):
+        finds.append(args)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(sites_service._SiteDoc, "find", _spy)
+
+    await _attach(ws, site_id, "www.noread.com")
+
+    assert finds == []

--- a/tests/cloud/sites/test_custom_domain_entitlement.py
+++ b/tests/cloud/sites/test_custom_domain_entitlement.py
@@ -18,6 +18,18 @@
 # pricing-spec rekey (basic/pro/business → free/site/staff) moves these tests with
 # the catalog instead of breaking them.
 #
+# Updated 2026-08-21 (feat/site-free-custom-domain, PW-1). Free now INCLUDES a
+# custom domain — one site's worth — so the headline assertions here invert: a free
+# site attaches its domain and the refusal moves to the SECOND site that wants one.
+# That count gate has its own tree (test_custom_domain_cap.py); what stays here is
+# the capability gate and the postures around it, which are unchanged.
+#
+# The lapsed-subscription cases invert too, and that one is worth reading twice: a
+# paid site whose subscription stopped falls to the FLOOR, not to zero. It keeps
+# what free would have given it and loses the uncapped allowance, which is what it
+# was actually paying for. Refusing it outright would leave a former customer worse
+# off than someone who never paid.
+#
 # Two postures inherited from the siblings this gate copies (``PocketLimitError``,
 # ``ConnectorLimitError``) and pinned here because both are easy to "fix" wrongly
 # later:
@@ -52,11 +64,17 @@ pytestmark = pytest.mark.usefixtures("mongo_db")
 
 
 def _a_tier_granting_custom_domain() -> str:
-    """The cheapest catalog tier that resells ``custom_domain``."""
+    """The cheapest catalog tier whose domain allowance is UNCAPPED.
+
+    Since free includes a domained site, "grants a custom domain" no longer picks
+    out a paid tier — every tier grants one. What a paid tier sells is the absence
+    of a ceiling, so that is what this selects on. Still read off the catalog, never
+    hardcoded, so the pricing-spec rekey moves it instead of breaking it.
+    """
     for tier in site_plans.list_site_plans():
-        if "custom_domain" in tier.cloudflare_features:
+        if tier.max_domained_sites is None:
             return tier.key
-    raise AssertionError("no site plan tier resells custom_domain — catalog changed")
+    raise AssertionError("no site plan tier has an uncapped domain allowance — catalog changed")
 
 
 def _the_free_tier() -> str:
@@ -118,6 +136,7 @@ async def _seed_site(
     plan_tier: str | None,
     subscription_status: str = "none",
     deployed: bool = True,
+    pocket_id: str = "pk_1",
 ) -> str:
     """Insert a real Site doc and return its id string.
 
@@ -127,7 +146,7 @@ async def _seed_site(
     """
     doc = Site(
         workspace=workspace_id,
-        pocket_id="pk_1",
+        pocket_id=pocket_id,
         owner="u1",
         name="My Site",
         plan_tier=plan_tier,
@@ -143,43 +162,49 @@ async def _seed_site(
 # --------------------------------------------------------------------------- #
 
 
-async def test_a_free_site_cannot_attach_a_custom_domain(monkeypatch):
-    """The headline case. A base-tier site resells no custom_domain, so the attach
-    is refused with a 402 the UI can turn into an upgrade prompt."""
+async def test_a_free_site_attaches_its_one_custom_domain(monkeypatch):
+    """The captain's rule, end to end at the seam that enforces it.
+
+    This assertion is the inverse of the one that stood here until 2026-08-21, and
+    the inversion IS the feature: free includes a custom domain on one site. What
+    free does not include is a second site with one, which is a count and lives in
+    test_custom_domain_cap.py.
+    """
     _enforce(monkeypatch, on=True)
     ws = "ws_free_domain"
     site_id = await _seed_site(workspace_id=ws, plan_tier=_the_free_tier())
     cf = _RecordingCF()
 
-    with pytest.raises(CloudError) as exc:
-        await sites_service.add_domain(
-            workspace_id=ws,
-            site_id=site_id,
-            hostname="www.freeloader.com",
-            _cloudflare=cf,
-        )
+    res = await sites_service.add_domain(
+        workspace_id=ws,
+        site_id=site_id,
+        hostname="www.freeloader.com",
+        _cloudflare=cf,
+    )
 
-    assert exc.value.status_code == 402
-    assert exc.value.code == "billing.custom_domain_not_entitled"
+    assert res.hostname == "www.freeloader.com"
+    assert len(cf.create_calls) == 1
+    doc = await Site.get(site_id)
+    assert [d.hostname for d in doc.domains] == ["www.freeloader.com"]
 
 
-async def test_an_unset_tier_cannot_attach_a_custom_domain(monkeypatch):
+async def test_an_unset_tier_gets_the_floor_allowance(monkeypatch):
     """A site with no ``plan_tier`` at all (pre-BC-9 rows, and every first publish)
-    resolves to the floor. Fail-closed: absent is free, not exempt."""
+    resolves to the floor — and the floor now carries a domain. Absent is free, and
+    free includes one."""
     _enforce(monkeypatch, on=True)
     ws = "ws_untiered_domain"
     site_id = await _seed_site(workspace_id=ws, plan_tier=None)
     cf = _RecordingCF()
 
-    with pytest.raises(CloudError) as exc:
-        await sites_service.add_domain(
-            workspace_id=ws,
-            site_id=site_id,
-            hostname="www.untiered.com",
-            _cloudflare=cf,
-        )
+    res = await sites_service.add_domain(
+        workspace_id=ws,
+        site_id=site_id,
+        hostname="www.untiered.com",
+        _cloudflare=cf,
+    )
 
-    assert exc.value.status_code == 402
+    assert res.hostname == "www.untiered.com"
 
 
 async def test_a_refused_attach_never_reaches_cloudflare(monkeypatch):
@@ -189,16 +214,23 @@ async def test_a_refused_attach_never_reaches_cloudflare(monkeypatch):
     shared zone with no Site row pointing at it — invisible to the product, and it
     makes the customer's next legitimate attach fail on a 1406 duplicate they
     cannot see or clear.
+
+    Driven through the COUNT gate now, since that is the one a free workspace can
+    actually trip: one site already holds a domain, a second one asks.
     """
     _enforce(monkeypatch, on=True)
     ws = "ws_no_cf_call"
-    site_id = await _seed_site(workspace_id=ws, plan_tier=_the_free_tier())
+    first = await _seed_site(workspace_id=ws, plan_tier=_the_free_tier())
+    await sites_service.add_domain(
+        workspace_id=ws, site_id=first, hostname="www.first.com", _cloudflare=_RecordingCF()
+    )
+    second = await _seed_site(workspace_id=ws, plan_tier=_the_free_tier(), pocket_id="pk_2")
     cf = _RecordingCF()
 
     with pytest.raises(CloudError):
         await sites_service.add_domain(
             workspace_id=ws,
-            site_id=site_id,
+            site_id=second,
             hostname="www.nocall.com",
             _cloudflare=cf,
         )
@@ -213,18 +245,22 @@ async def test_a_refused_attach_writes_nothing_to_the_site(monkeypatch):
     host to POST captures at the site."""
     _enforce(monkeypatch, on=True)
     ws = "ws_no_write"
-    site_id = await _seed_site(workspace_id=ws, plan_tier=_the_free_tier())
+    first = await _seed_site(workspace_id=ws, plan_tier=_the_free_tier())
+    await sites_service.add_domain(
+        workspace_id=ws, site_id=first, hostname="www.taken.com", _cloudflare=_RecordingCF()
+    )
+    second = await _seed_site(workspace_id=ws, plan_tier=_the_free_tier(), pocket_id="pk_2")
     cf = _RecordingCF()
 
     with pytest.raises(CloudError):
         await sites_service.add_domain(
             workspace_id=ws,
-            site_id=site_id,
+            site_id=second,
             hostname="www.nowrite.com",
             _cloudflare=cf,
         )
 
-    doc = await Site.get(site_id)
+    doc = await Site.get(second)
     assert doc.domains == []
     assert "www.nowrite.com" not in doc.allowed_origins
 
@@ -235,11 +271,15 @@ async def test_a_refused_attach_writes_nothing_to_the_site(monkeypatch):
 
 
 @pytest.mark.parametrize("status", ["none", "pending", "cancelled"])
-async def test_a_paid_tier_without_an_active_subscription_is_refused(monkeypatch, status):
+async def test_a_paid_tier_without_an_active_subscription_falls_to_the_floor(monkeypatch, status):
     """Cancellation never resets ``plan_tier``, and an unconfigured Dodo product
-    records a paid tier with no charge at all. Reading the tier alone therefore
-    hands a free custom domain to sites that have never paid — permanently. The
-    resolver gates on tier AND subscription; this proves the attach seam does too.
+    records a paid tier with no charge at all — so the tier alone still cannot be
+    trusted, and the resolver still gates the PAID grants on the subscription.
+
+    What changed is where the site lands when it fails that gate: on the free
+    floor, which now includes one domained site. So this attach SUCCEEDS, and the
+    thing the lapsed site lost is its uncapped allowance — the next test proves it
+    is genuinely capped rather than silently still uncapped.
     """
     _enforce(monkeypatch, on=True)
     ws = f"ws_paid_{status}"
@@ -250,16 +290,42 @@ async def test_a_paid_tier_without_an_active_subscription_is_refused(monkeypatch
     )
     cf = _RecordingCF()
 
+    res = await sites_service.add_domain(
+        workspace_id=ws,
+        site_id=site_id,
+        hostname=f"www.{status}.com",
+        _cloudflare=cf,
+    )
+
+    assert res.hostname == f"www.{status}.com"
+
+
+async def test_a_lapsed_paid_site_is_capped_like_a_free_one(monkeypatch):
+    """The other half: falling to the floor means being SUBJECT to the floor.
+
+    A lapsed ``pro`` site keeps one domained site, not its old uncapped allowance,
+    so a second site in the same workspace is refused exactly as it would be under
+    free. Without this the previous test would pass just as happily if lapsing did
+    nothing at all.
+    """
+    _enforce(monkeypatch, on=True)
+    ws = "ws_lapsed_capped"
+    lapsed = await _seed_site(
+        workspace_id=ws,
+        plan_tier=_a_tier_granting_custom_domain(),
+        subscription_status="cancelled",
+    )
+    await sites_service.add_domain(
+        workspace_id=ws, site_id=lapsed, hostname="www.lapsed.com", _cloudflare=_RecordingCF()
+    )
+    other = await _seed_site(workspace_id=ws, plan_tier=_the_free_tier(), pocket_id="pk_2")
+
     with pytest.raises(CloudError) as exc:
         await sites_service.add_domain(
-            workspace_id=ws,
-            site_id=site_id,
-            hostname=f"www.{status}.com",
-            _cloudflare=cf,
+            workspace_id=ws, site_id=other, hostname="www.other.com", _cloudflare=_RecordingCF()
         )
 
-    assert exc.value.status_code == 402
-    assert cf.create_calls == []
+    assert exc.value.code == "billing.custom_domain_limit"
 
 
 # --------------------------------------------------------------------------- #
@@ -358,6 +424,67 @@ async def test_an_already_connected_domain_still_repairs_its_route(monkeypatch):
 
 
 # --------------------------------------------------------------------------- #
+# The capability gate's remaining job.
+#
+# Free includes a domain, so ``_assert_entitled_to_custom_domain`` fires on no tier
+# the catalog currently ships — what bites is the COUNT. That makes the gate easy
+# to read as dead code and delete. It is not dead: it is the fail-closed floor for
+# a catalog that grants zero, which is exactly what reverting the captain's rule
+# would produce. These two prove it still works, so the guard is pinned rather than
+# merely present.
+# --------------------------------------------------------------------------- #
+
+
+async def test_a_catalog_granting_no_domain_at_all_still_refuses(monkeypatch):
+    """Floor allowance 0 → the capability gate is the whole defence again."""
+    _enforce(monkeypatch, on=True)
+    monkeypatch.setitem(site_plans._SITE_PLAN_MAX_DOMAINED_SITES, _the_free_tier(), 0)
+    ws = "ws_zero_floor"
+    site_id = await _seed_site(workspace_id=ws, plan_tier=_the_free_tier())
+    cf = _RecordingCF()
+
+    with pytest.raises(CloudError) as exc:
+        await sites_service.add_domain(
+            workspace_id=ws,
+            site_id=site_id,
+            hostname="www.zerofloor.com",
+            _cloudflare=cf,
+        )
+
+    assert exc.value.status_code == 402
+    assert exc.value.code == "billing.custom_domain_not_entitled"
+    assert cf.create_calls == []
+
+
+async def test_with_a_zero_floor_a_lapsed_paid_site_is_refused_too(monkeypatch):
+    """And the fall-to-the-floor rule falls to whatever the floor actually says.
+
+    The lapsed site is not special-cased anywhere — it simply resolves to the base
+    tier's allowance. Set that to 0 and a cancelled subscription refuses again,
+    which is the pre-2026-08-21 behaviour, reachable by one catalog edit.
+    """
+    _enforce(monkeypatch, on=True)
+    monkeypatch.setitem(site_plans._SITE_PLAN_MAX_DOMAINED_SITES, _the_free_tier(), 0)
+    ws = "ws_zero_floor_lapsed"
+    site_id = await _seed_site(
+        workspace_id=ws,
+        plan_tier=_a_tier_granting_custom_domain(),
+        subscription_status="cancelled",
+    )
+    cf = _RecordingCF()
+
+    with pytest.raises(CloudError) as exc:
+        await sites_service.add_domain(
+            workspace_id=ws,
+            site_id=site_id,
+            hostname="www.zerolapsed.com",
+            _cloudflare=cf,
+        )
+
+    assert exc.value.code == "billing.custom_domain_not_entitled"
+
+
+# --------------------------------------------------------------------------- #
 # OSS / self-host — billing off means no paywall.
 # --------------------------------------------------------------------------- #
 
@@ -380,6 +507,31 @@ async def test_with_billing_off_the_gate_never_fires(monkeypatch):
 
     assert res.hostname == "www.selfhost.com"
     assert len(cf.create_calls) == 1
+
+
+async def test_with_billing_off_even_a_zero_floor_attaches(monkeypatch):
+    """The pair to the zero-floor refusal above, and the only test that can see
+    the capability gate's own flag check.
+
+    On the catalog as shipped, dropping ``if not billing_enforced: return`` from
+    that gate changes nothing: every tier grants a domain, so the gate returns
+    either way and a mutation deleting the check escapes unnoticed. Zero the floor
+    and the two paths finally differ — enforced refuses, self-host attaches.
+    """
+    _enforce(monkeypatch, on=False)
+    monkeypatch.setitem(site_plans._SITE_PLAN_MAX_DOMAINED_SITES, _the_free_tier(), 0)
+    ws = "ws_oss_zero_floor"
+    site_id = await _seed_site(workspace_id=ws, plan_tier=_the_free_tier())
+    cf = _RecordingCF()
+
+    res = await sites_service.add_domain(
+        workspace_id=ws,
+        site_id=site_id,
+        hostname="www.ossfloor.com",
+        _cloudflare=cf,
+    )
+
+    assert res.hostname == "www.ossfloor.com"
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/mutations/custom_domain_entitlement.json
+++ b/tests/mutations/custom_domain_entitlement.json
@@ -1,77 +1,201 @@
 [
   {
-    "label": "the gate is deleted outright",
+    "label": "the capability gate is deleted outright",
     "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "    _assert_entitled_to_custom_domain(site)",
-    "replace": "    pass",
+    "find": "    _assert_entitled_to_custom_domain(site)\n\n    # Then the COUNT.",
+    "replace": "\n    # Then the COUNT.",
     "tests": [
-      "tests/cloud/sites/test_custom_domain_entitlement.py::test_a_free_site_cannot_attach_a_custom_domain",
-      "tests/cloud/sites/test_custom_domain_entitlement.py::test_an_unset_tier_cannot_attach_a_custom_domain"
+      "tests/cloud/sites/test_custom_domain_entitlement.py::test_a_catalog_granting_no_domain_at_all_still_refuses",
+      "tests/cloud/sites/test_custom_domain_entitlement.py::test_with_a_zero_floor_a_lapsed_paid_site_is_refused_too"
     ]
   },
   {
-    "label": "the gate reads the TIER alone, ignoring whether the subscription pays",
+    "label": "the capability gate reads resold Cloudflare features again, and free loses its domain",
     "file": "ee/pocketpaw_ee/sites/service.py",
     "find": "    if ent.custom_domain:\n        return",
     "replace": "    if \"custom_domain\" in (site_plans.get_site_plan(site.plan_tier).cloudflare_features if site_plans.get_site_plan(site.plan_tier) else set()):\n        return",
     "tests": [
-      "tests/cloud/sites/test_custom_domain_entitlement.py::test_a_paid_tier_without_an_active_subscription_is_refused"
+      "tests/cloud/sites/test_custom_domain_entitlement.py::test_a_free_site_attaches_its_one_custom_domain",
+      "tests/cloud/sites/test_custom_domain_entitlement.py::test_an_unset_tier_gets_the_floor_allowance"
     ]
   },
   {
-    "label": "the fail-closed default inverts — an unknown tier is handed a domain",
-    "file": "ee/pocketpaw_ee/cloud/entitlements/service.py",
-    "find": "    custom_domain = False",
-    "replace": "    custom_domain = True",
-    "tests": [
-      "tests/cloud/sites/test_custom_domain_entitlement.py::test_an_unset_tier_cannot_attach_a_custom_domain",
-      "tests/cloud/sites/test_custom_domain_entitlement.py::test_a_free_site_cannot_attach_a_custom_domain",
-      "tests/cloud/entitlements/test_site_entitlements.py::test_an_unknown_or_absent_tier_falls_to_the_base"
-    ]
-  },
-  {
-    "label": "the gate runs AFTER Cloudflare has already created the hostname",
+    "label": "the entitled path is broken too — the capability gate refuses everyone",
     "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "    _assert_entitled_to_custom_domain(site)\n\n    # Resolve the site's tier",
-    "replace": "\n    # Resolve the site's tier",
+    "find": "    if ent.custom_domain:\n        return",
+    "replace": "    if False:\n        return",
     "tests": [
+      "tests/cloud/sites/test_custom_domain_entitlement.py::test_an_active_paid_site_attaches_normally",
+      "tests/cloud/sites/test_custom_domain_entitlement.py::test_the_resold_feature_set_still_rides_along"
+    ]
+  },
+  {
+    "label": "the floor allowance leaks uncapped — every free workspace gets unlimited domained sites",
+    "file": "ee/pocketpaw_ee/cloud/entitlements/service.py",
+    "find": "    allowance = floor.max_domained_sites if floor is not None else 0",
+    "replace": "    allowance = None",
+    "tests": [
+      "tests/cloud/sites/test_custom_domain_cap.py::test_a_second_free_site_is_refused",
+      "tests/cloud/entitlements/test_site_entitlements.py::test_the_floor_grants_its_domain_with_no_subscription_at_all"
+    ]
+  },
+  {
+    "label": "the allowance ignores whether the subscription pays — a cancelled site keeps uncapped domains",
+    "file": "ee/pocketpaw_ee/cloud/entitlements/service.py",
+    "find": "    if tier is not None and _subscription_is_active(subscription_status):\n        allowance = tier.max_domained_sites",
+    "replace": "    if tier is not None:\n        allowance = tier.max_domained_sites",
+    "tests": [
+      "tests/cloud/sites/test_custom_domain_entitlement.py::test_a_lapsed_paid_site_is_capped_like_a_free_one",
+      "tests/cloud/entitlements/test_site_entitlements.py::test_a_lapsed_paid_site_falls_to_the_FLOOR_allowance_not_to_zero"
+    ]
+  },
+  {
+    "label": "an unknown key is handed the uncapped answer instead of zero",
+    "file": "ee/pocketpaw_ee/cloud/billing/site_plans.py",
+    "find": "        max_domained_sites=_SITE_PLAN_MAX_DOMAINED_SITES.get(key, 0),",
+    "replace": "        max_domained_sites=_SITE_PLAN_MAX_DOMAINED_SITES.get(key),",
+    "tests": [
+      "tests/cloud/billing/test_site_plan_domain_quota.py::test_an_unknown_key_gets_no_domains_at_all"
+    ]
+  },
+  {
+    "label": "the workspace count gate never fires",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    exceeded, _count, limit = await _domain_cap_exceeded(workspace_id, site)",
+    "replace": "    exceeded, _count, limit = (False, 0, None)",
+    "tests": [
+      "tests/cloud/sites/test_custom_domain_cap.py::test_a_second_free_site_is_refused",
+      "tests/cloud/sites/test_custom_domain_cap.py::test_a_free_site_may_carry_apex_plus_www_and_no_more"
+    ]
+  },
+  {
+    "label": "the count includes the site being attached to — apex plus www is refused",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "            \"_id\": {\"$ne\": site.id},\n",
+    "replace": "",
+    "tests": [
+      "tests/cloud/sites/test_custom_domain_cap.py::test_apex_and_www_both_land_on_one_free_site"
+    ]
+  },
+  {
+    "label": "the count counts PAID sites too — buying a plan takes the free domain away",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        if (\n            entitlements_service.site_domain_allowance(\n                plan_tier=row.plan_tier, subscription_status=row.subscription_status\n            )\n            is not None\n        ):\n            count += 1",
+    "replace": "        if row is not None:\n            count += 1",
+    "tests": [
+      "tests/cloud/sites/test_custom_domain_cap.py::test_a_paid_sites_domain_does_not_consume_the_free_allowance"
+    ]
+  },
+  {
+    "label": "archived dedupe tombstones spend the allowance",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "            \"archived\": {\"$ne\": True},\n            \"_id\": {\"$ne\": site.id},",
+    "replace": "            \"_id\": {\"$ne\": site.id},",
+    "tests": [
+      "tests/cloud/sites/test_custom_domain_cap.py::test_an_archived_duplicate_does_not_spend_the_allowance"
+    ]
+  },
+  {
+    "label": "the count is scoped to no workspace — a neighbour spends your allowance",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "            \"workspace\": workspace_id,\n            \"archived\": {\"$ne\": True},",
+    "replace": "            \"archived\": {\"$ne\": True},",
+    "tests": [
+      "tests/cloud/sites/test_custom_domain_cap.py::test_another_workspaces_domains_are_invisible"
+    ]
+  },
+  {
+    "label": "the count comparison is off by one — free gets two domained sites",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    return (count >= limit, count, limit)\n\n\ndef _hostname_cap_exceeded",
+    "replace": "    return (count > limit, count, limit)\n\n\ndef _hostname_cap_exceeded",
+    "tests": [
+      "tests/cloud/sites/test_custom_domain_cap.py::test_a_second_free_site_is_refused"
+    ]
+  },
+  {
+    "label": "an uncapped tier is treated as capped at zero — a paying site is refused",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if limit is None:\n        return (False, 0, None)\n\n    cursor = _SiteDoc.find(",
+    "replace": "    if limit is None:\n        limit = 0\n\n    cursor = _SiteDoc.find(",
+    "tests": [
+      "tests/cloud/sites/test_custom_domain_cap.py::test_an_uncapped_site_is_never_refused_however_many_siblings_have_domains"
+    ]
+  },
+  {
+    "label": "the per-site hostname guard never fires",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    limit = _site_plans.free_max_hostnames_per_site()\n    count = len(site.domains)\n    return (count >= limit, count, limit)",
+    "replace": "    limit = _site_plans.free_max_hostnames_per_site()\n    count = len(site.domains)\n    return (False, count, limit)",
+    "tests": [
+      "tests/cloud/sites/test_custom_domain_cap.py::test_a_free_site_may_carry_apex_plus_www_and_no_more"
+    ]
+  },
+  {
+    "label": "the per-site hostname guard is applied to paying sites too",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if (\n        entitlements_service.site_domain_allowance(\n            plan_tier=site.plan_tier, subscription_status=site.subscription_status\n        )\n        is None\n    ):\n        return (False, 0, None)",
+    "replace": "    pass",
+    "tests": [
+      "tests/cloud/sites/test_custom_domain_cap.py::test_the_hostname_guard_does_not_apply_to_a_paying_site"
+    ]
+  },
+  {
+    "label": "the count gate runs AFTER Cloudflare has already created the hostname",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    _assert_entitled_to_custom_domain(site)\n\n    # Then the COUNT.",
+    "replace": "    await cf.create_custom_hostname(hostname, features=set())\n    _assert_entitled_to_custom_domain(site)\n\n    # Then the COUNT.",
+    "tests": [
+      "tests/cloud/sites/test_custom_domain_cap.py::test_the_refusal_precedes_every_cloudflare_call",
       "tests/cloud/sites/test_custom_domain_entitlement.py::test_a_refused_attach_never_reaches_cloudflare"
     ]
   },
   {
     "label": "a refused attach still writes the hostname onto allowed_origins",
     "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "    _assert_entitled_to_custom_domain(site)",
-    "replace": "    site.allowed_origins.append(hostname)\n    await site.set({\"allowed_origins\": list(site.allowed_origins)})\n    _assert_entitled_to_custom_domain(site)",
+    "find": "    _assert_entitled_to_custom_domain(site)\n\n    # Then the COUNT.",
+    "replace": "    site.allowed_origins.append(hostname)\n    await site.set({\"allowed_origins\": list(site.allowed_origins)})\n    _assert_entitled_to_custom_domain(site)\n\n    # Then the COUNT.",
     "tests": [
+      "tests/cloud/sites/test_custom_domain_cap.py::test_a_refused_second_site_keeps_a_clean_document",
       "tests/cloud/sites/test_custom_domain_entitlement.py::test_a_refused_attach_writes_nothing_to_the_site"
     ]
   },
   {
-    "label": "the gate becomes retroactive — it runs before the already-connected repair",
+    "label": "the count gate becomes retroactive — it runs before the already-connected repair",
     "file": "ee/pocketpaw_ee/sites/service.py",
     "find": "    hostname = _normalize_hostname(hostname)\n    existing = next(",
-    "replace": "    _assert_entitled_to_custom_domain(site)\n    hostname = _normalize_hostname(hostname)\n    existing = next(",
+    "replace": "    if (await _domain_cap_exceeded(workspace_id, site))[0]:\n        raise CustomDomainLimitError(limit=1)\n    hostname = _normalize_hostname(hostname)\n    existing = next(",
     "tests": [
+      "tests/cloud/sites/test_custom_domain_cap.py::test_re_adding_a_connected_hostname_is_never_refused_for_quota",
       "tests/cloud/sites/test_custom_domain_entitlement.py::test_an_already_connected_domain_still_repairs_its_route"
     ]
   },
   {
-    "label": "the billing_enforced guard is dropped — OSS/self-host inherits the paywall",
+    "label": "the billing_enforced guard is dropped from the count — OSS/self-host inherits the cap",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if not get_settings().billing_enforced:\n        return (False, 0, None)\n\n    from pocketpaw_ee.cloud.entitlements import service as entitlements_service\n\n    limit = entitlements_service.site_domain_allowance(",
+    "replace": "    from pocketpaw_ee.cloud.entitlements import service as entitlements_service\n\n    limit = entitlements_service.site_domain_allowance(",
+    "tests": [
+      "tests/cloud/sites/test_custom_domain_cap.py::test_with_billing_off_a_second_site_attaches_freely",
+      "tests/cloud/sites/test_custom_domain_cap.py::test_with_billing_off_the_census_query_never_runs"
+    ]
+  },
+  {
+    "label": "the billing_enforced guard is dropped from the capability gate",
     "file": "ee/pocketpaw_ee/sites/service.py",
     "find": "    if not get_settings().billing_enforced:\n        return\n\n    from pocketpaw_ee.cloud.entitlements import service as entitlements_service",
     "replace": "    from pocketpaw_ee.cloud.entitlements import service as entitlements_service",
     "tests": [
-      "tests/cloud/sites/test_custom_domain_entitlement.py::test_with_billing_off_the_gate_never_fires"
+      "tests/cloud/sites/test_custom_domain_entitlement.py::test_with_billing_off_even_a_zero_floor_attaches"
     ]
   },
   {
-    "label": "the guard inverts — the gate fires ONLY when billing is off",
+    "label": "the capability guard inverts — the gate fires ONLY when billing is off",
     "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "    if not get_settings().billing_enforced:\n        return",
-    "replace": "    if get_settings().billing_enforced:\n        return",
+    "find": "    if not get_settings().billing_enforced:\n        return\n\n    from pocketpaw_ee.cloud.entitlements import service as entitlements_service\n\n    ent = entitlements_service.resolve_site_entitlements(",
+    "replace": "    if get_settings().billing_enforced:\n        return\n\n    from pocketpaw_ee.cloud.entitlements import service as entitlements_service\n\n    ent = entitlements_service.resolve_site_entitlements(",
     "tests": [
-      "tests/cloud/sites/test_custom_domain_entitlement.py::test_a_free_site_cannot_attach_a_custom_domain",
+      "tests/cloud/sites/test_custom_domain_entitlement.py::test_a_catalog_granting_no_domain_at_all_still_refuses",
       "tests/cloud/sites/test_custom_domain_entitlement.py::test_with_billing_off_the_gate_never_fires"
     ]
   },
@@ -81,18 +205,17 @@
     "find": "        super().__init__(402, \"billing.custom_domain_not_entitled\", f\"Custom domain: {detail}\")",
     "replace": "        super().__init__(422, \"sites.custom_domain_not_entitled\", f\"Custom domain: {detail}\")",
     "tests": [
-      "tests/cloud/sites/test_custom_domain_entitlement.py::test_a_free_site_cannot_attach_a_custom_domain",
-      "tests/cloud/sites/test_custom_domain_entitlement.py::test_a_paid_tier_without_an_active_subscription_is_refused"
+      "tests/cloud/sites/test_custom_domain_entitlement.py::test_a_catalog_granting_no_domain_at_all_still_refuses"
     ]
   },
   {
-    "label": "the entitled path is broken too — the gate refuses everyone",
-    "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "    if ent.custom_domain:\n        return",
-    "replace": "    if False:\n        return",
+    "label": "the count refusal degrades to a 4xx with no billing code",
+    "file": "ee/pocketpaw_ee/cloud/_core/errors.py",
+    "find": "        super().__init__(402, \"billing.custom_domain_limit\", f\"Custom domain: {detail}\")",
+    "replace": "        super().__init__(422, \"sites.custom_domain_limit\", f\"Custom domain: {detail}\")",
     "tests": [
-      "tests/cloud/sites/test_custom_domain_entitlement.py::test_an_active_paid_site_attaches_normally",
-      "tests/cloud/sites/test_custom_domain_entitlement.py::test_the_resold_feature_set_still_rides_along"
+      "tests/cloud/sites/test_custom_domain_cap.py::test_a_second_free_site_is_refused",
+      "tests/cloud/sites/test_custom_domain_cap.py::test_a_free_site_may_carry_apex_plus_www_and_no_more"
     ]
   },
   {


### PR DESCRIPTION
A free workspace can now point a custom domain at one of its sites. Apex and `www` both live on that one site, so `acme.com` and `www.acme.com` work together. A second site asking for a domain gets a 402 carrying `billing.custom_domain_limit`.

The unit is the site, not the hostname, and that distinction is the whole shape of the change. `SiteDomain` is one row per hostname, so any count that reads rows refuses the apex + `www` pair while looking perfectly correct. The catalog field is called `max_domained_sites` for the same reason; a name like `max_custom_domains` would have the next reader counting rows.

## Why the resolver had to be split

`resolve_site_entitlements` had a single branch, `if tier is not None and subscription_active`. Every $0 tier fell straight through it to all-False, so adding a domain allowance to the free row of the catalog would have granted exactly nothing.

That branch is now two. Floor grants resolve off the base tier with nobody paying, and `max_domained_sites` is the first one. Paid grants still need an active subscription: badge removal, the concierge, and the uncapped allowance.

One consequence worth stating plainly. A lapsed `pro` site lands on the floor's one domain rather than on zero. Losing a subscription should not leave a customer worse off than someone who never paid. What lapsing costs is the uncapped allowance, and `test_a_lapsed_paid_site_is_capped_like_a_free_one` is there so that stays true.

## The counting rules

`_domain_cap_exceeded` mirrors `pockets/service._pocket_cap_exceeded`: it returns a tuple rather than raising, it is gated on `billing_enforced`, and it does no DB read when billing is off. Three rules, each with its own test.

1. Counts sites holding at least one domain (via `domains.0 exists`), not hostnames.
2. Counts floor sites only. Without it, buying a plan for one site would quietly take the free domain away from every other site in the workspace.
3. Excludes the site being attached to. This is what lets apex and `www` coexist.

Archived sites are excluded too. They are dedupe tombstones of a live site, so counting one would charge a workspace twice for a site it can only see once.

## One judgement call

The site-unit rule leaves hostname count on the allowed site unbounded, so a free workspace could point fifty domains at it, each costing a Cloudflare custom hostname and a Worker route at $0. `_FREE_MAX_HOSTNAMES_PER_SITE = 2` caps that at apex + `www`.

This one is a recommendation rather than something that was asked for. It is one constant and one comparison; delete both and nothing else in the branch moves.

## About the capability gate

`_assert_entitled_to_custom_domain` no longer fires on any tier the catalog ships, because every tier now grants at least one domain. It stays as the fail-closed floor for a catalog that grants zero, which is what reverting this rule would look like. Two tests set the floor to 0 to prove it still works. Without them the gate would be present but unproven, and a mutation deleting it would kill nothing.

## What this does not do

Nothing here is live. Both gates read `billing_enforced`, which defaults to off and is set by no deployment. The sites-only enforcement flag is the next task in the chain.

Enforcement is attach-time only. No existing domain is detached, and re-adding a connected hostname, which is the only self-service repair for a missing Worker route, never reaches either gate.

No docs change. This adds no config flag and `pocketPaw/docs/` has no site-plan page; the flag and its documentation row arrive with the next PR.

## Tests

`tests/cloud/sites/test_custom_domain_cap.py` is new and covers the count seam in 14 tests. The first test in the file is apex + `www`, deliberately, because that is the case an earlier draft of the design got wrong.

`tests/cloud/billing/test_site_plan_domain_quota.py` is new and covers the catalog in 6 tests, including that a missing key resolves to 0 rather than to the uncapped `None`.

`tests/cloud/sites/test_custom_domain_entitlement.py` and `tests/cloud/entitlements/test_site_entitlements.py` have assertions that invert. A free site attaching a domain used to be the bug; it is now the feature. Both files say so at the top rather than leaving a future reader to wonder.

`tests/mutations/custom_domain_entitlement.json` went from 13 mutations to 26, all caught. Three of its old anchors stopped resolving against the changed code, which `scripts/mutate.py --validate` catches and which would otherwise have disabled the whole plan silently.

Green locally: `tests/cloud/sites`, `tests/cloud/billing`, `tests/cloud/entitlements` (255), `tests/ee/sites` (1340), `ruff check`, `ruff format`, both `lint-imports` configs, and the full mutation plan.

Full sweep, `pytest tests/ --ignore=tests/e2e --ignore=tests/test_frontend_syntax.py`: 10414 passed, 51 failed. The same sweep on this worktree with the five changed source files reverted to `origin/dev` fails **the same 51**, so the set of failing tests is identical with and without this branch. They sit in `test_herdr_runtime`, `test_code_mode_runner`, `test_code_mode_bridge`, `test_headless_permissions`, `foresight/test_substrate`, `test_multitenant_session_isolation`, `test_mem0_store` and `test_context_budget`, none of which import the sites, billing or entitlements layers.

The reverted run also fails two `test_mutate_validate` cases that the branch passes, which is the anchor check doing its job: the repointed mutation anchors describe this branch's code, not `dev`'s.

Plan: `docs/design/drafts/2026-08-21-paw-sites-plan-wiring-tasks.md`, task PW-1, in paw-workspace.
