### PR TITLE
The site catalog is the pricing spec: five plans, renamed keys

### DIFF
--- a/docs/runbooks/2026-08-21-site-plan-census.md
+++ b/docs/runbooks/2026-08-21-site-plan-census.md
@@ -143,3 +143,46 @@ each hold a domain, which puts that workspace over the cap of 1 already — on d
 with one hostname apiece. **These are dev numbers and say nothing about
 production.** They are recorded only as proof the queries run and as a worked
 example of what the output looks like.
+
+## The rekey happened — and the migration is optional
+
+**Updated 2026-08-22 (feat/site-pricing-ladder).** The rekey shipped:
+`basic`/`pro`/`business` are now `free`/`site`/`staff`, and the catalog gained two
+per-ORG flats (`studio`, `agency`) that are not legal `Site.plan_tier` values at
+all.
+
+**It did not wait for these numbers, and it did not need to.** The catalog
+resolves every legacy key permanently through `_LEGACY_SITE_TIER_ALIASES`, mapped
+by capability rather than ladder position — `pro` sells what `site` sells,
+`business` sells what `staff` sells. A database that is never touched keeps
+working: the entitlement resolver answers identically for the old key and the new
+one, and `_dodo_product_for` looks through the alias so an environment still keyed
+`{"pro": ..., "business": ...}` keeps opening checkouts.
+
+So question 1 above is no longer a gate. It is now just "how many rows will the
+tidy-up move", and the answer changes nothing about whether it is safe.
+
+### Running the migration
+
+```bash
+# Dry run — connects, counts, prints what it WOULD change, writes nothing.
+CLOUD_MONGODB_URI=... uv run python scripts/migrate_site_plan_keys.py
+
+# Then, once the dry run reads right:
+CLOUD_MONGODB_URI=... uv run python scripts/migrate_site_plan_keys.py --apply
+```
+
+Re-running is a no-op: each update filters on the OLD value, so a second pass
+matches nothing. Verify with the census above — a migrated database reports zero
+rows on the legacy keys.
+
+**What it deliberately will not touch:** any `plan_tier` that is neither a legacy
+key nor a current one. An unrecognised value is reported and left exactly as
+found, because rewriting an unplanned value to the floor silently revokes
+whatever it was granting, and the script cannot tell a typo from a restored
+backup written by a newer schema.
+
+**What it buys:** reads stop going through an alias and dashboards stop showing a
+key the catalog no longer lists. Nothing more. The aliases stay in the code
+afterwards — they are permanent, not transitional, because a restored backup or a
+replayed webhook can still present one years from now.

--- a/ee/pocketpaw_ee/cloud/billing/site_plans.py
+++ b/ee/pocketpaw_ee/cloud/billing/site_plans.py
@@ -63,63 +63,211 @@
 # ``_dodo_product_for`` reads ``dodo_site_products`` off settings, and that field
 # was never declared, so the read always found None no matter what the environment
 # said. The field exists now.
+#
+# Updated 2026-08-22 (feat/site-pricing-ladder): the catalog now IS the pricing
+# spec — five tiers on the captain's approved ladder (free / site / staff /
+# studio / agency), rekeyed off the placeholder basic/pro/business names, at
+# $0 / $7 / $19 / $39 / $149 a month.
+#
+# THE REKEY IS THE RISKY HALF, and it is handled by aliasing rather than by a
+# flag day. ``Site.plan_tier`` holds the OLD strings in production, and an
+# unrecognised key resolves to None — which drops the site to the free floor,
+# returning its badge and revoking its custom domain. So ``basic``/``pro``/
+# ``business`` remain resolvable FOREVER through ``_LEGACY_SITE_TIER_ALIASES``,
+# and resolve to the tier that carries the same capabilities they always did
+# (pro sold badge-removal and domains = ``site``; business added the concierge =
+# ``staff``). ``scripts/migrate_site_plan_keys.py`` rewrites the stored values so
+# the aliases go quiet; nothing breaks if it is never run.
+#
+# THE SAME TRAP EXISTS IN CONFIG and is easier to miss: the deployed
+# ``POCKETPAW_DODO_SITE_PRODUCTS`` map is keyed ``{"pro": ..., "business": ...}``.
+# A rekey that only renamed the catalog would have made every paid tier
+# ``purchasable = False`` the moment it deployed — no checkout, no charge, and a
+# publish silently recording the free floor. ``_dodo_product_for`` therefore
+# reads the canonical key FIRST and falls back to any legacy alias of it, so the
+# existing environment keeps working and the new key wins once it is set.
+#
+# TWO SCOPES NOW LIVE IN ONE CATALOG, which is new and is the other thing to read
+# carefully. ``free``/``site``/``staff`` are PER-SITE: they are bought one site at
+# a time and their key lands in ``Site.plan_tier``. ``studio``/``agency`` are
+# PER-ORG flats — one subscription covering many sites — and their key must NEVER
+# reach ``Site.plan_tier``, because a per-site publish cannot buy an org plan.
+# ``scope`` names the difference and ``site_scoped_tier`` enforces it: every
+# entitlement seam resolves through that function, so an org key stored on a site
+# (by a bug, a hand-edit, or a replayed webhook) fails closed to the floor instead
+# of handing one site the whole org's white-label allowance.
+#
+# The org tiers are CATALOG-ONLY today. There is no org subscription entity, no
+# org checkout and no webhook that could activate one, so they carry no Dodo
+# product and ``purchasable`` is False for both — the storefront renders them as
+# "talk to us", the same shape ``billing.plans`` already uses for Enterprise. That
+# is deliberate: a buy button that takes no money and grants nothing is worse than
+# an honest contact link. ``white_label`` / ``included_sites`` / the conversation
+# meter fields below are CATALOG CLAIMS — what a tier will sell — and no seam
+# reads them as an entitlement yet. ``SiteEntitlements`` still does not carry
+# them, for the reason its own docstring gives.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 # ---------------------------------------------------------------------------
-# The site-plan ladder. Each tier names its annual price + the Cloudflare
-# features it resells. Round, modest defaults — a real price sheet tunes them,
-# but the SHAPE (a growing ladder, base resells nothing) is the contract.
+# The site-plan ladder — the captain's approved pricing spec, monthly, in whole
+# US dollars.
 #
-#   basic    — $0/yr    — the included tier; no resold Cloudflare features.
-#   pro      — $120/yr  — adds analytics + uncapped custom domains.
-#   business — $480/yr  — adds the WAF + edge cache controls on top of pro.
+#   free    — $0    — per account. Unlimited builds, badge ON, our subdomain,
+#                     and ONE custom-domained site (the floor grant).
+#   site    — $7    — per SITE. Custom domain + the badge comes off.
+#   staff   — $19   — per SITE. Everything in site, plus the visitor concierge
+#                     with 200 conversations a month included.
+#   studio  — $39   — per ORG, flat. White-label across 5 included sites.
+#   agency  — $149  — per ORG, flat. 25 included sites, SSO + SLA, pooled
+#                     conversation credits at the agency rate.
 # ---------------------------------------------------------------------------
-# MONTHLY, and the rename is load-bearing rather than cosmetic: a field called
-# ``annual_price_usd`` holding 5 reads as $5/YEAR to every future caller, which is
-# below the Cloudflare floor for a single custom hostname ($0.10/hostname/month
-# past the first 100). The old $120/$480 annual figures had no cost basis at all.
-#
-# Decided 2026-08-22. See docs/design/drafts/2026-08-21-paw-sites-pricing-revision.md
-# for the floor, the market comparables, and why annual-only billing was its own
-# conversion problem.
 _SITE_PLAN_MONTHLY_PRICE_USD: dict[str, int] = {
-    "basic": 0,
-    "pro": 5,
-    "business": 19,
+    "free": 0,
+    "site": 7,
+    "staff": 19,
+    "studio": 39,
+    "agency": 149,
+}
+
+# What a subscription on this tier BUYS: one site, or the whole workspace.
+#
+# The distinction is load-bearing rather than descriptive. A ``site``-scoped key
+# is a legal ``Site.plan_tier``; an ``org``-scoped key is not, and storing one
+# there would hand a single site an allowance the org paid for once. Unknown keys
+# resolve to ``org`` in ``_build`` — the scope that is NOT a valid per-site tier —
+# so a typo fails closed out of the per-site path rather than into it.
+SITE_SCOPE = "site"
+ORG_SCOPE = "org"
+_SITE_PLAN_SCOPE: dict[str, str] = {
+    "free": SITE_SCOPE,
+    "site": SITE_SCOPE,
+    "staff": SITE_SCOPE,
+    "studio": ORG_SCOPE,
+    "agency": ORG_SCOPE,
 }
 
 # The Cloudflare features each tier resells (BC-10 provisions them on publish).
 # A higher tier is a superset of the one below it.
 _SITE_PLAN_CF_FEATURES: dict[str, frozenset[str]] = {
-    "basic": frozenset(),
-    "pro": frozenset({"custom_domain", "analytics"}),
-    "business": frozenset({"custom_domain", "analytics", "waf", "edge_cache"}),
+    "free": frozenset(),
+    "site": frozenset({"custom_domain", "analytics"}),
+    "staff": frozenset({"custom_domain", "analytics", "waf", "edge_cache"}),
+    "studio": frozenset({"custom_domain", "analytics", "waf", "edge_cache"}),
+    "agency": frozenset({"custom_domain", "analytics", "waf", "edge_cache"}),
 }
 
-# Whether a tier may ship a site WITHOUT the attribution badge. ``basic`` is the
-# free floor and keeps its badge — that is the whole difference between free and
-# paid. Absent/unknown keys resolve False in ``_build``, so a typo means BADGED:
-# fail-closed, matching ``sites.badge``'s posture everywhere else.
-# The concierge is the ENTIRE difference between the $5 and $19 rungs, so it has
-# to be mapped per tier rather than derived. It used to be "any tier above the
-# floor", which was correct only while the tier meant to sell it did not exist;
-# once the ladder has two paid rungs that derivation hands the cheap one the
-# expensive one's feature.
+# Does this tier sell the visitor concierge at all?
 #
-# ``.get(key, False)`` fails CLOSED: an unknown tier sells no concierge.
+# A per-tier map and NOT "any tier above the floor", which is what it used to be.
+# That derivation was only ever correct while no tier sold the concierge: under
+# this ladder the concierge is precisely the difference between ``site`` and
+# ``staff``, so deriving it would hand the $7 rung the $19 rung's feature.
+# ``studio`` is white-label hosting, not staffing — it sells the badge removal
+# five times over, not the concierge. ``agency`` sells it, which is what its
+# pooled conversation rate is for. Unknown keys resolve False in ``_build``.
 _SITE_PLAN_SELLS_CONCIERGE: dict[str, bool] = {
-    "basic": False,
-    "pro": False,
-    "business": True,
+    "free": False,
+    "site": False,
+    "staff": True,
+    "studio": False,
+    "agency": True,
 }
 
+# Whether a tier may ship a site WITHOUT the attribution badge. ``free`` is the
+# floor and keeps its badge — that is the whole difference between free and paid.
+# Absent/unknown keys resolve False in ``_build``, so a typo means BADGED:
+# fail-closed, matching ``sites.badge``'s posture everywhere else.
 _SITE_PLAN_BADGE_REMOVAL: dict[str, bool] = {
-    "basic": False,
-    "pro": True,
-    "business": True,
+    "free": False,
+    "site": True,
+    "staff": True,
+    "studio": True,
+    "agency": True,
+}
+
+# WHITE-LABEL: no Paw marks anywhere across the org, not just the badge off one
+# site. A CATALOG CLAIM — the org tiers that carry it cannot be bought yet, and no
+# seam reads this field as an entitlement. It exists so the plan card can name what
+# separates a $39 org flat from five $7 sites. When org billing lands, this is the
+# field the resolver will AND with an active org subscription.
+_SITE_PLAN_WHITE_LABEL: dict[str, bool] = {
+    "free": False,
+    "site": False,
+    "staff": False,
+    "studio": True,
+    "agency": True,
+}
+
+# How many sites an ORG-scoped flat includes before the bulk per-site rate starts.
+# ``None`` on every per-site tier — the question does not apply to a subscription
+# that buys exactly one site. Catalog claim, same caveat as ``white_label``.
+_SITE_PLAN_INCLUDED_SITES: dict[str, int | None] = {
+    "free": None,
+    "site": None,
+    "staff": None,
+    "studio": 5,
+    "agency": 25,
+}
+
+# Concierge conversations included per month, and the rate per conversation
+# beyond them, in CENTS.
+#
+# Cents rather than a float: $0.05 has no exact binary representation, and a
+# per-conversation rate is multiplied by a count and then billed. The one place
+# that must render dollars divides at the edge.
+#
+# Both are CATALOG CLAIMS. Nothing meters a conversation yet — there is no
+# conversation counter, no debit path and no overage — so these describe the
+# ladder rather than gate anything. ``SiteEntitlements`` deliberately does NOT
+# carry them (see its docstring: a field that always returns 0 reads as
+# implemented). The unit is defined in the pricing spec: one visitor thread that
+# received at least one agent reply, closing after 24h of inactivity.
+_SITE_PLAN_CONVERSATION_ALLOWANCE: dict[str, int] = {
+    "free": 0,
+    "site": 0,
+    "staff": 200,
+    "studio": 0,
+    "agency": 0,
+}
+
+# The list rate is 10 cents; ``agency``'s pooled rate is half of it and is the
+# reason the tier exists at its price. Tiers that sell no concierge still carry
+# the list rate rather than 0 — a 0 here would read as "free conversations" to
+# anything that renders it, which is the opposite of the truth (they get none).
+_LIST_CONVERSATION_RATE_CENTS = 10
+_SITE_PLAN_CONVERSATION_RATE_CENTS: dict[str, int] = {
+    "free": _LIST_CONVERSATION_RATE_CENTS,
+    "site": _LIST_CONVERSATION_RATE_CENTS,
+    "staff": _LIST_CONVERSATION_RATE_CENTS,
+    "studio": _LIST_CONVERSATION_RATE_CENTS,
+    "agency": 5,
+}
+
+# Buyer-facing name + the one line a plan card leads with. The catalog owns these
+# rather than the frontend, for the reason the storefront's own comment gives: a
+# blurb keyed on a tier name in the client says nothing the day the keys change,
+# and the keys just changed. Mirrors ``billing.plans._PLAN_DISPLAY``.
+_SITE_PLAN_DISPLAY: dict[str, tuple[str, str]] = {
+    "free": ("Free", "Build and publish as many sites as you like, on a pawsites subdomain."),
+    "site": ("Site", "Point your own domain at it and the Paw badge comes off."),
+    "staff": ("Staff", "Adds the visitor concierge — 200 conversations a month, then metered."),
+    "studio": ("Studio", "White-label across five sites, on one flat bill for the whole org."),
+    "agency": ("Agency", "Twenty-five sites with SSO, an SLA, and pooled conversation credits."),
+}
+
+# Extra selling points that are NOT capability flags, and the distinction matters
+# enough to keep them in their own field. Every other entry in this catalog is
+# something code can check; these are commitments a human honours. Putting SSO in
+# ``_SITE_PLAN_CF_FEATURES`` would make it look enforced by something.
+_SITE_PLAN_HIGHLIGHTS: dict[str, tuple[str, ...]] = {
+    "free": (),
+    "site": (),
+    "staff": (),
+    "studio": ("No Paw marks anywhere", "One bill for the whole org"),
+    "agency": ("Single sign-on", "Service-level agreement", "Pooled conversation credits"),
 }
 
 # How many SITES in a workspace may carry a custom domain on this tier.
