### PR TITLE
Editing a paid site charged the customer for a second one

### DIFF
--- a/ee/pocketpaw_ee/cloud/billing/providers/base.py
+++ b/ee/pocketpaw_ee/cloud/billing/providers/base.py
@@ -127,3 +127,23 @@ class IPaymentsProvider(ABC):
         webhook, NOT here, so this method only tells the gateway to stop billing.
         """
         raise NotImplementedError
+
+    @abstractmethod
+    async def change_plan(self, *, subscription_id: str, product_id: str, plan_key: str) -> None:
+        """Move an EXISTING gateway subscription onto a different product.
+
+        The alternative — cancel the old subscription and create a new one — is
+        wrong in both directions for a term subscription: the buyer forfeits the
+        remainder of a period they already paid for, and if the new checkout is
+        abandoned after the old sub is cancelled they are left on nothing. This is
+        the atomic move, with the gateway handling proration.
+
+        ``subscription_id`` MUST be the authoritative gateway subscription id, not
+        a checkout SESSION id — a session id names a checkout, not a subscription,
+        and the gateway will reject it.
+
+        Returns None; success is the absence of an exception. Callers persist the
+        new tier THEMSELVES on return — the resulting ``plan_changed`` webhook is
+        acked without action, so nothing else will record it.
+        """
+        raise NotImplementedError

--- a/ee/pocketpaw_ee/cloud/billing/providers/dodo.py
+++ b/ee/pocketpaw_ee/cloud/billing/providers/dodo.py
@@ -359,6 +359,31 @@ class DodoProvider:
         client = self._client()
         await client.subscriptions.update(subscription_id, status="cancelled")
 
+    async def change_plan(self, *, subscription_id: str, product_id: str, plan_key: str) -> None:
+        if not subscription_id:
+            raise ValidationError("billing.invalid_subscription", "subscription_id is required")
+        if not product_id:
+            raise ValidationError(
+                "billing.plan_product_unconfigured",
+                f"No Dodo product is configured for plan '{plan_key}'.",
+            )
+        client = self._client()
+        # ``quantity`` is REQUIRED by the SDK even for a plain one-seat plan.
+        #
+        # ``difference_immediately`` charges (or credits) only the delta between
+        # the two plans for the remainder of the current term, which is the whole
+        # reason to use this over cancel-then-create: the buyer keeps the time they
+        # already paid for. ``prevent_change`` means a declined card leaves the
+        # subscription on its CURRENT plan rather than moving it and then failing —
+        # the caller's persisted tier and the gateway's stay in agreement.
+        await client.subscriptions.change_plan(
+            subscription_id,
+            product_id=product_id,
+            quantity=1,
+            proration_billing_mode="difference_immediately",
+            on_payment_failure="prevent_change",
+        )
+
     # ------------------------------------------------------------------ #
     # Webhook
     # ------------------------------------------------------------------ #

--- a/ee/pocketpaw_ee/cloud/billing/service.py
+++ b/ee/pocketpaw_ee/cloud/billing/service.py
@@ -800,6 +800,12 @@ async def _handle_site_subscription_event(event: SubscriptionEvent) -> dict:
             await sites_service.activate_site(
                 workspace_id=event.workspace_id,
                 site_id=event.site_id,
+                # The authoritative gateway subscription id. Dodo creates the
+                # subscription at payment time, so this is the FIRST delivery that
+                # carries it — the site is still holding the ``cks_`` checkout
+                # session id until we hand it over. Without it nothing downstream
+                # can cancel or change the plan.
+                subscription_id=event.subscription_id or None,
             )
             status = "active"
         elif event.type == _SUB_RENEWED:

--- a/ee/pocketpaw_ee/sites/router.py
+++ b/ee/pocketpaw_ee/sites/router.py
@@ -260,6 +260,11 @@ async def publish_site(
         pocket_id=body.pocket_id,
         site_plan_key=body.site_plan_key,
         prewarm_origin=request.headers.get("origin") or None,
+        # Also the checkout's return base for a PAID publish. The frontend sends the
+        # whole page to ``checkout_url``, so with no return_url the buyer pays and
+        # has no route back into the app. Falls back to the
+        # ``dodo_checkout_return_base`` config inside the service when absent.
+        origin=request.headers.get("origin") or None,
     )
     return sites_service._to_response(doc)
 

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -4667,6 +4667,9 @@ async def publish_pocket(
     site_plan_key: str | None = None,
     builder_origin: str | None = None,
     prewarm_origin: str | None = None,
+    # The buyer's app origin (the router reads it off the Origin / Referer header),
+    # used to build the checkout's return_url so a paid publish can send them back.
+    origin: str | None = None,
     preview: bool = False,
     _generator: GeneratorClient | None = None,
     _cloudflare: Any | None = None,
@@ -4829,8 +4832,53 @@ async def publish_pocket(
             tier.key if tier is not None else site_plan_key,
         )
 
-    if is_paid and dodo_configured:
-        # PAID + chargeable → defer the deploy until subscription.active.
+    # Is this site ALREADY paying? A republish of a live paid site is a content
+    # edit, not a purchase, and the charge-first branch below used to treat the two
+    # identically: it re-ran ``create_subscription`` on every republish, opening a
+    # SECOND subscription that billed alongside the first (which was never
+    # cancelled, and whose id had just been overwritten with the new checkout
+    # session id, so nothing could ever cancel it). It also reset the status to
+    # "pending" — read as unpaid by every entitlement — and withheld the new content
+    # until a second payment that no honest customer would make.
+    #
+    # Gate on "active" specifically, not on "has a subscription_id": a site that is
+    # still PENDING has never been paid for, so a republish there SHOULD open a
+    # fresh checkout (the abandoned session simply expires unused).
+    existing_doc = await _SiteDoc.find_one(
+        {"_id": _live_object_id(workspace_id, pocket_id), "workspace": workspace_id}
+    )
+    already_paying = (
+        existing_doc is not None
+        and existing_doc.subscription_status == "active"
+        and bool(existing_doc.subscription_id)
+    )
+
+    if already_paying and is_paid and dodo_configured and existing_doc.plan_tier != tier.key:
+        # A genuine TIER CHANGE on a paying site. Move the existing subscription
+        # rather than buying a second one; the gateway prorates, so the buyer keeps
+        # the term they already paid for. Cancel-then-create would forfeit it.
+        #
+        # Deliberately NOT wrapped in a try/except that falls back to
+        # ``create_subscription``: that fallback is precisely the double-billing
+        # this branch exists to remove. A gateway refusal propagates, the site keeps
+        # the tier it is actually paying for, and the caller sees the error.
+        prov = _billing_provider or _default_billing_provider()
+        await prov.change_plan(
+            subscription_id=existing_doc.subscription_id,
+            product_id=tier.dodo_product_id,
+            plan_key=tier.key,
+        )
+        logger.info(
+            "sites.publish: site %s moved %s → %s on subscription %s (no new checkout)",
+            str(existing_doc.id),
+            existing_doc.plan_tier,
+            tier.key,
+            existing_doc.subscription_id,
+        )
+
+    if is_paid and dodo_configured and not already_paying:
+        # PAID + chargeable + not yet paying → defer the deploy until
+        # subscription.active.
         return await _publish_pending_site(
             workspace_id=workspace_id,
             user_id=user_id,
@@ -4845,6 +4893,7 @@ async def publish_pocket(
             keeps_client_bundle=keeps_client_bundle,
             tier=tier,
             provider=_billing_provider,
+            origin=origin,
         )
 
     # FREE/base (or paid-but-unconfigured fallback) → publish LIVE now.
@@ -4997,7 +5046,25 @@ async def _apply_site_plan(
     # recurring product. metadata.site_id is the per-site discriminator the
     # webhook routes on. No product configured (v1 default) → record the tier
     # without a live charge; never crash the publish.
-    if tier is not None and tier.dodo_product_id:
+    # A site that is ALREADY paying must not be charged again by the stamp path.
+    #
+    # This guard is here and not only in the caller on purpose. Until the republish
+    # fix, a paid+configured tier could never REACH this function — the dispatcher
+    # always routed it to ``_publish_pending_site`` — so the branch below was
+    # effectively dead for paying sites. Routing same-tier republishes through the
+    # live path is what arms it, and without this check it would open a fresh
+    # checkout, take the ``if subscription_id`` arm of the stamp below, overwrite
+    # the authoritative gateway id with a checkout session id, and knock the status
+    # back to "pending". That is the whole defect, reintroduced one layer down.
+    #
+    # With no new checkout, ``subscription_id`` stays None and the stamp falls to
+    # the ``elif`` — whose existing ``!= "active"`` carve-out then preserves both
+    # the id and the status untouched.
+    already_paying = (
+        getattr(doc, "subscription_status", None) == "active"
+        and bool(getattr(doc, "subscription_id", None))
+    )
+    if tier is not None and tier.dodo_product_id and not already_paying:
         try:
             prov = provider or _default_billing_provider()
             checkout = await prov.create_subscription(
@@ -5057,6 +5124,29 @@ async def _apply_site_plan(
     return doc
 
 
+def _site_checkout_return_urls(origin: str | None) -> tuple[str | None, str | None]:
+    """Build (return_url, cancel_url) for a per-site checkout, or (None, None).
+
+    The frontend navigates the WHOLE PAGE to the checkout url
+    (``window.location.href = site.checkout_url``), so without these the buyer pays
+    and is left sitting on the gateway with no route back into the app.
+
+    Deliberately not ``billing._checkout_return_urls``: that one lands the buyer on
+    ``/settings/billing``, which is right for a workspace plan and wrong here — the
+    buyer just bought a SITE and expects to see it. Same origin/config fallback
+    chain, different destination.
+    """
+    base = (origin or "").strip()
+    if not base:
+        from pocketpaw.config import get_settings
+
+        base = (getattr(get_settings(), "dodo_checkout_return_base", "") or "").strip()
+    if not base:
+        return None, None
+    base = base.rstrip("/")
+    return (f"{base}/sites?checkout=success", f"{base}/sites?checkout=cancel")
+
+
 async def _publish_pending_site(
     *,
     workspace_id: str,
@@ -5072,6 +5162,7 @@ async def _publish_pending_site(
     keeps_client_bundle: bool,
     tier: Any,
     provider: Any | None,
+    origin: str | None = None,
 ) -> _SiteDoc:
     """Charge-first: create a PAID-tier site as PENDING and open its checkout,
     WITHOUT deploying it live.
