### PR TITLE
The UI branches on billing state the API never sent

### DIFF
--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -233,6 +233,22 @@ class SiteResponse(BaseModel):
     # publish (which deploys immediately) and for any non-publish response.
     checkout_url: str | None = None
     # DP0-4: where a dynamic site sits in the durable D1 provision job
+    # ---- per-site billing state (BC-9) -------------------------------------
+    # The frontend has declared and branched on these since BC-9: SiteSummary types
+    # all three, and the [siteId] page gates its "awaiting checkout" bar on
+    # ``subscription_status === "pending"``. None of them was ever mapped onto the
+    # wire, so every read came back ``undefined``, every fallback took the "no
+    # per-site sub" branch, and a paid site rendered identically to a free one. The
+    # optional ``?`` on the TS fields is what kept it quiet — nothing throws when a
+    # field that is always absent is always absent.
+    #
+    # All three live on the Site document already, so sending them costs no query.
+    #
+    # ``plan_tier`` is "" rather than None when unstamped, so "this site has no
+    # tier" and "the backend did not send a tier" stay distinguishable on the wire.
+    plan_tier: str = ""
+    subscription_status: str = "none"
+    annual_renewal_date: str | None = None
     # (none | provisioning | provisioned | failed). A DYNAMIC-site publish does NOT
     # deploy inline — it enqueues the ``provision_site`` job and returns immediately
     # with ``provision_status="provisioning"`` (``deployed=False``); the site goes
@@ -616,6 +632,44 @@ class SiteInvoiceOut(BaseModel):
     currency: str
     paid: bool
     note: str = ""
+
+
+class SiteEntitlementsResponse(BaseModel):
+    """What this site is allowed to do, resolved — so the UI can disable a control
+    and say WHY instead of offering it and rendering the 402 that comes back.
+
+    ``resolve_site_entitlements`` has computed most of this since BC-9 and nothing
+    ever exposed it per site; the frontend fetched entitlements nowhere at all. The
+    result was a UI that could only discover a refusal by attempting the action.
+
+    The two fields that are NOT on ``SiteEntitlements`` are the ones that make the
+    difference between a usable message and a useless one:
+
+    * ``domained_sites_used`` — how many sites in this workspace already spend the
+      floor allowance. "You cannot add a domain" and "your one free domain is on
+      another site" are different sentences, and only the count separates them.
+    * ``domain_slots_available`` — the same answer ``add_domain`` will give,
+      computed by the SAME function it calls (``_domain_cap_exceeded``), so the
+      button's enabled state and the endpoint's verdict cannot drift apart. A
+      second copy of the rule here would eventually disagree with the gate, and
+      the UI would confidently offer a button that 402s.
+
+    ``max_domained_sites`` is None for an uncapped (paid) tier, mirroring the
+    catalog. ``subscription_active`` distinguishes a lapsed paid site from a site
+    that never had the capability — the tier stays recorded, only the payment
+    stopped, and the UI should say so.
+    """
+
+    site_id: str
+    plan_tier: str = ""
+    subscription_active: bool = False
+    badge_required: bool = True
+    custom_domain: bool = False
+    max_domained_sites: int | None = 0
+    domained_sites_used: int = 0
+    domain_slots_available: bool = False
+    concierge_entitled: bool = False
+    concierge_enabled: bool = False
 
 
 class SiteClientResponse(BaseModel):

