### PR TITLE
Every conversation on the pydantic_ai backend billed zero

### DIFF
--- a/src/pocketpaw/agents/pydantic_ai.py
+++ b/src/pocketpaw/agents/pydantic_ai.py
@@ -2283,6 +2283,36 @@ class PydanticAIBackend:
         shape, where ``input_tokens`` is the UNCACHED remainder, so the two
         subsets come back out here. Getting this subtraction backwards inflates
         the reported hit rate, which is exactly the number the A/B turns on.
+
+        THIS EVENT IS ALSO THE INVOICE, which it was not until 2026-08-21. It was
+        written for the prompt-cache A/B and carried only what that needed, so
+        every run on this backend reached ``metering.resolve_cost`` with no
+        ``model``, no ``output_tokens`` and no ``total_cost_usd`` — which is the
+        exact set that function needs, and it fell through to
+        ``source="none"``, billing zero. Worse, it returned None entirely on a
+        turn with no cache activity, so a cold first turn persisted ``usage: {}``.
+        Measured on the dev database that day: every one of the 37 runs on this
+        backend was unbillable, the visitor concierge among them, and the credit
+        ledger had never seen one.
+
+        Three things follow from that and all three are load-bearing:
+
+        * **It always emits.** No-cache is a real, priceable turn.
+        * **The model comes off the RESPONSE**, not off configuration. The
+          configured spec can be an alias, empty, or overridden per turn; only
+          the response says which model actually priced these tokens. Same
+          reason ``claude_sdk`` takes it from the CLI's own report.
+        * **The cost is computed here** rather than left to the meter's
+          estimator. ``resolve_cost``'s fallback expects an INCLUSIVE
+          ``input_tokens`` while every Anthropic-shaped payload in this codebase
+          reports the uncached remainder, so letting it estimate would subtract
+          the cached tokens a second time and undercount. Pricing where the
+          inclusive total is still in scope avoids the ambiguity; the table is
+          the same one the meter would have used.
+
+        Cache WRITE tokens are priced as ordinary input, which slightly
+        undercounts — Anthropic bills them at a premium. Named rather than
+        silently absorbed; the estimator has no concept of a write.
         """
         usage = getattr(getattr(event, "result", None), "usage", None)
         if usage is None:
@@ -2290,8 +2320,7 @@ class PydanticAIBackend:
         total = int(getattr(usage, "input_tokens", 0) or 0)
         read = int(getattr(usage, "cache_read_tokens", 0) or 0)
         write = int(getattr(usage, "cache_write_tokens", 0) or 0)
-        if not read and not write:
-            return None
+        output = int(getattr(usage, "output_tokens", 0) or 0)
 
         from pocketpaw.llm.caching import report_savings
 
@@ -2302,23 +2331,44 @@ class PydanticAIBackend:
                 "cache_creation_input_tokens": write,
             }
         )
-        logger.info(
-            "[pydantic_ai] prompt-cache: read=%d write=%d hit_rate=%.1f%% "
-            "est_saved=%.0f input-tok-equiv",
-            savings.cache_read_tokens,
-            savings.cache_write_tokens,
-            savings.hit_rate * 100,
-            savings.est_tokens_saved,
-        )
+        if read or write:
+            logger.info(
+                "[pydantic_ai] prompt-cache: read=%d write=%d hit_rate=%.1f%% "
+                "est_saved=%.0f input-tok-equiv",
+                savings.cache_read_tokens,
+                savings.cache_write_tokens,
+                savings.hit_rate * 100,
+                savings.est_tokens_saved,
+            )
+
+        response = getattr(getattr(event, "result", None), "response", None)
+        model_name = getattr(response, "model_name", None)
+        model_name = model_name if isinstance(model_name, str) and model_name else None
+
+        cost = 0.0
+        if model_name is not None:
+            from pocketpaw.usage_tracker import _estimate_cost
+
+            # ``total`` and not the remainder: the estimator subtracts the cached
+            # portion itself, so handing it the already-reduced number would
+            # remove those tokens twice.
+            estimated = _estimate_cost(model_name, total, output, read)
+            if estimated:
+                cost = float(estimated)
+
         return AgentEvent(
             type="token_usage",
             content="",
             metadata={
                 "input_tokens": max(0, total - read - write),
+                "output_tokens": output,
+                "cached_input_tokens": read,
                 "cache_read_tokens": savings.cache_read_tokens,
                 "cache_write_tokens": savings.cache_write_tokens,
                 "cache_hit_rate": savings.hit_rate,
                 "cache_est_tokens_saved": savings.est_tokens_saved,
+                "total_cost_usd": cost,
+                "model": model_name,
                 "backend": "pydantic_ai",
             },
         )

--- a/src/pocketpaw/usage_tracker.py
+++ b/src/pocketpaw/usage_tracker.py
@@ -24,6 +24,31 @@ logger = logging.getLogger(__name__)
 
 # ── Pricing (per 1M tokens, USD) ──
 # Updated 2025-05. Adjust as providers change pricing.
+# USD per MILLION tokens. ``cached_input`` is the cache-HIT (read) rate; cache
+# WRITES are billed at a premium (1.25x for 5m, 2x for 1h) that this table has no
+# column for, so an estimate slightly undercounts a write-heavy turn.
+#
+# A model missing from here estimates to None, which ``metering.resolve_cost``
+# turns into a $0 bill rather than an error. That is a quiet failure by design —
+# a run must not die over its own invoice — and it is exactly how it went unnoticed
+# that this table stopped at the mid-2025 ids while every model in production had
+# moved on. Measured 2026-08-21: claude-haiku-4-5-20251001, claude-sonnet-4-6 and
+# claude-opus-4-7 ALL priced to None, so the whole pydantic_ai backend billed
+# nothing. The claude_agent_sdk path never noticed because the SDK reports its own
+# cost and never consults this table.
+#
+# **When a model ships, add it here.** The lookup falls back to a two-way prefix
+# match, which is why the keys below are the undated family ids: they catch both
+# the dated variant (``claude-haiku-4-5-20251001``) and the context-window suffix
+# this codebase appends (``claude-opus-4-7[1m]``). New entries go AFTER the older
+# ones on purpose — a bare ``"claude"``, which the agentapi path uses as its
+# fallback name, prefix-matches the FIRST claude key in insertion order, and
+# reordering would silently reprice every run that reported it. That fallback
+# resolving to any particular model is a guess either way; it is left exactly as
+# it was rather than quietly changed here.
+#
+# Rates from https://platform.claude.com/docs/en/about-claude/pricing, read
+# 2026-08-21.
 _PRICING: dict[str, dict[str, float]] = {
     # Anthropic
     "claude-sonnet-4-20250514": {"input": 3.0, "output": 15.0, "cached_input": 0.30},
@@ -32,6 +57,18 @@ _PRICING: dict[str, dict[str, float]] = {
     "claude-3-5-sonnet-20241022": {"input": 3.0, "output": 15.0, "cached_input": 0.30},
     "claude-3-5-haiku-20241022": {"input": 0.80, "output": 4.0, "cached_input": 0.08},
     "claude-3-opus-20240229": {"input": 15.0, "output": 75.0, "cached_input": 1.50},
+    # Anthropic — current families (added 2026-08-21). Undated keys so the prefix
+    # match catches dated ids and the ``[1m]`` context suffix alike.
+    "claude-fable-5": {"input": 10.0, "output": 50.0, "cached_input": 1.0},
+    "claude-opus-5": {"input": 5.0, "output": 25.0, "cached_input": 0.50},
+    "claude-opus-4-8": {"input": 5.0, "output": 25.0, "cached_input": 0.50},
+    "claude-opus-4-7": {"input": 5.0, "output": 25.0, "cached_input": 0.50},
+    "claude-opus-4-6": {"input": 5.0, "output": 25.0, "cached_input": 0.50},
+    "claude-opus-4-5": {"input": 5.0, "output": 25.0, "cached_input": 0.50},
+    "claude-sonnet-5": {"input": 2.0, "output": 10.0, "cached_input": 0.20},
+    "claude-sonnet-4-6": {"input": 3.0, "output": 15.0, "cached_input": 0.30},
+    "claude-sonnet-4-5": {"input": 3.0, "output": 15.0, "cached_input": 0.30},
+    "claude-haiku-4-5": {"input": 1.0, "output": 5.0, "cached_input": 0.10},
     # OpenAI
     "gpt-4o": {"input": 2.50, "output": 10.0},
     "gpt-4o-mini": {"input": 0.15, "output": 0.60},

--- a/tests/mutations/pydantic_ai_metering.json
+++ b/tests/mutations/pydantic_ai_metering.json
@@ -1,0 +1,105 @@
+[
+  {
+    "label": "the usage event goes silent again on a turn with no cache activity",
+    "file": "src/pocketpaw/agents/pydantic_ai.py",
+    "find": "        output = int(getattr(usage, \"output_tokens\", 0) or 0)\n\n        from pocketpaw.llm.caching import report_savings",
+    "replace": "        output = int(getattr(usage, \"output_tokens\", 0) or 0)\n        if not read and not write:\n            return None\n\n        from pocketpaw.llm.caching import report_savings",
+    "tests": [
+      "tests/test_pydantic_ai_backend.py::test_a_run_with_no_cache_activity_is_still_metered"
+    ]
+  },
+  {
+    "label": "the cost is computed from the uncached remainder — cached tokens subtracted twice",
+    "file": "src/pocketpaw/agents/pydantic_ai.py",
+    "find": "            estimated = _estimate_cost(model_name, total, output, read)",
+    "replace": "            estimated = _estimate_cost(model_name, max(0, total - read - write), output, read)",
+    "tests": [
+      "tests/test_pydantic_ai_backend.py::test_the_meter_prices_a_pydantic_ai_run_end_to_end"
+    ]
+  },
+  {
+    "label": "the model is taken from configuration instead of the response that answered",
+    "file": "src/pocketpaw/agents/pydantic_ai.py",
+    "find": "        model_name = getattr(response, \"model_name\", None)",
+    "replace": "        model_name = None",
+    "tests": [
+      "tests/test_pydantic_ai_backend.py::test_the_usage_event_carries_what_the_meter_actually_reads",
+      "tests/test_pydantic_ai_backend.py::test_the_meter_prices_a_pydantic_ai_run_end_to_end"
+    ]
+  },
+  {
+    "label": "total_cost_usd is dropped from the payload — the meter falls through to zero",
+    "file": "src/pocketpaw/agents/pydantic_ai.py",
+    "find": "                \"total_cost_usd\": cost,\n                \"model\": model_name,",
+    "replace": "                \"model\": model_name,",
+    "tests": [
+      "tests/test_pydantic_ai_backend.py::test_the_usage_event_carries_what_the_meter_actually_reads",
+      "tests/test_pydantic_ai_backend.py::test_the_meter_prices_a_pydantic_ai_run_end_to_end"
+    ]
+  },
+  {
+    "label": "output tokens are dropped — the half of a conversation that costs the most",
+    "file": "src/pocketpaw/agents/pydantic_ai.py",
+    "find": "                \"output_tokens\": output,\n                \"cached_input_tokens\": read,",
+    "replace": "                \"cached_input_tokens\": read,",
+    "tests": [
+      "tests/test_pydantic_ai_backend.py::test_the_usage_event_carries_what_the_meter_actually_reads",
+      "tests/test_pydantic_ai_backend.py::test_a_run_with_no_cache_activity_is_still_metered"
+    ]
+  },
+  {
+    "label": "cached_input_tokens is dropped — a cache hit is billed at the full input rate",
+    "file": "src/pocketpaw/agents/pydantic_ai.py",
+    "find": "                \"cached_input_tokens\": read,\n                \"cache_read_tokens\": savings.cache_read_tokens,",
+    "replace": "                \"cache_read_tokens\": savings.cache_read_tokens,",
+    "tests": [
+      "tests/test_pydantic_ai_backend.py::test_the_usage_event_carries_what_the_meter_actually_reads"
+    ]
+  },
+  {
+    "label": "an unpriced model raises instead of billing zero — one bad model stalls the sweep",
+    "file": "src/pocketpaw/agents/pydantic_ai.py",
+    "find": "            estimated = _estimate_cost(model_name, total, output, read)\n            if estimated:\n                cost = float(estimated)",
+    "replace": "            estimated = _estimate_cost(model_name, total, output, read)\n            cost = float(estimated)",
+    "tests": [
+      "tests/test_pydantic_ai_backend.py::test_an_unpriced_model_degrades_instead_of_raising"
+    ]
+  },
+  {
+    "label": "the uncached-remainder subtraction inverts — the cache A/B's hit rate inflates",
+    "file": "src/pocketpaw/agents/pydantic_ai.py",
+    "find": "                \"input_tokens\": max(0, total - read - write),\n                \"output_tokens\": output,",
+    "replace": "                \"input_tokens\": total,\n                \"output_tokens\": output,",
+    "tests": [
+      "tests/test_pydantic_ai_backend.py::test_usage_event_reports_uncached_remainder"
+    ]
+  },
+  {
+    "label": "the current Claude families leave the pricing table — every run bills zero again",
+    "file": "src/pocketpaw/usage_tracker.py",
+    "find": "    \"claude-haiku-4-5\": {\"input\": 1.0, \"output\": 5.0, \"cached_input\": 0.10},",
+    "replace": "",
+    "tests": [
+      "tests/test_usage_tracker.py::TestTheModelsWeActuallyRunArePriceable::test_every_model_in_use_has_a_price",
+      "tests/test_pydantic_ai_backend.py::test_the_meter_prices_a_pydantic_ai_run_end_to_end"
+    ]
+  },
+  {
+    "label": "the new families are inserted first — a bare 'claude' silently reprices to Opus",
+    "file": "src/pocketpaw/usage_tracker.py",
+    "find": "    # Anthropic\n    \"claude-sonnet-4-20250514\": {\"input\": 3.0, \"output\": 15.0, \"cached_input\": 0.30},",
+    "replace": "    # Anthropic\n    \"claude-opus-5\": {\"input\": 5.0, \"output\": 25.0, \"cached_input\": 0.50},\n    \"claude-sonnet-4-20250514\": {\"input\": 3.0, \"output\": 15.0, \"cached_input\": 0.30},",
+    "tests": [
+      "tests/test_usage_tracker.py::TestTheModelsWeActuallyRunArePriceable::test_a_bare_claude_still_resolves_where_it_always_did"
+    ]
+  },
+  {
+    "label": "the cache-hit rate is charged as full input — the 69% discount disappears",
+    "file": "src/pocketpaw/usage_tracker.py",
+    "find": "        + cached_input_tokens * pricing.get(\"cached_input\", pricing[\"input\"])",
+    "replace": "        + cached_input_tokens * pricing[\"input\"]",
+    "tests": [
+      "tests/test_usage_tracker.py::TestTheModelsWeActuallyRunArePriceable::test_a_cache_hit_is_cheaper_than_a_cold_read"
+    ]
+  }
+]

--- a/tests/mutations/pydantic_ai_metering.json
+++ b/tests/mutations/pydantic_ai_metering.json
@@ -14,6 +14,7 @@
     "find": "            estimated = _estimate_cost(model_name, total, output, read)",
     "replace": "            estimated = _estimate_cost(model_name, max(0, total - read - write), output, read)",
     "tests": [
+      "tests/test_pydantic_ai_backend.py::test_the_usage_event_carries_what_the_meter_actually_reads",
       "tests/test_pydantic_ai_backend.py::test_the_meter_prices_a_pydantic_ai_run_end_to_end"
     ]
   },

--- a/tests/test_pydantic_ai_backend.py
+++ b/tests/test_pydantic_ai_backend.py
@@ -1410,19 +1410,146 @@ def test_usage_event_reports_uncached_remainder():
     assert event.metadata["backend"] == "pydantic_ai"
 
 
-def test_usage_event_absent_when_no_cache_activity():
+def test_a_run_with_no_cache_activity_is_still_metered():
+    """This test used to assert the event was ABSENT, and that assertion was the
+    bug held in place.
+
+    ``_usage_event`` returned None unless the turn had cache reads or writes,
+    because it was written for the prompt-cache A/B rather than for metering. A
+    first turn on a cold cache therefore persisted ``usage: {}`` and swept
+    through ``bill_run`` at $0. Measured on the dev database 2026-08-21: 34 of
+    the 37 runs on this backend carried a partial payload and the rest carried
+    nothing, and not one of them was billable.
+    """
+
     class _Usage:
         input_tokens = 500
+        output_tokens = 120
         cache_read_tokens = 0
         cache_write_tokens = 0
 
-    class _Result:
-        usage = _Usage()
+    event = PydanticAIBackend(_settings())._usage_event(_event_for(_Usage()))
 
-    class _Event:
-        result = _Result()
+    assert event is not None
+    assert event.metadata["input_tokens"] == 500
+    assert event.metadata["output_tokens"] == 120
 
-    assert PydanticAIBackend(_settings())._usage_event(_Event()) is None
+
+def _event_for(usage, model_name="claude-haiku-4-5-20251001"):
+    """The shape ``_usage_event`` reads: ``event.result.usage`` for the counts and
+    ``event.result.response.model_name`` for the model that actually answered.
+
+    The model comes off the RESPONSE and not off configuration for the same
+    reason claude_sdk takes it from the CLI's own report — the configured spec
+    can be an alias, empty, or overridden per turn, and only the response says
+    which model priced the tokens.
+    """
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        result=SimpleNamespace(
+            usage=usage,
+            response=SimpleNamespace(model_name=model_name),
+        )
+    )
+
+
+def test_the_usage_event_carries_what_the_meter_actually_reads():
+    """``metering.resolve_cost`` needs a reported cost, or a model plus counts.
+
+    The payload carried neither: no ``model``, no ``output_tokens``, no
+    ``cached_input_tokens``, no ``total_cost_usd``. Four fields, and their
+    absence is why every conversation on this backend was free.
+    """
+
+    class _Usage:
+        input_tokens = 1000
+        output_tokens = 250
+        cache_read_tokens = 700
+        cache_write_tokens = 100
+
+    meta = PydanticAIBackend(_settings())._usage_event(_event_for(_Usage())).metadata
+
+    assert meta["model"] == "claude-haiku-4-5-20251001"
+    assert meta["output_tokens"] == 250
+    assert meta["cached_input_tokens"] == 700
+    assert meta["total_cost_usd"] > 0
+
+
+def test_the_meter_prices_a_pydantic_ai_run_end_to_end():
+    """The assertion that matters, and the only one that would have caught this.
+
+    Every other test here inspects the payload. This one hands the payload to
+    the function that bills it and asserts a real number comes back —
+    ``resolve_cost`` falling through to ``source="none"`` is exactly what
+    happened in production and it raises nothing.
+    """
+    from pocketpaw_ee.cloud.metering.service import resolve_cost
+
+    class _Usage:
+        input_tokens = 20_000
+        output_tokens = 800
+        cache_read_tokens = 15_000
+        cache_write_tokens = 0
+
+    meta = PydanticAIBackend(_settings())._usage_event(_event_for(_Usage())).metadata
+    cost = resolve_cost(meta)
+
+    assert cost.source != "none", "the meter could not price this run"
+    assert cost.model == "claude-haiku-4-5-20251001"
+    # The exact number, not just "> 0". Haiku 4.5 is $1/$5/$0.10 per MTok, so
+    # 5k uncached input + 800 output + 15k cache reads = 0.005 + 0.004 + 0.0015.
+    #
+    # ">0" would pass on the double-subtraction bug this guards: hand the
+    # estimator the uncached REMAINDER instead of the inclusive total and it
+    # subtracts the cached tokens a second time, yielding 0.0055 — still
+    # positive, still wrong by nearly half, and invisible to a truthiness check.
+    assert cost.cost_usd == pytest.approx(0.0105)
+
+
+def test_an_unpriced_model_degrades_instead_of_raising():
+    """A model missing from the pricing table must cost 0, not blow up a turn.
+
+    Metering runs in a background sweep; a raise here would stall the sweep for
+    every workspace, and a visitor's answer is worth more than its own invoice.
+    """
+
+    class _Usage:
+        input_tokens = 100
+        output_tokens = 10
+        cache_read_tokens = 0
+        cache_write_tokens = 0
+
+    meta = (
+        PydanticAIBackend(_settings())
+        ._usage_event(_event_for(_Usage(), model_name="nonesuch-model-9"))
+        .metadata
+    )
+
+    assert meta["model"] == "nonesuch-model-9"
+    assert meta["total_cost_usd"] == 0
+
+
+def test_a_missing_response_does_not_lose_the_token_counts():
+    """No response object (a failed or synthetic turn) still meters the tokens.
+
+    Losing the model costs us the price; losing the counts costs us the ability
+    to ever reconstruct it.
+    """
+    from types import SimpleNamespace
+
+    class _Usage:
+        input_tokens = 300
+        output_tokens = 40
+        cache_read_tokens = 0
+        cache_write_tokens = 0
+
+    event = SimpleNamespace(result=SimpleNamespace(usage=_Usage()))
+    meta = PydanticAIBackend(_settings())._usage_event(event).metadata
+
+    assert meta["input_tokens"] == 300
+    assert meta["output_tokens"] == 40
+    assert meta["model"] is None
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_pydantic_ai_backend.py
+++ b/tests/test_pydantic_ai_backend.py
@@ -1473,7 +1473,18 @@ def test_the_usage_event_carries_what_the_meter_actually_reads():
     assert meta["model"] == "claude-haiku-4-5-20251001"
     assert meta["output_tokens"] == 250
     assert meta["cached_input_tokens"] == 700
-    assert meta["total_cost_usd"] > 0
+
+    # The exact number, not just "> 0", and asserted HERE rather than only in the
+    # end-to-end test below, because this test carries no pocketpaw_ee import and
+    # so runs in the OSS-only CI job too. Haiku 4.5 is $1/$5/$0.10 per MTok:
+    # 300 uncached input + 250 output + 700 cache reads.
+    #
+    # ">0" would pass on the double-subtraction bug this guards. ``input_tokens``
+    # here is the INCLUSIVE 1000 and the estimator removes the cached portion
+    # itself; handing it the uncached remainder instead removes those tokens a
+    # second time, giving 0.00132 - still positive, still wrong, invisible to a
+    # truthiness check.
+    assert meta["total_cost_usd"] == pytest.approx(0.00162)
 
 
 def test_the_meter_prices_a_pydantic_ai_run_end_to_end():
@@ -1484,6 +1495,8 @@ def test_the_meter_prices_a_pydantic_ai_run_end_to_end():
     ``resolve_cost`` falling through to ``source="none"`` is exactly what
     happened in production and it raises nothing.
     """