@@ -132,14 +280,23 @@ _SITE_PLAN_BADGE_REMOVAL: dict[str, bool] = {
 # ``SiteDomain`` rows, and ``SiteDomain`` is one row per hostname.
 #
 # The floor carries 1, not 0: "only 1 site is allowed to have a custom domain in
-# free" (captain, 2026-08-21). That 1 is a FLOOR GRANT — it needs no subscription,
-# unlike every other capability on this catalog — so the resolver reads it off the
-# base tier whether or not the site is paying. Unknown keys resolve to 0 in
-# ``_build``: fail-closed, matching ``badge_removal``.
+# free" (captain, 2026-08-21, reaffirmed against the pricing spec 2026-08-22 —
+# the spec itself says subdomain-only, and this is the one place we knowingly
+# depart from it). That 1 is a FLOOR GRANT — it needs no subscription, unlike
+# every other capability on this catalog — so the resolver reads it off the base
+# tier whether or not the site is paying. Unknown keys resolve to 0 in ``_build``:
+# fail-closed, matching ``badge_removal``.
+#
+# The ORG tiers are ``None`` here and carry their real allowance in
+# ``included_sites`` instead. This field answers "how many domained sites does
+# THIS SITE's own plan allow", and an org key can never be a site's own plan —
+# ``site_scoped_tier`` refuses it before this field is ever read.
 _SITE_PLAN_MAX_DOMAINED_SITES: dict[str, int | None] = {
-    "basic": 1,
-    "pro": None,
-    "business": None,
+    "free": 1,
+    "site": None,
+    "staff": None,
+    "studio": None,
+    "agency": None,
 }
 
 # How many HOSTNAMES one FLOOR-tier site may carry. The companion cap to
@@ -154,35 +311,109 @@ _SITE_PLAN_MAX_DOMAINED_SITES: dict[str, int | None] = {
 # subject to it.
 _FREE_MAX_HOSTNAMES_PER_SITE = 2
 
-# Order the catalog is listed in — the price ladder, cheapest first.
-_SITE_TIER_ORDER: tuple[str, ...] = ("basic", "pro", "business")
+# Order the catalog is listed in — the price ladder, cheapest first, per-site
+# tiers before the org flats.
+_SITE_TIER_ORDER: tuple[str, ...] = ("free", "site", "staff", "studio", "agency")
 
 # The base/floor site tier — a publish with no explicit tier resolves here.
-BASE_SITE_PLAN_KEY = "basic"
+BASE_SITE_PLAN_KEY = "free"
+
+# The keys this catalog shipped under before 2026-08-22, mapped to the tier that
+# carries the same capabilities today. ``Site.plan_tier`` holds these strings in
+# production and NOTHING rewrites a stored document on read, so dropping them
+# would silently demote every already-published site to the free floor: badge
+# back, custom domain revoked, concierge off.
+#
+# They are permanent, not transitional. The migration script exists to make them
+# unnecessary, not to make them removable — a restored backup, a replayed webhook
+# or an old client can still present one years from now, and resolving it costs a
+# dict lookup.
+#
+# The mapping is by CAPABILITY, not by ladder position: ``pro`` sold badge removal
+# and uncapped domains with no concierge, which is exactly ``site``; ``business``
+# added the concierge, which is exactly ``staff``. A position-based mapping would
+# have put ``business`` on ``studio``.
+_LEGACY_SITE_TIER_ALIASES: dict[str, str] = {
+    "basic": "free",
+    "pro": "site",
+    "business": "staff",
+}
 
 
 @dataclass(frozen=True)
 class SitePlanTier:
     """One row of the per-site plan catalog — the declarative view of a site tier.
 
-    ``key`` matches the ``Site.plan_tier`` string. ``monthly_price_usd`` is the
-    recurring annual sticker (USD, whole dollars). ``dodo_product_id`` is the
-    recurring-product id, or None until config populates it. ``cloudflare_features``
-    is the set of Cloudflare features the tier resells (BC-10 provisions them).
-    ``badge_removal`` is whether a site on this tier may ship without the
-    attribution badge — read by ``sites.badge.badge_required``. ``sells_concierge``
-    and ``purchasable`` are derived, not stored (see the properties).
-    ``max_domained_sites`` is how many SITES in the workspace may carry a custom
-    domain on this tier (None = uncapped) — the site, not the hostname, so apex +
-    ``www`` on one site spend one.
+    ``key`` matches the ``Site.plan_tier`` string FOR SITE-SCOPED TIERS ONLY; an
+    org-scoped row's key is never a legal value there (see ``scope``).
+    ``monthly_price_usd`` is the recurring MONTHLY sticker (USD, whole dollars).
+    ``dodo_product_id`` is the recurring-product id, or None until config
+    populates it. ``cloudflare_features`` is the set of Cloudflare features the
+    tier resells (BC-10 provisions them). ``badge_removal`` is whether a site on
+    this tier may ship without the attribution badge — read by
+    ``sites.badge.badge_required``. ``sells_concierge`` is whether the tier sells
+    the visitor concierge at all. ``max_domained_sites`` is how many SITES in the
+    workspace may carry a custom domain on this tier (None = uncapped) — the site,
+    not the hostname, so apex + ``www`` on one site spend one.
+
+    ``scope`` is ``"site"`` or ``"org"`` and decides which of the two billing
+    shapes this row is. Read it before doing anything with ``key``.
+
+    ``white_label``, ``included_sites``, ``conversation_allowance`` and
+    ``conversation_rate_cents`` are CATALOG CLAIMS — what the tier will sell. No
+    seam gates on them, and ``SiteEntitlements`` deliberately does not carry them.
+    They are here so a plan card can describe the ladder honestly; do not mistake
+    one for a resolved permission.
+
+    ``sells_concierge``, ``is_org_scoped`` and ``purchasable`` are derived, not
+    stored (see the properties).
     """
 
     key: str
     monthly_price_usd: int
     dodo_product_id: str | None
     cloudflare_features: frozenset[str]
+    scope: str = ORG_SCOPE
     badge_removal: bool = False
     max_domained_sites: int | None = 0
+    white_label: bool = False
+    included_sites: int | None = None
+    conversation_allowance: int = 0
+    conversation_rate_cents: int = _LIST_CONVERSATION_RATE_CENTS
+    display_name: str = ""
+    tagline: str = ""
+    highlights: tuple[str, ...] = field(default_factory=tuple)
+
+    @property
+    def is_org_scoped(self) -> bool:
+        """Is this an ORG flat rather than a per-site subscription?
+
+        The one question every caller holding a ``Site.plan_tier`` needs answered
+        before it trusts the key. A property rather than ``tier.scope == "org"``
+        repeated at each call site, because a string comparison typo'd to
+        ``"orgs"`` is silently False — which is the unsafe direction.
+        """
+        return self.scope == ORG_SCOPE
+
+    @property
+    def sells_concierge(self) -> bool:
+        """Does this tier sell the visitor concierge at all?
+
+        A PROPERTY over ``_SITE_PLAN_SELLS_CONCIERGE`` rather than a field
+        populated in ``_build``, and the difference is not stylistic: the resolver
+        test in ``tests/cloud/billing/test_site_plan_inclusions.py`` overrides this
+        property to prove ``resolve_site_entitlements`` actually READS the catalog
+        rather than re-deriving "any tier above the floor" inline. A dataclass
+        field cannot be overridden that way — the instance value shadows the class
+        attribute — so making it a field would silently turn that test into one
+        that passes against the bug it was written to catch.
+
+        This is the CATALOG question — "does this tier sell it" — and on its own
+        entitles nobody. ``resolve_site_entitlements`` ANDs it with an active
+        subscription to answer "may THIS site serve one", which is the question
+        every public seam asks.
+        """
+        return _SITE_PLAN_SELLS_CONCIERGE.get(self.key, False)
 
     @property
     def purchasable(self) -> bool:
@@ -195,29 +426,37 @@ class SitePlanTier:
         then holds a paid ``plan_tier`` with ``subscription_status="none"``, which
         every entitlement resolves against as the free floor.
 
+        AN ORG-SCOPED TIER IS NEVER PURCHASABLE HERE, whatever config says. The
+        per-site checkout is the only checkout that exists, and it buys one site;
+        pointing it at an org flat would charge the org price and grant one site's
+        worth of capability. The storefront renders these as "talk to us" — the
+        shape ``billing.plans`` already uses for Enterprise — until an org
+        subscription entity exists to buy them properly.
+
         Derived rather than stored, so it tracks configuration rather than a
-        deploy-time snapshot. Surfaced on the plan-catalog DTO so a buyer-facing
-        card can mark a tier unavailable instead of offering a button that quietly
-        does nothing.
+        deploy-time snapshot.
         """
+        if self.is_org_scoped:
+            return False
         return self.monthly_price_usd == 0 or self.dodo_product_id is not None
 
-    @property
-    def sells_concierge(self) -> bool:
-        """Does this tier sell the visitor concierge at all?
 
-        Mapped per tier as of 2026-08-22, having previously been derived as "any
-        tier above the floor". That derivation was right only while no tier
-        actually sold the concierge — under the $0/$5/$19 ladder the concierge IS
-        the difference between the two paid rungs, so deriving it would give the
-        $5 tier the thing the $19 tier is for.
+def canonical_site_tier_key(key: str | None) -> str | None:
+    """Map any tier key this catalog has ever shipped to its current name.
 
-        This is the CATALOG question — "does this tier sell it" — and on its own
-        entitles nobody. ``resolve_site_entitlements`` ANDs it with an active
-        subscription to answer "may THIS site serve one", which is the question
-        every public seam asks.
-        """
-        return _SITE_PLAN_SELLS_CONCIERGE.get(self.key, False)
+    Returns the canonical key for a live tier, the aliased key for a legacy one,
+    and None for anything else — including None itself, so callers can pass a
+    nullable ``Site.plan_tier`` straight in.
+
+    Public because two things outside the catalog need the same answer: the
+    migration script (which rewrites stored values) and any log line that wants
+    to report what an old key became.
+    """
+    if not key:
+        return None
+    if key in _SITE_PLAN_MONTHLY_PRICE_USD:
+        return key
+    return _LEGACY_SITE_TIER_ALIASES.get(key)
 
 
 def _dodo_product_for(key: str) -> str | None:
@@ -230,6 +469,13 @@ def _dodo_product_for(key: str) -> str | None:
     the catalog never forces config load in a context that doesn't have it (e.g. a
     unit test of ``list_site_plans``); any config error degrades safely to None
     rather than breaking the read. Mirrors ``billing.plans._dodo_product_for``.
+
+    THE CANONICAL KEY WINS, THEN ANY LEGACY ALIAS OF IT. The deployed environment
+    is keyed ``{"pro": ..., "business": ...}``, and a rename that only looked up
+    the new name would have found nothing — turning every paid tier unpurchasable
+    on deploy, with publishes quietly recording the free floor. Looking through
+    the alias means the running config keeps working and a re-keyed config takes
+    precedence the moment it is set.
     """
     try:
         from pocketpaw.config import get_settings
@@ -239,26 +485,43 @@ def _dodo_product_for(key: str) -> str | None:
         return None
     if not isinstance(mapping, dict):
         return None
-    val = mapping.get(key)
-    return val if isinstance(val, str) and val else None
+    candidates = [key] + [old for old, new in _LEGACY_SITE_TIER_ALIASES.items() if new == key]
+    for candidate in candidates:
+        val = mapping.get(candidate)
+        if isinstance(val, str) and val:
+            return val
+    return None
 
 
 def _build(key: str) -> SitePlanTier:
     """Construct a ``SitePlanTier`` for ``key`` from the catalog constants + config.
 
-    An unknown ``key`` yields a 0-price, no-feature tier — but callers go through
-    ``get_site_plan`` / ``list_site_plans``, which only ever pass known keys.
+    An unknown ``key`` yields a 0-price, no-feature, ORG-scoped tier — org because
+    that is the scope which is NOT a legal ``Site.plan_tier``, so an unknown key
+    fails closed out of the per-site path. Callers go through ``get_site_plan`` /
+    ``list_site_plans``, which only ever pass known keys.
     """
+    display_name, tagline = _SITE_PLAN_DISPLAY.get(key, ("", ""))
     return SitePlanTier(
         key=key,
         monthly_price_usd=_SITE_PLAN_MONTHLY_PRICE_USD.get(key, 0),
         dodo_product_id=_dodo_product_for(key),
         cloudflare_features=_SITE_PLAN_CF_FEATURES.get(key, frozenset()),
+        scope=_SITE_PLAN_SCOPE.get(key, ORG_SCOPE),
         badge_removal=_SITE_PLAN_BADGE_REMOVAL.get(key, False),
         # ``.get(key, 0)`` and not ``.get(key)``: a missing key must mean NO
         # domains, while a present key mapped to None means UNCAPPED. Collapsing
         # the two would hand an unknown tier the uncapped answer.
         max_domained_sites=_SITE_PLAN_MAX_DOMAINED_SITES.get(key, 0),
+        white_label=_SITE_PLAN_WHITE_LABEL.get(key, False),
+        included_sites=_SITE_PLAN_INCLUDED_SITES.get(key),
+        conversation_allowance=_SITE_PLAN_CONVERSATION_ALLOWANCE.get(key, 0),
+        conversation_rate_cents=_SITE_PLAN_CONVERSATION_RATE_CENTS.get(
+            key, _LIST_CONVERSATION_RATE_CENTS
+        ),
+        display_name=display_name,
+        tagline=tagline,
+        highlights=_SITE_PLAN_HIGHLIGHTS.get(key, ()),
     )
 
 
@@ -276,29 +539,80 @@ def free_max_hostnames_per_site() -> int:
 def list_site_plans() -> list[SitePlanTier]:
     """Return the full site-plan catalog, cheapest tier first.
 
+    ALL FIVE ROWS, both scopes — this is what the storefront renders, and a buyer
+    comparing plans needs to see the org flats beside the per-site rungs. A caller
+    that means "tiers a site may be published on" wants
+    ``list_site_scoped_plans`` instead; picking the wrong one here is how an org
+    key reaches ``Site.plan_tier``.
+
     Each ``SitePlanTier`` is built fresh from the catalog constants + config, so
     the catalog always reflects the current configuration.
     """
     return [_build(key) for key in _SITE_TIER_ORDER]
 
 
+def list_site_scoped_plans() -> list[SitePlanTier]:
+    """The per-site rungs only — the tiers a single site may actually be put on.
+
+    The publish path and the per-site tier picker want this list, never
+    ``list_site_plans``: an org flat in a per-site picker offers a purchase that
+    cannot happen and a key that must never be stored on the site.
+    """
+    return [tier for tier in list_site_plans() if not tier.is_org_scoped]
+
+
 def get_site_plan(key: str | None) -> SitePlanTier | None:
-    """Resolve a single site tier by its ``key`` (the ``Site.plan_tier`` string).
+    """Resolve a single tier by its ``key``, accepting any name it has shipped under.
 
     Returns None for an unknown / missing key. Callers that need a guaranteed
     floor map a None back to ``BASE_SITE_PLAN_KEY`` themselves — this function does
     NOT silently substitute, so a typo in a lookup is visible rather than masked
     (mirrors ``billing.plans.get_plan``).
+
+    Legacy keys resolve to their current tier, so the returned row's ``key`` is the
+    CANONICAL one — ``get_site_plan("pro").key == "site"``. That is deliberate: a
+    caller that echoes the resolved key back onto a document or into a response
+    quietly completes the migration rather than re-persisting the old name.
+
+    RESOLVES BOTH SCOPES. A caller holding a ``Site.plan_tier`` wants
+    ``site_scoped_tier`` instead — this one will happily hand back an org flat.
     """
-    if not key or key not in _SITE_PLAN_MONTHLY_PRICE_USD:
+    canonical = canonical_site_tier_key(key)
+    if canonical is None:
         return None
-    return _build(key)
+    return _build(canonical)
+
+
+def site_scoped_tier(key: str | None) -> SitePlanTier | None:
+    """Resolve ``key`` as A SITE'S OWN plan, or None if it cannot be one.
+
+    The guarded read every entitlement seam uses. It differs from
+    ``get_site_plan`` in exactly one way, and that way is the point: an
+    ORG-scoped key resolves to None here rather than to a tier.
+
+    ``Site.plan_tier`` is written by the publish path, which only offers per-site
+    rungs — so an org key in that field means something went wrong: a bug, a
+    hand-edited document, a replayed webhook, a restored backup from a future
+    schema. Whatever the cause, the safe reading is "this site has no plan of its
+    own", which lands it on the free floor. The unsafe reading is the one a plain
+    catalog lookup gives: one site silently holding the white-label allowance an
+    org pays $149 a month for.
+    """
+    tier = get_site_plan(key)
+    if tier is None or tier.is_org_scoped:
+        return None
+    return tier
 
 
 __all__ = [
     "BASE_SITE_PLAN_KEY",
+    "ORG_SCOPE",
+    "SITE_SCOPE",
     "SitePlanTier",
+    "canonical_site_tier_key",
     "free_max_hostnames_per_site",
     "get_site_plan",
     "list_site_plans",
+    "list_site_scoped_plans",
+    "site_scoped_tier",
 ]

--- a/ee/pocketpaw_ee/cloud/entitlements/dto.py
+++ b/ee/pocketpaw_ee/cloud/entitlements/dto.py
@@ -36,6 +36,18 @@
 #   badge or the concierge, which are the two capabilities the paid tiers are
 #   actually sold on. A card that cannot name what a tier includes cannot name what
 #   it omits either, which is the half buyers ask about.
+# Updated 2026-08-22 (feat/site-pricing-ladder): ``SitePlanTierResponse`` carries
+#   the rest of the catalog row now that the catalog is the five-tier pricing spec
+#   — ``scope`` (site rung vs org flat), the card copy the backend owns
+#   (``display_name`` / ``tagline`` / ``highlights``), and the ladder facts a card
+#   has to state to be comparable (``white_label``, ``included_sites``,
+#   ``conversation_allowance``, ``conversation_rate_cents``). The storefront was
+#   deriving its own per-key labels and blurbs client-side, which the rekey would
+#   have blanked; owning the copy here means renaming a tier is one edit.
+#   NOTE the asymmetry with ``SiteEntitlementsResponse``, and keep it: this DTO
+#   describes what a TIER SELLS, that one describes what a SITE MAY DO. The
+#   conversation meter and white-label are unenforced claims today and appear only
+#   here, never there.
 
 from __future__ import annotations
 
@@ -153,12 +165,45 @@ class SitePlanTierResponse(BaseModel):
     that AND lives in ``resolve_site_entitlements``, and it is why these two must
     never be read as a per-site entitlement. They are here so a plan CARD can say
     what each tier includes and, by their absence, what it does not.
+
+    ``scope`` is ``"site"`` or ``"org"`` and tells the storefront which of two
+    completely different things a row is. A site-scoped row is bought one site at
+    a time and its key is a legal ``Site.plan_tier``; an org-scoped flat covers a
+    whole workspace and its key must never be sent back as a publish's
+    ``site_plan_key``. Org rows always arrive with ``purchasable: false`` because
+    no org checkout exists yet — render them as "talk to us", never as a buy
+    button.
+
+    ``white_label``, ``included_sites``, ``conversation_allowance`` and
+    ``conversation_rate_cents`` describe the LADDER, not any site's permissions.
+    Nothing meters a conversation yet and nothing enforces white-label; they are
+    here so a card can state what a tier will sell. ``SiteEntitlementsResponse`` —
+    the read that answers "what may THIS site do" — deliberately carries none of
+    them.
+
+    ``conversation_rate_cents`` is cents, not dollars: $0.05 has no exact float
+    representation and the number gets multiplied by a conversation count.
+
+    ``display_name``, ``tagline`` and ``highlights`` are the card's copy, owned by
+    the catalog rather than the client. A blurb keyed on a tier name in the
+    frontend says nothing the day the keys change, and they just did.
+    ``highlights`` are commitments a human honours (SSO, an SLA) rather than flags
+    code checks — kept apart from ``cloudflare_features`` so they cannot be
+    mistaken for something enforced.
     """
 
     key: str
     monthly_price_usd: int
     dodo_product_id: str | None = None
     cloudflare_features: list[str] = Field(default_factory=list)
+    scope: str = "site"
+    white_label: bool = False
+    included_sites: int | None = None
+    conversation_allowance: int = 0
+    conversation_rate_cents: int = 0
+    display_name: str = ""
+    tagline: str = ""
+    highlights: list[str] = Field(default_factory=list)
     badge_removal: bool = False
     sells_concierge: bool = False
     purchasable: bool = True
@@ -177,6 +222,18 @@ def site_plan_tier_to_dto(tier: SitePlanTier) -> SitePlanTierResponse:
         monthly_price_usd=tier.monthly_price_usd,
         dodo_product_id=tier.dodo_product_id,
         cloudflare_features=sorted(tier.cloudflare_features),
+        scope=tier.scope,
+        white_label=tier.white_label,
+        included_sites=tier.included_sites,
+        conversation_allowance=tier.conversation_allowance,
+        conversation_rate_cents=tier.conversation_rate_cents,
+        display_name=tier.display_name,
+        tagline=tier.tagline,
+        # ``highlights`` is a tuple on the catalog row (frozen dataclass) and a
+        # list on the wire. Order is meaningful and preserved — it is card copy,
+        # not a set — so this is a cast, not the ``sorted(...)`` the feature
+        # collections above get.
+        highlights=list(tier.highlights),
         badge_removal=tier.badge_removal,
         sells_concierge=tier.sells_concierge,
         purchasable=tier.purchasable,

--- a/ee/pocketpaw_ee/cloud/entitlements/service.py
+++ b/ee/pocketpaw_ee/cloud/entitlements/service.py
@@ -55,6 +55,16 @@
 #   "above the free floor" here — the plan-catalog DTO needs the same answer for
 #   the buyer-facing plan cards, and two copies of one rule drift. The AND with an
 #   active subscription stays here; that is this resolver's job, not the catalog's.
+# Updated 2026-08-22 (feat/site-pricing-ladder): both per-site reads
+#   (``site_domain_allowance`` and ``resolve_site_entitlements``) now go through
+#   ``site_plans.site_scoped_tier`` instead of ``get_site_plan``. The catalog gained
+#   ORG-scoped flats (studio/agency) in the pricing rekey, and their keys are not
+#   legal ``Site.plan_tier`` values — a plain lookup would resolve one off a single
+#   site's field and grant that site an allowance the org buys once for many.
+#   ``site_scoped_tier`` returns None for them, so an org key on a site fails closed
+#   to the free floor exactly as an unknown key does. The same call also resolves
+#   the LEGACY basic/pro/business keys, which is what stops the rekey demoting every
+#   already-published site the day it deploys.
 
 from __future__ import annotations
 
@@ -166,7 +176,12 @@ def site_domain_allowance(*, plan_tier: str | None, subscription_status: str | N
     # A paying tier's own allowance REPLACES the floor — normally upward
     # (None = uncapped). Not ``max(...)``: None is not a number, and a tier that
     # deliberately sells fewer domained sites than free should be able to.
-    tier = site_plan_catalog.get_site_plan(plan_tier)
+    #
+    # ``site_scoped_tier`` and not ``get_site_plan``: the catalog now also holds
+    # ORG flats (studio/agency), whose keys are not legal ``Site.plan_tier``
+    # values. Resolving one here would read an org-wide allowance off a single
+    # site's field. It returns None for those, which lands on the floor.
+    tier = site_plan_catalog.site_scoped_tier(plan_tier)
     if tier is not None and _subscription_is_active(subscription_status):
         allowance = tier.max_domained_sites
     return allowance
@@ -204,9 +219,19 @@ def resolve_site_entitlements(
     (badged, and the base tier's own domain allowance) rather than raising or
     substituting a paid tier.
     """
-    tier = site_plan_catalog.get_site_plan(plan_tier)
-    # ``get_site_plan`` deliberately does not substitute a floor, so an unknown or
-    # missing key lands here as None — the fail-closed default.
+    # ``site_scoped_tier`` rather than ``get_site_plan``, and the difference is a
+    # security property rather than a tidiness one. The catalog now carries ORG
+    # flats (studio/agency) beside the per-site rungs, and an org key is not a
+    # legal ``Site.plan_tier``. A plain catalog lookup would resolve one and hand
+    # THIS SITE the badge removal and white-label allowance an org pays for across
+    # twenty-five. ``site_scoped_tier`` returns None for them, which is the same
+    # fail-closed answer an unknown key gets: the free floor.
+    tier = site_plan_catalog.site_scoped_tier(plan_tier)
+    # It deliberately does not substitute a floor, so an unknown, org-scoped or
+    # missing key lands here as None — the fail-closed default. A LEGACY key
+    # (basic/pro/business) does resolve, to the tier carrying the same
+    # capabilities, so ``resolved_key`` reports the current name for a site whose
+    # document still holds the old one.
     resolved_key = tier.key if tier is not None else site_plan_catalog.BASE_SITE_PLAN_KEY
 
     subscription_active = _subscription_is_active(subscription_status)

--- a/ee/pocketpaw_ee/cloud/models/site.py
+++ b/ee/pocketpaw_ee/cloud/models/site.py
@@ -354,8 +354,13 @@ class Site(TimestampedDocument):
     build_reason: str | None = None
     # BC-9: per-site annual plan (the Webflow model — each published site has its
     # OWN recurring annual plan on a tier, distinct from the workspace plan).
-    # ``plan_tier`` is the site-plan catalog key (basic | pro | business — see
-    # ``billing.site_plans``); None until a publish stamps one. ``subscription_id``
+    # ``plan_tier`` is the site-plan catalog key — one of the SITE-SCOPED rungs
+    # (free | site | staff — see ``billing.site_plans``), never one of the org
+    # flats (studio | agency), which cover a whole workspace and are refused here
+    # by ``site_plans.site_scoped_tier``. Documents written before 2026-08-22 hold
+    # the old names (basic | pro | business); those resolve through the catalog's
+    # permanent legacy aliases, and ``scripts/migrate_site_plan_keys.py`` rewrites
+    # them. None until a publish stamps one. ``subscription_id``
     # is the Dodo subscription id for this site's annual sub (None when Dodo is
     # unconfigured — the tier is recorded without a live charge in v1).
     # ``renewal_date`` is the next renewal stamp the per-site webhook

--- a/ee/pocketpaw_ee/sites/dto.py
+++ b/ee/pocketpaw_ee/sites/dto.py
@@ -173,9 +173,12 @@ from pydantic import BaseModel, field_validator
 
 class PublishRequest(BaseModel):
     # ``site_plan_key`` (BC-10) is the OPTIONAL per-site plan tier the site is
-    # published on (basic | pro | business — see ``billing.site_plans``). Omitted
-    # defaults to the base tier in ``publish_pocket``; a higher tier resells its
-    # Cloudflare features when a custom domain is later added.
+    # published on. Only the SITE-SCOPED rungs are valid here (free | site | staff
+    # — see ``billing.site_plans``); an org flat (studio | agency) covers a whole
+    # workspace and ``_apply_site_plan`` refuses it rather than stamping it on one
+    # site. Legacy names (basic | pro | business) still resolve. Omitted defaults
+    # to the base tier in ``publish_pocket``; a higher tier resells its Cloudflare
+    # features when a custom domain is later added.
     pocket_id: str
     site_plan_key: str | None = None
 

--- a/ee/pocketpaw_ee/sites/service.py
+++ b/ee/pocketpaw_ee/sites/service.py
@@ -868,6 +868,7 @@ from typing import Any
 
 from bson import ObjectId
 from bson.errors import InvalidId
+from dateutil.relativedelta import relativedelta
 from pydantic import BaseModel
 
 from pocketpaw.sites_capture.contact_form import CONTACT_FORM_TYPE, default_event_mapping
@@ -1710,6 +1711,32 @@ async def _promote_pocket_draft_to_published(
         )
 
 
+def _canonical_plan_tier(stored: str | None) -> str:
+    """A stored ``Site.plan_tier`` under the name the catalog uses TODAY.
+
+    Documents written before the 2026-08-22 rekey hold basic/pro/business. Every
+    client matches this value against the keys served by ``GET /billing/site-plans``
+    — to badge the current plan card, to decide what an upgrade costs — and the old
+    names are not in that list, so shipping the raw string makes a paying site look
+    like it is on no plan at all.
+
+    Falls back to the raw value for anything the catalog does not know, and to ""
+    for absent. Not to the floor: reporting a site as free because its tier string
+    is unrecognised is a confident wrong answer, while the odd string at least
+    tells whoever is reading a support ticket what is actually on the document.
+
+    A module-level function rather than an inline expression because both the
+    response mapper and the emitted ``SitePublished`` payload need the same answer,
+    and an event that disagrees with the response it accompanies is the kind of
+    drift nothing catches.
+    """
+    if not stored:
+        return ""
+    from pocketpaw_ee.cloud.billing import site_plans as _site_plans
+
+    return _site_plans.canonical_site_tier_key(stored) or stored
+
+
 def _to_response(doc: _SiteDoc, pattern: str = "", engine: str = "") -> SiteResponse:
     deployed_at = getattr(doc, "deployed_at", None)
     created_at = getattr(doc, "createdAt", None)
@@ -1749,7 +1776,20 @@ def _to_response(doc: _SiteDoc, pattern: str = "", engine: str = "") -> SiteResp
         checkout_url=getattr(doc, "_checkout_url", None),
         # The per-site billing state. Read straight off the doc — no extra query.
         # These were declared in the frontend and branched on, and never sent.
-        plan_tier=getattr(doc, "plan_tier", None) or "",
+        #
+        # ``plan_tier`` goes out under its CURRENT catalog name, not the raw
+        # stored string. Documents written before the 2026-08-22 rekey hold
+        # basic/pro/business, and the client matches this value against the keys
+        # in ``GET /billing/site-plans`` to decide which card reads "Current". A
+        # raw "pro" matches none of them, so a paying site's plan card would show
+        # nothing selected while the entitlements endpoint — which resolves
+        # through the catalog — reported "site" for the same site. Two endpoints
+        # disagreeing about one site's plan is worse than either answer.
+        #
+        # An unrecognised value falls back to the raw string rather than to "" or
+        # the floor: it is wrong either way, and the wrong value a human can read
+        # is more useful to whoever gets the support ticket than a blank.
+        plan_tier=_canonical_plan_tier(getattr(doc, "plan_tier", None)),
         subscription_status=getattr(doc, "subscription_status", None) or "none",
         renewal_date=(
             _renewal.isoformat()
@@ -4469,7 +4509,11 @@ async def add_domain(
     # Resolve the site's tier → its cloudflare_features and provision them on the
     # custom hostname. A base-tier (or unknown) site resolves to an empty set, so
     # create_custom_hostname stays on the basic path.
-    plan = site_plans.get_site_plan(site.plan_tier)
+    # ``site_scoped_tier`` — this reads a STORED ``plan_tier``, and the catalog
+    # also holds org flats whose keys are not legal there. Resolving one would
+    # provision the WAF and edge-cache controls an org buys across its whole
+    # estate onto one site nobody billed for them.
+    plan = site_plans.site_scoped_tier(site.plan_tier)
     features = set(plan.cloudflare_features) if plan else set()
     ch = await cf.create_custom_hostname(hostname, features=features)
 
@@ -4885,7 +4929,13 @@ async def publish_pocket(
     #     LIVE immediately, exactly as before, then stamps the (free/degraded) tier.
     from pocketpaw_ee.cloud.billing import site_plans
 
-    tier = site_plans.get_site_plan(site_plan_key) or site_plans.get_site_plan(
+    # ``site_scoped_tier`` so an ORG flat (studio/agency) resolves here exactly as
+    # an unknown key does — to the free floor. Left as a plain catalog lookup it
+    # would come back priced, take the charge-first branch, and log a misleading
+    # "paid tier has no configured Dodo product" on the way to being refused
+    # downstream by ``_apply_site_plan`` anyway. Refusing it once, here, keeps the
+    # dispatcher's two branches meaning what they say.
+    tier = site_plans.site_scoped_tier(site_plan_key) or site_plans.get_site_plan(
         site_plans.BASE_SITE_PLAN_KEY
     )
     is_paid = tier is not None and tier.monthly_price_usd > 0
@@ -5071,8 +5121,25 @@ async def _apply_site_plan(
     # carrying the target tier, not the absence of one. Only the None/unknown case
     # is treated as "leave it as it is".
     tier = site_plans.get_site_plan(site_plan_key)
+    # An ORG-SCOPED flat is not a tier a site can be put on. ``studio`` and
+    # ``agency`` are one subscription covering many sites; writing either into
+    # this site's ``plan_tier`` would hand this one site the allowance the org
+    # buys once for twenty-five. There is no org checkout yet, so the only way a
+    # request carries one is a client reading the full catalog and offering every
+    # row — which the storefront must not do, and which this refuses regardless.
+    # Dropped to None so it takes the same "keep what the site already has, else
+    # the floor" path as an unknown key.
+    if tier is not None and tier.is_org_scoped:
+        logger.warning(
+            "sites: publish for site %s asked for tier %s, which is an org-wide "
+            "flat and cannot be a single site's plan — falling back to the site's "
+            "own tier",
+            str(doc.id),
+            tier.key,
+        )
+        tier = None
     if tier is None:
-        existing_tier = site_plans.get_site_plan(getattr(doc, "plan_tier", None))
+        existing_tier = site_plans.site_scoped_tier(getattr(doc, "plan_tier", None))
         tier = existing_tier or site_plans.get_site_plan(site_plans.BASE_SITE_PLAN_KEY)
         if existing_tier is not None:
             logger.info(
@@ -5095,7 +5162,7 @@ async def _apply_site_plan(
     # already paying for something.
     if tier is not None and not tier.purchasable:
         unbuyable = tier.key
-        existing_tier = site_plans.get_site_plan(getattr(doc, "plan_tier", None))
+        existing_tier = site_plans.site_scoped_tier(getattr(doc, "plan_tier", None))
         tier = existing_tier or site_plans.get_site_plan(site_plans.BASE_SITE_PLAN_KEY)
         logger.warning(
             "sites: publish for site %s asked for tier %s, which has no configured "
@@ -5513,13 +5580,23 @@ async def activate_site(
     )
 
     # The deploy flipped ``deployed=True`` and cleared pending_deploy_inputs; advance
-    # the annual renewal date (one year out — the next charge cycle), mirroring the
-    # renewed path. ``subscription_status`` was already set above, BEFORE the deploy,
-    # so the paid capabilities were stamped correctly; re-asserted here because
-    # ``deployed`` is a separately-loaded doc and this save must not write back a
-    # stale value it read before that flip landed.
+    # the renewal date to the next charge cycle, mirroring the renewed path.
+    # ``subscription_status`` was already set above, BEFORE the deploy, so the paid
+    # capabilities were stamped correctly; re-asserted here because ``deployed`` is a
+    # separately-loaded doc and this save must not write back a stale value it read
+    # before that flip landed.
+    #
+    # ONE MONTH, not one year. This stamped +365 days until 2026-08-22 — a leftover
+    # from the annual ladder. ``billing.service`` was corrected when the prices moved
+    # monthly and this writer was missed, because it lives in the sites service
+    # rather than the billing package. A $7/month site was being told its next
+    # renewal was a year away.
+    #
+    # ``relativedelta`` rather than ``timedelta(days=30)``, same as
+    # ``billing.service``: fixed 30-day steps walk the date backwards through the
+    # calendar, losing five days over a year of renewals.
     deployed.subscription_status = "active"
-    deployed.renewal_date = datetime.now(UTC) + timedelta(days=365)
+    deployed.renewal_date = datetime.now(UTC) + relativedelta(months=1)
     await deployed.save()
 
     # Promote the pocket's draft to published — the durable "this was published"
@@ -5549,7 +5626,11 @@ async def activate_site(
                 "site_id": site_id,
                 "pocket_id": pocket_id,
                 "owner": doc.owner,
-                "plan_tier": deployed.plan_tier or "",
+                # Canonical, matching what ``_to_response`` puts on the wire for
+                # the same site — a subscriber that stores the event's tier and a
+                # client that reads the response must not end up with two
+                # different strings for one plan.
+                "plan_tier": _canonical_plan_tier(deployed.plan_tier),
             }
         )
     )

--- a/scripts/census_site_plans.py
+++ b/scripts/census_site_plans.py
@@ -53,8 +53,12 @@ from typing import Any
 # The tier keys as the catalog ships them today. Imported rather than hardcoded
 # where possible, but this script has to run on a host that may not have the ee
 # package installed, so it degrades to the literals with a note in the output.
-_FALLBACK_BASE_KEY = "basic"
-_FALLBACK_KNOWN_KEYS = ("basic", "pro", "business")
+# Both the current keys AND the pre-2026-08-22 ones. A census run on a host with
+# no ee package must not report every legacy row as "unknown tier" — that is the
+# exact number this script exists to measure, and getting it wrong in the
+# pessimistic direction would look like a migration emergency.
+_FALLBACK_BASE_KEY = "free"
+_FALLBACK_KNOWN_KEYS = ("free", "site", "staff", "studio", "agency", "basic", "pro", "business")
 
 # Statuses that mean money is actually moving. Mirrors
 # ``entitlements.service._ACTIVE_SITE_SUBSCRIPTION_STATUSES``; duplicated for the

--- a/scripts/migrate_site_plan_keys.py
+++ b/scripts/migrate_site_plan_keys.py
@@ -1,0 +1,246 @@
+"""Rewrite stored ``Site.plan_tier`` values from the pre-2026-08-22 tier names
+(basic / pro / business) to the pricing-spec ladder (free / site / staff).
+
+Created 2026-08-22 (feat/site-pricing-ladder). Companion to
+``scripts/census_site_plans.py``, which counts the same rows read-only — run the
+census first, run this, then run the census again to confirm zero legacy keys
+remain.
+
+THIS SCRIPT IS OPTIONAL AND ALWAYS HAS BEEN. ``site_plans`` resolves the legacy
+keys permanently through ``_LEGACY_SITE_TIER_ALIASES``, so a database that never
+sees this script keeps working: ``pro`` resolves to ``site``, ``business`` to
+``staff``, ``basic`` to ``free``, with identical capabilities. What the rewrite
+buys is that reads stop going through an alias, dashboards stop showing a key the
+catalog no longer lists, and the aliases become dead weight rather than
+load-bearing. It is a tidy-up, not a rescue — which is why it defaults to a DRY
+RUN and will not write anything until told to.
+
+WHY THE MAPPING IS WHAT IT IS. It maps by capability, not by ladder position:
+
+    basic    -> free    $0,  badged, one domained site
+    pro      -> site    was $5/mo, badge off + domains, no concierge
+    business -> staff   was $19/mo, adds the visitor concierge
+
+``pro`` did not sell the concierge and ``site`` does not either. ``business``
+did and ``staff`` does. A position-based mapping over the new five-rung ladder
+would have landed ``business`` on ``studio``, which is an ORG flat — a key that
+is not even legal in this field.
+
+WHAT IT REFUSES TO TOUCH. Any value that is not one of the three legacy keys:
+already-migrated rows, empty strings, nulls, and anything unrecognised. An
+unrecognised tier is left exactly as found and reported, because the safe move
+for a value nobody planned for is to leave it for a human — rewriting it to the
+floor would silently revoke a capability, and this script has no way to know
+whether that value came from a future schema or a typo.
+
+Usage — the URI comes from the environment, never from a command-line argument,
+so a production connection string does not land in shell history:
+
+    CLOUD_MONGODB_URI=... uv run python scripts/migrate_site_plan_keys.py
+    CLOUD_MONGODB_URI=... uv run python scripts/migrate_site_plan_keys.py --apply
+    CLOUD_MONGODB_URI=... uv run python scripts/migrate_site_plan_keys.py --apply --json
+
+Without ``--apply`` it connects, counts, prints exactly what it WOULD change, and
+exits 0 having written nothing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from typing import Any
+
+# The rewrite table. Imported from the catalog when the ee package is available
+# so the two can never disagree; the literals are the fallback for a deployment
+# host that has no Python environment for ee installed. The import is the
+# preferred path precisely because THIS table is the thing most likely to rot.
+_FALLBACK_ALIASES: dict[str, str] = {"basic": "free", "pro": "site", "business": "staff"}
+
+
+def _aliases() -> tuple[dict[str, str], str]:
+    """(alias table, provenance) — from the catalog if importable."""
+    try:
+        from pocketpaw_ee.cloud.billing import site_plans
+
+        table = {
+            old: new
+            for old, new in site_plans._LEGACY_SITE_TIER_ALIASES.items()  # noqa: SLF001
+        }
+        # Cross-check rather than trust: an alias pointing at a key the catalog
+        # does not list would rewrite live rows to a tier that resolves to None,
+        # which is the one outcome worse than leaving them alone.
+        known = {t.key for t in site_plans.list_site_plans()}
+        bad = {old: new for old, new in table.items() if new not in known}
+        if bad:
+            raise RuntimeError(f"alias table points at unknown tiers: {bad}")
+        return table, "imported from site_plans"
+    except Exception as exc:  # noqa: BLE001 - degrade to literals, but say why
+        return _FALLBACK_ALIASES, f"fallback literals ({type(exc).__name__})"
+
+
+def _db_label(uri: str) -> tuple[str, str]:
+    """(db_name, host_class) — never the URI itself, which carries credentials."""
+    tail = uri.rsplit("/", 1)[-1]
+    db_name = tail.split("?")[0] or "paw-enterprise"
+    lowered = uri.lower()
+    if "localhost" in lowered or "127.0.0.1" in lowered:
+        host_class = "local"
+    elif "mongodb+srv" in lowered:
+        host_class = "atlas/srv"
+    else:
+        host_class = "remote"
+    return db_name, host_class
+
+
+async def _run(db: Any, aliases: dict[str, str], *, apply: bool) -> dict[str, Any]:
+    """Count every distinct ``plan_tier``, then rewrite the legacy ones.
+
+    The count runs first and separately from the write so the report is the same
+    shape in dry-run and apply mode — the operator sees the identical breakdown
+    either way, and the only difference is whether ``matched``/``modified`` came
+    back from a real ``update_many``.
+    """
+    sites = db["sites"]
+
+    pipeline = [{"$group": {"_id": "$plan_tier", "count": {"$sum": 1}}}]
+    counts: dict[str, int] = {}
+    async for row in sites.aggregate(pipeline):
+        key = row["_id"]
+        counts["<null>" if key is None else str(key)] = int(row["count"])
+
+    legacy = {old: counts.get(old, 0) for old in sorted(aliases) if counts.get(old, 0)}
+    planned = [
+        {"from": old, "to": aliases[old], "documents": n} for old, n in sorted(legacy.items())
+    ]
+
+    # Anything that is neither a legacy key nor resolvable by the catalog. Reported
+    # and never touched — see the module docstring.
+    unrecognised = {
+        key: n
+        for key, n in sorted(counts.items())
+        if key not in aliases and key not in {"<null>", ""} and not _is_current(key)
+    }
+
+    results: list[dict[str, Any]] = []
+    if apply:
+        for old, new in sorted(aliases.items()):
+            if not legacy.get(old):
+                continue
+            # Filtered on the OLD value, so re-running is a no-op rather than a
+            # second rewrite: the second pass matches nothing.
+            res = await sites.update_many({"plan_tier": old}, {"$set": {"plan_tier": new}})
+            results.append(
+                {
+                    "from": old,
+                    "to": new,
+                    "matched": int(res.matched_count),
+                    "modified": int(res.modified_count),
+                }
+            )
+
+    return {
+        "applied": apply,
+        "total_sites": sum(counts.values()),
+        "tier_counts": counts,
+        "planned": planned,
+        "results": results,
+        "unrecognised": unrecognised,
+    }
+
+
+def _is_current(key: str) -> bool:
+    """Is ``key`` a tier the catalog lists under its current name?"""
+    try:
+        from pocketpaw_ee.cloud.billing import site_plans
+
+        return key in {t.key for t in site_plans.list_site_plans()}
+    except Exception:
+        return key in {"free", "site", "staff", "studio", "agency"}
+
+
+def _render(result: dict[str, Any], *, db_name: str, host_class: str, provenance: str) -> None:
+    mode = "APPLIED" if result["applied"] else "DRY RUN — nothing was written"
+    print(f"site plan-key migration — {mode}")
+    print(f"  database   : {db_name} ({host_class})")
+    print(f"  alias table: {provenance}")
+    print(f"  sites      : {result['total_sites']}")
+    print()
+
+    if not result["planned"]:
+        print("  no legacy tier keys found — nothing to migrate.")
+    else:
+        print("  legacy keys found:")
+        for row in result["planned"]:
+            print(f"    {row['from']:9} -> {row['to']:7} {row['documents']:>6} document(s)")
+
+    if result["results"]:
+        print()
+        print("  writes:")
+        for row in result["results"]:
+            print(
+                f"    {row['from']:9} -> {row['to']:7} "
+                f"matched {row['matched']}, modified {row['modified']}"
+            )
+
+    if result["unrecognised"]:
+        print()
+        print("  LEFT ALONE — tier values this script does not recognise.")
+        print("  Not rewritten on purpose: rewriting an unplanned value to the floor")
+        print("  would silently revoke whatever it was granting. Decide these by hand.")
+        for key, n in result["unrecognised"].items():
+            print(f"    {key!r}: {n} document(s)")
+
+    if not result["applied"] and result["planned"]:
+        print()
+        print("  re-run with --apply to write these changes.")
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="actually write. Without it this is a read-only dry run.",
+    )
+    parser.add_argument("--json", action="store_true", dest="as_json", help="machine-readable")
+    args = parser.parse_args()
+
+    uri = os.environ.get("CLOUD_MONGODB_URI", "").strip()
+    if not uri:
+        print(
+            "CLOUD_MONGODB_URI is not set.\n"
+            "Passed by env and not by argument on purpose: a production connection\n"
+            "string in a command line ends up in shell history.",
+            file=sys.stderr,
+        )
+        return 2
+
+    db_name, host_class = _db_label(uri)
+    aliases, provenance = _aliases()
+
+    from motor.motor_asyncio import AsyncIOMotorClient
+
+    client = AsyncIOMotorClient(uri, serverSelectionTimeoutMS=8000)
+    try:
+        result = await _run(client[db_name], aliases, apply=args.apply)
+    finally:
+        client.close()
+
+    if args.as_json:
+        print(
+            json.dumps(
+                {"database": db_name, "host": host_class, **result},
+                indent=2,
+                default=str,
+            )
+        )
+    else:
+        _render(result, db_name=db_name, host_class=host_class, provenance=provenance)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/src/pocketpaw/config.py
+++ b/src/pocketpaw/config.py
@@ -2348,8 +2348,13 @@ class Settings(BaseSettings):
             "checkout at all: with a product it goes charge-first (the site is "
             "created PENDING and deployed by the subscription.active webhook), "
             "without one it publishes live and records the tier with NO charge. "
-            "Set via POCKETPAW_DODO_SITE_PRODUCTS as a JSON object, e.g. "
-            '{"pro":"prod_site_pro","business":"prod_site_biz"}. Default empty '
+            "Set via POCKETPAW_DODO_SITE_PRODUCTS as a JSON object keyed by tier, "
+            'e.g. {"site":"pdt_...","staff":"pdt_..."}. Only the SITE-SCOPED rungs '
+            "belong here — the org flats (studio, agency) are bought through an "
+            "org subscription that does not exist yet, and site_plans refuses "
+            "them regardless of what this map says. The pre-2026-08-22 keys "
+            '("pro", "business") are still honoured, so an existing deployment '
+            "keeps charging while the env var is re-keyed. Default empty "
             "means no per-site tier is purchasable, which is what every "
             "deployment has been until now — this field was READ by "
             "site_plans._dodo_product_for from the day per-site plans shipped and "

--- a/tests/cloud/billing/test_site_plan_inclusions.py
+++ b/tests/cloud/billing/test_site_plan_inclusions.py
@@ -36,18 +36,36 @@ def test_base_tier_does_not_sell_the_concierge():
     assert base.sells_concierge is False
 
 
-def test_only_the_top_tier_sells_the_concierge():
-    """Was "every tier above the floor", which held only while nothing actually
-    sold the concierge. Under the $0/$5/$19 ladder (2026-08-22) the concierge is
-    the whole difference between the two paid rungs, so the middle one must not
-    have it — that derivation would have given the $5 tier a $19 feature."""
-    tiers = catalog.list_site_plans()
-    assert len(tiers) > 2, "needs at least two paid rungs to say anything"
+def test_only_the_top_per_site_rung_sells_the_concierge():
+    """The concierge is what separates the two PAID PER-SITE rungs, so the cheaper
+    one must not have it.
 
-    selling = [t.key for t in tiers if t.sells_concierge]
-    assert selling == [tiers[-1].key], (
-        f"expected only the top tier to sell the concierge, got {selling}"
+    Written against ``list_site_scoped_plans`` rather than the whole catalog, and
+    that is the point of the 2026-08-22 edit rather than a detail of it. The old
+    assertion was ``selling == [tiers[-1].key]`` — "only the last row in the
+    catalog" — which was a statement about POSITION that happened to coincide with
+    the rule while the catalog was one ladder. The five-tier catalog holds two
+    ladders: the per-site rungs (free/site/staff) and the org flats
+    (studio/agency), and ``agency`` legitimately sells the concierge too. Under the
+    old wording that reads as a violation, and "fixing" it by appending agency to
+    the expected list would have quietly permitted the actual regression this test
+    exists to catch — ``site`` gaining a ``staff`` feature.
+
+    So the rule is asserted where it lives: among the rungs a single site can be
+    put on, exactly one sells the concierge, and it is the most expensive one.
+    """
+    rungs = catalog.list_site_scoped_plans()
+    assert len(rungs) > 2, "needs at least two paid rungs to say anything"
+
+    selling = [t.key for t in rungs if t.sells_concierge]
+    assert selling == [rungs[-1].key], (
+        f"expected only the top per-site rung to sell the concierge, got {selling}"
     )
+    # And the rung below it must be a PAID one — otherwise "only the top rung"
+    # is satisfied by a two-rung ladder of free + one paid tier, where there is
+    # no cheaper paid rung to wrongly grant anything to.
+    assert rungs[-2].monthly_price_usd > 0
+    assert rungs[-2].sells_concierge is False
 
 
 def test_an_unknown_tier_sells_no_concierge():

--- a/tests/cloud/billing/test_site_pricing_ladder.py
+++ b/tests/cloud/billing/test_site_pricing_ladder.py
@@ -7,25 +7,39 @@
 # comparable product on the market prices monthly in single digits). Annual-only
 # billing was also a conversion problem in its own right.
 #
-# Decided 2026-08-22: $0 / $5 / $19, MONTHLY, per site.
+# Decided 2026-08-22, in two steps on the same day. First $0 / $5 / $19 monthly on
+# the placeholder keys, then the full pricing spec: FIVE tiers on the approved
+# ladder, rekeyed off basic/pro/business.
 #
-# Two things beyond the numbers change with it, and both are easy to miss:
+#   free    $0    per site (the floor)   badge on, 1 domained site
+#   site    $7    per site               badge off, custom domain
+#   staff   $19   per site               + the visitor concierge, 200 conv/mo
+#   studio  $39   per ORG, flat          white-label across 5 included sites
+#   agency  $149  per ORG, flat          25 sites, SSO + SLA, pooled credits
 #
-#   * The interval. A renewal webhook that stamps +365 days on a monthly plan puts
-#     the next renewal a year out on every single renewal, and the site keeps its
-#     paid capabilities for that whole year whatever happens to the card.
-#   * The concierge. It used to be sold by ANY tier above the floor, derived rather
-#     than mapped, because the tier that was meant to sell it did not exist yet.
-#     Under this ladder only the TOP tier does — that is the entire difference
-#     between the $5 and $19 rungs, so deriving it now hands the $5 tier a $19
-#     feature.
+# THREE THINGS THIS FILE EXISTS TO CATCH, none of them "is the number right":
 #
-# The tier KEYS deliberately do not change here. Renaming them (basic/pro/business
-# to free/site/staff) rewrites values stored in Site.plan_tier, and an orphaned key
-# resolves to None and drops a site to the floor. That is its own change, gated on
-# the census confirming what production actually holds.
+#   * THE REKEY DEMOTING PRODUCTION. ``Site.plan_tier`` holds basic/pro/business
+#     today. An unrecognised key resolves to None, which drops a site to the free
+#     floor: badge back, custom domain revoked. The legacy aliases are the only
+#     thing standing between the rename and that outcome, so they are asserted by
+#     CAPABILITY, not just by resolving to something non-None.
+#
+#   * THE REKEY SILENTLY DISABLING CHECKOUT. ``POCKETPAW_DODO_SITE_PRODUCTS`` is
+#     deployed keyed {"pro": ..., "business": ...}. A catalog that only looked up
+#     the new names would find nothing, every paid tier would go unpurchasable,
+#     and publishes would quietly record the free floor while taking no money.
+#
+#   * AN ORG FLAT REACHING A SITE. studio/agency are one subscription covering
+#     many sites. Their keys are not legal ``Site.plan_tier`` values, and a plain
+#     catalog lookup would happily resolve one — handing a single site the
+#     allowance an org buys once for twenty-five.
 #
 # Created 2026-08-22 (feat/site-pricing-monthly): new test module.
+# Updated 2026-08-22 (feat/site-pricing-ladder): rewritten for the five-tier spec
+#   ladder. The old file asserted the three placeholder keys and their $0/$5/$19
+#   prices; every one of those assertions is now expressed against the current
+#   names, plus the three properties above, which did not exist to break before.
 
 from __future__ import annotations
 
@@ -45,9 +59,9 @@ def _by_key() -> dict[str, SitePlanTier]:
 
 @pytest.mark.parametrize(
     ("key", "price"),
-    [("basic", 0), ("pro", 5), ("business", 19)],
+    [("free", 0), ("site", 7), ("staff", 19), ("studio", 39), ("agency", 149)],
 )
-def test_the_ladder_is_zero_five_nineteen(key, price):
+def test_the_ladder_matches_the_pricing_spec(key, price):
     tier = site_plans.get_site_plan(key)
     assert tier is not None, f"{key} left the catalog"
     assert tier.monthly_price_usd == price
@@ -55,9 +69,9 @@ def test_the_ladder_is_zero_five_nineteen(key, price):
 
 def test_the_price_is_monthly_and_nothing_still_calls_it_annual():
     """The rename is the point, not cosmetics. A field named ``annual_price_usd``
-    holding 5 would read as $5/year to every future caller, and $5/year is below
+    holding 7 would read as $7/year to every future caller, and $7/year is below
     the Cloudflare floor for a single custom hostname."""
-    tier = site_plans.get_site_plan("pro")
+    tier = site_plans.get_site_plan("site")
 
     assert hasattr(tier, "monthly_price_usd")
     assert not hasattr(tier, "annual_price_usd")
@@ -76,29 +90,257 @@ def test_the_ladder_only_goes_up():
     assert len(set(prices)) == len(prices), "two tiers at the same price"
 
 
+def test_every_tier_carries_the_copy_a_card_needs():
+    """The card copy moved server-side in this change, so an unnamed tier renders
+    as a bare key. Asserted for EVERY row rather than spot-checked: the failure
+    mode is a tier added later with no display entry, which spot-checks miss."""
+    for tier in site_plans.list_site_plans():
+        assert tier.display_name, f"{tier.key} has no display name"
+        assert tier.tagline, f"{tier.key} has no tagline"
+
+
 # ---------------------------------------------------------------------------
-# The concierge is the difference between the two paid rungs
+# The two scopes — the org flats must never become a site's own plan
 # ---------------------------------------------------------------------------
 
 
-def test_only_the_top_tier_sells_the_concierge():
-    """It used to be derived as "any tier above the floor", which was correct only
-    while the tier meant to sell it did not exist. Deriving it now would hand the
-    $5 rung the feature the $19 rung is for."""
+def test_the_catalog_holds_both_scopes_and_says_which_is_which():
     by_key = _by_key()
 
-    assert by_key["basic"].sells_concierge is False
-    assert by_key["pro"].sells_concierge is False, (
-        "the $5 tier is selling the concierge, which is what the $19 tier is for"
+    assert [t.key for t in site_plans.list_site_scoped_plans()] == ["free", "site", "staff"]
+    assert [t.key for t in site_plans.list_site_plans() if t.is_org_scoped] == [
+        "studio",
+        "agency",
+    ]
+    assert by_key["staff"].is_org_scoped is False
+    assert by_key["studio"].is_org_scoped is True
+
+
+@pytest.mark.parametrize("key", ["studio", "agency"])
+def test_an_org_flat_is_refused_as_a_sites_own_tier(key):
+    """The security property of the whole two-scope change.
+
+    ``get_site_plan`` resolves it — it is a real catalog row and the storefront
+    renders it. ``site_scoped_tier`` must NOT, because every entitlement seam
+    reads a site's stored ``plan_tier`` through that function, and an org key
+    resolving there hands one site the white-label allowance an org pays for
+    across its whole estate.
+
+    Breaks on: ``site_scoped_tier`` losing its ``is_org_scoped`` check, or any
+    entitlement seam being switched back to ``get_site_plan``.
+    """
+    assert site_plans.get_site_plan(key) is not None
+    assert site_plans.site_scoped_tier(key) is None
+
+
+@pytest.mark.parametrize("key", ["studio", "agency"])
+def test_an_org_flat_is_never_purchasable_however_config_is_set(key, monkeypatch):
+    """Not "has no product configured" — NEVER, whatever config says.
+
+    There is exactly one checkout and it buys one site. Pointing it at a $149
+    org flat would charge the org price and grant a single site's capability.
+    So the refusal cannot be left to "nobody configured a product for it": a
+    well-meaning operator filling in every key of POCKETPAW_DODO_SITE_PRODUCTS
+    would otherwise switch on a checkout that overcharges.
+
+    Breaks on: ``purchasable`` dropping its ``is_org_scoped`` early return.
+    """
+    monkeypatch.setattr(site_plans, "_dodo_product_for", lambda _k: "pdt_configured")
+
+    assert site_plans.get_site_plan(key).purchasable is False
+    # ...while a per-site rung with the same product IS purchasable, so the test
+    # is measuring the scope and not a blanket "nothing is purchasable".
+    assert site_plans.get_site_plan("site").purchasable is True
+
+
+def test_a_tier_the_catalog_does_not_know_is_built_org_scoped():
+    """The fail-closed default, tested where it lives.
+
+    ``_build`` is called directly here and that is not laziness — it is the only
+    way to reach the default at all. The public lookups resolve a canonical key
+    first and return None for anything else, so ``_SITE_PLAN_SCOPE.get(key,
+    ORG_SCOPE)`` never sees an unknown key today. Its whole job is to be correct
+    for the caller that eventually does, and a mutation flipping the default to
+    ``SITE_SCOPE`` escaped every other test in this file.
+
+    ORG is the safe default precisely because it is the scope that is NOT a legal
+    ``Site.plan_tier``: an unknown key fails closed OUT of the per-site path
+    rather than into it, and ``site_scoped_tier`` then refuses it.
+
+    Breaks on: changing that default to ``SITE_SCOPE``.
+    """
+    unknown = site_plans._build("tier-that-does-not-exist")
+
+    assert unknown.is_org_scoped is True
+    assert unknown.monthly_price_usd == 0
+    assert unknown.badge_removal is False
+    assert unknown.max_domained_sites == 0
+    assert unknown.purchasable is False
+
+
+def test_only_the_org_flats_include_a_site_count():
+    """``included_sites`` answers "how many sites does this flat cover", which is
+    not a question a per-site subscription has an answer to. A number there would
+    read as a per-site quota."""
+    by_key = _by_key()
+
+    assert by_key["studio"].included_sites == 5
+    assert by_key["agency"].included_sites == 25
+    for key in ("free", "site", "staff"):
+        assert by_key[key].included_sites is None, f"{key} should not include a site count"
+
+
+# ---------------------------------------------------------------------------
+# The rekey — legacy keys must keep resolving, by capability
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("legacy", "current"),
+    [("basic", "free"), ("pro", "site"), ("business", "staff")],
+)
+def test_a_legacy_key_resolves_to_the_tier_with_the_same_capabilities(legacy, current):
+    """Not merely "resolves to something" — to the tier that sells what the old one
+    sold.
+
+    ``pro`` sold badge removal and uncapped domains and NO concierge; ``site``
+    does exactly that. ``business`` added the concierge; ``staff`` does. Mapping
+    by ladder POSITION over the five-rung catalog instead would have put
+    ``business`` on ``studio``, which is an org flat and not even a legal value
+    for the field these keys are stored in.
+
+    Breaks on: deleting an alias (the tier resolves to None and every already-
+    published site on it drops to the free floor), or repointing one at the wrong
+    rung.
+    """
+    resolved = site_plans.get_site_plan(legacy)
+    expected = site_plans.get_site_plan(current)
+
+    assert resolved is not None, f"{legacy} no longer resolves — production sites hold this key"
+    assert resolved.key == current, "the resolved row must report its CURRENT name"
+    assert resolved.badge_removal == expected.badge_removal
+    assert resolved.sells_concierge == expected.sells_concierge
+    assert resolved.max_domained_sites == expected.max_domained_sites
+    assert resolved.monthly_price_usd == expected.monthly_price_usd
+
+
+def test_a_legacy_key_is_still_a_site_scoped_tier():
+    """The aliases have to survive the guarded read too, not just the plain one —
+    ``site_scoped_tier`` is what every entitlement seam calls, so an alias that
+    resolved only through ``get_site_plan`` would still demote every live site."""
+    for legacy in ("basic", "pro", "business"):
+        assert site_plans.site_scoped_tier(legacy) is not None
+
+
+def test_an_unknown_key_still_resolves_to_nothing():
+    """The aliases must not turn the lookup into "always find something"."""
+    assert site_plans.get_site_plan("nonesuch") is None
+    assert site_plans.get_site_plan("") is None
+    assert site_plans.get_site_plan(None) is None
+    assert site_plans.canonical_site_tier_key("nonesuch") is None
+
+
+# ---------------------------------------------------------------------------
+# The rekey must not break the DEPLOYED Dodo product map
+# ---------------------------------------------------------------------------
+
+
+def test_the_deployed_legacy_product_map_still_opens_a_checkout(monkeypatch):
+    """The trap that would have shipped silently.
+
+    The live environment sets POCKETPAW_DODO_SITE_PRODUCTS keyed by the OLD tier
+    names. Renaming the catalog without teaching ``_dodo_product_for`` about the
+    aliases means every paid tier comes back ``purchasable = False`` the moment
+    the rename deploys — no checkout opens, and ``publish_pocket`` falls back to
+    publishing live and recording the free floor. Nothing errors. The customer
+    picks a paid plan, is charged nothing, and gets nothing.
+
+    Breaks on: ``_dodo_product_for`` looking up only the canonical key.
+    """
+
+    class _Settings:
+        dodo_site_products = {"pro": "pdt_old_site", "business": "pdt_old_staff"}
+
+    import pocketpaw.config as config_mod
+
+    monkeypatch.setattr(config_mod, "get_settings", lambda: _Settings())
+
+    assert site_plans.get_site_plan("site").dodo_product_id == "pdt_old_site"
+    assert site_plans.get_site_plan("staff").dodo_product_id == "pdt_old_staff"
+    assert site_plans.get_site_plan("site").purchasable is True
+
+
+def test_the_new_key_wins_over_a_legacy_one_for_the_same_tier(monkeypatch):
+    """A half-migrated environment holding both must not be ambiguous — the
+    canonical key is the answer, so re-keying the env var takes effect
+    immediately rather than being shadowed by the value it replaces."""
+
+    class _Settings:
+        dodo_site_products = {"site": "pdt_new", "pro": "pdt_old"}
+
+    import pocketpaw.config as config_mod
+
+    monkeypatch.setattr(config_mod, "get_settings", lambda: _Settings())
+
+    assert site_plans.get_site_plan("site").dodo_product_id == "pdt_new"
+
+
+# ---------------------------------------------------------------------------
+# The concierge is the difference between the two paid PER-SITE rungs
+# ---------------------------------------------------------------------------
+
+
+def test_only_the_top_per_site_rung_sells_the_concierge():
+    """It used to be derived as "any tier above the floor", which was correct only
+    while the tier meant to sell it did not exist. Deriving it now would hand the
+    $7 rung the feature the $19 rung is for.
+
+    Scoped to the per-site rungs deliberately: ``agency`` also sells the
+    concierge, legitimately, and a whole-catalog assertion would have to list it
+    — at which point the assertion stops saying anything about ``site``.
+    """
+    by_key = _by_key()
+
+    assert by_key["free"].sells_concierge is False
+    assert by_key["site"].sells_concierge is False, (
+        "the $7 tier is selling the concierge, which is what the $19 tier is for"
     )
-    assert by_key["business"].sells_concierge is True
+    assert by_key["staff"].sells_concierge is True
+
+
+def test_the_conversation_allowance_belongs_to_the_tier_that_sells_the_concierge():
+    by_key = _by_key()
+
+    assert by_key["staff"].conversation_allowance == 200
+    assert by_key["site"].conversation_allowance == 0
+    assert by_key["free"].conversation_allowance == 0
+
+
+def test_the_agency_rate_is_the_discount_it_is_sold_on():
+    """$0.05 against a $0.10 list rate is half the headline reason to buy agency.
+    In CENTS — a float rate multiplied by a conversation count is a rounding bug
+    waiting for a big enough customer."""
+    by_key = _by_key()
+
+    assert by_key["agency"].conversation_rate_cents == 5
+    assert by_key["staff"].conversation_rate_cents == 10
+    assert isinstance(by_key["agency"].conversation_rate_cents, int)
+
+
+def test_a_tier_that_sells_no_concierge_still_carries_the_list_rate():
+    """0 would render as "free conversations" on a card. The truth is that the
+    tier gets none at all, which ``conversation_allowance == 0`` already says."""
+    by_key = _by_key()
+
+    for key in ("free", "site"):
+        assert by_key[key].conversation_rate_cents > 0
 
 
 def test_the_paid_rungs_are_actually_different_products():
-    """If the two paid tiers sold exactly the same things, the ladder would be a
-    price increase with no reason attached to it."""
+    """If the two paid per-site tiers sold exactly the same things, the ladder
+    would be a price increase with no reason attached to it."""
     by_key = _by_key()
-    mid, top = by_key["pro"], by_key["business"]
+    mid, top = by_key["site"], by_key["staff"]
 
     assert (mid.sells_concierge, mid.badge_removal) != (top.sells_concierge, top.badge_removal) or (
         mid.cloudflare_features != top.cloudflare_features
@@ -106,19 +348,42 @@ def test_the_paid_rungs_are_actually_different_products():
 
 
 def test_both_paid_rungs_still_drop_the_badge_and_take_a_domain():
-    """The $5 rung's whole pitch. Losing either while repricing would be a silent
+    """The $7 rung's whole pitch. Losing either while repricing would be a silent
     downgrade for anyone who buys it."""
     by_key = _by_key()
 
-    for key in ("pro", "business"):
+    for key in ("site", "staff"):
         assert by_key[key].badge_removal is True
         assert by_key[key].max_domained_sites is None, f"{key} should be uncapped"
 
 
 def test_the_free_floor_keeps_its_one_domained_site():
-    """Free includes a custom domain on ONE site. Repricing must not quietly take
-    the acquisition hook away."""
-    assert site_plans.get_site_plan("basic").max_domained_sites == 1
+    """Free includes a custom domain on ONE site. This is the one place the
+    catalog knowingly departs from the written pricing spec, which says
+    subdomain-only — the captain's call, and the acquisition hook. Repricing must
+    not quietly take it away."""
+    assert site_plans.get_site_plan("free").max_domained_sites == 1
+
+
+def test_white_label_is_what_separates_an_org_flat_from_five_site_subscriptions():
+    by_key = _by_key()
+
+    assert by_key["studio"].white_label is True
+    assert by_key["agency"].white_label is True
+    for key in ("free", "site", "staff"):
+        assert by_key[key].white_label is False
+
+
+def test_highlights_are_kept_out_of_the_enforced_feature_set():
+    """SSO and an SLA are commitments a human honours, not flags code checks.
+    Folded into ``cloudflare_features`` they would render as an enforced
+    inclusion beside the WAF, which nothing would be enforcing."""
+    agency = _by_key()["agency"]
+
+    assert agency.highlights, "agency's selling points vanished"
+    for claim in agency.highlights:
+        assert claim.lower() not in {f.lower() for f in agency.cloudflare_features}
+    assert "sso" not in {f.lower() for f in agency.cloudflare_features}
 
 
 # ---------------------------------------------------------------------------
@@ -132,14 +397,14 @@ def test_a_zero_price_tier_is_always_purchasable(monkeypatch):
     unconfigured and every publish falls back to nothing."""
     monkeypatch.setattr(site_plans, "_dodo_product_for", lambda key: None)
 
-    assert site_plans.get_site_plan("basic").purchasable is True
-    assert site_plans.get_site_plan("pro").purchasable is False
+    assert site_plans.get_site_plan("free").purchasable is True
+    assert site_plans.get_site_plan("site").purchasable is False
 
 
 def test_a_priced_tier_is_purchasable_once_it_has_a_product(monkeypatch):
     monkeypatch.setattr(
-        site_plans, "_dodo_product_for", lambda key: "prod_x" if key == "pro" else None
+        site_plans, "_dodo_product_for", lambda key: "prod_x" if key == "site" else None
     )
 
-    assert site_plans.get_site_plan("pro").purchasable is True
-    assert site_plans.get_site_plan("business").purchasable is False
+    assert site_plans.get_site_plan("site").purchasable is True
+    assert site_plans.get_site_plan("staff").purchasable is False

--- a/tests/cloud/entitlements/test_site_entitlements.py
+++ b/tests/cloud/entitlements/test_site_entitlements.py
@@ -39,7 +39,7 @@ def _resolve(**ov):
     kw = {
         "site_id": _SITE,
         "workspace_id": _WS,
-        "plan_tier": "pro",
+        "plan_tier": "site",
         "subscription_status": "active",
         "concierge_enabled": True,
     }
@@ -53,16 +53,16 @@ def _resolve(**ov):
 
 
 def test_an_active_paid_site_drops_the_badge_and_gets_its_domain():
-    ent = _resolve(plan_tier="pro", subscription_status="active")
+    ent = _resolve(plan_tier="site", subscription_status="active")
 
     assert ent.subscription_active is True
     assert ent.badge_required is False
     assert ent.custom_domain is True
-    assert ent.plan_tier == "pro"
+    assert ent.plan_tier == "site"
 
 
-def test_business_is_paid_too():
-    ent = _resolve(plan_tier="business", subscription_status="active")
+def test_staff_is_paid_too():
+    ent = _resolve(plan_tier="staff", subscription_status="active")
 
     assert ent.badge_required is False
     assert ent.custom_domain is True
@@ -71,7 +71,7 @@ def test_business_is_paid_too():
 def test_what_a_paying_site_actually_buys_is_an_UNCAPPED_allowance():
     """Free includes a custom domain, so the paid tiers no longer sell the
     capability — they sell the absence of a ceiling on it. None means uncapped."""
-    assert _resolve(plan_tier="pro", subscription_status="active").max_domained_sites is None
+    assert _resolve(plan_tier="site", subscription_status="active").max_domained_sites is None
 
 
 # --------------------------------------------------------------------------- #
@@ -81,10 +81,10 @@ def test_what_a_paying_site_actually_buys_is_an_UNCAPPED_allowance():
 
 @pytest.mark.parametrize("status", ["cancelled", "none", "pending", "", None, "garbage"])
 def test_a_paid_tier_without_an_active_subscription_is_badged(status):
-    """The whole reason this resolver exists. ``plan_tier`` stays "pro" through
+    """The whole reason this resolver exists. ``plan_tier`` stays on the paid key through
     cancellation — nothing resets it — so gating on the tier alone means a
     cancelled site never sees a badge again."""
-    ent = _resolve(plan_tier="pro", subscription_status=status)
+    ent = _resolve(plan_tier="site", subscription_status=status)
 
     assert ent.subscription_active is False
     assert ent.badge_required is True
@@ -101,7 +101,7 @@ def test_a_lapsed_paid_site_falls_to_the_FLOOR_allowance_not_to_zero(status):
     """
     floor = site_plan_catalog.get_site_plan(site_plan_catalog.BASE_SITE_PLAN_KEY)
 
-    ent = _resolve(plan_tier="pro", subscription_status=status)
+    ent = _resolve(plan_tier="site", subscription_status=status)
 
     assert ent.max_domained_sites == floor.max_domained_sites
     assert ent.custom_domain is True
@@ -111,7 +111,7 @@ def test_a_tier_recorded_but_never_charged_is_badged():
     """Today's live case, not a hypothetical: no Dodo product is configured, so a
     paid publish records the intended tier and takes no money —
     ``subscription_status`` stays "none"."""
-    ent = _resolve(plan_tier="business", subscription_status="none")
+    ent = _resolve(plan_tier="staff", subscription_status="none")
 
     assert ent.badge_required is True
 
@@ -119,9 +119,9 @@ def test_a_tier_recorded_but_never_charged_is_badged():
 def test_the_tier_is_still_reported_when_it_is_not_being_paid_for():
     """Report what the row says, gate on whether it is paid. Blanking the tier
     would lose the information a reconcile/dunning view needs."""
-    ent = _resolve(plan_tier="pro", subscription_status="cancelled")
+    ent = _resolve(plan_tier="site", subscription_status="cancelled")
 
-    assert ent.plan_tier == "pro"
+    assert ent.plan_tier == "site"
     assert ent.subscription_active is False
 
 
@@ -131,7 +131,7 @@ def test_the_tier_is_still_reported_when_it_is_not_being_paid_for():
 
 
 def test_the_base_tier_is_badged_even_when_active():
-    ent = _resolve(plan_tier="basic", subscription_status="active")
+    ent = _resolve(plan_tier="free", subscription_status="active")
 
     assert ent.badge_required is True
 
@@ -171,11 +171,20 @@ def test_a_free_site_still_carries_its_badge_and_still_has_no_concierge():
     assert ent.concierge_entitled is False
 
 
-@pytest.mark.parametrize("tier", [None, "", "stduio", "site", "staff"])
+@pytest.mark.parametrize("tier", [None, "", "stduio", "stafff", "enterprise"])
 def test_an_unknown_or_absent_tier_falls_to_the_base(tier):
-    """Includes the plan ids the pricing spec proposes but the catalog does not
-    carry yet — until they are added, they must resolve to badged, not to a
-    silent upgrade."""
+    """Typos and tiers from other ladders resolve to badged, never to a silent
+    upgrade.
+
+    The parameters used to include ``site`` and ``staff``, which were then the
+    pricing spec's PROPOSED names and not in the catalog. They are real tiers now,
+    so keeping them here would have asserted that the two tiers this change adds
+    grant nothing — a test passing for the exact reason the feature was broken.
+    They are replaced with near-misses (``stafff``) and a key from the WORKSPACE
+    plan ladder (``enterprise``), which is the realistic way a wrong string
+    arrives: the two catalogs are different and a caller can reach for the wrong
+    one.
+    """
     ent = _resolve(plan_tier=tier, subscription_status="active")
 
     assert ent.plan_tier == site_plan_catalog.BASE_SITE_PLAN_KEY
@@ -183,6 +192,65 @@ def test_an_unknown_or_absent_tier_falls_to_the_base(tier):
     # Fail-closed on the ALLOWANCE too: an unknown tier gets the floor's, never the
     # uncapped one. "active" here is a red herring — there is no tier to activate.
     assert ent.max_domained_sites == 1
+
+
+@pytest.mark.parametrize("org_key", ["studio", "agency"])
+def test_an_org_flat_stored_on_a_site_grants_that_site_nothing(org_key):
+    """The security property of the two-scope catalog, at the resolver.
+
+    ``studio`` and ``agency`` are real, resolvable catalog rows that sell
+    white-label and badge removal across a whole workspace. They are NOT legal
+    ``Site.plan_tier`` values, and this is what happens when one shows up there
+    anyway — a hand-edited document, a replayed webhook, a restored backup: the
+    site is treated as having no plan of its own and lands on the free floor.
+
+    Note the ``active`` status. That is deliberate: the tier grants badge removal
+    and the subscription says paid, so every gate this resolver has would open if
+    the key were accepted. The ONLY thing refusing is the scope check.
+
+    Breaks on: ``resolve_site_entitlements`` reading ``get_site_plan`` instead of
+    ``site_scoped_tier``.
+    """
+    assert site_plan_catalog.get_site_plan(org_key) is not None, "the row must still exist"
+    assert site_plan_catalog.get_site_plan(org_key).badge_removal is True, (
+        "if the org tier stopped selling badge removal this test would pass for the wrong reason"
+    )
+
+    ent = _resolve(plan_tier=org_key, subscription_status="active")
+
+    assert ent.plan_tier == site_plan_catalog.BASE_SITE_PLAN_KEY
+    assert ent.badge_required is True
+    assert ent.concierge_entitled is False
+    assert ent.max_domained_sites == 1
+
+
+# --------------------------------------------------------------------------- #
+# The rekey — documents written before 2026-08-22 hold the old keys
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("legacy", "current"), [("basic", "free"), ("pro", "site"), ("business", "staff")]
+)
+def test_a_site_stored_on_a_legacy_key_keeps_everything_it_had(legacy, current):
+    """Every published site in production holds one of these strings.
+
+    An unrecognised key resolves to None here and lands on the free floor, which
+    means the rename alone — with no alias — would have returned the badge to
+    every paying customer's site and revoked its custom domain, at deploy time,
+    silently. The resolver has to answer identically for the old key and the new
+    one.
+
+    Breaks on: removing an entry from ``_LEGACY_SITE_TIER_ALIASES``.
+    """
+    old = _resolve(plan_tier=legacy, subscription_status="active")
+    new = _resolve(plan_tier=current, subscription_status="active")
+
+    assert old.plan_tier == current, "the answer must report the tier's CURRENT name"
+    assert old.badge_required == new.badge_required
+    assert old.custom_domain == new.custom_domain
+    assert old.max_domained_sites == new.max_domained_sites
+    assert old.concierge_entitled == new.concierge_entitled
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/cloud/sites/test_billing_lifecycle.py
+++ b/tests/cloud/sites/test_billing_lifecycle.py
@@ -126,10 +126,10 @@ async def _make_pocket(*, workspace_id: str, owner: str = "u1", ripple_spec=None
     return str(doc.id)
 
 
-def _enable_pro_product(monkeypatch) -> None:
+def _enable_paid_site_product(monkeypatch) -> None:
     """Make the 'pro' site tier a chargeable PAID tier (price + a Dodo product)."""
     monkeypatch.setattr(
-        site_plans, "_dodo_product_for", lambda key: {"pro": "prod_site_pro"}.get(key)
+        site_plans, "_dodo_product_for", lambda key: {"site": "prod_site_pro"}.get(key)
     )
 
 
@@ -139,7 +139,7 @@ def _enable_pro_product(monkeypatch) -> None:
 
 
 async def test_oversized_deploy_inputs_raise_and_persist_nothing(mongo_db, monkeypatch):
-    _enable_pro_product(monkeypatch)
+    _enable_paid_site_product(monkeypatch)
     # A rippleSpec that serializes well past the 4MB cap.
     big_blob = "x" * (sites_service._MAX_PENDING_DEPLOY_INPUT_BYTES + 1)
     ripple_spec = {"bloat": big_blob}
@@ -153,7 +153,7 @@ async def test_oversized_deploy_inputs_raise_and_persist_nothing(mongo_db, monke
             workspace_id=ws,
             user_id="u1",
             pocket_id=pocket_id,
-            site_plan_key="pro",
+            site_plan_key="site",
             _generator=_RecordingGenerator(),
             _cloudflare=_RecordingCF(),
             _bundle_reader=lambda d: b"x",
@@ -174,7 +174,7 @@ async def test_oversized_deploy_inputs_raise_and_persist_nothing(mongo_db, monke
 
 
 async def test_pending_publish_persists_doc_with_subscription_id(mongo_db, monkeypatch):
-    _enable_pro_product(monkeypatch)
+    _enable_paid_site_product(monkeypatch)
     ws = await _make_workspace(plan="pro")
     pocket_id = await _make_pocket(workspace_id=ws)
 
@@ -183,7 +183,7 @@ async def test_pending_publish_persists_doc_with_subscription_id(mongo_db, monke
         workspace_id=ws,
         user_id="u1",
         pocket_id=pocket_id,
-        site_plan_key="pro",
+        site_plan_key="site",
         _generator=_RecordingGenerator(),
         _cloudflare=_RecordingCF(),
         _bundle_reader=lambda d: b"x",
@@ -203,7 +203,7 @@ async def test_pending_publish_persists_doc_with_subscription_id(mongo_db, monke
 
 
 async def test_checkout_failure_leaves_no_orphan_doc(mongo_db, monkeypatch):
-    _enable_pro_product(monkeypatch)
+    _enable_paid_site_product(monkeypatch)
     ws = await _make_workspace(plan="pro")
     pocket_id = await _make_pocket(workspace_id=ws)
 
@@ -213,7 +213,7 @@ async def test_checkout_failure_leaves_no_orphan_doc(mongo_db, monkeypatch):
             workspace_id=ws,
             user_id="u1",
             pocket_id=pocket_id,
-            site_plan_key="pro",
+            site_plan_key="site",
             _generator=_RecordingGenerator(),
             _cloudflare=_RecordingCF(),
             _bundle_reader=lambda d: b"x",
@@ -266,7 +266,7 @@ async def _insert_site(
         name=pocket_id,
         deployed=deployed,
         subscription_status=subscription_status,
-        plan_tier="pro",
+        plan_tier="site",
     )
     await doc.insert()
     # Backdate createdAt so the staleness threshold can be exercised.

--- a/tests/cloud/sites/test_billing_state_on_the_wire.py
+++ b/tests/cloud/sites/test_billing_state_on_the_wire.py
@@ -119,7 +119,7 @@ async def test_the_site_response_carries_the_plan_the_ui_renders(mongo_db):
 
     resp = sites_service._to_response(doc)
 
-    assert resp.plan_tier == "pro"
+    assert resp.plan_tier == "site"
     assert resp.subscription_status == "active"
     assert resp.renewal_date is not None
     assert resp.renewal_date.startswith("2027-01-15")
@@ -167,7 +167,7 @@ async def test_entitlements_say_whether_this_site_may_take_a_domain(mongo_db, mo
 
     assert ent.custom_domain is True
     assert ent.subscription_active is True
-    assert ent.plan_tier == "pro"
+    assert ent.plan_tier == "site"
 
 
 async def test_a_free_site_reports_its_floor_allowance_not_a_flat_no(mongo_db, monkeypatch):
@@ -178,7 +178,7 @@ async def test_a_free_site_reports_its_floor_allowance_not_a_flat_no(mongo_db, m
     ws = await _make_workspace()
     pocket_id = await _make_pocket(workspace_id=ws)
     doc = await _seed_site(
-        workspace_id=ws, pocket_id=pocket_id, plan_tier="basic", subscription_status="none"
+        workspace_id=ws, pocket_id=pocket_id, plan_tier="free", subscription_status="none"
     )
 
     ent = await sites_service.site_entitlements(workspace_id=ws, site_id=str(doc.id))
@@ -202,12 +202,12 @@ async def test_the_free_allowance_reads_as_spent_once_another_site_holds_a_domai
     await _seed_site(
         workspace_id=ws,
         pocket_id=other_pocket,
-        plan_tier="basic",
+        plan_tier="free",
         subscription_status="none",
         domains=["already.example.com"],
     )
     doc = await _seed_site(
-        workspace_id=ws, pocket_id=this_pocket, plan_tier="basic", subscription_status="none"
+        workspace_id=ws, pocket_id=this_pocket, plan_tier="free", subscription_status="none"
     )
 
     ent = await sites_service.site_entitlements(workspace_id=ws, site_id=str(doc.id))
@@ -230,12 +230,12 @@ async def test_a_paid_site_is_not_capped_by_the_free_allowance(mongo_db, monkeyp
     await _seed_site(
         workspace_id=ws,
         pocket_id=other_pocket,
-        plan_tier="basic",
+        plan_tier="free",
         subscription_status="none",
         domains=["already.example.com"],
     )
     doc = await _seed_site(
-        workspace_id=ws, pocket_id=this_pocket, plan_tier="pro", subscription_status="active"
+        workspace_id=ws, pocket_id=this_pocket, plan_tier="site", subscription_status="active"
     )
 
     ent = await sites_service.site_entitlements(workspace_id=ws, site_id=str(doc.id))
@@ -251,14 +251,14 @@ async def test_a_lapsed_paid_site_loses_the_capability_and_says_so(mongo_db, mon
     ws = await _make_workspace()
     pocket_id = await _make_pocket(workspace_id=ws)
     doc = await _seed_site(
-        workspace_id=ws, pocket_id=pocket_id, plan_tier="pro", subscription_status="cancelled"
+        workspace_id=ws, pocket_id=pocket_id, plan_tier="site", subscription_status="cancelled"
     )
 
     ent = await sites_service.site_entitlements(workspace_id=ws, site_id=str(doc.id))
 
     assert ent.subscription_active is False
     assert ent.concierge_entitled is False
-    assert ent.plan_tier == "pro", "the tier is still recorded; only the payment stopped"
+    assert ent.plan_tier == "site", "the tier is still recorded; only the payment stopped"
 
 
 async def test_another_workspace_cannot_read_this_site_s_entitlements(mongo_db, monkeypatch):
@@ -301,7 +301,7 @@ async def test_no_capability_means_no_slot_however_empty_the_workspace(mongo_db,
     ws = await _make_workspace()
     pocket_id = await _make_pocket(workspace_id=ws)
     doc = await _seed_site(
-        workspace_id=ws, pocket_id=pocket_id, plan_tier="basic", subscription_status="none"
+        workspace_id=ws, pocket_id=pocket_id, plan_tier="free", subscription_status="none"
     )
 
     monkeypatch.setattr(
@@ -310,7 +310,7 @@ async def test_no_capability_means_no_slot_however_empty_the_workspace(mongo_db,
         lambda **kw: SiteEntitlements(
             site_id=kw["site_id"],
             workspace_id=kw["workspace_id"],
-            plan_tier="basic",
+            plan_tier="free",
             subscription_active=False,
             badge_required=True,
             custom_domain=False,

--- a/tests/cloud/sites/test_charge_first.py
+++ b/tests/cloud/sites/test_charge_first.py
@@ -158,7 +158,7 @@ def _site_subscription_body(*, event_type: str, workspace_id: str, site_id: str)
                 "metadata": {
                     "workspace_id": workspace_id,
                     "site_id": site_id,
-                    "plan_key": "pro",
+                    "plan_key": "site",
                 },
             },
         }
@@ -176,7 +176,7 @@ async def test_paid_publish_is_pending_and_returns_checkout_url(
     # Configure a Dodo product for the "pro" site tier so it is a chargeable PAID
     # tier (positive price + a product) → charge-first defers the deploy.
     monkeypatch.setattr(
-        site_plans, "_dodo_product_for", lambda key: {"pro": "prod_site_pro"}.get(key)
+        site_plans, "_dodo_product_for", lambda key: {"site": "prod_site_pro"}.get(key)
     )
     ws = await _make_workspace(plan="pro")
     pocket_id = await _make_pocket(workspace_id=ws)
@@ -189,7 +189,7 @@ async def test_paid_publish_is_pending_and_returns_checkout_url(
         workspace_id=ws,
         user_id="u1",
         pocket_id=pocket_id,
-        site_plan_key="pro",
+        site_plan_key="site",
         _generator=gen,
         _cloudflare=cf,
         _bundle_reader=lambda d: b"x",
@@ -199,7 +199,7 @@ async def test_paid_publish_is_pending_and_returns_checkout_url(
     # The site is PENDING — created but NOT deployed live.
     assert doc.deployed is False
     assert doc.subscription_status == "pending"
-    assert doc.plan_tier == "pro"
+    assert doc.plan_tier == "site"
     assert doc.subscription_id == SITE_SUB_ID
 
     # The deploy was DEFERRED — neither the generator nor Cloudflare ran.
@@ -238,7 +238,7 @@ async def test_paid_publish_is_pending_and_returns_checkout_url(
 async def test_active_webhook_deploys_pending_site(mongo_db, recording_bus, monkeypatch):
     # PAID tier → pending publish (deploy deferred).
     monkeypatch.setattr(
-        site_plans, "_dodo_product_for", lambda key: {"pro": "prod_site_pro"}.get(key)
+        site_plans, "_dodo_product_for", lambda key: {"site": "prod_site_pro"}.get(key)
     )
     # Force local deploy mode + fake the generator/local-server so the webhook-driven
     # activation (which can't take injected seams) needs no Bun/workerd/Cloudflare.
@@ -261,7 +261,7 @@ async def test_active_webhook_deploys_pending_site(mongo_db, recording_bus, monk
         workspace_id=ws,
         user_id="u1",
         pocket_id=pocket_id,
-        site_plan_key="pro",
+        site_plan_key="site",
         _generator=_RecordingGenerator(),  # publish path generator (must NOT run)
         _billing_provider=_RecordingBillingProvider(),
     )
@@ -302,7 +302,7 @@ async def test_active_webhook_deploys_pending_site(mongo_db, recording_bus, monk
 async def test_active_webhook_is_idempotent(mongo_db, monkeypatch):
     """A replayed subscription.active does not re-deploy an already-active site."""
     monkeypatch.setattr(
-        site_plans, "_dodo_product_for", lambda key: {"pro": "prod_site_pro"}.get(key)
+        site_plans, "_dodo_product_for", lambda key: {"site": "prod_site_pro"}.get(key)
     )
     monkeypatch.setenv("PAW_SITES_LOCAL", "1")
     activation_gen = _RecordingGenerator()
@@ -319,7 +319,7 @@ async def test_active_webhook_is_idempotent(mongo_db, monkeypatch):
         workspace_id=ws,
         user_id="u1",
         pocket_id=pocket_id,
-        site_plan_key="pro",
+        site_plan_key="site",
         _generator=_RecordingGenerator(),
         _billing_provider=_RecordingBillingProvider(),
     )
@@ -347,7 +347,7 @@ async def test_activate_site_invokes_cloudflare(mongo_db, monkeypatch):
     """Direct activate_site with an injected CF client proves the Cloudflare deploy
     branch runs at activation (the CF-injected path the webhook can't reach)."""
     monkeypatch.setattr(
-        site_plans, "_dodo_product_for", lambda key: {"pro": "prod_site_pro"}.get(key)
+        site_plans, "_dodo_product_for", lambda key: {"site": "prod_site_pro"}.get(key)
     )
     ws = await _make_workspace(plan="pro")
     pocket_id = await _make_pocket(workspace_id=ws)
@@ -355,7 +355,7 @@ async def test_activate_site_invokes_cloudflare(mongo_db, monkeypatch):
         workspace_id=ws,
         user_id="u1",
         pocket_id=pocket_id,
-        site_plan_key="pro",
+        site_plan_key="site",
         _generator=_RecordingGenerator(),
         _cloudflare=_RecordingCF(),
         _bundle_reader=lambda d: b"x",
@@ -378,6 +378,68 @@ async def test_activate_site_invokes_cloudflare(mongo_db, monkeypatch):
     assert gen.build_calls and cf.put_calls == [site_id]
     assert activated.deployed is True
     assert activated.subscription_status == "active"
+
+
+async def test_activation_stamps_a_MONTHLY_renewal_not_an_annual_one(mongo_db, monkeypatch):
+    """The site plans bill monthly. This path stamped +365 days.
+
+    ``billing.service`` was corrected to ``relativedelta(months=1)`` when the
+    ladder moved to a monthly interval on 2026-08-22, and this second writer was
+    missed — it lives in ``sites.service.activate_site``, not in the billing
+    module, so a grep of the billing package does not find it.
+
+    What it costs is not a wrong date on a card. ``renewal_date`` is the stamp the
+    renewal webhook advances and the UI reads to say when the next charge lands;
+    a site activated through charge-first got a renewal a YEAR out on a $7/month
+    subscription. Every monthly renewal after it would then look overdue by
+    eleven months, and any future job that gates on the stamp would keep the paid
+    capabilities alive for the whole year regardless of the card.
+
+    ``relativedelta`` rather than ``timedelta(days=30)`` for the same reason
+    ``billing.service`` uses it: 30-day steps walk the renewal backwards through
+    the calendar, losing five days a year.
+
+    Breaks on: restoring ``timedelta(days=365)`` — or ``days=30``, which the
+    two-day tolerance below is deliberately tight enough to catch on a
+    month-boundary activation.
+    """
+    from dateutil.relativedelta import relativedelta
+
+    monkeypatch.setattr(
+        site_plans, "_dodo_product_for", lambda key: {"site": "prod_site_paid"}.get(key)
+    )
+    ws = await _make_workspace(plan="pro")
+    pocket_id = await _make_pocket(workspace_id=ws)
+    doc = await sites_service.publish_pocket(
+        workspace_id=ws,
+        user_id="u1",
+        pocket_id=pocket_id,
+        site_plan_key="site",
+        _generator=_RecordingGenerator(),
+        _cloudflare=_RecordingCF(),
+        _bundle_reader=lambda d: b"x",
+        _billing_provider=_RecordingBillingProvider(),
+    )
+
+    before = datetime.now(UTC)
+    activated = await sites_service.activate_site(
+        workspace_id=ws,
+        site_id=str(doc.id),
+        _generator=_RecordingGenerator(),
+        _cloudflare=_RecordingCF(),
+        _bundle_reader=lambda d: b"x",
+    )
+
+    assert activated.renewal_date is not None
+    stamped = activated.renewal_date
+    if stamped.tzinfo is None:
+        stamped = stamped.replace(tzinfo=UTC)
+
+    expected = before + relativedelta(months=1)
+    assert abs((stamped - expected).total_seconds()) < 2 * 86400, (
+        f"expected a renewal about one month out ({expected.isoformat()}), "
+        f"got {stamped.isoformat()}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -428,8 +490,8 @@ async def test_paid_tier_without_dodo_product_publishes_live(mongo_db):
     a checkout, so charge-first degrades to an immediate live publish — the user is
     never stranded with a pending, never-deployable site."""
     # No _dodo_product_for monkeypatch → pro has a price but NO configured product.
-    assert site_plans.get_site_plan("pro").monthly_price_usd > 0
-    assert site_plans.get_site_plan("pro").dodo_product_id is None
+    assert site_plans.get_site_plan("site").monthly_price_usd > 0
+    assert site_plans.get_site_plan("site").dodo_product_id is None
 
     ws = await _make_workspace(plan="pro")
     pocket_id = await _make_pocket(workspace_id=ws)
@@ -441,7 +503,7 @@ async def test_paid_tier_without_dodo_product_publishes_live(mongo_db):
         workspace_id=ws,
         user_id="u1",
         pocket_id=pocket_id,
-        site_plan_key="pro",
+        site_plan_key="site",
         _generator=gen,
         _cloudflare=cf,
         _bundle_reader=lambda d: b"x",
@@ -453,7 +515,7 @@ async def test_paid_tier_without_dodo_product_publishes_live(mongo_db):
     assert cf.put_calls == [str(doc.id)]
     # Records the FLOOR, not "pro" (#1995). A priced tier with no Dodo product
     # cannot be bought, and stamping it anyway wrote a claim the site could not
-    # back: plan_tier="pro" with subscription_status="none", which every
+    # back: plan_tier="site" with subscription_status="none", which every
     # entitlement resolves as free. The buyer picked a paid plan, was charged
     # nothing, received nothing, and the plan card said pro.
     assert doc.plan_tier == site_plans.BASE_SITE_PLAN_KEY
@@ -487,7 +549,7 @@ async def test_the_subscription_reads_active_before_the_activation_deploy_runs(
     is to look at the doc AT DEPLOY TIME, which is what the stampers do.
     """
     monkeypatch.setattr(
-        site_plans, "_dodo_product_for", lambda key: {"pro": "prod_site_pro"}.get(key)
+        site_plans, "_dodo_product_for", lambda key: {"site": "prod_site_pro"}.get(key)
     )
     ws = await _make_workspace(plan="pro")
     pocket_id = await _make_pocket(workspace_id=ws)
@@ -495,7 +557,7 @@ async def test_the_subscription_reads_active_before_the_activation_deploy_runs(
         workspace_id=ws,
         user_id="u1",
         pocket_id=pocket_id,
-        site_plan_key="pro",
+        site_plan_key="site",
         _generator=_RecordingGenerator(),
         _cloudflare=_RecordingCF(),
         _bundle_reader=lambda d: b"x",

--- a/tests/cloud/sites/test_cloudflare_tiers.py
+++ b/tests/cloud/sites/test_cloudflare_tiers.py
@@ -82,7 +82,7 @@ async def test_add_domain_passes_business_tier_features(mongo_db):
     """A business-tier site (resells WAF + edge_cache) → create_custom_hostname
     is called WITH that feature set."""
     ws = "ws_business"
-    site_id = await _seed_site(workspace_id=ws, plan_tier="business")
+    site_id = await _seed_site(workspace_id=ws, plan_tier="staff")
     cf = _RecordingCF()
 
     await sites_service.add_domain(
@@ -94,7 +94,7 @@ async def test_add_domain_passes_business_tier_features(mongo_db):
 
     assert len(cf.create_calls) == 1
     passed = cf.create_calls[0]["features"]
-    expected = site_plans.get_site_plan("business").cloudflare_features
+    expected = site_plans.get_site_plan("staff").cloudflare_features
     assert passed == set(expected)
     # The premium security features ride along.
     assert "waf" in passed
@@ -110,7 +110,7 @@ async def test_add_domain_basic_tier_passes_no_features(mongo_db):
     """A basic-tier site resells no Cloudflare features → create_custom_hostname is
     called with an EMPTY feature set (the basic path)."""
     ws = "ws_basic"
-    site_id = await _seed_site(workspace_id=ws, plan_tier="basic")
+    site_id = await _seed_site(workspace_id=ws, plan_tier="free")
     cf = _RecordingCF()
 
     await sites_service.add_domain(
@@ -140,12 +140,43 @@ async def test_add_domain_unset_tier_passes_no_features(mongo_db):
     assert cf.create_calls[0]["features"] == set()
 
 
+@pytest.mark.parametrize("org_key", ["studio", "agency"])
+async def test_add_domain_provisions_nothing_for_an_org_flat_stored_on_a_site(mongo_db, org_key):
+    """An ORG key on a site's ``plan_tier`` provisions no Cloudflare features.
+
+    ``studio`` and ``agency`` are real catalog rows and they DO resell the full
+    Cloudflare set — that is the point of the test. A plain ``get_site_plan``
+    here resolves one and provisions the WAF and edge-cache controls an org buys
+    across its whole estate onto a single site nobody billed for them, and
+    Cloudflare charges us for it. ``site_scoped_tier`` returns None, which is the
+    same answer an absent tier gets: nothing premium.
+
+    Breaks on: ``add_domain`` going back to ``site_plans.get_site_plan``.
+    """
+    assert site_plans.get_site_plan(org_key).cloudflare_features, (
+        "if the org tiers stopped reselling anything this test would pass for the wrong reason"
+    )
+
+    ws = f"ws_{org_key}"
+    site_id = await _seed_site(workspace_id=ws, plan_tier=org_key)
+    cf = _RecordingCF()
+
+    await sites_service.add_domain(
+        workspace_id=ws,
+        site_id=site_id,
+        hostname=f"www.{org_key}.com",
+        _cloudflare=cf,
+    )
+
+    assert cf.create_calls[0]["features"] == set()
+
+
 # ---------------------------------------------------------------------------
 # Criterion 3 — the tier → feature mapping is honored exactly, end to end.
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("tier", ["basic", "pro", "business"])
+@pytest.mark.parametrize("tier", ["free", "site", "staff"])
 async def test_add_domain_honors_exact_tier_feature_mapping(mongo_db, tier):
     """For every tier the features add_domain passes equal that tier's catalog
     cloudflare_features — no more, no less."""
@@ -260,16 +291,23 @@ def test_get_billing_site_plans_returns_catalog_with_cf_features(site_plans_clie
     assert resp.status_code == 200
     body = resp.json()
     rows = {row["key"]: row for row in body["site_plans"]}
-    assert set(rows.keys()) == {"basic", "pro", "business"}
+    # The whole catalog, both scopes — the storefront renders the org flats beside
+    # the per-site rungs, so this endpoint must not filter them out.
+    assert set(rows.keys()) == {"free", "site", "staff", "studio", "agency"}
+    # ...and each row says WHICH it is, because an org flat's key is not a legal
+    # ``site_plan_key`` on a publish and the client needs to know that from the
+    # payload rather than from a hardcoded list of two names.
+    assert rows["site"]["scope"] == "site"
+    assert rows["studio"]["scope"] == "org"
 
-    # Each tier carries its annual price + sorted cloudflare_features.
-    assert rows["basic"]["monthly_price_usd"] == 0
-    assert rows["basic"]["cloudflare_features"] == []
-    assert "custom_domain" in rows["pro"]["cloudflare_features"]
-    biz_features = rows["business"]["cloudflare_features"]
+    # Each tier carries its monthly price + sorted cloudflare_features.
+    assert rows["free"]["monthly_price_usd"] == 0
+    assert rows["free"]["cloudflare_features"] == []
+    assert "custom_domain" in rows["site"]["cloudflare_features"]
+    biz_features = rows["staff"]["cloudflare_features"]
     assert "waf" in biz_features
     assert "edge_cache" in biz_features
     # Features arrive as a SORTED JSON array (deterministic wire payload).
     assert biz_features == sorted(biz_features)
     # The catalog matches the source-of-truth site_plans exactly.
-    assert set(biz_features) == set(site_plans.get_site_plan("business").cloudflare_features)
+    assert set(biz_features) == set(site_plans.get_site_plan("staff").cloudflare_features)

--- a/tests/cloud/sites/test_keeps_client_bundle_publish.py
+++ b/tests/cloud/sites/test_keeps_client_bundle_publish.py
@@ -156,7 +156,7 @@ def _site_subscription_body(*, workspace_id: str, site_id: str) -> str:
                 "metadata": {
                     "workspace_id": workspace_id,
                     "site_id": site_id,
-                    "plan_key": "pro",
+                    "plan_key": "site",
                 },
             },
         }
@@ -166,7 +166,7 @@ def _site_subscription_body(*, workspace_id: str, site_id: str) -> str:
 def _paid_tier(monkeypatch) -> None:
     """Make the "pro" site tier chargeable so publish defers the deploy."""
     monkeypatch.setattr(
-        site_plans, "_dodo_product_for", lambda key: {"pro": "prod_site_pro"}.get(key)
+        site_plans, "_dodo_product_for", lambda key: {"site": "prod_site_pro"}.get(key)
     )
 
 
@@ -358,7 +358,7 @@ async def test_paid_publish_captures_the_flag_in_the_deploy_snapshot(mongo_db, m
         workspace_id=ws,
         user_id="u1",
         pocket_id=pocket_id,
-        site_plan_key="pro",
+        site_plan_key="site",
         _generator=gen,
         _cloudflare=_RecordingCF(),
         _bundle_reader=lambda d: b"x",
@@ -401,7 +401,7 @@ async def test_deferred_paid_publish_preserves_the_flag(mongo_db, recording_bus,
         workspace_id=ws,
         user_id="u1",
         pocket_id=pocket_id,
-        site_plan_key="pro",
+        site_plan_key="site",
         _generator=_RecordingGenerator(),  # publish-path generator: must NOT run
         _billing_provider=_RecordingBillingProvider(),
     )
@@ -446,7 +446,7 @@ async def test_activation_of_a_pre_mt1_pending_site_defaults_to_false(mongo_db, 
         workspace_id=ws,
         user_id="u1",
         pocket_id=pocket_id,
-        site_plan_key="pro",
+        site_plan_key="site",
         _generator=_RecordingGenerator(),
         _billing_provider=_RecordingBillingProvider(),
     )

--- a/tests/cloud/sites/test_republish_double_billing.py
+++ b/tests/cloud/sites/test_republish_double_billing.py
@@ -183,7 +183,7 @@ def _site_subscription_body(*, event_type: str, workspace_id: str, site_id: str)
                 "metadata": {
                     "workspace_id": workspace_id,
                     "site_id": site_id,
-                    "plan_key": "pro",
+                    "plan_key": "site",
                 },
             },
         }
@@ -250,7 +250,7 @@ async def test_activation_persists_the_real_gateway_subscription_id(
     Nothing can cancel or change a subscription it cannot name. Every other fix in
     this module depends on this one line of plumbing.
     """
-    _configure_products(monkeypatch, {"pro": "prod_site_pro"})
+    _configure_products(monkeypatch, {"site": "prod_site_pro"})
     ws = await _make_workspace()
     pocket_id = await _make_pocket(workspace_id=ws)
     provider = _RecordingBillingProvider()
@@ -273,7 +273,7 @@ async def test_republishing_a_paying_site_opens_no_second_subscription(
     mongo_db, recording_bus, monkeypatch
 ):
     """A content edit on a site that is already paying is not a purchase."""
-    _configure_products(monkeypatch, {"pro": "prod_site_pro"})
+    _configure_products(monkeypatch, {"site": "prod_site_pro"})
     ws = await _make_workspace()
     pocket_id = await _make_pocket(workspace_id=ws)
     provider = _RecordingBillingProvider()
@@ -286,7 +286,7 @@ async def test_republishing_a_paying_site_opens_no_second_subscription(
         workspace_id=ws,
         user_id="u1",
         pocket_id=pocket_id,
-        site_plan_key="pro",
+        site_plan_key="site",
         _generator=gen,
         _cloudflare=cf,
         _bundle_reader=lambda d: b"x",
@@ -304,7 +304,7 @@ async def test_republishing_a_paying_site_keeps_its_paid_status_and_goes_live(
 ):
     """The republish must not strip the capabilities the customer is paying for,
     and the new content must go live without a second payment."""
-    _configure_products(monkeypatch, {"pro": "prod_site_pro"})
+    _configure_products(monkeypatch, {"site": "prod_site_pro"})
     ws = await _make_workspace()
     pocket_id = await _make_pocket(workspace_id=ws)
     provider = _RecordingBillingProvider()
@@ -316,7 +316,7 @@ async def test_republishing_a_paying_site_keeps_its_paid_status_and_goes_live(
         workspace_id=ws,
         user_id="u1",
         pocket_id=pocket_id,
-        site_plan_key="pro",
+        site_plan_key="site",
         _generator=gen,
         _cloudflare=cf,
         _bundle_reader=lambda d: b"x",
@@ -327,7 +327,7 @@ async def test_republishing_a_paying_site_keeps_its_paid_status_and_goes_live(
     # entitlement resolves as unpaid while the customer is still being charged.
     assert doc.subscription_status == "active"
     assert doc.subscription_id == GATEWAY_SUB_ID
-    assert doc.plan_tier == "pro"
+    assert doc.plan_tier == "site"
 
     # And the edit actually shipped, rather than waiting on a payment that will
     # never come.
@@ -349,7 +349,7 @@ async def test_republishing_a_site_that_never_paid_still_opens_a_checkout(
 
     Opening a fresh checkout is correct here. The abandoned session simply expires.
     """
-    _configure_products(monkeypatch, {"pro": "prod_site_pro"})
+    _configure_products(monkeypatch, {"site": "prod_site_pro"})
     ws = await _make_workspace()
     pocket_id = await _make_pocket(workspace_id=ws)
     provider = _RecordingBillingProvider()
@@ -359,7 +359,7 @@ async def test_republishing_a_site_that_never_paid_still_opens_a_checkout(
             workspace_id=ws,
             user_id="u1",
             pocket_id=pocket_id,
-            site_plan_key="pro",
+            site_plan_key="site",
             _generator=_RecordingGenerator(),
             _cloudflare=_RecordingCF(),
             _bundle_reader=lambda d: b"x",
@@ -393,7 +393,7 @@ async def test_moving_a_paying_site_to_another_tier_changes_the_plan(
     term they already paid for; a second create bills them twice. The gateway's
     atomic plan change is the only option that does neither.
     """
-    _configure_products(monkeypatch, {"pro": "prod_site_pro", "business": "prod_site_business"})
+    _configure_products(monkeypatch, {"site": "prod_site_pro", "staff": "prod_site_staff"})
     ws = await _make_workspace()
     pocket_id = await _make_pocket(workspace_id=ws)
     provider = _RecordingBillingProvider()
@@ -405,7 +405,7 @@ async def test_moving_a_paying_site_to_another_tier_changes_the_plan(
         workspace_id=ws,
         user_id="u1",
         pocket_id=pocket_id,
-        site_plan_key="business",
+        site_plan_key="staff",
         _generator=gen,
         _cloudflare=cf,
         _bundle_reader=lambda d: b"x",
@@ -418,11 +418,11 @@ async def test_moving_a_paying_site_to_another_tier_changes_the_plan(
     assert call["subscription_id"] == GATEWAY_SUB_ID, (
         "change_plan was handed the checkout session id, not the gateway subscription"
     )
-    assert call["product_id"] == "prod_site_business"
+    assert call["product_id"] == "prod_site_staff"
 
     # The webhook acks plan_changed without acting, so the new tier has to be
     # written synchronously here or nothing ever records it.
-    assert doc.plan_tier == "business"
+    assert doc.plan_tier == "staff"
     assert doc.subscription_status == "active"
 
 
@@ -431,7 +431,7 @@ async def test_a_failed_plan_change_leaves_the_subscription_alone(
 ):
     """When the gateway refuses the change, the site keeps the tier it is paying
     for — and we never 'recover' by opening a second subscription."""
-    _configure_products(monkeypatch, {"pro": "prod_site_pro", "business": "prod_site_business"})
+    _configure_products(monkeypatch, {"site": "prod_site_pro", "staff": "prod_site_staff"})
     ws = await _make_workspace()
     pocket_id = await _make_pocket(workspace_id=ws)
 
@@ -445,7 +445,7 @@ async def test_a_failed_plan_change_leaves_the_subscription_alone(
             workspace_id=ws,
             user_id="u1",
             pocket_id=pocket_id,
-            site_plan_key="business",
+            site_plan_key="staff",
             _generator=gen,
             _cloudflare=cf,
             _bundle_reader=lambda d: b"x",
@@ -457,7 +457,7 @@ async def test_a_failed_plan_change_leaves_the_subscription_alone(
         "double-billing this fix exists to remove"
     )
     persisted = await Site.find_one(Site.id != None)  # noqa: E711
-    assert persisted.plan_tier == "pro"
+    assert persisted.plan_tier == "site"
     assert persisted.subscription_id == GATEWAY_SUB_ID
     assert persisted.subscription_status == "active"
 
@@ -472,7 +472,7 @@ async def test_the_site_checkout_sends_the_buyer_back_to_the_app(
 ):
     """The frontend navigates the whole page to the checkout url. Without a
     return url the buyer pays and is left on the gateway with no way back."""
-    _configure_products(monkeypatch, {"pro": "prod_site_pro"})
+    _configure_products(monkeypatch, {"site": "prod_site_pro"})
     ws = await _make_workspace()
     pocket_id = await _make_pocket(workspace_id=ws)
     provider = _RecordingBillingProvider()
@@ -482,7 +482,7 @@ async def test_the_site_checkout_sends_the_buyer_back_to_the_app(
         workspace_id=ws,
         user_id="u1",
         pocket_id=pocket_id,
-        site_plan_key="pro",
+        site_plan_key="site",
         origin="https://app.example.com",
         _generator=gen,
         _cloudflare=cf,

--- a/tests/cloud/sites/test_site_billing.py
+++ b/tests/cloud/sites/test_site_billing.py
@@ -174,21 +174,26 @@ def _site_subscription_body(
 def test_list_site_plans_returns_tiers_with_price_and_cf_features():
     tiers = site_plans.list_site_plans()
     keys = [t.key for t in tiers]
-    assert keys == ["basic", "pro", "business"]  # cheapest first
+    # Cheapest first, per-site rungs before the org flats.
+    assert keys == ["free", "site", "staff", "studio", "agency"]
+    # The per-site view is the subset a publish may choose from — the org flats
+    # cover a whole workspace and their keys are not legal ``Site.plan_tier``
+    # values.
+    assert [t.key for t in site_plans.list_site_scoped_plans()] == ["free", "site", "staff"]
 
     by_key = {t.key: t for t in tiers}
-    # Each tier carries an annual price (USD) + a cloudflare_features set.
-    assert by_key["basic"].monthly_price_usd == 0
-    assert by_key["pro"].monthly_price_usd > 0
-    assert isinstance(by_key["pro"].cloudflare_features, frozenset)
+    # Each tier carries a monthly price (USD) + a cloudflare_features set.
+    assert by_key["free"].monthly_price_usd == 0
+    assert by_key["site"].monthly_price_usd > 0
+    assert isinstance(by_key["site"].cloudflare_features, frozenset)
     # Higher tiers resell more Cloudflare features (a growing ladder).
-    assert by_key["basic"].cloudflare_features == frozenset()
-    assert "custom_domain" in by_key["pro"].cloudflare_features
-    assert by_key["pro"].cloudflare_features <= by_key["business"].cloudflare_features
+    assert by_key["free"].cloudflare_features == frozenset()
+    assert "custom_domain" in by_key["site"].cloudflare_features
+    assert by_key["site"].cloudflare_features <= by_key["staff"].cloudflare_features
 
 
 def test_get_site_plan_resolves_and_rejects():
-    assert site_plans.get_site_plan("pro").key == "pro"
+    assert site_plans.get_site_plan("site").key == "site"
     # An unknown / missing key resolves to None (not silently substituted).
     assert site_plans.get_site_plan("platinum") is None
     assert site_plans.get_site_plan(None) is None
@@ -207,7 +212,7 @@ async def test_publish_with_entitlement_stamps_plan_and_emits(mongo_db, recordin
 
     # Configure a Dodo product for the "pro" site tier so the per-site sub fires.
     monkeypatch.setattr(
-        site_plans, "_dodo_product_for", lambda key: {"pro": "prod_site_pro"}.get(key)
+        site_plans, "_dodo_product_for", lambda key: {"site": "prod_site_pro"}.get(key)
     )
     fake_provider = _FakeBillingProvider()
     fake_cf = _FakeCF()
@@ -216,7 +221,7 @@ async def test_publish_with_entitlement_stamps_plan_and_emits(mongo_db, recordin
         workspace_id=ws,
         user_id="u1",
         pocket_id=pocket_id,
-        site_plan_key="pro",
+        site_plan_key="site",
         _generator=_FakeGenerator(),
         _cloudflare=fake_cf,
         _bundle_reader=lambda d: b"x",
@@ -225,7 +230,7 @@ async def test_publish_with_entitlement_stamps_plan_and_emits(mongo_db, recordin
 
     # charge-first: a PAID tier (pro) is published as PENDING — stamped with its
     # tier + subscription id, but NOT deployed live until subscription.active.
-    assert doc.plan_tier == "pro"
+    assert doc.plan_tier == "site"
     assert doc.subscription_id == SITE_SUB_ID
     assert doc.subscription_status == "pending"
     assert doc.deployed is False
@@ -236,7 +241,7 @@ async def test_publish_with_entitlement_stamps_plan_and_emits(mongo_db, recordin
     # discriminator the renewal webhook routes on).
     assert len(fake_provider.calls) == 1
     call = fake_provider.calls[0]
-    assert call["plan_key"] == "pro"
+    assert call["plan_key"] == "site"
     assert call["product_id"] == "prod_site_pro"
     assert call["metadata"]["site_id"] == str(doc.id)
     assert call["metadata"]["workspace_id"] == ws
@@ -244,7 +249,7 @@ async def test_publish_with_entitlement_stamps_plan_and_emits(mongo_db, recordin
     # The persisted doc reflects the pending stamp.
     persisted = await Site.find_one(Site.id == doc.id)
     assert persisted is not None
-    assert persisted.plan_tier == "pro"
+    assert persisted.plan_tier == "site"
     assert persisted.deployed is False
 
     # charge-first: SitePublished is DEFERRED to activation (the site is not live
@@ -263,7 +268,7 @@ async def test_publish_degrades_gracefully_when_dodo_unconfigured(mongo_db, reco
         workspace_id=ws,
         user_id="u1",
         pocket_id=pocket_id,
-        site_plan_key="pro",
+        site_plan_key="site",
         _generator=_FakeGenerator(),
         _cloudflare=_FakeCF(),
         _bundle_reader=lambda d: b"x",
@@ -312,7 +317,7 @@ async def test_publish_without_entitlement_is_forbidden_and_creates_no_site(mong
             workspace_id=ws,
             user_id="u1",
             pocket_id=pocket_id,
-            site_plan_key="pro",
+            site_plan_key="site",
             _generator=_FakeGenerator(),
             _cloudflare=_FakeCF(),
             _bundle_reader=lambda d: b"x",
@@ -345,13 +350,13 @@ async def test_per_site_active_webhook_updates_site_not_workspace(mongo_db, monk
     ws = await _make_workspace(plan="pro")
     pocket_id = await _make_pocket(workspace_id=ws)
     monkeypatch.setattr(
-        site_plans, "_dodo_product_for", lambda key: {"pro": "prod_site_pro"}.get(key)
+        site_plans, "_dodo_product_for", lambda key: {"site": "prod_site_pro"}.get(key)
     )
     doc = await sites_service.publish_pocket(
         workspace_id=ws,
         user_id="u1",
         pocket_id=pocket_id,
-        site_plan_key="pro",
+        site_plan_key="site",
         _generator=_FakeGenerator(),
         _billing_provider=_FakeBillingProvider(),
     )
@@ -396,13 +401,13 @@ async def test_per_site_cancelled_webhook_marks_site_cancelled(mongo_db, monkeyp
     ws = await _make_workspace(plan="pro")
     pocket_id = await _make_pocket(workspace_id=ws)
     monkeypatch.setattr(
-        site_plans, "_dodo_product_for", lambda key: {"pro": "prod_site_pro"}.get(key)
+        site_plans, "_dodo_product_for", lambda key: {"site": "prod_site_pro"}.get(key)
     )
     doc = await sites_service.publish_pocket(
         workspace_id=ws,
         user_id="u1",
         pocket_id=pocket_id,
-        site_plan_key="pro",
+        site_plan_key="site",
         _generator=_FakeGenerator(),
         _cloudflare=_FakeCF(),
         _bundle_reader=lambda d: b"x",
@@ -440,7 +445,10 @@ async def test_workspace_plan_sub_still_routes_to_workspace_path(mongo_db):
             "data": {
                 "subscription_id": "sub_ws_plan",
                 "product_id": "prod_pro_recurring",
-                # NO site_id → workspace-plan path.
+                # NO site_id → workspace-plan path. ``plan_key`` here is a
+                # WORKSPACE tier (billing.plans: free/go/pro/pro_max/enterprise),
+                # not a site tier — the two catalogs share a field name on the
+                # webhook metadata and nothing else.
                 "metadata": {"workspace_id": ws, "plan_key": "pro"},
             },
         }

--- a/tests/cloud/sites/test_site_plan_rekey.py
+++ b/tests/cloud/sites/test_site_plan_rekey.py
@@ -1,0 +1,291 @@
+# tests/cloud/sites/test_site_plan_rekey.py — the 2026-08-22 tier rename, driven
+# through the real publish path rather than asserted against the catalog alone.
+#
+# WHY A SEPARATE FILE FROM test_site_pricing_ladder.py. That one is a unit test of
+# the catalog: given a key, what does the row say. This one is about what happens
+# to a SITE — and the two failure modes it covers are both invisible to a catalog
+# test, because both need a document and a publish:
+#
+#   1. A site published before the rename holds ``plan_tier="pro"``. Everything
+#      that reads it must still resolve it, and everything that reports it must
+#      report the CURRENT name — otherwise the entitlements endpoint says "site",
+#      the site response says "pro", and the plan card matches neither.
+#
+#   2. An ORG flat (studio/agency) must never become a site's own tier. It is a
+#      real, resolvable catalog row that sells badge removal and white-label
+#      across a whole workspace; stamped on one site it would hand that site the
+#      lot. The publish path has to refuse it, and refusing has to be visible in
+#      what gets persisted, not only in a log line.
+#
+# Created 2026-08-22 (feat/site-pricing-ladder): new test module.
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+import pytest
+from pocketpaw_ee.cloud.billing import site_plans
+from pocketpaw_ee.cloud.models.site import Site
+from pocketpaw_ee.sites import service as sites_service
+
+
+class _RecordingGenerator:
+    def __init__(self):
+        self.build_calls: list[dict] = []
+
+    async def build(self, **kw):
+        from pocketpaw_ee.sites.generator_client import BuildResult
+
+        self.build_calls.append(dict(kw))
+        return BuildResult(project_dir="/tmp/site", ripple_version="0.2.0")
+
+
+class _RecordingCF:
+    def __init__(self):
+        self.put_calls: list[str] = []
+
+    async def put_worker(self, *, script_name, bundle, bindings=None):
+        self.put_calls.append(script_name)
+        return True
+
+
+async def _make_workspace(plan: str = "pro") -> str:
+    from pocketpaw_ee.cloud.models.workspace import Workspace
+
+    ws = Workspace(
+        name="Acme", slug=f"acme-rekey-{datetime.now(UTC).timestamp()}", owner="u1", plan=plan
+    )
+    await ws.insert()
+    return str(ws.id)
+
+
+async def _make_pocket(*, workspace_id: str) -> str:
+    from pocketpaw_ee.cloud.models.pocket import Pocket as _PocketDoc
+
+    doc = _PocketDoc(
+        workspace=workspace_id, name="My Landing", owner="u1", type="site", pattern="landing"
+    )
+    await doc.insert()
+    return str(doc.id)
+
+
+async def _publish(ws: str, pocket_id: str, key: str | None):
+    return await sites_service.publish_pocket(
+        workspace_id=ws,
+        user_id="u1",
+        pocket_id=pocket_id,
+        site_plan_key=key,
+        _generator=_RecordingGenerator(),
+        _cloudflare=_RecordingCF(),
+        _bundle_reader=lambda d: b"x",
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1 — a document written before the rename
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("legacy", "current"), [("basic", "free"), ("pro", "site"), ("business", "staff")]
+)
+async def test_a_pre_rename_document_reports_its_current_tier_on_the_wire(
+    mongo_db, legacy, current
+):
+    """The two reads a client makes about one site must agree.
+
+    ``_to_response`` used to echo ``Site.plan_tier`` verbatim while
+    ``resolve_site_entitlements`` resolved it through the catalog. After the
+    rename that is two different strings for the same site: the response says
+    "pro", entitlements say "site", and the plan card — which matches the
+    response's value against the catalog keys from ``GET /billing/site-plans`` —
+    matches nothing at all and shows a paying customer no current plan.
+
+    Breaks on: ``_to_response`` going back to ``doc.plan_tier or ""``.
+    """
+    ws = await _make_workspace()
+    doc = Site(
+        workspace=ws,
+        pocket_id="p1",
+        name="Legacy",
+        owner="u1",
+        plan_tier=legacy,
+        subscription_status="active",
+    )
+    await doc.insert()
+
+    resp = sites_service._to_response(doc)
+    ent = await sites_service.site_entitlements(workspace_id=ws, site_id=str(doc.id))
+
+    assert resp.plan_tier == current
+    assert ent.plan_tier == current, "the two reads disagree about one site's plan"
+
+
+async def test_a_tier_string_nobody_recognises_is_reported_as_found(mongo_db):
+    """The mapper echoes an unknown value rather than substituting the floor.
+
+    Both are "wrong" in the sense that the client cannot match either against the
+    catalog — but they are wrong differently. Reporting ``free`` is a CONFIDENT
+    wrong answer: support reads a plan card saying Free, believes the site is on
+    the free tier, and stops looking. Echoing the odd string tells whoever gets
+    the ticket what is actually on the document.
+
+    The two entitlement fields still fail closed to the floor; only the reported
+    NAME passes through. Asserted together here, because it is the combination
+    that is the design — a tier name the resolver refuses to honour.
+
+    Breaks on: ``_canonical_plan_tier`` falling back to ``BASE_SITE_PLAN_KEY``.
+    """
+    ws = await _make_workspace()
+    doc = Site(
+        workspace=ws,
+        pocket_id="p1",
+        name="Odd",
+        owner="u1",
+        plan_tier="tier-from-the-future",
+        subscription_status="active",
+    )
+    await doc.insert()
+
+    resp = sites_service._to_response(doc)
+    ent = await sites_service.site_entitlements(workspace_id=ws, site_id=str(doc.id))
+
+    assert resp.plan_tier == "tier-from-the-future"
+    assert ent.plan_tier == site_plans.BASE_SITE_PLAN_KEY
+    assert ent.badge_required is True
+
+
+async def test_a_pre_rename_paying_site_keeps_its_paid_capabilities(mongo_db):
+    """The rename's worst case, stated plainly: every already-published paying
+    site holds ``plan_tier="pro"``, and an unrecognised key resolves to the free
+    floor. Without the aliases this read returns the badge and revokes the custom
+    domain for every paying customer at deploy time, with nothing raised.
+
+    Breaks on: dropping ``pro`` from ``_LEGACY_SITE_TIER_ALIASES``.
+    """
+    ws = await _make_workspace()
+    doc = Site(
+        workspace=ws,
+        pocket_id="p1",
+        name="Paying",
+        owner="u1",
+        plan_tier="pro",
+        subscription_status="active",
+    )
+    await doc.insert()
+
+    ent = await sites_service.site_entitlements(workspace_id=ws, site_id=str(doc.id))
+
+    assert ent.badge_required is False, "a paying site got its badge back"
+    assert ent.custom_domain is True
+    assert ent.max_domained_sites is None, "the uncapped allowance was revoked"
+
+
+async def test_a_republish_that_omits_the_tier_leaves_a_legacy_key_resolvable(mongo_db):
+    """A republish with no ``site_plan_key`` keeps the site's existing tier. That
+    path reads the stored value back through the catalog, so a legacy key has to
+    survive the round trip rather than being treated as unknown and reset to the
+    floor."""
+    ws = await _make_workspace()
+    pocket_id = await _make_pocket(workspace_id=ws)
+
+    doc = await _publish(ws, pocket_id, None)
+    persisted = await Site.find_one(Site.id == doc.id)
+    persisted.plan_tier = "pro"
+    persisted.subscription_status = "active"
+    await persisted.save()
+
+    await _publish(ws, pocket_id, None)
+
+    after = await Site.find_one(Site.id == doc.id)
+    assert site_plans.site_scoped_tier(after.plan_tier) is not None
+    assert sites_service._to_response(after).plan_tier == "site"
+
+
+# ---------------------------------------------------------------------------
+# 2 — an org flat must not become a site's own tier
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("org_key", ["studio", "agency"])
+async def test_publishing_a_site_on_an_org_flat_records_the_floor_instead(
+    mongo_db, org_key, monkeypatch, caplog
+):
+    """A publish asking for ``studio`` must not stamp ``studio``.
+
+    The Dodo product is configured for EVERY key here on purpose. Without it the
+    test would pass through the pre-existing "paid tier with no product" fallback
+    and prove nothing about the scope check — the org tier would be refused for
+    being unconfigured rather than for being org-scoped, and the day someone
+    added a studio product the refusal would silently stop happening.
+
+    THE LOG ASSERTION IS LOAD-BEARING, and this is why. Two guards stand between
+    an org key and the document: the scope check, and ``purchasable`` (hard-False
+    for org tiers). Belt and braces is right for the code and useless for a test
+    — deleting either one leaves the persisted result identical, so a
+    stored-state-only assertion measures "at least one guard survives", not the
+    one it names. It passed against a mutation that stubbed the scope check out
+    entirely. The two guards log different lines, so the line is the only
+    evidence that distinguishes them.
+
+    Breaks on: ``_apply_site_plan`` losing its ``is_org_scoped`` guard.
+    """
+    monkeypatch.setattr(site_plans, "_dodo_product_for", lambda key: f"prod_{key}")
+    ws = await _make_workspace()
+    pocket_id = await _make_pocket(workspace_id=ws)
+
+    with caplog.at_level(logging.WARNING, logger="pocketpaw_ee.sites.service"):
+        doc = await _publish(ws, pocket_id, org_key)
+
+    persisted = await Site.find_one(Site.id == doc.id)
+    assert persisted.plan_tier == site_plans.BASE_SITE_PLAN_KEY
+    assert persisted.subscription_status != "active"
+    # ``getMessage()``, not ``.message``: the latter is only populated once a
+    # Formatter has run, so on a raw captured record it is either absent or the
+    # unformatted template — and ``template % args`` blows up on a record whose
+    # args were already applied.
+    assert any("org-wide flat" in r.getMessage() for r in caplog.records), (
+        "the tier was refused, but not BY THE SCOPE CHECK — see the docstring"
+    )
+
+
+async def test_an_org_flat_cannot_downgrade_a_site_that_is_already_paying(mongo_db, monkeypatch):
+    """The refusal must fall back to the site's OWN tier, not to the floor.
+
+    An org key arriving on a republish is a bad request, and punishing a paying
+    site for it — by resetting ``plan_tier`` to free and dropping its badge
+    removal — turns a rejected upgrade into a silent downgrade. Same rule the
+    unknown-key and unpurchasable-tier paths already follow.
+    """
+    monkeypatch.setattr(site_plans, "_dodo_product_for", lambda key: f"prod_{key}")
+    ws = await _make_workspace()
+    pocket_id = await _make_pocket(workspace_id=ws)
+
+    doc = await _publish(ws, pocket_id, None)
+    persisted = await Site.find_one(Site.id == doc.id)
+    persisted.plan_tier = "site"
+    persisted.subscription_status = "active"
+    persisted.subscription_id = "sub_existing"
+    await persisted.save()
+
+    await _publish(ws, pocket_id, "studio")
+
+    after = await Site.find_one(Site.id == doc.id)
+    assert after.plan_tier == "site", "a rejected org key downgraded a paying site"
+
+
+async def test_the_catalog_endpoint_offers_org_flats_but_the_publish_path_does_not(mongo_db):
+    """The two lists exist for different callers and must not be confused.
+
+    The storefront reads the whole catalog — it has to render Studio and Agency to
+    sell them. The publish path reads only the per-site rungs. If a picker were
+    ever wired to ``list_site_plans`` it would offer a tier the backend refuses,
+    which reads to the buyer as an upgrade that did nothing.
+    """
+    catalog_keys = {t.key for t in site_plans.list_site_plans()}
+    publishable = {t.key for t in site_plans.list_site_scoped_plans()}
+
+    assert {"studio", "agency"} <= catalog_keys
+    assert not ({"studio", "agency"} & publishable)
+    assert publishable < catalog_keys

--- a/tests/ee/sites/test_free_badge.py
+++ b/tests/ee/sites/test_free_badge.py
@@ -573,7 +573,7 @@ async def test_a_first_publish_badges_before_it_deploys(tmp_path, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_a_basic_tier_site_is_badged(tmp_path, monkeypatch):
-    _site_doc_returning(monkeypatch, _Doc("basic"))
+    _site_doc_returning(monkeypatch, _Doc("free"))
     (tmp_path / "index.html").write_text("<body>home</body>", encoding="utf-8")
 
     await sites_service._stamp_free_badge(

--- a/tests/mutations/custom_domain_entitlement.json
+++ b/tests/mutations/custom_domain_entitlement.json
@@ -222,8 +222,8 @@
   {
     "label": "a republish without a plan key silently downgrades the tier to the floor",
     "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "    tier = site_plans.get_site_plan(site_plan_key)\n    if tier is None:\n        existing_tier = site_plans.get_site_plan(getattr(doc, \"plan_tier\", None))",
-    "replace": "    tier = site_plans.get_site_plan(site_plan_key)\n    if tier is None:\n        existing_tier = None",
+    "find": "    if tier is None:\n        existing_tier = site_plans.site_scoped_tier(getattr(doc, \"plan_tier\", None))\n        tier = existing_tier or site_plans.get_site_plan(site_plans.BASE_SITE_PLAN_KEY)\n        if existing_tier is not None:",
+    "replace": "    if tier is None:\n        existing_tier = None\n        tier = site_plans.get_site_plan(site_plans.BASE_SITE_PLAN_KEY)\n        if existing_tier is not None:",
     "tests": [
       "tests/cloud/sites/test_custom_domain_entitlement.py::test_a_republish_without_a_plan_key_keeps_the_paid_tier",
       "tests/cloud/sites/test_custom_domain_entitlement.py::test_a_republish_leaves_a_paying_site_able_to_attach_a_domain"
@@ -242,8 +242,8 @@
   {
     "label": "the keep-tier fallback swallows an EXPLICIT downgrade too",
     "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "    tier = site_plans.get_site_plan(site_plan_key)\n    if tier is None:",
-    "replace": "    tier = None\n    if tier is None:",
+    "find": "    tier = site_plans.get_site_plan(site_plan_key)\n    # An ORG-SCOPED flat is not a tier a site can be put on.",
+    "replace": "    tier = None\n    # An ORG-SCOPED flat is not a tier a site can be put on.",
     "tests": [
       "tests/cloud/sites/test_custom_domain_entitlement.py::test_an_explicit_tier_still_wins"
     ]

--- a/tests/mutations/free_badge.json
+++ b/tests/mutations/free_badge.json
@@ -12,8 +12,8 @@
   {
     "label": "the free tier is handed badge removal",
     "file": "ee/pocketpaw_ee/cloud/billing/site_plans.py",
-    "find": "_SITE_PLAN_BADGE_REMOVAL: dict[str, bool] = {\n    \"basic\": False,",
-    "replace": "_SITE_PLAN_BADGE_REMOVAL: dict[str, bool] = {\n    \"basic\": True,",
+    "find": "_SITE_PLAN_BADGE_REMOVAL: dict[str, bool] = {\n    \"free\": False,",
+    "replace": "_SITE_PLAN_BADGE_REMOVAL: dict[str, bool] = {\n    \"free\": True,",
     "tests": [
       "tests/ee/sites/test_free_badge.py::test_the_base_tier_is_badged",
       "tests/ee/sites/test_free_badge.py::test_a_basic_tier_site_is_badged"

--- a/tests/mutations/site_billing_wire.json
+++ b/tests/mutations/site_billing_wire.json
@@ -2,7 +2,7 @@
   {
     "label": "plan_tier stops reaching the wire — the Billing tab is blind again",
     "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "        plan_tier=getattr(doc, \"plan_tier\", None) or \"\",",
+    "find": "        plan_tier=_canonical_plan_tier(getattr(doc, \"plan_tier\", None)),",
     "replace": "",
     "tests": [
       "tests/cloud/sites/test_billing_state_on_the_wire.py::test_the_site_response_carries_the_plan_the_ui_renders"

--- a/tests/mutations/site_plan_purchasable.json
+++ b/tests/mutations/site_plan_purchasable.json
@@ -31,7 +31,7 @@
   {
     "label": "the guard downgrades to the floor instead of the site's existing tier",
     "file": "ee/pocketpaw_ee/sites/service.py",
-    "find": "        unbuyable = tier.key\n        existing_tier = site_plans.get_site_plan(getattr(doc, \"plan_tier\", None))\n        tier = existing_tier or site_plans.get_site_plan(site_plans.BASE_SITE_PLAN_KEY)",
+    "find": "        unbuyable = tier.key\n        existing_tier = site_plans.site_scoped_tier(getattr(doc, \"plan_tier\", None))\n        tier = existing_tier or site_plans.get_site_plan(site_plans.BASE_SITE_PLAN_KEY)",
     "replace": "        unbuyable = tier.key\n        tier = site_plans.get_site_plan(site_plans.BASE_SITE_PLAN_KEY)",
     "tests": [
       "tests/cloud/billing/test_site_plan_purchasable.py::TestThePublishRecordsWhatIsTrue::test_it_never_downgrades_a_site_that_already_has_a_tier"

--- a/tests/mutations/site_pricing_ladder.json
+++ b/tests/mutations/site_pricing_ladder.json
@@ -1,0 +1,227 @@
+[
+  {
+    "label": "the legacy alias table is emptied — every pre-rename site drops to the free floor",
+    "file": "ee/pocketpaw_ee/cloud/billing/site_plans.py",
+    "find": "_LEGACY_SITE_TIER_ALIASES: dict[str, str] = {\n    \"basic\": \"free\",\n    \"pro\": \"site\",\n    \"business\": \"staff\",\n}",
+    "replace": "_LEGACY_SITE_TIER_ALIASES: dict[str, str] = {}",
+    "tests": [
+      "tests/cloud/billing/test_site_pricing_ladder.py::test_a_legacy_key_resolves_to_the_tier_with_the_same_capabilities",
+      "tests/cloud/entitlements/test_site_entitlements.py::test_a_site_stored_on_a_legacy_key_keeps_everything_it_had",
+      "tests/cloud/sites/test_site_plan_rekey.py::test_a_pre_rename_paying_site_keeps_its_paid_capabilities"
+    ]
+  },
+  {
+    "label": "the aliases are mapped by ladder POSITION — business lands on studio, an org flat",
+    "file": "ee/pocketpaw_ee/cloud/billing/site_plans.py",
+    "find": "    \"pro\": \"site\",\n    \"business\": \"staff\",",
+    "replace": "    \"pro\": \"staff\",\n    \"business\": \"studio\",",
+    "tests": [
+      "tests/cloud/billing/test_site_pricing_ladder.py::test_a_legacy_key_resolves_to_the_tier_with_the_same_capabilities",
+      "tests/cloud/billing/test_site_pricing_ladder.py::test_a_legacy_key_is_still_a_site_scoped_tier"
+    ]
+  },
+  {
+    "label": "_dodo_product_for stops looking through the alias — the deployed product map goes dead",
+    "file": "ee/pocketpaw_ee/cloud/billing/site_plans.py",
+    "find": "    candidates = [key] + [old for old, new in _LEGACY_SITE_TIER_ALIASES.items() if new == key]",
+    "replace": "    candidates = [key]",
+    "tests": [
+      "tests/cloud/billing/test_site_pricing_ladder.py::test_the_deployed_legacy_product_map_still_opens_a_checkout"
+    ]
+  },
+  {
+    "label": "the legacy key wins over the canonical one — re-keying the env var does nothing",
+    "file": "ee/pocketpaw_ee/cloud/billing/site_plans.py",
+    "find": "    candidates = [key] + [old for old, new in _LEGACY_SITE_TIER_ALIASES.items() if new == key]",
+    "replace": "    candidates = [old for old, new in _LEGACY_SITE_TIER_ALIASES.items() if new == key] + [key]",
+    "tests": [
+      "tests/cloud/billing/test_site_pricing_ladder.py::test_the_new_key_wins_over_a_legacy_one_for_the_same_tier"
+    ]
+  },
+  {
+    "label": "site_scoped_tier stops refusing org flats — one site gets the whole org's allowance",
+    "file": "ee/pocketpaw_ee/cloud/billing/site_plans.py",
+    "find": "    tier = get_site_plan(key)\n    if tier is None or tier.is_org_scoped:\n        return None\n    return tier",
+    "replace": "    return get_site_plan(key)",
+    "tests": [
+      "tests/cloud/billing/test_site_pricing_ladder.py::test_an_org_flat_is_refused_as_a_sites_own_tier",
+      "tests/cloud/entitlements/test_site_entitlements.py::test_an_org_flat_stored_on_a_site_grants_that_site_nothing"
+    ]
+  },
+  {
+    "label": "purchasable stops excluding org flats — the per-site checkout can charge $149",
+    "file": "ee/pocketpaw_ee/cloud/billing/site_plans.py",
+    "find": "        if self.is_org_scoped:\n            return False\n        return self.monthly_price_usd == 0 or self.dodo_product_id is not None",
+    "replace": "        return self.monthly_price_usd == 0 or self.dodo_product_id is not None",
+    "tests": [
+      "tests/cloud/billing/test_site_pricing_ladder.py::test_an_org_flat_is_never_purchasable_however_config_is_set"
+    ]
+  },
+  {
+    "label": "is_org_scoped compares against the wrong literal — every scope check silently passes",
+    "file": "ee/pocketpaw_ee/cloud/billing/site_plans.py",
+    "find": "        return self.scope == ORG_SCOPE\n\n    @property\n    def sells_concierge",
+    "replace": "        return self.scope == \"orgs\"\n\n    @property\n    def sells_concierge",
+    "tests": [
+      "tests/cloud/billing/test_site_pricing_ladder.py::test_the_catalog_holds_both_scopes_and_says_which_is_which",
+      "tests/cloud/billing/test_site_pricing_ladder.py::test_an_org_flat_is_refused_as_a_sites_own_tier"
+    ]
+  },
+  {
+    "label": "an unknown tier defaults to SITE scope — a typo becomes a publishable tier",
+    "file": "ee/pocketpaw_ee/cloud/billing/site_plans.py",
+    "find": "        scope=_SITE_PLAN_SCOPE.get(key, ORG_SCOPE),",
+    "replace": "        scope=_SITE_PLAN_SCOPE.get(key, SITE_SCOPE),",
+    "tests": [
+      "tests/cloud/billing/test_site_pricing_ladder.py::test_a_tier_the_catalog_does_not_know_is_built_org_scoped",
+      "tests/cloud/billing/test_site_pricing_ladder.py::test_the_catalog_holds_both_scopes_and_says_which_is_which"
+    ]
+  },
+  {
+    "label": "the $7 rung is given the concierge — the $19 rung's only differentiator",
+    "file": "ee/pocketpaw_ee/cloud/billing/site_plans.py",
+    "find": "    \"site\": False,\n    \"staff\": True,\n    \"studio\": False,\n    \"agency\": True,\n}",
+    "replace": "    \"site\": True,\n    \"staff\": True,\n    \"studio\": False,\n    \"agency\": True,\n}",
+    "tests": [
+      "tests/cloud/billing/test_site_pricing_ladder.py::test_only_the_top_per_site_rung_sells_the_concierge",
+      "tests/cloud/billing/test_site_plan_inclusions.py::test_only_the_top_per_site_rung_sells_the_concierge"
+    ]
+  },
+  {
+    "label": "the free floor loses its one domained site — the acquisition hook goes quietly",
+    "file": "ee/pocketpaw_ee/cloud/billing/site_plans.py",
+    "find": "_SITE_PLAN_MAX_DOMAINED_SITES: dict[str, int | None] = {\n    \"free\": 1,",
+    "replace": "_SITE_PLAN_MAX_DOMAINED_SITES: dict[str, int | None] = {\n    \"free\": 0,",
+    "tests": [
+      "tests/cloud/billing/test_site_pricing_ladder.py::test_the_free_floor_keeps_its_one_domained_site",
+      "tests/cloud/entitlements/test_site_entitlements.py::test_the_floor_grants_its_domain_with_no_subscription_at_all"
+    ]
+  },
+  {
+    "label": "the ladder is repriced off spec — $7 becomes $5 again",
+    "file": "ee/pocketpaw_ee/cloud/billing/site_plans.py",
+    "find": "    \"site\": 7,\n    \"staff\": 19,",
+    "replace": "    \"site\": 5,\n    \"staff\": 19,",
+    "tests": [
+      "tests/cloud/billing/test_site_pricing_ladder.py::test_the_ladder_matches_the_pricing_spec"
+    ]
+  },
+  {
+    "label": "agency loses its half-price conversation rate — the reason the tier costs $149",
+    "file": "ee/pocketpaw_ee/cloud/billing/site_plans.py",
+    "find": "    \"studio\": _LIST_CONVERSATION_RATE_CENTS,\n    \"agency\": 5,",
+    "replace": "    \"studio\": _LIST_CONVERSATION_RATE_CENTS,\n    \"agency\": _LIST_CONVERSATION_RATE_CENTS,",
+    "tests": [
+      "tests/cloud/billing/test_site_pricing_ladder.py::test_the_agency_rate_is_the_discount_it_is_sold_on"
+    ]
+  },
+  {
+    "label": "staff loses its 200 included conversations — the tier bills from the first one",
+    "file": "ee/pocketpaw_ee/cloud/billing/site_plans.py",
+    "find": "    \"staff\": 200,\n    \"studio\": 0,",
+    "replace": "    \"staff\": 0,\n    \"studio\": 0,",
+    "tests": [
+      "tests/cloud/billing/test_site_pricing_ladder.py::test_the_conversation_allowance_belongs_to_the_tier_that_sells_the_concierge"
+    ]
+  },
+  {
+    "label": "the org flats lose their included-site counts — the flats price nothing",
+    "file": "ee/pocketpaw_ee/cloud/billing/site_plans.py",
+    "find": "    \"studio\": 5,\n    \"agency\": 25,\n}\n\n# Concierge conversations included per month",
+    "replace": "    \"studio\": None,\n    \"agency\": None,\n}\n\n# Concierge conversations included per month",
+    "tests": [
+      "tests/cloud/billing/test_site_pricing_ladder.py::test_only_the_org_flats_include_a_site_count"
+    ]
+  },
+  {
+    "label": "the resolver reads the unguarded lookup — an org key on a site grants everything",
+    "file": "ee/pocketpaw_ee/cloud/entitlements/service.py",
+    "find": "    tier = site_plan_catalog.site_scoped_tier(plan_tier)\n    # It deliberately does not substitute a floor",
+    "replace": "    tier = site_plan_catalog.get_site_plan(plan_tier)\n    # It deliberately does not substitute a floor",
+    "tests": [
+      "tests/cloud/entitlements/test_site_entitlements.py::test_an_org_flat_stored_on_a_site_grants_that_site_nothing"
+    ]
+  },
+  {
+    "label": "the domain allowance reads the unguarded lookup — an org key uncaps one site",
+    "file": "ee/pocketpaw_ee/cloud/entitlements/service.py",
+    "find": "    tier = site_plan_catalog.site_scoped_tier(plan_tier)\n    if tier is not None and _subscription_is_active(subscription_status):",
+    "replace": "    tier = site_plan_catalog.get_site_plan(plan_tier)\n    if tier is not None and _subscription_is_active(subscription_status):",
+    "tests": [
+      "tests/cloud/entitlements/test_site_entitlements.py::test_an_org_flat_stored_on_a_site_grants_that_site_nothing"
+    ]
+  },
+  {
+    "label": "the publish path stops refusing org flats — studio gets stamped on one site",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    if tier is not None and tier.is_org_scoped:",
+    "replace": "    if False:",
+    "tests": [
+      "tests/cloud/sites/test_site_plan_rekey.py::test_publishing_a_site_on_an_org_flat_records_the_floor_instead"
+    ]
+  },
+  {
+    "label": "a rejected org key resets a paying site to the floor instead of keeping its tier",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        existing_tier = site_plans.site_scoped_tier(getattr(doc, \"plan_tier\", None))\n        tier = existing_tier or site_plans.get_site_plan(site_plans.BASE_SITE_PLAN_KEY)\n        if existing_tier is not None:",
+    "replace": "        existing_tier = None\n        tier = site_plans.get_site_plan(site_plans.BASE_SITE_PLAN_KEY)\n        if existing_tier is not None:",
+    "tests": [
+      "tests/cloud/sites/test_site_plan_rekey.py::test_an_org_flat_cannot_downgrade_a_site_that_is_already_paying"
+    ]
+  },
+  {
+    "label": "the wire echoes the raw stored tier — the response and entitlements disagree",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "        plan_tier=_canonical_plan_tier(getattr(doc, \"plan_tier\", None)),",
+    "replace": "        plan_tier=getattr(doc, \"plan_tier\", None) or \"\",",
+    "tests": [
+      "tests/cloud/sites/test_site_plan_rekey.py::test_a_pre_rename_document_reports_its_current_tier_on_the_wire"
+    ]
+  },
+  {
+    "label": "_canonical_plan_tier silently floors an unknown value instead of passing it through",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    return _site_plans.canonical_site_tier_key(stored) or stored",
+    "replace": "    return _site_plans.canonical_site_tier_key(stored) or _site_plans.BASE_SITE_PLAN_KEY",
+    "tests": [
+      "tests/cloud/sites/test_site_plan_rekey.py::test_a_tier_string_nobody_recognises_is_reported_as_found",
+      "tests/cloud/sites/test_site_plan_rekey.py::test_a_pre_rename_document_reports_its_current_tier_on_the_wire"
+    ]
+  },
+  {
+    "label": "activation stamps an annual renewal again on a monthly plan",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    deployed.renewal_date = datetime.now(UTC) + relativedelta(months=1)",
+    "replace": "    deployed.renewal_date = datetime.now(UTC) + timedelta(days=365)",
+    "tests": [
+      "tests/cloud/sites/test_charge_first.py::test_activation_stamps_a_MONTHLY_renewal_not_an_annual_one"
+    ]
+  },
+  {
+    "label": "activation steps 30 days instead of a month — the date walks back through the year",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    deployed.renewal_date = datetime.now(UTC) + relativedelta(months=1)",
+    "replace": "    deployed.renewal_date = datetime.now(UTC) + timedelta(days=90)",
+    "tests": [
+      "tests/cloud/sites/test_charge_first.py::test_activation_stamps_a_MONTHLY_renewal_not_an_annual_one"
+    ]
+  },
+  {
+    "label": "the catalog endpoint stops shipping scope — the client cannot tell the ladders apart",
+    "file": "ee/pocketpaw_ee/cloud/entitlements/dto.py",
+    "find": "        scope=tier.scope,",
+    "replace": "",
+    "tests": [
+      "tests/cloud/sites/test_cloudflare_tiers.py::test_get_billing_site_plans_returns_catalog_with_cf_features"
+    ]
+  },
+  {
+    "label": "add_domain provisions Cloudflare features off an unguarded tier lookup",
+    "file": "ee/pocketpaw_ee/sites/service.py",
+    "find": "    plan = site_plans.site_scoped_tier(site.plan_tier)\n    features = set(plan.cloudflare_features) if plan else set()",
+    "replace": "    plan = site_plans.get_site_plan(site.plan_tier)\n    features = set(plan.cloudflare_features) if plan else set()",
+    "tests": [
+      "tests/cloud/sites/test_cloudflare_tiers.py"
+    ]
+  }
+]


### PR DESCRIPTION
$0 / $7 / $19 per site, $39 / $149 per org, on the keys the spec uses. The catalog was `basic` / `pro` / `business` at $0 / $5 / $19 and had no way to express a plan covering more than one site.

Source: `2026-08-13-paw-sites-pricing-spec`. One deliberate departure from it — free keeps one custom-domained site. The spec says subdomain-only; the captain's rule of 2026-08-21 stands.

| | key | price | scope |
|---|---|---|---|
| Free | `free` | $0 | per site (the floor) |
| Site | `site` | $7 / mo | per site |
| Staff | `staff` | $19 / mo | per site |
| Studio | `studio` | $39 / mo | per org, flat |
| Agency | `agency` | $149 / mo | per org, flat |

## The rename is the dangerous half

`Site.plan_tier` holds the old strings in production, and an unrecognised key resolves to None — which drops that site to the free floor: badge back, custom domain revoked, concierge off. Renaming the catalog on its own would have done that to every published site at deploy time, silently, with nothing raised.

So the old keys stay resolvable permanently, mapped by **capability** rather than ladder position. `pro` sold badge removal and uncapped domains and no concierge, which is exactly `site`. `business` added the concierge, which is `staff`. A position-based mapping over five rungs would have put `business` on `studio` — an org flat, not a legal value for the field these keys live in.

The same trap sits in config and is easier to miss. `POCKETPAW_DODO_SITE_PRODUCTS` is deployed keyed `{"pro": ..., "business": ...}`. A catalog that only looked up the new names would find nothing, every paid tier would go unpurchasable the moment this deployed, and publishes would keep succeeding while recording the free floor and taking no money. `_dodo_product_for` reads the canonical key first and falls back through the alias, so the running config keeps working and a re-keyed one wins as soon as it is set.

`scripts/migrate_site_plan_keys.py` rewrites the stored values. Dry run by default, no-op on re-run, and it refuses to touch a value it does not recognise — rewriting an unplanned string to the floor silently revokes whatever it was granting, and the script cannot tell a typo from a restored backup. Running it is optional. The aliases are permanent, not transitional.

## Two scopes in one catalog

`studio` and `agency` are one subscription covering many sites. Their keys must never reach `Site.plan_tier`: a per-site publish cannot buy an org plan, and a single site holding one would get the white-label allowance an org pays $149 a month for across twenty-five.

`site_scoped_tier` is the guarded read every entitlement seam uses now. It differs from `get_site_plan` in one way and that way is the point — an org key resolves to None, failing closed to the floor exactly as an unknown key does. The publish path refuses it too, falling back to the site's **own** tier rather than the floor, so a bad request cannot downgrade someone who is paying.

The org tiers are catalog-only. There is no org subscription, no org checkout, no webhook that could activate one — so `purchasable` is hard-False for them whatever config says. That is not paranoia: an operator filling in every key of the product map would otherwise switch on a checkout that charges $149 and grants one site's capability. The storefront renders them as talk-to-us, the shape `billing.plans` already uses for Enterprise.

`white_label`, `included_sites` and the conversation-meter fields are catalog claims describing the ladder. `SiteEntitlements` still does not carry them, for the reason its own docstring gives: a field that always returns 0 reads as implemented. Nothing meters a conversation yet.

## Two bugs found on the way

**The wire and the entitlements endpoint disagreed about one site's plan.** `_to_response` echoed the raw stored `plan_tier` while `resolve_site_entitlements` resolved it through the catalog. After the rename that is "pro" from one endpoint and "site" from the other, and the plan card — which matches the response against the catalog keys — matches neither, so a paying customer sees no current plan.

**`activate_site` stamped `+365 days` on a monthly plan.** `billing.service` was corrected when prices moved monthly and this second writer was missed, because it lives in the sites service rather than the billing package. A site activated through charge-first was told its next renewal was a year away. Test written first, watched fail at `2027-08-22`, then fixed.

## Verification

Full suite: **10472 passed, 51 failed** — the same 51 as dev, all in herdr / code-mode / headless-permissions, none in sites, billing, entitlements or plans. ruff and `ruff format` clean, checked by exit code rather than through a pipe.

**24 mutations, all caught.** Four escaped on the first run and every one was a real hole:

- the publish-path scope guard was indistinguishable from the `purchasable` guard by stored state alone — deleting either left the persisted result identical, so the test measured "at least one guard survives". It now asserts which log line fired.
- `add_domain` had no test that stored an org key, so nothing noticed it provisioning the full Cloudflare set off one.
- two fail-closed defaults had no direct coverage.

716 anchors validate repo-wide. Five were stranded by these edits across four **other** plans — a plan with a bad anchor applies nothing and reads as covered, so they are repointed here.

## Merge order

`paw-enterprise#825` renders this. Merge this one first: until it lands, `scope` is absent from every row, the frontend reads that as per-site, and the org section is empty.

## Still not built

Deliberate, not oversights: no org subscription (so studio and agency cannot be bought), no conversation metering (the allowances and rates are on the cards as claims and nothing counts), no annual billing (the spec offers 2 months free and lists it as an open decision). All three are in the runbook's gaps section.