### PR TITLE
A read-only census of what the sites collection holds

### DIFF
--- a/docs/runbooks/2026-08-21-site-plan-census.md
+++ b/docs/runbooks/2026-08-21-site-plan-census.md
@@ -1,0 +1,145 @@
+# Site-plan census — what production actually holds
+
+**Created:** 2026-08-21 · **Read-only.** Every command here is an aggregate or a
+count. Nothing writes. **Run it before the per-site plan rekey, and again before
+per-site billing enforcement is switched on.**
+
+## Why
+
+Two questions, and only the first one is about the rekey.
+
+**1. Is the rekey a migration or a rename?** `publish_pocket` stamps
+`Site.plan_tier` even when checkout degrades, so a paid-tier *value* can be
+persisted with `subscription_status="none"` and no money behind it. If production
+holds only floor-tier rows, renaming `basic`/`pro`/`business` to
+`free`/`site`/`staff` is a rename. If it holds paid keys, it is a data migration,
+and any of those rows carrying a custom domain drops to the free floor's
+allowance the moment it runs — which is a customer-comms line, not a code change.
+
+**2. Who does the cap bite when enforcement goes on?** Free includes a custom
+domain on one site. Enforcement is attach-time only and never retroactive, so a
+workspace already over that cap keeps every domain it has — but its *next* attach
+is refused. Support wants that number before the flag flips, not after.
+
+## Where production is
+
+Production Mongo is the `paw-mongo` container inside the Coolify deployment
+(`deploy/coolify/docker-compose.yaml`, service `mongo`, database
+`paw-enterprise`). It publishes no port, so it is reachable only from that host's
+docker network. There is no connection string in this repo and none on a dev
+machine — the only `CLOUD_MONGODB_URI` configured anywhere in the workspace points
+at localhost. Both routes below therefore start on the deployment host.
+
+## Route A — on the deployment host (no Python needed)
+
+Find the container first; Coolify may suffix the name.
+
+```bash
+docker ps --filter name=mongo --format '{{.Names}}'
+```
+
+Then, substituting the name if it is not `paw-mongo`:
+
+```bash
+docker exec paw-mongo mongosh --quiet paw-enterprise --eval '
+const live = { archived: { $ne: true } };
+print("sites total : " + db.sites.countDocuments({}));
+print("sites live  : " + db.sites.countDocuments(live));
+print("archived    : " + db.sites.countDocuments({ archived: true }));
+
+print("\n--- Q1: plan_tier x subscription_status (live only) ---");
+printjson(db.sites.aggregate([
+  { $match: live },
+  { $group: {
+      _id: {
+        plan_tier: { $ifNull: ["$plan_tier", "<unset>"] },
+        subscription_status: { $ifNull: ["$subscription_status", "<unset>"] }
+      },
+      sites: { $sum: 1 },
+      sites_with_domains: { $sum: { $cond: [ { $gt: [ { $size: { $ifNull: ["$domains", []] } }, 0 ] }, 1, 0 ] } },
+      hostnames: { $sum: { $size: { $ifNull: ["$domains", []] } } }
+  } },
+  { $sort: { "_id.plan_tier": 1, "_id.subscription_status": 1 } }
+]).toArray());
+
+print("\n--- Q2: per workspace, sites already holding a domain ---");
+printjson(db.sites.aggregate([
+  { $match: live },
+  { $project: {
+      workspace: 1,
+      hostnames: { $size: { $ifNull: ["$domains", []] } },
+      paid: { $cond: [ { $eq: [ { $ifNull: ["$subscription_status", "none"] }, "active" ] }, 1, 0 ] }
+  } },
+  { $match: { hostnames: { $gt: 0 } } },
+  { $group: {
+      _id: "$workspace",
+      domained_sites: { $sum: 1 },
+      floor_domained_sites: { $sum: { $cond: [ { $eq: ["$paid", 0] }, 1, 0 ] } },
+      max_hostnames_on_one_site: { $max: "$hostnames" }
+  } },
+  { $sort: { floor_domained_sites: -1 } }
+]).toArray());
+'
+```
+
+The `--eval` body is single-quoted, so the JavaScript inside uses only double
+quotes. Keep it that way when editing, or the shell will end the string early and
+mongosh will receive a fragment.
+
+## Route B — anywhere that can reach the database
+
+`scripts/census_site_plans.py` runs the same two aggregations and interprets them,
+which Route A leaves to the reader.
+
+```bash
+CLOUD_MONGODB_URI=... uv run python scripts/census_site_plans.py
+CLOUD_MONGODB_URI=... uv run python scripts/census_site_plans.py --json
+```
+
+The URI comes from the environment and never from an argument: a production
+connection string in a command line ends up in shell history. The script prints
+the database name and a coarse host class, never the URI.
+
+## Reading the result
+
+**Q1 — the grid.** `<unset>` in the `plan_tier` column is a pre-BC-9 row or a
+first publish; it resolves to the floor and migrates with `basic`. Add up every
+row whose `plan_tier` is neither the floor key nor `<unset>`:
+
+- **Zero.** The rekey is a rename. PW-4 ships the mapping and nothing else.
+- **Non-zero, none with `subscription_status: "active"`.** A migration with no
+  refund exposure, because no per-site subscription has ever charged
+  (`POCKETPAW_DODO_SITE_PRODUCTS` is configured nowhere). If any of those rows has
+  `sites_with_domains > 0`, PW-4 gains a comms line: the domain keeps working, but
+  the site lands on the free floor's allowance.
+- **Non-zero, some active.** Stop and escalate. Real subscriptions exist and the
+  ladder change is a pricing decision before it is a migration.
+
+**Q2 — the per-workspace rows.** `floor_domained_sites` is how many of that
+workspace's sites spend the free allowance: holding at least one domain and *not*
+on an active paid subscription. That predicate is
+`entitlements.site_domain_allowance(...) is not None` written in Mongo, and it is
+the same one `sites.service._domain_cap_exceeded` applies at attach time.
+
+- Any workspace with `floor_domained_sites > 1` is **already over** the cap of 1.
+  It loses nothing when the flag flips; it is refused on its next attach. Count
+  them and decide whether that population needs telling.
+- `max_hostnames_on_one_site` above 2 means some site is already past
+  `_FREE_MAX_HOSTNAMES_PER_SITE`. Same story: kept, not detached, refused next
+  time. If the number is common rather than rare, that constant wants raising.
+
+## Recording the answer
+
+Write the counts and the date into the open-questions section of
+`docs/design/drafts/2026-08-21-paw-sites-plan-wiring-prd.md` in paw-workspace.
+PW-4 reads it from there.
+
+## Known result
+
+**Local dev database, 2026-08-21:** 43 sites, all live, none archived. 40 on
+`basic`, 3 with `plan_tier` unset, every one of them `subscription_status: "none"`.
+Zero non-floor rows, so on dev the rekey is a rename. Three sites in one workspace
+each hold a domain, which puts that workspace over the cap of 1 already — on dev,
+with one hostname apiece. **These are dev numbers and say nothing about
+production.** They are recorded only as proof the queries run and as a worked
+example of what the output looks like.

