### PR TITLE
Bundle prefer-container-queries and webgl-components for the chat agent

### DIFF
--- a/src/pocketpaw/atlas/data/atlas.json
+++ b/src/pocketpaw/atlas/data/atlas.json
@@ -2069,6 +2069,20 @@
     },
     {
       "gist": "",
+      "how": "a user invokes it as /prefer-container-queries in chat; the agent loads it via the Skill tool (bundled Claude Code plugin). Workspace-installed skills are discovered via the system-prompt skills block, not atlas.",
+      "id": "skill:prefer-container-queries",
+      "keywords": [
+        "prefer-container-queries"
+      ],
+      "kind": "skill",
+      "name": "prefer-container-queries",
+      "narrative": "Enforce Tailwind container queries over viewport breakpoints for responsive components. Use when writing or reviewing responsive Tailwind code, when a component needs to adapt to its available space (cards, sidebars, lists, panels, anything reused in different layouts), or when migrating sm:/md:/lg: classes to @container variants.",
+      "requires": [],
+      "summary": "Enforce Tailwind container queries over viewport breakpoints for responsive components.",
+      "surface": ""
+    },
+    {
+      "gist": "",
       "how": "a user invokes it as /ship in chat; the agent loads it via the Skill tool (bundled Claude Code plugin). Workspace-installed skills are discovered via the system-prompt skills block, not atlas.",
       "id": "skill:ship",
       "keywords": [
@@ -2093,6 +2107,20 @@
       "narrative": "Generate media — images and short videos — from a text description and lay the results out in a gallery. Invoke when the user asks to create visual media: \"generate an image of...\", \"make a video of...\", \"create a poster for...\", \"render an illustration\", \"animate...\", or any describe-to-media request (especially on the /studio surface). You do NOT build a dashboard or a ui-spec — you call a deterministic media tool that produces the asset and adds it to a gallery pocket that opens on the canvas. This is the media-generation brain: pick image vs video by intent, write a vivid prompt, call the tool, and relay any provider/key error plainly. Loading this skill keeps the chat agent's always-on system prompt small while still delivering the full media flow when generation is actually requested.",
       "requires": [],
       "summary": "Generate media — images and short videos — from a text description and lay the results out in a gallery.",
+      "surface": ""
+    },
+    {
+      "gist": "",
+      "how": "a user invokes it as /webgl-components in chat; the agent loads it via the Skill tool (bundled Claude Code plugin). Workspace-installed skills are discovered via the system-prompt skills block, not atlas.",
+      "id": "skill:webgl-components",
+      "keywords": [
+        "webgl-components"
+      ],
+      "kind": "skill",
+      "name": "webgl-components",
+      "narrative": "Build small, always-on WebGL visuals (identity avatars, ambient orbs, glass and iridescent surfaces, animated textures) that ship inside a normal web app UI without wrecking performance, accessibility, SSR, or layout. Use whenever a shader-, GLSL-, or canvas-driven decorative element is added to a product UI, especially one rendered many times per page or per list; when reviewing or optimizing one; or when debugging one that renders blurry, aliased, all-black, or paints over the surrounding UI on machines without hardware acceleration.",
+      "requires": [],
+      "summary": "Build small, always-on WebGL visuals (identity avatars, ambient orbs, glass and iridescent surfaces, animated textures) that ship inside a normal web app UI without wrecking performance,…",
       "surface": ""
     },
     {

--- a/src/pocketpaw/bundled_skills/_bundled/skills/prefer-container-queries/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/skills/prefer-container-queries/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: prefer-container-queries
+description: "Enforce Tailwind container queries over viewport breakpoints for responsive components. Use when writing or reviewing responsive Tailwind code, when a component needs to adapt to its available space (cards, sidebars, lists, panels, anything reused in different layouts), or when migrating sm:/md:/lg: classes to @container variants."
+---
+
+# Prefer Container Queries
+
+> **PocketPaw note.** Vendored from
+> [flornkm/skills](https://github.com/flornkm/skills) (MIT). It applies wherever
+> Tailwind is actually in the pipeline:
+>
+> - **Generated Paw Sites** get Tailwind v4 (`tailwindcss` + `@tailwindcss/vite`
+>   in the generated `package.json`, `@import 'tailwindcss'` in `app.css`), so
+>   container queries are in core with no plugin. Note the site skills otherwise
+>   lean on a scoped `<style>` block per section; container queries are worth
+>   reaching for on the reusable pieces (cards, feature tiles, testimonial
+>   blocks), not as a reason to rewrite a hand-authored section in utilities.
+> - **`code-next` projects** ship Tailwind v4 too.
+> - **App UI** (paw-enterprise, ripple) is Tailwind v4.
+>
+> Everything below is unmodified upstream text.
+
+
+Components should respond to the space they are in, not to the viewport. A card that lives in a sidebar has maybe 300px of width even on a huge screen, and a viewport breakpoint like `md:flex-row` will get that wrong every time. Container queries fix this: the component asks "how wide am I?" instead of "how wide is the window?".
+
+When writing responsive Tailwind, default to container queries. Viewport breakpoints are the exception, not the rule.
+
+## How it works
+
+Mark the parent as a container, then use `@`-prefixed variants on its children:
+
+```html
+<div class="@container">
+  <div class="flex flex-col @md:flex-row @md:gap-6">
+    <img class="w-full @md:w-48" />
+    <div class="@md:flex-1">...</div>
+  </div>
+</div>
+```
+
+`@md:` here means "when the container is at least 28rem wide", regardless of viewport size. This card works in a sidebar, a modal, and a full-width grid without changing a single class.
+
+Two rules that trip people up:
+
+1. The `@container` class goes on the parent. The `@md:` variants go on descendants. An element cannot query its own size.
+2. Container variants respond to the nearest ancestor with `@container`. If styles are not applying, check which container you are actually querying.
+
+## Variants
+
+Tailwind v4 ships container queries in core. The sizes:
+
+| Variant | Min width |
+| --- | --- |
+| `@3xs` | 16rem (256px) |
+| `@2xs` | 18rem (288px) |
+| `@xs` | 20rem (320px) |
+| `@sm` | 24rem (384px) |
+| `@md` | 28rem (448px) |
+| `@lg` | 32rem (512px) |
+| `@xl` | 36rem (576px) |
+| `@2xl` | 42rem (672px) |
+| `@3xl` | 48rem (768px) |
+| `@4xl` | 56rem (896px) |
+| `@5xl` | 64rem (1024px) |
+| `@6xl` | 72rem (1152px) |
+| `@7xl` | 80rem (1280px) |
+
+Also available:
+
+- `@max-md:` styles below a container size.
+- `@min-[475px]:` arbitrary values when the scale does not fit.
+- `@container/sidebar` plus `@md/sidebar:flex-row` to name a container and query it from deeper in the tree, past other containers.
+
+The full docs for this can be found [here](https://tailwindcss.com/docs/responsive-design#container-queries).
+
+On Tailwind v3, the same syntax needs the `@tailwindcss/container-queries` plugin. Check the Tailwind version before writing classes.
+
+## When viewport breakpoints are still right
+
+Do not convert these:
+
+- Page-level layout. The overall grid, whether the sidebar exists at all, header and navigation behavior. These genuinely depend on the viewport.
+- Fixed or sticky elements positioned relative to the viewport, like a bottom bar that becomes a side rail.
+- Global typography scale tied to screen size.
+
+Everything inside those layout regions, meaning cards, forms, media objects, stat blocks, table-to-list switches, should use container queries.
+
+## Migrating existing code
+
+1. Find the component's responsive classes (`sm:`, `md:`, `lg:`).
+2. Add `@container` to the component's root or the wrapper that owns the available space.
+3. Replace viewport variants with the container variant that matches the actual width where the layout should change. Do not map `md:` to `@md:` blindly; `md` is 768px of viewport, `@md` is 448px of container. Resize the container, not the window, to find the real breakpoint.
+4. Test the component in its narrowest real context (sidebar, drawer, small grid cell), not just at mobile viewport widths.
+
+## Mistakes to catch in review
+
+- `md:flex-row` on a component that is rendered inside a sidebar or modal. It will stay stacked or break depending on the viewport, not its actual space.
+- `@md:` variants used with no `@container` ancestor. They silently never apply.
+- `@container` and a `@md:` variant on the same element. The element cannot query itself; move the variant to a child or the container class to the parent.
+- A component that only looks right at the exact spot it was built for. If moving it to a different column breaks it, it is viewport-coupled.

--- a/src/pocketpaw/bundled_skills/_bundled/skills/prefer-container-queries/VENDORED.md
+++ b/src/pocketpaw/bundled_skills/_bundled/skills/prefer-container-queries/VENDORED.md
@@ -1,0 +1,20 @@
+<!-- New file 2026-08-21: provenance + refresh recipe for the vendored prefer-container-queries skill. -->
+# Vendored: prefer-container-queries
+
+- **Source:** https://github.com/flornkm/skills (MIT, Florian Kiem)
+- **Vendored:** 2026-08-21 from commit `cf1c0094e182`
+- **Local edits:** one "PocketPaw note" blockquote added under the H1, naming
+  where Tailwind is actually in the pipeline (generated Paw Sites, code-next,
+  app UI) and cautioning that the site tracks otherwise author scoped `<style>`
+  blocks, so this is for the reusable pieces rather than a utilities rewrite.
+  Everything below that note is unmodified upstream text.
+- **What it does:** makes container queries the default for responsive Tailwind
+  work, with the variant table, the cases where viewport breakpoints are still
+  right, a migration recipe, and the review catches (`@md:` with no `@container`
+  ancestor silently never applies; an element cannot query itself).
+- **Why it ships bundled:** the generated site `package.json` carries
+  `tailwindcss` + `@tailwindcss/vite` ^4.2.2 and `app.css` opens with
+  `@import 'tailwindcss'`, so end-user sites have container queries in core.
+- **Not verified:** no site or app migration has been run under it yet.
+- **To refresh:** re-fetch upstream `skills/prefer-container-queries/SKILL.md`,
+  re-apply the PocketPaw note, keep this file, note the new commit here.

--- a/src/pocketpaw/bundled_skills/_bundled/skills/webgl-components/SKILL.md
+++ b/src/pocketpaw/bundled_skills/_bundled/skills/webgl-components/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: webgl-components
+description: "Build small, always-on WebGL visuals (identity avatars, ambient orbs, glass and iridescent surfaces, animated textures) that ship inside a normal web app UI without wrecking performance, accessibility, SSR, or layout. Use whenever a shader-, GLSL-, or canvas-driven decorative element is added to a product UI, especially one rendered many times per page or per list; when reviewing or optimizing one; or when debugging one that renders blurry, aliased, all-black, or paints over the surrounding UI on machines without hardware acceleration."
+---
+
+# WebGL Components
+
+> **PocketPaw note (read this first).** Vendored from
+> [flornkm/skills](https://github.com/flornkm/skills) (MIT) and true as written for
+> app UI. Two PocketPaw constraints come first and override anything below:
+>
+> 1. **A static Paw Site prunes its client bundle.** Static sites build with
+>    `csr = false` and a post-build step deletes the orphan client JS, so
+>    `onMount`, `use:` actions, IntersectionObserver and `requestAnimationFrame`
+>    never run and a `<canvas>` stays blank. Everything in this skill needs JS,
+>    so it applies ONLY where the bundle survives: a **dynamic** site, a site
+>    that explicitly declared `keepsClientBundle`, or app UI (paw-enterprise,
+>    ripple). On a plain static site, ship the CSS background alone. If you are
+>    unsure which you are on, assume the bundle is pruned.
+> 2. **No npm imports on a Paw Site.** The generated `package.json` is
+>    generator-owned and your source map supplies files only, so `three`, `ogl`,
+>    `threlte` and `gsap` never resolve. Hand-written GLSL only. See
+>    `pocketpaw-design-taste` §2.C, which owns the canvas guardrail and stays
+>    authoritative on Paw Sites; this skill supplies the mechanics behind it.
+>
+> The fallback section near the end is the part worth reading even when you never
+> write a shader, because it is about what users see when the GPU says no.
+
+
+Lessons for embedding shader-driven visuals (identity avatars, ambient orbs, animated textures) into product UI. The failure modes are predictable, and nearly all of them come from treating the widget like a demo instead of like a component that renders fifty times in a list.
+
+## Architecture: one context, many instances
+
+**Never create one WebGL context per component instance.** Browsers cap a document at roughly 8 to 16 live contexts, then silently evict the oldest. A list of avatars hits that cap immediately.
+
+- Keep **one module-level WebGL context** rendering offscreen, and give each component instance a cheap 2D canvas. Each frame: draw into the shared GL canvas, then blit the region into the instance's 2D canvas with `drawImage`.
+- The GL drawing buffer is only valid until the browser composites, so draw and blit **within the same task**. Never across an await.
+- GL's origin is bottom-left and the 2D canvas' is top-left, so blit from `canvas.height - size`, not from `0`.
+- Grow the shared canvas to fit the largest instance and never shrink it mid-session.
+- **Group identical draws.** Instances agreeing on every visual input (source, tint, size, pointer state) paint identical pixels, so draw once and blit that result to all of their canvases. A list of same-styled items then costs one draw per frame instead of one per row.
+
+## Frame loop discipline
+
+- One `requestAnimationFrame` loop for all instances, owned at module level. No per-instance loops.
+- Gate every instance on an `IntersectionObserver` so offscreen instances never draw.
+- Pause the loop entirely when `document.visibilityState !== "visible"`, and stop scheduling once nothing visible remains.
+- **Cap the frame rate.** Slow ambient drift gains nothing above 30fps, and an uncapped loop pins a core for as long as the widgets are on screen, twice over on a 120Hz display where rAF fires at 120.
+- Ration expensive one-time work. Generating source textures should be budgeted to roughly one per frame with the remainder rescheduled, because a page that introduces a dozen variants at once will otherwise generate them all in a single frame and stall first paint.
+
+## Cost lives in the fragment shader times area
+
+- **Per-pixel cost scales with widget area, not instance count.** Budget the fragment shader like a hot loop. A blur kernel sampled per pixel per frame (13, 25, 121 taps) is where these widgets die. Aim for **one texture tap plus a couple of noise evaluations** per pixel.
+- Move layered or expensive pattern generation into a **precomputed source texture**: render it once offscreen with the noise octaves, streaks, and grain baked in, then have the per-frame pass merely sample it at a warped position. Motion comes from *where* you sample, not from recomputing the pattern.
+- If the drift perturbs UVs with noise, the GPU's derivative-based mip selection over-blurs, because perturbed derivatives look larger than the real sampling density. Apply a **negative mip bias** in `texture2D(..., bias)` to pull the detail back. This presents as "why is it suddenly blurry and washed out" and is easy to misdiagnose as a texture problem.
+- Mipmaps are mandatory once nothing blurs. A 1024px source minified into a 16 to 48px widget aliases badly. WebGL1 requires power-of-two textures for `generateMipmap`, so keep generated sources power-of-two and **resample arbitrary images onto a power-of-two canvas** before upload.
+
+## Prefer real optics to painted ones
+
+Glass, chrome, iridescence and caustics are the usual reasons these widgets exist, and the instinct is to paint them: a gaussian for the highlight, a hand-authored violet-to-red ramp for the rainbow, a `smoothstep` ring for the edge. Painted optics need a new hand-tuned term for every angle and every background, and they stop being convincing the moment anything moves. Deriving them costs about the same per pixel and holds up on its own.
+
+- **One normal buys everything.** On a disc, `N = normalize(vec3(p, sqrt(1 - r*r)))`. From it, Fresnel `0.04 + 0.96 * pow(1 - dot(N, V), 5.0)` and a reflection vector are two more lines, and **a Fresnel-weighted `env(reflect(-V, N))` already is the specular edge** — grazing angles drive the weight to 1 and the rim shows nothing but environment. A separate rim term added on top of this is a sign the reflection is not doing its job.
+- **The environment can be a function, not a cubemap.** A direction-to-colour function with one soft key lobe, a vertical gradient and a floor bounce is a handful of `pow`s, needs no texture upload or GPU memory, and gives correct-looking reflections everywhere the widget curves.
+- **Dispersion should be produced, not drawn.** Sample the interior at several wavelengths, each with its own index of refraction, and weight each by the colour the eye assigns it. A white emitter inside then comes out as a spectrum in the right order, and the spread automatically widens toward the rim where the glass is thick, which no hand-authored ramp does. Three taps (plain RGB) only fringe the two edges — a full spectrum needs the middle sampled too, so budget 8 to 16.
+- Two things about a real optical setup that read as bugs but are not:
+  - **A sphere disperses along its own radius.** A horizontal feature separates lengthwise and stays stubbornly white. Getting the spread perpendicular to the feature needs a wedge — a tilt added to the refracting normal — which is a prism, not a hack.
+  - **Applying that wedge directly also displaces the image by its mean deviation**, throwing the feature off the edge of the widget. Position the image with the plain surface normal, compute the wedge's landing for a mid wavelength, and add only the *difference* per wavelength. Position and separation want separate controls, and usually separate depths — the ray depth that gives a good chromatic spread will bend the image into an arc if you also position with it.
+- Physical does not mean unexaggerated. Real glass disperses far too little to see at widget scale, so the index spread is the one number worth pushing well past reality. Keep it as a named constant and say so, since every other number then follows from it.
+- **The sharper the interior, the more wavelengths it needs.** Each wavelength draws its own copy of whatever is inside, so a soft feature hides a coarse sampling and a crisp one turns it into visible stripes — with three sharp ribbons at 14 taps you are drawing 42 separate lines, not a spectrum. Sharpening the interior and raising the tap count are the same change; doing only the first looks like a shader bug.
+- **Hoist everything that does not vary per wavelength out of the loop.** Dispersion displaces the sample along one axis, so anything derived from the other one — wave centre lines, width tapers, length falloffs — is identical on every tap and can be computed once. That is what makes 28 taps cost about what 14 did, and it is the difference between "too expensive, use fewer" and "sample it properly".
+- Cost check after hoisting: a wavelength tap is one `refract` and a few `exp`s — the whole loop is comparable to a 13-tap blur, and unlike the blur it scales with nothing but area. If it still needs trimming, drop taps before dropping resolution, but re-check for striping each time.
+
+## Transparency: what the shader can and cannot reach
+
+- **A widget that should sit over arbitrary page content must output what it *adds* plus what it *blocks*** — premultiplied `vec4(emitted, coverage)` — rather than a finished opaque image. The clear middle then lets the page through while only the reflective rim goes properly opaque.
+- **Any environment constant secretly assumes a background.** A dark studio reflected onto a widget sitting on a white page draws a hard black ring around it, because at grazing angles the edge shows nothing else. Drive the ambient level from `prefers-color-scheme` and pass it as a uniform.
+- **WebGL cannot read the pixels behind its own canvas.** True refraction of live page content is not available from the shader at all. The honest options are a DOM layer under the canvas carrying a `backdrop-filter` (`blur()` is universally supported; an SVG `feDisplacementMap` bends it properly but is not portable), or drawing the backdrop into the scene yourself. Say which one you did — a widget described as refracting the page when it is only reflecting a procedural environment will be found out the moment it moves over something patterned.
+
+## Resolution: let the shader cost decide
+
+Do not copy a device-pixel-ratio cap from another project. The right cap is a function of how expensive your fragment shader is.
+
+- An **expensive** shader (multi-tap blurs, many octaves per pixel) needs an aggressive cap, around 1.5, because fill cost scales with the square of the ratio.
+- A **cheap** shader (one texture tap) should render at the display's real density. Capping below it is just an upscale that visibly softens the widget's edge, and it buys almost nothing back.
+
+Optimizing the shader first is what earns the sharper rendering. Decide the cap after the shader is final, not before.
+
+## Texture cache and GPU memory
+
+- Cache textures by a stable source key so many instances share one upload.
+- **Bound the cache.** Each source texture is roughly a megapixel plus its mip chain, so an unbounded variant count grows GPU memory forever.
+- Evict on a real signal, not just insertion order: skip any key currently in use by a mounted instance, delete the rest with `gl.deleteTexture` until back under the cap. Evicting a texture that is on screen just forces an immediate regeneration.
+
+## Image sources
+
+- Decode off the main thread with `createImageBitmap`, falling back to `Image`, and `close()` the bitmap in a `finally` so early-return paths cannot leak decoded pixel memory.
+- Show a plausible placeholder such as a solid tint until the texture arrives, then repaint the listeners when it lands.
+- If you crop the image to cover-fit, every derived measurement (luminance probes, palette extraction) must measure **the same cropped region you display**, otherwise your guarantees hold only for pixels nobody sees.
+
+## Robustness
+
+- **Handle context loss.** Listen for `webglcontextlost`, call `preventDefault()`, tear down the loop, and flip every mounted instance to its DOM fallback. Context loss is routine under GPU resets and tab pressure, not exotic.
+- **Refuse software rasterization** with `failIfMajorPerformanceCaveat: true`. Where the GPU is blocklisted, a heavy source pass takes seconds and freezes the tab, and the flat fallback is strictly the better widget there.
+- Guarantee output bounds in the shader itself. Clamp generated luminance to a mid band and apply tints with a luminosity-preserving blend, taking hue and saturation from the tint and luminosity from the source, so **no input can produce an all-black or blown-out widget**. Do not rely on curated inputs staying curated.
+
+## The fallback is a production surface, not an edge case
+
+`failIfMajorPerformanceCaveat: true` is the right call, but accept what it implies: the widget refuses to render on **every machine with hardware acceleration switched off** — a plain Chrome settings toggle, not an exotic state — plus blocklisted GPUs, remote-desktop sessions, and lost contexts. Those users see only the fallback, and none of them are the machine you develop on, which is precisely how a broken fallback ships: nobody who could fix it ever renders it.
+
+- **Always ship a non-WebGL fallback** that preserves the element's identity: same color, same seed-derived look, rendered with plain DOM and CSS. The widget is decoration, the fallback is the contract.
+- **Make `fallback` part of the minimum API shape.** Take it as a prop next to `source`, and include it in every documented example — above all the first copy-paste snippet, because that is the one humans and agents lift. An example gallery where only a dedicated "fallback demo" passes one teaches everyone else to omit it.
+- Match the fallback to the source kind. Generated source → a flat disc in the same tint (the color is the identity signal, so it still reads as the right entity). Image source → the same image with `object-cover`, which matches the shader's cover-fit crop. A window onto a larger image → position it absolutely against the frame and let the clip do the cropping.
+- **The frame that clips the fallback must be its containing block.** `overflow: hidden` only clips an absolutely positioned descendant when the clipping element is itself positioned. A fallback that positions an oversized image against a static wrapper ignores the clip entirely and paints across the surrounding UI at full size. Put `position: relative` on the overflow-hidden frame, and treat its absence as a review blocker — this exact bug ships invisibly because the branch never renders on a dev machine.
+- **Make the branch reachable on a healthy GPU.** Ship a `forceFallback` prop and use it in the design-system or docs page with the hardest fallback shape supported (an image an order of magnitude larger than the widget, positioned off-center). A clipping regression then splatters a photo across the docs page where anyone sees it, instead of waiting for a customer report. If flipping to the fallback unmounts the canvas, the registration effect must depend on that flag so the stale instance is released, not leaked.
+- Verify the docs demo actually exercises what it claims. Docs pipelines that intercept intrinsic elements (an MDX `img` override, for instance) can silently strip the `className` or `style` a fallback depends on, leaving a demo that renders plausibly while testing nothing.
+
+## React and SSR integration
+
+- **Under React Server Components, the component file needs `"use client"`.** This is an RSC boundary marker rather than a React-wide requirement, so check which world you are in: it applies in the Next.js App Router and the other RSC setups (React Router's RSC mode, Waku, the Parcel and Vite RSC plugins), and is an inert directive in a plain SPA, the Next Pages Router, or Astro and Remix islands, where the only effect is a bundler warning about module-level directives. Where it does apply, omitting it often works in dev while the **production** server render fails with an opaque digest error, because dev and prod RSC behavior differ. Verify with a real production build, not the dev server.
+- **Any** server rendering, RSC or not, imports the module on the server. So no browser APIs (`window`, `document`, `matchMedia`) at module scope, only inside functions called after mount. This one bites in Astro, Remix, Gatsby and a Vite SSR build just as hard as in Next.
+- Spread object props into primitives for effect dependencies. An inline `source={{...}}` object re-registers the instance on every render when the effect depends on object identity.
+- Registration and teardown belong in one effect returning a cleanup. The imperative handle (pointer position, visibility) goes through refs rather than state, because pointer moves must not re-render React.
+
+## Accessibility and layout
+
+- **`prefers-reduced-motion` renders one still frame and never starts the loop.** Keep full visual fidelity, since reduced motion is not reduced appearance. Listen for the media-query change and repaint live.
+- Decorative instances get `aria-hidden`, meaningful ones get `role="img"` with a label. Make it a prop that defaults to hidden.
+- Wrap the component in `isolation: isolate` if it layers internally with z-index. Otherwise its internal stacking leaks into the page and the widget floats above sticky headers and navigation.
+- Make canvases and any backing images non-interactive: no pointer events on purely visual layers, no drag, no text selection.
+
+## Identity and determinism
+
+- Derive per-entity variety from a **stable hash of the entity id** into a small curated table of crop windows, palettes, or noise offsets. The same entity must look identical across sessions, surfaces, and the WebGL-to-fallback boundary.
+- Spread variants across the parameter space with a strong integer hash such as Knuth multiplicative, not sequential offsets, so neighbouring ids look clearly different.
+- Never use `Math.random()` in the render path. Determinism is what makes the widget an identity mark rather than a screensaver.
+
+## Verifying without eyeballs
+
+- Shader logic is plain math, so **port it to NumPy or PIL and assert on statistics**: mean luminance, percentile spread, and local-gradient detail metrics per variant. This catches "all variants render near-black" or "contrast collapsed" without opening a browser.
+- **Settle which branch a machine takes by measuring, not by reasoning from documentation.** [`scripts/gpu-probe.html`](scripts/gpu-probe.html) answers it directly: the strict-context result, whether WebGL exists at all, the live context cap, and the blit orientation. Edit `CONTEXT_OPTIONS` at the top of the file to match your component's real options first, because the answer only transfers if the options match. Serve it and read the JSON:
+
+```bash
+python3 -m http.server 8000 --directory scripts
+```
+
+- **Test the no-GPU path for real**, not by assumption. Point a GPU-less Chrome at the probe, then at your own app; a throwaway `--user-data-dir` keeps it out of the normal profile:
+
+```bash
+"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --disable-gpu --user-data-dir=/tmp/nogpu-profile http://localhost:8000/gpu-probe.html
+```
+
+  Expect the probe to report `FALLBACK`, then confirm every widget in your app shows its fallback, correctly clipped and painting nothing outside its frame. Note the two no-GPU states differ: `--disable-gpu` removes WebGL entirely, while the GUI toggle (Settings → System → "Use graphics acceleration when available", off, then restart) usually leaves a software rasterizer that the strict context refuses anyway. Both land on the fallback branch, and the GUI toggle is the exact state the affected users are in.
+- The browser checklist: a list of fifty instances scrolls at 60fps, tab-hidden CPU sits near zero, reduced motion shows a still frame, forced context loss flips to the fallback, `--disable-gpu` shows only fallbacks with nothing painting outside its frame, and a production build serves the page.

--- a/src/pocketpaw/bundled_skills/_bundled/skills/webgl-components/VENDORED.md
+++ b/src/pocketpaw/bundled_skills/_bundled/skills/webgl-components/VENDORED.md
@@ -1,0 +1,41 @@
+<!-- New file 2026-08-21: provenance + refresh recipe for the vendored webgl-components skill. -->
+# Vendored: webgl-components
+
+- **Source:** https://github.com/flornkm/skills (MIT, Florian Kiem)
+- **Vendored:** 2026-08-21 from commit `cf1c0094e182`
+- **Local edits:** one "PocketPaw note" blockquote added under the H1 carrying
+  the two constraints that override the upstream text — a static Paw Site prunes
+  its client bundle (so nothing in this skill runs there), and a Paw Site cannot
+  npm-import three/ogl/gsap. It defers to `pocketpaw-design-taste` §2.C as the
+  authority on the canvas guardrail. Everything below the note is unmodified.
+- **What it does:** production discipline for shader-driven UI rendered many
+  times per page — one shared GL context blitted into per-instance 2D canvases
+  (browsers cap a document at ~8-16 live contexts and evict the oldest
+  silently), a single module-level rAF loop gated on IntersectionObserver and
+  `visibilityState`, fragment cost budgeted by area, texture-cache eviction that
+  skips mounted instances, mip bias for UV-warped sampling, and context loss
+  treated as routine.
+- **The part worth reading even without writing a shader:** the fallback
+  section. `failIfMajorPerformanceCaveat: true` means the widget refuses to
+  render on any machine with hardware acceleration off — a plain Chrome settings
+  toggle — so the fallback is a production surface that never renders on the
+  developer's machine. It calls a missing `position: relative` on an
+  overflow-hidden frame a review blocker, since the fallback then paints across
+  surrounding UI at full size.
+- **`scripts/gpu-probe.html`:** self-contained page reporting which branch a
+  machine takes and why. Audited before vendoring: no network calls, no `eval`
+  or `new Function`, no external references, no storage access. It creates 8x8
+  canvases, reads context parameters, and releases contexts via
+  `WEBGL_lose_context`. `CONTEXT_OPTIONS` at the top must match the component's
+  real options or the answer does not transfer.
+- **Why it ships bundled:** `pocketpaw-design-taste` has WebGL canvas identities
+  (Immersive WebGL, Aurora Mesh) and already requires a polished CSS fallback
+  under every canvas. That skill owns the rule; this one supplies the mechanics
+  and the failure modes. Applies on dynamic sites, sites that keep their client
+  bundle, and app UI.
+- **Not verified:** nothing has been built or reviewed under it yet, and the
+  probe has not been run here. Upstream claims validation across multiple
+  codebases; that is their claim, not our measurement. The `--disable-gpu`
+  recipe gives the macOS Chrome path and needs the Windows equivalent.
+- **To refresh:** re-fetch upstream `skills/webgl-components/`, re-apply the
+  PocketPaw note, keep this file, note the new commit here.

--- a/src/pocketpaw/bundled_skills/_bundled/skills/webgl-components/scripts/gpu-probe.html
+++ b/src/pocketpaw/bundled_skills/_bundled/skills/webgl-components/scripts/gpu-probe.html
@@ -1,0 +1,153 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>WebGL branch probe</title>
+<style>
+  body { font: 13px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; margin: 2rem; }
+  h1 { font-size: 15px; margin: 0 0 .25rem; }
+  p  { margin: 0 0 1rem; color: #666; }
+  pre { background: #f4f4f5; padding: 1rem; border-radius: 6px; overflow-x: auto; }
+  .verdict { font-weight: 700; padding: .75rem 1rem; border-radius: 6px; margin-bottom: 1rem; }
+  .webgl    { background: #dcfce7; color: #14532d; }
+  .fallback { background: #fee2e2; color: #7f1d1d; }
+</style>
+
+<h1>WebGL branch probe</h1>
+<p>Answers "does this machine render the shader or the fallback?" — and why.</p>
+<div id="verdict" class="verdict">running…</div>
+<pre id="out">running…</pre>
+
+<script>
+// Edit these to match your component's ACTUAL context options. The strict-context
+// answer only transfers to your app if the options match what your app requests.
+const CONTEXT_OPTIONS = {
+  failIfMajorPerformanceCaveat: true,
+  alpha: true,
+  premultipliedAlpha: true,
+  antialias: false,
+};
+
+const results = {};
+const notes = [];
+
+function makeCanvas(size = 8) {
+  const c = document.createElement("canvas");
+  c.width = c.height = size;
+  return c;
+}
+
+// Hand a context back explicitly instead of waiting for GC, so the probe does not
+// leave the page sitting at the context cap after it reports.
+function releaseContext(gl) {
+  try {
+    const ext = gl && !gl.isContextLost() && gl.getExtension("WEBGL_lose_context");
+    if (ext) ext.loseContext();
+  } catch (_) { /* releasing is best-effort; never fail the probe over it */ }
+}
+
+// 1. THE BRANCH DECIDER ------------------------------------------------------
+// This is the single question the probe exists to answer. A null here means every
+// widget on this machine renders its DOM fallback, no matter how good the shader is.
+try {
+  const strict = makeCanvas().getContext("webgl", CONTEXT_OPTIONS);
+  results.strictContext = strict ? "granted" : "null";
+  results.branch = strict ? "webgl" : "fallback";
+  releaseContext(strict);
+} catch (err) {
+  results.strictContext = "threw: " + err.message;
+  results.branch = "fallback";
+}
+
+// 2. Is there any WebGL at all, or is it strictly the performance caveat? -----
+// Distinguishes "GPU blocklisted / acceleration off, software rasterizer offered"
+// from "no WebGL in this browser at all". Both take the fallback, for different reasons.
+try {
+  const loose = makeCanvas().getContext("webgl");
+  results.permissiveContext = loose ? "granted" : "null";
+  if (loose) {
+    results.maxTextureSize = loose.getParameter(loose.MAX_TEXTURE_SIZE);
+    // Renderer strings are hidden under fingerprinting protection; absence is not an error.
+    const info = loose.getExtension("WEBGL_debug_renderer_info");
+    if (info) {
+      results.vendor = loose.getParameter(info.UNMASKED_VENDOR_WEBGL);
+      results.renderer = loose.getParameter(info.UNMASKED_RENDERER_WEBGL);
+      if (/swiftshader|llvmpipe|software|basic render/i.test(String(results.renderer))) {
+        notes.push("Renderer string looks like a software rasterizer. This is exactly the machine failIfMajorPerformanceCaveat is meant to refuse.");
+      }
+    } else {
+      notes.push("WEBGL_debug_renderer_info unavailable (fingerprinting protection). Renderer identity unknown; the strict-context result above is still authoritative.");
+    }
+  }
+  if (results.permissiveContext === "granted" && results.strictContext === "null") {
+    notes.push("WebGL exists but is refused under the performance caveat: hardware acceleration is off, or this GPU is blocklisted. THIS IS THE COMMON CASE and it is a plain browser setting, not an exotic state.");
+  }
+  if (results.permissiveContext === "null") {
+    notes.push("No WebGL context at all, strict or not.");
+  }
+  releaseContext(loose);
+} catch (err) {
+  results.permissiveContext = "threw: " + err.message;
+}
+
+// 3. Blit orientation --------------------------------------------------------
+// Confirms the shared-canvas blit offset: GL's origin is bottom-left, the 2D
+// canvas' is top-left, so a region drawn at GL y=0 is read back at height - size.
+// This runs BEFORE the context-cap test on purpose — that test deliberately
+// exhausts the context pool, and anything needing a live context after it may be
+// handed an evicted one.
+try {
+  const src = makeCanvas(4);
+  const gl = src.getContext("webgl");
+  if (!gl) {
+    results.glOriginIsBottomLeft = "skipped (no context)";
+  } else {
+    gl.enable(gl.SCISSOR_TEST);
+    gl.scissor(0, 0, 4, 2);           // fill GL rows y = 0..2
+    gl.clearColor(1, 0, 0, 1);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    const dst = makeCanvas(4).getContext("2d");
+    dst.drawImage(src, 0, 0);
+    const isRed = (y) => dst.getImageData(0, y, 1, 1).data[0] === 255;
+    const top = isRed(0), bottom = isRed(3);
+    results.glOriginIsBottomLeft = bottom && !top;
+    if (results.glOriginIsBottomLeft !== true) {
+      notes.push("Blit orientation did not match the documented bottom-left origin. Re-derive the source offset before trusting canvas.height - size.");
+    }
+    releaseContext(gl);
+  }
+} catch (err) {
+  results.glOriginIsBottomLeft = "threw: " + err.message;
+}
+
+// 4. Live context cap --------------------------------------------------------
+// Demonstrates why one context per component instance does not work: the browser
+// keeps handing out contexts while silently killing the oldest ones. Destructive
+// by design, so it runs last, and everything it takes is released afterwards.
+try {
+  const held = [];
+  for (let i = 0; i < 40; i++) {
+    const gl = makeCanvas().getContext("webgl");
+    if (!gl) break;
+    held.push(gl);
+  }
+  const alive = held.filter((gl) => !gl.isContextLost()).length;
+  results.contextsRequested = held.length;
+  results.contextsStillAlive = alive;
+  if (held.length > alive) {
+    notes.push(`Requested ${held.length} contexts, only ${alive} survived, and getContext never returned null while evicting. A per-instance context silently loses its GPU out from under it.`);
+  }
+  held.forEach(releaseContext);
+} catch (err) {
+  results.contextCap = "threw: " + err.message;
+}
+
+results.notes = notes;
+
+const el = document.getElementById("verdict");
+el.className = "verdict " + results.branch;
+el.textContent = results.branch === "webgl"
+  ? "WEBGL — this machine renders the shader. It will NOT show you the fallback; force it to test that branch."
+  : "FALLBACK — this machine renders the DOM fallback for every instance. The shader never runs here.";
+
+document.getElementById("out").textContent = JSON.stringify(results, null, 2);
+window.__probe = results;
+</script>


### PR DESCRIPTION
Ships both skills from [flornkm/skills](https://github.com/flornkm/skills) (MIT, commit `cf1c009`) through the bundled plugin, so the chat agent can invoke them when building sites and pockets.

## Why bundled and not workspace-only

I originally put these in `paw-workspace` on the reasoning that the site tracks don't use Tailwind. That was wrong on the detail that matters: generated Paw Sites run a real Tailwind v4 pipeline. `paw-sites/templates/package.json.tmpl` carries `tailwindcss` and `@tailwindcss/vite` at `^4.2.2`, and `app.css.tmpl` opens with `@import 'tailwindcss'`. Container queries are in core there with no plugin, so the skill applies to end-user sites directly.

## The adaptation that matters

Each skill gets a short PocketPaw note under its H1. Everything below the note is unmodified upstream text.

The webgl note leads with the constraint that would otherwise make the skill **actively harmful** here. A static Paw Site builds with `csr = false`, and `prune-client.mjs` deletes the orphan client JS after `vite build`. So `onMount`, `requestAnimationFrame` and `IntersectionObserver` never run, and a `<canvas>` stays blank. Every technique in the skill needs JS. Without that note an agent would follow it into shipping a blank hero and no test would catch it, because the build succeeds.

So the note scopes it to where the bundle survives — dynamic sites, sites that declared `keepsClientBundle`, and app UI — and tells the agent to assume pruning when unsure. It also defers to `pocketpaw-design-taste` §2.C, which owns the canvas guardrail and separately bans npm imports (`three`, `ogl`, `gsap` never resolve, because the generated `package.json` is generator-owned).

The container-queries note is lighter: it names where Tailwind is actually in the pipeline, and cautions that the site tracks otherwise author scoped `<style>` blocks per section, so this is for reusable pieces rather than a reason to rewrite hand-authored sections into utilities.

## A gate caught something

`tests/atlas/test_widgets_skills.py` requires one atlas entry per bundled skill dir, and it failed on the first run naming its own fix. Ran `pocketpaw atlas build`; the artifact went from 22 to 24 skill entries and the diff is two added blocks with nothing existing perturbed.

Worth knowing for the next person adding a bundled skill: the installer needs no registration (it's directory-based `rglob`), but the checked-in atlas artifact does.

The design-taste byte budget is untouched. That gate covers the one skill inlined whole into the `/sites` preamble, and these two are invoked on demand, so their bytes are paid only when used.

## Verification

Ran the real installer against a temp destination: both install, `scripts/gpu-probe.html` comes along at 6622 bytes, `VENDORED.md` too, and a second run reports `skipped` on both, so the SHA-256 idempotency holds.

498 tests pass across the skill and atlas suites. `scripts/mutate.py --validate` still resolves all 634 anchors across 51 plans. Wheel packaging needs no change — `only-include = ["src/pocketpaw"]` already covers the tree.

`gpu-probe.html` ships executable JS, so I read it before vendoring: no network calls, no `eval` or `new Function`, no external references, no storage access.

## What is not verified

Neither skill has been exercised on our code, and the probe has not been run on this machine. Upstream claims validation across multiple codebases; that is their claim, not our measurement, and both `VENDORED.md` files say so. The `--disable-gpu` recipe also gives the macOS Chrome path and needs the Windows equivalent.

## Note on the workspace PR

qbtrix/paw-workspace#173 puts the same two skills in `.claude/skills/` for the crew. The two are independent: this one ships to end users, that one is for us. If you'd rather not maintain both copies, close #173 and I'll point the workspace at these instead.
