### PR TITLE
Price the site ladder monthly at $0 / $5 / $19

### DIFF
--- a/ee/pocketpaw_ee/cloud/billing/service.py
+++ b/ee/pocketpaw_ee/cloud/billing/service.py
@@ -51,7 +51,7 @@
 #   dispatch now FORKS on a ``site_id`` in the verified event metadata. A delivery
 #   WITH a ``site_id`` is a PER-SITE annual sub (each published site has its own
 #   plan) and routes to ``_handle_site_subscription_event``, which updates the
-#   SITE's ``subscription_status`` / ``annual_renewal_date`` (active/renewed →
+#   SITE's ``subscription_status`` / ``renewal_date`` (active/renewed →
 #   active; cancelled → cancelled) via the sites service — it NEVER grants
 #   workspace credits and NEVER changes ``Workspace.plan``. A delivery WITHOUT a
 #   ``site_id`` is the unchanged BC-7 workspace-plan path. Same verified-signature
@@ -105,8 +105,9 @@
 from __future__ import annotations
 
 import logging
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 
+from dateutil.relativedelta import relativedelta
 from pymongo.errors import DuplicateKeyError
 
 from pocketpaw_ee.cloud._core.errors import NoActiveSubscription, ValidationError
@@ -809,13 +810,20 @@ async def _handle_site_subscription_event(event: SubscriptionEvent) -> dict:
             )
             status = "active"
         elif event.type == _SUB_RENEWED:
-            # Already live — just refresh the annual renewal date (no re-deploy).
+            # Already live — just refresh the renewal date (no re-deploy).
+            #
+            # ONE MONTH, not 365 days. Site plans went monthly on 2026-08-22; a
+            # renewal that stamps a year ahead on a monthly plan puts every
+            # subsequent renewal a year out, and the site keeps its paid
+            # capabilities for that whole year regardless of what happens to the
+            # card. relativedelta rather than timedelta(days=30) so the date does
+            # not drift backwards through the calendar over a year of renewals.
             await sites_service.mark_site_subscription(
                 workspace_id=event.workspace_id,
                 site_id=event.site_id,
                 status="active",
                 subscription_id=event.subscription_id or None,
-                annual_renewal_date=datetime.now(UTC) + timedelta(days=365),
+                renewal_date=datetime.now(UTC) + relativedelta(months=1),
             )
             status = "active"
         elif event.type == _SUB_CANCELLED:
@@ -832,7 +840,7 @@ async def _handle_site_subscription_event(event: SubscriptionEvent) -> dict:
                 site_id=event.site_id,
                 status="cancelled",
                 subscription_id=event.subscription_id or None,
-                annual_renewal_date=None,
+                renewal_date=None,
             )
             status = "cancelled"
         else:

--- a/ee/pocketpaw_ee/cloud/billing/site_plans.py
+++ b/ee/pocketpaw_ee/cloud/billing/site_plans.py
@@ -5,7 +5,7 @@
 #
 # This is the read-only catalog the per-site subscription flow (publish_pocket)
 # builds on. For each site tier it pairs:
-#   * ``annual_price_usd`` — the recurring annual price for the tier (USD,
+#   * ``monthly_price_usd`` — the recurring MONTHLY price for the tier (USD,
 #     whole dollars). The intended sticker; the live charge runs through Dodo.
 #   * ``dodo_product_id`` — the Dodo recurring-product id for the tier, or None
 #     until config populates it (read from the ``POCKETPAW_DODO_SITE_PRODUCTS``
@@ -77,10 +77,18 @@ from dataclasses import dataclass
 #   pro      — $120/yr  — adds analytics + uncapped custom domains.
 #   business — $480/yr  — adds the WAF + edge cache controls on top of pro.
 # ---------------------------------------------------------------------------
