### PR TITLE
Every colour is settable, and the light/dark choice finally applies

### DIFF
--- a/ee/pocketpaw_ee/paw_bar/router.py
+++ b/ee/pocketpaw_ee/paw_bar/router.py
@@ -1038,7 +1038,21 @@ def _pawbar_frame_config(
         # filled it, so the whole white-label path was dead wire. ``theme`` was
         # never emitted at all, which is why every bar was dark regardless.
         "tokens": look.tokens(),
+        # ``scheme``, not ``theme`` (2026-08-22). This line said ``theme`` from
+        # the day the appearance model landed, and the widget stopped reading
+        # that key on 2026-08-19 — the one-theme change moved it to ``scheme``
+        # and left ``theme`` explicitly ignored so old frame HTML would keep
+        # booting. Nothing ever sent ``scheme``. So the owner's light/dark
+        # choice has never once reached a bar: every widget fell through to
+        # 'auto' and resolved off the host page instead.
+        #
+        # ``theme`` stays alongside it, carrying the same value, because a
+        # deployed bundle older than the one-theme change still reads it and a
+        # frame is served to whatever is already on the customer's page.
+        "scheme": look.surface_mode,
         "theme": look.surface_mode,
+        # How the docked bar rests — narrow-and-widens-on-hover, or full width.
+        "barResting": look.bar_resting,
         "agentName": look.agent_name,
         "agentSubtitle": look.agent_subtitle,
         "agentAvatar": look.agent_avatar_url,

--- a/src/pocketpaw/paw_bar/appearance.py
+++ b/src/pocketpaw/paw_bar/appearance.py
@@ -39,6 +39,15 @@ _HEX_RE = re.compile(r"^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$")
 _RADIUS_RANGE = (0, 32)
 _BLUR_RANGE = (0, 48)
 _HERO_HEIGHT_RANGE = (120, 340)
+# How opaque the panel ground is over an unknown host page. The floor is not 0:
+# a fully transparent surface is not a "clear" widget, it is unreadable text
+# floating over someone else's photograph, and the blur cannot rescue it.
+_SURFACE_OPACITY_RANGE = (55, 100)
+# Hairlines and hover washes, as a percentage of ink. 0 is allowed on both --
+# "no borders at all" is a legitimate look -- but the ceiling is well short of
+# 100, where a hairline stops being a hairline.
+_LINE_STRENGTH_RANGE = (0, 30)
+_WASH_STRENGTH_RANGE = (0, 20)
 
 # The widget ships no webfonts (an 80KB budget and a third-party origin per
 # font), so a family is chosen from stacks the bundle already declares rather
@@ -54,7 +63,20 @@ FONT_STACKS: dict[str, str] = {
 }
 
 LAUNCHER_POSITIONS = frozenset({"bottom-right", "bottom-left"})
-SURFACE_MODES = frozenset({"dark", "light"})
+# "auto" (2026-08-22) means FOLLOW THE CUSTOMER'S OWN SITE, and it is the new
+# default for a reason that is really a bug report: this field never reached the
+# widget at all. The frame emitted it as ``theme``, and the widget stopped
+# reading ``theme`` on 2026-08-19 (the one-theme change) in favour of ``scheme``,
+# which nothing ever sent. So every bar has been resolving light-or-dark from the
+# host page regardless of what its owner picked -- which is exactly what "auto"
+# means. Defaulting to it keeps every existing bar looking identical while the
+# setting starts working for the owners who set it deliberately.
+SURFACE_MODES = frozenset({"dark", "light", "auto"})
+# How the docked bar rests. "compact" is a narrow pill that widens to the full
+# composer on hover or focus; "full" is the whole-width bar. A visitor on a
+# coarse pointer gets the full bar either way -- the widget will not hand a
+# touch device a control that only opens with a gesture it cannot make.
+BAR_RESTING = frozenset({"full", "compact"})
 HERO_STYLES = frozenset({"gradient", "solid", "image"})
 # Motion presets. "none" is not the same as the visitor's reduced-motion
 # setting: this is the OWNER choosing a calmer bar for everyone, while the
@@ -104,6 +126,84 @@ def _safe_image_url(value: str) -> str:
     if lowered.startswith("data:image/"):
         return "" if any(c in v for c in "()\"'\\ \n\r\t;") else v
     return ""
+
+
+# ---------------------------------------------------------------------------
+# Colour maths
+# ---------------------------------------------------------------------------
+#
+# Everything below PARSES a validated hex into three ints and re-emits a literal
+# this module builds character by character. No stored string reaches the
+# stylesheet, which is the same posture the rest of the file keeps -- it just
+# has more arithmetic in it now.
+
+
+def _hex_to_rgb(value: str) -> tuple[int, int, int]:
+    """`#abc` or `#aabbcc` -> (r, g, b). Assumes _HEX_RE has already passed."""
+    v = value.lstrip("#")
+    if len(v) == 3:
+        v = "".join(c * 2 for c in v)
+    return int(v[0:2], 16), int(v[2:4], 16), int(v[4:6], 16)
+
+
+def _luminance(rgb: tuple[int, int, int]) -> float:
+    """Perceived lightness, 0 (black) to 1 (white).
+
+    The sRGB coefficients rather than a plain mean, because a plain mean calls
+    pure blue and pure yellow equally light and then picks white type for both.
+    """
+    r, g, b = (c / 255 for c in rgb)
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b
+
+
+def _mix(
+    rgb: tuple[int, int, int], toward: tuple[int, int, int], amount: float
+) -> tuple[int, int, int]:
+    """Move `rgb` a fraction of the way toward another colour."""
+    return tuple(  # type: ignore[return-value]
+        _clamp(round(c + (t - c) * amount), 0, 255) for c, t in zip(rgb, toward)
+    )
+
+
+_WHITE = (255, 255, 255)
+_BLACK = (0, 0, 0)
+
+
+def _rgba(rgb: tuple[int, int, int], opacity_pct: int) -> str:
+    """An `rgba(r, g, b, a)` literal we assemble from ints."""
+    r, g, b = rgb
+    alpha = _clamp(opacity_pct, 0, 100) / 100
+    return f"rgba({r}, {g}, {b}, {alpha:g})"
+
+
+def _surface_scale(base_hex: str, opacity: int) -> dict[str, str]:
+    """The four surface steps plus a legible ink, from ONE owner colour.
+
+    This exists because of a footgun documented in the widget's own tokens.css:
+    a light `--pawbar-surface` with everything else left alone is white type on
+    a white panel. The scale needs five values that agree with each other, and
+    an owner picking a brand colour out of a swatch has no way to know that.
+
+    So they pick the panel, and the direction is derived. "Raised" means lighter
+    than the panel on a dark widget and whiter-still on a light one; "sunken" is
+    the opposite; and the ink flips to whichever end of the range stays readable
+    on the ground they chose. One decision in, a coherent widget out.
+    """
+    base = _hex_to_rgb(base_hex)
+    dark = _luminance(base) < 0.5
+    lift, drop = (_WHITE, _BLACK) if dark else (_BLACK, _WHITE)
+    return {
+        "--pawbar-surface": _rgba(base, opacity),
+        # Popovers must OCCLUDE what is behind them, so this one is deliberately
+        # close to opaque whatever the owner chose for the panel.
+        "--pawbar-surface-strong": _rgba(_mix(base, lift, 0.06), max(opacity, 94)),
+        "--pawbar-surface-raised": _rgba(_mix(base, lift, 0.12), min(100, opacity + 6)),
+        "--pawbar-surface-sunken": _rgba(_mix(base, drop, 0.10), max(40, opacity - 30)),
+        # Not pure white or pure black: both read as a harsher widget than the
+        # surface underneath them deserves, and the near-values still clear
+        # contrast comfortably at the opacities above.
+        "--pawbar-ink": _rgba(_mix(_WHITE if dark else _BLACK, base, 0.06), 100),
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -183,11 +283,117 @@ class MotionAppearance(BaseModel):
         return True
 
 
+class ColorAppearance(BaseModel):
+    """Every colour in the widget the owner may name, beyond the accent.
+
+    ALL OF THE HEX FIELDS DEFAULT TO "", AND "" MEANS "THE WIDGET DECIDES". That
+    is the same rule the whole token map follows: a token we do not emit is a
+    token the widget's own stylesheet still owns, so a later retune of the base
+    scale reaches every site that never overrode it. Emitting defaults here
+    would freeze every site to whatever the values were on the day they saved.
+
+    Why this exists at all: the accent was the ONLY colour an owner could set,
+    and the bubbles, the ring and the hero did not follow it — three literals in
+    tokens.css that happened to spell the same blue. So "change my brand colour"
+    produced a widget that disagreed with itself. The widget side of that is
+    fixed (they derive from the accent now); this is the other half, for an
+    owner who wants to name them individually.
+    """
+
+    # The panel ground. Setting THIS is the big one — see `_surface_scale`,
+    # which derives the other three surface steps and a legible ink from it,
+    # because a light surface with everything else left alone is white type on
+    # a white panel and no colour picker can warn you about that.
+    surface: str = ""
+    surface_opacity: int = 86
+    # Type and hairlines. Left "" it follows the surface; set explicitly it
+    # wins, for an owner who wants warm-grey type on a near-black panel.
+    ink: str = ""
+    accent_fg: str = ""
+    # The three speakers. "" leaves each deriving from the accent.
+    user_bubble: str = ""
+    assistant_bubble: str = ""
+    owner_bubble: str = ""
+    ring: str = ""
+    # Deliberately separate from the accent, and this is the one place that
+    # matters most: an unread count re-skinned to a calm brand colour stops
+    # reading as "something needs you".
+    unread: str = ""
+    danger: str = ""
+    # How present the hairlines and hover washes are, as a percentage of ink.
+    line_strength: int = 11
+    wash_strength: int = 5
+
+    @field_validator(
+        "surface",
+        "ink",
+        "accent_fg",
+        "user_bubble",
+        "assistant_bubble",
+        "owner_bubble",
+        "ring",
+        "unread",
+        "danger",
+    )
+    @classmethod
+    def _hex_only(cls, v: str) -> str:
+        v = (v or "").strip()
+        return v if _HEX_RE.match(v) else ""
+
+    @field_validator("surface_opacity")
+    @classmethod
+    def _bounded_opacity(cls, v: int) -> int:
+        return _clamp(v, *_SURFACE_OPACITY_RANGE)
+
+    @field_validator("line_strength")
+    @classmethod
+    def _bounded_line(cls, v: int) -> int:
+        return _clamp(v, *_LINE_STRENGTH_RANGE)
+
+    @field_validator("wash_strength")
+    @classmethod
+    def _bounded_wash(cls, v: int) -> int:
+        return _clamp(v, *_WASH_STRENGTH_RANGE)
+
+    def tokens(self) -> dict[str, str]:
+        """Render to ``--pawbar-*``. Only what the owner actually named."""
+        out: dict[str, str] = {}
+
+        if self.surface:
+            # One colour in, a coherent five-token palette out.
+            out.update(_surface_scale(self.surface, self.surface_opacity))
+        if self.ink:
+            # An explicit ink beats the one derived above, which is why this
+            # runs second rather than inside the branch.
+            out["--pawbar-ink"] = _rgba(_hex_to_rgb(self.ink), 100)
+
+        for token, value in (
+            ("--pawbar-accent-fg", self.accent_fg),
+            ("--pawbar-user-bubble", self.user_bubble),
+            ("--pawbar-assistant-bubble", self.assistant_bubble),
+            ("--pawbar-owner-bubble", self.owner_bubble),
+            ("--pawbar-ring", self.ring),
+            ("--pawbar-unread", self.unread),
+            ("--pawbar-danger", self.danger),
+        ):
+            if value:
+                out[token] = _rgba(_hex_to_rgb(value), 100)
+
+        # Always emitted: these are numbers with a working default rather than
+        # overrides, and the widget multiplies both to reach its second step.
+        out["--pawbar-line-strength"] = f"{self.line_strength}%"
+        out["--pawbar-wash-strength"] = f"{self.wash_strength}%"
+        return out
+
+
 class ConciergeAppearance(BaseModel):
     """The owner's full Paw Bar appearance. Every field defaults to today's look."""
 
     accent: str = "#3b6fe0"
-    surface_mode: str = "dark"
+    surface_mode: str = "auto"
+    # How the docked bar rests: a narrow pill that widens on hover, or the full
+    # composer at all times. See BAR_RESTING.
+    bar_resting: str = "compact"
     radius: int = 20
     blur: int = 28
     font: str = "system"
@@ -203,6 +409,7 @@ class ConciergeAppearance(BaseModel):
     launcher: LauncherAppearance = Field(default_factory=LauncherAppearance)
     hero: HeroAppearance = Field(default_factory=HeroAppearance)
     motion: MotionAppearance = Field(default_factory=MotionAppearance)
+    colors: ColorAppearance = Field(default_factory=ColorAppearance)
 
     @field_validator("accent")
     @classmethod
@@ -213,7 +420,12 @@ class ConciergeAppearance(BaseModel):
     @field_validator("surface_mode")
     @classmethod
     def _known_mode(cls, v: str) -> str:
-        return v if v in SURFACE_MODES else "dark"
+        return v if v in SURFACE_MODES else "auto"
+
+    @field_validator("bar_resting")
+    @classmethod
+    def _known_resting(cls, v: str) -> str:
+        return v if v in BAR_RESTING else "compact"
 
     @field_validator("font")
     @classmethod
@@ -280,6 +492,10 @@ class ConciergeAppearance(BaseModel):
             out["--pawbar-hero-to"] = (
                 hero.from_color if hero.style == "solid" and hero.from_color else hero.to_color
             )
+
+        # The owner's named colours. Last, so an explicitly-named token wins over
+        # anything derived above it.
+        out.update(self.colors.tokens())
 
         duration, easing, travel = _MOTION.get(self.motion.preset, _MOTION["lively"])
         out["--pawbar-duration"] = f"{duration}ms"

--- a/tests/cloud/test_paw_bar_appearance.py
+++ b/tests/cloud/test_paw_bar_appearance.py
@@ -21,6 +21,7 @@ import pytest
 
 from pocketpaw.paw_bar.appearance import (
     FONT_STACKS,
+    ColorAppearance,
     ConciergeAppearance,
     HeroAppearance,
     LauncherAppearance,
@@ -37,7 +38,14 @@ def test_defaults_reproduce_todays_look():
     makes the field additive and the migration unnecessary."""
     look = ConciergeAppearance()
 
-    assert look.surface_mode == "dark"
+    # "auto" — follow the customer's own site. It reads like a changed default
+    # and is actually the SHIPPED behaviour finally being stated honestly: the
+    # frame emitted this as ``theme``, the widget has read ``scheme`` since the
+    # one-theme change, so no bar has ever received this field and every one of
+    # them resolved light-or-dark off the host page. Defaulting to "auto" is
+    # what keeps that true now that the frame really sends it.
+    assert look.surface_mode == "auto"
+    assert look.bar_resting == "compact"
     assert look.radius == 20
     assert look.blur == 28
     assert look.motion.preset == "lively"
@@ -140,7 +148,7 @@ def test_an_unknown_font_falls_back_rather_than_being_stored():
 @pytest.mark.parametrize(
     ("field", "cls", "hostile", "expected"),
     [
-        ("surface_mode", ConciergeAppearance, "neon", "dark"),
+        ("surface_mode", ConciergeAppearance, "neon", "auto"),
         ("style", HeroAppearance, "iframe", "gradient"),
         ("position", LauncherAppearance, "middle-of-the-screen", "bottom-right"),
         ("preset", MotionAppearance, "seizure", "lively"),
@@ -245,7 +253,10 @@ def test_a_site_with_no_appearance_still_frames():
     and the public frame must render for those rather than 500 the visitor."""
     config = _config(appearance=None)
 
-    assert config["theme"] == "dark"
+    # See test_defaults_reproduce_todays_look: "auto" is what these sites have
+    # effectively been getting all along.
+    assert config["theme"] == "auto"
+    assert config["scheme"] == "auto"
     assert config["tokens"]["--pawbar-radius"] == "20px"
     assert config["agentName"] == ""
 
@@ -299,3 +310,157 @@ def test_a_hostile_appearance_reaches_the_frame_defanged():
     assert "--pawbar-accent" not in tokens
     assert "--pawbar-hero-image" not in tokens
     assert not any("evil.test" in v for v in tokens.values())
+
+
+# --------------------------------------------------------------------------- #
+# The light/dark choice reaches the widget at all (2026-08-22)
+# --------------------------------------------------------------------------- #
+
+
+def test_the_scheme_key_is_what_the_widget_actually_reads():
+    """THE REGRESSION THIS EXISTS FOR, and it went unnoticed for months.
+
+    The frame emitted the owner's light/dark choice as ``theme``. The widget
+    stopped reading ``theme`` on 2026-08-19 — the one-theme change moved it to
+    ``scheme`` and left ``theme`` explicitly ignored so older frame HTML would
+    keep booting — and nothing ever sent ``scheme``. Both halves had tests.
+    Both halves passed. The setting still did nothing, because no test on
+    either side asserted that the key one wrote is the key the other reads.
+
+    Mutation that must break this: drop the ``"scheme"`` line from
+    ``_pawbar_frame_config``.
+    """
+    config = _config(appearance=ConciergeAppearance(surface_mode="light"))
+
+    assert config["scheme"] == "light"
+    # Still emitted alongside, for a bundle deployed before the rename that is
+    # already sitting on a customer's page.
+    assert config["theme"] == "light"
+
+
+def test_the_resting_mode_reaches_the_widget():
+    config = _config(appearance=ConciergeAppearance(bar_resting="full"))
+    assert config["barResting"] == "full"
+
+
+# --------------------------------------------------------------------------- #
+# Colours — the whole palette, not just the accent
+# --------------------------------------------------------------------------- #
+
+
+def test_unset_colours_are_absent_so_the_stylesheet_still_owns_them():
+    """The rule the whole token map follows. A colour we restate at its default
+    freezes every site to the value current at save time, and a later retune of
+    the base scale reaches nobody."""
+    tokens = ColorAppearance().tokens()
+
+    for absent in (
+        "--pawbar-surface",
+        "--pawbar-ink",
+        "--pawbar-user-bubble",
+        "--pawbar-ring",
+        "--pawbar-unread",
+    ):
+        assert absent not in tokens
+
+    # The two that ARE always emitted: numbers with a working default rather
+    # than overrides, and the widget derives a second step from each.
+    assert tokens["--pawbar-line-strength"] == "11%"
+    assert tokens["--pawbar-wash-strength"] == "5%"
+
+
+def test_one_surface_colour_produces_a_legible_widget():
+    """Setting a light panel and nothing else used to be white type on a white
+    panel — tokens.css documents that footgun, and a colour picker cannot warn
+    anyone about it. So the ink is derived from the ground rather than left to
+    the owner to work out."""
+    light = ColorAppearance(surface="#f7f7fb").tokens()
+    dark = ColorAppearance(surface="#101018").tokens()
+
+    # Four surface steps and an ink, every time, from the one input.
+    for token in (
+        "--pawbar-surface",
+        "--pawbar-surface-strong",
+        "--pawbar-surface-raised",
+        "--pawbar-surface-sunken",
+        "--pawbar-ink",
+    ):
+        assert token in light and token in dark
+
+    def _channels(value: str) -> tuple[int, int, int]:
+        inner = value[value.index("(") + 1 : value.index(")")]
+        r, g, b = (int(p.strip()) for p in inner.split(",")[:3])
+        return r, g, b
+
+    # The ink flips with the ground. This is the assertion that actually
+    # prevents the bug: a light panel must not get light type.
+    assert sum(_channels(light["--pawbar-ink"])) < 200, "dark ink on a light panel"
+    assert sum(_channels(dark["--pawbar-ink"])) > 550, "light ink on a dark panel"
+
+
+def test_an_explicit_ink_beats_the_derived_one():
+    """Derivation is a floor, not a ceiling — an owner who wants warm-grey type
+    on a near-black panel says so and wins."""
+    tokens = ColorAppearance(surface="#101018", ink="#c8b8a0").tokens()
+    assert tokens["--pawbar-ink"] == "rgba(200, 184, 160, 1)"
+
+
+def test_every_colour_field_refuses_a_value_that_is_not_hex():
+    """Each of these becomes the right-hand side of a CSS custom property in a
+    document the widget serves, so a value that is not a colour is a style
+    injection. Refused to "" — which means "the widget decides" — rather than
+    stored and emitted.
+
+    Mutation that must break this: widen _HEX_RE, or drop a field name from the
+    validator's list.
+    """
+    hostile = "red; background-image: url(https://evil.test/x.png)"
+    look = ColorAppearance(
+        surface=hostile,
+        ink=hostile,
+        accent_fg=hostile,
+        user_bubble=hostile,
+        assistant_bubble=hostile,
+        owner_bubble=hostile,
+        ring=hostile,
+        unread=hostile,
+        danger=hostile,
+    )
+    assert look.surface == ""
+    assert look.ink == ""
+    tokens = look.tokens()
+    assert not any("url(" in v or ";" in v for v in tokens.values())
+
+
+def test_named_colours_reach_the_token_map():
+    tokens = ColorAppearance(
+        user_bubble="#e2662a",
+        owner_bubble="#123",
+        unread="#ff0044",
+    ).tokens()
+
+    assert tokens["--pawbar-user-bubble"] == "rgba(226, 102, 42, 1)"
+    # Three-digit hex expands rather than being echoed.
+    assert tokens["--pawbar-owner-bubble"] == "rgba(17, 34, 51, 1)"
+    assert tokens["--pawbar-unread"] == "rgba(255, 0, 68, 1)"
+
+
+@pytest.mark.parametrize(
+    ("field", "given", "expected"),
+    [
+        ("surface_opacity", 5, 55),
+        ("surface_opacity", 400, 100),
+        ("line_strength", -3, 0),
+        ("line_strength", 900, 30),
+        ("wash_strength", 999, 20),
+    ],
+)
+def test_numeric_colour_fields_are_clamped(field, given, expected):
+    assert getattr(ColorAppearance(**{field: given}), field) == expected
+
+
+def test_colours_ride_through_the_full_appearance():
+    """The sub-model is wired into the appearance the frame actually renders,
+    not merely present on the class."""
+    look = ConciergeAppearance(colors=ColorAppearance(user_bubble="#e2662a"))
+    assert look.tokens()["--pawbar-user-bubble"] == "rgba(226, 102, 42, 1)"

--- a/tests/mutations/paw_bar_appearance.json
+++ b/tests/mutations/paw_bar_appearance.json
@@ -121,5 +121,68 @@
     "tests": [
       "tests/cloud/test_paw_bar_appearance.py::test_an_overlong_launcher_label_is_bounded_before_it_reaches_the_frame"
     ]
+  },
+  {
+    "label": "the frame stops sending `scheme` — the light/dark choice is invisible to the widget again",
+    "file": "ee/pocketpaw_ee/paw_bar/router.py",
+    "find": "        \"scheme\": look.surface_mode,\n",
+    "replace": "",
+    "tests": [
+      "tests/cloud/test_paw_bar_appearance.py::test_the_scheme_key_is_what_the_widget_actually_reads"
+    ]
+  },
+  {
+    "label": "the resting mode never reaches the frame — the bar can only rest one way",
+    "file": "ee/pocketpaw_ee/paw_bar/router.py",
+    "find": "        \"barResting\": look.bar_resting,\n",
+    "replace": "",
+    "tests": [
+      "tests/cloud/test_paw_bar_appearance.py::test_the_resting_mode_reaches_the_widget"
+    ]
+  },
+  {
+    "label": "the colour fields echo whatever they are given — nine style-injection points",
+    "file": "src/pocketpaw/paw_bar/appearance.py",
+    "find": "    @field_validator(\n        \"surface\",\n        \"ink\",\n        \"accent_fg\",\n        \"user_bubble\",\n        \"assistant_bubble\",\n        \"owner_bubble\",\n        \"ring\",\n        \"unread\",\n        \"danger\",\n    )\n    @classmethod\n    def _hex_only(cls, v: str) -> str:\n        v = (v or \"\").strip()\n        return v if _HEX_RE.match(v) else \"\"",
+    "replace": "    @field_validator(\n        \"surface\",\n        \"ink\",\n        \"accent_fg\",\n        \"user_bubble\",\n        \"assistant_bubble\",\n        \"owner_bubble\",\n        \"ring\",\n        \"unread\",\n        \"danger\",\n    )\n    @classmethod\n    def _hex_only(cls, v: str) -> str:\n        return (v or \"\").strip()",
+    "tests": [
+      "tests/cloud/test_paw_bar_appearance.py::test_every_colour_field_refuses_a_value_that_is_not_hex"
+    ]
+  },
+  {
+    "label": "the ink stops following the ground — a light panel gets light type",
+    "file": "src/pocketpaw/paw_bar/appearance.py",
+    "find": "    dark = _luminance(base) < 0.5",
+    "replace": "    dark = True",
+    "tests": [
+      "tests/cloud/test_paw_bar_appearance.py::test_one_surface_colour_produces_a_legible_widget"
+    ]
+  },
+  {
+    "label": "an explicitly named ink is discarded in favour of the derived one",
+    "file": "src/pocketpaw/paw_bar/appearance.py",
+    "find": "            out[\"--pawbar-ink\"] = _rgba(_hex_to_rgb(self.ink), 100)",
+    "replace": "            pass",
+    "tests": [
+      "tests/cloud/test_paw_bar_appearance.py::test_an_explicit_ink_beats_the_derived_one"
+    ]
+  },
+  {
+    "label": "the owner's colours never reach the appearance the frame renders",
+    "file": "src/pocketpaw/paw_bar/appearance.py",
+    "find": "        out.update(self.colors.tokens())",
+    "replace": "        pass",
+    "tests": [
+      "tests/cloud/test_paw_bar_appearance.py::test_colours_ride_through_the_full_appearance"
+    ]
+  },
+  {
+    "label": "unset colours are restated at their defaults, freezing every site to today's base",
+    "file": "src/pocketpaw/paw_bar/appearance.py",
+    "find": "            if value:\n                out[token] = _rgba(_hex_to_rgb(value), 100)",
+    "replace": "            out[token] = _rgba(_hex_to_rgb(value or \"#3b6fe0\"), 100)",
+    "tests": [
+      "tests/cloud/test_paw_bar_appearance.py::test_unset_colours_are_absent_so_the_stylesheet_still_owns_them"
+    ]
   }
 ]


### PR DESCRIPTION
The backend half of the Paw Bar customization work. The widget half is qbtrix/paw-bar#14 and the editor is paw-enterprise. All three are additive and defaulted, so they can merge in any order.

## The light/dark setting has never once worked

This is the part worth reading twice.

The frame emitted the owner's choice as `theme`. The widget stopped reading `theme` on 2026-08-19, when the one-theme change moved it to `scheme` and left `theme` explicitly ignored so older frame HTML would keep booting. Nothing has ever sent `scheme`.

Both sides had tests. Both passed. Neither asserted that the key one side writes is the key the other side reads. So every bar has resolved light or dark off the host page regardless of what its owner picked in the dashboard.

The frame sends `scheme` now, with `theme` alongside it for a bundle already sitting on a customer's page. `SURFACE_MODES` gains `auto` and the default becomes `auto`, which is less a changed default than the shipped behaviour finally being stated honestly: following the host page is what every bar has actually been doing.

Worth flagging before merge: a site that deliberately saved light or dark will start getting it. That is the setting beginning to work, but it means a bar can change appearance on deploy. The editor has also been sending `surface_mode: 'auto'` since it shipped, which the old validator silently coerced to `dark`.

## Colours beyond the accent

The accent was the only colour an owner could name, and it did not carry. The widget PR fixes the derivation; this adds `ColorAppearance` for owners who want the pieces to disagree deliberately: the panel and its opacity, the ink, all three bubble colours, the focus ring, text on accent, the unread badge, errors, and the strength of hairlines and hover washes.

Setting the panel derives the rest. A light surface with everything else left alone is white type on a white panel, which the widget's own `tokens.css` documents as a footgun and no colour picker can warn anyone about. One colour in gives four surface steps and an ink whose direction follows the ground's luminance.

Everything else stays optional and absent when unset. That is the rule the whole token map follows: a value the server does not emit is one the widget's stylesheet still owns, so retuning the base scale later still reaches every site that never overrode it.

The security posture is unchanged. Every colour is parsed to three ints and re-emitted as a literal this module assembles; nothing stored reaches the stylesheet. The nine new hex fields go through the same `_HEX_RE` gate as the accent.

## Resting mode

`bar_resting` picks whether the docked bar rests as a narrow pill that widens on hover or stays full width. Coarse pointers get the full bar either way.

## Mutations

Seven new entries in `tests/mutations/paw_bar_appearance.json`, all caught, including the one that matters most: delete the `scheme` line and the months-long bug comes back with the suite going red. All 20 in that plan are caught, and `mutate.py --validate` still resolves 665 anchors across 54 plans.

51 tests in `test_paw_bar_appearance.py`, ruff clean. Three existing assertions changed to match the new default, each with a comment explaining why.

The twelve unrelated tests failing under `-k paw_bar` (actions preambles, escape hatch, agent provisioning) fail identically on `dev`. I checked by stashing.