### PR TITLE
Serve the native artifact for react sites too

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1380,8 +1380,15 @@ Errors:
 
 ### `GET /sites/by-pocket/{pocket_id}/native-artifact`
 
-Serve the armed svelte build's body markup and CSS so the native editor can
+Serve the armed build's body markup and CSS so the native editor can
 shadow-render the site.
+
+Available on engines with a **native edit lane** — `svelte`, and `react` since
+RX-2. Not `html` (its served artifact IS its source, so it is selected through its
+own sandboxed `srcdoc` and has no build to render) and not `ripple` (no source
+map). Both armable engines emit a prerendered `index.html`; only the build output
+directory differs (`.svelte-kit/cloudflare` or `build` vs `dist`), and the server
+resolves that per engine.
 
 Response `200`:
 
@@ -1400,7 +1407,7 @@ Response `200`:
   stylesheet — concatenated into one string, injected as a single `<style>`.
 
 **Read-through cache — a plain view no longer rebuilds.** The endpoint hashes the
-pocket's render inputs (svelte source map + theme + builder origin + generator
+pocket's render inputs (source map + theme + builder origin + engine + generator
 version) and serves a prior render from the on-disk artifact store
 (`~/.pocketpaw/site-artifacts/<pocket_id>/<hash>.json`) on a **cache hit** — zero
 subprocess builds. It builds once only on a **cold miss** (then stores the result),
@@ -1442,7 +1449,7 @@ Errors:
 
 | HTTP | Code | When |
 |------|------|------|
-| 422 | `pocket.not_svelte_site` | The pocket is not a svelte Paw Site (no component build to render). |
+| 422 | `pocket.no_native_edit_lane` | The pocket's engine has no armable build to render (html, ripple). Renamed from `pocket.not_svelte_site` in RX-2, when react joined the lane. |
 | 404 | `pocket.not_found` | Unknown pocket id. |
 | 403 | `pocket.access_denied` | The caller lacks access to the pocket. |
 | 500 | `sites.generator_failed` | The arm build failed (missing toolchain, non-zero build, or smoke-gate failure). |

--- a/ee/pocketpaw_ee/sites/engines.py
+++ b/ee/pocketpaw_ee/sites/engines.py
@@ -191,6 +191,29 @@ def is_source_engine(engine: str | None) -> bool:
     return normalize_engine(engine) in _SOURCE_MAP_ENGINES
 
 