-_SITE_PLAN_ANNUAL_PRICE_USD: dict[str, int] = {
+# MONTHLY, and the rename is load-bearing rather than cosmetic: a field called
+# ``annual_price_usd`` holding 5 reads as $5/YEAR to every future caller, which is
+# below the Cloudflare floor for a single custom hostname ($0.10/hostname/month
+# past the first 100). The old $120/$480 annual figures had no cost basis at all.
+#
+# Decided 2026-08-22. See docs/design/drafts/2026-08-21-paw-sites-pricing-revision.md
+# for the floor, the market comparables, and why annual-only billing was its own
+# conversion problem.
+_SITE_PLAN_MONTHLY_PRICE_USD: dict[str, int] = {
     "basic": 0,
-    "pro": 120,
-    "business": 480,
+    "pro": 5,
+    "business": 19,
 }
 
 # The Cloudflare features each tier resells (BC-10 provisions them on publish).
@@ -95,6 +103,19 @@ _SITE_PLAN_CF_FEATURES: dict[str, frozenset[str]] = {
 # free floor and keeps its badge — that is the whole difference between free and
 # paid. Absent/unknown keys resolve False in ``_build``, so a typo means BADGED:
 # fail-closed, matching ``sites.badge``'s posture everywhere else.
+# The concierge is the ENTIRE difference between the $5 and $19 rungs, so it has
+# to be mapped per tier rather than derived. It used to be "any tier above the
+# floor", which was correct only while the tier meant to sell it did not exist;
+# once the ladder has two paid rungs that derivation hands the cheap one the
+# expensive one's feature.
+#
+# ``.get(key, False)`` fails CLOSED: an unknown tier sells no concierge.
+_SITE_PLAN_SELLS_CONCIERGE: dict[str, bool] = {
+    "basic": False,
+    "pro": False,
+    "business": True,
+}
+
 _SITE_PLAN_BADGE_REMOVAL: dict[str, bool] = {
     "basic": False,
     "pro": True,
@@ -144,7 +165,7 @@ BASE_SITE_PLAN_KEY = "basic"
 class SitePlanTier:
     """One row of the per-site plan catalog — the declarative view of a site tier.
 
-    ``key`` matches the ``Site.plan_tier`` string. ``annual_price_usd`` is the
+    ``key`` matches the ``Site.plan_tier`` string. ``monthly_price_usd`` is the
     recurring annual sticker (USD, whole dollars). ``dodo_product_id`` is the
     recurring-product id, or None until config populates it. ``cloudflare_features``
     is the set of Cloudflare features the tier resells (BC-10 provisions them).
@@ -157,7 +178,7 @@ class SitePlanTier:
     """
 
     key: str
-    annual_price_usd: int
+    monthly_price_usd: int
     dodo_product_id: str | None
     cloudflare_features: frozenset[str]
     badge_removal: bool = False
@@ -179,25 +200,24 @@ class SitePlanTier:
         card can mark a tier unavailable instead of offering a button that quietly
         does nothing.
         """
-        return self.annual_price_usd == 0 or self.dodo_product_id is not None
+        return self.monthly_price_usd == 0 or self.dodo_product_id is not None
 
     @property
     def sells_concierge(self) -> bool:
         """Does this tier sell the visitor concierge at all?
 
-        Derived from the floor rather than a per-tier catalog dict like
-        ``badge_removal``: no tier grants concierge today and the tier that will
-        (``staff``) does not exist until the pricing-spec rekey, which is blocked
-        on an open decision. A dict would need a basic/pro/business mapping
-        invented now and rewritten then; "any tier above the floor" needs no
-        mapping and survives the rekey untouched.
+        Mapped per tier as of 2026-08-22, having previously been derived as "any
+        tier above the floor". That derivation was right only while no tier
+        actually sold the concierge — under the $0/$5/$19 ladder the concierge IS
+        the difference between the two paid rungs, so deriving it would give the
+        $5 tier the thing the $19 tier is for.
 
         This is the CATALOG question — "does this tier sell it" — and on its own
         entitles nobody. ``resolve_site_entitlements`` ANDs it with an active
         subscription to answer "may THIS site serve one", which is the question
         every public seam asks.
         """
-        return self.key != BASE_SITE_PLAN_KEY
+        return _SITE_PLAN_SELLS_CONCIERGE.get(self.key, False)
 
 
 def _dodo_product_for(key: str) -> str | None:
@@ -231,7 +251,7 @@ def _build(key: str) -> SitePlanTier:
     """
     return SitePlanTier(
         key=key,
-        annual_price_usd=_SITE_PLAN_ANNUAL_PRICE_USD.get(key, 0),
+        monthly_price_usd=_SITE_PLAN_MONTHLY_PRICE_USD.get(key, 0),
         dodo_product_id=_dodo_product_for(key),
         cloudflare_features=_SITE_PLAN_CF_FEATURES.get(key, frozenset()),
         badge_removal=_SITE_PLAN_BADGE_REMOVAL.get(key, False),
@@ -270,7 +290,7 @@ def get_site_plan(key: str | None) -> SitePlanTier | None:
     NOT silently substitute, so a typo in a lookup is visible rather than masked
     (mirrors ``billing.plans.get_plan``).
     """
-    if not key or key not in _SITE_PLAN_ANNUAL_PRICE_USD:
+    if not key or key not in _SITE_PLAN_MONTHLY_PRICE_USD:
         return None
     return _build(key)
 

--- a/ee/pocketpaw_ee/cloud/entitlements/dto.py
+++ b/ee/pocketpaw_ee/cloud/entitlements/dto.py
@@ -135,7 +135,7 @@ def entitlements_to_dto(ent: Entitlements) -> EntitlementsResponse:
 class SitePlanTierResponse(BaseModel):
     """One row of the PER-SITE plan catalog on the wire — mirrors ``SitePlanTier``.
 
-    ``annual_price_usd`` is the recurring annual sticker (USD, whole dollars).
+    ``monthly_price_usd`` is the recurring MONTHLY sticker (USD, whole dollars).
     ``cloudflare_features`` is the SORTED list of Cloudflare features the tier
     resells (deterministic JSON; BC-10 provisions these when a domain is added).
     ``dodo_product_id`` is None until config populates it.
@@ -156,7 +156,7 @@ class SitePlanTierResponse(BaseModel):
     """
 
     key: str
-    annual_price_usd: int
+    monthly_price_usd: int
     dodo_product_id: str | None = None
     cloudflare_features: list[str] = Field(default_factory=list)
     badge_removal: bool = False
@@ -174,7 +174,7 @@ def site_plan_tier_to_dto(tier: SitePlanTier) -> SitePlanTierResponse:
     """Map a frozen ``site_plans.SitePlanTier`` to its wire DTO (features sorted)."""
     return SitePlanTierResponse(
         key=tier.key,
-        annual_price_usd=tier.annual_price_usd,
+        monthly_price_usd=tier.monthly_price_usd,
         dodo_product_id=tier.dodo_product_id,
         cloudflare_features=sorted(tier.cloudflare_features),
         badge_removal=tier.badge_removal,

--- a/ee/pocketpaw_ee/cloud/models/site.py
+++ b/ee/pocketpaw_ee/cloud/models/site.py
@@ -81,12 +81,12 @@
 # annual plan (the Webflow model — each site has its own tier, not just the
 # workspace plan). ``plan_tier`` is the site-plan catalog key (basic | pro |
 # business — ``site_plans.SITE_PLAN_CATALOG``), ``subscription_id`` the Dodo
-# subscription this site's annual sub maps to, ``annual_renewal_date`` the next
+# subscription this site's annual sub maps to, ``renewal_date`` the next
 # renewal stamp the webhook updates, and ``subscription_status`` the lifecycle
 # (none | active | cancelled). ``service.publish_pocket`` stamps ``plan_tier`` +
 # ``subscription_id`` at publish; the per-site ``subscription.*`` webhook (routed
 # by a ``site_id`` on its metadata) advances ``subscription_status`` /
-# ``annual_renewal_date``. All default to backward-compatible values (None /
+# ``renewal_date``. All default to backward-compatible values (None /
 # "none") so every pre-BC-9 row and every workspace-plan-only site reads as having
 # no per-site sub — no migration.
 #
@@ -358,12 +358,12 @@ class Site(TimestampedDocument):
     # ``billing.site_plans``); None until a publish stamps one. ``subscription_id``
     # is the Dodo subscription id for this site's annual sub (None when Dodo is
     # unconfigured — the tier is recorded without a live charge in v1).
-    # ``annual_renewal_date`` is the next renewal stamp the per-site webhook
+    # ``renewal_date`` is the next renewal stamp the per-site webhook
     # updates; ``subscription_status`` tracks the lifecycle (none | active |
     # cancelled). Defaults keep pre-BC-9 / workspace-plan-only sites at "no sub".
     plan_tier: str | None = None
     subscription_id: str | None = None
-    annual_renewal_date: datetime | None = None
+    renewal_date: datetime | None = None
     subscription_status: str = "none"
     # charge-first: the deploy inputs captured at publish time for a PENDING paid
     # site, so the ``subscription.active`` webhook can run the deferred deploy

--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -248,7 +248,7 @@ class SiteResponse(BaseModel):
     # tier" and "the backend did not send a tier" stay distinguishable on the wire.
     plan_tier: str = ""
     subscription_status: str = "none"
-    annual_renewal_date: str | None = None
+    renewal_date: str | None = None
     # (none | provisioning | provisioned | failed). A DYNAMIC-site publish does NOT
     # deploy inline — it enqueues the ``provision_site`` job and returns immediately
     # with ``provision_status="provisioning"`` (``deployed=False``); the site goes

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -488,7 +488,7 @@
 #   for operator visibility of sites stuck pending past a threshold.
 #
 # Updated 2026-06-24 (feat/charge-first-sites — charge-first per-site publishing):
-# a PAID site tier (positive ``annual_price_usd`` AND a configured
+# a PAID site tier (positive ``monthly_price_usd`` AND a configured
 # ``dodo_product_id``) is now CHARGE-FIRST — published as PENDING and NOT deployed
 # live until payment confirms; a FREE/base tier still deploys instantly.
 #   * Extracted ``_deploy_site_doc`` — the generate + smoke-gate + Cloudflare/local
@@ -1751,9 +1751,9 @@ def _to_response(doc: _SiteDoc, pattern: str = "", engine: str = "") -> SiteResp
         # These were declared in the frontend and branched on, and never sent.
         plan_tier=getattr(doc, "plan_tier", None) or "",
         subscription_status=getattr(doc, "subscription_status", None) or "none",
-        annual_renewal_date=(
+        renewal_date=(
             _renewal.isoformat()
-            if (_renewal := getattr(doc, "annual_renewal_date", None)) is not None
+            if (_renewal := getattr(doc, "renewal_date", None)) is not None
             else None
         ),
         # DP0-4: the dynamic-site provision state (persisted) + the id of the job a
@@ -3594,7 +3594,7 @@ async def mark_site_subscription(
     site_id: str,
     status: str,
     subscription_id: str | None = None,
-    annual_renewal_date: datetime | None = None,
+    renewal_date: datetime | None = None,
 ) -> _SiteDoc | None:
     """Advance a site's per-site annual subscription lifecycle (BC-9).
 
@@ -3603,7 +3603,7 @@ async def mark_site_subscription(
     the Workspace / credits writes, the sites service owns the Site write, so the
     per-site sub state is updated HERE, not by billing reaching into the Site
     model. Sets ``subscription_status`` (active | cancelled), and on an
-    activation/renewal also advances ``annual_renewal_date``. Reuses the stored
+    activation/renewal also advances ``renewal_date``. Reuses the stored
     ``subscription_id`` when the caller passes one (a renewal may re-confirm it).
 
     Tenant-scoped on ``workspace`` via ``_load`` (a missing / cross-tenant /
@@ -3614,8 +3614,8 @@ async def mark_site_subscription(
     site.subscription_status = status
     if subscription_id:
         site.subscription_id = subscription_id
-    if annual_renewal_date is not None:
-        site.annual_renewal_date = annual_renewal_date
+    if renewal_date is not None:
+        site.renewal_date = renewal_date
     await site.save()
     return site
 
@@ -4888,7 +4888,7 @@ async def publish_pocket(
     tier = site_plans.get_site_plan(site_plan_key) or site_plans.get_site_plan(
         site_plans.BASE_SITE_PLAN_KEY
     )
-    is_paid = tier is not None and tier.annual_price_usd > 0
+    is_paid = tier is not None and tier.monthly_price_usd > 0
     dodo_configured = tier is not None and bool(tier.dodo_product_id)
 
     if is_paid and not dodo_configured:
@@ -5519,7 +5519,7 @@ async def activate_site(
     # ``deployed`` is a separately-loaded doc and this save must not write back a
     # stale value it read before that flip landed.
     deployed.subscription_status = "active"
-    deployed.annual_renewal_date = datetime.now(UTC) + timedelta(days=365)
+    deployed.renewal_date = datetime.now(UTC) + timedelta(days=365)
     await deployed.save()
 
     # Promote the pocket's draft to published — the durable "this was published"

--- a/tests/cloud/billing/test_site_plan_inclusions.py
+++ b/tests/cloud/billing/test_site_plan_inclusions.py
@@ -36,22 +36,35 @@ def test_base_tier_does_not_sell_the_concierge():
     assert base.sells_concierge is False
 
 
-def test_every_tier_above_the_floor_sells_the_concierge():
-    paid = [t for t in catalog.list_site_plans() if t.key != catalog.BASE_SITE_PLAN_KEY]
-    assert paid, "catalog has no paid tier — this test would assert nothing"
-    assert all(t.sells_concierge for t in paid)
+def test_only_the_top_tier_sells_the_concierge():
+    """Was "every tier above the floor", which held only while nothing actually
+    sold the concierge. Under the $0/$5/$19 ladder (2026-08-22) the concierge is
+    the whole difference between the two paid rungs, so the middle one must not
+    have it — that derivation would have given the $5 tier a $19 feature."""
+    tiers = catalog.list_site_plans()
+    assert len(tiers) > 2, "needs at least two paid rungs to say anything"
+
+    selling = [t.key for t in tiers if t.sells_concierge]
+    assert selling == [tiers[-1].key], (
+        f"expected only the top tier to sell the concierge, got {selling}"
+    )
 
 
-def test_the_rule_follows_the_floor_rather_than_the_tier_name(monkeypatch):
-    """Rekeying the floor moves the answer with it — no basic/pro/business mapping.
+def test_an_unknown_tier_sells_no_concierge():
+    """The mapping fails CLOSED.
 
-    This is the property that makes the pricing-spec rekey cheap: point
-    ``BASE_SITE_PLAN_KEY`` at another tier and that tier stops selling the
-    concierge, with nothing else edited. A per-tier dict would fail here.
+    This replaces a test asserting the opposite property — that the answer
+    followed ``BASE_SITE_PLAN_KEY`` rather than the tier name, which was the thing
+    that made the derivation cheap. That stopped being true on 2026-08-22: the
+    concierge is now mapped per tier, because it is what separates the $5 rung
+    from the $19 one and a floor comparison cannot express that.
+
+    The cost of the map is that a new tier has to be added to it. Failing closed
+    is what makes forgetting safe: an unmapped tier sells nothing rather than
+    silently selling the most expensive feature in the catalog.
     """
-    monkeypatch.setattr(catalog, "BASE_SITE_PLAN_KEY", "pro")
-    assert catalog.get_site_plan("pro").sells_concierge is False
-    assert catalog.get_site_plan("basic").sells_concierge is True
+    assert catalog.get_site_plan("nonesuch-tier") is None
+    assert catalog._SITE_PLAN_SELLS_CONCIERGE.get("nonesuch-tier", False) is False
 
 
 def test_the_resolver_reads_the_catalog_rule_rather_than_its_own(monkeypatch):
@@ -107,8 +120,15 @@ def test_the_free_tier_card_can_say_what_it_omits():
     assert dto.cloudflare_features == []
 
 
-def test_a_paid_tier_card_carries_both_paid_capabilities():
+def test_a_paid_tier_card_carries_its_paid_capabilities():
+    """The $5 rung sells the badge removal and the domain, not the concierge."""
     dto = site_plan_tier_to_dto(catalog.get_site_plan("pro"))
     assert dto.badge_removal is True
-    assert dto.sells_concierge is True
+    assert dto.sells_concierge is False
     assert "custom_domain" in dto.cloudflare_features
+
+
+def test_the_top_tier_card_is_the_one_carrying_the_concierge():
+    dto = site_plan_tier_to_dto(catalog.get_site_plan("business"))
+    assert dto.sells_concierge is True
+    assert dto.badge_removal is True

--- a/tests/cloud/billing/test_site_plan_purchasable.py
+++ b/tests/cloud/billing/test_site_plan_purchasable.py
@@ -56,7 +56,7 @@ def _products(monkeypatch, mapping: dict[str, str] | None) -> None:
 
 def _a_priced_tier() -> str:
     for tier in site_plans.list_site_plans():
-        if tier.annual_price_usd > 0:
+        if tier.monthly_price_usd > 0:
             return tier.key
     raise AssertionError("no priced site tier in the catalog — ladder changed")
 
@@ -117,7 +117,7 @@ def test_the_free_tier_is_always_purchasable(monkeypatch):
     floor = site_plans.get_site_plan(site_plans.BASE_SITE_PLAN_KEY)
 
     assert floor is not None
-    assert floor.annual_price_usd == 0
+    assert floor.monthly_price_usd == 0
     assert floor.purchasable is True
 
 
@@ -142,7 +142,7 @@ def test_a_priced_tier_becomes_purchasable_once_its_product_is_configured(monkey
 def test_configuring_one_tier_does_not_make_its_siblings_purchasable(monkeypatch):
     """Partial configuration is the likely real state during a rollout, and the
     card has to be right about each tier independently."""
-    priced = [t.key for t in site_plans.list_site_plans() if t.annual_price_usd > 0]
+    priced = [t.key for t in site_plans.list_site_plans() if t.monthly_price_usd > 0]
     if len(priced) < 2:
         pytest.skip("catalog has fewer than two priced tiers")
     _products(monkeypatch, {priced[0]: "prod_only_the_first"})
@@ -322,7 +322,7 @@ class TestThePublishRecordsWhatIsTrue:
         from pocketpaw_ee.cloud.models.site import Site
         from pocketpaw_ee.sites import service as svc
 
-        priced = [t.key for t in site_plans.list_site_plans() if t.annual_price_usd > 0]
+        priced = [t.key for t in site_plans.list_site_plans() if t.monthly_price_usd > 0]
         if len(priced) < 2:
             pytest.skip("catalog has fewer than two priced tiers")
         _products(monkeypatch, {priced[0]: "prod_site_x"})

--- a/tests/cloud/billing/test_site_pricing_ladder.py
+++ b/tests/cloud/billing/test_site_pricing_ladder.py
@@ -1,0 +1,145 @@
+# tests/cloud/billing/test_site_pricing_ladder.py — the per-site price ladder, as
+# decided rather than as originally guessed.
+#
+# The old catalog was $0 / $120 / $480 ANNUAL, and the annual figures had no cost
+# basis behind them (see docs/design/drafts/2026-08-21-paw-sites-pricing-revision.md:
+# the real Cloudflare floor is $0.10 per custom hostname per month, and every
+# comparable product on the market prices monthly in single digits). Annual-only
+# billing was also a conversion problem in its own right.
+#
+# Decided 2026-08-22: $0 / $5 / $19, MONTHLY, per site.
+#
+# Two things beyond the numbers change with it, and both are easy to miss:
+#
+#   * The interval. A renewal webhook that stamps +365 days on a monthly plan puts
+#     the next renewal a year out on every single renewal, and the site keeps its
+#     paid capabilities for that whole year whatever happens to the card.
+#   * The concierge. It used to be sold by ANY tier above the floor, derived rather
+#     than mapped, because the tier that was meant to sell it did not exist yet.
+#     Under this ladder only the TOP tier does — that is the entire difference
+#     between the $5 and $19 rungs, so deriving it now hands the $5 tier a $19
+#     feature.
+#
+# The tier KEYS deliberately do not change here. Renaming them (basic/pro/business
+# to free/site/staff) rewrites values stored in Site.plan_tier, and an orphaned key
+# resolves to None and drops a site to the floor. That is its own change, gated on
+# the census confirming what production actually holds.
+#
+# Created 2026-08-22 (feat/site-pricing-monthly): new test module.
+
+from __future__ import annotations
+
+import pytest
+from pocketpaw_ee.cloud.billing import site_plans
+from pocketpaw_ee.cloud.billing.site_plans import SitePlanTier
+
+
+def _by_key() -> dict[str, SitePlanTier]:
+    return {t.key: t for t in site_plans.list_site_plans()}
+
+
+# ---------------------------------------------------------------------------
+# The numbers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("key", "price"),
+    [("basic", 0), ("pro", 5), ("business", 19)],
+)
+def test_the_ladder_is_zero_five_nineteen(key, price):
+    tier = site_plans.get_site_plan(key)
+    assert tier is not None, f"{key} left the catalog"
+    assert tier.monthly_price_usd == price
+
+
+def test_the_price_is_monthly_and_nothing_still_calls_it_annual():
+    """The rename is the point, not cosmetics. A field named ``annual_price_usd``
+    holding 5 would read as $5/year to every future caller, and $5/year is below
+    the Cloudflare floor for a single custom hostname."""
+    tier = site_plans.get_site_plan("pro")
+
+    assert hasattr(tier, "monthly_price_usd")
+    assert not hasattr(tier, "annual_price_usd")
+
+
+def test_the_floor_is_still_free():
+    assert site_plans.get_site_plan(site_plans.BASE_SITE_PLAN_KEY).monthly_price_usd == 0
+
+
+def test_the_ladder_only_goes_up():
+    """A cheaper tier that sells more is a pricing bug, and the catalog is ordered
+    cheapest-first for the buyer-facing cards."""
+    prices = [t.monthly_price_usd for t in site_plans.list_site_plans()]
+
+    assert prices == sorted(prices)
+    assert len(set(prices)) == len(prices), "two tiers at the same price"
+
+
+# ---------------------------------------------------------------------------
+# The concierge is the difference between the two paid rungs
+# ---------------------------------------------------------------------------
+
+
+def test_only_the_top_tier_sells_the_concierge():
+    """It used to be derived as "any tier above the floor", which was correct only
+    while the tier meant to sell it did not exist. Deriving it now would hand the
+    $5 rung the feature the $19 rung is for."""
+    by_key = _by_key()
+
+    assert by_key["basic"].sells_concierge is False
+    assert by_key["pro"].sells_concierge is False, (
+        "the $5 tier is selling the concierge, which is what the $19 tier is for"
+    )
+    assert by_key["business"].sells_concierge is True
+
+
+def test_the_paid_rungs_are_actually_different_products():
+    """If the two paid tiers sold exactly the same things, the ladder would be a
+    price increase with no reason attached to it."""
+    by_key = _by_key()
+    mid, top = by_key["pro"], by_key["business"]
+
+    assert (mid.sells_concierge, mid.badge_removal) != (top.sells_concierge, top.badge_removal) or (
+        mid.cloudflare_features != top.cloudflare_features
+    )
+
+
+def test_both_paid_rungs_still_drop_the_badge_and_take_a_domain():
+    """The $5 rung's whole pitch. Losing either while repricing would be a silent
+    downgrade for anyone who buys it."""
+    by_key = _by_key()
+
+    for key in ("pro", "business"):
+        assert by_key[key].badge_removal is True
+        assert by_key[key].max_domained_sites is None, f"{key} should be uncapped"
+
+
+def test_the_free_floor_keeps_its_one_domained_site():
+    """Free includes a custom domain on ONE site. Repricing must not quietly take
+    the acquisition hook away."""
+    assert site_plans.get_site_plan("basic").max_domained_sites == 1
+
+
+# ---------------------------------------------------------------------------
+# Purchasability still keys off the price being zero
+# ---------------------------------------------------------------------------
+
+
+def test_a_zero_price_tier_is_always_purchasable(monkeypatch):
+    """``purchasable`` is ``price == 0 or a product is configured``. The rename has
+    to carry that through, or the free tier becomes unbuyable the moment Dodo is
+    unconfigured and every publish falls back to nothing."""
+    monkeypatch.setattr(site_plans, "_dodo_product_for", lambda key: None)
+
+    assert site_plans.get_site_plan("basic").purchasable is True
+    assert site_plans.get_site_plan("pro").purchasable is False
+
+
+def test_a_priced_tier_is_purchasable_once_it_has_a_product(monkeypatch):
+    monkeypatch.setattr(
+        site_plans, "_dodo_product_for", lambda key: "prod_x" if key == "pro" else None
+    )
+
+    assert site_plans.get_site_plan("pro").purchasable is True
+    assert site_plans.get_site_plan("business").purchasable is False

--- a/tests/cloud/sites/test_billing_state_on_the_wire.py
+++ b/tests/cloud/sites/test_billing_state_on_the_wire.py
@@ -3,7 +3,7 @@
 #
 # The defect (found 2026-08-22, feat/site-entitlement-ui-state): the frontend's
 # SiteSummary and SiteStatusResponse both declare ``plan_tier``,
-# ``subscription_status`` and ``annual_renewal_date``, and the [siteId] page
+# ``subscription_status`` and ``renewal_date``, and the [siteId] page
 # branches on them — an "awaiting checkout" bar keys on
 # ``subscription_status === "pending"``, and the Billing tab renders the current
 # plan. Neither backend DTO carried a single one of those fields:
@@ -95,7 +95,7 @@ async def _seed_site(
         signed_key="site_key_wire",
         plan_tier=plan_tier,
         subscription_status=subscription_status,
-        annual_renewal_date=renewal,
+        renewal_date=renewal,
         domains=[SiteDomain(hostname=h) for h in (domains or [])],
     )
     await doc.insert()
@@ -121,8 +121,8 @@ async def test_the_site_response_carries_the_plan_the_ui_renders(mongo_db):
 
     assert resp.plan_tier == "pro"
     assert resp.subscription_status == "active"
-    assert resp.annual_renewal_date is not None
-    assert resp.annual_renewal_date.startswith("2027-01-15")
+    assert resp.renewal_date is not None
+    assert resp.renewal_date.startswith("2027-01-15")
 
 
 async def test_a_pending_site_says_pending_rather_than_nothing(mongo_db):

--- a/tests/cloud/sites/test_charge_first.py
+++ b/tests/cloud/sites/test_charge_first.py
@@ -290,7 +290,7 @@ async def test_active_webhook_deploys_pending_site(mongo_db, recording_bus, monk
     assert updated is not None
     assert updated.deployed is True
     assert updated.subscription_status == "active"
-    assert updated.annual_renewal_date is not None
+    assert updated.renewal_date is not None
     assert updated.pending_deploy_inputs == {}
 
     # SitePublished is emitted now that the site is actually live.
@@ -428,7 +428,7 @@ async def test_paid_tier_without_dodo_product_publishes_live(mongo_db):
     a checkout, so charge-first degrades to an immediate live publish — the user is
     never stranded with a pending, never-deployable site."""
     # No _dodo_product_for monkeypatch → pro has a price but NO configured product.
-    assert site_plans.get_site_plan("pro").annual_price_usd > 0
+    assert site_plans.get_site_plan("pro").monthly_price_usd > 0
     assert site_plans.get_site_plan("pro").dodo_product_id is None
 
     ws = await _make_workspace(plan="pro")

--- a/tests/cloud/sites/test_cloudflare_tiers.py
+++ b/tests/cloud/sites/test_cloudflare_tiers.py
@@ -263,7 +263,7 @@ def test_get_billing_site_plans_returns_catalog_with_cf_features(site_plans_clie
     assert set(rows.keys()) == {"basic", "pro", "business"}
 
     # Each tier carries its annual price + sorted cloudflare_features.
-    assert rows["basic"]["annual_price_usd"] == 0
+    assert rows["basic"]["monthly_price_usd"] == 0
     assert rows["basic"]["cloudflare_features"] == []
     assert "custom_domain" in rows["pro"]["cloudflare_features"]
     biz_features = rows["business"]["cloudflare_features"]

--- a/tests/cloud/sites/test_site_billing.py
+++ b/tests/cloud/sites/test_site_billing.py
@@ -178,8 +178,8 @@ def test_list_site_plans_returns_tiers_with_price_and_cf_features():
 
     by_key = {t.key: t for t in tiers}
     # Each tier carries an annual price (USD) + a cloudflare_features set.
-    assert by_key["basic"].annual_price_usd == 0
-    assert by_key["pro"].annual_price_usd > 0
+    assert by_key["basic"].monthly_price_usd == 0
+    assert by_key["pro"].monthly_price_usd > 0
     assert isinstance(by_key["pro"].cloudflare_features, frozenset)
     # Higher tiers resell more Cloudflare features (a growing ladder).
     assert by_key["basic"].cloudflare_features == frozenset()
@@ -389,7 +389,7 @@ async def test_per_site_active_webhook_updates_site_not_workspace(mongo_db, monk
     assert updated is not None
     assert updated.deployed is True
     assert updated.subscription_status == "active"
-    assert updated.annual_renewal_date is not None
+    assert updated.renewal_date is not None
 
 
 async def test_per_site_cancelled_webhook_marks_site_cancelled(mongo_db, monkeypatch):

--- a/tests/ee/sites/test_concierge_autoembed.py
+++ b/tests/ee/sites/test_concierge_autoembed.py
@@ -433,9 +433,17 @@ async def test_a_paying_site_mid_activation_still_gets_its_bar(
     monkeypatch.setenv("PAW_SITES_LOCAL", "1")
     _billing(monkeypatch, on=True)
     _fake_store(monkeypatch, _widget())
-    paid = next(
-        t.key for t in site_plans.list_site_plans() if t.key != site_plans.BASE_SITE_PLAN_KEY
-    )
+    # A tier that SELLS THE CONCIERGE, not merely one above the floor. Those were
+    # the same set until 2026-08-22, when the ladder went $0/$5/$19 and the
+    # concierge became the difference between the two paid rungs — "first non-floor
+    # tier" now picks the $5 one, which sells no concierge.
+    #
+    # For the mid-activation test that turns into a failure. For the cancelled test
+    # it is worse: it would still pass, but because the tier sells nothing rather
+    # than because the subscription was cancelled, which is not what it claims to
+    # prove. Selecting on the property both tests actually depend on fixes one and
+    # keeps the other honest.
+    paid = next(t.key for t in site_plans.list_site_plans() if t.sells_concierge)
 
     # First publish creates the doc; then put it in the exact mid-activation state.
     site = await _publish(tmp_path)
@@ -468,9 +476,17 @@ async def test_a_cancelled_paid_site_loses_its_bar_on_the_next_publish(
     monkeypatch.setenv("PAW_SITES_LOCAL", "1")
     _billing(monkeypatch, on=True)
     _fake_store(monkeypatch, _widget())
-    paid = next(
-        t.key for t in site_plans.list_site_plans() if t.key != site_plans.BASE_SITE_PLAN_KEY
-    )
+    # A tier that SELLS THE CONCIERGE, not merely one above the floor. Those were
+    # the same set until 2026-08-22, when the ladder went $0/$5/$19 and the
+    # concierge became the difference between the two paid rungs — "first non-floor
+    # tier" now picks the $5 one, which sells no concierge.
+    #
+    # For the mid-activation test that turns into a failure. For the cancelled test
+    # it is worse: it would still pass, but because the tier sells nothing rather
+    # than because the subscription was cancelled, which is not what it claims to
+    # prove. Selecting on the property both tests actually depend on fixes one and
+    # keeps the other honest.
+    paid = next(t.key for t in site_plans.list_site_plans() if t.sells_concierge)
 
     site = await _publish(tmp_path)
     doc = await Site.get(site.id)

--- a/tests/mutations/free_badge.json
+++ b/tests/mutations/free_badge.json
@@ -12,8 +12,8 @@
   {
     "label": "the free tier is handed badge removal",
     "file": "ee/pocketpaw_ee/cloud/billing/site_plans.py",
-    "find": "    \"basic\": False,",
-    "replace": "    \"basic\": True,",
+    "find": "_SITE_PLAN_BADGE_REMOVAL: dict[str, bool] = {\n    \"basic\": False,",
+    "replace": "_SITE_PLAN_BADGE_REMOVAL: dict[str, bool] = {\n    \"basic\": True,",
     "tests": [
       "tests/ee/sites/test_free_badge.py::test_the_base_tier_is_badged",
       "tests/ee/sites/test_free_badge.py::test_a_basic_tier_site_is_badged"

--- a/tests/mutations/site_billing_wire.json
+++ b/tests/mutations/site_billing_wire.json
@@ -21,7 +21,7 @@
   {
     "label": "the renewal date is dropped — the plan card cannot say when it renews",
     "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "        annual_renewal_date=(\n            _renewal.isoformat()\n            if (_renewal := getattr(doc, \"annual_renewal_date\", None)) is not None\n            else None\n        ),",
+    "find": "        renewal_date=(\n            _renewal.isoformat()\n            if (_renewal := getattr(doc, \"renewal_date\", None)) is not None\n            else None\n        ),",
     "replace": "",
     "tests": [
       "tests/cloud/sites/test_billing_state_on_the_wire.py::test_the_site_response_carries_the_plan_the_ui_renders"

--- a/tests/mutations/site_plan_purchasable.json
+++ b/tests/mutations/site_plan_purchasable.json
@@ -2,7 +2,7 @@
   {
     "label": "purchasable is always true — an unbuyable tier is recorded again",
     "file": "ee/pocketpaw_ee/cloud/billing/site_plans.py",
-    "find": "        return self.annual_price_usd == 0 or self.dodo_product_id is not None",
+    "find": "        return self.monthly_price_usd == 0 or self.dodo_product_id is not None",
     "replace": "        return True",
     "tests": [
       "tests/cloud/billing/test_site_plan_purchasable.py::test_a_priced_tier_with_no_product_is_not_purchasable",
@@ -12,7 +12,7 @@
   {
     "label": "the free tier reads as unbuyable — its card goes unavailable",
     "file": "ee/pocketpaw_ee/cloud/billing/site_plans.py",
-    "find": "        return self.annual_price_usd == 0 or self.dodo_product_id is not None",
+    "find": "        return self.monthly_price_usd == 0 or self.dodo_product_id is not None",
     "replace": "        return self.dodo_product_id is not None",
     "tests": [
       "tests/cloud/billing/test_site_plan_purchasable.py::test_the_free_tier_is_always_purchasable",


### PR DESCRIPTION
$0 / $5 / $19, monthly, per site.

## Why the old numbers had to go

The catalog was $0 / $120 / $480 **annual**, and those figures had no cost basis behind them. The real Cloudflare floor is $0.10 per custom hostname per month past the first 100, and every comparable product on the market prices monthly in single digits. Annual-only billing was a conversion problem in its own right.

Full working: `docs/design/drafts/2026-08-21-paw-sites-pricing-revision.md` (rescued onto workspace main in paw-workspace#174 — it had been stranded on a merged branch).

## Three things move together

**The interval.** The renewal webhook stamped `+365 days`. On a monthly plan that puts *every* renewal a year out, and the site keeps its paid capabilities for that whole year regardless of what happens to the card. Now `+1 month` via `relativedelta` rather than `timedelta(days=30)`, so the date does not drift backwards through the calendar over a year of renewals.

**The concierge.** It was derived as "any tier above the floor", which was correct only while no tier actually sold it. The tier meant to did not exist yet. Under this ladder the concierge *is* the difference between the $5 and $19 rungs, so deriving it hands the cheap rung the expensive rung's feature. It is now a per-tier map that **fails closed**: an unmapped tier sells nothing rather than silently selling the most expensive thing in the catalog.

Three existing tests encoded the old rule. They were rewritten to the new one rather than deleted, including the one that asserted the answer followed `BASE_SITE_PLAN_KEY` — that property was exactly what made the derivation cheap, and it is gone on purpose.

**The names.** `annual_price_usd` → `monthly_price_usd`, and the stored `annual_renewal_date` → `renewal_date`.

Not cosmetic in either case. A field called `annual_price_usd` holding `5` reads as $5/**year** to every future caller, which is below the Cloudflare floor for a single hostname. A field called `annual_renewal_date` holding a monthly date is a name that lies, and this codebase has been bitten by that shape before.

The renewal field has no index and is null everywhere (no per-site subscription has ever been bought, because the product map was never configured), so the rename costs no migration.

## What deliberately does not change

The tier **keys**. `basic`/`pro`/`business` → `free`/`site`/`staff` rewrites values stored in `Site.plan_tier`, and an orphaned key resolves to `None` and drops a site to the floor. That is its own change, gated on the census confirming what production actually holds.

Practical consequence for whoever configures Dodo: the product map keys are `pro` and `business`, not `site` and `staff`. An unrecognised key does not error. It silently means "no product", the tier goes unpurchasable, and a publish records the free floor.

## A mutation left a security hole in this branch, and the suite caught it

Worth recording rather than quietly fixing.

A mutation sweep was killed at a timeout mid-run and never restored the file it had mutated. The mutation was `site_billing_wire.json` → *"the entitlements read drops its tenant scope"*, so `site_entitlements` was left doing `find_one({"_id": ObjectId(site_id)})` with no workspace filter. Any workspace could read any other workspace's plan and billing state. It got committed.

`test_another_workspace_cannot_read_this_site_s_entitlements` failed, which is the entire reason that test exists. Before assuming the branch caused it, the same test was run against clean `origin/dev`, where it passed. That is what proved the regression was local rather than pre-existing.

The `.mutation-sweep-active` marker had recorded the plan and the exact mutation in flight, with instructions to check `git diff` and delete it. That tooling worked; it just needed reading.

Never pushed. The guard is restored, the marker cleared, and the diff was grepped for residue from every other mutation body.

## Verification

Tests, ruff, ruff format and anchor validation all checked by **exit code** rather than through a pipe. `| tail` masked a non-zero exit twice in this session's history and once more here, which is how the mutated file got committed in the first place.

268 tests pass. 692 anchors resolve. 16 mutations across the two repointed plans, all caught.

Three anchors were stranded by the rename and repointed. One is worth naming: `"basic": False,` stopped being unique the moment the concierge map was added, so the badge anchor now carries its own dict header.

## Merge order

The paw-enterprise branch of the same name renders these prices. Merge this first: until it lands, that branch's `monthly_price_usd` reads `undefined` and the cards show no price at all.