--- a/ee/pocketpaw_ee/sites/router.py
+++ b/ee/pocketpaw_ee/sites/router.py
@@ -220,6 +220,7 @@ from pocketpaw_ee.sites.dto import (
     SiteClientUpdate,
     SiteDataRowsResponse,
     SiteDataTablesResponse,
+    SiteEntitlementsResponse,
     SiteInvoiceCreate,
     SitePreviewRefreshResponse,
     SitePreviewResponse,
@@ -791,6 +792,23 @@ async def domain_status(
     return await sites_service.domain_status(
         workspace_id=ctx.workspace_id, site_id=site_id, hostname=hostname
     )
+
+
+@router.get("/sites/{site_id}/entitlements", response_model=SiteEntitlementsResponse)
+async def get_site_entitlements(
+    site_id: str,
+    ctx: RequestContext = Depends(request_context),
+    _: object = Depends(require_action_any_workspace("fabric.read")),
+) -> SiteEntitlementsResponse:
+    """What this site may do, so the UI can disable a control and say why.
+
+    Its own endpoint rather than fields on the list response: the domain-slot
+    answer needs a workspace-wide count of sites already holding a domain, and
+    riding that on ``GET /sites`` would run one count per card. The gallery stays a
+    single query; only a surface that actually offers a gated control pays for the
+    lookup.
+    """
+    return await sites_service.site_entitlements(workspace_id=ctx.workspace_id, site_id=site_id)
 
 
 @router.get("/sites/{site_id}/client", response_model=SiteClientResponse)

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -896,6 +896,7 @@ from pocketpaw_ee.sites.dto import (
     SiteDataRowsResponse,
     SiteDataTableInfo,
     SiteDataTablesResponse,
+    SiteEntitlementsResponse,
     SiteInvoiceCreate,
     SiteInvoiceOut,
     SitePreviewRefreshResponse,
@@ -1746,6 +1747,15 @@ def _to_response(doc: _SiteDoc, pattern: str = "", engine: str = "") -> SiteResp
         # for a free/live publish and for any list/status read (those docs are
         # loaded from Mongo, where the PrivateAttr defaults to None).
         checkout_url=getattr(doc, "_checkout_url", None),
+        # The per-site billing state. Read straight off the doc — no extra query.
+        # These were declared in the frontend and branched on, and never sent.
+        plan_tier=getattr(doc, "plan_tier", None) or "",
+        subscription_status=getattr(doc, "subscription_status", None) or "none",
+        annual_renewal_date=(
+            _renewal.isoformat()
+            if (_renewal := getattr(doc, "annual_renewal_date", None)) is not None
+            else None
+        ),
         # DP0-4: the dynamic-site provision state (persisted) + the id of the job a
         # dynamic publish just enqueued (transient ``_provision_job_id`` PrivateAttr,
         # None for a static publish / any DB-loaded doc / a single-flight no-op).
@@ -3522,6 +3532,60 @@ async def _load(workspace_id: str, site_id: str) -> _SiteDoc:
     if doc is None:
         raise NotFound("site", site_id)
     return doc
+
+
+async def site_entitlements(*, workspace_id: str, site_id: str) -> SiteEntitlementsResponse:
+    """What this site is allowed to do, resolved — the read the UI needs to disable
+    a control and explain itself instead of offering it and rendering the 402.
+
+    ``resolve_site_entitlements`` has answered most of this since BC-9 and nothing
+    exposed it per site, so the frontend fetched entitlements nowhere and could only
+    discover a refusal by attempting the action.
+
+    The domain slot answer comes from ``_domain_cap_exceeded`` — the SAME function
+    ``add_domain`` calls — rather than a second copy of the counting rule here. Two
+    copies would eventually disagree, and the failure mode is the ugly direction: a
+    button that looks enabled and 402s. Reusing it also inherits its three subtle
+    rules for free (count sites not hostnames, floor sites only, exclude this site).
+
+    ``max_domained_sites`` reports what the PLAN grants, while
+    ``domain_slots_available`` reports what the gate will actually do. They differ when
+    enforcement is off: nothing is capped operationally even though the tier still
+    has a number. Reporting both keeps the plan card honest without making the
+    button lie.
+    """
+    # ``_load`` is the tenant-scoped read the rest of this module uses: a missing,
+    # cross-tenant, or malformed site id raises NotFound rather than leaking one
+    # workspace's entitlements to another.
+    doc = await _load(workspace_id, site_id)
+
+    from pocketpaw_ee.cloud.entitlements import service as entitlements_service
+
+    resolved = entitlements_service.resolve_site_entitlements(
+        site_id=site_id,
+        workspace_id=workspace_id,
+        plan_tier=getattr(doc, "plan_tier", None),
+        subscription_status=getattr(doc, "subscription_status", None),
+        concierge_enabled=bool(getattr(doc, "concierge_enabled", False)),
+    )
+    exceeded, used, _limit = await _domain_cap_exceeded(workspace_id, doc)
+
+    return SiteEntitlementsResponse(
+        site_id=site_id,
+        plan_tier=resolved.plan_tier,
+        subscription_active=resolved.subscription_active,
+        badge_required=resolved.badge_required,
+        custom_domain=resolved.custom_domain,
+        max_domained_sites=resolved.max_domained_sites,
+        domained_sites_used=used,
+        # A site with no custom-domain capability at all has no slot either, however
+        # empty the workspace is — otherwise the UI would enable the button for a
+        # tier that cannot hold a domain and hand back
+        # ``billing.custom_domain_not_entitled``.
+        domain_slots_available=resolved.custom_domain and not exceeded,
+        concierge_entitled=resolved.concierge_entitled,
+        concierge_enabled=resolved.concierge_enabled,
+    )
 
 
 async def mark_site_subscription(

--- a/tests/cloud/sites/test_billing_state_on_the_wire.py
+++ b/tests/cloud/sites/test_billing_state_on_the_wire.py
@@ -1,0 +1,329 @@
+# tests/cloud/sites/test_billing_state_on_the_wire.py — proves the API actually
+# SENDS the per-site billing state the UI is written against.
+#
+# The defect (found 2026-08-22, feat/site-entitlement-ui-state): the frontend's
+# SiteSummary and SiteStatusResponse both declare ``plan_tier``,
+# ``subscription_status`` and ``annual_renewal_date``, and the [siteId] page
+# branches on them — an "awaiting checkout" bar keys on
+# ``subscription_status === "pending"``, and the Billing tab renders the current
+# plan. Neither backend DTO carried a single one of those fields:
+#
+#     SiteResponse        20 fields, billing fields: NONE
+#     SiteStatusResponse  13 fields, billing fields: NONE
+#
+# So every read yielded ``undefined``, every fallback took the "no per-site sub"
+# branch, and a paid site was indistinguishable from a free one in the UI. The
+# optional ``?`` on the TypeScript fields is what kept it quiet: nothing throws
+# when a field that is always absent is always absent.
+#
+# It survived because the frontend test does not test the page. It reimplements
+# the page's derivation as a local ``isPendingPayment`` helper and feeds it
+# hand-written strings — so it proves the rule is right while saying nothing about
+# whether the inputs ever arrive.
+#
+# These tests assert on the DTO the router actually returns, which is the only
+# place that question can be answered.
+#
+# Created 2026-08-22 (feat/site-entitlement-ui-state): new test module.
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+from pocketpaw_ee.cloud.models.site import Site, SiteDomain
+from pocketpaw_ee.sites import service as sites_service
+
+from pocketpaw import config as ppconfig
+
+
+def _enforce(monkeypatch, *, on: bool = True) -> None:
+    """Sites billing enforcement, same seam the cap tests use. The entitlement
+    ANSWER (what the plan grants) is independent of it; the domain SLOT answer is
+    not — with enforcement off nothing is capped, which is the correct thing for
+    the UI to report too."""
+    monkeypatch.setattr(
+        ppconfig,
+        "get_settings",
+        lambda: SimpleNamespace(billing_enforced=on, dodo_site_products=None),
+    )
+
+
+async def _make_workspace() -> str:
+    from pocketpaw_ee.cloud.models.workspace import Workspace
+
+    ws = Workspace(
+        name="Acme",
+        slug=f"acme-wire-{datetime.now(UTC).timestamp()}",
+        owner="u1",
+        plan="pro",
+    )
+    await ws.insert()
+    return str(ws.id)
+
+
+async def _make_pocket(*, workspace_id: str) -> str:
+    from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
+
+    doc = _PocketDoc(
+        workspace=workspace_id,
+        name="My Landing",
+        owner="u1",
+        type="site",
+        pattern="landing",
+    )
+    await doc.insert()
+    return str(doc.id)
+
+
+async def _seed_site(
+    *,
+    workspace_id: str,
+    pocket_id: str,
+    plan_tier: str | None = "pro",
+    subscription_status: str = "active",
+    renewal: datetime | None = None,
+    domains: list[str] | None = None,
+) -> Site:
+    doc = Site(
+        workspace=workspace_id,
+        pocket_id=pocket_id,
+        name="My Landing",
+        script_name="site-wire",
+        owner="u1",
+        deployed=True,
+        signed_key="site_key_wire",
+        plan_tier=plan_tier,
+        subscription_status=subscription_status,
+        annual_renewal_date=renewal,
+        domains=[SiteDomain(hostname=h) for h in (domains or [])],
+    )
+    await doc.insert()
+    return doc
+
+
+# ---------------------------------------------------------------------------
+# The plan state the UI already branches on
+# ---------------------------------------------------------------------------
+
+
+async def test_the_site_response_carries_the_plan_the_ui_renders(mongo_db):
+    """``plan_tier`` / ``subscription_status`` are on the document already, so
+    sending them costs no extra query — they were simply never mapped."""
+    ws = await _make_workspace()
+    pocket_id = await _make_pocket(workspace_id=ws)
+    renewal = datetime(2027, 1, 15, tzinfo=UTC)
+    doc = await _seed_site(
+        workspace_id=ws, pocket_id=pocket_id, renewal=renewal, subscription_status="active"
+    )
+
+    resp = sites_service._to_response(doc)
+
+    assert resp.plan_tier == "pro"
+    assert resp.subscription_status == "active"
+    assert resp.annual_renewal_date is not None
+    assert resp.annual_renewal_date.startswith("2027-01-15")
+
+
+async def test_a_pending_site_says_pending_rather_than_nothing(mongo_db):
+    """The [siteId] page's "awaiting checkout" bar keys on exactly this string.
+    While the field was absent it read ``undefined`` and the bar never showed, so
+    a buyer who abandoned a checkout saw a site that looked simply broken."""
+    ws = await _make_workspace()
+    pocket_id = await _make_pocket(workspace_id=ws)
+    doc = await _seed_site(workspace_id=ws, pocket_id=pocket_id, subscription_status="pending")
+
+    assert sites_service._to_response(doc).subscription_status == "pending"
+
+
+async def test_a_site_with_no_per_site_sub_reports_the_floor_not_null(mongo_db):
+    """A free site must be positively described, not described by absence. "none"
+    and "the backend forgot to send it" have to be distinguishable on the wire."""
+    ws = await _make_workspace()
+    pocket_id = await _make_pocket(workspace_id=ws)
+    doc = await _seed_site(
+        workspace_id=ws, pocket_id=pocket_id, plan_tier=None, subscription_status="none"
+    )
+
+    resp = sites_service._to_response(doc)
+
+    assert resp.subscription_status == "none"
+    assert resp.plan_tier in ("", None)
+
+
+# ---------------------------------------------------------------------------
+# The resolved entitlements — what the UI needs to disable a control and say why
+# ---------------------------------------------------------------------------
+
+
+async def test_entitlements_say_whether_this_site_may_take_a_domain(mongo_db, monkeypatch):
+    """The domain form must be able to ask before it offers the button."""
+    _enforce(monkeypatch)
+    ws = await _make_workspace()
+    pocket_id = await _make_pocket(workspace_id=ws)
+    doc = await _seed_site(workspace_id=ws, pocket_id=pocket_id)
+
+    ent = await sites_service.site_entitlements(workspace_id=ws, site_id=str(doc.id))
+
+    assert ent.custom_domain is True
+    assert ent.subscription_active is True
+    assert ent.plan_tier == "pro"
+
+
+async def test_a_free_site_reports_its_floor_allowance_not_a_flat_no(mongo_db, monkeypatch):
+    """Free includes a custom domain on ONE site. "you cannot" and "you already
+    used your one" are different sentences, and the UI can only tell them apart if
+    the allowance and the usage both come back."""
+    _enforce(monkeypatch)
+    ws = await _make_workspace()
+    pocket_id = await _make_pocket(workspace_id=ws)
+    doc = await _seed_site(
+        workspace_id=ws, pocket_id=pocket_id, plan_tier="basic", subscription_status="none"
+    )
+
+    ent = await sites_service.site_entitlements(workspace_id=ws, site_id=str(doc.id))
+
+    assert ent.custom_domain is True, "the free floor includes one domained site"
+    assert ent.max_domained_sites == 1
+    assert ent.domained_sites_used == 0
+    assert ent.domain_slots_available is True
+
+
+async def test_the_free_allowance_reads_as_spent_once_another_site_holds_a_domain(
+    mongo_db, monkeypatch
+):
+    """The cap counts SITES, not hostnames, and it excludes the site being asked
+    about. Without the usage count the UI cannot grey the button before the 402."""
+    _enforce(monkeypatch)
+    ws = await _make_workspace()
+    other_pocket = await _make_pocket(workspace_id=ws)
+    this_pocket = await _make_pocket(workspace_id=ws)
+
+    await _seed_site(
+        workspace_id=ws,
+        pocket_id=other_pocket,
+        plan_tier="basic",
+        subscription_status="none",
+        domains=["already.example.com"],
+    )
+    doc = await _seed_site(
+        workspace_id=ws, pocket_id=this_pocket, plan_tier="basic", subscription_status="none"
+    )
+
+    ent = await sites_service.site_entitlements(workspace_id=ws, site_id=str(doc.id))
+
+    assert ent.domained_sites_used == 1
+    assert ent.domain_slots_available is False, (
+        "the workspace's one free domained site is spent — the UI must say so "
+        "instead of offering a button that 402s"
+    )
+
+
+async def test_a_paid_site_is_not_capped_by_the_free_allowance(mongo_db, monkeypatch):
+    """An uncapped tier reports None, and slots stay available no matter how many
+    other sites hold domains."""
+    _enforce(monkeypatch)
+    ws = await _make_workspace()
+    other_pocket = await _make_pocket(workspace_id=ws)
+    this_pocket = await _make_pocket(workspace_id=ws)
+
+    await _seed_site(
+        workspace_id=ws,
+        pocket_id=other_pocket,
+        plan_tier="basic",
+        subscription_status="none",
+        domains=["already.example.com"],
+    )
+    doc = await _seed_site(
+        workspace_id=ws, pocket_id=this_pocket, plan_tier="pro", subscription_status="active"
+    )
+
+    ent = await sites_service.site_entitlements(workspace_id=ws, site_id=str(doc.id))
+
+    assert ent.max_domained_sites is None
+    assert ent.domain_slots_available is True
+
+
+async def test_a_lapsed_paid_site_loses_the_capability_and_says_so(mongo_db, monkeypatch):
+    """A cancelled subscription falls back to the floor. The UI needs the reason
+    to differ from "you never had this" — the site had it and stopped paying."""
+    _enforce(monkeypatch)
+    ws = await _make_workspace()
+    pocket_id = await _make_pocket(workspace_id=ws)
+    doc = await _seed_site(
+        workspace_id=ws, pocket_id=pocket_id, plan_tier="pro", subscription_status="cancelled"
+    )
+
+    ent = await sites_service.site_entitlements(workspace_id=ws, site_id=str(doc.id))
+
+    assert ent.subscription_active is False
+    assert ent.concierge_entitled is False
+    assert ent.plan_tier == "pro", "the tier is still recorded; only the payment stopped"
+
+
+async def test_another_workspace_cannot_read_this_site_s_entitlements(mongo_db, monkeypatch):
+    """Entitlements describe what someone is paying for. The read is tenant-scoped
+    through ``_load`` like every other site read; a raw ``find_one`` on the id
+    alone would answer for any workspace's site to any caller."""
+    import pytest
+    from pocketpaw_ee.cloud._core.errors import NotFound
+
+    _enforce(monkeypatch)
+    owner_ws = await _make_workspace()
+    pocket_id = await _make_pocket(workspace_id=owner_ws)
+    doc = await _seed_site(workspace_id=owner_ws, pocket_id=pocket_id)
+
+    intruder_ws = await _make_workspace()
+
+    with pytest.raises(NotFound):
+        await sites_service.site_entitlements(workspace_id=intruder_ws, site_id=str(doc.id))
+
+
+async def test_no_capability_means_no_slot_however_empty_the_workspace(mongo_db, monkeypatch):
+    """A tier that cannot hold a domain at all must not be offered a slot.
+
+    No tier in today's catalog can reach this: every one of them inherits the free
+    floor's single domained site, so ``custom_domain`` is True everywhere and the
+    guard is unreachable by construction. It is still the correct rule — the cap
+    answers "how many more", not "may you at all", and a tier mapped to 0 would
+    otherwise be handed a slot and then refused with
+    ``billing.custom_domain_not_entitled``.
+
+    Rather than leave that as dead code asserting nothing, this drives the resolver
+    to the state the catalog cannot currently produce, so the guard is observed
+    rather than assumed. If a paid-only-domains tier ever ships, this is already
+    its test.
+    """
+    from pocketpaw_ee.cloud.entitlements import service as entitlements_service
+    from pocketpaw_ee.cloud.entitlements.domain import SiteEntitlements
+
+    _enforce(monkeypatch)
+    ws = await _make_workspace()
+    pocket_id = await _make_pocket(workspace_id=ws)
+    doc = await _seed_site(
+        workspace_id=ws, pocket_id=pocket_id, plan_tier="basic", subscription_status="none"
+    )
+
+    monkeypatch.setattr(
+        entitlements_service,
+        "resolve_site_entitlements",
+        lambda **kw: SiteEntitlements(
+            site_id=kw["site_id"],
+            workspace_id=kw["workspace_id"],
+            plan_tier="basic",
+            subscription_active=False,
+            badge_required=True,
+            custom_domain=False,
+            max_domained_sites=0,
+            concierge_enabled=False,
+            concierge_entitled=False,
+        ),
+    )
+
+    ent = await sites_service.site_entitlements(workspace_id=ws, site_id=str(doc.id))
+
+    assert ent.custom_domain is False
+    assert ent.domain_slots_available is False, (
+        "an empty workspace made a slot look available on a tier that cannot hold "
+        "a domain — the button would enable and then 402"
+    )

--- a/tests/mutations/free_badge.json
+++ b/tests/mutations/free_badge.json
@@ -53,8 +53,8 @@
   {
     "label": "a first publish (no Site row yet) is read as a paid ACTIVE site",
     "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "        plan_tier=getattr(doc, \"plan_tier\", None),\n        subscription_status=getattr(doc, \"subscription_status\", None),",
-    "replace": "        plan_tier=getattr(doc, \"plan_tier\", \"pro\"),\n        subscription_status=getattr(doc, \"subscription_status\", \"active\"),",
+    "find": "    ent = entitlements_service.resolve_site_entitlements(\n        site_id=site_id,\n        workspace_id=workspace_id,\n        plan_tier=getattr(doc, \"plan_tier\", None),\n        subscription_status=getattr(doc, \"subscription_status\", None),",
+    "replace": "    ent = entitlements_service.resolve_site_entitlements(\n        site_id=site_id,\n        workspace_id=workspace_id,\n        plan_tier=getattr(doc, \"plan_tier\", \"pro\"),\n        subscription_status=getattr(doc, \"subscription_status\", \"active\"),",
     "tests": [
       "tests/ee/sites/test_free_badge.py::test_a_first_publish_badges_before_it_deploys"
     ]

--- a/tests/mutations/site_billing_wire.json
+++ b/tests/mutations/site_billing_wire.json
@@ -1,0 +1,66 @@
+[
+  {
+    "label": "plan_tier stops reaching the wire — the Billing tab is blind again",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        plan_tier=getattr(doc, \"plan_tier\", None) or \"\",",
+    "replace": "",
+    "tests": [
+      "tests/cloud/sites/test_billing_state_on_the_wire.py::test_the_site_response_carries_the_plan_the_ui_renders"
+    ]
+  },
+  {
+    "label": "subscription_status stops reaching the wire — the awaiting-checkout bar never shows",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        subscription_status=getattr(doc, \"subscription_status\", None) or \"none\",",
+    "replace": "",
+    "tests": [
+      "tests/cloud/sites/test_billing_state_on_the_wire.py::test_a_pending_site_says_pending_rather_than_nothing",
+      "tests/cloud/sites/test_billing_state_on_the_wire.py::test_the_site_response_carries_the_plan_the_ui_renders"
+    ]
+  },
+  {
+    "label": "the renewal date is dropped — the plan card cannot say when it renews",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        annual_renewal_date=(\n            _renewal.isoformat()\n            if (_renewal := getattr(doc, \"annual_renewal_date\", None)) is not None\n            else None\n        ),",
+    "replace": "",
+    "tests": [
+      "tests/cloud/sites/test_billing_state_on_the_wire.py::test_the_site_response_carries_the_plan_the_ui_renders"
+    ]
+  },
+  {
+    "label": "a slot is offered on a tier that cannot hold a domain at all",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        domain_slots_available=resolved.custom_domain and not exceeded,",
+    "replace": "        domain_slots_available=not exceeded,",
+    "tests": [
+      "tests/cloud/sites/test_billing_state_on_the_wire.py::test_no_capability_means_no_slot_however_empty_the_workspace"
+    ]
+  },
+  {
+    "label": "the used count is hardcoded to zero — the UI never says the allowance is spent",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    exceeded, used, _limit = await _domain_cap_exceeded(workspace_id, doc)",
+    "replace": "    exceeded, used, _limit = (False, 0, None)",
+    "tests": [
+      "tests/cloud/sites/test_billing_state_on_the_wire.py::test_the_free_allowance_reads_as_spent_once_another_site_holds_a_domain"
+    ]
+  },
+  {
+    "label": "the entitlements read drops its tenant scope — any workspace can read any site's plan",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    doc = await _load(workspace_id, site_id)\n\n    from pocketpaw_ee.cloud.entitlements import service as entitlements_service",
+    "replace": "    from bson import ObjectId\n\n    doc = await _SiteDoc.find_one({\"_id\": ObjectId(site_id)})\n\n    from pocketpaw_ee.cloud.entitlements import service as entitlements_service",
+    "tests": [
+      "tests/cloud/sites/test_billing_state_on_the_wire.py::test_another_workspace_cannot_read_this_site_s_entitlements"
+    ]
+  },
+  {
+    "label": "a lapsed subscription still reports as paying",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        subscription_active=resolved.subscription_active,\n        badge_required=resolved.badge_required,",
+    "replace": "        subscription_active=True,\n        badge_required=resolved.badge_required,",
+    "tests": [
+      "tests/cloud/sites/test_billing_state_on_the_wire.py::test_a_lapsed_paid_site_loses_the_capability_and_says_so"
+    ]
+  }
+]


### PR DESCRIPTION
The UI branches on billing state the API never sent.

## What was missing

The frontend's `SiteSummary` and `SiteStatusResponse` both declare `plan_tier`, `subscription_status` and `annual_renewal_date`. The `[siteId]` page branches on them — the "awaiting checkout" bar gates on `subscription_status === "pending"`, and the Billing tab renders the current plan.

Neither backend DTO carried a single one of those fields. Counted directly:

```
SiteResponse        20 fields, billing fields: NONE
SiteStatusResponse  13 fields, billing fields: NONE
```

`_to_response` mapped zero of them. So every read came back `undefined`, every fallback took the "no per-site sub" branch, and a paid site rendered identically to a free one. The optional `?` on those TypeScript fields is what kept it quiet: nothing throws when a field that is always absent is always absent.

It survived because the frontend test does not test the page. It reimplements the page's derivation as a local `isPendingPayment` helper and feeds it hand-written strings, so it proves the rule is correct while saying nothing about whether the inputs ever arrive.

All three fields are already on the Site document, so mapping them costs no query.

## The entitlements read

`resolve_site_entitlements` has answered "may this site do X" since BC-9 and nothing exposed it per site. There is a `GET /entitlements`, but it is workspace-scoped. The frontend fetched entitlements nowhere at all, so a refusal could only be discovered by attempting the action.

New: `GET /sites/{site_id}/entitlements`.

Two of its fields are not on `SiteEntitlements`, and they are the ones that turn a message from useless into useful:

**`domained_sites_used`**. *"You cannot add a domain"* and *"your one free domain is on another site"* call for different actions from the user. Upgrade versus move it. Only the count separates them, and only the second is recoverable without paying.

**`domain_slots_available`** — computed by the **same** `_domain_cap_exceeded` that `add_domain` calls, not a second copy of the rule. Two copies would eventually disagree, and the failure direction is the ugly one: a button that looks enabled and 402s. Reusing it also inherits its three subtle rules for free: count sites not hostnames, floor sites only, exclude the site being asked about.

It is its own endpoint rather than fields on the list response because the slot answer needs a workspace-wide count, and riding that on `GET /sites` would run one count per gallery card. Only a surface that actually offers a gated control pays for the lookup.

## Tests

Ten written first, all failing. Seven mutations, all caught.

Worth naming: **the tenant-scope mutation.** Entitlements describe what someone is paying for, and a raw `find_one` on the id alone would answer for any workspace's site to any caller. The read goes through `_load` like every other site read, and there is a test that proves an intruding workspace gets a 404.

**One mutation escaped first, and the reason is the interesting part.** The guard "no capability means no slot" is unreachable with today's catalog. Every tier inherits the free floor's single domained site, so `custom_domain` is `True` for all of them. I checked six tier/status combinations, including a cancelled paid tier and an unknown one; there is no input that makes it false.

The rule is still right: the cap answers "how many more", not "may you at all", and a tier mapped to 0 would otherwise be handed a slot and then refused. Rather than leave that as dead code asserting nothing, the test drives the resolver to the state the catalog cannot currently produce, so the guard is observed instead of assumed. If a paid-only-domains tier ever ships, its test already exists.

## Notes

Stacked on `fix/site-republish-double-billing` (#1998) — merge that first.

`plan_tier` is `""` rather than null when unstamped, so "this site has no tier" and "the backend did not send a tier" stay distinguishable on the wire. That distinction is exactly what went missing here, and it should not be reintroduced one level down.

The paw-enterprise branch of the same name consumes this. Until it merges nothing reads the new fields; until **this** merges, that branch's entitlement read 404s and both its gates stay inert, behaving exactly as they do today.