+#: Engines with a NATIVE EDIT LANE — a framework build that the generator can arm
+#: (stamping ``data-uid`` + embedding the ``paw-edit-manifest``), whose rendered
+#: output the native editor shadow-renders so a click resolves back to source.
+#:
+#: NOT the same question as :func:`is_source_engine`, and the difference is the
+#: whole reason this is its own set. ``html`` is a source engine but is absent
+#: here: its served artifact IS its source, so it is selected through the
+#: in-frame agent over its own srcdoc and never needs an armed build to render.
+#: ``react`` joined in RX-2, when the generator gained the seam RX-1 left empty.
+_NATIVE_EDIT_ENGINES: frozenset[str] = frozenset({"svelte", "react"})
+
+
+def has_native_edit_lane(engine: str | None) -> bool:
+    """True when this engine can be ARMED into a native-editable build.
+
+    The guard for ``/native-artifact`` and its background pre-warm. Both of those
+    read a BUILT tree, so the engine must be one the generator actually builds and
+    arms — which is why ``html`` (served straight from its source map) answers
+    False even though it is a source engine.
+    """
+    return normalize_engine(engine) in _NATIVE_EDIT_ENGINES
+
+
 def content_key(engine: str | None) -> str:
     """The pocket-dict key holding this engine's authored content.
 

--- a/ee/pocketpaw_ee/sites/router.py
+++ b/ee/pocketpaw_ee/sites/router.py
@@ -160,9 +160,17 @@
 # editor shadow-renders the site instead of framing an iframe. fabric.write (it
 # ensures/triggers the armed build); the builder_origin is resolved from the request
 # Origin header (the service applies the PAW_SITES_BUILDER_ORIGIN env fallback),
-# mirroring /editable + /dev-preview. A non-svelte pocket → 422; a missing /
-# access-denied pocket → 404 / 403 (the pockets service raises it). Delegates to
-# sites_service.get_native_artifact.
+# mirroring /editable + /dev-preview. A pocket with no native edit lane → 422; a
+# missing / access-denied pocket → 404 / 403 (the pockets service raises it).
+# Delegates to sites_service.get_native_artifact.
+#
+# Updated 2026-08-22 (RX-2): the 422 guard is no longer svelte-only — it is now
+# ``has_native_edit_lane`` (svelte + react), and the response body's error code
+# changed from ``pocket.not_svelte_site`` to ``pocket.no_native_edit_lane``. html
+# and ripple are still rejected: html's served artifact IS its source (selected
+# through its own srcdoc, no build to render) and ripple has no source map. The
+# rest of the wire contract (request/response, origin resolution, 404/403) is
+# unchanged.
 #
 # Updated 2026-07-17 (feat/sites-native-artifact-no-build): get_native_artifact is now a
 # READ-THROUGH cache — a repeat view with unchanged source is a disk read with ZERO
@@ -382,9 +390,10 @@ async def native_artifact_by_pocket(
     needs to stamp data-uid + the manifest — is resolved from the request's ``Origin``
     header, with the service applying the ``PAW_SITES_BUILDER_ORIGIN`` env fallback when
     it is absent (the same precedence as ``/editable`` / ``/dev-preview``), so the call
-    works with no header. A non-svelte pocket is a 422; a missing / access-denied
-    pocket surfaces as a 404 / 403 (the pockets service raises it inside the
-    service)."""
+    works with no header. A pocket with no native edit lane is a 422 — svelte and
+    react are armable, html (served straight from its source) and ripple are not;
+    a missing / access-denied pocket surfaces as a 404 / 403 (the pockets service
+    raises it inside the service)."""
     # Mirror /editable + /dev-preview origin resolution: the request Origin header
     # here; the service applies the PAW_SITES_BUILDER_ORIGIN env fallback when blank.
     builder_origin = request.headers.get("origin") or ""

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1015,17 +1015,23 @@ def _extract_css(html: str, cloudflare_dir: Path) -> str:
     return "\n".join(parts)
 
 
-def _read_native_artifact(project_dir: str) -> tuple[str, str]:
+def _read_native_artifact(project_dir: str, engine: str = "svelte") -> tuple[str, str]:
     """Read the armed build's ``<body>`` inner HTML + concatenated CSS from the built
     static output (NE-5b) — the default ``_read_built`` seam.
 
-    ``project_dir`` is the ``BuildResult.project_dir`` the generator returns; the
-    prerendered site lives under ``<project_dir>/.svelte-kit/cloudflare/`` (the SAME
-    tree ``_default_bundle_reader`` / ``local_server`` read). Returns
-    ``(body_html, css)``."""
-    cloudflare_dir = Path(project_dir, _CLOUDFLARE_BUILD_REL)
-    html = (cloudflare_dir / "index.html").read_text(encoding="utf-8")
-    return _extract_body_inner(html), _extract_css(html, cloudflare_dir)
+    ``project_dir`` is the ``BuildResult.project_dir`` the generator returns. WHERE
+    the built page lands is per-engine and is NOT this function's business to know:
+    svelte writes ``.svelte-kit/cloudflare`` (or ``build`` for a static landing
+    site) and react writes ``dist``, so the output dir is resolved through
+    ``resolve_static_output_rel``, which probes the tree on disk. Hardcoding the
+    SvelteKit path is what made this svelte-only (RX-2 widened it for react).
+
+    Returns ``(body_html, css)``."""
+    from pocketpaw_ee.sites.engines import resolve_static_output_rel
+
+    out_dir = Path(project_dir, resolve_static_output_rel(project_dir, engine))
+    html = (out_dir / "index.html").read_text(encoding="utf-8")
+    return _extract_body_inner(html), _extract_css(html, out_dir)
 
 
 # ---------------------------------------------------------------------------