+    pytest.importorskip("pocketpaw_ee", reason="pocketpaw-ee not installed")
+
     from pocketpaw_ee.cloud.metering.service import resolve_cost
 
     class _Usage:
@@ -1496,6 +1509,13 @@ def test_the_meter_prices_a_pydantic_ai_run_end_to_end():
     cost = resolve_cost(meta)
 
     assert cost.source != "none", "the meter could not price this run"
+    # "reported" and not "estimated": the payload now prices itself, so the meter
+    # takes the reported branch and never reaches its estimator. That is the
+    # point - the estimator expects an inclusive input_tokens while this payload
+    # carries the uncached remainder, and only pricing upstream avoids the
+    # mismatch. If this ever flips to "estimated", the cost is being computed
+    # from the wrong number.
+    assert cost.source == "reported"
     assert cost.model == "claude-haiku-4-5-20251001"
     # The exact number, not just "> 0". Haiku 4.5 is $1/$5/$0.10 per MTok, so
     # 5k uncached input + 800 output + 15k cache reads = 0.005 + 0.004 + 0.0015.

--- a/tests/test_usage_tracker.py
+++ b/tests/test_usage_tracker.py
@@ -207,3 +207,89 @@ class TestEstimateCost:
         # 0 fresh input, 1M cached, 0 output → 0.30 USD
         cost = _estimate_cost("claude-3-5-sonnet-20241022", 0, 0, cached_input_tokens=1_000_000)
         assert cost == pytest.approx(0.30, rel=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# The pricing table has to keep up with the models
+# ---------------------------------------------------------------------------
+
+
+class TestTheModelsWeActuallyRunArePriceable:
+    """A model missing from ``_PRICING`` estimates to None, which
+    ``metering.resolve_cost`` turns into a $0 bill and no error.
+
+    That silence is deliberate — a run must not die over its own invoice — and it
+    is why nobody noticed the table had stopped at the mid-2025 ids while every
+    model in production moved on. Measured on the dev database 2026-08-21:
+    claude-haiku-4-5-20251001, claude-sonnet-4-6 and claude-opus-4-7 all priced
+    to None, so every run on the pydantic_ai backend billed nothing. The
+    claude_agent_sdk path never surfaced it because the SDK reports its own cost
+    and never consults this table.
+
+    These are model ids observed in real run documents, not invented ones. When a
+    new family ships, it goes in the list and in the table.
+    """
+
+    OBSERVED = [
+        "claude-haiku-4-5-20251001",  # seen in chat_runs, 32 runs
+        "claude-opus-4-7[1m]",  # seen in chat_runs — note the context suffix
+        "claude-sonnet-4-6",
+        "claude-opus-5",
+        "claude-sonnet-5",
+        "claude-fable-5",
+    ]
+
+    @pytest.mark.parametrize("model", OBSERVED)
+    def test_every_model_in_use_has_a_price(self, model):
+        from pocketpaw.usage_tracker import _estimate_cost
+
+        assert _estimate_cost(model, 10_000, 500, 0) is not None, (
+            f"{model} is not in _PRICING — every run on it bills $0 silently"
+        )
+
+    @pytest.mark.parametrize("model", OBSERVED)
+    def test_a_cache_hit_is_cheaper_than_a_cold_read(self, model):
+        """The cached rate has to actually be applied, not silently fall back to
+        the full input price. At a 69% hit rate — what the dev database shows —
+        getting this wrong overstates the bill by roughly half."""
+        from pocketpaw.usage_tracker import _estimate_cost
+
+        cold = _estimate_cost(model, 10_000, 500, 0)
+        warm = _estimate_cost(model, 10_000, 500, 9_000)
+
+        assert warm < cold
+
+    def test_a_bare_claude_still_resolves_where_it_always_did(self):
+        """``"claude"`` is the agentapi fallback name and prefix-matches the FIRST
+        claude key in insertion order.
+
+        Adding the current families ahead of the older ones would have silently
+        repriced every run that reported it — Opus rates instead of Sonnet, a 66%
+        jump. The new entries go after the old ones for exactly this reason, and
+        this pins it.
+        """
+        from pocketpaw.usage_tracker import _PRICING, _estimate_cost
+
+        assert _estimate_cost("claude", 10_000, 500, 0) == _estimate_cost(
+            "claude-sonnet-4-20250514", 10_000, 500, 0
+        )
+        assert "claude-sonnet-4-20250514" in _PRICING
+
+    def test_a_retired_id_keeps_its_own_retired_price(self):
+        """Opus 4 and Opus 4.5+ are $15 and $5 per MTok respectively. A prefix
+        match that let one shadow the other would misprice by 3x in whichever
+        direction insertion order happened to fall."""
+        from pocketpaw.usage_tracker import _estimate_cost
+
+        retired = _estimate_cost("claude-opus-4-20250514", 1_000_000, 0, 0)
+        current = _estimate_cost("claude-opus-4-7", 1_000_000, 0, 0)
+
+        assert retired == 15.0
+        assert current == 5.0
+
+    def test_an_unknown_model_is_still_none(self):
+        """The fallback stays a fallback. Prefix matching must not start pricing
+        arbitrary strings just because the table grew."""
+        from pocketpaw.usage_tracker import _estimate_cost
+
+        assert _estimate_cost("some-other-vendor-model", 1000, 100, 0) is None


### PR DESCRIPTION
Conversations run on the `pydantic_ai` backend. **Every one of them has been billing zero.**

## Two bugs, and the first one alone wasn't the whole story

**The payload was built for the wrong job.** `_usage_event` was written for the prompt-cache A/B and carried what that needed: cache read/write counts, a hit rate, the uncached remainder. `metering.resolve_cost` needs a reported cost, *or* a model plus token counts. The payload had **no `model`, no `output_tokens`, no `cached_input_tokens`, no `total_cost_usd`** — precisely the set that function looks for — so it fell through to `source="none"` and billed $0. Worse, it returned `None` outright when a turn had no cache activity, so a cold first turn persisted `usage: {}` with nothing to bill at all.

Measured on the dev database, 2026-08-21:

| Kind | Backend | model | output_tokens | total_cost_usd | n |
|---|---|---|---|---|---|
| other | `claude_agent_sdk` | ✅ | ✅ | ✅ | 84 |
| other | `pydantic_ai` | ❌ | ❌ | ❌ | 34 |
| concierge | `pydantic_ai` | ❌ | ❌ | ❌ | 3 |

37 of 121 metered runs, none billable, the visitor concierge among them. That is why the concierge cost couldn't be measured yesterday, and it would still have been unmeasurable after a month of real traffic.

**Fixing the payload wasn't enough.** The pricing table stops at the mid-2025 ids:

```
claude-haiku-4-5-20251001  -> None
claude-sonnet-4-6          -> None
claude-opus-4-7            -> None
```

Every model actually in production estimated to `None`, so the corrected payload still produced $0. `claude_agent_sdk` never surfaced either bug for the same reason: the SDK reports its own cost and never consults the table. Rates added from [Anthropic's pricing page](https://platform.claude.com/docs/en/about-claude/pricing), read 2026-08-21.

## Three details that are load-bearing

**The model comes off the response, not configuration.** The configured spec can be an alias, empty, or overridden per turn; only the response says which model actually priced these tokens. Same reason `claude_sdk` takes it from the CLI's own report.

**The cost is computed where the inclusive input total is still in scope.** `resolve_cost`'s estimator does `max(0, input_tokens - cached_input_tokens)`, so it expects an *inclusive* input, while every Anthropic-shaped payload in this codebase reports the *uncached remainder*. Letting the meter estimate would subtract the cached tokens a second time. On the test case that's $0.0055 instead of $0.0105: still positive, wrong by nearly half, and invisible to a `> 0` check. The end-to-end test pins the exact number for that reason.

**The new pricing keys go after the old ones.** A bare `"claude"` (the agentapi fallback name, and what 47 runs in the database actually reported) prefix-matches the *first* claude key in insertion order. Inserting the current families ahead of the older ones would silently reprice every one of those runs from Sonnet to Opus rates, a 66% jump. There's a test pinning it, and a mutation that moves an entry to the front to prove the test bites.

## Tests first

Five written against the merged code, five failing, including the one that mattered:

```
FAILED test_the_meter_prices_a_pydantic_ai_run_end_to_end
  AssertionError: the meter could not price this run
```

**One existing test asserted the bug.** `test_usage_event_absent_when_no_cache_activity` pinned "no cache activity → no event" in place. It's now `test_a_run_with_no_cache_activity_is_still_metered` and asserts the opposite.

New coverage in `tests/test_usage_tracker.py` for the table itself: every model id observed in real run documents must price, a cache hit must be cheaper than a cold read, a retired Opus 4 keeps its $15 rate while Opus 4.7 gets $5, and an unknown vendor's model still returns `None` so prefix matching doesn't start pricing arbitrary strings.

## Mutations

`tests/mutations/pydantic_ai_metering.json` has 11, all caught. Worth naming: the double-subtraction, dropping `total_cost_usd`, dropping `output_tokens`, an unpriced model raising instead of billing zero (metering runs in a background sweep, so a raise stalls it for every workspace), removing the new families from the table, and reordering them to the front.

One of them escaped on the first run, and the escape was the useful part: my "reorder the table" mutation swapped two entries that both sit after the old block, so nothing about the `"claude"` lookup changed. Rewritten to move an entry ahead of the old block, which is the only arrangement that reproduces the harm.

## What this unblocks

Concierge conversations start carrying a real cost. After some traffic, the `staff` allowance can be set from the ledger instead of from anyone's estimate. See `2026-08-21-paw-sites-pricing-revision.md` in paw-workspace.

Cache **write** tokens are still priced as ordinary input, which slightly undercounts; Anthropic bills them at 1.25×/2×. The estimator has no column for it. Named in the code rather than absorbed silently.