@@ -5171,6 +5262,7 @@ async def _publish_pending_site(
     # raises, it PROPAGATES (no swallow) and NO pending doc is created — never an
     # orphan pending row with no subscription_id. The buyer can simply retry.
     prov = provider or _default_billing_provider()
+    return_url, cancel_url = _site_checkout_return_urls(origin)
     checkout = await prov.create_subscription(
         plan_key=plan_key,
         product_id=tier.dodo_product_id,
@@ -5181,6 +5273,8 @@ async def _publish_pending_site(
             "site_id": site_id,
             "plan_key": plan_key,
         },
+        return_url=return_url,
+        cancel_url=cancel_url,
     )
     checkout_url: str | None = checkout.checkout_url or None
     subscription_id: str | None = checkout.subscription_id or None
@@ -5231,6 +5325,7 @@ async def activate_site(
     *,
     workspace_id: str,
     site_id: str,
+    subscription_id: str | None = None,
     _generator: GeneratorClient | None = None,
     _cloudflare: Any | None = None,
     _bundle_reader: Callable[[str], bytes] = _default_bundle_reader,
@@ -5311,6 +5406,21 @@ async def activate_site(
     # opposite direction, and it is the lesser of the two: a paid site that retries
     # its deploy beats a paid site permanently branded as free.
     doc.subscription_status = "active"
+    # Persist the AUTHORITATIVE gateway subscription id from the verified webhook.
+    #
+    # What the doc holds until this point is the checkout SESSION id (``cks_``)
+    # that ``create_subscription`` returned — Dodo creates the subscription at
+    # PAYMENT time, so the real ``sub_`` id does not exist yet when the checkout
+    # opens. It arrives here, on subscription.active, and was previously dropped on
+    # the floor: the webhook called this function without it.
+    #
+    # A session id cannot cancel a subscription and cannot change its plan — the
+    # gateway rejects it. So every downstream lifecycle operation was unbuildable
+    # until this line existed, and any subscription opened before it shipped is
+    # unreachable from our side. ``mark_site_subscription`` already does the same
+    # thing on renewed/cancelled; activation was the gap.
+    if subscription_id:
+        doc.subscription_id = subscription_id
     await doc.save()
 
     deployed = await _deploy_site_doc(

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -5060,9 +5060,8 @@ async def _apply_site_plan(
     # With no new checkout, ``subscription_id`` stays None and the stamp falls to
     # the ``elif`` — whose existing ``!= "active"`` carve-out then preserves both
     # the id and the status untouched.
-    already_paying = (
-        getattr(doc, "subscription_status", None) == "active"
-        and bool(getattr(doc, "subscription_id", None))
+    already_paying = getattr(doc, "subscription_status", None) == "active" and bool(
+        getattr(doc, "subscription_id", None)
     )
     if tier is not None and tier.dodo_product_id and not already_paying:
         try:

--- a/tests/cloud/billing/test_change_plan_provider.py
+++ b/tests/cloud/billing/test_change_plan_provider.py
@@ -1,0 +1,106 @@
+# tests/cloud/billing/test_change_plan_provider.py — proves the DodoProvider's
+# change_plan wrapper sends the parameters that make an in-place plan move safe.
+#
+# change_plan exists so a paying site can move tiers without cancel-then-create.
+# The two SDK arguments that make that true are easy to get wrong and impossible
+# to notice afterwards, because the SDK returns None either way and the harm shows
+# up on a customer's card rather than in a log:
+#
+#   * ``proration_billing_mode`` — "difference_immediately" charges only the delta
+#     for the remainder of the term. "full_immediately" bills a whole new term and
+#     the buyer silently forfeits the one they already paid for. Both succeed.
+#   * ``on_payment_failure`` — "prevent_change" leaves a declined card on the OLD
+#     plan, which is the only setting that keeps the gateway and our persisted
+#     plan_tier in agreement (the caller writes the new tier on return, and the
+#     resulting plan_changed webhook is acked without action, so nothing reconciles
+#     a disagreement later).
+#
+# Created 2026-08-22 (fix/site-republish-double-billing): new test module.
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import ValidationError
+from pocketpaw_ee.cloud.billing.providers.dodo import DodoProvider
+
+SUB_ID = "sub_real_gateway_id"
+
+
+def _provider() -> DodoProvider:
+    return DodoProvider(
+        api_key="dodo_test_key",
+        environment="test_mode",
+        webhook_secret=None,
+        credit_product_id="prod_credits_sku",
+        plan_products={},
+    )
+
+
+def _fake_sdk(monkeypatch) -> MagicMock:
+    """Swap the async Dodo client for a mock so nothing touches the network."""
+    client = MagicMock()
+    client.subscriptions.change_plan = AsyncMock(return_value=None)
+
+    import pocketpaw_ee.cloud.billing.providers.dodo as dodo_mod
+
+    monkeypatch.setattr(dodo_mod, "AsyncDodoPayments", MagicMock(return_value=client))
+    return client
+
+
+async def test_the_plan_change_prorates_the_difference(monkeypatch):
+    """Only the delta for the remaining term, never a fresh full term."""
+    client = _fake_sdk(monkeypatch)
+
+    await _provider().change_plan(
+        subscription_id=SUB_ID, product_id="prod_site_business", plan_key="business"
+    )
+
+    args, kwargs = client.subscriptions.change_plan.call_args
+    assert args[0] == SUB_ID
+    assert kwargs["product_id"] == "prod_site_business"
+    assert kwargs["proration_billing_mode"] == "difference_immediately", (
+        "a full re-bill makes the buyer forfeit the term they already paid for — "
+        "the whole reason this exists instead of cancel-then-create"
+    )
+    # Required by the SDK even for a plain one-seat plan; omitting it raises.
+    assert kwargs["quantity"] == 1
+
+
+async def test_a_declined_card_leaves_the_plan_where_it_was(monkeypatch):
+    """The caller persists the new tier when this returns. If a declined card
+    still moved the plan at the gateway, our record and theirs would disagree with
+    nothing to reconcile them — the plan_changed webhook is acked without action."""
+    client = _fake_sdk(monkeypatch)
+
+    await _provider().change_plan(
+        subscription_id=SUB_ID, product_id="prod_site_business", plan_key="business"
+    )
+
+    _, kwargs = client.subscriptions.change_plan.call_args
+    assert kwargs["on_payment_failure"] == "prevent_change"
+
+
+async def test_an_empty_subscription_id_never_reaches_the_gateway(monkeypatch):
+    """A missing id means the caller had only a checkout session, or nothing at
+    all. Fail here with a named error rather than let the gateway reject it."""
+    client = _fake_sdk(monkeypatch)
+
+    with pytest.raises(ValidationError):
+        await _provider().change_plan(
+            subscription_id="", product_id="prod_site_business", plan_key="business"
+        )
+
+    client.subscriptions.change_plan.assert_not_called()
+
+
+async def test_an_unconfigured_product_never_reaches_the_gateway(monkeypatch):
+    """Mirrors create_subscription: an unconfigured tier is a configuration error
+    with a name, not an opaque gateway 4xx."""
+    client = _fake_sdk(monkeypatch)
+
+    with pytest.raises(ValidationError):
+        await _provider().change_plan(subscription_id=SUB_ID, product_id="", plan_key="business")
+
+    client.subscriptions.change_plan.assert_not_called()

--- a/tests/cloud/sites/test_billing_lifecycle.py
+++ b/tests/cloud/sites/test_billing_lifecycle.py
@@ -73,7 +73,15 @@ class _RecordingBillingProvider:
         self.calls: list[dict] = []
 
     async def create_subscription(
-        self, *, plan_key, product_id, workspace_id, customer_email, metadata
+        self,
+        *,
+        plan_key,
+        product_id,
+        workspace_id,
+        customer_email,
+        metadata,
+        return_url=None,
+        cancel_url=None,
     ) -> SubscriptionCheckout:
         self.calls.append({"metadata": dict(metadata)})
         return SubscriptionCheckout(

--- a/tests/cloud/sites/test_charge_first.py
+++ b/tests/cloud/sites/test_charge_first.py
@@ -75,7 +75,15 @@ class _RecordingBillingProvider:
         self.calls: list[dict] = []
 
     async def create_subscription(
-        self, *, plan_key, product_id, workspace_id, customer_email, metadata
+        self,
+        *,
+        plan_key,
+        product_id,
+        workspace_id,
+        customer_email,
+        metadata,
+        return_url=None,
+        cancel_url=None,
     ) -> SubscriptionCheckout:
         self.calls.append(
             {

--- a/tests/cloud/sites/test_charge_first.py
+++ b/tests/cloud/sites/test_charge_first.py
@@ -451,7 +451,12 @@ async def test_paid_tier_without_dodo_product_publishes_live(mongo_db):
     assert doc.deployed is True
     assert len(gen.build_calls) == 1
     assert cf.put_calls == [str(doc.id)]
-    assert doc.plan_tier == "pro"
+    # Records the FLOOR, not "pro" (#1995). A priced tier with no Dodo product
+    # cannot be bought, and stamping it anyway wrote a claim the site could not
+    # back: plan_tier="pro" with subscription_status="none", which every
+    # entitlement resolves as free. The buyer picked a paid plan, was charged
+    # nothing, received nothing, and the plan card said pro.
+    assert doc.plan_tier == site_plans.BASE_SITE_PLAN_KEY
     assert doc.subscription_id is None  # no charge opened
     assert getattr(doc, "_checkout_url", None) is None
     assert sites_service._to_response(doc).checkout_url is None

--- a/tests/cloud/sites/test_keeps_client_bundle_publish.py
+++ b/tests/cloud/sites/test_keeps_client_bundle_publish.py
@@ -82,7 +82,15 @@ class _RecordingBillingProvider:
         self.calls: list[dict] = []
 
     async def create_subscription(
-        self, *, plan_key, product_id, workspace_id, customer_email, metadata
+        self,
+        *,
+        plan_key,
+        product_id,
+        workspace_id,
+        customer_email,
+        metadata,
+        return_url=None,
+        cancel_url=None,
     ) -> SubscriptionCheckout:
         self.calls.append({"metadata": dict(metadata)})
         return SubscriptionCheckout(checkout_url=CHECKOUT_URL, subscription_id=SITE_SUB_ID)

--- a/tests/cloud/sites/test_republish_double_billing.py
+++ b/tests/cloud/sites/test_republish_double_billing.py
@@ -336,6 +336,49 @@ async def test_republishing_a_paying_site_keeps_its_paid_status_and_goes_live(
     assert doc._checkout_url is None
 
 
+async def test_republishing_a_site_that_never_paid_still_opens_a_checkout(
+    mongo_db, recording_bus, monkeypatch
+):
+    """The guard keys on "active", not on "has a subscription_id" — and it has to.
+
+    A site published on a paid tier but never paid for sits PENDING holding the
+    checkout SESSION id of an abandoned checkout. If that counted as "already
+    paying", the republish would skip billing entirely and the buyer would be left
+    with a site they cannot pay for and that never goes live: the deploy waits on a
+    subscription.active that no unpaid checkout will ever produce.
+
+    Opening a fresh checkout is correct here. The abandoned session simply expires.
+    """
+    _configure_products(monkeypatch, {"pro": "prod_site_pro"})
+    ws = await _make_workspace()
+    pocket_id = await _make_pocket(workspace_id=ws)
+    provider = _RecordingBillingProvider()
+
+    async def _publish():
+        return await sites_service.publish_pocket(
+            workspace_id=ws,
+            user_id="u1",
+            pocket_id=pocket_id,
+            site_plan_key="pro",
+            _generator=_RecordingGenerator(),
+            _cloudflare=_RecordingCF(),
+            _bundle_reader=lambda d: b"x",
+            _billing_provider=provider,
+        )
+
+    first = await _publish()
+    assert first.subscription_status == "pending"  # published, never paid
+
+    second = await _publish()
+
+    assert len(provider.calls) == 2, (
+        "a site that never paid was treated as already paying — it can now neither pay nor go live"
+    )
+    assert second.subscription_status == "pending"
+    assert second.deployed is False
+    assert second._checkout_url == CHECKOUT_URL
+
+
 # ---------------------------------------------------------------------------
 # A real tier change is a plan change, not a second purchase.
 # ---------------------------------------------------------------------------
@@ -350,9 +393,7 @@ async def test_moving_a_paying_site_to_another_tier_changes_the_plan(
     term they already paid for; a second create bills them twice. The gateway's
     atomic plan change is the only option that does neither.
     """
-    _configure_products(
-        monkeypatch, {"pro": "prod_site_pro", "business": "prod_site_business"}
-    )
+    _configure_products(monkeypatch, {"pro": "prod_site_pro", "business": "prod_site_business"})
     ws = await _make_workspace()
     pocket_id = await _make_pocket(workspace_id=ws)
     provider = _RecordingBillingProvider()
@@ -390,9 +431,7 @@ async def test_a_failed_plan_change_leaves_the_subscription_alone(
 ):
     """When the gateway refuses the change, the site keeps the tier it is paying
     for — and we never 'recover' by opening a second subscription."""
-    _configure_products(
-        monkeypatch, {"pro": "prod_site_pro", "business": "prod_site_business"}
-    )
+    _configure_products(monkeypatch, {"pro": "prod_site_pro", "business": "prod_site_business"})
     ws = await _make_workspace()
     pocket_id = await _make_pocket(workspace_id=ws)
 

--- a/tests/cloud/sites/test_republish_double_billing.py
+++ b/tests/cloud/sites/test_republish_double_billing.py
@@ -1,0 +1,456 @@
+# tests/cloud/sites/test_republish_double_billing.py — proves that republishing a
+# site that is ALREADY paying does not charge the customer a second time.
+#
+# The defect (found 2026-08-22, fix/site-republish-double-billing): the charge-first
+# dispatcher branched on the TIER alone — "paid tier + configured Dodo product →
+# open a checkout" — with no regard for whether this site already held an active
+# subscription. So every republish of a paid site (a content edit, a re-deploy, a
+# rename) ran ``create_subscription`` again:
+#
+#   * a SECOND Dodo subscription started billing, and the first was never cancelled;
+#   * ``doc.subscription_id`` was overwritten with the new checkout SESSION id, so
+#     the original subscription became unreachable — no later cancel could ever name
+#     it, and it would bill until the customer disputed the charge;
+#   * ``doc.subscription_status`` flipped to "pending", which every entitlement
+#     resolves as unpaid — so a paying customer's custom domain started returning
+#     402 and their concierge disappeared, mid-subscription;
+#   * and the new content did not go live until the buyer paid AGAIN, because the
+#     deploy was deferred to a ``subscription.active`` that only a second payment
+#     could produce.
+#
+# Underneath all of that sat a quieter root cause: ``activate_site`` was never given
+# the ``subscription_id`` off the verified webhook, so the site doc kept the ``cks_``
+# CHECKOUT SESSION id forever. The authoritative ``sub_`` id — the only handle that
+# can cancel or change a plan at the gateway — was received and thrown away. Nothing
+# downstream could have been built without fixing that first.
+#
+# Created 2026-08-22 (fix/site-republish-double-billing): new test module.
+
+from __future__ import annotations
+
+import base64
+import json
+from datetime import UTC, datetime
+
+import pytest
+from pocketpaw_ee.cloud.billing import service as billing
+from pocketpaw_ee.cloud.billing import site_plans
+from pocketpaw_ee.cloud.billing.domain import SubscriptionCheckout
+from pocketpaw_ee.cloud.billing.providers.dodo import DodoProvider
+from pocketpaw_ee.cloud.models.site import Site
+from pocketpaw_ee.sites import service as sites_service
+from standardwebhooks import Webhook
+
+SECRET = "whsec_" + base64.b64encode(b"republish-billing-secret-32byte!").decode()
+
+# The two ids are DELIBERATELY different. ``create_subscription`` returns a checkout
+# SESSION id (``cks_``); the authoritative gateway subscription id (``sub_``) only
+# arrives later on the verified subscription.active webhook. Tests that use one
+# value for both cannot tell whether activation persisted the real one.
+SESSION_ID = "cks_site_checkout_session"
+GATEWAY_SUB_ID = "sub_site_real_gateway_id"
+CHECKOUT_URL = "https://checkout.dodopayments.test/site/republish"
+
+
+class _RecordingGenerator:
+    def __init__(self):
+        self.build_calls: list[dict] = []
+
+    async def build(self, **kw):
+        from pocketpaw_ee.sites.generator_client import BuildResult
+
+        self.build_calls.append(dict(kw))
+        return BuildResult(project_dir="/tmp/site", ripple_version="0.2.0")
+
+
+class _RecordingCF:
+    def __init__(self):
+        self.put_calls: list[str] = []
+
+    async def put_worker(self, *, script_name, bundle, bindings=None):
+        self.put_calls.append(script_name)
+        return True
+
+
+class _RecordingBillingProvider:
+    """Records every billing call so a test can assert on what was NOT called.
+
+    ``create_subscription`` returns the SESSION id, mirroring the real Dodo
+    checkout-session flow. ``change_plan`` returns None on success, like the SDK.
+    """
+
+    def __init__(self, *, change_plan_raises: Exception | None = None):
+        self.calls: list[dict] = []
+        self.change_plan_calls: list[dict] = []
+        self.cancel_calls: list[str] = []
+        self._change_plan_raises = change_plan_raises
+
+    async def create_subscription(
+        self,
+        *,
+        plan_key,
+        product_id,
+        workspace_id,
+        customer_email,
+        metadata,
+        return_url=None,
+        cancel_url=None,
+    ) -> SubscriptionCheckout:
+        self.calls.append(
+            {
+                "plan_key": plan_key,
+                "product_id": product_id,
+                "workspace_id": workspace_id,
+                "metadata": dict(metadata),
+                "return_url": return_url,
+                "cancel_url": cancel_url,
+            }
+        )
+        return SubscriptionCheckout(checkout_url=CHECKOUT_URL, subscription_id=SESSION_ID)
+
+    async def change_plan(self, *, subscription_id, product_id, plan_key):
+        if self._change_plan_raises is not None:
+            raise self._change_plan_raises
+        self.change_plan_calls.append(
+            {
+                "subscription_id": subscription_id,
+                "product_id": product_id,
+                "plan_key": plan_key,
+            }
+        )
+
+    async def cancel_subscription(self, subscription_id: str) -> None:
+        self.cancel_calls.append(subscription_id)
+
+
+def _provider() -> DodoProvider:
+    return DodoProvider(
+        api_key="dodo_test_key",
+        environment="test_mode",
+        webhook_secret=SECRET,
+        credit_product_id="prod_credits_sku",
+        plan_products={},
+    )
+
+
+async def _make_workspace(plan: str = "pro") -> str:
+    from pocketpaw_ee.cloud.models.workspace import Workspace
+
+    ws = Workspace(
+        name="Acme",
+        slug=f"acme-republish-{datetime.now(UTC).timestamp()}",
+        owner="u1",
+        plan=plan,
+    )
+    await ws.insert()
+    return str(ws.id)
+
+
+async def _make_pocket(*, workspace_id: str, owner: str = "u1") -> str:
+    from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
+
+    doc = _PocketDoc(
+        workspace=workspace_id,
+        name="My Landing",
+        owner=owner,
+        type="site",
+        pattern="landing",
+    )
+    await doc.insert()
+    return str(doc.id)
+
+
+def _sign(body: str, *, msg_id: str) -> dict[str, str]:
+    ts = datetime.now(UTC)
+    sig = Webhook(SECRET).sign(msg_id=msg_id, timestamp=ts, data=body)
+    return {
+        "webhook-id": msg_id,
+        "webhook-timestamp": str(int(ts.timestamp())),
+        "webhook-signature": sig,
+    }
+
+
+def _site_subscription_body(*, event_type: str, workspace_id: str, site_id: str) -> str:
+    """A per-site subscription webhook body carrying the REAL gateway sub id."""
+    return json.dumps(
+        {
+            "business_id": "biz_1",
+            "type": event_type,
+            "timestamp": datetime.now(UTC).isoformat(),
+            "data": {
+                "subscription_id": GATEWAY_SUB_ID,
+                "product_id": "prod_site_pro",
+                "metadata": {
+                    "workspace_id": workspace_id,
+                    "site_id": site_id,
+                    "plan_key": "pro",
+                },
+            },
+        }
+    )
+
+
+def _configure_products(monkeypatch, mapping: dict[str, str]) -> None:
+    monkeypatch.setattr(site_plans, "_dodo_product_for", lambda key: mapping.get(key))
+
+
+def _fake_activation_deploy(monkeypatch):
+    """The webhook-driven activation takes no injected seams, so the generator and
+    the local deploy are monkeypatched instead (same approach as
+    test_charge_first.py). Returns the recording generator."""
+    monkeypatch.setenv("PAW_SITES_LOCAL", "1")
+    gen = _RecordingGenerator()
+    monkeypatch.setattr(sites_service, "GeneratorClient", lambda *a, **k: gen)
+    from pocketpaw_ee.sites import local_server
+
+    monkeypatch.setattr(
+        local_server, "deploy_local", lambda site_id, project_dir, **kw: f"http://local/{site_id}/"
+    )
+    return gen
+
+
+async def _publish_and_pay(ws, pocket_id, provider, monkeypatch, *, tier="pro"):
+    """Publish a paid site and drive it live through the real verified webhook.
+
+    Returns the activated Site doc — deployed, active, holding the gateway sub id.
+    """
+    _fake_activation_deploy(monkeypatch)
+    doc = await sites_service.publish_pocket(
+        workspace_id=ws,
+        user_id="u1",
+        pocket_id=pocket_id,
+        site_plan_key=tier,
+        _generator=_RecordingGenerator(),
+        _cloudflare=_RecordingCF(),
+        _bundle_reader=lambda d: b"x",
+        _billing_provider=provider,
+    )
+    body = _site_subscription_body(
+        event_type="subscription.active", workspace_id=ws, site_id=str(doc.id)
+    )
+    await billing.handle_webhook(
+        payload=body.encode(),
+        headers=_sign(body, msg_id="msg_activate_1"),
+        provider=_provider(),
+    )
+    return await Site.find_one(Site.id == doc.id)
+
+
+# ---------------------------------------------------------------------------
+# The root cause: the authoritative subscription id is received and discarded.
+# ---------------------------------------------------------------------------
+
+
+async def test_activation_persists_the_real_gateway_subscription_id(
+    mongo_db, recording_bus, monkeypatch
+):
+    """``create_subscription`` returns a checkout SESSION id; the real subscription
+    id arrives on the webhook. The site must end up holding the latter.
+
+    Nothing can cancel or change a subscription it cannot name. Every other fix in
+    this module depends on this one line of plumbing.
+    """
+    _configure_products(monkeypatch, {"pro": "prod_site_pro"})
+    ws = await _make_workspace()
+    pocket_id = await _make_pocket(workspace_id=ws)
+    provider = _RecordingBillingProvider()
+
+    site = await _publish_and_pay(ws, pocket_id, provider, monkeypatch)
+
+    assert site.subscription_status == "active"
+    assert site.subscription_id == GATEWAY_SUB_ID, (
+        "the site kept the checkout SESSION id — the authoritative gateway "
+        "subscription id from the webhook was thrown away"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The money bug: a republish must not buy the plan again.
+# ---------------------------------------------------------------------------
+
+
+async def test_republishing_a_paying_site_opens_no_second_subscription(
+    mongo_db, recording_bus, monkeypatch
+):
+    """A content edit on a site that is already paying is not a purchase."""
+    _configure_products(monkeypatch, {"pro": "prod_site_pro"})
+    ws = await _make_workspace()
+    pocket_id = await _make_pocket(workspace_id=ws)
+    provider = _RecordingBillingProvider()
+
+    await _publish_and_pay(ws, pocket_id, provider, monkeypatch)
+    assert len(provider.calls) == 1, "sanity: the first publish buys the plan once"
+
+    gen, cf = _RecordingGenerator(), _RecordingCF()
+    await sites_service.publish_pocket(
+        workspace_id=ws,
+        user_id="u1",
+        pocket_id=pocket_id,
+        site_plan_key="pro",
+        _generator=gen,
+        _cloudflare=cf,
+        _bundle_reader=lambda d: b"x",
+        _billing_provider=provider,
+    )
+
+    assert len(provider.calls) == 1, (
+        "republishing a site that already holds an active subscription opened a "
+        "SECOND one — the customer is now billed twice for one site"
+    )
+
+
+async def test_republishing_a_paying_site_keeps_its_paid_status_and_goes_live(
+    mongo_db, recording_bus, monkeypatch
+):
+    """The republish must not strip the capabilities the customer is paying for,
+    and the new content must go live without a second payment."""
+    _configure_products(monkeypatch, {"pro": "prod_site_pro"})
+    ws = await _make_workspace()
+    pocket_id = await _make_pocket(workspace_id=ws)
+    provider = _RecordingBillingProvider()
+
+    await _publish_and_pay(ws, pocket_id, provider, monkeypatch)
+
+    gen, cf = _RecordingGenerator(), _RecordingCF()
+    doc = await sites_service.publish_pocket(
+        workspace_id=ws,
+        user_id="u1",
+        pocket_id=pocket_id,
+        site_plan_key="pro",
+        _generator=gen,
+        _cloudflare=cf,
+        _bundle_reader=lambda d: b"x",
+        _billing_provider=provider,
+    )
+
+    # Status and the gateway handle both survive. "pending" here would mean every
+    # entitlement resolves as unpaid while the customer is still being charged.
+    assert doc.subscription_status == "active"
+    assert doc.subscription_id == GATEWAY_SUB_ID
+    assert doc.plan_tier == "pro"
+
+    # And the edit actually shipped, rather than waiting on a payment that will
+    # never come.
+    assert doc.deployed is True
+    assert gen.build_calls, "the republish deferred the deploy behind a second payment"
+    assert doc._checkout_url is None
+
+
+# ---------------------------------------------------------------------------
+# A real tier change is a plan change, not a second purchase.
+# ---------------------------------------------------------------------------
+
+
+async def test_moving_a_paying_site_to_another_tier_changes_the_plan(
+    mongo_db, recording_bus, monkeypatch
+):
+    """Upgrading pro → business must move the EXISTING subscription.
+
+    Cancel-then-create would make the customer forfeit the remainder of an annual
+    term they already paid for; a second create bills them twice. The gateway's
+    atomic plan change is the only option that does neither.
+    """
+    _configure_products(
+        monkeypatch, {"pro": "prod_site_pro", "business": "prod_site_business"}
+    )
+    ws = await _make_workspace()
+    pocket_id = await _make_pocket(workspace_id=ws)
+    provider = _RecordingBillingProvider()
+
+    await _publish_and_pay(ws, pocket_id, provider, monkeypatch)
+
+    gen, cf = _RecordingGenerator(), _RecordingCF()
+    doc = await sites_service.publish_pocket(
+        workspace_id=ws,
+        user_id="u1",
+        pocket_id=pocket_id,
+        site_plan_key="business",
+        _generator=gen,
+        _cloudflare=cf,
+        _bundle_reader=lambda d: b"x",
+        _billing_provider=provider,
+    )
+
+    assert len(provider.calls) == 1, "a tier change must not open a second subscription"
+    assert len(provider.change_plan_calls) == 1
+    call = provider.change_plan_calls[0]
+    assert call["subscription_id"] == GATEWAY_SUB_ID, (
+        "change_plan was handed the checkout session id, not the gateway subscription"
+    )
+    assert call["product_id"] == "prod_site_business"
+
+    # The webhook acks plan_changed without acting, so the new tier has to be
+    # written synchronously here or nothing ever records it.
+    assert doc.plan_tier == "business"
+    assert doc.subscription_status == "active"
+
+
+async def test_a_failed_plan_change_leaves_the_subscription_alone(
+    mongo_db, recording_bus, monkeypatch
+):
+    """When the gateway refuses the change, the site keeps the tier it is paying
+    for — and we never 'recover' by opening a second subscription."""
+    _configure_products(
+        monkeypatch, {"pro": "prod_site_pro", "business": "prod_site_business"}
+    )
+    ws = await _make_workspace()
+    pocket_id = await _make_pocket(workspace_id=ws)
+
+    provider = _RecordingBillingProvider()
+    await _publish_and_pay(ws, pocket_id, provider, monkeypatch)
+    provider._change_plan_raises = RuntimeError("gateway said no")
+
+    gen, cf = _RecordingGenerator(), _RecordingCF()
+    with pytest.raises(Exception):
+        await sites_service.publish_pocket(
+            workspace_id=ws,
+            user_id="u1",
+            pocket_id=pocket_id,
+            site_plan_key="business",
+            _generator=gen,
+            _cloudflare=cf,
+            _bundle_reader=lambda d: b"x",
+            _billing_provider=provider,
+        )
+
+    assert len(provider.calls) == 1, (
+        "a failed plan change fell back to create_subscription — that is the "
+        "double-billing this fix exists to remove"
+    )
+    persisted = await Site.find_one(Site.id != None)  # noqa: E711
+    assert persisted.plan_tier == "pro"
+    assert persisted.subscription_id == GATEWAY_SUB_ID
+    assert persisted.subscription_status == "active"
+
+
+# ---------------------------------------------------------------------------
+# The buyer has to be able to get back.
+# ---------------------------------------------------------------------------
+
+
+async def test_the_site_checkout_sends_the_buyer_back_to_the_app(
+    mongo_db, recording_bus, monkeypatch
+):
+    """The frontend navigates the whole page to the checkout url. Without a
+    return url the buyer pays and is left on the gateway with no way back."""
+    _configure_products(monkeypatch, {"pro": "prod_site_pro"})
+    ws = await _make_workspace()
+    pocket_id = await _make_pocket(workspace_id=ws)
+    provider = _RecordingBillingProvider()
+
+    gen, cf = _RecordingGenerator(), _RecordingCF()
+    await sites_service.publish_pocket(
+        workspace_id=ws,
+        user_id="u1",
+        pocket_id=pocket_id,
+        site_plan_key="pro",
+        origin="https://app.example.com",
+        _generator=gen,
+        _cloudflare=cf,
+        _bundle_reader=lambda d: b"x",
+        _billing_provider=provider,
+    )
+
+    call = provider.calls[0]
+    assert call["return_url"] and call["return_url"].startswith("https://app.example.com")
+    assert call["cancel_url"] and call["cancel_url"].startswith("https://app.example.com")

--- a/tests/cloud/sites/test_site_billing.py
+++ b/tests/cloud/sites/test_site_billing.py
@@ -270,7 +270,9 @@ async def test_publish_degrades_gracefully_when_dodo_unconfigured(mongo_db, reco
         # No _billing_provider injected and no product configured → no live sub.
     )
 
-    assert doc.plan_tier == "pro"
+    # The FLOOR, not "pro" (#1995) — an unpurchasable paid tier is not recorded,
+    # because a tier the site does not actually hold is worse than no tier.
+    assert doc.plan_tier == site_plans.BASE_SITE_PLAN_KEY
     assert doc.subscription_id is None
     assert doc.subscription_status == "none"
     # The publish still emits SitePublished (the site IS published, just no charge).

--- a/tests/cloud/sites/test_site_billing.py
+++ b/tests/cloud/sites/test_site_billing.py
@@ -72,7 +72,15 @@ class _FakeBillingProvider:
         self.calls: list[dict] = []
 
     async def create_subscription(
-        self, *, plan_key, product_id, workspace_id, customer_email, metadata
+        self,
+        *,
+        plan_key,
+        product_id,
+        workspace_id,
+        customer_email,
+        metadata,
+        return_url=None,
+        cancel_url=None,
     ) -> SubscriptionCheckout:
         self.calls.append(
             {

--- a/tests/mutations/concierge_entitlement.json
+++ b/tests/mutations/concierge_entitlement.json
@@ -144,8 +144,8 @@
   {
     "label": "activation flips the status AFTER the deploy again (the original P0)",
     "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "    doc.subscription_status = \"active\"\n    await doc.save()\n\n    deployed = await _deploy_site_doc(",
-    "replace": "    deployed = await _deploy_site_doc(",
+    "find": "    doc.subscription_status = \"active\"\n",
+    "replace": "",
     "tests": [
       "tests/cloud/sites/test_charge_first.py::test_the_subscription_reads_active_before_the_activation_deploy_runs"
     ]

--- a/tests/mutations/site_republish_billing.json
+++ b/tests/mutations/site_republish_billing.json
@@ -1,0 +1,113 @@
+[
+  {
+    "label": "the dispatcher forgets to ask whether the site is already paying",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if is_paid and dodo_configured and not already_paying:",
+    "replace": "    if is_paid and dodo_configured:",
+    "tests": [
+      "tests/cloud/sites/test_republish_double_billing.py::test_republishing_a_paying_site_opens_no_second_subscription",
+      "tests/cloud/sites/test_republish_double_billing.py::test_republishing_a_paying_site_keeps_its_paid_status_and_goes_live"
+    ]
+  },
+  {
+    "label": "the stamp path re-charges a paying site one layer below the dispatcher",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if tier is not None and tier.dodo_product_id and not already_paying:",
+    "replace": "    if tier is not None and tier.dodo_product_id:",
+    "tests": [
+      "tests/cloud/sites/test_republish_double_billing.py::test_republishing_a_paying_site_opens_no_second_subscription",
+      "tests/cloud/sites/test_republish_double_billing.py::test_republishing_a_paying_site_keeps_its_paid_status_and_goes_live"
+    ]
+  },
+  {
+    "label": "\"already paying\" accepts a PENDING site — a never-paid site never gets its checkout",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    already_paying = (\n        existing_doc is not None\n        and existing_doc.subscription_status == \"active\"\n        and bool(existing_doc.subscription_id)\n    )",
+    "replace": "    already_paying = existing_doc is not None and bool(existing_doc.subscription_id)",
+    "tests": [
+      "tests/cloud/sites/test_republish_double_billing.py::test_republishing_a_site_that_never_paid_still_opens_a_checkout"
+    ]
+  },
+  {
+    "label": "activation drops the gateway subscription id again — the doc keeps a session id",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if subscription_id:\n        doc.subscription_id = subscription_id\n    await doc.save()\n\n    deployed = await _deploy_site_doc(",
+    "replace": "    await doc.save()\n\n    deployed = await _deploy_site_doc(",
+    "tests": [
+      "tests/cloud/sites/test_republish_double_billing.py::test_activation_persists_the_real_gateway_subscription_id",
+      "tests/cloud/sites/test_republish_double_billing.py::test_moving_a_paying_site_to_another_tier_changes_the_plan"
+    ]
+  },
+  {
+    "label": "the webhook stops handing the subscription id to activation",
+    "file": "ee/pocketpaw_ee/cloud/billing/service.py",
+    "find": "                subscription_id=event.subscription_id or None,\n            )",
+    "replace": "            )",
+    "tests": [
+      "tests/cloud/sites/test_republish_double_billing.py::test_activation_persists_the_real_gateway_subscription_id"
+    ]
+  },
+  {
+    "label": "a tier change buys a second subscription instead of moving the existing one",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if already_paying and is_paid and dodo_configured and existing_doc.plan_tier != tier.key:",
+    "replace": "    if False:",
+    "tests": [
+      "tests/cloud/sites/test_republish_double_billing.py::test_moving_a_paying_site_to_another_tier_changes_the_plan"
+    ]
+  },
+  {
+    "label": "a refused plan change falls back to opening a fresh checkout",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        prov = _billing_provider or _default_billing_provider()\n        await prov.change_plan(\n            subscription_id=existing_doc.subscription_id,\n            product_id=tier.dodo_product_id,\n            plan_key=tier.key,\n        )",
+    "replace": "        prov = _billing_provider or _default_billing_provider()\n        try:\n            await prov.change_plan(\n                subscription_id=existing_doc.subscription_id,\n                product_id=tier.dodo_product_id,\n                plan_key=tier.key,\n            )\n        except Exception:\n            already_paying = False",
+    "tests": [
+      "tests/cloud/sites/test_republish_double_billing.py::test_a_failed_plan_change_leaves_the_subscription_alone"
+    ]
+  },
+  {
+    "label": "the site checkout stops sending a return url — the buyer is stranded on the gateway",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        return_url=return_url,\n        cancel_url=cancel_url,\n    )",
+    "replace": "    )",
+    "tests": [
+      "tests/cloud/sites/test_republish_double_billing.py::test_the_site_checkout_sends_the_buyer_back_to_the_app"
+    ]
+  },
+  {
+    "label": "the return url points at the workspace billing page, not the site the buyer bought",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    return (f\"{base}/sites?checkout=success\", f\"{base}/sites?checkout=cancel\")",
+    "replace": "    return (None, None)",
+    "tests": [
+      "tests/cloud/sites/test_republish_double_billing.py::test_the_site_checkout_sends_the_buyer_back_to_the_app"
+    ]
+  },
+  {
+    "label": "change_plan sends no proration mode — the buyer forfeits the term they paid for",
+    "file": "ee/pocketpaw_ee/cloud/billing/providers/dodo.py",
+    "find": "            proration_billing_mode=\"difference_immediately\",",
+    "replace": "            proration_billing_mode=\"full_immediately\",",
+    "tests": [
+      "tests/cloud/billing/test_change_plan_provider.py::test_the_plan_change_prorates_the_difference"
+    ]
+  },
+  {
+    "label": "a declined card moves the plan anyway, so our tier and the gateway's disagree",
+    "file": "ee/pocketpaw_ee/cloud/billing/providers/dodo.py",
+    "find": "            on_payment_failure=\"prevent_change\",",
+    "replace": "            on_payment_failure=\"apply_change\",",
+    "tests": [
+      "tests/cloud/billing/test_change_plan_provider.py::test_a_declined_card_leaves_the_plan_where_it_was"
+    ]
+  },
+  {
+    "label": "change_plan accepts an empty subscription id and calls the gateway with it",
+    "file": "ee/pocketpaw_ee/cloud/billing/providers/dodo.py",
+    "find": "    async def change_plan(self, *, subscription_id: str, product_id: str, plan_key: str) -> None:\n        if not subscription_id:\n            raise ValidationError(\"billing.invalid_subscription\", \"subscription_id is required\")",
+    "replace": "    async def change_plan(self, *, subscription_id: str, product_id: str, plan_key: str) -> None:",
+    "tests": [
+      "tests/cloud/billing/test_change_plan_provider.py::test_an_empty_subscription_id_never_reaches_the_gateway"
+    ]
+  }
+]


### PR DESCRIPTION
Editing a paid site charged the customer for a second one.

## What happened

The charge-first dispatcher branched on the tier alone — *paid tier with a configured Dodo product, open a checkout*, and never asked whether this site was already paying. So every republish of a paid site, including a plain content edit, ran `create_subscription` again.

Four things went wrong at once:

- a second Dodo subscription started billing, and the first was never cancelled
- `doc.subscription_id` was overwritten with the new checkout **session** id, so the original subscription became unreachable. No later cancel could name it, and it would bill until the customer disputed the charge
- `doc.subscription_status` flipped to `"pending"`, which every entitlement resolves as unpaid, so a paying customer's custom domain started returning 402 and their concierge disappeared mid-term
- the edit did not go live until the buyer paid **again**, because the deploy was deferred to a `subscription.active` that only a second payment could produce

That last one is the part a customer would actually report. The first three are the part that costs money.

## The root cause underneath it

`activate_site` was never handed the `subscription_id` off the verified webhook.

Dodo creates the subscription at payment time, so what `create_subscription` returns is a checkout session id (`cks_…`). The authoritative `sub_…` id arrives later, on `subscription.active`, and the webhook called `activate_site` without it. The site doc kept the session id forever.

A session id cannot cancel a subscription and cannot change its plan; the gateway rejects it. So every lifecycle operation anyone might want to build on top of per-site billing was unbuildable, and the reason was one missing argument.

## What changes

| Case | Before | After |
|---|---|---|
| Activation | keeps the `cks_` session id | persists the gateway `sub_` id |
| Republish, same tier | buys the plan again | no billing call at all, publishes live |
| Republish, tier changed | buys a second plan | moves the existing subscription |
| Republish, never paid | opens a checkout | unchanged — still opens one |
| Plan change refused | n/a | propagates; no fallback to a second purchase |

The tier change goes through the gateway's atomic `change_plan` rather than cancel-then-create. On an annual term, cancelling and recreating makes the buyer forfeit the months they already paid for; `difference_immediately` charges only the delta. `on_payment_failure="prevent_change"` keeps a declined card on the old plan, because the caller writes the new tier on return and the resulting `plan_changed` webhook is acked without action — nothing would reconcile a disagreement later.

The failed-change path deliberately has no `try/except` that falls back to `create_subscription`. That fallback *is* the double billing this removes.

## Two details worth a second look

**The guard is duplicated on purpose.** It sits in the dispatcher and again in `_apply_site_plan`. The second one is not redundant: until now a paid, configured tier could never reach `_apply_site_plan` (the dispatcher always routed it to `_publish_pending_site`), so its checkout branch was effectively dead for paying sites. Routing same-tier republishes through the live path is exactly what arms it, and without the second guard it would open a fresh checkout, overwrite the gateway id with a session id, and knock the status back to `pending`. The whole defect, one layer down.

**It keys on `"active"`, not on "has a subscription id".** A site published on a paid tier but never paid for holds an abandoned session id. Counting that as "already paying" would skip billing forever and leave a buyer who can neither pay nor get their site live. A mutation caught me getting this wrong — see below.

## No migration, but there is a deploy ordering

No deployment can have a live per-site subscription yet. `POCKETPAW_DODO_SITE_PRODUCTS` was read but never declared until #1995 merged yesterday, and it is still unset everywhere, so no per-site checkout has ever opened. There are no orphaned session ids to migrate.

That holds **only if this lands before that env var is ever set.** Set it first and every subscription opened in between is unreachable from our side permanently.

## Tests

Seven written first, six failing, including the two that pinned the money bug:

```
assert 2 == 1          # create_subscription called twice for one site
assert 'pending' == 'active'   # a paying site's status, after an edit
```

Twelve mutations, all caught. **One escaped on the first run and found a real hole.** It loosens "already paying" to accept any site holding a subscription id, including a pending one, and both tests I had pointed at it publish only once, so no existing doc ever carried an id and nothing noticed. Added the missing case: a never-paid site must still get a fresh checkout on republish.

Also fixes two tests that have been red on `dev` since #1995. Both assert `plan_tier == "pro"` after publishing an unpurchasable paid tier, which is the exact claim #1995 stopped writing. I ran them against clean `origin/dev` before touching them and they fail there identically — pre-existing, not caused by this branch, fixed here because they sit in its blast radius.

## Not in this PR

The customer portal (self-serve cancel, invoices, payment-method updates) needs a Dodo `customer_id`, and nothing stores one. It is not even on the parsed webhook event, only potentially in the raw body. That is its own change.

Still open after this, and each is a deliberate deferral rather than an oversight: there is no cancel path for a site subscription, no delete or unpublish route for a site at all, `payment.failed` and `on_hold` are acked without action so a failed renewal keeps every paid feature, and a cancelled site keeps serving. That last one is TODO'd in the code, pending a grace-period decision that is yours to make.