@@ -1043,20 +1049,28 @@ def _read_native_artifact(project_dir: str) -> tuple[str, str]:
 
 
 def _artifact_content_hash(
-    *, source: dict[str, Any], theme: dict[str, Any], builder_origin: str, gen_version: str
+    *,
+    source: dict[str, Any],
+    theme: dict[str, Any],
+    builder_origin: str,
+    gen_version: str,
+    engine: str = "svelte",
 ) -> str:
     """Fingerprint the inputs that determine a native artifact's rendered output — the
-    svelte source map, the theme, the builder origin (it changes the stamped
-    data-uid + edit-bridge), and the generator version (a toolchain/dep bump changes
-    the built HTML/CSS). A stable hash for an unchanged render; it changes the moment
-    any input does, which is exactly when the cached artifact is stale and a rebuild is
-    required. The store is already keyed per pocket by path, so this need only separate
-    an unchanged render from a changed one within a pocket."""
+    source map, the theme, the builder origin (it changes the stamped
+    data-uid + edit-bridge), the ENGINE (RX-2: the same source map builds to
+    materially different HTML on the svelte and react tracks), and the generator
+    version (a toolchain/dep bump changes the built HTML/CSS). A stable hash for an
+    unchanged render; it changes the moment any input does, which is exactly when the
+    cached artifact is stale and a rebuild is required. The store is already keyed per
+    pocket by path, so this need only separate an unchanged render from a changed one
+    within a pocket."""
     import hashlib
 
     h = hashlib.sha256()
     for part in (
         gen_version,
+        engine,
         builder_origin or "",
         json.dumps(source, sort_keys=True, separators=(",", ":"), ensure_ascii=False),
         json.dumps(theme, sort_keys=True, separators=(",", ":"), ensure_ascii=False),
@@ -1186,8 +1200,16 @@ async def _build_native_artifact(
     builder_origin: str,
     pocket_id: str,
     read: Callable[[str], tuple[str, str]],
+    engine: str = "svelte",
 ) -> tuple[str, str]:
-    """Run the ARMED svelte build for a native artifact and extract ``(body_html, css)``.
+    """Run the ARMED build for a native artifact and extract ``(body_html, css)``.
+
+    ``engine`` selects which track is built — ``"svelte"`` or, since RX-2,
+    ``"react"``. Both arm the same way (the generator stamps ``data-uid`` and
+    embeds the manifest when ``builder_origin`` is set) and both emit a prerendered
+    ``index.html``; only the output directory differs, and the ``read`` seam owns
+    that. Anything without a native edit lane never reaches here — the callers
+    gate on ``has_native_edit_lane`` first.
 
     The single build path shared by get_native_artifact's cache MISS and the
     background pre-warm. It builds with ``builder_origin`` set (so the paw-sites
@@ -1210,7 +1232,7 @@ async def _build_native_artifact(
         title=site_name,
         capture_api_base=_capture_base(),
         capture_signed_key=f"site_key_{secrets.token_urlsafe(24)}",
-        engine="svelte",
+        engine=engine,
         source=source,
         builder_origin=builder_origin,
         pocket_id=pocket_id,
@@ -1245,10 +1267,15 @@ async def _prewarm_native_artifact(
     from pocketpaw_ee.cloud.pockets import service as pockets_service
     from pocketpaw_ee.sites import generator_client
 
+    from pocketpaw_ee.sites.engines import has_native_edit_lane, normalize_engine
+
     pocket = await pockets_service.get(pocket_id, user_id)
-    # Only svelte sites have a native shadow-render build; ripple/html don't use this
-    # path (an html site's served artifact IS its source). Nothing to arm otherwise.
-    if (pocket.get("engine") or "ripple") != "svelte" or not isinstance(pocket.get("source"), dict):
+    # Only engines with a native shadow-render BUILD use this path (svelte, and
+    # react since RX-2). ripple has no source map; html's served artifact IS its
+    # source, so it is selected through its own srcdoc and never armed. Nothing to
+    # pre-warm otherwise.
+    engine = normalize_engine(pocket.get("engine"))
+    if not has_native_edit_lane(engine) or not isinstance(pocket.get("source"), dict):
         return
     source = pocket["source"]
     ripple_spec = pocket.get("rippleSpec") or {}
@@ -1262,11 +1289,14 @@ async def _prewarm_native_artifact(
         theme=theme,
         builder_origin=origin,
         gen_version=generator_client.generator_version(),
+        engine=engine,
     )
     if store.read(pocket_id, content_hash) is not None:
         return  # already warm — no rebuild
     generator = _generator or GeneratorClient()
-    read = _read_built or _read_native_artifact
+    # The ``_read_built`` seam stays SINGLE-ARG so injected test doubles keep
+    # working; the engine is bound into the default reader instead.
+    read = _read_built or (lambda d: _read_native_artifact(d, engine))
     body_html, css = await _build_native_artifact(
         generator=generator,
         theme=theme,
@@ -1275,6 +1305,7 @@ async def _prewarm_native_artifact(
         builder_origin=origin,
         pocket_id=pocket_id,
         read=read,
+        engine=engine,
     )
     store.write(pocket_id, content_hash, body_html, css)
 
@@ -1534,15 +1565,44 @@ def _capture_base() -> str:
     return os.environ.get("PAW_CAPTURE_API_BASE", "http://localhost:8888/api/v1")
 
 
+_LOCAL_BUILDER_ORIGIN = "http://localhost:8888"
+
+
 def _builder_origin() -> str:
     """The dashboard/builder origin an editable Paw Site postMessages its
     section rects to (SE-2b). The generated edit-bridge only accepts messages
     from this exact origin. Defaults to the local dashboard; overridable via
     PAW_SITES_BUILDER_ORIGIN. Used by ``make_site_editable`` when the caller does
