### PR TITLE
Drop the 10k character cap on chat message content

### DIFF
--- a/ee/pocketpaw_ee/cloud/chat/agent_schemas.py
+++ b/ee/pocketpaw_ee/cloud/chat/agent_schemas.py
@@ -51,6 +51,17 @@
 #   existing smart-routing / ``claude_sdk_model`` logic — behavior byte-identical.
 #   It rides ``RunSpec.model_override`` → ``ScopeContext`` → ``AgentPool.run`` to
 #   the Claude SDK backend, where it wins over ALL other model sources.
+# Changes: 2026-08-21 (fix/uncap-chat-message-content) — ``content`` LOST its
+#   ``max_length=10_000``. The cap dated to this file's first commit and was a
+#   scaffolded default, not a sized decision — the runtime API has always taken
+#   100_000 on the identical field. 10k characters is roughly 2.5k tokens, well
+#   under a site-authoring prompt, and the composer has no matching client-side
+#   guard, so the cap only ever surfaced as a raw pydantic ``string_too_long``
+#   422 after the user had already written the thing. ``min_length=1`` stays.
+#   With no app-level ceiling the effective one is MongoDB's 16MB BSON document
+#   limit at insert (a 500, not a 422); no proxy body cap exists in the deploy
+#   config. ``model`` keeps its own ``max_length=100`` — that one guards a
+#   subprocess launch arg and is a real gate.
 """Request and SSE-event payload schemas for the enterprise agent chat endpoint.
 
 The endpoint lives at ``POST /cloud/chat/{scope}/{scope_id}/agent`` and streams
@@ -70,7 +81,7 @@ from pydantic import BaseModel, Field, field_validator
 class CloudAgentChatRequest(BaseModel):
     """Body of ``POST /cloud/chat/{scope}/{scope_id}/agent``."""
 
-    content: str = Field(min_length=1, max_length=10_000)
+    content: str = Field(min_length=1)
     attachments: list[dict[str, Any]] = Field(default_factory=list)
     reply_to: str | None = None
     mentions: list[dict[str, Any]] = Field(default_factory=list)

--- a/ee/pocketpaw_ee/cloud/chat/schemas.py
+++ b/ee/pocketpaw_ee/cloud/chat/schemas.py
@@ -1,4 +1,21 @@
-"""Request/response and WebSocket message schemas for chat."""
+"""Request/response and WebSocket message schemas for chat.
+
+Changes: 2026-08-21 (fix/uncap-chat-message-content) — ``SendMessageRequest.content``
+and ``EditMessageRequest.content`` LOST their ``max_length=10_000``. The cap was
+never a sized decision: it arrived with the ee/cloud rebuild bulk merge (#778,
+2026-04-10) in the same pass that stamped ``name<=100`` / ``emoji<=50`` /
+``q<=200`` across this module, and the runtime API has always taken 100_000 on
+the identical field (``pocketpaw.api.v1.schemas.chat``). 10k characters is
+roughly 2.5k tokens, which a site-authoring or "recreate this page" prompt
+clears easily — and the frontend composer has no matching guard, so the only
+thing the cap produced was a raw pydantic ``string_too_long`` 422 mid-compose.
+
+``min_length=1`` STAYS on both: an empty message is still a real rejection.
+There is no app-level ceiling on message content any more. The effective
+ceiling is MongoDB's 16MB BSON document limit, which surfaces as a 500 at
+insert rather than a 422 at the edge, and no proxy body cap was found in the
+deploy config.
+"""
 
 from __future__ import annotations
 
@@ -59,7 +76,7 @@ class CreateThreadRequest(BaseModel):
 
 
 class SendMessageRequest(BaseModel):
-    content: str = Field(min_length=1, max_length=10_000)
+    content: str = Field(min_length=1)
     reply_to: str | None = None
     mentions: list[dict] = Field(default_factory=list)
     attachments: list[dict] = Field(default_factory=list)
@@ -67,7 +84,7 @@ class SendMessageRequest(BaseModel):
 
 
 class EditMessageRequest(BaseModel):
-    content: str = Field(min_length=1, max_length=10_000)
+    content: str = Field(min_length=1)
 
 
 class ReactRequest(BaseModel):

--- a/tests/cloud/test_agent_chat_schemas.py
+++ b/tests/cloud/test_agent_chat_schemas.py
@@ -15,6 +15,16 @@ def test_request_requires_content():
         CloudAgentChatRequest(content="")
 
 
+def test_request_accepts_long_content():
+    """The agent endpoint takes a full site-authoring prompt.
+
+    This field used to cap at 10_000; 100_001 chars proves the cap is gone
+    rather than merely raised.
+    """
+    body = "x" * 100_001
+    assert CloudAgentChatRequest(content=body).content == body
+
+
 def test_request_accepts_minimal_body():
     req = CloudAgentChatRequest(content="hello")
     assert req.content == "hello"

--- a/tests/cloud/test_chat_schemas.py
+++ b/tests/cloud/test_chat_schemas.py
@@ -33,9 +33,14 @@ def test_send_message_content_required():
     assert req.content == "hello" and req.reply_to is None and req.mentions == []
 
 
-def test_send_message_max_length():
-    with pytest.raises(PydanticValidationError):
-        SendMessageRequest(content="x" * 10_001)
+def test_send_message_accepts_long_content():
+    """No upper bound on message content — see fix/uncap-chat-message-content.
+
+    100_001 chars is 10x the cap this field used to carry, so a pass here means
+    "uncapped", not merely "the number went up".
+    """
+    body = "x" * 100_001
+    assert SendMessageRequest(content=body).content == body
 
 
 def test_send_message_min_length():
@@ -217,9 +222,9 @@ def test_send_message_with_attachments():
     assert len(req.attachments) == 1
 
 
-def test_edit_message_max_length():
-    with pytest.raises(PydanticValidationError):
-        EditMessageRequest(content="x" * 10_001)
+def test_edit_message_accepts_long_content():
+    body = "x" * 100_001
+    assert EditMessageRequest(content=body).content == body
 
 
 def test_edit_message_min_length():


### PR DESCRIPTION
A prompt for building a site hit `422 string_too_long` partway through composing it. 10,000 characters is roughly 2,500 tokens, and any real "recreate this page in good quality" prompt clears that without trying.

## Why the cap was wrong

It was never sized for this field. It came in with the ee/cloud rebuild bulk merge (#778, April) in the same pass that stamped `name<=100`, `emoji<=50` and `q<=200` across the chat module. Generic edge validation, applied uniformly.

The runtime API has taken 100,000 on the identical field since February (`src/pocketpaw/api/v1/schemas/chat.py:43`). Same content, same agent downstream, ten times the room. The cloud copy just drifted.

It also had no client-side counterpart. `ChatInput.svelte` caps attachments but not characters and shows no counter, so the cap only ever surfaced as a raw pydantic `detail[]` blob after the message was already written.

## What changed

`max_length` comes off three fields:

- `SendMessageRequest.content`
- `EditMessageRequest.content`
- `CloudAgentChatRequest.content` (the agent endpoint, the one the failure came from)

`min_length=1` stays on all three. Empty messages are still rejected. `CloudAgentChatRequest.model` keeps its own `max_length=100` because that value lands in a subprocess launch arg and is a real gate.

## What now bounds message size

Nothing at the application layer. The effective ceiling is MongoDB's 16MB BSON document limit, which shows up as a 500 at insert instead of a 422 at the edge. I checked `deploy/coolify` for a proxy body cap and there isn't one. Calling that out because it is a real change in posture, not an oversight. If you want a ceiling back, it should be a byte-based one sized against the BSON limit with a matching composer counter, not a character count copied from a sibling DTO.

## Tests

The two tests that asserted the cap now assert the opposite at 100,001 characters, so a pass means "uncapped" rather than "the number went up". Added the same for the agent endpoint, which had no length test at all.

`tests/cloud/test_chat_schemas.py`, `test_agent_chat_schemas.py`, `tests/cloud/chat/` and the agent router suites: 255 passed. ruff clean.

## Follow-up worth doing separately

The composer still has no character counter and `http-errors.ts` does not map `string_too_long`, so any future length rejection will look just as raw as this one did. Separate PR, separate repo.