--- a/scripts/census_site_plans.py
+++ b/scripts/census_site_plans.py
@@ -1,0 +1,309 @@
+"""Census of what the ``sites`` collection actually holds, before the per-site
+plan rekey and before per-site billing enforcement is switched on.
+
+Created 2026-08-21 (PW-3 of docs/design/drafts/2026-08-21-paw-sites-plan-wiring-tasks.md).
+STRICTLY READ-ONLY: every query here is a ``$group`` aggregate or a
+``count_documents``. Nothing writes, nothing indexes, nothing drops. Safe to run
+against production, which is the entire point of it existing.
+
+WHY A SCRIPT AND NOT A ONE-OFF QUERY. The plan called PW-3 "a number, not code",
+on the assumption someone would open a shell and look. There is no production
+Mongo reachable from a dev machine: the only ``CLOUD_MONGODB_URI`` configured
+anywhere in the workspace points at localhost, and production Mongo runs as the
+``paw-mongo`` container inside the Coolify deployment with no published port. So
+the deliverable became "one command whoever has host access can run". The same
+command is also how PW-4 verifies its migration afterwards, and how anyone
+re-checks the numbers before actually flipping the flag — which a shell session
+would not have been.
+
+TWO QUESTIONS, and only the first one was asked:
+
+  1. IS THE REKEY A MIGRATION OR A RENAME? ``publish_pocket`` stamps
+     ``Site.plan_tier`` even when checkout degrades, so paid-tier VALUES can be
+     persisted with ``subscription_status="none"`` and no money behind them. If
+     production holds only floor-tier rows the rekey is a rename; if it holds
+     paid keys it is a real data migration, and any of those rows carrying a
+     domain drops to the free floor's allowance when it runs.
+
+  2. WHO BREAKS WHEN ENFORCEMENT GOES ON? Enforcement is attach-time only and
+     never retroactive, so an over-cap workspace keeps every domain it has — but
+     its NEXT attach is refused, and support needs to know how many customers
+     that is before the flag flips rather than after. Same single pass answers
+     it, so it is here.
+
+Usage — the URI comes from the environment, never from a command-line argument,
+so a production connection string does not land in shell history:
+
+    CLOUD_MONGODB_URI=... uv run python scripts/census_site_plans.py
+    CLOUD_MONGODB_URI=... uv run python scripts/census_site_plans.py --json
+
+On the deployment host, where there is no Python environment, the mongosh
+equivalent is in docs/runbooks/2026-08-21-site-plan-census.md.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from collections import defaultdict
+from typing import Any
+
+# The tier keys as the catalog ships them today. Imported rather than hardcoded
+# where possible, but this script has to run on a host that may not have the ee
+# package installed, so it degrades to the literals with a note in the output.
+_FALLBACK_BASE_KEY = "basic"
+_FALLBACK_KNOWN_KEYS = ("basic", "pro", "business")
+
+# Statuses that mean money is actually moving. Mirrors
+# ``entitlements.service._ACTIVE_SITE_SUBSCRIPTION_STATUSES``; duplicated for the
+# same reason as the tier keys, and cross-checked against it when the import works.
+_ACTIVE = frozenset({"active"})
+
+
+def _catalog() -> tuple[str, tuple[str, ...], str]:
+    """(base_key, known_keys, provenance) — from the catalog if importable."""
+    try:
+        from pocketpaw_ee.cloud.billing import site_plans
+
+        keys = tuple(t.key for t in site_plans.list_site_plans())
+        return site_plans.BASE_SITE_PLAN_KEY, keys, "imported from site_plans"
+    except Exception:
+        return _FALLBACK_BASE_KEY, _FALLBACK_KNOWN_KEYS, "fallback literals (ee not installed)"
+
+
+def _db_label(uri: str) -> tuple[str, str]:
+    """(db_name, host_class) — never the URI itself, which carries credentials."""
+    tail = uri.rsplit("/", 1)[-1]
+    db_name = tail.split("?")[0] or "paw-enterprise"
+    lowered = uri.lower()
+    if "localhost" in lowered or "127.0.0.1" in lowered:
+        host_class = "localhost (a DEV database - these numbers are not production)"
+    elif "@mongo:" in lowered or "//mongo:" in lowered:
+        host_class = "in-cluster 'mongo' host (the deployment's own container)"
+    else:
+        host_class = "remote host"
+    return db_name, host_class
+
+
+async def _collect(db: Any, base_key: str) -> dict:
+    sites = db["sites"]
+
+    totals = {
+        "documents": await sites.count_documents({}),
+        "archived": await sites.count_documents({"archived": True}),
+        "live": await sites.count_documents({"archived": {"$ne": True}}),
+    }
+
+    # Q1 — the tier x status grid. ``$ifNull`` because ``plan_tier`` defaults to
+    # None and pre-BC-9 rows have no key at all; both mean "the floor", and
+    # collapsing them into the literal null would hide how many rows are which.
+    grid_rows = await sites.aggregate(
+        [
+            {"$match": {"archived": {"$ne": True}}},
+            {
+                "$group": {
+                    "_id": {
+                        "plan_tier": {"$ifNull": ["$plan_tier", "<unset>"]},
+                        "subscription_status": {"$ifNull": ["$subscription_status", "<unset>"]},
+                    },
+                    "sites": {"$sum": 1},
+                    "with_domains": {
+                        "$sum": {
+                            "$cond": [
+                                {"$gt": [{"$size": {"$ifNull": ["$domains", []]}}, 0]},
+                                1,
+                                0,
+                            ]
+                        }
+                    },
+                    "hostnames": {"$sum": {"$size": {"$ifNull": ["$domains", []]}}},
+                }
+            },
+            {"$sort": {"_id.plan_tier": 1, "_id.subscription_status": 1}},
+        ]
+    ).to_list(length=None)
+
+    grid = [
+        {
+            "plan_tier": r["_id"]["plan_tier"],
+            "subscription_status": r["_id"]["subscription_status"],
+            "sites": r["sites"],
+            "sites_with_domains": r["with_domains"],
+            "hostnames": r["hostnames"],
+        }
+        for r in grid_rows
+    ]
+
+    # Q2 — the workspaces the cap would bite. A site spends the workspace's floor
+    # allowance when it holds >= 1 domain AND is not on an active paid
+    # subscription; that predicate is
+    # ``entitlements.site_domain_allowance(...) is not None`` expressed in Mongo.
+    # Archived rows excluded, matching both the gallery read and the counting seam.
+    per_workspace = await sites.aggregate(
+        [
+            {"$match": {"archived": {"$ne": True}}},
+            {
+                "$project": {
+                    "workspace": 1,
+                    "hostnames": {"$size": {"$ifNull": ["$domains", []]}},
+                    "paid": {
+                        "$cond": [
+                            {"$in": [{"$ifNull": ["$subscription_status", "none"]}, list(_ACTIVE)]},
+                            1,
+                            0,
+                        ]
+                    },
+                }
+            },
+            {"$match": {"hostnames": {"$gt": 0}}},
+            {
+                "$group": {
+                    "_id": "$workspace",
+                    "domained_sites": {"$sum": 1},
+                    "floor_domained_sites": {"$sum": {"$cond": [{"$eq": ["$paid", 0]}, 1, 0]}},
+                    "max_hostnames_on_one_site": {"$max": "$hostnames"},
+                    "hostnames": {"$sum": "$hostnames"},
+                }
+            },
+        ]
+    ).to_list(length=None)
+
+    over_cap = [w for w in per_workspace if w["floor_domained_sites"] > 1]
+    # Keyed on WORKSPACES, not sites: "how many workspaces have a busiest site
+    # carrying N hostnames". Says directly whether _FREE_MAX_HOSTNAMES_PER_SITE = 2
+    # would refuse anyone who is already here.
+    busiest_site_spread: dict[int, int] = defaultdict(int)
+    for w in per_workspace:
+        busiest_site_spread[w["max_hostnames_on_one_site"]] += 1
+
+    return {
+        "totals": totals,
+        "grid": grid,
+        "workspaces_with_a_domain": len(per_workspace),
+        "workspaces_over_the_free_cap": len(over_cap),
+        "over_cap_detail": sorted(
+            (
+                {"workspace": w["_id"], "floor_domained_sites": w["floor_domained_sites"]}
+                for w in over_cap
+            ),
+            key=lambda w: -w["floor_domained_sites"],
+        ),
+        "max_hostnames_on_one_site": max(
+            (w["max_hostnames_on_one_site"] for w in per_workspace), default=0
+        ),
+        "workspaces_by_busiest_site_hostnames": dict(sorted(busiest_site_spread.items())),
+        "non_floor": {
+            "sites": sum(r["sites"] for r in grid if r["plan_tier"] not in (base_key, "<unset>")),
+            "sites_with_domains": sum(
+                r["sites_with_domains"] for r in grid if r["plan_tier"] not in (base_key, "<unset>")
+            ),
+            "paying": sum(
+                r["sites"]
+                for r in grid
+                if r["plan_tier"] not in (base_key, "<unset>")
+                and r["subscription_status"] in _ACTIVE
+            ),
+        },
+    }
+
+
+def _render(result: dict, *, db_name: str, host_class: str, provenance: str, base_key: str) -> None:
+    print(f"database        : {db_name}")
+    print(f"host            : {host_class}")
+    print(f"catalog keys    : {provenance}  (floor = {base_key!r})")
+    t = result["totals"]
+    print(f"\nsites           : {t['documents']} total, {t['live']} live, {t['archived']} archived")
+
+    print("\n--- plan_tier x subscription_status (live sites only) ---")
+    if not result["grid"]:
+        print("  (none)")
+    else:
+        print(
+            f"  {'plan_tier':<12} {'status':<12} {'sites':>7} {'w/ domain':>10} {'hostnames':>10}"
+        )
+        for r in result["grid"]:
+            print(
+                f"  {r['plan_tier']:<12} {r['subscription_status']:<12} "
+                f"{r['sites']:>7} {r['sites_with_domains']:>10} {r['hostnames']:>10}"
+            )
+
+    nf = result["non_floor"]
+    print("\n--- Q1: is the rekey a migration or a rename? ---")
+    if nf["sites"] == 0:
+        print("  RENAME. No live site carries a non-floor plan_tier.")
+    else:
+        print(f"  MIGRATION. {nf['sites']} live site(s) carry a non-floor plan_tier.")
+        print(f"    of those, {nf['paying']} have an ACTIVE subscription (real money)")
+        print(f"    of those, {nf['sites_with_domains']} already hold a custom domain")
+        if nf["sites_with_domains"] and not nf["paying"]:
+            print("    -> those domains survive (attach-time only), but the sites drop to")
+            print("       the free floor's allowance. PW-4 needs a comms line.")
+
+    print("\n--- Q2: who does the cap bite when enforcement goes on? ---")
+    print(f"  workspaces holding at least one custom domain : {result['workspaces_with_a_domain']}")
+    print(
+        "  workspaces already over the free cap of 1     : "
+        f"{result['workspaces_over_the_free_cap']}"
+    )
+    for w in result["over_cap_detail"][:20]:
+        print(f"    {w['workspace']}: {w['floor_domained_sites']} floor sites with a domain")
+    if len(result["over_cap_detail"]) > 20:
+        print(f"    ... and {len(result['over_cap_detail']) - 20} more")
+    print(f"  most hostnames on any one site               : {result['max_hostnames_on_one_site']}")
+    print(
+        "  workspaces by busiest site's hostname count   : "
+        f"{result['workspaces_by_busiest_site_hostnames']}"
+    )
+    if result["max_hostnames_on_one_site"] > 2:
+        print("    -> at least one site is already past _FREE_MAX_HOSTNAMES_PER_SITE = 2.")
+    print("\n  Nothing is detached by enforcement. These workspaces keep what they have")
+    print("  and are refused only on the NEXT attach.")
+
+
+async def main() -> int:
+    as_json = "--json" in sys.argv
+
+    uri = os.environ.get("CLOUD_MONGODB_URI") or os.environ.get("POCKETPAW_CLOUD_MONGO_URI")
+    if not uri:
+        print(
+            "Set CLOUD_MONGODB_URI (the variable the ee cloud layer itself reads).\n"
+            "Passed by env and not by argument on purpose: a production connection\n"
+            "string in a command line ends up in shell history.",
+            file=sys.stderr,
+        )
+        return 2
+
+    db_name, host_class = _db_label(uri)
+    base_key, _, provenance = _catalog()
+
+    from motor.motor_asyncio import AsyncIOMotorClient
+
+    client = AsyncIOMotorClient(uri, serverSelectionTimeoutMS=8000)
+    try:
+        result = await _collect(client[db_name], base_key)
+    finally:
+        client.close()
+
+    if as_json:
+        print(
+            json.dumps(
+                {"database": db_name, "host": host_class, "floor_key": base_key, **result},
+                indent=2,
+                default=str,
+            )
+        )
+    else:
+        _render(
+            result,
+            db_name=db_name,
+            host_class=host_class,
+            provenance=provenance,
+            base_key=base_key,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))


### PR DESCRIPTION
PW-3 was planned as "a number, not code" — open a shell against production, count the `plan_tier` distribution, write it down, unblock the rekey. That turned out not to be available.

There is no production Mongo reachable from a dev machine. The only `CLOUD_MONGODB_URI` configured anywhere in the workspace points at localhost; production Mongo is the `paw-mongo` container inside the Coolify deployment (`deploy/coolify/docker-compose.yaml`), which publishes no port and whose connection string lives in the external Coolify config, not in any repo. No runbook documents a way in.

So the deliverable became the means to run it in one command by whoever does have host access. The same command is also how PW-4 verifies its migration afterwards, and how anyone re-checks before actually flipping enforcement on — which an ad-hoc shell session would not have been.

## Two routes, because the host has no Python

`docs/runbooks/2026-08-21-site-plan-census.md` carries a paste-able `docker exec paw-mongo mongosh --eval`. That is the one that matters: it needs nothing installed.

`scripts/census_site_plans.py` runs the same two aggregations and interprets them, for anywhere that can reach the database. `--json` for machine reading.

Both are strictly read-only: every query is a `$group` aggregate or a `count_documents`.

## The second question

The plan asked one thing — is the rekey a migration or a rename. The same single pass answers another that matters more before the flag flips: **how many workspaces already hold more than one domained floor site.**

Enforcement is attach-time only, so nobody loses a domain. Those workspaces keep everything they have and are refused only on their *next* attach. But that is exactly the population support hears from, and knowing its size before turning enforcement on beats discovering it after. The floor-vs-paid predicate is the same one `_domain_cap_exceeded` applies — a site spends the allowance when it holds a domain and is not on an active subscription — written in Mongo.

It also reports the largest hostname count on any one site, which is the empirical check on whether `_FREE_MAX_HOSTNAMES_PER_SITE = 2` would refuse anyone who is already here.

## On handling the URI

It comes from the environment and never from a command-line argument, because a production connection string in a command line ends up in shell history. The script prints the database name and a coarse host class ("localhost", "in-cluster", "remote") and never the URI itself.

The runbook's `--eval` body is single-quoted, so the JavaScript inside uses only double quotes. There is a note saying so, because editing that carelessly makes the shell end the string early and hands mongosh a fragment.

## Verification

Run against the local dev database, which is what proves the queries work:

```
sites           : 43 total, 43 live, 0 archived

  plan_tier    status         sites  w/ domain  hostnames
  <unset>      none               3          0          0
  basic        none              40          3          3

Q1: RENAME. No live site carries a non-floor plan_tier.
Q2: 1 workspace holds a domain; 1 is already over the free cap of 1
    69f88339dc8997d1f758cb5e: 3 floor sites with a domain
```

**Dev numbers. They say nothing about production** and are recorded in the runbook only as a worked example of the output. `ruff check` and `ruff format` clean. No tests: this matches the other `diag_*` / `smoke_*` scripts, and running it against a real database exercises more of it than a unit test would.

## What is still open

The production answer. Paste the counts into the open-questions section of `docs/design/drafts/2026-08-21-paw-sites-plan-wiring-prd.md` in paw-workspace, with a date, and PW-4 unblocks. If any non-floor row has `subscription_status: "active"`, stop — real subscriptions exist and the ladder change is a pricing decision before it is a migration.