-    not pass an explicit origin."""
+    not pass an explicit origin.
+
+    WARNS WHEN IT FALLS BACK. The default is correct only on a developer's own
+    box, and its two failure modes in a real deployment are both SILENT:
+
+      * the armed build's bridge posts to an origin the operator's browser will
+        never deliver to, so click-to-edit dies with the page still rendering
+        perfectly and nothing in the console;
+      * this value is part of the native-artifact content hash, so publishes and
+        edits with no request Origin (chat-agent / MCP) warm the cache under a
+        hash no browser view will ever ask for — every view then stays a cold
+        miss and rebuilds the whole site.
+
+    Neither surfaces as an error, so an unset env reads exactly like a working
+    one. Logging the fallback is what makes it findable.
+    """
     import os
 
-    return os.environ.get("PAW_SITES_BUILDER_ORIGIN", "http://localhost:8888")
+    configured = os.environ.get("PAW_SITES_BUILDER_ORIGIN", "").strip()
+    if configured:
+        return configured
+    logger.warning(
+        "PAW_SITES_BUILDER_ORIGIN is unset — falling back to %s. On any "
+        "deployment where the dashboard is not that origin, editable sites arm "
+        "against the wrong origin (click-to-edit silently does nothing) and the "
+        "native-artifact cache never hits (every view triggers a full rebuild). "
+        "Set it to the dashboard origin.",
+        _LOCAL_BUILDER_ORIGIN,
+    )
+    return _LOCAL_BUILDER_ORIGIN
 
 
 # The default logical form type. The generated /api/submit endpoint sends this
@@ -5932,13 +5992,19 @@ async def get_native_artifact(
     # The pockets service's PUBLIC get raises NotFound / Forbidden itself (entity
     # isolation) — a missing / cross-tenant pocket surfaces as 404 / 403.
     pocket = await pockets_service.get(pocket_id, user_id)
-    # KEPT svelte-specific (not is_source_engine): this shadow-renders the SvelteKit
-    # ARMED build by reading ``.svelte-kit/cloudflare/index.html``. An html site's
-    # served artifact IS its source, so it never uses this SvelteKit render path.
-    if (pocket.get("engine") or "ripple") != "svelte" or not isinstance(pocket.get("source"), dict):
+    from pocketpaw_ee.sites.engines import has_native_edit_lane, normalize_engine
+
+    # NATIVE-EDIT engines only (not is_source_engine): this shadow-renders an ARMED
+    # BUILD, so the engine has to be one the generator builds and arms — svelte, and
+    # react since RX-2. Deliberately NOT widened to every source engine: an html
+    # site's served artifact IS its source, so it is selected through its own srcdoc
+    # and has no build to render here.
+    engine = normalize_engine(pocket.get("engine"))
+    if not has_native_edit_lane(engine) or not isinstance(pocket.get("source"), dict):
         raise ValidationError(
-            "pocket.not_svelte_site",
-            "This pocket is not a svelte Paw Site — it has no component build to render.",
+            "pocket.no_native_edit_lane",
+            "This Paw Site has no component build to render — native editing is "
+            "available on svelte and react sites.",
         )
     source = pocket["source"]
     # theme rides the build on both engine tracks (mirrors publish_pocket); a svelte
@@ -5957,6 +6023,7 @@ async def get_native_artifact(
         theme=theme,
         builder_origin=origin,
         gen_version=generator_client.generator_version(),
+        engine=engine,
     )
     # READ-THROUGH: a hit serves the prior render straight off disk — no generator, no
     # subprocess, no build. This is what makes a VIEW instant on the prod box.
@@ -5969,7 +6036,9 @@ async def get_native_artifact(
     # _build_or_cloud_error so a missing-toolchain / non-zero build / SmokeGateFailed
     # becomes a clean CloudError (sites.generator_failed → 5xx), not an opaque 500.
     generator = _generator or GeneratorClient()
-    read = _read_built or _read_native_artifact
+    # Single-arg seam preserved for injected test doubles; the engine is bound into
+    # the default reader, which resolves the per-engine output dir off disk.
+    read = _read_built or (lambda d: _read_native_artifact(d, engine))
     body_html, css = await _build_native_artifact(
         generator=generator,
         theme=theme,
@@ -5978,6 +6047,7 @@ async def get_native_artifact(
         builder_origin=origin,
         pocket_id=pocket_id,
         read=read,
+        engine=engine,
     )
     store.write(pocket_id, content_hash, body_html, css)
     return {"pocket_id": pocket_id, "body_html": body_html, "css": css}

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -1267,7 +1267,6 @@ async def _prewarm_native_artifact(
     failure (missing toolchain, a non-svelte pocket, a read error)."""
     from pocketpaw_ee.cloud.pockets import service as pockets_service
     from pocketpaw_ee.sites import generator_client
-
     from pocketpaw_ee.sites.engines import has_native_edit_lane, normalize_engine
 
     pocket = await pockets_service.get(pocket_id, user_id)

--- a/tests/ee/sites/test_native_artifact_react.py
+++ b/tests/ee/sites/test_native_artifact_react.py
@@ -41,7 +41,7 @@ _REACT_SOURCE = {
     "src/components/Hero.tsx": (
         "export default function Hero() {\n"
         "  return (\n"
-        "    <section className=\"hero\">\n"
+        '    <section className="hero">\n'
         "      <h1>Bright Smile</h1>\n"
         "    </section>\n"
         "  );\n"

--- a/tests/ee/sites/test_native_artifact_react.py
+++ b/tests/ee/sites/test_native_artifact_react.py
@@ -1,0 +1,218 @@
+# tests/ee/sites/test_native_artifact_react.py — the native-artifact path on the
+# REACT track (RX-2). Created 2026-08-22.
+#
+# WHY A SEPARATE FILE. test_native_artifact.py is svelte end-to-end: its fixture
+# writes a `.svelte-kit/cloudflare/` tree, and every assertion reads through it.
+# React's build lands in `dist/` instead, so the two need different on-disk
+# fixtures; forcing them into one file would mean parameterizing the output dir
+# through helpers whose whole job is to BE the SvelteKit shape.
+#
+# WHAT THIS PINS. RX-1 shipped react with no edit lane, and `get_native_artifact`
+# rejected any non-svelte pocket with a 422 before doing anything — which is what
+# made the builder's Select tool dimmed on react sites. RX-2 widens the guard to
+# every engine with a native edit lane, and the properties worth pinning are:
+#
+#   * a react pocket is ACCEPTED and its build is ARMED on the react track;
+#   * the render is read from `dist/`, NOT the SvelteKit path — the bug this
+#     replaces was a hardcoded `.svelte-kit/cloudflare` read;
+#   * `html` and `ripple` are still REJECTED. Widening to "any source engine"
+#     would have swept html in, and html has no build to render — it is selected
+#     through its own srcdoc. The guard is about a BUILD, not about a source map,
+#     so the rejection is as load-bearing as the acceptance;
+#   * the artifact cache separates the two engines. The hash feeds a per-pocket
+#     store, so this is belt-and-braces rather than a live collision — but an
+#     engine-blind hash would serve a svelte render for a react pocket the moment
+#     a pocket's engine ever changed under a stable id.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pocketpaw_ee.cloud._core.errors import ValidationError
+from pocketpaw_ee.cloud.pockets import service as pockets_service
+from pocketpaw_ee.sites import service as sites_service
+
+_REACT_SOURCE = {
+    "src/App.tsx": (
+        "import Hero from './components/Hero';\n"
+        "export default function App() { return <main><Hero /></main>; }\n"
+    ),
+    "src/components/Hero.tsx": (
+        "export default function Hero() {\n"
+        "  return (\n"
+        "    <section className=\"hero\">\n"
+        "      <h1>Bright Smile</h1>\n"
+        "    </section>\n"
+        "  );\n"
+        "}\n"
+    ),
+    "src/index.css": ":root{--brand:#0A84FF}",
+}
+
+# A stand-in for the react ARMED build's PRERENDERED dist/index.html: the prerender
+# pass has already spliced the server-rendered markup into <div id="root">, so the
+# stamped leaf and the manifest are real elements in the served body.
+_ARMED_DIST_HTML = """<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <link rel="stylesheet" href="/assets/index.css" />
+  <style>.inline-critical{margin:0}</style>
+  <script id="paw-edit-manifest" type="application/json">[{"uid":"Hero:headline:1"}]</script>
+</head>
+<body>
+  <div id="root"><section class="hero" data-paw-section="Hero">
+    <h1 data-uid="Hero:headline:1">Bright Smile</h1>
+  </section></div>
+  <script id="paw-edit-bridge">/* gated */</script>
+</body>
+</html>
+"""
+_LINKED_CSS = ".hero{color:#0A84FF}"
+
+
+class _FakeGenerator:
+    """Records build kwargs and points at a pre-populated `dist/` tree so the REAL
+    extraction runs without Bun or Vite."""
+
+    def __init__(self, project_dir: str) -> None:
+        self.project_dir = project_dir
+        self.built: dict | None = None
+
+    async def build(self, **kw):
+        from pocketpaw_ee.sites.generator_client import BuildResult
+
+        self.built = kw
+        return BuildResult(project_dir=self.project_dir, ripple_version=None)
+
+
+class _NoBuildGenerator:
+    """A generator whose build MUST NOT run — the reject paths must fail first."""
+
+    async def build(self, **kw):  # pragma: no cover - must not be reached
+        raise AssertionError("the build must not run on the reject path")
+
+
+def _write_react_dist(project_dir: Path) -> None:
+    """Write a react build's static output under <project_dir>/dist/ — the shape
+    `static_output_rel("react")` names and Vite actually emits."""
+    dist = project_dir / "dist"
+    (dist / "assets").mkdir(parents=True, exist_ok=True)
+    (dist / "index.html").write_text(_ARMED_DIST_HTML, encoding="utf-8")
+    (dist / "assets" / "index.css").write_text(_LINKED_CSS, encoding="utf-8")
+
+
+async def _make_pocket(engine: str, source, workspace_id="ws1", user_id="u1") -> str:
+    _view, pocket_id, err = await pockets_service.agent_create(
+        workspace_id=workspace_id,
+        owner_id=user_id,
+        name="Bright Smile",
+        type_="site",
+        pattern="landing",
+        ripple_spec=None,
+        engine=engine,
+        source=source,
+        trusted=True,
+    )
+    assert err is None, err
+    assert pocket_id is not None
+    return pocket_id
+
+
+@pytest.mark.asyncio
+async def test_react_pocket_renders_from_dist(beanie_test_db, tmp_path):
+    """A react pocket is accepted, armed on the REACT track, and read from dist/."""
+    pocket_id = await _make_pocket("react", dict(_REACT_SOURCE))
+    _write_react_dist(tmp_path)
+    gen = _FakeGenerator(str(tmp_path))
+
+    result = await sites_service.get_native_artifact(
+        workspace_id="ws1",
+        user_id="u1",
+        pocket_id=pocket_id,
+        builder_origin="https://dash.paw.example",
+        _generator=gen,
+    )
+
+    assert result["pocket_id"] == pocket_id
+    # The prerendered, stamped markup came back as <body> INNER.
+    assert 'data-uid="Hero:headline:1"' in result["body_html"]
+    assert 'data-paw-section="Hero"' in result["body_html"]
+    assert "<body" not in result["body_html"]
+    # CSS concatenates the inline critical style and the linked stylesheet — proving
+    # the read resolved dist/, not the SvelteKit path (which does not exist here).
+    assert ".inline-critical{margin:0}" in result["css"]
+    assert _LINKED_CSS in result["css"]
+    # The build was ARMED, and on the react track.
+    assert gen.built is not None
+    assert gen.built["engine"] == "react"
+    assert gen.built["builder_origin"] == "https://dash.paw.example"
+    assert gen.built["smoke"] is False
+    assert gen.built["source"]["src/App.tsx"] == _REACT_SOURCE["src/App.tsx"]
+
+
+@pytest.mark.asyncio
+async def test_html_pocket_still_rejected(beanie_test_db):
+    """html is a SOURCE engine but has no build to render — its served artifact IS
+    its source. Widening the guard to `is_source_engine` would have swept it in."""
+    pocket_id = await _make_pocket("html", {"index.html": "<h1>hi</h1>"})
+
+    with pytest.raises(ValidationError):
+        await sites_service.get_native_artifact(
+            workspace_id="ws1",
+            user_id="u1",
+            pocket_id=pocket_id,
+            _generator=_NoBuildGenerator(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_ripple_pocket_still_rejected(beanie_test_db):
+    """ripple has no source map at all — rejected before any build, as before."""
+    _view, pocket_id, err = await pockets_service.agent_create(
+        workspace_id="ws1",
+        owner_id="u1",
+        name="Spec site",
+        type_="site",
+        pattern="landing",
+        ripple_spec={"blocks": []},
+        engine="ripple",
+        source=None,
+        trusted=True,
+    )
+    assert err is None, err
+
+    with pytest.raises(ValidationError):
+        await sites_service.get_native_artifact(
+            workspace_id="ws1",
+            user_id="u1",
+            pocket_id=pocket_id,
+            _generator=_NoBuildGenerator(),
+        )
+
+
+def test_content_hash_separates_engines():
+    """The same source map builds to materially different HTML per engine, so the
+    engine has to be part of the artifact's identity."""
+    common = dict(
+        source=dict(_REACT_SOURCE),
+        theme={},
+        builder_origin="https://dash.paw.example",
+        gen_version="1.2.3",
+    )
+    svelte = sites_service._artifact_content_hash(**common, engine="svelte")
+    react = sites_service._artifact_content_hash(**common, engine="react")
+    assert svelte != react
+
+
+def test_has_native_edit_lane_is_narrower_than_source_engine():
+    """The predicate that gates this path: a BUILD to arm, not merely a source map."""
+    from pocketpaw_ee.sites.engines import has_native_edit_lane, is_source_engine
+
+    assert has_native_edit_lane("svelte") is True
+    assert has_native_edit_lane("react") is True
+    # html is a source engine but has no armed build — the distinction this exists for.
+    assert is_source_engine("html") is True
+    assert has_native_edit_lane("html") is False
+    assert has_native_edit_lane("ripple") is False


### PR DESCRIPTION
`GET /native-artifact` rejected any non-svelte pocket with a 422 before doing any work, so the builder had nothing to shadow-render for a react site and its Select tool stayed dimmed. Reported as *"opening react sites, I am not able to select any elements"*.

## The guard

Now `has_native_edit_lane` — a new predicate in `sites/engines.py`, deliberately **narrower** than `is_source_engine`:

| engine | source map? | armable build? |
|---|---|---|
| svelte | yes | yes |
| react | yes | **yes** (new) |
| html | yes | no |
| ripple | no | no |

`html` stays rejected on purpose. Its served artifact *is* its source, so it's selected through its own sandboxed srcdoc and has no build to render. Widening to "any source engine" would have swept it in and offered an editor with nothing behind it.

## Guard and body widened together

The module header requires this, and the body was svelte-specific in exactly one place: `_read_native_artifact` hardcoded a `.svelte-kit/cloudflare` read. It now resolves through `resolve_static_output_rel`, which probes the tree on disk — react lands in `dist/`, and svelte has had two shapes of its own since SL-1.

The engine also joins the artifact content hash. The store is keyed per pocket, so this isn't a live collision today — but an engine-blind hash would serve a svelte render for a react pocket the moment an engine changed under a stable id.

`_read_built` stays a single-arg seam; the engine is bound into the default reader, so injected test doubles keep working unchanged.

## Error code

`pocket.not_svelte_site` → `pocket.no_native_edit_lane`, **on this endpoint only**. The other two svelte-only guards (`leaf-edits`, `edit_svelte_component`) keep theirs — their bodies really are svelte-only until the react write side exists. `docs/api-reference.md` updated.

## Also in here

`_builder_origin()` now warns when it falls back to `http://localhost:8888`.

That default is right on a laptop and wrong everywhere else, and both its failure modes are silent:

- the armed build's bridge posts to an origin the operator's browser never receives, so click-to-edit dies with the page still rendering perfectly
- the value is part of the native-artifact content hash, so publishes and edits with no request `Origin` (chat-agent / MCP) warm the cache under a hash no browser view asks for — every view then stays a cold miss and rebuilds the site (1–2 min on the prod box)

An unset env read exactly like a working one. The matching `.env.example` entry is in the paw-workspace PR.

## Depends on

paw-sites `feat/react-edit-lane` for the arming itself — **and that has to be re-vendored** into `deploy/coolify/vendor/sites-generator/` or a react build here produces an unstamped page.

## Verification

1351 tests pass in `tests/ee/sites/`. Five new tests cover react acceptance, the `dist/` read, html and ripple still rejected, per-engine hash separation, and that `has_native_edit_lane` is strictly narrower than `is_source_engine`.
